### PR TITLE
Rename widget template component name to be consistent

### DIFF
--- a/.changeset/gold-balloons-grin.md
+++ b/.changeset/gold-balloons-grin.md
@@ -1,0 +1,6 @@
+---
+"@osdk/create-widget.template.react.v2": patch
+"@osdk/widget.vite-plugin.unstable": patch
+---
+
+Rename widget template component name consistent

--- a/examples/example-widget-react-sdk-2.x/src/Widget.tsx
+++ b/examples/example-widget-react-sdk-2.x/src/Widget.tsx
@@ -14,7 +14,7 @@ import {
 import React, { useCallback, useState } from "react";
 import { useWidgetContext } from "./context.js";
 
-export const App: React.FC = () => {
+export const Widget: React.FC = () => {
   const { parameters, emitEvent } = useWidgetContext();
   const { headerText, todoItems } = parameters.values;
   const [newTodoItem, setNewTodoItem] = useState("");

--- a/examples/example-widget-react-sdk-2.x/src/main.tsx
+++ b/examples/example-widget-react-sdk-2.x/src/main.tsx
@@ -5,14 +5,14 @@ import { FoundryWidget } from "@osdk/widget.client-react.unstable";
 import { Theme } from "@radix-ui/themes";
 import { createRoot } from "react-dom/client";
 import MainConfig from "./main.config.js";
-import { App } from "./widget.js";
+import { Widget } from "./Widget.js";
 
 const root = document.querySelector("body")!;
 
 createRoot(root).render(
   <Theme>
     <FoundryWidget config={MainConfig}>
-      <App />
+      <Widget />
     </FoundryWidget>
   </Theme>,
 );

--- a/packages/create-widget.template.react.v2/templates/src/Widget.tsx.hbs
+++ b/packages/create-widget.template.react.v2/templates/src/Widget.tsx.hbs
@@ -14,7 +14,7 @@ import {
 import React, { useCallback, useState } from "react";
 import { useWidgetContext } from "./context.js";
 
-export const App: React.FC = () => {
+export const Widget: React.FC = () => {
   const { parameters, emitEvent } = useWidgetContext();
   const { headerText, todoItems } = parameters.values;
   const [newTodoItem, setNewTodoItem] = useState("");

--- a/packages/create-widget.template.react.v2/templates/src/main.tsx
+++ b/packages/create-widget.template.react.v2/templates/src/main.tsx
@@ -5,14 +5,14 @@ import { FoundryWidget } from "@osdk/widget.client-react.unstable";
 import { Theme } from "@radix-ui/themes";
 import { createRoot } from "react-dom/client";
 import MainConfig from "./main.config.js";
-import { App } from "./widget.js";
+import { Widget } from "./Widget.js";
 
 const root = document.querySelector("body")!;
 
 createRoot(root).render(
   <Theme>
     <FoundryWidget config={MainConfig}>
-      <App />
+      <Widget />
     </FoundryWidget>
   </Theme>,
 );

--- a/packages/widget.vite-plugin.unstable/README.md
+++ b/packages/widget.vite-plugin.unstable/README.md
@@ -99,13 +99,13 @@ Import your configuration file in `src/main.tsx` so the vite plugin will discove
 import { FoundryWidget } from "@osdk/widget.client-react";
 import React from "react";
 import { createRoot } from "react-dom/client";
-import { App } from "./app.js";
+import { Widget } from "./Widget.js";
 import MainConfig from "./main.config.js";
 
 const root = document.querySelector("body")!;
 createRoot(root).render(
   <FoundryWidget config={MainConfig}>
-    <App />
+    <Widget />
   </FoundryWidget>
 );
 ```


### PR DESCRIPTION
For the create-app templates we use pascal case component names so matching that with the create-widget template. Also call the export Widget rather than App.

We will need to remember the manifest template token file name needs to be updated from the file name change