### PR TITLE
Version Packages

### DIFF
--- a/.changeset/early-berries-complain.md
+++ b/.changeset/early-berries-complain.md
@@ -1,5 +1,0 @@
----
-"@osdk/foundry-sdk-generator": patch
----
-
-Update beta dependency to fix beta package generation

--- a/packages/e2e.test.foundry-sdk-generator/CHANGELOG.md
+++ b/packages/e2e.test.foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/e2e.test.foundry-sdk-generator
 
+## 0.2.6
+
+### Patch Changes
+
+- Updated dependencies [47b5a58]
+  - @osdk/foundry-sdk-generator@1.3.6
+
 ## 0.2.5
 
 ### Patch Changes

--- a/packages/e2e.test.foundry-sdk-generator/package.json
+++ b/packages/e2e.test.foundry-sdk-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.test.foundry-sdk-generator",
   "private": true,
-  "version": "0.2.5",
+  "version": "0.2.6",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/foundry-sdk-generator
 
+## 1.3.6
+
+### Patch Changes
+
+- 47b5a58: Update beta dependency to fix beta package generation
+
 ## 1.3.5
 
 ### Patch Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/1.3.x, this PR will be updated.


# Releases
## @osdk/foundry-sdk-generator@1.3.6

### Patch Changes

-   47b5a58: Update beta dependency to fix beta package generation

## @osdk/e2e.test.foundry-sdk-generator@0.2.6

### Patch Changes

-   Updated dependencies [47b5a58]
    -   @osdk/foundry-sdk-generator@1.3.6
