### PR TITLE
Display site link after deploy

### DIFF
--- a/packages/cli/src/commands/site/deploy/siteDeployCommand.mts
+++ b/packages/cli/src/commands/site/deploy/siteDeployCommand.mts
@@ -117,26 +117,30 @@ export default async function siteDeployCommand(
       { siteVersion: { version: siteVersion } },
     );
     consola.success(`Deployed ${siteVersion} successfully`);
-    consola.box({
-      message: `View live site:\n\n${
-        colorize(
-          "green",
-          `https://${domain}`,
-        )
-      }`,
-      style: BOX_STYLES,
-    });
+    if (domain != null) {
+      consola.box({
+        message: `View live site:\n\n${
+          colorize(
+            "green",
+            `https://${domain}`,
+          )
+        }`,
+        style: BOX_STYLES,
+      });
+    }
   } else {
     consola.debug("Upload only mode enabled, skipping deployment");
-    consola.box({
-      message: `Preview link:\n\n${
-        colorize(
-          "green",
-          `https://${domain}/.system/preview?previewVersion=${siteVersion}`,
-        )
-      }`,
-      style: BOX_STYLES,
-    });
+    if (domain != null) {
+      consola.box({
+        message: `Preview link:\n\n${
+          colorize(
+            "green",
+            `https://${domain}/.system/preview?previewVersion=${siteVersion}`,
+          )
+        }`,
+        style: BOX_STYLES,
+      });
+    }
   }
 }
 
@@ -165,7 +169,7 @@ function getFirstSiteDomain(
   domains: Array<SiteDomainInfo>,
 ): string | undefined {
   if (domains.length === 0) {
-    consola.debug("No registered domains for site found");
+    consola.warn("No registered domains for site found");
     return undefined;
   }
   switch (domains[0].type) {

--- a/packages/cli/src/net/index.mts
+++ b/packages/cli/src/net/index.mts
@@ -15,6 +15,7 @@
  */
 
 export { ArtifactsSitesAdminV2Service } from "../generated/artifacts-sites/index.js";
+export type { SiteDomainInfo } from "../generated/artifacts-sites/SiteDomainInfo.js";
 export * as artifacts from "./artifacts/index.mjs";
 export { createConjureContext } from "./createConjureContext.mjs";
 export { createInternalClientContext } from "./createInternalClientContext.mjs";


### PR DESCRIPTION
Fetch registered domains (only one is exposed at the moment) and display link for live site or for preview version depending on `--uploadOnly`.

Note that the preview link sets a cookie and redirects to the root page so going back to the live link later will still show that preview version until clicking exit in the banner