### PR TITLE
Include default tests for .env.production in templates

### DIFF
--- a/.changeset/wise-files-smash.md
+++ b/.changeset/wise-files-smash.md
@@ -1,0 +1,9 @@
+---
+"@osdk/create-app.template.tutorial-todo-aip-app": minor
+"@osdk/create-app.template.next-static-export": minor
+"@osdk/create-app.template.tutorial-todo-app": minor
+"@osdk/create-app.template.react": minor
+"@osdk/create-app.template.vue": minor
+---
+
+Include default tests for .env.production in templates

--- a/examples/example-next-static-export/package.json
+++ b/examples/example-next-static-export/package.json
@@ -11,7 +11,8 @@
     "build": "next build",
     "dev": "next dev -p 8080",
     "lint": "next lint",
-    "start": "next start"
+    "start": "next start",
+    "test": "vitest"
   },
   "dependencies": {
     "@osdk/e2e.generated.1.1.x": "workspace:*",
@@ -25,6 +26,7 @@
     "@types/react-dom": "^18",
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.3",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "vitest": "^2.0.5"
   }
 }

--- a/examples/example-next-static-export/package.json
+++ b/examples/example-next-static-export/package.json
@@ -21,6 +21,7 @@
     "react-dom": "^18"
   },
   "devDependencies": {
+    "@next/env": "^14.2.7",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/examples/example-next-static-export/src/env.test.ts
+++ b/examples/example-next-static-export/src/env.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { loadEnvConfig } from "@next/env";
+
+const ENV_VARS = [
+  "NEXT_PUBLIC_FOUNDRY_API_URL",
+  "NEXT_PUBLIC_FOUNDRY_CLIENT_ID",
+  "NEXT_PUBLIC_FOUNDRY_REDIRECT_URL",
+];
+
+beforeEach(() => {
+  vi.stubEnv("NODE_ENV", "production");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+for (const envVar of ENV_VARS) {
+  test.skipIf(process.env.VERIFY_ENV_PRODUCTION !== "true")(
+    `production env should contain ${envVar}`,
+    () => {
+      const env = loadEnvConfig(process.cwd());
+      expect(
+        env.combinedEnv[envVar],
+        `${envVar} should be defined`
+      ).toBeDefined();
+      expect(
+        env.combinedEnv[envVar],
+        `${envVar} should not contain placeholder value`
+      ).not.toMatch(/<.*>/);
+    }
+  );
+}

--- a/examples/example-next-static-export/src/env.test.ts
+++ b/examples/example-next-static-export/src/env.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { loadEnvConfig } from "@next/env";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
 
 const ENV_VARS = [
   "NEXT_PUBLIC_FOUNDRY_API_URL",
@@ -22,12 +22,12 @@ for (const envVar of ENV_VARS) {
       const env = loadEnvConfig(process.cwd());
       expect(
         env.combinedEnv[envVar],
-        `${envVar} should be defined`
+        `${envVar} should be defined`,
       ).toBeDefined();
       expect(
         env.combinedEnv[envVar],
-        `${envVar} should not contain placeholder value`
+        `${envVar} should not contain placeholder value`,
       ).not.toMatch(/<.*>/);
-    }
+    },
   );
 }

--- a/examples/example-react/package.json
+++ b/examples/example-react/package.json
@@ -11,7 +11,8 @@
     "build": "tsc && vite build",
     "dev": "vite",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@osdk/e2e.generated.1.1.x": "workspace:*",
@@ -29,7 +30,8 @@
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.6",
     "typescript": "^5.5.4",
-    "vite": "^5.3.4"
+    "vite": "^5.3.4",
+    "vitest": "^2.0.5"
   },
   "type": "module"
 }

--- a/examples/example-react/src/env.test.ts
+++ b/examples/example-react/src/env.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "vitest";
 import { loadEnv } from "vite";
+import { expect, test } from "vitest";
 
 const ENV_VARS = [
   "VITE_FOUNDRY_API_URL",
@@ -15,8 +15,8 @@ for (const envVar of ENV_VARS) {
       expect(env[envVar], `${envVar} should be defined`).toBeDefined();
       expect(
         env[envVar],
-        `${envVar} should not contain placeholder value`
+        `${envVar} should not contain placeholder value`,
       ).not.toMatch(/<.*>/);
-    }
+    },
   );
 }

--- a/examples/example-react/src/env.test.ts
+++ b/examples/example-react/src/env.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "vitest";
+import { loadEnv } from "vite";
+
+const ENV_VARS = [
+  "VITE_FOUNDRY_API_URL",
+  "VITE_FOUNDRY_CLIENT_ID",
+  "VITE_FOUNDRY_REDIRECT_URL",
+];
+
+for (const envVar of ENV_VARS) {
+  test.skipIf(process.env.VERIFY_ENV_PRODUCTION !== "true")(
+    `production env should contain ${envVar}`,
+    () => {
+      const env = loadEnv("production", process.cwd());
+      expect(env[envVar], `${envVar} should be defined`).toBeDefined();
+      expect(
+        env[envVar],
+        `${envVar} should not contain placeholder value`
+      ).not.toMatch(/<.*>/);
+    }
+  );
+}

--- a/examples/example-tutorial-todo-aip-app/package.json
+++ b/examples/example-tutorial-todo-aip-app/package.json
@@ -11,7 +11,8 @@
     "build": "tsc && vite build",
     "dev": "vite",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@osdk/e2e.generated.1.1.x": "workspace:*",
@@ -30,7 +31,8 @@
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.6",
     "typescript": "^5.5.4",
-    "vite": "^5.3.4"
+    "vite": "^5.3.4",
+    "vitest": "^2.0.5"
   },
   "type": "module"
 }

--- a/examples/example-tutorial-todo-aip-app/src/env.test.ts
+++ b/examples/example-tutorial-todo-aip-app/src/env.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "vitest";
 import { loadEnv } from "vite";
