### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -148,9 +148,15 @@
     "@osdk-widget.vite-plugin.unstable-simulatedRelease",
     "afraid-spies-build",
     "breezy-adults-call",
+    "chubby-impalas-walk",
+    "common-shrimps-look",
     "early-lions-cough",
+    "fancy-boats-kneel",
+    "few-hats-shout",
     "few-spies-reply",
     "four-ads-compare",
+    "free-spiders-itch",
+    "large-snails-yell",
     "lucky-points-report",
     "nasty-hairs-travel",
     "proud-weeks-accept",
@@ -160,9 +166,11 @@
     "quiet-impalas-learn",
     "shiny-pumas-raise",
     "stale-forks-fry",
+    "strong-bananas-lick",
     "thin-deers-punch",
     "wet-candles-sing",
     "wicked-dingos-melt",
+    "yellow-onions-boil",
     "yellow-wasps-doubt"
   ]
 }

--- a/benchmarks/tests/primary/CHANGELOG.md
+++ b/benchmarks/tests/primary/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/benchmarks.primary
 
+## 0.1.0-beta.21
+
+### Patch Changes
+
+- Updated dependencies [1ba3871]
+- Updated dependencies [63b2e63]
+- Updated dependencies [26c2d95]
+- Updated dependencies [63b2e63]
+- Updated dependencies [63b2e63]
+  - @osdk/client@2.2.0-beta.8
+
 ## 0.1.0-beta.20
 
 ### Patch Changes

--- a/benchmarks/tests/primary/package.json
+++ b/benchmarks/tests/primary/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/benchmarks.primary",
   "private": true,
-  "version": "0.1.0-beta.20",
+  "version": "0.1.0-beta.21",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/api
 
+## 2.2.0-beta.8
+
+### Minor Changes
+
+- 0e874b1: Exporting more entities from functions package.
+- 63b2e63: Update Platform SDK Dependencies
+- 26c2d95: Add experimental function to load page of objects by rid.
+- 63b2e63: Supports generating queries for entrySet function types
+- 63b2e63: Adds ObjectSpecifiers to generated OSDK objects
+
 ## 2.2.0-beta.7
 
 ### Minor Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/api",
-  "version": "2.2.0-beta.7",
+  "version": "2.2.0-beta.8",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @osdk/cli.cmd.typescript
 
+## 0.26.0-beta.8
+
+### Minor Changes
+
+- 63b2e63: Update Platform SDK Dependencies
+
+### Patch Changes
+
+- Updated dependencies [63b2e63]
+- Updated dependencies [63b2e63]
+  - @osdk/generator@2.2.0-beta.8
+  - @osdk/shared.client.impl@1.2.0-beta.2
+  - @osdk/cli.common@0.26.0-beta.8
+
 ## 0.26.0-beta.7
 
 ### Minor Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.26.0-beta.7",
+  "version": "0.26.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli.common/CHANGELOG.md
+++ b/packages/cli.common/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/cli.common
 
+## 0.26.0-beta.8
+
 ## 0.26.0-beta.7
 
 ### Minor Changes

--- a/packages/cli.common/package.json
+++ b/packages/cli.common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.common",
   "private": true,
-  "version": "0.26.0-beta.7",
+  "version": "0.26.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/cli
 
+## 0.26.0-beta.8
+
+### Minor Changes
+
+- ad93d55: Include deep inspect information about unknown errors
+
 ## 0.26.0-beta.7
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.26.0-beta.7",
+  "version": "0.26.0-beta.8",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client.test.ontology/CHANGELOG.md
+++ b/packages/client.test.ontology/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/client.test.ontology
 
+## 2.2.0-beta.8
+
+### Patch Changes
+
+- Updated dependencies [0e874b1]
+- Updated dependencies [63b2e63]
+- Updated dependencies [26c2d95]
+- Updated dependencies [63b2e63]
+- Updated dependencies [63b2e63]
+  - @osdk/api@2.2.0-beta.8
+
 ## 2.2.0-beta.7
 
 ### Patch Changes

