### PR TITLE
Fix windows code generation

### DIFF
--- a/.changeset/tidy-times-beg.md
+++ b/.changeset/tidy-times-beg.md
@@ -1,0 +1,5 @@
+---
+"@osdk/foundry-sdk-generator": patch
+---
+
+Fix windows generation bug.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Build
+        run: pnpm build
+
       - name: Run codegen
         run: pnpm codegen
         working-directory: packages/e2e.test.foundry-sdk-generator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,29 +154,3 @@ jobs:
       - name: Faux Publish
         run: pnpm publish -r --no-git-checks
 
-  windowsCodegen:
-    name: Windows Code Generation
-    runs-on: windows-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build
-        run: pnpm build
-
-      - name: Run codegen
-        run: pnpm codegen
-        working-directory: packages/e2e.test.foundry-sdk-generator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,4 +176,4 @@ jobs:
 
       - name: Run codegen
         run: pnpm codegen
-        working-directory: packages/foundry-sdk-generator
+        working-directory: packages/e2e.test.foundry-sdk-generator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,3 +153,27 @@ jobs:
 
       - name: Faux Publish
         run: pnpm publish -r --no-git-checks
+
+  windowsCodegen:
+    name: Windows Code Generation
+    runs-on: windows-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run codegen
+        run: pnpm codegen
+        working-directory: packages/foundry-sdk-generator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,4 +153,3 @@ jobs:
 
       - name: Faux Publish
         run: pnpm publish -r --no-git-checks
-

--- a/packages/foundry-sdk-generator/src/generate/betaClient/__tests__/customNormalize.test.ts
+++ b/packages/foundry-sdk-generator/src/generate/betaClient/__tests__/customNormalize.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { customNormalize } from "../generatePackage.js";
+
+describe("test path normalization", () => {
+  it("works for mac", () => {
+    const macPath =
+      "/Volumes/testFolder/osdk-ts/packages/foundry-sdk-generator/src/generate/betaClient/__tests__/customNormalize.test.ts";
+    expect(customNormalize(macPath)).toEqual(macPath);
+
+    const macPathExtraSlashes =
+      "/Volumes/testFolder/osdk-ts//packages/foundry-sdk-generator/src//generate/betaClient/__tests__/customNormalize.test.ts";
+    expect(customNormalize(macPathExtraSlashes)).toEqual(macPath);
+  });
+
+  it("works for windows", () => {
+    const normalizedWindowsPath =
+      "C/Users/testFolder/osdk-ts/packages/foundry-sdk-generator/src/generate/betaClient/__tests__/customNormalize.test.ts";
+
+    const windowsPath =
+      "C\\Users\\testFolder\\osdk-ts\\packages\\foundry-sdk-generator\\src\\generate\\betaClient\\__tests__\\customNormalize.test.ts";
+    expect(customNormalize(windowsPath)).toEqual(normalizedWindowsPath);
+
+    const macPathExtraSlashes =
+      "C\\Users\\testFolder\\osdk-ts\\\\packages\\foundry-sdk-generator\\src\\generate\\betaClient\\__tests__\\\\customNormalize.test.ts";
+    expect(customNormalize(macPathExtraSlashes)).toEqual(
+      normalizedWindowsPath,
+    );
+  });
+});

--- a/packages/foundry-sdk-generator/src/generate/betaClient/__tests__/customNormalize.test.ts
+++ b/packages/foundry-sdk-generator/src/generate/betaClient/__tests__/customNormalize.test.ts
@@ -42,4 +42,19 @@ describe("test path normalization", () => {
       normalizedWindowsPath,
     );
   });
+
+  it("works for mixed slashes", () => {
+    const normalizedWindowsPath =
+      "C/Users/testFolder/osdk-ts/packages/foundry-sdk-generator/src/generate/betaClient/__tests__/customNormalize.test.ts";
+
+    const windowsPath =
+      "C\\Users\\testFolder\\osdk-ts\\packages/foundry-sdk-generator/src/generate\\betaClient\\__tests__\\customNormalize.test.ts";
+    expect(customNormalize(windowsPath)).toEqual(normalizedWindowsPath);
+
+    const macPathExtraSlashes =
+      "C\\Users\\testFolder\\osdk-ts\\\\packages\\foundry-sdk-generator//src\\generate//betaClient\\__tests__\\\\customNormalize.test.ts";
+    expect(customNormalize(macPathExtraSlashes)).toEqual(
+      normalizedWindowsPath,
+    );
+  });
 });

--- a/packages/foundry-sdk-generator/src/generate/betaClient/generatePackage.ts
+++ b/packages/foundry-sdk-generator/src/generate/betaClient/generatePackage.ts
@@ -55,8 +55,9 @@ export async function generatePackage(
     return;
   }
 
-  const packagePath = join(options.outputDir, options.packageName);
-
+  const packagePath = customNormalize(
+    join(options.outputDir, options.packageName),
+  );
   const resolvedPeerDependencies = await resolveDependenciesFromFindUp(
     betaPeerDependencies,
     dirname(fileURLToPath(import.meta.url)),
@@ -67,10 +68,10 @@ export async function generatePackage(
   const inMemoryFileSystem: { [fileName: string]: string } = {};
   const hostFs: MinimalFs = {
     writeFile: async (path, contents) => {
-      inMemoryFileSystem[normalize(path)] = contents;
+      inMemoryFileSystem[customNormalize(path)] = contents;
     },
     mkdir: async (path, _options?: { recursive: boolean }) => {
-      await mkdir(normalize(path), { recursive: true });
+      await mkdir(customNormalize(path), { recursive: true });
     },
     readdir: path => readdir(path),
   };
@@ -183,4 +184,8 @@ export async function generatePackage(
   if (!success) {
     throw new Error("Failed to generate package");
   }
+}
+
+export function customNormalize(pathName: string): string {
+  return normalize(pathName.replace(/\\/g, "/"));
 }


### PR DESCRIPTION
We started getting complaints that people could not run `foundry-sdk-generator` locally on windows. The issue seemed to be that we would create a directory structure, but would not actually write any files to populate it with.

The problem area was where we compiled in memory. When generating on Windows, our[ in-memory file system ](https://github.com/palantir/osdk-ts/blob/d0911c279e6f19d5fd04fba20707a6b449215bbb/packages/foundry-sdk-generator/src/generate/betaClient/compileInMemory.ts#L32) would have all files keyed by path names with backslashes. However, when the typescript compiler would [try and get the source files](https://github.com/palantir/osdk-ts/blob/d0911c279e6f19d5fd04fba20707a6b449215bbb/packages/foundry-sdk-generator/src/generate/betaClient/compileInMemory.ts#L57) it should write,  it could never find them because it was looking for files with forward slashes, and would therefore never be able to write anything back.

Looking a bit closer, it seems like typescript [normalizes all paths internally to be forward slash ](https://github.com/microsoft/TypeScript/blob/0aac72020ee8414218273f654eb7ce1dc2dd0d6b/src/compiler/path.ts#L526).

To fix the issue, we now normalize all paths in our internal memory store to use forward slashes as well, I confirmed this works on a windows machine as well