### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -75,10 +75,12 @@
     "giant-pianos-film",
     "gorgeous-coats-hang",
     "healthy-tools-accept",
+    "itchy-goats-pump",
     "mean-dragons-stare",
     "old-deers-chew",
     "purple-students-sin",
     "rich-bobcats-pretend",
+    "silent-carpets-kick",
     "twelve-foxes-walk"
   ]
 }

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/cli.cmd.typescript
 
+## 0.5.0-beta.1
+
+### Patch Changes
+
+- Updated dependencies [e2ab8db]
+  - @osdk/generator@1.13.0-beta.1
+
 ## 0.5.0-beta.0
 
 ### Patch Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.5.0-beta.0",
+  "version": "0.5.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/cli
 
+## 0.23.0-beta.1
+
+### Patch Changes
+
+- Updated dependencies [e2ab8db]
+  - @osdk/generator@1.13.0-beta.1
+
 ## 0.23.0-beta.0
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.23.0-beta.0",
+  "version": "0.23.0-beta.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client.api/CHANGELOG.md
+++ b/packages/client.api/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/client.api
 
+## 0.21.0-beta.1
+
 ## 0.21.0-beta.0
 
 ### Minor Changes

--- a/packages/client.api/package.json
+++ b/packages/client.api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.api",
-  "version": "0.21.0-beta.0",
+  "version": "0.21.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.test.ontology/CHANGELOG.md
+++ b/packages/client.test.ontology/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/client.test.ontology
 
+## 1.1.0-beta.1
+
+### Patch Changes
+
+- @osdk/client.api@0.21.0-beta.1
+
 ## 1.1.0-beta.0
 
 ### Patch Changes

--- a/packages/client.test.ontology/package.json
+++ b/packages/client.test.ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/client.test.ontology",
   "private": true,
-  "version": "1.1.0-beta.0",
+  "version": "1.1.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/client
 
+## 0.21.0-beta.1
+
+### Minor Changes
+
+- f91cd58: Temporarily disable X-OSDK-Request-Context header
+
+### Patch Changes
+
+- @osdk/client.api@0.21.0-beta.1
+
 ## 0.21.0-beta.0
 
 ### Minor Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client",
-  "version": "0.21.0-beta.0",
+  "version": "0.21.0-beta.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/e2e.generated.1.1.x/CHANGELOG.md
+++ b/packages/e2e.generated.1.1.x/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/e2e.generated.1.1.x
 
+## 0.2.0-beta.1
+
+### Minor Changes
+
+- e2ab8db: Fix long aggregations in legacy-client
+
+### Patch Changes
+
+- Updated dependencies [e2ab8db]
+  - @osdk/legacy-client@2.5.0-beta.1
+  - @osdk/generator@1.13.0-beta.1
+
 ## 0.2.0-beta.0
 
 ### Patch Changes

--- a/packages/e2e.generated.1.1.x/package.json
+++ b/packages/e2e.generated.1.1.x/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.generated.1.1.x",
   "private": true,
