### PR TITLE
Revert `api:x-read/write` back to `api:read/write-x`

### DIFF
--- a/.changeset/red-ladybugs-jump.md
+++ b/.changeset/red-ladybugs-jump.md
@@ -1,0 +1,7 @@
+---
+"@osdk/cli.common": minor
+"@osdk/create-app": minor
+"@osdk/oauth": minor
+---
+
+Revert api:x-read/write back to api:read/write-x

--- a/packages/cli.common/src/commands/auth/login/loginFlow.ts
+++ b/packages/cli.common/src/commands/auth/login/loginFlow.ts
@@ -158,7 +158,7 @@ function generateAuthorizeUrl(
   );
   queryParams.append(
     "scope",
-    ["offline_access", "api:ontologies-read"].join(" "),
+    ["offline_access", "api:read-data"].join(" "),
   );
 
   return join(baseUrl, "multipass", "api", "oauth2", "authorize") + `?`

--- a/packages/create-app/src/prompts/promptScopes.ts
+++ b/packages/create-app/src/prompts/promptScopes.ts
@@ -38,8 +38,8 @@ export async function promptScopes(
     );
     const stringScopes = await consola.prompt("Scopes:", {
       type: "text",
-      placeholder: "api:ontologies-read api:ontologies-write",
-      default: "api:ontologies-read api:ontologies-write",
+      placeholder: "api:read-data api:write-data",
+      default: "api:read-data api:write-data",
     });
     scopes = stringScopes.split(" ");
   }

--- a/packages/e2e.sandbox.oauth.public.react-router/src/client.ts
+++ b/packages/e2e.sandbox.oauth.public.react-router/src/client.ts
@@ -34,7 +34,7 @@ export const publicOauthClient = createPublicOauthClient(
   // where to redirect after login, defaults to "page before redirect"
   /* post login page */ undefined,
   //
-  // Scopes to use, defaults to: ["api:ontologies-read", "api:ontologies-write"],
+  // Scopes to use, defaults to: ["api:read-data", "api:write-data"],
   /* scopes */ undefined,
 );
 

--- a/packages/oauth/src/createConfidentialOauthClient.ts
+++ b/packages/oauth/src/createConfidentialOauthClient.ts
@@ -37,7 +37,7 @@ export function createConfidentialOauthClient(
   client_id: string,
   client_secret: string,
   url: string,
-  scopes: string[] = ["api:ontologies-read", "api:ontologies-write"],
+  scopes: string[] = ["api:read-data", "api:write-data"],
   fetchFn: typeof globalThis.fetch = globalThis.fetch,
   ctxPath: string = "multipass",
 ): ConfidentialOauthClient {

--- a/packages/oauth/src/createPublicOauthClient.ts
+++ b/packages/oauth/src/createPublicOauthClient.ts
@@ -62,7 +62,7 @@ export interface PublicOauthClientOptions {
   postLoginPage?: string;
 
   /**
-   * * @param {string[]} [scopes=[]] - OAuth scopes to request. If not provided, defaults to `["api:ontologies-read", "api:ontologies-write"]`
+   * * @param {string[]} [scopes=[]] - OAuth scopes to request. If not provided, defaults to `["api:read-data", "api:write-data"]`
    */
   scopes?: string[];
 
@@ -102,7 +102,7 @@ export function createPublicOauthClient(
  * @param {boolean} useHistory - If true, uses `history.replaceState()`, otherwise uses `window.location.assign()` (defaults to true)
  * @param {string} loginPage - Custom landing page URL prior to logging in
  * @param {string} postLoginPage - URL to return to after completed authentication cycle (defaults to `window.location.toString()`)
- * @param {string[]} scopes - OAuth scopes to request. If not provided, defaults to `["api:ontologies-read", "api:ontologies-write"]`
+ * @param {string[]} scopes - OAuth scopes to request. If not provided, defaults to `["api:read-data", "api:write-data"]`
  * @param {typeof globalThis.fetch} fetchFn - Custom fetch function to use for requests (defaults to `globalThis.fetch`)
  * @param {string} ctxPath - Context path for the authorization server (defaults to "multipass")
  * @returns {PublicOauthClient} A client that can be used as a token provider

--- a/packages/oauth/src/publicOauth.test.ts
+++ b/packages/oauth/src/publicOauth.test.ts
@@ -311,8 +311,7 @@ describe(createPublicOauthClient, () => {
                 redirect_uri: clientArgs.redirectUrl,
                 response_type: "code",
                 code_challenge_method: "S256",
-                scope:
-                  "offline_access api:ontologies-read api:ontologies-write",
+                scope: "offline_access api:read-data api:write-data",
                 state: expect.any(String),
               }),
             );

--- a/packages/oauth/src/utils.ts
+++ b/packages/oauth/src/utils.ts
@@ -60,7 +60,7 @@ export function processOptionsAndAssignDefaults(
     useHistory: options.useHistory ?? true,
     loginPage: options.loginPage,
     postLoginPage: options.postLoginPage || window.location.toString(),
-    scopes: options.scopes ?? ["api:ontologies-read", "api:ontologies-write"],
+    scopes: options.scopes ?? ["api:read-data", "api:write-data"],
     fetchFn: options.fetchFn ?? globalThis.fetch,
     ctxPath: options.ctxPath ?? "multipass",
   };


### PR DESCRIPTION
Reverts #1023 

We need to do this because when we officially release Typescript 2.1, existing applications that are using the TS OSDK with the TS Platform SDK may break when we update to stricter scope checking.