### PR TITLE
Remove lint statements

### DIFF
--- a/.changeset/quiet-dots-cheat.md
+++ b/.changeset/quiet-dots-cheat.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Removed unneeded lint statements.

--- a/packages/client/src/observable/internal/objectMatchesWhereClause.ts
+++ b/packages/client/src/observable/internal/objectMatchesWhereClause.ts
@@ -116,12 +116,10 @@ export function objectSortaMatchesWhereClause(
         case "$ne":
           return realValue !== expected;
         case "$in":
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-call
           return expected.$in.includes(realValue);
         case "$isNull":
           return realValue == null;
         case "$startsWith":
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-call
           return realValue.startsWith(
             expected,
           );


### PR DESCRIPTION
Now that we turned off the no-unsafe-call rule, we can remove these lint statements from the code