### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -70,5 +70,15 @@
     "@osdk/tests.verify-fallback-package": "0.0.3",
     "@osdk/tests.verify-fallback-package-v2": "0.0.3"
   },
-  "changesets": []
+  "changesets": [
+    "eleven-planets-taste",
+    "giant-pianos-film",
+    "gorgeous-coats-hang",
+    "healthy-tools-accept",
+    "mean-dragons-stare",
+    "old-deers-chew",
+    "purple-students-sin",
+    "rich-bobcats-pretend",
+    "twelve-foxes-walk"
+  ]
 }

--- a/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,12 +1,12 @@
 import { OntologyMetadata as OM } from '@osdk/api';
 
-export type $ExpectedClientVersion = '0.20.0';
+export type $ExpectedClientVersion = '0.21.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export interface OntologyMetadata extends OM<$ExpectedClientVersion> {}
 
 export const OntologyMetadata: OntologyMetadata = {
-  expectsClientVersion: '0.20.0',
+  expectsClientVersion: '0.21.0',
   ontologyRid: 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e',
   ontologyApiName: 'ontology-d097f725-ab77-46cf-83c0-e3cb9186bff1',
   userAgent: 'typescript-sdk/dev osdk-cli/dev',

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/cli.cmd.typescript
 
+## 0.5.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [8c76c1a]
+  - @osdk/generator@1.13.0-beta.0
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/cli
 
+## 0.23.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [8c76c1a]
+  - @osdk/generator@1.13.0-beta.0
+
 ## 0.22.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.22.0",
+  "version": "0.23.0-beta.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client.api/CHANGELOG.md
+++ b/packages/client.api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/client.api
 
+## 0.21.0-beta.0
+
+### Minor Changes
+
+- 2deb4d9: Fixing types for within and intersects so they don't take more than the permitted keys
+- e54f413: Marks things as @internal to clean up API requirements
+
 ## 0.20.0
 
 ### Minor Changes

--- a/packages/client.api/package.json
+++ b/packages/client.api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.api",
-  "version": "0.20.0",
+  "version": "0.21.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.test.ontology/CHANGELOG.md
+++ b/packages/client.test.ontology/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/client.test.ontology
 
+## 1.1.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [2deb4d9]
+- Updated dependencies [e54f413]
+  - @osdk/client.api@0.21.0-beta.0
+
 ## 1.0.0
 
 ### Minor Changes

--- a/packages/client.test.ontology/package.json
+++ b/packages/client.test.ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/client.test.ontology",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @osdk/client
 
+## 0.21.0-beta.0
+
+### Minor Changes
+
+- 2deb4d9: Fixing types for within and intersects so they don't take more than the permitted keys
+- e54f413: Marks things as @internal to clean up API requirements
+- 6387a92: Makes defining process.env.NODE_ENV optional
+- 651c1b8: Fixes rids in interfaces
+
+### Patch Changes
+
+- Updated dependencies [2deb4d9]
+- Updated dependencies [e54f413]
+  - @osdk/client.api@0.21.0-beta.0
+
 ## 0.20.0
 
 ### Minor Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client",
-  "version": "0.20.0",
+  "version": "0.21.0-beta.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -53,7 +53,7 @@ export interface Client extends SharedClient<MinimalClient> {
 }
 
 // BEGIN: THIS IS GENERATED CODE. DO NOT EDIT.
-const MaxOsdkVersion = "0.20.0";
+const MaxOsdkVersion = "0.21.0";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 export type MaxOsdkVersion = typeof MaxOsdkVersion;
 const ErrorMessage = Symbol("ErrorMessage");

--- a/packages/create-app.template.next-static-export/CHANGELOG.md
+++ b/packages/create-app.template.next-static-export/CHANGELOG.md
@@ -1,3 +1,5 @@
 # @osdk/create-app.template.next-static-export
 
+## 0.18.0-beta.0
+
 ## 0.17.0

--- a/packages/create-app.template.next-static-export/package.json
+++ b/packages/create-app.template.next-static-export/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.next-static-export",
   "private": true,
-  "version": "0.17.0",
+  "version": "0.18.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react/CHANGELOG.md
+++ b/packages/create-app.template.react/CHANGELOG.md
@@ -1,3 +1,5 @@
 # @osdk/create-app.template.react
 
+## 0.18.0-beta.0
+
 ## 0.17.0

--- a/packages/create-app.template.react/package.json
+++ b/packages/create-app.template.react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react",
   "private": true,
-  "version": "0.17.0",
+  "version": "0.18.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
@@ -1,3 +1,9 @@
 # @osdk/create-app.template.tutorial-todo-aip-app
 
