### PR TITLE
Fix array and string filters

### DIFF
--- a/examples-extra/docs_example/ontology.json
+++ b/examples-extra/docs_example/ontology.json
@@ -378,6 +378,24 @@
             "dataType": {
               "type": "string"
             }
+          },
+          "meetingRooms": {
+            "description": "The Names of meetings rooms in the fofice",
+            "dataType": {
+              "type": "array",
+              "subType": {
+                "type": "string"
+              }
+            }
+          },
+          "meetingRoomCapacities": {
+            "description": "The individual capacities of meetings rooms in the fofice",
+            "dataType": {
+              "type": "array",
+              "subType": {
+                "type": "integer"
+              }
+            }
           }
         },
         "rid": "ri.ontology.main.object-type.404ac022-89eb-4591-8b7e-1a912b9efb45",

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Office.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Office.ts
@@ -7,6 +7,8 @@ export interface Office extends ObjectTypeDefinition<'Office', Office> {
   primaryKeyType: 'string';
   properties: {
     entrance: PropertyDef<'geopoint', 'nullable', 'single'>;
+    meetingRoomCapacities: PropertyDef<'integer', 'nullable', 'array'>;
+    meetingRooms: PropertyDef<'string', 'nullable', 'array'>;
     name: PropertyDef<'string', 'nullable', 'single'>;
     occupiedArea: PropertyDef<'geoshape', 'nullable', 'single'>;
     officeId: PropertyDef<'string', 'non-nullable', 'single'>;
@@ -40,6 +42,18 @@ export const Office: Office = {
       multiplicity: false,
       description: 'The Name of the Office',
       type: 'string',
+      nullable: true,
+    },
+    meetingRooms: {
+      multiplicity: true,
+      description: 'The Names of meetings rooms in the fofice',
+      type: 'string',
+      nullable: true,
+    },
+    meetingRoomCapacities: {
+      multiplicity: true,
+      description: 'The individual capacities of meetings rooms in the fofice',
+      type: 'integer',
       nullable: true,
     },
   },

--- a/examples-extra/docs_example/src/osdkExample.tsx
+++ b/examples-extra/docs_example/src/osdkExample.tsx
@@ -24,16 +24,16 @@ export async function osdkObjectSetExample() {
   // Simple where clause
   // This defaults to AND together all the parameters
   const simpleFilteredEmployeeObjectSet = await client(Employee).where({
-    fullName: { $contains: "Clooney" },
+    fullName: { $startsWith: "Clooney" },
     employeeId: { $eq: 12 },
   });
 
   // Where clause with ors, ands, nots
   const complexFilteredEmployeeObjectSet = await client(Employee).where({
-    $or: [{ fullName: { $contains: "Clooney" }, employeeId: { $gt: 10 } }, {
-      $and: [{ $not: { fullName: { $contains: "Pitt" } } }, {
-        $or: [{ fullName: { $contains: "Downey" } }, {
-          fullName: { $startsWith: "Hemsworth" },
+    $or: [{ fullName: { $startsWith: "Clooney" }, employeeId: { $gt: 10 } }, {
+      $and: [{ $not: { fullName: { $containsAllTerms: "Pitt Redford" } } }, {
+        $or: [{ fullName: { $containsAnyTerm: "Downey Evans Scott" } }, {
+          fullName: { $containsAllTermsInOrder: "Hemsworth Pratt Tucker" },
           employeeId: { $gte: 20 },
         }],
       }],
@@ -43,6 +43,13 @@ export async function osdkObjectSetExample() {
   // Where clause boolean
 
   await client(Todo).where({ isComplete: true });
+
+  // Where clause arrays
+
+  await client(Office).where({
+    meetingRooms: { $contains: "Grand Central" },
+    meetingRoomCapacities: { $contains: 30 },
+  });
 
   // Where clause GEOTYPES
 


### PR DESCRIPTION
Realized that the `contains` filter only works on array properties, so fixed that in the OSDK. Also added remaining string filters while I was there