### PR TITLE
Update template READMEs with note about foundry.config.json

### DIFF
--- a/packages/create-app/templates/template-next-static-export/README.md.hbs
+++ b/packages/create-app/templates/template-next-static-export/README.md.hbs
@@ -1,6 +1,6 @@
 # {{project}}
 
-This project was generated with `@osdk/create-app` and demonstrates using the OSDK package `{{osdkPackage}}` with React on top of Next.js. Check out the [Next.js](https://nextjs.org/docs) docs for further configuration.
+This project was generated with [`@osdk/create-app`](https://www.npmjs.com/package/@osdk/create-app) and demonstrates using the Ontology SDK package `{{osdkPackage}}` with React on top of Next.js. Check out the [Next.js](https://nextjs.org/docs) docs for further configuration.
 
 ## Developing
 
@@ -15,7 +15,7 @@ Development configuration is stored in `.env.development`.
 {{#if corsProxy}}
 In order to make API requests to Foundry, a CORS proxy has been set up for local development which may be removed if the stack is configured to allow `http://localhost:8080` to load resources. The configured OAuth client must also allow `http://localhost:8080/auth/callback` as a redirect URL.
 {{else}}
-In order to make API requests to Foundry, CORS must be configured for the stack to allow `http://localhost:8080` to load resources. The configured OAuth client must also allow `http://localhost:8080/auth/callback` as a redirect URL.
+In order to make API requests to Foundry, CORS must be configured for the stack to allow `http://localhost:8080` to load resources. If this has not been configured and you are unable to request this, you can alternatively generate your project again with `--corsProxy true` to use a proxy for API requests during local development. The configured OAuth client must also allow `http://localhost:8080/auth/callback` as a redirect URL.
 {{/if}}
 
 ## Deploying
@@ -30,4 +30,6 @@ Production configuration is stored in `.env.production`.
 
 If you did not fill in the URL your production application will be hosted on you will need to fill in the `NEXT_PUBLIC_FOUNDRY_REDIRECT_URL` in `.env.production`.
 
-In order to make API requests to Foundry, CORS must be configured for the stack to allow the production origin to load resources. The configured OAuth client must also allow the production origin auth callback as a redirect URL.
+In order to make API requests to Foundry, CORS must be configured for the stack to allow the production origin to load resources. This will be automatically done for you if you are using Foundry website hosting. The configured OAuth client must also allow the production origin auth callback as a redirect URL.
+
+A `foundry.config.json` file is included in the root of this project to make deploying to Foundry website hosting with [`@osdk/cli`](https://www.npmjs.com/package/@osdk/cli) easier. If you are not using Foundry website hosting for your application you may delete this file.

--- a/packages/create-app/templates/template-react/README.md.hbs
+++ b/packages/create-app/templates/template-react/README.md.hbs
@@ -1,6 +1,6 @@
 # {{project}}
 
-This project was generated with `@osdk/create-app` and demonstrates using the OSDK package `{{osdkPackage}}` with React on top of Vite. Check out the [Vite](https://vitejs.dev/guide/) docs for further configuration.
+This project was generated with [`@osdk/create-app`](https://www.npmjs.com/package/@osdk/create-app) and demonstrates using the Ontology SDK package `{{osdkPackage}}` with React on top of Vite. Check out the [Vite](https://vitejs.dev/guide/) docs for further configuration.
 
 ## Developing
 
@@ -15,7 +15,7 @@ Development configuration is stored in `.env.development`.
 {{#if corsProxy}}
 In order to make API requests to Foundry, a CORS proxy has been set up for local development which may be removed if the stack is configured to allow `http://localhost:8080` to load resources. The configured OAuth client must also allow `http://localhost:8080/auth/callback` as a redirect URL.
 {{else}}
-In order to make API requests to Foundry, CORS must be configured for the stack to allow `http://localhost:8080` to load resources. The configured OAuth client must also allow `http://localhost:8080/auth/callback` as a redirect URL.
+In order to make API requests to Foundry, CORS must be configured for the stack to allow `http://localhost:8080` to load resources. If this has not been configured and you are unable to request this, you can alternatively generate your project again with `--corsProxy true` to use a proxy for API requests during local development. The configured OAuth client must also allow `http://localhost:8080/auth/callback` as a redirect URL.
 {{/if}}
 
 ## Deploying
@@ -30,4 +30,6 @@ Production configuration is stored in `.env.production`.
 
 If you did not fill in the URL your production application will be hosted on you will need to fill in the `VITE_FOUNDRY_REDIRECT_URL` in `.env.production`.
 
-In order to make API requests to Foundry, CORS must be configured for the stack to allow the production origin to load resources. The configured OAuth client must also allow the production origin auth callback as a redirect URL.
+In order to make API requests to Foundry, CORS must be configured for the stack to allow the production origin to load resources. This will be automatically done for you if you are using Foundry website hosting. The configured OAuth client must also allow the production origin auth callback as a redirect URL.
+
+A `foundry.config.json` file is included in the root of this project to make deploying to Foundry website hosting with [`@osdk/cli`](https://www.npmjs.com/package/@osdk/cli) easier. If you are not using Foundry website hosting for your application you may delete this file.

--- a/packages/create-app/templates/template-vue/README.md.hbs
+++ b/packages/create-app/templates/template-vue/README.md.hbs
@@ -1,6 +1,6 @@
 # {{project}}
 
-This project was generated with `@osdk/create-app` and demonstrates using the OSDK package `{{osdkPackage}}` with Vue on top of Vite. Check out the [Vite](https://vitejs.dev/guide/) docs for further configuration.
+This project was generated with [`@osdk/create-app`](https://www.npmjs.com/package/@osdk/create-app) and demonstrates using the Ontology SDK package `{{osdkPackage}}` with Vue on top of Vite. Check out the [Vite](https://vitejs.dev/guide/) docs for further configuration.
 
 ## Developing
 
@@ -15,7 +15,7 @@ Development configuration is stored in `.env.development`.
 {{#if corsProxy}}
 In order to make API requests to Foundry, a CORS proxy has been set up for local development which may be removed if the stack is configured to allow `http://localhost:8080` to load resources. The configured OAuth client must also allow `http://localhost:8080/auth/callback` as a redirect URL.
 {{else}}
-In order to make API requests to Foundry, CORS must be configured for the stack to allow `http://localhost:8080` to load resources. The configured OAuth client must also allow `http://localhost:8080/auth/callback` as a redirect URL.
+In order to make API requests to Foundry, CORS must be configured for the stack to allow `http://localhost:8080` to load resources. If this has not been configured and you are unable to request this, you can alternatively generate your project again with `--corsProxy true` to use a proxy for API requests during local development. The configured OAuth client must also allow `http://localhost:8080/auth/callback` as a redirect URL.
 {{/if}}
 
 ## Deploying
@@ -30,4 +30,6 @@ Production configuration is stored in `.env.production`.
 
 If you did not fill in the URL your production application will be hosted on you will need to fill in the `VITE_FOUNDRY_REDIRECT_URL` in `.env.production`.
 
-In order to make API requests to Foundry, CORS must be configured for the stack to allow the production origin to load resources. The configured OAuth client must also allow the production origin auth callback as a redirect URL.
+In order to make API requests to Foundry, CORS must be configured for the stack to allow the production origin to load resources. This will be automatically done for you if you are using Foundry website hosting. The configured OAuth client must also allow the production origin auth callback as a redirect URL.
+
+A `foundry.config.json` file is included in the root of this project to make deploying to Foundry website hosting with [`@osdk/cli`](https://www.npmjs.com/package/@osdk/cli) easier. If you are not using Foundry website hosting for your application you may delete this file.


### PR DESCRIPTION
- Explain that a `foundry.config.json` file is created and can be deleted if not using Foundry website hosting
- Add instruction that `--corsProxy true` can be used if needed for local development
- Add detail that with Foundry website hosting CORS is automatically set up for production
- Link to NPM packages (will pick up https://github.com/palantir/osdk-ts/pull/92 when it's merged)