### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -154,15 +154,22 @@
     "@osdk-widget.client.unstable-simulatedRelease",
     "@osdk-widget.vite-plugin.unstable-simulatedRelease",
     "afraid-spies-build",
+    "breezy-adults-call",
+    "early-lions-cough",
     "few-spies-reply",
+    "four-ads-compare",
     "lucky-points-report",
     "nasty-hairs-travel",
     "proud-weeks-accept",
     "proud-yaks-judge",
     "quick-spiders-add",
     "quiet-dots-cheat",
+    "quiet-impalas-learn",
     "shiny-pumas-raise",
+    "stale-forks-fry",
     "thin-deers-punch",
-    "wicked-dingos-melt"
+    "wet-candles-sing",
+    "wicked-dingos-melt",
+    "yellow-wasps-doubt"
   ]
 }

--- a/benchmarks/tests/primary/CHANGELOG.md
+++ b/benchmarks/tests/primary/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/benchmarks.primary
 
+## 0.1.0-beta.20
+
+### Patch Changes
+
+- Updated dependencies [7416ce4]
+- Updated dependencies [7416ce4]
+- Updated dependencies [879b6c3]
+- Updated dependencies [805df40]
+  - @osdk/client@2.2.0-beta.7
+
 ## 0.1.0-beta.19
 
 ### Patch Changes

--- a/benchmarks/tests/primary/package.json
+++ b/benchmarks/tests/primary/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/benchmarks.primary",
   "private": true,
-  "version": "0.1.0-beta.19",
+  "version": "0.1.0-beta.20",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/api
 
+## 2.2.0-beta.7
+
+### Minor Changes
+
+- 7416ce4: Adds deleted objects and links returned from applyAction
+- 7416ce4: Update Platform SDK Dependencies
+- 805df40: Fix interface action types.
+
 ## 2.2.0-beta.6
 
 ### Minor Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/api",
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.7",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @osdk/cli.cmd.typescript
 
+## 0.26.0-beta.7
+
+### Minor Changes
+
+- 21e33a5: Upgrade consola to 3.4.0
+- 7416ce4: Update Platform SDK Dependencies
+
+### Patch Changes
+
+- Updated dependencies [21e33a5]
+- Updated dependencies [7416ce4]
+- Updated dependencies [805df40]
+  - @osdk/cli.common@0.26.0-beta.7
+  - @osdk/generator@2.2.0-beta.7
+
 ## 0.26.0-beta.6
 
 ### Minor Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.26.0-beta.6",
+  "version": "0.26.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli.common/CHANGELOG.md
+++ b/packages/cli.common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/cli.common
 
+## 0.26.0-beta.7
+
+### Minor Changes
+
+- 21e33a5: Upgrade consola to 3.4.0
+
 ## 0.26.0-beta.6
 
 ## 0.26.0-beta.5

--- a/packages/cli.common/package.json
+++ b/packages/cli.common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.common",
   "private": true,
-  "version": "0.26.0-beta.6",
+  "version": "0.26.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/cli
 
+## 0.26.0-beta.7
+
+### Minor Changes
+
+- 21e33a5: Upgrade consola to 3.4.0
+
 ## 0.26.0-beta.6
 
 ## 0.26.0-beta.5

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.26.0-beta.6",
+  "version": "0.26.0-beta.7",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client.test.ontology/CHANGELOG.md
+++ b/packages/client.test.ontology/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/client.test.ontology
 
+## 2.2.0-beta.7
+
+### Patch Changes
+
+- Updated dependencies [7416ce4]
+- Updated dependencies [7416ce4]
+- Updated dependencies [805df40]
+  - @osdk/api@2.2.0-beta.7
+
 ## 2.2.0-beta.6
 
 ### Patch Changes

--- a/packages/client.test.ontology/package.json
+++ b/packages/client.test.ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/client.test.ontology",
   "private": true,
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.unstable/CHANGELOG.md
+++ b/packages/client.unstable/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/client.unstable
 
