### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -84,6 +84,7 @@
     "brown-seas-tell",
     "chatty-schools-behave",
     "chilled-houses-run",
+    "clean-moles-report",
     "clever-rings-yawn",
     "cold-shirts-complain",
     "cuddly-flies-smash",
@@ -98,6 +99,7 @@
     "four-ants-complain",
     "four-radios-love",
     "gentle-worms-smoke",
+    "gold-rivers-fix",
     "gorgeous-ants-cheer",
     "great-cows-admire",
     "green-years-shake",
@@ -123,6 +125,7 @@
     "shiny-lizards-lay",
     "short-bottles-sniff",
     "short-news-kiss",
+    "silly-trainers-rescue",
     "slimy-snails-protect",
     "small-beans-travel",
     "spotty-cows-destroy",
@@ -141,7 +144,9 @@
     "wicked-socks-develop",
     "wild-cats-hug",
     "wise-files-smash",
+    "yellow-lions-provide",
     "yellow-months-walk",
+    "young-candles-hunt",
     "young-frogs-clap",
     "young-goats-jump"
   ]

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/api
 
+## 2.0.0-beta.9
+
+### Minor Changes
+
+- b946e00: Emitted action definition is minimal size now
+
+### Patch Changes
+
+- Updated dependencies [01724ae]
+  - @osdk/shared.net@2.0.0-beta.2
+
 ## 2.0.0-beta.8
 
 ### Patch Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/api",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/cli.cmd.typescript
 
+## 0.6.0-beta.8
+
+### Patch Changes
+
+- Updated dependencies [b946e00]
+- Updated dependencies [01724ae]
+  - @osdk/generator@2.0.0-beta.9
+  - @osdk/shared.net@2.0.0-beta.2
+  - @osdk/internal.foundry.core@0.2.0-beta.6
+  - @osdk/internal.foundry.ontologiesv2@0.2.0-beta.6
+
 ## 0.6.0-beta.7
 
 ### Minor Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.6.0-beta.7",
+  "version": "0.6.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/cli
 
+## 0.24.0-beta.8
+
+### Patch Changes
+
+- Updated dependencies [b946e00]
+- Updated dependencies [01724ae]
+  - @osdk/generator@2.0.0-beta.9
+  - @osdk/shared.net@2.0.0-beta.2
+
 ## 0.24.0-beta.7
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.24.0-beta.7",
+  "version": "0.24.0-beta.8",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client.api/CHANGELOG.md
+++ b/packages/client.api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/client.api
 
+## 2.0.0-beta.9
+
+### Patch Changes
+
+- Updated dependencies [b946e00]
+  - @osdk/api@2.0.0-beta.9
+
 ## 2.0.0-beta.8
 
 ### Minor Changes

--- a/packages/client.api/package.json
+++ b/packages/client.api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.api",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.test.ontology/CHANGELOG.md
+++ b/packages/client.test.ontology/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/client.test.ontology
 
+## 2.0.0-beta.9
+
+### Patch Changes
+
+- Updated dependencies [b946e00]
+  - @osdk/api@2.0.0-beta.9
+  - @osdk/client.api@2.0.0-beta.9
+
 ## 2.0.0-beta.8
 
 ### Patch Changes

--- a/packages/client.test.ontology/package.json
+++ b/packages/client.test.ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/client.test.ontology",
   "private": true,
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.unstable/CHANGELOG.md
+++ b/packages/client.unstable/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/client.unstable
 
+## 2.0.0-beta.9
+
 ## 2.0.0-beta.8
 
 ## 2.0.0-beta.7

--- a/packages/client.unstable/package.json
+++ b/packages/client.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.unstable",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @osdk/client
 
+## 2.0.0-beta.9
+
+### Minor Changes
+
+- b946e00: Emitted action definition is minimal size now
+
+### Patch Changes
+
+- Updated dependencies [b946e00]
+  - @osdk/api@2.0.0-beta.9
+  - @osdk/client.api@2.0.0-beta.9
+  - @osdk/generator-converters@2.0.0-beta.9
+  - @osdk/client.unstable@2.0.0-beta.9
+
 ## 2.0.0-beta.8
 
 ### Minor Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/create-app.template.next-static-export/CHANGELOG.md
