### PR TITLE
Update ExitProcessError tips and use option instead of argument

### DIFF
--- a/packages/cli/changelog/@unreleased/pr-63.v2.yml
+++ b/packages/cli/changelog/@unreleased/pr-63.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Update ExitProcessError tips and use option instead of argument
+  links:
+  - https://github.com/palantir/osdk-ts/pull/63

--- a/packages/cli/src/util/autoVersion.test.ts
+++ b/packages/cli/src/util/autoVersion.test.ts
@@ -71,7 +71,7 @@ describe("autoVersion", () => {
     });
 
     await expect(autoVersion()).rejects.toThrowError(
-      "Unable to determine the version using git-describe as git is not installed",
+      "git is not installed",
     );
   });
 
@@ -81,7 +81,7 @@ describe("autoVersion", () => {
     });
 
     await expect(autoVersion()).rejects.toThrowError(
-      "Unable to determine the version using git-describe as the current directory is not a git repository",
+      "the current directory is not a git repository",
     );
   });
 
@@ -91,7 +91,7 @@ describe("autoVersion", () => {
     });
 
     await expect(autoVersion()).rejects.toThrowError(
-      "Unable to determine the version using git-describe as no matching tags were found.",
+      "no matching tags were found.",
     );
   });
 });

--- a/packages/cli/src/util/autoVersion.ts
+++ b/packages/cli/src/util/autoVersion.ts
@@ -95,7 +95,7 @@ async function gitDescribe(matchPrefix: string | undefined): Promise<string> {
 
     throw new ExitProcessError(
       2,
-      `Unable to determine the version automatically: ${error}.`,
+      `Unable to determine auto version using git-describe: ${error}.`,
       `You can supply a --version option to set the version manually`,
     );
   }

--- a/packages/cli/src/util/autoVersion.ts
+++ b/packages/cli/src/util/autoVersion.ts
@@ -65,7 +65,7 @@ async function gitDescribe(matchPrefix: string | undefined): Promise<string> {
       ) {
         throw new ExitProcessError(
           2,
-          `Unable to determine the version using git-describe as git is not installed or found in the PATH.`,
+          "Unable to determine auto version using git-describe as git is not installed or found in the PATH.",
           `You can set up git and try again or supply a --version option to set the version manually`,
         );
       }

--- a/packages/cli/src/util/autoVersion.ts
+++ b/packages/cli/src/util/autoVersion.ts
@@ -87,7 +87,7 @@ async function gitDescribe(matchPrefix: string | undefined): Promise<string> {
       ) {
         throw new ExitProcessError(
           2,
-          `Unable to determine the version using git-describe as no matching tags were found.`,
+          `Unable to determine auto version using git-describe as no matching tags were found.`,
           `You can create a tag matching the configured tag prefix and try again or supply a --version option to set the version manually`,
         );
       }

--- a/packages/cli/src/util/autoVersion.ts
+++ b/packages/cli/src/util/autoVersion.ts
@@ -66,7 +66,7 @@ async function gitDescribe(matchPrefix: string | undefined): Promise<string> {
         throw new ExitProcessError(
           2,
           `Unable to determine the version using git-describe as git is not installed or found in the PATH.`,
-          `You can correctly configure git and try again or supply a --version option`,
+          `You can set up git and try again or supply a --version option to set the version manually`,
         );
       }
 

--- a/packages/cli/src/util/autoVersion.ts
+++ b/packages/cli/src/util/autoVersion.ts
@@ -88,7 +88,7 @@ async function gitDescribe(matchPrefix: string | undefined): Promise<string> {
         throw new ExitProcessError(
           2,
           `Unable to determine the version using git-describe as no matching tags were found.`,
-          `You can tag a matching version and try again or supply a --version option`,
+          `You can create a tag matching the configured tag prefix and try again or supply a --version option to set the version manually`,
         );
       }
     }

--- a/packages/cli/src/util/autoVersion.ts
+++ b/packages/cli/src/util/autoVersion.ts
@@ -75,7 +75,7 @@ async function gitDescribe(matchPrefix: string | undefined): Promise<string> {
       ) {
         throw new ExitProcessError(
           2,
-          `Unable to determine the version using git-describe as the current directory is not a git repository.`,
+          `Unable to determine auto version using git-describe as the current directory is not a git repository.`,
           `You can run the command in a git respository and try again or supply a --version option`,
         );
       }

