### PR TITLE
Log OSDK CLI version on start of CLI

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -29,6 +29,10 @@ import { logVersionMiddleware } from "./yargs/logVersionMiddleware.js";
 import { YargsCheckError } from "./YargsCheckError.js";
 
 export async function cli(args: string[] = process.argv) {
+  consola.info(
+    `Palantir OSDK CLI ${process.env.PACKAGE_VERSION}`,
+  );
+
   const base: Argv<CliCommonArgs> = yargs(hideBin(args))
     .wrap(Math.min(150, yargs().terminalWidth()))
     .env("OSDK")

--- a/packages/cli/src/yargs/logVersionMiddleware.ts
+++ b/packages/cli/src/yargs/logVersionMiddleware.ts
@@ -21,10 +21,6 @@ let firstTime = true;
 export async function logVersionMiddleware(args: CliCommonArgs) {
   if (firstTime) {
     firstTime = false;
-    // This will be called before any command is executed
-    consola.info(
-      `Palantir OSDK CLI ${process.env.PACKAGE_VERSION}`,
-    );
 
     consola.level = 3 + args.verbose; // so 1 -v is debug logs and -vv is trace
     if (consola.level > 3) {


### PR DESCRIPTION
Logging OSDK CLI version doesn't depend on verbosity level, so if we want it to be visible even when running `--help` we can move logging the version to top of the CLI.

<img width="257" alt="image" src="https://github.com/palantir/osdk-ts/assets/35533361/3e0e8be9-78a0-4c9d-8da6-d9967fafa284">

Doesn't affect already existing behavior of when errors occur

<img width="371" alt="image" src="https://github.com/palantir/osdk-ts/assets/35533361/56be3a4c-cdc8-4953-999a-0bb85b1c0e8b">
