### PR TITLE
Use workspace version for widget-client-react peer dependency

### DIFF
--- a/.changeset/nervous-spies-approve.md
+++ b/.changeset/nervous-spies-approve.md
@@ -1,0 +1,5 @@
+---
+"@osdk/widget-client-react.unstable": patch
+---
+
+Use workspace version for widget-client peer dependency

--- a/packages/widget.client-react.unstable/package.json
+++ b/packages/widget.client-react.unstable/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "@osdk/client": "^2",
-    "@osdk/widget-client.unstable": "^0.1.0",
+    "@osdk/widget-client.unstable": "workspace:~",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "react": "^18",


### PR DESCRIPTION
This peer dependency being pinned to `^0.1.0` prevents taking equal versions for both `@osdk/widget-client-react.unstable` and `@osdk/widget-client.unstable` as is desired.