### PR TITLE
Fix long and decimal types to correctly be strings in legacy-client

### DIFF
--- a/examples-extra/one_dot_one/src/generatedNoCheck/ontology/objects/ObjectTypeWithAllPropertyTypes.ts
+++ b/examples-extra/one_dot_one/src/generatedNoCheck/ontology/objects/ObjectTypeWithAllPropertyTypes.ts
@@ -25,8 +25,8 @@ export interface ObjectTypeWithAllPropertyTypes extends OntologyObject {
   readonly dateArray: LocalDate[] | undefined;
   readonly dateTime: Timestamp | undefined;
   readonly dateTimeArray: Timestamp[] | undefined;
-  readonly decimal: number | undefined;
-  readonly decimalArray: number[] | undefined;
+  readonly decimal: string | undefined;
+  readonly decimalArray: string[] | undefined;
   readonly double: number | undefined;
   readonly doubleArray: number[] | undefined;
   readonly float: number | undefined;
@@ -38,8 +38,8 @@ export interface ObjectTypeWithAllPropertyTypes extends OntologyObject {
   readonly id: number | undefined;
   readonly integer: number | undefined;
   readonly integerArray: number[] | undefined;
-  readonly long: number | undefined;
-  readonly longArray: number[] | undefined;
+  readonly long: string | undefined;
+  readonly longArray: string[] | undefined;
   readonly numericTimeseries: TimeSeries<number> | undefined;
   readonly short: number | undefined;
   readonly shortArray: number[] | undefined;

--- a/examples-extra/one_dot_one/src/generatedNoCheck/ontology/queries/Queries.ts
+++ b/examples-extra/one_dot_one/src/generatedNoCheck/ontology/queries/Queries.ts
@@ -18,7 +18,7 @@ export interface Queries {
    * @param {number} params.double - a double parameter
    * @param {number} params.float
    * @param {number} params.integer
-   * @param {number} params.long
+   * @param {string|number} params.long
    * @param {Attachment} params.attachment
    * @param {boolean} params.boolean
    * @param {LocalDate} params.date
@@ -39,7 +39,7 @@ export interface Queries {
     double: number;
     float: number;
     integer: number;
-    long: number;
+    long: string | number;
     attachment: Attachment;
     boolean: boolean;
     date: LocalDate;

--- a/packages/api/changelog/@unreleased/pr-113.v2.yml
+++ b/packages/api/changelog/@unreleased/pr-113.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix long and decimal types to correctly be strings in legacy-client
+  links:
+  - https://github.com/palantir/osdk-ts/pull/113

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -72,6 +72,5 @@ export type {
   TwoDimensionalAggregationDataType,
   TwoDimensionalQueryAggregationDefinition,
   UnionQueryDataType,
-  WireQueryDataTypes,
 } from "./ontology/QueryDefinition";
 export type { WirePropertyTypes } from "./ontology/WirePropertyTypes";

--- a/packages/api/src/ontology/ActionDefinition.ts
+++ b/packages/api/src/ontology/ActionDefinition.ts
@@ -35,17 +35,16 @@ export interface ActionModifiedEntity {
   modified: boolean;
 }
 
-export interface ValidBaseActionParameterTypes {
-  boolean: boolean;
-  string: string;
-  integer: number;
-  long: number;
-  double: number;
-  datetime: Date;
-  timestamp: Date;
-  attachment: any;
-  marking: string;
-}
+export type ValidBaseActionParameterTypes =
+  | "boolean"
+  | "string"
+  | "integer"
+  | "long"
+  | "double"
+  | "datetime"
+  | "timestamp"
+  | "attachment"
+  | "marking";
 
 export interface ObjectActionDataType<
   K extends string,
@@ -69,7 +68,7 @@ export type ValidActionParameterTypes<
   K extends string = never,
   T_Target extends ObjectTypeDefinition<any> = never,
 > =
-  | keyof ValidBaseActionParameterTypes
+  | ValidBaseActionParameterTypes
   | ObjectActionDataType<K, T_Target>
   | ObjectSetActionDataType<K, T_Target>;
 

--- a/packages/api/src/ontology/ObjectTypeDefinition.ts
+++ b/packages/api/src/ontology/ObjectTypeDefinition.ts
@@ -64,7 +64,7 @@ export interface ObjectTypeDefinition<
 > extends ObjectInterfaceBaseDefinition<K, N> {
   type: "object";
   primaryKeyApiName: keyof this["properties"];
-  primaryKeyType: keyof WirePropertyTypes;
+  primaryKeyType: WirePropertyTypes;
 }
 
 export type ObjectTypeLinkKeysFrom<
@@ -101,13 +101,13 @@ export interface ObjectTypePropertyDefinition {
   readonly?: boolean;
   displayName?: string;
   description?: string;
-  type: keyof WirePropertyTypes;
+  type: WirePropertyTypes;
   multiplicity?: boolean;
   nullable?: boolean;
 }
 
 export type PropertyDef<
-  T extends keyof WirePropertyTypes,
+  T extends WirePropertyTypes,
   N extends "nullable" | "non-nullable" = "nullable",
   M extends "array" | "single" = "single",
   E extends Record<string, any> = {},

--- a/packages/api/src/ontology/QueryDefinition.ts
+++ b/packages/api/src/ontology/QueryDefinition.ts
@@ -44,20 +44,19 @@ export type BaseQueryDataTypeDefinition<T extends string> = {
   type: T;
 };
 
-export interface WireQueryDataTypes {
-  double: number;
-  float: number;
-  integer: number;
-  long: number;
-  boolean: boolean;
-  string: string;
-  date: Date;
-  timestamp: Date;
-  attachment: any; // TODO surely we can be more strict here
-}
+export type WireQueryDataTypes =
+  | "double"
+  | "float"
+  | "integer"
+  | "long"
+  | "boolean"
+  | "string"
+  | "date"
+  | "timestamp"
+  | "attachment";
 
 export type PrimitiveDataType<
-  Q extends keyof WireQueryDataTypes = keyof WireQueryDataTypes,
+  Q extends WireQueryDataTypes = WireQueryDataTypes,
 > = BaseQueryDataTypeDefinition<Q>;
 
 export interface ObjectQueryDataType<K extends string>

--- a/packages/api/src/ontology/WirePropertyTypes.ts
+++ b/packages/api/src/ontology/WirePropertyTypes.ts
@@ -14,26 +14,21 @@
  * limitations under the License.
  */
 
-import type * as GeoJSON from "geojson";
-
-export interface WirePropertyTypes {
-  string: string;
-  datetime: string;
-  double: number;
-  boolean: boolean;
-  integer: number;
-  timestamp: string;
-  short: number;
-  long: number;
-  float: number;
-  decimal: number;
-  byte: number;
-  marking: string;
-
-  numericTimeseries: any;
-  stringTimeseries: any;
-
-  attachment: any;
-  geopoint: GeoJSON.Point;
-  geoshape: GeoJSON.Geometry;
-}
+export type WirePropertyTypes =
+  | "string"
+  | "datetime"
+  | "double"
+  | "boolean"
+  | "integer"
+  | "timestamp"
+  | "short"
+  | "long"
+  | "float"
+  | "decimal"
+  | "byte"
+  | "marking"
+  | "numericTimeseries"
+  | "stringTimeseries"
+  | "attachment"
+  | "geopoint"
+  | "geoshape";

--- a/packages/api/src/ontology/index.ts
+++ b/packages/api/src/ontology/index.ts
@@ -69,6 +69,4 @@ export type {
   TwoDimensionalAggregationDataType,
   TwoDimensionalQueryAggregationDefinition,
   UnionQueryDataType,
-  WireQueryDataTypes,
 } from "./QueryDefinition";
-export type { WirePropertyTypes } from "./WirePropertyTypes";

--- a/packages/generator-converters/changelog/@unreleased/pr-113.v2.yml
+++ b/packages/generator-converters/changelog/@unreleased/pr-113.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix long and decimal types to correctly be strings in legacy-client
+  links:
+  - https://github.com/palantir/osdk-ts/pull/113

--- a/packages/generator-converters/src/wirePropertyV2ToSdkPrimaryKeyTypeDefinition.ts
+++ b/packages/generator-converters/src/wirePropertyV2ToSdkPrimaryKeyTypeDefinition.ts
@@ -19,7 +19,7 @@ import type { PropertyV2 } from "@osdk/gateway/types";
 
 export function wirePropertyV2ToSdkPrimaryKeyTypeDefinition(
   input: PropertyV2,
-): keyof WirePropertyTypes {
+): WirePropertyTypes {
   switch (input.dataType.type) {
     case "integer":
     case "double":

--- a/packages/generator-converters/src/wirePropertyV2ToSdkPropertyDefinition.ts
+++ b/packages/generator-converters/src/wirePropertyV2ToSdkPropertyDefinition.ts
@@ -65,7 +65,7 @@ export function wirePropertyV2ToSdkPropertyDefinition(
 
 function objectPropertyTypeToSdkPropertyDefinition(
   propertyType: ObjectPropertyType,
-): keyof WirePropertyTypes {
+): WirePropertyTypes {
   switch (propertyType.type) {
     case "integer":
     case "string":

--- a/packages/generator/changelog/@unreleased/pr-113.v2.yml
+++ b/packages/generator/changelog/@unreleased/pr-113.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix long and decimal types to correctly be strings in legacy-client
+  links:
+  - https://github.com/palantir/osdk-ts/pull/113

--- a/packages/generator/src/v1.1/generateQueries.ts
+++ b/packages/generator/src/v1.1/generateQueries.ts
@@ -113,8 +113,9 @@ function handleQueryDataType(
     case "double":
     case "float":
     case "integer":
-    case "long":
       return "number";
+    case "long":
+      return isReturnValue ? "string" : "string | number";
 
     case "date":
       return "LocalDate";

--- a/packages/generator/src/v1.1/wireObjectTypeV2ToV1ObjectInterfaceString.ts
+++ b/packages/generator/src/v1.1/wireObjectTypeV2ToV1ObjectInterfaceString.ts
@@ -103,7 +103,7 @@ function wirePropertyTypeV2ToTypeScriptType(
     case "date":
       return "LocalDate";
     case "decimal":
-      return "number";
+      return "string";
     case "double":
       return "number";
     case "float":
@@ -113,7 +113,7 @@ function wirePropertyTypeV2ToTypeScriptType(
     case "geoshape":
       return "GeoShape";
     case "long":
-      return "number";
+      return "string";
     case "short":
       return "number";
     case "timestamp":

--- a/packages/legacy-client/changelog/@unreleased/pr-113.v2.yml
+++ b/packages/legacy-client/changelog/@unreleased/pr-113.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix long and decimal types to correctly be strings in legacy-client
+  links:
+  - https://github.com/palantir/osdk-ts/pull/113

--- a/packages/legacy-client/src/client/OsdkLegacyObject.ts
+++ b/packages/legacy-client/src/client/OsdkLegacyObject.ts
@@ -45,9 +45,9 @@ export interface ValidLegacyPropertyTypes {
   integer: number;
   timestamp: Timestamp;
   short: number;
-  long: number;
+  long: string;
   float: number;
-  decimal: number;
+  decimal: string;
   byte: number;
   marking: string;
 

--- a/packages/legacy-client/src/client/actions/actions.ts
+++ b/packages/legacy-client/src/client/actions/actions.ts
@@ -39,7 +39,7 @@ export interface ValidLegacyActionParameterTypes {
   boolean: boolean;
   string: string;
   integer: number;
-  long: number;
+  long: number | string;
   double: number;
   datetime: LocalDate;
   timestamp: Timestamp;

--- a/packages/legacy-client/src/client/queries.test.ts
+++ b/packages/legacy-client/src/client/queries.test.ts
@@ -310,7 +310,7 @@ describe("Queries", () => {
         double: number;
         float: number;
         integer: number;
-        long: number;
+        long: number | string;
         attachment: any;
         boolean: boolean;
         date: LocalDate;

--- a/packages/legacy-client/src/client/queries.ts
+++ b/packages/legacy-client/src/client/queries.ts
@@ -113,7 +113,7 @@ export interface ValidLegacyBaseQueryDataTypes {
   double: number;
   float: number;
   integer: number;
-  long: number;
+  long: number | string;
   boolean: boolean;
   string: string;
   date: LocalDate;
@@ -125,7 +125,11 @@ export type QueryDataTypeBase<
   O extends OntologyDefinition<any>,
   T extends QueryDataType<O, any, R>,
   R extends boolean,
-> = T extends PrimitiveDataType<infer X> ? ValidLegacyBaseQueryDataTypes[X]
+> = T extends PrimitiveDataType<infer X>
+  // returned longs are always strings, but we can accept numbers as input
+  ? (R extends true
+    ? X extends "long" ? string : ValidLegacyBaseQueryDataTypes[X]
+    : ValidLegacyBaseQueryDataTypes[X])
   : T extends ObjectQueryDataType<any>
     ? R extends true ? OsdkLegacyObjectFrom<O, T["object"]>
     :

--- a/packages/legacy-client/src/util/test/ObjectTypeWithAllPropertyTypes.ts
+++ b/packages/legacy-client/src/util/test/ObjectTypeWithAllPropertyTypes.ts
@@ -31,9 +31,9 @@ export interface ObjectTypeWithAllPropertyTypes extends OntologyObject {
   readonly boolean: boolean | undefined;
   readonly date: LocalDate | undefined;
   readonly dateTime: Timestamp | undefined;
-  readonly decimal: number | undefined;
+  readonly decimal: string | undefined;
   readonly integer: number | undefined;
-  readonly long: number | undefined;
+  readonly long: string | undefined;
   readonly short: number | undefined;
   readonly float: number | undefined;
   readonly double: number | undefined;


### PR DESCRIPTION
Update the types for Decimal and Long to correctly be `string` instead of `number` to match the actual type of the data that we return.

Queries and Actions should take `number | string` and not break back-compatability, Queries would return `string` now instead for longs. Object set `.get(primaryKey)` will also have to change from number to string for longs (and decimals? I forget if they can be used for PK).