### PR TITLE
Add numeric groupbys

### DIFF
--- a/examples/basic/cli/src/index.ts
+++ b/examples/basic/cli/src/index.ts
@@ -196,7 +196,37 @@ async function runTests() {
     const testAggregateCountWithGroups = await client.objects.BoundariesUsState
       .aggregateOrThrow({
         select: { $count: true, latitude: ["min", "max", "avg"] },
-        groupBy: { usState: "exact" },
+        groupBy: {
+          usState: "exact",
+          longitude: {
+            fixedWidth: 10,
+          },
+        },
+      });
+
+    const testAggregateCountWithFixedGroups = await client.objects
+      .BoundariesUsState
+      .aggregateOrThrow({
+        select: { $count: true, latitude: ["min", "max", "avg"] },
+        groupBy: {
+          longitude: {
+            exactWithLimit: 40,
+          },
+        },
+      });
+
+    const testAggregateCountWithRangeGroups = await client.objects
+      .BoundariesUsState
+      .aggregateOrThrow({
+        select: { $count: true },
+        groupBy: {
+          latitude: {
+            ranges: [[34, 39], [
+              39,
+              42,
+            ], [43, 45]],
+          },
+        },
       });
 
     console.log(
@@ -206,6 +236,18 @@ async function runTests() {
       testAggregateCountWithGroups[0].latitude.max,
       testAggregateCountWithGroups[0].latitude.min,
     );
+
+    console.log(testAggregateCountWithGroups[0].$group.longitude);
+    console.log(
+      "Limit worked:",
+      testAggregateCountWithFixedGroups.length === 40,
+    );
+
+    for (const group of testAggregateCountWithRangeGroups) {
+      console.log(
+        `start:${group.$group.latitude.startValue},end:${group.$group.latitude.endValue}:${group.$count}`,
+      );
+    }
 
     if (runOld) await typeChecks(client);
   } catch (e) {

--- a/packages/client/src/internal/conversions/modernToLegacyGroupByClause.ts
+++ b/packages/client/src/internal/conversions/modernToLegacyGroupByClause.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import type { AggregationGroupByV2 } from "@osdk/gateway/types";
+import type {
+  AggregationGroupByV2,
+  AggregationRangeV2,
+} from "@osdk/gateway/types";
+import type { GroupByRange } from "../../query/aggregations/GroupByClause.js";
 import type { AllGroupByValues, GroupByClause } from "../../query/index.js";
 
 export function modernToLegacyGroupByClause(
@@ -47,8 +51,12 @@ export function modernToLegacyGroupByClause(
       return [{
         type: "ranges",
         field,
-        ranges: [],
+        ranges: type.ranges.map(range => convertRange(range)),
       }];
     } else return [];
   });
+}
+
+function convertRange(range: GroupByRange): AggregationRangeV2 {
+  return { startValue: range[0], endValue: range[1] };
 }

--- a/packages/client/src/internal/conversions/modernToLegacyGroupByClause.ts
+++ b/packages/client/src/internal/conversions/modernToLegacyGroupByClause.ts
@@ -27,16 +27,28 @@ export function modernToLegacyGroupByClause(
   ).flatMap<AggregationGroupByV2>(([field, type]) => {
     if (type === "exact") {
       return [{ type, field }];
-    } else if (type.exactWithLimit) {
-      return [
-        {
-          type: "exact",
-          field,
-          maxGroupCount: type.exactWithLimit,
-        },
-      ];
-    } else {
-      return [];
-    }
+    } else if ("exactWithLimit" in type) {
+      {
+        return [
+          {
+            type: "exact",
+            field,
+            maxGroupCount: type.exactWithLimit,
+          },
+        ];
+      }
+    } else if ("fixedWidth" in type) {
+      return [{
+        type: "fixedWidth",
+        field,
+        fixedWidth: type.fixedWidth,
+      }];
+    } else if ("ranges" in type) {
+      return [{
+        type: "ranges",
+        field,
+        ranges: [],
+      }];
+    } else return [];
   });
 }

--- a/packages/client/src/object/aggregateOrThrow.test.ts
+++ b/packages/client/src/object/aggregateOrThrow.test.ts
@@ -21,6 +21,7 @@ import type { TypeOf } from "ts-expect";
 import { expectType } from "ts-expect";
 import { describe, it, type Mock, vi } from "vitest";
 import type { AggregateOpts } from "../query/aggregations/AggregateOpts.js";
