### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -68,7 +68,35 @@
     "@osdk/tool.release": "0.4.0",
     "@osdk/version-updater": "0.0.0",
     "@osdk/tests.verify-fallback-package": "0.0.3",
-    "@osdk/tests.verify-fallback-package-v2": "0.0.3"
+    "@osdk/tests.verify-fallback-package-v2": "0.0.3",
+    "@osdk/client.unstable.tpsa": "0.1.0",
+    "@osdk/e2e.generated.api-namespace.dep": "0.0.0",
+    "@osdk/e2e.generated.api-namespace.local": "0.0.0",
+    "@osdk/foundry.filesystem": "0.0.0",
+    "@osdk/foundry.orchestration": "0.0.0",
+    "@osdk/foundry.publicapis": "0.0.0"
   },
-  "changesets": []
+  "changesets": [
+    "blue-rivers-enjoy",
+    "bright-gorillas-draw",
+    "bright-panthers-lick",
+    "clever-rings-yawn",
+    "cuddly-flies-smash",
+    "eight-swans-help",
+    "five-wasps-design",
+    "four-ants-complain",
+    "late-students-sleep",
+    "lemon-schools-develop",
+    "lovely-kangaroos-think",
+    "modern-boats-lick",
+    "moody-parrots-sing",
+    "nasty-seals-camp",
+    "olive-crabs-exercise",
+    "quiet-mails-attend",
+    "short-bottles-sniff",
+    "small-beans-travel",
+    "stale-plants-itch",
+    "violet-apples-end",
+    "weak-masks-suffer"
+  ]
 }

--- a/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '0.21.0';
+export type $ExpectedClientVersion = '0.22.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/cli.cmd.typescript
 
+## 0.6.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [ac4f4fd]
+- Updated dependencies [7494995]
+- Updated dependencies [1770490]
+  - @osdk/generator@1.14.0-beta.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/cli
 
+## 0.24.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [ac4f4fd]
+- Updated dependencies [7494995]
+- Updated dependencies [1770490]
+  - @osdk/generator@1.14.0-beta.0
+
 ## 0.23.0
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.23.0",
+  "version": "0.24.0-beta.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client.api/CHANGELOG.md
+++ b/packages/client.api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/client.api
 
+## 0.22.0-beta.0
+
+### Minor Changes
+
+- a2c7b37: Add docs for object sets and attachments.
+- 795777a: Change how queries are executed, now use executeFunction call instead
+
 ## 0.21.0
 
 ### Minor Changes

--- a/packages/client.api/package.json
+++ b/packages/client.api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.api",
-  "version": "0.21.0",
+  "version": "0.22.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.test.ontology/CHANGELOG.md
+++ b/packages/client.test.ontology/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/client.test.ontology
 
+## 1.2.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [a2c7b37]
+- Updated dependencies [795777a]
+  - @osdk/client.api@0.22.0-beta.0
+
 ## 1.1.0
 
 ### Patch Changes

--- a/packages/client.test.ontology/package.json
+++ b/packages/client.test.ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/client.test.ontology",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,27 @@
 # @osdk/client
 
+## 0.22.0-beta.0
+
+### Minor Changes
+
+- ac4f4fd: Notable changes:
+  - `{{actionApiName}}$Params` is deprecated in favor of `ActionParams${{actionApiName}}`.
+  - All generated `{{actionApiName}}$Params` objects are now exported from generated code.
+  - All `{{actionApiName}}$Params` are marked as `readonly`.
+  - Some types that are now only needed in `@osdk/client` have been moved back out of `@osdk/client.api`.
+  - Generated `ActionParams${{actionApiName}}` are simpler and do not rely on type mapping for the keys, the array'ness, nor multiplicity.
+  - `AttachmentUpload.name` is now `readonly`.
+- f86f8d0: Re-enable X-OSDK-Request-Context header
+- a2c7b37: Add docs for object sets and attachments.
+- 5a41e5e: Adds version compatibility checks to Queries
+- 795777a: Change how queries are executed, now use executeFunction call instead
+
+### Patch Changes
+
+- Updated dependencies [a2c7b37]
+- Updated dependencies [795777a]
+  - @osdk/client.api@0.22.0-beta.0
+
 ## 0.21.0
 
 ### Minor Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client",
-  "version": "0.21.0",
+  "version": "0.22.0-beta.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -51,7 +51,7 @@ export interface Client extends SharedClient<MinimalClient> {
 }
 
 // BEGIN: THIS IS GENERATED CODE. DO NOT EDIT.
-const MaxOsdkVersion = "0.21.0";
+const MaxOsdkVersion = "0.22.0";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 export type MaxOsdkVersion = typeof MaxOsdkVersion;
 const ErrorMessage = Symbol("ErrorMessage");

--- a/packages/create-app.template.next-static-export/CHANGELOG.md
+++ b/packages/create-app.template.next-static-export/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.next-static-export
 
+## 0.19.0-beta.0
+
 ## 0.18.0
 
 ## 0.18.0-beta.0