+import { expect, test } from "vitest";
 
 const ENV_VARS = [
   "VITE_FOUNDRY_API_URL",
@@ -15,8 +15,8 @@ for (const envVar of ENV_VARS) {
       expect(env[envVar], `${envVar} should be defined`).toBeDefined();
       expect(
         env[envVar],
-        `${envVar} should not contain placeholder value`
+        `${envVar} should not contain placeholder value`,
       ).not.toMatch(/<.*>/);
-    }
+    },
   );
 }

--- a/examples/example-tutorial-todo-aip-app/src/env.test.ts
+++ b/examples/example-tutorial-todo-aip-app/src/env.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "vitest";
+import { loadEnv } from "vite";
+
+const ENV_VARS = [
+  "VITE_FOUNDRY_API_URL",
+  "VITE_FOUNDRY_CLIENT_ID",
+  "VITE_FOUNDRY_REDIRECT_URL",
+];
+
+for (const envVar of ENV_VARS) {
+  test.skipIf(process.env.VERIFY_ENV_PRODUCTION !== "true")(
+    `production env should contain ${envVar}`,
+    () => {
+      const env = loadEnv("production", process.cwd());
+      expect(env[envVar], `${envVar} should be defined`).toBeDefined();
+      expect(
+        env[envVar],
+        `${envVar} should not contain placeholder value`
+      ).not.toMatch(/<.*>/);
+    }
+  );
+}

--- a/examples/example-tutorial-todo-app/package.json
+++ b/examples/example-tutorial-todo-app/package.json
@@ -11,7 +11,8 @@
     "build": "tsc && vite build",
     "dev": "vite",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@osdk/e2e.generated.1.1.x": "workspace:*",
@@ -30,7 +31,8 @@
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.6",
     "typescript": "^5.5.4",
-    "vite": "^5.3.4"
+    "vite": "^5.3.4",
+    "vitest": "^2.0.5"
   },
   "type": "module"
 }

--- a/examples/example-tutorial-todo-app/src/env.test.ts
+++ b/examples/example-tutorial-todo-app/src/env.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "vitest";
 import { loadEnv } from "vite";
+import { expect, test } from "vitest";
 
 const ENV_VARS = [
   "VITE_FOUNDRY_API_URL",
@@ -15,8 +15,8 @@ for (const envVar of ENV_VARS) {
       expect(env[envVar], `${envVar} should be defined`).toBeDefined();
       expect(
         env[envVar],
-        `${envVar} should not contain placeholder value`
+        `${envVar} should not contain placeholder value`,
       ).not.toMatch(/<.*>/);
-    }
+    },
   );
 }

--- a/examples/example-tutorial-todo-app/src/env.test.ts
+++ b/examples/example-tutorial-todo-app/src/env.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "vitest";
+import { loadEnv } from "vite";
+
+const ENV_VARS = [
+  "VITE_FOUNDRY_API_URL",
+  "VITE_FOUNDRY_CLIENT_ID",
+  "VITE_FOUNDRY_REDIRECT_URL",
+];
+
+for (const envVar of ENV_VARS) {
+  test.skipIf(process.env.VERIFY_ENV_PRODUCTION !== "true")(
+    `production env should contain ${envVar}`,
+    () => {
+      const env = loadEnv("production", process.cwd());
+      expect(env[envVar], `${envVar} should be defined`).toBeDefined();
+      expect(
+        env[envVar],
+        `${envVar} should not contain placeholder value`
+      ).not.toMatch(/<.*>/);
+    }
+  );
+}

--- a/examples/example-vue/package.json
+++ b/examples/example-vue/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "build": "vue-tsc && vite build",
     "dev": "vite",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@osdk/e2e.generated.1.1.x": "workspace:*",
@@ -21,6 +22,7 @@
     "@vitejs/plugin-vue": "^4.5.0",
     "typescript": "^5.5.4",
     "vite": "^5.3.4",
+    "vitest": "^2.0.5",
     "vue-tsc": "^2"
   },
   "type": "module"

--- a/examples/example-vue/src/env.test.ts
+++ b/examples/example-vue/src/env.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "vitest";
 import { loadEnv } from "vite";
+import { expect, test } from "vitest";
 
 const ENV_VARS = [
   "VITE_FOUNDRY_API_URL",
@@ -15,8 +15,8 @@ for (const envVar of ENV_VARS) {
       expect(env[envVar], `${envVar} should be defined`).toBeDefined();
       expect(
         env[envVar],
-        `${envVar} should not contain placeholder value`
+        `${envVar} should not contain placeholder value`,
       ).not.toMatch(/<.*>/);
-    }
+    },
   );
 }

--- a/examples/example-vue/src/env.test.ts
+++ b/examples/example-vue/src/env.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "vitest";
+import { loadEnv } from "vite";
+
+const ENV_VARS = [
+  "VITE_FOUNDRY_API_URL",
+  "VITE_FOUNDRY_CLIENT_ID",
+  "VITE_FOUNDRY_REDIRECT_URL",
+];
+
+for (const envVar of ENV_VARS) {
+  test.skipIf(process.env.VERIFY_ENV_PRODUCTION !== "true")(
+    `production env should contain ${envVar}`,
+    () => {
+      const env = loadEnv("production", process.cwd());
+      expect(env[envVar], `${envVar} should be defined`).toBeDefined();
+      expect(
+        env[envVar],
+        `${envVar} should not contain placeholder value`
+      ).not.toMatch(/<.*>/);
+    }
+  );
+}

