### PR TITLE
Avoid caching auth related calls

### DIFF
--- a/packages/legacy-client/changelog/@unreleased/pr-148.v2.yml
+++ b/packages/legacy-client/changelog/@unreleased/pr-148.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Avoid caching auth related calls
+  links:
+  - https://github.com/palantir/osdk-ts/pull/148

--- a/packages/legacy-client/src/oauth-client/ConfidentialClient/ConfidentialClientFlow.test.ts
+++ b/packages/legacy-client/src/oauth-client/ConfidentialClient/ConfidentialClientFlow.test.ts
@@ -57,6 +57,7 @@ describe("ConfidentialClientFlow", () => {
       {
         body:
           "grant_type=client_credentials&client_id=testClientId&client_secret=testClientSecret&scopes=offline_access+api%3Aread+api%3Awrite",
+        cache: "no-cache",
         headers: {
           "Content-Type": "application/x-www-form-urlencoded",
         },
@@ -97,6 +98,7 @@ describe("ConfidentialClientFlow", () => {
       {
         body:
           "client_id=testClientId&client_secret=testClientSecret&token=testAccessToken",
+        cache: "no-cache",
         headers: {
           "Content-Type": "application/x-www-form-urlencoded",
         },

--- a/packages/legacy-client/src/oauth-client/utils/fetchFormEncoded.ts
+++ b/packages/legacy-client/src/oauth-client/utils/fetchFormEncoded.ts
@@ -25,6 +25,7 @@ export async function fetchFormEncoded(
       "Content-Type": "application/x-www-form-urlencoded",
     },
     method: "POST",
+    cache: "no-cache",
   });
 
   return response;


### PR DESCRIPTION
nextjs can be aggressive with caching. According to their docs this change should prevent our auth related calls from caching.