### PR TITLE
Remove platform specific commands in template scripts

### DIFF
--- a/.changeset/thin-eggs-prove.md
+++ b/.changeset/thin-eggs-prove.md
@@ -1,0 +1,6 @@
+---
+"@osdk/example-generator": minor
+"@osdk/create-app": minor
+---
+
+Remove platform specific commands in template scripts

--- a/packages/create-app/templates/template-react/package.json.hbs
+++ b/packages/create-app/templates/template-react/package.json.hbs
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/packages/create-app/templates/template-tutorial-todo-app/package.json.hbs
+++ b/packages/create-app/templates/template-tutorial-todo-app/package.json.hbs
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/packages/example-generator/src/run.ts
+++ b/packages/example-generator/src/run.ts
@@ -192,11 +192,17 @@ const UPDATE_PACKAGE_JSON: Mutator = {
   mutate: (template, content) => ({
     type: "modify",
     newContent: content.replace(
+      // Use locally generated SDK in the monorepo
       "\"@osdk/examples.one.dot.one\": \"latest\"",
       "\"@osdk/examples.one.dot.one\": \"workspace:*\"",
     ).replace(
+      // Follow monorepo package naming convention
       `"name": "${templateExampleId(template)}"`,
       `"name": "@osdk/examples.${templateCanonicalId(template)}"`,
+    ).replace(
+      // Monorepo uses eslint 9 whereas templates are still on eslint 8
+      "\"lint\": \"eslint",
+      "\"lint\": \"ESLINT_USE_FLAT_CONFIG=false eslint",
     ),
   }),
 };


### PR DESCRIPTION
The template scripts had `ESLINT_USE_FLAT_CONFIG=false eslint ...` added which is specifically for the rendered examples in this monorepo which are using eslint 9 where the new eslint flat config format is the default and so you need to opt-out of it rather than opt-in for eslint 8 that the templates are still on.

This would be incompatible for running the scripts on windows without using something like cross-env. However, given that this only is needed for this monorepo I removed it completely and applied it in the example generator.