### PR TITLE
Version Packages

### DIFF
--- a/.changeset/backported-fix-release.md
+++ b/.changeset/backported-fix-release.md
@@ -1,6 +1,0 @@
----
-"@osdk/generator-converters": patch
-"@osdk/generator": patch
----
-
-Ignore unknown properties

--- a/.changeset/twenty-trees-warn.md
+++ b/.changeset/twenty-trees-warn.md
@@ -1,7 +1,0 @@
----
-"@osdk/shared.net.platformapi": patch
-"@osdk/legacy-client": patch
-"@osdk/shared.net": patch
----
-
-Fix fetch functions.

--- a/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,12 +1,12 @@
 import { OntologyMetadata as OM } from '@osdk/api';
 
-export type $ExpectedClientVersion = '0.21.2';
+export type $ExpectedClientVersion = '0.21.3';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export interface OntologyMetadata extends OM<$ExpectedClientVersion> {}
 
 export const OntologyMetadata: OntologyMetadata = {
-  expectsClientVersion: '0.21.2',
+  expectsClientVersion: '0.21.3',
   ontologyRid: 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e',
   ontologyApiName: 'ontology-d097f725-ab77-46cf-83c0-e3cb9186bff1',
   userAgent: 'typescript-sdk/dev osdk-cli/dev',

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/api
 
+## 1.9.3
+
+### Patch Changes
+
+- Updated dependencies [d67e753]
+  - @osdk/shared.net@1.12.3
+
 ## 1.9.2
 
 ### Patch Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/api",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/cli.cmd.typescript
 
+## 0.5.6
+
+### Patch Changes
+
+- Updated dependencies [507ae4a]
+- Updated dependencies [d67e753]
+  - @osdk/generator@1.13.6
+  - @osdk/shared.net@1.12.3
+
 ## 0.5.5
 
 ### Patch Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.5.5",
+  "version": "0.5.6",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/cli
 
+## 0.23.6
+
+### Patch Changes
+
+- Updated dependencies [507ae4a]
+- Updated dependencies [d67e753]
+  - @osdk/generator@1.13.6
+  - @osdk/shared.net@1.12.3
+  - @osdk/api@1.9.3
+
 ## 0.23.5
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.23.5",
+  "version": "0.23.6",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client.api/CHANGELOG.md
+++ b/packages/client.api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/client.api
 
+## 0.21.3
+
+### Patch Changes
+
+- @osdk/api@1.9.3
+
 ## 0.21.2
 
 ### Patch Changes

--- a/packages/client.api/package.json
+++ b/packages/client.api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.api",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.test.ontology/CHANGELOG.md
+++ b/packages/client.test.ontology/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/client.test.ontology
 
+## 1.1.3
+
+### Patch Changes
+
+- @osdk/api@1.9.3
+- @osdk/client.api@0.21.3
+
 ## 1.1.2
 
 ### Patch Changes

--- a/packages/client.test.ontology/package.json
+++ b/packages/client.test.ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/client.test.ontology",
   "private": true,
-  "version": "1.1.2",
+  "version": "1.1.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/client
 
+## 0.21.3
+
+### Patch Changes
+
+- Updated dependencies [507ae4a]
+  - @osdk/generator-converters@0.7.3
+  - @osdk/api@1.9.3
+  - @osdk/client.api@0.21.3
+
 ## 0.21.2
 
 ### Patch Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -53,7 +53,7 @@ export interface Client extends SharedClient<MinimalClient> {
 }
 
 // BEGIN: THIS IS GENERATED CODE. DO NOT EDIT.
-const MaxOsdkVersion = "0.21.2";
+const MaxOsdkVersion = "0.21.3";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 export type MaxOsdkVersion = typeof MaxOsdkVersion;
 const ErrorMessage = Symbol("ErrorMessage");

--- a/packages/e2e.generated.1.1.x/CHANGELOG.md
+++ b/packages/e2e.generated.1.1.x/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/e2e.generated.1.1.x
 
+## 0.2.6
+
+### Patch Changes
+
+- Updated dependencies [507ae4a]
+- Updated dependencies [d67e753]
+  - @osdk/generator@1.13.6
+  - @osdk/legacy-client@2.5.4
+  - @osdk/api@1.9.3
+
 ## 0.2.5
 
 ### Patch Changes

