### PR TITLE
Fix Vite plugin dependency on @osdk/foundry-config-json

### DIFF
--- a/.changeset/violet-wasps-dress.md
+++ b/.changeset/violet-wasps-dress.md
@@ -1,0 +1,5 @@
+---
+"@osdk/widget.vite-plugin.unstable": patch
+---
+
+Fix Vite plugin @osdk/foundry-config-json dependency

--- a/packages/widget.vite-plugin.unstable/package.json
+++ b/packages/widget.vite-plugin.unstable/package.json
@@ -30,6 +30,7 @@
     "transpile": "monorepo.tool.transpile"
   },
   "dependencies": {
+    "@osdk/foundry-config-json": "workspace:~",
     "@osdk/widget-api.unstable": "workspace:~",
     "escodegen": "^2.1.0",
     "fs-extra": "^11.2.0",
@@ -42,7 +43,6 @@
   "devDependencies": {
     "@blueprintjs/core": "^5.16.0",
     "@blueprintjs/icons": "^5.15.0",
-    "@osdk/foundry-config-json": "workspace:~",
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
     "@osdk/monorepo.tsup": "workspace:~",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3815,6 +3815,9 @@ importers:
 
   packages/widget.vite-plugin.unstable:
     dependencies:
+      '@osdk/foundry-config-json':
+        specifier: workspace:~
+        version: link:../foundry-config-json
       '@osdk/widget-api.unstable':
         specifier: workspace:~
         version: link:../widget.api.unstable
@@ -3837,9 +3840,6 @@ importers:
       '@blueprintjs/icons':
         specifier: ^5.15.0
         version: 5.15.0(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@osdk/foundry-config-json':
-        specifier: workspace:~
-        version: link:../foundry-config-json
       '@osdk/monorepo.api-extractor':
         specifier: workspace:~
         version: link:../monorepo.api-extractor


### PR DESCRIPTION
The Vite plugin uses this dependency during execution (the user's code is in dev but its prod for this package).

Currently we are running into this error:
```
failed to load config from  <project path>/vite.config.ts
error when starting dev server:
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@osdk/foundry-config-json' imported from <project path>/node_modules/@osdk/widget.vite-plugin.unstable/build/esm/plugin.js
    at Object.getPackageJSONURL (node:internal/modules/package_json_reader:267:9)
    at packageResolve (node:internal/modules/esm/resolve:768:81)
    at moduleResolve (node:internal/modules/esm/resolve:854:18)
    at defaultResolve (node:internal/modules/esm/resolve:984:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:716:12)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:640:25)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:623:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:276:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:136:49)
```