### PR TITLE
Version Packages

### DIFF
--- a/.changeset/fast-mirrors-attend.md
+++ b/.changeset/fast-mirrors-attend.md
@@ -1,5 +1,0 @@
----
-"@osdk/foundry-sdk-generator": patch
----
-
-Updating the beta generator version on stable branch.

--- a/packages/e2e.test.foundry-sdk-generator/CHANGELOG.md
+++ b/packages/e2e.test.foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/e2e.test.foundry-sdk-generator
 
+## 0.2.10
+
+### Patch Changes
+
+- Updated dependencies [8fc2c9a]
+  - @osdk/foundry-sdk-generator@1.3.10
+
 ## 0.2.9
 
 ### Patch Changes

--- a/packages/e2e.test.foundry-sdk-generator/package.json
+++ b/packages/e2e.test.foundry-sdk-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.test.foundry-sdk-generator",
   "private": true,
-  "version": "0.2.9",
+  "version": "0.2.10",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/foundry-sdk-generator
 
+## 1.3.10
+
+### Patch Changes
+
+- 8fc2c9a: Updating the beta generator version on stable branch.
+
 ## 1.3.9
 
 ### Patch Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/1.3.x, this PR will be updated.


# Releases
## @osdk/foundry-sdk-generator@1.3.10

### Patch Changes

-   8fc2c9a: Updating the beta generator version on stable branch.

## @osdk/e2e.test.foundry-sdk-generator@0.2.10

### Patch Changes

-   Updated dependencies [8fc2c9a]
    -   @osdk/foundry-sdk-generator@1.3.10
