### PR TITLE
Deprecate get and add fetchOne

### DIFF
--- a/.changeset/rich-eels-cough.md
+++ b/.changeset/rich-eels-cough.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": minor
+---
+
+Deprecated get and added fetchOne as a replacement. They function exactly the same.

--- a/packages/client/src/definitions/LinkDefinitions.ts
+++ b/packages/client/src/definitions/LinkDefinitions.ts
@@ -45,8 +45,26 @@ export type DefaultToFalse<B extends boolean | undefined> = false extends B
   : true;
 
 export interface SingleLinkAccessor<T extends ObjectTypeDefinition<any>> {
-  /** Load the linked object */
+  /** Load the linked object
+   * @deprecated use fetchOne instead
+   */
   get: <
+    const A extends SelectArg<
+      T,
+      ObjectOrInterfacePropertyKeysFrom2<T>,
+      boolean
+    >,
+  >(
+    options?: A,
+  ) => Promise<
+    DefaultToFalse<A["includeRid"]> extends false
+      ? Osdk<T, SelectArgToKeys<T, A>>
+      : Osdk<T, SelectArgToKeys<T, A> | "$rid">
+  >;
+
+  /** Load the linked object
+   */
+  fetchOne: <
     const A extends SelectArg<
       T,
       ObjectOrInterfacePropertyKeysFrom2<T>,

--- a/packages/client/src/object/convertWireToOsdkObjects.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.ts
@@ -57,7 +57,15 @@ class LinkFetcherProxyHandler<Q extends AugmentedObjectTypeDefinition<any, any>>
 
     if (!linkDef.multiplicity) {
       return {
+        /** @deprecated  */
         get: <A extends SelectArg<any>>(options?: A) =>
+          fetchSingle(
+            this.client,
+            this.objDef,
+            options ?? {},
+            getWireObjectSet(objectSet),
+          ),
+        fetchOne: <A extends SelectArg<any>>(options?: A) =>
           fetchSingle(
             this.client,
             this.objDef,
@@ -104,6 +112,7 @@ function createPrototype<Q extends AugmentedObjectTypeDefinition<any, any>>(
 
   const objectProto = Object.defineProperties({}, {
     $link: {
+      /** @deprecated */
       get: function() {
         return new Proxy(
           {},

--- a/packages/client/src/object/convertWireToOsdkObjects.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.ts
@@ -112,7 +112,6 @@ function createPrototype<Q extends AugmentedObjectTypeDefinition<any, any>>(
 
   const objectProto = Object.defineProperties({}, {
     $link: {
-      /** @deprecated */
       get: function() {
         return new Proxy(
           {},

--- a/packages/client/src/object/object.test.ts
+++ b/packages/client/src/object/object.test.ts
@@ -118,5 +118,29 @@ describe("OsdkObject", () => {
       expect(peep.employeeId).toBeDefined();
       expect((peep as any).employeeStatus).toBeUndefined();
     });
+
+    it("traverses the link from an lead to their peep by primaryKey with fetchOne", async () => {
+      // slightly weird request here to hit the existing mocks for employee2
+      const employees = await client(MockOntology.objects.Employee).where({
+        $and: [
+          { "employeeId": { "$gt": 50030 } },
+          { "employeeId": { "$lt": 50032 } },
+        ],
+      }).fetchPage();
+      const lead = employees.data[0];
+      expect(lead).toBeDefined();
+
+      const peep = await lead.$link.peeps.fetchOne(
+        stubData.employee1.employeeId,
+        {
+          select: ["employeeId"],
+        },
+      );
+      expect(peep).toBeDefined();
+
+      // ensure that select worked
+      expect(peep.employeeId).toBeDefined();
+      expect((peep as any).employeeStatus).toBeUndefined();
+    });
   });
 });

--- a/packages/client/src/objectSet/ObjectSet.test.ts
+++ b/packages/client/src/objectSet/ObjectSet.test.ts
@@ -154,7 +154,7 @@ describe("ObjectSet", () => {
     expect(employee.$primaryKey).toBe(stubData.employee1.employeeId);
   });
 
-  it("allows fetching by PK from a base object set - fetchONe", async () => {
+  it("allows fetching by PK from a base object set - fetchOne", async () => {
     const employee = await client(MockOntology.objects.Employee).fetchOne(
       stubData.employee1.employeeId,
     );

--- a/packages/client/src/objectSet/ObjectSet.test.ts
+++ b/packages/client/src/objectSet/ObjectSet.test.ts
@@ -154,8 +154,29 @@ describe("ObjectSet", () => {
     expect(employee.$primaryKey).toBe(stubData.employee1.employeeId);
   });
 
+  it("allows fetching by PK from a base object set - fetchONe", async () => {
+    const employee = await client(MockOntology.objects.Employee).fetchOne(
+      stubData.employee1.employeeId,
+    );
+    expectTypeOf<typeof employee>().toMatchTypeOf<
+      Osdk<Employee, ObjectOrInterfacePropertyKeysFrom2<Employee>>
+    >;
+    expect(employee.$primaryKey).toBe(stubData.employee1.employeeId);
+  });
+
   it("allows fetching by PK from a base object set with selected properties", async () => {
     const employee = await client(MockOntology.objects.Employee).get(
+      stubData.employee1.employeeId,
+      { select: ["fullName"] },
+    );
+    expectTypeOf<typeof employee>().toEqualTypeOf<
+      Osdk<Employee, "fullName">
+    >;
+    expect(employee.$primaryKey).toBe(stubData.employee1.employeeId);
+  });
+
+  it("allows fetching by PK from a base object set with selected properties - fetchOne", async () => {
+    const employee = await client(MockOntology.objects.Employee).fetchOne(
       stubData.employee1.employeeId,
       { select: ["fullName"] },
     );
@@ -170,11 +191,25 @@ describe("ObjectSet", () => {
       .toThrow();
   });
 
+  it("throws when fetching by PK with an object that does not exist - fetchOne", async () => {
+    await expect(client(MockOntology.objects.Employee).fetchOne(-1)).rejects
+      .toThrow();
+  });
+
   it("allows fetching by PK from a pivoted object set", async () => {
     const employee = await client(MockOntology.objects.Employee).where({
       employeeId: stubData.employee2.employeeId,
     })
       .pivotTo("peeps").get(stubData.employee1.employeeId);
+
+    expect(employee.$primaryKey).toBe(stubData.employee1.employeeId);
+  });
+
+  it("allows fetching by PK from a pivoted object set - fetchOne", async () => {
+    const employee = await client(MockOntology.objects.Employee).where({
+      employeeId: stubData.employee2.employeeId,
+    })
+      .pivotTo("peeps").fetchOne(stubData.employee1.employeeId);
 
     expect(employee.$primaryKey).toBe(stubData.employee1.employeeId);
   });

--- a/packages/client/src/objectSet/ObjectSet.ts
+++ b/packages/client/src/objectSet/ObjectSet.ts
@@ -92,7 +92,15 @@ export interface ObjectSet<Q extends ObjectOrInterfaceDefinition>
 
   pivotTo: <L extends LinkNames<Q>>(type: L) => ObjectSet<LinkedType<Q, L>>;
 
+  /** @deprecated use fetchOne instead*/
   get: Q extends ObjectTypeDefinition<any>
+    ? <L extends ObjectOrInterfacePropertyKeysFrom2<Q>>(
+      primaryKey: PropertyValueClientToWire[Q["primaryKeyType"]],
+      options?: SelectArg<Q, L>,
+    ) => Promise<Osdk<Q, L>>
+    : never;
+
+  fetchOne: Q extends ObjectTypeDefinition<any>
     ? <L extends ObjectOrInterfacePropertyKeysFrom2<Q>>(
       primaryKey: PropertyValueClientToWire[Q["primaryKeyType"]],
       options?: SelectArg<Q, L>,

--- a/packages/client/src/objectSet/createObjectSet.ts
+++ b/packages/client/src/objectSet/createObjectSet.ts
@@ -174,6 +174,32 @@ export function createObjectSet<Q extends ObjectOrInterfaceDefinition>(
         ) as Osdk<Q>;
       }
       : undefined) as ObjectSet<Q>["get"],
+
+    fetchOne: (isObjectTypeDefinition(objectType)
+      ? async <A extends SelectArg<Q>>(
+        primaryKey: Q extends ObjectTypeDefinition<any>
+          ? PropertyValueClientToWire[Q["primaryKeyType"]]
+          : never,
+        options: A,
+      ) => {
+        const withPk: WireObjectSet = {
+          type: "filter",
+          objectSet: objectSet,
+          where: {
+            type: "eq",
+            field: objectType.primaryKeyApiName,
+            value: primaryKey,
+          },
+        };
+
+        return await fetchSingle(
+          clientCtx,
+          objectType,
+          options,
+          withPk,
+        ) as Osdk<Q>;
+      }
+      : undefined) as ObjectSet<Q>["fetchOne"],
   };
 
   function createSearchAround<L extends LinkNames<Q>>(link: L) {


### PR DESCRIPTION
Deprecates get in 2.0 and adds fetchOne.

Once we migrate nucleus over to using fetchOne, we will just delete get