### PR TITLE
Export namespaces for objects,queries,actions

### DIFF
--- a/.changeset/violet-avocados-leave.md
+++ b/.changeset/violet-avocados-leave.md
@@ -1,0 +1,10 @@
+---
+"@osdk/e2e.generated.api-namespace.local": patch
+"@osdk/e2e.generated.api-namespace.dep": patch
+"@osdk/e2e.generated.catchall": patch
+"@osdk/e2e.sandbox.todoapp": patch
+"@osdk/generator": patch
+"@osdk/client": patch
+---
+
+Add namespaces for objects,actions,queries so that you can enumerate them.

--- a/examples-extra/docs_example/src/generatedNoCheck/index.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/index.ts
@@ -1,5 +1,9 @@
 export * from './ontology/actions';
+export * as $Actions from './ontology/actions';
 export * from './ontology/interfaces';
+export * as $Interfaces from './ontology/interfaces';
 export * from './ontology/objects';
+export * as $Objects from './ontology/objects';
 export * from './ontology/queries';
+export * as $Queries from './ontology/queries';
 export { $ontologyRid } from './OntologyMetadata';

--- a/packages/client/src/actions/actions.test.ts
+++ b/packages/client/src/actions/actions.test.ts
@@ -20,6 +20,7 @@ import type {
   AttachmentUpload,
 } from "@osdk/client.api";
 import {
+  $Actions,
   $ontologyRid,
   actionTakesAttachment,
   createOffice,
@@ -238,5 +239,17 @@ describe("actions", () => {
   "modifiedObjectsCount": 2,
   "type": "edits",
 }`);
+  });
+  it("actions are enumerable", async () => {
+    const actions = Object.keys($Actions);
+    expect(actions).toStrictEqual([
+      "actionTakesAttachment",
+      "actionTakesObjectSet",
+      "createOffice",
+      "createOfficeAndEmployee",
+      "moveOffice",
+      "promoteEmployee",
+      "promoteEmployeeObject",
+    ]);
   });
 });

--- a/packages/client/src/object/object.test.ts
+++ b/packages/client/src/object/object.test.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Osdk } from "@osdk/client.api";
-import { $ontologyRid, Employee } from "@osdk/client.test.ontology";
+import { $Objects, $ontologyRid, Employee } from "@osdk/client.test.ontology";
 import { apiServer, stubData, withoutRid } from "@osdk/shared.test";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { Client } from "../Client.js";
@@ -150,6 +150,19 @@ describe("OsdkObject", () => {
       expect(leadRid).toBe(
         "ri.phonograph2-objects.main.object.88a6fccb-f333-46d6-a07e-7725c5f18b61",
       );
+    });
+    it("objects are enumerable in an sdk", async () => {
+      const objects = Object.keys($Objects);
+      expect(objects).toStrictEqual([
+        "Employee",
+        "ObjectWithTimestampPrimaryKey",
+        "Office",
+        "Person",
+        "Task",
+        "Todo",
+        "equipment",
+        "objectTypeWithAllPropertyTypes",
+      ]);
     });
   });
 });

--- a/packages/client/src/queries/queries.test.ts
+++ b/packages/client/src/queries/queries.test.ts
@@ -17,6 +17,7 @@
 import type { ObjectSet } from "@osdk/client.api";
 import {
   $ontologyRid,
+  $Queries,
   acceptsThreeDimensionalAggregationFunction,
   acceptsTwoDimensionalAggregationFunction,
   addOne,
@@ -209,6 +210,22 @@ describe("queries", () => {
         key: "Q-AFO",
         groups: [],
       },
+    ]);
+  });
+  it("queries are enumerable", async () => {
+    const queries = Object.keys($Queries);
+    expect(queries).toStrictEqual([
+      "acceptsThreeDimensionalAggregationFunction",
+      "acceptsTwoDimensionalAggregationFunction",
+      "addOne",
+      "incrementPersonAge",
+      "queryAcceptsObject",
+      "queryAcceptsObjectSets",
+      "returnsDate",
+      "returnsObject",
+      "returnsTimestamp",
+      "threeDimensionalAggregationFunction",
+      "twoDimensionalAggregationFunction",
     ]);
   });
 });

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/index.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/index.ts
@@ -1,4 +1,8 @@
 export * from './ontology/actions.js';
+export * as $Actions from './ontology/actions.js';
 export * from './ontology/interfaces.js';
+export * as $Interfaces from './ontology/interfaces.js';
 export * from './ontology/objects.js';
+export * as $Objects from './ontology/objects.js';
 export * from './ontology/queries.js';
+export * as $Queries from './ontology/queries.js';

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/index.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/index.ts
@@ -1,5 +1,9 @@
 export * from './ontology/actions.js';
+export * as $Actions from './ontology/actions.js';
 export * from './ontology/interfaces.js';
+export * as $Interfaces from './ontology/interfaces.js';
 export * from './ontology/objects.js';
+export * as $Objects from './ontology/objects.js';
 export * from './ontology/queries.js';
+export * as $Queries from './ontology/queries.js';
 export { $ontologyRid } from './OntologyMetadata.js';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/index.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/index.ts
@@ -1,5 +1,9 @@
 export * from './ontology/actions.js';
+export * as $Actions from './ontology/actions.js';
 export * from './ontology/interfaces.js';
+export * as $Interfaces from './ontology/interfaces.js';
 export * from './ontology/objects.js';
+export * as $Objects from './ontology/objects.js';
 export * from './ontology/queries.js';
+export * as $Queries from './ontology/queries.js';
 export { $ontologyRid } from './OntologyMetadata.js';

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/index.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/index.ts
@@ -1,5 +1,9 @@
 export * from './ontology/actions';
+export * as $Actions from './ontology/actions';
 export * from './ontology/interfaces';
+export * as $Interfaces from './ontology/interfaces';
 export * from './ontology/objects';
+export * as $Objects from './ontology/objects';
 export * from './ontology/queries';
+export * as $Queries from './ontology/queries';
 export { $ontologyRid } from './OntologyMetadata';

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -474,9 +474,13 @@ describe("generator", () => {
       export const $ontologyRid = 'ridHere';
       ",
         "/foo/index.ts": "export * from './ontology/actions';
+      export * as $Actions from './ontology/actions';
       export * from './ontology/interfaces';
+      export * as $Interfaces from './ontology/interfaces';
       export * from './ontology/objects';
+      export * as $Objects from './ontology/objects';
       export * from './ontology/queries';
+      export * as $Queries from './ontology/queries';
       export { $ontologyRid } from './OntologyMetadata';
       ",
         "/foo/ontology/actions.ts": "export { deleteTodos } from './actions/deleteTodos';
@@ -1443,9 +1447,13 @@ describe("generator", () => {
         export const $osdkMetadata = { extraUserAgent: '' };
         ",
           "/foo/index.ts": "export * from './ontology/actions.js';
+        export * as $Actions from './ontology/actions.js';
         export * from './ontology/interfaces.js';
+        export * as $Interfaces from './ontology/interfaces.js';
         export * from './ontology/objects.js';
+        export * as $Objects from './ontology/objects.js';
         export * from './ontology/queries.js';
+        export * as $Queries from './ontology/queries.js';
         ",
           "/foo/ontology/actions.ts": "export { deleteTodos } from './actions/deleteTodos.js';
         export { markTodoCompleted } from './actions/markTodoCompleted.js';
@@ -2891,9 +2899,13 @@ describe("generator", () => {
         export const $ontologyRid = 'ri.ontology.main.ontology.dep';
         ",
           "/foo/index.ts": "export * from './ontology/actions.js';
+        export * as $Actions from './ontology/actions.js';
         export * from './ontology/interfaces.js';
+        export * as $Interfaces from './ontology/interfaces.js';
         export * from './ontology/objects.js';
+        export * as $Objects from './ontology/objects.js';
         export * from './ontology/queries.js';
+        export * as $Queries from './ontology/queries.js';
         export { $ontologyRid } from './OntologyMetadata.js';
         ",
           "/foo/ontology/actions.ts": "export {};

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
@@ -42,9 +42,13 @@ async function generateRootIndexTsFile(
           : ``
       }
         export * from "./ontology/actions${importExt}";
+        export * as $Actions from "./ontology/actions${importExt}";
         export * from "./ontology/objects${importExt}";
+        export * as $Objects from "./ontology/objects${importExt}";
         export * from "./ontology/interfaces${importExt}";
+        export * as $Interfaces from "./ontology/interfaces${importExt}";
         export * from "./ontology/queries${importExt}";
+        export * as $Queries from "./ontology/queries${importExt}";
     `,
     ),
   );


### PR DESCRIPTION
This will allow users to easily enumerate entities in their generated ontology.