### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -81,7 +81,8 @@
     "@osdk/react": "0.2.1",
     "@osdk/examples.widget-react-sdk-2.x": "0.0.0",
     "@osdk/create-widget": "0.0.0",
-    "@osdk/create-widget.template.react.v2": "0.0.0"
+    "@osdk/create-widget.template.react.v2": "0.0.0",
+    "@osdk/benchmarks.primary": "0.0.0"
   },
   "changesets": [
     "blue-tips-heal",
@@ -94,6 +95,7 @@
     "cyan-suns-study",
     "dirty-lions-drive",
     "dirty-snails-punch",
+    "dry-foxes-fly",
     "dull-cherries-pay",
     "eighty-bulldogs-sniff",
     "eighty-kangaroos-sing",
@@ -125,9 +127,11 @@
     "long-rats-end",
     "lovely-eels-attend",
     "lovely-llamas-rescue",
+    "lovely-news-talk",
     "lucky-coins-breathe",
     "metal-parents-march",
     "mighty-mugs-clean",
+    "modern-spiders-sleep",
     "odd-fans-destroy",
     "old-clouds-wink",
     "olive-items-retire",
@@ -153,6 +157,7 @@
     "selfish-suits-thank",
     "seven-knives-hug",
     "shiny-bananas-knock",
+    "shiny-suns-cover",
     "short-bikes-fold",
     "shy-bees-fly",
     "shy-worms-share",

--- a/benchmarks/tests/primary/CHANGELOG.md
+++ b/benchmarks/tests/primary/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @osdk/benchmarks.primary
+
+## 0.1.0-beta.0
+
+### Patch Changes
+
+- @osdk/client@2.1.0-beta.17

--- a/benchmarks/tests/primary/package.json
+++ b/benchmarks/tests/primary/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/benchmarks.primary",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/api
 
+## 2.1.0-beta.17
+
 ## 2.1.0-beta.16
 
 ### Minor Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/api",
-  "version": "2.1.0-beta.16",
+  "version": "2.1.0-beta.17",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/cli.cmd.typescript
 
+## 0.25.0-beta.17
+
+### Minor Changes
+
+- 1b60b3d: Packages use more specific versions instead of indirection through shared.net
+
+### Patch Changes
+
+- Updated dependencies [1b60b3d]
+  - @osdk/shared.client.impl@1.1.0-beta.3
+  - @osdk/generator@2.1.0-beta.17
+  - @osdk/cli.common@0.25.0-beta.17
+
 ## 0.25.0-beta.16
 
 ### Patch Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.25.0-beta.16",
+  "version": "0.25.0-beta.17",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli.common/CHANGELOG.md
+++ b/packages/cli.common/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/cli.common
 
+## 0.25.0-beta.17
+
 ## 0.25.0-beta.16
 
 ### Minor Changes

--- a/packages/cli.common/package.json
+++ b/packages/cli.common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.common",
   "private": true,
-  "version": "0.25.0-beta.16",
+  "version": "0.25.0-beta.17",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/cli
 
+## 0.25.0-beta.17
+
+### Minor Changes
+
+- 1b60b3d: Packages use more specific versions instead of indirection through shared.net
+- b42399b: Site version and file limit custom error message and tips
+
 ## 0.25.0-beta.16
 
 ## 0.25.0-beta.15

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.25.0-beta.16",
+  "version": "0.25.0-beta.17",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client.test.ontology/CHANGELOG.md
+++ b/packages/client.test.ontology/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/client.test.ontology
 
+## 2.1.0-beta.17
+
+### Patch Changes
+
+- @osdk/api@2.1.0-beta.17
+
 ## 2.1.0-beta.16
 
 ### Patch Changes

--- a/packages/client.test.ontology/package.json
+++ b/packages/client.test.ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/client.test.ontology",
   "private": true,
-  "version": "2.1.0-beta.16",
+  "version": "2.1.0-beta.17",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.unstable/CHANGELOG.md
+++ b/packages/client.unstable/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/client.unstable
 
+## 2.1.0-beta.17
+
 ## 2.1.0-beta.16
 
 ## 2.1.0-beta.15

--- a/packages/client.unstable/package.json
+++ b/packages/client.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.unstable",
-  "version": "2.1.0-beta.16",
+  "version": "2.1.0-beta.17",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/client
 
+## 2.1.0-beta.17
+
+### Patch Changes
+
+- Updated dependencies [1b60b3d]
+  - @osdk/shared.client.impl@1.1.0-beta.3
+  - @osdk/api@2.1.0-beta.17
+  - @osdk/client.unstable@2.1.0-beta.17
+  - @osdk/generator-converters@2.1.0-beta.17
+
 ## 2.1.0-beta.16
 
 ### Minor Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client",
-  "version": "2.1.0-beta.16",
+  "version": "2.1.0-beta.17",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/create-app.template-packager/CHANGELOG.md
+++ b/packages/create-app.template-packager/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template-packager
 
+## 2.1.0-beta.17
+
 ## 2.1.0-beta.16
 
 ## 2.1.0-beta.15

--- a/packages/create-app.template-packager/package.json
+++ b/packages/create-app.template-packager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template-packager",
   "private": true,
-  "version": "2.1.0-beta.16",
+  "version": "2.1.0-beta.17",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.next-static-export.v2/CHANGELOG.md
+++ b/packages/create-app.template.next-static-export.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.next-static-export.v2
 
+## 2.1.0-beta.17
+
 ## 2.1.0-beta.16
 
 ## 2.1.0-beta.15

--- a/packages/create-app.template.next-static-export.v2/package.json
+++ b/packages/create-app.template.next-static-export.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.next-static-export.v2",
   "private": true,
-  "version": "2.1.0-beta.16",
+  "version": "2.1.0-beta.17",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.next-static-export/CHANGELOG.md
+++ b/packages/create-app.template.next-static-export/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.next-static-export
 
+## 2.1.0-beta.17
+
 ## 2.1.0-beta.16
 
 ## 2.1.0-beta.15

--- a/packages/create-app.template.next-static-export/package.json
+++ b/packages/create-app.template.next-static-export/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.next-static-export",
   "private": true,
-  "version": "2.1.0-beta.16",
+  "version": "2.1.0-beta.17",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react.beta/CHANGELOG.md
+++ b/packages/create-app.template.react.beta/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/create-app.template.react
 
+## 2.1.0-beta.17
+
+### Minor Changes
+
+- 1f7e0a1: "Fixes dependency on OSDK"
+
 ## 2.1.0-beta.16
 
 ## 2.1.0-beta.15

--- a/packages/create-app.template.react.beta/package.json
+++ b/packages/create-app.template.react.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react.beta",
   "private": true,
-  "version": "2.1.0-beta.16",
+  "version": "2.1.0-beta.17",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react/CHANGELOG.md
+++ b/packages/create-app.template.react/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.react
 
+## 2.1.0-beta.17
+
 ## 2.1.0-beta.16
 
 ## 2.1.0-beta.15

--- a/packages/create-app.template.react/package.json
+++ b/packages/create-app.template.react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react",
   "private": true,
-  "version": "2.1.0-beta.16",
+  "version": "2.1.0-beta.17",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-aip-app.beta
 
+## 2.1.0-beta.17
+
 ## 2.1.0-beta.16
 
 ## 2.1.0-beta.15

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app.beta",
   "private": true,
-  "version": "2.1.0-beta.16",
+  "version": "2.1.0-beta.17",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-aip-app
 
+## 2.1.0-beta.17
+
 ## 2.1.0-beta.16
 
 ## 2.1.0-beta.15

--- a/packages/create-app.template.tutorial-todo-aip-app/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app",
   "private": true,
-  "version": "2.1.0-beta.16",
+  "version": "2.1.0-beta.17",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-app.beta/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-app.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-app.beta
 
+## 2.1.0-beta.17
+
 ## 2.1.0-beta.16
 
 ## 2.1.0-beta.15

--- a/packages/create-app.template.tutorial-todo-app.beta/package.json
+++ b/packages/create-app.template.tutorial-todo-app.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app.beta",
   "private": true,
-  "version": "2.1.0-beta.16",
+  "version": "2.1.0-beta.17",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-app
 
+## 2.1.0-beta.17
+
 ## 2.1.0-beta.16
 
 ## 2.1.0-beta.15

--- a/packages/create-app.template.tutorial-todo-app/package.json
+++ b/packages/create-app.template.tutorial-todo-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app",
   "private": true,
-  "version": "2.1.0-beta.16",
+  "version": "2.1.0-beta.17",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.vue.v2/CHANGELOG.md
+++ b/packages/create-app.template.vue.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.vue.v2
 
+## 2.1.0-beta.17
+
 ## 2.1.0-beta.16
 
 ## 2.1.0-beta.15

--- a/packages/create-app.template.vue.v2/package.json
+++ b/packages/create-app.template.vue.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.vue.v2",
   "private": true,
-  "version": "2.1.0-beta.16",
+  "version": "2.1.0-beta.17",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.vue/CHANGELOG.md
+++ b/packages/create-app.template.vue/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.vue
 
+## 2.1.0-beta.17
+
 ## 2.1.0-beta.16
 
 ## 2.1.0-beta.15

--- a/packages/create-app.template.vue/package.json
+++ b/packages/create-app.template.vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.vue",
   "private": true,
-  "version": "2.1.0-beta.16",
+  "version": "2.1.0-beta.17",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app
 
+## 2.1.0-beta.17
+
 ## 2.1.0-beta.16
 
 ## 2.1.0-beta.15

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-app",
-  "version": "2.1.0-beta.16",
+  "version": "2.1.0-beta.17",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/create-widget.template.react.v2/CHANGELOG.md
+++ b/packages/create-widget.template.react.v2/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/create-widget.template.react.v2
 
+## 0.3.0-beta.2
+
+### Patch Changes
+
+- @osdk/client@2.1.0-beta.17
+- @osdk/widget-client.unstable@0.3.0-beta.2
+- @osdk/widget-client-react.unstable@0.3.0-beta.2
+
 ## 0.3.0-beta.1
 
 ### Patch Changes

--- a/packages/create-widget.template.react.v2/package.json
+++ b/packages/create-widget.template.react.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-widget.template.react.v2",
   "private": true,
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-widget/CHANGELOG.md
+++ b/packages/create-widget/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-widget
 
+## 0.3.0-beta.2
+
 ## 0.3.0-beta.1
 
 ## 0.2.0

--- a/packages/create-widget/package.json
+++ b/packages/create-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-widget",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0-beta.2",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/example-generator/CHANGELOG.md
+++ b/packages/example-generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/example-generator
 
+## 0.9.0-beta.16
+
+### Patch Changes
+
+- @osdk/create-app@2.1.0-beta.17
+- @osdk/create-widget@0.3.0-beta.2
+
 ## 0.9.0-beta.15
 
 ### Patch Changes

--- a/packages/example-generator/package.json
+++ b/packages/example-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/example-generator",
   "private": true,
-  "version": "0.9.0-beta.15",
+  "version": "0.9.0-beta.16",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @osdk/foundry-sdk-generator
 
+## 2.1.0-beta.17
+
+### Minor Changes
+
+- 1b60b3d: Packages use more specific versions instead of indirection through shared.net
+
+### Patch Changes
+
+- Updated dependencies [1b60b3d]
+  - @osdk/shared.client.impl@1.1.0-beta.3
+  - @osdk/client@2.1.0-beta.17
+  - @osdk/api@2.1.0-beta.17
+  - @osdk/generator@2.1.0-beta.17
+
 ## 2.1.0-beta.16
 
 ### Minor Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "2.1.0-beta.16",
+  "version": "2.1.0-beta.17",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-converters/CHANGELOG.md
+++ b/packages/generator-converters/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/generator-converters
 
+## 2.1.0-beta.17
+
+### Patch Changes
+
+- @osdk/api@2.1.0-beta.17
+
 ## 2.1.0-beta.16
 
 ### Patch Changes

--- a/packages/generator-converters/package.json
+++ b/packages/generator-converters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-converters",
-  "version": "2.1.0-beta.16",
+  "version": "2.1.0-beta.17",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-utils/CHANGELOG.md
+++ b/packages/generator-utils/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/generator-utils
 
+## 2.1.0-beta.17
+
 ## 2.1.0-beta.16
 
 ## 2.1.0-beta.15

--- a/packages/generator-utils/package.json
+++ b/packages/generator-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-utils",
-  "version": "2.1.0-beta.16",
+  "version": "2.1.0-beta.17",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/generator
 
+## 2.1.0-beta.17
+
+### Patch Changes
+
+- @osdk/api@2.1.0-beta.17
+- @osdk/generator-converters@2.1.0-beta.17
+
 ## 2.1.0-beta.16
 
 ### Patch Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "2.1.0-beta.16",
+  "version": "2.1.0-beta.17",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/maker/CHANGELOG.md
+++ b/packages/maker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/maker
 
+## 0.9.0-beta.17
+
+### Patch Changes
+
+- @osdk/api@2.1.0-beta.17
+
 ## 0.9.0-beta.16
 
 ### Minor Changes

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker",
-  "version": "0.9.0-beta.16",
+  "version": "0.9.0-beta.17",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdkkit/react
 
+## 0.3.0-beta.0
+
+### Minor Changes
+
+- 287de1d: Adjusts dependencies on @osdk/client and @osdk/api to work with prerelease packages
+
+### Patch Changes
+
+- @osdk/client@2.1.0-beta.17
+- @osdk/api@2.1.0-beta.17
+
 ## 0.2.1
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/react",
-  "version": "0.2.1",
+  "version": "0.3.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.client.impl/CHANGELOG.md
+++ b/packages/shared.client.impl/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/shared.client.impl
 
+## 1.1.0-beta.3
+
+### Minor Changes
+
+- 1b60b3d: Packages use more specific versions instead of indirection through shared.net
+
 ## 1.1.0-beta.2
 
 ### Minor Changes

--- a/packages/shared.client.impl/package.json
+++ b/packages/shared.client.impl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/shared.client.impl",
-  "version": "1.1.0-beta.2",
+  "version": "1.1.0-beta.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.net/CHANGELOG.md
+++ b/packages/shared.net/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/shared.net
 
+## 2.1.0-beta.3
+
+### Minor Changes
+
+- 1b60b3d: Packages use more specific versions instead of indirection through shared.net
+
+### Patch Changes
+
+- Updated dependencies [1b60b3d]
+  - @osdk/shared.client.impl@1.1.0-beta.3
+
 ## 2.1.0-beta.2
 
 ### Minor Changes

--- a/packages/shared.net/package.json
+++ b/packages/shared.net/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/shared.net",
-  "version": "2.1.0-beta.2",
+  "version": "2.1.0-beta.3",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/shared.test/CHANGELOG.md
+++ b/packages/shared.test/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/shared.test
 
+## 2.1.0-beta.17
+
+### Patch Changes
+
+- @osdk/api@2.1.0-beta.17
+
 ## 2.1.0-beta.16
 
 ### Patch Changes

--- a/packages/shared.test/package.json
+++ b/packages/shared.test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/shared.test",
   "private": true,
-  "version": "2.1.0-beta.16",
+  "version": "2.1.0-beta.17",
   "description": "",
   "access": "private",
   "license": "Apache-2.0",

--- a/packages/widget.api.unstable/CHANGELOG.md
+++ b/packages/widget.api.unstable/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/widget-api.unstable
 
+## 0.3.0-beta.2
+
 ## 0.3.0-beta.1
 
 ## 0.2.0

--- a/packages/widget.api.unstable/package.json
+++ b/packages/widget.api.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget-api.unstable",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0-beta.2",
   "description": "API contract between Foundry UIs that can embed custom widgets and the custom widgets themselves",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/widget.client-react.unstable/CHANGELOG.md
+++ b/packages/widget.client-react.unstable/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/widget-client-react.unstable
 
+## 0.3.0-beta.2
+
+### Patch Changes
+
+- @osdk/client@2.1.0-beta.17
+- @osdk/widget-client.unstable@0.3.0-beta.2
+
 ## 0.3.0-beta.1
 
 ### Patch Changes

--- a/packages/widget.client-react.unstable/package.json
+++ b/packages/widget.client-react.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget-client-react.unstable",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0-beta.2",
   "description": "Wrapper around @osdk/widget-client",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/widget.client.unstable/CHANGELOG.md
+++ b/packages/widget.client.unstable/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/widget-client.unstable
 
+## 0.3.0-beta.2
+
+### Patch Changes
+
+- @osdk/client@2.1.0-beta.17
+- @osdk/widget-api.unstable@0.3.0-beta.2
+
 ## 0.3.0-beta.1
 
 ### Patch Changes

--- a/packages/widget.client.unstable/package.json
+++ b/packages/widget.client.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget-client.unstable",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0-beta.2",
   "description": "Client that sets up listeners for the custom widgets embedded into Foundry, adhering to the contract laid out in @osdk/widget-api",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/widget.vite-plugin/CHANGELOG.md
+++ b/packages/widget.vite-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/widget-manifest-vite-plugin
 
+## 0.3.0-beta.2
+
+### Patch Changes
+
+- @osdk/widget-api.unstable@0.3.0-beta.2
+
 ## 0.3.0-beta.1
 
 ### Minor Changes

--- a/packages/widget.vite-plugin/package.json
+++ b/packages/widget.vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget-manifest-vite-plugin",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0-beta.2",
   "description": "A vite plugin that will extract parameter definitions from TS/JS files + entrypoint info into a manifest file to be uploaded to Foundry ",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/cli@0.25.0-beta.17

### Minor Changes

-   1b60b3d: Packages use more specific versions instead of indirection through shared.net
-   b42399b: Site version and file limit custom error message and tips

## @osdk/foundry-sdk-generator@2.1.0-beta.17

### Minor Changes

-   1b60b3d: Packages use more specific versions instead of indirection through shared.net

### Patch Changes

-   Updated dependencies [1b60b3d]
    -   @osdk/shared.client.impl@1.1.0-beta.3
    -   @osdk/client@2.1.0-beta.17
    -   @osdk/api@2.1.0-beta.17
    -   @osdk/generator@2.1.0-beta.17

## @osdk/react@0.3.0-beta.0

### Minor Changes

-   287de1d: Adjusts dependencies on @osdk/client and @osdk/api to work with prerelease packages

### Patch Changes

-   @osdk/client@2.1.0-beta.17
-   @osdk/api@2.1.0-beta.17

## @osdk/shared.client.impl@1.1.0-beta.3

### Minor Changes

-   1b60b3d: Packages use more specific versions instead of indirection through shared.net

## @osdk/shared.net@2.1.0-beta.3

### Minor Changes

-   1b60b3d: Packages use more specific versions instead of indirection through shared.net

### Patch Changes

-   Updated dependencies [1b60b3d]
    -   @osdk/shared.client.impl@1.1.0-beta.3

## @osdk/client@2.1.0-beta.17

### Patch Changes

-   Updated dependencies [1b60b3d]
    -   @osdk/shared.client.impl@1.1.0-beta.3
    -   @osdk/api@2.1.0-beta.17
    -   @osdk/client.unstable@2.1.0-beta.17
    -   @osdk/generator-converters@2.1.0-beta.17

## @osdk/generator@2.1.0-beta.17

### Patch Changes

-   @osdk/api@2.1.0-beta.17
-   @osdk/generator-converters@2.1.0-beta.17

## @osdk/generator-converters@2.1.0-beta.17

### Patch Changes

-   @osdk/api@2.1.0-beta.17

## @osdk/maker@0.9.0-beta.17

### Patch Changes

-   @osdk/api@2.1.0-beta.17

## @osdk/widget-client-react.unstable@0.3.0-beta.2

### Patch Changes

-   @osdk/client@2.1.0-beta.17
-   @osdk/widget-client.unstable@0.3.0-beta.2

## @osdk/widget-client.unstable@0.3.0-beta.2

### Patch Changes

-   @osdk/client@2.1.0-beta.17
-   @osdk/widget-api.unstable@0.3.0-beta.2

## @osdk/widget-manifest-vite-plugin@0.3.0-beta.2

### Patch Changes

-   @osdk/widget-api.unstable@0.3.0-beta.2

## @osdk/api@2.1.0-beta.17



## @osdk/client.unstable@2.1.0-beta.17



## @osdk/create-app@2.1.0-beta.17



## @osdk/create-widget@0.3.0-beta.2



## @osdk/generator-utils@2.1.0-beta.17



## @osdk/widget-api.unstable@0.3.0-beta.2



## @osdk/cli.cmd.typescript@0.25.0-beta.17

### Minor Changes

-   1b60b3d: Packages use more specific versions instead of indirection through shared.net

### Patch Changes

-   Updated dependencies [1b60b3d]
    -   @osdk/shared.client.impl@1.1.0-beta.3
    -   @osdk/generator@2.1.0-beta.17
    -   @osdk/cli.common@0.25.0-beta.17

## @osdk/create-app.template.react.beta@2.1.0-beta.17

### Minor Changes

-   1f7e0a1: "Fixes dependency on OSDK"

## @osdk/benchmarks.primary@0.1.0-beta.0

### Patch Changes

-   @osdk/client@2.1.0-beta.17

## @osdk/client.test.ontology@2.1.0-beta.17

### Patch Changes

-   @osdk/api@2.1.0-beta.17

## @osdk/create-widget.template.react.v2@0.3.0-beta.2

### Patch Changes

-   @osdk/client@2.1.0-beta.17
-   @osdk/widget-client.unstable@0.3.0-beta.2
-   @osdk/widget-client-react.unstable@0.3.0-beta.2

## @osdk/example-generator@0.9.0-beta.16

### Patch Changes

-   @osdk/create-app@2.1.0-beta.17
-   @osdk/create-widget@0.3.0-beta.2

## @osdk/shared.test@2.1.0-beta.17

### Patch Changes

-   @osdk/api@2.1.0-beta.17

## @osdk/cli.common@0.25.0-beta.17



## @osdk/create-app.template-packager@2.1.0-beta.17



## @osdk/create-app.template.next-static-export@2.1.0-beta.17



## @osdk/create-app.template.next-static-export.v2@2.1.0-beta.17



## @osdk/create-app.template.react@2.1.0-beta.17



## @osdk/create-app.template.tutorial-todo-aip-app@2.1.0-beta.17



## @osdk/create-app.template.tutorial-todo-aip-app.beta@2.1.0-beta.17



## @osdk/create-app.template.tutorial-todo-app@2.1.0-beta.17



## @osdk/create-app.template.tutorial-todo-app.beta@2.1.0-beta.17



## @osdk/create-app.template.vue@2.1.0-beta.17



## @osdk/create-app.template.vue.v2@2.1.0-beta.17


