### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -95,8 +95,10 @@
     "fifty-eels-report",
     "five-wasps-design",
     "flat-rats-poke",
+    "fluffy-suns-roll",
     "forty-apricots-shop",
     "four-ants-complain",
+    "four-radios-love",
     "gentle-worms-smoke",
     "gorgeous-ants-cheer",
     "great-cows-admire",
@@ -133,6 +135,7 @@
     "tame-coins-drop",
     "tasty-clouds-kick",
     "tasty-roses-double",
+    "tidy-rice-heal",
     "violet-apples-end",
     "violet-avocados-leave",
     "weak-masks-suffer",
@@ -140,6 +143,8 @@
     "wicked-socks-develop",
     "wild-cats-hug",
     "wise-files-smash",
+    "yellow-months-walk",
+    "young-frogs-clap",
     "young-goats-jump"
   ]
 }

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/api
 
+## 2.0.0-beta.8
+
+### Patch Changes
+
+- Updated dependencies [64818dc]
+  - @osdk/shared.net@2.0.0-beta.1
+
 ## 2.0.0-beta.7
 
 ### Major Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/api",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @osdk/cli.cmd.typescript
 
+## 0.6.0-beta.7
+
+### Minor Changes
+
+- 64818dc: Drop support for internal gateway package
+
+### Patch Changes
+
+- Updated dependencies [96ea876]
+- Updated dependencies [64818dc]
+  - @osdk/generator@2.0.0-beta.8
+  - @osdk/shared.net@2.0.0-beta.1
+  - @osdk/internal.foundry.core@0.2.0-beta.5
+  - @osdk/internal.foundry.ontologiesv2@0.2.0-beta.5
+
 ## 0.6.0-beta.6
 
 ### Patch Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.6.0-beta.6",
+  "version": "0.6.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/cli
 
+## 0.24.0-beta.7
+
+### Patch Changes
+
+- Updated dependencies [96ea876]
+- Updated dependencies [64818dc]
+  - @osdk/generator@2.0.0-beta.8
+  - @osdk/shared.net@2.0.0-beta.1
+
 ## 0.24.0-beta.6
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.24.0-beta.6",
+  "version": "0.24.0-beta.7",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client.api/CHANGELOG.md
+++ b/packages/client.api/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/client.api
 
+## 2.0.0-beta.8
+
+### Minor Changes
+
+- 64818dc: Drop support for internal gateway package
+
+### Patch Changes
+
+- @osdk/api@2.0.0-beta.8
+
 ## 2.0.0-beta.7
 
 ### Minor Changes

--- a/packages/client.api/package.json
+++ b/packages/client.api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.api",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.test.ontology/CHANGELOG.md
+++ b/packages/client.test.ontology/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/client.test.ontology
 
+## 2.0.0-beta.8
+
+### Patch Changes
+
+- Updated dependencies [64818dc]
+  - @osdk/client.api@2.0.0-beta.8
+  - @osdk/api@2.0.0-beta.8
+
 ## 2.0.0-beta.7
 
 ### Patch Changes

--- a/packages/client.test.ontology/package.json
+++ b/packages/client.test.ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/client.test.ontology",
   "private": true,
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.unstable/CHANGELOG.md
+++ b/packages/client.unstable/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/client.unstable
 
+## 2.0.0-beta.8
+
 ## 2.0.0-beta.7
 
 ### Minor Changes

--- a/packages/client.unstable/package.json
+++ b/packages/client.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.unstable",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @osdk/client
 
+## 2.0.0-beta.8
+
+### Minor Changes
+
+- 64818dc: Drop support for internal gateway package
+
+### Patch Changes
+
+- Updated dependencies [64818dc]
+  - @osdk/client.api@2.0.0-beta.8
+  - @osdk/api@2.0.0-beta.8
+  - @osdk/generator-converters@2.0.0-beta.8
+  - @osdk/client.unstable@2.0.0-beta.8
+
 ## 2.0.0-beta.7
 
 ### Minor Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/create-app.template.next-static-export/CHANGELOG.md