--- a/packages/create-app.template.next-static-export/package.json
+++ b/packages/create-app.template.next-static-export/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.next-static-export",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.19.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react/CHANGELOG.md
+++ b/packages/create-app.template.react/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.react
 
+## 0.19.0-beta.0
+
 ## 0.18.0
 
 ## 0.18.0-beta.0

--- a/packages/create-app.template.react/package.json
+++ b/packages/create-app.template.react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.19.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/create-app.template.tutorial-todo-aip-app
 
+## 0.19.0-beta.0
+
+### Minor Changes
+
+- 0131ade: Update tutorial template READMEs to match others
+
 ## 0.18.0
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-aip-app/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.19.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/create-app.template.tutorial-todo-app
 
+## 0.19.0-beta.0
+
+### Minor Changes
+
+- 0131ade: Update tutorial template READMEs to match others
+
 ## 0.18.0
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-app/package.json
+++ b/packages/create-app.template.tutorial-todo-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.19.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.vue/CHANGELOG.md
+++ b/packages/create-app.template.vue/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.vue
 
+## 0.19.0-beta.0
+
 ## 0.18.0
 
 ## 0.18.0-beta.0

--- a/packages/create-app.template.vue/package.json
+++ b/packages/create-app.template.vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.vue",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.19.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app
 
+## 0.19.0-beta.0
+
 ## 0.18.0
 
 ### Minor Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-app",
-  "version": "0.18.0",
+  "version": "0.19.0-beta.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/e2e.generated.1.1.x/CHANGELOG.md
+++ b/packages/e2e.generated.1.1.x/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/e2e.generated.1.1.x
 
+## 0.3.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [ac4f4fd]
+- Updated dependencies [7494995]
+- Updated dependencies [1770490]
+  - @osdk/generator@1.14.0-beta.0
+  - @osdk/legacy-client@2.5.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/e2e.generated.1.1.x/package.json
+++ b/packages/e2e.generated.1.1.x/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.generated.1.1.x",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0-beta.0",
   "description": "",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/e2e.generated.api-namespace.dep/CHANGELOG.md
+++ b/packages/e2e.generated.api-namespace.dep/CHANGELOG.md
@@ -1,0 +1,17 @@
+# @osdk/e2e.generated.api-namespace.dep
+
+## 1.0.0-beta.0
+
+### Minor Changes
+
+- fa33757: Update imports no longer point at index
+
+### Patch Changes
+
+- Updated dependencies [ac4f4fd]
+- Updated dependencies [f86f8d0]
+- Updated dependencies [a2c7b37]
+- Updated dependencies [5a41e5e]
+- Updated dependencies [795777a]
+  - @osdk/client@0.22.0-beta.0
+  - @osdk/client.api@0.22.0-beta.0

--- a/packages/e2e.generated.api-namespace.dep/package.json
+++ b/packages/e2e.generated.api-namespace.dep/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.generated.api-namespace.dep",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,2 +1,2 @@
-export type $ExpectedClientVersion = '0.21.0';
+export type $ExpectedClientVersion = '0.22.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };

--- a/packages/e2e.generated.api-namespace.local/CHANGELOG.md
+++ b/packages/e2e.generated.api-namespace.local/CHANGELOG.md
@@ -1,0 +1,19 @@
+# @osdk/e2e.generated.api-namespace.local
+
+## 1.0.0-beta.0
+
+### Minor Changes
+
+- fa33757: Update imports no longer point at index
+
+### Patch Changes
+
+- Updated dependencies [ac4f4fd]
+- Updated dependencies [f86f8d0]
+- Updated dependencies [a2c7b37]
+- Updated dependencies [5a41e5e]
+- Updated dependencies [fa33757]
+- Updated dependencies [795777a]
+  - @osdk/client@0.22.0-beta.0
+  - @osdk/client.api@0.22.0-beta.0
+  - @osdk/e2e.generated.api-namespace.dep@1.0.0-beta.0

--- a/packages/e2e.generated.api-namespace.local/package.json
+++ b/packages/e2e.generated.api-namespace.local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.generated.api-namespace.local",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '0.21.0';
+export type $ExpectedClientVersion = '0.22.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.dep';

--- a/packages/e2e.generated.catchall/CHANGELOG.md
+++ b/packages/e2e.generated.catchall/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/e2e.generated.catchall
 
+## 3.0.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [ac4f4fd]
+- Updated dependencies [f86f8d0]
+- Updated dependencies [a2c7b37]
+- Updated dependencies [5a41e5e]
+- Updated dependencies [795777a]
+  - @osdk/client@0.22.0-beta.0
+  - @osdk/client.api@0.22.0-beta.0
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/e2e.generated.catchall/package.json
+++ b/packages/e2e.generated.catchall/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.generated.catchall",
   "private": true,
-  "version": "2.0.0",
+  "version": "3.0.0-beta.0",
   "description": "",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '0.21.0';
+export type $ExpectedClientVersion = '0.22.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';

--- a/packages/e2e.sandbox.catchall/CHANGELOG.md
+++ b/packages/e2e.sandbox.catchall/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @osdk/e2e.sandbox.catchall
 
