### PR TITLE
Minor improvements everywhere

### DIFF
--- a/examples-extra/basic/cli/src/index.ts
+++ b/examples-extra/basic/cli/src/index.ts
@@ -107,6 +107,22 @@ async function runTests() {
     //   throw new Error("Should not be allowed to convert between mixed types");
     // }
 
+    // {
+    //   const { data } = await client(Employee).fetchPage();
+    //   console.log(data[0].$link);
+    //   console.log("link keys", Object.keys(data[0].$link));
+    //   console.log(data[0].$link.lead);
+    //   console.log(data[0].$link.peeps);
+    //   console.log((data[0].$link as any).comments);
+    // }
+
+    // this has the nice effect of faking a 'race' with the below code
+    (async () => {
+      const { data } = await client(FooInterface).fetchPage();
+      const first = data[0];
+      const e = first.$as(Employee);
+    })();
+
     try {
       const r = true
         ? await client(FooInterface)

--- a/examples-extra/basic/sdk/ontology.json
+++ b/examples-extra/basic/sdk/ontology.json
@@ -386,8 +386,8 @@
       ],
       "implementsInterfaces": ["FooInterface"],
       "sharedPropertyTypeMapping": {
-        "firstName": "name",
-        "email": "description"
+        "name": "firstName",
+        "description": "email"
       }
     },
     "Venture": {

--- a/examples-extra/basic/sdk/src/generatedNoCheck/ontology/objects/Employee.ts
+++ b/examples-extra/basic/sdk/src/generatedNoCheck/ontology/objects/Employee.ts
@@ -6,8 +6,8 @@ export interface Employee extends ObjectTypeDefinition<'Employee', Employee> {
   description: 'An employee';
   implements: ['FooInterface'];
   inverseSpts: {
-    name: 'firstName';
-    description: 'email';
+    firstName: 'name';
+    email: 'description';
   };
   links: {
     lead: ObjectTypeLinkDefinition<Employee, false>;
@@ -31,8 +31,8 @@ export interface Employee extends ObjectTypeDefinition<'Employee', Employee> {
     locationType: PropertyDef<'string', 'nullable', 'single'>;
   };
   spts: {
-    firstName: 'name';
-    email: 'description';
+    name: 'firstName';
+    description: 'email';
   };
 }
 
@@ -41,8 +41,8 @@ export const Employee: Employee = {
   description: 'An employee',
   implements: ['FooInterface'],
   inverseSpts: {
-    name: 'firstName',
-    description: 'email',
+    firstName: 'name',
+    email: 'description',
   },
   links: {
     lead: {
@@ -123,8 +123,8 @@ export const Employee: Employee = {
     },
   },
   spts: {
-    firstName: 'name',
-    email: 'description',
+    name: 'firstName',
+    description: 'email',
   },
   type: 'object',
 };

--- a/monorepo/tsconfig/tsconfig.base.json
+++ b/monorepo/tsconfig/tsconfig.base.json
@@ -6,6 +6,7 @@
     "moduleResolution": "nodenext",
 
     "emitDeclarationOnly": true,
+    "declarationMap": true,
     "declaration": true,
 
     "isolatedModules": true,

--- a/packages/api/changelog/@unreleased/pr-131.v2.yml
+++ b/packages/api/changelog/@unreleased/pr-131.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Minor improvements everywhere
+  links:
+  - https://github.com/palantir/osdk-ts/pull/131

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -39,6 +39,7 @@ export type {
   ObjectOrInterfacePropertyKeysFrom2,
 } from "./ontology/ObjectOrInterface";
 export type {
+  BrandedApiName,
   ObjectTypeDefinition,
   ObjectTypeDefinitionFrom,
   ObjectTypeKeysFrom,

--- a/packages/api/src/ontology/ObjectTypeDefinition.ts
+++ b/packages/api/src/ontology/ObjectTypeDefinition.ts
@@ -49,7 +49,7 @@ export type ObjectTypePropertyDefinitionFrom2<
 
 export interface ObjectInterfaceBaseDefinition<K extends string, N = unknown> {
   type: "object" | "interface";
-  apiName: K & { __OsdkType?: N };
+  apiName: BrandedApiName<K, N>;
   description?: string;
   properties: Record<string, ObjectTypePropertyDefinition>;
   links: Record<
@@ -100,6 +100,16 @@ export type ObjectTypeLinkTargetTypeFrom<
   K extends ObjectTypeKeysFrom<O>,
   L extends ObjectTypeLinkKeysFrom<O, K>,
 > = ObjectTypeLinkDefinitionFrom<O, K, L>["targetType"];
+
+export type BrandedApiName<
+  K extends string,
+  N,
+> =
+  & K
+  & {
+    __OsdkType?: N;
+    __Unbranded?: K;
+  };
 
 export interface ObjectTypePropertyDefinition {
   readonly?: boolean;

--- a/packages/cli/changelog/@unreleased/pr-131.v2.yml
+++ b/packages/cli/changelog/@unreleased/pr-131.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Minor improvements everywhere
+  links:
+  - https://github.com/palantir/osdk-ts/pull/131

--- a/packages/cli/src/commands/typescript/generate/TypescriptGenerateArgs.ts
+++ b/packages/cli/src/commands/typescript/generate/TypescriptGenerateArgs.ts
@@ -23,4 +23,5 @@ export interface TypescriptGenerateArgs {
   beta?: boolean;
   packageType: "commonjs" | "module";
   version: string;
+  ontologyRid?: string;
 }

--- a/packages/cli/src/commands/typescript/generate/generate.ts
+++ b/packages/cli/src/commands/typescript/generate/generate.ts
@@ -55,6 +55,11 @@ export const command: CommandModule<
             conflicts: "ontologyPath",
             implies: "foundryUrl",
           },
+          ontologyRid: {
+            description: "Limit requests to this ontology rid only",
+            type: "string",
+            demandOption: false,
+          },
           ontologyWritePath: {
             description: "Path to write the ontology wire json",
             type: "string",

--- a/packages/cli/src/commands/typescript/generate/handleGenerate.mts
+++ b/packages/cli/src/commands/typescript/generate/handleGenerate.mts
@@ -91,6 +91,12 @@ async function generateFromStack(args: TypescriptGenerateArgs) {
       createOpenApiRequest(foundryUrl, fetch),
     );
 
+    if (args.ontologyRid) {
+      ontologies.data = ontologies.data.filter(
+        (o) => o.rid === args.ontologyRid,
+      );
+    }
+
     if (ontologies.data.length !== 1) {
       consola.error(
         `Could not look up ontology with these credentials. Found ${ontologies.data.length} ontologies.`,

--- a/packages/client/changelog/@unreleased/pr-131.v2.yml
+++ b/packages/client/changelog/@unreleased/pr-131.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Minor improvements everywhere
+  links:
+  - https://github.com/palantir/osdk-ts/pull/131

--- a/packages/client/src/OsdkObject.ts
+++ b/packages/client/src/OsdkObject.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export type OsdkObject<N extends string> = { $apiName: N };
+export type OsdkObject<N extends string> = { $apiName: N; $objectType: string };

--- a/packages/client/src/OsdkObjectFrom.test.ts
+++ b/packages/client/src/OsdkObjectFrom.test.ts
@@ -133,4 +133,21 @@ describe("Osdk", () => {
       >
     >().toEqualTypeOf<"fullName">();
   });
+
+  it("falls back to all props as undefined when never", () => {
+    expectTypeOf<
+      Omit<
+        Osdk<FooInterface, never>,
+        | "$as"
+        | "$apiName"
+        | "__apiName"
+        | "$link"
+        | "__primaryKey"
+        | "$objectType"
+        | "$primaryKey"
+      >
+    >().toEqualTypeOf<
+      { fooSpt: string | undefined }
+    >();
+  });
 });

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -44,3 +44,5 @@ export type { NOOP } from "./util/NOOP.js";
 
 export { createMinimalClient } from "./createMinimalClient.js";
 export type { MinimalClient } from "./MinimalClientContext.js";
+
+export { augment } from "./object/fetchPage.js";

--- a/packages/client/src/object/convertWireToOsdkObjects.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.test.ts
@@ -20,7 +20,10 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { Client } from "../Client.js";
 import { createClient } from "../createClient.js";
 import { createMinimalClient } from "../createMinimalClient.js";
-import { Ontology as MockOntology } from "../generatedNoCheck/index.js";
+import {
+  Employee,
+  Ontology as MockOntology,
+} from "../generatedNoCheck/index.js";
 import { Attachment } from "./Attachment.js";
 import { convertWireToOsdkObjects } from "./convertWireToOsdkObjects.js";
 
@@ -38,6 +41,29 @@ describe("convertWireToOsdkObjects", () => {
 
   afterAll(() => {
     apiServer.close();
+  });
+
+  it("configures properties correctly", async () => {
+    const { data: [employee] } = await client(Employee).fetchPage();
+
+    expect(Object.keys(employee)).toEqual([
+      "employeeId",
+      "fullName",
+      "office",
+      "class",
+      "startDate",
+      "employeeStatus",
+      "$apiName",
+      "$objectType",
+      "$primaryKey",
+    ]);
+
+    expect(Object.keys(employee.$as)).toEqual([]);
+    expect(Object.keys(employee.$link)).toEqual([
+      "peeps",
+      "lead",
+      "officeLink",
+    ]);
   });
 
   it("reuses the object prototype across objects", async () => {

--- a/packages/client/src/objectSet/ObjectSet.ts
+++ b/packages/client/src/objectSet/ObjectSet.ts
@@ -26,6 +26,7 @@ import type {
 import type { PropertyValueClientToWire } from "../mapping/PropertyValueMapping.js";
 import type { AggregateOptsThatErrors } from "../object/aggregate.js";
 import type {
+  Augments,
   FetchPageArgs,
   FetchPageResult,
   SelectArg,
@@ -40,8 +41,9 @@ export interface MinimalObjectSet<Q extends ObjectOrInterfaceDefinition> {
   fetchPage: <
     L extends ObjectOrInterfacePropertyKeysFrom2<Q>,
     R extends boolean,
+    const A extends Augments,
   >(
-    args?: FetchPageArgs<Q, L, R>,
+    args?: FetchPageArgs<Q, L, R, A>,
   ) => FetchPageResult<Q, L, R>;
 
   where: (

--- a/packages/foundry-sdk-generator/changelog/pr-131.v2.yml
+++ b/packages/foundry-sdk-generator/changelog/pr-131.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Minor improvements everywhere
+  links:
+  - https://github.com/palantir/osdk-ts/pull/131

--- a/packages/foundry-sdk-generator/src/__e2e_tests__/__snapshots__/metadataResolver.test.ts.snap
+++ b/packages/foundry-sdk-generator/src/__e2e_tests__/__snapshots__/metadataResolver.test.ts.snap
@@ -103,7 +103,7 @@ exports[`Load Ontologies Metadata > Loads object and action types using only spe
         "titleProperty": "fullName",
       },
       "sharedPropertyTypeMapping": {
-        "fullName": "fooSpt",
+        "fooSpt": "fullName",
       },
     },
     "Office": {
@@ -243,7 +243,7 @@ exports[`Load Ontologies Metadata > Loads object and action types without link t
         "titleProperty": "fullName",
       },
       "sharedPropertyTypeMapping": {
-        "fullName": "fooSpt",
+        "fooSpt": "fullName",
       },
     },
   },

--- a/packages/shared.test/changelog/@unreleased/pr-131.v2.yml
+++ b/packages/shared.test/changelog/@unreleased/pr-131.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Minor improvements everywhere
+  links:
+  - https://github.com/palantir/osdk-ts/pull/131

--- a/packages/shared.test/src/mock-ontology/ObjectTypeWithAllPropertyTypes.ts
+++ b/packages/shared.test/src/mock-ontology/ObjectTypeWithAllPropertyTypes.ts
@@ -147,7 +147,7 @@ export interface ObjectTypeWithAllPropertyTypesDef
 export const ObjectTypeWithAllPropertyTypes: ObjectTypeWithAllPropertyTypesDef =
   {
     type: "object",
-    apiName: "ObjectTypeWithAllPropertyTypes",
+    apiName: "ObjectTypeWithAllPropertyTypes" as const,
     primaryKeyApiName: "id" as const,
     primaryKeyType: "integer",
     links: {},

--- a/packages/shared.test/src/stubs/objectTypesWithLinkTypes.ts
+++ b/packages/shared.test/src/stubs/objectTypesWithLinkTypes.ts
@@ -34,7 +34,7 @@ export const employeeObjectWithLinkTypes: ObjectTypeFullMetadata = {
   linkTypes: [peepsLinkType, leadLinkType, officeLinkType],
   implementsInterfaces: ["FooInterface"],
   sharedPropertyTypeMapping: {
-    fullName: "fooSpt",
+    fooSpt: "fullName",
   },
 };
 


### PR DESCRIPTION
- @osdk/cli typescript generator learns `--ontologyRid` optional argument to limit which ontologies are considered when you use a `--clientId` that is open ended.
- `apiName` on `ObjectInterfaceBaseDefinition` gets a stronger brand so we can select out the raw string without the brand
- `console.log(someObj.$link)` now prints something like `{ lead: [class ObjectSet], peeps: [class ObjectSet] }` instead of `{}`
- Using `fetchPage` with an interface now properly removes `$rid` unless you requested it (prototype interfaces backend always returns $rid sadly, meaning console.log()/JSON.stringify() does the wrong thing)
- `fetchPage` learns to `augment` interface queries for additional properties
- `OsdkObject` gets the `$objectType` field added to its type (value was already there)
- `Osdk<SomeType, never>` now returns all property types, however unions them with `undefined` since we don't know anything about them. You
- The test data had the spt maps inverted from the way the backend returns them, causing real ontology's we fetch to be represented wrong. This is now fixed