### PR TITLE
Improvement: Support using a token for typescript generate

### DIFF
--- a/packages/cli/changelog/@unreleased/pr-90.v2.yml
+++ b/packages/cli/changelog/@unreleased/pr-90.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Support using a token for typescript generate
+  links:
+  - https://github.com/palantir/osdk-ts/pull/90

--- a/packages/cli/src/commands/typescript/generate/TypescriptGenerateArgs.ts
+++ b/packages/cli/src/commands/typescript/generate/TypescriptGenerateArgs.ts
@@ -23,4 +23,6 @@ export interface TypescriptGenerateArgs {
   beta?: boolean;
   packageType: "commonjs" | "module";
   version: string;
+  token?: string;
+  tokenFile?: string;
 }

--- a/packages/cli/src/commands/typescript/generate/generate.ts
+++ b/packages/cli/src/commands/typescript/generate/generate.ts
@@ -75,6 +75,16 @@ export const command: CommandModule<
             description: "Version of the generated code, or 'dev'",
             demandOption: true,
           },
+          token: {
+            type: "string",
+            conflicts: "tokenFile",
+            description: "Foundry API token",
+          },
+          tokenFile: {
+            type: "string",
+            conflicts: "token",
+            description: "Path to file containing Foundry API token",
+          },
         } as const,
       ).group(
         ["ontologyPath", "outDir", "version"],


### PR DESCRIPTION
Allow using an Auth token instead of getting one through the login flow. The order of providing a token is as follows in this order

`--token > --tokenFile > FOUNDRY_TOKEN env > FOUNDRY_SDK_AUTH_TOKEN env > login flow`