### PR TITLE
Interfaces are synthetic.

### DIFF
--- a/.changeset/nervous-parrots-admire.md
+++ b/.changeset/nervous-parrots-admire.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Objects that are $as are now linked directly to changes from source object

--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -239,16 +239,16 @@ function standardPackageRules(shared, options) {
               ...(options.esmOnly ? {} : {
                 "require": "./build/cjs/index.cjs",
               }),
+              "browser": "./build/browser/index.js",
               "import": "./build/esm/index.js",
-              "browser": "./build/browser/index.browser.js",
             },
 
             "./*": {
               ...(options.esmOnly ? {} : {
                 require: "./build/cjs/public/*.cjs",
               }),
-              import: "./build/esm/public/*.js",
               browser: "./build/browser/public/*.js",
+              import: "./build/esm/public/*.js",
             },
           },
           publishConfig: {

--- a/examples-extra/basic/cli/package.json
+++ b/examples-extra/basic/cli/package.json
@@ -9,12 +9,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/examples-extra/basic/sdk/package.json
+++ b/examples-extra/basic/sdk/package.json
@@ -10,12 +10,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/examples-extra/one_dot_one/package.json
+++ b/examples-extra/one_dot_one/package.json
@@ -11,13 +11,13 @@
   "exports": {
     ".": {
       "require": "./build/cjs/index.cjs",
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
       "require": "./build/cjs/public/*.cjs",
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,13 +11,13 @@
   "exports": {
     ".": {
       "require": "./build/cjs/index.cjs",
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
       "require": "./build/cjs/public/*.cjs",
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -9,12 +9,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/cli.common/package.json
+++ b/packages/cli.common/package.json
@@ -9,12 +9,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,12 +10,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/client.api/package.json
+++ b/packages/client.api/package.json
@@ -8,12 +8,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/client.test.ontology/package.json
+++ b/packages/client.test.ontology/package.json
@@ -9,12 +9,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -10,12 +10,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/client/src/OsdkObjectFrom.ts
+++ b/packages/client/src/OsdkObjectFrom.ts
@@ -71,11 +71,11 @@ type UnderlyingProps<
   Q extends ObjectOrInterfaceDefinition,
   P extends string,
   Z extends string,
-  NEWQ extends ValidToFrom<Q>,
+  NEW_Q extends ValidToFrom<Q>,
 > =
   & Z
   & Q extends InterfaceDefinition<any, any>
-  ? NEWQ extends ObjectTypeDefinition<any> ? ConvertProps<Q, NEWQ, P>
+  ? NEW_Q extends ObjectTypeDefinition<any> ? ConvertProps<Q, NEW_Q, P>
   : Z
   : Z;
 
@@ -115,13 +115,13 @@ export type Osdk<
     $link: Q extends ObjectTypeDefinition<any> ? OsdkObjectLinksObject<Q>
       : never;
 
-    $as: <NEWQ extends ValidToFrom<Q>>(type: NEWQ | string) => Osdk<
-      NEWQ,
-      ConvertProps<Q, NEWQ, P>,
-      UnderlyingProps<Q, P, Z, NEWQ>
+    $as: <NEW_Q extends ValidToFrom<Q>>(type: NEW_Q | string) => Osdk<
+      NEW_Q,
+      ConvertProps<Q, NEW_Q, P>,
+      UnderlyingProps<Q, P, Z, NEW_Q>
     >;
   }
-  // We are hiding the $rid field if it wasnt requested as we want to discourage its use
+  // We are hiding the $rid field if it wasn't requested as we want to discourage its use
   & (IsNever<P> extends true ? {}
     : string extends P ? {}
     : "$rid" extends P ? { $rid: string }

--- a/packages/client/src/createMinimalClient.ts
+++ b/packages/client/src/createMinimalClient.ts
@@ -34,7 +34,7 @@ export function createMinimalClient(
   tokenProvider: () => Promise<string>,
   options: OntologyCachingOptions & { logger?: Logger } = {},
   fetchFn: (
-    input: RequestInfo | URL,
+    input: Request | URL | string,
     init?: RequestInit | undefined,
   ) => Promise<Response> = global.fetch,
   objectSetFactory: ObjectSetFactory<any, any> = createObjectSet,

--- a/packages/client/src/object/Cache.ts
+++ b/packages/client/src/object/Cache.ts
@@ -147,12 +147,20 @@ export function createAsyncClientCache<K, V extends {}>(
 /**
  * A simple cache that can be used to store values for a given client.
  */
-interface SimpleCache<K, V> {
+export interface SimpleCache<K, V> {
   get: (key: K) => V;
   set: <X extends V>(key: K, value: X) => X;
   remove: (key: K) => boolean;
 }
 
+/**
+ * Create a new cache with a factory function.
+ * @param fn A factory function that will be used to create the value if it does not exist in the cache.
+ */
+export function createSimpleCache<K, V>(
+  map: Map<K, V> | (K extends object ? WeakMap<K, V> : never),
+  fn: (k: K) => V,
+): SimpleCache<K, V>;
 /**
  * Create a new cache without a factory function.
  */
@@ -162,14 +170,6 @@ export function createSimpleCache<K, V>(
   K,
   V | undefined
 >;
-/**
- * Create a new cache with a factory function.
- * @param fn A factory function that will be used to create the value if it does not exist in the cache.
- */
-export function createSimpleCache<K, V>(
-  map: Map<K, V> | (K extends object ? WeakMap<K, V> : never),
-  fn: (k: K) => V,
-): SimpleCache<K, V>;
 export function createSimpleCache<K, V>(
   map: Map<K, V> | (K extends object ? WeakMap<K, V> : never) =
     new Map() as any,

--- a/packages/client/src/object/convertWireToOsdkObjects/InterfaceHolder.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/InterfaceHolder.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { InterfaceDefinition } from "@osdk/api";
+import type { FetchedObjectTypeDefinition } from "../../ontology/OntologyProvider.js";
+import type { Osdk } from "../../OsdkObjectFrom.js";
+import type {
+  InterfaceDefRef,
+  UnderlyingOsdkObject,
+} from "./InternalSymbols.js";
+import type { ObjectHolder } from "./ObjectHolder.js";
+
+export interface InterfaceHolderOwnProps<
+  Q extends FetchedObjectTypeDefinition<any, any>,
+> {
+  [UnderlyingOsdkObject]: Osdk<Q> & ObjectHolder<Q>;
+  [InterfaceDefRef]: InterfaceDefinition<any>;
+}
+
+export interface InterfaceHolder<
+  Q extends FetchedObjectTypeDefinition<any, any>,
+> extends InterfaceHolderOwnProps<Q> {
+}

--- a/packages/client/src/object/convertWireToOsdkObjects/InternalSymbols.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/InternalSymbols.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectOrInterfaceDefinition } from "@osdk/api";
+import type { OsdkObject } from "../../OsdkObject.js";
+
+export const UnderlyingOsdkObject = Symbol(
+  process.env.MODE !== "production" ? "Underlying Object" : undefined,
+);
+
+export const ObjectDefRef = Symbol(
+  process.env.MODE !== "production" ? "ObjectDefinition" : undefined,
+);
+
+export const InterfaceDefRef = Symbol(
+  process.env.MODE !== "production" ? "InterfaceDefinition" : undefined,
+);
+
+/** A symbol for getting the raw data object off of the holder an osdk object proxy points to */
+export const RawObject = Symbol(
+  process.env.MODE !== "production" ? "RawObject" : undefined,
+);
+
+export const ClientRef = Symbol(
+  process.env.MODE !== "production" ? "ClientRef" : undefined,
+);
+
+export interface HolderBase<T extends ObjectOrInterfaceDefinition<any, any>> {
+  [UnderlyingOsdkObject]: OsdkObject<any>;
+  [ObjectDefRef]?: T;
+  [InterfaceDefRef]?: T;
+}

--- a/packages/client/src/object/convertWireToOsdkObjects/ObjectHolder.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/ObjectHolder.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { OntologyObjectV2 } from "@osdk/internal.foundry";
+import type { MinimalClient } from "../../MinimalClientContext.js";
+import type { FetchedObjectTypeDefinition } from "../../ontology/OntologyProvider.js";
+import type { Osdk } from "../../OsdkObjectFrom.js";
+import type { DollarAsFn } from "./getDollarAs.js";
+import type { get$link } from "./getDollarLink.js";
+import type {
+  ClientRef,
+  ObjectDefRef,
+  RawObject,
+  UnderlyingOsdkObject,
+} from "./InternalSymbols.js";
+
+export interface ObjectHolderPrototypeOwnProps {
+  readonly [ObjectDefRef]: FetchedObjectTypeDefinition<any, any>;
+  readonly [ClientRef]: MinimalClient;
+  readonly "$as": DollarAsFn;
+  readonly "$link": ReturnType<typeof get$link>;
+  readonly "$updateInternalValues": (newValues: Record<string, any>) => void;
+}
+export interface ObjectHolderOwnProperties {
+  [RawObject]: OntologyObjectV2;
+}
+
+export interface ObjectHolder<Q extends FetchedObjectTypeDefinition<any, any>>
+  extends ObjectHolderPrototypeOwnProps, ObjectHolderOwnProperties
+{
+  [UnderlyingOsdkObject]: Osdk<Q>;
+}

--- a/packages/client/src/object/convertWireToOsdkObjects/OsdkCustomInspectPrototype.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/OsdkCustomInspectPrototype.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectOrInterfaceDefinition } from "@osdk/api";
+import type { inspect, InspectOptionsStylized } from "node:util";
+import type { Osdk } from "../../OsdkObjectFrom.js";
+import type { HolderBase } from "./InternalSymbols.js";
+import {
+  InterfaceDefRef,
+  ObjectDefRef,
+  UnderlyingOsdkObject,
+} from "./InternalSymbols.js";
+
+export const OsdkCustomInspectPrototype = Object.create(null, {
+  [Symbol.for("nodejs.util.inspect.custom")]: { value: customInspect },
+});
+
+/**
+ * A custom `util.inspect`/`console.log` for nodejs. Not emitted in the browser version
+ * @param this
+ * @param _depth
+ * @param options
+ * @param inspect
+ * @returns
+ */
+function customInspect(
+  this:
+    & HolderBase<ObjectOrInterfaceDefinition<any, any>>
+    & Osdk<any>,
+  _depth: number,
+  options: InspectOptionsStylized,
+  localInspect: typeof inspect,
+) {
+  const newOptions = {
+    ...options,
+    depth: options.depth == null ? null : options.depth - 1,
+  };
+
+  let ret = `Osdk<${
+    options.stylize(
+      this[ObjectDefRef]?.apiName ?? this[InterfaceDefRef]?.apiName,
+      "special",
+    )
+  }> {\n`;
+
+  for (
+    const k of new Set([
+      "$apiName",
+      "$objectType",
+      "$primaryKey",
+      ...Reflect.ownKeys(this),
+    ])
+  ) {
+    if (typeof k === "symbol") continue;
+    ret += `  ${options.stylize(k.toString(), "undefined")}: ${
+      localInspect(this[k as any], newOptions)
+    }\n`;
+  }
+
+  if (this[UnderlyingOsdkObject] !== this) {
+    ret += "\n";
+    ret += `  ${options.stylize("$as", "special")}: ${
+      localInspect(this[UnderlyingOsdkObject], newOptions).replace(
+        /\n/g,
+        `\n  `,
+      )
+    }`;
+    ret += "\n";
+  }
+
+  ret += "}";
+  return ret;
+}

--- a/packages/client/src/object/convertWireToOsdkObjects/PropertyDescriptorRecord.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/PropertyDescriptorRecord.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Helper object to make sure property descriptors are declared correctly */
+export type PropertyDescriptorRecord<X> = {
+  [K in keyof X]: PropertyDescriptor & { get?: () => X[K]; value?: X[K] };
+};

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { InterfaceDefinition } from "@osdk/api";
+import type { FetchedObjectTypeDefinition } from "../../ontology/OntologyProvider.js";
+import type { OsdkObject } from "../../OsdkObject.js";
+import type { Osdk } from "../../OsdkObjectFrom.js";
+import { createSimpleCache } from "../Cache.js";
+import type {
+  InterfaceHolder,
+  InterfaceHolderOwnProps,
+} from "./InterfaceHolder.js";
+import {
+  InterfaceDefRef,
+  ObjectDefRef,
+  UnderlyingOsdkObject,
+} from "./InternalSymbols.js";
+import type { ObjectHolder } from "./ObjectHolder.js";
+import { OsdkCustomInspectPrototype } from "./OsdkCustomInspectPrototype.js";
+
+const handlerCache = createSimpleCache<
+  InterfaceDefinition<any>,
+  ProxyHandler<InterfaceHolder<any> & Osdk<any>>
+>(
+  new WeakMap(),
+  createInterfaceProxyHandler,
+);
+
+export function createOsdkInterface<
+  Q extends FetchedObjectTypeDefinition<any, any>,
+>(
+  underlying: Osdk<Q> & ObjectHolder<Q>,
+  interfaceDef: InterfaceDefinition<any>,
+) {
+  const interfaceHolder: InterfaceHolderOwnProps<Q> = {
+    [UnderlyingOsdkObject]: underlying,
+    [InterfaceDefRef]: interfaceDef,
+  };
+
+  if (process.env.TARGET !== "browser") {
+    Object.setPrototypeOf(interfaceHolder, OsdkCustomInspectPrototype);
+  }
+
+  const handler = handlerCache.get(interfaceDef);
+
+  const proxy = new Proxy<OsdkObject<any>>(
+    interfaceHolder as unknown as OsdkObject<any>, // the wrapper doesn't contain everything obviously. we proxy
+    handler,
+  );
+  return proxy;
+}
+
+function createInterfaceProxyHandler(
+  newDef: InterfaceDefinition<any, any>,
+): ProxyHandler<InterfaceHolder<any> & Osdk<any>> {
+  return {
+    getOwnPropertyDescriptor(target, p) {
+      const underlying = target[UnderlyingOsdkObject];
+      const objDef = underlying[ObjectDefRef];
+
+      switch (p) {
+        case "$primaryKey":
+        case "$objectType":
+          return Reflect.getOwnPropertyDescriptor(underlying, p);
+
+        case "$apiName":
+          return {
+            enumerable: true,
+            configurable: true,
+            value: target[InterfaceDefRef].apiName,
+          };
+      }
+
+      if (newDef.properties[p as string] != null) {
+        return {
+          enumerable: true,
+          configurable: true,
+          value: underlying[
+            objDef.interfaceMap![newDef.apiName][p as string] as any
+          ],
+        };
+      }
+    },
+
+    ownKeys(target) {
+      return [
+        "$apiName",
+        "$objectType",
+        "$primaryKey",
+        ...Object.keys(newDef.properties),
+      ];
+    },
+
+    get(target, p) {
+      const underlying = target[UnderlyingOsdkObject];
+      switch (p) {
+        case InterfaceDefRef:
+          return newDef;
+        case "$apiName":
+          return newDef.apiName;
+        case "$as":
+        case UnderlyingOsdkObject:
+        case "$primaryKey":
+        case "$objectType":
+          return underlying[p as string];
+      }
+
+      if (newDef.properties[p as string] != null) {
+        const objDef = target[UnderlyingOsdkObject][ObjectDefRef];
+        return underlying[objDef.interfaceMap![newDef.apiName][p as string]];
+      }
+    },
+  };
+}

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { OntologyObjectV2 } from "@osdk/internal.foundry";
+import type { MinimalClient } from "../../MinimalClientContext.js";
+import type { FetchedObjectTypeDefinition } from "../../ontology/OntologyProvider.js";
+import { Attachment } from "../Attachment.js";
+import { createClientCache } from "../Cache.js";
+import { get$as } from "./getDollarAs.js";
+import { get$link } from "./getDollarLink.js";
+import {
+  ClientRef,
+  ObjectDefRef,
+  RawObject,
+  UnderlyingOsdkObject,
+} from "./InternalSymbols.js";
+import type {
+  ObjectHolder,
+  ObjectHolderPrototypeOwnProps,
+} from "./ObjectHolder.js";
+import { OsdkCustomInspectPrototype } from "./OsdkCustomInspectPrototype.js";
+import type { PropertyDescriptorRecord } from "./PropertyDescriptorRecord.js";
+
+const objectPrototypeCache = createClientCache(
+  function(client, objectDef: FetchedObjectTypeDefinition<any, any>) {
+    return Object.create(
+      process.env.target !== "browser" ? OsdkCustomInspectPrototype : null,
+      {
+        [ObjectDefRef]: { value: objectDef },
+        [ClientRef]: { value: client },
+        "$as": { value: get$as(objectDef) },
+        "$link": {
+          get: function(this: ObjectHolder<typeof objectDef>) {
+            return get$link(this);
+          },
+        },
+        "$updateInternalValues": {
+          value: function(
+            this: ObjectHolder<typeof objectDef>,
+            newValues: Record<string, any>,
+          ) {
+            this[RawObject] = Object.assign(
+              {},
+              this[RawObject],
+              newValues,
+            );
+          },
+        },
+      } satisfies PropertyDescriptorRecord<ObjectHolderPrototypeOwnProps>,
+    );
+  },
+);
+
+export function createOsdkObject<
+  Q extends FetchedObjectTypeDefinition<any, any>,
+>(
+  client: MinimalClient,
+  objectDef: Q,
+  rawObj: OntologyObjectV2,
+) {
+  const kk = Object.create(objectPrototypeCache.get(client, objectDef), {
+    [RawObject]: {
+      value: rawObj,
+      writable: true, // so we can allow updates
+    },
+  });
+
+  // we separate the holder out so we can update
+  // the underlying data without having to return a new
+  // we also need the holder so we can customize the console.log output
+  const holder: ObjectHolder<Q> = Object.create(kk);
+
+  const osdkObject: any = new Proxy(holder, {
+    ownKeys(target) {
+      return Reflect.ownKeys(target[RawObject]);
+    },
+    get(target, p, receiver) {
+      switch (p) {
+        case UnderlyingOsdkObject:
+          // effectively point back to the proxy
+          return receiver;
+      }
+
+      if (p in target) return target[p as keyof typeof target];
+
+      if (p in rawObj) {
+        const rawValue = target[RawObject][p as any];
+        const propDef = objectDef.properties[p as any];
+        if (propDef) {
+          if (propDef.type === "attachment") {
+            if (Array.isArray(rawValue)) {
+              return rawValue.map(a => new Attachment(a));
+            }
+            return new Attachment(rawValue);
+          }
+        }
+        return rawValue;
+      }
+
+      // we do not do any fall through to avoid unexpected behavior
+    },
+
+    set(target, p, newValue) {
+      // allow the prototype to update this value
+      if (p === RawObject) {
+        // symbol only exists internally so no one else can hit this
+        target[p as typeof RawObject] = newValue;
+        return true;
+      }
+      return false;
+    },
+
+    getOwnPropertyDescriptor(target, p) {
+      if (p === RawObject) {
+        return Reflect.getOwnPropertyDescriptor(target, p);
+      }
+      if (target[RawObject][p as string] != null) {
+        return { configurable: true, enumerable: true };
+      }
+      return { enumerable: false };
+    },
+  });
+  return osdkObject;
+}

--- a/packages/client/src/object/convertWireToOsdkObjects/getDollarAs.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/getDollarAs.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectOrInterfaceDefinition } from "@osdk/api";
+import {
+  type FetchedObjectTypeDefinition,
+  InterfaceDefinitions,
+} from "../../ontology/OntologyProvider.js";
+import type { OsdkObject } from "../../OsdkObject.js";
+import type { Osdk } from "../../OsdkObjectFrom.js";
+import { createSimpleCache } from "../Cache.js";
+import { createOsdkInterface } from "./createOsdkInterface.js";
+import type { InterfaceHolder } from "./InterfaceHolder.js";
+import { UnderlyingOsdkObject } from "./InternalSymbols.js";
+import type { ObjectHolder } from "./ObjectHolder.js";
+
+export type DollarAsFn = <
+  Q extends FetchedObjectTypeDefinition<any, any>,
+  NEW_Q extends ObjectOrInterfaceDefinition<any>,
+>(
+  this: Osdk<any> & (InterfaceHolder<Q> | ObjectHolder<Q>),
+  newDef: string | NEW_Q,
+) => OsdkObject<any>;
+
+export const get$as = createSimpleCache<
+  FetchedObjectTypeDefinition<any, any>,
+  DollarAsFn
+>(new WeakMap(), $asFactory).get;
+
+const osdkObjectToInterfaceView = createSimpleCache(
+  new WeakMap<
+    OsdkObject<any>,
+    Map<string, OsdkObject<any>>
+  >(),
+  () =>
+    new Map<
+      /* interface api name */ string,
+      /* $as'd object */ OsdkObject<any>
+    >(),
+);
+
+function $asFactory(
+  objDef: FetchedObjectTypeDefinition<any, any>,
+): DollarAsFn {
+  // We use the exact same logic for both the interface rep and the underlying rep
+  return function $as<
+    NEW_Q extends ObjectOrInterfaceDefinition<any>,
+  >(
+    this: OsdkObject<any> & { [UnderlyingOsdkObject]: any },
+    newDef: NEW_Q | string,
+  ): OsdkObject<any> {
+    if (typeof newDef === "string") {
+      if (newDef === objDef.apiName) {
+        return this[UnderlyingOsdkObject];
+      }
+
+      // this is sufficient to determine if we implement the interface
+      if (objDef.interfaceMap?.[newDef] == null) {
+        throw new Error(`Object does not implement interface '${newDef}'.`);
+      }
+
+      const def = objDef[InterfaceDefinitions][newDef];
+      if (!def) {
+        throw new Error(`Object does not implement interface '${newDef}'.`);
+      }
+      newDef = def.def as NEW_Q;
+    } else if (newDef.apiName === objDef.apiName) {
+      return this[UnderlyingOsdkObject];
+    }
+
+    if (newDef.type === "object") {
+      throw new Error(`'${newDef.apiName}' is not an interface.`);
+    }
+
+    const underlying = this[UnderlyingOsdkObject];
+
+    const existing = osdkObjectToInterfaceView
+      .get(underlying)
+      .get(newDef.apiName);
+    if (existing) return existing;
+
+    const osdkInterface = createOsdkInterface(underlying, newDef);
+    osdkObjectToInterfaceView.get(underlying).set(
+      newDef.apiName,
+      osdkInterface,
+    );
+    return osdkInterface;
+  };
+}

--- a/packages/client/src/object/convertWireToOsdkObjects/getDollarAs.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/getDollarAs.ts
@@ -82,7 +82,9 @@ function $asFactory(
     }
 
     if (newDef.type === "object") {
-      throw new Error(`'${newDef.apiName}' is not an interface.`);
+      throw new Error(
+        `'${newDef.apiName}' is not an interface nor is it '${objDef.apiName}', which is the object type.`,
+      );
     }
 
     const underlying = this[UnderlyingOsdkObject];

--- a/packages/client/src/object/convertWireToOsdkObjects/getDollarLink.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/getDollarLink.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectTypeDefinition } from "@osdk/api";
+import type { OsdkObjectLinksObject } from "../../definitions/LinkDefinitions.js";
+import { getWireObjectSet } from "../../objectSet/createObjectSet.js";
+import type { ObjectSet } from "../../objectSet/ObjectSet.js";
+import type { Osdk } from "../../OsdkObjectFrom.js";
+import type { WhereClause } from "../../query/WhereClause.js";
+import type { SelectArg } from "../FetchPageArgs.js";
+import { fetchSingle, fetchSingleWithErrors } from "../fetchSingle.js";
+import { ClientRef, ObjectDefRef, RawObject } from "./InternalSymbols.js";
+import type {
+  ObjectHolder,
+  ObjectHolderOwnProperties,
+} from "./ObjectHolder.js";
+
+export function get$link(
+  holder: ObjectHolder<any>,
+): OsdkObjectLinksObject<any> {
+  return new Proxy(holder, DollarLinkProxyHandler) as
+    & ObjectHolder<any>
+    & OsdkObjectLinksObject<any>;
+}
+
+const DollarLinkProxyHandler: ProxyHandler<ObjectHolder<any>> = {
+  get(target: ObjectHolder<any>, p: string | symbol) {
+    const {
+      [ObjectDefRef]: objDef,
+      [ClientRef]: client,
+      [RawObject]: rawObj,
+    } = target;
+    const linkDef = objDef.links[p as string];
+    if (linkDef == null) {
+      return;
+    }
+    const objectSet =
+      (client.objectSetFactory(objDef, client) as ObjectSet<any>)
+        .where({
+          [objDef.primaryKeyApiName]: rawObj.$primaryKey,
+        } as WhereClause<ObjectTypeDefinition<any>>)
+        .pivotTo(p as string);
+
+    if (!linkDef.multiplicity) {
+      return {
+        fetchOne: <A extends SelectArg<any>>(options?: A) =>
+          fetchSingle(
+            client,
+            objDef,
+            options ?? {},
+            getWireObjectSet(objectSet),
+          ),
+        fetchOneWithErrors: <A extends SelectArg<any>>(options?: A) =>
+          fetchSingleWithErrors(
+            client,
+            objDef,
+            options ?? {},
+            getWireObjectSet(objectSet),
+          ),
+      };
+    } else {
+      return objectSet;
+    }
+  },
+
+  ownKeys(
+    target: ObjectHolder<any>,
+  ): ArrayLike<keyof ObjectHolderOwnProperties | string> {
+    return [...Object.keys(target[ObjectDefRef].links)];
+  },
+
+  getOwnPropertyDescriptor(
+    target: ObjectHolder<any>,
+    p: string | symbol,
+  ): PropertyDescriptor | undefined {
+    if (target[ObjectDefRef].links[p as any]) {
+      return {
+        enumerable: true,
+        configurable: true, // fixme
+        writable: false,
+      };
+    }
+  },
+};

--- a/packages/client/src/objectSet/createObjectSet.ts
+++ b/packages/client/src/objectSet/createObjectSet.ts
@@ -141,13 +141,7 @@ export function createObjectSet<Q extends ObjectOrInterfaceDefinition>(
       do {
         const result = await base.fetchPage({ nextPageToken });
 
-        for (
-          const obj of await convertWireToOsdkObjects(
-            clientCtx,
-            result.data,
-            undefined,
-          )
-        ) {
+        for (const obj of result.data) {
           yield obj as Osdk<Q, "$all">;
         }
       } while (nextPageToken != null);

--- a/packages/client/src/ontology/OntologyProvider.ts
+++ b/packages/client/src/ontology/OntologyProvider.ts
@@ -22,6 +22,21 @@ import type {
 } from "@osdk/api";
 import type { MinimalClient } from "../MinimalClientContext.js";
 
+export const InterfaceDefinitions = Symbol(
+  process.env.MODE !== "production" ? "InterfaceDefinitions" : undefined,
+);
+
+export interface FetchedObjectTypeDefinition<K extends string, N = unknown>
+  extends ObjectTypeDefinition<K, N>
+{
+  rid: string;
+
+  // we keep this here so we can depend on these synchronously
+  [InterfaceDefinitions]: {
+    [key: string]: { def: InterfaceDefinition<any> };
+  };
+}
+
 export interface OntologyProvider {
   /**
    * Returns the current known definition for the object.
@@ -32,7 +47,7 @@ export interface OntologyProvider {
    */
   getObjectDefinition: (
     apiName: string,
-  ) => Promise<ObjectTypeDefinition<any> & { rid: string }>;
+  ) => Promise<FetchedObjectTypeDefinition<any>>;
 
   /**
    * Returns the current known definition for the interface.

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -10,12 +10,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/example-generator/package.json
+++ b/packages/example-generator/package.json
@@ -9,12 +9,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -10,12 +10,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/foundry.core/package.json
+++ b/packages/foundry.core/package.json
@@ -8,12 +8,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/foundry.security/package.json
+++ b/packages/foundry.security/package.json
@@ -8,12 +8,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/foundry.thirdpartyapplications/package.json
+++ b/packages/foundry.thirdpartyapplications/package.json
@@ -8,12 +8,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/foundry/package.json
+++ b/packages/foundry/package.json
@@ -8,12 +8,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/gateway-generator/package.json
+++ b/packages/gateway-generator/package.json
@@ -11,12 +11,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -11,13 +11,13 @@
   "exports": {
     ".": {
       "require": "./build/cjs/index.cjs",
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
       "require": "./build/cjs/public/*.cjs",
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/generator-converters/package.json
+++ b/packages/generator-converters/package.json
@@ -11,13 +11,13 @@
   "exports": {
     ".": {
       "require": "./build/cjs/index.cjs",
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
       "require": "./build/cjs/public/*.cjs",
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -11,13 +11,13 @@
   "exports": {
     ".": {
       "require": "./build/cjs/index.cjs",
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
       "require": "./build/cjs/public/*.cjs",
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/internal.foundry.core/package.json
+++ b/packages/internal.foundry.core/package.json
@@ -8,12 +8,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/internal.foundry.datasets/package.json
+++ b/packages/internal.foundry.datasets/package.json
@@ -8,12 +8,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/internal.foundry.models/package.json
+++ b/packages/internal.foundry.models/package.json
@@ -8,12 +8,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/internal.foundry.ontologies/package.json
+++ b/packages/internal.foundry.ontologies/package.json
@@ -8,12 +8,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/internal.foundry.ontologiesv2/package.json
+++ b/packages/internal.foundry.ontologiesv2/package.json
@@ -8,12 +8,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/internal.foundry/package.json
+++ b/packages/internal.foundry/package.json
@@ -9,12 +9,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/legacy-client/package.json
+++ b/packages/legacy-client/package.json
@@ -11,13 +11,13 @@
   "exports": {
     ".": {
       "require": "./build/cjs/index.cjs",
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
       "require": "./build/cjs/public/*.cjs",
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -8,12 +8,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -8,12 +8,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/platform-sdk-generator/package.json
+++ b/packages/platform-sdk-generator/package.json
@@ -9,12 +9,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/shared.client.impl/package.json
+++ b/packages/shared.client.impl/package.json
@@ -9,13 +9,13 @@
   "exports": {
     ".": {
       "require": "./build/cjs/index.cjs",
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
       "require": "./build/cjs/public/*.cjs",
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/shared.net.errors/package.json
+++ b/packages/shared.net.errors/package.json
@@ -9,13 +9,13 @@
   "exports": {
     ".": {
       "require": "./build/cjs/index.cjs",
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
       "require": "./build/cjs/public/*.cjs",
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/shared.net.fetch/package.json
+++ b/packages/shared.net.fetch/package.json
@@ -9,13 +9,13 @@
   "exports": {
     ".": {
       "require": "./build/cjs/index.cjs",
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
       "require": "./build/cjs/public/*.cjs",
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/shared.net.platformapi/package.json
+++ b/packages/shared.net.platformapi/package.json
@@ -8,12 +8,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/shared.net/package.json
+++ b/packages/shared.net/package.json
@@ -11,13 +11,13 @@
   "exports": {
     ".": {
       "require": "./build/cjs/index.cjs",
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
       "require": "./build/cjs/public/*.cjs",
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/shared.test/package.json
+++ b/packages/shared.test/package.json
@@ -12,13 +12,13 @@
   "exports": {
     ".": {
       "require": "./build/cjs/index.cjs",
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
       "require": "./build/cjs/public/*.cjs",
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/tool.release/package.json
+++ b/packages/tool.release/package.json
@@ -9,12 +9,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/version-updater/package.json
+++ b/packages/version-updater/package.json
@@ -11,12 +11,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {

--- a/packages/watch/package.json
+++ b/packages/watch/package.json
@@ -9,12 +9,12 @@
   },
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "browser": "./build/browser/index.browser.js"
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
     },
     "./*": {
-      "import": "./build/esm/public/*.js",
-      "browser": "./build/browser/public/*.js"
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
Tip to reviewer: I had to change all package.json to make this work. I broke this into two commits to make it easier on you.

## Interfaces are synthetic
...AND
- Removed the overly complex ontology cache skipping logic.
- Removes code for doing "full ontology load" from the server as it has not been needed for awhile
- Introduces a way to update the underlying values of an object.
- Adds a pretty console.log() if you're on nodejs.
  ![image](https://github.com/palantir/osdk-ts/assets/120899/07426351-7aa8-43d7-981e-16892872bead)

Example of the synthetic interfaces and their connection to objects:

```ts
expect(obj.fullName).toEqual("Steve");
const objAsFoo = obj.$as(FooInterface);
(obj as any).$updateInternalValues({
  fullName: "Bob",
});
expect(obj.fullName).toEqual("Bob");
expect(objAsFoo.fooSpt).toEqual("Bob");


expect(obj).toBe(objAsFoo.$as(Employee));
expect(objAsFoo).toBe(obj.$as(FooInterface));
```

Fixes #304 