+++ b/packages/create-app.template.next-static-export/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.next-static-export
 
+## 0.19.0-beta.3
+
 ## 0.19.0-beta.2
 
 ## 0.19.0-beta.1

--- a/packages/create-app.template.next-static-export/package.json
+++ b/packages/create-app.template.next-static-export/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.next-static-export",
   "private": true,
-  "version": "0.19.0-beta.2",
+  "version": "0.19.0-beta.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react.beta/CHANGELOG.md
+++ b/packages/create-app.template.react.beta/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/create-app.template.react
 
+## 0.19.0-beta.3
+
+### Minor Changes
+
+- 5d98af2: Add dev dependency
+
 ## 0.19.0-beta.2
 
 ### Minor Changes

--- a/packages/create-app.template.react.beta/package.json
+++ b/packages/create-app.template.react.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react.beta",
   "private": true,
-  "version": "0.19.0-beta.2",
+  "version": "0.19.0-beta.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react/CHANGELOG.md
+++ b/packages/create-app.template.react/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.react
 
+## 0.19.0-beta.3
+
 ## 0.19.0-beta.2
 
 ### Minor Changes

--- a/packages/create-app.template.react/package.json
+++ b/packages/create-app.template.react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react",
   "private": true,
-  "version": "0.19.0-beta.2",
+  "version": "0.19.0-beta.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-aip-app
 
+## 0.19.0-beta.3
+
 ## 0.19.0-beta.2
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-aip-app/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app",
   "private": true,
-  "version": "0.19.0-beta.2",
+  "version": "0.19.0-beta.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-app
 
+## 0.19.0-beta.3
+
 ## 0.19.0-beta.2
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-app/package.json
+++ b/packages/create-app.template.tutorial-todo-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app",
   "private": true,
-  "version": "0.19.0-beta.2",
+  "version": "0.19.0-beta.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.vue/CHANGELOG.md
+++ b/packages/create-app.template.vue/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.vue
 
+## 0.19.0-beta.3
+
 ## 0.19.0-beta.2
 
 ## 0.19.0-beta.1

--- a/packages/create-app.template.vue/package.json
+++ b/packages/create-app.template.vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.vue",
   "private": true,
-  "version": "0.19.0-beta.2",
+  "version": "0.19.0-beta.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app
 
+## 0.19.0-beta.3
+
 ## 0.19.0-beta.2
 
 ### Minor Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-app",
-  "version": "0.19.0-beta.2",
+  "version": "0.19.0-beta.3",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/e2e.generated.api-namespace.dep/CHANGELOG.md
+++ b/packages/e2e.generated.api-namespace.dep/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/e2e.generated.api-namespace.dep
 
+## 1.0.0-beta.8
+
+### Patch Changes
+
+- Updated dependencies [64818dc]
+  - @osdk/client.api@2.0.0-beta.8
+  - @osdk/client@2.0.0-beta.8
+  - @osdk/api@2.0.0-beta.8
+
 ## 1.0.0-beta.7
 
 ### Patch Changes

--- a/packages/e2e.generated.api-namespace.dep/package.json
+++ b/packages/e2e.generated.api-namespace.dep/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.generated.api-namespace.dep",
   "private": true,
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.generated.api-namespace.local/CHANGELOG.md
+++ b/packages/e2e.generated.api-namespace.local/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @osdk/e2e.generated.api-namespace.local
 
+## 1.0.0-beta.8
+
+### Minor Changes
+
+- 96ea876: Adding js docs for actions so you can hover and see params and description.
+
+### Patch Changes
+
+- Updated dependencies [64818dc]
+  - @osdk/client.api@2.0.0-beta.8
+  - @osdk/client@2.0.0-beta.8
+  - @osdk/api@2.0.0-beta.8
+  - @osdk/e2e.generated.api-namespace.dep@1.0.0-beta.8
+
 ## 1.0.0-beta.7
 
 ### Patch Changes

