### PR TITLE
Fixe for AttachmentUpload in react browser context

### DIFF
--- a/.changeset/rare-jobs-attend.md
+++ b/.changeset/rare-jobs-attend.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Fixes AttachmentUpload for browser contexts

--- a/packages/client/src/object/AttachmentUpload.ts
+++ b/packages/client/src/object/AttachmentUpload.ts
@@ -24,7 +24,11 @@ export function createAttachmentUpload(
   data: Blob,
   name: string,
 ): AttachmentUpload {
-  const attachmentUpload = Object.create(data, { name: { value: name } });
+  const attachmentUpload = Object.create(data, {
+    name: { value: name },
+    size: { value: data.size },
+    type: { value: data.type },
+  });
 
   return attachmentUpload as AttachmentUpload;
 }


### PR DESCRIPTION
The platform SDK's couldn't access the .type and .size properties of the Blob class due to a change in context. This enables that functionality