### PR TITLE
Prompt user for destructive commands

### DIFF
--- a/packages/cli/changelog/@unreleased/pr-56.v2.yml
+++ b/packages/cli/changelog/@unreleased/pr-56.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Prompt user for destructive CLI commands
+  links:
+  - https://github.com/palantir/osdk-ts/pull/56

--- a/packages/cli/src/commands/site/deploy/index.ts
+++ b/packages/cli/src/commands/site/deploy/index.ts
@@ -75,11 +75,11 @@ const command: CommandModule<
       })
       .group(
         ["directory", "version", "uploadOnly"],
-        "Deploy Arguments",
+        "Deploy Options",
       )
       .group(
         ["autoVersion", "gitTagPrefix"],
-        "Auto Version Arguments",
+        "Auto Version Options",
       )
       .check((args) => {
         // This is required because we can't use demandOption with conflicts. conflicts protects us against the case where both are provided.

--- a/packages/cli/src/commands/site/index.ts
+++ b/packages/cli/src/commands/site/index.ts
@@ -63,7 +63,7 @@ const command: CommandModule<CliCommonArgs, CommonSiteArgs> = {
       })
       .group(
         ["application", "foundryUrl", "token", "tokenFile"],
-        "Common Arguments",
+        "Common Options",
       )
       .command(version)
       .command(deploy)

--- a/packages/cli/src/commands/site/version/delete/VersionDeleteArgs.ts
+++ b/packages/cli/src/commands/site/version/delete/VersionDeleteArgs.ts
@@ -14,23 +14,9 @@
  * limitations under the License.
  */
 
-import type { CommandModule } from "yargs";
 import type { CommonSiteArgs } from "../../CommonSiteArgs.js";
-import type { VersionGetArgs } from "./VersionGetArgs.js";
 
-const command: CommandModule<
-  CommonSiteArgs,
-  VersionGetArgs
-> = {
-  command: "get",
-  describe: "Get live site version",
-  builder: (argv) => {
-    return argv;
-  },
-  handler: async (args) => {
-    const command = await import("./versionGetCommand.mjs");
-    await command.default(args);
-  },
-};
-
-export default command;
+export interface VersionDeleteArgs extends CommonSiteArgs {
+  version: string;
+  yes?: boolean;
+}

--- a/packages/cli/src/commands/site/version/delete/index.ts
+++ b/packages/cli/src/commands/site/version/delete/index.ts
@@ -16,11 +16,11 @@
 
 import type { CommandModule } from "yargs";
 import type { CommonSiteArgs } from "../../CommonSiteArgs.js";
-import type { SiteVersionArgs } from "../SiteVersionArgs.js";
+import type { VersionDeleteArgs } from "./VersionDeleteArgs.js";
 
 const command: CommandModule<
   CommonSiteArgs,
-  SiteVersionArgs
+  VersionDeleteArgs
 > = {
   command: "delete <version>",
   describe: "Delete site version",
@@ -30,7 +30,13 @@ const command: CommandModule<
         type: "string",
         demandOption: true,
         description: "Version to set as live",
-      });
+      })
+      .option("yes", {
+        alias: "y",
+        type: "boolean",
+        description: "Automatically confirm destructive changes",
+      })
+      .group(["yes"], "Delete Options");
   },
   handler: async (args) => {
     const command = await import("./versionDeleteCommand.mjs");

--- a/packages/cli/src/commands/site/version/delete/versionDeleteCommand.mts
+++ b/packages/cli/src/commands/site/version/delete/versionDeleteCommand.mts
@@ -16,6 +16,7 @@
 
 import { artifacts, createInternalClientContext } from "#net";
 import { consola } from "consola";
+import { colorize } from "consola/utils";
 import { handlePromptCancel } from "../../../../consola/handlePromptCancel.js";
 import { loadToken } from "../../../../util/token.js";
 import type { VersionDeleteArgs } from "./VersionDeleteArgs.js";
@@ -26,7 +27,9 @@ export default async function versionDeleteCommand(
 ) {
   if (!yes) {
     const confirmed = await consola.prompt(
-      `Are you sure you want to delete the version ${version}? This action cannot be undone.`,
+      `Are you sure you want to delete the version ${version}?\n${
+        colorize("bold", "This action cannot be undone.")
+      }`,
       { type: "confirm" },
     );
     handlePromptCancel(confirmed);

--- a/packages/cli/src/commands/site/version/delete/versionDeleteCommand.mts
+++ b/packages/cli/src/commands/site/version/delete/versionDeleteCommand.mts
@@ -16,11 +16,22 @@
 
 import { artifacts, createInternalClientContext } from "#net";
 import { consola } from "consola";
+import { handlePromptCancel } from "../../../../consola/handlePromptCancel.js";
 import { loadToken } from "../../../../util/token.js";
-import type { SiteVersionArgs } from "../SiteVersionArgs.js";
+import type { VersionDeleteArgs } from "./VersionDeleteArgs.js";
+
 export default async function versionDeleteCommand(
-  { version, application, foundryUrl, token, tokenFile }: SiteVersionArgs,
+  { version, yes, application, foundryUrl, token, tokenFile }:
+    VersionDeleteArgs,
 ) {
+  if (!yes) {
+    const confirmed = await consola.prompt(
+      `Are you sure you want to delete the version ${version}? This action cannot be undone.`,
+      { type: "confirm" },
+    );
+    handlePromptCancel(confirmed);
+  }
+
   consola.start(`Deleting version ${version}`);
   const loadedToken = await loadToken(token, tokenFile);
   const tokenProvider = () => loadedToken;

--- a/packages/cli/src/commands/site/version/get/VersionGetArgs.ts
+++ b/packages/cli/src/commands/site/version/get/VersionGetArgs.ts
@@ -14,23 +14,6 @@
  * limitations under the License.
  */
 
-import type { CommandModule } from "yargs";
 import type { CommonSiteArgs } from "../../CommonSiteArgs.js";
-import type { VersionGetArgs } from "./VersionGetArgs.js";
 
-const command: CommandModule<
-  CommonSiteArgs,
-  VersionGetArgs
-> = {
-  command: "get",
-  describe: "Get live site version",
-  builder: (argv) => {
-    return argv;
-  },
-  handler: async (args) => {
-    const command = await import("./versionGetCommand.mjs");
-    await command.default(args);
-  },
-};
-
-export default command;
+export interface VersionGetArgs extends CommonSiteArgs {}

--- a/packages/cli/src/commands/site/version/get/versionGetCommand.mts
+++ b/packages/cli/src/commands/site/version/get/versionGetCommand.mts
@@ -22,10 +22,10 @@ import {
 } from "#net";
 import { consola } from "consola";
 import { loadToken } from "../../../../util/token.js";
-import type { CommonSiteArgs } from "../../CommonSiteArgs.js";
+import type { VersionGetArgs } from "./VersionGetArgs.js";
 
 export default async function versionGetCommand(
-  { foundryUrl, application, token, tokenFile }: CommonSiteArgs,
+  { foundryUrl, application, token, tokenFile }: VersionGetArgs,
 ) {
   const loadedToken = await loadToken(token, tokenFile);
   const tokenProvider = () => loadedToken;

--- a/packages/cli/src/commands/site/version/list/VersionListArgs.ts
+++ b/packages/cli/src/commands/site/version/list/VersionListArgs.ts
@@ -14,23 +14,6 @@
  * limitations under the License.
  */
 
-import type { CommandModule } from "yargs";
 import type { CommonSiteArgs } from "../../CommonSiteArgs.js";
-import type { VersionGetArgs } from "./VersionGetArgs.js";
 
-const command: CommandModule<
-  CommonSiteArgs,
-  VersionGetArgs
-> = {
-  command: "get",
-  describe: "Get live site version",
-  builder: (argv) => {
-    return argv;
-  },
-  handler: async (args) => {
-    const command = await import("./versionGetCommand.mjs");
-    await command.default(args);
-  },
-};
-
-export default command;
+export interface VersionListArgs extends CommonSiteArgs {}

--- a/packages/cli/src/commands/site/version/list/index.ts
+++ b/packages/cli/src/commands/site/version/list/index.ts
@@ -16,10 +16,11 @@
 
 import type { CommandModule } from "yargs";
 import type { CommonSiteArgs } from "../../CommonSiteArgs.js";
+import type { VersionListArgs } from "./VersionListArgs.js";
 
 const command: CommandModule<
   CommonSiteArgs,
-  CommonSiteArgs
+  VersionListArgs
 > = {
   command: "list",
   describe: "List site versions",

--- a/packages/cli/src/commands/site/version/list/versionListCommand.mts
+++ b/packages/cli/src/commands/site/version/list/versionListCommand.mts
@@ -24,10 +24,10 @@ import {
 import { consola } from "consola";
 import { colorize } from "consola/utils";
 import { loadToken } from "../../../../util/token.js";
-import type { CommonSiteArgs } from "../../CommonSiteArgs.js";
+import type { VersionListArgs } from "./VersionListArgs.js";
 
 export default async function versionListCommand(
-  { foundryUrl, application, token, tokenFile }: CommonSiteArgs,
+  { foundryUrl, application, token, tokenFile }: VersionListArgs,
 ) {
   const loadedToken = await loadToken(token, tokenFile);
   const tokenProvider = () => loadedToken;

--- a/packages/cli/src/commands/site/version/set/VersionSetArgs.ts
+++ b/packages/cli/src/commands/site/version/set/VersionSetArgs.ts
@@ -14,23 +14,8 @@
  * limitations under the License.
  */
 
-import type { CommandModule } from "yargs";
 import type { CommonSiteArgs } from "../../CommonSiteArgs.js";
-import type { VersionGetArgs } from "./VersionGetArgs.js";
 
-const command: CommandModule<
-  CommonSiteArgs,
-  VersionGetArgs
-> = {
-  command: "get",
-  describe: "Get live site version",
-  builder: (argv) => {
-    return argv;
-  },
-  handler: async (args) => {
-    const command = await import("./versionGetCommand.mjs");
-    await command.default(args);
-  },
-};
-
-export default command;
+export interface VersionSetArgs extends CommonSiteArgs {
+  version: string;
+}

--- a/packages/cli/src/commands/site/version/set/index.ts
+++ b/packages/cli/src/commands/site/version/set/index.ts
@@ -16,11 +16,11 @@
 
 import type { CommandModule } from "yargs";
 import type { CommonSiteArgs } from "../../CommonSiteArgs.js";
-import type { SiteVersionArgs } from "../SiteVersionArgs.js";
+import type { VersionSetArgs } from "./VersionSetArgs.js";
 
 const command: CommandModule<
   CommonSiteArgs,
-  SiteVersionArgs
+  VersionSetArgs
 > = {
   command: "set <version>",
   describe: "Set live site version",

--- a/packages/cli/src/commands/site/version/set/versionSetCommand.mts
+++ b/packages/cli/src/commands/site/version/set/versionSetCommand.mts
@@ -23,10 +23,10 @@ import {
   thirdPartyApplicationService,
 } from "#net";
 import { loadToken } from "../../../../util/token.js";
-import type { SiteVersionArgs } from "../SiteVersionArgs.js";
+import type { VersionSetArgs } from "./VersionSetArgs.js";
 
 export default async function versionSetCommand(
-  { version, application, foundryUrl, token, tokenFile }: SiteVersionArgs,
+  { version, application, foundryUrl, token, tokenFile }: VersionSetArgs,
 ) {
   consola.start(`Setting live version`);
   const loadedToken = await loadToken(token, tokenFile);

--- a/packages/cli/src/commands/site/version/unset/VersionUnsetArgs.ts
+++ b/packages/cli/src/commands/site/version/unset/VersionUnsetArgs.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import type { CommonSiteArgs } from "../CommonSiteArgs.js";
+import type { CommonSiteArgs } from "../../CommonSiteArgs.js";
 
-export interface SiteVersionArgs extends CommonSiteArgs {
-  version: string;
+export interface VersionUnsetArgs extends CommonSiteArgs {
+  yes?: boolean;
 }

--- a/packages/cli/src/commands/site/version/unset/index.ts
+++ b/packages/cli/src/commands/site/version/unset/index.ts
@@ -16,15 +16,21 @@
 
 import type { CommandModule } from "yargs";
 import type { CommonSiteArgs } from "../../CommonSiteArgs.js";
+import type { VersionUnsetArgs } from "./VersionUnsetArgs.js";
 
 const command: CommandModule<
   CommonSiteArgs,
-  CommonSiteArgs
+  VersionUnsetArgs
 > = {
   command: "unset",
   describe: "Clear live site version",
   builder: (argv) => {
-    return argv;
+    return argv.option("yes", {
+      alias: "y",
+      type: "boolean",
+      description: "Automatically confirm destructive changes",
+    })
+      .group(["yes"], "Unset Options");
   },
   handler: async (args) => {
     const command = await import("./versionUnsetCommand.mjs");

--- a/packages/cli/src/commands/site/version/unset/versionUnsetCommand.mts
+++ b/packages/cli/src/commands/site/version/unset/versionUnsetCommand.mts
@@ -22,6 +22,7 @@ import {
   createInternalClientContext,
   thirdPartyApplicationService,
 } from "#net";
+import { colorize } from "consola/utils";
 import { handlePromptCancel } from "../../../../consola/handlePromptCancel.js";
 import { loadToken } from "../../../../util/token.js";
 import type { VersionUnsetArgs } from "./VersionUnsetArgs.js";
@@ -31,7 +32,12 @@ export default async function versionUnsetCommand(
 ) {
   if (!yes) {
     const confirmed = await consola.prompt(
-      `Are you sure you want to clear the live site version? Your site will no longer be accessible until a new live site version is set.`,
+      `Are you sure you want to clear the live site version?\n${
+        colorize(
+          "bold",
+          "Your site will no longer be accessible until a new live site version is set.",
+        )
+      }`,
       { type: "confirm" },
     );
     handlePromptCancel(confirmed);

--- a/packages/cli/src/commands/site/version/unset/versionUnsetCommand.mts
+++ b/packages/cli/src/commands/site/version/unset/versionUnsetCommand.mts
@@ -22,12 +22,21 @@ import {
   createInternalClientContext,
   thirdPartyApplicationService,
 } from "#net";
+import { handlePromptCancel } from "../../../../consola/handlePromptCancel.js";
 import { loadToken } from "../../../../util/token.js";
-import type { CommonSiteArgs } from "../../CommonSiteArgs.js";
+import type { VersionUnsetArgs } from "./VersionUnsetArgs.js";
 
 export default async function versionUnsetCommand(
-  { application, foundryUrl, token, tokenFile }: CommonSiteArgs,
+  { yes, application, foundryUrl, token, tokenFile }: VersionUnsetArgs,
 ) {
+  if (!yes) {
+    const confirmed = await consola.prompt(
+      `Are you sure you want to clear the live site version? Your site will no longer be accessible until a new live site version is set.`,
+      { type: "confirm" },
+    );
+    handlePromptCancel(confirmed);
+  }
+
   const loadedToken = await loadToken(token, tokenFile);
   const tokenProvider = () => loadedToken;
   const clientCtx = createInternalClientContext(foundryUrl, tokenProvider);

--- a/packages/cli/src/consola/handlePromptCancel.ts
+++ b/packages/cli/src/consola/handlePromptCancel.ts
@@ -14,23 +14,15 @@
  * limitations under the License.
  */
 
-import type { CommandModule } from "yargs";
-import type { CommonSiteArgs } from "../../CommonSiteArgs.js";
-import type { VersionGetArgs } from "./VersionGetArgs.js";
+import { consola } from "consola";
 
-const command: CommandModule<
-  CommonSiteArgs,
-  VersionGetArgs
-> = {
-  command: "get",
-  describe: "Get live site version",
-  builder: (argv) => {
-    return argv;
-  },
-  handler: async (args) => {
-    const command = await import("./versionGetCommand.mjs");
-    await command.default(args);
-  },
-};
-
-export default command;
+export function handlePromptCancel(promptResponse: any) {
+  const isFalse = typeof promptResponse === "boolean" && !promptResponse;
+  // https://github.com/unjs/consola/issues/251
+  const isSigInt = typeof promptResponse === "symbol"
+    && promptResponse.toString() === "Symbol(clack:cancel)";
+  if (isSigInt || isFalse) {
+    consola.fail("Operation cancelled");
+    process.exit(0);
+  }
+}


### PR DESCRIPTION
- `version unset` and `version delete` has prompts that can be skipped automatically with `-y`/`--yes`
- Move to all commands having their own args interface now that they are diverging a bit
- Use "Options" wording rather than "Arguments" for option groups which matches the default "Options" group name