### PR TITLE
Make @osdk/foundry-config-json public

### DIFF
--- a/.changeset/khaki-needles-fix.md
+++ b/.changeset/khaki-needles-fix.md
@@ -1,5 +1,0 @@
----
-"@osdk/foundry-config-json": patch
----
-
-Make @osdk/foundry-config-json public

--- a/.changeset/khaki-needles-fix.md
+++ b/.changeset/khaki-needles-fix.md
@@ -1,0 +1,5 @@
+---
+"@osdk/foundry-config-json": patch
+---
+
+Make @osdk/foundry-config-json public

--- a/.changeset/moody-gifts-clap.md
+++ b/.changeset/moody-gifts-clap.md
@@ -1,0 +1,5 @@
+---
+"@osdk/foundry-config-json": major
+---
+
+Make @osdk/foundry/config-json public

--- a/.changeset/moody-gifts-clap.md
+++ b/.changeset/moody-gifts-clap.md
@@ -2,4 +2,4 @@
 "@osdk/foundry-config-json": major
 ---
 
-Make @osdk/foundry/config-json public
+Make @osdk/foundry-config-json public

--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -64,7 +64,6 @@ const privatePackages = [
   "@osdk/e2e.*",
   "@osdk/example-generator",
   "@osdk/examples.*",
-  "@osdk/foundry-config-json",
   "@osdk/monorepo.*",
   "@osdk/platform-sdk-generator",
   "@osdk/shared.test",

--- a/packages/foundry-config-json/package.json
+++ b/packages/foundry-config-json/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/foundry-config-json",
-  "private": true,
   "version": "0.1.0-beta.2",
+  "access": "public",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This package contains shared `foundry.config.json` types and parsing/validation for it. It also contains the implementation of the auto version strategy for the `autoVersion` field in `foundry.config.json`.

It is used in:
- `@osdk/cli` as devDependencies which is bundled
- `@osdk/widget.vite-plugin.unstable` as dependencies where it is not bundled and requires this dependency package to be public