### PR TITLE
Fix action params issue with objects

### DIFF
--- a/.changeset/new-points-sing.md
+++ b/.changeset/new-points-sing.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Fix action params that take objects to correctly parse out primary key.

--- a/packages/client/src/util/isOsdkObject.ts
+++ b/packages/client/src/util/isOsdkObject.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { OsdkBase } from "@osdk/client.api";
+
+export function isOsdkBaseObject(o: any): o is OsdkBase<any> {
+  return o && typeof o === "object" && typeof o.$apiName === "string"
+    && o.$primaryKey != null;
+}

--- a/packages/client/src/util/toDataValue.test.ts
+++ b/packages/client/src/util/toDataValue.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Ontology } from "@osdk/client.test.ontology";
 import { apiServer, MockOntology, stubData } from "@osdk/shared.test";
 import type { MockedFunction } from "vitest";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
@@ -35,7 +36,7 @@ describe(toDataValue, () => {
     apiServer.listen();
     client = createClient(
       "https://stack.palantir.com",
-      MockOntology.metadata.ontologyRid,
+      Ontology.metadata.ontologyRid,
       async () => "myAccessToken",
     );
 
@@ -102,6 +103,14 @@ describe(toDataValue, () => {
     const ontologyConversion = await toDataValue(employee, clientCtx);
     expect(ontologyConversion).toEqual(
       stubData.employee1.__primaryKey,
+    );
+  });
+
+  it("maps an ontology object into just its primary key with osdk wrapper", async () => {
+    const task = await client(Ontology.objects.Employee).fetchOne(50030);
+    const ontologyConversion = await toDataValue(task, clientCtx);
+    expect(ontologyConversion).toEqual(
+      task.$primaryKey,
     );
   });
 

--- a/packages/client/src/util/toDataValue.ts
+++ b/packages/client/src/util/toDataValue.ts
@@ -19,6 +19,7 @@ import type { MinimalClient } from "../MinimalClientContext.js";
 import { isAttachmentUpload } from "../object/AttachmentUpload.js";
 import { getWireObjectSet, isObjectSet } from "../objectSet/createObjectSet.js";
 import { isOntologyObjectV2 } from "./isOntologyObjectV2.js";
+import { isOsdkBaseObject } from "./isOsdkObject.js";
 import { isWireObjectSet } from "./WireObjectSet.js";
 
 /**
@@ -63,6 +64,10 @@ export async function toDataValue(
   // objects just send the JSON'd primaryKey
   if (isOntologyObjectV2(value)) {
     return await toDataValue(value.__primaryKey, client);
+  }
+
+  if (isOsdkBaseObject(value)) {
+    return await toDataValue(value.$primaryKey, client);
   }
 
   // object set (the rid as a string (passes through the last return), or the ObjectSet definition directly)


### PR DESCRIPTION
When you pass in an Osdk<> object to an action param, we don't correctly parse out the primary key since we used to look for the `__primaryKey` field, but we should be looking for `$primaryKey`