### PR TITLE
Add fetchpagewitherrors

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "check-mrl": "mrl check --verbose",
     "ci:publish": "pnpm run prePublish && pnpm exec changeset publish --no-git-tag",
     "ci:publishSnapshot": "pnpm run prePublish && pnpm exec changeset version --snapshot && pnpm exec changeset publish --no-git-tag --snapshot --tag=next",
-    "dev": "turbo run dev --concurrency 27",
+    "dev": "turbo run dev --concurrency 26",
     "dev:typecheck": "tsc --build --watch --preserveWatchOutput packages/* examples-extra/basic/*",
     "lint": "turbo run lint",
     "prePublish": "turbo build && turbo lint",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "check-mrl": "mrl check --verbose",
     "ci:publish": "pnpm run prePublish && pnpm exec changeset publish --no-git-tag",
     "ci:publishSnapshot": "pnpm run prePublish && pnpm exec changeset version --snapshot && pnpm exec changeset publish --no-git-tag --snapshot --tag=next",
-    "dev": "turbo run dev --concurrency 26",
+    "dev": "turbo run dev --concurrency 27",
     "dev:typecheck": "tsc --build --watch --preserveWatchOutput packages/* examples-extra/basic/*",
     "lint": "turbo run lint",
     "prePublish": "turbo build && turbo lint",

--- a/packages/foundry-sdk-generator/changelog/@unreleased/pr-139.v2.yml
+++ b/packages/foundry-sdk-generator/changelog/@unreleased/pr-139.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add fetchpagewitherrors
+  links:
+  - https://github.com/palantir/osdk-ts/pull/139

