### PR TITLE
Clean up yargs and consola imports

### DIFF
--- a/packages/cli/changelog/@unreleased/pr-51.v2.yml
+++ b/packages/cli/changelog/@unreleased/pr-51.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Clean up yargs handling and consola imports
+  links:
+  - https://github.com/palantir/osdk-ts/pull/51

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -79,7 +79,6 @@ export async function cli(args: string[] = process.argv) {
   } catch (err) {
     if (err instanceof ExitProcessError) {
       consola.error(err);
-      consola.debug(err.stack);
     }
   }
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { consola } from "consola";
 import type { Argv } from "yargs";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
@@ -46,6 +47,7 @@ export async function cli(args: string[] = process.argv) {
     .command({
       command: "unstable",
       aliases: ["experimental"],
+      describe: "Unstable commands",
       builder: async (argv) => {
         return argv
           .command(site)
@@ -55,26 +57,17 @@ export async function cli(args: string[] = process.argv) {
       },
       handler: (_args) => {},
     })
-    .fail(async (msg, err, yargsContext) => {
-      const Consola = await import("consola");
-      const isVerbose = args.some(arg =>
-        ["-v", "--v", "--verbose"].includes(arg)
-      );
-
+    .fail(async (msg, err, argv) => {
       if (err instanceof ExitProcessError) {
-        if (isVerbose) {
-          Consola.consola.error(err);
-        } else {
-          Consola.consola.error(err.message);
-        }
+        consola.error(err.message);
+        consola.debug(err.stack);
       } else {
         if (err && err instanceof YargsCheckError === false) {
           throw err;
         } else {
-          yargsContext.showHelp();
-          Consola.consola.log(""); // intentional blank line
-          // eslint-disable-next-line no-console
-          console.error(msg);
+          argv.showHelp();
+          consola.log(""); // intentional blank line
+          consola.error(msg);
         }
       }
       process.exit(1);
@@ -85,8 +78,8 @@ export async function cli(args: string[] = process.argv) {
     return await base.parseAsync();
   } catch (err) {
     if (err instanceof ExitProcessError) {
-      const Consola = await import("consola");
-      Consola.consola.error(err);
+      consola.error(err);
+      consola.debug(err.stack);
     }
   }
 }

--- a/packages/cli/src/commands/site/deploy/index.ts
+++ b/packages/cli/src/commands/site/deploy/index.ts
@@ -80,26 +80,26 @@ const command: CommandModule<
         ["version", "directory", "uploadOnly"],
         "Common Arguments",
       )
-      .check((argv) => {
+      .check((args) => {
         // This is required because we can't use demandOption with conflicts. conflicts protects us against the case where both are provided.
         // So this case is for when nothing is provided.
         if (
-          autoVersion == null && argv.autoVersion == null
-          && argv.version == null
+          autoVersion == null && args.autoVersion == null
+          && args.version == null
         ) {
           throw new YargsCheckError(
             "One of --version or --autoVersion must be specified",
           );
         }
 
-        const autoVersionType = argv.autoVersion ?? autoVersion;
+        const autoVersionType = args.autoVersion ?? autoVersion;
         if (autoVersionType !== "git-describe") {
           throw new YargsCheckError(
             `Only 'git-describe' is supported for autoVersion`,
           );
         }
 
-        const gitTagPrefixValue = argv.gitTagPrefix ?? gitTagPrefix;
+        const gitTagPrefixValue = args.gitTagPrefix ?? gitTagPrefix;
         // Future proofing for when we support other autoVersion types
         if (gitTagPrefixValue != null && autoVersionType !== "git-describe") {
           throw new YargsCheckError(
@@ -108,9 +108,9 @@ const command: CommandModule<
         }
 
         return true;
-      }).middleware((argv) =>
+      }).middleware((args) =>
         logDeployCommandConfigFileOverride(
-          argv,
+          args,
           siteConfig,
         )
       );

--- a/packages/cli/src/commands/site/deploy/logDeployCommandConfigFileOverride.ts
+++ b/packages/cli/src/commands/site/deploy/logDeployCommandConfigFileOverride.ts
@@ -14,38 +14,36 @@
  * limitations under the License.
  */
 
+import { consola } from "consola";
 import type { Arguments } from "yargs";
 import type { SiteConfig } from "../../../util/config.js";
 import type { SiteDeployArgs } from "./SiteDeployArgs.js";
 
 export async function logDeployCommandConfigFileOverride(
-  argv: Arguments<SiteDeployArgs>,
+  args: Arguments<SiteDeployArgs>,
   config: SiteConfig | undefined,
 ) {
-  const Consola = await import("consola");
-  const consola = Consola.consola;
-
   if (
-    config?.autoVersion != null && argv.autoVersion !== config?.autoVersion.type
+    config?.autoVersion != null && args.autoVersion !== config?.autoVersion.type
   ) {
     consola.debug(
-      `Overriding "autoVersion" from config file with ${argv.autoVersion}`,
+      `Overriding "autoVersion" from config file with ${args.autoVersion}`,
     );
   }
 
-  if (config?.directory != null && argv.directory !== config?.directory) {
+  if (config?.directory != null && args.directory !== config?.directory) {
     consola.debug(
-      `Overriding "directory" from config file with ${argv.directory}`,
+      `Overriding "directory" from config file with ${args.directory}`,
     );
   }
 
   if (
     config?.autoVersion?.tagPrefix != null
-    && argv.gitTagPrefix != null
-    && argv.gitTagPrefix !== config?.autoVersion.tagPrefix
+    && args.gitTagPrefix != null
+    && args.gitTagPrefix !== config?.autoVersion.tagPrefix
   ) {
     consola.debug(
-      `Overriding "gitTagPrefix" from config file with ${argv.gitTagPrefix}`,
+      `Overriding "gitTagPrefix" from config file with ${args.gitTagPrefix}`,
     );
   }
 }

--- a/packages/cli/src/commands/site/index.ts
+++ b/packages/cli/src/commands/site/index.ts
@@ -68,14 +68,14 @@ const command: CommandModule<CliCommonArgs, CommonSiteArgs> = {
       )
       .command(version)
       .command(deploy)
-      .check((argv) => {
-        if (!argv.foundryUrl.startsWith("https://")) {
+      .check((args) => {
+        if (!args.foundryUrl.startsWith("https://")) {
           throw new YargsCheckError("foundryUrl must start with https://");
         }
         return true;
       })
-      .middleware((argv) =>
-        logSiteCommandConfigFileOverride(argv, config?.foundryConfig)
+      .middleware((args) =>
+        logSiteCommandConfigFileOverride(args, config?.foundryConfig)
       )
       .demandCommand();
   },

--- a/packages/cli/src/commands/site/logSiteCommandConfigFileOverride.ts
+++ b/packages/cli/src/commands/site/logSiteCommandConfigFileOverride.ts
@@ -14,29 +14,27 @@
  * limitations under the License.
  */
 
+import { consola } from "consola";
 import type { Arguments } from "yargs";
 import type { FoundryConfig } from "../../util/config.js";
 import type { CommonSiteArgs } from "./CommonSiteArgs.js";
 
 export async function logSiteCommandConfigFileOverride(
-  argv: Arguments<CommonSiteArgs>,
+  args: Arguments<CommonSiteArgs>,
   config: FoundryConfig | undefined,
 ) {
-  const Consola = await import("consola");
-  const consola = Consola.consola;
-
   if (
     config?.site.application != null
-    && argv.application !== config.site.application
+    && args.application !== config.site.application
   ) {
     consola.debug(
-      `Overriding "application" from config file with ${argv.application}`,
+      `Overriding "application" from config file with ${args.application}`,
     );
   }
 
-  if (config?.foundryUrl != null && argv.foundryUrl !== config.foundryUrl) {
+  if (config?.foundryUrl != null && args.foundryUrl !== config.foundryUrl) {
     consola.debug(
-      `Overriding "foundryUrl" from config file with ${argv.foundryUrl}`,
+      `Overriding "foundryUrl" from config file with ${args.foundryUrl}`,
     );
   }
 }

--- a/packages/cli/src/commands/typescript/generate/generate.ts
+++ b/packages/cli/src/commands/typescript/generate/generate.ts
@@ -82,14 +82,14 @@ export const command: CommandModule<
         "OR Generate from a stack",
       )
       .check(
-        (argv) => {
-          if (!argv.ontologyPath && !argv.stack) {
+        (args) => {
+          if (!args.ontologyPath && !args.stack) {
             throw new Error(
               "Error: Must specify either ontologyPath or stack and clientId",
             );
           }
 
-          if (argv.version !== "dev" && !isValidSemver(argv.version)) {
+          if (args.version !== "dev" && !isValidSemver(args.version)) {
             throw new Error(
               "Error: Version must be 'dev' or a valid semver version",
             );

--- a/packages/cli/src/util/config.ts
+++ b/packages/cli/src/util/config.ts
@@ -87,9 +87,6 @@ export async function loadFoundryConfig(): Promise<
   const ajv = new Ajv({ allErrors: true });
   const validate = ajv.compile(CONFIG_FILE_SCHEMA);
 
-  const Consola = await import("consola");
-  const consola = Consola.consola;
-
   const { findUp } = await import("find-up");
   const configFilePath = await findUp(CONFIG_FILE_NAMES);
 

--- a/packages/cli/src/yargs/logConfigFileMiddleware.ts
+++ b/packages/cli/src/yargs/logConfigFileMiddleware.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { consola } from "consola";
 import getConfig from "../util/configLoader.js";
 
 let firstTime = true;
@@ -23,8 +24,6 @@ export async function logConfigFileMiddleware() {
     const config = getConfig();
     const configFilePath = (await config)?.configFilePath;
     if (configFilePath) {
-      const Consola = await import("consola");
-      const consola = Consola.consola;
       consola.debug(
         `Using configuration from file: "${configFilePath}"`,
       );

--- a/packages/cli/src/yargs/logVersionMiddleware.ts
+++ b/packages/cli/src/yargs/logVersionMiddleware.ts
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
+import { consola } from "consola";
 import type { CliCommonArgs } from "../CliCommonArgs.js";
 
 let firstTime = true;
 export async function logVersionMiddleware(args: CliCommonArgs) {
   if (firstTime) {
     firstTime = false;
-    const Consola = await import("consola");
     // This will be called before any command is executed
-    const consola = Consola.consola;
-
     consola.info(
       `Palantir OSDK CLI ${process.env.PACKAGE_VERSION}`,
     );


### PR DESCRIPTION
- Consistently name `argv` as the `yargs.Argv` builder type and `args` as the parsed `yargs.Arguments` type
- Make all consola imports static imports at the moment there's a big mix of both and consola is always going to be needed immediately in the CLI
- Add description for top level unstable command so that it actually shows up in the default generated help text
- Simplify custom fail logging verbose logic to just log stack in debug level
- Print CLI errors as consola error for consistency and more visibility at end of CLI