### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -80,6 +80,7 @@
   },
   "changesets": [
     "big-trainers-love",
+    "blue-kangaroos-cheer",
     "blue-rivers-enjoy",
     "bright-gorillas-draw",
     "bright-panthers-lick",
@@ -90,6 +91,7 @@
     "chilled-houses-run",
     "clean-moles-report",
     "clever-rings-yawn",
+    "cold-mirrors-push",
     "cold-shirts-complain",
     "cuddly-flies-smash",
     "curvy-months-jump",
@@ -120,6 +122,7 @@
     "happy-numbers-wash",
     "hot-ways-impress",
     "kind-boats-dream",
+    "kind-bugs-nail",
     "large-singers-complain",
     "late-students-sleep",
     "late-wasps-check",

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/api
 
+## 2.0.0-beta.17
+
 ## 2.0.0-beta.16
 
 ### Minor Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/api",
-  "version": "2.0.0-beta.16",
+  "version": "2.0.0-beta.17",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/cli.cmd.typescript
 
+## 0.6.0-beta.16
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+  - @osdk/internal.foundry.ontologiesv2@0.2.0-beta.11
+  - @osdk/internal.foundry.core@0.2.0-beta.11
+  - @osdk/generator@2.0.0-beta.17
+
 ## 0.6.0-beta.15
 
 ### Minor Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.6.0-beta.15",
+  "version": "0.6.0-beta.16",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/cli
 
+## 0.24.0-beta.16
+
+### Patch Changes
+
+- @osdk/generator@2.0.0-beta.17
+
 ## 0.24.0-beta.15
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.24.0-beta.15",
+  "version": "0.24.0-beta.16",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client.test.ontology/CHANGELOG.md
+++ b/packages/client.test.ontology/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/client.test.ontology
 
+## 2.0.0-beta.17
+
+### Patch Changes
+
+- @osdk/api@2.0.0-beta.17
+
 ## 2.0.0-beta.16
 
 ### Patch Changes

--- a/packages/client.test.ontology/package.json
+++ b/packages/client.test.ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/client.test.ontology",
   "private": true,
-  "version": "2.0.0-beta.16",
+  "version": "2.0.0-beta.17",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.unstable/CHANGELOG.md
+++ b/packages/client.unstable/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/client.unstable
 
+## 2.0.0-beta.17
+
+### Minor Changes
+
+- ee39a61: Adding value types to ont as code
+
 ## 2.0.0-beta.16
 
 ## 2.0.0-beta.15

--- a/packages/client.unstable/package.json
+++ b/packages/client.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.unstable",
-  "version": "2.0.0-beta.16",
+  "version": "2.0.0-beta.17",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/client
 
+## 2.0.0-beta.17
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+- Updated dependencies [ee39a61]
+  - @osdk/internal.foundry.ontologiesv2@0.2.0-beta.11
+  - @osdk/internal.foundry.core@0.2.0-beta.11
+  - @osdk/client.unstable@2.0.0-beta.17
+  - @osdk/generator-converters@2.0.0-beta.17
+  - @osdk/api@2.0.0-beta.17
+
 ## 2.0.0-beta.16
 
 ### Minor Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client",
-  "version": "2.0.0-beta.16",
+  "version": "2.0.0-beta.17",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/foundry.admin/CHANGELOG.md
+++ b/packages/foundry.admin/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/foundry.admin
 
+## 2.1.0-beta.7
+
+### Minor Changes
+
+- 5d6d5ab: Use the "verb" where possible
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+  - @osdk/foundry.core@2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Patch Changes

--- a/packages/foundry.admin/package.json
+++ b/packages/foundry.admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.admin",
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.core/CHANGELOG.md
+++ b/packages/foundry.core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/foundry.core
 
+## 2.1.0-beta.7
+
+### Minor Changes
+
+- 5d6d5ab: Use the "verb" where possible
+
 ## 2.1.0-beta.6
 
 ### Patch Changes

--- a/packages/foundry.core/package.json
+++ b/packages/foundry.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.core",
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.datasets/CHANGELOG.md
+++ b/packages/foundry.datasets/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/foundry.datasets
 
+## 2.1.0-beta.7
+
+### Minor Changes
+
+- 5d6d5ab: Use the "verb" where possible
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+  - @osdk/foundry.filesystem@2.1.0-beta.7
+  - @osdk/foundry.core@2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Patch Changes

--- a/packages/foundry.datasets/package.json
+++ b/packages/foundry.datasets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.datasets",
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.filesystem/CHANGELOG.md
+++ b/packages/foundry.filesystem/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/foundry.filesystem
 
+## 2.1.0-beta.7
+
+### Minor Changes
+
+- 5d6d5ab: Use the "verb" where possible
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+  - @osdk/foundry.core@2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Patch Changes

--- a/packages/foundry.filesystem/package.json
+++ b/packages/foundry.filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.filesystem",
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.functions/CHANGELOG.md
+++ b/packages/foundry.functions/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/foundry.functions
 
+## 2.1.0-beta.7
+
+### Minor Changes
+
+- 5d6d5ab: Use the "verb" where possible
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+  - @osdk/foundry.core@2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Patch Changes

--- a/packages/foundry.functions/package.json
+++ b/packages/foundry.functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.functions",
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.ontologies/CHANGELOG.md
+++ b/packages/foundry.ontologies/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/foundry.ontologies
 
+## 2.1.0-beta.7
+
+### Minor Changes
+
+- 5d6d5ab: Use the "verb" where possible
+
 ## 2.1.0-beta.6
 
 ### Patch Changes

--- a/packages/foundry.ontologies/package.json
+++ b/packages/foundry.ontologies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.ontologies",
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.orchestration/CHANGELOG.md
+++ b/packages/foundry.orchestration/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/foundry.orchestration
 
+## 2.1.0-beta.7
+
+### Minor Changes
+
+- 5d6d5ab: Use the "verb" where possible
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+  - @osdk/foundry.filesystem@2.1.0-beta.7
+  - @osdk/foundry.datasets@2.1.0-beta.7
+  - @osdk/foundry.core@2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Patch Changes

--- a/packages/foundry.orchestration/package.json
+++ b/packages/foundry.orchestration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.orchestration",
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.publicapis/CHANGELOG.md
+++ b/packages/foundry.publicapis/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/foundry.publicapis
 
+## 2.1.0-beta.7
+
+### Minor Changes
+
+- 5d6d5ab: Use the "verb" where possible
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+  - @osdk/foundry.core@2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Patch Changes

--- a/packages/foundry.publicapis/package.json
+++ b/packages/foundry.publicapis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.publicapis",
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.streams/CHANGELOG.md
+++ b/packages/foundry.streams/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/foundry.streams
 
+## 2.1.0-beta.7
+
+### Minor Changes
+
+- 5d6d5ab: Use the "verb" where possible
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+  - @osdk/foundry.filesystem@2.1.0-beta.7
+  - @osdk/foundry.datasets@2.1.0-beta.7
+  - @osdk/foundry.core@2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Patch Changes

--- a/packages/foundry.streams/package.json
+++ b/packages/foundry.streams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.streams",
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.thirdpartyapplications/CHANGELOG.md
+++ b/packages/foundry.thirdpartyapplications/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/foundry.thirdpartyapplications
 
+## 2.1.0-beta.7
+
+### Minor Changes
+
+- 5d6d5ab: Use the "verb" where possible
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+  - @osdk/foundry.core@2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Patch Changes

--- a/packages/foundry.thirdpartyapplications/package.json
+++ b/packages/foundry.thirdpartyapplications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.thirdpartyapplications",
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry/CHANGELOG.md
+++ b/packages/foundry/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @osdk/foundry
 
+## 2.1.0-beta.7
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+  - @osdk/foundry.thirdpartyapplications@2.1.0-beta.7
+  - @osdk/foundry.orchestration@2.1.0-beta.7
+  - @osdk/foundry.filesystem@2.1.0-beta.7
+  - @osdk/foundry.ontologies@2.1.0-beta.7
+  - @osdk/foundry.publicapis@2.1.0-beta.7
+  - @osdk/foundry.functions@2.1.0-beta.7
+  - @osdk/foundry.datasets@2.1.0-beta.7
+  - @osdk/foundry.streams@2.1.0-beta.7
+  - @osdk/foundry.admin@2.1.0-beta.7
+  - @osdk/foundry.core@2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Patch Changes

--- a/packages/foundry/package.json
+++ b/packages/foundry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry",
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/generator-converters/CHANGELOG.md
+++ b/packages/generator-converters/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/generator-converters
 
+## 2.0.0-beta.17
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+  - @osdk/internal.foundry.core@0.2.0-beta.11
+  - @osdk/api@2.0.0-beta.17
+
 ## 2.0.0-beta.16
 
 ### Minor Changes

--- a/packages/generator-converters/package.json
+++ b/packages/generator-converters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-converters",
-  "version": "2.0.0-beta.16",
+  "version": "2.0.0-beta.17",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/generator
 
+## 2.0.0-beta.17
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+  - @osdk/internal.foundry.core@0.2.0-beta.11
+  - @osdk/generator-converters@2.0.0-beta.17
+  - @osdk/api@2.0.0-beta.17
+
 ## 2.0.0-beta.16
 
 ### Minor Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "2.0.0-beta.16",
+  "version": "2.0.0-beta.17",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/internal.foundry.core/CHANGELOG.md
+++ b/packages/internal.foundry.core/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/internal.foundry.core
 
+## 0.2.0-beta.11
+
+### Minor Changes
+
+- 5d6d5ab: Use the "verb" where possible
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+  - @osdk/internal.foundry.geo@0.1.0-beta.4
+
 ## 0.2.0-beta.10
 
 ### Patch Changes

--- a/packages/internal.foundry.core/package.json
+++ b/packages/internal.foundry.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.core",
-  "version": "0.2.0-beta.10",
+  "version": "0.2.0-beta.11",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.datasets/CHANGELOG.md
+++ b/packages/internal.foundry.datasets/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/internal.foundry.datasets
 
+## 0.2.0-beta.11
+
+### Minor Changes
+
+- 5d6d5ab: Use the "verb" where possible
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+  - @osdk/internal.foundry.core@0.2.0-beta.11
+
 ## 0.2.0-beta.10
 
 ### Patch Changes

--- a/packages/internal.foundry.datasets/package.json
+++ b/packages/internal.foundry.datasets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.datasets",
-  "version": "0.2.0-beta.10",
+  "version": "0.2.0-beta.11",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.geo/CHANGELOG.md
+++ b/packages/internal.foundry.geo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/internal.foundry.geo
 
+## 0.1.0-beta.4
+
+### Minor Changes
+
+- 5d6d5ab: Use the "verb" where possible
+
 ## 0.1.0-beta.3
 
 ### Patch Changes

--- a/packages/internal.foundry.geo/package.json
+++ b/packages/internal.foundry.geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.geo",
-  "version": "0.1.0-beta.3",
+  "version": "0.1.0-beta.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.ontologies/CHANGELOG.md
+++ b/packages/internal.foundry.ontologies/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/internal.foundry.ontologies
 
+## 0.2.0-beta.11
+
+### Minor Changes
+
+- 5d6d5ab: Use the "verb" where possible
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+  - @osdk/internal.foundry.core@0.2.0-beta.11
+
 ## 0.2.0-beta.10
 
 ### Patch Changes

--- a/packages/internal.foundry.ontologies/package.json
+++ b/packages/internal.foundry.ontologies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.ontologies",
-  "version": "0.2.0-beta.10",
+  "version": "0.2.0-beta.11",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.ontologiesv2/CHANGELOG.md
+++ b/packages/internal.foundry.ontologiesv2/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/internal.foundry.ontologiesv2
 
+## 0.2.0-beta.11
+
+### Minor Changes
+
+- 5d6d5ab: Use the "verb" where possible
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+  - @osdk/internal.foundry.core@0.2.0-beta.11
+
 ## 0.2.0-beta.10
 
 ### Patch Changes

--- a/packages/internal.foundry.ontologiesv2/package.json
+++ b/packages/internal.foundry.ontologiesv2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.ontologiesv2",
-  "version": "0.2.0-beta.10",
+  "version": "0.2.0-beta.11",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry/CHANGELOG.md
+++ b/packages/internal.foundry/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @osdk/foundry
 
+## 0.5.0-beta.12
+
+### Minor Changes
+
+- 5d6d5ab: Use the "verb" where possible
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+  - @osdk/internal.foundry.ontologiesv2@0.2.0-beta.11
+  - @osdk/internal.foundry.ontologies@0.2.0-beta.11
+  - @osdk/internal.foundry.datasets@0.2.0-beta.11
+  - @osdk/internal.foundry.core@0.2.0-beta.11
+  - @osdk/internal.foundry.geo@0.1.0-beta.4
+
 ## 0.5.0-beta.11
 
 ### Patch Changes

--- a/packages/internal.foundry/package.json
+++ b/packages/internal.foundry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry",
-  "version": "0.5.0-beta.11",
+  "version": "0.5.0-beta.12",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/maker/CHANGELOG.md
+++ b/packages/maker/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/maker
 
+## 0.8.0-beta.13
+
+### Minor Changes
+
+- ee39a61: Adding value types to ont as code
+
+### Patch Changes
+
+- @osdk/api@2.0.0-beta.17
+
 ## 0.8.0-beta.12
 
 ### Minor Changes

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker",
-  "version": "0.8.0-beta.12",
+  "version": "0.8.0-beta.13",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/oauth/CHANGELOG.md
+++ b/packages/oauth/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/oauth
 
+## 1.0.0-beta.4
+
+### Major Changes
+
+- 7e90f77: Releasing first major version of oauth package.
+
 ## 0.4.0-beta.3
 
 ### Minor Changes

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/oauth",
-  "version": "0.4.0-beta.3",
+  "version": "1.0.0-beta.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/platform-sdk-generator/CHANGELOG.md
+++ b/packages/platform-sdk-generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/platform-sdk-generator
 
+## 0.5.0-beta.6
+
+### Minor Changes
+
+- 5d6d5ab: Use the "verb" where possible
+
 ## 0.5.0-beta.5
 
 ### Minor Changes

--- a/packages/platform-sdk-generator/package.json
+++ b/packages/platform-sdk-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/platform-sdk-generator",
   "private": true,
-  "version": "0.5.0-beta.5",
+  "version": "0.5.0-beta.6",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.test/CHANGELOG.md
+++ b/packages/shared.test/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/shared.test
 
+## 2.0.0-beta.13
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+  - @osdk/internal.foundry.ontologiesv2@0.2.0-beta.11
+  - @osdk/internal.foundry.ontologies@0.2.0-beta.11
+  - @osdk/internal.foundry.core@0.2.0-beta.11
+  - @osdk/internal.foundry.geo@0.1.0-beta.4
+  - @osdk/api@2.0.0-beta.17
+
 ## 2.0.0-beta.12
 
 ### Minor Changes

--- a/packages/shared.test/package.json
+++ b/packages/shared.test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/shared.test",
   "private": true,
-  "version": "2.0.0-beta.12",
+  "version": "2.0.0-beta.13",
   "description": "",
   "access": "private",
   "license": "Apache-2.0",

--- a/packages/tmp-foundry-sdk-generator/CHANGELOG.md
+++ b/packages/tmp-foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/foundry-sdk-generator
 
+## 2.0.0-beta.17
+
+### Patch Changes
+
+- Updated dependencies [5d6d5ab]
+  - @osdk/internal.foundry.ontologiesv2@0.2.0-beta.11
+  - @osdk/internal.foundry.ontologies@0.2.0-beta.11
+  - @osdk/internal.foundry.core@0.2.0-beta.11
+  - @osdk/client@2.0.0-beta.17
+  - @osdk/generator@2.0.0-beta.17
+  - @osdk/api@2.0.0-beta.17
+
 ## 2.0.0-beta.16
 
 ### Patch Changes

--- a/packages/tmp-foundry-sdk-generator/package.json
+++ b/packages/tmp-foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/tmp-foundry-sdk-generator",
-  "version": "2.0.0-beta.16",
+  "version": "2.0.0-beta.17",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/oauth@1.0.0-beta.4

### Major Changes

-   7e90f77: Releasing first major version of oauth package.

## @osdk/client.unstable@2.0.0-beta.17

### Minor Changes

-   ee39a61: Adding value types to ont as code

## @osdk/foundry.admin@2.1.0-beta.7

### Minor Changes

-   5d6d5ab: Use the "verb" where possible

### Patch Changes

-   Updated dependencies [5d6d5ab]
    -   @osdk/foundry.core@2.1.0-beta.7

## @osdk/foundry.core@2.1.0-beta.7

### Minor Changes

-   5d6d5ab: Use the "verb" where possible

## @osdk/foundry.datasets@2.1.0-beta.7

### Minor Changes

-   5d6d5ab: Use the "verb" where possible

### Patch Changes

-   Updated dependencies [5d6d5ab]
    -   @osdk/foundry.filesystem@2.1.0-beta.7
    -   @osdk/foundry.core@2.1.0-beta.7

## @osdk/foundry.filesystem@2.1.0-beta.7

### Minor Changes

-   5d6d5ab: Use the "verb" where possible

### Patch Changes

-   Updated dependencies [5d6d5ab]
    -   @osdk/foundry.core@2.1.0-beta.7

## @osdk/foundry.functions@2.1.0-beta.7

### Minor Changes

-   5d6d5ab: Use the "verb" where possible

### Patch Changes

-   Updated dependencies [5d6d5ab]
    -   @osdk/foundry.core@2.1.0-beta.7

## @osdk/foundry.ontologies@2.1.0-beta.7

### Minor Changes

-   5d6d5ab: Use the "verb" where possible

## @osdk/foundry.orchestration@2.1.0-beta.7

### Minor Changes

-   5d6d5ab: Use the "verb" where possible

### Patch Changes

-   Updated dependencies [5d6d5ab]
    -   @osdk/foundry.filesystem@2.1.0-beta.7
    -   @osdk/foundry.datasets@2.1.0-beta.7
    -   @osdk/foundry.core@2.1.0-beta.7

## @osdk/foundry.publicapis@2.1.0-beta.7

### Minor Changes

-   5d6d5ab: Use the "verb" where possible

### Patch Changes

-   Updated dependencies [5d6d5ab]
    -   @osdk/foundry.core@2.1.0-beta.7

## @osdk/foundry.streams@2.1.0-beta.7

### Minor Changes

-   5d6d5ab: Use the "verb" where possible

### Patch Changes

-   Updated dependencies [5d6d5ab]
    -   @osdk/foundry.filesystem@2.1.0-beta.7
    -   @osdk/foundry.datasets@2.1.0-beta.7
    -   @osdk/foundry.core@2.1.0-beta.7

## @osdk/foundry.thirdpartyapplications@2.1.0-beta.7

### Minor Changes

-   5d6d5ab: Use the "verb" where possible

### Patch Changes

-   Updated dependencies [5d6d5ab]
    -   @osdk/foundry.core@2.1.0-beta.7

## @osdk/internal.foundry@0.5.0-beta.12

### Minor Changes

-   5d6d5ab: Use the "verb" where possible

### Patch Changes

-   Updated dependencies [5d6d5ab]
    -   @osdk/internal.foundry.ontologiesv2@0.2.0-beta.11
    -   @osdk/internal.foundry.ontologies@0.2.0-beta.11
    -   @osdk/internal.foundry.datasets@0.2.0-beta.11
    -   @osdk/internal.foundry.core@0.2.0-beta.11
    -   @osdk/internal.foundry.geo@0.1.0-beta.4

## @osdk/internal.foundry.core@0.2.0-beta.11

### Minor Changes

-   5d6d5ab: Use the "verb" where possible

### Patch Changes

-   Updated dependencies [5d6d5ab]
    -   @osdk/internal.foundry.geo@0.1.0-beta.4

## @osdk/internal.foundry.datasets@0.2.0-beta.11

### Minor Changes

-   5d6d5ab: Use the "verb" where possible

### Patch Changes

-   Updated dependencies [5d6d5ab]
    -   @osdk/internal.foundry.core@0.2.0-beta.11

## @osdk/internal.foundry.geo@0.1.0-beta.4

### Minor Changes

-   5d6d5ab: Use the "verb" where possible

## @osdk/internal.foundry.ontologies@0.2.0-beta.11

### Minor Changes

-   5d6d5ab: Use the "verb" where possible

### Patch Changes

-   Updated dependencies [5d6d5ab]
    -   @osdk/internal.foundry.core@0.2.0-beta.11

## @osdk/internal.foundry.ontologiesv2@0.2.0-beta.11

### Minor Changes

-   5d6d5ab: Use the "verb" where possible

### Patch Changes

-   Updated dependencies [5d6d5ab]
    -   @osdk/internal.foundry.core@0.2.0-beta.11

## @osdk/maker@0.8.0-beta.13

### Minor Changes

-   ee39a61: Adding value types to ont as code

### Patch Changes

-   @osdk/api@2.0.0-beta.17

## @osdk/cli@0.24.0-beta.16

### Patch Changes

-   @osdk/generator@2.0.0-beta.17

## @osdk/client@2.0.0-beta.17

### Patch Changes

-   Updated dependencies [5d6d5ab]
-   Updated dependencies [ee39a61]
    -   @osdk/internal.foundry.ontologiesv2@0.2.0-beta.11
    -   @osdk/internal.foundry.core@0.2.0-beta.11
    -   @osdk/client.unstable@2.0.0-beta.17
    -   @osdk/generator-converters@2.0.0-beta.17
    -   @osdk/api@2.0.0-beta.17

## @osdk/foundry@2.1.0-beta.7

### Patch Changes

-   Updated dependencies [5d6d5ab]
    -   @osdk/foundry.thirdpartyapplications@2.1.0-beta.7
    -   @osdk/foundry.orchestration@2.1.0-beta.7
    -   @osdk/foundry.filesystem@2.1.0-beta.7
    -   @osdk/foundry.ontologies@2.1.0-beta.7
    -   @osdk/foundry.publicapis@2.1.0-beta.7
    -   @osdk/foundry.functions@2.1.0-beta.7
    -   @osdk/foundry.datasets@2.1.0-beta.7
    -   @osdk/foundry.streams@2.1.0-beta.7
    -   @osdk/foundry.admin@2.1.0-beta.7
    -   @osdk/foundry.core@2.1.0-beta.7

## @osdk/generator@2.0.0-beta.17

### Patch Changes

-   Updated dependencies [5d6d5ab]
    -   @osdk/internal.foundry.core@0.2.0-beta.11
    -   @osdk/generator-converters@2.0.0-beta.17
    -   @osdk/api@2.0.0-beta.17

## @osdk/generator-converters@2.0.0-beta.17

### Patch Changes

-   Updated dependencies [5d6d5ab]
    -   @osdk/internal.foundry.core@0.2.0-beta.11
    -   @osdk/api@2.0.0-beta.17

## @osdk/tmp-foundry-sdk-generator@2.0.0-beta.17

### Patch Changes

-   Updated dependencies [5d6d5ab]
    -   @osdk/internal.foundry.ontologiesv2@0.2.0-beta.11
    -   @osdk/internal.foundry.ontologies@0.2.0-beta.11
    -   @osdk/internal.foundry.core@0.2.0-beta.11
    -   @osdk/client@2.0.0-beta.17
    -   @osdk/generator@2.0.0-beta.17
    -   @osdk/api@2.0.0-beta.17

## @osdk/api@2.0.0-beta.17



## @osdk/platform-sdk-generator@0.5.0-beta.6

### Minor Changes

-   5d6d5ab: Use the "verb" where possible

## @osdk/cli.cmd.typescript@0.6.0-beta.16

### Patch Changes

-   Updated dependencies [5d6d5ab]
    -   @osdk/internal.foundry.ontologiesv2@0.2.0-beta.11
    -   @osdk/internal.foundry.core@0.2.0-beta.11
    -   @osdk/generator@2.0.0-beta.17

## @osdk/client.test.ontology@2.0.0-beta.17

### Patch Changes

-   @osdk/api@2.0.0-beta.17

## @osdk/shared.test@2.0.0-beta.13

### Patch Changes

-   Updated dependencies [5d6d5ab]
    -   @osdk/internal.foundry.ontologiesv2@0.2.0-beta.11
    -   @osdk/internal.foundry.ontologies@0.2.0-beta.11
    -   @osdk/internal.foundry.core@0.2.0-beta.11
    -   @osdk/internal.foundry.geo@0.1.0-beta.4
    -   @osdk/api@2.0.0-beta.17
