### PR TITLE
fix ToDo sample to allow build on lesson level

### DIFF
--- a/.changeset/happy-lizards-sneeze.md
+++ b/.changeset/happy-lizards-sneeze.md
@@ -1,0 +1,6 @@
+---
+"@osdk/create-app.template.tutorial-todo-aip-app.beta": patch
+"@osdk/create-app.template.tutorial-todo-app.beta": patch
+---
+
+update todo sample to allow build on a lesson level

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/src/CreateTaskButton.tsx
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/src/CreateTaskButton.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useState } from "react";
 import css from "./CreateTaskButton.module.css";
 import CreateTaskDialog from "./CreateTaskDialog";
-import type { MockProject } from "./mocks";
 import { useProjectTasks } from "./useProjectTasks";
+import { IProject } from "./useProjects";
 
 interface CreateTaskButtonProps {
-  project: MockProject;
+  project: IProject;
   onTaskCreated: (taskId: string) => void;
 }
 

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/src/CreateTaskDialog.tsx
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/src/CreateTaskDialog.tsx
@@ -3,11 +3,11 @@ import type { ChangeEvent } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import css from "./CreateTaskDialog.module.css";
 import Dialog from "./Dialog";
-import type { MockProject } from "./mocks";
 import { useProjectTasks } from "./useProjectTasks";
