### PR TITLE
Embed templates in create-app

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,8 @@
   "commit": false,
   "fixed": [
     ["@osdk/foundry.*", "@osdk/foundry"],
-    ["@osdk/client.api", "@osdk/client"]
+    ["@osdk/client.api", "@osdk/client"],
+    ["@osdk/create-app", "@osdk/create-app.template.*"]
   ],
   "linked": [],
   "access": "restricted",
@@ -12,9 +13,9 @@
   "updateInternalDependencies": "patch",
   "ignore": [
     "@osdk/examples.*",
+    "@osdk/monorepo.*",
     "@osdk/tests.*",
-    "@osdk/version-updater",
-    "@osdk/monorepo.*"
+    "@osdk/version-updater"
   ],
   "bumpVersionsWithWorkspaceProtocolOnly": true,
   "snapshot": {

--- a/.changeset/old-deers-chew.md
+++ b/.changeset/old-deers-chew.md
@@ -1,0 +1,5 @@
+---
+"@osdk/create-app": minor
+---
+
+Makes the templates get embedded create-app instead of referencing them

--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -420,6 +420,14 @@ function standardPackageRules(shared, options) {
  */
 export default {
   rules: [
+    packageEntry({
+      includePackages: ["@osdk/create-app.template.*"],
+      options: {
+        entries: {
+          private: true,
+        },
+      },
+    }),
     fileContents({
       includePackages: ["@osdk/create-app.template.*"],
       options: {

--- a/packages/create-app.template-packager/package.json
+++ b/packages/create-app.template-packager/package.json
@@ -2,6 +2,7 @@
   "name": "@osdk/create-app.template-packager",
   "version": "0.0.0",
   "license": "Apache-2.0",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/palantir/osdk-ts.git"

--- a/packages/create-app.template-packager/package.json
+++ b/packages/create-app.template-packager/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@osdk/create-app.template-packager",
+  "private": true,
   "version": "0.0.0",
   "license": "Apache-2.0",
-  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/palantir/osdk-ts.git"

--- a/packages/create-app.template.next-static-export/package.json
+++ b/packages/create-app.template.next-static-export/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@osdk/create-app.template.next-static-export",
+  "private": true,
   "version": "0.17.0",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/create-app.template.react/package.json
+++ b/packages/create-app.template.react/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@osdk/create-app.template.react",
+  "private": true,
   "version": "0.17.0",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/create-app.template.tutorial-todo-aip-app/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app",
+  "private": true,
   "version": "0.17.0",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/create-app.template.tutorial-todo-app/package.json
+++ b/packages/create-app.template.tutorial-todo-app/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app",
+  "private": true,
   "version": "0.17.0",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/create-app.template.vue/package.json
+++ b/packages/create-app.template.vue/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@osdk/create-app.template.vue",
+  "private": true,
   "version": "0.17.0",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -31,17 +31,17 @@
     "typecheck": "monorepo.tool.typecheck esm"
   },
   "dependencies": {
-    "@osdk/create-app.template.next-static-export": "workspace:*",
-    "@osdk/create-app.template.react": "workspace:*",
-    "@osdk/create-app.template.tutorial-todo-aip-app": "workspace:*",
-    "@osdk/create-app.template.tutorial-todo-app": "workspace:*",
-    "@osdk/create-app.template.vue": "workspace:*",
     "consola": "^3.2.3",
     "find-up": "^7.0.0",
     "handlebars": "^4.7.8",
     "yargs": "^17.7.2"
   },
   "devDependencies": {
+    "@osdk/create-app.template.next-static-export": "workspace:*",
+    "@osdk/create-app.template.react": "workspace:*",
+    "@osdk/create-app.template.tutorial-todo-aip-app": "workspace:*",
+    "@osdk/create-app.template.tutorial-todo-app": "workspace:*",
+    "@osdk/create-app.template.vue": "workspace:*",
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
     "@osdk/monorepo.tsup": "workspace:~",

--- a/packages/create-app/src/run.ts
+++ b/packages/create-app/src/run.ts
@@ -82,9 +82,7 @@ export async function run(
   const files: Map<
     string,
     { type: "base64"; body: string } | { type: "raw"; body: string }
-  > = (await import(
-    `@osdk/create-app.template.${template.id.replace(/^template-/, "")}`
-  )).files;
+  > = await template.getFiles();
 
   for (const [filePath, contents] of files) {
     const finalPath = path.join(root, filePath);

--- a/packages/create-app/src/templates.ts
+++ b/packages/create-app/src/templates.ts
@@ -20,6 +20,12 @@ export interface Template {
   envPrefix: string;
   buildDirectory: string;
   hidden?: boolean;
+  getFiles: () => Promise<
+    Map<
+      string,
+      { type: "base64"; body: string } | { type: "raw"; body: string }
+    >
+  >;
 }
 
 export interface TemplateContext {
@@ -35,18 +41,27 @@ export const TEMPLATES: readonly Template[] = [
     label: "React",
     envPrefix: "VITE_",
     buildDirectory: "./dist",
+    getFiles: async () => ((await import(
+      `@osdk/create-app.template.react`
+    )).files),
   },
   {
     id: "template-vue",
     label: "Vue",
     envPrefix: "VITE_",
     buildDirectory: "./dist",
+    getFiles: async () => ((await import(
+      `@osdk/create-app.template.vue`
+    )).files),
   },
   {
     id: "template-next-static-export",
     label: "Next (static export)",
     envPrefix: "NEXT_PUBLIC_",
     buildDirectory: "./out",
+    getFiles: async () => ((await import(
+      `@osdk/create-app.template.next-static-export`
+    )).files),
   },
   {
     id: "template-tutorial-todo-app",
@@ -54,6 +69,9 @@ export const TEMPLATES: readonly Template[] = [
     envPrefix: "VITE_",
     buildDirectory: "./dist",
     hidden: true,
+    getFiles: async () => ((await import(
+      `@osdk/create-app.template.tutorial-todo-app`
+    )).files),
   },
   {
     id: "template-tutorial-todo-aip-app",
@@ -61,5 +79,8 @@ export const TEMPLATES: readonly Template[] = [
     envPrefix: "VITE_",
     buildDirectory: "./dist",
     hidden: true,
+    getFiles: async () => ((await import(
+      `@osdk/create-app.template.tutorial-todo-aip-app`
+    )).files),
   },
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -815,6 +815,19 @@ importers:
 
   packages/create-app:
     dependencies:
+      consola:
+        specifier: ^3.2.3
+        version: 3.2.3
+      find-up:
+        specifier: ^7.0.0
+        version: 7.0.0
+      handlebars:
+        specifier: ^4.7.8
+        version: 4.7.8
+      yargs:
+        specifier: ^17.7.2
+        version: 17.7.2
+    devDependencies:
       '@osdk/create-app.template.next-static-export':
         specifier: workspace:*
         version: link:../create-app.template.next-static-export
@@ -830,19 +843,6 @@ importers:
       '@osdk/create-app.template.vue':
         specifier: workspace:*
         version: link:../create-app.template.vue
-      consola:
-        specifier: ^3.2.3
-        version: 3.2.3
-      find-up:
-        specifier: ^7.0.0
-        version: 7.0.0
-      handlebars:
-        specifier: ^4.7.8
-        version: 4.7.8
-      yargs:
-        specifier: ^17.7.2
-        version: 17.7.2
-    devDependencies:
       '@osdk/monorepo.api-extractor':
         specifier: workspace:~
         version: link:../monorepo.api-extractor


### PR DESCRIPTION
The shift to `devDependency` in `@osdk/create-app`'s `package.json` informs tsup/rollup to bundle the contents in. To simplify debugging, we are tying the version of each `create-app.template.*` to the same version as `create-app` as they are sentamental only now that they don't publish.