+## 0.18.0-beta.0
+
+### Minor Changes
+
+- 71ddf63: fix gitignore
+
 ## 0.17.0

--- a/packages/create-app.template.tutorial-todo-aip-app/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app",
   "private": true,
-  "version": "0.17.0",
+  "version": "0.18.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
@@ -1,3 +1,9 @@
 # @osdk/create-app.template.tutorial-todo-app
 
+## 0.18.0-beta.0
+
+### Minor Changes
+
+- 71ddf63: fix gitignore
+
 ## 0.17.0

--- a/packages/create-app.template.tutorial-todo-app/package.json
+++ b/packages/create-app.template.tutorial-todo-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app",
   "private": true,
-  "version": "0.17.0",
+  "version": "0.18.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.vue/CHANGELOG.md
+++ b/packages/create-app.template.vue/CHANGELOG.md
@@ -1,3 +1,5 @@
 # @osdk/create-app.template.vue
 
+## 0.18.0-beta.0
+
 ## 0.17.0

--- a/packages/create-app.template.vue/package.json
+++ b/packages/create-app.template.vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.vue",
   "private": true,
-  "version": "0.17.0",
+  "version": "0.18.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/create-app
 
+## 0.18.0-beta.0
+
+### Minor Changes
+
+- 9e956e3: Makes the templates get embedded create-app instead of referencing them
+
 ## 0.17.0
 
 ### Minor Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-app",
-  "version": "0.17.0",
+  "version": "0.18.0-beta.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/e2e.generated.1.1.x/CHANGELOG.md
+++ b/packages/e2e.generated.1.1.x/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/e2e.generated.1.1.x
 
+## 0.2.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [cd37441]
+- Updated dependencies [8c76c1a]
+  - @osdk/legacy-client@2.5.0-beta.0
+  - @osdk/generator@1.13.0-beta.0
+
 ## 0.1.0
 
 ### Patch Changes

