### PR TITLE
Improve create-app package discovery

### DIFF
--- a/.changeset/thirty-falcons-crash.md
+++ b/.changeset/thirty-falcons-crash.md
@@ -1,0 +1,6 @@
+---
+"@osdk/example-generator": patch
+"@osdk/create-app": patch
+---
+
+internal create-app code is codegen'd

--- a/packages/create-app/.gitignore
+++ b/packages/create-app/.gitignore
@@ -1,0 +1,1 @@
+/src/generatedNoCheck/

--- a/packages/create-app/codegen.mjs
+++ b/packages/create-app/codegen.mjs
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import dedent from "dedent";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export const TEMPLATES = [
+  {
+    id: "react",
+    label: "React",
+    envPrefix: "VITE_",
+    buildDirectory: "./dist",
+  },
+  {
+    id: "vue",
+    label: "Vue",
+    envPrefix: "VITE_",
+    buildDirectory: "./dist",
+  },
+  {
+    id: "next-static-export",
+    label: "Next (static export)",
+    envPrefix: "NEXT_PUBLIC_",
+    buildDirectory: "./out",
+  },
+  {
+    id: "tutorial-todo-app",
+    label: "Tutorial: To do App",
+    envPrefix: "VITE_",
+    buildDirectory: "./dist",
+    hidden: true,
+  },
+  {
+    id: "tutorial-todo-aip-app",
+    label: "Tutorial: To do AIP App",
+    envPrefix: "VITE_",
+    buildDirectory: "./dist",
+    hidden: true,
+  },
+];
+
+const packagesDir = path.join(__dirname, "../");
+
+fs.mkdirSync(path.join(__dirname, "./src/generatedNoCheck"), {
+  recursive: true,
+});
+
+fs.writeFileSync(
+  path.join(__dirname, "./src/generatedNoCheck/templates.ts"),
+  dedent`
+  // THIS FILE IS GENERATED. DO NOT MODIFY.
+  // You probably want to modify ../../../codegen.mjs instead.
+  import type { Template } from "../templates.js";
+  import { getPackageFiles } from "../getPackageFiles.js";
+
+  export const TEMPLATES: readonly Template[] = [
+  ${
+    TEMPLATES.map((template) => {
+      const v1Name = findPackageName([
+        `@osdk/create-app.template.${template.id}.v1`,
+        `@osdk/create-app.template.${template.id}`,
+      ]);
+      const v2Name = findPackageName([
+        `@osdk/create-app.template.${template.id}.v2`,
+        `@osdk/create-app.template.${template.id}.beta`,
+        `@osdk/create-app.template.${template.id}`,
+      ]);
+      return dedent`
+          // ${template.label}
+          {
+            id: "template-${template.id}",
+            label: "${template.label}",
+            envPrefix: "${template.envPrefix}",
+            buildDirectory: "${template.buildDirectory}",
+            files: {
+              ${v1Name ? `"1.x": getPackageFiles(import("${v1Name}")),` : ""}
+              ${v2Name ? `"2.x": getPackageFiles(import("${v2Name}")),` : ""}
+            },
+          },`;
+    }).join("\n")
+  }
+  ];
+  `,
+);
+
+/**
+ * @param {string[]} names
+ * @returns
+ */
+function findPackageName(names) {
+  return names.find((name) => {
+    return fs.existsSync(path.join(packagesDir, `${name.split("/")[1]}`));
+  });
+}

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -22,6 +22,7 @@
     "check-attw": "monorepo.tool.attw esm",
     "check-spelling": "cspell --quiet .",
     "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
+    "codegen": "node codegen.mjs",
     "fix-lint": "eslint . --fix && dprint fmt --config $(find-up dprint.json)",
     "lint": "eslint . && dprint check  --config $(find-up dprint.json)",
     "test": "vitest run --pool=forks",
@@ -52,6 +53,8 @@
     "@types/node": "^18.0.0",
     "@types/tmp": "^0.2.6",
     "@types/yargs": "^17.0.29",
+    "dedent": "1.5.3",
+    "redent": "^4.0.0",
     "tmp": "^0.2.3",
     "typescript": "~5.5.4"
   },

--- a/packages/create-app/src/cli.test.ts
+++ b/packages/create-app/src/cli.test.ts
@@ -20,8 +20,8 @@ import { fileURLToPath } from "node:url";
 import { dirSync } from "tmp";
 import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { cli } from "./cli.js";
