### PR TITLE
Move from "views" naming to "widgets"

### DIFF
--- a/.changeset/itchy-moons-invite.md
+++ b/.changeset/itchy-moons-invite.md
@@ -1,0 +1,9 @@
+---
+"@osdk/widget.vite-plugin.unstable": minor
+"@osdk/widget-client.unstable": minor
+"@osdk/widget-api.unstable": minor
+"@osdk/example-generator": minor
+"@osdk/create-widget": minor
+---
+
+Move from "views" naming to "widgets"

--- a/examples/example-widget-react-sdk-2.x/foundry.config.json
+++ b/examples/example-widget-react-sdk-2.x/foundry.config.json
@@ -1,7 +1,7 @@
 {
   "foundryUrl": "https://fake.palantirfoundry.com",
   "widget": {
-    "rid": "ri.viewregistry.main.view.fake",
+    "rid": "ri.widgetregistry.main.widget.fake",
     "directory": "./dist",
     "autoVersion": {
       "type": "package-json"

--- a/examples/example-widget-react-sdk-2.x/src/main.config.ts
+++ b/examples/example-widget-react-sdk-2.x/src/main.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "@osdk/widget-client.unstable";
 
 export default defineConfig({
   type: "workshop",
-  rid: "ri.viewregistry.main.view.fake",
+  rid: "ri.widgetregistry.main.widget.fake",
   parameters: {
     headerText: {
       displayName: "Widget title",

--- a/packages/create-widget/src/cli.test.ts
+++ b/packages/create-widget/src/cli.test.ts
@@ -75,7 +75,7 @@ async function runTest({
     "--foundryUrl",
     "https://example.palantirfoundry.com",
     "--widget",
-    "ri.viewregistry.main.view.fake",
+    "ri.widgetregistry.main.widget.fake",
     "--osdkPackage",
     "@custom-widget/sdk",
     "--osdkRegistryUrl",

--- a/packages/create-widget/src/generate/generateFoundryConfigJson.test.ts
+++ b/packages/create-widget/src/generate/generateFoundryConfigJson.test.ts
@@ -21,7 +21,7 @@ const expected = `
 {
   "foundryUrl": "https://example.palantirfoundry.com",
   "widget": {
-    "rid": "ri.viewregistry.main.view.fake",
+    "rid": "ri.widgetregistry.main.widget.fake",
     "directory": "./dist",
     "autoVersion": {
       "type": "git-describe",
@@ -35,7 +35,7 @@ test("it generates foundry.config.json", () => {
   expect(
     generateFoundryConfigJson({
       foundryUrl: "https://example.palantirfoundry.com",
-      widget: "ri.viewregistry.main.view.fake",
+      widget: "ri.widgetregistry.main.widget.fake",
       directory: "./dist",
     }),
   ).toEqual(expected);

--- a/packages/create-widget/src/prompts/promptWidgetRid.test.ts
+++ b/packages/create-widget/src/prompts/promptWidgetRid.test.ts
@@ -24,7 +24,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-const valid = "ri.viewregistry.main.view.0000-0000-0000-0000";
+const valid = "ri.widgetregistry.main.widget.0000-0000-0000-0000";
 
 test("it accepts valid application rid from prompt", async () => {
   vi.mocked(consola).prompt.mockResolvedValueOnce(valid);

--- a/packages/create-widget/src/prompts/promptWidgetRid.ts
+++ b/packages/create-widget/src/prompts/promptWidgetRid.ts
@@ -24,7 +24,7 @@ export async function promptWidgetRid({
 }): Promise<string> {
   while (
     widget == null
-    || !/^ri\.viewregistry\.[^.]*\.view\.[^.]+$/.test(widget)
+    || !/^ri\.widgetregistry\.[^.]*\.widget\.[^.]+$/.test(widget)
   ) {
     if (widget != null) {
       consola.fail("Please enter a valid widget resource identifier (rid)");
@@ -32,7 +32,7 @@ export async function promptWidgetRid({
     widget = await consola.prompt(
       `Enter the widget resource identifier (rid) for your widget:\n${
         italic(
-          "(Example: ri.viewregistry.main.view.1c66b352-4e00-40d2-995d-061c9d533ace)",
+          "(Example: ri.widgetregistry.main.widget.1c66b352-4e00-40d2-995d-061c9d533ace)",
         )
       }`,
       { type: "text" },

--- a/packages/e2e.sandbox.todowidget/foundry.config.json
+++ b/packages/e2e.sandbox.todowidget/foundry.config.json
@@ -1,7 +1,7 @@
 {
   "foundryUrl": "https://fake.palantirfoundry.com/",
   "widget": {
-    "rid": "ri.viewregistry..view.fake",
+    "rid": "ri.widgetregistry..widget.fake",
     "directory": "./dist",
     "autoVersion": {
       "type": "package-json"

--- a/packages/e2e.sandbox.todowidget/src/main.config.ts
+++ b/packages/e2e.sandbox.todowidget/src/main.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "@osdk/widget-client.unstable";
 
 export default defineConfig({
   type: "workshop",
-  rid: "ri.viewregistry..view.0000-0000-0000-0000",
+  rid: "ri.widgetregistry..widget.0000-0000-0000-0000",
   parameters: {
     headerText: {
       displayName: "Widget title",

--- a/packages/e2e.sandbox.todowidget/src/second.config.ts
+++ b/packages/e2e.sandbox.todowidget/src/second.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "@osdk/widget-client.unstable";
 
 const Config = defineConfig({
   type: "workshop",
-  rid: "ri.viewregistry..view.1234-0000-0000-0000",
+  rid: "ri.widgetregistry..widget.1234-0000-0000-0000",
   parameters: {
     headerText: {
       displayName: "Widget title",

--- a/packages/example-generator/src/run.ts
+++ b/packages/example-generator/src/run.ts
@@ -111,7 +111,7 @@ async function generateExamples(tmpDir: tmp.DirResult): Promise<void> {
       template,
       sdkVersion,
       foundryUrl: "https://fake.palantirfoundry.com",
-      widget: "ri.viewregistry.main.view.fake",
+      widget: "ri.widgetregistry.main.widget.fake",
       osdkPackage,
       osdkRegistryUrl:
         "https://fake.palantirfoundry.com/artifacts/api/repositories/ri.artifacts.main.repository.fake/contents/release/npm",

--- a/packages/monorepo.cspell/cspell.config.js
+++ b/packages/monorepo.cspell/cspell.config.js
@@ -150,7 +150,7 @@ const cspell = {
         "blueprintjs",
         "picocolors",
         // used in a RID template literal string
-        "viewregistry",
+        "widgetregistry",
       ],
     },
     {

--- a/packages/widget.api.unstable/src/config.test.ts
+++ b/packages/widget.api.unstable/src/config.test.ts
@@ -31,7 +31,7 @@ describe("WidgetConfig", () => {
     it("should be able to infer the type of the parameter ID", () => {
       const test = defineConfig({
         type: "workshop",
-        rid: "ri.viewregistry..view.0000-0000-0000-0000",
+        rid: "ri.widgetregistry..widget.0000-0000-0000-0000",
         parameters: {
           test: {
             displayName: "Testing",
@@ -52,7 +52,7 @@ describe("WidgetConfig", () => {
     it("should construct a type safe map of async parameter values", () => {
       const test = defineConfig({
         type: "workshop",
-        rid: "ri.viewregistry..view.0000-0000-0000-0000",
+        rid: "ri.widgetregistry..widget.0000-0000-0000-0000",
         parameters: {
           test: {
             displayName: "Testing",
@@ -74,7 +74,7 @@ describe("WidgetConfig", () => {
     it("should construct a type safe map of async parameter values with arrays", () => {
       const test = defineConfig({
         type: "workshop",
-        rid: "ri.viewregistry..view.0000-0000-0000-0000",
+        rid: "ri.widgetregistry..widget.0000-0000-0000-0000",
         parameters: {
           test: {
             displayName: "Testing",
@@ -103,7 +103,7 @@ describe("WidgetConfig", () => {
     it("should construct a type safe map of parameter values", () => {
       const test = defineConfig({
         type: "workshop",
-        rid: "ri.viewregistry..view.0000-0000-0000-0000",
+        rid: "ri.widgetregistry..widget.0000-0000-0000-0000",
         parameters: {
           test: {
             displayName: "Testing",
@@ -132,7 +132,7 @@ describe("WidgetConfig", () => {
     it("should construct a type safe map of events that reference parameters", () => {
       const test = defineConfig({
         type: "workshop",
-        rid: "ri.viewregistry..view.0000-0000-0000-0000",
+        rid: "ri.widgetregistry..widget.0000-0000-0000-0000",
         parameters: {
           test: {
             displayName: "Testing",
@@ -164,7 +164,7 @@ describe("WidgetConfig", () => {
     it("will not extract an event that references a parameter ID that doesn't exist", () => {
       const test = defineConfig({
         type: "workshop",
-        rid: "ri.viewregistry..view.0000-0000-0000-0000",
+        rid: "ri.widgetregistry..widget.0000-0000-0000-0000",
         parameters: {
           test: {
             displayName: "Testing",
@@ -197,7 +197,7 @@ describe("WidgetConfig", () => {
     it("should extract event IDs correctly", () => {
       const test = defineConfig({
         type: "workshop",
-        rid: "ri.viewregistry..view.0000-0000-0000-0000",
+        rid: "ri.widgetregistry..widget.0000-0000-0000-0000",
         parameters: {
           test: {
             displayName: "Testing",
@@ -233,7 +233,7 @@ describe("WidgetConfig", () => {
     it("should extract an event to the parameter values", () => {
       const test = defineConfig({
         type: "workshop",
-        rid: "ri.viewregistry..view.0000-0000-0000-0000",
+        rid: "ri.widgetregistry..widget.0000-0000-0000-0000",
         parameters: {
           test: {
             displayName: "Testing",
@@ -269,7 +269,7 @@ describe("WidgetConfig", () => {
       const test = defineConfig({
         type: "workshop",
         // @ts-expect-error
-        rid: "ri.asdf..view.0000-0000-0000-0000",
+        rid: "ri.asdf..widget.0000-0000-0000-0000",
         parameters: {
           test: {
             displayName: "Testing",

--- a/packages/widget.api.unstable/src/config.ts
+++ b/packages/widget.api.unstable/src/config.ts
@@ -39,7 +39,7 @@ export type ParameterConfig = Record<string, ParameterDefinition>;
 
 export interface WidgetConfig<P extends ParameterConfig> {
   parameters: ParameterConfig;
-  rid: `ri.viewregistry.${string}.view.${string}`;
+  rid: `ri.widgetregistry.${string}.widget.${string}`;
   // TODO: Add specific config for each type of widget. For now, all the config is generic and can be used by any widget.
   type: "workshop";
   events: { [eventId: string]: EventDefinition<NoInfer<P>> };

--- a/packages/widget.api.unstable/src/messages/widgetMessages.test.ts
+++ b/packages/widget.api.unstable/src/messages/widgetMessages.test.ts
@@ -23,7 +23,7 @@ describe("WidgetMessages", () => {
     it("should emit an event with the correct payload", () => {
       const test = defineConfig({
         type: "workshop",
-        rid: "ri.viewregistry..view.0000-0000-0000-0000",
+        rid: "ri.widgetregistry..widget.0000-0000-0000-0000",
         parameters: {
           test: {
             displayName: "Testing",
@@ -72,7 +72,7 @@ describe("WidgetMessages", () => {
     it("should be able to assign specific events to the union", () => {
       const test = defineConfig({
         type: "workshop",
-        rid: "ri.viewregistry..view.0000-0000-0000-0000",
+        rid: "ri.widgetregistry..widget.0000-0000-0000-0000",
         parameters: {
           test: {
             displayName: "Testing",

--- a/packages/widget.api.unstable/src/metaTags.ts
+++ b/packages/widget.api.unstable/src/metaTags.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const META_TAG_HOST_ORIGIN = "x-palantir-views-host-origin";
+export const META_TAG_HOST_ORIGIN = "x-palantir-widgets-host-origin";

--- a/packages/widget.client.unstable/src/host.test.ts
+++ b/packages/widget.client.unstable/src/host.test.ts
@@ -24,7 +24,7 @@ describe("FoundryHostEventTarget", () => {
   it("should narrow the event payload based on host message type for addEventListener", () => {
     const test = defineConfig({
       type: "workshop",
-      rid: "ri.viewregistry..view.0000-0000-0000-0000",
+      rid: "ri.widgetregistry..widget.0000-0000-0000-0000",
       parameters: {
         test: {
           displayName: "Testing",
@@ -69,7 +69,7 @@ describe("FoundryHostEventTarget", () => {
   it("should narrow the event payload based on host message type for removeEventListener", () => {
     const test = defineConfig({
       type: "workshop",
-      rid: "ri.viewregistry..view.0000-0000-0000-0000",
+      rid: "ri.widgetregistry..widget.0000-0000-0000-0000",
       parameters: {
         test: {
           displayName: "Testing",
@@ -109,7 +109,7 @@ describe("FoundryHostEventTarget", () => {
   it("should narrow the event payload when dispatching an event", () => {
     const test = defineConfig({
       type: "workshop",
-      rid: "ri.viewregistry..view.0000-0000-0000-0000",
+      rid: "ri.widgetregistry..widget.0000-0000-0000-0000",
       parameters: {
         test: {
           displayName: "Testing",

--- a/packages/widget.vite-plugin.unstable/src/plugin.ts
+++ b/packages/widget.vite-plugin.unstable/src/plugin.ts
@@ -268,7 +268,7 @@ export function FoundryWidgetVitePlugin(_options: Options = {}): Plugin {
               res.end(
                 JSON.stringify({
                   redirectUrl:
-                    `${foundryUrl.origin}/workspace/custom-views/preview/${foundryConfig.foundryConfig.widget.rid}`,
+                    `${foundryUrl.origin}/workspace/custom-widgets/preview/${foundryConfig.foundryConfig.widget.rid}`,
                 }),
               );
             } catch (error: any) {
@@ -588,7 +588,7 @@ function setWidgetSettings(
     entrypointCss: [],
   };
   return fetch(
-    `${foundryUrl.origin}/view-registry/api/dev-mode/settings/${widgetRid}`,
+    `${foundryUrl.origin}/widget-registry/api/dev-mode/settings/${widgetRid}`,
     {
       body: JSON.stringify(widgetDevModeSettings),
       method: "PUT",
@@ -602,7 +602,7 @@ function setWidgetSettings(
 }
 
 function enableDevMode(foundryUrl: URL) {
-  return fetch(`${foundryUrl.origin}/view-registry/api/dev-mode/enable`, {
+  return fetch(`${foundryUrl.origin}/widget-registry/api/dev-mode/enable`, {
     method: "POST",
     headers: {
       authorization: `Bearer ${process.env.FOUNDRY_TOKEN}`,


### PR DESCRIPTION
Reflect recent product renaming from "custom views" to "custom widgets". The main effect here is on the RID patterns, API  and app routes. 

E.g. `ri.viewregistry.main.view.1` becomes `ri.widgetregistry.main.widget.1`