--- a/packages/client.test.ontology/package.json
+++ b/packages/client.test.ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/client.test.ontology",
   "private": true,
-  "version": "2.2.0-beta.7",
+  "version": "2.2.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.unstable/CHANGELOG.md
+++ b/packages/client.unstable/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/client.unstable
 
+## 2.2.0-beta.8
+
 ## 2.2.0-beta.7
 
 ## 2.2.0-beta.6

--- a/packages/client.unstable/package.json
+++ b/packages/client.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.unstable",
-  "version": "2.2.0-beta.7",
+  "version": "2.2.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,30 @@
 # @osdk/client
 
+## 2.2.0-beta.8
+
+### Minor Changes
+
+- 1ba3871: Support $clone for interface objects
+- 63b2e63: Update Platform SDK Dependencies
+- 26c2d95: Add experimental function to load page of objects by rid.
+- 63b2e63: Supports generating queries for entrySet function types
+- 63b2e63: Adds ObjectSpecifiers to generated OSDK objects
+
+### Patch Changes
+
+- Updated dependencies [ad93d55]
+- Updated dependencies [0e874b1]
+- Updated dependencies [63b2e63]
+- Updated dependencies [26c2d95]
+- Updated dependencies [63b2e63]
+- Updated dependencies [63b2e63]
+  - @osdk/shared.net.errors@2.2.0-beta.2
+  - @osdk/shared.net.fetch@1.2.0-beta.2
+  - @osdk/api@2.2.0-beta.8
+  - @osdk/generator-converters@2.2.0-beta.8
+  - @osdk/shared.client.impl@1.2.0-beta.2
+  - @osdk/client.unstable@2.2.0-beta.8
+
 ## 2.2.0-beta.7
 
 ### Minor Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client",
-  "version": "2.2.0-beta.7",
+  "version": "2.2.0-beta.8",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/create-app.template-packager/CHANGELOG.md
+++ b/packages/create-app.template-packager/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template-packager
 
+## 2.2.0-beta.8
+
 ## 2.2.0-beta.7
 
 ### Minor Changes

--- a/packages/create-app.template-packager/package.json
+++ b/packages/create-app.template-packager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template-packager",
   "private": true,
-  "version": "2.2.0-beta.7",
+  "version": "2.2.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.expo.v2/CHANGELOG.md
+++ b/packages/create-app.template.expo.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.expo.v2
 
+## 2.2.0-beta.8
+
 ## 2.2.0-beta.7
 
 ## 2.2.0-beta.6

--- a/packages/create-app.template.expo.v2/package.json
+++ b/packages/create-app.template.expo.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.expo.v2",
   "private": true,
-  "version": "2.2.0-beta.7",
+  "version": "2.2.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react.beta/CHANGELOG.md
+++ b/packages/create-app.template.react.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.react
 
+## 2.2.0-beta.8
+
 ## 2.2.0-beta.7
 
 ## 2.2.0-beta.6

--- a/packages/create-app.template.react.beta/package.json
+++ b/packages/create-app.template.react.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react.beta",
   "private": true,
-  "version": "2.2.0-beta.7",
+  "version": "2.2.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react/CHANGELOG.md
+++ b/packages/create-app.template.react/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.react
 
+## 2.2.0-beta.8
+
 ## 2.2.0-beta.7
 
 ## 2.2.0-beta.6

--- a/packages/create-app.template.react/package.json
+++ b/packages/create-app.template.react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react",
   "private": true,
-  "version": "2.2.0-beta.7",
+  "version": "2.2.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-aip-app.beta
 
+## 2.2.0-beta.8
+
 ## 2.2.0-beta.7
 
 ## 2.2.0-beta.6

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app.beta",
   "private": true,
-  "version": "2.2.0-beta.7",
+  "version": "2.2.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-aip-app
 
