### PR TITLE
Rework codegen for namespaces

### DIFF
--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -73,7 +73,7 @@ const privatePackages = [
 const consumerCliPackages = [
   "@osdk/cli",
   "@osdk/create-app",
-  "@osdk/foundry-sdk-generator",
+  "@osdk/tmp-foundry-sdk-generator",
 ];
 
 /**

--- a/packages/cli.cmd.typescript/src/generate/TypescriptGenerateArgs.ts
+++ b/packages/cli.cmd.typescript/src/generate/TypescriptGenerateArgs.ts
@@ -28,8 +28,6 @@ export interface TypescriptGenerateArgs {
   packageName?: string;
   clean?: boolean;
   internal: boolean;
-  ontologyApiNamespace: string | undefined;
-  apiNamespaceMap: Map<string, string>;
   externalObjects: Map<string, string>;
   externalInterfaces: Map<string, string>;
 }

--- a/packages/cli.cmd.typescript/src/generate/TypescriptGenerateArgs.ts
+++ b/packages/cli.cmd.typescript/src/generate/TypescriptGenerateArgs.ts
@@ -30,4 +30,6 @@ export interface TypescriptGenerateArgs {
   internal: boolean;
   ontologyApiNamespace: string | undefined;
   apiNamespaceMap: Map<string, string>;
+  externalObjects: Map<string, string>;
+  externalInterfaces: Map<string, string>;
 }

--- a/packages/cli.cmd.typescript/src/generate/generate.ts
+++ b/packages/cli.cmd.typescript/src/generate/generate.ts
@@ -95,9 +95,6 @@ export const generateCommand: CommandModule<
             type: "boolean",
             default: false,
           },
-          ontologyApiNamespace: {
-            type: "string",
-          },
           externalObjects: {
             type: "string",
             coerce: (value) => {
@@ -113,20 +110,6 @@ export const generateCommand: CommandModule<
             default: "",
           },
           externalInterfaces: {
-            type: "string",
-            coerce: (value) => {
-              const map = new Map<string, string>();
-              if (value) {
-                for (const entry of value.split(",")) {
-                  const [api, ns] = entry.split(":");
-                  map.set(api, ns);
-                }
-              }
-              return map;
-            },
-            default: "",
-          },
-          apiNamespaceMap: {
             type: "string",
             coerce: (value) => {
               const map = new Map<string, string>();

--- a/packages/cli.cmd.typescript/src/generate/generate.ts
+++ b/packages/cli.cmd.typescript/src/generate/generate.ts
@@ -98,6 +98,34 @@ export const generateCommand: CommandModule<
           ontologyApiNamespace: {
             type: "string",
           },
+          externalObjects: {
+            type: "string",
+            coerce: (value) => {
+              const map = new Map<string, string>();
+              if (value) {
+                for (const entry of value.split(",")) {
+                  const [api, ns] = entry.split(":");
+                  map.set(api, ns);
+                }
+              }
+              return map;
+            },
+            default: "",
+          },
+          externalInterfaces: {
+            type: "string",
+            coerce: (value) => {
+              const map = new Map<string, string>();
+              if (value) {
+                for (const entry of value.split(",")) {
+                  const [api, ns] = entry.split(":");
+                  map.set(api, ns);
+                }
+              }
+              return map;
+            },
+            default: "",
+          },
           apiNamespaceMap: {
             type: "string",
             coerce: (value) => {

--- a/packages/cli.cmd.typescript/src/generate/handleGenerate.mts
+++ b/packages/cli.cmd.typescript/src/generate/handleGenerate.mts
@@ -242,8 +242,8 @@ async function generateClientSdk(
       minimalFs,
       await getDependencyVersions(),
       process.env.PACKAGE_CLI_VERSION!,
-      args.ontologyApiNamespace,
-      args.apiNamespaceMap,
+      args.externalObjects,
+      args.externalInterfaces,
     );
     return true;
   } catch (e) {
@@ -320,8 +320,8 @@ async function generateSourceFiles(
     fs,
     args.outDir,
     args.packageType,
-    args.ontologyApiNamespace,
-    args.apiNamespaceMap,
+    args.externalObjects,
+    args.externalInterfaces,
   );
 }
 

--- a/packages/client.unstable.tpsa/src/index.ts
+++ b/packages/client.unstable.tpsa/src/index.ts
@@ -15,4 +15,6 @@
  */
 
 export type * from "./generated/third-party-application-service/index.js";
+export { getSdk } from "./generated/third-party-application-service/SdkService/getSdk.js";
+export { getSdkPackage } from "./generated/third-party-application-service/SdkService/getSdkPackage.js";
 export {};

--- a/packages/e2e.generated.api-namespace.dep/package.json
+++ b/packages/e2e.generated.api-namespace.dep/package.json
@@ -21,7 +21,7 @@
     "check-attw": "monorepo.tool.attw esm",
     "check-spelling": "cspell --quiet .",
     "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
-    "codegen": "rm -rf src/generatedNoCheck/* && osdk-unstable-typescript generate --outDir src/generatedNoCheck --ontologyPath ontology.json --beta true --packageType module --version dev --internal --ontologyApiNamespace com.example.dep",
+    "codegen": "rm -rf src/generatedNoCheck/* && osdk-unstable-typescript generate --outDir src/generatedNoCheck --ontologyPath ontology.json --beta true --packageType module --version dev --internal",
     "fix-lint": "eslint . --fix && dprint fmt --config $(find-up dprint.json)",
     "lint": "eslint . && dprint check  --config $(find-up dprint.json)",
     "transpile": "monorepo.tool.transpile"

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,2 +1,4 @@
 export type $ExpectedClientVersion = '2.0.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
+
+export const $ontologyRid = 'ri.ontology.main.ontology.dep';

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/index.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/index.ts
@@ -6,3 +6,4 @@ export * from './ontology/objects.js';
 export * as $Objects from './ontology/objects.js';
 export * from './ontology/queries.js';
 export * as $Queries from './ontology/queries.js';
+export { $ontologyRid } from './OntologyMetadata.js';

--- a/packages/e2e.generated.api-namespace.local/ontology.json
+++ b/packages/e2e.generated.api-namespace.local/ontology.json
@@ -36,6 +36,33 @@
   },
   "interfaceTypes": {},
   "objectTypes": {
+    "com.example.dep.Task": {
+      "implementsInterfaces": [],
+      "implementsInterfaces2": {},
+      "sharedPropertyTypeMapping": {},
+      "objectType": {
+        "apiName": "com.example.dep.Task",
+        "primaryKey": "taskId",
+
+        "titleProperty": "taskId",
+
+        "properties": {
+          "taskId": {
+            "dataType": {
+              "type": "string"
+            }
+          },
+          "body": {
+            "dataType": {
+              "type": "string"
+            }
+          }
+        },
+        "status": "ACTIVE",
+        "rid": "ridForTask"
+      },
+      "linkTypes": []
+    },
     "Thing": {
       "implementsInterfaces": ["com.example.dep.SomeInterface"],
       "implementsInterfaces2": {

--- a/packages/e2e.generated.api-namespace.local/ontology.json
+++ b/packages/e2e.generated.api-namespace.local/ontology.json
@@ -34,7 +34,24 @@
       ]
     }
   },
