### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -106,11 +106,14 @@
     "quick-buttons-pull",
     "quiet-jobs-return",
     "quiet-windows-teach",
+    "rare-brooms-move",
+    "rare-jobs-attend",
     "red-keys-allow",
     "rude-balloons-brake",
     "selfish-badgers-obey",
     "selfish-moles-divide",
     "selfish-suits-thank",
+    "seven-knives-hug",
     "shiny-bananas-knock",
     "short-bikes-fold",
     "shy-bees-fly",
@@ -122,6 +125,7 @@
     "soft-ligers-film",
     "spicy-fishes-matter",
     "spicy-weeks-drum",
+    "spotty-feet-beg",
     "sweet-ants-pull",
     "thick-coins-wink",
     "thirty-falcons-crash",
@@ -131,6 +135,8 @@
     "tiny-oranges-grow",
     "two-geckos-care",
     "two-gifts-decide",
+    "weak-frogs-fold",
+    "wild-flies-yell",
     "wild-moles-call"
   ]
 }

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/api
 
+## 2.1.0-beta.7
+
+### Minor Changes
+
+- 27866a8: Removing interface argument for selecting object types. This is not supported in the new apis, and is not being used internally anywhere with the old apis.
+- 31e7d70: Fixes extra generic
+
 ## 2.1.0-beta.6
 
 ### Minor Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/api",
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/cli.cmd.typescript
 
+## 0.25.0-beta.7
+
+### Minor Changes
+
+- 9018dc2: Updating platform api dependencies.
+
+### Patch Changes
+
+- Updated dependencies [9018dc2]
+  - @osdk/generator@2.1.0-beta.7
+  - @osdk/cli.common@0.25.0-beta.7
+
 ## 0.25.0-beta.6
 
 ### Minor Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.25.0-beta.6",
+  "version": "0.25.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli.common/CHANGELOG.md
+++ b/packages/cli.common/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/cli.common
 
+## 0.25.0-beta.7
+
 ## 0.25.0-beta.6
 
 ### Minor Changes

--- a/packages/cli.common/package.json
+++ b/packages/cli.common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.common",
   "private": true,
-  "version": "0.25.0-beta.6",
+  "version": "0.25.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/cli
 
+## 0.25.0-beta.7
+
 ## 0.25.0-beta.6
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.25.0-beta.6",
+  "version": "0.25.0-beta.7",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client.test.ontology/CHANGELOG.md
+++ b/packages/client.test.ontology/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/client.test.ontology
 
+## 2.1.0-beta.7
+
+### Patch Changes
+
+- Updated dependencies [27866a8]
+- Updated dependencies [31e7d70]
+  - @osdk/api@2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Minor Changes

--- a/packages/client.test.ontology/package.json
+++ b/packages/client.test.ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/client.test.ontology",
   "private": true,
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.unstable/CHANGELOG.md
+++ b/packages/client.unstable/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/client.unstable
 
+## 2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Minor Changes

--- a/packages/client.unstable/package.json
+++ b/packages/client.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.unstable",
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @osdk/client
 
+## 2.1.0-beta.7
+
+### Minor Changes
+
+- 27866a8: Removing interface argument for selecting object types. This is not supported in the new apis, and is not being used internally anywhere with the old apis.
+- 0cd1603: Fixes AttachmentUpload for browser contexts
+- 9018dc2: Updating platform api dependencies.
+
+### Patch Changes
+
+- Updated dependencies [27866a8]
+- Updated dependencies [9018dc2]
+- Updated dependencies [31e7d70]
+  - @osdk/api@2.1.0-beta.7
+  - @osdk/generator-converters@2.1.0-beta.7
+  - @osdk/client.unstable@2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Minor Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client",
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/create-app.template-packager/CHANGELOG.md
+++ b/packages/create-app.template-packager/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template-packager
 
+## 2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Minor Changes

--- a/packages/create-app.template-packager/package.json
+++ b/packages/create-app.template-packager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template-packager",
   "private": true,
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.next-static-export.v2/CHANGELOG.md
+++ b/packages/create-app.template.next-static-export.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.next-static-export.v2
 
+## 2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Minor Changes

--- a/packages/create-app.template.next-static-export.v2/package.json
+++ b/packages/create-app.template.next-static-export.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.next-static-export.v2",
   "private": true,
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.next-static-export/CHANGELOG.md
+++ b/packages/create-app.template.next-static-export/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.next-static-export
 
+## 2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Minor Changes

--- a/packages/create-app.template.next-static-export/package.json
+++ b/packages/create-app.template.next-static-export/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.next-static-export",
   "private": true,
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react.beta/CHANGELOG.md
+++ b/packages/create-app.template.react.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.react
 
+## 2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Minor Changes

--- a/packages/create-app.template.react.beta/package.json
+++ b/packages/create-app.template.react.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react.beta",
   "private": true,
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react/CHANGELOG.md
+++ b/packages/create-app.template.react/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.react
 
