### PR TITLE
Check client env variables at runtime

### DIFF
--- a/packages/create-app/changelog/@unreleased/pr-71.v2.yml
+++ b/packages/create-app/changelog/@unreleased/pr-71.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Check client env variables at runtime
+  links:
+  - https://github.com/palantir/osdk-ts/pull/71

--- a/packages/create-app/src/__snapshots__/expected-template-next-static-export/src/lib/client.ts
+++ b/packages/create-app/src/__snapshots__/expected-template-next-static-export/src/lib/client.ts
@@ -1,14 +1,30 @@
 import { FoundryClient, PublicClientAuth } from "@fake/sdk";
 
+const url = process.env.NEXT_PUBLIC_FOUNDRY_API_URL;
+const clientId = process.env.NEXT_PUBLIC_FOUNDRY_CLIENT_ID;
+const redirectUrl = process.env.NEXT_PUBLIC_FOUNDRY_REDIRECT_URL;
+checkEnv(url, "NEXT_PUBLIC_FOUNDRY_API_URL");
+checkEnv(clientId, "NEXT_PUBLIC_FOUNDRY_CLIENT_ID");
+checkEnv(redirectUrl, "NEXT_PUBLIC_FOUNDRY_REDIRECT_URL");
+
+function checkEnv(
+  value: string | undefined,
+  name: string,
+): asserts value is string {
+  if (value == null) {
+    throw new Error(`Missing environment variable: ${name}`);
+  }
+}
+
 /**
  * Initialize the client to interact with the Ontology SDK
  */
 const client = new FoundryClient({
-  url: process.env.NEXT_PUBLIC_FOUNDRY_API_URL!,
+  url,
   auth: new PublicClientAuth({
-    clientId: process.env.NEXT_PUBLIC_FOUNDRY_CLIENT_ID!,
-    url: process.env.NEXT_PUBLIC_FOUNDRY_API_URL!,
-    redirectUrl: process.env.NEXT_PUBLIC_FOUNDRY_REDIRECT_URL!,
+    clientId,
+    url,
+    redirectUrl,
   }),
 });
 

--- a/packages/create-app/src/__snapshots__/expected-template-react/src/client.ts
+++ b/packages/create-app/src/__snapshots__/expected-template-react/src/client.ts
@@ -1,14 +1,30 @@
 import { FoundryClient, PublicClientAuth } from "@fake/sdk";
 
+const url = import.meta.env.VITE_FOUNDRY_API_URL;
+const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
+const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
+checkEnv(url, "VITE_FOUNDRY_API_URL");
+checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
+checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
+
+function checkEnv(
+  value: string | undefined,
+  name: string,
+): asserts value is string {
+  if (value == null) {
+    throw new Error(`Missing environment variable: ${name}`);
+  }
+}
+
 /**
  * Initialize the client to interact with the Ontology SDK
  */
 const client = new FoundryClient({
-  url: import.meta.env.VITE_FOUNDRY_API_URL!,
+  url,
   auth: new PublicClientAuth({
-    clientId: import.meta.env.VITE_FOUNDRY_CLIENT_ID!,
-    url: import.meta.env.VITE_FOUNDRY_API_URL!,
-    redirectUrl: import.meta.env.VITE_FOUNDRY_REDIRECT_URL!,
+    clientId,
+    url,
+    redirectUrl,
   }),
 });
 

--- a/packages/create-app/src/__snapshots__/expected-template-vue/src/client.ts
+++ b/packages/create-app/src/__snapshots__/expected-template-vue/src/client.ts
@@ -1,14 +1,30 @@
 import { FoundryClient, PublicClientAuth } from "@fake/sdk";
 
+const url = import.meta.env.VITE_FOUNDRY_API_URL;
+const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
+const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
+checkEnv(url, "VITE_FOUNDRY_API_URL");
+checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
+checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
+
+function checkEnv(
+  value: string | undefined,
+  name: string,
+): asserts value is string {
+  if (value == null) {
+    throw new Error(`Missing environment variable: ${name}`);
+  }
+}
+
 /**
  * Initialize the client to interact with the Ontology SDK
  */
 const client = new FoundryClient({
-  url: import.meta.env.VITE_FOUNDRY_API_URL!,
+  url,
   auth: new PublicClientAuth({
-    clientId: import.meta.env.VITE_FOUNDRY_CLIENT_ID!,
-    url: import.meta.env.VITE_FOUNDRY_API_URL!,
-    redirectUrl: import.meta.env.VITE_FOUNDRY_REDIRECT_URL!,
+    clientId,
+    url,
+    redirectUrl,
   }),
 });
 

--- a/packages/create-app/src/generate/generateEnv.test.ts
+++ b/packages/create-app/src/generate/generateEnv.test.ts
@@ -34,7 +34,7 @@ PUBLIC_FOUNDRY_CLIENT_ID=123
 
 const expectedEnvProductionNoAppUrl = `
 PUBLIC_FOUNDRY_API_URL=https://example.palantirfoundry.com
-PUBLIC_FOUNDRY_REDIRECT_URL=<Fill in the domain at which you deploy your application>/auth/callback
+# PUBLIC_FOUNDRY_REDIRECT_URL=<Fill in the domain at which you deploy your application>/auth/callback
 PUBLIC_FOUNDRY_CLIENT_ID=123
 `.trimStart();
 

