### PR TITLE
React/Vue router respects vite base path

### DIFF
--- a/.changeset/unlucky-wombats-switch.md
+++ b/.changeset/unlucky-wombats-switch.md
@@ -1,0 +1,5 @@
+---
+"@osdk/create-app": minor
+---
+
+React/Vue router respects vite base path

--- a/examples/example-react/src/main.tsx
+++ b/examples/example-react/src/main.tsx
@@ -6,27 +6,30 @@ import Home from "./Home";
 import Login from "./Login";
 import "./index.css";
 
-const router = createBrowserRouter([
-  {
-    path: "/",
-    element: <AuthenticatedRoute />,
-    children: [
-      {
-        path: "/",
-        element: <Home />,
-      },
-    ],
-  },
-  {
-    path: "/login",
-    element: <Login />,
-  },
-  {
-    // This is the route defined in your application's redirect URL
-    path: "/auth/callback",
-    element: <AuthCallback />,
-  },
-]);
+const router = createBrowserRouter(
+  [
+    {
+      path: "/",
+      element: <AuthenticatedRoute />,
+      children: [
+        {
+          path: "/",
+          element: <Home />,
+        },
+      ],
+    },
+    {
+      path: "/login",
+      element: <Login />,
+    },
+    {
+      // This is the route defined in your application's redirect URL
+      path: "/auth/callback",
+      element: <AuthCallback />,
+    },
+  ],
+  { basename: import.meta.env.BASE_URL },
+);
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <RouterProvider router={router} />,

--- a/examples/example-tutorial-todo-app/src/main.tsx
+++ b/examples/example-tutorial-todo-app/src/main.tsx
@@ -6,27 +6,30 @@ import Home from "./Home";
 import Login from "./Login";
 import "./index.css";
 
-const router = createBrowserRouter([
-  {
-    path: "/",
-    element: <AuthenticatedRoute />,
-    children: [
-      {
-        path: "/",
-        element: <Home />,
-      },
-    ],
-  },
-  {
-    path: "/login",
-    element: <Login />,
-  },
-  {
-    // This is the route defined in your application's redirect URL
-    path: "/auth/callback",
-    element: <AuthCallback />,
-  },
-]);
+const router = createBrowserRouter(
+  [
+    {
+      path: "/",
+      element: <AuthenticatedRoute />,
+      children: [
+        {
+          path: "/",
+          element: <Home />,
+        },
+      ],
+    },
+    {
+      path: "/login",
+      element: <Login />,
+    },
+    {
+      // This is the route defined in your application's redirect URL
+      path: "/auth/callback",
+      element: <AuthCallback />,
+    },
+  ],
+  { basename: import.meta.env.BASE_URL },
+);
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <RouterProvider router={router} />,

--- a/examples/example-vue/src/main.ts
+++ b/examples/example-vue/src/main.ts
@@ -14,7 +14,7 @@ const routes = [
 ];
 
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHistory(import.meta.env.BASE_URL),
   routes,
 });
 

--- a/packages/create-app/templates/template-react/src/main.tsx
+++ b/packages/create-app/templates/template-react/src/main.tsx
@@ -6,27 +6,30 @@ import Home from "./Home";
 import Login from "./Login";
 import "./index.css";
 
-const router = createBrowserRouter([
-  {
-    path: "/",
-    element: <AuthenticatedRoute />,
-    children: [
-      {
-        path: "/",
-        element: <Home />,
-      },
-    ],
-  },
-  {
-    path: "/login",
-    element: <Login />,
-  },
-  {
-    // This is the route defined in your application's redirect URL
-    path: "/auth/callback",
-    element: <AuthCallback />,
-  },
-]);
+const router = createBrowserRouter(
+  [
+    {
+      path: "/",
+      element: <AuthenticatedRoute />,
+      children: [
+        {
+          path: "/",
+          element: <Home />,
+        },
+      ],
+    },
+    {
+      path: "/login",
+      element: <Login />,
+    },
+    {
+      // This is the route defined in your application's redirect URL
+      path: "/auth/callback",
+      element: <AuthCallback />,
+    },
+  ],
+  { basename: import.meta.env.BASE_URL },
+);
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <RouterProvider router={router} />,

--- a/packages/create-app/templates/template-tutorial-todo-app/src/main.tsx
+++ b/packages/create-app/templates/template-tutorial-todo-app/src/main.tsx
@@ -6,27 +6,30 @@ import Home from "./Home";
 import Login from "./Login";
 import "./index.css";
 
-const router = createBrowserRouter([
-  {
-    path: "/",
-    element: <AuthenticatedRoute />,
-    children: [
-      {
-        path: "/",
-        element: <Home />,
-      },
-    ],
-  },
-  {
-    path: "/login",
-    element: <Login />,
-  },
-  {
-    // This is the route defined in your application's redirect URL
-    path: "/auth/callback",
-    element: <AuthCallback />,
-  },
-]);
+const router = createBrowserRouter(
+  [
+    {
+      path: "/",
+      element: <AuthenticatedRoute />,
+      children: [
+        {
+          path: "/",
+          element: <Home />,
+        },
+      ],
+    },
+    {
+      path: "/login",
+      element: <Login />,
+    },
+    {
+      // This is the route defined in your application's redirect URL
+      path: "/auth/callback",
+      element: <AuthCallback />,
+    },
+  ],
+  { basename: import.meta.env.BASE_URL },
+);
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <RouterProvider router={router} />,

--- a/packages/create-app/templates/template-vue/src/main.ts
+++ b/packages/create-app/templates/template-vue/src/main.ts
@@ -14,7 +14,7 @@ const routes = [
 ];
 
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHistory(import.meta.env.BASE_URL),
   routes,
 });
 


### PR DESCRIPTION
When setting a base path for the app for example on github pages `/{user}/{repo}` files will be served from a different base path which requires client side routing to also be aware of this.

For vite templates this is set via the `base` option in `vite.config.js` and available in code via `import.meta.env.BASE_URL` ([docs](https://vitejs.dev/guide/build.html#public-base-path))

For the Next.js with static export template this is set via the `basePath` option in `next.config.js` [docs](https://nextjs.org/docs/app/api-reference/next-config-js/basePath) but doesn't need router settings as routing is handled directly by Next.js. However, one extra step the user would have to do when configuring this is make sure image src references in the public folder also [respect the basePath](https://nextjs.org/docs/app/api-reference/next-config-js/basePath#images) which isn't exposed out of the box like vite. This could be done by syncing through an env variable such as `NEXT_PUBLIC_BASE_PATH` but it's up to the user to set this up if they want it.