### PR TITLE
Rework @osdk/client type mapping

### DIFF
--- a/packages/client/changelog/@unreleased/pr-106.v2.yml
+++ b/packages/client/changelog/@unreleased/pr-106.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Rework @osdk/client type mapping
+  links:
+  - https://github.com/palantir/osdk-ts/pull/106

--- a/packages/client/src/Definitions.ts
+++ b/packages/client/src/Definitions.ts
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-import type {
-  ObjectTypePropertyDefinition,
-  WirePropertyTypes,
-} from "@osdk/api";
-import type { Attachment } from "./object/Attachment.js";
+import type { ObjectTypePropertyDefinition } from "@osdk/api";
+import type { PropertyValueWireToClient } from "./mapping/PropertyValueMapping.js";
 
 type MaybeArray<T extends { multiplicity?: boolean | undefined }, U> =
   T["multiplicity"] extends true ? Array<U> : U;
@@ -30,12 +27,11 @@ type MaybeNullable<T extends ObjectTypePropertyDefinition, U> =
 type Raw<T> = T extends Array<any> ? T[0] : T;
 type Converted<T> = T extends Array<any> ? T[1] : T;
 
-// certain data types must be converted at hydration time
-type HydrationConversions<T extends ObjectTypePropertyDefinition> =
-  T["type"] extends "attachment" ? Attachment : WirePropertyTypes[T["type"]];
-
 export type OsdkObjectPropertyType<T extends ObjectTypePropertyDefinition> =
-  MaybeNullable<T, MaybeArray<T, Converted<HydrationConversions<T>>>>;
+  MaybeNullable<
+    T,
+    MaybeArray<T, Converted<PropertyValueWireToClient[T["type"]]>>
+  >;
 
 export type OsdkObjectRawPropertyType<T extends ObjectTypePropertyDefinition> =
-  MaybeNullable<T, MaybeArray<T, Raw<WirePropertyTypes[T["type"]]>>>;
+  MaybeNullable<T, MaybeArray<T, Raw<PropertyValueWireToClient[T["type"]]>>>;

--- a/packages/client/src/OsdkObjectFrom.ts
+++ b/packages/client/src/OsdkObjectFrom.ts
@@ -14,17 +14,15 @@
  * limitations under the License.
  */
 
-import type {
-  InterfaceDefinition,
-  ObjectTypeDefinition,
-  WirePropertyTypes,
-} from "@osdk/api";
+import type { InterfaceDefinition, ObjectTypeDefinition } from "@osdk/api";
 import type { OsdkObjectPropertyType } from "./Definitions.js";
 import type { OsdkObjectLinksObject } from "./definitions/LinkDefinitions.js";
+import type { PropertyValueWireToClient } from "./mapping/PropertyValueMapping.js";
 
 export type OsdkObjectPrimaryKeyType<
   O extends ObjectTypeDefinition<any>,
-> = WirePropertyTypes[O["primaryKeyType"]];
+> = PropertyValueWireToClient[O["primaryKeyType"]];
+
 export type Osdk<
   Q extends ObjectTypeDefinition<any> | InterfaceDefinition<any, any>,
   P extends keyof Q["properties"] | "$all" = "$all",

--- a/packages/client/src/actions/Actions.ts
+++ b/packages/client/src/actions/Actions.ts
@@ -20,14 +20,13 @@ import type {
   ObjectActionDataType,
   ObjectSetActionDataType,
   OntologyDefinition,
-  WirePropertyTypes,
 } from "@osdk/api";
 import type {
   ActionResults,
   ValidateActionResponseV2,
 } from "@osdk/gateway/types";
 import type { ObjectSet } from "../index.js";
-import type { Attachment } from "../object/Attachment.js";
+import type { DataValueClientToWire } from "../mapping/DataValueMapping.js";
 import type { Osdk, OsdkObjectPrimaryKeyType } from "../OsdkObjectFrom.js";
 import type { NOOP } from "../util/NOOP.js";
 import type { NullableProps } from "../util/NullableProps.js";
@@ -41,19 +40,14 @@ export type ApplyActionOptions =
     returnEdits?: false;
   };
 
-// we have to override the @osdk/api WirePropertyTypes to specify how we handle the Attachment types
-interface OverrideWirePropertyTypes extends WirePropertyTypes {
-  attachment: Attachment;
-}
-
 type BaseType<APD extends ActionParameterDefinition<any, any>> =
   APD["type"] extends ObjectActionDataType<any, infer TTargetType> ?
       | Osdk<TTargetType>
       | OsdkObjectPrimaryKeyType<TTargetType>
     : APD["type"] extends ObjectSetActionDataType<any, infer TTargetType>
       ? ObjectSet<TTargetType>
-    : APD["type"] extends keyof OverrideWirePropertyTypes
-      ? OverrideWirePropertyTypes[APD["type"]]
+    : APD["type"] extends keyof DataValueClientToWire
+      ? DataValueClientToWire[APD["type"]]
     : never;
 
 type MaybeArrayType<APD extends ActionParameterDefinition<any, any>> =

