### PR TITLE
Adding bulk actions to 1.1

### DIFF
--- a/examples/one_dot_one/src/generatedNoCheck/Ontology.ts
+++ b/examples/one_dot_one/src/generatedNoCheck/Ontology.ts
@@ -1,6 +1,7 @@
 import type { OntologyDefinition } from '@osdk/api';
 import type { Ontology as ClientOntology } from '@osdk/legacy-client';
 import type { Actions } from './ontology/actions/Actions';
+import type { BulkActions } from './ontology/actions/BulkActions';
 import { actionTakesAllParameterTypes } from './ontology/actions/actionTakesAllParameterTypes';
 import { createTodo } from './ontology/actions/createTodo';
 import { ObjectTypeWithAllPropertyTypes } from './ontology/objects/ObjectTypeWithAllPropertyTypes';
@@ -58,5 +59,6 @@ export const Ontology: {
 export interface Ontology extends ClientOntology<typeof Ontology> {
   objects: Objects;
   actions: Actions;
+  bulkActions: BulkActions;
   queries: Queries;
 }

--- a/examples/one_dot_one/src/generatedNoCheck/ontology/actions/BulkActions.ts
+++ b/examples/one_dot_one/src/generatedNoCheck/ontology/actions/BulkActions.ts
@@ -38,6 +38,7 @@ export interface BulkActions {
    * Creates a new Todo
    */
   createTodo<O extends BulkActionExecutionOptions>(
+    params: {}[],
     options?: O,
   ): Promise<Result<BulkActionResponseFromOptions<O, Edits<Todo, void>>, ActionError>>;
 }

--- a/examples/one_dot_one/src/generatedNoCheck/ontology/actions/BulkActions.ts
+++ b/examples/one_dot_one/src/generatedNoCheck/ontology/actions/BulkActions.ts
@@ -38,7 +38,7 @@ export interface BulkActions {
    * Creates a new Todo
    */
   createTodo<O extends BulkActionExecutionOptions>(
-    params: {}[],
+    params: Record<string, never>[],
     options?: O,
   ): Promise<Result<BulkActionResponseFromOptions<O, Edits<Todo, void>>, ActionError>>;
 }

--- a/examples/one_dot_one/src/generatedNoCheck/ontology/actions/BulkActions.ts
+++ b/examples/one_dot_one/src/generatedNoCheck/ontology/actions/BulkActions.ts
@@ -12,7 +12,7 @@ import type {
 import type { ObjectTypeWithAllPropertyTypes } from '../objects/ObjectTypeWithAllPropertyTypes';
 import type { Person } from '../objects/Person';
 import type { Todo } from '../objects/Todo';
-export interface Actions {
+export interface BulkActions {
   /**
    * An action which takes different types of parameters
    * @param {ObjectSet<Todo>} params.objectSet
@@ -38,7 +38,6 @@ export interface Actions {
    * Creates a new Todo
    */
   createTodo<O extends BulkActionExecutionOptions>(
-    [],
     options?: O,
   ): Promise<Result<BulkActionResponseFromOptions<O, Edits<Todo, void>>, ActionError>>;
 }

--- a/examples/one_dot_one/src/generatedNoCheck/ontology/actions/BulkActions.ts
+++ b/examples/one_dot_one/src/generatedNoCheck/ontology/actions/BulkActions.ts
@@ -1,0 +1,44 @@
+import type {
+  ActionError,
+  Attachment,
+  BulkActionExecutionOptions,
+  BulkActionResponseFromOptions,
+  Edits,
+  LocalDate,
+  ObjectSet,
+  Result,
+  Timestamp,
+} from '@osdk/legacy-client';
+import type { ObjectTypeWithAllPropertyTypes } from '../objects/ObjectTypeWithAllPropertyTypes';
+import type { Person } from '../objects/Person';
+import type { Todo } from '../objects/Todo';
+export interface Actions {
+  /**
+   * An action which takes different types of parameters
+   * @param {ObjectSet<Todo>} params.objectSet
+   * @param {Person | Person["__primaryKey"]} params.object
+   * @param {string} params.string
+   * @param {Timestamp} params.time-stamp
+   * @param {Array<LocalDate>} params.dateArray
+   * @param {Array<Attachment>} params.attachmentArray
+   */
+  actionTakesAllParameterTypes<O extends BulkActionExecutionOptions>(
+    params: {
+      objectSet: ObjectSet<Todo>;
+      object?: Person | Person['__primaryKey'];
+      string: string;
+      'time-stamp': Timestamp;
+      dateArray?: Array<LocalDate>;
+      attachmentArray: Array<Attachment>;
+    }[],
+    options?: O,
+  ): Promise<Result<BulkActionResponseFromOptions<O, Edits<Todo, Todo | ObjectTypeWithAllPropertyTypes>>, ActionError>>;
+
+  /**
+   * Creates a new Todo
+   */
+  createTodo<O extends BulkActionExecutionOptions>(
+    [],
+    options?: O,
+  ): Promise<Result<BulkActionResponseFromOptions<O, Edits<Todo, void>>, ActionError>>;
+}

--- a/examples/todoapp/src/generatedNoCheck/Ontology.ts
+++ b/examples/todoapp/src/generatedNoCheck/Ontology.ts
@@ -1,6 +1,7 @@
 import type { OntologyDefinition } from '@osdk/api';
 import type { Ontology as ClientOntology } from '@osdk/legacy-client';
 import type { Actions } from './ontology/actions/Actions';
+import type { BulkActions } from './ontology/actions/BulkActions';
 import { completeTodo } from './ontology/actions/completeTodo';
 import { createTodo } from './ontology/actions/createTodo';
 import type { Objects } from './ontology/objects/Objects';
@@ -40,5 +41,6 @@ export const Ontology: {
 export interface Ontology extends ClientOntology<typeof Ontology> {
   objects: Objects;
   actions: Actions;
+  bulkActions: BulkActions;
   queries: Queries;
 }

--- a/examples/todoapp/src/generatedNoCheck/ontology/actions/BulkActions.ts
+++ b/examples/todoapp/src/generatedNoCheck/ontology/actions/BulkActions.ts
@@ -1,0 +1,35 @@
+import type {
+  ActionError,
+  BulkActionExecutionOptions,
+  BulkActionResponseFromOptions,
+  Edits,
+  Result,
+} from '@osdk/legacy-client';
+import type { Todo } from '../objects/Todo';
+export interface Actions {
+  /**
+   * Creates Todo
+   * @param {string} params.Todo
+   * @param {boolean} params.is_complete
+   */
+  createTodo<O extends BulkActionExecutionOptions>(
+    params: {
+      Todo: string;
+      is_complete: boolean;
+    }[],
+    options?: O,
+  ): Promise<Result<BulkActionResponseFromOptions<O, Edits<Todo, void>>, ActionError>>;
+
+  /**
+   * Completes Todo
+   * @param {Todo | Todo["__primaryKey"]} params.Todo
+   * @param {boolean} params.is_complete
+   */
+  completeTodo<O extends BulkActionExecutionOptions>(
+    params: {
+      Todo: Todo | Todo['__primaryKey'];
+      is_complete: boolean;
+    }[],
+    options?: O,
+  ): Promise<Result<BulkActionResponseFromOptions<O, Edits<void, Todo>>, ActionError>>;
+}

--- a/examples/todoapp/src/generatedNoCheck/ontology/actions/BulkActions.ts
+++ b/examples/todoapp/src/generatedNoCheck/ontology/actions/BulkActions.ts
@@ -6,7 +6,7 @@ import type {
   Result,
 } from '@osdk/legacy-client';
 import type { Todo } from '../objects/Todo';
-export interface Actions {
+export interface BulkActions {
   /**
    * Creates Todo
    * @param {string} params.Todo

--- a/packages/generator/changelog/@unreleased/pr-53.v2.yml
+++ b/packages/generator/changelog/@unreleased/pr-53.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Adding bulk actions to 1.1
+  links:
+  - https://github.com/palantir/osdk-ts/pull/53

--- a/packages/generator/src/v1.1/generateActions.ts
+++ b/packages/generator/src/v1.1/generateActions.ts
@@ -98,7 +98,7 @@ export async function generateActions(
   );
 }
 
-function getTypeScriptTypeFromDataType(
+export function getTypeScriptTypeFromDataType(
   actionParameter: ActionParameterType,
   importedObjects: Set<string>,
 ): string {

--- a/packages/generator/src/v1.1/generateBulkActions.test.ts
+++ b/packages/generator/src/v1.1/generateBulkActions.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { createMockMinimalFiles } from "../util/test/createMockMinimalFiles";
+import { TodoWireOntology } from "../util/test/TodoWireOntology";
+import { generateBulkActions } from "./generateBulkActions";
+
+describe(generateBulkActions, () => {
+  it("generates bulk action interface", async () => {
+    const helper = createMockMinimalFiles();
+    const BASE_PATH = "/foo";
+
+    await generateBulkActions(
+      TodoWireOntology,
+      helper.minimalFiles,
+      BASE_PATH,
+    );
+
+    expect(helper.minimalFiles.writeFile).toBeCalled();
+
+    expect(helper.getFiles()[`${BASE_PATH}/BulkActions.ts`])
+      .toMatchInlineSnapshot(`
+      "import type {
+        ActionError,
+        BulkActionExecutionOptions,
+        BulkActionResponseFromOptions,
+        Edits,
+        Result,
+      } from '@osdk/legacy-client';
+      import type { Todo } from '../objects/Todo';
+      export interface BulkActions {
+        /**
+         * An action which takes different types of parameters
+         * @param {Todo | Todo["__primaryKey"]} params.object
+         */
+        markTodoCompleted<O extends BulkActionExecutionOptions>(
+          params: {
+            object?: Todo | Todo['__primaryKey'];
+          }[],
+          options?: O,
+        ): Promise<Result<BulkActionResponseFromOptions<O, Edits<void, Todo>>, ActionError>>;
+      }
+      "
+      `);
+  });
+});

--- a/packages/generator/src/v1.1/generateBulkActions.ts
+++ b/packages/generator/src/v1.1/generateBulkActions.ts
@@ -61,14 +61,14 @@ export async function generateBulkActions(
           `* @param {${typeScriptType}} params.${parameterName}`,
         );
       }
-      parameterBlock += "} ";
+      parameterBlock += "}[], ";
     }
 
     jsDocBlock.push(`*/`);
     actionSignatures.push(
       `
       ${jsDocBlock.join("\n")}
-      ${action.apiName}<O extends BulkActionExecutionOptions>(${parameterBlock}[],options?: O): 
+      ${action.apiName}<O extends BulkActionExecutionOptions>(${parameterBlock}options?: O): 
         Promise<Result<BulkActionResponseFromOptions<O, Edits<${
         addedObjects.length > 0
           ? addedObjects.join(" | ")

--- a/packages/generator/src/v1.1/generateBulkActions.ts
+++ b/packages/generator/src/v1.1/generateBulkActions.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import type { ActionParameterType } from "@osdk/gateway/types";
 import path from "node:path";
 import type { MinimalFs } from "../MinimalFs";
 import { getModifiedEntityTypes } from "../shared/getEditedEntities";
 import { formatTs } from "../util/test/formatTs";
 import type { WireOntologyDefinition } from "../WireOntologyDefinition";
+import { getTypeScriptTypeFromDataType } from "./generateActions";
 
 export async function generateBulkActions(
   ontology: WireOntologyDefinition,
@@ -97,43 +97,4 @@ export async function generateBulkActions(
     }
   `),
   );
-}
-
-function getTypeScriptTypeFromDataType(
-  actionParameter: ActionParameterType,
-  importedObjects: Set<string>,
-): string {
-  switch (actionParameter.type) {
-    case "objectSet": {
-      const objectType = actionParameter.objectTypeApiName!;
-      importedObjects.add(objectType);
-      return `ObjectSet<${objectType}>`;
-    }
-    case "object": {
-      const objectType = actionParameter.objectTypeApiName!;
-      importedObjects.add(objectType);
-      return `${objectType} | ${objectType}["__primaryKey"]`;
-    }
-    case "array":
-      return `Array<${
-        getTypeScriptTypeFromDataType(actionParameter.subType, importedObjects)
-      }>`;
-    case "string":
-      return `string`;
-    case "boolean":
-      return `boolean`;
-    case "attachment":
-      return `Attachment`;
-    case "date":
-      return `LocalDate`;
-    case "double":
-    case "integer":
-    case "long":
-      return `number`;
-    case "timestamp":
-      return `Timestamp`;
-    default:
-      const _: never = actionParameter;
-      throw new Error(`Unsupported action parameter type: ${actionParameter}`);
-  }
 }

--- a/packages/generator/src/v1.1/generateBulkActions.ts
+++ b/packages/generator/src/v1.1/generateBulkActions.ts
@@ -63,7 +63,7 @@ export async function generateBulkActions(
       }
       parameterBlock += "}[], ";
     } else {
-      parameterBlock = `params: {}[], `;
+      parameterBlock = `params: Record<string,never>[], `;
     }
 
     jsDocBlock.push(`*/`);

--- a/packages/generator/src/v1.1/generateBulkActions.ts
+++ b/packages/generator/src/v1.1/generateBulkActions.ts
@@ -62,6 +62,8 @@ export async function generateBulkActions(
         );
       }
       parameterBlock += "}[], ";
+    } else {
+      parameterBlock = `params: {}[], `;
     }
 
     jsDocBlock.push(`*/`);

--- a/packages/generator/src/v1.1/generateBulkActions.ts
+++ b/packages/generator/src/v1.1/generateBulkActions.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ActionParameterType } from "@osdk/gateway/types";
+import path from "node:path";
+import type { MinimalFs } from "../MinimalFs";
+import { getModifiedEntityTypes } from "../shared/getEditedEntities";
+import { formatTs } from "../util/test/formatTs";
+import type { WireOntologyDefinition } from "../WireOntologyDefinition";
+
+export async function generateBulkActions(
+  ontology: WireOntologyDefinition,
+  fs: MinimalFs,
+  outDir: string,
+  importExt: string = "",
+) {
+  const importedObjects = new Set<string>();
+  let actionSignatures: any[] = [];
+  for (const action of Object.values(ontology.actionTypes)) {
+    const entries = Object.entries(action.parameters);
+
+    const modifiedEntityTypes = getModifiedEntityTypes(action);
+    const addedObjects = Array.from(modifiedEntityTypes.addedObjects);
+    const modifiedObjects = Array.from(modifiedEntityTypes.modifiedObjects);
+    addedObjects.forEach(importedObjects.add, importedObjects);
+    modifiedObjects.forEach(importedObjects.add, importedObjects);
+
+    let jsDocBlock = ["/**"];
+    if (action.description) {
+      jsDocBlock.push(`* ${action.description}`);
+    }
+
+    let parameterBlock = "";
+    if (entries.length > 0) {
+      parameterBlock = `params: { \n`;
+      for (
+        const [parameterName, parameterData] of entries
+      ) {
+        parameterBlock += `"${parameterName}"`;
+        parameterBlock += parameterData.required ? ": " : "?: ";
+        const typeScriptType = getTypeScriptTypeFromDataType(
+          parameterData.dataType,
+          importedObjects,
+        );
+        parameterBlock += `${typeScriptType};\n`;
+
+        jsDocBlock.push(
+          `* @param {${typeScriptType}} params.${parameterName}`,
+        );
+      }
+      parameterBlock += "} ";
+    }
+
+    jsDocBlock.push(`*/`);
+    actionSignatures.push(
+      `
+      ${jsDocBlock.join("\n")}
+      ${action.apiName}<O extends BulkActionExecutionOptions>(${parameterBlock}[],options?: O): 
+        Promise<Result<BulkActionResponseFromOptions<O, Edits<${
+        addedObjects.length > 0
+          ? addedObjects.join(" | ")
+          : "void"
+      }, ${
+        modifiedObjects.length > 0
+          ? modifiedObjects.join(" | ")
+          : "void"
+      }>>, ActionError>>;
+      `,
+    );
+  }
+
+  await fs.mkdir(outDir, { recursive: true });
+  await fs.writeFile(
+    path.join(outDir, "BulkActions.ts"),
+    await formatTs(`
+    import type { ObjectSet, LocalDate, Timestamp, Attachment, Edits, ActionExecutionOptions, BulkActionExecutionOptions, ActionError, Result, ActionResponseFromOptions, BulkActionResponseFromOptions } from "@osdk/legacy-client";
+    ${
+      Array.from(importedObjects).map(importedObject =>
+        `import type { ${importedObject} } from "../objects/${importedObject}${importExt}";`
+      ).join("\n")
+    }
+    export interface BulkActions {
+    ${actionSignatures.join("\n")}
+    }
+  `),
+  );
+}
+
+function getTypeScriptTypeFromDataType(
+  actionParameter: ActionParameterType,
+  importedObjects: Set<string>,
+): string {
+  switch (actionParameter.type) {
+    case "objectSet": {
+      const objectType = actionParameter.objectTypeApiName!;
+      importedObjects.add(objectType);
+      return `ObjectSet<${objectType}>`;
+    }
+    case "object": {
+      const objectType = actionParameter.objectTypeApiName!;
+      importedObjects.add(objectType);
+      return `${objectType} | ${objectType}["__primaryKey"]`;
+    }
+    case "array":
+      return `Array<${
+        getTypeScriptTypeFromDataType(actionParameter.subType, importedObjects)
+      }>`;
+    case "string":
+      return `string`;
+    case "boolean":
+      return `boolean`;
+    case "attachment":
+      return `Attachment`;
+    case "date":
+      return `LocalDate`;
+    case "double":
+    case "integer":
+    case "long":
+      return `number`;
+    case "timestamp":
+      return `Timestamp`;
+    default:
+      const _: never = actionParameter;
+      throw new Error(`Unsupported action parameter type: ${actionParameter}`);
+  }
+}

--- a/packages/generator/src/v1.1/generateClientSdkVersionOneDotOne.ts
+++ b/packages/generator/src/v1.1/generateClientSdkVersionOneDotOne.ts
@@ -21,6 +21,7 @@ import { verifyOutdir } from "../util/verifyOutdir";
 import type { WireOntologyDefinition } from "../WireOntologyDefinition";
 import { generateActions } from "./generateActions";
 import { generateBackCompatDeprecatedExports } from "./generateBackCompatDeprecatedExports";
+import { generateBulkActions } from "./generateBulkActions";
 import { generateFoundryClientFile } from "./generateFoundryClientFile";
 import { generateIndexFile } from "./generateIndexFile";
 import { generateMetadataFile } from "./generateMetadataFile";
@@ -79,12 +80,14 @@ export async function generateClientSdkVersionOneDotOne(
     importExt,
   );
   await generateActions(sanitizedOntology, fs, actionsDir, importExt);
+  await generateBulkActions(sanitizedOntology, fs, actionsDir, importExt);
   await generatePerActionDataFiles(
     sanitizedOntology,
     fs,
     actionsDir,
     importExt,
   );
+
   await generateQueries(sanitizedOntology, fs, queriesDir, importExt);
   await generatePerQueryDataFiles(
     sanitizedOntology,

--- a/packages/generator/src/v1.1/generateClientSdkVersionOneDotOne.ts
+++ b/packages/generator/src/v1.1/generateClientSdkVersionOneDotOne.ts
@@ -87,7 +87,6 @@ export async function generateClientSdkVersionOneDotOne(
     actionsDir,
     importExt,
   );
-
   await generateQueries(sanitizedOntology, fs, queriesDir, importExt);
   await generatePerQueryDataFiles(
     sanitizedOntology,

--- a/packages/generator/src/v1.1/generateMetadataFile.test.ts
+++ b/packages/generator/src/v1.1/generateMetadataFile.test.ts
@@ -39,6 +39,7 @@ describe(generateMetadataFile, () => {
       "import type { OntologyDefinition } from '@osdk/api';
       import type { Ontology as ClientOntology } from '@osdk/legacy-client';
       import type { Actions } from './ontology/actions/Actions';
+      import type { BulkActions } from './ontology/actions/BulkActions';
       import { markTodoCompleted } from './ontology/actions/markTodoCompleted';
       import type { Objects } from './ontology/objects/Objects';
       import { Person } from './ontology/objects/Person';
@@ -83,6 +84,7 @@ describe(generateMetadataFile, () => {
       export interface Ontology extends ClientOntology<typeof Ontology> {
         objects: Objects;
         actions: Actions;
+        bulkActions: BulkActions;
         queries: Queries;
       }
       "
@@ -165,6 +167,7 @@ describe(generateMetadataFile, () => {
       "import type { OntologyDefinition } from '@osdk/api';
       import type { Ontology as ClientOntology } from '@osdk/legacy-client';
       import type { Actions } from './ontology/actions/Actions';
+      import type { BulkActions } from './ontology/actions/BulkActions';
       import { bar } from './ontology/actions/bar';
       import { foo as fooAction } from './ontology/actions/foo';
       import type { Objects } from './ontology/objects/Objects';
@@ -212,6 +215,7 @@ describe(generateMetadataFile, () => {
       export interface Ontology extends ClientOntology<typeof Ontology> {
         objects: Objects;
         actions: Actions;
+        bulkActions: BulkActions;
         queries: Queries;
       }
       "
@@ -249,6 +253,7 @@ describe(generateMetadataFile, () => {
       "import type { OntologyDefinition } from '@osdk/api';
       import type { Ontology as ClientOntology } from '@osdk/legacy-client';
       import type { Actions } from './ontology/actions/Actions';
+      import type { BulkActions } from './ontology/actions/BulkActions';
       import type { Objects } from './ontology/objects/Objects';
       import type { Queries } from './ontology/queries/Queries';
 
@@ -275,6 +280,7 @@ describe(generateMetadataFile, () => {
       export interface Ontology extends ClientOntology<typeof Ontology> {
         objects: Objects;
         actions: Actions;
+        bulkActions: BulkActions;
         queries: Queries;
       }
       "

--- a/packages/generator/src/v1.1/generateMetadataFile.ts
+++ b/packages/generator/src/v1.1/generateMetadataFile.ts
@@ -70,6 +70,7 @@ export async function generateMetadataFile(
   import type { Objects } from "./ontology/objects/Objects${importExt}";
   import type { Actions } from "./ontology/actions/Actions${importExt}";
   import type { Queries } from "./ontology/queries/Queries${importExt}";
+  import type { BulkActions } from "./ontology/actions/BulkActions${importExt}";
   ${
       objectNames.map((name) =>
         `import {${name}} from "./ontology/objects/${name}${importExt}";`
@@ -142,6 +143,7 @@ export async function generateMetadataFile(
 export interface Ontology extends ClientOntology<typeof Ontology> {
     objects: Objects;
     actions: Actions;
+    bulkActions: BulkActions;
     queries: Queries;
 }`),
   );

--- a/packages/legacy-client/changelog/@unreleased/pr-53.v2.yml
+++ b/packages/legacy-client/changelog/@unreleased/pr-53.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Adding bulk actions to 1.1
+  links:
+  - https://github.com/palantir/osdk-ts/pull/53

--- a/packages/legacy-client/src/client/actions/actions.test.ts
+++ b/packages/legacy-client/src/client/actions/actions.test.ts
@@ -162,6 +162,7 @@ describe("Actions", () => {
 
       expectTypeOf<Parameters<typeof bulkActions.createTodo>>().toEqualTypeOf<
         [
+          {}[],
           BulkActionExecutionOptions?,
         ]
       >();

--- a/packages/legacy-client/src/client/actions/actions.test.ts
+++ b/packages/legacy-client/src/client/actions/actions.test.ts
@@ -17,6 +17,7 @@
 import { createClientContext } from "@osdk/shared.net";
 import type { ClientContext } from "@osdk/shared.net";
 import {
+  apiServer,
   getMockTodoObject,
   MOCK_ORIGIN,
   mockFetchResponse,
@@ -25,6 +26,7 @@ import {
 import type { MockedFunction } from "vitest";
 import {
   assert,
+  beforeAll,
   beforeEach,
   describe,
   expect,
@@ -40,23 +42,45 @@ import type {
   Edits,
   Result,
 } from "../..";
+import { Ontology as MockOntologyGenerated } from "../../generatedNoCheck/Ontology";
 import { USER_AGENT } from "../../USER_AGENT";
 import {
   expectFetchToBeCalledWithBody,
   expectFetchToBeCalledWithGet,
 } from "../../util/test/expectUtils";
 import { unwrapResultOrThrow } from "../../util/test/resultUtils";
+import type {
+  BulkActionExecutionOptions,
+  BulkActionResponseFromOptions,
+} from "../baseTypes";
 import { createBaseOsdkObjectSet } from "../objectSets/OsdkObjectSet";
 import type { OsdkLegacyObjectFrom } from "../OsdkLegacyObject";
-import type { Actions } from "./actions";
-import { createActionProxy } from "./createActionProxy";
+import type { Actions, BulkActions } from "./actions";
+import { createActionProxy, createBulkActionProxy } from "./createActionProxy";
 
 describe("Actions", () => {
   let client: ClientContext<typeof MockOntology>;
+  let sharedClient: ClientContext<typeof MockOntologyGenerated>;
   let fetch: MockedFunction<typeof globalThis.fetch>;
   let actions: Actions<
     typeof MockOntology
   >;
+  let bulkActions: BulkActions<typeof MockOntology>;
+  let sharedBulkActions: BulkActions<typeof MockOntologyGenerated>;
+
+  beforeAll(async () => {
+    apiServer.listen();
+    sharedClient = createClientContext(
+      MockOntologyGenerated,
+      "https://stack.palantir.com",
+      () => "myAccessToken",
+      USER_AGENT,
+      globalThis.fetch,
+    );
+    sharedBulkActions = createBulkActionProxy<typeof MockOntologyGenerated>(
+      sharedClient,
+    );
+  });
 
   beforeEach(() => {
     fetch = vi.fn();
@@ -68,6 +92,7 @@ describe("Actions", () => {
       fetch,
     );
     actions = createActionProxy<typeof MockOntology>(client);
+    bulkActions = createBulkActionProxy<typeof MockOntology>(client);
   });
 
   describe("type tests", () => {
@@ -81,9 +106,27 @@ describe("Actions", () => {
         ]
       >();
 
+      expectTypeOf<Parameters<typeof bulkActions.createTask>>()
+        .toEqualTypeOf<
+          [
+            {
+              id?: number;
+            }[],
+            BulkActionExecutionOptions?,
+          ]
+        >();
+
       expectTypeOf<typeof actions.createTask>()
         // @ts-expect-error
         .toBeCallableWith([{ id: 1 }]);
+
+      expectTypeOf<typeof bulkActions.createTask>().toBeCallableWith([{
+        id: 1,
+      }], {
+        // @ts-expect-error
+        mode: ActionExecutionMode.VALIDATE_AND_EXECUTE,
+        returnEdits: ReturnEditsMode.ALL,
+      });
 
       expectTypeOf<ReturnType<typeof actions.createTask>>().toMatchTypeOf<
         Promise<
@@ -96,12 +139,30 @@ describe("Actions", () => {
           >
         >
       >();
+
+      expectTypeOf<ReturnType<typeof bulkActions.createTask>>().toMatchTypeOf<
+        Promise<
+          Result<
+            BulkActionResponseFromOptions<
+              BulkActionExecutionOptions,
+              Edits<OsdkLegacyObjectFrom<typeof MockOntology, "Task">, void>
+            >,
+            ActionError
+          >
+        >
+      >();
     });
 
     it("skips empty parameters", () => {
       expectTypeOf<Parameters<typeof actions.createTodo>>().toMatchTypeOf<
         [
           ActionExecutionOptions?,
+        ]
+      >();
+
+      expectTypeOf<Parameters<typeof bulkActions.createTodo>>().toEqualTypeOf<
+        [
+          BulkActionExecutionOptions?,
         ]
       >();
     });
@@ -121,6 +182,20 @@ describe("Actions", () => {
         ]
       >();
 
+      expectTypeOf<Parameters<typeof bulkActions.updateTask>>().toMatchTypeOf<
+        [
+          {
+            task?:
+              | OsdkLegacyObjectFrom<typeof MockOntology, "Task">
+              | OsdkLegacyObjectFrom<
+                typeof MockOntology,
+                "Task"
+              >["__primaryKey"];
+          }[],
+          ActionExecutionOptions?,
+        ]
+      >();
+
       expectTypeOf<ReturnType<typeof actions.updateTask>>().toMatchTypeOf<
         Promise<
           Result<
@@ -135,143 +210,220 @@ describe("Actions", () => {
           >
         >
       >();
-    });
-  });
 
-  describe("proxy", () => {
-    it("proxies action calls with parameters", async () => {
+      expectTypeOf<ReturnType<typeof bulkActions.updateTask>>().toMatchTypeOf<
+        Promise<
+          Result<
+            BulkActionResponseFromOptions<
+              BulkActionExecutionOptions,
+              Edits<
+                void,
+                OsdkLegacyObjectFrom<typeof MockOntology, "Task">
+              >
+            >,
+            ActionError
+          >
+        >
+      >();
+    });
+
+    describe("proxy", () => {
+      it("proxies action calls with parameters", async () => {
+        mockFetchResponse(fetch, {});
+        const actionResponse = await actions.createTask({ id: 1 });
+        expectFetchToBeCalledWithBody(
+          fetch,
+          `Ontology/actions/createTask/apply`,
+          {
+            parameters: {
+              id: 1,
+            },
+            options: {},
+          },
+        );
+        expect(actionResponse.type).toEqual("ok");
+      });
+
+      it("proxies action calls with no parameters and parses edits", async () => {
+        mockFetchResponse(fetch, {
+          edits: {
+            type: "edits",
+            edits: [{
+              type: "addObject",
+              primaryKey: 1,
+              objectType: "Todo",
+            }],
+            addedObjectCount: 1,
+            modifiedObjectsCount: 0,
+            addedLinksCount: 0,
+          },
+        });
+
+        const actionResponse = await actions.createTodo({
+          mode: ActionExecutionMode.VALIDATE_AND_EXECUTE,
+          returnEdits: ReturnEditsMode.ALL,
+        });
+
+        expectFetchToBeCalledWithBody(
+          fetch,
+          `Ontology/actions/createTodo/apply`,
+          {
+            parameters: {},
+            options: {
+              mode: "VALIDATE_AND_EXECUTE",
+              returnEdits: "ALL",
+            },
+          },
+        );
+
+        const value = unwrapResultOrThrow(actionResponse);
+        assert(value.edits.type === "edits");
+        mockFetchResponse(fetch, getMockTodoObject());
+        const loadAddedObject = await value.edits.added[0].get();
+
+        expectFetchToBeCalledWithGet(fetch, `Ontology/objects/Todo/1`);
+        const createdObject = unwrapResultOrThrow(loadAddedObject);
+        expect(createdObject.__primaryKey).toEqual(
+          getMockTodoObject().__primaryKey,
+        );
+      });
+    });
+
+    it("proxies action calls transforms arguments", async () => {
+      const taskOs = createBaseOsdkObjectSet(client, "Task");
+      mockFetchResponse(fetch, getMockTodoObject());
+      const taskObjectResult = await taskOs.get(1);
+      const taskObject = unwrapResultOrThrow(taskObjectResult);
+
       mockFetchResponse(fetch, {});
-      const actionResponse = await actions.createTask({ id: 1 });
+      const actionResponse = await actions.updateTask({
+        task: taskObject,
+        tasks: taskOs,
+      }, {});
+
       expectFetchToBeCalledWithBody(
         fetch,
-        `Ontology/actions/createTask/apply`,
+        `Ontology/actions/updateTask/apply`,
         {
           parameters: {
-            id: 1,
+            task: 1,
+            tasks: {
+              type: "base",
+              objectType: "Task",
+            },
           },
-          options: {},
+          options: {
+            mode: "VALIDATE_AND_EXECUTE",
+            returnEdits: "NONE",
+          },
         },
       );
-      expect(actionResponse.type).toEqual("ok");
+
+      assert(actionResponse.type === "ok");
     });
 
-    it("proxies action calls with no parameters and parses edits", async () => {
-      mockFetchResponse(fetch, {
-        edits: {
-          type: "edits",
-          edits: [{
-            type: "addObject",
-            primaryKey: 1,
-            objectType: "Todo",
-          }],
-          addedObjectCount: 1,
-          modifiedObjectsCount: 0,
-          addedLinksCount: 0,
-        },
-      });
+    it("proxies action calls takes object primary key", async () => {
+      const taskOs = createBaseOsdkObjectSet(client, "Task");
+      mockFetchResponse(fetch, getMockTodoObject());
 
-      const actionResponse = await actions.createTodo({
-        mode: ActionExecutionMode.VALIDATE_AND_EXECUTE,
-        returnEdits: ReturnEditsMode.ALL,
-      });
+      mockFetchResponse(fetch, {});
+      const actionResponse = await actions.updateTask({
+        task: 1,
+        tasks: taskOs,
+      }, {});
 
       expectFetchToBeCalledWithBody(
         fetch,
-        `Ontology/actions/createTodo/apply`,
+        `Ontology/actions/updateTask/apply`,
         {
-          parameters: {},
+          parameters: {
+            task: 1,
+            tasks: {
+              type: "base",
+              objectType: "Task",
+            },
+          },
           options: {
             mode: "VALIDATE_AND_EXECUTE",
-            returnEdits: "ALL",
+            returnEdits: "NONE",
           },
         },
       );
 
-      const value = unwrapResultOrThrow(actionResponse);
-      assert(value.edits.type === "edits");
-      mockFetchResponse(fetch, getMockTodoObject());
-      const loadAddedObject = await value.edits.added[0].get();
-
-      expectFetchToBeCalledWithGet(fetch, `Ontology/objects/Todo/1`);
-      const createdObject = unwrapResultOrThrow(loadAddedObject);
-      expect(createdObject.__primaryKey).toEqual(
-        getMockTodoObject().__primaryKey,
-      );
+      assert(actionResponse.type === "ok");
     });
-  });
 
-  it("proxies action calls transforms arguments", async () => {
-    const taskOs = createBaseOsdkObjectSet(client, "Task");
-    mockFetchResponse(fetch, getMockTodoObject());
-    const taskObjectResult = await taskOs.get(1);
-    const taskObject = unwrapResultOrThrow(taskObjectResult);
-
-    mockFetchResponse(fetch, {});
-    const actionResponse = await actions.updateTask({
-      task: taskObject,
-      tasks: taskOs,
-    }, {});
-
-    expectFetchToBeCalledWithBody(
-      fetch,
-      `Ontology/actions/updateTask/apply`,
-      {
-        parameters: {
-          task: 1,
-          tasks: {
-            type: "base",
-            objectType: "Task",
-          },
-        },
-        options: {
-          mode: "VALIDATE_AND_EXECUTE",
-          returnEdits: "NONE",
-        },
-      },
-    );
-
-    assert(actionResponse.type === "ok");
-  });
-
-  it("proxies action calls takes object primary key", async () => {
-    const taskOs = createBaseOsdkObjectSet(client, "Task");
-    mockFetchResponse(fetch, getMockTodoObject());
-
-    mockFetchResponse(fetch, {});
-    const actionResponse = await actions.updateTask({
-      task: 1,
-      tasks: taskOs,
-    }, {});
-
-    expectFetchToBeCalledWithBody(
-      fetch,
-      `Ontology/actions/updateTask/apply`,
-      {
-        parameters: {
-          task: 1,
-          tasks: {
-            type: "base",
-            objectType: "Task",
-          },
-        },
-        options: {
-          mode: "VALIDATE_AND_EXECUTE",
-          returnEdits: "NONE",
-        },
-      },
-    );
-
-    assert(actionResponse.type === "ok");
-  });
-
-  it("has an enumerable list of actions", () => {
-    const actionProxy = createActionProxy(client);
-    expect(Object.getOwnPropertyNames(actionProxy)).toMatchInlineSnapshot(`
+    it("has an enumerable list of actions", () => {
+      const actionProxy = createActionProxy(client);
+      const bulkActionProxy = createBulkActionProxy(client);
+      expect(Object.getOwnPropertyNames(actionProxy)).toMatchInlineSnapshot(`
       [
         "createTask",
         "createTodo",
         "updateTask",
       ]
     `);
+      expect(Object.getOwnPropertyNames(bulkActionProxy)).toMatchInlineSnapshot(
+        `
+      [
+        "createTask",
+        "createTodo",
+        "updateTask",
+      ]
+    `,
+      );
+    });
+  });
+
+  it("conditionally returns edits in batch mode", async () => {
+    const result = await sharedBulkActions.moveOffice([
+      {
+        officeId: "SEA",
+        newAddress: "456 Good Place",
+        newCapacity: 40,
+      },
+      {
+        officeId: "NYC",
+        newAddress: "123 Main Street",
+        newCapacity: 80,
+      },
+    ], { returnEdits: ReturnEditsMode.ALL });
+
+    expect(unwrapResultOrThrow(result)).toMatchInlineSnapshot(` 
+   {
+  "edits": {
+    "added": [],
+    "modified": [
+      {
+        "apiName": "Office",
+        "get": [Function],
+        "primaryKey": "SEA",
+      },
+      {
+        "apiName": "Office",
+        "get": [Function],
+        "primaryKey": "NYC",
+      },
+    ],
+    "type": "edits",
+  },
+}`);
+
+    const noEditsResult = await sharedBulkActions.moveOffice([
+      {
+        officeId: "SEA",
+        newAddress: "456 Good Place",
+        newCapacity: 40,
+      },
+      {
+        officeId: "NYC",
+        newAddress: "123 Main Street",
+        newCapacity: 80,
+      },
+    ]);
+
+    expect(unwrapResultOrThrow(noEditsResult)).toMatchInlineSnapshot(` 
+  {}
+  `);
   });
 });

--- a/packages/legacy-client/src/client/actions/actions.test.ts
+++ b/packages/legacy-client/src/client/actions/actions.test.ts
@@ -162,7 +162,7 @@ describe("Actions", () => {
 
       expectTypeOf<Parameters<typeof bulkActions.createTodo>>().toEqualTypeOf<
         [
-          {}[],
+          Record<string, never>[],
           BulkActionExecutionOptions?,
         ]
       >();

--- a/packages/legacy-client/src/client/actions/actions.ts
+++ b/packages/legacy-client/src/client/actions/actions.ts
@@ -160,20 +160,6 @@ export type BulkActionReturnType<
   Edits<CreatedObjectOrVoid<O, A>, ModifiedObjectsOrVoid<O, A>>
 >;
 
-// export type ActionReturnType<
-//   O extends OntologyDefinition<any>,
-//   A extends keyof O["actions"],
-//   Op extends ActionExecutionOptions,
-//   P extends ActionArgs<O, A> | ActionArgs<O, A>[] | undefined,
-// > = P extends ActionArgs<O, A>[] ? BulkActionResponseFromOptions<
-//     Op,
-//     Edits<CreatedObjectOrVoid<O, A>, ModifiedObjectsOrVoid<O, A>>
-//   >
-//   : ActionResponseFromOptions<
-//     Op,
-//     Edits<CreatedObjectOrVoid<O, A>, ModifiedObjectsOrVoid<O, A>>
-//   >;
-
 export type ActionReturnType<
   O extends OntologyDefinition<any>,
   A extends keyof O["actions"],

--- a/packages/legacy-client/src/client/actions/actions.ts
+++ b/packages/legacy-client/src/client/actions/actions.ts
@@ -184,8 +184,14 @@ export type Actions<
 };
 
 export type BulkActions<O extends OntologyDefinition<any>> = {
-  [A in keyof O["actions"]]: <Op extends BulkActionExecutionOptions>(
-    params: ActionArgs<O, A>[],
-    options?: Op,
-  ) => WrappedBulkActionReturnType<O, A, Op>;
+  [A in keyof O["actions"]]:
+    IsEmptyRecord<O["actions"][A]["parameters"]> extends true
+      ? <Op extends BulkActionExecutionOptions>(
+        params: Record<string, never>[],
+        options?: Op,
+      ) => WrappedBulkActionReturnType<O, A, Op>
+      : <Op extends BulkActionExecutionOptions>(
+        params: ActionArgs<O, A>[],
+        options?: Op,
+      ) => WrappedBulkActionReturnType<O, A, Op>;
 };

--- a/packages/legacy-client/src/client/actions/actions.ts
+++ b/packages/legacy-client/src/client/actions/actions.ts
@@ -133,47 +133,55 @@ export type WrappedActionReturnType<
   O extends OntologyDefinition<any>,
   A extends keyof O["actions"],
   Op extends ActionExecutionOptions,
-  P extends ActionArgs<O, A> | ActionArgs<O, A>[] | undefined = undefined,
 > = Promise<
   Result<
-    ActionReturnType<O, A, Op, P>,
+    ActionReturnType<O, A, Op>,
     ActionError
   >
 >;
 
-// export type WrappedBulkActionReturnType<
-//   O extends OntologyDefinition<any>,
-//   A extends keyof O["actions"],
-//   Op extends BulkActionExecutionOptions,
-// > = Promise<
-//   Result<
-//     BulkActionReturnType<O, A, Op>,
-//     ActionError
-//   >
-// >;
+export type WrappedBulkActionReturnType<
+  O extends OntologyDefinition<any>,
+  A extends keyof O["actions"],
+  Op extends BulkActionExecutionOptions,
+> = Promise<
+  Result<
+    BulkActionReturnType<O, A, Op>,
+    ActionError
+  >
+>;
 
-// export type BulkActionReturnType<
+export type BulkActionReturnType<
+  O extends OntologyDefinition<any>,
+  A extends keyof O["actions"],
+  Op extends BulkActionExecutionOptions,
+> = BulkActionResponseFromOptions<
+  Op,
+  Edits<CreatedObjectOrVoid<O, A>, ModifiedObjectsOrVoid<O, A>>
+>;
+
+// export type ActionReturnType<
 //   O extends OntologyDefinition<any>,
 //   A extends keyof O["actions"],
-//   Op extends BulkActionExecutionOptions,
-// > = BulkActionResponseFromOptions<
-//   Op,
-//   Edits<CreatedObjectOrVoid<O, A>, ModifiedObjectsOrVoid<O, A>>
-// >;
+//   Op extends ActionExecutionOptions,
+//   P extends ActionArgs<O, A> | ActionArgs<O, A>[] | undefined,
+// > = P extends ActionArgs<O, A>[] ? BulkActionResponseFromOptions<
+//     Op,
+//     Edits<CreatedObjectOrVoid<O, A>, ModifiedObjectsOrVoid<O, A>>
+//   >
+//   : ActionResponseFromOptions<
+//     Op,
+//     Edits<CreatedObjectOrVoid<O, A>, ModifiedObjectsOrVoid<O, A>>
+//   >;
 
 export type ActionReturnType<
   O extends OntologyDefinition<any>,
   A extends keyof O["actions"],
   Op extends ActionExecutionOptions,
-  P extends ActionArgs<O, A> | ActionArgs<O, A>[] | undefined,
-> = P extends ActionArgs<O, A>[] ? BulkActionResponseFromOptions<
-    Op,
-    Edits<CreatedObjectOrVoid<O, A>, ModifiedObjectsOrVoid<O, A>>
-  >
-  : ActionResponseFromOptions<
-    Op,
-    Edits<CreatedObjectOrVoid<O, A>, ModifiedObjectsOrVoid<O, A>>
-  >;
+> = ActionResponseFromOptions<
+  Op,
+  Edits<CreatedObjectOrVoid<O, A>, ModifiedObjectsOrVoid<O, A>>
+>;
 
 export type Actions<
   O extends OntologyDefinition<any>,
@@ -194,9 +202,9 @@ export type BulkActions<O extends OntologyDefinition<any>> = {
     IsEmptyRecord<O["actions"][A]["parameters"]> extends true
       ? <Op extends BulkActionExecutionOptions>(
         options?: Op,
-      ) => WrappedActionReturnType<O, A, Op>
+      ) => WrappedBulkActionReturnType<O, A, Op>
       : <Op extends BulkActionExecutionOptions, P extends ActionArgs<O, A>[]>(
         params: P,
         options?: Op,
-      ) => WrappedActionReturnType<O, A, Op, P>;
+      ) => WrappedBulkActionReturnType<O, A, Op>;
 };

--- a/packages/legacy-client/src/client/actions/actions.ts
+++ b/packages/legacy-client/src/client/actions/actions.ts
@@ -184,13 +184,8 @@ export type Actions<
 };
 
 export type BulkActions<O extends OntologyDefinition<any>> = {
-  [A in keyof O["actions"]]:
-    IsEmptyRecord<O["actions"][A]["parameters"]> extends true
-      ? <Op extends BulkActionExecutionOptions>(
-        options?: Op,
-      ) => WrappedBulkActionReturnType<O, A, Op>
-      : <Op extends BulkActionExecutionOptions, P extends ActionArgs<O, A>[]>(
-        params: P,
-        options?: Op,
-      ) => WrappedBulkActionReturnType<O, A, Op>;
+  [A in keyof O["actions"]]: <Op extends BulkActionExecutionOptions>(
+    params: ActionArgs<O, A>[],
+    options?: Op,
+  ) => WrappedBulkActionReturnType<O, A, Op>;
 };

--- a/packages/legacy-client/src/client/actions/createActionProxy.ts
+++ b/packages/legacy-client/src/client/actions/createActionProxy.ts
@@ -90,19 +90,6 @@ export function createBulkActionProxy<
     {
       get: (_target, p: keyof O["actions"], _receiver) => {
         if (typeof p === "string") {
-          if (Object.keys(client.ontology.actions[p].parameters).length === 0) {
-            return async function<Op extends BulkActionExecutionOptions>(
-              options?: Op,
-            ): Promise<WrappedBulkActionReturnType<O, typeof p, Op>> {
-              return executeBatchAction<O, typeof p, Op>(
-                client,
-                p,
-                undefined,
-                options,
-              );
-            };
-          }
-
           return async function<
             Op extends BulkActionExecutionOptions,
           >(

--- a/packages/legacy-client/src/client/actions/createActionProxy.ts
+++ b/packages/legacy-client/src/client/actions/createActionProxy.ts
@@ -24,6 +24,7 @@ import type {
   Actions,
   BulkActions,
   WrappedActionReturnType,
+  WrappedBulkActionReturnType,
 } from "./actions";
 
 export function createActionProxy<
@@ -53,7 +54,7 @@ export function createActionProxy<
           >(
             params: P,
             options?: Op,
-          ): Promise<WrappedActionReturnType<O, typeof p, Op, P>> {
+          ): Promise<WrappedActionReturnType<O, typeof p, Op>> {
             return executeAction<O, typeof p, Op, P>(
               client,
               p,
@@ -93,7 +94,7 @@ export function createBulkActionProxy<
           if (Object.keys(client.ontology.actions[p].parameters).length === 0) {
             return async function<Op extends BulkActionExecutionOptions>(
               options?: Op,
-            ): Promise<WrappedActionReturnType<O, typeof p, Op>> {
+            ): Promise<WrappedBulkActionReturnType<O, typeof p, Op>> {
               return executeBatchAction<O, typeof p, Op, undefined>(
                 client,
                 p,
@@ -109,7 +110,7 @@ export function createBulkActionProxy<
           >(
             params: P,
             options?: Op,
-          ): Promise<WrappedActionReturnType<O, typeof p, Op, P>> {
+          ): Promise<WrappedBulkActionReturnType<O, typeof p, Op>> {
             return executeBatchAction<O, typeof p, Op, P>(
               client,
               p,

--- a/packages/legacy-client/src/client/actions/createActionProxy.ts
+++ b/packages/legacy-client/src/client/actions/createActionProxy.ts
@@ -50,12 +50,11 @@ export function createActionProxy<
 
           return async function<
             Op extends ActionExecutionOptions,
-            P extends ActionArgs<O, typeof p>,
           >(
-            params: P,
+            params: ActionArgs<O, typeof p>,
             options?: Op,
           ): Promise<WrappedActionReturnType<O, typeof p, Op>> {
-            return executeAction<O, typeof p, Op, P>(
+            return executeAction<O, typeof p, Op>(
               client,
               p,
               params,
@@ -95,7 +94,7 @@ export function createBulkActionProxy<
             return async function<Op extends BulkActionExecutionOptions>(
               options?: Op,
             ): Promise<WrappedBulkActionReturnType<O, typeof p, Op>> {
-              return executeBatchAction<O, typeof p, Op, undefined>(
+              return executeBatchAction<O, typeof p, Op>(
                 client,
                 p,
                 undefined,
@@ -106,12 +105,11 @@ export function createBulkActionProxy<
 
           return async function<
             Op extends BulkActionExecutionOptions,
-            P extends ActionArgs<O, typeof p>[],
           >(
-            params: P,
+            params: ActionArgs<O, typeof p>[],
             options?: Op,
           ): Promise<WrappedBulkActionReturnType<O, typeof p, Op>> {
-            return executeBatchAction<O, typeof p, Op, P>(
+            return executeBatchAction<O, typeof p, Op>(
               client,
               p,
               params,

--- a/packages/legacy-client/src/client/baseTypes/ActionType.ts
+++ b/packages/legacy-client/src/client/baseTypes/ActionType.ts
@@ -15,7 +15,10 @@
  */
 
 import type { OntologyDefinition } from "@osdk/api";
-import type { SyncApplyActionResponseV2 } from "@osdk/gateway/types";
+import type {
+  BatchApplyActionResponseV2,
+  SyncApplyActionResponseV2,
+} from "@osdk/gateway/types";
 import type { ClientContext } from "@osdk/shared.net";
 import { getObject } from "../../client/net/getObject";
 import type { GetObjectError } from "../errors";
@@ -27,6 +30,11 @@ export type ActionExecutionOptions = {
   mode: ActionExecutionMode.VALIDATE_ONLY;
 } | {
   mode?: ActionExecutionMode.VALIDATE_AND_EXECUTE;
+  returnEdits?: ReturnEditsMode;
+};
+
+export type BulkActionExecutionOptions = {
+  mode?: never;
   returnEdits?: ReturnEditsMode;
 };
 
@@ -116,6 +124,12 @@ export interface ActionResponse<
   edits: TEdits extends undefined ? never : TEdits | BulkEdits;
 }
 
+export interface BulkActionResponse<
+  TEdits extends Edits<any, any> | undefined = undefined,
+> {
+  edits: TEdits extends undefined ? never : TEdits | BulkEdits;
+}
+
 export type ActionResponseFromOptions<
   TOptions extends ActionExecutionOptions | undefined = undefined,
   TEdits extends Edits<any, any> | undefined = undefined,
@@ -123,6 +137,14 @@ export type ActionResponseFromOptions<
   returnEdits: ReturnEditsMode.ALL;
 } ? ActionResponse<TEdits>
   : ActionResponse;
+
+export type BulkActionResponseFromOptions<
+  TOptions extends ActionExecutionOptions | undefined = undefined,
+  TEdits extends Edits<any, any> | undefined = undefined,
+> = TOptions extends {
+  returnEdits: ReturnEditsMode.ALL;
+} ? BulkActionResponse<TEdits>
+  : BulkActionResponse;
 
 export const ActionResponse = {
   of: <
@@ -141,8 +163,8 @@ export const ActionResponse = {
       ],
     };
     if (response.edits?.type === "edits") {
-      const added = [];
-      const modified = [];
+      const added: any[] = [];
+      const modified: any[] = [];
       for (const edit of response.edits.edits) {
         if (edit.type === "addObject") {
           added.push({
@@ -177,5 +199,54 @@ export const ActionResponse = {
       };
     }
     return { validation } as ActionResponse;
+  },
+};
+
+export const BulkActionResponse = {
+  of: <
+    TAddedObjects extends OntologyObject<string, NonNullable<ParameterValue>>,
+    TModifiedObjects extends OntologyObject<
+      string,
+      NonNullable<ParameterValue>
+    >,
+  >(
+    client: ClientContext<OntologyDefinition<any>>,
+    response: BatchApplyActionResponseV2,
+  ): BulkActionResponse<Edits<TAddedObjects, TModifiedObjects> | undefined> => {
+    if (response.edits?.type === "edits") {
+      const added: any[] = [];
+      const modified: any[] = [];
+      for (const edit of response.edits.edits) {
+        if (edit.type === "addObject") {
+          added.push({
+            apiName: edit.objectType,
+            primaryKey: edit.primaryKey,
+            get: () => getObject(client, edit.objectType, edit.primaryKey),
+          });
+        }
+        if (edit.type === "modifyObject") {
+          modified.push({
+            apiName: edit.objectType,
+            primaryKey: edit.primaryKey,
+            get: () => getObject(client, edit.objectType, edit.primaryKey),
+          });
+        }
+      }
+      return {
+        edits: {
+          type: "edits",
+          added,
+          modified,
+        },
+      } as BulkActionResponse<Edits<TAddedObjects, TModifiedObjects>>;
+    }
+    if (response.edits?.type === "largeScaleEdits") {
+      return {
+        edits: {
+          type: "bulkEdits",
+        },
+      };
+    }
+    return {} as BulkActionResponse;
   },
 };

--- a/packages/legacy-client/src/client/baseTypes/ActionType.ts
+++ b/packages/legacy-client/src/client/baseTypes/ActionType.ts
@@ -162,8 +162,8 @@ export const ActionResponse = {
       ],
     };
     if (response.edits?.type === "edits") {
-      const added: any[] = [];
-      const modified: any[] = [];
+      const added = [];
+      const modified = [];
       for (const edit of response.edits.edits) {
         if (edit.type === "addObject") {
           added.push({
@@ -213,8 +213,8 @@ export const BulkActionResponse = {
     response: BatchApplyActionResponseV2,
   ): BulkActionResponse<Edits<TAddedObjects, TModifiedObjects> | undefined> => {
     if (response.edits?.type === "edits") {
-      const added: any[] = [];
-      const modified: any[] = [];
+      const added = [];
+      const modified = [];
       for (const edit of response.edits.edits) {
         if (edit.type === "addObject") {
           added.push({

--- a/packages/legacy-client/src/client/baseTypes/ActionType.ts
+++ b/packages/legacy-client/src/client/baseTypes/ActionType.ts
@@ -139,7 +139,7 @@ export type ActionResponseFromOptions<
   : ActionResponse;
 
 export type BulkActionResponseFromOptions<
-  TOptions extends ActionExecutionOptions | undefined = undefined,
+  TOptions extends BulkActionExecutionOptions | undefined = undefined,
   TEdits extends Edits<any, any> | undefined = undefined,
 > = TOptions extends {
   returnEdits: ReturnEditsMode.ALL;

--- a/packages/legacy-client/src/client/baseTypes/ActionType.ts
+++ b/packages/legacy-client/src/client/baseTypes/ActionType.ts
@@ -34,7 +34,6 @@ export type ActionExecutionOptions = {
 };
 
 export type BulkActionExecutionOptions = {
-  mode?: never;
   returnEdits?: ReturnEditsMode;
 };
 

--- a/packages/legacy-client/src/client/net/executeAction.ts
+++ b/packages/legacy-client/src/client/net/executeAction.ts
@@ -44,11 +44,10 @@ export async function executeAction<
   O extends OntologyDefinition<any>,
   A extends keyof O["actions"],
   Op extends ActionExecutionOptions,
-  P extends ActionArgs<O, A> | undefined = undefined,
 >(
   client: ClientContext<OntologyDefinition<any>>,
   actionApiName: A,
-  params?: P,
+  params?: ActionArgs<O, A>,
   options?: Op,
 ): WrappedActionReturnType<O, A, Op> {
   return wrapResult(
@@ -82,11 +81,10 @@ export async function executeBatchAction<
   O extends OntologyDefinition<any>,
   A extends keyof O["actions"],
   Op extends BulkActionExecutionOptions,
-  P extends ActionArgs<O, A>[] | undefined = undefined,
 >(
   client: ClientContext<OntologyDefinition<any>>,
   actionApiName: A,
-  params?: P,
+  params?: ActionArgs<O, A>[],
   options?: Op,
 ): WrappedBulkActionReturnType<O, A, Op> {
   return wrapResult(

--- a/packages/legacy-client/src/client/net/executeAction.ts
+++ b/packages/legacy-client/src/client/net/executeAction.ts
@@ -22,7 +22,9 @@ import type { ClientContext } from "@osdk/shared.net";
 import type {
   ActionArgs,
   ActionReturnType,
+  BulkActionReturnType,
   WrappedActionReturnType,
+  WrappedBulkActionReturnType,
 } from "../actions/actions";
 import {
   ActionExecutionMode,
@@ -48,7 +50,7 @@ export async function executeAction<
   actionApiName: A,
   params?: P,
   options?: Op,
-): WrappedActionReturnType<O, A, Op, P> {
+): WrappedActionReturnType<O, A, Op> {
   return wrapResult(
     async () => {
       const response = await applyActionV2(
@@ -64,8 +66,7 @@ export async function executeAction<
       return ActionResponse.of(client, response) as ActionReturnType<
         O,
         A,
-        Op,
-        P
+        Op
       >;
     },
     e =>
@@ -87,7 +88,7 @@ export async function executeBatchAction<
   actionApiName: A,
   params?: P,
   options?: Op,
-): WrappedActionReturnType<O, A, Op, P> {
+): WrappedBulkActionReturnType<O, A, Op> {
   return wrapResult(
     async () => {
       const response = await applyActionBatchV2(
@@ -101,11 +102,10 @@ export async function executeBatchAction<
           options: options ? remapBulkOptions(options) : {},
         },
       );
-      return BulkActionResponse.of(client, response) as ActionReturnType<
+      return BulkActionResponse.of(client, response) as BulkActionReturnType<
         O,
         A,
-        Op,
-        P
+        Op
       >;
     },
     e =>

--- a/packages/legacy-client/src/client/ontology.ts
+++ b/packages/legacy-client/src/client/ontology.ts
@@ -16,8 +16,11 @@
 
 import type { OntologyDefinition } from "@osdk/api";
 import type { ClientContext } from "@osdk/shared.net";
-import type { Actions } from "./actions/actions";
-import { createActionProxy } from "./actions/createActionProxy";
+import type { Actions, BulkActions } from "./actions/actions";
+import {
+  createActionProxy,
+  createBulkActionProxy,
+} from "./actions/createActionProxy";
 import { Attachments } from "./baseTypes";
 import type { Objects } from "./objects";
 import { createBaseOsdkObjectSet } from "./objectSets/OsdkObjectSet";
@@ -36,6 +39,10 @@ export class Ontology<O extends OntologyDefinition<any>> {
 
   get actions(): Actions<O> {
     return createActionProxy(this.#client);
+  }
+
+  get bulkActions(): BulkActions<O> {
+    return createBulkActionProxy(this.#client);
   }
 
   get queries(): Queries<O> {

--- a/packages/legacy-client/src/index.ts
+++ b/packages/legacy-client/src/index.ts
@@ -140,6 +140,8 @@ export type {
   Bucketing,
   BucketKey,
   BucketValue,
+  BulkActionExecutionOptions,
+  BulkActionResponseFromOptions,
   BulkEdits,
   CommonApiError,
   CompositePrimaryKeyNotSupported,

--- a/packages/shared.test/changelog/@unreleased/pr-53.v2.yml
+++ b/packages/shared.test/changelog/@unreleased/pr-53.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Adding bulk actions to 1.1
+  links:
+  - https://github.com/palantir/osdk-ts/pull/53

--- a/packages/shared.test/src/handlers/actionEndpoints.ts
+++ b/packages/shared.test/src/handlers/actionEndpoints.ts
@@ -23,8 +23,11 @@ import stableStringify from "json-stable-stringify";
 import type {
   DefaultBodyType,
   MockedRequest,
+  PathParams,
   ResponseComposition,
+  RestContext,
   RestHandler,
+  RestRequest,
 } from "msw";
 import { rest } from "msw";
 import type { BaseAPIError } from "../BaseError";
@@ -76,77 +79,53 @@ export const actionHandlers: RestHandler<
   rest.post(
     "https://stack.palantir.com/api/v2/ontologies/:ontologyApiName/actions/:actionType/apply",
     authHandlerMiddleware(
-      async (
-        req,
-        res: ResponseComposition<SyncApplyActionResponseV2 | BaseAPIError>,
-        ctx,
-      ) => {
-        const body = await req.text();
-        const parsedBody = JSON.parse(body);
-        const ontologyApiName = req.params.ontologyApiName;
-        const actionType = req.params.actionType;
-
-        if (
-          typeof ontologyApiName !== "string" || typeof actionType !== "string"
-        ) {
-          return res(
-            ctx.status(400),
-            ctx.json(InvalidRequest("Invalid parameters")),
-          );
-        }
-
-        const actionResponse =
-          actionResponseMap[actionType][stableStringify(parsedBody)];
-        if (
-          req.params.ontologyApiName === defaultOntology.apiName
-          && actionResponse
-        ) {
-          return res(ctx.json(actionResponse));
-        }
-
-        return res(ctx.status(400), ctx.json(ApplyActionFailedError));
-      },
+      handleAction<SyncApplyActionResponseV2>,
     ),
   ),
+
   /**
    * Apply a Batch Action
    */
   rest.post(
     "https://stack.palantir.com/api/v2/ontologies/:ontologyApiName/actions/:actionType/applyBatch",
     authHandlerMiddleware(
-      async (
-        req,
-        res: ResponseComposition<
-          BatchApplyActionResponse | BaseAPIError
-        >,
-        ctx,
-      ) => {
-        const body = await req.text();
-        const parsedBody = JSON.parse(body);
-        const ontologyApiName = req.params.ontologyApiName;
-        const actionType = req.params.actionType;
-
-        if (
-          typeof ontologyApiName !== "string" || typeof actionType !== "string"
-        ) {
-          return res(
-            ctx.status(400),
-            ctx.json(InvalidRequest("Invalid parameters")),
-          );
-        }
-
-        const actionResponse =
-          actionResponseMap[actionType][stableStringify(parsedBody)];
-
-        if (
-          req.params.ontologyApiName === defaultOntology.apiName
-          && actionResponse
-        ) {
-          return res(ctx.json(actionResponse));
-        }
-
-        return res(ctx.status(400), ctx.json(ApplyActionFailedError));
-      },
+      handleAction<BatchApplyActionResponse>,
     ),
   ),
 ];
+
+async function handleAction<
+  T extends BatchApplyActionResponse | SyncApplyActionResponseV2,
+>(
+  req: RestRequest<DefaultBodyType, PathParams<string>>,
+  res: ResponseComposition<
+    T | BaseAPIError
+  >,
+  ctx: RestContext,
+) {
+  const body = await req.text();
+  const parsedBody = JSON.parse(body);
+  const ontologyApiName = req.params.ontologyApiName;
+  const actionType = req.params.actionType;
+
+  if (
+    typeof ontologyApiName !== "string" || typeof actionType !== "string"
+  ) {
+    return res(
+      ctx.status(400),
+      ctx.json(InvalidRequest("Invalid parameters")),
+    );
+  }
+
+  const actionResponse =
+    actionResponseMap[actionType][stableStringify(parsedBody)];
+
+  if (
+    req.params.ontologyApiName === defaultOntology.apiName
+    && actionResponse
+  ) {
+    return res(ctx.json(actionResponse));
+  }
+
+  return res(ctx.status(400), ctx.json(ApplyActionFailedError));
+}

--- a/packages/shared.test/src/handlers/actionEndpoints.ts
+++ b/packages/shared.test/src/handlers/actionEndpoints.ts
@@ -15,6 +15,7 @@
  */
 
 import type {
+  BatchApplyActionResponse,
   ListActionTypesResponseV2,
   SyncApplyActionResponseV2,
 } from "@osdk/gateway/types";
@@ -96,6 +97,47 @@ export const actionHandlers: RestHandler<
 
         const actionResponse =
           actionResponseMap[actionType][stableStringify(parsedBody)];
+        if (
+          req.params.ontologyApiName === defaultOntology.apiName
+          && actionResponse
+        ) {
+          return res(ctx.json(actionResponse));
+        }
+
+        return res(ctx.status(400), ctx.json(ApplyActionFailedError));
+      },
+    ),
+  ),
+  /**
+   * Apply a Batch Action
+   */
+  rest.post(
+    "https://stack.palantir.com/api/v2/ontologies/:ontologyApiName/actions/:actionType/applyBatch",
+    authHandlerMiddleware(
+      async (
+        req,
+        res: ResponseComposition<
+          BatchApplyActionResponse | BaseAPIError
+        >,
+        ctx,
+      ) => {
+        const body = await req.text();
+        const parsedBody = JSON.parse(body);
+        const ontologyApiName = req.params.ontologyApiName;
+        const actionType = req.params.actionType;
+
+        if (
+          typeof ontologyApiName !== "string" || typeof actionType !== "string"
+        ) {
+          return res(
+            ctx.status(400),
+            ctx.json(InvalidRequest("Invalid parameters")),
+          );
+        }
+
+        const actionResponse =
+          actionResponseMap[actionType][stableStringify(parsedBody)];
+
         if (
           req.params.ontologyApiName === defaultOntology.apiName
           && actionResponse

--- a/packages/shared.test/src/stubs/actions.ts
+++ b/packages/shared.test/src/stubs/actions.ts
@@ -16,6 +16,8 @@
 
 import type {
   ApplyActionRequestV2,
+  BatchApplyActionRequestV2,
+  BatchApplyActionResponseV2,
   SyncApplyActionResponseV2,
 } from "@osdk/gateway/types";
 import stableStringify from "json-stable-stringify";
@@ -150,6 +152,58 @@ export const actionRequestWithAttachment: ApplyActionRequestV2 = {
   parameters: { attachment: "attachment.rid" },
 };
 
+export const actionRequestMoveOfficeBatch: BatchApplyActionRequestV2 = {
+  requests: [{
+    parameters: {
+      officeId: "SEA",
+      newAddress: "456 Good Place",
+      newCapacity: 40,
+    },
+  }, {
+    parameters: {
+      officeId: "NYC",
+      newAddress: "123 Main Street",
+      newCapacity: 80,
+    },
+  }],
+  options: {},
+};
+
+export const actionRequestMoveOfficeBatchWithEdits: BatchApplyActionRequestV2 =
+  {
+    requests: [{
+      parameters: {
+        officeId: "SEA",
+        newAddress: "456 Good Place",
+        newCapacity: 40,
+      },
+    }, {
+      parameters: {
+        officeId: "NYC",
+        newAddress: "123 Main Street",
+        newCapacity: 80,
+      },
+    }],
+    options: { returnEdits: "ALL" },
+  };
+
+export const actionRequestMoveOfficeBatchInvalid: BatchApplyActionRequestV2 = {
+  requests: [{
+    parameters: {
+      officeId: "SEA",
+      newAddress: "456 Pike Place",
+      newCapacity: 40,
+    },
+  }, {
+    parameters: {
+      officeId: "NYC",
+      newAddress: "123 Main Street",
+      newCapacity: 80,
+    },
+  }],
+  options: { returnEdits: "ALL" },
+};
+
 const actionResponseCreateOfficeAndEmployee: SyncApplyActionResponseV2 = {
   validation: {
     submissionCriteria: [],
@@ -242,6 +296,24 @@ const actionResponseInvalid: SyncApplyActionResponseV2 = {
   },
 };
 
+const actionResponseMoveOfficeBatch: BatchApplyActionResponseV2 = {
+  edits: {
+    type: "edits",
+    edits: [{
+      type: "modifyObject",
+      primaryKey: "SEA",
+      objectType: officeObjectType.apiName,
+    }, {
+      type: "modifyObject",
+      primaryKey: "NYC",
+      objectType: officeObjectType.apiName,
+    }],
+    addedObjectCount: 0,
+    addedLinksCount: 0,
+    modifiedObjectsCount: 2,
+  },
+};
+
 export const actionResponseMap: {
   [actionApiName: string]: {
     [actionBody: string]: any;
@@ -264,6 +336,10 @@ export const actionResponseMap: {
     [stableStringify(actionRequestMoveOfficeInvalid)]: actionResponseInvalid,
     [stableStringify(actionRequestMoveOffice2)]: undefined,
     [stableStringify(actionRequestMoveOffice3)]: undefined,
+    [stableStringify(actionRequestMoveOfficeBatch)]: {},
+    [stableStringify(actionRequestMoveOfficeBatchWithEdits)]:
+      actionResponseMoveOfficeBatch,
+    [stableStringify(actionRequestMoveOfficeBatchInvalid)]: undefined,
   },
   createOfficeAndEmployee: {
     [stableStringify(actionRequestCreateOfficeAndEmployee)]:


### PR DESCRIPTION
We added bulk actions to the top level client ontology due to difficulties wrangling with the types that would conditionally enforce options and return types based on what parameters were passed in (array vs single input)