+import type { GroupByRange } from "../query/aggregations/GroupByClause.js";
 import { USER_AGENT } from "../util/UserAgent.js";
 import { aggregateOrThrow } from "./aggregateOrThrow.js";
 
@@ -205,7 +206,13 @@ describe("aggregateOrThrow", () => {
         groupBy: {
           text: "exact",
           priority: { exactWithLimit: 10 },
-          intProp: { fixedWidth: 20 },
+          intProp: { ranges: [{ startValue: 1, endValue: 2 }] },
+          shortProp: {
+            ranges: [{ startValue: 2, endValue: 3 }, {
+              startValue: 4,
+              endValue: 5,
+            }],
+          },
         },
       },
     );
@@ -214,6 +221,8 @@ describe("aggregateOrThrow", () => {
     expectType<number>(grouped[0].id.approximateDistinct);
     expectType<number>(grouped[0].$group.priority);
     expectType<number>(grouped[0].$count);
+    expectType<GroupByRange>(grouped[0].$group.intProp);
+    expectType<GroupByRange>(grouped[0].$group.shortProp);
   });
 
   it("works with where: todo", async () => {

--- a/packages/client/src/object/aggregateOrThrow.test.ts
+++ b/packages/client/src/object/aggregateOrThrow.test.ts
@@ -37,6 +37,21 @@ interface TodoDef extends ObjectTypeDefinition<"Todo"> {
     id: {
       type: "double";
     };
+    intProp: {
+      type: "integer";
+    };
+    floatProp: {
+      type: "float";
+    };
+    shortProp: {
+      type: "short";
+    };
+    byteProp: {
+      type: "byte";
+    };
+    decimalProp: {
+      type: "decimal";
+    };
     priority: {
       type: "double";
     };
@@ -61,6 +76,21 @@ const Todo: TodoDef = {
     },
     priority: {
       type: "double",
+    },
+    intProp: {
+      type: "integer",
+    },
+    floatProp: {
+      type: "float",
+    },
+    shortProp: {
+      type: "short",
+    },
+    byteProp: {
+      type: "byte",
+    },
+    decimalProp: {
+      type: "decimal",
     },
     other: {
       type: "string",
@@ -171,12 +201,15 @@ describe("aggregateOrThrow", () => {
         },
         groupBy: {
           text: "exact",
+          priority: { exactWithLimit: 10 },
+          intProp: { fixedWidth: 20 },
         },
       },
     );
     expectType<Array<any>>(grouped);
     expectType<string | undefined>(grouped[0].$group.text);
     expectType<number>(grouped[0].id.approximateDistinct);
+    expectType<number>(grouped[0].$group.priority);
   });
 
   it("works with where: todo", async () => {

--- a/packages/client/src/object/aggregateOrThrow.test.ts
+++ b/packages/client/src/object/aggregateOrThrow.test.ts
@@ -21,7 +21,6 @@ import type { TypeOf } from "ts-expect";
 import { expectType } from "ts-expect";
 import { describe, it, type Mock, vi } from "vitest";
 import type { AggregateOpts } from "../query/aggregations/AggregateOpts.js";
-import type { GroupByRange } from "../query/aggregations/GroupByClause.js";
 import { USER_AGENT } from "../util/UserAgent.js";
 import { aggregateOrThrow } from "./aggregateOrThrow.js";
 
@@ -206,13 +205,11 @@ describe("aggregateOrThrow", () => {
         groupBy: {
           text: "exact",
           priority: { exactWithLimit: 10 },
-          intProp: { ranges: [{ startValue: 1, endValue: 2 }] },
+          intProp: { ranges: [[1, 2]] },
           shortProp: {
-            ranges: [{ startValue: 2, endValue: 3 }, {
-              startValue: 4,
-              endValue: 5,
-            }],
+            ranges: [[2, 3], [4, 5]],
           },
+          floatProp: { fixedWidth: 10 },
         },
       },
     );
@@ -221,8 +218,13 @@ describe("aggregateOrThrow", () => {
     expectType<number>(grouped[0].id.approximateDistinct);
     expectType<number>(grouped[0].$group.priority);
     expectType<number>(grouped[0].$count);
-    expectType<GroupByRange>(grouped[0].$group.intProp);
-    expectType<GroupByRange>(grouped[0].$group.shortProp);
+    expectType<{ startValue: number; endValue: number }>(
+      grouped[0].$group.intProp,
+    );
+    expectType<{ startValue: number; endValue: number }>(
+      grouped[0].$group.shortProp,
+    );
+    expectType<number>(grouped[0].$group.floatProp);
   });
 
   it("works with where: todo", async () => {

--- a/packages/client/src/query/aggregations/AggregationResultsWithGroups.ts
+++ b/packages/client/src/query/aggregations/AggregationResultsWithGroups.ts
@@ -31,9 +31,11 @@ export type AggregationResultsWithGroups<
   & {
     $group: {
       [P in keyof G & keyof Q["properties"]]: G[P] extends
-        { ranges: GroupByRange[] } ? GroupByRange : OsdkObjectPropertyType<
-        Q["properties"][P]
-      >;
+        { ranges: GroupByRange[] }
+        ? { startValue: GroupByRange[0]; endValue: GroupByRange[1] }
+        : OsdkObjectPropertyType<
+          Q["properties"][P]
+        >;
     };
   }
   & AggregationCountResult<Q, A>

--- a/packages/client/src/query/aggregations/AggregationResultsWithGroups.ts
+++ b/packages/client/src/query/aggregations/AggregationResultsWithGroups.ts
@@ -21,7 +21,7 @@ import type {
   AggregationResultsWithoutGroups,
 } from "./AggregationResultsWithoutGroups.js";
 import type { AggregationClause } from "./AggregationsClause.js";
-import type { GroupByClause } from "./GroupByClause.js";
+import type { GroupByClause, GroupByRange } from "./GroupByClause.js";
 
 export type AggregationResultsWithGroups<
   Q extends ObjectOrInterfaceDefinition<any, any>,
@@ -30,7 +30,8 @@ export type AggregationResultsWithGroups<
 > = (
   & {
     $group: {
-      [P in keyof G & keyof Q["properties"]]: OsdkObjectPropertyType<
+      [P in keyof G & keyof Q["properties"]]: G[P] extends
+        { ranges: GroupByRange[] } ? GroupByRange : OsdkObjectPropertyType<
         Q["properties"][P]
       >;
     };

--- a/packages/client/src/query/aggregations/GroupByClause.ts
+++ b/packages/client/src/query/aggregations/GroupByClause.ts
@@ -25,6 +25,12 @@ export type GroupByClause<
 };
 export type StringGroupByValue = "exact" | { exactWithLimit: number };
 
+export type GroupByRange = { start: number; end: number };
+
+export type NumericGroupByValue = "exact" | { exactWithLimit: number } | {
+  fixedWidth: number;
+} | { ranges: GroupByRange[] };
+
 type GroupByEntry<
   Q extends ObjectOrInterfaceDefinition<any, any>,
   P extends AggregatableKeys<Q>,

--- a/packages/client/src/query/aggregations/GroupByClause.ts
+++ b/packages/client/src/query/aggregations/GroupByClause.ts
@@ -25,7 +25,7 @@ export type GroupByClause<
 };
 export type StringGroupByValue = "exact" | { exactWithLimit: number };
 
-export type GroupByRange = { start: number; end: number };
+export type GroupByRange = { startValue?: number; endValue?: number };
 
 export type NumericGroupByValue = "exact" | { exactWithLimit: number } | {
   fixedWidth: number;

--- a/packages/client/src/query/aggregations/GroupByClause.ts
+++ b/packages/client/src/query/aggregations/GroupByClause.ts
@@ -25,7 +25,7 @@ export type GroupByClause<
 };
 export type StringGroupByValue = "exact" | { exactWithLimit: number };
 
-export type GroupByRange = { startValue?: number; endValue?: number };
+export type GroupByRange = [number, number];
 
 export type NumericGroupByValue = "exact" | { exactWithLimit: number } | {
   fixedWidth: number;

--- a/packages/client/src/query/aggregations/GroupByMapper.ts
+++ b/packages/client/src/query/aggregations/GroupByMapper.ts
@@ -14,8 +14,17 @@
  * limitations under the License.
  */
 
-import type { StringGroupByValue } from "./GroupByClause.js";
+import type {
+  NumericGroupByValue,
+  StringGroupByValue,
+} from "./GroupByClause.js";
 
 export interface GroupByMapper {
   string: StringGroupByValue;
+  short: NumericGroupByValue;
+  float: NumericGroupByValue;
+  decimal: NumericGroupByValue;
+  byte: NumericGroupByValue;
+  double: NumericGroupByValue;
+  integer: NumericGroupByValue;
 }


### PR DESCRIPTION
Added the following groupby syntax for number properties:

```
groupBy: {
          longProp: "exact",
          intProp: { exactWithLimit: 10 },
          shortProp: {
            ranges: [[2, 3], [4, 5]],
          },
          floatProp: { fixedWidth: 10 },
        },
```