+++ b/packages/create-app.template.next-static-export/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/create-app.template.next-static-export
 
+## 0.19.0-beta.4
+
+### Minor Changes
+
+- b190539: Upgrade to next 14.2.10
+
 ## 0.19.0-beta.3
 
 ## 0.19.0-beta.2

--- a/packages/create-app.template.next-static-export/package.json
+++ b/packages/create-app.template.next-static-export/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.next-static-export",
   "private": true,
-  "version": "0.19.0-beta.3",
+  "version": "0.19.0-beta.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react.beta/CHANGELOG.md
+++ b/packages/create-app.template.react.beta/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/create-app.template.react
 
+## 0.19.0-beta.4
+
+### Minor Changes
+
+- 646081b: fix latest to "workspace:\*" on examples
+
 ## 0.19.0-beta.3
 
 ### Minor Changes

--- a/packages/create-app.template.react.beta/package.json
+++ b/packages/create-app.template.react.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react.beta",
   "private": true,
-  "version": "0.19.0-beta.3",
+  "version": "0.19.0-beta.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react/CHANGELOG.md
+++ b/packages/create-app.template.react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/create-app.template.react
 
+## 0.19.0-beta.4
+
+### Minor Changes
+
+- 5a85d65: Fix react template
+- 646081b: fix latest to "workspace:\*" on examples
+
 ## 0.19.0-beta.3
 
 ## 0.19.0-beta.2

--- a/packages/create-app.template.react/package.json
+++ b/packages/create-app.template.react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react",
   "private": true,
-  "version": "0.19.0-beta.3",
+  "version": "0.19.0-beta.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-aip-app
 
+## 0.19.0-beta.4
+
 ## 0.19.0-beta.3
 
 ## 0.19.0-beta.2

--- a/packages/create-app.template.tutorial-todo-aip-app/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app",
   "private": true,
-  "version": "0.19.0-beta.3",
+  "version": "0.19.0-beta.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-app
 
+## 0.19.0-beta.4
+
 ## 0.19.0-beta.3
 
 ## 0.19.0-beta.2

--- a/packages/create-app.template.tutorial-todo-app/package.json
+++ b/packages/create-app.template.tutorial-todo-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app",
   "private": true,
-  "version": "0.19.0-beta.3",
+  "version": "0.19.0-beta.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.vue/CHANGELOG.md
+++ b/packages/create-app.template.vue/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.vue
 
+## 0.19.0-beta.4
+
 ## 0.19.0-beta.3
 
 ## 0.19.0-beta.2

--- a/packages/create-app.template.vue/package.json
+++ b/packages/create-app.template.vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.vue",
   "private": true,
-  "version": "0.19.0-beta.3",
+  "version": "0.19.0-beta.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app
 
+## 0.19.0-beta.4
+
 ## 0.19.0-beta.3
 
 ## 0.19.0-beta.2

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-app",
-  "version": "0.19.0-beta.3",
+  "version": "0.19.0-beta.4",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/example-generator/CHANGELOG.md
+++ b/packages/example-generator/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/example-generator
 
+## 0.8.0-beta.4
+
+### Minor Changes
+
+- 646081b: fix latest to "workspace:\*" on examples
+
+### Patch Changes
+
+- @osdk/create-app@0.19.0-beta.4
+
 ## 0.8.0-beta.3
 
 ### Patch Changes

--- a/packages/example-generator/package.json
+++ b/packages/example-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/example-generator",
   "private": true,
-  "version": "0.8.0-beta.3",
+  "version": "0.8.0-beta.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @osdk/foundry-sdk-generator
 
+## 2.0.0-beta.9
+
+### Patch Changes
+
+- Updated dependencies [b946e00]
+- Updated dependencies [01724ae]
+  - @osdk/generator@2.0.0-beta.9
+  - @osdk/client@2.0.0-beta.9
+  - @osdk/api@2.0.0-beta.9
+  - @osdk/shared.net@2.0.0-beta.2
+  - @osdk/client.api@2.0.0-beta.9
+  - @osdk/internal.foundry.core@0.2.0-beta.6
+  - @osdk/internal.foundry.ontologies@0.2.0-beta.6
+  - @osdk/internal.foundry.ontologiesv2@0.2.0-beta.6
+
 ## 2.0.0-beta.8
 
 ### Minor Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-converters/CHANGELOG.md
