### PR TITLE
change application url prompt

### DIFF
--- a/packages/create-app/src/prompts/promptApplicationUrl.ts
+++ b/packages/create-app/src/prompts/promptApplicationUrl.ts
@@ -33,8 +33,12 @@ export async function promptApplicationUrl(
       {
         type: "select",
         options: [
-          { label: "Yes, prefill it for me", value: "yes" },
-          { label: "No, I will fill it in myself later", value: "no" },
+          { label: "Yes, let me fill it here", value: "yes" },
+          {
+            label:
+              "No, I will set `VITE_FOUNDRY_REDIRECT_URL` variable in `.env.production` file later",
+            value: "no",
+          },
         ],
       },
       // Types for "select" are wrong the value is returned rather than the option object

--- a/packages/create-app/src/prompts/promptApplicationUrl.ts
+++ b/packages/create-app/src/prompts/promptApplicationUrl.ts
@@ -35,8 +35,7 @@ export async function promptApplicationUrl(
         options: [
           { label: "Yes, let me fill it here", value: "yes" },
           {
-            label:
-              "No, I will set `VITE_FOUNDRY_REDIRECT_URL` variable in `.env.production` file later",
+            label: "No, I will set `VITE_FOUNDRY_REDIRECT_URL` variable later",
             value: "no",
           },
         ],

--- a/packages/create-app/src/prompts/promptApplicationUrl.ts
+++ b/packages/create-app/src/prompts/promptApplicationUrl.ts
@@ -36,7 +36,7 @@ export async function promptApplicationUrl(
           { label: "Yes, let me fill it here", value: "yes" },
           {
             label:
-              "No, I will set it up later based on the instructions in the README",
+              "No, I will fill it in later following the instructions in the generated README",
             value: "no",
           },
         ],

--- a/packages/create-app/src/prompts/promptApplicationUrl.ts
+++ b/packages/create-app/src/prompts/promptApplicationUrl.ts
@@ -35,7 +35,8 @@ export async function promptApplicationUrl(
         options: [
           { label: "Yes, let me fill it here", value: "yes" },
           {
-            label: "No, I will set `VITE_FOUNDRY_REDIRECT_URL` variable later",
+            label:
+              "No, I will set it up later based on the instructions in the README",
             value: "no",
           },
         ],


### PR DESCRIPTION
Application url prompt in `create-app` is confusing
`Do you know the URL your production application will be hosted on? This is required to create a production build of your application with the correct OAuth redirect URL.` options are:
`Yes, prefill it for me` - this reads like the app will pre-fill the url for me when we actually want the user to provide the url on the next prompt
`No, I will fill it manually later` - we don't instruct the user where we expect them to fill it. 

This PR suggest a different language for both ahead of a user testing. 