### PR TITLE
Version Packages

### DIFF
--- a/.changeset/blue-insects-attend.md
+++ b/.changeset/blue-insects-attend.md
@@ -1,5 +1,0 @@
----
-"@osdk/foundry-sdk-generator": patch
----
-
-Releasing a new beta version

--- a/packages/e2e.test.foundry-sdk-generator/CHANGELOG.md
+++ b/packages/e2e.test.foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/e2e.test.foundry-sdk-generator
 
+## 0.2.8
+
+### Patch Changes
+
+- Updated dependencies [9b48bf8]
+  - @osdk/foundry-sdk-generator@1.3.8
+
 ## 0.2.7
 
 ### Patch Changes

--- a/packages/e2e.test.foundry-sdk-generator/package.json
+++ b/packages/e2e.test.foundry-sdk-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.test.foundry-sdk-generator",
   "private": true,
-  "version": "0.2.7",
+  "version": "0.2.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/foundry-sdk-generator
 
+## 1.3.8
+
+### Patch Changes
+
+- 9b48bf8: Releasing a new beta version
+
 ## 1.3.7
 
 ### Patch Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/1.3.x, this PR will be updated.


# Releases
## @osdk/foundry-sdk-generator@1.3.8

### Patch Changes

-   9b48bf8: Releasing a new beta version

## @osdk/e2e.test.foundry-sdk-generator@0.2.8

### Patch Changes

-   Updated dependencies [9b48bf8]
    -   @osdk/foundry-sdk-generator@1.3.8
