### PR TITLE
Confidential client

### DIFF
--- a/.changeset/tame-rules-wash.md
+++ b/.changeset/tame-rules-wash.md
@@ -1,0 +1,5 @@
+---
+"@osdk/oauth": minor
+---
+
+Adds createConfidentialOauthClient

--- a/docs/vite.md
+++ b/docs/vite.md
@@ -1,0 +1,24 @@
+# Using OSDK with Vite
+
+## Fixing common problems
+
+### "ReferenceError: process is not defined"
+
+The OSDK related libraries leverage a long standing convention to use `process.env.NODE_ENV` to determine the level of verbosity for `console.log`/`console.warn`/`console.error` and to create optimized production code.
+
+Recent versions of Vite have begun pushing developers to use `import.meta.env` instead of `process.env` which is a noble change with good intentions but one that creates problems for library authors trying to support multiple bundling frameworks.
+
+Out of the box, Vite will not perform the required replacement to optimize the code which leads to `process` being undefined and a runtime error for you. This can be worked around by updating your Vite config to process the replacement:
+
+```ts
+// ...
+export default defineConfig(({ mode }) => {
+  // ...
+  return {
+    define: {
+      "process.env.NODE_ENV": JSON.stringify(mode)
+    },
+    // ...
+  }
+}
+```

--- a/etc/client.report.api.md
+++ b/etc/client.report.api.md
@@ -35,7 +35,7 @@ import type { QueryDefinition } from '@osdk/api';
 import type { QuerySignatureFromDef } from '@osdk/client.api';
 import { Result } from '@osdk/client.api';
 import type { SharedClient } from '@osdk/shared.client';
-import { SharedClientContext } from '@osdk/shared.client';
+import type { SharedClientContext } from '@osdk/shared.client';
 import type { VersionBound } from '@osdk/api';
 import { WhereClause } from '@osdk/client.api';
 
