### PR TITLE
Do not restart auth flow on failed auth callback

### DIFF
--- a/.changeset/great-geese-fail.md
+++ b/.changeset/great-geese-fail.md
@@ -1,0 +1,5 @@
+---
+"@osdk/legacy-client": patch
+---
+
+Do not restart auth flow on failed auth callback

--- a/packages/legacy-client/src/oauth-client/PublicClient/PublicClientAuth.ts
+++ b/packages/legacy-client/src/oauth-client/PublicClient/PublicClientAuth.ts
@@ -142,10 +142,11 @@ export class PublicClientAuth implements Auth {
       } catch (e) {
         // eslint-disable-next-line no-console
         console.warn(
-          "Failed to get OAuth2 token using PCKE, removing PCKE and starting a new auth flow",
+          "Failed to get OAuth2 token using PCKE, removing PCKE",
           e,
         );
         localStorage.removeItem(this.palantirPcke);
+        throw e;
       }
     }
 


### PR DESCRIPTION
If the final token request to complete the authorization_code for public clients fails, currently the client resets state and restarts the whole oauth flow with a new login redirect. If there is a persistent error causing the token request to fail this will cause a repeated cycle from the auth callback back to a new login redirect. Instead, surface the error in the token request for application code to handle which by default in the create-app templates displays the error in text on the AuthCallback component