### PR TITLE
Experiment with no proxy for objects

### DIFF
--- a/.changeset/lucky-tomatoes-admire.md
+++ b/.changeset/lucky-tomatoes-admire.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": minor
+---
+
+OSDK Client no longer uses javascript proxies for its objects. This results in a 13% increase in construction time but at 1kb per object reduction in memory

--- a/packages/client/src/fetchMetadata.test.ts
+++ b/packages/client/src/fetchMetadata.test.ts
@@ -105,6 +105,13 @@ describe("FetchMetadata", () => {
         "primaryKeyApiName": "employeeId",
         "primaryKeyType": "integer",
         "properties": {
+          "class": {
+            "description": "",
+            "displayName": undefined,
+            "multiplicity": false,
+            "nullable": true,
+            "type": "string",
+          },
           "employeeId": {
             "description": undefined,
             "displayName": undefined,

--- a/packages/client/src/object/convertWireToOsdkObjects.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.test.ts
@@ -64,6 +64,7 @@ describe("convertWireToOsdkObjects", () => {
 
     expect(Object.keys(employee).sort()).toEqual([
       "employeeId",
+      "$title",
       "fullName",
       "office",
       "class",
@@ -225,128 +226,6 @@ describe("convertWireToOsdkObjects", () => {
     const prototypeAfter = Object.getPrototypeOf(object2);
 
     expect(prototypeBefore).not.toBe(prototypeAfter);
-  });
-
-  it("updates interface when underlying changes - old", async () => {
-    const clientCtx = createMinimalClient(
-      { ontologyRid: $ontologyRid },
-      "https://stack.palantir.com",
-      async () => "myAccessToken",
-    );
-
-    let objectFromWire = {
-      __apiName: "Employee" as const,
-      __primaryKey: 0,
-      __title: "Steve",
-      fullName: "Steve",
-      employeeId: "5",
-    } satisfies OntologyObjectV2;
-
-    const [obj] = (await convertWireToOsdkObjects(
-      clientCtx,
-      [objectFromWire],
-      undefined,
-    )) as unknown as Osdk<Employee>[];
-
-    expect(obj.fullName).toEqual("Steve");
-    expect(Object.keys(obj).sort()).toEqual([
-      "$apiName",
-      "$objectType",
-      "$primaryKey",
-      "$title",
-      "employeeId",
-      "fullName",
-    ].sort());
-
-    const objAsFoo = obj.$as(FooInterface);
-    expect(objAsFoo).toMatchObject({
-      fooSpt: obj.fullName,
-      $apiName: FooInterface.apiName,
-      $primaryKey: obj.$primaryKey,
-      $objectType: obj.$objectType,
-      $title: obj.$title,
-    });
-
-    console.log(obj);
-    console.log(objAsFoo);
-
-    (obj as any).$updateInternalValues({
-      fullName: "Bob",
-    });
-    expect(obj.fullName).toEqual("Bob");
-    expect(objAsFoo.fooSpt).toEqual(obj.fullName);
-
-    expect(Object.keys(objAsFoo).sort()).toEqual([
-      "$apiName",
-      "$objectType",
-      "$primaryKey",
-      "$title",
-      "fooSpt",
-    ].sort());
-
-    expect(obj).toBe(objAsFoo.$as(Employee));
-    expect(objAsFoo).toBe(obj.$as(FooInterface));
-  });
-
-  it("updates interface when underlying changes - new", async () => {
-    const clientCtx = createMinimalClient(
-      { ontologyRid: $ontologyRid },
-      "https://stack.palantir.com",
-      async () => "myAccessToken",
-    );
-
-    let objectFromWire = {
-      __apiName: "Employee" as const,
-      __primaryKey: 0,
-      __title: "Steve",
-      fullName: "Steve",
-      employeeId: "5",
-    } satisfies OntologyObjectV2;
-
-    const [obj] = (await convertWireToOsdkObjects2(
-      clientCtx,
-      [objectFromWire],
-      undefined,
-    )) as unknown as Osdk<Employee>[];
-
-    expect(obj.fullName).toEqual("Steve");
-    expect(Object.keys(obj).sort()).toEqual([
-      "$apiName",
-      "$objectType",
-      "$primaryKey",
-      "$title",
-      "employeeId",
-      "fullName",
-    ].sort());
-
-    const objAsFoo = obj.$as(FooInterface);
-    expect(objAsFoo).toMatchObject({
-      fooSpt: obj.fullName,
-      $apiName: FooInterface.apiName,
-      $primaryKey: obj.$primaryKey,
-      $objectType: obj.$objectType,
-      $title: obj.$title,
-    });
-
-    console.log(obj);
-    console.log(objAsFoo);
-
-    (obj as any).$updateInternalValues({
-      fullName: "Bob",
-    });
-    expect(obj.fullName).toEqual("Bob");
-    expect(objAsFoo.fooSpt).toEqual(obj.fullName);
-
-    expect(Object.keys(objAsFoo).sort()).toEqual([
-      "$apiName",
-      "$objectType",
-      "$primaryKey",
-      "$title",
-      "fooSpt",
-    ].sort());
-
-    expect(obj).toBe(objAsFoo.$as(Employee));
-    expect(objAsFoo).toBe(obj.$as(FooInterface));
   });
 
   it("reconstitutes interfaces properly without rid - old", async () => {

--- a/packages/client/src/object/convertWireToOsdkObjects/InterfaceHolder.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/InterfaceHolder.ts
@@ -23,15 +23,9 @@ import type {
 import type { ObjectHolder } from "./ObjectHolder.js";
 
 /** @internal */
-export interface InterfaceHolderOwnProps<
+export interface InterfaceHolder<
   Q extends FetchedObjectTypeDefinition,
 > {
   [UnderlyingOsdkObject]: Osdk<Q> & ObjectHolder<Q>;
   [InterfaceDefRef]: InterfaceMetadata;
-}
-
-/** @internal */
-export interface InterfaceHolder<
-  Q extends FetchedObjectTypeDefinition,
-> extends InterfaceHolderOwnProps<Q> {
 }

--- a/packages/client/src/object/convertWireToOsdkObjects/InternalSymbols.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/InternalSymbols.ts
@@ -31,12 +31,6 @@ export const InterfaceDefRef = Symbol(
   process.env.MODE !== "production" ? "InterfaceDefinition" : undefined,
 );
 
-/** A symbol for getting the raw data object off of the holder an osdk object proxy points to */
-/** @internal */
-export const RawObject = Symbol(
-  process.env.MODE !== "production" ? "RawObject" : undefined,
-);
-
 /** @internal */
 export const ClientRef = Symbol(
   process.env.MODE !== "production" ? "ClientRef" : undefined,

--- a/packages/client/src/object/convertWireToOsdkObjects/InternalSymbols.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/InternalSymbols.ts
@@ -42,11 +42,6 @@ export const ClientRef = Symbol(
   process.env.MODE !== "production" ? "ClientRef" : undefined,
 );
 
-/** @internal */
-export const CachedPropertiesRef = Symbol(
-  process.env.MODE !== "production" ? "CachedProperties" : undefined,
-);
-
 export interface HolderBase<T extends ObjectOrInterfaceDefinition> {
   [UnderlyingOsdkObject]: OsdkBase<any>;
   [ObjectDefRef]?: T;

--- a/packages/client/src/object/convertWireToOsdkObjects/ObjectHolder.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/ObjectHolder.ts
@@ -21,7 +21,6 @@ import type { FetchedObjectTypeDefinition } from "../../ontology/OntologyProvide
 import type { DollarAsFn } from "./getDollarAs.js";
 import type { get$link } from "./getDollarLink.js";
 import type {
-  CachedPropertiesRef,
   ClientRef,
   ObjectDefRef,
   RawObject,
@@ -34,12 +33,10 @@ export interface ObjectHolderPrototypeOwnProps {
   readonly [ClientRef]: MinimalClient;
   readonly "$as": DollarAsFn;
   readonly "$link": ReturnType<typeof get$link>;
-  readonly "$updateInternalValues": (newValues: Record<string, any>) => void;
 }
 /** @internal */
 export interface ObjectHolderOwnProperties {
   [RawObject]: OntologyObjectV2;
-  [CachedPropertiesRef]: Map<string | symbol, any>;
 }
 
 /** @internal */

--- a/packages/client/src/object/convertWireToOsdkObjects/ObjectHolder.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/ObjectHolder.ts
@@ -15,7 +15,6 @@
  */
 
 import type { Osdk } from "@osdk/api";
-import type { OntologyObjectV2 } from "@osdk/internal.foundry.core";
 import type { MinimalClient } from "../../MinimalClientContext.js";
 import type { FetchedObjectTypeDefinition } from "../../ontology/OntologyProvider.js";
 import type { DollarAsFn } from "./getDollarAs.js";
@@ -23,25 +22,14 @@ import type { get$link } from "./getDollarLink.js";
 import type {
   ClientRef,
   ObjectDefRef,
-  RawObject,
   UnderlyingOsdkObject,
 } from "./InternalSymbols.js";
 
 /** @internal */
-export interface ObjectHolderPrototypeOwnProps {
+export interface ObjectHolder<Q extends FetchedObjectTypeDefinition> {
+  readonly [UnderlyingOsdkObject]: Osdk<Q>;
   readonly [ObjectDefRef]: FetchedObjectTypeDefinition;
   readonly [ClientRef]: MinimalClient;
   readonly "$as": DollarAsFn;
   readonly "$link": ReturnType<typeof get$link>;
-}
-/** @internal */
-export interface ObjectHolderOwnProperties {
-  [RawObject]: OntologyObjectV2;
-}
-
-/** @internal */
-export interface ObjectHolder<Q extends FetchedObjectTypeDefinition>
-  extends ObjectHolderPrototypeOwnProps, ObjectHolderOwnProperties
-{
-  [UnderlyingOsdkObject]: Osdk<Q>;
 }

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
@@ -52,8 +52,7 @@ describe(createOsdkInterface, () => {
         status: "ACTIVE",
       } satisfies FetchedObjectTypeDefinition,
     };
-    // underlying: Osdk<Q> & ObjectHolder<Q>,
-    // interfaceDef: InterfaceMetadata,
+
     const iface = createOsdkInterface(underlying as any, {
       "apiName": "IFoo",
       displayName: "",
@@ -114,8 +113,7 @@ describe(createOsdkInterface, () => {
         status: "ACTIVE",
       } satisfies FetchedObjectTypeDefinition,
     };
-    // underlying: Osdk<Q> & ObjectHolder<Q>,
-    // interfaceDef: InterfaceMetadata,
+
     const iface = createOsdkInterface(underlying as any, {
       "apiName": "a.IFoo",
       displayName: "",
@@ -176,8 +174,7 @@ describe(createOsdkInterface, () => {
         status: "ACTIVE",
       } satisfies FetchedObjectTypeDefinition,
     };
-    // underlying: Osdk<Q> & ObjectHolder<Q>,
-    // interfaceDef: InterfaceMetadata,
+
     const iface = createOsdkInterface(underlying as any, {
       "apiName": "a.IFoo",
       displayName: "",

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.ts
@@ -14,28 +14,16 @@
  * limitations under the License.
  */
 
-import type { InterfaceMetadata, Osdk, OsdkBase } from "@osdk/api";
+import type { InterfaceMetadata, Osdk } from "@osdk/api";
 import { extractNamespace } from "../../internal/conversions/modernToLegacyWhereClause.js";
 import type { FetchedObjectTypeDefinition } from "../../ontology/OntologyProvider.js";
-import { createSimpleCache } from "../SimpleCache.js";
-import type {
-  InterfaceHolder,
-  InterfaceHolderOwnProps,
-} from "./InterfaceHolder.js";
+import type { InterfaceHolder } from "./InterfaceHolder.js";
 import {
   InterfaceDefRef,
   ObjectDefRef,
   UnderlyingOsdkObject,
 } from "./InternalSymbols.js";
 import type { ObjectHolder } from "./ObjectHolder.js";
-
-const handlerCache = createSimpleCache<
-  InterfaceMetadata,
-  ProxyHandler<InterfaceHolder<any> & Osdk<any>>
->(
-  new WeakMap(),
-  createInterfaceProxyHandler,
-);
 
 /** @internal */
 export function createOsdkInterface<
@@ -44,131 +32,52 @@ export function createOsdkInterface<
   underlying: Osdk<Q> & ObjectHolder<Q>,
   interfaceDef: InterfaceMetadata,
 ) {
-  const interfaceHolder: InterfaceHolderOwnProps<Q> = Object.create(null, {
-    [UnderlyingOsdkObject]: { value: underlying },
-    [InterfaceDefRef]: { value: interfaceDef },
-  });
+  const [objApiNamespace] = extractNamespace(interfaceDef.apiName);
 
-  const handler = handlerCache.get(interfaceDef);
+  return Object.freeze(
+    Object.defineProperties({}, {
+      // first to minimize hidden classes
+      [UnderlyingOsdkObject]: { value: underlying },
 
-  const proxy = new Proxy<OsdkBase<any>>(
-    interfaceHolder as unknown as OsdkBase<any>, // the wrapper doesn't contain everything obviously. we proxy
-    handler,
+      "$apiName": { value: interfaceDef.apiName, enumerable: true },
+      "$as": {
+        value: underlying.$as,
+        enumerable: false,
+      },
+      "$objectType": {
+        value: underlying.$objectType,
+        enumerable: "$objectType" in underlying,
+      },
+      "$primaryKey": {
+        value: underlying.$primaryKey,
+        enumerable: "$primaryKey" in underlying,
+      },
+      "$title": {
+        value: underlying.$title,
+        enumerable: "$title" in underlying,
+      },
+      "$rid": {
+        value: (underlying as any).$rid,
+        enumerable: "$rid" in underlying,
+      },
+
+      [InterfaceDefRef]: { value: interfaceDef },
+
+      ...Object.fromEntries(
+        Object.keys(interfaceDef.properties).map(p => {
+          const objDef = underlying[ObjectDefRef];
+
+          const [apiNamespace, apiName] = extractNamespace(p);
+
+          const targetPropName = objDef
+            .interfaceMap![interfaceDef.apiName][p];
+
+          return [apiNamespace === objApiNamespace ? apiName : p, {
+            enumerable: targetPropName in underlying,
+            value: underlying[targetPropName as keyof typeof underlying],
+          }];
+        }),
+      ),
+    }) as InterfaceHolder<any> & Osdk<any>,
   );
-  return proxy;
-}
-
-function createInterfaceProxyHandler(
-  newDef: InterfaceMetadata,
-): ProxyHandler<InterfaceHolder<any> & Osdk<any>> {
-  return {
-    getOwnPropertyDescriptor(target, p) {
-      const underlying = target[UnderlyingOsdkObject];
-      const objDef = underlying[ObjectDefRef];
-
-      switch (p) {
-        case UnderlyingOsdkObject:
-        case InterfaceDefRef:
-          return Reflect.getOwnPropertyDescriptor(target, p);
-
-        case "$primaryKey":
-        case "$title":
-        case "$objectType":
-        case "$rid":
-          return p in underlying
-            ? {
-              value: underlying[p],
-              configurable: true,
-              enumerable: true,
-            }
-            : undefined;
-
-        case "$apiName":
-          return {
-            enumerable: true,
-            configurable: true,
-            value: target[InterfaceDefRef].apiName,
-          };
-      }
-
-      const [objApiNamespace] = extractNamespace(newDef.apiName);
-      if (objApiNamespace != null) {
-        const [apiNamespace, apiName] = extractNamespace(p as string);
-        if (apiNamespace == null) {
-          p = `${objApiNamespace}.${apiName}`;
-        }
-      }
-
-      if (newDef.properties[p as string] != null) {
-        return {
-          enumerable: true,
-          configurable: true,
-          value: underlying[
-            objDef.interfaceMap![newDef.apiName][p as string] as any
-          ],
-        };
-      }
-    },
-
-    ownKeys(target) {
-      const underlying = target[UnderlyingOsdkObject];
-      const [objApiNamespace] = extractNamespace(newDef.apiName);
-      let propNames = Object.keys(newDef.properties);
-
-      if (objApiNamespace != null) {
-        propNames = propNames.map(p => {
-          const [apiNamespace, apiName] = extractNamespace(p as string);
-          if (apiNamespace === objApiNamespace) {
-            p = apiName;
-          }
-          return p;
-        });
-      }
-
-      return [
-        "$apiName",
-        "$objectType",
-        "$primaryKey",
-        ...(underlying["$rid"] ? ["$rid"] : []),
-        "$title",
-        UnderlyingOsdkObject,
-        InterfaceDefRef,
-        ...propNames,
-      ];
-    },
-
-    set() {
-      return false;
-    },
-
-    get(target, p) {
-      const underlying = target[UnderlyingOsdkObject];
-      switch (p) {
-        case InterfaceDefRef:
-          return newDef;
-        case "$apiName":
-          return newDef.apiName;
-        case "$as":
-        case UnderlyingOsdkObject:
-        case "$primaryKey":
-        case "$title":
-        case "$objectType":
-        case "$rid":
-          return underlying[p as string];
-      }
-
-      const [objApiNamespace] = extractNamespace(newDef.apiName);
-      if (objApiNamespace != null) {
-        const [apiNamespace, apiName] = extractNamespace(p as string);
-        if (apiNamespace == null) {
-          p = `${objApiNamespace}.${apiName}`;
-        }
-      }
-
-      if (newDef.properties[p as string] != null) {
-        const objDef = target[UnderlyingOsdkObject][ObjectDefRef];
-        return underlying[objDef.interfaceMap![newDef.apiName][p as string]];
-      }
-    },
-  };
 }

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -27,13 +27,11 @@ import { get$link } from "./getDollarLink.js";
 import {
   ClientRef,
   ObjectDefRef,
-  RawObject,
   UnderlyingOsdkObject,
 } from "./InternalSymbols.js";
 import type { ObjectHolder } from "./ObjectHolder.js";
 
 interface InternalOsdkInstance {
-  [RawObject]: OntologyObjectV2;
   [ObjectDefRef]: FetchedObjectTypeDefinition;
   [ClientRef]: MinimalClient;
 }
@@ -62,7 +60,6 @@ const basePropDefs = {
         [UnderlyingOsdkObject]: this as any,
         [ObjectDefRef]: this[ObjectDefRef],
         [ClientRef]: this[ClientRef],
-        [RawObject]: this[RawObject],
       } as ObjectHolder<any>);
     },
   },
@@ -78,18 +75,13 @@ export function createOsdkObject<
 ): Osdk<ObjectTypeDefinition, any> {
   // updates the object's "hidden class/map".
   Object.defineProperties(rawObj, {
-    [ObjectDefRef]: { value: objectDef, enumerable: false },
-    [ClientRef]: { value: client, enumerable: false },
-    [RawObject]: {
-      value: rawObj,
-      enumerable: false,
-    },
-    ...basePropDefs,
-
     [UnderlyingOsdkObject]: {
       enumerable: false,
       value: rawObj,
     },
+    [ObjectDefRef]: { value: objectDef, enumerable: false },
+    [ClientRef]: { value: client, enumerable: false },
+    ...basePropDefs,
   });
 
   // Assign the special values
@@ -98,9 +90,6 @@ export function createOsdkObject<
       propKey in objectDef.properties
       && specialPropertyTypes.has(objectDef.properties[propKey].type)
     ) {
-      const rawValue = rawObj[propKey as any];
-      const propDef = objectDef.properties[propKey as any];
-
       rawObj[propKey] = createSpecialProperty(
         client,
         objectDef,

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -14,123 +14,59 @@
  * limitations under the License.
  */
 
-import type {
-  GeotimeSeriesProperty,
-  ObjectTypeDefinition,
-  Osdk,
-  TimeSeriesPoint,
-} from "@osdk/api";
+import type { ObjectTypeDefinition, Osdk } from "@osdk/api";
 import type { OntologyObjectV2 } from "@osdk/internal.foundry.core";
-import { OntologiesV2 } from "@osdk/internal.foundry.ontologiesv2";
+import invariant from "tiny-invariant";
 import { createAttachmentFromRid } from "../../createAttachmentFromRid.js";
 import { GeotimeSeriesPropertyImpl } from "../../createGeotimeSeriesProperty.js";
 import { TimeSeriesPropertyImpl } from "../../createTimeseriesProperty.js";
 import type { MinimalClient } from "../../MinimalClientContext.js";
 import type { FetchedObjectTypeDefinition } from "../../ontology/OntologyProvider.js";
-import { createClientCache } from "../Cache.js";
 import { get$as } from "./getDollarAs.js";
 import { get$link } from "./getDollarLink.js";
 import {
-  CachedPropertiesRef,
   ClientRef,
   ObjectDefRef,
   RawObject,
   UnderlyingOsdkObject,
 } from "./InternalSymbols.js";
-import type {
-  ObjectHolder,
-  ObjectHolderPrototypeOwnProps,
-} from "./ObjectHolder.js";
-import type { PropertyDescriptorRecord } from "./PropertyDescriptorRecord.js";
+import type { ObjectHolder } from "./ObjectHolder.js";
 
-const objectPrototypeCache = createClientCache(
-  function(client, objectDef: FetchedObjectTypeDefinition) {
-    return Object.create(
-      null,
-      {
-        [ObjectDefRef]: { value: objectDef },
-        [ClientRef]: { value: client },
-        "$as": { value: get$as(objectDef) },
-        "$link": {
-          get: function(this: ObjectHolder<typeof objectDef>) {
-            return get$link(this);
-          },
-        },
-        "$updateInternalValues": {
-          value: function(
-            this: ObjectHolder<typeof objectDef>,
-            newValues: Record<string, any>,
-          ) {
-            this[RawObject] = Object.assign(
-              {},
-              this[RawObject],
-              newValues,
-            );
-          },
-        },
-      } satisfies PropertyDescriptorRecord<ObjectHolderPrototypeOwnProps>,
-    );
-  },
+interface InternalOsdkInstance {
+  [RawObject]: OntologyObjectV2;
+  [ObjectDefRef]: FetchedObjectTypeDefinition;
+  [ClientRef]: MinimalClient;
+}
+
+const specialPropertyTypes = new Set(
+  [
+    "attachment",
+    "geotimeSeriesReference",
+    "numericTimeseries",
+    "stringTimeseries",
+    "sensorTimeseries",
+  ],
 );
 
-if (process.env.NODE_ENV !== "production") {
-  const installed = Symbol();
-  const gw: any = typeof window === "undefined" ? global : window;
-  if (!(installed in gw)) {
-    gw[installed] = true;
-
-    gw.devtoolsFormatters ??= [];
-    gw.devtoolsFormatters.push({
-      header: function(object: any) {
-        const raw = object[RawObject];
-        if (raw == null) return null;
-
-        return [
-          "div",
-          {},
-
-          `Osdk.Instance<${raw.$apiName}> { $primaryKey:`,
-          ["object", { object: raw.$primaryKey }],
-          `, $title:`,
-          ["object", { object: raw.$title }],
-          `, ... }`,
-        ];
-      },
-      hasBody: function(object: any) {
-        return object[RawObject] != null;
-      },
-      body: function(object: any) {
-        const raw = object[RawObject];
-        if (raw == null) return null;
-
-        return [
-          "ol",
-          {
-            style: `
-            list-style-type: none;
-            padding-left: 0;
-            margin-top: 0;
-            margin-left: 18px
-          `,
-          },
-          ["li", {}, "$raw:", ["object", { object: raw }]],
-          // ...Object.keys(raw).map(key => {
-          //   return [
-          //     "li",
-          //     {},
-          //     [
-          //       "span",
-          //       { style: "color: #888888" },
-          //       `${key}: `,
-          //     ],
-          //     ["object", { object: raw[key] }], // ["span", {}, `${key}: `]],
-          //   ];
-          // }),
-        ];
-      },
-    });
-  }
-}
+// kept separate so we are not redefining these functions
+// every time an object is created.
+const basePropDefs = {
+  "$as": {
+    get: function(this: InternalOsdkInstance) {
+      return get$as(this[ObjectDefRef]);
+    },
+  },
+  "$link": {
+    get: function(this: InternalOsdkInstance & ObjectHolder<any>) {
+      return get$link({
+        [UnderlyingOsdkObject]: this as any,
+        [ObjectDefRef]: this[ObjectDefRef],
+        [ClientRef]: this[ClientRef],
+        [RawObject]: this[RawObject],
+      } as ObjectHolder<any>);
+    },
+  },
+};
 
 /** @internal */
 export function createOsdkObject<
@@ -140,50 +76,65 @@ export function createOsdkObject<
   objectDef: Q,
   rawObj: OntologyObjectV2,
 ): Osdk<ObjectTypeDefinition, any> {
-  // We use multiple layers of prototypes to maximize reuse and also to keep
-  // [RawObject] out of `ownKeys`. This keeps the code in the proxy below simpler.
-  const objectHolderPrototype = Object.create(
-    objectPrototypeCache.get(client, objectDef),
+  // updates the object's "hidden class/map".
+  Object.defineProperties(rawObj, {
+    [ObjectDefRef]: { value: objectDef, enumerable: false },
+    [ClientRef]: { value: client, enumerable: false },
+    [RawObject]: {
+      value: rawObj,
+      enumerable: false,
+    },
+    ...basePropDefs,
+
+    [UnderlyingOsdkObject]: {
+      enumerable: false,
+      value: rawObj,
+    },
+  });
+
+  // Assign the special values
+  for (const propKey of Object.keys(rawObj)) {
+    if (
+      propKey in objectDef.properties
+      && specialPropertyTypes.has(objectDef.properties[propKey].type)
+    ) {
+      const rawValue = rawObj[propKey as any];
+      const propDef = objectDef.properties[propKey as any];
+
+      rawObj[propKey] = createSpecialProperty(
+        client,
+        objectDef,
+        rawObj as any,
+        propKey,
+      );
+    }
+  }
+
+  return Object.freeze(rawObj) as Osdk<ObjectTypeDefinition, any>;
+}
+
+function createSpecialProperty(
+  client: MinimalClient,
+  objectDef: FetchedObjectTypeDefinition,
+  rawObject: Osdk.Instance<any>,
+  p: keyof typeof rawObject & string | symbol,
+) {
+  const rawValue = rawObject[p as any];
+  const propDef = objectDef.properties[p as any];
+  if (process.env.NODE_ENV !== "production") {
+    invariant(propDef != null && specialPropertyTypes.has(propDef.type));
+  }
+  {
     {
-      [RawObject]: {
-        value: rawObj,
-        writable: true, // so we can allow updates
-      },
-      [CachedPropertiesRef]: {
-        value: new Map<string | symbol, any>(),
-        writable: true,
-      },
-    },
-  );
-
-  // we separate the holder out so we can update
-  // the underlying data without having to return a new object
-  // we also need the holder so we can customize the console.log output
-  const holder: ObjectHolder<Q> = Object.create(objectHolderPrototype);
-
-  const osdkObject: any = new Proxy(holder, {
-    ownKeys(target) {
-      return Reflect.ownKeys(target[RawObject]);
-    },
-    get(target, p, receiver) {
-      switch (p) {
-        case UnderlyingOsdkObject:
-          // effectively point back to the proxy
-          return receiver;
-      }
-
-      if (p in target) return target[p as keyof typeof target];
-
-      if (p in rawObj) {
-        const rawValue = target[RawObject][p as any];
-        const propDef = objectDef.properties[p as any];
-        if (propDef) {
+      {
+        {
           if (propDef.type === "attachment") {
             if (Array.isArray(rawValue)) {
               return rawValue.map(a => createAttachmentFromRid(client, a.rid));
             }
             return createAttachmentFromRid(client, rawValue.rid);
           }
+
           if (
             propDef.type === "numericTimeseries"
             || propDef.type === "stringTimeseries"
@@ -196,19 +147,16 @@ export function createOsdkObject<
             >(
               client,
               objectDef.apiName,
-              target[RawObject][objectDef.primaryKeyApiName as string],
+              rawObject[objectDef.primaryKeyApiName as string],
               p as string,
             );
           }
+
           if (propDef.type === "geotimeSeriesReference") {
-            const instance = target[CachedPropertiesRef].get(p);
-            if (instance != null) {
-              return instance;
-            }
-            const geotimeProp = new GeotimeSeriesPropertyImpl<GeoJSON.Point>(
+            return new GeotimeSeriesPropertyImpl<GeoJSON.Point>(
               client,
               objectDef.apiName,
-              target[RawObject][objectDef.primaryKeyApiName as string],
+              rawObject[objectDef.primaryKeyApiName as string],
               p as string,
               rawValue.type === "geotimeSeriesValue"
                 ? {
@@ -220,36 +168,9 @@ export function createOsdkObject<
                 }
                 : undefined,
             );
-            target[CachedPropertiesRef].set(p, geotimeProp);
-            return geotimeProp;
           }
         }
-        return rawValue;
       }
-
-      // we do not do any fall through to avoid unexpected behavior
-    },
-
-    set(target, p, newValue) {
-      // allow the prototype to update this value
-      if (p === RawObject) {
-        // symbol only exists internally so no one else can hit this
-        target[p as typeof RawObject] = newValue;
-        return true;
-      }
-      return false;
-    },
-
-    getOwnPropertyDescriptor(target, p) {
-      if (p === RawObject) {
-        return Reflect.getOwnPropertyDescriptor(target, p);
-      }
-
-      if (target[RawObject][p as string] != null) {
-        return { configurable: true, enumerable: true };
-      }
-      return undefined;
-    },
-  });
-  return osdkObject;
+    }
+  }
 }

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -56,11 +56,7 @@ const basePropDefs = {
   },
   "$link": {
     get: function(this: InternalOsdkInstance & ObjectHolder<any>) {
-      return get$link({
-        [UnderlyingOsdkObject]: this as any,
-        [ObjectDefRef]: this[ObjectDefRef],
-        [ClientRef]: this[ClientRef],
-      } as ObjectHolder<any>);
+      return get$link(this);
     },
   },
 };

--- a/packages/client/src/object/convertWireToOsdkObjects/getDollarLink.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/getDollarLink.ts
@@ -23,11 +23,12 @@ import type {
 } from "@osdk/api";
 import { getWireObjectSet } from "../../objectSet/createObjectSet.js";
 import { fetchSingle, fetchSingleWithErrors } from "../fetchSingle.js";
-import { ClientRef, ObjectDefRef, RawObject } from "./InternalSymbols.js";
-import type {
-  ObjectHolder,
-  ObjectHolderOwnProperties,
-} from "./ObjectHolder.js";
+import {
+  ClientRef,
+  ObjectDefRef,
+  UnderlyingOsdkObject,
+} from "./InternalSymbols.js";
+import type { ObjectHolder } from "./ObjectHolder.js";
 
 /** @internal */
 export function get$link(
@@ -43,7 +44,7 @@ const DollarLinkProxyHandler: ProxyHandler<ObjectHolder<any>> = {
     const {
       [ObjectDefRef]: objDef,
       [ClientRef]: client,
-      [RawObject]: rawObj,
+      [UnderlyingOsdkObject]: rawObj,
     } = target;
     const linkDef = objDef.links[p as string];
     if (linkDef == null) {
@@ -80,7 +81,7 @@ const DollarLinkProxyHandler: ProxyHandler<ObjectHolder<any>> = {
 
   ownKeys(
     target: ObjectHolder<any>,
-  ): ArrayLike<keyof ObjectHolderOwnProperties | string> {
+  ): ArrayLike<keyof ObjectHolder<any> | string> {
     return [...Object.keys(target[ObjectDefRef].links)];
   },
 

--- a/packages/client/src/objectSet/ObjectSet.test.ts
+++ b/packages/client/src/objectSet/ObjectSet.test.ts
@@ -524,6 +524,7 @@ describe("ObjectSet", () => {
 
         expectTypeOf<JustProps<Employee, "$all">>()
           .toEqualTypeOf<
+            | "class"
             | "fullName"
             | "office"
             | "employeeId"

--- a/packages/client/src/objectSet/ObjectSetListenerWebsocket.test.ts
+++ b/packages/client/src/objectSet/ObjectSetListenerWebsocket.test.ts
@@ -219,6 +219,7 @@ describe("ObjectSetListenerWebsocket", async () => {
           "employeeId",
           "fullName",
           "office",
+          "class",
           "startDate",
           "employeeStatus",
           "employeeSensor",
@@ -278,6 +279,8 @@ describe("ObjectSetListenerWebsocket", async () => {
               "object": {
                 "$apiName": "Employee",
                 "$objectType": "Employee",
+                "$primaryKey": undefined,
+                "$title": undefined,
                 "employeeId": 1,
               },
               "state": "ADDED_OR_UPDATED",
@@ -297,6 +300,7 @@ describe("ObjectSetListenerWebsocket", async () => {
                 "$apiName": "Employee",
                 "$objectType": "Employee",
                 "$primaryKey": "12345",
+                "$title": undefined,
                 "employeeId": "12345",
                 "employeeLocation": GeotimeSeriesPropertyImpl {
                   "lastFetchedValue": {

--- a/packages/foundry-sdk-generator/src/ontologyMetadata/__snapshots__/metadataResolver.test.ts.snap
+++ b/packages/foundry-sdk-generator/src/ontologyMetadata/__snapshots__/metadataResolver.test.ts.snap
@@ -84,6 +84,13 @@ exports[`Load Ontologies Metadata > Loads object and action types using only spe
           "pluralDisplayName": "Employees",
           "primaryKey": "employeeId",
           "properties": {
+            "class": {
+              "dataType": {
+                "type": "string",
+              },
+              "description": "",
+              "rid": "rid",
+            },
             "employeeId": {
               "dataType": {
                 "type": "integer",
@@ -274,6 +281,13 @@ exports[`Load Ontologies Metadata > Loads object and action types without link t
           "pluralDisplayName": "Employees",
           "primaryKey": "employeeId",
           "properties": {
+            "class": {
+              "dataType": {
+                "type": "string",
+              },
+              "description": "",
+              "rid": "rid",
+            },
             "employeeId": {
               "dataType": {
                 "type": "integer",

--- a/packages/shared.test/src/stubs/objectTypeV2.ts
+++ b/packages/shared.test/src/stubs/objectTypeV2.ts
@@ -46,6 +46,13 @@ export const employeeObjectType: ObjectTypeV2 = {
       },
       rid: "rid",
     },
+    class: {
+      description: "",
+      dataType: {
+        type: "string",
+      },
+      rid: "rid",
+    },
     startDate: {
       description:
         "The date the employee was hired (most recently, if they were re-hired)",


### PR DESCRIPTION
# BLUF

This PR removes the proxy objects in favor of simply adding functionality to objects from the wire. Originally this was to make it easier for people when they `console.log()` objects but additionally it seems we get a per object size reduction from `2,324 bytes` per object in this test bed to `1,332 bytes`. This does increase construction of the objects by `13%` which seems reasonable. 

# What does it cost us?

We lose a few things in this exchange:

- The ability to do `$updateInternalValues()` and have it reflect across any object that was `$as()`'d. OSDK objects effectively become immutable in this scenario. I think this is okay, it just removes some future ideas I had.
- An obvious tie in for telemetry metrics on per property usage. Before, in "telemetry mode" we would have been able to just hook into the proxy property access. We could still build this but will need to rethink how it would work.

# What else did we gain?

I think the code is a bit easier to reason about after we remove the proxies. Also the bundled minified client for nodejs (via esbuild) is reduced by about 4k in bytes.

# Other notes

In a separate repo where I originally experimented with this, retrieving properties from a proxy vs directly on an object was about 2x as expensive. So for anyone iterating over all of the objects returned, the 13% construction time increase would be saved on property access.

# Detailed benchmark info

On my machine, `createObjects.ts` benchmark stats prior (1b60b3d3):
```json
      "stats": {
        "time": {
          "std": 20.022638911991578,
          "mean": 542.9110000000001,
          "min": 523,
          "max": 593.92
        },
        "heapUsed": {
          "std": 44488.05771620065,
          "mean": 232406548.8,
          "min": 232355784,
          "max": 232456888
        },
        "rss": {
          "std": 2388346.6567709134,
          "mean": 237371392,
          "min": 233029632,
          "max": 241123328
        }
      }
```

So per object in the test data we were paying about `232406548.8/1000/100 ~= 2,324 bytes` per object.

On my machine, `createObjects.ts` benchmark stats after:
```json
      "stats": {
        "time": {
          "std": 19.36567313573169,
          "mean": 613.712,
          "min": 589.16,
          "max": 653.87
        },
        "heapUsed": {
          "std": 21950.770067585327,
          "mean": 133270992.8,
          "min": 133241184,
          "max": 133293728
        },
        "rss": {
          "std": 2037190.144079202,
          "mean": 158664294.4,
          "min": 155582464,
          "max": 162185216
        }
      }
```

`133270992.8/1000/100 ~= 1,332 bytes` per object.
