### PR TITLE
Version Packages

### DIFF
--- a/.changeset/lemon-walls-march.md
+++ b/.changeset/lemon-walls-march.md
@@ -1,6 +1,0 @@
----
-"@osdk/foundry-sdk-generator": patch
-"@osdk/generator": patch
----
-
-Fixed an edge case where generation caused compile errors

--- a/.changeset/mighty-tigers-provide.md
+++ b/.changeset/mighty-tigers-provide.md
@@ -1,5 +1,0 @@
----
-"@osdk/foundry-sdk-generator": patch
----
-
---beta now loads from the beta package

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/cli.cmd.typescript
 
+## 0.5.2
+
+### Patch Changes
+
+- Updated dependencies [ef2018e]
+  - @osdk/generator@1.13.2
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/cli
 
+## 0.23.2
+
+### Patch Changes
+
+- Updated dependencies [ef2018e]
+  - @osdk/generator@1.13.2
+
 ## 0.23.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/e2e.generated.1.1.x/CHANGELOG.md
+++ b/packages/e2e.generated.1.1.x/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/e2e.generated.1.1.x
 
+## 0.2.2
+
+### Patch Changes
+
+- Updated dependencies [ef2018e]
+  - @osdk/generator@1.13.2
+  - @osdk/legacy-client@2.5.1
+
 ## 0.2.1
 
 ### Patch Changes

--- a/packages/e2e.generated.1.1.x/package.json
+++ b/packages/e2e.generated.1.1.x/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.generated.1.1.x",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/e2e.test.foundry-sdk-generator/CHANGELOG.md
+++ b/packages/e2e.test.foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/e2e.test.foundry-sdk-generator
 
+## 0.2.3
+
+### Patch Changes
+
+- Updated dependencies [ef2018e]
+- Updated dependencies [bf5d49e]
+  - @osdk/foundry-sdk-generator@1.3.3
+
 ## 0.2.2
 
 ### Patch Changes

--- a/packages/e2e.test.foundry-sdk-generator/package.json
+++ b/packages/e2e.test.foundry-sdk-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.test.foundry-sdk-generator",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/foundry-sdk-generator
 
+## 1.3.3
+
+### Patch Changes
+
+- ef2018e: Fixed an edge case where generation caused compile errors
+- bf5d49e: --beta now loads from the beta package
+- Updated dependencies [ef2018e]
+  - @osdk/generator@1.13.2
+  - @osdk/legacy-client@2.5.1
+
 ## 1.3.2
 
 ### Patch Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/generator
 
+## 1.13.2
+
+### Patch Changes
+
+- ef2018e: Fixed an edge case where generation caused compile errors
+
 ## 1.13.1
 
 ### Patch Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/1.3.x, this PR will be updated.


# Releases
## @osdk/cli@0.23.2

### Patch Changes

-   Updated dependencies [ef2018e]
    -   @osdk/generator@1.13.2

## @osdk/foundry-sdk-generator@1.3.3

### Patch Changes

-   ef2018e: Fixed an edge case where generation caused compile errors
-   bf5d49e: --beta now loads from the beta package
-   Updated dependencies [ef2018e]
    -   @osdk/generator@1.13.2
    -   @osdk/legacy-client@2.5.1

## @osdk/generator@1.13.2

### Patch Changes

-   ef2018e: Fixed an edge case where generation caused compile errors

## @osdk/cli.cmd.typescript@0.5.2

### Patch Changes

-   Updated dependencies [ef2018e]
    -   @osdk/generator@1.13.2

## @osdk/e2e.generated.1.1.x@0.2.2

### Patch Changes

-   Updated dependencies [ef2018e]
    -   @osdk/generator@1.13.2
    -   @osdk/legacy-client@2.5.1

## @osdk/e2e.test.foundry-sdk-generator@0.2.3

### Patch Changes

-   Updated dependencies [ef2018e]
-   Updated dependencies [bf5d49e]
    -   @osdk/foundry-sdk-generator@1.3.3
