### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -54,5 +54,32 @@
     "@osdk/tests.verify-fallback-package": "0.0.3",
     "@osdk/tests.verify-fallback-package-v2": "0.0.3"
   },
-  "changesets": []
+  "changesets": [
+    "cuddly-pens-smash",
+    "dirty-hotels-build",
+    "early-coats-sip",
+    "eight-hats-joke",
+    "fast-parents-learn",
+    "four-ways-add",
+    "great-geese-fail",
+    "itchy-radios-own",
+    "khaki-plants-sort",
+    "large-ads-listen",
+    "nervous-parrots-admire",
+    "nervous-pets-return",
+    "pink-insects-itch",
+    "plenty-peaches-scream",
+    "pretty-cherries-hunt",
+    "pretty-dingos-smash",
+    "purple-cameras-invite",
+    "rotten-shirts-cross",
+    "serious-glasses-try",
+    "shy-cougars-remain",
+    "smart-feet-chew",
+    "tasty-kiwis-attack",
+    "thin-eggs-prove",
+    "tough-hats-push",
+    "unlucky-wombats-switch",
+    "wild-plums-yell"
+  ]
 }

--- a/examples-extra/basic/sdk/src/generatedNoCheck/OntologyMetadata.ts
+++ b/examples-extra/basic/sdk/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,12 +1,12 @@
 import { OntologyMetadata as OM } from '@osdk/api';
 
