### PR TITLE
Drop rid boolean for "$rid"

### DIFF
--- a/examples-extra/basic/cli/src/index.ts
+++ b/examples-extra/basic/cli/src/index.ts
@@ -107,15 +107,6 @@ async function runTests() {
     //   throw new Error("Should not be allowed to convert between mixed types");
     // }
 
-    // {
-    //   const { data } = await client(Employee).fetchPage();
-    //   console.log(data[0].$link);
-    //   console.log("link keys", Object.keys(data[0].$link));
-    //   console.log(data[0].$link.lead);
-    //   console.log(data[0].$link.peeps);
-    //   console.log((data[0].$link as any).comments);
-    // }
-
     // this has the nice effect of faking a 'race' with the below code
     (async () => {
       const { data } = await client(FooInterface).fetchPage();
@@ -130,10 +121,11 @@ async function runTests() {
           .where({ name: { $ne: "Roth" } })
           .fetchPage({ pageSize: 1, select: ["name"] })
         : await fetchPage(clientCtx, FooInterface, {
-          select: ["name", "description"],
+          select: ["name"],
           pageSize: 5,
         });
 
+      // This technically matches because the types are `| undefined`
       expectType<TypeOf<typeof r, PageResult<Osdk<FooInterface, "$all">>>>(
         true,
       );

--- a/packages/client/changelog/@unreleased/pr-133.v2.yml
+++ b/packages/client/changelog/@unreleased/pr-133.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Drop rid boolean for "$rid"
+  links:
+  - https://github.com/palantir/osdk-ts/pull/133

--- a/packages/client/src/OsdkObjectFrom.test.ts
+++ b/packages/client/src/OsdkObjectFrom.test.ts
@@ -65,11 +65,10 @@ describe("Osdk", () => {
   class OsdkAsHelperClass<
     FROM extends ObjectOrInterfaceDefinition,
     P extends string,
-    R extends boolean,
     Z extends string,
     TO extends ValidToFrom<FROM>,
   > {
-    constructor(private osdkObj: Osdk<FROM, P, R, Z>) {}
+    constructor(private osdkObj: Osdk<FROM, P, Z>) {}
 
     public as(to: TO) {
       return this.osdkObj.$as(to);
@@ -78,13 +77,12 @@ describe("Osdk", () => {
   type OsdkAsHelper<
     FROM extends ObjectOrInterfaceDefinition,
     P extends string,
-    R extends boolean,
     Z extends string,
     TO extends ValidToFrom<FROM>,
-  > = ReturnType<OsdkAsHelperClass<FROM, P, R, Z, TO>["as"]>;
+  > = ReturnType<OsdkAsHelperClass<FROM, P, Z, TO>["as"]>;
 
-  type GetUnderlyingProps<O extends Osdk<any, any, boolean, string>> = O extends
-    Osdk<any, any, any, infer Z> ? Z : never;
+  type GetUnderlyingProps<O extends Osdk<any, any, any>> = O extends
+    Osdk<any, any, infer Z> ? Z : never;
 
   describe("the reason for this weird test", () => {
     it("can't properly compare the retained types without it", () => {
@@ -93,31 +91,36 @@ describe("Osdk", () => {
       // This should fail but it doesnt. We dont actively capture Z
       // (and we cant)
       expectTypeOf<
-        OsdkAsHelper<Employee, "fullName", false, "fullName", FooInterface>
+        OsdkAsHelper<Employee, "fullName", "fullName", FooInterface>
       >().toEqualTypeOf<
-        Osdk<FooInterface, "fooSpt", false, InvalidPropertyName>
+        Osdk<FooInterface, "fooSpt", InvalidPropertyName>
       >();
 
       // See, when we dig via infer we find it doesnt match
       expectTypeOf<
         GetUnderlyingProps<
-          OsdkAsHelper<Employee, "fullName", false, "fullName", FooInterface>
+          OsdkAsHelper<Employee, "fullName", "fullName", FooInterface>
         >
       >().not.toEqualTypeOf<InvalidPropertyName>();
 
       // and that it can match correctly
       expectTypeOf<
         GetUnderlyingProps<
-          OsdkAsHelper<Employee, "fullName", false, "fullName", FooInterface>
+          OsdkAsHelper<Employee, "fullName", "fullName", FooInterface>
         >
       >().toEqualTypeOf<"fullName">();
+
+      // converting to self preserves the original props
+      expectTypeOf<
+        OsdkAsHelper<FooInterface, "fooSpt", "fullName", FooInterface>
+      >().toEqualTypeOf<Osdk<FooInterface, "fooSpt", "fullName">>();
     });
   });
 
   it("Converts into self properly", () => {
     expectTypeOf<
       GetUnderlyingProps<
-        OsdkAsHelper<FooInterface, "fooSpt", false, "fullName", FooInterface>
+        OsdkAsHelper<FooInterface, "fooSpt", "fullName", FooInterface>
       >
     >().toEqualTypeOf<"fullName">();
 
@@ -129,7 +132,7 @@ describe("Osdk", () => {
   it("retains original props if set", () => {
     expectTypeOf<
       GetUnderlyingProps<
-        OsdkAsHelper<Employee, "fullName", false, "fullName", FooInterface>
+        OsdkAsHelper<Employee, "fullName", "fullName", FooInterface>
       >
     >().toEqualTypeOf<"fullName">();
   });

--- a/packages/client/src/definitions/LinkDefinitions.ts
+++ b/packages/client/src/definitions/LinkDefinitions.ts
@@ -57,6 +57,6 @@ export interface SingleLinkAccessor<T extends ObjectTypeDefinition<any>> {
   ) => Promise<
     DefaultToFalse<A["includeRid"]> extends false
       ? Osdk<T, SelectArgToKeys<T, A>>
-      : Osdk<T, SelectArgToKeys<T, A>, DefaultToFalse<A["includeRid"]>>
+      : Osdk<T, SelectArgToKeys<T, A> | "$rid">
   >;
 }

--- a/packages/client/src/internal/conversions/modernToLegacyWhereClause.ts
+++ b/packages/client/src/internal/conversions/modernToLegacyWhereClause.ts
@@ -115,7 +115,10 @@ function handleWherePair([field, filter]: [string, any]): SearchJsonQueryV2 {
     "Defined key values are only allowed when they are not undefined.",
   );
 
-  if (typeof filter === "string" || typeof filter === "number") {
+  if (
+    typeof filter === "string" || typeof filter === "number"
+    || typeof filter === "boolean"
+  ) {
     return {
       type: "eq",
       field,
@@ -137,7 +140,9 @@ function handleWherePair([field, filter]: [string, any]): SearchJsonQueryV2 {
   if (!hasDollarSign) {
     // Future case for structs
     throw new Error(
-      "Unsupported filter. Did you forget to use a $-prefixed filter?",
+      `Unsupported filter. Did you forget to use a $-prefixed filter? (${
+        JSON.stringify(filter)
+      })`,
     );
   }
 

--- a/packages/client/src/object/fetchPage.test.ts
+++ b/packages/client/src/object/fetchPage.test.ts
@@ -18,7 +18,12 @@ import type { ObjectTypeDefinition } from "@osdk/api";
 import type { SearchJsonQueryV2 } from "@osdk/gateway/types";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { createMinimalClient } from "../createMinimalClient.js";
-import type { FetchPageArgs, SelectArgToKeys } from "../object/fetchPage.js";
+import type { FooInterface } from "../generatedNoCheck/index.js";
+import type {
+  FetchPageArgs,
+  FetchPageResult,
+  SelectArgToKeys,
+} from "../object/fetchPage.js";
 import { fetchPage, objectSetToSearchJsonV2 } from "../object/fetchPage.js";
 import {
   createObjectSet,
@@ -146,5 +151,53 @@ describe(fetchPage, () => {
         ],
       } satisfies SearchJsonQueryV2,
     );
+  });
+
+  describe("includeRid", () => {
+    it("properly returns the correct string for includeRid", () => {
+      expectTypeOf<Awaited<FetchPageResult<TodoDef, "text", false>>>()
+        .toEqualTypeOf<{
+          data: Osdk<TodoDef, "text">[];
+          nextPageToken: string | undefined;
+        }>();
+
+      expectTypeOf<Awaited<FetchPageResult<TodoDef, "text", true>>>()
+        .toEqualTypeOf<{
+          data: Osdk<TodoDef, "text" | "$rid">[];
+          nextPageToken: string | undefined;
+        }>();
+    });
+
+    it("works with $all", () => {
+      expectTypeOf<Awaited<FetchPageResult<TodoDef, "text" | "id", false>>>()
+        .toEqualTypeOf<{
+          data: Osdk<TodoDef>[];
+          nextPageToken: string | undefined;
+        }>();
+
+      expectTypeOf<Awaited<FetchPageResult<TodoDef, "text" | "id", true>>>()
+        .toEqualTypeOf<{
+          data: Osdk<TodoDef, "$all" | "$rid">[];
+          nextPageToken: string | undefined;
+        }>();
+
+      expectTypeOf<Awaited<FetchPageResult<TodoDef, "text" | "id", true>>>()
+        .toEqualTypeOf<{
+          data: Osdk<TodoDef, "$all" | "$rid", "$all" | "$rid">[];
+          nextPageToken: string | undefined;
+        }>();
+
+      expectTypeOf<Awaited<FetchPageResult<FooInterface, "fooSpt", true>>>()
+        .toEqualTypeOf<{
+          data: Osdk<FooInterface, "$all" | "$rid", never>[];
+          nextPageToken: string | undefined;
+        }>();
+
+      expectTypeOf<Awaited<FetchPageResult<FooInterface, "fooSpt", true>>>()
+        .toEqualTypeOf<{
+          data: Osdk<FooInterface, "$all" | "$rid">[];
+          nextPageToken: string | undefined;
+        }>();
+    });
   });
 });

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -123,20 +123,9 @@ export type FetchPageResult<
   R extends boolean,
 > = Promise<
   PageResult<
-    ObjectOrInterfacePropertyKeysFrom2<Q> extends L ? (
-        DefaultToFalse<R> extends false ? Osdk<Q>
-          : Osdk<
-            Q,
-            "$all",
-            true,
-            Q extends InterfaceDefinition<any> ? "$all" : L
-          >
-      )
-      : (
-        DefaultToFalse<R> extends false
-          ? Osdk<Q, L, false, Q extends InterfaceDefinition<any> ? never : L>
-          : Osdk<Q, L, true, Q extends InterfaceDefinition<any> ? never : L>
-      )
+    ObjectOrInterfacePropertyKeysFrom2<Q> extends L
+      ? (DefaultToFalse<R> extends false ? Osdk<Q> : Osdk<Q, "$all" | "$rid">)
+      : (DefaultToFalse<R> extends false ? Osdk<Q, L> : Osdk<Q, L | "$rid">)
   >
 >;
 

--- a/packages/client/src/object/fetchSingle.ts
+++ b/packages/client/src/object/fetchSingle.ts
@@ -35,8 +35,8 @@ export async function fetchSingle<
 ): Promise<
   Osdk<
     Q,
-    SelectArgToKeys<Q, A>,
-    A["includeRid"] extends true ? true : false
+    A["includeRid"] extends true ? SelectArgToKeys<Q, A> | "$rid"
+      : SelectArgToKeys<Q, A>
   >
 > {
   const result = await fetchPage(


### PR DESCRIPTION
chains to #131

* Simplifies types so that getting a rid is now `Osdk<Foo, "selectedProp" | "$rid">` instead of `Osdk<Foo, "selectedProp", true>`. 
* Fixes bug where you couldn't do a where clause on a boolean.