### PR TITLE
Add missing error handlers to LoadObjectSetErrorHandler

### DIFF
--- a/packages/legacy-client/changelog/@unreleased/pr-178.v2.yml
+++ b/packages/legacy-client/changelog/@unreleased/pr-178.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Add missing error handlers to LoadObjectSetErrorHandler
+  links:
+  - https://github.com/palantir/osdk-ts/pull/178

--- a/packages/legacy-client/src/client/errors/ApiErrors.ts
+++ b/packages/legacy-client/src/client/errors/ApiErrors.ts
@@ -66,6 +66,7 @@ export type LoadObjectSetError =
   | ObjectsExceededLimit
   | ObjectTypeNotFound
   | ObjectTypeNotSynced
+  | PropertiesNotFound
   | PropertiesNotSearchable
   | PropertyTypesSearchNotSupported
   | PropertiesNotFilterable

--- a/packages/legacy-client/src/client/errors/handlers/ErrorHandlers.ts
+++ b/packages/legacy-client/src/client/errors/handlers/ErrorHandlers.ts
@@ -123,6 +123,14 @@ export function handleLoadObjectSetError(
       return handler.handleObjectTypeNotSynced(error, parameters.objectType);
     case "ObjectsExceededLimit":
       return handler.handleObjectsExceededLimit(error);
+    case "OntologySyncing":
+      return handler.handleOntologySyncing(error, parameters.objectType);
+    case "PropertiesNotFound":
+      return handler.handlePropertiesNotFound(
+        error,
+        parameters.objectType,
+        parameters.properties,
+      );
     case "PropertiesNotSearchable":
       return handler.handlePropertiesNotSearchable(
         error,

--- a/packages/legacy-client/src/client/errors/handlers/LoadObjectSetErrorHandler.ts
+++ b/packages/legacy-client/src/client/errors/handlers/LoadObjectSetErrorHandler.ts
@@ -29,6 +29,7 @@ import type {
   ObjectTypeNotSynced,
   OntologySyncing,
   PropertiesNotFilterable,
+  PropertiesNotFound,
   PropertiesNotSearchable,
   PropertiesNotSortable,
   PropertyFiltersNotSupported,
@@ -77,6 +78,23 @@ export class LoadObjectSetErrorHandler extends DefaultErrorHandler {
       errorType: "INVALID_ARGUMENT",
       errorInstanceId: error.errorInstanceId,
       statusCode: error.statusCode,
+    };
+  }
+
+  handlePropertiesNotFound(
+    error: PalantirApiError,
+    objectType: string,
+    properties: string[],
+  ): PropertiesNotFound {
+    return {
+      name: error.errorName,
+      message: error.message,
+      errorName: "PropertiesNotFound",
+      errorType: "NOT_FOUND",
+      errorInstanceId: error.errorInstanceId,
+      statusCode: error.statusCode,
+      objectType,
+      properties,
     };
   }
 


### PR DESCRIPTION
LoadObjectSetErrorHandler didn't handle `OntologySyncing` nor `PropertiesNotFound`, so the error is processed as `UNKNOWN`