### PR TITLE
Improve groupby key verification

### DIFF
--- a/packages/client/changelog/@unreleased/pr-112.v2.yml
+++ b/packages/client/changelog/@unreleased/pr-112.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Improve groupby key verification
+  links:
+  - https://github.com/palantir/osdk-ts/pull/112

--- a/packages/client/src/object/aggregate.test.ts
+++ b/packages/client/src/object/aggregate.test.ts
@@ -18,9 +18,10 @@ import type { ObjectTypeDefinition, OntologyDefinition } from "@osdk/api";
 import type { AggregateObjectsResponseV2 } from "@osdk/gateway/types";
 import type { TypeOf } from "ts-expect";
 import { expectType } from "ts-expect";
-import { describe, it, type Mock, vi } from "vitest";
+import { describe, expectTypeOf, it, type Mock, vi } from "vitest";
 import { createMinimalClient } from "../createMinimalClient.js";
 import type { AggregateOpts } from "../query/aggregations/AggregateOpts.js";
+import type { AggregateOptsThatErrors } from "./aggregate.js";
 import { aggregate } from "./aggregate.js";
 
 interface TodoDef extends ObjectTypeDefinition<"Todo"> {
@@ -224,6 +225,122 @@ describe("aggregate", () => {
       grouped[0].$group.shortProp,
     );
     expectType<number>(grouped[0].$group.floatProp);
+
+    expectType<
+      AggregateOptsThatErrors<TodoDef, {
+        select: {
+          id: "approximateDistinct";
+          $count: true;
+        };
+        groupBy: {
+          text: "exact";
+          priority: { exactWithLimit: 10 };
+          intProp: { ranges: [[1, 2]] };
+          shortProp: {
+            ranges: [[2, 3], [4, 5]];
+          };
+          floatProp: { fixedWidth: 10 };
+        };
+      }>
+    >({
+      select: {
+        id: "approximateDistinct",
+        $count: true,
+      },
+      groupBy: {
+        text: "exact",
+        priority: { exactWithLimit: 10 },
+        intProp: { ranges: [[1, 2]] },
+        shortProp: {
+          ranges: [[2, 3], [4, 5]],
+        },
+        floatProp: { fixedWidth: 10 },
+      },
+    });
+
+    expectType<
+      AggregateOptsThatErrors<TodoDef, {
+        select: {
+          id: "approximateDistinct";
+          wrongSelectKey: "don't work";
+          $count: true;
+        };
+        groupBy: {
+          wrongKey: "don't work";
+          text: "exact";
+          priority: { exactWithLimit: 10 };
+          intProp: { ranges: [[1, 2]] };
+          shortProp: {
+            ranges: [[2, 3], [4, 5]];
+          };
+          floatProp: { fixedWidth: 10 };
+        };
+      }>
+    >({
+      select: {
+        id: "approximateDistinct",
+        // @ts-expect-error
+        wrongSelectKey: "don't work",
+        $count: true,
+      },
+      groupBy: {
+        // @ts-expect-error
+        wrongKey: "don't work",
+        text: "exact",
+        priority: { exactWithLimit: 10 },
+        intProp: { ranges: [[1, 2]] },
+        shortProp: {
+          ranges: [[2, 3], [4, 5]],
+        },
+        floatProp: { fixedWidth: 10 },
+      },
+    });
+
+    expectTypeOf<
+      typeof aggregate<TodoDef, {
+        select: {
+          id: "approximateDistinct";
+          wrongSelectKey: "wrongKey";
+          $count: true;
+        };
+        groupBy: {
+          text: "exact";
+          wrongKey: "wrongKey";
+          priority: { exactWithLimit: 10 };
+          intProp: { ranges: [[1, 2]] };
+          shortProp: {
+            ranges: [[2, 3], [4, 5]];
+          };
+          floatProp: { fixedWidth: 10 };
+        };
+      }>
+    >().toBeCallableWith(
+      clientCtx,
+      Todo,
+      {
+        type: "base",
+        objectType: "ToDo",
+      },
+      {
+        select: {
+          id: "approximateDistinct",
+          // @ts-expect-error
+          wrongSelectKey: "wrongKey",
+          $count: true,
+        },
+        groupBy: {
+          text: "exact",
+          // @ts-expect-error
+          wrongKey: "wrongKey",
+          priority: { exactWithLimit: 10 },
+          intProp: { ranges: [[1, 2]] },
+          shortProp: {
+            ranges: [[2, 3], [4, 5]],
+          },
+          floatProp: { fixedWidth: 10 },
+        },
+      },
+    );
   });
 
   it("works with where: todo", async () => {

--- a/packages/client/src/object/aggregate.ts
+++ b/packages/client/src/object/aggregate.ts
@@ -34,6 +34,7 @@ import type { AggregateOpts } from "../query/aggregations/AggregateOpts.js";
 import type {
   AggregationResultsWithGroups,
   AggregationsResults,
+  GroupByClause,
 } from "../query/index.js";
 import type { ArrayElement } from "../util/ArrayElement.js";
 
@@ -52,7 +53,20 @@ export type AggregateOptsThatErrors<
         Exclude<keyof AO["select"], keyof AggregateOpts<Q>["select"]>,
         never
       >;
-  };
+  }
+  & (unknown extends AO["groupBy"] ? {}
+    : Exclude<AO["groupBy"], undefined> extends never ? {}
+    : {
+      groupBy:
+        & Pick<
+          AO["groupBy"],
+          keyof GroupByClause<Q> & keyof AO["groupBy"]
+        >
+        & Record<
+          Exclude<keyof AO["groupBy"], keyof GroupByClause<Q>>,
+          never
+        >;
+    });
 
 /** @deprecated use `aggregate` */
 export async function aggregateOrThrow<

--- a/packages/client/src/query/aggregations/AggregationsResults.ts
+++ b/packages/client/src/query/aggregations/AggregationsResults.ts
@@ -35,7 +35,12 @@ export type AggregationsResults<
     ?
       & AggregationResultsWithoutGroups<Q, AO["select"]>
       & AggregationCountResult<Q, AO["select"]>
-  : AggregationResultsWithGroups<Q, AO["select"], AO["groupBy"]>
+  : Exclude<keyof AO["groupBy"], AggregatableKeys<Q>> extends never
+    ? AggregationResultsWithGroups<Q, AO["select"], AO["groupBy"]>
+  : `Sorry, the following are not valid groups for an aggregation: ${Exclude<
+    keyof AO["groupBy"] & string,
+    AggregatableKeys<Q>
+  >}`
   : `Sorry, the following are not valid selectors for an aggregation: ${Exclude<
     keyof AO["select"] & string,
     AggregatableKeys<Q> | "$count"


### PR DESCRIPTION
Prevent incompatible keys from being used in groupBy clauses

![image](https://github.com/palantir/osdk-ts/assets/67482244/d2e112ab-af9d-4925-9da5-edb691924229)

![image](https://github.com/palantir/osdk-ts/assets/67482244/9e1d9f85-d99a-490f-b6db-553e54de1f58)
