### PR TITLE
Always include trailing slash for registry urls in .npmrc

### DIFF
--- a/.changeset/famous-lies-dress.md
+++ b/.changeset/famous-lies-dress.md
@@ -1,0 +1,5 @@
+---
+"@osdk/create-app": minor
+---
+
+Always include trailing slash for registry urls in .npmrc

--- a/packages/create-app/src/generate/generateNpmRc.test.ts
+++ b/packages/create-app/src/generate/generateNpmRc.test.ts
@@ -18,8 +18,8 @@ import { expect, test } from "vitest";
 import { generateNpmRc } from "./generateNpmRc.js";
 
 const expected = `
-//registry.com:_authToken=\${FOUNDRY_TOKEN}
-@myapp:registry=https://registry.com
+//registry.com/:_authToken=\${FOUNDRY_TOKEN}
+@myapp:registry=https://registry.com/
 `.trimStart();
 
 test("it generates .npmrc for packge and registry", () => {

--- a/packages/create-app/src/generate/generateNpmRc.ts
+++ b/packages/create-app/src/generate/generateNpmRc.ts
@@ -21,7 +21,12 @@ export function generateNpmRc({
   osdkPackage: string;
   osdkRegistryUrl: string;
 }): string {
-  const withoutProtocol = osdkRegistryUrl.replace(/^https:\/\//, "");
+  // pnpm requires a trailing slash in .npmrc
+  // https://github.com/pnpm/pnpm/issues/5941
+  const withTrailingSlash = osdkRegistryUrl.endsWith("/")
+    ? osdkRegistryUrl
+    : osdkRegistryUrl + "/";
+  const withoutProtocol = withTrailingSlash.replace(/^https:\/\//, "");
   return `//${withoutProtocol}:_authToken=\${FOUNDRY_TOKEN}\n`
-    + `${osdkPackage.split("/")[0]}:registry=${osdkRegistryUrl}\n`;
+    + `${osdkPackage.split("/")[0]}:registry=${withTrailingSlash}\n`;
 }

--- a/packages/create-app/src/generate/generateNpmRc.ts
+++ b/packages/create-app/src/generate/generateNpmRc.ts
@@ -27,6 +27,8 @@ export function generateNpmRc({
     ? osdkRegistryUrl
     : osdkRegistryUrl + "/";
   const withoutProtocol = withTrailingSlash.replace(/^https:\/\//, "");
+  const packageScope = osdkPackage.split("/")[0];
+
   return `//${withoutProtocol}:_authToken=\${FOUNDRY_TOKEN}\n`
-    + `${osdkPackage.split("/")[0]}:registry=${withTrailingSlash}\n`;
+    + `${packageScope}:registry=${withTrailingSlash}\n`;
 }


### PR DESCRIPTION
The sample instructions suggest `npm install` however when using other package managers such as `pnpm install` pnpm does not correctly pick up the registry url for auth unless there is a trailing slash