### PR TITLE
Fix: git describe using regex instead of glob for autoVersion util

### DIFF
--- a/packages/cli/changelog/@unreleased/pr-35.v2.yml
+++ b/packages/cli/changelog/@unreleased/pr-35.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Git describe using regex instead of glob for autoVersion util
+  links:
+  - https://github.com/palantir/osdk-ts/pull/35

--- a/packages/cli/src/util/autoVersion.test.ts
+++ b/packages/cli/src/util/autoVersion.test.ts
@@ -56,7 +56,7 @@ describe("autoVersion", () => {
 
     expect(version).toBe("1.2.3");
     expect(execSyncMock).toHaveBeenCalledWith(
-      "git describe --tags --first-parent --dirty --match=\"/^@package@/*\"",
+      "git describe --tags --first-parent --dirty --match=\"@package@*\"",
       { encoding: "utf8" },
     );
   });
@@ -69,7 +69,7 @@ describe("autoVersion", () => {
 
     expect(version).toBe("1.2.3-package");
     expect(execSyncMock).toHaveBeenCalledWith(
-      "git describe --tags --first-parent --dirty --match=\"/^-package/*\"",
+      "git describe --tags --first-parent --dirty --match=\"-package*\"",
       { encoding: "utf8" },
     );
   });

--- a/packages/cli/src/util/autoVersion.ts
+++ b/packages/cli/src/util/autoVersion.ts
@@ -25,14 +25,15 @@ import { isValidSemver } from "./isValidSemver.js";
  * @throws An error if the version string is not SemVer compliant or if the version cannot be determined.
  */
 export async function autoVersion(tagPrefix: string = ""): Promise<string> {
-  const matchRegExp = new RegExp(tagPrefix == "" ? "^v?" : `^${tagPrefix}`);
-  const matchClause = tagPrefix != "" ? ` --match="${matchRegExp}*"` : "";
+  const matchGlobExp = tagPrefix == "" ? "v?" : `${tagPrefix}`;
+  const matchClause = tagPrefix != "" ? ` --match="${matchGlobExp}*"` : "";
   try {
     const gitVersion = execSync(
       `git describe --tags --first-parent --dirty${matchClause}`,
       { encoding: "utf8" },
     );
-    const version = gitVersion.trim().replace(matchRegExp, "");
+    const replaceRegExp = new RegExp(`^${matchGlobExp}`);
+    const version = gitVersion.trim().replace(replaceRegExp, "");
     if (!isValidSemver(version)) {
       throw new Error(`The version string ${version} is not SemVer compliant.`);
     }

--- a/packages/cli/src/util/autoVersion.ts
+++ b/packages/cli/src/util/autoVersion.ts
@@ -25,14 +25,17 @@ import { isValidSemver } from "./isValidSemver.js";
  * @throws An error if the version string is not SemVer compliant or if the version cannot be determined.
  */
 export async function autoVersion(tagPrefix: string = ""): Promise<string> {
-  const matchGlobExp = tagPrefix == "" ? "v?" : `${tagPrefix}`;
-  const matchClause = tagPrefix != "" ? ` --match="${matchGlobExp}*"` : "";
+  const [matchPrefix, prefixRegex] = tagPrefix !== ""
+    ? [tagPrefix, new RegExp(`^${tagPrefix}`)]
+    : [undefined, new RegExp(`^v?`)];
   try {
     const gitVersion = execSync(
-      `git describe --tags --first-parent --dirty${matchClause}`,
+      `git describe --tags --first-parent --dirty${
+        matchPrefix != null ? ` --match="${matchPrefix}*"` : ""
+      }`,
       { encoding: "utf8" },
     );
-    const replaceRegExp = new RegExp(`^${matchGlobExp}`);
+    const replaceRegExp = new RegExp(prefixRegex);
     const version = gitVersion.trim().replace(replaceRegExp, "");
     if (!isValidSemver(version)) {
       throw new Error(`The version string ${version} is not SemVer compliant.`);


### PR DESCRIPTION
FLUP to https://github.com/palantir/osdk-ts/pull/15

A fix to an issue where the match string passed to `git describe` was using RegEx instead of glob format. However, replace uses RegEx so split into different variables.