### PR TITLE
[widgets] Support serving a basic widget manifest in vite serve mode

### DIFF
--- a/.changeset/warm-schools-relax.md
+++ b/.changeset/warm-schools-relax.md
@@ -1,0 +1,5 @@
+---
+"@osdk/widget-manifest-vite-plugin": minor
+---
+
+Support basic manifest in vite serve mode

--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -45,6 +45,7 @@ const nonStandardPackages = [
   "@osdk/monorepo.*", // internal monorepo packages
   "@osdk/tests.*",
   "@osdk/widget-client-react.unstable", // uses react
+  "@osdk/widget-manifest-vite-plugin", // has a vite-bundled app + react
   // removed the following from the repo to avoid it being edited
   // "@osdk/shared.client2", // hand written package that only exposes a symbol
 ];

--- a/packages/e2e.sandbox.todowidget/foundry.config.json
+++ b/packages/e2e.sandbox.todowidget/foundry.config.json
@@ -1,0 +1,11 @@
+{
+    "foundryUrl": "https://fake.palantirfoundry.com/",
+    "widget": {
+      "rid": "ri.viewregistry..view.fake",
+      "directory": "./dist",
+      "autoVersion": {
+        "type": "git-describe",
+        "tagPrefix": ""
+      }
+    }
+  }