--- a/packages/create-app.template.next-static-export/package.json
+++ b/packages/create-app.template.next-static-export/package.json
@@ -33,6 +33,7 @@
     "react-dom": "^18"
   },
   "devDependencies": {
+    "@next/env": "^14.2.7",
     "@osdk/create-app.template-packager": "workspace:~",
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",

--- a/packages/create-app.template.next-static-export/package.json
+++ b/packages/create-app.template.next-static-export/package.json
@@ -42,7 +42,8 @@
     "@types/react-dom": "^18",
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.3",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "vitest": "^2.0.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/create-app.template.next-static-export/templates/README.md.hbs
+++ b/packages/create-app.template.next-static-export/templates/README.md.hbs
@@ -28,7 +28,7 @@ npm run build
 
 Production configuration is stored in `.env.production`.
 
-If you did not fill in the URL your production application will be hosted on you will need to fill in the `NEXT_PUBLIC_FOUNDRY_REDIRECT_URL` in `.env.production`.
+If you did not fill in the URL your production application will be hosted on you will need to fill in the `NEXT_PUBLIC_FOUNDRY_REDIRECT_URL` in `.env.production`. A default test is included in `env.test.ts` to verify your production environment variables which you can enable by removing the skip condition or running tests with `VERIFY_ENV_PRODUCTION=true`.
 
 In order to make API requests to Foundry, CORS must be configured for the stack to allow the production origin to load resources. This will be automatically done for you if you are using Foundry website hosting. The configured OAuth client must also allow the production origin auth callback as a redirect URL.
 

--- a/packages/create-app.template.next-static-export/templates/README.md.hbs
+++ b/packages/create-app.template.next-static-export/templates/README.md.hbs
@@ -28,7 +28,7 @@ npm run build
 
 Production configuration is stored in `.env.production`.
 
-If you did not fill in the URL your production application will be hosted on you will need to fill in the `NEXT_PUBLIC_FOUNDRY_REDIRECT_URL` in `.env.production`. A default test is included in `env.test.ts` to verify your production environment variables which you can enable by removing the skip condition or running tests with `VERIFY_ENV_PRODUCTION=true`.
+If you did not fill in the URL your production application will be hosted on you will need to fill in the `NEXT_PUBLIC_FOUNDRY_REDIRECT_URL` in `.env.production`. A default test is included in `env.test.ts` to verify your production environment variables which you can enable by removing the skip condition or running tests with the environment variable set `VERIFY_ENV_PRODUCTION=true`.
 
 In order to make API requests to Foundry, CORS must be configured for the stack to allow the production origin to load resources. This will be automatically done for you if you are using Foundry website hosting. The configured OAuth client must also allow the production origin auth callback as a redirect URL.
 

--- a/packages/create-app.template.next-static-export/templates/package.json.hbs
+++ b/packages/create-app.template.next-static-export/templates/package.json.hbs
@@ -6,7 +6,8 @@
     "dev": "next dev -p 8080",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "{{osdkPackage}}": "latest"

--- a/packages/create-app.template.next-static-export/templates/src/env.test.ts
+++ b/packages/create-app.template.next-static-export/templates/src/env.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { loadEnvConfig } from "@next/env";
+
+const ENV_VARS = [
+  "NEXT_PUBLIC_FOUNDRY_API_URL",
+  "NEXT_PUBLIC_FOUNDRY_CLIENT_ID",
+  "NEXT_PUBLIC_FOUNDRY_REDIRECT_URL",
+];
+
+beforeEach(() => {
+  vi.stubEnv("NODE_ENV", "production");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+for (const envVar of ENV_VARS) {
+  test.skipIf(process.env.VERIFY_ENV_PRODUCTION !== "true")(
+    `production env should contain ${envVar}`,
+    () => {
+      const env = loadEnvConfig(process.cwd());
+      expect(
+        env.combinedEnv[envVar],
+        `${envVar} should be defined`
+      ).toBeDefined();
+      expect(
+        env.combinedEnv[envVar],
+        `${envVar} should not contain placeholder value`
+      ).not.toMatch(/<.*>/);
+    }
+  );
+}

--- a/packages/create-app.template.next-static-export/templates/src/env.test.ts
+++ b/packages/create-app.template.next-static-export/templates/src/env.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { loadEnvConfig } from "@next/env";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
 
 const ENV_VARS = [
   "NEXT_PUBLIC_FOUNDRY_API_URL",
@@ -22,12 +22,12 @@ for (const envVar of ENV_VARS) {
       const env = loadEnvConfig(process.cwd());
       expect(
         env.combinedEnv[envVar],
-        `${envVar} should be defined`
+        `${envVar} should be defined`,
       ).toBeDefined();
       expect(
         env.combinedEnv[envVar],
-        `${envVar} should not contain placeholder value`
+        `${envVar} should not contain placeholder value`,
       ).not.toMatch(/<.*>/);
-    }
+    },
   );
 }

--- a/packages/create-app.template.react/package.json
+++ b/packages/create-app.template.react/package.json
@@ -46,7 +46,8 @@
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.6",
     "typescript": "^5.5.4",
-    "vite": "^5.3.4"
+    "vite": "^5.3.4",
+    "vitest": "^2.0.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/create-app.template.react/templates/README.md.hbs
+++ b/packages/create-app.template.react/templates/README.md.hbs
@@ -28,7 +28,7 @@ npm run build
 
 Production configuration is stored in `.env.production`.
 
-If you did not fill in the URL your production application will be hosted on you will need to fill in the `VITE_FOUNDRY_REDIRECT_URL` in `.env.production`.
+If you did not fill in the URL your production application will be hosted on you will need to fill in the `VITE_FOUNDRY_REDIRECT_URL` in `.env.production`. A default test is included in `env.test.ts` to verify your production environment variables which you can enable by removing the skip condition or running tests with `VERIFY_ENV_PRODUCTION=true`.
 
 In order to make API requests to Foundry, CORS must be configured for the stack to allow the production origin to load resources. This will be automatically done for you if you are using Foundry website hosting. The configured OAuth client must also allow the production origin auth callback as a redirect URL.
 

--- a/packages/create-app.template.react/templates/README.md.hbs
+++ b/packages/create-app.template.react/templates/README.md.hbs
@@ -28,7 +28,7 @@ npm run build
 
 Production configuration is stored in `.env.production`.
 
-If you did not fill in the URL your production application will be hosted on you will need to fill in the `VITE_FOUNDRY_REDIRECT_URL` in `.env.production`. A default test is included in `env.test.ts` to verify your production environment variables which you can enable by removing the skip condition or running tests with `VERIFY_ENV_PRODUCTION=true`.
+If you did not fill in the URL your production application will be hosted on you will need to fill in the `VITE_FOUNDRY_REDIRECT_URL` in `.env.production`. A default test is included in `env.test.ts` to verify your production environment variables which you can enable by removing the skip condition or running tests with the environment variable set `VERIFY_ENV_PRODUCTION=true`.
 
 In order to make API requests to Foundry, CORS must be configured for the stack to allow the production origin to load resources. This will be automatically done for you if you are using Foundry website hosting. The configured OAuth client must also allow the production origin auth callback as a redirect URL.
 

--- a/packages/create-app.template.react/templates/package.json.hbs
+++ b/packages/create-app.template.react/templates/package.json.hbs
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "test": "vitest",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/packages/create-app.template.react/templates/src/env.test.ts
+++ b/packages/create-app.template.react/templates/src/env.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "vitest";
 import { loadEnv } from "vite";
+import { expect, test } from "vitest";
 
 const ENV_VARS = [
   "VITE_FOUNDRY_API_URL",
@@ -15,8 +15,8 @@ for (const envVar of ENV_VARS) {
       expect(env[envVar], `${envVar} should be defined`).toBeDefined();
       expect(
         env[envVar],
-        `${envVar} should not contain placeholder value`
+        `${envVar} should not contain placeholder value`,
       ).not.toMatch(/<.*>/);
-    }
+    },
   );
 }

