### PR TITLE
Polish casing, option description, and YargsCheckErrors across CLIs and commands

### DIFF
--- a/packages/cli/changelog/@unreleased/pr-68.v2.yml
+++ b/packages/cli/changelog/@unreleased/pr-68.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Polish casing, option description, and YargsCheckErrors across CLIs
+    and commands
+  links:
+  - https://github.com/palantir/osdk-ts/pull/68

--- a/packages/cli/src/commands/auth/index.ts
+++ b/packages/cli/src/commands/auth/index.ts
@@ -29,6 +29,7 @@ const site: yargs.CommandModule<CliCommonArgs, CommonAuthArgs> = {
           type: "string",
           demandOption: true,
           alias: "baseUrl", // for backwards compatibility
+          describe: "URL for the Foundry stack",
         },
       })
       .command(login)

--- a/packages/cli/src/commands/auth/login/index.ts
+++ b/packages/cli/src/commands/auth/login/index.ts
@@ -30,6 +30,7 @@ export const command: CommandModule<
         alias: "applicationId", // for backwards compatibility
         type: "string",
         demandOption: true,
+        describe: "OAuth client ID for application",
       });
   },
   handler: async (args) => {

--- a/packages/cli/src/commands/site/deploy/index.ts
+++ b/packages/cli/src/commands/site/deploy/index.ts
@@ -101,7 +101,7 @@ const command: CommandModule<
 
         if (args.version != null && !isValidSemver(args.version)) {
           throw new YargsCheckError(
-          `--version "${args.version}" must be a valid SemVer string`,
+            `--version "${args.version}" must be a valid SemVer string`,
           );
         }
 

--- a/packages/cli/src/commands/site/deploy/index.ts
+++ b/packages/cli/src/commands/site/deploy/index.ts
@@ -21,6 +21,7 @@ import type {
   SiteConfig,
 } from "../../../util/config.js";
 import configLoader from "../../../util/configLoader.js";
+import { isValidSemver } from "../../../util/isValidSemver.js";
 import { YargsCheckError } from "../../../YargsCheckError.js";
 import type { CommonSiteArgs } from "../CommonSiteArgs.js";
 import { logDeployCommandConfigFileOverride } from "./logDeployCommandConfigFileOverride.js";
@@ -95,6 +96,12 @@ const command: CommandModule<
         ) {
           throw new YargsCheckError(
             "One of --version or --autoVersion must be specified",
+          );
+        }
+
+        if (args.version != null && !isValidSemver(args.version)) {
+          throw new YargsCheckError(
+            "--version must be a valid SemVer string",
           );
         }
 

--- a/packages/cli/src/commands/site/deploy/index.ts
+++ b/packages/cli/src/commands/site/deploy/index.ts
@@ -101,7 +101,7 @@ const command: CommandModule<
 
         if (args.version != null && !isValidSemver(args.version)) {
           throw new YargsCheckError(
-            "--version must be a valid SemVer string",
+          `--version "${args.version}" must be a valid SemVer string`,
           );
         }
 

