### PR TITLE
Support widget dev server on non-root paths

### DIFF
--- a/.changeset/tricky-wasps-breathe.md
+++ b/.changeset/tricky-wasps-breathe.md
@@ -1,0 +1,5 @@
+---
+"@osdk/widget.vite-plugin.unstable": patch
+---
+
+Support widget dev server on non-root paths

--- a/packages/widget.vite-plugin.unstable/src/client/app.tsx
+++ b/packages/widget.vite-plugin.unstable/src/client/app.tsx
@@ -92,14 +92,14 @@ export const App: React.FC = () => {
       )}
       {/* To load the entrypoint info, we have to actually load it in the browser to get vite to follow the module graph. Since we know these files will fail, we just load them in iframes set to display: none to trigger the load hook in vite */}
       {entrypointPaths.map((entrypointPath) => (
-        <iframe key={entrypointPath} src={`/${entrypointPath}`} />
+        <iframe key={entrypointPath} src={entrypointPath} />
       ))}
     </div>
   );
 };
 
 function loadEntrypoints(): Promise<string[]> {
-  return fetch("./entrypoints").then((res) => res.json());
+  return fetch("../entrypoints").then((res) => res.json());
 }
 
 function finish(): Promise<
@@ -113,5 +113,5 @@ function finish(): Promise<
     status: "pending";
   }
 > {
-  return fetch("./finish").then((res) => res.json());
+  return fetch("../finish").then((res) => res.json());
 }

--- a/packages/widget.vite-plugin.unstable/src/common/constants.ts
+++ b/packages/widget.vite-plugin.unstable/src/common/constants.ts
@@ -17,6 +17,7 @@
 export const PALANTIR_PATH: string = ".palantir";
 export const SETUP_PATH: string = `${PALANTIR_PATH}/setup`;
 export const ENTRYPOINTS_PATH: string = `${PALANTIR_PATH}/entrypoints`;
+export const FINISH_PATH: string = `${PALANTIR_PATH}/finish`;
 export const VITE_INJECTIONS_PATH: string =
   `${PALANTIR_PATH}/vite-injections.js`;
 export const CONFIG_FILE_SUFFIX = ".config";

--- a/packages/widget.vite-plugin.unstable/vite.config.ts
+++ b/packages/widget.vite-plugin.unstable/vite.config.ts
@@ -18,11 +18,12 @@ import react from "@vitejs/plugin-react";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
-import { SETUP_PATH } from "./src/common/constants.js";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: `/${SETUP_PATH}`,
+  // Support being served on a non-root path
+  // https://vite.dev/guide/build#relative-base
+  base: "./",
   plugins: [react()],
   server: {
     port: 8080,


### PR DESCRIPTION
Support running the widget dev-server plugin's setup UI on non-root paths by making all asset and API paths relative. When running within Foundry on a container the set up UI is accessed using a proxy route rather than directly via it's port.

I'm also redirecting from `.palantir/setup` to `.palantir/setup/` in order to ensure a single consistent route is used to hit the setup page.