### PR TITLE
Bump TS and make writing test network mocks easier

### DIFF
--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -58,12 +58,16 @@ const formatedGeneratorHelper = (contents, ext) => async (context) => {
 
 /**
  * @param {string} baseTsconfigPath
- * @param {{customTsconfigExcludes?: string[]}} opts
+ * @param {{
+ *   customTsconfigExcludes?: string[]
+ *   skipTsconfigReferences?: boolean
+ * }} opts
  * @returns
  */
 function getTsconfigOptions(baseTsconfigPath, opts) {
   return {
     file: "tsconfig.json",
+    excludedReferences: opts.skipTsconfigReferences ? ["**/*"] : undefined,
     template: {
       extends: baseTsconfigPath,
 
@@ -108,7 +112,8 @@ function getTsconfigOptionsE2E(baseTsconfigPath) {
  *  packageDepth: number,
  *  type: "library" | "example",
  *  customTsconfigExcludes?: string[],
- *  tsVersion?: "^5.2.2"|"^4.9.0",
+ *  tsVersion?: "^5.4.2"|"^4.9.0",
+ *  skipTsconfigReferences?: boolean
  * }} options
  */
 function standardPackageRules(shared, options) {
@@ -119,7 +124,7 @@ function standardPackageRules(shared, options) {
         `${
           "../".repeat(options.packageDepth)
         }monorepo/tsconfig/tsconfig.base.json`,
-        { customTsconfigExcludes: options.customTsconfigExcludes },
+        options,
       ),
     }),
     ...(options.tsVersion
@@ -263,7 +268,7 @@ export default {
       legacy: false,
       packageDepth: 2,
       type: "library",
-      tsVersion: "^5.2.2",
+      tsVersion: "^5.4.2",
     }),
 
     ...standardPackageRules({
@@ -272,7 +277,7 @@ export default {
       legacy: false,
       packageDepth: 2,
       type: "library",
-      tsVersion: "^5.2.2",
+      tsVersion: "^5.4.2",
       customTsconfigExcludes: [
         "./src/__e2e_tests__/**/**.test.ts",
         "./src/generatedNoCheck/**/*",
@@ -286,7 +291,7 @@ export default {
       legacy: true,
       packageDepth: 2,
       type: "library",
-      tsVersion: "^5.2.2",
+      tsVersion: "^5.4.2",
     }),
 
     ...standardPackageRules({
@@ -307,6 +312,7 @@ export default {
       packageDepth: 2,
       type: "example",
       tsVersion: "^4.9.0",
+      skipTsconfigReferences: true,
     }),
 
     packageEntry({

--- a/examples-extra/one_dot_one/tsconfig.json
+++ b/examples-extra/one_dot_one/tsconfig.json
@@ -12,21 +12,5 @@
   "exclude": [
     "**/__snapshots__"
   ],
-  "references": [
-    {
-      "path": "../../packages/api"
-    },
-    {
-      "path": "../../packages/cli"
-    },
-    {
-      "path": "../../packages/generator"
-    },
-    {
-      "path": "../../packages/legacy-client"
-    },
-    {
-      "path": "../../packages/cli"
-    }
-  ]
+  "references": []
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "tsconfig": "workspace:*",
     "tsup": "^7.2.0",
     "turbo": "^1.10.13",
-    "typescript": "^5.2.2",
+    "typescript": "^5.3.2",
     "vitest": "^1.2.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "tsconfig": "workspace:*",
     "tsup": "^7.2.0",
     "turbo": "^1.10.13",
-    "typescript": "^5.3.2",
+    "typescript": "^5.4.2",
     "vitest": "^1.2.2"
   },
   "dependencies": {

--- a/packages/api/changelog/@unreleased/pr-120.v2.yml
+++ b/packages/api/changelog/@unreleased/pr-120.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Bump TS and make writing test network mocks easier
+  links:
+  - https://github.com/palantir/osdk-ts/pull/120

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -40,12 +40,12 @@
   },
   "devDependencies": {
     "ts-expect": "^1.3.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.4.2"
   },
   "publishConfig": {
     "access": "public"
   },
-  "keywords": [ ],
+  "keywords": [],
   "files": [
     "build/types",
     "build/js",

--- a/packages/cli/changelog/@unreleased/pr-120.v2.yml
+++ b/packages/cli/changelog/@unreleased/pr-120.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Bump TS and make writing test network mocks easier
+  links:
+  - https://github.com/palantir/osdk-ts/pull/120

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,7 @@
     "@types/semver": "^7.5.7",
     "@types/yargs": "^17.0.29",
     "ts-expect": "^1.3.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.4.2"
   },
   "publishConfig": {
     "access": "public"
@@ -60,7 +60,7 @@
   "imports": {
     "#net": "./src/net/index.mts"
   },
-  "keywords": [ ],
+  "keywords": [],
   "bin": {
     "osdk": "./bin/osdk.mjs"
   },

--- a/packages/client/changelog/@unreleased/pr-120.v2.yml
+++ b/packages/client/changelog/@unreleased/pr-120.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Bump TS and make writing test network mocks easier
+  links:
+  - https://github.com/palantir/osdk-ts/pull/120

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -50,12 +50,12 @@
     "@types/geojson": "^7946.0.14",
     "@types/ws": "^8.5.10",
     "ts-expect": "^1.3.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.4.2"
   },
   "publishConfig": {
     "access": "public"
   },
-  "keywords": [ ],
+  "keywords": [],
   "files": [
     "build/types",
     "build/js",

--- a/packages/create-app/changelog/@unreleased/pr-120.v2.yml
+++ b/packages/create-app/changelog/@unreleased/pr-120.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Bump TS and make writing test network mocks easier
+  links:
+  - https://github.com/palantir/osdk-ts/pull/120

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -44,7 +44,7 @@
     "@types/yargs": "^17.0.29",
     "dir-compare": "^4.2.0",
     "tmp": "^0.2.1",
-    "typescript": "^5.2.2"
+    "typescript": "^5.4.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/foundry-sdk-generator/changelog/@unreleased/pr-120.v2.yml
+++ b/packages/foundry-sdk-generator/changelog/@unreleased/pr-120.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Bump TS and make writing test network mocks easier
+  links:
+  - https://github.com/palantir/osdk-ts/pull/120

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -49,12 +49,12 @@
     "@osdk/shared.test": "workspace:*",
     "@types/node": "^18.0.0",
     "@types/yargs": "^17.0.29",
-    "typescript": "^5.2.2"
+    "typescript": "^5.4.2"
   },
   "publishConfig": {
     "access": "public"
   },
-  "keywords": [ ],
+  "keywords": [],
   "bin": {
     "foundry-sdk-generator": "./bin/foundry-sdk-generator"
   },

--- a/packages/gateway-generator/changelog/@unreleased/pr-120.v2.yml
+++ b/packages/gateway-generator/changelog/@unreleased/pr-120.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Bump TS and make writing test network mocks easier
+  links:
+  - https://github.com/palantir/osdk-ts/pull/120

--- a/packages/gateway-generator/package.json
+++ b/packages/gateway-generator/package.json
@@ -39,12 +39,12 @@
   },
   "devDependencies": {
     "@types/yargs": "^17.0.29",
-    "typescript": "^5.2.2"
+    "typescript": "^5.4.2"
   },
   "publishConfig": {
     "access": "public"
   },
-  "keywords": [ ],
+  "keywords": [],
   "bin": {
     "gateway-generator": "./bin/gateway-generator.cjs"
   },

--- a/packages/gateway/changelog/@unreleased/pr-120.v2.yml
+++ b/packages/gateway/changelog/@unreleased/pr-120.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Bump TS and make writing test network mocks easier
+  links:
+  - https://github.com/palantir/osdk-ts/pull/120

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "ts-expect": "^1.3.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.4.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/generator-converters/changelog/@unreleased/pr-120.v2.yml
+++ b/packages/generator-converters/changelog/@unreleased/pr-120.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Bump TS and make writing test network mocks easier
+  links:
+  - https://github.com/palantir/osdk-ts/pull/120

--- a/packages/generator-converters/package.json
+++ b/packages/generator-converters/package.json
@@ -37,13 +37,13 @@
   },
   "devDependencies": {
     "ts-expect": "^1.3.0",
-    "typescript": "^5.2.2",
+    "typescript": "^5.4.2",
     "vitest": "^1.2.2"
   },
   "publishConfig": {
     "access": "public"
   },
-  "keywords": [ ],
+  "keywords": [],
   "files": [
     "build/types",
     "build/js",

--- a/packages/generator/changelog/@unreleased/pr-120.v2.yml
+++ b/packages/generator/changelog/@unreleased/pr-120.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Bump TS and make writing test network mocks easier
+  links:
+  - https://github.com/palantir/osdk-ts/pull/120

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -43,13 +43,13 @@
   "devDependencies": {
     "@types/node": "^18.0.0",
     "ts-expect": "^1.3.0",
-    "typescript": "^5.2.2",
+    "typescript": "^5.4.2",
     "vitest": "^1.2.2"
   },
   "publishConfig": {
     "access": "public"
   },
-  "keywords": [ ],
+  "keywords": [],
   "files": [
     "build/types",
     "build/js",

--- a/packages/legacy-client/changelog/@unreleased/pr-120.v2.yml
+++ b/packages/legacy-client/changelog/@unreleased/pr-120.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Bump TS and make writing test network mocks easier
+  links:
+  - https://github.com/palantir/osdk-ts/pull/120

--- a/packages/legacy-client/package.json
+++ b/packages/legacy-client/package.json
@@ -47,12 +47,12 @@
     "@types/luxon": "^3.3.3",
     "@types/ngeohash": "^0.6.4",
     "ts-expect": "^1.3.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.4.2"
   },
   "publishConfig": {
     "access": "public"
   },
-  "keywords": [ ],
+  "keywords": [],
   "files": [
     "build/types",
     "build/js",

--- a/packages/shared.net/changelog/@unreleased/pr-120.v2.yml
+++ b/packages/shared.net/changelog/@unreleased/pr-120.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Bump TS and make writing test network mocks easier
+  links:
+  - https://github.com/palantir/osdk-ts/pull/120

--- a/packages/shared.net/package.json
+++ b/packages/shared.net/package.json
@@ -37,12 +37,12 @@
   },
   "devDependencies": {
     "ts-expect": "^1.3.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.4.2"
   },
   "publishConfig": {
     "access": "public"
   },
-  "keywords": [ ],
+  "keywords": [],
   "files": [
     "build/types",
     "build/js",

--- a/packages/shared.test/changelog/@unreleased/pr-120.v2.yml
+++ b/packages/shared.test/changelog/@unreleased/pr-120.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Bump TS and make writing test network mocks easier
+  links:
+  - https://github.com/palantir/osdk-ts/pull/120

--- a/packages/shared.test/package.json
+++ b/packages/shared.test/package.json
@@ -40,12 +40,12 @@
   "devDependencies": {
     "@types/json-stable-stringify": "^1.0.36",
     "ts-expect": "^1.3.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.4.2"
   },
   "publishConfig": {
     "access": "public"
   },
-  "keywords": [ ],
+  "keywords": [],
   "files": [
     "build/types",
     "build/js",

--- a/packages/shared.test/src/handlers/commonHandlers.ts
+++ b/packages/shared.test/src/handlers/commonHandlers.ts
@@ -22,7 +22,9 @@ import type {
   RestRequest,
 } from "msw";
 
-type MiddlewareHandler<TReqBody extends DefaultBodyType = DefaultBodyType> = (
+export type MiddlewareHandler<
+  TReqBody extends DefaultBodyType = DefaultBodyType,
+> = (
   req: RestRequest<TReqBody>,
   res: ResponseComposition,
   ctx: RestContext,

--- a/packages/shared.test/src/handlers/util/handleOpenApiCall.ts
+++ b/packages/shared.test/src/handlers/util/handleOpenApiCall.ts
@@ -26,13 +26,6 @@ import { rest } from "msw";
 import type { BaseAPIError } from "../../BaseError";
 import { authHandlerMiddleware } from "../commonHandlers";
 
-type Tuple<T, N extends number> = N extends N
-  ? number extends N ? T[] : _TupleOf<T, N, []>
-  : never;
-type _TupleOf<T, N extends number, R extends unknown[]> = R["length"] extends N
-  ? R
-  : _TupleOf<T, N, [T, ...R]>;
-
 export class OpenApiCallError extends Error {
   constructor(
     public status: number,

--- a/packages/shared.test/src/handlers/util/handleOpenApiCall.ts
+++ b/packages/shared.test/src/handlers/util/handleOpenApiCall.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { OpenApiRequest } from "@osdk/gateway/types";
+import type {
+  MockedRequest,
+  ResponseComposition,
+  RestContext,
+  RestHandler,
+  RestRequest,
+} from "msw";
+import { rest } from "msw";
+import type { BaseAPIError } from "../../BaseError";
+import { authHandlerMiddleware } from "../commonHandlers";
+
+type Tuple<T, N extends number> = N extends N
+  ? number extends N ? T[] : _TupleOf<T, N, []>
+  : never;
+type _TupleOf<T, N extends number, R extends unknown[]> = R["length"] extends N
+  ? R
+  : _TupleOf<T, N, [T, ...R]>;
+
+export class OpenApiCallError extends Error {
+  constructor(
+    public status: number,
+    public json: {
+      errorCode: string;
+      errorName: string;
+    },
+  ) {
+    super(json.errorName ?? "Unknown error");
+  }
+}
+
+type ExtractStringParams<T extends any[]> = T extends [infer A, ...infer B]
+  ? A extends string ? [A, ...ExtractStringParams<B>] : []
+  : [];
+
+type SkipStringParams<T extends any[]> = T extends [infer A, ...infer B]
+  ? A extends string ? SkipStringParams<B> : T
+  : T;
+
+/**
+ * This relies on a trick that generally our query params and header params are optional therefore
+ * the body can generally be assumed to be the first payload following the strings which are path
+ * params.
+ *
+ * This will also fail if your body is defined as a string as that will get interpreted as a path param.
+ * If this happens, you cannot use the helper. Sorry
+ */
+type ExtractBody<
+  X extends ((reqCall: any, ...args: any[]) => Promise<any>),
+> = SkipStringParams<ParamsAfterReqCall<X>>[0] extends undefined ? never
+  : SkipStringParams<ParamsAfterReqCall<X>>[0];
+
+type ParamsAfterReqCall<
+  T extends (reqCall: any, ...args: any[]) => Promise<any>,
+> = T extends (reqCall: any, ...args: infer Z) => Promise<any> ? Z : never;
+
+export function handleOpenApiCall<
+  const N extends ExtractStringParams<ParamsAfterReqCall<X>>,
+  const X extends ((...args: any[]) => Promise<any>),
+>(
+  openApiCall: X,
+  names: N,
+  restImpl: (
+    req: RestRequest<ExtractBody<X>, Record<N[number], string>>,
+    res: ResponseComposition<
+      | (
+        & (Parameters<X>[0] extends OpenApiRequest<infer R, any> ? R : never)
+        & {}
+      )
+      | BaseAPIError
+    >,
+    ctx: RestContext,
+  ) => any,
+): RestHandler<MockedRequest<ExtractBody<X>>> {
+  let captured: {
+    method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+    endPoint: string;
+    data?: any;
+    queryArguments?: Record<string, any>;
+    headers?: Record<string, any>;
+    requestMediaType?: string;
+    responseMediaType?: string;
+  } = {} as any;
+
+  const capture: OpenApiRequest<any> = (
+    method,
+    endPoint,
+  ): Promise<any> => {
+    captured = {
+      method: method as any,
+      endPoint,
+    };
+
+    return Promise.resolve();
+  };
+
+  // we dont care about the promise here, we are just building the url
+  openApiCall(
+    capture as any,
+    ...(names.map(n => `:${n}`) as any),
+  );
+
+  return rest
+    [captured.method.toLowerCase() as Lowercase<typeof captured.method>](
+      `https://stack.palantir.com/api${captured.endPoint}`,
+      authHandlerMiddleware((req, res, ctx) => {
+        try {
+          return restImpl(req as any, res, ctx);
+        } catch (e) {
+          if (e instanceof OpenApiCallError) {
+            return res(ctx.status(e.status), ctx.json(e.json));
+          }
+          throw e;
+        }
+      }),
+    );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,19 +68,19 @@ importers:
         version: link:monorepo/mytsup
       tsc-absolute:
         specifier: ^1.0.1
-        version: 1.0.1(typescript@5.2.2)
+        version: 1.0.1(typescript@5.4.2)
       tsconfig:
         specifier: workspace:*
         version: link:monorepo/tsconfig
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.4.2)
       turbo:
         specifier: ^1.10.13
         version: 1.10.13
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.3.2
+        version: 5.4.2
       vitest:
         specifier: ^1.2.2
         version: 1.2.2(@types/node@18.17.15)
@@ -391,10 +391,10 @@ importers:
     dependencies:
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.13.0
-        version: 6.13.1(@typescript-eslint/parser@6.13.1)(eslint@8.49.0)(typescript@5.2.2)
+        version: 6.13.1(@typescript-eslint/parser@6.13.1)(eslint@8.49.0)(typescript@5.4.2)
       '@typescript-eslint/parser':
         specifier: ^6.13.0
-        version: 6.13.1(eslint@8.49.0)(typescript@5.2.2)
+        version: 6.13.1(eslint@8.49.0)(typescript@5.4.2)
       eslint:
         specifier: ^8.49.0
         version: 8.49.0
@@ -415,10 +415,10 @@ importers:
     dependencies:
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.13.0
-        version: 6.13.1(@typescript-eslint/parser@6.13.1)(eslint@8.49.0)(typescript@5.2.2)
+        version: 6.13.1(@typescript-eslint/parser@6.13.1)(eslint@8.49.0)(typescript@5.4.2)
       '@typescript-eslint/parser':
         specifier: ^6.13.0
-        version: 6.13.1(eslint@8.49.0)(typescript@5.2.2)
+        version: 6.13.1(eslint@8.49.0)(typescript@5.4.2)
       eslint:
         specifier: ^8.49.0
         version: 8.49.0
@@ -434,7 +434,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(typescript@5.2.2)
+        version: 7.2.0(typescript@5.4.2)
 
   monorepo/tsconfig: {}
 
@@ -460,8 +460,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.4.2
+        version: 5.4.2
 
   packages/cli:
     dependencies:
@@ -521,8 +521,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.4.2
+        version: 5.4.2
 
   packages/client:
     dependencies:
@@ -573,8 +573,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.4.2
+        version: 5.4.2
 
   packages/create-app:
     dependencies:
@@ -607,8 +607,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.4.2
+        version: 5.4.2
 
   packages/foundry-sdk-generator:
     dependencies:
@@ -659,8 +659,8 @@ importers:
         specifier: ^17.0.29
         version: 17.0.29
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.4.2
+        version: 5.4.2
 
   packages/gateway:
     dependencies:
@@ -675,8 +675,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.4.2
+        version: 5.4.2
 
   packages/gateway-generator:
     dependencies:
@@ -697,8 +697,8 @@ importers:
         specifier: ^17.0.29
         version: 17.0.29
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.4.2
+        version: 5.4.2
 
   packages/generator:
     dependencies:
@@ -719,7 +719,7 @@ importers:
         version: 3.0.3
       prettier-plugin-organize-imports:
         specifier: ^3.2.3
-        version: 3.2.3(prettier@3.0.3)(typescript@5.2.2)
+        version: 3.2.3(prettier@3.0.3)(typescript@5.4.2)
       tiny-invariant:
         specifier: ^1.3.1
         version: 1.3.1
@@ -731,8 +731,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.4.2
+        version: 5.4.2
       vitest:
         specifier: ^1.2.2
         version: 1.2.2(@types/node@18.17.15)
@@ -750,8 +750,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.4.2
+        version: 5.4.2
       vitest:
         specifier: ^1.2.2
         version: 1.2.2(@types/node@18.17.15)
@@ -796,8 +796,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.4.2
+        version: 5.4.2
 
   packages/shared.net:
     dependencies:
@@ -812,8 +812,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.4.2
+        version: 5.4.2
 
   packages/shared.test:
     dependencies:
@@ -834,7 +834,7 @@ importers:
         version: 1.1.0
       msw:
         specifier: ^1.2.4
-        version: 1.3.2(typescript@5.2.2)
+        version: 1.3.2(typescript@5.4.2)
     devDependencies:
       '@types/json-stable-stringify':
         specifier: ^1.0.36
@@ -843,8 +843,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.4.2
+        version: 5.4.2
 
   tests/verify-fallback-package:
     dependencies:
@@ -2654,7 +2654,7 @@ packages:
       '@types/yargs-parser': 21.0.2
     dev: true
 
-  /@typescript-eslint/eslint-plugin@6.13.1(@typescript-eslint/parser@6.13.1)(eslint@8.49.0)(typescript@5.2.2):
+  /@typescript-eslint/eslint-plugin@6.13.1(@typescript-eslint/parser@6.13.1)(eslint@8.49.0)(typescript@5.4.2):
     resolution: {integrity: sha512-5bQDGkXaxD46bPvQt08BUz9YSaO4S0fB1LB5JHQuXTfkGPI3+UUeS387C/e9jRie5GqT8u5kFTrMvAjtX4O5kA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -2666,10 +2666,10 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.8.1
-      '@typescript-eslint/parser': 6.13.1(eslint@8.49.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.13.1(eslint@8.49.0)(typescript@5.4.2)
       '@typescript-eslint/scope-manager': 6.13.1
-      '@typescript-eslint/type-utils': 6.13.1(eslint@8.49.0)(typescript@5.2.2)
-      '@typescript-eslint/utils': 6.13.1(eslint@8.49.0)(typescript@5.2.2)
+      '@typescript-eslint/type-utils': 6.13.1(eslint@8.49.0)(typescript@5.4.2)
+      '@typescript-eslint/utils': 6.13.1(eslint@8.49.0)(typescript@5.4.2)
       '@typescript-eslint/visitor-keys': 6.13.1
       debug: 4.3.4
       eslint: 8.49.0
@@ -2677,8 +2677,8 @@ packages:
       ignore: 5.2.4
       natural-compare: 1.4.0
       semver: 7.6.0
-      ts-api-utils: 1.0.3(typescript@5.2.2)
-      typescript: 5.2.2
+      ts-api-utils: 1.0.3(typescript@5.4.2)
+      typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2712,7 +2712,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@6.13.1(eslint@8.49.0)(typescript@5.2.2):
+  /@typescript-eslint/parser@6.13.1(eslint@8.49.0)(typescript@5.4.2):
     resolution: {integrity: sha512-fs2XOhWCzRhqMmQf0eicLa/CWSaYss2feXsy7xBD/pLyWke/jCIVc2s1ikEAtSW7ina1HNhv7kONoEfVNEcdDQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -2724,11 +2724,11 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 6.13.1
       '@typescript-eslint/types': 6.13.1
-      '@typescript-eslint/typescript-estree': 6.13.1(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 6.13.1(typescript@5.4.2)
       '@typescript-eslint/visitor-keys': 6.13.1
       debug: 4.3.4
       eslint: 8.49.0
-      typescript: 5.2.2
+      typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2761,7 +2761,7 @@ packages:
       '@typescript-eslint/types': 6.13.1
       '@typescript-eslint/visitor-keys': 6.13.1
 
-  /@typescript-eslint/type-utils@6.13.1(eslint@8.49.0)(typescript@5.2.2):
+  /@typescript-eslint/type-utils@6.13.1(eslint@8.49.0)(typescript@5.4.2):
     resolution: {integrity: sha512-A2qPlgpxx2v//3meMqQyB1qqTg1h1dJvzca7TugM3Yc2USDY+fsRBiojAEo92HO7f5hW5mjAUF6qobOPzlBCBQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -2771,12 +2771,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.13.1(typescript@5.2.2)
-      '@typescript-eslint/utils': 6.13.1(eslint@8.49.0)(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 6.13.1(typescript@5.4.2)
+      '@typescript-eslint/utils': 6.13.1(eslint@8.49.0)(typescript@5.4.2)
       debug: 4.3.4
       eslint: 8.49.0
-      ts-api-utils: 1.0.3(typescript@5.2.2)
-      typescript: 5.2.2
+      ts-api-utils: 1.0.3(typescript@5.4.2)
+      typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2824,8 +2824,30 @@ packages:
       typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
-  /@typescript-eslint/utils@6.13.1(eslint@8.49.0)(typescript@5.2.2):
+  /@typescript-eslint/typescript-estree@6.13.1(typescript@5.4.2):
+    resolution: {integrity: sha512-sBLQsvOC0Q7LGcUHO5qpG1HxRgePbT6wwqOiGLpR8uOJvPJbfs0mW3jPA3ujsDvfiVwVlWUDESNXv44KtINkUQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 6.13.1
+      '@typescript-eslint/visitor-keys': 6.13.1
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.6.0
+      ts-api-utils: 1.0.3(typescript@5.4.2)
+      typescript: 5.4.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@typescript-eslint/utils@6.13.1(eslint@8.49.0)(typescript@5.4.2):
     resolution: {integrity: sha512-ouPn/zVoan92JgAegesTXDB/oUp6BP1v8WpfYcqh649ejNc9Qv+B4FF2Ff626kO1xg0wWwwG48lAJ4JuesgdOw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -2836,7 +2858,7 @@ packages:
       '@types/semver': 7.5.7
       '@typescript-eslint/scope-manager': 6.13.1
       '@typescript-eslint/types': 6.13.1
-      '@typescript-eslint/typescript-estree': 6.13.1(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 6.13.1(typescript@5.4.2)
       eslint: 8.49.0
       semver: 7.6.0
     transitivePeerDependencies:
@@ -4420,7 +4442,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.13.1(eslint@8.49.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.13.1(eslint@8.49.0)(typescript@5.4.2)
       debug: 3.2.7
       eslint: 8.49.0
       eslint-import-resolver-node: 0.3.9
@@ -4477,7 +4499,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.13.1(eslint@8.49.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.13.1(eslint@8.49.0)(typescript@5.4.2)
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
@@ -6173,7 +6195,7 @@ packages:
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  /msw@1.3.2(typescript@5.2.2):
+  /msw@1.3.2(typescript@5.4.2):
     resolution: {integrity: sha512-wKLhFPR+NitYTkQl5047pia0reNGgf0P6a1eTnA5aNlripmiz0sabMvvHcicE8kQ3/gZcI0YiPFWmYfowfm3lA==}
     engines: {node: '>=14'}
     hasBin: true
@@ -6202,7 +6224,7 @@ packages:
       path-to-regexp: 6.2.1
       strict-event-emitter: 0.4.6
       type-fest: 2.19.0
-      typescript: 5.2.2
+      typescript: 5.4.2
       yargs: 17.7.2
     transitivePeerDependencies:
       - encoding
@@ -6763,7 +6785,7 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  /prettier-plugin-organize-imports@3.2.3(prettier@3.0.3)(typescript@5.2.2):
+  /prettier-plugin-organize-imports@3.2.3(prettier@3.0.3)(typescript@5.4.2):
     resolution: {integrity: sha512-KFvk8C/zGyvUaE3RvxN2MhCLwzV6OBbFSkwZ2OamCrs9ZY4i5L77jQ/w4UmUr+lqX8qbaqVq6bZZkApn+IgJSg==}
     peerDependencies:
       '@volar/vue-language-plugin-pug': ^1.0.4
@@ -6777,7 +6799,7 @@ packages:
         optional: true
     dependencies:
       prettier: 3.0.3
-      typescript: 5.2.2
+      typescript: 5.4.2
     dev: false
 
   /prettier@2.8.8:
@@ -7814,6 +7836,16 @@ packages:
       typescript: '>=4.2.0'
     dependencies:
       typescript: 5.2.2
+    dev: true
+
+  /ts-api-utils@1.0.3(typescript@5.4.2):
+    resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
+    engines: {node: '>=16.13.0'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+    dependencies:
+      typescript: 5.4.2
+    dev: false
 
   /ts-expect@1.3.0:
     resolution: {integrity: sha512-e4g0EJtAjk64xgnFPD6kTBUtpnMVzDrMb12N1YZV0VvSlhnVT3SGxiYTLdGy8Q5cYHOIC/FAHmZ10eGrAguicQ==}
@@ -7830,14 +7862,14 @@ packages:
       code-block-writer: 12.0.0
     dev: false
 
-  /tsc-absolute@1.0.1(typescript@5.2.2):
+  /tsc-absolute@1.0.1(typescript@5.4.2):
     resolution: {integrity: sha512-GeN6O5T9t9rKRPEEtGB3pt2sc3ypa4jhVrAVWXDp/pggVW3p8FBLQz8s+5Sv56fjI4Fxe4gd4L6sxrjMAGbVlA==}
     hasBin: true
     peerDependencies:
       typescript: '>=4.6'
     dependencies:
       process-wrapper: 1.0.0
-      typescript: 5.2.2
+      typescript: 5.4.2
     dev: true
 
   /tsconfig-paths@3.14.2:
@@ -7855,7 +7887,7 @@ packages:
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
-  /tsup@7.2.0(typescript@5.2.2):
+  /tsup@7.2.0(typescript@5.4.2):
     resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}
     engines: {node: '>=16.14'}
     hasBin: true
@@ -7885,7 +7917,7 @@ packages:
       source-map: 0.8.0-beta.0
       sucrase: 3.34.0
       tree-kill: 1.2.2
-      typescript: 5.2.2
+      typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -8102,6 +8134,11 @@ packages:
 
   /typescript@5.2.2:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  /typescript@5.4.2:
+    resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,7 +79,7 @@ importers:
         specifier: ^1.10.13
         version: 1.10.13
       typescript:
-        specifier: ^5.3.2
+        specifier: ^5.4.2
         version: 5.4.2
       vitest:
         specifier: ^1.2.2


### PR DESCRIPTION
## Changes
* Upgrade to latest typescript on packages that can
* Sever ts references for the legacy package because the TS 4 doesn't play nicely with modern syntax
* Implement a helper so you can write network mocks faster and more correctly.


## Why the helper is great
* I dont need to know the url / copy it from the generated code.
* I dont need to copy/paste the request response
* I am forced to specify all the path parameter names and cant do too few or too many
* I get typesafety on the path params instead of `Record<string, string | string[]>` 
* I don't have to cast the path params to `string` because we know they aren't `string[]`

## Example
```
  handleOpenApiCall(
    executeQueryV2,
    ["ontologyApiName", "queryApiName"],
    async (req, res, ctx) => {
...
});
```
* The number of path params is inferred from `executeQueryV2` to be 2. Giving more or fewer as the names to use will fail.
* `req` is inferred to be `RestRequest<ExecuteQueryRequest, Record<"ontologyApiName" | "queryApiName", string>>`
  * Note it declares the body of the request type AND the path params.
* `res` is inferred to be `ResponseComposition<BaseAPIError | ExecuteQueryResponse>`. Now I get errors if I try to return JSON that doesn't match the type.