+## 2.2.0-beta.7
+
 ## 2.2.0-beta.6
 
 ## 2.2.0-beta.5

--- a/packages/client.unstable/package.json
+++ b/packages/client.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.unstable",
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @osdk/client
 
+## 2.2.0-beta.7
+
+### Minor Changes
+
+- 7416ce4: Adds deleted objects and links returned from applyAction
+- 7416ce4: Update Platform SDK Dependencies
+- 879b6c3: Include a more descriptive error message for multiple filters on a single property filter clause
+- 805df40: Fix interface action types.
+
+### Patch Changes
+
+- Updated dependencies [7416ce4]
+- Updated dependencies [7416ce4]
+- Updated dependencies [805df40]
+  - @osdk/api@2.2.0-beta.7
+  - @osdk/generator-converters@2.2.0-beta.7
+  - @osdk/client.unstable@2.2.0-beta.7
+
 ## 2.2.0-beta.6
 
 ### Minor Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client",
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.7",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/create-app.template-packager/CHANGELOG.md
+++ b/packages/create-app.template-packager/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/create-app.template-packager
 
+## 2.2.0-beta.7
+
+### Minor Changes
+
+- 21e33a5: Upgrade consola to 3.4.0
+
 ## 2.2.0-beta.6
 
 ## 2.2.0-beta.5

--- a/packages/create-app.template-packager/package.json
+++ b/packages/create-app.template-packager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template-packager",
   "private": true,
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.expo.v2/CHANGELOG.md
+++ b/packages/create-app.template.expo.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.expo.v2
 
+## 2.2.0-beta.7
+
 ## 2.2.0-beta.6
 
 ## 2.2.0-beta.5

--- a/packages/create-app.template.expo.v2/package.json
+++ b/packages/create-app.template.expo.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.expo.v2",
   "private": true,
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.next-static-export.v2/CHANGELOG.md
+++ b/packages/create-app.template.next-static-export.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.next-static-export.v2
 
+## 2.2.0-beta.7
+
 ## 2.2.0-beta.6
 
 ## 2.2.0-beta.5

--- a/packages/create-app.template.next-static-export.v2/package.json
+++ b/packages/create-app.template.next-static-export.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.next-static-export.v2",
   "private": true,
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.next-static-export/CHANGELOG.md
+++ b/packages/create-app.template.next-static-export/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.next-static-export
 
+## 2.2.0-beta.7
+
 ## 2.2.0-beta.6
 
 ## 2.2.0-beta.5

--- a/packages/create-app.template.next-static-export/package.json
+++ b/packages/create-app.template.next-static-export/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.next-static-export",
   "private": true,
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react.beta/CHANGELOG.md
+++ b/packages/create-app.template.react.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.react
 
+## 2.2.0-beta.7
+
 ## 2.2.0-beta.6
 
 ## 2.2.0-beta.5

--- a/packages/create-app.template.react.beta/package.json
+++ b/packages/create-app.template.react.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react.beta",
   "private": true,
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react/CHANGELOG.md
+++ b/packages/create-app.template.react/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.react
 
+## 2.2.0-beta.7
+
 ## 2.2.0-beta.6
 
 ## 2.2.0-beta.5

--- a/packages/create-app.template.react/package.json
+++ b/packages/create-app.template.react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react",
   "private": true,
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-aip-app.beta
 
+## 2.2.0-beta.7
+
 ## 2.2.0-beta.6
 
 ## 2.2.0-beta.5

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app.beta",
   "private": true,
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-aip-app
 
+## 2.2.0-beta.7
+
 ## 2.2.0-beta.6
 
 ## 2.2.0-beta.5

--- a/packages/create-app.template.tutorial-todo-aip-app/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app",
   "private": true,
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-app.beta/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-app.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-app.beta
 