-  "version": "0.2.0-beta.0",
+  "version": "0.2.0-beta.1",
   "description": "",
   "license": "Apache-2.0",
   "repository": {
@@ -38,13 +38,13 @@
   },
   "peerDependencies": {
     "@osdk/api": "^1.9.0",
-    "@osdk/legacy-client": "^2.5.0-beta.0"
+    "@osdk/legacy-client": "^2.5.0-beta.1"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.2",
     "@osdk/api": "^1.9.0",
     "@osdk/cli.cmd.typescript": "workspace:~",
-    "@osdk/legacy-client": "^2.5.0-beta.0",
+    "@osdk/legacy-client": "^2.5.0-beta.1",
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
     "@osdk/monorepo.tsup": "workspace:~",

--- a/packages/e2e.generated.catchall/CHANGELOG.md
+++ b/packages/e2e.generated.catchall/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/e2e.generated.catchall
 
+## 2.0.0-beta.1
+
+### Patch Changes
+
+- Updated dependencies [f91cd58]
+  - @osdk/client@0.21.0-beta.1
+  - @osdk/client.api@0.21.0-beta.1
+
 ## 2.0.0-beta.0
 
 ### Patch Changes

--- a/packages/e2e.generated.catchall/package.json
+++ b/packages/e2e.generated.catchall/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.generated.catchall",
   "private": true,
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "description": "",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/e2e.sandbox.catchall/CHANGELOG.md
+++ b/packages/e2e.sandbox.catchall/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/e2e.sandbox.catchall
 
+## 0.2.0-beta.1
+
+### Patch Changes
+
+- Updated dependencies [f91cd58]
+  - @osdk/client@0.21.0-beta.1
+  - @osdk/e2e.generated.catchall@2.0.0-beta.1
+  - @osdk/foundry@3.0.0-beta.1
+  - @osdk/client.api@0.21.0-beta.1
+
 ## 0.2.0-beta.0
 
 ### Patch Changes

--- a/packages/e2e.sandbox.catchall/package.json
+++ b/packages/e2e.sandbox.catchall/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.sandbox.catchall",
   "private": true,
-  "version": "0.2.0-beta.0",
+  "version": "0.2.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.sandbox.oauth/CHANGELOG.md
+++ b/packages/e2e.sandbox.oauth/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/e2e.sandbox.oauth
 
+## 0.2.0-beta.1
+
+### Patch Changes
+
+- Updated dependencies [f91cd58]
+  - @osdk/client@0.21.0-beta.1
+
 ## 0.2.0-beta.0
 
 ### Patch Changes

--- a/packages/e2e.sandbox.oauth/package.json
+++ b/packages/e2e.sandbox.oauth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.sandbox.oauth",
   "private": true,
-  "version": "0.2.0-beta.0",
+  "version": "0.2.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.sandbox.todoapp/CHANGELOG.md
+++ b/packages/e2e.sandbox.todoapp/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/e2e.sandbox.todoappapp
 
+## 2.0.0-beta.1
+
+### Patch Changes
+
+- Updated dependencies [f91cd58]
+  - @osdk/client@0.21.0-beta.1
+  - @osdk/client.api@0.21.0-beta.1
+
 ## 2.0.0-beta.0
 
 ### Patch Changes

--- a/packages/e2e.sandbox.todoapp/package.json
+++ b/packages/e2e.sandbox.todoapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.sandbox.todoapp",
   "private": true,
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.test.foundry-sdk-generator/CHANGELOG.md
+++ b/packages/e2e.test.foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/e2e.test.foundry-sdk-generator
 
+## 0.2.0-beta.1
+
+### Patch Changes
+
+- @osdk/foundry-sdk-generator@1.3.0-beta.1
+
 ## 0.2.0-beta.0
 
 ### Patch Changes

--- a/packages/e2e.test.foundry-sdk-generator/package.json
+++ b/packages/e2e.test.foundry-sdk-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.test.foundry-sdk-generator",
   "private": true,
-  "version": "0.2.0-beta.0",
+  "version": "0.2.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/foundry-sdk-generator
 
+## 1.3.0-beta.1
+
+### Patch Changes
+
+- Updated dependencies [f91cd58]
+- Updated dependencies [e2ab8db]
+  - @osdk/client@0.21.0-beta.1
+  - @osdk/legacy-client@2.5.0-beta.1
+  - @osdk/generator@1.13.0-beta.1
+  - @osdk/client.api@0.21.0-beta.1
+
 ## 1.3.0-beta.0
 
 ### Patch Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "1.3.0-beta.0",
+  "version": "1.3.0-beta.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/foundry.admin/CHANGELOG.md
+++ b/packages/foundry.admin/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/foundry.admin
 
+## 3.0.0-beta.1
+
+### Patch Changes
+
+- Updated dependencies [f91cd58]
+  - @osdk/client@0.21.0-beta.1
+  - @osdk/foundry.core@3.0.0-beta.1
+
 ## 3.0.0-beta.0
 
 ### Patch Changes

--- a/packages/foundry.admin/package.json
+++ b/packages/foundry.admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.admin",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.core/CHANGELOG.md
+++ b/packages/foundry.core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/foundry.core
 
+## 3.0.0-beta.1
+
 ## 3.0.0-beta.0
 
 ## 2.0.0

--- a/packages/foundry.core/package.json
+++ b/packages/foundry.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.core",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.datasets/CHANGELOG.md
+++ b/packages/foundry.datasets/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/foundry.datasets
 
+## 3.0.0-beta.1
+
+### Patch Changes
+
+- Updated dependencies [f91cd58]
+  - @osdk/client@0.21.0-beta.1
+  - @osdk/foundry.core@3.0.0-beta.1
+
 ## 3.0.0-beta.0
 
 ### Patch Changes

--- a/packages/foundry.datasets/package.json
+++ b/packages/foundry.datasets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.datasets",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.thirdpartyapplications/CHANGELOG.md
+++ b/packages/foundry.thirdpartyapplications/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/foundry.thirdpartyapplications
 
+## 3.0.0-beta.1
+
+### Patch Changes
+
+- @osdk/foundry.core@3.0.0-beta.1
+
 ## 3.0.0-beta.0
 
 ### Patch Changes

--- a/packages/foundry.thirdpartyapplications/package.json
+++ b/packages/foundry.thirdpartyapplications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.thirdpartyapplications",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry/CHANGELOG.md
+++ b/packages/foundry/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/foundry
 
+## 3.0.0-beta.1
+
+### Patch Changes
+
+- @osdk/foundry.admin@3.0.0-beta.1
+- @osdk/foundry.datasets@3.0.0-beta.1
+- @osdk/foundry.core@3.0.0-beta.1
+- @osdk/foundry.thirdpartyapplications@3.0.0-beta.1
+
 ## 3.0.0-beta.0
 
 ### Patch Changes

--- a/packages/foundry/package.json
+++ b/packages/foundry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/generator
 
+## 1.13.0-beta.1
+
+### Minor Changes
+
+- e2ab8db: Fix long aggregations in legacy-client
+
 ## 1.13.0-beta.0
 
 ### Minor Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "1.13.0-beta.0",
+  "version": "1.13.0-beta.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/legacy-client/CHANGELOG.md
+++ b/packages/legacy-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/legacy-client
 
+## 2.5.0-beta.1
+
+### Minor Changes
+
+- e2ab8db: Fix long aggregations in legacy-client
+
 ## 2.5.0-beta.0
 
 ### Minor Changes

--- a/packages/legacy-client/package.json
+++ b/packages/legacy-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/legacy-client",
-  "version": "2.5.0-beta.0",
+  "version": "2.5.0-beta.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/shared.test/CHANGELOG.md
+++ b/packages/shared.test/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/shared.test
 
+## 1.6.0-beta.0
+
+### Minor Changes
+
+- e2ab8db: Fix long aggregations in legacy-client
+
 ## 1.5.0
 
 ### Minor Changes

--- a/packages/shared.test/package.json
+++ b/packages/shared.test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/shared.test",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.6.0-beta.0",
   "description": "",
   "access": "private",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/client@0.21.0-beta.1

### Minor Changes

-   f91cd58: Temporarily disable X-OSDK-Request-Context header

### Patch Changes

-   @osdk/client.api@0.21.0-beta.1

## @osdk/generator@1.13.0-beta.1

### Minor Changes

-   e2ab8db: Fix long aggregations in legacy-client

## @osdk/legacy-client@2.5.0-beta.1

### Minor Changes

-   e2ab8db: Fix long aggregations in legacy-client

## @osdk/cli@0.23.0-beta.1

### Patch Changes

-   Updated dependencies [e2ab8db]
    -   @osdk/generator@1.13.0-beta.1

## @osdk/foundry@3.0.0-beta.1

### Patch Changes

-   @osdk/foundry.admin@3.0.0-beta.1
-   @osdk/foundry.datasets@3.0.0-beta.1
-   @osdk/foundry.core@3.0.0-beta.1
-   @osdk/foundry.thirdpartyapplications@3.0.0-beta.1

## @osdk/foundry-sdk-generator@1.3.0-beta.1

### Patch Changes

-   Updated dependencies [f91cd58]
-   Updated dependencies [e2ab8db]
    -   @osdk/client@0.21.0-beta.1
    -   @osdk/legacy-client@2.5.0-beta.1
    -   @osdk/generator@1.13.0-beta.1
    -   @osdk/client.api@0.21.0-beta.1

## @osdk/foundry.admin@3.0.0-beta.1

### Patch Changes

-   Updated dependencies [f91cd58]
    -   @osdk/client@0.21.0-beta.1
    -   @osdk/foundry.core@3.0.0-beta.1

## @osdk/foundry.datasets@3.0.0-beta.1

### Patch Changes

-   Updated dependencies [f91cd58]
    -   @osdk/client@0.21.0-beta.1
    -   @osdk/foundry.core@3.0.0-beta.1

## @osdk/foundry.thirdpartyapplications@3.0.0-beta.1

### Patch Changes

-   @osdk/foundry.core@3.0.0-beta.1

## @osdk/client.api@0.21.0-beta.1



## @osdk/foundry.core@3.0.0-beta.1



## @osdk/e2e.generated.1.1.x@0.2.0-beta.1

### Minor Changes

-   e2ab8db: Fix long aggregations in legacy-client

### Patch Changes

-   Updated dependencies [e2ab8db]
    -   @osdk/legacy-client@2.5.0-beta.1
    -   @osdk/generator@1.13.0-beta.1

## @osdk/shared.test@1.6.0-beta.0

### Minor Changes

-   e2ab8db: Fix long aggregations in legacy-client

## @osdk/cli.cmd.typescript@0.5.0-beta.1

### Patch Changes

-   Updated dependencies [e2ab8db]
    -   @osdk/generator@1.13.0-beta.1

## @osdk/client.test.ontology@1.1.0-beta.1

### Patch Changes

-   @osdk/client.api@0.21.0-beta.1

## @osdk/e2e.generated.catchall@2.0.0-beta.1

### Patch Changes

-   Updated dependencies [f91cd58]
    -   @osdk/client@0.21.0-beta.1
    -   @osdk/client.api@0.21.0-beta.1

## @osdk/e2e.sandbox.catchall@0.2.0-beta.1

### Patch Changes

-   Updated dependencies [f91cd58]
    -   @osdk/client@0.21.0-beta.1
    -   @osdk/e2e.generated.catchall@2.0.0-beta.1
    -   @osdk/foundry@3.0.0-beta.1
    -   @osdk/client.api@0.21.0-beta.1

## @osdk/e2e.sandbox.oauth@0.2.0-beta.1

### Patch Changes

-   Updated dependencies [f91cd58]
    -   @osdk/client@0.21.0-beta.1

## @osdk/e2e.sandbox.todoapp@2.0.0-beta.1

### Patch Changes

-   Updated dependencies [f91cd58]
    -   @osdk/client@0.21.0-beta.1
    -   @osdk/client.api@0.21.0-beta.1

## @osdk/e2e.test.foundry-sdk-generator@0.2.0-beta.1

### Patch Changes

-   @osdk/foundry-sdk-generator@1.3.0-beta.1