+## 0.3.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [ac4f4fd]
+- Updated dependencies [f86f8d0]
+- Updated dependencies [a2c7b37]
+- Updated dependencies [5d6d5ab]
+- Updated dependencies [5a41e5e]
+- Updated dependencies [795777a]
+- Updated dependencies [5d6d5ab]
+  - @osdk/client@0.22.0-beta.0
+  - @osdk/client.api@0.22.0-beta.0
+  - @osdk/internal.foundry@0.5.0-beta.0
+  - @osdk/foundry@2.1.0-beta.0
+  - @osdk/e2e.generated.catchall@3.0.0-beta.0
+
 ## 0.2.0
 
 ### Patch Changes

--- a/packages/e2e.sandbox.catchall/package.json
+++ b/packages/e2e.sandbox.catchall/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.sandbox.catchall",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.sandbox.oauth/CHANGELOG.md
+++ b/packages/e2e.sandbox.oauth/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/e2e.sandbox.oauth
 
+## 0.3.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [ac4f4fd]
+- Updated dependencies [f86f8d0]
+- Updated dependencies [a2c7b37]
+- Updated dependencies [5a41e5e]
+- Updated dependencies [795777a]
+  - @osdk/client@0.22.0-beta.0
+
 ## 0.2.0
 
 ### Patch Changes

--- a/packages/e2e.sandbox.oauth/package.json
+++ b/packages/e2e.sandbox.oauth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.sandbox.oauth",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.sandbox.todoapp/CHANGELOG.md
+++ b/packages/e2e.sandbox.todoapp/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/e2e.sandbox.todoappapp
 
+## 3.0.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [ac4f4fd]
+- Updated dependencies [f86f8d0]
+- Updated dependencies [a2c7b37]
+- Updated dependencies [5a41e5e]
+- Updated dependencies [795777a]
+  - @osdk/client@0.22.0-beta.0
+  - @osdk/client.api@0.22.0-beta.0
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/e2e.sandbox.todoapp/package.json
+++ b/packages/e2e.sandbox.todoapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.sandbox.todoapp",
   "private": true,
-  "version": "2.0.0",
+  "version": "3.0.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/OntologyMetadata.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '0.21.0';
+export type $ExpectedClientVersion = '0.22.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';

--- a/packages/example-generator/CHANGELOG.md
+++ b/packages/example-generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/example-generator
 
+## 0.8.0-beta.0
+
+### Patch Changes
+
+- @osdk/create-app@0.19.0-beta.0
+
 ## 0.7.0
 
 ### Patch Changes

--- a/packages/example-generator/package.json
+++ b/packages/example-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/example-generator",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.8.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @osdk/foundry-sdk-generator
 
+## 1.4.0-beta.0
+
+### Minor Changes
+
+- ff718df: Fixes an issue where ambiguous ontology api names can conflict. Used rid instead.
+- 9eb7c6e: Restore cjs exports
+
+### Patch Changes
+
+- Updated dependencies [ac4f4fd]
+- Updated dependencies [f86f8d0]
+- Updated dependencies [a2c7b37]
+- Updated dependencies [7494995]
+- Updated dependencies [1770490]
+- Updated dependencies [5a41e5e]
+- Updated dependencies [795777a]
+  - @osdk/generator@1.14.0-beta.0
+  - @osdk/client@0.22.0-beta.0
+  - @osdk/client.api@0.22.0-beta.0
+  - @osdk/legacy-client@2.5.0
+
 ## 1.3.0
 
 ### Patch Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "1.3.0",
+  "version": "1.4.0-beta.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/foundry.admin/CHANGELOG.md
+++ b/packages/foundry.admin/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/foundry.admin
 
+## 2.1.0-beta.0
+
+### Minor Changes
+
+- 5d6d5ab: Updated to latest gateway apis
+- 5d6d5ab: Includes @alpha/@beta/@public jsdoc tags
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+- Updated dependencies [5d6d5ab]
+  - @osdk/foundry.core@2.1.0-beta.0
+
 ## 2.0.0
 
 ### Minor Changes

--- a/packages/foundry.admin/package.json
+++ b/packages/foundry.admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.admin",
-  "version": "2.0.0",
+  "version": "2.1.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.core/CHANGELOG.md
+++ b/packages/foundry.core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/foundry.core
 
+## 2.1.0-beta.0
+
+### Minor Changes
+
+- 5d6d5ab: Updated to latest gateway apis
+- 5d6d5ab: Includes @alpha/@beta/@public jsdoc tags
+
 ## 2.0.0
 
 ### Minor Changes

--- a/packages/foundry.core/package.json
+++ b/packages/foundry.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.core",
-  "version": "2.0.0",
+  "version": "2.1.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.datasets/CHANGELOG.md
+++ b/packages/foundry.datasets/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @osdk/foundry.datasets
 
