### PR TITLE
Add fetchAsBase64Url to media reference props

### DIFF
--- a/packages/api/src/object/Media.ts
+++ b/packages/api/src/object/Media.ts
@@ -23,6 +23,10 @@ export interface Media {
    * Fetches content of a media reference property
    */
   fetchContents(): Promise<Response>;
+  /**
+   * Returns base64 encoded contents
+   */
+  fetchAsBase64Url(): Promise<string>;
 }
 
 /**

--- a/packages/client/src/createMediaReferenceProperty.ts
+++ b/packages/client/src/createMediaReferenceProperty.ts
@@ -59,4 +59,16 @@ export class MediaReferencePropertyImpl implements Media {
       mediaType: r.mediaType,
     };
   }
+
+  public async fetchAsBase64Url(): Promise<string> {
+    const response = await this.fetchContents();
+    if (!response.ok) {
+      throw new Error(`Error fetching media contents: ${response.status}`);
+    }
+    const arrayBuffer = await response.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    const base64String = buffer.toString("base64");
+    const mimeType = response.headers.get("content-type") || "image/jpeg";
+    return `data:${mimeType};base64,${base64String}`;
+  }
 }

--- a/packages/client/src/object/media.test.ts
+++ b/packages/client/src/object/media.test.ts
@@ -66,4 +66,23 @@ describe("media", () => {
       content: "Hello World",
     });
   });
+
+  it("reads media content as base64 successfully", async () => {
+    const result = await client(objectTypeWithAllPropertyTypes)
+      .where({ id: stubData.objectWithAllPropertyTypes1.id }).fetchPage();
+
+    const object1 = result.data[0];
+    expect(object1.mediaReference).toBeDefined();
+
+    const mediaContent = await object1?.mediaReference?.fetchAsBase64Url();
+    const encodedString = mediaContent != null
+      ? mediaContent.split("base64,")[1]
+      : "";
+    const buffer = Buffer.from(encodedString, "base64");
+    const decodedString = buffer.toString("utf-8");
+
+    expect(JSON.parse(decodedString)).toEqual({
+      content: "Hello World",
+    });
+  });
 });


### PR DESCRIPTION
Added fetchAsBase64Url method to media reference properties that encodes the response as a base64 url. 
