### PR TITLE
Set base branch for changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,7 +16,7 @@
   ],
   "linked": [],
   "access": "restricted",
-  "baseBranch": "main",
+  "baseBranch": "release/2.0.x",
   "updateInternalDependencies": "patch",
   "ignore": [
     "@osdk/examples.*",


### PR DESCRIPTION
I think this saying `main` is why `release/1.3.x` always tells us everything has changed.