### PR TITLE
Fix primary key type on action edits

### DIFF
--- a/.changeset/small-glasses-eat.md
+++ b/.changeset/small-glasses-eat.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client.api": patch
+---
+
+Fix primary key type on action edits

--- a/packages/client.api/src/actions/ActionResults.ts
+++ b/packages/client.api/src/actions/ActionResults.ts
@@ -38,7 +38,7 @@ type ObjectEdit =
     bSideObject: ObjectReference;
   });
 interface ObjectReference {
-  primaryKey: unknown;
+  primaryKey: string | number;
   objectType: string;
 }
 export interface ValidateActionResponseV2 {


### PR DESCRIPTION
Replaced unknown with `string|number`