### PR TITLE
Force dollar sign in osdk verbs for where (break)

### DIFF
--- a/examples/basic/cli/src/examples/fetchEmployeePageByAdUsername.ts
+++ b/examples/basic/cli/src/examples/fetchEmployeePageByAdUsername.ts
@@ -25,7 +25,7 @@ export async function fetchEmployeePageByAdUsername(
   adUsername: string,
 ) {
   const result = await client.objects.Employee.where({
-    $and: [{ adUsername }, { employeeNumber: { ne: 5 } }],
+    $and: [{ adUsername }, { employeeNumber: { $ne: 5 } }],
   }).fetchPageOrThrow();
   // for await (const e of client.objects.Employee.asyncIter()) {
   //   e.__apiName;

--- a/examples/basic/cli/src/examples/fetchEmployeePageByAdUsernameAndLimit.ts
+++ b/examples/basic/cli/src/examples/fetchEmployeePageByAdUsernameAndLimit.ts
@@ -28,8 +28,8 @@ export async function fetchEmployeePageByAdUsernameAndLimit(
   const result = await client.objects.Employee.where({
     $and: [
       { adUsername },
-      { employeeNumber: { ne: 5 } },
-      { employeeNumber: { gte: 5 } },
+      { employeeNumber: { $ne: 5 } },
+      { employeeNumber: { $gte: 5 } },
     ],
   }).fetchPageOrThrow({
     select: ["adUsername", "employeeNumber", "jobProfile"],

--- a/examples/basic/sdk/src/syntax.test.ts
+++ b/examples/basic/sdk/src/syntax.test.ts
@@ -170,7 +170,7 @@ async function aggregateThingsWithGroupsAndHandleErrors() {
     groupBy: {
       text: "exact",
     },
-    where: { id: { gt: 5 } },
+    where: { id: { $gt: 5 } },
   });
 
   if (isOk(result)) {

--- a/packages/client/changelog/@unreleased/pr-45.v2.yml
+++ b/packages/client/changelog/@unreleased/pr-45.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Force dollar sign in osdk verbs for where (break)
+  links:
+  - https://github.com/palantir/osdk-ts/pull/45

--- a/packages/client/src/internal/conversions/modernToLegacyWhereClause.test.ts
+++ b/packages/client/src/internal/conversions/modernToLegacyWhereClause.test.ts
@@ -223,7 +223,7 @@ describe(modernToLegacyWhereClause, () => {
 
     it("inverts ne short hand properly", () => {
       expect(modernToLegacyWhereClause<ObjAllProps>({
-        integer: { ne: 5 },
+        integer: { $ne: 5 },
       })).toMatchInlineSnapshot(`
         {
           "type": "not",

--- a/packages/client/src/object/object.test.ts
+++ b/packages/client/src/object/object.test.ts
@@ -68,8 +68,8 @@ describe("OsdkObject", () => {
       // slightly weird request here to hit the existing mocks for employee2
       const employees = await client.objects.Employee.where({
         $and: [
-          { "employeeId": { "gt": 50030 } },
-          { "employeeId": { "lt": 50032 } },
+          { "employeeId": { "$gt": 50030 } },
+          { "employeeId": { "$lt": 50032 } },
         ],
       }).fetchPageOrThrow();
       const lead = employees.data[0];
@@ -90,8 +90,8 @@ describe("OsdkObject", () => {
       // slightly weird request here to hit the existing mocks for employee2
       const employees = await client.objects.Employee.where({
         $and: [
-          { "employeeId": { "gt": 50030 } },
-          { "employeeId": { "lt": 50032 } },
+          { "employeeId": { "$gt": 50030 } },
+          { "employeeId": { "$lt": 50032 } },
         ],
       }).fetchPageOrThrow();
       const lead = employees.data[0];

--- a/packages/client/src/query/WhereClause.ts
+++ b/packages/client/src/query/WhereClause.ts
@@ -23,14 +23,14 @@ import type {
 import type { DistanceUnit } from "@osdk/gateway/types";
 
 export type PossibleWhereClauseFilters =
-  | "gt"
-  | "eq"
-  | "ne"
-  | "isNull"
-  | "contains"
-  | "gte"
-  | "lt"
-  | "lte"
+  | "$gt"
+  | "$eq"
+  | "$ne"
+  | "$isNull"
+  | "$contains"
+  | "$gte"
+  | "$lt"
+  | "$lte"
   | "$within";
 
 // We need to conditional here to force the union to be distributed
@@ -41,13 +41,13 @@ type MakeFilter<K extends PossibleWhereClauseFilters, V> = K extends string ? {
 
 type BaseFilter<T> =
   | T
-  | MakeFilter<"eq" | "ne" | "contains", T>
-  | MakeFilter<"isNull", boolean>;
+  | MakeFilter<"$eq" | "$ne" | "$contains", T>
+  | MakeFilter<"$isNull", boolean>;
 
 type StringFilter = BaseFilter<string>;
 type NumberFilter =
   | BaseFilter<number>
-  | MakeFilter<"gt" | "gte" | "lt" | "lte", number>;
+  | MakeFilter<"$gt" | "$gte" | "$lt" | "$lte", number>;
 
 export const DistanceUnitMapping = {
   "centimeter": "CENTIMETERS",


### PR DESCRIPTION
Given the struct future, forcing the strict syntax now.

This will break internal 2.0 users. 