### PR TITLE
Add type module to package.json

### DIFF
--- a/.changeset/chilly-colts-jam.md
+++ b/.changeset/chilly-colts-jam.md
@@ -1,0 +1,5 @@
+---
+"@osdk/foundry-sdk-generator": patch
+---
+
+Explicitly label package.json as type module now.

--- a/packages/foundry-sdk-generator/src/generate/betaClient/generatePackageJson.ts
+++ b/packages/foundry-sdk-generator/src/generate/betaClient/generatePackageJson.ts
@@ -48,6 +48,7 @@ export async function generatePackageJson(options: {
     },
     dependencies: packageDeps,
     peerDependencies: packagePeerDeps,
+    type: "module",
   };
 
   await writeFile(


### PR DESCRIPTION
We now explicitly add `type:module` to our generated code's `package.json`