+import { IProject } from "./useProjects";
 
 interface CreateTaskDialogProps {
-  project: MockProject;
+  project: IProject;
   isOpen: boolean;
   onClose: () => void;
   onTaskCreated: (taskId: string) => void;

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/src/DeleteProjectButton.tsx
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/src/DeleteProjectButton.tsx
@@ -1,11 +1,10 @@
 import { useCallback, useState } from "react";
 import css from "./DeleteProjectButton.module.css";
 import DeleteProjectDialog from "./DeleteProjectDialog";
-import type { MockProject } from "./mocks";
-import useProjects from "./useProjects";
+import useProjects, { IProject } from "./useProjects";
 
 interface DeleteProjectButtonProps {
-  project: MockProject;
+  project: IProject;
 }
 
 function DeleteProjectButton({ project }: DeleteProjectButtonProps) {

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/src/DeleteProjectDialog.tsx
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/src/DeleteProjectDialog.tsx
@@ -1,11 +1,10 @@
 import { useCallback, useState } from "react";
 import css from "./DeleteProjectDialog.module.css";
 import Dialog from "./Dialog";
-import type { MockProject } from "./mocks";
-import useProjects from "./useProjects";
+import useProjects, { IProject } from "./useProjects";
 
 interface DeleteProjectDialogProps {
-  project: MockProject;
+  project: IProject;
   isOpen: boolean;
   onClose: () => void;
 }

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/src/Home.tsx
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/src/Home.tsx
@@ -3,10 +3,9 @@ import CreateProjectButton from "./CreateProjectButton";
 import DeleteProjectButton from "./DeleteProjectButton";
 import css from "./Home.module.css";
 import Layout from "./Layout";
-import type { MockProject } from "./mocks";
 import { ProjectDetails } from "./ProjectDetails";
 import ProjectSelect from "./ProjectSelect";
-import useProjects from "./useProjects";
+import useProjects, { IProject } from "./useProjects";
 
 function Home() {
   const [projectId, setProjectId] = useState<string | undefined>(undefined);
@@ -15,7 +14,7 @@ function Home() {
   const project = projects?.find((p) => p.id === projectId);
 
   const handleSelectProject = useCallback(
-    (p: MockProject) => setProjectId(p.id),
+    (p: IProject) => setProjectId(p.id),
     [],
   );
 

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/src/ProjectDetails.tsx
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/src/ProjectDetails.tsx
@@ -1,14 +1,13 @@
 import aipLogo from "/aip-icon.svg";
 import { useCallback, useEffect, useRef, useState } from "react";
 import CreateTaskButton from "./CreateTaskButton";
-import type { MockProject } from "./mocks";
 import css from "./ProjectDetails.module.css";
 import TaskList from "./TaskList";
-import useProjects from "./useProjects";
+import useProjects, { IProject } from "./useProjects";
 import { useProjectTasks } from "./useProjectTasks";
 
 interface ProjectDetailsProps {
-  project: MockProject;
+  project: IProject;
 }
 
 export function ProjectDetails({ project }: ProjectDetailsProps) {

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/src/ProjectSelect.tsx
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/src/ProjectSelect.tsx
@@ -1,10 +1,10 @@
 import { ChangeEvent, useCallback } from "react";
-import { MockProject } from "./mocks";
+import { IProject } from "./useProjects";
 
 interface ProjectSelectProps {
-  project: MockProject | undefined;
-  projects: MockProject[];
-  onSelectProject: (project: MockProject) => void;
+  project: IProject | undefined;
+  projects: IProject[];
+  onSelectProject: (project: IProject) => void;
 }
 
 function ProjectSelect({

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/src/TaskList.tsx
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/src/TaskList.tsx
@@ -1,10 +1,10 @@
-import type { MockProject } from "./mocks";
 import css from "./TaskList.module.css";
 import TaskListItem from "./TaskListItem";
+import { IProject } from "./useProjects";
 import { useProjectTasks } from "./useProjectTasks";
 
 interface TaskListProps {
-  project: MockProject;
+  project: IProject;
   onTaskDeleted: (taskId: string | undefined) => void;
 }
 

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/src/TaskListItem.tsx
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/src/TaskListItem.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { MockTask } from "./mocks";
 import css from "./TaskListItem.module.css";
+import { ITask } from "./useProjects";
 
 interface TaskListItemProps {
-  task: MockTask;
-  deleteTask: (task: MockTask) => Promise<void>;
+  task: ITask;
+  deleteTask: (task: ITask) => Promise<void>;
   onTaskDeleted: (taskId: string | undefined) => void;
 }
 

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/src/mocks.ts
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/src/mocks.ts
@@ -1,50 +1,12 @@
-export interface MockProject {
-  $apiName: string;
-  $primaryKey: string;
-  id: string;
-  name: string;
-  description: string;
-  tasks: MockTask[];
-}
+import { IProject, ITask } from "./useProjects";
 
-export interface MockTask {
-  $apiName: string;
-  $primaryKey: string;
-  id: string;
-  title: string;
-  description: string;
-}
-
-const projects: MockProject[] = [
+const projects: IProject[] = [
   {
     $apiName: "MockProject",
     $primaryKey: "1",
     id: "1",
     name: "Mock project",
     description: "This is a mock description",
-    tasks: [
-      {
-        $apiName: "MockTask",
-        $primaryKey: "1",
-        id: "1",
-        title: "Try to",
-        description: "task description 1",
-      },
-      {
-        $apiName: "MockTask",
-        $primaryKey: "2",
-        id: "2",
-        title: "Implement this",
-        description: "task description 2",
-      },
-      {
-        $apiName: "MockTask",
-        $primaryKey: "3",
-        id: "3",
-        title: "With the Ontology SDK!",
-        description: "task description 3",
-      },
-    ],
   },
   {
     $apiName: "MockProject",
@@ -52,18 +14,43 @@ const projects: MockProject[] = [
     id: "2",
     name: "Yet another mock project",
     description: "This is another mock description",
-    tasks: [
-      {
-        $apiName: "MockTask",
-        $primaryKey: "4",
-        id: "4",
-        title: "More tasks here",
-        description: "More task description",
-      },
-    ],
   },
 ];
 
+const tasks: ITask[] = [
+  {
+    $apiName: "MockTask",
+    $primaryKey: "1",
+    id: "1",
+    title: "Try to",
+    description: "task description 1",
+    projectId: "1",
+  },
+  {
+    $apiName: "MockTask",
+    $primaryKey: "2",
+    id: "2",
+    title: "Implement this",
+    description: "task description 2",
+    projectId: "1",
+  },
+  {
+    $apiName: "MockTask",
+    $primaryKey: "3",
+    id: "3",
+    title: "With the Ontology SDK!",
+    description: "task description 3",
+    projectId: "1",
+  },
+  {
+    $apiName: "MockTask",
+    $primaryKey: "4",
+    id: "4",
+    title: "More tasks here",
+    description: "More task description",
+    projectId: "2",
+  },
+];
 async function delay(): Promise<void> {
   return new Promise((resolve) =>
     setTimeout(() => resolve(), 500 + Math.random() * 1000)
@@ -75,7 +62,7 @@ function randomId(): string {
   return `${Math.floor(Math.random() * 2 ** 31)}`;
 }
 
-async function getProjects(): Promise<MockProject[]> {
+async function getProjects(): Promise<IProject[]> {
   await delay();
   const result = [...projects];
   result.sort((p1, p2) => p1.name.localeCompare(p2.name));
@@ -84,11 +71,10 @@ async function getProjects(): Promise<MockProject[]> {
 
 async function createProject({
   name,
-  description = "",
 }: {
   name: string;
   description?: string;
-}): Promise<MockProject["$primaryKey"]> {
+}): Promise<IProject["$primaryKey"]> {
   await delay();
   const id = randomId();
   projects.push({
@@ -96,24 +82,24 @@ async function createProject({
     $primaryKey: id,
     id,
     name,
-    description,
-    tasks: [],
+    description: "",
   });
   return id;
 }
 
 async function getRecommendedProjectDescription(
-  project: MockProject,
+  project: IProject,
 ): Promise<string> {
   await delay();
-  if (project.tasks != null && project.tasks.length === 0) {
+  const projectTasks = tasks.filter((t) => t.projectId === project.id);
+  if (projectTasks.length === 0) {
     throw new Error("Project description recommendation requires tasks");
   }
   return `AIP Logic mock description for project`;
 }
 
 async function updateProjectDescription(
-  project: MockProject,
+  project: IProject,
 ): Promise<void> {
   await delay();
   project.description = await getRecommendedProjectDescription(project);
@@ -127,6 +113,11 @@ async function deleteProject(id: string): Promise<void> {
   }
 }
 
+async function getProjectTasks(projectId: string): Promise<ITask[]> {
+  await delay();
+  return tasks.filter((t) => t.projectId === projectId);
+}
+
 async function createTask({
   title,
   description = "",
@@ -135,19 +126,20 @@ async function createTask({
   title: string;
   description: string;
   projectId: string;
-}): Promise<MockTask["$primaryKey"]> {
+}): Promise<ITask["$primaryKey"]> {
   await delay();
   const project = projects.find((p) => p.id === projectId);
   if (project == null) {
     throw new Error(`Project ${projectId} not found!`);
   }
   const id = randomId();
-  project.tasks.unshift({
+  tasks.unshift({
     $apiName: "MockTask",
     $primaryKey: id,
     id,
     title,
     description,
+    projectId,
   });
   return id;
 }
@@ -164,11 +156,9 @@ async function getRecommendedTaskDescription(
 
 async function deleteTask(id: string): Promise<void> {
   await delay();
-  for (const project of projects) {
-    const idx = project.tasks.findIndex((t) => t.id === id);
-    if (idx !== -1) {
-      project.tasks.splice(idx, 1);
-    }
+  const idx = tasks.findIndex((t) => t.id === id);
+  if (idx !== -1) {
+    tasks.splice(idx, 1);
   }
 }
 
@@ -177,6 +167,7 @@ const Mocks = {
   createProject,
   getRecommendedProjectDescription,
   deleteProject,
+  getProjectTasks,
   createTask,
   deleteTask,
   getRecommendedTaskDescription,

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/src/useProjectTasks.ts
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/src/useProjectTasks.ts
@@ -1,23 +1,24 @@
 import { useCallback } from "react";
 import useSWR from "swr";
-import Mocks, { MockProject, MockTask } from "./mocks";
+import Mocks from "./mocks";
+import { IProject, ITask } from "./useProjects";
 
-export function useProjectTasks(project: MockProject | undefined) {
-  const { data, isLoading, isValidating, error, mutate } = useSWR<MockTask[]>(
+export function useProjectTasks(project: IProject | undefined) {
+  const { data, isLoading, isValidating, error, mutate } = useSWR<ITask[]>(
     project != null ? `projects/${project.id}/tasks` : null,
     // Try to implement this with the Ontology SDK!
     async () => {
       if (project == null) {
         return [];
       }
-      return project.tasks;
+      return Mocks.getProjectTasks(project.$primaryKey);
     },
   );
 
   const createTask: (
     title: string,
     description: string,
-  ) => Promise<MockTask["$primaryKey"] | undefined> = useCallback(
+  ) => Promise<ITask["$primaryKey"] | undefined> = useCallback(
     async (title: string, description: string) => {
       if (project == null) {
         return undefined;
@@ -34,12 +35,11 @@ export function useProjectTasks(project: MockProject | undefined) {
     [project, mutate],
   );
 
-  const deleteTask: (task: MockTask) => Promise<void> = useCallback(
+  const deleteTask: (task: ITask) => Promise<void> = useCallback(
     async (task) => {
       if (project == null) {
         return;
       }
-      await sleep(1000);
       // Try to implement this with the Ontology SDK!
       await Mocks.deleteTask(task.$primaryKey);
       await mutate();
@@ -68,8 +68,4 @@ export function useProjectTasks(project: MockProject | undefined) {
     deleteTask,
     getRecommendedTaskDescription,
   };
-}
-
-function sleep(ms: number) {
-  return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/src/useProjects.ts
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/src/useProjects.ts
@@ -1,19 +1,37 @@
 import { useCallback } from "react";
 import useSWR from "swr";
-import type { MockProject } from "./mocks";
 import Mocks from "./mocks";
 
+export interface IProject {
+  $apiName: string;
+  $primaryKey: string;
+  id: string;
+  name: string;
+  description: string;
+}
+
+export interface ITask {
+  $apiName: string;
+  $primaryKey: string;
+  id: string;
+  title: string;
+  description: string;
+  projectId: string;
+}
+
 function useProjects() {
-  const { data, isLoading, isValidating, error, mutate } = useSWR<
-    MockProject[]
-  >("projects", async () => {
+  const { data, isLoading, isValidating, error, mutate } = useSWR<IProject[]>("projects", async () => {
     // Try to implement this with the Ontology SDK!
-    return Mocks.getProjects();
-  });
+    const projectsList: IProject[] = (await Mocks.getProjects()).map((project) => ({
+      ...project
+    }));
+    return projectsList;
+    }
+  );
 
   const createProject: (
     name: string,
-  ) => Promise<MockProject["$primaryKey"]> = useCallback(
+  ) => Promise<IProject["$primaryKey"]> = useCallback(
     async (name: string) => {
       // Try to implement this with the Ontology SDK!
       const id = await Mocks.createProject({ name });
@@ -24,7 +42,7 @@ function useProjects() {
   );
 
   const updateProjectDescription: (
-    project: MockProject,
+    project: IProject,
   ) => Promise<void> = useCallback(
     async (project) => {
       // Try to implement this with the Ontology SDK!
@@ -34,7 +52,7 @@ function useProjects() {
     [mutate],
   );
 
-  const deleteProject: (project: MockProject) => Promise<void> = useCallback(
+  const deleteProject: (project: IProject) => Promise<void> = useCallback(
     async (project) => {
       // Try to implement this with the Ontology SDK!
       await Mocks.deleteProject(project.$primaryKey);

--- a/examples/example-tutorial-todo-app-sdk-2.x/src/CreateTaskButton.tsx
+++ b/examples/example-tutorial-todo-app-sdk-2.x/src/CreateTaskButton.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useState } from "react";
 import CreateTaskDialog from "./CreateTaskDialog";
-import { MockProject } from "./mocks";
 import { useProjectTasks } from "./useProjectTasks";
+import { IProject } from "./useProjects";
 
 interface CreateTaskButtonProps {
-  project: MockProject;
+  project: IProject;
 }
 
 function CreateTaskButton({ project }: CreateTaskButtonProps) {

--- a/examples/example-tutorial-todo-app-sdk-2.x/src/CreateTaskDialog.tsx
+++ b/examples/example-tutorial-todo-app-sdk-2.x/src/CreateTaskDialog.tsx
@@ -1,10 +1,10 @@
 import { ChangeEvent, useCallback, useEffect, useState } from "react";
 import Dialog from "./Dialog";
-import { MockProject } from "./mocks";
 import { useProjectTasks } from "./useProjectTasks";
+import { IProject } from "./useProjects";
 
 interface CreateTaskDialogProps {
-  project: MockProject;
+  project: IProject;
   isOpen: boolean;
   onClose: () => void;
 }

--- a/examples/example-tutorial-todo-app-sdk-2.x/src/DeleteProjectButton.tsx
+++ b/examples/example-tutorial-todo-app-sdk-2.x/src/DeleteProjectButton.tsx
@@ -1,10 +1,9 @@
 import { useCallback, useState } from "react";
 import DeleteProjectDialog from "./DeleteProjectDialog";
-import { MockProject } from "./mocks";
-import useProjects from "./useProjects";
+import useProjects, { IProject } from "./useProjects";
 
 interface DeleteProjectButtonProps {
-  project: MockProject;
+  project: IProject;
 }
 
 function DeleteProjectButton({ project }: DeleteProjectButtonProps) {

--- a/examples/example-tutorial-todo-app-sdk-2.x/src/DeleteProjectDialog.tsx
+++ b/examples/example-tutorial-todo-app-sdk-2.x/src/DeleteProjectDialog.tsx
@@ -1,10 +1,9 @@
 import { useCallback, useState } from "react";
 import Dialog from "./Dialog";
-import { MockProject } from "./mocks";
-import useProjects from "./useProjects";
+import useProjects, { IProject } from "./useProjects";
 
 interface DeleteProjectDialogProps {
-  project: MockProject;
+  project: IProject;
   isOpen: boolean;
   onClose: () => void;
 }

--- a/examples/example-tutorial-todo-app-sdk-2.x/src/Home.tsx
+++ b/examples/example-tutorial-todo-app-sdk-2.x/src/Home.tsx
@@ -4,10 +4,9 @@ import CreateTaskButton from "./CreateTaskButton";
 import DeleteProjectButton from "./DeleteProjectButton";
 import css from "./Home.module.css";
 import Layout from "./Layout";
-import { MockProject } from "./mocks";
 import ProjectSelect from "./ProjectSelect";
 import TaskList from "./TaskList";
-import useProjects from "./useProjects";
+import useProjects, { IProject } from "./useProjects";
 
 function Home() {
   const [projectId, setProjectId] = useState<string | undefined>(undefined);
@@ -15,7 +14,7 @@ function Home() {
   const project = projects?.find((p) => p.id === projectId);
 
   const handleSelectProject = useCallback(
-    (p: MockProject) => setProjectId(p.id),
+    (p: IProject) => setProjectId(p.id),
     [],
   );
 

--- a/examples/example-tutorial-todo-app-sdk-2.x/src/ProjectSelect.tsx
+++ b/examples/example-tutorial-todo-app-sdk-2.x/src/ProjectSelect.tsx
@@ -1,10 +1,10 @@
 import { ChangeEvent, useCallback } from "react";
-import { MockProject } from "./mocks";
+import { IProject } from "./useProjects";
 
 interface ProjectSelectProps {
-  project: MockProject | undefined;
-  projects: MockProject[];
-  onSelectProject: (project: MockProject) => void;
+  project: IProject | undefined;
+  projects: IProject[];
+  onSelectProject: (project: IProject) => void;
 }
 
 function ProjectSelect({

--- a/examples/example-tutorial-todo-app-sdk-2.x/src/TaskList.tsx
+++ b/examples/example-tutorial-todo-app-sdk-2.x/src/TaskList.tsx
@@ -1,10 +1,10 @@
-import { MockProject } from "./mocks";
 import css from "./TaskList.module.css";
 import TaskListItem from "./TaskListItem";
+import { IProject } from "./useProjects";
 import { useProjectTasks } from "./useProjectTasks";
 
 interface TaskListProps {
-  project: MockProject;
+  project: IProject;
 }
 
 function TaskList({ project }: TaskListProps) {

--- a/examples/example-tutorial-todo-app-sdk-2.x/src/TaskListItem.tsx
+++ b/examples/example-tutorial-todo-app-sdk-2.x/src/TaskListItem.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useState } from "react";
-import { MockTask } from "./mocks";
 import css from "./TaskListItem.module.css";
+import { ITask } from "./useProjects";
 
 interface TaskListItemProps {
-  task: MockTask;
-  deleteTask: (task: MockTask) => Promise<void>;
+  task: ITask;
+  deleteTask: (task: ITask) => Promise<void>;
 }
 
 function TaskListItem({ task, deleteTask }: TaskListItemProps) {

--- a/examples/example-tutorial-todo-app-sdk-2.x/src/mocks.ts
+++ b/examples/example-tutorial-todo-app-sdk-2.x/src/mocks.ts
@@ -1,60 +1,51 @@
-export interface MockProject {
-  $apiName: string;
-  $primaryKey: string;
-  id: string;
-  name: string;
-  tasks: MockTask[];
-}
+import { IProject, ITask } from "./useProjects";
 
-export interface MockTask {
-  $apiName: string;
-  $primaryKey: string;
-  id: string;
-  title: string;
-}
-
-const projects: MockProject[] = [
+const projects: IProject[] = [
   {
     $apiName: "MockProject",
     $primaryKey: "1",
     id: "1",
-    name: "Mock project",
-    tasks: [
-      {
-        $apiName: "MockTask",
-        $primaryKey: "1",
-        id: "1",
-        title: "Try to",
-      },
-      {
-        $apiName: "MockTask",
-        $primaryKey: "2",
-        id: "2",
-        title: "Implement this",
-      },
-      {
-        $apiName: "MockTask",
-        $primaryKey: "3",
-        id: "3",
-        title: "With the Ontology SDK!",
-      },
-    ],
+    name: "Mock project"
   },
   {
     $apiName: "MockProject",
     $primaryKey: "2",
     id: "2",
     name: "Yet another mock project",
-    tasks: [
-      {
-        $apiName: "MockTask",
-        $primaryKey: "4",
-        id: "4",
-        title: "More tasks here",
-      },
-    ],
   },
 ];
+
+const tasks: ITask[] = [
+    {
+      $apiName: "MockTask",
+      $primaryKey: "1",
+      id: "1",
+      title: "Try to",
+      projectId: "1",
+    },
+    {
+      $apiName: "MockTask",
+      $primaryKey: "2",
+      id: "2",
+      title: "Implement this",
+      projectId: "1",
+    },
+    {
+      $apiName: "MockTask",
+      $primaryKey: "3",
+      id: "3",
+      title: "With the Ontology SDK!",
+      projectId: "1",
+    },
+    {
+      $apiName: "MockTask",
+      $primaryKey: "4",
+      id: "4",
+      title: "More tasks here",
+      projectId: "2",
+    },
+  ]
+
 
 async function delay(): Promise<void> {
   return new Promise((resolve) =>
@@ -67,7 +58,7 @@ function randomId(): string {
   return `${Math.floor(Math.random() * 2 ** 31)}`;
 }
 
-async function getProjects(): Promise<MockProject[]> {
+async function getProjects(): Promise<IProject[]> {
   await delay();
   const result = [...projects];
   result.sort((p1, p2) => p1.name.localeCompare(p2.name));
@@ -78,7 +69,7 @@ async function createProject({
   name,
 }: {
   name: string;
-}): Promise<MockProject["$primaryKey"]> {
+}): Promise<IProject["$primaryKey"]> {
   await delay();
   const id = randomId();
   projects.push({
@@ -86,7 +77,6 @@ async function createProject({
     $primaryKey: id,
     id,
     name,
-    tasks: [],
   });
   return id;
 }
@@ -99,37 +89,41 @@ async function deleteProject(id: string): Promise<void> {
   }
 }
 
+async function getProjectTasks(projectId: string): Promise<ITask[]> {
+  await delay();
+  return tasks.filter((t) => t.projectId === projectId);
+}
+
 async function createTask({
   title,
   projectId,
 }: {
   title: string;
   projectId: string;
-}): Promise<MockTask["$primaryKey"]> {
+}): Promise<ITask["$primaryKey"]> {
   await delay();
-  const project = projects.find((p) => p.id === projectId);
-  if (project == null) {
+  const task = tasks.find((t) => t.projectId === projectId);
+  if (task == null) {
     throw new Error(`Project ${projectId} not found!`);
   }
   const id = randomId();
-  project.tasks.unshift({ $apiName: "MockTask", $primaryKey: id, id, title });
+  tasks.unshift({ $apiName: "MockTask", $primaryKey: id, id, title, projectId });
   return id;
 }
 
 async function deleteTask(id: string): Promise<void> {
   await delay();
-  for (const project of projects) {
-    const idx = project.tasks.findIndex((t) => t.id === id);
-    if (idx !== -1) {
-      project.tasks.splice(idx, 1);
+  const idx = tasks.findIndex((t) => t.projectId === id);
+  if (idx !== -1) {
+      tasks.splice(idx, 1);
     }
-  }
 }
 
 const Mocks = {
   getProjects,
   createProject,
   deleteProject,
+  getProjectTasks,
   createTask,
   deleteTask,
 };

--- a/examples/example-tutorial-todo-app-sdk-2.x/src/useProjectTasks.ts
+++ b/examples/example-tutorial-todo-app-sdk-2.x/src/useProjectTasks.ts
@@ -1,22 +1,23 @@
 import { useCallback } from "react";
 import useSWR from "swr";
-import Mocks, { MockProject, MockTask } from "./mocks";
+import Mocks from "./mocks";
+import { IProject, ITask } from "./useProjects";
 
-export function useProjectTasks(project: MockProject | undefined) {
-  const { data, isLoading, isValidating, error, mutate } = useSWR<MockTask[]>(
+export function useProjectTasks(project: IProject | undefined) {
+  const { data, isLoading, isValidating, error, mutate } = useSWR<ITask[]>(
     project != null ? `projects/${project.id}/tasks` : null,
     // Try to implement this with the Ontology SDK!
     async () => {
       if (project == null) {
         return [];
       }
-      return project.tasks;
-    },
+      return (await Mocks.getProjectTasks(project.$primaryKey))
+    }
   );
 
   const createTask: (
     title: string,
-  ) => Promise<MockTask["$primaryKey"] | undefined> = useCallback(
+  ) => Promise<ITask["$primaryKey"] | undefined> = useCallback(
     async (title) => {
       if (project == null) {
         return undefined;
@@ -32,12 +33,11 @@ export function useProjectTasks(project: MockProject | undefined) {
     [project, mutate],
   );
 
-  const deleteTask: (task: MockTask) => Promise<void> = useCallback(
+  const deleteTask: (task: ITask) => Promise<void> = useCallback(
     async (task) => {
       if (project == null) {
         return;
       }
-      await sleep(1000);
       // Try to implement this with the Ontology SDK!
       await Mocks.deleteTask(task.$primaryKey);
       await mutate();
@@ -53,8 +53,4 @@ export function useProjectTasks(project: MockProject | undefined) {
     createTask,
     deleteTask,
   };
-}
-
-function sleep(ms: number) {
-  return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/examples/example-tutorial-todo-app-sdk-2.x/src/useProjects.ts
+++ b/examples/example-tutorial-todo-app-sdk-2.x/src/useProjects.ts
@@ -1,16 +1,33 @@
 import { useCallback } from "react";
 import useSWR from "swr";
-import Mocks, { MockProject } from "./mocks";
+import Mocks from "./mocks";
+
+export interface IProject {
+  $apiName: string;
+  $primaryKey: string;
+  id: string;
+  name: string;
+}
+
+export interface ITask {
+  $apiName: string;
+  $primaryKey: string;
+  id: string;
+  title: string | undefined;
+  projectId: string;
+}
 
 function useProjects() {
-  const { data, isLoading, isValidating, error, mutate } = useSWR<
-    MockProject[]
-  >("projects", async () => {
+  const { data, isLoading, isValidating, error, mutate } = useSWR<IProject[]>("projects", async () => {
     // Try to implement this with the Ontology SDK!
-    return Mocks.getProjects();
-  });
+    const projectsList: IProject[] = (await Mocks.getProjects()).map((project) => ({
+      ...project,
+    }));
+    return projectsList;
+    }
+  );
 
-  const createProject: (name: string) => Promise<MockProject["$primaryKey"]> =
+  const createProject: (name: string) => Promise<IProject["$primaryKey"]> =
     useCallback(
       async (name) => {
         // Try to implement this with the Ontology SDK!
@@ -21,7 +38,7 @@ function useProjects() {
       [mutate],
     );
 
-  const deleteProject: (project: MockProject) => Promise<void> = useCallback(
+  const deleteProject: (project: IProject) => Promise<void> = useCallback(
     async (project) => {
       // Try to implement this with the Ontology SDK!
       await Mocks.deleteProject(project.$primaryKey);

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/CreateTaskButton.tsx
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/CreateTaskButton.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useState } from "react";
 import css from "./CreateTaskButton.module.css";
 import CreateTaskDialog from "./CreateTaskDialog";
-import type { MockProject } from "./mocks";
 import { useProjectTasks } from "./useProjectTasks";
+import { IProject } from "./useProjects";
 
 interface CreateTaskButtonProps {
-  project: MockProject;
+  project: IProject;
   onTaskCreated: (taskId: string) => void;
 }
 

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/CreateTaskDialog.tsx
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/CreateTaskDialog.tsx
@@ -3,11 +3,11 @@ import type { ChangeEvent } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import css from "./CreateTaskDialog.module.css";
 import Dialog from "./Dialog";
-import type { MockProject } from "./mocks";
 import { useProjectTasks } from "./useProjectTasks";
+import { IProject } from "./useProjects";
 
 interface CreateTaskDialogProps {
-  project: MockProject;
+  project: IProject;
   isOpen: boolean;
   onClose: () => void;
   onTaskCreated: (taskId: string) => void;

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/DeleteProjectButton.tsx
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/DeleteProjectButton.tsx
@@ -1,11 +1,10 @@
 import { useCallback, useState } from "react";
 import css from "./DeleteProjectButton.module.css";
 import DeleteProjectDialog from "./DeleteProjectDialog";
-import type { MockProject } from "./mocks";
-import useProjects from "./useProjects";
+import useProjects, { IProject } from "./useProjects";
 
 interface DeleteProjectButtonProps {
-  project: MockProject;
+  project: IProject;
 }
 
 function DeleteProjectButton({ project }: DeleteProjectButtonProps) {

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/DeleteProjectDialog.tsx
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/DeleteProjectDialog.tsx
@@ -1,11 +1,10 @@
 import { useCallback, useState } from "react";
 import css from "./DeleteProjectDialog.module.css";
 import Dialog from "./Dialog";
-import type { MockProject } from "./mocks";
-import useProjects from "./useProjects";
+import useProjects, { IProject } from "./useProjects";
 
 interface DeleteProjectDialogProps {
-  project: MockProject;
+  project: IProject;
   isOpen: boolean;
   onClose: () => void;
 }

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/Home.tsx
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/Home.tsx
@@ -3,10 +3,9 @@ import CreateProjectButton from "./CreateProjectButton";
 import DeleteProjectButton from "./DeleteProjectButton";
 import css from "./Home.module.css";
 import Layout from "./Layout";
-import type { MockProject } from "./mocks";
 import { ProjectDetails } from "./ProjectDetails";
 import ProjectSelect from "./ProjectSelect";
-import useProjects from "./useProjects";
+import useProjects, { IProject } from "./useProjects";
 
 function Home() {
   const [projectId, setProjectId] = useState<string | undefined>(undefined);
@@ -15,7 +14,7 @@ function Home() {
   const project = projects?.find((p) => p.id === projectId);
 
   const handleSelectProject = useCallback(
-    (p: MockProject) => setProjectId(p.id),
+    (p: IProject) => setProjectId(p.id),
     [],
   );
 

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/ProjectDetails.tsx
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/ProjectDetails.tsx
@@ -1,14 +1,13 @@
 import aipLogo from "/aip-icon.svg";
 import { useCallback, useEffect, useRef, useState } from "react";
 import CreateTaskButton from "./CreateTaskButton";
-import type { MockProject } from "./mocks";
 import css from "./ProjectDetails.module.css";
 import TaskList from "./TaskList";
-import useProjects from "./useProjects";
+import useProjects, { IProject } from "./useProjects";
 import { useProjectTasks } from "./useProjectTasks";
 
 interface ProjectDetailsProps {
-  project: MockProject;
+  project: IProject;
 }
 
 export function ProjectDetails({ project }: ProjectDetailsProps) {

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/ProjectSelect.tsx
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/ProjectSelect.tsx
@@ -1,10 +1,10 @@
 import { ChangeEvent, useCallback } from "react";
-import { MockProject } from "./mocks";
+import { IProject } from "./useProjects";
 
 interface ProjectSelectProps {
-  project: MockProject | undefined;
-  projects: MockProject[];
-  onSelectProject: (project: MockProject) => void;
+  project: IProject | undefined;
+  projects: IProject[];
+  onSelectProject: (project: IProject) => void;
 }
 
 function ProjectSelect({

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/TaskList.tsx
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/TaskList.tsx
@@ -1,10 +1,10 @@
-import type { MockProject } from "./mocks";
 import css from "./TaskList.module.css";
 import TaskListItem from "./TaskListItem";
+import { IProject } from "./useProjects";
 import { useProjectTasks } from "./useProjectTasks";
 
 interface TaskListProps {
-  project: MockProject;
+  project: IProject;
   onTaskDeleted: (taskId: string | undefined) => void;
 }
 

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/TaskListItem.tsx
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/TaskListItem.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { MockTask } from "./mocks";
 import css from "./TaskListItem.module.css";
+import { ITask } from "./useProjects";
 
 interface TaskListItemProps {
-  task: MockTask;
-  deleteTask: (task: MockTask) => Promise<void>;
+  task: ITask;
+  deleteTask: (task: ITask) => Promise<void>;
   onTaskDeleted: (taskId: string | undefined) => void;
 }
 

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/mocks.ts
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/mocks.ts
@@ -1,50 +1,12 @@
-export interface MockProject {
-  $apiName: string;
-  $primaryKey: string;
-  id: string;
-  name: string;
-  description: string;
-  tasks: MockTask[];
-}
+import { IProject, ITask } from "./useProjects";
 
-export interface MockTask {
-  $apiName: string;
-  $primaryKey: string;
-  id: string;
-  title: string;
-  description: string;
-}
-
-const projects: MockProject[] = [
+const projects: IProject[] = [
   {
     $apiName: "MockProject",
     $primaryKey: "1",
     id: "1",
     name: "Mock project",
     description: "This is a mock description",
-    tasks: [
-      {
-        $apiName: "MockTask",
-        $primaryKey: "1",
-        id: "1",
-        title: "Try to",
-        description: "task description 1",
-      },
-      {
-        $apiName: "MockTask",
-        $primaryKey: "2",
-        id: "2",
-        title: "Implement this",
-        description: "task description 2",
-      },
-      {
-        $apiName: "MockTask",
-        $primaryKey: "3",
-        id: "3",
-        title: "With the Ontology SDK!",
-        description: "task description 3",
-      },
-    ],
   },
   {
     $apiName: "MockProject",
@@ -52,18 +14,43 @@ const projects: MockProject[] = [
     id: "2",
     name: "Yet another mock project",
     description: "This is another mock description",
-    tasks: [
-      {
-        $apiName: "MockTask",
-        $primaryKey: "4",
-        id: "4",
-        title: "More tasks here",
-        description: "More task description",
-      },
-    ],
   },
 ];
 
+const tasks: ITask[] = [
+  {
+    $apiName: "MockTask",
+    $primaryKey: "1",
+    id: "1",
+    title: "Try to",
+    description: "task description 1",
+    projectId: "1",
+  },
+  {
+    $apiName: "MockTask",
+    $primaryKey: "2",
+    id: "2",
+    title: "Implement this",
+    description: "task description 2",
+    projectId: "1",
+  },
+  {
+    $apiName: "MockTask",
+    $primaryKey: "3",
+    id: "3",
+    title: "With the Ontology SDK!",
+    description: "task description 3",
+    projectId: "1",
+  },
+  {
+    $apiName: "MockTask",
+    $primaryKey: "4",
+    id: "4",
+    title: "More tasks here",
+    description: "More task description",
+    projectId: "2",
+  },
+];
 async function delay(): Promise<void> {
   return new Promise((resolve) =>
     setTimeout(() => resolve(), 500 + Math.random() * 1000)
@@ -75,7 +62,7 @@ function randomId(): string {
   return `${Math.floor(Math.random() * 2 ** 31)}`;
 }
 
-async function getProjects(): Promise<MockProject[]> {
+async function getProjects(): Promise<IProject[]> {
   await delay();
   const result = [...projects];
   result.sort((p1, p2) => p1.name.localeCompare(p2.name));
@@ -84,11 +71,10 @@ async function getProjects(): Promise<MockProject[]> {
 
 async function createProject({
   name,
-  description = "",
 }: {
   name: string;
   description?: string;
-}): Promise<MockProject["$primaryKey"]> {
+}): Promise<IProject["$primaryKey"]> {
   await delay();
   const id = randomId();
   projects.push({
@@ -96,24 +82,24 @@ async function createProject({
     $primaryKey: id,
     id,
     name,
-    description,
-    tasks: [],
+    description: "",
   });
   return id;
 }
 
 async function getRecommendedProjectDescription(
-  project: MockProject,
+  project: IProject,
 ): Promise<string> {
   await delay();
-  if (project.tasks != null && project.tasks.length === 0) {
+  const projectTasks = tasks.filter((t) => t.projectId === project.id);
+  if (projectTasks.length === 0) {
     throw new Error("Project description recommendation requires tasks");
   }
   return `AIP Logic mock description for project`;
 }
 
 async function updateProjectDescription(
-  project: MockProject,
+  project: IProject,
 ): Promise<void> {
   await delay();
   project.description = await getRecommendedProjectDescription(project);
@@ -127,6 +113,11 @@ async function deleteProject(id: string): Promise<void> {
   }
 }
 
+async function getProjectTasks(projectId: string): Promise<ITask[]> {
+  await delay();
+  return tasks.filter((t) => t.projectId === projectId);
+}
+
 async function createTask({
   title,
   description = "",
@@ -135,19 +126,20 @@ async function createTask({
   title: string;
   description: string;
   projectId: string;
-}): Promise<MockTask["$primaryKey"]> {
+}): Promise<ITask["$primaryKey"]> {
   await delay();
   const project = projects.find((p) => p.id === projectId);
   if (project == null) {
     throw new Error(`Project ${projectId} not found!`);
   }
   const id = randomId();
-  project.tasks.unshift({
+  tasks.unshift({
     $apiName: "MockTask",
     $primaryKey: id,
     id,
     title,
     description,
+    projectId,
   });
   return id;
 }
@@ -164,11 +156,9 @@ async function getRecommendedTaskDescription(
 
 async function deleteTask(id: string): Promise<void> {
   await delay();
-  for (const project of projects) {
-    const idx = project.tasks.findIndex((t) => t.id === id);
-    if (idx !== -1) {
-      project.tasks.splice(idx, 1);
-    }
+  const idx = tasks.findIndex((t) => t.id === id);
+  if (idx !== -1) {
+    tasks.splice(idx, 1);
   }
 }
 
@@ -177,6 +167,7 @@ const Mocks = {
   createProject,
   getRecommendedProjectDescription,
   deleteProject,
+  getProjectTasks,
   createTask,
   deleteTask,
   getRecommendedTaskDescription,

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/useProjectTasks.ts
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/useProjectTasks.ts
@@ -1,23 +1,24 @@
 import { useCallback } from "react";
 import useSWR from "swr";
-import Mocks, { MockProject, MockTask } from "./mocks";
+import Mocks from "./mocks";
+import { IProject, ITask } from "./useProjects";
 
-export function useProjectTasks(project: MockProject | undefined) {
-  const { data, isLoading, isValidating, error, mutate } = useSWR<MockTask[]>(
+export function useProjectTasks(project: IProject | undefined) {
+  const { data, isLoading, isValidating, error, mutate } = useSWR<ITask[]>(
     project != null ? `projects/${project.id}/tasks` : null,
     // Try to implement this with the Ontology SDK!
     async () => {
       if (project == null) {
         return [];
       }
-      return project.tasks;
+      return Mocks.getProjectTasks(project.$primaryKey);
     },
   );
 
   const createTask: (
     title: string,
     description: string,
-  ) => Promise<MockTask["$primaryKey"] | undefined> = useCallback(
+  ) => Promise<ITask["$primaryKey"] | undefined> = useCallback(
     async (title: string, description: string) => {
       if (project == null) {
         return undefined;
@@ -34,12 +35,11 @@ export function useProjectTasks(project: MockProject | undefined) {
     [project, mutate],
   );
 
-  const deleteTask: (task: MockTask) => Promise<void> = useCallback(
+  const deleteTask: (task: ITask) => Promise<void> = useCallback(
     async (task) => {
       if (project == null) {
         return;
       }
-      await sleep(1000);
       // Try to implement this with the Ontology SDK!
       await Mocks.deleteTask(task.$primaryKey);
       await mutate();
@@ -68,8 +68,4 @@ export function useProjectTasks(project: MockProject | undefined) {
     deleteTask,
     getRecommendedTaskDescription,
   };
-}
-
-function sleep(ms: number) {
-  return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/useProjects.ts
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/useProjects.ts
@@ -1,19 +1,37 @@
 import { useCallback } from "react";
 import useSWR from "swr";
-import type { MockProject } from "./mocks";
 import Mocks from "./mocks";
 
+export interface IProject {
+  $apiName: string;
+  $primaryKey: string;
+  id: string;
+  name: string;
+  description: string;
+}
+
+export interface ITask {
+  $apiName: string;
+  $primaryKey: string;
+  id: string;
+  title: string;
+  description: string;
+  projectId: string;
+}
+
 function useProjects() {
-  const { data, isLoading, isValidating, error, mutate } = useSWR<
-    MockProject[]
-  >("projects", async () => {
+  const { data, isLoading, isValidating, error, mutate } = useSWR<IProject[]>("projects", async () => {
     // Try to implement this with the Ontology SDK!
-    return Mocks.getProjects();
-  });
+    const projectsList: IProject[] = (await Mocks.getProjects()).map((project) => ({
+      ...project
+    }));
+    return projectsList;
+    }
+  );
 
   const createProject: (
     name: string,
-  ) => Promise<MockProject["$primaryKey"]> = useCallback(
+  ) => Promise<IProject["$primaryKey"]> = useCallback(
     async (name: string) => {
       // Try to implement this with the Ontology SDK!
       const id = await Mocks.createProject({ name });
@@ -24,7 +42,7 @@ function useProjects() {
   );
 
   const updateProjectDescription: (
-    project: MockProject,
+    project: IProject,
   ) => Promise<void> = useCallback(
     async (project) => {
       // Try to implement this with the Ontology SDK!
@@ -34,7 +52,7 @@ function useProjects() {
     [mutate],
   );
 
-  const deleteProject: (project: MockProject) => Promise<void> = useCallback(
+  const deleteProject: (project: IProject) => Promise<void> = useCallback(
     async (project) => {
       // Try to implement this with the Ontology SDK!
       await Mocks.deleteProject(project.$primaryKey);

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/src/CreateTaskButton.tsx
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/src/CreateTaskButton.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useState } from "react";
 import CreateTaskDialog from "./CreateTaskDialog";
-import { MockProject } from "./mocks";
 import { useProjectTasks } from "./useProjectTasks";
+import { IProject } from "./useProjects";
 
 interface CreateTaskButtonProps {
-  project: MockProject;
+  project: IProject;
 }
 
 function CreateTaskButton({ project }: CreateTaskButtonProps) {

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/src/CreateTaskDialog.tsx
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/src/CreateTaskDialog.tsx
@@ -1,10 +1,10 @@
 import { ChangeEvent, useCallback, useEffect, useState } from "react";
 import Dialog from "./Dialog";
-import { MockProject } from "./mocks";
 import { useProjectTasks } from "./useProjectTasks";
+import { IProject } from "./useProjects";
 
 interface CreateTaskDialogProps {
-  project: MockProject;
+  project: IProject;
   isOpen: boolean;
   onClose: () => void;
 }

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/src/DeleteProjectButton.tsx
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/src/DeleteProjectButton.tsx
@@ -1,10 +1,9 @@
 import { useCallback, useState } from "react";
 import DeleteProjectDialog from "./DeleteProjectDialog";
-import { MockProject } from "./mocks";
-import useProjects from "./useProjects";
+import useProjects, { IProject } from "./useProjects";
 
 interface DeleteProjectButtonProps {
-  project: MockProject;
+  project: IProject;
 }
 
 function DeleteProjectButton({ project }: DeleteProjectButtonProps) {

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/src/DeleteProjectDialog.tsx
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/src/DeleteProjectDialog.tsx
@@ -1,10 +1,9 @@
 import { useCallback, useState } from "react";
 import Dialog from "./Dialog";
-import { MockProject } from "./mocks";
-import useProjects from "./useProjects";
+import useProjects, { IProject } from "./useProjects";
 
 interface DeleteProjectDialogProps {
-  project: MockProject;
+  project: IProject;
   isOpen: boolean;
   onClose: () => void;
 }

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/src/Home.tsx
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/src/Home.tsx
@@ -4,10 +4,9 @@ import CreateTaskButton from "./CreateTaskButton";
 import DeleteProjectButton from "./DeleteProjectButton";
 import css from "./Home.module.css";
 import Layout from "./Layout";
-import { MockProject } from "./mocks";
 import ProjectSelect from "./ProjectSelect";
 import TaskList from "./TaskList";
-import useProjects from "./useProjects";
+import useProjects, { IProject } from "./useProjects";
 
 function Home() {
   const [projectId, setProjectId] = useState<string | undefined>(undefined);
@@ -15,7 +14,7 @@ function Home() {
   const project = projects?.find((p) => p.id === projectId);
 
   const handleSelectProject = useCallback(
-    (p: MockProject) => setProjectId(p.id),
+    (p: IProject) => setProjectId(p.id),
     [],
   );
 

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/src/ProjectSelect.tsx
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/src/ProjectSelect.tsx
@@ -1,10 +1,10 @@
 import { ChangeEvent, useCallback } from "react";
-import { MockProject } from "./mocks";
+import { IProject } from "./useProjects";
 
 interface ProjectSelectProps {
-  project: MockProject | undefined;
-  projects: MockProject[];
-  onSelectProject: (project: MockProject) => void;
+  project: IProject | undefined;
+  projects: IProject[];
+  onSelectProject: (project: IProject) => void;
 }
 
 function ProjectSelect({

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/src/TaskList.tsx
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/src/TaskList.tsx
@@ -1,10 +1,10 @@
-import { MockProject } from "./mocks";
 import css from "./TaskList.module.css";
 import TaskListItem from "./TaskListItem";
+import { IProject } from "./useProjects";
 import { useProjectTasks } from "./useProjectTasks";
 
 interface TaskListProps {
-  project: MockProject;
+  project: IProject;
 }
 
 function TaskList({ project }: TaskListProps) {

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/src/TaskListItem.tsx
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/src/TaskListItem.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useState } from "react";
-import { MockTask } from "./mocks";
 import css from "./TaskListItem.module.css";
+import { ITask } from "./useProjects";
 
 interface TaskListItemProps {
-  task: MockTask;
-  deleteTask: (task: MockTask) => Promise<void>;
+  task: ITask;
+  deleteTask: (task: ITask) => Promise<void>;
 }
 
 function TaskListItem({ task, deleteTask }: TaskListItemProps) {

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/src/mocks.ts
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/src/mocks.ts
@@ -1,60 +1,51 @@
-export interface MockProject {
-  $apiName: string;
-  $primaryKey: string;
-  id: string;
-  name: string;
-  tasks: MockTask[];
-}
+import { IProject, ITask } from "./useProjects";
 
-export interface MockTask {
-  $apiName: string;
-  $primaryKey: string;
-  id: string;
-  title: string;
-}
-
-const projects: MockProject[] = [
+const projects: IProject[] = [
   {
     $apiName: "MockProject",
     $primaryKey: "1",
     id: "1",
-    name: "Mock project",
-    tasks: [
-      {
-        $apiName: "MockTask",
-        $primaryKey: "1",
-        id: "1",
-        title: "Try to",
-      },
-      {
-        $apiName: "MockTask",
-        $primaryKey: "2",
-        id: "2",
-        title: "Implement this",
-      },
-      {
-        $apiName: "MockTask",
-        $primaryKey: "3",
-        id: "3",
-        title: "With the Ontology SDK!",
-      },
-    ],
+    name: "Mock project"
   },
   {
     $apiName: "MockProject",
     $primaryKey: "2",
     id: "2",
     name: "Yet another mock project",
-    tasks: [
-      {
-        $apiName: "MockTask",
-        $primaryKey: "4",
-        id: "4",
-        title: "More tasks here",
-      },
-    ],
   },
 ];
+
+const tasks: ITask[] = [
+    {
+      $apiName: "MockTask",
+      $primaryKey: "1",
+      id: "1",
+      title: "Try to",
+      projectId: "1",
+    },
+    {
+      $apiName: "MockTask",
+      $primaryKey: "2",
+      id: "2",
+      title: "Implement this",
+      projectId: "1",
+    },
+    {
+      $apiName: "MockTask",
+      $primaryKey: "3",
+      id: "3",
+      title: "With the Ontology SDK!",
+      projectId: "1",
+    },
+    {
+      $apiName: "MockTask",
+      $primaryKey: "4",
+      id: "4",
+      title: "More tasks here",
+      projectId: "2",
+    },
+  ]
+
 
 async function delay(): Promise<void> {
   return new Promise((resolve) =>
@@ -67,7 +58,7 @@ function randomId(): string {
   return `${Math.floor(Math.random() * 2 ** 31)}`;
 }
 
-async function getProjects(): Promise<MockProject[]> {
+async function getProjects(): Promise<IProject[]> {
   await delay();
   const result = [...projects];
   result.sort((p1, p2) => p1.name.localeCompare(p2.name));
@@ -78,7 +69,7 @@ async function createProject({
   name,
 }: {
   name: string;
-}): Promise<MockProject["$primaryKey"]> {
+}): Promise<IProject["$primaryKey"]> {
   await delay();
   const id = randomId();
   projects.push({
@@ -86,7 +77,6 @@ async function createProject({
     $primaryKey: id,
     id,
     name,
-    tasks: [],
   });
   return id;
 }
@@ -99,37 +89,41 @@ async function deleteProject(id: string): Promise<void> {
   }
 }
 
+async function getProjectTasks(projectId: string): Promise<ITask[]> {
+  await delay();
+  return tasks.filter((t) => t.projectId === projectId);
+}
+
 async function createTask({
   title,
   projectId,
 }: {
   title: string;
   projectId: string;
-}): Promise<MockTask["$primaryKey"]> {
+}): Promise<ITask["$primaryKey"]> {
   await delay();
-  const project = projects.find((p) => p.id === projectId);
-  if (project == null) {
+  const task = tasks.find((t) => t.projectId === projectId);
+  if (task == null) {
     throw new Error(`Project ${projectId} not found!`);
   }
   const id = randomId();
-  project.tasks.unshift({ $apiName: "MockTask", $primaryKey: id, id, title });
+  tasks.unshift({ $apiName: "MockTask", $primaryKey: id, id, title, projectId });
   return id;
 }
 
 async function deleteTask(id: string): Promise<void> {
   await delay();
-  for (const project of projects) {
-    const idx = project.tasks.findIndex((t) => t.id === id);
-    if (idx !== -1) {
-      project.tasks.splice(idx, 1);
+  const idx = tasks.findIndex((t) => t.projectId === id);
+  if (idx !== -1) {
+      tasks.splice(idx, 1);
     }
-  }
 }
 
 const Mocks = {
   getProjects,
   createProject,
   deleteProject,
+  getProjectTasks,
   createTask,
   deleteTask,
 };

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/src/useProjectTasks.ts
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/src/useProjectTasks.ts
@@ -1,22 +1,23 @@
 import { useCallback } from "react";
 import useSWR from "swr";
-import Mocks, { MockProject, MockTask } from "./mocks";
+import Mocks from "./mocks";
+import { IProject, ITask } from "./useProjects";
 
-export function useProjectTasks(project: MockProject | undefined) {
-  const { data, isLoading, isValidating, error, mutate } = useSWR<MockTask[]>(
+export function useProjectTasks(project: IProject | undefined) {
+  const { data, isLoading, isValidating, error, mutate } = useSWR<ITask[]>(
     project != null ? `projects/${project.id}/tasks` : null,
     // Try to implement this with the Ontology SDK!
     async () => {
       if (project == null) {
         return [];
       }
-      return project.tasks;
-    },
+      return (await Mocks.getProjectTasks(project.$primaryKey))
+    }
   );
 
   const createTask: (
     title: string,
-  ) => Promise<MockTask["$primaryKey"] | undefined> = useCallback(
+  ) => Promise<ITask["$primaryKey"] | undefined> = useCallback(
     async (title) => {
       if (project == null) {
         return undefined;
@@ -32,12 +33,11 @@ export function useProjectTasks(project: MockProject | undefined) {
     [project, mutate],
   );
 
-  const deleteTask: (task: MockTask) => Promise<void> = useCallback(
+  const deleteTask: (task: ITask) => Promise<void> = useCallback(
     async (task) => {
       if (project == null) {
         return;
       }
-      await sleep(1000);
       // Try to implement this with the Ontology SDK!
       await Mocks.deleteTask(task.$primaryKey);
       await mutate();
@@ -53,8 +53,4 @@ export function useProjectTasks(project: MockProject | undefined) {
     createTask,
     deleteTask,
   };
-}
-
-function sleep(ms: number) {
-  return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/src/useProjects.ts
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/src/useProjects.ts
@@ -1,16 +1,33 @@
 import { useCallback } from "react";
 import useSWR from "swr";
-import Mocks, { MockProject } from "./mocks";
+import Mocks from "./mocks";
+
+export interface IProject {
+  $apiName: string;
+  $primaryKey: string;
+  id: string;
+  name: string;
+}
+
+export interface ITask {
+  $apiName: string;
+  $primaryKey: string;
+  id: string;
+  title: string | undefined;
+  projectId: string;
+}
 
 function useProjects() {
-  const { data, isLoading, isValidating, error, mutate } = useSWR<
-    MockProject[]
-  >("projects", async () => {
+  const { data, isLoading, isValidating, error, mutate } = useSWR<IProject[]>("projects", async () => {
     // Try to implement this with the Ontology SDK!
-    return Mocks.getProjects();
-  });
+    const projectsList: IProject[] = (await Mocks.getProjects()).map((project) => ({
+      ...project,
+    }));
+    return projectsList;
+    }
+  );
 
-  const createProject: (name: string) => Promise<MockProject["$primaryKey"]> =
+  const createProject: (name: string) => Promise<IProject["$primaryKey"]> =
     useCallback(
       async (name) => {
         // Try to implement this with the Ontology SDK!
@@ -21,7 +38,7 @@ function useProjects() {
       [mutate],
     );
 
-  const deleteProject: (project: MockProject) => Promise<void> = useCallback(
+  const deleteProject: (project: IProject) => Promise<void> = useCallback(
     async (project) => {
       // Try to implement this with the Ontology SDK!
       await Mocks.deleteProject(project.$primaryKey);


### PR DESCRIPTION
ToDo tutorial on version 2.0 fails to build when you complete only lesson 1 out of the 2-3 lessons. This is due to type mismatch with the mock objects. 
When users are using VS code in platform and check in the code the CI will fail as it run `npm run build`, which is a poor experience. 
This PR extract the dependency of most of the code from the Mock objects so you can implement each method at a time and code will still compile. This PR will go together with a [forge pr](https://github.palantir.build/foundry/forge/pull/153270) to fix the suggested solutions to the lessons.