### PR TITLE
Improve types

### DIFF
--- a/.changeset/curvy-cups-check.md
+++ b/.changeset/curvy-cups-check.md
@@ -1,0 +1,7 @@
+---
+"@osdk/generator": patch
+"@osdk/client": patch
+"@osdk/api": patch
+---
+
+Switch to OSDK.Instance

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import type { BBox } from 'geojson';
+import type { IsAny } from 'type-fest';
 import type { Point } from 'geojson';
 import type { Polygon } from 'geojson';
 import type { SingleKeyObject } from 'type-fest';
@@ -396,8 +397,10 @@ export interface FetchPageArgs<Q extends ObjectOrInterfaceDefinition, K extends 
     $pageSize?: number;
 }
 
-// @public (undocumented)
-export type FetchPageResult<Q extends ObjectOrInterfaceDefinition, L extends PropertyKeys<Q>, R extends boolean, S extends NullabilityAdherence> = PageResult<SingleOsdkResult<Q, L, R, S>>;
+// Warning: (ae-forgotten-export) The symbol "ExtractOptions" needs to be exported by the entry point index.d.ts
+//
+// @public
+export type FetchPageResult<Q extends ObjectOrInterfaceDefinition, L extends PropertyKeys<Q>, R extends boolean, S extends NullabilityAdherence> = PageResult<PropertyKeys<Q> extends L ? Osdk.Instance<Q, ExtractOptions<R, S>> : Osdk.Instance<Q, ExtractOptions<R, S>, L>>;
 
 // @public (undocumented)
 export type GeoFilter_Intersects = {
@@ -568,8 +571,8 @@ export interface ObjectSet<Q extends ObjectOrInterfaceDefinition = any, _UNUSED 
     // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
     // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
     readonly aggregate: <AO extends AggregateOpts<Q>>(req: AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<Q, AO>) => Promise<AggregationsResults<Q, AO>>;
-    readonly fetchOne: Q extends ObjectTypeDefinition ? <const L extends PropertyKeys<Q>, const R extends boolean, const S extends false | "throw" = NullabilityAdherence.Default>(primaryKey: PrimaryKeyType<Q>, options?: SelectArg<Q, L, R, S>) => Promise<SingleOsdkResult<Q, [L] extends [never] ? any : L, R, S>> : never;
-    readonly fetchOneWithErrors: Q extends ObjectTypeDefinition ? <L extends PropertyKeys<Q>, R extends boolean, S extends false | "throw" = NullabilityAdherence.Default>(primaryKey: PrimaryKeyType<Q>, options?: SelectArg<Q, L, R, S>) => Promise<Result<SingleOsdkResult<Q, [L] extends [never] ? any : L, R, S>>> : never;
+    readonly fetchOne: Q extends ObjectTypeDefinition ? <const L extends PropertyKeys<Q>, const R extends boolean, const S extends false | "throw" = NullabilityAdherence.Default>(primaryKey: PrimaryKeyType<Q>, options?: SelectArg<Q, L, R, S>) => Promise<Osdk.Instance<Q, ExtractOptions<R, S>, L>> : never;
+    readonly fetchOneWithErrors: Q extends ObjectTypeDefinition ? <L extends PropertyKeys<Q>, R extends boolean, S extends false | "throw" = NullabilityAdherence.Default>(primaryKey: PrimaryKeyType<Q>, options?: SelectArg<Q, L, R, S>) => Promise<Result<Osdk.Instance<Q, ExtractOptions<R, S>, L>>> : never;
     readonly intersect: (...objectSets: ReadonlyArray<CompileTimeMetadata<Q>["objectSet"]>) => this;
     readonly pivotTo: <L extends LinkNames<Q>>(type: L) => CompileTimeMetadata<LinkedType<Q, L>>["objectSet"];
     readonly subtract: (...objectSets: ReadonlyArray<CompileTimeMetadata<Q>["objectSet"]>) => this;
@@ -608,19 +611,27 @@ export interface OntologyMetadata<_NEVER_USED_KEPT_FOR_BACKCOMPAT = any> {
     userAgent: string;
 }
 
-// Warning: (ae-forgotten-export) The symbol "GetProps" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "GetPropsKeys" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "IsNever" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ExtractPropsKeysFromOldPropsStyle" needs to be exported by the entry point index.d.ts
 //
+// @public
+export type Osdk<Q extends ObjectOrInterfaceDefinition, OPTIONS extends string = never, P extends PropertyKeys<Q> = PropertyKeys<Q>> = IsNever<OPTIONS> extends true ? Osdk.Instance<Q, never, P> : IsNever<Exclude<OPTIONS, "$notStrict" | "$rid">> extends true ? Osdk.Instance<Q, OPTIONS & ("$notStrict" | "$rid"), P> : Osdk.Instance<Q, ("$notStrict" extends OPTIONS ? "$notStrict" : never) | ("$rid" extends OPTIONS ? "$rid" : never), ExtractPropsKeysFromOldPropsStyle<Q, OPTIONS>>;
+
 // @public (undocumented)
-export type Osdk<Q extends ObjectOrInterfaceDefinition, P extends ValidOsdkPropParams<Q> = "$all"> = OsdkBase<Q> & Pick<GetProps<Q, P>, GetPropsKeys<Q, P>> & {
-    readonly $link: Q extends {
-        linksType?: any;
-    } ? Q["linksType"] : Q extends ObjectTypeDefinition ? OsdkObjectLinksObject<Q> : never;
-    readonly $as: <NEW_Q extends ValidToFrom<Q>>(type: NEW_Q | string) => Osdk<NEW_Q, ConvertProps<Q, NEW_Q, P>>;
-} & (IsNever<P> extends true ? {} : string extends P ? {} : "$rid" extends P ? {
-    readonly $rid: string;
-} : {});
+export namespace Osdk {
+    // Warning: (ae-forgotten-export) The symbol "GetProps" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "GetPropsKeys" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    export type Instance<Q extends ObjectOrInterfaceDefinition, OPTIONS extends never | "$notStrict" | "$rid" = never, P extends PropertyKeys<Q> = PropertyKeys<Q>> = OsdkBase<Q> & Pick<GetProps<Q, OPTIONS>, GetPropsKeys<Q, P>> & {
+        readonly $link: Q extends {
+            linksType?: any;
+        } ? Q["linksType"] : Q extends ObjectTypeDefinition ? OsdkObjectLinksObject<Q> : never;
+        readonly $as: <NEW_Q extends ValidToFrom<Q>>(type: NEW_Q | string) => Osdk.Instance<NEW_Q, OPTIONS, ConvertProps<Q, NEW_Q, P>>;
+    } & (IsNever<OPTIONS> extends true ? {} : "$rid" extends OPTIONS ? {
+        readonly $rid: string;
+    } : {});
+}
 
 // @public (undocumented)
 export type OsdkBase<Q extends ObjectOrInterfaceDefinition> = {
@@ -630,7 +641,7 @@ export type OsdkBase<Q extends ObjectOrInterfaceDefinition> = {
     readonly $title: string | undefined;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type OsdkObject<N extends string> = {
     readonly $apiName: N;
     readonly $objectType: string;
@@ -816,10 +827,8 @@ export interface SingleLinkAccessor<T extends ObjectTypeDefinition> {
     fetchOneWithErrors: <const A extends SelectArg<T, PropertyKeys<T>, boolean>>(options?: A) => Promise<Result<DefaultToFalse<A["$includeRid"]> extends false ? Osdk<T, SelectArgToKeys<T, A>> : Osdk<T, SelectArgToKeys<T, A> | "$rid">>>;
 }
 
-// Warning: (ae-forgotten-export) The symbol "IsAny" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-export type SingleOsdkResult<Q extends ObjectOrInterfaceDefinition, L extends PropertyKeys<Q>, R extends boolean, S extends NullabilityAdherence> = Osdk<Q, (IsAny<L> extends true ? PropertyKeys<Q> : L) | (S extends false ? "$notStrict" : never) | (DefaultToFalse<R> extends false ? never : "$rid")>;
+// @public
+export type SingleOsdkResult<Q extends ObjectOrInterfaceDefinition, L extends PropertyKeys<Q>, R extends boolean, S extends NullabilityAdherence> = Osdk.Instance<Q, ExtractOptions<R, S>, L>;
 
 // Warning: (ae-forgotten-export) The symbol "AggregationKeyDataType" needs to be exported by the entry point index.d.ts
 //

--- a/etc/client.report.api.md
+++ b/etc/client.report.api.md
@@ -30,6 +30,7 @@ import { ObjectSet } from '@osdk/api';
 import type { ObjectSetQueryDataType } from '@osdk/api';
 import type { ObjectTypeDefinition } from '@osdk/api';
 import { Osdk } from '@osdk/api';
+import type { OsdkBase } from '@osdk/api';
 import { OsdkObject } from '@osdk/api';
 import { PageResult } from '@osdk/api';
 import { PalantirApiError } from '@osdk/shared.net.errors';

--- a/examples-extra/docs_example/src/generatedNoCheck/index.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/index.ts
@@ -1,9 +1,17 @@
-export * from './ontology/actions';
+export {
+  completeTodo,
+  createOffice,
+  createOfficeAndEmployee,
+  createTodo,
+  moveOffice,
+  promoteEmployee,
+  promoteEmployeeObject,
+} from './ontology/actions';
 export * as $Actions from './ontology/actions';
-export * from './ontology/interfaces';
+export {} from './ontology/interfaces';
 export * as $Interfaces from './ontology/interfaces';
-export * from './ontology/objects';
+export { Employee, equipment, Office, Todo } from './ontology/objects';
 export * as $Objects from './ontology/objects';
-export * from './ontology/queries';
+export {} from './ontology/queries';
 export * as $Queries from './ontology/queries';
 export { $ontologyRid } from './OntologyMetadata';

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/objects.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/objects.ts
@@ -1,4 +1,4 @@
-export * from './objects/Employee';
-export * from './objects/equipment';
-export * from './objects/Office';
-export * from './objects/Todo';
+export { Employee } from './objects/Employee';
+export { equipment } from './objects/equipment';
+export { Office } from './objects/Office';
+export { Todo } from './objects/Todo';

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Employee.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Employee.ts
@@ -41,10 +41,16 @@ export namespace Employee {
 
   export interface ObjectSet extends $ObjectSet<Employee, Employee.ObjectSet> {}
 
+  export type OsdkInstance<
+    OPTIONS extends never | '$notStrict' | '$rid' = never,
+    K extends keyof Employee.Props = keyof Employee.Props,
+  > = $Osdk.Instance<Employee, OPTIONS, K>;
+
+  /** @deprecated use OsdkInstance */
   export type OsdkObject<
     OPTIONS extends never | '$notStrict' | '$rid' = never,
     K extends keyof Employee.Props = keyof Employee.Props,
-  > = $Osdk<Employee, K | OPTIONS>;
+  > = OsdkInstance<OPTIONS, K>;
 }
 
 export interface Employee extends $ObjectTypeDefinition {

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Office.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Office.ts
@@ -44,10 +44,16 @@ export namespace Office {
 
   export interface ObjectSet extends $ObjectSet<Office, Office.ObjectSet> {}
 
+  export type OsdkInstance<
+    OPTIONS extends never | '$notStrict' | '$rid' = never,
+    K extends keyof Office.Props = keyof Office.Props,
+  > = $Osdk.Instance<Office, OPTIONS, K>;
+
+  /** @deprecated use OsdkInstance */
   export type OsdkObject<
     OPTIONS extends never | '$notStrict' | '$rid' = never,
     K extends keyof Office.Props = keyof Office.Props,
-  > = $Osdk<Office, K | OPTIONS>;
+  > = OsdkInstance<OPTIONS, K>;
 }
 
 export interface Office extends $ObjectTypeDefinition {

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Todo.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Todo.ts
@@ -32,10 +32,16 @@ export namespace Todo {
 
   export interface ObjectSet extends $ObjectSet<Todo, Todo.ObjectSet> {}
 
+  export type OsdkInstance<
+    OPTIONS extends never | '$notStrict' | '$rid' = never,
+    K extends keyof Todo.Props = keyof Todo.Props,
+  > = $Osdk.Instance<Todo, OPTIONS, K>;
+
+  /** @deprecated use OsdkInstance */
   export type OsdkObject<
     OPTIONS extends never | '$notStrict' | '$rid' = never,
     K extends keyof Todo.Props = keyof Todo.Props,
-  > = $Osdk<Todo, K | OPTIONS>;
+  > = OsdkInstance<OPTIONS, K>;
 }
 
 export interface Todo extends $ObjectTypeDefinition {

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/equipment.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/equipment.ts
@@ -30,10 +30,16 @@ export namespace equipment {
 
   export interface ObjectSet extends $ObjectSet<equipment, equipment.ObjectSet> {}
 
+  export type OsdkInstance<
+    OPTIONS extends never | '$notStrict' | '$rid' = never,
+    K extends keyof equipment.Props = keyof equipment.Props,
+  > = $Osdk.Instance<equipment, OPTIONS, K>;
+
+  /** @deprecated use OsdkInstance */
   export type OsdkObject<
     OPTIONS extends never | '$notStrict' | '$rid' = never,
     K extends keyof equipment.Props = keyof equipment.Props,
-  > = $Osdk<equipment, K | OPTIONS>;
+  > = OsdkInstance<OPTIONS, K>;
 }
 
 export interface equipment extends $ObjectTypeDefinition {

--- a/packages/api/src/OsdkObject.ts
+++ b/packages/api/src/OsdkObject.ts
@@ -17,6 +17,9 @@
 import type { PropertyValueWireToClient } from "./mapping/PropertyValueMapping.js";
 import type { PrimaryKeyTypes } from "./ontology/PrimaryKeyTypes.js";
 
+/**
+ * @deprecated Use OsdkBase
+ */
 export type OsdkObject<N extends string> = {
   readonly $apiName: N;
   readonly $objectType: string;

--- a/packages/api/src/PageResult.ts
+++ b/packages/api/src/PageResult.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import type { OsdkObject } from "./OsdkObject.js";
-
 export interface PageResult<T> {
   data: T[];
   nextPageToken: string | undefined;

--- a/packages/api/src/object/FetchPageResult.ts
+++ b/packages/api/src/object/FetchPageResult.ts
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-import type { DefaultToFalse } from "../definitions/LinkDefinitions.js";
 import type {
   ObjectOrInterfaceDefinition,
   PropertyKeys,
 } from "../ontology/ObjectOrInterface.js";
-import type { IsNever, Osdk } from "../OsdkObjectFrom.js";
+import type { ExtractOptions, IsNever, Osdk } from "../OsdkObjectFrom.js";
 import type { PageResult } from "../PageResult.js";
 import type { NullabilityAdherence } from "./FetchPageArgs.js";
 
@@ -43,24 +42,28 @@ export type UnionIfTrue<
   : UNION_IF_TRUE extends true ? S | E
   : S;
 
+/**
+ * Helper type for converting fetch options into an Osdk object
+ */
 export type FetchPageResult<
   Q extends ObjectOrInterfaceDefinition,
   L extends PropertyKeys<Q>,
   R extends boolean,
   S extends NullabilityAdherence,
-> = PageResult<SingleOsdkResult<Q, L, R, S>>;
+> = PageResult<
+  PropertyKeys<Q> extends L ? Osdk.Instance<Q, ExtractOptions<R, S>>
+    : Osdk.Instance<Q, ExtractOptions<R, S>, L>
+>;
 
+/**
+ * Helper type for converting fetch options into an Osdk object
+ */
 export type SingleOsdkResult<
   Q extends ObjectOrInterfaceDefinition,
   L extends PropertyKeys<Q>,
   R extends boolean,
   S extends NullabilityAdherence,
-> = Osdk<
-  Q,
-  | (IsAny<L> extends true ? PropertyKeys<Q> : L)
-  | (S extends false ? "$notStrict" : never)
-  | (DefaultToFalse<R> extends false ? never : "$rid")
->;
+> = Osdk.Instance<Q, ExtractOptions<R, S>, L>;
 
 export type IsAny<T> = unknown extends T
   ? [keyof T] extends [never] ? false : true

--- a/packages/api/src/objectSet/EXPERIMENTAL_ObjectSetListener.ts
+++ b/packages/api/src/objectSet/EXPERIMENTAL_ObjectSetListener.ts
@@ -15,7 +15,7 @@
  */
 
 import type { ObjectOrInterfaceDefinition } from "../ontology/ObjectOrInterface.js";
-import type { OsdkObjectOrInterfaceFrom } from "../OsdkObjectFrom.js";
+import type { Osdk } from "../OsdkObjectFrom.js";
 
 export interface EXPERIMENTAL_ObjectSetListener<
   O extends ObjectOrInterfaceDefinition,
@@ -23,7 +23,7 @@ export interface EXPERIMENTAL_ObjectSetListener<
   /**
    * Specific objects have changed and can be immediately updated
    */
-  onChange?: (objects: Array<OsdkObjectOrInterfaceFrom<O>>) => void;
+  onChange?: (objects: Array<Osdk.Instance<O>>) => void;
 
   /**
    * The ObjectSet has become outdated and should be re-fetched in its entirety.

--- a/packages/api/src/objectSet/ObjectSet.ts
+++ b/packages/api/src/objectSet/ObjectSet.ts
@@ -25,10 +25,7 @@ import type {
   NullabilityAdherence,
   SelectArg,
 } from "../object/FetchPageArgs.js";
-import type {
-  FetchPageResult,
-  SingleOsdkResult,
-} from "../object/FetchPageResult.js";
+import type { SingleOsdkResult } from "../object/FetchPageResult.js";
 import type { Result } from "../object/Result.js";
 import type { InterfaceDefinition } from "../ontology/InterfaceDefinition.js";
 import type {
@@ -40,6 +37,8 @@ import type {
   ObjectTypeDefinition,
 } from "../ontology/ObjectTypeDefinition.js";
 import type { PrimaryKeyType } from "../OsdkBase.js";
+import type { ExtractOptions, Osdk } from "../OsdkObjectFrom.js";
+import type { PageResult } from "../PageResult.js";
 import type {
   __EXPERIMENTAL__NOT_SUPPORTED_YET_subscribe,
   EXPERIMENTAL_ObjectSetListener,
@@ -69,7 +68,12 @@ export interface MinimalObjectSet<Q extends ObjectOrInterfaceDefinition>
     S extends NullabilityAdherence = NullabilityAdherence.Default,
   >(
     args?: FetchPageArgs<Q, L, R, A, S>,
-  ) => Promise<FetchPageResult<Q, L, R, S>>;
+  ) => Promise<
+    PageResult<
+      PropertyKeys<Q> extends L ? Osdk.Instance<Q, ExtractOptions<R, S>>
+        : Osdk.Instance<Q, ExtractOptions<R, S>, L>
+    >
+  >;
 
   /**
    * Gets a page of objects of this type, with a result wrapper
@@ -92,7 +96,7 @@ export interface MinimalObjectSet<Q extends ObjectOrInterfaceDefinition>
     S extends NullabilityAdherence = NullabilityAdherence.Default,
   >(
     args?: FetchPageArgs<Q, L, R, A, S>,
-  ) => Promise<Result<FetchPageResult<Q, L, R, S>>>;
+  ) => Promise<Result<PageResult<Osdk.Instance<Q, ExtractOptions<R, S>, L>>>>;
 
   /**
    * Allows you to filter an object set with a given clause
@@ -220,7 +224,7 @@ export interface ObjectSet<
     >(
       primaryKey: PrimaryKeyType<Q>,
       options?: SelectArg<Q, L, R, S>,
-    ) => Promise<SingleOsdkResult<Q, [L] extends [never] ? any : L, R, S>>
+    ) => Promise<Osdk.Instance<Q, ExtractOptions<R, S>, L>>
     : never;
 
   /**
@@ -234,7 +238,7 @@ export interface ObjectSet<
       primaryKey: PrimaryKeyType<Q>,
       options?: SelectArg<Q, L, R, S>,
     ) => Promise<
-      Result<SingleOsdkResult<Q, [L] extends [never] ? any : L, R, S>>
+      Result<Osdk.Instance<Q, ExtractOptions<R, S>, L>>
     >
     : never;
 

--- a/packages/client/src/__unstable/createBulkLinksAsyncIterFactory.ts
+++ b/packages/client/src/__unstable/createBulkLinksAsyncIterFactory.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { OsdkObject } from "@osdk/api";
+import type { OsdkBase } from "@osdk/api";
 import type {
   DirectedLinkTypeRid,
   FoundryObjectReference,
@@ -34,7 +34,7 @@ import {
 import { metadataCacheClient } from "./ConjureSupport.js";
 
 export interface BulkLinkResult {
-  object: OsdkObject<any>;
+  object: OsdkBase<any>;
   linkApiName: string;
   otherObjectApiName: string | undefined;
   otherObjectPk: unknown;
@@ -42,7 +42,7 @@ export interface BulkLinkResult {
 
 export function createBulkLinksAsyncIterFactory(ctx: MinimalClient) {
   return async function*(
-    objs: Array<OsdkObject<any>>,
+    objs: Array<OsdkBase<any>>,
     linkTypes: string[],
   ): AsyncGenerator<BulkLinkResult, void, unknown> {
     if (objs.length === 0) {
@@ -158,7 +158,7 @@ export function createBulkLinksAsyncIterFactory(ctx: MinimalClient) {
 
 function findObject(
   objectIdentifier: ObjectIdentifier,
-  objs: (OsdkObject<any>)[],
+  objs: (OsdkBase<any>)[],
 ) {
   const { pkValue } = getPrimaryKeyOrThrow(objectIdentifier);
 

--- a/packages/client/src/object/convertWireToOsdkObjects/InternalSymbols.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/InternalSymbols.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ObjectOrInterfaceDefinition, OsdkObject } from "@osdk/api";
+import type { ObjectOrInterfaceDefinition, OsdkBase } from "@osdk/api";
 
 export const UnderlyingOsdkObject = Symbol(
   process.env.MODE !== "production" ? "Underlying Object" : undefined,
@@ -38,7 +38,7 @@ export const ClientRef = Symbol(
 );
 
 export interface HolderBase<T extends ObjectOrInterfaceDefinition> {
-  [UnderlyingOsdkObject]: OsdkObject<any>;
+  [UnderlyingOsdkObject]: OsdkBase<any>;
   [ObjectDefRef]?: T;
   [InterfaceDefRef]?: T;
 }

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { InterfaceMetadata, Osdk, OsdkObject } from "@osdk/api";
+import type { InterfaceMetadata, Osdk, OsdkBase } from "@osdk/api";
 import { extractNamespace } from "../../internal/conversions/modernToLegacyWhereClause.js";
 import type { FetchedObjectTypeDefinition } from "../../ontology/OntologyProvider.js";
 import { createSimpleCache } from "../SimpleCache.js";
@@ -51,8 +51,8 @@ export function createOsdkInterface<
 
   const handler = handlerCache.get(interfaceDef);
 
-  const proxy = new Proxy<OsdkObject<any>>(
-    interfaceHolder as unknown as OsdkObject<any>, // the wrapper doesn't contain everything obviously. we proxy
+  const proxy = new Proxy<OsdkBase<any>>(
+    interfaceHolder as unknown as OsdkBase<any>, // the wrapper doesn't contain everything obviously. we proxy
     handler,
   );
   return proxy;

--- a/packages/client/src/object/convertWireToOsdkObjects/getDollarAs.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/getDollarAs.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ObjectOrInterfaceDefinition, Osdk, OsdkObject } from "@osdk/api";
+import type { ObjectOrInterfaceDefinition, Osdk, OsdkBase } from "@osdk/api";
 import {
   type FetchedObjectTypeDefinition,
   InterfaceDefinitions,
@@ -32,7 +32,7 @@ export type DollarAsFn = <
 >(
   this: Osdk<any> & (InterfaceHolder<Q> | ObjectHolder<Q>),
   newDef: string | NEW_Q,
-) => OsdkObject<any>;
+) => OsdkBase<any>;
 
 export const get$as = createSimpleCache<
   FetchedObjectTypeDefinition,
@@ -41,13 +41,13 @@ export const get$as = createSimpleCache<
 
 const osdkObjectToInterfaceView = createSimpleCache(
   new WeakMap<
-    OsdkObject<any>,
-    Map<string, OsdkObject<any>>
+    OsdkBase<any>,
+    Map<string, OsdkBase<any>>
   >(),
   () =>
     new Map<
       /* interface api name */ string,
-      /* $as'd object */ OsdkObject<any>
+      /* $as'd object */ OsdkBase<any>
     >(),
 );
 
@@ -58,9 +58,9 @@ function $asFactory(
   return function $as<
     NEW_Q extends ObjectOrInterfaceDefinition,
   >(
-    this: OsdkObject<any> & { [UnderlyingOsdkObject]: any },
+    this: OsdkBase<any> & { [UnderlyingOsdkObject]: any },
     targetMinDef: NEW_Q | string,
-  ): OsdkObject<any> {
+  ): OsdkBase<any> {
     let targetInterfaceApiName: string;
 
     if (typeof targetMinDef === "string") {

--- a/packages/client/src/object/fetchSingle.ts
+++ b/packages/client/src/object/fetchSingle.ts
@@ -17,9 +17,8 @@
 import type {
   FetchPageArgs,
   ObjectOrInterfaceDefinition,
-  Osdk,
   Result,
-  SelectArgToKeys,
+  SingleOsdkResult,
 } from "@osdk/api";
 import type { ObjectSet } from "@osdk/internal.foundry.core";
 import { PalantirApiError } from "@osdk/shared.net.errors";
@@ -36,16 +35,14 @@ export async function fetchSingle<
   args: A,
   objectSet: ObjectSet,
 ): Promise<
-  Osdk<
-    Q,
-    A["$includeRid"] extends true ? SelectArgToKeys<Q, A> | "$rid"
-      : SelectArgToKeys<Q, A>
-  >
+  A extends FetchPageArgs<Q, infer L, infer R, any, infer S>
+    ? SingleOsdkResult<Q, L, R, S>
+    : SingleOsdkResult<Q, any, any, any>
 > {
   const result = await fetchPage(
     client,
     objectType,
-    { ...args, pageSize: 1 },
+    { ...args, $pageSize: 1 },
     objectSet,
   );
 
@@ -71,11 +68,9 @@ export async function fetchSingleWithErrors<
   objectSet: ObjectSet,
 ): Promise<
   Result<
-    Osdk<
-      Q,
-      A["$includeRid"] extends true ? SelectArgToKeys<Q, A> | "$rid"
-        : SelectArgToKeys<Q, A>
-    >
+    A extends FetchPageArgs<Q, infer L, infer R, any, infer S>
+      ? SingleOsdkResult<Q, L, R, S>
+      : SingleOsdkResult<Q, any, any, any>
   >
 > {
   try {

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/index.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/index.ts
@@ -1,9 +1,9 @@
-export * from './ontology/actions.js';
+export {} from './ontology/actions.js';
 export * as $Actions from './ontology/actions.js';
-export * from './ontology/interfaces.js';
+export { SomeInterface } from './ontology/interfaces.js';
 export * as $Interfaces from './ontology/interfaces.js';
-export * from './ontology/objects.js';
+export { Task } from './ontology/objects.js';
 export * as $Objects from './ontology/objects.js';
-export * from './ontology/queries.js';
+export {} from './ontology/queries.js';
 export * as $Queries from './ontology/queries.js';
 export { $ontologyRid } from './OntologyMetadata.js';

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/ontology/interfaces.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/ontology/interfaces.ts
@@ -1,1 +1,1 @@
-export * from './interfaces/SomeInterface.js';
+export { SomeInterface } from './interfaces/SomeInterface.js';

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/ontology/interfaces/SomeInterface.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/ontology/interfaces/SomeInterface.ts
@@ -22,10 +22,16 @@ export namespace SomeInterface {
 
   export interface ObjectSet extends $ObjectSet<SomeInterface, SomeInterface.ObjectSet> {}
 
+  export type OsdkInstance<
+    OPTIONS extends never | '$notStrict' | '$rid' = never,
+    K extends keyof SomeInterface.Props = keyof SomeInterface.Props,
+  > = $Osdk.Instance<SomeInterface, OPTIONS, K>;
+
+  /** @deprecated use OsdkInstance */
   export type OsdkObject<
     OPTIONS extends never | '$notStrict' | '$rid' = never,
     K extends keyof SomeInterface.Props = keyof SomeInterface.Props,
-  > = $Osdk<SomeInterface, K | OPTIONS>;
+  > = OsdkInstance<OPTIONS, K>;
 }
 
 export interface SomeInterface extends $InterfaceDefinition {

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/ontology/objects.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/ontology/objects.ts
@@ -1,1 +1,1 @@
-export * from './objects/Task.js';
+export { Task } from './objects/Task.js';

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/ontology/objects/Task.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/ontology/objects/Task.ts
@@ -30,10 +30,16 @@ export namespace Task {
 
   export interface ObjectSet extends $ObjectSet<Task, Task.ObjectSet> {}
 
+  export type OsdkInstance<
+    OPTIONS extends never | '$notStrict' | '$rid' = never,
+    K extends keyof Task.Props = keyof Task.Props,
+  > = $Osdk.Instance<Task, OPTIONS, K>;
+
+  /** @deprecated use OsdkInstance */
   export type OsdkObject<
     OPTIONS extends never | '$notStrict' | '$rid' = never,
     K extends keyof Task.Props = keyof Task.Props,
-  > = $Osdk<Task, K | OPTIONS>;
+  > = OsdkInstance<OPTIONS, K>;
 }
 
 export interface Task extends $ObjectTypeDefinition {

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/index.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/index.ts
@@ -1,9 +1,9 @@
-export * from './ontology/actions.js';
+export { setTaskBody } from './ontology/actions.js';
 export * as $Actions from './ontology/actions.js';
-export * from './ontology/interfaces.js';
+export { SomeInterface } from './ontology/interfaces.js';
 export * as $Interfaces from './ontology/interfaces.js';
-export * from './ontology/objects.js';
+export { Thing, UsesForeignSpt } from './ontology/objects.js';
 export * as $Objects from './ontology/objects.js';
-export * from './ontology/queries.js';
+export { getTask } from './ontology/queries.js';
 export * as $Queries from './ontology/queries.js';
 export { $ontologyRid } from './OntologyMetadata.js';

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/interfaces.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/interfaces.ts
@@ -1,1 +1,1 @@
-export * from './interfaces/SomeInterface.js';
+export { SomeInterface } from './interfaces/SomeInterface.js';

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/interfaces/SomeInterface.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/interfaces/SomeInterface.ts
@@ -22,10 +22,16 @@ export namespace SomeInterface {
 
   export interface ObjectSet extends $ObjectSet<SomeInterface, SomeInterface.ObjectSet> {}
 
+  export type OsdkInstance<
+    OPTIONS extends never | '$notStrict' | '$rid' = never,
+    K extends keyof SomeInterface.Props = keyof SomeInterface.Props,
+  > = $Osdk.Instance<SomeInterface, OPTIONS, K>;
+
+  /** @deprecated use OsdkInstance */
   export type OsdkObject<
     OPTIONS extends never | '$notStrict' | '$rid' = never,
     K extends keyof SomeInterface.Props = keyof SomeInterface.Props,
-  > = $Osdk<SomeInterface, K | OPTIONS>;
+  > = OsdkInstance<OPTIONS, K>;
 }
 
 export interface SomeInterface extends $InterfaceDefinition {

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/objects.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/objects.ts
@@ -1,2 +1,2 @@
-export * from './objects/Thing.js';
-export * from './objects/UsesForeignSpt.js';
+export { Thing } from './objects/Thing.js';
+export { UsesForeignSpt } from './objects/UsesForeignSpt.js';

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/objects/Thing.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/objects/Thing.ts
@@ -30,10 +30,16 @@ export namespace Thing {
 
   export interface ObjectSet extends $ObjectSet<Thing, Thing.ObjectSet> {}
 
+  export type OsdkInstance<
+    OPTIONS extends never | '$notStrict' | '$rid' = never,
+    K extends keyof Thing.Props = keyof Thing.Props,
+  > = $Osdk.Instance<Thing, OPTIONS, K>;
+
+  /** @deprecated use OsdkInstance */
   export type OsdkObject<
     OPTIONS extends never | '$notStrict' | '$rid' = never,
     K extends keyof Thing.Props = keyof Thing.Props,
-  > = $Osdk<Thing, K | OPTIONS>;
+  > = OsdkInstance<OPTIONS, K>;
 }
 
 export interface Thing extends $ObjectTypeDefinition {

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/objects/UsesForeignSpt.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/objects/UsesForeignSpt.ts
@@ -30,10 +30,16 @@ export namespace UsesForeignSpt {
 
   export interface ObjectSet extends $ObjectSet<UsesForeignSpt, UsesForeignSpt.ObjectSet> {}
 
+  export type OsdkInstance<
+    OPTIONS extends never | '$notStrict' | '$rid' = never,
+    K extends keyof UsesForeignSpt.Props = keyof UsesForeignSpt.Props,
+  > = $Osdk.Instance<UsesForeignSpt, OPTIONS, K>;
+
+  /** @deprecated use OsdkInstance */
   export type OsdkObject<
     OPTIONS extends never | '$notStrict' | '$rid' = never,
     K extends keyof UsesForeignSpt.Props = keyof UsesForeignSpt.Props,
-  > = $Osdk<UsesForeignSpt, K | OPTIONS>;
+  > = OsdkInstance<OPTIONS, K>;
 }
 
 export interface UsesForeignSpt extends $ObjectTypeDefinition {

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/queries.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/queries.ts
@@ -1,1 +1,1 @@
-export * from './queries/getTask.js';
+export { getTask } from './queries/getTask.js';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/index.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/index.ts
@@ -1,9 +1,19 @@
-export * from './ontology/actions.js';
+export { actionTakesAllParameterTypes, assignEmployee1, createTodo } from './ontology/actions.js';
 export * as $Actions from './ontology/actions.js';
-export * from './ontology/interfaces.js';
+export { FooInterface } from './ontology/interfaces.js';
 export * as $Interfaces from './ontology/interfaces.js';
-export * from './ontology/objects.js';
+export {
+  BoundariesUsState,
+  BuilderDeploymentState,
+  DherlihyComplexObject,
+  Employee,
+  ObjectTypeWithAllPropertyTypes,
+  Person,
+  Todo,
+  Venture,
+  WeatherStation,
+} from './ontology/objects.js';
 export * as $Objects from './ontology/objects.js';
-export * from './ontology/queries.js';
+export { getNamesOfCustomersFromCountry, getTodoCount, queryTakesAllParameterTypes } from './ontology/queries.js';
 export * as $Queries from './ontology/queries.js';
 export { $ontologyRid } from './OntologyMetadata.js';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces.ts
@@ -1,1 +1,1 @@
-export * from './interfaces/FooInterface.js';
+export { FooInterface } from './interfaces/FooInterface.js';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/FooInterface.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/FooInterface.ts
@@ -24,10 +24,16 @@ export namespace FooInterface {
 
   export interface ObjectSet extends $ObjectSet<FooInterface, FooInterface.ObjectSet> {}
 
+  export type OsdkInstance<
+    OPTIONS extends never | '$notStrict' | '$rid' = never,
+    K extends keyof FooInterface.Props = keyof FooInterface.Props,
+  > = $Osdk.Instance<FooInterface, OPTIONS, K>;
+
+  /** @deprecated use OsdkInstance */
   export type OsdkObject<
     OPTIONS extends never | '$notStrict' | '$rid' = never,
     K extends keyof FooInterface.Props = keyof FooInterface.Props,
-  > = $Osdk<FooInterface, K | OPTIONS>;
+  > = OsdkInstance<OPTIONS, K>;
 }
 
 export interface FooInterface extends $InterfaceDefinition {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects.ts
@@ -1,9 +1,9 @@
-export * from './objects/BoundariesUsState.js';
-export * from './objects/BuilderDeploymentState.js';
-export * from './objects/DherlihyComplexObject.js';
-export * from './objects/Employee.js';
-export * from './objects/ObjectTypeWithAllPropertyTypes.js';
-export * from './objects/Person.js';
-export * from './objects/Todo.js';
-export * from './objects/Venture.js';
-export * from './objects/WeatherStation.js';
+export { BoundariesUsState } from './objects/BoundariesUsState.js';
+export { BuilderDeploymentState } from './objects/BuilderDeploymentState.js';
+export { DherlihyComplexObject } from './objects/DherlihyComplexObject.js';
+export { Employee } from './objects/Employee.js';
+export { ObjectTypeWithAllPropertyTypes } from './objects/ObjectTypeWithAllPropertyTypes.js';
+export { Person } from './objects/Person.js';
+export { Todo } from './objects/Todo.js';
+export { Venture } from './objects/Venture.js';
+export { WeatherStation } from './objects/WeatherStation.js';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/BoundariesUsState.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/BoundariesUsState.ts
@@ -34,10 +34,16 @@ export namespace BoundariesUsState {
 
   export interface ObjectSet extends $ObjectSet<BoundariesUsState, BoundariesUsState.ObjectSet> {}
 
+  export type OsdkInstance<
+    OPTIONS extends never | '$notStrict' | '$rid' = never,
+    K extends keyof BoundariesUsState.Props = keyof BoundariesUsState.Props,
+  > = $Osdk.Instance<BoundariesUsState, OPTIONS, K>;
+
+  /** @deprecated use OsdkInstance */
   export type OsdkObject<
     OPTIONS extends never | '$notStrict' | '$rid' = never,
     K extends keyof BoundariesUsState.Props = keyof BoundariesUsState.Props,
-  > = $Osdk<BoundariesUsState, K | OPTIONS>;
+  > = OsdkInstance<OPTIONS, K>;
 }
 
 export interface BoundariesUsState extends $ObjectTypeDefinition {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/BuilderDeploymentState.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/BuilderDeploymentState.ts
@@ -32,10 +32,16 @@ export namespace BuilderDeploymentState {
 
   export interface ObjectSet extends $ObjectSet<BuilderDeploymentState, BuilderDeploymentState.ObjectSet> {}
 
+  export type OsdkInstance<
+    OPTIONS extends never | '$notStrict' | '$rid' = never,
+    K extends keyof BuilderDeploymentState.Props = keyof BuilderDeploymentState.Props,
+  > = $Osdk.Instance<BuilderDeploymentState, OPTIONS, K>;
+
+  /** @deprecated use OsdkInstance */
   export type OsdkObject<
     OPTIONS extends never | '$notStrict' | '$rid' = never,
     K extends keyof BuilderDeploymentState.Props = keyof BuilderDeploymentState.Props,
-  > = $Osdk<BuilderDeploymentState, K | OPTIONS>;
+  > = OsdkInstance<OPTIONS, K>;
 }
 
 export interface BuilderDeploymentState extends $ObjectTypeDefinition {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/DherlihyComplexObject.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/DherlihyComplexObject.ts
@@ -32,10 +32,16 @@ export namespace DherlihyComplexObject {
 
   export interface ObjectSet extends $ObjectSet<DherlihyComplexObject, DherlihyComplexObject.ObjectSet> {}
 
+  export type OsdkInstance<
+    OPTIONS extends never | '$notStrict' | '$rid' = never,
+    K extends keyof DherlihyComplexObject.Props = keyof DherlihyComplexObject.Props,
+  > = $Osdk.Instance<DherlihyComplexObject, OPTIONS, K>;
+
+  /** @deprecated use OsdkInstance */
   export type OsdkObject<
     OPTIONS extends never | '$notStrict' | '$rid' = never,
     K extends keyof DherlihyComplexObject.Props = keyof DherlihyComplexObject.Props,
-  > = $Osdk<DherlihyComplexObject, K | OPTIONS>;
+  > = OsdkInstance<OPTIONS, K>;
 }
 
 export interface DherlihyComplexObject extends $ObjectTypeDefinition {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Employee.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Employee.ts
@@ -67,10 +67,16 @@ export namespace Employee {
 
   export interface ObjectSet extends $ObjectSet<Employee, Employee.ObjectSet> {}
 
+  export type OsdkInstance<
+    OPTIONS extends never | '$notStrict' | '$rid' = never,
+    K extends keyof Employee.Props = keyof Employee.Props,
+  > = $Osdk.Instance<Employee, OPTIONS, K>;
+
+  /** @deprecated use OsdkInstance */
   export type OsdkObject<
     OPTIONS extends never | '$notStrict' | '$rid' = never,
     K extends keyof Employee.Props = keyof Employee.Props,
-  > = $Osdk<Employee, K | OPTIONS>;
+  > = OsdkInstance<OPTIONS, K>;
 }
 
 export interface Employee extends $ObjectTypeDefinition {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/ObjectTypeWithAllPropertyTypes.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/ObjectTypeWithAllPropertyTypes.ts
@@ -120,10 +120,16 @@ export namespace ObjectTypeWithAllPropertyTypes {
   export interface ObjectSet
     extends $ObjectSet<ObjectTypeWithAllPropertyTypes, ObjectTypeWithAllPropertyTypes.ObjectSet> {}
 
+  export type OsdkInstance<
+    OPTIONS extends never | '$notStrict' | '$rid' = never,
+    K extends keyof ObjectTypeWithAllPropertyTypes.Props = keyof ObjectTypeWithAllPropertyTypes.Props,
+  > = $Osdk.Instance<ObjectTypeWithAllPropertyTypes, OPTIONS, K>;
+
+  /** @deprecated use OsdkInstance */
   export type OsdkObject<
     OPTIONS extends never | '$notStrict' | '$rid' = never,
     K extends keyof ObjectTypeWithAllPropertyTypes.Props = keyof ObjectTypeWithAllPropertyTypes.Props,
-  > = $Osdk<ObjectTypeWithAllPropertyTypes, K | OPTIONS>;
+  > = OsdkInstance<OPTIONS, K>;
 }
 
 export interface ObjectTypeWithAllPropertyTypes extends $ObjectTypeDefinition {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Person.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Person.ts
@@ -32,10 +32,16 @@ export namespace Person {
 
   export interface ObjectSet extends $ObjectSet<Person, Person.ObjectSet> {}
 
+  export type OsdkInstance<
+    OPTIONS extends never | '$notStrict' | '$rid' = never,
+    K extends keyof Person.Props = keyof Person.Props,
+  > = $Osdk.Instance<Person, OPTIONS, K>;
+
+  /** @deprecated use OsdkInstance */
   export type OsdkObject<
     OPTIONS extends never | '$notStrict' | '$rid' = never,
     K extends keyof Person.Props = keyof Person.Props,
-  > = $Osdk<Person, K | OPTIONS>;
+  > = OsdkInstance<OPTIONS, K>;
 }
 
 export interface Person extends $ObjectTypeDefinition {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Todo.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Todo.ts
@@ -39,10 +39,16 @@ export namespace Todo {
 
   export interface ObjectSet extends $ObjectSet<Todo, Todo.ObjectSet> {}
 
+  export type OsdkInstance<
+    OPTIONS extends never | '$notStrict' | '$rid' = never,
+    K extends keyof Todo.Props = keyof Todo.Props,
+  > = $Osdk.Instance<Todo, OPTIONS, K>;
+
+  /** @deprecated use OsdkInstance */
   export type OsdkObject<
     OPTIONS extends never | '$notStrict' | '$rid' = never,
     K extends keyof Todo.Props = keyof Todo.Props,
-  > = $Osdk<Todo, K | OPTIONS>;
+  > = OsdkInstance<OPTIONS, K>;
 }
 
 export interface Todo extends $ObjectTypeDefinition {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Venture.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Venture.ts
@@ -35,10 +35,16 @@ export namespace Venture {
 
   export interface ObjectSet extends $ObjectSet<Venture, Venture.ObjectSet> {}
 
+  export type OsdkInstance<
+    OPTIONS extends never | '$notStrict' | '$rid' = never,
+    K extends keyof Venture.Props = keyof Venture.Props,
+  > = $Osdk.Instance<Venture, OPTIONS, K>;
+
+  /** @deprecated use OsdkInstance */
   export type OsdkObject<
     OPTIONS extends never | '$notStrict' | '$rid' = never,
     K extends keyof Venture.Props = keyof Venture.Props,
-  > = $Osdk<Venture, K | OPTIONS>;
+  > = OsdkInstance<OPTIONS, K>;
 }
 
 export interface Venture extends $ObjectTypeDefinition {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/WeatherStation.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/WeatherStation.ts
@@ -30,10 +30,16 @@ export namespace WeatherStation {
 
   export interface ObjectSet extends $ObjectSet<WeatherStation, WeatherStation.ObjectSet> {}
 
+  export type OsdkInstance<
+    OPTIONS extends never | '$notStrict' | '$rid' = never,
+    K extends keyof WeatherStation.Props = keyof WeatherStation.Props,
+  > = $Osdk.Instance<WeatherStation, OPTIONS, K>;
+
+  /** @deprecated use OsdkInstance */
   export type OsdkObject<
     OPTIONS extends never | '$notStrict' | '$rid' = never,
     K extends keyof WeatherStation.Props = keyof WeatherStation.Props,
-  > = $Osdk<WeatherStation, K | OPTIONS>;
+  > = OsdkInstance<OPTIONS, K>;
 }
 
 export interface WeatherStation extends $ObjectTypeDefinition {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/queries.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/queries.ts
@@ -1,3 +1,3 @@
-export * from './queries/getNamesOfCustomersFromCountry.js';
-export * from './queries/getTodoCount.js';
-export * from './queries/queryTakesAllParameterTypes.js';
+export { getNamesOfCustomersFromCountry } from './queries/getNamesOfCustomersFromCountry.js';
+export { getTodoCount } from './queries/getTodoCount.js';
+export { queryTakesAllParameterTypes } from './queries/queryTakesAllParameterTypes.js';

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/index.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/index.ts
@@ -1,9 +1,9 @@
-export * from './ontology/actions';
+export { completeTodo, createTodo } from './ontology/actions';
 export * as $Actions from './ontology/actions';
-export * from './ontology/interfaces';
+export {} from './ontology/interfaces';
 export * as $Interfaces from './ontology/interfaces';
-export * from './ontology/objects';
+export { Todo } from './ontology/objects';
 export * as $Objects from './ontology/objects';
-export * from './ontology/queries';
+export {} from './ontology/queries';
 export * as $Queries from './ontology/queries';
 export { $ontologyRid } from './OntologyMetadata';

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/ontology/objects.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/ontology/objects.ts
@@ -1,1 +1,1 @@
-export * from './objects/Todo';
+export { Todo } from './objects/Todo';

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/ontology/objects/Todo.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/ontology/objects/Todo.ts
@@ -32,10 +32,16 @@ export namespace Todo {
 
   export interface ObjectSet extends $ObjectSet<Todo, Todo.ObjectSet> {}
 
+  export type OsdkInstance<
+    OPTIONS extends never | '$notStrict' | '$rid' = never,
+    K extends keyof Todo.Props = keyof Todo.Props,
+  > = $Osdk.Instance<Todo, OPTIONS, K>;
+
+  /** @deprecated use OsdkInstance */
   export type OsdkObject<
     OPTIONS extends never | '$notStrict' | '$rid' = never,
     K extends keyof Todo.Props = keyof Todo.Props,
-  > = $Osdk<Todo, K | OPTIONS>;
+  > = OsdkInstance<OPTIONS, K>;
 }
 
 export interface Todo extends $ObjectTypeDefinition {

--- a/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.test.ts
+++ b/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.test.ts
@@ -137,10 +137,16 @@ describe(__UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst, () => {
 
         export interface ObjectSet extends $ObjectSet<Bar, Bar.ObjectSet> {}
 
+        export type OsdkInstance<
+          OPTIONS extends never | "$notStrict" | "$rid" = never,
+          K extends keyof Bar.Props = keyof Bar.Props,
+        > = $Osdk.Instance<Bar, OPTIONS, K>;
+
+        /** @deprecated use OsdkInstance */
         export type OsdkObject<
           OPTIONS extends never | "$notStrict" | "$rid" = never,
           K extends keyof Bar.Props = keyof Bar.Props,
-        > = $Osdk<Bar, K | OPTIONS>;
+        > = OsdkInstance<OPTIONS, K>;
       }
 
       export interface Bar extends $InterfaceDefinition {
@@ -223,10 +229,16 @@ describe(__UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst, () => {
 
         export interface ObjectSet extends $ObjectSet<Foo, Foo.ObjectSet> {}
 
+        export type OsdkInstance<
+          OPTIONS extends never | "$notStrict" | "$rid" = never,
+          K extends keyof Foo.Props = keyof Foo.Props,
+        > = $Osdk.Instance<Foo, OPTIONS, K>;
+
+        /** @deprecated use OsdkInstance */
         export type OsdkObject<
           OPTIONS extends never | "$notStrict" | "$rid" = never,
           K extends keyof Foo.Props = keyof Foo.Props,
-        > = $Osdk<Foo, K | OPTIONS>;
+        > = OsdkInstance<OPTIONS, K>;
       }
 
       export interface Foo extends $InterfaceDefinition {
@@ -312,10 +324,16 @@ describe(__UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst, () => {
 
         export interface ObjectSet extends $ObjectSet<Foo, Foo.ObjectSet> {}
 
+        export type OsdkInstance<
+          OPTIONS extends never | "$notStrict" | "$rid" = never,
+          K extends keyof Foo.Props = keyof Foo.Props,
+        > = $Osdk.Instance<Foo, OPTIONS, K>;
+
+        /** @deprecated use OsdkInstance */
         export type OsdkObject<
           OPTIONS extends never | "$notStrict" | "$rid" = never,
           K extends keyof Foo.Props = keyof Foo.Props,
-        > = $Osdk<Foo, K | OPTIONS>;
+        > = OsdkInstance<OPTIONS, K>;
       }
 
       export interface Foo extends $InterfaceDefinition {

--- a/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.ts
+++ b/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.ts
@@ -169,7 +169,7 @@ ${
 
       ${createObjectSet(interfaceDef, ids)}
 
-      ${createOsdkObject(interfaceDef, "OsdkObject", ids)}
+      ${createOsdkObject(interfaceDef, "OsdkInstance", ids)}
       
     }    
 

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -496,13 +496,13 @@ describe("generator", () => {
 
       export const $ontologyRid = 'ridHere';
       ",
-        "/foo/index.ts": "export * from './ontology/actions';
+        "/foo/index.ts": "export { deleteTodos, markTodoCompleted } from './ontology/actions';
       export * as $Actions from './ontology/actions';
-      export * from './ontology/interfaces';
+      export { SomeInterface } from './ontology/interfaces';
       export * as $Interfaces from './ontology/interfaces';
-      export * from './ontology/objects';
+      export { Person, Todo } from './ontology/objects';
       export * as $Objects from './ontology/objects';
-      export * from './ontology/queries';
+      export { getCount, returnsTodo } from './ontology/queries';
       export * as $Queries from './ontology/queries';
       export { $ontologyRid } from './OntologyMetadata';
       ",
@@ -666,7 +666,7 @@ describe("generator", () => {
         osdkMetadata: $osdkMetadata,
       };
       ",
-        "/foo/ontology/interfaces.ts": "export * from './interfaces/SomeInterface';
+        "/foo/ontology/interfaces.ts": "export { SomeInterface } from './interfaces/SomeInterface';
       ",
         "/foo/ontology/interfaces/SomeInterface.ts": "import type { PropertyDef as $PropertyDef } from '@osdk/api';
       import { $osdkMetadata } from '../../OntologyMetadata';
@@ -692,10 +692,16 @@ describe("generator", () => {
 
         export interface ObjectSet extends $ObjectSet<SomeInterface, SomeInterface.ObjectSet> {}
 
+        export type OsdkInstance<
+          OPTIONS extends never | '$notStrict' | '$rid' = never,
+          K extends keyof SomeInterface.Props = keyof SomeInterface.Props,
+        > = $Osdk.Instance<SomeInterface, OPTIONS, K>;
+
+        /** @deprecated use OsdkInstance */
         export type OsdkObject<
           OPTIONS extends never | '$notStrict' | '$rid' = never,
           K extends keyof SomeInterface.Props = keyof SomeInterface.Props,
-        > = $Osdk<SomeInterface, K | OPTIONS>;
+        > = OsdkInstance<OPTIONS, K>;
       }
 
       export interface SomeInterface extends $InterfaceDefinition {
@@ -730,8 +736,8 @@ describe("generator", () => {
         osdkMetadata: $osdkMetadata,
       };
       ",
-        "/foo/ontology/objects.ts": "export * from './objects/Person';
-      export * from './objects/Todo';
+        "/foo/ontology/objects.ts": "export { Person } from './objects/Person';
+      export { Todo } from './objects/Todo';
       ",
         "/foo/ontology/objects/Person.ts": "import type { PropertyDef as $PropertyDef } from '@osdk/api';
       import { $osdkMetadata } from '../../OntologyMetadata';
@@ -766,10 +772,16 @@ describe("generator", () => {
 
         export interface ObjectSet extends $ObjectSet<Person, Person.ObjectSet> {}
 
+        export type OsdkInstance<
+          OPTIONS extends never | '$notStrict' | '$rid' = never,
+          K extends keyof Person.Props = keyof Person.Props,
+        > = $Osdk.Instance<Person, OPTIONS, K>;
+
+        /** @deprecated use OsdkInstance */
         export type OsdkObject<
           OPTIONS extends never | '$notStrict' | '$rid' = never,
           K extends keyof Person.Props = keyof Person.Props,
-        > = $Osdk<Person, K | OPTIONS>;
+        > = OsdkInstance<OPTIONS, K>;
       }
 
       export interface Person extends $ObjectTypeDefinition {
@@ -854,10 +866,16 @@ describe("generator", () => {
 
         export interface ObjectSet extends $ObjectSet<Todo, Todo.ObjectSet> {}
 
+        export type OsdkInstance<
+          OPTIONS extends never | '$notStrict' | '$rid' = never,
+          K extends keyof Todo.Props = keyof Todo.Props,
+        > = $Osdk.Instance<Todo, OPTIONS, K>;
+
+        /** @deprecated use OsdkInstance */
         export type OsdkObject<
           OPTIONS extends never | '$notStrict' | '$rid' = never,
           K extends keyof Todo.Props = keyof Todo.Props,
-        > = $Osdk<Todo, K | OPTIONS>;
+        > = OsdkInstance<OPTIONS, K>;
       }
 
       export interface Todo extends $ObjectTypeDefinition {
@@ -922,8 +940,8 @@ describe("generator", () => {
         osdkMetadata: $osdkMetadata,
       };
       ",
-        "/foo/ontology/queries.ts": "export * from './queries/getCount';
-      export * from './queries/returnsTodo';
+        "/foo/ontology/queries.ts": "export { getCount } from './queries/getCount';
+      export { returnsTodo } from './queries/returnsTodo';
       ",
         "/foo/ontology/queries/getCount.ts": "import type { QueryDefinition, VersionBound } from '@osdk/api';
       import type { QueryParam, QueryResult } from '@osdk/api';
@@ -1094,13 +1112,13 @@ describe("generator", () => {
 
         export const $ontologyRid = 'ridHere';
         ",
-          "/foo/index.ts": "export * from './ontology/actions.js';
+          "/foo/index.ts": "export { deleteTodos, markTodoCompleted } from './ontology/actions.js';
         export * as $Actions from './ontology/actions.js';
-        export * from './ontology/interfaces.js';
+        export { SomeInterface } from './ontology/interfaces.js';
         export * as $Interfaces from './ontology/interfaces.js';
-        export * from './ontology/objects.js';
+        export { Person, Todo } from './ontology/objects.js';
         export * as $Objects from './ontology/objects.js';
-        export * from './ontology/queries.js';
+        export { getCount, returnsTodo } from './ontology/queries.js';
         export * as $Queries from './ontology/queries.js';
         export { $ontologyRid } from './OntologyMetadata.js';
         ",
@@ -1264,7 +1282,7 @@ describe("generator", () => {
           osdkMetadata: $osdkMetadata,
         };
         ",
-          "/foo/ontology/interfaces.ts": "export * from './interfaces/SomeInterface.js';
+          "/foo/ontology/interfaces.ts": "export { SomeInterface } from './interfaces/SomeInterface.js';
         ",
           "/foo/ontology/interfaces/SomeInterface.ts": "import type { PropertyDef as $PropertyDef } from '@osdk/api';
         import { $osdkMetadata } from '../../OntologyMetadata.js';
@@ -1290,10 +1308,16 @@ describe("generator", () => {
 
           export interface ObjectSet extends $ObjectSet<SomeInterface, SomeInterface.ObjectSet> {}
 
+          export type OsdkInstance<
+            OPTIONS extends never | '$notStrict' | '$rid' = never,
+            K extends keyof SomeInterface.Props = keyof SomeInterface.Props,
+          > = $Osdk.Instance<SomeInterface, OPTIONS, K>;
+
+          /** @deprecated use OsdkInstance */
           export type OsdkObject<
             OPTIONS extends never | '$notStrict' | '$rid' = never,
             K extends keyof SomeInterface.Props = keyof SomeInterface.Props,
-          > = $Osdk<SomeInterface, K | OPTIONS>;
+          > = OsdkInstance<OPTIONS, K>;
         }
 
         export interface SomeInterface extends $InterfaceDefinition {
@@ -1328,8 +1352,8 @@ describe("generator", () => {
           osdkMetadata: $osdkMetadata,
         };
         ",
-          "/foo/ontology/objects.ts": "export * from './objects/Person.js';
-        export * from './objects/Todo.js';
+          "/foo/ontology/objects.ts": "export { Person } from './objects/Person.js';
+        export { Todo } from './objects/Todo.js';
         ",
           "/foo/ontology/objects/Person.ts": "import type { PropertyDef as $PropertyDef } from '@osdk/api';
         import { $osdkMetadata } from '../../OntologyMetadata.js';
@@ -1364,10 +1388,16 @@ describe("generator", () => {
 
           export interface ObjectSet extends $ObjectSet<Person, Person.ObjectSet> {}
 
+          export type OsdkInstance<
+            OPTIONS extends never | '$notStrict' | '$rid' = never,
+            K extends keyof Person.Props = keyof Person.Props,
+          > = $Osdk.Instance<Person, OPTIONS, K>;
+
+          /** @deprecated use OsdkInstance */
           export type OsdkObject<
             OPTIONS extends never | '$notStrict' | '$rid' = never,
             K extends keyof Person.Props = keyof Person.Props,
-          > = $Osdk<Person, K | OPTIONS>;
+          > = OsdkInstance<OPTIONS, K>;
         }
 
         export interface Person extends $ObjectTypeDefinition {
@@ -1452,10 +1482,16 @@ describe("generator", () => {
 
           export interface ObjectSet extends $ObjectSet<Todo, Todo.ObjectSet> {}
 
+          export type OsdkInstance<
+            OPTIONS extends never | '$notStrict' | '$rid' = never,
+            K extends keyof Todo.Props = keyof Todo.Props,
+          > = $Osdk.Instance<Todo, OPTIONS, K>;
+
+          /** @deprecated use OsdkInstance */
           export type OsdkObject<
             OPTIONS extends never | '$notStrict' | '$rid' = never,
             K extends keyof Todo.Props = keyof Todo.Props,
-          > = $Osdk<Todo, K | OPTIONS>;
+          > = OsdkInstance<OPTIONS, K>;
         }
 
         export interface Todo extends $ObjectTypeDefinition {
@@ -1520,8 +1556,8 @@ describe("generator", () => {
           osdkMetadata: $osdkMetadata,
         };
         ",
-          "/foo/ontology/queries.ts": "export * from './queries/getCount.js';
-        export * from './queries/returnsTodo.js';
+          "/foo/ontology/queries.ts": "export { getCount } from './queries/getCount.js';
+        export { returnsTodo } from './queries/returnsTodo.js';
         ",
           "/foo/ontology/queries/getCount.ts": "import type { QueryDefinition, VersionBound } from '@osdk/api';
         import type { QueryParam, QueryResult } from '@osdk/api';
@@ -1847,10 +1883,16 @@ describe("generator", () => {
 
             export interface ObjectSet extends $ObjectSet<UsesForeignSpt, UsesForeignSpt.ObjectSet> {}
 
+            export type OsdkInstance<
+              OPTIONS extends never | '$notStrict' | '$rid' = never,
+              K extends keyof UsesForeignSpt.Props = keyof UsesForeignSpt.Props,
+            > = $Osdk.Instance<UsesForeignSpt, OPTIONS, K>;
+
+            /** @deprecated use OsdkInstance */
             export type OsdkObject<
               OPTIONS extends never | '$notStrict' | '$rid' = never,
               K extends keyof UsesForeignSpt.Props = keyof UsesForeignSpt.Props,
-            > = $Osdk<UsesForeignSpt, K | OPTIONS>;
+            > = OsdkInstance<OPTIONS, K>;
           }
 
           export interface UsesForeignSpt extends $ObjectTypeDefinition {
@@ -2020,19 +2062,19 @@ describe("generator", () => {
 
         export const $ontologyRid = 'ri.ontology.main.ontology.dep';
         ",
-          "/foo/index.ts": "export * from './ontology/actions.js';
+          "/foo/index.ts": "export {} from './ontology/actions.js';
         export * as $Actions from './ontology/actions.js';
-        export * from './ontology/interfaces.js';
+        export { SomeInterface } from './ontology/interfaces.js';
         export * as $Interfaces from './ontology/interfaces.js';
-        export * from './ontology/objects.js';
+        export { Task } from './ontology/objects.js';
         export * as $Objects from './ontology/objects.js';
-        export * from './ontology/queries.js';
+        export {} from './ontology/queries.js';
         export * as $Queries from './ontology/queries.js';
         export { $ontologyRid } from './OntologyMetadata.js';
         ",
           "/foo/ontology/actions.ts": "export {};
         ",
-          "/foo/ontology/interfaces.ts": "export * from './interfaces/SomeInterface.js';
+          "/foo/ontology/interfaces.ts": "export { SomeInterface } from './interfaces/SomeInterface.js';
         ",
           "/foo/ontology/interfaces/SomeInterface.ts": "import type { PropertyDef as $PropertyDef } from '@osdk/api';
         import { $osdkMetadata } from '../../OntologyMetadata.js';
@@ -2058,10 +2100,16 @@ describe("generator", () => {
 
           export interface ObjectSet extends $ObjectSet<SomeInterface, SomeInterface.ObjectSet> {}
 
+          export type OsdkInstance<
+            OPTIONS extends never | '$notStrict' | '$rid' = never,
+            K extends keyof SomeInterface.Props = keyof SomeInterface.Props,
+          > = $Osdk.Instance<SomeInterface, OPTIONS, K>;
+
+          /** @deprecated use OsdkInstance */
           export type OsdkObject<
             OPTIONS extends never | '$notStrict' | '$rid' = never,
             K extends keyof SomeInterface.Props = keyof SomeInterface.Props,
-          > = $Osdk<SomeInterface, K | OPTIONS>;
+          > = OsdkInstance<OPTIONS, K>;
         }
 
         export interface SomeInterface extends $InterfaceDefinition {
@@ -2094,7 +2142,7 @@ describe("generator", () => {
           osdkMetadata: $osdkMetadata,
         };
         ",
-          "/foo/ontology/objects.ts": "export * from './objects/Task.js';
+          "/foo/ontology/objects.ts": "export { Task } from './objects/Task.js';
         ",
           "/foo/ontology/objects/Task.ts": "import type { PropertyDef as $PropertyDef } from '@osdk/api';
         import { $osdkMetadata } from '../../OntologyMetadata.js';
@@ -2128,10 +2176,16 @@ describe("generator", () => {
 
           export interface ObjectSet extends $ObjectSet<Task, Task.ObjectSet> {}
 
+          export type OsdkInstance<
+            OPTIONS extends never | '$notStrict' | '$rid' = never,
+            K extends keyof Task.Props = keyof Task.Props,
+          > = $Osdk.Instance<Task, OPTIONS, K>;
+
+          /** @deprecated use OsdkInstance */
           export type OsdkObject<
             OPTIONS extends never | '$notStrict' | '$rid' = never,
             K extends keyof Task.Props = keyof Task.Props,
-          > = $Osdk<Task, K | OPTIONS>;
+          > = OsdkInstance<OPTIONS, K>;
         }
 
         export interface Task extends $ObjectTypeDefinition {

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
@@ -14,81 +14,18 @@
  * limitations under the License.
  */
 
-import path from "node:path";
-import { EnhancedInterfaceType } from "../GenerateContext/EnhancedInterfaceType.js";
-import { EnhancedObjectType } from "../GenerateContext/EnhancedObjectType.js";
 import { enhanceOntology } from "../GenerateContext/enhanceOntology.js";
-import { ForeignType } from "../GenerateContext/ForeignType.js";
 import type { GenerateContext } from "../GenerateContext/GenerateContext.js";
 import type { MinimalFs } from "../MinimalFs.js";
 import { sanitizeMetadata } from "../shared/sanitizeMetadata.js";
-import { formatTs } from "../util/test/formatTs.js";
 import { verifyOutDir } from "../util/verifyOutDir.js";
 import type { WireOntologyDefinition } from "../WireOntologyDefinition.js";
 import { generateOntologyMetadataFile } from "./generateMetadata.js";
 import { generatePerActionDataFiles } from "./generatePerActionDataFiles.js";
+import { generatePerInterfaceDataFiles } from "./generatePerInterfaceDataFiles.js";
+import { generatePerObjectDataFiles } from "./generatePerObjectDataFiles.js";
 import { generatePerQueryDataFilesV2 } from "./generatePerQueryDataFiles.js";
-import { __UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst } from "./UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.js";
-import {
-  wireObjectTypeV2ToSdkObjectConstV2,
-} from "./wireObjectTypeV2ToSdkObjectConstV2.js";
-
-async function generateRootIndexTsFile(
-  { fs, outDir, importExt, ontologyApiNamespace }: GenerateContext,
-) {
-  fs.writeFile(
-    path.join(outDir, "index.ts"),
-    await formatTs(
-      `export * from "./ontology/actions${importExt}";
-        export * as $Actions from "./ontology/actions${importExt}";
-        export * from "./ontology/interfaces${importExt}";
-        export * as $Interfaces from "./ontology/interfaces${importExt}";
-        export * from "./ontology/objects${importExt}";
-        export * as $Objects from "./ontology/objects${importExt}";
-        export * from "./ontology/queries${importExt}";
-        export * as $Queries from "./ontology/queries${importExt}";
-        ${
-        ontologyApiNamespace == null
-          ? `export { $ontologyRid } from "./OntologyMetadata${importExt}";`
-          : ``
-      }
-    `,
-    ),
-  );
-}
-
-async function generateEachObjectFile(
-  ctx: GenerateContext,
-) {
-  const {
-    fs,
-    outDir,
-    ontology,
-    importExt,
-  } = ctx;
-  await fs.mkdir(path.join(outDir, "ontology", "objects"), { recursive: true });
-  for (const obj of Object.values(ontology.objectTypes)) {
-    if (obj instanceof ForeignType) continue;
-
-    const relPath = path.join(
-      ".",
-      "ontology",
-      `objects`,
-      `${obj.shortApiName}.ts`,
-    );
-
-    const outFilePath = path.join(outDir, relPath);
-    await fs.writeFile(
-      outFilePath,
-      await formatTs(`
-        import type { PropertyDef as $PropertyDef } from "@osdk/api";
-        import { $osdkMetadata } from "../../OntologyMetadata${importExt}";
-        import type { $ExpectedClientVersion } from "../../OntologyMetadata${importExt}";
-        ${wireObjectTypeV2ToSdkObjectConstV2(obj.raw, ctx, relPath)}
-      `),
-    );
-  }
-}
+import { generateRootIndexTsFile } from "./generateRootIndexTsFile.js";
 
 export async function generateClientSdkVersionTwoPointZero(
   ontology: WireOntologyDefinition,
@@ -128,73 +65,8 @@ export async function generateClientSdkVersionTwoPointZero(
 
   await generateRootIndexTsFile(ctx);
   await generateOntologyMetadataFile(ctx, userAgent);
-  await generateEachObjectFile(ctx);
-  await generateOntologyInterfaces(ctx);
-
-  const actionsDir = path.join(outDir, "ontology", "actions");
-  await fs.mkdir(actionsDir, { recursive: true });
+  await generatePerObjectDataFiles(ctx);
+  await generatePerInterfaceDataFiles(ctx);
   await generatePerActionDataFiles(ctx);
-
-  await fs.writeFile(
-    path.join(outDir, "ontology", "objects.ts"),
-    await formatTs(`
-    ${
-      Object.values(enhancedOntology.objectTypes).filter(o =>
-        o instanceof EnhancedObjectType
-      ).map(objType =>
-        `export * from "./objects/${objType.shortApiName}${importExt}";`
-      ).join("\n")
-    }
-    ${Object.keys(ontology.objectTypes).length === 0 ? "export {};" : ""}
-    `),
-  );
-
   await generatePerQueryDataFilesV2(ctx, true);
-}
-
-/** @internal */
-async function generateOntologyInterfaces(
-  { fs, outDir, ontology, importExt }: GenerateContext,
-) {
-  const interfacesDir = path.join(outDir, "ontology", "interfaces");
-  await fs.mkdir(interfacesDir, {
-    recursive: true,
-  });
-
-  for (const obj of Object.values(ontology.interfaceTypes)) {
-    if (obj instanceof ForeignType) continue;
-
-    await fs.writeFile(
-      path.join(interfacesDir, `${obj.shortApiName}.ts`),
-      await formatTs(`
-        import type { PropertyDef as $PropertyDef } from "@osdk/api";
-        import { $osdkMetadata } from "../../OntologyMetadata${importExt}";
-      ${
-        __UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst(
-          obj,
-          ontology,
-          true,
-        )
-      }
-    `),
-    );
-  }
-
-  await fs.writeFile(
-    interfacesDir + ".ts",
-    await formatTs(`
-    ${
-      Object.values(ontology.interfaceTypes).filter(i =>
-        i instanceof EnhancedInterfaceType
-      ).map(interfaceType =>
-        `export * from "./interfaces/${interfaceType.shortApiName}${importExt}";`
-      ).join("\n")
-    }
-    ${
-      Object.keys(ontology.interfaceTypes).length === 0
-        ? "export {}"
-        : ""
-    }
-    `),
-  );
 }

--- a/packages/generator/src/v2.0/generatePerInterfaceDataFiles.ts
+++ b/packages/generator/src/v2.0/generatePerInterfaceDataFiles.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import path from "node:path";
+import { EnhancedInterfaceType } from "../GenerateContext/EnhancedInterfaceType.js";
+import { ForeignType } from "../GenerateContext/ForeignType.js";
+import type { GenerateContext } from "../GenerateContext/GenerateContext.js";
+import { formatTs } from "../util/test/formatTs.js";
+import { __UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst } from "./UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.js";
+
+/** @internal */
+export async function generatePerInterfaceDataFiles(
+  { fs, outDir, ontology, importExt }: GenerateContext,
+) {
+  const interfacesDir = path.join(outDir, "ontology", "interfaces");
+  await fs.mkdir(interfacesDir, {
+    recursive: true,
+  });
+
+  for (const obj of Object.values(ontology.interfaceTypes)) {
+    if (obj instanceof ForeignType) continue;
+
+    await fs.writeFile(
+      path.join(interfacesDir, `${obj.shortApiName}.ts`),
+      await formatTs(`
+        import type { PropertyDef as $PropertyDef } from "@osdk/api";
+        import { $osdkMetadata } from "../../OntologyMetadata${importExt}";
+      ${
+        __UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst(
+          obj,
+          ontology,
+          true,
+        )
+      }
+    `),
+    );
+  }
+
+  await fs.writeFile(
+    interfacesDir + ".ts",
+    await formatTs(`
+    ${
+      Object.values(ontology.interfaceTypes).filter(i =>
+        i instanceof EnhancedInterfaceType
+      ).map(interfaceType =>
+        `export {${interfaceType.shortApiName}} from "./interfaces/${interfaceType.shortApiName}${importExt}";`
+      ).join("\n")
+    }
+    ${
+      Object.keys(ontology.interfaceTypes).length === 0
+        ? "export {}"
+        : ""
+    }
+    `),
+  );
+}

--- a/packages/generator/src/v2.0/generatePerObjectDataFiles.ts
+++ b/packages/generator/src/v2.0/generatePerObjectDataFiles.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import path from "node:path";
+import { EnhancedObjectType } from "../GenerateContext/EnhancedObjectType.js";
+import { ForeignType } from "../GenerateContext/ForeignType.js";
+import type { GenerateContext } from "../GenerateContext/GenerateContext.js";
+import { formatTs } from "../util/test/formatTs.js";
+import {
+  wireObjectTypeV2ToSdkObjectConstV2,
+} from "./wireObjectTypeV2ToSdkObjectConstV2.js";
+
+export async function generatePerObjectDataFiles(
+  ctx: GenerateContext,
+) {
+  const {
+    fs,
+    outDir,
+    ontology,
+    importExt,
+  } = ctx;
+  await fs.mkdir(path.join(outDir, "ontology", "objects"), { recursive: true });
+  for (const obj of Object.values(ontology.objectTypes)) {
+    if (obj instanceof ForeignType) continue;
+    const relPath = path.join(
+      ".",
+      "ontology",
+      `objects`,
+      `${obj.shortApiName}.ts`,
+    );
+
+    const outFilePath = path.join(outDir, relPath);
+    await fs.writeFile(
+      outFilePath,
+      await formatTs(`
+        import type { PropertyDef as $PropertyDef } from "@osdk/api";
+        import { $osdkMetadata } from "../../OntologyMetadata${importExt}";
+        import type { $ExpectedClientVersion } from "../../OntologyMetadata${importExt}";
+        ${wireObjectTypeV2ToSdkObjectConstV2(obj.raw, ctx, relPath)}
+      `),
+    );
+  }
+
+  await fs.writeFile(
+    path.join(outDir, "ontology", "objects.ts"),
+    await formatTs(`
+    ${
+      Object.values(ctx.ontology.objectTypes).filter(o =>
+        o instanceof EnhancedObjectType
+      ).map(objType =>
+        `export {${objType.shortApiName}} from "./objects/${objType.shortApiName}${importExt}";`
+      ).join("\n")
+    }
+    ${Object.keys(ontology.objectTypes).length === 0 ? "export {};" : ""}
+    `),
+  );
+}

--- a/packages/generator/src/v2.0/generatePerQueryDataFiles.test.ts
+++ b/packages/generator/src/v2.0/generatePerQueryDataFiles.test.ts
@@ -44,8 +44,8 @@ describe("generatePerQueryDataFiles", () => {
 
     expect(helper.getFiles()).toMatchInlineSnapshot(`
       {
-        "/foo/ontology/queries.ts": "export * from './queries/getCount.js';
-      export * from './queries/returnsTodo.js';
+        "/foo/ontology/queries.ts": "export { getCount } from './queries/getCount.js';
+      export { returnsTodo } from './queries/returnsTodo.js';
       ",
         "/foo/ontology/queries/getCount.ts": "import type { QueryDefinition, VersionBound } from '@osdk/api';
       import type { QueryParam, QueryResult } from '@osdk/api';

--- a/packages/generator/src/v2.0/generatePerQueryDataFiles.ts
+++ b/packages/generator/src/v2.0/generatePerQueryDataFiles.ts
@@ -70,7 +70,9 @@ export async function generatePerQueryDataFilesV2(
     await formatTs(`
     ${
       Object.values(ontology.queryTypes).map(query =>
-        `export * from "${query.getImportPathRelTo(relOutDir)}";`
+        `export {${query.shortApiName}} from "${
+          query.getImportPathRelTo(relOutDir)
+        }";`
       )
         .join("\n")
     }

--- a/packages/generator/src/v2.0/generateRootIndexTsFile.ts
+++ b/packages/generator/src/v2.0/generateRootIndexTsFile.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import path from "node:path";
+import { ForeignType } from "../GenerateContext/ForeignType.js";
+import type { GenerateContext } from "../GenerateContext/GenerateContext.js";
+import { formatTs } from "../util/test/formatTs.js";
+
+export async function generateRootIndexTsFile(
+  { fs, outDir, importExt, ontologyApiNamespace, ontology }: GenerateContext,
+) {
+  fs.writeFile(
+    path.join(outDir, "index.ts"),
+    await formatTs(
+      `export {${
+        helper(ontology.actionTypes)
+      }} from "./ontology/actions${importExt}";
+        export * as $Actions from "./ontology/actions${importExt}";
+        export {${
+        helper(ontology.interfaceTypes)
+      }} from "./ontology/interfaces${importExt}";
+        export * as $Interfaces from "./ontology/interfaces${importExt}";
+        export {${
+        helper(ontology.objectTypes)
+      }} from "./ontology/objects${importExt}";
+        export * as $Objects from "./ontology/objects${importExt}";
+        export {${
+        helper(ontology.queryTypes)
+      }} from "./ontology/queries${importExt}";
+        export * as $Queries from "./ontology/queries${importExt}";
+        ${
+        ontologyApiNamespace == null
+          ? `export { $ontologyRid } from "./OntologyMetadata${importExt}";`
+          : ``
+      }
+    `,
+    ),
+  );
+}
+
+function helper(x: Record<string, { shortApiName: string }>) {
+  return Object.values(x).filter(x => !(x instanceof ForeignType)).map(a =>
+    a.shortApiName
+  ).join(
+    ", ",
+  );
+}

--- a/packages/generator/src/v2.0/wireObjectTypeV2ToSdkObjectConstV2.ts
+++ b/packages/generator/src/v2.0/wireObjectTypeV2ToSdkObjectConstV2.ts
@@ -106,7 +106,7 @@ export function wireObjectTypeV2ToSdkObjectConstV2(
 
       ${createObjectSet(object, identifiers)}
       
-      ${createOsdkObject(object, "OsdkObject", identifiers)}
+      ${createOsdkObject(object, "OsdkInstance", identifiers)}
     }    
 
 
@@ -157,16 +157,22 @@ export function createOsdkObject(
 ) {
   const definition = object.getCleanedUpDefinition(true);
   return `
-  export type ${identifier}<
+    export type ${identifier}<
       OPTIONS extends never | "$notStrict" | "$rid" = never,
       K extends keyof ${osdkObjectPropsIdentifier}= keyof ${osdkObjectPropsIdentifier},
-
-  > 
-    = $Osdk<
+    > 
+    = $Osdk.Instance<
         ${objectDefIdentifier}, 
-        K | OPTIONS
-      > 
+        OPTIONS,
+        K
+      >;
    
+
+    /** @deprecated use ${identifier} */
+    export type OsdkObject<
+      OPTIONS extends never | "$notStrict" | "$rid" = never,
+      K extends keyof ${osdkObjectPropsIdentifier}= keyof ${osdkObjectPropsIdentifier},
+    > = ${identifier}<OPTIONS, K>;
   ;
     `;
 }


### PR DESCRIPTION
Following some confusion about type assignability and that the `Osdk<>` type was causing a bit of complexity,  I thought it might make sense to further refine the types.

Further we can adapt what we have as well such that:
- `Osdk` object still remains the primary object used but generated code refers to the `Instance` or `OsdkObject`.


