### PR TITLE
Rename objectorinterface definition namespace

### DIFF
--- a/.changeset/spicy-ties-kneel.md
+++ b/.changeset/spicy-ties-kneel.md
@@ -1,0 +1,5 @@
+---
+"@osdk/api": patch
+---
+
+Rename namespace so not exported from api package.

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -707,18 +707,6 @@ export namespace ObjectMetadata {
 // @public (undocumented)
 export type ObjectOrInterfaceDefinition = ObjectTypeDefinition | InterfaceDefinition;
 
-// @public (undocumented)
-export namespace ObjectOrInterfaceDefinition {
-    	// (undocumented)
-    export type WithDerivedProperties<
-    		K extends ObjectOrInterfaceDefinition,
-    		D extends Record<string, SimplePropertyDef>
-    	> = { __DefinitionMetadata: {
-            		properties: { [T in keyof D] : SimplePropertyDef.ToPropertyDef<D[T]> };
-            		props: { [T in keyof D] : SimplePropertyDef.ToRuntimeProperty<D[T]> };
-            	} } & K;
-}
-
 // Warning: (ae-forgotten-export) The symbol "BaseQueryDataTypeDefinition" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)

--- a/packages/api/src/objectSet/ObjectSet.ts
+++ b/packages/api/src/objectSet/ObjectSet.ts
@@ -29,6 +29,7 @@ import type {
 import type { Result } from "../object/Result.js";
 import type { InterfaceDefinition } from "../ontology/InterfaceDefinition.js";
 import type {
+  DerivedObjectOrInterfaceDefinition,
   ObjectOrInterfaceDefinition,
   PropertyKeys,
 } from "../ontology/ObjectOrInterface.js";
@@ -51,7 +52,7 @@ type MergeObjectSet<
   Q extends ObjectOrInterfaceDefinition,
   D extends ObjectSet<Q> | Record<string, SimplePropertyDef> = {},
 > = D extends Record<string, SimplePropertyDef>
-  ? ObjectOrInterfaceDefinition.WithDerivedProperties<Q, D>
+  ? DerivedObjectOrInterfaceDefinition.WithDerivedProperties<Q, D>
   : Q;
 
 type ExtractRdp<

--- a/packages/api/src/ontology/ObjectOrInterface.ts
+++ b/packages/api/src/ontology/ObjectOrInterface.ts
@@ -22,7 +22,7 @@ export type ObjectOrInterfaceDefinition =
   | ObjectTypeDefinition
   | InterfaceDefinition;
 
-export namespace ObjectOrInterfaceDefinition {
+export namespace DerivedObjectOrInterfaceDefinition {
   export type WithDerivedProperties<
     K extends ObjectOrInterfaceDefinition,
     D extends Record<string, SimplePropertyDef>,


### PR DESCRIPTION
Renaming the namespace for now so we can keep the type internal. We can rethink naming/location of the type if we decide to push this out externally