### PR TITLE
Fix queries that return arrays

### DIFF
--- a/.changeset/selfish-suits-thank.md
+++ b/.changeset/selfish-suits-thank.md
@@ -1,0 +1,6 @@
+---
+"@osdk/shared.test": patch
+"@osdk/client": patch
+---
+
+Fix queries that have response types with nested values, like arrays.

--- a/packages/client/src/queries/applyQuery.ts
+++ b/packages/client/src/queries/applyQuery.ts
@@ -116,9 +116,9 @@ async function remapQueryResponse<
     const withoutMultiplicity = { ...responseDataType, multiplicity: false };
     for (let i = 0; i < responseValue.length; i++) {
       responseValue[i] = await remapQueryResponse(
-        responseValue[i],
-        withoutMultiplicity,
         client,
+        withoutMultiplicity,
+        responseValue[i],
         definitions,
       );
     }
@@ -133,9 +133,9 @@ async function remapQueryResponse<
     case "set": {
       for (let i = 0; i < responseValue.length; i++) {
         responseValue[i] = await remapQueryResponse(
-          responseValue[i],
-          responseDataType.set,
           client,
+          responseDataType.set,
+          responseValue[i],
           definitions,
         );
       }
@@ -193,9 +193,9 @@ async function remapQueryResponse<
       for (const [key, subtype] of Object.entries(responseDataType.struct)) {
         if (requiresConversion(subtype)) {
           responseValue[key] = await remapQueryResponse(
-            responseValue[key],
-            subtype,
             client,
+            subtype,
+            responseValue[key],
             definitions,
           );
         }

--- a/packages/client/src/queries/queries.test.ts
+++ b/packages/client/src/queries/queries.test.ts
@@ -232,7 +232,7 @@ describe("queries", () => {
 
   it("queries work with arrays", async () => {
     const result = await client($Queries.queryTypeReturnsArray).executeFunction(
-      { country: ["Brad", "George", "Ryan"] },
+      { people: ["Brad", "George", "Ryan"] },
     );
     expect(result).toEqual(["Pitt", "Clooney", "Reynolds"]);
   });

--- a/packages/client/src/queries/queries.test.ts
+++ b/packages/client/src/queries/queries.test.ts
@@ -221,11 +221,19 @@ describe("queries", () => {
       "incrementPersonAge",
       "queryAcceptsObject",
       "queryAcceptsObjectSets",
+      "queryTypeReturnsArray",
       "returnsDate",
       "returnsObject",
       "returnsTimestamp",
       "threeDimensionalAggregationFunction",
       "twoDimensionalAggregationFunction",
     ]);
+  });
+
+  it("queries work with arrays", async () => {
+    const result = await client($Queries.queryTypeReturnsArray).executeFunction(
+      { country: ["Brad", "George", "Ryan"] },
+    );
+    expect(result).toEqual(["Pitt", "Clooney", "Reynolds"]);
   });
 });

--- a/packages/e2e.generated.catchall/ontology.json
+++ b/packages/e2e.generated.catchall/ontology.json
@@ -880,6 +880,20 @@
       "parameters": {},
       "rid": "query.rid2",
       "version": "0.1.2"
