### PR TITLE
Remove count

### DIFF
--- a/packages/client/changelog/@unreleased/pr-125.v2.yml
+++ b/packages/client/changelog/@unreleased/pr-125.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Remove count
+  links:
+  - https://github.com/palantir/osdk-ts/pull/125

--- a/packages/client/src/query/aggregations/AggregationsClause.ts
+++ b/packages/client/src/query/aggregations/AggregationsClause.ts
@@ -17,9 +17,8 @@
 import type { ObjectOrInterfaceDefinition } from "@osdk/api";
 import type { AggregatableKeys } from "./AggregatableKeys.js";
 
-type StringAggregateOption = "approximateDistinct" | "count";
+type StringAggregateOption = "approximateDistinct";
 type NumericAggregateOption =
-  | "count"
   | "min"
   | "max"
   | "sum"


### PR DESCRIPTION
Remove count option from property aggregations as you can only do counts on whole objects