### PR TITLE
Deprecate legacy entities

### DIFF
--- a/.changeset/late-ways-impress.md
+++ b/.changeset/late-ways-impress.md
@@ -1,0 +1,7 @@
+---
+"@osdk/e2e.generated.1.1.x": minor
+"@osdk/legacy-client": minor
+"@osdk/generator": minor
+---
+
+Deprecate basic legacy entities

--- a/packages/e2e.generated.1.1.x/src/generatedNoCheck/FoundryClient.ts
+++ b/packages/e2e.generated.1.1.x/src/generatedNoCheck/FoundryClient.ts
@@ -3,6 +3,9 @@ import { BaseFoundryClient } from '@osdk/legacy-client';
 import { Ontology } from './Ontology.js';
 
 export class FoundryClient<TAuth extends Auth = Auth> extends BaseFoundryClient<typeof Ontology, TAuth> {
+  /**
+   * @deprecated
+   */
   constructor(options: FoundryClientOptions<TAuth>) {
     super(options, Ontology);
   }

--- a/packages/e2e.generated.1.1.x/src/generatedNoCheck/ontology/actions/Actions.ts
+++ b/packages/e2e.generated.1.1.x/src/generatedNoCheck/ontology/actions/Actions.ts
@@ -21,6 +21,7 @@ export interface Actions {
    * @param {Timestamp} params.time-stamp
    * @param {Array<LocalDate>} params.dateArray
    * @param {Array<Attachment>} params.attachmentArray
+   * @deprecated
    */
   actionTakesAllParameterTypes<O extends ActionExecutionOptions>(
     params: {
@@ -36,6 +37,7 @@ export interface Actions {
 
   /**
    * Creates a new Todo
+   * @deprecated
    */
   createTodo<O extends ActionExecutionOptions>(
     options?: O,

--- a/packages/e2e.generated.1.1.x/src/generatedNoCheck/ontology/actions/BatchActions.ts
+++ b/packages/e2e.generated.1.1.x/src/generatedNoCheck/ontology/actions/BatchActions.ts
@@ -21,6 +21,7 @@ export interface BatchActions {
    * @param {Timestamp} params.time-stamp
    * @param {Array<LocalDate>} params.dateArray
    * @param {Array<Attachment>} params.attachmentArray
+   * @deprecated
    */
   actionTakesAllParameterTypes<O extends BatchActionExecutionOptions>(
     params: {
@@ -38,6 +39,7 @@ export interface BatchActions {
 
   /**
    * Creates a new Todo
+   * @deprecated
    */
   createTodo<O extends BatchActionExecutionOptions>(
     params: Record<string, never>[],

--- a/packages/e2e.generated.1.1.x/src/generatedNoCheck/ontology/queries/Queries.ts
+++ b/packages/e2e.generated.1.1.x/src/generatedNoCheck/ontology/queries/Queries.ts
@@ -34,6 +34,7 @@ export interface Queries {
    * @param {TwoDimensionalAggregation<string,number>} params.twoDimensionalAggregation
    * @param {ThreeDimensionalAggregation<Range<LocalDate>,Range<Timestamp>,LocalDate>} params.threeDimensionalAggregation
    * @returns string
+   * @deprecated
    */
   queryTakesAllParameterTypes(params: {
     double: number;
@@ -58,6 +59,7 @@ export interface Queries {
 
   /**
    * @returns number
+   * @deprecated
    */
   getTodoCount(): Promise<Result<QueryResponse<number>, QueryError>>;
 }

--- a/packages/generator/src/v1.1/generateActions.test.ts
+++ b/packages/generator/src/v1.1/generateActions.test.ts
@@ -46,6 +46,7 @@ describe(generateActions, () => {
           /**
            * An action which takes different types of parameters
            * @param {Todo | Todo["__primaryKey"]} params.object
+           * @deprecated
            */
           markTodoCompleted<O extends ActionExecutionOptions>(
             params: {
@@ -57,6 +58,7 @@ describe(generateActions, () => {
           /**
            * An action which takes in an array of objects
            * @param {Array<Todo | Todo["__primaryKey"]>} params.object
+           * @deprecated
            */
           deleteTodos<O extends ActionExecutionOptions>(
             params: {

--- a/packages/generator/src/v1.1/generateActions.ts
+++ b/packages/generator/src/v1.1/generateActions.ts
@@ -63,7 +63,7 @@ export async function generateActions(
       }
       parameterBlock += "}, ";
     }
-
+    jsDocBlock.push(`* @deprecated`);
     jsDocBlock.push(`*/`);
     actionSignatures.push(
       `

--- a/packages/generator/src/v1.1/generateBatchActions.test.ts
+++ b/packages/generator/src/v1.1/generateBatchActions.test.ts
@@ -46,6 +46,7 @@ describe(generateBatchActions, () => {
         /**
          * An action which takes different types of parameters
          * @param {Todo | Todo["__primaryKey"]} params.object
+         * @deprecated
          */
         markTodoCompleted<O extends BatchActionExecutionOptions>(
           params: {
@@ -57,6 +58,7 @@ describe(generateBatchActions, () => {
         /**
          * An action which takes in an array of objects
          * @param {Array<Todo | Todo["__primaryKey"]>} params.object
+         * @deprecated
          */
         deleteTodos<O extends BatchActionExecutionOptions>(
           params: {

--- a/packages/generator/src/v1.1/generateBatchActions.ts
+++ b/packages/generator/src/v1.1/generateBatchActions.ts
@@ -66,6 +66,7 @@ export async function generateBatchActions(
       parameterBlock = `params: Record<string,never>[], `;
     }
 
+    jsDocBlock.push(`* @deprecated`);
     jsDocBlock.push(`*/`);
     actionSignatures.push(
       `

--- a/packages/generator/src/v1.1/generateFoundryClientFile.test.ts
+++ b/packages/generator/src/v1.1/generateFoundryClientFile.test.ts
@@ -38,6 +38,9 @@ describe(generateFoundryClientFile, () => {
       import { Ontology } from './Ontology';
 
       export class FoundryClient<TAuth extends Auth = Auth> extends BaseFoundryClient<typeof Ontology, TAuth> {
+      /**
+       * @deprecated
+       */
         constructor(options: FoundryClientOptions<TAuth>) {
           super(options, Ontology);
         }

--- a/packages/generator/src/v1.1/generateFoundryClientFile.ts
+++ b/packages/generator/src/v1.1/generateFoundryClientFile.ts
@@ -31,6 +31,9 @@ export async function generateFoundryClientFile(
     import { Ontology } from "./Ontology${importExt}";
 
     export class FoundryClient<TAuth extends Auth = Auth> extends BaseFoundryClient<typeof Ontology, TAuth> {
+        /**
+         * @deprecated
+         */
         constructor(options: FoundryClientOptions<TAuth>) {
           super(options, Ontology);
         }

--- a/packages/generator/src/v1.1/generateQueries.test.ts
+++ b/packages/generator/src/v1.1/generateQueries.test.ts
@@ -37,12 +37,14 @@ describe(generateQueries, () => {
           /**
            * @param {boolean} params.completed
            * @returns number
+           * @deprecated
            */
           getCount(params: { completed: boolean }): Promise<Result<QueryResponse<number>, QueryError>>;
 
           /**
            * @param {Todo|Todo["__primaryKey"]} params.someTodo - Random desc so we test jsdoc
            * @returns Todo
+           * @deprecated
            */
           returnsTodo(params: { someTodo: Todo | Todo['__primaryKey'] }): Promise<Result<QueryResponse<Todo>, QueryError>>;
         }

--- a/packages/generator/src/v1.1/generateQueries.ts
+++ b/packages/generator/src/v1.1/generateQueries.ts
@@ -71,6 +71,7 @@ export async function generateQueries(
 
     jsDocBlock.push(
       `* @returns ${sanitizeDocTypeName(outputType)}`,
+      `* @deprecated`,
       "*/",
     );
 

--- a/packages/legacy-client/src/client/baseTypes/attachments/Attachment.ts
+++ b/packages/legacy-client/src/client/baseTypes/attachments/Attachment.ts
@@ -22,10 +22,12 @@ export interface Attachment {
   attachmentRid: string | undefined;
   /**
    * Get the metadata of an attachment.
+   * @deprecated
    */
   getMetadata(): Promise<Result<AttachmentMetadata, AttachmentsError>>;
   /**
    * Read the content of an attachment.
+   * @deprecated
    */
   read(): Promise<Result<Blob, AttachmentsError>>;
 }

--- a/packages/legacy-client/src/client/baseTypes/attachments/Attachments.ts
+++ b/packages/legacy-client/src/client/baseTypes/attachments/Attachments.ts
@@ -22,6 +22,11 @@ import type { AttachmentsError } from "../../errors/index.js";
 import type { Attachment } from "./Attachment.js";
 
 export interface Attachments {
+  /**
+   * @deprecated
+   * @param fileName
+   * @param data
+   */
   upload(
     fileName: string,
     data: Blob,

--- a/packages/legacy-client/src/client/baseTypes/objectset/FilteredPropertiesTerminalOperations.ts
+++ b/packages/legacy-client/src/client/baseTypes/objectset/FilteredPropertiesTerminalOperations.ts
@@ -55,6 +55,9 @@ export type FilteredPropertiesTerminalOperations<
     >
   >;
 
+  /**
+   * @deprecated
+   */
   asyncIter(): AsyncIterableIterator<
     Pick<
       T,
@@ -62,6 +65,10 @@ export type FilteredPropertiesTerminalOperations<
     >
   >;
 
+  /**
+   * @deprecated
+   * @param options
+   */
   fetchPage(options?: {
     pageSize?: number;
     pageToken?: string;
@@ -73,6 +80,10 @@ export type FilteredPropertiesTerminalOperations<
       >
     >
   >;
+  /**
+   * @deprecated
+   * @param options
+   */
   fetchPageWithErrors(options?: {
     pageSize?: number;
     pageToken?: string;
@@ -105,6 +116,10 @@ export type FilteredPropertiesTerminalOperationsWithGet<
       GetObjectError
     >
   >;
+  /**
+   * @deprecated
+   * @param primaryKey
+   */
   fetchOneWithErrors(
     primaryKey: T["$primaryKey"],
   ): Promise<
@@ -116,6 +131,10 @@ export type FilteredPropertiesTerminalOperationsWithGet<
       GetObjectError
     >
   >;
+  /**
+   * @deprecated
+   * @param primaryKey
+   */
   fetchOne(
     primaryKey: T["$primaryKey"],
   ): Promise<

--- a/packages/legacy-client/src/client/baseTypes/objectset/OntologyObjectSet.ts
+++ b/packages/legacy-client/src/client/baseTypes/objectset/OntologyObjectSet.ts
@@ -20,12 +20,24 @@ export interface OntologyObjectSet<
   TOntologyObject extends OntologyObject = OntologyObject,
 > {
   definition: ObjectSetDefinition;
+  /**
+   * @deprecated
+   * @param objectSet
+   */
   union(
     objectSet: OntologyObjectSet<TOntologyObject>,
   ): OntologyObjectSet<TOntologyObject>;
+  /**
+   * @deprecated
+   * @param objectSet
+   */
   intersect(
     objectSet: OntologyObjectSet<TOntologyObject>,
   ): OntologyObjectSet<TOntologyObject>;
+  /**
+   * deprecated
+   * @param objectSet
+   */
   subtract(
     objectSet: OntologyObjectSet<TOntologyObject>,
   ): OntologyObjectSet<TOntologyObject>;

--- a/packages/legacy-client/src/client/baseTypes/timeseries/TimeSeries.ts
+++ b/packages/legacy-client/src/client/baseTypes/timeseries/TimeSeries.ts
@@ -23,14 +23,17 @@ export interface TimeSeries<T extends number | string> {
   type: "TimeSeries";
   /**
    * Queries the First Point of the Time Series.
+   * @deprecated
    */
   getFirstPoint(): Promise<Result<TimeSeriesPoint<T>, TimeSeriesError>>;
   /**
    * Queries the Last Point of the Time Series.
+   * @deprecated
    */
   getLastPoint(): Promise<Result<TimeSeriesPoint<T>, TimeSeriesError>>;
   /**
    * Queries a stream of Time Series points using different operations and filters.
+   * @deprecated
    *
    * @example
    * const allPoints = object.property.points.all();

--- a/packages/legacy-client/src/client/baseTypes/timeseries/TimeSeriesQuery.ts
+++ b/packages/legacy-client/src/client/baseTypes/timeseries/TimeSeriesQuery.ts
@@ -35,6 +35,7 @@ export interface TimeSeriesQuery<T extends string | number>
 {
   /**
    * Creates a query to grab Time Series points from a specified duration in years from today.
+   * @deprecated
    *
    * @param value a number representing the duration of years.
    * @example
@@ -48,6 +49,7 @@ export interface TimeSeriesQuery<T extends string | number>
 
   /**
    * Creates a query to grab Time Series points from a specified duration in months from today.
+   * @deprecated
    *
    * @param value a number representing the duration of months.
    * @example
@@ -61,6 +63,7 @@ export interface TimeSeriesQuery<T extends string | number>
 
   /**
    * Creates a query to grab Time Series points from a specified duration in weeks from today.
+   * @deprecated
    *
    * @param value a number representing the duration of weeks.
    * @example
@@ -74,6 +77,7 @@ export interface TimeSeriesQuery<T extends string | number>
 
   /**
    * Creates a query to grab Time Series points from a specified duration in days from today.
+   * @deprecated
    *
    * @param value a number representing the duration of days.
    * @example
@@ -87,6 +91,7 @@ export interface TimeSeriesQuery<T extends string | number>
 
   /**
    * Creates a query to grab Time Series points from a specified duration in hours from today.
+   * @deprecated
    *
    * @param value a number representing the duration of hours.
    * @example
@@ -100,6 +105,7 @@ export interface TimeSeriesQuery<T extends string | number>
 
   /**
    * Creates a query to grab Time Series points from a specified duration in minutes from today.
+   * @deprecated
    *
    * @param value a number representing the duration of minutes.
    * @example
@@ -113,6 +119,7 @@ export interface TimeSeriesQuery<T extends string | number>
 
   /**
    * Creates a query to grab Time Series points from a specified duration in seconds from today.
+   * @deprecated
    *
    * @param value a number representing the duration of seconds.
    * @example
@@ -126,6 +133,7 @@ export interface TimeSeriesQuery<T extends string | number>
 
   /**
    * Creates a query to grab Time Series points from a specified duration in milliseconds from today.
+   * @deprecated
    *
    * @param value a number representing the duration of milliseconds.
    * @example
@@ -139,6 +147,7 @@ export interface TimeSeriesQuery<T extends string | number>
 
   /**
    * Creates a query to grab Time Series points between a specified start and end time.
+   * @deprecated
    *
    * @param range a query representing the specified start and time of the range of points.
    * @example

--- a/packages/legacy-client/src/client/interfaces/baseObjectSet.ts
+++ b/packages/legacy-client/src/client/interfaces/baseObjectSet.ts
@@ -38,14 +38,26 @@ export type BaseObjectSetOperations<O extends OntologyObject> = {
   /** @deprecated use fetchOneWithErrors instead */
   get(primaryKey: O["$primaryKey"]): Promise<Result<O, GetObjectError>>;
 
+  /**
+   * @deprecated
+   * @param primaryKey
+   */
   fetchOneWithErrors(
     primaryKey: O["$primaryKey"],
   ): Promise<Result<O, GetObjectError>>;
 
+  /**
+   * @deprecated
+   * @param primaryKey
+   */
   fetchOne(
     primaryKey: O["$primaryKey"],
   ): Promise<O>;
 
+  /**
+   * @deprecated
+   * @param properties
+   */
   select<T extends keyof SelectableProperties<O>>(
     properties: readonly T[],
   ): FilteredPropertiesTerminalOperationsWithGet<O, T[]>;

--- a/packages/legacy-client/src/client/interfaces/objectSet.ts
+++ b/packages/legacy-client/src/client/interfaces/objectSet.ts
@@ -51,26 +51,50 @@ export type ObjectSet<O extends OntologyObject> =
   >;
 
 export type ObjectSetOperations<O extends OntologyObject> = {
+  /**
+   * @deprecated
+   * @param predicate
+   */
   where(
     predicate: ObjectTypeFilterFunction<O>,
   ): ObjectSet<O>;
 
+  /**
+   * @deprecated
+   * @param otherObjectSets
+   */
   union(
     ...otherObjectSets: ObjectSet<O>[]
   ): ObjectSet<O>;
 
+  /**
+   * @deprecated
+   * @param otherObjectSets
+   */
   intersect(
     ...otherObjectSets: ObjectSet<O>[]
   ): ObjectSet<O>;
 
+  /**
+   * @deprecated
+   * @param otherObjectSets
+   */
   subtract(
     ...otherObjectSets: ObjectSet<O>[]
   ): ObjectSet<O>;
 
+  /**
+   * @deprecated
+   * @param properties
+   */
   select<T extends keyof SelectableProperties<O>>(
     properties: readonly T[],
   ): FilteredPropertiesTerminalOperations<O, T[]>;
 
+  /**
+   * @deprecated
+   * @param linkType
+   */
   pivotTo<
     K extends keyof LinksProperties<O>,
   >(
@@ -79,10 +103,19 @@ export type ObjectSetOperations<O extends OntologyObject> = {
 };
 
 export type ObjectSetOrderByStep<O extends OntologyObject> = {
+  /**
+   * @deprecated
+   * @param predicate
+   * @returns
+   */
   orderBy: (
     predicate: OrderByFunction<O>,
   ) => ObjectSetOrderByStep<O>;
 
+  /**
+   * @deprecated
+   * @param properties
+   */
   select<T extends keyof SelectableProperties<O>>(
     properties: readonly T[],
   ): FilteredPropertiesTerminalOperations<O, T[]>;
@@ -98,6 +131,10 @@ export type ObjectSetTerminalLoadStep<O extends OntologyObject> = {
     pageToken?: string;
   }): Promise<Result<Page<O>, ListObjectsError>>;
 
+  /**
+   * @deprecated
+   * @param options
+   */
   fetchPageWithErrors(options?: {
     pageSize?: number;
     pageToken?: string;
@@ -105,6 +142,7 @@ export type ObjectSetTerminalLoadStep<O extends OntologyObject> = {
 
   /**
    * Get a page of objects of this type, without a result wrapper
+   * @deprecated
    */
   fetchPage(options?: {
     pageSize?: number;
@@ -119,6 +157,7 @@ export type ObjectSetTerminalLoadStep<O extends OntologyObject> = {
 
   /**
    * Iterate through all objects
+   * @deprecated
    */
   asyncIter(): AsyncIterableIterator<O>;
 };

--- a/packages/legacy-client/src/client/objectSets/aggregations/Aggregations.ts
+++ b/packages/legacy-client/src/client/objectSets/aggregations/Aggregations.ts
@@ -145,6 +145,7 @@ export interface AggregatableObjectSetStep<
    * Group the results by a specified property
    *
    * @param propertySelector a function that selects the property to group by
+   * @deprecated
    */
   groupBy<TGroupKey extends BucketValue, TPropertyName extends string>(
     propertySelector: (
@@ -167,6 +168,7 @@ export interface GroupedTerminalAggregationOperations<
 > {
   /**
    * Computes the count of total objects.
+   * @deprecated
    */
   count(): AggregationComputeStep<
     TBucketGroup,
@@ -178,6 +180,7 @@ export interface GroupedTerminalAggregationOperations<
    * Compute the maximum value of the specified property.
    *
    * @param propertySelector A function that selects the property to find the maximum of.
+   * @deprecated
    */
   max<TResult extends MetricValue>(
     propertySelector: (
@@ -196,6 +199,7 @@ export interface GroupedTerminalAggregationOperations<
    * Computes the minimum of the specified property.
    *
    * @param propertySelector A function that selects the property to compute the minimum of.
+   * @deprecated
    */
   min<TResult extends MetricValue>(
     propertySelector: (
@@ -214,6 +218,7 @@ export interface GroupedTerminalAggregationOperations<
    * Computes approximate count of distinct values of the specified property.
    *
    * @param propertySelector A function that selects the property to count.
+   * @deprecated
    */
   approximateDistinct(
     propertySelector: (
@@ -224,6 +229,7 @@ export interface GroupedTerminalAggregationOperations<
    * Compute the average of the specified property.
    *
    * @param propertySelector A function that selects the property to calculate the average of.
+   * @deprecated
    */
   avg<TResult extends MetricValue>(
     propertySelector: (
@@ -242,6 +248,7 @@ export interface GroupedTerminalAggregationOperations<
    * Compute the sum of the specified property.
    *
    * @param propertySelector A function that selects the property to calculate the sum of.
+   * @deprecated
    */
   sum<TResult extends MetricValue>(
     propertySelector: (
@@ -256,6 +263,10 @@ export interface GroupedTerminalAggregationOperations<
       sum: TResult;
     }
   >;
+  /**
+   * @deprecated
+   * @param aggregateBuilder
+   */
   aggregate<
     TOperation extends
       | MultipleAggregationsOperations<MetricValue>

--- a/packages/legacy-client/src/client/objectSets/aggregations/ComputeStep.ts
+++ b/packages/legacy-client/src/client/objectSets/aggregations/ComputeStep.ts
@@ -71,7 +71,10 @@ export interface AggregationComputeStep<
   TBucketGroup extends BucketGroup,
   TMetrics extends Metrics | MetricValue,
 > {
-  /** Compute the specified aggregation(s) */
+  /**
+   * Compute the specified aggregation(s)
+   * @deprecated
+   */
   compute(): Promise<
     Result<AggregationResult<TBucketGroup, TMetrics>, AggregateObjectsError>
   >;

--- a/packages/legacy-client/src/oauth-client/ConfidentialClient/ConfidentialClientAuth.ts
+++ b/packages/legacy-client/src/oauth-client/ConfidentialClient/ConfidentialClientAuth.ts
@@ -38,6 +38,7 @@ export class ConfidentialClientAuth implements Auth {
    * @param options.url The base URL of the OAuth server (required).
    * @param options.multipassContextPath The context path for the multipass authentication (optional).
    * @param options.scopes An array of strings representing the requested OAuth scopes (optional).
+   * @deprecated
    */
   constructor(
     private options: {

--- a/packages/legacy-client/src/oauth-client/PublicClient/PublicClientAuth.ts
+++ b/packages/legacy-client/src/oauth-client/PublicClient/PublicClientAuth.ts
@@ -54,6 +54,7 @@ export class PublicClientAuth implements Auth {
    * @param options.redirectUrl The URL where the OAuth server should redirect the user after authentication (required).
    * @param options.multipassContextPath The context path for the multipass authentication (optional).
    * @param options.scopes An array of strings representing the requested OAuth scopes (optional).
+   * @deprecated
    */
   constructor(
     private options: {


### PR DESCRIPTION
Deprecating legacy entities

**What we deprecated**

- All base object set calls
- FoundryClient constructor
- Public and Confidential OAuth client constructors
- Any special property methods (e.g. for attachments and timeseries)
- All actions and queries