@@ -87,7 +87,7 @@ export const createClient: (baseUrl: string, ontologyRid: string | Promise<strin
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 //
 // @public
-export function createPlatformClient(baseUrl: string, tokenProvider: () => Promise<string>, options?: undefined, fetchFn?: typeof globalThis.fetch): SharedClientContext;
+export function createPlatformClient(baseUrl: string, tokenProvider: () => Promise<string>, options?: undefined, fetchFn?: typeof globalThis.fetch): PlatformClient;
 
 export { InterfaceObjectSet }
 
@@ -106,6 +106,10 @@ export { OsdkObject }
 export { PageResult }
 
 export { PalantirApiError }
+
+// @public (undocumented)
+export interface PlatformClient extends SharedClientContext {
+}
 
 export { Result }
 

--- a/packages/client/src/createPlatformClient.ts
+++ b/packages/client/src/createPlatformClient.ts
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
+import type { SharedClientContext } from "@osdk/shared.client";
 import { createSharedClientContext } from "@osdk/shared.client.impl";
 import { USER_AGENT } from "./util/UserAgent.js";
+
+export interface PlatformClient extends SharedClientContext {}
 
 /**
  * Creates a client that can only be used with Platform APIs.
@@ -34,7 +37,7 @@ export function createPlatformClient(
   tokenProvider: () => Promise<string>,
   options: undefined = undefined,
   fetchFn: typeof globalThis.fetch = fetch,
-) {
+): PlatformClient {
   return createSharedClientContext(
     baseUrl,
     tokenProvider,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -34,12 +34,11 @@ export type {
 export { isOk } from "@osdk/client.api";
 export { PalantirApiError } from "@osdk/shared.net.errors";
 
+export { ActionValidationError } from "./actions/ActionValidationError.js";
 export type { Client } from "./Client.js";
+export { createAttachmentFromRid } from "./createAttachmentFromRid.js";
 export { createClient } from "./createClient.js";
 export { createPlatformClient } from "./createPlatformClient.js";
-
-export { createAttachmentFromRid } from "./createAttachmentFromRid.js";
+export type { PlatformClient } from "./createPlatformClient.js";
 export { createAttachmentUpload } from "./object/AttachmentUpload.js";
-
-export { ActionValidationError } from "./actions/ActionValidationError.js";
 export type { ResultOrError } from "./ResultOrError.js";

--- a/packages/e2e.sandbox.oauth/bin/testConfidentialClientNode.mjs
+++ b/packages/e2e.sandbox.oauth/bin/testConfidentialClientNode.mjs
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { testConfidentialClientNode } from "../build/esm/index.js";
+
+testConfidentialClientNode();

--- a/packages/e2e.sandbox.oauth/package.json
+++ b/packages/e2e.sandbox.oauth/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "@osdk/oauth",
-  "version": "0.3.0-beta.0",
+  "name": "@osdk/e2e.sandbox.oauth",
+  "private": true,
+  "version": "0.0.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -8,34 +9,35 @@
   },
   "exports": {
     ".": {
+      "require": "./build/cjs/index.cjs",
       "browser": "./build/browser/index.js",
       "import": "./build/esm/index.js"
     },
     "./*": {
+      "require": "./build/cjs/public/*.cjs",
       "browser": "./build/browser/public/*.js",
       "import": "./build/esm/public/*.js"
     }
   },
   "scripts": {
-    "check-attw": "monorepo.tool.attw esm",
+    "check-attw": "monorepo.tool.attw both",
     "check-spelling": "cspell --quiet .",
     "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
     "fix-lint": "eslint . --fix && dprint fmt --config $(find-up dprint.json)",
     "lint": "eslint . && dprint check  --config $(find-up dprint.json)",
     "transpile": "monorepo.tool.transpile",
-    "typecheck": "monorepo.tool.typecheck esm"
+    "typecheck": "monorepo.tool.typecheck both"
   },
   "dependencies": {
-    "delay": "^6.0.0",
-    "oauth4webapi": "^2.10.3",
-    "tiny-invariant": "^1.3.1",
-    "typescript-event-target": "^1.1.1"
+    "@osdk/client": "workspace:~",
+    "@osdk/oauth": "workspace:~",
+    "consola": "^3.2.3",
+    "tiny-invariant": "^1.3.3"
   },
   "devDependencies": {
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
     "@osdk/monorepo.tsup": "workspace:~",
-    "jest-extended": "^4.0.2",
     "typescript": "^5.5.2"
   },
   "publishConfig": {
@@ -50,8 +52,8 @@
     "templates",
     "*.d.ts"
   ],
-  "main": "./build/js/index.cjs",
+  "main": "./build/cjs/index.cjs",
   "module": "./build/esm/index.js",
-  "types": "./build/esm/index.d.ts",
+  "types": "./build/cjs/index.d.cts",
   "type": "module"
 }

--- a/packages/e2e.sandbox.oauth/src/index.ts
+++ b/packages/e2e.sandbox.oauth/src/index.ts
@@ -14,11 +14,4 @@
  * limitations under the License.
  */
 
-import type { BaseOauthClient } from "./BaseOauthClient.js";
-import type { Token } from "./Token.js";
-
-export interface PublicOauthClient
-  extends BaseOauthClient<"signIn" | "signOut" | "refresh">
-{
-  refresh: () => Promise<Token | undefined>;
-}
+export { testConfidentialClientNode } from "./testConfidentialClientNode.js";

--- a/packages/e2e.sandbox.oauth/src/testConfidentialClientNode.ts
+++ b/packages/e2e.sandbox.oauth/src/testConfidentialClientNode.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createConfidentialOauthClient } from "@osdk/oauth";
+import consola from "consola";
+import invariant from "tiny-invariant";
+
+declare const process: {
+  env: Record<string, string | undefined>;
+};
+
+export async function testConfidentialClientNode() {
+  const prefix = "TS_OSDK_E2E_OAUTH_CONFIDENTIAL_";
+  const FOUNDRY_CLIENT_ID = process.env[`${prefix}FOUNDRY_CLIENT_ID`];
+  const FOUNDRY_URL = process.env[`${prefix}FOUNDRY_URL`];
+  const FOUNDRY_CLIENT_SECRET = process.env[`${prefix}FOUNDRY_CLIENT_SECRET`];
+
+  invariant(
+    FOUNDRY_CLIENT_ID != null,
+    `${prefix}FOUNDRY_CLIENT_ID is required`,
+  );
+  invariant(
+    FOUNDRY_URL != null,
+    `${prefix}FOUNDRY_URL is required`,
+  );
+  invariant(
+    FOUNDRY_CLIENT_SECRET != null,
+    `${prefix}FOUNDRY_URL is required`,
+  );
+
+  const auth = createConfidentialOauthClient(
+    FOUNDRY_CLIENT_ID,
+    FOUNDRY_CLIENT_SECRET,
+    FOUNDRY_URL,
+  );
+
+  const token = await auth();
+  invariant(
+    token != null && token.length > 0,
+    "token should have been received",
+  );
+  consola.log(token);
+}

