### PR TITLE
Fix query return values

### DIFF
--- a/.changeset/dirty-lions-drive.md
+++ b/.changeset/dirty-lions-drive.md
@@ -1,0 +1,6 @@
+---
+"@osdk/shared.test": patch
+"@osdk/client": patch
+---
+
+Fix bug where object return types in a query were not properly mapped when wrapped in a struct.

--- a/packages/client/src/queries/applyQuery.ts
+++ b/packages/client/src/queries/applyQuery.ts
@@ -294,7 +294,6 @@ function requiresConversion(dataType: QueryDataTypeDefinition) {
     case "float":
     case "integer":
     case "long":
-    case "object": // JSON encoded primary key
     case "string":
     case "timestamp":
       return false;
@@ -312,6 +311,7 @@ function requiresConversion(dataType: QueryDataTypeDefinition) {
     case "objectSet":
     case "twoDimensionalAggregation":
     case "threeDimensionalAggregation":
+    case "object":
       return true;
 
     default:

--- a/packages/client/src/queries/queries.test.ts
+++ b/packages/client/src/queries/queries.test.ts
@@ -23,6 +23,7 @@ import {
   addOne,
   Employee,
   incrementPersonAge,
+  incrementPersonAgeComplex,
   queryAcceptsObject,
   queryAcceptsObjectSets,
   returnsDate,
@@ -113,6 +114,25 @@ describe("queries", () => {
       firstName: "John",
       lastName: "Doe",
       age: 43,
+    });
+  });
+
+  it("returns and accepts complex structs property", async () => {
+    const employee = await client(Employee).fetchOne(
+      50030,
+    );
+    const result = await client(incrementPersonAgeComplex).executeFunction({
+      person: { firstName: "John", lastName: "Doe", age: 42, object: employee },
+    });
+    expect(result).toEqual({
+      firstName: "John",
+      lastName: "Doe",
+      age: 43,
+      object: {
+        $apiName: "Employee",
+        $objectType: "Employee",
+        $primaryKey: 50031,
+      },
     });
   });
 
@@ -212,6 +232,15 @@ describe("queries", () => {
       },
     ]);
   });
+
+  it("accepts and returns objects", async () => {
+    const employeeObjectSet = client(Employee);
+    const result = await client(queryAcceptsObjectSets).executeFunction({
+      objectSet: employeeObjectSet,
+    });
+
+    expectTypeOf<ObjectSet<Employee>>().toMatchTypeOf<typeof result>();
+  });
   it("queries are enumerable", async () => {
     const queries = Object.keys($Queries);
     expect(queries).toStrictEqual([
@@ -219,6 +248,7 @@ describe("queries", () => {
       "acceptsTwoDimensionalAggregationFunction",
       "addOne",
       "incrementPersonAge",
+      "incrementPersonAgeComplex",
       "queryAcceptsObject",
       "queryAcceptsObjectSets",
       "queryTypeReturnsArray",

--- a/packages/shared.test/src/stubs/queries.ts
+++ b/packages/shared.test/src/stubs/queries.ts
@@ -26,6 +26,7 @@ import {
   queryTypeAcceptsThreeDimensionalAggregation,
   queryTypeAcceptsTwoDimensionalAggregation,
   queryTypeReturnsArray,
+  queryTypeReturnsComplexStruct,
   queryTypeReturnsDate,
   queryTypeReturnsObject,
   queryTypeReturnsStruct,
@@ -65,6 +66,26 @@ export const queryTypeReturnsStructResponse: ExecuteQueryResponse = {
     firstName: "John",
     lastName: "Doe",
     age: 43,
+  },
+};
+
+export const queryTypeReturnsComplexStructRequest: ExecuteQueryRequest = {
+  parameters: {
+    person: {
+      firstName: "John",
+      lastName: "Doe",
+      age: 42,
+      object: employee1.__primaryKey,
+    },
+  },
+};
+
+export const queryTypeReturnsComplexStructResponse: ExecuteQueryResponse = {
+  value: {
+    firstName: "John",
+    lastName: "Doe",
+    age: 43,
+    object: employee2.__primaryKey,
   },
 };
 
@@ -250,6 +271,10 @@ export const queryRequestHandlers: {
   [queryTypeReturnsStruct.apiName]: {
     [JSON.stringify(queryTypeReturnsStructRequest)]:
       queryTypeReturnsStructResponse,
+  },
+  [queryTypeReturnsComplexStruct.apiName]: {
+    [JSON.stringify(queryTypeReturnsComplexStructRequest)]:
+      queryTypeReturnsComplexStructResponse,
   },
   [queryTypeReturnsTimestamp.apiName]: {
     [emptyBody]: queryTypeReturnsTimestampResponse,

--- a/packages/shared.test/src/stubs/queryTypes.ts
+++ b/packages/shared.test/src/stubs/queryTypes.ts
@@ -108,6 +108,96 @@ export const queryTypeReturnsStruct: QueryTypeV2 = {
   version: "0.0.9",
 };
 
+export const queryTypeReturnsComplexStruct: QueryTypeV2 = {
+  apiName: "incrementPersonAgeComplex",
+  displayName: "incrementAgeComplex",
+  parameters: {
+    person: {
+      dataType: {
+        type: "struct",
+        fields: [
+          {
+            name: "firstName",
+            fieldType: {
+              type: "string",
+            },
+          },
+          {
+            name: "lastName",
+            fieldType: {
+              type: "string",
+            },
+          },
+          {
+            name: "age",
+            fieldType: {
+              type: "union",
+              unionTypes: [
+                {
+                  type: "integer",
+                },
+                {
+                  type: "null",
+                },
+              ],
+            },
+          },
+          {
+            name: "object",
+            fieldType: {
+              type: "object",
+              objectApiName: "Employee",
+              objectTypeApiName: "Employee",
+            },
+          },
+        ],
+      },
+    },
+  },
+  output: {
+    type: "struct",
+    fields: [
+      {
+        name: "firstName",
+        fieldType: {
+          type: "string",
+        },
+      },
+      {
+        name: "lastName",
+        fieldType: {
+          type: "string",
+        },
+      },
+      {
+        name: "age",
+        fieldType: {
+          type: "union",
+          unionTypes: [
+            {
+              type: "integer",
+            },
+            {
+              type: "null",
+            },
+          ],
+        },
+      },
+      {
+        name: "object",
+        fieldType: {
+          type: "object",
+          objectApiName: "Employee",
+          objectTypeApiName: "Employee",
+        },
+      },
+    ],
+  },
+  rid:
+    "ri.function-registry.main.function.b2ae7b3e-2c89-42f5-a762-68957a9c039d",
+  version: "0.0.9",
+};
+
 export const queryTypeReturnsTimestamp: QueryTypeV2 = {
   apiName: "returnsTimestamp",
   displayName: "returnsTimestamp",
@@ -343,4 +433,5 @@ export const queryTypes: QueryTypeV2[] = [
   queryTypeAcceptsTwoDimensionalAggregation,
   queryTypeAcceptsThreeDimensionalAggregation,
   queryTypeReturnsArray,
+  queryTypeReturnsComplexStruct,
 ];


### PR DESCRIPTION
We were not properly mapping object response types when they were in nested types like a struct