+## 2.2.0-beta.7
+
 ## 2.2.0-beta.6
 
 ## 2.2.0-beta.5

--- a/packages/create-app.template.tutorial-todo-app.beta/package.json
+++ b/packages/create-app.template.tutorial-todo-app.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app.beta",
   "private": true,
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-app
 
+## 2.2.0-beta.7
+
 ## 2.2.0-beta.6
 
 ## 2.2.0-beta.5

--- a/packages/create-app.template.tutorial-todo-app/package.json
+++ b/packages/create-app.template.tutorial-todo-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app",
   "private": true,
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.vue.v2/CHANGELOG.md
+++ b/packages/create-app.template.vue.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.vue.v2
 
+## 2.2.0-beta.7
+
 ## 2.2.0-beta.6
 
 ## 2.2.0-beta.5

--- a/packages/create-app.template.vue.v2/package.json
+++ b/packages/create-app.template.vue.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.vue.v2",
   "private": true,
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.vue/CHANGELOG.md
+++ b/packages/create-app.template.vue/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.vue
 
+## 2.2.0-beta.7
+
 ## 2.2.0-beta.6
 
 ## 2.2.0-beta.5

--- a/packages/create-app.template.vue/package.json
+++ b/packages/create-app.template.vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.vue",
   "private": true,
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/create-app
 
+## 2.2.0-beta.7
+
+### Minor Changes
+
+- 21e33a5: Upgrade consola to 3.4.0
+
 ## 2.2.0-beta.6
 
 ## 2.2.0-beta.5

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-app",
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.7",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/create-widget.template.minimal-react.v2/CHANGELOG.md
+++ b/packages/create-widget.template.minimal-react.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-widget.template.react.v2
 
+## 2.1.0-beta.3
+
 ## 2.1.0-beta.2
 
 ## 2.0.0-beta.16

--- a/packages/create-widget.template.minimal-react.v2/package.json
+++ b/packages/create-widget.template.minimal-react.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-widget.template.minimal-react.v2",
   "private": true,
-  "version": "2.1.0-beta.2",
+  "version": "2.1.0-beta.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-widget.template.react.v2/CHANGELOG.md
+++ b/packages/create-widget.template.react.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-widget.template.react.v2
 
+## 2.1.0-beta.3
+
 ## 2.1.0-beta.2
 
 ## 2.0.0-beta.16

--- a/packages/create-widget.template.react.v2/package.json
+++ b/packages/create-widget.template.react.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-widget.template.react.v2",
   "private": true,
-  "version": "2.1.0-beta.2",
+  "version": "2.1.0-beta.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-widget/CHANGELOG.md
+++ b/packages/create-widget/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/create-widget
 
+## 2.1.0-beta.3
+
+### Minor Changes
+
+- 21e33a5: Upgrade consola to 3.4.0
+
 ## 2.1.0-beta.2
 
 ## 2.0.0-beta.16

--- a/packages/create-widget/package.json
+++ b/packages/create-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-widget",
-  "version": "2.1.0-beta.2",
+  "version": "2.1.0-beta.3",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/example-generator/CHANGELOG.md
+++ b/packages/example-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/example-generator
 
+## 0.10.0-beta.7
+
+### Minor Changes
+
+- 21e33a5: Upgrade consola to 3.4.0
+
+### Patch Changes
+
+- Updated dependencies [21e33a5]
+  - @osdk/create-widget@2.1.0-beta.3
+  - @osdk/create-app@2.2.0-beta.7
+
 ## 0.10.0-beta.6
 
 ### Patch Changes

--- a/packages/example-generator/package.json
+++ b/packages/example-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/example-generator",
   "private": true,
-  "version": "0.10.0-beta.6",
+  "version": "0.10.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @osdk/foundry-sdk-generator
 