--- a/packages/e2e.sandbox.oauth/tsconfig.cjs.json
+++ b/packages/e2e.sandbox.oauth/tsconfig.cjs.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "target": "ES6",
+    "rootDir": "src",
+    "outDir": "build/cjs"
+  },
+  "include": [
+    "./src/**/*"
+  ],
+  "references": []
+}

--- a/packages/e2e.sandbox.oauth/tsconfig.json
+++ b/packages/e2e.sandbox.oauth/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@osdk/monorepo.tsconfig/base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build/esm"
+  },
+  "include": [
+    "./src/**/*"
+  ],
+  "references": []
+}

--- a/packages/e2e.sandbox.oauth/tsup.config.js
+++ b/packages/e2e.sandbox.oauth/tsup.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-import type { BaseOauthClient } from "./BaseOauthClient.js";
-import type { Token } from "./Token.js";
+import { defineConfig } from "tsup";
 
-export interface PublicOauthClient
-  extends BaseOauthClient<"signIn" | "signOut" | "refresh">
-{
-  refresh: () => Promise<Token | undefined>;
-}
+export default defineConfig(async (options) =>
+  (await import("@osdk/monorepo.tsup")).default(options, {})
+);

--- a/packages/e2e.sandbox.todoapp/vite.config.mts
+++ b/packages/e2e.sandbox.todoapp/vite.config.mts
@@ -9,6 +9,9 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
 
   return {
+    define: {
+      "process.env.NODE_ENV": JSON.stringify(mode),
+    },
     plugins: [
       react(),
       visualizer({
@@ -24,6 +27,12 @@ export default defineConfig(({ mode }) => {
         "/object-set-watcher": `${env.VITE_FOUNDRY_URL}`,
         "/object-set-service": `${env.VITE_FOUNDRY_URL}`,
       },
+    },
+    optimizeDeps: {
+      // shared.client is a mixed package that needs to be properly processed by vite
+      // but normally linked packages do not get that treatment so we have to explicitly add it here
+      // and in the `commonjsOptions` below
+      include: ["@osdk/client > @osdk/shared.client"],
     },
     build: {
       outDir: "build/site/",

--- a/packages/oauth/src/BaseOauthClient.ts
+++ b/packages/oauth/src/BaseOauthClient.ts
@@ -14,11 +14,29 @@
  * limitations under the License.
  */
 
-import type { BaseOauthClient } from "./BaseOauthClient.js";
 import type { Token } from "./Token.js";
 
-export interface PublicOauthClient
-  extends BaseOauthClient<"signIn" | "signOut" | "refresh">
-{
-  refresh: () => Promise<Token | undefined>;
+export type Events = {
+  signIn: CustomEvent<Token>;
+  signOut: Event;
+  refresh: CustomEvent<Token>;
+};
+
+export interface BaseOauthClient<K extends keyof Events & string> {
+  (): Promise<string>;
+
+  signIn: () => Promise<Token>;
+  signOut: () => Promise<void>;
+
+  addEventListener: <T extends K>(
+    type: T,
+    listener: ((evt: Events[T]) => void) | null,
+    options?: boolean | AddEventListenerOptions,
+  ) => void;
+
+  removeEventListener: <T extends K>(
+    type: T,
+    callback: ((evt: Events[T]) => void) | null,
+    options?: EventListenerOptions | boolean,
+  ) => void;
 }

--- a/packages/oauth/src/ConfidentialOauthClient.ts
+++ b/packages/oauth/src/ConfidentialOauthClient.ts
@@ -15,10 +15,8 @@
  */
 
 import type { BaseOauthClient } from "./BaseOauthClient.js";
-import type { Token } from "./Token.js";
 
-export interface PublicOauthClient
-  extends BaseOauthClient<"signIn" | "signOut" | "refresh">
+export interface ConfidentialOauthClient
+  extends BaseOauthClient<"signIn" | "signOut">
 {
-  refresh: () => Promise<Token | undefined>;
 }

--- a/packages/oauth/src/common.ts
+++ b/packages/oauth/src/common.ts
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  AuthorizationServer,
+  Client,
+  HttpRequestOptions,
+  OAuth2TokenEndpointResponse,
+} from "oauth4webapi";
+import { processRevocationResponse, revocationRequest } from "oauth4webapi";
+import invariant from "tiny-invariant";
+import { TypedEventTarget } from "typescript-event-target";
+import type { BaseOauthClient, Events } from "./BaseOauthClient.js";
+import { throwIfError } from "./throwIfError.js";
+import type { Token } from "./Token.js";
+
+// Node 18 is supposed to have a `CustomEvent` but it is not exposed on `globalThis`
+// which creates a problem for making a single codebase for node and browser. This polyfill works around it
+const CustomEvent = process.env.target === "browser"
+  ? globalThis.CustomEvent
+  : globalThis.CustomEvent
+    ?? class CustomEvent<T> extends Event {
+      #detail: T | null;
+
+      constructor(type: string, options: EventInit & { detail: T }) {
+        super(type, options);
+        this.#detail = options?.detail ?? null;
+      }
+
+      get detail() {
+        return this.#detail;
+      }
+    };
+
+declare const process: {
+  env: Record<string, string | undefined>;
+};
+
+const localStorage = globalThis.localStorage;
+
+type LocalStorageState =
+  // when we are going to the login page
+  | {
+    refresh_token?: never;
+    codeVerifier?: never;
+    state?: never;
+    oldUrl: string;
+  }
+  // when we are redirecting to oauth login
+  | {
+    refresh_token?: never;
+    codeVerifier: string;
+    state: string;
+    oldUrl: string;
+  }
+  // when we have the refresh token
+  | {
+    refresh_token?: string;
+    codeVerifier?: never;
+    state?: never;
+    oldUrl?: never;
+  }
+  | {
+    refresh_token?: never;
+    codeVerifier?: never;
+    state?: never;
+    oldUrl?: never;
+  };
+
+export function saveLocal(client: Client, x: LocalStorageState) {
+  // MUST `localStorage?` as nodejs does not have localStorage
+  localStorage?.setItem(
+    `@osdk/oauth : refresh : ${client.client_id}`,
+    JSON.stringify(x),
+  );
+}
+
+export function removeLocal(client: Client) {
+  // MUST `localStorage?` as nodejs does not have localStorage
+  localStorage?.removeItem(`@osdk/oauth : refresh : ${client.client_id}`);
+}
+
+export function readLocal(client: Client): LocalStorageState {
+  return JSON.parse(
+    // MUST `localStorage?` as nodejs does not have localStorage
+    localStorage?.getItem(`@osdk/oauth : refresh : ${client.client_id}`)
+      ?? "{}",
+  );
+}
+
+export function common<
+  R extends undefined | (() => Promise<Token | undefined>),
+>(
+  client: Client,
+  as: AuthorizationServer,
+  _signIn: () => Promise<Token>,
+  oauthHttpOptions: HttpRequestOptions,
+  refresh: R,
+): {
+  getToken: BaseOauthClient<keyof Events & string> & { refresh: R };
+  makeTokenAndSaveRefresh: (
+    resp: OAuth2TokenEndpointResponse,
+    type: "signIn" | "refresh",
+  ) => Token;
+} {
+  let token: Token | undefined;
+  const eventTarget = new TypedEventTarget<Events>();
+
+  function makeTokenAndSaveRefresh(
+    resp: OAuth2TokenEndpointResponse,
+    type: "signIn" | "refresh",
+  ): Token {
+    const { refresh_token, expires_in, access_token } = resp;
+    invariant(expires_in != null);
+    saveLocal(client, { refresh_token });
+    token = {
+      refresh_token,
+      expires_in,
+      access_token,
+      expires_at: Date.now() + expires_in * 1000,
+    };
+
+    eventTarget.dispatchTypedEvent(
+      type,
+      new CustomEvent(
+        type,
+        { detail: token },
+      ),
+    );
+    return token;
+  }
+
+  let refreshTimeout: ReturnType<typeof setTimeout>;
+  function rmTimeout() {
+    if (refreshTimeout) clearTimeout(refreshTimeout);
+  }
+  function restartRefreshTimer(evt: CustomEvent<Token>) {
+    if (refresh) {
+      rmTimeout();
+      refreshTimeout = setTimeout(
+        refresh,
+        evt.detail.expires_in * 1000 - 60 * 1000,
+      );
+    }
+  }
+
+  async function signOut() {
+    invariant(token, "not signed in");
+
+    const result = await processRevocationResponse(
+      await revocationRequest(
+        as,
+        client,
+        token.access_token,
+        oauthHttpOptions,
+      ),
+    );
+
+    rmTimeout();
+
+    // Clean up
+    removeLocal(client);
+    token = undefined;
+    throwIfError(result);
+    eventTarget.dispatchTypedEvent("signOut", new Event("signOut"));
+  }
+
+  let pendingSignIn: Promise<Token> | undefined;
+  async function signIn() {
+    if (pendingSignIn) {
+      return pendingSignIn;
+    }
+    try {
+      pendingSignIn = _signIn();
+      return await pendingSignIn;
+    } finally {
+      pendingSignIn = undefined;
+    }
+  }
+
+  eventTarget.addEventListener("signIn", restartRefreshTimer);
+  eventTarget.addEventListener("refresh", restartRefreshTimer);
+
+  const getToken = Object.assign(async function getToken() {
+    if (!token || Date.now() >= token.expires_at) {
+      token = await signIn();
+    }
+    return token!.access_token;
+  }, {
+    signIn,
+    refresh,
+    signOut,
+    rmTimeout,
+    addEventListener: eventTarget.addEventListener.bind(
+      eventTarget,
+    ) as typeof eventTarget.addEventListener,
+    removeEventListener: eventTarget.removeEventListener.bind(
+      eventTarget,
+    ) as typeof eventTarget.removeEventListener,
+  });
+
+  return { getToken, makeTokenAndSaveRefresh };
+}
+
+export function createAuthorizationServer(
+  ctxPath: string,
+  url: string,
+): Required<
+  Pick<
+    AuthorizationServer,
+    | "issuer"
+    | "token_endpoint"
+    | "authorization_endpoint"
+    | "revocation_endpoint"
+  >
+> {
+  const issuer = `${new URL(ctxPath, url)}`;
+  return {
+    token_endpoint: `${issuer}/api/oauth2/token`,
+    authorization_endpoint: `${issuer}/api/oauth2/authorize`,
+    revocation_endpoint: `${issuer}/api/oauth2/revoke_token`,
+    issuer,
+  };
+}

--- a/packages/oauth/src/createConfidentialOauthClient.ts
+++ b/packages/oauth/src/createConfidentialOauthClient.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Client, HttpRequestOptions } from "oauth4webapi";
+import {
+  clientCredentialsGrantRequest,
+  customFetch,
+  processClientCredentialsResponse,
+} from "oauth4webapi";
+import { common, createAuthorizationServer } from "./common.js";
+import type { ConfidentialOauthClient } from "./ConfidentialOauthClient.js";
+import { throwIfError } from "./throwIfError.js";
+
+/**
+ * @param client_id
+ * @param client_secret
+ * @param url the base url of your foundry server
+ * @param scopes
+ * @param fetchFn
+ * @param ctxPath
+ * @returns which can be used as a token provider
+ */
+export function createConfidentialOauthClient(
+  client_id: string,
+  client_secret: string,
+  url: string,
+  scopes: string[] = ["api:read-data", "api:write-data"],
+  fetchFn: typeof globalThis.fetch = globalThis.fetch,
+  ctxPath: string = "/multipass",
+): ConfidentialOauthClient {
+  const client: Client = { client_id, client_secret };
+  const authServer = createAuthorizationServer(ctxPath, url);
+  const oauthHttpOptions: HttpRequestOptions = { [customFetch]: fetchFn };
+
+  const { getToken, makeTokenAndSaveRefresh } = common(
+    client,
+    authServer,
+    _signIn,
+    oauthHttpOptions,
+    undefined,
+  );
+
+  async function _signIn() {
+    return makeTokenAndSaveRefresh(
+      throwIfError(
+        await processClientCredentialsResponse(
+          authServer,
+          client,
+          await clientCredentialsGrantRequest(
+            authServer,
+            client,
+            new URLSearchParams({ scope: scopes.join(" ") }),
+            oauthHttpOptions,
+          ),
+        ),
+      ),
+      "signIn",
+    );
+  }
+
+  return getToken;
+}

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -14,5 +14,6 @@
  * limitations under the License.
  */
 
+export { createConfidentialOauthClient } from "./createConfidentialOauthClient.js";
 export { createPublicOauthClient } from "./createPublicOauthClient.js";
 export type { PublicOauthClient } from "./PublicOauthClient.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1282,6 +1282,34 @@ importers:
         specifier: ^5.5.2
         version: 5.5.3
 
+  packages/e2e.sandbox.oauth:
+    dependencies:
+      '@osdk/client':
+        specifier: workspace:~
+        version: link:../client
+      '@osdk/oauth':
+        specifier: workspace:~
+        version: link:../oauth
+      consola:
+        specifier: ^3.2.3
+        version: 3.2.3
+      tiny-invariant:
+        specifier: ^1.3.3
+        version: 1.3.3
+    devDependencies:
+      '@osdk/monorepo.api-extractor':
+        specifier: workspace:~
+        version: link:../monorepo.api-extractor
+      '@osdk/monorepo.tsconfig':
+        specifier: workspace:~
+        version: link:../monorepo.tsconfig
+      '@osdk/monorepo.tsup':
+        specifier: workspace:~
+        version: link:../monorepo.tsup
+      typescript:
+        specifier: ^5.5.2
+        version: 5.5.3
+
   packages/e2e.sandbox.todoapp:
     dependencies:
       '@osdk/api':
@@ -2130,9 +2158,6 @@ importers:
       jest-extended:
         specifier: ^4.0.2
         version: 4.0.2
-      ts-expect:
-        specifier: ^1.3.0
-        version: 1.3.0
       typescript:
         specifier: ^5.5.2
         version: 5.5.2
@@ -8993,7 +9018,7 @@ snapshots:
 
   '@types/ws@8.5.10':
     dependencies:
-      '@types/node': 20.12.12
+      '@types/node': 20.14.10
 
   '@types/yargs-parser@21.0.2': {}
 
@@ -10277,8 +10302,8 @@ snapshots:
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.5.3)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.16.0(eslint@9.3.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.16.0(eslint@9.3.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@9.3.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.16.0(eslint@9.3.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.16.0(eslint@9.3.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@9.3.0))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-react: 7.34.1(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -10296,13 +10321,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.16.0(eslint@9.3.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.16.0(eslint@9.3.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@9.3.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.16.1
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.16.0(eslint@9.3.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.16.0(eslint@9.3.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@9.3.0))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.16.0(eslint@9.3.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.16.0(eslint@9.3.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@9.3.0))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.13.1
@@ -10330,14 +10355,25 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.16.0(eslint@9.3.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.16.0(eslint@9.3.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@9.3.0))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.5.3)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.16.0(eslint@9.3.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.16.0(eslint@9.3.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@9.3.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.16.0(eslint@9.3.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.16.0(eslint@9.3.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@9.3.0))(eslint@8.57.0):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.16.0(eslint@9.3.0)(typescript@5.5.3)
+      eslint: 8.57.0
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.16.0(eslint@9.3.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@9.3.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10366,7 +10402,7 @@ snapshots:
     dependencies:
       eslint: 9.3.0
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.16.0(eslint@9.3.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.16.0(eslint@9.3.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@9.3.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -10376,7 +10412,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.16.0(eslint@9.3.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.16.0(eslint@9.3.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@9.3.0))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.16.0(eslint@9.3.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.16.0(eslint@9.3.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@9.3.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -10387,7 +10423,7 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.5.3)
+      '@typescript-eslint/parser': 7.16.0(eslint@9.3.0)(typescript@5.5.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack


### PR DESCRIPTION
Introduces `createConfidentialClient` along with:
- adds some documentation for working around `ReferenceError: process is not defined` when using vite.
- ensures that usage of `createPlatformClient` can be named
- adds e2e.sandbox.oauth as a tool to verify that confidential client is working correctly

Fixes #410
Fixes #295 
