### PR TITLE
Check requested scopes are equal before exchanging refresh token

### DIFF
--- a/.changeset/pretty-forks-sniff.md
+++ b/.changeset/pretty-forks-sniff.md
@@ -1,0 +1,5 @@
+---
+"@osdk/oauth": patch
+---
+
+Discard refresh token if requested scopes have changed

--- a/packages/oauth/src/common.test.ts
+++ b/packages/oauth/src/common.test.ts
@@ -82,7 +82,7 @@ describe("local functions", () => {
       {},
       refresh,
       "marker marker",
-      ["yay:my-fun-scope", "sad:my-boring-scope"],
+      "yay:my-fun-scope sad:my-boring-scope",
     );
 
     makeTokenAndSaveRefresh({
@@ -97,7 +97,7 @@ describe("local functions", () => {
       JSON.stringify({
         refresh_token: "refresh",
         refreshTokenMarker: "marker marker",
-        requestedScopes: ["yay:my-fun-scope", "sad:my-boring-scope"],
+        requestedScopes: "yay:my-fun-scope sad:my-boring-scope",
       }),
     );
   });

--- a/packages/oauth/src/common.test.ts
+++ b/packages/oauth/src/common.test.ts
@@ -62,7 +62,7 @@ describe("local functions", () => {
     );
   });
 
-  it("should save the refreshTokenMaker if it exists", () => {
+  it("should save the refreshTokenMaker if it exists, as well as the requested scopes", () => {
     const client = {
       client_id: "hi_mom",
     };
@@ -82,6 +82,7 @@ describe("local functions", () => {
       {},
       refresh,
       "marker marker",
+      ["yay:my-fun-scope", "sad:my-boring-scope"],
     );
 
     makeTokenAndSaveRefresh({
@@ -96,6 +97,7 @@ describe("local functions", () => {
       JSON.stringify({
         refresh_token: "refresh",
         refreshTokenMarker: "marker marker",
+        requestedScopes: ["yay:my-fun-scope", "sad:my-boring-scope"],
       }),
     );
   });

--- a/packages/oauth/src/common.ts
+++ b/packages/oauth/src/common.ts
@@ -52,9 +52,9 @@ declare const process: {
 export interface LocalStorageState {
   refresh_token?: string;
   refreshTokenMarker?: string;
-  // The scopes requested during the initial auth grant, which our refresh token is still valid for
+  // The stringified space-separated list of scopes requested during the initial auth grant, which our refresh token is still valid for
   // Note any or none of these scopes may have actually been granted when we received our last access token
-  requestedScopes?: string[];
+  requestedScopes?: string;
 }
 
 export type SessionStorageState =
@@ -140,7 +140,7 @@ export function common<
   oauthHttpOptions: HttpRequestOptions,
   refresh: R,
   refreshTokenMarker: string | undefined,
-  scopes: string[],
+  scopes: string,
 ): {
   getToken: BaseOauthClient<keyof Events & string> & { refresh: R };
   makeTokenAndSaveRefresh: (

--- a/packages/oauth/src/common.ts
+++ b/packages/oauth/src/common.ts
@@ -52,7 +52,7 @@ declare const process: {
 export interface LocalStorageState {
   refresh_token?: string;
   refreshTokenMarker?: string;
-  // The scopes requested during the initial auth grant, which our request token is still valid for
+  // The scopes requested during the initial auth grant, which our refresh token is still valid for
   // Note any or none of these scopes may have actually been granted when we received our last access token
   requestedScopes?: string[];
 }

--- a/packages/oauth/src/common.ts
+++ b/packages/oauth/src/common.ts
@@ -52,6 +52,9 @@ declare const process: {
 export interface LocalStorageState {
   refresh_token?: string;
   refreshTokenMarker?: string;
+  // The scopes requested during the initial auth grant, which our request token is still valid for
+  // Note any or none of these scopes may have actually been granted when we received our last access token
+  requestedScopes?: string[];
 }
 
 export type SessionStorageState =
@@ -137,6 +140,7 @@ export function common<
   oauthHttpOptions: HttpRequestOptions,
   refresh: R,
   refreshTokenMarker: string | undefined,
+  scopes: string[],
 ): {
   getToken: BaseOauthClient<keyof Events & string> & { refresh: R };
   makeTokenAndSaveRefresh: (
@@ -156,6 +160,7 @@ export function common<
     saveLocal(client, {
       refresh_token,
       refreshTokenMarker,
+      requestedScopes: scopes,
     });
     token = {
       refresh_token,

--- a/packages/oauth/src/createConfidentialOauthClient.ts
+++ b/packages/oauth/src/createConfidentialOauthClient.ts
@@ -44,6 +44,7 @@ export function createConfidentialOauthClient(
   const client: Client = { client_id, client_secret };
   const authServer = createAuthorizationServer(ctxPath, url);
   const oauthHttpOptions: HttpRequestOptions = { [customFetch]: fetchFn };
+  const joinedScopes = scopes.join(" ");
 
   const { getToken, makeTokenAndSaveRefresh } = common(
     client,
@@ -52,7 +53,7 @@ export function createConfidentialOauthClient(
     oauthHttpOptions,
     undefined,
     undefined,
-    scopes,
+    joinedScopes,
   );
 
   async function _signIn() {
@@ -64,7 +65,7 @@ export function createConfidentialOauthClient(
           await clientCredentialsGrantRequest(
             authServer,
             client,
-            new URLSearchParams({ scope: scopes.join(" ") }),
+            new URLSearchParams({ scope: joinedScopes }),
             oauthHttpOptions,
           ),
         ),

--- a/packages/oauth/src/createConfidentialOauthClient.ts
+++ b/packages/oauth/src/createConfidentialOauthClient.ts
@@ -52,6 +52,7 @@ export function createConfidentialOauthClient(
     oauthHttpOptions,
     undefined,
     undefined,
+    scopes,
   );
 
   async function _signIn() {

--- a/packages/oauth/src/createPublicOauthClient.ts
+++ b/packages/oauth/src/createPublicOauthClient.ts
@@ -138,11 +138,12 @@ export function createPublicOauthClient(
   ctxPath?: string,
 ): PublicOauthClient {
   let refreshTokenMarker: string | undefined;
+  let joinedScopes: string;
   ({
     useHistory,
     loginPage,
     postLoginPage,
-    scopes,
+    joinedScopes,
     fetchFn,
     ctxPath,
     refreshTokenMarker,
@@ -171,7 +172,7 @@ export function createPublicOauthClient(
     oauthHttpOptions,
     maybeRefresh.bind(globalThis, true),
     refreshTokenMarker,
-    scopes,
+    joinedScopes,
   );
 
   // as an arrow function, `useHistory` is known to be a boolean
@@ -195,8 +196,7 @@ export function createPublicOauthClient(
     } = readLocal(client);
 
     const areScopesEqual = initialRequestedScopes != null
-      && scopes!.every(scope => initialRequestedScopes.includes(scope))
-      && scopes!.length === initialRequestedScopes.length;
+      && joinedScopes === initialRequestedScopes;
 
     if (
       !refresh_token || lastRefreshTokenMarker !== refreshTokenMarker
@@ -321,7 +321,7 @@ export function createPublicOauthClient(
       redirect_uri,
       code_challenge: await calculatePKCECodeChallenge(codeVerifier),
       code_challenge_method: "S256",
-      scope: ["offline_access", ...scopes].join(" "),
+      scope: "offline_access" + ` ${joinedScopes}`,
     })}`);
 
     // Give time for redirect to happen

--- a/packages/oauth/src/createPublicOauthClient.ts
+++ b/packages/oauth/src/createPublicOauthClient.ts
@@ -321,7 +321,7 @@ export function createPublicOauthClient(
       redirect_uri,
       code_challenge: await calculatePKCECodeChallenge(codeVerifier),
       code_challenge_method: "S256",
-      scope: "offline_access" + ` ${joinedScopes}`,
+      scope: `offline_access ${joinedScopes}`,
     })}`);
 
     // Give time for redirect to happen

--- a/packages/oauth/src/createPublicOauthClient.ts
+++ b/packages/oauth/src/createPublicOauthClient.ts
@@ -171,6 +171,7 @@ export function createPublicOauthClient(
     oauthHttpOptions,
     maybeRefresh.bind(globalThis, true),
     refreshTokenMarker,
+    scopes,
   );
 
   // as an arrow function, `useHistory` is known to be a boolean
@@ -187,10 +188,20 @@ export function createPublicOauthClient(
   async function maybeRefresh(
     expectRefreshToken?: boolean,
   ): Promise<Token | undefined> {
-    const { refresh_token, refreshTokenMarker: lastRefreshTokenMarker } =
-      readLocal(client);
+    const {
+      refresh_token,
+      refreshTokenMarker: lastRefreshTokenMarker,
+      requestedScopes: initialRequestedScopes,
+    } = readLocal(client);
 
-    if (!refresh_token || lastRefreshTokenMarker !== refreshTokenMarker) {
+    const areScopesEqual = initialRequestedScopes != null
+      && scopes!.every(scope => initialRequestedScopes.includes(scope))
+      && scopes!.length === initialRequestedScopes.length;
+
+    if (
+      !refresh_token || lastRefreshTokenMarker !== refreshTokenMarker
+      || !areScopesEqual
+    ) {
       if (expectRefreshToken) throw new Error("No refresh token found");
       return;
     }

--- a/packages/oauth/src/publicOauth.test.ts
+++ b/packages/oauth/src/publicOauth.test.ts
@@ -202,10 +202,10 @@ describe(createPublicOauthClient, () => {
         redirect_uri: clientArgs.redirectUrl,
         response_type: "code",
         code_challenge_method: "S256",
-        scope: "offline_access "
-          + (clientArgs.scopes ?? ["api:read-data", "api:write-data"]).join(
-            " ",
-          ),
+        scope: [
+          "offline_access",
+          ...(clientArgs.scopes ?? ["api:read-data", "api:write-data"].sort()),
+        ].join(" "),
         state: expect.any(String),
       }),
     );
@@ -235,7 +235,7 @@ describe(createPublicOauthClient, () => {
     it("should not allow refresh if requested scopes are different", async () => {
       setupLocalState({
         refresh_token: "refreshToken",
-        requestedScopes: ["api:read-data"],
+        requestedScopes: "api:read-data",
       });
 
       setupClient({
@@ -252,7 +252,7 @@ describe(createPublicOauthClient, () => {
       setupLocalState({
         refresh_token: "refreshToken",
         refreshTokenMarker: "not-the-right-marker",
-        requestedScopes: ["api:read-data"],
+        requestedScopes: "api:read-data",
       });
 
       setupClient({
@@ -270,13 +270,13 @@ describe(createPublicOauthClient, () => {
       setupLocalState({
         refresh_token: "refreshToken",
         refreshTokenMarker: "marker",
-        requestedScopes: ["api:datasets-read", "api:admin-read"],
+        requestedScopes: "api:admin-read api:datasets-read",
       });
 
       setupClient({
         ...BASE_CLIENT_ARGS,
         refreshTokenMarker: "marker",
-        scopes: ["api:admin-read", "api:datasets-read"],
+        scopes: ["api:datasets-read", "api:admin-read"],
       });
 
       hoistedMocks.makeTokenAndSaveRefresh.mockImplementationOnce(
@@ -383,7 +383,8 @@ describe(createPublicOauthClient, () => {
         expect.anything(),
         expect.any(Function),
         undefined,
-        clientArgs.scopes ?? ["api:read-data", "api:write-data"],
+        (clientArgs.scopes
+          ?? ["api:read-data", "api:write-data"]).sort().join(" "),
       );
     });
 
@@ -393,8 +394,8 @@ describe(createPublicOauthClient, () => {
       {
         localStorage: {
           refresh_token: "a-refresh-token",
-          requestedScopes: clientArgs.scopes
-            ?? ["api:read-data", "api:write-data"],
+          requestedScopes: (clientArgs.scopes
+            ?? ["api:read-data", "api:write-data"]).sort().join(" "),
         },
         sessionStorage: {},
       },

--- a/packages/oauth/src/utils.ts
+++ b/packages/oauth/src/utils.ts
@@ -17,12 +17,15 @@
 import invariant from "tiny-invariant";
 import type { PublicOauthClientOptions } from "./createPublicOauthClient.js";
 
-interface ProcessedPublicOauthClientOptions
-  extends
-    Omit<Required<PublicOauthClientOptions>, "loginPage" | "refreshTokenMarker">
+interface ProcessedPublicOauthClientOptions extends
+  Omit<
+    Required<PublicOauthClientOptions>,
+    "loginPage" | "refreshTokenMarker" | "scopes"
+  >
 {
   loginPage?: string;
   refreshTokenMarker?: string;
+  joinedScopes: string;
 }
 
 export function processOptionsAndAssignDefaults(
@@ -62,7 +65,8 @@ export function processOptionsAndAssignDefaults(
     useHistory: options.useHistory ?? true,
     loginPage: options.loginPage,
     postLoginPage: options.postLoginPage || window.location.toString(),
-    scopes: options.scopes ?? ["api:read-data", "api:write-data"],
+    joinedScopes: [...options.scopes ?? ["api:read-data", "api:write-data"]]
+      .sort().join(" "),
     fetchFn: options.fetchFn ?? globalThis.fetch,
     ctxPath: options.ctxPath ?? "multipass",
     refreshTokenMarker: options.refreshTokenMarker,


### PR DESCRIPTION
We don't check whether the requested scopes have changed before using the refresh token in local storage if there is one. This has led to an issue flagged by a couple different users where, even after they've requested more scopes in their code, they can't get a token back with those permissions because we continue to exchange their old refresh token.

The scopes granted from exchanging a refresh token are taken from the intersection of 1) the requested scopes during the initial auth code grant (not to be confused with the scopes that actually get granted and returned in the auth response) and 2) the allowed client operations at this current moment in time.

So there's no risk of having a refresh token based off stale client allowed operations, as those get re-evaluated every time we refresh our token. But we do need to check whether the requested scopes have changed since we kicked off the auth code grant last, which this PR does by storing those scopes in local storage and checking if they've changed before attempting to exchange the refresh token.