### PR TITLE
Fix `FetchPageByRid` generics

### DIFF
--- a/packages/api/src/experimental/fetchPageByRid.ts
+++ b/packages/api/src/experimental/fetchPageByRid.ts
@@ -35,7 +35,7 @@ type fetchPageByRidFn = <
 >(
   objectType: Q,
   rids: string[],
-  options?: FetchPageArgs<Q, L, R, any, S>,
+  options?: FetchPageArgs<Q, L, R, any, S, T>,
 ) => Promise<FetchPageResult<Q, L, R, S, T>>;
 
 export const __EXPERIMENTAL__NOT_SUPPORTED_YET__fetchPageByRid: Experiment<


### PR DESCRIPTION
- Fix the generic to support `$allBaseProperties` w/ `__EXPERIMENTAL__NOT_SUPPORTED_YET__fetchPageByRid` 