### PR TITLE
Version Packages

### DIFF
--- a/.changeset/pretty-dingos-smash.md
+++ b/.changeset/pretty-dingos-smash.md
@@ -1,5 +1,0 @@
----
-"@osdk/create-app": patch
----
-
-Update global layout styles

--- a/.changeset/thin-eggs-prove.md
+++ b/.changeset/thin-eggs-prove.md
@@ -1,6 +1,0 @@
----
-"@osdk/example-generator": patch
-"@osdk/create-app": patch
----
-
-Remove platform specific commands in template scripts

--- a/.changeset/unlucky-wombats-switch.md
+++ b/.changeset/unlucky-wombats-switch.md
@@ -1,5 +1,0 @@
----
-"@osdk/create-app": patch
----
-
-React/Vue router respects vite base path

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/create-app
 
+## 0.16.2
+
+### Patch Changes
+
+- 524f1fe: Update global layout styles
+- 524f1fe: Remove platform specific commands in template scripts
+- 524f1fe: React/Vue router respects vite base path
+
 ## 0.16.1
 
 ### Patch Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-app",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/example-generator/CHANGELOG.md
+++ b/packages/example-generator/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/example-generator
 
+## 0.5.2
+
+### Patch Changes
+
+- 524f1fe: Remove platform specific commands in template scripts
+- Updated dependencies [524f1fe]
+- Updated dependencies [524f1fe]
+- Updated dependencies [524f1fe]
+  - @osdk/create-app@0.16.2
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/example-generator/package.json
+++ b/packages/example-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/example-generator",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/cli, this PR will be updated.


# Releases
## @osdk/create-app@0.16.2

### Patch Changes

-   524f1fe: Update global layout styles
-   524f1fe: Remove platform specific commands in template scripts
-   524f1fe: React/Vue router respects vite base path

## @osdk/example-generator@0.5.2

### Patch Changes

-   524f1fe: Remove platform specific commands in template scripts
-   Updated dependencies [524f1fe]
-   Updated dependencies [524f1fe]
-   Updated dependencies [524f1fe]
    -   @osdk/create-app@0.16.2
