### PR TITLE
Edit foundry fetch return type to Response instead of Blob

### DIFF
--- a/.changeset/wild-flies-yell.md
+++ b/.changeset/wild-flies-yell.md
@@ -1,0 +1,5 @@
+---
+"@osdk/shared.net.platformapi": minor
+---
+
+Return type of binary data changed to response

--- a/packages/shared.net.platformapi/src/foundryPlatformFetch.ts
+++ b/packages/shared.net.platformapi/src/foundryPlatformFetch.ts
@@ -171,5 +171,5 @@ async function apiFetch(
     return await response.json();
   }
 
-  return response.blob();
+  return response;
 }


### PR DESCRIPTION
New Platform SDKs will ship with this version of shared.net.platformapi