--- a/packages/cli/src/util/autoVersion.ts
+++ b/packages/cli/src/util/autoVersion.ts
@@ -65,7 +65,8 @@ async function gitDescribe(matchPrefix: string | undefined): Promise<string> {
       ) {
         throw new ExitProcessError(
           2,
-          `Unable to determine the version using git-describe as git is not installed or found in the PATH.\nPlease correctly configure git or supply a --version option.`,
+          `Unable to determine the version using git-describe as git is not installed or found in the PATH.`,
+          `You can correctly configure git and try again or supply a --version option`,
         );
       }
 
@@ -74,7 +75,8 @@ async function gitDescribe(matchPrefix: string | undefined): Promise<string> {
       ) {
         throw new ExitProcessError(
           2,
-          `Unable to determine the version using git-describe as the current directory is not a git repository.\nPlease run the command in a git respository or supply a --version option.`,
+          `Unable to determine the version using git-describe as the current directory is not a git repository.`,
+          `You can run the command in a git respository and try again or supply a --version option`,
         );
       }
 
@@ -85,14 +87,16 @@ async function gitDescribe(matchPrefix: string | undefined): Promise<string> {
       ) {
         throw new ExitProcessError(
           2,
-          `Unable to determine the version using git-describe as no matching tags were found.\nPlease tag a matching version or supply a --version option.`,
+          `Unable to determine the version using git-describe as no matching tags were found.`,
+          `You can tag a matching version and try again or supply a --version option`,
         );
       }
     }
 
     throw new ExitProcessError(
       2,
-      `Unable to determine the version automatically: ${error}.\nPlease supply a --version option.`,
+      `Unable to determine the version automatically: ${error}.`,
+      `You can supply a --version option to set the version manually`,
     );
   }
 

--- a/packages/cli/src/util/autoVersion.ts
+++ b/packages/cli/src/util/autoVersion.ts
@@ -76,7 +76,7 @@ async function gitDescribe(matchPrefix: string | undefined): Promise<string> {
         throw new ExitProcessError(
           2,
           `Unable to determine auto version using git-describe as the current directory is not a git repository.`,
-          `You can run the command in a git respository and try again or supply a --version option`,
+          `You can run the command in a git repository and try again or supply a --version option to set the version manually`,
         );
       }
 

--- a/packages/cli/src/util/token.ts
+++ b/packages/cli/src/util/token.ts
@@ -33,7 +33,7 @@ export async function loadToken(
   tokenFile?: string,
 ): Promise<string> {
   if (token) {
-    consola.debug(`Using token from --token argument`);
+    consola.debug(`Using token from --token option`);
     validate(token);
     return token;
   }
@@ -41,7 +41,7 @@ export async function loadToken(
   if (tokenFile) {
     const loadedToken = await loadTokenFile(tokenFile);
     consola.debug(
-      `Using token from --tokenFile=${loadedToken.filePath} argument`,
+      `Using token from --tokenFile=${loadedToken.filePath} option`,
     );
     validate(loadedToken.token);
     return loadedToken.token;
@@ -63,9 +63,10 @@ export async function loadToken(
 
   throw new ExitProcessError(
     2,
-    `No token found. Please supply a --token argument, a --token-file argument or set the ${
+    `No token found.`,
+    `You can supply a --token option, a --token-file option or set the ${
       TOKEN_ENV_VARS[0]
-    } environment variable.`,
+    } environment variable`,
   );
 }
 

--- a/packages/cli/src/util/token.ts
+++ b/packages/cli/src/util/token.ts
@@ -64,7 +64,7 @@ export async function loadToken(
   throw new ExitProcessError(
     2,
     `No token found.`,
-    `You can supply a --token option, a --token-file option or set the ${
+    `You can supply a --token or --token-file option, or set the ${
       TOKEN_ENV_VARS[0]
     } environment variable`,
   );

--- a/packages/create-app/changelog/@unreleased/pr-63.v2.yml
+++ b/packages/create-app/changelog/@unreleased/pr-63.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Update ExitProcessError tips and use option instead of argument
+  links:
+  - https://github.com/palantir/osdk-ts/pull/63

--- a/packages/create-app/src/cli.ts
+++ b/packages/create-app/src/cli.ts
@@ -61,7 +61,7 @@ export async function cli(args: string[] = process.argv) {
     .help()
     .command(
       "$0 [project] [--<option>]",
-      "Create a new OSDK application based on framework templates. Information may be provided through arguments to skip interactive prompts.",
+      "Create a new OSDK application based on framework templates. Information may be provided through options to skip interactive prompts.",
       (yargs) =>
         yargs
           .positional("project", {


### PR DESCRIPTION
Two minor improvements:

- Use ExitProcessError tips where valid
- Consistently use option instead of argument

<img width="755" alt="image" src="https://github.com/palantir/osdk-ts/assets/35533361/574dc428-503f-4d08-866e-61b26f08fcc8">
