### PR TITLE
Make sure to run all tests

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,6 +21,7 @@
     "dev:transpile": "tsup --watch",
     "fix-lint": "eslint . --fix && dprint fmt --config $(find-up dprint.json)",
     "lint": "eslint . && dprint check  --config $(find-up dprint.json)",
+    "test": "vitest run",
     "test:watch": "vitest",
     "transpile": "tsup",
     "transpileWatch": "tsup --watch",

--- a/packages/cli/src/util/config.ts
+++ b/packages/cli/src/util/config.ts
@@ -58,7 +58,7 @@ const CONFIG_FILE_SCHEMA: JSONSchemaType<FoundryConfig> = {
           oneOf: [
             {
               properties: {
-                "type": { enum: ["git-describe"], type: "string" },
+                "type": { const: "git-describe", type: "string" },
                 "tagPrefix": { type: "string", nullable: true },
               },
             },

--- a/packages/cli/src/util/token.test.ts
+++ b/packages/cli/src/util/token.test.ts
@@ -35,19 +35,25 @@ describe("loadToken", () => {
       validToken,
     );
     const token = await loadToken(undefined, "valid-token.txt");
-
     expect(token).toBe(validToken);
   });
 
-  it("should load a valid token from an environment variable", async () => {
+  it("should load a valid token from the FOUNDRY_TOKEN environment variable", async () => {
     vi.stubEnv("FOUNDRY_TOKEN", validToken);
+    vi.stubEnv("FOUNDRY_SDK_AUTH_TOKEN", "");
+    expect(await loadToken()).toBe(validToken);
+  });
 
-    const token = await loadToken();
-    expect(token).toBe(validToken);
+  it("should load a valid token from the deprecated FOUNDRY_SDK_AUTH_TOKEN environment variable", async () => {
+    vi.stubEnv("FOUNDRY_TOKEN", "");
+    vi.stubEnv("FOUNDRY_SDK_AUTH_TOKEN", validToken);
+    expect(await loadToken()).toBe(validToken);
   });
 
   it("should throw an error if no token is found", async () => {
-    expect(() => loadToken()).rejects.toThrow("No token found.");
+    vi.stubEnv("FOUNDRY_TOKEN", "");
+    vi.stubEnv("FOUNDRY_SDK_AUTH_TOKEN", "");
+    await expect(() => loadToken()).rejects.toThrow("No token found.");
   });
 
   afterEach(() => {
@@ -57,15 +63,15 @@ describe("loadToken", () => {
 });
 
 describe("loadTokenFile", async () => {
-  it("should throw an error if the token file is not found", () => {
-    expect(() => loadTokenFile("doesnt-exist.txt"))
+  it("should throw an error if the token file is not found", async () => {
+    await expect(() => loadTokenFile("doesnt-exist.txt"))
       .rejects.toThrow(`Unable to read token file "doesnt-exist.txt"`);
   });
 });
 
 describe("validate", () => {
-  it("should throw an error if the token is invalid", () => {
-    expect(() => validate("token"))
+  it("should throw an error if the token is invalid", async () => {
+    await expect(() => validate("token"))
       .toThrow(`Token does not appear to be a JWT`);
   });
 });

--- a/packages/gateway-generator/package.json
+++ b/packages/gateway-generator/package.json
@@ -21,6 +21,8 @@
     "dev:transpile": "tsup --watch",
     "fix-lint": "eslint . --fix && dprint fmt --config $(find-up dprint.json)",
     "lint": "eslint . && dprint check  --config $(find-up dprint.json)",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "transpile": "tsup",
     "transpileWatch": "tsup --watch",
     "typecheck": "tsc-absolute --build"

--- a/packages/gateway-generator/src/generate/component.test.ts
+++ b/packages/gateway-generator/src/generate/component.test.ts
@@ -16,44 +16,36 @@
 
 import { Project } from "ts-morph";
 import { describe, expect, it } from "vitest";
-import { generateError } from "../error";
+import { generateComponent } from "./component";
 
-describe("Errors", () => {
-  it("should generate an error interface", () => {
+describe("Components", () => {
+  it("generates a component", () => {
     const project = new Project({});
-    const directory = project.createDirectory("errors");
-    generateError(
+    const directory = project.createDirectory("components");
+
+    generateComponent(
       {
-        name: "MyError",
-        errorType: "ERROR_TYPE",
-        parameters: {
-          param1: {
-            type: {
-              type: "builtin",
-              builtin: {
-                type: "string",
-                string: {},
-              },
-            },
-            safety: "SAFE",
-            documentation: {},
+        name: "MyRid",
+        type: {
+          type: "builtin",
+          builtin: {
+            type: "rid",
+            rid: {},
           },
         },
+        safety: "SAFE",
         documentation: {},
       },
       directory,
+      {
+        generateVisitors: true,
+      },
     );
+
     const sourceFiles = project.getSourceFiles();
-    const sourceFile = project.getSourceFile("errors/MyError.ts");
+    const sourceFile = project.getSourceFile("components/MyRid.ts");
     expect(sourceFile?.getFullText()).toMatchInlineSnapshot(`
-            "export interface MyError {
-                errorCode: \\"ERROR_TYPE\\";
-                errorName: \\"MyError\\";
-                errorInstanceId: string;
-                parameters: {
-                        param1: string;
-                    };
-            }
+            "export type MyRid = string;
             "
         `);
     expect(sourceFiles.length).toBe(1);

--- a/packages/gateway-generator/src/generate/error.test.ts
+++ b/packages/gateway-generator/src/generate/error.test.ts
@@ -16,36 +16,44 @@
 
 import { Project } from "ts-morph";
 import { describe, expect, it } from "vitest";
-import { generateComponent } from "../component";
+import { generateError } from "./error";
 
-describe("Components", () => {
-  it("generates a component", () => {
+describe("Errors", () => {
+  it("should generate an error interface", () => {
     const project = new Project({});
-    const directory = project.createDirectory("components");
-
-    generateComponent(
+    const directory = project.createDirectory("errors");
+    generateError(
       {
-        name: "MyRid",
-        type: {
-          type: "builtin",
-          builtin: {
-            type: "rid",
-            rid: {},
+        name: "MyError",
+        errorType: "ERROR_TYPE",
+        parameters: {
+          param1: {
+            type: {
+              type: "builtin",
+              builtin: {
+                type: "string",
+                string: {},
+              },
+            },
+            safety: "SAFE",
+            documentation: {},
           },
         },
-        safety: "SAFE",
         documentation: {},
       },
       directory,
-      {
-        generateVisitors: true,
-      },
     );
-
     const sourceFiles = project.getSourceFiles();
-    const sourceFile = project.getSourceFile("components/MyRid.ts");
+    const sourceFile = project.getSourceFile("errors/MyError.ts");
     expect(sourceFile?.getFullText()).toMatchInlineSnapshot(`
-            "export type MyRid = string;
+            "export interface MyError {
+                errorCode: "ERROR_TYPE";
+                errorName: "MyError";
+                errorInstanceId: string;
+                parameters: {
+                        param1: string;
+                    };
+            }
             "
         `);
     expect(sourceFiles.length).toBe(1);

--- a/packages/gateway-generator/src/generate/namespace.test.ts
+++ b/packages/gateway-generator/src/generate/namespace.test.ts
@@ -16,8 +16,8 @@
 
 import { Project } from "ts-morph";
 import { describe, expect, it } from "vitest";
-import type { Namespace } from "../../spec";
-import { generateNamespace } from "../namespace";
+import type { Namespace } from "../spec";
+import { generateNamespace } from "./namespace";
 
 describe("Namespace", () => {
   it("Generates a resource static method on a namespace correctly", () => {
@@ -119,9 +119,9 @@ describe("Namespace", () => {
     const sourceFiles = project.getSourceFiles();
     const sourceFile = project.getSourceFile("namespaces/Datasets.ts");
     expect(sourceFile?.getFullText()).toMatchInlineSnapshot(`
-            "import type { CreateDatasetRequest } from \\"../components/CreateDatasetRequest\\";
-            import type { Dataset } from \\"../components/Dataset\\";
-            import { OpenApiRequest } from \\"../request\\";
+            "import type { CreateDatasetRequest } from "../components/CreateDatasetRequest";
+            import type { Dataset } from "../components/Dataset";
+            import { OpenApiRequest } from "../request";
 
             /**
              * Creates a new Dataset. A default branch - \`master\` for most enrollments - will be created on the Dataset.
@@ -131,7 +131,7 @@ describe("Namespace", () => {
              */
             export function createDataset<TResponse>(_request: OpenApiRequest<Dataset, TResponse>, request: CreateDatasetRequest): Promise<TResponse> {
                 return _request(
-                    \\"POST\\",
+                    "POST",
                     \`/v1/datasets\`,
                     request,
                     __undefined,
@@ -139,8 +139,8 @@ describe("Namespace", () => {
                 );
             }
 
-            const __anyMediaType: string = \\"*/*\\";
-            const __applicationJson: string = \\"application/json\\";
+            const __anyMediaType: string = "*/*";
+            const __applicationJson: string = "application/json";
             /** Constant reference to \`undefined\` that we expect to get minified and therefore reduce total code size */
             const __undefined: undefined = undefined;
             "

--- a/packages/gateway-generator/src/generate/types.test.ts
+++ b/packages/gateway-generator/src/generate/types.test.ts
@@ -15,8 +15,8 @@
  */
 
 import { beforeEach, describe, expect, it } from "vitest";
-import type { DataType } from "../../spec";
-import { generateType } from "../types";
+import type { DataType } from "../spec";
+import { generateType } from "./types";
 
 describe("generateTypes", () => {
   let referenceSet: Set<string>;


### PR DESCRIPTION
- `@osdk/cli` has `test:watch` but no `test` script so turbo is not running tests under test -> check
- `@osdk/generator` has tests but looks like it was copied in and converted to vitest but also not running properly. I updated this to match the repo style with the test file next to the source file and fixed the escaping within backticks
- Some random clean up on existing tests to make them properly await promise rejections and stub out local token envs always to not conflict when running locally