### PR TITLE
improve missing rid inference

### DIFF
--- a/examples/basic/cli/src/examples/fetchEmployeeLead.ts
+++ b/examples/basic/cli/src/examples/fetchEmployeeLead.ts
@@ -31,6 +31,13 @@ export async function fetchEmployeeLead(
       select: ["adUsername", "businessTitle", "employeeNumber"],
     });
 
+  const lead = await result.data[0].$link.lead.get({
+    select: ["adUsername"],
+    includeRid: false,
+  });
+  const lead2 = await result.data[0].$link.lead.get({});
+  const peeps = await result.data[0].$link.peeps.fetchPageOrThrow({});
+
   // const result = await client
   //   .objectSet("Employee", {
   //     $where: { locationCity: "Palo Alto" },

--- a/packages/client/changelog/@unreleased/pr-86.v2.yml
+++ b/packages/client/changelog/@unreleased/pr-86.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: improve missing rid inference
+  links:
+  - https://github.com/palantir/osdk-ts/pull/86

--- a/packages/client/src/OsdkObjectFrom.ts
+++ b/packages/client/src/OsdkObjectFrom.ts
@@ -25,8 +25,7 @@ import type { OsdkObjectLinksObject } from "./definitions/LinkDefinitions.js";
 export type OsdkObjectPrimaryKeyType<
   O extends ObjectTypeDefinition<any>,
 > = WirePropertyTypes[O["primaryKeyType"]];
-
-type OsdkCommonFrom<
+export type Osdk<
   Q extends ObjectTypeDefinition<any> | InterfaceDefinition<any, any>,
   P extends keyof Q["properties"] | "$all" = "$all",
   R extends boolean = false,
@@ -66,53 +65,3 @@ export type OsdkObjectOrInterfaceFrom<
   P extends keyof Q["properties"] | "$all" = "$all",
   R extends boolean = false,
 > = Osdk<Q, P, R>;
-
-export type Osdk<
-  Q extends ObjectTypeDefinition<any> | InterfaceDefinition<any, any>,
-  P extends keyof Q["properties"] | "$all" = "$all",
-  R extends boolean = false,
-> = OsdkCommonFrom<Q, P, R>;
-
-// type ObjectShaped<T extends string> = {
-//   __apiName: string & { __OsdkType?: ObjectTypeDefinition<any> };
-// };
-
-// type Q<T> = T extends ObjectTypeDefinition<any> ? number : string;
-
-// // type Osdk<
-// //   T extends ObjectShaped<string>,
-// //   K extends keyof NonNullable<T["__apiName"]["__OsdkType"]>["properties"],
-// // > = NonNullable<T["__apiName"]["__OsdkType"]> extends
-// //   ObjectTypeDefinition<any> | InterfaceDefinition<any, any>
-// //   ? OsdkObjectFrom<NonNullable<T["__apiName"]["__OsdkType"]>, K>
-// //   : never;
-
-// type Osdk<
-//   T extends ObjectShaped<string>,
-//   K extends keyof NonNullable<T["__apiName"]["__OsdkType"]>["properties"],
-// > = NOOP<Q<T>>;
-
-// type ObjectShaped<T extends string> = {
-//   __apiName: T & { __OsdkType?: ObjectTypeDefinition<any> };
-// };
-
-// type Q<T, L> = T extends ObjectTypeDefinition<any> ? L extends string & keyof T["properties"] ? OsdkObjectFrom<T, L> : string : never;
-
-// // type Osdk<
-// //   T extends ObjectShaped<string>,
-// //   K extends keyof NonNullable<T["__apiName"]["__OsdkType"]>["properties"],
-// // > = NonNullable<T["__apiName"]["__OsdkType"]> extends
-// //   ObjectTypeDefinition<any> | InterfaceDefinition<any, any>
-// //   ? OsdkObjectFrom<NonNullable<T["__apiName"]["__OsdkType"]>, K>
-// //   : never;
-
-// type Osdk<
-//   T extends ObjectShaped<string>,
-//   K extends keyof NonNullable<T["__apiName"]["__OsdkType"]>["properties"],
-// > = Q<NonNullable<T["__apiName"]["__OsdkType"]>, K>;
-
-// type qq = NOOP<Osdk<Employee, "employeeNumber">>;
-
-// export interface Employee extends OsdkObjectFrom<EmployeeDef, keyof ObjectDef$Employee$Properties, EmployeeDef> {}
-
-// const q: Employee = {}  as any;

