### PR TITLE
Add fetchOneWithErrors to 2.0

### DIFF
--- a/.changeset/rotten-moose-call.md
+++ b/.changeset/rotten-moose-call.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": minor
+---
+
+Add fetchOneWithErrors that will add a result wrapper when fetching one object. This wrapper will either contain the data value, or an error if an error was thrown.

--- a/packages/client/src/definitions/LinkDefinitions.ts
+++ b/packages/client/src/definitions/LinkDefinitions.ts
@@ -21,6 +21,7 @@ import type {
   ObjectTypeLinkKeysFrom2,
 } from "@osdk/api";
 import type { SelectArg, SelectArgToKeys } from "../object/fetchPage.js";
+import type { Result } from "../object/Result.js";
 import type { ObjectSet } from "../objectSet/ObjectSet.js";
 import type { Osdk } from "../OsdkObjectFrom.js";
 
@@ -76,5 +77,23 @@ export interface SingleLinkAccessor<T extends ObjectTypeDefinition<any>> {
     DefaultToFalse<A["includeRid"]> extends false
       ? Osdk<T, SelectArgToKeys<T, A>>
       : Osdk<T, SelectArgToKeys<T, A> | "$rid">
+  >;
+
+  /** Load the linked object
+   */
+  fetchOneWithErrors: <
+    const A extends SelectArg<
+      T,
+      ObjectOrInterfacePropertyKeysFrom2<T>,
+      boolean
+    >,
+  >(
+    options?: A,
+  ) => Promise<
+    Result<
+      DefaultToFalse<A["includeRid"]> extends false
+        ? Osdk<T, SelectArgToKeys<T, A>>
+        : Osdk<T, SelectArgToKeys<T, A> | "$rid">
+    >
   >;
 }

--- a/packages/client/src/definitions/LinkDefinitions.ts
+++ b/packages/client/src/definitions/LinkDefinitions.ts
@@ -79,7 +79,7 @@ export interface SingleLinkAccessor<T extends ObjectTypeDefinition<any>> {
       : Osdk<T, SelectArgToKeys<T, A> | "$rid">
   >;
 
-  /** Load the linked object
+  /** Load the linked object, with a result wrapper
    */
   fetchOneWithErrors: <
     const A extends SelectArg<

--- a/packages/client/src/object/convertWireToOsdkObjects.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.ts
@@ -29,7 +29,7 @@ import type { WhereClause } from "../query/WhereClause.js";
 import { Attachment } from "./Attachment.js";
 import { createAsyncCache, createCache } from "./Cache.js";
 import type { SelectArg } from "./fetchPage.js";
-import { fetchSingle } from "./fetchSingle.js";
+import { fetchSingle, fetchSingleWithErrors } from "./fetchSingle.js";
 
 const OriginClient = Symbol();
 const UnderlyingObject = Symbol();
@@ -67,6 +67,13 @@ class LinkFetcherProxyHandler<Q extends AugmentedObjectTypeDefinition<any, any>>
           ),
         fetchOne: <A extends SelectArg<any>>(options?: A) =>
           fetchSingle(
+            this.client,
+            this.objDef,
+            options ?? {},
+            getWireObjectSet(objectSet),
+          ),
+        fetchOneWithErrors: <A extends SelectArg<any>>(options?: A) =>
+          fetchSingleWithErrors(
             this.client,
             this.objDef,
             options ?? {},

--- a/packages/client/src/object/fetchSingle.ts
+++ b/packages/client/src/object/fetchSingle.ts
@@ -24,6 +24,7 @@ import {
   type FetchPageArgs,
   type SelectArgToKeys,
 } from "./fetchPage.js";
+import type { Result } from "./Result.js";
 
 export async function fetchSingle<
   Q extends ObjectOrInterfaceDefinition,
@@ -56,4 +57,45 @@ export async function fetchSingle<
   }
 
   return result.data[0] as any;
+}
+
+export async function fetchSingleWithErrors<
+  Q extends ObjectOrInterfaceDefinition,
+  const A extends FetchPageArgs<Q, any, any>,
+>(
+  client: MinimalClient,
+  objectType: Q,
+  args: A,
+  objectSet: ObjectSet,
+): Promise<
+  Result<
+    Osdk<
+      Q,
+      A["includeRid"] extends true ? SelectArgToKeys<Q, A> | "$rid"
+        : SelectArgToKeys<Q, A>
+    >
+  >
+> {
+  try {
+    const result = await fetchPage(
+      client,
+      objectType,
+      { ...args, pageSize: 1 },
+      objectSet,
+    );
+
+    if (result.data.length !== 1 || result.nextPageToken != null) {
+      throw new PalantirApiError(
+        `Expected a single result but got ${result.data.length} instead${
+          result.nextPageToken != null ? " with nextPageToken set" : ""
+        }`,
+      );
+    }
+    return { value: result.data[0] as any };
+  } catch (e) {
+    if (e instanceof Error) {
+      return { error: e };
+    }
+    return { error: e as Error };
+  }
 }

