### PR TITLE
Prevent pino error

### DIFF
--- a/.changeset/big-trainers-love.md
+++ b/.changeset/big-trainers-love.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": minor
+---
+
+We now have a hard dependency on pino for type resolution. This has no effect on a project if it doesn't provide a logger to the client.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -47,6 +47,7 @@
     "fetch-retry": "^6.0.0",
     "find-up": "7.0.0",
     "isomorphic-ws": "^5.0.0",
+    "pino": "^9.1.0",
     "tiny-invariant": "^1.3.1",
     "type-fest": "^4.18.2",
     "ws": "^8.18.0"
@@ -79,7 +80,6 @@
     "p-locate": "^6.0.0",
     "p-map": "^7.0.2",
     "p-state": "^2.0.1",
-    "pino": "^9.1.0",
     "pino-pretty": "^11.2.1",
     "ts-expect": "^1.3.0",
     "typescript": "^5.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -715,6 +715,9 @@ importers:
       isomorphic-ws:
         specifier: ^5.0.0
         version: 5.0.0(ws@8.18.0)
+      pino:
+        specifier: ^9.1.0
+        version: 9.1.0
       tiny-invariant:
         specifier: ^1.3.1
         version: 1.3.3
@@ -779,9 +782,6 @@ importers:
       p-state:
         specifier: ^2.0.1
         version: 2.0.1
-      pino:
-        specifier: ^9.1.0
-        version: 9.1.0
       pino-pretty:
         specifier: ^11.2.1
         version: 11.2.1


### PR DESCRIPTION
A very simple project that uses typescript, does not have `skipLibCheck`, and did not add the optional pino peer dep would get `tsc` errors due to missing pino types. 

This change ensures that we ship the pino dependency so the types can resolve.