### PR TITLE
Fix query return types

### DIFF
--- a/.changeset/eleven-views-travel.md
+++ b/.changeset/eleven-views-travel.md
@@ -1,0 +1,5 @@
+---
+"@osdk/legacy-client": patch
+---
+
+Prevent multiple calls for queries that return arrays of objects

--- a/packages/legacy-client/src/client/queries.test.ts
+++ b/packages/legacy-client/src/client/queries.test.ts
@@ -281,6 +281,56 @@ describe("Queries", () => {
         },
       });
     });
+
+    it("Loads multiple returned objects with a fetchAll", async () => {
+      mockFetchResponse(
+        fetch,
+        {
+          value: ["1", "2", "3"],
+        },
+      );
+
+      mockFetchResponse(
+        fetch,
+        {
+          data: [{
+            __apiName: "Todo",
+            __primaryKey: "1",
+          }, {
+            __apiName: "Todo",
+            __primaryKey: "2",
+          }, {
+            __apiName: "Todo",
+            __primaryKey: "3",
+          }],
+        },
+      );
+
+      const response = await queries.queryTypeReturnsObjectArray();
+
+      expectFetchToBeCalledWithBody(
+        fetch,
+        `Ontology/objectSets/loadObjects`,
+        {
+          "objectSet": {
+            "type": "filter",
+            "where": {
+              "type": "in",
+              "field": "id",
+              "value": ["1", "2", "3"],
+            },
+            "objectSet": {
+              "type": "base",
+              "objectType": "Todo",
+            },
+          },
+          "select": [],
+        },
+      );
+
+      response.type === "ok"
+        && expect(response.value.value[0].$primaryKey).toEqual("1");
+    });
   });
 
   describe("type tests", () => {
@@ -358,6 +408,7 @@ describe("Queries", () => {
         "queryTakesNestedObjects",
         "queryWithOnlyOptionalArgs",
         "queryWithOnlyRequiredArgs",
+        "queryTypeReturnsObjectArray",
       ]
     `);
   });

--- a/packages/shared.test/src/mock-ontology/mockOntology.ts
+++ b/packages/shared.test/src/mock-ontology/mockOntology.ts
@@ -384,6 +384,19 @@ export const MockOntology = {
         },
       },
     },
+    queryTypeReturnsObjectArray: {
+      type: "query",
+      apiName: "queryTypeReturnsObjectArray",
+      description: "a query that returns an object array",
+      version: "version",
+      parameters: {},
+      output: {
+        type: "object",
+        nullable: false,
+        multiplicity: true,
+        object: "Todo",
+      },
+    },
   },
 } as const satisfies OntologyDefinition<any, any, any, any>;
 type capture = typeof MockOntology;


### PR DESCRIPTION
For arrays of objects returned from queries, we used to make several fetch one requests. Now, we dispatch a fetch page instead. Fixes #1442 