--- a/packages/e2e.sandbox.todowidget/foundry.config.json
+++ b/packages/e2e.sandbox.todowidget/foundry.config.json
@@ -1,11 +1,11 @@
 {
-    "foundryUrl": "https://fake.palantirfoundry.com/",
-    "widget": {
-      "rid": "ri.viewregistry..view.fake",
-      "directory": "./dist",
-      "autoVersion": {
-        "type": "git-describe",
-        "tagPrefix": ""
-      }
+  "foundryUrl": "https://fake.palantirfoundry.com/",
+  "widget": {
+    "rid": "ri.viewregistry..view.fake",
+    "directory": "./dist",
+    "autoVersion": {
+      "type": "git-describe",
+      "tagPrefix": ""
     }
   }
+}

--- a/packages/monorepo.cspell/cspell.config.js
+++ b/packages/monorepo.cspell/cspell.config.js
@@ -147,6 +147,8 @@ const cspell = {
       ignoreWords: [
         // it's an NPM package
         "escodegen",
+        "blueprintjs",
+        "picocolors",
         // used in a RID template literal string
         "viewregistry",
       ],

--- a/packages/widget.vite-plugin/README.md
+++ b/packages/widget.vite-plugin/README.md
@@ -163,3 +163,20 @@ This vite plugin will then discover both entrypoints and output a combined `.pal
   }
 }
 ```
+
+## Developer mode
+
+The vite plugin also automatically configures developer mode so that you can preview the changes you make locally live on your Foundry environment. For developer mode to work, make sure you follow the following steps:
+
+1. Have a `FOUNDRY_TOKEN` variable that has a token from your Foundry environment stored in it
+1. Have a `foundry.config.json` in the root of your project (where you run vite from), with at minimum the following contents:
+
+   ```json
+   {
+     "foundryUrl": "https://{YOUR_STACK_URL}",
+     "widget": {
+       "rid": "{YOUR_WIDGET_COLLECTION_RID}"
+       // Rest of config
+     }
+   }
+   ```

--- a/packages/widget.vite-plugin/client/app.tsx
+++ b/packages/widget.vite-plugin/client/app.tsx
@@ -30,6 +30,7 @@ export const App: React.FC = () => {
       .then((res) => res.json())
       .then(({ entrypoints }: { entrypoints: string[] }) => {
         setEntrypointPaths(entrypoints);
+        // Poll the manifest endpoint until all entrypoints have JS files listed for them
         let poll = window.setInterval(() => {
           fetch("./manifest")
             .then((res) => res.json())
@@ -46,7 +47,9 @@ export const App: React.FC = () => {
               if (clearInterval) {
                 window.clearInterval(poll);
                 setLoading({ state: "loading" });
+                // Tell the vite server to start dev mode for the specified entrypoint
                 fetch("./finish", {
+                  // TODO: Actually handle multiple entrypoints
                   body: JSON.stringify({ entrypoint: entrypoints[0] }),
                   method: "POST",
                 }).then((res) => {
@@ -97,6 +100,7 @@ export const App: React.FC = () => {
           description={loading.error}
         />
       )}
+      {/* To load the entrypoint info, we have to actually load it in the browser to get vite to follow the module graph. Since we know these files will fail, we just load them in iframes set to display: none to trigger the load hook in vite */}
       {entrypointPaths.map((entrypointPath) => (
         <iframe key={entrypointPath} src={`/${entrypointPath}`} />
       ))}

--- a/packages/widget.vite-plugin/client/app.tsx
+++ b/packages/widget.vite-plugin/client/app.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NonIdealState, Spinner, SpinnerSize } from "@blueprintjs/core";
+import React, { useEffect } from "react";
+
+export const App: React.FC = () => {
+  const [entrypointPaths, setEntrypointPaths] = React.useState<string[]>([]);
+  const [loading, setLoading] = React.useState<
+    | { state: "success" }
+    | { state: "failed"; error: string }
+    | { state: "loading" }
+    | { state: "not-started" }
+  >({ state: "not-started" });
+  useEffect(() => {
+    fetch("./entrypoints")
+      .then((res) => res.json())
+      .then(({ entrypoints }: { entrypoints: string[] }) => {
+        setEntrypointPaths(entrypoints);
+        let poll = window.setInterval(() => {
+          fetch("./manifest")
+            .then((res) => res.json())
+            .then(({ manifest }) => {
+              let clearInterval = true;
+              for (const entrypoint of entrypoints) {
+                if (
+                  manifest[entrypoint] == null
+                  || manifest[entrypoint].length === 0
+                ) {
+                  clearInterval = false;
+                }
+              }
+              if (clearInterval) {
+                window.clearInterval(poll);
+                setLoading({ state: "loading" });
+                fetch("./finish", {
+                  body: JSON.stringify({ entrypoint: entrypoints[0] }),
+                  method: "POST",
+                }).then((res) => {
+                  if (res.status !== 200) {
+                    setLoading({ state: "failed", error: res.statusText });
+                  } else {
+                    setLoading({ state: "success" });
+                    setTimeout(() => {
+                      res
+                        .json()
+                        .then(
+                          (
+                            { redirectUrl },
+                          ) => (window.location.href = redirectUrl),
+                        );
+                    }, 500);
+                  }
+                });
+              }
+            });
+        }, 100);
+      });
+  }, []);
+  return (
+    <div className="body">
+      {(loading.state === "loading" || loading.state === "not-started") && (
+        <NonIdealState
+          title="Generating developer mode manifest…"
+          icon={<Spinner intent="primary" />}
+        />
+      )}
+      {loading.state === "success" && (
+        <NonIdealState
+          title="Started dev mode"
+          icon="tick-circle"
+          description={
+            <div className="description">
+              <Spinner intent="primary" size={SpinnerSize.SMALL} />{" "}
+              Redirecting you…
+            </div>
+          }
+        />
+      )}
+      {loading.state === "failed" && (
+        <NonIdealState
+          title="Failed to start dev mode"
+          icon="error"
+          description={loading.error}
+        />
+      )}
+      {entrypointPaths.map((entrypointPath) => (
+        <iframe key={entrypointPath} src={`/${entrypointPath}`} />
+      ))}
+    </div>
+  );
+};

--- a/packages/widget.vite-plugin/client/main.css
+++ b/packages/widget.vite-plugin/client/main.css
@@ -1,0 +1,20 @@
+.body {
+    align-items: center;
+    display: flex;
+    height: 100%;
+}
+
+body,
+html {
+    height: 100%;
+}
+
+iframe {
+    display: none;
+}
+
+.description {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}

--- a/packages/widget.vite-plugin/client/main.tsx
+++ b/packages/widget.vite-plugin/client/main.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import "@blueprintjs/core/lib/css/blueprint.css";
+import "./main.css";
+
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./app.js";
+
+const root = document.querySelector("body")!;
+
+createRoot(root).render(
+  <App />,
+);

--- a/packages/widget.vite-plugin/index.html
+++ b/packages/widget.vite-plugin/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Palantir: Widget dev mode setup</title>
+  </head>
+  <body>
+    <div id="root-container">
+      <div id="root"></div>
+    </div>
+    <script type="module" src="/client/main.tsx"></script>
+  </body>
+</html>

--- a/packages/widget.vite-plugin/package.json
+++ b/packages/widget.vite-plugin/package.json
@@ -21,6 +21,7 @@
     }
   },
   "scripts": {
+    "build": "tsc --project tsconfig.client.json && vite build",
     "check-attw": "monorepo.tool.attw esm",
     "check-spelling": "cspell --quiet .",
     "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
@@ -31,18 +32,27 @@
   "dependencies": {
     "@osdk/widget-api.unstable": "workspace:~",
     "escodegen": "^2.1.0",
-    "fs-extra": "^11.2.0"
+    "fs-extra": "^11.2.0",
+    "picocolors": "^1.1.1",
+    "sirv": "^3.0.0"
   },
   "peerDependencies": {
     "vite": "^5.0.0"
   },
   "devDependencies": {
+    "@blueprintjs/core": "^5.16.0",
+    "@blueprintjs/icons": "^5.15.0",
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
     "@osdk/monorepo.tsup": "workspace:~",
     "@types/escodegen": "~0.0.10",
     "@types/estree": "^1.0.6",
     "@types/fs-extra": "^11.0.4",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.2.0",
+    "react": "^18",
+    "react-dom": "^18",
     "ts-expect": "^1.3.0",
     "typescript": "~5.5.4",
     "vite": "^5.4.8"
@@ -54,6 +64,7 @@
     "vite-plugin"
   ],
   "files": [
+    "build/client",
     "build/cjs",
     "build/esm",
     "build/browser",

--- a/packages/widget.vite-plugin/src/constants.ts
+++ b/packages/widget.vite-plugin/src/constants.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const SETUP_PATH = ".palantir/setup";

--- a/packages/widget.vite-plugin/src/constants.ts
+++ b/packages/widget.vite-plugin/src/constants.ts
@@ -14,4 +14,5 @@
  * limitations under the License.
  */
 
-export const SETUP_PATH = ".palantir/setup";
+export const PALANTIR_PATH = ".palantir";
+export const SETUP_PATH = `${PALANTIR_PATH}/setup`;

--- a/packages/widget.vite-plugin/src/plugin.ts
+++ b/packages/widget.vite-plugin/src/plugin.ts
@@ -94,7 +94,9 @@ export function FoundryWidgetVitePlugin(options: Options = {}): Plugin {
 
         config?.logger.info(
           `  ${color.green("➜")}  ${
-            color.bold("Click to enter developer mode for your widget")
+            color.bold(
+              "Click to enter developer mode for your widget",
+            )
           }: ${
             colorUrl(
               `${localhostUrl}${server.config.base ?? "/"}${SETUP_PATH}`,
@@ -272,7 +274,7 @@ export function FoundryWidgetVitePlugin(options: Options = {}): Plugin {
                 } else {
                   res.statusCode = 500;
                   res.statusMessage =
-                    `Unable to start dev mode in Foundry: ${devResponse.statusText}`;
+                    `Unable to start dev mode in Foundry (see terminal for more): ${devResponse.statusText}`;
                   devResponse.json().then((err) => {
                     config?.logger.error(err);
                     res.end();

--- a/packages/widget.vite-plugin/src/plugin.ts
+++ b/packages/widget.vite-plugin/src/plugin.ts
@@ -25,8 +25,15 @@ import escodegen from "escodegen";
 import type { ObjectExpression } from "estree";
 import fs from "fs-extra";
 import path from "node:path";
-import type { Plugin } from "vite";
+import { fileURLToPath } from "node:url";
+import color from "picocolors";
+import sirv from "sirv";
+import type { Plugin, ResolvedConfig, ViteDevServer } from "vite";
+import { SETUP_PATH } from "./constants.js";
 
+export const DIR_DIST = typeof __dirname !== "undefined"
+  ? __dirname
+  : path.dirname(fileURLToPath(import.meta.url));
 export interface Options {
   /**
    * By default, looks in the directory from which vite is invoked
@@ -40,8 +47,9 @@ const DEFINE_CONFIG_FUNCTION = "defineConfig";
 export function FoundryWidgetVitePlugin(options: Options = {}): Plugin {
   const { packageJsonPath = path.join(process.cwd(), "package.json") } =
     options;
+  const baseDir = path.dirname(packageJsonPath);
 
-  const entrypointFileIds: string[] = [];
+  const entrypointToJsSourceFileMap: Record<string, Set<string>> = {};
   const jsSourceFileToEntrypointMap: Record<string, string> = {};
   const fileIdToSourceFileMap: Record<string, string> = {};
   const configSourceFileToEntrypointMap: Record<string, string> = {};
@@ -49,17 +57,272 @@ export function FoundryWidgetVitePlugin(options: Options = {}): Plugin {
     string,
     WidgetConfig<ParameterConfig>
   > = {};
+  let devServer: ViteDevServer | undefined;
+  let config: ResolvedConfig | undefined;
 
   return {
     name: "@osdk:widget-manifest",
     enforce: "pre",
+    configResolved: (_config) => {
+      config = _config;
+    },
+    configureServer(server) {
+      devServer = server;
+
+      const _print = server.printUrls;
+      let localhostUrl = `${
+        config?.server.https ? "https" : "http"
+      }://localhost:${config?.server.port ?? "80"}`;
+      const url = server.resolvedUrls?.local[0];
+      if (url) {
+        try {
+          const u = new URL(url);
+          localhostUrl = `${u.protocol}//${u.host}`;
+        } catch (error) {
+          config?.logger.warn(`Parse resolved url failed: ${error}`);
+        }
+      }
+
+      server.printUrls = () => {
+        _print();
+
+        const colorUrl = (url: string) =>
+          color.green(
+            url.replace(/:(\d+)\//, (_, port) => `:${color.bold(port)}/`),
+          );
+
+        config?.logger.info(
+          `  ${color.green("➜")}  ${color.bold("Foundry developer mode")}: ${
+            colorUrl(`${localhostUrl}${server.config.base ?? "/"}${SETUP_PATH}`)
+          }`,
+        );
+      };
+
+      server.middlewares.use(
+        `${server.config.base ?? "/"}.palantir/entrypoints`,
+        (req, res) => {
+          res.setHeader("Content-Type", "application/json");
+          // We need to turn the entrypoint files to relative paths
+          res.end(
+            JSON.stringify({
+              entrypoints: Object.keys(entrypointToJsSourceFileMap).map((id) =>
+                path.relative(baseDir, id)
+              ),
+            }),
+          );
+        },
+      );
+      server.middlewares.use(
+        `${server.config.base ?? "/"}.palantir/manifest`,
+        (req, res) => {
+          res.setHeader("Content-Type", "application/json");
+          res.end(
+            JSON.stringify({
+              manifest: Object.fromEntries(
+                Object.entries(entrypointToJsSourceFileMap).map(
+                  ([entrypoint, sourceFiles]) => [
+                    path.relative(baseDir, entrypoint),
+                    [...sourceFiles],
+                  ],
+                ),
+              ),
+            }),
+          );
+        },
+      );
+      server.middlewares.use(
+        `${server.config.base ?? "/"}.palantir/finish`,
+        (req, res) => {
+          if (req.method !== "POST") {
+            res.statusCode = 400;
+            res.statusMessage = "Method not allowed";
+            res.end();
+            return;
+          }
+
+          let body = "";
+          req.on("readable", () => {
+            const readResult = req.read();
+            if (readResult != null) {
+              body += readResult;
+            }
+          });
+          req.on("end", () => {
+            if (body.length === 0) {
+              res.statusCode = 400;
+              res.statusMessage =
+                "Bad request: Expected { \"entrypoint\": \"<relativeEntrypointFileName>\" }, received nothing";
+              res.end();
+              return;
+            }
+            let request: { entrypoint: string };
+            try {
+              request = JSON.parse(body);
+            } catch (error) {
+              res.statusCode = 400;
+              res.statusMessage =
+                "Bad request: Expected { \"entrypoint\": \"<relativeEntrypointFileName>\" }, received "
+                + body;
+              res.end();
+              return;
+            }
+
+            const entrypointFileName = path.join(baseDir, request.entrypoint);
+            if (entrypointToJsSourceFileMap[entrypointFileName] == null) {
+              res.statusCode = 400;
+              res.statusMessage =
+                `Entrypoint ${request.entrypoint} not found. It may have not been loaded?`;
+              res.end();
+              return;
+            }
+
+            const foundryConfigJsonPath = path.join(
+              baseDir,
+              "foundry.config.json",
+            );
+            if (!fs.existsSync(foundryConfigJsonPath)) {
+              res.statusCode = 500;
+              res.statusMessage = "foundry.config.json file not found.";
+              res.end();
+              return;
+            }
+
+            if (process.env.FOUNDRY_TOKEN == null) {
+              res.statusCode = 500;
+              res.statusMessage =
+                "FOUNDRY_TOKEN environment variable not found, unable to start dev mode.";
+              res.end();
+              return;
+            }
+
+            const foundryConfig = fs.readJSONSync(foundryConfigJsonPath);
+            if (foundryConfig.foundryUrl == null) {
+              res.statusCode = 500;
+              res.statusMessage =
+                "foundry.config.json is missing the \"foundryUrl\" field, unable to start dev mode.";
+              res.end();
+              return;
+            }
+
+            let url: URL;
+            try {
+              url = new URL(foundryConfig.foundryUrl);
+            } catch (error) {
+              res.statusCode = 500;
+              res.statusMessage =
+                `"foundryUrl" in foundry.config.json is invalid, found: ${foundryConfig.foundryUrl}`;
+              res.end();
+              return;
+            }
+
+            if (foundryConfig.widget?.rid == null) {
+              res.statusCode = 500;
+              res.statusMessage =
+                "foundry.config.json is missing the \"widget.rid\" field, unable to start dev mode.";
+              res.end();
+              return;
+            }
+
+            // TODO: Actually handle the widget RID from within the config, which will require somehow parsing the config
+            // Unfortunately, moduleParsed is not called during vite's dev mode for performance reasons, so the config file
+            // will need to be parsed/read a different way
+            fetch(
+              `${url.origin}/view-registry/api/dev-mode/${foundryConfig.widget.rid}/settings`,
+              {
+                body: JSON.stringify({
+                  entrypointJs: [
+                    ...entrypointToJsSourceFileMap[entrypointFileName],
+                  ].map((file) => ({
+                    scriptType: {
+                      type: "module",
+                      module: {},
+                    },
+                    filePath: `${localhostUrl}${file}`,
+                  })),
+                  entrypointCss: [],
+                }),
+                method: "POST",
+                headers: {
+                  authorization: `Bearer ${process.env.FOUNDRY_TOKEN}`,
+                  accept: "application/json",
+                  "content-type": "application/json",
+                  "x-b3-sampled": "1",
+                },
+              },
+            )
+              .then((devResponse) => {
+                if (devResponse.status === 200) {
+                  res.setHeader("Content-Type", "application/json");
+                  res.end(
+                    JSON.stringify({
+                      redirectUrl:
+                        `${url.origin}/workspace/custom-views/preview/${foundryConfig.widget.rid}`,
+                    }),
+                  );
+                } else {
+                  res.statusCode = 500;
+                  res.statusMessage =
+                    `Unable to start dev mode in Foundry: ${devResponse.statusText}`;
+                  devResponse.json().then((err) => {
+                    config?.logger.error(err);
+                    res.end();
+                  });
+                }
+              })
+              .catch((error) => {
+                res.statusCode = 500;
+                res.statusMessage =
+                  `Unable to start dev mode in Foundry: ${error.message}`;
+                res.end();
+              });
+          });
+        },
+      );
+
+      server.middlewares.use(
+        `${server.config.base ?? "/"}${SETUP_PATH}`,
+        sirv(path.resolve(DIR_DIST, "../client"), {
+          single: true,
+          dev: true,
+        }),
+      );
+    },
+    async buildStart(options) {
+      if (devServer != null) {
+        // Save off what all the entrypoint files are for generating a manifest for dev mode
+        if (Array.isArray(options.input)) {
+          Object.assign(
+            entrypointToJsSourceFileMap,
+            Object.fromEntries(
+              options.input.map((entrypoint) => [entrypoint, new Set()]),
+            ),
+          );
+        } else if (options.input != null) {
+          Object.assign(
+            entrypointToJsSourceFileMap,
+            Object.values(options.input).map((entrypoint) => [
+              entrypoint,
+              new Set(),
+            ]),
+          );
+        } else {
+          // Couldn't find any defined entrypoints, assume index.html
+          // TODO: Crib from https://github.com/wesbos/vite-plugin-list-directory-contents/blob/main/plugin.ts#L19 and actually look for all HTML files manually instead
+          entrypointToJsSourceFileMap[path.join(baseDir, "index.html")] =
+            new Set();
+        }
+      }
+    },
     // Look for .config.(j|t)s files that are imported from an entrypoint JS file
     resolveId: (source, importer, options) => {
       if (options.isEntry) {
-        entrypointFileIds.push(source);
+        if (entrypointToJsSourceFileMap[source] == null) {
+          entrypointToJsSourceFileMap[source] = new Set();
+        }
       } else if (importer != null) {
-        if (entrypointFileIds.includes(importer)) {
+        if (entrypointToJsSourceFileMap[importer] != null) {
           // This is a JS entrypoint, save it so we can look for a config file that it imports
+          entrypointToJsSourceFileMap[importer].add(source);
           jsSourceFileToEntrypointMap[source] = importer;
           return;
         }
@@ -206,10 +469,7 @@ export function FoundryWidgetVitePlugin(options: Options = {}): Plugin {
         if (chunk.type !== "chunk") {
           continue;
         }
-        if (
-          chunk.isEntry
-          && chunk.facadeModuleId != null
-        ) {
+        if (chunk.isEntry && chunk.facadeModuleId != null) {
           if (entrypointFileIdToConfigMap[chunk.facadeModuleId] == null) {
             throw new Error(
               `Could not find widget configuration object for entrypoint ${chunk.fileName}. Ensure that the default export of your imported *.${CONFIG_FILE_SUFFIX}.js file is a widget configuration object as returned by defineConfig()`,
@@ -225,10 +485,12 @@ export function FoundryWidgetVitePlugin(options: Options = {}): Plugin {
           }
           const widgetConfig: WidgetManifestConfig = {
             type: "workshopWidgetV1",
-            entrypointJs: [{
-              path: chunk.fileName,
-              type: "module",
-            }],
+            entrypointJs: [
+              {
+                path: chunk.fileName,
+                type: "module",
+              },
+            ],
             entrypointCss: chunk.viteMetadata?.importedCss.size
               ? [...chunk.viteMetadata.importedCss].map((css) => ({
                 path: css,
@@ -248,7 +510,9 @@ export function FoundryWidgetVitePlugin(options: Options = {}): Plugin {
           // Check if it's an imported chunk, since any CSS files we will need to put on the page for them
           // JS files will get imported on their own
           for (
-            const [entrypointName, imports] of Object.entries(entrypointImports)
+            const [entrypointName, imports] of Object.entries(
+              entrypointImports,
+            )
           ) {
             if (
               imports.includes(chunk.fileName)
@@ -259,11 +523,11 @@ export function FoundryWidgetVitePlugin(options: Options = {}): Plugin {
                   ({ path }) => path,
                 ) ?? [];
               widgetConfigManifest.widgets[entrypointName].entrypointCss?.push(
-                ...[...chunk.viteMetadata.importedCss].filter(css =>
-                  !existingCssFiles.includes(css)
-                ).map((css) => ({
-                  path: css,
-                })),
+                ...[...chunk.viteMetadata.importedCss]
+                  .filter((css) => !existingCssFiles.includes(css))
+                  .map((css) => ({
+                    path: css,
+                  })),
               );
             }
           }

--- a/packages/widget.vite-plugin/src/plugin.ts
+++ b/packages/widget.vite-plugin/src/plugin.ts
@@ -263,7 +263,7 @@ export function FoundryWidgetVitePlugin(options: Options = {}): Plugin {
               },
             )
               .then((devResponse) => {
-                if (devResponse.status === 200) {
+                if (devResponse.status === 200 || devResponse.status === 204) {
                   res.setHeader("Content-Type", "application/json");
                   res.end(
                     JSON.stringify({
@@ -272,10 +272,10 @@ export function FoundryWidgetVitePlugin(options: Options = {}): Plugin {
                     }),
                   );
                 } else {
-                  res.statusCode = 500;
+                  res.statusCode = devResponse.status;
                   res.statusMessage =
                     `Unable to start dev mode in Foundry (see terminal for more): ${devResponse.statusText}`;
-                  devResponse.json().then((err) => {
+                  devResponse.text().then((err) => {
                     config?.logger.error(err);
                     res.end();
                   });

--- a/packages/widget.vite-plugin/src/plugin.ts
+++ b/packages/widget.vite-plugin/src/plugin.ts
@@ -258,7 +258,6 @@ export function FoundryWidgetVitePlugin(options: Options = {}): Plugin {
                   authorization: `Bearer ${process.env.FOUNDRY_TOKEN}`,
                   accept: "application/json",
                   "content-type": "application/json",
-                  "x-b3-sampled": "1",
                 },
               },
             )

--- a/packages/widget.vite-plugin/src/test.html
+++ b/packages/widget.vite-plugin/src/test.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Custom Widget: Ontology SDK + React</title>
+  </head>
+  <body>
+    <div>Hello world</div>
+  </body>
+</html>

--- a/packages/widget.vite-plugin/tsconfig.client.json
+++ b/packages/widget.vite-plugin/tsconfig.client.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@osdk/monorepo.tsconfig/base.json",
+  "compilerOptions": {
+    "rootDir": "client",
+    "outDir": "build/esm",
+    "jsx": "react"
+  },
+  "include": [
+    "./client/**/*"
+  ],
+  "references": []
+}

--- a/packages/widget.vite-plugin/vite.config.ts
+++ b/packages/widget.vite-plugin/vite.config.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import react from "@vitejs/plugin-react";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vite";
+import { SETUP_PATH } from "./src/constants.js";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  base: `/${SETUP_PATH}`,
+  plugins: [react()],
+  server: {
+    port: 8080,
+  },
+  build: {
+    outDir: resolve(dirname(fileURLToPath(import.meta.url)), "./build/client"),
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2582,6 +2582,9 @@ importers:
       vite:
         specifier: ^5.4.8
         version: 5.4.8(@types/node@22.7.9)
+      vite-plugin-inspect:
+        specifier: ^0.8.8
+        version: 0.8.8(rollup@4.24.0)(vite@5.4.8(@types/node@22.7.9))
       vitest:
         specifier: ^2.1.2
         version: 2.1.3(@types/node@22.7.9)(happy-dom@15.11.6)
@@ -3373,7 +3376,19 @@ importers:
       fs-extra:
         specifier: ^11.2.0
         version: 11.2.0
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+      sirv:
+        specifier: ^3.0.0
+        version: 3.0.0
     devDependencies:
+      '@blueprintjs/core':
+        specifier: ^5.16.0
+        version: 5.16.0(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@blueprintjs/icons':
+        specifier: ^5.15.0
+        version: 5.15.0(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@osdk/monorepo.api-extractor':
         specifier: workspace:~
         version: link:../monorepo.api-extractor
@@ -3392,6 +3407,21 @@ importers:
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.12
+      '@types/react-dom':
+        specifier: ^18.3.1
+        version: 18.3.1
+      '@vitejs/plugin-react':
+        specifier: ^4.2.0
+        version: 4.2.1(vite@5.4.8(@types/node@22.7.9))
+      react:
+        specifier: ^18
+        version: 18.3.1
+      react-dom:
+        specifier: ^18
+        version: 18.3.1(react@18.3.1)
       ts-expect:
         specifier: ^1.3.0
         version: 1.3.0
@@ -3433,6 +3463,9 @@ packages:
 
   '@andrewbranch/untar.js@1.0.3':
     resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
+
+  '@antfu/utils@0.7.10':
+    resolution: {integrity: sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww==}
 
   '@arethetypeswrong/cli@0.15.3':
     resolution: {integrity: sha512-sIMA9ZJBWDEg1+xt5RkAEflZuf8+PO8SdKj17x6PtETuUho+qlZJg4DgmKc3q+QwQ9zOB5VLK6jVRbFdNLdUIA==}
@@ -3614,6 +3647,30 @@ packages:
   '@babel/types@7.25.7':
     resolution: {integrity: sha512-vwIVdXG+j+FOpkwqHRcBgHLYNL7XMkufrlaFvL9o6Ai9sJn9+PdyIL5qa0XzTZw084c+u9LOls53eoZWP/W5WQ==}
     engines: {node: '>=6.9.0'}
+
+  '@blueprintjs/colors@5.1.4':
+    resolution: {integrity: sha512-OBRswl1v/AQXtx8PLP6PhZX+xY+Q/LP/eQATQi/ZUCrNbE0ZkMXQRS9PK/7ZVllnQqcACkC4x/JVthkzkLoG2g==}
+
+  '@blueprintjs/core@5.16.0':
+    resolution: {integrity: sha512-umWvCL9iHP01AO11fILCLK8ZT8mkOouSC+MFwk4cVx8HElxLoUFCf64lUFSQpQMPyNKICYJ4qBrN/hKsez11lQ==}
+    hasBin: true
+    peerDependencies:
+      '@types/react': ^16.14.41 || 17 || 18
+      react: ^16.8 || 17 || 18
+      react-dom: ^16.8 || 17 || 18
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@blueprintjs/icons@5.15.0':
+    resolution: {integrity: sha512-5OiDY0hdQwfljfo9ynmmUBh3ibXTDuJ74WpwCakTr4hD9zGMhpzjnpEoZMfrMCsKZubGBiOFcT5riPljrDpdLw==}
+    peerDependencies:
+      '@types/react': ^16.14.41 || 17 || 18
+      react: ^16.8 || 17 || 18
+      react-dom: ^16.8 || 17 || 18
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@bundled-es-modules/cookie@2.0.0':
     resolution: {integrity: sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==}
@@ -4871,6 +4928,12 @@ packages:
     resolution: {integrity: sha512-nRqvPYO8xUVdgy/KhJuaCrWlVT/4uZr97Mpbuizsa6CmvtCQf3NuYnVvOOrpYiKUJcZYtEvm84OooJ8+lJytMQ==}
     engines: {node: '>=14.6'}
 
+  '@polka/url@1.0.0-next.28':
+    resolution: {integrity: sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==}
+
+  '@popperjs/core@2.11.8':
+    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
+
   '@radix-ui/colors@3.0.0':
     resolution: {integrity: sha512-FUOsGBkHrYJwCSEtWRCIfQbZG7q1e6DgxCIOe1SUQzDe/7rXXeA47s8yCn6fuTNQAj1Zq4oTFi9Yjp3wzElcxg==}
 
@@ -5476,6 +5539,15 @@ packages:
 
   '@rollup/pluginutils@5.1.0':
     resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/pluginutils@5.1.3':
+    resolution: {integrity: sha512-Pnsb6f32CD2W3uCaLZIzDmeFyQ2b8UWMFI7xtwUezpcGBDVDW6y9XgAWIlARiGAo6eNF5FK5aQTr0LFyNyqq5A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
@@ -6265,12 +6337,18 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  camel-case@4.1.2:
+    resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
+
   camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
 
   caniuse-lite@1.0.30001643:
     resolution: {integrity: sha512-ERgWGNleEilSrHM6iUz/zJNSQTP8Mr21wDWpdgvRwcTXGAq6jMtOUPP4dqFPTdKqZ2wKTdtB+uucZ3MRpAUSmg==}
+
+  capital-case@1.0.4:
+    resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
 
   cardinal@2.1.1:
     resolution: {integrity: sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==}
@@ -6298,6 +6376,9 @@ packages:
   chalk@5.3.0:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  change-case@4.1.2:
+    resolution: {integrity: sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==}
 
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -6440,6 +6521,9 @@ packages:
   consola@3.2.3:
     resolution: {integrity: sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==}
     engines: {node: ^14.18.0 || >=16.10.0}
+
+  constant-case@3.0.4:
+    resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -6653,6 +6737,12 @@ packages:
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+
+  dot-case@3.0.4:
+    resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
+
   dprint@0.47.2:
     resolution: {integrity: sha512-geUcVIIrmLaY+YtuOl4gD7J/QCjsXZa5gUqre9sO6cgH0X/Fa9heBN3l/AWVII6rKPw45ATuCSDWz1pyO+HkPQ==}
     hasBin: true
@@ -6696,6 +6786,9 @@ packages:
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+
+  error-stack-parser-es@0.1.5:
+    resolution: {integrity: sha512-xHku1X40RO+fO8yJ8Wh2f2rZWVjqyhb1zgq1yZ8aZRQkv6OOKhKWRUaht3eSCUbAOBaKIgM+ykwFLE+QUxgGeg==}
 
   es-abstract@1.23.3:
     resolution: {integrity: sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==}
@@ -7302,6 +7395,9 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
 
+  header-case@2.0.4:
+    resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
+
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
@@ -7804,6 +7900,9 @@ packages:
   loupe@3.1.2:
     resolution: {integrity: sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==}
 
+  lower-case@2.0.2:
+    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
+
   lru-cache@10.2.2:
     resolution: {integrity: sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==}
     engines: {node: 14 || >=16.14}
@@ -7917,6 +8016,10 @@ packages:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
 
+  mrmime@2.0.0:
+    resolution: {integrity: sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==}
+    engines: {node: '>=10'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -7976,6 +8079,9 @@ packages:
     resolution: {integrity: sha512-kltF0cOxgx1AbmVzKxYZaoB0aj7mOxZeHaerEtQV0YaqnkXNq26WWqMmJ6lTqShYxVRWZ/mwvvTrNeOwdslWiw==}
     engines: {node: '>=v0.2.0'}
 
+  no-case@3.0.4:
+    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
+
   node-emoji@2.1.3:
     resolution: {integrity: sha512-E2WEOVsgs7O16zsURJ/eH8BqhF029wGpEOnv7Urwdo2wmQanOACwJQh0devF9D9RhoZru0+9JXIS0dBXIAz+lA==}
     engines: {node: '>=18'}
@@ -7990,6 +8096,9 @@ packages:
   normalize-range@0.1.2:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
+
+  normalize.css@8.0.1:
+    resolution: {integrity: sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==}
 
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -8137,6 +8246,9 @@ packages:
   package-manager-detector@0.2.4:
     resolution: {integrity: sha512-H/OUu9/zUfP89z1APcBf2X8Us0tt8dUK4lUmKqz12QNXif3DxAs1/YqjGtcutZi1zQqeNQRWr9C+EbQnnvSSFA==}
 
+  param-case@3.0.4:
+    resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -8156,8 +8268,14 @@ packages:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
 
+  pascal-case@3.1.2:
+    resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  path-case@3.0.4:
+    resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -8212,12 +8330,22 @@ packages:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
     engines: {node: '>= 14.16'}
 
+  perfect-debounce@1.0.0:
+    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
   picocolors@1.1.0:
     resolution: {integrity: sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
 
   pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
@@ -8404,6 +8532,9 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-fast-compare@3.2.2:
+    resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -8412,6 +8543,13 @@ packages:
 
   react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
+
+  react-popper@2.3.0:
+    resolution: {integrity: sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==}
+    peerDependencies:
+      '@popperjs/core': ^2.0.0
+      react: ^16.8.0 || ^17 || ^18
+      react-dom: ^16.8.0 || ^17 || ^18
 
   react-refresh@0.14.0:
     resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
@@ -8452,6 +8590,22 @@ packages:
 
   react-style-singleton@2.2.1:
     resolution: {integrity: sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+
+  react-uid@2.3.3:
+    resolution: {integrity: sha512-iNpDovcb9qBpBTo8iUgqRSQOS8GV3bWoNaTaUptHkXtAooXSo0OWe7vN6TqqB8x3x0bNBbQx96kkmSltQ5h9kQ==}
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -8654,6 +8808,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  sentence-case@3.0.4:
+    resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
+
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
@@ -8694,6 +8851,10 @@ packages:
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
+  sirv@3.0.0:
+    resolution: {integrity: sha512-BPwJGUeDaDCHihkORDchNyyTvWFhcusy1XMmhEVTQTwGeybFbp8YEmB+njbPnth1FibULBSBVwCQni25XlCUDg==}
+    engines: {node: '>=18'}
+
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
     engines: {node: '>=8'}
@@ -8717,6 +8878,9 @@ packages:
   slice-ansi@7.1.0:
     resolution: {integrity: sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==}
     engines: {node: '>=18'}
+
+  snake-case@3.0.4:
+    resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
 
   sonic-boom@4.0.1:
     resolution: {integrity: sha512-hTSD/6JMLyT4r9zeof6UtuBDpjJ9sO08/nmS5djaA9eozT9oOlNdpXSnzcgj4FTqpk3nkLrs61l4gip9r1HCrQ==}
@@ -8980,6 +9144,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
+
   tough-cookie@4.1.4:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
     engines: {node: '>=6'}
@@ -9041,6 +9209,9 @@ packages:
 
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
+
+  tslib@2.6.3:
+    resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
 
   tslib@2.7.0:
     resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
@@ -9232,6 +9403,12 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  upper-case-first@2.0.2:
+    resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
+
+  upper-case@2.0.2:
+    resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -9291,6 +9468,16 @@ packages:
     resolution: {integrity: sha512-I1JadzO+xYX887S39Do+paRePCKoiDrWRRjp9kkG5he0t7RXNvPAJPCQSJqbGN4uCrFFeS3Kj3sLqY8NMYBEdA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
+
+  vite-plugin-inspect@0.8.8:
+    resolution: {integrity: sha512-aZlBuXsWUPJFmMK92GIv6lH7LrwG2POu4KJ+aEdcqnu92OAf+rhBnfMDQvxIJPEB7hE2t5EyY/PMgf5aDLT8EA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@nuxt/kit': '*'
+      vite: ^3.1.0 || ^4.0.0 || ^5.0.0-0
+    peerDependenciesMeta:
+      '@nuxt/kit':
+        optional: true
 
   vite@5.4.8:
     resolution: {integrity: sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==}
@@ -9397,6 +9584,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  warning@4.0.3:
+    resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
 
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
@@ -9555,6 +9745,8 @@ snapshots:
 
   '@andrewbranch/untar.js@1.0.3': {}
 
+  '@antfu/utils@0.7.10': {}
+
   '@arethetypeswrong/cli@0.15.3':
     dependencies:
       '@arethetypeswrong/core': 0.15.1
@@ -9591,7 +9783,7 @@ snapshots:
   '@babel/code-frame@7.24.7':
     dependencies:
       '@babel/highlight': 7.24.7
-      picocolors: 1.1.0
+      picocolors: 1.1.1
 
   '@babel/compat-data@7.24.9': {}
 
@@ -9736,7 +9928,7 @@ snapshots:
       '@babel/helper-validator-identifier': 7.25.7
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.1.0
+      picocolors: 1.1.1
 
   '@babel/parser@7.25.7':
     dependencies:
@@ -9822,6 +10014,37 @@ snapshots:
       '@babel/helper-string-parser': 7.25.7
       '@babel/helper-validator-identifier': 7.25.7
       to-fast-properties: 2.0.0
+
+  '@blueprintjs/colors@5.1.4':
+    dependencies:
+      tslib: 2.6.3
+
+  '@blueprintjs/core@5.16.0(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@blueprintjs/colors': 5.1.4
+      '@blueprintjs/icons': 5.15.0(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@popperjs/core': 2.11.8
+      classnames: 2.5.1
+      normalize.css: 8.0.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-popper: 2.3.0(@popperjs/core@2.11.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-uid: 2.3.3(@types/react@18.3.12)(react@18.3.1)
+      tslib: 2.6.3
+      use-sync-external-store: 1.2.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+
+  '@blueprintjs/icons@5.15.0(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      change-case: 4.1.2
+      classnames: 2.5.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tslib: 2.6.3
+    optionalDependencies:
+      '@types/react': 18.3.12
 
   '@bundled-es-modules/cookie@2.0.0':
     dependencies:
@@ -9914,7 +10137,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
-      picocolors: 1.1.0
+      picocolors: 1.1.1
       semver: 7.6.3
 
   '@changesets/get-release-plan@4.0.5':
@@ -9938,7 +10161,7 @@ snapshots:
 
   '@changesets/logger@0.1.1':
     dependencies:
-      picocolors: 1.1.0
+      picocolors: 1.1.1
 
   '@changesets/parse@0.4.0':
     dependencies:
@@ -11225,6 +11448,10 @@ snapshots:
       write-file-atomic: 5.0.1
       write-yaml-file: 4.2.0
 
+  '@polka/url@1.0.0-next.28': {}
+
+  '@popperjs/core@2.11.8': {}
+
   '@radix-ui/colors@3.0.0': {}
 
   '@radix-ui/number@1.1.0': {}
@@ -11895,6 +12122,14 @@ snapshots:
       picomatch: 2.3.1
     optionalDependencies:
       rollup: 3.29.5
+
+  '@rollup/pluginutils@5.1.3(rollup@4.24.0)':
+    dependencies:
+      '@types/estree': 1.0.6
+      estree-walker: 2.0.2
+      picomatch: 4.0.2
+    optionalDependencies:
+      rollup: 4.24.0
 
   '@rollup/rollup-android-arm-eabi@4.24.0':
     optional: true
@@ -12850,9 +13085,20 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camel-case@4.1.2:
+    dependencies:
+      pascal-case: 3.1.2
+      tslib: 2.7.0
+
   camelcase-css@2.0.1: {}
 
   caniuse-lite@1.0.30001643: {}
+
+  capital-case@1.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.7.0
+      upper-case-first: 2.0.2
 
   cardinal@2.1.1:
     dependencies:
@@ -12885,6 +13131,21 @@ snapshots:
       supports-color: 7.2.0
 
   chalk@5.3.0: {}
+
+  change-case@4.1.2:
+    dependencies:
+      camel-case: 4.1.2
+      capital-case: 1.0.4
+      constant-case: 3.0.4
+      dot-case: 3.0.4
+      header-case: 2.0.4
+      no-case: 3.0.4
+      param-case: 3.0.4
+      pascal-case: 3.1.2
+      path-case: 3.0.4
+      sentence-case: 3.0.4
+      snake-case: 3.0.4
+      tslib: 2.7.0
 
   char-regex@1.0.2: {}
 
@@ -13020,6 +13281,12 @@ snapshots:
   conjure-lite@0.4.4: {}
 
   consola@3.2.3: {}
+
+  constant-case@3.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.7.0
+      upper-case: 2.0.2
 
   convert-source-map@2.0.0: {}
 
@@ -13242,6 +13509,16 @@ snapshots:
 
   dom-accessibility-api@0.5.16: {}
 
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.24.5
+      csstype: 3.1.3
+
+  dot-case@3.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.7.0
+
   dprint@0.47.2:
     optionalDependencies:
       '@dprint/darwin-arm64': 0.47.2
@@ -13286,6 +13563,8 @@ snapshots:
   error-ex@1.3.2:
     dependencies:
       is-arrayish: 0.2.1
+
+  error-stack-parser-es@0.1.5: {}
 
   es-abstract@1.23.3:
     dependencies:
@@ -14250,6 +14529,11 @@ snapshots:
 
   he@1.2.0: {}
 
+  header-case@2.0.4:
+    dependencies:
+      capital-case: 1.0.4
+      tslib: 2.7.0
+
   headers-polyfill@4.0.3: {}
 
   help-me@5.0.0: {}
@@ -14687,6 +14971,10 @@ snapshots:
 
   loupe@3.1.2: {}
 
+  lower-case@2.0.2:
+    dependencies:
+      tslib: 2.7.0
+
   lru-cache@10.2.2: {}
 
   lru-cache@5.1.1:
@@ -14779,6 +15067,8 @@ snapshots:
 
   mri@1.2.0: {}
 
+  mrmime@2.0.0: {}
+
   ms@2.1.3: {}
 
   msw@2.3.4(typescript@5.5.4):
@@ -14846,6 +15136,11 @@ snapshots:
 
   ngeohash@0.6.3: {}
 
+  no-case@3.0.4:
+    dependencies:
+      lower-case: 2.0.2
+      tslib: 2.7.0
+
   node-emoji@2.1.3:
     dependencies:
       '@sindresorhus/is': 4.6.0
@@ -14858,6 +15153,8 @@ snapshots:
   normalize-path@3.0.0: {}
 
   normalize-range@0.1.2: {}
+
+  normalize.css@8.0.1: {}
 
   npm-run-path@4.0.1:
     dependencies:
@@ -15015,6 +15312,11 @@ snapshots:
 
   package-manager-detector@0.2.4: {}
 
+  param-case@3.0.4:
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.7.0
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -15041,7 +15343,17 @@ snapshots:
 
   parse-ms@4.0.0: {}
 
+  pascal-case@3.1.2:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.7.0
+
   path-browserify@1.0.1: {}
+
+  path-case@3.0.4:
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.7.0
 
   path-exists@4.0.0: {}
 
@@ -15076,9 +15388,15 @@ snapshots:
 
   pathval@2.0.0: {}
 
+  perfect-debounce@1.0.0: {}
+
   picocolors@1.1.0: {}
 
+  picocolors@1.1.1: {}
+
   picomatch@2.3.1: {}
+
+  picomatch@4.0.2: {}
 
   pidtree@0.6.0: {}
 
@@ -15175,7 +15493,7 @@ snapshots:
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.7
-      picocolors: 1.1.0
+      picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.4.47:
@@ -15260,11 +15578,21 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-fast-compare@3.2.2: {}
+
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
 
   react-is@18.2.0: {}
+
+  react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@popperjs/core': 2.11.8
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-fast-compare: 3.2.2
+      warning: 4.0.3
 
   react-refresh@0.14.0: {}
 
@@ -15303,6 +15631,22 @@ snapshots:
     dependencies:
       get-nonce: 1.0.1
       invariant: 2.2.4
+      react: 18.3.1
+      tslib: 2.7.0
+    optionalDependencies:
+      '@types/react': 18.3.12
+
+  react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.24.5
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  react-uid@2.3.3(@types/react@18.3.12)(react@18.3.1):
+    dependencies:
       react: 18.3.1
       tslib: 2.7.0
     optionalDependencies:
@@ -15551,6 +15895,12 @@ snapshots:
 
   semver@7.6.3: {}
 
+  sentence-case@3.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.7.0
+      upper-case-first: 2.0.2
+
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
@@ -15622,6 +15972,12 @@ snapshots:
       is-arrayish: 0.3.2
     optional: true
 
+  sirv@3.0.0:
+    dependencies:
+      '@polka/url': 1.0.0-next.28
+      mrmime: 2.0.0
+      totalist: 3.0.1
+
   skin-tone@2.0.0:
     dependencies:
       unicode-emoji-modifier-base: 1.0.0
@@ -15641,6 +15997,11 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 5.0.0
+
+  snake-case@3.0.4:
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.7.0
 
   sonic-boom@4.0.1:
     dependencies:
@@ -15919,6 +16280,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  totalist@3.0.1: {}
+
   tough-cookie@4.1.4:
     dependencies:
       psl: 1.9.0
@@ -15982,6 +16345,8 @@ snapshots:
       json5: 1.0.2
       minimist: 1.2.8
       strip-bom: 3.0.0
+
+  tslib@2.6.3: {}
 
   tslib@2.7.0: {}
 
@@ -16182,7 +16547,15 @@ snapshots:
     dependencies:
       browserslist: 4.23.2
       escalade: 3.1.2
-      picocolors: 1.1.0
+      picocolors: 1.1.1
+
+  upper-case-first@2.0.2:
+    dependencies:
+      tslib: 2.7.0
+
+  upper-case@2.0.2:
+    dependencies:
+      tslib: 2.7.0
 
   uri-js@4.4.1:
     dependencies:
@@ -16335,6 +16708,22 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  vite-plugin-inspect@0.8.8(rollup@4.24.0)(vite@5.4.8(@types/node@22.7.9)):
+    dependencies:
+      '@antfu/utils': 0.7.10
+      '@rollup/pluginutils': 5.1.3(rollup@4.24.0)
+      debug: 4.3.7
+      error-stack-parser-es: 0.1.5
+      fs-extra: 11.2.0
+      open: 10.1.0
+      perfect-debounce: 1.0.0
+      picocolors: 1.1.1
+      sirv: 3.0.0
+      vite: 5.4.8(@types/node@22.7.9)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
 
   vite@5.4.8(@types/node@18.17.15):
     dependencies:
@@ -16616,6 +17005,10 @@ snapshots:
       '@vue/shared': 3.5.11
     optionalDependencies:
       typescript: 5.5.4
+
+  warning@4.0.3:
+    dependencies:
+      loose-envify: 1.4.0
 
   webidl-conversions@4.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2582,9 +2582,6 @@ importers:
       vite:
         specifier: ^5.4.8
         version: 5.4.8(@types/node@22.7.9)
-      vite-plugin-inspect:
-        specifier: ^0.8.8
-        version: 0.8.8(rollup@4.24.0)(vite@5.4.8(@types/node@22.7.9))
       vitest:
         specifier: ^2.1.2
         version: 2.1.3(@types/node@22.7.9)(happy-dom@15.11.6)
@@ -3463,9 +3460,6 @@ packages:
 
   '@andrewbranch/untar.js@1.0.3':
     resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
-
-  '@antfu/utils@0.7.10':
-    resolution: {integrity: sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww==}
 
   '@arethetypeswrong/cli@0.15.3':
     resolution: {integrity: sha512-sIMA9ZJBWDEg1+xt5RkAEflZuf8+PO8SdKj17x6PtETuUho+qlZJg4DgmKc3q+QwQ9zOB5VLK6jVRbFdNLdUIA==}
@@ -5546,15 +5540,6 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/pluginutils@5.1.3':
-    resolution: {integrity: sha512-Pnsb6f32CD2W3uCaLZIzDmeFyQ2b8UWMFI7xtwUezpcGBDVDW6y9XgAWIlARiGAo6eNF5FK5aQTr0LFyNyqq5A==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-
   '@rollup/rollup-android-arm-eabi@4.24.0':
     resolution: {integrity: sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==}
     cpu: [arm]
@@ -6786,9 +6771,6 @@ packages:
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
-
-  error-stack-parser-es@0.1.5:
-    resolution: {integrity: sha512-xHku1X40RO+fO8yJ8Wh2f2rZWVjqyhb1zgq1yZ8aZRQkv6OOKhKWRUaht3eSCUbAOBaKIgM+ykwFLE+QUxgGeg==}
 
   es-abstract@1.23.3:
     resolution: {integrity: sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==}
@@ -8330,9 +8312,6 @@ packages:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
     engines: {node: '>= 14.16'}
 
-  perfect-debounce@1.0.0:
-    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
-
   picocolors@1.1.0:
     resolution: {integrity: sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==}
 
@@ -8342,10 +8321,6 @@ packages:
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.2:
-    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
-    engines: {node: '>=12'}
 
   pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
@@ -9469,16 +9444,6 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
-  vite-plugin-inspect@0.8.8:
-    resolution: {integrity: sha512-aZlBuXsWUPJFmMK92GIv6lH7LrwG2POu4KJ+aEdcqnu92OAf+rhBnfMDQvxIJPEB7hE2t5EyY/PMgf5aDLT8EA==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@nuxt/kit': '*'
-      vite: ^3.1.0 || ^4.0.0 || ^5.0.0-0
-    peerDependenciesMeta:
-      '@nuxt/kit':
-        optional: true
-
   vite@5.4.8:
     resolution: {integrity: sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -9744,8 +9709,6 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
 
   '@andrewbranch/untar.js@1.0.3': {}
-
-  '@antfu/utils@0.7.10': {}
 
   '@arethetypeswrong/cli@0.15.3':
     dependencies:
@@ -12123,14 +12086,6 @@ snapshots:
     optionalDependencies:
       rollup: 3.29.5
 
-  '@rollup/pluginutils@5.1.3(rollup@4.24.0)':
-    dependencies:
-      '@types/estree': 1.0.6
-      estree-walker: 2.0.2
-      picomatch: 4.0.2
-    optionalDependencies:
-      rollup: 4.24.0
-
   '@rollup/rollup-android-arm-eabi@4.24.0':
     optional: true
 
@@ -13563,8 +13518,6 @@ snapshots:
   error-ex@1.3.2:
     dependencies:
       is-arrayish: 0.2.1
-
-  error-stack-parser-es@0.1.5: {}
 
   es-abstract@1.23.3:
     dependencies:
@@ -15388,15 +15341,11 @@ snapshots:
 
   pathval@2.0.0: {}
 
-  perfect-debounce@1.0.0: {}
-
   picocolors@1.1.0: {}
 
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
-
-  picomatch@4.0.2: {}
 
   pidtree@0.6.0: {}
 
@@ -16708,22 +16657,6 @@ snapshots:
       - sugarss
       - supports-color
       - terser
-
-  vite-plugin-inspect@0.8.8(rollup@4.24.0)(vite@5.4.8(@types/node@22.7.9)):
-    dependencies:
-      '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.3(rollup@4.24.0)
-      debug: 4.3.7
-      error-stack-parser-es: 0.1.5
-      fs-extra: 11.2.0
-      open: 10.1.0
-      perfect-debounce: 1.0.0
-      picocolors: 1.1.1
-      sirv: 3.0.0
-      vite: 5.4.8(@types/node@22.7.9)
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
 
   vite@5.4.8(@types/node@18.17.15):
     dependencies:


### PR DESCRIPTION
This augments the widget vite plugin to serve a basic form of the manifest so that we can trigger a localhost-driven developer mode against a Foundry environment. The workflow would look like the following:

1. Set your `FOUNDRY_TOKEN` in your terminal
2. Make sure your `foundry.config.json` is set
3. Run `dev`
4. Click on the indicated URL in the terminal output

![image](https://github.com/user-attachments/assets/e32200e5-53e0-45db-b9cd-1becdbe8ed7b)

5. Wait for the page to redirect you to Foundry
6. Land in developer mode within our preview harness UI

Some considerations for this (incomplete) version:
- I haven't fully figured out how HMR should work. I think there's something funky in either the order in which vite traverses the module graph (and thus our scripts in the manifest are out of order) or with a script tag that has inline JS that appears on the page for react refresh window variables :| 
- Vite does not parse modules in dev mode for performance reasons. This means that although we can (more or less) find the entrypoint assets to add to the manifest, in dev mode the parameter/event config is not getting served. We could perhaps find the imported `.config` file and parse it on the fly instead, if that's not too expensive?
- This currently isn't handling CSS specially - it's mostly assuming that a JS file has imported the CSS. If there is a css file referenced in the HTML instead, I'm not sure what will happen
- This is calling an internal/beta endpoint, which should be published to our public API at some point instead
- Vite in serve mode is extremely conservative, and refuses to load any modules until the very last moment. As a result, I ended up making a tiny little app that is served by vite at `./palantir/setup`, which will receive the list of HTML entrypoint files and then load them in invisible iframes. The loading of these HTML files triggers the vite plugin code which goes and logs all the JS entrypoint files, which we then use to compose a manifest file. The tiny app then sits there and polls for the manifest until it sees an entrypoint file for every manifest, and then it tells the plugin to send the manifest to Foundry. If successful, it will redirect the dev to Foundry to see their widget in the preview harness
- I'm not handling the multiple entrypoint case, since it requires parsing the config file to figure out which RID the dev actually wants/intends. I think platinum version, the tiny app hosted by the vite plugin probably shows a selector to pick which entrypoint they want to launch dev mode for, and then the corresponding RID is found and used to start dev mode