--- a/packages/e2e.generated.api-namespace.local/package.json
+++ b/packages/e2e.generated.api-namespace.local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.generated.api-namespace.local",
   "private": true,
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.generated.catchall/CHANGELOG.md
+++ b/packages/e2e.generated.catchall/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/e2e.generated.catchall
 
+## 3.0.0-beta.8
+
+### Minor Changes
+
+- 96ea876: Adding js docs for actions so you can hover and see params and description.
+
+### Patch Changes
+
+- Updated dependencies [64818dc]
+  - @osdk/client.api@2.0.0-beta.8
+  - @osdk/client@2.0.0-beta.8
+  - @osdk/api@2.0.0-beta.8
+
 ## 3.0.0-beta.7
 
 ### Patch Changes

--- a/packages/e2e.generated.catchall/package.json
+++ b/packages/e2e.generated.catchall/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.generated.catchall",
   "private": true,
-  "version": "3.0.0-beta.7",
+  "version": "3.0.0-beta.8",
   "description": "",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/e2e.sandbox.catchall/CHANGELOG.md
+++ b/packages/e2e.sandbox.catchall/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/e2e.sandbox.catchall
 
+## 0.3.0-beta.8
+
+### Patch Changes
+
+- Updated dependencies [96ea876]
+- Updated dependencies [64818dc]
+  - @osdk/e2e.generated.catchall@3.0.0-beta.8
+  - @osdk/client.api@2.0.0-beta.8
+  - @osdk/client@2.0.0-beta.8
+  - @osdk/api@2.0.0-beta.8
+  - @osdk/internal.foundry@0.5.0-beta.5
+
 ## 0.3.0-beta.7
 
 ### Patch Changes

--- a/packages/e2e.sandbox.catchall/package.json
+++ b/packages/e2e.sandbox.catchall/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.sandbox.catchall",
   "private": true,
-  "version": "0.3.0-beta.7",
+  "version": "0.3.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.sandbox.oauth.public.react-router/CHANGELOG.md
+++ b/packages/e2e.sandbox.oauth.public.react-router/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/e2e.sandbox.oauth.public.react-router
 
+## 0.1.0-beta.1
+
+### Patch Changes
+
+- Updated dependencies [64818dc]
+  - @osdk/client@2.0.0-beta.8
+
 ## 0.1.0-beta.0
 
 ### Patch Changes

--- a/packages/e2e.sandbox.oauth.public.react-router/package.json
+++ b/packages/e2e.sandbox.oauth.public.react-router/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.sandbox.oauth.public.react-router",
   "private": true,
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.sandbox.oauth/CHANGELOG.md
+++ b/packages/e2e.sandbox.oauth/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/e2e.sandbox.oauth
 
+## 0.3.0-beta.8
+
+### Patch Changes
+
+- Updated dependencies [64818dc]
+  - @osdk/client@2.0.0-beta.8
+
 ## 0.3.0-beta.7
 
 ### Patch Changes

--- a/packages/e2e.sandbox.oauth/package.json
+++ b/packages/e2e.sandbox.oauth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.sandbox.oauth",
   "private": true,
-  "version": "0.3.0-beta.7",
+  "version": "0.3.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.sandbox.todoapp/CHANGELOG.md
+++ b/packages/e2e.sandbox.todoapp/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/e2e.sandbox.todoappapp
 
+## 3.0.0-beta.8
+
+### Minor Changes
+
+- 96ea876: Adding js docs for actions so you can hover and see params and description.
+
+### Patch Changes
+
+- Updated dependencies [64818dc]
+  - @osdk/client.api@2.0.0-beta.8
+  - @osdk/client@2.0.0-beta.8
+  - @osdk/api@2.0.0-beta.8
+
 ## 3.0.0-beta.7
 
 ### Patch Changes

--- a/packages/e2e.sandbox.todoapp/package.json
+++ b/packages/e2e.sandbox.todoapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.sandbox.todoapp",
   "private": true,
-  "version": "3.0.0-beta.7",
+  "version": "3.0.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/example-generator/CHANGELOG.md
+++ b/packages/example-generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/example-generator
 
