### PR TITLE
Add package.json auto version strategy

### DIFF
--- a/.changeset/giant-cows-play.md
+++ b/.changeset/giant-cows-play.md
@@ -1,0 +1,5 @@
+---
+"@osdk/cli": patch
+---
+
+Add package.json auto version strategy

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -80,12 +80,14 @@ Auto Version options
 
 | Option         | Description                                                                                                                                                         |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| --autoVersion  | Enable auto versioning [string][choices: "git-describe"]                                                                                                            |
+| --autoVersion  | Enable auto versioning [string][choices: "git-describe", "package-json"]                                                                                            |
 | --gitTagPrefix | Prefix to match git tags on when 'git-describe' auto versioning is used. If not provided, all tags are matched and the prefix 'v ' is stripped if present. [string] |
 
 `--version` and `--autoVersion` are mutually exclusive and only one can be passed.
 
 If `git-describe` is used for `--autoVersion`, the CLI will try to infer the version by running the `git describe` command with optionally `--match=<gitTagPrefix>` set if `--gitTagPrefix` is passed.
+
+If `package-json` is used for `--autoVersion`, the CLI will try to infer the version by looking at the `version` field of the nearest `package.json` file. The current working directory will be traversed up to the root directory and the first `package.json` file, if found, will be used.
 
 ### `version` subcommand
 

--- a/packages/cli/src/commands/site/deploy/index.ts
+++ b/packages/cli/src/commands/site/deploy/index.ts
@@ -37,7 +37,9 @@ const command: CommandModule<
     const siteConfig: SiteConfig | undefined = config?.foundryConfig.site;
     const directory = siteConfig?.directory;
     const autoVersion = siteConfig?.autoVersion;
-    const gitTagPrefix = autoVersion?.tagPrefix;
+    const gitTagPrefix = autoVersion?.type === "git-describe"
+      ? autoVersion.tagPrefix
+      : undefined;
     const uploadOnly = siteConfig?.uploadOnly;
 
     return argv
@@ -64,7 +66,7 @@ const command: CommandModule<
         autoVersion: {
           coerce: (autoVersion) => autoVersion as AutoVersionConfigType,
           type: "string",
-          choices: ["git-describe"],
+          choices: ["git-describe", "package-json"],
           description: "Enable auto versioning",
           ...(autoVersion != null)
             ? { default: autoVersion.type }
@@ -121,9 +123,12 @@ const command: CommandModule<
         }
 
         const autoVersionType = args.autoVersion ?? autoVersion;
-        if (autoVersionType !== "git-describe") {
+        if (
+          autoVersionType !== "git-describe"
+          && autoVersionType !== "package-json"
+        ) {
           throw new YargsCheckError(
-            `Only 'git-describe' is supported for autoVersion`,
+            `Only 'git-describe' and 'package-json' are supported for autoVersion`,
           );
         }
 

--- a/packages/cli/src/commands/site/deploy/logDeployCommandConfigFileOverride.ts
+++ b/packages/cli/src/commands/site/deploy/logDeployCommandConfigFileOverride.ts
@@ -38,7 +38,8 @@ export async function logDeployCommandConfigFileOverride(
   }
 
   if (
-    config?.autoVersion?.tagPrefix != null
+    config?.autoVersion?.type === "git-describe"
+    && config.autoVersion.tagPrefix != null
     && args.gitTagPrefix != null
     && args.gitTagPrefix !== config.autoVersion.tagPrefix
   ) {

--- a/packages/cli/src/commands/site/deploy/siteDeployCommand.mts
+++ b/packages/cli/src/commands/site/deploy/siteDeployCommand.mts
@@ -58,7 +58,7 @@ export default async function siteDeployCommand(
   if (typeof selectedVersion === "string") {
     siteVersion = selectedVersion;
   } else {
-    siteVersion = await findAutoVersion(selectedVersion.tagPrefix);
+    siteVersion = await findAutoVersion(selectedVersion);
     consola.info(
       `Auto version inferred next version to be: ${siteVersion}`,
     );

--- a/packages/cli/src/util/config.test.ts
+++ b/packages/cli/src/util/config.test.ts
@@ -74,6 +74,29 @@ describe("loadFoundryConfig", () => {
     });
   });
 
+  it("should load and parse package.json auto version strategy", async () => {
+    const correctConfig = {
+      foundryUrl: "http://localhost",
+      site: {
+        application: "test-app",
+        directory: "/test/directory",
+        autoVersion: {
+          type: "package-json",
+        },
+      },
+    };
+
+    vi.mocked(fsPromises.readFile).mockResolvedValue(
+      JSON.stringify(correctConfig),
+    );
+    await expect(loadFoundryConfig()).resolves.toEqual({
+      configFilePath: "/path/foundry.config.json",
+      foundryConfig: {
+        ...correctConfig,
+      },
+    });
+  });
+
   it("should throw an error if autoVersion type isn't allowed", async () => {
     const inCorrectConfig = {
       foundryUrl: "http://localhost",
@@ -110,7 +133,7 @@ describe("loadFoundryConfig", () => {
     );
 
     await expect(loadFoundryConfig()).rejects.toThrow(
-      "The configuration file does not match the expected schema: data/site/autoVersion must have required property 'type'",
+      "The configuration file does not match the expected schema: data/site/autoVersion must match exactly one schema in oneOf",
     );
   });
 

--- a/packages/cli/src/util/config.ts
+++ b/packages/cli/src/util/config.ts
@@ -23,7 +23,12 @@ export interface GitDescribeAutoVersionConfig {
   type: "git-describe";
   tagPrefix?: string;
 }
-export type AutoVersionConfig = GitDescribeAutoVersionConfig;
+export interface PackageJsonAutoVersionConfig {
+  type: "package-json";
+}
+export type AutoVersionConfig =
+  | GitDescribeAutoVersionConfig
+  | PackageJsonAutoVersionConfig;
 export type AutoVersionConfigType = AutoVersionConfig["type"];
 export interface SiteConfig {
   application: string;
@@ -63,6 +68,11 @@ const CONFIG_FILE_SCHEMA: JSONSchemaType<FoundryConfig> = {
               properties: {
                 type: { const: "git-describe", type: "string" },
                 tagPrefix: { type: "string", nullable: true },
+              },
+            },
+            {
+              properties: {
+                type: { const: "package-json", type: "string" },
               },
             },
           ],


### PR DESCRIPTION
This PR adds a `package-json` auto version strategy to `@osdk/cli` as an alternative way of inferring a version from the `git-describe` strategy.

The vite plugin currently manually reads package.json version field to populate the widgets.config.json manifest. We will want to move this over to share the foundry.config.json parsing and auto version utils from `@osdk/cli` so that they can use the same git-describe strategy. Although we won't use the `package-json` strategy as the default it still makes sense to support this as a way of inferring versions.

https://github.com/palantir/osdk-ts/blob/720218d1e6d0251ed66604d849cdc5d47ff025d9/packages/widget.vite-plugin/src/plugin.ts#L470-L511