--- a/packages/create-app.template.react/templates/src/env.test.ts
+++ b/packages/create-app.template.react/templates/src/env.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "vitest";
+import { loadEnv } from "vite";
+
+const ENV_VARS = [
+  "VITE_FOUNDRY_API_URL",
+  "VITE_FOUNDRY_CLIENT_ID",
+  "VITE_FOUNDRY_REDIRECT_URL",
+];
+
+for (const envVar of ENV_VARS) {
+  test.skipIf(process.env.VERIFY_ENV_PRODUCTION !== "true")(
+    `production env should contain ${envVar}`,
+    () => {
+      const env = loadEnv("production", process.cwd());
+      expect(env[envVar], `${envVar} should be defined`).toBeDefined();
+      expect(
+        env[envVar],
+        `${envVar} should not contain placeholder value`
+      ).not.toMatch(/<.*>/);
+    }
+  );
+}

--- a/packages/create-app.template.tutorial-todo-aip-app/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app/package.json
@@ -47,7 +47,8 @@
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.6",
     "typescript": "^5.5.4",
-    "vite": "^5.3.4"
+    "vite": "^5.3.4",
+    "vitest": "^2.0.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/create-app.template.tutorial-todo-aip-app/templates/README.md.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app/templates/README.md.hbs
@@ -28,7 +28,7 @@ npm run build
 
 Production configuration is stored in `.env.production`.
 
-If you did not fill in the URL your production application will be hosted on you will need to fill in the `VITE_FOUNDRY_REDIRECT_URL` in `.env.production`.
+If you did not fill in the URL your production application will be hosted on you will need to fill in the `VITE_FOUNDRY_REDIRECT_URL` in `.env.production`. A default test is included in `env.test.ts` to verify your production environment variables which you can enable by removing the skip condition or running tests with `VERIFY_ENV_PRODUCTION=true`.
 
 In order to make API requests to Foundry, CORS must be configured for the stack to allow the production origin to load resources. This will be automatically done for you if you are using Foundry website hosting. The configured OAuth client must also allow the production origin auth callback as a redirect URL.
 

--- a/packages/create-app.template.tutorial-todo-aip-app/templates/README.md.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app/templates/README.md.hbs
@@ -28,7 +28,7 @@ npm run build
 
 Production configuration is stored in `.env.production`.
 
-If you did not fill in the URL your production application will be hosted on you will need to fill in the `VITE_FOUNDRY_REDIRECT_URL` in `.env.production`. A default test is included in `env.test.ts` to verify your production environment variables which you can enable by removing the skip condition or running tests with `VERIFY_ENV_PRODUCTION=true`.
+If you did not fill in the URL your production application will be hosted on you will need to fill in the `VITE_FOUNDRY_REDIRECT_URL` in `.env.production`. A default test is included in `env.test.ts` to verify your production environment variables which you can enable by removing the skip condition or running tests with the environment variable set `VERIFY_ENV_PRODUCTION=true`.
 
 In order to make API requests to Foundry, CORS must be configured for the stack to allow the production origin to load resources. This will be automatically done for you if you are using Foundry website hosting. The configured OAuth client must also allow the production origin auth callback as a redirect URL.
 

--- a/packages/create-app.template.tutorial-todo-aip-app/templates/package.json.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app/templates/package.json.hbs
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "test": "vitest",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/packages/create-app.template.tutorial-todo-aip-app/templates/src/env.test.ts
+++ b/packages/create-app.template.tutorial-todo-aip-app/templates/src/env.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "vitest";
 import { loadEnv } from "vite";
+import { expect, test } from "vitest";
 
 const ENV_VARS = [
   "VITE_FOUNDRY_API_URL",
@@ -15,8 +15,8 @@ for (const envVar of ENV_VARS) {
       expect(env[envVar], `${envVar} should be defined`).toBeDefined();
       expect(
         env[envVar],
-        `${envVar} should not contain placeholder value`
+        `${envVar} should not contain placeholder value`,
       ).not.toMatch(/<.*>/);
-    }
+    },
   );
 }

