### PR TITLE
Export interfaces for function signatures

### DIFF
--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -187,10 +187,7 @@ export type AggregationsResults<
 export type AllGroupByValues = GroupByMapper[keyof GroupByMapper];
 
 // @public (undocumented)
-export type AllowedBucketKeyTypes = AllowedBucketTypes | {
-    	startValue: AllowedBucketTypes;
-    	endValue: AllowedBucketTypes;
-};
+export type AllowedBucketKeyTypes = AllowedBucketTypes | Range_2<AllowedBucketTypes>;
 
 // @public (undocumented)
 export type AllowedBucketTypes = string | number | boolean;
@@ -306,20 +303,11 @@ export interface DataValueClientToWire {
     	// (undocumented)
     struct: Record<string, any>;
     	// (undocumented)
-    threeDimensionalAggregation: {
-        		key: AllowedBucketKeyTypes;
-        		groups: {
-            			key: AllowedBucketKeyTypes;
-            			value: AllowedBucketTypes;
-            		}[];
-        	}[];
+    threeDimensionalAggregation: ThreeDimensionalAggregation<AllowedBucketKeyTypes, AllowedBucketKeyTypes, AllowedBucketTypes>;
     	// (undocumented)
     timestamp: string;
     	// (undocumented)
-    twoDimensionalAggregation: {
-        		key: AllowedBucketKeyTypes;
-        		value: AllowedBucketTypes;
-        	}[];
+    twoDimensionalAggregation: TwoDimensionalAggregation<AllowedBucketKeyTypes, AllowedBucketTypes>;
 }
 
 // @public
@@ -359,20 +347,11 @@ export interface DataValueWireToClient {
     	// (undocumented)
     struct: Record<string, any>;
     	// (undocumented)
-    threeDimensionalAggregation: {
-        		key: AllowedBucketKeyTypes;
-        		groups: {
-            			key: AllowedBucketKeyTypes;
-            			value: AllowedBucketTypes;
-            		}[];
-        	}[];
+    threeDimensionalAggregation: ThreeDimensionalAggregation<AllowedBucketKeyTypes, AllowedBucketKeyTypes, AllowedBucketTypes>;
     	// (undocumented)
     timestamp: string;
     	// (undocumented)
-    twoDimensionalAggregation: {
-        		key: AllowedBucketKeyTypes;
-        		value: AllowedBucketTypes;
-        	}[];
+    twoDimensionalAggregation: TwoDimensionalAggregation<AllowedBucketKeyTypes, AllowedBucketTypes>;
 }
 
 // @public (undocumented)
@@ -980,6 +959,16 @@ export namespace QueryResult {
     export type PrimitiveType<T extends keyof DataValueClientToWire> = DataValueWireToClient[T];
 }
 
+// @public (undocumented)
+type Range_2<T extends AllowedBucketTypes> = {
+    	startValue?: T;
+    	endValue: T;
+} | {
+    	startValue: T;
+    	endValue?: T;
+};
+export { Range_2 as Range }
+
 // Warning: (ae-forgotten-export) The symbol "ErrorResult" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -1020,6 +1009,19 @@ export type SingleOsdkResult<
 	R extends boolean,
 	S extends NullabilityAdherence
 > = Osdk.Instance<Q, ExtractOptions<R, S>, L>;
+
+// @public (undocumented)
+export type ThreeDimensionalAggregation<
+	T extends AllowedBucketKeyTypes,
+	U extends AllowedBucketKeyTypes,
+	V extends AllowedBucketTypes
+> = {
+    	key: T;
+    	groups: {
+        		key: U;
+        		value: V;
+        	}[];
+}[];
 
 // Warning: (ae-forgotten-export) The symbol "AggregationKeyDataType" needs to be exported by the entry point index.d.ts
 //
@@ -1100,6 +1102,15 @@ export type TimeSeriesQuery = {
     	$after?: never;
     	$unit?: never;
 };
+
+// @public (undocumented)
+export type TwoDimensionalAggregation<
+	T extends AllowedBucketKeyTypes,
+	U extends AllowedBucketTypes
+> = {
+    	key: T;
+    	value: U;
+}[];
 
 // @public (undocumented)
 export type TwoDimensionalQueryAggregationDefinition = AggregationKeyDataType<"date" | "double" | "timestamp">;

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -49,8 +49,6 @@ export type {
   GroupByRange,
 } from "./groupby/GroupByClause.js";
 export type {
-  AllowedBucketKeyTypes,
-  AllowedBucketTypes,
   DataValueClientToWire,
   DataValueWireToClient,
 } from "./mapping/DataValueMapping.js";
@@ -118,6 +116,21 @@ export type { OsdkBase, PrimaryKeyType } from "./OsdkBase.js";
 export type { OsdkObject } from "./OsdkObject.js";
 export type { ConvertProps, Osdk } from "./OsdkObjectFrom.js";
 export type { PageResult } from "./PageResult.js";
