### PR TITLE
Fixes releasing related to recent prs

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,15 @@
   "commit": false,
   "fixed": [
     ["@osdk/foundry.*", "@osdk/foundry"],
-    ["@osdk/client.api", "@osdk/client", "@osdk/foundry-sdk-generator", "@osdk/generator", "@osdk/api"],
+    [
+      "@osdk/client.api",
+      "@osdk/client",
+      "@osdk/foundry-sdk-generator",
+      "@osdk/generator",
+      "@osdk/generator-converters",
+      "@osdk/client.unstable",
+      "@osdk/api"
+    ],
     ["@osdk/create-app", "@osdk/create-app.template.*"]
   ],
   "linked": [],

--- a/.changeset/four-ants-complain.md
+++ b/.changeset/four-ants-complain.md
@@ -2,7 +2,6 @@
 "@osdk/internal.foundry.ontologiesv2": patch
 "@osdk/internal.foundry.ontologies": patch
 "@osdk/internal.foundry.datasets": patch
-"@osdk/internal.foundry.models": patch
 "@osdk/platform-sdk-generator": patch
 "@osdk/foundry.datasets": patch
 "@osdk/generator": patch

--- a/.changeset/late-students-sleep.md
+++ b/.changeset/late-students-sleep.md
@@ -3,7 +3,6 @@
 "@osdk/internal.foundry.ontologiesv2": patch
 "@osdk/internal.foundry.ontologies": patch
 "@osdk/internal.foundry.datasets": patch
-"@osdk/internal.foundry.models": patch
 "@osdk/foundry.orchestration": patch
 "@osdk/internal.foundry.core": patch
 "@osdk/foundry.datasets": patch

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -44,7 +44,6 @@
     "@osdk/internal.foundry": "0.4.0",
     "@osdk/internal.foundry.core": "0.1.0",
     "@osdk/internal.foundry.datasets": "0.1.0",
-    "@osdk/internal.foundry.models": "0.1.0",
     "@osdk/internal.foundry.ontologies": "0.1.0",
     "@osdk/internal.foundry.ontologiesv2": "0.1.0",
     "@osdk/legacy-client": "2.5.0",

--- a/.changeset/quiet-mails-attend.md
+++ b/.changeset/quiet-mails-attend.md
@@ -3,7 +3,6 @@
 "@osdk/internal.foundry.ontologiesv2": patch
 "@osdk/internal.foundry.ontologies": patch
 "@osdk/internal.foundry.datasets": patch
-"@osdk/internal.foundry.models": patch
 "@osdk/foundry.orchestration": patch
 "@osdk/internal.foundry.core": patch
 "@osdk/foundry.datasets": patch

--- a/.changeset/tasty-clouds-kick.md
+++ b/.changeset/tasty-clouds-kick.md
@@ -3,7 +3,6 @@
 "@osdk/internal.foundry.ontologiesv2": patch
 "@osdk/internal.foundry.ontologies": patch
 "@osdk/internal.foundry.datasets": patch
-"@osdk/internal.foundry.models": patch
 "@osdk/platform-sdk-generator": patch
 "@osdk/foundry.orchestration": patch
 "@osdk/internal.foundry.core": patch

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2109,34 +2109,6 @@ importers:
         specifier: ^5.5.4
         version: 5.5.4
 
-  packages/internal.foundry.models:
-    dependencies:
-      '@osdk/internal.foundry.core':
-        specifier: workspace:*
-        version: link:../internal.foundry.core
-      '@osdk/shared.client':
-        specifier: workspace:~
-        version: link:../shared.client
-      '@osdk/shared.net':
-        specifier: workspace:~
-        version: link:../shared.net
-      '@osdk/shared.net.platformapi':
-        specifier: workspace:~
-        version: link:../shared.net.platformapi
-    devDependencies:
-      '@osdk/monorepo.api-extractor':
-        specifier: workspace:~
-        version: link:../monorepo.api-extractor
-      '@osdk/monorepo.tsconfig':
-        specifier: workspace:~
-        version: link:../monorepo.tsconfig
-      '@osdk/monorepo.tsup':
-        specifier: workspace:~
-        version: link:../monorepo.tsup
-      typescript:
-        specifier: ^5.5.4
-        version: 5.5.4
-
   packages/internal.foundry.ontologies:
     dependencies:
       '@osdk/internal.foundry.core':


### PR DESCRIPTION
- Adds @osdk/generator-converters to the packages to synchronize versions with @osdk/client
- Removes references to the recently removed `internal.foundry.models` so that the release script doesnt npe
- Fixes lockfile from semantic merge conflict