### PR TITLE
Fix proxy handler

### DIFF
--- a/.changeset/smart-garlics-pretend.md
+++ b/.changeset/smart-garlics-pretend.md
@@ -1,0 +1,6 @@
+---
+"@osdk/shared.test": patch
+"@osdk/client": patch
+---
+
+Fixing proxy handlers.

--- a/packages/client/src/object/convertWireToOsdkObjects.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.test.ts
@@ -77,6 +77,31 @@ describe("convertWireToOsdkObjects", () => {
     ]);
   });
 
+  it("stringifies properties on objects and interfaces correctly", async () => {
+    const { data: [employee] } = await client(Employee).fetchPage();
+    const { data: [employee2] } = await client(Employee).where({
+      $and: [{ employeeId: { $gt: 50030 } }, { employeeId: { $lt: 50032 } }],
+    }).fetchPage();
+
+    // Should not have $title
+    expect(JSON.stringify(employee)).toMatchInlineSnapshot(
+      `"{"employeeId":50030,"fullName":"John Doe","office":"NYC","class":"Red","startDate":"2019-01-01","employeeStatus":{},"$apiName":"Employee","$objectType":"Employee","$primaryKey":50030}"`,
+    );
+
+    expect(JSON.stringify(employee.$as(FooInterface))).toMatchInlineSnapshot(
+      `"{"$apiName":"FooInterface","$objectType":"Employee","$primaryKey":50030,"fooSpt":"John Doe"}"`,
+    );
+
+    // Should have $title
+    expect(JSON.stringify(employee2)).toMatchInlineSnapshot(
+      `"{"employeeId":50031,"fullName":"Jane Doe","office":"SEA","class":"Blue","startDate":"2012-02-12","employeeStatus":{},"$apiName":"Employee","$objectType":"Employee","$primaryKey":50031,"$title":"Jane Doe"}"`,
+    );
+
+    expect(JSON.stringify(employee2.$as(FooInterface))).toMatchInlineSnapshot(
+      `"{"$apiName":"FooInterface","$objectType":"Employee","$primaryKey":50031,"$title":"Jane Doe","fooSpt":"Jane Doe"}"`,
+    );
+  });
+
   it("reuses the object prototype across objects", async () => {
     const employees = await client(Employee).fetchPage();
     expect(employees.data.length).toBeGreaterThanOrEqual(2);

--- a/packages/client/src/object/convertWireToOsdkObjects.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.test.ts
@@ -67,7 +67,6 @@ describe("convertWireToOsdkObjects", () => {
       "$apiName",
       "$objectType",
       "$primaryKey",
-      "$title",
     ].sort());
 
     expect(Object.keys(employee.$as)).toEqual([]);

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -143,8 +143,7 @@ export function createOsdkObject<
       }
       return false;
     },
-    // console.log("this is p", p);
-    // console.log(Reflect.getOwnPropertyDescriptor(target, p));
+
     getOwnPropertyDescriptor(target, p) {
       if (p === RawObject) {
         return Reflect.getOwnPropertyDescriptor(target, p);

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -143,15 +143,17 @@ export function createOsdkObject<
       }
       return false;
     },
-
+    // console.log("this is p", p);
+    // console.log(Reflect.getOwnPropertyDescriptor(target, p));
     getOwnPropertyDescriptor(target, p) {
       if (p === RawObject) {
         return Reflect.getOwnPropertyDescriptor(target, p);
       }
+
       if (target[RawObject][p as string] != null) {
         return { configurable: true, enumerable: true };
       }
-      return { enumerable: false };
+      return undefined;
     },
   });
   return osdkObject;

--- a/packages/client/src/object/object.test.ts
+++ b/packages/client/src/object/object.test.ts
@@ -57,11 +57,11 @@ describe("OsdkObject", () => {
 
       // we should get the employee we requested
       const employee = result.data[0];
+      expect(JSON.stringify(employee)).toBeDefined();
       expect(employee).toMatchObject({
         "$apiName": "Employee",
         "$objectType": "Employee",
         "$primaryKey": 50030,
-        "$title": "John Doe",
         "class": "Red",
         "employeeId": 50030,
         "employeeStatus": expect.anything(),

--- a/packages/client/src/objectSet/ObjectSet.test.ts
+++ b/packages/client/src/objectSet/ObjectSet.test.ts
@@ -153,7 +153,6 @@ describe("ObjectSet", () => {
         $apiName: "Employee",
         $objectType: "Employee",
         $primaryKey: 50030,
-        $title: "John Doe",
         class: "Red",
         employeeId: 50030,
         employeeStatus: expect.anything(),

--- a/packages/shared.test/src/stubs/objects.ts
+++ b/packages/shared.test/src/stubs/objects.ts
@@ -23,7 +23,6 @@ export const employee1 = {
     "ri.phonograph2-objects.main.object.88a6fccb-f333-46d6-a07e-7725c5f18b61",
   __primaryKey: 50030,
   __apiName: "Employee",
-  __title: "John Doe",
   employeeId: 50030,
   fullName: "John Doe",
   office: "NYC",


### PR DESCRIPTION
We ran into an issue where someone deleted the `$title` property on their object and they ran into this error:
`TypeError: 'getOwnPropertyDescriptor' on proxy: trap reported non-configurability for property '$title' which is either non-existent or configurable in the proxy target`.

This is because our handler for `getOwnPropertyDescriptor` was violating this invariant: 
**_A property cannot be reported as non-configurable, unless it exists as a non-configurable own property of the target object. That is, if [Reflect.getOwnPropertyDescriptor()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/getOwnPropertyDescriptor) returns undefined or configurable: true for the property on target, then the trap must not return configurable: false._**

This is now fixed by returning `undefined` in the default case, rather than `{enumerable:false}` which will also set `configurable` to false