### PR TITLE
Update templates with meta tags and use it for client creation

### DIFF
--- a/.changeset/calm-ducks-bake.md
+++ b/.changeset/calm-ducks-bake.md
@@ -1,14 +1,14 @@
 ---
-"@osdk/create-app.template.tutorial-todo-aip-app.beta": minor
-"@osdk/create-app.template.tutorial-todo-app.beta": minor
-"@osdk/create-app.template.tutorial-todo-aip-app": minor
-"@osdk/create-app.template.tutorial-todo-app": minor
-"@osdk/create-app.template.react.beta": minor
-"@osdk/create-app.template.vue.v2": minor
-"@osdk/create-app.template.react": minor
-"@osdk/create-app.template.vue": minor
-"@osdk/example-generator": minor
-"@osdk/create-app": minor
+"@osdk/create-app.template.tutorial-todo-aip-app.beta": patch
+"@osdk/create-app.template.tutorial-todo-app.beta": patch
+"@osdk/create-app.template.tutorial-todo-aip-app": patch
+"@osdk/create-app.template.tutorial-todo-app": patch
+"@osdk/create-app.template.react.beta": patch
+"@osdk/create-app.template.vue.v2": patch
+"@osdk/create-app.template.react": patch
+"@osdk/create-app.template.vue": patch
+"@osdk/example-generator": patch
+"@osdk/create-app": patch
 ---
 
-Update templates with meta tags
+Read environment variables from index.html meta tags

