### PR TITLE
Resurface `Version already exists` message

### DIFF
--- a/packages/cli/changelog/@unreleased/pr-69.v2.yml
+++ b/packages/cli/changelog/@unreleased/pr-69.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Resurface `Version Already Exists` message
+  links:
+  - https://github.com/palantir/osdk-ts/pull/69

--- a/packages/cli/src/net/createFetch.mts
+++ b/packages/cli/src/net/createFetch.mts
@@ -61,11 +61,14 @@ function handleFetchError(e: unknown): Promise<Response> {
     tip = "Check your token is valid and has not expired or been disabled";
   } else if (e.statusCode === 403) {
     tip = "Check your token has the required scopes for this operation";
-  } else if (e.errorName === "Artifacts:ArtifactAlreadyExists") {
-    e.message = "Version already exists";
   }
 
-  throw new ExitProcessError(1, e.message, tip);
+  let message = e.message;
+  if (e.errorName === "Artifacts:ArtifactAlreadyExists") {
+    message = "Version already exists";
+  }
+
+  throw new ExitProcessError(1, message, tip);
 }
 
 function createRequestLoggingFetch(

--- a/packages/cli/src/net/createFetch.mts
+++ b/packages/cli/src/net/createFetch.mts
@@ -61,6 +61,8 @@ function handleFetchError(e: unknown): Promise<Response> {
     tip = "Check your token is valid and has not expired or been disabled";
   } else if (e.statusCode === 403) {
     tip = "Check your token has the required scopes for this operation";
+  } else if (e.errorName === "Artifacts:ArtifactAlreadyExists") {
+    e.message = "Version already exists";
   }
 
   throw new ExitProcessError(1, e.message, tip);


### PR DESCRIPTION
Due to the logic introduced [here](https://github.com/palantir/osdk-ts/pull/61) where fetch errors are being directly thrown, the logic of checking if the upload failed due to clashing versions wasn't reachable.

So we explicitly overwrite the error message if its of the specific Conjure error type we expect.

<img width="543" alt="image" src="https://github.com/palantir/osdk-ts/assets/35533361/fb82a4d0-ec00-4054-bf08-253083463c49">