### PR TITLE
Version Packages

### DIFF
--- a/.changeset/chilled-balloons-camp.md
+++ b/.changeset/chilled-balloons-camp.md
@@ -1,5 +1,0 @@
----
-"@osdk/client": patch
----
-
-Adds experimental batch link support

--- a/.changeset/dirty-cups-fetch.md
+++ b/.changeset/dirty-cups-fetch.md
@@ -1,5 +1,0 @@
----
-"@osdk/client": patch
----
-
-Support importing the unstable-do-not-use from moduleResolution: node

--- a/.changeset/funny-bears-matter.md
+++ b/.changeset/funny-bears-matter.md
@@ -1,9 +1,0 @@
----
-"@osdk/internal.foundry": minor
-"@osdk/shared.test": minor
-"@osdk/generator": minor
-"@osdk/gateway": minor
-"@osdk/maker": minor
----
-
-Adds support for latest api definitions

--- a/.changeset/gentle-walls-ring.md
+++ b/.changeset/gentle-walls-ring.md
@@ -1,5 +1,0 @@
----
-"@osdk/client": patch
----
-
-Rexport PalantirApiError

--- a/.changeset/grumpy-pans-rest.md
+++ b/.changeset/grumpy-pans-rest.md
@@ -1,5 +1,0 @@
----
-"@osdk/client": patch
----
-
-Client is now usable for calling Platform SDK

--- a/.changeset/polite-donkeys-tan.md
+++ b/.changeset/polite-donkeys-tan.md
@@ -1,6 +1,0 @@
----
-"@osdk/foundry.security": minor
-"@osdk/foundry": minor
----
-
-Updates "meUser" to be "getCurrentUser"

--- a/.changeset/rude-crabs-sin.md
+++ b/.changeset/rude-crabs-sin.md
@@ -1,7 +1,0 @@
----
-"@osdk/generator": minor
-"@osdk/client": minor
-"@osdk/api": minor
----
-
-Interfaces are now mapped as views

--- a/.changeset/weak-squids-remember.md
+++ b/.changeset/weak-squids-remember.md
@@ -1,5 +1,0 @@
----
-"@osdk/legacy-client": minor
----
-
-Fix legacy-client to handle fetch token errors

--- a/examples-extra/basic/sdk/src/generatedNoCheck/OntologyMetadata.ts
+++ b/examples-extra/basic/sdk/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,12 +1,12 @@
 import { OntologyMetadata as OM } from '@osdk/api';
 
