### PR TITLE
Add new TimeSeriesQueryV2 type with nested operations

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -131,6 +131,15 @@ export type {
   TimeSeriesPoint,
   TimeSeriesProperty,
   TimeSeriesQuery,
+  TimeSeriesQueryV2,
+  TimeSeriesQueryWrapper,
+  TimeSeriesRange,
 } from "./timeseries/timeseries.js";
+export {
+  isAbsoluteTimeRange,
+  isLegacyTimeSeriesQuery,
+  isRelativeTimeRange,
+  isTimeSeriesQueryV2,
+} from "./timeseries/timeSeriesGuards.js";
 export type { LinkedType, LinkNames } from "./util/LinkUtils.js";
 export {};

--- a/packages/api/src/timeseries/timeSeriesGuards.ts
+++ b/packages/api/src/timeseries/timeSeriesGuards.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  AbsoluteTimeRange,
+  RelativeTimeRange,
+  TimeSeriesQuery,
+  TimeSeriesQueryV2,
+  TimeSeriesQueryWrapper,
+  TimeSeriesRange,
+} from "./timeseries.js";
+
+/**
+ * Type Guards to handle union time series types.
+ */
+
+/**
+ * Checks if the query is a TimeSeriesQueryV2 (new nested version)
+ * by verifying that it has any of the available operations:
+ * - `range`
+ */
+export function isTimeSeriesQueryV2(
+  query: TimeSeriesQueryWrapper,
+): query is TimeSeriesQueryV2 {
+  return "range" in query;
+}
+
+/**
+ * Checks if the query is a legacy TimeSeriesQuery type.
+ * Since legacy queries have a flat structure, they do not include nested operations
+ * such as the `range` operation used in TimeSeriesQueryV2.
+ */
+export function isLegacyTimeSeriesQuery(
+  query: TimeSeriesQueryWrapper,
+): query is TimeSeriesQuery {
+  return !("range" in query);
+}
+
+// Type Guards for TimeRanges
+
+export function isAbsoluteTimeRange(
+  range: TimeSeriesRange,
+): range is AbsoluteTimeRange {
+  return "startTime" in range || "endTime" in range;
+}
+
+export function isRelativeTimeRange(
+  range: TimeSeriesRange,
+): range is RelativeTimeRange {
+  return "unit" in range && ("before" in range || "after" in range);
+}

--- a/packages/api/src/timeseries/timeseries.ts
+++ b/packages/api/src/timeseries/timeseries.ts
@@ -46,6 +46,25 @@ export type TimeSeriesQuery =
     $unit?: never;
   };
 
+export type TimeSeriesQueryV2 = {
+  range: TimeSeriesRange;
+};
+
+export type TimeSeriesQueryWrapper = TimeSeriesQuery | TimeSeriesQueryV2;
+
+export type TimeSeriesRange = AbsoluteTimeRange | RelativeTimeRange;
+
+export type AbsoluteTimeRange = {
+  startTime?: string;
+  endTime?: string;
+};
+
+export type RelativeTimeRange = {
+  before?: number;
+  unit: keyof typeof TimeseriesDurationMapping;
+  after?: number;
+};
+
 export type TimeseriesDurationUnits =
   | "YEARS"
   | "MONTHS"
@@ -109,7 +128,7 @@ export interface TimeSeriesProperty<T extends number | string> {
       });
      */
   readonly getAllPoints: (
-    query?: TimeSeriesQuery,
+    query?: TimeSeriesQueryWrapper,
   ) => Promise<Array<TimeSeriesPoint<T>>>;
   /**
      * Returns an async iterator to load all points
@@ -125,7 +144,7 @@ export interface TimeSeriesProperty<T extends number | string> {
       }
      */
   readonly asyncIterPoints: (
-    query?: TimeSeriesQuery,
+    query?: TimeSeriesQueryWrapper,
   ) => AsyncGenerator<TimeSeriesPoint<T>>;
 }
 

--- a/packages/client/src/createTimeseriesProperty.ts
+++ b/packages/client/src/createTimeseriesProperty.ts
@@ -17,11 +17,14 @@
 import type {
   TimeSeriesPoint,
   TimeSeriesProperty,
-  TimeSeriesQuery,
+  TimeSeriesQueryWrapper,
 } from "@osdk/api";
 import * as OntologiesV2 from "@osdk/foundry.ontologies";
 import type { MinimalClient } from "./MinimalClientContext.js";
