### PR TITLE
Use fixed versions for create-app client and oauth deps

### DIFF
--- a/.changeset/blue-tips-heal.md
+++ b/.changeset/blue-tips-heal.md
@@ -1,0 +1,11 @@
+---
+"@osdk/create-app.template.tutorial-todo-aip-app.beta": patch
+"@osdk/create-app.template.tutorial-todo-app.beta": patch
+"@osdk/create-app.template.next-static-export.v2": patch
+"@osdk/create-app.template.react.beta": patch
+"@osdk/create-app.template.vue.v2": patch
+"@osdk/example-generator": patch
+"@osdk/create-app": patch
+---
+
+Use fixed versions for create-app client and oauth deps

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,7 +9,10 @@
       "@osdk/generator",
       "@osdk/generator-converters",
       "@osdk/client.unstable",
-      "@osdk/api"
+      "@osdk/api",
+      "@osdk/create-app",
+      "@osdk/create-app.template.*",
+      "@osdk/create-app.template-packager"
     ],
     ["@osdk/create-app", "@osdk/create-app.template.*"],
     ["@osdk/cli", "@osdk/cli.*"]

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -14,7 +14,6 @@
       "@osdk/create-app.template.*",
       "@osdk/create-app.template-packager"
     ],
-    ["@osdk/create-app", "@osdk/create-app.template.*"],
     ["@osdk/cli", "@osdk/cli.*"]
   ],
   "linked": [],

--- a/examples/example-next-static-export-sdk-2.x/package.json
+++ b/examples/example-next-static-export-sdk-2.x/package.json
@@ -15,9 +15,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@osdk/client": "latest",
+    "@osdk/client": "workspace:*",
     "@osdk/e2e.generated.catchall": "workspace:*",
-    "@osdk/oauth": "latest",
+    "@osdk/oauth": "workspace:*",
     "next": "14.2.10",
     "react": "^18",
     "react-dom": "^18"

--- a/examples/example-react-sdk-2.x/package.json
+++ b/examples/example-react-sdk-2.x/package.json
@@ -16,9 +16,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@osdk/client": "latest",
+    "@osdk/client": "workspace:*",
     "@osdk/e2e.generated.catchall": "workspace:*",
-    "@osdk/oauth": "latest",
+    "@osdk/oauth": "workspace:*",
     "react": "^18",
     "react-dom": "^18",
     "react-router-dom": "^6.23.1"

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/package.json
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/package.json
@@ -15,9 +15,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@osdk/client": "latest",
+    "@osdk/client": "workspace:*",
     "@osdk/e2e.generated.catchall": "workspace:*",
-    "@osdk/oauth": "latest",
+    "@osdk/oauth": "workspace:*",
     "react": "^18",
     "react-dom": "^18",
     "react-router-dom": "^6.23.1",

--- a/examples/example-tutorial-todo-app-sdk-2.x/package.json
+++ b/examples/example-tutorial-todo-app-sdk-2.x/package.json
@@ -15,9 +15,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@osdk/client": "latest",
+    "@osdk/client": "workspace:*",
     "@osdk/e2e.generated.catchall": "workspace:*",
-    "@osdk/oauth": "latest",
+    "@osdk/oauth": "workspace:*",
     "react": "^18",
     "react-dom": "^18",
     "react-router-dom": "^6.23.1",

--- a/examples/example-vue-sdk-2.x/package.json
+++ b/examples/example-vue-sdk-2.x/package.json
@@ -14,9 +14,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@osdk/client": "latest",
+    "@osdk/client": "workspace:*",
     "@osdk/e2e.generated.catchall": "workspace:*",
-    "@osdk/oauth": "latest",
+    "@osdk/oauth": "workspace:*",
     "vue": "^3.5.11",
     "vue-router": "^4.4.5"
   },