+## 2.1.0-beta.0
+
+### Minor Changes
+
+- 1770490: URLs in jsdoc now link to palantir.com
+- 5d6d5ab: Updated to latest gateway apis
+- 5d6d5ab: Includes @alpha/@beta/@public jsdoc tags
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+- Updated dependencies [5d6d5ab]
+  - @osdk/foundry.core@2.1.0-beta.0
+  - @osdk/foundry.filesystem@2.1.0-beta.0
+
 ### Patch Changes
 
 - Updated dependencies [2deb4d9]

--- a/packages/foundry.datasets/package.json
+++ b/packages/foundry.datasets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.datasets",
-  "version": "2.0.0",
+  "version": "2.1.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.filesystem/CHANGELOG.md
+++ b/packages/foundry.filesystem/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @osdk/foundry.filesystem
+
+## 2.1.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+- Updated dependencies [5d6d5ab]
+  - @osdk/foundry.core@2.1.0-beta.0

--- a/packages/foundry.filesystem/package.json
+++ b/packages/foundry.filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.filesystem",
-  "version": "0.0.0",
+  "version": "2.1.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.orchestration/CHANGELOG.md
+++ b/packages/foundry.orchestration/CHANGELOG.md
@@ -1,0 +1,17 @@
+# @osdk/foundry.orchestration
+
+## 2.1.0-beta.0
+
+### Minor Changes
+
+- 5d6d5ab: Updated to latest gateway apis
+- 5d6d5ab: Includes @alpha/@beta/@public jsdoc tags
+
+### Patch Changes
+
+- Updated dependencies [1770490]
+- Updated dependencies [5d6d5ab]
+- Updated dependencies [5d6d5ab]
+  - @osdk/foundry.datasets@2.1.0-beta.0
+  - @osdk/foundry.core@2.1.0-beta.0
+  - @osdk/foundry.filesystem@2.1.0-beta.0

--- a/packages/foundry.orchestration/package.json
+++ b/packages/foundry.orchestration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.orchestration",
-  "version": "0.0.0",
+  "version": "2.1.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.publicapis/CHANGELOG.md
+++ b/packages/foundry.publicapis/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @osdk/foundry.publicapis
+
+## 2.1.0-beta.0
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+- Updated dependencies [5d6d5ab]
+  - @osdk/foundry.core@2.1.0-beta.0

--- a/packages/foundry.publicapis/package.json
+++ b/packages/foundry.publicapis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.publicapis",
-  "version": "0.0.0",
+  "version": "2.1.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.thirdpartyapplications/CHANGELOG.md
+++ b/packages/foundry.thirdpartyapplications/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/foundry.thirdpartyapplications
 
+## 2.1.0-beta.0
+
+### Minor Changes
+
+- 5d6d5ab: Updated to latest gateway apis
+- 5d6d5ab: Includes @alpha/@beta/@public jsdoc tags
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+- Updated dependencies [5d6d5ab]
+  - @osdk/foundry.core@2.1.0-beta.0
+
 ## 2.0.0
 
 ### Minor Changes

--- a/packages/foundry.thirdpartyapplications/package.json
+++ b/packages/foundry.thirdpartyapplications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.thirdpartyapplications",
-  "version": "2.0.0",
+  "version": "2.1.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry/CHANGELOG.md
+++ b/packages/foundry/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @osdk/foundry
 
+## 2.1.0-beta.0
+
+### Minor Changes
+
+- 5d6d5ab: Updated to latest gateway apis
+- 5d6d5ab: Includes @alpha/@beta/@public jsdoc tags
+
+### Patch Changes
+
+- Updated dependencies [1770490]
+- Updated dependencies [5d6d5ab]
+- Updated dependencies [5d6d5ab]
+  - @osdk/foundry.datasets@2.1.0-beta.0
+  - @osdk/foundry.thirdpartyapplications@2.1.0-beta.0
+  - @osdk/foundry.orchestration@2.1.0-beta.0
+  - @osdk/foundry.admin@2.1.0-beta.0
+  - @osdk/foundry.core@2.1.0-beta.0
+  - @osdk/foundry.filesystem@2.1.0-beta.0
+  - @osdk/foundry.publicapis@2.1.0-beta.0
+
 ## 2.0.0
 
 ### Minor Changes

--- a/packages/foundry/package.json
+++ b/packages/foundry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry",
-  "version": "2.0.0",
+  "version": "2.1.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @osdk/generator
 
+## 1.14.0-beta.0
+
+### Minor Changes
+
+- ac4f4fd: Notable changes:
+  - `{{actionApiName}}$Params` is deprecated in favor of `ActionParams${{actionApiName}}`.
+  - All generated `{{actionApiName}}$Params` objects are now exported from generated code.
+  - All `{{actionApiName}}$Params` are marked as `readonly`.
+  - Some types that are now only needed in `@osdk/client` have been moved back out of `@osdk/client.api`.
+  - Generated `ActionParams${{actionApiName}}` are simpler and do not rely on type mapping for the keys, the array'ness, nor multiplicity.
+  - `AttachmentUpload.name` is now `readonly`.
+- 7494995: Internal changes to file paths
+- 1770490: URLs in jsdoc now link to palantir.com
+
 ## 1.13.0
 
 ### Minor Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "1.13.0",
