### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -68,9 +68,11 @@
     "@osdk/monorepo.tool.attw": "0.0.0",
     "@osdk/monorepo.tool.transpile": "0.0.0",
     "@osdk/monorepo.tool.typecheck": "0.0.0",
-    "@osdk/monorepo.tsconfig": "0.0.0"
+    "@osdk/monorepo.tsconfig": "0.0.0",
+    "@osdk/e2e.test.foundry-sdk-generator": "0.0.0"
   },
   "changesets": [
+    "bright-apples-bake",
     "calm-pillows-collect",
     "chilly-mayflies-vanish",
     "chilly-melons-hammer",
@@ -128,6 +130,7 @@
     "tasty-kiwis-attack",
     "thin-eggs-prove",
     "tough-hats-push",
+    "unlucky-geese-hug",
     "unlucky-moose-lay",
     "unlucky-wombats-switch",
     "weak-dragons-wonder",

--- a/packages/e2e.test.foundry-sdk-generator/CHANGELOG.md
+++ b/packages/e2e.test.foundry-sdk-generator/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @osdk/e2e.test.foundry-sdk-generator
+
+## 0.1.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [6bf66d5]
+- Updated dependencies [029d816]
+  - @osdk/foundry-sdk-generator@1.2.0-beta.4

--- a/packages/e2e.test.foundry-sdk-generator/package.json
+++ b/packages/e2e.test.foundry-sdk-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.test.foundry-sdk-generator",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/foundry-sdk-generator
 
+## 1.2.0-beta.4
+
+### Minor Changes
+
+- 6bf66d5: Actually fix the script to run
+- 029d816: Fixes bin script being interpreted as esm
+
 ## 1.2.0-beta.3
 
 ### Minor Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "1.2.0-beta.3",
+  "version": "1.2.0-beta.4",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/foundry-sdk-generator@1.2.0-beta.4

### Minor Changes

-   6bf66d5: Actually fix the script to run
-   029d816: Fixes bin script being interpreted as esm

## @osdk/e2e.test.foundry-sdk-generator@0.1.0-beta.0

### Patch Changes

-   Updated dependencies [6bf66d5]
-   Updated dependencies [029d816]
    -   @osdk/foundry-sdk-generator@1.2.0-beta.4
