### PR TITLE
Display errors more consistently in @osdk/cli

### DIFF
--- a/packages/cli/changelog/@unreleased/pr-41.v2.yml
+++ b/packages/cli/changelog/@unreleased/pr-41.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Display errors more consistently in @osdk/cli
+  links:
+  - https://github.com/palantir/osdk-ts/pull/41

--- a/packages/cli/src/YargsCheckError.ts
+++ b/packages/cli/src/YargsCheckError.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class YargsCheckError extends Error {
+  constructor(msg?: string) {
+    super(msg);
+  }
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -59,12 +59,27 @@ export async function cli(args: string[] = process.argv) {
       if (err instanceof ExitProcessError) {
         Consola.consola.error(err);
       } else {
-        yargs.showHelp();
-        // eslint-disable-next-line no-console
-        console.error(msg);
+        // if yargs.check returns a string it populates the err variable with a string
+        if (err && typeof err !== "string") {
+          throw err;
+        } else {
+          yargs.showHelp();
+          // eslint-disable-next-line no-console
+          console.log(""); // intentional new line
+          // eslint-disable-next-line no-console
+          console.error(msg);
+        }
       }
       process.exit(1);
     });
 
-  return base.parseAsync();
+  // Special handling where failures happen before yargs does its error handling within .fail
+  try {
+    return await base.parseAsync();
+  } catch (err) {
+    if (err instanceof ExitProcessError) {
+      const Consola = await import("consola");
+      Consola.consola.error(err);
+    }
+  }
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -53,14 +53,18 @@ export async function cli(args: string[] = process.argv) {
           .demandCommand();
       },
       handler: (_args) => {},
+    })
+    .fail(async (msg, err, yargs) => {
+      const Consola = await import("consola");
+      if (err && err instanceof ExitProcessError) {
+        Consola.consola.error(err);
+      } else {
+        yargs.showHelp();
+        // eslint-disable-next-line no-console
+        console.error(msg);
+      }
+      process.exit(1);
     });
 
-  try {
-    return base.parseAsync();
-  } catch (e) {
-    if (e instanceof ExitProcessError) {
-      const Consola = await import("consola");
-      Consola.consola.error(e.message);
-    }
-  }
+  return base.parseAsync();
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -55,15 +55,23 @@ export async function cli(args: string[] = process.argv) {
       },
       handler: (_args) => {},
     })