+    },
+    "getNamesOfCustomersFromCountry": {
+      "apiName": "getNamesOfCustomersFromCountry",
+      "output": {
+        "type": "array",
+        "subType": { "type": "string" }
+      },
+      "parameters": {
+        "country": {
+          "dataType": { "type": "string" }
+        }
+      },
+      "rid": "ri.function-registry.main.function.c3e58d52-8430-44ee-9f0b-3785d9a9bdda",
+      "version": "0.1.1"
     }
   },
   "interfaceTypes": {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/queries.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/queries.ts
@@ -1,2 +1,3 @@
+export * from './queries/getNamesOfCustomersFromCountry.js';
 export * from './queries/getTodoCount.js';
 export * from './queries/queryTakesAllParameterTypes.js';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/queries/getNamesOfCustomersFromCountry.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/queries/getNamesOfCustomersFromCountry.ts
@@ -1,0 +1,54 @@
+import type { QueryDefinition, VersionBound } from '@osdk/api';
+import type { QueryParam, QueryResult } from '@osdk/api';
+import type { $ExpectedClientVersion } from '../../OntologyMetadata.js';
+import { $osdkMetadata } from '../../OntologyMetadata.js';
+
+export namespace getNamesOfCustomersFromCountry {
+  export interface Signature {
+    (query: getNamesOfCustomersFromCountry.Parameters): Promise<Array<QueryResult.PrimitiveType<'string'>>>;
+  }
+
+  export interface Parameters {
+    /**
+     * (no ontology metadata)
+     */
+    readonly country: QueryParam.PrimitiveType<'string'>;
+  }
+}
+
+export interface getNamesOfCustomersFromCountry
+  extends QueryDefinition<getNamesOfCustomersFromCountry.Signature>,
+    VersionBound<$ExpectedClientVersion> {
+  __DefinitionMetadata?: {
+    apiName: 'getNamesOfCustomersFromCountry';
+    rid: 'ri.function-registry.main.function.c3e58d52-8430-44ee-9f0b-3785d9a9bdda';
+    type: 'query';
+    version: '0.1.1';
+    parameters: {
+      /**
+       * (no ontology metadata)
+       */
+      country: {
+        nullable: false;
+        type: 'string';
+      };
+    };
+    output: {
+      multiplicity: true;
+      nullable: false;
+      type: 'string';
+    };
+    signature: getNamesOfCustomersFromCountry.Signature;
+  };
+  apiName: 'getNamesOfCustomersFromCountry';
+  type: 'query';
+  version: '0.1.1';
+  osdkMetadata: typeof $osdkMetadata;
+}
+
+export const getNamesOfCustomersFromCountry: getNamesOfCustomersFromCountry = {
+  apiName: 'getNamesOfCustomersFromCountry',
+  type: 'query',
+  version: '0.1.1',
+  osdkMetadata: $osdkMetadata,
+};

--- a/packages/e2e.sandbox.catchall/src/index.ts
+++ b/packages/e2e.sandbox.catchall/src/index.ts
@@ -23,6 +23,7 @@ import { runFoundrySdkClientVerificationTest } from "./runFoundrySdkClientVerifi
 import { runGeoQueriesTest } from "./runGeoQueriesTest.js";
 import { runInterfacesTest } from "./runInterfacesTest.js";
 import { runLegacyExamples } from "./runLegacyExamples.js";
+import { runQueriesTest } from "./runQueriesTest.js";
 import { runSubscriptionsTest } from "./runSubscriptionsTest.js";
 import { runTimeseriesTest } from "./runTimeseriesTest.js";
 import { typeChecks } from "./typeChecks.js";
@@ -58,6 +59,8 @@ async function runTests() {
     await runAggregationsTest();
 
     await runAggregationGroupByDatesTest();
+
+    await runQueriesTest();
 
     if (runOld) await typeChecks(client);
 

--- a/packages/e2e.sandbox.catchall/src/runQueriesTest.ts
+++ b/packages/e2e.sandbox.catchall/src/runQueriesTest.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  $Queries,
+  getNamesOfCustomersFromCountry,
+} from "@osdk/e2e.generated.catchall";
+import { client } from "./client.js";
+
+export async function runQueriesTest() {
+  const result = await client(getNamesOfCustomersFromCountry).executeFunction({
+    country: "Denmark",
+  });
+
+  console.log(result);
+}

--- a/packages/monorepo.cspell/cspell.config.js
+++ b/packages/monorepo.cspell/cspell.config.js
@@ -140,6 +140,9 @@ const cspell = {
 
         // used in a const (that is removed in a different PR)
         "asdfasdfdhjlkajhgj",
+
+        // Used in a stub
+        "Clooney",
       ],
     },
     {

--- a/packages/shared.test/src/stubs/queries.ts
+++ b/packages/shared.test/src/stubs/queries.ts
@@ -25,6 +25,7 @@ import {
   queryTypeAcceptsObjectSets,
   queryTypeAcceptsThreeDimensionalAggregation,
   queryTypeAcceptsTwoDimensionalAggregation,
+  queryTypeReturnsArray,
   queryTypeReturnsDate,
   queryTypeReturnsObject,
   queryTypeReturnsStruct,
@@ -223,6 +224,16 @@ export const queryTypeAcceptsThreeDimensionalAggregationResponse:
     },
   };
 