-import { asyncIterPointsHelper, getTimeRange } from "./util/timeseriesUtils.js";
+import {
+  asyncIterPointsHelper,
+  parseTimeSeriesQuery,
+} from "./util/timeseriesUtils.js";
 
 export class TimeSeriesPropertyImpl<T extends number | string>
   implements TimeSeriesProperty<T>
@@ -56,7 +59,7 @@ export class TimeSeriesPropertyImpl<T extends number | string>
   }
 
   public async getAllPoints(
-    query?: TimeSeriesQuery,
+    query?: TimeSeriesQueryWrapper,
   ): Promise<TimeSeriesPoint<T>[]> {
     const allPoints: Array<TimeSeriesPoint<T>> = [];
 
@@ -67,7 +70,7 @@ export class TimeSeriesPropertyImpl<T extends number | string>
   }
 
   public async *asyncIterPoints(
-    query?: TimeSeriesQuery,
+    query?: TimeSeriesQueryWrapper,
   ): AsyncGenerator<
     {
       time: any;
@@ -81,7 +84,7 @@ export class TimeSeriesPropertyImpl<T extends number | string>
         this.#client,
         await this.#client.ontologyRid,
         ...this.#triplet,
-        query ? { range: getTimeRange(query) } : {},
+        query ? parseTimeSeriesQuery(query) : {},
       );
 
     for await (

--- a/packages/client/src/object/timeseries.test.ts
+++ b/packages/client/src/object/timeseries.test.ts
@@ -166,4 +166,52 @@ describe("Timeseries", () => {
       { time: "2014-04-14", value: 30 },
     ]);
   });
+
+  it("getAll points works with before in TimeSeriesQueryV2", async () => {
+    const employee = await client(Employee).fetchOne(50030);
+    expect(employee.$primaryKey).toEqual(50030);
+    const points = await employee.employeeStatus?.getAllPoints({
+      range: {
+        before: 1,
+        unit: "month",
+      },
+    });
+    expect(points).toBeDefined();
+    expect(points!).toEqual([{ time: "2012-02-12", value: 10 }, {
+      time: "2013-03-13",
+      value: 20,
+    }, { time: "2014-04-14", value: 30 }]);
+  });
+
+  it("getAll points works with after in TimeSeriesQueryV2", async () => {
+    const employee = await client(Employee).fetchOne(50030);
+    expect(employee.$primaryKey).toEqual(50030);
+    const points = await employee.employeeStatus?.getAllPoints({
+      range: {
+        after: 1,
+        unit: "month",
+      },
+    });
+    expect(points).toBeDefined();
+    expect(points!).toEqual([{ time: "2012-02-12", value: 10 }, {
+      time: "2014-04-14",
+      value: 30,
+    }]);
+  });
+
+  it("getAll points works with absolute range in TimeSeriesQueryV2", async () => {
+    const employee = await client(Employee).fetchOne(50030);
+    expect(employee.$primaryKey).toEqual(50030);
+    const points = await employee.employeeStatus?.getAllPoints({
+      range: {
+        startTime: "2013-03-12T12:00:00.000Z",
+        endTime: "2014-04-14T12:00:00.000Z",
+      },
+    });
+    expect(points).toBeDefined();
+    expect(points!).toEqual([{
+      time: "2013-03-13",
+      value: 20,
+    }, { time: "2014-04-14", value: 30 }]);
+  });
 });


### PR DESCRIPTION
The current `TimeSeriesQuery` type has a flat structure, making it difficult to add and maintain any new operations or args.

So we're adding a new `TimeSeriesQueryV2` type with nested operations, which will make it easy for users to express their time series operations.

### Handling Unions
To avoid breaking existing `TimeSeriesQuery` usages, I've added a union of `TimeSeriesQuery` and `TimeSeriesQueryV2`.

To handle unions, I've added time-series specific type-guards.

Alternatively I considered using discriminated unions however they would require users to pass the discriminator which, although explicit and clean, I'm not confident would be the best UX or be consistent with the rest of the SDK. I'm open to alternatives for handling unions.