### PR TITLE
Version Packages

### DIFF
--- a/.changeset/bright-pumpkins-fry.md
+++ b/.changeset/bright-pumpkins-fry.md
@@ -1,5 +1,0 @@
----
-"@osdk/api": patch
----
-
-Fixes unneeded union in ValidAggregationKeys generic

--- a/.changeset/thirty-meals-design.md
+++ b/.changeset/thirty-meals-design.md
@@ -1,5 +1,0 @@
----
-"@osdk/functions.unstable": patch
----
-
-Released with support for ontology edits

--- a/benchmarks/tests/primary/CHANGELOG.md
+++ b/benchmarks/tests/primary/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/benchmarks.primary
 
+## 0.1.1
+
+### Patch Changes
+
+- @osdk/client@2.1.1
+
 ## 0.1.0
 
 ### Patch Changes

--- a/benchmarks/tests/primary/package.json
+++ b/benchmarks/tests/primary/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/benchmarks.primary",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.1.0';
+export type $ExpectedClientVersion = '2.1.1';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/api
 
+## 2.1.1
+
+### Patch Changes
+
+- 2e827ae: Fixes unneeded union in ValidAggregationKeys generic
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/api",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/cli.cmd.typescript
 
+## 0.25.1
+
+### Patch Changes
+
+- @osdk/generator@2.1.1
+- @osdk/cli.common@0.25.1
+
 ## 0.25.0
 
 ### Minor Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.25.0",
+  "version": "0.25.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli.common/CHANGELOG.md
+++ b/packages/cli.common/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/cli.common
 
+## 0.25.1
+
 ## 0.25.0
 
 ### Minor Changes

--- a/packages/cli.common/package.json
+++ b/packages/cli.common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.common",
   "private": true,
-  "version": "0.25.0",
+  "version": "0.25.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/cli
 
+## 0.25.1
+
 ## 0.25.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client.test.ontology/CHANGELOG.md
+++ b/packages/client.test.ontology/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/client.test.ontology
 
+## 2.1.1
+
+### Patch Changes
+
+- Updated dependencies [2e827ae]
+  - @osdk/api@2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/client.test.ontology/package.json
+++ b/packages/client.test.ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/client.test.ontology",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.unstable/CHANGELOG.md
+++ b/packages/client.unstable/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/client.unstable
 
+## 2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/client.unstable/package.json
+++ b/packages/client.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.unstable",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/client
 