+## 0.8.0-beta.3
+
+### Patch Changes
+
+- @osdk/create-app@0.19.0-beta.3
+
 ## 0.8.0-beta.2
 
 ### Minor Changes

--- a/packages/example-generator/package.json
+++ b/packages/example-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/example-generator",
   "private": true,
-  "version": "0.8.0-beta.2",
+  "version": "0.8.0-beta.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @osdk/foundry-sdk-generator
 
+## 2.0.0-beta.8
+
+### Minor Changes
+
+- 45b8178: Generation now works with or without https prefix on stack name
+
+### Patch Changes
+
+- Updated dependencies [96ea876]
+- Updated dependencies [64818dc]
+  - @osdk/generator@2.0.0-beta.8
+  - @osdk/shared.net@2.0.0-beta.1
+  - @osdk/client.api@2.0.0-beta.8
+  - @osdk/client@2.0.0-beta.8
+  - @osdk/api@2.0.0-beta.8
+  - @osdk/internal.foundry.core@0.2.0-beta.5
+  - @osdk/internal.foundry.ontologies@0.2.0-beta.5
+  - @osdk/internal.foundry.ontologiesv2@0.2.0-beta.5
+
 ## 2.0.0-beta.7
 
 ### Patch Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-converters/CHANGELOG.md
+++ b/packages/generator-converters/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/generator-converters
 
+## 2.0.0-beta.8
+
+### Patch Changes
+
+- @osdk/api@2.0.0-beta.8
+
 ## 2.0.0-beta.7
 
 ### Patch Changes

--- a/packages/generator-converters/package.json
+++ b/packages/generator-converters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-converters",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/generator
 
+## 2.0.0-beta.8
+
+### Minor Changes
+
+- 96ea876: Adding js docs for actions so you can hover and see params and description.
+
+### Patch Changes
+
+- @osdk/api@2.0.0-beta.8
+- @osdk/internal.foundry.core@0.2.0-beta.5
+- @osdk/generator-converters@2.0.0-beta.8
+
 ## 2.0.0-beta.7
 
 ### Minor Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/internal.foundry.core/CHANGELOG.md
+++ b/packages/internal.foundry.core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/internal.foundry.core
 
+## 0.2.0-beta.5
+
+### Patch Changes
+
+- Updated dependencies [64818dc]
+  - @osdk/shared.net@2.0.0-beta.1
+
 ## 0.2.0-beta.4
 
 ### Minor Changes

--- a/packages/internal.foundry.core/package.json
+++ b/packages/internal.foundry.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.core",
-  "version": "0.2.0-beta.4",
+  "version": "0.2.0-beta.5",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.datasets/CHANGELOG.md
+++ b/packages/internal.foundry.datasets/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/internal.foundry.datasets
 
+## 0.2.0-beta.5
+
+### Patch Changes
+
+- Updated dependencies [64818dc]
+  - @osdk/shared.net@2.0.0-beta.1
+  - @osdk/internal.foundry.core@0.2.0-beta.5
+
 ## 0.2.0-beta.4
 
 ### Minor Changes

--- a/packages/internal.foundry.datasets/package.json
+++ b/packages/internal.foundry.datasets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.datasets",
-  "version": "0.2.0-beta.4",
+  "version": "0.2.0-beta.5",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.ontologies/CHANGELOG.md
+++ b/packages/internal.foundry.ontologies/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/internal.foundry.ontologies
 
+## 0.2.0-beta.5
+
+### Patch Changes
+
+- Updated dependencies [64818dc]
+  - @osdk/shared.net@2.0.0-beta.1
+  - @osdk/internal.foundry.core@0.2.0-beta.5
+
 ## 0.2.0-beta.4
 
 ### Minor Changes

--- a/packages/internal.foundry.ontologies/package.json
+++ b/packages/internal.foundry.ontologies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.ontologies",
-  "version": "0.2.0-beta.4",
+  "version": "0.2.0-beta.5",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.ontologiesv2/CHANGELOG.md
+++ b/packages/internal.foundry.ontologiesv2/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/internal.foundry.ontologiesv2
 
