### PR TITLE
Fix version adjusting logic for snapshots

### DIFF
--- a/.changeset/slow-eyes-build.md
+++ b/.changeset/slow-eyes-build.md
@@ -1,0 +1,5 @@
+---
+"@osdk/generator": patch
+---
+
+For 2.0, fixes codegen version matching in snapshot builds

--- a/examples-extra/basic/sdk/src/generatedNoCheck/OntologyMetadata.ts
+++ b/examples-extra/basic/sdk/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,11 +1,9 @@
 import { OntologyMetadata as OM } from '@osdk/api';
 
-export const expectedClientVersion = '0.15.0';
+export type $ExpectedClientVersion = '0.15.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
-export interface OntologyMetadata extends OM<'0.15.0'> {
-  expectsClientVersion: '0.15.0';
-}
+export interface OntologyMetadata extends OM<$ExpectedClientVersion> {}
 
 export const OntologyMetadata: OntologyMetadata = {
   expectsClientVersion: '0.15.0',

--- a/examples-extra/basic/sdk/src/generatedNoCheck/ontology/interfaces/FooInterface.ts
+++ b/examples-extra/basic/sdk/src/generatedNoCheck/ontology/interfaces/FooInterface.ts
@@ -1,7 +1,10 @@
 import type { InterfaceDefinition, PropertyDef, VersionBound } from '@osdk/api';
+import type { $ExpectedClientVersion } from '../../OntologyMetadata.js';
 import { $osdkMetadata } from '../../OntologyMetadata.js';
 
-export interface FooInterface extends InterfaceDefinition<'FooInterface', FooInterface>, VersionBound<'0.15.0'> {
+export interface FooInterface
+  extends InterfaceDefinition<'FooInterface', FooInterface>,
+    VersionBound<$ExpectedClientVersion> {
   osdkMetadata: typeof $osdkMetadata;
   description: 'Its a Foo.';
   links: {};

--- a/examples-extra/basic/sdk/src/generatedNoCheck/ontology/objects/BoundariesUsState.ts
+++ b/examples-extra/basic/sdk/src/generatedNoCheck/ontology/objects/BoundariesUsState.ts
@@ -1,9 +1,10 @@
 import type { ObjectTypeDefinition, PropertyDef, VersionBound } from '@osdk/api';
+import type { $ExpectedClientVersion } from '../../OntologyMetadata.js';
 import { $osdkMetadata } from '../../OntologyMetadata.js';
 
 export interface BoundariesUsState
   extends ObjectTypeDefinition<'BoundariesUsState', BoundariesUsState>,
-    VersionBound<'0.15.0'> {
+    VersionBound<$ExpectedClientVersion> {
   osdkMetadata: typeof $osdkMetadata;
   description: 'Boundaries US State';
   links: {};

--- a/examples-extra/basic/sdk/src/generatedNoCheck/ontology/objects/BuilderDeploymentState.ts
+++ b/examples-extra/basic/sdk/src/generatedNoCheck/ontology/objects/BuilderDeploymentState.ts
@@ -1,9 +1,10 @@
 import type { ObjectTypeDefinition, PropertyDef, VersionBound } from '@osdk/api';
+import type { $ExpectedClientVersion } from '../../OntologyMetadata.js';
 import { $osdkMetadata } from '../../OntologyMetadata.js';
 
 export interface BuilderDeploymentState
   extends ObjectTypeDefinition<'BuilderDeploymentState', BuilderDeploymentState>,
-    VersionBound<'0.15.0'> {
+    VersionBound<$ExpectedClientVersion> {
   osdkMetadata: typeof $osdkMetadata;
   description: 'Builder Deployment State';
   links: {};

--- a/examples-extra/basic/sdk/src/generatedNoCheck/ontology/objects/Employee.ts
+++ b/examples-extra/basic/sdk/src/generatedNoCheck/ontology/objects/Employee.ts
@@ -1,9 +1,10 @@
 import type { ObjectTypeDefinition, ObjectTypeLinkDefinition, PropertyDef, VersionBound } from '@osdk/api';
+import type { $ExpectedClientVersion } from '../../OntologyMetadata.js';
 import { $osdkMetadata } from '../../OntologyMetadata.js';
 
 import type { Venture } from './Venture.js';
 
-export interface Employee extends ObjectTypeDefinition<'Employee', Employee>, VersionBound<'0.15.0'> {
+export interface Employee extends ObjectTypeDefinition<'Employee', Employee>, VersionBound<$ExpectedClientVersion> {
   osdkMetadata: typeof $osdkMetadata;
   description: 'An employee';
   implements: ['FooInterface'];

--- a/examples-extra/basic/sdk/src/generatedNoCheck/ontology/objects/ObjectTypeWithAllPropertyTypes.ts
+++ b/examples-extra/basic/sdk/src/generatedNoCheck/ontology/objects/ObjectTypeWithAllPropertyTypes.ts
@@ -1,9 +1,10 @@
 import type { ObjectTypeDefinition, PropertyDef, VersionBound } from '@osdk/api';
+import type { $ExpectedClientVersion } from '../../OntologyMetadata.js';
 import { $osdkMetadata } from '../../OntologyMetadata.js';
 
 export interface ObjectTypeWithAllPropertyTypes
   extends ObjectTypeDefinition<'ObjectTypeWithAllPropertyTypes', ObjectTypeWithAllPropertyTypes>,
-    VersionBound<'0.15.0'> {
+    VersionBound<$ExpectedClientVersion> {
   osdkMetadata: typeof $osdkMetadata;
   description: 'A type with all property types';
   links: {};

--- a/examples-extra/basic/sdk/src/generatedNoCheck/ontology/objects/Person.ts
+++ b/examples-extra/basic/sdk/src/generatedNoCheck/ontology/objects/Person.ts
@@ -1,9 +1,10 @@
 import type { ObjectTypeDefinition, ObjectTypeLinkDefinition, PropertyDef, VersionBound } from '@osdk/api';
+import type { $ExpectedClientVersion } from '../../OntologyMetadata.js';
 import { $osdkMetadata } from '../../OntologyMetadata.js';
 
 import type { Todo } from './Todo.js';
 
-export interface Person extends ObjectTypeDefinition<'Person', Person>, VersionBound<'0.15.0'> {
+export interface Person extends ObjectTypeDefinition<'Person', Person>, VersionBound<$ExpectedClientVersion> {
   osdkMetadata: typeof $osdkMetadata;
   description: 'A person';
   links: {

--- a/examples-extra/basic/sdk/src/generatedNoCheck/ontology/objects/Todo.ts
+++ b/examples-extra/basic/sdk/src/generatedNoCheck/ontology/objects/Todo.ts
@@ -1,9 +1,10 @@
 import type { ObjectTypeDefinition, ObjectTypeLinkDefinition, PropertyDef, VersionBound } from '@osdk/api';
+import type { $ExpectedClientVersion } from '../../OntologyMetadata.js';
 import { $osdkMetadata } from '../../OntologyMetadata.js';
 
 import type { Person } from './Person.js';
 
-export interface Todo extends ObjectTypeDefinition<'Todo', Todo>, VersionBound<'0.15.0'> {
+export interface Todo extends ObjectTypeDefinition<'Todo', Todo>, VersionBound<$ExpectedClientVersion> {
   osdkMetadata: typeof $osdkMetadata;
   description: 'Its a todo item.';
   links: {

--- a/examples-extra/basic/sdk/src/generatedNoCheck/ontology/objects/Venture.ts
+++ b/examples-extra/basic/sdk/src/generatedNoCheck/ontology/objects/Venture.ts
@@ -1,9 +1,10 @@
 import type { ObjectTypeDefinition, ObjectTypeLinkDefinition, PropertyDef, VersionBound } from '@osdk/api';
+import type { $ExpectedClientVersion } from '../../OntologyMetadata.js';
 import { $osdkMetadata } from '../../OntologyMetadata.js';
 
 import type { Employee } from './Employee.js';
 
-export interface Venture extends ObjectTypeDefinition<'Venture', Venture>, VersionBound<'0.15.0'> {
+export interface Venture extends ObjectTypeDefinition<'Venture', Venture>, VersionBound<$ExpectedClientVersion> {
   osdkMetadata: typeof $osdkMetadata;
   description: 'A venture';
   links: {

--- a/examples-extra/basic/sdk/src/generatedNoCheck/ontology/objects/WeatherStation.ts
+++ b/examples-extra/basic/sdk/src/generatedNoCheck/ontology/objects/WeatherStation.ts
@@ -1,7 +1,10 @@
 import type { ObjectTypeDefinition, PropertyDef, VersionBound } from '@osdk/api';
+import type { $ExpectedClientVersion } from '../../OntologyMetadata.js';
 import { $osdkMetadata } from '../../OntologyMetadata.js';
 
-export interface WeatherStation extends ObjectTypeDefinition<'WeatherStation', WeatherStation>, VersionBound<'0.15.0'> {
+export interface WeatherStation
+  extends ObjectTypeDefinition<'WeatherStation', WeatherStation>,
+    VersionBound<$ExpectedClientVersion> {
   osdkMetadata: typeof $osdkMetadata;
   description: 'Weather Station';
   links: {};

--- a/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,11 +1,9 @@
 import { OntologyMetadata as OM } from '@osdk/api';
 
-export const expectedClientVersion = '0.15.0';
+export type $ExpectedClientVersion = '0.15.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
-export interface OntologyMetadata extends OM<'0.15.0'> {
-  expectsClientVersion: '0.15.0';
-}
+export interface OntologyMetadata extends OM<$ExpectedClientVersion> {}
 
 export const OntologyMetadata: OntologyMetadata = {
   expectsClientVersion: '0.15.0',

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Employee.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Employee.ts
@@ -1,7 +1,8 @@
 import type { ObjectTypeDefinition, ObjectTypeLinkDefinition, PropertyDef, VersionBound } from '@osdk/api';
+import type { $ExpectedClientVersion } from '../../OntologyMetadata';
 import { $osdkMetadata } from '../../OntologyMetadata';
 
-export interface Employee extends ObjectTypeDefinition<'Employee', Employee>, VersionBound<'0.15.0'> {
+export interface Employee extends ObjectTypeDefinition<'Employee', Employee>, VersionBound<$ExpectedClientVersion> {
   osdkMetadata: typeof $osdkMetadata;
   description: 'A full-time or part-time employee of our firm';
   links: {

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Office.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Office.ts
@@ -1,7 +1,8 @@
 import type { ObjectTypeDefinition, PropertyDef, VersionBound } from '@osdk/api';
+import type { $ExpectedClientVersion } from '../../OntologyMetadata';
 import { $osdkMetadata } from '../../OntologyMetadata';
 
-export interface Office extends ObjectTypeDefinition<'Office', Office>, VersionBound<'0.15.0'> {
+export interface Office extends ObjectTypeDefinition<'Office', Office>, VersionBound<$ExpectedClientVersion> {
   osdkMetadata: typeof $osdkMetadata;
   description: 'A office in our Company';
   links: {};

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Todo.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Todo.ts
@@ -1,7 +1,8 @@
 import type { ObjectTypeDefinition, PropertyDef, VersionBound } from '@osdk/api';
+import type { $ExpectedClientVersion } from '../../OntologyMetadata';
 import { $osdkMetadata } from '../../OntologyMetadata';
 
-export interface Todo extends ObjectTypeDefinition<'Todo', Todo>, VersionBound<'0.15.0'> {
+export interface Todo extends ObjectTypeDefinition<'Todo', Todo>, VersionBound<$ExpectedClientVersion> {
   osdkMetadata: typeof $osdkMetadata;
   description: 'Its a todo item.';
   links: {};

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/equipment.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/equipment.ts
@@ -1,7 +1,8 @@
 import type { ObjectTypeDefinition, PropertyDef, VersionBound } from '@osdk/api';
+import type { $ExpectedClientVersion } from '../../OntologyMetadata';
 import { $osdkMetadata } from '../../OntologyMetadata';
 
-export interface equipment extends ObjectTypeDefinition<'equipment', equipment>, VersionBound<'0.15.0'> {
+export interface equipment extends ObjectTypeDefinition<'equipment', equipment>, VersionBound<$ExpectedClientVersion> {
   osdkMetadata: typeof $osdkMetadata;
   links: {};
   primaryKeyApiName: 'equipmentId';

--- a/examples-extra/todoapp/src/generatedNoCheck2/OntologyMetadata.ts
+++ b/examples-extra/todoapp/src/generatedNoCheck2/OntologyMetadata.ts
@@ -1,11 +1,9 @@
 import { OntologyMetadata as OM } from '@osdk/api';
 
-export const expectedClientVersion = '0.15.0';
+export type $ExpectedClientVersion = '0.15.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
-export interface OntologyMetadata extends OM<'0.15.0'> {
-  expectsClientVersion: '0.15.0';
-}
+export interface OntologyMetadata extends OM<$ExpectedClientVersion> {}
 
 export const OntologyMetadata: OntologyMetadata = {
   expectsClientVersion: '0.15.0',

--- a/examples-extra/todoapp/src/generatedNoCheck2/ontology/objects/Todo.ts
+++ b/examples-extra/todoapp/src/generatedNoCheck2/ontology/objects/Todo.ts
@@ -1,7 +1,8 @@
 import type { ObjectTypeDefinition, PropertyDef, VersionBound } from '@osdk/api';
+import type { $ExpectedClientVersion } from '../../OntologyMetadata';
 import { $osdkMetadata } from '../../OntologyMetadata';
 
-export interface Todo extends ObjectTypeDefinition<'Todo', Todo>, VersionBound<'0.15.0'> {
+export interface Todo extends ObjectTypeDefinition<'Todo', Todo>, VersionBound<$ExpectedClientVersion> {
   osdkMetadata: typeof $osdkMetadata;
   description: 'Its a todo item.';
   links: {};

--- a/packages/generator/src/shared/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.ts
+++ b/packages/generator/src/shared/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.ts
@@ -40,7 +40,7 @@ export function __UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst(
 
   function getV2Types() {
     return `
-  export interface ${objectDefIdentifier} extends InterfaceDefinition<"${interfaceDef.apiName}", ${interfaceDef.apiName}>, VersionBound<"${process.env.PACKAGE_CLIENT_VERSION}"> {
+  export interface ${objectDefIdentifier} extends InterfaceDefinition<"${interfaceDef.apiName}", ${interfaceDef.apiName}>, VersionBound<$ExpectedClientVersion> {
     osdkMetadata: typeof $osdkMetadata;
     ${
       stringify(definition, {

--- a/packages/generator/src/shared/wireObjectTypeV2ToSdkObjectConst.ts
+++ b/packages/generator/src/shared/wireObjectTypeV2ToSdkObjectConst.ts
@@ -70,7 +70,7 @@ export function wireObjectTypeV2ToSdkObjectConst(
 
   function getV2Types() {
     return `
-      export interface ${objectDefIdentifier} extends ObjectTypeDefinition<"${object.objectType.apiName}", ${object.objectType.apiName}>, VersionBound<"${process.env.PACKAGE_CLIENT_VERSION}"> {
+      export interface ${objectDefIdentifier} extends ObjectTypeDefinition<"${object.objectType.apiName}", ${object.objectType.apiName}>, VersionBound<$ExpectedClientVersion> {
         osdkMetadata: typeof $osdkMetadata;
         ${
       stringify(definition, {

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
@@ -124,7 +124,8 @@ export async function generateClientSdkVersionTwoPointZero(
       await formatTs(`
         import type { ObjectTypeDefinition, VersionBound, ObjectTypeLinkDefinition, PropertyDef } from "@osdk/api";
         import { Osdk } from "@osdk/client";
-        import { $osdkMetadata} from "../../OntologyMetadata${importExt}";
+        import { $osdkMetadata } from "../../OntologyMetadata${importExt}";
+        import type { $ExpectedClientVersion } from "../../OntologyMetadata${importExt}";
 
         ${wireObjectTypeV2ToSdkObjectConst(obj, importExt, true)}
       `),
@@ -191,7 +192,8 @@ async function generateOntologyInterfaces(
       await formatTs(`
     
       import type { InterfaceDefinition, PropertyDef, VersionBound } from "@osdk/api";
-      import { $osdkMetadata} from "../../OntologyMetadata${importExt}";
+      import { $osdkMetadata, $expectedClientVersion } from "../../OntologyMetadata${importExt}";
+      import type { $ExpectedClientVersion } from "../../OntologyMetadata${importExt}";
 
       ${__UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst(obj, true)}
     `),

--- a/packages/generator/src/v2.0/generateMetadata.ts
+++ b/packages/generator/src/v2.0/generateMetadata.ts
@@ -35,12 +35,10 @@ export async function generateOntologyMetadataFile(
       `
       import { OntologyMetadata as OM } from "@osdk/api";
 
-      export const expectedClientVersion = "${process.env.PACKAGE_CLIENT_VERSION}";
+      export type $ExpectedClientVersion = "${ExpectedOsdkVersion}";
       export const $osdkMetadata = { extraUserAgent: "${userAgent}" };
 
-      export interface OntologyMetadata extends OM<"${ExpectedOsdkVersion}"> {
-        expectsClientVersion: "${ExpectedOsdkVersion}",
-      };
+      export interface OntologyMetadata extends OM<$ExpectedClientVersion> {};
 
       export const OntologyMetadata: OntologyMetadata = {
         expectsClientVersion: "${ExpectedOsdkVersion}",


### PR DESCRIPTION
Version bumps with snapshots have `-whatever` in them which breaks the semver logic. We are instead just assuming its a release version to get through it.

This also fixes a bug in the logic for auto version updating.

This change also pushes the version expected for generated code into one central place per generated sdk which should prevent future repo churn as we rev client versions.