+## 2.2.0-beta.8
+
 ## 2.2.0-beta.7
 
 ## 2.2.0-beta.6

--- a/packages/create-app.template.tutorial-todo-aip-app/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app",
   "private": true,
-  "version": "2.2.0-beta.7",
+  "version": "2.2.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-app.beta/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-app.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-app.beta
 
+## 2.2.0-beta.8
+
 ## 2.2.0-beta.7
 
 ## 2.2.0-beta.6

--- a/packages/create-app.template.tutorial-todo-app.beta/package.json
+++ b/packages/create-app.template.tutorial-todo-app.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app.beta",
   "private": true,
-  "version": "2.2.0-beta.7",
+  "version": "2.2.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-app
 
+## 2.2.0-beta.8
+
 ## 2.2.0-beta.7
 
 ## 2.2.0-beta.6

--- a/packages/create-app.template.tutorial-todo-app/package.json
+++ b/packages/create-app.template.tutorial-todo-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app",
   "private": true,
-  "version": "2.2.0-beta.7",
+  "version": "2.2.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.vue.v2/CHANGELOG.md
+++ b/packages/create-app.template.vue.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.vue.v2
 
+## 2.2.0-beta.8
+
 ## 2.2.0-beta.7
 
 ## 2.2.0-beta.6

--- a/packages/create-app.template.vue.v2/package.json
+++ b/packages/create-app.template.vue.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.vue.v2",
   "private": true,
-  "version": "2.2.0-beta.7",
+  "version": "2.2.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.vue/CHANGELOG.md
+++ b/packages/create-app.template.vue/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.vue
 
+## 2.2.0-beta.8
+
 ## 2.2.0-beta.7
 
 ## 2.2.0-beta.6

--- a/packages/create-app.template.vue/package.json
+++ b/packages/create-app.template.vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.vue",
   "private": true,
-  "version": "2.2.0-beta.7",
+  "version": "2.2.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/create-app
 
+## 2.2.0-beta.8
+
+### Minor Changes
+
+- 770ec64: Drop Next.js templates
+
 ## 2.2.0-beta.7
 
 ### Minor Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-app",
-  "version": "2.2.0-beta.7",
+  "version": "2.2.0-beta.8",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/example-generator/CHANGELOG.md
+++ b/packages/example-generator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/example-generator
 
+## 0.10.0-beta.8
+
+### Patch Changes
+
+- Updated dependencies [770ec64]
+  - @osdk/create-app@2.2.0-beta.8
+  - @osdk/create-widget@2.1.0-beta.3
+
 ## 0.10.0-beta.7
 
 ### Minor Changes

--- a/packages/example-generator/package.json
+++ b/packages/example-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/example-generator",
   "private": true,
-  "version": "0.10.0-beta.7",
+  "version": "0.10.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @osdk/foundry-sdk-generator
 
+## 2.2.0-beta.8
+
+### Minor Changes
+
+- 63b2e63: Update Platform SDK Dependencies
+
+### Patch Changes
+
+- Updated dependencies [1ba3871]
+- Updated dependencies [0e874b1]
+- Updated dependencies [63b2e63]
+- Updated dependencies [26c2d95]
+- Updated dependencies [63b2e63]
+- Updated dependencies [63b2e63]
+  - @osdk/client@2.2.0-beta.8
+  - @osdk/api@2.2.0-beta.8
+  - @osdk/generator@2.2.0-beta.8
+  - @osdk/shared.client.impl@1.2.0-beta.2
+
 ## 2.2.0-beta.7
 
 ### Minor Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "2.2.0-beta.7",
+  "version": "2.2.0-beta.8",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/functions/CHANGELOG.md
+++ b/packages/functions/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @osdk/functions.unstable
 