+++ b/packages/generator-converters/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/generator-converters
 
+## 2.0.0-beta.9
+
+### Patch Changes
+
+- Updated dependencies [b946e00]
+  - @osdk/api@2.0.0-beta.9
+
 ## 2.0.0-beta.8
 
 ### Patch Changes

--- a/packages/generator-converters/package.json
+++ b/packages/generator-converters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-converters",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/generator
 
+## 2.0.0-beta.9
+
+### Minor Changes
+
+- b946e00: Emitted action definition is minimal size now
+
+### Patch Changes
+
+- Updated dependencies [b946e00]
+  - @osdk/api@2.0.0-beta.9
+  - @osdk/generator-converters@2.0.0-beta.9
+  - @osdk/internal.foundry.core@0.2.0-beta.6
+
 ## 2.0.0-beta.8
 
 ### Minor Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/internal.foundry.core/CHANGELOG.md
+++ b/packages/internal.foundry.core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/internal.foundry.core
 
+## 0.2.0-beta.6
+
+### Patch Changes
+
+- Updated dependencies [01724ae]
+  - @osdk/shared.net@2.0.0-beta.2
+
 ## 0.2.0-beta.5
 
 ### Patch Changes

--- a/packages/internal.foundry.core/package.json
+++ b/packages/internal.foundry.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.core",
-  "version": "0.2.0-beta.5",
+  "version": "0.2.0-beta.6",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.datasets/CHANGELOG.md
+++ b/packages/internal.foundry.datasets/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/internal.foundry.datasets
 
+## 0.2.0-beta.6
+
+### Patch Changes
+
+- Updated dependencies [01724ae]
+  - @osdk/shared.net@2.0.0-beta.2
+  - @osdk/internal.foundry.core@0.2.0-beta.6
+
 ## 0.2.0-beta.5
 
 ### Patch Changes

--- a/packages/internal.foundry.datasets/package.json
+++ b/packages/internal.foundry.datasets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.datasets",
-  "version": "0.2.0-beta.5",
+  "version": "0.2.0-beta.6",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.ontologies/CHANGELOG.md
+++ b/packages/internal.foundry.ontologies/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/internal.foundry.ontologies
 
+## 0.2.0-beta.6
+
+### Patch Changes
+
+- Updated dependencies [01724ae]
+  - @osdk/shared.net@2.0.0-beta.2
+  - @osdk/internal.foundry.core@0.2.0-beta.6
+
 ## 0.2.0-beta.5
 
 ### Patch Changes

--- a/packages/internal.foundry.ontologies/package.json
+++ b/packages/internal.foundry.ontologies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.ontologies",
-  "version": "0.2.0-beta.5",
+  "version": "0.2.0-beta.6",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.ontologiesv2/CHANGELOG.md
+++ b/packages/internal.foundry.ontologiesv2/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/internal.foundry.ontologiesv2
 
+## 0.2.0-beta.6
+
+### Patch Changes
+
+- Updated dependencies [01724ae]
+  - @osdk/shared.net@2.0.0-beta.2
+  - @osdk/internal.foundry.core@0.2.0-beta.6
+  - @osdk/internal.foundry.ontologies@0.2.0-beta.6
+
 ## 0.2.0-beta.5
 
 ### Patch Changes

--- a/packages/internal.foundry.ontologiesv2/package.json
+++ b/packages/internal.foundry.ontologiesv2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.ontologiesv2",
-  "version": "0.2.0-beta.5",
+  "version": "0.2.0-beta.6",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry/CHANGELOG.md
+++ b/packages/internal.foundry/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/foundry
 
+## 0.5.0-beta.6
+
+### Patch Changes
+
+- Updated dependencies [01724ae]
+  - @osdk/shared.net@2.0.0-beta.2
+  - @osdk/internal.foundry.core@0.2.0-beta.6
+  - @osdk/internal.foundry.datasets@0.2.0-beta.6
+  - @osdk/internal.foundry.ontologies@0.2.0-beta.6
+  - @osdk/internal.foundry.ontologiesv2@0.2.0-beta.6
+
 ## 0.5.0-beta.5
 
 ### Patch Changes

