### PR TITLE
Prep work for splitting clis

### DIFF
--- a/.changeset/seven-gorillas-work.md
+++ b/.changeset/seven-gorillas-work.md
@@ -1,0 +1,9 @@
+---
+"@osdk/cli.cmd.typescript": patch
+"@osdk/create-widget": patch
+"@osdk/cli.common": patch
+"@osdk/create-app": patch
+"@osdk/cli": patch
+---
+
+Internal: preparation for repo splitting

--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -59,7 +59,6 @@ const checkApiPackages = [
 
 // Packages that should be private
 const privatePackages = [
-  "@osdk/cli.*",
   "@osdk/client.test.ontology",
   "@osdk/create-app.template-packager",
   "@osdk/create-app.template.*",

--- a/babel.config.mjs
+++ b/babel.config.mjs
@@ -18,6 +18,7 @@ import { findUp } from "find-up";
 import { readFile } from "fs/promises";
 import * as path from "node:path";
 
+process.env.STABLE_PACKAGE_CLIENT_VERSION = "~2.0.11";
 process.env.PACKAGE_VERSION = await readPackageVersion(process.cwd());
 process.env.PACKAGE_API_VERSION = await readPackageVersion("packages/api");
 process.env.PACKAGE_CLIENT_VERSION = await readPackageVersion(
@@ -40,6 +41,7 @@ const config = function(api) {
           "PACKAGE_API_VERSION",
           "PACKAGE_CLIENT_VERSION",
           "PACKAGE_CLI_VERSION",
+          "STABLE_PACKAGE_CLIENT_VERSION",
           "TARGET",
           "MODE",
         ],

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli.cmd.typescript",
-  "private": true,
+  "private": false,
   "version": "0.25.0-beta.20",
   "license": "Apache-2.0",
   "repository": {
@@ -30,8 +30,9 @@
   },
   "dependencies": {
     "@arethetypeswrong/cli": "^0.15.2",
-    "@osdk/cli.common": "workspace:~",
-    "@osdk/generator": "workspace:~",
+    "@osdk/cli.common": "workspace:*",
+    "@osdk/generator": "workspace:*",
+    "@osdk/generator-utils": "workspace:*",
     "@osdk/internal.foundry.core": "2.8.0",
     "@osdk/internal.foundry.ontologiesv2": "2.8.0",
     "@osdk/shared.client.impl": "workspace:~",

--- a/packages/cli.cmd.typescript/src/generate/generate.ts
+++ b/packages/cli.cmd.typescript/src/generate/generate.ts
@@ -162,7 +162,7 @@ export const generateCommand: CommandModule<
       );
   },
   handler: async (args) => {
-    const command = await import("./handleGenerate.mjs");
+    const command = await import("./handleGenerate.js");
     await command.handleGenerate(args);
   },
 };

--- a/packages/cli.cmd.typescript/src/generate/handleGenerate.test.ts
+++ b/packages/cli.cmd.typescript/src/generate/handleGenerate.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { updateVersionsIfTheyExist } from "./handleGenerate.mjs";
+import { updateVersionsIfTheyExist } from "./handleGenerate.js";
 
 describe(updateVersionsIfTheyExist, () => {
   it("should update versions if they exist", () => {

--- a/packages/cli.cmd.typescript/src/generate/handleGenerate.ts
+++ b/packages/cli.cmd.typescript/src/generate/handleGenerate.ts
@@ -22,6 +22,7 @@ import {
   generateClientSdkVersionTwoPointZero,
   getExpectedDependencies,
 } from "@osdk/generator";
+import { changeVersionPrefix } from "@osdk/generator-utils";
 import type { OntologyIdentifier } from "@osdk/internal.foundry.core";
 import { OntologiesV2 } from "@osdk/internal.foundry.ontologiesv2";
 import { createSharedClientContext } from "@osdk/shared.client.impl";
@@ -281,8 +282,16 @@ export async function getDependencyVersions() {
   const tslibVersion = ourPackageJson.dependencies.tslib;
   const areTheTypesWrongVersion =
     ourPackageJson.dependencies["@arethetypeswrong/cli"];
-  const osdkClientVersion = `^${process.env.PACKAGE_CLIENT_VERSION}`;
-  const osdkApiVersion = `^${process.env.PACKAGE_API_VERSION}`;
+  const osdkClientVersion = changeVersionPrefix(
+    process.env.PACKAGE_CLIENT_VERSION!,
+    "^",
+  );
+
+  const osdkApiVersion = changeVersionPrefix(
+    process.env.PACKAGE_API_VERSION!,
+    "^",
+  );
+
   const osdkLegacyClientVersion =
     `^${process.env.PACKAGE_LEGACY_CLIENT_VERSION}`;
 

--- a/packages/cli.common/package.json
+++ b/packages/cli.common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli.common",
-  "private": true,
+  "private": false,
   "version": "0.25.0-beta.20",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/client.test.ontology/generateMockOntology.js
+++ b/packages/client.test.ontology/generateMockOntology.js
@@ -23,8 +23,8 @@ import { mkdir, readdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "url";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const outDir = join(__dirname, "src", "generatedNoCheck");
+const THIS_FILE_DIR = dirname(fileURLToPath(import.meta.url));
+const outDir = join(THIS_FILE_DIR, "src", "generatedNoCheck");
 
 try {
   rmSync(outDir, { recursive: true, force: true });

--- a/packages/create-app/codegen.mjs
+++ b/packages/create-app/codegen.mjs
@@ -19,7 +19,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const THIS_FILE_DIR = path.dirname(fileURLToPath(import.meta.url));
 
 export const TEMPLATES = [
   {
@@ -62,14 +62,14 @@ export const TEMPLATES = [
   },
 ];
 
-const packagesDir = path.join(__dirname, "../");
+const packagesDir = path.join(THIS_FILE_DIR, "../");
 
-fs.mkdirSync(path.join(__dirname, "./src/generatedNoCheck"), {
+fs.mkdirSync(path.join(THIS_FILE_DIR, "./src/generatedNoCheck"), {
   recursive: true,
 });
 
 fs.writeFileSync(
-  path.join(__dirname, "./src/generatedNoCheck/templates.ts"),
+  path.join(THIS_FILE_DIR, "./src/generatedNoCheck/templates.ts"),
   dedent`
   // THIS FILE IS GENERATED. DO NOT MODIFY.
   // You probably want to modify ../../../codegen.mjs instead.

--- a/packages/create-app/src/run.ts
+++ b/packages/create-app/src/run.ts
@@ -15,11 +15,9 @@
  */
 
 import { changeVersionPrefix } from "@osdk/generator-utils";
-import { findUpSync } from "find-up";
 import Handlebars from "handlebars";
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { consola } from "./consola.js";
 import {
   generateEnvDevelopment,
@@ -108,16 +106,9 @@ export async function run(
     );
   }
 
-  const ourPackageJsonPath = findUpSync("package.json", {
-    cwd: fileURLToPath(import.meta.url),
-  });
-
-  const ourPackageJsonVersion: string | undefined = ourPackageJsonPath
-    ? JSON.parse(fs.readFileSync(ourPackageJsonPath, "utf-8")).version
-    : undefined;
-
-  const clientVersion = process.env.PACKAGE_CLIENT_VERSION
-    ?? ourPackageJsonVersion;
+  // In the future we should try to get this information directly from NPM
+  // or maybe add it as a devDependency once it moves out of repo
+  const clientVersion = process.env.STABLE_PACKAGE_CLIENT_VERSION;
 
   if (clientVersion === undefined) {
     throw new Error("Could not determine current @osdk/client version");

--- a/packages/create-widget/codegen.mjs
+++ b/packages/create-widget/codegen.mjs
@@ -19,7 +19,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const THIS_FILE_DIR = path.dirname(fileURLToPath(import.meta.url));
 
 export const TEMPLATES = [
   {
@@ -30,14 +30,14 @@ export const TEMPLATES = [
   },
 ];
 
-const packagesDir = path.join(__dirname, "../");
+const packagesDir = path.join(THIS_FILE_DIR, "../");
 
-fs.mkdirSync(path.join(__dirname, "./src/generatedNoCheck"), {
+fs.mkdirSync(path.join(THIS_FILE_DIR, "./src/generatedNoCheck"), {
   recursive: true,
 });
 
 fs.writeFileSync(
-  path.join(__dirname, "./src/generatedNoCheck/templates.ts"),
+  path.join(THIS_FILE_DIR, "./src/generatedNoCheck/templates.ts"),
   dedent`
   // THIS FILE IS GENERATED. DO NOT MODIFY.
   // You probably want to modify ../../../codegen.mjs instead.

--- a/packages/create-widget/src/run.ts
+++ b/packages/create-widget/src/run.ts
@@ -15,11 +15,9 @@
  */
 
 import { changeVersionPrefix } from "@osdk/generator-utils";
-import { findUpSync } from "find-up";
 import Handlebars from "handlebars";
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { consola } from "./consola.js";
 import { generateFoundryConfigJson } from "./generate/generateFoundryConfigJson.js";
 import { generateNpmRc } from "./generate/generateNpmRc.js";
@@ -91,16 +89,9 @@ export async function run({
     );
   }
 
-  const ourPackageJsonPath = findUpSync("package.json", {
-    cwd: fileURLToPath(import.meta.url),
-  });
-
-  const ourPackageJsonVersion: string | undefined = ourPackageJsonPath
-    ? JSON.parse(fs.readFileSync(ourPackageJsonPath, "utf-8")).version
-    : undefined;
-
-  const clientVersion = process.env.PACKAGE_CLIENT_VERSION
-    ?? ourPackageJsonVersion;
+  // In the future we should try to get this information directly from NPM
+  // or maybe add it as a devDependency once it moves out of repo
+  const clientVersion = process.env.STABLE_PACKAGE_CLIENT_VERSION;
 
   if (clientVersion === undefined) {
     throw new Error("Could not determine current @osdk/client version");

--- a/packages/example-generator/src/check.test.ts
+++ b/packages/example-generator/src/check.test.ts
@@ -19,13 +19,13 @@ import { fileURLToPath } from "node:url";
 import { it } from "vitest";
 import { run } from "./run.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const THIS_FILE_DIR = path.dirname(fileURLToPath(import.meta.url));
 
 it(
   "Generates code that matches the files on disk in the examples dir",
   async () => {
     await run({
-      outputDirectory: path.join(__dirname, "..", "..", "..", "examples"),
+      outputDirectory: path.join(THIS_FILE_DIR, "..", "..", "..", "examples"),
       check: true,
     });
   },

--- a/packages/foundry-sdk-generator/src/generate/generateBundles.ts
+++ b/packages/foundry-sdk-generator/src/generate/generateBundles.ts
@@ -16,9 +16,13 @@
 
 import commonjs from "@rollup/plugin-commonjs";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { ModuleFormat, RollupBuild } from "rollup";
 import { rollup } from "rollup";
 import nodePolyfill from "rollup-plugin-polyfill-node";
+
+const THIS_FILE_DIR = path.dirname(fileURLToPath(import.meta.url));
 
 async function createRollupBuild(
   absolutePackagePath: string,
@@ -28,7 +32,7 @@ async function createRollupBuild(
 
   const { findUp } = await import("find-up");
   const nodeModulesPath = await findUp("node_modules", {
-    cwd: __dirname,
+    cwd: THIS_FILE_DIR,
     type: "directory",
   });
 

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -22,12 +22,16 @@ import type {
 import { consola } from "consola";
 import { mkdir, readdir, rmdir, writeFile } from "fs/promises";
 import * as immer from "immer";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import { beforeEach, describe, expect, it, test, vi } from "vitest";
 import { compileThis } from "../util/test/compileThis.js";
 import { createMockMinimalFiles } from "../util/test/createMockMinimalFiles.js";
 import { TodoWireOntology } from "../util/test/TodoWireOntology.js";
 import type { WireOntologyDefinition } from "../WireOntologyDefinition.js";
 import { generateClientSdkVersionTwoPointZero } from "./generateClientSdkVersionTwoPointZero.js";
+
+const THIS_FILE_DIR = path.dirname(fileURLToPath(import.meta.url));
 
 function changeValue<T extends Record<K, any>, K extends keyof immer.Draft<T>>(
   draft: immer.Draft<T>,
@@ -1706,10 +1710,10 @@ describe("generator", () => {
 
   test.skip("runs generator locally", async () => {
     try {
-      await rmdir(`${__dirname}/generated`, { recursive: true });
+      await rmdir(`${THIS_FILE_DIR}/generated`, { recursive: true });
     } catch (e) {
     }
-    await mkdir(`${__dirname}/generated`, { recursive: true });
+    await mkdir(`${THIS_FILE_DIR}/generated`, { recursive: true });
     await generateClientSdkVersionTwoPointZero(
       TodoWireOntology,
       "typescript-sdk/0.0.0 osdk-cli/0.0.0",
@@ -1722,7 +1726,7 @@ describe("generator", () => {
         },
         readdir: async (path) => await readdir(path),
       },
-      `${__dirname}/generated/`,
+      `${THIS_FILE_DIR}/generated/`,
     );
   });
 

--- a/packages/monorepo.cspell/cspell.config.js
+++ b/packages/monorepo.cspell/cspell.config.js
@@ -20,6 +20,7 @@
 const fs = require("fs");
 const path = require("path");
 
+// this is okay because this file is a commonjs file
 const DICT_FOLDER = __dirname;
 
 const REGEX_OSDK_PACKAGE_NAME = /@osdk\/[\w\d.\-]+/g;

--- a/packages/monorepo.tsup/tsup.mjs
+++ b/packages/monorepo.tsup/tsup.mjs
@@ -32,6 +32,7 @@ export default async (options, ourOptions) => {
       PACKAGE_API_VERSION: await readPackageVersion("packages/api"),
       PACKAGE_CLIENT_VERSION: await readPackageVersion("packages/client"),
       PACKAGE_CLI_VERSION: await readPackageVersion("packages/cli"),
+      STABLE_PACKAGE_CLIENT_VERSION: "~2.0.11",
       TARGET: "node",
       MODE: process.env.production ? "production" : "development",
     },
@@ -39,7 +40,7 @@ export default async (options, ourOptions) => {
     silent: true,
     sourcemap: true,
     splitting: true,
-    shims: true, // so we can use __dirname in both esm and cjs
+    shims: false,
     minify: false, // !options.watch,
     onSuccess: async () => {
       console.log("👍");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,7 +96,7 @@ importers:
         version: 3.1.1(eslint@9.16.0(jiti@1.21.6))
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.16.0(jiti@1.21.6))
+        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6))
       eslint-plugin-unused-imports:
         specifier: ^4.0.1
         version: 4.0.1(@typescript-eslint/eslint-plugin@8.15.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint@9.16.0(jiti@1.21.6))
@@ -123,7 +123,7 @@ importers:
         version: 1.0.1(typescript@5.5.4)
       tsup:
         specifier: ^8.2.3
-        version: 8.2.3(@microsoft/api-extractor@7.47.0(@types/node@22.10.2))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.5.4)(yaml@2.4.5)
+        version: 8.2.3(@microsoft/api-extractor@7.47.0(@types/node@22.10.5))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.5.4)(yaml@2.4.5)
       turbo:
         specifier: ^2.0.9
         version: 2.0.9
@@ -135,7 +135,7 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       vitest:
         specifier: ^2.1.2
-        version: 2.1.3(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 2.1.3(@types/node@22.10.5)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
 
   benchmarks/tests/primary:
     dependencies:
@@ -215,7 +215,7 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.2.1(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))
+        version: 4.2.1(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))
       autoprefixer:
         specifier: ^10.4.19
         version: 10.4.19(postcss@8.4.47)
@@ -236,7 +236,7 @@ importers:
         version: 5.12.0(rollup@4.24.0)
       tailwindcss:
         specifier: ^3.4.4
-        version: 3.4.4(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.5.4))
+        version: 3.4.4(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.5.4))
       tslib:
         specifier: ^2.6.3
         version: 2.7.0
@@ -248,7 +248,7 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       vite:
         specifier: ^5.4.8
-        version: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
 
   examples/example-expo-sdk-2.x:
     dependencies:
@@ -423,7 +423,7 @@ importers:
         version: 29.7.0(@types/node@22.10.1)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.5.4))
       jest-expo:
         specifier: ~52.0.2
-        version: 52.0.2(@babel/core@7.26.0)(expo@52.0.11(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1)))(graphql@16.8.1)(react-native-webview@13.12.2(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1))(jest@29.7.0(@types/node@22.10.1)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.5.4)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)(webpack@5.96.1(esbuild@0.23.0))
+        version: 52.0.2(@babel/core@7.26.0)(expo@52.0.11(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1)))(graphql@16.8.1)(react-native-webview@13.12.2(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1))(jest@29.7.0(@types/node@22.10.1)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.5.4)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)(webpack@5.96.1)
       react-test-renderer:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
@@ -561,13 +561,13 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       '@vitejs/plugin-react':
         specifier: ^4.2.0
-        version: 4.2.1(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))
+        version: 4.2.1(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))
       eslint:
         specifier: ^9.15.0
         version: 9.16.0(jiti@1.21.6)
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.16.0(jiti@1.21.6))
+        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.1
         version: 6.10.1(eslint@9.16.0(jiti@1.21.6))
@@ -591,10 +591,10 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       vite:
         specifier: ^5.4.8
-        version: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
       vitest:
         specifier: ^2.1.2
-        version: 2.1.3(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 2.1.3(@types/node@22.10.5)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
 
   examples/example-react-sdk-2.x:
     dependencies:
@@ -652,7 +652,7 @@ importers:
         version: 9.16.0(jiti@1.21.6)
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.16.0(jiti@1.21.6))
+        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.1
         version: 6.10.1(eslint@9.16.0(jiti@1.21.6))
@@ -719,13 +719,13 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       '@vitejs/plugin-react':
         specifier: ^4.2.0
-        version: 4.2.1(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))
+        version: 4.2.1(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))
       eslint:
         specifier: ^9.15.0
         version: 9.16.0(jiti@1.21.6)
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.16.0(jiti@1.21.6))
+        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.1
         version: 6.10.1(eslint@9.16.0(jiti@1.21.6))
@@ -749,10 +749,10 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       vite:
         specifier: ^5.4.8
-        version: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
       vitest:
         specifier: ^2.1.2
-        version: 2.1.3(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 2.1.3(@types/node@22.10.5)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
 
   examples/example-tutorial-todo-aip-app-sdk-2.x:
     dependencies:
@@ -795,13 +795,13 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       '@vitejs/plugin-react':
         specifier: ^4.2.0
-        version: 4.2.1(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))
+        version: 4.2.1(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))
       eslint:
         specifier: ^9.15.0
         version: 9.16.0(jiti@1.21.6)
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.16.0(jiti@1.21.6))
+        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.1
         version: 6.10.1(eslint@9.16.0(jiti@1.21.6))
