### PR TITLE
Fix $rid access issue

### DIFF
--- a/.changeset/nervous-pets-return.md
+++ b/.changeset/nervous-pets-return.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Fixed issue accessing $rid when requested on an object.

--- a/packages/client/src/OsdkObjectFrom.ts
+++ b/packages/client/src/OsdkObjectFrom.ts
@@ -123,7 +123,8 @@ export type Osdk<
   }
   // We are hiding the $rid field if it wasnt requested as we want to discourage its use
   & (IsNever<P> extends true ? {}
-    : P extends "$rid" ? { $rid: string }
+    : string extends P ? {}
+    : "$rid" extends P ? { $rid: string }
     : {});
 
 export type OsdkObjectOrInterfaceFrom<

--- a/packages/client/src/object/object.test.ts
+++ b/packages/client/src/object/object.test.ts
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+import type { Employee } from "@osdk/client.test.ontology";
 import { Ontology as MockOntology } from "@osdk/client.test.ontology";
 import { apiServer, stubData, withoutRid } from "@osdk/shared.test";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { Client } from "../Client.js";
 import { createClient } from "../createClient.js";
+import type { Osdk } from "../OsdkObjectFrom.js";
 
 function asV2Object(o: any, includeRid?: boolean) {
   o = includeRid ? { ...o } : withoutRid(o);
@@ -122,6 +124,21 @@ describe("OsdkObject", () => {
       // ensure that select worked
       expect(peep.employeeId).toBeDefined();
       expect((peep as any).employeeStatus).toBeUndefined();
+    });
+    it("gives $rid access when requested", async () => {
+      // slightly weird request here to hit the existing mocks for employee2
+      const result = await client(MockOntology.objects.Employee).where({
+        employeeId: stubData.employee1.employeeId,
+      }).fetchPage(
+        {
+          includeRid: true,
+        },
+      );
+      const leadRid = result.data[0].$rid;
+      expect(leadRid).toBeDefined();
+      expect(leadRid).toBe(
+        "ri.phonograph2-objects.main.object.88a6fccb-f333-46d6-a07e-7725c5f18b61",
+      );
     });
   });
 });

--- a/packages/client/src/object/object.test.ts
+++ b/packages/client/src/object/object.test.ts
@@ -126,7 +126,6 @@ describe("OsdkObject", () => {
       expect((peep as any).employeeStatus).toBeUndefined();
     });
     it("gives $rid access when requested", async () => {
-      // slightly weird request here to hit the existing mocks for employee2
       const result = await client(MockOntology.objects.Employee).where({
         employeeId: stubData.employee1.employeeId,
       }).fetchPage(


### PR DESCRIPTION
We had a bug in our Osdk<> type where if you requested a rid along with other fields, the rid would not be populated on the object type.