### PR TITLE
Bump unstable widget packages to v1 to avoid undesired v0.x version behavior

### DIFF
--- a/.changeset/big-readers-refuse.md
+++ b/.changeset/big-readers-refuse.md
@@ -1,0 +1,7 @@
+---
+"@osdk/widget-client-react.unstable": major
+"@osdk/widget-client.unstable": major
+"@osdk/widget-api.unstable": major
+---
+
+Bump unstable widget packages to v1 to avoid undesired v0.x version behavior

--- a/packages/widget.api.unstable/package.json
+++ b/packages/widget.api.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget-api.unstable",
-  "version": "0.3.0-beta.3",
+  "version": "1.0.0",
   "description": "API contract between Foundry UIs that can embed custom widgets and the custom widgets themselves",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/widget.client-react.unstable/package.json
+++ b/packages/widget.client-react.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget-client-react.unstable",
-  "version": "0.3.0-beta.3",
+  "version": "1.0.0",
   "description": "Wrapper around @osdk/widget-client",
   "access": "public",
   "license": "Apache-2.0",
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "@osdk/client": "^2",
-    "@osdk/widget-client.unstable": "^0.1.0",
+    "@osdk/widget-client.unstable": "workspace:~",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "react": "^18",

--- a/packages/widget.client.unstable/package.json
+++ b/packages/widget.client.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget-client.unstable",
-  "version": "0.3.0-beta.3",
+  "version": "1.0.0",
   "description": "Client that sets up listeners for the custom widgets embedded into Foundry, adhering to the contract laid out in @osdk/widget-api",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
We are already using throwaway `*-unstable` names for these packages and we can make the downstream consumption story much simpler if we use a `v1.x` version range. E.g. we won't need to bump our deployed template bundles every time we do a minor version release.

When we exit the unstable mode for these packages we can reset to `v1.0.0`