### PR TITLE
Remove crypto from OSDK

### DIFF
--- a/.changeset/red-carpets-wave.md
+++ b/.changeset/red-carpets-wave.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Removes dependency on crypto

--- a/packages/client/src/objectSet/ObjectSetListenerWebsocket.ts
+++ b/packages/client/src/objectSet/ObjectSetListenerWebsocket.ts
@@ -141,6 +141,11 @@ export class ObjectSetListenerWebsocket {
     string,
     Subscription<any, any>
   >();
+
+  #endedSubscriptions = new Set<
+    string
+  >();
+
   #maybeDisconnectTimeout: ReturnType<typeof setTimeout> | undefined;
 
   // DO NOT CONSTRUCT DIRECTLY. ONLY EXPOSED AS A TESTING SEAM
@@ -171,12 +176,6 @@ export class ObjectSetListenerWebsocket {
     listener: ObjectSetListener<Q, P>,
     properties: Array<P> = [],
   ): Promise<() => void> {
-    if (process.env.TARGET !== "browser") {
-      // Node 18 does not expose 'crypto' on globalThis, so we need to do it ourselves. This
-      // will not be needed after our minimum version is 19 or greater.
-      globalThis.crypto ??= (await import("node:crypto")).webcrypto as any;
-    }
-
     const objDef = objectType.type === "object"
       ? await this.#client.ontologyProvider.getObjectDefinition(
         objectType.apiName,
@@ -216,7 +215,7 @@ export class ObjectSetListenerWebsocket {
       status: "preparing",
       // Since we don't have a real subscription id yet but we need to keep
       // track of this reference, we can just use a random uuid.
-      subscriptionId: `TMP-${crypto.randomUUID()}`,
+      subscriptionId: `TMP-${nextUuid()}}`,
       interfaceApiName: objDef.type === "object"
         ? undefined
         : objDef.apiName,
@@ -275,18 +274,7 @@ export class ObjectSetListenerWebsocket {
     // so we filter those out.
     const readySubs = [...this.#subscriptions.values()].filter(isReady);
 
-    if (readySubs.length === 0) {
-      if (process.env.NODE_ENV !== "production") {
-        this.#logger?.trace(
-          "#sendSubscribeMessage(): aborting due to no ready subscriptions",
-        );
-      }
-
-      return;
-    }
-
-    // Assumes the node 18 crypto fallback to globalThis in `subscribe` has happened.
-    const id = crypto.randomUUID();
+    const id = nextUuid();
     // responses come back as an array of subIds, so we need to know the sources
     this.#pendingSubscriptions.set(id, readySubs);
 
@@ -327,11 +315,16 @@ export class ObjectSetListenerWebsocket {
       // if we are already done, we don't need to do anything
       return;
     }
+
     sub.status = newStatus;
+
     // make sure listeners do nothing now
     sub.listener = fillOutListener<Q, any>({});
+
     this.#subscriptions.delete(sub.subscriptionId);
+    this.#endedSubscriptions.add(sub.subscriptionId);
     this.#sendSubscribeMessage();
+
     // If we have no more subscriptions, we can disconnect the websocket
     // however we should wait a bit to see if we get any more subscriptions.
     // For example, when switching between react views, you may unsubscribe
@@ -572,6 +565,7 @@ export class ObjectSetListenerWebsocket {
 
   #handleMessage_subscriptionClosed(payload: SubscriptionClosed) {
     const sub = this.#subscriptions.get(payload.id);
+    if (sub == null && this.#endedSubscriptions.has(payload.id)) return;
     invariant(sub, `Expected subscription id ${payload.id}`);
     sub.listener.onError([payload.cause]);
     this.#unsubscribe(sub, "error");
@@ -632,4 +626,12 @@ export function constructWebsocketUrl(
   );
   url.protocol = url.protocol.replace("https", "wss");
   return url;
+}
+
+let uuidCounter = 0;
+
+function nextUuid() {
+  return `00000000-0000-0000-0000-${
+    (uuidCounter++).toString().padStart(12, "0")
+  }`;
 }


### PR DESCRIPTION
React-native has issues with dependencies on crypto. Removes our polyfill and usage in object set watcher. Also fixes a small bug that can cause issues with unsubscribing with multiple subscriptions