### PR TITLE
Fix includeAllBaseObjectProperties type

### DIFF
--- a/.changeset/nine-spies-mix.md
+++ b/.changeset/nine-spies-mix.md
@@ -1,0 +1,5 @@
+---
+"@osdk/api": patch
+---
+
+Fix include all properties flag.

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -235,7 +235,7 @@ export interface AsyncIterArgs<
     	// (undocumented)
     $__UNSTABLE_useOldInterfaceApis?: boolean;
     	// (undocumented)
-    $includeAllBaseObjectProperties?: T;
+    $includeAllBaseObjectProperties?: PropertyKeys<Q> extends K ? T : never;
 }
 
 // @public (undocumented)

--- a/packages/api/src/object/FetchPageArgs.ts
+++ b/packages/api/src/object/FetchPageArgs.ts
@@ -72,7 +72,7 @@ export interface AsyncIterArgs<
   T extends boolean = false,
 > extends SelectArg<Q, K, R, S>, OrderByArg<Q, PropertyKeys<Q>> {
   $__UNSTABLE_useOldInterfaceApis?: boolean;
-  $includeAllBaseObjectProperties?: T;
+  $includeAllBaseObjectProperties?: PropertyKeys<Q> extends K ? T : never;
 }
 
 export type Augment<

--- a/packages/e2e.sandbox.catchall/src/runInterfacesTest2.ts
+++ b/packages/e2e.sandbox.catchall/src/runInterfacesTest2.ts
@@ -25,6 +25,7 @@ export async function runInterfacesTest2(): Promise<void> {
   const athletes = await dsClient(Athlete).where({
     name22: { $eq: "Michael Jordan" },
   }).fetchPage({ $includeAllBaseObjectProperties: true });
+
   invariant(athletes.data.length > 0);
 
   const athlete1 = athletes.data[0];
@@ -43,7 +44,7 @@ export async function runInterfacesTest2(): Promise<void> {
   const athletesSelected = await dsClient(Athlete).where({
     name22: { $eq: "Michael Jordan" },
   }).fetchPage({
-    $select: ["athleteId"],
+    $select: ["athleteId", "jerseyNumber", "name22"],
     $includeAllBaseObjectProperties: true,
   });
 
@@ -60,6 +61,14 @@ export async function runInterfacesTest2(): Promise<void> {
       typeof nbaPlayer1
     >
   >(true);
+
+  const athletesNotAllSelected = await dsClient(Athlete).where({
+    name22: { $eq: "Michael Jordan" },
+  }).fetchPage({
+    $select: ["athleteId", "name22"],
+    // @ts-expect-error
+    $includeAllBaseObjectProperties: true,
+  });
 }
 
 void runInterfacesTest2();


### PR DESCRIPTION
We now make it so that if you downselect properties, you can't set this flag.

If you include all properties on the interface, we still let you use the flag since nothing is downselected.