### PR TITLE
Fix action imports for object array params 

### DIFF
--- a/examples-extra/docs_example/ontology.json
+++ b/examples-extra/docs_example/ontology.json
@@ -39,9 +39,9 @@
         "Todo": {
           "description": "A todo Object",
           "dataType": {
-            "type": "object",
-            "objectApiName": "Todo",
-            "objectTypeApiName": "Todo"
+            "type": "array",
+
+            "subType": { "type": "object", "objectApiName": "Todo", "objectTypeApiName": "Todo" }
           },
           "required": true
         },

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/actions/completeTodo.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/actions/completeTodo.ts
@@ -11,7 +11,7 @@ export type ActionDef$completeTodo$Params = {
   };
   Todo: {
     description: 'A todo Object';
-    multiplicity: false;
+    multiplicity: true;
     nullable: false;
     type: ObjectActionDataType<'Todo', Todo>;
   };
@@ -42,7 +42,7 @@ export const completeTodo: ActionDef$completeTodo = {
   apiName: 'completeTodo',
   parameters: {
     Todo: {
-      multiplicity: false,
+      multiplicity: true,
       type: {
         type: 'object',
         object: 'Todo',

--- a/packages/generator/changelog/@unreleased/pr-138.v2.yml
+++ b/packages/generator/changelog/@unreleased/pr-138.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix action params
+  links:
+  - https://github.com/palantir/osdk-ts/pull/138

--- a/packages/generator/src/util/test/TodoWireOntology.ts
+++ b/packages/generator/src/util/test/TodoWireOntology.ts
@@ -45,6 +45,31 @@ export const TodoWireOntology = {
       }],
       status: "ACTIVE",
     },
+    "deleteTodos": {
+      apiName: "deleteTodos",
+      description: "An action which takes in an array of objects",
+      parameters: {
+        object: {
+          description: "Todo(s) to be deleted",
+          "dataType": {
+            "type": "array",
+
+            "subType": {
+              "type": "object",
+              "objectApiName": "Todo",
+              "objectTypeApiName": "Todo",
+            },
+          },
+          required: false,
+        },
+      },
+      rid: "ri.ontology.main.action-type.8f94017d-cf17-4fa8-84c3-8e01e5d594f2",
+      operations: [{
+        type: "deleteObject",
+        objectTypeApiName: "Todo",
+      }],
+      status: "ACTIVE",
+    },
   },
   objectTypes: {
     Todo: {

--- a/packages/generator/src/v1.1/generateActions.test.ts
+++ b/packages/generator/src/v1.1/generateActions.test.ts
@@ -53,6 +53,17 @@ describe(generateActions, () => {
             },
             options?: O,
           ): Promise<Result<ActionResponseFromOptions<O, Edits<void, Todo>>, ActionError>>;
+
+          /**
+           * An action which takes in an array of objects
+           * @param {Array<Todo | Todo["__primaryKey"]>} params.object
+           */
+          deleteTodos<O extends ActionExecutionOptions>(
+            params: {
+              object?: Array<Todo | Todo['__primaryKey']>;
+            },
+            options?: O,
+          ): Promise<Result<ActionResponseFromOptions<O, Edits<void, void>>, ActionError>>;
         }
         "
       `);

--- a/packages/generator/src/v1.1/generateBulkActions.test.ts
+++ b/packages/generator/src/v1.1/generateBulkActions.test.ts
@@ -31,7 +31,6 @@ describe(generateBulkActions, () => {
     );
 
     expect(helper.minimalFiles.writeFile).toBeCalled();
-
     expect(helper.getFiles()[`${BASE_PATH}/BulkActions.ts`])
       .toMatchInlineSnapshot(`
       "import type {
@@ -53,6 +52,17 @@ describe(generateBulkActions, () => {
           }[],
           options?: O,
         ): Promise<Result<BulkActionResponseFromOptions<O, Edits<void, Todo>>, ActionError>>;
+
+        /**
+         * An action which takes in an array of objects
+         * @param {Array<Todo | Todo["__primaryKey"]>} params.object
+         */
+        deleteTodos<O extends BulkActionExecutionOptions>(
+          params: {
+            object?: Array<Todo | Todo['__primaryKey']>;
+          }[],
+          options?: O,
+        ): Promise<Result<BulkActionResponseFromOptions<O, Edits<void, void>>, ActionError>>;
       }
       "
       `);

--- a/packages/generator/src/v1.1/generateBulkActions.test.ts
+++ b/packages/generator/src/v1.1/generateBulkActions.test.ts
@@ -31,6 +31,7 @@ describe(generateBulkActions, () => {
     );
 
     expect(helper.minimalFiles.writeFile).toBeCalled();
+
     expect(helper.getFiles()[`${BASE_PATH}/BulkActions.ts`])
       .toMatchInlineSnapshot(`
       "import type {

--- a/packages/generator/src/v1.1/generateMetadataFile.test.ts
+++ b/packages/generator/src/v1.1/generateMetadataFile.test.ts
@@ -40,6 +40,7 @@ describe(generateMetadataFile, () => {
       import type { Ontology as ClientOntology } from '@osdk/legacy-client';
       import type { Actions } from './ontology/actions/Actions';
       import type { BulkActions } from './ontology/actions/BulkActions';
+      import { deleteTodos } from './ontology/actions/deleteTodos';
       import { markTodoCompleted } from './ontology/actions/markTodoCompleted';
       import type { Objects } from './ontology/objects/Objects';
       import { Person } from './ontology/objects/Person';
@@ -59,6 +60,7 @@ describe(generateMetadataFile, () => {
         };
         actions: {
           markTodoCompleted: typeof markTodoCompleted;
+          deleteTodos: typeof deleteTodos;
         };
         queries: {
           getCount: typeof getCount;
@@ -75,11 +77,12 @@ describe(generateMetadataFile, () => {
         },
         actions: {
           markTodoCompleted,
+          deleteTodos,
         },
         queries: {
           getCount,
         },
-      } satisfies OntologyDefinition<'Todo' | 'Person', 'markTodoCompleted', 'getCount'>;
+      } satisfies OntologyDefinition<'Todo' | 'Person', 'markTodoCompleted' | 'deleteTodos', 'getCount'>;
 
       export interface Ontology extends ClientOntology<typeof Ontology> {
         objects: Objects;

--- a/packages/generator/src/v1.1/generatePerActionDataFiles.test.ts
+++ b/packages/generator/src/v1.1/generatePerActionDataFiles.test.ts
@@ -62,8 +62,7 @@ describe(generatePerActionDataFiles, () => {
       "",
       true,
     );
-    console.error("OH NO");
-    console.error(helper.getFiles()[`${BASE_PATH}/deleteTodos.ts`]);
+
     expect(helper.getFiles()[`${BASE_PATH}/deleteTodos.ts`]).toContain(
       "import type { Todo } from '../objects';\n",
     );

--- a/packages/generator/src/v1.1/generatePerActionDataFiles.test.ts
+++ b/packages/generator/src/v1.1/generatePerActionDataFiles.test.ts
@@ -51,4 +51,21 @@ describe(generatePerActionDataFiles, () => {
     );
     expect(helper.getFiles()[`${BASE_PATH}/index.ts`]).toEqual("export {};\n");
   });
+
+  it("imports object types correctly with array params in actions", async () => {
+    const helper = createMockMinimalFiles();
+    const BASE_PATH = "/foo/actions";
+    await generatePerActionDataFiles(
+      TodoWireOntology,
+      helper.minimalFiles,
+      BASE_PATH,
+      "",
+      true,
+    );
+    console.error("OH NO");
+    console.error(helper.getFiles()[`${BASE_PATH}/deleteTodos.ts`]);
+    expect(helper.getFiles()[`${BASE_PATH}/deleteTodos.ts`]).toContain(
+      "import type { Todo } from '../objects';\n",
+    );
+  });
 });

--- a/packages/generator/src/v1.1/generatePerActionDataFiles.ts
+++ b/packages/generator/src/v1.1/generatePerActionDataFiles.ts
@@ -147,6 +147,18 @@ export async function generatePerActionDataFiles(
             getObjectDefIdentifier(p.dataType.objectTypeApiName!, v2),
           );
         }
+        if (
+          p.dataType.type === "array"
+          && (p.dataType.subType.type === "object"
+            || p.dataType.subType.type === "objectSet")
+        ) {
+          referencedObjectDefs.add(
+            getObjectDefIdentifier(p.dataType.subType.objectApiName!, v2),
+          );
+          referencedObjectDefs.add(
+            getObjectDefIdentifier(p.dataType.subType.objectTypeApiName!, v2),
+          );
+        }
       }
 
       const importObjects = referencedObjectDefs.size > 0


### PR DESCRIPTION
We had a bug where our generated action files would not correctly import object types if the params had an array of objectTypes. This fixes that by checking the subtypes of array params to see if they contain objects or objectsets

