### PR TITLE
Make interface type status configurable

### DIFF
--- a/.changeset/unlucky-oranges-peel.md
+++ b/.changeset/unlucky-oranges-peel.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client.unstable": minor
+"@osdk/maker": minor
+---
+
+Making interface type status configurable

--- a/packages/client.unstable/src/index.ts
+++ b/packages/client.unstable/src/index.ts
@@ -49,6 +49,13 @@ export type { ValueTypeStatus } from "./generated/type-registry/api/ValueTypeSta
 export type { ValueTypeVersion } from "./generated/type-registry/api/ValueTypeVersion.js";
 
 export type {
+  InterfaceTypeStatus,
+  InterfaceTypeStatus_active,
+  InterfaceTypeStatus_deprecated,
+  InterfaceTypeStatus_experimental,
+} from "./generated/ontology-metadata/api/InterfaceTypeStatus.js";
+
+export type {
   ApiNameValueTypeReference,
   ImportedSharedPropertyTypes,
   ImportedTypes,

--- a/packages/client.unstable/src/index.ts
+++ b/packages/client.unstable/src/index.ts
@@ -48,6 +48,7 @@ export type { ValueTypeDisplayMetadata } from "./generated/type-registry/api/Val
 export type { ValueTypeStatus } from "./generated/type-registry/api/ValueTypeStatus.js";
 export type { ValueTypeVersion } from "./generated/type-registry/api/ValueTypeVersion.js";
 
+export type { InterfaceTypeRid } from "./generated/ontology-metadata/api/InterfaceTypeRid.js";
 export type {
   InterfaceTypeStatus,
   InterfaceTypeStatus_active,

--- a/packages/maker/src/api/defineInterface.ts
+++ b/packages/maker/src/api/defineInterface.ts
@@ -23,7 +23,6 @@ import type {
   InterfaceTypeStatus,
   InterfaceTypeStatus_active,
   InterfaceTypeStatus_deprecated,
-  InterfaceTypeStatus_example,
   InterfaceTypeStatus_experimental,
   PropertyTypeType,
   SharedPropertyType,
@@ -150,8 +149,6 @@ function mapStringToStatus(status: string): InterfaceTypeStatus {
         type: "experimental",
         experimental: {} as InterfaceTypeStatus_experimental,
       };
-    case "example":
-      return { type: "example", example: {} as InterfaceTypeStatus_example };
     case "active":
       return { type: "active", active: {} as InterfaceTypeStatus_active };
     case "deprecated":

--- a/packages/maker/src/api/defineInterface.ts
+++ b/packages/maker/src/api/defineInterface.ts
@@ -20,13 +20,23 @@ import { defineSharedPropertyType } from "./defineSpt.js";
 import type { BlueprintIcon } from "./iconNames.js";
 import type {
   InterfaceType,
+  InterfaceTypeRid,
   InterfaceTypeStatus,
   InterfaceTypeStatus_active,
-  InterfaceTypeStatus_deprecated,
   InterfaceTypeStatus_experimental,
   PropertyTypeType,
   SharedPropertyType,
 } from "./types.js";
+
+/**
+ * This status indicates that the interface is reaching the end of its life and will be removed as per the
+ * deadline specified.
+ */
+export interface DeprecatedInterfaceTypeStatus {
+  message: string;
+  deadline: string;
+  replacedBy: InterfaceTypeRid | undefined;
+}
 
 export function defineInterface(
   opts: {
@@ -109,6 +119,13 @@ export function defineInterface(
     ? mapStringToStatus(opts.status)
     : opts.status ?? { type: "active", active: {} };
 
+  invariant(
+    status.type !== "deprecated"
+      || (status.deprecated && status.deprecated.message
+        && status.deprecated.deadline),
+    `Deprecated status must include message, deadline, and replacedBy properties.`,
+  );
+
   const a: InterfaceType = {
     apiName,
     displayMetadata: {
@@ -152,10 +169,9 @@ function mapStringToStatus(status: string): InterfaceTypeStatus {
     case "active":
       return { type: "active", active: {} as InterfaceTypeStatus_active };
     case "deprecated":
-      return {
-        type: "deprecated",
-        deprecated: {} as InterfaceTypeStatus_deprecated,
-      };
+      throw new Error(
+        `Deprecated status must be fully specified with message, deadline, and replacedBy properties.`,
+      );
     default:
       throw new Error(`Invalid status type: ${status}`);
   }

--- a/packages/maker/src/api/defineInterface.ts
+++ b/packages/maker/src/api/defineInterface.ts
@@ -20,7 +20,6 @@ import { defineSharedPropertyType } from "./defineSpt.js";
 import type { BlueprintIcon } from "./iconNames.js";
 import type {
   InterfaceType,
-  InterfaceTypeRid,
   InterfaceTypeStatus,
   InterfaceTypeStatus_active,
   InterfaceTypeStatus_experimental,
@@ -35,7 +34,6 @@ import type {
 export interface DeprecatedInterfaceTypeStatus {
   message: string;
   deadline: string;
-  replacedBy: InterfaceTypeRid | undefined;
 }
 
 export function defineInterface(

--- a/packages/maker/src/api/defineInterface.ts
+++ b/packages/maker/src/api/defineInterface.ts
@@ -20,6 +20,11 @@ import { defineSharedPropertyType } from "./defineSpt.js";
 import type { BlueprintIcon } from "./iconNames.js";
 import type {
   InterfaceType,
+  InterfaceTypeStatus,
+  InterfaceTypeStatus_active,
+  InterfaceTypeStatus_deprecated,
+  InterfaceTypeStatus_example,
+  InterfaceTypeStatus_experimental,
   PropertyTypeType,
   SharedPropertyType,
 } from "./types.js";
@@ -30,10 +35,12 @@ export function defineInterface(
     displayName?: string;
     description?: string;
     icon?: { locator: BlueprintIcon; color: string };
+    status?: string | InterfaceTypeStatus;
     properties?: Record<
       string,
       SharedPropertyType | PropertyTypeType
     >;
+
     extends?: InterfaceType | InterfaceType[] | string | string[];
   },
 ): InterfaceType {
@@ -99,6 +106,10 @@ export function defineInterface(
     }
   }
 
+  const status: InterfaceTypeStatus = typeof opts.status === "string"
+    ? mapStringToStatus(opts.status)
+    : opts.status ?? { type: "active", active: {} };
+
   const a: InterfaceType = {
     apiName,
     displayMetadata: {
@@ -114,7 +125,7 @@ export function defineInterface(
     extendsInterfaces: extendsInterfaces,
     links: [],
     properties,
-    status: { type: "active", active: {} },
+    status: status,
   };
 
   return ontologyDefinition.interfaceTypes[apiName] = a;
@@ -130,4 +141,25 @@ function isPropertyTypeType(
     || (typeof v === "object" && v.type === "marking")
     || v === "short" || v === "string"
     || v === "timestamp";
+}
+
+function mapStringToStatus(status: string): InterfaceTypeStatus {
+  switch (status) {
+    case "experimental":
+      return {
+        type: "experimental",
+        experimental: {} as InterfaceTypeStatus_experimental,
+      };
+    case "example":
+      return { type: "example", example: {} as InterfaceTypeStatus_example };
+    case "active":
+      return { type: "active", active: {} as InterfaceTypeStatus_active };
+    case "deprecated":
+      return {
+        type: "deprecated",
+        deprecated: {} as InterfaceTypeStatus_deprecated,
+      };
+    default:
+      throw new Error(`Invalid status type: ${status}`);
+  }
 }

--- a/packages/maker/src/api/defineInterface.ts
+++ b/packages/maker/src/api/defineInterface.ts
@@ -132,7 +132,7 @@ export function defineInterface(
     extendsInterfaces: extendsInterfaces,
     links: [],
     properties,
-    status: status,
+    status,
   };
 
   return ontologyDefinition.interfaceTypes[apiName] = a;

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -27,7 +27,6 @@ import { defineSharedPropertyType } from "./defineSpt.js";
 import { defineValueType } from "./defineValueType.js";
 import type {
   InterfaceType,
-  InterfaceTypeRid,
   InterfaceTypeStatus_deprecated,
   InterfaceTypeStatus_experimental,
 } from "./types.js";
@@ -1333,7 +1332,6 @@ describe("Ontology Defining", () => {
       deprecated: {
         message: "foo",
         deadline: "foo",
-        replacedBy: "foo" as InterfaceTypeRid,
       },
     } as InterfaceTypeStatus_deprecated;
     const result = defineInterface({ apiName: "Foo", status: customStatus });

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -1317,37 +1317,30 @@ describe("Ontology Defining", () => {
     expect(result.status).toEqual({ type: "active", active: {} });
   });
 
-  it("sets interface status from opts as typed", () => {
-    const customStatus = {
+  it("sets interface status as experimental from opts as typed", () => {
+    const experimentalStatus = {
       type: "experimental",
       experimental: {},
     } as InterfaceTypeStatus_experimental;
-    const result = defineInterface({ apiName: "Foo", status: customStatus });
-    expect(result.status).toEqual(customStatus);
+    const result = defineInterface({
+      apiName: "Foo",
+      status: { type: "experimental" },
+    });
+    expect(result.status).toEqual(experimentalStatus);
   });
 
   it("sets interface status as deprecated from opts as typed", () => {
-    const customStatus = {
+    const deprecatedStatus = {
       type: "deprecated",
       deprecated: {
         message: "foo",
         deadline: "foo",
       },
     } as InterfaceTypeStatus_deprecated;
-    const result = defineInterface({ apiName: "Foo", status: customStatus });
-    expect(result.status).toEqual(customStatus);
-  });
-
-  it("sets interface status from opts as string", () => {
-    const customStatusString = "experimental";
-    const customStatusTyped = {
-      type: "experimental",
-      experimental: {} as InterfaceTypeStatus_experimental,
-    };
     const result = defineInterface({
       apiName: "Foo",
-      status: customStatusString,
+      status: { type: "deprecated", message: "foo", deadline: "foo" },
     });
-    expect(result.status).toEqual(customStatusTyped);
+    expect(result.status).toEqual(deprecatedStatus);
   });
 });

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -25,7 +25,10 @@ import {
 } from "./defineOntology.js";
 import { defineSharedPropertyType } from "./defineSpt.js";
 import { defineValueType } from "./defineValueType.js";
-import type { InterfaceType } from "./types.js";
+import type {
+  InterfaceType,
+  InterfaceTypeStatus_experimental,
+} from "./types.js";
 
 describe("Ontology Defining", () => {
   beforeEach(() => {
@@ -1306,5 +1309,32 @@ describe("Ontology Defining", () => {
          ],
        }
     `);
+  });
+
+  it("defaults interface status to active", () => {
+    const result = defineInterface({ apiName: "Foo" });
+    expect(result.status).toEqual({ type: "active", active: {} });
+  });
+
+  it("sets interface status from opts as typed", () => {
+    const customStatus = {
+      type: "experimental",
+      experimental: {} as InterfaceTypeStatus_experimental,
+    };
+    const result = defineInterface({ apiName: "Foo", status: customStatus });
+    expect(result.status).toEqual(customStatus);
+  });
+
+  it("sets interface status from opts as string", () => {
+    const customStatusString = "experimental";
+    const customStatusTyped = {
+      type: "experimental",
+      experimental: {} as InterfaceTypeStatus_experimental,
+    };
+    const result = defineInterface({
+      apiName: "Foo",
+      status: customStatusString,
+    });
+    expect(result.status).toEqual(customStatusTyped);
   });
 });

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -27,6 +27,8 @@ import { defineSharedPropertyType } from "./defineSpt.js";
 import { defineValueType } from "./defineValueType.js";
 import type {
   InterfaceType,
+  InterfaceTypeRid,
+  InterfaceTypeStatus_deprecated,
   InterfaceTypeStatus_experimental,
 } from "./types.js";
 
@@ -1319,8 +1321,21 @@ describe("Ontology Defining", () => {
   it("sets interface status from opts as typed", () => {
     const customStatus = {
       type: "experimental",
-      experimental: {} as InterfaceTypeStatus_experimental,
-    };
+      experimental: {},
+    } as InterfaceTypeStatus_experimental;
+    const result = defineInterface({ apiName: "Foo", status: customStatus });
+    expect(result.status).toEqual(customStatus);
+  });
+
+  it("sets interface status as deprecated from opts as typed", () => {
+    const customStatus = {
+      type: "deprecated",
+      deprecated: {
+        message: "foo",
+        deadline: "foo",
+        replacedBy: "foo" as InterfaceTypeRid,
+      },
+    } as InterfaceTypeStatus_deprecated;
     const result = defineInterface({ apiName: "Foo", status: customStatus });
     expect(result.status).toEqual(customStatus);
   });

--- a/packages/maker/src/api/types.ts
+++ b/packages/maker/src/api/types.ts
@@ -24,7 +24,6 @@ import type {
   InterfaceTypeStatus,
   InterfaceTypeStatus_active,
   InterfaceTypeStatus_deprecated,
-  InterfaceTypeStatus_example,
   InterfaceTypeStatus_experimental,
   OntologyIrInterfaceType,
   SharedPropertyTypeGothamMapping,
@@ -53,7 +52,6 @@ export type {
   InterfaceTypeStatus,
   InterfaceTypeStatus_active,
   InterfaceTypeStatus_deprecated,
-  InterfaceTypeStatus_example,
   InterfaceTypeStatus_experimental,
 };
 

--- a/packages/maker/src/api/types.ts
+++ b/packages/maker/src/api/types.ts
@@ -21,6 +21,7 @@ import type {
   ExampleValue,
   FailureMessage,
   ImportedTypes,
+  InterfaceTypeRid,
   InterfaceTypeStatus,
   InterfaceTypeStatus_active,
   InterfaceTypeStatus_deprecated,
@@ -49,6 +50,7 @@ export interface Ontology extends
   importedTypes: ImportedTypes;
 }
 export type {
+  InterfaceTypeRid,
   InterfaceTypeStatus,
   InterfaceTypeStatus_active,
   InterfaceTypeStatus_deprecated,

--- a/packages/maker/src/api/types.ts
+++ b/packages/maker/src/api/types.ts
@@ -21,7 +21,6 @@ import type {
   ExampleValue,
   FailureMessage,
   ImportedTypes,
-  InterfaceTypeRid,
   InterfaceTypeStatus,
   InterfaceTypeStatus_active,
   InterfaceTypeStatus_deprecated,
@@ -50,7 +49,6 @@ export interface Ontology extends
   importedTypes: ImportedTypes;
 }
 export type {
-  InterfaceTypeRid,
   InterfaceTypeStatus,
   InterfaceTypeStatus_active,
   InterfaceTypeStatus_deprecated,

--- a/packages/maker/src/api/types.ts
+++ b/packages/maker/src/api/types.ts
@@ -21,6 +21,11 @@ import type {
   ExampleValue,
   FailureMessage,
   ImportedTypes,
+  InterfaceTypeStatus,
+  InterfaceTypeStatus_active,
+  InterfaceTypeStatus_deprecated,
+  InterfaceTypeStatus_example,
+  InterfaceTypeStatus_experimental,
   OntologyIrInterfaceType,
   SharedPropertyTypeGothamMapping,
   StructFieldType,
@@ -44,6 +49,13 @@ export interface Ontology extends
   valueTypes: Record<string, ValueTypeDefinitionVersion[]>;
   importedTypes: ImportedTypes;
 }
+export type {
+  InterfaceTypeStatus,
+  InterfaceTypeStatus_active,
+  InterfaceTypeStatus_deprecated,
+  InterfaceTypeStatus_example,
+  InterfaceTypeStatus_experimental,
+};
 
 export interface InterfaceType extends
   Omit<
@@ -57,6 +69,7 @@ export interface InterfaceType extends
   >
 {
   properties: Record<string, SharedPropertyType>;
+  status: InterfaceTypeStatus;
 }
 
 export interface PropertyType {


### PR DESCRIPTION
Make interface type status configurable via a string (for "experimental" or "active" only) or using the InterfaceTypeStatus definition struct.