### PR TITLE
Implement typesafe events in views API

### DIFF
--- a/.changeset/empty-poems-hug.md
+++ b/.changeset/empty-poems-hug.md
@@ -1,0 +1,9 @@
+---
+"@osdk/views-client-react.unstable": minor
+"@osdk/views-client.unstable": minor
+"@osdk/views-api.unstable": minor
+"@osdk/client": patch
+"@osdk/api": patch
+---
+
+Add support for events

--- a/.changeset/empty-poems-hug.md
+++ b/.changeset/empty-poems-hug.md
@@ -2,8 +2,6 @@
 "@osdk/views-client-react.unstable": minor
 "@osdk/views-client.unstable": minor
 "@osdk/views-api.unstable": minor
-"@osdk/client": patch
-"@osdk/api": patch
 ---
 
 Add support for events

--- a/packages/e2e.sandbox.views.todo-widget/src/app.tsx
+++ b/packages/e2e.sandbox.views.todo-widget/src/app.tsx
@@ -24,11 +24,9 @@ export const App: React.FC = () => {
 
   const handleAddRow = useCallback(() => {
     emitEvent("view.emit-event", {
-      eventId: "todo",
+      eventId: "updateHeader",
       parameterUpdates: {
-        todoItems: [
-          "New item",
-        ],
+        headerText: "Hello again!",
       },
     });
   }, []);

--- a/packages/e2e.sandbox.views.todo-widget/src/context.ts
+++ b/packages/e2e.sandbox.views.todo-widget/src/context.ts
@@ -1,6 +1,6 @@
 import { useFoundryViewContext } from "@osdk/views-client-react.unstable";
-import type MainParameters from "./main.parameters.js";
+import type MainConfig from "./main.parameters.js";
 
 export const useFoundryContext = useFoundryViewContext.withTypes<
-  typeof MainParameters
+  typeof MainConfig
 >();

--- a/packages/e2e.sandbox.views.todo-widget/src/main.parameters.ts
+++ b/packages/e2e.sandbox.views.todo-widget/src/main.parameters.ts
@@ -1,6 +1,6 @@
-import type { ParameterConfig } from "@osdk/views-client.unstable";
+import type { ViewConfig } from "@osdk/views-client.unstable";
 
-const MainParameters = {
+const MainConfig = {
   parameters: {
     headerText: {
       displayName: "Widget title",
@@ -16,5 +16,15 @@ const MainParameters = {
       subType: "string",
     },
   },
-} as const satisfies ParameterConfig;
-export default MainParameters;
+  events: {
+    updateHeader: {
+      displayName: "Update header",
+      parameterIds: ["headerText"],
+    },
+    updateTodoItems: {
+      displayName: "Update todo items",
+      parameterIds: ["todoItems"],
+    },
+  },
+} as const satisfies ViewConfig;
+export default MainConfig;

--- a/packages/e2e.sandbox.views.todo-widget/src/main.tsx
+++ b/packages/e2e.sandbox.views.todo-widget/src/main.tsx
@@ -6,7 +6,7 @@ import { Theme } from "@radix-ui/themes";
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./app.js";
-import MainParameters from "./main.parameters.js";
+import MainConfig from "./main.parameters.js";
 
 const root = document.querySelector("body")!;
 
@@ -14,7 +14,7 @@ createRoot(root).render(
   (
     <Theme>
       <FoundryView
-        config={MainParameters}
+        config={MainConfig}
       >
         <App />
       </FoundryView>

--- a/packages/views.api.unstable/src/config.test.ts
+++ b/packages/views.api.unstable/src/config.test.ts
@@ -17,13 +17,16 @@
 import { describe, expectTypeOf, it } from "vitest";
 import type {
   AsyncParameterValueMap,
-  ParameterConfig,
+  EventId,
+  EventParameterIdList,
+  EventParameterValueMap,
   ParameterId,
   ParameterValueMap,
+  ViewConfig,
 } from "./config.js";
 import type { ParameterValue } from "./parameters.js";
 
-describe("ParameterConfig", () => {
+describe("ViewConfig", () => {
   describe("ParameterConfigId", () => {
     it("should be able to infer the type of the parameter ID", () => {
       const test = {
@@ -37,7 +40,8 @@ describe("ParameterConfig", () => {
             type: "string",
           },
         },
-      } as const satisfies ParameterConfig;
+        events: {},
+      } as const satisfies ViewConfig;
       expectTypeOf<ParameterId<typeof test>>().toEqualTypeOf<
         "test" | "test2"
       >();
@@ -55,7 +59,8 @@ describe("ParameterConfig", () => {
             type: "string",
           },
         },
-      } as const satisfies ParameterConfig;
+        events: {},
+      } as const satisfies ViewConfig;
       expectTypeOf<AsyncParameterValueMap<typeof test>>().toMatchTypeOf<{
         test: ParameterValue.Boolean;
         test2: ParameterValue.String;
@@ -80,7 +85,8 @@ describe("ParameterConfig", () => {
             type: "number",
           },
         },
-      } as const satisfies ParameterConfig;
+        events: {},
+      } as const satisfies ViewConfig;
       expectTypeOf<AsyncParameterValueMap<typeof test>>().toMatchTypeOf<{
         test: ParameterValue.BooleanArray;
         test2: ParameterValue.StringArray;
@@ -106,11 +112,140 @@ describe("ParameterConfig", () => {
             type: "number",
           },
         },
-      } as const satisfies ParameterConfig;
+        events: {},
+      } as const satisfies ViewConfig;
       expectTypeOf<ParameterValueMap<typeof test>>().toMatchTypeOf<{
         test: boolean[];
         test2: string[];
         test3: number;
+      }>();
+    });
+
+    it("should construct a type safe map of events that reference parameters", () => {
+      const test = {
+        parameters: {
+          test: {
+            displayName: "Testing",
+            type: "array",
+            subType: "boolean",
+          },
+          test2: {
+            displayName: "Testing 2",
+            type: "array",
+            subType: "string",
+          },
+          test3: {
+            displayName: "Testing 3",
+            type: "number",
+          },
+        },
+        events: {
+          myEvent: {
+            displayName: "My Event",
+            parameterIds: ["test"],
+          },
+        },
+      } as const satisfies ViewConfig;
+      expectTypeOf<
+        EventParameterIdList<typeof test, "myEvent">
+      >().toMatchTypeOf<["test"]>();
+    });
+
+    it("will not extract an event that references a parameter ID that doesn't exist", () => {
+      const test = {
+        parameters: {
+          test: {
+            displayName: "Testing",
+            type: "array",
+            subType: "boolean",
+          },
+          test2: {
+            displayName: "Testing 2",
+            type: "array",
+            subType: "string",
+          },
+          test3: {
+            displayName: "Testing 3",
+            type: "number",
+          },
+        },
+        events: {
+          myEvent: {
+            displayName: "My Event",
+            parameterIds: ["test4"],
+          },
+        },
+      } as const satisfies ViewConfig;
+      expectTypeOf<
+        // @ts-expect-error
+        EventParameterIdList<typeof test, "myEvent">
+      >().toMatchTypeOf<never>();
+    });
+
+    it("should extract event IDs correctly", () => {
+      const test = {
+        parameters: {
+          test: {
+            displayName: "Testing",
+            type: "array",
+            subType: "boolean",
+          },
+          test2: {
+            displayName: "Testing 2",
+            type: "array",
+            subType: "string",
+          },
+          test3: {
+            displayName: "Testing 3",
+            type: "number",
+          },
+        },
+        events: {
+          myEvent: {
+            displayName: "My Event",
+            parameterIds: ["test", "test2"],
+          },
+          myEvent2: {
+            displayName: "My second event",
+            parameterIds: [],
+          },
+        },
+      } as const satisfies ViewConfig;
+      expectTypeOf<EventId<typeof test>>().toEqualTypeOf<
+        "myEvent" | "myEvent2"
+      >();
+    });
+
+    it("should extract an event to the parameter values", () => {
+      const test = {
+        parameters: {
+          test: {
+            displayName: "Testing",
+            type: "array",
+            subType: "boolean",
+          },
+          test2: {
+            displayName: "Testing 2",
+            type: "array",
+            subType: "string",
+          },
+          test3: {
+            displayName: "Testing 3",
+            type: "number",
+          },
+        },
+        events: {
+          myEvent: {
+            displayName: "My Event",
+            parameterIds: ["test", "test2"],
+          },
+        },
+      } as const satisfies ViewConfig;
+      expectTypeOf<
+        EventParameterValueMap<typeof test, "myEvent">
+      >().toMatchTypeOf<{
+        test: boolean[];
+        test2: string[];
       }>();
     });
   });

--- a/packages/views.api.unstable/src/index.ts
+++ b/packages/views.api.unstable/src/index.ts
@@ -16,9 +16,11 @@
 
 export type {
   AsyncParameterValueMap,
-  ParameterConfig,
+  EventId,
+  EventParameterValueMap,
   ParameterId,
   ParameterValueMap,
+  ViewConfig,
 } from "./config.js";
 export {
   HostMessage,

--- a/packages/views.api.unstable/src/messages/hostMessages.ts
+++ b/packages/views.api.unstable/src/messages/hostMessages.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { AsyncParameterValueMap, ParameterConfig } from "../config.js";
+import type { AsyncParameterValueMap, ViewConfig } from "../config.js";
 
 // Interfaces and type guards for messages passed from the host Foundry UI to the child view
 interface HostBaseMessage<T extends string, P = unknown> {
@@ -27,26 +27,28 @@ export namespace HostMessage {
   export type Version = typeof Version;
 
   export namespace Payload {
-    export type UpdateParameters<CONFIG extends ParameterConfig> = {
+    export type UpdateParameters<CONFIG extends ViewConfig> = {
       parameters: AsyncParameterValueMap<CONFIG>;
     };
   }
 
-  export type UpdateParameters<CONFIG extends ParameterConfig> =
-    HostBaseMessage<"host.update-parameters", Payload.UpdateParameters<CONFIG>>;
+  export type UpdateParameters<CONFIG extends ViewConfig> = HostBaseMessage<
+    "host.update-parameters",
+    Payload.UpdateParameters<CONFIG>
+  >;
 }
 
 // Union type
-export type HostMessage<CONFIG extends ParameterConfig> =
+export type HostMessage<CONFIG extends ViewConfig> =
   HostMessage.UpdateParameters<CONFIG>;
 
-export function isHostParametersUpdatedMessage<CONFIG extends ParameterConfig>(
+export function isHostParametersUpdatedMessage<CONFIG extends ViewConfig>(
   event: HostMessage<CONFIG>,
 ): event is HostMessage.UpdateParameters<CONFIG> {
   return event.type === "host.update-parameters";
 }
 
-type HostMessageVisitor<CONFIG extends ParameterConfig> =
+type HostMessageVisitor<CONFIG extends ViewConfig> =
   & {
     [T in HostMessage<CONFIG>["type"]]: (
       payload: Extract<HostMessage<CONFIG>, { type: T }> extends {
@@ -62,7 +64,7 @@ type HostMessageVisitor<CONFIG extends ParameterConfig> =
 /**
  * Strongly typed visitor to handle every type of host message
  */
-export function visitHostMessage<CONFIG extends ParameterConfig>(
+export function visitHostMessage<CONFIG extends ViewConfig>(
   message: HostMessage<CONFIG>,
   visitor: HostMessageVisitor<CONFIG>,
 ) {

--- a/packages/views.api.unstable/src/messages/hostMessages.ts
+++ b/packages/views.api.unstable/src/messages/hostMessages.ts
@@ -27,15 +27,18 @@ export namespace HostMessage {
   export type Version = typeof Version;
 
   export namespace Payload {
-    export type UpdateParameters<CONFIG extends ViewConfig> = {
+    export interface UpdateParameters<CONFIG extends ViewConfig> {
       parameters: AsyncParameterValueMap<CONFIG>;
-    };
+    }
   }
 
-  export type UpdateParameters<CONFIG extends ViewConfig> = HostBaseMessage<
-    "host.update-parameters",
-    Payload.UpdateParameters<CONFIG>
-  >;
+  export interface UpdateParameters<CONFIG extends ViewConfig>
+    extends
+      HostBaseMessage<
+        "host.update-parameters",
+        Payload.UpdateParameters<CONFIG>
+      >
+  {}
 }
 
 // Union type

--- a/packages/views.api.unstable/src/messages/viewMessages.test.ts
+++ b/packages/views.api.unstable/src/messages/viewMessages.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expectTypeOf, it } from "vitest";
+import type { ViewConfig } from "../config.js";
+import type { ViewMessage } from "./viewMessages.js";
+
+describe("ViewMessages", () => {
+  describe("EmitEvent", () => {
+    it("should emit an event with the correct payload", () => {
+      const test = {
+        parameters: {
+          test: {
+            displayName: "Testing",
+            type: "array",
+            subType: "boolean",
+          },
+          test2: {
+            displayName: "Testing 2",
+            type: "array",
+            subType: "string",
+          },
+          test3: {
+            displayName: "Testing 3",
+            type: "number",
+          },
+        },
+        events: {
+          myEvent: {
+            displayName: "My Event",
+            parameterIds: ["test"],
+          },
+          myEvent2: {
+            displayName: "My Event 2",
+            parameterIds: ["test", "test2"],
+          },
+        },
+      } as const satisfies ViewConfig;
+      expectTypeOf<{
+        type: "view.emit-event";
+        payload: {
+          eventId: "myEvent";
+          parameterUpdates: {
+            test: boolean[];
+          };
+        };
+      }>().toMatchTypeOf<ViewMessage<typeof test>>();
+      expectTypeOf<{
+        eventId: "myEvent2";
+        parameterUpdates: {
+          test: boolean[];
+          test2: string[];
+        };
+      }>().toMatchTypeOf<ViewMessage.Payload.EmitEvent<typeof test>>();
+    });
+
+    it("should be able to assign specific events to the union", () => {
+      const test = {
+        parameters: {
+          test: {
+            displayName: "Testing",
+            type: "array",
+            subType: "boolean",
+          },
+          test2: {
+            displayName: "Testing 2",
+            type: "array",
+            subType: "string",
+          },
+          test3: {
+            displayName: "Testing 3",
+            type: "number",
+          },
+        },
+        events: {
+          myEvent: {
+            displayName: "My Event",
+            parameterIds: ["test"],
+          },
+          myEvent2: {
+            displayName: "My Event 2",
+            parameterIds: ["test", "test2"],
+          },
+        },
+      } as const satisfies ViewConfig;
+      expectTypeOf<{
+        type: "view.emit-event";
+        payload: {
+          eventId: "myEvent";
+          parameterUpdates: {
+            test: boolean[];
+          };
+        };
+      }>().toMatchTypeOf<ViewMessage<typeof test>>();
+    });
+  });
+});

--- a/packages/views.client-react.unstable/src/client.tsx
+++ b/packages/views.client-react.unstable/src/client.tsx
@@ -16,7 +16,7 @@
 
 import type {
   AsyncParameterValueMap,
-  ParameterConfig,
+  ViewConfig,
 } from "@osdk/views-client.unstable";
 import { createFoundryViewClient } from "@osdk/views-client.unstable";
 import React, { useEffect, useMemo } from "react";
@@ -24,7 +24,9 @@ import type { FoundryViewClientContext } from "./context.js";
 import { FoundryViewContext } from "./context.js";
 import { initializeParameters } from "./utils/initializeParameters.js";
 
-interface FoundryViewProps<CONFIG extends ParameterConfig> {
+interface FoundryViewProps<
+  CONFIG extends ViewConfig<{ parameters: CONFIG["parameters"] }>,
+> {
   children: React.ReactNode;
 
   /**
@@ -43,7 +45,9 @@ interface FoundryViewProps<CONFIG extends ParameterConfig> {
 /**
  * Handles subscribing to messages from the host Foundry UI and updating the view's parameter values accordingly via React context
  */
-export const FoundryView = <CONFIG extends ParameterConfig>({
+export const FoundryView = <
+  CONFIG extends ViewConfig<{ parameters: CONFIG["parameters"] }>,
+>({
   children,
   config,
   initialValues,
@@ -77,7 +81,9 @@ export const FoundryView = <CONFIG extends ParameterConfig>({
         hostEventTarget: client.hostEventTarget,
         parameterValues,
         // Unfortunately the context is statically defined so we can't use the generic type, hence the cast
-      } as FoundryViewClientContext<ParameterConfig>}
+      } as FoundryViewClientContext<
+        ViewConfig<{ parameters: CONFIG["parameters"] }>
+      >}
     >
       {children}
     </FoundryViewContext.Provider>

--- a/packages/views.client-react.unstable/src/context.ts
+++ b/packages/views.client-react.unstable/src/context.ts
@@ -16,36 +16,46 @@
 
 import {
   type AsyncParameterValueMap,
+  type EventId,
   FoundryHostEventTarget,
-  type FoundryViewClient,
-  type ParameterConfig,
+  type ViewConfig,
+  type ViewMessage,
 } from "@osdk/views-client.unstable";
 import React, { useContext } from "react";
 
-export interface FoundryViewClientContext<CONFIG extends ParameterConfig> {
-  emitEvent: FoundryViewClient<CONFIG>["emit"];
+export interface FoundryViewClientContext<
+  CONFIG extends ViewConfig<{ parameters: CONFIG["parameters"] }>,
+> {
+  emitEvent: <
+    M extends Extract<ViewMessage<CONFIG>, ViewMessage.EmitEvent<CONFIG>>,
+  >(
+    type: M["type"],
+    payload: M["payload"],
+  ) => void;
   hostEventTarget: FoundryHostEventTarget<CONFIG>;
   parameterValues: AsyncParameterValueMap<CONFIG>;
 }
 
 export const FoundryViewContext = React.createContext<
-  FoundryViewClientContext<ParameterConfig>
+  FoundryViewClientContext<ViewConfig>
 >({
   emitEvent: () => {},
-  hostEventTarget: new FoundryHostEventTarget<ParameterConfig>(),
+  hostEventTarget: new FoundryHostEventTarget<ViewConfig>(),
   parameterValues: {},
 });
 
 /**
  * @returns The current FoundryViewClientContext, in the context of your specific parameter configuration
  */
-export function useFoundryViewContext<CONFIG extends ParameterConfig>() {
+export function useFoundryViewContext<
+  CONFIG extends ViewConfig<{ parameters: CONFIG["parameters"] }>,
+>() {
   return useContext(FoundryViewContext) as FoundryViewClientContext<CONFIG>;
 }
 
 export namespace useFoundryViewContext {
   export function withTypes<
-    CONFIG extends ParameterConfig,
+    CONFIG extends ViewConfig<{ parameters: CONFIG["parameters"] }>,
   >(): () => FoundryViewClientContext<CONFIG> {
     return () => {
       return useFoundryViewContext<CONFIG>();

--- a/packages/views.client-react.unstable/src/utils/initializeParameters.ts
+++ b/packages/views.client-react.unstable/src/utils/initializeParameters.ts
@@ -16,13 +16,13 @@
 
 import type {
   AsyncParameterValueMap,
-  ParameterConfig,
+  ViewConfig,
 } from "@osdk/views-client.unstable";
 
 /**
  * Utility function to initialize a map of parameter values to either a loading or not-started loading state
  */
-export function initializeParameters<CONFIG extends ParameterConfig>(
+export function initializeParameters<CONFIG extends ViewConfig>(
   config: CONFIG,
   initialLoadingState: "loading" | "not-started",
 ): AsyncParameterValueMap<CONFIG> {

--- a/packages/views.client.unstable/src/client.ts
+++ b/packages/views.client.unstable/src/client.ts
@@ -15,8 +15,9 @@
  */
 
 import {
+  type EventId,
   HostMessage,
-  type ParameterConfig,
+  type ViewConfig,
   type ViewMessage,
   visitHostMessage,
 } from "@osdk/views-api.unstable";
@@ -24,7 +25,7 @@ import { META_TAG_HOST_ORIGIN } from "@osdk/views-api.unstable";
 import invariant from "tiny-invariant";
 import { FoundryHostEventTarget } from "./host.js";
 
-export interface FoundryViewClient<CONFIG extends ParameterConfig> {
+export interface FoundryViewClient<CONFIG extends ViewConfig> {
   /**
    * Notifies the host that this client is ready to receive the first parameter values
    */
@@ -35,7 +36,7 @@ export interface FoundryViewClient<CONFIG extends ParameterConfig> {
    */
   emit: <M extends Extract<ViewMessage<CONFIG>, ViewMessage.EmitEvent<CONFIG>>>(
     type: M["type"],
-    message: M["payload"],
+    payload: M["payload"],
   ) => void;
 
   /**
@@ -55,7 +56,7 @@ export interface FoundryViewClient<CONFIG extends ParameterConfig> {
 }
 
 export function createFoundryViewClient<
-  CONFIG extends ParameterConfig,
+  CONFIG extends ViewConfig,
 >(): FoundryViewClient<CONFIG> {
   invariant(window.top, "[FoundryViewClient] Must be run in an iframe");
   const parentWindow = window.top;
@@ -110,10 +111,7 @@ export function createFoundryViewClient<
       window.removeEventListener("message", listenForHostMessages);
     },
     emit: (type, payload) => {
-      sendMessage({
-        type,
-        payload,
-      });
+      sendMessage({ type, payload });
     },
   };
 }

--- a/packages/views.client.unstable/src/host.ts
+++ b/packages/views.client.unstable/src/host.ts
@@ -14,24 +14,24 @@
  * limitations under the License.
  */
 
-import type { HostMessage, ParameterConfig } from "@osdk/views-api.unstable";
+import type { HostMessage, ViewConfig } from "@osdk/views-api.unstable";
 
 export interface HostMessageEventListener<
-  CONFIG extends ParameterConfig,
+  CONFIG extends ViewConfig,
   M extends HostMessage<CONFIG>,
 > extends EventListener {
   (event: CustomEvent<M["payload"]>): void;
 }
 
 export interface HostMessageEventListenerObject<
-  CONFIG extends ParameterConfig,
+  CONFIG extends ViewConfig,
   M extends HostMessage<CONFIG>,
 > extends EventListenerObject {
   handleEvent(object: CustomEvent<M["payload"]>): void;
 }
 
 export class FoundryHostEventTarget<
-  CONFIG extends ParameterConfig,
+  CONFIG extends ViewConfig,
 > extends EventTarget {
   addEventListener<M extends HostMessage<CONFIG>>(
     type: M["type"],

--- a/packages/views.client.unstable/src/index.ts
+++ b/packages/views.client.unstable/src/index.ts
@@ -22,10 +22,12 @@ export type {
   AsyncParameterValueMap,
   AsyncReloadingValue,
   AsyncValue,
-  ParameterConfig,
+  EventId,
+  EventParameterValueMap,
   ParameterId,
   ParameterValue,
   ParameterValueMap,
+  ViewConfig,
   ViewMessage,
 } from "@osdk/views-api.unstable";
 export {


### PR DESCRIPTION
This wires up events in the configuration. The key thing with events is that they should only be allowed to reference parameter IDs that are actually defined in the same config. Because we're inferring the config type on the fly, the only way I could get the typechecking to work is to error when creating the client.

For example, the following config will produce the error below:

```
const MainConfig = {
  parameters: {
    headerText: {
      displayName: "Widget title",
      type: "string",
    },
    showWarning: {
      displayName: "Show warning callout",
      type: "boolean",
    },
    todoItems: {
      displayName: "Todo items",
      type: "array",
      subType: "string",
    },
  },
  events: {
    updateHeader: {
      displayName: "Update header",
      parameterIds: ["asdfasdf"], // Will cause error, because this parameter ID does not exist
    },
  },
} as const satisfies ViewConfig;
```

<img width="1024" alt="image" src="https://github.com/user-attachments/assets/4f33c4bb-c188-433a-804d-c2d6caa93297">
