### PR TITLE
Extract package generation

### DIFF
--- a/monorepo/mytsup/tsup.mjs
+++ b/monorepo/mytsup/tsup.mjs
@@ -28,6 +28,7 @@ export default async (options, ourOptions) => {
       PACKAGE_VERSION: packageJson.version,
       PACKAGE_API_VERSION: await readPackageVersion("packages/api"),
       PACKAGE_CLIENT_VERSION: await readPackageVersion("packages/client"),
+      PACKAGE_CLI_VERSION: await readPackageVersion("packages/cli"),
       PACKAGE_LEGACY_CLIENT_VERSION: await readPackageVersion(
         "packages/legacy-client",
       ),

--- a/packages/cli.cmd.typescript/changelog/@unreleased/pr-162.v2.yml
+++ b/packages/cli.cmd.typescript/changelog/@unreleased/pr-162.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Extract package generation
+  links:
+  - https://github.com/palantir/osdk-ts/pull/162

--- a/packages/cli.cmd.typescript/src/generate/handleGenerate.mts
+++ b/packages/cli.cmd.typescript/src/generate/handleGenerate.mts
@@ -22,7 +22,7 @@ import {
 } from "@osdk/gateway/requests";
 import type { MinimalFs, WireOntologyDefinition } from "@osdk/generator";
 import {
-  __UNSTALE_generateClientSdkPackage,
+  __UNSTABLE_generateClientSdkPackage,
   generateClientSdkVersionOneDotOne,
   generateClientSdkVersionTwoPointZero,
 } from "@osdk/generator";
@@ -141,7 +141,7 @@ async function generateClientSdk(
       return true;
     }
 
-    await __UNSTALE_generateClientSdkPackage(
+    await __UNSTABLE_generateClientSdkPackage(
       args.packageName!,
       args.version,
       args.beta ? "2.0" : "1.1",

--- a/packages/generator/changelog/@unreleased/pr-162.v2.yml
+++ b/packages/generator/changelog/@unreleased/pr-162.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Extract package generation
+  links:
+  - https://github.com/palantir/osdk-ts/pull/162

--- a/packages/generator/src/generateClientSdkPackage.test.ts
+++ b/packages/generator/src/generateClientSdkPackage.test.ts
@@ -14,26 +14,22 @@
  * limitations under the License.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { getPackageJsonContents } from "./handleGenerate.mjs";
+import { describe, expect, test } from "vitest";
+import { getPackageJsonContents } from "./generateClientSdkPackage";
 
-describe("handleGenerate", () => {
-  beforeEach(() => {
-    process.env.PACKAGE_API_VERSION = "99.9.9";
-    process.env.PACKAGE_CLIENT_VERSION = "88.8.8";
-    process.env.PACKAGE_LEGACY_CLIENT_VERSION = "77.7.7";
-  });
-
-  afterEach(() => {
-    delete process.env.PACKAGE_API_VERSION;
-    delete process.env.PACKAGE_CLIENT_VERSION;
-    delete process.env.PACKAGE_LEGACY_CLIENT_VERSION;
-  });
-
+describe("generateClientSdkPackage", () => {
   describe(getPackageJsonContents, () => {
+    const versions = {
+      osdkApiVersion: "^99.9.9",
+      osdkClientVersion: "^88.8.8",
+      osdkLegacyClientVersion: "^77.7.7",
+      areTheTypesWrongVersion: "^0.15.2",
+      tslibVersion: "^2.6.2",
+      typescriptVersion: "^5.4.2",
+    } as const;
     describe("v1", () => {
       test("returns the package.json contents", async () => {
-        expect(await getPackageJsonContents("foo", "1.1.1", 1))
+        expect(getPackageJsonContents("foo", "1.1.1", "1.1", versions))
           .toMatchInlineSnapshot(`
             {
               "devDependencies": {
@@ -77,7 +73,7 @@ describe("handleGenerate", () => {
 
     describe("v2", () => {
       test("returns the package.json contents", async () => {
-        expect(await getPackageJsonContents("foo", "1.2.3", 2))
+        expect(getPackageJsonContents("foo", "1.2.3", "2.0", versions))
           .toMatchInlineSnapshot(`
             {
               "devDependencies": {

--- a/packages/generator/src/generateClientSdkPackage.ts
+++ b/packages/generator/src/generateClientSdkPackage.ts
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { MinimalFs } from "./MinimalFs";
+import { generateClientSdkVersionOneDotOne } from "./v1.1/generateClientSdkVersionOneDotOne";
+import { generateClientSdkVersionTwoPointZero } from "./v2.0/generateClientSdkVersionTwoPointZero";
+import type { WireOntologyDefinition } from "./WireOntologyDefinition";
+
+export async function generateClientSdkPackage(
+  packageName: string,
+  packageVersion: string,
+  sdkVersion: "1.1" | "2.0",
+  baseOutDir: string,
+  ontology: WireOntologyDefinition,
+  minimalFs: MinimalFs,
+  dependencyVersions: DependencyVersions,
+  cliVersion: string,
+) {
+  if (!packageName) throw new Error("Package name is require");
+
+  for (const packageType of ["module", "commonjs"] as const) {
+    const outDir = path.join(baseOutDir, "dist", packageType);
+
+    await (sdkVersion === "1.1"
+      ? generateClientSdkVersionOneDotOne
+      : sdkVersion === "2.0"
+      ? generateClientSdkVersionTwoPointZero
+      : undefined!)(
+        ontology,
+        `typescript-sdk/${packageVersion} osdk-cli/${cliVersion}`,
+        minimalFs,
+        outDir,
+        packageType,
+      );
+
+    await fs.promises.mkdir(outDir, { recursive: true });
+    await writeJson(
+      minimalFs,
+      path.join(outDir, "package.json"),
+      { type: packageType },
+    );
+
+    await writeJson(
+      minimalFs,
+      path.join(outDir, `tsconfig.json`),
+      {
+        compilerOptions: getTsCompilerOptions(packageType),
+      },
+    );
+  }
+
+  await writeJson(
+    minimalFs,
+    path.join(baseOutDir, "package.json"),
+    await getPackageJsonContents(
+      packageName,
+      packageVersion,
+      sdkVersion,
+      dependencyVersions,
+    ),
+  );
+
+  // we need to shim for the node10 resolver
+  await minimalFs.mkdir(path.join(baseOutDir, "ontology"), {
+    recursive: true,
+  });
+  await minimalFs.writeFile(
+    path.join(baseOutDir, "ontology", "objects.js"),
+    `module.exports = require("../../dist/module/ontology/objects")`,
+  );
+  await minimalFs.writeFile(
+    path.join(baseOutDir, "ontology", "objects.d.ts"),
+    `export * from "../dist/module/ontology/objects"`,
+  );
+}
+
+function getTsCompilerOptions(packageType: "commonjs" | "module") {
+  const commonTsconfig = {
+    importHelpers: true,
+
+    declaration: true,
+
+    isolatedModules: true,
+    esModuleInterop: true,
+
+    forceConsistentCasingInFileNames: true,
+    strict: true,
+
+    skipLibCheck: true,
+  };
+
+  const compilerOptions = packageType === "commonjs"
+    ? {
+      ...commonTsconfig,
+      module: "commonjs",
+      target: "es2018",
+    }
+    : {
+      ...commonTsconfig,
+      module: "NodeNext",
+      target: "ES2020",
+    };
+  return compilerOptions;
+}
+
+export interface DependencyVersions {
+  typescriptVersion: string;
+  tslibVersion: string;
+  areTheTypesWrongVersion: string;
+  osdkApiVersion: string;
+  osdkClientVersion: string;
+  osdkLegacyClientVersion: string;
+}
+
+export function getPackageJsonContents(
+  name: string,
+  version: string,
+  sdkVersion: "2.0" | "1.1",
+  {
+    typescriptVersion,
+    tslibVersion,
+    areTheTypesWrongVersion,
+    osdkApiVersion,
+    osdkClientVersion,
+    osdkLegacyClientVersion,
+  }: DependencyVersions,
+) {
+  const esmPrefix = "./dist/module";
+  const commonjsPrefix = "./dist/commonjs";
+  return {
+    name,
+    version,
+    main: `${commonjsPrefix}/index.js`,
+    module: `${esmPrefix}/index.js`,
+    exports: {
+      ".": {
+        import: `${esmPrefix}/index.js`,
+        require: `${commonjsPrefix}/index.js`,
+      },
+      "./ontology/objects": {
+        import: `${esmPrefix}/ontology/objects${
+          sdkVersion === "2.0" ? "" : "/index"
+        }.js`,
+        require: `${commonjsPrefix}/ontology/objects${
+          sdkVersion === "2.0" ? "" : "/index"
+        }.js`,
+      },
+    },
+    scripts: {
+      prepack:
+        `tsc -p ${esmPrefix}/tsconfig.json && tsc -p ${commonjsPrefix}/tsconfig.json`,
+      check: "npm exec attw $(npm pack)",
+    },
+    devDependencies: {
+      "typescript": typescriptVersion,
+      "tslib": tslibVersion,
+      "@arethetypeswrong/cli": areTheTypesWrongVersion,
+      "@osdk/api": osdkApiVersion,
+      ...(sdkVersion
+          === "2.0"
+        ? { "@osdk/client": osdkClientVersion }
+        : { "@osdk/legacy-client": osdkLegacyClientVersion }),
+    },
+    peerDependencies: {
+      "@osdk/api": osdkApiVersion,
+      ...(sdkVersion === "2.0"
+        ? { "@osdk/client": osdkClientVersion }
+        : { "@osdk/legacy-client": osdkLegacyClientVersion }),
+    },
+    files: [
+      "**/*.js",
+      "**/*.d.ts",
+      "dist/**/package.json",
+    ],
+  };
+}
+
+async function writeJson(
+  minimalFs: MinimalFs,
+  filePath: string,
+  body: unknown,
+) {
+  // consola.info(`Writing ${filePath}`);
+  // consola.debug(`Writing ${filePath} with body`, body);
+  return await minimalFs.writeFile(
+    filePath,
+    JSON.stringify(body, undefined, 2) + "\n",
+  );
+}

--- a/packages/generator/src/index.ts
+++ b/packages/generator/src/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export { generateClientSdkPackage as __UNSTALE_generateClientSdkPackage } from "./generateClientSdkPackage";
+export { generateClientSdkPackage as __UNSTABLE_generateClientSdkPackage } from "./generateClientSdkPackage";
 export type { MinimalFs } from "./MinimalFs";
 export { generateClientSdkVersionOneDotOne } from "./v1.1/generateClientSdkVersionOneDotOne";
 export { generateClientSdkVersionTwoPointZero } from "./v2.0/generateClientSdkVersionTwoPointZero";

--- a/packages/generator/src/index.ts
+++ b/packages/generator/src/index.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+export { generateClientSdkPackage as __UNSTALE_generateClientSdkPackage } from "./generateClientSdkPackage";
 export type { MinimalFs } from "./MinimalFs";
 export { generateClientSdkVersionOneDotOne } from "./v1.1/generateClientSdkVersionOneDotOne";
 export { generateClientSdkVersionTwoPointZero } from "./v2.0/generateClientSdkVersionTwoPointZero";
 export type { WireOntologyDefinition } from "./WireOntologyDefinition";
-//


### PR DESCRIPTION
For now this still requires running `(p)npm prepack` after installing deps. In a future version we can just have this skip the compile step all together which will make this slimmer and faster.