### PR TITLE
Add `Media#getMediaReference` method to get media reference object

### DIFF
--- a/.changeset/breezy-hotels-melt.md
+++ b/.changeset/breezy-hotels-melt.md
@@ -1,0 +1,7 @@
+---
+"@osdk/shared.test": patch
+"@osdk/client": patch
+"@osdk/api": patch
+---
+
+Add 'getMediaReference' method to Media

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -716,6 +716,7 @@ export namespace Logger {
 export interface Media {
     	fetchContents(): Promise<Response>;
     	fetchMetadata(): Promise<MediaMetadata_2>;
+    	getMediaReference(): MediaReference;
 }
 
 // @public

--- a/packages/api/src/object/Media.ts
+++ b/packages/api/src/object/Media.ts
@@ -26,7 +26,7 @@ export interface Media {
   /**
    * Returns the media reference
    */
-  getReference(): MediaReference;
+  getMediaReference(): MediaReference;
 }
 
 /**

--- a/packages/api/src/object/Media.ts
+++ b/packages/api/src/object/Media.ts
@@ -23,6 +23,10 @@ export interface Media {
    * Fetches content of a media reference property
    */
   fetchContents(): Promise<Response>;
+  /**
+   * Returns the media reference
+   */
+  getReference(): MediaReference;
 }
 
 /**

--- a/packages/client/src/createMediaReferenceProperty.ts
+++ b/packages/client/src/createMediaReferenceProperty.ts
@@ -15,6 +15,7 @@
  */
 
 import type { Media, MediaMetadata, MediaReference } from "@osdk/api";
+import type { MediaReference as CoreMediaReference } from "@osdk/foundry.core";
 import * as OntologiesV2 from "@osdk/foundry.ontologies";
 import type { MinimalClient } from "./MinimalClientContext.js";
 
@@ -28,18 +29,18 @@ export class MediaReferencePropertyImpl implements Media {
     objectApiName: string;
     primaryKey: any;
     propertyName: string;
-    mediaReferencePropertyValue: OntologiesV2.MediaReferenceProperty;
+    mediaReference: CoreMediaReference;
   }) {
     const {
       client,
       objectApiName,
       primaryKey,
       propertyName,
-      mediaReferencePropertyValue,
+      mediaReference,
     } = args;
     this.#client = client;
     this.#triplet = [objectApiName, primaryKey, propertyName];
-    this.#mediaReference = JSON.parse(mediaReferencePropertyValue);
+    this.#mediaReference = mediaReference;
   }
 
   public async fetchContents(): Promise<Response> {

--- a/packages/client/src/createMediaReferenceProperty.ts
+++ b/packages/client/src/createMediaReferenceProperty.ts
@@ -69,7 +69,7 @@ export class MediaReferencePropertyImpl implements Media {
     };
   }
 
-  public getReference(): MediaReference {
+  public getMediaReference(): MediaReference {
     return this.#mediaReference;
   }
 }

--- a/packages/client/src/createMediaReferenceProperty.ts
+++ b/packages/client/src/createMediaReferenceProperty.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import type { Media, MediaMetadata } from "@osdk/api";
+import type { Media, MediaMetadata, MediaReference } from "@osdk/api";
 import * as OntologiesV2 from "@osdk/foundry.ontologies";
 import type { MinimalClient } from "./MinimalClientContext.js";
 
 export class MediaReferencePropertyImpl implements Media {
+  #mediaReference: MediaReference;
   #triplet: [string, any, string];
   #client: MinimalClient;
 
@@ -27,10 +28,18 @@ export class MediaReferencePropertyImpl implements Media {
     objectApiName: string;
     primaryKey: any;
     propertyName: string;
+    mediaReferencePropertyValue: OntologiesV2.MediaReferenceProperty;
   }) {
-    const { client, objectApiName, primaryKey, propertyName } = args;
+    const {
+      client,
+      objectApiName,
+      primaryKey,
+      propertyName,
+      mediaReferencePropertyValue,
+    } = args;
     this.#client = client;
     this.#triplet = [objectApiName, primaryKey, propertyName];
+    this.#mediaReference = JSON.parse(mediaReferencePropertyValue);
   }
 
   public async fetchContents(): Promise<Response> {
@@ -58,5 +67,9 @@ export class MediaReferencePropertyImpl implements Media {
       sizeBytes: Number(r.sizeBytes),
       mediaType: r.mediaType,
     };
+  }
+
+  public getReference(): MediaReference {
+    return this.#mediaReference;
   }
 }

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import type { Attachment, ReferenceValue } from "@osdk/foundry.ontologies";
+
+import type { 
+  Attachment,
+  MediaReferenceProperty,
+  ReferenceValue,
+} from "@osdk/foundry.ontologies";
 import invariant from "tiny-invariant";
 import { GeotimeSeriesPropertyImpl } from "../../createGeotimeSeriesProperty.js";
 import { MediaReferencePropertyImpl } from "../../createMediaReferenceProperty.js";
@@ -273,6 +278,7 @@ function createSpecialProperty(
       objectApiName: objectDef.apiName,
       primaryKey: rawObject[objectDef.primaryKeyApiName as string],
       propertyName: p as string,
+      mediaReferencePropertyValue: rawValue as MediaReferenceProperty,
     });
   }
 }

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -14,12 +14,8 @@
  * limitations under the License.
  */
 
