### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -79,9 +79,14 @@
   },
   "changesets": [
     "few-gifts-rule",
+    "green-kids-type",
     "lemon-seas-fail",
     "little-months-join",
     "old-clouds-wink",
-    "spicy-fishes-matter"
+    "pretty-pumpkins-wave",
+    "selfish-suits-thank",
+    "smart-garlics-pretend",
+    "spicy-fishes-matter",
+    "sweet-ants-pull"
   ]
 }

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/api
 
+## 2.0.2-beta.3
+
+### Patch Changes
+
+- 4c5e0ae: Add support for null filter on geo properties.
+
 ## 2.0.2-beta.2
 
 ## 2.0.2-beta.1

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/api",
-  "version": "2.0.2-beta.2",
+  "version": "2.0.2-beta.3",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/cli.cmd.typescript
 
+## 0.6.2-beta.3
+
+### Patch Changes
+
+- @osdk/generator@2.0.2-beta.3
+
 ## 0.6.2-beta.2
 
 ### Patch Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.6.2-beta.2",
+  "version": "0.6.2-beta.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.test.ontology/CHANGELOG.md
+++ b/packages/client.test.ontology/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/client.test.ontology
 
+## 2.0.2-beta.3
+
+### Patch Changes
+
+- Updated dependencies [4c5e0ae]
+  - @osdk/api@2.0.2-beta.3
+
 ## 2.0.2-beta.2
 
 ### Patch Changes

--- a/packages/client.test.ontology/package.json
+++ b/packages/client.test.ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/client.test.ontology",
   "private": true,
-  "version": "2.0.2-beta.2",
+  "version": "2.0.2-beta.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.unstable/CHANGELOG.md
+++ b/packages/client.unstable/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/client.unstable
 
+## 2.0.2-beta.3
+
 ## 2.0.2-beta.2
 
 ## 2.0.2-beta.1

--- a/packages/client.unstable/package.json
+++ b/packages/client.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.unstable",
-  "version": "2.0.2-beta.2",
+  "version": "2.0.2-beta.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/client
 
+## 2.0.2-beta.3
+
+### Patch Changes
+
+- 4c5e0ae: Fix queries that have response types with nested values, like arrays.
+- ba1c42a: Fixing proxy handlers.
+- Updated dependencies [4c5e0ae]
+  - @osdk/api@2.0.2-beta.3
+  - @osdk/generator-converters@2.0.2-beta.3
+  - @osdk/client.unstable@2.0.2-beta.3
+
 ## 2.0.2-beta.2
 
 ### Patch Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client",
-  "version": "2.0.2-beta.2",
+  "version": "2.0.2-beta.3",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/foundry-sdk-generator
 
+## 2.0.2-beta.3
+
+### Patch Changes
+
+- Updated dependencies [4c5e0ae]
+- Updated dependencies [4c5e0ae]
+- Updated dependencies [ba1c42a]
+  - @osdk/api@2.0.2-beta.3
+  - @osdk/client@2.0.2-beta.3
+  - @osdk/generator@2.0.2-beta.3
+
 ## 2.0.2-beta.2
 
 ### Patch Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "2.0.2-beta.2",
+  "version": "2.0.2-beta.3",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-converters/CHANGELOG.md
+++ b/packages/generator-converters/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/generator-converters
 
+## 2.0.2-beta.3
+
+### Patch Changes
+
+- Updated dependencies [4c5e0ae]
+  - @osdk/api@2.0.2-beta.3
+
 ## 2.0.2-beta.2
 
 ### Patch Changes

--- a/packages/generator-converters/package.json
+++ b/packages/generator-converters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-converters",
-  "version": "2.0.2-beta.2",
+  "version": "2.0.2-beta.3",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/generator
 