+export type {
+  AllowedBucketKeyTypes,
+  AllowedBucketTypes,
+  Range,
+  ThreeDimensionalAggregation,
+  TwoDimensionalAggregation,
+} from "./queries/Aggregations.js";
+export type {
+  DateISO,
+  Double,
+  Float,
+  Integer,
+  Long,
+  TimestampISO,
+} from "./queries/Primitives.js";
 export type { QueryParam, QueryResult } from "./queries/Queries.js";
 export { TimeseriesDurationMapping } from "./timeseries/timeseries.js";
 export type {

--- a/packages/api/src/mapping/DataValueMapping.ts
+++ b/packages/api/src/mapping/DataValueMapping.ts
@@ -16,6 +16,12 @@
 
 import type { Attachment, AttachmentUpload } from "../object/Attachment.js";
 import type { MediaReference } from "../object/Media.js";
+import type {
+  AllowedBucketKeyTypes,
+  AllowedBucketTypes,
+  ThreeDimensionalAggregation,
+  TwoDimensionalAggregation,
+} from "../queries/Aggregations.js";
 
 /**
  * Map from the DataValue type to the typescript type that we return
@@ -36,14 +42,15 @@ export interface DataValueWireToClient {
   string: string;
   timestamp: string;
   mediaReference: MediaReference;
-  twoDimensionalAggregation: {
-    key: AllowedBucketKeyTypes;
-    value: AllowedBucketTypes;
-  }[];
-  threeDimensionalAggregation: {
-    key: AllowedBucketKeyTypes;
-    groups: { key: AllowedBucketKeyTypes; value: AllowedBucketTypes }[];
-  }[];
+  twoDimensionalAggregation: TwoDimensionalAggregation<
+    AllowedBucketKeyTypes,
+    AllowedBucketTypes
+  >;
+  threeDimensionalAggregation: ThreeDimensionalAggregation<
+    AllowedBucketKeyTypes,
+    AllowedBucketKeyTypes,
+    AllowedBucketTypes
+  >;
   struct: Record<string, any>;
   set: Set<any>;
   objectType: string;
@@ -69,22 +76,15 @@ export interface DataValueClientToWire {
   timestamp: string;
   set: Set<any>;
   mediaReference: MediaReference;
-  twoDimensionalAggregation: {
-    key: AllowedBucketKeyTypes;
-    value: AllowedBucketTypes;
-  }[];
-  threeDimensionalAggregation: {
-    key: AllowedBucketKeyTypes;
-    groups: { key: AllowedBucketKeyTypes; value: AllowedBucketTypes }[];
-  }[];
+  twoDimensionalAggregation: TwoDimensionalAggregation<
+    AllowedBucketKeyTypes,
+    AllowedBucketTypes
+  >;
+  threeDimensionalAggregation: ThreeDimensionalAggregation<
+    AllowedBucketKeyTypes,
+    AllowedBucketKeyTypes,
+    AllowedBucketTypes
+  >;
   struct: Record<string, any>;
   objectType: string;
 }
-
-export type AllowedBucketTypes = string | number | boolean;
-export type AllowedBucketKeyTypes =
-  | AllowedBucketTypes
-  | {
-    startValue: AllowedBucketTypes;
-    endValue: AllowedBucketTypes;
-  };

--- a/packages/api/src/queries/Aggregations.ts
+++ b/packages/api/src/queries/Aggregations.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type Range<T extends AllowedBucketTypes> = {
+  startValue?: T;
+  endValue: T;
+} | {
+  startValue: T;
+  endValue?: T;
+};
+
+export type AllowedBucketTypes = string | number | boolean;
+export type AllowedBucketKeyTypes =
+  | AllowedBucketTypes
+  | Range<AllowedBucketTypes>;
+
+export type TwoDimensionalAggregation<
+  T extends AllowedBucketKeyTypes,
+  U extends AllowedBucketTypes,
+> = { key: T; value: U }[];
+
+export type ThreeDimensionalAggregation<
+  T extends AllowedBucketKeyTypes,
+  U extends AllowedBucketKeyTypes,
+  V extends AllowedBucketTypes,
+> = { key: T; groups: { key: U; value: V }[] }[];

--- a/packages/api/src/queries/Primitives.ts
+++ b/packages/api/src/queries/Primitives.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type Integer<T extends number = number> = T;
+export type Float<T extends number = number> = T;
+export type Double<T extends number = number> = T;
+export type Long<T extends string = string> = T;
+
+export type DateISO<T extends string = string> = T;
+export type TimestampISO<T extends string = string> = T;


### PR DESCRIPTION
Export interfaces for the following:

- Integer
- Long
- Float
- Double
- Date (represented as string)
- Timestamp (represented as string)
- TwoDimensionalAggregation
- ThreeDimensionalAggregation

Would a new package `@osdk/functions` be a better place to export these types?