### PR TITLE
Add fetch page without result wrapper

### DIFF
--- a/packages/legacy-client/changelog/@unreleased/pr-154.v2.yml
+++ b/packages/legacy-client/changelog/@unreleased/pr-154.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add fetch page without result wrapper
+  links:
+  - https://github.com/palantir/osdk-ts/pull/154

--- a/packages/legacy-client/src/client/baseTypes/links.ts
+++ b/packages/legacy-client/src/client/baseTypes/links.ts
@@ -44,4 +44,12 @@ export interface MultiLink<T extends OntologyObject = OntologyObject> {
     pageSize?: number;
     pageToken?: string;
   }): Promise<Result<Page<T>, ListLinkedObjectsError>>;
+
+  /**
+   * Pages through linked objects, without a result wrapper
+   */
+  fetchPage(options?: {
+    pageSize?: number;
+    pageToken?: string;
+  }): Promise<Page<T>>;
 }

--- a/packages/legacy-client/src/client/baseTypes/objectset/FilteredPropertiesTerminalOperations.ts
+++ b/packages/legacy-client/src/client/baseTypes/objectset/FilteredPropertiesTerminalOperations.ts
@@ -48,6 +48,18 @@ export type FilteredPropertiesTerminalOperations<
       LoadObjectSetError
     >
   >;
+
+  fetchPage(options?: {
+    pageSize?: number;
+    pageToken?: string;
+  }): Promise<
+    Page<
+      Pick<
+        T,
+        V[number] | "$apiName" | "$primaryKey" | "__apiName" | "__primaryKey"
+      >
+    >
+  >;
 };
 
 export type FilteredPropertiesTerminalOperationsWithGet<

--- a/packages/legacy-client/src/client/interfaces/objectSet.ts
+++ b/packages/legacy-client/src/client/interfaces/objectSet.ts
@@ -89,6 +89,14 @@ export type ObjectSetTerminalLoadStep<O extends OntologyObject> = {
   }): Promise<Result<Page<O>, ListObjectsError>>;
 
   /**
+   * Get a page of objects of this type, without a result wrapper
+   */
+  fetchPage(options?: {
+    pageSize?: number;
+    pageToken?: string;
+  }): Promise<Page<O>>;
+
+  /**
    * Get all objects of this type.
    */
   all(): Promise<Result<O[], ListObjectsError>>;

--- a/packages/legacy-client/src/client/net/pageLinkedObjects.ts
+++ b/packages/legacy-client/src/client/net/pageLinkedObjects.ts
@@ -26,7 +26,10 @@ import type { PalantirApiError } from "../errors/Errors";
 import type { Page } from "../Page";
 import type { Result } from "../Result";
 import { getLinkedObjectsPage } from "./getLinkedObjectsPage";
-import { createPageIterator } from "./util/createPageIterator";
+import {
+  createPageIterator,
+  createPageIteratorOrThrow,
+} from "./util/createPageIterator";
 import { iterateLinkedObjects } from "./util/iterateLinkedObjects";
 
 export async function pageLinkedObjects<T extends OntologyObject>(
@@ -64,6 +67,38 @@ export async function pageLinkedObjects<T extends OntologyObject>(
         palantirApiError.parameters,
       );
     },
+  );
+  return response;
+}
+
+export async function pageLinkedObjectsOrThrow<T extends OntologyObject>(
+  client: ClientContext<OntologyDefinition<any>>,
+  sourceApiName: string,
+  primaryKey: any,
+  linkTypeApiName: string,
+  options?: {
+    pageSize?: number;
+    pageToken?: string;
+  },
+): Promise<Page<T>> {
+  const response = createPageIteratorOrThrow<T>(
+    async () => {
+      return getLinkedObjectsPage<T>(
+        client,
+        sourceApiName,
+        primaryKey,
+        linkTypeApiName,
+        options,
+      );
+    },
+    () =>
+      iterateLinkedObjects(
+        client,
+        sourceApiName,
+        primaryKey,
+        linkTypeApiName,
+        options,
+      ),
   );
   return response;
 }

--- a/packages/legacy-client/src/client/net/util/createPageIterator.ts
+++ b/packages/legacy-client/src/client/net/util/createPageIterator.ts
@@ -31,3 +31,14 @@ export async function createPageIterator<T, E extends FoundryApiError>(
     [Symbol.asyncIterator]: () => iterator,
   });
 }