--- a/packages/client/src/object/fetchSingle.ts
+++ b/packages/client/src/object/fetchSingle.ts
@@ -77,7 +77,7 @@ export async function fetchSingleWithErrors<
   >
 > {
   try {
-    const result = fetchSingle(client, objectType, args, objectSet);
+    const result = await fetchSingle(client, objectType, args, objectSet);
     return { value: result as any };
   } catch (e) {
     if (e instanceof Error) {

--- a/packages/client/src/object/fetchSingle.ts
+++ b/packages/client/src/object/fetchSingle.ts
@@ -77,21 +77,8 @@ export async function fetchSingleWithErrors<
   >
 > {
   try {
-    const result = await fetchPage(
-      client,
-      objectType,
-      { ...args, pageSize: 1 },
-      objectSet,
-    );
-
-    if (result.data.length !== 1 || result.nextPageToken != null) {
-      throw new PalantirApiError(
-        `Expected a single result but got ${result.data.length} instead${
-          result.nextPageToken != null ? " with nextPageToken set" : ""
-        }`,
-      );
-    }
-    return { value: result.data[0] as any };
+    const result = fetchSingle(client, objectType, args, objectSet);
+    return { value: result as any };
   } catch (e) {
     if (e instanceof Error) {
       return { error: e };

--- a/packages/client/src/objectSet/ObjectSet.test.ts
+++ b/packages/client/src/objectSet/ObjectSet.test.ts
@@ -202,7 +202,7 @@ describe("ObjectSet", () => {
     expect(employee.$primaryKey).toBe(stubData.employee1.employeeId);
   });
 
-  it("allows fetching by PK from a base object set with selected properties - fetchOne", async () => {
+  it("allows fetching by PK from a base object set with selected properties - fetchOneWithErrors", async () => {
     const employeeResult = await client(MockOntology.objects.Employee)
       .fetchOneWithErrors(
         stubData.employee1.employeeId,

--- a/packages/client/src/objectSet/ObjectSet.test.ts
+++ b/packages/client/src/objectSet/ObjectSet.test.ts
@@ -28,6 +28,7 @@ import { Ontology as MockOntology } from "../generatedNoCheck/Ontology.js";
 import { Employee } from "../generatedNoCheck/ontology/objects.js";
 import { createClient } from "../index.js";
 import type { Client, Osdk } from "../index.js";
+import type { Result } from "../object/Result.js";
 import { isOk } from "../object/Result.js";
 
 describe("ObjectSet", () => {
@@ -164,6 +165,21 @@ describe("ObjectSet", () => {
     expect(employee.$primaryKey).toBe(stubData.employee1.employeeId);
   });
 
+  it("allows fetching by PK from a base object set - fetchOneWithErrors", async () => {
+    const employeeResult = await client(MockOntology.objects.Employee)
+      .fetchOneWithErrors(
+        stubData.employee1.employeeId,
+      );
+    expectTypeOf<typeof employeeResult>().toMatchTypeOf<
+      Result<Osdk<Employee, ObjectOrInterfacePropertyKeysFrom2<Employee>>>
+    >;
+
+    if (isOk(employeeResult)) {
+      const employee = employeeResult.value;
+      expect(employee.$primaryKey).toBe(stubData.employee1.employeeId);
+    }
+  });
+
   it("allows fetching by PK from a base object set with selected properties", async () => {
     const employee = await client(MockOntology.objects.Employee).get(
       stubData.employee1.employeeId,
@@ -186,6 +202,22 @@ describe("ObjectSet", () => {
     expect(employee.$primaryKey).toBe(stubData.employee1.employeeId);
   });
 
+  it("allows fetching by PK from a base object set with selected properties - fetchOne", async () => {
+    const employeeResult = await client(MockOntology.objects.Employee)
+      .fetchOneWithErrors(
+        stubData.employee1.employeeId,
+        { select: ["fullName"] },
+      );
+    expectTypeOf<typeof employeeResult>().toEqualTypeOf<
+      Result<Osdk<Employee, "fullName">>
+    >;
+
+    if (isOk(employeeResult)) {
+      const employee = employeeResult.value;
+      expect(employee.$primaryKey).toBe(stubData.employee1.employeeId);
+    }
+  });
+
   it("throws when fetching by PK with an object that does not exist", async () => {
     await expect(client(MockOntology.objects.Employee).get(-1)).rejects
       .toThrow();
@@ -194,6 +226,17 @@ describe("ObjectSet", () => {
   it("throws when fetching by PK with an object that does not exist - fetchOne", async () => {
     await expect(client(MockOntology.objects.Employee).fetchOne(-1)).rejects
       .toThrow();
+  });
+
+  it("throws when fetching by PK with an object that does not exist - fetchOneWithErrors", async () => {
+    const employeeResult = await client(MockOntology.objects.Employee)
+      .fetchOneWithErrors(-1);
+
+    expectTypeOf<typeof employeeResult>().toEqualTypeOf<
+      Result<Osdk<Employee, ObjectOrInterfacePropertyKeysFrom2<Employee>>>
+    >;
+
+    expect("error" in employeeResult);
   });
 
   it("allows fetching by PK from a pivoted object set", async () => {
@@ -212,6 +255,18 @@ describe("ObjectSet", () => {
       .pivotTo("peeps").fetchOne(stubData.employee1.employeeId);
 
     expect(employee.$primaryKey).toBe(stubData.employee1.employeeId);
+  });
+
+  it("allows fetching by PK from a pivoted object set - fetchOneWithErrors", async () => {
+    const employeeResult = await client(MockOntology.objects.Employee).where({
+      employeeId: stubData.employee2.employeeId,
+    })
+      .pivotTo("peeps").fetchOneWithErrors(stubData.employee1.employeeId);
+
+    if (isOk(employeeResult)) {
+      const employee = employeeResult.value;
+      expect(employee.$primaryKey).toBe(stubData.employee1.employeeId);
+    }
   });
 
   it(" object set union works with fetchPageWithErrors", async () => {

--- a/packages/client/src/objectSet/ObjectSet.ts
+++ b/packages/client/src/objectSet/ObjectSet.ts
@@ -106,4 +106,11 @@ export interface ObjectSet<Q extends ObjectOrInterfaceDefinition>
       options?: SelectArg<Q, L>,
     ) => Promise<Osdk<Q, L>>
     : never;
+
+  fetchOneWithErrors: Q extends ObjectTypeDefinition<any>
+    ? <L extends ObjectOrInterfacePropertyKeysFrom2<Q>>(
+      primaryKey: PropertyValueClientToWire[Q["primaryKeyType"]],
+      options?: SelectArg<Q, L>,
+    ) => Promise<Result<Osdk<Q, L>>>
+    : never;
 }

--- a/packages/client/src/objectSet/createObjectSet.ts
+++ b/packages/client/src/objectSet/createObjectSet.ts
@@ -28,8 +28,9 @@ import {
   fetchPageWithErrorsInternal,
   type SelectArg,
 } from "../object/fetchPage.js";
-import { fetchSingle } from "../object/fetchSingle.js";
+import { fetchSingle, fetchSingleWithErrors } from "../object/fetchSingle.js";
 import { aggregate } from "../object/index.js";
+import type { Result } from "../object/Result.js";
 import type { Osdk } from "../OsdkObjectFrom.js";
 import { isWireObjectSet } from "../util/WireObjectSet.js";
 import type { LinkedType, LinkNames } from "./LinkUtils.js";
@@ -200,6 +201,32 @@ export function createObjectSet<Q extends ObjectOrInterfaceDefinition>(
         ) as Osdk<Q>;
       }
       : undefined) as ObjectSet<Q>["fetchOne"],
+
+    fetchOneWithErrors: (isObjectTypeDefinition(objectType)
+      ? async <A extends SelectArg<Q>>(
+        primaryKey: Q extends ObjectTypeDefinition<any>
+          ? PropertyValueClientToWire[Q["primaryKeyType"]]
+          : never,
+        options: A,
+      ) => {
+        const withPk: WireObjectSet = {
+          type: "filter",
+          objectSet: objectSet,
+          where: {
+            type: "eq",
+            field: objectType.primaryKeyApiName,
+            value: primaryKey,
+          },
+        };
+
+        return await fetchSingleWithErrors(
+          clientCtx,
+          objectType,
+          options,
+          withPk,
+        ) as Result<Osdk<Q>>;
+      }
+      : undefined) as ObjectSet<Q>["fetchOneWithErrors"],
   };
 
   function createSearchAround<L extends LinkNames<Q>>(link: L) {


### PR DESCRIPTION
Add fetchOneWithErrors, which functions the same as fetchOne, but adds a Result wrapper