### PR TITLE
Generate jsdoc for properties and add test

### DIFF
--- a/.changeset/hungry-stars-doubt.md
+++ b/.changeset/hungry-stars-doubt.md
@@ -1,0 +1,6 @@
+---
+"@osdk/generator": patch
+"@osdk/client": patch
+---
+
+JSdoc for object properties are generated

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Employee.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Employee.ts
@@ -23,11 +23,29 @@ export namespace Employee {
   }
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly class: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly employeeId: $PropType['integer'];
+    /**
+     *   description: TimeSeries of the status of the employee
+     */
     readonly employeeStatus: $PropType['stringTimeseries'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly fullName: $PropType['string'] | undefined;
+    /**
+     *   description: The unique of the employee's assigned office. This is some more text.
+     */
     readonly office: $PropType['integer'] | undefined;
+    /**
+     *   description: The date the employee was hired (most recently, if they were re-hired)
+     */
     readonly startDate: $PropType['datetime'] | undefined;
   }
   export type StrictProps = Props;

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Office.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Office.ts
@@ -26,11 +26,29 @@ export namespace Office {
   export type Links = {};
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly entrance: $PropType['geopoint'] | undefined;
+    /**
+     *   description: The individual capacities of meetings rooms in the office
+     */
     readonly meetingRoomCapacities: $PropType['integer'][] | undefined;
+    /**
+     *   description: The Names of meetings rooms in the office
+     */
     readonly meetingRooms: $PropType['string'][] | undefined;
+    /**
+     *   description: The Name of the Office
+     */
     readonly name: $PropType['string'] | undefined;
+    /**
+     *   description: The occupied area of the Office
+     */
     readonly occupiedArea: $PropType['geoshape'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly officeId: $PropType['string'];
   }
   export type StrictProps = Props;

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Todo.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/Todo.ts
@@ -20,8 +20,18 @@ export namespace Todo {
   export type Links = {};
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly id: $PropType['string'];
+    /**
+     * (no ontology metadata)
+     */
     readonly isComplete: $PropType['boolean'] | undefined;
+    /**
+     *   display name: 'Title',
+     *   description: The text of the todo
+     */
     readonly title: $PropType['string'] | undefined;
   }
   export type StrictProps = Props;

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/equipment.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/objects/equipment.ts
@@ -20,7 +20,13 @@ export namespace equipment {
   export type Links = {};
 
   export interface Props {
+    /**
+     *   description: The id of an equipment
+     */
     readonly equipmentId: $PropType['string'];
+    /**
+     * (no ontology metadata)
+     */
     readonly type: $PropType['string'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/client/src/intellisense.test.helpers/showsObjectPropertyJsdoc.ts
+++ b/packages/client/src/intellisense.test.helpers/showsObjectPropertyJsdoc.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// WARNING!
+// WARNING!
+// This file is used for tests that check intellisense. Editing this file by hand will likely
+// break tests that have hard coded line numbers and line offsets.
+
+import type { Osdk } from "@osdk/api";
+import type { Employee } from "@osdk/client.test.ontology";
+
+const employee: Osdk.Instance<Employee> = {} as any;
+employee.employeeLocation;

--- a/packages/client/src/intellisense.test.ts
+++ b/packages/client/src/intellisense.test.ts
@@ -111,4 +111,15 @@ describe("intellisense", () => {
       `"(no ontology metadata)"`,
     );
   });
+
+  it("showsObjectPropertyJsdoc", { timeout: 40_000 }, async () => {
+    const { resp } = await tsServer.sendQuickInfoRequest({
+      file: intellisenseFilePath,
+      line: 26,
+      offset: 13,
+    });
+    expect(resp.body?.documentation).toMatchInlineSnapshot(
+      `"description: Geotime series reference of the location of the employee"`,
+    );
+  });
 });

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/ontology/interfaces/SomeInterface.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/ontology/interfaces/SomeInterface.ts
@@ -14,6 +14,9 @@ export namespace SomeInterface {
   export type PropertyKeys = 'spt';
 
   export interface Props {
+    /**
+     *   display name: 'Some Property'
+     */
     readonly spt: $PropType['string'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/ontology/objects/Task.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/ontology/objects/Task.ts
@@ -20,7 +20,13 @@ export namespace Task {
   export type Links = {};
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly body: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly taskId: $PropType['string'];
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/interfaces/SomeInterface.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/interfaces/SomeInterface.ts
@@ -14,6 +14,9 @@ export namespace SomeInterface {
   export type PropertyKeys = 'com.example.dep.spt';
 
   export interface Props {
+    /**
+     *   display name: 'Some Property'
+     */
     readonly 'com.example.dep.spt': $PropType['string'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/objects/Thing.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/objects/Thing.ts
@@ -20,7 +20,13 @@ export namespace Thing {
   export type Links = {};
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly body: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly id: $PropType['integer'];
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/objects/UsesForeignSpt.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/objects/UsesForeignSpt.ts
@@ -20,7 +20,13 @@ export namespace UsesForeignSpt {
   export type Links = {};
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly body: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly id: $PropType['integer'];
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/Athlete.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/Athlete.ts
@@ -14,8 +14,20 @@ export namespace Athlete {
   export type PropertyKeys = 'jerseyNumber' | 'athleteId' | 'name22';
 
   export interface Props {
+    /**
+     *   display name: 'Athlete ID',
+     *   description: Athlete ID
+     */
     readonly athleteId: $PropType['string'] | undefined;
+    /**
+     *   display name: 'Jersey Number',
+     *   description: Jersey Number
+     */
     readonly jerseyNumber: $PropType['integer'] | undefined;
+    /**
+     *   display name: 'Name',
+     *   description: Name
+     */
     readonly name22: $PropType['string'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/FooInterface.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/FooInterface.ts
@@ -14,8 +14,20 @@ export namespace FooInterface {
   export type PropertyKeys = 'name' | 'description' | 'inheritedDescription';
 
   export interface Props {
+    /**
+     *   display name: 'Description',
+     *   description: Description of Description
+     */
     readonly description: $PropType['string'] | undefined;
+    /**
+     *   display name: 'Inherited Description',
+     *   description: Description property we inherited from some parent interface
+     */
     readonly inheritedDescription: $PropType['string'] | undefined;
+    /**
+     *   display name: 'Name',
+     *   description: Name of Foo
+     */
     readonly name: $PropType['string'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/OsdkTestInterface.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/OsdkTestInterface.ts
@@ -14,6 +14,9 @@ export namespace OsdkTestInterface {
   export type PropertyKeys = 'objectDescription';
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly objectDescription: $PropType['string'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/BgaoNflPlayer.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/BgaoNflPlayer.ts
@@ -20,6 +20,9 @@ export namespace BgaoNflPlayer {
   export type Links = {};
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly address:
       | {
           addressLine1: $PropType['string'] | undefined;
@@ -29,10 +32,25 @@ export namespace BgaoNflPlayer {
           zipCode: $PropType['integer'] | undefined;
         }
       | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly gamesPlayed: $PropType['integer'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly id: $PropType['string'];
+    /**
+     * (no ontology metadata)
+     */
     readonly name: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly number: $PropType['integer'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly wikiUrl: $PropType['string'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/BoundariesUsState.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/BoundariesUsState.ts
@@ -20,9 +20,22 @@ export namespace BoundariesUsState {
   export type Links = {};
 
   export interface Props {
+    /**
+     *   display name: 'Geometry10M',
+     *   description: geoshape
+     */
     readonly geometry10M: $PropType['geoshape'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly latitude: $PropType['double'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly longitude: $PropType['double'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly usState: $PropType['string'];
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/BuilderDeploymentState.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/BuilderDeploymentState.ts
@@ -20,8 +20,17 @@ export namespace BuilderDeploymentState {
   export type Links = {};
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly currentTimestamp: $PropType['timestamp'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly date: $PropType['datetime'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly skuId: $PropType['string'];
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Country_1.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Country_1.ts
@@ -23,7 +23,13 @@ export namespace Country_1 {
   }
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly airportCountryIsoCode: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly airportCountryName: $PropType['string'];
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/DherlihyComplexObject.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/DherlihyComplexObject.ts
@@ -20,8 +20,17 @@ export namespace DherlihyComplexObject {
   export type Links = {};
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly id: $PropType['string'];
+    /**
+     * (no ontology metadata)
+     */
     readonly secret: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly seriesId: $PropType['numericTimeseries'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Employee.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Employee.ts
@@ -37,17 +37,53 @@ export namespace Employee {
   }
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly adUsername: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly businessTitle: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly email: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly employeeNumber: $PropType['double'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly favPlace: $PropType['geopoint'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly firstFullTimeStartDate: $PropType['datetime'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly firstName: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly id: $PropType['string'];
+    /**
+     * (no ontology metadata)
+     */
     readonly jobProfile: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly locationCity: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly locationName: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly locationType: $PropType['string'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/FintrafficAis.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/FintrafficAis.ts
@@ -20,12 +20,33 @@ export namespace FintrafficAis {
   export type Links = {};
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly centroid: $PropType['geopoint'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly geometry: $PropType['geoshape'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly mmsi: $PropType['string'];
+    /**
+     * (no ontology metadata)
+     */
     readonly name: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly seriesId: $PropType['geotimeSeriesReference'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly shipType: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly timestamp: $PropType['timestamp'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/GtfsTripTrackObject.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/GtfsTripTrackObject.ts
@@ -20,8 +20,17 @@ export namespace GtfsTripTrackObject {
   export type Links = {};
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly entityId: $PropType['string'];
+    /**
+     * (no ontology metadata)
+     */
     readonly geotimeSeriesReferences: $PropType['geotimeSeriesReference'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly timestamp: $PropType['timestamp'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/McAirportStruct.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/McAirportStruct.ts
@@ -20,7 +20,13 @@ export namespace McAirportStruct {
   export type Links = {};
 
   export interface Props {
+    /**
+     *   display name: 'Airport Name'
+     */
     readonly airportName: $PropType['string'];
+    /**
+     *   display name: 'Airport Struct'
+     */
     readonly airportStruct:
       | {
           code: $PropType['string'] | undefined;
@@ -28,8 +34,17 @@ export namespace McAirportStruct {
           timestamp: $PropType['string'] | undefined;
         }
       | undefined;
+    /**
+     *   display name: 'City'
+     */
     readonly city: $PropType['string'] | undefined;
+    /**
+     *   display name: 'Origin Date'
+     */
     readonly originDate: $PropType['timestamp'] | undefined;
+    /**
+     *   display name: 'State'
+     */
     readonly state: $PropType['string'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/MnayanOsdkMediaObject.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/MnayanOsdkMediaObject.ts
@@ -20,8 +20,17 @@ export namespace MnayanOsdkMediaObject {
   export type Links = {};
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly id: $PropType['string'];
+    /**
+     * (no ontology metadata)
+     */
     readonly mediaReference: $PropType['mediaReference'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly path: $PropType['string'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/MtaBus.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/MtaBus.ts
@@ -20,9 +20,21 @@ export namespace MtaBus {
   export type Links = {};
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly nextStopId: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly positionId: $PropType['geotimeSeriesReference'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly routeId: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly vehicleId: $PropType['string'];
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/NbaPlayer.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/NbaPlayer.ts
@@ -20,10 +20,25 @@ export namespace NbaPlayer {
   export type Links = {};
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly gamesPlayed: $PropType['integer'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly id: $PropType['string'];
+    /**
+     * (no ontology metadata)
+     */
     readonly jerseyNumber: $PropType['integer'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly name: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly wikiUrl: $PropType['string'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/ObjectTypeWithAllPropertyTypes.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/ObjectTypeWithAllPropertyTypes.ts
@@ -51,36 +51,129 @@ export namespace ObjectTypeWithAllPropertyTypes {
   export type Links = {};
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly attachment: $PropType['attachment'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly attachmentArray: $PropType['attachment'][] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly boolean: $PropType['boolean'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly booleanArray: $PropType['boolean'][] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly byte: $PropType['byte'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly byteArray: $PropType['byte'][] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly date: $PropType['datetime'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly dateArray: $PropType['datetime'][] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly dateTime: $PropType['timestamp'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly dateTimeArray: $PropType['timestamp'][] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly decimal: $PropType['decimal'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly decimalArray: $PropType['decimal'][] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly double: $PropType['double'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly doubleArray: $PropType['double'][] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly float: $PropType['float'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly floatArray: $PropType['float'][] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly geoPoint: $PropType['geopoint'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly geoPointArray: $PropType['geopoint'][] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly geoShape: $PropType['geoshape'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly geoShapeArray: $PropType['geoshape'][] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly id: $PropType['integer'];
+    /**
+     * (no ontology metadata)
+     */
     readonly integer: $PropType['integer'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly integerArray: $PropType['integer'][] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly long: $PropType['long'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly longArray: $PropType['long'][] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly numericTimeseries: $PropType['numericTimeseries'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly short: $PropType['short'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly shortArray: $PropType['short'][] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly string: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly stringArray: $PropType['string'][] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly stringTimeseries: $PropType['stringTimeseries'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/OsdkTestObject.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/OsdkTestObject.ts
@@ -20,9 +20,21 @@ export namespace OsdkTestObject {
   export type Links = {};
 
   export interface Props {
+    /**
+     *   display name: 'Description'
+     */
     readonly description: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly osdkObjectName: $PropType['string'] | undefined;
+    /**
+     *   display name: 'Primary Key'
+     */
     readonly primaryKey_: $PropType['string'];
+    /**
+     *   display name: 'String Property'
+     */
     readonly stringProperty: $PropType['string'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Person.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Person.ts
@@ -24,6 +24,9 @@ export namespace Person {
   }
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly email: $PropType['string'];
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/RhemmingsObjectWithGtsrProperty2.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/RhemmingsObjectWithGtsrProperty2.ts
@@ -20,10 +20,25 @@ export namespace RhemmingsObjectWithGtsrProperty2 {
   export type Links = {};
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly gtsr: $PropType['geotimeSeriesReference'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly id: $PropType['string'];
+    /**
+     * (no ontology metadata)
+     */
     readonly location: $PropType['geopoint'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly timestamp: $PropType['timestamp'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly type: $PropType['string'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/SotSensor.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/SotSensor.ts
@@ -20,10 +20,25 @@ export namespace SotSensor {
   export type Links = {};
 
   export interface Props {
+    /**
+     *   display name: 'Is Enum'
+     */
     readonly isEnum: $PropType['boolean'] | undefined;
+    /**
+     *   display name: 'Sensor Name'
+     */
     readonly sensorName: $PropType['string'] | undefined;
+    /**
+     *   display name: 'Series Id'
+     */
     readonly seriesId: $PropType['string'];
+    /**
+     *   display name: 'Time Series Property'
+     */
     readonly timeSeriesProperty: $PropType['sensorTimeseries'] | undefined;
+    /**
+     *   display name: 'Well Id'
+     */
     readonly wellId: $PropType['string'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/StateTerritory.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/StateTerritory.ts
@@ -23,8 +23,17 @@ export namespace StateTerritory {
   }
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly airportStateCode: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly airportStateName: $PropType['string'];
+    /**
+     * (no ontology metadata)
+     */
     readonly country: $PropType['string'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/StructPerson.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/StructPerson.ts
@@ -20,7 +20,13 @@ export namespace StructPerson {
   export type Links = {};
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly address: { city: $PropType['string'] | undefined; state: $PropType['string'] | undefined } | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly name: $PropType['string'];
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/StructPersonOpisTeam.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/StructPersonOpisTeam.ts
@@ -20,6 +20,9 @@ export namespace StructPersonOpisTeam {
   export type Links = {};
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly address:
       | {
           city: $PropType['string'] | undefined;
@@ -27,7 +30,13 @@ export namespace StructPersonOpisTeam {
           zipcode: $PropType['integer'] | undefined;
         }
       | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly age: $PropType['integer'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly id: $PropType['string'];
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/TestGeoAction.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/TestGeoAction.ts
@@ -20,8 +20,19 @@ export namespace TestGeoAction {
   export type Links = {};
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly geoPk: $PropType['string'];
+    /**
+     *   display name: 'Geoshape',
+     *   description: geoshape
+     */
     readonly geoshapeProp: $PropType['geoshape'] | undefined;
+    /**
+     *   display name: 'Geotitle',
+     *   description: geoTitle
+     */
     readonly geoTitle: $PropType['string'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Todo.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Todo.ts
@@ -23,10 +23,26 @@ export namespace Todo {
   }
 
   export interface Props {
+    /**
+     *   display name: 'Body',
+     *   description: The text of the todo
+     */
     readonly body: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly complete: $PropType['boolean'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly id: $PropType['integer'];
+    /**
+     * (no ontology metadata)
+     */
     readonly priority: $PropType['integer'] | undefined;
+    /**
+     *   display name: 'Text'
+     */
     readonly text: $PropType['string'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Venture.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Venture.ts
@@ -23,8 +23,17 @@ export namespace Venture {
   }
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly ventureId: $PropType['string'];
+    /**
+     * (no ontology metadata)
+     */
     readonly ventureName: $PropType['string'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly ventureStart: $PropType['datetime'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/WeatherStation.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/WeatherStation.ts
@@ -20,7 +20,14 @@ export namespace WeatherStation {
   export type Links = {};
 
   export interface Props {
+    /**
+     *   display name: 'Geohash',
+     *   description: geopoint
+     */
     readonly geohash: $PropType['geopoint'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly stationId: $PropType['string'];
   }
   export type StrictProps = Props;

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/ontology/interfaces/TodoLike.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/ontology/interfaces/TodoLike.ts
@@ -14,7 +14,13 @@ export namespace TodoLike {
   export type PropertyKeys = 'name' | 'isComplete';
 
   export interface Props {
+    /**
+     * (no ontology metadata)
+     */
     readonly isComplete: $PropType['boolean'] | undefined;
+    /**
+     *   display name: 'Name'
+     */
     readonly name: $PropType['string'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/ontology/objects/Todo.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/ontology/objects/Todo.ts
@@ -20,9 +20,21 @@ export namespace Todo {
   export type Links = {};
 
   export interface Props {
+    /**
+     *   display name: 'Id'
+     */
     readonly id: $PropType['string'];
+    /**
+     *   display name: 'Is Complete'
+     */
     readonly isComplete: $PropType['boolean'] | undefined;
+    /**
+     * (no ontology metadata)
+     */
     readonly location: $PropType['geopoint'] | undefined;
+    /**
+     *   display name: 'Title'
+     */
     readonly title: $PropType['string'] | undefined;
   }
   export type StrictProps = Props;

--- a/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.test.ts
+++ b/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.test.ts
@@ -137,6 +137,9 @@ describe(__UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst, () => {
         export type PropertyKeys = "bar";
 
         export interface Props {
+          /**
+           * (no ontology metadata)
+           */
           readonly bar: $PropType["integer"] | undefined;
         }
         export type StrictProps = Props;
@@ -229,6 +232,10 @@ describe(__UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst, () => {
         export type PropertyKeys = "foo";
 
         export interface Props {
+          /**
+           *   display name: 'foo property dn',
+           *   description: foo property desc
+           */
           readonly foo: $PropType["integer"] | undefined;
         }
         export type StrictProps = Props;
@@ -322,7 +329,15 @@ describe(__UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst, () => {
         export type PropertyKeys = "foo" | "bar";
 
         export interface Props {
+          /**
+           *   display name: 'bar property dn',
+           *   description: bar property desc
+           */
           readonly bar: $PropType["integer"] | undefined;
+          /**
+           *   display name: 'foo property dn',
+           *   description: foo property desc
+           */
           readonly foo: $PropType["integer"] | undefined;
         }
         export type StrictProps = Props;
@@ -421,6 +436,10 @@ describe(__UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst, () => {
         export type PropertyKeys = "foo";
 
         export interface Props {
+          /**
+           *   display name: 'foo property dn',
+           *   description: foo property desc
+           */
           readonly foo: $PropType["integer"] | undefined;
         }
         export type StrictProps = Props;

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -729,6 +729,10 @@ describe("generator", () => {
           export type PropertyKeys = 'SomeProperty';
 
           export interface Props {
+            /**
+             *   display name: 'Sum Property',
+             *   description: Some property
+             */
             readonly SomeProperty: $PropType['string'] | undefined;
           }
           export type StrictProps = Props;
@@ -808,6 +812,9 @@ describe("generator", () => {
           }
 
           export interface Props {
+            /**
+             * (no ontology metadata)
+             */
             readonly email: $PropType['string'];
           }
           export type StrictProps = Props;
@@ -896,8 +903,18 @@ describe("generator", () => {
           }
 
           export interface Props {
+            /**
+             *   display name: 'Body',
+             *   description: The text of the todo
+             */
             readonly body: $PropType['string'] | undefined;
+            /**
+             * (no ontology metadata)
+             */
             readonly complete: $PropType['boolean'] | undefined;
+            /**
+             * (no ontology metadata)
+             */
             readonly id: $PropType['integer'];
           }
           export type StrictProps = Props;
@@ -1350,6 +1367,10 @@ describe("generator", () => {
           export type PropertyKeys = 'SomeProperty';
 
           export interface Props {
+            /**
+             *   display name: 'Sum Property',
+             *   description: Some property
+             */
             readonly SomeProperty: $PropType['string'] | undefined;
           }
           export type StrictProps = Props;
@@ -1429,6 +1450,9 @@ describe("generator", () => {
           }
 
           export interface Props {
+            /**
+             * (no ontology metadata)
+             */
             readonly email: $PropType['string'];
           }
           export type StrictProps = Props;
@@ -1517,8 +1541,18 @@ describe("generator", () => {
           }
 
           export interface Props {
+            /**
+             *   display name: 'Body',
+             *   description: The text of the todo
+             */
             readonly body: $PropType['string'] | undefined;
+            /**
+             * (no ontology metadata)
+             */
             readonly complete: $PropType['boolean'] | undefined;
+            /**
+             * (no ontology metadata)
+             */
             readonly id: $PropType['integer'];
           }
           export type StrictProps = Props;
@@ -1921,7 +1955,13 @@ describe("generator", () => {
             export type Links = {};
 
             export interface Props {
+              /**
+               * (no ontology metadata)
+               */
               readonly body: $PropType['string'] | undefined;
+              /**
+               * (no ontology metadata)
+               */
               readonly id: $PropType['integer'];
             }
             export type StrictProps = Props;
@@ -2144,7 +2184,13 @@ describe("generator", () => {
           export type PropertyKeys = 'spt' | 'spt2';
 
           export interface Props {
+            /**
+             *   display name: 'Some Property'
+             */
             readonly spt: $PropType['string'] | undefined;
+            /**
+             *   display name: 'Some Property 2'
+             */
             readonly spt2: $PropType['string'] | undefined;
           }
           export type StrictProps = Props;
@@ -2222,7 +2268,13 @@ describe("generator", () => {
           export type Links = {};
 
           export interface Props {
+            /**
+             * (no ontology metadata)
+             */
             readonly body: $PropType['string'] | undefined;
+            /**
+             * (no ontology metadata)
+             */
             readonly taskId: $PropType['string'];
           }
           export type StrictProps = Props;

--- a/packages/generator/src/v2.0/wireObjectTypeV2ToSdkObjectConstV2.ts
+++ b/packages/generator/src/v2.0/wireObjectTypeV2ToSdkObjectConstV2.ts
@@ -226,10 +226,9 @@ ${
     stringify(definition.properties, {
       "*": (propertyDefinition, _, apiName) => {
         return [
-          `readonly "${maybeStripNamespace(type, apiName)}"${
-            // after we convert everything over we can do this:
-            // !strict || propertyDefinition.nullable ? "?" : ""
-            ""}`,
+          `${propertyJsdoc(propertyDefinition, { apiName })}readonly "${
+            maybeStripNamespace(type, apiName)
+          }"`,
           (typeof propertyDefinition.type === "object"
             ? remapStructType(propertyDefinition.type)
             : `$PropType[${JSON.stringify(propertyDefinition.type)}]`)


### PR DESCRIPTION
First commit was hand written, second is from generators. I split them out so we could backport just the hand written code. 