### PR TITLE
Add fetchOneWithErrors

### DIFF
--- a/.changeset/angry-trees-carry.md
+++ b/.changeset/angry-trees-carry.md
@@ -1,0 +1,6 @@
+---
+"@osdk/foundry-sdk-generator": patch
+"@osdk/legacy-client": patch
+---
+
+Add fetchone, that is get replacement without result wrapper

--- a/.changeset/slow-kids-hide.md
+++ b/.changeset/slow-kids-hide.md
@@ -1,0 +1,6 @@
+---
+"@osdk/foundry-sdk-generator": patch
+"@osdk/legacy-client": patch
+---
+
+Deprecate get and add fetchonewitherrors, which functionally is the same

--- a/packages/foundry-sdk-generator/src/__e2e_tests__/actions.test.ts
+++ b/packages/foundry-sdk-generator/src/__e2e_tests__/actions.test.ts
@@ -108,6 +108,13 @@ describe("test", () => {
       expect(officeImpl2.__rid).toBe(
         "ri.phonograph2-objects.main.object.c0c0c0c0-c0c0-c0c0-c0c0-c0c0c0c0c0c0",
       );
+
+      const officeNoErrors: Office = await objectEdit.fetchOne();
+      expect(officeNoErrors.__apiName).toBe("Office");
+      expect(officeNoErrors.__primaryKey).toBe("NYC");
+      expect(officeNoErrors.__rid).toBe(
+        "ri.phonograph2-objects.main.object.c0c0c0c0-c0c0-c0c0-c0c0-c0c0c0c0c0c0",
+      );
     }
   });
 

--- a/packages/foundry-sdk-generator/src/__e2e_tests__/actions.test.ts
+++ b/packages/foundry-sdk-generator/src/__e2e_tests__/actions.test.ts
@@ -100,6 +100,14 @@ describe("test", () => {
       expect(officeImpl.__rid).toBe(
         "ri.phonograph2-objects.main.object.c0c0c0c0-c0c0-c0c0-c0c0-c0c0c0c0c0c0",
       );
+      const officeResult2: Result<Office, GetObjectError> = await objectEdit
+        .fetchOneWithErrors();
+      const officeImpl2: Office = assertOkOrThrow(officeResult2);
+      expect(officeImpl2.__apiName).toBe("Office");
+      expect(officeImpl2.__primaryKey).toBe("NYC");
+      expect(officeImpl2.__rid).toBe(
+        "ri.phonograph2-objects.main.object.c0c0c0c0-c0c0-c0c0-c0c0-c0c0c0c0c0c0",
+      );
     }
   });
 

--- a/packages/foundry-sdk-generator/src/__e2e_tests__/loadObjects.test.ts
+++ b/packages/foundry-sdk-generator/src/__e2e_tests__/loadObjects.test.ts
@@ -101,6 +101,22 @@ describe("LoadObjects", () => {
     expect(destructured.office).toEqual("SF");
   });
 
