### PR TITLE
Accept template id without prefix as template name

### DIFF
--- a/packages/create-app/README.md
+++ b/packages/create-app/README.md
@@ -43,8 +43,8 @@ npx @osdk/create-app [project] [--<option>]
 
 ## Templates
 
-| Template ID                 | Description                                                                                                                           |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| template-react              | [React](https://react.dev/) with [Vite](https://vitejs.dev/guide/why.html)                                                            |
-| template-vue                | [Vue](https://vuejs.org/) with [Vite](https://vitejs.dev/guide/why.html)                                                              |
-| template-next-static-export | [Next.js](https://nextjs.org/) with [static export](https://nextjs.org/docs/pages/building-your-application/deploying/static-exports) |
+| Template name      | Description                                                                                                                           |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| react              | [React](https://react.dev/) with [Vite](https://vitejs.dev/guide/why.html)                                                            |
+| vue                | [Vue](https://vuejs.org/) with [Vite](https://vitejs.dev/guide/why.html)                                                              |
+| next-static-export | [Next.js](https://nextjs.org/) with [static export](https://nextjs.org/docs/pages/building-your-application/deploying/static-exports) |

--- a/packages/create-app/changelog/@unreleased/pr-77.v2.yml
+++ b/packages/create-app/changelog/@unreleased/pr-77.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Accept template id without prefix as template name
+  links:
+  - https://github.com/palantir/osdk-ts/pull/77

--- a/packages/create-app/src/prompts/promptTemplate.test.ts
+++ b/packages/create-app/src/prompts/promptTemplate.test.ts
@@ -31,8 +31,19 @@ test("it accepts valid template from prompt", async () => {
   expect(vi.mocked(consola).prompt).toHaveBeenCalledTimes(1);
 });
 
-test("it accepts valid initial value without prompt", async () => {
+test("it accepts valid initial template id value without prompt", async () => {
   expect(await promptTemplate({ template: TEMPLATES[0].id })).toEqual(
+    TEMPLATES[0],
+  );
+  expect(vi.mocked(consola).prompt).not.toHaveBeenCalled();
+});
+
+test("it accepts valid initial template id value without 'template-' prefix without prompt", async () => {
+  expect(
+    await promptTemplate({
+      template: TEMPLATES[0].id.substring("template-".length),
+    }),
+  ).toEqual(
     TEMPLATES[0],
   );
   expect(vi.mocked(consola).prompt).not.toHaveBeenCalled();

--- a/packages/create-app/src/prompts/promptTemplate.ts
+++ b/packages/create-app/src/prompts/promptTemplate.ts
@@ -21,7 +21,9 @@ import { type Template, TEMPLATES } from "../templates.js";
 export async function promptTemplate(
   parsed: { template?: string },
 ): Promise<Template> {
-  let template = TEMPLATES.find((t) => t.id === parsed.template);
+  let template = TEMPLATES.find((t) =>
+    t.id === parsed.template || t.id === `template-${parsed.template}`
+  );
   if (template == null) {
     const templateId = (await consola.prompt(
       parsed.template != null


### PR DESCRIPTION
For example `--template react` is accepted as well as `--template template-react`. This better matches behaviour of other create app CLIs.