### PR TITLE
Support site snapshot upload

### DIFF
--- a/.changeset/brave-toes-work.md
+++ b/.changeset/brave-toes-work.md
@@ -1,0 +1,5 @@
+---
+"@osdk/cli": patch
+---
+
+Support site snapshot upload

--- a/packages/cli/src/commands/site/deploy/SiteDeployArgs.ts
+++ b/packages/cli/src/commands/site/deploy/SiteDeployArgs.ts
@@ -23,4 +23,6 @@ export interface SiteDeployArgs extends CommonSiteArgs {
   uploadOnly: boolean;
   autoVersion?: AutoVersionConfigType;
   gitTagPrefix?: string;
+  snapshot: boolean;
+  snapshotId?: string;
 }

--- a/packages/cli/src/commands/site/deploy/index.ts
+++ b/packages/cli/src/commands/site/deploy/index.ts
@@ -78,6 +78,17 @@ const command: CommandModule<
             ? { default: gitTagPrefix }
             : {},
         },
+        snapshot: {
+          type: "boolean",
+          description:
+            "Upload a snapshot version only with automatic retention",
+          default: false,
+        },
+        snapshotId: {
+          type: "string",
+          description:
+            "Optional id to associate with snapshot version as an alias",
+        },
       })
       .group(
         ["directory", "version", "uploadOnly"],
@@ -86,6 +97,10 @@ const command: CommandModule<
       .group(
         ["autoVersion", "gitTagPrefix"],
         "Auto Version Options",
+      )
+      .group(
+        ["snapshot", "snapshotId"],
+        "Snapshot Options",
       )
       .check((args) => {
         // This is required because we can't use demandOption with conflicts. conflicts protects us against the case where both are provided.
@@ -117,6 +132,18 @@ const command: CommandModule<
         if (gitTagPrefixValue != null && autoVersionType !== "git-describe") {
           throw new YargsCheckError(
             `--gitTagPrefix is only supported when --autoVersion=git-describe`,
+          );
+        }
+
+        if (args.uploadOnly && args.snapshot) {
+          throw new YargsCheckError(
+            `--uploadOnly and --snapshot cannot be enabled together`,
+          );
+        }
+
+        if (args.snapshotId != null && !args.snapshot) {
+          throw new YargsCheckError(
+            "--snapshotId is only supported when --snapshot is enabled",
           );
         }
 

--- a/packages/cli/src/net/third-party-applications/index.mts
+++ b/packages/cli/src/net/third-party-applications/index.mts
@@ -21,6 +21,7 @@ export { getWebsite } from "./getWebsite.mjs";
 export { listVersions } from "./listVersions.mjs";
 export type { ListVersionsResponse } from "./ListVersionsResponse.mjs";
 export { undeployWebsite } from "./undeployWebsite.mjs";
+export { uploadSnapshotVersion } from "./uploadSnapshotVersion.mjs";
 export { uploadVersion } from "./uploadVersion.mjs";
 export type { Version } from "./Version.mjs";
 export type { Website } from "./Website.mjs";

--- a/packages/cli/src/net/third-party-applications/uploadSnapshotVersion.mts
+++ b/packages/cli/src/net/third-party-applications/uploadSnapshotVersion.mts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createFetch } from "../createFetch.mjs";
+import type { InternalClientContext } from "../internalClientContext.mjs";
+import type { ThirdPartyAppRid } from "../ThirdPartyAppRid.js";
+import type { Version } from "./Version.mjs";
+
+export async function uploadSnapshotVersion(
+  ctx: InternalClientContext,
+  thirdPartyAppRid: ThirdPartyAppRid,
+  version: string,
+  snapshotId: string,
+  zipFile: ReadableStream | Blob | BufferSource,
+): Promise<Version> {
+  const fetch = createFetch(ctx.tokenProvider);
+  const url =
+    `${ctx.foundryUrl}/api/v2/thirdPartyApplications/${thirdPartyAppRid}/website/versions/uploadSnapshot?version=${version}&preview=true${
+      snapshotId !== ""
+        ? `&snapshotIdentifier=${snapshotId}`
+        : ""
+    }`;
+
+  const result = await fetch(
+    url,
+    {
+      method: "POST",
+      body: zipFile,
+      headers: {
+        "Content-Type": "application/octet-stream",
+      },
+      duplex: "half", // Node hates me
+    } satisfies RequestInit & { duplex: "half" } as any,
+  );
+  return result.json();
+}


### PR DESCRIPTION
Allow specifying `--snapshot` to opt-in to uploading versions to a different bucket which have automatic retention. An optional `--snapshotId` can be additionally specified in order to associate an alias with the version. This will be used for PR previews using a specific snapshot identifier format