### PR TITLE
Version Packages

### DIFF
--- a/.changeset/mean-chicken-arrive.md
+++ b/.changeset/mean-chicken-arrive.md
@@ -1,5 +1,0 @@
----
-"@osdk/shared.client": patch
----
-
-Actually publish the d.ts file

--- a/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.0.0';
+export type $ExpectedClientVersion = '2.1.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/api
 
+## 2.1.0
+
+### Patch Changes
+
+- @osdk/shared.net@2.1.0
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/api",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/cli.cmd.typescript
 
+## 0.7.0
+
+### Patch Changes
+
+- @osdk/internal.foundry.core@0.3.0
+- @osdk/internal.foundry.ontologiesv2@0.3.0
+- @osdk/shared.net@2.1.0
+- @osdk/generator@2.1.0
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/cli
 
+## 0.25.0
+
+### Patch Changes
+
+- @osdk/shared.net@2.1.0
+- @osdk/generator@2.1.0
+
 ## 0.24.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client.test.ontology/CHANGELOG.md
+++ b/packages/client.test.ontology/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/client.test.ontology
 
+## 2.1.0
+
+### Patch Changes
+
+- @osdk/api@2.1.0
+
 ## 2.0.0
 
 ### Minor Changes

--- a/packages/client.test.ontology/package.json
+++ b/packages/client.test.ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/client.test.ontology",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.unstable/CHANGELOG.md
+++ b/packages/client.unstable/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/client.unstable
 
+## 2.1.0
+
 ## 2.0.0
 
 ### Minor Changes

--- a/packages/client.unstable/package.json
+++ b/packages/client.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.unstable",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/client
 
+## 2.1.0
+
+### Patch Changes
+
+- Updated dependencies [a4343af]
+  - @osdk/shared.client@1.1.0
+  - @osdk/internal.foundry.core@0.3.0
+  - @osdk/internal.foundry.ontologiesv2@0.3.0
+  - @osdk/shared.client.impl@1.1.0
+  - @osdk/generator-converters@2.1.0
+  - @osdk/api@2.1.0
+  - @osdk/client.unstable@2.1.0
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -114,7 +114,7 @@ export interface Client extends SharedClient<MinimalClient> {
 }
 
 // BEGIN: THIS IS GENERATED CODE. DO NOT EDIT.
-const MaxOsdkVersion = "2.0.0";
+const MaxOsdkVersion = "2.1.0";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 export type MaxOsdkVersion = typeof MaxOsdkVersion;
 const ErrorMessage = Symbol("ErrorMessage");

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,2 +1,2 @@
-export type $ExpectedClientVersion = '2.0.0';
+export type $ExpectedClientVersion = '2.1.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.0.0';
+export type $ExpectedClientVersion = '2.1.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.dep';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.0.0';
+export type $ExpectedClientVersion = '2.1.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/OntologyMetadata.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.0.0';
+export type $ExpectedClientVersion = '2.1.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';

--- a/packages/foundry.admin/CHANGELOG.md
+++ b/packages/foundry.admin/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/foundry.admin
 
+## 2.2.0
+
+### Patch Changes
+
+- Updated dependencies [a4343af]
+  - @osdk/shared.client@1.1.0
+  - @osdk/foundry.core@2.2.0
+  - @osdk/shared.net.platformapi@0.4.0
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/foundry.admin/package.json
+++ b/packages/foundry.admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.admin",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.core/CHANGELOG.md
+++ b/packages/foundry.core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/foundry.core
 
+## 2.2.0
+
+### Patch Changes
+
+- Updated dependencies [a4343af]
+  - @osdk/shared.client@1.1.0
+  - @osdk/shared.net.platformapi@0.4.0
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/foundry.core/package.json
+++ b/packages/foundry.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.core",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.datasets/CHANGELOG.md
+++ b/packages/foundry.datasets/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/foundry.datasets
 
