### PR TITLE
Correct widget template package dependency versions

### DIFF
--- a/.changeset/tender-apricots-tell.md
+++ b/.changeset/tender-apricots-tell.md
@@ -1,0 +1,5 @@
+---
+"@osdk/create-widget.template.react.v2": patch
+---
+
+Correct widget template package dependency versions

--- a/examples/example-widget-react-sdk-2.x/package.json
+++ b/examples/example-widget-react-sdk-2.x/package.json
@@ -15,10 +15,10 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
-    "@osdk/client": "workspace:~",
+    "@osdk/client": "workspace:*",
     "@osdk/e2e.generated.catchall": "workspace:*",
-    "@osdk/widget-client-react.unstable": "workspace:~",
-    "@osdk/widget-client.unstable": "workspace:~",
+    "@osdk/widget-client-react.unstable": "^1.0.0",
+    "@osdk/widget-client.unstable": "^1.0.0",
     "@radix-ui/react-icons": "^1.3.1",
     "@radix-ui/themes": "^3.1.4",
     "react": "^18",
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@eslint/compat": "^1.2.1",
     "@eslint/js": "^9.13.0",
-    "@osdk/widget.vite-plugin.unstable": "workspace:~",
+    "@osdk/widget.vite-plugin.unstable": "^1.0.0",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@typescript-eslint/eslint-plugin": "^8.11.0",

--- a/examples/example-widget-react-sdk-2.x/package.json
+++ b/examples/example-widget-react-sdk-2.x/package.json
@@ -17,8 +17,8 @@
   "dependencies": {
     "@osdk/client": "workspace:*",
     "@osdk/e2e.generated.catchall": "workspace:*",
-    "@osdk/widget-client-react.unstable": "^1.0.0",
-    "@osdk/widget-client.unstable": "^1.0.0",
+    "@osdk/widget-client-react.unstable": "workspace:*",
+    "@osdk/widget-client.unstable": "workspace:*",
     "@radix-ui/react-icons": "^1.3.1",
     "@radix-ui/themes": "^3.1.4",
     "react": "^18",
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@eslint/compat": "^1.2.1",
     "@eslint/js": "^9.13.0",
-    "@osdk/widget.vite-plugin.unstable": "^1.0.0",
+    "@osdk/widget.vite-plugin.unstable": "workspace:*",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@typescript-eslint/eslint-plugin": "^8.11.0",

--- a/packages/create-widget.template.react.v2/package.json
+++ b/packages/create-widget.template.react.v2/package.json
@@ -29,9 +29,6 @@
     "transpile": "monorepo.tool.transpile"
   },
   "dependencies": {
-    "@osdk/client": "workspace:~",
-    "@osdk/widget-client-react.unstable": "workspace:~",
-    "@osdk/widget-client.unstable": "workspace:~",
     "@radix-ui/react-icons": "^1.3.1",
     "@radix-ui/themes": "^3.1.4",
     "react": "^18",
@@ -45,7 +42,6 @@
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
     "@osdk/monorepo.tsup": "workspace:~",
-    "@osdk/widget.vite-plugin.unstable": "workspace:~",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@typescript-eslint/eslint-plugin": "^8.11.0",

--- a/packages/create-widget.template.react.v2/templates/package.json.hbs
+++ b/packages/create-widget.template.react.v2/templates/package.json.hbs
@@ -11,10 +11,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "{{osdkPackage}}": "latest"
-    
+    "{{osdkPackage}}": "latest",
+    "@osdk/client": "^2.0.0",
+    "@osdk/widget-client-react.unstable": "^1.0.0",
+    "@osdk/widget-client.unstable": "^1.0.0"
   },
   "devDependencies": {
-    
+    "@osdk/widget.vite-plugin.unstable": "^1.0.0"
   }
 }