+## 2.2.0-beta.7
+
+### Minor Changes
+
+- 21e33a5: Upgrade consola to 3.4.0
+- 7416ce4: Update Platform SDK Dependencies
+- 5774599: Fix resolution of new action parameter type.
+
+### Patch Changes
+
+- Updated dependencies [7416ce4]
+- Updated dependencies [21e33a5]
+- Updated dependencies [7416ce4]
+- Updated dependencies [879b6c3]
+- Updated dependencies [805df40]
+  - @osdk/client@2.2.0-beta.7
+  - @osdk/api@2.2.0-beta.7
+  - @osdk/generator@2.2.0-beta.7
+
 ## 2.2.0-beta.6
 
 ### Patch Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.7",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-converters/CHANGELOG.md
+++ b/packages/generator-converters/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/generator-converters
 
+## 2.2.0-beta.7
+
+### Minor Changes
+
+- 7416ce4: Update Platform SDK Dependencies
+
+### Patch Changes
+
+- Updated dependencies [7416ce4]
+- Updated dependencies [7416ce4]
+- Updated dependencies [805df40]
+  - @osdk/api@2.2.0-beta.7
+
 ## 2.2.0-beta.6
 
 ### Minor Changes

--- a/packages/generator-converters/package.json
+++ b/packages/generator-converters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-converters",
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.7",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-utils/CHANGELOG.md
+++ b/packages/generator-utils/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/generator-utils
 
+## 2.2.0-beta.7
+
 ## 2.2.0-beta.6
 
 ## 2.2.0-beta.5

--- a/packages/generator-utils/package.json
+++ b/packages/generator-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-utils",
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @osdk/generator
 
+## 2.2.0-beta.7
+
+### Minor Changes
+
+- 21e33a5: Upgrade consola to 3.4.0
+- 7416ce4: Update Platform SDK Dependencies
+- 805df40: Fix interface action types.
+
+### Patch Changes
+
+- Updated dependencies [7416ce4]
+- Updated dependencies [7416ce4]
+- Updated dependencies [805df40]
+  - @osdk/api@2.2.0-beta.7
+  - @osdk/generator-converters@2.2.0-beta.7
+
 ## 2.2.0-beta.6
 
 ### Minor Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.7",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/maker/CHANGELOG.md
+++ b/packages/maker/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @osdk/maker
 
+## 0.10.0-beta.7
+
+### Minor Changes
+
+- 21e33a5: Upgrade consola to 3.4.0
+- 7416ce4: Update Platform SDK Dependencies
+
+### Patch Changes
+
+- Updated dependencies [7416ce4]
+- Updated dependencies [7416ce4]
+- Updated dependencies [805df40]
+  - @osdk/api@2.2.0-beta.7
+
 ## 0.10.0-beta.6
 
 ### Patch Changes

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker",
-  "version": "0.10.0-beta.6",
+  "version": "0.10.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.test/CHANGELOG.md
+++ b/packages/shared.test/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @osdk/shared.test
 
+## 2.2.0-beta.7
+
+### Minor Changes
+
+- 7416ce4: Update Platform SDK Dependencies
+- 805df40: Fix interface action types.
+
+### Patch Changes
+
+- Updated dependencies [7416ce4]
+- Updated dependencies [7416ce4]
+- Updated dependencies [805df40]
+  - @osdk/api@2.2.0-beta.7
+
 ## 2.2.0-beta.6
 
 ### Patch Changes

--- a/packages/shared.test/package.json
+++ b/packages/shared.test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/shared.test",
   "private": true,
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.7",
   "description": "",
   "access": "private",
   "license": "Apache-2.0",

--- a/packages/tool.generate-with-mock-ontology/CHANGELOG.md
+++ b/packages/tool.generate-with-mock-ontology/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/tool.generate-with-mock-ontology
 
+## 0.2.0-beta.7
+
+### Patch Changes
+
+- Updated dependencies [7416ce4]
+- Updated dependencies [7416ce4]
+- Updated dependencies [879b6c3]
+- Updated dependencies [805df40]
+  - @osdk/client@2.2.0-beta.7
+  - @osdk/api@2.2.0-beta.7
+
 ## 0.2.0-beta.6
 
 ### Patch Changes

