### PR TITLE
change path resolution for windows

### DIFF
--- a/.changeset/tricky-eels-count.md
+++ b/.changeset/tricky-eels-count.md
@@ -1,0 +1,6 @@
+---
+"@osdk/platform-sdk-generator": patch
+"@osdk/generator": patch
+---
+
+Fixing bug for codegen on windows machines, where we would use backslashes instead of forward slashes for import paths, which should be OS agnostic.

--- a/packages/generator/src/GenerateContext/EnhancedBase.ts
+++ b/packages/generator/src/GenerateContext/EnhancedBase.ts
@@ -60,7 +60,8 @@ export abstract class AbstractImportable {
 
   getImportPathRelTo = (filePath: string) => {
     if (this.importPath.startsWith(".")) {
-      const result = path.relative(path.dirname(filePath), this.importPath);
+      const result = path.relative(path.dirname(filePath), this.importPath)
+        .split(path.sep).join("/");
 
       if (result.startsWith(".")) {
         return result;

--- a/packages/platform-sdk-generator/src/generatePlatformSdkv2.ts
+++ b/packages/platform-sdk-generator/src/generatePlatformSdkv2.ts
@@ -67,7 +67,7 @@ export async function generatePlatformSdkV2(
         + path.relative(
           ns.paths.srcDir,
           ns.paths.resourcesDir,
-        );
+        ).split(path.sep).join("/");
 
       const resourceName = pluralize(r.component);
       if (componentsGenerated.get(ns)!.some(c => c === resourceName)) {


### PR DESCRIPTION
Before we used the node path utility to generate the import paths for our generated code files. On Windows this resolves to backslashes, which we replace manually