### PR TITLE
Enable yargs cli version for @osdk/create-app

### DIFF
--- a/packages/create-app/changelog/@unreleased/pr-26.v2.yml
+++ b/packages/create-app/changelog/@unreleased/pr-26.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Enable yargs cli version for @osdk/create-app
+  links:
+  - https://github.com/palantir/osdk-ts/pull/26

--- a/packages/create-app/src/cli.ts
+++ b/packages/create-app/src/cli.ts
@@ -41,7 +41,7 @@ interface CliArgs {
 
 export async function cli(args: string[] = process.argv) {
   const base: Argv<CliArgs> = yargs(hideBin(args))
-    .version(false)
+    .version(process.env.PACKAGE_VERSION ?? "")
     .strict()
     .help()
     .command(


### PR DESCRIPTION
Enable `--version` to print the CLI version for `@osdk/create-app`. In `@osdk/cli` the version middleware is used instead right now which reserves `--version` for site commands.

This reuses the work done for user agents to have package.json version available in `process.env.PACKAGE_VERSION` at compile time https://github.com/palantir/osdk-ts/blob/a5c361c8f1915d9336ecdb0a94abd295f9151bc1/monorepo/mytsup/tsup.mjs#L26