+## 2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Minor Changes

--- a/packages/create-app.template.react/package.json
+++ b/packages/create-app.template.react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react",
   "private": true,
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-aip-app.beta
 
+## 2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app.beta",
   "private": true,
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-aip-app
 
+## 2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-aip-app/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app",
   "private": true,
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-app.beta/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-app.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-app.beta
 
+## 2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-app.beta/package.json
+++ b/packages/create-app.template.tutorial-todo-app.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app.beta",
   "private": true,
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-app
 
+## 2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-app/package.json
+++ b/packages/create-app.template.tutorial-todo-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app",
   "private": true,
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.vue.v2/CHANGELOG.md
+++ b/packages/create-app.template.vue.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.vue.v2
 
+## 2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Minor Changes

--- a/packages/create-app.template.vue.v2/package.json
+++ b/packages/create-app.template.vue.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.vue.v2",
   "private": true,
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.vue/CHANGELOG.md
+++ b/packages/create-app.template.vue/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.vue
 
+## 2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Minor Changes

--- a/packages/create-app.template.vue/package.json
+++ b/packages/create-app.template.vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.vue",
   "private": true,
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app
 
+## 2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Minor Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-app",
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/example-generator/CHANGELOG.md
+++ b/packages/example-generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/example-generator
 
+## 0.9.0-beta.6
+
+### Patch Changes
+
+- @osdk/create-app@2.1.0-beta.7
+
 ## 0.9.0-beta.5
 
 ### Minor Changes

--- a/packages/example-generator/package.json
+++ b/packages/example-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/example-generator",
   "private": true,
-  "version": "0.9.0-beta.5",
+  "version": "0.9.0-beta.6",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @osdk/foundry-sdk-generator
 
+## 2.1.0-beta.7
+
+### Minor Changes
+
+- 9018dc2: Updating platform api dependencies.
+
+### Patch Changes
+
+- Updated dependencies [27866a8]
+- Updated dependencies [0cd1603]
+- Updated dependencies [9018dc2]
+- Updated dependencies [31e7d70]
+  - @osdk/client@2.1.0-beta.7
+  - @osdk/api@2.1.0-beta.7
+  - @osdk/generator@2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Minor Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-converters/CHANGELOG.md
+++ b/packages/generator-converters/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/generator-converters
 
+## 2.1.0-beta.7
+
+### Minor Changes
+
+- 9018dc2: Updating platform api dependencies.
+
+### Patch Changes
+
+- Updated dependencies [27866a8]
+- Updated dependencies [31e7d70]
+  - @osdk/api@2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Minor Changes

--- a/packages/generator-converters/package.json
+++ b/packages/generator-converters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-converters",
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-utils/CHANGELOG.md
+++ b/packages/generator-utils/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/generator-utils
 
+## 2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Minor Changes

--- a/packages/generator-utils/package.json
+++ b/packages/generator-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-utils",
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @osdk/generator
 
+## 2.1.0-beta.7
+
+### Minor Changes
+
+- 9018dc2: Updating platform api dependencies.
+
+### Patch Changes
+
+- Updated dependencies [27866a8]
+- Updated dependencies [9018dc2]
+- Updated dependencies [31e7d70]
+  - @osdk/api@2.1.0-beta.7
+  - @osdk/generator-converters@2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Minor Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/maker/CHANGELOG.md
+++ b/packages/maker/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/maker
 
+## 0.9.0-beta.7
+
+### Minor Changes
+
+- cd8d657: Support importing foreign SPTs
+- 9018dc2: Updating platform api dependencies.
+
+### Patch Changes
+
+- Updated dependencies [27866a8]
+- Updated dependencies [31e7d70]
+  - @osdk/api@2.1.0-beta.7
+
 ## 0.9.0-beta.6
 
 ### Minor Changes

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker",
-  "version": "0.9.0-beta.6",
+  "version": "0.9.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.net.platformapi/CHANGELOG.md
+++ b/packages/shared.net.platformapi/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/shared.net.platformapi
 
+## 0.4.0-beta.3
+
+### Minor Changes
+
+- af2a390: Return type of binary data changed to response
+
 ## 0.4.0-beta.2
 
 ### Minor Changes

--- a/packages/shared.net.platformapi/package.json
+++ b/packages/shared.net.platformapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/shared.net.platformapi",
-  "version": "0.4.0-beta.2",
+  "version": "0.4.0-beta.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.test/CHANGELOG.md
+++ b/packages/shared.test/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/shared.test
 
+## 2.1.0-beta.7
+
+### Minor Changes
+
+- 9018dc2: Updating platform api dependencies.
+
+### Patch Changes
+
+- Updated dependencies [27866a8]
+- Updated dependencies [31e7d70]
+  - @osdk/api@2.1.0-beta.7
+
 ## 2.1.0-beta.6
 
 ### Minor Changes