+## 2.1.1
+
+### Patch Changes
+
+- Updated dependencies [2e827ae]
+  - @osdk/api@2.1.1
+  - @osdk/generator-converters@2.1.1
+  - @osdk/client.unstable@2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -97,7 +97,7 @@ export interface Client extends SharedClient, OldSharedClient {
 export const additionalContext: unique symbol = Symbol("additionalContext");
 
 // BEGIN: THIS IS GENERATED CODE. DO NOT EDIT.
-const MaxOsdkVersion = "2.1.0";
+const MaxOsdkVersion = "2.1.1";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 export type MaxOsdkVersion = typeof MaxOsdkVersion;
 const ErrorMessage: unique symbol = Symbol("ErrorMessage");

--- a/packages/create-app.template-packager/CHANGELOG.md
+++ b/packages/create-app.template-packager/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template-packager
 
+## 2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/create-app.template-packager/package.json
+++ b/packages/create-app.template-packager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template-packager",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.expo.v2/CHANGELOG.md
+++ b/packages/create-app.template.expo.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.expo.v2
 
+## 2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/create-app.template.expo.v2/package.json
+++ b/packages/create-app.template.expo.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.expo.v2",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.next-static-export.v2/CHANGELOG.md
+++ b/packages/create-app.template.next-static-export.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.next-static-export.v2
 
+## 2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/create-app.template.next-static-export.v2/package.json
+++ b/packages/create-app.template.next-static-export.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.next-static-export.v2",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.next-static-export/CHANGELOG.md
+++ b/packages/create-app.template.next-static-export/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.next-static-export
 
+## 2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/create-app.template.next-static-export/package.json
+++ b/packages/create-app.template.next-static-export/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.next-static-export",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react.beta/CHANGELOG.md
+++ b/packages/create-app.template.react.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.react
 
+## 2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/create-app.template.react.beta/package.json
+++ b/packages/create-app.template.react.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react.beta",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react/CHANGELOG.md
+++ b/packages/create-app.template.react/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.react
 
+## 2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/create-app.template.react/package.json
+++ b/packages/create-app.template.react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-aip-app.beta
 
+## 2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app.beta",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-aip-app
 
+## 2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-aip-app/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-app.beta/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-app.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-app.beta
 
+## 2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-app.beta/package.json
+++ b/packages/create-app.template.tutorial-todo-app.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app.beta",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-app
 
+## 2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-app/package.json
+++ b/packages/create-app.template.tutorial-todo-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.vue.v2/CHANGELOG.md
+++ b/packages/create-app.template.vue.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.vue.v2
 
+## 2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/create-app.template.vue.v2/package.json
+++ b/packages/create-app.template.vue.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.vue.v2",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.vue/CHANGELOG.md
+++ b/packages/create-app.template.vue/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.vue
 
+## 2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/create-app.template.vue/package.json
+++ b/packages/create-app.template.vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.vue",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app
 
+## 2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-app",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.1.0';
+export type $ExpectedClientVersion = '2.1.1';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.dep';

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.1.0';
+export type $ExpectedClientVersion = '2.1.1';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.dep';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.1.0';
+export type $ExpectedClientVersion = '2.1.1';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/OntologyMetadata.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.1.0';
+export type $ExpectedClientVersion = '2.1.1';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';

--- a/packages/example-generator/CHANGELOG.md
+++ b/packages/example-generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/example-generator
 
+## 0.9.1
+
+### Patch Changes
+
+- @osdk/create-app@2.1.1
+- @osdk/create-widget@2.0.0
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/example-generator/package.json
+++ b/packages/example-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/example-generator",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/foundry-sdk-generator
 
+## 2.1.1
+
+### Patch Changes
+
+- Updated dependencies [2e827ae]
+  - @osdk/api@2.1.1
+  - @osdk/client@2.1.1
+  - @osdk/generator@2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/functions/CHANGELOG.md
+++ b/packages/functions/CHANGELOG.md
@@ -1,0 +1,10 @@
+# @osdk/functions.unstable
+
+## 0.0.1
+
+### Patch Changes
+
+- 8f393cb: Released with support for ontology edits
+- Updated dependencies [2e827ae]
+  - @osdk/api@2.1.1
+  - @osdk/client@2.1.1

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/functions.unstable",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-converters/CHANGELOG.md
+++ b/packages/generator-converters/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/generator-converters
 
+## 2.1.1
+
+### Patch Changes
+
+- Updated dependencies [2e827ae]
+  - @osdk/api@2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/generator-converters/package.json
+++ b/packages/generator-converters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-converters",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-utils/CHANGELOG.md
+++ b/packages/generator-utils/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/generator-utils
 
+## 2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/generator-utils/package.json
+++ b/packages/generator-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-utils",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/generator
 
+## 2.1.1
+
+### Patch Changes
+
+- Updated dependencies [2e827ae]
+  - @osdk/api@2.1.1
+  - @osdk/generator-converters@2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator/src/v2.0/generateMetadata.ts
+++ b/packages/generator/src/v2.0/generateMetadata.ts
@@ -19,7 +19,7 @@ import type { GenerateContext } from "../GenerateContext/GenerateContext.js";
 import { formatTs } from "../util/test/formatTs.js";
 
 // BEGIN: THIS IS GENERATED CODE. DO NOT EDIT.
-const ExpectedOsdkVersion = "2.1.0";
+const ExpectedOsdkVersion = "2.1.1";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 
 export async function generateOntologyMetadataFile(

--- a/packages/maker/CHANGELOG.md
+++ b/packages/maker/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/maker
 
+## 0.9.1
+
+### Patch Changes
+
+- Updated dependencies [2e827ae]
+  - @osdk/api@2.1.1
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.test/CHANGELOG.md
+++ b/packages/shared.test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/shared.test
 
+## 2.1.1
+
+### Patch Changes
+
+- Updated dependencies [2e827ae]
+  - @osdk/api@2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/shared.test/package.json
+++ b/packages/shared.test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/shared.test",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "",
   "access": "private",
   "license": "Apache-2.0",

--- a/packages/tool.generate-with-mock-ontology/CHANGELOG.md
+++ b/packages/tool.generate-with-mock-ontology/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/tool.generate-with-mock-ontology
 
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies [2e827ae]
+  - @osdk/api@2.1.1
+  - @osdk/client@2.1.1
+
 ## 0.1.0
 
 ### Patch Changes

--- a/packages/tool.generate-with-mock-ontology/package.json
+++ b/packages/tool.generate-with-mock-ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/tool.generate-with-mock-ontology",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/2.1.x, this PR will be updated.


# Releases
## @osdk/api@2.1.1

### Patch Changes

-   2e827ae: Fixes unneeded union in ValidAggregationKeys generic

## @osdk/client@2.1.1

### Patch Changes

-   Updated dependencies [2e827ae]
    -   @osdk/api@2.1.1
    -   @osdk/generator-converters@2.1.1
    -   @osdk/client.unstable@2.1.1

## @osdk/foundry-sdk-generator@2.1.1

### Patch Changes

-   Updated dependencies [2e827ae]
    -   @osdk/api@2.1.1
    -   @osdk/client@2.1.1
    -   @osdk/generator@2.1.1

## @osdk/functions.unstable@0.0.1

### Patch Changes

-   8f393cb: Released with support for ontology edits
-   Updated dependencies [2e827ae]
    -   @osdk/api@2.1.1
    -   @osdk/client@2.1.1

## @osdk/generator@2.1.1

### Patch Changes

-   Updated dependencies [2e827ae]
    -   @osdk/api@2.1.1
    -   @osdk/generator-converters@2.1.1

## @osdk/generator-converters@2.1.1

### Patch Changes

-   Updated dependencies [2e827ae]
    -   @osdk/api@2.1.1

## @osdk/maker@0.9.1

### Patch Changes

-   Updated dependencies [2e827ae]
    -   @osdk/api@2.1.1

## @osdk/cli@0.25.1



## @osdk/client.unstable@2.1.1



## @osdk/create-app@2.1.1



## @osdk/generator-utils@2.1.1



## @osdk/benchmarks.primary@0.1.1

### Patch Changes

-   @osdk/client@2.1.1

## @osdk/cli.cmd.typescript@0.25.1

### Patch Changes

-   @osdk/generator@2.1.1
-   @osdk/cli.common@0.25.1

## @osdk/client.test.ontology@2.1.1

### Patch Changes

-   Updated dependencies [2e827ae]
    -   @osdk/api@2.1.1

## @osdk/example-generator@0.9.1

### Patch Changes

-   @osdk/create-app@2.1.1
-   @osdk/create-widget@2.0.0

## @osdk/shared.test@2.1.1

### Patch Changes

-   Updated dependencies [2e827ae]
    -   @osdk/api@2.1.1

## @osdk/tool.generate-with-mock-ontology@0.1.1

### Patch Changes

-   Updated dependencies [2e827ae]
    -   @osdk/api@2.1.1
    -   @osdk/client@2.1.1

## @osdk/cli.common@0.25.1



## @osdk/create-app.template-packager@2.1.1



## @osdk/create-app.template.expo.v2@2.1.1



## @osdk/create-app.template.next-static-export@2.1.1



## @osdk/create-app.template.next-static-export.v2@2.1.1



## @osdk/create-app.template.react@2.1.1



## @osdk/create-app.template.react.beta@2.1.1



## @osdk/create-app.template.tutorial-todo-aip-app@2.1.1



## @osdk/create-app.template.tutorial-todo-aip-app.beta@2.1.1



## @osdk/create-app.template.tutorial-todo-app@2.1.1



## @osdk/create-app.template.tutorial-todo-app.beta@2.1.1



## @osdk/create-app.template.vue@2.1.1



## @osdk/create-app.template.vue.v2@2.1.1


