### PR TITLE
Properly handle any and never for fetch results

### DIFF
--- a/.changeset/lucky-coins-breathe.md
+++ b/.changeset/lucky-coins-breathe.md
@@ -1,0 +1,5 @@
+---
+"@osdk/api": patch
+---
+
+Fixes a bug where any/never could be interpreted wrong when used in types for determining fetch results

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -611,10 +611,11 @@ export interface OntologyMetadata<_NEVER_USED_KEPT_FOR_BACKCOMPAT = any> {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IsNever" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "IsAny" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "ExtractPropsKeysFromOldPropsStyle" needs to be exported by the entry point index.d.ts
 //
 // @public
-export type Osdk<Q extends ObjectOrInterfaceDefinition, OPTIONS extends string = never, P extends PropertyKeys<Q> = PropertyKeys<Q>> = IsNever<OPTIONS> extends true ? Osdk.Instance<Q, never, P> : IsNever<Exclude<OPTIONS, "$notStrict" | "$rid">> extends true ? Osdk.Instance<Q, OPTIONS & ("$notStrict" | "$rid"), P> : Osdk.Instance<Q, ("$notStrict" extends OPTIONS ? "$notStrict" : never) | ("$rid" extends OPTIONS ? "$rid" : never), ExtractPropsKeysFromOldPropsStyle<Q, OPTIONS>>;
+export type Osdk<Q extends ObjectOrInterfaceDefinition, OPTIONS extends string = never, P extends PropertyKeys<Q> = PropertyKeys<Q>> = IsNever<OPTIONS> extends true ? Osdk.Instance<Q, never, P> : IsAny<OPTIONS> extends true ? Osdk.Instance<Q, never, P> : (IsNever<Exclude<OPTIONS, "$notStrict" | "$rid">>) extends true ? Osdk.Instance<Q, OPTIONS & ("$notStrict" | "$rid"), P> : Osdk.Instance<Q, ("$notStrict" extends OPTIONS ? "$notStrict" : never) | ("$rid" extends OPTIONS ? "$rid" : never), ExtractPropsKeysFromOldPropsStyle<Q, OPTIONS>>;
 
 // @public (undocumented)
 export namespace Osdk {
@@ -627,7 +628,7 @@ export namespace Osdk {
             linksType?: any;
         } ? Q["linksType"] : Q extends ObjectTypeDefinition ? OsdkObjectLinksObject<Q> : never;
         readonly $as: <NEW_Q extends ValidToFrom<Q>>(type: NEW_Q | string) => Osdk.Instance<NEW_Q, OPTIONS, ConvertProps<Q, NEW_Q, P>>;
-    } & (IsNever<OPTIONS> extends true ? {} : "$rid" extends OPTIONS ? {
+    } & (IsNever<OPTIONS> extends true ? {} : IsAny<OPTIONS> extends true ? {} : "$rid" extends OPTIONS ? {
         readonly $rid: string;
     } : {});
 }

--- a/packages/api/src/OsdkObjectFrom.test.ts
+++ b/packages/api/src/OsdkObjectFrom.test.ts
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expectTypeOf, it } from "vitest";
+import type { ExtractOptions, Osdk } from "./OsdkObjectFrom.js";
+
+describe("ExtractOptions", () => {
+  describe("NullabilityAdherence Generic", () => {
+    it("does not add $notStrict for any", () => {
+      expectTypeOf<ExtractOptions<any, any>>().toEqualTypeOf<never>();
+    });
+
+    it("does not add $notStrict for never", () => {
+      expectTypeOf<ExtractOptions<any, never>>().toEqualTypeOf<never>();
+    });
+
+    it("does add add $notStrict for false", () => {
+      expectTypeOf<ExtractOptions<any, false>>().toEqualTypeOf<"$notStrict">();
+    });
+
+    it("does not add $notStrict for throw", () => {
+      expectTypeOf<ExtractOptions<any, "throw">>().toEqualTypeOf<never>();
+    });
+
+    it("does not add $notStrict for drop", () => {
+      expectTypeOf<ExtractOptions<any, "drop">>().toEqualTypeOf<never>();
+    });
+  });
+
+  describe("Rid Generic", () => {
+    it("does not add $rid for false", () => {
+      expectTypeOf<ExtractOptions<false, any>>().toEqualTypeOf<never>();
+    });
+
+    it("does add $rid for true", () => {
+      expectTypeOf<ExtractOptions<true, any>>().toEqualTypeOf<"$rid">();
+    });
+
+    it("does not add $rid for any", () => {
+      expectTypeOf<ExtractOptions<any, any>>().toEqualTypeOf<never>();
+    });
+
+    it("does not add $rid for never", () => {
+      expectTypeOf<ExtractOptions<never, any>>().toEqualTypeOf<never>();
+    });
+  });
+
+  type quickAndDirty = {
+    apiName: "Foo";
+    type: "object";
+    __DefinitionMetadata: {
+      props: {
+        name: string;
+        foo: number | undefined;
+      };
+      strictProps: {
+        name: string;
+        foo: number;
+      };
+      apiName: "Foo";
+      displayName: "";
+      interfaceMap: {};
+      inverseInterfaceMap: {};
+      links: {};
+      pluralDisplayName: "";
+      primaryKeyApiName: "";
+      primaryKeyType: "string";
+      properties: {
+        name: {
+          type: "string";
+        };
+        foo: {
+          type: "integer";
+        };
+      };
+      rid: "";
+      status: "ACTIVE";
+      titleProperty: "name";
+      type: "object";
+    };
+  };
+
+  describe("Osdk.Instance", () => {
+    it("defaults to second argument never if omitted", () => {
+      type toCheck = Osdk.Instance<quickAndDirty>;
+      expectTypeOf<toCheck>().toEqualTypeOf<
+        Osdk.Instance<quickAndDirty, never>
+      >();
+
+      // ensure its the strict type
+      expectTypeOf<Pick<toCheck, "name" | "foo">>().toEqualTypeOf<
+        quickAndDirty["__DefinitionMetadata"]["strictProps"]
+      >();
+    });
+
+    it("defaults to second argument never if never", () => {
+      type toCheck = Osdk.Instance<quickAndDirty, never>;
+      expectTypeOf<toCheck>().toEqualTypeOf<
+        Osdk.Instance<quickAndDirty, never>
+      >();
+      // ensure its the strict type
+      expectTypeOf<Pick<toCheck, "name" | "foo">>().toEqualTypeOf<
+        quickAndDirty["__DefinitionMetadata"]["strictProps"]
+      >();
+    });
+
+    it("defaults to second argument never if any", () => {
+      type toCheck = Osdk.Instance<quickAndDirty, any>;
+      expectTypeOf<toCheck>().branded.toEqualTypeOf<
+        Osdk.Instance<quickAndDirty, never>
+      >();
+      // ensure its the strict type
+      expectTypeOf<Pick<toCheck, "name" | "foo">>().toEqualTypeOf<
+        quickAndDirty["__DefinitionMetadata"]["strictProps"]
+      >();
+    });
+
+    it("uses not strict if requested", () => {
+      type toCheck = Osdk.Instance<quickAndDirty, "$notStrict">;
+      expectTypeOf<toCheck>().branded
+        .toEqualTypeOf<Osdk.Instance<quickAndDirty, "$notStrict">>();
+      // ensure its not the strict type
+      expectTypeOf<Pick<toCheck, "name" | "foo">>().toEqualTypeOf<
+        quickAndDirty["__DefinitionMetadata"]["props"]
+      >();
+    });
+
+    it("defaults to last argument all props if never", () => {
+      expectTypeOf<Osdk.Instance<quickAndDirty, never, never>>().branded
+        .toEqualTypeOf<
+          Osdk.Instance<quickAndDirty, never, "name" | "foo">
+        >();
+    });
+
+    it("defaults to last argument all props if any", () => {
+      expectTypeOf<Osdk.Instance<quickAndDirty, never, any>>().branded
+        .toEqualTypeOf<
+          Osdk.Instance<quickAndDirty, never, "name" | "foo">
+        >();
+    });
+
+    it("defaults to last argument exactly if specified", () => {
+      expectTypeOf<Osdk.Instance<quickAndDirty, never, "name">>().branded
+        .toEqualTypeOf<
+          Osdk.Instance<quickAndDirty, never, "name">
+        >();
+    });
+  });
+
+  describe("Osdk<>", () => {
+    it("defaults to second argument never if omitted", () => {
+      type toCheck = Osdk<quickAndDirty>;
+      expectTypeOf<toCheck>().toEqualTypeOf<
+        Osdk.Instance<quickAndDirty, never>
+      >();
+
+      // expect no rid
+      expectTypeOf<keyof toCheck & "$rid">().toEqualTypeOf<never>();
+
+      // ensure its the strict type
+      expectTypeOf<Pick<toCheck, "name" | "foo">>().toEqualTypeOf<
+        quickAndDirty["__DefinitionMetadata"]["strictProps"]
+      >();
+    });
+
+    it("returns $rid if only thing specified", () => {
+      type toCheck = Osdk<quickAndDirty, "$rid">;
+      expectTypeOf<toCheck>().toEqualTypeOf<
+        Osdk.Instance<quickAndDirty, "$rid">
+      >();
+
+      // expect rid
+      expectTypeOf<keyof toCheck & "$rid">().toEqualTypeOf<"$rid">();
+
+      // ensure its the strict type
+      expectTypeOf<Pick<toCheck, "name" | "foo">>().toEqualTypeOf<
+        quickAndDirty["__DefinitionMetadata"]["strictProps"]
+      >();
+    });
+
+    it("handles legacy properly: $rid and name", () => {
+      type toCheck = Osdk<quickAndDirty, "$rid" | "name">;
+      expectTypeOf<toCheck>().toEqualTypeOf<
+        Osdk.Instance<quickAndDirty, "$rid", "name">
+      >();
+
+      // expect rid
+      expectTypeOf<keyof toCheck & "$rid">().toEqualTypeOf<"$rid">();
+
+      // ensure its the strict type
+      expectTypeOf<Pick<toCheck, "name">>().toEqualTypeOf<{
+        name: quickAndDirty["__DefinitionMetadata"]["strictProps"]["name"];
+      }>();
+    });
+
+    it("handles legacy properly: $rid and $all", () => {
+      type toCheck = Osdk<quickAndDirty, "$rid" | "$all">;
+      expectTypeOf<toCheck>().branded.toEqualTypeOf<
+        Osdk.Instance<quickAndDirty, "$rid", "name" | "foo">
+      >();
+
+      // expect rid
+      expectTypeOf<keyof toCheck & "$rid">().toEqualTypeOf<"$rid">();
+
+      // ensure its the strict type
+      expectTypeOf<Pick<toCheck, "name" | "foo">>().toEqualTypeOf<
+        quickAndDirty["__DefinitionMetadata"]["strictProps"]
+      >();
+    });
+
+    it("handles legacy properly: just $all", () => {
+      type toCheck = Osdk<quickAndDirty, "$all">;
+      expectTypeOf<toCheck>().branded.toEqualTypeOf<
+        Osdk.Instance<quickAndDirty, never, "name" | "foo">
+      >();
+
+      // expect no rid
+      expectTypeOf<keyof toCheck & "$rid">().toEqualTypeOf<never>();
+
+      // ensure its the strict type
+      expectTypeOf<Pick<toCheck, "name" | "foo">>().toEqualTypeOf<
+        quickAndDirty["__DefinitionMetadata"]["strictProps"]
+      >();
+    });
+
+    it("defaults to second argument never if never", () => {
+      type toCheck = Osdk<quickAndDirty, never>;
+      expectTypeOf<toCheck>().toEqualTypeOf<
+        Osdk.Instance<quickAndDirty, never>
+      >();
+      // ensure its the strict type
+      expectTypeOf<Pick<toCheck, "name" | "foo">>().toEqualTypeOf<
+        quickAndDirty["__DefinitionMetadata"]["strictProps"]
+      >();
+
+      // expect no rid
+      expectTypeOf<keyof toCheck & "$rid">().toEqualTypeOf<never>();
+    });
+
+    it("defaults to second argument never if any", () => {
+      type toCheck = Osdk<quickAndDirty, any>;
+      expectTypeOf<toCheck>().branded.toEqualTypeOf<
+        Osdk.Instance<quickAndDirty, never>
+      >();
+      // ensure its the strict type
+      expectTypeOf<Pick<toCheck, "name" | "foo">>().toEqualTypeOf<
+        quickAndDirty["__DefinitionMetadata"]["strictProps"]
+      >();
+
+      // expect no rid
+      expectTypeOf<keyof toCheck & "$rid">().toEqualTypeOf<never>();
+    });
+
+    it("uses not strict if requested", () => {
+      type toCheck = Osdk<quickAndDirty, "$notStrict">;
+      expectTypeOf<toCheck>().branded
+        .toEqualTypeOf<Osdk.Instance<quickAndDirty, "$notStrict">>();
+      // ensure its not the strict type
+      expectTypeOf<Pick<toCheck, "name" | "foo">>().toEqualTypeOf<
+        quickAndDirty["__DefinitionMetadata"]["props"]
+      >();
+
+      // expect no rid
+      expectTypeOf<keyof toCheck & "$rid">().toEqualTypeOf<never>();
+    });
+
+    it("defaults to last argument all props if never", () => {
+      expectTypeOf<Osdk<quickAndDirty, never, never>>().branded
+        .toEqualTypeOf<
+          Osdk.Instance<quickAndDirty, never, "name" | "foo">
+        >();
+    });
+
+    it("defaults to last argument all props if any", () => {
+      expectTypeOf<Osdk<quickAndDirty, never, any>>().branded
+        .toEqualTypeOf<
+          Osdk.Instance<quickAndDirty, never, "name" | "foo">
+        >();
+    });
+
+    it("defaults to last argument exactly if specified", () => {
+      expectTypeOf<Osdk<quickAndDirty, never, "name">>()
+        .toEqualTypeOf<
+          Osdk.Instance<quickAndDirty, never, "name">
+        >();
+    });
+  });
+});