--- a/packages/e2e.generated.1.1.x/package.json
+++ b/packages/e2e.generated.1.1.x/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.generated.1.1.x",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0-beta.0",
   "description": "",
   "license": "Apache-2.0",
   "repository": {
@@ -38,13 +38,13 @@
   },
   "peerDependencies": {
     "@osdk/api": "^1.9.0",
-    "@osdk/legacy-client": "^2.4.0"
+    "@osdk/legacy-client": "^2.5.0-beta.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.2",
     "@osdk/api": "^1.9.0",
     "@osdk/cli.cmd.typescript": "workspace:~",
-    "@osdk/legacy-client": "^2.4.0",
+    "@osdk/legacy-client": "^2.5.0-beta.0",
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
     "@osdk/monorepo.tsup": "workspace:~",

--- a/packages/e2e.generated.catchall/CHANGELOG.md
+++ b/packages/e2e.generated.catchall/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/e2e.generated.catchall
 
+## 2.0.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [2deb4d9]
+- Updated dependencies [e54f413]
+- Updated dependencies [6387a92]
+- Updated dependencies [651c1b8]
+  - @osdk/client.api@0.21.0-beta.0
+  - @osdk/client@0.21.0-beta.0
+
 ## 1.0.0
 
 ### Minor Changes

--- a/packages/e2e.generated.catchall/package.json
+++ b/packages/e2e.generated.catchall/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.generated.catchall",
   "private": true,
-  "version": "1.0.0",
+  "version": "2.0.0-beta.0",
   "description": "",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,12 +1,12 @@
 import { OntologyMetadata as OM } from '@osdk/api';
 
-export type $ExpectedClientVersion = '0.20.0';
+export type $ExpectedClientVersion = '0.21.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export interface OntologyMetadata extends OM<$ExpectedClientVersion> {}
 
 export const OntologyMetadata: OntologyMetadata = {
-  expectsClientVersion: '0.20.0',
+  expectsClientVersion: '0.21.0',
   ontologyRid: 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e',
   ontologyApiName: 'default',
   userAgent: 'typescript-sdk/dev osdk-cli/dev',

--- a/packages/e2e.sandbox.catchall/CHANGELOG.md
+++ b/packages/e2e.sandbox.catchall/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/e2e.sandbox.catchall
 
+## 0.2.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [2deb4d9]
+- Updated dependencies [e54f413]
+- Updated dependencies [6387a92]
+- Updated dependencies [651c1b8]
+  - @osdk/client.api@0.21.0-beta.0
+  - @osdk/client@0.21.0-beta.0
+  - @osdk/e2e.generated.catchall@2.0.0-beta.0
+  - @osdk/foundry@3.0.0-beta.0
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/e2e.sandbox.catchall/package.json
+++ b/packages/e2e.sandbox.catchall/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.sandbox.catchall",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.sandbox.oauth/CHANGELOG.md
+++ b/packages/e2e.sandbox.oauth/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/e2e.sandbox.oauth
 
+## 0.2.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [2deb4d9]
+- Updated dependencies [e54f413]
+- Updated dependencies [6387a92]
+- Updated dependencies [651c1b8]
+  - @osdk/client@0.21.0-beta.0
+
 ## 0.1.0
 
 ### Patch Changes

--- a/packages/e2e.sandbox.oauth/package.json
+++ b/packages/e2e.sandbox.oauth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.sandbox.oauth",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.sandbox.todoapp/CHANGELOG.md
+++ b/packages/e2e.sandbox.todoapp/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/e2e.sandbox.todoappapp
 
+## 2.0.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [2deb4d9]
+- Updated dependencies [e54f413]
+- Updated dependencies [6387a92]
+- Updated dependencies [651c1b8]
+  - @osdk/client.api@0.21.0-beta.0
+  - @osdk/client@0.21.0-beta.0
+
 ## 1.0.0
 
 ### Patch Changes

--- a/packages/e2e.sandbox.todoapp/package.json
+++ b/packages/e2e.sandbox.todoapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.sandbox.todoapp",
   "private": true,
-  "version": "1.0.0",
+  "version": "2.0.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/OntologyMetadata.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/OntologyMetadata.ts
@@ -1,12 +1,12 @@
 import { OntologyMetadata as OM } from '@osdk/api';
 
-export type $ExpectedClientVersion = '0.20.0';
+export type $ExpectedClientVersion = '0.21.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export interface OntologyMetadata extends OM<$ExpectedClientVersion> {}
 
 export const OntologyMetadata: OntologyMetadata = {
-  expectsClientVersion: '0.20.0',
+  expectsClientVersion: '0.21.0',
   ontologyRid: 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e',
   ontologyApiName: 'ontology-d097f725-ab77-46cf-83c0-e3cb9186bff1',
   userAgent: 'typescript-sdk/dev osdk-cli/dev',

--- a/packages/e2e.test.foundry-sdk-generator/CHANGELOG.md
+++ b/packages/e2e.test.foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/e2e.test.foundry-sdk-generator
 
+## 0.2.0-beta.0
+
+### Patch Changes
+
+- @osdk/foundry-sdk-generator@1.3.0-beta.0
+
 ## 0.1.0
 
 ### Patch Changes

--- a/packages/e2e.test.foundry-sdk-generator/package.json
+++ b/packages/e2e.test.foundry-sdk-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.test.foundry-sdk-generator",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/example-generator/CHANGELOG.md
+++ b/packages/example-generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/example-generator
 
+## 0.7.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [9e956e3]
+  - @osdk/create-app@0.18.0-beta.0
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/example-generator/package.json
+++ b/packages/example-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/example-generator",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @osdk/foundry-sdk-generator
 
+## 1.3.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [2deb4d9]
+- Updated dependencies [e54f413]
+- Updated dependencies [6387a92]
+- Updated dependencies [cd37441]
+- Updated dependencies [8c76c1a]
+- Updated dependencies [651c1b8]
+  - @osdk/client.api@0.21.0-beta.0
+  - @osdk/client@0.21.0-beta.0
+  - @osdk/legacy-client@2.5.0-beta.0
+  - @osdk/generator@1.13.0-beta.0
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "1.2.0",
+  "version": "1.3.0-beta.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/foundry.admin/CHANGELOG.md
+++ b/packages/foundry.admin/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/foundry.admin
 
+## 3.0.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [2deb4d9]
+- Updated dependencies [e54f413]
+- Updated dependencies [6387a92]
+- Updated dependencies [651c1b8]
+  - @osdk/client@0.21.0-beta.0
+  - @osdk/foundry.core@3.0.0-beta.0
+
 ## 2.0.0
 
 ### Minor Changes

--- a/packages/foundry.admin/package.json
+++ b/packages/foundry.admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.admin",
-  "version": "2.0.0",
+  "version": "3.0.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.core/CHANGELOG.md
+++ b/packages/foundry.core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/foundry.core
 
+## 3.0.0-beta.0
+
 ## 2.0.0
 
 ### Minor Changes

--- a/packages/foundry.core/package.json
+++ b/packages/foundry.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.core",
-  "version": "2.0.0",
+  "version": "3.0.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.datasets/CHANGELOG.md
+++ b/packages/foundry.datasets/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/foundry.datasets
 
+## 3.0.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [2deb4d9]
+- Updated dependencies [e54f413]
+- Updated dependencies [6387a92]
+- Updated dependencies [651c1b8]
+  - @osdk/client@0.21.0-beta.0
+  - @osdk/foundry.core@3.0.0-beta.0
+
 ## 2.0.0
 
 ### Minor Changes

--- a/packages/foundry.datasets/package.json
+++ b/packages/foundry.datasets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.datasets",
-  "version": "2.0.0",
+  "version": "3.0.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.thirdpartyapplications/CHANGELOG.md
+++ b/packages/foundry.thirdpartyapplications/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/foundry.thirdpartyapplications
 
+## 3.0.0-beta.0
+
+### Patch Changes
+
+- @osdk/foundry.core@3.0.0-beta.0
+
 ## 2.0.0
 
 ### Minor Changes

--- a/packages/foundry.thirdpartyapplications/package.json
+++ b/packages/foundry.thirdpartyapplications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.thirdpartyapplications",
-  "version": "2.0.0",
+  "version": "3.0.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry/CHANGELOG.md
+++ b/packages/foundry/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/foundry
 
+## 3.0.0-beta.0
+
+### Patch Changes
+
+- @osdk/foundry.admin@3.0.0-beta.0
+- @osdk/foundry.datasets@3.0.0-beta.0
+- @osdk/foundry.core@3.0.0-beta.0
+- @osdk/foundry.thirdpartyapplications@3.0.0-beta.0
+
 ## 2.0.0
 
 ### Minor Changes

--- a/packages/foundry/package.json
+++ b/packages/foundry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry",
-  "version": "2.0.0",
+  "version": "3.0.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/generator
 
+## 1.13.0-beta.0
+
+### Minor Changes
+
+- 8c76c1a: Adds VersionBound to actions
+
 ## 1.12.0
 
 ### Minor Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "1.12.0",
+  "version": "1.13.0-beta.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator/src/v2.0/generateMetadata.ts
+++ b/packages/generator/src/v2.0/generateMetadata.ts
@@ -20,7 +20,7 @@ import { formatTs } from "../util/test/formatTs.js";
 import type { WireOntologyDefinition } from "../WireOntologyDefinition.js";
 
 // BEGIN: THIS IS GENERATED CODE. DO NOT EDIT.
-const ExpectedOsdkVersion = "0.20.0";
+const ExpectedOsdkVersion = "0.21.0";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 
 export async function generateOntologyMetadataFile(

--- a/packages/legacy-client/CHANGELOG.md
+++ b/packages/legacy-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/legacy-client
 
+## 2.5.0-beta.0
+
+### Minor Changes
+
+- cd37441: Fix primary key encoding in URLs
+
 ## 2.4.0
 
 ### Minor Changes

--- a/packages/legacy-client/package.json
+++ b/packages/legacy-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/legacy-client",
-  "version": "2.4.0",
+  "version": "2.5.0-beta.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/client@0.21.0-beta.0

### Minor Changes

-   2deb4d9: Fixing types for within and intersects so they don't take more than the permitted keys
-   e54f413: Marks things as @internal to clean up API requirements
-   6387a92: Makes defining process.env.NODE_ENV optional
-   651c1b8: Fixes rids in interfaces

### Patch Changes

-   Updated dependencies [2deb4d9]
-   Updated dependencies [e54f413]
    -   @osdk/client.api@0.21.0-beta.0

## @osdk/client.api@0.21.0-beta.0

### Minor Changes

-   2deb4d9: Fixing types for within and intersects so they don't take more than the permitted keys
-   e54f413: Marks things as @internal to clean up API requirements

## @osdk/create-app@0.18.0-beta.0

### Minor Changes

-   9e956e3: Makes the templates get embedded create-app instead of referencing them

## @osdk/generator@1.13.0-beta.0

### Minor Changes

-   8c76c1a: Adds VersionBound to actions

## @osdk/legacy-client@2.5.0-beta.0

### Minor Changes

-   cd37441: Fix primary key encoding in URLs

## @osdk/cli@0.23.0-beta.0

### Patch Changes

-   Updated dependencies [8c76c1a]
    -   @osdk/generator@1.13.0-beta.0

## @osdk/foundry@3.0.0-beta.0

### Patch Changes

-   @osdk/foundry.admin@3.0.0-beta.0
-   @osdk/foundry.datasets@3.0.0-beta.0
-   @osdk/foundry.core@3.0.0-beta.0
-   @osdk/foundry.thirdpartyapplications@3.0.0-beta.0

## @osdk/foundry-sdk-generator@1.3.0-beta.0

### Patch Changes

-   Updated dependencies [2deb4d9]
-   Updated dependencies [e54f413]
-   Updated dependencies [6387a92]
-   Updated dependencies [cd37441]
-   Updated dependencies [8c76c1a]
-   Updated dependencies [651c1b8]
    -   @osdk/client.api@0.21.0-beta.0
    -   @osdk/client@0.21.0-beta.0
    -   @osdk/legacy-client@2.5.0-beta.0
    -   @osdk/generator@1.13.0-beta.0

## @osdk/foundry.admin@3.0.0-beta.0

### Patch Changes

-   Updated dependencies [2deb4d9]
-   Updated dependencies [e54f413]
-   Updated dependencies [6387a92]
-   Updated dependencies [651c1b8]
    -   @osdk/client@0.21.0-beta.0
    -   @osdk/foundry.core@3.0.0-beta.0

## @osdk/foundry.datasets@3.0.0-beta.0

### Patch Changes

-   Updated dependencies [2deb4d9]
-   Updated dependencies [e54f413]
-   Updated dependencies [6387a92]
-   Updated dependencies [651c1b8]
    -   @osdk/client@0.21.0-beta.0
    -   @osdk/foundry.core@3.0.0-beta.0

## @osdk/foundry.thirdpartyapplications@3.0.0-beta.0

### Patch Changes

-   @osdk/foundry.core@3.0.0-beta.0

## @osdk/foundry.core@3.0.0-beta.0



## @osdk/create-app.template.tutorial-todo-aip-app@0.18.0-beta.0

### Minor Changes

-   71ddf63: fix gitignore

## @osdk/create-app.template.tutorial-todo-app@0.18.0-beta.0

### Minor Changes

-   71ddf63: fix gitignore

## @osdk/cli.cmd.typescript@0.5.0-beta.0

### Patch Changes

-   Updated dependencies [8c76c1a]
    -   @osdk/generator@1.13.0-beta.0

## @osdk/client.test.ontology@1.1.0-beta.0

### Patch Changes

-   Updated dependencies [2deb4d9]
-   Updated dependencies [e54f413]
    -   @osdk/client.api@0.21.0-beta.0

## @osdk/e2e.generated.1.1.x@0.2.0-beta.0

### Patch Changes

-   Updated dependencies [cd37441]
-   Updated dependencies [8c76c1a]
    -   @osdk/legacy-client@2.5.0-beta.0
    -   @osdk/generator@1.13.0-beta.0

## @osdk/e2e.generated.catchall@2.0.0-beta.0

### Patch Changes

-   Updated dependencies [2deb4d9]
-   Updated dependencies [e54f413]
-   Updated dependencies [6387a92]
-   Updated dependencies [651c1b8]
    -   @osdk/client.api@0.21.0-beta.0
    -   @osdk/client@0.21.0-beta.0

## @osdk/e2e.sandbox.catchall@0.2.0-beta.0

### Patch Changes

-   Updated dependencies [2deb4d9]
-   Updated dependencies [e54f413]
-   Updated dependencies [6387a92]
-   Updated dependencies [651c1b8]
    -   @osdk/client.api@0.21.0-beta.0
    -   @osdk/client@0.21.0-beta.0
    -   @osdk/e2e.generated.catchall@2.0.0-beta.0
    -   @osdk/foundry@3.0.0-beta.0

## @osdk/e2e.sandbox.oauth@0.2.0-beta.0

### Patch Changes

-   Updated dependencies [2deb4d9]
-   Updated dependencies [e54f413]
-   Updated dependencies [6387a92]
-   Updated dependencies [651c1b8]
    -   @osdk/client@0.21.0-beta.0

## @osdk/e2e.sandbox.todoapp@2.0.0-beta.0

### Patch Changes

-   Updated dependencies [2deb4d9]
-   Updated dependencies [e54f413]
-   Updated dependencies [6387a92]
-   Updated dependencies [651c1b8]
    -   @osdk/client.api@0.21.0-beta.0
    -   @osdk/client@0.21.0-beta.0

## @osdk/e2e.test.foundry-sdk-generator@0.2.0-beta.0

### Patch Changes

-   @osdk/foundry-sdk-generator@1.3.0-beta.0

## @osdk/example-generator@0.7.0-beta.0

### Patch Changes

-   Updated dependencies [9e956e3]
    -   @osdk/create-app@0.18.0-beta.0

## @osdk/create-app.template.next-static-export@0.18.0-beta.0



## @osdk/create-app.template.react@0.18.0-beta.0



## @osdk/create-app.template.vue@0.18.0-beta.0


