### PR TITLE
Add no query support for timeseries

### DIFF
--- a/.changeset/hip-cameras-rhyme.md
+++ b/.changeset/hip-cameras-rhyme.md
@@ -1,0 +1,7 @@
+---
+"@osdk/shared.test": patch
+"@osdk/client.api": patch
+"@osdk/client": patch
+---
+
+Add support for no query time series pulls.

--- a/etc/client.api.report.api.md
+++ b/etc/client.api.report.api.md
@@ -719,9 +719,9 @@ export interface TimeSeriesPoint<T extends string | number> {
 // @public (undocumented)
 export interface TimeSeriesProperty<T extends number | string> {
     // (undocumented)
-    asyncIterPoints(query: TimeSeriesQuery): AsyncGenerator<TimeSeriesPoint<T>>;
+    asyncIterPoints(query?: TimeSeriesQuery): AsyncGenerator<TimeSeriesPoint<T>>;
     // (undocumented)
-    getAllPoints(query: TimeSeriesQuery): Promise<Array<TimeSeriesPoint<T>>>;
+    getAllPoints(query?: TimeSeriesQuery): Promise<Array<TimeSeriesPoint<T>>>;
     // (undocumented)
     getFirstPoint(): Promise<TimeSeriesPoint<T>>;
     // (undocumented)

--- a/packages/client.api/src/timeseries/timeseries.ts
+++ b/packages/client.api/src/timeseries/timeseries.ts
@@ -70,6 +70,6 @@ export interface TimeSeriesPoint<T extends string | number> {
 export interface TimeSeriesProperty<T extends number | string> {
   getFirstPoint(): Promise<TimeSeriesPoint<T>>;
   getLastPoint(): Promise<TimeSeriesPoint<T>>;
-  getAllPoints(query: TimeSeriesQuery): Promise<Array<TimeSeriesPoint<T>>>;
-  asyncIterPoints(query: TimeSeriesQuery): AsyncGenerator<TimeSeriesPoint<T>>;
+  getAllPoints(query?: TimeSeriesQuery): Promise<Array<TimeSeriesPoint<T>>>;
+  asyncIterPoints(query?: TimeSeriesQuery): AsyncGenerator<TimeSeriesPoint<T>>;
 }

--- a/packages/client/src/createTimeseriesProperty.ts
+++ b/packages/client/src/createTimeseriesProperty.ts
@@ -60,7 +60,7 @@ export function createTimeseriesProperty<T extends number | string>(
         propertyName,
       ) as Promise<TimeSeriesPoint<T>>;
     },
-    async getAllPoints(query: TimeSeriesQuery) {
+    async getAllPoints(query?: TimeSeriesQuery) {
       return getAllTimeSeriesPoints(
         client,
         objectApiName,
@@ -70,7 +70,7 @@ export function createTimeseriesProperty<T extends number | string>(
       );
     },
 
-    asyncIterPoints(query: TimeSeriesQuery) {
+    asyncIterPoints(query?: TimeSeriesQuery) {
       return iterateTimeSeriesPoints(
         client,
         objectApiName,
@@ -87,7 +87,7 @@ async function getAllTimeSeriesPoints<T extends string | number>(
   objectApiName: string,
   primaryKey: any,
   propertyName: string,
-  body: TimeSeriesQuery,
+  body?: TimeSeriesQuery,
 ): Promise<Array<TimeSeriesPoint<T>>> {
   const allPoints: Array<TimeSeriesPoint<T>> = [];
 
@@ -113,7 +113,7 @@ async function* iterateTimeSeriesPoints<T extends string | number>(
   objectApiName: string,
   primaryKey: any,
   propertyName: string,
-  body: TimeSeriesQuery,
+  body?: TimeSeriesQuery,
 ): AsyncGenerator<TimeSeriesPoint<T>, any, unknown> {
   const utf8decoder = new TextDecoder("utf-8");
 
@@ -124,7 +124,7 @@ async function* iterateTimeSeriesPoints<T extends string | number>(
       objectApiName,
       primaryKey,
       propertyName,
-      { range: getTimeRange(body) },
+      body ? { range: getTimeRange(body) } : {},
     );
 
   const reader = streamPointsIterator.stream().getReader();

--- a/packages/client/src/object/timeseries.test.ts
+++ b/packages/client/src/object/timeseries.test.ts
@@ -109,6 +109,23 @@ describe("Timeseries", () => {
     }, { time: "2014-04-14", value: 30 }]);
   });
 
+  it("getAll points with no query works", async () => {
+    const employee = await client(Employee).fetchOne(50030);
+    expect(employee.$primaryKey).toEqual(50030);
+    const points = await employee.employeeStatus?.getAllPoints();
+    expect(points).toBeDefined();
+    expect(points!).toEqual([
+      { time: "2012-02-12", value: 10 },
+      { time: "2012-02-12", value: 10 },
+      {
+        time: "2013-03-13",
+        value: 20,
+      },
+      { time: "2014-04-14", value: 30 },
+      { time: "2014-04-14", value: 30 },
+    ]);
+  });
+
   it("async iter points with absolute range works", async () => {
     const employee = await client(Employee).fetchOne(50030);
     expect(employee.$primaryKey).toEqual(50030);
@@ -126,5 +143,27 @@ describe("Timeseries", () => {
       time: "2013-03-13",
       value: 20,
     }, { time: "2014-04-14", value: 30 }]);
+  });
+
+  it("async iter points with no query", async () => {
+    const employee = await client(Employee).fetchOne(50030);
+    expect(employee.$primaryKey).toEqual(50030);
+    const pointsIter = employee.employeeStatus?.asyncIterPoints();
+
+    const points: TimeSeriesPoint<string>[] = [];
+    for await (const point of pointsIter!) {
+      points.push(point);
+    }
+    expect(points).toBeDefined();
+    expect(points!).toEqual([
+      { time: "2012-02-12", value: 10 },
+      { time: "2012-02-12", value: 10 },
+      {
+        time: "2013-03-13",
+        value: 20,
+      },
+      { time: "2014-04-14", value: 30 },
+      { time: "2014-04-14", value: 30 },
+    ]);
   });
 });

--- a/packages/shared.test/src/stubs/timeseriesRequests.ts
+++ b/packages/shared.test/src/stubs/timeseriesRequests.ts
@@ -55,6 +55,8 @@ const noBodyRequest: StreamTimeSeriesPointsRequest = {
   range: { type: "absolute" },
 };
 
+const noRangeRequest: StreamTimeSeriesPointsRequest = {};
+
 const fromBodyRequest: StreamTimeSeriesPointsRequest = {
   range: {
     type: "relative",
@@ -121,6 +123,7 @@ export const streamPointsRequestHandlers: Record<
   StreamTimeSeriesPointsResponse
 > = {
   [stableStringify(noBodyRequest)]: streamPointsNoBody,
+  [stableStringify(noRangeRequest)]: streamPointsNoBody,
   [stableStringify(rangeBodyRequest)]: streamPointsRange,
   [stableStringify(fromBodyRequest)]: streamPointsFrom,
   [stableStringify(afterBodyRequest)]: streamPointsAfter,


### PR DESCRIPTION
In legacy you can just load all points without filtering down to a timeframe, adding that support to 2.0