+## 2.2.0
+
+### Patch Changes
+
+- Updated dependencies [a4343af]
+  - @osdk/shared.client@1.1.0
+  - @osdk/foundry.core@2.2.0
+  - @osdk/foundry.filesystem@2.2.0
+  - @osdk/shared.net.platformapi@0.4.0
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/foundry.datasets/package.json
+++ b/packages/foundry.datasets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.datasets",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.filesystem/CHANGELOG.md
+++ b/packages/foundry.filesystem/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/foundry.filesystem
 
+## 2.2.0
+
+### Patch Changes
+
+- Updated dependencies [a4343af]
+  - @osdk/shared.client@1.1.0
+  - @osdk/foundry.core@2.2.0
+  - @osdk/shared.net.platformapi@0.4.0
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/foundry.filesystem/package.json
+++ b/packages/foundry.filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.filesystem",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.functions/CHANGELOG.md
+++ b/packages/foundry.functions/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/foundry.functions
 
+## 2.2.0
+
+### Patch Changes
+
+- Updated dependencies [a4343af]
+  - @osdk/shared.client@1.1.0
+  - @osdk/foundry.core@2.2.0
+  - @osdk/shared.net.platformapi@0.4.0
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/foundry.functions/package.json
+++ b/packages/foundry.functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.functions",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.ontologies/CHANGELOG.md
+++ b/packages/foundry.ontologies/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/foundry.ontologies
 
+## 2.2.0
+
+### Patch Changes
+
+- Updated dependencies [a4343af]
+  - @osdk/shared.client@1.1.0
+  - @osdk/shared.net.platformapi@0.4.0
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/foundry.ontologies/package.json
+++ b/packages/foundry.ontologies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.ontologies",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.orchestration/CHANGELOG.md
+++ b/packages/foundry.orchestration/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/foundry.orchestration
 
+## 2.2.0
+
+### Patch Changes
+
+- Updated dependencies [a4343af]
+  - @osdk/shared.client@1.1.0
+  - @osdk/foundry.core@2.2.0
+  - @osdk/foundry.datasets@2.2.0
+  - @osdk/foundry.filesystem@2.2.0
+  - @osdk/shared.net.platformapi@0.4.0
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/foundry.orchestration/package.json
+++ b/packages/foundry.orchestration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.orchestration",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.publicapis/CHANGELOG.md
+++ b/packages/foundry.publicapis/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/foundry.publicapis
 
+## 2.2.0
+
+### Patch Changes
+
+- Updated dependencies [a4343af]
+  - @osdk/shared.client@1.1.0
+  - @osdk/foundry.core@2.2.0
+  - @osdk/shared.net.platformapi@0.4.0
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/foundry.publicapis/package.json
+++ b/packages/foundry.publicapis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.publicapis",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.streams/CHANGELOG.md
+++ b/packages/foundry.streams/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/foundry.streams
 
+## 2.2.0
+
+### Patch Changes
+
+- Updated dependencies [a4343af]
+  - @osdk/shared.client@1.1.0
+  - @osdk/foundry.core@2.2.0
+  - @osdk/foundry.datasets@2.2.0
+  - @osdk/foundry.filesystem@2.2.0
+  - @osdk/shared.net.platformapi@0.4.0
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/foundry.streams/package.json
+++ b/packages/foundry.streams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.streams",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.thirdpartyapplications/CHANGELOG.md
+++ b/packages/foundry.thirdpartyapplications/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/foundry.thirdpartyapplications
 
+## 2.2.0
+
+### Patch Changes
+
+- Updated dependencies [a4343af]
+  - @osdk/shared.client@1.1.0
+  - @osdk/foundry.core@2.2.0
+  - @osdk/shared.net.platformapi@0.4.0
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/foundry.thirdpartyapplications/package.json
+++ b/packages/foundry.thirdpartyapplications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.thirdpartyapplications",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry/CHANGELOG.md
+++ b/packages/foundry/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @osdk/foundry
 
