### PR TITLE
Fixes RDP types

### DIFF
--- a/.changeset/shiny-ends-learn.md
+++ b/.changeset/shiny-ends-learn.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client": patch
+"@osdk/api": patch
+---
+
+Fix types for RDPs

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -232,7 +232,7 @@ export interface AsyncIterArgs<
 	S extends NullabilityAdherence = NullabilityAdherence.Default,
 	T extends boolean = false,
 	RDP_KEYS extends string = never
-> extends SelectArg<Q, K, R, S, RDP_KEYS>, OrderByArg<Q, PropertyKeys<Q>> {
+> extends SelectArg<Q, K, R, S>, OrderByArg<Q, PropertyKeys<Q>> {
     	// (undocumented)
     $__UNSTABLE_useOldInterfaceApis?: boolean;
     	// (undocumented)
@@ -791,6 +791,23 @@ export interface ObjectQueryDataType<T_Target extends ObjectTypeDefinition = nev
     object: string;
 }
 
+// @public (undocumented)
+export namespace ObjectSet {
+    	// (undocumented)
+    export interface FetchPageSignature<
+    		Q extends ObjectOrInterfaceDefinition,
+    		RDPs extends Record<string, SimplePropertyDef> = {}
+    	> {
+        		// Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+        // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+        // Warning: (ae-forgotten-export) The symbol "ValidFetchPageArgs" needs to be exported by the entry point index.d.ts
+        // Warning: (ae-forgotten-export) The symbol "ExtractOptions2" needs to be exported by the entry point index.d.ts
+        // Warning: (ae-forgotten-export) The symbol "SubSelectKeys" needs to be exported by the entry point index.d.ts
+        // Warning: (ae-forgotten-export) The symbol "SubSelectRDPs" needs to be exported by the entry point index.d.ts
+        <const X extends ValidFetchPageArgs<Q, RDPs> = never>(args?: X): Promise<PageResult<Osdk.Instance<Q, ExtractOptions2<X>, SubSelectKeys<Q, X>, SubSelectRDPs<RDPs, X>>>>;
+        	}
+}
+
 // Warning: (ae-forgotten-export) The symbol "ObjectSetCleanedTypes" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "ExtractRdp" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "MergeObjectSet" needs to be exported by the entry point index.d.ts
@@ -1144,13 +1161,12 @@ export interface SelectArg<
 	Q extends ObjectOrInterfaceDefinition,
 	L extends PropertyKeys<Q> = PropertyKeys<Q>,
 	R extends boolean = false,
-	S extends NullabilityAdherence = NullabilityAdherence.Default,
-	RDP_KEYS extends string = never
+	S extends NullabilityAdherence = NullabilityAdherence.Default
 > {
     	// (undocumented)
     $includeRid?: R;
     	// (undocumented)
-    $select?: readonly (L | RDP_KEYS)[];
+    $select?: readonly L[];
 }
 
 // @public (undocumented)

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -791,23 +791,6 @@ export interface ObjectQueryDataType<T_Target extends ObjectTypeDefinition = nev
     object: string;
 }
 
-// @public (undocumented)
-export namespace ObjectSet {
-    	// (undocumented)
-    export interface FetchPageSignature<
-    		Q extends ObjectOrInterfaceDefinition,
-    		RDPs extends Record<string, SimplePropertyDef> = {}
-    	> {
-        		// Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-        // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-        // Warning: (ae-forgotten-export) The symbol "ValidFetchPageArgs" needs to be exported by the entry point index.d.ts
-        // Warning: (ae-forgotten-export) The symbol "ExtractOptions2" needs to be exported by the entry point index.d.ts
-        // Warning: (ae-forgotten-export) The symbol "SubSelectKeys" needs to be exported by the entry point index.d.ts
-        // Warning: (ae-forgotten-export) The symbol "SubSelectRDPs" needs to be exported by the entry point index.d.ts
-        <const X extends ValidFetchPageArgs<Q, RDPs> = never>(args?: X): Promise<PageResult<Osdk.Instance<Q, ExtractOptions2<X>, SubSelectKeys<Q, X>, SubSelectRDPs<RDPs, X>>>>;
-        	}
-}
-
 // Warning: (ae-forgotten-export) The symbol "ObjectSetCleanedTypes" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "ExtractRdp" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "MergeObjectSet" needs to be exported by the entry point index.d.ts

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -230,8 +230,9 @@ export interface AsyncIterArgs<
 	R extends boolean = false,
 	A extends Augments = never,
 	S extends NullabilityAdherence = NullabilityAdherence.Default,