--- a/packages/create-app.template.tutorial-todo-aip-app/templates/src/env.test.ts
+++ b/packages/create-app.template.tutorial-todo-aip-app/templates/src/env.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "vitest";
+import { loadEnv } from "vite";
+
+const ENV_VARS = [
+  "VITE_FOUNDRY_API_URL",
+  "VITE_FOUNDRY_CLIENT_ID",
+  "VITE_FOUNDRY_REDIRECT_URL",
+];
+
+for (const envVar of ENV_VARS) {
+  test.skipIf(process.env.VERIFY_ENV_PRODUCTION !== "true")(
+    `production env should contain ${envVar}`,
+    () => {
+      const env = loadEnv("production", process.cwd());
+      expect(env[envVar], `${envVar} should be defined`).toBeDefined();
+      expect(
+        env[envVar],
+        `${envVar} should not contain placeholder value`
+      ).not.toMatch(/<.*>/);
+    }
+  );
+}

--- a/packages/create-app.template.tutorial-todo-app/package.json
+++ b/packages/create-app.template.tutorial-todo-app/package.json
@@ -47,7 +47,8 @@
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.6",
     "typescript": "^5.5.4",
-    "vite": "^5.3.4"
+    "vite": "^5.3.4",
+    "vitest": "^2.0.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/create-app.template.tutorial-todo-app/templates/README.md.hbs
+++ b/packages/create-app.template.tutorial-todo-app/templates/README.md.hbs
@@ -28,7 +28,7 @@ npm run build
 
 Production configuration is stored in `.env.production`.
 
-If you did not fill in the URL your production application will be hosted on you will need to fill in the `VITE_FOUNDRY_REDIRECT_URL` in `.env.production`.
+If you did not fill in the URL your production application will be hosted on you will need to fill in the `VITE_FOUNDRY_REDIRECT_URL` in `.env.production`. A default test is included in `env.test.ts` to verify your production environment variables which you can enable by removing the skip condition or running tests with `VERIFY_ENV_PRODUCTION=true`.
 
 In order to make API requests to Foundry, CORS must be configured for the stack to allow the production origin to load resources. This will be automatically done for you if you are using Foundry website hosting. The configured OAuth client must also allow the production origin auth callback as a redirect URL.
 

--- a/packages/create-app.template.tutorial-todo-app/templates/README.md.hbs
+++ b/packages/create-app.template.tutorial-todo-app/templates/README.md.hbs
@@ -28,7 +28,7 @@ npm run build
 
 Production configuration is stored in `.env.production`.
 
-If you did not fill in the URL your production application will be hosted on you will need to fill in the `VITE_FOUNDRY_REDIRECT_URL` in `.env.production`. A default test is included in `env.test.ts` to verify your production environment variables which you can enable by removing the skip condition or running tests with `VERIFY_ENV_PRODUCTION=true`.
+If you did not fill in the URL your production application will be hosted on you will need to fill in the `VITE_FOUNDRY_REDIRECT_URL` in `.env.production`. A default test is included in `env.test.ts` to verify your production environment variables which you can enable by removing the skip condition or running tests with the environment variable set `VERIFY_ENV_PRODUCTION=true`.
 
 In order to make API requests to Foundry, CORS must be configured for the stack to allow the production origin to load resources. This will be automatically done for you if you are using Foundry website hosting. The configured OAuth client must also allow the production origin auth callback as a redirect URL.
 

--- a/packages/create-app.template.tutorial-todo-app/templates/package.json.hbs
+++ b/packages/create-app.template.tutorial-todo-app/templates/package.json.hbs
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "test": "vitest",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/packages/create-app.template.tutorial-todo-app/templates/src/env.test.ts
+++ b/packages/create-app.template.tutorial-todo-app/templates/src/env.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "vitest";
 import { loadEnv } from "vite";
+import { expect, test } from "vitest";
 
 const ENV_VARS = [
   "VITE_FOUNDRY_API_URL",
@@ -15,8 +15,8 @@ for (const envVar of ENV_VARS) {
       expect(env[envVar], `${envVar} should be defined`).toBeDefined();
       expect(
         env[envVar],
-        `${envVar} should not contain placeholder value`
+        `${envVar} should not contain placeholder value`,
       ).not.toMatch(/<.*>/);
-    }
+    },
   );
 }

--- a/packages/create-app.template.tutorial-todo-app/templates/src/env.test.ts
+++ b/packages/create-app.template.tutorial-todo-app/templates/src/env.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "vitest";
+import { loadEnv } from "vite";
+
+const ENV_VARS = [
+  "VITE_FOUNDRY_API_URL",
+  "VITE_FOUNDRY_CLIENT_ID",
+  "VITE_FOUNDRY_REDIRECT_URL",
+];
+
+for (const envVar of ENV_VARS) {
+  test.skipIf(process.env.VERIFY_ENV_PRODUCTION !== "true")(
+    `production env should contain ${envVar}`,
+    () => {
+      const env = loadEnv("production", process.cwd());
+      expect(env[envVar], `${envVar} should be defined`).toBeDefined();
+      expect(
+        env[envVar],
+        `${envVar} should not contain placeholder value`
+      ).not.toMatch(/<.*>/);
+    }
+  );
+}

--- a/packages/create-app.template.vue/package.json
+++ b/packages/create-app.template.vue/package.json
@@ -39,6 +39,7 @@
     "@vitejs/plugin-vue": "^4.5.0",
     "typescript": "^5.5.4",
     "vite": "^5.3.4",