-
-import type { 
-  Attachment,
-  MediaReferenceProperty,
-  ReferenceValue,
-} from "@osdk/foundry.ontologies";
+import type { MediaReference } from "@osdk/foundry.core";
+import type { Attachment, ReferenceValue } from "@osdk/foundry.ontologies";
 import invariant from "tiny-invariant";
 import { GeotimeSeriesPropertyImpl } from "../../createGeotimeSeriesProperty.js";
 import { MediaReferencePropertyImpl } from "../../createMediaReferenceProperty.js";
@@ -278,7 +274,7 @@ function createSpecialProperty(
       objectApiName: objectDef.apiName,
       primaryKey: rawObject[objectDef.primaryKeyApiName as string],
       propertyName: p as string,
-      mediaReferencePropertyValue: rawValue as MediaReferenceProperty,
+      mediaReference: rawValue as MediaReference,
     });
   }
 }

--- a/packages/client/src/object/media.test.ts
+++ b/packages/client/src/object/media.test.ts
@@ -48,7 +48,8 @@ describe("media", () => {
         ),
         "application/json",
         "file1.txt",
-        stubData.objectWithAllPropertyTypes1.mediaReference,
+        stubData.objectWithAllPropertyTypes1.mediaReference.reference
+          .mediaSetViewItem.mediaItemRid,
       );
 
     return () => {
@@ -81,6 +82,29 @@ describe("media", () => {
     const mediaContent = await object1?.mediaReference?.fetchContents();
     expect(await mediaContent!.json()).toEqual({
       content: "Hello World",
+    });
+  });
+
+  it("gets media reference successfully", async () => {
+    const result = await client(objectTypeWithAllPropertyTypes)
+      .where({ id: stubData.objectWithAllPropertyTypes1.id }).fetchPage();
+
+    const object1 = result.data[0];
+    expect(object1.mediaReference).toBeDefined();
+    const mediaReference = object1.mediaReference?.getMediaReference();
+    expect(mediaReference).toEqual({
+      mimeType: "application/pdf",
+      reference: {
+        type: "mediaSetViewItem",
+        mediaSetViewItem: {
+          mediaSetRid:
+            "ri.mio.main.media-set.4153d42f-ca4b-4e42-8ca5-8e6aa7edb642",
+          mediaSetViewRid:
+            "ri.mio.main.view.82a798ad-d637-4595-acc6-987bcf16629b",
+          mediaItemRid:
+            "ri.mio.main.media-item.001ec98b-1620-4814-9e17-8e9c4e536225",
+        },
+      },
     });
   });
 });

--- a/packages/e2e.sandbox.catchall/src/runMediaTest.ts
+++ b/packages/e2e.sandbox.catchall/src/runMediaTest.ts
@@ -24,7 +24,10 @@ export async function runMediaTest(): Promise<void> {
   );
 
   console.log("Object id:", result?.id);
-  console.log("Object Media reference:", result?.mediaReference);
+  console.log(
+    "Object Media reference:",
+    result?.mediaReference?.getMediaReference(),
+  );
 
   const mediaMetadata = await result.mediaReference?.fetchMetadata();
   const response = await result.mediaReference?.fetchContents().then(

--- a/packages/shared.test/src/FauxFoundry/FauxDataStore.ts
+++ b/packages/shared.test/src/FauxFoundry/FauxDataStore.ts
@@ -526,7 +526,7 @@ export class FauxDataStore {
       );
     }
 
-    const rid = obj[property];
+    const rid = obj[property].reference.mediaSetViewItem.mediaItemRid;
 
     if (!rid || !rid.startsWith("ri.")) {
       throw new OpenApiCallError(

--- a/packages/shared.test/src/stubs/objects.ts
+++ b/packages/shared.test/src/stubs/objects.ts
@@ -256,7 +256,20 @@ export const objectWithAllPropertyTypes1 = {
       type: "Polygon",
     },
   ],
-  mediaReference: "ri.MediaReferencePlaceholder",
+  mediaReference: {
+    mimeType: "application/pdf",
+    reference: {
+      type: "mediaSetViewItem",
+      mediaSetViewItem: {
+        mediaSetRid:
+          "ri.mio.main.media-set.4153d42f-ca4b-4e42-8ca5-8e6aa7edb642",
+        mediaSetViewRid:
+          "ri.mio.main.view.82a798ad-d637-4595-acc6-987bcf16629b",
+        mediaItemRid:
+          "ri.mio.main.media-item.001ec98b-1620-4814-9e17-8e9c4e536225",
+      },
+    },
+  },
 } as const;
 
 export const objectWithAllPropertyTypesEmptyEntries = {


### PR DESCRIPTION
When editing/creating an object with a media reference property, Actions BE expects a media reference object in the form of:
```
{ 
    mimeType: string,
    mediaReference: {
        type: "mediaSetViewItem",
        mediaSetViewItem: {
            mediaSetRid: string,
            mediaSetViewRid: string,
            mediaItemRid: string,
        }
    }
}
```

Currently, we do not have a way to access this info given a `Media` object in TS OSDK at runtime, but gateway does provide us these values. Example from API:
```
{
    mimeType: "application/pdf",
    reference: {
        type: "mediaSetViewItem",
        mediaSetViewItem: {
            mediaSetRid: "ri.mio.main.media-set.4153d42f-ca4b-4e42-8ca5-8e6aa7edb642",
            mediaSetViewRid: "ri.mio.main.view.82a798ad-d637-4595-acc6-987bcf16629b",
            mediaItemRid: "ri.mio.main.media-item.001ec98b-1620-4814-9e17-8e9c4e536225",
        },
    },
 }
```