--- a/packages/client/src/createClient.ts
+++ b/packages/client/src/createClient.ts
@@ -59,7 +59,7 @@ export function createClient<O extends OntologyDefinition<any>>(
 
   const actionInvoker = createActionInvoker(clientCtx);
 
-  function newClient<
+  function clientFn<
     T extends ObjectOrInterfaceDefinition | ActionDefinition<any, any>,
   >(o: T): T extends ObjectOrInterfaceDefinition ? ObjectSet<T>
     : T extends ActionDefinition<any, any> ? ActionSignatureFromDef<T>
@@ -75,7 +75,7 @@ export function createClient<O extends OntologyDefinition<any>>(
   }
 
   const client: Client<O> = Object.defineProperties(
-    newClient as Client<O>,
+    clientFn as Client<O>,
     {
       objectSet: { get: () => objectSetFactory },
       objects: { get: () => createObjectSetCreator(client, clientCtx) },

--- a/packages/client/src/definitions/LinkDefinitions.test.ts
+++ b/packages/client/src/definitions/LinkDefinitions.test.ts
@@ -24,6 +24,7 @@ import type { Osdk, OsdkObjectPrimaryKeyType } from "../OsdkObjectFrom.js";
 import type { PageResult } from "../PageResult.js";
 import type { MockOntology } from "../util/test/mockOntology.js";
 import type {
+  DefaultToFalse,
   MultiLinkAccessor,
   OsdkObjectLinksObject,
   SingleLinkAccessor,
@@ -51,6 +52,15 @@ describe("LinkDefinitions", () => {
             RP: SingleLinkAccessor<PersonDef>;
           }
         >();
+    });
+
+    describe("DefaultToFalse", () => {
+      it("infers properly", () => {
+        expectTypeOf<DefaultToFalse<true>>().toEqualTypeOf<true>();
+        expectTypeOf<DefaultToFalse<false>>().toEqualTypeOf<false>();
+        expectTypeOf<DefaultToFalse<undefined>>().toEqualTypeOf<false>();
+        expectTypeOf<DefaultToFalse<boolean>>().toEqualTypeOf<false>();
+      });
     });
 
     describe("SingletonLinkAccessor", () => {

--- a/packages/client/src/definitions/LinkDefinitions.ts
+++ b/packages/client/src/definitions/LinkDefinitions.ts
@@ -45,6 +45,7 @@ export type OsdkObjectLinksEntry<
 
 export type DefaultToFalse<B extends boolean | undefined> = false extends B
   ? false
+  : undefined extends B ? false
   : true;
 
 export interface SingleLinkAccessor<T extends ObjectTypeDefinition<any>> {

--- a/packages/client/src/definitions/LinkDefinitions.ts
+++ b/packages/client/src/definitions/LinkDefinitions.ts
@@ -15,6 +15,7 @@
  */
 
 import type {
+  ObjectOrInterfacePropertyKeysFrom2,
   ObjectTypeDefinition,
   ObjectTypeLinkDefinition,
   ObjectTypeLinkKeysFrom2,
@@ -42,30 +43,58 @@ export type OsdkObjectLinksEntry<
   )
   : never;
 
-export type SingleLinkReturnType<
-  T extends ObjectTypeDefinition<any>,
-  A extends SelectArg<T>,
-> = Promise<Osdk<T, SelectArgToKeys<T, A>>>;
-
-export type MultiLinkReturnType<
-  T extends ObjectTypeDefinition<any>,
-  A extends SelectArg<T>,
-> = Promise<PageResult<Osdk<T, SelectArgToKeys<T, A>>>>;
+export type DefaultToFalse<B extends boolean | undefined> = false extends B
+  ? false
+  : true;
 
 export interface SingleLinkAccessor<T extends ObjectTypeDefinition<any>> {
   /** Load the linked object */
-  get: <const A extends SelectArg<T>>(
+  get: <
+    const A extends SelectArg<
+      T,
+      ObjectOrInterfacePropertyKeysFrom2<T>,
+      boolean
+    >,
+  >(
     options?: A,
-  ) => SingleLinkReturnType<T, A>;
+  ) => Promise<
+    DefaultToFalse<A["includeRid"]> extends false
+      ? Osdk<T, SelectArgToKeys<T, A>>
+      : Osdk<T, SelectArgToKeys<T, A>, DefaultToFalse<A["includeRid"]>>
+  >;
 }
 
+// note to future editor: these types may look gross but they were specifically
+// written to make it clear what the return type is when you use intellisense.
+// sorry i have no way to test this right now (ever?)
+
 export interface MultiLinkAccessor<T extends ObjectTypeDefinition<any>> {
-  get: <const A extends SelectArg<T>>(
+  get: <
+    const A extends SelectArg<
+      T,
+      ObjectOrInterfacePropertyKeysFrom2<T>,
+      boolean
+    >,
+  >(
     pk: OsdkObjectPrimaryKeyType<T>,
     options?: A,
-  ) => SingleLinkReturnType<T, A>;
+  ) => Promise<
+    DefaultToFalse<A["includeRid"]> extends false
+      ? Osdk<T, SelectArgToKeys<T, A>>
+      : Osdk<T, SelectArgToKeys<T, A>, DefaultToFalse<A["includeRid"]>>
+  >;
 
   fetchPageOrThrow: <
-    const A extends FetchPageOrThrowArgs<T>,
-  >(options?: A) => MultiLinkReturnType<T, A>;
+    const A extends FetchPageOrThrowArgs<
+      T,
+      ObjectOrInterfacePropertyKeysFrom2<T>,
+      boolean
+    >,
+  >(options?: A) => Promise<
+    PageResult<
+      DefaultToFalse<A["includeRid"]> extends false
+        ? Osdk<T, SelectArgToKeys<T, A>>
+        : Osdk<T, SelectArgToKeys<T, A>, DefaultToFalse<A["includeRid"]>>
+    >
+  >;
 }

--- a/packages/client/src/object/fetchPageOrThrow.ts
+++ b/packages/client/src/object/fetchPageOrThrow.ts
@@ -28,7 +28,8 @@ import { convertWireToOsdkObjects } from "./convertWireToOsdkObjects.js";
 
 export interface SelectArg<
   Q extends ObjectOrInterfaceDefinition<any, any>,
-  L = ObjectOrInterfacePropertyKeysFrom2<Q>,
+  L extends ObjectOrInterfacePropertyKeysFrom2<Q> =
+    ObjectOrInterfacePropertyKeysFrom2<Q>,
   R extends boolean = false,
 > {
   select?: readonly L[];
@@ -47,14 +48,15 @@ export interface OrderByArg<
 
 export type SelectArgToKeys<
   Q extends ObjectOrInterfaceDefinition,
-  A extends SelectArg<Q>,
+  A extends SelectArg<Q, any, any>,
 > = A extends SelectArg<Q, never> ? "$all"
   : A["select"] extends readonly string[] ? A["select"][number]
   : "$all";
 
 export interface FetchPageOrThrowArgs<
   Q extends ObjectOrInterfaceDefinition,
-  K = ObjectOrInterfacePropertyKeysFrom2<Q>,
+  K extends ObjectOrInterfacePropertyKeysFrom2<Q> =
+    ObjectOrInterfacePropertyKeysFrom2<Q>,
   R extends boolean = false,
 > extends
   SelectArg<Q, K, R>,

--- a/packages/client/src/object/getLinkedObjectByPkOrThrow.ts
+++ b/packages/client/src/object/getLinkedObjectByPkOrThrow.ts
@@ -18,15 +18,16 @@ import type { ObjectOrInterfaceDefinition } from "@osdk/api";
 import { getLinkedObjectV2 } from "@osdk/gateway/requests";
 import type { ClientContext } from "@osdk/shared.net";
 import { createOpenApiRequest } from "@osdk/shared.net";
-import type { SingleLinkReturnType } from "../definitions/LinkDefinitions.js";
+import type { DefaultToFalse } from "../definitions/LinkDefinitions.js";
 import type { LinkedType, LinkNames } from "../objectSet/LinkUtils.js";
+import type { Osdk } from "../OsdkObjectFrom.js";
 import { convertWireToOsdkObjects } from "./convertWireToOsdkObjects.js";
-import type { SelectArg } from "./fetchPageOrThrow.js";
+import type { SelectArg, SelectArgToKeys } from "./fetchPageOrThrow.js";
 
 export async function getLinkedObjectByPkOrThrow<
   Q extends ObjectOrInterfaceDefinition,
   L extends LinkNames<Q>,
-  const A extends SelectArg<Q>,
+  const A extends SelectArg<LinkedType<Q, L>>,
 >(
   client: ClientContext<any>,
   objectType: Q,
@@ -34,7 +35,15 @@ export async function getLinkedObjectByPkOrThrow<
   linkTypeApiName: L,
   linkedObjectPrimaryKey: any,
   selectOpts?: A,
-): SingleLinkReturnType<LinkedType<Q, L>, A> {
+): Promise<
+  DefaultToFalse<A["includeRid"]> extends false
+    ? Osdk<LinkedType<Q, L>, SelectArgToKeys<LinkedType<Q, L>, A>>
+    : Osdk<
+      LinkedType<Q, L>,
+      SelectArgToKeys<LinkedType<Q, L>, A>,
+      DefaultToFalse<A["includeRid"]>
+    >
+> {
   const object = await getLinkedObjectV2(
     createOpenApiRequest(client.stack, client.fetch),
     client.ontology.metadata.ontologyApiName,

--- a/packages/client/src/object/pageLinkedObjectsOrThrow.ts
+++ b/packages/client/src/object/pageLinkedObjectsOrThrow.ts
@@ -17,11 +17,15 @@
 import type { ObjectOrInterfaceDefinition } from "@osdk/api";
 import { listLinkedObjectsV2 } from "@osdk/gateway/requests";
 import { type ClientContext, createOpenApiRequest } from "@osdk/shared.net";
-import type { MultiLinkReturnType } from "../definitions/LinkDefinitions.js";
+import type { DefaultToFalse } from "../definitions/LinkDefinitions.js";
 import type { LinkedType, LinkNames } from "../objectSet/LinkUtils.js";
+import type { Osdk } from "../OsdkObjectFrom.js";
 import type { PageResult } from "../PageResult.js";
 import { convertWireToOsdkObjects } from "./convertWireToOsdkObjects.js";
-import type { FetchPageOrThrowArgs } from "./fetchPageOrThrow.js";
+import type {
+  FetchPageOrThrowArgs,
+  SelectArgToKeys,
+} from "./fetchPageOrThrow.js";
 
 export async function pageLinkedObjectsOrThrow<
   Q extends ObjectOrInterfaceDefinition,
@@ -33,7 +37,17 @@ export async function pageLinkedObjectsOrThrow<
   primaryKey: any,
   linkTypeApiName: L,
   options?: A,
-): MultiLinkReturnType<LinkedType<Q, L>, A> {
+): Promise<
+  PageResult<
+    DefaultToFalse<A["includeRid"]> extends false
+      ? Osdk<LinkedType<Q, L>, SelectArgToKeys<LinkedType<Q, L>, A>>
+      : Osdk<
+        LinkedType<Q, L>,
+        SelectArgToKeys<LinkedType<Q, L>, A>,
+        true
+      >
+  >
+> {
   const page = await listLinkedObjectsV2(
     createOpenApiRequest(client.stack, client.fetch),
     client.ontology.metadata.ontologyApiName,

--- a/packages/client/src/objectSet/ObjectSet.ts
+++ b/packages/client/src/objectSet/ObjectSet.ts
@@ -22,6 +22,7 @@ import type {
   OntologyDefinition,
 } from "@osdk/api";
 import type { ObjectSet as WireObjectSet } from "@osdk/gateway/types";
+import type { DefaultToFalse } from "../definitions/LinkDefinitions.js";
 import type { FetchPageOrThrowArgs } from "../object/fetchPageOrThrow.js";
 import type { Osdk } from "../OsdkObjectFrom.js";
 import type { PageResult } from "../PageResult.js";
@@ -43,9 +44,15 @@ export interface BaseObjectSet<Q extends ObjectOrInterfaceDefinition> {
   >(
     args?: FetchPageOrThrowArgs<Q, L, R>,
   ) => Promise<
-    ObjectOrInterfacePropertyKeysFrom2<Q> extends L
-      ? PageResult<Osdk<Q, "$all", R>>
-      : PageResult<Osdk<Q, L, R>>
+    PageResult<
+      ObjectOrInterfacePropertyKeysFrom2<Q> extends L ? (
+          DefaultToFalse<R> extends false ? Osdk<Q, "$all">
+            : Osdk<Q, "$all", true>
+        )
+        : (
+          DefaultToFalse<R> extends false ? Osdk<Q, L> : Osdk<Q, L, true>
+        )
+    >
   >;
 
   // qq: <Q extends K>(foo: Q) => ObjectTypePropertyKeysFrom<O, K>;


### PR DESCRIPTION
In case where its omitted or false, we use the short version of the type that relies on the default value for include rid (false)


Before:
* ![image](https://github.com/palantir/osdk-ts/assets/120899/73950362-f706-451b-8f6d-57054cf2eb6c)
* ![image](https://github.com/palantir/osdk-ts/assets/120899/066ff478-1fe1-482f-99ad-c1c23ebdcdaf)
* ![image](https://github.com/palantir/osdk-ts/assets/120899/e182f6db-87b3-4c8a-b5f8-769f26c418b9)
* ![image](https://github.com/palantir/osdk-ts/assets/120899/c7d5a18c-bbf4-4652-9243-9a016cc831e1)

After:
* ![image](https://github.com/palantir/osdk-ts/assets/120899/5082b260-4653-4e1e-afe3-fcde64402521)
* ![image](https://github.com/palantir/osdk-ts/assets/120899/fe8bcba8-f9cd-4c13-8426-3ec3cd507a35)
* ![image](https://github.com/palantir/osdk-ts/assets/120899/9e0d8798-2e99-4b8a-8064-ecae61622c60)
* ![image](https://github.com/palantir/osdk-ts/assets/120899/d28249ce-aa0a-4981-99c2-e082fa9d3de6)