+## 2.2.0
+
+### Patch Changes
+
+- Updated dependencies [a4343af]
+  - @osdk/shared.client@1.1.0
+  - @osdk/foundry.admin@2.2.0
+  - @osdk/foundry.core@2.2.0
+  - @osdk/foundry.datasets@2.2.0
+  - @osdk/foundry.filesystem@2.2.0
+  - @osdk/foundry.functions@2.2.0
+  - @osdk/foundry.ontologies@2.2.0
+  - @osdk/foundry.orchestration@2.2.0
+  - @osdk/foundry.publicapis@2.2.0
+  - @osdk/foundry.streams@2.2.0
+  - @osdk/foundry.thirdpartyapplications@2.2.0
+  - @osdk/shared.net.platformapi@0.4.0
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/foundry/package.json
+++ b/packages/foundry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/generator-converters/CHANGELOG.md
+++ b/packages/generator-converters/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/generator-converters
 
+## 2.1.0
+
+### Patch Changes
+
+- @osdk/internal.foundry.core@0.3.0
+- @osdk/api@2.1.0
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/generator-converters/package.json
+++ b/packages/generator-converters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-converters",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/generator
 
+## 2.1.0
+
+### Patch Changes
+
+- @osdk/internal.foundry.core@0.3.0
+- @osdk/generator-converters@2.1.0
+- @osdk/api@2.1.0
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator/src/v2.0/generateMetadata.ts
+++ b/packages/generator/src/v2.0/generateMetadata.ts
@@ -19,7 +19,7 @@ import type { GenerateContext } from "../GenerateContext/GenerateContext.js";
 import { formatTs } from "../util/test/formatTs.js";
 
 // BEGIN: THIS IS GENERATED CODE. DO NOT EDIT.
