### PR TITLE
Fix object property selection inference

### DIFF
--- a/.changeset/green-years-shake.md
+++ b/.changeset/green-years-shake.md
@@ -1,0 +1,7 @@
+---
+"@osdk/client.api": patch
+"@osdk/generator": patch
+"@osdk/client": patch
+---
+
+Fixes an issue that could cause an object with sub-selection to be assigned as a full object

--- a/etc/client.api.report.api.md
+++ b/etc/client.api.report.api.md
@@ -448,7 +448,7 @@ export interface ObjectSet<Q extends ObjectOrInterfaceDefinition = any, Z extend
     // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
     // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
     readonly aggregate: <AO extends AggregateOpts<Q>>(req: AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<Q, AO>) => Promise<AggregationsResults<Q, AO>>;
-    readonly fetchOne: Q extends ObjectTypeDefinition<any> ? <L extends ObjectOrInterfacePropertyKeysFrom2<Q>, R extends boolean, S extends false | "throw" = NullabilityAdherenceDefault>(primaryKey: PropertyValueClientToWire[Q["primaryKeyType"]], options?: SelectArg<Q, L, R, S>) => Promise<SingleOsdkResult<Q, L, R, S>> : never;
+    readonly fetchOne: Q extends ObjectTypeDefinition<any> ? <const L extends ObjectOrInterfacePropertyKeysFrom2<Q>, const R extends boolean, const S extends false | "throw" = NullabilityAdherenceDefault>(primaryKey: PropertyValueClientToWire[Q["primaryKeyType"]], options?: SelectArg<Q, L, R, S>) => Promise<SingleOsdkResult<Q, L, R, S>> : never;
     readonly fetchOneWithErrors: Q extends ObjectTypeDefinition<any> ? <L extends ObjectOrInterfacePropertyKeysFrom2<Q>, R extends boolean, S extends false | "throw" = NullabilityAdherenceDefault>(primaryKey: PropertyValueClientToWire[Q["primaryKeyType"]], options?: SelectArg<Q, L, R, S>) => Promise<Result<SingleOsdkResult<Q, L, R, S>>> : never;
     readonly intersect: (...objectSets: ReadonlyArray<Z>) => this;
     readonly pivotTo: <L extends LinkNames<Q>>(type: L) => LinkedType<Q, L>["objectSet"];