--- a/packages/shared.test/package.json
+++ b/packages/shared.test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/shared.test",
   "private": true,
-  "version": "2.1.0-beta.6",
+  "version": "2.1.0-beta.7",
   "description": "",
   "access": "private",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/api@2.1.0-beta.7

### Minor Changes

-   27866a8: Removing interface argument for selecting object types. This is not supported in the new apis, and is not being used internally anywhere with the old apis.
-   31e7d70: Fixes extra generic

## @osdk/client@2.1.0-beta.7

### Minor Changes

-   27866a8: Removing interface argument for selecting object types. This is not supported in the new apis, and is not being used internally anywhere with the old apis.
-   0cd1603: Fixes AttachmentUpload for browser contexts
-   9018dc2: Updating platform api dependencies.

### Patch Changes

-   Updated dependencies [27866a8]
-   Updated dependencies [9018dc2]
-   Updated dependencies [31e7d70]
    -   @osdk/api@2.1.0-beta.7
    -   @osdk/generator-converters@2.1.0-beta.7
    -   @osdk/client.unstable@2.1.0-beta.7

## @osdk/foundry-sdk-generator@2.1.0-beta.7

### Minor Changes

-   9018dc2: Updating platform api dependencies.

### Patch Changes

-   Updated dependencies [27866a8]
-   Updated dependencies [0cd1603]
-   Updated dependencies [9018dc2]
-   Updated dependencies [31e7d70]
    -   @osdk/client@2.1.0-beta.7
    -   @osdk/api@2.1.0-beta.7
    -   @osdk/generator@2.1.0-beta.7

## @osdk/generator@2.1.0-beta.7

### Minor Changes

-   9018dc2: Updating platform api dependencies.

### Patch Changes

-   Updated dependencies [27866a8]
-   Updated dependencies [9018dc2]
-   Updated dependencies [31e7d70]
    -   @osdk/api@2.1.0-beta.7
    -   @osdk/generator-converters@2.1.0-beta.7

## @osdk/generator-converters@2.1.0-beta.7

### Minor Changes

-   9018dc2: Updating platform api dependencies.

### Patch Changes

-   Updated dependencies [27866a8]
-   Updated dependencies [31e7d70]
    -   @osdk/api@2.1.0-beta.7

## @osdk/maker@0.9.0-beta.7

### Minor Changes

-   cd8d657: Support importing foreign SPTs
-   9018dc2: Updating platform api dependencies.

### Patch Changes

-   Updated dependencies [27866a8]
-   Updated dependencies [31e7d70]
    -   @osdk/api@2.1.0-beta.7

## @osdk/shared.net.platformapi@0.4.0-beta.3

### Minor Changes

-   af2a390: Return type of binary data changed to response

## @osdk/cli@0.25.0-beta.7



## @osdk/client.unstable@2.1.0-beta.7



## @osdk/create-app@2.1.0-beta.7



## @osdk/generator-utils@2.1.0-beta.7



## @osdk/cli.cmd.typescript@0.25.0-beta.7

### Minor Changes

-   9018dc2: Updating platform api dependencies.

### Patch Changes

-   Updated dependencies [9018dc2]
    -   @osdk/generator@2.1.0-beta.7
    -   @osdk/cli.common@0.25.0-beta.7

## @osdk/shared.test@2.1.0-beta.7

### Minor Changes

-   9018dc2: Updating platform api dependencies.

### Patch Changes

-   Updated dependencies [27866a8]
-   Updated dependencies [31e7d70]
    -   @osdk/api@2.1.0-beta.7

## @osdk/client.test.ontology@2.1.0-beta.7

### Patch Changes

-   Updated dependencies [27866a8]
-   Updated dependencies [31e7d70]
    -   @osdk/api@2.1.0-beta.7

## @osdk/example-generator@0.9.0-beta.6

### Patch Changes

-   @osdk/create-app@2.1.0-beta.7

## @osdk/cli.common@0.25.0-beta.7



## @osdk/create-app.template-packager@2.1.0-beta.7



## @osdk/create-app.template.next-static-export@2.1.0-beta.7



## @osdk/create-app.template.next-static-export.v2@2.1.0-beta.7



## @osdk/create-app.template.react@2.1.0-beta.7



## @osdk/create-app.template.react.beta@2.1.0-beta.7



## @osdk/create-app.template.tutorial-todo-aip-app@2.1.0-beta.7



## @osdk/create-app.template.tutorial-todo-aip-app.beta@2.1.0-beta.7



## @osdk/create-app.template.tutorial-todo-app@2.1.0-beta.7



## @osdk/create-app.template.tutorial-todo-app.beta@2.1.0-beta.7



## @osdk/create-app.template.vue@2.1.0-beta.7



## @osdk/create-app.template.vue.v2@2.1.0-beta.7


