### PR TITLE
Version Packages (rc)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -218,6 +218,7 @@
     "quiet-windows-teach",
     "rare-brooms-move",
     "rare-jobs-attend",
+    "react-cache-set",
     "real-cups-refuse",
     "red-carpets-wave",
     "red-cherries-sleep",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdkkit/react
 
+## 0.3.0-rc.4
+
+### Patch Changes
+
+- 66a8ee4: Adding support for react caching work.
+
 ## 0.3.0-beta.3
 
 ### Minor Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/react",
-  "version": "0.3.0-beta.3",
+  "version": "0.3.0-rc.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/2.1.x, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`release/2.1.x` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `release/2.1.x`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/react@0.3.0-rc.4

### Patch Changes

-   66a8ee4: Adding support for react caching work.
