### PR TITLE
Improve logging for client

### DIFF
--- a/.changeset/sharp-rice-press.md
+++ b/.changeset/sharp-rice-press.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Exposes MinimalLogger and BrowserLogger via @osdk/client/internal

--- a/.changeset/swift-frogs-help.md
+++ b/.changeset/swift-frogs-help.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Default logging is error level only

--- a/packages/client/src/logger/BaseLogger.ts
+++ b/packages/client/src/logger/BaseLogger.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import type { LogFn, Logger } from "./Logger.js";
+import type { Logger } from "@osdk/api";
+import type { LogFn } from "./Logger.js";
 
-function noop() {
+export function noop(): any {
 }
 
 interface LoggerConstructor {
@@ -48,7 +49,21 @@ export abstract class BaseLogger implements Logger {
     this.bindings = bindings;
     this.options = options;
     this.#factory = factory;
+
+    for (
+      const k of ["trace", "debug", "info", "warn", "error", "fatal"] as const
+    ) {
+      if (this.options?.level && !this.isLevelEnabled(k)) {
+        continue;
+      }
+      this[k] = this.createLogMethod(k, bindings);
+    }
   }
+
+  protected abstract createLogMethod(
+    name: "trace" | "debug" | "info" | "warn" | "error" | "fatal",
+    bindings: Record<string, any>,
+  ): LogFn;
 
   trace: LogFn = noop;
   debug: LogFn = noop;

--- a/packages/client/src/logger/BrowserLogger.ts
+++ b/packages/client/src/logger/BrowserLogger.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Logger } from "@osdk/api";
+import { BaseLogger } from "./BaseLogger.js";
+import type { LogFn } from "./Logger.js";
+
+function createStyle({ color }: { color: string }) {
+  return `color: ${color}; border: 1px solid ${color}; padding: 2px; border-radius: 3px;`;
+}
+
+const levelStyles = {
+  debug: createStyle({
+    color: "LightBlue",
+  }),
+  error: createStyle({
+    color: "red",
+  }),
+  fatal: createStyle({
+    color: "red",
+  }),
+  info: createStyle({
+    color: "green",
+  }),
+  trace: createStyle({
+    color: "gray",
+  }),
+  warn: createStyle({
+    color: "orange",
+  }),
+};
+
+export class BrowserLogger extends BaseLogger implements Logger {
+  constructor(
+    bindings: Record<string, any> = {},
+    options: { level?: string; msgPrefix?: string } = {},
+  ) {
+    super(
+      bindings,
+      { ...options, level: options.level ?? "error" },
+      BrowserLogger,
+    );
+  }
+
+  protected createLogMethod(
+    name: "trace" | "debug" | "info" | "warn" | "error" | "fatal",
+    bindings: Record<string, any>,
+  ): LogFn {
+    const msgs: string[] = [`%c${name}%c`];
+    const styles: string[] = [levelStyles[name], ""];
+
+    if (this.options?.msgPrefix) {
+      msgs.push(`%c${this.options.msgPrefix}%c`);
+      styles.push(
+        "font-style: italic; color: gray",
+        "",
+      );
+    }
+
+    if (typeof bindings === "object" && "methodName" in bindings) {
+      msgs.push(`%c.${bindings.methodName}()%c`);
+      styles.push(
+        "font-style: italic;color: orchid",
+        "",
+      );
+    }
+
+    return (...args: any[]): any => {
+      // eslint-disable-next-line no-console
+      console[name === "fatal" ? "error" : name](
+        msgs.join(" "),
+        ...styles,
+        ...args,
+      );
+    };
+  }
+}

--- a/packages/client/src/logger/MinimalLogger.test.ts
+++ b/packages/client/src/logger/MinimalLogger.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { MockInstance } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MinimalLogger } from "./MinimalLogger.js";
+
+const orderedLevels = [
+  "trace",
+  "debug",
+  "info",
+  "warn",
+  "error",
+  "fatal",
+] as const;
+
+describe(MinimalLogger, () => {
+  const consoleTypes = ["log", "error", "warn", "trace"] as const;
+  type consoleTypes = typeof consoleTypes[number];
+
+  const consoleMocks = Object.fromEntries(
+    consoleTypes.map(name =>
+      [name, vi.spyOn(console, name)] as [consoleTypes, MockInstance<any>]
+    ),
+  ) as Record<
+    typeof consoleTypes[number],
+    MockInstance<any>
+  >;
+
+  beforeEach(() => {
+    for (const consoleMock of Object.values(consoleMocks)) {
+      consoleMock.mockClear();
+    }
+  });
+
+  it("does not debug log by default", () => {
+    const logger = new MinimalLogger();
+    logger.debug("hi");
+
+    for (const consoleMock of Object.values(consoleMocks)) {
+      expect(consoleMock).not.toHaveBeenCalled();
+    }
+  });
+
+  it("can log", () => {
+    new MinimalLogger({}, {});
+  });
+
+  describe.for(orderedLevels)("For level %s", (level) => {
+    const idx = orderedLevels.findIndex(a => a === level);
+    expect(idx).toBeGreaterThan(-1);
+
+    const shouldNotOutput = orderedLevels.slice(0, idx);
+    const shouldOutput = orderedLevels.slice(idx);
+
+    const x = [
+      ...shouldNotOutput.map(x => [x, false] as const),
+      ...shouldOutput.map(x => [x, true] as const),
+    ];
+
+    it.for(x)("It should log for %s? %s", ([levelToCheck, shouldLog]) => {
+      const logger = new MinimalLogger({}, { level });
+
+      logger[levelToCheck]("logging");
+
+      let calls = 0;
+
+      for (const consoleMock of Object.values(consoleMocks)) {
+        calls += consoleMock.mock.calls.length;
+      }
+
+      if (shouldLog) {
+        expect(calls === 1, `Should log one time but got ${calls}`);
+      } else {
+        expect(calls === 0, "should not call console.thing");
+      }
+    });
+  });
+});