--- a/packages/example-generator/src/run.ts
+++ b/packages/example-generator/src/run.ts
@@ -330,6 +330,21 @@ const UPDATE_PACKAGE_JSON: Mutator = {
         `"@osdk/oauth": "workspace:*"`,
       )
       .replace(
+        // Use locally generated SDK in the monorepo
+        /"@osdk\/widget-client-react.unstable": "\^.*?"/,
+        `"@osdk/widget-client-react.unstable": "workspace:*"`,
+      )
+      .replace(
+        // Use locally generated SDK in the monorepo
+        /"@osdk\/widget-client.unstable": "\^.*?"/,
+        `"@osdk/widget-client.unstable": "workspace:*"`,
+      )
+      .replace(
+        // Use locally generated SDK in the monorepo
+        /"@osdk\/widget.vite-plugin.unstable": "\^.*?"/,
+        `"@osdk/widget.vite-plugin.unstable": "workspace:*"`,
+      )
+      .replace(
         // Follow monorepo package naming convention
         `"name": "${sdkVersionedTemplateExampleId(template, sdkVersion)}"`,
         `"name": "@osdk/examples.${

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1050,11 +1050,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/e2e.generated.catchall
       '@osdk/widget-client-react.unstable':
-        specifier: ^1.0.0
-        version: 1.0.0(@osdk/client@packages+client)(@osdk/widget-client.unstable@1.0.0(@osdk/client@packages+client))(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: workspace:*
+        version: link:../../packages/widget.client-react.unstable
       '@osdk/widget-client.unstable':
-        specifier: ^1.0.0
-        version: 1.0.0(@osdk/client@packages+client)
+        specifier: workspace:*
+        version: link:../../packages/widget.client.unstable
       '@radix-ui/react-icons':
         specifier: ^1.3.1
         version: 1.3.2(react@18.3.1)
@@ -1078,8 +1078,8 @@ importers:
         specifier: ^9.13.0
         version: 9.15.0
       '@osdk/widget.vite-plugin.unstable':
-        specifier: ^1.0.0
-        version: 1.0.0(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))
+        specifier: workspace:*
+        version: link:../../packages/widget.vite-plugin.unstable
       '@types/react':
         specifier: ^18
         version: 18.3.12
@@ -6344,32 +6344,6 @@ packages:
 
   '@osdk/shared.net@1.12.1':
     resolution: {integrity: sha512-uJE124K3O21A1Of2TdOqMHBfrIYshcDSLr5em4v1vNZZGSsSCYUYGo5vvkS6vzUVDA2xSn/Uf2FgdzX6BWxIhQ==}
-
-  '@osdk/widget-api.unstable@1.0.0':
-    resolution: {integrity: sha512-c8ws68RLRWCdVuqevv2QPWxNY3FIe4P0Qn37lbcbTwpKlU4P2ewhFJm9q6BOIhyqX9ucU/LyNnq+rzN1dNa9/w==}
-
-  '@osdk/widget-api.unstable@2.0.0-beta.4':
-    resolution: {integrity: sha512-XQHE1SC/InHFi8EFz77pfkWCfuOXdbuuZ60VnR2t1XLt4HJgnazZNCMqp9fUoFei6lGKSpURjObqxZyNO6xdJQ==}
-
-  '@osdk/widget-client-react.unstable@1.0.0':
-    resolution: {integrity: sha512-w7luVCQhbKQEVU3hyq8Hd7nQ5cd28yxWT9qMn8d3mfUi0BcuD1qJVjeshUxk4eF01zXG8VL3PmKWEkIUd40L7Q==}
-    peerDependencies:
-      '@osdk/client': ^2
-      '@osdk/widget-client.unstable': ~1.0.0
-      '@types/react': ^18
-      '@types/react-dom': ^18
-      react: ^18
-      react-dom: '18'
-
-  '@osdk/widget-client.unstable@1.0.0':
-    resolution: {integrity: sha512-Gg4EdOZBrGWo1iOBr4J99H7NKr8REUpRKPBape1iVqqz291ur2goqsjd3dyWpDDV3vhuU62Uo3e+RqtOzDN+fw==}
-    peerDependencies:
-      '@osdk/client': ^2
-
-  '@osdk/widget.vite-plugin.unstable@1.0.0':
-    resolution: {integrity: sha512-tShTx3RYn2E7mBtEJP1atWV+hJ8iOeiwtEsDBazqMBAsfljfnwgK5aCx5ppLg+zq2W5dyfGmXFo6BVVuM67aPQ==}
-    peerDependencies:
-      vite: ^5.0.0
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -17164,34 +17138,6 @@ snapshots:
       '@osdk/shared.client.impl': 0.1.0
       '@osdk/shared.net.errors': 1.1.0
       '@osdk/shared.net.fetch': 0.1.0
-
-  '@osdk/widget-api.unstable@1.0.0': {}
-
-  '@osdk/widget-api.unstable@2.0.0-beta.4': {}
-
-  '@osdk/widget-client-react.unstable@1.0.0(@osdk/client@packages+client)(@osdk/widget-client.unstable@1.0.0(@osdk/client@packages+client))(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@osdk/client': link:packages/client
-      '@osdk/widget-client.unstable': 1.0.0(@osdk/client@packages+client)
-      '@types/react': 18.3.12
-      '@types/react-dom': 18.3.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  '@osdk/widget-client.unstable@1.0.0(@osdk/client@packages+client)':
-    dependencies:
-      '@osdk/client': link:packages/client
-      '@osdk/widget-api.unstable': 1.0.0
-      tiny-invariant: 1.3.3
-
-  '@osdk/widget.vite-plugin.unstable@1.0.0(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))':
-    dependencies:
-      '@osdk/widget-api.unstable': 2.0.0-beta.4
-      escodegen: 2.1.0
-      fs-extra: 11.2.0
-      picocolors: 1.1.1
-      sirv: 3.0.0
-      vite: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
 
   '@pkgjs/parseargs@0.11.0':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1044,17 +1044,17 @@ importers:
   examples/example-widget-react-sdk-2.x:
     dependencies:
       '@osdk/client':
-        specifier: workspace:~
+        specifier: workspace:*
         version: link:../../packages/client
       '@osdk/e2e.generated.catchall':
         specifier: workspace:*
         version: link:../../packages/e2e.generated.catchall
       '@osdk/widget-client-react.unstable':
-        specifier: workspace:~
-        version: link:../../packages/widget.client-react.unstable
+        specifier: ^1.0.0
+        version: 1.0.0(@osdk/client@packages+client)(@osdk/widget-client.unstable@1.0.0(@osdk/client@packages+client))(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@osdk/widget-client.unstable':
-        specifier: workspace:~
-        version: link:../../packages/widget.client.unstable
+        specifier: ^1.0.0
+        version: 1.0.0(@osdk/client@packages+client)
       '@radix-ui/react-icons':
         specifier: ^1.3.1
         version: 1.3.2(react@18.3.1)
@@ -1078,8 +1078,8 @@ importers:
         specifier: ^9.13.0
         version: 9.15.0
       '@osdk/widget.vite-plugin.unstable':
-        specifier: workspace:~
-        version: link:../../packages/widget.vite-plugin.unstable
+        specifier: ^1.0.0
+        version: 1.0.0(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))
       '@types/react':
         specifier: ^18
         version: 18.3.12
@@ -2542,15 +2542,6 @@ importers:
 
   packages/create-widget.template.react.v2:
     dependencies:
-      '@osdk/client':
-        specifier: workspace:~
-        version: link:../client
-      '@osdk/widget-client-react.unstable':
-        specifier: workspace:~
-        version: link:../widget.client-react.unstable
-      '@osdk/widget-client.unstable':
-        specifier: workspace:~
-        version: link:../widget.client.unstable
       '@radix-ui/react-icons':
         specifier: ^1.3.1
         version: 1.3.2(react@18.3.1)
@@ -2585,9 +2576,6 @@ importers:
       '@osdk/monorepo.tsup':
         specifier: workspace:~
         version: link:../monorepo.tsup
-      '@osdk/widget.vite-plugin.unstable':
-        specifier: workspace:~
-        version: link:../widget.vite-plugin.unstable
       '@types/react':
         specifier: ^18
         version: 18.3.12
@@ -6356,6 +6344,32 @@ packages:
 
   '@osdk/shared.net@1.12.1':
     resolution: {integrity: sha512-uJE124K3O21A1Of2TdOqMHBfrIYshcDSLr5em4v1vNZZGSsSCYUYGo5vvkS6vzUVDA2xSn/Uf2FgdzX6BWxIhQ==}
+
+  '@osdk/widget-api.unstable@1.0.0':
+    resolution: {integrity: sha512-c8ws68RLRWCdVuqevv2QPWxNY3FIe4P0Qn37lbcbTwpKlU4P2ewhFJm9q6BOIhyqX9ucU/LyNnq+rzN1dNa9/w==}
+
+  '@osdk/widget-api.unstable@2.0.0-beta.4':
+    resolution: {integrity: sha512-XQHE1SC/InHFi8EFz77pfkWCfuOXdbuuZ60VnR2t1XLt4HJgnazZNCMqp9fUoFei6lGKSpURjObqxZyNO6xdJQ==}
+
+  '@osdk/widget-client-react.unstable@1.0.0':
+    resolution: {integrity: sha512-w7luVCQhbKQEVU3hyq8Hd7nQ5cd28yxWT9qMn8d3mfUi0BcuD1qJVjeshUxk4eF01zXG8VL3PmKWEkIUd40L7Q==}
+    peerDependencies:
+      '@osdk/client': ^2
+      '@osdk/widget-client.unstable': ~1.0.0
+      '@types/react': ^18
+      '@types/react-dom': ^18
+      react: ^18
+      react-dom: '18'
+
+  '@osdk/widget-client.unstable@1.0.0':
+    resolution: {integrity: sha512-Gg4EdOZBrGWo1iOBr4J99H7NKr8REUpRKPBape1iVqqz291ur2goqsjd3dyWpDDV3vhuU62Uo3e+RqtOzDN+fw==}
+    peerDependencies:
+      '@osdk/client': ^2
+
+  '@osdk/widget.vite-plugin.unstable@1.0.0':
+    resolution: {integrity: sha512-tShTx3RYn2E7mBtEJP1atWV+hJ8iOeiwtEsDBazqMBAsfljfnwgK5aCx5ppLg+zq2W5dyfGmXFo6BVVuM67aPQ==}
+    peerDependencies:
+      vite: ^5.0.0
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -17150,6 +17164,34 @@ snapshots:
       '@osdk/shared.client.impl': 0.1.0
       '@osdk/shared.net.errors': 1.1.0
       '@osdk/shared.net.fetch': 0.1.0
+
+  '@osdk/widget-api.unstable@1.0.0': {}
+
+  '@osdk/widget-api.unstable@2.0.0-beta.4': {}
+
+  '@osdk/widget-client-react.unstable@1.0.0(@osdk/client@packages+client)(@osdk/widget-client.unstable@1.0.0(@osdk/client@packages+client))(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@osdk/client': link:packages/client
+      '@osdk/widget-client.unstable': 1.0.0(@osdk/client@packages+client)
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@osdk/widget-client.unstable@1.0.0(@osdk/client@packages+client)':
+    dependencies:
+      '@osdk/client': link:packages/client
+      '@osdk/widget-api.unstable': 1.0.0
+      tiny-invariant: 1.3.3
+
+  '@osdk/widget.vite-plugin.unstable@1.0.0(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))':
+    dependencies:
+      '@osdk/widget-api.unstable': 2.0.0-beta.4
+      escodegen: 2.1.0
+      fs-extra: 11.2.0
+      picocolors: 1.1.1
+      sirv: 3.0.0
+      vite: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
 
   '@pkgjs/parseargs@0.11.0':
     optional: true


### PR DESCRIPTION
The dependencies are currently being copied into the template from the `package.json`, resulting in invalid `workspace` versions in the end user's project. The convention used in all other templates is for these in-repo packages to be declared in the handlebars file instead. E.g:
https://github.com/palantir/osdk-ts/blob/5f75268e26e987b52103fca228e93d18894d19e6/packages/create-app.template.react.beta/templates/package.json.hbs#L14-L19

I'm targeting #1065 because then I can also pick up a `^1` version of the Vite plugin and won't need to further bump template versions to pick up fixes for that package.