### PR TITLE
Version Packages

### DIFF
--- a/.changeset/itchy-radios-own.md
+++ b/.changeset/itchy-radios-own.md
@@ -1,5 +1,0 @@
----
-"@osdk/create-app": patch
----
-
-Fix runtime warnings on AipNow template

--- a/.changeset/khaki-plants-sort.md
+++ b/.changeset/khaki-plants-sort.md
@@ -1,5 +1,0 @@
----
-"@osdk/create-app": patch
----
-
-update the mock objects to the new TypeScript 1.1.1 syntax version

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/create-app
 
+## 0.16.1
+
+### Patch Changes
+
+- 1ee2d4f: Fix runtime warnings on AipNow template
+- 843f932: update the mock objects to the new TypeScript 1.1.1 syntax version
+
 ## 0.16.0
 
 ### Minor Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-app",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/example-generator/CHANGELOG.md
+++ b/packages/example-generator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/example-generator
 
+## 0.5.1
+
+### Patch Changes
+
+- Updated dependencies [1ee2d4f]
+- Updated dependencies [843f932]
+  - @osdk/create-app@0.16.1
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/example-generator/package.json
+++ b/packages/example-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/example-generator",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/cli, this PR will be updated.


# Releases
## @osdk/create-app@0.16.1

### Patch Changes

-   1ee2d4f: Fix runtime warnings on AipNow template
-   843f932: update the mock objects to the new TypeScript 1.1.1 syntax version

## @osdk/example-generator@0.5.1

### Patch Changes

-   Updated dependencies [1ee2d4f]
-   Updated dependencies [843f932]
    -   @osdk/create-app@0.16.1
