### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -82,6 +82,7 @@
     "bright-gorillas-draw",
     "bright-panthers-lick",
     "clever-rings-yawn",
+    "cold-shirts-complain",
     "cuddly-flies-smash",
     "eight-swans-help",
     "five-wasps-design",

--- a/packages/client.api/CHANGELOG.md
+++ b/packages/client.api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/client.api
 
+## 0.22.0-beta.4
+
+### Minor Changes
+
+- 0ea1a17: Fixes an issue where properties may not be inferred correctly when directly used in a return statement
+
 ## 0.22.0-beta.3
 
 ### Patch Changes

--- a/packages/client.api/package.json
+++ b/packages/client.api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.api",
-  "version": "0.22.0-beta.3",
+  "version": "0.22.0-beta.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.test.ontology/CHANGELOG.md
+++ b/packages/client.test.ontology/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/client.test.ontology
 
+## 1.2.0-beta.4
+
+### Patch Changes
+
+- Updated dependencies [0ea1a17]
+  - @osdk/client.api@0.22.0-beta.4
+
 ## 1.2.0-beta.3
 
 ### Patch Changes

--- a/packages/client.test.ontology/package.json
+++ b/packages/client.test.ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/client.test.ontology",
   "private": true,
-  "version": "1.2.0-beta.3",
+  "version": "1.2.0-beta.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/client
 
+## 0.22.0-beta.4
+
+### Patch Changes
+
+- Updated dependencies [0ea1a17]
+  - @osdk/client.api@0.22.0-beta.4
+
 ## 0.22.0-beta.3
 
 ### Patch Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client",
-  "version": "0.22.0-beta.3",
+  "version": "0.22.0-beta.4",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/e2e.generated.api-namespace.dep/CHANGELOG.md
+++ b/packages/e2e.generated.api-namespace.dep/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/e2e.generated.api-namespace.dep
 
+## 1.0.0-beta.4
+
+### Patch Changes
+
+- Updated dependencies [0ea1a17]
+  - @osdk/client.api@0.22.0-beta.4
+  - @osdk/client@0.22.0-beta.4
+
 ## 1.0.0-beta.3
 
 ### Patch Changes

--- a/packages/e2e.generated.api-namespace.dep/package.json
+++ b/packages/e2e.generated.api-namespace.dep/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.generated.api-namespace.dep",
   "private": true,
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.generated.api-namespace.local/CHANGELOG.md
+++ b/packages/e2e.generated.api-namespace.local/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/e2e.generated.api-namespace.local
 
+## 1.0.0-beta.4
+
+### Patch Changes
+
+- Updated dependencies [0ea1a17]
+  - @osdk/client.api@0.22.0-beta.4
+  - @osdk/client@0.22.0-beta.4
+  - @osdk/e2e.generated.api-namespace.dep@1.0.0-beta.4
+
 ## 1.0.0-beta.3
 
 ### Patch Changes

--- a/packages/e2e.generated.api-namespace.local/package.json
+++ b/packages/e2e.generated.api-namespace.local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.generated.api-namespace.local",
   "private": true,
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.generated.catchall/CHANGELOG.md
+++ b/packages/e2e.generated.catchall/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/e2e.generated.catchall
 
+## 3.0.0-beta.4
+
+### Patch Changes
+
+- Updated dependencies [0ea1a17]
+  - @osdk/client.api@0.22.0-beta.4
+  - @osdk/client@0.22.0-beta.4
+
 ## 3.0.0-beta.3
 
 ### Patch Changes

--- a/packages/e2e.generated.catchall/package.json
+++ b/packages/e2e.generated.catchall/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.generated.catchall",
   "private": true,
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "description": "",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/e2e.sandbox.catchall/CHANGELOG.md
+++ b/packages/e2e.sandbox.catchall/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/e2e.sandbox.catchall
 
+## 0.3.0-beta.4
+
+### Patch Changes
+
+- Updated dependencies [0ea1a17]
+  - @osdk/client.api@0.22.0-beta.4
+  - @osdk/client@0.22.0-beta.4
+  - @osdk/e2e.generated.catchall@3.0.0-beta.4
+
 ## 0.3.0-beta.3
 
 ### Patch Changes

