### PR TITLE
Attachments Work V3

### DIFF
--- a/.changeset/eight-hats-joke.md
+++ b/.changeset/eight-hats-joke.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client.api": minor
+"@osdk/client": minor
+---
+
+Attachments reworked so that you can now fetch directly from object properties. Also added a helper to create an attachment object directly from a rid.

--- a/packages/client.api/src/index.ts
+++ b/packages/client.api/src/index.ts
@@ -34,6 +34,7 @@ export type {
   AttachmentMetadata,
   AttachmentSignature,
   AttachmentUpload,
+  AttachmentWrapper,
 } from "./object/Attachment.js";
 export type { BaseObjectSet } from "./objectSet/BaseObjectSet.js";
 export type { OsdkBase } from "./OsdkBase.js";

--- a/packages/client.api/src/index.ts
+++ b/packages/client.api/src/index.ts
@@ -32,7 +32,6 @@ export type {
 export type {
   Attachment,
   AttachmentMetadata,
-  AttachmentSignature,
   AttachmentUpload,
 } from "./object/Attachment.js";
 export type { BaseObjectSet } from "./objectSet/BaseObjectSet.js";

--- a/packages/client.api/src/index.ts
+++ b/packages/client.api/src/index.ts
@@ -30,10 +30,10 @@ export type {
   PropertyValueWireToClient,
 } from "./mapping/PropertyValueMapping.js";
 export type {
+  Attachment,
   AttachmentMetadata,
   AttachmentSignature,
   AttachmentUpload,
-  AttachmentWrapper,
 } from "./object/Attachment.js";
 export type { BaseObjectSet } from "./objectSet/BaseObjectSet.js";
 export type { OsdkBase } from "./OsdkBase.js";

--- a/packages/client.api/src/index.ts
+++ b/packages/client.api/src/index.ts
@@ -30,7 +30,6 @@ export type {
   PropertyValueWireToClient,
 } from "./mapping/PropertyValueMapping.js";
 export type {
-  Attachment,
   AttachmentMetadata,
   AttachmentSignature,
   AttachmentUpload,

--- a/packages/client.api/src/mapping/DataValueMapping.ts
+++ b/packages/client.api/src/mapping/DataValueMapping.ts
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
-import type { Attachment, AttachmentUpload } from "../object/Attachment.js";
+import type {
+  AttachmentUpload,
+  AttachmentWrapper,
+} from "../object/Attachment.js";
 
 /**
  * Map from the DataValue type to the typescript type that we return
  */
 export interface DataValueWireToClient {
-  attachment: Attachment;
+  attachment: AttachmentWrapper;
   boolean: boolean;
   byte: number;
   datetime: string;
@@ -40,7 +43,7 @@ export interface DataValueWireToClient {
  * Map from the DataValue type to the typescript type that we accept
  */
 export interface DataValueClientToWire {
-  attachment: Attachment | AttachmentUpload;
+  attachment: string | AttachmentUpload;
   boolean: boolean;
   byte: number;
   datetime: string;

--- a/packages/client.api/src/mapping/DataValueMapping.ts
+++ b/packages/client.api/src/mapping/DataValueMapping.ts
@@ -14,16 +14,13 @@
  * limitations under the License.
  */
 
-import type {
-  AttachmentUpload,
-  AttachmentWrapper,
-} from "../object/Attachment.js";
+import type { Attachment, AttachmentUpload } from "../object/Attachment.js";
 
 /**
  * Map from the DataValue type to the typescript type that we return
  */
 export interface DataValueWireToClient {
-  attachment: AttachmentWrapper;
+  attachment: Attachment;
   boolean: boolean;
   byte: number;
   datetime: string;

--- a/packages/client.api/src/mapping/PropertyValueMapping.ts
+++ b/packages/client.api/src/mapping/PropertyValueMapping.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import type { Attachment } from "../object/Attachment.js";
+import type { Attachment, AttachmentWrapper } from "../object/Attachment.js";
 
 /**
  * Map from the PropertyDefinition type to the typescript type that we return
  */
 export interface PropertyValueWireToClient {
-  attachment: Attachment;
+  attachment: AttachmentWrapper;
   boolean: boolean;
   byte: number;
   datetime: string;

--- a/packages/client.api/src/mapping/PropertyValueMapping.ts
+++ b/packages/client.api/src/mapping/PropertyValueMapping.ts
@@ -14,16 +14,13 @@
  * limitations under the License.
  */
 
-import type {
-  AttachmentUpload,
-  AttachmentWrapper,
-} from "../object/Attachment.js";
+import type { Attachment, AttachmentUpload } from "../object/Attachment.js";
 
 /**
  * Map from the PropertyDefinition type to the typescript type that we return
  */
 export interface PropertyValueWireToClient {
-  attachment: AttachmentWrapper;
+  attachment: Attachment;
   boolean: boolean;
   byte: number;
   datetime: string;

--- a/packages/client.api/src/mapping/PropertyValueMapping.ts
+++ b/packages/client.api/src/mapping/PropertyValueMapping.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import type { Attachment, AttachmentWrapper } from "../object/Attachment.js";
+import type {
+  AttachmentUpload,
+  AttachmentWrapper,
+} from "../object/Attachment.js";
 
 /**
  * Map from the PropertyDefinition type to the typescript type that we return
@@ -44,7 +47,7 @@ export interface PropertyValueWireToClient {
  * Map from the PropertyDefinition type to the typescript type that we accept
  */
 export interface PropertyValueClientToWire {
-  attachment: Attachment | { rid: string };
+  attachment: string | AttachmentUpload;
   boolean: boolean;
   byte: number;
   datetime: string;

--- a/packages/client.api/src/object/Attachment.ts
+++ b/packages/client.api/src/object/Attachment.ts
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-export interface Attachment {
-  rid: string;
-}
-
-export interface AttachmentWrapper extends Attachment {
+export interface AttachmentWrapper {
   rid: string;
   fetchMetadata(): Promise<AttachmentMetadata>;
   fetchContents(): Promise<Blob>;

--- a/packages/client.api/src/object/Attachment.ts
+++ b/packages/client.api/src/object/Attachment.ts
@@ -33,8 +33,3 @@ export interface AttachmentMetadata {
   sizeBytes: string;
   mediaType: string;
 }
-
-export interface AttachmentSignature {
-  fetchMetadata(): Promise<AttachmentMetadata>;
-  fetchContents(): Promise<Blob>;
-}

--- a/packages/client.api/src/object/Attachment.ts
+++ b/packages/client.api/src/object/Attachment.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export interface AttachmentWrapper {
+export interface Attachment {
   rid: string;
   fetchMetadata(): Promise<AttachmentMetadata>;
   fetchContents(): Promise<Blob>;

--- a/packages/client.api/src/object/Attachment.ts
+++ b/packages/client.api/src/object/Attachment.ts
@@ -17,6 +17,12 @@
 export interface Attachment {
   rid: string;
 }
+
+export interface AttachmentWrapper extends Attachment {
+  rid: string;
+  fetchMetadata(): Promise<AttachmentMetadata>;
+  fetchContents(): Promise<Blob>;
+}
 /**
  * This interface should also accept the File object from
  * the W3C FileApi https://www.w3.org/TR/FileAPI/#file-section

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -19,11 +19,7 @@ import type {
   ObjectTypeDefinition,
   VersionBound,
 } from "@osdk/api";
-import type {
-  ActionSignatureFromDef,
-  Attachment,
-  AttachmentSignature,
-} from "@osdk/client.api";
+import type { ActionSignatureFromDef } from "@osdk/client.api";
 import type { SharedClient } from "@osdk/shared.client";
 import type { MinimalClient } from "./MinimalClientContext.js";
 import type { ObjectSet } from "./objectSet/ObjectSet.js";

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -46,8 +46,6 @@ export interface Client extends SharedClient<MinimalClient> {
   <Q extends ActionDefinition<any, any, any>>(
     o: CheckVersionBound<Q>,
   ): ActionSignatureFromDef<Q>;
-
-  (o: Attachment): AttachmentSignature;
 }
 
 // BEGIN: THIS IS GENERATED CODE. DO NOT EDIT.

--- a/packages/client/src/actions/actions.test.ts
+++ b/packages/client/src/actions/actions.test.ts
@@ -17,7 +17,6 @@
 import type {
   ActionEditResponse,
   ActionValidationResponse,
-  Attachment as IAttachment,
   AttachmentUpload,
 } from "@osdk/client.api";
 import {
@@ -37,7 +36,7 @@ import {
 } from "vitest";
 import type { Client } from "../Client.js";
 import { createClient } from "../createClient.js";
-import { Attachment, createAttachmentUpload } from "../object/Attachment.js";
+import { createAttachmentUpload } from "../object/AttachmentUpload.js";
 import { ActionValidationError } from "./ActionValidationError.js";
 
 describe("actions", () => {
@@ -146,14 +145,13 @@ describe("actions", () => {
     );
     expectTypeOf<Parameters<typeof clientBoundActionTakesAttachment>[0]>()
       .toEqualTypeOf<
-        { attachment: IAttachment | AttachmentUpload } | {
-          attachment: IAttachment | AttachmentUpload;
+        { attachment: string | AttachmentUpload } | {
+          attachment: string | AttachmentUpload;
         }[]
       >();
 
-    const attachment = new Attachment("attachment.rid");
     const result = await client(actionTakesAttachment)({
-      attachment,
+      attachment: "attachment.rid",
     });
 
     expectTypeOf<typeof result>().toEqualTypeOf<undefined>();
@@ -166,8 +164,8 @@ describe("actions", () => {
     );
     expectTypeOf<Parameters<typeof clientBoundActionTakesAttachment>[0]>()
       .toEqualTypeOf<
-        { attachment: IAttachment | AttachmentUpload } | {
-          attachment: IAttachment | AttachmentUpload;
+        { attachment: string | AttachmentUpload } | {
+          attachment: string | AttachmentUpload;
         }[]
       >();
     const blob =

--- a/packages/client/src/actions/applyAction.ts
+++ b/packages/client/src/actions/applyAction.ts
@@ -24,7 +24,6 @@ import type {
 import type { DataValue } from "@osdk/internal.foundry";
 import { Ontologies, OntologiesV2 } from "@osdk/internal.foundry";
 import type { MinimalClient } from "../MinimalClientContext.js";
-import { Attachment, isAttachmentUpload } from "../object/Attachment.js";
 import { addUserAgent } from "../util/addUserAgent.js";
 import { toDataValue } from "../util/toDataValue.js";
 import { ActionValidationError } from "./ActionValidationError.js";

--- a/packages/client/src/createAttachmentFromRid.ts
+++ b/packages/client/src/createAttachmentFromRid.ts
@@ -15,30 +15,12 @@
  */
 
 import type {
-  Attachment,
   AttachmentMetadata,
   AttachmentSignature,
   AttachmentWrapper,
 } from "@osdk/client.api";
 import { Ontologies } from "@osdk/internal.foundry";
 import type { MinimalClient } from "./MinimalClientContext.js";
-
-export function createAttachmentReader(
-  client: MinimalClient,
-  attachment: Attachment,
-): AttachmentSignature {
-  return {
-    fetchContents() {
-      return Ontologies.Attachments.getAttachmentContent(
-        client,
-        attachment.rid,
-      ) as Promise<Blob>;
-    },
-    fetchMetadata() {
-      return Ontologies.Attachments.getAttachment(client, attachment.rid);
-    },
-  };
-}
 
 export function createAttachmentFromRid(
   client: MinimalClient,

--- a/packages/client/src/createAttachmentFromRid.ts
+++ b/packages/client/src/createAttachmentFromRid.ts
@@ -14,18 +14,14 @@
  * limitations under the License.
  */
 
-import type {
-  AttachmentMetadata,
-  AttachmentSignature,
-  AttachmentWrapper,
-} from "@osdk/client.api";
+import type { Attachment } from "@osdk/client.api";
 import { Ontologies } from "@osdk/internal.foundry";
 import type { MinimalClient } from "./MinimalClientContext.js";
 
 export function createAttachmentFromRid(
   client: MinimalClient,
   rid: string,
-): AttachmentWrapper {
+): Attachment {
   return {
     rid,
     async fetchContents() {

--- a/packages/client/src/createAttachmentReader.ts
+++ b/packages/client/src/createAttachmentReader.ts
@@ -18,6 +18,7 @@ import type {
   Attachment,
   AttachmentMetadata,
   AttachmentSignature,
+  AttachmentWrapper,
 } from "@osdk/client.api";
 import { Ontologies } from "@osdk/internal.foundry";
 import type { MinimalClient } from "./MinimalClientContext.js";
@@ -35,6 +36,24 @@ export function createAttachmentReader(
     },
     fetchMetadata() {
       return Ontologies.Attachments.getAttachment(client, attachment.rid);
+    },
+  };
+}
+
+export function createAttachmentFromRid(
+  client: MinimalClient,
+  rid: string,
+): AttachmentWrapper {
+  return {
+    rid,
+    async fetchContents() {
+      return Ontologies.Attachments.getAttachmentContent(
+        client,
+        rid,
+      ) as Promise<Blob>;
+    },
+    async fetchMetadata() {
+      return Ontologies.Attachments.getAttachment(client, rid);
     },
   };
 }

--- a/packages/client/src/createClient.ts
+++ b/packages/client/src/createClient.ts
@@ -28,11 +28,8 @@ import { symbolClientContext } from "@osdk/shared.client";
 import type { Logger } from "pino";
 import { createActionInvoker } from "./actions/createActionInvoker.js";
 import type { Client } from "./Client.js";
-import { createAttachmentReader } from "./createAttachmentReader.js";
 import { createMinimalClient } from "./createMinimalClient.js";
 import type { MinimalClient } from "./MinimalClientContext.js";
-import type { Attachment } from "./object/Attachment.js";
-import { isAttachment } from "./object/Attachment.js";
 import { createObjectSet } from "./objectSet/createObjectSet.js";
 import type { MinimalObjectSet, ObjectSet } from "./objectSet/ObjectSet.js";
 import type { ObjectSetFactory } from "./objectSet/ObjectSetFactory.js";
@@ -57,17 +54,12 @@ export function createClientInternal(
   function clientFn<
     T extends
       | ObjectOrInterfaceDefinition
-      | ActionDefinition<any, any, any>
-      | Attachment,
+      | ActionDefinition<any, any, any>,
   >(o: T): T extends ObjectTypeDefinition<any> ? ObjectSet<T>
     : T extends InterfaceDefinition<any, any> ? MinimalObjectSet<T>
     : T extends ActionDefinition<any, any, any> ? ActionSignatureFromDef<T>
-    : T extends Attachment ? AttachmentSignature
     : never
   {
-    if (isAttachment(o)) {
-      return createAttachmentReader(clientCtx, o) as any;
-    }
     if (o.type === "object" || o.type === "interface") {
       clientCtx.ontologyProvider.maybeSeed(o);
       return objectSetFactory(o, clientCtx) as any;

--- a/packages/client/src/createClient.ts
+++ b/packages/client/src/createClient.ts
@@ -20,10 +20,7 @@ import type {
   ObjectOrInterfaceDefinition,
   ObjectTypeDefinition,
 } from "@osdk/api";
-import type {
-  ActionSignatureFromDef,
-  AttachmentSignature,
-} from "@osdk/client.api";
+import type { ActionSignatureFromDef } from "@osdk/client.api";
 import { symbolClientContext } from "@osdk/shared.client";
 import type { Logger } from "pino";
 import { createActionInvoker } from "./actions/createActionInvoker.js";

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -29,6 +29,8 @@ export type { Client } from "./Client.js";
 export { createClient } from "./createClient.js";
 export { createPlatformClient } from "./createPlatformClient.js";
 
+export { createAttachmentFromRid } from "./createAttachmentFromRid.js";
+
 export { ActionValidationError } from "./actions/ActionValidationError.js";
 export type { InterfaceObjectSet, ObjectSet } from "./objectSet/ObjectSet.js";
 export type { OsdkObject } from "./OsdkObject.js";

--- a/packages/client/src/object/AttachmentUpload.ts
+++ b/packages/client/src/object/AttachmentUpload.ts
@@ -14,28 +14,17 @@
  * limitations under the License.
  */
 
-import type {
-  Attachment as IAttachment,
-  AttachmentUpload as IAttachmentUpload,
-} from "@osdk/client.api";
+import type { AttachmentUpload } from "@osdk/client.api";
 
-export class Attachment implements IAttachment {
-  constructor(public rid: string) {}
-}
-
-export function isAttachment(o: any): o is Attachment {
-  return o instanceof Attachment;
-}
-
-export function isAttachmentUpload(o: any): o is IAttachmentUpload {
+export function isAttachmentUpload(o: any): o is AttachmentUpload {
   return o instanceof Blob && "name" in o;
 }
 
 export function createAttachmentUpload(
   data: Blob,
   name: string,
-): IAttachmentUpload {
+): AttachmentUpload {
   const attachmentUpload = Object.create(data, { name: { value: name } });
 
-  return attachmentUpload as IAttachmentUpload;
+  return attachmentUpload as AttachmentUpload;
 }

--- a/packages/client/src/object/ObjectDefinitions.test.ts
+++ b/packages/client/src/object/ObjectDefinitions.test.ts
@@ -17,7 +17,6 @@
 import type { AttachmentWrapper } from "@osdk/client.api";
 import { describe, expectTypeOf, it } from "vitest";
 import type { OsdkObjectPropertyType } from "../Definitions.js";
-import type { Attachment } from "./Attachment.js";
 
 describe("Object definitions", () => {
   it("correctly upgrades attachment types at conversion time", () => {

--- a/packages/client/src/object/ObjectDefinitions.test.ts
+++ b/packages/client/src/object/ObjectDefinitions.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { AttachmentWrapper } from "@osdk/client.api";
 import { describe, expectTypeOf, it } from "vitest";
 import type { OsdkObjectPropertyType } from "../Definitions.js";
 import type { Attachment } from "./Attachment.js";
@@ -30,12 +31,12 @@ describe("Object definitions", () => {
     } as const;
 
     expectTypeOf<OsdkObjectPropertyType<typeof attachment>>().toEqualTypeOf<
-      Attachment
+      AttachmentWrapper
     >();
 
     expectTypeOf<OsdkObjectPropertyType<typeof attachmentArray>>()
       .toEqualTypeOf<
-        Attachment[]
+        AttachmentWrapper[]
       >();
   });
 });

--- a/packages/client/src/object/ObjectDefinitions.test.ts
+++ b/packages/client/src/object/ObjectDefinitions.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { AttachmentWrapper } from "@osdk/client.api";
+import type { Attachment } from "@osdk/client.api";
 import { describe, expectTypeOf, it } from "vitest";
 import type { OsdkObjectPropertyType } from "../Definitions.js";
 
@@ -30,12 +30,12 @@ describe("Object definitions", () => {
     } as const;
 
     expectTypeOf<OsdkObjectPropertyType<typeof attachment>>().toEqualTypeOf<
-      AttachmentWrapper
+      Attachment
     >();
 
     expectTypeOf<OsdkObjectPropertyType<typeof attachmentArray>>()
       .toEqualTypeOf<
-        AttachmentWrapper[]
+        Attachment[]
       >();
   });
 });

--- a/packages/client/src/object/attachment.test.ts
+++ b/packages/client/src/object/attachment.test.ts
@@ -44,12 +44,12 @@ describe("attachments", () => {
 
     const object1 = result.data[0];
     expect(object1.attachment).toBeDefined();
-    const attachmentMetadata = await client(object1.attachment!)
-      .fetchMetadata();
-    expect(attachmentMetadata.filename).toEqual("file1.txt");
-    expect(attachmentMetadata.mediaType).toEqual("application/json");
-    expect(attachmentMetadata.sizeBytes).toEqual(18);
-    expect(attachmentMetadata.rid).toEqual(
+    const attachmentMetadata = await object1.attachment?.fetchMetadata();
+    expect(attachmentMetadata).toBeDefined();
+    expect(attachmentMetadata!.filename).toEqual("file1.txt");
+    expect(attachmentMetadata!.mediaType).toEqual("application/json");
+    expect(attachmentMetadata!.sizeBytes).toEqual(18);
+    expect(attachmentMetadata!.rid).toEqual(
       "ri.attachments.main.attachment.86016861-707f-4292-b258-6a7108915a75",
     );
   });
@@ -62,8 +62,8 @@ describe("attachments", () => {
 
     const object1 = result.data[0];
     expect(object1.attachment).toBeDefined();
-    const attachmentContent = await client(object1.attachment!).fetchContents();
-    const attachmentText = await attachmentContent.text();
+    const attachmentContent = await object1!.attachment?.fetchContents();
+    const attachmentText = await attachmentContent!.text();
     expect(JSON.parse(attachmentText)).toEqual({
       name: "Hello World 2",
     });

--- a/packages/client/src/object/attachment.test.ts
+++ b/packages/client/src/object/attachment.test.ts
@@ -46,10 +46,10 @@ describe("attachments", () => {
     expect(object1.attachment).toBeDefined();
     const attachmentMetadata = await object1.attachment?.fetchMetadata();
     expect(attachmentMetadata).toBeDefined();
-    expect(attachmentMetadata!.filename).toEqual("file1.txt");
-    expect(attachmentMetadata!.mediaType).toEqual("application/json");
-    expect(attachmentMetadata!.sizeBytes).toEqual(18);
-    expect(attachmentMetadata!.rid).toEqual(
+    expect(attachmentMetadata?.filename).toEqual("file1.txt");
+    expect(attachmentMetadata?.mediaType).toEqual("application/json");
+    expect(attachmentMetadata?.sizeBytes).toEqual(18);
+    expect(attachmentMetadata?.rid).toEqual(
       "ri.attachments.main.attachment.86016861-707f-4292-b258-6a7108915a75",
     );
   });
@@ -62,7 +62,7 @@ describe("attachments", () => {
 
     const object1 = result.data[0];
     expect(object1.attachment).toBeDefined();
-    const attachmentContent = await object1!.attachment?.fetchContents();
+    const attachmentContent = await object1?.attachment?.fetchContents();
     const attachmentText = await attachmentContent!.text();
     expect(JSON.parse(attachmentText)).toEqual({
       name: "Hello World 2",

--- a/packages/client/src/object/convertWireToOsdkObjects.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { AttachmentWrapper } from "@osdk/client.api";
 import {
   Employee,
   FooInterface,
@@ -23,7 +24,14 @@ import type { OntologyObjectV2 } from "@osdk/internal.foundry";
 import { symbolClientContext } from "@osdk/shared.client";
 import { createSharedClientContext } from "@osdk/shared.client.impl";
 import { apiServer } from "@osdk/shared.test";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  expectTypeOf,
+  it,
+} from "vitest";
 import type { Client } from "../Client.js";
 import { createClient } from "../createClient.js";
 import { createMinimalClient } from "../createMinimalClient.js";
@@ -90,12 +98,14 @@ describe("convertWireToOsdkObjects", () => {
 
     const { attachment, attachmentArray } = withValues.data[0];
 
-    expect(attachment).toBeInstanceOf(Attachment);
+    expectTypeOf(attachment).toMatchTypeOf<
+      AttachmentWrapper | undefined
+    >;
     expect(attachment?.rid).toEqual(
       "ri.attachments.main.attachment.86016861-707f-4292-b258-6a7108915a75",
     );
     expect(Array.isArray(attachmentArray)).toBeTruthy();
-    expect(attachmentArray![0]).toBeInstanceOf(Attachment);
+    expectTypeOf(attachmentArray![0]).toMatchTypeOf<AttachmentWrapper>;
 
     const withoutValues = await client(
       MockOntology.objects.objectTypeWithAllPropertyTypes,

--- a/packages/client/src/object/convertWireToOsdkObjects.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.test.ts
@@ -36,7 +36,6 @@ import type { Client } from "../Client.js";
 import { createClient } from "../createClient.js";
 import { createMinimalClient } from "../createMinimalClient.js";
 import type { Osdk } from "../OsdkObjectFrom.js";
-import { Attachment } from "./Attachment.js";
 import { convertWireToOsdkObjects } from "./convertWireToOsdkObjects.js";
 
 describe("convertWireToOsdkObjects", () => {

--- a/packages/client/src/object/convertWireToOsdkObjects.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { AttachmentWrapper } from "@osdk/client.api";
+import type { Attachment } from "@osdk/client.api";
 import {
   Employee,
   FooInterface,
@@ -98,13 +98,13 @@ describe("convertWireToOsdkObjects", () => {
     const { attachment, attachmentArray } = withValues.data[0];
 
     expectTypeOf(attachment).toMatchTypeOf<
-      AttachmentWrapper | undefined
+      Attachment | undefined
     >;
     expect(attachment?.rid).toEqual(
       "ri.attachments.main.attachment.86016861-707f-4292-b258-6a7108915a75",
     );
     expect(Array.isArray(attachmentArray)).toBeTruthy();
-    expectTypeOf(attachmentArray![0]).toMatchTypeOf<AttachmentWrapper>;
+    expectTypeOf(attachmentArray![0]).toMatchTypeOf<Attachment>;
 
     const withoutValues = await client(
       MockOntology.objects.objectTypeWithAllPropertyTypes,

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -15,6 +15,7 @@
  */
 
 import type { OntologyObjectV2 } from "@osdk/internal.foundry";
+import { createAttachmentFromRid } from "../../createAttachmentReader.js";
 import type { MinimalClient } from "../../MinimalClientContext.js";
 import type { FetchedObjectTypeDefinition } from "../../ontology/OntologyProvider.js";
 import type { Osdk } from "../../OsdkObjectFrom.js";
@@ -108,9 +109,9 @@ export function createOsdkObject<
         if (propDef) {
           if (propDef.type === "attachment") {
             if (Array.isArray(rawValue)) {
-              return rawValue.map(a => new Attachment(a.rid));
+              return rawValue.map(a => createAttachmentFromRid(client, a.rid));
             }
-            return new Attachment(rawValue.rid);
+            return createAttachmentFromRid(client, rawValue.rid);
           }
         }
         return rawValue;

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -19,7 +19,6 @@ import { createAttachmentFromRid } from "../../createAttachmentReader.js";
 import type { MinimalClient } from "../../MinimalClientContext.js";
 import type { FetchedObjectTypeDefinition } from "../../ontology/OntologyProvider.js";
 import type { Osdk } from "../../OsdkObjectFrom.js";
-import { Attachment } from "../Attachment.js";
 import { createClientCache } from "../Cache.js";
 import { get$as } from "./getDollarAs.js";
 import { get$link } from "./getDollarLink.js";

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -15,7 +15,7 @@
  */
 
 import type { OntologyObjectV2 } from "@osdk/internal.foundry";
-import { createAttachmentFromRid } from "../../createAttachmentReader.js";
+import { createAttachmentFromRid } from "../../createAttachmentFromRid.js";
 import type { MinimalClient } from "../../MinimalClientContext.js";
 import type { FetchedObjectTypeDefinition } from "../../ontology/OntologyProvider.js";
 import type { Osdk } from "../../OsdkObjectFrom.js";

--- a/packages/client/src/util/toDataValue.test.ts
+++ b/packages/client/src/util/toDataValue.test.ts
@@ -21,7 +21,7 @@ import type { Client } from "../Client.js";
 import { createClient } from "../createClient.js";
 import { createMinimalClient } from "../createMinimalClient.js";
 import type { MinimalClient } from "../MinimalClientContext.js";
-import { Attachment, createAttachmentUpload } from "../object/Attachment.js";
+import { createAttachmentUpload } from "../object/AttachmentUpload.js";
 import { getWireObjectSet } from "../objectSet/createObjectSet.js";
 import { toDataValue } from "./toDataValue.js";
 
@@ -66,7 +66,7 @@ describe(toDataValue, () => {
   });
 
   it("recursively converts arrays and sets into array types", async () => {
-    const attachment = new Attachment("rid");
+    const attachment = "rid";
     const attachmentArray = [attachment];
     const attachmentSet = new Set(attachmentArray);
 
@@ -84,10 +84,9 @@ describe(toDataValue, () => {
   });
 
   it("recursively handles structs", async () => {
-    const attachment = new Attachment("rid");
     const struct = {
       inner: {
-        attachment,
+        attachment: "rid",
       },
     };
 

--- a/packages/client/src/util/toDataValue.ts
+++ b/packages/client/src/util/toDataValue.ts
@@ -15,13 +15,8 @@
  */
 
 import { type DataValue, Ontologies } from "@osdk/internal.foundry";
-import type { SharedClient, SharedClientContext } from "@osdk/shared.client";
 import type { MinimalClient } from "../MinimalClientContext.js";
-import {
-  Attachment,
-  isAttachment,
-  isAttachmentUpload,
-} from "../object/Attachment.js";
+import { isAttachmentUpload } from "../object/AttachmentUpload.js";
 import { getWireObjectSet, isObjectSet } from "../objectSet/createObjectSet.js";
 import { isOntologyObjectV2 } from "./isOntologyObjectV2.js";
 import { isWireObjectSet } from "./WireObjectSet.js";
@@ -49,11 +44,6 @@ export async function toDataValue(
     return Promise.all(promiseArray);
   }
 
-  // attachments just send the rid directly
-  if (isAttachment(value)) {
-    return value.rid;
-  }
-
   // For uploads, we need to upload ourselves first to get the RID of the attachment
   if (isAttachmentUpload(value)) {
     const attachment = await Ontologies.Attachments.uploadAttachment(
@@ -67,7 +57,7 @@ export async function toDataValue(
         "Content-Type": value.type,
       },
     );
-    return await toDataValue(new Attachment(attachment.rid), client);
+    return await toDataValue(attachment.rid, client);
   }
 
   // objects just send the JSON'd primaryKey


### PR DESCRIPTION
Modified attachment syntax for fetching data, now instead of using the client, attachment properties on objects will have this functionality exposed already:

```
const result = client(objectType).fetchPage();
const metadata = result.data[0].myAttachment.fetchMetadata();
const contents = result.data[0].myAttachment.fetchContents();
```

If you already have a rid, you can also reconstruct an Attachment object as follows:
```
import {createAttachmentFromRid} from "@osdk/client; 
const attachment = createAttachmentFromRid(client, "myAttachmentRid");
```
