### PR TITLE
Make map record types partial

### DIFF
--- a/.changeset/afraid-rocks-eat.md
+++ b/.changeset/afraid-rocks-eat.md
@@ -1,0 +1,6 @@
+---
+"@osdk/generator": patch
+"@osdk/client": patch
+---
+
+Make Query Map Types Optional

--- a/packages/client/src/queries/queries.test.ts
+++ b/packages/client/src/queries/queries.test.ts
@@ -277,7 +277,7 @@ describe("queries", () => {
 
     expectTypeOf<InferredParamType>()
       .toMatchTypeOf<
-        { peopleMap: Record<ObjectSpecifier<Employee>, string> }
+        { peopleMap: Partial<Record<ObjectSpecifier<Employee>, string>> }
       >();
 
     const myMap: Record<ObjectSpecifier<Employee>, string> = {
@@ -294,7 +294,7 @@ describe("queries", () => {
     `);
 
     expectTypeOf<typeof result>().toMatchTypeOf<
-      Record<ObjectSpecifier<Employee>, number>
+      Partial<Record<ObjectSpecifier<Employee>, number>>
     >();
 
     const object = await client(Employee).fetchOne(50030);

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/queries/queryTakesAllParameterTypes.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/queries/queryTakesAllParameterTypes.ts
@@ -45,12 +45,12 @@ export namespace queryTakesAllParameterTypes {
     /**
      * (no ontology metadata)
      */
-    readonly functionMap: Record<QueryParam.PrimitiveType<'float'>, QueryParam.PrimitiveType<'string'>>;
+    readonly functionMap: Partial<Record<QueryParam.PrimitiveType<'float'>, QueryParam.PrimitiveType<'string'>>>;
 
     /**
      * (no ontology metadata)
      */
-    readonly functionMapObjectKey: Record<ObjectSpecifier<Todo>, QueryParam.PrimitiveType<'string'>>;
+    readonly functionMapObjectKey: Partial<Record<ObjectSpecifier<Todo>, QueryParam.PrimitiveType<'string'>>>;
 
     /**
      * (no ontology metadata)

--- a/packages/generator/src/v2.0/generatePerQueryDataFiles.ts
+++ b/packages/generator/src/v2.0/generatePerQueryDataFiles.ts
@@ -371,9 +371,9 @@ export function getQueryParamType(
       break;
 
     case "map":
-      inner = `Record<${
+      inner = `Partial<Record<${
         getQueryParamType(enhancedOntology, input.keyType, type, true)
-      }, ${getQueryParamType(enhancedOntology, input.valueType, type)}>`;
+      }, ${getQueryParamType(enhancedOntology, input.valueType, type)}>>`;
   }
 
   if (input.multiplicity && type === "Param") {


### PR DESCRIPTION
We want users to be aware their object specifier may not be in the map