### PR TITLE
Fix example widget repo description typo

### DIFF
--- a/.changeset/itchy-radios-vanish.md
+++ b/.changeset/itchy-radios-vanish.md
@@ -1,0 +1,5 @@
+---
+"@osdk/create-widget.template.react.v2": patch
+---
+
+Fix a typo in the generated widget description

--- a/examples/example-widget-react-sdk-2.x/src/main.config.ts
+++ b/examples/example-widget-react-sdk-2.x/src/main.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "@osdk/widget-client.unstable";
 export default defineConfig({
   id: "widgetId",
   name: "Custom Widget",
-  description: "And example custom widget implementation",
+  description: "An example custom widget implementation",
   type: "workshop",
   parameters: {
     headerText: {

--- a/packages/create-widget.template.react.v2/templates/src/main.config.ts.hbs
+++ b/packages/create-widget.template.react.v2/templates/src/main.config.ts.hbs
@@ -3,7 +3,7 @@ import { defineConfig } from "@osdk/widget-client.unstable";
 export default defineConfig({
   id: "widgetId",
   name: "Custom Widget",
-  description: "And example custom widget implementation",
+  description: "An example custom widget implementation",
   type: "workshop",
   parameters: {
     headerText: {


### PR DESCRIPTION
Fixing a typo in the example widget project template, just used as the in-platform description of the widget.