### PR TITLE
OSDK learns __EXPERIMENTAL_strictNonNull...

### DIFF
--- a/.changeset/purple-cameras-invite.md
+++ b/.changeset/purple-cameras-invite.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": minor
+---
+
+OSDK learns \_\_EXPERIMENTAL_strictNonNull to throw, drop objects, or return `| undefined` for properties, allowing for correct typesafety.

--- a/examples-extra/basic/cli/src/demoStrictness.ts
+++ b/examples-extra/basic/cli/src/demoStrictness.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Osdk } from "@osdk/client";
+import {
+  BoundariesUsState,
+  Employee,
+  FooInterface,
+} from "@osdk/examples.basic.sdk";
+import { expectType } from "ts-expect";
+import { client } from "./client.js";
+
+export async function demoStrictnessObject() {
+  const { data: defaultResults } = await client(BoundariesUsState)
+    .fetchPage();
+  expectType<string>(defaultResults[0].usState);
+
+  const { data: dropResults } = await client(BoundariesUsState)
+    .fetchPage({ $__EXPERIMENTAL_strictNonNull: "drop" });
+  expectType<string>(dropResults[0].usState);
+
+  const { data: notStrictResults } = await client(BoundariesUsState)
+    .fetchPage({ $__EXPERIMENTAL_strictNonNull: false });
+  expectType<string | undefined>(notStrictResults[0].usState);
+
+  const { data: throwResults } = await client(BoundariesUsState)
+    .fetchPage({ $__EXPERIMENTAL_strictNonNull: "throw" });
+  expectType<string>(throwResults[0].usState);
+
+  const { data: fooDataNotStrict } = await client(FooInterface)
+    .fetchPage({ $__EXPERIMENTAL_strictNonNull: false });
+
+  const employeeNotStrict = fooDataNotStrict[0].$as(Employee);
+}
+
+export async function demoStrictnessInterface() {
+  const { data: fooDataNotStrict } = await client(FooInterface)
+    .fetchPage({ $__EXPERIMENTAL_strictNonNull: false });
+
+  const employeeNotStrict = fooDataNotStrict[0].$as(Employee);
+  expectType<
+    Osdk<
+      Employee,
+      "$notStrict" | "firstName" | "email",
+      "$notStrict" | "firstName" | "email"
+    >
+  >(employeeNotStrict);
+}

--- a/packages/api/src/ontology/ObjectOrInterface.ts
+++ b/packages/api/src/ontology/ObjectOrInterface.ts
@@ -39,6 +39,7 @@ export type ObjectOrInterfaceDefinition<
   | ObjectTypeDefinition<K>
   | InterfaceDefinition<K, L>;
 
+/** @deprecated */
 export type ObjectOrInterfacePropertyKeysFrom<
   O extends OntologyDefinition<any, any>,
   K extends ObjectOrInterfaceKeysFrom<O>,

--- a/packages/client/src/Definitions.test.ts
+++ b/packages/client/src/Definitions.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectTypePropertyDefinition } from "@osdk/api";
+import { describe, expectTypeOf, it } from "vitest";
+import type { OsdkObjectPropertyType } from "./Definitions.js";
+
+describe("OsdkObjectPropertyType", () => {
+  describe("{ nullable: false } property", () => {
+    const nonNullDef = {
+      type: "string",
+      nullable: false,
+    } satisfies ObjectTypePropertyDefinition;
+
+    it("is `| undefined` for `false`", () => {
+      expectTypeOf<OsdkObjectPropertyType<typeof nonNullDef, false>>()
+        .toEqualTypeOf<string | undefined>();
+    });
+
+    it("is not `| undefined` for `true`", () => {
+      expectTypeOf<OsdkObjectPropertyType<typeof nonNullDef, true>>()
+        .toEqualTypeOf<string>();
+    });
+  });
+
+  describe("{ nullable: true } property", () => {
+    const nullableDef = {
+      type: "string",
+      nullable: true,
+    } satisfies ObjectTypePropertyDefinition;
+
+    it("is | undefined for `false`", () => {
+      expectTypeOf<OsdkObjectPropertyType<typeof nullableDef, false>>()
+        .toEqualTypeOf<string | undefined>();
+    });
+
+    it("is `| undefined` for `true`", () => {
+      expectTypeOf<OsdkObjectPropertyType<typeof nullableDef, true>>()
+        .toEqualTypeOf<string | undefined>();
+    });
+  });
+});

--- a/packages/client/src/Definitions.ts
+++ b/packages/client/src/Definitions.ts
@@ -27,8 +27,16 @@ type MaybeNullable<T extends ObjectTypePropertyDefinition, U> =
 type Raw<T> = T extends Array<any> ? T[0] : T;
 type Converted<T> = T extends Array<any> ? T[1] : T;
 
-export type OsdkObjectPropertyType<T extends ObjectTypePropertyDefinition> =
-  MaybeNullable<
+/**
+ * @param {T} ObjectTypePropertyDefinition in literal form
+ * @param {STRICTLY_ENFORCE_NULLABLE}  S for strict. If false, always `|undefined`
+ */
+export type OsdkObjectPropertyType<
+  T extends ObjectTypePropertyDefinition,
+  STRICTLY_ENFORCE_NULLABLE extends boolean = true,
+> = STRICTLY_ENFORCE_NULLABLE extends false
+  ? MaybeArray<T, Converted<PropertyValueWireToClient[T["type"]]>> | undefined
+  : MaybeNullable<
     T,
     MaybeArray<T, Converted<PropertyValueWireToClient[T["type"]]>>
   >;