+## 0.2.0-beta.5
+
+### Patch Changes
+
+- Updated dependencies [64818dc]
+  - @osdk/shared.net@2.0.0-beta.1
+  - @osdk/internal.foundry.core@0.2.0-beta.5
+  - @osdk/internal.foundry.ontologies@0.2.0-beta.5
+
 ## 0.2.0-beta.4
 
 ### Minor Changes

--- a/packages/internal.foundry.ontologiesv2/package.json
+++ b/packages/internal.foundry.ontologiesv2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.ontologiesv2",
-  "version": "0.2.0-beta.4",
+  "version": "0.2.0-beta.5",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry/CHANGELOG.md
+++ b/packages/internal.foundry/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/foundry
 
+## 0.5.0-beta.5
+
+### Patch Changes
+
+- Updated dependencies [64818dc]
+  - @osdk/shared.net@2.0.0-beta.1
+  - @osdk/internal.foundry.core@0.2.0-beta.5
+  - @osdk/internal.foundry.datasets@0.2.0-beta.5
+  - @osdk/internal.foundry.ontologies@0.2.0-beta.5
+  - @osdk/internal.foundry.ontologiesv2@0.2.0-beta.5
+
 ## 0.5.0-beta.4
 
 ### Minor Changes

--- a/packages/internal.foundry/package.json
+++ b/packages/internal.foundry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/internal.foundry",
   "private": "true",
-  "version": "0.5.0-beta.4",
+  "version": "0.5.0-beta.5",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/maker/CHANGELOG.md
+++ b/packages/maker/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/maker
 
+## 0.8.0-beta.4
+
+### Minor Changes
+
+- 7282cf6: Add Default Type Classes to maker
+- 64818dc: Drop support for internal gateway package
+
+### Patch Changes
+
+- @osdk/api@2.0.0-beta.8
+
 ## 0.8.0-beta.3
 
 ### Minor Changes

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker",
-  "version": "0.8.0-beta.3",
+  "version": "0.8.0-beta.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.net/CHANGELOG.md
+++ b/packages/shared.net/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/shared.net
 
+## 2.0.0-beta.1
+
+### Major Changes
+
+- 64818dc: Drop support for internal gateway package
+
 ## 1.13.0-beta.0
 
 ### Patch Changes

--- a/packages/shared.net/package.json
+++ b/packages/shared.net/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/shared.net",
-  "version": "1.13.0-beta.0",
+  "version": "2.0.0-beta.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/shared.test/CHANGELOG.md
+++ b/packages/shared.test/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/shared.test
 
+## 1.7.0-beta.4
+
+### Minor Changes
+
+- 64818dc: Drop support for internal gateway package
+
+### Patch Changes
+
+- @osdk/api@2.0.0-beta.8
+- @osdk/internal.foundry.core@0.2.0-beta.5
+- @osdk/internal.foundry.ontologies@0.2.0-beta.5
+- @osdk/internal.foundry.ontologiesv2@0.2.0-beta.5
+
 ## 1.7.0-beta.3
 
 ### Patch Changes

--- a/packages/shared.test/package.json
+++ b/packages/shared.test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/shared.test",
   "private": true,
-  "version": "1.7.0-beta.3",
+  "version": "1.7.0-beta.4",
   "description": "",
   "access": "private",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/shared.net@2.0.0-beta.1

### Major Changes

-   64818dc: Drop support for internal gateway package

## @osdk/client@2.0.0-beta.8

### Minor Changes

-   64818dc: Drop support for internal gateway package

### Patch Changes

-   Updated dependencies [64818dc]
    -   @osdk/client.api@2.0.0-beta.8
    -   @osdk/api@2.0.0-beta.8
    -   @osdk/generator-converters@2.0.0-beta.8
    -   @osdk/client.unstable@2.0.0-beta.8

## @osdk/client.api@2.0.0-beta.8