--- a/packages/create-app.template.next-static-export.v2/templates/package.json.hbs
+++ b/packages/create-app.template.next-static-export.v2/templates/package.json.hbs
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "{{osdkPackage}}": "latest",
-    "@osdk/client": "latest",
-    "@osdk/oauth": "latest"
+    "@osdk/client": "{{clientVersion}}",
+    "@osdk/oauth": "^1.0.0"
   },
   "devDependencies": {
 

--- a/packages/create-app.template.react.beta/templates/package.json.hbs
+++ b/packages/create-app.template.react.beta/templates/package.json.hbs
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "{{osdkPackage}}": "latest",
-    "@osdk/client": "latest",
-    "@osdk/oauth": "latest"
+    "@osdk/client": "{{clientVersion}}",
+    "@osdk/oauth": "^1.0.0"
   },
   "devDependencies": {
     "@types/node": "latest"

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/package.json.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/package.json.hbs
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "{{osdkPackage}}": "latest",
-    "@osdk/client": "latest",
-    "@osdk/oauth": "latest"
+    "@osdk/client": "{{clientVersion}}",
+    "@osdk/oauth": "^1.0.0"
   },
   "devDependencies": {
   }

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/package.json.hbs
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/package.json.hbs
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "{{osdkPackage}}": "latest",
-    "@osdk/client": "latest",
-    "@osdk/oauth": "latest"
+    "@osdk/client": "{{clientVersion}}",
+    "@osdk/oauth": "^1.0.0"
   },
   "devDependencies": {
   }

--- a/packages/create-app.template.vue.v2/templates/package.json.hbs
+++ b/packages/create-app.template.vue.v2/templates/package.json.hbs
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "{{osdkPackage}}": "latest",
-    "@osdk/client": "latest",
-    "@osdk/oauth": "latest"
+    "@osdk/client": "{{clientVersion}}",
+    "@osdk/oauth": "^1.0.0"
   },
   "devDependencies": {
     "@types/node": "latest"

--- a/packages/create-app/src/run.ts
+++ b/packages/create-app/src/run.ts
@@ -105,12 +105,23 @@ export async function run(
     );
   }
 
