### PR TITLE
Version Packages

### DIFF
--- a/.changeset/lovely-llamas-rescue.md
+++ b/.changeset/lovely-llamas-rescue.md
@@ -1,5 +1,0 @@
----
-"@osdk/foundry-sdk-generator": patch
----
-
-Fixes being unable to generate in dev console without --beta

--- a/.changeset/selfish-badgers-obey.md
+++ b/.changeset/selfish-badgers-obey.md
@@ -1,5 +1,0 @@
----
-"@osdk/generator": patch
----
-
-Namespaced object sets in actions no longer generate wrong

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/api
 
+## 2.0.3
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/api",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/cli.cmd.typescript
 
+## 0.24.3
+
+### Patch Changes
+
+- Updated dependencies [444e7a4]
+  - @osdk/generator@2.0.3
+  - @osdk/cli.common@0.24.3
+
 ## 0.6.2
 
 ### Patch Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.6.2",
+  "version": "0.24.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli.common/CHANGELOG.md
+++ b/packages/cli.common/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/cli.common
 
+## 0.24.3
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/cli.common/package.json
+++ b/packages/cli.common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.common",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.24.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/cli
 
+## 0.24.3
+
 ## 0.24.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client.test.ontology/CHANGELOG.md
+++ b/packages/client.test.ontology/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/client.test.ontology
 
+## 2.0.3
+
+### Patch Changes
+
+- @osdk/api@2.0.3
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/client.test.ontology/package.json
+++ b/packages/client.test.ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/client.test.ontology",
   "private": true,
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.unstable/CHANGELOG.md
+++ b/packages/client.unstable/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/client.unstable
 
+## 2.0.3
+
 ## 2.0.2
 
 ## 2.0.2-rc.3

--- a/packages/client.unstable/package.json
+++ b/packages/client.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.unstable",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/client
 
+## 2.0.3
+
+### Patch Changes
+
+- @osdk/generator-converters@2.0.3
+- @osdk/client.unstable@2.0.3
+- @osdk/api@2.0.3
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -114,7 +114,7 @@ export interface Client extends SharedClient<MinimalClient> {
 }
 
 // BEGIN: THIS IS GENERATED CODE. DO NOT EDIT.
-const MaxOsdkVersion = "2.0.2";
+const MaxOsdkVersion = "2.0.3";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 export type MaxOsdkVersion = typeof MaxOsdkVersion;
 const ErrorMessage = Symbol("ErrorMessage");

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/foundry-sdk-generator
 
+## 2.0.3
+
+### Patch Changes
+
+- 7132212: Fixes being unable to generate in dev console without --beta
+- Updated dependencies [444e7a4]
+  - @osdk/generator@2.0.3
+  - @osdk/client@2.0.3
+  - @osdk/api@2.0.3
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-converters/CHANGELOG.md
+++ b/packages/generator-converters/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/generator-converters
 
+## 2.0.3
+
+### Patch Changes
+
+- @osdk/api@2.0.3
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/generator-converters/package.json
+++ b/packages/generator-converters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-converters",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/generator
 
+## 2.0.3
+
+### Patch Changes
+
+- 444e7a4: Namespaced object sets in actions no longer generate wrong
+  - @osdk/generator-converters@2.0.3
+  - @osdk/api@2.0.3
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator/src/v2.0/generateMetadata.ts
+++ b/packages/generator/src/v2.0/generateMetadata.ts
@@ -19,7 +19,7 @@ import type { GenerateContext } from "../GenerateContext/GenerateContext.js";
 import { formatTs } from "../util/test/formatTs.js";
 
 // BEGIN: THIS IS GENERATED CODE. DO NOT EDIT.
-const ExpectedOsdkVersion = "2.0.2";
+const ExpectedOsdkVersion = "2.0.3";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 
 export async function generateOntologyMetadataFile(

--- a/packages/maker/CHANGELOG.md
+++ b/packages/maker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/maker
 
+## 0.8.3
+
+### Patch Changes
+
+- @osdk/api@2.0.3
+
 ## 0.8.2
 
 ### Patch Changes

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.test/CHANGELOG.md
+++ b/packages/shared.test/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/shared.test
 
+## 2.0.3
+
+### Patch Changes
+
+- @osdk/api@2.0.3
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/shared.test/package.json
+++ b/packages/shared.test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/shared.test",
   "private": true,
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "",
   "access": "private",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/2.0.x, this PR will be updated.


# Releases
## @osdk/client@2.0.3

### Patch Changes

-   @osdk/generator-converters@2.0.3
-   @osdk/client.unstable@2.0.3
-   @osdk/api@2.0.3

## @osdk/foundry-sdk-generator@2.0.3

### Patch Changes

-   7132212: Fixes being unable to generate in dev console without --beta
-   Updated dependencies [444e7a4]
    -   @osdk/generator@2.0.3
    -   @osdk/client@2.0.3
    -   @osdk/api@2.0.3

## @osdk/generator@2.0.3

### Patch Changes

-   444e7a4: Namespaced object sets in actions no longer generate wrong
    -   @osdk/generator-converters@2.0.3
    -   @osdk/api@2.0.3

## @osdk/generator-converters@2.0.3

### Patch Changes

-   @osdk/api@2.0.3

## @osdk/maker@0.8.3

### Patch Changes

-   @osdk/api@2.0.3

## @osdk/api@2.0.3



## @osdk/cli@0.24.3



## @osdk/client.unstable@2.0.3



## @osdk/cli.cmd.typescript@0.24.3

### Patch Changes

-   Updated dependencies [444e7a4]
    -   @osdk/generator@2.0.3
    -   @osdk/cli.common@0.24.3

## @osdk/client.test.ontology@2.0.3

### Patch Changes

-   @osdk/api@2.0.3

## @osdk/shared.test@2.0.3

### Patch Changes

-   @osdk/api@2.0.3

## @osdk/cli.common@0.24.3


