### PR TITLE
Allow http with localhost for CORS proxy

### DIFF
--- a/packages/legacy-client/changelog/@unreleased/pr-80.v2.yml
+++ b/packages/legacy-client/changelog/@unreleased/pr-80.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Allow http with localhost for CORS proxy
+  links:
+  - https://github.com/palantir/osdk-ts/pull/80

--- a/packages/legacy-client/src/oauth-client/utils/oauthUris.test.ts
+++ b/packages/legacy-client/src/oauth-client/utils/oauthUris.test.ts
@@ -71,4 +71,13 @@ describe("OAuthUris", () => {
       "https://stack.com/multipass-foundry/api/oauth2/revoke_token",
     );
   });
+
+  it("creates uris with http replaced with https except for localhost", () => {
+    expect(getTokenUri("http://stack.com")).toEqual(
+      "https://stack.com/multipass/api/oauth2/token",
+    );
+    expect(getTokenUri("http://localhost:8080")).toEqual(
+      "http://localhost:8080/multipass/api/oauth2/token",
+    );
+  });
 });

--- a/packages/legacy-client/src/oauth-client/utils/oauthUris.ts
+++ b/packages/legacy-client/src/oauth-client/utils/oauthUris.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { replaceHttpIfNotLocalhost } from "@osdk/shared.net";
+
 const httpsProtocol = "https://";
 const baseContextPath = "/multipass";
 const authorizeRequestPath = "/api/oauth2/authorize";
@@ -57,14 +59,4 @@ function createUri(
 
   const url = new URL(resolvedPath, baseUri);
   return url.toString();
-}
-
-function replaceHttpIfNotLocalhost(url: string): string {
-  const parsed = new URL(url);
-  if (parsed.protocol === "http:" && parsed.hostname === "localhost") {
-    // Allow special case http for localhost CORS proxy during development
-    return url;
-  }
-  parsed.protocol = "https:";
-  return parsed.toString();
 }

--- a/packages/legacy-client/src/oauth-client/utils/oauthUris.ts
+++ b/packages/legacy-client/src/oauth-client/utils/oauthUris.ts
@@ -46,15 +46,25 @@ function createUri(
   contextPath: string,
   requestPath: string,
 ): string {
+  const protocolRegex = /^https?:\/\//i;
+  baseUri = protocolRegex.test(baseUri)
+    ? replaceHttpIfNotLocalhost(baseUri)
+    : `${httpsProtocol}${baseUri}`;
+
   const resolvedPath = `${contextPath.replace(/\/$/, "")}/${
     requestPath.replace(/^\//, "")
   }`;
 
-  const url = baseUri.startsWith(httpsProtocol)
-    ? new URL(resolvedPath, baseUri)
-    : new URL(resolvedPath, "https://" + baseUri);
-
-  url.protocol = httpsProtocol;
-
+  const url = new URL(resolvedPath, baseUri);
   return url.toString();
+}
+
+function replaceHttpIfNotLocalhost(url: string): string {
+  const parsed = new URL(url);
+  if (parsed.protocol === "http:" && parsed.hostname === "localhost") {
+    // Allow special case http for localhost CORS proxy during development
+    return url;
+  }
+  parsed.protocol = "https:";
+  return parsed.toString();
 }

--- a/packages/shared.net/changelog/@unreleased/pr-80.v2.yml
+++ b/packages/shared.net/changelog/@unreleased/pr-80.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Allow http with localhost for CORS proxy
+  links:
+  - https://github.com/palantir/osdk-ts/pull/80

--- a/packages/shared.net/src/client/createOpenApiRequest.test.ts
+++ b/packages/shared.net/src/client/createOpenApiRequest.test.ts
@@ -119,6 +119,32 @@ describe("createOpenApiRequest", () => {
     );
   });
 
