### PR TITLE
Accept default values for exact groupbys

### DIFF
--- a/.changeset/few-spies-reply.md
+++ b/.changeset/few-spies-reply.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client": patch
+"@osdk/api": patch
+---
+
+Adds default value option to group by

--- a/packages/api/src/groupby/GroupByClause.ts
+++ b/packages/api/src/groupby/GroupByClause.ts
@@ -26,7 +26,15 @@ export type GroupByClause<
   [P in AggregatableKeys<Q>]?: GroupByEntry<Q, P>;
 };
 
-type BaseGroupByValue = "exact" | { $exactWithLimit: number };
+type BaseGroupByValue =
+  | "exact"
+  | { $exactWithLimit: number }
+  | ExactGroupByWithOptions;
+
+type ExactGroupByWithOptions = {
+  $exact: { $limit?: number; $defaultValue: string };
+};
+
 export type GroupByRange<T> = [T, T];
 
 export type StringGroupByValue = BaseGroupByValue;

--- a/packages/api/src/groupby/GroupByClause.ts
+++ b/packages/api/src/groupby/GroupByClause.ts
@@ -32,7 +32,7 @@ type BaseGroupByValue =
   | ExactGroupByWithOptions;
 
 type ExactGroupByWithOptions = {
-  $exact: { $limit?: number; $defaultValue: string };
+  $exact: { $limit?: number; $defaultValue?: string };
 };
 
 export type GroupByRange<T> = [T, T];

--- a/packages/client/src/internal/conversions/modernToLegacyGroupByClause.ts
+++ b/packages/client/src/internal/conversions/modernToLegacyGroupByClause.ts
@@ -42,6 +42,15 @@ export function modernToLegacyGroupByClause(
           },
         ];
       }
+    } else if ("$exact" in type) {
+      return [
+        {
+          type: "exact",
+          field,
+          maxGroupCount: type.$exact?.$limit ?? undefined,
+          defaultValue: type.$exact.$defaultValue ?? undefined,
+        },
+      ];
     } else if ("$fixedWidth" in type) {
       return [{
         type: "fixedWidth",

--- a/packages/client/src/object/aggregate.test.ts
+++ b/packages/client/src/object/aggregate.test.ts
@@ -201,6 +201,7 @@ describe("aggregate", () => {
           dateTime: { $duration: [10, "seconds"] },
           date: { $ranges: [["2024-01-02", "2024-01-09"]] },
           boolean: "exact",
+          double: { "$exact": { $defaultValue: "default", $limit: 300 } },
         },
       },
     );
@@ -222,6 +223,7 @@ describe("aggregate", () => {
       grouped[0].$group.date,
     );
     expectType<boolean | undefined>(grouped[0].$group.boolean);
+    expectType<number | undefined>(grouped[0].$group.double);
 
     expectType<
       AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<
@@ -270,7 +272,7 @@ describe("aggregate", () => {
           $groupBy: {
             wrongKey: "don't work";
             text: "exact";
-            id: { $exactWithLimit: 10 };
+            id: { $exact: { $limit: 10; $defaultValue: "default" } };
             integer: { $ranges: [[1, 2]] };
             short: {
               $ranges: [[2, 3], [4, 5]];
@@ -290,7 +292,7 @@ describe("aggregate", () => {
         // @ts-expect-error
         wrongKey: "don't work",
         string: "exact",
-        id: { $exactWithLimit: 10 },
+        id: { $exact: { $limit: 10, $defaultValue: "default" } },
         integer: { $ranges: [[1, 2]] },
         short: {
           $ranges: [[2, 3], [4, 5]],

--- a/packages/e2e.sandbox.catchall/src/runAggregationsTest.ts
+++ b/packages/e2e.sandbox.catchall/src/runAggregationsTest.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { BoundariesUsState } from "@osdk/e2e.generated.catchall";
+import {
+  BoundariesUsState,
+  OsdkTestObject,
+} from "@osdk/e2e.generated.catchall";
 import { client } from "./client.js";
 
 export async function runAggregationsTest(): Promise<void> {
@@ -90,6 +93,15 @@ export async function runAggregationsTest(): Promise<void> {
       },
     });
 
+  const testExactMatchWithDefault = await client(OsdkTestObject).aggregate({
+    $select: {
+      $count: "unordered",
+    },
+    $groupBy: {
+      "description": { "$exact": { $defaultValue: "default", $limit: 300 } },
+    },
+  });
+
   console.log(
     testAggregateCountWithGroups[0].$group.usState,
     testAggregateCountWithGroups[0].$count,
@@ -109,6 +121,8 @@ export async function runAggregationsTest(): Promise<void> {
       `start:${group.$group.latitude.startValue},end:${group.$group.latitude.endValue}:${group.$count}`,
     );
   }
+
+  console.log(testExactMatchWithDefault);
 }
 
 void runAggregationsTest();


### PR DESCRIPTION
We will need to phase out $exactWithLimit. Is there a place we should mark this or are tracking things like this?