-    .fail(async (msg, err, argv) => {
+    .fail(async (msg, err, yargsContext) => {
       const Consola = await import("consola");
+      const isVerbose = args.some(arg =>
+        ["-v", "--v", "--verbose"].includes(arg)
+      );
+
       if (err instanceof ExitProcessError) {
-        Consola.consola.error(err);
+        if (isVerbose) {
+          Consola.consola.error(err);
+        } else {
+          Consola.consola.error(err.message);
+        }
       } else {
-        if (err instanceof YargsCheckError === false) {
+        if (err && err instanceof YargsCheckError === false) {
           throw err;
         } else {
-          argv.showHelp();
+          yargsContext.showHelp();
           Consola.consola.log(""); // intentional blank line
           // eslint-disable-next-line no-console
           console.error(msg);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -24,6 +24,7 @@ import typescript from "./commands/typescript/index.js";
 import { ExitProcessError } from "./ExitProcessError.js";
 import { logConfigFileMiddleware } from "./yargs/logConfigFileMiddleware.js";
 import { logVersionMiddleware } from "./yargs/logVersionMiddleware.js";
+import { YargsCheckError } from "./YargsCheckError.js";
 
 export async function cli(args: string[] = process.argv) {
   const base: Argv<CliCommonArgs> = yargs(hideBin(args))
@@ -54,18 +55,16 @@ export async function cli(args: string[] = process.argv) {
       },
       handler: (_args) => {},
     })
-    .fail(async (msg, err, yargs) => {
+    .fail(async (msg, err, argv) => {
       const Consola = await import("consola");
       if (err instanceof ExitProcessError) {
         Consola.consola.error(err);
       } else {
-        // if yargs.check returns a string it populates the err variable with a string
-        if (err && typeof err !== "string") {
+        if (err instanceof YargsCheckError === false) {
           throw err;
         } else {
-          yargs.showHelp();
-          // eslint-disable-next-line no-console
-          console.log(""); // intentional new line
+          argv.showHelp();
+          Consola.consola.log(""); // intentional blank line
           // eslint-disable-next-line no-console
           console.error(msg);
         }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -56,7 +56,7 @@ export async function cli(args: string[] = process.argv) {
     })
     .fail(async (msg, err, yargs) => {
       const Consola = await import("consola");
-      if (err && err instanceof ExitProcessError) {
+      if (err instanceof ExitProcessError) {
         Consola.consola.error(err);
       } else {
         yargs.showHelp();

--- a/packages/cli/src/commands/site/deploy/index.ts
+++ b/packages/cli/src/commands/site/deploy/index.ts
@@ -18,6 +18,7 @@ import { consola } from "consola";
 import type { CommandModule } from "yargs";
 import type { LoadedFoundryConfig, SiteConfig } from "../../../util/config.js";
 import configLoader from "../../../util/configLoader.js";
+import { YargsCheckError } from "../../../YargsCheckError.js";
 import type { CommonSiteArgs } from "../CommonSiteArgs.js";
 import type { SiteDeployArgs } from "./SiteDeployArgs.js";
 
@@ -86,7 +87,9 @@ const command: CommandModule<
           autoVersion == null && argv.autoVersion == null
           && argv.version == null
         ) {
-          return "One of --version or --autoVersion must be specified";
+          throw new YargsCheckError(
+            "One of --version or --autoVersion must be specified",
+          );
         }
 
         if (
@@ -94,7 +97,9 @@ const command: CommandModule<
             || argv.autoVersion !== "git-describe")
           && argv.gitTagPrefix != null
         ) {
-          return `--gitTagPrefix is only supported when --autoVersion=git-describe`;
+          throw new YargsCheckError(
+            `--gitTagPrefix is only supported when --autoVersion=git-describe`,
+          );
         }
 
         if (autoVersion != null && argv.autoVersion !== autoVersion.type) {
@@ -102,7 +107,9 @@ const command: CommandModule<
             `Overriding "autoVersion" from config file with ${argv.autoVersion}`,
           );
           if (argv.autoVersion !== "git-describe") {
-            return `Only 'git-describe' is supported for autoVersion`;
+            throw new YargsCheckError(
+              `Only 'git-describe' is supported for autoVersion`,
+            );
           }
         }
 

--- a/packages/cli/src/commands/site/deploy/index.ts
+++ b/packages/cli/src/commands/site/deploy/index.ts
@@ -106,6 +106,8 @@ const command: CommandModule<
             `--gitTagPrefix is only supported when --autoVersion=git-describe`,
           );
         }
+
+        return true;
       }).middleware((argv) =>
         logDeployCommandConfigFileOverride(
           argv,

--- a/packages/cli/src/commands/site/deploy/index.ts
+++ b/packages/cli/src/commands/site/deploy/index.ts
@@ -86,9 +86,7 @@ const command: CommandModule<
           autoVersion == null && argv.autoVersion == null
           && argv.version == null
         ) {
-          throw new Error(
-            "One of --version or --autoVersion must be specified",
-          );
+          return "One of --version or --autoVersion must be specified";
         }
 
         if (
@@ -96,9 +94,7 @@ const command: CommandModule<
             || argv.autoVersion !== "git-describe")
           && argv.gitTagPrefix != null
         ) {
-          throw new Error(
-            `--gitTagPrefix is only supported when --autoVersion=git-describe`,
-          );
+          return `--gitTagPrefix is only supported when --autoVersion=git-describe`;
         }
 
         if (autoVersion != null && argv.autoVersion !== autoVersion.type) {
@@ -106,9 +102,7 @@ const command: CommandModule<
             `Overriding "autoVersion" from config file with ${argv.autoVersion}`,
           );
           if (argv.autoVersion !== "git-describe") {
-            throw new Error(
-              `Only 'git-describe' is supported for autoVersion`,
-            );
+            return `Only 'git-describe' is supported for autoVersion`;
           }
         }
 

--- a/packages/cli/src/commands/site/deploy/siteDeployCommand.mts
+++ b/packages/cli/src/commands/site/deploy/siteDeployCommand.mts
@@ -47,7 +47,7 @@ export default async function siteDeployCommand(
   }
 
   const siteVersion = !version ? await findAutoVersion(gitTagPrefix) : version;
-  if (autoVersion) {
+  if (!version && autoVersion) {
     consola.info(
       `Auto version inferred next version to be: ${siteVersion}`,
     );

--- a/packages/cli/src/commands/site/deploy/siteDeployCommand.mts
+++ b/packages/cli/src/commands/site/deploy/siteDeployCommand.mts
@@ -40,14 +40,20 @@ export default async function siteDeployCommand(
     directory,
   }: SiteDeployArgs,
 ) {
-  if (!version && !autoVersion) {
+  if (version == null && autoVersion == null) {
     throw new Error(
       "Either version or autoVersion must be specified",
     );
   }
 
-  const siteVersion = !version ? await findAutoVersion(gitTagPrefix) : version;
-  if (!version && autoVersion) {
+  // version has a priority over autoVersion. Both could be defined at the same time when
+  // autoVersion is present in the config file (it assigns that as a default value to argv.autoVersion)
+  // and --version is passed as an argument
+  let siteVersion: string;
+  if (version != null) {
+    siteVersion = version;
+  } else {
+    siteVersion = await findAutoVersion(gitTagPrefix);
     consola.info(
       `Auto version inferred next version to be: ${siteVersion}`,
     );

--- a/packages/cli/src/commands/site/deploy/siteDeployCommand.mts
+++ b/packages/cli/src/commands/site/deploy/siteDeployCommand.mts
@@ -41,8 +41,7 @@ export default async function siteDeployCommand(
   }: SiteDeployArgs,
 ) {
   if (!version && !autoVersion) {
-    throw new ExitProcessError(
-      2,
+    throw new Error(
       "Either version or autoVersion must be specified",
     );
   }

--- a/packages/cli/src/commands/site/index.ts
+++ b/packages/cli/src/commands/site/index.ts
@@ -17,7 +17,6 @@
 import { consola } from "consola";
 import type { CommandModule } from "yargs";
 import type { CliCommonArgs } from "../../CliCommonArgs.js";
-import { ExitProcessError } from "../../ExitProcessError.js";
 import type { ThirdPartyAppRid } from "../../net/ThirdPartyAppRid.js";
 import type { LoadedFoundryConfig } from "../../util/config.js";
 import configLoader from "../../util/configLoader.js";
@@ -81,7 +80,7 @@ const command: CommandModule<CliCommonArgs, CommonSiteArgs> = {
         }
 
         if (!argv.foundryUrl.startsWith("https://")) {
-          throw new ExitProcessError(1, "foundryUrl must start with https://");
+          throw new Error("foundryUrl must start with https://");
         }
 
         argv.foundryUrl = argv.foundryUrl.replace(/\/$/, "");

--- a/packages/cli/src/commands/site/index.ts
+++ b/packages/cli/src/commands/site/index.ts
@@ -20,6 +20,7 @@ import type { CliCommonArgs } from "../../CliCommonArgs.js";
 import type { ThirdPartyAppRid } from "../../net/ThirdPartyAppRid.js";
 import type { LoadedFoundryConfig } from "../../util/config.js";
 import configLoader from "../../util/configLoader.js";
+import { YargsCheckError } from "../../YargsCheckError.js";
 import type { CommonSiteArgs } from "./CommonSiteArgs.js";
 import deploy from "./deploy/index.js";
 import version from "./version/index.js";
@@ -80,7 +81,7 @@ const command: CommandModule<CliCommonArgs, CommonSiteArgs> = {
         }
 
         if (!argv.foundryUrl.startsWith("https://")) {
-          return "foundryUrl must start with https://";
+          throw new YargsCheckError("foundryUrl must start with https://");
         }
 
         argv.foundryUrl = argv.foundryUrl.replace(/\/$/, "");

--- a/packages/cli/src/commands/site/index.ts
+++ b/packages/cli/src/commands/site/index.ts
@@ -80,7 +80,7 @@ const command: CommandModule<CliCommonArgs, CommonSiteArgs> = {
         }
 
         if (!argv.foundryUrl.startsWith("https://")) {
-          throw new Error("foundryUrl must start with https://");
+          return "foundryUrl must start with https://";
         }
 
         argv.foundryUrl = argv.foundryUrl.replace(/\/$/, "");

--- a/packages/cli/src/net/artifacts/SiteAssetArtifactsService/fetchSiteVersions.mts
+++ b/packages/cli/src/net/artifacts/SiteAssetArtifactsService/fetchSiteVersions.mts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { ExitProcessError } from "../../../ExitProcessError.js";
 import { createFetch } from "../../createFetch.mjs";
 import { fetchWebsiteRepositoryRid } from "../../third-party-application-service/fetchWebsiteRepositoryRid.mjs";
 import type { ThirdPartyAppRid } from "../../ThirdPartyAppRid.js";
@@ -37,7 +38,8 @@ export async function fetchSiteVersions(
     const response: SiteAssetVersions = await result.json();
     return response.versions;
   } else {
-    throw new Error(
+    throw new ExitProcessError(
+      result.status,
       `Unexpected response code ${result.status} (${result.statusText})`,
     );
   }

--- a/packages/cli/src/net/third-party-application-service/fetchWebsiteRepositoryRid.mts
+++ b/packages/cli/src/net/third-party-application-service/fetchWebsiteRepositoryRid.mts
@@ -15,6 +15,7 @@
  */
 
 import { consola } from "consola";
+import { ExitProcessError } from "../../ExitProcessError.js";
 import { createFetch } from "../createFetch.mjs";
 import type { RepositoryRid } from "../RepositoryRid.js";
 import type { ThirdPartyAppRid } from "../ThirdPartyAppRid.js";
@@ -33,7 +34,8 @@ export async function fetchWebsiteRepositoryRid(
     consola.debug(`Repository RID: ${repositoryRid}`);
     return repositoryRid;
   }
-  throw new Error(
+  throw new ExitProcessError(
+    result.status,
     `Unexpected response code ${result.status} (${result.statusText})`,
   );
 }

--- a/packages/cli/src/util/autoVersion.ts
+++ b/packages/cli/src/util/autoVersion.ts
@@ -15,6 +15,7 @@
  */
 
 import { execSync } from "node:child_process";
+import { ExitProcessError } from "../ExitProcessError.js";
 import { isValidSemver } from "./isValidSemver.js";
 
 /**
@@ -37,12 +38,16 @@ export async function autoVersion(tagPrefix: string = ""): Promise<string> {
     );
     const version = gitVersion.trim().replace(prefixRegex, "");
     if (!isValidSemver(version)) {
-      throw new Error(`The version string ${version} is not SemVer compliant.`);
+      throw new ExitProcessError(
+        2,
+        `The version string ${version} is not SemVer compliant.`,
+      );
     }
 
     return version;
   } catch (error) {
-    throw new Error(
+    throw new ExitProcessError(
+      2,
       `Unable to determine the version automatically. Please supply a --version argument. ${error}`,
     );
   }

--- a/packages/cli/src/util/config.test.ts
+++ b/packages/cli/src/util/config.test.ts
@@ -65,7 +65,7 @@ describe("loadFoundryConfig", () => {
     );
 
     await expect(loadFoundryConfig()).rejects.toThrow(
-      "Config file schema is invalid.",
+      "The configuration file does not match",
     );
   });
 
@@ -84,7 +84,7 @@ describe("loadFoundryConfig", () => {
     );
 
     await expect(loadFoundryConfig()).rejects.toThrow(
-      "Config file schema is invalid.",
+      "The configuration file does not match",
     );
   });
 
@@ -106,7 +106,7 @@ describe("loadFoundryConfig", () => {
     );
 
     await expect(loadFoundryConfig()).rejects.toThrow(
-      "Config file schema is invalid.",
+      "The configuration file does not match",
     );
   });
 
@@ -123,7 +123,7 @@ describe("loadFoundryConfig", () => {
     );
 
     await expect(loadFoundryConfig()).rejects.toThrow(
-      "Config file schema is invalid.",
+      "The configuration file does not match",
     );
   });
 
@@ -141,7 +141,7 @@ describe("loadFoundryConfig", () => {
     );
 
     await expect(loadFoundryConfig()).rejects.toThrow(
-      "Config file schema is invalid.",
+      "The configuration file does not match",
     );
   });
 

--- a/packages/cli/src/util/config.ts
+++ b/packages/cli/src/util/config.ts
@@ -16,6 +16,7 @@
 
 import type { JSONSchemaType } from "ajv";
 import { promises as fsPromises } from "node:fs";
+import { ExitProcessError } from "../ExitProcessError.js";
 
 interface GitDescribeAutoVersionConfig {
   type: "git-describe";
@@ -98,15 +99,19 @@ export async function loadFoundryConfig(): Promise<
       const fileContent = await fsPromises.readFile(configFilePath, "utf-8");
       foundryConfig = JSON.parse(fileContent);
     } catch {
-      throw Error(`Couldn't read or parse config file ${configFilePath}`);
+      throw new ExitProcessError(
+        2,
+        `Couldn't read or parse config file ${configFilePath}`,
+      );
     }
 
     if (!validate(foundryConfig)) {
-      consola.error(
-        "The configuration file does not match the expected schema:",
-        ajv.errorsText(validate.errors),
+      throw new ExitProcessError(
+        2,
+        `The configuration file does not match the expected schema: ${
+          ajv.errorsText(validate.errors)
+        }`,
       );
-      throw new Error("Config file schema is invalid.");
     }
 
     return { foundryConfig, configFilePath };

--- a/packages/cli/src/util/token.ts
+++ b/packages/cli/src/util/token.ts
@@ -17,6 +17,7 @@
 import { consola } from "consola";
 import { promises as fsPromises } from "node:fs";
 import path from "node:path";
+import { ExitProcessError } from "../ExitProcessError.js";
 
 const TOKEN_ENV_VARS = ["FOUNDRY_TOKEN", "FOUNDRY_SDK_AUTH_TOKEN"] as const;
 
@@ -60,7 +61,8 @@ export async function loadToken(
     }
   }
 
-  throw new Error(
+  throw new ExitProcessError(
+    2,
     `No token found. Please supply a --token argument, a --token-file argument or set the ${
       TOKEN_ENV_VARS[0]
     } environment variable.`,
@@ -85,7 +87,10 @@ export async function loadTokenFile(filePath: string): Promise<LoadedToken> {
     token = await fsPromises.readFile(resolvedPath, "utf8");
     token = token.trim();
   } catch (error) {
-    throw new Error(`Unable to read token file "${filePath}": ${error}`);
+    throw new ExitProcessError(
+      2,
+      `Unable to read token file "${filePath}": ${error}`,
+    );
   }
 
   return { filePath: resolvedPath, token };
@@ -93,7 +98,7 @@ export async function loadTokenFile(filePath: string): Promise<LoadedToken> {
 
 export function validate(token: string): void {
   if (!isJWT(token)) {
-    throw new Error(`Token does not appear to be a JWT`);
+    throw new ExitProcessError(2, `Token does not appear to be a JWT`);
   }
 }
 

--- a/packages/cli/src/yargs/logVersionMiddleware.ts
+++ b/packages/cli/src/yargs/logVersionMiddleware.ts
@@ -35,7 +35,6 @@ export async function logVersionMiddleware(args: CliCommonArgs) {
       );
     }
 
-    // eslint-disable-next-line no-console
-    console.log(); // Not consola. Just want a blank line
+    consola.log(""); // intentional blank line
   }
 }


### PR DESCRIPTION
- Throw ExitProcessError from all clients and command handlers
- Throw normal Errors in yargs validation and check paths
- Use yargs [`fail`](https://yargs.js.org/docs/#api-reference-failfn-boolean) to handle failures manually and display `ExitProcessError` as consola.error without the cli help text