### PR TITLE
Send baseHref when setting widget set settings

### DIFF
--- a/.changeset/fuzzy-towns-grab.md
+++ b/.changeset/fuzzy-towns-grab.md
@@ -1,0 +1,5 @@
+---
+"@osdk/widget.vite-plugin.unstable": patch
+---
+
+Send baseHref when setting widget set settings

--- a/packages/widget.vite-plugin.unstable/src/dev-plugin/FoundryWidgetDevPlugin.ts
+++ b/packages/widget.vite-plugin.unstable/src/dev-plugin/FoundryWidgetDevPlugin.ts
@@ -143,7 +143,12 @@ export function FoundryWidgetDevPlugin(): Plugin {
             configFiles,
             getLocalhostUrl(server),
           );
-          await publishDevModeSettings(server, widgetIdToOverrides, res);
+          await publishDevModeSettings(
+            server,
+            widgetIdToOverrides,
+            getBaseHref(server),
+            res,
+          );
         },
       );
 
@@ -220,6 +225,10 @@ function getLocalhostUrl(server: ViteDevServer): string {
   return `${
     server.config.server.https ? "https" : "http"
   }://localhost:${server.config.server.port}`;
+}
+
+function getBaseHref(server: ViteDevServer): string {
+  return `${getLocalhostUrl(server)}${server.config.base}`;
 }
 
 /**

--- a/packages/widget.vite-plugin.unstable/src/dev-plugin/network.ts
+++ b/packages/widget.vite-plugin.unstable/src/dev-plugin/network.ts
@@ -26,6 +26,7 @@ export function setWidgetSetSettings(
   foundryUrl: string,
   widgetSetRid: string,
   widgetIdToOverrides: Record<string, string[]>,
+  baseHref: string,
 ): Promise<Response> {
   const widgetSettings: WidgetSettings = Object.fromEntries(
     Object.entries(widgetIdToOverrides).map(
@@ -44,7 +45,7 @@ export function setWidgetSetSettings(
   return fetch(
     `${foundryUrl}/widget-registry/api/dev-mode/settings/${widgetSetRid}/ids`,
     {
-      body: JSON.stringify({ widgetSettings }),
+      body: JSON.stringify({ baseHref, widgetSettings }),
       method: "PUT",
       headers: {
         authorization: `Bearer ${process.env.FOUNDRY_TOKEN}`,

--- a/packages/widget.vite-plugin.unstable/src/dev-plugin/publishDevModeSettings.ts
+++ b/packages/widget.vite-plugin.unstable/src/dev-plugin/publishDevModeSettings.ts
@@ -25,6 +25,7 @@ import { enableDevMode, setWidgetSetSettings } from "./network.js";
 export async function publishDevModeSettings(
   server: ViteDevServer,
   widgetIdToOverrides: Record<string, string[]>,
+  baseHref: string,
   res: ServerResponse,
 ): Promise<void> {
   try {
@@ -48,6 +49,7 @@ export async function publishDevModeSettings(
       foundryUrl,
       widgetSetRid,
       widgetIdToOverrides,
+      baseHref,
     );
     if (settingsResponse.status !== 200) {
       server.config.logger.warn(


### PR DESCRIPTION
Send the local dev server's base URL as the `baseHref` value when setting widget set dev mode settings (e.g. `http://localhost:8080/`). This value is used as the `href` value of the `<base />` element for custom widgets when their HTML is returned from the server. This fixes issues with loading image assets from localhost locations when running a widget in dev mode.