--- a/packages/client/src/OsdkObjectFrom.test.ts
+++ b/packages/client/src/OsdkObjectFrom.test.ts
@@ -30,6 +30,24 @@ describe("ConvertProps", () => {
       expectTypeOf<ConvertProps<FooInterface, Employee, "$all">>()
         .toEqualTypeOf<"fullName">();
     });
+
+    it("converts non-strict nullness for handles single prop", () => {
+      expectTypeOf<
+        ConvertProps<
+          FooInterface,
+          Employee,
+          | "fooSpt"
+          | "$notStrict"
+        >
+      >()
+        .toEqualTypeOf<"fullName" | "$notStrict">();
+    });
+    it("converts non-strict nullness for $all", () => {
+      expectTypeOf<
+        ConvertProps<FooInterface, Employee, "$all" | "$notStrict">
+      >()
+        .toEqualTypeOf<"fullName" | "$notStrict">();
+    });
   });
 
   describe("converts from a concrete to an interface", () => {
@@ -43,6 +61,27 @@ describe("ConvertProps", () => {
         expectTypeOf<ConvertProps<Employee, FooInterface, "peeps">>()
           .toEqualTypeOf<never>();
       });
+
+      it("resolves to never for unused when not strict", () => {
+        expectTypeOf<
+          ConvertProps<Employee, FooInterface, "peeps" | "$notStrict">
+        >()
+          .toEqualTypeOf<never>();
+      });
+
+      it("converts non-strict nullness for single prop", () => {
+        expectTypeOf<
+          ConvertProps<Employee, FooInterface, "fullName" | "$notStrict">
+        >()
+          .toEqualTypeOf<"fooSpt" | "$notStrict">();
+      });
+
+      it("converts non-strict nullness for $all", () => {
+        expectTypeOf<
+          ConvertProps<Employee, FooInterface, "$all" | "$notStrict">
+        >()
+          .toEqualTypeOf<"$all" | "$notStrict">();
+      });
     });
 
     describe("multiprop", () => {
@@ -51,6 +90,17 @@ describe("ConvertProps", () => {
           ConvertProps<Employee, FooInterface, "peeps" | "fullName">
         >()
           .toEqualTypeOf<"fooSpt">();
+      });
+
+      it("resolves to known only when not strict", () => {
+        expectTypeOf<
+          ConvertProps<
+            Employee,
+            FooInterface,
+            "peeps" | "fullName" | "$notStrict"
+          >
+        >()
+          .toEqualTypeOf<"fooSpt" | "$notStrict">();
       });
     });
 
