### PR TITLE
Allow passing a Promise<string> for ontologyRid

### DIFF
--- a/.changeset/old-kiwis-marry.md
+++ b/.changeset/old-kiwis-marry.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+It is possible to pass a Promise<string> for ontologyRid on client creation

--- a/packages/client/src/MinimalClientContext.ts
+++ b/packages/client/src/MinimalClientContext.ts
@@ -20,7 +20,7 @@ import type { ObjectSetFactory } from "./objectSet/ObjectSetFactory.js";
 import type { OntologyProvider } from "./ontology/OntologyProvider.js";
 
 export interface MinimalClient extends SharedClientContext {
-  ontologyRid: string;
+  ontologyRid: string | Promise<string>;
   ontologyProvider: OntologyProvider;
   logger?: Logger;
   objectSetFactory: ObjectSetFactory<any, any>;
@@ -32,5 +32,5 @@ export type MinimalClientParams = {
 };
 
 export interface MinimalClientMetadata {
-  ontologyRid: string;
+  ontologyRid: string | Promise<string>;
 }

--- a/packages/client/src/__unstable/ConjureSupport.ts
+++ b/packages/client/src/__unstable/ConjureSupport.ts
@@ -213,8 +213,8 @@ export class MetadataClient {
     return entities.objectTypes[objectTypeRid];
   });
 
-  ontologyVersion = strongMemoAsync((_: string) =>
-    getOntologyVersionForRid(this.#ctx, this.#client.ontologyRid)
+  ontologyVersion = strongMemoAsync(async (_: string) =>
+    getOntologyVersionForRid(this.#ctx, await this.#client.ontologyRid)
   );
 }
 

--- a/packages/client/src/actions/applyAction.ts
+++ b/packages/client/src/actions/applyAction.ts
@@ -48,7 +48,7 @@ export async function applyAction<
   if (Array.isArray(parameters)) {
     const response = await OntologiesV2.Actions.applyActionBatchV2(
       addUserAgent(client, action),
-      client.ontologyRid,
+      await client.ontologyRid,
       action.apiName,
       {
         requests: parameters
@@ -66,7 +66,7 @@ export async function applyAction<
   } else {
     const response = await OntologiesV2.Actions.applyActionV2(
       addUserAgent(client, action),
-      client.ontologyRid,
+      await client.ontologyRid,
       action.apiName,
       {
         parameters: await remapActionParams(

--- a/packages/client/src/createClient.ts
+++ b/packages/client/src/createClient.ts
@@ -54,7 +54,7 @@ class ActionInvoker<Q extends ActionDefinition<any, any, any>>
 export function createClientInternal(
   objectSetFactory: ObjectSetFactory<any, any>, // first so i can bind
   baseUrl: string,
-  ontologyRid: string,
+  ontologyRid: string | Promise<string>,
   tokenProvider: () => Promise<string>,
   options: { logger?: Logger } | undefined = undefined,
   fetchFn: typeof globalThis.fetch = fetch,

--- a/packages/client/src/object/aggregate.ts
+++ b/packages/client/src/object/aggregate.ts
@@ -80,7 +80,7 @@ export async function aggregate<
   }
   const result = await OntologiesV2.OntologyObjectSets.aggregateObjectSetV2(
     addUserAgent(clientCtx, objectType),
-    clientCtx.ontologyRid,
+    await clientCtx.ontologyRid,
     {
       objectSet,
       groupBy: body.groupBy,

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -96,7 +96,7 @@ async function fetchInterfacePage<
 ): Promise<FetchPageResult<Q, L, R, S>> {
   const result = await OntologiesV2.OntologyObjectsV2.searchObjectsForInterface(
     addUserAgent(client, interfaceType),
-    client.ontologyRid,
+    await client.ontologyRid,
     interfaceType.apiName,
     applyFetchArgs<SearchObjectsForInterfaceRequest>(args, {
       augmentedProperties: args.$augment ?? {},
@@ -238,7 +238,7 @@ export async function fetchObjectPage<
 ): Promise<FetchPageResult<Q, L, R, S>> {
   const r = await OntologiesV2.OntologyObjectSets.loadObjectSetV2(
     addUserAgent(client, objectType),
-    client.ontologyRid,
+    await client.ontologyRid,
     applyFetchArgs<LoadObjectSetRequestV2>(args, {
       objectSet,
       // We have to do the following case because LoadObjectSetRequestV2 isnt readonly

--- a/packages/client/src/objectSet/ObjectSetListenerWebsocket.ts
+++ b/packages/client/src/objectSet/ObjectSetListenerWebsocket.ts
@@ -231,6 +231,8 @@ export class ObjectSetListenerWebsocket {
     // in `#createTemporaryObjectSet`. They should be in sync
     sub.expiry = setTimeout(() => this.#expire(sub), this.OBJECT_SET_EXPIRY_MS);
 
+    const ontologyRid = await this.#client.ontologyRid;
+
     try {
       const [temporaryObjectSet] = await Promise.all([
         // create a time-bounded object set representation for watching
@@ -243,7 +245,7 @@ export class ObjectSetListenerWebsocket {
         getObjectSetBaseType(sub.objectSet).then(baseType =>
           OntologiesV2.ObjectTypesV2.getObjectTypeV2(
             this.#client,
-            this.#client.ontologyRid,
+            ontologyRid,
             baseType,
           )
         ).then(
@@ -700,16 +702,18 @@ async function getOntologyPropertyMappingForApiName(
     );
   }
 
+  const ontologyRid = await client.ontologyRid;
+
   const wireObjectType = await OntologiesV2.ObjectTypesV2
     .getObjectTypeV2(
       client,
-      client.ontologyRid,
+      ontologyRid,
       objectApiName,
     );
 
   return getOntologyPropertyMappingForRid(
     ctx,
-    client.ontologyRid,
+    ontologyRid,
     wireObjectType.rid,
   );
 }

--- a/packages/client/src/ontology/loadFullObjectMetadata.ts
+++ b/packages/client/src/ontology/loadFullObjectMetadata.ts
@@ -25,7 +25,7 @@ export async function loadFullObjectMetadata(
 ): Promise<ObjectTypeDefinition<any, any> & { rid: string }> {
   const full = await OntologiesV2.OntologyObjectsV2.getObjectTypeFullMetadata(
     client,
-    client.ontologyRid,
+    await client.ontologyRid,
     objtype,
     { preview: true },
   );

--- a/packages/client/src/ontology/loadInterfaceDefinition.ts
+++ b/packages/client/src/ontology/loadInterfaceDefinition.ts
@@ -25,7 +25,7 @@ export async function loadInterfaceDefinition(
 ): Promise<InterfaceDefinition<any, any>> {
   const r = await OntologiesV2.OntologyObjectsV2.getInterfaceType(
     client,
-    client.ontologyRid,
+    await client.ontologyRid,
     objtype,
     { preview: true },
   );


### PR DESCRIPTION
Enables having a globally defined static client even if you need to asynchronously load the ontologyRid.

Technically, there is a cost to doing the extra awaits but the network call will take at least 1-2 orders of magnitude longer so its not the end of the world.

This is accepting a `Promise<string>` instead of `() => Promise<string>` because the caching for the client assumes the ontology will not change and a promise can only be resolved once. By contrast, we allow a `() => Promise<string>` for the security token because workflows that involve refreshing the token should not affect the cache.