### PR TITLE
Fix client exports

### DIFF
--- a/.changeset/chilly-melons-hammer.md
+++ b/.changeset/chilly-melons-hammer.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": minor
+---
+
+Fix exports from client

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -20,8 +20,13 @@ export type {
   ActionValidationResponse,
   ApplyActionOptions,
   ApplyBatchActionOptions,
+  InterfaceObjectSet,
   NOOP,
+  ObjectSet,
+  Osdk,
   OsdkActionParameters,
+  OsdkObject,
+  PageResult,
   WhereClause,
 } from "@osdk/client.api";
 export { PalantirApiError } from "@osdk/shared.net.errors";


### PR DESCRIPTION
When we refactored client.api, we accidentally stopped exporting certain entities from client, which broke internal usecases. Fixing with this