### PR TITLE
Version Packages

### DIFF
--- a/.changeset/odd-hornets-protect.md
+++ b/.changeset/odd-hornets-protect.md
@@ -1,5 +1,0 @@
----
-"@osdk/legacy-client": patch
----
-
-Oauth errors should include a cause now on supported platforms

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/foundry-sdk-generator
 
+## 1.1.4
+
+### Patch Changes
+
+- Updated dependencies [31dc247]
+  - @osdk/legacy-client@2.2.4
+
 ## 1.1.3
 
 ### Patch Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/legacy-client/CHANGELOG.md
+++ b/packages/legacy-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/legacy-client
 
+## 2.2.4
+
+### Patch Changes
+
+- 31dc247: Oauth errors should include a cause now on supported platforms
+
 ## 2.2.3
 
 ### Patch Changes

--- a/packages/legacy-client/package.json
+++ b/packages/legacy-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/legacy-client",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/1.1.x, this PR will be updated.


# Releases
## @osdk/foundry-sdk-generator@1.1.4

### Patch Changes

-   Updated dependencies [31dc247]
    -   @osdk/legacy-client@2.2.4

## @osdk/legacy-client@2.2.4

### Patch Changes

-   31dc247: Oauth errors should include a cause now on supported platforms
