### PR TITLE
Skip package.json in dprint.json

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -12,6 +12,7 @@
     "**/.turbo",
     "**/src/generatedNoCheck/",
     "**/src/generatedNoCheck2/",
+    "**/package.json",
     "pnpm-lock.yaml",
     ".vscode/settings.json"
   ],


### PR DESCRIPTION
Short term fix to deconflict with autorelease's formatting of keywords array

Example:
```
@osdk/examples.basic.sdk:lint
  Error: @osdk/examples.basic.sdk#lint: command (/home/runner/work/osdk-ts/osdk-ts/examples/basic/sdk) pnpm run lint exited (1)
  cache miss, executing 3357313617e475df
  
  > @osdk/examples.basic.sdk@0.0.0 lint /home/runner/work/osdk-ts/osdk-ts/examples/basic/sdk
  > eslint . && dprint check  --config $(find-up dprint.json)
  
  from /home/runner/work/osdk-ts/osdk-ts/examples/basic/sdk/package.json:
  37 37| ··"publishConfig":·{
  38 38| ····"access":·"public"
  39 39| ··},
     40|-··"keywords":·[·],
  40   |+··"keywords":·[],
  41 41| ··"files":·[
  42 42| ····"build/types",
  43 43| ····"build/js",
  --
  Found 1 not formatted file.
   ELIFECYCLE  Command failed with exit code 20.
  Error:  command finished with error: command (/home/runner/work/osdk-ts/osdk-ts/examples/basic/sdk) pnpm run lint exited (1)
```

https://github.com/palantir/osdk-ts/actions/runs/7715258311/job/21029381034