### PR TITLE
Update where clause error to say use and clause

### DIFF
--- a/.changeset/stale-forks-fry.md
+++ b/.changeset/stale-forks-fry.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Include a more descriptive error message for multiple filters on a single property filter clause

--- a/packages/client/src/internal/conversions/modernToLegacyWhereClause.ts
+++ b/packages/client/src/internal/conversions/modernToLegacyWhereClause.ts
@@ -176,7 +176,7 @@ function handleWherePair(
   invariant(
     !hasDollarSign
       || keysOfFilter.length === 1,
-    "A WhereClause Filter with multiple clauses/fields is not allowed. Instead, use an 'and' clause to combine multiple filters.",
+    "A WhereClause Filter with multiple clauses/fields is not allowed. Instead, use an 'or'/'and' clause to combine multiple filters.",
   );
 
   if (!hasDollarSign) {

--- a/packages/client/src/internal/conversions/modernToLegacyWhereClause.ts
+++ b/packages/client/src/internal/conversions/modernToLegacyWhereClause.ts
@@ -176,7 +176,7 @@ function handleWherePair(
   invariant(
     !hasDollarSign
       || keysOfFilter.length === 1,
-    "WhereClause Filter with multiple clauses isn't allowed",
+    "A WhereClause Filter with multiple clauses/fields is not allowed. Instead, use an 'and' clause to combine multiple filters.",
   );
 
   if (!hasDollarSign) {


### PR DESCRIPTION
This was done in order to fix #710. We also have added type guards for this now, so this would only be if someone was brute forcing this through