@@ -825,10 +825,10 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       vite:
         specifier: ^5.3.4
-        version: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
       vitest:
         specifier: ^2.0.5
-        version: 2.1.3(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 2.1.3(@types/node@22.10.5)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
 
   examples/example-tutorial-todo-app-sdk-1.x:
     dependencies:
@@ -865,13 +865,13 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       '@vitejs/plugin-react':
         specifier: ^4.2.0
-        version: 4.2.1(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))
+        version: 4.2.1(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))
       eslint:
         specifier: ^9.15.0
         version: 9.16.0(jiti@1.21.6)
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.16.0(jiti@1.21.6))
+        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.1
         version: 6.10.1(eslint@9.16.0(jiti@1.21.6))
@@ -895,10 +895,10 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       vite:
         specifier: ^5.4.8
-        version: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
       vitest:
         specifier: ^2.1.2
-        version: 2.1.3(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 2.1.3(@types/node@22.10.5)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
 
   examples/example-tutorial-todo-app-sdk-2.x:
     dependencies:
@@ -941,13 +941,13 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       '@vitejs/plugin-react':
         specifier: ^4.2.0
-        version: 4.2.1(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))
+        version: 4.2.1(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))
       eslint:
         specifier: ^9.15.0
         version: 9.16.0(jiti@1.21.6)
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.16.0(jiti@1.21.6))
+        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.1
         version: 6.10.1(eslint@9.16.0(jiti@1.21.6))