--- a/packages/tool.generate-with-mock-ontology/package.json
+++ b/packages/tool.generate-with-mock-ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/tool.generate-with-mock-ontology",
   "private": true,
-  "version": "0.2.0-beta.6",
+  "version": "0.2.0-beta.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/tool.release/CHANGELOG.md
+++ b/packages/tool.release/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/tool.release
 
+## 0.7.0-beta.2
+
+### Minor Changes
+
+- 21e33a5: Upgrade consola to 3.4.0
+
 ## 0.6.0-beta.5
 
 ### Minor Changes

--- a/packages/tool.release/package.json
+++ b/packages/tool.release/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/tool.release",
   "private": true,
-  "version": "0.7.0-beta.1",
+  "version": "0.7.0-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/widget.api.unstable/CHANGELOG.md
+++ b/packages/widget.api.unstable/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/widget.api.unstable
 
+## 2.1.0-beta.3
+
 ## 2.1.0-beta.2
 
 ## 2.0.0-beta.16

--- a/packages/widget.api.unstable/package.json
+++ b/packages/widget.api.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget.api.unstable",
-  "version": "2.1.0-beta.2",
+  "version": "2.1.0-beta.3",
   "description": "API contract between Foundry UIs that can embed custom widgets and the custom widgets themselves",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/widget.client-react.unstable/CHANGELOG.md
+++ b/packages/widget.client-react.unstable/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/widget.client-react.unstable
 
+## 2.1.0-beta.3
+
+### Patch Changes
+
+- Updated dependencies [7416ce4]
+- Updated dependencies [7416ce4]
+- Updated dependencies [879b6c3]
+- Updated dependencies [805df40]
+  - @osdk/client@2.2.0-beta.7
+  - @osdk/widget.client.unstable@2.1.0-beta.3
+
 ## 2.1.0-beta.2
 
 ### Patch Changes

--- a/packages/widget.client-react.unstable/package.json
+++ b/packages/widget.client-react.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget.client-react.unstable",
-  "version": "2.1.0-beta.2",
+  "version": "2.1.0-beta.3",
   "description": "Wrapper around @osdk/widget.client",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/widget.client.unstable/CHANGELOG.md
+++ b/packages/widget.client.unstable/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/widget.client.unstable
 
+## 2.1.0-beta.3
+
+### Patch Changes
+
+- Updated dependencies [7416ce4]
+- Updated dependencies [7416ce4]
+- Updated dependencies [879b6c3]
+- Updated dependencies [805df40]
+  - @osdk/client@2.2.0-beta.7
+  - @osdk/widget.api.unstable@2.1.0-beta.3
+
 ## 2.1.0-beta.2
 
 ### Patch Changes

--- a/packages/widget.client.unstable/package.json
+++ b/packages/widget.client.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget.client.unstable",
-  "version": "2.1.0-beta.2",
+  "version": "2.1.0-beta.3",
   "description": "Client that sets up listeners for the custom widgets embedded into Foundry, adhering to the contract laid out in @osdk/widget.api",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/widget.vite-plugin.unstable/CHANGELOG.md
+++ b/packages/widget.vite-plugin.unstable/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/widget.vite-plugin.unstable
 
+## 2.1.0-beta.3
+
+### Patch Changes
+
+- @osdk/widget.api.unstable@2.1.0-beta.3
+
 ## 2.1.0-beta.2
 
 ### Minor Changes

--- a/packages/widget.vite-plugin.unstable/package.json
+++ b/packages/widget.vite-plugin.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget.vite-plugin.unstable",
-  "version": "2.1.0-beta.2",
+  "version": "2.1.0-beta.3",
   "description": "A vite plugin that will extract parameter definitions from TS/JS files + entrypoint info into a manifest file to be uploaded to Foundry ",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/api@2.2.0-beta.7

