### PR TITLE
Handle Vite plugin injections in Custom Widget Vite plugin

### DIFF
--- a/.changeset/long-frogs-reflect.md
+++ b/.changeset/long-frogs-reflect.md
@@ -1,0 +1,5 @@
+---
+"@osdk/widget-manifest-vite-plugin": patch
+---
+
+Handle Vite plugin injections in Custom Widget Vite plugin

--- a/packages/widget.vite-plugin/src/constants.ts
+++ b/packages/widget.vite-plugin/src/constants.ts
@@ -16,3 +16,4 @@
 
 export const PALANTIR_PATH = ".palantir";
 export const SETUP_PATH = `${PALANTIR_PATH}/setup`;
+export const VITE_INJECTIONS = `${PALANTIR_PATH}/vite-injections.js`;

--- a/packages/widget.vite-plugin/src/plugin.ts
+++ b/packages/widget.vite-plugin/src/plugin.ts
@@ -257,39 +257,39 @@ export function FoundryWidgetVitePlugin(options: Options = {}): Plugin {
               return;
             }
 
-            const settingsResponse = await setWidgetSettings(
-              // TODO: Actually handle the widget RID from within the config, which will require somehow parsing the config
-              // Unfortunately, moduleParsed is not called during vite's dev mode for performance reasons, so the config file
-              // will need to be parsed/read a different way
-              foundryConfig.widget.rid,
-              foundryUrl,
-              localhostUrl,
-              entrypointToJsSourceFileMap,
-              entrypointFileName,
-            );
-            if (
-              settingsResponse.status !== 200
-            ) {
-              res.statusCode = settingsResponse.status;
-              res.statusMessage =
-                `Unable to set widget settings in Foundry: ${settingsResponse.statusText}`;
-              settingsResponse.text().then((err) => {
-                config?.logger.error(err);
-                res.end();
-              });
-              return;
-            }
-
-            const enableResponse = await enableDevMode(foundryUrl);
-            if (enableResponse.status !== 200) {
-              res.statusCode = enableResponse.status;
-              res.statusMessage =
-                `Unable to start dev mode in Foundry: ${enableResponse.statusText}`;
-              res.end();
-              return;
-            }
-
             try {
+              const settingsResponse = await setWidgetSettings(
+                // TODO: Actually handle the widget RID from within the config, which will require somehow parsing the config
+                // Unfortunately, moduleParsed is not called during vite's dev mode for performance reasons, so the config file
+                // will need to be parsed/read a different way
+                foundryConfig.widget.rid,
+                foundryUrl,
+                localhostUrl,
+                entrypointToJsSourceFileMap,
+                entrypointFileName,
+              );
+              if (
+                settingsResponse.status !== 200
+              ) {
+                res.statusCode = settingsResponse.status;
+                res.statusMessage =
+                  `Unable to set widget settings in Foundry: ${settingsResponse.statusText}`;
+                settingsResponse.text().then((err) => {
+                  config?.logger.error(err);
+                  res.end();
+                });
+                return;
+              }
+
+              const enableResponse = await enableDevMode(foundryUrl);
+              if (enableResponse.status !== 200) {
+                res.statusCode = enableResponse.status;
+                res.statusMessage =
+                  `Unable to start dev mode in Foundry: ${enableResponse.statusText}`;
+                res.end();
+                return;
+              }
+
               res.setHeader("Content-Type", "application/json");
               res.end(
                 JSON.stringify({


### PR DESCRIPTION
Vite plugins are able to inject scripts & javascript into the target HTML entrypoint file, which in the case of the React plugin inserts some code as an inline script tag which enables hot module refresh ([source](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/src/fast-refresh.ts#L23)). As we are server-side rendering our HTML file, we need to capture these injections and get them onto the page before other scripts using a different mechanism.

Vite exposes access to other plugins from our own, and on these plugins we are able to call the `transformIndexHtml` hook (if present). This hook returns descriptors of the scripts that would be injected. The actual return format is more complex than the cases I'm selecting from here, so we may need to expand this in the future. Its well typed & structured but I don't have a sense of how widely used this mechanism is yet, and so want to cap the effort.

This has led me to question whether Vite is the right tool for us to focus on here, given that Vite expects full control of the HTML file whereas we expect to manage it (https://vite.dev/guide/#index-html-and-project-root). We should push forwards with what we have now, but it's worth bearing this in mind and potentially experimenting with out build tools.

Also started to break this code up, which I'll continue to do in FLUPs. Also fixed the `set-settings` call and introduced the `enable` call based on latest API changes.

------

#### Example HTML file compiled by Vite
```html
<!doctype html>
<html lang="en">
  <head>
    <script type="module">
        import RefreshRuntime from "/@react-refresh"
        RefreshRuntime.injectIntoGlobalHook(window)
        window.$RefreshReg$ = () => {}
        window.$RefreshSig$ = () => (type) => type
        window.__vite_plugin_react_preamble_installed__ = true
    </script>
    <script type="module" src="/@vite/client"></script>
    <meta charset="UTF-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>Widget: Ontology SDK + React</title>
  </head>
  <body>
    <script type="module" src="/src/main.tsx"></script>
  </body>
</html>
```

#### The contents of the auto-generated `vite-injections.js` in this case:
```javascript
import RefreshRuntime from "/@react-refresh"
RefreshRuntime.injectIntoGlobalHook(window)
window.$RefreshReg$ = () => {}
window.$RefreshSig$ = () => (type) => type
window.__vite_plugin_react_preamble_installed__ = true
```
