### PR TITLE
Add geotime and mediareference datasources in OAC

### DIFF
--- a/.changeset/nice-teeth-sit.md
+++ b/.changeset/nice-teeth-sit.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker": patch
+---
+
+Add geotime and mediaset datasources to OAC

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -2945,5 +2945,269 @@ describe("Ontology Defining", () => {
         `[Error: Invariant failed: Retention period "bad retention period string" on object "buzz" is not a valid ISO 8601 duration string]`,
       );
     });
+
+    it("Property-level datasources are properly defined", () => {
+      const objectDatasourceIgnored = defineObject({
+        titlePropertyApiName: "bar",
+        displayName: "objectDatasourceIgnored",
+        pluralDisplayName: "objectDatasourceIgnored",
+        apiName: "foo",
+        primaryKeys: ["bar"],
+        properties: [{
+          apiName: "bar",
+          type: "geotimeSeries",
+          displayName: "Bar",
+        }],
+        datasource: { type: "dataset" },
+      });
+
+      const defaultToObjectDatasource = defineObject({
+        titlePropertyApiName: "fizz",
+        displayName: "defaultToObjectDatasource",
+        pluralDisplayName: "defaultToObjectDatasource",
+        apiName: "fizz",
+        primaryKeys: ["fizz"],
+        properties: [{
+          apiName: "fizz",
+          type: "mediaReference",
+          displayName: "Fizz",
+        }, {
+          apiName: "bar",
+          type: "string",
+          displayName: "Bar",
+        }],
+        datasource: { type: "stream" },
+      });
+
+      expect(dumpOntologyFullMetadata()).toMatchInlineSnapshot(`
+      {
+        "blockData": {
+          "blockPermissionInformation": {
+            "actionTypes": {},
+            "linkTypes": {},
+            "objectTypes": {},
+          },
+          "interfaceTypes": {},
+          "linkTypes": {},
+          "objectTypes": {
+            "com.palantir.fizz": {
+              "datasources": [
+                {
+                  "datasource": {
+                    "mediaSetView": {
+                      "assumedMarkings": [],
+                      "mediaSetViewLocator": "com.palantir.fizz.fizz",
+                      "properties": [
+                        "fizz",
+                      ],
+                    },
+                    "type": "mediaSetView",
+                  },
+                  "editsConfiguration": {
+                    "onlyAllowPrivilegedEdits": false,
+                  },
+                  "redacted": false,
+                  "rid": "ri.ontology.main.datasource.fizz",
+                },
+                {
+                  "datasource": {
+                    "streamV2": {
+                      "propertyMapping": {
+                        "bar": "bar",
+                      },
+                      "propertySecurityGroups": undefined,
+                      "retentionPolicy": {
+                        "none": {},
+                        "type": "none",
+                      },
+                      "streamLocator": "com.palantir.fizz",
+                    },
+                    "type": "streamV2",
+                  },
+                  "editsConfiguration": {
+                    "onlyAllowPrivilegedEdits": false,
+                  },
+                  "redacted": false,
+                  "rid": "ri.ontology.main.datasource.com.palantir.fizz",
+                },
+              ],
+              "entityMetadata": {
+                "arePatchesEnabled": false,
+              },
+              "objectType": {
+                "allImplementsInterfaces": {},
+                "apiName": "com.palantir.fizz",
+                "displayMetadata": {
+                  "description": undefined,
+                  "displayName": "defaultToObjectDatasource",
+                  "groupDisplayName": undefined,
+                  "icon": {
+                    "blueprint": {
+                      "color": "#2D72D2",
+                      "locator": "cube",
+                    },
+                    "type": "blueprint",
+                  },
+                  "pluralDisplayName": "defaultToObjectDatasource",
+                  "visibility": "NORMAL",
+                },
+                "implementsInterfaces2": [],
+                "primaryKeys": [
+                  "fizz",
+                ],
+                "propertyTypes": {
+                  "bar": {
+                    "apiName": "bar",
+                    "baseFormatter": undefined,
+                    "dataConstraints": undefined,
+                    "displayMetadata": {
+                      "description": undefined,
+                      "displayName": "Bar",
+                      "visibility": "NORMAL",
+                    },
+                    "indexedForSearch": true,
+                    "inlineAction": undefined,
+                    "ruleSetBinding": undefined,
+                    "sharedPropertyTypeApiName": undefined,
+                    "sharedPropertyTypeRid": undefined,
+                    "status": {
+                      "active": {},
+                      "type": "active",
+                    },
+                    "type": {
+                      "string": {
+                        "analyzerOverride": undefined,
+                        "enableAsciiFolding": undefined,
+                        "isLongText": false,
+                        "supportsEfficientLeadingWildcard": false,
+                        "supportsExactMatching": true,
+                      },
+                      "type": "string",
+                    },
+                    "typeClasses": [],
+                    "valueType": undefined,
+                  },
+                  "fizz": {
+                    "apiName": "fizz",
+                    "baseFormatter": undefined,
+                    "dataConstraints": undefined,
+                    "displayMetadata": {
+                      "description": undefined,
+                      "displayName": "Fizz",
+                      "visibility": "NORMAL",
+                    },
+                    "indexedForSearch": true,
+                    "inlineAction": undefined,
+                    "ruleSetBinding": undefined,
+                    "sharedPropertyTypeApiName": undefined,
+                    "sharedPropertyTypeRid": undefined,
+                    "status": {
+                      "active": {},
+                      "type": "active",
+                    },
+                    "type": {
+                      "mediaReference": {},
+                      "type": "mediaReference",
+                    },
+                    "typeClasses": [],
+                    "valueType": undefined,
+                  },
+                },
+                "redacted": false,
+                "status": {
+                  "active": {},
+                  "type": "active",
+                },
+                "titlePropertyTypeRid": "fizz",
+              },
+            },
+            "com.palantir.foo": {
+              "datasources": [
+                {
+                  "datasource": {
+                    "geotimeSeries": {
+                      "geotimeSeriesIntegrationRid": "com.palantir.foo.bar",
+                      "properties": [
+                        "bar",
+                      ],
+                    },
+                    "type": "geotimeSeries",
+                  },
+                  "editsConfiguration": {
+                    "onlyAllowPrivilegedEdits": false,
+                  },
+                  "redacted": false,
+                  "rid": "ri.ontology.main.datasource.bar",
+                },
+              ],
+              "entityMetadata": {
+                "arePatchesEnabled": false,
+              },
+              "objectType": {
+                "allImplementsInterfaces": {},
+                "apiName": "com.palantir.foo",
+                "displayMetadata": {
+                  "description": undefined,
+                  "displayName": "objectDatasourceIgnored",
+                  "groupDisplayName": undefined,
+                  "icon": {
+                    "blueprint": {
+                      "color": "#2D72D2",
+                      "locator": "cube",
+                    },
+                    "type": "blueprint",
+                  },
+                  "pluralDisplayName": "objectDatasourceIgnored",
+                  "visibility": "NORMAL",
+                },
+                "implementsInterfaces2": [],
+                "primaryKeys": [
+                  "bar",
+                ],
+                "propertyTypes": {
+                  "bar": {
+                    "apiName": "bar",
+                    "baseFormatter": undefined,
+                    "dataConstraints": undefined,
+                    "displayMetadata": {
+                      "description": undefined,
+                      "displayName": "Bar",
+                      "visibility": "NORMAL",
+                    },
+                    "indexedForSearch": true,
+                    "inlineAction": undefined,
+                    "ruleSetBinding": undefined,
+                    "sharedPropertyTypeApiName": undefined,
+                    "sharedPropertyTypeRid": undefined,
+                    "status": {
+                      "active": {},
+                      "type": "active",
+                    },
+                    "type": {
+                      "geotimeSeriesReference": {},
+                      "type": "geotimeSeriesReference",
+                    },
+                    "typeClasses": [],
+                    "valueType": undefined,
+                  },
+                },
+                "redacted": false,
+                "status": {
+                  "active": {},
+                  "type": "active",
+                },
+                "titlePropertyTypeRid": "bar",
+              },
+            },
+          },
+          "sharedPropertyTypes": {},
+        },
+        "importedTypes": {
+          "sharedPropertyTypes": [],
+        },
+      }
+
+ `);
+    });
   });
 });

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -2947,25 +2947,12 @@ describe("Ontology Defining", () => {
     });
 
     it("Property-level datasources are properly defined", () => {
-      const simpleExoticProperty = defineObject({
+      const exampleObject = defineObject({
         titlePropertyApiName: "bar",
-        displayName: "simpleExoticProperty",
-        pluralDisplayName: "simpleExoticProperty",
-        apiName: "foo",
-        primaryKeys: ["bar"],
-        properties: [{
-          apiName: "bar",
-          type: "geotimeSeries",
-          displayName: "Bar",
-        }],
-      });
-
-      const defaultToObjectDatasource = defineObject({
-        titlePropertyApiName: "fizz",
-        displayName: "defaultToObjectDatasource",
-        pluralDisplayName: "defaultToObjectDatasource",
+        displayName: "exampleObject",
+        pluralDisplayName: "exampleObject",
         apiName: "fizz",
-        primaryKeys: ["fizz"],
+        primaryKeys: ["bar"],
         properties: [{
           apiName: "fizz",
           type: "mediaReference",
@@ -2979,234 +2966,156 @@ describe("Ontology Defining", () => {
       });
 
       expect(dumpOntologyFullMetadata()).toMatchInlineSnapshot(`
-      {
-        "blockData": {
-          "blockPermissionInformation": {
-            "actionTypes": {},
+        {
+          "blockData": {
+            "blockPermissionInformation": {
+              "actionTypes": {},
+              "linkTypes": {},
+              "objectTypes": {},
+            },
+            "interfaceTypes": {},
             "linkTypes": {},
-            "objectTypes": {},
-          },
-          "interfaceTypes": {},
-          "linkTypes": {},
-          "objectTypes": {
-            "com.palantir.fizz": {
-              "datasources": [
-                {
-                  "datasource": {
-                    "mediaSetView": {
-                      "assumedMarkings": [],
-                      "mediaSetViewLocator": "com.palantir.fizz.fizz",
-                      "properties": [
-                        "fizz",
-                      ],
-                    },
-                    "type": "mediaSetView",
-                  },
-                  "editsConfiguration": {
-                    "onlyAllowPrivilegedEdits": false,
-                  },
-                  "redacted": false,
-                  "rid": "ri.ontology.main.datasource.fizz",
-                },
-                {
-                  "datasource": {
-                    "streamV2": {
-                      "propertyMapping": {
-                        "bar": "bar",
+            "objectTypes": {
+              "com.palantir.fizz": {
+                "datasources": [
+                  {
+                    "datasource": {
+                      "mediaSetView": {
+                        "assumedMarkings": [],
+                        "mediaSetViewLocator": "com.palantir.fizz.fizz",
+                        "properties": [
+                          "fizz",
+                        ],
                       },
-                      "propertySecurityGroups": undefined,
-                      "retentionPolicy": {
-                        "none": {},
-                        "type": "none",
+                      "type": "mediaSetView",
+                    },
+                    "editsConfiguration": {
+                      "onlyAllowPrivilegedEdits": false,
+                    },
+                    "redacted": false,
+                    "rid": "ri.ontology.main.datasource.fizz",
+                  },
+                  {
+                    "datasource": {
+                      "streamV2": {
+                        "propertyMapping": {
+                          "bar": "bar",
+                          "fizz": "fizz",
+                        },
+                        "propertySecurityGroups": undefined,
+                        "retentionPolicy": {
+                          "none": {},
+                          "type": "none",
+                        },
+                        "streamLocator": "com.palantir.fizz",
                       },
-                      "streamLocator": "com.palantir.fizz",
+                      "type": "streamV2",
                     },
-                    "type": "streamV2",
-                  },
-                  "editsConfiguration": {
-                    "onlyAllowPrivilegedEdits": false,
-                  },
-                  "redacted": false,
-                  "rid": "ri.ontology.main.datasource.com.palantir.fizz",
-                },
-              ],
-              "entityMetadata": {
-                "arePatchesEnabled": false,
-              },
-              "objectType": {
-                "allImplementsInterfaces": {},
-                "apiName": "com.palantir.fizz",
-                "displayMetadata": {
-                  "description": undefined,
-                  "displayName": "defaultToObjectDatasource",
-                  "groupDisplayName": undefined,
-                  "icon": {
-                    "blueprint": {
-                      "color": "#2D72D2",
-                      "locator": "cube",
+                    "editsConfiguration": {
+                      "onlyAllowPrivilegedEdits": false,
                     },
-                    "type": "blueprint",
+                    "redacted": false,
+                    "rid": "ri.ontology.main.datasource.com.palantir.fizz",
                   },
-                  "pluralDisplayName": "defaultToObjectDatasource",
-                  "visibility": "NORMAL",
-                },
-                "implementsInterfaces2": [],
-                "primaryKeys": [
-                  "fizz",
                 ],
-                "propertyTypes": {
-                  "bar": {
-                    "apiName": "bar",
-                    "baseFormatter": undefined,
-                    "dataConstraints": undefined,
-                    "displayMetadata": {
-                      "description": undefined,
-                      "displayName": "Bar",
-                      "visibility": "NORMAL",
-                    },
-                    "indexedForSearch": true,
-                    "inlineAction": undefined,
-                    "ruleSetBinding": undefined,
-                    "sharedPropertyTypeApiName": undefined,
-                    "sharedPropertyTypeRid": undefined,
-                    "status": {
-                      "active": {},
-                      "type": "active",
-                    },
-                    "type": {
-                      "string": {
-                        "analyzerOverride": undefined,
-                        "enableAsciiFolding": undefined,
-                        "isLongText": false,
-                        "supportsEfficientLeadingWildcard": false,
-                        "supportsExactMatching": true,
+                "entityMetadata": {
+                  "arePatchesEnabled": false,
+                },
+                "objectType": {
+                  "allImplementsInterfaces": {},
+                  "apiName": "com.palantir.fizz",
+                  "displayMetadata": {
+                    "description": undefined,
+                    "displayName": "exampleObject",
+                    "groupDisplayName": undefined,
+                    "icon": {
+                      "blueprint": {
+                        "color": "#2D72D2",
+                        "locator": "cube",
                       },
-                      "type": "string",
+                      "type": "blueprint",
                     },
-                    "typeClasses": [],
-                    "valueType": undefined,
+                    "pluralDisplayName": "exampleObject",
+                    "visibility": "NORMAL",
                   },
-                  "fizz": {
-                    "apiName": "fizz",
-                    "baseFormatter": undefined,
-                    "dataConstraints": undefined,
-                    "displayMetadata": {
-                      "description": undefined,
-                      "displayName": "Fizz",
-                      "visibility": "NORMAL",
+                  "implementsInterfaces2": [],
+                  "primaryKeys": [
+                    "bar",
+                  ],
+                  "propertyTypes": {
+                    "bar": {
+                      "apiName": "bar",
+                      "baseFormatter": undefined,
+                      "dataConstraints": undefined,
+                      "displayMetadata": {
+                        "description": undefined,
+                        "displayName": "Bar",
+                        "visibility": "NORMAL",
+                      },
+                      "indexedForSearch": true,
+                      "inlineAction": undefined,
+                      "ruleSetBinding": undefined,
+                      "sharedPropertyTypeApiName": undefined,
+                      "sharedPropertyTypeRid": undefined,
+                      "status": {
+                        "active": {},
+                        "type": "active",
+                      },
+                      "type": {
+                        "string": {
+                          "analyzerOverride": undefined,
+                          "enableAsciiFolding": undefined,
+                          "isLongText": false,
+                          "supportsEfficientLeadingWildcard": false,
+                          "supportsExactMatching": true,
+                        },
+                        "type": "string",
+                      },
+                      "typeClasses": [],
+                      "valueType": undefined,
                     },
-                    "indexedForSearch": true,
-                    "inlineAction": undefined,
-                    "ruleSetBinding": undefined,
-                    "sharedPropertyTypeApiName": undefined,
-                    "sharedPropertyTypeRid": undefined,
-                    "status": {
-                      "active": {},
-                      "type": "active",
+                    "fizz": {
+                      "apiName": "fizz",
+                      "baseFormatter": undefined,
+                      "dataConstraints": undefined,
+                      "displayMetadata": {
+                        "description": undefined,
+                        "displayName": "Fizz",
+                        "visibility": "NORMAL",
+                      },
+                      "indexedForSearch": true,
+                      "inlineAction": undefined,
+                      "ruleSetBinding": undefined,
+                      "sharedPropertyTypeApiName": undefined,
+                      "sharedPropertyTypeRid": undefined,
+                      "status": {
+                        "active": {},
+                        "type": "active",
+                      },
+                      "type": {
+                        "mediaReference": {},
+                        "type": "mediaReference",
+                      },
+                      "typeClasses": [],
+                      "valueType": undefined,
                     },
-                    "type": {
-                      "mediaReference": {},
-                      "type": "mediaReference",
-                    },
-                    "typeClasses": [],
-                    "valueType": undefined,
                   },
+                  "redacted": false,
+                  "status": {
+                    "active": {},
+                    "type": "active",
+                  },
+                  "titlePropertyTypeRid": "bar",
                 },
-                "redacted": false,
-                "status": {
-                  "active": {},
-                  "type": "active",
-                },
-                "titlePropertyTypeRid": "fizz",
               },
             },
-            "com.palantir.foo": {
-              "datasources": [
-                {
-                  "datasource": {
-                    "geotimeSeries": {
-                      "geotimeSeriesIntegrationRid": "com.palantir.foo.bar",
-                      "properties": [
-                        "bar",
-                      ],
-                    },
-                    "type": "geotimeSeries",
-                  },
-                  "editsConfiguration": {
-                    "onlyAllowPrivilegedEdits": false,
-                  },
-                  "redacted": false,
-                  "rid": "ri.ontology.main.datasource.bar",
-                },
-              ],
-              "entityMetadata": {
-                "arePatchesEnabled": false,
-              },
-              "objectType": {
-                "allImplementsInterfaces": {},
-                "apiName": "com.palantir.foo",
-                "displayMetadata": {
-                  "description": undefined,
-                  "displayName": "objectDatasourceIgnored",
-                  "groupDisplayName": undefined,
-                  "icon": {
-                    "blueprint": {
-                      "color": "#2D72D2",
-                      "locator": "cube",
-                    },
-                    "type": "blueprint",
-                  },
-                  "pluralDisplayName": "objectDatasourceIgnored",
-                  "visibility": "NORMAL",
-                },
-                "implementsInterfaces2": [],
-                "primaryKeys": [
-                  "bar",
-                ],
-                "propertyTypes": {
-                  "bar": {
-                    "apiName": "bar",
-                    "baseFormatter": undefined,
-                    "dataConstraints": undefined,
-                    "displayMetadata": {
-                      "description": undefined,
-                      "displayName": "Bar",
-                      "visibility": "NORMAL",
-                    },
-                    "indexedForSearch": true,
-                    "inlineAction": undefined,
-                    "ruleSetBinding": undefined,
-                    "sharedPropertyTypeApiName": undefined,
-                    "sharedPropertyTypeRid": undefined,
-                    "status": {
-                      "active": {},
-                      "type": "active",
-                    },
-                    "type": {
-                      "geotimeSeriesReference": {},
-                      "type": "geotimeSeriesReference",
-                    },
-                    "typeClasses": [],
-                    "valueType": undefined,
-                  },
-                },
-                "redacted": false,
-                "status": {
-                  "active": {},
-                  "type": "active",
-                },
-                "titlePropertyTypeRid": "bar",
-              },
-            },
+            "sharedPropertyTypes": {},
           },
-          "sharedPropertyTypes": {},
-        },
-        "importedTypes": {
-          "sharedPropertyTypes": [],
-        },
-      }
-
- `);
+          "importedTypes": {
+            "sharedPropertyTypes": [],
+          },
+        }
+      `);
     });
   });
 });

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -2947,10 +2947,10 @@ describe("Ontology Defining", () => {
     });
 
     it("Property-level datasources are properly defined", () => {
-      const objectDatasourceIgnored = defineObject({
+      const simpleExoticProperty = defineObject({
         titlePropertyApiName: "bar",
-        displayName: "objectDatasourceIgnored",
-        pluralDisplayName: "objectDatasourceIgnored",
+        displayName: "simpleExoticProperty",
+        pluralDisplayName: "simpleExoticProperty",
         apiName: "foo",
         primaryKeys: ["bar"],
         properties: [{
@@ -2958,7 +2958,6 @@ describe("Ontology Defining", () => {
           type: "geotimeSeries",
           displayName: "Bar",
         }],
-        datasource: { type: "dataset" },
       });
 
       const defaultToObjectDatasource = defineObject({

--- a/packages/maker/src/api/types.ts
+++ b/packages/maker/src/api/types.ts
@@ -173,38 +173,48 @@ export interface SharedPropertyType extends PropertyType {
 }
 
 export type PropertyTypeType =
-  | PropertyTypeTypesWithoutStruct
-  | {
-    type: "struct";
-    structDefinition: {
-      [api_name: string]:
-        | StructPropertyType
-        | Exclude<PropertyTypeTypesWithoutStruct, MarkingPropertyType>;
-    };
-  };
+  | PropertyTypeTypePrimitive
+  | PropertyTypeTypeExotic;
 
-export type PropertyTypeTypesWithoutStruct =
+export type PropertyTypeTypePrimitive =
   | "boolean"
   | "byte"
   | "date"
   | "decimal"
   | "double"
   | "float"
-  | "geopoint"
-  | "geoshape"
   | "integer"
   | "long"
-  | MarkingPropertyType
   | "short"
   | "string"
-  | "timestamp"
+  | "timestamp";
+
+export type PropertyTypeTypeExotic =
+  | "geopoint"
+  | "geoshape"
   | "mediaReference"
-  | "geotimeSeries";
+  | "geotimeSeries"
+  | MarkingPropertyType
+  | PropertyTypeTypeStruct;
 
 type MarkingPropertyType = {
   type: "marking";
   markingType: "MANDATORY" | "CBAC";
 };
+
+type PropertyTypeTypeStruct = {
+  type: "struct";
+  structDefinition: {
+    [api_name: string]:
+      | StructPropertyType
+      | Exclude<PropertyTypeTypesWithoutStruct, MarkingPropertyType>;
+  };
+};
+
+export type PropertyTypeTypesWithoutStruct = Exclude<
+  PropertyTypeType,
+  PropertyTypeTypeStruct
+>;
 
 type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
 

--- a/packages/maker/src/api/types.ts
+++ b/packages/maker/src/api/types.ts
@@ -198,7 +198,8 @@ export type PropertyTypeTypesWithoutStruct =
   | "short"
   | "string"
   | "timestamp"
-  | "mediaReference";
+  | "mediaReference"
+  | "geotimeSeries";
 
 type MarkingPropertyType = {
   type: "marking";

--- a/packages/maker/src/api/types.ts
+++ b/packages/maker/src/api/types.ts
@@ -194,10 +194,10 @@ export type PropertyTypeTypeExotic =
   | "geoshape"
   | "mediaReference"
   | "geotimeSeries"
-  | MarkingPropertyType
+  | PropertyTypeTypeMarking
   | PropertyTypeTypeStruct;
 
-type MarkingPropertyType = {
+type PropertyTypeTypeMarking = {
   type: "marking";
   markingType: "MANDATORY" | "CBAC";
 };
@@ -207,7 +207,7 @@ type PropertyTypeTypeStruct = {
   structDefinition: {
     [api_name: string]:
       | StructPropertyType
-      | Exclude<PropertyTypeTypesWithoutStruct, MarkingPropertyType>;
+      | Exclude<PropertyTypeTypesWithoutStruct, PropertyTypeTypeMarking>;
   };
 };
 

--- a/packages/monorepo.cspell/dict.osdk.txt
+++ b/packages/monorepo.cspell/dict.osdk.txt
@@ -1,13 +1,14 @@
 forwardslash
 haptics
+mediaset
 Nativewind
 osdk
 palantirfoundry
 paperplane
 Pivotable
 Pressable
+siteasset
 Tamagui
 unistyles
-siteasset
-widgetset
 widgetregistry
+widgetset


### PR DESCRIPTION
Some decisions that were made:
- Right now it's impossible to use the same geotime/mediaset datasource for multiple properties. We can add that later if necessary though
- ~~If all properties are exotic, then we ignore the object-level datasource, since it would have no properties sourced from it~~
- Timeseries was not included yet, since it's a special case and includes some extra metadata that's unrelated to these sources