+    "vitest": "^2.0.5",
     "vue-tsc": "^2"
   },
   "publishConfig": {

--- a/packages/create-app.template.vue/templates/README.md.hbs
+++ b/packages/create-app.template.vue/templates/README.md.hbs
@@ -28,7 +28,7 @@ npm run build
 
 Production configuration is stored in `.env.production`.
 
-If you did not fill in the URL your production application will be hosted on you will need to fill in the `VITE_FOUNDRY_REDIRECT_URL` in `.env.production`.
+If you did not fill in the URL your production application will be hosted on you will need to fill in the `VITE_FOUNDRY_REDIRECT_URL` in `.env.production`. A default test is included in `env.test.ts` to verify your production environment variables which you can enable by removing the skip condition or running tests with `VERIFY_ENV_PRODUCTION=true`.
 
 In order to make API requests to Foundry, CORS must be configured for the stack to allow the production origin to load resources. This will be automatically done for you if you are using Foundry website hosting. The configured OAuth client must also allow the production origin auth callback as a redirect URL.
 

--- a/packages/create-app.template.vue/templates/README.md.hbs
+++ b/packages/create-app.template.vue/templates/README.md.hbs
@@ -28,7 +28,7 @@ npm run build
 
 Production configuration is stored in `.env.production`.
 
-If you did not fill in the URL your production application will be hosted on you will need to fill in the `VITE_FOUNDRY_REDIRECT_URL` in `.env.production`. A default test is included in `env.test.ts` to verify your production environment variables which you can enable by removing the skip condition or running tests with `VERIFY_ENV_PRODUCTION=true`.
+If you did not fill in the URL your production application will be hosted on you will need to fill in the `VITE_FOUNDRY_REDIRECT_URL` in `.env.production`. A default test is included in `env.test.ts` to verify your production environment variables which you can enable by removing the skip condition or running tests with the environment variable set `VERIFY_ENV_PRODUCTION=true`.
 
 In order to make API requests to Foundry, CORS must be configured for the stack to allow the production origin to load resources. This will be automatically done for you if you are using Foundry website hosting. The configured OAuth client must also allow the production origin auth callback as a redirect URL.
 

--- a/packages/create-app.template.vue/templates/package.json.hbs
+++ b/packages/create-app.template.vue/templates/package.json.hbs
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc && vite build",
+    "test": "vitest",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/packages/create-app.template.vue/templates/src/env.test.ts
+++ b/packages/create-app.template.vue/templates/src/env.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "vitest";
 import { loadEnv } from "vite";
+import { expect, test } from "vitest";
 
 const ENV_VARS = [
   "VITE_FOUNDRY_API_URL",
@@ -15,8 +15,8 @@ for (const envVar of ENV_VARS) {
       expect(env[envVar], `${envVar} should be defined`).toBeDefined();
       expect(
         env[envVar],
-        `${envVar} should not contain placeholder value`
+        `${envVar} should not contain placeholder value`,
       ).not.toMatch(/<.*>/);
-    }
+    },
   );
 }

