### PR TITLE
Version Packages

### DIFF
--- a/.changeset/dull-feet-change.md
+++ b/.changeset/dull-feet-change.md
@@ -1,5 +1,0 @@
----
-"@osdk/generator": patch
----
-
-Fixes additional compile breaks when formatting is off

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/cli.cmd.typescript
 
+## 0.5.3
+
+### Patch Changes
+
+- Updated dependencies [52317e9]
+  - @osdk/generator@1.13.3
+
 ## 0.5.2
 
 ### Patch Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.5.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/cli
 
+## 0.23.3
+
+### Patch Changes
+
+- Updated dependencies [52317e9]
+  - @osdk/generator@1.13.3
+
 ## 0.23.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/e2e.generated.1.1.x/CHANGELOG.md
+++ b/packages/e2e.generated.1.1.x/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/e2e.generated.1.1.x
 
+## 0.2.3
+
+### Patch Changes
+
+- Updated dependencies [52317e9]
+  - @osdk/generator@1.13.3
+  - @osdk/legacy-client@2.5.1
+
 ## 0.2.2
 
 ### Patch Changes

--- a/packages/e2e.generated.1.1.x/package.json
+++ b/packages/e2e.generated.1.1.x/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.generated.1.1.x",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/e2e.test.foundry-sdk-generator/CHANGELOG.md
+++ b/packages/e2e.test.foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/e2e.test.foundry-sdk-generator
 
+## 0.2.4
+
+### Patch Changes
+
+- @osdk/foundry-sdk-generator@1.3.4
+
 ## 0.2.3
 
 ### Patch Changes

--- a/packages/e2e.test.foundry-sdk-generator/package.json
+++ b/packages/e2e.test.foundry-sdk-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.test.foundry-sdk-generator",
   "private": true,
-  "version": "0.2.3",
+  "version": "0.2.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/foundry-sdk-generator
 
+## 1.3.4
+
+### Patch Changes
+
+- Updated dependencies [52317e9]
+  - @osdk/generator@1.13.3
+  - @osdk/legacy-client@2.5.1
+
 ## 1.3.3
 
 ### Patch Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/generator
 
+## 1.13.3
+
+### Patch Changes
+
+- 52317e9: Fixes additional compile breaks when formatting is off
+
 ## 1.13.2
 
 ### Patch Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/1.3.x, this PR will be updated.


# Releases
## @osdk/cli@0.23.3

### Patch Changes

-   Updated dependencies [52317e9]
    -   @osdk/generator@1.13.3

## @osdk/foundry-sdk-generator@1.3.4

### Patch Changes

-   Updated dependencies [52317e9]
    -   @osdk/generator@1.13.3
    -   @osdk/legacy-client@2.5.1

## @osdk/generator@1.13.3

### Patch Changes

-   52317e9: Fixes additional compile breaks when formatting is off

## @osdk/cli.cmd.typescript@0.5.3

### Patch Changes

-   Updated dependencies [52317e9]
    -   @osdk/generator@1.13.3

## @osdk/e2e.generated.1.1.x@0.2.3

### Patch Changes

-   Updated dependencies [52317e9]
    -   @osdk/generator@1.13.3
    -   @osdk/legacy-client@2.5.1

## @osdk/e2e.test.foundry-sdk-generator@0.2.4

### Patch Changes

-   @osdk/foundry-sdk-generator@1.3.4
