### PR TITLE
Manually restore omni versions and prevent future issues

### DIFF
--- a/packages/foundry.admin/CHANGELOG.md
+++ b/packages/foundry.admin/CHANGELOG.md
@@ -1,24 +1,5 @@
 # @osdk/foundry.admin
 
-## 3.0.0-beta.1
-
-### Patch Changes
-
-- Updated dependencies [f91cd58]
-  - @osdk/client@0.21.0-beta.1
-  - @osdk/foundry.core@3.0.0-beta.1
-
-## 3.0.0-beta.0
-
-### Patch Changes
-
-- Updated dependencies [2deb4d9]
-- Updated dependencies [e54f413]
-- Updated dependencies [6387a92]
-- Updated dependencies [651c1b8]
-  - @osdk/client@0.21.0-beta.0
-  - @osdk/foundry.core@3.0.0-beta.0
-
 ## 2.0.0
 
 ### Minor Changes

--- a/packages/foundry.admin/package.json
+++ b/packages/foundry.admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.admin",
-  "version": "3.0.0-beta.1",
+  "version": "2.0.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -29,11 +29,6 @@
     "@osdk/foundry.core": "workspace:*",
     "@osdk/shared.client": "workspace:~",
     "@osdk/shared.net.platformapi": "workspace:~"
-  },
-  "peerDependencies": {
-    "@osdk/api": "workspace:~",
-    "@osdk/client": "workspace:~",
-    "@osdk/shared.net": "workspace:~"
   },
   "devDependencies": {
     "@osdk/monorepo.api-extractor": "workspace:~",

--- a/packages/foundry.core/CHANGELOG.md
+++ b/packages/foundry.core/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @osdk/foundry.core
 
-## 3.0.0-beta.1
-
-## 3.0.0-beta.0
-
 ## 2.0.0
 
 ### Minor Changes

--- a/packages/foundry.core/package.json
+++ b/packages/foundry.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.core",
-  "version": "3.0.0-beta.1",
+  "version": "2.0.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.datasets/CHANGELOG.md
+++ b/packages/foundry.datasets/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @osdk/foundry.datasets
 
-## 3.0.0-beta.1
-
-### Patch Changes
-
-- Updated dependencies [f91cd58]
-  - @osdk/client@0.21.0-beta.1
-  - @osdk/foundry.core@3.0.0-beta.1
-
-## 3.0.0-beta.0
-
 ### Patch Changes
 
 - Updated dependencies [2deb4d9]

--- a/packages/foundry.datasets/package.json
+++ b/packages/foundry.datasets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.datasets",
-  "version": "3.0.0-beta.1",
+  "version": "2.0.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -29,11 +29,6 @@
     "@osdk/foundry.core": "workspace:*",
     "@osdk/shared.client": "workspace:~",
     "@osdk/shared.net.platformapi": "workspace:~"
-  },
-  "peerDependencies": {
-    "@osdk/api": "workspace:~",
-    "@osdk/client": "workspace:~",
-    "@osdk/shared.net": "workspace:~"
   },
   "devDependencies": {
     "@osdk/monorepo.api-extractor": "workspace:~",

--- a/packages/foundry.thirdpartyapplications/CHANGELOG.md
+++ b/packages/foundry.thirdpartyapplications/CHANGELOG.md
@@ -1,17 +1,5 @@
 # @osdk/foundry.thirdpartyapplications
 
-## 3.0.0-beta.1
-
-### Patch Changes
-
-- @osdk/foundry.core@3.0.0-beta.1
-
-## 3.0.0-beta.0
-
-### Patch Changes
-
-- @osdk/foundry.core@3.0.0-beta.0
-
 ## 2.0.0
 
 ### Minor Changes

--- a/packages/foundry.thirdpartyapplications/package.json
+++ b/packages/foundry.thirdpartyapplications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.thirdpartyapplications",
-  "version": "3.0.0-beta.1",
+  "version": "2.0.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry/CHANGELOG.md
+++ b/packages/foundry/CHANGELOG.md
@@ -1,23 +1,5 @@
 # @osdk/foundry
 
-## 3.0.0-beta.1
-
-### Patch Changes
-
-- @osdk/foundry.admin@3.0.0-beta.1
-- @osdk/foundry.datasets@3.0.0-beta.1
-- @osdk/foundry.core@3.0.0-beta.1
-- @osdk/foundry.thirdpartyapplications@3.0.0-beta.1
-
-## 3.0.0-beta.0
-
-### Patch Changes
-
-- @osdk/foundry.admin@3.0.0-beta.0
-- @osdk/foundry.datasets@3.0.0-beta.0
-- @osdk/foundry.core@3.0.0-beta.0
-- @osdk/foundry.thirdpartyapplications@3.0.0-beta.0
-
 ## 2.0.0
 
 ### Minor Changes

--- a/packages/foundry/package.json
+++ b/packages/foundry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry",
-  "version": "3.0.0-beta.1",
+  "version": "2.0.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/platform-sdk-generator/src/generatePlatformSdkv2.ts
+++ b/packages/platform-sdk-generator/src/generatePlatformSdkv2.ts
@@ -224,11 +224,6 @@ const BASE_PACKAGE_JSON = {
     "typecheck": "tsc-absolute",
   },
   "dependencies": {},
-  "peerDependencies": {
-    "@osdk/api": "workspace:~",
-    "@osdk/client": "workspace:~",
-    "@osdk/shared.net": "workspace:~",
-  },
   "devDependencies": {
     "typescript": "^5.4.5",
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1560,21 +1560,12 @@ importers:
 
   packages/foundry.admin:
     dependencies:
-      '@osdk/api':
-        specifier: workspace:~
-        version: link:../api
-      '@osdk/client':
-        specifier: workspace:~
-        version: link:../client
       '@osdk/foundry.core':
         specifier: workspace:*
         version: link:../foundry.core
       '@osdk/shared.client':
         specifier: workspace:~
         version: link:../shared.client
-      '@osdk/shared.net':
-        specifier: workspace:~
-        version: link:../shared.net
       '@osdk/shared.net.platformapi':
         specifier: workspace:~
         version: link:../shared.net.platformapi
@@ -1616,21 +1607,12 @@ importers:
 
   packages/foundry.datasets:
     dependencies:
-      '@osdk/api':
-        specifier: workspace:~
-        version: link:../api
-      '@osdk/client':
-        specifier: workspace:~
-        version: link:../client
       '@osdk/foundry.core':
         specifier: workspace:*
         version: link:../foundry.core
       '@osdk/shared.client':
         specifier: workspace:~
         version: link:../shared.client
-      '@osdk/shared.net':
-        specifier: workspace:~
-        version: link:../shared.net
       '@osdk/shared.net.platformapi':
         specifier: workspace:~
         version: link:../shared.net.platformapi


### PR DESCRIPTION
The omni's got hit by the peerDependencies paradox (for lack of a better name). We already oops over to 2.x for them and almost went to 3.x so this gets us back to a stable state and they won't major rev with client updates any more.