### PR TITLE
Fix release script

### DIFF
--- a/.changeset/light-horses-mate.md
+++ b/.changeset/light-horses-mate.md
@@ -1,0 +1,5 @@
+---
+"@osdk/tool.release": patch
+---
+
+Fix release for none release types.

--- a/packages/tool.release/src/runVersion.ts
+++ b/packages/tool.release/src/runVersion.ts
@@ -170,7 +170,7 @@ export async function runVersion({
 
   for (const release of releasePlan.releases) {
     const versions = await packageVersionsOrEmptySet(release.name);
-    if (versions.has(release.newVersion)) {
+    if (versions.has(release.newVersion) && release.type !== "none") {
       throw new FailedWithUserMessage(
         `The version ${release.newVersion} of ${release.name} is already published on npm`,
       );


### PR DESCRIPTION
Before, if the release type was none, we'd still flag in our script that the version was already published on npm and fail. Changesets ignores any releases marked as type:none when applying the release plan, so we should do the same when erroring.