@@ -971,10 +971,10 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       vite:
         specifier: ^5.3.4
-        version: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
       vitest:
         specifier: ^2.0.5
-        version: 2.1.3(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 2.1.3(@types/node@22.10.5)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
 
   examples/example-vue-sdk-1.x:
     dependencies:
@@ -990,16 +990,16 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^5.1.4
-        version: 5.1.4(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))(vue@3.5.11(typescript@5.5.4))
+        version: 5.1.4(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))(vue@3.5.11(typescript@5.5.4))
       typescript:
         specifier: ~5.5.4
         version: 5.5.4
       vite:
         specifier: ^5.4.8
-        version: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
       vitest:
         specifier: ^2.1.2
-        version: 2.1.3(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 2.1.3(@types/node@22.10.5)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
       vue-tsc:
         specifier: ^2.1.6
         version: 2.1.6(typescript@5.5.4)
@@ -1094,7 +1094,7 @@ importers:
         version: 8.15.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.5.4)
       '@vitejs/plugin-react':
         specifier: ^4.2.0
-        version: 4.2.1(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))
+        version: 4.2.1(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))
       eslint:
         specifier: ^9.13.0
         version: 9.13.0(jiti@1.21.6)
@@ -1124,10 +1124,10 @@ importers:
         version: 8.15.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.5.4)
       vite:
         specifier: ^5.4.8
