### PR TITLE
Fix type api break

### DIFF
--- a/.changeset/four-dancers-warn.md
+++ b/.changeset/four-dancers-warn.md
@@ -1,0 +1,5 @@
+---
+"@osdk/api": patch
+---
+
+Fix type break.

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -520,7 +520,7 @@ export type FetchPageResult<
 	L extends PropertyKeys<Q>,
 	R extends boolean,
 	S extends NullabilityAdherence,
-	T extends boolean
+	T extends boolean = false
 > = PageResult<PropertyKeys<Q> extends L ? Osdk.Instance<Q, ExtractOptions<R, S, T>> : Osdk.Instance<Q, ExtractOptions<R, S, T>, L>>;
 
 // @public (undocumented)

--- a/packages/api/src/object/FetchPageResult.ts
+++ b/packages/api/src/object/FetchPageResult.ts
@@ -51,7 +51,7 @@ export type FetchPageResult<
   L extends PropertyKeys<Q>,
   R extends boolean,
   S extends NullabilityAdherence,
-  T extends boolean,
+  T extends boolean = false,
 > = PageResult<
   PropertyKeys<Q> extends L ? Osdk.Instance<Q, ExtractOptions<R, S, T>>
     : Osdk.Instance<Q, ExtractOptions<R, S, T>, L>


### PR DESCRIPTION
Fetchpage result had a new required parameter in the generic, which is technically a break. Now it is optional.