--- a/packages/client/src/logger/TestLogger.ts
+++ b/packages/client/src/logger/TestLogger.ts
@@ -45,23 +45,16 @@ export class TestLogger extends BaseLogger implements Logger {
       { ...options, level: options.level ?? "error" },
       TestLogger,
     );
-
-    for (
-      const k of ["trace", "debug", "info", "warn", "error", "fatal"] as const
-    ) {
-      this[k] = this.#createLogMethod(k, bindings, options);
-    }
   }
 
-  #createLogMethod(
+  protected createLogMethod(
     name: "trace" | "debug" | "info" | "warn" | "error" | "fatal",
     bindings: Record<string, any>,
-    options: { level?: string; msgPrefix?: string },
   ): LogFn {
     const msgs: string[] = [colors[name][1](name)];
 
-    if (options?.msgPrefix) {
-      msgs.push(colors[name][0](options.msgPrefix));
+    if (this.options?.msgPrefix) {
+      msgs.push(colors[name][0](this.options.msgPrefix));
     }
 
     if (typeof bindings === "object" && "methodName" in bindings) {

--- a/packages/client/src/object/convertWireToOsdkObjects.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.ts
@@ -62,8 +62,6 @@ export async function convertWireToOsdkObjects(
   selectedProps?: ReadonlyArray<string>,
   strictNonNull: NullabilityAdherence = false,
 ): Promise<Array<ObjectHolder | InterfaceHolder>> {
-  client.logger?.debug(`START convertWireToOsdkObjects()`);
-
   // remove the __ prefixed properties and convert them to $ prefixed.
   // updates in place
   fixObjectPropertiesInPlace(objects, forceRemoveRid);
@@ -124,7 +122,6 @@ export async function convertWireToOsdkObjects(
     ret.push(osdkObject);
   }
 
-  client.logger?.debug(`END convertWireToOsdkObjects()`);
   return ret;
 }
 
@@ -195,8 +192,6 @@ export async function convertWireToOsdkObjects2(
     InterfaceToObjectTypeMappings
   > = {},
 ): Promise<Array<ObjectHolder | InterfaceHolder>> {
-  client.logger?.debug(`START convertWireToOsdkObjects2()`);
-
   fixObjectPropertiesInPlace(objects, forceRemoveRid);
 
   const ret = [];
@@ -258,7 +253,6 @@ export async function convertWireToOsdkObjects2(
     ret.push(osdkObject);
   }
 
-  client.logger?.debug(`END convertWireToOsdkObjects2()`);
   return ret;
 }
 

--- a/packages/client/src/ontology/loadFullObjectMetadata.ts
+++ b/packages/client/src/ontology/loadFullObjectMetadata.ts
@@ -30,6 +30,5 @@ export async function loadFullObjectMetadata(
     { preview: true },
   );
   const ret = wireObjectTypeFullMetadataToSdkObjectMetadata(full, true);
-  client.logger?.debug(`END loadFullObjectMetadata(${objectType})`);
   return { ...ret };
 }

--- a/packages/client/src/public/internal.ts
+++ b/packages/client/src/public/internal.ts
@@ -17,3 +17,6 @@
 export { createAndFetchTempObjectSetRid } from "../public-utils/createAndFetchTempObjectSetRid.js";
 export { hydrateAttachmentFromRid } from "../public-utils/hydrateAttachmentFromRid.js";
 export { hydrateObjectSetFromRid } from "../public-utils/hydrateObjectSetFromRid.js";
+
+export { BrowserLogger } from "../logger/BrowserLogger.js";
+export { MinimalLogger } from "../logger/MinimalLogger.js";

--- a/packages/e2e.sandbox.todoapp/src/foundryClient.ts
+++ b/packages/e2e.sandbox.todoapp/src/foundryClient.ts
@@ -1,5 +1,5 @@
-import type { Logger } from "@osdk/client";
 import { createClient } from "@osdk/client";
+import { BrowserLogger } from "@osdk/client/internal";
 import { createPublicOauthClient } from "@osdk/oauth";
 import invariant from "tiny-invariant";
 import { $ontologyRid } from "./generatedNoCheck2/index.js";
@@ -18,94 +18,9 @@ const auth = createPublicOauthClient(
   { useHistory: true },
 );
 
-export interface LogFn {
-  (obj: unknown, msg?: string, ...args: any[]): void;
-  (msg: string, ...args: any[]): void;
-}
-
-function createStyle({ color }: { color: string }) {
-  return `color: ${color}; border: 1px solid ${color}; padding: 2px; border-radius: 3px;`;
-}
-
-const levelStyles = {
-  debug: createStyle({
-    color: "LightBlue",
-  }),
-  error: createStyle({
-    color: "red",
-  }),
-  fatal: createStyle({
-    color: "red",
-  }),
-  info: createStyle({
-    color: "green",
-  }),
-  trace: createStyle({
-    color: "gray",
-  }),
-  warn: createStyle({
-    color: "orange",
-  }),
-};
-
-export function createLogger(
-  bindings: Record<string, any>,
-  options?: { level?: string; msgPrefix?: string },
-): Logger {
-  function createLogMethod(
-    name: "debug" | "error" | "info" | "warn" | "fatal" | "trace",
-  ): LogFn {
-    const msgs: string[] = [`%c${name}%c`];
-    const styles: string[] = [levelStyles[name], ""];
-
-    // const params = ["%c%s", levelStyles[name], name];
-    if (options?.msgPrefix) {
-      msgs.push(`%c${options.msgPrefix}%c`);
-      styles.push(
-        "font-style: italic; color: gray",
-        // "border: 1px solid green; ",
-        "",
-      );
-    }
-
-    if (typeof bindings === "object" && "methodName" in bindings) {
-      msgs.push(`%c.${bindings.methodName}()%c`);
-      styles.push(
-        "font-style: italic;color: orchid",
-        "",
-      );
-    }
-
-    return console[name === "fatal" ? "error" : name].bind(
-      console,
-      msgs.join(" "),
-      ...styles,
-      // ...args,
-    );
-  }
-  return {
-    debug: createLogMethod("debug"),
-    error: createLogMethod("error"),
-    info: createLogMethod("info"),
-    warn: createLogMethod("warn"),
-    fatal: createLogMethod("fatal"),
-    child: (theseBindings, theseOptions) =>
-      createLogger({
-        ...bindings,
-        ...theseBindings,
-      }, {
-        level: (theseOptions ?? options)?.level,
-        msgPrefix: [options?.msgPrefix, theseOptions?.msgPrefix].filter(x => x)
-          .join(""),
-      }),
-    trace: createLogMethod("trace"),
-    isLevelEnabled: ((level) => !!level), // always true, no error from tsc
-  };
-}
-
 export const $ = createClient(
   "http://localhost:8080",
   $ontologyRid,
   auth,
-  { logger: createLogger({}) },
+  { logger: new BrowserLogger({}, { level: "debug" }) },
 );

--- a/packages/monorepo.tool.transpile/bin/transpile2.mjs
+++ b/packages/monorepo.tool.transpile/bin/transpile2.mjs
@@ -340,6 +340,21 @@ async function transpileWithBabel(format, target) {
     if (result.map) {
       const mapFilePath = destPath + ".map";
       result.map.file = path.basename(destPath);
+
+      // this lets us mark the loggers for the sourceMap
+      // to be ignored by browsers so you still see
+      // the correct line numbers!
+      // See https://developer.chrome.com/docs/devtools/x-google-ignore-list
+      // and https://tc39.es/ecma426/#sec-source-map-format
+      if (
+        result.map.sources.some(s =>
+          s === "MinimalLogger.ts" || s === "BrowserLogger.ts"
+        )
+      ) {
+        // @ts-ignore
+        (result.map.ignoreList ??= []).push(0);
+      }
+
       await mkdir(path.dirname(mapFilePath), { recursive: true });
       await writeFile(mapFilePath, JSON.stringify(result.map));
 


### PR DESCRIPTION
In a previous commit, I started using a logger by default for our clients. Unfortunately, that logger included everything which was a bit much for our internal consumers.

In this change, we have:
* Made it so the logger we create for the consumer only logs at error and fatal by default.
* Exposed the `MinimalLogger` that we were applying by default so that consumers could create their own at their own log levels.
* Exposed the `BrowserLogger` that I have been using in the e2e todoapp sandbox.
* Configured our sourcemaps so that they tell the browser to ignore BrowserLogger/MinimalLogger, allowing original filenames from where the log message originated to show up!

BrowserLogger sorta looks like this:

![image](https://github.com/user-attachments/assets/428f52bc-5571-47f3-bf70-4ebba800eee6)