### Minor Changes

-   64818dc: Drop support for internal gateway package

### Patch Changes

-   @osdk/api@2.0.0-beta.8

## @osdk/foundry-sdk-generator@2.0.0-beta.8

### Minor Changes

-   45b8178: Generation now works with or without https prefix on stack name

### Patch Changes

-   Updated dependencies [96ea876]
-   Updated dependencies [64818dc]
    -   @osdk/generator@2.0.0-beta.8
    -   @osdk/shared.net@2.0.0-beta.1
    -   @osdk/client.api@2.0.0-beta.8
    -   @osdk/client@2.0.0-beta.8
    -   @osdk/api@2.0.0-beta.8
    -   @osdk/internal.foundry.core@0.2.0-beta.5
    -   @osdk/internal.foundry.ontologies@0.2.0-beta.5
    -   @osdk/internal.foundry.ontologiesv2@0.2.0-beta.5

## @osdk/generator@2.0.0-beta.8

### Minor Changes

-   96ea876: Adding js docs for actions so you can hover and see params and description.

### Patch Changes

-   @osdk/api@2.0.0-beta.8
-   @osdk/internal.foundry.core@0.2.0-beta.5
-   @osdk/generator-converters@2.0.0-beta.8

## @osdk/maker@0.8.0-beta.4

### Minor Changes

-   7282cf6: Add Default Type Classes to maker
-   64818dc: Drop support for internal gateway package

### Patch Changes

-   @osdk/api@2.0.0-beta.8

## @osdk/api@2.0.0-beta.8

### Patch Changes

-   Updated dependencies [64818dc]
    -   @osdk/shared.net@2.0.0-beta.1

## @osdk/cli@0.24.0-beta.7

### Patch Changes

-   Updated dependencies [96ea876]
-   Updated dependencies [64818dc]
    -   @osdk/generator@2.0.0-beta.8
    -   @osdk/shared.net@2.0.0-beta.1

## @osdk/generator-converters@2.0.0-beta.8

### Patch Changes

-   @osdk/api@2.0.0-beta.8

## @osdk/internal.foundry.core@0.2.0-beta.5

### Patch Changes

-   Updated dependencies [64818dc]
    -   @osdk/shared.net@2.0.0-beta.1

## @osdk/internal.foundry.datasets@0.2.0-beta.5

### Patch Changes

-   Updated dependencies [64818dc]
    -   @osdk/shared.net@2.0.0-beta.1
    -   @osdk/internal.foundry.core@0.2.0-beta.5

## @osdk/internal.foundry.ontologies@0.2.0-beta.5

### Patch Changes

-   Updated dependencies [64818dc]
    -   @osdk/shared.net@2.0.0-beta.1
    -   @osdk/internal.foundry.core@0.2.0-beta.5

## @osdk/internal.foundry.ontologiesv2@0.2.0-beta.5

### Patch Changes

-   Updated dependencies [64818dc]
    -   @osdk/shared.net@2.0.0-beta.1
    -   @osdk/internal.foundry.core@0.2.0-beta.5
    -   @osdk/internal.foundry.ontologies@0.2.0-beta.5

## @osdk/client.unstable@2.0.0-beta.8



## @osdk/create-app@0.19.0-beta.3



## @osdk/cli.cmd.typescript@0.6.0-beta.7

### Minor Changes

-   64818dc: Drop support for internal gateway package

### Patch Changes

-   Updated dependencies [96ea876]
-   Updated dependencies [64818dc]
    -   @osdk/generator@2.0.0-beta.8
    -   @osdk/shared.net@2.0.0-beta.1
    -   @osdk/internal.foundry.core@0.2.0-beta.5
    -   @osdk/internal.foundry.ontologiesv2@0.2.0-beta.5

## @osdk/create-app.template.react.beta@0.19.0-beta.3

### Minor Changes

-   5d98af2: Add dev dependency

## @osdk/e2e.generated.api-namespace.local@1.0.0-beta.8

### Minor Changes