### Minor Changes

-   7416ce4: Adds deleted objects and links returned from applyAction
-   7416ce4: Update Platform SDK Dependencies
-   805df40: Fix interface action types.

## @osdk/cli@0.26.0-beta.7

### Minor Changes

-   21e33a5: Upgrade consola to 3.4.0

## @osdk/client@2.2.0-beta.7

### Minor Changes

-   7416ce4: Adds deleted objects and links returned from applyAction
-   7416ce4: Update Platform SDK Dependencies
-   879b6c3: Include a more descriptive error message for multiple filters on a single property filter clause
-   805df40: Fix interface action types.

### Patch Changes

-   Updated dependencies [7416ce4]
-   Updated dependencies [7416ce4]
-   Updated dependencies [805df40]
    -   @osdk/api@2.2.0-beta.7
    -   @osdk/generator-converters@2.2.0-beta.7
    -   @osdk/client.unstable@2.2.0-beta.7

## @osdk/create-app@2.2.0-beta.7

### Minor Changes

-   21e33a5: Upgrade consola to 3.4.0

## @osdk/create-widget@2.1.0-beta.3

### Minor Changes

-   21e33a5: Upgrade consola to 3.4.0

## @osdk/foundry-sdk-generator@2.2.0-beta.7

### Minor Changes

-   21e33a5: Upgrade consola to 3.4.0
-   7416ce4: Update Platform SDK Dependencies
-   5774599: Fix resolution of new action parameter type.

### Patch Changes

-   Updated dependencies [7416ce4]
-   Updated dependencies [21e33a5]
-   Updated dependencies [7416ce4]
-   Updated dependencies [879b6c3]
-   Updated dependencies [805df40]
    -   @osdk/client@2.2.0-beta.7
    -   @osdk/api@2.2.0-beta.7
    -   @osdk/generator@2.2.0-beta.7

## @osdk/generator@2.2.0-beta.7

### Minor Changes

-   21e33a5: Upgrade consola to 3.4.0
-   7416ce4: Update Platform SDK Dependencies
-   805df40: Fix interface action types.

### Patch Changes

-   Updated dependencies [7416ce4]
-   Updated dependencies [7416ce4]
-   Updated dependencies [805df40]
    -   @osdk/api@2.2.0-beta.7
    -   @osdk/generator-converters@2.2.0-beta.7

## @osdk/generator-converters@2.2.0-beta.7

### Minor Changes

-   7416ce4: Update Platform SDK Dependencies

### Patch Changes

-   Updated dependencies [7416ce4]
-   Updated dependencies [7416ce4]
-   Updated dependencies [805df40]
    -   @osdk/api@2.2.0-beta.7

## @osdk/maker@0.10.0-beta.7

### Minor Changes

-   21e33a5: Upgrade consola to 3.4.0
-   7416ce4: Update Platform SDK Dependencies

### Patch Changes

-   Updated dependencies [7416ce4]
-   Updated dependencies [7416ce4]
-   Updated dependencies [805df40]
    -   @osdk/api@2.2.0-beta.7

## @osdk/widget.client-react.unstable@2.1.0-beta.3

### Patch Changes

-   Updated dependencies [7416ce4]
-   Updated dependencies [7416ce4]
-   Updated dependencies [879b6c3]
-   Updated dependencies [805df40]
    -   @osdk/client@2.2.0-beta.7
    -   @osdk/widget.client.unstable@2.1.0-beta.3

## @osdk/widget.client.unstable@2.1.0-beta.3

### Patch Changes

-   Updated dependencies [7416ce4]
-   Updated dependencies [7416ce4]
-   Updated dependencies [879b6c3]
-   Updated dependencies [805df40]
    -   @osdk/client@2.2.0-beta.7
    -   @osdk/widget.api.unstable@2.1.0-beta.3