+import { TEMPLATES } from "./generatedNoCheck/templates.js";
 import type { Template } from "./templates.js";
-import { TEMPLATES } from "./templates.js";
 
 let createAppVersion: string;
 beforeAll(() => {

--- a/packages/create-app/src/getPackageFiles.ts
+++ b/packages/create-app/src/getPackageFiles.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-export { cli } from "./cli.js";
-export { TEMPLATES } from "./generatedNoCheck/templates.js";
-export { run } from "./run.js";
-export type { Template } from "./templates.js";
+import type { ModuleImportFiles } from "./templates.js";
+
+export const getPackageFiles =
+  (importPromise: Promise<{ files: ModuleImportFiles }>) => async () =>
+    (await importPromise).files;

--- a/packages/create-app/src/prompts/promptTemplate.test.ts
+++ b/packages/create-app/src/prompts/promptTemplate.test.ts
@@ -16,7 +16,7 @@
 
 import { afterEach, expect, test, vi } from "vitest";
 import { consola } from "../consola.js";
-import { TEMPLATES } from "../templates.js";
+import { TEMPLATES } from "../generatedNoCheck/templates.js";
 import { promptTemplate } from "./promptTemplate.js";
 
 vi.mock("../consola.js");

--- a/packages/create-app/src/prompts/promptTemplate.ts
+++ b/packages/create-app/src/prompts/promptTemplate.ts
@@ -15,8 +15,9 @@
  */
 
 import { consola } from "../consola.js";
+import { TEMPLATES } from "../generatedNoCheck/templates.js";
 import { green } from "../highlight.js";
-import { type Template, TEMPLATES } from "../templates.js";
+import type { Template } from "../templates.js";
 
 export async function promptTemplate(
   parsed: { template?: string; beta?: boolean },

--- a/packages/create-app/src/templates.ts
+++ b/packages/create-app/src/templates.ts
@@ -16,7 +16,7 @@
 
 export type SdkVersion = "1.x" | "2.x";
 
-type ModuleImportFiles = Map<
+export type ModuleImportFiles = Map<
   string,
   {
     type: "base64";
@@ -48,74 +48,3 @@ export interface TemplateContext {
   clientVersion: string;
   corsProxy: boolean;
 }
-
-const getPackageFiles =
-  (importPromise: Promise<{ files: ModuleImportFiles }>) => async () =>
-    (await importPromise).files;
-
-export const TEMPLATES: readonly Template[] = [
-  {
-    id: "template-react",
-    label: "React",
-    envPrefix: "VITE_",
-    buildDirectory: "./dist",
-    files: {
-      "1.x": getPackageFiles(import("@osdk/create-app.template.react")),
-      "2.x": getPackageFiles(import("@osdk/create-app.template.react.beta")),
-    },
-  },
-  {
-    id: "template-vue",
-    label: "Vue",
-    envPrefix: "VITE_",
-    buildDirectory: "./dist",
-    files: {
-      "1.x": getPackageFiles(import("@osdk/create-app.template.vue")),
-      "2.x": getPackageFiles(import("@osdk/create-app.template.vue.v2")),
-    },
-  },
-  {
-    id: "template-next-static-export",
-    label: "Next (static export)",
-    envPrefix: "NEXT_PUBLIC_",
-    buildDirectory: "./out",
-    files: {
-      "1.x": getPackageFiles(
-        import("@osdk/create-app.template.next-static-export"),
-      ),
-      "2.x": getPackageFiles(
-        import("@osdk/create-app.template.next-static-export.v2"),
-      ),
-    },
-  },
-  {
-    id: "template-tutorial-todo-app",
-    label: "Tutorial: To do App",
-    envPrefix: "VITE_",
-    buildDirectory: "./dist",
-    hidden: true,
-    files: {
-      "1.x": getPackageFiles(
-        import("@osdk/create-app.template.tutorial-todo-app"),
-      ),
-      "2.x": getPackageFiles(
-        import("@osdk/create-app.template.tutorial-todo-app.beta"),
-      ),
-    },
-  },
-  {
-    id: "template-tutorial-todo-aip-app",
-    label: "Tutorial: To do AIP App",
-    envPrefix: "VITE_",
-    buildDirectory: "./dist",
-    hidden: true,
-    files: {
-      "1.x": getPackageFiles(
-        import("@osdk/create-app.template.tutorial-todo-aip-app"),
-      ),
-      "2.x": getPackageFiles(
-        import("@osdk/create-app.template.tutorial-todo-aip-app.beta"),
-      ),
-    },
-  },
-];

--- a/packages/create-app/turbo.json
+++ b/packages/create-app/turbo.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "codegen": {
+      "inputs": ["codegen.mjs"],
+      "outputs": ["src/generatedNoCheck/**/*"]
+    }
+  }
+}

--- a/packages/example-generator/package.json
+++ b/packages/example-generator/package.json
@@ -18,13 +18,13 @@
     }
   },
   "scripts": {
-    "check": "./bin/exampleGenerator.mjs ../../examples --check",
     "check-attw": "monorepo.tool.attw esm",
     "check-spelling": "cspell --quiet .",
     "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
     "fix-lint": "eslint . --fix && dprint fmt --config $(find-up dprint.json)",
     "generate": "./bin/exampleGenerator.mjs ../../examples",
     "lint": "eslint . && dprint check  --config $(find-up dprint.json)",
+    "test": "vitest run --pool=forks",
     "transpile": "monorepo.tool.transpile"
   },
   "dependencies": {

--- a/packages/example-generator/src/check.test.ts
+++ b/packages/example-generator/src/check.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,16 @@
  * limitations under the License.
  */
 
-export { cli } from "./cli.js";
-export { TEMPLATES } from "./generatedNoCheck/templates.js";
-export { run } from "./run.js";
-export type { Template } from "./templates.js";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { it } from "vitest";
+import { run } from "./run.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+it("Generates code that matches the files on disk in the examples dir", async () => {
+  await run({
+    outputDirectory: path.join(__dirname, "..", "..", "..", "examples"),
+    check: true,
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1149,6 +1149,12 @@ importers:
       '@types/yargs':
         specifier: ^17.0.29
         version: 17.0.32
+      dedent:
+        specifier: 1.5.3
+        version: 1.5.3
+      redent:
+        specifier: ^4.0.0
+        version: 4.0.0
       tmp:
         specifier: ^0.2.3
         version: 0.2.3
@@ -5157,6 +5163,14 @@ packages:
       supports-color:
         optional: true
 
+  dedent@1.5.3:
+    resolution: {integrity: sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -6425,6 +6439,10 @@ packages:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimatch@3.0.8:
     resolution: {integrity: sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==}
 
@@ -7003,6 +7021,10 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  redent@4.0.0:
+    resolution: {integrity: sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==}
+    engines: {node: '>=12'}
+
   redeyed@2.1.1:
     resolution: {integrity: sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==}
 
@@ -7359,6 +7381,10 @@ packages:
   strip-final-newline@4.0.0:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
+
+  strip-indent@4.0.0:
+    resolution: {integrity: sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==}
+    engines: {node: '>=12'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -10974,6 +11000,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  dedent@1.5.3: {}
+
   deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
@@ -12574,6 +12602,8 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
+  min-indent@1.0.1: {}
+
   minimatch@3.0.8:
     dependencies:
       brace-expansion: 1.1.11
@@ -13154,6 +13184,11 @@ snapshots:
 
   real-require@0.2.0: {}
 
+  redent@4.0.0:
+    dependencies:
+      indent-string: 5.0.0
+      strip-indent: 4.0.0
+
   redeyed@2.1.1:
     dependencies:
       esprima: 4.0.1
@@ -13551,6 +13586,10 @@ snapshots:
   strip-final-newline@3.0.0: {}
 
   strip-final-newline@4.0.0: {}
+
+  strip-indent@4.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   strip-json-comments@2.0.1: {}
 


### PR DESCRIPTION
Primary changes:
1. running `turbo test` verifies the directories. You don't have call `turbo check`. This fixes some annoyances some people have had in the past.
2. Generates the TEMPLATES variable for create-app.

There were a few other changes in flight elsewhere but I found it frustrating that create-app packages were inconsistently named (e.g. `@osdk/create-app.template.react.beta` and `@osdk/create-app.template.next-static-export.v2`). I also found it frustrating that they didn't follow the same naming conventions in the examples directory e.g`example-react-sdk-2.x` for the `@osdk/create-app.template.react.beta` package.

However, because of the existing changes happening to templates, renaming and moving around packages would likely cause pain while we get our releases out.

So this change simply sets the stage for being able to enforce naming conventions later (and possibly move some of these files around too). 