--- a/packages/internal.foundry/package.json
+++ b/packages/internal.foundry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/internal.foundry",
   "private": "true",
-  "version": "0.5.0-beta.5",
+  "version": "0.5.0-beta.6",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/maker/CHANGELOG.md
+++ b/packages/maker/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/maker
 
+## 0.8.0-beta.5
+
+### Patch Changes
+
+- Updated dependencies [b946e00]
+  - @osdk/api@2.0.0-beta.9
+
 ## 0.8.0-beta.4
 
 ### Minor Changes

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker",
-  "version": "0.8.0-beta.4",
+  "version": "0.8.0-beta.5",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.net/CHANGELOG.md
+++ b/packages/shared.net/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/shared.net
 
+## 2.0.0-beta.2
+
+### Minor Changes
+
+- 01724ae: Remove unnecessary dependency
+
 ## 2.0.0-beta.1
 
 ### Major Changes

--- a/packages/shared.net/package.json
+++ b/packages/shared.net/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/shared.net",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/shared.test/CHANGELOG.md
+++ b/packages/shared.test/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @osdk/shared.test
 
+## 1.7.0-beta.5
+
+### Minor Changes
+
+- 01724ae: Remove unnecessary dependency
+
+### Patch Changes
+
+- Updated dependencies [b946e00]
+  - @osdk/api@2.0.0-beta.9
+  - @osdk/internal.foundry.core@0.2.0-beta.6
+  - @osdk/internal.foundry.ontologies@0.2.0-beta.6
+  - @osdk/internal.foundry.ontologiesv2@0.2.0-beta.6
+
 ## 1.7.0-beta.4
 
 ### Minor Changes

--- a/packages/shared.test/package.json
+++ b/packages/shared.test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/shared.test",
   "private": true,
-  "version": "1.7.0-beta.4",
+  "version": "1.7.0-beta.5",
   "description": "",
   "access": "private",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/api@2.0.0-beta.9

### Minor Changes

-   b946e00: Emitted action definition is minimal size now

### Patch Changes

-   Updated dependencies [01724ae]
    -   @osdk/shared.net@2.0.0-beta.2

## @osdk/client@2.0.0-beta.9

### Minor Changes

-   b946e00: Emitted action definition is minimal size now

### Patch Changes

-   Updated dependencies [b946e00]
    -   @osdk/api@2.0.0-beta.9
    -   @osdk/client.api@2.0.0-beta.9
    -   @osdk/generator-converters@2.0.0-beta.9
    -   @osdk/client.unstable@2.0.0-beta.9

## @osdk/generator@2.0.0-beta.9

### Minor Changes

-   b946e00: Emitted action definition is minimal size now

### Patch Changes

-   Updated dependencies [b946e00]
    -   @osdk/api@2.0.0-beta.9
    -   @osdk/generator-converters@2.0.0-beta.9
    -   @osdk/internal.foundry.core@0.2.0-beta.6

## @osdk/shared.net@2.0.0-beta.2

### Minor Changes

-   01724ae: Remove unnecessary dependency

## @osdk/cli@0.24.0-beta.8

### Patch Changes

-   Updated dependencies [b946e00]
-   Updated dependencies [01724ae]
    -   @osdk/generator@2.0.0-beta.9
    -   @osdk/shared.net@2.0.0-beta.2

## @osdk/client.api@2.0.0-beta.9

### Patch Changes

-   Updated dependencies [b946e00]
    -   @osdk/api@2.0.0-beta.9

## @osdk/foundry-sdk-generator@2.0.0-beta.9

### Patch Changes

-   Updated dependencies [b946e00]
-   Updated dependencies [01724ae]
    -   @osdk/generator@2.0.0-beta.9
    -   @osdk/client@2.0.0-beta.9
    -   @osdk/api@2.0.0-beta.9
    -   @osdk/shared.net@2.0.0-beta.2
    -   @osdk/client.api@2.0.0-beta.9
    -   @osdk/internal.foundry.core@0.2.0-beta.6
    -   @osdk/internal.foundry.ontologies@0.2.0-beta.6
    -   @osdk/internal.foundry.ontologiesv2@0.2.0-beta.6

