### PR TITLE
Add refresh on scopes change to the Legacy Typescript OSDK

### DIFF
--- a/.changeset/tame-peaches-walk.md
+++ b/.changeset/tame-peaches-walk.md
@@ -1,0 +1,5 @@
+---
+"@osdk/oauth": patch
+---
+
+Added the ability to re-create the refresh token if the operation scopes change

--- a/packages/oauth/src/common.test.ts
+++ b/packages/oauth/src/common.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  common,
+  createAuthorizationServer,
+  readLocal,
+  removeLocal,
+  saveLocal,
+} from "./common.js";
+
+describe("local functions", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", {
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      getItem: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    // cspell:ignore unstub
+    vi.unstubAllGlobals();
+  });
+
+  it("should use the old style keys when there is no refresh token scopes", () => {
+    const client = {
+      client_id: "hi_mom",
+    };
+
+    const oldLocalStorageKey = `@osdk/oauth : refresh : ${client.client_id}`;
+
+    readLocal(client);
+    removeLocal(client);
+    saveLocal(client, {});
+
+    expect(vi.mocked(globalThis.localStorage.getItem)).toBeCalledWith(
+      oldLocalStorageKey,
+    );
+
+    expect(vi.mocked(globalThis.localStorage.setItem)).toBeCalledWith(
+      oldLocalStorageKey,
+      expect.anything(),
+    );
+
+    expect(vi.mocked(globalThis.localStorage.removeItem)).toBeCalledWith(
+      oldLocalStorageKey,
+    );
+  });
+
+  it("should save the requested scopes", () => {
+    const client = {
+      client_id: "hi_mom",
+    };
+
+    const signIn = vi.fn();
+    const refresh = vi.fn();
+
+    const authServer = createAuthorizationServer(
+      "multipass",
+      "https://stack.palantir.com",
+    );
+
+    const { makeTokenAndSaveRefresh } = common(
+      client,
+      authServer,
+      signIn,
+      {},
+      refresh,
+      "yay:my-fun-scope sad:my-boring-scope",
+    );
+
+    makeTokenAndSaveRefresh({
+      refresh_token: "refresh",
+      access_token: "access",
+      token_type: "idk",
+      expires_in: 10_000,
+    }, "signIn");
+
+    expect(globalThis.localStorage.setItem).toBeCalledWith(
+      `@osdk/oauth : refresh : ${client.client_id}`,
+      JSON.stringify({
+        refresh_token: "refresh",
+        requestedScopes: "yay:my-fun-scope sad:my-boring-scope",
+      }),
+    );
+  });
+});

--- a/packages/oauth/src/common.ts
+++ b/packages/oauth/src/common.ts
@@ -58,6 +58,9 @@ type LocalStorageState =
     codeVerifier?: never;
     state?: never;
     oldUrl: string;
