### PR TITLE
Modifying query agg return types

### DIFF
--- a/.changeset/seven-knives-breathe.md
+++ b/.changeset/seven-knives-breathe.md
@@ -1,0 +1,8 @@
+---
+"@osdk/generator-converters": patch
+"@osdk/generator": patch
+"@osdk/client": patch
+"@osdk/api": patch
+---
+
+Explicitly type aggregation types in queries.

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -278,6 +278,8 @@ export interface DataValueClientToWire {
     	// (undocumented)
     byte: number;
     	// (undocumented)
+    date: string;
+    	// (undocumented)
     datetime: string;
     	// (undocumented)
     decimal: string | number;
@@ -330,6 +332,8 @@ export interface DataValueWireToClient {
     boolean: boolean;
     	// (undocumented)
     byte: number;
+    	// (undocumented)
+    date: string;
     	// (undocumented)
     datetime: string;
     	// (undocumented)
@@ -966,6 +970,29 @@ export namespace QueryParam {
     export type ObjectType<T extends ObjectTypeDefinition> = OsdkBase<T> | OsdkObjectPrimaryKeyType<T>;
     	// (undocumented)
     export type PrimitiveType<T extends keyof DataValueClientToWire> = DataValueClientToWire[T];
+    	// Warning: (ae-forgotten-export) The symbol "AggregationRangeKeyTypes" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "AggKeyClientToWire" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    export type RangeKey<T extends AggregationRangeKeyTypes> = AggKeyClientToWire<"range", T>;
+    	// Warning: (ae-forgotten-export) The symbol "ThreeDimensionalAggregation" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    export type ThreeDimensionalAggregationType<
+    		OUT extends AggregationKeyTypes | RangeKey<any>,
+    		IN extends AggregationKeyTypes | RangeKey<any>,
+    		V extends AggregationValueTypes
+    	> = ThreeDimensionalAggregation<OUT extends AggregationKeyTypes ? AggKeyClientToWire<OUT> : OUT, IN extends AggregationKeyTypes ? AggKeyClientToWire<IN> : IN, AggValueClientToWire<V>>;
+    	// Warning: (ae-forgotten-export) The symbol "AggregationKeyTypes" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "AggregationValueTypes" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "TwoDimensionalAggregation" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "AggValueClientToWire" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    export type TwoDimensionalAggregationType<
+    		T extends AggregationKeyTypes | RangeKey<any>,
+    		V extends AggregationValueTypes
+    	> = TwoDimensionalAggregation<T extends AggregationKeyTypes ? AggKeyClientToWire<T> : T, AggValueClientToWire<V>>;
 }
 
 // @public (undocumented)
@@ -979,6 +1006,23 @@ export namespace QueryResult {
     export type ObjectType<T extends ObjectTypeDefinition> = OsdkBase<T>;
     	// (undocumented)
     export type PrimitiveType<T extends keyof DataValueClientToWire> = DataValueWireToClient[T];
+    	// Warning: (ae-forgotten-export) The symbol "AggKeyWireToClient" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    export type RangeKey<T extends AggregationRangeKeyTypes> = AggKeyWireToClient<"range", T>;
+    	// (undocumented)
+    export type ThreeDimensionalAggregationType<
+    		OUT extends AggregationKeyTypes | RangeKey<any>,
+    		IN extends AggregationKeyTypes | RangeKey<any>,
+    		V extends AggregationValueTypes
+    	> = ThreeDimensionalAggregation<OUT extends AggregationKeyTypes ? AggKeyWireToClient<OUT> : OUT, IN extends AggregationKeyTypes ? AggKeyWireToClient<IN> : IN, AggValueWireToClient<V>>;
+    	// Warning: (ae-forgotten-export) The symbol "AggValueWireToClient" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    export type TwoDimensionalAggregationType<
+    		T extends AggregationKeyTypes | RangeKey<any>,
+    		V extends AggregationValueTypes
+    	> = TwoDimensionalAggregation<T extends AggregationKeyTypes ? AggKeyWireToClient<T> : T, AggValueWireToClient<V>>;
 }
 
 // Warning: (ae-forgotten-export) The symbol "ErrorResult" needs to be exported by the entry point index.d.ts
@@ -1103,7 +1147,7 @@ export type TimeSeriesQuery = {
 };
 
 // @public (undocumented)
-export type TwoDimensionalQueryAggregationDefinition = AggregationKeyDataType<"date" | "double" | "timestamp">;
+export type TwoDimensionalQueryAggregationDefinition = AggregationKeyDataType<AggregationValueTypes>;
 
 // Warning: (ae-forgotten-export) The symbol "AGG_FOR_TYPE" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "GetWirePropertyValueFromClient" needs to be exported by the entry point index.d.ts

--- a/packages/api/src/mapping/DataValueMapping.ts
+++ b/packages/api/src/mapping/DataValueMapping.ts
@@ -25,6 +25,7 @@ export interface DataValueWireToClient {
   boolean: boolean;
   byte: number;
   datetime: string;
+  date: string;
   decimal: string;
   float: number;
   double: number;
@@ -57,6 +58,7 @@ export interface DataValueClientToWire {
   boolean: boolean;
   byte: number;
   datetime: string;
+  date: string;
   decimal: string | number;
   float: number;
   double: number;

--- a/packages/api/src/ontology/QueryDefinition.ts
+++ b/packages/api/src/ontology/QueryDefinition.ts
@@ -127,7 +127,7 @@ export type AggregationKeyDataType<V = any> =
   | RangeAggregationKeyDataType<V>;
 
 export interface SimpleAggregationKeyDataType<V = any> {
-  keyType: "boolean" | "string";
+  keyType: "boolean" | "string" | "date" | "double" | "integer" | "timestamp";
   valueType: V;
 }
 

--- a/packages/api/src/ontology/QueryDefinition.ts
+++ b/packages/api/src/ontology/QueryDefinition.ts
@@ -127,10 +127,9 @@ export type AggregationKeyDataType<V = any> =
   | RangeAggregationKeyDataType<V>;
 
 export interface SimpleAggregationKeyDataType<V = any> {
-  keyType: "boolean" | "string" | "date" | "double" | "integer" | "timestamp";
+  keyType: Exclude<AggregationKeyTypes, "range">;
   valueType: V;
 }
-
 export interface RangeAggregationKeyDataType<V = any> {
   keyType: "range";
   keySubtype: AggregationRangeKeyTypes;

--- a/packages/api/src/ontology/QueryDefinition.ts
+++ b/packages/api/src/ontology/QueryDefinition.ts
@@ -133,14 +133,31 @@ export interface SimpleAggregationKeyDataType<V = any> {
 
 export interface RangeAggregationKeyDataType<V = any> {
   keyType: "range";
-  keySubtype: "date" | "double" | "integer" | "timestamp";
+  keySubtype: AggregationRangeKeyTypes;
   valueType: V;
 }
 
 export type TwoDimensionalQueryAggregationDefinition = AggregationKeyDataType<
-  "date" | "double" | "timestamp"
+  AggregationValueTypes
 >;
 
 export type ThreeDimensionalQueryAggregationDefinition = AggregationKeyDataType<
   TwoDimensionalQueryAggregationDefinition
 >;
+
+export type AggregationKeyTypes =
+  | "boolean"
+  | "string"
+  | "date"
+  | "double"
+  | "integer"
+  | "timestamp"
+  | "range";
+
+export type AggregationRangeKeyTypes =
+  | "date"
+  | "double"
+  | "integer"
+  | "timestamp";
+
+export type AggregationValueTypes = "date" | "double" | "timestamp";

--- a/packages/api/src/queries/Aggregations.ts
+++ b/packages/api/src/queries/Aggregations.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DataValueClientToWire } from "../mapping/DataValueMapping.js";
+import type { AggregationKeyDataType } from "../ontology/QueryDefinition.js";
+
+export type Range<T extends AllowedBucketTypes> = {
+  startValue?: T;
+  endValue: T;
+} | {
+  startValue: T;
+  endValue?: T;
+};
+
+export type AllowedBucketTypes = string | number | boolean;
+export type AllowedBucketKeyTypes =
+  | AllowedBucketTypes
+  | Range<AllowedBucketTypes>;
+
+export type TwoDimensionalAggregation<
+  T extends AllowedBucketKeyTypes,
+  U extends AllowedBucketTypes,
+> = { key: T; value: U }[];
+
+export type ThreeDimensionalAggregation<
+  T extends AllowedBucketKeyTypes,
+  U extends AllowedBucketKeyTypes,
+  V extends AllowedBucketTypes,
+> = { key: T; groups: { key: U; value: V }[] }[];
+
+type WireAggKeyTypeMapping<T extends AggregationKeyDataType<any>["keyType"]> =
+  DataValueClientToWire[T];
+
+export interface AggregationTypeMapping {
+  boolean: boolean;
+  string: string;
+  integer: number;
+  date: string;
+  double: number;
+  timestamp: string;
+}

--- a/packages/api/src/queries/Aggregations.ts
+++ b/packages/api/src/queries/Aggregations.ts
@@ -14,8 +14,15 @@
  * limitations under the License.
  */
 
-import type { DataValueClientToWire } from "../mapping/DataValueMapping.js";
-import type { AggregationKeyDataType } from "../ontology/QueryDefinition.js";
+import type {
+  DataValueClientToWire,
+  DataValueWireToClient,
+} from "../mapping/DataValueMapping.js";
+import type {
+  AggregationKeyTypes,
+  AggregationRangeKeyTypes,
+  AggregationValueTypes,
+} from "../ontology/QueryDefinition.js";
 
 export type Range<T extends AllowedBucketTypes> = {
   startValue?: T;
@@ -41,14 +48,26 @@ export type ThreeDimensionalAggregation<
   V extends AllowedBucketTypes,
 > = { key: T; groups: { key: U; value: V }[] }[];
 
-type WireAggKeyTypeMapping<T extends AggregationKeyDataType<any>["keyType"]> =
-  DataValueClientToWire[T];
+export type AggKeyWireToClient<
+  T extends AggregationKeyTypes,
+  S extends AggregationRangeKeyTypes = never,
+> = T extends keyof DataValueWireToClient ? DataValueWireToClient[T]
+  : T extends "range"
+    ? S extends keyof DataValueWireToClient ? Range<DataValueWireToClient[S]>
+    : never
+  : never;
 
-export interface AggregationTypeMapping {
-  boolean: boolean;
-  string: string;
-  integer: number;
-  date: string;
-  double: number;
-  timestamp: string;
-}
+export type AggKeyClientToWire<
+  T extends AggregationKeyTypes,
+  S extends AggregationRangeKeyTypes = never,
+> = T extends keyof DataValueClientToWire ? DataValueClientToWire[T]
+  : T extends "range"
+    ? S extends keyof DataValueClientToWire ? Range<DataValueClientToWire[S]>
+    : never
+  : never;
+
+export type AggValueWireToClient<T extends AggregationValueTypes> = T extends
+  keyof DataValueWireToClient ? DataValueWireToClient[T] : never;
+
+export type AggValueClientToWire<T extends AggregationValueTypes> = T extends
+  keyof DataValueClientToWire ? DataValueClientToWire[T] : never;

--- a/packages/api/src/queries/Queries.ts
+++ b/packages/api/src/queries/Queries.ts
@@ -20,8 +20,10 @@ import type {
 } from "../mapping/DataValueMapping.js";
 import type { ObjectSet } from "../objectSet/ObjectSet.js";
 import type { ObjectTypeDefinition } from "../ontology/ObjectTypeDefinition.js";
+import type { TwoDimensionalQueryAggregationDefinition } from "../ontology/QueryDefinition.js";
 import type { OsdkBase } from "../OsdkBase.js";
 import type { OsdkObjectPrimaryKeyType } from "../OsdkObjectPrimaryKeyType.js";
+import type { TwoDimensionalAggregation } from "./Aggregations.js";
 
 /**
  * Helper types for converting query definition parameter types to typescript types
@@ -44,6 +46,13 @@ export namespace QueryParam {
    * Helper type to convert action definition parameter object sets to typescript types
    */
   export type ObjectSetType<T extends ObjectTypeDefinition> = ObjectSet<T>;
+
+  export type TwoDimensionalAggregationType<
+    T extends TwoDimensionalQueryAggregationDefinition,
+  > = TwoDimensionalAggregation<
+    DataValueClientToWire[T["keyType"]],
+    DataValueClientToWire[T["valueType"]]
+  >;
 }
 
 /**

--- a/packages/api/src/queries/Queries.ts
+++ b/packages/api/src/queries/Queries.ts
@@ -20,10 +20,21 @@ import type {
 } from "../mapping/DataValueMapping.js";
 import type { ObjectSet } from "../objectSet/ObjectSet.js";
 import type { ObjectTypeDefinition } from "../ontology/ObjectTypeDefinition.js";
-import type { TwoDimensionalQueryAggregationDefinition } from "../ontology/QueryDefinition.js";
+import type {
+  AggregationKeyTypes,
+  AggregationRangeKeyTypes,
+  AggregationValueTypes,
+} from "../ontology/QueryDefinition.js";
 import type { OsdkBase } from "../OsdkBase.js";
 import type { OsdkObjectPrimaryKeyType } from "../OsdkObjectPrimaryKeyType.js";
-import type { TwoDimensionalAggregation } from "./Aggregations.js";
+import type {
+  AggKeyClientToWire,
+  AggKeyWireToClient,
+  AggValueClientToWire,
+  AggValueWireToClient,
+  ThreeDimensionalAggregation,
+  TwoDimensionalAggregation,
+} from "./Aggregations.js";
 
 /**
  * Helper types for converting query definition parameter types to typescript types
@@ -47,11 +58,27 @@ export namespace QueryParam {
    */
   export type ObjectSetType<T extends ObjectTypeDefinition> = ObjectSet<T>;
 
+  export type RangeKey<T extends AggregationRangeKeyTypes> = AggKeyClientToWire<
+    "range",
+    T
+  >;
+
   export type TwoDimensionalAggregationType<
-    T extends TwoDimensionalQueryAggregationDefinition,
+    T extends AggregationKeyTypes | RangeKey<any>,
+    V extends AggregationValueTypes,
   > = TwoDimensionalAggregation<
-    DataValueClientToWire[T["keyType"]],
-    DataValueClientToWire[T["valueType"]]
+    T extends AggregationKeyTypes ? AggKeyClientToWire<T> : T,
+    AggValueClientToWire<V>
+  >;
+
+  export type ThreeDimensionalAggregationType<
+    OUT extends AggregationKeyTypes | RangeKey<any>,
+    IN extends AggregationKeyTypes | RangeKey<any>,
+    V extends AggregationValueTypes,
+  > = ThreeDimensionalAggregation<
+    OUT extends AggregationKeyTypes ? AggKeyClientToWire<OUT> : OUT,
+    IN extends AggregationKeyTypes ? AggKeyClientToWire<IN> : IN,
+    AggValueClientToWire<V>
   >;
 }
 
@@ -75,5 +102,28 @@ export namespace QueryResult {
    */
   export type ObjectSetType<T extends ObjectTypeDefinition> = ObjectSet<
     T
+  >;
+
+  export type RangeKey<T extends AggregationRangeKeyTypes> = AggKeyWireToClient<
+    "range",
+    T
+  >;
+
+  export type TwoDimensionalAggregationType<
+    T extends AggregationKeyTypes | RangeKey<any>,
+    V extends AggregationValueTypes,
+  > = TwoDimensionalAggregation<
+    T extends AggregationKeyTypes ? AggKeyWireToClient<T> : T,
+    AggValueWireToClient<V>
+  >;
+
+  export type ThreeDimensionalAggregationType<
+    OUT extends AggregationKeyTypes | RangeKey<any>,
+    IN extends AggregationKeyTypes | RangeKey<any>,
+    V extends AggregationValueTypes,
+  > = ThreeDimensionalAggregation<
+    OUT extends AggregationKeyTypes ? AggKeyWireToClient<OUT> : OUT,
+    IN extends AggregationKeyTypes ? AggKeyWireToClient<IN> : IN,
+    AggValueWireToClient<V>
   >;
 }

--- a/packages/client/src/queries/applyQuery.ts
+++ b/packages/client/src/queries/applyQuery.ts
@@ -111,7 +111,7 @@ async function remapQueryResponse<
 
   if (
     responseDataType.multiplicity != null
-    && responseDataType.multiplicity !== false
+    && responseDataType.multiplicity
   ) {
     const withoutMultiplicity = { ...responseDataType, multiplicity: false };
     for (let i = 0; i < responseValue.length; i++) {

--- a/packages/client/src/queries/queries.test.ts
+++ b/packages/client/src/queries/queries.test.ts
@@ -139,6 +139,9 @@ describe("queries", () => {
   it("two dimensional aggregation response works", async () => {
     const result = await client(twoDimensionalAggregationFunction)
       .executeFunction();
+    expectTypeOf<typeof result>().toEqualTypeOf<
+      { key: string; value: number }[]
+    >;
     expect(result).toEqual([{ key: "Q-AFN", value: 1 }, {
       key: "Q-AFO",
       value: 2,
@@ -146,6 +149,15 @@ describe("queries", () => {
   });
 
   it("two dimensional aggregation request/response works", async () => {
+    const clientBoundQueryFunction =
+      client(acceptsTwoDimensionalAggregationFunction).executeFunction;
+    type InferredParamType = Parameters<
+      typeof clientBoundQueryFunction
+    >[0];
+
+    expectTypeOf<{ aggFunction: { key: string; value: number }[] }>()
+      .toMatchTypeOf<InferredParamType>();
+
     const result = await client(acceptsTwoDimensionalAggregationFunction)
       .executeFunction({
         aggFunction: [
@@ -159,6 +171,10 @@ describe("queries", () => {
           },
         ],
       });
+    expectTypeOf<typeof result>().toEqualTypeOf<
+      { key: string; value: number }[]
+    >;
+
     expect(result).toEqual([{ key: "responseKey1", value: 3 }, {
       key: "responseKey2",
       value: 4,
@@ -168,6 +184,16 @@ describe("queries", () => {
   it("three dimensional aggregation response works", async () => {
     const result = await client(threeDimensionalAggregationFunction)
       .executeFunction();
+
+    expectTypeOf<typeof result>().toEqualTypeOf<
+      {
+        key: string;
+        groups: {
+          key: { startValue: string | undefined; endValue: string | undefined };
+          value: number;
+        }[];
+      }[]
+    >;
     expect(result).toEqual([{
       key: "Q-AFN",
       groups: [{
@@ -192,6 +218,23 @@ describe("queries", () => {
   });
 
   it("three dimensional aggregation request/response works", async () => {
+    const clientBoundQueryFunction =
+      client(acceptsThreeDimensionalAggregationFunction).executeFunction;
+    type InferredParamType = Parameters<
+      typeof clientBoundQueryFunction
+    >[0];
+
+    expectTypeOf<{
+      aggFunction: {
+        key: string;
+        groups: {
+          key: { startValue: string | undefined; endValue: string };
+          value: number;
+        }[];
+      }[];
+    }>()
+      .toMatchTypeOf<InferredParamType>();
+
     const result = await client(acceptsThreeDimensionalAggregationFunction)
       .executeFunction({
         aggFunction: [
@@ -213,6 +256,7 @@ describe("queries", () => {
           },
         ],
       });
+
     expect(result).toEqual([
       {
         key: "Q-AFN",

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/queries/queryTakesAllParameterTypes.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/queries/queryTakesAllParameterTypes.ts
@@ -84,7 +84,11 @@ export namespace queryTakesAllParameterTypes {
     /**
      * (no ontology metadata)
      */
-    readonly threeDimensionalAggregation: QueryParam.PrimitiveType<'threeDimensionalAggregation'>;
+    readonly threeDimensionalAggregation: QueryParam.ThreeDimensionalAggregationType<
+      QueryParam.RangeKey<'date'>,
+      QueryParam.RangeKey<'timestamp'>,
+      'date'
+    >;
 
     /**
      * (no ontology metadata)
@@ -94,7 +98,7 @@ export namespace queryTakesAllParameterTypes {
     /**
      * (no ontology metadata)
      */
-    readonly twoDimensionalAggregation: QueryParam.PrimitiveType<'twoDimensionalAggregation'>;
+    readonly twoDimensionalAggregation: QueryParam.TwoDimensionalAggregationType<'string', 'double'>;
 
     /**
      *   description: a union of strings and integers

--- a/packages/generator-converters/src/wireQueryDataTypeToQueryDataTypeDefinition.ts
+++ b/packages/generator-converters/src/wireQueryDataTypeToQueryDataTypeDefinition.ts
@@ -90,13 +90,13 @@ export function wireQueryDataTypeToQueryDataTypeDefinition<
 
       return {
         type: "union",
-        union: input.unionTypes.reduce((acc, t) => {
+        union: input.unionTypes.reduce<QueryDataTypeDefinition[]>((acc, t) => {
           if (t.type === "null") {
             return acc;
           }
           acc.push(wireQueryDataTypeToQueryDataTypeDefinition(t));
           return acc;
-        }, [] as QueryDataTypeDefinition[]),
+        }, []),
         nullable: allowNulls,
       };
 

--- a/packages/generator/src/v2.0/generatePerQueryDataFiles.ts
+++ b/packages/generator/src/v2.0/generatePerQueryDataFiles.ts
@@ -150,7 +150,7 @@ async function generateV2QueryFile(
                 ${
                   queryParamJsDoc(paramToDef(parameter), { apiName })
                 }readonly "${apiName}"${q.nullable ? "?" : ""}`,
-                `${getQueryParamType(ontology, q, "Param")}`,
+                getQueryParamType(ontology, q, "Param"),
               ];
             },
           })
@@ -312,7 +312,7 @@ export function getQueryParamType(
                 ${type === "Param" ? "readonly " : ""}"${apiName}"${
                 p.nullable ? "?" : ""
               }`,
-              `${getQueryParamType(enhancedOntology, p, type)}`,
+              getQueryParamType(enhancedOntology, p, type),
             ];
           },
         })

--- a/packages/generator/src/v2.0/generatePerQueryDataFiles.ts
+++ b/packages/generator/src/v2.0/generatePerQueryDataFiles.ts
@@ -296,12 +296,9 @@ export function getQueryParamType(
     case "integer":
     case "long":
     case "string":
-    case "threeDimensionalAggregation":
     case "timestamp":
-    case "twoDimensionalAggregation":
       inner = `Query${type}.PrimitiveType<${JSON.stringify(input.type)}>`;
       break;
-
     case "struct":
       inner = `{
             ${
@@ -319,7 +316,26 @@ export function getQueryParamType(
       }
             }`;
       break;
+    case "twoDimensionalAggregation":
+      inner = `Query${type}.TwoDimensionalAggregationType<${
+        input.twoDimensionalAggregation.keyType === "range"
+          ? `Query${type}.RangeKey<"${input.twoDimensionalAggregation.keySubtype}">`
+          : `"${input.twoDimensionalAggregation.keyType}"`
+      }, "${input.twoDimensionalAggregation.valueType}">`;
+      break;
 
+    case "threeDimensionalAggregation":
+      inner = `Query${type}.ThreeDimensionalAggregationType<${
+        input.threeDimensionalAggregation.keyType === "range"
+          ? `Query${type}.RangeKey<"${input.threeDimensionalAggregation.keySubtype}">`
+          : `"${input.threeDimensionalAggregation.keyType}"`
+      },${
+        input.threeDimensionalAggregation.valueType.keyType === "range"
+          ? `Query${type}.RangeKey<"${input.threeDimensionalAggregation.valueType.keySubtype}">`
+          : `"${input.threeDimensionalAggregation.valueType.keyType}"`
+      }, 
+        "${input.threeDimensionalAggregation.valueType.valueType}">`;
+      break;
     case "object":
       inner = `Query${type}.ObjectType<${
         enhancedOntology.requireObjectType(input.object)


### PR DESCRIPTION
Fleshing out aggregation types on a query so you can explicitly set the key and value types