--- a/packages/create-app/src/generate/generateEnv.ts
+++ b/packages/create-app/src/generate/generateEnv.ts
@@ -45,8 +45,7 @@ export function generateEnvProduction({
   return generateEnv({
     envPrefix,
     foundryUrl,
-    applicationUrl: applicationUrl
-      ?? "<Fill in the domain at which you deploy your application>",
+    applicationUrl,
     clientId,
   });
 }
@@ -59,10 +58,13 @@ function generateEnv({
 }: {
   envPrefix: string;
   foundryUrl: string;
-  applicationUrl: string;
+  applicationUrl: string | undefined;
   clientId: string;
 }): string {
   return `${envPrefix}FOUNDRY_API_URL=${foundryUrl}\n`
-    + `${envPrefix}FOUNDRY_REDIRECT_URL=${applicationUrl}/auth/callback\n`
+    + `${applicationUrl == null ? "# " : ""}${envPrefix}FOUNDRY_REDIRECT_URL=${
+      applicationUrl
+        ?? "<Fill in the domain at which you deploy your application>"
+    }/auth/callback\n`
     + `${envPrefix}FOUNDRY_CLIENT_ID=${clientId}\n`;
 }

--- a/packages/create-app/templates/template-next-static-export/src/lib/client.ts.hbs
+++ b/packages/create-app/templates/template-next-static-export/src/lib/client.ts.hbs
@@ -1,14 +1,30 @@
 import { FoundryClient, PublicClientAuth } from "{{osdkPackage}}";
 
+const url = process.env.NEXT_PUBLIC_FOUNDRY_API_URL;
+const clientId = process.env.NEXT_PUBLIC_FOUNDRY_CLIENT_ID;
+const redirectUrl = process.env.NEXT_PUBLIC_FOUNDRY_REDIRECT_URL;
+checkEnv(url, "NEXT_PUBLIC_FOUNDRY_API_URL");
+checkEnv(clientId, "NEXT_PUBLIC_FOUNDRY_CLIENT_ID");
+checkEnv(redirectUrl, "NEXT_PUBLIC_FOUNDRY_REDIRECT_URL");
+
+function checkEnv(
+  value: string | undefined,
+  name: string,
+): asserts value is string {
+  if (value == null) {
+    throw new Error(`Missing environment variable: ${name}`);
+  }
+}
+
 /**
  * Initialize the client to interact with the Ontology SDK
  */
 const client = new FoundryClient({
-  url: process.env.NEXT_PUBLIC_FOUNDRY_API_URL!,
+  url,
   auth: new PublicClientAuth({
-    clientId: process.env.NEXT_PUBLIC_FOUNDRY_CLIENT_ID!,
-    url: process.env.NEXT_PUBLIC_FOUNDRY_API_URL!,
-    redirectUrl: process.env.NEXT_PUBLIC_FOUNDRY_REDIRECT_URL!,
+    clientId,
+    url,
+    redirectUrl,
   }),
 });
 

--- a/packages/create-app/templates/template-react/src/client.ts.hbs
+++ b/packages/create-app/templates/template-react/src/client.ts.hbs
@@ -1,14 +1,30 @@
 import { FoundryClient, PublicClientAuth } from "{{osdkPackage}}";
 
+const url = import.meta.env.VITE_FOUNDRY_API_URL;
+const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
+const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
+checkEnv(url, "VITE_FOUNDRY_API_URL");
+checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
+checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
+
+function checkEnv(
+  value: string | undefined,
+  name: string,
+): asserts value is string {
+  if (value == null) {
+    throw new Error(`Missing environment variable: ${name}`);
+  }
+}
+
 /**
  * Initialize the client to interact with the Ontology SDK
  */
 const client = new FoundryClient({
-  url: import.meta.env.VITE_FOUNDRY_API_URL!,
+  url,
   auth: new PublicClientAuth({
-    clientId: import.meta.env.VITE_FOUNDRY_CLIENT_ID!,
-    url: import.meta.env.VITE_FOUNDRY_API_URL!,
-    redirectUrl: import.meta.env.VITE_FOUNDRY_REDIRECT_URL!,
+    clientId,
+    url,
+    redirectUrl,
   }),
 });
 

--- a/packages/create-app/templates/template-vue/src/client.ts.hbs
+++ b/packages/create-app/templates/template-vue/src/client.ts.hbs
@@ -1,14 +1,30 @@
 import { FoundryClient, PublicClientAuth } from "{{osdkPackage}}";
 
+const url = import.meta.env.VITE_FOUNDRY_API_URL;
+const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
+const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
+checkEnv(url, "VITE_FOUNDRY_API_URL");
+checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
+checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
+
+function checkEnv(
+  value: string | undefined,
+  name: string,
+): asserts value is string {
+  if (value == null) {
+    throw new Error(`Missing environment variable: ${name}`);
+  }
+}
+
 /**
  * Initialize the client to interact with the Ontology SDK
  */
 const client = new FoundryClient({
-  url: import.meta.env.VITE_FOUNDRY_API_URL!,
+  url,
   auth: new PublicClientAuth({
-    clientId: import.meta.env.VITE_FOUNDRY_CLIENT_ID!,
-    url: import.meta.env.VITE_FOUNDRY_API_URL!,
-    redirectUrl: import.meta.env.VITE_FOUNDRY_REDIRECT_URL!,
+    clientId,
+    url,
+    redirectUrl,
   }),
 });
 


### PR DESCRIPTION
Currently app renders fine but difficult to debug when client has not been initialized correctly. This will fail faster where the app will fail to render completely showing something is wrong with the console error showing the missing env variable.