### PR TITLE
Fix attachment creation

### DIFF
--- a/.changeset/cuddly-pens-smash.md
+++ b/.changeset/cuddly-pens-smash.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Fixing attachment creation when converting objects from the wire

--- a/packages/client/src/object/convertWireToOsdkObjects.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.test.ts
@@ -91,6 +91,9 @@ describe("convertWireToOsdkObjects", () => {
     const { attachment, attachmentArray } = withValues.data[0];
 
     expect(attachment).toBeInstanceOf(Attachment);
+    expect(attachment?.rid).toEqual(
+      "ri.attachments.main.attachment.86016861-707f-4292-b258-6a7108915a75",
+    );
     expect(Array.isArray(attachmentArray)).toBeTruthy();
     expect(attachmentArray![0]).toBeInstanceOf(Attachment);
 

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -107,9 +107,9 @@ export function createOsdkObject<
         if (propDef) {
           if (propDef.type === "attachment") {
             if (Array.isArray(rawValue)) {
-              return rawValue.map(a => new Attachment(a));
+              return rawValue.map(a => new Attachment(a.rid));
             }
-            return new Attachment(rawValue);
+            return new Attachment(rawValue.rid);
           }
         }
         return rawValue;


### PR DESCRIPTION
When converting wire objects, we didn't pull out the rid for attachments, which causes errors downstream as the rid value becomes double-nested