+## 2.0.2-beta.3
+
+### Patch Changes
+
+- Updated dependencies [4c5e0ae]
+  - @osdk/api@2.0.2-beta.3
+  - @osdk/generator-converters@2.0.2-beta.3
+
 ## 2.0.2-beta.2
 
 ### Patch Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "2.0.2-beta.2",
+  "version": "2.0.2-beta.3",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/maker/CHANGELOG.md
+++ b/packages/maker/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/maker
 
+## 0.8.2-beta.3
+
+### Patch Changes
+
+- 76defb9: Allowing interfaces to extend other interfaces for ontology as code.
+- 76defb9: Add media reference to maker
+- Updated dependencies [4c5e0ae]
+  - @osdk/api@2.0.2-beta.3
+
 ## 0.8.2-beta.2
 
 ### Patch Changes

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker",
-  "version": "0.8.2-beta.2",
+  "version": "0.8.2-beta.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.test/CHANGELOG.md
+++ b/packages/shared.test/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/shared.test
 
+## 2.0.2-beta.3
+
+### Patch Changes
+
+- 4c5e0ae: Fix queries that have response types with nested values, like arrays.
+- ba1c42a: Fixing proxy handlers.
+- Updated dependencies [4c5e0ae]
+  - @osdk/api@2.0.2-beta.3
+
 ## 2.0.2-beta.2
 
 ### Patch Changes

--- a/packages/shared.test/package.json
+++ b/packages/shared.test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/shared.test",
   "private": true,
-  "version": "2.0.2-beta.2",
+  "version": "2.0.2-beta.3",
   "description": "",
   "access": "private",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/2.0.x, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`release/2.0.x` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `release/2.0.x`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/api@2.0.2-beta.3

### Patch Changes

-   4c5e0ae: Add support for null filter on geo properties.

## @osdk/client@2.0.2-beta.3

### Patch Changes

-   4c5e0ae: Fix queries that have response types with nested values, like arrays.
-   ba1c42a: Fixing proxy handlers.
-   Updated dependencies [4c5e0ae]
    -   @osdk/api@2.0.2-beta.3
    -   @osdk/generator-converters@2.0.2-beta.3
    -   @osdk/client.unstable@2.0.2-beta.3

## @osdk/foundry-sdk-generator@2.0.2-beta.3

### Patch Changes

-   Updated dependencies [4c5e0ae]
-   Updated dependencies [4c5e0ae]
-   Updated dependencies [ba1c42a]
    -   @osdk/api@2.0.2-beta.3
    -   @osdk/client@2.0.2-beta.3
    -   @osdk/generator@2.0.2-beta.3

## @osdk/generator@2.0.2-beta.3

### Patch Changes

-   Updated dependencies [4c5e0ae]
    -   @osdk/api@2.0.2-beta.3
    -   @osdk/generator-converters@2.0.2-beta.3

## @osdk/generator-converters@2.0.2-beta.3

### Patch Changes

-   Updated dependencies [4c5e0ae]
    -   @osdk/api@2.0.2-beta.3

## @osdk/maker@0.8.2-beta.3

### Patch Changes

-   76defb9: Allowing interfaces to extend other interfaces for ontology as code.
-   76defb9: Add media reference to maker
-   Updated dependencies [4c5e0ae]
    -   @osdk/api@2.0.2-beta.3

## @osdk/client.unstable@2.0.2-beta.3



## @osdk/cli.cmd.typescript@0.6.2-beta.3

### Patch Changes

-   @osdk/generator@2.0.2-beta.3

## @osdk/client.test.ontology@2.0.2-beta.3

### Patch Changes

-   Updated dependencies [4c5e0ae]
    -   @osdk/api@2.0.2-beta.3

## @osdk/shared.test@2.0.2-beta.3

### Patch Changes

-   4c5e0ae: Fix queries that have response types with nested values, like arrays.
-   ba1c42a: Fixing proxy handlers.
-   Updated dependencies [4c5e0ae]
    -   @osdk/api@2.0.2-beta.3
