### PR TITLE
Check for changesets separately

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,37 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
+  changesets:
+    name: Check for changesets
+    if: ${{ github.event_name == 'pull_request' }}
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 8.7.4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Check for changesets
+        run: |
+          git fetch origin main:main
+          git checkout ${GITHUB_HEAD_REF}
+          pnpm exec changeset status --since=main
+
+
   build:
     name: Build and Test
     timeout-minutes: 15
@@ -26,7 +57,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - uses: pnpm/action-setup@v3
         with:
@@ -53,11 +84,4 @@ jobs:
 
       - name: Verify nothing added
         run: u="$(git ls-files --others --exclude-standard)" && test -z "$u"
-
-      - name: Check for changesets
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          git fetch origin main:main
-          git checkout ${GITHUB_HEAD_REF}
-          pnpm exec changeset status --since=main
 


### PR DESCRIPTION
It's annoying to see a build failure on 18,20,21 when its really a changeset error, especially when dealing with dependabot. 

This change separates the check. We can also use this to skip the changeset if we so desire.