--- a/packages/cli/src/commands/site/index.ts
+++ b/packages/cli/src/commands/site/index.ts
@@ -48,7 +48,7 @@ const command: CommandModule<CliCommonArgs, CommonSiteArgs> = {
           ...foundryUrl
             ? { default: foundryUrl }
             : { demandOption: true },
-          description: "Foundry URL including protocol",
+          description: "URL for the Foundry stack",
         },
         token: {
           type: "string",

--- a/packages/cli/src/commands/typescript/generate/generate.ts
+++ b/packages/cli/src/commands/typescript/generate/generate.ts
@@ -16,6 +16,7 @@
 
 import type { CommandModule } from "yargs";
 import { isValidSemver } from "../../../util/isValidSemver.js";
+import { YargsCheckError } from "../../../YargsCheckError.js";
 import type { TypescriptGenerateArgs } from "./TypescriptGenerateArgs.js";
 
 export const command: CommandModule<
@@ -40,8 +41,7 @@ export const command: CommandModule<
             conflicts: ["foundryUrl", "clientId"],
           },
           foundryUrl: {
-            description:
-              "The URL to the foundry stack that contains the ontology",
+            description: "URL for the foundry stack that contains the ontology",
             type: "string",
             demandOption: false,
             conflicts: "ontologyPath",
@@ -49,7 +49,7 @@ export const command: CommandModule<
             alias: "stack", // for backwards compatibility
           },
           clientId: {
-            description: "The application's client id",
+            description: "OAuth client ID for application",
             type: "string",
             demandOption: false,
             conflicts: "ontologyPath",
@@ -86,14 +86,14 @@ export const command: CommandModule<
       .check(
         (args) => {
           if (!args.ontologyPath && !args.foundryUrl) {
-            throw new Error(
-              "Error: Must specify either ontologyPath or foundryUrl and clientId",
+            throw new YargsCheckError(
+              "Must specify either ontologyPath or foundryUrl and clientId",
             );
           }
 
           if (args.version !== "dev" && !isValidSemver(args.version)) {
-            throw new Error(
-              "Error: Version must be 'dev' or a valid semver version",
+            throw new YargsCheckError(
+              "Version must be 'dev' or a valid semver version",
             );
           }
 

--- a/packages/cli/src/commands/typescript/generate/handleGenerate.mts
+++ b/packages/cli/src/commands/typescript/generate/handleGenerate.mts
@@ -26,6 +26,7 @@ import {
 import { createClientContext, createOpenApiRequest } from "@osdk/shared.net";
 import { consola } from "consola";
 import * as fs from "node:fs";
+import { YargsCheckError } from "../../../YargsCheckError.js";
 import invokeLoginFlow from "../../auth/login/loginFlow.js";
 import type { TypescriptGenerateArgs } from "./TypescriptGenerateArgs.js";
 
@@ -38,7 +39,9 @@ export default async function handleGenerate(args: TypescriptGenerateArgs) {
   } else if (args.foundryUrl && args.clientId) {
     success = await generateFromStack(args);
   } else {
-    throw new Error("Must have specified ontologyPath or stack and clientId");
+    throw new YargsCheckError(
+      "Must have specified ontologyPath or stack and clientId",
+    );
   }
 
   if (success) {

--- a/packages/create-app/changelog/@unreleased/pr-68.v2.yml
+++ b/packages/create-app/changelog/@unreleased/pr-68.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Polish casing, option description, and YargsCheckErrors across CLIs
+    and commands
+  links:
+  - https://github.com/palantir/osdk-ts/pull/68

--- a/packages/create-app/src/cli.ts
+++ b/packages/create-app/src/cli.ts
@@ -57,6 +57,7 @@ interface CliArgs {
 export async function cli(args: string[] = process.argv) {
   const base: Argv<CliArgs> = yargs(hideBin(args))
     .version(process.env.PACKAGE_VERSION ?? "")
+    .wrap(Math.min(150, yargs().terminalWidth()))
     .strict()
     .help()
     .command(
@@ -76,15 +77,15 @@ export async function cli(args: string[] = process.argv) {
             type: "string",
             describe: "Template name to use",
           })
-          .option("foundry-url", {
+          .option("foundryUrl", {
             type: "string",
             describe: "URL for the Foundry stack",
           })
-          .option("application-url", {
+          .option("applicationUrl", {
             type: "string",
             describe: "URL the production application will be hosted on",
           })
-          .option("skip-application-url", {
+          .option("skipApplicationUrl", {
             type: "boolean",
             describe:
               "Skip filling in URL the production application will be hosted on",
@@ -93,15 +94,15 @@ export async function cli(args: string[] = process.argv) {
             type: "string",
             describe: "Application resource identifier (rid)",
           })
-          .option("client-id", {
+          .option("clientId", {
             type: "string",
             describe: "OAuth client ID for application",
           })
-          .option("osdk-package", {
+          .option("osdkPackage", {
             type: "string",
             describe: "OSDK package name for application",
           })
-          .option("osdk-registry-url", {
+          .option("osdkRegistryUrl", {
             type: "string",
             describe: "URL for NPM registry to install OSDK package",
           }),


### PR DESCRIPTION
- Update the create-app CLI to use camelCase for the options
- Make create-app CLI width consistent with other CLI
   - <img width="1077" alt="image" src="https://github.com/palantir/osdk-ts/assets/35533361/7bf9ae0c-b378-437d-a77f-622527448e36">
  
- Update several option description to be consistent across CLIs
- Update errors thrown inside yargs check
   - (After/Before) <img width="1080" alt="image" src="https://github.com/palantir/osdk-ts/assets/35533361/c38ffd22-3c28-412c-b16b-d1a326c5982a">
 - Throw YargsCheckError if version isn't valid strict semVer 
     - <img width="532" alt="image" src="https://github.com/palantir/osdk-ts/assets/35533361/8f6829b7-2e6f-47e2-ac2a-5aac9e61c638">
 

