### PR TITLE
lock deps of generated.1.1.x

### DIFF
--- a/packages/e2e.generated.1.1.x/package.json
+++ b/packages/e2e.generated.1.1.x/package.json
@@ -31,8 +31,7 @@
     "typecheck": "monorepo.tool.typecheck both"
   },
   "dependencies": {
-    "@osdk/api": "workspace:~",
-    "@osdk/generator": "workspace:~",
+    "@osdk/api": "^1.10.0-beta.1",
     "@osdk/legacy-client": "^2.5.0"
   },
   "peerDependencies": {
@@ -42,7 +41,6 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.2",
     "@osdk/api": "^1.10.0-beta.1",
-    "@osdk/cli.cmd.typescript": "workspace:~",
     "@osdk/legacy-client": "^2.6.0-beta.1",
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1229,11 +1229,8 @@ importers:
   packages/e2e.generated.1.1.x:
     dependencies:
       '@osdk/api':
-        specifier: workspace:~
-        version: link:../api
-      '@osdk/generator':
-        specifier: workspace:~
-        version: link:../generator
+        specifier: ^1.10.0-beta.1
+        version: 1.10.0-beta.1
       '@osdk/legacy-client':
         specifier: ^2.5.0
         version: 2.5.1
@@ -1241,9 +1238,6 @@ importers:
       '@arethetypeswrong/cli':
         specifier: ^0.15.2
         version: 0.15.3
-      '@osdk/cli.cmd.typescript':
-        specifier: workspace:~
-        version: link:../cli.cmd.typescript
       '@osdk/monorepo.api-extractor':
         specifier: workspace:~
         version: link:../monorepo.api-extractor
@@ -3856,6 +3850,9 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@osdk/api@1.10.0-beta.1':
+    resolution: {integrity: sha512-q1X+5FVJXWTDmC+ni6kpjHHHDeU88/nUtt0YH5cSTTWpVOsjvaHYIT4Dq32eR4chzXQHeaPotKLzuVIPOBrI2w==}
 
   '@osdk/api@1.9.1':
     resolution: {integrity: sha512-a67IMGvlLYkGDsO0Dja9J+vTzWfshn6xAICZlv3d12ys71YvMoTA6kKUgiMrec+cC0vp4R3IE3ESlczsfiJ/iQ==}
@@ -9557,6 +9554,14 @@ snapshots:
       outvariant: 1.4.2
 
   '@open-draft/until@2.1.0': {}
+
+  '@osdk/api@1.10.0-beta.1':
+    dependencies:
+      '@osdk/gateway': 2.4.1
+      '@osdk/shared.net': 1.12.1
+      '@types/geojson': 7946.0.14
+      fetch-retry: 6.0.0
+      tiny-invariant: 1.3.3
 
   '@osdk/api@1.9.1':
     dependencies:


### PR DESCRIPTION
We no longer generate this package as we are full on 2.0 now in this branch. We shouldnt be getting changeset updates for this either.