### PR TITLE
Version Packages

### DIFF
--- a/.changeset/cuddly-sloths-lay.md
+++ b/.changeset/cuddly-sloths-lay.md
@@ -1,5 +1,0 @@
----
-"@osdk/functions.unstable": patch
----
-
-Fix exports from @osdk/functions.unstable package

--- a/packages/functions/CHANGELOG.md
+++ b/packages/functions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/functions.unstable
 
+## 0.0.2
+
+### Patch Changes
+
+- 586be29: Fix exports from @osdk/functions.unstable package
+
 ## 0.0.1
 
 ### Patch Changes

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/functions.unstable",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/2.1.x, this PR will be updated.


# Releases
## @osdk/functions.unstable@0.0.2

### Patch Changes

-   586be29: Fix exports from @osdk/functions.unstable package
