### PR TITLE
Fix interface action type params

### DIFF
--- a/.changeset/wet-candles-sing.md
+++ b/.changeset/wet-candles-sing.md
@@ -1,0 +1,8 @@
+---
+"@osdk/shared.test": patch
+"@osdk/generator": patch
+"@osdk/client": patch
+"@osdk/api": patch
+---
+
+Fix interface action types.

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -115,7 +115,7 @@ export namespace ActionParam {
     export type InterfaceType<T extends InterfaceDefinition> = {
         		$objectType: NonNullable<T["__DefinitionMetadata"]> extends {
             			implementedBy: infer U
-            		} ? (U extends ReadonlyArray<string> ? U[number] : string) : string
+            		} ? (U extends ReadonlyArray<never> ? string : U extends ReadonlyArray<string> ? U[number] : string) : string
         		$primaryKey: string | number
         	};
     	// (undocumented)

--- a/packages/api/src/actions/Actions.ts
+++ b/packages/api/src/actions/Actions.ts
@@ -62,8 +62,9 @@ export namespace ActionParam {
    */
   export type InterfaceType<T extends InterfaceDefinition> = {
     $objectType: NonNullable<T["__DefinitionMetadata"]> extends
-      { implementedBy: infer U }
-      ? (U extends ReadonlyArray<string> ? U[number] : string)
+      { implementedBy: infer U } ? (U extends ReadonlyArray<never> ? string
+        : U extends ReadonlyArray<string> ? U[number]
+        : string)
       : string;
     $primaryKey: string | number;
   };

--- a/packages/client/src/actions/actions.test.ts
+++ b/packages/client/src/actions/actions.test.ts
@@ -28,6 +28,7 @@ import {
   createFooInterface,
   createOffice,
   createStructPerson,
+  deleteBarInterface,
   deleteFooInterface,
   moveOffice,
 } from "@osdk/client.test.ontology";
@@ -359,6 +360,40 @@ describe("actions", () => {
 
     expectTypeOf<typeof result>().toEqualTypeOf<undefined>();
     expect(result).toBeUndefined();
+  });
+  it("Accepts interfaces if implementing object types unknown", async () => {
+    const clientBoundTakesInterface = client(
+      deleteBarInterface,
+    ).applyAction;
+
+    type InferredParamType = Parameters<
+      typeof clientBoundTakesInterface
+    >[0];
+
+    expectTypeOf<
+      {
+        deletedInterface: {
+          $objectType: string;
+          $primaryKey: string | number;
+        };
+      }
+    >().toMatchTypeOf<
+      InferredParamType
+    >();
+
+    const clientBoundBatchActionTakesInterface = client(
+      deleteBarInterface,
+    ).batchApplyAction;
+    type InferredBatchParamType = Parameters<
+      typeof clientBoundBatchActionTakesInterface
+    >[0];
+
+    expectTypeOf<{
+      deletedInterface: {
+        $objectType: string;
+        $primaryKey: string | number;
+      };
+    }[]>().toMatchTypeOf<InferredBatchParamType>();
   });
   it("Accepts object type refs", async () => {
     const clientBoundTakesObjectType = client(

--- a/packages/client/src/actions/actions.test.ts
+++ b/packages/client/src/actions/actions.test.ts
@@ -616,6 +616,7 @@ describe("ActionResponse remapping", () => {
       "createOffice",
       "createOfficeAndEmployee",
       "createStructPerson",
+      "deleteBarInterface",
       "deleteFooInterface",
       "moveOffice",
       "promoteEmployee",

--- a/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.test.ts
+++ b/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.test.ts
@@ -43,6 +43,7 @@ function simpleInterface<T extends string, Q extends SharedPropertyType>(
   spts: Q[],
   parents: string[],
   metadataLevel: 0 | 1 | 2 = 2,
+  implementedByObjectTypes: string[] = [],
 ) {
   const properties = Object.fromEntries(spts.map(spt => [spt.apiName, spt]));
 
@@ -54,7 +55,7 @@ function simpleInterface<T extends string, Q extends SharedPropertyType>(
     extendsInterfaces: parents,
     links: {},
     properties,
-    implementedByObjectTypes: [],
+    implementedByObjectTypes,
     allExtendsInterfaces: parents,
     allLinks: {},
     allProperties: properties,
@@ -359,6 +360,99 @@ describe(__UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst, () => {
              *   description: bar property desc
              */
             bar: $PropertyDef<"integer", "nullable", "single">;
+            /**
+             *   display name: 'foo property dn',
+             *   description: foo property desc
+             */
+            foo: $PropertyDef<"integer", "nullable", "single">;
+          };
+          rid: "FooRid";
+          type: "interface";
+        };
+      }
+
+      export const Foo: Foo = {
+        type: "interface",
+        apiName: "Foo",
+        osdkMetadata: $osdkMetadata,
+      };
+      "
+    `);
+  });
+  it("Generates map for implementedBy", async () => {
+    const fooSpt = simpleSpt("foo");
+    const barSpt = simpleSpt("bar");
+
+    const ontology = enhanceOntology(
+      {
+        sanitized: simpleOntology("ontology", [
+          simpleInterface("Foo", [fooSpt], ["Parent"], 2, ["childrenObject"]),
+          simpleInterface("Parent", [barSpt], []),
+        ]),
+
+        importExt: "",
+      },
+    );
+
+    const formattedCode = await format(
+      __UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst(
+        ontology.interfaceTypes.Foo as EnhancedInterfaceType,
+        ontology,
+        true,
+        true,
+      ),
+      {
+        parser: "typescript",
+      },
+    );
+    expect(formattedCode).toMatchInlineSnapshot(`
+      "import type {
+        InterfaceDefinition as $InterfaceDefinition,
+        ObjectSet as $ObjectSet,
+        Osdk as $Osdk,
+        PropertyValueWireToClient as $PropType,
+      } from "@osdk/api";
+
+      export type OsdkObjectLinks$Foo = {};
+
+      export namespace Foo {
+        export type PropertyKeys = "foo";
+
+        export interface Props {
+          readonly foo: $PropType["integer"] | undefined;
+        }
+        export type StrictProps = Props;
+
+        export interface ObjectSet extends $ObjectSet<Foo, Foo.ObjectSet> {}
+
+        export type OsdkInstance<
+          OPTIONS extends never | "$rid" = never,
+          K extends keyof Foo.Props = keyof Foo.Props,
+        > = $Osdk.Instance<Foo, OPTIONS, K>;
+
+        /** @deprecated use OsdkInstance */
+        export type OsdkObject<
+          OPTIONS extends never | "$rid" = never,
+          K extends keyof Foo.Props = keyof Foo.Props,
+        > = OsdkInstance<OPTIONS, K>;
+      }
+
+      export interface Foo extends $InterfaceDefinition {
+        osdkMetadata: typeof $osdkMetadata;
+        type: "interface";
+        apiName: "Foo";
+        __DefinitionMetadata?: {
+          objectSet: Foo.ObjectSet;
+          props: Foo.Props;
+          linksType: OsdkObjectLinks$Foo;
+          strictProps: Foo.StrictProps;
+          apiName: "Foo";
+          description: "Foo interface desc";
+          displayName: "Foo interface dn";
+          implementedBy: ["childrenObject"];
+          implements: ["Parent"];
+          links: {};
+          properties: {
             /**
              *   display name: 'foo property dn',
              *   description: foo property desc

--- a/packages/shared.test/src/stubs/actionsTypes.ts
+++ b/packages/shared.test/src/stubs/actionsTypes.ts
@@ -15,7 +15,7 @@
  */
 
 import type { ActionTypeV2 } from "@osdk/foundry.ontologies";
-import { FooInterface } from "./interfaces.js";
+import { BarInterface, FooInterface } from "./interfaces.js";
 import { employeeObjectType, officeObjectType } from "./objectTypes.js";
 
 export const PromoteEmployee: ActionTypeV2 = {
@@ -321,6 +321,28 @@ export const ActionTakesInterface: ActionTypeV2 = {
   ],
 };
 
+export const ActionTakesAnotherInterface: ActionTypeV2 = {
+  apiName: "delete-bar-interface",
+  displayName: "Delete Bar Interface",
+  status: "EXPERIMENTAL",
+  parameters: {
+    deletedInterface: {
+      dataType: {
+        type: "interfaceObject",
+        interfaceTypeApiName: BarInterface.apiName,
+      },
+      required: true,
+    },
+  },
+  rid: "ri.actions.main.action-type.3828bab4-4ac7-4fdf-a780-6ccbc359d817",
+  operations: [
+    {
+      type: "deleteInterfaceObject",
+      interfaceTypeApiName: BarInterface.apiName,
+    },
+  ],
+};
+
 export const ActionCreatesInterface: ActionTypeV2 = {
   apiName: "create-foo-interface",
   displayName: "Create Foo Interface",
@@ -397,6 +419,7 @@ export const actionTypes: ActionTypeV2[] = [
   ActionTakesAttachment,
   ActionTakesMedia,
   ActionTakesInterface,
+  ActionTakesAnotherInterface,
   ActionTakesStruct,
   ActionCreatesInterface,
 ];


### PR DESCRIPTION
In the case where an interface type we accept in the action does not have any implementingObjectTypes in its map, we just default to accepting strings rather than being typed `never`