--- a/packages/e2e.sandbox.catchall/package.json
+++ b/packages/e2e.sandbox.catchall/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.sandbox.catchall",
   "private": true,
-  "version": "0.3.0-beta.3",
+  "version": "0.3.0-beta.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.sandbox.oauth/CHANGELOG.md
+++ b/packages/e2e.sandbox.oauth/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/e2e.sandbox.oauth
 
+## 0.3.0-beta.4
+
+### Patch Changes
+
+- @osdk/client@0.22.0-beta.4
+
 ## 0.3.0-beta.3
 
 ### Patch Changes

--- a/packages/e2e.sandbox.oauth/package.json
+++ b/packages/e2e.sandbox.oauth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.sandbox.oauth",
   "private": true,
-  "version": "0.3.0-beta.3",
+  "version": "0.3.0-beta.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.sandbox.todoapp/CHANGELOG.md
+++ b/packages/e2e.sandbox.todoapp/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/e2e.sandbox.todoappapp
 
+## 3.0.0-beta.4
+
+### Patch Changes
+
+- Updated dependencies [0ea1a17]
+  - @osdk/client.api@0.22.0-beta.4
+  - @osdk/client@0.22.0-beta.4
+
 ## 3.0.0-beta.3
 
 ### Patch Changes

--- a/packages/e2e.sandbox.todoapp/package.json
+++ b/packages/e2e.sandbox.todoapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.sandbox.todoapp",
   "private": true,
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/foundry-sdk-generator
 
+## 1.4.0-beta.4
+
+### Patch Changes
+
+- Updated dependencies [0ea1a17]
+  - @osdk/client.api@0.22.0-beta.4
+  - @osdk/client@0.22.0-beta.4
+
 ## 1.4.0-beta.3
 
 ### Patch Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "1.4.0-beta.3",
+  "version": "1.4.0-beta.4",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/client.api@0.22.0-beta.4

### Minor Changes

-   0ea1a17: Fixes an issue where properties may not be inferred correctly when directly used in a return statement

## @osdk/client@0.22.0-beta.4

### Patch Changes

-   Updated dependencies [0ea1a17]
    -   @osdk/client.api@0.22.0-beta.4

## @osdk/foundry-sdk-generator@1.4.0-beta.4

### Patch Changes

-   Updated dependencies [0ea1a17]
    -   @osdk/client.api@0.22.0-beta.4
    -   @osdk/client@0.22.0-beta.4

## @osdk/client.test.ontology@1.2.0-beta.4

### Patch Changes

-   Updated dependencies [0ea1a17]
    -   @osdk/client.api@0.22.0-beta.4

## @osdk/e2e.generated.api-namespace.dep@1.0.0-beta.4

### Patch Changes

-   Updated dependencies [0ea1a17]
    -   @osdk/client.api@0.22.0-beta.4
    -   @osdk/client@0.22.0-beta.4

## @osdk/e2e.generated.api-namespace.local@1.0.0-beta.4

### Patch Changes

-   Updated dependencies [0ea1a17]
    -   @osdk/client.api@0.22.0-beta.4
    -   @osdk/client@0.22.0-beta.4
    -   @osdk/e2e.generated.api-namespace.dep@1.0.0-beta.4

## @osdk/e2e.generated.catchall@3.0.0-beta.4

### Patch Changes

-   Updated dependencies [0ea1a17]
    -   @osdk/client.api@0.22.0-beta.4
    -   @osdk/client@0.22.0-beta.4

## @osdk/e2e.sandbox.catchall@0.3.0-beta.4

### Patch Changes

-   Updated dependencies [0ea1a17]
    -   @osdk/client.api@0.22.0-beta.4
    -   @osdk/client@0.22.0-beta.4
    -   @osdk/e2e.generated.catchall@3.0.0-beta.4

## @osdk/e2e.sandbox.oauth@0.3.0-beta.4

### Patch Changes

-   @osdk/client@0.22.0-beta.4

## @osdk/e2e.sandbox.todoapp@3.0.0-beta.4

### Patch Changes

-   Updated dependencies [0ea1a17]
    -   @osdk/client.api@0.22.0-beta.4
    -   @osdk/client@0.22.0-beta.4