-   96ea876: Adding js docs for actions so you can hover and see params and description.

### Patch Changes

-   Updated dependencies [64818dc]
    -   @osdk/client.api@2.0.0-beta.8
    -   @osdk/client@2.0.0-beta.8
    -   @osdk/api@2.0.0-beta.8
    -   @osdk/e2e.generated.api-namespace.dep@1.0.0-beta.8

## @osdk/e2e.generated.catchall@3.0.0-beta.8

### Minor Changes

-   96ea876: Adding js docs for actions so you can hover and see params and description.

### Patch Changes

-   Updated dependencies [64818dc]
    -   @osdk/client.api@2.0.0-beta.8
    -   @osdk/client@2.0.0-beta.8
    -   @osdk/api@2.0.0-beta.8

## @osdk/e2e.sandbox.todoapp@3.0.0-beta.8

### Minor Changes

-   96ea876: Adding js docs for actions so you can hover and see params and description.

### Patch Changes

-   Updated dependencies [64818dc]
    -   @osdk/client.api@2.0.0-beta.8
    -   @osdk/client@2.0.0-beta.8
    -   @osdk/api@2.0.0-beta.8

## @osdk/shared.test@1.7.0-beta.4

### Minor Changes

-   64818dc: Drop support for internal gateway package

### Patch Changes

-   @osdk/api@2.0.0-beta.8
-   @osdk/internal.foundry.core@0.2.0-beta.5
-   @osdk/internal.foundry.ontologies@0.2.0-beta.5
-   @osdk/internal.foundry.ontologiesv2@0.2.0-beta.5

## @osdk/client.test.ontology@2.0.0-beta.8

### Patch Changes

-   Updated dependencies [64818dc]
    -   @osdk/client.api@2.0.0-beta.8
    -   @osdk/api@2.0.0-beta.8

## @osdk/e2e.generated.api-namespace.dep@1.0.0-beta.8

### Patch Changes

-   Updated dependencies [64818dc]
    -   @osdk/client.api@2.0.0-beta.8
    -   @osdk/client@2.0.0-beta.8
    -   @osdk/api@2.0.0-beta.8

## @osdk/e2e.sandbox.catchall@0.3.0-beta.8

### Patch Changes

-   Updated dependencies [96ea876]
-   Updated dependencies [64818dc]
    -   @osdk/e2e.generated.catchall@3.0.0-beta.8
    -   @osdk/client.api@2.0.0-beta.8
    -   @osdk/client@2.0.0-beta.8
    -   @osdk/api@2.0.0-beta.8
    -   @osdk/internal.foundry@0.5.0-beta.5

## @osdk/e2e.sandbox.oauth@0.3.0-beta.8

### Patch Changes

-   Updated dependencies [64818dc]
    -   @osdk/client@2.0.0-beta.8

## @osdk/e2e.sandbox.oauth.public.react-router@0.1.0-beta.1

### Patch Changes

-   Updated dependencies [64818dc]
    -   @osdk/client@2.0.0-beta.8

## @osdk/example-generator@0.8.0-beta.3

### Patch Changes

-   @osdk/create-app@0.19.0-beta.3

## @osdk/internal.foundry@0.5.0-beta.5

### Patch Changes

-   Updated dependencies [64818dc]
    -   @osdk/shared.net@2.0.0-beta.1
    -   @osdk/internal.foundry.core@0.2.0-beta.5
    -   @osdk/internal.foundry.datasets@0.2.0-beta.5
    -   @osdk/internal.foundry.ontologies@0.2.0-beta.5
    -   @osdk/internal.foundry.ontologiesv2@0.2.0-beta.5

## @osdk/create-app.template.next-static-export@0.19.0-beta.3



## @osdk/create-app.template.react@0.19.0-beta.3



## @osdk/create-app.template.tutorial-todo-aip-app@0.19.0-beta.3



## @osdk/create-app.template.tutorial-todo-app@0.19.0-beta.3



## @osdk/create-app.template.vue@0.19.0-beta.3


