### PR TITLE
Introduce createPlatformClient

### DIFF
--- a/.changeset/shy-cougars-remain.md
+++ b/.changeset/shy-cougars-remain.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Adds a createPlatformClient if you only need platform apis

--- a/examples-extra/basic/cli/src/client.ts
+++ b/examples-extra/basic/cli/src/client.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { createPlatformClient } from "@osdk/client";
 import type { Client } from "@osdk/client/unstable-do-not-use";
 import { createClient } from "@osdk/client/unstable-do-not-use";
 import invariant from "tiny-invariant";
@@ -29,4 +30,13 @@ export const client: Client = createClient(
   async () => process.env.FOUNDRY_USER_TOKEN!,
   { logger },
   loggingFetch,
+);
+
+/**
+ * Generally consumers wont need this and will use their createClient() but
+ * I want to use this to be sure everything works.
+ */
+export const platformClient = createPlatformClient(
+  process.env.FOUNDRY_STACK,
+  async () => process.env.FOUNDRY_USER_TOKEN!,
 );

--- a/examples-extra/basic/cli/src/runFoundrySdkClientVerificationTest.ts
+++ b/examples-extra/basic/cli/src/runFoundrySdkClientVerificationTest.ts
@@ -16,7 +16,7 @@
 
 import { PalantirApiError } from "@osdk/client";
 import { Datasets } from "@osdk/internal.foundry";
-import { client } from "./client.js";
+import { platformClient as client } from "./client.js";
 import { logger } from "./logger.js";
 
 export async function runFoundrySdkClientVerificationTest(

--- a/packages/client/src/createPlatformClient.ts
+++ b/packages/client/src/createPlatformClient.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createSharedClientContext } from "@osdk/shared.client.impl";
+import { USER_AGENT } from "./util/UserAgent.js";
+
+/**
+ * Creates a client that can only be used with Platform APIs.
+ *
+ * If you already have an OSDK Client (from `createClient`), you do not need to
+ * create one of these - those clients can be used with Platform APIs as well.
+ *
+ * @param baseUrl
+ * @param tokenProvider
+ * @param options Currently unused, reserved for future use.
+ * @param fetchFn
+ * @returns
+ */
+export function createPlatformClient(
+  baseUrl: string,
+  tokenProvider: () => Promise<string>,
+  options: undefined = undefined,
+  fetchFn: typeof globalThis.fetch = fetch,
+) {
+  return createSharedClientContext(
+    baseUrl,
+    tokenProvider,
+    USER_AGENT,
+    fetchFn,
+  );
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -26,6 +26,7 @@ export { PalantirApiError } from "@osdk/shared.net.errors";
 
 export type { Client } from "./Client.js";
 export { createClient } from "./createClient.js";
+export { createPlatformClient } from "./createPlatformClient.js";
 
 export { ActionValidationError } from "./actions/ActionValidationError.js";
 export type { InterfaceObjectSet, ObjectSet } from "./objectSet/ObjectSet.js";


### PR DESCRIPTION
This is fine for now because we can always break the 0.x series but I am unsure if we want the platform client to live in `@osdk/client` is it will trigger/require a lot of updates if you aren't using OSDK and we are not ready to provide a back-compat promise on that package.

Fixes #375