### PR TITLE
Version Packages

### DIFF
--- a/.changeset/nasty-birds-switch.md
+++ b/.changeset/nasty-birds-switch.md
@@ -1,5 +1,0 @@
----
-"@osdk/foundry-sdk-generator": patch
----
-
-Update beta generator.

--- a/packages/e2e.test.foundry-sdk-generator/CHANGELOG.md
+++ b/packages/e2e.test.foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/e2e.test.foundry-sdk-generator
 
+## 0.2.11
+
+### Patch Changes
+
+- Updated dependencies [232f0f0]
+  - @osdk/foundry-sdk-generator@1.3.11
+
 ## 0.2.10
 
 ### Patch Changes

--- a/packages/e2e.test.foundry-sdk-generator/package.json
+++ b/packages/e2e.test.foundry-sdk-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.test.foundry-sdk-generator",
   "private": true,
-  "version": "0.2.10",
+  "version": "0.2.11",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/foundry-sdk-generator
 
+## 1.3.11
+
+### Patch Changes
+
+- 232f0f0: Update beta generator.
+
 ## 1.3.10
 
 ### Patch Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/1.3.x, this PR will be updated.


# Releases
## @osdk/foundry-sdk-generator@1.3.11

### Patch Changes

-   232f0f0: Update beta generator.

## @osdk/e2e.test.foundry-sdk-generator@0.2.11

### Patch Changes

-   Updated dependencies [232f0f0]
    -   @osdk/foundry-sdk-generator@1.3.11