--- a/packages/e2e.generated.1.1.x/package.json
+++ b/packages/e2e.generated.1.1.x/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.generated.1.1.x",
   "private": true,
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "",
   "license": "Apache-2.0",
   "repository": {
@@ -37,14 +37,14 @@
     "@osdk/legacy-client": "workspace:~"
   },
   "peerDependencies": {
-    "@osdk/api": "^1.9.2",
-    "@osdk/legacy-client": "^2.5.3"
+    "@osdk/api": "^1.9.3",
+    "@osdk/legacy-client": "^2.5.4"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.2",
-    "@osdk/api": "^1.9.2",
+    "@osdk/api": "^1.9.3",
     "@osdk/cli.cmd.typescript": "workspace:~",
-    "@osdk/legacy-client": "^2.5.3",
+    "@osdk/legacy-client": "^2.5.4",
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
     "@osdk/monorepo.tsup": "workspace:~",

--- a/packages/e2e.generated.catchall/CHANGELOG.md
+++ b/packages/e2e.generated.catchall/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/e2e.generated.catchall
 
+## 2.0.3
+
+### Patch Changes
+
+- @osdk/client@0.21.3
+- @osdk/api@1.9.3
+- @osdk/client.api@0.21.3
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/e2e.generated.catchall/package.json
+++ b/packages/e2e.generated.catchall/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.generated.catchall",
   "private": true,
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,12 +1,12 @@
 import { OntologyMetadata as OM } from '@osdk/api';
 
-export type $ExpectedClientVersion = '0.21.2';
+export type $ExpectedClientVersion = '0.21.3';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export interface OntologyMetadata extends OM<$ExpectedClientVersion> {}
 
 export const OntologyMetadata: OntologyMetadata = {
-  expectsClientVersion: '0.21.2',
+  expectsClientVersion: '0.21.3',
   ontologyRid: 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e',
   ontologyApiName: 'default',
   userAgent: 'typescript-sdk/dev osdk-cli/dev',

--- a/packages/e2e.sandbox.catchall/CHANGELOG.md
+++ b/packages/e2e.sandbox.catchall/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/e2e.sandbox.catchall
 
+## 0.2.3
+
+### Patch Changes
+
+- @osdk/client@0.21.3
+- @osdk/foundry@2.0.3
+- @osdk/internal.foundry@0.4.3
+- @osdk/api@1.9.3
+- @osdk/e2e.generated.catchall@2.0.3
+- @osdk/client.api@0.21.3
+
 ## 0.2.2
 
 ### Patch Changes

--- a/packages/e2e.sandbox.catchall/package.json
+++ b/packages/e2e.sandbox.catchall/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.sandbox.catchall",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.sandbox.oauth/CHANGELOG.md
+++ b/packages/e2e.sandbox.oauth/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/e2e.sandbox.oauth
 
+## 0.2.3
+
+### Patch Changes
+
+- @osdk/client@0.21.3
+
 ## 0.2.2
 
 ### Patch Changes

--- a/packages/e2e.sandbox.oauth/package.json
+++ b/packages/e2e.sandbox.oauth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.sandbox.oauth",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.sandbox.todoapp/CHANGELOG.md
+++ b/packages/e2e.sandbox.todoapp/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/e2e.sandbox.todoappapp
 
+## 2.0.3
+
+### Patch Changes
+
+- @osdk/client@0.21.3
+- @osdk/api@1.9.3
+- @osdk/client.api@0.21.3
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/e2e.sandbox.todoapp/package.json
+++ b/packages/e2e.sandbox.todoapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.sandbox.todoapp",
   "private": true,
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/OntologyMetadata.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/OntologyMetadata.ts
@@ -1,12 +1,12 @@
 import { OntologyMetadata as OM } from '@osdk/api';
 
-export type $ExpectedClientVersion = '0.21.2';
+export type $ExpectedClientVersion = '0.21.3';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export interface OntologyMetadata extends OM<$ExpectedClientVersion> {}
 
 export const OntologyMetadata: OntologyMetadata = {
-  expectsClientVersion: '0.21.2',
+  expectsClientVersion: '0.21.3',
   ontologyRid: 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e',
   ontologyApiName: 'ontology-d097f725-ab77-46cf-83c0-e3cb9186bff1',
   userAgent: 'typescript-sdk/dev osdk-cli/dev',

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/foundry-sdk-generator
 
+## 1.3.14
+
+### Patch Changes
+
+- Updated dependencies [507ae4a]
+- Updated dependencies [d67e753]
+  - @osdk/generator@1.13.6
+  - @osdk/legacy-client@2.5.4
+  - @osdk/shared.net@1.12.3
+  - @osdk/client@0.21.3
+  - @osdk/api@1.9.3
+  - @osdk/client.api@0.21.3
+
 ## 1.3.13
 
 ### Patch Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/foundry.admin/CHANGELOG.md
+++ b/packages/foundry.admin/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/foundry.admin
 
+## 2.0.3
+
+### Patch Changes
+
+- Updated dependencies [d67e753]
+  - @osdk/shared.net.platformapi@0.2.2
+  - @osdk/foundry.core@2.0.3
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/foundry.admin/package.json
+++ b/packages/foundry.admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.admin",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.core/CHANGELOG.md
+++ b/packages/foundry.core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/foundry.core
 
+## 2.0.3
+
+### Patch Changes
+
+- Updated dependencies [d67e753]
+  - @osdk/shared.net.platformapi@0.2.2
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/foundry.core/package.json
+++ b/packages/foundry.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.core",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.datasets/CHANGELOG.md
+++ b/packages/foundry.datasets/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/foundry.datasets
 
+## 2.0.3
+
+### Patch Changes
+
+- Updated dependencies [d67e753]
+  - @osdk/shared.net.platformapi@0.2.2
+  - @osdk/foundry.core@2.0.3
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/foundry.datasets/package.json
+++ b/packages/foundry.datasets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.datasets",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.thirdpartyapplications/CHANGELOG.md
+++ b/packages/foundry.thirdpartyapplications/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/foundry.thirdpartyapplications
 
+## 2.0.3
+
+### Patch Changes
+
+- Updated dependencies [d67e753]
+  - @osdk/shared.net.platformapi@0.2.2
+  - @osdk/foundry.core@2.0.3
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/foundry.thirdpartyapplications/package.json
+++ b/packages/foundry.thirdpartyapplications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.thirdpartyapplications",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry/CHANGELOG.md
+++ b/packages/foundry/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/foundry
 
+## 2.0.3
+
+### Patch Changes
+
+- Updated dependencies [d67e753]
+  - @osdk/shared.net.platformapi@0.2.2
+  - @osdk/foundry.admin@2.0.3
+  - @osdk/foundry.core@2.0.3
+  - @osdk/foundry.datasets@2.0.3
+  - @osdk/foundry.thirdpartyapplications@2.0.3
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/foundry/package.json
+++ b/packages/foundry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/generator-converters/CHANGELOG.md
+++ b/packages/generator-converters/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/generator-converters
 
+## 0.7.3
+
+### Patch Changes
+
+- 507ae4a: Ignore unknown properties
+  - @osdk/api@1.9.3
+
 ## 0.7.2
 
 ### Patch Changes

--- a/packages/generator-converters/package.json
+++ b/packages/generator-converters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-converters",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/generator
 
+## 1.13.6
+
+### Patch Changes
+
+- 507ae4a: Ignore unknown properties
+- Updated dependencies [507ae4a]
+  - @osdk/generator-converters@0.7.3
+  - @osdk/api@1.9.3
+
 ## 1.13.5
 
 ### Patch Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "1.13.5",
+  "version": "1.13.6",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator/src/v2.0/generateMetadata.ts
+++ b/packages/generator/src/v2.0/generateMetadata.ts
@@ -20,7 +20,7 @@ import { formatTs } from "../util/test/formatTs.js";
 import type { WireOntologyDefinition } from "../WireOntologyDefinition.js";
 
 // BEGIN: THIS IS GENERATED CODE. DO NOT EDIT.
-const ExpectedOsdkVersion = "0.21.2";
+const ExpectedOsdkVersion = "0.21.3";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 
 export async function generateOntologyMetadataFile(

--- a/packages/internal.foundry.core/CHANGELOG.md
+++ b/packages/internal.foundry.core/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/internal.foundry.core
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies [d67e753]
+  - @osdk/shared.net.platformapi@0.2.2
+  - @osdk/shared.net@1.12.3
+  - @osdk/api@1.9.3
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/internal.foundry.core/package.json
+++ b/packages/internal.foundry.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.core",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.datasets/CHANGELOG.md
+++ b/packages/internal.foundry.datasets/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/internal.foundry.datasets
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies [d67e753]
+  - @osdk/shared.net.platformapi@0.2.2
+  - @osdk/shared.net@1.12.3
+  - @osdk/internal.foundry.core@0.1.3
+  - @osdk/api@1.9.3
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/internal.foundry.datasets/package.json
+++ b/packages/internal.foundry.datasets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.datasets",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.models/CHANGELOG.md
+++ b/packages/internal.foundry.models/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/internal.foundry.models
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies [d67e753]
+  - @osdk/shared.net.platformapi@0.2.2
+  - @osdk/shared.net@1.12.3
+  - @osdk/internal.foundry.core@0.1.3
+  - @osdk/api@1.9.3
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/internal.foundry.models/package.json
+++ b/packages/internal.foundry.models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.models",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.ontologies/CHANGELOG.md
+++ b/packages/internal.foundry.ontologies/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/internal.foundry.ontologies
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies [d67e753]
+  - @osdk/shared.net.platformapi@0.2.2
+  - @osdk/shared.net@1.12.3
+  - @osdk/internal.foundry.core@0.1.3
+  - @osdk/api@1.9.3
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/internal.foundry.ontologies/package.json
+++ b/packages/internal.foundry.ontologies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.ontologies",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.ontologiesv2/CHANGELOG.md
+++ b/packages/internal.foundry.ontologiesv2/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/internal.foundry.ontologiesv2
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies [d67e753]
+  - @osdk/shared.net.platformapi@0.2.2
+  - @osdk/shared.net@1.12.3
+  - @osdk/internal.foundry.core@0.1.3
+  - @osdk/internal.foundry.ontologies@0.1.3
+  - @osdk/api@1.9.3
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/internal.foundry.ontologiesv2/package.json
+++ b/packages/internal.foundry.ontologiesv2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.ontologiesv2",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry/CHANGELOG.md
+++ b/packages/internal.foundry/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @osdk/foundry
 
+## 0.4.3
+
+### Patch Changes
+
+- Updated dependencies [d67e753]
+  - @osdk/shared.net.platformapi@0.2.2
+  - @osdk/shared.net@1.12.3
+  - @osdk/internal.foundry.core@0.1.3
+  - @osdk/internal.foundry.datasets@0.1.3
+  - @osdk/internal.foundry.models@0.1.3
+  - @osdk/internal.foundry.ontologies@0.1.3
+  - @osdk/internal.foundry.ontologiesv2@0.1.3
+  - @osdk/api@1.9.3
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/internal.foundry/package.json
+++ b/packages/internal.foundry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/internal.foundry",
   "private": "true",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/legacy-client/CHANGELOG.md
+++ b/packages/legacy-client/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/legacy-client
 
+## 2.5.4
+
+### Patch Changes
+
+- d67e753: Fix fetch functions.
+- Updated dependencies [d67e753]
+  - @osdk/shared.net@1.12.3
+  - @osdk/api@1.9.3
+
 ## 2.5.3
 
 ### Patch Changes

--- a/packages/legacy-client/package.json
+++ b/packages/legacy-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/legacy-client",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/maker/CHANGELOG.md
+++ b/packages/maker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/maker
 
+## 0.7.3
+
+### Patch Changes
+
+- @osdk/api@1.9.3
+
 ## 0.7.2
 
 ### Patch Changes

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.net.platformapi/CHANGELOG.md
+++ b/packages/shared.net.platformapi/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/shared.net.platformapi
 
+## 0.2.2
+
+### Patch Changes
+
+- d67e753: Fix fetch functions.
+
 ## 0.2.1
 
 ### Patch Changes

--- a/packages/shared.net.platformapi/package.json
+++ b/packages/shared.net.platformapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/shared.net.platformapi",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.net/CHANGELOG.md
+++ b/packages/shared.net/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/shared.net
 
+## 1.12.3
+
+### Patch Changes
+
+- d67e753: Fix fetch functions.
+
 ## 1.12.2
 
 ### Patch Changes

--- a/packages/shared.net/package.json
+++ b/packages/shared.net/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/shared.net",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/shared.test/CHANGELOG.md
+++ b/packages/shared.test/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/shared.test
 
+## 1.6.3
+
+### Patch Changes
+
+- @osdk/api@1.9.3
+
 ## 1.6.2
 
 ### Patch Changes

--- a/packages/shared.test/package.json
+++ b/packages/shared.test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/shared.test",
   "private": true,
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "",
   "access": "private",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/1.3.x, this PR will be updated.


# Releases
## @osdk/api@1.9.3

### Patch Changes

-   Updated dependencies [d67e753]
    -   @osdk/shared.net@1.12.3

## @osdk/cli@0.23.6

### Patch Changes

-   Updated dependencies [507ae4a]
-   Updated dependencies [d67e753]
    -   @osdk/generator@1.13.6
    -   @osdk/shared.net@1.12.3
    -   @osdk/api@1.9.3

## @osdk/client@0.21.3

### Patch Changes

-   Updated dependencies [507ae4a]
    -   @osdk/generator-converters@0.7.3
    -   @osdk/api@1.9.3
    -   @osdk/client.api@0.21.3

## @osdk/client.api@0.21.3

### Patch Changes

-   @osdk/api@1.9.3

## @osdk/foundry@2.0.3

### Patch Changes

-   Updated dependencies [d67e753]
    -   @osdk/shared.net.platformapi@0.2.2
    -   @osdk/foundry.admin@2.0.3
    -   @osdk/foundry.core@2.0.3
    -   @osdk/foundry.datasets@2.0.3
    -   @osdk/foundry.thirdpartyapplications@2.0.3

## @osdk/foundry-sdk-generator@1.3.14

### Patch Changes

-   Updated dependencies [507ae4a]
-   Updated dependencies [d67e753]
    -   @osdk/generator@1.13.6
    -   @osdk/legacy-client@2.5.4
    -   @osdk/shared.net@1.12.3
    -   @osdk/client@0.21.3
    -   @osdk/api@1.9.3
    -   @osdk/client.api@0.21.3

## @osdk/foundry.admin@2.0.3

### Patch Changes

-   Updated dependencies [d67e753]
    -   @osdk/shared.net.platformapi@0.2.2
    -   @osdk/foundry.core@2.0.3

## @osdk/foundry.core@2.0.3

### Patch Changes

-   Updated dependencies [d67e753]
    -   @osdk/shared.net.platformapi@0.2.2

## @osdk/foundry.datasets@2.0.3

### Patch Changes

-   Updated dependencies [d67e753]
    -   @osdk/shared.net.platformapi@0.2.2
    -   @osdk/foundry.core@2.0.3

## @osdk/foundry.thirdpartyapplications@2.0.3

### Patch Changes

-   Updated dependencies [d67e753]
    -   @osdk/shared.net.platformapi@0.2.2
    -   @osdk/foundry.core@2.0.3

## @osdk/generator@1.13.6

### Patch Changes

-   507ae4a: Ignore unknown properties
-   Updated dependencies [507ae4a]
    -   @osdk/generator-converters@0.7.3
    -   @osdk/api@1.9.3

## @osdk/generator-converters@0.7.3

### Patch Changes

-   507ae4a: Ignore unknown properties
    -   @osdk/api@1.9.3

## @osdk/internal.foundry.core@0.1.3

### Patch Changes

-   Updated dependencies [d67e753]
    -   @osdk/shared.net.platformapi@0.2.2
    -   @osdk/shared.net@1.12.3
    -   @osdk/api@1.9.3

## @osdk/internal.foundry.datasets@0.1.3

### Patch Changes

-   Updated dependencies [d67e753]
    -   @osdk/shared.net.platformapi@0.2.2
    -   @osdk/shared.net@1.12.3
    -   @osdk/internal.foundry.core@0.1.3
    -   @osdk/api@1.9.3

## @osdk/internal.foundry.models@0.1.3

### Patch Changes

-   Updated dependencies [d67e753]
    -   @osdk/shared.net.platformapi@0.2.2
    -   @osdk/shared.net@1.12.3
    -   @osdk/internal.foundry.core@0.1.3
    -   @osdk/api@1.9.3

## @osdk/internal.foundry.ontologies@0.1.3

### Patch Changes

-   Updated dependencies [d67e753]
    -   @osdk/shared.net.platformapi@0.2.2
    -   @osdk/shared.net@1.12.3
    -   @osdk/internal.foundry.core@0.1.3
    -   @osdk/api@1.9.3

## @osdk/internal.foundry.ontologiesv2@0.1.3

### Patch Changes

-   Updated dependencies [d67e753]
    -   @osdk/shared.net.platformapi@0.2.2
    -   @osdk/shared.net@1.12.3
    -   @osdk/internal.foundry.core@0.1.3
    -   @osdk/internal.foundry.ontologies@0.1.3
    -   @osdk/api@1.9.3

## @osdk/legacy-client@2.5.4

### Patch Changes

-   d67e753: Fix fetch functions.
-   Updated dependencies [d67e753]
    -   @osdk/shared.net@1.12.3
    -   @osdk/api@1.9.3

## @osdk/maker@0.7.3

### Patch Changes

-   @osdk/api@1.9.3

## @osdk/shared.net@1.12.3

### Patch Changes

-   d67e753: Fix fetch functions.

## @osdk/shared.net.platformapi@0.2.2

### Patch Changes

-   d67e753: Fix fetch functions.

## @osdk/cli.cmd.typescript@0.5.6

### Patch Changes

-   Updated dependencies [507ae4a]
-   Updated dependencies [d67e753]
    -   @osdk/generator@1.13.6
    -   @osdk/shared.net@1.12.3

## @osdk/client.test.ontology@1.1.3

### Patch Changes

-   @osdk/api@1.9.3
-   @osdk/client.api@0.21.3

## @osdk/e2e.generated.1.1.x@0.2.6

### Patch Changes

-   Updated dependencies [507ae4a]
-   Updated dependencies [d67e753]
    -   @osdk/generator@1.13.6
    -   @osdk/legacy-client@2.5.4
    -   @osdk/api@1.9.3

## @osdk/e2e.generated.catchall@2.0.3

### Patch Changes

-   @osdk/client@0.21.3
-   @osdk/api@1.9.3
-   @osdk/client.api@0.21.3

## @osdk/e2e.sandbox.catchall@0.2.3

### Patch Changes

-   @osdk/client@0.21.3
-   @osdk/foundry@2.0.3
-   @osdk/internal.foundry@0.4.3
-   @osdk/api@1.9.3
-   @osdk/e2e.generated.catchall@2.0.3
-   @osdk/client.api@0.21.3

## @osdk/e2e.sandbox.oauth@0.2.3

### Patch Changes

-   @osdk/client@0.21.3

## @osdk/e2e.sandbox.todoapp@2.0.3

### Patch Changes

-   @osdk/client@0.21.3
-   @osdk/api@1.9.3
-   @osdk/client.api@0.21.3

## @osdk/internal.foundry@0.4.3

### Patch Changes

-   Updated dependencies [d67e753]
    -   @osdk/shared.net.platformapi@0.2.2
    -   @osdk/shared.net@1.12.3
    -   @osdk/internal.foundry.core@0.1.3
    -   @osdk/internal.foundry.datasets@0.1.3
    -   @osdk/internal.foundry.models@0.1.3
    -   @osdk/internal.foundry.ontologies@0.1.3
    -   @osdk/internal.foundry.ontologiesv2@0.1.3
    -   @osdk/api@1.9.3

## @osdk/shared.test@1.6.3

### Patch Changes

-   @osdk/api@1.9.3