-        version: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
       vitest:
         specifier: ^2.1.2
-        version: 2.1.3(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 2.1.3(@types/node@22.10.5)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
 
   packages/api:
     dependencies:
@@ -1146,10 +1146,10 @@ importers:
     devDependencies:
       '@microsoft/api-documenter':
         specifier: ^7.25.3
-        version: 7.25.3(@types/node@22.10.2)
+        version: 7.25.3(@types/node@22.10.5)
       '@microsoft/api-extractor':
         specifier: ^7.47.0
-        version: 7.47.0(@types/node@22.10.2)
+        version: 7.47.0(@types/node@22.10.5)
       '@osdk/monorepo.api-extractor':
         specifier: workspace:~
         version: link:../monorepo.api-extractor
@@ -1248,11 +1248,14 @@ importers:
         specifier: ^0.15.2
         version: 0.15.3
       '@osdk/cli.common':
-        specifier: workspace:~
+        specifier: workspace:*
         version: link:../cli.common
       '@osdk/generator':
-        specifier: workspace:~
+        specifier: workspace:*
         version: link:../generator
+      '@osdk/generator-utils':
+        specifier: workspace:*
+        version: link:../generator-utils
       '@osdk/internal.foundry.core':
         specifier: 2.8.0
         version: 2.8.0
@@ -1396,10 +1399,10 @@ importers:
     devDependencies:
       '@microsoft/api-documenter':
         specifier: ^7.25.3
-        version: 7.25.3(@types/node@22.10.2)
+        version: 7.25.3(@types/node@22.10.5)
       '@microsoft/api-extractor':
         specifier: ^7.47.0
-        version: 7.47.0(@types/node@22.10.2)
+        version: 7.47.0(@types/node@22.10.5)
       '@osdk/client.test.ontology':
         specifier: workspace:~
         version: link:../client.test.ontology
@@ -1423,7 +1426,7 @@ importers:
         version: 9.5.1
       jest-extended:
         specifier: ^4.0.2
-        version: 4.0.2(jest@29.7.0(@types/node@22.10.2))
+        version: 4.0.2(jest@29.7.0(@types/node@22.10.5))
       msw:
         specifier: ^2.3.4
         version: 2.3.4(typescript@5.5.4)
@@ -1816,7 +1819,7 @@ importers:
         version: 29.7.0(@types/node@22.10.0)(ts-node@10.9.2(@types/node@22.10.0)(typescript@5.5.4))
       jest-expo:
         specifier: ~52.0.2
-        version: 52.0.2(@babel/core@7.26.0)(expo@52.0.11(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1)))(graphql@16.8.1)(react-native-webview@13.12.2(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1))(jest@29.7.0(@types/node@22.10.0)(ts-node@10.9.2(@types/node@22.10.0)(typescript@5.5.4)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)(webpack@5.96.1(esbuild@0.23.0))
+        version: 52.0.2(@babel/core@7.26.0)(expo@52.0.11(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1)))(graphql@16.8.1)(react-native-webview@13.12.2(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1))(jest@29.7.0(@types/node@22.10.0)(ts-node@10.9.2(@types/node@22.10.0)(typescript@5.5.4)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)(webpack@5.96.1)
       react-test-renderer:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
@@ -1975,13 +1978,13 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       '@vitejs/plugin-react':
         specifier: ^4.2.0
-        version: 4.2.1(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))
+        version: 4.2.1(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))
       eslint:
         specifier: ^9.15.0
         version: 9.16.0(jiti@1.21.6)
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.16.0(jiti@1.21.6))
+        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.1
         version: 6.10.1(eslint@9.16.0(jiti@1.21.6))
@@ -2005,10 +2008,10 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       vite:
         specifier: ^5.4.8
-        version: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
       vitest:
         specifier: ^2.1.2