@@ -88,7 +138,7 @@ describe("Osdk", () => {
     it("can't properly compare the retained types without it", () => {
       type InvalidPropertyName = "not a real prop";
 
-      // This should fail but it doesnt. We dont actively capture Z
+      // This should fail but it doesn't. We don't actively capture Z
       // (and we cant)
       expectTypeOf<
         OsdkAsHelper<Employee, "fullName", "fullName", FooInterface>
@@ -117,18 +167,42 @@ describe("Osdk", () => {
     });
   });
 
+  describe("$notStrict", () => {
+    describe("is present", () => {
+      it("makes { nullable: false } as `|undefined`", () => {
+        expectTypeOf<
+          Osdk<Employee, "employeeId" | "$notStrict">["employeeId"]
+        >()
+          .toEqualTypeOf<number | undefined>();
+        expectTypeOf<
+          GetUnderlyingProps<
+            OsdkAsHelper<Employee, "fullName", "fullName", FooInterface>
+          >
+        >().toEqualTypeOf<"fullName">();
+      });
+    });
+
+    describe("is absent", () => {
+      it("makes { nullable: false } as NOT `|undefined`", () => {
+        expectTypeOf<
+          Osdk<Employee, "employeeId">["employeeId"]
+        >()
+          .toEqualTypeOf<number>();
+        expectTypeOf<
+          GetUnderlyingProps<
+            OsdkAsHelper<Employee, "fullName", "fullName", FooInterface>
+          >
+        >().toEqualTypeOf<"fullName">();
+      });
+    });
+  });
+
   it("Converts into self properly", () => {
     expectTypeOf<
       GetUnderlyingProps<
         OsdkAsHelper<FooInterface, "fooSpt", "fullName", FooInterface>
       >
     >().toEqualTypeOf<"fullName">();
-
-    type z = Osdk<FooInterface, "fooSpt">;
-    type FM<T extends any[]> = T extends (infer P)[] ? P : never;
-    type zz = Awaited<
-      Promise<FetchPageResult<FooInterface, "fooSpt", false>>
-    >["data"];
   });
 
   it("retains original props if set", () => {

--- a/packages/client/src/object/FetchPageArgs.ts
+++ b/packages/client/src/object/FetchPageArgs.ts
@@ -20,14 +20,20 @@ import type {
   ObjectOrInterfaceDefinition,
   ObjectOrInterfacePropertyKeysFrom2,
 } from "@osdk/api";
+
+export type NullabilityAdherence = false | "throw" | "drop";
+export type NullabilityAdherenceDefault = "throw";
+
 export interface SelectArg<
   Q extends ObjectOrInterfaceDefinition<any, any>,
   L extends ObjectOrInterfacePropertyKeysFrom2<Q> =
     ObjectOrInterfacePropertyKeysFrom2<Q>,
   R extends boolean = false,
+  S extends NullabilityAdherence = NullabilityAdherenceDefault,
 > {
   $select?: readonly L[];
   $includeRid?: R;
+  $__EXPERIMENTAL_strictNonNull?: S;
 }
 
 export interface OrderByArg<
@@ -53,8 +59,9 @@ export interface FetchPageArgs<
     ObjectOrInterfacePropertyKeysFrom2<Q>,
   R extends boolean = false,
   A extends Augments = {},
+  S extends NullabilityAdherence = NullabilityAdherenceDefault,
 > extends
-  SelectArg<Q, K, R>,
+  SelectArg<Q, K, R, S>,
   OrderByArg<Q, ObjectOrInterfacePropertyKeysFrom2<Q>>
 {
   $nextPageToken?: string;

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -17,6 +17,7 @@
 import type { OntologyObjectV2 } from "@osdk/internal.foundry";
 import type { MinimalClient } from "../../MinimalClientContext.js";
 import type { FetchedObjectTypeDefinition } from "../../ontology/OntologyProvider.js";
+import type { Osdk } from "../../OsdkObjectFrom.js";
 import { Attachment } from "../Attachment.js";
 import { createClientCache } from "../Cache.js";
 import { get$as } from "./getDollarAs.js";
@@ -70,7 +71,7 @@ export function createOsdkObject<
   client: MinimalClient,
   objectDef: Q,
   rawObj: OntologyObjectV2,
-) {
+): Osdk<Q, string, never> {
   // We use multiple layers of prototypes to maximize reuse and also to keep
   // [RawObject] out of `ownKeys`. This keeps the code in the proxy below simpler.
   const objectHolderPrototype = Object.create(

--- a/packages/client/src/object/fetchPage.test.ts
+++ b/packages/client/src/object/fetchPage.test.ts
@@ -44,7 +44,7 @@ describe(fetchPage, () => {
         L extends SelectArgToKeys<T, A>,
         R extends A["$includeRid"] extends true ? true : false,
       >() {
-        return fetchPage<T, L, R>({} as any, {} as any, {} as any);
+        return fetchPage<T, L, R, "drop">({} as any, {} as any, {} as any);
       }
     }
 
@@ -156,45 +156,58 @@ describe(fetchPage, () => {
 
   describe("includeRid", () => {
     it("properly returns the correct string for includeRid", () => {
-      expectTypeOf<Awaited<FetchPageResult<TodoDef, "text", false>>>()
+      expectTypeOf<Awaited<FetchPageResult<TodoDef, "text", false, "throw">>>()
         .toEqualTypeOf<{
           data: Osdk<TodoDef, "text">[];
           nextPageToken: string | undefined;
         }>();
 
-      expectTypeOf<Awaited<FetchPageResult<TodoDef, "text", true>>>()
+      const a: Awaited<FetchPageResult<TodoDef, "text", true, false>> =
+        1 as any;
+
+      expectTypeOf<Awaited<FetchPageResult<TodoDef, "text", true, false>>>()
         .toEqualTypeOf<{
-          data: Osdk<TodoDef, "text" | "$rid">[];
+          data: Osdk<TodoDef, "text" | "$rid" | "$notStrict">[];
           nextPageToken: string | undefined;
         }>();
     });
 
     it("works with $all", () => {
-      expectTypeOf<Awaited<FetchPageResult<TodoDef, "text" | "id", false>>>()
+      expectTypeOf<
+        Awaited<FetchPageResult<TodoDef, "text" | "id", false, "drop">>
+      >()
         .toEqualTypeOf<{
           data: Osdk<TodoDef>[];
           nextPageToken: string | undefined;
         }>();
 
-      expectTypeOf<Awaited<FetchPageResult<TodoDef, "text" | "id", true>>>()
+      expectTypeOf<
+        Awaited<FetchPageResult<TodoDef, "text" | "id", true, "drop">>
+      >()
         .toEqualTypeOf<{
           data: Osdk<TodoDef, "$all" | "$rid">[];
           nextPageToken: string | undefined;
         }>();
 
-      expectTypeOf<Awaited<FetchPageResult<TodoDef, "text" | "id", true>>>()
+      expectTypeOf<
+        Awaited<FetchPageResult<TodoDef, "text" | "id", true, "drop">>
+      >()
         .toEqualTypeOf<{
           data: Osdk<TodoDef, "$all" | "$rid", "$all" | "$rid">[];
           nextPageToken: string | undefined;
         }>();
 
-      expectTypeOf<Awaited<FetchPageResult<FooInterface, "fooSpt", true>>>()
+      expectTypeOf<
+        Awaited<FetchPageResult<FooInterface, "fooSpt", true, "drop">>
+      >()
         .toEqualTypeOf<{
           data: Osdk<FooInterface, "$all" | "$rid", never>[];
           nextPageToken: string | undefined;
         }>();
 
-      expectTypeOf<Awaited<FetchPageResult<FooInterface, "fooSpt", true>>>()
+      expectTypeOf<
+        Awaited<FetchPageResult<FooInterface, "fooSpt", true, "drop">>
+      >()
         .toEqualTypeOf<{
           data: Osdk<FooInterface, "$all" | "$rid">[];
           nextPageToken: string | undefined;

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -34,7 +34,12 @@ import { OntologiesV2 } from "@osdk/internal.foundry";
 import type { MinimalClient } from "../MinimalClientContext.js";
 import { addUserAgent } from "../util/addUserAgent.js";
 import { convertWireToOsdkObjects } from "./convertWireToOsdkObjects.js";
-import type { Augment, Augments, FetchPageArgs } from "./FetchPageArgs.js";
+import type {
+  Augment,
+  Augments,
+  FetchPageArgs,
+  NullabilityAdherence,
+} from "./FetchPageArgs.js";
 import type { FetchPageResult } from "./FetchPageResult.js";
 import type { Result } from "./Result.js";
 
@@ -82,12 +87,13 @@ async function fetchInterfacePage<
   Q extends InterfaceDefinition<any, any>,
   L extends ObjectOrInterfacePropertyKeysFrom2<Q>,
   R extends boolean,
+  S extends NullabilityAdherence,
 >(
   client: MinimalClient,
   interfaceType: Q,
-  args: FetchPageArgs<Q, L, R>,
+  args: FetchPageArgs<Q, L, R, any, S>,
   objectSet: ObjectSet,
-): Promise<FetchPageResult<Q, L, R>> {
+): Promise<FetchPageResult<Q, L, R, S>> {
   const result = await OntologiesV2.OntologyObjectsV2.searchObjectsForInterface(
     addUserAgent(client, interfaceType),
     client.ontologyRid,
@@ -117,12 +123,13 @@ export async function fetchPageInternal<
   L extends ObjectOrInterfacePropertyKeysFrom2<Q>,
   R extends boolean,
   A extends Augments,
+  S extends NullabilityAdherence,
 >(
   client: MinimalClient,
   objectType: Q,
   objectSet: ObjectSet,
-  args: FetchPageArgs<Q, L, R, A> = {},
-): Promise<FetchPageResult<Q, L, R>> {
+  args: FetchPageArgs<Q, L, R, A, S> = {},
+): Promise<FetchPageResult<Q, L, R, S>> {
   if (objectType.type === "interface") {
     return await fetchInterfacePage(client, objectType, args, objectSet) as any; // fixme
   } else {
@@ -136,12 +143,13 @@ export async function fetchPageWithErrorsInternal<
   L extends ObjectOrInterfacePropertyKeysFrom2<Q>,
   R extends boolean,
   A extends Augments,
+  S extends NullabilityAdherence,
 >(
   client: MinimalClient,
   objectType: Q,
   objectSet: ObjectSet,
-  args: FetchPageArgs<Q, L, R, A> = {},
-): Promise<Result<FetchPageResult<Q, L, R>>> {
+  args: FetchPageArgs<Q, L, R, A, S> = {},
+): Promise<Result<FetchPageResult<Q, L, R, S>>> {
   try {
     const result = await fetchPageInternal(client, objectType, objectSet, args);
     return { value: result };
@@ -157,15 +165,16 @@ export async function fetchPage<
   Q extends ObjectOrInterfaceDefinition,
   L extends ObjectOrInterfacePropertyKeysFrom2<Q>,
   R extends boolean,
+  S extends NullabilityAdherence,
 >(
   client: MinimalClient,
   objectType: Q,
-  args: FetchPageArgs<Q, L, R>,
+  args: FetchPageArgs<Q, L, R, any, S>,
   objectSet: ObjectSet = {
     type: "base",
     objectType: objectType["apiName"] as string,
   },
-): Promise<FetchPageResult<Q, L, R>> {
+): Promise<FetchPageResult<Q, L, R, S>> {
   return fetchPageInternal(client, objectType, objectSet, args);
 }
 
@@ -173,15 +182,16 @@ export async function fetchPageWithErrors<
   Q extends ObjectOrInterfaceDefinition,
   L extends ObjectOrInterfacePropertyKeysFrom2<Q>,
   R extends boolean,
+  S extends NullabilityAdherence,
 >(
   client: MinimalClient,
   objectType: Q,
-  args: FetchPageArgs<Q, L, R>,
+  args: FetchPageArgs<Q, L, R, any, S>,
   objectSet: ObjectSet = {
     type: "base",
     objectType: objectType["apiName"] as string,
   },
-): Promise<Result<FetchPageResult<Q, L, R>>> {
+): Promise<Result<FetchPageResult<Q, L, R, S>>> {
   return fetchPageWithErrorsInternal(client, objectType, objectSet, args);
 }
 
@@ -192,7 +202,7 @@ function applyFetchArgs<
     pageSize?: PageSize;
   },
 >(
-  args: FetchPageArgs<any, any, any>,
+  args: FetchPageArgs<any, any, any, any, any>,
   body: X,
 ): X {
   if (args?.$nextPageToken) {
@@ -219,12 +229,13 @@ export async function fetchObjectPage<
   Q extends ObjectTypeDefinition<any>,
   L extends ObjectOrInterfacePropertyKeysFrom2<Q>,
   R extends boolean,
+  S extends NullabilityAdherence,
 >(
   client: MinimalClient,
   objectType: Q,
-  args: FetchPageArgs<Q, L, R>,
+  args: FetchPageArgs<Q, L, R, Augments, S>,
   objectSet: ObjectSet,
-): Promise<FetchPageResult<Q, L, R>> {
+): Promise<FetchPageResult<Q, L, R, S>> {
   const r = await OntologiesV2.OntologyObjectSets.loadObjectSetV2(
     addUserAgent(client, objectType),
     client.ontologyRid,
@@ -241,7 +252,10 @@ export async function fetchObjectPage<
       client,
       r.data as OntologyObjectV2[],
       undefined,
+      undefined,
+      args.$select,
+      args.$__EXPERIMENTAL_strictNonNull,
     ),
     nextPageToken: r.nextPageToken,
-  }) as Promise<FetchPageResult<Q, L, R>>;
+  }) as Promise<FetchPageResult<Q, L, R, S>>;
 }

--- a/packages/client/src/objectSet/ObjectSet.test.ts
+++ b/packages/client/src/objectSet/ObjectSet.test.ts
@@ -15,7 +15,11 @@
  */
 
 import type { ObjectOrInterfacePropertyKeysFrom2 } from "@osdk/api";
-import { Employee, Ontology as MockOntology } from "@osdk/client.test.ontology";
+import {
+  Employee,
+  FooInterface,
+  Ontology as MockOntology,
+} from "@osdk/client.test.ontology";
 import { apiServer, stubData } from "@osdk/shared.test";
 import {
   afterAll,
@@ -25,6 +29,7 @@ import {
   expectTypeOf,
   it,
 } from "vitest";
+import type { InterfaceDefinition } from "../../../api/build/cjs/index.cjs";
 import type { Client } from "../Client.js";
 import { createClient } from "../createClient.js";
 import type { Result } from "../object/Result.js";
@@ -207,7 +212,7 @@ describe("ObjectSet", () => {
       .fetchOneWithErrors(-1);
 
     expectTypeOf<typeof employeeResult>().toEqualTypeOf<
-      Result<Osdk<Employee, ObjectOrInterfacePropertyKeysFrom2<Employee>>>
+      Result<Osdk<Employee>>
     >;
 
     expect("error" in employeeResult);
@@ -247,5 +252,176 @@ describe("ObjectSet", () => {
       }
       expect(iter).toEqual(2);
     }
+  });
+
+  describe.each(["fetchPage", "fetchPageWithErrors"] as const)("%s", (k) => {
+    describe("strictNonNull: \"drop\"", () => {
+      describe("includeRid: true", () => {
+        it("drops bad data", async () => {
+          const opts = {
+            $__EXPERIMENTAL_strictNonNull: "drop",
+            $includeRid: true,
+          } as const;
+          const result = k === "fetchPage"
+            ? await client(Employee).fetchPage(opts)
+            : (await client(Employee).fetchPageWithErrors(opts)).value!;
+
+          expect(result.data).toHaveLength(3);
+          expectTypeOf(result.data[0]).toEqualTypeOf<
+            Osdk<Employee, "$rid" | "$all">
+          >();
+        });
+      });
+
+      describe("includeRid: false", () => {
+        it("drops bad data", async () => {
+          const opts = {
+            $__EXPERIMENTAL_strictNonNull: "drop",
+            $includeRid: false,
+          } as const;
+          const result = k === "fetchPage"
+            ? await client(Employee).fetchPage(opts)
+            : (await client(Employee).fetchPageWithErrors(opts)).value!;
+
+          expect(result.data).toHaveLength(3);
+          expectTypeOf(result.data[0]).toEqualTypeOf<Osdk<Employee>>();
+        });
+      });
+    });
+
+    describe("strictNonNull: false", () => {
+      describe("includeRid: true", () => {
+        it("returns bad data", async () => {
+          const opts = {
+            $__EXPERIMENTAL_strictNonNull: false,
+            $includeRid: true,
+          } as const;
+          const result = k === "fetchPage"
+            ? await client(Employee).fetchPage(opts)
+            : (await client(Employee).fetchPageWithErrors(opts)).value!;
+
+          expect(result.data).toHaveLength(4);
+          expectTypeOf(result.data[0]).toEqualTypeOf<
+            Osdk<Employee, "$all" | "$notStrict" | "$rid">
+          >();
+        });
+      });
+
+      describe("includeRid: false", () => {
+        it("returns bad data", async () => {
+          const opts = {
+            $__EXPERIMENTAL_strictNonNull: false,
+            includeRid: false,
+          } as const;
+          const result = k === "fetchPage"
+            ? await client(Employee).fetchPage(opts)
+            : (await client(Employee).fetchPageWithErrors(opts)).value!;
+
+          expect(result.data).toHaveLength(4);
+          expectTypeOf(result.data[0]).toEqualTypeOf<
+            Osdk<Employee, "$all" | "$notStrict">
+          >();
+        });
+      });
+    });
+  });
+
+  describe("strictNonNull: \"throw\"", () => {
+    it("throws when getting bad data", () => {
+      expect(() =>
+        client(Employee).fetchPage({
+          $__EXPERIMENTAL_strictNonNull: "throw",
+        })
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[Error: Unable to safely convert objects as some non nullable properties are null]`,
+      );
+    });
+  });
+
+  describe.each(["fetchOne", "fetchOneWithErrors"] as const)("%s", (k) => {
+    describe("strictNonNull: false", () => {
+      describe("includeRid: true", () => {
+        it("returns bad data", async () => {
+          const opts = {
+            $__EXPERIMENTAL_strictNonNull: false,
+            $includeRid: true,
+          } as const;
+          const result = k === "fetchOne"
+            ? await client(Employee).fetchOne(50033, opts)
+            : (await client(Employee).fetchOneWithErrors(50033, opts)).value!;
+
+          expect(result).not.toBeUndefined();
+          expectTypeOf(result).toEqualTypeOf<
+            Osdk<Employee, "$all" | "$notStrict" | "$rid">
+          >();
+        });
+      });
+
+      describe("includeRid: false", () => {
+        it("returns bad data", async () => {
+          const opts = {
+            $__EXPERIMENTAL_strictNonNull: false,
+            includeRid: false,
+          } as const;
+          const result = k === "fetchOne"
+            ? await client(Employee).fetchOne(50033, opts)
+            : (await client(Employee).fetchOneWithErrors(50033, opts)).value!;
+
+          expect(result).not.toBeUndefined();
+          expectTypeOf(result).toEqualTypeOf<
+            Osdk<Employee, "$all" | "$notStrict">
+          >();
+        });
+      });
+    });
+  });
+
+  describe("strictNonNull: \"throw\"", () => {
+    it("throws when getting bad data", () => {
+      expect(() =>
+        client(Employee).fetchPage({
+          $__EXPERIMENTAL_strictNonNull: "throw",
+        })
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[Error: Unable to safely convert objects as some non nullable properties are null]`,
+      );
+    });
+  });
+
+  describe("conversions", () => {
+    describe("strictNonNull: false", () => {
+      it("returns bad data", async () => {
+        const result = await client(Employee).fetchPage({
+          $__EXPERIMENTAL_strictNonNull: false,
+        });
+
+        const empNotStrict = result.data[0];
+
+        expectTypeOf(empNotStrict).toEqualTypeOf<
+          Osdk<Employee, "$all" | "$notStrict">
+        >();
+        expectTypeOf(empNotStrict.employeeId).toEqualTypeOf<
+          number | undefined
+        >();
+
+        // We don't have a proper definition that has
+        // a non-null property on an interface so
+        // we cheese it here to be sure the types work
+        type CheesedProp<
+          T extends InterfaceDefinition<any>,
+          K extends keyof T["properties"],
+        > = T & { properties: { [KK in K]: { nullable: false } } };
+
+        type CheesedFoo = CheesedProp<FooInterface, "fooSpt">;
+        const CheesedFoo: CheesedFoo = FooInterface as CheesedFoo;
+
+        const cheesedFooNotStrict = result.data[0].$as(CheesedFoo);
+        expectTypeOf(cheesedFooNotStrict).toEqualTypeOf<
+          Osdk<CheesedFoo, "$all" | "$notStrict", never>
+        >();
+
+        cheesedFooNotStrict.fooSpt;
+      });
+    });
   });
 });

--- a/packages/client/src/objectSet/ObjectSet.ts
+++ b/packages/client/src/objectSet/ObjectSet.ts
@@ -28,9 +28,14 @@ import type { AggregateOptsThatErrors } from "../object/AggregateOptsThatErrors.
 import type {
   Augments,
   FetchPageArgs,
+  NullabilityAdherence,
+  NullabilityAdherenceDefault,
   SelectArg,
 } from "../object/FetchPageArgs.js";
-import type { FetchPageResult } from "../object/FetchPageResult.js";
+import type {
+  FetchPageResult,
+  SingleOsdkResult,
+} from "../object/FetchPageResult.js";
 import type { Result } from "../object/Result.js";
 import type { Osdk } from "../OsdkObjectFrom.js";
 import type { AggregateOpts } from "../query/aggregations/AggregateOpts.js";
@@ -45,17 +50,19 @@ export interface MinimalObjectSet<Q extends ObjectOrInterfaceDefinition>
     L extends ObjectOrInterfacePropertyKeysFrom2<Q>,
     R extends boolean,
     const A extends Augments,
+    S extends NullabilityAdherence = NullabilityAdherenceDefault,
   >(
-    args?: FetchPageArgs<Q, L, R, A>,
-  ) => Promise<FetchPageResult<Q, L, R>>;
+    args?: FetchPageArgs<Q, L, R, A, S>,
+  ) => Promise<FetchPageResult<Q, L, R, S>>;
 
   fetchPageWithErrors: <
     L extends ObjectOrInterfacePropertyKeysFrom2<Q>,
     R extends boolean,
     const A extends Augments,
+    S extends NullabilityAdherence = NullabilityAdherenceDefault,
   >(
-    args?: FetchPageArgs<Q, L, R, A>,
-  ) => Promise<Result<FetchPageResult<Q, L, R>>>;
+    args?: FetchPageArgs<Q, L, R, A, S>,
+  ) => Promise<Result<FetchPageResult<Q, L, R, S>>>;
 
   where: (
     clause: WhereClause<Q>,
@@ -94,17 +101,23 @@ export interface ObjectSet<Q extends ObjectOrInterfaceDefinition>
 
   pivotTo: <L extends LinkNames<Q>>(type: L) => ObjectSet<LinkedType<Q, L>>;
 
-  fetchOne: Q extends ObjectTypeDefinition<any>
-    ? <L extends ObjectOrInterfacePropertyKeysFrom2<Q>>(
+  fetchOne: Q extends ObjectTypeDefinition<any> ? <
+      L extends ObjectOrInterfacePropertyKeysFrom2<Q>,
+      R extends boolean,
+      S extends false | "throw" = NullabilityAdherenceDefault,
+    >(
       primaryKey: PropertyValueClientToWire[Q["primaryKeyType"]],
-      options?: SelectArg<Q, L>,
-    ) => Promise<Osdk<Q, L>>
+      options?: SelectArg<Q, L, R, S>,
+    ) => Promise<SingleOsdkResult<Q, L, R, S>>
     : never;
 
-  fetchOneWithErrors: Q extends ObjectTypeDefinition<any>
-    ? <L extends ObjectOrInterfacePropertyKeysFrom2<Q>>(
+  fetchOneWithErrors: Q extends ObjectTypeDefinition<any> ? <
+      L extends ObjectOrInterfacePropertyKeysFrom2<Q>,
+      R extends boolean,
+      S extends false | "throw" = NullabilityAdherenceDefault,
+    >(
       primaryKey: PropertyValueClientToWire[Q["primaryKeyType"]],
-      options?: SelectArg<Q, L>,
-    ) => Promise<Result<Osdk<Q, L>>>
+      options?: SelectArg<Q, L, R, S>,
+    ) => Promise<Result<SingleOsdkResult<Q, L, R, S>>>
     : never;
 }

--- a/packages/client/src/objectSet/createObjectSet.ts
+++ b/packages/client/src/objectSet/createObjectSet.ts
@@ -141,7 +141,9 @@ export function createObjectSet<Q extends ObjectOrInterfaceDefinition>(
       do {
         const result = await base.fetchPage({ $nextPageToken });
 
-        for (const obj of result.data) {
+        for (
+          const obj of result.data
+        ) {
           yield obj as Osdk<Q, "$all">;
         }
       } while ($nextPageToken != null);

--- a/packages/client/src/query/aggregations/AggregationResultsWithGroups.ts
+++ b/packages/client/src/query/aggregations/AggregationResultsWithGroups.ts
@@ -31,13 +31,8 @@ export type AggregationResultsWithGroups<
   & {
     $group: {
       [P in keyof G & keyof Q["properties"]]: G[P] extends
-        { $ranges: GroupByRange<number>[] }
-        ? { startValue: number; endValue: number }
-        : G[P] extends { $ranges: GroupByRange<string>[] }
-          ? { startValue: string; endValue: string }
-        : OsdkObjectPropertyType<
-          Q["properties"][P]
-        >;
+        { $ranges: GroupByRange<infer T>[] } ? { startValue: T; endValue: T }
+        : OsdkObjectPropertyType<Q["properties"][P], true>;
     };
   }
   & AggregationCountResult<Q, A>

--- a/packages/foundry-sdk-generator/src/__e2e_tests__/loadObjects.test.ts
+++ b/packages/foundry-sdk-generator/src/__e2e_tests__/loadObjects.test.ts
@@ -267,7 +267,7 @@ describe("LoadObjects", () => {
         pageToken: employees.nextPageToken,
       });
     const secondEmployeesPage = assertOkOrThrow(secondResult);
-    expect(secondEmployeesPage.data.length).toEqual(1);
+    expect(secondEmployeesPage.data.length).toEqual(2);
     expect(secondEmployeesPage.data[0].employeeId).toEqual(50032);
   });
 
@@ -277,10 +277,10 @@ describe("LoadObjects", () => {
       .objects.Employee.all();
     const employees = assertOkOrThrow(result);
     for (const emp of employees) {
-      expect(emp.employeeId).toEqual(50030 + iter);
+      expect(emp.$primaryKey).toEqual(50030 + iter);
       iter += 1;
     }
-    expect(iter).toEqual(3);
+    expect(iter).toEqual(4);
   });
 
   it("Gets All Objects with async iter", async () => {
@@ -290,10 +290,10 @@ describe("LoadObjects", () => {
         .objects.Employee.asyncIter(),
     );
     for (const emp of employees) {
-      expect(emp.employeeId).toEqual(50030 + iter);
+      expect(emp.$primaryKey).toEqual(50030 + iter);
       iter += 1;
     }
-    expect(iter).toEqual(3);
+    expect(iter).toEqual(4);
   });
 
   it("Links with a cardinality of ONE are loaded properly", async () => {

--- a/packages/foundry-sdk-generator/src/__e2e_tests__/objectSet.test.ts
+++ b/packages/foundry-sdk-generator/src/__e2e_tests__/objectSet.test.ts
@@ -61,10 +61,14 @@ describe("Object Sets", () => {
     const employeesPage = assertOkOrThrow(result);
     const employees = employeesPage.data;
     for (const emp of employees) {
-      expect(emp.employeeId).toEqual(50030 + iter);
+      expect(emp.$primaryKey).toEqual(50030 + iter);
+      if (emp.employeeId) {
+        // one of the objects is invalid intentionally, so we don't want to check it
+        expect(emp.employeeId).toEqual(50030 + iter);
+      }
       iter += 1;
     }
-    expect(iter).toEqual(3);
+    expect(iter).toEqual(4);
   });
 
   it("objects set union", async () => {
@@ -214,7 +218,7 @@ describe("Object Sets", () => {
   it("object set page gets all elements", async () => {
     const objectSet: ObjectSet<Employee> = client.ontology.objects.Employee;
     const pageResults = await fetchAllPages(objectSet, 1);
-    expect(pageResults.length).toEqual(3);
+    expect(pageResults.length).toEqual(4);
   });
 
   it("object set page respects page size", async () => {

--- a/packages/shared.test/src/stubs/objectSetRequest.ts
+++ b/packages/shared.test/src/stubs/objectSetRequest.ts
@@ -23,6 +23,7 @@ import {
   employee1,
   employee2,
   employee3,
+  employeeFailsStrict,
   nycOffice,
   objectWithAllPropertyTypes1,
   objectWithAllPropertyTypesEmptyEntries,
@@ -88,6 +89,19 @@ const eqSearchBody: LoadObjectSetRequestV2 = {
       type: "eq",
       field: "employeeId",
       value: 50030,
+    },
+  },
+  select: [],
+};
+
+const eqSearchBodyBadObject: LoadObjectSetRequestV2 = {
+  objectSet: {
+    type: "filter",
+    objectSet: { type: "base", objectType: employeeObjectType.apiName },
+    where: {
+      type: "eq",
+      field: "employeeId",
+      value: 50033,
     },
   },
   select: [],
@@ -409,11 +423,17 @@ const employee2ToToEmployee1PeepByPk: LoadObjectSetRequestV2 = {
 export const loadObjectSetRequestHandlers: {
   [key: string]: LoadObjectSetResponseV2["data"];
 } = {
-  [stableStringify(baseObjectSet)]: [employee1, employee2, employee3],
+  [stableStringify(baseObjectSet)]: [
+    employee1,
+    employee2,
+    employee3,
+    employeeFailsStrict,
+  ],
   [stableStringify(unionedObjectSet)]: [employee1, employee2],
   [stableStringify(intersectedObjectSet)]: [employee3],
   [stableStringify(subtractedObjectSet)]: [employee2, employee3],
   [stableStringify(eqSearchBody)]: [employee1],
+  [stableStringify(eqSearchBodyBadObject)]: [employeeFailsStrict],
   [stableStringify(eqSearchBodyWithSelect)]: [employee1],
   [stableStringify(andSearchBody)]: [employee2],
   [stableStringify(geoPointSearchBody)]: [nycOffice],

--- a/packages/shared.test/src/stubs/objects.ts
+++ b/packages/shared.test/src/stubs/objects.ts
@@ -55,6 +55,19 @@ export const employee3 = {
   employeeStatus: "TimeSeries<String>",
 };
 
+export const employeeFailsStrict = {
+  __rid:
+    "ri.phonograph2-objects.main.object.b9a0b2b0-0a2b-0b8b-9e4b-a9a9b9a0b9a0",
+  __primaryKey: 50033,
+  __apiName: "Employee",
+  employeeId: undefined,
+  fullName: "Jack Smith",
+  office: "LON",
+  class: "Red",
+  startDate: "2015-05-15",
+  employeeStatus: "TimeSeries<String>",
+};
+
 export const officeAreaGeoJson: GeoJsonObject = {
   coordinates: [
     [
@@ -170,6 +183,7 @@ export const objectLoadResponseMap: {
     [employee1.__primaryKey.toString()]: employee1,
     [employee2.__primaryKey.toString()]: employee2,
     [employee3.__primaryKey.toString()]: employee3,
+    [employeeFailsStrict.__primaryKey.toString()]: employeeFailsStrict,
   },
   Office: {
     [nycOffice.__primaryKey.toString()]: nycOffice,


### PR DESCRIPTION
to throw, drop objects, or return `| undefined` for properties, allowing for correct type safety.

## Additional info

Right now, it is not possible to generate an sdk with nullable types (besides the one we do for the primary key which can't be null), however this now lays the ground work so that when we do implement those, we can leverage strict types. 🎉 

## Demos

![image](https://github.com/palantir/osdk-ts/assets/120899/2be4a6ee-a74a-490d-83b8-5f6aeff90935)

![image](https://github.com/palantir/osdk-ts/assets/120899/78da21ee-3a3a-4854-bef9-59f6eb4ba67f)

