### PR TITLE
Add helper for asyncIter

### DIFF
--- a/packages/foundry-sdk-generator/src/__e2e_tests__/loadObjects.test.ts
+++ b/packages/foundry-sdk-generator/src/__e2e_tests__/loadObjects.test.ts
@@ -40,7 +40,8 @@ import type {
   Result,
 } from "../generatedNoCheck/@test-app/osdk";
 
-import { apiServer, loadAll, stubData } from "@osdk/shared.test";
+import { fromAsyncIterator } from "@osdk/legacy-client";
+import { apiServer, stubData } from "@osdk/shared.test";
 import type {
   Employee,
   Office,
@@ -285,7 +286,7 @@ describe("LoadObjects", () => {
 
   it("Gets All Objects with async iter", async () => {
     let iter = 0;
-    const employees: Employee[] = await loadAll(
+    const employees: Employee[] = await fromAsyncIterator(
       client.ontology
         .objects.Employee.asyncIter(),
     );
@@ -371,7 +372,7 @@ describe("LoadObjects", () => {
       );
 
     const emp = assertOkOrThrow(result);
-    const peepsAll: Employee[] = await loadAll(
+    const peepsAll: Employee[] = await fromAsyncIterator(
       await emp.peeps
         .asyncIter(),
     );
@@ -509,7 +510,7 @@ describe("LoadObjects", () => {
   });
 
   it("Loads specified properties when loading all with async iter", async () => {
-    const employees = await loadAll(
+    const employees = await fromAsyncIterator(
       client.ontology.objects.Employee.select(["fullName"])
         .asyncIter(),
     );

--- a/packages/foundry-sdk-generator/src/__e2e_tests__/search.test.ts
+++ b/packages/foundry-sdk-generator/src/__e2e_tests__/search.test.ts
@@ -36,7 +36,8 @@ import type {
   SearchObjectsError,
 } from "../generatedNoCheck/@test-app/osdk";
 
-import { apiServer, loadAll } from "@osdk/shared.test";
+import { fromAsyncIterator } from "@osdk/legacy-client";
+import { apiServer } from "@osdk/shared.test";
 import type {
   Employee,
   Office,
@@ -64,7 +65,7 @@ describe("SearchObjects", () => {
   });
 
   it("orders objects in ascending order without a filter, and returns all results with async iter", async () => {
-    const employees = await loadAll(
+    const employees = await fromAsyncIterator(
       client.ontology
         .objects.Employee.orderBy(emp => emp.employeeId.asc()).asyncIter(),
     );
@@ -319,7 +320,7 @@ describe("SearchObjects", () => {
   });
 
   it("orders objects in ascending order with a filter, and returns all results", async () => {
-    const result: Employee[] = await loadAll(
+    const result: Employee[] = await fromAsyncIterator(
       client.ontology
         .objects.Employee.where(emp => emp.employeeId.eq(50030))
         .orderBy(emp => emp.employeeId.asc())

--- a/packages/legacy-client/src/client/objectSets/OsdkObjectSet.test.ts
+++ b/packages/legacy-client/src/client/objectSets/OsdkObjectSet.test.ts
@@ -20,12 +20,12 @@ import type {
   LoadObjectSetResponseV2,
   OntologyObjectV2,
 } from "@osdk/gateway/types";
+import { fromAsyncIterator } from "@osdk/legacy-client";
 import { createClientContext, isOk } from "@osdk/shared.net";
 import type { ClientContext } from "@osdk/shared.net";
 import {
   getMockTaskObject,
   getMockTodoObject,
-  loadAll,
   mockFetchResponse,
   MockOntology,
 } from "@osdk/shared.test";
@@ -251,7 +251,7 @@ describe("OsdkObjectSet", () => {
   it("supports select methods - asyncIter", async () => {
     const os = createBaseObjectSet(client, "Todo");
     mockObjectPage([getMockTodoObject()]);
-    const result = await loadAll(
+    const result = await fromAsyncIterator(
       os.select(["id", "body", "complete"]).asyncIter(),
     );
     expect(fetch).toHaveBeenCalledOnce();
@@ -427,7 +427,7 @@ describe("OsdkObjectSet", () => {
     }
 
     mockObjectPage([getMockTodoObject()]);
-    const linkedTodosResponse = await loadAll(
+    const linkedTodosResponse = await fromAsyncIterator(
       taskResponse.value.linkedTodos.asyncIter(),
     );
 

--- a/packages/legacy-client/src/index.ts
+++ b/packages/legacy-client/src/index.ts
@@ -388,3 +388,4 @@ export type {
   TokenValue,
   UnsubscribeFunction,
 } from "./oauth-client";
+export { fromAsyncIterator } from "./util";

--- a/packages/legacy-client/src/util/fromAsyncIterator.ts
+++ b/packages/legacy-client/src/util/fromAsyncIterator.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export async function fromAsyncIterator<T>(
+  gen: AsyncIterableIterator<T>,
+): Promise<T[]> {
+  const result: T[] = [];
+  for await (const r of gen) {
+    result.push(r);
+  }
+  return result;
+}

--- a/packages/legacy-client/src/util/index.ts
+++ b/packages/legacy-client/src/util/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from "./fromAsyncIterator.js";


### PR DESCRIPTION
Add helper to asyncIter so users can emulate `all()`