+## 0.1.0-beta.1
+
+### Minor Changes
+
+- 0e874b1: Exporting more entities from functions package.
+
+### Patch Changes
+
+- Updated dependencies [0e874b1]
+- Updated dependencies [63b2e63]
+- Updated dependencies [26c2d95]
+- Updated dependencies [63b2e63]
+- Updated dependencies [63b2e63]
+  - @osdk/api@2.2.0-beta.8
+
 ## 0.1.0-beta.0
 
 ### Minor Changes

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/functions.unstable",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-converters/CHANGELOG.md
+++ b/packages/generator-converters/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @osdk/generator-converters
 
+## 2.2.0-beta.8
+
+### Minor Changes
+
+- 63b2e63: Update Platform SDK Dependencies
+- 63b2e63: Supports generating queries for entrySet function types
+
+### Patch Changes
+
+- Updated dependencies [0e874b1]
+- Updated dependencies [63b2e63]
+- Updated dependencies [26c2d95]
+- Updated dependencies [63b2e63]
+- Updated dependencies [63b2e63]
+  - @osdk/api@2.2.0-beta.8
+
 ## 2.2.0-beta.7
 
 ### Minor Changes

--- a/packages/generator-converters/package.json
+++ b/packages/generator-converters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-converters",
-  "version": "2.2.0-beta.7",
+  "version": "2.2.0-beta.8",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-utils/CHANGELOG.md
+++ b/packages/generator-utils/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/generator-utils
 
+## 2.2.0-beta.8
+
 ## 2.2.0-beta.7
 
 ## 2.2.0-beta.6

--- a/packages/generator-utils/package.json
+++ b/packages/generator-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-utils",
-  "version": "2.2.0-beta.7",
+  "version": "2.2.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @osdk/generator
 
+## 2.2.0-beta.8
+
+### Minor Changes
+
+- 63b2e63: Update Platform SDK Dependencies
+- 63b2e63: Supports generating queries for entrySet function types
+
+### Patch Changes
+
+- Updated dependencies [0e874b1]
+- Updated dependencies [63b2e63]
+- Updated dependencies [26c2d95]
+- Updated dependencies [63b2e63]
+- Updated dependencies [63b2e63]
+  - @osdk/api@2.2.0-beta.8
+  - @osdk/generator-converters@2.2.0-beta.8
+
 ## 2.2.0-beta.7
 
 ### Minor Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "2.2.0-beta.7",
+  "version": "2.2.0-beta.8",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/maker/CHANGELOG.md
+++ b/packages/maker/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @osdk/maker
 
+## 0.10.0-beta.8
+
+### Minor Changes
+
+- 63b2e63: Update Platform SDK Dependencies
+
+### Patch Changes
+
+- Updated dependencies [0e874b1]
+- Updated dependencies [63b2e63]
+- Updated dependencies [26c2d95]
+- Updated dependencies [63b2e63]
+- Updated dependencies [63b2e63]
+  - @osdk/api@2.2.0-beta.8
+
 ## 0.10.0-beta.7
 
 ### Minor Changes

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker",
-  "version": "0.10.0-beta.7",
+  "version": "0.10.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.client.impl/CHANGELOG.md
+++ b/packages/shared.client.impl/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/shared.client.impl
 
+## 1.2.0-beta.2
+
+### Patch Changes
+
+- Updated dependencies [ad93d55]
+  - @osdk/shared.net.errors@2.2.0-beta.2
+  - @osdk/shared.net.fetch@1.2.0-beta.2
+
 ## 1.1.0-beta.5
 
 ### Minor Changes

--- a/packages/shared.client.impl/package.json
+++ b/packages/shared.client.impl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/shared.client.impl",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.net.errors/CHANGELOG.md
+++ b/packages/shared.net.errors/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/shared.net.errors
 
+## 2.2.0-beta.2
+
+### Minor Changes
+
+- ad93d55: Include deep inspect information about unknown errors
+
 ## 2.1.0-beta.2
 
 ### Minor Changes