--- a/packages/foundry-sdk-generator/src/__e2e_tests__/loadObjects.test.ts
+++ b/packages/foundry-sdk-generator/src/__e2e_tests__/loadObjects.test.ts
@@ -158,16 +158,19 @@ describe("LoadObjects", () => {
   });
 
   it("Pages through Objects with small PageSize", async () => {
-    const result = await client.ontology.objects.Employee.page({ pageSize: 2 });
+    const result = await client.ontology.objects.Employee.fetchPageWithErrors({
+      pageSize: 2,
+    });
     const employees = assertOkOrThrow(result);
     expect(employees.data.length).toEqual(2);
     expect(employees.data[0].employeeId).toEqual(50030);
     expect(employees.data[1].employeeId).toEqual(50031);
     expect(employees.nextPageToken).toBeDefined();
-    const secondResult = await client.ontology.objects.Employee.page({
-      pageSize: 2,
-      pageToken: employees.nextPageToken,
-    });
+    const secondResult = await client.ontology.objects.Employee
+      .fetchPageWithErrors({
+        pageSize: 2,
+        pageToken: employees.nextPageToken,
+      });
     const secondEmployeesPage = assertOkOrThrow(secondResult);
     expect(secondEmployeesPage.data.length).toEqual(1);
     expect(secondEmployeesPage.data[0].employeeId).toEqual(50032);
@@ -241,7 +244,7 @@ describe("LoadObjects", () => {
     const peeps: Result<Employee[], ListLinkedObjectsError> = await emp.peeps
       .all();
     const peepsPageResult: Result<Page<Employee>, ListLinkedObjectsError> =
-      await emp.peeps.page();
+      await emp.peeps.fetchPageWithErrors();
     const peepsAll = assertOkOrThrow(peeps);
     expect(peepsAll.length).toEqual(2);
     expect(peepsAll[0].employeeId).toEqual(50030);
@@ -374,7 +377,7 @@ describe("LoadObjects", () => {
 
   it("Loads specified properties when loading page", async () => {
     const result = await client.ontology.objects.Employee.select(["fullName"])
-      .page({ pageSize: 2 });
+      .fetchPageWithErrors({ pageSize: 2 });
     const employees = assertOkOrThrow(result);
     expect(employees.data.length).toEqual(2);
     expectTypeOf(employees.data[0]).toEqualTypeOf<{

--- a/packages/foundry-sdk-generator/src/__e2e_tests__/objectSet.test.ts
+++ b/packages/foundry-sdk-generator/src/__e2e_tests__/objectSet.test.ts
@@ -57,7 +57,7 @@ describe("Object Sets", () => {
   it("objects set base", async () => {
     let iter = 0;
     const result: Result<Page<Employee>, ListObjectsError> = await client
-      .ontology.objects.Employee.page();
+      .ontology.objects.Employee.fetchPageWithErrors();
     const employeesPage = assertOkOrThrow(result);
     const employees = employeesPage.data;
     for (const emp of employees) {
@@ -72,7 +72,7 @@ describe("Object Sets", () => {
     const unionedObjectSet: ObjectSet<Employee> = objectSet.union(objectSet);
     let iter = 0;
     const result: Result<Page<Employee>, LoadObjectSetError> =
-      await unionedObjectSet.page();
+      await unionedObjectSet.fetchPageWithErrors();
     const employeesPage = assertOkOrThrow(result);
     const employees = employeesPage.data;
     for (const emp of employees) {
@@ -101,7 +101,7 @@ describe("Object Sets", () => {
     const subtractedObjectSet = objectSet.subtract(objectSet2);
     let iter = 0;
     const result: Result<Page<Employee>, LoadObjectSetError> =
-      await subtractedObjectSet.page();
+      await subtractedObjectSet.fetchPageWithErrors();
     const employeesPage = assertOkOrThrow(result);
     const employees = employeesPage.data;
     for (const emp of employees) {
@@ -118,7 +118,7 @@ describe("Object Sets", () => {
     );
     let iter = 0;
     const result: Result<Page<Employee>, LoadObjectSetError> =
-      await intersectedObjectSet.page();
+      await intersectedObjectSet.fetchPageWithErrors();
     const employeesPage = assertOkOrThrow(result);
     const employees = employeesPage.data;
     for (const emp of employees) {
@@ -134,7 +134,7 @@ describe("Object Sets", () => {
       emp.employeeId.eq(50030)
     );
     const result: Result<Page<Employee>, LoadObjectSetError> =
-      await filteredObjectSet.page();
+      await filteredObjectSet.fetchPageWithErrors();
     const employeesPage = assertOkOrThrow(result);
     const employees = employeesPage.data;
     let iter = 0;
@@ -150,7 +150,7 @@ describe("Object Sets", () => {
     const searchAroundObjectSet: ObjectSet<Office> = objectSet
       .searchAroundOfficeLink();
     const result: Result<Page<Office>, LoadObjectSetError> =
-      await searchAroundObjectSet.page();
+      await searchAroundObjectSet.fetchPageWithErrors();
     const officePage = assertOkOrThrow(result);
     const offices = officePage.data;
     let iter = 0;
@@ -167,7 +167,7 @@ describe("Object Sets", () => {
       .searchAroundOfficeLink()
       .where(off => off.officeId.eq("NYC"));
     const result: Result<Page<Office>, LoadObjectSetError> =
-      await officeObjectSet.page();
+      await officeObjectSet.fetchPageWithErrors();
     const officePage = assertOkOrThrow(result);
     const offices = officePage.data;
     let iter = 0;

--- a/packages/foundry-sdk-generator/src/__e2e_tests__/search.test.ts
+++ b/packages/foundry-sdk-generator/src/__e2e_tests__/search.test.ts
@@ -215,7 +215,8 @@ describe("SearchObjects", () => {
 
   it("filters objects using the equality operator, and returns all results", async () => {
     const result: Result<Page<Employee>, LoadObjectSetError> = await client
-      .ontology.objects.Employee.where(emp => emp.employeeId.eq(50030)).page();
+      .ontology.objects.Employee.where(emp => emp.employeeId.eq(50030))
+      .fetchPageWithErrors();
 
     const employees = assertOkOrThrow(result);
     expect(employees).toMatchInlineSnapshot(`
@@ -263,7 +264,7 @@ describe("SearchObjects", () => {
       emp.employeeId.eq(50030)
     )
       .select(["fullName"])
-      .page();
+      .fetchPageWithErrors();
 
     const employees = assertOkOrThrow(result);
     expect(employees.data.length).toEqual(1);
@@ -281,7 +282,7 @@ describe("SearchObjects", () => {
     )
       .orderBy(emp => emp.employeeId.asc())
       .select(["fullName"])
-      .page();
+      .fetchPageWithErrors();
 
     const employees = assertOkOrThrow(result);
     expect(employees.data.length).toEqual(1);
@@ -297,7 +298,7 @@ describe("SearchObjects", () => {
     const result: Result<Page<Employee>, LoadObjectSetError> = await client
       .ontology.objects.Employee.where(emp =>
         Op.and(emp.employeeId.gt(50030), emp.employeeId.lt(50032))
-      ).page();
+      ).fetchPageWithErrors();
 
     expect(result).toMatchInlineSnapshot(`
       {
@@ -352,7 +353,7 @@ describe("SearchObjects", () => {
             longitude: 1.9,
           }),
         })
-      ).page();
+      ).fetchPageWithErrors();
 
     const offices = assertOkOrThrow(result);
     expect(offices.data).toHaveLength(1);
@@ -365,7 +366,7 @@ describe("SearchObjects", () => {
           GeoPoint.fromCoordinates({ latitude: 1.1, longitude: 0.9 }),
           100,
         )
-      ).page();
+      ).fetchPageWithErrors();
 
     const offices = assertOkOrThrow(result);
     expect(offices.data).toHaveLength(1);
@@ -386,7 +387,7 @@ describe("SearchObjects", () => {
 
     const result: Result<Page<Office>, LoadObjectSetError> = await client
       .ontology.objects.Office.where(o => o.entrance.withinPolygon(geoShape))
-      .page();
+      .fetchPageWithErrors();
 
     const offices = assertOkOrThrow(result);
     expect(offices.data).toHaveLength(1);
@@ -408,7 +409,7 @@ describe("SearchObjects", () => {
     const result: Result<Page<Office>, LoadObjectSetError> = await client
       .ontology.objects.Office.where(o =>
         o.occupiedArea.intersectsPolygon(geoShape)
-      ).page();
+      ).fetchPageWithErrors();
 
     const offices = assertOkOrThrow(result);
     expect(offices.data).toHaveLength(1);
@@ -424,7 +425,7 @@ describe("SearchObjects", () => {
             longitude: 1.9,
           }),
         })
-      ).page();
+      ).fetchPageWithErrors();
 
     const offices = assertOkOrThrow(result);
     expect(offices.data).toHaveLength(1);

--- a/packages/legacy-client/changelog/@unreleased/pr-139.v2.yml
+++ b/packages/legacy-client/changelog/@unreleased/pr-139.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add fetchpagewitherrors
+  links:
+  - https://github.com/palantir/osdk-ts/pull/139

--- a/packages/legacy-client/src/client/baseTypes/links.ts
+++ b/packages/legacy-client/src/client/baseTypes/links.ts
@@ -39,8 +39,16 @@ export interface MultiLink<T extends OntologyObject = OntologyObject> {
   all(): Promise<Result<T[], ListLinkedObjectsError>>;
   /**
    * Pages through the linked objects
+   * @deprecated use fetchPageWithErrors instead
    */
   page(options?: {
+    pageSize?: number;
+    pageToken?: string;
+  }): Promise<Result<Page<T>, ListLinkedObjectsError>>;
+  /**
+   * Pages through the linked objects
+   */
+  fetchPageWithErrors(options?: {
     pageSize?: number;
     pageToken?: string;
   }): Promise<Result<Page<T>, ListLinkedObjectsError>>;

--- a/packages/legacy-client/src/client/baseTypes/objectset/FilteredPropertiesTerminalOperations.ts
+++ b/packages/legacy-client/src/client/baseTypes/objectset/FilteredPropertiesTerminalOperations.ts
@@ -29,7 +29,19 @@ export type FilteredPropertiesTerminalOperations<
       LoadObjectSetError
     >
   >;
+  /**
+   * @deprecated use fetchPageWithErrors instead
+   */
   page(options?: {
+    pageSize?: number;
+    pageToken?: string;
+  }): Promise<
+    Result<
+      Page<Pick<T, V[number] | "__apiName" | "__primaryKey">>,
+      LoadObjectSetError
+    >
+  >;
+  fetchPageWithErrors(options?: {
     pageSize?: number;
     pageToken?: string;
   }): Promise<

--- a/packages/legacy-client/src/client/interfaces/objectSet.ts
+++ b/packages/legacy-client/src/client/interfaces/objectSet.ts
@@ -82,8 +82,14 @@ export type ObjectSetOrderByStep<O extends OntologyObject> = {
 export type ObjectSetTerminalLoadStep<O extends OntologyObject> = {
   /**
    * Get a page of objects of this type.
+   * @deprecated use fetchPageWithErrors instead
    */
   page(options?: {
+    pageSize?: number;
+    pageToken?: string;
+  }): Promise<Result<Page<O>, ListObjectsError>>;
+
+  fetchPageWithErrors(options?: {
     pageSize?: number;
     pageToken?: string;
   }): Promise<Result<Page<O>, ListObjectsError>>;

--- a/packages/legacy-client/src/client/objectSets/OsdkObjectSet.test.ts
+++ b/packages/legacy-client/src/client/objectSets/OsdkObjectSet.test.ts
@@ -240,10 +240,11 @@ describe("OsdkObjectSet", () => {
   it("supports select methods - page", async () => {
     const os = createBaseTodoObjectSet(client);
     mockObjectPage([getMockTodoObject()]);
-    const result = await os.select(["id", "body", "complete"]).page({
-      pageSize: 5,
-      pageToken: "fakePageToken",
-    });
+    const result = await os.select(["id", "body", "complete"])
+      .fetchPageWithErrors({
+        pageSize: 5,
+        pageToken: "fakePageToken",
+      });
     expect(fetch).toHaveBeenCalledOnce();
     expect(fetch).toHaveBeenCalledWith(
       ...expectedJestResponse("Ontology/objectSets/loadObjects", {
@@ -304,7 +305,7 @@ describe("OsdkObjectSet", () => {
   it("loads a page", async () => {
     const os = createBaseTodoObjectSet(client);
     mockObjectPage([getMockTodoObject()]);
-    const page = await os.page({ pageSize: 1 });
+    const page = await os.fetchPageWithErrors({ pageSize: 1 });
     expect(fetch).toHaveBeenCalledOnce();
     expect(fetch).toHaveBeenCalledWith(
       ...expectedJestResponse("Ontology/objectSets/loadObjects", {

--- a/packages/legacy-client/src/client/objectSets/createFilteredPropertiesObjectSetWithGetTerminalOperationsStep.ts
+++ b/packages/legacy-client/src/client/objectSets/createFilteredPropertiesObjectSetWithGetTerminalOperationsStep.ts
@@ -61,6 +61,16 @@ export function createFilteredPropertiesObjectSetWithGetTerminalOperationsStep<
         options,
       );
     },
+    fetchPageWithErrors(options) {
+      return loadObjectsPage(
+        client,
+        apiName,
+        objectSetDefinition,
+        orderByClause,
+        properties,
+        options,
+      );
+    },
     get(primaryKey) {
       return getObject(client, apiName as string, primaryKey, properties);
     },

--- a/packages/legacy-client/src/client/objectSets/createObjectSetOrderByStep.ts
+++ b/packages/legacy-client/src/client/objectSets/createObjectSetOrderByStep.ts
@@ -39,7 +39,7 @@ export function createObjectSetBaseOrderByStepMethod<
   orderByClauses: OrderByClause[] = [],
 ): Omit<
   ObjectSetOrderByStep<OsdkLegacyObjectFrom<O, K>>,
-  "all" | "page" | "select"
+  "all" | "page" | "select" | "fetchPageWithErrors"
 > {
   return {
     orderBy(predicate) {

--- a/packages/legacy-client/src/client/objectSets/createObjectSetTerminalLoadStep.ts
+++ b/packages/legacy-client/src/client/objectSets/createObjectSetTerminalLoadStep.ts
@@ -44,6 +44,16 @@ export function createObjectSetTerminalLoadStep<
         options,
       );
     },
+    async fetchPageWithErrors(options) {
+      return loadObjectsPage<O, K, OsdkLegacyObjectFrom<O, K>>(
+        client,
+        apiName,
+        objectSet,
+        orderByClauses,
+        selectedProperties,
+        options,
+      );
+    },
     async all() {
       return loadAllObjects<O, K, OsdkLegacyObjectFrom<O, K>>(
         client,

--- a/packages/legacy-client/src/client/objects/createMultiLinkStep.ts
+++ b/packages/legacy-client/src/client/objects/createMultiLinkStep.ts
@@ -64,5 +64,18 @@ export function createMultiLinkStep<T extends OntologyObject = OntologyObject>(
         options,
       );
     },
+    fetchPageWithErrors(
+      options?:
+        | { pageSize?: number | undefined; pageToken?: string | undefined }
+        | undefined,
+    ): Promise<Result<Page<T>, ListLinkedObjectsError>> {
+      return pageLinkedObjects(
+        client,
+        sourceApiName,
+        sourcePrimaryKey,
+        targetApiName,
+        options,
+      );
+    },
   };
 }


### PR DESCRIPTION
To aid with migrating to the 2.0 version of the osdk, we add this paging call to align with 2.0 syntax. 

_Note_: 2.0 still does not have this syntax to return a page wrapped with errors, so we may want to wait on merging this until we get that in