### PR TITLE
Update create-widget template README and autoVersion strategy

### DIFF
--- a/.changeset/fuzzy-mice-occur.md
+++ b/.changeset/fuzzy-mice-occur.md
@@ -1,0 +1,7 @@
+---
+"@osdk/create-widget.template.react.v2": patch
+"@osdk/example-generator": patch
+"@osdk/create-widget": patch
+---
+
+Update create-widget template README and autoVersion strategy

--- a/packages/create-widget.template.react.v2/templates/README.md.hbs
+++ b/packages/create-widget.template.react.v2/templates/README.md.hbs
@@ -1,25 +1,41 @@
 # {{project}}
 
-This project was generated with [`@osdk/create-widget`](https://www.npmjs.com/package/@osdk/create-widget) and demonstrates developing a custom widget to be embedded within Foundry UIs such as Workshop. It uses the Ontology SDK package `{{osdkPackage}}` with React on top of Vite. Check out the [Vite](https://vitejs.dev/guide/) docs for further configuration.
+This project was generated with [`@osdk/create-widget`](https://www.npmjs.com/package/@osdk/create-widget) and demonstrates developing custom widgets to be embedded within Foundry UIs such as Workshop. It uses the Ontology SDK package `{{osdkPackage}}` with React on top of Vite. Check out the [Vite](https://vitejs.dev/guide/) docs for further configuration. The Vite plugin [`@osdk/widget.vite-plugin.unstable`](https://www.npmjs.com/package/@osdk/widget.vite-plugin.unstable) automatically generates a `widgets.config.json` manifest file containing metadata about widgets inside this project during the build command.
 
 ## Developing
 
-Run the following command or equivalent with your preferred package manager to start a local development server on `http://localhost:8080`:
+Run the following command or equivalent with your preferred package manager to start a local development server and follow the instructions printed to set up developer mode in Foundry:
 
 ```sh
 npm run dev
 ```
 
-Development configuration is stored in `.env.development`.
 
 ## Deploying
 
-Run the following command or equivalent with your preferred package manager to create a production build of your application:
+A `foundry.config.json` file is included in the root of this project containing the deployment configuration to Foundry.
+
+Run the following command or equivalent with your preferred package manager to create a production build of your widgets:
 
 ```sh
 npm run build
 ```
 
-Production configuration is stored in `.env.production`.
+A `.palantir/widgets.config.json` manifest file containing metadata about your widgets is created during the build.
 
-A `foundry.config.json` file is included in the root of this project to make deploying to Foundry website hosting with [`@osdk/cli`](https://www.npmjs.com/package/@osdk/cli) easier. If you are not using Foundry website hosting for your application you may delete this file.
+Run the following command or equivalent with your preferred package manager to deploy the production build of your widgets:
+
+```sh
+npx @osdk/cli@beta unstable widgetset deploy
+```
+
+By default the `package-json` strategy is used for determining the version for your widgets from the `version` field in this project's `package.json` file. Remember to update this field and rerun the build command to update the manifest file when deploying a new version.
+
+If you prefer to infer the version from a git tag, you can use the `git-describe` strategy by setting the `autoVersion` field in the `foundry.config.json` file to:
+
+```json
+{
+  "type": "git-describe",
+  "tagPrefix": ""
+}
+```

--- a/packages/create-widget/src/generate/generateFoundryConfigJson.test.ts
+++ b/packages/create-widget/src/generate/generateFoundryConfigJson.test.ts
@@ -24,8 +24,7 @@ const expected = `
     "rid": "ri.widgetregistry..widget-set.fake",
     "directory": "./dist",
     "autoVersion": {
-      "type": "git-describe",
-      "tagPrefix": ""
+      "type": "package-json"
     }
   }
 }

--- a/packages/create-widget/src/generate/generateFoundryConfigJson.ts
+++ b/packages/create-widget/src/generate/generateFoundryConfigJson.ts
@@ -31,8 +31,7 @@ export function generateFoundryConfigJson({
           rid: widgetSet,
           directory,
           autoVersion: {
-            type: "git-describe",
-            tagPrefix: "",
+            type: "package-json",
           },
         },
       },

--- a/packages/example-generator/src/run.ts
+++ b/packages/example-generator/src/run.ts
@@ -364,36 +364,10 @@ const UPDATE_README: Mutator = {
   }),
 };
 
-const UPDATE_WIDGET_FOUNDRY_CONFIG_JSON: Mutator = {
-  filePattern: "foundry.config.json",
-  mutate: (template, content, _sdkVersion) => {
-    if (!WIDGET_TEMPLATES.find(t => t.id === template.id)) {
-      return {
-        type: "modify",
-        newContent: content,
-      };
-    }
-    // Use package-json auto version strategy in vite manifest
-    return {
-      type: "modify",
-      newContent: content.replace(
-        `{
-      "type": "git-describe",
-      "tagPrefix": ""
-    }`,
-        `{
-      "type": "package-json"
-    }`,
-      ),
-    };
-  },
-};
-
 const MUTATORS: Mutator[] = [
   DELETE_NPM_RC,
   UPDATE_PACKAGE_JSON,
   UPDATE_README,
-  UPDATE_WIDGET_FOUNDRY_CONFIG_JSON,
 ];
 
 function templateCanonicalId(template: Template): string {


### PR DESCRIPTION
- Make the generated README a bit easier to use for new users
- Start the autoVersion strategy for widgets to be back to package-json as this works out of the box without needing to git init and git tag