### PR TITLE
More interface args cleanup

### DIFF
--- a/.changeset/rare-brooms-move.md
+++ b/.changeset/rare-brooms-move.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client": patch
+"@osdk/api": patch
+---
+
+Removing interface argument for selecting object types. This is not supported in the new apis, and is not being used internally anywhere with the old apis.

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -191,8 +191,6 @@ export type ApplyBatchActionOptions = {
 //
 // @public (undocumented)
 export interface AsyncIterArgs<Q extends ObjectOrInterfaceDefinition, K extends PropertyKeys<Q> = PropertyKeys<Q>, R extends boolean = false, A extends Augments = never, S extends NullabilityAdherence = NullabilityAdherence.Default> extends SelectArg<Q, K, R, S>, OrderByArg<Q, PropertyKeys<Q>> {
-    // (undocumented)
-    $__EXPERIMENTAL_selectedObjectTypes?: string[];
 }
 
 // @public (undocumented)

--- a/packages/api/src/object/FetchPageArgs.ts
+++ b/packages/api/src/object/FetchPageArgs.ts
@@ -70,7 +70,6 @@ export interface AsyncIterArgs<
   A extends Augments = never,
   S extends NullabilityAdherence = NullabilityAdherence.Default,
 > extends SelectArg<Q, K, R, S>, OrderByArg<Q, PropertyKeys<Q>> {
-  $__EXPERIMENTAL_selectedObjectTypes?: string[];
 }
 
 export type Augment<

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -102,7 +102,7 @@ async function fetchInterfacePage<
         augmentedProperties: {},
         augmentedSharedPropertyTypes: {},
         otherInterfaceTypes: [],
-        selectedObjectTypes: args.$__EXPERIMENTAL_selectedObjectTypes ?? [],
+        selectedObjectTypes: [],
         selectedSharedPropertyTypes: args.$select as undefined | string[] ?? [],
         where: objectSetToSearchJsonV2(objectSet, interfaceType.apiName),
       }),

--- a/packages/e2e.sandbox.catchall/src/runInterfacesTest.ts
+++ b/packages/e2e.sandbox.catchall/src/runInterfacesTest.ts
@@ -31,15 +31,15 @@ export async function runInterfacesTest() {
 
   const qqq = await client(FooInterface).where({ name: { $ne: "Patti" } });
 
-  const fooLimitedToEmployees = await client(FooInterface).fetchPage({
-    $__EXPERIMENTAL_selectedObjectTypes: ["Employee"],
-  });
-  invariant(fooLimitedToEmployees.data.length > 0);
+  // const fooLimitedToEmployees = await client(FooInterface).fetchPage({
+  //   $__EXPERIMENTAL_selectedObjectTypes: ["Employee"],
+  // });
+  // invariant(fooLimitedToEmployees.data.length > 0);
 
-  const fooLimitedToOther = await client(FooInterface).fetchPage({
-    $__EXPERIMENTAL_selectedObjectTypes: ["Other"],
-  });
-  invariant(fooLimitedToOther.data.length === 0);
+  // const fooLimitedToOther = await client(FooInterface).fetchPage({
+  //   $__EXPERIMENTAL_selectedObjectTypes: ["Other"],
+  // });
+  // invariant(fooLimitedToOther.data.length === 0);
 
   const r = await client(FooInterface)
     .where({ name: { $ne: "Patti" } })


### PR DESCRIPTION
The new apis do not directly support selecting by object type. While I can simulate this with objectset -> interfaceset intersections, I'm not sure this is the best way to expose this functionality, rather than just letting users directly do an intersect themselves. As I experiment with this more, I want to start with a clean slate first.

There is no internal usage of this, so should be safe to remove.