### PR TITLE
Remove ObjectSpecifier from OSDK base

### DIFF
--- a/.changeset/big-animals-teach.md
+++ b/.changeset/big-animals-teach.md
@@ -1,0 +1,5 @@
+---
+"@osdk/api": patch
+---
+
+Removes ObjectSpecifier from OsdkBase

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -875,7 +875,8 @@ export type Osdk<
 
 // @public (undocumented)
 export namespace Osdk {
-    	// Warning: (ae-forgotten-export) The symbol "GetPropsKeys" needs to be exported by the entry point index.d.ts
+    	// Warning: (ae-forgotten-export) The symbol "OsdkBaseWithObjectSpecifier" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "GetPropsKeys" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
     export type Instance<
@@ -883,7 +884,7 @@ export namespace Osdk {
     		OPTIONS extends never | "$rid" | "$allBaseProperties" = never,
     		P extends PropertyKeys<Q> = PropertyKeys<Q>,
     		R extends Record<string, SimplePropertyDef> = {}
-    	> = OsdkBase<Q> & Pick<CompileTimeMetadata<Q>["props"], GetPropsKeys<Q, P, [R] extends [{}] ? false : true>> & ([R] extends [never] ? {} : { [A in keyof R] : SimplePropertyDef.ToRuntimeProperty<R[A]> }) & {
+    	> = OsdkBaseWithObjectSpecifier<Q> & Pick<CompileTimeMetadata<Q>["props"], GetPropsKeys<Q, P, [R] extends [{}] ? false : true>> & ([R] extends [never] ? {} : { [A in keyof R] : SimplePropertyDef.ToRuntimeProperty<R[A]> }) & {
         		readonly $link: Q extends {
             			linksType?: any
             		} ? Q["linksType"] : Q extends ObjectTypeDefinition ? OsdkObjectLinksObject<Q> : never
@@ -900,7 +901,6 @@ export type OsdkBase<Q extends ObjectOrInterfaceDefinition> = {
     	readonly $objectType: string
     	readonly $primaryKey: PrimaryKeyType<Q>
     	readonly $title: string | undefined
-    	readonly $objectSpecifier: ObjectSpecifier<Q>
 };
 
 // @public @deprecated (undocumented)
@@ -1101,7 +1101,7 @@ export namespace QueryResult {
     	// (undocumented)
     export type ObjectSetType<T extends ObjectTypeDefinition> = ObjectSet<T>;
     	// (undocumented)
-    export type ObjectType<T extends ObjectTypeDefinition> = OsdkBase<T>;
+    export type ObjectType<T extends ObjectTypeDefinition> = OsdkBaseWithObjectSpecifier<T>;
     	// (undocumented)
     export type PrimitiveType<T extends keyof DataValueClientToWire> = DataValueWireToClient[T];
     	// Warning: (ae-forgotten-export) The symbol "AggKeyWireToClient" needs to be exported by the entry point index.d.ts

--- a/packages/api/src/OsdkBase.ts
+++ b/packages/api/src/OsdkBase.ts
@@ -16,6 +16,7 @@
 
 import type { PropertyValueWireToClient } from "./mapping/PropertyValueMapping.js";
 import type { ObjectOrInterfaceDefinition } from "./ontology/ObjectOrInterface.js";
+import type { ObjectSpecifier } from "./ontology/ObjectSpecifier.js";
 import type { ObjectTypeDefinition } from "./ontology/ObjectTypeDefinition.js";
 import type { PrimaryKeyTypes } from "./ontology/PrimaryKeyTypes.js";
 import type { OsdkObjectPrimaryKeyType } from "./OsdkObjectPrimaryKeyType.js";
@@ -31,6 +32,12 @@ export type OsdkBase<
 
   readonly $title: string | undefined;
 };
+
+export interface OsdkBaseWithObjectSpecifier<
+  Q extends ObjectOrInterfaceDefinition,
+> extends OsdkBase<Q> {
+  readonly $objectSpecifier: ObjectSpecifier<Q>;
+}
 
 export type PrimaryKeyType<Q extends ObjectOrInterfaceDefinition> =
   & (Q extends ObjectTypeDefinition ? OsdkObjectPrimaryKeyType<Q>

--- a/packages/api/src/OsdkBase.ts
+++ b/packages/api/src/OsdkBase.ts
@@ -16,7 +16,6 @@
 
 import type { PropertyValueWireToClient } from "./mapping/PropertyValueMapping.js";
 import type { ObjectOrInterfaceDefinition } from "./ontology/ObjectOrInterface.js";
-import type { ObjectSpecifier } from "./ontology/ObjectSpecifier.js";
 import type { ObjectTypeDefinition } from "./ontology/ObjectTypeDefinition.js";
 import type { PrimaryKeyTypes } from "./ontology/PrimaryKeyTypes.js";
 import type { OsdkObjectPrimaryKeyType } from "./OsdkObjectPrimaryKeyType.js";
@@ -31,8 +30,6 @@ export type OsdkBase<
   readonly $primaryKey: PrimaryKeyType<Q>;
 
   readonly $title: string | undefined;
-
-  readonly $objectSpecifier: ObjectSpecifier<Q>;
 };
 
 export type PrimaryKeyType<Q extends ObjectOrInterfaceDefinition> =

--- a/packages/api/src/OsdkObjectFrom.ts
+++ b/packages/api/src/OsdkObjectFrom.ts
@@ -25,13 +25,12 @@ import type {
   ObjectOrInterfaceDefinition,
   PropertyKeys,
 } from "./ontology/ObjectOrInterface.js";
-import type { ObjectSpecifier } from "./ontology/ObjectSpecifier.js";
 import type {
   CompileTimeMetadata,
   ObjectTypeDefinition,
 } from "./ontology/ObjectTypeDefinition.js";
 import type { SimplePropertyDef } from "./ontology/SimplePropertyDef.js";
-import type { OsdkBase } from "./OsdkBase.js";
+import type { OsdkBaseWithObjectSpecifier } from "./OsdkBase.js";
 
 type DropDollarOptions<T extends string> = Exclude<
   T,
@@ -198,8 +197,7 @@ export namespace Osdk {
     P extends PropertyKeys<Q> = PropertyKeys<Q>,
     R extends Record<string, SimplePropertyDef> = {},
   > =
-    & OsdkBase<Q>
-    & { $objectSpecifier: ObjectSpecifier<Q> }
+    & OsdkBaseWithObjectSpecifier<Q>
     & Pick<
       CompileTimeMetadata<Q>["props"],
       // If there aren't any additional properties, then we want GetPropsKeys to default to PropertyKeys<Q>

--- a/packages/api/src/OsdkObjectFrom.ts
+++ b/packages/api/src/OsdkObjectFrom.ts
@@ -25,6 +25,7 @@ import type {
   ObjectOrInterfaceDefinition,
   PropertyKeys,
 } from "./ontology/ObjectOrInterface.js";
+import type { ObjectSpecifier } from "./ontology/ObjectSpecifier.js";
 import type {
   CompileTimeMetadata,
   ObjectTypeDefinition,
@@ -198,6 +199,7 @@ export namespace Osdk {
     R extends Record<string, SimplePropertyDef> = {},
   > =
     & OsdkBase<Q>
+    & { $objectSpecifier: ObjectSpecifier<Q> }
     & Pick<
       CompileTimeMetadata<Q>["props"],
       // If there aren't any additional properties, then we want GetPropsKeys to default to PropertyKeys<Q>

--- a/packages/api/src/queries/Queries.ts
+++ b/packages/api/src/queries/Queries.ts
@@ -25,7 +25,7 @@ import type {
   AggregationRangeKeyTypes,
   AggregationValueTypes,
 } from "../ontology/QueryDefinition.js";
-import type { OsdkBase } from "../OsdkBase.js";
+import type { OsdkBase, OsdkBaseWithObjectSpecifier } from "../OsdkBase.js";
 import type { OsdkObjectPrimaryKeyType } from "../OsdkObjectPrimaryKeyType.js";
 import type {
   AggKeyClientToWire,
@@ -95,7 +95,8 @@ export namespace QueryResult {
   /**
    * Helper type to convert action definition parameter object types to typescript types
    */
-  export type ObjectType<T extends ObjectTypeDefinition> = OsdkBase<T>;
+  export type ObjectType<T extends ObjectTypeDefinition> =
+    OsdkBaseWithObjectSpecifier<T>;
 
   /**
    * Helper type to convert action definition parameter object sets to typescript types

--- a/packages/client/src/objectSet/ObjectSetListenerWebsocket.test.ts
+++ b/packages/client/src/objectSet/ObjectSetListenerWebsocket.test.ts
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-import type { ObjectSetSubscription, PropertyKeys } from "@osdk/api";
+import type { ObjectSetSubscription, Osdk, PropertyKeys } from "@osdk/api";
 import { $ontologyRid, Employee } from "@osdk/client.test.ontology";
 import type {
   ObjectSetStreamSubscribeRequests,
-  ObjectUpdate,
   StreamMessage,
 } from "@osdk/foundry.ontologies";
 import {
@@ -125,7 +124,10 @@ describe("ObjectSetListenerWebsocket", async () => {
     >;
     let oslwInst = 0;
 
-    let updateReceived: ObjectUpdate | undefined = undefined;
+    let updateReceived: {
+      object: Osdk.Instance<Employee>;
+      state: "ADDED_OR_UPDATED" | "REMOVED";
+    } | undefined = undefined;
 
     let listenerPromise: DeferredPromise<void>;
 
@@ -147,7 +149,7 @@ describe("ObjectSetListenerWebsocket", async () => {
 
       listener = {
         onChange: vi.fn((o) => {
-          updateReceived = o;
+          updateReceived = { object: o.object, state: o.state };
           listenerPromise.resolve();
         }),
         onError: vi.fn(),

--- a/packages/client/src/queries/applyQuery.ts
+++ b/packages/client/src/queries/applyQuery.ts
@@ -19,6 +19,7 @@ import type {
   AllowedBucketTypes,
   CompileTimeMetadata,
   ObjectOrInterfaceDefinition,
+  ObjectSpecifier,
   ObjectTypeDefinition,
   OsdkBase,
   PrimaryKeyType,
@@ -382,7 +383,7 @@ export function createQueryObjectResponse<
 >(
   primaryKey: PrimaryKeyType<Q>,
   objectDef: Q,
-): OsdkBase<Q> {
+): OsdkBase<Q> & { $objectSpecifier: ObjectSpecifier<Q> } {
   return {
     $apiName: objectDef.apiName,
     $title: undefined,


### PR DESCRIPTION
Having `ObjectSpecifier` on OSDK Base caused issues since we use that type for Functions and Queries object parameters. Leaving `ObjectSpecifier` on OSDK Base and modifying the accepted type of Functions and Queries caused issues since object literals cannot have more than the specifier properties. Additionally, edited the return type of queries that returned objects since they should include the object specifier