### PR TITLE
Add visibility field to shared property type definition in maker

### DIFF
--- a/.changeset/grumpy-cows-fly.md
+++ b/.changeset/grumpy-cows-fly.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker": minor
+---
+
+Add visibility field to shared property type in maker

--- a/packages/maker/src/api/defineOntology.ts
+++ b/packages/maker/src/api/defineOntology.ts
@@ -489,6 +489,7 @@ function convertSpt(
     description,
     apiName,
     displayName,
+    visibility,
     gothamMapping,
     typeClasses,
     valueType,
@@ -507,7 +508,7 @@ function convertSpt(
     apiName,
     displayMetadata: {
       displayName: displayName ?? apiName,
-      visibility: "NORMAL",
+      visibility: visibility ?? "NORMAL",
       description,
     },
     type: array

--- a/packages/maker/src/api/defineSpt.ts
+++ b/packages/maker/src/api/defineSpt.ts
@@ -17,6 +17,7 @@
 import type {
   ApiNameValueTypeReference,
   SharedPropertyTypeGothamMapping,
+  Visibility,
 } from "@osdk/client.unstable";
 import invariant from "tiny-invariant";
 import { namespace, ontologyDefinition } from "./defineOntology.js";
@@ -35,6 +36,7 @@ export function defineSharedPropertyType(
     description?: string;
     displayName?: string;
     valueType?: ApiNameValueTypeReference;
+    visibility?: Visibility;
     typeClasses?: SharedPropertyType["typeClasses"];
     gothamMapping?: SharedPropertyTypeGothamMapping;
   },

--- a/packages/maker/src/api/types.ts
+++ b/packages/maker/src/api/types.ts
@@ -161,6 +161,7 @@ export interface PropertyType {
   description?: string;
   displayName?: string;
   valueType?: ApiNameValueTypeReference;
+  visibility?: Visibility;
   typeClasses?: TypeClass[];
 }
 


### PR DESCRIPTION
This PR allows for the `visibility` field on a shared property type to be set.