+  it("Loads object which can be destructured with fetchOne", async () => {
+    const emp: Employee = await client.ontology
+      .objects.Employee.fetchOne(
+        stubData.employee1.__primaryKey,
+      );
+
+    expect(emp.employeeId).toEqual(50030);
+    expect(emp.fullName).toEqual("John Doe");
+    expect(emp.office).toEqual("NYC");
+    expect(emp.startDate).toEqual(LocalDate.fromISOString("2019-01-01"));
+
+    const destructured: Employee = { ...emp, office: "SF" };
+    expect(destructured.fullName).toEqual("John Doe");
+    expect(destructured.office).toEqual("SF");
+  });
+
   it("Loads object with specified properties", async () => {
     const result = await client.ontology.objects.Employee.select(["fullName"])
       .get(stubData.employee1.__primaryKey);
@@ -124,6 +140,22 @@ describe("LoadObjects", () => {
       .fetchOneWithErrors(stubData.employee1.__primaryKey);
 
     const emp = assertOkOrThrow(result);
+
+    expectTypeOf(emp).toEqualTypeOf<{
+      readonly fullName: string | undefined;
+      readonly __primaryKey: number;
+      readonly __apiName: "Employee";
+      readonly $primaryKey: number;
+      readonly $apiName: "Employee";
+    }>();
+
+    expect(emp.fullName).toEqual("John Doe");
+    expect((emp as any).office).toBeUndefined();
+  });
+
+  it("Loads object with specified properties - fetchOne", async () => {
+    const emp = await client.ontology.objects.Employee.select(["fullName"])
+      .fetchOne(stubData.employee1.__primaryKey);
 
     expectTypeOf(emp).toEqualTypeOf<{
       readonly fullName: string | undefined;

--- a/packages/legacy-client/src/client/actions/actions.test.ts
+++ b/packages/legacy-client/src/client/actions/actions.test.ts
@@ -501,12 +501,14 @@ describe("Actions", () => {
     "modified": [
       {
         "apiName": "Office",
+        "fetchOne": [Function],
         "fetchOneWithErrors": [Function],
         "get": [Function],
         "primaryKey": "SEA",
       },
       {
         "apiName": "Office",
+        "fetchOne": [Function],
         "fetchOneWithErrors": [Function],
         "get": [Function],
         "primaryKey": "NYC",

--- a/packages/legacy-client/src/client/actions/actions.test.ts
+++ b/packages/legacy-client/src/client/actions/actions.test.ts
@@ -501,11 +501,13 @@ describe("Actions", () => {
     "modified": [
       {
         "apiName": "Office",
+        "fetchOneWithErrors": [Function],
         "get": [Function],
         "primaryKey": "SEA",
       },
       {
         "apiName": "Office",
+        "fetchOneWithErrors": [Function],
         "get": [Function],
         "primaryKey": "NYC",
       },

--- a/packages/legacy-client/src/client/baseTypes/ActionType.ts
+++ b/packages/legacy-client/src/client/baseTypes/ActionType.ts
@@ -66,7 +66,9 @@ export declare type ObjectEdit<T extends OntologyObject> = {
     primaryKey: Extract<T, {
       __apiName: K;
     }>["__primaryKey"];
+    /** @deprecated use fetchOneWithErrors instead */
     get: () => Promise<Result<T, GetObjectError>>;
+    fetchOneWithErrors: () => Promise<Result<T, GetObjectError>>;
   };
 }[T["$apiName"]];
 
@@ -228,6 +230,8 @@ function getEdits(
         apiName: edit.objectType,
         primaryKey: edit.primaryKey,
         get: () => getObject(client, edit.objectType, edit.primaryKey),
+        fetchOneWithErrors: () =>
+          getObject(client, edit.objectType, edit.primaryKey),
       });
     }
     if (edit.type === "modifyObject") {
@@ -235,6 +239,8 @@ function getEdits(
         apiName: edit.objectType,
         primaryKey: edit.primaryKey,
         get: () => getObject(client, edit.objectType, edit.primaryKey),
+        fetchOneWithErrors: () =>
+          getObject(client, edit.objectType, edit.primaryKey),
       });
     }
   }

--- a/packages/legacy-client/src/client/baseTypes/ActionType.ts
+++ b/packages/legacy-client/src/client/baseTypes/ActionType.ts
@@ -21,7 +21,7 @@ import type {
   SyncApplyActionResponseV2,
 } from "@osdk/gateway/types";
 import type { ClientContext } from "@osdk/shared.net";
-import { getObject } from "../../client/net/getObject";
+import { getObject, getObjectWithoutErrors } from "../../client/net/getObject";
 import type { GetObjectError } from "../errors";
 import type { Result } from "../Result";
 import type { OntologyObject } from "./OntologyObject";
@@ -69,6 +69,7 @@ export declare type ObjectEdit<T extends OntologyObject> = {
     /** @deprecated use fetchOneWithErrors instead */
     get: () => Promise<Result<T, GetObjectError>>;
     fetchOneWithErrors: () => Promise<Result<T, GetObjectError>>;
+    fetchOne: () => Promise<T>;
   };
 }[T["$apiName"]];
 
@@ -232,6 +233,8 @@ function getEdits(
         get: () => getObject(client, edit.objectType, edit.primaryKey),
         fetchOneWithErrors: () =>
           getObject(client, edit.objectType, edit.primaryKey),
+        fetchOne: () =>
+          getObjectWithoutErrors(client, edit.objectType, edit.primaryKey),
       });
     }
     if (edit.type === "modifyObject") {
@@ -241,6 +244,8 @@ function getEdits(
         get: () => getObject(client, edit.objectType, edit.primaryKey),
         fetchOneWithErrors: () =>
           getObject(client, edit.objectType, edit.primaryKey),
+        fetchOne: () =>
+          getObjectWithoutErrors(client, edit.objectType, edit.primaryKey),
       });
     }
   }

--- a/packages/legacy-client/src/client/baseTypes/links.ts
+++ b/packages/legacy-client/src/client/baseTypes/links.ts
@@ -29,6 +29,10 @@ export interface SingleLink<T extends OntologyObject = OntologyObject> {
    * Loads the linked object
    */
   fetchOneWithErrors(): Promise<Result<T, GetLinkedObjectError>>;
+  /**
+   * Loads the linked object, without a result wrapper
+   */
+  fetchOne(): Promise<T>;
 }
 
 export interface MultiLink<T extends OntologyObject = OntologyObject> {
@@ -47,6 +51,14 @@ export interface MultiLink<T extends OntologyObject = OntologyObject> {
   fetchOneWithErrors(
     primaryKey: T["__primaryKey"],
   ): Promise<Result<T, GetLinkedObjectError>>;
+  /**
+   * Loads the linked object with the given primary key, without a result wrapper
+   *
+   * @param primaryKey
+   */
+  fetchOne(
+    primaryKey: T["__primaryKey"],
+  ): Promise<T>;
   /**
    * Gets all the linked objects
    * @deprecated use asyncIter instead

--- a/packages/legacy-client/src/client/baseTypes/links.ts
+++ b/packages/legacy-client/src/client/baseTypes/links.ts
@@ -22,8 +22,13 @@ import type { OntologyObject } from "./OntologyObject";
 export interface SingleLink<T extends OntologyObject = OntologyObject> {
   /**
    * Loads the linked object
+   * @deprecated use fetchOneWithErrors instead
    */
   get(): Promise<Result<T, GetLinkedObjectError>>;
+  /**
+   * Loads the linked object
+   */
+  fetchOneWithErrors(): Promise<Result<T, GetLinkedObjectError>>;
 }
 
 export interface MultiLink<T extends OntologyObject = OntologyObject> {
@@ -31,8 +36,17 @@ export interface MultiLink<T extends OntologyObject = OntologyObject> {
    * Loads the linked object with the given primary key
    *
    * @param primaryKey
+   * @deprecated use fetchOneWithErrors instead
    */
   get(primaryKey: T["__primaryKey"]): Promise<Result<T, GetLinkedObjectError>>;
+  /**
+   * Loads the linked object with the given primary key
+   *
+   * @param primaryKey
+   */
+  fetchOneWithErrors(
+    primaryKey: T["__primaryKey"],
+  ): Promise<Result<T, GetLinkedObjectError>>;
   /**
    * Gets all the linked objects
    * @deprecated use asyncIter instead

--- a/packages/legacy-client/src/client/baseTypes/objectset/FilteredPropertiesTerminalOperations.ts
+++ b/packages/legacy-client/src/client/baseTypes/objectset/FilteredPropertiesTerminalOperations.ts
@@ -116,4 +116,12 @@ export type FilteredPropertiesTerminalOperationsWithGet<
       GetObjectError
     >
   >;
+  fetchOne(
+    primaryKey: T["$primaryKey"],
+  ): Promise<
+    Pick<
+      T,
+      V[number] | "$apiName" | "$primaryKey" | "__apiName" | "__primaryKey"
+    >
+  >;
 };

--- a/packages/legacy-client/src/client/baseTypes/objectset/FilteredPropertiesTerminalOperations.ts
+++ b/packages/legacy-client/src/client/baseTypes/objectset/FilteredPropertiesTerminalOperations.ts
@@ -93,7 +93,19 @@ export type FilteredPropertiesTerminalOperationsWithGet<
   T extends OntologyObject,
   V extends Array<keyof T>,
 > = FilteredPropertiesTerminalOperations<T, V> & {
+  /** @deprecated use fetchOneWithErrors */
   get(
+    primaryKey: T["$primaryKey"],
+  ): Promise<
+    Result<
+      Pick<
+        T,
+        V[number] | "$apiName" | "$primaryKey" | "__apiName" | "__primaryKey"
+      >,
+      GetObjectError
+    >
+  >;
+  fetchOneWithErrors(
     primaryKey: T["$primaryKey"],
   ): Promise<
     Result<

--- a/packages/legacy-client/src/client/interfaces/baseObjectSet.ts
+++ b/packages/legacy-client/src/client/interfaces/baseObjectSet.ts
@@ -35,7 +35,12 @@ export type BaseObjectSetOperations<O extends OntologyObject> = {
 
   properties: Properties<O>;
 
+  /** @deprecated use fetchOneWithErrors instead */
   get(primaryKey: O["$primaryKey"]): Promise<Result<O, GetObjectError>>;
+
+  fetchOneWithErrors(
+    primaryKey: O["$primaryKey"],
+  ): Promise<Result<O, GetObjectError>>;
 
   select<T extends keyof SelectableProperties<O>>(
     properties: readonly T[],

--- a/packages/legacy-client/src/client/interfaces/baseObjectSet.ts
+++ b/packages/legacy-client/src/client/interfaces/baseObjectSet.ts
@@ -42,6 +42,10 @@ export type BaseObjectSetOperations<O extends OntologyObject> = {
     primaryKey: O["$primaryKey"],
   ): Promise<Result<O, GetObjectError>>;
 
+  fetchOne(
+    primaryKey: O["$primaryKey"],
+  ): Promise<O>;
+
   select<T extends keyof SelectableProperties<O>>(
     properties: readonly T[],
   ): FilteredPropertiesTerminalOperationsWithGet<O, T[]>;

--- a/packages/legacy-client/src/client/net/getLinkedObject.ts
+++ b/packages/legacy-client/src/client/net/getLinkedObject.ts
@@ -37,23 +37,14 @@ export function getLinkedObject<T extends OntologyObject>(
   linkedObjectPrimaryKey: string,
 ): Promise<Result<T, GetLinkedObjectError>> {
   return wrapResult(
-    async () => {
-      const object = await getLinkedObjectV2(
-        createOpenApiRequest(client.stack, client.fetch),
-        client.ontology.metadata.ontologyApiName,
+    async () =>
+      getLinkedObjectNoErrors(
+        client,
         sourceApiName,
         primaryKey,
         linkTypeApiName,
         linkedObjectPrimaryKey,
-        {
-          select: [],
-        },
-      );
-      return convertWireToOsdkObject(
-        client,
-        object as WireOntologyObjectV2<T["__apiName"]>,
-      ) as unknown as T;
-    },
+      ),
     e =>
       handleGetLinkedObjectError(
         new GetLinkedObjectErrorHandler(),
@@ -61,4 +52,28 @@ export function getLinkedObject<T extends OntologyObject>(
         e.parameters,
       ),
   );
+}
+
+export async function getLinkedObjectNoErrors<T extends OntologyObject>(
+  client: ClientContext<OntologyDefinition<T["__apiName"]>>,
+  sourceApiName: string,
+  primaryKey: any,
+  linkTypeApiName: string,
+  linkedObjectPrimaryKey: string,
+): Promise<T> {
+  const object = await getLinkedObjectV2(
+    createOpenApiRequest(client.stack, client.fetch),
+    client.ontology.metadata.ontologyApiName,
+    sourceApiName,
+    primaryKey,
+    linkTypeApiName,
+    linkedObjectPrimaryKey,
+    {
+      select: [],
+    },
+  );
+  return convertWireToOsdkObject(
+    client,
+    object as WireOntologyObjectV2<T["__apiName"]>,
+  ) as unknown as T;
 }

--- a/packages/legacy-client/src/client/net/getOnlyLinkedObject.ts
+++ b/packages/legacy-client/src/client/net/getOnlyLinkedObject.ts
@@ -15,11 +15,14 @@
  */
 
 import type { OntologyDefinition } from "@osdk/api";
-import type { ClientContext } from "@osdk/shared.net";
+import { type ClientContext, PalantirApiError } from "@osdk/shared.net";
 import type { OntologyObject, ParameterValue } from "../baseTypes";
 import type { GetLinkedObjectError, LinkedObjectNotFound } from "../errors";
 import { isErr, type Result } from "../Result";
-import { listLinkedObjects } from "./listLinkedObjects";
+import {
+  listLinkedObjects,
+  listLinkedObjectsWithoutErrors,
+} from "./listLinkedObjects";
 import { createErrorResponse } from "./util/ResponseCreators";
 
 /**
@@ -78,4 +81,27 @@ export async function getOnlyLinkedObject<
   }
 
   return { type: "ok", value: result.value[0] };
+}
+
+export async function getOnlyLinkedObjectNoErrors<
+  T extends OntologyObject = OntologyObject,
+>(
+  client: ClientContext<OntologyDefinition<any>>,
+  sourceObjectType: string,
+  sourcePrimaryKey: NonNullable<ParameterValue>,
+  targetLinkType: string,
+): Promise<T> {
+  const result = await listLinkedObjectsWithoutErrors<T>(
+    client,
+    sourceObjectType,
+    sourcePrimaryKey,
+    targetLinkType,
+  );
+  if (result.length !== 1) {
+    throw new PalantirApiError(
+      `Expected a single result but got ${result.length} instead`,
+    );
+  }
+
+  return result[0];
 }

--- a/packages/legacy-client/src/client/net/listLinkedObjects.ts
+++ b/packages/legacy-client/src/client/net/listLinkedObjects.ts
@@ -34,27 +34,13 @@ export function listLinkedObjects<T extends OntologyObject>(
   linkTypeApiName: T["__apiName"],
 ): Promise<Result<T[], ListLinkedObjectsError>> {
   return wrapResult(
-    async () => {
-      const allObjects: T[] = [];
-
-      let page: Page<T> | undefined;
-      do {
-        page = await getLinkedObjectsPage<T>(
-          client,
-          sourceApiName,
-          primaryKey,
-          linkTypeApiName,
-          {
-            pageToken: page?.nextPageToken,
-          },
-        );
-        for (const object of page.data) {
-          allObjects.push(object);
-        }
-      } while (page.nextPageToken);
-
-      return allObjects;
-    },
+    async () =>
+      listLinkedObjectsWithoutErrors(
+        client,
+        sourceApiName,
+        primaryKey,
+        linkTypeApiName,
+      ),
     e =>
       handleListLinkedObjectsError(
         new ListLinkedObjectsErrorHandler(),
@@ -62,6 +48,33 @@ export function listLinkedObjects<T extends OntologyObject>(
         e.parameters,
       ),
   );
+}
+
+export async function listLinkedObjectsWithoutErrors<T extends OntologyObject>(
+  client: ClientContext<OntologyDefinition<any>>,
+  sourceApiName: string,
+  primaryKey: any,
+  linkTypeApiName: T["__apiName"],
+): Promise<T[]> {
+  const allObjects: T[] = [];
+
+  let page: Page<T> | undefined;
+  do {
+    page = await getLinkedObjectsPage<T>(
+      client,
+      sourceApiName,
+      primaryKey,
+      linkTypeApiName,
+      {
+        pageToken: page?.nextPageToken,
+      },
+    );
+    for (const object of page.data) {
+      allObjects.push(object);
+    }
+  } while (page.nextPageToken);
+
+  return allObjects;
 }
 
 export async function* loadLinkedObjects<T extends OntologyObject>(

--- a/packages/legacy-client/src/client/objectSets/OsdkObjectSet.ts
+++ b/packages/legacy-client/src/client/objectSets/OsdkObjectSet.ts
@@ -34,7 +34,7 @@ import type {
   LinksProperties,
   SelectableProperties,
 } from "../interfaces/utils/OmitProperties";
-import { getObject } from "../net/getObject";
+import { getObject, getObjectWithoutErrors } from "../net/getObject";
 import type { OsdkLegacyObjectFrom } from "../OsdkLegacyObject";
 import { createCachedOntologyTransform } from "./createCachedOntologyTransform";
 import { createFilteredPropertiesObjectSetWithGetTerminalOperationsStep } from "./createFilteredPropertiesObjectSetWithGetTerminalOperationsStep";
@@ -202,6 +202,11 @@ export function createBaseOsdkObjectSet<
     fetchOneWithErrors(primaryKey) {
       return getObject(client, apiName, primaryKey);
     },
+
+    fetchOne(primaryKey) {
+      return getObjectWithoutErrors(client, apiName, primaryKey);
+    },
+
     select(properties) {
       return createFilteredPropertiesObjectSetWithGetTerminalOperationsStep(
         client,

--- a/packages/legacy-client/src/client/objectSets/OsdkObjectSet.ts
+++ b/packages/legacy-client/src/client/objectSets/OsdkObjectSet.ts
@@ -198,6 +198,10 @@ export function createBaseOsdkObjectSet<
     get(primaryKey) {
       return getObject(client, apiName, primaryKey);
     },
+
+    fetchOneWithErrors(primaryKey) {
+      return getObject(client, apiName, primaryKey);
+    },
     select(properties) {
       return createFilteredPropertiesObjectSetWithGetTerminalOperationsStep(
         client,

--- a/packages/legacy-client/src/client/objectSets/createFilteredPropertiesObjectSetWithGetTerminalOperationsStep.ts
+++ b/packages/legacy-client/src/client/objectSets/createFilteredPropertiesObjectSetWithGetTerminalOperationsStep.ts
@@ -21,7 +21,7 @@ import type {
   ObjectSetDefinition,
 } from "..";
 import type { SelectableProperties } from "../interfaces/utils/OmitProperties";
-import { getObject } from "../net/getObject";
+import { getObject, getObjectWithoutErrors } from "../net/getObject";
 import { loadAllObjects } from "../net/loadObjects";
 import {
   loadObjectsIterator,
@@ -100,6 +100,14 @@ export function createFilteredPropertiesObjectSetWithGetTerminalOperationsStep<
     },
     fetchOneWithErrors(primaryKey) {
       return getObject(client, apiName as string, primaryKey, properties);
+    },
+    fetchOne(primaryKey) {
+      return getObjectWithoutErrors(
+        client,
+        apiName as string,
+        primaryKey,
+        properties,
+      );
     },
   };
 }

--- a/packages/legacy-client/src/client/objectSets/createFilteredPropertiesObjectSetWithGetTerminalOperationsStep.ts
+++ b/packages/legacy-client/src/client/objectSets/createFilteredPropertiesObjectSetWithGetTerminalOperationsStep.ts
@@ -98,5 +98,8 @@ export function createFilteredPropertiesObjectSetWithGetTerminalOperationsStep<
     get(primaryKey) {
       return getObject(client, apiName as string, primaryKey, properties);
     },
+    fetchOneWithErrors(primaryKey) {
+      return getObject(client, apiName as string, primaryKey, properties);
+    },
   };
 }

--- a/packages/legacy-client/src/client/objects/createMultiLinkStep.ts
+++ b/packages/legacy-client/src/client/objects/createMultiLinkStep.ts
@@ -44,7 +44,17 @@ export function createMultiLinkStep<T extends OntologyObject = OntologyObject>(
         primaryKey.toString(),
       );
     },
-
+    fetchOneWithErrors(
+      primaryKey: T["__primaryKey"],
+    ): Promise<Result<T, GetLinkedObjectError>> {
+      return getLinkedObject(
+        client,
+        sourceApiName,
+        sourcePrimaryKey,
+        targetApiName,
+        primaryKey.toString(),
+      );
+    },
     all(): Promise<Result<T[], ListLinkedObjectsError>> {
       return listLinkedObjects(
         client,

--- a/packages/legacy-client/src/client/objects/createMultiLinkStep.ts
+++ b/packages/legacy-client/src/client/objects/createMultiLinkStep.ts
@@ -17,7 +17,10 @@
 import type { ClientContext } from "@osdk/shared.net";
 import type { MultiLink, OntologyObject, ParameterValue } from "../baseTypes";
 import type { GetLinkedObjectError, ListLinkedObjectsError } from "../errors";
-import { getLinkedObject } from "../net/getLinkedObject";
+import {
+  getLinkedObject,
+  getLinkedObjectNoErrors,
+} from "../net/getLinkedObject";
 import { listLinkedObjects, loadLinkedObjects } from "../net/listLinkedObjects";
 import {
   pageLinkedObjects,
@@ -48,6 +51,17 @@ export function createMultiLinkStep<T extends OntologyObject = OntologyObject>(
       primaryKey: T["__primaryKey"],
     ): Promise<Result<T, GetLinkedObjectError>> {
       return getLinkedObject(
+        client,
+        sourceApiName,
+        sourcePrimaryKey,
+        targetApiName,
+        primaryKey.toString(),
+      );
+    },
+    fetchOne(
+      primaryKey: T["__primaryKey"],
+    ): Promise<T> {
+      return getLinkedObjectNoErrors(
         client,
         sourceApiName,
         sourcePrimaryKey,

--- a/packages/legacy-client/src/client/objects/createSingleLinkStep.ts
+++ b/packages/legacy-client/src/client/objects/createSingleLinkStep.ts
@@ -18,7 +18,10 @@ import type { ClientContext } from "@osdk/shared.net";
 
 import type { OntologyObject, ParameterValue, SingleLink } from "../baseTypes";
 import type { GetLinkedObjectError } from "../errors";
-import { getOnlyLinkedObject } from "../net/getOnlyLinkedObject";
+import {
+  getOnlyLinkedObject,
+  getOnlyLinkedObjectNoErrors,
+} from "../net/getOnlyLinkedObject";
 import type { Result } from "../Result";
 
 export function createSingleLinkStep<T extends OntologyObject = OntologyObject>(
@@ -38,6 +41,14 @@ export function createSingleLinkStep<T extends OntologyObject = OntologyObject>(
     },
     async fetchOneWithErrors(): Promise<Result<T, GetLinkedObjectError>> {
       return getOnlyLinkedObject(
+        client,
+        sourceObjectType,
+        sourcePrimaryKey,
+        targetLinkType,
+      );
+    },
+    async fetchOne(): Promise<T> {
+      return getOnlyLinkedObjectNoErrors(
         client,
         sourceObjectType,
         sourcePrimaryKey,

--- a/packages/legacy-client/src/client/objects/createSingleLinkStep.ts
+++ b/packages/legacy-client/src/client/objects/createSingleLinkStep.ts
@@ -36,5 +36,13 @@ export function createSingleLinkStep<T extends OntologyObject = OntologyObject>(
         targetLinkType,
       );
     },
+    async fetchOneWithErrors(): Promise<Result<T, GetLinkedObjectError>> {
+      return getOnlyLinkedObject(
+        client,
+        sourceObjectType,
+        sourcePrimaryKey,
+        targetLinkType,
+      );
+    },
   };
 }


### PR DESCRIPTION
Deprecates `get` and replaces with `fetchOneWithErrors`, functionally they are exactly the same. This is just to be more consistent with our other fetch methods, and the `fetchOne` method that will be added to return without a `Result` wrapper.