### PR TITLE
Fixing main

### DIFF
--- a/.changeset/ten-bees-fix.md
+++ b/.changeset/ten-bees-fix.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client": patch
+"@osdk/api": patch
+---
+
+Remove unused imports.

--- a/packages/api/src/Definitions.ts
+++ b/packages/api/src/Definitions.ts
@@ -16,7 +16,6 @@
 
 import type {
   GetClientPropertyValueFromWire,
-  PropertyValueWireToClient,
 } from "./mapping/PropertyValueMapping.js";
 import type { ObjectMetadata } from "./ontology/ObjectTypeDefinition.js";
 

--- a/packages/api/src/aggregate/AggregatableKeys.ts
+++ b/packages/api/src/aggregate/AggregatableKeys.ts
@@ -16,7 +16,6 @@
 
 import type {
   GetWirePropertyValueFromClient,
-  PropertyValueClientToWire,
 } from "../mapping/PropertyValueMapping.js";
 import type {
   ObjectOrInterfaceDefinition,

--- a/packages/client/src/object/aggregate.test.ts
+++ b/packages/client/src/object/aggregate.test.ts
@@ -17,10 +17,7 @@
 import type {
   AggregateOpts,
   AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy,
-  CompileTimeMetadata,
   GroupByClause,
-  ObjectOrInterfaceDefinition,
-  PropertyKeys,
   ValidAggregationKeys,
 } from "@osdk/api";
 import type { Employee } from "@osdk/client.test.ontology";


### PR DESCRIPTION
 We turned on ES Lint last week, but my PR's tests ran before that was enabled, so fixing ES lint errors in this. Just removes unused imports