### PR TITLE
Fix interface creation actions

### DIFF
--- a/.changeset/friendly-rocks-rule.md
+++ b/.changeset/friendly-rocks-rule.md
@@ -1,0 +1,8 @@
+---
+"@osdk/generator-converters": patch
+"@osdk/shared.test": patch
+"@osdk/client": patch
+"@osdk/api": patch
+---
+
+Add ability to create interfaces through actions now.

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -296,6 +296,8 @@ export interface DataValueClientToWire {
     	// (undocumented)
     null: null;
     	// (undocumented)
+    objectType: string;
+    	// (undocumented)
     set: Set<any>;
     	// (undocumented)
     short: number;
@@ -344,6 +346,8 @@ export interface DataValueWireToClient {
     marking: string;
     	// (undocumented)
     null: null;
+    	// (undocumented)
+    objectType: string;
     	// (undocumented)
     set: Set<any>;
     	// (undocumented)
@@ -1090,7 +1094,7 @@ export type TwoDimensionalQueryAggregationDefinition = AggregationKeyDataType<"d
 export type ValidAggregationKeys<Q extends ObjectOrInterfaceDefinition> = keyof ({ [KK in AggregatableKeys<Q> as `${KK & string}:${AGG_FOR_TYPE<GetWirePropertyValueFromClient<CompileTimeMetadata<Q>["properties"][KK]["type"]>>}`]? : any } & { $count?: any });
 
 // @public (undocumented)
-export type ValidBaseActionParameterTypes = "boolean" | "string" | "integer" | "long" | "double" | "datetime" | "timestamp" | "attachment" | "marking";
+export type ValidBaseActionParameterTypes = "boolean" | "string" | "integer" | "long" | "double" | "datetime" | "timestamp" | "attachment" | "marking" | "objectType";
 
 // Warning: (ae-forgotten-export) The symbol "VersionString" needs to be exported by the entry point index.d.ts
 //

--- a/packages/api/src/mapping/DataValueMapping.ts
+++ b/packages/api/src/mapping/DataValueMapping.ts
@@ -44,6 +44,7 @@ export interface DataValueWireToClient {
   }[];
   struct: Record<string, any>;
   set: Set<any>;
+  objectType: string;
 }
 
 /**
@@ -74,6 +75,7 @@ export interface DataValueClientToWire {
     groups: { key: AllowedBucketKeyTypes; value: AllowedBucketTypes }[];
   }[];
   struct: Record<string, any>;
+  objectType: string;
 }
 
 export type AllowedBucketTypes = string | number | boolean;

--- a/packages/api/src/ontology/ActionDefinition.ts
+++ b/packages/api/src/ontology/ActionDefinition.ts
@@ -108,4 +108,5 @@ export type ValidBaseActionParameterTypes =
   | "datetime"
   | "timestamp"
   | "attachment"
-  | "marking";
+  | "marking"
+  | "objectType";

--- a/packages/client/src/actions/actions.test.ts
+++ b/packages/client/src/actions/actions.test.ts
@@ -550,6 +550,7 @@ describe("ActionResponse remapping", () => {
     expect(actions).toStrictEqual([
       "actionTakesAttachment",
       "actionTakesObjectSet",
+      "createFooInterface",
       "createOffice",
       "createOfficeAndEmployee",
       "createStructPerson",

--- a/packages/client/src/actions/actions.test.ts
+++ b/packages/client/src/actions/actions.test.ts
@@ -23,6 +23,7 @@ import {
   $Actions,
   $ontologyRid,
   actionTakesAttachment,
+  createFooInterface,
   createOffice,
   createStructPerson,
   deleteFooInterface,
@@ -328,6 +329,41 @@ describe("actions", () => {
         $objectType: "Employee",
         $primaryKey: 1,
       },
+    });
+
+    expectTypeOf<typeof result>().toEqualTypeOf<undefined>();
+    expect(result).toBeUndefined();
+  });
+  it("Accepts object type refs", async () => {
+    const clientBoundTakesObjectType = client(
+      createFooInterface,
+    ).applyAction;
+
+    type InferredParamType = Parameters<
+      typeof clientBoundTakesObjectType
+    >[0];
+
+    expectTypeOf<
+      {
+        createdInterface: string;
+      }
+    >().toMatchTypeOf<
+      InferredParamType
+    >();
+
+    const clientBoundBatchActionTakesObjectType = client(
+      createFooInterface,
+    ).batchApplyAction;
+    type InferredBatchParamType = Parameters<
+      typeof clientBoundBatchActionTakesObjectType
+    >[0];
+
+    expectTypeOf<{
+      createdInterface: string;
+    }[]>().toMatchTypeOf<InferredBatchParamType>();
+
+    const result = await client(createFooInterface).applyAction({
+      createdInterface: "UnderlyingObject",
     });
 
     expectTypeOf<typeof result>().toEqualTypeOf<undefined>();

--- a/packages/client/src/util/toDataValue.ts
+++ b/packages/client/src/util/toDataValue.ts
@@ -111,6 +111,6 @@ export async function toDataValue(
     );
   }
 
-  // expected to pass through - boolean, byte, date, decimal, float, double, integer, long, short, string, timestamp
+  // expected to pass through - boolean, byte, date, decimal, float, double, integer, long, short, string, timestamp, object type reference
   return value;
 }

--- a/packages/e2e.generated.catchall/ontology.json
+++ b/packages/e2e.generated.catchall/ontology.json
@@ -221,6 +221,26 @@
         }
       ]
     },
+    "create-foo-interface": {
+      "apiName": "create-foo-interface",
+      "displayName": "Create Foo Interface",
+      "status": "EXPERIMENTAL",
+      "parameters": {
+        "createdInterface": {
+          "dataType": {
+            "type": "objectType"
+          },
+          "required": true
+        }
+      },
+      "rid": "ri.actions.main.action-type.3828bab4-49c7-4fdf-a780-6ccbc359d817",
+      "operations": [
+        {
+          "type": "createInterfaceObject",
+          "interfaceTypeApiName": "FooInterface"
+        }
+      ]
+    },
     "create-struct-person": {
       "apiName": "create-struct-person",
       "description": "Create a struct",

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/index.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/index.ts
@@ -1,6 +1,7 @@
 export {
   actionTakesAllParameterTypes,
   assignEmployee1,
+  createFooInterface,
   createOsdkTestObject,
   createStructPerson,
   createStructPersonOpiTeam,

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions.ts
@@ -1,5 +1,6 @@
 export { actionTakesAllParameterTypes } from './actions/actionTakesAllParameterTypes.js';
 export { assignEmployee1 } from './actions/assignEmployee1.js';
+export { createFooInterface } from './actions/createFooInterface.js';
 export { createOsdkTestObject } from './actions/createOsdkTestObject.js';
 export { createStructPerson } from './actions/createStructPerson.js';
 export { createStructPersonOpiTeam } from './actions/createStructPersonOpiTeam.js';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createFooInterface.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createFooInterface.ts
@@ -1,0 +1,63 @@
+import type {
+  ActionDefinition,
+  ActionMetadata,
+  ActionParam,
+  ActionReturnTypeForOptions,
+  ApplyActionOptions,
+  ApplyBatchActionOptions,
+} from '@osdk/client';
+import { $osdkMetadata } from '../../OntologyMetadata.js';
+
+export namespace createFooInterface {
+  // Represents the definition of the parameters for the action
+  export type ParamsDefinition = {
+    createdInterface: {
+      multiplicity: false;
+      nullable: false;
+      type: 'objectType';
+    };
+  };
+
+  export interface Params {
+    readonly createdInterface: ActionParam.PrimitiveType<'objectType'>;
+  }
+
+  // Represents a fqn of the action
+  export interface Signatures {
+    applyAction<P extends createFooInterface.Params, OP extends ApplyActionOptions>(
+      args: P,
+      options?: OP,
+    ): Promise<ActionReturnTypeForOptions<OP>>;
+
+    batchApplyAction<P extends ReadonlyArray<createFooInterface.Params>, OP extends ApplyBatchActionOptions>(
+      args: P,
+      options?: OP,
+    ): Promise<ActionReturnTypeForOptions<OP>>;
+  }
+}
+
+/**
+ * @param {ActionParam.PrimitiveType<"objectType">} createdInterface
+ */
+export interface createFooInterface extends ActionDefinition<createFooInterface.Signatures> {
+  __DefinitionMetadata?: {
+    apiName: 'createFooInterface';
+    displayName: 'Create Foo Interface';
+    modifiedEntities: {};
+    parameters: createFooInterface.ParamsDefinition;
+    rid: 'ri.actions.main.action-type.3828bab4-49c7-4fdf-a780-6ccbc359d817';
+    status: 'EXPERIMENTAL';
+    type: 'action';
+
+    signatures: createFooInterface.Signatures;
+  };
+  apiName: 'createFooInterface';
+  type: 'action';
+  osdkMetadata: typeof $osdkMetadata;
+}
+
+export const createFooInterface: createFooInterface = {
+  apiName: 'createFooInterface',
+  type: 'action',
+  osdkMetadata: $osdkMetadata,
+};

--- a/packages/e2e.sandbox.catchall/src/runInterfacesTest.ts
+++ b/packages/e2e.sandbox.catchall/src/runInterfacesTest.ts
@@ -15,7 +15,11 @@
  */
 
 import type { Osdk } from "@osdk/api";
-import { FooInterface, OsdkTestObject } from "@osdk/e2e.generated.catchall";
+import {
+  createFooInterface,
+  FooInterface,
+  OsdkTestObject,
+} from "@osdk/e2e.generated.catchall";
 import invariant from "tiny-invariant";
 import type { TypeOf } from "ts-expect";
 import { expectType } from "ts-expect";
@@ -93,4 +97,8 @@ export async function runInterfacesTest(): Promise<void> {
     // underlyings are ref equal!
     console.log("employee === employee2", testObject === testObject2);
   }
+
+  const result = await client(createFooInterface).applyAction({
+    createdInterface: "testObject",
+  });
 }

