### PR TITLE
Add support for extra nullable field on properties

### DIFF
--- a/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectTypeDefinition.test.ts
+++ b/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectTypeDefinition.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { wireObjectTypeFullMetadataToSdkObjectTypeDefinition } from "./wireObjectTypeFullMetadataToSdkObjectTypeDefinition.js";
+
+describe(wireObjectTypeFullMetadataToSdkObjectTypeDefinition, () => {
+  it("handles magic nullable properties", () => {
+    const result = wireObjectTypeFullMetadataToSdkObjectTypeDefinition({
+      implementsInterfaces: [],
+      implementsInterfaces2: {},
+      linkTypes: [],
+      objectType: {
+        apiName: "apiName",
+        description: "description",
+        displayName: "displayName",
+        primaryKey: "primaryKey",
+        properties: {
+          primaryKey: { dataType: { type: "string" } },
+          otherKey: { nullable: false, dataType: { type: "string" } },
+          defaulted: { dataType: { type: "string" } },
+        },
+        rid: "rid",
+        status: "ACTIVE",
+        titleProperty: "otherKey",
+      },
+      sharedPropertyTypeMapping: {},
+    }, true);
+
+    // PK is never nullable
+    expect(result.properties["primaryKey"].nullable).toBe(false);
+
+    // was specified above
+    expect(result.properties["otherKey"].nullable).toBe(false);
+
+    // was unspecified, so should be nullable
+    expect(result.properties["defaulted"].nullable).toBe(true);
+  });
+});

--- a/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectTypeDefinition.ts
+++ b/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectTypeDefinition.ts
@@ -20,7 +20,9 @@ import { wirePropertyV2ToSdkPrimaryKeyTypeDefinition } from "./wirePropertyV2ToS
 import { wirePropertyV2ToSdkPropertyDefinition } from "./wirePropertyV2ToSdkPropertyDefinition.js";
 
 export function wireObjectTypeFullMetadataToSdkObjectTypeDefinition(
-  objectTypeWithLink: ObjectTypeFullMetadata,
+  objectTypeWithLink: ObjectTypeFullMetadata & {
+    objectType: { properties: Record<string, { nullable?: boolean }> };
+  },
   v2: boolean,
 ): ObjectTypeDefinition<any> {
   if (

--- a/packages/generator-converters/src/wirePropertyV2ToSdkPropertyDefinition.ts
+++ b/packages/generator-converters/src/wirePropertyV2ToSdkPropertyDefinition.ts
@@ -25,7 +25,7 @@ import type {
 } from "@osdk/gateway/types";
 
 export function wirePropertyV2ToSdkPropertyDefinition(
-  input: PropertyV2 | SharedPropertyType,
+  input: (PropertyV2 | SharedPropertyType) & { nullable?: boolean },
   isNullable: boolean = true,
 ): ObjectTypePropertyDefinition {
   switch (input.dataType.type) {
@@ -50,7 +50,7 @@ export function wirePropertyV2ToSdkPropertyDefinition(
         multiplicity: false,
         description: input.description,
         type: objectPropertyTypeToSdkPropertyDefinition(input.dataType),
-        nullable: isNullable,
+        nullable: input.nullable == null ? isNullable : input.nullable,
       };
     case "array": {
       return {


### PR DESCRIPTION
One of the really old internal first uses hard coded all properties not to be null. I would love for the gateway to expose nullability to us but if we can't then we can at least make it possible to specify in the raw ontology.json file.

Thats what this does. I may hold off until I know if we will add this to gateway proper (and if not perhaps give it an unlikely name so it won't collide in the future).