-	T extends boolean = false
-> extends SelectArg<Q, K, R, S>, OrderByArg<Q, PropertyKeys<Q>> {
+	T extends boolean = false,
+	RDP_KEYS extends string = never
+> extends SelectArg<Q, K, R, S, RDP_KEYS>, OrderByArg<Q, PropertyKeys<Q>> {
     	// (undocumented)
     $__UNSTABLE_useOldInterfaceApis?: boolean;
     	// (undocumented)
@@ -504,8 +505,9 @@ export interface FetchPageArgs<
 	R extends boolean = false,
 	A extends Augments = never,
 	S extends NullabilityAdherence = NullabilityAdherence.Default,
-	T extends boolean = false
-> extends AsyncIterArgs<Q, K, R, A, S, T> {
+	T extends boolean = false,
+	RDP_KEYS extends string = never
+> extends AsyncIterArgs<Q, K, R, A, S, T, RDP_KEYS> {
     	// (undocumented)
     $nextPageToken?: string;
     	// (undocumented)
@@ -796,8 +798,8 @@ export interface ObjectQueryDataType<T_Target extends ObjectTypeDefinition = nev
 // @public (undocumented)
 export interface ObjectSet<
 	Q extends ObjectOrInterfaceDefinition = any,
-	UNUSED_OR_RDP extends ObjectSet<Q, any> | Record<string, SimplePropertyDef> = ObjectSet<Q, any>
-> extends ObjectSetCleanedTypes<Q, ExtractRdp<UNUSED_OR_RDP>, MergeObjectSet<Q, UNUSED_OR_RDP>> {}
+	UNUSED_OR_RDP extends BaseObjectSet<Q> | Record<string, SimplePropertyDef> = never
+> extends ObjectSetCleanedTypes<Q, ExtractRdp<UNUSED_OR_RDP>, MergeObjectSet<Q, ExtractRdp<UNUSED_OR_RDP>>> {}
 
 // @public (undocumented)
 export interface ObjectSetQueryDataType<T_Target extends ObjectTypeDefinition = never> extends BaseQueryDataTypeDefinition<"objectSet"> {
@@ -967,10 +969,7 @@ export interface PropertyDef<
 }
 
 // @public (undocumented)
-export type PropertyKeys<
-	O extends ObjectOrInterfaceDefinition,
-	RDPs extends Record<string, SimplePropertyDef> = {}
-> = (keyof NonNullable<O["__DefinitionMetadata"]>["properties"] | keyof RDPs) & string;
+export type PropertyKeys<O extends ObjectOrInterfaceDefinition> = (keyof NonNullable<O["__DefinitionMetadata"]>["properties"]) & string;
 
 // @public
 export interface PropertyValueWireToClient {
@@ -1145,12 +1144,13 @@ export interface SelectArg<
 	Q extends ObjectOrInterfaceDefinition,
 	L extends PropertyKeys<Q> = PropertyKeys<Q>,
 	R extends boolean = false,
-	S extends NullabilityAdherence = NullabilityAdherence.Default
+	S extends NullabilityAdherence = NullabilityAdherence.Default,
+	RDP_KEYS extends string = never
 > {
     	// (undocumented)
     $includeRid?: R;
     	// (undocumented)
-    $select?: readonly L[];
+    $select?: readonly (L | RDP_KEYS)[];
 }
 
 // @public (undocumented)

--- a/packages/api/src/OsdkObjectFrom.test.ts
+++ b/packages/api/src/OsdkObjectFrom.test.ts
@@ -16,8 +16,7 @@
 
 import { describe, expectTypeOf, it } from "vitest";
 import type { NullabilityAdherence } from "./object/FetchPageArgs.js";
-import type { ObjectSet } from "./objectSet/ObjectSet.js";
-import type { ObjectOrInterfaceDefinition } from "./ontology/ObjectOrInterface.js";
+import { createMockObjectSet } from "./objectSet/ObjectSet.test.js";
 import type { ExtractOptions, Osdk } from "./OsdkObjectFrom.js";
 
 describe("ExtractOptions", () => {
@@ -343,21 +342,12 @@ describe("ExtractOptions", () => {
   });
 
   describe("Inferred return types from fetchPage work", () => {
-    function createObjectSetChannel<O extends ObjectOrInterfaceDefinition>(
-      objectSet: ObjectSet<O>,
-    ): Awaited<ReturnType<ObjectSet<O>["fetchPage"]>>["data"] {
-      return {} as any;
-    }
-
-    class Helper<O extends ObjectOrInterfaceDefinition> {
-      constructor(private objectSet: ObjectSet<O>) {}
-      public go() {
-        return createObjectSetChannel(this.objectSet);
-      }
-    }
+    const fauxObjectSet = createMockObjectSet<quickAndDirty>();
 
     it("is not $notStrict", async () => {
-      expectTypeOf<ReturnType<Helper<quickAndDirty>["go"]>>().branded
+      const page = await fauxObjectSet.fetchPage();
+
+      expectTypeOf<typeof page["data"]>().branded
         .toEqualTypeOf<
           Osdk.Instance<quickAndDirty>[]
         >();

--- a/packages/api/src/object/FetchPageArgs.ts
+++ b/packages/api/src/object/FetchPageArgs.ts
@@ -77,9 +77,6 @@ export interface OrderByArg<
   Q extends ObjectOrInterfaceDefinition,
   L extends PropertyKeys<Q> = PropertyKeys<Q>,
 > extends ObjectSetArgs.OrderBy<L> {
-  // $orderBy?: {
-  //   [K in L]?: "asc" | "desc";
-  // };
 }
 
 export type SelectArgToKeys<

--- a/packages/api/src/object/FetchPageArgs.ts
+++ b/packages/api/src/object/FetchPageArgs.ts
@@ -25,6 +25,44 @@ export namespace NullabilityAdherence {
   export type Default = "throw";
 }
 
+export namespace ObjectSetArgs {
+  export interface Select<
+    OBJECT_KEYS extends string = never,
+    RDP_KEYS extends string = never,
+  > {
+    $select?: readonly (OBJECT_KEYS | RDP_KEYS)[];
+    $includeRid?: boolean;
+  }
+
+  export interface OrderBy<
+    L extends string = never,
+  > {
+    $orderBy?: {
+      [K in L]?: "asc" | "desc";
+    };
+  }
+
+  export interface AsyncIter<
+    Q extends ObjectOrInterfaceDefinition,
+    K extends PropertyKeys<Q> = never,
+    T extends boolean = false,
+    RDP_KEYS extends string = never,
+  > extends Select<K, RDP_KEYS>, OrderBy<K> {
+    $__UNSTABLE_useOldInterfaceApis?: boolean;
+    $includeAllBaseObjectProperties?: PropertyKeys<Q> extends K ? T : never;
+  }
+
+  export interface FetchPage<
+    Q extends ObjectOrInterfaceDefinition,
+    K extends PropertyKeys<Q> = never,
+    T extends boolean = false,
+    RDP_KEYS extends string = never,
+  > extends AsyncIter<Q, K, T, RDP_KEYS> {
+    $nextPageToken?: string;
+    $pageSize?: number;
+  }
+}
+
 export interface SelectArg<
   Q extends ObjectOrInterfaceDefinition,
   L extends PropertyKeys<Q> = PropertyKeys<Q>,
@@ -38,10 +76,10 @@ export interface SelectArg<
 export interface OrderByArg<
   Q extends ObjectOrInterfaceDefinition,
   L extends PropertyKeys<Q> = PropertyKeys<Q>,
-> {
-  $orderBy?: {
-    [K in L]?: "asc" | "desc";
-  };
+> extends ObjectSetArgs.OrderBy<L> {
+  // $orderBy?: {
+  //   [K in L]?: "asc" | "desc";
+  // };
 }
 
 export type SelectArgToKeys<
@@ -58,7 +96,8 @@ export interface FetchPageArgs<
   A extends Augments = never,
   S extends NullabilityAdherence = NullabilityAdherence.Default,
   T extends boolean = false,
-> extends AsyncIterArgs<Q, K, R, A, S, T> {
+  RDP_KEYS extends string = never,
+> extends AsyncIterArgs<Q, K, R, A, S, T, RDP_KEYS> {
   $nextPageToken?: string;
   $pageSize?: number;
 }
@@ -70,6 +109,7 @@ export interface AsyncIterArgs<
   A extends Augments = never,
   S extends NullabilityAdherence = NullabilityAdherence.Default,
   T extends boolean = false,
+  RDP_KEYS extends string = never,
 > extends SelectArg<Q, K, R, S>, OrderByArg<Q, PropertyKeys<Q>> {
   $__UNSTABLE_useOldInterfaceApis?: boolean;
   $includeAllBaseObjectProperties?: PropertyKeys<Q> extends K ? T : never;

--- a/packages/api/src/objectSet/ObjectSet.test.ts
+++ b/packages/api/src/objectSet/ObjectSet.test.ts
@@ -29,14 +29,34 @@ import type { EmployeeApiTest } from "../test/EmployeeApiTest.js";
 export function createMockObjectSet<
   Q extends ObjectOrInterfaceDefinition,
 >(): $ObjectSet<Q, never> {
-  const fauxObjectSet = {
+  let fauxObject: Osdk.Instance<Q>,
+    fauxResults: any,
+    fauxObjectSet: $ObjectSet<Q>;
+
+  // eslint-disable-next-line prefer-const
+  fauxObject = {
+    $link: {
+      peeps: {
+        $objectSetInternals: {
+          def: {},
+        },
+      },
+    },
+  } as Osdk.Instance<Q>;
+
+  fauxResults = {
+    data: [fauxObject],
+  };
+
+  fauxObjectSet = {
     where: vi.fn(() => {
       return fauxObjectSet;
     }),
     withProperties: vi.fn(() => {
       return fauxObjectSet;
     }),
-    fetchPage: vi.fn(() => Promise.resolve({ data: [{}] })),
+    fetchPage: vi.fn(() => Promise.resolve(fauxResults)),
+    fetchOne: vi.fn(() => fauxObject),
     asyncIter: vi.fn(() => {
       return {};
     }),
@@ -140,6 +160,8 @@ describe("ObjectSet", () => {
             "isActive",
             "mediaReference",
             "timeseries",
+            "lastClockIn",
+            "dateOfBirth",
           ],
         });
 
@@ -161,6 +183,8 @@ describe("ObjectSet", () => {
             "isActive",
             "mediaReference",
             "timeseries",
+            "lastClockIn",
+            "dateOfBirth",
           ],
         });
     });
@@ -198,7 +222,6 @@ describe("ObjectSet", () => {
           return base.pivotTo("lead").aggregate("class:exactDistinct");
         },
       });
-      withA.pivotTo("lead");
 
       const isWithAAssignable: $ObjectSet<EmployeeApiTest, {}> = withA;
 

--- a/packages/api/src/objectSet/ObjectSet.test.ts
+++ b/packages/api/src/objectSet/ObjectSet.test.ts
@@ -16,10 +16,19 @@
 
 import { describe, expectTypeOf, it, test, vi } from "vitest";
 
-import type { ObjectSet as $ObjectSet, Osdk, PropertyKeys } from "../index.js";
+import type {
+  NullabilityAdherence,
+  ObjectOrInterfaceDefinition,
+  ObjectSet as $ObjectSet,
+  Osdk,
+  PageResult,
+  PropertyKeys,
+} from "../index.js";
 import type { EmployeeApiTest } from "../test/EmployeeApiTest.js";
 
-describe("ObjectSet", () => {
+export function createMockObjectSet<
+  Q extends ObjectOrInterfaceDefinition,
+>(): $ObjectSet<Q, never> {
   const fauxObjectSet = {
     where: vi.fn(() => {
       return fauxObjectSet;
@@ -34,13 +43,32 @@ describe("ObjectSet", () => {
     aggregate: vi.fn(() => {
       return {};
     }),
-  } as any as EmployeeApiTest.ObjectSet;
+    pivotTo: vi.fn(() => {
+      return fauxObjectSet;
+    }),
+  } as any as $ObjectSet<Q>;
+
+  return fauxObjectSet;
+}
+
+describe("ObjectSet", () => {
+  const fauxObjectSet = createMockObjectSet<EmployeeApiTest>();
 
   describe("normal", () => {
     test("select none", async () => {
       const result = await fauxObjectSet.fetchPage();
       expectTypeOf<typeof result.data[0]>().toEqualTypeOf<
-        Osdk.Instance<EmployeeApiTest, never>
+        Osdk.Instance<EmployeeApiTest, never, PropertyKeys<EmployeeApiTest>>
+      >();
+
+      // Do it again but be explicit about the params to be sure
+      // we don't break them
+      const result2 = await fauxObjectSet.fetchPage<
+        PropertyKeys<EmployeeApiTest>,
+        false,
+        never,
+        NullabilityAdherence.Default,
+        false
       >();
     });
 
@@ -52,6 +80,117 @@ describe("ObjectSet", () => {
     });
   });
 
+  describe("includeAllBaseObjectProperties", () => {
+    it("has the right types if you pass true", async () => {
+      const fetchPageResult = await fauxObjectSet
+        .where({ class: "idk" })
+        .fetchPage({ $includeAllBaseObjectProperties: true });
+
+      expectTypeOf(fetchPageResult).toEqualTypeOf<
+        PageResult<
+          Osdk.Instance<EmployeeApiTest, "$allBaseProperties">
+        >
+      >();
+
+      const asyncIterResult = fauxObjectSet
+        .where({ class: "idk" })
+        .asyncIter({ $includeAllBaseObjectProperties: true });
+
+      expectTypeOf(asyncIterResult).toEqualTypeOf<
+        AsyncIterableIterator<
+          Osdk.Instance<EmployeeApiTest, "$allBaseProperties">
+        >
+      >();
+    });
+
+    it("does not let you pass partial $select and true", async () => {
+      const fetchPageResult = await fauxObjectSet
+        .where({ class: "idk" })
+        .fetchPage({
+          // @ts-expect-error
+          $includeAllBaseObjectProperties: true,
+          $select: ["attachment"],
+        });
+
+      const asyncIterResult = fauxObjectSet
+        .where({ class: "idk" })
+        .asyncIter({
+          // @ts-expect-error
+          $includeAllBaseObjectProperties: true,
+          $select: ["attachment"],
+        });
+    });
+
+    it("does let you pass full select options and false", async () => {
+      const fetchPageResult = await fauxObjectSet
+        .where({ class: "idk" })
+        .fetchPage({
+          $includeAllBaseObjectProperties: true,
+
+          // this select list is intended to represent all properties on `EmployeeApiTest`,
+          // so if you get an error here later and you added properties to that object,
+          // be sure to add them here too.
+          $select: [
+            "attachment",
+            "class",
+            "employeeId",
+            "fullName",
+            "geopoint",
+            "geotimeSeriesReference",
+            "isActive",
+            "mediaReference",
+            "timeseries",
+          ],
+        });
+
+      const asyncIterResult = await fauxObjectSet
+        .where({ class: "idk" })
+        .fetchPage({
+          $includeAllBaseObjectProperties: true,
+
+          // this select list is intended to represent all properties on `EmployeeApiTest`,
+          // so if you get an error here later and you added properties to that object,
+          // be sure to add them here too.
+          $select: [
+            "attachment",
+            "class",
+            "employeeId",
+            "fullName",
+            "geopoint",
+            "geotimeSeriesReference",
+            "isActive",
+            "mediaReference",
+            "timeseries",
+          ],
+        });
+    });
+  });
+
+  test("includeRid", async () => {
+    const x = await fauxObjectSet
+      .where({ class: "idk" })
+      .fetchPage({ $includeRid: true });
+
+    expectTypeOf(x).toEqualTypeOf<
+      PageResult<
+        Osdk.Instance<EmployeeApiTest, "$rid">
+      >
+    >();
+  });
+
+  test("pivotTo", async () => {
+    const noArgs = await fauxObjectSet.pivotTo("peeps").fetchPage({});
+    const subselect = await fauxObjectSet.pivotTo("peeps").fetchPage({
+      $select: ["employeeId", "class"],
+    });
+
+    expectTypeOf(subselect).toEqualTypeOf<
+      PageResult<
+        Osdk.Instance<EmployeeApiTest, never, "employeeId" | "class">
+      >
+    >();
+  });
+
   describe(".withProperties", () => {
     test("single property", async () => {
       const withA = fauxObjectSet.withProperties({
@@ -59,6 +198,9 @@ describe("ObjectSet", () => {
           return base.pivotTo("lead").aggregate("class:exactDistinct");
         },
       });
+      withA.pivotTo("lead");
+
+      const isWithAAssignable: $ObjectSet<EmployeeApiTest, {}> = withA;
 
       expectTypeOf(withA).toEqualTypeOf<
         $ObjectSet<EmployeeApiTest, {
@@ -76,6 +218,15 @@ describe("ObjectSet", () => {
 
       expectTypeOf<typeof withAResults["data"][0]["a"]>()
         .toEqualTypeOf<number>();
+    });
+
+    it("can be sub-selected", () => {
+      const objectWithUndefinedRdp = fauxObjectSet.withProperties({
+        "derivedPropertyName": (base) =>
+          base.pivotTo("lead").selectProperty("employeeId"),
+      }).fetchOne(3, {
+        $select: ["derivedPropertyName"],
+      });
     });
 
     test("multiple properties", async () => {
@@ -206,6 +357,37 @@ describe("ObjectSet", () => {
         const where = withFamily.where({ "mom": 1 });
         const whereResults = await where.fetchPage();
 
+        // Checks that if you did an `await where.fetchPage()` that you can then
+        // pass/assign it to something explicit.
+        const _assignPreviouslyInferredPages: PageResult<
+          Osdk.Instance<
+            EmployeeApiTest,
+            never,
+            PropertyKeys<EmployeeApiTest>,
+            {
+              mom: "integer";
+              dad: "string" | undefined;
+              sister: "string"[] | undefined;
+            }
+          >
+        > = whereResults;
+
+        // Checks that if you did an `await where.fetchPage()` that you can then
+        // pass/assign it to something explicit.
+        const _assignPreviouslyInferredInstance: Osdk.Instance<
+          EmployeeApiTest,
+          never,
+          PropertyKeys<EmployeeApiTest>,
+          {
+            mom: "integer";
+            dad: "string" | undefined;
+            sister: "string"[] | undefined;
+          }
+        > = whereResults.data[0];
+
+        const q = whereResults.data[0].$link.peeps.$objectSetInternals.def;
+
+        // same as above but with expectTypeOf
         expectTypeOf<typeof where>().toEqualTypeOf<typeof withFamily>();
         expectTypeOf<typeof whereResults["data"][0]>()
           .toEqualTypeOf<
@@ -220,6 +402,34 @@ describe("ObjectSet", () => {
               }
             >
           >();
+
+        // Checks that when you directly assign, it infers correctly.
+        // Sometimes an explicit assignment can affect how typescript infers
+        // types.
+        const shouldBeAssignablePage: PageResult<
+          Osdk.Instance<
+            EmployeeApiTest,
+            never,
+            PropertyKeys<EmployeeApiTest>,
+            {
+              mom: "integer";
+              dad: "string" | undefined;
+              sister: "string"[] | undefined;
+            }
+          >
+        > = await where.fetchPage();
+
+        const _shouldBeAssignableSingle: Osdk.Instance<
+          EmployeeApiTest,
+          never,
+          PropertyKeys<EmployeeApiTest>,
+          {
+            mom: "integer";
+            dad: "string" | undefined;
+            sister: "string"[] | undefined;
+          }
+        > = await withFamily.fetchOne(1);
+        await withFamily.fetchOne(1);
       });
 
       it("works with .async", () => {

--- a/packages/api/src/objectSet/ObjectSet.ts
+++ b/packages/api/src/objectSet/ObjectSet.ts
@@ -24,10 +24,10 @@ import type {
   Augments,
   FetchPageArgs,
   NullabilityAdherence,
+  ObjectSetArgs,
   SelectArg,
 } from "../object/FetchPageArgs.js";
 import type { Result } from "../object/Result.js";
-import type { InterfaceDefinition } from "../ontology/InterfaceDefinition.js";
 import type {
   DerivedObjectOrInterfaceDefinition,
   ObjectOrInterfaceDefinition,
@@ -39,7 +39,12 @@ import type {
 } from "../ontology/ObjectTypeDefinition.js";
 import type { SimplePropertyDef } from "../ontology/SimplePropertyDef.js";
 import type { PrimaryKeyType } from "../OsdkBase.js";
-import type { ExtractOptions, Osdk } from "../OsdkObjectFrom.js";
+import type {
+  ExtractAllPropertiesOption,
+  ExtractOptions,
+  ExtractRidOption,
+  Osdk,
+} from "../OsdkObjectFrom.js";
 import type { PageResult } from "../PageResult.js";
 import type { LinkedType, LinkNames } from "../util/LinkUtils.js";
 import type { BaseObjectSet } from "./BaseObjectSet.js";
@@ -47,14 +52,50 @@ import type { ObjectSetSubscription } from "./ObjectSetListener.js";
 
 type MergeObjectSet<
   Q extends ObjectOrInterfaceDefinition,
-  D extends ObjectSet<Q> | Record<string, SimplePropertyDef> = {},
-> = D extends Record<string, SimplePropertyDef>
-  ? DerivedObjectOrInterfaceDefinition.WithDerivedProperties<Q, D>
-  : Q;
+  D extends Record<string, SimplePropertyDef> = {},
+> = DerivedObjectOrInterfaceDefinition.WithDerivedProperties<Q, D>;
 
 type ExtractRdp<
-  D extends ObjectSet<any, any> | Record<string, SimplePropertyDef>,
-> = D extends Record<string, SimplePropertyDef> ? D : {};
+  D extends
+    | BaseObjectSet<any>
+    | Record<string, SimplePropertyDef>,
+> = [D] extends [never] ? {}
+  : D extends BaseObjectSet<any> ? {}
+  : D extends Record<string, SimplePropertyDef> ? D
+  : {};
+
+type MaybeSimplifyPropertyKeys<
+  Q extends ObjectOrInterfaceDefinition,
+  L extends PropertyKeys<Q>,
+> = PropertyKeys<Q> extends L ? PropertyKeys<Q> : L;
+
+type SubSelectKeysHelper<
+  Q extends ObjectOrInterfaceDefinition,
+  L extends string,
+> = [L] extends [never] ? PropertyKeys<Q>
+  : PropertyKeys<Q> extends L ? PropertyKeys<Q>
+  : L & PropertyKeys<Q>;
+
+type SubSelectKeys<
+  Q extends ObjectOrInterfaceDefinition,
+  X extends SelectArg<Q, PropertyKeys<Q>, any, any> = never,
+> = SubSelectKeysHelper<Q, Extract$Select<X>>;
+
+type NOOP<T> = T extends (...args: any[]) => any ? T
+  : T extends abstract new(...args: any[]) => any ? T
+  : { [K in keyof T]: T[K] };
+
+type SubSelectRDPsHelper<
+  X extends ValidFetchPageArgs<any, any> | ValidAsyncIterArgs<any, any>,
+  DEFAULT extends string,
+> = [X] extends [never] ? DEFAULT
+  : (X["$select"] & string[])[number] & DEFAULT;
+
+type SubSelectRDPs<
+  RDPs extends Record<string, SimplePropertyDef>,
+  X extends ValidFetchPageArgs<any, RDPs> | ValidAsyncIterArgs<any, RDPs>,
+> = [RDPs] extends [never] ? never
+  : NOOP<{ [K in SubSelectRDPsHelper<X, string & keyof RDPs>]: RDPs[K] }>;
 
 export interface MinimalObjectSet<
   Q extends ObjectOrInterfaceDefinition,
@@ -67,8 +108,65 @@ export interface MinimalObjectSet<
 {
 }
 
-// TODO MOVE THIS
+export type ExtractOptions2<
+  X extends FetchPageArgs<any, any, any, any, any, any, any>,
+> = [X] extends [never] ? never
+  :
+    | ExtractRidOption<X["$includeRid"] extends true ? true : false>
+    | ExtractAllPropertiesOption<
+      X["$includeAllBaseObjectProperties"] extends true ? true : false
+    >;
+
+type Extract$Select<X extends FetchPageArgs<any, any>> = NonNullable<
+  X["$select"]
+>[number];
+
 interface FetchPage<
+  Q extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef> = {},
+> {
+  readonly fetchPage: FetchPageSignature<Q, RDPs>;
+  readonly fetchPageWithErrors: FetchPageWithErrorsSignature<Q, RDPs>;
+}
+
+type ValidFetchPageArgs<
+  Q extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef>,
+> =
+  | ObjectSetArgs.FetchPage<
+    Q,
+    PropertyKeys<Q>,
+    false,
+    string & keyof RDPs
+  >
+  | ObjectSetArgs.FetchPage<
+    Q,
+    never,
+    true,
+    string & keyof RDPs
+  >;
+
+type ValidAsyncIterArgs<
+  Q extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef>,
+> =
+  | ObjectSetArgs.AsyncIter<
+    Q,
+    PropertyKeys<Q>,
+    false,
+    string & keyof RDPs
+  >
+  | AsyncIterArgs<
+    Q,
+    never,
+    any,
+    any,
+    any,
+    true,
+    string & keyof RDPs
+  >;
+
+interface FetchPageSignature<
   Q extends ObjectOrInterfaceDefinition,
   RDPs extends Record<string, SimplePropertyDef> = {},
 > {
@@ -84,21 +182,79 @@ interface FetchPage<
 
    * @returns a page of objects
    */
-  readonly fetchPage: <
-    L extends PropertyKeys<Q, RDPs>,
+  <const X extends ValidFetchPageArgs<Q, RDPs> = never>(
+    args?: X,
+  ): Promise<
+    PageResult<
+      Osdk.Instance<
+        Q,
+        ExtractOptions2<X>,
+        SubSelectKeys<Q, X>,
+        SubSelectRDPs<RDPs, X>
+      >
+    >
+  >;
+
+  /**
+   * Gets a page of objects of this type, with a result wrapper
+   * @param args - Args to specify next page token and page size, if applicable
+   * @example
+   *  const myObjs = await objectSet.fetchPage({
+      $pageSize: 10,
+      $nextPageToken: "nextPage"
+    });
+     const myObjsResult = myObjs.data;
+
+   * @returns a page of objects
+   */
+  <
+    L extends PropertyKeys<Q>,
     R extends boolean,
     const A extends Augments,
     S extends NullabilityAdherence = NullabilityAdherence.Default,
     T extends boolean = false,
   >(
     args?: FetchPageArgs<Q, L, R, A, S, T>,
-  ) => Promise<
+  ): Promise<
     PageResult<
       Osdk.Instance<
         Q,
         ExtractOptions<R, S, T>,
-        PropertyKeys<Q> extends L ? PropertyKeys<Q> : PropertyKeys<Q> & L,
-        { [K in Extract<keyof RDPs, L>]: RDPs[K] }
+        MaybeSimplifyPropertyKeys<Q, L>
+      >
+    >
+  >;
+}
+
+interface FetchPageWithErrorsSignature<
+  Q extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef> = {},
+> {
+  /**
+   * Gets a page of objects of this type, with a result wrapper
+   * @param args - Args to specify next page token and page size, if applicable
+   * @example
+   *  const myObjs = await objectSet.fetchPage({
+      $pageSize: 10,
+      $nextPageToken: "nextPage"
+    });
+
+     if(isOk(myObjs)){
+     const myObjsResult = myObjs.value.data;
+    }
+   * @returns a page of objects, wrapped in a result wrapper
+   */
+  <X extends ValidFetchPageArgs<Q, RDPs> = never>(
+    args?: X,
+  ): Promise<
+    Result<
+      PageResult<
+        Osdk.Instance<
+          Q,
+          ExtractOptions2<X>,
+          SubSelectKeys<Q, X>,
+          SubSelectRDPs<RDPs, X>
+        >
       >
     >
   >;
@@ -117,22 +273,21 @@ interface FetchPage<
     }
    * @returns a page of objects, wrapped in a result wrapper
    */
-  readonly fetchPageWithErrors: <
-    L extends PropertyKeys<Q, RDPs>,
+  <
+    L extends PropertyKeys<Q>,
     R extends boolean,
     const A extends Augments,
     S extends NullabilityAdherence = NullabilityAdherence.Default,
     T extends boolean = false,
   >(
     args?: FetchPageArgs<Q, L, R, A, S, T>,
-  ) => Promise<
+  ): Promise<
     Result<
       PageResult<
         Osdk.Instance<
           Q,
           ExtractOptions<R, S, T>,
-          PropertyKeys<Q> extends L ? PropertyKeys<Q> : PropertyKeys<Q> & L,
-          { [K in Extract<keyof RDPs, L>]: RDPs[K] }
+          MaybeSimplifyPropertyKeys<Q, L>
         >
       >
     >
@@ -159,7 +314,7 @@ interface Where<
   ) => this;
 }
 
-interface AsyncIter<
+interface AsyncIterSignature<
   Q extends ObjectOrInterfaceDefinition,
   RDPs extends Record<string, SimplePropertyDef> = {},
 > {
@@ -171,27 +326,47 @@ interface AsyncIter<
    * }
    * @returns an async iterator to load all objects
    */
-  readonly asyncIter: <
-    L extends PropertyKeys<Q, RDPs>,
+  <X extends ValidAsyncIterArgs<Q, RDPs> = never>(
+    args?: X,
+  ): AsyncIterableIterator<
+    Osdk.Instance<
+      Q,
+      ExtractOptions2<X>,
+      SubSelectKeys<Q, X>,
+      SubSelectRDPs<RDPs, X>
+    >
+  >;
+
+  /**
+   * Returns an async iterator to load all objects of this type
+   * @example
+   * for await (const obj of myObjectSet.asyncIter()){
+   * // Handle obj
+   * }
+   * @returns an async iterator to load all objects
+   */
+  <
+    L extends PropertyKeys<Q>,
     R extends boolean,
     const A extends Augments,
     S extends NullabilityAdherence = NullabilityAdherence.Default,
     T extends boolean = false,
   >(
     args?: AsyncIterArgs<Q, L, R, A, S, T>,
-  ) => AsyncIterableIterator<
+  ): AsyncIterableIterator<
     Osdk.Instance<
       Q,
       ExtractOptions<R, S, T>,
-      PropertyKeys<Q> extends L ? PropertyKeys<Q> : PropertyKeys<Q> & L,
-      { [K in Extract<keyof RDPs, L>]: RDPs[K] }
+      MaybeSimplifyPropertyKeys<Q, L>
     >
   >;
 }
 
-interface InterfaceObjectSet<
-  Q extends InterfaceDefinition,
-> extends MinimalObjectSet<Q> {
+interface AsyncIter<
+  Q extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef> = {},
+> {
+  asyncIter: AsyncIterSignature<Q, RDPs>;
 }
 
 interface WithProperties<
@@ -216,13 +391,14 @@ export interface ObjectSet<
   Q extends ObjectOrInterfaceDefinition = any,
   // Generated code has what is basically ObjectSet<Q> set in here
   // but we never used it so I am repurposing it for RDP
-  UNUSED_OR_RDP extends ObjectSet<Q, any> | Record<string, SimplePropertyDef> =
-    ObjectSet<Q, any>,
+  UNUSED_OR_RDP extends
+    | BaseObjectSet<Q>
+    | Record<string, SimplePropertyDef> = never,
 > extends
   ObjectSetCleanedTypes<
     Q,
     ExtractRdp<UNUSED_OR_RDP>,
-    MergeObjectSet<Q, UNUSED_OR_RDP>
+    MergeObjectSet<Q, ExtractRdp<UNUSED_OR_RDP>>
   >
 {
 }
@@ -314,53 +490,99 @@ interface PivotTo<
    */
   readonly pivotTo: <L extends LinkNames<Q>>(
     type: L,
-  ) => CompileTimeMetadata<LinkedType<Q, L>>["objectSet"]; // ObjectSet<LinkedType<Q, L>>;
+  ) => ObjectSet<LinkedType<Q, L>>;
+}
+
+interface FetchOneSignature<
+  Q extends ObjectTypeDefinition,
+  RDPs extends Record<string, SimplePropertyDef>,
+> {
+  /**
+   * Fetches one object with the specified primary key, without a result wrapper
+   */
+  <
+    X extends ObjectSetArgs.Select<PropertyKeys<Q>, string & keyof RDPs> =
+      never,
+  >(
+    primaryKey: PrimaryKeyType<Q>,
+    options?: X,
+  ): Promise<
+    Osdk.Instance<
+      Q,
+      ExtractOptions2<X>,
+      SubSelectKeys<Q, X>,
+      SubSelectRDPs<RDPs, X>
+    >
+  >;
+
+  /**
+   * Fetches one object with the specified primary key, without a result wrapper
+   */
+  <
+    const L extends PropertyKeys<Q>,
+    const R extends boolean,
+    const S extends false | "throw" = NullabilityAdherence.Default,
+  >(
+    primaryKey: PrimaryKeyType<Q>,
+    options?: SelectArg<Q, L, R, S>,
+  ): Promise<
+    Osdk.Instance<
+      Q,
+      ExtractOptions<R, S>,
+      MaybeSimplifyPropertyKeys<Q, L>
+    >
+  >;
+}
+
+interface FetchOneWithErrorsSignature<
+  Q extends ObjectTypeDefinition,
+  RDPs extends Record<string, SimplePropertyDef>,
+> {
+  /**
+   * Fetches one object with the specified primary key, with a result wrapper
+   */
+  <X extends ObjectSetArgs.Select<PropertyKeys<Q>, string & keyof RDPs>>(
+    primaryKey: PrimaryKeyType<Q>,
+    options?: X,
+  ): Promise<
+    Result<
+      Osdk.Instance<
+        Q,
+        ExtractOptions2<X>,
+        SubSelectKeys<Q, X>,
+        SubSelectRDPs<RDPs, X>
+      >
+    >
+  >;
+
+  /**
+   * Fetches one object with the specified primary key, with a result wrapper
+   */
+  <
+    const L extends PropertyKeys<Q>,
+    const R extends boolean,
+    const S extends false | "throw" = NullabilityAdherence.Default,
+  >(
+    primaryKey: PrimaryKeyType<Q>,
+    options?: SelectArg<Q, L, R, S>,
+  ): Promise<
+    Result<
+      Osdk.Instance<
+        Q,
+        ExtractOptions<R, S>,
+        MaybeSimplifyPropertyKeys<Q, L>
+      >
+    >
+  >;
 }
 
 interface FetchOne<
   Q extends ObjectOrInterfaceDefinition,
   RDPs extends Record<string, SimplePropertyDef>,
 > {
-  /**
-   * Fetches one object with the specified primary key, without a result wrapper
-   */
-  readonly fetchOne: Q extends ObjectTypeDefinition ? <
-      const L extends PropertyKeys<Q, RDPs>,
-      const R extends boolean,
-      const S extends false | "throw" = NullabilityAdherence.Default,
-    >(
-      primaryKey: PrimaryKeyType<Q>,
-      options?: SelectArg<Q, L, R, S>,
-    ) => Promise<
-      Osdk.Instance<
-        Q,
-        ExtractOptions<R, S>,
-        PropertyKeys<Q> extends L ? PropertyKeys<Q> : PropertyKeys<Q> & L,
-        { [K in Extract<keyof RDPs, L>]: RDPs[K] }
-      >
-    >
-    : never;
-
-  /**
-   * Fetches one object with the specified primary key, with a result wrapper
-   */
-  readonly fetchOneWithErrors: Q extends ObjectTypeDefinition ? <
-      L extends PropertyKeys<Q, RDPs>,
-      R extends boolean,
-      S extends false | "throw" = NullabilityAdherence.Default,
-    >(
-      primaryKey: PrimaryKeyType<Q>,
-      options?: SelectArg<Q, L, R, S>,
-    ) => Promise<
-      Result<
-        Osdk.Instance<
-          Q,
-          ExtractOptions<R, S>,
-          PropertyKeys<Q> extends L ? PropertyKeys<Q> : PropertyKeys<Q> & L,
-          { [K in Extract<keyof RDPs, L>]: RDPs[K] }
-        >
-      >
-    >
+  fetchOne: Q extends ObjectTypeDefinition ? FetchOneSignature<Q, RDPs> : never;
+  fetchOneWithErrors: Q extends ObjectTypeDefinition
+    ? FetchOneWithErrorsSignature<Q, RDPs>
     : never;
 }
 
@@ -385,13 +607,13 @@ interface Subscribe<
 interface ObjectSetCleanedTypes<
   Q extends ObjectOrInterfaceDefinition,
   D extends Record<string, SimplePropertyDef>,
-  MERGED extends ObjectOrInterfaceDefinition,
+  MERGED extends ObjectOrInterfaceDefinition & Q,
 > extends
   MinimalObjectSet<Q, D>,
   WithProperties<Q, D>,
   Aggregate<MERGED>,
   SetArithmetic<MERGED>,
-  PivotTo<MERGED>,
+  PivotTo<Q>,
   FetchOne<Q, D>,
   Subscribe<MERGED>
 {

--- a/packages/api/src/ontology/ObjectOrInterface.ts
+++ b/packages/api/src/ontology/ObjectOrInterface.ts
@@ -40,7 +40,6 @@ export namespace DerivedObjectOrInterfaceDefinition {
 
 export type PropertyKeys<
   O extends ObjectOrInterfaceDefinition,
-  RDPs extends Record<string, SimplePropertyDef> = {},
 > =
-  & (keyof NonNullable<O["__DefinitionMetadata"]>["properties"] | keyof RDPs)
+  & (keyof NonNullable<O["__DefinitionMetadata"]>["properties"])
   & string;

--- a/packages/client/src/object/convertWireToOsdkObjects/getDollarLink.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/getDollarLink.ts
@@ -18,6 +18,7 @@ import type {
   ObjectSet,
   OsdkObjectLinksObject,
   SelectArg,
+  SingleLinkAccessor,
   WhereClause,
 } from "@osdk/api";
 import { getWireObjectSet } from "../../objectSet/createObjectSet.js";
@@ -49,21 +50,25 @@ export function get$link(
 
         const value = !linkDef.multiplicity
           ? {
-            fetchOne: <A extends SelectArg<any>>(options?: A) =>
+            fetchOne: <A extends SelectArg<any, any, any, any>>(
+              options?: A,
+            ) =>
               fetchSingle(
                 client,
                 objDef,
                 options ?? {},
                 getWireObjectSet(objectSet),
               ),
-            fetchOneWithErrors: <A extends SelectArg<any>>(options?: A) =>
+            fetchOneWithErrors: <A extends SelectArg<any, any, any, any>>(
+              options?: A,
+            ) =>
               fetchSingleWithErrors(
                 client,
                 objDef,
                 options ?? {},
                 getWireObjectSet(objectSet),
               ),
-          }
+          } as SingleLinkAccessor<any>
           : objectSet;
 
         return [linkName, value];

--- a/packages/client/src/objectSet/createObjectSet.ts
+++ b/packages/client/src/objectSet/createObjectSet.ts
@@ -86,7 +86,7 @@ export function createObjectSet<Q extends ObjectOrInterfaceDefinition>(
       augmentRequestContext(clientCtx, _ => ({ finalMethodCall: "aggregate" })),
       objectType,
       objectSet,
-    ),
+    ) as ObjectSet<Q>["aggregate"],
 
     fetchPage: fetchPageInternal.bind(
       globalThis,

--- a/packages/client/src/observable/internal/testUtils.ts
+++ b/packages/client/src/observable/internal/testUtils.ts
@@ -17,6 +17,7 @@
 import type {
   ActionDefinition,
   ActionEditResponse,
+  FetchPageArgs,
   InterfaceDefinition,
   ObjectOrInterfaceDefinition,
   ObjectSet,
@@ -235,7 +236,7 @@ export function createClientMockHelper(): MockClientHelper {
     const d = pDefer<X>();
 
     const objectSet: ObjectSet<ObjectTypeDefinition> = {
-      fetchPage: async (fetchPageArgs) => {
+      fetchPage: async (fetchPageArgs: FetchPageArgs<any>) => {
         mockLog("fetchPage", fetchPageArgs);
         const r = await d.promise;
         return { ...r, $primaryKey: fetchPageArgs };
@@ -260,7 +261,7 @@ export function createClientMockHelper(): MockClientHelper {
 
     client.mockReturnValueOnce(
       {
-        fetchOne: async (a) => {
+        fetchOne: async (a: FetchPageArgs<any>) => {
           mockLog("fetchOne", a);
           invariant(
             expectedId === undefined || a === expectedId,
@@ -269,9 +270,11 @@ export function createClientMockHelper(): MockClientHelper {
           const r = await d.promise;
           invariant(
             r.$primaryKey === a,
-            `expected id to match. Got ${a} but object to return was ${r.$primaryKey}`,
+            `expected id to match. Got ${
+              JSON.stringify(a)
+            } but object to return was ${r.$primaryKey}`,
           );
-          return r;
+          return r as Osdk.Instance<any>;
         },
       } as Pick<ObjectSet<ObjectTypeDefinition>, "fetchOne">,
     );

--- a/packages/e2e.sandbox.catchall/src/runInterfacesTest2.ts
+++ b/packages/e2e.sandbox.catchall/src/runInterfacesTest2.ts
@@ -62,6 +62,7 @@ export async function runInterfacesTest2(): Promise<void> {
     >
   >(true);
 
+  // You cannot specify both $select and $includeAllBaseObjectProperties
   const athletesNotAllSelected = await dsClient(Athlete).where({
     name22: { $eq: "Michael Jordan" },
   }).fetchPage({


### PR DESCRIPTION
Rough gist, if you assigned the result of loading RDPs, the typechecker might infer the wrong thing. If you had let it assign to a typeless const and then compared it was fine though! Very strange.

Basically this should have worked in `ObjectSet.test.ts` and didn't:

```ts
    const shouldBeAssignablePage: PageResult<
          Osdk.Instance<
            EmployeeApiTest,
            never,
            PropertyKeys<EmployeeApiTest>,
            {
              mom: "integer";
              dad: "string" | undefined;
              sister: "string"[] | undefined;
            }
          >
        > = await withFamily.fetchPage();

        const shouldBeAssignableSingle: Osdk.Instance<
          EmployeeApiTest,
          never,
          PropertyKeys<EmployeeApiTest>,
          {
            mom: "integer";
            dad: "string" | undefined;
            sister: "string"[] | undefined;
          }
        > = await withFamily.fetchOne(1);
```