### PR TITLE
remove duplication

### DIFF
--- a/.changeset/rich-carrots-dream.md
+++ b/.changeset/rich-carrots-dream.md
@@ -1,0 +1,5 @@
+---
+"@osdk/generator-converters": patch
+---
+
+Remove duplicate types in case statement.

--- a/packages/generator-converters/src/wirePropertyV2ToSdkPrimaryKeyTypeDefinition.ts
+++ b/packages/generator-converters/src/wirePropertyV2ToSdkPrimaryKeyTypeDefinition.ts
@@ -45,7 +45,6 @@ export function wirePropertyV2ToSdkPrimaryKeyTypeDefinition(
     case "marking":
     case "float":
     case "geotimeSeriesReference":
-    case "cipherText":
     case "mediaReference":
     case "struct":
     case "cipherText":

--- a/packages/generator-converters/src/wirePropertyV2ToSdkPropertyDefinition.ts
+++ b/packages/generator-converters/src/wirePropertyV2ToSdkPropertyDefinition.ts
@@ -40,7 +40,6 @@ export function wirePropertyV2ToSdkPropertyDefinition(
     case "integer":
     case "string":
     case "byte":
-    case "cipherText":
     case "decimal":
     case "double":
     case "float":


### PR DESCRIPTION
We had cipherText duplicated in a couple of places, and could have run into a bug where someone thinks they're supported by accident. This fixes that