+    // The stringified space-separated list of scopes requested during the initial auth grant, which our refresh token is still valid for
+    // Note any or none of these scopes may have actually been granted when we received our last access token
+    requestedScopes?: string;
   }
   // when we are redirecting to oauth login
   | {
@@ -65,6 +68,7 @@ type LocalStorageState =
     codeVerifier: string;
     state: string;
     oldUrl: string;
+    requestedScopes?: string;
   }
   // when we have the refresh token
   | {
@@ -72,12 +76,14 @@ type LocalStorageState =
     codeVerifier?: never;
     state?: never;
     oldUrl?: never;
+    requestedScopes?: string;
   }
   | {
     refresh_token?: never;
     codeVerifier?: never;
     state?: never;
     oldUrl?: never;
+    requestedScopes?: string;
   };
 
 export function saveLocal(client: Client, x: LocalStorageState) {
@@ -109,6 +115,7 @@ export function common<
   _signIn: () => Promise<Token>,
   oauthHttpOptions: HttpRequestOptions,
   refresh: R,
+  scopes: string,
 ): {
   getToken: BaseOauthClient<keyof Events & string> & { refresh: R };
   makeTokenAndSaveRefresh: (
@@ -125,7 +132,7 @@ export function common<
   ): Token {
     const { refresh_token, expires_in, access_token } = resp;
     invariant(expires_in != null);
-    saveLocal(client, { refresh_token });
+    saveLocal(client, { refresh_token, requestedScopes: scopes });
     token = {
       refresh_token,
       expires_in,

--- a/packages/oauth/src/common.ts
+++ b/packages/oauth/src/common.ts
@@ -49,8 +49,6 @@ declare const process: {
   env: Record<string, string | undefined>;
 };
 
-const localStorage = globalThis.localStorage;
-
 type LocalStorageState =
   // when we are going to the login page
   | {
@@ -88,7 +86,7 @@ type LocalStorageState =
 
 export function saveLocal(client: Client, x: LocalStorageState) {
   // MUST `localStorage?` as nodejs does not have localStorage
-  localStorage?.setItem(
+  globalThis.localStorage?.setItem(
     `@osdk/oauth : refresh : ${client.client_id}`,
     JSON.stringify(x),
   );
@@ -96,13 +94,17 @@ export function saveLocal(client: Client, x: LocalStorageState) {
 
 export function removeLocal(client: Client) {
   // MUST `localStorage?` as nodejs does not have localStorage
-  localStorage?.removeItem(`@osdk/oauth : refresh : ${client.client_id}`);
+  globalThis.localStorage?.removeItem(
+    `@osdk/oauth : refresh : ${client.client_id}`,
+  );
 }
 
 export function readLocal(client: Client): LocalStorageState {
   return JSON.parse(
     // MUST `localStorage?` as nodejs does not have localStorage
-    localStorage?.getItem(`@osdk/oauth : refresh : ${client.client_id}`)
+    globalThis.localStorage?.getItem(
+      `@osdk/oauth : refresh : ${client.client_id}`,
+    )
       ?? "{}",
   );
 }

--- a/packages/oauth/src/createConfidentialOauthClient.ts
+++ b/packages/oauth/src/createConfidentialOauthClient.ts
@@ -44,6 +44,7 @@ export function createConfidentialOauthClient(
   const client: Client = { client_id, client_secret };
   const authServer = createAuthorizationServer(ctxPath, url);
   const oauthHttpOptions: HttpRequestOptions = { [customFetch]: fetchFn };
+  const joinedScopes = scopes.join(" ");
 
   const { getToken, makeTokenAndSaveRefresh } = common(
     client,
@@ -51,6 +52,7 @@ export function createConfidentialOauthClient(
     _signIn,
     oauthHttpOptions,
     undefined,
+    joinedScopes,
   );
 
   async function _signIn() {
@@ -62,7 +64,7 @@ export function createConfidentialOauthClient(
           await clientCredentialsGrantRequest(
             authServer,
             client,
-            new URLSearchParams({ scope: scopes.join(" ") }),
+            new URLSearchParams({ scope: joinedScopes }),
             oauthHttpOptions,
           ),
         ),

--- a/packages/oauth/src/createPublicOauthClient.ts
+++ b/packages/oauth/src/createPublicOauthClient.ts
@@ -99,10 +99,10 @@ export function createPublicOauthClient(
       return;
     }
 
-    const areScopesEqual = initialRequestedScopes != null
-      && joinedScopes === initialRequestedScopes;
-
-    if (!refresh_token || !areScopesEqual) {
+    if (
+      !refresh_token || !(initialRequestedScopes != null
+        && joinedScopes === initialRequestedScopes)
+    ) {
       if (expectRefreshToken) throw new Error("No refresh token found");
       return;
     }


### PR DESCRIPTION
Previously, we added support for regenerating our Public OAuth token if the scopes on multipass change on the 2.x version in https://github.com/palantir/osdk-ts/pull/1319 

We need to port this change over to our legacy client to make sure users don't run into the same issue