-        version: 2.1.3(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 2.1.3(@types/node@22.10.5)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
 
   packages/create-app.template.react.beta:
     dependencies:
@@ -2066,7 +2069,7 @@ importers:
         version: 9.16.0(jiti@1.21.6)
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.16.0(jiti@1.21.6))
+        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.1
         version: 6.10.1(eslint@9.16.0(jiti@1.21.6))
@@ -2142,13 +2145,13 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       '@vitejs/plugin-react':
         specifier: ^4.2.0
-        version: 4.2.1(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))
+        version: 4.2.1(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))
       eslint:
         specifier: ^9.15.0
         version: 9.16.0(jiti@1.21.6)
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.16.0(jiti@1.21.6))
+        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.1
         version: 6.10.1(eslint@9.16.0(jiti@1.21.6))
@@ -2172,10 +2175,10 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       vite:
         specifier: ^5.4.8
-        version: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
       vitest:
         specifier: ^2.1.2
-        version: 2.1.3(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 2.1.3(@types/node@22.10.5)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
 
   packages/create-app.template.tutorial-todo-aip-app.beta:
     dependencies:
@@ -2221,13 +2224,13 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       '@vitejs/plugin-react':
         specifier: ^4.2.0
-        version: 4.2.1(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))
+        version: 4.2.1(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))
       eslint:
         specifier: ^9.15.0
         version: 9.16.0(jiti@1.21.6)
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.16.0(jiti@1.21.6))
+        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.1
         version: 6.10.1(eslint@9.16.0(jiti@1.21.6))
@@ -2251,10 +2254,10 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       vite:
         specifier: ^5.3.4
-        version: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
       vitest:
         specifier: ^2.0.5
-        version: 2.1.3(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 2.1.3(@types/node@22.10.5)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
 
   packages/create-app.template.tutorial-todo-app:
     dependencies:
@@ -2300,13 +2303,13 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       '@vitejs/plugin-react':
         specifier: ^4.2.0
-        version: 4.2.1(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))
+        version: 4.2.1(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))
       eslint:
         specifier: ^9.15.0
         version: 9.16.0(jiti@1.21.6)
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.16.0(jiti@1.21.6))
+        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.1
         version: 6.10.1(eslint@9.16.0(jiti@1.21.6))
@@ -2330,10 +2333,10 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       vite:
         specifier: ^5.4.8
-        version: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
       vitest:
         specifier: ^2.1.2
-        version: 2.1.3(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 2.1.3(@types/node@22.10.5)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
 
   packages/create-app.template.tutorial-todo-app.beta:
     dependencies:
@@ -2379,13 +2382,13 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       '@vitejs/plugin-react':
         specifier: ^4.2.0
-        version: 4.2.1(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))
+        version: 4.2.1(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))
       eslint:
         specifier: ^9.15.0
         version: 9.16.0(jiti@1.21.6)
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.16.0(jiti@1.21.6))
+        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.1
         version: 6.10.1(eslint@9.16.0(jiti@1.21.6))
@@ -2409,10 +2412,10 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       vite:
         specifier: ^5.3.4
-        version: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
       vitest:
         specifier: ^2.0.5
-        version: 2.1.3(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 2.1.3(@types/node@22.10.5)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
 
   packages/create-app.template.vue:
     dependencies:
@@ -2437,16 +2440,16 @@ importers:
         version: link:../monorepo.tsup
       '@vitejs/plugin-vue':
         specifier: ^5.1.4
-        version: 5.1.4(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))(vue@3.5.11(typescript@5.5.4))
+        version: 5.1.4(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))(vue@3.5.11(typescript@5.5.4))
       typescript:
         specifier: ~5.5.4
         version: 5.5.4
       vite:
         specifier: ^5.4.8
-        version: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
       vitest:
         specifier: ^2.1.2
-        version: 2.1.3(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 2.1.3(@types/node@22.10.5)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
       vue-tsc:
         specifier: ^2.1.6
         version: 2.1.6(typescript@5.5.4)
@@ -2474,16 +2477,16 @@ importers:
         version: link:../monorepo.tsup
       '@vitejs/plugin-vue':
         specifier: ^5.1.4
-        version: 5.1.4(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))(vue@3.5.11(typescript@5.5.4))
+        version: 5.1.4(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))(vue@3.5.11(typescript@5.5.4))
       typescript:
         specifier: ~5.5.4
         version: 5.5.4
       vite:
         specifier: ^5.4.8
-        version: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
       vitest:
         specifier: ^2.1.2
-        version: 2.1.3(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 2.1.3(@types/node@22.10.5)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
       vue-tsc:
         specifier: ^2.1.6
         version: 2.1.6(typescript@5.5.4)
@@ -2590,7 +2593,7 @@ importers:
         version: 8.15.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.5.4)
       '@vitejs/plugin-react':
         specifier: ^4.2.0
-        version: 4.2.1(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))
+        version: 4.2.1(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))
       eslint:
         specifier: ^9.13.0
         version: 9.13.0(jiti@1.21.6)
@@ -2620,10 +2623,10 @@ importers:
         version: 8.15.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.5.4)
       vite:
         specifier: ^5.4.8
-        version: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
       vitest:
         specifier: ^2.1.2
-        version: 2.1.3(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 2.1.3(@types/node@22.10.5)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
 
   packages/e2e.generated.1.1.x:
     dependencies:
@@ -2855,16 +2858,16 @@ importers:
         version: 18.3.1
       '@vitejs/plugin-react':
         specifier: ^4.2.0
-        version: 4.2.1(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))
+        version: 4.2.1(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))
       typescript:
         specifier: ~5.5.4
         version: 5.5.4
       vite:
         specifier: ^5.4.8
-        version: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
       vitest:
         specifier: ^2.1.2
-        version: 2.1.3(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 2.1.3(@types/node@22.10.5)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
 
   packages/e2e.sandbox.todoapp:
     dependencies:
@@ -2916,7 +2919,7 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.2.1(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))
+        version: 4.2.1(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))
       autoprefixer:
         specifier: ^10.4.19
         version: 10.4.19(postcss@8.4.47)
@@ -2928,7 +2931,7 @@ importers:
         version: 5.12.0(rollup@4.24.0)
       tailwindcss:
         specifier: ^3.4.4
-        version: 3.4.4(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.5.4))
+        version: 3.4.4(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.5.4))
       tslib:
         specifier: ^2.6.3
         version: 2.7.0
@@ -2940,7 +2943,7 @@ importers:
         version: 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       vite:
         specifier: ^5.4.8
-        version: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
 
   packages/e2e.sandbox.todowidget:
     dependencies:
@@ -2989,16 +2992,16 @@ importers:
         version: 18.3.1
       '@vitejs/plugin-react':
         specifier: ^4.2.0
-        version: 4.2.1(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))
+        version: 4.2.1(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))
       typescript:
         specifier: ~5.5.4
         version: 5.5.4
       vite:
         specifier: ^5.4.8
-        version: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
       vitest:
         specifier: ^2.1.2
-        version: 2.1.3(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 2.1.3(@types/node@22.10.5)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
 
   packages/e2e.test.foundry-sdk-generator:
     dependencies:
@@ -3274,7 +3277,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^2.1.2
-        version: 2.1.3(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 2.1.3(@types/node@22.10.5)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
 
   packages/generator-utils:
     dependencies:
@@ -3323,7 +3326,7 @@ importers:
         version: 1.3.3
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.10.2)(typescript@5.5.4)
+        version: 10.9.2(@types/node@22.10.5)(typescript@5.5.4)
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -3351,7 +3354,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^2.1.2
-        version: 2.1.3(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 2.1.3(@types/node@22.10.5)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0)
 
   packages/monorepo.api-extractor: {}
 
@@ -3380,7 +3383,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.2.3
-        version: 8.2.3(@microsoft/api-extractor@7.47.0(@types/node@22.10.2))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.5.4)(yaml@2.4.5)
+        version: 8.2.3(@microsoft/api-extractor@7.47.0(@types/node@22.10.5))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.5.4)(yaml@2.4.5)
 
   packages/oauth:
     dependencies:
@@ -3408,7 +3411,7 @@ importers:
         version: link:../monorepo.tsup
       jest-extended:
         specifier: ^4.0.2
-        version: 4.0.2(jest@29.7.0(@types/node@22.10.2))
+        version: 4.0.2(jest@29.7.0(@types/node@22.10.5))
       typescript:
         specifier: ~5.5.4
         version: 5.5.4
@@ -3863,7 +3866,7 @@ importers:
         version: 18.3.1
       '@vitejs/plugin-react':
         specifier: ^4.2.0
-        version: 4.2.1(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))
+        version: 4.2.1(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))
       react:
         specifier: ^18
         version: 18.3.1
@@ -3878,7 +3881,7 @@ importers:
         version: 5.5.4
       vite:
         specifier: ^5.4.8
-        version: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+        version: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
 
   tests/verify-fallback-package-v2:
     dependencies:
@@ -7557,6 +7560,9 @@ packages:
 
   '@types/node@22.10.2':
     resolution: {integrity: sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==}
+
+  '@types/node@22.10.5':
+    resolution: {integrity: sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==}
 
   '@types/node@22.9.1':
     resolution: {integrity: sha512-p8Yy/8sw1caA8CdRIQBG5tiLHmxtQKObCijiAa9Ez+d4+PRffM4054xbju0msf+cvhJpnFEeNjxmVT/0ipktrg==}
@@ -16580,35 +16586,35 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@microsoft/api-documenter@7.25.3(@types/node@22.10.2)':
+  '@microsoft/api-documenter@7.25.3(@types/node@22.10.5)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.29.2(@types/node@22.10.2)
+      '@microsoft/api-extractor-model': 7.29.2(@types/node@22.10.5)
       '@microsoft/tsdoc': 0.15.0
-      '@rushstack/node-core-library': 5.4.1(@types/node@22.10.2)
-      '@rushstack/terminal': 0.13.0(@types/node@22.10.2)
-      '@rushstack/ts-command-line': 4.22.0(@types/node@22.10.2)
+      '@rushstack/node-core-library': 5.4.1(@types/node@22.10.5)
+      '@rushstack/terminal': 0.13.0(@types/node@22.10.5)
+      '@rushstack/ts-command-line': 4.22.0(@types/node@22.10.5)
       js-yaml: 3.13.1
       resolve: 1.22.8
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor-model@7.29.2(@types/node@22.10.2)':
+  '@microsoft/api-extractor-model@7.29.2(@types/node@22.10.5)':
     dependencies:
       '@microsoft/tsdoc': 0.15.0
       '@microsoft/tsdoc-config': 0.17.0
-      '@rushstack/node-core-library': 5.4.1(@types/node@22.10.2)
+      '@rushstack/node-core-library': 5.4.1(@types/node@22.10.5)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.47.0(@types/node@22.10.2)':
+  '@microsoft/api-extractor@7.47.0(@types/node@22.10.5)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.29.2(@types/node@22.10.2)
+      '@microsoft/api-extractor-model': 7.29.2(@types/node@22.10.5)
       '@microsoft/tsdoc': 0.15.0
       '@microsoft/tsdoc-config': 0.17.0
-      '@rushstack/node-core-library': 5.4.1(@types/node@22.10.2)
+      '@rushstack/node-core-library': 5.4.1(@types/node@22.10.5)
       '@rushstack/rig-package': 0.5.2
-      '@rushstack/terminal': 0.13.0(@types/node@22.10.2)
-      '@rushstack/ts-command-line': 4.22.0(@types/node@22.10.2)
+      '@rushstack/terminal': 0.13.0(@types/node@22.10.5)
+      '@rushstack/ts-command-line': 4.22.0(@types/node@22.10.5)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.8
@@ -18198,7 +18204,7 @@ snapshots:
 
   '@rushstack/eslint-patch@1.10.3': {}
 
-  '@rushstack/node-core-library@5.4.1(@types/node@22.10.2)':
+  '@rushstack/node-core-library@5.4.1(@types/node@22.10.5)':
     dependencies:
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
@@ -18209,23 +18215,23 @@ snapshots:
       resolve: 1.22.8
       semver: 7.5.4
     optionalDependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.10.5
 
   '@rushstack/rig-package@0.5.2':
     dependencies:
       resolve: 1.22.8
       strip-json-comments: 3.1.1
 
-  '@rushstack/terminal@0.13.0(@types/node@22.10.2)':
+  '@rushstack/terminal@0.13.0(@types/node@22.10.5)':
     dependencies:
-      '@rushstack/node-core-library': 5.4.1(@types/node@22.10.2)
+      '@rushstack/node-core-library': 5.4.1(@types/node@22.10.5)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.10.5
 
-  '@rushstack/ts-command-line@4.22.0(@types/node@22.10.2)':
+  '@rushstack/ts-command-line@4.22.0(@types/node@22.10.5)':
     dependencies:
-      '@rushstack/terminal': 0.13.0(@types/node@22.10.2)
+      '@rushstack/terminal': 0.13.0(@types/node@22.10.5)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -18510,6 +18516,10 @@ snapshots:
       undici-types: 6.20.0
 
   '@types/node@22.10.2':