+  "version": "1.14.0-beta.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator/src/v2.0/generateMetadata.ts
+++ b/packages/generator/src/v2.0/generateMetadata.ts
@@ -19,7 +19,7 @@ import type { GenerateContext } from "../GenerateContext/GenerateContext.js";
 import { formatTs } from "../util/test/formatTs.js";
 
 // BEGIN: THIS IS GENERATED CODE. DO NOT EDIT.
-const ExpectedOsdkVersion = "0.21.0";
+const ExpectedOsdkVersion = "0.22.0";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 
 export async function generateOntologyMetadataFile(

--- a/packages/internal.foundry.core/CHANGELOG.md
+++ b/packages/internal.foundry.core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/internal.foundry.core
 
+## 0.2.0-beta.0
+
+### Minor Changes
+
+- 5d6d5ab: Updated to latest gateway apis
+- 5d6d5ab: Includes @alpha/@beta/@public jsdoc tags
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/internal.foundry.core/package.json
+++ b/packages/internal.foundry.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.core",
-  "version": "0.1.0",
+  "version": "0.2.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.datasets/CHANGELOG.md
+++ b/packages/internal.foundry.datasets/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @osdk/internal.foundry.datasets
 
+## 0.2.0-beta.0
+
+### Minor Changes
+
+- 1770490: URLs in jsdoc now link to palantir.com
+- 5d6d5ab: Updated to latest gateway apis
+- 5d6d5ab: Includes @alpha/@beta/@public jsdoc tags
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+- Updated dependencies [5d6d5ab]
+  - @osdk/internal.foundry.core@0.2.0-beta.0
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/internal.foundry.datasets/package.json
+++ b/packages/internal.foundry.datasets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.datasets",
-  "version": "0.1.0",
+  "version": "0.2.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.models/CHANGELOG.md
+++ b/packages/internal.foundry.models/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @osdk/internal.foundry.models
 
+## 0.2.0-beta.0
+
+### Minor Changes
+
+- 1770490: URLs in jsdoc now link to palantir.com
+- 5d6d5ab: Updated to latest gateway apis
+- 5d6d5ab: Includes @alpha/@beta/@public jsdoc tags
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+- Updated dependencies [5d6d5ab]
+  - @osdk/internal.foundry.core@0.2.0-beta.0
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/internal.foundry.models/package.json
+++ b/packages/internal.foundry.models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.models",
-  "version": "0.1.0",
+  "version": "0.2.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.ontologies/CHANGELOG.md
+++ b/packages/internal.foundry.ontologies/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @osdk/internal.foundry.ontologies
 
+## 0.2.0-beta.0
+
+### Minor Changes
+
+- 1770490: URLs in jsdoc now link to palantir.com
+- 5d6d5ab: Updated to latest gateway apis
+- 5d6d5ab: Includes @alpha/@beta/@public jsdoc tags
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+- Updated dependencies [5d6d5ab]
+  - @osdk/internal.foundry.core@0.2.0-beta.0
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/internal.foundry.ontologies/package.json
+++ b/packages/internal.foundry.ontologies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.ontologies",
-  "version": "0.1.0",
+  "version": "0.2.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.ontologiesv2/CHANGELOG.md
+++ b/packages/internal.foundry.ontologiesv2/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @osdk/internal.foundry.ontologiesv2
 
+## 0.2.0-beta.0
+
+### Minor Changes
+
+- 1770490: URLs in jsdoc now link to palantir.com
+- 5d6d5ab: Updated to latest gateway apis
+- 5d6d5ab: Includes @alpha/@beta/@public jsdoc tags
+
+### Patch Changes
+
+- Updated dependencies [1770490]
+- Updated dependencies [5d6d5ab]
+- Updated dependencies [5d6d5ab]
+  - @osdk/internal.foundry.ontologies@0.2.0-beta.0
+  - @osdk/internal.foundry.core@0.2.0-beta.0
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/internal.foundry.ontologiesv2/package.json
+++ b/packages/internal.foundry.ontologiesv2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.ontologiesv2",
-  "version": "0.1.0",
+  "version": "0.2.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry/CHANGELOG.md
+++ b/packages/internal.foundry/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @osdk/foundry
 
+## 0.5.0-beta.0
+
+### Minor Changes
+
+- 5d6d5ab: Updated to latest gateway apis
+- 5d6d5ab: Includes @alpha/@beta/@public jsdoc tags
+
+### Patch Changes
+
+- Updated dependencies [1770490]
+- Updated dependencies [5d6d5ab]
+- Updated dependencies [5d6d5ab]
+  - @osdk/internal.foundry.ontologiesv2@0.2.0-beta.0
+  - @osdk/internal.foundry.ontologies@0.2.0-beta.0
+  - @osdk/internal.foundry.datasets@0.2.0-beta.0
+  - @osdk/internal.foundry.models@0.2.0-beta.0
+  - @osdk/internal.foundry.core@0.2.0-beta.0
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/internal.foundry/package.json
+++ b/packages/internal.foundry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/internal.foundry",
   "private": "true",
-  "version": "0.4.0",
+  "version": "0.5.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/platform-sdk-generator/CHANGELOG.md
+++ b/packages/platform-sdk-generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/platform-sdk-generator
 
+## 0.5.0-beta.0
+
+### Minor Changes
+
+- 0441dab: Generates @alpha/@beta/@public jsdoc tags
+- 1770490: URLs in jsdoc now link to palantir.com
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/platform-sdk-generator/package.json
+++ b/packages/platform-sdk-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/platform-sdk-generator",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/client@0.22.0-beta.0

### Minor Changes

-   ac4f4fd: Notable changes:
    -   `{{actionApiName}}$Params` is deprecated in favor of `ActionParams${{actionApiName}}`.
    -   All generated `{{actionApiName}}$Params` objects are now exported from generated code.
    -   All `{{actionApiName}}$Params` are marked as `readonly`.
    -   Some types that are now only needed in `@osdk/client` have been moved back out of `@osdk/client.api`.
    -   Generated `ActionParams${{actionApiName}}` are simpler and do not rely on type mapping for the keys, the array'ness, nor multiplicity.
    -   `AttachmentUpload.name` is now `readonly`.
-   f86f8d0: Re-enable X-OSDK-Request-Context header
-   a2c7b37: Add docs for object sets and attachments.
-   5a41e5e: Adds version compatibility checks to Queries
-   795777a: Change how queries are executed, now use executeFunction call instead

### Patch Changes

-   Updated dependencies [a2c7b37]
-   Updated dependencies [795777a]
    -   @osdk/client.api@0.22.0-beta.0

## @osdk/client.api@0.22.0-beta.0

### Minor Changes

-   a2c7b37: Add docs for object sets and attachments.
-   795777a: Change how queries are executed, now use executeFunction call instead

## @osdk/foundry@2.1.0-beta.0

### Minor Changes

-   5d6d5ab: Updated to latest gateway apis
-   5d6d5ab: Includes @alpha/@beta/@public jsdoc tags

### Patch Changes

-   Updated dependencies [1770490]
-   Updated dependencies [5d6d5ab]
-   Updated dependencies [5d6d5ab]
    -   @osdk/foundry.datasets@2.1.0-beta.0
    -   @osdk/foundry.thirdpartyapplications@2.1.0-beta.0
    -   @osdk/foundry.orchestration@2.1.0-beta.0
    -   @osdk/foundry.admin@2.1.0-beta.0
    -   @osdk/foundry.core@2.1.0-beta.0
    -   @osdk/foundry.filesystem@2.1.0-beta.0
    -   @osdk/foundry.publicapis@2.1.0-beta.0

## @osdk/foundry-sdk-generator@1.4.0-beta.0

### Minor Changes

-   ff718df: Fixes an issue where ambiguous ontology api names can conflict. Used rid instead.
-   9eb7c6e: Restore cjs exports

### Patch Changes

-   Updated dependencies [ac4f4fd]
-   Updated dependencies [f86f8d0]
-   Updated dependencies [a2c7b37]
-   Updated dependencies [7494995]
-   Updated dependencies [1770490]
-   Updated dependencies [5a41e5e]
-   Updated dependencies [795777a]
    -   @osdk/generator@1.14.0-beta.0
    -   @osdk/client@0.22.0-beta.0
    -   @osdk/client.api@0.22.0-beta.0
    -   @osdk/legacy-client@2.5.0

## @osdk/foundry.admin@2.1.0-beta.0

### Minor Changes

-   5d6d5ab: Updated to latest gateway apis
-   5d6d5ab: Includes @alpha/@beta/@public jsdoc tags

### Patch Changes

-   Updated dependencies [5d6d5ab]
-   Updated dependencies [5d6d5ab]
    -   @osdk/foundry.core@2.1.0-beta.0

## @osdk/foundry.core@2.1.0-beta.0

### Minor Changes

-   5d6d5ab: Updated to latest gateway apis
-   5d6d5ab: Includes @alpha/@beta/@public jsdoc tags

## @osdk/foundry.datasets@2.1.0-beta.0

### Minor Changes

-   1770490: URLs in jsdoc now link to palantir.com
-   5d6d5ab: Updated to latest gateway apis
-   5d6d5ab: Includes @alpha/@beta/@public jsdoc tags

### Patch Changes

-   Updated dependencies [5d6d5ab]
-   Updated dependencies [5d6d5ab]
    -   @osdk/foundry.core@2.1.0-beta.0
    -   @osdk/foundry.filesystem@2.1.0-beta.0

### Patch Changes

-   Updated dependencies [2deb4d9]
-   Updated dependencies [e54f413]
-   Updated dependencies [6387a92]
-   Updated dependencies [651c1b8]
    -   @osdk/client@0.21.0-beta.0
    -   @osdk/foundry.core@3.0.0-beta.0

## @osdk/foundry.orchestration@2.1.0-beta.0

### Minor Changes

-   5d6d5ab: Updated to latest gateway apis
-   5d6d5ab: Includes @alpha/@beta/@public jsdoc tags

### Patch Changes

-   Updated dependencies [1770490]
-   Updated dependencies [5d6d5ab]
-   Updated dependencies [5d6d5ab]
    -   @osdk/foundry.datasets@2.1.0-beta.0
    -   @osdk/foundry.core@2.1.0-beta.0
    -   @osdk/foundry.filesystem@2.1.0-beta.0

## @osdk/foundry.thirdpartyapplications@2.1.0-beta.0

### Minor Changes

-   5d6d5ab: Updated to latest gateway apis
-   5d6d5ab: Includes @alpha/@beta/@public jsdoc tags

### Patch Changes

-   Updated dependencies [5d6d5ab]
-   Updated dependencies [5d6d5ab]
    -   @osdk/foundry.core@2.1.0-beta.0

## @osdk/generator@1.14.0-beta.0

### Minor Changes

-   ac4f4fd: Notable changes:
    -   `{{actionApiName}}$Params` is deprecated in favor of `ActionParams${{actionApiName}}`.
    -   All generated `{{actionApiName}}$Params` objects are now exported from generated code.
    -   All `{{actionApiName}}$Params` are marked as `readonly`.
    -   Some types that are now only needed in `@osdk/client` have been moved back out of `@osdk/client.api`.
    -   Generated `ActionParams${{actionApiName}}` are simpler and do not rely on type mapping for the keys, the array'ness, nor multiplicity.
    -   `AttachmentUpload.name` is now `readonly`.
-   7494995: Internal changes to file paths
-   1770490: URLs in jsdoc now link to palantir.com

## @osdk/internal.foundry.core@0.2.0-beta.0

### Minor Changes

-   5d6d5ab: Updated to latest gateway apis
-   5d6d5ab: Includes @alpha/@beta/@public jsdoc tags

## @osdk/internal.foundry.datasets@0.2.0-beta.0

### Minor Changes

-   1770490: URLs in jsdoc now link to palantir.com
-   5d6d5ab: Updated to latest gateway apis
-   5d6d5ab: Includes @alpha/@beta/@public jsdoc tags

### Patch Changes

-   Updated dependencies [5d6d5ab]
-   Updated dependencies [5d6d5ab]
    -   @osdk/internal.foundry.core@0.2.0-beta.0

## @osdk/internal.foundry.models@0.2.0-beta.0

### Minor Changes

-   1770490: URLs in jsdoc now link to palantir.com
-   5d6d5ab: Updated to latest gateway apis
-   5d6d5ab: Includes @alpha/@beta/@public jsdoc tags

### Patch Changes

-   Updated dependencies [5d6d5ab]
-   Updated dependencies [5d6d5ab]
    -   @osdk/internal.foundry.core@0.2.0-beta.0

## @osdk/internal.foundry.ontologies@0.2.0-beta.0

### Minor Changes

-   1770490: URLs in jsdoc now link to palantir.com
-   5d6d5ab: Updated to latest gateway apis
-   5d6d5ab: Includes @alpha/@beta/@public jsdoc tags

### Patch Changes

-   Updated dependencies [5d6d5ab]
-   Updated dependencies [5d6d5ab]
    -   @osdk/internal.foundry.core@0.2.0-beta.0

## @osdk/internal.foundry.ontologiesv2@0.2.0-beta.0

### Minor Changes

-   1770490: URLs in jsdoc now link to palantir.com
-   5d6d5ab: Updated to latest gateway apis
-   5d6d5ab: Includes @alpha/@beta/@public jsdoc tags

### Patch Changes

-   Updated dependencies [1770490]
-   Updated dependencies [5d6d5ab]
-   Updated dependencies [5d6d5ab]
    -   @osdk/internal.foundry.ontologies@0.2.0-beta.0
    -   @osdk/internal.foundry.core@0.2.0-beta.0

## @osdk/cli@0.24.0-beta.0

### Patch Changes

-   Updated dependencies [ac4f4fd]
-   Updated dependencies [7494995]
-   Updated dependencies [1770490]
    -   @osdk/generator@1.14.0-beta.0

## @osdk/foundry.filesystem@2.1.0-beta.0

### Patch Changes

-   Updated dependencies [5d6d5ab]
-   Updated dependencies [5d6d5ab]
    -   @osdk/foundry.core@2.1.0-beta.0

## @osdk/foundry.publicapis@2.1.0-beta.0

### Patch Changes

-   Updated dependencies [5d6d5ab]
-   Updated dependencies [5d6d5ab]
    -   @osdk/foundry.core@2.1.0-beta.0

## @osdk/create-app@0.19.0-beta.0



## @osdk/create-app.template.tutorial-todo-aip-app@0.19.0-beta.0

### Minor Changes

-   0131ade: Update tutorial template READMEs to match others

## @osdk/create-app.template.tutorial-todo-app@0.19.0-beta.0

### Minor Changes

-   0131ade: Update tutorial template READMEs to match others

## @osdk/e2e.generated.api-namespace.dep@1.0.0-beta.0

### Minor Changes

-   fa33757: Update imports no longer point at index

### Patch Changes

-   Updated dependencies [ac4f4fd]
-   Updated dependencies [f86f8d0]
-   Updated dependencies [a2c7b37]
-   Updated dependencies [5a41e5e]
-   Updated dependencies [795777a]
    -   @osdk/client@0.22.0-beta.0
    -   @osdk/client.api@0.22.0-beta.0

## @osdk/e2e.generated.api-namespace.local@1.0.0-beta.0

### Minor Changes

-   fa33757: Update imports no longer point at index

### Patch Changes

-   Updated dependencies [ac4f4fd]
-   Updated dependencies [f86f8d0]
-   Updated dependencies [a2c7b37]
-   Updated dependencies [5a41e5e]
-   Updated dependencies [fa33757]
-   Updated dependencies [795777a]
    -   @osdk/client@0.22.0-beta.0
    -   @osdk/client.api@0.22.0-beta.0
    -   @osdk/e2e.generated.api-namespace.dep@1.0.0-beta.0

## @osdk/internal.foundry@0.5.0-beta.0

### Minor Changes

-   5d6d5ab: Updated to latest gateway apis
-   5d6d5ab: Includes @alpha/@beta/@public jsdoc tags

### Patch Changes

-   Updated dependencies [1770490]
-   Updated dependencies [5d6d5ab]
-   Updated dependencies [5d6d5ab]
    -   @osdk/internal.foundry.ontologiesv2@0.2.0-beta.0
    -   @osdk/internal.foundry.ontologies@0.2.0-beta.0
    -   @osdk/internal.foundry.datasets@0.2.0-beta.0
    -   @osdk/internal.foundry.models@0.2.0-beta.0
    -   @osdk/internal.foundry.core@0.2.0-beta.0

## @osdk/platform-sdk-generator@0.5.0-beta.0

### Minor Changes

-   0441dab: Generates @alpha/@beta/@public jsdoc tags
-   1770490: URLs in jsdoc now link to palantir.com

## @osdk/cli.cmd.typescript@0.6.0-beta.0

### Patch Changes

-   Updated dependencies [ac4f4fd]
-   Updated dependencies [7494995]
-   Updated dependencies [1770490]
    -   @osdk/generator@1.14.0-beta.0

## @osdk/client.test.ontology@1.2.0-beta.0

### Patch Changes

-   Updated dependencies [a2c7b37]
-   Updated dependencies [795777a]
    -   @osdk/client.api@0.22.0-beta.0

## @osdk/e2e.generated.1.1.x@0.3.0-beta.0

### Patch Changes

-   Updated dependencies [ac4f4fd]
-   Updated dependencies [7494995]
-   Updated dependencies [1770490]
    -   @osdk/generator@1.14.0-beta.0
    -   @osdk/legacy-client@2.5.0

## @osdk/e2e.generated.catchall@3.0.0-beta.0

### Patch Changes

-   Updated dependencies [ac4f4fd]
-   Updated dependencies [f86f8d0]
-   Updated dependencies [a2c7b37]
-   Updated dependencies [5a41e5e]
-   Updated dependencies [795777a]
    -   @osdk/client@0.22.0-beta.0
    -   @osdk/client.api@0.22.0-beta.0

## @osdk/e2e.sandbox.catchall@0.3.0-beta.0

### Patch Changes

-   Updated dependencies [ac4f4fd]
-   Updated dependencies [f86f8d0]
-   Updated dependencies [a2c7b37]
-   Updated dependencies [5d6d5ab]
-   Updated dependencies [5a41e5e]
-   Updated dependencies [795777a]
-   Updated dependencies [5d6d5ab]
    -   @osdk/client@0.22.0-beta.0
    -   @osdk/client.api@0.22.0-beta.0
    -   @osdk/internal.foundry@0.5.0-beta.0
    -   @osdk/foundry@2.1.0-beta.0
    -   @osdk/e2e.generated.catchall@3.0.0-beta.0

## @osdk/e2e.sandbox.oauth@0.3.0-beta.0

### Patch Changes

-   Updated dependencies [ac4f4fd]
-   Updated dependencies [f86f8d0]
-   Updated dependencies [a2c7b37]
-   Updated dependencies [5a41e5e]
-   Updated dependencies [795777a]
    -   @osdk/client@0.22.0-beta.0

## @osdk/e2e.sandbox.todoapp@3.0.0-beta.0

### Patch Changes

-   Updated dependencies [ac4f4fd]
-   Updated dependencies [f86f8d0]
-   Updated dependencies [a2c7b37]
-   Updated dependencies [5a41e5e]
-   Updated dependencies [795777a]
    -   @osdk/client@0.22.0-beta.0
    -   @osdk/client.api@0.22.0-beta.0

## @osdk/example-generator@0.8.0-beta.0

### Patch Changes

-   @osdk/create-app@0.19.0-beta.0

## @osdk/create-app.template.next-static-export@0.19.0-beta.0



## @osdk/create-app.template.react@0.19.0-beta.0



## @osdk/create-app.template.vue@0.19.0-beta.0