--- a/packages/shared.net.errors/package.json
+++ b/packages/shared.net.errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/shared.net.errors",
-  "version": "2.2.0-beta.1",
+  "version": "2.2.0-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.net.fetch/CHANGELOG.md
+++ b/packages/shared.net.fetch/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/shared.net.fetch
 
+## 1.2.0-beta.2
+
+### Minor Changes
+
+- ad93d55: Include deep inspect information about unknown errors
+
+### Patch Changes
+
+- Updated dependencies [ad93d55]
+  - @osdk/shared.net.errors@2.2.0-beta.2
+
 ## 1.1.0-beta.3
 
 ### Minor Changes

--- a/packages/shared.net.fetch/package.json
+++ b/packages/shared.net.fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/shared.net.fetch",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.net/CHANGELOG.md
+++ b/packages/shared.net/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/shared.net
 
+## 2.2.0-beta.2
+
+### Patch Changes
+
+- Updated dependencies [ad93d55]
+  - @osdk/shared.net.errors@2.2.0-beta.2
+  - @osdk/shared.net.fetch@1.2.0-beta.2
+  - @osdk/shared.client.impl@1.2.0-beta.2
+
 ## 2.1.0-beta.5
 
 ### Minor Changes

--- a/packages/shared.net/package.json
+++ b/packages/shared.net/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/shared.net",
-  "version": "2.2.0-beta.1",
+  "version": "2.2.0-beta.2",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/shared.test/CHANGELOG.md
+++ b/packages/shared.test/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @osdk/shared.test
 
+## 2.2.0-beta.8
+
+### Minor Changes
+
+- 63b2e63: Update Platform SDK Dependencies
+- 26c2d95: Add experimental function to load page of objects by rid.
+- 63b2e63: Supports generating queries for entrySet function types
+
+### Patch Changes
+
+- Updated dependencies [0e874b1]
+- Updated dependencies [63b2e63]
+- Updated dependencies [26c2d95]
+- Updated dependencies [63b2e63]
+- Updated dependencies [63b2e63]
+  - @osdk/api@2.2.0-beta.8
+
 ## 2.2.0-beta.7
 
 ### Minor Changes

--- a/packages/shared.test/package.json
+++ b/packages/shared.test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/shared.test",
   "private": true,
-  "version": "2.2.0-beta.7",
+  "version": "2.2.0-beta.8",
   "description": "",
   "access": "private",
   "license": "Apache-2.0",

--- a/packages/tool.generate-with-mock-ontology/CHANGELOG.md
+++ b/packages/tool.generate-with-mock-ontology/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/tool.generate-with-mock-ontology
 
+## 0.2.0-beta.8
+
+### Patch Changes
+
+- Updated dependencies [1ba3871]
+- Updated dependencies [0e874b1]
+- Updated dependencies [63b2e63]
+- Updated dependencies [26c2d95]
+- Updated dependencies [63b2e63]
+- Updated dependencies [63b2e63]
+  - @osdk/client@2.2.0-beta.8
+  - @osdk/api@2.2.0-beta.8
+
 ## 0.2.0-beta.7
 
 ### Patch Changes

--- a/packages/tool.generate-with-mock-ontology/package.json
+++ b/packages/tool.generate-with-mock-ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/tool.generate-with-mock-ontology",
   "private": true,
-  "version": "0.2.0-beta.7",
+  "version": "0.2.0-beta.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/api@2.2.0-beta.8

### Minor Changes

-   0e874b1: Exporting more entities from functions package.
-   63b2e63: Update Platform SDK Dependencies
-   26c2d95: Add experimental function to load page of objects by rid.
-   63b2e63: Supports generating queries for entrySet function types
-   63b2e63: Adds ObjectSpecifiers to generated OSDK objects

## @osdk/cli@0.26.0-beta.8

### Minor Changes

-   ad93d55: Include deep inspect information about unknown errors

## @osdk/client@2.2.0-beta.8

### Minor Changes