--- a/etc/client.report.api.md
+++ b/etc/client.report.api.md
@@ -62,7 +62,7 @@ export { ApplyBatchActionOptions }
 // @public (undocumented)
 export interface Client extends SharedClient<MinimalClient> {
     // (undocumented)
-    <Q extends ObjectTypeDefinition<any, any>>(o: Q): Q["objectSet"];
+    <Q extends ObjectTypeDefinition<any, any>>(o: Q): unknown extends Q["objectSet"] ? ObjectSet<Q> : Q["objectSet"];
     // Warning: (ae-forgotten-export) The symbol "ActionSignatureFromDef" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Employee.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Employee.ts
@@ -57,18 +57,18 @@ export namespace Employee {
   }
 
   export interface ObjectSet extends $ObjectSet<Employee.Definition, Employee.ObjectSet> {
-    readonly aggregate: <AO extends $AggregateOpts<Employee.Definition>>(
+    readonly aggregate: <const AO extends $AggregateOpts<Employee.Definition>>(
       req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<Employee.Definition, AO>,
     ) => Promise<$AggregationsResults<Employee.Definition, AO>>;
 
-    readonly pivotTo: <L extends $LinkNames<Employee.Definition>>(
+    readonly pivotTo: <const L extends $LinkNames<Employee.Definition>>(
       type: L,
     ) => $LinkedType<Employee.Definition, L>['objectSet'];
 
     readonly fetchOne: <
-      L extends Employee.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends Employee.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[Employee.Definition['primaryKeyType']],
       options?: $SelectArg<Employee.Definition, L, R, S>,
@@ -80,9 +80,9 @@ export namespace Employee {
     >;
 
     readonly fetchOneWithErrors: <
-      L extends Employee.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends Employee.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[Employee.Definition['primaryKeyType']],
       options?: $SelectArg<Employee.Definition, L, R, S>,
@@ -96,10 +96,10 @@ export namespace Employee {
     >;
 
     readonly fetchPage: <
-      L extends Employee.PropertyKeys,
-      R extends boolean,
+      const L extends Employee.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<Employee.Definition, L, R, A, S>,
     ) => Promise<
@@ -112,10 +112,10 @@ export namespace Employee {
     >;
 
     readonly fetchPageWithErrors: <
-      L extends Employee.PropertyKeys,
-      R extends boolean,
+      const L extends Employee.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<Employee.Definition, L, R, A, S>,
     ) => Promise<
@@ -196,7 +196,6 @@ export namespace Employee {
     } & $OsdkObject<'Employee'>;
 }
 
-/** @deprecated use Employee.Definition **/
 export type Employee = Employee.Definition;
 
 export const Employee: Employee & $VersionBound<$ExpectedClientVersion> = {

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Office.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Office.ts
@@ -58,18 +58,18 @@ export namespace Office {
   }
 
   export interface ObjectSet extends $ObjectSet<Office.Definition, Office.ObjectSet> {
-    readonly aggregate: <AO extends $AggregateOpts<Office.Definition>>(
+    readonly aggregate: <const AO extends $AggregateOpts<Office.Definition>>(
       req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<Office.Definition, AO>,
     ) => Promise<$AggregationsResults<Office.Definition, AO>>;
 
-    readonly pivotTo: <L extends $LinkNames<Office.Definition>>(
+    readonly pivotTo: <const L extends $LinkNames<Office.Definition>>(
       type: L,
     ) => $LinkedType<Office.Definition, L>['objectSet'];
 
     readonly fetchOne: <
-      L extends Office.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends Office.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[Office.Definition['primaryKeyType']],
       options?: $SelectArg<Office.Definition, L, R, S>,
@@ -81,9 +81,9 @@ export namespace Office {
     >;
 
     readonly fetchOneWithErrors: <
-      L extends Office.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends Office.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[Office.Definition['primaryKeyType']],
       options?: $SelectArg<Office.Definition, L, R, S>,
@@ -97,10 +97,10 @@ export namespace Office {
     >;
 
     readonly fetchPage: <
-      L extends Office.PropertyKeys,
-      R extends boolean,
+      const L extends Office.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<Office.Definition, L, R, A, S>,
     ) => Promise<
@@ -113,10 +113,10 @@ export namespace Office {
     >;
 
     readonly fetchPageWithErrors: <
-      L extends Office.PropertyKeys,
-      R extends boolean,
+      const L extends Office.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<Office.Definition, L, R, A, S>,
     ) => Promise<
@@ -190,7 +190,6 @@ export namespace Office {
     } & $OsdkObject<'Office'>;
 }
 
-/** @deprecated use Office.Definition **/
 export type Office = Office.Definition;
 
 export const Office: Office & $VersionBound<$ExpectedClientVersion> = {

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Todo.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Todo.ts
@@ -46,16 +46,18 @@ export namespace Todo {
   }
 
   export interface ObjectSet extends $ObjectSet<Todo.Definition, Todo.ObjectSet> {
-    readonly aggregate: <AO extends $AggregateOpts<Todo.Definition>>(
+    readonly aggregate: <const AO extends $AggregateOpts<Todo.Definition>>(
       req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<Todo.Definition, AO>,
     ) => Promise<$AggregationsResults<Todo.Definition, AO>>;
 
-    readonly pivotTo: <L extends $LinkNames<Todo.Definition>>(type: L) => $LinkedType<Todo.Definition, L>['objectSet'];
+    readonly pivotTo: <const L extends $LinkNames<Todo.Definition>>(
+      type: L,
+    ) => $LinkedType<Todo.Definition, L>['objectSet'];
 
     readonly fetchOne: <
-      L extends Todo.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends Todo.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[Todo.Definition['primaryKeyType']],
       options?: $SelectArg<Todo.Definition, L, R, S>,
@@ -64,9 +66,9 @@ export namespace Todo {
     >;
 
     readonly fetchOneWithErrors: <
-      L extends Todo.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends Todo.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[Todo.Definition['primaryKeyType']],
       options?: $SelectArg<Todo.Definition, L, R, S>,
@@ -80,10 +82,10 @@ export namespace Todo {
     >;
 
     readonly fetchPage: <
-      L extends Todo.PropertyKeys,
-      R extends boolean,
+      const L extends Todo.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<Todo.Definition, L, R, A, S>,
     ) => Promise<
@@ -96,10 +98,10 @@ export namespace Todo {
     >;
 
     readonly fetchPageWithErrors: <
-      L extends Todo.PropertyKeys,
-      R extends boolean,
+      const L extends Todo.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<Todo.Definition, L, R, A, S>,
     ) => Promise<
@@ -162,7 +164,6 @@ export namespace Todo {
     } & $OsdkObject<'Todo'>;
 }
 
-/** @deprecated use Todo.Definition **/
 export type Todo = Todo.Definition;
 
 export const Todo: Todo & $VersionBound<$ExpectedClientVersion> = {

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/equipment.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/equipment.ts
@@ -44,18 +44,18 @@ export namespace equipment {
   }
 
   export interface ObjectSet extends $ObjectSet<equipment.Definition, equipment.ObjectSet> {
-    readonly aggregate: <AO extends $AggregateOpts<equipment.Definition>>(
+    readonly aggregate: <const AO extends $AggregateOpts<equipment.Definition>>(
       req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<equipment.Definition, AO>,
     ) => Promise<$AggregationsResults<equipment.Definition, AO>>;
 
-    readonly pivotTo: <L extends $LinkNames<equipment.Definition>>(
+    readonly pivotTo: <const L extends $LinkNames<equipment.Definition>>(
       type: L,
     ) => $LinkedType<equipment.Definition, L>['objectSet'];
 
     readonly fetchOne: <
-      L extends equipment.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends equipment.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[equipment.Definition['primaryKeyType']],
       options?: $SelectArg<equipment.Definition, L, R, S>,
@@ -67,9 +67,9 @@ export namespace equipment {
     >;
 
     readonly fetchOneWithErrors: <
-      L extends equipment.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends equipment.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[equipment.Definition['primaryKeyType']],
       options?: $SelectArg<equipment.Definition, L, R, S>,
@@ -83,10 +83,10 @@ export namespace equipment {
     >;
 
     readonly fetchPage: <
-      L extends equipment.PropertyKeys,
-      R extends boolean,
+      const L extends equipment.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<equipment.Definition, L, R, A, S>,
     ) => Promise<
@@ -99,10 +99,10 @@ export namespace equipment {
     >;
 
     readonly fetchPageWithErrors: <
-      L extends equipment.PropertyKeys,
-      R extends boolean,
+      const L extends equipment.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<equipment.Definition, L, R, A, S>,
     ) => Promise<
@@ -166,7 +166,6 @@ export namespace equipment {
     } & $OsdkObject<'equipment'>;
 }
 
-/** @deprecated use equipment.Definition **/
 export type equipment = equipment.Definition;
 
 export const equipment: equipment & $VersionBound<$ExpectedClientVersion> = {

--- a/packages/client.api/src/objectSet/ObjectSet.ts
+++ b/packages/client.api/src/objectSet/ObjectSet.ts
@@ -201,9 +201,9 @@ export interface ObjectSet<
    * Fetches one object with the specified primary key, without a result wrapper
    */
   readonly fetchOne: Q extends ObjectTypeDefinition<any> ? <
-      L extends ObjectOrInterfacePropertyKeysFrom2<Q>,
-      R extends boolean,
-      S extends false | "throw" = NullabilityAdherenceDefault,
+      const L extends ObjectOrInterfacePropertyKeysFrom2<Q>,
+      const R extends boolean,
+      const S extends false | "throw" = NullabilityAdherenceDefault,
     >(
       primaryKey: PropertyValueClientToWire[Q["primaryKeyType"]],
       options?: SelectArg<Q, L, R, S>,

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -20,6 +20,7 @@ import type {
   QueryDefinition,
   VersionBound,
 } from "@osdk/api";
+import type { ObjectSet } from "@osdk/client.api";
 import type { SharedClient } from "@osdk/shared.client";
 import type { ActionSignatureFromDef } from "./actions/applyAction.js";
 import type { MinimalClient } from "./MinimalClientContext.js";
@@ -39,7 +40,7 @@ export type CheckVersionBound<Q> = Q extends VersionBound<infer V> ? (
 export interface Client extends SharedClient<MinimalClient> {
   <Q extends ObjectTypeDefinition<any, any>>(
     o: Q,
-  ): Q["objectSet"];
+  ): unknown extends Q["objectSet"] ? ObjectSet<Q> : Q["objectSet"];
 
   <Q extends ActionDefinition<any, any, any>>(
     o: Q,

--- a/packages/client/src/__unstable/UnstableClient.ts
+++ b/packages/client/src/__unstable/UnstableClient.ts
@@ -19,7 +19,7 @@ import type {
   ObjectOrInterfaceDefinition,
   ObjectTypeDefinition,
 } from "@osdk/api";
-import type { Osdk } from "@osdk/client.api";
+import type { MinimalObjectSet, Osdk } from "@osdk/client.api";
 import type { Client } from "../Client.js";
 import type { UNSTABLE_ObjectSet } from "../objectSet/createUnstableObjectSet.js";
 import type { BulkLinkResult } from "./createBulkLinksAsyncIterFactory.js";
@@ -27,7 +27,7 @@ import type { BulkLinkResult } from "./createBulkLinksAsyncIterFactory.js";
 export interface UnstableClient extends Client {
   <Q extends (InterfaceDefinition<any, any>)>(
     o: Q,
-  ): Q["objectSet"];
+  ): unknown extends Q["objectSet"] ? MinimalObjectSet<Q> : Q["objectSet"];
 
   <Q extends (ObjectTypeDefinition<any, any>)>(
     o: Q,

--- a/packages/client/src/object/object.test.ts
+++ b/packages/client/src/object/object.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { Osdk } from "@osdk/client.api";
 import { $ontologyRid, Employee } from "@osdk/client.test.ontology";
 import { apiServer, stubData, withoutRid } from "@osdk/shared.test";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -152,3 +153,33 @@ describe("OsdkObject", () => {
     });
   });
 });
+
+async function shouldError(client: Client): Promise<Osdk<Employee>> {
+  // @ts-expect-error
+  return client(Employee).fetchOne(1, {
+    $select: ["employeeId"],
+  });
+}
+
+async function shouldError2(client: Client): Promise<Employee.OsdkObject> {
+  // @ts-expect-error
+  return client(Employee).fetchOne(1, {
+    $select: ["employeeId"],
+  });
+}
+
+async function shouldCompile(
+  client: Client,
+): Promise<Osdk<Employee, "employeeId">> {
+  return client(Employee).fetchOne(1, {
+    $select: ["employeeId"],
+  });
+}
+
+async function shouldCompile2(
+  client: Client,
+): Promise<Employee.OsdkObject<never, "employeeId">> {
+  return client(Employee).fetchOne(1, {
+    $select: ["employeeId"],
+  });
+}

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/ontology/interfaces/SomeInterface.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/ontology/interfaces/SomeInterface.ts
@@ -37,19 +37,19 @@ export namespace SomeInterface {
   }
 
   export interface ObjectSet extends $ObjectSet<SomeInterface.Definition, SomeInterface.ObjectSet> {
-    readonly aggregate: <AO extends $AggregateOpts<SomeInterface.Definition>>(
+    readonly aggregate: <const AO extends $AggregateOpts<SomeInterface.Definition>>(
       req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<SomeInterface.Definition, AO>,
     ) => Promise<$AggregationsResults<SomeInterface.Definition, AO>>;
 
-    readonly pivotTo: <L extends $LinkNames<SomeInterface.Definition>>(
+    readonly pivotTo: <const L extends $LinkNames<SomeInterface.Definition>>(
       type: L,
     ) => $LinkedType<SomeInterface.Definition, L>['objectSet'];
 
     readonly fetchPage: <
-      L extends SomeInterface.PropertyKeys,
-      R extends boolean,
+      const L extends SomeInterface.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<SomeInterface.Definition, L, R, A, S>,
     ) => Promise<
@@ -62,10 +62,10 @@ export namespace SomeInterface {
     >;
 
     readonly fetchPageWithErrors: <
-      L extends SomeInterface.PropertyKeys,
-      R extends boolean,
+      const L extends SomeInterface.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<SomeInterface.Definition, L, R, A, S>,
     ) => Promise<

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/ontology/objects/Task.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/ontology/objects/Task.ts
@@ -44,16 +44,18 @@ export namespace Task {
   }
 
   export interface ObjectSet extends $ObjectSet<Task.Definition, Task.ObjectSet> {
-    readonly aggregate: <AO extends $AggregateOpts<Task.Definition>>(
+    readonly aggregate: <const AO extends $AggregateOpts<Task.Definition>>(
       req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<Task.Definition, AO>,
     ) => Promise<$AggregationsResults<Task.Definition, AO>>;
 
-    readonly pivotTo: <L extends $LinkNames<Task.Definition>>(type: L) => $LinkedType<Task.Definition, L>['objectSet'];
+    readonly pivotTo: <const L extends $LinkNames<Task.Definition>>(
+      type: L,
+    ) => $LinkedType<Task.Definition, L>['objectSet'];
 
     readonly fetchOne: <
-      L extends Task.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends Task.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[Task.Definition['primaryKeyType']],
       options?: $SelectArg<Task.Definition, L, R, S>,
@@ -62,9 +64,9 @@ export namespace Task {
     >;
 
     readonly fetchOneWithErrors: <
-      L extends Task.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends Task.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[Task.Definition['primaryKeyType']],
       options?: $SelectArg<Task.Definition, L, R, S>,
@@ -78,10 +80,10 @@ export namespace Task {
     >;
 
     readonly fetchPage: <
-      L extends Task.PropertyKeys,
-      R extends boolean,
+      const L extends Task.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<Task.Definition, L, R, A, S>,
     ) => Promise<
@@ -94,10 +96,10 @@ export namespace Task {
     >;
 
     readonly fetchPageWithErrors: <
-      L extends Task.PropertyKeys,
-      R extends boolean,
+      const L extends Task.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<Task.Definition, L, R, A, S>,
     ) => Promise<
@@ -159,7 +161,6 @@ export namespace Task {
     } & $OsdkObject<'com.example.dep.Task'>;
 }
 
-/** @deprecated use Task.Definition **/
 export type Task = Task.Definition;
 
 export const Task: Task & $VersionBound<$ExpectedClientVersion> = {

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/objects/Thing.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/objects/Thing.ts
@@ -44,18 +44,18 @@ export namespace Thing {
   }
 
   export interface ObjectSet extends $ObjectSet<Thing.Definition, Thing.ObjectSet> {
-    readonly aggregate: <AO extends $AggregateOpts<Thing.Definition>>(
+    readonly aggregate: <const AO extends $AggregateOpts<Thing.Definition>>(
       req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<Thing.Definition, AO>,
     ) => Promise<$AggregationsResults<Thing.Definition, AO>>;
 
-    readonly pivotTo: <L extends $LinkNames<Thing.Definition>>(
+    readonly pivotTo: <const L extends $LinkNames<Thing.Definition>>(
       type: L,
     ) => $LinkedType<Thing.Definition, L>['objectSet'];
 
     readonly fetchOne: <
-      L extends Thing.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends Thing.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[Thing.Definition['primaryKeyType']],
       options?: $SelectArg<Thing.Definition, L, R, S>,
@@ -67,9 +67,9 @@ export namespace Thing {
     >;
 
     readonly fetchOneWithErrors: <
-      L extends Thing.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends Thing.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[Thing.Definition['primaryKeyType']],
       options?: $SelectArg<Thing.Definition, L, R, S>,
@@ -83,10 +83,10 @@ export namespace Thing {
     >;
 
     readonly fetchPage: <
-      L extends Thing.PropertyKeys,
-      R extends boolean,
+      const L extends Thing.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<Thing.Definition, L, R, A, S>,
     ) => Promise<
@@ -99,10 +99,10 @@ export namespace Thing {
     >;
 
     readonly fetchPageWithErrors: <
-      L extends Thing.PropertyKeys,
-      R extends boolean,
+      const L extends Thing.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<Thing.Definition, L, R, A, S>,
     ) => Promise<
@@ -172,7 +172,6 @@ export namespace Thing {
     } & $OsdkObject<'Thing'>;
 }
 
-/** @deprecated use Thing.Definition **/
 export type Thing = Thing.Definition;
 
 export const Thing: Thing & $VersionBound<$ExpectedClientVersion> = {

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/objects/UsesForeignSpt.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/objects/UsesForeignSpt.ts
@@ -44,18 +44,18 @@ export namespace UsesForeignSpt {
   }
 
   export interface ObjectSet extends $ObjectSet<UsesForeignSpt.Definition, UsesForeignSpt.ObjectSet> {
-    readonly aggregate: <AO extends $AggregateOpts<UsesForeignSpt.Definition>>(
+    readonly aggregate: <const AO extends $AggregateOpts<UsesForeignSpt.Definition>>(
       req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<UsesForeignSpt.Definition, AO>,
     ) => Promise<$AggregationsResults<UsesForeignSpt.Definition, AO>>;
 
-    readonly pivotTo: <L extends $LinkNames<UsesForeignSpt.Definition>>(
+    readonly pivotTo: <const L extends $LinkNames<UsesForeignSpt.Definition>>(
       type: L,
     ) => $LinkedType<UsesForeignSpt.Definition, L>['objectSet'];
 
     readonly fetchOne: <
-      L extends UsesForeignSpt.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends UsesForeignSpt.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[UsesForeignSpt.Definition['primaryKeyType']],
       options?: $SelectArg<UsesForeignSpt.Definition, L, R, S>,
@@ -67,9 +67,9 @@ export namespace UsesForeignSpt {
     >;
 
     readonly fetchOneWithErrors: <
-      L extends UsesForeignSpt.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends UsesForeignSpt.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[UsesForeignSpt.Definition['primaryKeyType']],
       options?: $SelectArg<UsesForeignSpt.Definition, L, R, S>,
@@ -83,10 +83,10 @@ export namespace UsesForeignSpt {
     >;
 
     readonly fetchPage: <
-      L extends UsesForeignSpt.PropertyKeys,
-      R extends boolean,
+      const L extends UsesForeignSpt.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<UsesForeignSpt.Definition, L, R, A, S>,
     ) => Promise<
@@ -99,10 +99,10 @@ export namespace UsesForeignSpt {
     >;
 
     readonly fetchPageWithErrors: <
-      L extends UsesForeignSpt.PropertyKeys,
-      R extends boolean,
+      const L extends UsesForeignSpt.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<UsesForeignSpt.Definition, L, R, A, S>,
     ) => Promise<
@@ -172,7 +172,6 @@ export namespace UsesForeignSpt {
     } & $OsdkObject<'UsesForeignSpt'>;
 }
 
-/** @deprecated use UsesForeignSpt.Definition **/
 export type UsesForeignSpt = UsesForeignSpt.Definition;
 
 export const UsesForeignSpt: UsesForeignSpt & $VersionBound<$ExpectedClientVersion> = {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/FooInterface.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/FooInterface.ts
@@ -39,19 +39,19 @@ export namespace FooInterface {
   }
 
   export interface ObjectSet extends $ObjectSet<FooInterface.Definition, FooInterface.ObjectSet> {
-    readonly aggregate: <AO extends $AggregateOpts<FooInterface.Definition>>(
+    readonly aggregate: <const AO extends $AggregateOpts<FooInterface.Definition>>(
       req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<FooInterface.Definition, AO>,
     ) => Promise<$AggregationsResults<FooInterface.Definition, AO>>;
 
-    readonly pivotTo: <L extends $LinkNames<FooInterface.Definition>>(
+    readonly pivotTo: <const L extends $LinkNames<FooInterface.Definition>>(
       type: L,
     ) => $LinkedType<FooInterface.Definition, L>['objectSet'];
 
     readonly fetchPage: <
-      L extends FooInterface.PropertyKeys,
-      R extends boolean,
+      const L extends FooInterface.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<FooInterface.Definition, L, R, A, S>,
     ) => Promise<
@@ -64,10 +64,10 @@ export namespace FooInterface {
     >;
 
     readonly fetchPageWithErrors: <
-      L extends FooInterface.PropertyKeys,
-      R extends boolean,
+      const L extends FooInterface.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<FooInterface.Definition, L, R, A, S>,
     ) => Promise<

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/BoundariesUsState.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/BoundariesUsState.ts
@@ -48,18 +48,18 @@ export namespace BoundariesUsState {
   }
 
   export interface ObjectSet extends $ObjectSet<BoundariesUsState.Definition, BoundariesUsState.ObjectSet> {
-    readonly aggregate: <AO extends $AggregateOpts<BoundariesUsState.Definition>>(
+    readonly aggregate: <const AO extends $AggregateOpts<BoundariesUsState.Definition>>(
       req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<BoundariesUsState.Definition, AO>,
     ) => Promise<$AggregationsResults<BoundariesUsState.Definition, AO>>;
 
-    readonly pivotTo: <L extends $LinkNames<BoundariesUsState.Definition>>(
+    readonly pivotTo: <const L extends $LinkNames<BoundariesUsState.Definition>>(
       type: L,
     ) => $LinkedType<BoundariesUsState.Definition, L>['objectSet'];
 
     readonly fetchOne: <
-      L extends BoundariesUsState.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends BoundariesUsState.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[BoundariesUsState.Definition['primaryKeyType']],
       options?: $SelectArg<BoundariesUsState.Definition, L, R, S>,
@@ -71,9 +71,9 @@ export namespace BoundariesUsState {
     >;
 
     readonly fetchOneWithErrors: <
-      L extends BoundariesUsState.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends BoundariesUsState.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[BoundariesUsState.Definition['primaryKeyType']],
       options?: $SelectArg<BoundariesUsState.Definition, L, R, S>,
@@ -87,10 +87,10 @@ export namespace BoundariesUsState {
     >;
 
     readonly fetchPage: <
-      L extends BoundariesUsState.PropertyKeys,
-      R extends boolean,
+      const L extends BoundariesUsState.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<BoundariesUsState.Definition, L, R, A, S>,
     ) => Promise<
@@ -103,10 +103,10 @@ export namespace BoundariesUsState {
     >;
 
     readonly fetchPageWithErrors: <
-      L extends BoundariesUsState.PropertyKeys,
-      R extends boolean,
+      const L extends BoundariesUsState.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<BoundariesUsState.Definition, L, R, A, S>,
     ) => Promise<
@@ -177,7 +177,6 @@ export namespace BoundariesUsState {
     } & $OsdkObject<'BoundariesUsState'>;
 }
 
-/** @deprecated use BoundariesUsState.Definition **/
 export type BoundariesUsState = BoundariesUsState.Definition;
 
 export const BoundariesUsState: BoundariesUsState & $VersionBound<$ExpectedClientVersion> = {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/BuilderDeploymentState.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/BuilderDeploymentState.ts
@@ -46,18 +46,18 @@ export namespace BuilderDeploymentState {
   }
 
   export interface ObjectSet extends $ObjectSet<BuilderDeploymentState.Definition, BuilderDeploymentState.ObjectSet> {
-    readonly aggregate: <AO extends $AggregateOpts<BuilderDeploymentState.Definition>>(
+    readonly aggregate: <const AO extends $AggregateOpts<BuilderDeploymentState.Definition>>(
       req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<BuilderDeploymentState.Definition, AO>,
     ) => Promise<$AggregationsResults<BuilderDeploymentState.Definition, AO>>;
 
-    readonly pivotTo: <L extends $LinkNames<BuilderDeploymentState.Definition>>(
+    readonly pivotTo: <const L extends $LinkNames<BuilderDeploymentState.Definition>>(
       type: L,
     ) => $LinkedType<BuilderDeploymentState.Definition, L>['objectSet'];
 
     readonly fetchOne: <
-      L extends BuilderDeploymentState.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends BuilderDeploymentState.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[BuilderDeploymentState.Definition['primaryKeyType']],
       options?: $SelectArg<BuilderDeploymentState.Definition, L, R, S>,
@@ -69,9 +69,9 @@ export namespace BuilderDeploymentState {
     >;
 
     readonly fetchOneWithErrors: <
-      L extends BuilderDeploymentState.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends BuilderDeploymentState.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[BuilderDeploymentState.Definition['primaryKeyType']],
       options?: $SelectArg<BuilderDeploymentState.Definition, L, R, S>,
@@ -85,10 +85,10 @@ export namespace BuilderDeploymentState {
     >;
 
     readonly fetchPage: <
-      L extends BuilderDeploymentState.PropertyKeys,
-      R extends boolean,
+      const L extends BuilderDeploymentState.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<BuilderDeploymentState.Definition, L, R, A, S>,
     ) => Promise<
@@ -101,10 +101,10 @@ export namespace BuilderDeploymentState {
     >;
 
     readonly fetchPageWithErrors: <
-      L extends BuilderDeploymentState.PropertyKeys,
-      R extends boolean,
+      const L extends BuilderDeploymentState.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<BuilderDeploymentState.Definition, L, R, A, S>,
     ) => Promise<
@@ -170,7 +170,6 @@ export namespace BuilderDeploymentState {
     } & $OsdkObject<'BuilderDeploymentState'>;
 }
 
-/** @deprecated use BuilderDeploymentState.Definition **/
 export type BuilderDeploymentState = BuilderDeploymentState.Definition;
 
 export const BuilderDeploymentState: BuilderDeploymentState & $VersionBound<$ExpectedClientVersion> = {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/DherlihyComplexObject.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/DherlihyComplexObject.ts
@@ -46,18 +46,18 @@ export namespace DherlihyComplexObject {
   }
 
   export interface ObjectSet extends $ObjectSet<DherlihyComplexObject.Definition, DherlihyComplexObject.ObjectSet> {
-    readonly aggregate: <AO extends $AggregateOpts<DherlihyComplexObject.Definition>>(
+    readonly aggregate: <const AO extends $AggregateOpts<DherlihyComplexObject.Definition>>(
       req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<DherlihyComplexObject.Definition, AO>,
     ) => Promise<$AggregationsResults<DherlihyComplexObject.Definition, AO>>;
 
-    readonly pivotTo: <L extends $LinkNames<DherlihyComplexObject.Definition>>(
+    readonly pivotTo: <const L extends $LinkNames<DherlihyComplexObject.Definition>>(
       type: L,
     ) => $LinkedType<DherlihyComplexObject.Definition, L>['objectSet'];
 
     readonly fetchOne: <
-      L extends DherlihyComplexObject.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends DherlihyComplexObject.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[DherlihyComplexObject.Definition['primaryKeyType']],
       options?: $SelectArg<DherlihyComplexObject.Definition, L, R, S>,
@@ -69,9 +69,9 @@ export namespace DherlihyComplexObject {
     >;
 
     readonly fetchOneWithErrors: <
-      L extends DherlihyComplexObject.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends DherlihyComplexObject.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[DherlihyComplexObject.Definition['primaryKeyType']],
       options?: $SelectArg<DherlihyComplexObject.Definition, L, R, S>,
@@ -85,10 +85,10 @@ export namespace DherlihyComplexObject {
     >;
 
     readonly fetchPage: <
-      L extends DherlihyComplexObject.PropertyKeys,
-      R extends boolean,
+      const L extends DherlihyComplexObject.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<DherlihyComplexObject.Definition, L, R, A, S>,
     ) => Promise<
@@ -101,10 +101,10 @@ export namespace DherlihyComplexObject {
     >;
 
     readonly fetchPageWithErrors: <
-      L extends DherlihyComplexObject.PropertyKeys,
-      R extends boolean,
+      const L extends DherlihyComplexObject.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<DherlihyComplexObject.Definition, L, R, A, S>,
     ) => Promise<
@@ -170,7 +170,6 @@ export namespace DherlihyComplexObject {
     } & $OsdkObject<'DherlihyComplexObject'>;
 }
 
-/** @deprecated use DherlihyComplexObject.Definition **/
 export type DherlihyComplexObject = DherlihyComplexObject.Definition;
 
 export const DherlihyComplexObject: DherlihyComplexObject & $VersionBound<$ExpectedClientVersion> = {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Employee.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Employee.ts
@@ -83,18 +83,18 @@ export namespace Employee {
   }
 
   export interface ObjectSet extends $ObjectSet<Employee.Definition, Employee.ObjectSet> {
-    readonly aggregate: <AO extends $AggregateOpts<Employee.Definition>>(
+    readonly aggregate: <const AO extends $AggregateOpts<Employee.Definition>>(
       req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<Employee.Definition, AO>,
     ) => Promise<$AggregationsResults<Employee.Definition, AO>>;
 
-    readonly pivotTo: <L extends $LinkNames<Employee.Definition>>(
+    readonly pivotTo: <const L extends $LinkNames<Employee.Definition>>(
       type: L,
     ) => $LinkedType<Employee.Definition, L>['objectSet'];
 
     readonly fetchOne: <
-      L extends Employee.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends Employee.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[Employee.Definition['primaryKeyType']],
       options?: $SelectArg<Employee.Definition, L, R, S>,
@@ -106,9 +106,9 @@ export namespace Employee {
     >;
 
     readonly fetchOneWithErrors: <
-      L extends Employee.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends Employee.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[Employee.Definition['primaryKeyType']],
       options?: $SelectArg<Employee.Definition, L, R, S>,
@@ -122,10 +122,10 @@ export namespace Employee {
     >;
 
     readonly fetchPage: <
-      L extends Employee.PropertyKeys,
-      R extends boolean,
+      const L extends Employee.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<Employee.Definition, L, R, A, S>,
     ) => Promise<
@@ -138,10 +138,10 @@ export namespace Employee {
     >;
 
     readonly fetchPageWithErrors: <
-      L extends Employee.PropertyKeys,
-      R extends boolean,
+      const L extends Employee.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<Employee.Definition, L, R, A, S>,
     ) => Promise<
@@ -268,7 +268,6 @@ export namespace Employee {
     } & $OsdkObject<'Employee'>;
 }
 
-/** @deprecated use Employee.Definition **/
 export type Employee = Employee.Definition;
 
 export const Employee: Employee & $VersionBound<$ExpectedClientVersion> = {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/ObjectTypeWithAllPropertyTypes.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/ObjectTypeWithAllPropertyTypes.ts
@@ -134,21 +134,21 @@ export namespace ObjectTypeWithAllPropertyTypes {
 
   export interface ObjectSet
     extends $ObjectSet<ObjectTypeWithAllPropertyTypes.Definition, ObjectTypeWithAllPropertyTypes.ObjectSet> {
-    readonly aggregate: <AO extends $AggregateOpts<ObjectTypeWithAllPropertyTypes.Definition>>(
+    readonly aggregate: <const AO extends $AggregateOpts<ObjectTypeWithAllPropertyTypes.Definition>>(
       req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<
         ObjectTypeWithAllPropertyTypes.Definition,
         AO
       >,
     ) => Promise<$AggregationsResults<ObjectTypeWithAllPropertyTypes.Definition, AO>>;
 
-    readonly pivotTo: <L extends $LinkNames<ObjectTypeWithAllPropertyTypes.Definition>>(
+    readonly pivotTo: <const L extends $LinkNames<ObjectTypeWithAllPropertyTypes.Definition>>(
       type: L,
     ) => $LinkedType<ObjectTypeWithAllPropertyTypes.Definition, L>['objectSet'];
 
     readonly fetchOne: <
-      L extends ObjectTypeWithAllPropertyTypes.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends ObjectTypeWithAllPropertyTypes.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[ObjectTypeWithAllPropertyTypes.Definition['primaryKeyType']],
       options?: $SelectArg<ObjectTypeWithAllPropertyTypes.Definition, L, R, S>,
@@ -160,9 +160,9 @@ export namespace ObjectTypeWithAllPropertyTypes {
     >;
 
     readonly fetchOneWithErrors: <
-      L extends ObjectTypeWithAllPropertyTypes.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends ObjectTypeWithAllPropertyTypes.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[ObjectTypeWithAllPropertyTypes.Definition['primaryKeyType']],
       options?: $SelectArg<ObjectTypeWithAllPropertyTypes.Definition, L, R, S>,
@@ -176,10 +176,10 @@ export namespace ObjectTypeWithAllPropertyTypes {
     >;
 
     readonly fetchPage: <
-      L extends ObjectTypeWithAllPropertyTypes.PropertyKeys,
-      R extends boolean,
+      const L extends ObjectTypeWithAllPropertyTypes.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<ObjectTypeWithAllPropertyTypes.Definition, L, R, A, S>,
     ) => Promise<
@@ -192,10 +192,10 @@ export namespace ObjectTypeWithAllPropertyTypes {
     >;
 
     readonly fetchPageWithErrors: <
-      L extends ObjectTypeWithAllPropertyTypes.PropertyKeys,
-      R extends boolean,
+      const L extends ObjectTypeWithAllPropertyTypes.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<ObjectTypeWithAllPropertyTypes.Definition, L, R, A, S>,
     ) => Promise<
@@ -373,7 +373,6 @@ export namespace ObjectTypeWithAllPropertyTypes {
     } & $OsdkObject<'ObjectTypeWithAllPropertyTypes'>;
 }
 
-/** @deprecated use ObjectTypeWithAllPropertyTypes.Definition **/
 export type ObjectTypeWithAllPropertyTypes = ObjectTypeWithAllPropertyTypes.Definition;
 
 export const ObjectTypeWithAllPropertyTypes: ObjectTypeWithAllPropertyTypes & $VersionBound<$ExpectedClientVersion> = {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Person.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Person.ts
@@ -47,18 +47,18 @@ export namespace Person {
   }
 
   export interface ObjectSet extends $ObjectSet<Person.Definition, Person.ObjectSet> {
-    readonly aggregate: <AO extends $AggregateOpts<Person.Definition>>(
+    readonly aggregate: <const AO extends $AggregateOpts<Person.Definition>>(
       req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<Person.Definition, AO>,
     ) => Promise<$AggregationsResults<Person.Definition, AO>>;
 
-    readonly pivotTo: <L extends $LinkNames<Person.Definition>>(
+    readonly pivotTo: <const L extends $LinkNames<Person.Definition>>(
       type: L,
     ) => $LinkedType<Person.Definition, L>['objectSet'];
 
     readonly fetchOne: <
-      L extends Person.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends Person.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[Person.Definition['primaryKeyType']],
       options?: $SelectArg<Person.Definition, L, R, S>,
@@ -70,9 +70,9 @@ export namespace Person {
     >;
 
     readonly fetchOneWithErrors: <
-      L extends Person.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends Person.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[Person.Definition['primaryKeyType']],
       options?: $SelectArg<Person.Definition, L, R, S>,
@@ -86,10 +86,10 @@ export namespace Person {
     >;
 
     readonly fetchPage: <
-      L extends Person.PropertyKeys,
-      R extends boolean,
+      const L extends Person.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<Person.Definition, L, R, A, S>,
     ) => Promise<
@@ -102,10 +102,10 @@ export namespace Person {
     >;
 
     readonly fetchPageWithErrors: <
-      L extends Person.PropertyKeys,
-      R extends boolean,
+      const L extends Person.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<Person.Definition, L, R, A, S>,
     ) => Promise<
@@ -162,7 +162,6 @@ export namespace Person {
     } & $OsdkObject<'Person'>;
 }
 
-/** @deprecated use Person.Definition **/
 export type Person = Person.Definition;
 
 export const Person: Person & $VersionBound<$ExpectedClientVersion> = {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Todo.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Todo.ts
@@ -55,16 +55,18 @@ export namespace Todo {
   }
 
   export interface ObjectSet extends $ObjectSet<Todo.Definition, Todo.ObjectSet> {
-    readonly aggregate: <AO extends $AggregateOpts<Todo.Definition>>(
+    readonly aggregate: <const AO extends $AggregateOpts<Todo.Definition>>(
       req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<Todo.Definition, AO>,
     ) => Promise<$AggregationsResults<Todo.Definition, AO>>;
 
-    readonly pivotTo: <L extends $LinkNames<Todo.Definition>>(type: L) => $LinkedType<Todo.Definition, L>['objectSet'];
+    readonly pivotTo: <const L extends $LinkNames<Todo.Definition>>(
+      type: L,
+    ) => $LinkedType<Todo.Definition, L>['objectSet'];
 
     readonly fetchOne: <
-      L extends Todo.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends Todo.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[Todo.Definition['primaryKeyType']],
       options?: $SelectArg<Todo.Definition, L, R, S>,
@@ -73,9 +75,9 @@ export namespace Todo {
     >;
 
     readonly fetchOneWithErrors: <
-      L extends Todo.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends Todo.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[Todo.Definition['primaryKeyType']],
       options?: $SelectArg<Todo.Definition, L, R, S>,
@@ -89,10 +91,10 @@ export namespace Todo {
     >;
 
     readonly fetchPage: <
-      L extends Todo.PropertyKeys,
-      R extends boolean,
+      const L extends Todo.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<Todo.Definition, L, R, A, S>,
     ) => Promise<
@@ -105,10 +107,10 @@ export namespace Todo {
     >;
 
     readonly fetchPageWithErrors: <
-      L extends Todo.PropertyKeys,
-      R extends boolean,
+      const L extends Todo.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<Todo.Definition, L, R, A, S>,
     ) => Promise<
@@ -181,7 +183,6 @@ export namespace Todo {
     } & $OsdkObject<'Todo'>;
 }
 
-/** @deprecated use Todo.Definition **/
 export type Todo = Todo.Definition;
 
 export const Todo: Todo & $VersionBound<$ExpectedClientVersion> = {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Venture.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Venture.ts
@@ -50,18 +50,18 @@ export namespace Venture {
   }
 
   export interface ObjectSet extends $ObjectSet<Venture.Definition, Venture.ObjectSet> {
-    readonly aggregate: <AO extends $AggregateOpts<Venture.Definition>>(
+    readonly aggregate: <const AO extends $AggregateOpts<Venture.Definition>>(
       req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<Venture.Definition, AO>,
     ) => Promise<$AggregationsResults<Venture.Definition, AO>>;
 
-    readonly pivotTo: <L extends $LinkNames<Venture.Definition>>(
+    readonly pivotTo: <const L extends $LinkNames<Venture.Definition>>(
       type: L,
     ) => $LinkedType<Venture.Definition, L>['objectSet'];
 
     readonly fetchOne: <
-      L extends Venture.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends Venture.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[Venture.Definition['primaryKeyType']],
       options?: $SelectArg<Venture.Definition, L, R, S>,
@@ -73,9 +73,9 @@ export namespace Venture {
     >;
 
     readonly fetchOneWithErrors: <
-      L extends Venture.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends Venture.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[Venture.Definition['primaryKeyType']],
       options?: $SelectArg<Venture.Definition, L, R, S>,
@@ -89,10 +89,10 @@ export namespace Venture {
     >;
 
     readonly fetchPage: <
-      L extends Venture.PropertyKeys,
-      R extends boolean,
+      const L extends Venture.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<Venture.Definition, L, R, A, S>,
     ) => Promise<
@@ -105,10 +105,10 @@ export namespace Venture {
     >;
 
     readonly fetchPageWithErrors: <
-      L extends Venture.PropertyKeys,
-      R extends boolean,
+      const L extends Venture.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<Venture.Definition, L, R, A, S>,
     ) => Promise<
@@ -176,7 +176,6 @@ export namespace Venture {
     } & $OsdkObject<'Venture'>;
 }
 
-/** @deprecated use Venture.Definition **/
 export type Venture = Venture.Definition;
 
 export const Venture: Venture & $VersionBound<$ExpectedClientVersion> = {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/WeatherStation.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/WeatherStation.ts
@@ -44,18 +44,18 @@ export namespace WeatherStation {
   }
 
   export interface ObjectSet extends $ObjectSet<WeatherStation.Definition, WeatherStation.ObjectSet> {
-    readonly aggregate: <AO extends $AggregateOpts<WeatherStation.Definition>>(
+    readonly aggregate: <const AO extends $AggregateOpts<WeatherStation.Definition>>(
       req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<WeatherStation.Definition, AO>,
     ) => Promise<$AggregationsResults<WeatherStation.Definition, AO>>;
 
-    readonly pivotTo: <L extends $LinkNames<WeatherStation.Definition>>(
+    readonly pivotTo: <const L extends $LinkNames<WeatherStation.Definition>>(
       type: L,
     ) => $LinkedType<WeatherStation.Definition, L>['objectSet'];
 
     readonly fetchOne: <
-      L extends WeatherStation.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends WeatherStation.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[WeatherStation.Definition['primaryKeyType']],
       options?: $SelectArg<WeatherStation.Definition, L, R, S>,
@@ -67,9 +67,9 @@ export namespace WeatherStation {
     >;
 
     readonly fetchOneWithErrors: <
-      L extends WeatherStation.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends WeatherStation.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[WeatherStation.Definition['primaryKeyType']],
       options?: $SelectArg<WeatherStation.Definition, L, R, S>,
@@ -83,10 +83,10 @@ export namespace WeatherStation {
     >;
 
     readonly fetchPage: <
-      L extends WeatherStation.PropertyKeys,
-      R extends boolean,
+      const L extends WeatherStation.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<WeatherStation.Definition, L, R, A, S>,
     ) => Promise<
@@ -99,10 +99,10 @@ export namespace WeatherStation {
     >;
 
     readonly fetchPageWithErrors: <
-      L extends WeatherStation.PropertyKeys,
-      R extends boolean,
+      const L extends WeatherStation.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<WeatherStation.Definition, L, R, A, S>,
     ) => Promise<
@@ -165,7 +165,6 @@ export namespace WeatherStation {
     } & $OsdkObject<'WeatherStation'>;
 }
 
-/** @deprecated use WeatherStation.Definition **/
 export type WeatherStation = WeatherStation.Definition;
 
 export const WeatherStation: WeatherStation & $VersionBound<$ExpectedClientVersion> = {

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/ontology/objects/Todo.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/ontology/objects/Todo.ts
@@ -46,16 +46,18 @@ export namespace Todo {
   }
 
   export interface ObjectSet extends $ObjectSet<Todo.Definition, Todo.ObjectSet> {
-    readonly aggregate: <AO extends $AggregateOpts<Todo.Definition>>(
+    readonly aggregate: <const AO extends $AggregateOpts<Todo.Definition>>(
       req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<Todo.Definition, AO>,
     ) => Promise<$AggregationsResults<Todo.Definition, AO>>;
 
-    readonly pivotTo: <L extends $LinkNames<Todo.Definition>>(type: L) => $LinkedType<Todo.Definition, L>['objectSet'];
+    readonly pivotTo: <const L extends $LinkNames<Todo.Definition>>(
+      type: L,
+    ) => $LinkedType<Todo.Definition, L>['objectSet'];
 
     readonly fetchOne: <
-      L extends Todo.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends Todo.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[Todo.Definition['primaryKeyType']],
       options?: $SelectArg<Todo.Definition, L, R, S>,
@@ -64,9 +66,9 @@ export namespace Todo {
     >;
 
     readonly fetchOneWithErrors: <
-      L extends Todo.PropertyKeys,
-      R extends boolean,
-      S extends false | 'throw' = $NullabilityAdherenceDefault,
+      const L extends Todo.PropertyKeys,
+      const R extends boolean,
+      const S extends false | 'throw' = $NullabilityAdherenceDefault,
     >(
       primaryKey: $PropertyValueClientToWire[Todo.Definition['primaryKeyType']],
       options?: $SelectArg<Todo.Definition, L, R, S>,
@@ -80,10 +82,10 @@ export namespace Todo {
     >;
 
     readonly fetchPage: <
-      L extends Todo.PropertyKeys,
-      R extends boolean,
+      const L extends Todo.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<Todo.Definition, L, R, A, S>,
     ) => Promise<
@@ -96,10 +98,10 @@ export namespace Todo {
     >;
 
     readonly fetchPageWithErrors: <
-      L extends Todo.PropertyKeys,
-      R extends boolean,
+      const L extends Todo.PropertyKeys,
+      const R extends boolean,
       const A extends $Augments,
-      S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+      const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
     >(
       args?: $FetchPageArgs<Todo.Definition, L, R, A, S>,
     ) => Promise<
@@ -162,7 +164,6 @@ export namespace Todo {
     } & $OsdkObject<'Todo'>;
 }
 
-/** @deprecated use Todo.Definition **/
 export type Todo = Todo.Definition;
 
 export const Todo: Todo & $VersionBound<$ExpectedClientVersion> = {

--- a/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.test.ts
+++ b/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.test.ts
@@ -154,19 +154,19 @@ describe(__UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst, () => {
         }
 
         export interface ObjectSet extends $ObjectSet<Bar.Definition, Bar.ObjectSet> {
-          readonly aggregate: <AO extends $AggregateOpts<Bar.Definition>>(
+          readonly aggregate: <const AO extends $AggregateOpts<Bar.Definition>>(
             req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<Bar.Definition, AO>,
           ) => Promise<$AggregationsResults<Bar.Definition, AO>>;
 
-          readonly pivotTo: <L extends $LinkNames<Bar.Definition>>(
+          readonly pivotTo: <const L extends $LinkNames<Bar.Definition>>(
             type: L,
           ) => $LinkedType<Bar.Definition, L>["objectSet"];
 
           readonly fetchPage: <
-            L extends Bar.PropertyKeys,
-            R extends boolean,
+            const L extends Bar.PropertyKeys,
+            const R extends boolean,
             const A extends $Augments,
-            S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+            const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
           >(
             args?: $FetchPageArgs<Bar.Definition, L, R, A, S>,
           ) => Promise<
@@ -180,10 +180,10 @@ describe(__UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst, () => {
           >;
 
           readonly fetchPageWithErrors: <
-            L extends Bar.PropertyKeys,
-            R extends boolean,
+            const L extends Bar.PropertyKeys,
+            const R extends boolean,
             const A extends $Augments,
-            S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+            const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
           >(
             args?: $FetchPageArgs<Bar.Definition, L, R, A, S>,
           ) => Promise<
@@ -342,22 +342,22 @@ describe(__UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst, () => {
         }
 
         export interface ObjectSet extends $ObjectSet<Foo.Definition, Foo.ObjectSet> {
-          readonly aggregate: <AO extends $AggregateOpts<Foo.Definition>>(
+          readonly aggregate: <const AO extends $AggregateOpts<Foo.Definition>>(
             req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<
               Foo.Definition,
               AO
             >,
           ) => Promise<$AggregationsResults<Foo.Definition, AO>>;
 
-          readonly pivotTo: <L extends $LinkNames<Foo.Definition>>(
+          readonly pivotTo: <const L extends $LinkNames<Foo.Definition>>(
             type: L,
           ) => $LinkedType<Foo.Definition, L>["objectSet"];
 
           readonly fetchPage: <
-            L extends Foo.PropertyKeys,
-            R extends boolean,
+            const L extends Foo.PropertyKeys,
+            const R extends boolean,
             const A extends $Augments,
-            S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+            const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
           >(
             args?: $FetchPageArgs<Foo.Definition, L, R, A, S>,
           ) => Promise<
@@ -371,10 +371,10 @@ describe(__UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst, () => {
           >;
 
           readonly fetchPageWithErrors: <
-            L extends Foo.PropertyKeys,
-            R extends boolean,
+            const L extends Foo.PropertyKeys,
+            const R extends boolean,
             const A extends $Augments,
-            S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+            const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
           >(
             args?: $FetchPageArgs<Foo.Definition, L, R, A, S>,
           ) => Promise<
@@ -546,22 +546,22 @@ describe(__UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst, () => {
         }
 
         export interface ObjectSet extends $ObjectSet<Foo.Definition, Foo.ObjectSet> {
-          readonly aggregate: <AO extends $AggregateOpts<Foo.Definition>>(
+          readonly aggregate: <const AO extends $AggregateOpts<Foo.Definition>>(
             req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<
               Foo.Definition,
               AO
             >,
           ) => Promise<$AggregationsResults<Foo.Definition, AO>>;
 
-          readonly pivotTo: <L extends $LinkNames<Foo.Definition>>(
+          readonly pivotTo: <const L extends $LinkNames<Foo.Definition>>(
             type: L,
           ) => $LinkedType<Foo.Definition, L>["objectSet"];
 
           readonly fetchPage: <
-            L extends Foo.PropertyKeys,
-            R extends boolean,
+            const L extends Foo.PropertyKeys,
+            const R extends boolean,
             const A extends $Augments,
-            S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+            const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
           >(
             args?: $FetchPageArgs<Foo.Definition, L, R, A, S>,
           ) => Promise<
@@ -575,10 +575,10 @@ describe(__UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst, () => {
           >;
 
           readonly fetchPageWithErrors: <
-            L extends Foo.PropertyKeys,
-            R extends boolean,
+            const L extends Foo.PropertyKeys,
+            const R extends boolean,
             const A extends $Augments,
-            S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+            const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
           >(
             args?: $FetchPageArgs<Foo.Definition, L, R, A, S>,
           ) => Promise<

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -708,19 +708,19 @@ describe("generator", () => {
         }
 
         export interface ObjectSet extends $ObjectSet<SomeInterface.Definition, SomeInterface.ObjectSet> {
-          readonly aggregate: <AO extends $AggregateOpts<SomeInterface.Definition>>(
+          readonly aggregate: <const AO extends $AggregateOpts<SomeInterface.Definition>>(
             req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<SomeInterface.Definition, AO>,
           ) => Promise<$AggregationsResults<SomeInterface.Definition, AO>>;
 
-          readonly pivotTo: <L extends $LinkNames<SomeInterface.Definition>>(
+          readonly pivotTo: <const L extends $LinkNames<SomeInterface.Definition>>(
             type: L,
           ) => $LinkedType<SomeInterface.Definition, L>['objectSet'];
 
           readonly fetchPage: <
-            L extends SomeInterface.PropertyKeys,
-            R extends boolean,
+            const L extends SomeInterface.PropertyKeys,
+            const R extends boolean,
             const A extends $Augments,
-            S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+            const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
           >(
             args?: $FetchPageArgs<SomeInterface.Definition, L, R, A, S>,
           ) => Promise<
@@ -733,10 +733,10 @@ describe("generator", () => {
           >;
 
           readonly fetchPageWithErrors: <
-            L extends SomeInterface.PropertyKeys,
-            R extends boolean,
+            const L extends SomeInterface.PropertyKeys,
+            const R extends boolean,
             const A extends $Augments,
-            S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+            const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
           >(
             args?: $FetchPageArgs<SomeInterface.Definition, L, R, A, S>,
           ) => Promise<
@@ -871,18 +871,18 @@ describe("generator", () => {
         }
 
         export interface ObjectSet extends $ObjectSet<Person.Definition, Person.ObjectSet> {
-          readonly aggregate: <AO extends $AggregateOpts<Person.Definition>>(
+          readonly aggregate: <const AO extends $AggregateOpts<Person.Definition>>(
             req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<Person.Definition, AO>,
           ) => Promise<$AggregationsResults<Person.Definition, AO>>;
 
-          readonly pivotTo: <L extends $LinkNames<Person.Definition>>(
+          readonly pivotTo: <const L extends $LinkNames<Person.Definition>>(
             type: L,
           ) => $LinkedType<Person.Definition, L>['objectSet'];
 
           readonly fetchOne: <
-            L extends Person.PropertyKeys,
-            R extends boolean,
-            S extends false | 'throw' = $NullabilityAdherenceDefault,
+            const L extends Person.PropertyKeys,
+            const R extends boolean,
+            const S extends false | 'throw' = $NullabilityAdherenceDefault,
           >(
             primaryKey: $PropertyValueClientToWire[Person.Definition['primaryKeyType']],
             options?: $SelectArg<Person.Definition, L, R, S>,
@@ -894,9 +894,9 @@ describe("generator", () => {
           >;
 
           readonly fetchOneWithErrors: <
-            L extends Person.PropertyKeys,
-            R extends boolean,
-            S extends false | 'throw' = $NullabilityAdherenceDefault,
+            const L extends Person.PropertyKeys,
+            const R extends boolean,
+            const S extends false | 'throw' = $NullabilityAdherenceDefault,
           >(
             primaryKey: $PropertyValueClientToWire[Person.Definition['primaryKeyType']],
             options?: $SelectArg<Person.Definition, L, R, S>,
@@ -910,10 +910,10 @@ describe("generator", () => {
           >;
 
           readonly fetchPage: <
-            L extends Person.PropertyKeys,
-            R extends boolean,
+            const L extends Person.PropertyKeys,
+            const R extends boolean,
             const A extends $Augments,
-            S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+            const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
           >(
             args?: $FetchPageArgs<Person.Definition, L, R, A, S>,
           ) => Promise<
@@ -926,10 +926,10 @@ describe("generator", () => {
           >;
 
           readonly fetchPageWithErrors: <
-            L extends Person.PropertyKeys,
-            R extends boolean,
+            const L extends Person.PropertyKeys,
+            const R extends boolean,
             const A extends $Augments,
-            S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+            const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
           >(
             args?: $FetchPageArgs<Person.Definition, L, R, A, S>,
           ) => Promise<
@@ -990,7 +990,6 @@ describe("generator", () => {
           } & $OsdkObject<'Person'>;
       }
 
-      /** @deprecated use Person.Definition **/
       export type Person = Person.Definition;
 
       export const Person: Person & $VersionBound<$ExpectedClientVersion> = {
@@ -1076,16 +1075,18 @@ describe("generator", () => {
         }
 
         export interface ObjectSet extends $ObjectSet<Todo.Definition, Todo.ObjectSet> {
-          readonly aggregate: <AO extends $AggregateOpts<Todo.Definition>>(
+          readonly aggregate: <const AO extends $AggregateOpts<Todo.Definition>>(
             req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<Todo.Definition, AO>,
           ) => Promise<$AggregationsResults<Todo.Definition, AO>>;
 
-          readonly pivotTo: <L extends $LinkNames<Todo.Definition>>(type: L) => $LinkedType<Todo.Definition, L>['objectSet'];
+          readonly pivotTo: <const L extends $LinkNames<Todo.Definition>>(
+            type: L,
+          ) => $LinkedType<Todo.Definition, L>['objectSet'];
 
           readonly fetchOne: <
-            L extends Todo.PropertyKeys,
-            R extends boolean,
-            S extends false | 'throw' = $NullabilityAdherenceDefault,
+            const L extends Todo.PropertyKeys,
+            const R extends boolean,
+            const S extends false | 'throw' = $NullabilityAdherenceDefault,
           >(
             primaryKey: $PropertyValueClientToWire[Todo.Definition['primaryKeyType']],
             options?: $SelectArg<Todo.Definition, L, R, S>,
@@ -1094,9 +1095,9 @@ describe("generator", () => {
           >;
 
           readonly fetchOneWithErrors: <
-            L extends Todo.PropertyKeys,
-            R extends boolean,
-            S extends false | 'throw' = $NullabilityAdherenceDefault,
+            const L extends Todo.PropertyKeys,
+            const R extends boolean,
+            const S extends false | 'throw' = $NullabilityAdherenceDefault,
           >(
             primaryKey: $PropertyValueClientToWire[Todo.Definition['primaryKeyType']],
             options?: $SelectArg<Todo.Definition, L, R, S>,
@@ -1110,10 +1111,10 @@ describe("generator", () => {
           >;
 
           readonly fetchPage: <
-            L extends Todo.PropertyKeys,
-            R extends boolean,
+            const L extends Todo.PropertyKeys,
+            const R extends boolean,
             const A extends $Augments,
-            S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+            const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
           >(
             args?: $FetchPageArgs<Todo.Definition, L, R, A, S>,
           ) => Promise<
@@ -1126,10 +1127,10 @@ describe("generator", () => {
           >;
 
           readonly fetchPageWithErrors: <
-            L extends Todo.PropertyKeys,
-            R extends boolean,
+            const L extends Todo.PropertyKeys,
+            const R extends boolean,
             const A extends $Augments,
-            S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+            const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
           >(
             args?: $FetchPageArgs<Todo.Definition, L, R, A, S>,
           ) => Promise<
@@ -1207,7 +1208,6 @@ describe("generator", () => {
           } & $OsdkObject<'Todo'>;
       }
 
-      /** @deprecated use Todo.Definition **/
       export type Todo = Todo.Definition;
 
       export const Todo: Todo & $VersionBound<$ExpectedClientVersion> = {
@@ -1676,19 +1676,19 @@ describe("generator", () => {
           }
 
           export interface ObjectSet extends $ObjectSet<SomeInterface.Definition, SomeInterface.ObjectSet> {
-            readonly aggregate: <AO extends $AggregateOpts<SomeInterface.Definition>>(
+            readonly aggregate: <const AO extends $AggregateOpts<SomeInterface.Definition>>(
               req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<SomeInterface.Definition, AO>,
             ) => Promise<$AggregationsResults<SomeInterface.Definition, AO>>;
 
-            readonly pivotTo: <L extends $LinkNames<SomeInterface.Definition>>(
+            readonly pivotTo: <const L extends $LinkNames<SomeInterface.Definition>>(
               type: L,
             ) => $LinkedType<SomeInterface.Definition, L>['objectSet'];
 
             readonly fetchPage: <
-              L extends SomeInterface.PropertyKeys,
-              R extends boolean,
+              const L extends SomeInterface.PropertyKeys,
+              const R extends boolean,
               const A extends $Augments,
-              S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+              const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
             >(
               args?: $FetchPageArgs<SomeInterface.Definition, L, R, A, S>,
             ) => Promise<
@@ -1701,10 +1701,10 @@ describe("generator", () => {
             >;
 
             readonly fetchPageWithErrors: <
-              L extends SomeInterface.PropertyKeys,
-              R extends boolean,
+              const L extends SomeInterface.PropertyKeys,
+              const R extends boolean,
               const A extends $Augments,
-              S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+              const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
             >(
               args?: $FetchPageArgs<SomeInterface.Definition, L, R, A, S>,
             ) => Promise<
@@ -1839,18 +1839,18 @@ describe("generator", () => {
           }
 
           export interface ObjectSet extends $ObjectSet<Person.Definition, Person.ObjectSet> {
-            readonly aggregate: <AO extends $AggregateOpts<Person.Definition>>(
+            readonly aggregate: <const AO extends $AggregateOpts<Person.Definition>>(
               req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<Person.Definition, AO>,
             ) => Promise<$AggregationsResults<Person.Definition, AO>>;
 
-            readonly pivotTo: <L extends $LinkNames<Person.Definition>>(
+            readonly pivotTo: <const L extends $LinkNames<Person.Definition>>(
               type: L,
             ) => $LinkedType<Person.Definition, L>['objectSet'];
 
             readonly fetchOne: <
-              L extends Person.PropertyKeys,
-              R extends boolean,
-              S extends false | 'throw' = $NullabilityAdherenceDefault,
+              const L extends Person.PropertyKeys,
+              const R extends boolean,
+              const S extends false | 'throw' = $NullabilityAdherenceDefault,
             >(
               primaryKey: $PropertyValueClientToWire[Person.Definition['primaryKeyType']],
               options?: $SelectArg<Person.Definition, L, R, S>,
@@ -1862,9 +1862,9 @@ describe("generator", () => {
             >;
 
             readonly fetchOneWithErrors: <
-              L extends Person.PropertyKeys,
-              R extends boolean,
-              S extends false | 'throw' = $NullabilityAdherenceDefault,
+              const L extends Person.PropertyKeys,
+              const R extends boolean,
+              const S extends false | 'throw' = $NullabilityAdherenceDefault,
             >(
               primaryKey: $PropertyValueClientToWire[Person.Definition['primaryKeyType']],
               options?: $SelectArg<Person.Definition, L, R, S>,
@@ -1878,10 +1878,10 @@ describe("generator", () => {
             >;
 
             readonly fetchPage: <
-              L extends Person.PropertyKeys,
-              R extends boolean,
+              const L extends Person.PropertyKeys,
+              const R extends boolean,
               const A extends $Augments,
-              S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+              const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
             >(
               args?: $FetchPageArgs<Person.Definition, L, R, A, S>,
             ) => Promise<
@@ -1894,10 +1894,10 @@ describe("generator", () => {
             >;
 
             readonly fetchPageWithErrors: <
-              L extends Person.PropertyKeys,
-              R extends boolean,
+              const L extends Person.PropertyKeys,
+              const R extends boolean,
               const A extends $Augments,
-              S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+              const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
             >(
               args?: $FetchPageArgs<Person.Definition, L, R, A, S>,
             ) => Promise<
@@ -1958,7 +1958,6 @@ describe("generator", () => {
             } & $OsdkObject<'foo.bar.Person'>;
         }
 
-        /** @deprecated use Person.Definition **/
         export type Person = Person.Definition;
 
         export const Person: Person & $VersionBound<$ExpectedClientVersion> = {
@@ -2044,16 +2043,18 @@ describe("generator", () => {
           }
 
           export interface ObjectSet extends $ObjectSet<Todo.Definition, Todo.ObjectSet> {
-            readonly aggregate: <AO extends $AggregateOpts<Todo.Definition>>(
+            readonly aggregate: <const AO extends $AggregateOpts<Todo.Definition>>(
               req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<Todo.Definition, AO>,
             ) => Promise<$AggregationsResults<Todo.Definition, AO>>;
 
-            readonly pivotTo: <L extends $LinkNames<Todo.Definition>>(type: L) => $LinkedType<Todo.Definition, L>['objectSet'];
+            readonly pivotTo: <const L extends $LinkNames<Todo.Definition>>(
+              type: L,
+            ) => $LinkedType<Todo.Definition, L>['objectSet'];
 
             readonly fetchOne: <
-              L extends Todo.PropertyKeys,
-              R extends boolean,
-              S extends false | 'throw' = $NullabilityAdherenceDefault,
+              const L extends Todo.PropertyKeys,
+              const R extends boolean,
+              const S extends false | 'throw' = $NullabilityAdherenceDefault,
             >(
               primaryKey: $PropertyValueClientToWire[Todo.Definition['primaryKeyType']],
               options?: $SelectArg<Todo.Definition, L, R, S>,
@@ -2062,9 +2063,9 @@ describe("generator", () => {
             >;
 
             readonly fetchOneWithErrors: <
-              L extends Todo.PropertyKeys,
-              R extends boolean,
-              S extends false | 'throw' = $NullabilityAdherenceDefault,
+              const L extends Todo.PropertyKeys,
+              const R extends boolean,
+              const S extends false | 'throw' = $NullabilityAdherenceDefault,
             >(
               primaryKey: $PropertyValueClientToWire[Todo.Definition['primaryKeyType']],
               options?: $SelectArg<Todo.Definition, L, R, S>,
@@ -2078,10 +2079,10 @@ describe("generator", () => {
             >;
 
             readonly fetchPage: <
-              L extends Todo.PropertyKeys,
-              R extends boolean,
+              const L extends Todo.PropertyKeys,
+              const R extends boolean,
               const A extends $Augments,
-              S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+              const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
             >(
               args?: $FetchPageArgs<Todo.Definition, L, R, A, S>,
             ) => Promise<
@@ -2094,10 +2095,10 @@ describe("generator", () => {
             >;
 
             readonly fetchPageWithErrors: <
-              L extends Todo.PropertyKeys,
-              R extends boolean,
+              const L extends Todo.PropertyKeys,
+              const R extends boolean,
               const A extends $Augments,
-              S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+              const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
             >(
               args?: $FetchPageArgs<Todo.Definition, L, R, A, S>,
             ) => Promise<
@@ -2175,7 +2176,6 @@ describe("generator", () => {
             } & $OsdkObject<'foo.bar.Todo'>;
         }
 
-        /** @deprecated use Todo.Definition **/
         export type Todo = Todo.Definition;
 
         export const Todo: Todo & $VersionBound<$ExpectedClientVersion> = {
@@ -2588,18 +2588,18 @@ describe("generator", () => {
             }
 
             export interface ObjectSet extends $ObjectSet<UsesForeignSpt.Definition, UsesForeignSpt.ObjectSet> {
-              readonly aggregate: <AO extends $AggregateOpts<UsesForeignSpt.Definition>>(
+              readonly aggregate: <const AO extends $AggregateOpts<UsesForeignSpt.Definition>>(
                 req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<UsesForeignSpt.Definition, AO>,
               ) => Promise<$AggregationsResults<UsesForeignSpt.Definition, AO>>;
 
-              readonly pivotTo: <L extends $LinkNames<UsesForeignSpt.Definition>>(
+              readonly pivotTo: <const L extends $LinkNames<UsesForeignSpt.Definition>>(
                 type: L,
               ) => $LinkedType<UsesForeignSpt.Definition, L>['objectSet'];
 
               readonly fetchOne: <
-                L extends UsesForeignSpt.PropertyKeys,
-                R extends boolean,
-                S extends false | 'throw' = $NullabilityAdherenceDefault,
+                const L extends UsesForeignSpt.PropertyKeys,
+                const R extends boolean,
+                const S extends false | 'throw' = $NullabilityAdherenceDefault,
               >(
                 primaryKey: $PropertyValueClientToWire[UsesForeignSpt.Definition['primaryKeyType']],
                 options?: $SelectArg<UsesForeignSpt.Definition, L, R, S>,
@@ -2611,9 +2611,9 @@ describe("generator", () => {
               >;
 
               readonly fetchOneWithErrors: <
-                L extends UsesForeignSpt.PropertyKeys,
-                R extends boolean,
-                S extends false | 'throw' = $NullabilityAdherenceDefault,
+                const L extends UsesForeignSpt.PropertyKeys,
+                const R extends boolean,
+                const S extends false | 'throw' = $NullabilityAdherenceDefault,
               >(
                 primaryKey: $PropertyValueClientToWire[UsesForeignSpt.Definition['primaryKeyType']],
                 options?: $SelectArg<UsesForeignSpt.Definition, L, R, S>,
@@ -2627,10 +2627,10 @@ describe("generator", () => {
               >;
 
               readonly fetchPage: <
-                L extends UsesForeignSpt.PropertyKeys,
-                R extends boolean,
+                const L extends UsesForeignSpt.PropertyKeys,
+                const R extends boolean,
                 const A extends $Augments,
-                S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+                const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
               >(
                 args?: $FetchPageArgs<UsesForeignSpt.Definition, L, R, A, S>,
               ) => Promise<
@@ -2643,10 +2643,10 @@ describe("generator", () => {
               >;
 
               readonly fetchPageWithErrors: <
-                L extends UsesForeignSpt.PropertyKeys,
-                R extends boolean,
+                const L extends UsesForeignSpt.PropertyKeys,
+                const R extends boolean,
                 const A extends $Augments,
-                S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+                const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
               >(
                 args?: $FetchPageArgs<UsesForeignSpt.Definition, L, R, A, S>,
               ) => Promise<
@@ -2716,7 +2716,6 @@ describe("generator", () => {
               } & $OsdkObject<'UsesForeignSpt'>;
           }
 
-          /** @deprecated use UsesForeignSpt.Definition **/
           export type UsesForeignSpt = UsesForeignSpt.Definition;
 
           export const UsesForeignSpt: UsesForeignSpt & $VersionBound<$ExpectedClientVersion> = {
@@ -2940,19 +2939,19 @@ describe("generator", () => {
           }
 
           export interface ObjectSet extends $ObjectSet<SomeInterface.Definition, SomeInterface.ObjectSet> {
-            readonly aggregate: <AO extends $AggregateOpts<SomeInterface.Definition>>(
+            readonly aggregate: <const AO extends $AggregateOpts<SomeInterface.Definition>>(
               req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<SomeInterface.Definition, AO>,
             ) => Promise<$AggregationsResults<SomeInterface.Definition, AO>>;
 
-            readonly pivotTo: <L extends $LinkNames<SomeInterface.Definition>>(
+            readonly pivotTo: <const L extends $LinkNames<SomeInterface.Definition>>(
               type: L,
             ) => $LinkedType<SomeInterface.Definition, L>['objectSet'];
 
             readonly fetchPage: <
-              L extends SomeInterface.PropertyKeys,
-              R extends boolean,
+              const L extends SomeInterface.PropertyKeys,
+              const R extends boolean,
               const A extends $Augments,
-              S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+              const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
             >(
               args?: $FetchPageArgs<SomeInterface.Definition, L, R, A, S>,
             ) => Promise<
@@ -2965,10 +2964,10 @@ describe("generator", () => {
             >;
 
             readonly fetchPageWithErrors: <
-              L extends SomeInterface.PropertyKeys,
-              R extends boolean,
+              const L extends SomeInterface.PropertyKeys,
+              const R extends boolean,
               const A extends $Augments,
-              S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+              const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
             >(
               args?: $FetchPageArgs<SomeInterface.Definition, L, R, A, S>,
             ) => Promise<
@@ -3096,16 +3095,18 @@ describe("generator", () => {
           }
 
           export interface ObjectSet extends $ObjectSet<Task.Definition, Task.ObjectSet> {
-            readonly aggregate: <AO extends $AggregateOpts<Task.Definition>>(
+            readonly aggregate: <const AO extends $AggregateOpts<Task.Definition>>(
               req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<Task.Definition, AO>,
             ) => Promise<$AggregationsResults<Task.Definition, AO>>;
 
-            readonly pivotTo: <L extends $LinkNames<Task.Definition>>(type: L) => $LinkedType<Task.Definition, L>['objectSet'];
+            readonly pivotTo: <const L extends $LinkNames<Task.Definition>>(
+              type: L,
+            ) => $LinkedType<Task.Definition, L>['objectSet'];
 
             readonly fetchOne: <
-              L extends Task.PropertyKeys,
-              R extends boolean,
-              S extends false | 'throw' = $NullabilityAdherenceDefault,
+              const L extends Task.PropertyKeys,
+              const R extends boolean,
+              const S extends false | 'throw' = $NullabilityAdherenceDefault,
             >(
               primaryKey: $PropertyValueClientToWire[Task.Definition['primaryKeyType']],
               options?: $SelectArg<Task.Definition, L, R, S>,
@@ -3114,9 +3115,9 @@ describe("generator", () => {
             >;
 
             readonly fetchOneWithErrors: <
-              L extends Task.PropertyKeys,
-              R extends boolean,
-              S extends false | 'throw' = $NullabilityAdherenceDefault,
+              const L extends Task.PropertyKeys,
+              const R extends boolean,
+              const S extends false | 'throw' = $NullabilityAdherenceDefault,
             >(
               primaryKey: $PropertyValueClientToWire[Task.Definition['primaryKeyType']],
               options?: $SelectArg<Task.Definition, L, R, S>,
@@ -3130,10 +3131,10 @@ describe("generator", () => {
             >;
 
             readonly fetchPage: <
-              L extends Task.PropertyKeys,
-              R extends boolean,
+              const L extends Task.PropertyKeys,
+              const R extends boolean,
               const A extends $Augments,
-              S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+              const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
             >(
               args?: $FetchPageArgs<Task.Definition, L, R, A, S>,
             ) => Promise<
@@ -3146,10 +3147,10 @@ describe("generator", () => {
             >;
 
             readonly fetchPageWithErrors: <
-              L extends Task.PropertyKeys,
-              R extends boolean,
+              const L extends Task.PropertyKeys,
+              const R extends boolean,
               const A extends $Augments,
-              S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+              const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
             >(
               args?: $FetchPageArgs<Task.Definition, L, R, A, S>,
             ) => Promise<
@@ -3211,7 +3212,6 @@ describe("generator", () => {
             } & $OsdkObject<'com.example.dep.Task'>;
         }
 
-        /** @deprecated use Task.Definition **/
         export type Task = Task.Definition;
 
         export const Task: Task & $VersionBound<$ExpectedClientVersion> = {

--- a/packages/generator/src/v2.0/wireObjectTypeV2ToSdkObjectConstV2.ts
+++ b/packages/generator/src/v2.0/wireObjectTypeV2ToSdkObjectConstV2.ts
@@ -132,7 +132,7 @@ export function wireObjectTypeV2ToSdkObjectConstV2(
 
 
 
-  /** @deprecated use ${object.shortApiName}.Definition **/
+  
   export type ${objectDefIdentifier} = ${object.shortApiName}.Definition;
 
 
@@ -237,19 +237,19 @@ $ObjectSet<${objectDefIdentifier},
 ${objectSetIdentifier}
 >
 {
-readonly aggregate: <AO extends $AggregateOpts<${objectDefIdentifier}>>(
+readonly aggregate: <const AO extends $AggregateOpts<${objectDefIdentifier}>>(
   req: $AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<${objectDefIdentifier}, AO>,
 ) => Promise<$AggregationsResults<${objectDefIdentifier}, AO>>;
 
 
-readonly pivotTo: <L extends $LinkNames<${objectDefIdentifier}>>(type: L) => $LinkedType<${objectDefIdentifier}, L>["objectSet"];
+readonly pivotTo: <const L extends $LinkNames<${objectDefIdentifier}>>(type: L) => $LinkedType<${objectDefIdentifier}, L>["objectSet"];
  ${
     object instanceof EnhancedObjectType
       ? ` 
 readonly fetchOne: <
-    L extends ${propertyKeysIdentifier},
-    R extends boolean,
-    S extends false | "throw" = $NullabilityAdherenceDefault,
+    const L extends ${propertyKeysIdentifier},
+    const R extends boolean,
+    const S extends false | "throw" = $NullabilityAdherenceDefault,
   >(
     primaryKey: $PropertyValueClientToWire[${objectDefIdentifier}["primaryKeyType"]],
     options?: $SelectArg<${objectDefIdentifier}, L, R, S>,
@@ -261,9 +261,9 @@ readonly fetchOne: <
   ;
 
 readonly fetchOneWithErrors: <
-    L extends ${propertyKeysIdentifier},
-    R extends boolean,
-    S extends false | "throw" = $NullabilityAdherenceDefault,
+    const L extends ${propertyKeysIdentifier},
+    const R extends boolean,
+    const S extends false | "throw" = $NullabilityAdherenceDefault,
   >(
     primaryKey: $PropertyValueClientToWire[${objectDefIdentifier}["primaryKeyType"]],
     options?: $SelectArg<${objectDefIdentifier}, L, R, S>,
@@ -281,10 +281,10 @@ readonly fetchOneWithErrors: <
   }
 
 readonly fetchPage: <
-  L extends ${propertyKeysIdentifier},
-  R extends boolean,
-  const A extends $Augments,
-  S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+  const L extends ${propertyKeysIdentifier},
+  const R extends boolean,
+  const const A extends $Augments,
+  const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
 >(
   args?: $FetchPageArgs<${objectDefIdentifier}, L, R, A, S>,
 ) => Promise<
@@ -295,10 +295,10 @@ readonly fetchPage: <
 >;
 
 readonly fetchPageWithErrors: <
-  L extends ${propertyKeysIdentifier},
-  R extends boolean,
+  const L extends ${propertyKeysIdentifier},
+  const R extends boolean,
   const A extends $Augments,
-  S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
+  const S extends $NullabilityAdherence = $NullabilityAdherenceDefault,
 >(
   args?: $FetchPageArgs<${objectDefIdentifier}, L, R, A, S>,
 ) => Promise<$Result<


### PR DESCRIPTION
Chains to #558 

We were in a scenario where the following would compile but should fail:
```ts
function asdf(client: Client): Promise<Osdk<Employee>> {
  return client(Employee).fetchOne(1, {
    $select: ["employeeId"],
  });
}
```
