### PR TITLE
Fix custom widget Vite 6 CORS issues and release @osdk/widget.vite-plugin.unstable 1.1.1

### DIFF
--- a/.changeset/slow-months-dream.md
+++ b/.changeset/slow-months-dream.md
@@ -1,0 +1,5 @@
+---
+"@osdk/widget.vite-plugin.unstable": patch
+---
+
+Release @osdk/widget.vite-plugin.unstable 1.1.1

--- a/.changeset/slow-months-dream.md
+++ b/.changeset/slow-months-dream.md
@@ -2,4 +2,4 @@
 "@osdk/widget.vite-plugin.unstable": patch
 ---
 
-Release @osdk/widget.vite-plugin.unstable 1.1.1
+Fix custom widget Vite 6 CORS issues and release @osdk/widget.vite-plugin.unstable 1.1.1

--- a/examples/example-widget-react-sdk-2.x/vite.config.ts
+++ b/examples/example-widget-react-sdk-2.x/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   plugins: [react(), foundryWidgetPlugin()],
   server: {
     port: 8080,
+    cors: true,
   },
   build: {
     rollupOptions: {

--- a/packages/create-widget.template.react.v2/templates/vite.config.ts.hbs
+++ b/packages/create-widget.template.react.v2/templates/vite.config.ts.hbs
@@ -7,6 +7,7 @@ export default defineConfig({
   plugins: [react(), foundryWidgetPlugin()],
   server: {
     port: 8080,
+    cors: true,
   },
   build: {
     rollupOptions: {

--- a/packages/e2e.sandbox.todowidget/vite.config.ts
+++ b/packages/e2e.sandbox.todowidget/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   plugins: [react(), foundryWidgetPlugin()],
   server: {
     port: 8080,
+    cors: true,
   },
   build: {
     rollupOptions: {

--- a/packages/widget.vite-plugin.unstable/package.json
+++ b/packages/widget.vite-plugin.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget.vite-plugin.unstable",
-  "version": "2.0.0-beta.13",
+  "version": "1.1.1",
   "description": "A vite plugin that will extract parameter definitions from TS/JS files + entrypoint info into a manifest file to be uploaded to Foundry ",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
Releasing #1172 to a non-beta release range and fixing CORS for dev-mode asset loading.

Looks like `cors: false` became the default with Vite 6.