### PR TITLE
Version Packages (rc)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -77,5 +77,7 @@
     "@osdk/version-updater": "0.0.0",
     "@osdk/tests.verify-fallback-package-v2": "0.0.3"
   },
-  "changesets": []
+  "changesets": [
+    "little-months-join"
+  ]
 }

--- a/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.0.1';
+export type $ExpectedClientVersion = '2.0.2';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/api
 
+## 2.0.2-rc.0
+
 ## 2.0.1
 
 ### Patch Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/api",
-  "version": "2.0.1",
+  "version": "2.0.2-rc.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/cli.cmd.typescript
 
+## 0.6.2-rc.0
+
+### Patch Changes
+
+- @osdk/generator@2.0.2-rc.0
+
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.2-rc.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/cli
 
+## 0.24.2-rc.0
+
+### Patch Changes
+
+- @osdk/generator@2.0.2-rc.0
+
 ## 0.24.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.24.1",
+  "version": "0.24.2-rc.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client.test.ontology/CHANGELOG.md
+++ b/packages/client.test.ontology/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/client.test.ontology
 
+## 2.0.2-rc.0
+
+### Patch Changes
+
+- @osdk/api@2.0.2-rc.0
+
 ## 2.0.1
 
 ### Patch Changes

--- a/packages/client.test.ontology/package.json
+++ b/packages/client.test.ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/client.test.ontology",
   "private": true,
-  "version": "2.0.1",
+  "version": "2.0.2-rc.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.unstable/CHANGELOG.md
+++ b/packages/client.unstable/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/client.unstable
 
+## 2.0.2-rc.0
+
 ## 2.0.1
 
 ## 2.0.0

--- a/packages/client.unstable/package.json
+++ b/packages/client.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.unstable",
-  "version": "2.0.1",
+  "version": "2.0.2-rc.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/client
 
+## 2.0.2-rc.0
+
+### Patch Changes
+
+- @osdk/generator-converters@2.0.2-rc.0
+- @osdk/client.unstable@2.0.2-rc.0
+- @osdk/api@2.0.2-rc.0
+
 ## 2.0.1
 
 ### Patch Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client",
-  "version": "2.0.1",
+  "version": "2.0.2-rc.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -114,7 +114,7 @@ export interface Client extends SharedClient<MinimalClient> {
 }
 
 // BEGIN: THIS IS GENERATED CODE. DO NOT EDIT.
-const MaxOsdkVersion = "2.0.1";
+const MaxOsdkVersion = "2.0.2";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 export type MaxOsdkVersion = typeof MaxOsdkVersion;
 const ErrorMessage = Symbol("ErrorMessage");

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,2 +1,2 @@
-export type $ExpectedClientVersion = '2.0.1';
+export type $ExpectedClientVersion = '2.0.2';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.0.1';
+export type $ExpectedClientVersion = '2.0.2';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.dep';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.0.1';
+export type $ExpectedClientVersion = '2.0.2';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/OntologyMetadata.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.0.1';
+export type $ExpectedClientVersion = '2.0.2';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';

--- a/packages/generator-converters/CHANGELOG.md
+++ b/packages/generator-converters/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/generator-converters
 
+## 2.0.2-rc.0
+
+### Patch Changes
+
+- @osdk/api@2.0.2-rc.0
+
 ## 2.0.1
 
 ### Patch Changes

--- a/packages/generator-converters/package.json
+++ b/packages/generator-converters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-converters",
-  "version": "2.0.1",
+  "version": "2.0.2-rc.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/generator
 
+## 2.0.2-rc.0
+
+### Patch Changes
+
+- @osdk/generator-converters@2.0.2-rc.0
+- @osdk/api@2.0.2-rc.0
+
 ## 2.0.1
 
 ### Patch Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "2.0.1",
+  "version": "2.0.2-rc.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator/src/v2.0/generateMetadata.ts
+++ b/packages/generator/src/v2.0/generateMetadata.ts
@@ -19,7 +19,7 @@ import type { GenerateContext } from "../GenerateContext/GenerateContext.js";
 import { formatTs } from "../util/test/formatTs.js";
 
 // BEGIN: THIS IS GENERATED CODE. DO NOT EDIT.
-const ExpectedOsdkVersion = "2.0.1";
+const ExpectedOsdkVersion = "2.0.2";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 
 export async function generateOntologyMetadataFile(

--- a/packages/maker/CHANGELOG.md
+++ b/packages/maker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/maker
 
+## 0.8.2-rc.0
+
+### Patch Changes
+
+- @osdk/api@2.0.2-rc.0
+
 ## 0.8.1
 
 ### Patch Changes

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker",
-  "version": "0.8.1",
+  "version": "0.8.2-rc.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.test/CHANGELOG.md
+++ b/packages/shared.test/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/shared.test
 
+## 2.0.2-rc.0
+
+### Patch Changes
+
+- @osdk/api@2.0.2-rc.0
+
 ## 2.0.1
 
 ### Patch Changes

--- a/packages/shared.test/package.json
+++ b/packages/shared.test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/shared.test",
   "private": true,
-  "version": "2.0.1",
+  "version": "2.0.2-rc.0",
   "description": "",
   "access": "private",
   "license": "Apache-2.0",

--- a/packages/tmp-foundry-sdk-generator/CHANGELOG.md
+++ b/packages/tmp-foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/foundry-sdk-generator
 
+## 2.0.2-rc.0
+
+### Patch Changes
+
+- 85e03ec: Prepare foundry-sdk-generator for GA
+  - @osdk/client@2.0.2-rc.0
+  - @osdk/generator@2.0.2-rc.0
+  - @osdk/api@2.0.2-rc.0
+
 ## 2.0.1
 
 ### Patch Changes

--- a/packages/tmp-foundry-sdk-generator/package.json
+++ b/packages/tmp-foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/tmp-foundry-sdk-generator",
-  "version": "2.0.1",
+  "version": "2.0.2-rc.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/2.0.x, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`release/2.0.x` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `release/2.0.x`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/cli@0.24.2-rc.0

### Patch Changes

-   @osdk/generator@2.0.2-rc.0

## @osdk/client@2.0.2-rc.0

### Patch Changes

-   @osdk/generator-converters@2.0.2-rc.0
-   @osdk/client.unstable@2.0.2-rc.0
-   @osdk/api@2.0.2-rc.0

## @osdk/generator@2.0.2-rc.0

### Patch Changes

-   @osdk/generator-converters@2.0.2-rc.0
-   @osdk/api@2.0.2-rc.0

## @osdk/generator-converters@2.0.2-rc.0

### Patch Changes

-   @osdk/api@2.0.2-rc.0

## @osdk/maker@0.8.2-rc.0

### Patch Changes

-   @osdk/api@2.0.2-rc.0

## @osdk/tmp-foundry-sdk-generator@2.0.2-rc.0

### Patch Changes

-   85e03ec: Prepare foundry-sdk-generator for GA
    -   @osdk/client@2.0.2-rc.0
    -   @osdk/generator@2.0.2-rc.0
    -   @osdk/api@2.0.2-rc.0

## @osdk/api@2.0.2-rc.0



## @osdk/client.unstable@2.0.2-rc.0



## @osdk/cli.cmd.typescript@0.6.2-rc.0

### Patch Changes

-   @osdk/generator@2.0.2-rc.0

## @osdk/client.test.ontology@2.0.2-rc.0

### Patch Changes

-   @osdk/api@2.0.2-rc.0

## @osdk/shared.test@2.0.2-rc.0

### Patch Changes

-   @osdk/api@2.0.2-rc.0
