### PR TITLE
Include deep inspect information about unknown errors

### DIFF
--- a/.changeset/common-shrimps-look.md
+++ b/.changeset/common-shrimps-look.md
@@ -1,0 +1,7 @@
+---
+"@osdk/shared.net.errors": patch
+"@osdk/shared.net.fetch": patch
+"@osdk/cli": patch
+---
+
+Include deep inspect information about unknown errors

--- a/packages/shared.net.errors/src/UnknownError.ts
+++ b/packages/shared.net.errors/src/UnknownError.ts
@@ -18,8 +18,13 @@ import { PalantirApiError } from "./PalantirApiError.js";
 
 export class UnknownError extends PalantirApiError {
   originalError: Error | undefined;
-  constructor(message: string, statusCode?: number, originalError?: Error) {
-    super(message, undefined, undefined, statusCode);
+  constructor(
+    message: string,
+    errorName?: string,
+    originalError?: Error,
+    statusCode?: number,
+  ) {
+    super(message, errorName, undefined, statusCode);
     this.originalError = originalError;
   }
 }

--- a/packages/shared.net.errors/src/UnknownError.ts
+++ b/packages/shared.net.errors/src/UnknownError.ts
@@ -18,8 +18,8 @@ import { PalantirApiError } from "./PalantirApiError.js";
 
 export class UnknownError extends PalantirApiError {
   originalError: Error | undefined;
-  constructor(message: string, errorType: string, originalError?: Error) {
-    super(message, errorType);
+  constructor(message: string, statusCode?: number, originalError?: Error) {
+    super(message, undefined, undefined, statusCode);
     this.originalError = originalError;
   }
 }


### PR DESCRIPTION
- Don't try to parse response body as json when response is a HTML error page
- Throw UnknownError (subclass of PalantirApiError) instead of PalantirApiError when we don't actually have a JSON API error defined by https://www.palantir.com/docs/foundry/api/v2/general/overview/errors
- Include status code in UnknownError and remove "UNKNOWN" error name which is unhelpful and not real
- For unexpected UnknownError in `@osdk/cli`, include a deep inspect about the unknown error which will make sure to preserve any nested original errors for help debugging. This is more verbose but is only when we do not receive an actual JSON API error and instead in more rarer cases like fetch network failures or network ingress rules blocking the request

This should help cases where there's no original error being propagated through in the CLI:

```
[error] fetch failed

{
  "errorName": "UNKNOWN"
}
```

Before running npx (testing 403 with incorrect stack token filter):
```
ℹ Palantir OSDK CLI 0.25.0                                                                                  11:27:49 AM

◐ Fetching versions & deployed version                                                                       11:27:49 AM

 ERROR  Failed to fetch 403 Forbidden                                                                        11:27:49 AM

{
  "errorName": "UNKNOWN"
}

💡 Tip: Check your token has the required scopes for this operation                                          11:27:49 AM
```

After running locally (testing 403 with incorrect stack token filter):

```
ℹ Palantir OSDK CLI 0.26.0-beta.7                                                                           11:25:23 AM

◐ Fetching versions & deployed version                                                                       11:25:23 AM

 ERROR  Failed to fetch 403 Forbidden                                                                        11:25:23 AM

UnknownError: Failed to fetch 403 Forbidden
    at file:///Volumes/git/osdk-ts/packages/cli/build/esm/chunk-TNKJJ5U4.js:180:15
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Object.listVersions (file:///Volumes/git/osdk-ts/packages/cli/build/esm/chunk-FFGBT3SW.js:190:18)
    at async Promise.all (index 0)
    at async Module.versionListCommand (file:///Volumes/git/osdk-ts/packages/cli/build/esm/versionListCommand-GNNBU4AO.js:20:31)
    at async Object.handler (file:///Volumes/git/osdk-ts/packages/cli/build/esm/index.js:433:5) {
  errorName: undefined,
  errorCode: undefined,
  statusCode: 403,
  errorInstanceId: undefined,
  parameters: undefined,
  originalError: Error: Received HTML error page: <!DOCTYPE html><html lang="en">...some content here...</html>
      at file:///Volumes/git/osdk-ts/packages/cli/build/esm/chunk-TNKJJ5U4.js:180:66
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
      at async Object.listVersions (file:///Volumes/git/osdk-ts/packages/cli/build/esm/chunk-FFGBT3SW.js:190:18)
      at async Promise.all (index 0)
      at async Module.versionListCommand (file:///Volumes/git/osdk-ts/packages/cli/build/esm/versionListCommand-GNNBU4AO.js:20:31)
      at async Object.handler (file:///Volumes/git/osdk-ts/packages/cli/build/esm/index.js:433:5)
}

💡 Tip: Check your token has the required scopes for this operation                                          11:25:23 AM
```