### PR TITLE
[Functions] Ontology edits API improvements

### DIFF
--- a/.changeset/wicked-stars-jog.md
+++ b/.changeset/wicked-stars-jog.md
@@ -1,0 +1,5 @@
+---
+"@osdk/functions.unstable": patch
+---
+
+Small improvements to functions ontology edits API

--- a/etc/functions.unstable.report.api.md
+++ b/etc/functions.unstable.report.api.md
@@ -21,7 +21,7 @@ export { Attachment }
 // Warning: (ae-forgotten-export) The symbol "AnyEdit" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export function createEditBatch<T extends AnyEdit>(_client: Client): EditBatch<T>;
+export function createEditBatch<T extends AnyEdit = never>(_client: Client): EditBatch<T>;
 
 // @public (undocumented)
 export type DateISOString<T extends string = string> = T & {

--- a/packages/functions/src/edits/createEditBatch.test.ts
+++ b/packages/functions/src/edits/createEditBatch.test.ts
@@ -48,12 +48,14 @@ describe(createEditBatch, () => {
 
     editBatch.create(Task, { id: 0, name: "My Task Name" });
     editBatch.create(Task, { id: 1, name: "My Other Task Name" });
+    editBatch.create(Task, { id: 3 });
     editBatch.delete({ $apiName: "Task", $primaryKey: 0 });
     editBatch.delete(taskInstance);
     editBatch.update({ $apiName: "Task", $primaryKey: 0 }, {
       name: "My New Task Name",
     });
     editBatch.update(taskInstance, { name: "My Very New Task Name" });
+    editBatch.update({ $apiName: "Task", $primaryKey: 3 }, {});
     editBatch.create(Task, { id: 0, name: "My Task Name" });
 
     editBatch.link({ $apiName: "Task", $primaryKey: 0 }, "RP", {
@@ -81,6 +83,11 @@ describe(createEditBatch, () => {
         obj: Task,
         properties: { id: 1, name: "My Other Task Name" },
       },
+      {
+        type: "createObject",
+        obj: Task,
+        properties: { id: 3 },
+      },
       { type: "deleteObject", obj: { $apiName: "Task", $primaryKey: 0 } },
       { type: "deleteObject", obj: { $apiName: "Task", $primaryKey: 2 } },
       {
@@ -92,6 +99,11 @@ describe(createEditBatch, () => {
         type: "updateObject",
         obj: { $apiName: "Task", $primaryKey: 2 },
         properties: { name: "My Very New Task Name" },
+      },
+      {
+        type: "updateObject",
+        obj: { $apiName: "Task", $primaryKey: 3 },
+        properties: {},
       },
       {
         type: "createObject",

--- a/packages/functions/src/edits/createEditBatch.ts
+++ b/packages/functions/src/edits/createEditBatch.ts
@@ -87,7 +87,7 @@ class InMemoryEditBatch<X extends AnyEdit = never> implements EditBatch<X> {
   }
 }
 
-export function createEditBatch<T extends AnyEdit>(
+export function createEditBatch<T extends AnyEdit = never>(
   _client: Client,
 ): EditBatch<T> {
   return new InMemoryEditBatch<T>();

--- a/packages/functions/src/edits/types.ts
+++ b/packages/functions/src/edits/types.ts
@@ -64,14 +64,24 @@ export interface RemoveLink<
     ObjectMetadata.Link<infer T, any> ? ObjectLocator<T> : never;
 }
 
+type PartialForOptionalProperties<T> =
+  & {
+    [K in keyof T as undefined extends T[K] ? K : never]?: T[K];
+  }
+  & {
+    [K in keyof T as undefined extends T[K] ? never : K]-?: T[K];
+  };
+
 export interface CreateObject<S extends ObjectTypeDefinition> {
   type: "createObject";
   obj: S;
-  properties: {
-    [P in PropertyKeys<S>]: OsdkObjectPropertyType<
-      CompileTimeMetadata<S>["properties"][P]
-    >;
-  };
+  properties: PartialForOptionalProperties<
+    {
+      [P in PropertyKeys<S>]: OsdkObjectPropertyType<
+        CompileTimeMetadata<S>["properties"][P]
+      >;
+    }
+  >;
 }
 
 export interface DeleteObject<S extends ObjectTypeDefinition> {
@@ -82,14 +92,16 @@ export interface DeleteObject<S extends ObjectTypeDefinition> {
 export interface UpdateObject<S extends ObjectTypeDefinition> {
   type: "updateObject";
   obj: ObjectLocator<S>;
-  properties: {
-    [
-      P in Exclude<
-        PropertyKeys<S>,
-        CompileTimeMetadata<S>["primaryKeyApiName"]
-      >
-    ]: OsdkObjectPropertyType<CompileTimeMetadata<S>["properties"][P]>;
-  };
+  properties: Partial<
+    {
+      [
+        P in Exclude<
+          PropertyKeys<S>,
+          CompileTimeMetadata<S>["primaryKeyApiName"]
+        >
+      ]: OsdkObjectPropertyType<CompileTimeMetadata<S>["properties"][P]>;
+    }
+  >;
 }
 
 export type AnyEdit =


### PR DESCRIPTION
Makes the following improvements:
1. Optional properties can be omitted from calls to `create` for creating objects. At runtime, an omitted property will be treated the same as explicitly providing `undefined` values.
2. All properties can be omitted from calls to `update` for updating objects. At runtime, an omitted property will be treated as a no-op (i.e., keep the property value the same).
3. Fix `createEditBatch` default typing to `never`