### PR TITLE
Add more logging to legacy-client oauth

### DIFF
--- a/.changeset/odd-hornets-protect.md
+++ b/.changeset/odd-hornets-protect.md
@@ -1,0 +1,5 @@
+---
+"@osdk/legacy-client": patch
+---
+
+Oauth errors should include a cause now on supported platforms

--- a/packages/legacy-client/src/client/addCause.ts
+++ b/packages/legacy-client/src/client/addCause.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function addCause(e: Error, cause: any) {
+  if (process.env.NODE_ENV !== "production") {
+    // In case someone is debugging on an older browser or the `.cause` assignment trick
+    // does not work in certain environments, we log the cause to the console to aid debugging.
+    // eslint-disable-next-line no-console
+    console.error("Preparing to throw error due to", cause);
+  }
+
+  (e as any).cause = cause;
+  return e;
+}

--- a/packages/legacy-client/src/oauth-client/ConfidentialClient/ConfidentialClientFlow.ts
+++ b/packages/legacy-client/src/oauth-client/ConfidentialClient/ConfidentialClientFlow.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { addCause } from "../../client/addCause.js";
 import { OAuthToken } from "../OAuthToken.js";
 import { fetchFormEncoded, getRevokeUri, getTokenUri } from "../utils/index.js";
 
@@ -43,8 +44,11 @@ export async function getTokenWithClientSecret(
     const responseText = await response.json();
     return new OAuthToken(responseText);
   } catch (e) {
-    throw new Error(
-      `Failed to get token: ${e ? e.toString() : "Unknown error"}`,
+    throw addCause(
+      new Error(
+        `Failed to get token: ${e ? e.toString() : "Unknown error"}`,
+      ),
+      e,
     );
   }
 }
@@ -66,8 +70,11 @@ export async function revokeTokenWithClientSecret(
   try {
     await fetchFormEncoded(fetchFn, tokenUrl, body);
   } catch (e) {
-    throw new Error(
-      `Failed to revoke token: ${e ? e.toString() : "Unknown error"}`,
+    throw addCause(
+      new Error(
+        `Failed to revoke token: ${e ? e.toString() : "Unknown error"}`,
+      ),
+      e,
     );
   }
 }

--- a/packages/legacy-client/src/oauth-client/PublicClient/PublicClientFlowProvider.ts
+++ b/packages/legacy-client/src/oauth-client/PublicClient/PublicClientFlowProvider.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { addCause } from "../../client/addCause.js";
 import { OAuthToken } from "../OAuthToken.js";
 import {
   fetchFormEncoded,
@@ -107,8 +108,11 @@ export async function getTokenWithCodeVerifier(
     const responseText = await response.json();
     return new OAuthToken(responseText);
   } catch (e) {
-    throw new Error(
-      `Failed to get token: ${e ? e.toString() : "Unknown error"}`,
+    throw addCause(
+      new Error(
+        `Failed to get token: ${e ? e.toString() : "Unknown error"}`,
+      ),
+      e,
     );
   }
 }
@@ -131,8 +135,11 @@ export async function refreshTokenPublicClient(
     const responseText = await response.json();
     return new OAuthToken(responseText);
   } catch (e) {
-    throw new Error(
-      `Failed to refresh token: ${e ? e.toString() : "Unknown error"}`,
+    throw addCause(
+      new Error(
+        `Failed to refresh token: ${e ? e.toString() : "Unknown error"}`,
+      ),
+      e,
     );
   }
 }
@@ -152,8 +159,11 @@ export async function revokeTokenPublicClient(
   try {
     await fetchFormEncoded(fetchFn, tokenUrl, body);
   } catch (e) {
-    throw new Error(
-      `Failed to revoke token: ${e ? e.toString() : "Unknown error"}`,
+    throw addCause(
+      new Error(
+        `Failed to revoke token: ${e ? e.toString() : "Unknown error"}`,
+      ),
+      e,
     );
   }
 }


### PR DESCRIPTION
Validated node 18 will do what we want with this test program:

```
const foo = new Error("whatever");
foo.cause = new Error("cause");
throw foo;
```