--- a/packages/client/src/mapping/DataValueMapping.ts
+++ b/packages/client/src/mapping/DataValueMapping.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Attachment } from "../object/Attachment.js";
+
+/**
+ * Map from the DataValue type to the typescript type that we return
+ */
+export interface DataValueWireToClient {
+  attachment: Attachment;
+  boolean: boolean;
+  byte: number;
+  datetime: string;
+  decimal: string;
+  float: number;
+  double: number;
+  integer: number;
+  long: string;
+  marking: string;
+  null: null;
+  short: number;
+  string: string;
+  timestamp: string;
+}
+
+/**
+ * Map from the DataValue type to the typescript type that we accept
+ */
+export interface DataValueClientToWire {
+  attachment: Attachment;
+  boolean: boolean;
+  byte: number;
+  datetime: string;
+  decimal: string | number;
+  float: number;
+  double: number;
+  integer: number;
+  long: string | number;
+  marking: string;
+  null: null;
+  short: number;
+  string: string;
+  timestamp: string;
+}

--- a/packages/client/src/mapping/PropertyValueMapping.ts
+++ b/packages/client/src/mapping/PropertyValueMapping.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Attachment } from "../object/Attachment.js";
+
+/**
+ * Map from the PropertyDefinition type to the typescript type that we return
+ */
+export interface PropertyValueWireToClient {
+  attachment: Attachment;
+  boolean: boolean;
+  byte: number;
+  datetime: string;
+  decimal: string;
+  double: number;
+  float: number;
+  geopoint: GeoJSON.Point;
+  geoshape: GeoJSON.GeoJSON;
+  integer: number;
+  long: string;
+  marking: string;
+  short: number;
+  string: string;
+  timestamp: string;
+
+  numericTimeseries: unknown;
+  stringTimeseries: unknown;
+}
+
+/**
+ * Map from the PropertyDefinition type to the typescript type that we accept
+ */
+export interface PropertyValueClientToWire {
+  attachment: Attachment | { rid: string };
+  boolean: boolean;
+  byte: number;
+  datetime: string;
+  decimal: string | number;
+  double: number;
+  float: number;
+  geopoint: GeoJSON.Point;
+  geoshape: GeoJSON.GeoJSON;
+  integer: number;
+  long: string | number;
+  marking: string;
+  short: number;
+  string: string;
+  timestamp: string;
+
+  numericTimeseries: unknown;
+  stringTimeseries: unknown;
+}

--- a/packages/client/src/objectSet/ObjectSet.ts
+++ b/packages/client/src/objectSet/ObjectSet.ts
@@ -21,9 +21,9 @@ import type {
   ObjectOrInterfacePropertyKeysFrom2,
   ObjectTypeDefinition,
   OntologyDefinition,
-  WirePropertyTypes,
 } from "@osdk/api";
 import type { ObjectSet as WireObjectSet } from "@osdk/gateway/types";
+import type { PropertyValueClientToWire } from "../mapping/PropertyValueMapping.js";
 import type { AggregateOptsThatErrors } from "../object/aggregate.js";
 import type {
   FetchPageArgs,
@@ -96,7 +96,7 @@ export interface BaseObjectSet<
 > extends ObjectSet<Q> {
   get: Q extends ObjectTypeDefinition<any>
     ? <L extends ObjectOrInterfacePropertyKeysFrom2<Q>>(
-      primaryKey: WirePropertyTypes[Q["primaryKeyType"]],
+      primaryKey: PropertyValueClientToWire[Q["primaryKeyType"]],
       options?: SelectArg<Q, L>,
     ) => Promise<OsdkObjectOrInterfaceFrom<Q, L>>
     : never;

--- a/packages/client/src/objectSet/createObjectSet.ts
+++ b/packages/client/src/objectSet/createObjectSet.ts
@@ -18,10 +18,10 @@ import type {
   ObjectOrInterfaceDefinition,
   ObjectOrInterfacePropertyKeysFrom2,
   ObjectTypeDefinition,
-  WirePropertyTypes,
 } from "@osdk/api";
 import type { ObjectSet as WireObjectSet } from "@osdk/gateway/types";
 import { modernToLegacyWhereClause } from "../internal/conversions/index.js";
+import type { PropertyValueClientToWire } from "../mapping/PropertyValueMapping.js";
 import type { MinimalClient } from "../MinimalClientContext.js";
 import type { AggregateOptsThatErrors } from "../object/aggregate.js";
 import { convertWireToOsdkObjectsInPlace } from "../object/convertWireToOsdkObjects.js";
@@ -195,16 +195,18 @@ export function createBaseObjectSet<
     get: (isObjectTypeDefinition(objectType)
       ? async <A extends SelectArg<Q>>(
         primaryKey: Q extends ObjectTypeDefinition<any>
-          ? WirePropertyTypes[Q["primaryKeyType"]]
+          ? PropertyValueClientToWire[Q["primaryKeyType"]]
           : never,
         options: A,
       ) => {
         const withPk: WireObjectSet = {
           type: "filter",
           objectSet: objectSet,
-          where: modernToLegacyWhereClause({
-            [objectType.primaryKeyApiName]: primaryKey,
-          }),
+          where: {
+            type: "eq",
+            field: objectType.primaryKeyApiName,
+            value: primaryKey,
+          },
         };
 
         return await fetchSingle(


### PR DESCRIPTION
Using @osdk/api mapping interfaces is pretty flawed because of things like Attachments which cannot be represented there.

This changes @osdk/client to contain clearer mapping interfaces for Client<>Wire for both PropertyValue (object) and DataValue (action, query). The DataValue mapping interfaces exclude some of the more complicated types: ObjectSet, Object references, Sets, Structs, TwoDimensionalAggregation, ThreeDimensionalAggregation.

This also changes long and decimal data to be correctly marked as strings when we get them from the backend, but we will still accept numbers to send to the backend.

Are we happy with the naming here `DataValueWireToClient` `DataValueClientToWire` `PropertyValueWireToClient` `PropertyValueClientToWire`?