### PR TITLE
Removes support for Boolean Primary Keys

### DIFF
--- a/.changeset/fancy-cats-accept.md
+++ b/.changeset/fancy-cats-accept.md
@@ -1,0 +1,7 @@
+---
+"@osdk/generator-converters": patch
+"@osdk/client": patch
+"@osdk/api": patch
+---
+
+Removes support for boolean primary keys

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -950,7 +950,7 @@ export type PossibleWhereClauseFilters = "$gt" | "$eq" | "$ne" | "$isNull" | "$c
 export type PrimaryKeyType<Q extends ObjectOrInterfaceDefinition> = (Q extends ObjectTypeDefinition ? OsdkObjectPrimaryKeyType<Q> : unknown) & PropertyValueWireToClient[PrimaryKeyTypes];
 
 // @public (undocumented)
-export type PrimaryKeyTypes = "string" | "datetime" | "double" | "boolean" | "integer" | "timestamp" | "short" | "long" | "byte";
+export type PrimaryKeyTypes = "string" | "datetime" | "double" | "integer" | "timestamp" | "short" | "long" | "byte";
 
 // @public (undocumented)
 export interface PropertyDef<

--- a/packages/api/src/ontology/PrimaryKeyTypes.ts
+++ b/packages/api/src/ontology/PrimaryKeyTypes.ts
@@ -18,7 +18,6 @@ export type PrimaryKeyTypes =
   | "string"
   | "datetime"
   | "double"
-  | "boolean"
   | "integer"
   | "timestamp"
   | "short"

--- a/packages/client/src/object/convertWireToOsdkObjects/BaseHolder.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/BaseHolder.ts
@@ -26,7 +26,7 @@ export interface BaseHolder {
 
   readonly $apiName: string;
   readonly $objectType: string;
-  readonly $primaryKey: string | number | boolean;
+  readonly $primaryKey: string | number;
   readonly $title: string | undefined;
   readonly $objectSpecifier: ObjectSpecifier<any>;
 

--- a/packages/generator-converters/src/wirePropertyV2ToSdkPrimaryKeyTypeDefinition.ts
+++ b/packages/generator-converters/src/wirePropertyV2ToSdkPrimaryKeyTypeDefinition.ts
@@ -24,18 +24,16 @@ export function wirePropertyV2ToSdkPrimaryKeyTypeDefinition(
     case "integer":
     case "double":
     case "string":
-    case "boolean":
     case "byte":
     case "long":
-    case "short": {
+    case "short":
+    case "timestamp": {
       return input.dataType.type;
     }
     case "date": {
       return "datetime";
     }
-    case "timestamp": {
-      return "timestamp";
-    }
+    case "boolean":
     case "geopoint":
     case "geoshape":
     case "decimal":
@@ -50,7 +48,7 @@ export function wirePropertyV2ToSdkPrimaryKeyTypeDefinition(
     case "cipherText":
     case "vector":
       throw new Error(
-        `Type not supported for primaryKey: ${input.dataType.type}`,
+        `Primary key of type ${input.dataType.type} is not supported`,
       );
     default:
       const _: never = input.dataType;


### PR DESCRIPTION
Boolean PK types are rarely used across the ontology and cause conflicts with React cache keys.