### PR TITLE
Fix up extractRdpDefinition for intersect object sets

### DIFF
--- a/.changeset/thick-shrimps-design.md
+++ b/.changeset/thick-shrimps-design.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Fixes error when using intersection, subtraction, or union object sets

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -143,7 +143,7 @@ async function fetchInterfacePage<
       result.data as OntologyObjectV2[], // drop readonly
       interfaceType.apiName,
       !args.$includeRid,
-      await extractRdpDefinition(client, objectSet, interfaceType.apiName),
+      await extractRdpDefinition(client, objectSet),
     );
     return result as any;
   }
@@ -332,7 +332,7 @@ export async function fetchObjectPage<
       r.data as OntologyObjectV2[],
       undefined,
       undefined,
-      await extractRdpDefinition(client, objectSet, objectType.apiName),
+      await extractRdpDefinition(client, objectSet),
       args.$select,
     ),
     nextPageToken: r.nextPageToken,

--- a/packages/client/src/util/extractRdpDefinition.test.ts
+++ b/packages/client/src/util/extractRdpDefinition.test.ts
@@ -57,7 +57,7 @@ describe("extractRdpDefinition", () => {
     } as any,
   } as MinimalClient;
 
-  const objectSet: ObjectSet = {
+  const objectSetWithRdps: ObjectSet = {
     type: "withProperties",
     objectSet: {
       type: "searchAround",
@@ -80,8 +80,7 @@ describe("extractRdpDefinition", () => {
   it("handles 'withProperties' object set type", async () => {
     const result = await extractRdpDefinition(
       mockClientCtx,
-      objectSet,
-      "",
+      objectSetWithRdps,
     );
 
     expect(result).toMatchInlineSnapshot(
@@ -98,7 +97,7 @@ describe("extractRdpDefinition", () => {
   it("combines definitions from multiple derived properties", async () => {
     const nestedObjectSet: ObjectSet = {
       type: "withProperties",
-      objectSet,
+      objectSet: objectSetWithRdps,
       derivedProperties: {
         rdp1: {
           type: "selection",
@@ -132,7 +131,6 @@ describe("extractRdpDefinition", () => {
     const result = await extractRdpDefinition(
       mockClientCtx,
       nestedObjectSet,
-      "",
     );
 
     expect(result).toMatchInlineSnapshot(`
@@ -148,5 +146,70 @@ describe("extractRdpDefinition", () => {
         },
       }
     `);
+  });
+
+  it("handles `intersection` object set type", async () => {
+    const intersectionObjectSet: ObjectSet = {
+      type: "intersect",
+      objectSets: [{
+        type: "searchAround",
+        objectSet: { type: "base", objectType: "BaseType" },
+        link: "testLink1",
+      }, {
+        type: "searchAround",
+        objectSet: { type: "base", objectType: "BaseType" },
+        link: "testLink1",
+      }],
+    };
+
+    const RdpWithIntersectionBaseObjectSet: ObjectSet = {
+      type: "withProperties",
+      objectSet: intersectionObjectSet,
+      derivedProperties: {
+        myRdp: {
+          type: "selection",
+          objectSet: {
+            type: "searchAround",
+            objectSet: { type: "methodInput" },
+            link: "testLink2",
+          },
+          operation: {
+            type: "get",
+            selectedPropertyApiName: "testProperty",
+          },
+        },
+      },
+    };
+
+    const result = await extractRdpDefinition(
+      mockClientCtx,
+      RdpWithIntersectionBaseObjectSet,
+    );
+
+    expect(result).toMatchInlineSnapshot(
+      `
+      {
+        "myRdp": {
+          "type": "attachment",
+        },
+      }
+    `,
+    );
+  });
+
+  it("throws with intersect, subtract, or union having nested RDPs", async () => {
+    const intersectionObjectSetWithNestedRdps: ObjectSet = {
+      type: "intersect",
+      objectSets: [objectSetWithRdps, {
+        type: "base",
+        objectType: "ThirdType",
+      }],
+    };
+
+    await expect(
+      extractRdpDefinition(mockClientCtx, intersectionObjectSetWithNestedRdps),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: Invariant failed: Object sets combined using intersect, subtract, or union must not contain any derived property definitions]`,
+    );
   });
 });

--- a/packages/monorepo.cspell/dict.foundry-words.txt
+++ b/packages/monorepo.cspell/dict.foundry-words.txt
@@ -1,8 +1,9 @@
-geopoint
-geoshape
-gtsr
 bellaso
 fforms
-mediaReference
+geopoint
+geoshape
 Geotime
+gtsr
+mediaReference
+Rdps
 writeback


### PR DESCRIPTION
Users started encountering errors of the OSDK fetching the metadata of an empty string object type when using intersection, subtraction, or union object set types. This was due to improperly handled edge cases. This PR cleans up the extractRdpDefinition method and removes as many runtime errors as possible besides those that we know will throw in OSS