### PR TITLE
Version Packages

### DIFF
--- a/.changeset/great-geese-fail.md
+++ b/.changeset/great-geese-fail.md
@@ -1,5 +1,0 @@
----
-"@osdk/legacy-client": patch
----
-
-Do not restart auth flow on failed auth callback

--- a/.changeset/pretty-cherries-hunt.md
+++ b/.changeset/pretty-cherries-hunt.md
@@ -1,5 +1,0 @@
----
-"@osdk/create-app": patch
----
-
-Fix login page not redirecting when oauth redirect not required

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/create-app
 
+## 0.16.3
+
+### Patch Changes
+
+- 68c0b42: Fix login page not redirecting when oauth redirect not required
+
 ## 0.16.2
 
 ### Patch Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-app",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/example-generator/CHANGELOG.md
+++ b/packages/example-generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/example-generator
 
+## 0.5.3
+
+### Patch Changes
+
+- Updated dependencies [68c0b42]
+  - @osdk/create-app@0.16.3
+
 ## 0.5.2
 
 ### Patch Changes

--- a/packages/example-generator/package.json
+++ b/packages/example-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/example-generator",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.5.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/foundry-sdk-generator
 
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [68c0b42]
+  - @osdk/legacy-client@2.3.1
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/legacy-client/CHANGELOG.md
+++ b/packages/legacy-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/legacy-client
 
+## 2.3.1
+
+### Patch Changes
+
+- 68c0b42: Do not restart auth flow on failed auth callback
+
 ## 2.3.0
 
 ### Minor Changes

--- a/packages/legacy-client/package.json
+++ b/packages/legacy-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/legacy-client",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/cli, this PR will be updated.


# Releases
## @osdk/create-app@0.16.3

### Patch Changes

-   68c0b42: Fix login page not redirecting when oauth redirect not required

## @osdk/foundry-sdk-generator@1.1.2

### Patch Changes

-   Updated dependencies [68c0b42]
    -   @osdk/legacy-client@2.3.1

## @osdk/legacy-client@2.3.1

### Patch Changes

-   68c0b42: Do not restart auth flow on failed auth callback

## @osdk/example-generator@0.5.3

### Patch Changes

-   Updated dependencies [68c0b42]
    -   @osdk/create-app@0.16.3