--- a/packages/generator-converters/src/wireActionTypeV2ToSdkActionMetadata.ts
+++ b/packages/generator-converters/src/wireActionTypeV2ToSdkActionMetadata.ts
@@ -70,6 +70,7 @@ function actionPropertyToSdkPropertyDefinition(
     case "long":
     case "timestamp":
     case "marking":
+    case "objectType":
       return parameterType.type;
     case "date":
       return "datetime";

--- a/packages/shared.test/src/stubs/actions.ts
+++ b/packages/shared.test/src/stubs/actions.ts
@@ -167,6 +167,13 @@ export const actionRequestWithInterface: ApplyActionRequestV2 = {
   },
 };
 
+export const actionRequestWithObjectTypeReference: ApplyActionRequestV2 = {
+  options: { mode: "VALIDATE_AND_EXECUTE", returnEdits: "NONE" },
+  parameters: {
+    createdInterface: "UnderlyingObject",
+  },
+};
+
 export const actionRequestWithStruct: ApplyActionRequestV2 = {
   options: { mode: "VALIDATE_AND_EXECUTE", returnEdits: "NONE" },
   parameters: {
@@ -388,5 +395,8 @@ export const actionResponseMap: {
   },
   createStructPerson: {
     [stableStringify(actionRequestWithStruct)]: actionResponse,
+  },
+  createFooInterface: {
+    [stableStringify(actionRequestWithObjectTypeReference)]: actionResponse,
   },
 };

--- a/packages/shared.test/src/stubs/actionsTypes.ts
+++ b/packages/shared.test/src/stubs/actionsTypes.ts
@@ -305,6 +305,27 @@ export const ActionTakesInterface: ActionTypeV2 = {
   ],
 };
 
+export const ActionCreatesInterface: ActionTypeV2 = {
+  apiName: "create-foo-interface",
+  displayName: "Create Foo Interface",
+  status: "EXPERIMENTAL",
+  parameters: {
+    createdInterface: {
+      dataType: {
+        type: "objectType",
+      },
+      required: true,
+    },
+  },
+  rid: "ri.actions.main.action-type.3828bab4-49c7-4fdf-a780-6ccbc359d817",
+  operations: [
+    {
+      "type": "createInterfaceObject",
+      "interfaceTypeApiName": "FooInterface",
+    },
+  ],
+};
+
 export const ActionTakesStruct: ActionTypeV2 = {
   apiName: "createStructPerson",
   description: "Create a struct",
@@ -360,4 +381,5 @@ export const actionTypes: ActionTypeV2[] = [
   ActionTakesAttachment,
   ActionTakesInterface,
   ActionTakesStruct,
+  ActionCreatesInterface,
 ];


### PR DESCRIPTION
For actions where you create an interface, you have to specify what the underlying object type should be. Unfortunately, as it stands we do not get any sort of information telling us what kinds of objects it will accept, so it just takes a string for now. The backend will throw if it is incompatible.