### PR TITLE
Ignore new examples packages in changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,6 +8,9 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [
+    "@osdk/examples.next-static-export",
+    "@osdk/examples.react",
+    "@osdk/examples.vue",
     "@osdk/examples.basic.cli",
     "@osdk/examples.basic.sdk",
     "@osdk/examples.one.dot.one",


### PR DESCRIPTION
Fixes release using changesets publish after #108 added more examples package that need to be added to the ignore list