-export type $ExpectedClientVersion = '0.19.0';
+export type $ExpectedClientVersion = '0.20.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export interface OntologyMetadata extends OM<$ExpectedClientVersion> {}
 
 export const OntologyMetadata: OntologyMetadata = {
-  expectsClientVersion: '0.19.0',
+  expectsClientVersion: '0.20.0',
   ontologyRid: 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e',
   ontologyApiName: 'default',
   userAgent: 'typescript-sdk/dev osdk-cli/dev',

--- a/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,12 +1,12 @@
 import { OntologyMetadata as OM } from '@osdk/api';
 
-export type $ExpectedClientVersion = '0.19.0';
+export type $ExpectedClientVersion = '0.20.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export interface OntologyMetadata extends OM<$ExpectedClientVersion> {}
 
 export const OntologyMetadata: OntologyMetadata = {
-  expectsClientVersion: '0.19.0',
+  expectsClientVersion: '0.20.0',
   ontologyRid: 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e',
   ontologyApiName: 'ontology-d097f725-ab77-46cf-83c0-e3cb9186bff1',
   userAgent: 'typescript-sdk/dev osdk-cli/dev',

--- a/examples-extra/one_dot_one/package.json
+++ b/examples-extra/one_dot_one/package.json
@@ -37,13 +37,13 @@
   },
   "peerDependencies": {
     "@osdk/api": "^1.8.0",
-    "@osdk/legacy-client": "^2.3.0"
+    "@osdk/legacy-client": "^2.4.0-beta.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.2",
     "@osdk/api": "^1.8.0",
     "@osdk/cli.cmd.typescript": "workspace:^",
-    "@osdk/legacy-client": "^2.3.0",
+    "@osdk/legacy-client": "^2.4.0-beta.0",
     "@types/node": "^18.0.0",
     "tslib": "^2.6.2",
     "typescript": "^4.9.5"

--- a/examples-extra/todoapp/src/generatedNoCheck2/OntologyMetadata.ts
+++ b/examples-extra/todoapp/src/generatedNoCheck2/OntologyMetadata.ts
@@ -1,12 +1,12 @@
 import { OntologyMetadata as OM } from '@osdk/api';
 
-export type $ExpectedClientVersion = '0.19.0';
+export type $ExpectedClientVersion = '0.20.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export interface OntologyMetadata extends OM<$ExpectedClientVersion> {}
 
 export const OntologyMetadata: OntologyMetadata = {
-  expectsClientVersion: '0.19.0',
+  expectsClientVersion: '0.20.0',
   ontologyRid: 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e',
   ontologyApiName: 'ontology-d097f725-ab77-46cf-83c0-e3cb9186bff1',
   userAgent: 'typescript-sdk/dev osdk-cli/dev',

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/cli.cmd.typescript
 
+## 0.4.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [5378312]
+- Updated dependencies [0ecd42b]
+  - @osdk/generator@1.12.0-beta.0
+
 ## 0.3.0
 
 ### Patch Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/cli
 
+## 0.22.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [5378312]
+- Updated dependencies [0ecd42b]
+  - @osdk/generator@1.12.0-beta.0
+
 ## 0.21.0
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.21.0",
+  "version": "0.22.0-beta.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client.api/CHANGELOG.md
+++ b/packages/client.api/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @osdk/client.api
+
+## 0.20.0-beta.0
+
+### Minor Changes
+
+- a6119bd: Attachments reworked so that you can now fetch directly from object properties. Also added a helper to create an attachment object directly from a rid.
+- 413e511: Added attachment uploading, reading, and metadata fetching support to 2.0.

--- a/packages/client.api/package.json
+++ b/packages/client.api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.api",
-  "version": "0.19.0",
+  "version": "0.20.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.test.ontology/CHANGELOG.md
+++ b/packages/client.test.ontology/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @osdk/client.test.ontology
+
+## 0.1.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [a6119bd]
+- Updated dependencies [413e511]
+  - @osdk/client.api@0.20.0-beta.0

--- a/packages/client.test.ontology/package.json
+++ b/packages/client.test.ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/client.test.ontology",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @osdk/client
 
+## 0.20.0-beta.0
+
+### Minor Changes
+
+- 564adbf: Fixing attachment creation when converting objects from the wire
+- 505b993: Experimental subscription no longer fires outOfDate when first subscribing
+- a6119bd: Attachments reworked so that you can now fetch directly from object properties. Also added a helper to create an attachment object directly from a rid.
+- f6d8850: Removed get, which is now replaced by fetchOne(). This has the exact same functionality and is essentially just a rename.
+- 527e8ab: Objects that are $as are now linked directly to changes from source object
+- a519655: Fixed issue accessing $rid when requested on an object.
+- 5378312: Added batch action support for 2.0 client
+- b3563e0: OSDK learns \_\_EXPERIMENTAL_strictNonNull to throw, drop objects, or return `| undefined` for properties, allowing for correct typesafety.
+- dd6033a: Adds a createPlatformClient if you only need platform apis
+- 4dbac7e: Fixes link direction for experiental bulk loads
+- 413e511: Added attachment uploading, reading, and metadata fetching support to 2.0.
+- 44add10: Standardize the use of dollar signs as prefixes for object properties that are specific to the OSDK.
+
+### Patch Changes
+
+- Updated dependencies [a6119bd]
+- Updated dependencies [413e511]
+  - @osdk/client.api@0.20.0-beta.0
+
 ## 0.19.0
 
 ### Minor Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client",
-  "version": "0.19.0",
+  "version": "0.20.0-beta.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -45,7 +45,7 @@ export interface Client extends SharedClient<MinimalClient> {
 }
 
 // BEGIN: THIS IS GENERATED CODE. DO NOT EDIT.
-const MaxOsdkVersion = "0.19.0";
+const MaxOsdkVersion = "0.20.0";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 export type MaxOsdkVersion = typeof MaxOsdkVersion;
 const ErrorMessage = Symbol("ErrorMessage");

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/create-app
 
+## 0.17.0-beta.0
+
+### Minor Changes
+
+- e660cbd: Fix runtime warnings on AipNow template
+- 78c24a1: update the mock objects to the new TypeScript 1.1.1 syntax version
+- af8675a: Fix login page not redirecting when oauth redirect not required
+- 4ee6e25: Update global layout styles
+- 2f5cfac: Remove platform specific commands in template scripts
+- 8da6d12: React/Vue router respects vite base path
+
 ## 0.16.0
 
 ### Minor Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-app",
-  "version": "0.16.0",
+  "version": "0.17.0-beta.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/example-generator/CHANGELOG.md
+++ b/packages/example-generator/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @osdk/example-generator
 
+## 0.6.0-beta.0
+
+### Minor Changes
+
+- 2f5cfac: Remove platform specific commands in template scripts
+
+### Patch Changes
+
+- Updated dependencies [e660cbd]
+- Updated dependencies [78c24a1]
+- Updated dependencies [af8675a]
+- Updated dependencies [4ee6e25]
+- Updated dependencies [2f5cfac]
+- Updated dependencies [8da6d12]
+  - @osdk/create-app@0.17.0-beta.0
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/example-generator/package.json
+++ b/packages/example-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/example-generator",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/foundry-sdk-generator
 
+## 1.2.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [c1924df]
+- Updated dependencies [5378312]
+- Updated dependencies [0ecd42b]
+  - @osdk/legacy-client@2.4.0-beta.0
+  - @osdk/generator@1.12.0-beta.0
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "1.1.1",
+  "version": "1.2.0-beta.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/foundry.core/CHANGELOG.md
+++ b/packages/foundry.core/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/foundry.core
 
+## 1.1.0-beta.0
+
+### Minor Changes
+
+- af1d316: Added support to omni api code gen for binary type bodies in requests.
+
+### Patch Changes
+
+- Updated dependencies [94833a7]
+  - @osdk/shared.net.platformapi@0.2.0-beta.0
+
 ## 1.0.0
 
 ### Patch Changes

--- a/packages/foundry.core/package.json
+++ b/packages/foundry.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.core",
-  "version": "1.0.0",
+  "version": "1.1.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.security/CHANGELOG.md
+++ b/packages/foundry.security/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/foundry.security
 
+## 1.1.0-beta.0
+
+### Minor Changes
+
+- af1d316: Added support to omni api code gen for binary type bodies in requests.
+
+### Patch Changes
+
+- Updated dependencies [af1d316]
+- Updated dependencies [94833a7]
+  - @osdk/foundry.core@1.1.0-beta.0
+  - @osdk/shared.net.platformapi@0.2.0-beta.0
+
 ## 1.0.0
 
 ### Minor Changes

--- a/packages/foundry.security/package.json
+++ b/packages/foundry.security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.security",
-  "version": "1.0.0",
+  "version": "1.1.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.thirdpartyapplications/CHANGELOG.md
+++ b/packages/foundry.thirdpartyapplications/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/foundry.thirdpartyapplications
 
+## 1.1.0-beta.0
+
+### Minor Changes
+
+- af1d316: Added support to omni api code gen for binary type bodies in requests.
+
+### Patch Changes
+
+- Updated dependencies [af1d316]
+- Updated dependencies [94833a7]
+  - @osdk/foundry.core@1.1.0-beta.0
+  - @osdk/shared.net.platformapi@0.2.0-beta.0
+
 ## 1.0.0
 
 ### Patch Changes

--- a/packages/foundry.thirdpartyapplications/package.json
+++ b/packages/foundry.thirdpartyapplications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.thirdpartyapplications",
-  "version": "1.0.0",
+  "version": "1.1.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry/CHANGELOG.md
+++ b/packages/foundry/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @osdk/foundry
 
+## 1.1.0-beta.0
+
+### Minor Changes
+
+- af1d316: Added support to omni api code gen for binary type bodies in requests.
+
+### Patch Changes
+
+- Updated dependencies [af1d316]
+- Updated dependencies [94833a7]
+  - @osdk/foundry.thirdpartyapplications@1.1.0-beta.0
+  - @osdk/foundry.security@1.1.0-beta.0
+  - @osdk/foundry.core@1.1.0-beta.0
+  - @osdk/shared.net.platformapi@0.2.0-beta.0
+
 ## 1.0.0
 
 ### Minor Changes

--- a/packages/foundry/package.json
+++ b/packages/foundry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry",
-  "version": "1.0.0",
+  "version": "1.1.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/generator
 
+## 1.12.0-beta.0
+
+### Minor Changes
+
+- 5378312: Added batch action support for 2.0 client
+- 0ecd42b: Generates 2.0's Ontology.ts in a typescript 5.5.0-beta safe way
+
 ## 1.11.0
 
 ### Minor Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "1.11.0",
+  "version": "1.12.0-beta.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator/src/v2.0/generateMetadata.ts
+++ b/packages/generator/src/v2.0/generateMetadata.ts
@@ -20,7 +20,7 @@ import { formatTs } from "../util/test/formatTs.js";
 import type { WireOntologyDefinition } from "../WireOntologyDefinition.js";
 
 // BEGIN: THIS IS GENERATED CODE. DO NOT EDIT.
-const ExpectedOsdkVersion = "0.19.0";
+const ExpectedOsdkVersion = "0.20.0";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 
 export async function generateOntologyMetadataFile(

--- a/packages/internal.foundry.core/CHANGELOG.md
+++ b/packages/internal.foundry.core/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @osdk/internal.foundry.core
+
+## 0.1.0-beta.0
+
+### Minor Changes
+
+- af1d316: Added support to omni api code gen for binary type bodies in requests.
+
+### Patch Changes
+
+- Updated dependencies [94833a7]
+  - @osdk/shared.net.platformapi@0.2.0-beta.0

--- a/packages/internal.foundry.core/package.json
+++ b/packages/internal.foundry.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.core",
-  "version": "0.0.0",
+  "version": "0.1.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.datasets/CHANGELOG.md
+++ b/packages/internal.foundry.datasets/CHANGELOG.md
@@ -1,0 +1,14 @@
+# @osdk/internal.foundry.datasets
+
+## 0.1.0-beta.0
+
+### Minor Changes
+
+- af1d316: Added support to omni api code gen for binary type bodies in requests.
+
+### Patch Changes
+
+- Updated dependencies [af1d316]
+- Updated dependencies [94833a7]
+  - @osdk/internal.foundry.core@0.1.0-beta.0
+  - @osdk/shared.net.platformapi@0.2.0-beta.0

--- a/packages/internal.foundry.datasets/package.json
+++ b/packages/internal.foundry.datasets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.datasets",
-  "version": "0.0.0",
+  "version": "0.1.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.models/CHANGELOG.md
+++ b/packages/internal.foundry.models/CHANGELOG.md
@@ -1,0 +1,14 @@
+# @osdk/internal.foundry.models
+
+## 0.1.0-beta.0
+
+### Minor Changes
+
+- af1d316: Added support to omni api code gen for binary type bodies in requests.
+
+### Patch Changes
+
+- Updated dependencies [af1d316]
+- Updated dependencies [94833a7]
+  - @osdk/internal.foundry.core@0.1.0-beta.0
+  - @osdk/shared.net.platformapi@0.2.0-beta.0

--- a/packages/internal.foundry.models/package.json
+++ b/packages/internal.foundry.models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.models",
-  "version": "0.0.0",
+  "version": "0.1.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.ontologies/CHANGELOG.md
+++ b/packages/internal.foundry.ontologies/CHANGELOG.md
@@ -1,0 +1,14 @@
+# @osdk/internal.foundry.ontologies
+
+## 0.1.0-beta.0
+
+### Minor Changes
+
+- af1d316: Added support to omni api code gen for binary type bodies in requests.
+
+### Patch Changes
+
+- Updated dependencies [af1d316]
+- Updated dependencies [94833a7]
+  - @osdk/internal.foundry.core@0.1.0-beta.0
+  - @osdk/shared.net.platformapi@0.2.0-beta.0

--- a/packages/internal.foundry.ontologies/package.json
+++ b/packages/internal.foundry.ontologies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.ontologies",
-  "version": "0.0.0",
+  "version": "0.1.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.ontologiesv2/CHANGELOG.md
+++ b/packages/internal.foundry.ontologiesv2/CHANGELOG.md
@@ -1,0 +1,15 @@
+# @osdk/internal.foundry.ontologiesv2
+
+## 0.1.0-beta.0
+
+### Minor Changes
+
+- af1d316: Added support to omni api code gen for binary type bodies in requests.
+
+### Patch Changes
+
+- Updated dependencies [af1d316]
+- Updated dependencies [94833a7]
+  - @osdk/internal.foundry.ontologies@0.1.0-beta.0
+  - @osdk/internal.foundry.core@0.1.0-beta.0
+  - @osdk/shared.net.platformapi@0.2.0-beta.0

--- a/packages/internal.foundry.ontologiesv2/package.json
+++ b/packages/internal.foundry.ontologiesv2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.ontologiesv2",
-  "version": "0.0.0",
+  "version": "0.1.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry/CHANGELOG.md
+++ b/packages/internal.foundry/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @osdk/foundry
 
+## 0.4.0-beta.0
+
+### Minor Changes
+
+- af1d316: Added support to omni api code gen for binary type bodies in requests.
+
+### Patch Changes
+
+- Updated dependencies [af1d316]
+- Updated dependencies [94833a7]
+  - @osdk/internal.foundry.ontologiesv2@0.1.0-beta.0
+  - @osdk/internal.foundry.ontologies@0.1.0-beta.0
+  - @osdk/internal.foundry.datasets@0.1.0-beta.0
+  - @osdk/internal.foundry.models@0.1.0-beta.0
+  - @osdk/internal.foundry.core@0.1.0-beta.0
+  - @osdk/shared.net.platformapi@0.2.0-beta.0
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/internal.foundry/package.json
+++ b/packages/internal.foundry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/internal.foundry",
   "private": "true",
-  "version": "0.3.0",
+  "version": "0.4.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/legacy-client/CHANGELOG.md
+++ b/packages/legacy-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/legacy-client
 
+## 2.4.0-beta.0
+
+### Minor Changes
+
+- c1924df: Do not restart auth flow on failed auth callback
+
 ## 2.3.0
 
 ### Minor Changes

--- a/packages/legacy-client/package.json
+++ b/packages/legacy-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/legacy-client",
-  "version": "2.3.0",
+  "version": "2.4.0-beta.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/platform-sdk-generator/CHANGELOG.md
+++ b/packages/platform-sdk-generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/platform-sdk-generator
 
+## 0.4.0-beta.0
+
+### Minor Changes
+
+- af1d316: Added support to omni api code gen for binary type bodies in requests.
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/platform-sdk-generator/package.json
+++ b/packages/platform-sdk-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/platform-sdk-generator",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.net.platformapi/CHANGELOG.md
+++ b/packages/shared.net.platformapi/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @osdk/shared.net.platformapi
+
+## 0.2.0-beta.0
+
+### Minor Changes
+
+- 94833a7: URL encode path portions for foundry platform sdk

--- a/packages/shared.net.platformapi/package.json
+++ b/packages/shared.net.platformapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/shared.net.platformapi",
-  "version": "0.1.0",
+  "version": "0.2.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.test/CHANGELOG.md
+++ b/packages/shared.test/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/shared.test
 
+## 1.5.0-beta.0
+
+### Minor Changes
+
+- 413e511: Added attachment uploading, reading, and metadata fetching support to 2.0.
+
 ## 1.4.0
 
 ### Minor Changes

--- a/packages/shared.test/package.json
+++ b/packages/shared.test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/shared.test",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.5.0-beta.0",
   "description": "",
   "access": "private",
   "license": "Apache-2.0",

--- a/packages/tool.release/CHANGELOG.md
+++ b/packages/tool.release/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/tool.release
 
+## 0.3.0-beta.0
+
+### Minor Changes
+
+- e3f900e: Log GitHub token being found in createReleasePr, addressing #266
+
+  Also replace "github cli" with "GitHub CLI" in the log messages.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/tool.release/package.json
+++ b/packages/tool.release/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/tool.release",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/client@0.20.0-beta.0

### Minor Changes

-   564adbf: Fixing attachment creation when converting objects from the wire
-   505b993: Experimental subscription no longer fires outOfDate when first subscribing
-   a6119bd: Attachments reworked so that you can now fetch directly from object properties. Also added a helper to create an attachment object directly from a rid.
-   f6d8850: Removed get, which is now replaced by fetchOne(). This has the exact same functionality and is essentially just a rename.
-   527e8ab: Objects that are $as are now linked directly to changes from source object
-   a519655: Fixed issue accessing $rid when requested on an object.
-   5378312: Added batch action support for 2.0 client
-   b3563e0: OSDK learns \_\_EXPERIMENTAL_strictNonNull to throw, drop objects, or return `| undefined` for properties, allowing for correct typesafety.
-   dd6033a: Adds a createPlatformClient if you only need platform apis
-   4dbac7e: Fixes link direction for experiental bulk loads
-   413e511: Added attachment uploading, reading, and metadata fetching support to 2.0.
-   44add10: Standardize the use of dollar signs as prefixes for object properties that are specific to the OSDK.

### Patch Changes

-   Updated dependencies [a6119bd]
-   Updated dependencies [413e511]
    -   @osdk/client.api@0.20.0-beta.0

## @osdk/client.api@0.20.0-beta.0

### Minor Changes

-   a6119bd: Attachments reworked so that you can now fetch directly from object properties. Also added a helper to create an attachment object directly from a rid.
-   413e511: Added attachment uploading, reading, and metadata fetching support to 2.0.

## @osdk/create-app@0.17.0-beta.0

### Minor Changes

-   e660cbd: Fix runtime warnings on AipNow template
-   78c24a1: update the mock objects to the new TypeScript 1.1.1 syntax version
-   af8675a: Fix login page not redirecting when oauth redirect not required
-   4ee6e25: Update global layout styles
-   2f5cfac: Remove platform specific commands in template scripts
-   8da6d12: React/Vue router respects vite base path

## @osdk/foundry@1.1.0-beta.0

### Minor Changes

-   af1d316: Added support to omni api code gen for binary type bodies in requests.

### Patch Changes

-   Updated dependencies [af1d316]
-   Updated dependencies [94833a7]
    -   @osdk/foundry.thirdpartyapplications@1.1.0-beta.0
    -   @osdk/foundry.security@1.1.0-beta.0
    -   @osdk/foundry.core@1.1.0-beta.0
    -   @osdk/shared.net.platformapi@0.2.0-beta.0

## @osdk/foundry.core@1.1.0-beta.0

### Minor Changes

-   af1d316: Added support to omni api code gen for binary type bodies in requests.

### Patch Changes

-   Updated dependencies [94833a7]
    -   @osdk/shared.net.platformapi@0.2.0-beta.0

## @osdk/foundry.security@1.1.0-beta.0

### Minor Changes

-   af1d316: Added support to omni api code gen for binary type bodies in requests.

### Patch Changes

-   Updated dependencies [af1d316]
-   Updated dependencies [94833a7]
    -   @osdk/foundry.core@1.1.0-beta.0
    -   @osdk/shared.net.platformapi@0.2.0-beta.0

## @osdk/foundry.thirdpartyapplications@1.1.0-beta.0

### Minor Changes

-   af1d316: Added support to omni api code gen for binary type bodies in requests.

### Patch Changes

-   Updated dependencies [af1d316]
-   Updated dependencies [94833a7]
    -   @osdk/foundry.core@1.1.0-beta.0
    -   @osdk/shared.net.platformapi@0.2.0-beta.0

## @osdk/generator@1.12.0-beta.0

### Minor Changes

-   5378312: Added batch action support for 2.0 client
-   0ecd42b: Generates 2.0's Ontology.ts in a typescript 5.5.0-beta safe way

## @osdk/internal.foundry.core@0.1.0-beta.0

### Minor Changes

-   af1d316: Added support to omni api code gen for binary type bodies in requests.

### Patch Changes

-   Updated dependencies [94833a7]
    -   @osdk/shared.net.platformapi@0.2.0-beta.0

## @osdk/internal.foundry.datasets@0.1.0-beta.0

### Minor Changes

-   af1d316: Added support to omni api code gen for binary type bodies in requests.

### Patch Changes

-   Updated dependencies [af1d316]
-   Updated dependencies [94833a7]
    -   @osdk/internal.foundry.core@0.1.0-beta.0
    -   @osdk/shared.net.platformapi@0.2.0-beta.0

## @osdk/internal.foundry.models@0.1.0-beta.0

### Minor Changes

-   af1d316: Added support to omni api code gen for binary type bodies in requests.

### Patch Changes

-   Updated dependencies [af1d316]
-   Updated dependencies [94833a7]
    -   @osdk/internal.foundry.core@0.1.0-beta.0
    -   @osdk/shared.net.platformapi@0.2.0-beta.0

## @osdk/internal.foundry.ontologies@0.1.0-beta.0

### Minor Changes

-   af1d316: Added support to omni api code gen for binary type bodies in requests.

### Patch Changes

-   Updated dependencies [af1d316]
-   Updated dependencies [94833a7]
    -   @osdk/internal.foundry.core@0.1.0-beta.0
    -   @osdk/shared.net.platformapi@0.2.0-beta.0

## @osdk/internal.foundry.ontologiesv2@0.1.0-beta.0

### Minor Changes

-   af1d316: Added support to omni api code gen for binary type bodies in requests.

### Patch Changes

-   Updated dependencies [af1d316]
-   Updated dependencies [94833a7]
    -   @osdk/internal.foundry.ontologies@0.1.0-beta.0
    -   @osdk/internal.foundry.core@0.1.0-beta.0
    -   @osdk/shared.net.platformapi@0.2.0-beta.0

## @osdk/legacy-client@2.4.0-beta.0

### Minor Changes

-   c1924df: Do not restart auth flow on failed auth callback

## @osdk/shared.net.platformapi@0.2.0-beta.0

### Minor Changes

-   94833a7: URL encode path portions for foundry platform sdk

## @osdk/cli@0.22.0-beta.0

### Patch Changes

-   Updated dependencies [5378312]
-   Updated dependencies [0ecd42b]
    -   @osdk/generator@1.12.0-beta.0

## @osdk/foundry-sdk-generator@1.2.0-beta.0

### Patch Changes

-   Updated dependencies [c1924df]
-   Updated dependencies [5378312]
-   Updated dependencies [0ecd42b]
    -   @osdk/legacy-client@2.4.0-beta.0
    -   @osdk/generator@1.12.0-beta.0

## @osdk/example-generator@0.6.0-beta.0

### Minor Changes

-   2f5cfac: Remove platform specific commands in template scripts

### Patch Changes

-   Updated dependencies [e660cbd]
-   Updated dependencies [78c24a1]
-   Updated dependencies [af8675a]
-   Updated dependencies [4ee6e25]
-   Updated dependencies [2f5cfac]
-   Updated dependencies [8da6d12]
    -   @osdk/create-app@0.17.0-beta.0

## @osdk/internal.foundry@0.4.0-beta.0

### Minor Changes

-   af1d316: Added support to omni api code gen for binary type bodies in requests.

### Patch Changes

-   Updated dependencies [af1d316]
-   Updated dependencies [94833a7]
    -   @osdk/internal.foundry.ontologiesv2@0.1.0-beta.0
    -   @osdk/internal.foundry.ontologies@0.1.0-beta.0
    -   @osdk/internal.foundry.datasets@0.1.0-beta.0
    -   @osdk/internal.foundry.models@0.1.0-beta.0
    -   @osdk/internal.foundry.core@0.1.0-beta.0
    -   @osdk/shared.net.platformapi@0.2.0-beta.0

## @osdk/platform-sdk-generator@0.4.0-beta.0

### Minor Changes

-   af1d316: Added support to omni api code gen for binary type bodies in requests.

## @osdk/shared.test@1.5.0-beta.0

### Minor Changes

-   413e511: Added attachment uploading, reading, and metadata fetching support to 2.0.

## @osdk/tool.release@0.3.0-beta.0

### Minor Changes

-   e3f900e: Log GitHub token being found in createReleasePr, addressing #266

    Also replace "github cli" with "GitHub CLI" in the log messages.

## @osdk/cli.cmd.typescript@0.4.0-beta.0

### Patch Changes

-   Updated dependencies [5378312]
-   Updated dependencies [0ecd42b]
    -   @osdk/generator@1.12.0-beta.0

## @osdk/client.test.ontology@0.1.0-beta.0

### Patch Changes

-   Updated dependencies [a6119bd]
-   Updated dependencies [413e511]
    -   @osdk/client.api@0.20.0-beta.0
