### PR TITLE
Defend against empty action or object needing an export

### DIFF
--- a/packages/generator/changelog/@unreleased/pr-121.v2.yml
+++ b/packages/generator/changelog/@unreleased/pr-121.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Defend against empty action or object needing an export
+  links:
+  - https://github.com/palantir/osdk-ts/pull/121

--- a/packages/generator/src/v1.1/generatePerActionDataFiles.test.ts
+++ b/packages/generator/src/v1.1/generatePerActionDataFiles.test.ts
@@ -38,4 +38,17 @@ describe(generatePerActionDataFiles, () => {
       [`${BASE_PATH}/index.ts`]: expect.anything(),
     });
   });
+
+  it("guards against empty actions", async () => {
+    const helper = createMockMinimalFiles();
+    const BASE_PATH = "/foo/actions";
+    await generatePerActionDataFiles(
+      { ...TodoWireOntology, actionTypes: {} },
+      helper.minimalFiles,
+      BASE_PATH,
+      "",
+      true,
+    );
+    expect(helper.getFiles()[`${BASE_PATH}/index.ts`]).toEqual("export {};\n");
+  });
 });

--- a/packages/generator/src/v1.1/generatePerActionDataFiles.ts
+++ b/packages/generator/src/v1.1/generatePerActionDataFiles.ts
@@ -177,6 +177,7 @@ export async function generatePerActionDataFiles(
       )
         .join("\n")
     }
+    ${Object.keys(ontology.actionTypes).length === 0 ? "export {};" : ""}
       `),
   );
 }

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { mkdir, readdir, rmdir, writeFile } from "fs/promises";
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, it, test, vi } from "vitest";
 import { compileThis } from "../util/test/compileThis";
 import { createMockMinimalFiles } from "../util/test/createMockMinimalFiles";
 import { TodoWireOntology } from "../util/test/TodoWireOntology";
@@ -69,6 +69,21 @@ describe("generator", () => {
         BASE_PATH,
       )).rejects.toThrow();
     });
+  });
+
+  it("guards against empty objects", async () => {
+    const helper = createMockMinimalFiles();
+    const BASE_PATH = "/foo";
+    await generateClientSdkVersionTwoPointZero(
+      { ...TodoWireOntology, objectTypes: {} },
+      "",
+      helper.minimalFiles,
+      BASE_PATH,
+    );
+
+    expect(helper.getFiles()[`${BASE_PATH}/ontology/objects.ts`]).toEqual(
+      "export {};\n",
+    );
   });
 
   test.skip("runs generator locally", async () => {

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
@@ -148,6 +148,7 @@ export async function generateClientSdkVersionTwoPointZero(
         `export * from "./objects/${apiName}${importExt}";`
       ).join("\n")
     }
+    ${Object.keys(ontology.objectTypes).length === 0 ? "export {};" : ""}
     `),
   );
 }


### PR DESCRIPTION
Previously an empty list of actions would cause the generated code to have compile errors. Adding an empty `export {}` allows things to work as expected.