### PR TITLE
Fix struct filter

### DIFF
--- a/.changeset/shy-impalas-sip.md
+++ b/.changeset/shy-impalas-sip.md
@@ -1,0 +1,5 @@
+---
+"@osdk/api": patch
+---
+
+Remove ability to filter on entire struct.

--- a/packages/api/src/aggregate/WhereClause.ts
+++ b/packages/api/src/aggregate/WhereClause.ts
@@ -153,7 +153,7 @@ type FilterFor<PD extends ObjectMetadata.Property> = PD["multiplicity"] extends
       : ArrayFilter<number>))
   : PD["type"] extends Record<string, BaseWirePropertyTypes> ?
       | StructFilter<PD["type"]>
-      | BaseFilter<string>
+      | BaseFilter.$isNull<string>
   : (PD["type"] extends "string" ? StringFilter
     : PD["type"] extends "geopoint" | "geoshape" ? GeoFilter
     : PD["type"] extends "datetime" | "timestamp" ? DatetimeFilter


### PR DESCRIPTION
The backend does not actually support filtering on entire structs, so this PR restricts filtering for those types.