## @osdk/widget.vite-plugin.unstable@2.1.0-beta.3

### Patch Changes

-   @osdk/widget.api.unstable@2.1.0-beta.3

## @osdk/client.unstable@2.2.0-beta.7



## @osdk/generator-utils@2.2.0-beta.7



## @osdk/widget.api.unstable@2.1.0-beta.3



## @osdk/cli.cmd.typescript@0.26.0-beta.7

### Minor Changes

-   21e33a5: Upgrade consola to 3.4.0
-   7416ce4: Update Platform SDK Dependencies

### Patch Changes

-   Updated dependencies [21e33a5]
-   Updated dependencies [7416ce4]
-   Updated dependencies [805df40]
    -   @osdk/cli.common@0.26.0-beta.7
    -   @osdk/generator@2.2.0-beta.7

## @osdk/cli.common@0.26.0-beta.7

### Minor Changes

-   21e33a5: Upgrade consola to 3.4.0

## @osdk/create-app.template-packager@2.2.0-beta.7

### Minor Changes

-   21e33a5: Upgrade consola to 3.4.0

## @osdk/example-generator@0.10.0-beta.7

### Minor Changes

-   21e33a5: Upgrade consola to 3.4.0

### Patch Changes

-   Updated dependencies [21e33a5]
    -   @osdk/create-widget@2.1.0-beta.3
    -   @osdk/create-app@2.2.0-beta.7

## @osdk/shared.test@2.2.0-beta.7

### Minor Changes

-   7416ce4: Update Platform SDK Dependencies
-   805df40: Fix interface action types.

### Patch Changes

-   Updated dependencies [7416ce4]
-   Updated dependencies [7416ce4]
-   Updated dependencies [805df40]
    -   @osdk/api@2.2.0-beta.7

## @osdk/tool.release@0.7.0-beta.2

### Minor Changes

-   21e33a5: Upgrade consola to 3.4.0

## @osdk/benchmarks.primary@0.1.0-beta.20

### Patch Changes

-   Updated dependencies [7416ce4]
-   Updated dependencies [7416ce4]
-   Updated dependencies [879b6c3]
-   Updated dependencies [805df40]
    -   @osdk/client@2.2.0-beta.7

## @osdk/client.test.ontology@2.2.0-beta.7

### Patch Changes

-   Updated dependencies [7416ce4]
-   Updated dependencies [7416ce4]
-   Updated dependencies [805df40]
    -   @osdk/api@2.2.0-beta.7

## @osdk/tool.generate-with-mock-ontology@0.2.0-beta.7

### Patch Changes

-   Updated dependencies [7416ce4]
-   Updated dependencies [7416ce4]
-   Updated dependencies [879b6c3]
-   Updated dependencies [805df40]
    -   @osdk/client@2.2.0-beta.7
    -   @osdk/api@2.2.0-beta.7

## @osdk/create-app.template.expo.v2@2.2.0-beta.7



## @osdk/create-app.template.next-static-export@2.2.0-beta.7



## @osdk/create-app.template.next-static-export.v2@2.2.0-beta.7



## @osdk/create-app.template.react@2.2.0-beta.7



## @osdk/create-app.template.react.beta@2.2.0-beta.7



## @osdk/create-app.template.tutorial-todo-aip-app@2.2.0-beta.7



## @osdk/create-app.template.tutorial-todo-aip-app.beta@2.2.0-beta.7



## @osdk/create-app.template.tutorial-todo-app@2.2.0-beta.7



## @osdk/create-app.template.tutorial-todo-app.beta@2.2.0-beta.7



## @osdk/create-app.template.vue@2.2.0-beta.7



## @osdk/create-app.template.vue.v2@2.2.0-beta.7



## @osdk/create-widget.template.minimal-react.v2@2.1.0-beta.3



## @osdk/create-widget.template.react.v2@2.1.0-beta.3