-const ExpectedOsdkVersion = "2.0.0";
+const ExpectedOsdkVersion = "2.1.0";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 
 export async function generateOntologyMetadataFile(

--- a/packages/internal.foundry.core/CHANGELOG.md
+++ b/packages/internal.foundry.core/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/internal.foundry.core
 
+## 0.3.0
+
+### Patch Changes
+
+- Updated dependencies [a4343af]
+  - @osdk/shared.client@1.1.0
+  - @osdk/internal.foundry.geo@0.2.0
+  - @osdk/shared.net.platformapi@0.4.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/internal.foundry.core/package.json
+++ b/packages/internal.foundry.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.datasets/CHANGELOG.md
+++ b/packages/internal.foundry.datasets/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/internal.foundry.datasets
 
+## 0.3.0
+
+### Patch Changes
+
+- Updated dependencies [a4343af]
+  - @osdk/shared.client@1.1.0
+  - @osdk/internal.foundry.core@0.3.0
+  - @osdk/shared.net.platformapi@0.4.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/internal.foundry.datasets/package.json
+++ b/packages/internal.foundry.datasets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.datasets",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.geo/CHANGELOG.md
+++ b/packages/internal.foundry.geo/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/internal.foundry.geo
 
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [a4343af]
+  - @osdk/shared.client@1.1.0
+  - @osdk/shared.net.platformapi@0.4.0
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/internal.foundry.geo/package.json
+++ b/packages/internal.foundry.geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.geo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.ontologies/CHANGELOG.md
+++ b/packages/internal.foundry.ontologies/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/internal.foundry.ontologies
 
+## 0.3.0
+
+### Patch Changes
+
+- Updated dependencies [a4343af]
+  - @osdk/shared.client@1.1.0
+  - @osdk/internal.foundry.core@0.3.0
+  - @osdk/shared.net.platformapi@0.4.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/internal.foundry.ontologies/package.json
+++ b/packages/internal.foundry.ontologies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.ontologies",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.ontologiesv2/CHANGELOG.md
+++ b/packages/internal.foundry.ontologiesv2/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/internal.foundry.ontologiesv2
 
+## 0.3.0
+
+### Patch Changes
+
+- Updated dependencies [a4343af]
+  - @osdk/shared.client@1.1.0
+  - @osdk/internal.foundry.core@0.3.0
+  - @osdk/shared.net.platformapi@0.4.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/internal.foundry.ontologiesv2/package.json
+++ b/packages/internal.foundry.ontologiesv2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.ontologiesv2",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry/CHANGELOG.md
+++ b/packages/internal.foundry/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/foundry
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies [a4343af]
+  - @osdk/shared.client@1.1.0
+  - @osdk/internal.foundry.core@0.3.0
+  - @osdk/internal.foundry.datasets@0.3.0
+  - @osdk/internal.foundry.geo@0.2.0
+  - @osdk/internal.foundry.ontologies@0.3.0
+  - @osdk/internal.foundry.ontologiesv2@0.3.0
+  - @osdk/shared.net.platformapi@0.4.0
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/internal.foundry/package.json
+++ b/packages/internal.foundry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/maker/CHANGELOG.md
+++ b/packages/maker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/maker
 
+## 0.9.0
+
+### Patch Changes
+
+- @osdk/api@2.1.0
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.client.impl/CHANGELOG.md
+++ b/packages/shared.client.impl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/shared.client.impl
 
+## 1.1.0
+
+### Patch Changes
+
+- Updated dependencies [a4343af]
+  - @osdk/shared.client@1.1.0
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/shared.client.impl/package.json
+++ b/packages/shared.client.impl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/shared.client.impl",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.client/CHANGELOG.md
+++ b/packages/shared.client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/shared.client
 
+## 1.1.0
+
+### Minor Changes
+
+- a4343af: Actually publish the d.ts file
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/shared.client/package.json
+++ b/packages/shared.client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/shared.client",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.net.platformapi/CHANGELOG.md
+++ b/packages/shared.net.platformapi/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/shared.net.platformapi
 
+## 0.4.0
+
+### Patch Changes
+
+- Updated dependencies [a4343af]
+  - @osdk/shared.client@1.1.0
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/shared.net.platformapi/package.json
+++ b/packages/shared.net.platformapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/shared.net.platformapi",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.net/CHANGELOG.md
+++ b/packages/shared.net/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/shared.net
 
+## 2.1.0
+
+### Patch Changes
+
+- Updated dependencies [a4343af]
+  - @osdk/shared.client@1.1.0
+  - @osdk/shared.client.impl@1.1.0
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/shared.net/package.json
+++ b/packages/shared.net/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/shared.net",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/shared.test/CHANGELOG.md
+++ b/packages/shared.test/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/shared.test
 
+## 2.1.0
+
+### Patch Changes
+
+- @osdk/internal.foundry.core@0.3.0
+- @osdk/internal.foundry.geo@0.2.0
+- @osdk/internal.foundry.ontologies@0.3.0
+- @osdk/internal.foundry.ontologiesv2@0.3.0
+- @osdk/api@2.1.0
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/shared.test/package.json
+++ b/packages/shared.test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/shared.test",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "",
   "access": "private",
   "license": "Apache-2.0",

--- a/packages/tmp-foundry-sdk-generator/CHANGELOG.md
+++ b/packages/tmp-foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/foundry-sdk-generator
 
+## 2.1.0
+
+### Patch Changes
+
+- @osdk/client@2.1.0
+- @osdk/internal.foundry.core@0.3.0
+- @osdk/internal.foundry.ontologies@0.3.0
+- @osdk/internal.foundry.ontologiesv2@0.3.0
+- @osdk/shared.net@2.1.0
+- @osdk/generator@2.1.0
+- @osdk/api@2.1.0
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/tmp-foundry-sdk-generator/package.json
+++ b/packages/tmp-foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/tmp-foundry-sdk-generator",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.


# Releases
## @osdk/shared.client@1.1.0

### Minor Changes

-   a4343af: Actually publish the d.ts file

## @osdk/api@2.1.0

### Patch Changes

-   @osdk/shared.net@2.1.0

## @osdk/cli@0.25.0

### Patch Changes

-   @osdk/shared.net@2.1.0
-   @osdk/generator@2.1.0

## @osdk/client@2.1.0

### Patch Changes

-   Updated dependencies [a4343af]
    -   @osdk/shared.client@1.1.0
    -   @osdk/internal.foundry.core@0.3.0
    -   @osdk/internal.foundry.ontologiesv2@0.3.0
    -   @osdk/shared.client.impl@1.1.0
    -   @osdk/generator-converters@2.1.0
    -   @osdk/api@2.1.0
    -   @osdk/client.unstable@2.1.0

## @osdk/foundry@2.2.0

### Patch Changes

-   Updated dependencies [a4343af]
    -   @osdk/shared.client@1.1.0
    -   @osdk/foundry.admin@2.2.0
    -   @osdk/foundry.core@2.2.0
    -   @osdk/foundry.datasets@2.2.0
    -   @osdk/foundry.filesystem@2.2.0
    -   @osdk/foundry.functions@2.2.0
    -   @osdk/foundry.ontologies@2.2.0
    -   @osdk/foundry.orchestration@2.2.0
    -   @osdk/foundry.publicapis@2.2.0
    -   @osdk/foundry.streams@2.2.0
    -   @osdk/foundry.thirdpartyapplications@2.2.0
    -   @osdk/shared.net.platformapi@0.4.0

## @osdk/foundry.admin@2.2.0

### Patch Changes

-   Updated dependencies [a4343af]
    -   @osdk/shared.client@1.1.0
    -   @osdk/foundry.core@2.2.0
    -   @osdk/shared.net.platformapi@0.4.0

## @osdk/foundry.core@2.2.0

### Patch Changes

-   Updated dependencies [a4343af]
    -   @osdk/shared.client@1.1.0
    -   @osdk/shared.net.platformapi@0.4.0

## @osdk/foundry.datasets@2.2.0

### Patch Changes

-   Updated dependencies [a4343af]
    -   @osdk/shared.client@1.1.0
    -   @osdk/foundry.core@2.2.0
    -   @osdk/foundry.filesystem@2.2.0
    -   @osdk/shared.net.platformapi@0.4.0

## @osdk/foundry.filesystem@2.2.0

### Patch Changes

-   Updated dependencies [a4343af]
    -   @osdk/shared.client@1.1.0
    -   @osdk/foundry.core@2.2.0
    -   @osdk/shared.net.platformapi@0.4.0

## @osdk/foundry.functions@2.2.0

### Patch Changes

-   Updated dependencies [a4343af]
    -   @osdk/shared.client@1.1.0
    -   @osdk/foundry.core@2.2.0
    -   @osdk/shared.net.platformapi@0.4.0

## @osdk/foundry.ontologies@2.2.0

### Patch Changes

-   Updated dependencies [a4343af]
    -   @osdk/shared.client@1.1.0
    -   @osdk/shared.net.platformapi@0.4.0

## @osdk/foundry.orchestration@2.2.0

### Patch Changes

-   Updated dependencies [a4343af]
    -   @osdk/shared.client@1.1.0
    -   @osdk/foundry.core@2.2.0
    -   @osdk/foundry.datasets@2.2.0
    -   @osdk/foundry.filesystem@2.2.0
    -   @osdk/shared.net.platformapi@0.4.0

## @osdk/foundry.publicapis@2.2.0

### Patch Changes

-   Updated dependencies [a4343af]
    -   @osdk/shared.client@1.1.0
    -   @osdk/foundry.core@2.2.0
    -   @osdk/shared.net.platformapi@0.4.0

## @osdk/foundry.streams@2.2.0

### Patch Changes

-   Updated dependencies [a4343af]
    -   @osdk/shared.client@1.1.0
    -   @osdk/foundry.core@2.2.0
    -   @osdk/foundry.datasets@2.2.0
    -   @osdk/foundry.filesystem@2.2.0
    -   @osdk/shared.net.platformapi@0.4.0

## @osdk/foundry.thirdpartyapplications@2.2.0

### Patch Changes

-   Updated dependencies [a4343af]
    -   @osdk/shared.client@1.1.0
    -   @osdk/foundry.core@2.2.0
    -   @osdk/shared.net.platformapi@0.4.0

## @osdk/generator@2.1.0

### Patch Changes

-   @osdk/internal.foundry.core@0.3.0
-   @osdk/generator-converters@2.1.0
-   @osdk/api@2.1.0

## @osdk/generator-converters@2.1.0

### Patch Changes

-   @osdk/internal.foundry.core@0.3.0
-   @osdk/api@2.1.0

## @osdk/internal.foundry@0.6.0

### Patch Changes

-   Updated dependencies [a4343af]
    -   @osdk/shared.client@1.1.0
    -   @osdk/internal.foundry.core@0.3.0
    -   @osdk/internal.foundry.datasets@0.3.0
    -   @osdk/internal.foundry.geo@0.2.0
    -   @osdk/internal.foundry.ontologies@0.3.0
    -   @osdk/internal.foundry.ontologiesv2@0.3.0
    -   @osdk/shared.net.platformapi@0.4.0

## @osdk/internal.foundry.core@0.3.0

### Patch Changes

-   Updated dependencies [a4343af]
    -   @osdk/shared.client@1.1.0
    -   @osdk/internal.foundry.geo@0.2.0
    -   @osdk/shared.net.platformapi@0.4.0

## @osdk/internal.foundry.datasets@0.3.0

### Patch Changes

-   Updated dependencies [a4343af]
    -   @osdk/shared.client@1.1.0
    -   @osdk/internal.foundry.core@0.3.0
    -   @osdk/shared.net.platformapi@0.4.0

## @osdk/internal.foundry.geo@0.2.0

### Patch Changes

-   Updated dependencies [a4343af]
    -   @osdk/shared.client@1.1.0
    -   @osdk/shared.net.platformapi@0.4.0

## @osdk/internal.foundry.ontologies@0.3.0

### Patch Changes

-   Updated dependencies [a4343af]
    -   @osdk/shared.client@1.1.0
    -   @osdk/internal.foundry.core@0.3.0
    -   @osdk/shared.net.platformapi@0.4.0

## @osdk/internal.foundry.ontologiesv2@0.3.0

### Patch Changes

-   Updated dependencies [a4343af]
    -   @osdk/shared.client@1.1.0
    -   @osdk/internal.foundry.core@0.3.0
    -   @osdk/shared.net.platformapi@0.4.0

## @osdk/maker@0.9.0

### Patch Changes

-   @osdk/api@2.1.0

## @osdk/shared.client.impl@1.1.0

### Patch Changes

-   Updated dependencies [a4343af]
    -   @osdk/shared.client@1.1.0

## @osdk/shared.net@2.1.0

### Patch Changes

-   Updated dependencies [a4343af]
    -   @osdk/shared.client@1.1.0
    -   @osdk/shared.client.impl@1.1.0

## @osdk/shared.net.platformapi@0.4.0

### Patch Changes

-   Updated dependencies [a4343af]
    -   @osdk/shared.client@1.1.0

## @osdk/tmp-foundry-sdk-generator@2.1.0

### Patch Changes

-   @osdk/client@2.1.0
-   @osdk/internal.foundry.core@0.3.0
-   @osdk/internal.foundry.ontologies@0.3.0
-   @osdk/internal.foundry.ontologiesv2@0.3.0
-   @osdk/shared.net@2.1.0
-   @osdk/generator@2.1.0
-   @osdk/api@2.1.0

## @osdk/client.unstable@2.1.0



## @osdk/cli.cmd.typescript@0.7.0

### Patch Changes

-   @osdk/internal.foundry.core@0.3.0
-   @osdk/internal.foundry.ontologiesv2@0.3.0
-   @osdk/shared.net@2.1.0
-   @osdk/generator@2.1.0

## @osdk/client.test.ontology@2.1.0

### Patch Changes

-   @osdk/api@2.1.0

## @osdk/shared.test@2.1.0

### Patch Changes

-   @osdk/internal.foundry.core@0.3.0
-   @osdk/internal.foundry.geo@0.2.0
-   @osdk/internal.foundry.ontologies@0.3.0
-   @osdk/internal.foundry.ontologiesv2@0.3.0
-   @osdk/api@2.1.0
