### PR TITLE
Rename base action param types

### DIFF
--- a/.changeset/beige-schools-flow.md
+++ b/.changeset/beige-schools-flow.md
@@ -1,0 +1,7 @@
+---
+"@osdk/generator-converters": patch
+"@osdk/client": patch
+"@osdk/api": patch
+---
+
+Rename type for base action parameter types.

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -60,6 +60,8 @@ export namespace ActionMetadata {
     	// (undocumented)
     export namespace DataType {
         		// (undocumented)
+        export type BaseActionParameterTypes = "boolean" | "string" | "integer" | "long" | "double" | "datetime" | "timestamp" | "attachment" | "marking" | "mediaReference" | "objectType";
+        		// (undocumented)
         export interface Interface<T_Target extends InterfaceDefinition = never> {
             			// (undocumented)
             __OsdkTargetType?: T_Target;
@@ -87,7 +89,7 @@ export namespace ActionMetadata {
             type: "objectSet";
             		}
         		// (undocumented)
-        export interface Struct<T extends Record<string, ValidBaseActionParameterTypes>> {
+        export interface Struct<T extends Record<string, DataType.BaseActionParameterTypes>> {
             			// (undocumented)
             struct: T;
             			// (undocumented)
@@ -103,7 +105,7 @@ export namespace ActionMetadata {
         		// (undocumented)
         nullable?: boolean;
         		// (undocumented)
-        type: ValidBaseActionParameterTypes | DataType.Object<any> | DataType.ObjectSet<any> | DataType.Interface<any> | DataType.Struct<any>;
+        type: DataType.BaseActionParameterTypes | DataType.Object<any> | DataType.ObjectSet<any> | DataType.Interface<any> | DataType.Struct<any>;
         	}
 }
 
@@ -1144,9 +1146,6 @@ export type ValidAggregationKeys<
 	Q extends ObjectOrInterfaceDefinition,
 	R extends "aggregate" | "withPropertiesAggregate" = "aggregate"
 > = keyof ({ [KK in AggregatableKeys<Q> as `${KK & string}:${AGG_FOR_TYPE<GetWirePropertyValueFromClient<CompileTimeMetadata<Q>["properties"][KK]["type"]>, R extends "aggregate" ? true : false>}`]? : any } & { $count?: any });
-
-// @public (undocumented)
-export type ValidBaseActionParameterTypes = "boolean" | "string" | "integer" | "long" | "double" | "datetime" | "timestamp" | "attachment" | "marking" | "mediaReference" | "objectType";
 
 // Warning: (ae-forgotten-export) The symbol "VersionString" needs to be exported by the entry point index.d.ts
 //

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -82,7 +82,6 @@ export type { ObjectSetListenerOptions } from "./objectSet/ObjectSetListener.js"
 export type {
   ActionDefinition,
   ActionMetadata,
-  ValidBaseActionParameterTypes,
 } from "./ontology/ActionDefinition.js";
 export type {
   InterfaceDefinition,

--- a/packages/api/src/ontology/ActionDefinition.ts
+++ b/packages/api/src/ontology/ActionDefinition.ts
@@ -42,7 +42,7 @@ export namespace ActionMetadata {
     T_Target extends ObjectTypeDefinition = never,
   > {
     type:
-      | ValidBaseActionParameterTypes
+      | DataType.BaseActionParameterTypes
       | DataType.Object<any>
       | DataType.ObjectSet<any>
       | DataType.Interface<any>
@@ -53,6 +53,19 @@ export namespace ActionMetadata {
   }
 
   export namespace DataType {
+    export type BaseActionParameterTypes =
+      | "boolean"
+      | "string"
+      | "integer"
+      | "long"
+      | "double"
+      | "datetime"
+      | "timestamp"
+      | "attachment"
+      | "marking"
+      | "mediaReference"
+      | "objectType";
+
     export interface Object<
       T_Target extends ObjectTypeDefinition = never,
     > {
@@ -76,7 +89,7 @@ export namespace ActionMetadata {
     }
 
     export interface Struct<
-      T extends Record<string, ValidBaseActionParameterTypes>,
+      T extends Record<string, DataType.BaseActionParameterTypes>,
     > {
       type: "struct";
       struct: T;

--- a/packages/api/src/ontology/ActionDefinition.ts
+++ b/packages/api/src/ontology/ActionDefinition.ts
@@ -111,16 +111,3 @@ export interface ActionDefinition<
     & ActionCompileTimeMetadata<T_signatures>
     & ActionMetadata;
 }
-
-export type ValidBaseActionParameterTypes =
-  | "boolean"
-  | "string"
-  | "integer"
-  | "long"
-  | "double"
-  | "datetime"
-  | "timestamp"
-  | "attachment"
-  | "marking"
-  | "mediaReference"
-  | "objectType";

--- a/packages/client/src/queries/queries.test.ts
+++ b/packages/client/src/queries/queries.test.ts
@@ -90,6 +90,7 @@ describe("queries", () => {
 
   it("accepts objectSets", async () => {
     const employeeObjectSet = client(Employee);
+
     const result = await client(queryAcceptsObjectSets).executeFunction({
       objectSet: employeeObjectSet,
     });

--- a/packages/client/src/queries/queries.test.ts
+++ b/packages/client/src/queries/queries.test.ts
@@ -90,7 +90,6 @@ describe("queries", () => {
 
   it("accepts objectSets", async () => {
     const employeeObjectSet = client(Employee);
-
     const result = await client(queryAcceptsObjectSets).executeFunction({
       objectSet: employeeObjectSet,
     });

--- a/packages/generator-converters/src/wireActionTypeV2ToSdkActionMetadata.ts
+++ b/packages/generator-converters/src/wireActionTypeV2ToSdkActionMetadata.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ActionMetadata, ValidBaseActionParameterTypes } from "@osdk/api";
+import type { ActionMetadata } from "@osdk/api";
 import type {
   ActionParameterType,
   ActionParameterV2,
@@ -91,12 +91,15 @@ function actionPropertyToSdkPropertyDefinition(
         type: "struct",
         struct: parameterType.fields.reduce(
           (
-            structMap: Record<string, ValidBaseActionParameterTypes>,
+            structMap: Record<
+              string,
+              ActionMetadata.DataType.BaseActionParameterTypes
+            >,
             structField,
           ) => {
             structMap[structField.name] = actionPropertyToSdkPropertyDefinition(
               structField.fieldType as ActionParameterType,
-            ) as ValidBaseActionParameterTypes;
+            ) as ActionMetadata.DataType.BaseActionParameterTypes;
             return structMap;
           },
           {},


### PR DESCRIPTION
Renaming to use our namespace instead