### PR TITLE
Simulate symbols

### DIFF
--- a/.changeset/thick-bottles-love.md
+++ b/.changeset/thick-bottles-love.md
@@ -1,0 +1,7 @@
+---
+"@osdk/shared.client": minor
+"@osdk/client": minor
+"@osdk/api": minor
+---
+
+Simulate symbols since symbols are too complex

--- a/packages/api/src/public/unstable.ts
+++ b/packages/api/src/public/unstable.ts
@@ -14,10 +14,14 @@
  * limitations under the License.
  */
 
-export const __EXPERIMENTAL__NOT_SUPPORTED_YET_subscribe = Symbol();
+export const __EXPERIMENTAL__NOT_SUPPORTED_YET_subscribe: unique symbol =
+  "__EXPERIMENTAL__NOT_SUPPORTED_YET_subscribe" as any;
 
-export const __EXPERIMENTAL__NOT_SUPPORTED_YET__preexistingObjectSet = Symbol();
-export const __EXPERIMENTAL__NOT_SUPPORTED_YET__getBulkLinks = Symbol();
+export const __EXPERIMENTAL__NOT_SUPPORTED_YET__preexistingObjectSet:
+  unique symbol =
+    "__EXPERIMENTAL__NOT_SUPPORTED_YET__preexistingObjectSet" as any;
+export const __EXPERIMENTAL__NOT_SUPPORTED_YET__getBulkLinks: unique symbol =
+  "__EXPERIMENTAL__NOT_SUPPORTED_YET__getBulkLinks" as any;
 
 export type { EXPERIMENTAL_ObjectSetListener } from "../objectSet/EXPERIMENTAL_ObjectSetListener.js";
 export type { MinimalObjectSet } from "../objectSet/ObjectSet.js";

--- a/packages/client/src/createClient.ts
+++ b/packages/client/src/createClient.ts
@@ -133,9 +133,15 @@ export function createClientInternal(
     {
       [symbolClientContext]: {
         value: clientCtx,
+        // defaults to configurable: false,
+        // defaults to enumerable: false,
+        // defaults to writable: false,
       },
       [__EXPERIMENTAL__NOT_SUPPORTED_YET__getBulkLinks]: {
         get: () => createBulkLinksAsyncIterFactory(clientCtx),
+        // defaults to configurable: false,
+        // defaults to enumerable: false,
+        // defaults to writable: false,
       },
       [__EXPERIMENTAL__NOT_SUPPORTED_YET__preexistingObjectSet]: {
         get: () =>
@@ -161,9 +167,15 @@ export function createClientInternal(
             },
           );
         },
+        // defaults to configurable: false,
+        // defaults to enumerable: false,
+        // defaults to writable: false,
       },
       fetchMetadata: {
         value: fetchMetadata,
+        // defaults to configurable: false,
+        // defaults to enumerable: false,
+        // defaults to writable: false,
       },
     } satisfies Record<keyof Client, PropertyDescriptor>,
   );

--- a/packages/client/src/objectSet/createObjectSet.ts
+++ b/packages/client/src/objectSet/createObjectSet.ts
@@ -228,20 +228,27 @@ export function createObjectSet<Q extends ObjectOrInterfaceDefinition>(
         ) as Result<Osdk<Q>>;
       }
       : undefined) as ObjectSet<Q>["fetchOneWithErrors"],
-
-    [__EXPERIMENTAL__NOT_SUPPORTED_YET_subscribe]: (
-      listener: EXPERIMENTAL_ObjectSetListener<Q>,
-    ) => {
-      const pendingSubscribe = ObjectSetListenerWebsocket.getInstance(
-        clientCtx,
-      ).subscribe(
-        objectSet,
-        listener,
-      );
-
-      return async () => (await pendingSubscribe)();
-    },
   };
+
+  Object.defineProperties(base, {
+    [__EXPERIMENTAL__NOT_SUPPORTED_YET_subscribe]: {
+      value: (
+        listener: EXPERIMENTAL_ObjectSetListener<Q>,
+      ) => {
+        const pendingSubscribe = ObjectSetListenerWebsocket.getInstance(
+          clientCtx,
+        ).subscribe(
+          objectSet,
+          listener,
+        );
+
+        return async () => (await pendingSubscribe)();
+      },
+      // enumerable: false is default
+      // configurable: false is default
+      // writable: false is default
+    },
+  });
 
   function createSearchAround<L extends LinkNames<Q>>(link: L) {
     return () => {

--- a/packages/shared.client/index.js
+++ b/packages/shared.client/index.js
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const symbolClientContext = Symbol("ClientContext");
+export const symbolClientContext = "$osdkClientContext";


### PR DESCRIPTION
Pros of using symbols:
* You can't fake it. You must have the source package.
* They are don't show up in `for in` and `Object.keys` (but [do still copy](https://www.typescriptlang.org/play/?#code/MYewdgzgLgBBMF4YGUCeBbARiANgCgEoBuAKBNElgDMQREYBvEmFmAbQgF0AuGAIgAWASz4kAvmQrQYmAIYAnek1YwAdOpohxZWTgCm8qHk0dOBIA), unsure if thats good or bad.)
* Guarantees compatibility between packages when working correctly since an exported symbol is different from two different versions.

Cons of symbols:
* If people get in weird situations, they have a hard time debugging/fixing


Cons of strings:
* Requires extra work to make them non-enumerable
* Easier to get unexpected behavior across versions