### PR TITLE
Harmonize usage of options `foundryUrl` & `clientId` across all cli commands

### DIFF
--- a/packages/cli/changelog/@unreleased/pr-50.v2.yml
+++ b/packages/cli/changelog/@unreleased/pr-50.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Harmonize usage of optional `foundryUrl` across all cli commands
+  links:
+  - https://github.com/palantir/osdk-ts/pull/50

--- a/packages/cli/src/commands/auth/CommonAuthArgs.ts
+++ b/packages/cli/src/commands/auth/CommonAuthArgs.ts
@@ -17,5 +17,5 @@
 import type { CliCommonArgs } from "../../CliCommonArgs.js";
 
 export interface CommonAuthArgs extends CliCommonArgs {
-  baseUrl: string;
+  foundryUrl: string;
 }

--- a/packages/cli/src/commands/auth/index.ts
+++ b/packages/cli/src/commands/auth/index.ts
@@ -25,9 +25,10 @@ const site: yargs.CommandModule<CliCommonArgs, CommonAuthArgs> = {
   builder: (argv) => {
     return argv
       .options({
-        baseUrl: {
+        foundryUrl: {
           type: "string",
           demandOption: true,
+          alias: "baseUrl", // for backwards compatibility
         },
       })
       .command(login)

--- a/packages/cli/src/commands/auth/login/LoginArgs.ts
+++ b/packages/cli/src/commands/auth/login/LoginArgs.ts
@@ -17,5 +17,5 @@
 import type { CommonAuthArgs } from "../CommonAuthArgs.js";
 
 export interface LoginArgs extends CommonAuthArgs {
-  applicationId: string;
+  clientId: string;
 }

--- a/packages/cli/src/commands/auth/login/index.ts
+++ b/packages/cli/src/commands/auth/login/index.ts
@@ -26,7 +26,8 @@ export const command: CommandModule<
   describe: "Authenticate with an application ID",
   builder: (argv) => {
     return argv
-      .option("applicationId", {
+      .option("clientId", {
+        alias: "applicationId", // for backwards compatibility
         type: "string",
         demandOption: true,
       });

--- a/packages/cli/src/commands/auth/login/loginFlow.ts
+++ b/packages/cli/src/commands/auth/login/loginFlow.ts
@@ -60,7 +60,7 @@ export default async function invokeLoginFlow(args: LoginArgs) {
   const codeChallenge = await generateCodeChallenge(codeVerifier);
 
   const authorizeUrl = generateAuthorizeUrl(
-    args.baseUrl,
+    args.foundryUrl,
     clientId,
     state,
     redirectUrl,
@@ -91,7 +91,7 @@ export default async function invokeLoginFlow(args: LoginArgs) {
     clientId,
     redirectUrl,
     code,
-    args.baseUrl,
+    args.foundryUrl,
     codeVerifier,
   );
 

--- a/packages/cli/src/commands/auth/login/loginFlow.ts
+++ b/packages/cli/src/commands/auth/login/loginFlow.ts
@@ -29,7 +29,7 @@ import { isTokenErrorResponse } from "./token.js";
 const BROWSER_PROMPT_TIME_MS = 60 * 1000;
 
 export default async function invokeLoginFlow(args: LoginArgs) {
-  consola.start(`Authenticating using application id: ${args.applicationId}`);
+  consola.start(`Authenticating using application id: ${args.clientId}`);
   const redirectUrl = "http://localhost:8080/auth/callback";
   const port = parse(redirectUrl).port;
   let resolve: (value: string) => void;
@@ -54,7 +54,7 @@ export default async function invokeLoginFlow(args: LoginArgs) {
   });
 
   server.listen(port);
-  const clientId = args.applicationId;
+  const clientId = args.clientId;
   const state = generateRandomString();
   const codeVerifier = generateRandomString();
   const codeChallenge = await generateCodeChallenge(codeVerifier);

--- a/packages/cli/src/commands/typescript/generate/TypescriptGenerateArgs.ts
+++ b/packages/cli/src/commands/typescript/generate/TypescriptGenerateArgs.ts
@@ -18,7 +18,7 @@ export interface TypescriptGenerateArgs {
   outDir: string;
   ontologyPath?: string;
   ontologyWritePath?: string;
-  stack?: string;
+  foundryUrl?: string;
   clientId?: string;
   beta?: boolean;
   packageType: "commonjs" | "module";

--- a/packages/cli/src/commands/typescript/generate/generate.ts
+++ b/packages/cli/src/commands/typescript/generate/generate.ts
@@ -34,27 +34,29 @@ export const command: CommandModule<
             demandOption: true,
           },
           ontologyPath: {
-            description: "path to the ontology wire json",
+            description: "Path to the ontology wire json",
             type: "string",
             demandOption: false,
-            conflicts: ["stack", "clientId"],
+            conflicts: ["foundryUrl", "clientId"],
           },
-          stack: {
-            description: "the URL to the stack that contains the ontology",
+          foundryUrl: {
+            description:
+              "The URL to the foundry stack that contains the ontology",
             type: "string",
             demandOption: false,
             conflicts: "ontologyPath",
             implies: "clientId",
+            alias: "stack", // For backwards compatibility
           },
           clientId: {
-            description: "the application's client id",
+            description: "The application's client id",
             type: "string",
             demandOption: false,
             conflicts: "ontologyPath",
-            implies: "stack",
+            implies: "foundryUrl",
           },
           ontologyWritePath: {
-            description: "path to write the ontology wire json",
+            description: "Path to write the ontology wire json",
             type: "string",
             demandOption: false,
             conflicts: ["ontologyPath"],
@@ -78,14 +80,14 @@ export const command: CommandModule<
         ["ontologyPath", "outDir", "version"],
         "Generate from a local file",
       ).group(
-        ["stack", "clientId", "outDir", "ontologyWritePath", "version"],
-        "OR Generate from a stack",
+        ["foundryUrl", "clientId", "outDir", "ontologyWritePath", "version"],
+        "OR Generate from Foundry",
       )
       .check(
         (argv) => {
-          if (!argv.ontologyPath && !argv.stack) {
+          if (!argv.ontologyPath && !argv.foundryUrl) {
             throw new Error(
-              "Error: Must specify either ontologyPath or stack and clientId",
+              "Error: Must specify either ontologyPath or foundryUrl and clientId",
             );
           }
 

--- a/packages/cli/src/commands/typescript/generate/generate.ts
+++ b/packages/cli/src/commands/typescript/generate/generate.ts
@@ -46,7 +46,7 @@ export const command: CommandModule<
             demandOption: false,
             conflicts: "ontologyPath",
             implies: "clientId",
-            alias: "stack", // For backwards compatibility
+            alias: "stack", // for backwards compatibility
           },
           clientId: {
             description: "The application's client id",

--- a/packages/cli/src/commands/typescript/generate/handleGenerate.mts
+++ b/packages/cli/src/commands/typescript/generate/handleGenerate.mts
@@ -35,7 +35,7 @@ export default async function handleGenerate(args: TypescriptGenerateArgs) {
   let success = false;
   if (args.ontologyPath) {
     success = await generateFromLocalFile(args);
-  } else if (args.stack && args.clientId) {
+  } else if (args.foundryUrl && args.clientId) {
     success = await generateFromStack(args);
   } else {
     throw new Error("Must have specified ontologyPath or stack and clientId");
@@ -60,13 +60,13 @@ async function generateFromLocalFile(args: TypescriptGenerateArgs) {
 }
 
 async function generateFromStack(args: TypescriptGenerateArgs) {
-  const { stack, clientId, ontologyWritePath } = args as
+  const { foundryUrl, clientId, ontologyWritePath } = args as
     & TypescriptGenerateArgs
-    & { stack: string; clientId: string };
+    & { foundryUrl: string; clientId: string };
 
   const token = await invokeLoginFlow({
     applicationId: clientId,
-    baseUrl: stack,
+    foundryUrl,
     verbose: 0,
   });
   const { fetch } = createClientContext(
@@ -75,14 +75,14 @@ async function generateFromStack(args: TypescriptGenerateArgs) {
         userAgent: USER_AGENT,
       },
     },
-    args.stack!,
+    args.foundryUrl!,
     () => token.access_token,
     USER_AGENT,
   );
 
   try {
     const ontologies = await listOntologiesV2(
-      createOpenApiRequest(stack, fetch),
+      createOpenApiRequest(foundryUrl, fetch),
     );
 
     if (ontologies.data.length !== 1) {
@@ -93,7 +93,7 @@ async function generateFromStack(args: TypescriptGenerateArgs) {
     }
 
     const ontology = await getOntologyFullMetadata(
-      createOpenApiRequest(stack, fetch),
+      createOpenApiRequest(foundryUrl, fetch),
       ontologies.data[0].apiName,
     );
 

--- a/packages/cli/src/commands/typescript/generate/handleGenerate.mts
+++ b/packages/cli/src/commands/typescript/generate/handleGenerate.mts
@@ -65,7 +65,7 @@ async function generateFromStack(args: TypescriptGenerateArgs) {
     & { foundryUrl: string; clientId: string };
 
   const token = await invokeLoginFlow({
-    applicationId: clientId,
+    clientId,
     foundryUrl,
     verbose: 0,
   });


### PR DESCRIPTION
## Changes

Replaces the option "stack" in generate command and option "baseUrl" in login command with "foundryUrl" to be consistent with the site command.

Similarly, replace the option "applicationId" to "clientId"

Left both old options as aliases of the new option to maintain backwards compatibility. If that shouldn't be the case will remove the aliases.

## Open Questions

- Considered changing applicationId to clientId in the login command for consistency with the typescript command, but wasn't sure if application could be anything but the clientId.
- `outDir` reflects the output directory unlike in site command `directory` actually maps to input directory, so didn't think there is much use of changing that unless we want to have consistency of using dir vs directory and in/out?