--- a/packages/api/src/OsdkObjectFrom.ts
+++ b/packages/api/src/OsdkObjectFrom.ts
@@ -162,6 +162,7 @@ export type GetProps<
   Q extends ObjectOrInterfaceDefinition,
   OPTIONS extends never | "$notStrict" | "$rid" = never,
 > = IsNever<OPTIONS> extends true ? CompileTimeMetadata<Q>["strictProps"]
+  : IsAny<OPTIONS> extends true ? CompileTimeMetadata<Q>["strictProps"]
   : (OPTIONS extends "$notStrict" ? CompileTimeMetadata<Q>["props"]
     : CompileTimeMetadata<Q>["strictProps"]);
 
@@ -175,8 +176,9 @@ export type Osdk<
 > =
   // no middle options is simplest
   IsNever<OPTIONS> extends true ? Osdk.Instance<Q, never, P>
+    : IsAny<OPTIONS> extends true ? Osdk.Instance<Q, never, P>
     // Options only includes the two allowed in the new style
-    : IsNever<Exclude<OPTIONS, "$notStrict" | "$rid">> extends true
+    : (IsNever<Exclude<OPTIONS, "$notStrict" | "$rid">>) extends true
       ? Osdk.Instance<Q, OPTIONS & ("$notStrict" | "$rid"), P>
     // else we are in the old style which was just Q and OPTIONS
     // and OPTIONS was $things + prop names
@@ -213,18 +215,20 @@ export namespace Osdk {
     }
     // We are hiding the $rid field if it wasn't requested as we want to discourage its use
     & (IsNever<OPTIONS> extends true ? {}
+      : IsAny<OPTIONS> extends true ? {}
       : "$rid" extends OPTIONS ? { readonly $rid: string }
       : {});
 }
 
 // not exported from package
-export type ExtractStrictOption<S extends NullabilityAdherence> = S extends
-  false ? "$notStrict"
+export type ExtractStrictOption<S extends NullabilityAdherence> =
+  IsAny<S> extends true ? never : S extends false ? "$notStrict"
   : never;
 
 // not exported from package
-export type ExtractRidOption<R extends boolean> = DefaultToFalse<R> extends
-  false ? never
+export type ExtractRidOption<R extends boolean> = IsAny<R> extends true ? never
+  : IsNever<R> extends true ? never
+  : DefaultToFalse<R> extends false ? never
   : "$rid";
 
 // not exported from package


### PR DESCRIPTION
In certain places internally, we could see `any` or `never` end up in positions we did not expect. This PR safe gaurds the expected behavior:
- Unless explicitly asked for, we always use strictProps
- Unless explicitly asked for, we always omit $rid