-  "interfaceTypes": {},
+  "interfaceTypes": {
+    "com.example.local.SomeInterface": {
+      "apiName": "com.example.local.SomeInterface",
+      "rid": "idk2",
+      "displayName": "Sum Interface",
+      "extendsInterfaces": ["com.example.dep.SomeInterface"],
+      "properties": {
+        "com.example.dep.spt": {
+          "apiName": "com.example.dep.spt",
+          "dataType": {
+            "type": "string"
+          },
+          "displayName": "Some Property",
+          "rid": "idk"
+        }
+      }
+    }
+  },
   "objectTypes": {
     "com.example.dep.Task": {
       "implementsInterfaces": [],

--- a/packages/e2e.generated.api-namespace.local/package.json
+++ b/packages/e2e.generated.api-namespace.local/package.json
@@ -21,7 +21,7 @@
     "check-attw": "monorepo.tool.attw esm",
     "check-spelling": "cspell --quiet .",
     "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
-    "codegen": "rm -rf src/generatedNoCheck/* && osdk-unstable-typescript generate --outDir src/generatedNoCheck --ontologyPath ontology.json --beta true --packageType module --version dev --internal --apiNamespaceMap 'com.example.dep:@osdk/e2e.generated.api-namespace.dep'",
+    "codegen": "rm -rf src/generatedNoCheck/* && osdk-unstable-typescript generate --outDir src/generatedNoCheck --ontologyPath ontology.json --beta true --packageType module --version dev --internal --apiNamespaceMap 'com.example.dep:@osdk/e2e.generated.api-namespace.dep' --externalObjects 'com.example.dep.Task:@osdk/e2e.generated.api-namespace.dep'",
     "fix-lint": "eslint . --fix && dprint fmt --config $(find-up dprint.json)",
     "lint": "eslint . && dprint check  --config $(find-up dprint.json)",
     "transpile": "monorepo.tool.transpile"

--- a/packages/e2e.generated.api-namespace.local/package.json
+++ b/packages/e2e.generated.api-namespace.local/package.json
@@ -21,7 +21,7 @@
     "check-attw": "monorepo.tool.attw esm",
     "check-spelling": "cspell --quiet .",
     "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
-    "codegen": "rm -rf src/generatedNoCheck/* && osdk-unstable-typescript generate --outDir src/generatedNoCheck --ontologyPath ontology.json --beta true --packageType module --version dev --internal --externalObjects 'com.example.dep.Task:@osdk/e2e.generated.api-namespace.dep'",
+    "codegen": "rm -rf src/generatedNoCheck/* && osdk-unstable-typescript generate --outDir src/generatedNoCheck --ontologyPath ontology.json --beta true --packageType module --version dev --internal --externalObjects 'com.example.dep.Task:@osdk/e2e.generated.api-namespace.dep' --externalInterfaces 'com.example.dep.SomeInterface:@osdk/e2e.generated.api-namespace.dep'",
     "fix-lint": "eslint . --fix && dprint fmt --config $(find-up dprint.json)",
     "lint": "eslint . && dprint check  --config $(find-up dprint.json)",
     "transpile": "monorepo.tool.transpile"

--- a/packages/e2e.generated.api-namespace.local/package.json
+++ b/packages/e2e.generated.api-namespace.local/package.json
@@ -21,7 +21,7 @@
     "check-attw": "monorepo.tool.attw esm",
     "check-spelling": "cspell --quiet .",
     "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
-    "codegen": "rm -rf src/generatedNoCheck/* && osdk-unstable-typescript generate --outDir src/generatedNoCheck --ontologyPath ontology.json --beta true --packageType module --version dev --internal --apiNamespaceMap 'com.example.dep:@osdk/e2e.generated.api-namespace.dep' --externalObjects 'com.example.dep.Task:@osdk/e2e.generated.api-namespace.dep'",
+    "codegen": "rm -rf src/generatedNoCheck/* && osdk-unstable-typescript generate --outDir src/generatedNoCheck --ontologyPath ontology.json --beta true --packageType module --version dev --internal --externalObjects 'com.example.dep.Task:@osdk/e2e.generated.api-namespace.dep'",
     "fix-lint": "eslint . --fix && dprint fmt --config $(find-up dprint.json)",
     "lint": "eslint . && dprint check  --config $(find-up dprint.json)",
     "transpile": "monorepo.tool.transpile"

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/actions/setTaskBody.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/actions/setTaskBody.ts
@@ -7,7 +7,7 @@ import type {
   ApplyBatchActionOptions,
 } from '@osdk/api';
 import { $osdkMetadata } from '../../OntologyMetadata.js';
-import type { Task as $Imported$objectTypes$com$example$dep$Task } from '@osdk/e2e.generated.api-namespace.dep';
+import type { Task as $Imported$com$example$dep$Task } from '@osdk/e2e.generated.api-namespace.dep';
 
 export namespace setTaskBody {
   // Represents the definition of the parameters for the action
@@ -20,14 +20,14 @@ export namespace setTaskBody {
     task: {
       multiplicity: false;
       nullable: false;
-      type: ActionMetadata.DataType.Object<$Imported$objectTypes$com$example$dep$Task>;
+      type: ActionMetadata.DataType.Object<$Imported$com$example$dep$Task>;
     };
   };
 
   export interface Params {
     readonly body: ActionParam.PrimitiveType<'string'>;
 
-    readonly task: ActionParam.ObjectType<$Imported$objectTypes$com$example$dep$Task>;
+    readonly task: ActionParam.ObjectType<$Imported$com$example$dep$Task>;
   }
 
   // Represents a fqn of the action
@@ -46,7 +46,7 @@ export namespace setTaskBody {
 
 /**
  * @param {ActionParam.PrimitiveType<"string">} body
- * @param {ActionParam.ObjectType<$Imported$objectTypes$com$example$dep$Task>} task
+ * @param {ActionParam.ObjectType<$Imported$com$example$dep$Task>} task
  */
 export interface setTaskBody extends ActionDefinition<setTaskBody.Signatures> {
   __DefinitionMetadata?: {

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/interfaces.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/interfaces.ts
@@ -1,1 +1,1 @@
-export {};
+export * from './interfaces/SomeInterface.js';

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/interfaces/SomeInterface.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/interfaces/SomeInterface.ts
@@ -1,0 +1,59 @@
+import type { PropertyDef as $PropertyDef } from '@osdk/api';
+import { $osdkMetadata } from '../../OntologyMetadata.js';
+
+import type {
+  InterfaceDefinition as $InterfaceDefinition,
+  ObjectSet as $ObjectSet,
+  Osdk as $Osdk,
+  PropertyValueWireToClient as $PropType,
+} from '@osdk/api';
+
+export type OsdkObjectLinks$SomeInterface = {};
+
+export namespace SomeInterface {
+  export type PropertyKeys = 'com.example.dep.spt';
+
+  export interface Props {
+    readonly 'com.example.dep.spt': $PropType['string'] | undefined;
+  }
+  export interface StrictProps {
+    readonly 'com.example.dep.spt': $PropType['string'] | undefined;
+  }
+
+  export interface ObjectSet extends $ObjectSet<SomeInterface, SomeInterface.ObjectSet> {}
+
+  export type OsdkObject<
+    OPTIONS extends never | '$notStrict' | '$rid' = never,
+    K extends keyof SomeInterface.Props = keyof SomeInterface.Props,
+  > = $Osdk<SomeInterface, K | OPTIONS>;
+}
+
+export interface SomeInterface extends $InterfaceDefinition {
+  osdkMetadata: typeof $osdkMetadata;
+  type: 'interface';
+  apiName: 'com.example.local.SomeInterface';
+  __DefinitionMetadata?: {
+    objectSet: SomeInterface.ObjectSet;
+    props: SomeInterface.Props;
+    linksType: OsdkObjectLinks$SomeInterface;
+    strictProps: SomeInterface.StrictProps;
+    apiName: 'com.example.local.SomeInterface';
+    displayName: 'Sum Interface';
+    implements: ['com.example.dep.SomeInterface'];
+    links: {};
+    properties: {
+      /**
+       *   display name: 'Some Property'
+       */
+      'com.example.dep.spt': $PropertyDef<'string', 'nullable', 'single'>;
+    };
+    rid: 'idk2';
+    type: 'interface';
+  };
+}
+
+export const SomeInterface: SomeInterface = {
+  type: 'interface',
+  apiName: 'com.example.local.SomeInterface',
+  osdkMetadata: $osdkMetadata,
+};

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/queries/getTask.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/queries/getTask.ts
@@ -2,18 +2,18 @@ import type { QueryDefinition, VersionBound } from '@osdk/api';
 import type { QueryParam, QueryResult } from '@osdk/api';
 import type { $ExpectedClientVersion } from '../../OntologyMetadata.js';
 import { $osdkMetadata } from '../../OntologyMetadata.js';
-import type { Task as $Imported$objectTypes$com$example$dep$Task } from '@osdk/e2e.generated.api-namespace.dep';
+import type { Task as $Imported$com$example$dep$Task } from '@osdk/e2e.generated.api-namespace.dep';
 
 export namespace getTask {
   export interface Signature {
-    (query: getTask.Parameters): Promise<QueryResult.ObjectType<$Imported$objectTypes$com$example$dep$Task>>;
+    (query: getTask.Parameters): Promise<QueryResult.ObjectType<$Imported$com$example$dep$Task>>;
   }
 
   export interface Parameters {
     /**
      * (no ontology metadata)
      */
-    readonly a: QueryParam.ObjectType<$Imported$objectTypes$com$example$dep$Task>;
+    readonly a: QueryParam.ObjectType<$Imported$com$example$dep$Task>;
   }
 }
 
@@ -31,14 +31,14 @@ export interface getTask extends QueryDefinition<getTask.Signature>, VersionBoun
         nullable: false;
         object: 'com.example.dep.Task';
         type: 'object';
-        __OsdkTargetType?: $Imported$objectTypes$com$example$dep$Task;
+        __OsdkTargetType?: $Imported$com$example$dep$Task;
       };
     };
     output: {
       nullable: false;
       object: 'com.example.dep.Task';
       type: 'object';
-      __OsdkTargetType?: $Imported$objectTypes$com$example$dep$Task;
+      __OsdkTargetType?: $Imported$com$example$dep$Task;
     };
     signature: getTask.Signature;
   };

--- a/packages/e2e.test.foundry-sdk-generator/generateMockOntology.js
+++ b/packages/e2e.test.foundry-sdk-generator/generateMockOntology.js
@@ -50,8 +50,8 @@ async function setup() {
     foundryHostname: "https://stack.palantir.com",
     ontology: "ri.ontology.main.ontology.698267cc-6b48-4d98-beff-29beb24e9361",
     objectTypes: [
-      "employee",
-      "office",
+      "Employee",
+      "Office",
       "objectTypeWithAllPropertyTypes",
       "ObjectWithTimestampPrimaryKey",
       "equipment",

--- a/packages/generator/src/GenerateContext/EnhanceCommon.ts
+++ b/packages/generator/src/GenerateContext/EnhanceCommon.ts
@@ -17,8 +17,6 @@
 import type { EnhancedOntologyDefinition } from "./EnhancedOntologyDefinition.js";
 
 export interface EnhanceCommon {
-  ontologyApiNamespace: string | undefined;
-  apiNamespacePackageMap: Map<string, string>;
   importExt: string;
   /** DO NOT USE THIS IN THE CONSTRUCTOR(S) */
   enhancedOntology: EnhancedOntologyDefinition;

--- a/packages/generator/src/GenerateContext/EnhancedBase.ts
+++ b/packages/generator/src/GenerateContext/EnhancedBase.ts
@@ -32,12 +32,12 @@ export abstract class AbstractImportable {
   uniqueImportName: string;
 
   readonly isLocal: boolean;
-  readonly sourcePackage: string | undefined;
 
   constructor(
     common: EnhanceCommon,
     fullApiName: string,
     basePath: string,
+    isLocal: boolean = true,
   ) {
     this._common = common;
     this.fullApiName = fullApiName;
@@ -46,15 +46,12 @@ export abstract class AbstractImportable {
       this.fullApiName,
     );
 
-    const { ontologyApiNamespace, apiNamespacePackageMap, importExt } = common;
-    this.isLocal = ontologyApiNamespace === this.apiNamespace;
-    this.sourcePackage = this.apiNamespace && !this.isLocal
-      ? apiNamespacePackageMap.get(this.apiNamespace)
-      : undefined;
+    const { importExt } = common;
+    this.isLocal = isLocal;
 
     this.importPath = this.isLocal
       ? `${basePath}/${this.shortApiName}${importExt}`
-      : this.sourcePackage!;
+      : basePath;
     this.uniqueImportName = this.shortApiName;
   }
 
@@ -86,11 +83,11 @@ export abstract class EnhancedBase<T> extends AbstractImportable {
     super(common, fullApiName, basePath);
     this.raw = raw;
 
-    if (!this.isLocal && !this.sourcePackage) {
-      throw new Error(
-        `Expected { ns:'${this.apiNamespace}', shortName: '${this.shortApiName}'} to be in namespace '${common.ontologyApiNamespace}' or in a provided package mapping`,
-      );
-    }
+    // if (this.apiNamespace !== common.ontologyApiNamespace) {
+    //   throw new Error(
+    //     `Found type { ns:'${this.apiNamespace}', shortName: '${this.shortApiName}'} but it is not in the generation namespace '${this._common.ontologyApiNamespace}'. This violates the contract of the generator.`,
+    //   );
+    // }
   }
 }
 

--- a/packages/generator/src/GenerateContext/EnhancedBase.ts
+++ b/packages/generator/src/GenerateContext/EnhancedBase.ts
@@ -31,8 +31,6 @@ export abstract class AbstractImportable {
   importPath: string;
   uniqueImportName: string;
 
-  readonly isLocal: boolean;
-
   constructor(
     common: EnhanceCommon,
     fullApiName: string,
@@ -47,9 +45,8 @@ export abstract class AbstractImportable {
     );
 
     const { importExt } = common;
-    this.isLocal = isLocal;
 
-    this.importPath = this.isLocal
+    this.importPath = isLocal
       ? `${basePath}/${this.shortApiName}${importExt}`
       : basePath;
     this.uniqueImportName = this.shortApiName;
@@ -82,12 +79,6 @@ export abstract class EnhancedBase<T> extends AbstractImportable {
   ) {
     super(common, fullApiName, basePath);
     this.raw = raw;
-
-    // if (this.apiNamespace !== common.ontologyApiNamespace) {
-    //   throw new Error(
-    //     `Found type { ns:'${this.apiNamespace}', shortName: '${this.shortApiName}'} but it is not in the generation namespace '${this._common.ontologyApiNamespace}'. This violates the contract of the generator.`,
-    //   );
-    // }
   }
 }
 

--- a/packages/generator/src/GenerateContext/ForeignType.ts
+++ b/packages/generator/src/GenerateContext/ForeignType.ts
@@ -20,28 +20,25 @@ import { AbstractImportable } from "./EnhancedBase.js";
 export class ForeignType extends AbstractImportable {
   constructor(
     public _common: EnhanceCommon,
-    public readonly type: string,
-    apiNamespace: string,
+    apiNamespace: string | undefined,
     shortApiName: string,
+    destinationPackage: string,
   ) {
     super(
       _common,
-      `${apiNamespace}.${shortApiName}`,
-      _common.apiNamespacePackageMap.get(apiNamespace)!,
+      apiNamespace ? `${apiNamespace}.${shortApiName}` : shortApiName,
+      destinationPackage,
+      false,
     );
   }
 
   getImportedDefinitionIdentifier(v2: boolean) {
-    return `$Imported$${this.type}$${
-      this.apiNamespace!.replace(/\./g, "$")
+    return `$Imported$${
+      this.apiNamespace?.replace(/\./g, "$")
     }$${this.shortApiName}`;
   }
 
   getDefinitionIdentifier(v2: boolean) {
-    if (this.type === "objectTypes") {
-      return v2 ? this.uniqueImportName : `${this.uniqueImportName}Def`;
-    } else {
-      return this.uniqueImportName;
-    }
+    return this.uniqueImportName;
   }
 }

--- a/packages/generator/src/GenerateContext/enhanceOntology.ts
+++ b/packages/generator/src/GenerateContext/enhanceOntology.ts
@@ -18,15 +18,25 @@ import type { WireOntologyDefinition } from "../WireOntologyDefinition.js";
 import { EnhancedOntologyDefinition } from "./EnhancedOntologyDefinition.js";
 
 export function enhanceOntology(
-  sanitized: WireOntologyDefinition,
-  ontologyApiNamespace: string | undefined,
-  apiNamespacePackageMap: Map<string, string>,
-  importExt: string,
+  {
+    sanitized,
+    importExt,
+    externalObjects,
+    externalInterfaces,
+    externalSpts,
+  }: {
+    sanitized: WireOntologyDefinition;
+    externalObjects?: Map<string, string>;
+    externalInterfaces?: Map<string, string>;
+    externalSpts?: Map<string, string>;
+    importExt: string;
+  },
 ): EnhancedOntologyDefinition {
   return new EnhancedOntologyDefinition(
     sanitized,
-    ontologyApiNamespace,
-    apiNamespacePackageMap,
     importExt,
+    externalObjects,
+    externalInterfaces,
+    externalSpts,
   );
 }

--- a/packages/generator/src/generateClientSdkPackage.ts
+++ b/packages/generator/src/generateClientSdkPackage.ts
@@ -29,8 +29,8 @@ export async function generateClientSdkPackage(
   minimalFs: MinimalFs,
   dependencyVersions: DependencyVersions,
   cliVersion: string,
-  ontologyApiNamespace: string | undefined,
-  apiNamespacePackageMap: Map<string, string>,
+  externalObjects: Map<string, string> = new Map(),
+  externalInterfaces: Map<string, string> = new Map(),
 ) {
   if (!packageName) throw new Error("Package name is required");
   if (sdkVersion === "1.1") {
@@ -48,8 +48,8 @@ export async function generateClientSdkPackage(
       minimalFs,
       outDir,
       packageType,
-      ontologyApiNamespace,
-      apiNamespacePackageMap,
+      externalObjects,
+      externalInterfaces,
     );
 
     await fs.promises.mkdir(outDir, { recursive: true });

--- a/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.test.ts
+++ b/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.test.ts
@@ -20,8 +20,9 @@ import type {
 } from "@osdk/internal.foundry.core";
 import { format } from "prettier";
 import { describe, expect, it } from "vitest";
-import type { EnhancedInterfaceType } from "../GenerateContext/EnhancedInterfaceType.js";
+import { EnhancedInterfaceType } from "../GenerateContext/EnhancedInterfaceType.js";
 import { enhanceOntology } from "../GenerateContext/enhanceOntology.js";
+import { ForeignType } from "../GenerateContext/ForeignType.js";
 import type { WireOntologyDefinition } from "../WireOntologyDefinition.js";
 import { __UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst } from "./UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.js";
 
@@ -94,9 +95,18 @@ describe(__UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst, () => {
       importExt: "",
     });
 
+    expect(ontology.interfaceTypes.Bar instanceof EnhancedInterfaceType).toBe(
+      true,
+    );
+
+    // type guard for below
+    if (ontology.interfaceTypes.Bar instanceof ForeignType) {
+      throw new Error("Expected Bar to be an EnhancedInterfaceType");
+    }
+
     const formattedCode = await format(
       __UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst(
-        ontology.interfaceTypes.Bar as EnhancedInterfaceType,
+        ontology.interfaceTypes.Bar,
         ontology,
         true,
       ),

--- a/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.test.ts
+++ b/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.test.ts
@@ -20,6 +20,7 @@ import type {
 } from "@osdk/internal.foundry.core";
 import { format } from "prettier";
 import { describe, expect, it } from "vitest";
+import type { EnhancedInterfaceType } from "../GenerateContext/EnhancedInterfaceType.js";
 import { enhanceOntology } from "../GenerateContext/enhanceOntology.js";
 import type { WireOntologyDefinition } from "../WireOntologyDefinition.js";
 import { __UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst } from "./UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.js";
@@ -86,18 +87,16 @@ function simpleOntology<I extends InterfaceType>(
 
 describe(__UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst, () => {
   it("Does not say (inherited) on properties locally defined", async () => {
-    const ontology = enhanceOntology(
-      simpleOntology("ontology", [
+    const ontology = enhanceOntology({
+      sanitized: simpleOntology("ontology", [
         simpleInterface("Bar", [simpleSpt("bar", 0)], [], 0),
       ]),
-      undefined,
-      new Map(),
-      "",
-    );
+      importExt: "",
+    });
 
     const formattedCode = await format(
       __UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst(
-        ontology.interfaceTypes.Bar,
+        ontology.interfaceTypes.Bar as EnhancedInterfaceType,
         ontology,
         true,
       ),
@@ -172,18 +171,19 @@ describe(__UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst, () => {
     const barSpt = simpleSpt("bar");
 
     const ontology = enhanceOntology(
-      simpleOntology("ontology", [
-        simpleInterface("Foo", [fooSpt], ["Parent"]),
-        simpleInterface("Parent", [barSpt], []),
-      ]),
-      undefined,
-      new Map(),
-      "",
+      {
+        sanitized: simpleOntology("ontology", [
+          simpleInterface("Foo", [fooSpt], ["Parent"]),
+          simpleInterface("Parent", [barSpt], []),
+        ]),
+
+        importExt: "",
+      },
     );
 
     const formattedCode = await format(
       __UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst(
-        ontology.interfaceTypes.Foo,
+        ontology.interfaceTypes.Foo as EnhancedInterfaceType,
         ontology,
         true,
       ),
@@ -259,18 +259,18 @@ describe(__UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst, () => {
     const barSpt = simpleSpt("bar");
 
     const ontology = enhanceOntology(
-      simpleOntology("ontology", [
-        simpleInterface("Foo", [fooSpt, barSpt], ["Parent"]),
-        simpleInterface("Parent", [barSpt], []),
-      ]),
-      undefined,
-      new Map(),
-      "",
+      {
+        sanitized: simpleOntology("ontology", [
+          simpleInterface("Foo", [fooSpt, barSpt], ["Parent"]),
+          simpleInterface("Parent", [barSpt], []),
+        ]),
+        importExt: "",
+      },
     );
 
     const formattedCode = await format(
       __UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst(
-        ontology.interfaceTypes.Foo,
+        ontology.interfaceTypes.Foo as EnhancedInterfaceType,
         ontology,
         true,
       ),

--- a/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.ts
+++ b/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.ts
@@ -56,7 +56,9 @@ export function __UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst(
 
     const parent = ontology.requireInterfaceType(p, true);
     if (parent instanceof ForeignType) {
-      throw new Error("Don't current support this");
+      throw new Error(
+        "Currently, parent types must be within the same package to work",
+      );
     }
 
     const it = deleteUndefineds(
@@ -93,25 +95,7 @@ export function __UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst(
     }
   }
 
-  const ogProperties = definition.properties;
   definition.properties = mergedProperties;
-
-  function localPropertyJsdoc(apiName: string) {
-    const property = definition.properties[apiName]!;
-    const isInherited = ogProperties[apiName] == null;
-
-    return propertyJsdoc(property, { isInherited, apiName });
-  }
-
-  function maybeStripNamespace(q: string) {
-    if (
-      interfaceDef.apiNamespace && q.startsWith(`${interfaceDef.apiNamespace}.`)
-    ) {
-      return q.slice(interfaceDef.apiNamespace.length + 1);
-    } else {
-      return q;
-    }
-  }
 
   const objectSetIdentifier = `${interfaceDef.shortApiName}.ObjectSet`;
   const propertyKeysIdentifier = `${interfaceDef.shortApiName}.PropertyKeys`;

--- a/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.ts
+++ b/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.ts
@@ -20,6 +20,7 @@ import invariant from "tiny-invariant";
 import { extractNamespace } from "../GenerateContext/EnhancedBase.js";
 import type { EnhancedInterfaceType } from "../GenerateContext/EnhancedInterfaceType.js";
 import type { EnhancedOntologyDefinition } from "../GenerateContext/EnhancedOntologyDefinition.js";
+import { ForeignType } from "../GenerateContext/ForeignType.js";
 import { propertyJsdoc } from "../shared/propertyJsdoc.js";
 import { deleteUndefineds } from "../util/deleteUndefineds.js";
 import { stringify } from "../util/stringify.js";
@@ -53,9 +54,14 @@ export function __UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst(
       `Expected to find a parent interface named ${p} in the ontology and did not.`,
     );
 
+    const parent = ontology.requireInterfaceType(p, true);
+    if (parent instanceof ForeignType) {
+      throw new Error("Don't current support this");
+    }
+
     const it = deleteUndefineds(
       __UNSTABLE_wireInterfaceTypeV2ToSdkObjectDefinition(
-        ontology.requireInterfaceType(p, true).raw,
+        parent.raw,
         v2,
       ),
     );

--- a/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.ts
+++ b/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.ts
@@ -18,7 +18,7 @@ import { __UNSTABLE_wireInterfaceTypeV2ToSdkObjectDefinition } from "@osdk/gener
 import fastDeepEqual from "fast-deep-equal";
 import invariant from "tiny-invariant";
 import { extractNamespace } from "../GenerateContext/EnhancedBase.js";
-import type { EnhancedInterfaceType } from "../GenerateContext/EnhancedInterfaceType.js";
+import { EnhancedInterfaceType } from "../GenerateContext/EnhancedInterfaceType.js";
 import type { EnhancedOntologyDefinition } from "../GenerateContext/EnhancedOntologyDefinition.js";
 import { ForeignType } from "../GenerateContext/ForeignType.js";
 import { propertyJsdoc } from "../shared/propertyJsdoc.js";
@@ -49,30 +49,25 @@ export function __UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst(
   const objectDefIdentifier = interfaceDef.getDefinitionIdentifier(v2);
 
   const parents = definition.implements?.map(p => {
-    invariant(
-      ontology.interfaceTypes[p] != null,
-      `Expected to find a parent interface named ${p} in the ontology and did not.`,
-    );
-
     const parent = ontology.requireInterfaceType(p, true);
-    if (parent instanceof ForeignType) {
-      throw new Error(
-        "Currently, parent types must be within the same package to work",
+    if (parent instanceof EnhancedInterfaceType) {
+      const it = deleteUndefineds(
+        __UNSTABLE_wireInterfaceTypeV2ToSdkObjectDefinition(
+          parent.raw,
+          v2,
+        ),
       );
+      return it;
     }
-
-    const it = deleteUndefineds(
-      __UNSTABLE_wireInterfaceTypeV2ToSdkObjectDefinition(
-        parent.raw,
-        v2,
-      ),
-    );
-
-    return it;
   }) ?? [];
 
   const mergedProperties = { ...definition.properties };
   for (const parent of parents) {
+    if (parent == null) {
+      // came from a foreign type and we cannot merge properties yet
+      // so if they weren't listed on the interface its over
+      continue;
+    }
     for (const apiName of Object.keys(parent.properties)) {
       if (definition.properties[apiName] != null) {
         invariant(

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -337,8 +337,11 @@ const referencingOntology = {
       ],
     },
   },
-  interfaceTypes: {},
+  interfaceTypes: {
+    ...referencedOntology.interfaceTypes,
+  },
   objectTypes: {
+    ...referencedOntology.objectTypes,
     "Thing": {
       implementsInterfaces: ["com.example.dep.SomeInterface"],
       implementsInterfaces2: {
@@ -1057,11 +1060,13 @@ describe("generator", () => {
         helper.minimalFiles,
         BASE_PATH,
         "module",
-        "foo.bar",
       ),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: Expected { ns:'undefined', shortName: 'Todo'} to be in namespace 'foo.bar' or in a provided package mapping]`,
     );
+
+    // Disabled for now since we can't really enforce it from dev console at the moment
+    // .rejects.toThrowErrorMatchingInlineSnapshot(
+    //   `[Error: Found type { ns:'undefined', shortName: 'Todo'} but it is not in the generation namespace 'foo.bar'. This violates the contract of the generator.]`,
+    // );
   });
 
   it("does not throw an error if a namespace is provided that all top levels use", async () => {
@@ -1072,7 +1077,6 @@ describe("generator", () => {
         helper.minimalFiles,
         BASE_PATH,
         "module",
-        "foo.bar",
       ),
     ).resolves.toMatchInlineSnapshot(`undefined`);
 
@@ -1087,6 +1091,8 @@ describe("generator", () => {
         {
           "/foo/OntologyMetadata.ts": "export type $ExpectedClientVersion = 'PLACEHOLDER';
         export const $osdkMetadata = { extraUserAgent: '' };
+
+        export const $ontologyRid = 'ridHere';
         ",
           "/foo/index.ts": "export * from './ontology/actions.js';
         export * as $Actions from './ontology/actions.js';
@@ -1096,6 +1102,7 @@ describe("generator", () => {
         export * as $Objects from './ontology/objects.js';
         export * from './ontology/queries.js';
         export * as $Queries from './ontology/queries.js';
+        export { $ontologyRid } from './OntologyMetadata.js';
         ",
           "/foo/ontology/actions.ts": "export { deleteTodos } from './actions/deleteTodos.js';
         export { markTodoCompleted } from './actions/markTodoCompleted.js';
@@ -1683,14 +1690,13 @@ describe("generator", () => {
           helper.minimalFiles,
           BASE_PATH,
           "module",
-          "foo.bar",
           new Map(),
         ),
       ).resolves.toMatchInlineSnapshot(`undefined`);
 
-      expect(helper.getFiles()["/foo/index.ts"]).not.toContain(
-        "$ontologyRid",
-      );
+      // expect(helper.getFiles()["/foo/index.ts"]).not.toContain(
+      //   "$ontologyRid",
+      // );
     });
 
     it("does exist when an ontology api name is not provided", async () => {
@@ -1723,8 +1729,9 @@ describe("generator", () => {
           helper.minimalFiles,
           BASE_PATH,
           "module",
-          undefined,
-          new Map([["com.example.dep", "@com.example.dep/osdk"]]),
+          new Map([["com.example.dep.Task", "@com.example.dep/osdk"]]),
+          new Map([["com.example.dep.SomeInterface", "@com.example.dep/osdk"]]),
+          new Map([["com.example.dep.spt", "@com.example.dep/osdk"]]),
         ),
       ).resolves.toMatchInlineSnapshot(`undefined`);
 
@@ -1734,18 +1741,18 @@ describe("generator", () => {
           import type { QueryParam, QueryResult } from '@osdk/api';
           import type { $ExpectedClientVersion } from '../../OntologyMetadata.js';
           import { $osdkMetadata } from '../../OntologyMetadata.js';
-          import type { Task as $Imported$objectTypes$com$example$dep$Task } from '@com.example.dep/osdk';
+          import type { Task as $Imported$com$example$dep$Task } from '@com.example.dep/osdk';
 
           export namespace getTask {
             export interface Signature {
-              (query: getTask.Parameters): Promise<QueryResult.ObjectType<$Imported$objectTypes$com$example$dep$Task>>;
+              (query: getTask.Parameters): Promise<QueryResult.ObjectType<$Imported$com$example$dep$Task>>;
             }
 
             export interface Parameters {
               /**
                * (no ontology metadata)
                */
-              readonly a: QueryParam.ObjectType<$Imported$objectTypes$com$example$dep$Task>;
+              readonly a: QueryParam.ObjectType<$Imported$com$example$dep$Task>;
             }
           }
 
@@ -1763,14 +1770,14 @@ describe("generator", () => {
                   nullable: false;
                   object: 'com.example.dep.Task';
                   type: 'object';
-                  __OsdkTargetType?: $Imported$objectTypes$com$example$dep$Task;
+                  __OsdkTargetType?: $Imported$com$example$dep$Task;
                 };
               };
               output: {
                 nullable: false;
                 object: 'com.example.dep.Task';
                 type: 'object';
-                __OsdkTargetType?: $Imported$objectTypes$com$example$dep$Task;
+                __OsdkTargetType?: $Imported$com$example$dep$Task;
               };
               signature: getTask.Signature;
             };
@@ -1800,8 +1807,9 @@ describe("generator", () => {
           helper.minimalFiles,
           BASE_PATH,
           "module",
-          undefined,
-          new Map([["com.example.dep", "@com.example.dep/osdk"]]),
+          new Map([["com.example.dep.Task", "@com.example.dep/osdk"]]),
+          new Map([["com.example.dep.SomeInterface", "@com.example.dep/osdk"]]),
+          new Map([["com.example.dep.spt", "@com.example.dep/osdk"]]),
         ),
       ).resolves.toMatchInlineSnapshot(`undefined`);
 
@@ -1896,7 +1904,7 @@ describe("generator", () => {
   });
 
   describe("action depends on foreign object", () => {
-    it("stuff", async () => {
+    it("stuff2", async () => {
       await expect(
         generateClientSdkVersionTwoPointZero(
           referencingOntology,
@@ -1904,8 +1912,9 @@ describe("generator", () => {
           helper.minimalFiles,
           BASE_PATH,
           "module",
-          undefined,
-          new Map([["com.example.dep", "@com.example.dep/osdk"]]),
+          new Map([["com.example.dep.Task", "@com.example.dep/osdk"]]),
+          new Map([["com.example.dep.SomeInterface", "@com.example.dep/osdk"]]),
+          new Map([["com.example.dep.spt", "@com.example.dep/osdk"]]),
         ),
       ).resolves.toMatchInlineSnapshot(`undefined`);
 
@@ -1920,7 +1929,7 @@ describe("generator", () => {
             ApplyBatchActionOptions,
           } from '@osdk/api';
           import { $osdkMetadata } from '../../OntologyMetadata.js';
-          import type { Task as $Imported$objectTypes$com$example$dep$Task } from '@com.example.dep/osdk';
+          import type { Task as $Imported$com$example$dep$Task } from '@com.example.dep/osdk';
 
           export namespace setTaskBody {
             // Represents the definition of the parameters for the action
@@ -1933,14 +1942,14 @@ describe("generator", () => {
               task: {
                 multiplicity: false;
                 nullable: false;
-                type: ActionMetadata.DataType.Object<$Imported$objectTypes$com$example$dep$Task>;
+                type: ActionMetadata.DataType.Object<$Imported$com$example$dep$Task>;
               };
             };
 
             export interface Params {
               readonly body: ActionParam.PrimitiveType<'string'>;
 
-              readonly task: ActionParam.ObjectType<$Imported$objectTypes$com$example$dep$Task>;
+              readonly task: ActionParam.ObjectType<$Imported$com$example$dep$Task>;
             }
 
             // Represents a fqn of the action
@@ -1959,7 +1968,7 @@ describe("generator", () => {
 
           /**
            * @param {ActionParam.PrimitiveType<"string">} body
-           * @param {ActionParam.ObjectType<$Imported$objectTypes$com$example$dep$Task>} task
+           * @param {ActionParam.ObjectType<$Imported$com$example$dep$Task>} task
            */
           export interface setTaskBody extends ActionDefinition<setTaskBody.Signatures> {
             __DefinitionMetadata?: {
@@ -2000,8 +2009,6 @@ describe("generator", () => {
         helper.minimalFiles,
         BASE_PATH,
         "module",
-        undefined,
-        new Map([["com.example.dep", "@com.example.dep/osdk"]]),
       ),
     ).resolves.toMatchInlineSnapshot(`undefined`);
 

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -1904,7 +1904,7 @@ describe("generator", () => {
   });
 
   describe("action depends on foreign object", () => {
-    it("stuff2", async () => {
+    it("can generate the action", async () => {
       await expect(
         generateClientSdkVersionTwoPointZero(
           referencingOntology,

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
@@ -99,11 +99,6 @@ export async function generateClientSdkVersionTwoPointZero(
   externalObjects: Map<string, string> = new Map(),
   externalInterfaces: Map<string, string> = new Map(),
   externalSpts: Map<string, string> = new Map(),
-  extraOntologies: Array<{
-    ontology: WireOntologyDefinition;
-    npmPackageName: string;
-    npmPackageVersion: string;
-  }> = [],
 ) {
   const importExt = packageType === "module" ? ".js" : "";
 

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
@@ -15,7 +15,10 @@
  */
 
 import path from "node:path";
+import { EnhancedInterfaceType } from "../GenerateContext/EnhancedInterfaceType.js";
+import { EnhancedObjectType } from "../GenerateContext/EnhancedObjectType.js";
 import { enhanceOntology } from "../GenerateContext/enhanceOntology.js";
+import { ForeignType } from "../GenerateContext/ForeignType.js";
 import type { GenerateContext } from "../GenerateContext/GenerateContext.js";
 import type { MinimalFs } from "../MinimalFs.js";
 import { sanitizeMetadata } from "../shared/sanitizeMetadata.js";
@@ -65,6 +68,8 @@ async function generateEachObjectFile(
   } = ctx;
   await fs.mkdir(path.join(outDir, "ontology", "objects"), { recursive: true });
   for (const obj of Object.values(ontology.objectTypes)) {
+    if (obj instanceof ForeignType) continue;
+
     const relPath = path.join(
       ".",
       "ontology",
@@ -91,22 +96,32 @@ export async function generateClientSdkVersionTwoPointZero(
   fs: MinimalFs,
   outDir: string,
   packageType: "module" | "commonjs" = "commonjs",
-  ontologyApiNamespace?: string,
-  apiNamespacePackageMap: Map<string, string> = new Map(),
+  externalObjects: Map<string, string> = new Map(),
+  externalInterfaces: Map<string, string> = new Map(),
+  externalSpts: Map<string, string> = new Map(),
+  extraOntologies: Array<{
+    ontology: WireOntologyDefinition;
+    npmPackageName: string;
+    npmPackageVersion: string;
+  }> = [],
 ) {
   const importExt = packageType === "module" ? ".js" : "";
+
+  // Structurally, we need to have multiple ontologies read in
+  // with one per package.
 
   await verifyOutDir(outDir, fs);
 
   const sanitizedOntology = sanitizeMetadata(ontology);
 
   await fs.mkdir(outDir, { recursive: true });
-  const enhancedOntology = enhanceOntology(
-    sanitizedOntology,
-    ontologyApiNamespace,
-    apiNamespacePackageMap,
+  const enhancedOntology = enhanceOntology({
+    sanitized: sanitizedOntology,
     importExt,
-  );
+    externalObjects,
+    externalInterfaces,
+    externalSpts,
+  });
 
   const ctx: GenerateContext = {
     sanitizedOntology,
@@ -114,8 +129,6 @@ export async function generateClientSdkVersionTwoPointZero(
     importExt,
     fs,
     outDir,
-    ontologyApiNamespace,
-    apiNamespacePackageMap,
   };
 
   await generateRootIndexTsFile(ctx);
@@ -131,7 +144,9 @@ export async function generateClientSdkVersionTwoPointZero(
     path.join(outDir, "ontology", "objects.ts"),
     await formatTs(`
     ${
-      Object.values(enhancedOntology.objectTypes).map(objType =>
+      Object.values(enhancedOntology.objectTypes).filter(o =>
+        o instanceof EnhancedObjectType
+      ).map(objType =>
         `export * from "./objects/${objType.shortApiName}${importExt}";`
       ).join("\n")
     }
@@ -152,6 +167,8 @@ async function generateOntologyInterfaces(
   });
 
   for (const obj of Object.values(ontology.interfaceTypes)) {
+    if (obj instanceof ForeignType) continue;
+
     await fs.writeFile(
       path.join(interfacesDir, `${obj.shortApiName}.ts`),
       await formatTs(`
@@ -172,7 +189,9 @@ async function generateOntologyInterfaces(
     interfacesDir + ".ts",
     await formatTs(`
     ${
-      Object.values(ontology.interfaceTypes).map(interfaceType =>
+      Object.values(ontology.interfaceTypes).filter(i =>
+        i instanceof EnhancedInterfaceType
+      ).map(interfaceType =>
         `export * from "./interfaces/${interfaceType.shortApiName}${importExt}";`
       ).join("\n")
     }

--- a/packages/generator/src/v2.0/generatePerActionDataFiles.test.ts
+++ b/packages/generator/src/v2.0/generatePerActionDataFiles.test.ts
@@ -31,7 +31,13 @@ describe(generatePerActionDataFiles, () => {
         sanitizedOntology,
         fs: helper.minimalFiles,
         outDir: BASE_PATH,
-        ontology: enhanceOntology(sanitizedOntology, undefined, new Map(), ""),
+        ontology: enhanceOntology({
+          sanitized: sanitizedOntology,
+          importExt: "",
+          externalObjects: new Map(),
+          externalInterfaces: new Map(),
+          externalSpts: new Map(),
+        }),
       },
     );
     expect(helper.getFiles()[`${BASE_PATH}/ontology/actions.ts`]).toEqual(
@@ -48,7 +54,13 @@ describe(generatePerActionDataFiles, () => {
         sanitizedOntology,
         fs: helper.minimalFiles,
         outDir: path.join(BASE_PATH, "..", ".."),
-        ontology: enhanceOntology(sanitizedOntology, undefined, new Map(), ""),
+        ontology: enhanceOntology({
+          sanitized: sanitizedOntology,
+          importExt: "",
+          externalObjects: new Map(),
+          externalInterfaces: new Map(),
+          externalSpts: new Map(),
+        }),
       },
     );
 

--- a/packages/generator/src/v2.0/generatePerQueryDataFiles.test.ts
+++ b/packages/generator/src/v2.0/generatePerQueryDataFiles.test.ts
@@ -29,12 +29,13 @@ describe("generatePerQueryDataFiles", () => {
     await generatePerQueryDataFilesV2(
       {
         fs: helper.minimalFiles,
-        ontology: enhanceOntology(
-          TodoWireOntology,
-          undefined,
-          new Map(),
-          ".js",
-        ),
+        ontology: enhanceOntology({
+          sanitized: TodoWireOntology,
+          importExt: ".js",
+          externalObjects: new Map(),
+          externalInterfaces: new Map(),
+          externalSpts: new Map(),
+        }),
         outDir: BASE_PATH,
         importExt: ".js",
       },

--- a/packages/generator/src/v2.0/wireObjectTypeV2ToSdkObjectConstV2.ts
+++ b/packages/generator/src/v2.0/wireObjectTypeV2ToSdkObjectConstV2.ts
@@ -19,6 +19,7 @@ import type { ObjectTypeFullMetadata } from "@osdk/internal.foundry.core";
 import type { EnhancedInterfaceType } from "../GenerateContext/EnhancedInterfaceType.js";
 import { EnhancedObjectType } from "../GenerateContext/EnhancedObjectType.js";
 import type { EnhancedOntologyDefinition } from "../GenerateContext/EnhancedOntologyDefinition.js";
+import { ForeignType } from "../GenerateContext/ForeignType.js";
 import type { GenerateContext } from "../GenerateContext/GenerateContext.js";
 import { getObjectImports } from "../shared/getObjectImports.js";
 import { propertyJsdoc } from "../shared/propertyJsdoc.js";
@@ -42,6 +43,9 @@ export function wireObjectTypeV2ToSdkObjectConstV2(
     wireObject.objectType.apiName,
     true,
   );
+  if (object instanceof ForeignType) {
+    throw new Error("Should not be generating types for an external type");
+  }
   const uniqueLinkTargetTypes = new Set(
     wireObject.linkTypes.map(a =>
       ontology.requireObjectType(a.objectTypeApiName, false)
@@ -75,7 +79,7 @@ export function wireObjectTypeV2ToSdkObjectConstV2(
     propertyKeysIdentifier,
   };
 
-  function getV2Types() {
+  function getV2Types(object: EnhancedObjectType) {
     return `import type {
       PropertyKeys as $PropertyKeys,  
       ObjectTypeDefinition as $ObjectTypeDefinition,
@@ -118,7 +122,7 @@ export function wireObjectTypeV2ToSdkObjectConstV2(
     true,
   );
 
-  return `${imports}${getV2Types()}
+  return `${imports}${getV2Types(object)}
 
     export const ${object.shortApiName}: ${objectDefIdentifier}
     = {

--- a/packages/tmp-foundry-sdk-generator/package.json
+++ b/packages/tmp-foundry-sdk-generator/package.json
@@ -31,6 +31,8 @@
   "dependencies": {
     "@osdk/api": "workspace:*",
     "@osdk/client": "workspace:*",
+    "@osdk/foundry.core": "workspace:*",
+    "@osdk/foundry.thirdpartyapplications": "workspace:*",
     "@osdk/generator": "workspace:*",
     "@osdk/internal.foundry.core": "workspace:*",
     "@osdk/internal.foundry.ontologies": "workspace:*",
@@ -47,9 +49,12 @@
     "yargs": "17.7.2"
   },
   "devDependencies": {
+    "@osdk/client.unstable": "workspace:~",
+    "@osdk/client.unstable.tpsa": "workspace:~",
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
     "@osdk/monorepo.tsup": "workspace:~",
+    "@osdk/shared.client.impl": "workspace:~",
     "@osdk/shared.test": "workspace:~",
     "@types/node": "^18.0.0",
     "@types/yargs": "^17.0.29",

--- a/packages/tmp-foundry-sdk-generator/src/generate/betaClient/generatePackage.ts
+++ b/packages/tmp-foundry-sdk-generator/src/generate/betaClient/generatePackage.ts
@@ -19,6 +19,7 @@ import { generateClientSdkVersionTwoPointZero } from "@osdk/generator";
 import { mkdir, readdir, readFile, writeFile } from "fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, isAbsolute, join, normalize } from "path";
+import type { OntologyInfo } from "../../ontologyMetadata/ontologyMetadataResolver.js";
 import { USER_AGENT } from "../../utils/UserAgent.js";
 import { generateBundles } from "../generateBundles.js";
 import { bundleDependencies } from "./bundleDependencies.js";
@@ -40,7 +41,7 @@ const betaPeerDependencies: { [key: string]: string | undefined } = {
 };
 
 export async function generatePackage(
-  ontology: WireOntologyDefinition,
+  ontologyInfo: OntologyInfo,
   options: {
     packageName: string;
     packageVersion: string;
@@ -73,11 +74,13 @@ export async function generatePackage(
     throw new Error("Only beta is supported in this version");
   } else {
     await generateClientSdkVersionTwoPointZero(
-      ontology,
+      ontologyInfo.filteredFullMetadata,
       `typescript-sdk/${options.packageVersion} ${USER_AGENT}`,
       hostFs,
       packagePath,
       "module",
+      ontologyInfo.externalObjects,
+      ontologyInfo.externalInterfaces,
     );
   }
 

--- a/packages/tmp-foundry-sdk-generator/src/ontologyMetadata/__snapshots__/metadataResolver.test.ts.snap
+++ b/packages/tmp-foundry-sdk-generator/src/ontologyMetadata/__snapshots__/metadataResolver.test.ts.snap
@@ -2,298 +2,306 @@
 
 exports[`Load Ontologies Metadata > Loads object and action types using only specified link types 1`] = `
 {
-  "actionTypes": {
-    "promoteEmployee": {
-      "apiName": "promoteEmployee",
-      "description": "Update an employee's title and compensation",
-      "operations": [
-        {
-          "objectTypeApiName": "Employee",
-          "type": "modifyObject",
-        },
-      ],
-      "parameters": {
-        "employeeId": {
-          "dataType": {
-            "type": "integer",
+  "externalInterfaces": Map {},
+  "externalObjects": Map {},
+  "filteredFullMetadata": {
+    "actionTypes": {
+      "promoteEmployee": {
+        "apiName": "promoteEmployee",
+        "description": "Update an employee's title and compensation",
+        "operations": [
+          {
+            "objectTypeApiName": "Employee",
+            "type": "modifyObject",
           },
-          "required": true,
-        },
-        "newCompensation": {
-          "dataType": {
-            "type": "double",
-          },
-          "required": true,
-        },
-        "newTitle": {
-          "dataType": {
-            "type": "string",
-          },
-          "required": true,
-        },
-      },
-      "rid": "ri.ontology.main.action-type.7ed72754-7491-428a-bb18-4d7296eb2167",
-      "status": "ACTIVE",
-    },
-  },
-  "interfaceTypes": {},
-  "objectTypes": {
-    "Employee": {
-      "implementsInterfaces": [
-        "FooInterface",
-      ],
-      "implementsInterfaces2": {
-        "FooInterface": {
-          "properties": {
-            "fooSpt": "fullName",
-          },
-        },
-      },
-      "linkTypes": [
-        {
-          "apiName": "peeps",
-          "cardinality": "MANY",
-          "displayName": "Peeps",
-          "linkTypeRid": "rid.link-type.327",
-          "objectTypeApiName": "Employee",
-          "status": "EXPERIMENTAL",
-        },
-        {
-          "apiName": "officeLink",
-          "cardinality": "ONE",
-          "displayName": "Office",
-          "linkTypeRid": "rid.link-type.324",
-          "objectTypeApiName": "Office",
-          "status": "EXPERIMENTAL",
-        },
-      ],
-      "objectType": {
-        "apiName": "Employee",
-        "description": "A full-time or part-time 
-
- employee of our firm",
-        "displayName": "Employee",
-        "icon": {
-          "color": "blue",
-          "name": "person",
-          "type": "blueprint",
-        },
-        "pluralDisplayName": "Employees",
-        "primaryKey": "employeeId",
-        "properties": {
+        ],
+        "parameters": {
           "employeeId": {
             "dataType": {
               "type": "integer",
             },
+            "required": true,
           },
-          "employeeStatus": {
+          "newCompensation": {
             "dataType": {
-              "itemType": {
+              "type": "double",
+            },
+            "required": true,
+          },
+          "newTitle": {
+            "dataType": {
+              "type": "string",
+            },
+            "required": true,
+          },
+        },
+        "rid": "ri.ontology.main.action-type.7ed72754-7491-428a-bb18-4d7296eb2167",
+        "status": "ACTIVE",
+      },
+    },
+    "interfaceTypes": {},
+    "objectTypes": {
+      "Employee": {
+        "implementsInterfaces": [
+          "FooInterface",
+        ],
+        "implementsInterfaces2": {
+          "FooInterface": {
+            "properties": {
+              "fooSpt": "fullName",
+            },
+          },
+        },
+        "linkTypes": [
+          {
+            "apiName": "peeps",
+            "cardinality": "MANY",
+            "displayName": "Peeps",
+            "linkTypeRid": "rid.link-type.327",
+            "objectTypeApiName": "Employee",
+            "status": "EXPERIMENTAL",
+          },
+          {
+            "apiName": "officeLink",
+            "cardinality": "ONE",
+            "displayName": "Office",
+            "linkTypeRid": "rid.link-type.324",
+            "objectTypeApiName": "Office",
+            "status": "EXPERIMENTAL",
+          },
+        ],
+        "objectType": {
+          "apiName": "Employee",
+          "description": "A full-time or part-time 
+
+ employee of our firm",
+          "displayName": "Employee",
+          "icon": {
+            "color": "blue",
+            "name": "person",
+            "type": "blueprint",
+          },
+          "pluralDisplayName": "Employees",
+          "primaryKey": "employeeId",
+          "properties": {
+            "employeeId": {
+              "dataType": {
+                "type": "integer",
+              },
+            },
+            "employeeStatus": {
+              "dataType": {
+                "itemType": {
+                  "type": "string",
+                },
+                "type": "timeseries",
+              },
+              "description": "TimeSeries of the status of the employee",
+            },
+            "fullName": {
+              "dataType": {
                 "type": "string",
               },
-              "type": "timeseries",
             },
-            "description": "TimeSeries of the status of the employee",
-          },
-          "fullName": {
-            "dataType": {
-              "type": "string",
-            },
-          },
-          "office": {
-            "dataType": {
-              "type": "string",
-            },
-            "description": "The unique "ID" of the employee's \\"primary\\" assigned office.
+            "office": {
+              "dataType": {
+                "type": "string",
+              },
+              "description": "The unique "ID" of the employee's \\"primary\\" assigned office.
  This is some more text.",
-          },
-          "startDate": {
-            "dataType": {
-              "type": "date",
             },
-            "description": "The date the employee was hired (most recently, if they were re-hired)",
+            "startDate": {
+              "dataType": {
+                "type": "date",
+              },
+              "description": "The date the employee was hired (most recently, if they were re-hired)",
+            },
           },
+          "rid": "ri.ontology.main.object-type.401ac022-89eb-4591-8b7e-0a912b9efb44",
+          "status": "ACTIVE",
+          "titleProperty": "fullName",
+          "visibility": "NORMAL",
         },
-        "rid": "ri.ontology.main.object-type.401ac022-89eb-4591-8b7e-0a912b9efb44",
-        "status": "ACTIVE",
-        "titleProperty": "fullName",
-        "visibility": "NORMAL",
+        "sharedPropertyTypeMapping": {
+          "fooSpt": "fullName",
+        },
       },
-      "sharedPropertyTypeMapping": {
-        "fooSpt": "fullName",
+      "Office": {
+        "implementsInterfaces": [],
+        "implementsInterfaces2": {},
+        "linkTypes": [],
+        "objectType": {
+          "apiName": "Office",
+          "description": "A office in our Company",
+          "displayName": "Office",
+          "icon": {
+            "color": "blue",
+            "name": "office",
+            "type": "blueprint",
+          },
+          "pluralDisplayName": "Office",
+          "primaryKey": "officeId",
+          "properties": {
+            "entrance": {
+              "dataType": {
+                "type": "geopoint",
+              },
+            },
+            "name": {
+              "dataType": {
+                "type": "string",
+              },
+              "description": "The Name of the Office",
+            },
+            "occupiedArea": {
+              "dataType": {
+                "type": "geoshape",
+              },
+              "description": "The occupied area of the Office",
+            },
+            "officeId": {
+              "dataType": {
+                "type": "string",
+              },
+            },
+          },
+          "rid": "ri.ontology.main.object-type.404ac022-89eb-4591-8b7e-1a912b9efb45",
+          "status": "ACTIVE",
+          "titleProperty": "officeId",
+        },
+        "sharedPropertyTypeMapping": {},
       },
     },
-    "Office": {
-      "implementsInterfaces": [],
-      "implementsInterfaces2": {},
-      "linkTypes": [],
-      "objectType": {
-        "apiName": "Office",
-        "description": "A office in our Company",
-        "displayName": "Office",
-        "icon": {
-          "color": "blue",
-          "name": "office",
-          "type": "blueprint",
-        },
-        "pluralDisplayName": "Office",
-        "primaryKey": "officeId",
-        "properties": {
-          "entrance": {
-            "dataType": {
-              "type": "geopoint",
-            },
-          },
-          "name": {
-            "dataType": {
-              "type": "string",
-            },
-            "description": "The Name of the Office",
-          },
-          "occupiedArea": {
-            "dataType": {
-              "type": "geoshape",
-            },
-            "description": "The occupied area of the Office",
-          },
-          "officeId": {
-            "dataType": {
-              "type": "string",
-            },
-          },
-        },
-        "rid": "ri.ontology.main.object-type.404ac022-89eb-4591-8b7e-1a912b9efb45",
-        "status": "ACTIVE",
-        "titleProperty": "officeId",
-      },
-      "sharedPropertyTypeMapping": {},
+    "ontology": {
+      "apiName": "default-ontology",
+      "description": "The default ontology",
+      "displayName": "Ontology",
+      "rid": "ri.ontology.main.ontology.698267cc-6b48-4d98-beff-29beb24e9361",
     },
+    "queryTypes": {},
+    "sharedPropertyTypes": {},
   },
-  "ontology": {
-    "apiName": "default-ontology",
-    "description": "The default ontology",
-    "displayName": "Ontology",
-    "rid": "ri.ontology.main.ontology.698267cc-6b48-4d98-beff-29beb24e9361",
-  },
-  "queryTypes": {},
-  "sharedPropertyTypes": {},
 }
 `;
 
 exports[`Load Ontologies Metadata > Loads object and action types without link types 1`] = `
 {
-  "actionTypes": {
-    "promoteEmployee": {
-      "apiName": "promoteEmployee",
-      "description": "Update an employee's title and compensation",
-      "operations": [
-        {
-          "objectTypeApiName": "Employee",
-          "type": "modifyObject",
-        },
-      ],
-      "parameters": {
-        "employeeId": {
-          "dataType": {
-            "type": "integer",
+  "externalInterfaces": Map {},
+  "externalObjects": Map {},
+  "filteredFullMetadata": {
+    "actionTypes": {
+      "promoteEmployee": {
+        "apiName": "promoteEmployee",
+        "description": "Update an employee's title and compensation",
+        "operations": [
+          {
+            "objectTypeApiName": "Employee",
+            "type": "modifyObject",
           },
-          "required": true,
-        },
-        "newCompensation": {
-          "dataType": {
-            "type": "double",
-          },
-          "required": true,
-        },
-        "newTitle": {
-          "dataType": {
-            "type": "string",
-          },
-          "required": true,
-        },
-      },
-      "rid": "ri.ontology.main.action-type.7ed72754-7491-428a-bb18-4d7296eb2167",
-      "status": "ACTIVE",
-    },
-  },
-  "interfaceTypes": {},
-  "objectTypes": {
-    "Employee": {
-      "implementsInterfaces": [
-        "FooInterface",
-      ],
-      "implementsInterfaces2": {
-        "FooInterface": {
-          "properties": {
-            "fooSpt": "fullName",
-          },
-        },
-      },
-      "linkTypes": [],
-      "objectType": {
-        "apiName": "Employee",
-        "description": "A full-time or part-time 
-
- employee of our firm",
-        "displayName": "Employee",
-        "icon": {
-          "color": "blue",
-          "name": "person",
-          "type": "blueprint",
-        },
-        "pluralDisplayName": "Employees",
-        "primaryKey": "employeeId",
-        "properties": {
+        ],
+        "parameters": {
           "employeeId": {
             "dataType": {
               "type": "integer",
             },
+            "required": true,
           },
-          "employeeStatus": {
+          "newCompensation": {
             "dataType": {
-              "itemType": {
-                "type": "string",
-              },
-              "type": "timeseries",
+              "type": "double",
             },
-            "description": "TimeSeries of the status of the employee",
+            "required": true,
           },
-          "fullName": {
+          "newTitle": {
             "dataType": {
               "type": "string",
             },
-          },
-          "office": {
-            "dataType": {
-              "type": "string",
-            },
-            "description": "The unique "ID" of the employee's \\"primary\\" assigned office.
- This is some more text.",
-          },
-          "startDate": {
-            "dataType": {
-              "type": "date",
-            },
-            "description": "The date the employee was hired (most recently, if they were re-hired)",
+            "required": true,
           },
         },
-        "rid": "ri.ontology.main.object-type.401ac022-89eb-4591-8b7e-0a912b9efb44",
+        "rid": "ri.ontology.main.action-type.7ed72754-7491-428a-bb18-4d7296eb2167",
         "status": "ACTIVE",
-        "titleProperty": "fullName",
-        "visibility": "NORMAL",
-      },
-      "sharedPropertyTypeMapping": {
-        "fooSpt": "fullName",
       },
     },
+    "interfaceTypes": {},
+    "objectTypes": {
+      "Employee": {
+        "implementsInterfaces": [
+          "FooInterface",
+        ],
+        "implementsInterfaces2": {
+          "FooInterface": {
+            "properties": {
+              "fooSpt": "fullName",
+            },
+          },
+        },
+        "linkTypes": [],
+        "objectType": {
+          "apiName": "Employee",
+          "description": "A full-time or part-time 
+
+ employee of our firm",
+          "displayName": "Employee",
+          "icon": {
+            "color": "blue",
+            "name": "person",
+            "type": "blueprint",
+          },
+          "pluralDisplayName": "Employees",
+          "primaryKey": "employeeId",
+          "properties": {
+            "employeeId": {
+              "dataType": {
+                "type": "integer",
+              },
+            },
+            "employeeStatus": {
+              "dataType": {
+                "itemType": {
+                  "type": "string",
+                },
+                "type": "timeseries",
+              },
+              "description": "TimeSeries of the status of the employee",
+            },
+            "fullName": {
+              "dataType": {
+                "type": "string",
+              },
+            },
+            "office": {
+              "dataType": {
+                "type": "string",
+              },
+              "description": "The unique "ID" of the employee's \\"primary\\" assigned office.
+ This is some more text.",
+            },
+            "startDate": {
+              "dataType": {
+                "type": "date",
+              },
+              "description": "The date the employee was hired (most recently, if they were re-hired)",
+            },
+          },
+          "rid": "ri.ontology.main.object-type.401ac022-89eb-4591-8b7e-0a912b9efb44",
+          "status": "ACTIVE",
+          "titleProperty": "fullName",
+          "visibility": "NORMAL",
+        },
+        "sharedPropertyTypeMapping": {
+          "fooSpt": "fullName",
+        },
+      },
+    },
+    "ontology": {
+      "apiName": "default-ontology",
+      "description": "The default ontology",
+      "displayName": "Ontology",
+      "rid": "ri.ontology.main.ontology.698267cc-6b48-4d98-beff-29beb24e9361",
+    },
+    "queryTypes": {},
+    "sharedPropertyTypes": {},
   },
-  "ontology": {
-    "apiName": "default-ontology",
-    "description": "The default ontology",
-    "displayName": "Ontology",
-    "rid": "ri.ontology.main.ontology.698267cc-6b48-4d98-beff-29beb24e9361",
-  },
-  "queryTypes": {},
-  "sharedPropertyTypes": {},
 }
 `;

--- a/packages/tmp-foundry-sdk-generator/src/ontologyMetadata/metadataResolver.test.ts
+++ b/packages/tmp-foundry-sdk-generator/src/ontologyMetadata/metadataResolver.test.ts
@@ -48,17 +48,21 @@ describe("Load Ontologies Metadata", () => {
 
     expect(ontologyDefinitions.value).toMatchInlineSnapshot(`
       {
-        "actionTypes": {},
-        "interfaceTypes": {},
-        "objectTypes": {},
-        "ontology": {
-          "apiName": "default-ontology",
-          "description": "The default ontology",
-          "displayName": "Ontology",
-          "rid": "ri.ontology.main.ontology.698267cc-6b48-4d98-beff-29beb24e9361",
+        "externalInterfaces": Map {},
+        "externalObjects": Map {},
+        "filteredFullMetadata": {
+          "actionTypes": {},
+          "interfaceTypes": {},
+          "objectTypes": {},
+          "ontology": {
+            "apiName": "default-ontology",
+            "description": "The default ontology",
+            "displayName": "Ontology",
+            "rid": "ri.ontology.main.ontology.698267cc-6b48-4d98-beff-29beb24e9361",
+          },
+          "queryTypes": {},
+          "sharedPropertyTypes": {},
         },
-        "queryTypes": {},
-        "sharedPropertyTypes": {},
       }
     `);
   });
@@ -72,7 +76,7 @@ describe("Load Ontologies Metadata", () => {
       .getWireOntologyDefinition(
         "ri.ontology.main.ontology.698267cc-6b48-4d98-beff-29beb24e9361",
         {
-          objectTypesApiNamesToLoad: ["objectDoesNotExist", "employee"],
+          objectTypesApiNamesToLoad: ["objectDoesNotExist", "Employee"],
           actionTypesApiNamesToLoad: ["action-does-not-exit"],
           linkTypesApiNamesToLoad: ["employee.doesNotExist"],
           queryTypesApiNamesToLoad: ["queryDoesNotExist"],
@@ -85,10 +89,9 @@ describe("Load Ontologies Metadata", () => {
 
     expect(ontologyDefinitions.error).toMatchInlineSnapshot(`
       [
-        "Unable to find link type doesnotexist for Object Type employee",
-        "Unable to find the following Object Types: objectdoesnotexist",
-        "Unable to find the following Query Types: querydoesnotexist",
-        "Unable to find the following Action Types: actiondoesnotexit",
+        "Unable to find the following Object Types: objectDoesNotExist",
+        "Unable to find the following Query Types: queryDoesNotExist",
+        "Unable to find the following Action Types: actionDoesNotExit",
       ]
     `);
   });
@@ -140,9 +143,11 @@ describe("Load Ontologies Metadata", () => {
     if (ontologyDefinitions.isErr()) {
       throw new Error();
     }
-    expect(Object.keys(ontologyDefinitions.value.objectTypes)).toHaveLength(0);
-    expect(Object.keys(ontologyDefinitions.value.actionTypes)).toHaveLength(0);
-    expect(Object.keys(ontologyDefinitions.value.queryTypes)).toHaveLength(0);
+
+    const fullMetadata = ontologyDefinitions.value.filteredFullMetadata;
+    expect(Object.keys(fullMetadata.objectTypes)).toHaveLength(0);
+    expect(Object.keys(fullMetadata.actionTypes)).toHaveLength(0);
+    expect(Object.keys(fullMetadata.queryTypes)).toHaveLength(0);
   });
 
   it("Loads object and action types without link types", async () => {
@@ -154,19 +159,22 @@ describe("Load Ontologies Metadata", () => {
       .getWireOntologyDefinition(
         "ri.ontology.main.ontology.698267cc-6b48-4d98-beff-29beb24e9361",
         {
-          objectTypesApiNamesToLoad: ["employee"],
+          objectTypesApiNamesToLoad: ["Employee"],
           actionTypesApiNamesToLoad: ["promote-employee"],
         },
       );
 
     if (ontologyDefinitions.isErr()) {
+      console.error(ontologyDefinitions.error);
       throw new Error();
     }
 
-    expect(Object.keys(ontologyDefinitions.value.objectTypes)).toHaveLength(1);
-    expect(ontologyDefinitions.value.objectTypes.Employee.linkTypes)
+    const fullMetadata = ontologyDefinitions.value.filteredFullMetadata;
+
+    expect(Object.keys(fullMetadata.objectTypes)).toHaveLength(1);
+    expect(fullMetadata.objectTypes.Employee.linkTypes)
       .toHaveLength(0);
-    expect(Object.keys(ontologyDefinitions.value.actionTypes)).toHaveLength(1);
+    expect(Object.keys(fullMetadata.actionTypes)).toHaveLength(1);
     expect(ontologyDefinitions.value).toMatchSnapshot();
   });
 
@@ -189,13 +197,12 @@ describe("Load Ontologies Metadata", () => {
       throw new Error(ontologyDefinitions.error.join("\n"));
     }
 
-    expect(Object.keys(ontologyDefinitions.value.objectTypes)).toHaveLength(2);
-    expect(ontologyDefinitions.value.objectTypes.Employee.linkTypes)
-      .toHaveLength(2);
-    expect(ontologyDefinitions.value.objectTypes.Office.linkTypes).toHaveLength(
-      0,
-    );
-    expect(Object.keys(ontologyDefinitions.value.actionTypes)).toHaveLength(1);
+    const fullMetadata = ontologyDefinitions.value.filteredFullMetadata;
+
+    expect(Object.keys(fullMetadata.objectTypes)).toHaveLength(2);
+    expect(fullMetadata.objectTypes.Employee.linkTypes).toHaveLength(2);
+    expect(fullMetadata.objectTypes.Office.linkTypes).toHaveLength(0);
+    expect(Object.keys(fullMetadata.actionTypes)).toHaveLength(1);
     expect(ontologyDefinitions.value).toMatchSnapshot();
   });
 });

--- a/packages/tmp-foundry-sdk-generator/src/ontologyMetadata/ontologyMetadataResolver.ts
+++ b/packages/tmp-foundry-sdk-generator/src/ontologyMetadata/ontologyMetadataResolver.ts
@@ -66,12 +66,12 @@ export class OntologyMetadataResolver {
       actionTypes: Set<string>;
       interfaceTypes: Set<string>;
     },
-    z: PackageInfo,
+    pkgInfo: PackageInfo,
   ): OntologyFullMetadata {
     const filteredObjectTypes = Object.fromEntries(
       Object.entries(ontologyFullMetadata.objectTypes).filter(
         ([, { objectType }]) => {
-          for (const { sdk: { inputs: { dataScope } } } of z.values()) {
+          for (const { sdk: { inputs: { dataScope } } } of pkgInfo.values()) {
             for (const objectTypeRid of dataScope.ontologyV2.objectTypes) {
               if (objectTypeRid === objectType.rid) {
                 return true;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2603,6 +2603,12 @@ importers:
       '@osdk/client':
         specifier: workspace:*
         version: link:../client
+      '@osdk/foundry.core':
+        specifier: workspace:*
+        version: link:../foundry.core
+      '@osdk/foundry.thirdpartyapplications':
+        specifier: workspace:*
+        version: link:../foundry.thirdpartyapplications
       '@osdk/generator':
         specifier: workspace:*
         version: link:../generator
@@ -2646,6 +2652,12 @@ importers:
         specifier: 17.7.2
         version: 17.7.2
     devDependencies:
+      '@osdk/client.unstable':
+        specifier: workspace:~
+        version: link:../client.unstable
+      '@osdk/client.unstable.tpsa':
+        specifier: workspace:~
+        version: link:../client.unstable.tpsa
       '@osdk/monorepo.api-extractor':
         specifier: workspace:~
         version: link:../monorepo.api-extractor
@@ -2655,6 +2667,9 @@ importers:
       '@osdk/monorepo.tsup':
         specifier: workspace:~
         version: link:../monorepo.tsup
+      '@osdk/shared.client.impl':
+        specifier: workspace:~
+        version: link:../shared.client.impl
       '@osdk/shared.test':
         specifier: workspace:~
         version: link:../shared.test
@@ -8876,7 +8891,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.24.5
       '@babel/parser': 7.24.5
       '@babel/types': 7.24.5
-      debug: 4.3.5
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -10681,7 +10696,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.5
+      debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -10741,7 +10756,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.17.0
       '@typescript-eslint/visitor-keys': 7.17.0
-      debug: 4.3.5
+      debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.4
@@ -10756,7 +10771,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.17.0
       '@typescript-eslint/visitor-keys': 7.17.0
-      debug: 4.3.5
+      debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.4


### PR DESCRIPTION
We now simply do whatever the backend tells us to do, including redundant generation of types when the type might be available in an external package.

