### PR TITLE
FetchPageWithErrors type fix

### DIFF
--- a/packages/legacy-client/changelog/@unreleased/pr-161.v2.yml
+++ b/packages/legacy-client/changelog/@unreleased/pr-161.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: FetchPageWithErrors type fix
+  links:
+  - https://github.com/palantir/osdk-ts/pull/161

--- a/packages/legacy-client/src/client/baseTypes/objectset/FilteredPropertiesTerminalOperations.ts
+++ b/packages/legacy-client/src/client/baseTypes/objectset/FilteredPropertiesTerminalOperations.ts
@@ -68,7 +68,12 @@ export type FilteredPropertiesTerminalOperations<
     pageToken?: string;
   }): Promise<
     Result<
-      Page<Pick<T, V[number] | "__apiName" | "__primaryKey">>,
+      Page<
+        Pick<
+          T,
+          V[number] | "__apiName" | "__primaryKey" | "$apiName" | "$primaryKey"
+        >
+      >,
       LoadObjectSetError
     >
   >;


### PR DESCRIPTION
Realized this PR didn't have the updates from the __apiName/__primaryKey deprecation PR, so just adding the new $ fields as well