### PR TITLE
Fix login page not redirecting

### DIFF
--- a/.changeset/pretty-cherries-hunt.md
+++ b/.changeset/pretty-cherries-hunt.md
@@ -1,0 +1,5 @@
+---
+"@osdk/create-app": patch
+---
+
+Fix login page not redirecting when oauth redirect not required

--- a/examples/example-next-static-export/src/app/login/page.tsx
+++ b/examples/example-next-static-export/src/app/login/page.tsx
@@ -19,6 +19,8 @@ function Login() {
     } catch (e: unknown) {
       console.error(e);
       setError((e as Error).message ?? e);
+    } finally {
+      setIsLoggingIn(false);
     }
   }, []);
 

--- a/examples/example-react/src/Login.tsx
+++ b/examples/example-react/src/Login.tsx
@@ -18,6 +18,8 @@ function Login() {
     } catch (e: unknown) {
       console.error(e);
       setError((e as Error).message ?? e);
+    } finally {
+      setIsLoggingIn(false);
     }
   }, []);
 

--- a/examples/example-tutorial-todo-app/src/Login.tsx
+++ b/examples/example-tutorial-todo-app/src/Login.tsx
@@ -19,6 +19,8 @@ function Login() {
     } catch (e: unknown) {
       console.error(e);
       setError((e as Error).message ?? e);
+    } finally {
+      setIsLoggingIn(false);
     }
   }, []);
 

--- a/packages/create-app/templates/template-next-static-export/src/app/login/page.tsx
+++ b/packages/create-app/templates/template-next-static-export/src/app/login/page.tsx
@@ -19,6 +19,8 @@ function Login() {
     } catch (e: unknown) {
       console.error(e);
       setError((e as Error).message ?? e);
+    } finally {
+      setIsLoggingIn(false);
     }
   }, []);
 

--- a/packages/create-app/templates/template-react/src/Login.tsx
+++ b/packages/create-app/templates/template-react/src/Login.tsx
@@ -18,6 +18,8 @@ function Login() {
     } catch (e: unknown) {
       console.error(e);
       setError((e as Error).message ?? e);
+    } finally {
+      setIsLoggingIn(false);
     }
   }, []);
 

--- a/packages/create-app/templates/template-tutorial-todo-app/src/Login.tsx
+++ b/packages/create-app/templates/template-tutorial-todo-app/src/Login.tsx
@@ -19,6 +19,8 @@ function Login() {
     } catch (e: unknown) {
       console.error(e);
       setError((e as Error).message ?? e);
+    } finally {
+      setIsLoggingIn(false);
     }
   }, []);
 


### PR DESCRIPTION
Currently legacy-client oauth does not redirect if the token can be refreshed:

https://github.com/palantir/osdk-ts/blob/44add1016e48498fc75df2b54a1a8f986d36ea88/packages/legacy-client/src/oauth-client/PublicClient/PublicClientAuth.ts#L110-L119

The login page incorrectly did not update state if the `signIn()` method actually returns without performing the oauth redirect leading to the login button being stuck. Updating the state after returning successfully here causes a rerender which indirectly also reruns the check to navigate the user back to the home page if the token is present.

This affected the react based templates but not the vue one:

https://github.com/palantir/osdk-ts/blob/44add1016e48498fc75df2b54a1a8f986d36ea88/packages/create-app/templates/template-vue/src/Login.vue#L17-L19