--- a/.changeset/calm-ducks-bake.md
+++ b/.changeset/calm-ducks-bake.md
@@ -1,0 +1,14 @@
+---
+"@osdk/create-app.template.tutorial-todo-aip-app.beta": minor
+"@osdk/create-app.template.tutorial-todo-app.beta": minor
+"@osdk/create-app.template.tutorial-todo-aip-app": minor
+"@osdk/create-app.template.tutorial-todo-app": minor
+"@osdk/create-app.template.react.beta": minor
+"@osdk/create-app.template.vue.v2": minor
+"@osdk/create-app.template.react": minor
+"@osdk/create-app.template.vue": minor
+"@osdk/example-generator": minor
+"@osdk/create-app": minor
+---
+
+Update templates with meta tags

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,10 +2,10 @@
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "dprint.dprint",
   "[javascript]": {
-    "editor.defaultFormatter": "dprint.dprint"
+    "editor.defaultFormatter": "vscode.typescript-language-features"
   },
   "[typescript]": {
-    "editor.defaultFormatter": "dprint.dprint"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[json]": {
     "editor.defaultFormatter": "dprint.dprint"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,10 +2,10 @@
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "dprint.dprint",
   "[javascript]": {
-    "editor.defaultFormatter": "vscode.typescript-language-features"
+    "editor.defaultFormatter": "dprint.dprint"
   },
   "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "dprint.dprint"
   },
   "[json]": {
     "editor.defaultFormatter": "dprint.dprint"

--- a/examples/example-expo-sdk-2.x/.env.development
+++ b/examples/example-expo-sdk-2.x/.env.development
@@ -30,4 +30,4 @@ EXPO_PUBLIC_FOUNDRY_CLIENT_ID=123
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-EXPO_PUBLIC_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake
+EXPO_PUBLIC_FOUNDRY_ONTOLOGY_RID=ri.ontology.main.ontology.fake

--- a/examples/example-expo-sdk-2.x/.env.development
+++ b/examples/example-expo-sdk-2.x/.env.development
@@ -25,3 +25,9 @@ EXPO_PUBLIC_FOUNDRY_API_URL=https://fake.palantirfoundry.com
 # Developer Console. It typically does not need to be changed.
 
 EXPO_PUBLIC_FOUNDRY_CLIENT_ID=123
+
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
+# It typically does not need to be changed.
+
+EXPO_PUBLIC_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake

--- a/examples/example-expo-sdk-2.x/.env.production
+++ b/examples/example-expo-sdk-2.x/.env.production
@@ -30,4 +30,4 @@ EXPO_PUBLIC_FOUNDRY_CLIENT_ID=123
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-EXPO_PUBLIC_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake
+EXPO_PUBLIC_FOUNDRY_ONTOLOGY_RID=ri.ontology.main.ontology.fake

--- a/examples/example-expo-sdk-2.x/.env.production
+++ b/examples/example-expo-sdk-2.x/.env.production
@@ -25,3 +25,9 @@ EXPO_PUBLIC_FOUNDRY_API_URL=https://fake.palantirfoundry.com
 # Developer Console. It typically does not need to be changed.
 
 EXPO_PUBLIC_FOUNDRY_CLIENT_ID=123
+
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
+# It typically does not need to be changed.
+
+EXPO_PUBLIC_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake

--- a/examples/example-react-sdk-1.x/.env.development
+++ b/examples/example-react-sdk-1.x/.env.development
@@ -30,4 +30,4 @@ VITE_FOUNDRY_CLIENT_ID=123
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontology.main.ontology.fake

--- a/examples/example-react-sdk-1.x/.env.development
+++ b/examples/example-react-sdk-1.x/.env.development
@@ -25,3 +25,9 @@ VITE_FOUNDRY_API_URL=https://fake.palantirfoundry.com
 # Developer Console. It typically does not need to be changed.
 
 VITE_FOUNDRY_CLIENT_ID=123
+
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
+# It typically does not need to be changed.
+
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake

--- a/examples/example-react-sdk-1.x/.env.production
+++ b/examples/example-react-sdk-1.x/.env.production
@@ -30,4 +30,4 @@ VITE_FOUNDRY_CLIENT_ID=123
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontology.main.ontology.fake

--- a/examples/example-react-sdk-1.x/.env.production
+++ b/examples/example-react-sdk-1.x/.env.production
@@ -25,3 +25,9 @@ VITE_FOUNDRY_API_URL=https://fake.palantirfoundry.com
 # Developer Console. It typically does not need to be changed.
 
 VITE_FOUNDRY_CLIENT_ID=123
+
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
+# It typically does not need to be changed.
+
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake

--- a/examples/example-react-sdk-1.x/index.html
+++ b/examples/example-react-sdk-1.x/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/react.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="osdk-clientId" content="%VITE_FOUNDRY_CLIENT_ID%" />
+    <meta name="osdk-redirectUrl" content="%VITE_FOUNDRY_REDIRECT_URL%" />
+    <meta name="osdk-foundryUrl" content="%VITE_FOUNDRY_API_URL%" />
+    <meta name="osdk-ontologyRid" content="%VITE_FOUNDRY_ONTOLOGY_RID%" />
     <title>Ontology SDK + React</title>
   </head>
   <body>

--- a/examples/example-react-sdk-1.x/src/client.ts
+++ b/examples/example-react-sdk-1.x/src/client.ts
@@ -1,33 +1,31 @@
 import { FoundryClient, PublicClientAuth } from "@osdk/e2e.generated.1.1.x";
 
-const url = import.meta.env.VITE_FOUNDRY_API_URL;
-const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
-const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
-checkEnv(url, "VITE_FOUNDRY_API_URL");
-checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
-checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
+function getMetaTagContent(tagName: string): string {
+  const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
+  const element = elements.item(elements.length - 1);
+  const value = element ? element.getAttribute("content") : null;
+  if (value == null) {
+    throw new Error(`Meta tag ${tagName} not found`);
+  }
+  return value;
+}
+
+const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const clientId = getMetaTagContent("osdk-clientId");
+const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 const scopes = [
   "api:ontologies-read",
   "api:ontologies-write",
 ];
 
-function checkEnv(
-  value: string | undefined,
-  name: string,
-): asserts value is string {
-  if (value == null) {
-    throw new Error(`Missing environment variable: ${name}`);
-  }
-}
-
 /**
  * Initialize the client to interact with the Ontology SDK
  */
 const client = new FoundryClient({
-  url,
+  foundryUrl,
   auth: new PublicClientAuth({
     clientId,
-    url,
+    foundryUrl,
     redirectUrl,
     scopes,
   }),

--- a/examples/example-react-sdk-1.x/src/client.ts
+++ b/examples/example-react-sdk-1.x/src/client.ts
@@ -5,10 +5,10 @@ function getMetaTagContent(tagName: string): string {
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
   if (value == null || value === "") {
-    throw new Error(`Meta tag ${tagName} not found`);
+    throw new Error(`Meta tag ${tagName} not found or empty`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files`);
   }
   return value;
 }

--- a/examples/example-react-sdk-1.x/src/client.ts
+++ b/examples/example-react-sdk-1.x/src/client.ts
@@ -4,11 +4,11 @@ function getMetaTagContent(tagName: string): string {
   const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
-  if (value == null) {
+  if (value == null || value === "") {
     throw new Error(`Meta tag ${tagName} not found`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} in your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
   }
   return value;
 }

--- a/examples/example-react-sdk-1.x/src/client.ts
+++ b/examples/example-react-sdk-1.x/src/client.ts
@@ -7,6 +7,9 @@ function getMetaTagContent(tagName: string): string {
   if (value == null) {
     throw new Error(`Meta tag ${tagName} not found`);
   }
+  if (value.match(/%.+%/)) {
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} in your .env files.`);
+  }
   return value;
 }
 

--- a/examples/example-react-sdk-1.x/src/client.ts
+++ b/examples/example-react-sdk-1.x/src/client.ts
@@ -10,7 +10,7 @@ function getMetaTagContent(tagName: string): string {
   return value;
 }
 
-const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const url = getMetaTagContent("osdk-foundryUrl");
 const clientId = getMetaTagContent("osdk-clientId");
 const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 const scopes = [
@@ -22,10 +22,10 @@ const scopes = [
  * Initialize the client to interact with the Ontology SDK
  */
 const client = new FoundryClient({
-  foundryUrl,
+  url,
   auth: new PublicClientAuth({
     clientId,
-    foundryUrl,
+    url,
     redirectUrl,
     scopes,
   }),

--- a/examples/example-react-sdk-2.x/.env.development
+++ b/examples/example-react-sdk-2.x/.env.development
@@ -30,4 +30,4 @@ VITE_FOUNDRY_CLIENT_ID=123
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontology.main.ontology.fake

--- a/examples/example-react-sdk-2.x/.env.development
+++ b/examples/example-react-sdk-2.x/.env.development
@@ -25,3 +25,9 @@ VITE_FOUNDRY_API_URL=https://fake.palantirfoundry.com
 # Developer Console. It typically does not need to be changed.
 
 VITE_FOUNDRY_CLIENT_ID=123
+
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
+# It typically does not need to be changed.
+
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake

--- a/examples/example-react-sdk-2.x/.env.production
+++ b/examples/example-react-sdk-2.x/.env.production
@@ -30,4 +30,4 @@ VITE_FOUNDRY_CLIENT_ID=123
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontology.main.ontology.fake

--- a/examples/example-react-sdk-2.x/.env.production
+++ b/examples/example-react-sdk-2.x/.env.production
@@ -25,3 +25,9 @@ VITE_FOUNDRY_API_URL=https://fake.palantirfoundry.com
 # Developer Console. It typically does not need to be changed.
 
 VITE_FOUNDRY_CLIENT_ID=123
+
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
+# It typically does not need to be changed.
+
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake

--- a/examples/example-react-sdk-2.x/index.html
+++ b/examples/example-react-sdk-2.x/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/react.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="osdk-clientId" content="%VITE_FOUNDRY_CLIENT_ID%" />
+    <meta name="osdk-redirectUrl" content="%VITE_FOUNDRY_REDIRECT_URL%" />
+    <meta name="osdk-foundryUrl" content="%VITE_FOUNDRY_API_URL%" />
+    <meta name="osdk-ontologyRid" content="%VITE_FOUNDRY_ONTOLOGY_RID%" />
     <title>Ontology SDK + React</title>
   </head>
   <body>

--- a/examples/example-react-sdk-2.x/src/client.ts
+++ b/examples/example-react-sdk-2.x/src/client.ts
@@ -8,6 +8,9 @@ function getMetaTagContent(tagName: string): string {
   if (value == null) {
     throw new Error(`Meta tag ${tagName} not found`);
   }
+  if (value.match(/%.+%/)) {
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} in your .env files.`);
+  }
   return value;
 }
 

--- a/examples/example-react-sdk-2.x/src/client.ts
+++ b/examples/example-react-sdk-2.x/src/client.ts
@@ -5,11 +5,11 @@ function getMetaTagContent(tagName: string): string {
   const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
-  if (value == null) {
+  if (value == null || value === "") {
     throw new Error(`Meta tag ${tagName} not found`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} in your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
   }
   return value;
 }

--- a/examples/example-react-sdk-2.x/src/client.ts
+++ b/examples/example-react-sdk-2.x/src/client.ts
@@ -6,10 +6,10 @@ function getMetaTagContent(tagName: string): string {
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
   if (value == null || value === "") {
-    throw new Error(`Meta tag ${tagName} not found`);
+    throw new Error(`Meta tag ${tagName} not found or empty`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files`);
   }
   return value;
 }

--- a/examples/example-react-sdk-2.x/src/client.ts
+++ b/examples/example-react-sdk-2.x/src/client.ts
@@ -1,32 +1,28 @@
-import type { Client } from "@osdk/client";
-import { createClient } from "@osdk/client";
-import { $ontologyRid } from "@osdk/e2e.generated.catchall";
-import { createPublicOauthClient } from "@osdk/oauth";
+import { createClient, type Client } from "@osdk/client";
+import { createPublicOauthClient, type PublicOauthClient } from "@osdk/oauth";
 
-const url = import.meta.env.VITE_FOUNDRY_API_URL;
-const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
-const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
+function getMetaTagContent(tagName: string): string {
+  const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
+  const element = elements.item(elements.length - 1);
+  const value = element ? element.getAttribute("content") : null;
+  if (value == null) {
+    throw new Error(`Meta tag ${tagName} not found`);
+  }
+  return value;
+}
+
+const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const clientId = getMetaTagContent("osdk-clientId");
+const redirectUrl = getMetaTagContent("osdk-redirectUrl");
+const ontologyRid = getMetaTagContent("osdk-ontologyRid");
 const scopes = [
   "api:ontologies-read",
   "api:ontologies-write",
 ];
 
-checkEnv(url, "VITE_FOUNDRY_API_URL");
-checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
-checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
-
-function checkEnv(
-  value: string | undefined,
-  name: string,
-): asserts value is string {
-  if (value == null) {
-    throw new Error(`Missing environment variable: ${name}`);
-  }
-}
-
-export const auth = createPublicOauthClient(
+export const auth: PublicOauthClient = createPublicOauthClient(
   clientId,
-  url,
+  foundryUrl,
   redirectUrl,
   { scopes },
 );
@@ -35,8 +31,8 @@ export const auth = createPublicOauthClient(
  * Initialize the client to interact with the Ontology SDK
  */
 const client: Client = createClient(
-  url,
-  $ontologyRid,
+  foundryUrl,
+  ontologyRid,
   auth,
 );
 

--- a/examples/example-tutorial-todo-aip-app-sdk-1.x/.env.development
+++ b/examples/example-tutorial-todo-aip-app-sdk-1.x/.env.development
@@ -30,4 +30,4 @@ VITE_FOUNDRY_CLIENT_ID=123
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontology.main.ontology.fake

--- a/examples/example-tutorial-todo-aip-app-sdk-1.x/.env.development
+++ b/examples/example-tutorial-todo-aip-app-sdk-1.x/.env.development
@@ -25,3 +25,9 @@ VITE_FOUNDRY_API_URL=https://fake.palantirfoundry.com
 # Developer Console. It typically does not need to be changed.
 
 VITE_FOUNDRY_CLIENT_ID=123
+
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
+# It typically does not need to be changed.
+
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake

--- a/examples/example-tutorial-todo-aip-app-sdk-1.x/.env.production
+++ b/examples/example-tutorial-todo-aip-app-sdk-1.x/.env.production
@@ -30,4 +30,4 @@ VITE_FOUNDRY_CLIENT_ID=123
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontology.main.ontology.fake

--- a/examples/example-tutorial-todo-aip-app-sdk-1.x/.env.production
+++ b/examples/example-tutorial-todo-aip-app-sdk-1.x/.env.production
@@ -25,3 +25,9 @@ VITE_FOUNDRY_API_URL=https://fake.palantirfoundry.com
 # Developer Console. It typically does not need to be changed.
 
 VITE_FOUNDRY_CLIENT_ID=123
+
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
+# It typically does not need to be changed.
+
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake

--- a/examples/example-tutorial-todo-aip-app-sdk-1.x/index.html
+++ b/examples/example-tutorial-todo-aip-app-sdk-1.x/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/todo-aip-app.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="osdk-clientId" content="%VITE_FOUNDRY_CLIENT_ID%" />
+    <meta name="osdk-redirectUrl" content="%VITE_FOUNDRY_REDIRECT_URL%" />
+    <meta name="osdk-foundryUrl" content="%VITE_FOUNDRY_API_URL%" />
+    <meta name="osdk-ontologyRid" content="%VITE_FOUNDRY_ONTOLOGY_RID%" />
     <title>Ontology SDK Tutorial - To do AIP App</title>
   </head>
   <body>

--- a/examples/example-tutorial-todo-aip-app-sdk-1.x/src/client.ts
+++ b/examples/example-tutorial-todo-aip-app-sdk-1.x/src/client.ts
@@ -1,33 +1,31 @@
 import { FoundryClient, PublicClientAuth } from "@osdk/e2e.generated.1.1.x";
 
-const url = import.meta.env.VITE_FOUNDRY_API_URL;
-const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
-const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
-checkEnv(url, "VITE_FOUNDRY_API_URL");
-checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
-checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
+function getMetaTagContent(tagName: string): string {
+  const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
+  const element = elements.item(elements.length - 1);
+  const value = element ? element.getAttribute("content") : null;
+  if (value == null) {
+    throw new Error(`Meta tag ${tagName} not found`);
+  }
+  return value;
+}
+
+const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const clientId = getMetaTagContent("osdk-clientId");
+const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 const scopes = [
   "api:ontologies-read",
   "api:ontologies-write",
 ];
 
-function checkEnv(
-  value: string | undefined,
-  name: string,
-): asserts value is string {
-  if (value == null) {
-    throw new Error(`Missing environment variable: ${name}`);
-  }
-}
-
 /**
  * Initialize the client to interact with the Ontology SDK
  */
 const client = new FoundryClient({
-  url,
+  foundryUrl,
   auth: new PublicClientAuth({
     clientId,
-    url,
+    foundryUrl,
     redirectUrl,
     scopes,
   }),

--- a/examples/example-tutorial-todo-aip-app-sdk-1.x/src/client.ts
+++ b/examples/example-tutorial-todo-aip-app-sdk-1.x/src/client.ts
@@ -8,7 +8,7 @@ function getMetaTagContent(tagName: string): string {
     throw new Error(`Meta tag ${tagName} not found`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files`);
   }
   return value;
 }

--- a/examples/example-tutorial-todo-aip-app-sdk-1.x/src/client.ts
+++ b/examples/example-tutorial-todo-aip-app-sdk-1.x/src/client.ts
@@ -5,7 +5,7 @@ function getMetaTagContent(tagName: string): string {
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
   if (value == null || value === "") {
-    throw new Error(`Meta tag ${tagName} not found`);
+    throw new Error(`Meta tag ${tagName} not found or empty`);
   }
   if (value.match(/%.+%/)) {
     throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files`);

--- a/examples/example-tutorial-todo-aip-app-sdk-1.x/src/client.ts
+++ b/examples/example-tutorial-todo-aip-app-sdk-1.x/src/client.ts
@@ -4,11 +4,11 @@ function getMetaTagContent(tagName: string): string {
   const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
-  if (value == null) {
+  if (value == null || value === "") {
     throw new Error(`Meta tag ${tagName} not found`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} in your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
   }
   return value;
 }

--- a/examples/example-tutorial-todo-aip-app-sdk-1.x/src/client.ts
+++ b/examples/example-tutorial-todo-aip-app-sdk-1.x/src/client.ts
@@ -7,6 +7,9 @@ function getMetaTagContent(tagName: string): string {
   if (value == null) {
     throw new Error(`Meta tag ${tagName} not found`);
   }
+  if (value.match(/%.+%/)) {
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} in your .env files.`);
+  }
   return value;
 }
 

--- a/examples/example-tutorial-todo-aip-app-sdk-1.x/src/client.ts
+++ b/examples/example-tutorial-todo-aip-app-sdk-1.x/src/client.ts
@@ -10,7 +10,7 @@ function getMetaTagContent(tagName: string): string {
   return value;
 }
 
-const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const url = getMetaTagContent("osdk-foundryUrl");
 const clientId = getMetaTagContent("osdk-clientId");
 const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 const scopes = [
@@ -22,10 +22,10 @@ const scopes = [
  * Initialize the client to interact with the Ontology SDK
  */
 const client = new FoundryClient({
-  foundryUrl,
+  url,
   auth: new PublicClientAuth({
     clientId,
-    foundryUrl,
+    url,
     redirectUrl,
     scopes,
   }),

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/.env.development
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/.env.development
@@ -30,4 +30,4 @@ VITE_FOUNDRY_CLIENT_ID=123
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontology.main.ontology.fake

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/.env.development
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/.env.development
@@ -25,3 +25,9 @@ VITE_FOUNDRY_API_URL=https://fake.palantirfoundry.com
 # Developer Console. It typically does not need to be changed.
 
 VITE_FOUNDRY_CLIENT_ID=123
+
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
+# It typically does not need to be changed.
+
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/.env.production
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/.env.production
@@ -30,4 +30,4 @@ VITE_FOUNDRY_CLIENT_ID=123
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontology.main.ontology.fake

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/.env.production
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/.env.production
@@ -25,3 +25,9 @@ VITE_FOUNDRY_API_URL=https://fake.palantirfoundry.com
 # Developer Console. It typically does not need to be changed.
 
 VITE_FOUNDRY_CLIENT_ID=123
+
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
+# It typically does not need to be changed.
+
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/index.html
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/todo-aip-app.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="osdk-clientId" content="%VITE_FOUNDRY_CLIENT_ID%" />
+    <meta name="osdk-redirectUrl" content="%VITE_FOUNDRY_REDIRECT_URL%" />
+    <meta name="osdk-foundryUrl" content="%VITE_FOUNDRY_API_URL%" />
+    <meta name="osdk-ontologyRid" content="%VITE_FOUNDRY_ONTOLOGY_RID%" />
     <title>Ontology SDK Tutorial - To do AIP App</title>
   </head>
   <body>

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/src/client.ts
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/src/client.ts
@@ -8,6 +8,9 @@ function getMetaTagContent(tagName: string): string {
   if (value == null) {
     throw new Error(`Meta tag ${tagName} not found`);
   }
+  if (value.match(/%.+%/)) {
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} in your .env files.`);
+  }
   return value;
 }
 

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/src/client.ts
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/src/client.ts
@@ -5,11 +5,11 @@ function getMetaTagContent(tagName: string): string {
   const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
-  if (value == null) {
+  if (value == null || value === "") {
     throw new Error(`Meta tag ${tagName} not found`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} in your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
   }
   return value;
 }

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/src/client.ts
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/src/client.ts
@@ -1,32 +1,28 @@
-import type { Client } from "@osdk/client";
-import { createClient } from "@osdk/client";
-import { createPublicOauthClient } from "@osdk/oauth";
-import { $ontologyRid } from "@osdk/e2e.generated.catchall";
+import { createClient, type Client } from "@osdk/client";
+import { createPublicOauthClient, type PublicOauthClient } from "@osdk/oauth";
 
-const url = import.meta.env.VITE_FOUNDRY_API_URL;
-const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
-const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
+function getMetaTagContent(tagName: string): string {
+  const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
+  const element = elements.item(elements.length - 1);
+  const value = element ? element.getAttribute("content") : null;
+  if (value == null) {
+    throw new Error(`Meta tag ${tagName} not found`);
+  }
+  return value;
+}
+
+const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const clientId = getMetaTagContent("osdk-clientId");
+const redirectUrl = getMetaTagContent("osdk-redirectUrl");
+const ontologyRid = getMetaTagContent("osdk-ontologyRid");
 const scopes = [
   "api:ontologies-read",
   "api:ontologies-write",
 ];
 
-checkEnv(url, "VITE_FOUNDRY_API_URL");
-checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
-checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
-
-function checkEnv(
-  value: string | undefined,
-  name: string,
-): asserts value is string {
-  if (value == null) {
-    throw new Error(`Missing environment variable: ${name}`);
-  }
-}
-
-export const auth = createPublicOauthClient(
+export const auth: PublicOauthClient = createPublicOauthClient(
   clientId,
-  url,
+  foundryUrl,
   redirectUrl,
   { scopes },
 );
@@ -35,8 +31,8 @@ export const auth = createPublicOauthClient(
  * Initialize the client to interact with the Ontology SDK
  */
 const client: Client = createClient(
-  url,
-  $ontologyRid,
+  foundryUrl,
+  ontologyRid,
   auth,
 );
 

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/src/client.ts
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/src/client.ts
@@ -6,10 +6,10 @@ function getMetaTagContent(tagName: string): string {
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
   if (value == null || value === "") {
-    throw new Error(`Meta tag ${tagName} not found`);
+    throw new Error(`Meta tag ${tagName} not found or empty`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files`);
   }
   return value;
 }

--- a/examples/example-tutorial-todo-app-sdk-1.x/.env.development
+++ b/examples/example-tutorial-todo-app-sdk-1.x/.env.development
@@ -30,4 +30,4 @@ VITE_FOUNDRY_CLIENT_ID=123
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontology.main.ontology.fake

--- a/examples/example-tutorial-todo-app-sdk-1.x/.env.development
+++ b/examples/example-tutorial-todo-app-sdk-1.x/.env.development
@@ -25,3 +25,9 @@ VITE_FOUNDRY_API_URL=https://fake.palantirfoundry.com
 # Developer Console. It typically does not need to be changed.
 
 VITE_FOUNDRY_CLIENT_ID=123
+
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
+# It typically does not need to be changed.
+
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake

--- a/examples/example-tutorial-todo-app-sdk-1.x/.env.production
+++ b/examples/example-tutorial-todo-app-sdk-1.x/.env.production
@@ -30,4 +30,4 @@ VITE_FOUNDRY_CLIENT_ID=123
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontology.main.ontology.fake

--- a/examples/example-tutorial-todo-app-sdk-1.x/.env.production
+++ b/examples/example-tutorial-todo-app-sdk-1.x/.env.production
@@ -25,3 +25,9 @@ VITE_FOUNDRY_API_URL=https://fake.palantirfoundry.com
 # Developer Console. It typically does not need to be changed.
 
 VITE_FOUNDRY_CLIENT_ID=123
+
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
+# It typically does not need to be changed.
+
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake

--- a/examples/example-tutorial-todo-app-sdk-1.x/index.html
+++ b/examples/example-tutorial-todo-app-sdk-1.x/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/todo-app.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="osdk-clientId" content="%VITE_FOUNDRY_CLIENT_ID%" />
+    <meta name="osdk-redirectUrl" content="%VITE_FOUNDRY_REDIRECT_URL%" />
+    <meta name="osdk-foundryUrl" content="%VITE_FOUNDRY_API_URL%" />
+    <meta name="osdk-ontologyRid" content="%VITE_FOUNDRY_ONTOLOGY_RID%" />
     <title>Ontology SDK Tutorial - Todo App</title>
   </head>
   <body>

--- a/examples/example-tutorial-todo-app-sdk-1.x/src/client.ts
+++ b/examples/example-tutorial-todo-app-sdk-1.x/src/client.ts
@@ -1,33 +1,31 @@
 import { FoundryClient, PublicClientAuth } from "@osdk/e2e.generated.1.1.x";
 
-const url = import.meta.env.VITE_FOUNDRY_API_URL;
-const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
-const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
-checkEnv(url, "VITE_FOUNDRY_API_URL");
-checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
-checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
+function getMetaTagContent(tagName: string): string {
+  const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
+  const element = elements.item(elements.length - 1);
+  const value = element ? element.getAttribute("content") : null;
+  if (value == null) {
+    throw new Error(`Meta tag ${tagName} not found`);
+  }
+  return value;
+}
+
+const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const clientId = getMetaTagContent("osdk-clientId");
+const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 const scopes = [
   "api:ontologies-read",
   "api:ontologies-write",
 ];
 
-function checkEnv(
-  value: string | undefined,
-  name: string,
-): asserts value is string {
-  if (value == null) {
-    throw new Error(`Missing environment variable: ${name}`);
-  }
-}
-
 /**
  * Initialize the client to interact with the Ontology SDK
  */
 const client = new FoundryClient({
-  url,
+  foundryUrl,
   auth: new PublicClientAuth({
     clientId,
-    url,
+    foundryUrl,
     redirectUrl,
     scopes,
   }),

--- a/examples/example-tutorial-todo-app-sdk-1.x/src/client.ts
+++ b/examples/example-tutorial-todo-app-sdk-1.x/src/client.ts
@@ -5,10 +5,10 @@ function getMetaTagContent(tagName: string): string {
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
   if (value == null || value === "") {
-    throw new Error(`Meta tag ${tagName} not found`);
+    throw new Error(`Meta tag ${tagName} not found or empty`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files`);
   }
   return value;
 }

--- a/examples/example-tutorial-todo-app-sdk-1.x/src/client.ts
+++ b/examples/example-tutorial-todo-app-sdk-1.x/src/client.ts
@@ -4,11 +4,11 @@ function getMetaTagContent(tagName: string): string {
   const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
-  if (value == null) {
+  if (value == null || value === "") {
     throw new Error(`Meta tag ${tagName} not found`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} in your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
   }
   return value;
 }

--- a/examples/example-tutorial-todo-app-sdk-1.x/src/client.ts
+++ b/examples/example-tutorial-todo-app-sdk-1.x/src/client.ts
@@ -7,6 +7,9 @@ function getMetaTagContent(tagName: string): string {
   if (value == null) {
     throw new Error(`Meta tag ${tagName} not found`);
   }
+  if (value.match(/%.+%/)) {
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} in your .env files.`);
+  }
   return value;
 }
 

--- a/examples/example-tutorial-todo-app-sdk-1.x/src/client.ts
+++ b/examples/example-tutorial-todo-app-sdk-1.x/src/client.ts
@@ -10,7 +10,7 @@ function getMetaTagContent(tagName: string): string {
   return value;
 }
 
-const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const url = getMetaTagContent("osdk-foundryUrl");
 const clientId = getMetaTagContent("osdk-clientId");
 const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 const scopes = [
@@ -22,10 +22,10 @@ const scopes = [
  * Initialize the client to interact with the Ontology SDK
  */
 const client = new FoundryClient({
-  foundryUrl,
+  url,
   auth: new PublicClientAuth({
     clientId,
-    foundryUrl,
+    url,
     redirectUrl,
     scopes,
   }),

--- a/examples/example-tutorial-todo-app-sdk-2.x/.env.development
+++ b/examples/example-tutorial-todo-app-sdk-2.x/.env.development
@@ -30,4 +30,4 @@ VITE_FOUNDRY_CLIENT_ID=123
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontology.main.ontology.fake

--- a/examples/example-tutorial-todo-app-sdk-2.x/.env.development
+++ b/examples/example-tutorial-todo-app-sdk-2.x/.env.development
@@ -25,3 +25,9 @@ VITE_FOUNDRY_API_URL=https://fake.palantirfoundry.com
 # Developer Console. It typically does not need to be changed.
 
 VITE_FOUNDRY_CLIENT_ID=123
+
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
+# It typically does not need to be changed.
+
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake

--- a/examples/example-tutorial-todo-app-sdk-2.x/.env.production
+++ b/examples/example-tutorial-todo-app-sdk-2.x/.env.production
@@ -30,4 +30,4 @@ VITE_FOUNDRY_CLIENT_ID=123
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontology.main.ontology.fake

--- a/examples/example-tutorial-todo-app-sdk-2.x/.env.production
+++ b/examples/example-tutorial-todo-app-sdk-2.x/.env.production
@@ -25,3 +25,9 @@ VITE_FOUNDRY_API_URL=https://fake.palantirfoundry.com
 # Developer Console. It typically does not need to be changed.
 
 VITE_FOUNDRY_CLIENT_ID=123
+
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
+# It typically does not need to be changed.
+
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake

--- a/examples/example-tutorial-todo-app-sdk-2.x/index.html
+++ b/examples/example-tutorial-todo-app-sdk-2.x/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/todo-app.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="osdk-clientId" content="%VITE_FOUNDRY_CLIENT_ID%" />
+    <meta name="osdk-redirectUrl" content="%VITE_FOUNDRY_REDIRECT_URL%" />
+    <meta name="osdk-foundryUrl" content="%VITE_FOUNDRY_API_URL%" />
+    <meta name="osdk-ontologyRid" content="%VITE_FOUNDRY_ONTOLOGY_RID%" />
     <title>Ontology SDK Tutorial - Todo App</title>
   </head>
   <body>

--- a/examples/example-tutorial-todo-app-sdk-2.x/src/client.ts
+++ b/examples/example-tutorial-todo-app-sdk-2.x/src/client.ts
@@ -8,6 +8,9 @@ function getMetaTagContent(tagName: string): string {
   if (value == null) {
     throw new Error(`Meta tag ${tagName} not found`);
   }
+  if (value.match(/%.+%/)) {
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} in your .env files.`);
+  }
   return value;
 }
 

--- a/examples/example-tutorial-todo-app-sdk-2.x/src/client.ts
+++ b/examples/example-tutorial-todo-app-sdk-2.x/src/client.ts
@@ -5,11 +5,11 @@ function getMetaTagContent(tagName: string): string {
   const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
-  if (value == null) {
+  if (value == null || value === "") {
     throw new Error(`Meta tag ${tagName} not found`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} in your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
   }
   return value;
 }

--- a/examples/example-tutorial-todo-app-sdk-2.x/src/client.ts
+++ b/examples/example-tutorial-todo-app-sdk-2.x/src/client.ts
@@ -1,32 +1,28 @@
-import type { Client } from "@osdk/client";
-import { createClient } from "@osdk/client";
-import { createPublicOauthClient } from "@osdk/oauth";
-import { $ontologyRid } from "@osdk/e2e.generated.catchall";
+import { createClient, type Client } from "@osdk/client";
+import { createPublicOauthClient, type PublicOauthClient } from "@osdk/oauth";
 
-const url = import.meta.env.VITE_FOUNDRY_API_URL;
-const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
-const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
+function getMetaTagContent(tagName: string): string {
+  const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
+  const element = elements.item(elements.length - 1);
+  const value = element ? element.getAttribute("content") : null;
+  if (value == null) {
+    throw new Error(`Meta tag ${tagName} not found`);
+  }
+  return value;
+}
+
+const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const clientId = getMetaTagContent("osdk-clientId");
+const redirectUrl = getMetaTagContent("osdk-redirectUrl");
+const ontologyRid = getMetaTagContent("osdk-ontologyRid");
 const scopes = [
   "api:ontologies-read",
   "api:ontologies-write",
 ];
 
-checkEnv(url, "VITE_FOUNDRY_API_URL");
-checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
-checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
-
-function checkEnv(
-  value: string | undefined,
-  name: string,
-): asserts value is string {
-  if (value == null) {
-    throw new Error(`Missing environment variable: ${name}`);
-  }
-}
-
-export const auth = createPublicOauthClient(
+export const auth: PublicOauthClient = createPublicOauthClient(
   clientId,
-  url,
+  foundryUrl,
   redirectUrl,
   { scopes },
 );
@@ -35,8 +31,8 @@ export const auth = createPublicOauthClient(
  * Initialize the client to interact with the Ontology SDK
  */
 const client: Client = createClient(
-  url,
-  $ontologyRid,
+  foundryUrl,
+  ontologyRid,
   auth,
 );
 

--- a/examples/example-tutorial-todo-app-sdk-2.x/src/client.ts
+++ b/examples/example-tutorial-todo-app-sdk-2.x/src/client.ts
@@ -6,10 +6,10 @@ function getMetaTagContent(tagName: string): string {
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
   if (value == null || value === "") {
-    throw new Error(`Meta tag ${tagName} not found`);
+    throw new Error(`Meta tag ${tagName} not found or empty`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files`);
   }
   return value;
 }

--- a/examples/example-vue-sdk-1.x/.env.development
+++ b/examples/example-vue-sdk-1.x/.env.development
@@ -30,4 +30,4 @@ VITE_FOUNDRY_CLIENT_ID=123
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontology.main.ontology.fake

--- a/examples/example-vue-sdk-1.x/.env.development
+++ b/examples/example-vue-sdk-1.x/.env.development
@@ -25,3 +25,9 @@ VITE_FOUNDRY_API_URL=https://fake.palantirfoundry.com
 # Developer Console. It typically does not need to be changed.
 
 VITE_FOUNDRY_CLIENT_ID=123
+
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
+# It typically does not need to be changed.
+
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake

--- a/examples/example-vue-sdk-1.x/.env.production
+++ b/examples/example-vue-sdk-1.x/.env.production
@@ -30,4 +30,4 @@ VITE_FOUNDRY_CLIENT_ID=123
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontology.main.ontology.fake

--- a/examples/example-vue-sdk-1.x/.env.production
+++ b/examples/example-vue-sdk-1.x/.env.production
@@ -25,3 +25,9 @@ VITE_FOUNDRY_API_URL=https://fake.palantirfoundry.com
 # Developer Console. It typically does not need to be changed.
 
 VITE_FOUNDRY_CLIENT_ID=123
+
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
+# It typically does not need to be changed.
+
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake

--- a/examples/example-vue-sdk-1.x/index.html
+++ b/examples/example-vue-sdk-1.x/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vue.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="osdk-clientId" content="%VITE_FOUNDRY_CLIENT_ID%" />
+    <meta name="osdk-redirectUrl" content="%VITE_FOUNDRY_REDIRECT_URL%" />
+    <meta name="osdk-foundryUrl" content="%VITE_FOUNDRY_API_URL%" />
+    <meta name="osdk-ontologyRid" content="%VITE_FOUNDRY_ONTOLOGY_RID%" />
     <title>Ontology SDK + Vue</title>
   </head>
   <body>

--- a/examples/example-vue-sdk-1.x/src/client.ts
+++ b/examples/example-vue-sdk-1.x/src/client.ts
@@ -1,33 +1,31 @@
 import { FoundryClient, PublicClientAuth } from "@osdk/e2e.generated.1.1.x";
 
-const url = import.meta.env.VITE_FOUNDRY_API_URL;
-const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
-const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
-checkEnv(url, "VITE_FOUNDRY_API_URL");
-checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
-checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
+function getMetaTagContent(tagName: string): string {
+  const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
+  const element = elements.item(elements.length - 1);
+  const value = element ? element.getAttribute("content") : null;
+  if (value == null) {
+    throw new Error(`Meta tag ${tagName} not found`);
+  }
+  return value;
+}
+
+const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const clientId = getMetaTagContent("osdk-clientId");
+const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 const scopes = [
   "api:ontologies-read",
   "api:ontologies-write",
 ];
 
-function checkEnv(
-  value: string | undefined,
-  name: string,
-): asserts value is string {
-  if (value == null) {
-    throw new Error(`Missing environment variable: ${name}`);
-  }
-}
-
 /**
  * Initialize the client to interact with the Ontology SDK
  */
 const client = new FoundryClient({
-  url,
+  foundryUrl,
   auth: new PublicClientAuth({
     clientId,
-    url,
+    foundryUrl,
     redirectUrl,
     scopes,
   }),

--- a/examples/example-vue-sdk-1.x/src/client.ts
+++ b/examples/example-vue-sdk-1.x/src/client.ts
@@ -5,10 +5,10 @@ function getMetaTagContent(tagName: string): string {
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
   if (value == null || value === "") {
-    throw new Error(`Meta tag ${tagName} not found`);
+    throw new Error(`Meta tag ${tagName} not found or empty`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files`);
   }
   return value;
 }

--- a/examples/example-vue-sdk-1.x/src/client.ts
+++ b/examples/example-vue-sdk-1.x/src/client.ts
@@ -4,11 +4,11 @@ function getMetaTagContent(tagName: string): string {
   const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
-  if (value == null) {
+  if (value == null || value === "") {
     throw new Error(`Meta tag ${tagName} not found`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} in your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
   }
   return value;
 }

--- a/examples/example-vue-sdk-1.x/src/client.ts
+++ b/examples/example-vue-sdk-1.x/src/client.ts
@@ -7,6 +7,9 @@ function getMetaTagContent(tagName: string): string {
   if (value == null) {
     throw new Error(`Meta tag ${tagName} not found`);
   }
+  if (value.match(/%.+%/)) {
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} in your .env files.`);
+  }
   return value;
 }
 

--- a/examples/example-vue-sdk-1.x/src/client.ts
+++ b/examples/example-vue-sdk-1.x/src/client.ts
@@ -10,7 +10,7 @@ function getMetaTagContent(tagName: string): string {
   return value;
 }
 
-const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const url = getMetaTagContent("osdk-foundryUrl");
 const clientId = getMetaTagContent("osdk-clientId");
 const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 const scopes = [
@@ -22,10 +22,10 @@ const scopes = [
  * Initialize the client to interact with the Ontology SDK
  */
 const client = new FoundryClient({
-  foundryUrl,
+  url,
   auth: new PublicClientAuth({
     clientId,
-    foundryUrl,
+    url,
     redirectUrl,
     scopes,
   }),

--- a/examples/example-vue-sdk-2.x/.env.development
+++ b/examples/example-vue-sdk-2.x/.env.development
@@ -30,4 +30,4 @@ VITE_FOUNDRY_CLIENT_ID=123
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontology.main.ontology.fake

--- a/examples/example-vue-sdk-2.x/.env.development
+++ b/examples/example-vue-sdk-2.x/.env.development
@@ -25,3 +25,9 @@ VITE_FOUNDRY_API_URL=https://fake.palantirfoundry.com
 # Developer Console. It typically does not need to be changed.
 
 VITE_FOUNDRY_CLIENT_ID=123
+
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
+# It typically does not need to be changed.
+
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake

--- a/examples/example-vue-sdk-2.x/.env.production
+++ b/examples/example-vue-sdk-2.x/.env.production
@@ -30,4 +30,4 @@ VITE_FOUNDRY_CLIENT_ID=123
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontology.main.ontology.fake

--- a/examples/example-vue-sdk-2.x/.env.production
+++ b/examples/example-vue-sdk-2.x/.env.production
@@ -25,3 +25,9 @@ VITE_FOUNDRY_API_URL=https://fake.palantirfoundry.com
 # Developer Console. It typically does not need to be changed.
 
 VITE_FOUNDRY_CLIENT_ID=123
+
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
+# It typically does not need to be changed.
+
+VITE_FOUNDRY_ONTOLOGY_RID=ri.ontologies.main.ontology.fake

--- a/examples/example-vue-sdk-2.x/index.html
+++ b/examples/example-vue-sdk-2.x/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vue.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="osdk-clientId" content="%VITE_FOUNDRY_CLIENT_ID%" />
+    <meta name="osdk-redirectUrl" content="%VITE_FOUNDRY_REDIRECT_URL%" />
+    <meta name="osdk-foundryUrl" content="%VITE_FOUNDRY_API_URL%" />
+    <meta name="osdk-ontologyRid" content="%VITE_FOUNDRY_ONTOLOGY_RID%" />
     <title>Ontology SDK + Vue</title>
   </head>
   <body>

--- a/examples/example-vue-sdk-2.x/src/client.ts
+++ b/examples/example-vue-sdk-2.x/src/client.ts
@@ -8,6 +8,9 @@ function getMetaTagContent(tagName: string): string {
   if (value == null) {
     throw new Error(`Meta tag ${tagName} not found`);
   }
+  if (value.match(/%.+%/)) {
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} in your .env files.`);
+  }
   return value;
 }
 

--- a/examples/example-vue-sdk-2.x/src/client.ts
+++ b/examples/example-vue-sdk-2.x/src/client.ts
@@ -5,11 +5,11 @@ function getMetaTagContent(tagName: string): string {
   const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
-  if (value == null) {
+  if (value == null || value === "") {
     throw new Error(`Meta tag ${tagName} not found`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} in your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
   }
   return value;
 }

--- a/examples/example-vue-sdk-2.x/src/client.ts
+++ b/examples/example-vue-sdk-2.x/src/client.ts
@@ -1,32 +1,28 @@
-import type { Client } from "@osdk/client";
-import { createClient } from "@osdk/client";
-import { $ontologyRid } from "@osdk/e2e.generated.catchall";
-import { createPublicOauthClient } from "@osdk/oauth";
+import { createClient, type Client } from "@osdk/client";
+import { createPublicOauthClient, type PublicOauthClient } from "@osdk/oauth";
 
-const url = import.meta.env.VITE_FOUNDRY_API_URL;
-const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
-const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
+function getMetaTagContent(tagName: string): string {
+  const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
+  const element = elements.item(elements.length - 1);
+  const value = element ? element.getAttribute("content") : null;
+  if (value == null) {
+    throw new Error(`Meta tag ${tagName} not found`);
+  }
+  return value;
+}
+
+const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const clientId = getMetaTagContent("osdk-clientId");
+const redirectUrl = getMetaTagContent("osdk-redirectUrl");
+const ontologyRid = getMetaTagContent("osdk-ontologyRid");
 const scopes = [
   "api:ontologies-read",
   "api:ontologies-write",
 ];
 
-checkEnv(url, "VITE_FOUNDRY_API_URL");
-checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
-checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
-
-function checkEnv(
-  value: string | undefined,
-  name: string,
-): asserts value is string {
-  if (value == null) {
-    throw new Error(`Missing environment variable: ${name}`);
-  }
-}
-
-export const auth = createPublicOauthClient(
+export const auth: PublicOauthClient = createPublicOauthClient(
   clientId,
-  url,
+  foundryUrl,
   redirectUrl,
   { scopes },
 );
@@ -35,8 +31,8 @@ export const auth = createPublicOauthClient(
  * Initialize the client to interact with the Ontology SDK
  */
 const client: Client = createClient(
-  url,
-  $ontologyRid,
+  foundryUrl,
+  ontologyRid,
   auth,
 );
 

--- a/examples/example-vue-sdk-2.x/src/client.ts
+++ b/examples/example-vue-sdk-2.x/src/client.ts
@@ -6,10 +6,10 @@ function getMetaTagContent(tagName: string): string {
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
   if (value == null || value === "") {
-    throw new Error(`Meta tag ${tagName} not found`);
+    throw new Error(`Meta tag ${tagName} not found  or empty`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files`);
   }
   return value;
 }

--- a/examples/example-vue-sdk-2.x/src/client.ts
+++ b/examples/example-vue-sdk-2.x/src/client.ts
@@ -6,7 +6,7 @@ function getMetaTagContent(tagName: string): string {
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
   if (value == null || value === "") {
-    throw new Error(`Meta tag ${tagName} not found  or empty`);
+    throw new Error(`Meta tag ${tagName} not found or empty`);
   }
   if (value.match(/%.+%/)) {
     throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files`);

--- a/packages/create-app.template.react.beta/templates/index.html
+++ b/packages/create-app.template.react.beta/templates/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/react.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="osdk-clientId" content="%VITE_FOUNDRY_CLIENT_ID%" />
+    <meta name="osdk-redirectUrl" content="%VITE_FOUNDRY_REDIRECT_URL%" />
+    <meta name="osdk-foundryUrl" content="%VITE_FOUNDRY_API_URL%" />
+    <meta name="osdk-ontologyRid" content="%VITE_FOUNDRY_ONTOLOGY_RID%" />
     <title>Ontology SDK + React</title>
   </head>
   <body>

--- a/packages/create-app.template.react.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.react.beta/templates/src/client.ts.hbs
@@ -5,7 +5,7 @@ function getMetaTagContent(tagName: string): string {
   const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
-  if (value == null) {
+  if (value == null || value === "") {
     throw new Error(`Meta tag ${tagName} not found`);
   }
   if (value.match(/%.+%/)) {

--- a/packages/create-app.template.react.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.react.beta/templates/src/client.ts.hbs
@@ -1,11 +1,20 @@
-import type { Client } from "@osdk/client";
-import { createClient } from "@osdk/client";
-import { $ontologyRid } from "{{osdkPackage}}";
-import { createPublicOauthClient } from "@osdk/oauth";
+import { createClient, type Client } from "@osdk/client";
+import { createPublicOauthClient, type PublicOauthClient } from "@osdk/oauth";
 
-const url = import.meta.env.VITE_FOUNDRY_API_URL;
-const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
-const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
+function getMetaTagContent(tagName: string): string {
+  const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
+  const element = elements.item(elements.length - 1);
+  const value = element ? element.getAttribute("content") : null;
+  if (value == null) {
+    throw new Error(`Meta tag ${tagName} not found`);
+  }
+  return value;
+}
+
+const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const clientId = getMetaTagContent("osdk-clientId");
+const redirectUrl = getMetaTagContent("osdk-redirectUrl");
+const ontologyRid = getMetaTagContent("osdk-ontologyRid");
 {{#if scopes}}
 const scopes = [
   {{#each scopes}}
@@ -14,22 +23,9 @@ const scopes = [
 ];
 {{/if}}
 
-checkEnv(url, "VITE_FOUNDRY_API_URL");
-checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
-checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
-
-function checkEnv(
-  value: string | undefined,
-  name: string,
-): asserts value is string {
-  if (value == null) {
-    throw new Error(`Missing environment variable: ${name}`);
-  }
-}
-
-export const auth = createPublicOauthClient(
+export const auth: PublicOauthClient = createPublicOauthClient(
   clientId,
-  url,
+  foundryUrl,
   redirectUrl,
   {{#if scopes}}
   { scopes },
@@ -40,8 +36,8 @@ export const auth = createPublicOauthClient(
  * Initialize the client to interact with the Ontology SDK
  */
 const client: Client = createClient(
-  url,
-  $ontologyRid,
+  foundryUrl,
+  ontologyRid,
   auth,
 );
 

--- a/packages/create-app.template.react.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.react.beta/templates/src/client.ts.hbs
@@ -6,10 +6,10 @@ function getMetaTagContent(tagName: string): string {
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
   if (value == null || value === "") {
-    throw new Error(`Meta tag ${tagName} not found`);
+    throw new Error(`Meta tag ${tagName} not found or empty`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files`);
   }
   return value;
 }

--- a/packages/create-app.template.react.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.react.beta/templates/src/client.ts.hbs
@@ -8,6 +8,9 @@ function getMetaTagContent(tagName: string): string {
   if (value == null) {
     throw new Error(`Meta tag ${tagName} not found`);
   }
+  if (value.match(/%.+%/)) {
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+  }
   return value;
 }
 

--- a/packages/create-app.template.react/templates/index.html
+++ b/packages/create-app.template.react/templates/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/react.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="osdk-clientId" content="%VITE_FOUNDRY_CLIENT_ID%" />
+    <meta name="osdk-redirectUrl" content="%VITE_FOUNDRY_REDIRECT_URL%" />
+    <meta name="osdk-foundryUrl" content="%VITE_FOUNDRY_API_URL%" />
+    <meta name="osdk-ontologyRid" content="%VITE_FOUNDRY_ONTOLOGY_RID%" />
     <title>Ontology SDK + React</title>
   </head>
   <body>

--- a/packages/create-app.template.react/templates/src/client.ts.hbs
+++ b/packages/create-app.template.react/templates/src/client.ts.hbs
@@ -4,7 +4,7 @@ function getMetaTagContent(tagName: string): string {
   const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
-  if (value == null) {
+  if (value == null || value === "") {
     throw new Error(`Meta tag ${tagName} not found`);
   }
   if (value.match(/%.+%/)) {

--- a/packages/create-app.template.react/templates/src/client.ts.hbs
+++ b/packages/create-app.template.react/templates/src/client.ts.hbs
@@ -5,10 +5,10 @@ function getMetaTagContent(tagName: string): string {
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
   if (value == null || value === "") {
-    throw new Error(`Meta tag ${tagName} not found`);
+    throw new Error(`Meta tag ${tagName} not found or empty`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files`);
   }
   return value;
 }

--- a/packages/create-app.template.react/templates/src/client.ts.hbs
+++ b/packages/create-app.template.react/templates/src/client.ts.hbs
@@ -10,7 +10,7 @@ function getMetaTagContent(tagName: string): string {
   return value;
 }
 
-const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const url = getMetaTagContent("osdk-foundryUrl");
 const clientId = getMetaTagContent("osdk-clientId");
 const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 {{#if scopes}}
@@ -25,10 +25,10 @@ const scopes = [
  * Initialize the client to interact with the Ontology SDK
  */
 const client = new FoundryClient({
-  foundryUrl,
+  url,
   auth: new PublicClientAuth({
     clientId,
-    foundryUrl,
+    url,
     redirectUrl,
     {{#if scopes}}
     scopes,

--- a/packages/create-app.template.react/templates/src/client.ts.hbs
+++ b/packages/create-app.template.react/templates/src/client.ts.hbs
@@ -1,11 +1,18 @@
 import { FoundryClient, PublicClientAuth } from "{{osdkPackage}}";
 
-const url = import.meta.env.VITE_FOUNDRY_API_URL;
-const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
-const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
-checkEnv(url, "VITE_FOUNDRY_API_URL");
-checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
-checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
+function getMetaTagContent(tagName: string): string {
+  const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
+  const element = elements.item(elements.length - 1);
+  const value = element ? element.getAttribute("content") : null;
+  if (value == null) {
+    throw new Error(`Meta tag ${tagName} not found`);
+  }
+  return value;
+}
+
+const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const clientId = getMetaTagContent("osdk-clientId");
+const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 {{#if scopes}}
 const scopes = [
   {{#each scopes}}
@@ -14,23 +21,14 @@ const scopes = [
 ];
 {{/if}}
 
-function checkEnv(
-  value: string | undefined,
-  name: string,
-): asserts value is string {
-  if (value == null) {
-    throw new Error(`Missing environment variable: ${name}`);
-  }
-}
-
 /**
  * Initialize the client to interact with the Ontology SDK
  */
 const client = new FoundryClient({
-  url,
+  foundryUrl,
   auth: new PublicClientAuth({
     clientId,
-    url,
+    foundryUrl,
     redirectUrl,
     {{#if scopes}}
     scopes,

--- a/packages/create-app.template.react/templates/src/client.ts.hbs
+++ b/packages/create-app.template.react/templates/src/client.ts.hbs
@@ -7,6 +7,9 @@ function getMetaTagContent(tagName: string): string {
   if (value == null) {
     throw new Error(`Meta tag ${tagName} not found`);
   }
+  if (value.match(/%.+%/)) {
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+  }
   return value;
 }
 

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/index.html
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/todo-aip-app.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="osdk-clientId" content="%VITE_FOUNDRY_CLIENT_ID%" />
+    <meta name="osdk-redirectUrl" content="%VITE_FOUNDRY_REDIRECT_URL%" />
+    <meta name="osdk-foundryUrl" content="%VITE_FOUNDRY_API_URL%" />
+    <meta name="osdk-ontologyRid" content="%VITE_FOUNDRY_ONTOLOGY_RID%" />
     <title>Ontology SDK Tutorial - To do AIP App</title>
   </head>
   <body>

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/client.ts.hbs
@@ -1,11 +1,20 @@
-import type { Client } from "@osdk/client";
-import { createClient } from "@osdk/client";
-import { createPublicOauthClient } from "@osdk/oauth";
-import { $ontologyRid } from "{{osdkPackage}}";
+import { createClient, type Client } from "@osdk/client";
+import { createPublicOauthClient, type PublicOauthClient } from "@osdk/oauth";
 
-const url = import.meta.env.VITE_FOUNDRY_API_URL;
-const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
-const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
+function getMetaTagContent(tagName: string): string {
+  const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
+  const element = elements.item(elements.length - 1);
+  const value = element ? element.getAttribute("content") : null;
+  if (value == null) {
+    throw new Error(`Meta tag ${tagName} not found`);
+  }
+  return value;
+}
+
+const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const clientId = getMetaTagContent("osdk-clientId");
+const redirectUrl = getMetaTagContent("osdk-redirectUrl");
+const ontologyRid = getMetaTagContent("osdk-ontologyRid");
 {{#if scopes}}
 const scopes = [
   {{#each scopes}}
@@ -14,22 +23,9 @@ const scopes = [
 ];
 {{/if}}
 
-checkEnv(url, "VITE_FOUNDRY_API_URL");
-checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
-checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
-
-function checkEnv(
-  value: string | undefined,
-  name: string,
-): asserts value is string {
-  if (value == null) {
-    throw new Error(`Missing environment variable: ${name}`);
-  }
-}
-
-export const auth = createPublicOauthClient(
+export const auth: PublicOauthClient = createPublicOauthClient(
   clientId,
-  url,
+  foundryUrl,
   redirectUrl,
   {{#if scopes}}
   { scopes },
@@ -40,8 +36,8 @@ export const auth = createPublicOauthClient(
  * Initialize the client to interact with the Ontology SDK
  */
 const client: Client = createClient(
-  url,
-  $ontologyRid,
+  foundryUrl,
+  ontologyRid,
   auth,
 );
 

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/client.ts.hbs
@@ -5,7 +5,7 @@ function getMetaTagContent(tagName: string): string {
   const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
-  if (value == null) {
+  if (value == null || value === "") {
     throw new Error(`Meta tag ${tagName} not found`);
   }
   if (value.match(/%.+%/)) {

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/client.ts.hbs
@@ -6,10 +6,10 @@ function getMetaTagContent(tagName: string): string {
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
   if (value == null || value === "") {
-    throw new Error(`Meta tag ${tagName} not found`);
+    throw new Error(`Meta tag ${tagName} not found or empty`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files`);
   }
   return value;
 }

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/client.ts.hbs
@@ -8,6 +8,9 @@ function getMetaTagContent(tagName: string): string {
   if (value == null) {
     throw new Error(`Meta tag ${tagName} not found`);
   }
+  if (value.match(/%.+%/)) {
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+  }
   return value;
 }
 

--- a/packages/create-app.template.tutorial-todo-aip-app/templates/index.html
+++ b/packages/create-app.template.tutorial-todo-aip-app/templates/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/todo-aip-app.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="osdk-clientId" content="%VITE_FOUNDRY_CLIENT_ID%" />
+    <meta name="osdk-redirectUrl" content="%VITE_FOUNDRY_REDIRECT_URL%" />
+    <meta name="osdk-foundryUrl" content="%VITE_FOUNDRY_API_URL%" />
+    <meta name="osdk-ontologyRid" content="%VITE_FOUNDRY_ONTOLOGY_RID%" />
     <title>Ontology SDK Tutorial - To do AIP App</title>
   </head>
   <body>

--- a/packages/create-app.template.tutorial-todo-aip-app/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app/templates/src/client.ts.hbs
@@ -8,7 +8,7 @@ function getMetaTagContent(tagName: string): string {
     throw new Error(`Meta tag ${tagName} not found`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files`);
   }
   return value;
 }

--- a/packages/create-app.template.tutorial-todo-aip-app/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app/templates/src/client.ts.hbs
@@ -4,7 +4,7 @@ function getMetaTagContent(tagName: string): string {
   const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
-  if (value == null) {
+  if (value == null || value === "") {
     throw new Error(`Meta tag ${tagName} not found`);
   }
   if (value.match(/%.+%/)) {

--- a/packages/create-app.template.tutorial-todo-aip-app/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app/templates/src/client.ts.hbs
@@ -5,7 +5,7 @@ function getMetaTagContent(tagName: string): string {
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
   if (value == null || value === "") {
-    throw new Error(`Meta tag ${tagName} not found`);
+    throw new Error(`Meta tag ${tagName} not found or empty`);
   }
   if (value.match(/%.+%/)) {
     throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files`);

--- a/packages/create-app.template.tutorial-todo-aip-app/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app/templates/src/client.ts.hbs
@@ -10,7 +10,7 @@ function getMetaTagContent(tagName: string): string {
   return value;
 }
 
-const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const url = getMetaTagContent("osdk-foundryUrl");
 const clientId = getMetaTagContent("osdk-clientId");
 const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 {{#if scopes}}
@@ -25,10 +25,10 @@ const scopes = [
  * Initialize the client to interact with the Ontology SDK
  */
 const client = new FoundryClient({
-  foundryUrl,
+  url,
   auth: new PublicClientAuth({
     clientId,
-    foundryUrl,
+    url,
     redirectUrl,
     {{#if scopes}}
     scopes,

--- a/packages/create-app.template.tutorial-todo-aip-app/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app/templates/src/client.ts.hbs
@@ -1,11 +1,18 @@
 import { FoundryClient, PublicClientAuth } from "{{osdkPackage}}";
 
-const url = import.meta.env.VITE_FOUNDRY_API_URL;
-const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
-const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
-checkEnv(url, "VITE_FOUNDRY_API_URL");
-checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
-checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
+function getMetaTagContent(tagName: string): string {
+  const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
+  const element = elements.item(elements.length - 1);
+  const value = element ? element.getAttribute("content") : null;
+  if (value == null) {
+    throw new Error(`Meta tag ${tagName} not found`);
+  }
+  return value;
+}
+
+const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const clientId = getMetaTagContent("osdk-clientId");
+const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 {{#if scopes}}
 const scopes = [
   {{#each scopes}}
@@ -14,23 +21,14 @@ const scopes = [
 ];
 {{/if}}
 
-function checkEnv(
-  value: string | undefined,
-  name: string,
-): asserts value is string {
-  if (value == null) {
-    throw new Error(`Missing environment variable: ${name}`);
-  }
-}
-
 /**
  * Initialize the client to interact with the Ontology SDK
  */
 const client = new FoundryClient({
-  url,
+  foundryUrl,
   auth: new PublicClientAuth({
     clientId,
-    url,
+    foundryUrl,
     redirectUrl,
     {{#if scopes}}
     scopes,

--- a/packages/create-app.template.tutorial-todo-aip-app/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app/templates/src/client.ts.hbs
@@ -7,6 +7,9 @@ function getMetaTagContent(tagName: string): string {
   if (value == null) {
     throw new Error(`Meta tag ${tagName} not found`);
   }
+  if (value.match(/%.+%/)) {
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+  }
   return value;
 }
 

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/index.html
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/todo-app.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="osdk-clientId" content="%VITE_FOUNDRY_CLIENT_ID%" />
+    <meta name="osdk-redirectUrl" content="%VITE_FOUNDRY_REDIRECT_URL%" />
+    <meta name="osdk-foundryUrl" content="%VITE_FOUNDRY_API_URL%" />
+    <meta name="osdk-ontologyRid" content="%VITE_FOUNDRY_ONTOLOGY_RID%" />
     <title>Ontology SDK Tutorial - Todo App</title>
   </head>
   <body>

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/src/client.ts.hbs
@@ -1,11 +1,20 @@
-import type { Client } from "@osdk/client";
-import { createClient } from "@osdk/client";
-import { createPublicOauthClient } from "@osdk/oauth";
-import { $ontologyRid } from "{{osdkPackage}}";
+import { createClient, type Client } from "@osdk/client";
+import { createPublicOauthClient, type PublicOauthClient } from "@osdk/oauth";
 
-const url = import.meta.env.VITE_FOUNDRY_API_URL;
-const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
-const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
+function getMetaTagContent(tagName: string): string {
+  const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
+  const element = elements.item(elements.length - 1);
+  const value = element ? element.getAttribute("content") : null;
+  if (value == null) {
+    throw new Error(`Meta tag ${tagName} not found`);
+  }
+  return value;
+}
+
+const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const clientId = getMetaTagContent("osdk-clientId");
+const redirectUrl = getMetaTagContent("osdk-redirectUrl");
+const ontologyRid = getMetaTagContent("osdk-ontologyRid");
 {{#if scopes}}
 const scopes = [
   {{#each scopes}}
@@ -14,22 +23,9 @@ const scopes = [
 ];
 {{/if}}
 
-checkEnv(url, "VITE_FOUNDRY_API_URL");
-checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
-checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
-
-function checkEnv(
-  value: string | undefined,
-  name: string,
-): asserts value is string {
-  if (value == null) {
-    throw new Error(`Missing environment variable: ${name}`);
-  }
-}
-
-export const auth = createPublicOauthClient(
+export const auth: PublicOauthClient = createPublicOauthClient(
   clientId,
-  url,
+  foundryUrl,
   redirectUrl,
   {{#if scopes}}
   { scopes },
@@ -40,8 +36,8 @@ export const auth = createPublicOauthClient(
  * Initialize the client to interact with the Ontology SDK
  */
 const client: Client = createClient(
-  url,
-  $ontologyRid,
+  foundryUrl,
+  ontologyRid,
   auth,
 );
 

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/src/client.ts.hbs
@@ -5,7 +5,7 @@ function getMetaTagContent(tagName: string): string {
   const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
-  if (value == null) {
+  if (value == null || value === "") {
     throw new Error(`Meta tag ${tagName} not found`);
   }
   if (value.match(/%.+%/)) {

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/src/client.ts.hbs
@@ -6,10 +6,10 @@ function getMetaTagContent(tagName: string): string {
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
   if (value == null || value === "") {
-    throw new Error(`Meta tag ${tagName} not found`);
+    throw new Error(`Meta tag ${tagName} not found or empty`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files`);
   }
   return value;
 }

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/src/client.ts.hbs
@@ -8,6 +8,9 @@ function getMetaTagContent(tagName: string): string {
   if (value == null) {
     throw new Error(`Meta tag ${tagName} not found`);
   }
+  if (value.match(/%.+%/)) {
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+  }
   return value;
 }
 

--- a/packages/create-app.template.tutorial-todo-app/templates/index.html
+++ b/packages/create-app.template.tutorial-todo-app/templates/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/todo-app.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="osdk-clientId" content="%VITE_FOUNDRY_CLIENT_ID%" />
+    <meta name="osdk-redirectUrl" content="%VITE_FOUNDRY_REDIRECT_URL%" />
+    <meta name="osdk-foundryUrl" content="%VITE_FOUNDRY_API_URL%" />
+    <meta name="osdk-ontologyRid" content="%VITE_FOUNDRY_ONTOLOGY_RID%" />
     <title>Ontology SDK Tutorial - Todo App</title>
   </head>
   <body>

--- a/packages/create-app.template.tutorial-todo-app/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-app/templates/src/client.ts.hbs
@@ -4,7 +4,7 @@ function getMetaTagContent(tagName: string): string {
   const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
-  if (value == null) {
+  if (value == null || value === "") {
     throw new Error(`Meta tag ${tagName} not found`);
   }
   if (value.match(/%.+%/)) {

--- a/packages/create-app.template.tutorial-todo-app/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-app/templates/src/client.ts.hbs
@@ -5,10 +5,10 @@ function getMetaTagContent(tagName: string): string {
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
   if (value == null || value === "") {
-    throw new Error(`Meta tag ${tagName} not found`);
+    throw new Error(`Meta tag ${tagName} not found or empty`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files`);
   }
   return value;
 }

--- a/packages/create-app.template.tutorial-todo-app/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-app/templates/src/client.ts.hbs
@@ -10,7 +10,7 @@ function getMetaTagContent(tagName: string): string {
   return value;
 }
 
-const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const url = getMetaTagContent("osdk-foundryUrl");
 const clientId = getMetaTagContent("osdk-clientId");
 const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 {{#if scopes}}
@@ -25,10 +25,10 @@ const scopes = [
  * Initialize the client to interact with the Ontology SDK
  */
 const client = new FoundryClient({
-  foundryUrl,
+  url,
   auth: new PublicClientAuth({
     clientId,
-    foundryUrl,
+    url,
     redirectUrl,
     {{#if scopes}}
     scopes,

--- a/packages/create-app.template.tutorial-todo-app/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-app/templates/src/client.ts.hbs
@@ -1,11 +1,18 @@
 import { FoundryClient, PublicClientAuth } from "{{osdkPackage}}";
 
-const url = import.meta.env.VITE_FOUNDRY_API_URL;
-const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
-const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
-checkEnv(url, "VITE_FOUNDRY_API_URL");
-checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
-checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
+function getMetaTagContent(tagName: string): string {
+  const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
+  const element = elements.item(elements.length - 1);
+  const value = element ? element.getAttribute("content") : null;
+  if (value == null) {
+    throw new Error(`Meta tag ${tagName} not found`);
+  }
+  return value;
+}
+
+const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const clientId = getMetaTagContent("osdk-clientId");
+const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 {{#if scopes}}
 const scopes = [
   {{#each scopes}}
@@ -14,23 +21,14 @@ const scopes = [
 ];
 {{/if}}
 
-function checkEnv(
-  value: string | undefined,
-  name: string,
-): asserts value is string {
-  if (value == null) {
-    throw new Error(`Missing environment variable: ${name}`);
-  }
-}
-
 /**
  * Initialize the client to interact with the Ontology SDK
  */
 const client = new FoundryClient({
-  url,
+  foundryUrl,
   auth: new PublicClientAuth({
     clientId,
-    url,
+    foundryUrl,
     redirectUrl,
     {{#if scopes}}
     scopes,

--- a/packages/create-app.template.tutorial-todo-app/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-app/templates/src/client.ts.hbs
@@ -7,6 +7,9 @@ function getMetaTagContent(tagName: string): string {
   if (value == null) {
     throw new Error(`Meta tag ${tagName} not found`);
   }
+  if (value.match(/%.+%/)) {
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+  }
   return value;
 }
 

--- a/packages/create-app.template.vue.v2/templates/index.html
+++ b/packages/create-app.template.vue.v2/templates/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vue.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="osdk-clientId" content="%VITE_FOUNDRY_CLIENT_ID%" />
+    <meta name="osdk-redirectUrl" content="%VITE_FOUNDRY_REDIRECT_URL%" />
+    <meta name="osdk-foundryUrl" content="%VITE_FOUNDRY_API_URL%" />
+    <meta name="osdk-ontologyRid" content="%VITE_FOUNDRY_ONTOLOGY_RID%" />
     <title>Ontology SDK + Vue</title>
   </head>
   <body>

--- a/packages/create-app.template.vue.v2/templates/src/client.ts.hbs
+++ b/packages/create-app.template.vue.v2/templates/src/client.ts.hbs
@@ -5,7 +5,7 @@ function getMetaTagContent(tagName: string): string {
   const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
-  if (value == null) {
+  if (value == null || value === "") {
     throw new Error(`Meta tag ${tagName} not found`);
   }
   if (value.match(/%.+%/)) {

--- a/packages/create-app.template.vue.v2/templates/src/client.ts.hbs
+++ b/packages/create-app.template.vue.v2/templates/src/client.ts.hbs
@@ -1,11 +1,20 @@
-import type { Client } from "@osdk/client";
-import { createClient } from "@osdk/client";
-import { $ontologyRid } from "{{osdkPackage}}";
-import { createPublicOauthClient } from "@osdk/oauth";
+import { createClient, type Client } from "@osdk/client";
+import { createPublicOauthClient, type PublicOauthClient } from "@osdk/oauth";
 
-const url = import.meta.env.VITE_FOUNDRY_API_URL;
-const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
-const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
+function getMetaTagContent(tagName: string): string {
+  const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
+  const element = elements.item(elements.length - 1);
+  const value = element ? element.getAttribute("content") : null;
+  if (value == null) {
+    throw new Error(`Meta tag ${tagName} not found`);
+  }
+  return value;
+}
+
+const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const clientId = getMetaTagContent("osdk-clientId");
+const redirectUrl = getMetaTagContent("osdk-redirectUrl");
+const ontologyRid = getMetaTagContent("osdk-ontologyRid");
 {{#if scopes}}
 const scopes = [
   {{#each scopes}}
@@ -14,22 +23,9 @@ const scopes = [
 ];
 {{/if}}
 
-checkEnv(url, "VITE_FOUNDRY_API_URL");
-checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
-checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
-
-function checkEnv(
-  value: string | undefined,
-  name: string,
-): asserts value is string {
-  if (value == null) {
-    throw new Error(`Missing environment variable: ${name}`);
-  }
-}
-
-export const auth = createPublicOauthClient(
+export const auth: PublicOauthClient = createPublicOauthClient(
   clientId,
-  url,
+  foundryUrl,
   redirectUrl,
   {{#if scopes}}
   { scopes },
@@ -40,8 +36,8 @@ export const auth = createPublicOauthClient(
  * Initialize the client to interact with the Ontology SDK
  */
 const client: Client = createClient(
-  url,
-  $ontologyRid,
+  foundryUrl,
+  ontologyRid,
   auth,
 );
 

--- a/packages/create-app.template.vue.v2/templates/src/client.ts.hbs
+++ b/packages/create-app.template.vue.v2/templates/src/client.ts.hbs
@@ -6,10 +6,10 @@ function getMetaTagContent(tagName: string): string {
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
   if (value == null || value === "") {
-    throw new Error(`Meta tag ${tagName} not found`);
+    throw new Error(`Meta tag ${tagName} not found  or empty`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files`);
   }
   return value;
 }

--- a/packages/create-app.template.vue.v2/templates/src/client.ts.hbs
+++ b/packages/create-app.template.vue.v2/templates/src/client.ts.hbs
@@ -8,6 +8,9 @@ function getMetaTagContent(tagName: string): string {
   if (value == null) {
     throw new Error(`Meta tag ${tagName} not found`);
   }
+  if (value.match(/%.+%/)) {
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+  }
   return value;
 }
 

--- a/packages/create-app.template.vue.v2/templates/src/client.ts.hbs
+++ b/packages/create-app.template.vue.v2/templates/src/client.ts.hbs
@@ -6,7 +6,7 @@ function getMetaTagContent(tagName: string): string {
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
   if (value == null || value === "") {
-    throw new Error(`Meta tag ${tagName} not found  or empty`);
+    throw new Error(`Meta tag ${tagName} not found or empty`);
   }
   if (value.match(/%.+%/)) {
     throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files`);

--- a/packages/create-app.template.vue/templates/index.html
+++ b/packages/create-app.template.vue/templates/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vue.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="osdk-clientId" content="%VITE_FOUNDRY_CLIENT_ID%" />
+    <meta name="osdk-redirectUrl" content="%VITE_FOUNDRY_REDIRECT_URL%" />
+    <meta name="osdk-foundryUrl" content="%VITE_FOUNDRY_API_URL%" />
+    <meta name="osdk-ontologyRid" content="%VITE_FOUNDRY_ONTOLOGY_RID%" />
     <title>Ontology SDK + Vue</title>
   </head>
   <body>

--- a/packages/create-app.template.vue/templates/src/client.ts.hbs
+++ b/packages/create-app.template.vue/templates/src/client.ts.hbs
@@ -4,7 +4,7 @@ function getMetaTagContent(tagName: string): string {
   const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
-  if (value == null) {
+  if (value == null || value === "") {
     throw new Error(`Meta tag ${tagName} not found`);
   }
   if (value.match(/%.+%/)) {

--- a/packages/create-app.template.vue/templates/src/client.ts.hbs
+++ b/packages/create-app.template.vue/templates/src/client.ts.hbs
@@ -5,10 +5,10 @@ function getMetaTagContent(tagName: string): string {
   const element = elements.item(elements.length - 1);
   const value = element ? element.getAttribute("content") : null;
   if (value == null || value === "") {
-    throw new Error(`Meta tag ${tagName} not found`);
+    throw new Error(`Meta tag ${tagName} not found or empty`);
   }
   if (value.match(/%.+%/)) {
-    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files`);
   }
   return value;
 }

--- a/packages/create-app.template.vue/templates/src/client.ts.hbs
+++ b/packages/create-app.template.vue/templates/src/client.ts.hbs
@@ -10,7 +10,7 @@ function getMetaTagContent(tagName: string): string {
   return value;
 }
 
-const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const url = getMetaTagContent("osdk-foundryUrl");
 const clientId = getMetaTagContent("osdk-clientId");
 const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 {{#if scopes}}
@@ -25,10 +25,10 @@ const scopes = [
  * Initialize the client to interact with the Ontology SDK
  */
 const client = new FoundryClient({
-  foundryUrl,
+  url,
   auth: new PublicClientAuth({
     clientId,
-    foundryUrl,
+    url,
     redirectUrl,
     {{#if scopes}}
     scopes,

--- a/packages/create-app.template.vue/templates/src/client.ts.hbs
+++ b/packages/create-app.template.vue/templates/src/client.ts.hbs
@@ -1,11 +1,18 @@
 import { FoundryClient, PublicClientAuth } from "{{osdkPackage}}";
 
-const url = import.meta.env.VITE_FOUNDRY_API_URL;
-const clientId = import.meta.env.VITE_FOUNDRY_CLIENT_ID;
-const redirectUrl = import.meta.env.VITE_FOUNDRY_REDIRECT_URL;
-checkEnv(url, "VITE_FOUNDRY_API_URL");
-checkEnv(clientId, "VITE_FOUNDRY_CLIENT_ID");
-checkEnv(redirectUrl, "VITE_FOUNDRY_REDIRECT_URL");
+function getMetaTagContent(tagName: string): string {
+  const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
+  const element = elements.item(elements.length - 1);
+  const value = element ? element.getAttribute("content") : null;
+  if (value == null) {
+    throw new Error(`Meta tag ${tagName} not found`);
+  }
+  return value;
+}
+
+const foundryUrl = getMetaTagContent("osdk-foundryUrl");
+const clientId = getMetaTagContent("osdk-clientId");
+const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 {{#if scopes}}
 const scopes = [
   {{#each scopes}}
@@ -14,23 +21,14 @@ const scopes = [
 ];
 {{/if}}
 
-function checkEnv(
-  value: string | undefined,
-  name: string,
-): asserts value is string {
-  if (value == null) {
-    throw new Error(`Missing environment variable: ${name}`);
-  }
-}
-
 /**
  * Initialize the client to interact with the Ontology SDK
  */
 const client = new FoundryClient({
-  url,
+  foundryUrl,
   auth: new PublicClientAuth({
     clientId,
-    url,
+    foundryUrl,
     redirectUrl,
     {{#if scopes}}
     scopes,

--- a/packages/create-app.template.vue/templates/src/client.ts.hbs
+++ b/packages/create-app.template.vue/templates/src/client.ts.hbs
@@ -7,6 +7,9 @@ function getMetaTagContent(tagName: string): string {
   if (value == null) {
     throw new Error(`Meta tag ${tagName} not found`);
   }
+  if (value.match(/%.+%/)) {
+    throw new Error(`Meta tag ${tagName} contains placeholder value. Please add ${value.replace(/%/g, "")} to your .env files.`);
+  }
   return value;
 }
 

--- a/packages/create-app/README.md
+++ b/packages/create-app/README.md
@@ -34,10 +34,12 @@ npx @osdk/create-app [project] [--<option>]
 | --applicationUrl     | URL the production application will be hosted on [string]                        |
 | --skipApplicationUrl | Skip filling in URL the production application will be hosted on [boolean]       |
 | --application        | Application resource identifier (rid) [string]                                   |
+| --ontology           | Ontology resource identifier (rid) [string]                                      |
 | --clientId           | OAuth client ID for application [string]                                         |
 | --osdkPackage        | OSDK package name for application [string]                                       |
 | --osdkRegistryUrl    | URL for NPM registry to install OSDK package [string]                            |
 | --corsProxy          | Include a CORS proxy for Foundry API requests during local development [boolean] |
+| --scopes             | Scopes to request during OAuth flow [array<string>]                              |
 
 ## Templates
 

--- a/packages/create-app/src/cli.test.ts
+++ b/packages/create-app/src/cli.test.ts
@@ -88,6 +88,8 @@ async function runTest(
     "https://app.example.palantirfoundry.com",
     "--application",
     "ri.third-party-applications.main.application.fake",
+    "--ontology",
+    "ri.ontology.main.ontology.fake",
     "--clientId",
     "123",
     "--osdkPackage",
@@ -100,8 +102,6 @@ async function runTest(
     sdkVersion,
     "--scopes",
     "api:read-data",
-    "--ontologyRid",
-    "ri.ontology.main.ontology.fake",
   ]);
 
   expect(fs.readdirSync(path.join(process.cwd(), project)).length)

--- a/packages/create-app/src/cli.test.ts
+++ b/packages/create-app/src/cli.test.ts
@@ -100,6 +100,8 @@ async function runTest(
     sdkVersion,
     "--scopes",
     "api:read-data",
+    "--ontologyRid",
+    "ri.ontology.main.ontology.fake",
   ]);
 
   expect(fs.readdirSync(path.join(process.cwd(), project)).length)

--- a/packages/create-app/src/cli.ts
+++ b/packages/create-app/src/cli.ts
@@ -102,6 +102,10 @@ export async function cli(args: string[] = process.argv): Promise<void> {
             type: "string",
             describe: "Application resource identifier (rid)",
           })
+          .option("ontology", {
+            type: "string",
+            describe: "Ontology resource identifier (rid)",
+          })
           .option("clientId", {
             type: "string",
             describe: "OAuth client ID for application",
@@ -124,10 +128,6 @@ export async function cli(args: string[] = process.argv): Promise<void> {
             array: true,
             describe:
               "List of client-side scopes to be used when creating a client",
-          })
-          .option("ontologyRid", {
-            type: "string",
-            describe: "RID of the Ontology your application is using",
           }),
     );
 
@@ -142,12 +142,12 @@ export async function cli(args: string[] = process.argv): Promise<void> {
   const foundryUrl: string = await promptFoundryUrl(parsed);
   const applicationUrl: string | undefined = await promptApplicationUrl(parsed);
   const application: string = await promptApplicationRid(parsed);
+  const ontology: string = await promptOntologyRid(parsed);
   const clientId: string = await promptClientId(parsed);
   const osdkPackage: string = await promptOsdkPackage(parsed);
   const osdkRegistryUrl: string = await promptOsdkRegistryUrl(parsed);
   const corsProxy: boolean = await promptCorsProxy(parsed);
   const scopes: string[] | undefined = await promptScopes(parsed);
-  const ontologyRid: string = await promptOntologyRid(parsed);
 
   await run({
     project,
@@ -162,6 +162,6 @@ export async function cli(args: string[] = process.argv): Promise<void> {
     osdkRegistryUrl,
     corsProxy,
     scopes,
-    ontologyRid,
+    ontology,
   });
 }

--- a/packages/create-app/src/cli.ts
+++ b/packages/create-app/src/cli.ts
@@ -44,12 +44,12 @@ interface CliArgs {
   applicationUrl?: string;
   skipApplicationUrl?: boolean;
   application?: string;
+  ontology?: string;
   clientId?: string;
   osdkPackage?: string;
   osdkRegistryUrl?: string;
   corsProxy?: boolean;
   scopes?: string[];
-  ontologyRid?: string;
 }
 
 export async function cli(args: string[] = process.argv): Promise<void> {

--- a/packages/create-app/src/cli.ts
+++ b/packages/create-app/src/cli.ts
@@ -127,7 +127,7 @@ export async function cli(args: string[] = process.argv): Promise<void> {
           })
           .option("ontologyRid", {
             type: "string",
-            describe: "RID of the Ontology your application is using.",
+            describe: "RID of the Ontology your application is using",
           }),
     );
 

--- a/packages/create-app/src/cli.ts
+++ b/packages/create-app/src/cli.ts
@@ -23,6 +23,7 @@ import { promptApplicationUrl } from "./prompts/promptApplicationUrl.js";
 import { promptClientId } from "./prompts/promptClientId.js";
 import { promptCorsProxy } from "./prompts/promptCorsProxy.js";
 import { promptFoundryUrl } from "./prompts/promptFoundryUrl.js";
+import { promptOntologyRid } from "./prompts/promptOntologyRid.js";
 import { promptOsdkPackage } from "./prompts/promptOsdkPackage.js";
 import { promptOsdkRegistryUrl } from "./prompts/promptOsdkRegistryUrl.js";
 import { promptOverwrite } from "./prompts/promptOverwrite.js";
@@ -48,6 +49,7 @@ interface CliArgs {
   osdkRegistryUrl?: string;
   corsProxy?: boolean;
   scopes?: string[];
+  ontologyRid?: string;
 }
 
 export async function cli(args: string[] = process.argv): Promise<void> {
@@ -122,6 +124,10 @@ export async function cli(args: string[] = process.argv): Promise<void> {
             array: true,
             describe:
               "List of client-side scopes to be used when creating a client",
+          })
+          .option("ontologyRid", {
+            type: "string",
+            describe: "RID of the Ontology your application is using.",
           }),
     );
 
@@ -141,6 +147,7 @@ export async function cli(args: string[] = process.argv): Promise<void> {
   const osdkRegistryUrl: string = await promptOsdkRegistryUrl(parsed);
   const corsProxy: boolean = await promptCorsProxy(parsed);
   const scopes: string[] | undefined = await promptScopes(parsed);
+  const ontologyRid: string = await promptOntologyRid(parsed);
 
   await run({
     project,
@@ -155,5 +162,6 @@ export async function cli(args: string[] = process.argv): Promise<void> {
     osdkRegistryUrl,
     corsProxy,
     scopes,
+    ontologyRid,
   });
 }

--- a/packages/create-app/src/generate/generateEnv.test.ts
+++ b/packages/create-app/src/generate/generateEnv.test.ts
@@ -53,7 +53,7 @@ PUBLIC_FOUNDRY_CLIENT_ID=123
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-PUBLIC_FOUNDRY_ONTOLOGY_RID=ontology-rid
+PUBLIC_FOUNDRY_ONTOLOGY_RID=ri.ontology.main.ontology.fake
 `.trimStart();
 
 const expectedEnvDevelopmentCorsProxy = `
@@ -89,7 +89,7 @@ PUBLIC_FOUNDRY_CLIENT_ID=123
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-PUBLIC_FOUNDRY_ONTOLOGY_RID=ontology-rid
+PUBLIC_FOUNDRY_ONTOLOGY_RID=ri.ontology.main.ontology.fake
 `.trimStart();
 
 const expectedEnvProduction = `
@@ -125,7 +125,7 @@ PUBLIC_FOUNDRY_CLIENT_ID=123
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-PUBLIC_FOUNDRY_ONTOLOGY_RID=ontology-rid
+PUBLIC_FOUNDRY_ONTOLOGY_RID=ri.ontology.main.ontology.fake
 `.trimStart();
 
 const expectedEnvProductionNoAppUrl = `
@@ -161,7 +161,7 @@ PUBLIC_FOUNDRY_CLIENT_ID=123
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-PUBLIC_FOUNDRY_ONTOLOGY_RID=ontology-rid
+PUBLIC_FOUNDRY_ONTOLOGY_RID=ri.ontology.main.ontology.fake
 `.trimStart();
 
 test("it generates .env.development", () => {
@@ -170,7 +170,7 @@ test("it generates .env.development", () => {
     foundryUrl: "https://example.palantirfoundry.com",
     clientId: "123",
     corsProxy: false,
-    ontologyRid: "ontology-rid",
+    ontology: "ri.ontology.main.ontology.fake",
   })).toEqual(expectedEnvDevelopment);
 });
 
@@ -180,7 +180,7 @@ test("it generates .env.development assuming CORS proxy", () => {
     foundryUrl: "https://example.palantirfoundry.com",
     clientId: "123",
     corsProxy: true,
-    ontologyRid: "ontology-rid",
+    ontology: "ri.ontology.main.ontology.fake",
   })).toEqual(expectedEnvDevelopmentCorsProxy);
 });
 
@@ -190,7 +190,7 @@ test("it generates .env.production", () => {
     foundryUrl: "https://example.palantirfoundry.com",
     applicationUrl: "https://app.com",
     clientId: "123",
-    ontologyRid: "ontology-rid",
+    ontology: "ri.ontology.main.ontology.fake",
   })).toEqual(expectedEnvProduction);
 });
 
@@ -200,6 +200,6 @@ test("it generates .env.production without app url", () => {
     foundryUrl: "https://example.palantirfoundry.com",
     applicationUrl: undefined,
     clientId: "123",
-    ontologyRid: "ontology-rid",
+    ontology: "ri.ontology.main.ontology.fake",
   })).toEqual(expectedEnvProductionNoAppUrl);
 });

--- a/packages/create-app/src/generate/generateEnv.test.ts
+++ b/packages/create-app/src/generate/generateEnv.test.ts
@@ -48,6 +48,11 @@ PUBLIC_FOUNDRY_API_URL=https://example.palantirfoundry.com
 # Developer Console. It typically does not need to be changed.
 
 PUBLIC_FOUNDRY_CLIENT_ID=123
+
+# This Ontology RID must match the Ontology RID your application is using.
+# It typically does not need to be changed.
+
+PUBLIC_FOUNDRY_ONTOLOGY_RID=ontology-rid
 `.trimStart();
 
 const expectedEnvDevelopmentCorsProxy = `
@@ -78,6 +83,11 @@ PUBLIC_FOUNDRY_API_URL=http://localhost:8080
 # Developer Console. It typically does not need to be changed.
 
 PUBLIC_FOUNDRY_CLIENT_ID=123
+
+# This Ontology RID must match the Ontology RID your application is using.
+# It typically does not need to be changed.
+
+PUBLIC_FOUNDRY_ONTOLOGY_RID=ontology-rid
 `.trimStart();
 
 const expectedEnvProduction = `
@@ -108,6 +118,12 @@ PUBLIC_FOUNDRY_API_URL=https://example.palantirfoundry.com
 # Developer Console. It typically does not need to be changed.
 
 PUBLIC_FOUNDRY_CLIENT_ID=123
+
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
+# It typically does not need to be changed.
+
+PUBLIC_FOUNDRY_ONTOLOGY_RID=ontology-rid
 `.trimStart();
 
 const expectedEnvProductionNoAppUrl = `
@@ -138,6 +154,12 @@ PUBLIC_FOUNDRY_API_URL=https://example.palantirfoundry.com
 # Developer Console. It typically does not need to be changed.
 
 PUBLIC_FOUNDRY_CLIENT_ID=123
+
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
+# It typically does not need to be changed.
+
+PUBLIC_FOUNDRY_ONTOLOGY_RID=ontology-rid
 `.trimStart();
 
 test("it generates .env.development", () => {
@@ -146,6 +168,7 @@ test("it generates .env.development", () => {
     foundryUrl: "https://example.palantirfoundry.com",
     clientId: "123",
     corsProxy: false,
+    ontologyRid: "ontology-rid",
   })).toEqual(expectedEnvDevelopment);
 });
 
@@ -155,6 +178,7 @@ test("it generates .env.development assuming CORS proxy", () => {
     foundryUrl: "https://example.palantirfoundry.com",
     clientId: "123",
     corsProxy: true,
+    ontologyRid: "ontology-rid",
   })).toEqual(expectedEnvDevelopmentCorsProxy);
 });
 
@@ -164,6 +188,7 @@ test("it generates .env.production", () => {
     foundryUrl: "https://example.palantirfoundry.com",
     applicationUrl: "https://app.com",
     clientId: "123",
+    ontologyRid: "ontology-rid",
   })).toEqual(expectedEnvProduction);
 });
 
@@ -173,5 +198,6 @@ test("it generates .env.production without app url", () => {
     foundryUrl: "https://example.palantirfoundry.com",
     applicationUrl: undefined,
     clientId: "123",
+    ontologyRid: "ontology-rid",
   })).toEqual(expectedEnvProductionNoAppUrl);
 });

--- a/packages/create-app/src/generate/generateEnv.test.ts
+++ b/packages/create-app/src/generate/generateEnv.test.ts
@@ -49,7 +49,8 @@ PUBLIC_FOUNDRY_API_URL=https://example.palantirfoundry.com
 
 PUBLIC_FOUNDRY_CLIENT_ID=123
 
-# This Ontology RID must match the Ontology RID your application is using.
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
 PUBLIC_FOUNDRY_ONTOLOGY_RID=ontology-rid
@@ -84,7 +85,8 @@ PUBLIC_FOUNDRY_API_URL=http://localhost:8080
 
 PUBLIC_FOUNDRY_CLIENT_ID=123
 
-# This Ontology RID must match the Ontology RID your application is using.
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
 PUBLIC_FOUNDRY_ONTOLOGY_RID=ontology-rid

--- a/packages/create-app/src/generate/generateEnv.ts
+++ b/packages/create-app/src/generate/generateEnv.ts
@@ -19,11 +19,13 @@ export function generateEnvDevelopment({
   foundryUrl,
   clientId,
   corsProxy,
+  ontologyRid,
 }: {
   envPrefix: string;
   foundryUrl: string;
   clientId: string;
   corsProxy: boolean;
+  ontologyRid: string;
 }): string {
   const foundryApiUrl = corsProxy ? "http://localhost:8080" : foundryUrl;
   const applicationUrl = "http://localhost:8080";
@@ -54,6 +56,12 @@ ${envPrefix}FOUNDRY_API_URL=${foundryApiUrl}
 # Developer Console. It typically does not need to be changed.
 
 ${envPrefix}FOUNDRY_CLIENT_ID=${clientId}
+
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
+# It typically does not need to be changed.
+
+${envPrefix}FOUNDRY_ONTOLOGY_RID=${ontologyRid}
 `;
 }
 
@@ -62,11 +70,13 @@ export function generateEnvProduction({
   foundryUrl,
   applicationUrl,
   clientId,
+  ontologyRid,
 }: {
   envPrefix: string;
   foundryUrl: string;
   applicationUrl: string | undefined;
   clientId: string;
+  ontologyRid: string;
 }): string {
   const applicationUrlOrDefault = applicationUrl
     ?? "<Fill in the domain at which you deploy your application>";
@@ -101,5 +111,11 @@ ${envPrefix}FOUNDRY_API_URL=${foundryUrl}
 # Developer Console. It typically does not need to be changed.
 
 ${envPrefix}FOUNDRY_CLIENT_ID=${clientId}
+
+# This Ontology RID must match the Ontology RID your Developer Console is associated with.
+# You can check the Ontology on the "Data Resources" page of Developer Console. 
+# It typically does not need to be changed.
+
+${envPrefix}FOUNDRY_ONTOLOGY_RID=${ontologyRid}
 `;
 }

--- a/packages/create-app/src/generate/generateEnv.ts
+++ b/packages/create-app/src/generate/generateEnv.ts
@@ -19,13 +19,13 @@ export function generateEnvDevelopment({
   foundryUrl,
   clientId,
   corsProxy,
-  ontologyRid,
+  ontology,
 }: {
   envPrefix: string;
   foundryUrl: string;
   clientId: string;
   corsProxy: boolean;
-  ontologyRid: string;
+  ontology: string;
 }): string {
   const foundryApiUrl = corsProxy ? "http://localhost:8080" : foundryUrl;
   const applicationUrl = "http://localhost:8080";
@@ -61,7 +61,7 @@ ${envPrefix}FOUNDRY_CLIENT_ID=${clientId}
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-${envPrefix}FOUNDRY_ONTOLOGY_RID=${ontologyRid}
+${envPrefix}FOUNDRY_ONTOLOGY_RID=${ontology}
 `;
 }
 
@@ -70,13 +70,13 @@ export function generateEnvProduction({
   foundryUrl,
   applicationUrl,
   clientId,
-  ontologyRid,
+  ontology,
 }: {
   envPrefix: string;
   foundryUrl: string;
   applicationUrl: string | undefined;
   clientId: string;
-  ontologyRid: string;
+  ontology: string;
 }): string {
   const applicationUrlOrDefault = applicationUrl
     ?? "<Fill in the domain at which you deploy your application>";
@@ -116,6 +116,6 @@ ${envPrefix}FOUNDRY_CLIENT_ID=${clientId}
 # You can check the Ontology on the "Data Resources" page of Developer Console. 
 # It typically does not need to be changed.
 
-${envPrefix}FOUNDRY_ONTOLOGY_RID=${ontologyRid}
+${envPrefix}FOUNDRY_ONTOLOGY_RID=${ontology}
 `;
 }

--- a/packages/create-app/src/prompts/promptOntologyRid.test.ts
+++ b/packages/create-app/src/prompts/promptOntologyRid.test.ts
@@ -40,7 +40,7 @@ test("it prompts again if answered value is invalid", async () => {
 });
 
 test("it accepts valid initial value without prompt", async () => {
-  expect(await promptOntologyRid({ ontologyRid: validOntologyRid })).toEqual(
+  expect(await promptOntologyRid({ ontology: validOntologyRid })).toEqual(
     validOntologyRid,
   );
   expect(vi.mocked(consola).prompt).not.toHaveBeenCalled();
@@ -49,7 +49,7 @@ test("it accepts valid initial value without prompt", async () => {
 test("it prompts if initial value is invalid", async () => {
   vi.mocked(consola).prompt.mockResolvedValueOnce(validOntologyRid);
   expect(
-    await promptOntologyRid({ ontologyRid: "ri.something.else.and.fake" }),
+    await promptOntologyRid({ ontology: "ri.something.else.and.fake" }),
   ).toEqual(validOntologyRid);
   expect(vi.mocked(consola).prompt).toHaveBeenCalledTimes(1);
 });

--- a/packages/create-app/src/prompts/promptOntologyRid.test.ts
+++ b/packages/create-app/src/prompts/promptOntologyRid.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, expect, test, vi } from "vitest";
+import { consola } from "../consola.js";
+import { promptOntologyRid } from "./promptOntologyRid.js";
+
+vi.mock("../consola.js");
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const validOntologyRid = "ri.ontology.main.ontology.fake";
+
+test("it accepts valid ontology rid from prompt", async () => {
+  vi.mocked(consola).prompt.mockResolvedValueOnce(validOntologyRid);
+  expect(await promptOntologyRid({})).toEqual(validOntologyRid);
+  expect(vi.mocked(consola).prompt).toHaveBeenCalledTimes(1);
+});
+
+test("it prompts again if answered value is invalid", async () => {
+  vi.mocked(consola).prompt.mockResolvedValueOnce("ri.something.else.and.fake");
+  vi.mocked(consola).prompt.mockResolvedValueOnce(validOntologyRid);
+  expect(await promptOntologyRid({})).toEqual(validOntologyRid);
+  expect(vi.mocked(consola).prompt).toHaveBeenCalledTimes(2);
+});
+
+test("it accepts valid initial value without prompt", async () => {
+  expect(await promptOntologyRid({ ontologyRid: validOntologyRid })).toEqual(
+    validOntologyRid,
+  );
+  expect(vi.mocked(consola).prompt).not.toHaveBeenCalled();
+});
+
+test("it prompts if initial value is invalid", async () => {
+  vi.mocked(consola).prompt.mockResolvedValueOnce(validOntologyRid);
+  expect(
+    await promptOntologyRid({ ontologyRid: "ri.something.else.and.fake" }),
+  ).toEqual(validOntologyRid);
+  expect(vi.mocked(consola).prompt).toHaveBeenCalledTimes(1);
+});

--- a/packages/create-app/src/prompts/promptOntologyRid.ts
+++ b/packages/create-app/src/prompts/promptOntologyRid.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { consola } from "../consola.js";
+import { italic } from "../highlight.js";
+
+export async function promptOntologyRid({
+  ontologyRid,
+}: {
+  ontologyRid?: string;
+}): Promise<string> {
+  while (
+    ontologyRid == null
+    || !/^ri\.ontology\.[^.]+\.ontology\.[^.]+$/.test(ontologyRid)
+  ) {
+    if (ontologyRid != null) {
+      consola.fail("Please enter a valid Ontology resource identifier (rid)");
+    }
+    ontologyRid = await consola.prompt(
+      `Enter the Ontology resource identifier (rid) associated with your Developer Console:\n${
+        italic(
+          "(Example: ri.ontology.main.ontology.1df1ce4c-f9d2-0f78-a316-287f6ac80bb2)",
+        )
+      }`,
+      { type: "text" },
+    );
+  }
+  return ontologyRid;
+}

--- a/packages/create-app/src/prompts/promptOntologyRid.ts
+++ b/packages/create-app/src/prompts/promptOntologyRid.ts
@@ -18,18 +18,18 @@ import { consola } from "../consola.js";
 import { italic } from "../highlight.js";
 
 export async function promptOntologyRid({
-  ontologyRid,
+  ontology,
 }: {
-  ontologyRid?: string;
+  ontology?: string;
 }): Promise<string> {
   while (
-    ontologyRid == null
-    || !/^ri\.ontology\.[^.]+\.ontology\.[^.]+$/.test(ontologyRid)
+    ontology == null
+    || !/^ri\.ontology\.[^.]+\.ontology\.[^.]+$/.test(ontology)
   ) {
-    if (ontologyRid != null) {
+    if (ontology != null) {
       consola.fail("Please enter a valid Ontology resource identifier (rid)");
     }
-    ontologyRid = await consola.prompt(
+    ontology = await consola.prompt(
       `Enter the Ontology resource identifier (rid) associated with your Developer Console:\n${
         italic(
           "(Example: ri.ontology.main.ontology.1df1ce4c-f9d2-0f78-a316-287f6ac80bb2)",
@@ -38,5 +38,5 @@ export async function promptOntologyRid({
       { type: "text" },
     );
   }
-  return ontologyRid;
+  return ontology;
 }

--- a/packages/create-app/src/run.ts
+++ b/packages/create-app/src/run.ts
@@ -43,6 +43,7 @@ interface RunArgs {
   osdkRegistryUrl: string;
   corsProxy: boolean;
   scopes: string[] | undefined;
+  ontologyRid: string;
 }
 
 export async function run(
@@ -59,6 +60,7 @@ export async function run(
     osdkRegistryUrl,
     corsProxy,
     scopes,
+    ontologyRid,
   }: RunArgs,
 ): Promise<void> {
   consola.log("");
@@ -164,6 +166,7 @@ export async function run(
     foundryUrl,
     clientId,
     corsProxy,
+    ontologyRid,
   });
   fs.writeFileSync(path.join(root, ".env.development"), envDevelopment);
   const envProduction = generateEnvProduction({
@@ -171,6 +174,7 @@ export async function run(
     foundryUrl,
     applicationUrl,
     clientId,
+    ontologyRid,
   });
   fs.writeFileSync(path.join(root, ".env.production"), envProduction);
   const foundryConfigJson = generateFoundryConfigJson({

--- a/packages/create-app/src/run.ts
+++ b/packages/create-app/src/run.ts
@@ -38,12 +38,12 @@ interface RunArgs {
   foundryUrl: string;
   applicationUrl: string | undefined;
   application: string;
+  ontology: string;
   clientId: string;
   osdkPackage: string;
   osdkRegistryUrl: string;
   corsProxy: boolean;
   scopes: string[] | undefined;
-  ontologyRid: string;
 }
 
 export async function run(
@@ -55,12 +55,12 @@ export async function run(
     foundryUrl,
     applicationUrl,
     application,
+    ontology,
     clientId,
     osdkPackage,
     osdkRegistryUrl,
     corsProxy,
     scopes,
-    ontologyRid,
   }: RunArgs,
 ): Promise<void> {
   consola.log("");
@@ -166,7 +166,7 @@ export async function run(
     foundryUrl,
     clientId,
     corsProxy,
-    ontologyRid,
+    ontology,
   });
   fs.writeFileSync(path.join(root, ".env.development"), envDevelopment);
   const envProduction = generateEnvProduction({
@@ -174,7 +174,7 @@ export async function run(
     foundryUrl,
     applicationUrl,
     clientId,
-    ontologyRid,
+    ontology,
   });
   fs.writeFileSync(path.join(root, ".env.production"), envProduction);
   const foundryConfigJson = generateFoundryConfigJson({

--- a/packages/example-generator/src/run.ts
+++ b/packages/example-generator/src/run.ts
@@ -85,13 +85,13 @@ async function generateExamples(tmpDir: tmp.DirResult): Promise<void> {
       foundryUrl: "https://fake.palantirfoundry.com",
       applicationUrl: "https://example.com",
       application: "ri.third-party-applications.main.application.fake",
+      ontology: "ri.ontology.main.ontology.fake",
       clientId: "123",
       osdkPackage,
       osdkRegistryUrl:
         "https://fake.palantirfoundry.com/artifacts/api/repositories/ri.artifacts.main.repository.fake/contents/release/npm",
       corsProxy: false,
       scopes: ["api:ontologies-read", "api:ontologies-write"],
-      ontologyRid: "ri.ontologies.main.ontology.fake",
     });
 
     await mutateFiles(tmpDir, exampleId, template, sdkVersion);

--- a/packages/example-generator/src/run.ts
+++ b/packages/example-generator/src/run.ts
@@ -91,6 +91,7 @@ async function generateExamples(tmpDir: tmp.DirResult): Promise<void> {
         "https://fake.palantirfoundry.com/artifacts/api/repositories/ri.artifacts.main.repository.fake/contents/release/npm",
       corsProxy: false,
       scopes: ["api:ontologies-read", "api:ontologies-write"],
+      ontologyRid: "ri.ontologies.main.ontology.fake",
     });
 
     await mutateFiles(tmpDir, exampleId, template, sdkVersion);


### PR DESCRIPTION
This PR is in place of https://github.com/palantir/osdk-ts/pull/1352 and it is meant to be a simplification from the original one. 

We leverage [VITE constant replacement](https://vite.dev/guide/env-and-mode#html-constant-replacement) to inject the .env variables in the index.html. We then read those injected meta tags while intializing the client.

The PR adds support for providing ontologyRid in create-app args and uses that to write the FOUNDRY_ONTOLOGY_RID env variable in the generated .env files so they could be injected in the index.html.

This allows the template to remain usable by both foundry-hosted apps and externally hosted apps.