-   1ba3871: Support $clone for interface objects
-   63b2e63: Update Platform SDK Dependencies
-   26c2d95: Add experimental function to load page of objects by rid.
-   63b2e63: Supports generating queries for entrySet function types
-   63b2e63: Adds ObjectSpecifiers to generated OSDK objects

### Patch Changes

-   Updated dependencies [ad93d55]
-   Updated dependencies [0e874b1]
-   Updated dependencies [63b2e63]
-   Updated dependencies [26c2d95]
-   Updated dependencies [63b2e63]
-   Updated dependencies [63b2e63]
    -   @osdk/shared.net.errors@2.2.0-beta.2
    -   @osdk/shared.net.fetch@1.2.0-beta.2
    -   @osdk/api@2.2.0-beta.8
    -   @osdk/generator-converters@2.2.0-beta.8
    -   @osdk/shared.client.impl@1.2.0-beta.2
    -   @osdk/client.unstable@2.2.0-beta.8

## @osdk/create-app@2.2.0-beta.8

### Minor Changes

-   770ec64: Drop Next.js templates

## @osdk/foundry-sdk-generator@2.2.0-beta.8

### Minor Changes

-   63b2e63: Update Platform SDK Dependencies

### Patch Changes

-   Updated dependencies [1ba3871]
-   Updated dependencies [0e874b1]
-   Updated dependencies [63b2e63]
-   Updated dependencies [26c2d95]
-   Updated dependencies [63b2e63]
-   Updated dependencies [63b2e63]
    -   @osdk/client@2.2.0-beta.8
    -   @osdk/api@2.2.0-beta.8
    -   @osdk/generator@2.2.0-beta.8
    -   @osdk/shared.client.impl@1.2.0-beta.2

## @osdk/functions.unstable@0.1.0-beta.1

### Minor Changes

-   0e874b1: Exporting more entities from functions package.

### Patch Changes

-   Updated dependencies [0e874b1]
-   Updated dependencies [63b2e63]
-   Updated dependencies [26c2d95]
-   Updated dependencies [63b2e63]
-   Updated dependencies [63b2e63]
    -   @osdk/api@2.2.0-beta.8

## @osdk/generator@2.2.0-beta.8

### Minor Changes

-   63b2e63: Update Platform SDK Dependencies
-   63b2e63: Supports generating queries for entrySet function types

### Patch Changes

-   Updated dependencies [0e874b1]
-   Updated dependencies [63b2e63]
-   Updated dependencies [26c2d95]
-   Updated dependencies [63b2e63]
-   Updated dependencies [63b2e63]
    -   @osdk/api@2.2.0-beta.8
    -   @osdk/generator-converters@2.2.0-beta.8

## @osdk/generator-converters@2.2.0-beta.8

### Minor Changes

-   63b2e63: Update Platform SDK Dependencies
-   63b2e63: Supports generating queries for entrySet function types

### Patch Changes

-   Updated dependencies [0e874b1]
-   Updated dependencies [63b2e63]
-   Updated dependencies [26c2d95]
-   Updated dependencies [63b2e63]
-   Updated dependencies [63b2e63]
    -   @osdk/api@2.2.0-beta.8

## @osdk/maker@0.10.0-beta.8

### Minor Changes

-   63b2e63: Update Platform SDK Dependencies

### Patch Changes

-   Updated dependencies [0e874b1]
-   Updated dependencies [63b2e63]
-   Updated dependencies [26c2d95]
-   Updated dependencies [63b2e63]
-   Updated dependencies [63b2e63]
    -   @osdk/api@2.2.0-beta.8

## @osdk/shared.net.errors@2.2.0-beta.2

### Minor Changes

-   ad93d55: Include deep inspect information about unknown errors

## @osdk/shared.net.fetch@1.2.0-beta.2

### Minor Changes

-   ad93d55: Include deep inspect information about unknown errors

### Patch Changes

-   Updated dependencies [ad93d55]
    -   @osdk/shared.net.errors@2.2.0-beta.2

