### PR TITLE
Demo dev-console-snippets

### DIFF
--- a/packages/dev-console-snippets/.gitignore
+++ b/packages/dev-console-snippets/.gitignore
@@ -1,0 +1,1 @@
+/src/generatedNoCheck/

--- a/packages/dev-console-snippets/codegen.mjs
+++ b/packages/dev-console-snippets/codegen.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Handlebars from "handlebars";
+import * as fs from "node:fs";
+import * as templates from "./templates.mjs";
+
+let indexContents = "";
+
+fs.mkdirSync("./src/generatedNoCheck", { recursive: true });
+
+for (const c of ["loadObjectPageGuide"]) {
+  const h = Handlebars.compile(templates[c]);
+
+  fs.writeFileSync(
+    `./src/generatedNoCheck/${c}.ts`,
+    `import {client} from "../client.js";\n`
+      + h({
+        objectType: "Employee",
+        packageName: "@osdk/e2e.generated.catchall",
+        titleProperty: "firstName",
+      }),
+  );
+
+  indexContents = `export const ${c} = ${JSON.stringify(templates[c])}\n\n`;
+}
+
+fs.writeFileSync(`./src/generatedNoCheck/index.ts`, indexContents);

--- a/packages/dev-console-snippets/package.json
+++ b/packages/dev-console-snippets/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@osdk/dev-console-snippets",
+  "version": "0.0.0",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/palantir/osdk-ts.git"
+  },
+  "exports": {
+    ".": {
+      "browser": "./build/browser/index.js",
+      "import": "./build/esm/index.js"
+    },
+    "./*": {
+      "browser": "./build/browser/public/*.js",
+      "import": "./build/esm/public/*.js"
+    }
+  },
+  "scripts": {
+    "check-attw": "monorepo.tool.attw esm",
+    "check-spelling": "cspell --quiet .",
+    "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
+    "codegen": "node codegen.mjs",
+    "fix-lint": "eslint . --fix && dprint fmt --config $(find-up dprint.json)",
+    "lint": "eslint . && dprint check  --config $(find-up dprint.json)",
+    "transpile": "monorepo.tool.transpile"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@osdk/client": "workspace:*",
+    "@osdk/e2e.generated.catchall": "workspace:*",
+    "@osdk/monorepo.api-extractor": "workspace:~",
+    "@osdk/monorepo.tsconfig": "workspace:~",
+    "@osdk/monorepo.tsup": "workspace:~",
+    "handlebars": "^4.7.8",
+    "outdent": "^0.8.0",
+    "typescript": "~5.5.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "build/cjs",
+    "build/esm",
+    "build/browser",
+    "CHANGELOG.md",
+    "package.json",
+    "templates",
+    "*.d.ts"
+  ],
+  "module": "./build/esm/index.js",
+  "types": "./build/esm/index.d.ts",
+  "type": "module"
+}

--- a/packages/dev-console-snippets/src/client.ts
+++ b/packages/dev-console-snippets/src/client.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createClient } from "@osdk/client";
+export const client = createClient("", "", () => Promise.resolve(""));

--- a/packages/dev-console-snippets/src/index.ts
+++ b/packages/dev-console-snippets/src/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { loadObjectPageGuide } from "./generatedNoCheck/index.js";

--- a/packages/dev-console-snippets/templates.mjs
+++ b/packages/dev-console-snippets/templates.mjs
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { outdent } from "outdent";
+
+export const loadObjectPageGuide = outdent`
+    import { {{objectType}} } from "{{{packageName}}}";
+    import { isOk, Osdk, PageResult, Result } from "@osdk/client";
+    const firstPage: Result<PageResult<Osdk.Instance<{{objectType}}>>>
+        = await client({{objectType}}).fetchPageWithErrors({ $pageSize: 30 });
+    if (isOk(firstPage)) {
+        const secondPage: Result<PageResult<Osdk.Instance<{{objectType}}, never, "{{titleProperty}}">>>
+        // You can also down select properties to only get the properties you need from the object
+        = await client({{objectType}}).fetchPageWithErrors({ $select: ["{{titleProperty}}"], $pageSize: 30, $nextPageToken: firstPage.value.nextPageToken });
+        const objects = isOk(secondPage) ? [...firstPage.value.data, ...secondPage.value.data] : firstPage.value.data;
+        const object = objects[0];
+    }
+    // To fetch a page without a result wrapper, use fetchPage with a try/catch instead
+    try {
+        const firstPage: PageResult<Osdk.Instance<{{objectType}}>>
+            = await client({{objectType}}).fetchPage({ $pageSize: 30 });
+        const secondPage: PageResult<Osdk.Instance<{{objectType}}>>
+        = await client({{objectType}}).fetchPage({ $pageSize: 30, $nextPageToken: firstPage.nextPageToken });
+        const objects = [...firstPage.data, ...secondPage.data];
+        const object = objects[0];
+    }
+    catch (e) {
+        console.error(e);
+    }
+`;

--- a/packages/dev-console-snippets/tsconfig.json
+++ b/packages/dev-console-snippets/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@osdk/monorepo.tsconfig/base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build/esm"
+  },
+  "include": [
+    "./src/**/*"
+  ],
+  "references": []
+}

