### PR TITLE
Version Packages

### DIFF
--- a/.changeset/hungry-feet-refuse.md
+++ b/.changeset/hungry-feet-refuse.md
@@ -1,7 +1,0 @@
----
-"@osdk/foundry-sdk-generator": patch
-"@osdk/legacy-client": patch
-"@osdk/generator": patch
----
-
-Fixes .d.ts generation for slate

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/cli.cmd.typescript
 
+## 0.5.5
+
+### Patch Changes
+
+- Updated dependencies [03fbf31]
+  - @osdk/generator@1.13.5
+
 ## 0.5.4
 
 ### Patch Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.5.4",
+  "version": "0.5.5",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/cli
 
+## 0.23.5
+
+### Patch Changes
+
+- Updated dependencies [03fbf31]
+  - @osdk/generator@1.13.5
+
 ## 0.23.4
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.23.4",
+  "version": "0.23.5",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/e2e.generated.1.1.x/CHANGELOG.md
+++ b/packages/e2e.generated.1.1.x/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/e2e.generated.1.1.x
 
+## 0.2.5
+
+### Patch Changes
+
+- Updated dependencies [03fbf31]
+  - @osdk/legacy-client@2.5.3
+  - @osdk/generator@1.13.5
+
 ## 0.2.4
 
 ### Patch Changes

--- a/packages/e2e.generated.1.1.x/package.json
+++ b/packages/e2e.generated.1.1.x/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.generated.1.1.x",
   "private": true,
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "",
   "license": "Apache-2.0",
   "repository": {
@@ -38,13 +38,13 @@
   },
   "peerDependencies": {
     "@osdk/api": "^1.9.2",
-    "@osdk/legacy-client": "^2.5.2"
+    "@osdk/legacy-client": "^2.5.3"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.2",
     "@osdk/api": "^1.9.2",
     "@osdk/cli.cmd.typescript": "workspace:~",
-    "@osdk/legacy-client": "^2.5.2",
+    "@osdk/legacy-client": "^2.5.3",
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
     "@osdk/monorepo.tsup": "workspace:~",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/foundry-sdk-generator
 
+## 1.3.13
+
+### Patch Changes
+
+- 03fbf31: Fixes .d.ts generation for slate
+- Updated dependencies [03fbf31]
+  - @osdk/legacy-client@2.5.3
+  - @osdk/generator@1.13.5
+
 ## 1.3.12
 
 ### Patch Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/generator
 
+## 1.13.5
+
+### Patch Changes
+
+- 03fbf31: Fixes .d.ts generation for slate
+
 ## 1.13.4
 
 ### Patch Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "1.13.4",
+  "version": "1.13.5",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/legacy-client/CHANGELOG.md
+++ b/packages/legacy-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/legacy-client
 
+## 2.5.3
+
+### Patch Changes
+
+- 03fbf31: Fixes .d.ts generation for slate
+
 ## 2.5.2
 
 ### Patch Changes

--- a/packages/legacy-client/package.json
+++ b/packages/legacy-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/legacy-client",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/1.3.x, this PR will be updated.


# Releases
## @osdk/cli@0.23.5

### Patch Changes

-   Updated dependencies [03fbf31]
    -   @osdk/generator@1.13.5

## @osdk/foundry-sdk-generator@1.3.13

### Patch Changes

-   03fbf31: Fixes .d.ts generation for slate
-   Updated dependencies [03fbf31]
    -   @osdk/legacy-client@2.5.3
    -   @osdk/generator@1.13.5

## @osdk/generator@1.13.5

### Patch Changes

-   03fbf31: Fixes .d.ts generation for slate

## @osdk/legacy-client@2.5.3

### Patch Changes

-   03fbf31: Fixes .d.ts generation for slate

## @osdk/cli.cmd.typescript@0.5.5

### Patch Changes

-   Updated dependencies [03fbf31]
    -   @osdk/generator@1.13.5

## @osdk/e2e.generated.1.1.x@0.2.5

### Patch Changes

-   Updated dependencies [03fbf31]
    -   @osdk/legacy-client@2.5.3
    -   @osdk/generator@1.13.5
