### PR TITLE
Explicitly ignore tsup temporary files

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -16,7 +16,8 @@
     "**/src/generatedNoCheck/",
     "**/src/generatedNoCheck2/",
     "pnpm-lock.yaml",
-    ".vscode/settings.json"
+    ".vscode/settings.json",
+    "**/tsup.config.bundled_*"
   ],
   "plugins": [
     "https://plugins.dprint.dev/typescript-0.90.4.wasm",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,9 @@ import * as importPlugin from "eslint-plugin-import";
 import * as tseslint from "typescript-eslint";
 
 export default tseslint.config(
+  {
+    ignores: ["**/tsup.config.bundled_*"],
+  },
   { files: ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"] },
   tseslint.configs.base,
   {


### PR DESCRIPTION
Should prevent the occasional failures we see when tsup runs concurrently with eslint/dprint