--- a/packages/create-app.template.vue/templates/src/env.test.ts
+++ b/packages/create-app.template.vue/templates/src/env.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "vitest";
+import { loadEnv } from "vite";
+
+const ENV_VARS = [
+  "VITE_FOUNDRY_API_URL",
+  "VITE_FOUNDRY_CLIENT_ID",
+  "VITE_FOUNDRY_REDIRECT_URL",
+];
+
+for (const envVar of ENV_VARS) {
+  test.skipIf(process.env.VERIFY_ENV_PRODUCTION !== "true")(
+    `production env should contain ${envVar}`,
+    () => {
+      const env = loadEnv("production", process.cwd());
+      expect(env[envVar], `${envVar} should be defined`).toBeDefined();
+      expect(
+        env[envVar],
+        `${envVar} should not contain placeholder value`
+      ).not.toMatch(/<.*>/);
+    }
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,9 @@ importers:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@next/env':
+        specifier: ^14.2.7
+        version: 14.2.7
       '@types/node':
         specifier: ^20
         version: 20.12.12
@@ -232,6 +235,9 @@ importers:
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
+      vitest:
+        specifier: ^2.0.5
+        version: 2.0.5(@types/node@20.12.12)
 
   examples/example-react:
     dependencies:
@@ -278,6 +284,9 @@ importers:
       vite:
         specifier: ^5.3.4
         version: 5.3.4(@types/node@20.14.10)
+      vitest:
+        specifier: ^2.0.5
+        version: 2.0.5(@types/node@20.14.10)
 
   examples/example-tutorial-todo-aip-app:
     dependencies:
@@ -327,6 +336,9 @@ importers:
       vite:
         specifier: ^5.3.4
         version: 5.3.4(@types/node@20.14.10)
+      vitest:
+        specifier: ^2.0.5
+        version: 2.0.5(@types/node@20.14.10)
 
   examples/example-tutorial-todo-app:
     dependencies:
@@ -376,6 +388,9 @@ importers:
       vite:
         specifier: ^5.3.4
         version: 5.3.4(@types/node@20.14.10)
+      vitest:
+        specifier: ^2.0.5
+        version: 2.0.5(@types/node@20.14.10)
 
   examples/example-vue:
     dependencies:
@@ -398,6 +413,9 @@ importers:
       vite:
         specifier: ^5.3.4
         version: 5.3.4(@types/node@20.14.10)
+      vitest:
+        specifier: ^2.0.5
+        version: 2.0.5(@types/node@20.14.10)
       vue-tsc:
         specifier: ^2
         version: 2.0.26(typescript@5.5.4)
@@ -957,6 +975,9 @@ importers:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@next/env':
+        specifier: ^14.2.7
+        version: 14.2.7
       '@osdk/create-app.template-packager':
         specifier: workspace:~
         version: link:../create-app.template-packager
@@ -987,6 +1008,9 @@ importers:
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
+      vitest:
+        specifier: ^2.0.5
+        version: 2.0.5(@types/node@20.14.10)
 
   packages/create-app.template.react:
     dependencies:
@@ -1042,6 +1066,9 @@ importers:
       vite:
         specifier: ^5.3.4
         version: 5.3.4(@types/node@20.14.10)
+      vitest:
+        specifier: ^2.0.5
+        version: 2.0.5(@types/node@20.14.10)
 
   packages/create-app.template.tutorial-todo-aip-app:
     dependencies:
@@ -1100,6 +1127,9 @@ importers:
       vite:
         specifier: ^5.3.4
         version: 5.3.4(@types/node@20.14.10)
+      vitest:
+        specifier: ^2.0.5
+        version: 2.0.5(@types/node@20.14.10)
 
   packages/create-app.template.tutorial-todo-app:
     dependencies:
@@ -1158,6 +1188,9 @@ importers:
       vite:
         specifier: ^5.3.4
         version: 5.3.4(@types/node@20.14.10)
+      vitest:
+        specifier: ^2.0.5
+        version: 2.0.5(@types/node@20.14.10)
 
   packages/create-app.template.vue:
     dependencies:
@@ -1189,6 +1222,9 @@ importers:
       vite:
         specifier: ^5.3.4
         version: 5.3.4(@types/node@20.14.10)
+      vitest:
+        specifier: ^2.0.5
+        version: 2.0.5(@types/node@20.14.10)
       vue-tsc:
         specifier: ^2
         version: 2.0.26(typescript@5.5.4)
@@ -3639,6 +3675,7 @@ packages:
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -3646,6 +3683,7 @@ packages:
 
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
+    deprecated: Use @eslint/object-schema instead
 
   '@humanwhocodes/retry@0.3.0':
     resolution: {integrity: sha512-d2CGZR2o7fS6sWB7DG/3a95bGKQyHMACZ5aW8qGkkqQpUoZV6C0X7Pc7l4ZNMZkfNBf4VWNe9E1jRsf0G146Ew==}
@@ -3746,6 +3784,9 @@ packages:
 
   '@next/env@14.2.3':
     resolution: {integrity: sha512-W7fd7IbkfmeeY2gXrzJYDx8D2lWKbVoTIj1o1ScPHNzvp30s1AuoEFSdr39bC5sjxJaxTtq3OTCZboNp0lNWHA==}
+
+  '@next/env@14.2.7':
+    resolution: {integrity: sha512-OTx9y6I3xE/eih+qtthppwLytmpJVPM5PPoJxChFsbjIEFXIayG0h/xLzefHGJviAa3Q5+Fd+9uYojKkHDKxoQ==}
 
   '@next/eslint-plugin-next@14.2.3':
     resolution: {integrity: sha512-L3oDricIIjgj1AVnRdRor21gI7mShlSwU/1ZGHmqM3LzHhXXhdkrfeNY5zif25Bi5Dd7fiJHsbhoZCHfXYvlAw==}
@@ -4528,20 +4569,38 @@ packages:
   '@vitest/expect@2.0.4':
     resolution: {integrity: sha512-39jr5EguIoanChvBqe34I8m1hJFI4+jxvdOpD7gslZrVQBKhh8H9eD7J/LJX4zakrw23W+dITQTDqdt43xVcJw==}
 
+  '@vitest/expect@2.0.5':
+    resolution: {integrity: sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==}
+
   '@vitest/pretty-format@2.0.4':
     resolution: {integrity: sha512-RYZl31STbNGqf4l2eQM1nvKPXE0NhC6Eq0suTTePc4mtMQ1Fn8qZmjV4emZdEdG2NOWGKSCrHZjmTqDCDoeFBw==}
+
+  '@vitest/pretty-format@2.0.5':
+    resolution: {integrity: sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==}
 
   '@vitest/runner@2.0.4':
     resolution: {integrity: sha512-Gk+9Su/2H2zNfNdeJR124gZckd5st4YoSuhF1Rebi37qTXKnqYyFCd9KP4vl2cQHbtuVKjfEKrNJxHHCW8thbQ==}
 
+  '@vitest/runner@2.0.5':
+    resolution: {integrity: sha512-TfRfZa6Bkk9ky4tW0z20WKXFEwwvWhRY+84CnSEtq4+3ZvDlJyY32oNTJtM7AW9ihW90tX/1Q78cb6FjoAs+ig==}
+
   '@vitest/snapshot@2.0.4':
     resolution: {integrity: sha512-or6Mzoz/pD7xTvuJMFYEtso1vJo1S5u6zBTinfl+7smGUhqybn6VjzCDMhmTyVOFWwkCMuNjmNNxnyXPgKDoPw==}
+
+  '@vitest/snapshot@2.0.5':
+    resolution: {integrity: sha512-SgCPUeDFLaM0mIUHfaArq8fD2WbaXG/zVXjRupthYfYGzc8ztbFbu6dUNOblBG7XLMR1kEhS/DNnfCZ2IhdDew==}
 
   '@vitest/spy@2.0.4':
     resolution: {integrity: sha512-uTXU56TNoYrTohb+6CseP8IqNwlNdtPwEO0AWl+5j7NelS6x0xZZtP0bDWaLvOfUbaYwhhWp1guzXUxkC7mW7Q==}
 
+  '@vitest/spy@2.0.5':
+    resolution: {integrity: sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==}
+
   '@vitest/utils@2.0.4':
     resolution: {integrity: sha512-Zc75QuuoJhOBnlo99ZVUkJIuq4Oj0zAkrQ2VzCqNCx6wAwViHEh5Fnp4fiJTE9rA+sAoXRf00Z9xGgfEzV6fzQ==}
+
+  '@vitest/utils@2.0.5':
+    resolution: {integrity: sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==}
 
   '@volar/language-core@2.4.0-alpha.16':
     resolution: {integrity: sha512-oOTnIZlx0P/idFwVw+W0NbzKDtZAQMzXSdIFfTePCKcXlb4Ys12GaGkx8NF9dsvPYV3nbv3ZsSxnkZWBmNKd7A==}
@@ -5771,9 +5830,11 @@ packages:
 
   glob@7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
@@ -7934,6 +7995,11 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
+  vite-node@2.0.5:
+    resolution: {integrity: sha512-LdsW4pxj0Ot69FAoXZ1yTnA9bjGohr2yNBU7QKRxpz8ITSkhuDl6h3zS/tvgz4qrNjeRnvrWeXQ8ZF7Um4W00Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite@5.3.4:
     resolution: {integrity: sha512-Cw+7zL3ZG9/NZBB8C+8QbQZmR54GwqIz+WMI4b3JgdYJvX+ny9AjJXqkGQlDXSXRP9rP0B4tbciRMOVEKulVOA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -7971,6 +8037,31 @@ packages:
       '@types/node': ^18.0.0 || >=20.0.0
       '@vitest/browser': 2.0.4
       '@vitest/ui': 2.0.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@2.0.5:
+    resolution: {integrity: sha512-8GUxONfauuIdeSl5f9GTgVEpg5BTOlplET4WEDaeY2QBiN8wSm68vxN/tb5z405OwppfoCavnwXafiaYBC/xOA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.0.5
+      '@vitest/ui': 2.0.5
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -9361,6 +9452,8 @@ snapshots:
 
   '@next/env@14.2.3': {}
 
+  '@next/env@14.2.7': {}
+
   '@next/eslint-plugin-next@14.2.3':
     dependencies:
       glob: 10.3.10
@@ -10301,7 +10394,18 @@ snapshots:
       chai: 5.1.1
       tinyrainbow: 1.2.0
 
+  '@vitest/expect@2.0.5':
+    dependencies:
+      '@vitest/spy': 2.0.5
+      '@vitest/utils': 2.0.5
+      chai: 5.1.1
+      tinyrainbow: 1.2.0
+
   '@vitest/pretty-format@2.0.4':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/pretty-format@2.0.5':
     dependencies:
       tinyrainbow: 1.2.0
 
@@ -10310,9 +10414,20 @@ snapshots:
       '@vitest/utils': 2.0.4
       pathe: 1.1.2
 
+  '@vitest/runner@2.0.5':
+    dependencies:
+      '@vitest/utils': 2.0.5
+      pathe: 1.1.2
+
   '@vitest/snapshot@2.0.4':
     dependencies:
       '@vitest/pretty-format': 2.0.4
+      magic-string: 0.30.10
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.0.5':
+    dependencies:
+      '@vitest/pretty-format': 2.0.5
       magic-string: 0.30.10
       pathe: 1.1.2
 
@@ -10320,9 +10435,20 @@ snapshots:
     dependencies:
       tinyspy: 3.0.0
 
+  '@vitest/spy@2.0.5':
+    dependencies:
+      tinyspy: 3.0.0
+
   '@vitest/utils@2.0.4':
     dependencies:
       '@vitest/pretty-format': 2.0.4
+      estree-walker: 3.0.3
+      loupe: 3.1.1
+      tinyrainbow: 1.2.0
+
+  '@vitest/utils@2.0.5':
+    dependencies:
+      '@vitest/pretty-format': 2.0.5
       estree-walker: 3.0.3
       loupe: 3.1.1
       tinyrainbow: 1.2.0
@@ -14377,6 +14503,40 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@2.0.5(@types/node@20.12.12):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.5
+      pathe: 1.1.2
+      tinyrainbow: 1.2.0
+      vite: 5.3.4(@types/node@20.12.12)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite-node@2.0.5(@types/node@20.14.10):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.5
+      pathe: 1.1.2
+      tinyrainbow: 1.2.0
+      vite: 5.3.4(@types/node@20.14.10)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite@5.3.4(@types/node@18.17.15):
     dependencies:
       esbuild: 0.21.5
@@ -14488,6 +14648,70 @@ snapshots:
       tinyrainbow: 1.2.0
       vite: 5.3.4(@types/node@20.14.10)
       vite-node: 2.0.4(@types/node@20.14.10)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.14.10
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@2.0.5(@types/node@20.12.12):
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@vitest/expect': 2.0.5
+      '@vitest/pretty-format': 2.0.5
+      '@vitest/runner': 2.0.5
+      '@vitest/snapshot': 2.0.5
+      '@vitest/spy': 2.0.5
+      '@vitest/utils': 2.0.5
+      chai: 5.1.1
+      debug: 4.3.5
+      execa: 8.0.1
+      magic-string: 0.30.10
+      pathe: 1.1.2
+      std-env: 3.7.0
+      tinybench: 2.8.0
+      tinypool: 1.0.0
+      tinyrainbow: 1.2.0
+      vite: 5.3.4(@types/node@20.12.12)
+      vite-node: 2.0.5(@types/node@20.12.12)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.12.12
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@2.0.5(@types/node@20.14.10):
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@vitest/expect': 2.0.5
+      '@vitest/pretty-format': 2.0.5
+      '@vitest/runner': 2.0.5
+      '@vitest/snapshot': 2.0.5
+      '@vitest/spy': 2.0.5
+      '@vitest/utils': 2.0.5
+      chai: 5.1.1
+      debug: 4.3.5
+      execa: 8.0.1
+      magic-string: 0.30.10
+      pathe: 1.1.2
+      std-env: 3.7.0
+      tinybench: 2.8.0
+      tinypool: 1.0.0
+      tinyrainbow: 1.2.0
+      vite: 5.3.4(@types/node@20.14.10)
+      vite-node: 2.0.5(@types/node@20.14.10)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.14.10


### PR DESCRIPTION
Add vitest with a default `env.test.ts` test in create-app templates to verify production env variables have been set up correctly and not forgotten. This is skipped by default to not cause immediate test failures during development but on Foundry CI/CD will be enabled by default on tag builds.