### PR TITLE
add object type reference support

### DIFF
--- a/.changeset/yellow-wasps-doubt.md
+++ b/.changeset/yellow-wasps-doubt.md
@@ -1,0 +1,5 @@
+---
+"@osdk/foundry-sdk-generator": patch
+---
+
+Fix resolution of new action parameter type.

--- a/packages/foundry-sdk-generator/src/ontologyMetadata/ontologyMetadataResolver.ts
+++ b/packages/foundry-sdk-generator/src/ontologyMetadata/ontologyMetadataResolver.ts
@@ -656,6 +656,7 @@ export class OntologyMetadataResolver {
       case "timestamp":
       case "struct":
       case "mediaReference":
+      case "objectType":
         return Result.ok({});
 
       default:


### PR DESCRIPTION
We had support in our generators, but the ontology metadata resolver was not updated, so upon load, we failed on this new action param type