-export type $ExpectedClientVersion = '0.18.0';
+export type $ExpectedClientVersion = '0.19.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export interface OntologyMetadata extends OM<$ExpectedClientVersion> {}
 
 export const OntologyMetadata: OntologyMetadata = {
-  expectsClientVersion: '0.18.0',
+  expectsClientVersion: '0.19.0',
   ontologyRid: 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e',
   ontologyApiName: 'default',
   userAgent: 'typescript-sdk/dev osdk-cli/dev',

--- a/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,12 +1,12 @@
 import { OntologyMetadata as OM } from '@osdk/api';
 
-export type $ExpectedClientVersion = '0.18.0';
+export type $ExpectedClientVersion = '0.19.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export interface OntologyMetadata extends OM<$ExpectedClientVersion> {}
 
 export const OntologyMetadata: OntologyMetadata = {
-  expectsClientVersion: '0.18.0',
+  expectsClientVersion: '0.19.0',
   ontologyRid: 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e',
   ontologyApiName: 'ontology-d097f725-ab77-46cf-83c0-e3cb9186bff1',
   userAgent: 'typescript-sdk/dev osdk-cli/dev',

--- a/examples-extra/todoapp/src/generatedNoCheck2/OntologyMetadata.ts
+++ b/examples-extra/todoapp/src/generatedNoCheck2/OntologyMetadata.ts
@@ -1,12 +1,12 @@
 import { OntologyMetadata as OM } from '@osdk/api';
 
-export type $ExpectedClientVersion = '0.18.0';
+export type $ExpectedClientVersion = '0.19.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export interface OntologyMetadata extends OM<$ExpectedClientVersion> {}
 
 export const OntologyMetadata: OntologyMetadata = {
-  expectsClientVersion: '0.18.0',
+  expectsClientVersion: '0.19.0',
   ontologyRid: 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e',
   ontologyApiName: 'ontology-d097f725-ab77-46cf-83c0-e3cb9186bff1',
   userAgent: 'typescript-sdk/dev osdk-cli/dev',

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/api
 
+## 1.8.0
+
+### Minor Changes
+
+- c9f3214: Interfaces are now mapped as views
+
+### Patch Changes
+
+- Updated dependencies [c9f3214]
+  - @osdk/gateway@2.3.0
+  - @osdk/shared.net@1.11.0
+
 ## 1.7.0
 
 ### Patch Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/api",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/cli.cmd.typescript
 
+## 0.3.0
+
+### Patch Changes
+
+- Updated dependencies [c9f3214]
+- Updated dependencies [c9f3214]
+  - @osdk/generator@1.11.0
+  - @osdk/gateway@2.3.0
+  - @osdk/shared.net@1.11.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/cli
 
+## 0.21.0
+
+### Patch Changes
+
+- Updated dependencies [c9f3214]
+- Updated dependencies [c9f3214]
+  - @osdk/generator@1.11.0
+  - @osdk/gateway@2.3.0
+  - @osdk/api@1.8.0
+  - @osdk/shared.net@1.11.0
+
 ## 0.20.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @osdk/client
 
+## 0.19.0
+
+### Minor Changes
+
+- 0a64def: Adds experimental batch link support
+- f9b3c72: Support importing the unstable-do-not-use from moduleResolution: node
+- 978ecd5: Rexport PalantirApiError
+- 978ecd5: Client is now usable for calling Platform SDK
+- c9f3214: Interfaces are now mapped as views
+
+### Patch Changes
+
+- Updated dependencies [c9f3214]
+  - @osdk/api@1.8.0
+  - @osdk/generator-converters@0.6.0
+  - @osdk/shared.net@1.11.0
+
 ## 0.18.0
 
 ### Minor Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -45,7 +45,7 @@ export interface Client extends SharedClient<MinimalClient> {
 }
 
 // BEGIN: THIS IS GENERATED CODE. DO NOT EDIT.
-const MaxOsdkVersion = "0.18.0";
+const MaxOsdkVersion = "0.19.0";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 export type MaxOsdkVersion = typeof MaxOsdkVersion;
 const ErrorMessage = Symbol("ErrorMessage");

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/foundry-sdk-generator
 
+## 1.2.0
+
+### Patch Changes
+
+- Updated dependencies [c9f3214]
+- Updated dependencies [c9f3214]
+- Updated dependencies [6b03c55]
+  - @osdk/generator@1.11.0
+  - @osdk/gateway@2.3.0
+  - @osdk/api@1.8.0
+  - @osdk/legacy-client@2.3.0
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,17 +1,5 @@
 # @osdk/foundry-sdk-generator
 
-## 1.2.0
-
-### Patch Changes
-
-- Updated dependencies [c9f3214]
-- Updated dependencies [c9f3214]
-- Updated dependencies [6b03c55]
-  - @osdk/generator@1.11.0
-  - @osdk/gateway@2.3.0
-  - @osdk/api@1.8.0
-  - @osdk/legacy-client@2.3.0
-
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "1.2.0",
+  "version": "1.1.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/foundry.core/CHANGELOG.md
+++ b/packages/foundry.core/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/foundry.core
 
+## 1.0.0
+
+### Patch Changes
+
+- Updated dependencies [0a64def]
+- Updated dependencies [f9b3c72]
+- Updated dependencies [978ecd5]
+- Updated dependencies [978ecd5]
+- Updated dependencies [c9f3214]
+  - @osdk/client@0.19.0
+  - @osdk/api@1.8.0
+  - @osdk/shared.net@1.11.0
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/foundry.core/package.json
+++ b/packages/foundry.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.core",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.security/CHANGELOG.md
+++ b/packages/foundry.security/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @osdk/foundry.security
 
+## 1.0.0
+
+### Minor Changes
+
+- 1914fd4: Updates "meUser" to be "getCurrentUser"
+
+### Patch Changes
+
+- Updated dependencies [0a64def]
+- Updated dependencies [f9b3c72]
+- Updated dependencies [978ecd5]
+- Updated dependencies [978ecd5]
+- Updated dependencies [c9f3214]
+  - @osdk/client@0.19.0
+  - @osdk/api@1.8.0
+  - @osdk/foundry.core@1.0.0
+  - @osdk/shared.net@1.11.0
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/foundry.security/package.json
+++ b/packages/foundry.security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.security",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.thirdpartyapplications/CHANGELOG.md
+++ b/packages/foundry.thirdpartyapplications/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @osdk/foundry.thirdpartyapplications
 
+## 1.0.0
+
+### Patch Changes
+
+- Updated dependencies [0a64def]
+- Updated dependencies [f9b3c72]
+- Updated dependencies [978ecd5]
+- Updated dependencies [978ecd5]
+- Updated dependencies [c9f3214]
+  - @osdk/client@0.19.0
+  - @osdk/api@1.8.0
+  - @osdk/foundry.core@1.0.0
+  - @osdk/shared.net@1.11.0
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/foundry.thirdpartyapplications/package.json
+++ b/packages/foundry.thirdpartyapplications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.thirdpartyapplications",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry/CHANGELOG.md
+++ b/packages/foundry/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @osdk/foundry
 
+## 1.0.0
+
+### Minor Changes
+
+- 1914fd4: Updates "meUser" to be "getCurrentUser"
+
+### Patch Changes
+
+- Updated dependencies [0a64def]
+- Updated dependencies [f9b3c72]
+- Updated dependencies [978ecd5]
+- Updated dependencies [978ecd5]
+- Updated dependencies [1914fd4]
+- Updated dependencies [c9f3214]
+  - @osdk/client@0.19.0
+  - @osdk/foundry.security@1.0.0
+  - @osdk/api@1.8.0
+  - @osdk/foundry.core@1.0.0
+  - @osdk/foundry.thirdpartyapplications@1.0.0
+  - @osdk/shared.net@1.11.0
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/foundry/package.json
+++ b/packages/foundry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/gateway/CHANGELOG.md
+++ b/packages/gateway/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/gateway
 
+## 2.3.0
+
+### Minor Changes
+
+- c9f3214: Adds support for latest api definitions
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/gateway",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-converters/CHANGELOG.md
+++ b/packages/generator-converters/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/generator-converters
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies [c9f3214]
+- Updated dependencies [c9f3214]
+  - @osdk/gateway@2.3.0
+  - @osdk/api@1.8.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/generator-converters/package.json
+++ b/packages/generator-converters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-converters",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @osdk/generator
 
+## 1.11.0
+
+### Minor Changes
+
+- c9f3214: Adds support for latest api definitions
+- c9f3214: Interfaces are now mapped as views
+
+### Patch Changes
+
+- Updated dependencies [c9f3214]
+- Updated dependencies [c9f3214]
+  - @osdk/gateway@2.3.0
+  - @osdk/api@1.8.0
+  - @osdk/generator-converters@0.6.0
+
 ## 1.10.0
 
 ### Minor Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator/src/v2.0/generateMetadata.ts
+++ b/packages/generator/src/v2.0/generateMetadata.ts
@@ -20,7 +20,7 @@ import { formatTs } from "../util/test/formatTs";
 import type { WireOntologyDefinition } from "../WireOntologyDefinition";
 
 // BEGIN: THIS IS GENERATED CODE. DO NOT EDIT.
-const ExpectedOsdkVersion = "0.18.0";
+const ExpectedOsdkVersion = "0.19.0";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 
 export async function generateOntologyMetadataFile(

--- a/packages/internal.foundry/CHANGELOG.md
+++ b/packages/internal.foundry/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/foundry
 
+## 0.3.0
+
+### Minor Changes
+
+- c9f3214: Adds support for latest api definitions
+
+### Patch Changes
+
+- Updated dependencies [c9f3214]
+  - @osdk/api@1.8.0
+  - @osdk/shared.net@1.11.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/internal.foundry/package.json
+++ b/packages/internal.foundry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/internal.foundry",
   "private": "true",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/legacy-client/CHANGELOG.md
+++ b/packages/legacy-client/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @osdk/legacy-client
 
+## 2.3.0
+
+### Minor Changes
+
+- 6b03c55: Fix legacy-client to handle fetch token errors
+
+### Patch Changes
+
+- Updated dependencies [c9f3214]
+- Updated dependencies [c9f3214]
+  - @osdk/gateway@2.3.0
+  - @osdk/api@1.8.0
+  - @osdk/shared.net@1.11.0
+
 ## 2.2.1
 
 ### Patch Changes

--- a/packages/legacy-client/package.json
+++ b/packages/legacy-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/legacy-client",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/maker/CHANGELOG.md
+++ b/packages/maker/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/maker
 
+## 0.6.0
+
+### Minor Changes
+
+- c9f3214: Adds support for latest api definitions
+
+### Patch Changes
+
+- Updated dependencies [c9f3214]
+- Updated dependencies [c9f3214]
+  - @osdk/gateway@2.3.0
+  - @osdk/api@1.8.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.net/CHANGELOG.md
+++ b/packages/shared.net/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/shared.net
 
+## 1.11.0
+
+### Patch Changes
+
+- Updated dependencies [c9f3214]
+  - @osdk/gateway@2.3.0
+
 ## 1.10.0
 
 ### Minor Changes

--- a/packages/shared.net/package.json
+++ b/packages/shared.net/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/shared.net",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/shared.test/CHANGELOG.md
+++ b/packages/shared.test/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/shared.test
 
+## 1.4.0
+
+### Minor Changes
+
+- c9f3214: Adds support for latest api definitions
+
+### Patch Changes
+
+- Updated dependencies [c9f3214]
+- Updated dependencies [c9f3214]
+  - @osdk/gateway@2.3.0
+  - @osdk/api@1.8.0
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/shared.test/package.json
+++ b/packages/shared.test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/shared.test",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "",
   "access": "private",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.


# Releases
## @osdk/api@1.8.0

### Minor Changes

-   c9f3214: Interfaces are now mapped as views

### Patch Changes

-   Updated dependencies [c9f3214]
    -   @osdk/gateway@2.3.0
    -   @osdk/shared.net@1.11.0

## @osdk/client@0.19.0

### Minor Changes

-   0a64def: Adds experimental batch link support
-   f9b3c72: Support importing the unstable-do-not-use from moduleResolution: node
-   978ecd5: Rexport PalantirApiError
-   978ecd5: Client is now usable for calling Platform SDK
-   c9f3214: Interfaces are now mapped as views

### Patch Changes

-   Updated dependencies [c9f3214]
    -   @osdk/api@1.8.0
    -   @osdk/generator-converters@0.6.0
    -   @osdk/shared.net@1.11.0

## @osdk/foundry@1.0.0

### Minor Changes

-   1914fd4: Updates "meUser" to be "getCurrentUser"

### Patch Changes

-   Updated dependencies [0a64def]
-   Updated dependencies [f9b3c72]
-   Updated dependencies [978ecd5]
-   Updated dependencies [978ecd5]
-   Updated dependencies [1914fd4]
-   Updated dependencies [c9f3214]
    -   @osdk/client@0.19.0
    -   @osdk/foundry.security@1.0.0
    -   @osdk/api@1.8.0
    -   @osdk/foundry.core@1.0.0
    -   @osdk/foundry.thirdpartyapplications@1.0.0
    -   @osdk/shared.net@1.11.0

## @osdk/foundry.security@1.0.0

### Minor Changes

-   1914fd4: Updates "meUser" to be "getCurrentUser"

### Patch Changes

-   Updated dependencies [0a64def]
-   Updated dependencies [f9b3c72]
-   Updated dependencies [978ecd5]
-   Updated dependencies [978ecd5]
-   Updated dependencies [c9f3214]
    -   @osdk/client@0.19.0
    -   @osdk/api@1.8.0
    -   @osdk/foundry.core@1.0.0
    -   @osdk/shared.net@1.11.0

## @osdk/gateway@2.3.0

### Minor Changes

-   c9f3214: Adds support for latest api definitions

## @osdk/generator@1.11.0

### Minor Changes

-   c9f3214: Adds support for latest api definitions
-   c9f3214: Interfaces are now mapped as views

### Patch Changes

-   Updated dependencies [c9f3214]
-   Updated dependencies [c9f3214]
    -   @osdk/gateway@2.3.0
    -   @osdk/api@1.8.0
    -   @osdk/generator-converters@0.6.0

## @osdk/legacy-client@2.3.0

### Minor Changes

-   6b03c55: Fix legacy-client to handle fetch token errors

### Patch Changes

-   Updated dependencies [c9f3214]
-   Updated dependencies [c9f3214]
    -   @osdk/gateway@2.3.0
    -   @osdk/api@1.8.0
    -   @osdk/shared.net@1.11.0

## @osdk/maker@0.6.0

### Minor Changes

-   c9f3214: Adds support for latest api definitions

### Patch Changes

-   Updated dependencies [c9f3214]
-   Updated dependencies [c9f3214]
    -   @osdk/gateway@2.3.0
    -   @osdk/api@1.8.0

## @osdk/cli@0.21.0

### Patch Changes

-   Updated dependencies [c9f3214]
-   Updated dependencies [c9f3214]
    -   @osdk/generator@1.11.0
    -   @osdk/gateway@2.3.0
    -   @osdk/api@1.8.0
    -   @osdk/shared.net@1.11.0

## @osdk/foundry-sdk-generator@1.2.0

### Patch Changes

-   Updated dependencies [c9f3214]
-   Updated dependencies [c9f3214]
-   Updated dependencies [6b03c55]
    -   @osdk/generator@1.11.0
    -   @osdk/gateway@2.3.0
    -   @osdk/api@1.8.0
    -   @osdk/legacy-client@2.3.0

## @osdk/foundry.core@1.0.0

### Patch Changes

-   Updated dependencies [0a64def]
-   Updated dependencies [f9b3c72]
-   Updated dependencies [978ecd5]
-   Updated dependencies [978ecd5]
-   Updated dependencies [c9f3214]
    -   @osdk/client@0.19.0
    -   @osdk/api@1.8.0
    -   @osdk/shared.net@1.11.0

## @osdk/foundry.thirdpartyapplications@1.0.0

### Patch Changes

-   Updated dependencies [0a64def]
-   Updated dependencies [f9b3c72]
-   Updated dependencies [978ecd5]
-   Updated dependencies [978ecd5]
-   Updated dependencies [c9f3214]
    -   @osdk/client@0.19.0
    -   @osdk/api@1.8.0
    -   @osdk/foundry.core@1.0.0
    -   @osdk/shared.net@1.11.0

## @osdk/generator-converters@0.6.0

### Patch Changes

-   Updated dependencies [c9f3214]
-   Updated dependencies [c9f3214]
    -   @osdk/gateway@2.3.0
    -   @osdk/api@1.8.0

## @osdk/shared.net@1.11.0

### Patch Changes

-   Updated dependencies [c9f3214]
    -   @osdk/gateway@2.3.0

## @osdk/internal.foundry@0.3.0

### Minor Changes

-   c9f3214: Adds support for latest api definitions

### Patch Changes

-   Updated dependencies [c9f3214]
    -   @osdk/api@1.8.0
    -   @osdk/shared.net@1.11.0

## @osdk/shared.test@1.4.0

### Minor Changes

-   c9f3214: Adds support for latest api definitions

### Patch Changes

-   Updated dependencies [c9f3214]
-   Updated dependencies [c9f3214]
    -   @osdk/gateway@2.3.0
    -   @osdk/api@1.8.0

## @osdk/cli.cmd.typescript@0.3.0

### Patch Changes

-   Updated dependencies [c9f3214]
-   Updated dependencies [c9f3214]
    -   @osdk/generator@1.11.0
    -   @osdk/gateway@2.3.0
    -   @osdk/shared.net@1.11.0