+    dependencies:
+      undici-types: 6.20.0
+
+  '@types/node@22.10.5':
     dependencies:
       undici-types: 6.20.0
 
@@ -18816,14 +18826,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.2.1(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))':
+  '@vitejs/plugin-react@4.2.1(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))':
     dependencies:
       '@babel/core': 7.24.9
       '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.24.9)
       '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.24.9)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+      vite: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18843,9 +18853,9 @@ snapshots:
       vite: 5.4.8(@types/node@22.10.0)(lightningcss@1.27.0)(terser@5.36.0)
       vue: 3.5.11(typescript@5.5.4)
 
-  '@vitejs/plugin-vue@5.1.4(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))(vue@3.5.11(typescript@5.5.4))':
+  '@vitejs/plugin-vue@5.1.4(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))(vue@3.5.11(typescript@5.5.4))':
     dependencies:
-      vite: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+      vite: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
       vue: 3.5.11(typescript@5.5.4)
 
   '@vitest/expect@2.1.3':
@@ -18887,13 +18897,13 @@ snapshots:
     optionalDependencies:
       vite: 5.4.8(@types/node@22.10.1)(lightningcss@1.27.0)(terser@5.36.0)
 
-  '@vitest/mocker@2.1.3(@vitest/spy@2.1.3)(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))':
+  '@vitest/mocker@2.1.3(@vitest/spy@2.1.3)(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))':
     dependencies:
       '@vitest/spy': 2.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.11
     optionalDependencies:
-      vite: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+      vite: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
 
   '@vitest/mocker@2.1.3(@vitest/spy@2.1.3)(vite@5.4.8(@types/node@22.9.1)(lightningcss@1.27.0)(terser@5.36.0))':
     dependencies:
@@ -20066,13 +20076,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@22.10.2):
+  create-jest@29.7.0(@types/node@22.10.5):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.10.2)
+      jest-config: 29.7.0(@types/node@22.10.5)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -20728,8 +20738,8 @@ snapshots:
       '@typescript-eslint/parser': 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       eslint: 9.16.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.16.0(jiti@1.21.6))
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6))
       eslint-plugin-jsx-a11y: 6.10.1(eslint@9.16.0(jiti@1.21.6))
       eslint-plugin-react: 7.37.2(eslint@9.16.0(jiti@1.21.6))
       eslint-plugin-react-hooks: 5.0.0(eslint@9.16.0(jiti@1.21.6))
@@ -20747,13 +20757,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6)):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)):
     dependencies:
       debug: 4.3.7
       enhanced-resolve: 5.16.1
       eslint: 9.16.0(jiti@1.21.6)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.16.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6))
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.15.1
@@ -20843,14 +20853,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
       eslint: 9.16.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6))
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6))
     transitivePeerDependencies:
       - supports-color
 
@@ -20970,6 +20980,35 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 8.15.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.5.4)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.8
+      array.prototype.findlastindex: 1.2.5
+      array.prototype.flat: 1.3.2
+      array.prototype.flatmap: 1.3.2
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.16.0(jiti@1.21.6)
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6))
+      hasown: 2.0.2
+      is-core-module: 2.15.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.0
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.8
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.15.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.5.4)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -22519,16 +22558,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@22.10.2):
+  jest-cli@29.7.0(@types/node@22.10.5):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.10.2)
+      create-jest: 29.7.0(@types/node@22.10.5)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.10.2)
+      jest-config: 29.7.0(@types/node@22.10.5)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -22694,6 +22733,37 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-config@29.7.0(@types/node@22.10.5):
+    dependencies:
+      '@babel/core': 7.26.0
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.26.0)
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.10.5
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+    optional: true
+
   jest-diff@29.7.0:
     dependencies:
       chalk: 4.1.2
@@ -22737,7 +22807,7 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  jest-expo@52.0.2(@babel/core@7.26.0)(expo@52.0.11(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1)))(graphql@16.8.1)(react-native-webview@13.12.2(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1))(jest@29.7.0(@types/node@22.10.0)(ts-node@10.9.2(@types/node@22.10.0)(typescript@5.5.4)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)(webpack@5.96.1(esbuild@0.23.0)):
+  jest-expo@52.0.2(@babel/core@7.26.0)(expo@52.0.11(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1)))(graphql@16.8.1)(react-native-webview@13.12.2(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1))(jest@29.7.0(@types/node@22.10.0)(ts-node@10.9.2(@types/node@22.10.0)(typescript@5.5.4)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)(webpack@5.96.1):
     dependencies:
       '@expo/config': 10.0.5
       '@expo/json-file': 9.0.0
@@ -22754,7 +22824,7 @@ snapshots:
       json5: 2.2.3
       lodash: 4.17.21
       react-native: 0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1)
-      react-server-dom-webpack: 19.0.0-rc-6230622a1a-20240610(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.96.1(esbuild@0.23.0))
+      react-server-dom-webpack: 19.0.0-rc-6230622a1a-20240610(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.96.1)
       react-test-renderer: 18.3.1(react@18.3.1)
       server-only: 0.0.1
       stacktrace-js: 2.0.2
@@ -22770,7 +22840,7 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  jest-expo@52.0.2(@babel/core@7.26.0)(expo@52.0.11(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1)))(graphql@16.8.1)(react-native-webview@13.12.2(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1))(jest@29.7.0(@types/node@22.10.1)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.5.4)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)(webpack@5.96.1(esbuild@0.23.0)):
+  jest-expo@52.0.2(@babel/core@7.26.0)(expo@52.0.11(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1)))(graphql@16.8.1)(react-native-webview@13.12.2(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1))(jest@29.7.0(@types/node@22.10.1)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.5.4)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)(webpack@5.96.1):
     dependencies:
       '@expo/config': 10.0.5
       '@expo/json-file': 9.0.0
@@ -22787,7 +22857,7 @@ snapshots:
       json5: 2.2.3
       lodash: 4.17.21
       react-native: 0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1)
-      react-server-dom-webpack: 19.0.0-rc-6230622a1a-20240610(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.96.1(esbuild@0.23.0))
+      react-server-dom-webpack: 19.0.0-rc-6230622a1a-20240610(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.96.1)
       react-test-renderer: 18.3.1(react@18.3.1)
       server-only: 0.0.1
       stacktrace-js: 2.0.2
