### PR TITLE
Add scopes to CLI options

### DIFF
--- a/.changeset/weak-rice-talk.md
+++ b/.changeset/weak-rice-talk.md
@@ -1,0 +1,16 @@
+---
+"@osdk/create-app.template.tutorial-todo-aip-app.beta": minor
+"@osdk/create-app.template.tutorial-todo-app.beta": minor
+"@osdk/create-app.template.next-static-export.v2": minor
+"@osdk/create-app.template.tutorial-todo-aip-app": minor
+"@osdk/create-app.template.next-static-export": minor
+"@osdk/create-app.template.tutorial-todo-app": minor
+"@osdk/create-app.template.react.beta": minor
+"@osdk/create-app.template.vue.v2": minor
+"@osdk/create-app.template.react": minor
+"@osdk/create-app.template.vue": minor
+"@osdk/example-generator": minor
+"@osdk/create-app": minor
+---
+
+Add the scopes option to OSDK CLI and update all example generators to include the scopes if provided, else, hide the scopes to avoid confusion

--- a/README.md
+++ b/README.md
@@ -24,4 +24,3 @@
    > Full docs on the `changesets` tool can be found at the [changesets/changesets github repo](https://github.com/changesets/changesets).
 7. If you're curious what the final build output might look like you can run `pnpm build` from root.
 8. Run all lint rules and tests with `pnpm check` from root.
-hi

--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@
    > Full docs on the `changesets` tool can be found at the [changesets/changesets github repo](https://github.com/changesets/changesets).
 7. If you're curious what the final build output might look like you can run `pnpm build` from root.
 8. Run all lint rules and tests with `pnpm check` from root.
+hi

--- a/examples/example-next-static-export-sdk-1.x/src/lib/client.ts
+++ b/examples/example-next-static-export-sdk-1.x/src/lib/client.ts
@@ -25,6 +25,10 @@ const client = new FoundryClient({
     clientId,
     url,
     redirectUrl,
+    scopes: [
+        "api:read-data",
+        "api:write-data",
+    ],
   }),
 });
 

--- a/examples/example-next-static-export-sdk-1.x/src/lib/client.ts
+++ b/examples/example-next-static-export-sdk-1.x/src/lib/client.ts
@@ -26,8 +26,8 @@ const client = new FoundryClient({
     url,
     redirectUrl,
     scopes: [
-        "api:read-data",
-        "api:write-data",
+        "api:ontologies-read",
+        "api:ontologies-write",
     ],
   }),
 });

--- a/examples/example-next-static-export-sdk-2.x/src/lib/client.ts
+++ b/examples/example-next-static-export-sdk-2.x/src/lib/client.ts
@@ -11,8 +11,8 @@ checkEnv(url, "NEXT_PUBLIC_FOUNDRY_API_URL");
 checkEnv(clientId, "NEXT_PUBLIC_FOUNDRY_CLIENT_ID");
 checkEnv(redirectUrl, "NEXT_PUBLIC_FOUNDRY_REDIRECT_URL");
 const scopes = [
-    "api:read-data",
-    "api:write-data",
+    "api:ontologies-read",
+    "api:ontologies-write",
 ];
 
 function checkEnv(

--- a/examples/example-next-static-export-sdk-2.x/src/lib/client.ts
+++ b/examples/example-next-static-export-sdk-2.x/src/lib/client.ts
@@ -10,6 +10,10 @@ const redirectUrl = process.env.NEXT_PUBLIC_FOUNDRY_REDIRECT_URL;
 checkEnv(url, "NEXT_PUBLIC_FOUNDRY_API_URL");
 checkEnv(clientId, "NEXT_PUBLIC_FOUNDRY_CLIENT_ID");
 checkEnv(redirectUrl, "NEXT_PUBLIC_FOUNDRY_REDIRECT_URL");
+const scopes = [
+    "api:read-data",
+    "api:write-data",
+];
 
 function checkEnv(
   value: string | undefined,
@@ -30,6 +34,10 @@ export const getAuth = () => {
       clientId,
       url,
       redirectUrl,
+      true,
+      undefined,
+      window.location.toString(),
+      scopes,
     );
   }
   return auth;

--- a/examples/example-react-sdk-1.x/src/client.ts
+++ b/examples/example-react-sdk-1.x/src/client.ts
@@ -26,8 +26,8 @@ const client = new FoundryClient({
     url,
     redirectUrl,
     scopes: [
-        "api:read-data",
-        "api:write-data",
+        "api:ontologies-read",
+        "api:ontologies-write",
     ],
   }),
 });