+  it("should allow http protocol with localhost", async () => {
+    const mockFetch = vi.fn();
+
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ test: 1 }),
+    });
+
+    const request = createOpenApiRequest("http://localhost:8080", mockFetch);
+    expect(
+      await request("POST", "/foo"),
+    ).toEqual(
+      { test: 1 },
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8080/api/foo",
+      {
+        method: "POST",
+        headers: new Headers({
+          "content-type": "application/json",
+          "accept": "application/json",
+        }),
+      },
+    );
+  });
+
   it("should return readable stream", async () => {
     const mockFetch = vi.fn();
 

--- a/packages/shared.net/src/client/createOpenApiRequest.ts
+++ b/packages/shared.net/src/client/createOpenApiRequest.ts
@@ -100,6 +100,16 @@ function withHttps(url: string): string {
   const httpsProtocol = "https://";
 
   return protocolRegex.test(url)
-    ? url.replace(/^http:\/\//i, httpsProtocol)
+    ? replaceHttpIfNotLocalhost(url)
     : `${httpsProtocol}${url}`;
+}
+
+function replaceHttpIfNotLocalhost(url: string): string {
+  const parsed = new URL(url);
+  if (parsed.protocol === "http:" && parsed.hostname === "localhost") {
+    // Allow special case http for localhost CORS proxy during development
+    return url;
+  }
+  parsed.protocol = "https:";
+  return parsed.toString();
 }

--- a/packages/shared.net/src/client/createOpenApiRequest.ts
+++ b/packages/shared.net/src/client/createOpenApiRequest.ts
@@ -15,6 +15,7 @@
  */
 
 import type { OpenApiRequest } from "@osdk/gateway/types";
+import { replaceHttpIfNotLocalhost } from "../util/index.js";
 
 export function createOpenApiRequest<
   TExpectedResponse,
@@ -102,14 +103,4 @@ function withHttps(url: string): string {
   return protocolRegex.test(url)
     ? replaceHttpIfNotLocalhost(url)
     : `${httpsProtocol}${url}`;
-}
-
-function replaceHttpIfNotLocalhost(url: string): string {
-  const parsed = new URL(url);
-  if (parsed.protocol === "http:" && parsed.hostname === "localhost") {
-    // Allow special case http for localhost CORS proxy during development
-    return url;
-  }
-  parsed.protocol = "https:";
-  return parsed.toString();
 }

--- a/packages/shared.net/src/index.ts
+++ b/packages/shared.net/src/index.ts
@@ -23,3 +23,4 @@ export { isOk, type ResultOrError } from "./ResultOrError.js";
 export { UnknownError } from "./UnknownError.js";
 export { createFetchHeaderMutator } from "./util/createFetchHeaderMutator.js";
 export { createFetchOrThrow } from "./util/createFetchOrThrow.js";
+export { replaceHttpIfNotLocalhost } from "./util/replaceHttpIfNotLocalhost.js";

--- a/packages/shared.net/src/util/replaceHttpIfNotLocalhost.ts
+++ b/packages/shared.net/src/util/replaceHttpIfNotLocalhost.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-export { createFetchAsJson } from "./createFetchAsJson.js";
-export { createFetchHeaderMutator } from "./createFetchHeaderMutator.js";
-export { createFetchOrThrow } from "./createFetchOrThrow.js";
-export { createRetryingFetch } from "./createRetryingFetch.js";
-export { replaceHttpIfNotLocalhost } from "./replaceHttpIfNotLocalhost.js";
-export { stringifyBody } from "./stringifyBody.js";
+export function replaceHttpIfNotLocalhost(url: string): string {
+  const parsed = new URL(url);
+  if (parsed.protocol === "http:" && parsed.hostname === "localhost") {
+    // Allow special case http for localhost CORS proxy during development
+    return url;
+  }
+  parsed.protocol = "https:";
+  return parsed.toString();
+}


### PR DESCRIPTION
API requests and OAuth requests allow http with localhost so that a CORS proxy can work without needing to convert over local dev servers to use https with a self signed certificate