--- a/packages/dev-console-snippets/tsup.config.js
+++ b/packages/dev-console-snippets/tsup.config.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineConfig } from "tsup";
+
+export default defineConfig(async (options) =>
+  (await import("@osdk/monorepo.tsup")).default(options, {
+    esmOnly: true,
+  })
+);

--- a/packages/dev-console-snippets/vitest.config.mts
+++ b/packages/dev-console-snippets/vitest.config.mts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { configDefaults, defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    pool: "forks",
+    exclude: [...configDefaults.exclude, "**/build/**/*"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1743,6 +1743,33 @@ importers:
         specifier: ^2.1.6
         version: 2.1.6(typescript@5.5.4)
 
+  packages/dev-console-snippets:
+    devDependencies:
+      '@osdk/client':
+        specifier: workspace:*
+        version: link:../client
+      '@osdk/e2e.generated.catchall':
+        specifier: workspace:*
+        version: link:../e2e.generated.catchall
+      '@osdk/monorepo.api-extractor':
+        specifier: workspace:~
+        version: link:../monorepo.api-extractor
+      '@osdk/monorepo.tsconfig':
+        specifier: workspace:~
+        version: link:../monorepo.tsconfig
+      '@osdk/monorepo.tsup':
+        specifier: workspace:~
+        version: link:../monorepo.tsup
+      handlebars:
+        specifier: ^4.7.8
+        version: 4.7.8
+      outdent:
+        specifier: ^0.8.0
+        version: 0.8.0
+      typescript:
+        specifier: ~5.5.4
+        version: 5.5.4
+
   packages/e2e.generated.1.1.x:
     dependencies:
       '@osdk/api':
@@ -6613,6 +6640,9 @@ packages:
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
+
+  outdent@0.8.0:
+    resolution: {integrity: sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==}
 
   outvariant@1.4.2:
     resolution: {integrity: sha512-Ou3dJ6bA/UJ5GVHxah4LnqDwZRwAmWxrG3wtrHrbGnP4RnLCtA64A4F+ae7Y8ww660JaddSoArUR5HjipWSHAQ==}
@@ -12784,6 +12814,8 @@ snapshots:
   os-tmpdir@1.0.2: {}
 
   outdent@0.5.0: {}
+
+  outdent@0.8.0: {}
 
   outvariant@1.4.2: {}
 


### PR DESCRIPTION
Generated `./src/generatedNoCheck/loadObjectPageGuide.ts`

```ts
import {client} from "../client.js";
import { Employee } from "@osdk/e2e.generated.catchall";
import { isOk, Osdk, PageResult, Result } from "@osdk/client";
const firstPage: Result<PageResult<Osdk.Instance<Employee>>>
    = await client(Employee).fetchPageWithErrors({ $pageSize: 30 });
if (isOk(firstPage)) {
    const secondPage: Result<PageResult<Osdk.Instance<Employee, never, "firstName">>>
    // You can also down select properties to only get the properties you need from the object
    = await client(Employee).fetchPageWithErrors({ $select: ["firstName"], $pageSize: 30, $nextPageToken: firstPage.value.nextPageToken });
    const objects = isOk(secondPage) ? [...firstPage.value.data, ...secondPage.value.data] : firstPage.value.data;
    const object = objects[0];
}
// To fetch a page without a result wrapper, use fetchPage with a try/catch instead
try {
    const firstPage: PageResult<Osdk.Instance<Employee>>
        = await client(Employee).fetchPage({ $pageSize: 30 });
    const secondPage: PageResult<Osdk.Instance<Employee>>
    = await client(Employee).fetchPage({ $pageSize: 30, $nextPageToken: firstPage.nextPageToken });
    const objects = [...firstPage.data, ...secondPage.data];
    const object = objects[0];
}
catch (e) {
    console.error(e);
}
```

Generated `./src/generatedNoCheck/index.ts`:

```ts
export const loadObjectPageGuide = "import { {{objectType}} } from \"{{{packageName}}}\";\nimport { isOk, Osdk, PageResult, Result } from \"@osdk/client\";\nconst firstPage: Result<PageResult<Osdk.Instance<{{objectType}}>>>\n    = await client({{objectType}}).fetchPageWithErrors({ $pageSize: 30 });\nif (isOk(firstPage)) {\n    const secondPage: Result<PageResult<Osdk.Instance<{{objectType}}, never, \"{{titleProperty}}\">>>\n    // You can also down select properties to only get the properties you need from the object\n    = await client({{objectType}}).fetchPageWithErrors({ $select: [\"{{titleProperty}}\"], $pageSize: 30, $nextPageToken: firstPage.value.nextPageToken });\n    const objects = isOk(secondPage) ? [...firstPage.value.data, ...secondPage.value.data] : firstPage.value.data;\n    const object = objects[0];\n}\n// To fetch a page without a result wrapper, use fetchPage with a try/catch instead\ntry {\n    const firstPage: PageResult<Osdk.Instance<{{objectType}}>>\n        = await client({{objectType}}).fetchPage({ $pageSize: 30 });\n    const secondPage: PageResult<Osdk.Instance<{{objectType}}>>\n    = await client({{objectType}}).fetchPage({ $pageSize: 30, $nextPageToken: firstPage.nextPageToken });\n    const objects = [...firstPage.data, ...secondPage.data];\n    const object = objects[0];\n}\ncatch (e) {\n    console.error(e);\n}"

```