### PR TITLE
Include API error info in CLI error messages

### DIFF
--- a/.changeset/quick-buttons-pull.md
+++ b/.changeset/quick-buttons-pull.md
@@ -1,0 +1,8 @@
+---
+"@osdk/shared.client.impl": patch
+"@osdk/shared.net.errors": patch
+"@osdk/shared.net": patch
+"@osdk/cli": patch
+---
+
+Include API error info in CLI error messages

--- a/packages/shared.client.impl/src/createSharedClientContext.ts
+++ b/packages/shared.client.impl/src/createSharedClientContext.ts
@@ -63,7 +63,7 @@ export function createSharedClientContext(
         ? new PalantirApiError(
           e.message,
           e.errorName,
-          e.errorType,
+          e.errorCode,
           e.statusCode,
           e.errorInstanceId,
           e.parameters,

--- a/packages/shared.net.errors/src/PalantirApiError.ts
+++ b/packages/shared.net.errors/src/PalantirApiError.ts
@@ -17,7 +17,7 @@
 export class PalantirApiError extends Error implements PalantirApiError {
   public message: string;
   public errorName?: string;
-  public errorType?: string;
+  public errorCode?: string;
   public statusCode?: number;
   public errorInstanceId?: string;
   public parameters?: any;
@@ -25,7 +25,7 @@ export class PalantirApiError extends Error implements PalantirApiError {
   constructor(
     message: string,
     errorName?: string,
-    errorType?: string,
+    errorCode?: string,
     statusCode?: number,
     errorInstanceId?: string,
     parameters?: any,
@@ -33,7 +33,7 @@ export class PalantirApiError extends Error implements PalantirApiError {
     super(message);
     this.message = message;
     this.errorName = errorName;
-    this.errorType = errorType;
+    this.errorCode = errorCode;
     this.statusCode = statusCode;
     this.errorInstanceId = errorInstanceId;
     this.parameters = parameters;

--- a/packages/shared.net/src/createClientContext.ts
+++ b/packages/shared.net/src/createClientContext.ts
@@ -66,7 +66,7 @@ export function createClientContext(
         ? new PalantirApiError(
           e.message,
           e.errorName,
-          e.errorType,
+          e.errorCode,
           e.statusCode,
           e.errorInstanceId,
           e.parameters,


### PR DESCRIPTION
Include API error info about the public gateway errors https://www.palantir.com/docs/foundry/api/general/overview/errors/ in CLI error messages to help debug. Currently only the network status code and text are exposed, but not any specific detail about the API error.

For the specific case of 404, also include a tip like 401 and 403 to make it clear that this can mean either the resource doesn't exist or the token is missing permissions.

Example error for non-verbose output now:

```
ℹ Palantir OSDK CLI 0.25.0-beta.4                                                                          2:15:35 PM

ℹ Auto version inferred next version to be: 0.109.0-1-g945314d-dirty                                       2:15:35 PM
◐ Zipping site files                                                                                        2:15:35 PM
◐ Uploading site files                                                                                      2:15:35 PM

 ERROR  Failed to fetch 404 Not Found                                                                       2:15:36 PM

{
  "errorCode": "NOT_FOUND",
  "errorName": "ThirdPartyApplicationNotFound",
  "errorInstanceId": "xxx",
  "parameters": {
    "thirdPartyApplicationRid": "xxx"
  }
}

💡 Tip: The resource may not exist or your token may not have the required scopes to load it                2:15:36 PM
```