### PR TITLE
Migrate deprecated OntologyMetadataService.loadOntologyEntities call to bulkLoadOntologyEntities

### DIFF
--- a/.changeset/fifty-eels-report.md
+++ b/.changeset/fifty-eels-report.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client.unstable": minor
+"@osdk/client": minor
+---
+
+Use OntologyMetadataService.bulkLoadOntologyEntities in place of deprecated loadOntologyEntities

--- a/packages/client.unstable/src/index.ts
+++ b/packages/client.unstable/src/index.ts
@@ -31,9 +31,9 @@ export type { Type } from "./generated/ontology-metadata/api/Type.js";
 
 export { createTemporaryObjectSet } from "./generated/object-set-service/api/ObjectSetService.js";
 export { getBulkLinksPage } from "./generated/object-set-service/api/ObjectSetServiceV2/getBulkLinksPage.js";
+export { bulkLoadOntologyEntities } from "./generated/ontology-metadata/api/OntologyMetadataService/bulkLoadOntologyEntities.js";
 export { getLinkTypesForObjectTypes } from "./generated/ontology-metadata/api/OntologyMetadataService/getLinkTypesForObjectTypes.js";
 export { loadAllOntologies } from "./generated/ontology-metadata/api/OntologyMetadataService/loadAllOntologies.js";
-export { loadOntologyEntities } from "./generated/ontology-metadata/api/OntologyMetadataService/loadOntologyEntities.js";
 
 export type {
   OntologyIrInterfaceType,


### PR DESCRIPTION
The `OntologyMetadataService.loadOntologyEntities` endpoint is deprecated and throws exceptions when it attempts to load an Object Type which has a Link Type which is not also loaded in the same call.

This change migrates the unstable OSDK client's usage to the supported `OntologyMetadataService.bulkLoadOntologyEntities` which does not fail when a Link Type is excluded from the call.