## @osdk/generator-converters@2.0.0-beta.9

### Patch Changes

-   Updated dependencies [b946e00]
    -   @osdk/api@2.0.0-beta.9

## @osdk/internal.foundry.core@0.2.0-beta.6

### Patch Changes

-   Updated dependencies [01724ae]
    -   @osdk/shared.net@2.0.0-beta.2

## @osdk/internal.foundry.datasets@0.2.0-beta.6

### Patch Changes

-   Updated dependencies [01724ae]
    -   @osdk/shared.net@2.0.0-beta.2
    -   @osdk/internal.foundry.core@0.2.0-beta.6

## @osdk/internal.foundry.ontologies@0.2.0-beta.6

### Patch Changes

-   Updated dependencies [01724ae]
    -   @osdk/shared.net@2.0.0-beta.2
    -   @osdk/internal.foundry.core@0.2.0-beta.6

## @osdk/internal.foundry.ontologiesv2@0.2.0-beta.6

### Patch Changes

-   Updated dependencies [01724ae]
    -   @osdk/shared.net@2.0.0-beta.2
    -   @osdk/internal.foundry.core@0.2.0-beta.6
    -   @osdk/internal.foundry.ontologies@0.2.0-beta.6

## @osdk/maker@0.8.0-beta.5

### Patch Changes

-   Updated dependencies [b946e00]
    -   @osdk/api@2.0.0-beta.9

## @osdk/client.unstable@2.0.0-beta.9



## @osdk/create-app@0.19.0-beta.4



## @osdk/create-app.template.next-static-export@0.19.0-beta.4

### Minor Changes

-   b190539: Upgrade to next 14.2.10

## @osdk/create-app.template.react@0.19.0-beta.4

### Minor Changes

-   5a85d65: Fix react template
-   646081b: fix latest to "workspace:\*" on examples

## @osdk/create-app.template.react.beta@0.19.0-beta.4

### Minor Changes

-   646081b: fix latest to "workspace:\*" on examples

## @osdk/example-generator@0.8.0-beta.4

### Minor Changes

-   646081b: fix latest to "workspace:\*" on examples

### Patch Changes

-   @osdk/create-app@0.19.0-beta.4

## @osdk/shared.test@1.7.0-beta.5

### Minor Changes

-   01724ae: Remove unnecessary dependency

### Patch Changes

-   Updated dependencies [b946e00]
    -   @osdk/api@2.0.0-beta.9
    -   @osdk/internal.foundry.core@0.2.0-beta.6
    -   @osdk/internal.foundry.ontologies@0.2.0-beta.6
    -   @osdk/internal.foundry.ontologiesv2@0.2.0-beta.6

## @osdk/cli.cmd.typescript@0.6.0-beta.8

### Patch Changes

-   Updated dependencies [b946e00]
-   Updated dependencies [01724ae]
    -   @osdk/generator@2.0.0-beta.9
    -   @osdk/shared.net@2.0.0-beta.2
    -   @osdk/internal.foundry.core@0.2.0-beta.6
    -   @osdk/internal.foundry.ontologiesv2@0.2.0-beta.6

## @osdk/client.test.ontology@2.0.0-beta.9

### Patch Changes

-   Updated dependencies [b946e00]
    -   @osdk/api@2.0.0-beta.9
    -   @osdk/client.api@2.0.0-beta.9

## @osdk/internal.foundry@0.5.0-beta.6

### Patch Changes

-   Updated dependencies [01724ae]
    -   @osdk/shared.net@2.0.0-beta.2
    -   @osdk/internal.foundry.core@0.2.0-beta.6
    -   @osdk/internal.foundry.datasets@0.2.0-beta.6
    -   @osdk/internal.foundry.ontologies@0.2.0-beta.6
    -   @osdk/internal.foundry.ontologiesv2@0.2.0-beta.6

## @osdk/create-app.template.tutorial-todo-aip-app@0.19.0-beta.4



## @osdk/create-app.template.tutorial-todo-app@0.19.0-beta.4



## @osdk/create-app.template.vue@0.19.0-beta.4