--- a/examples/example-react-sdk-1.x/src/client.ts
+++ b/examples/example-react-sdk-1.x/src/client.ts
@@ -28,7 +28,7 @@ const client = new FoundryClient({
     scopes: [
         "api:read-data",
         "api:write-data",
-    ]
+    ],
   }),
 });
 

--- a/examples/example-react-sdk-1.x/src/client.ts
+++ b/examples/example-react-sdk-1.x/src/client.ts
@@ -25,6 +25,10 @@ const client = new FoundryClient({
     clientId,
     url,
     redirectUrl,
+    scopes: [
+        "api:read-data",
+        "api:write-data",
+    ]
   }),
 });
 

--- a/examples/example-react-sdk-2.x/src/client.ts
+++ b/examples/example-react-sdk-2.x/src/client.ts
@@ -7,8 +7,8 @@ const url = import.meta.env.VITE_FOUNDRY_API_URL;
 const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
 const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
 const scopes = [
-    "api:read-data",
-    "api:write-data",
+    "api:ontologies-read",
+    "api:ontologies-write",
 ];
 
 checkEnv(url, "VITE_FOUNDRY_API_URL");

--- a/examples/example-react-sdk-2.x/src/client.ts
+++ b/examples/example-react-sdk-2.x/src/client.ts
@@ -6,6 +6,10 @@ import { createPublicOauthClient } from "@osdk/oauth";
 const url = import.meta.env.VITE_FOUNDRY_API_URL;
 const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
 const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
+const scopes = [
+    "api:read-data",
+    "api:write-data",
+];
 
 checkEnv(url, "VITE_FOUNDRY_API_URL");
 checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
@@ -24,7 +28,12 @@ export const auth = createPublicOauthClient(
   clientId,
   url,
   redirectUrl,
-  )
+  true,
+  undefined,
+  window.location.toString(),
+  scopes,
+);
+
 /**
  * Initialize the client to interact with the Ontology SDK
  */

--- a/examples/example-tutorial-todo-aip-app-sdk-1.x/src/client.ts
+++ b/examples/example-tutorial-todo-aip-app-sdk-1.x/src/client.ts
@@ -25,6 +25,10 @@ const client = new FoundryClient({
     clientId,
     url,
     redirectUrl,
+    scopes: [
+        "api:read-data",
+        "api:write-data",
+    ],
   }),
 });
 

--- a/examples/example-tutorial-todo-aip-app-sdk-1.x/src/client.ts
+++ b/examples/example-tutorial-todo-aip-app-sdk-1.x/src/client.ts
@@ -26,8 +26,8 @@ const client = new FoundryClient({
     url,
     redirectUrl,
     scopes: [
-        "api:read-data",
-        "api:write-data",
+        "api:ontologies-read",
+        "api:ontologies-write",
     ],
   }),
 });

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/src/client.ts
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/src/client.ts
@@ -9,8 +9,8 @@ checkEnv(url, "VITE_FOUNDRY_API_URL");
 checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
 checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
 const scopes = [
-    "api:read-data",
-    "api:write-data",
+    "api:ontologies-read",
+    "api:ontologies-write",
 ];
 
 function checkEnv(

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/src/client.ts
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/src/client.ts
@@ -8,6 +8,10 @@ const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
 checkEnv(url, "VITE_FOUNDRY_API_URL");
 checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
 checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
+const scopes = [
+    "api:read-data",
+    "api:write-data",
+];
 
 function checkEnv(
   value: string | undefined,
@@ -25,6 +29,10 @@ const auth = createPublicOauthClient(
   clientId,
   url,
   redirectUrl,
+  true,
+  undefined,
+  window.location.toString(),
+  scopes,
 );
 
 const client = createClient(

--- a/examples/example-tutorial-todo-app-sdk-1.x/src/client.ts
+++ b/examples/example-tutorial-todo-app-sdk-1.x/src/client.ts
@@ -25,6 +25,10 @@ const client = new FoundryClient({
     clientId,
     url,
     redirectUrl,
+    scopes: [
+        "api:read-data",
+        "api:write-data",
+    ],
   }),
 });
 

--- a/examples/example-tutorial-todo-app-sdk-1.x/src/client.ts
+++ b/examples/example-tutorial-todo-app-sdk-1.x/src/client.ts
@@ -26,8 +26,8 @@ const client = new FoundryClient({
     url,
     redirectUrl,
     scopes: [
-        "api:read-data",
-        "api:write-data",
+        "api:ontologies-read",
+        "api:ontologies-write",
     ],
   }),
 });