+export const queryTypeReturnsArrayRequest: ExecuteQueryRequest = {
+  parameters: {
+    country: ["Brad", "George", "Ryan"],
+  },
+};
+
+export const queryTypeReturnsArrayResponse: ExecuteQueryResponse = {
+  value: ["Pitt", "Clooney", "Reynolds"],
+};
+
 export const emptyBody: string = JSON.stringify({
   parameters: {},
 });
@@ -270,5 +281,9 @@ export const queryRequestHandlers: {
   [queryTypeAcceptsThreeDimensionalAggregation.apiName]: {
     [JSON.stringify(queryTypeAcceptsThreeDimensionalAggregationRequest)]:
       queryTypeAcceptsThreeDimensionalAggregationResponse,
+  },
+  [queryTypeReturnsArray.apiName]: {
+    [JSON.stringify(queryTypeReturnsArrayRequest)]:
+      queryTypeReturnsArrayResponse,
   },
 };

--- a/packages/shared.test/src/stubs/queries.ts
+++ b/packages/shared.test/src/stubs/queries.ts
@@ -226,7 +226,7 @@ export const queryTypeAcceptsThreeDimensionalAggregationResponse:
 
 export const queryTypeReturnsArrayRequest: ExecuteQueryRequest = {
   parameters: {
-    country: ["Brad", "George", "Ryan"],
+    people: ["Brad", "George", "Ryan"],
   },
 };
 

--- a/packages/shared.test/src/stubs/queryTypes.ts
+++ b/packages/shared.test/src/stubs/queryTypes.ts
@@ -311,6 +311,25 @@ export const queryTypeAcceptsObjectSets: QueryTypeV2 = {
     "ri.function-registry.main.function.9b55870a-63c7-4d48-8f06-9627c0805968",
   version: "0.11.0",
 };
+
+export const queryTypeReturnsArray: QueryTypeV2 = {
+  "apiName": "queryTypeReturnsArray",
+  "output": {
+    "type": "array",
+    "subType": { "type": "string" },
+  },
+  "parameters": {
+    "country": {
+      "dataType": {
+        "type": "array",
+        "subType": { "type": "string" },
+      },
+    },
+  },
+  "rid":
+    "ri.function-registry.main.function.c3e58d52-8430-44ee-9f0b-3785d9a9bdda",
+  "version": "0.1.1",
+};
 export const queryTypes: QueryTypeV2[] = [
   addOneQueryType,
   queryTypeReturnsStruct,
@@ -323,4 +342,5 @@ export const queryTypes: QueryTypeV2[] = [
   queryTypeAcceptsObjectSets,
   queryTypeAcceptsTwoDimensionalAggregation,
   queryTypeAcceptsThreeDimensionalAggregation,
+  queryTypeReturnsArray,
 ];

--- a/packages/shared.test/src/stubs/queryTypes.ts
+++ b/packages/shared.test/src/stubs/queryTypes.ts
@@ -319,7 +319,7 @@ export const queryTypeReturnsArray: QueryTypeV2 = {
     "subType": { "type": "string" },
   },
   "parameters": {
-    "country": {
+    "people": {
       "dataType": {
         "type": "array",
         "subType": { "type": "string" },


### PR DESCRIPTION
There was a mismatch of inputs for remapping query responses when we had arrays and other nested response types, which caused us to return the client context instead of the actual return data