@@ -22803,12 +22873,12 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  jest-extended@4.0.2(jest@29.7.0(@types/node@22.10.2)):
+  jest-extended@4.0.2(jest@29.7.0(@types/node@22.10.5)):
     dependencies:
       jest-diff: 29.7.0
       jest-get-type: 29.6.3
     optionalDependencies:
-      jest: 29.7.0(@types/node@22.10.2)
+      jest: 29.7.0(@types/node@22.10.5)
 
   jest-get-type@29.6.3: {}
 
@@ -23020,7 +23090,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.10.5
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -23055,12 +23125,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@22.10.2):
+  jest@29.7.0(@types/node@22.10.5):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.10.2)
+      jest-cli: 29.7.0(@types/node@22.10.5)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -24274,13 +24344,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.47
 
-  postcss-load-config@4.0.1(postcss@8.4.47)(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.5.4)):
+  postcss-load-config@4.0.1(postcss@8.4.47)(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.5.4)):
     dependencies:
       lilconfig: 2.1.0
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.47
-      ts-node: 10.9.2(@types/node@22.10.2)(typescript@5.5.4)
+      ts-node: 10.9.2(@types/node@22.10.5)(typescript@5.5.4)
 
   postcss-load-config@6.0.1(jiti@1.21.6)(postcss@8.4.47)(yaml@2.4.5):
     dependencies:
@@ -24663,13 +24733,13 @@ snapshots:
       '@remix-run/router': 1.16.1
       react: 18.3.1
 
-  react-server-dom-webpack@19.0.0-rc-6230622a1a-20240610(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.96.1(esbuild@0.23.0)):
+  react-server-dom-webpack@19.0.0-rc-6230622a1a-20240610(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.96.1):
     dependencies:
       acorn-loose: 8.4.0
       neo-async: 2.6.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      webpack: 5.96.1(esbuild@0.23.0)
+      webpack: 5.96.1
 
   react-shallow-renderer@16.15.0(react@18.3.1):
     dependencies:
@@ -25541,7 +25611,7 @@ snapshots:
       '@pkgr/core': 0.1.1
       tslib: 2.7.0
 
-  tailwindcss@3.4.4(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.5.4)):
+  tailwindcss@3.4.4(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.5.4)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -25560,7 +25630,7 @@ snapshots:
       postcss: 8.4.47
       postcss-import: 15.1.0(postcss@8.4.47)
       postcss-js: 4.0.1(postcss@8.4.47)
-      postcss-load-config: 4.0.1(postcss@8.4.47)(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.5.4))
+      postcss-load-config: 4.0.1(postcss@8.4.47)(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.5.4))
       postcss-nested: 6.0.1(postcss@8.4.47)
       postcss-selector-parser: 6.0.13
       resolve: 1.22.8
@@ -25606,16 +25676,14 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser-webpack-plugin@5.3.10(esbuild@0.23.0)(webpack@5.96.1(esbuild@0.23.0)):
+  terser-webpack-plugin@5.3.10(webpack@5.96.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.36.0
-      webpack: 5.96.1(esbuild@0.23.0)
-    optionalDependencies:
-      esbuild: 0.23.0
+      webpack: 5.96.1
 
   terser@5.36.0:
     dependencies:
@@ -25765,14 +25833,14 @@ snapshots:
       yn: 3.1.1
     optional: true
 
-  ts-node@10.9.2(@types/node@22.10.2)(typescript@5.5.4):
+  ts-node@10.9.2(@types/node@22.10.5)(typescript@5.5.4):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.10.2
+      '@types/node': 22.10.5
       acorn: 8.14.0
       acorn-walk: 8.3.2
       arg: 4.1.3
@@ -25799,7 +25867,7 @@ snapshots:
 
   tslib@2.7.0: {}
 
-  tsup@8.2.3(@microsoft/api-extractor@7.47.0(@types/node@22.10.2))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.5.4)(yaml@2.4.5):
+  tsup@8.2.3(@microsoft/api-extractor@7.47.0(@types/node@22.10.5))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.5.4)(yaml@2.4.5):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.23.0)
       cac: 6.7.14
@@ -25818,7 +25886,7 @@ snapshots:
       sucrase: 3.35.0
       tree-kill: 1.2.2
     optionalDependencies:
-      '@microsoft/api-extractor': 7.47.0(@types/node@22.10.2)
+      '@microsoft/api-extractor': 7.47.0(@types/node@22.10.5)
       postcss: 8.4.47
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -26219,12 +26287,12 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@2.1.3(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0):
+  vite-node@2.1.3(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.7
       pathe: 1.1.2
-      vite: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+      vite: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -26297,13 +26365,13 @@ snapshots:
       lightningcss: 1.27.0
       terser: 5.36.0
 
-  vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0):
+  vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.47
       rollup: 4.24.0
     optionalDependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.10.5
       fsevents: 2.3.3
       lightningcss: 1.27.0
       terser: 5.36.0
@@ -26463,10 +26531,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.3(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0):
+  vitest@2.1.3(@types/node@22.10.5)(happy-dom@15.11.6)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.36.0):
     dependencies:
       '@vitest/expect': 2.1.3
-      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0))
+      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(vite@5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0))
       '@vitest/pretty-format': 2.1.3
       '@vitest/runner': 2.1.3
       '@vitest/snapshot': 2.1.3
@@ -26481,11 +26549,11 @@ snapshots:
       tinyexec: 0.3.0
       tinypool: 1.0.0
       tinyrainbow: 1.2.0
-      vite: 5.4.8(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
-      vite-node: 2.1.3(@types/node@22.10.2)(lightningcss@1.27.0)(terser@5.36.0)
+      vite: 5.4.8(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
+      vite-node: 2.1.3(@types/node@22.10.5)(lightningcss@1.27.0)(terser@5.36.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.10.5
       happy-dom: 15.11.6
       jsdom: 20.0.3
     transitivePeerDependencies:
@@ -26604,7 +26672,7 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
-  webpack@5.96.1(esbuild@0.23.0):
+  webpack@5.96.1:
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.6
@@ -26626,7 +26694,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(esbuild@0.23.0)(webpack@5.96.1(esbuild@0.23.0))
+      terser-webpack-plugin: 5.3.10(webpack@5.96.1)
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
The ultimate goal is to move a bunch of packages to `osdk-ts-clis`, specifically:

- `create-app`
- `create-app.*`
- `create-widget`
- `create-widget.*`
- `cli`
- `cli.common`
- `example-generator`

NOTE: Intent is to keep `cli.cmd.typescript` in this repo still.