--- a/examples/example-tutorial-todo-app-sdk-2.x/src/client.ts
+++ b/examples/example-tutorial-todo-app-sdk-2.x/src/client.ts
@@ -9,8 +9,8 @@ checkEnv(url, "VITE_FOUNDRY_API_URL");
 checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
 checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
 const scopes = [
-    "api:read-data",
-    "api:write-data",
+    "api:ontologies-read",
+    "api:ontologies-write",
 ];
 
 function checkEnv(

--- a/examples/example-tutorial-todo-app-sdk-2.x/src/client.ts
+++ b/examples/example-tutorial-todo-app-sdk-2.x/src/client.ts
@@ -8,6 +8,10 @@ const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
 checkEnv(url, "VITE_FOUNDRY_API_URL");
 checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
 checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
+const scopes = [
+    "api:read-data",
+    "api:write-data",
+];
 
 function checkEnv(
   value: string | undefined,
@@ -25,6 +29,10 @@ const auth = createPublicOauthClient(
   clientId,
   url,
   redirectUrl,
+  true,
+  undefined,
+  window.location.toString(),
+  scopes,
 );
 
 const client = createClient(

--- a/examples/example-vue-sdk-1.x/src/client.ts
+++ b/examples/example-vue-sdk-1.x/src/client.ts
@@ -25,6 +25,10 @@ const client = new FoundryClient({
     clientId,
     url,
     redirectUrl,
+    scopes: [
+        "api:read-data",
+        "api:write-data",
+    ],
   }),
 });
 

--- a/examples/example-vue-sdk-1.x/src/client.ts
+++ b/examples/example-vue-sdk-1.x/src/client.ts
@@ -26,8 +26,8 @@ const client = new FoundryClient({
     url,
     redirectUrl,
     scopes: [
-        "api:read-data",
-        "api:write-data",
+        "api:ontologies-read",
+        "api:ontologies-write",
     ],
   }),
 });

--- a/examples/example-vue-sdk-2.x/src/client.ts
+++ b/examples/example-vue-sdk-2.x/src/client.ts
@@ -7,8 +7,8 @@ const url = import.meta.env.VITE_FOUNDRY_API_URL;
 const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
 const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
 const scopes = [
-    "api:read-data",
-    "api:write-data",
+    "api:ontologies-read",
+    "api:ontologies-write",
 ];
 
 checkEnv(url, "VITE_FOUNDRY_API_URL");

--- a/examples/example-vue-sdk-2.x/src/client.ts
+++ b/examples/example-vue-sdk-2.x/src/client.ts
@@ -6,6 +6,10 @@ import { createPublicOauthClient } from "@osdk/oauth";
 const url = import.meta.env.VITE_FOUNDRY_API_URL;
 const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
 const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
+const scopes = [
+    "api:read-data",
+    "api:write-data",
+];
 
 checkEnv(url, "VITE_FOUNDRY_API_URL");
 checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
