### PR TITLE
Overload createPublicOauthClient to support object of options

### DIFF
--- a/.changeset/silent-dodos-talk.md
+++ b/.changeset/silent-dodos-talk.md
@@ -1,0 +1,5 @@
+---
+"@osdk/oauth": minor
+---
+
+Overload createPublicOauthClient to support object of options

--- a/packages/e2e.sandbox.todoapp/src/foundryClient.ts
+++ b/packages/e2e.sandbox.todoapp/src/foundryClient.ts
@@ -9,13 +9,21 @@ invariant(
 );
 invariant(import.meta.env.VITE_FOUNDRY_URL, "VITE_FOUNDRY_URL is required");
 
-const auth = createPublicOauthClient(
-  import.meta.env.VITE_FOUNDRY_CLIENT_ID,
-  // import.meta.env.VITE_FOUNDRY_URL,
-  "http://localhost:8080",
-  "http://localhost:8080/auth/callback",
-  true,
-);
+const auth = createPublicOauthClient({
+  client_id: import.meta.env.VITE_FOUNDRY_CLIENT_ID,
+  // url: import.meta.env.VITE_FOUNDRY_URL,
+  url: "http://localhost:8080",
+  redirectUrl: "http://localhost:8080/auth/callback",
+  useHistory: true,
+});
+// Alternative:
+// const auth = createPublicOauthClient(
+//   import.meta.env.VITE_FOUNDRY_CLIENT_ID,
+//   // import.meta.env.VITE_FOUNDRY_URL,
+//   "http://localhost:8080",
+//   "http://localhost:8080/auth/callback",
+//   true,
+// );
 
 export const $ = createClient(
   "http://localhost:8080",

--- a/packages/e2e.sandbox.todoapp/src/foundryClient.ts
+++ b/packages/e2e.sandbox.todoapp/src/foundryClient.ts
@@ -9,21 +9,13 @@ invariant(
 );
 invariant(import.meta.env.VITE_FOUNDRY_URL, "VITE_FOUNDRY_URL is required");
 
-const auth = createPublicOauthClient({
-  client_id: import.meta.env.VITE_FOUNDRY_CLIENT_ID,
-  // url: import.meta.env.VITE_FOUNDRY_URL,
-  url: "http://localhost:8080",
-  redirectUrl: "http://localhost:8080/auth/callback",
-  useHistory: true,
-});
-// Alternative:
-// const auth = createPublicOauthClient(
-//   import.meta.env.VITE_FOUNDRY_CLIENT_ID,
-//   // import.meta.env.VITE_FOUNDRY_URL,
-//   "http://localhost:8080",
-//   "http://localhost:8080/auth/callback",
-//   true,
-// );
+const auth = createPublicOauthClient(
+  import.meta.env.VITE_FOUNDRY_CLIENT_ID,
+  // import.meta.env.VITE_FOUNDRY_URL,
+  "http://localhost:8080",
+  "http://localhost:8080/auth/callback",
+  { useHistory: true },
+);
 
 export const $ = createClient(
   "http://localhost:8080",

--- a/packages/oauth/src/createPublicOauthClient.ts
+++ b/packages/oauth/src/createPublicOauthClient.ts
@@ -103,7 +103,7 @@ export function createPublicOauthClient(
     postLoginPage: postLoginPageUrl = window.location.toString(),
     scopes: scopeList = [],
     fetchFn: fetchFunction = globalThis.fetch,
-    ctxPath: context = "/multipass",
+    ctxPath: contextPath = "/multipass",
   } = processOptions(
     clientIdOrOptions,
     url,
@@ -117,7 +117,7 @@ export function createPublicOauthClient(
   );
 
   const client: Client = { client_id, token_endpoint_auth_method: "none" };
-  const authServer = createAuthorizationServer(context, baseUrl);
+  const authServer = createAuthorizationServer(contextPath, baseUrl);
   const oauthHttpOptions: HttpRequestOptions = { [customFetch]: fetchFunction };
 
   if (scopeList.length === 0) {
@@ -298,17 +298,16 @@ function processOptions(
       ctxPath: "/multipass",
       ...clientIdOrOptions,
     };
-  } else {
-    return {
-      client_id: clientIdOrOptions,
-      url: url!,
-      redirectUrl: redirectUrl!,
-      useHistory,
-      loginPage,
-      postLoginPage,
-      scopes,
-      fetchFn,
-      ctxPath,
-    };
   }
+  return {
+    client_id: clientIdOrOptions,
+    url: url!,
+    redirectUrl: redirectUrl!,
+    useHistory,
+    loginPage,
+    postLoginPage,
+    scopes,
+    fetchFn,
+    ctxPath,
+  };
 }

--- a/packages/oauth/src/createPublicOauthClient.ts
+++ b/packages/oauth/src/createPublicOauthClient.ts
@@ -97,14 +97,14 @@ export function createPublicOauthClient(
  * Creates a PublicOauthClient for authentication.
  *
  * @param {string} clientId - The client_id from the OAuth configuration on the server
- * @param {string} [url] - The base URL of your Foundry server
- * @param {string} [redirectUrl] - The URL configured for redirect in the OAuth configuration on the server
- * @param {boolean} [useHistory=true] - If true, uses `history.replaceState()`, otherwise uses `window.location.assign()`
- * @param {string} [loginPage] - Custom landing page URL prior to logging in
- * @param {string} [postLoginPage=window.location.toString()] - URL to return to after completed authentication cycle
- * @param {string[]} [scopes=[]] - OAuth scopes to request. If not provided, defaults to `["api:read-data", "api:write-data"]`
- * @param {typeof globalThis.fetch} [fetchFn=globalThis.fetch] - Custom fetch function to use for requests
- * @param {string} [ctxPath="/multipass"] - Context path for the authorization server
+ * @param {string} url - The base URL of your Foundry server
+ * @param {string} redirectUrl - The URL configured for redirect in the OAuth configuration on the server
+ * @param {boolean} useHistory - If true, uses `history.replaceState()`, otherwise uses `window.location.assign()` (defaults to true)
+ * @param {string} loginPage - Custom landing page URL prior to logging in
+ * @param {string} postLoginPage - URL to return to after completed authentication cycle (defaults to `window.location.toString()`)
+ * @param {string[]} scopes - OAuth scopes to request. If not provided, defaults to `["api:read-data", "api:write-data"]`
+ * @param {typeof globalThis.fetch} fetchFn - Custom fetch function to use for requests (defaults to `globalThis.fetch`)
+ * @param {string} ctxPath - Context path for the authorization server (defaults to "/multipass")
  * @returns {PublicOauthClient} A client that can be used as a token provider
  */
 export function createPublicOauthClient(


### PR DESCRIPTION
* Overload `createPublicOauthClient` function to support passing in an object of options, rather than just taking an bunch of optional params.
* Update JSDocs
* Wasn't sure where to write tests for this
* Open to suggestions on variable renames