## @osdk/shared.client.impl@1.2.0-beta.2

### Patch Changes

-   Updated dependencies [ad93d55]
    -   @osdk/shared.net.errors@2.2.0-beta.2
    -   @osdk/shared.net.fetch@1.2.0-beta.2

## @osdk/shared.net@2.2.0-beta.2

### Patch Changes

-   Updated dependencies [ad93d55]
    -   @osdk/shared.net.errors@2.2.0-beta.2
    -   @osdk/shared.net.fetch@1.2.0-beta.2
    -   @osdk/shared.client.impl@1.2.0-beta.2

## @osdk/client.unstable@2.2.0-beta.8



## @osdk/generator-utils@2.2.0-beta.8



## @osdk/cli.cmd.typescript@0.26.0-beta.8

### Minor Changes

-   63b2e63: Update Platform SDK Dependencies

### Patch Changes

-   Updated dependencies [63b2e63]
-   Updated dependencies [63b2e63]
    -   @osdk/generator@2.2.0-beta.8
    -   @osdk/shared.client.impl@1.2.0-beta.2
    -   @osdk/cli.common@0.26.0-beta.8

## @osdk/shared.test@2.2.0-beta.8

### Minor Changes

-   63b2e63: Update Platform SDK Dependencies
-   26c2d95: Add experimental function to load page of objects by rid.
-   63b2e63: Supports generating queries for entrySet function types

### Patch Changes

-   Updated dependencies [0e874b1]
-   Updated dependencies [63b2e63]
-   Updated dependencies [26c2d95]
-   Updated dependencies [63b2e63]
-   Updated dependencies [63b2e63]
    -   @osdk/api@2.2.0-beta.8

## @osdk/benchmarks.primary@0.1.0-beta.21

### Patch Changes

-   Updated dependencies [1ba3871]
-   Updated dependencies [63b2e63]
-   Updated dependencies [26c2d95]
-   Updated dependencies [63b2e63]
-   Updated dependencies [63b2e63]
    -   @osdk/client@2.2.0-beta.8

## @osdk/client.test.ontology@2.2.0-beta.8

### Patch Changes

-   Updated dependencies [0e874b1]
-   Updated dependencies [63b2e63]
-   Updated dependencies [26c2d95]
-   Updated dependencies [63b2e63]
-   Updated dependencies [63b2e63]
    -   @osdk/api@2.2.0-beta.8

## @osdk/example-generator@0.10.0-beta.8

### Patch Changes

-   Updated dependencies [770ec64]
    -   @osdk/create-app@2.2.0-beta.8
    -   @osdk/create-widget@2.1.0-beta.3

## @osdk/tool.generate-with-mock-ontology@0.2.0-beta.8

### Patch Changes

-   Updated dependencies [1ba3871]
-   Updated dependencies [0e874b1]
-   Updated dependencies [63b2e63]
-   Updated dependencies [26c2d95]
-   Updated dependencies [63b2e63]
-   Updated dependencies [63b2e63]
    -   @osdk/client@2.2.0-beta.8
    -   @osdk/api@2.2.0-beta.8

## @osdk/cli.common@0.26.0-beta.8



## @osdk/create-app.template-packager@2.2.0-beta.8



## @osdk/create-app.template.expo.v2@2.2.0-beta.8



## @osdk/create-app.template.react@2.2.0-beta.8



## @osdk/create-app.template.react.beta@2.2.0-beta.8



## @osdk/create-app.template.tutorial-todo-aip-app@2.2.0-beta.8



## @osdk/create-app.template.tutorial-todo-aip-app.beta@2.2.0-beta.8



## @osdk/create-app.template.tutorial-todo-app@2.2.0-beta.8



## @osdk/create-app.template.tutorial-todo-app.beta@2.2.0-beta.8



## @osdk/create-app.template.vue@2.2.0-beta.8



## @osdk/create-app.template.vue.v2@2.2.0-beta.8


