### PR TITLE
Update aggregation types for Regular Aggregations and RDPs pt 2

### DIFF
--- a/.changeset/lemon-humans-cry.md
+++ b/.changeset/lemon-humans-cry.md
@@ -1,0 +1,5 @@
+---
+"@osdk/api": patch
+---
+
+Updates aggregation types to support operations on additional property types

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -1284,6 +1284,7 @@ export type TwoDimensionalQueryAggregationDefinition = AggregationKeyDataType<Ag
 
 // Warning: (ae-forgotten-export) The symbol "AGG_FOR_TYPE" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "WITH_PROPERTIES_AGG_FOR_TYPE" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "WITH_PROPERTIES_AGG_FOR_TYPE" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
 export type ValidAggregationKeys<

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -1283,14 +1283,13 @@ export type TwoDimensionalAggregation<
 export type TwoDimensionalQueryAggregationDefinition = AggregationKeyDataType<AggregationValueTypes>;
 
 // Warning: (ae-forgotten-export) The symbol "AGG_FOR_TYPE" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "GetWirePropertyValueFromClient" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "WITH_PROPERTIES_AGG_FOR_TYPE" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
 export type ValidAggregationKeys<
 	Q extends ObjectOrInterfaceDefinition,
 	R extends "aggregate" | "withPropertiesAggregate" = "aggregate"
-> = keyof ({ [KK in AggregatableKeys<Q> as `${KK & string}:${R extends "aggregate" ? AGG_FOR_TYPE<GetWirePropertyValueFromClient<CompileTimeMetadata<Q>["properties"][KK]["type"]>> : WITH_PROPERTIES_AGG_FOR_TYPE<CompileTimeMetadata<Q>["properties"][KK]["type"]>}`]? : any } & {
+> = keyof ({ [KK in AggregatableKeys<Q> as `${KK & string}:${R extends "aggregate" ? AGG_FOR_TYPE<CompileTimeMetadata<Q>["properties"][KK]["type"]> : WITH_PROPERTIES_AGG_FOR_TYPE<CompileTimeMetadata<Q>["properties"][KK]["type"]>}`]? : any } & {
     	$count?: any
 });
 

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -1284,7 +1284,6 @@ export type TwoDimensionalQueryAggregationDefinition = AggregationKeyDataType<Ag
 
 // Warning: (ae-forgotten-export) The symbol "AGG_FOR_TYPE" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "WITH_PROPERTIES_AGG_FOR_TYPE" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "WITH_PROPERTIES_AGG_FOR_TYPE" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
 export type ValidAggregationKeys<

--- a/packages/api/src/aggregate/AggregatableKeys.ts
+++ b/packages/api/src/aggregate/AggregatableKeys.ts
@@ -45,11 +45,10 @@ export type NumericAggregateOption =
   | "exactDistinct"
   | MinMaxAggregateOption;
 
-type AGG_FOR_TYPE<WIRE_TYPE extends WirePropertyTypes> =
-  GetWirePropertyValueFromClient<WIRE_TYPE> extends number
-    ? NumericAggregateOption
-    : WIRE_TYPE extends "datetime" | "timestamp" ? DatetimeAggregateOption
-    : BaseAggregateOptions;
+type AGG_FOR_TYPE<WIRE_TYPE extends WirePropertyTypes> = number extends
+  GetWirePropertyValueFromClient<WIRE_TYPE> ? NumericAggregateOption
+  : WIRE_TYPE extends "datetime" | "timestamp" ? DatetimeAggregateOption
+  : BaseAggregateOptions;
 
 type WITH_PROPERTIES_AGG_FOR_TYPE<WIRE_TYPE extends WirePropertyTypes> =
   number extends GetWirePropertyValueFromClient<WIRE_TYPE>

--- a/packages/api/src/derivedProperties/WithPropertiesAggregationOptions.ts
+++ b/packages/api/src/derivedProperties/WithPropertiesAggregationOptions.ts
@@ -18,10 +18,11 @@ export type DistinctWithPropAggregateOption =
   | "approximateDistinct"
   | "exactDistinct";
 
+export type CollectWithPropAggregations = "collectSet" | "collectList";
+
 export type BaseWithPropAggregations =
   | DistinctWithPropAggregateOption
-  | "collectSet"
-  | "collectList";
+  | CollectWithPropAggregations;
 
 export type MinMaxWithPropAggregateOption = "min" | "max";
 

--- a/packages/api/src/derivedProperties/WithPropertiesAggregationOptions.ts
+++ b/packages/api/src/derivedProperties/WithPropertiesAggregationOptions.ts
@@ -14,21 +14,30 @@
  * limitations under the License.
  */
 
-export type CollectWithPropAggregations = "collectSet" | "collectList";
-
-export type BaseWithPropAggregations =
+export type DistinctWithPropAggregateOption =
   | "approximateDistinct"
   | "exactDistinct";
 
-export type StringWithPropAggregateOption =
-  | BaseWithPropAggregations
-  | CollectWithPropAggregations;
+export type BaseWithPropAggregations =
+  | DistinctWithPropAggregateOption
+  | "collectSet"
+  | "collectList";
+
+export type MinMaxWithPropAggregateOption = "min" | "max";
+
+export type DatetimeAggregateOption =
+  | MinMaxWithPropAggregateOption
+  | BaseWithPropAggregations;
 
 export type NumericWithPropAggregateOption =
-  | "min"
-  | "max"
   | "sum"
   | "avg"
   | "approximatePercentile"
-  | BaseWithPropAggregations
-  | CollectWithPropAggregations;
+  | MinMaxWithPropAggregateOption
+  | BaseWithPropAggregations;
+
+export type ValidCollectPropertyKeysForSpecialTypes =
+  | "attachment"
+  | "geopoint"
+  | "geoshape"
+  | "boolean";


### PR DESCRIPTION
Copy of #1289 

Allows datetime min/max operations for basic aggregations, as well as cleans up RDP types