+  const ourPackageJsonPath = findUpSync("package.json", {
+    cwd: fileURLToPath(import.meta.url),
+  });
+
+  const ourPackageJsonVersion = ourPackageJsonPath
+    ? JSON.parse(fs.readFileSync(ourPackageJsonPath, "utf-8")).version
+    : undefined;
+
+  const clientVersion = process.env.PACKAGE_CLIENT_VERSION
+    ?? ourPackageJsonVersion;
+
   const templateContext: TemplateContext = {
     project,
     foundryUrl,
     osdkPackage,
     corsProxy,
-    clientVersion: "^2.0.7",
+    clientVersion: `~${clientVersion}`,
   };
   const processFiles = function(dir: string) {
     fs.readdirSync(dir).forEach(function(file) {

--- a/packages/create-app/src/run.ts
+++ b/packages/create-app/src/run.ts
@@ -110,6 +110,7 @@ export async function run(
     foundryUrl,
     osdkPackage,
     corsProxy,
+    clientVersion: "^2.0.7",
   };
   const processFiles = function(dir: string) {
     fs.readdirSync(dir).forEach(function(file) {

--- a/packages/create-app/src/templates.ts
+++ b/packages/create-app/src/templates.ts
@@ -45,6 +45,7 @@ export interface TemplateContext {
   project: string;
   foundryUrl: string;
   osdkPackage: string;
+  clientVersion: string;
   corsProxy: boolean;
 }
 

--- a/packages/example-generator/src/run.ts
+++ b/packages/example-generator/src/run.ts
@@ -264,7 +264,7 @@ const UPDATE_PACKAGE_JSON: Mutator = {
       "\"@osdk/e2e.generated.catchall\": \"workspace:*\"",
     ).replace(
       // Use locally generated SDK in the monorepo
-      /"@osdk\/client": "\^.*?"/,
+      /"@osdk\/client": "[\^~].*?"/,
       `"@osdk/client": "workspace:*"`,
     ).replace(
       // Use locally generated SDK in the monorepo

--- a/packages/example-generator/src/run.ts
+++ b/packages/example-generator/src/run.ts
@@ -263,6 +263,14 @@ const UPDATE_PACKAGE_JSON: Mutator = {
       "\"@osdk/e2e.generated.catchall\": \"latest\"",
       "\"@osdk/e2e.generated.catchall\": \"workspace:*\"",
     ).replace(
+      // Use locally generated SDK in the monorepo
+      /"@osdk\/client": "\^.*?"/,
+      `"@osdk/client": "workspace:*"`,
+    ).replace(
+      // Use locally generated SDK in the monorepo
+      /"@osdk\/oauth": "\^.*?"/,
+      `"@osdk/oauth": "workspace:*"`,
+    ).replace(
       // Follow monorepo package naming convention
       `"name": "${sdkVersionedTemplateExampleId(template, sdkVersion)}"`,
       `"name": "@osdk/examples.${

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,14 +253,14 @@ importers:
   examples/example-next-static-export-sdk-2.x:
     dependencies:
       '@osdk/client':
-        specifier: latest
-        version: 2.0.7
+        specifier: workspace:*
+        version: link:../../packages/client
       '@osdk/e2e.generated.catchall':
         specifier: workspace:*
         version: link:../../packages/e2e.generated.catchall
       '@osdk/oauth':
-        specifier: latest
-        version: 1.0.0
+        specifier: workspace:*
+        version: link:../../packages/oauth
       next:
         specifier: 14.2.10
         version: 14.2.10(@babel/core@7.24.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -348,14 +348,14 @@ importers:
   examples/example-react-sdk-2.x:
     dependencies:
       '@osdk/client':
-        specifier: latest
-        version: 2.0.7
+        specifier: workspace:*
+        version: link:../../packages/client
       '@osdk/e2e.generated.catchall':
         specifier: workspace:*
         version: link:../../packages/e2e.generated.catchall
       '@osdk/oauth':
-        specifier: latest
-        version: 1.0.0
+        specifier: workspace:*
+        version: link:../../packages/oauth
       react:
         specifier: ^18
         version: 18.3.1
@@ -470,14 +470,14 @@ importers:
   examples/example-tutorial-todo-aip-app-sdk-2.x:
     dependencies:
       '@osdk/client':
-        specifier: latest
-        version: 2.0.7
+        specifier: workspace:*
+        version: link:../../packages/client
       '@osdk/e2e.generated.catchall':
         specifier: workspace:*
         version: link:../../packages/e2e.generated.catchall
       '@osdk/oauth':
-        specifier: latest
-        version: 1.0.0
+        specifier: workspace:*
+        version: link:../../packages/oauth
       react:
         specifier: ^18
         version: 18.3.1
@@ -580,14 +580,14 @@ importers:
   examples/example-tutorial-todo-app-sdk-2.x:
     dependencies:
       '@osdk/client':
-        specifier: latest
-        version: 2.0.7
+        specifier: workspace:*
+        version: link:../../packages/client
       '@osdk/e2e.generated.catchall':
         specifier: workspace:*
         version: link:../../packages/e2e.generated.catchall
       '@osdk/oauth':
-        specifier: latest
-        version: 1.0.0
+        specifier: workspace:*
+        version: link:../../packages/oauth
       react:
         specifier: ^18
         version: 18.3.1
@@ -666,14 +666,14 @@ importers:
   examples/example-vue-sdk-2.x:
     dependencies:
       '@osdk/client':
-        specifier: latest
-        version: 2.0.7
+        specifier: workspace:*
+        version: link:../../packages/client
       '@osdk/e2e.generated.catchall':
         specifier: workspace:*
         version: link:../../packages/e2e.generated.catchall
       '@osdk/oauth':
-        specifier: latest
-        version: 1.0.0
+        specifier: workspace:*
+        version: link:../../packages/oauth
       vue:
         specifier: ^3.5.11
         version: 3.5.11(typescript@5.5.4)
@@ -3843,18 +3843,6 @@ packages:
   '@osdk/api@1.9.1':
     resolution: {integrity: sha512-a67IMGvlLYkGDsO0Dja9J+vTzWfshn6xAICZlv3d12ys71YvMoTA6kKUgiMrec+cC0vp4R3IE3ESlczsfiJ/iQ==}
 
-  '@osdk/api@2.0.7':
-    resolution: {integrity: sha512-fStUlePQV4oFcy8dUhBb8DtsvLec5TjNyhcnTAUr13ym4rMryJPdgJl7K5BD4y36Lyf3VP49e7IKIfJ/sqNKBQ==}
-
-  '@osdk/client.unstable.osw@0.2.0':
-    resolution: {integrity: sha512-BPE+adWcHw/3V9SjMLbHlHVdMRhC+ZxPMqjj1FY/i1BhS+oCj3n1IsEp+AzFAj2yTaYUswuybKjW9iIPnKcEMA==}
-
-  '@osdk/client.unstable@2.0.7':
-    resolution: {integrity: sha512-CeFPwPrIYSaqVVHCwtB3T9xT5QMnNsq+U9ePQevUN8eb4s4XtVp96FPc3tA27xWWxFyEBX7f1H91ISKMiX2DPA==}
-
-  '@osdk/client@2.0.7':
-    resolution: {integrity: sha512-/TqkmKkXdsMgS1eJwcaqO+WjZbQO0zGRi3xWvRLrpIHWc99WgOh9+krpgdu91I2AzuuUP8zETrhNf5r0GL3sZA==}
-
   '@osdk/foundry.admin@2.1.0':
     resolution: {integrity: sha512-PSepSLbxzddudaXcWa5b2eCpFSKl2GHfcZhvY3+yHImqFqcjXpnJakS0un3DfZvjjrY8MCMHXjbJYzTvwFyFTg==}
 
@@ -3897,9 +3885,6 @@ packages:
   '@osdk/gateway@2.4.1':
     resolution: {integrity: sha512-RHwTFQ2dGKbu25YwjukRKQj9CzoO3xdueSEetIkfCuuHvOLOlIUAJsjj+j7UV96MzsbefAcsQyJC+PqENdU57w==}
 
-  '@osdk/generator-converters@2.0.7':
-    resolution: {integrity: sha512-2h1WFcupkuIBm5XxObtd9VfAGH/+rQ7CzvGRXpa3+IFAddC7aDxXutbG8q23gykeZNjOgnBQ28kkVz9i9FFO5w==}
-
   '@osdk/internal.foundry.core@0.2.0':
     resolution: {integrity: sha512-+It/huASzz4nK/kNVw+hILo2wapzE2ZfptIiem6iEt19KEQVtw/fqJ2VRGMUEop0Q4+rT3VLHdqkNxq5nSUzdA==}
 
@@ -3933,14 +3918,8 @@ packages:
   '@osdk/legacy-client@2.5.1':
     resolution: {integrity: sha512-vo5mMnnAIoBhQORSlKfbVH7G9UNMxJYiRCUxwdrKMkBaJKT5ClJbLTiv9anpqTFkBaw82vMxd7MA80nt3X8hXg==}
 
-  '@osdk/oauth@1.0.0':
-    resolution: {integrity: sha512-/6nk6sgLjlO5d80ziELlYW0avQiovpyJj9aAoOzSUpbwQnuVodruuVxj81uLOrFnO8AFSs/4cicV/EJ0Zs/w2g==}
-
   '@osdk/shared.client.impl@0.1.0':
     resolution: {integrity: sha512-mNpUkkwnDuPK3LNgilQ0uaUUstrTZ/gqNejSil0Q7Zd+Nq05sAmuyiC6a+5el6p1zByzv+XthQAnJF5Nwcuoag==}
-
-  '@osdk/shared.client.impl@1.0.2':
-    resolution: {integrity: sha512-M7UHi6nLtW5K7NjbBmDrXybo1TR0mERoR0hHsajIpMF05TPTq91Hxu/aw0ZCYopOXuXPO6cejPH9dsxazhMnRw==}
 
   '@osdk/shared.client2@1.0.0':
     resolution: {integrity: sha512-AZiDypfNrsH/men2mB12KDQM8t5iGyUI7QO2BTpgQ1pNKgwdILUY/xBsNEAUCnp0eYqSuPI1puJuJB2xogMDHA==}
@@ -3959,9 +3938,6 @@ packages:
 
   '@osdk/shared.net.fetch@0.1.0':
     resolution: {integrity: sha512-YQXAy2ZcBRtI12/Yrivj7Yf33NYg9EQs0FX2uCGeSapkLqb8hQH7VBgTdDWXMJIJeUdIgANg0+DmWckNIY9DDQ==}
-
-  '@osdk/shared.net.fetch@1.0.0':
-    resolution: {integrity: sha512-3xd3VJpFZ5tnqFS6cNpq0BhWRt8KCydhx7dngOztef0ndXe7WXjbVb5TXK640M4kVZEf6iCxWCvscQrqiTTMkQ==}
 
   '@osdk/shared.net.platformapi@0.3.1':
     resolution: {integrity: sha512-5pJH/5abA2zm59SqJG5cLnZM/VKjTg/K/ULqlZun1K067rbIVt0G96+y84PbyE0nPgneCl9LSlbiA/hzt9KgCg==}
@@ -9193,47 +9169,6 @@ snapshots:
       fetch-retry: 6.0.0
       tiny-invariant: 1.3.3
 
-  '@osdk/api@2.0.7':
-    dependencies:
-      '@types/geojson': 7946.0.14
-      fetch-retry: 6.0.0
-      tiny-invariant: 1.3.3
-      type-fest: 4.18.2
-
-  '@osdk/client.unstable.osw@0.2.0':
-    dependencies:
-      conjure-lite: 0.4.4
-
-  '@osdk/client.unstable@2.0.7':
-    dependencies:
-      conjure-lite: 0.4.4
-
-  '@osdk/client@2.0.7':
-    dependencies:
-      '@osdk/api': 2.0.7
-      '@osdk/client.unstable': 2.0.7
-      '@osdk/client.unstable.osw': 0.2.0
-      '@osdk/generator-converters': 2.0.7
-      '@osdk/internal.foundry.core': 2.2.0
-      '@osdk/internal.foundry.ontologiesv2': 2.2.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client.impl': 1.0.2
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.errors': 2.0.0
-      '@osdk/shared.net.fetch': 1.0.0
-      '@types/geojson': 7946.0.14
-      conjure-lite: 0.4.4
-      fast-deep-equal: 3.1.3
-      fetch-retry: 6.0.0
-      find-up: 7.0.0
-      isomorphic-ws: 5.0.0(ws@8.18.0)
-      tiny-invariant: 1.3.3
-      type-fest: 4.18.2
-      ws: 8.18.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   '@osdk/foundry.admin@2.1.0':
     dependencies:
       '@osdk/foundry.core': 2.1.0
@@ -9330,11 +9265,6 @@ snapshots:
       fetch-retry: 6.0.0
       tiny-invariant: 1.3.3
 
-  '@osdk/generator-converters@2.0.7':
-    dependencies:
-      '@osdk/api': 2.0.7
-      '@osdk/internal.foundry.core': 2.2.0
-
   '@osdk/internal.foundry.core@0.2.0':
     dependencies:
       '@osdk/internal.foundry.geo': 0.1.0
@@ -9411,25 +9341,11 @@ snapshots:
       ngeohash: 0.6.3
       tiny-invariant: 1.3.3
 
-  '@osdk/oauth@1.0.0':
-    dependencies:
-      delay: 6.0.0
-      oauth4webapi: 2.10.4
-      tiny-invariant: 1.3.3
-      typescript-event-target: 1.1.1
-
   '@osdk/shared.client.impl@0.1.0':
     dependencies:
       '@osdk/shared.client': 0.0.0
       '@osdk/shared.net.errors': 1.1.0
       '@osdk/shared.net.fetch': 0.1.0
-
-  '@osdk/shared.client.impl@1.0.2':
-    dependencies:
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.errors': 2.0.0
-      '@osdk/shared.net.fetch': 1.0.0
 
   '@osdk/shared.client2@1.0.0': {}
 
@@ -9444,11 +9360,6 @@ snapshots:
   '@osdk/shared.net.fetch@0.1.0':
     dependencies:
       '@osdk/shared.net.errors': 1.1.0
-      fetch-retry: 6.0.0
-
-  '@osdk/shared.net.fetch@1.0.0':
-    dependencies:
-      '@osdk/shared.net.errors': 2.0.0
       fetch-retry: 6.0.0
 
   '@osdk/shared.net.platformapi@0.3.1':
@@ -11039,7 +10950,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.0)
-      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.17.0(eslint@9.7.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.17.0(eslint@9.7.0)(typescript@5.5.4))(eslint-plugin-import@2.30.0)(eslint@9.7.0))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-react: 7.37.1(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -11063,7 +10974,7 @@ snapshots:
       enhanced-resolve: 5.16.1
       eslint: 8.57.0
       eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.17.0(eslint@9.7.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.17.0(eslint@9.7.0)(typescript@5.5.4))(eslint-plugin-import@2.30.0)(eslint@9.7.0))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.15.1
@@ -11113,6 +11024,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.17.0(eslint@9.7.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.17.0(eslint@9.7.0)(typescript@5.5.4))(eslint-plugin-import@2.30.0)(eslint@9.7.0))(eslint@8.57.0):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.17.0(eslint@9.7.0)(typescript@5.5.4)
+      eslint: 8.57.0
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.17.0(eslint@9.7.0)(typescript@5.5.4))(eslint-plugin-import@2.30.0)(eslint@9.7.0)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-module-utils@2.12.0(@typescript-eslint/parser@7.17.0(eslint@9.7.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.17.0(eslint@9.7.0)(typescript@5.5.4))(eslint-plugin-import@2.30.0)(eslint@9.7.0))(eslint@9.7.0):
     dependencies:
       debug: 3.2.7
@@ -11138,34 +11060,6 @@ snapshots:
     dependencies:
       eslint: 9.7.0
 
-  eslint-plugin-import@2.30.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.8
-      array.prototype.findlastindex: 1.2.5
-      array.prototype.flat: 1.3.2
-      array.prototype.flatmap: 1.3.2
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 8.57.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.0))(eslint@8.57.0)
-      hasown: 2.0.2
-      is-core-module: 2.15.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.0
-      semver: 6.3.1
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.5.4)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
   eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.17.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.17.0(eslint@9.7.0)(typescript@5.5.4))(eslint-plugin-import@2.30.0)(eslint@9.7.0))(eslint@8.57.0):
     dependencies:
       '@rtsao/scc': 1.1.0
@@ -11189,6 +11083,34 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 7.17.0(eslint@8.57.0)(typescript@5.5.4)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.17.0(eslint@9.7.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.17.0(eslint@9.7.0)(typescript@5.5.4))(eslint-plugin-import@2.30.0)(eslint@9.7.0))(eslint@8.57.0):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.8
+      array.prototype.findlastindex: 1.2.5
+      array.prototype.flat: 1.3.2
+      array.prototype.flatmap: 1.3.2
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.57.0
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.17.0(eslint@9.7.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.17.0(eslint@9.7.0)(typescript@5.5.4))(eslint-plugin-import@2.30.0)(eslint@9.7.0))(eslint@8.57.0)
+      hasown: 2.0.2
+      is-core-module: 2.15.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.0
+      semver: 6.3.1
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.17.0(eslint@9.7.0)(typescript@5.5.4)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack


### PR DESCRIPTION
`"@osdk/client": "latest"` with `npm install` in a created package either always or often just consults `npm cache`. Even though we think our users get latest they are not. 

This change is not perfect as it requires us to keep updating the version by hand but is superior to what we had.