@@ -24,7 +28,12 @@ export const auth = createPublicOauthClient(
   clientId,
   url,
   redirectUrl,
-  )
+  true,
+  undefined,
+  window.location.toString(),
+  scopes,
+);
+
 /**
  * Initialize the client to interact with the Ontology SDK
  */

--- a/packages/create-app.template.next-static-export.v2/templates/src/lib/client.ts.hbs
+++ b/packages/create-app.template.next-static-export.v2/templates/src/lib/client.ts.hbs
@@ -37,10 +37,10 @@ export const getAuth = () => {
       clientId,
       url,
       redirectUrl,
+      {{#if scopes}}
       true,
       undefined,
       window.location.toString(),
-      {{#if scopes}}
       scopes,
       {{/if}}
     );

--- a/packages/create-app.template.next-static-export.v2/templates/src/lib/client.ts.hbs
+++ b/packages/create-app.template.next-static-export.v2/templates/src/lib/client.ts.hbs
@@ -10,6 +10,13 @@ const redirectUrl = process.env.NEXT_PUBLIC_FOUNDRY_REDIRECT_URL;
 checkEnv(url, "NEXT_PUBLIC_FOUNDRY_API_URL");
 checkEnv(clientId, "NEXT_PUBLIC_FOUNDRY_CLIENT_ID");
 checkEnv(redirectUrl, "NEXT_PUBLIC_FOUNDRY_REDIRECT_URL");
+{{#if scopes}}
+const scopes = [
+  {{#each scopes}}
+    "{{this}}",
+  {{/each}}
+];
+{{/if}}
 
 function checkEnv(
   value: string | undefined,
@@ -30,6 +37,12 @@ export const getAuth = () => {
       clientId,
       url,
       redirectUrl,
+      true,
+      undefined,
+      window.location.toString(),
+      {{#if scopes}}
+      scopes,
+      {{/if}}
     );
   }
   return auth;

--- a/packages/create-app.template.next-static-export/templates/src/lib/client.ts.hbs
+++ b/packages/create-app.template.next-static-export/templates/src/lib/client.ts.hbs
@@ -25,6 +25,13 @@ const client = new FoundryClient({
     clientId,
     url,
     redirectUrl,
+    {{#if scopes}}
+    scopes: [
+      {{#each scopes}}
+        "{{this}}",
+      {{/each}}
+    ],
+    {{/if}}
   }),
 });
 

--- a/packages/create-app.template.react.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.react.beta/templates/src/client.ts.hbs
@@ -6,6 +6,13 @@ import { createPublicOauthClient } from "@osdk/oauth";
 const url = import.meta.env.VITE_FOUNDRY_API_URL;
 const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
 const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
+{{#if scopes}}
+const scopes = [
+  {{#each scopes}}
+    "{{this}}",
+  {{/each}}
+];
+{{/if}}
 
 checkEnv(url, "VITE_FOUNDRY_API_URL");
 checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
@@ -24,7 +31,14 @@ export const auth = createPublicOauthClient(
   clientId,
   url,
   redirectUrl,
-  )
+  true,
+  undefined,
+  window.location.toString(),
+  {{#if scopes}}
+  scopes,
+  {{/if}}
+);
+
 /**
  * Initialize the client to interact with the Ontology SDK
  */

--- a/packages/create-app.template.react.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.react.beta/templates/src/client.ts.hbs
@@ -31,10 +31,10 @@ export const auth = createPublicOauthClient(
   clientId,
   url,
   redirectUrl,
+  {{#if scopes}}
   true,
   undefined,
   window.location.toString(),
-  {{#if scopes}}
   scopes,
   {{/if}}
 );

--- a/packages/create-app.template.react/templates/src/client.ts.hbs
+++ b/packages/create-app.template.react/templates/src/client.ts.hbs
@@ -25,6 +25,13 @@ const client = new FoundryClient({
     clientId,
     url,
     redirectUrl,
+    {{#if scopes}}
+    scopes: [
+      {{#each scopes}}
+        "{{this}}",
+      {{/each}}
+    ]
+    {{/if}}
   }),
 });
 

--- a/packages/create-app.template.react/templates/src/client.ts.hbs
+++ b/packages/create-app.template.react/templates/src/client.ts.hbs
@@ -30,7 +30,7 @@ const client = new FoundryClient({
       {{#each scopes}}
         "{{this}}",
       {{/each}}
-    ]
+    ],
     {{/if}}
   }),
 });

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/client.ts.hbs
@@ -32,10 +32,10 @@ const auth = createPublicOauthClient(
   clientId,
   url,
   redirectUrl,
+  {{#if scopes}}
   true,
   undefined,
   window.location.toString(),
-  {{#if scopes}}
   scopes,
   {{/if}}
 );

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/client.ts.hbs
@@ -8,6 +8,13 @@ const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
 checkEnv(url, "VITE_FOUNDRY_API_URL");
 checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
 checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
+{{#if scopes}}
+const scopes = [
+  {{#each scopes}}
+    "{{this}}",
+  {{/each}}
+];
+{{/if}}
 
 function checkEnv(
   value: string | undefined,
@@ -25,6 +32,12 @@ const auth = createPublicOauthClient(
   clientId,
   url,
   redirectUrl,
+  true,
+  undefined,
+  window.location.toString(),
+  {{#if scopes}}
+  scopes,
+  {{/if}}
 );
 
 const client = createClient(

--- a/packages/create-app.template.tutorial-todo-aip-app/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app/templates/src/client.ts.hbs
@@ -25,6 +25,13 @@ const client = new FoundryClient({
     clientId,
     url,
     redirectUrl,
+    {{#if scopes}}
+    scopes: [
+      {{#each scopes}}
+        "{{this}}",
+      {{/each}}
+    ],
+    {{/if}}
   }),
 });
 

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/src/client.ts.hbs
@@ -32,10 +32,10 @@ const auth = createPublicOauthClient(
   clientId,
   url,
   redirectUrl,
+  {{#if scopes}}
   true,
   undefined,
   window.location.toString(),
-  {{#if scopes}}
   scopes,
   {{/if}}
 );

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/src/client.ts.hbs
@@ -8,6 +8,13 @@ const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
 checkEnv(url, "VITE_FOUNDRY_API_URL");
 checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
 checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
+{{#if scopes}}
+const scopes = [
+  {{#each scopes}}
+    "{{this}}",
+  {{/each}}
+];
+{{/if}}
 
 function checkEnv(
   value: string | undefined,
@@ -25,6 +32,12 @@ const auth = createPublicOauthClient(
   clientId,
   url,
   redirectUrl,
+  true,
+  undefined,
+  window.location.toString(),
+  {{#if scopes}}
+  scopes,
+  {{/if}}
 );
 
 const client = createClient(

--- a/packages/create-app.template.tutorial-todo-app/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-app/templates/src/client.ts.hbs
@@ -25,6 +25,13 @@ const client = new FoundryClient({
     clientId,
     url,
     redirectUrl,
+    {{#if scopes}}
+    scopes: [
+      {{#each scopes}}
+        "{{this}}",
+      {{/each}}
+    ],
+    {{/if}}
   }),
 });
 

--- a/packages/create-app.template.vue.v2/templates/src/client.ts.hbs
+++ b/packages/create-app.template.vue.v2/templates/src/client.ts.hbs
@@ -6,6 +6,13 @@ import { createPublicOauthClient } from "@osdk/oauth";
 const url = import.meta.env.VITE_FOUNDRY_API_URL;
 const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
 const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
+{{#if scopes}}
+const scopes = [
+  {{#each scopes}}
+    "{{this}}",
+  {{/each}}
+];
+{{/if}}
 
 checkEnv(url, "VITE_FOUNDRY_API_URL");
 checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
@@ -24,7 +31,14 @@ export const auth = createPublicOauthClient(
   clientId,
   url,
   redirectUrl,
-  )
+  true,
+  undefined,
+  window.location.toString(),
+  {{#if scopes}}
+  scopes,
+  {{/if}}
+);
+
 /**
  * Initialize the client to interact with the Ontology SDK
  */

--- a/packages/create-app.template.vue.v2/templates/src/client.ts.hbs
+++ b/packages/create-app.template.vue.v2/templates/src/client.ts.hbs
@@ -31,10 +31,10 @@ export const auth = createPublicOauthClient(
   clientId,
   url,
   redirectUrl,
+  {{#if scopes}}
   true,
   undefined,
   window.location.toString(),
-  {{#if scopes}}
   scopes,
   {{/if}}
 );

--- a/packages/create-app.template.vue/templates/src/client.ts.hbs
+++ b/packages/create-app.template.vue/templates/src/client.ts.hbs
@@ -25,6 +25,13 @@ const client = new FoundryClient({
     clientId,
     url,
     redirectUrl,
+    {{#if scopes}}
+    scopes: [
+      {{#each scopes}}
+        "{{this}}",
+      {{/each}}
+    ],
+    {{/if}}
   }),
 });
 

--- a/packages/create-app/src/cli.ts
+++ b/packages/create-app/src/cli.ts
@@ -120,7 +120,8 @@ export async function cli(args: string[] = process.argv): Promise<void> {
           .option("scopes", {
             type: "string",
             array: true,
-            describe: "Includes a list of scopes for the client call",
+            describe:
+              "List of client-side scopes to be used when creating a client",
           }),
     );
 

--- a/packages/create-app/src/cli.ts
+++ b/packages/create-app/src/cli.ts
@@ -27,6 +27,7 @@ import { promptOsdkPackage } from "./prompts/promptOsdkPackage.js";
 import { promptOsdkRegistryUrl } from "./prompts/promptOsdkRegistryUrl.js";
 import { promptOverwrite } from "./prompts/promptOverwrite.js";
 import { promptProject } from "./prompts/promptProject.js";
+import { promptScopes } from "./prompts/promptScopes.js";
 import { promptSdkVersion } from "./prompts/promptSdkVersion.js";
 import { promptTemplate } from "./prompts/promptTemplate.js";
 import { run } from "./run.js";
@@ -46,6 +47,7 @@ interface CliArgs {
   osdkPackage?: string;
   osdkRegistryUrl?: string;
   corsProxy?: boolean;
+  scopes?: string[];
 }
 
 export async function cli(args: string[] = process.argv): Promise<void> {
@@ -114,6 +116,11 @@ export async function cli(args: string[] = process.argv): Promise<void> {
             type: "boolean",
             describe:
               "Include a CORS proxy for Foundry API requests during local development",
+          })
+          .option("scopes", {
+            type: "string",
+            array: true,
+            describe: "Includes a list of scopes for the client call",
           }),
     );
 
@@ -132,6 +139,7 @@ export async function cli(args: string[] = process.argv): Promise<void> {
   const osdkPackage: string = await promptOsdkPackage(parsed);
   const osdkRegistryUrl: string = await promptOsdkRegistryUrl(parsed);
   const corsProxy: boolean = await promptCorsProxy(parsed);
+  const scopes: string[] | undefined = await promptScopes(parsed);
 
   await run({
     project,
@@ -145,5 +153,6 @@ export async function cli(args: string[] = process.argv): Promise<void> {
     osdkPackage,
     osdkRegistryUrl,
     corsProxy,
+    scopes,
   });
 }

--- a/packages/create-app/src/prompts/promptScopes.ts
+++ b/packages/create-app/src/prompts/promptScopes.ts
@@ -25,10 +25,10 @@ export async function promptScopes(
     return undefined;
   }
 
-  for (const scope in scopes) {
+  for (const scope of scopes) {
     if (!scopeNameRegex.test(scope)) {
       consola.fail(
-        "Scope name can only contain letters, hyphens, underscores, and colons",
+        `Scope name ${scope} can only contain letters, hyphens, underscores, and colons`,
       );
       // Following promptOverwrite
       process.exit(0);

--- a/packages/create-app/src/prompts/promptScopes.ts
+++ b/packages/create-app/src/prompts/promptScopes.ts
@@ -26,17 +26,15 @@ export async function promptScopes(
   }
 
   while (true) {
-    const allValidScopes = scopes.every(scope => scopeNameRegex.test(scope));
+    const invalidScopes = scopes.filter(scope => !scopeNameRegex.test(scope));
+    const allValidScopes = invalidScopes.length === 0;
     if (allValidScopes) {
       break;
     }
 
-    const firstFailingScopeIndex = scopes.findIndex(scope =>
-      !scopeNameRegex.test(scope)
-    );
-    const failingScope = scopes[firstFailingScopeIndex];
+    const joinedInvalidScopes = invalidScopes.join(", ");
     consola.fail(
-      `Scope name ${failingScope} can only contain letters, hyphens, underscores, and colons`,
+      `Scopes [ ${joinedInvalidScopes} ] are invalid. Scope names can only contain letters, hyphens, underscores, and colons`,
     );
     const stringScopes = await consola.prompt("Scopes:", {
       type: "text",

--- a/packages/create-app/src/prompts/promptScopes.ts
+++ b/packages/create-app/src/prompts/promptScopes.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { consola } from "../consola.js";
+
+const scopeNameRegex = /^[a-zA-Z-_:]+$/;
+
+export async function promptScopes(
+  { scopes }: { scopes?: string[] },
+): Promise<string[] | undefined> {
+  if (scopes == null) {
+    return undefined;
+  }
+
+  for (const scope in scopes) {
+    if (!scopeNameRegex.test(scope)) {
+      consola.fail(
+        "Scope name can only contain letters, hyphens, underscores, and colons",
+      );
+      // Following promptOverwrite
+      process.exit(0);
+    }
+  }
+
+  return scopes;
+}

--- a/packages/create-app/src/run.ts
+++ b/packages/create-app/src/run.ts
@@ -42,6 +42,7 @@ interface RunArgs {
   osdkPackage: string;
   osdkRegistryUrl: string;
   corsProxy: boolean;
+  scopes: string[] | undefined;
 }
 
 export async function run(
@@ -57,6 +58,7 @@ export async function run(
     osdkPackage,
     osdkRegistryUrl,
     corsProxy,
+    scopes,
   }: RunArgs,
 ): Promise<void> {
   consola.log("");
@@ -127,6 +129,7 @@ export async function run(
     osdkPackage,
     corsProxy,
     clientVersion: changeVersionPrefix(clientVersion, "^"),
+    scopes,
   };
   const processFiles = function(dir: string) {
     fs.readdirSync(dir).forEach(function(file) {

--- a/packages/create-app/src/templates.ts
+++ b/packages/create-app/src/templates.ts
@@ -47,6 +47,7 @@ export interface TemplateContext {
   osdkPackage: string;
   clientVersion: string;
   corsProxy: boolean;
+  scopes: string[] | undefined;
 }
 
 const getPackageFiles =

--- a/packages/example-generator/src/run.ts
+++ b/packages/example-generator/src/run.ts
@@ -84,7 +84,7 @@ async function generateExamples(tmpDir: tmp.DirResult): Promise<void> {
       osdkRegistryUrl:
         "https://fake.palantirfoundry.com/artifacts/api/repositories/ri.artifacts.main.repository.fake/contents/release/npm",
       corsProxy: false,
-      scopes: ["api:read-data", "api:write-data"],
+      scopes: ["api:ontologies-read", "api:ontologies-write"],
     });
 
     for (const mutator of MUTATORS) {

--- a/packages/example-generator/src/run.ts
+++ b/packages/example-generator/src/run.ts
@@ -84,6 +84,7 @@ async function generateExamples(tmpDir: tmp.DirResult): Promise<void> {
       osdkRegistryUrl:
         "https://fake.palantirfoundry.com/artifacts/api/repositories/ri.artifacts.main.repository.fake/contents/release/npm",
       corsProxy: false,
+      scopes: ["api:read-data", "api:write-data"],
     });
 
     for (const mutator of MUTATORS) {


### PR DESCRIPTION
Currently, there's no way for users to configure the `scopes` parameter of their OSDK application. We want to add a way for them to configure this and have the templates either include or hide the `scopes` parameter as a result