+
+export async function createPageIteratorOrThrow<T>(
+  apiCall: () => Promise<Page<T>>,
+  generator: () => AsyncGenerator<T, any, unknown>,
+) {
+  const page = await apiCall();
+
+  return Object.assign(page, {
+    [Symbol.asyncIterator]: generator,
+  });
+}

--- a/packages/legacy-client/src/client/objectSets/OsdkObjectSet.test.ts
+++ b/packages/legacy-client/src/client/objectSets/OsdkObjectSet.test.ts
@@ -319,6 +319,24 @@ describe("OsdkObjectSet", () => {
     expect(page.type).toEqual("ok");
   });
 
+  it("loads a page without result wrapper", async () => {
+    const os = createBaseTodoObjectSet(client);
+    mockObjectPage([getMockTodoObject()]);
+    const page = await os.fetchPage({ pageSize: 1 });
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(fetch).toHaveBeenCalledWith(
+      ...expectedJestResponse("Ontology/objectSets/loadObjects", {
+        objectSet: {
+          type: "base",
+          objectType: "Todo",
+        },
+        select: [],
+        pageSize: 1,
+      }),
+    );
+    expect(page.data).toBeDefined;
+  });
+
   it("handles multiple clients correctly", async () => {
     const fetch1: MockedFunction<typeof globalThis.fetch> = vi.fn();
     const client1 = createClientContext(

--- a/packages/legacy-client/src/client/objectSets/OsdkObjectSet.test.ts
+++ b/packages/legacy-client/src/client/objectSets/OsdkObjectSet.test.ts
@@ -16,6 +16,7 @@
 
 import type {
   AggregateObjectsResponseV2,
+  ListLinkedObjectsResponseV2,
   LoadObjectSetResponseV2,
   OntologyObjectV2,
 } from "@osdk/gateway/types";
@@ -59,7 +60,7 @@ describe("OsdkObjectSet", () => {
   });
 
   it("exposes descriptions", () => {
-    const os = createBaseTodoObjectSet(client);
+    const os = createBaseObjectSet(client, "Todo");
     expect(os.description).toEqual("A todo object");
     expect(os.properties.id.apiName).toEqual("id");
     expect(os.properties.id.description).toEqual("The id");
@@ -68,7 +69,7 @@ describe("OsdkObjectSet", () => {
   });
 
   it("creates a search on an ObjectSet", () => {
-    const os = createBaseTodoObjectSet(client);
+    const os = createBaseObjectSet(client, "Todo");
     const whereObjectSet = os.where(a => a.id.eq("123"));
 
     expect(whereObjectSet.definition).toEqual({
@@ -83,7 +84,7 @@ describe("OsdkObjectSet", () => {
   });
 
   it("creates a searchAround on an ObjectSet", () => {
-    const os = createBaseTodoObjectSet(client);
+    const os = createBaseObjectSet(client, "Todo");
     const searchAroundObjectSet = os.searchAroundLinkedTask();
 
     expect(searchAroundObjectSet.definition).toEqual({
@@ -94,7 +95,7 @@ describe("OsdkObjectSet", () => {
   });
 
   it("creates the count aggregation", async () => {
-    const os = createBaseTodoObjectSet(client);
+    const os = createBaseObjectSet(client, "Todo");
     mockAggregateResponse({ data: [] });
     await os.count().compute();
     expect(fetch).toHaveBeenCalledOnce();
@@ -108,7 +109,7 @@ describe("OsdkObjectSet", () => {
   });
 
   it("creates the min aggregation", async () => {
-    const os = createBaseTodoObjectSet(client);
+    const os = createBaseObjectSet(client, "Todo");
     mockAggregateResponse({ data: [] });
     await os.min(s => s.points).compute();
     expect(fetch).toHaveBeenCalledOnce();
@@ -122,7 +123,7 @@ describe("OsdkObjectSet", () => {
   });
 
   it("creates the max aggregation", async () => {
-    const os = createBaseTodoObjectSet(client);
+    const os = createBaseObjectSet(client, "Todo");
     mockAggregateResponse({ data: [] });
     await os.max(s => s.points).compute();
     expect(fetch).toHaveBeenCalledOnce();
@@ -136,7 +137,7 @@ describe("OsdkObjectSet", () => {
   });
 
   it("creates the sum aggregation", async () => {
-    const os = createBaseTodoObjectSet(client);
+    const os = createBaseObjectSet(client, "Todo");
     mockAggregateResponse({ data: [] });
     await os.sum(s => s.points).compute();
     expect(fetch).toHaveBeenCalledOnce();
@@ -150,7 +151,7 @@ describe("OsdkObjectSet", () => {
   });
 
   it("creates the avg aggregation", async () => {
-    const os = createBaseTodoObjectSet(client);
+    const os = createBaseObjectSet(client, "Todo");
     mockAggregateResponse({ data: [] });
     await os.avg(s => s.points).compute();
     expect(fetch).toHaveBeenCalledOnce();
@@ -164,7 +165,7 @@ describe("OsdkObjectSet", () => {
   });
 
   it("creates the groupBy clauses", async () => {
-    const os = createBaseTodoObjectSet(client);
+    const os = createBaseObjectSet(client, "Todo");
     mockAggregateResponse({ data: [] });
     await os.groupBy(s => s.complete.exact()).groupBy(s => s.body.exact())
       .count().compute();
@@ -182,7 +183,7 @@ describe("OsdkObjectSet", () => {
   });
 
   it("creates complex aggregation queries", async () => {
-    const os = createBaseTodoObjectSet(client);
+    const os = createBaseObjectSet(client, "Todo");
     mockAggregateResponse({ data: [] });
     await (os.aggregate(b => ({
       foo: b.complete.approximateDistinct(),
@@ -203,7 +204,7 @@ describe("OsdkObjectSet", () => {
   });
 
   it("creates approximateDistinct queries", async () => {
-    const os = createBaseTodoObjectSet(client);
+    const os = createBaseObjectSet(client, "Todo");
     mockAggregateResponse({ data: [] });
     await os.approximateDistinct(s => s.complete).compute();
     expect(fetch).toHaveBeenCalledOnce();
@@ -221,7 +222,7 @@ describe("OsdkObjectSet", () => {
   });
 
   it("supports select methods - all", async () => {
-    const os = createBaseTodoObjectSet(client);
+    const os = createBaseObjectSet(client, "Todo");
     mockObjectPage([getMockTodoObject()]);
     const result = await os.select(["id", "body", "complete"]).all();
     expect(fetch).toHaveBeenCalledOnce();
@@ -238,7 +239,7 @@ describe("OsdkObjectSet", () => {
   });
 
   it("supports select methods - page", async () => {
-    const os = createBaseTodoObjectSet(client);
+    const os = createBaseObjectSet(client, "Todo");
     mockObjectPage([getMockTodoObject()]);
     const result = await os.select(["id", "body", "complete"]).page({
       pageSize: 5,
@@ -260,7 +261,7 @@ describe("OsdkObjectSet", () => {
   });
 
   it("supports select methods - get", async () => {
-    const os = createBaseTodoObjectSet(client);
+    const os = createBaseObjectSet(client, "Todo");
     mockFetchResponse(fetch, getMockTodoObject());
     const result = await os.select(["id", "body", "complete"]).get("123");
     expect(fetch).toHaveBeenCalledOnce();
@@ -276,7 +277,7 @@ describe("OsdkObjectSet", () => {
   });
 
   it("supports round-trip of circular links", async () => {
-    const os = createBaseTodoObjectSet(client);
+    const os = createBaseObjectSet(client, "Todo");
     mockFetchResponse(fetch, getMockTodoObject());
     const todoResponse = await os.get("1");
 
@@ -302,7 +303,7 @@ describe("OsdkObjectSet", () => {
   });
 
   it("loads a page", async () => {
-    const os = createBaseTodoObjectSet(client);
+    const os = createBaseObjectSet(client, "Todo");
     mockObjectPage([getMockTodoObject()]);
     const page = await os.page({ pageSize: 1 });
     expect(fetch).toHaveBeenCalledOnce();
@@ -320,7 +321,7 @@ describe("OsdkObjectSet", () => {
   });
 
   it("loads a page without result wrapper", async () => {
-    const os = createBaseTodoObjectSet(client);
+    const os = createBaseObjectSet(client, "Todo");
     mockObjectPage([getMockTodoObject()]);
     const page = await os.fetchPage({ pageSize: 1 });
     expect(fetch).toHaveBeenCalledOnce();
@@ -335,6 +336,66 @@ describe("OsdkObjectSet", () => {
       }),
     );
     expect(page.data).toBeDefined;
+  });
+
+  it("loads a page without result wrapper, when downselecting properties", async () => {
+    const os = createBaseObjectSet(client, "Todo");
+    mockObjectPage([getMockTodoObject()]);
+    const page = await os.select(["id"]).fetchPage({ pageSize: 1 });
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(fetch).toHaveBeenCalledWith(
+      ...expectedJestResponse("Ontology/objectSets/loadObjects", {
+        objectSet: {
+          type: "base",
+          objectType: "Todo",
+        },
+        select: ["id"],
+        pageSize: 1,
+      }),
+    );
+    expect(page.data).toBeDefined;
+  });
+
+  it("loads a page without result wrapper, when ordering", async () => {
+    const os = createBaseObjectSet(client, "Todo");
+    mockObjectPage([getMockTodoObject()]);
+    const page = await os.orderBy(todo => todo.id.asc()).fetchPage({
+      pageSize: 1,
+    });
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(fetch).toHaveBeenCalledWith(
+      ...expectedJestResponse("Ontology/objectSets/loadObjects", {
+        objectSet: {
+          type: "base",
+          objectType: "Todo",
+        },
+        select: [],
+        orderBy: { "fields": [{ "field": "id", "direction": "asc" }] },
+        pageSize: 1,
+      }),
+    );
+    expect(page.data).toBeDefined;
+  });
+
+  it("loads a page without result wrapper, when accessing multilinks", async () => {
+    const os = createBaseObjectSet(client, "Task");
+    mockObjectPage([getMockTaskObject()]);
+    mockLinkPage([getMockTodoObject()]);
+    const page = await os.fetchPage({ pageSize: 1 });
+    const linkPage = await page.data[0].linkedTodos.fetchPage({ pageSize: 1 });
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch).toHaveBeenCalledWith(
+      ...expectedJestResponse("Ontology/objectSets/loadObjects", {
+        objectSet: {
+          type: "base",
+          objectType: "Task",
+        },
+        select: [],
+        pageSize: 1,
+      }),
+    );
+    expect(page.data).toBeDefined;
+    expect(linkPage.data).toBeDefined;
   });
 
   it("handles multiple clients correctly", async () => {
@@ -406,6 +467,19 @@ describe("OsdkObjectSet", () => {
     } as any);
   }
 
+  function mockLinkPage(objects: OntologyObjectV2[]) {
+    const response: ListLinkedObjectsResponseV2 = {
+      data: objects,
+    };
+    fetch.mockResolvedValueOnce({
+      json: () => {
+        return Promise.resolve(response);
+      },
+      status: 200,
+      ok: true,
+    } as any);
+  }
+
   function mockAggregateResponse(response: AggregateObjectsResponseV2) {
     fetch.mockResolvedValue({
       json: () => Promise.resolve(response),
@@ -434,12 +508,13 @@ const baseObjectSet: ObjectSetDefinition = {
   objectType: "Todo",
 };
 
-function createBaseTodoObjectSet(
+function createBaseObjectSet<T extends keyof typeof MockOntology.objects>(
   client: ClientContext<typeof MockOntology>,
+  objectName: T,
 ) {
-  const os = createBaseOsdkObjectSet<typeof MockOntology, "Todo">(
+  const os = createBaseOsdkObjectSet<typeof MockOntology, T>(
     client,
-    "Todo",
+    objectName,
   );
 
   return os;

--- a/packages/legacy-client/src/client/objectSets/createFilteredPropertiesObjectSetWithGetTerminalOperationsStep.ts
+++ b/packages/legacy-client/src/client/objectSets/createFilteredPropertiesObjectSetWithGetTerminalOperationsStep.ts
@@ -23,7 +23,10 @@ import type {
 import type { SelectableProperties } from "../interfaces/utils/OmitProperties";
 import { getObject } from "../net/getObject";
 import { loadAllObjects } from "../net/loadObjects";
-import { loadObjectsPage } from "../net/loadObjectsPage";
+import {
+  loadObjectsPage,
+  loadObjectsPageOrThrows,
+} from "../net/loadObjectsPage";
 import type { OsdkLegacyObjectFrom } from "../OsdkLegacyObject";
 import type { OrderByClause } from "./filters";
 
@@ -53,6 +56,16 @@ export function createFilteredPropertiesObjectSetWithGetTerminalOperationsStep<
     },
     page(options) {
       return loadObjectsPage(
+        client,
+        apiName,
+        objectSetDefinition,
+        orderByClause,
+        properties,
+        options,
+      );
+    },
+    fetchPage(options) {
+      return loadObjectsPageOrThrows(
         client,
         apiName,
         objectSetDefinition,

--- a/packages/legacy-client/src/client/objectSets/createObjectSetOrderByStep.ts
+++ b/packages/legacy-client/src/client/objectSets/createObjectSetOrderByStep.ts
@@ -39,7 +39,7 @@ export function createObjectSetBaseOrderByStepMethod<
   orderByClauses: OrderByClause[] = [],
 ): Omit<
   ObjectSetOrderByStep<OsdkLegacyObjectFrom<O, K>>,
-  "all" | "page" | "select"
+  "all" | "page" | "select" | "fetchPage"
 > {
   return {
     orderBy(predicate) {

--- a/packages/legacy-client/src/client/objectSets/createObjectSetTerminalLoadStep.ts
+++ b/packages/legacy-client/src/client/objectSets/createObjectSetTerminalLoadStep.ts
@@ -19,7 +19,10 @@ import type { ClientContext } from "@osdk/shared.net";
 import type { ObjectSetDefinition } from "../baseTypes";
 import type { ObjectSetTerminalLoadStep } from "../interfaces";
 import { loadAllObjects } from "../net/loadObjects";
-import { loadObjectsPage } from "../net/loadObjectsPage";
+import {
+  loadObjectsPage,
+  loadObjectsPageOrThrows,
+} from "../net/loadObjectsPage";
 import type { OsdkLegacyObjectFrom } from "../OsdkLegacyObject";
 import type { OrderByClause } from "./filters";
 
@@ -36,6 +39,16 @@ export function createObjectSetTerminalLoadStep<
   return {
     async page(options) {
       return loadObjectsPage<O, K, OsdkLegacyObjectFrom<O, K>>(
+        client,
+        apiName,
+        objectSet,
+        orderByClauses,
+        selectedProperties,
+        options,
+      );
+    },
+    async fetchPage(options) {
+      return loadObjectsPageOrThrows<O, K, OsdkLegacyObjectFrom<O, K>>(
         client,
         apiName,
         objectSet,

--- a/packages/legacy-client/src/client/objects/createMultiLinkStep.ts
+++ b/packages/legacy-client/src/client/objects/createMultiLinkStep.ts
@@ -19,7 +19,10 @@ import type { MultiLink, OntologyObject, ParameterValue } from "../baseTypes";
 import type { GetLinkedObjectError, ListLinkedObjectsError } from "../errors";
 import { getLinkedObject } from "../net/getLinkedObject";
 import { listLinkedObjects } from "../net/listLinkedObjects";
-import { pageLinkedObjects } from "../net/pageLinkedObjects";
+import {
+  pageLinkedObjects,
+  pageLinkedObjectsOrThrow,
+} from "../net/pageLinkedObjects";
 import type { Page } from "../Page";
 import type { Result } from "../Result";
 
@@ -57,6 +60,20 @@ export function createMultiLinkStep<T extends OntologyObject = OntologyObject>(
         | undefined,
     ): Promise<Result<Page<T>, ListLinkedObjectsError>> {
       return pageLinkedObjects(
+        client,
+        sourceApiName,
+        sourcePrimaryKey,
+        targetApiName,
+        options,
+      );
+    },
+
+    fetchPage(
+      options?:
+        | { pageSize?: number | undefined; pageToken?: string | undefined }
+        | undefined,
+    ): Promise<Page<T>> {
+      return pageLinkedObjectsOrThrow(
         client,
         sourceApiName,
         sourcePrimaryKey,


### PR DESCRIPTION
Add a `fetchPage` method in 1.1 that doesn't wrap results, and just throws errors

Once this merges, we can merge in https://github.com/palantir/osdk-ts/pull/139 to deprecate `page` and rename `fetchPageWithErrors`