### PR TITLE
Adds geopoint $within where clauses

### DIFF
--- a/examples/basic/cli/src/index.ts
+++ b/examples/basic/cli/src/index.ts
@@ -73,6 +73,18 @@ async function runTests() {
       interfaceResults.data[0].body;
     }
 
+    // only works in default ontology
+    const result = await client.objects.WeatherStation.where({
+      geohash: {
+        $within: {
+          distance: [1_000, "miles"],
+          of: [0, 0],
+        },
+      },
+    }).fetchPageOrThrow();
+
+    console.log(result.data[0].geohash);
+
     await typeChecks(client);
   } catch (e) {
     console.error("Caught an error we did not expect", typeof e);

--- a/examples/basic/sdk/ontology.json
+++ b/examples/basic/sdk/ontology.json
@@ -110,7 +110,7 @@
           }
         },
         "status": "ACTIVE",
-        "rid": "ridForTodo"
+        "rid": "ridForWeatherStation"
       },
       "linkTypes": []
     },

--- a/examples/basic/sdk/ontology.json
+++ b/examples/basic/sdk/ontology.json
@@ -1,7 +1,7 @@
 {
   "ontology": {
-    "apiName": "OntologyApiName",
-    "rid": "ridHere",
+    "apiName": "default",
+    "rid": "ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e",
     "displayName": "",
     "description": ""
   },
@@ -89,6 +89,31 @@
     }
   },
   "objectTypes": {
+    "WeatherStation": {
+      "objectType": {
+        "apiName": "WeatherStation",
+        "primaryKey": "stationId",
+        "displayName": "Weather Station",
+        "description": "Weather Station",
+        "properties": {
+          "stationId": {
+            "dataType": {
+              "type": "string"
+            }
+          },
+          "geohash": {
+            "dataType": {
+              "type": "geopoint"
+            },
+            "description": "geopoint",
+            "displayName": "Geohash"
+          }
+        },
+        "status": "ACTIVE",
+        "rid": "ridForTodo"
+      },
+      "linkTypes": []
+    },
     "Todo": {
       "objectType": {
         "apiName": "Todo",

--- a/examples/basic/sdk/src/generatedNoCheck/Ontology.ts
+++ b/examples/basic/sdk/src/generatedNoCheck/Ontology.ts
@@ -7,6 +7,7 @@ import * as Objects from './ontology/objects.js';
 const _Ontology = {
   metadata: OntologyMetadata,
   objects: {
+    WeatherStation: Objects.WeatherStation,
     Todo: Objects.Todo,
     Person: Objects.Person,
     Employee: Objects.Employee,
@@ -22,7 +23,7 @@ const _Ontology = {
   interfaces: {
     SimpleInterface: Interfaces.SimpleInterface,
   },
-} satisfies OntologyDefinition<'Todo' | 'Person' | 'Employee' | 'ObjectTypeWithAllPropertyTypes'>;
+} satisfies OntologyDefinition<'WeatherStation' | 'Todo' | 'Person' | 'Employee' | 'ObjectTypeWithAllPropertyTypes'>;
 
 type _Ontology = typeof _Ontology;
 export interface Ontology extends _Ontology {}

--- a/examples/basic/sdk/src/generatedNoCheck/OntologyMetadata.ts
+++ b/examples/basic/sdk/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,5 +1,5 @@
 export const OntologyMetadata = {
-  ontologyRid: 'ridHere',
-  ontologyApiName: 'OntologyApiName',
+  ontologyRid: 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e',
+  ontologyApiName: 'default',
   userAgent: 'typescript-sdk/dev osdk-cli/dev',
 };

--- a/examples/basic/sdk/src/generatedNoCheck/ontology/objects.ts
+++ b/examples/basic/sdk/src/generatedNoCheck/ontology/objects.ts
@@ -2,3 +2,4 @@ export * from './objects/Employee.js';
 export * from './objects/ObjectTypeWithAllPropertyTypes.js';
 export * from './objects/Person.js';
 export * from './objects/Todo.js';
+export * from './objects/WeatherStation.js';

--- a/examples/basic/sdk/src/generatedNoCheck/ontology/objects/WeatherStation.ts
+++ b/examples/basic/sdk/src/generatedNoCheck/ontology/objects/WeatherStation.ts
@@ -1,0 +1,21 @@
+import type { ObjectTypeDefinition } from '@osdk/api';
+
+export const WeatherStation = {
+  apiName: 'WeatherStation',
+  description: 'Weather Station',
+  primaryKeyType: 'string',
+  links: {},
+  properties: {
+    stationId: {
+      multiplicity: false,
+      type: 'string',
+      nullable: false,
+    },
+    geohash: {
+      multiplicity: false,
+      description: 'geopoint',
+      type: 'geopoint',
+      nullable: true,
+    },
+  },
+} satisfies ObjectTypeDefinition<'WeatherStation', never>;

--- a/packages/client/changelog/@unreleased/pr-30.v2.yml
+++ b/packages/client/changelog/@unreleased/pr-30.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Adds geopoint $within where clauses
+  links:
+    - https://github.com/palantir/osdk-ts/pull/30

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@osdk/generator": "workspace:*",
     "@osdk/shared.test": "workspace:*",
+    "@types/geojson": "^7946.0.14",
     "@types/ws": "^8.5.10",
     "ts-expect": "^1.3.0",
     "typescript": "^5.2.2"

--- a/packages/client/src/internal/conversions/modernToLegacyWhereClause.test.ts
+++ b/packages/client/src/internal/conversions/modernToLegacyWhereClause.test.ts
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { MockOntology } from "@osdk/shared.test";
+import type { Point } from "geojson";
+import { describe, expect, it } from "vitest";
+import { modernToLegacyWhereClause } from "./modernToLegacyWhereClause.js";
+
+type ObjAllProps = MockOntology["objects"]["ObjectTypeWithAllPropertyTypes"];
+describe(modernToLegacyWhereClause, () => {
+  describe("single checks", () => {
+    describe("$within", () => {
+      it("properly generates bbox shortcut", async () => {
+        expect(modernToLegacyWhereClause<ObjAllProps>(
+          {
+            geoPoint: {
+              $within: [-5, 5, -10, 10],
+            },
+          },
+        )).toMatchInlineSnapshot(`
+          {
+            "field": "geoPoint",
+            "type": "withinBoundingBox",
+            "value": {
+              "bottomRight": {
+                "coordinates": [
+                  -10,
+                  5,
+                ],
+                "type": "Point",
+              },
+              "topLeft": {
+                "coordinates": [
+                  -5,
+                  10,
+                ],
+                "type": "Point",
+              },
+            },
+          }
+        `);
+      });
+
+      it("properly generates bbox long form", async () => {
+        expect(modernToLegacyWhereClause<ObjAllProps>(
+          {
+            geoPoint: {
+              $within: {
+                bbox: [-5, 5, -10, 10],
+              },
+            },
+          },
+        )).toMatchInlineSnapshot(`
+          {
+            "field": "geoPoint",
+            "type": "withinBoundingBox",
+            "value": {
+              "bottomRight": {
+                "coordinates": [
+                  -10,
+                  5,
+                ],
+                "type": "Point",
+              },
+              "topLeft": {
+                "coordinates": [
+                  -5,
+                  10,
+                ],
+                "type": "Point",
+              },
+            },
+          }
+        `);
+      });
+
+      it("properly generates within radius", async () => {
+        expect(modernToLegacyWhereClause<ObjAllProps>(
+          {
+            geoPoint: {
+              $within: { distance: [5, "km"], of: [-5, 5] },
+            },
+          },
+        )).toMatchInlineSnapshot(`
+        {
+          "field": "geoPoint",
+          "type": "withinDistanceOf",
+          "value": {
+            "center": {
+              "coordinates": [
+                -5,
+                5,
+              ],
+              "type": "Point",
+            },
+            "distance": {
+              "unit": "KILOMETERS",
+              "value": 5,
+            },
+          },
+        }
+      `);
+      });
+
+      it("properly generates within radius of geopoint", async () => {
+        // suppose you loaded an object with a geopoint field
+        // and you want to find all objects within 5 km of that point
+        const pointAsGeoJsonPoint: Point = {
+          type: "Point",
+          coordinates: [-5, 5],
+        };
+        expect(modernToLegacyWhereClause<ObjAllProps>(
+          {
+            geoPoint: {
+              $within: { distance: [5, "km"], of: pointAsGeoJsonPoint },
+            },
+          },
+        )).toMatchInlineSnapshot(`
+        {
+          "field": "geoPoint",
+          "type": "withinDistanceOf",
+          "value": {
+            "center": {
+              "coordinates": [
+                -5,
+                5,
+              ],
+              "type": "Point",
+            },
+            "distance": {
+              "unit": "KILOMETERS",
+              "value": 5,
+            },
+          },
+        }
+      `);
+      });
+
+      it("properly generates within polygon", async () => {
+        expect(modernToLegacyWhereClause<ObjAllProps>(
+          {
+            geoPoint: {
+              $within: { polygon: [[[0, 1], [3, 2], [0, 1]]] },
+            },
+          },
+        )).toMatchInlineSnapshot(`
+          {
+            "field": "geoPoint",
+            "type": "withinPolygon",
+            "value": {
+              "coordinates": [
+                [
+                  [
+                    0,
+                    1,
+                  ],
+                  [
+                    3,
+                    2,
+                  ],
+                  [
+                    0,
+                    1,
+                  ],
+                ],
+              ],
+              "type": "Polygon",
+            },
+          }
+        `);
+      });
+
+      it("properly generates within polygon geojson", async () => {
+        expect(modernToLegacyWhereClause<ObjAllProps>(
+          {
+            geoPoint: {
+              $within: {
+                type: "Polygon",
+                coordinates: [[[0, 1], [3, 2], [0, 1]]],
+              },
+            },
+          },
+        )).toMatchInlineSnapshot(`
+          {
+            "field": "geoPoint",
+            "type": "withinPolygon",
+            "value": {
+              "coordinates": [
+                [
+                  [
+                    0,
+                    1,
+                  ],
+                  [
+                    3,
+                    2,
+                  ],
+                  [
+                    0,
+                    1,
+                  ],
+                ],
+              ],
+              "type": "Polygon",
+            },
+          }
+        `);
+      });
+    }); // describe("$within", () => {
+
+    it("inverts ne short hand properly", () => {
+      expect(modernToLegacyWhereClause<ObjAllProps>({
+        integer: { ne: 5 },
+      })).toMatchInlineSnapshot(`
+        {
+          "type": "not",
+          "value": {
+            "field": "integer",
+            "type": "eq",
+            "value": 5,
+          },
+        }
+      `);
+    });
+  }); // describe("single checks", () => {
+
+  describe("multiple checks", () => {
+    it("properly handles multiple simple where checks", () => {
+      expect(modernToLegacyWhereClause<ObjAllProps>(
+        {
+          decimal: 5,
+          integer: 10,
+        },
+      )).toMatchInlineSnapshot(`
+        {
+          "type": "and",
+          "value": [
+            {
+              "field": "decimal",
+              "type": "eq",
+              "value": 5,
+            },
+            {
+              "field": "integer",
+              "type": "eq",
+              "value": 10,
+            },
+          ],
+        }
+      `);
+    });
+
+    it("properly handles $and", () => {
+      expect(modernToLegacyWhereClause<ObjAllProps>(
+        {
+          $and: [{
+            decimal: 5,
+          }, {
+            integer: 10,
+          }],
+        },
+      )).toMatchInlineSnapshot(`
+          {
+            "type": "and",
+            "value": [
+              {
+                "field": "decimal",
+                "type": "eq",
+                "value": 5,
+              },
+              {
+                "field": "integer",
+                "type": "eq",
+                "value": 10,
+              },
+            ],
+          }
+        `);
+    });
+
+    it("properly handles $or", () => {
+      expect(modernToLegacyWhereClause<ObjAllProps>(
+        {
+          $or: [{
+            decimal: 5,
+          }, {
+            integer: 10,
+          }],
+        },
+      )).toMatchInlineSnapshot(`
+            {
+              "type": "or",
+              "value": [
+                {
+                  "field": "decimal",
+                  "type": "eq",
+                  "value": 5,
+                },
+                {
+                  "field": "integer",
+                  "type": "eq",
+                  "value": 10,
+                },
+              ],
+            }
+          `);
+    });
+  }); // describe("multiple checks", () => {
+}); // describe(modernToLegacyWhereClause, () => {

--- a/packages/client/src/internal/conversions/modernToLegacyWhereClause.test.ts
+++ b/packages/client/src/internal/conversions/modernToLegacyWhereClause.test.ts
@@ -219,7 +219,7 @@ describe(modernToLegacyWhereClause, () => {
           }
         `);
       });
-    }); // describe("$within", () => {
+    });
 
     it("inverts ne short hand properly", () => {
       expect(modernToLegacyWhereClause<ObjAllProps>({
@@ -235,7 +235,7 @@ describe(modernToLegacyWhereClause, () => {
         }
       `);
     });
-  }); // describe("single checks", () => {
+  });
 
   describe("multiple checks", () => {
     it("properly handles multiple simple where checks", () => {
@@ -318,5 +318,5 @@ describe(modernToLegacyWhereClause, () => {
             }
           `);
     });
-  }); // describe("multiple checks", () => {
-}); // describe(modernToLegacyWhereClause, () => {
+  });
+});

--- a/packages/client/src/internal/conversions/modernToLegacyWhereClause.ts
+++ b/packages/client/src/internal/conversions/modernToLegacyWhereClause.ts
@@ -62,7 +62,7 @@ export function modernToLegacyWhereClause<
 
   return {
     type: "and",
-    value: Object.entries(whereClause).map<SearchJsonQueryV2>(
+    value: parts.map<SearchJsonQueryV2>(
       handleWherePair,
     ),
   };
@@ -103,22 +103,22 @@ function handleWherePair([field, filter]: [string, any]): SearchJsonQueryV2 {
     Object.keys(filter).length === 1,
     "WhereClause Filter with multiple properties isn't allowed",
   );
-  const q = Object.keys(filter)[0] as PossibleWhereClauseFilters;
-  invariant(filter[q] != null);
+  const firstKey = Object.keys(filter)[0] as PossibleWhereClauseFilters;
+  invariant(filter[firstKey] != null);
 
-  if (q === "ne") {
+  if (firstKey === "ne") {
     return {
       type: "not",
       value: {
         type: "eq",
         field,
-        value: filter[q],
+        value: filter[firstKey],
       },
     };
   }
 
-  if (q === "$within") {
-    const withinBody = filter[q] as GeoFilter_Within["$within"];
+  if (firstKey === "$within") {
+    const withinBody = filter[firstKey] as GeoFilter_Within["$within"];
 
     if (Array.isArray(withinBody)) {
       return makeWithinBbox(field, withinBody);
@@ -157,8 +157,8 @@ function handleWherePair([field, filter]: [string, any]): SearchJsonQueryV2 {
   }
 
   return {
-    type: q,
+    type: firstKey,
     field,
-    value: filter[q] as any,
+    value: filter[firstKey] as any,
   };
 }

--- a/packages/client/src/internal/conversions/modernToLegacyWhereClause.ts
+++ b/packages/client/src/internal/conversions/modernToLegacyWhereClause.ts
@@ -16,6 +16,7 @@
 
 import type { ObjectOrInterfaceDefinition } from "@osdk/api";
 import type { SearchJsonQueryV2 } from "@osdk/gateway/types";
+import type { BBox } from "geojson";
 import invariant from "tiny-invariant";
 import type {
   AndWhereClause,
@@ -24,6 +25,8 @@ import type {
   PossibleWhereClauseFilters,
   WhereClause,
 } from "../../query/index.js";
+import type { GeoFilter_Within } from "../../query/WhereClause.js";
+import { DistanceUnitMapping } from "../../query/WhereClause.js";
 
 export function modernToLegacyWhereClause<
   T extends ObjectOrInterfaceDefinition<any, any>,
@@ -54,84 +57,108 @@ export function modernToLegacyWhereClause<
   const parts = Object.entries(whereClause);
 
   if (parts.length === 1) {
-    const [field, filter] = parts[0];
-    invariant(
-      filter != null,
-      "Defined key values are only allowed when they are not undefined.",
-    );
-    if (typeof filter === "string" || typeof filter === "number") {
-      return {
-        type: "eq",
-        field,
-        value: filter,
-      };
-    }
-
-    invariant(
-      Object.keys(filter).length === 1,
-      "WhereClause Filter with multiple properties isn't allowed",
-    );
-    const type = Object.keys(filter)[0] as PossibleWhereClauseFilters;
-    invariant(filter[type] != null);
-
-    if (type === "ne") {
-      return {
-        type: "not",
-        value: {
-          type: "eq",
-          field,
-          value: filter[type],
-        },
-      };
-    }
-
-    return {
-      type,
-      field,
-      value: filter[type] as any,
-    };
+    return handleWherePair(parts[0]);
   }
 
   return {
     type: "and",
     value: Object.entries(whereClause).map<SearchJsonQueryV2>(
-      ([field, filter]) => {
-        invariant(
-          filter != null,
-          "Defined key values are only allowed when they are not undefined.",
-        );
-        if (typeof filter === "string" || typeof filter === "number") {
-          return {
-            type: "eq",
-            field,
-            value: filter,
-          };
-        }
-
-        invariant(
-          Object.keys(filter).length === 1,
-          "WhereClause Filter with multiple properties isn't allowed",
-        );
-        const q = Object.keys(filter)[0] as PossibleWhereClauseFilters;
-        invariant(filter[q] != null);
-
-        if (q === "ne") {
-          return {
-            type: "not",
-            value: {
-              type: "eq",
-              field,
-              value: filter[q],
-            },
-          };
-        }
-
-        return {
-          type: q,
-          field,
-          value: filter[q] as any,
-        };
-      },
+      handleWherePair,
     ),
+  };
+}
+
+function makeWithinBbox(field: string, bbox: BBox): SearchJsonQueryV2 {
+  return {
+    type: "withinBoundingBox",
+    field,
+    value: {
+      topLeft: {
+        type: "Point",
+        coordinates: [bbox[0], bbox[3]],
+      },
+      bottomRight: {
+        type: "Point",
+        coordinates: [bbox[2], bbox[1]],
+      },
+    },
+  };
+}
+
+function handleWherePair([field, filter]: [string, any]): SearchJsonQueryV2 {
+  invariant(
+    filter != null,
+    "Defined key values are only allowed when they are not undefined.",
+  );
+
+  if (typeof filter === "string" || typeof filter === "number") {
+    return {
+      type: "eq",
+      field,
+      value: filter,
+    };
+  }
+
+  invariant(
+    Object.keys(filter).length === 1,
+    "WhereClause Filter with multiple properties isn't allowed",
+  );
+  const q = Object.keys(filter)[0] as PossibleWhereClauseFilters;
+  invariant(filter[q] != null);
+
+  if (q === "ne") {
+    return {
+      type: "not",
+      value: {
+        type: "eq",
+        field,
+        value: filter[q],
+      },
+    };
+  }
+
+  if (q === "$within") {
+    const withinBody = filter[q] as GeoFilter_Within["$within"];
+
+    if (Array.isArray(withinBody)) {
+      return makeWithinBbox(field, withinBody);
+    } else if ("bbox" in withinBody && !("type" in withinBody)) {
+      return makeWithinBbox(field, withinBody.bbox);
+    } else if ("distance" in withinBody && "of" in withinBody) {
+      return {
+        type: "withinDistanceOf",
+        field,
+        value: {
+          center: Array.isArray(withinBody.of)
+            ? {
+              type: "Point",
+              coordinates: withinBody.of,
+            }
+            : withinBody.of,
+          distance: {
+            value: withinBody.distance[0],
+            unit: DistanceUnitMapping[withinBody.distance[1]],
+          },
+        },
+      };
+    } else {
+      const coordinates = ("polygon" in withinBody)
+        ? withinBody.polygon
+        : withinBody.coordinates;
+      return {
+        type: "withinPolygon",
+        field,
+        value: {
+          type: "Polygon",
+          coordinates,
+        },
+      };
+    }
+  }
+
+  return {
+    type: q,
+    field,
+    value: filter[q] as any,
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -376,6 +376,9 @@ importers:
       '@osdk/shared.test':
         specifier: workspace:*
         version: link:../shared.test
+      '@types/geojson':
+        specifier: ^7946.0.14
+        version: 7946.0.14
       '@types/ws':
         specifier: ^8.5.10
         version: 8.5.10
@@ -2242,6 +2245,10 @@ packages:
   /@types/geojson@7946.0.13:
     resolution: {integrity: sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ==}
     dev: false
+
+  /@types/geojson@7946.0.14:
+    resolution: {integrity: sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==}
+    dev: true
 
   /@types/is-ci@3.0.1:
     resolution: {integrity: sha512-mnb1ngaGQPm6LFZaNdh3xPOoQMkrQb/KBPhPPN2p2Wk8XgeUqWj6xPnvyQ8rvcK/VFritVmQG8tvQuy7g+9/nQ==}


### PR DESCRIPTION
Provides for the 3 current types of within with multiple syntaxes for convience:

Within Bounding box (2 ways)
- `.where({ propName: { $within: [-5,5,-10,10] })`
- `.where({ propName: { $within: { bbox: [-5,5,-10,10] } })`

Within circle radius (2 ways) 
- `.where({ propName: { $within: { distance: [5 "miles"], of: [10, 10] }})`
- `.where({ propName: { $within: { distance: [5 "miles"], of: properGeoJsonPoint }})`

Within polygon (2 ways)
- `.where({ propName: { $within: properGeoJsonPolygon }})`
- `.where({ propName: { $within: { polygon: [[[1,0], [2,1], [1,0]] }}})`