### PR TITLE
Version Packages

### DIFF
--- a/.changeset/mean-dragons-stare.md
+++ b/.changeset/mean-dragons-stare.md
@@ -1,5 +1,0 @@
----
-"@osdk/legacy-client": patch
----
-
-Fix primary key encoding in URLs

--- a/.changeset/twelve-foxes-walk.md
+++ b/.changeset/twelve-foxes-walk.md
@@ -1,6 +1,0 @@
----
-"@osdk/create-app.template.tutorial-todo-aip-app": patch
-"@osdk/create-app.template.tutorial-todo-app": patch
----
-
-fix gitignore

--- a/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
@@ -1,3 +1,9 @@
 # @osdk/create-app.template.tutorial-todo-aip-app
 
+## 0.17.1
+
+### Patch Changes
+
+- 71ddf63: fix gitignore
+
 ## 0.17.0

--- a/packages/create-app.template.tutorial-todo-aip-app/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
@@ -1,3 +1,9 @@
 # @osdk/create-app.template.tutorial-todo-app
 
+## 0.17.1
+
+### Patch Changes
+
+- 71ddf63: fix gitignore
+
 ## 0.17.0

--- a/packages/create-app.template.tutorial-todo-app/package.json
+++ b/packages/create-app.template.tutorial-todo-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/create-app
 
+## 0.17.1
+
+### Patch Changes
+
+- Updated dependencies [71ddf63]
+  - @osdk/create-app.template.tutorial-todo-aip-app@0.17.1
+  - @osdk/create-app.template.tutorial-todo-app@0.17.1
+
 ## 0.17.0
 
 ### Minor Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-app",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/e2e.generated.1.1.x/package.json
+++ b/packages/e2e.generated.1.1.x/package.json
@@ -38,13 +38,13 @@
   },
   "peerDependencies": {
     "@osdk/api": "^1.9.0",
-    "@osdk/legacy-client": "^2.4.0"
+    "@osdk/legacy-client": "^2.4.1"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.2",
     "@osdk/api": "^1.9.0",
     "@osdk/cli.cmd.typescript": "workspace:~",
-    "@osdk/legacy-client": "^2.4.0",
+    "@osdk/legacy-client": "^2.4.1",
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
     "@osdk/monorepo.tsup": "workspace:~",

--- a/packages/e2e.test.foundry-sdk-generator/CHANGELOG.md
+++ b/packages/e2e.test.foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/e2e.test.foundry-sdk-generator
 
+## 0.1.1
+
+### Patch Changes
+
+- @osdk/foundry-sdk-generator@1.2.1
+
 ## 0.1.0
 
 ### Patch Changes

--- a/packages/e2e.test.foundry-sdk-generator/package.json
+++ b/packages/e2e.test.foundry-sdk-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.test.foundry-sdk-generator",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/example-generator/CHANGELOG.md
+++ b/packages/example-generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/example-generator
 
+## 0.6.1
+
+### Patch Changes
+
+- @osdk/create-app@0.17.1
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/example-generator/package.json
+++ b/packages/example-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/example-generator",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/foundry-sdk-generator
 
+## 1.2.1
+
+### Patch Changes
+
+- Updated dependencies [0d69b95]
+  - @osdk/legacy-client@2.4.1
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/legacy-client/CHANGELOG.md
+++ b/packages/legacy-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/legacy-client
 
+## 2.4.1
+
+### Patch Changes
+
+- 0d69b95: Fix primary key encoding in URLs
+
 ## 2.4.0
 
 ### Minor Changes

--- a/packages/legacy-client/package.json
+++ b/packages/legacy-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/legacy-client",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/1.2.x, this PR will be updated.


# Releases
## @osdk/create-app@0.17.1

### Patch Changes

-   Updated dependencies [71ddf63]
    -   @osdk/create-app.template.tutorial-todo-aip-app@0.17.1
    -   @osdk/create-app.template.tutorial-todo-app@0.17.1

## @osdk/create-app.template.tutorial-todo-aip-app@0.17.1

### Patch Changes

-   71ddf63: fix gitignore

## @osdk/create-app.template.tutorial-todo-app@0.17.1

### Patch Changes

-   71ddf63: fix gitignore

## @osdk/foundry-sdk-generator@1.2.1

### Patch Changes

-   Updated dependencies [0d69b95]
    -   @osdk/legacy-client@2.4.1

## @osdk/legacy-client@2.4.1

### Patch Changes

-   0d69b95: Fix primary key encoding in URLs

## @osdk/e2e.test.foundry-sdk-generator@0.1.1

### Patch Changes

-   @osdk/foundry-sdk-generator@1.2.1

## @osdk/example-generator@0.6.1

### Patch Changes

-   @osdk/create-app@0.17.1
