### PR TITLE
Move Vite plugin to API Gateway public endpoints

### DIFF
--- a/.changeset/dry-hats-scream.md
+++ b/.changeset/dry-hats-scream.md
@@ -1,0 +1,5 @@
+---
+"@osdk/widget.vite-plugin.unstable": patch
+---
+
+Move Vite plugin to API Gateway public endpoints

--- a/packages/widget.vite-plugin.unstable/src/dev-plugin/network.ts
+++ b/packages/widget.vite-plugin.unstable/src/dev-plugin/network.ts
@@ -15,11 +15,11 @@
  */
 
 type WidgetSettings = Record<string, {
-  entrypointJs: Array<{
+  scriptEntrypoints: Array<{
     filePath: string;
-    scriptType: { type: "module"; module: {} };
+    scriptType: "DEFAULT" | "MODULE";
   }>;
-  entrypointCss: Array<{ filePath: string }>;
+  stylesheetEntrypoints: Array<{ filePath: string }>;
 }>;
 
 export function setWidgetSetSettings(
@@ -33,20 +33,26 @@ export function setWidgetSetSettings(
       ([widgetId, overrides]) => ([
         widgetId,
         {
-          entrypointJs: overrides.map((filePath) => ({
+          scriptEntrypoints: overrides.map((filePath) => ({
             filePath,
-            scriptType: { type: "module", module: {} },
+            scriptType: "MODULE",
           })),
-          entrypointCss: [],
+          stylesheetEntrypoints: [],
         },
       ] as const),
     ),
   );
   return fetch(
-    `${foundryUrl}/widget-registry/api/dev-mode/settings/${widgetSetRid}/ids`,
+    `${foundryUrl}/api/v2/widgets/devModeSettings/setWidgetSetById?preview=true`,
     {
-      body: JSON.stringify({ baseHref, widgetSettings }),
-      method: "PUT",
+      body: JSON.stringify({
+        widgetSetRid,
+        settings: {
+          baseHref,
+          widgetSettings,
+        },
+      }),
+      method: "POST",
       headers: {
         authorization: `Bearer ${process.env.FOUNDRY_TOKEN}`,
         accept: "application/json",
@@ -57,11 +63,14 @@ export function setWidgetSetSettings(
 }
 
 export function enableDevMode(foundryUrl: string): Promise<Response> {
-  return fetch(`${foundryUrl}/widget-registry/api/dev-mode/enable`, {
-    method: "POST",
-    headers: {
-      authorization: `Bearer ${process.env.FOUNDRY_TOKEN}`,
-      accept: "application/json",
+  return fetch(
+    `${foundryUrl}/api/v2/widgets/devModeSettings/enable?preview=true`,
+    {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${process.env.FOUNDRY_TOKEN}`,
+        accept: "application/json",
+      },
     },
-  });
+  );
 }


### PR DESCRIPTION
We recently created public API equivalents of the internal APIs being used by this plugin, so this change moves the implementation over to using those.

The APIs aren't rolled out everywhere yet, but we need to cut a new release of this package and update our templates before this change will be used.