### PR TITLE
Discover widget set input specs

### DIFF
--- a/.changeset/nice-knives-follow.md
+++ b/.changeset/nice-knives-follow.md
@@ -1,0 +1,6 @@
+---
+"@osdk/widget.vite-plugin.unstable": patch
+"@osdk/widget.api.unstable": patch
+---
+
+Discover widget set input specs

--- a/packages/monorepo.cspell/dict.normal-dev-words.txt
+++ b/packages/monorepo.cspell/dict.normal-dev-words.txt
@@ -16,6 +16,7 @@ geosearch
 groupable
 inbetween
 isModifierable
+jsons
 Multimap
 objs
 onwarn

--- a/packages/widget.api.unstable/src/index.ts
+++ b/packages/widget.api.unstable/src/index.ts
@@ -25,7 +25,10 @@ export type {
 } from "./config.js";
 export { defineConfig } from "./config.js";
 export type {
+  OntologySdkInputSpecV1 as OntologySdkInputSpec,
   WidgetManifestConfigV1 as WidgetManifestConfig,
+  WidgetSetDiscoveredInputSpecV1 as WidgetSetDiscoveredInputSpec,
+  WidgetSetInputSpecV1 as WidgetSetInputSpec,
   WidgetSetManifestV1 as WidgetSetManifest,
 } from "./manifest.js";
 export { MANIFEST_FILE_LOCATION } from "./manifest.js";

--- a/packages/widget.api.unstable/src/manifest.ts
+++ b/packages/widget.api.unstable/src/manifest.ts
@@ -41,6 +41,12 @@ export interface WidgetSetManifestContentV1 {
    * The key can be arbitrary, and is usually the name of your entrypoint, e.g. "main"
    */
   widgets: Record<string, WidgetManifestConfigV1>;
+
+  /**
+   * The input specification for Foundry data required by the widget set.
+   * @optional
+   */
+  inputSpec?: WidgetSetInputSpecV1;
 }
 
 export interface WidgetManifestConfigV1 {
@@ -93,6 +99,28 @@ export interface WidgetManifestConfigV1 {
    * The map of events to their definition. Any parameter IDs referenced must be defined in the `parameters` field
    */
   events: Record<string, EventDefinition<ParameterConfig>>;
+}
+
+export interface WidgetSetInputSpecV1 {
+  /**
+   * The input specification for the widget set that was automatically discovered from the project.
+   * @optional
+   */
+  discovered?: WidgetSetDiscoveredInputSpecV1;
+}
+
+export interface WidgetSetDiscoveredInputSpecV1 {
+  /**
+   * The discovered Ontology SDK packages in the project
+   */
+  sdks: Array<OntologySdkInputSpecV1>;
+}
+
+export interface OntologySdkInputSpecV1 {
+  /** The Ontology SDK package rid */
+  rid: string;
+  /** The Ontology SDK package version */
+  version: string;
 }
 
 export const MANIFEST_FILE_LOCATION = ".palantir/widgets.config.json";

--- a/packages/widget.vite-plugin.unstable/package.json
+++ b/packages/widget.vite-plugin.unstable/package.json
@@ -63,6 +63,7 @@
     "@vitejs/plugin-react": "^4.2.0",
     "react": "^18",
     "react-dom": "^18",
+    "resolve-package-path": "^4.0.3",
     "ts-expect": "^1.3.0",
     "typescript": "~5.5.4",
     "vite": "^6.3.5",

--- a/packages/widget.vite-plugin.unstable/src/build-plugin/FoundryWidgetBuildPlugin.ts
+++ b/packages/widget.vite-plugin.unstable/src/build-plugin/FoundryWidgetBuildPlugin.ts
@@ -26,6 +26,7 @@ import { getInputHtmlEntrypoints } from "../common/getInputHtmlEntrypoints.js";
 import { standardizeFileExtension } from "../common/standardizeFileExtension.js";
 import { buildWidgetSetManifest } from "./buildWidgetSetManifest.js";
 import { getWidgetBuildOutputs } from "./getWidgetBuildOutputs.js";
+import { getWidgetSetInputSpec } from "./getWidgetSetInputSpec.js";
 import { isConfigFile } from "./isConfigFile.js";
 
 export function FoundryWidgetBuildPlugin(): Plugin {
@@ -86,10 +87,14 @@ export function FoundryWidgetBuildPlugin(): Plugin {
       const widgetBuilds = htmlEntrypoints.map((input) =>
         getWidgetBuildOutputs(bundle, input, config.build.outDir, configFiles)
       );
+      const widgetSetInputSpec = await getWidgetSetInputSpec(
+        path.resolve(process.cwd(), "package.json"),
+      );
       const widgetSetManifest = buildWidgetSetManifest(
         foundryConfig.foundryConfig.widgetSet.rid,
         widgetSetVersion,
         widgetBuilds,
+        widgetSetInputSpec,
       );
 
       // Write the manifest to the dist directory

--- a/packages/widget.vite-plugin.unstable/src/build-plugin/__tests__/getWidgetSetInputSpec.test.ts
+++ b/packages/widget.vite-plugin.unstable/src/build-plugin/__tests__/getWidgetSetInputSpec.test.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { resolve } from "path";
+import { expect, test, vi } from "vitest";
+import type { PackageJson } from "../../common/PackageJson.js";
+import { visitNpmPackages } from "../../common/visitNpmPackages.js";
+import { getWidgetSetInputSpec } from "../getWidgetSetInputSpec.js";
+
+vi.mock("../../common/visitNpmPackages.ts");
+
+test("getWidgetSetInputSpec successfully discovers OSDK packages", async () => {
+  const packageJson1: PackageJson = {
+    name: "package1",
+    version: "0.1.0",
+    dependencies: {
+      "package2": "0.2.0",
+      "package3": "0.3.0",
+    },
+  };
+  const packageJson2: PackageJson = {
+    name: "package2",
+    version: "0.2.0",
+    dependencies: {
+      "package3": "0.3.0",
+      "package4": "0.4.0",
+    },
+    osdk: {
+      rid: "ridPackage2",
+    },
+  };
+  const packageJson3: PackageJson = {
+    name: "package3",
+    version: "0.3.0",
+    dependencies: {
+      "package4": "0.4.1",
+    },
+    osdk: {
+      rid: "ridPackage3",
+    },
+  };
+  const packageJson4: PackageJson = {
+    name: "package3",
+    version: "0.4.0",
+    osdk: {
+      rid: "ridPackage4",
+    },
+  };
+  const packageJson4_1: PackageJson = {
+    name: "package4",
+    version: "0.4.1",
+    osdk: {
+      rid: "ridPackage4",
+    },
+  };
+
+  vi.mocked(visitNpmPackages).mockImplementation(
+    (packageJsonPath, onVisit) => {
+      onVisit(packageJsonPath, packageJson1);
+      onVisit(
+        resolve(packageJsonPath, "/node_modules/package2@0.2.0/package.json"),
+        packageJson2,
+      );
+      onVisit(
+        resolve(packageJsonPath, "/node_modules/package3@0.3.0/package.json"),
+        packageJson3,
+      );
+      // Handle multiple versions of same OSDK package
+      onVisit(
+        resolve(packageJsonPath, "/node_modules/package4@0.4.0/package.json"),
+        packageJson4,
+      );
+      onVisit(
+        resolve(packageJsonPath, "/node_modules/package4@0.4.1/package.json"),
+        packageJson4_1,
+      );
+      // Handle multiple occurrences of same version of OSDK package
+      onVisit(
+        resolve(packageJsonPath, "/node_modules/package4@0.4.1/package.json"),
+        packageJson4_1,
+      );
+      return Promise.resolve();
+    },
+  );
+  const widgetSetInputSpec = await getWidgetSetInputSpec(
+    "/path/to/package.json",
+  );
+
+  expect(widgetSetInputSpec).toEqual({
+    discovered: {
+      sdks: [
+        { rid: "ridPackage2", version: "0.2.0" },
+        { rid: "ridPackage3", version: "0.3.0" },
+        { rid: "ridPackage4", version: "0.4.0" },
+        { rid: "ridPackage4", version: "0.4.1" },
+      ],
+    },
+  });
+});

--- a/packages/widget.vite-plugin.unstable/src/build-plugin/buildWidgetSetManifest.ts
+++ b/packages/widget.vite-plugin.unstable/src/build-plugin/buildWidgetSetManifest.ts
@@ -16,6 +16,7 @@
 
 import type {
   WidgetManifestConfig,
+  WidgetSetInputSpec,
   WidgetSetManifest,
 } from "@osdk/widget.api.unstable";
 import type { WidgetBuildOutputs } from "./getWidgetBuildOutputs.js";
@@ -24,6 +25,7 @@ export function buildWidgetSetManifest(
   widgetSetRid: string,
   widgetSetVersion: string,
   widgetBuilds: WidgetBuildOutputs[],
+  widgetSetInputSpec: WidgetSetInputSpec,
 ): WidgetSetManifest {
   return {
     manifestVersion: "1.0.0",
@@ -35,6 +37,7 @@ export function buildWidgetSetManifest(
           .map(buildWidgetManifest)
           .map((widgetManifest) => [widgetManifest.id, widgetManifest]),
       ),
+      inputSpec: widgetSetInputSpec,
     },
   };
 }

--- a/packages/widget.vite-plugin.unstable/src/build-plugin/getWidgetSetInputSpec.ts
+++ b/packages/widget.vite-plugin.unstable/src/build-plugin/getWidgetSetInputSpec.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  OntologySdkInputSpec,
+  WidgetSetInputSpec,
+} from "@osdk/widget.api.unstable";
+import type { PackageJson } from "../common/PackageJson.js";
+import { visitNpmPackages } from "../common/visitNpmPackages.js";
+
+export async function getWidgetSetInputSpec(
+  packageJsonPath: string,
+): Promise<WidgetSetInputSpec> {
+  const sdks = await discoverOntologySdkInputSpecs(packageJsonPath);
+  return {
+    discovered: {
+      sdks,
+    },
+  };
+}
+
+async function discoverOntologySdkInputSpecs(
+  packageJsonPath: string,
+): Promise<Array<OntologySdkInputSpec>> {
+  const sdks = new Set<string>();
+  const onVisit = (_packageJsonPath: string, packageJson: PackageJson) => {
+    if (packageJson.osdk != null && packageJson.osdk.rid != null) {
+      sdks.add(toKey(packageJson.osdk.rid, packageJson.version));
+    }
+  };
+  await visitNpmPackages(packageJsonPath, onVisit);
+  return [...sdks].map(fromKey);
+}
+
+const SEPARATOR = "//";
+const toKey = (rid: string, version: string) => `${rid}${SEPARATOR}${version}`;
+const fromKey = (key: string): OntologySdkInputSpec => {
+  const [rid, version] = key.split(SEPARATOR);
+  return {
+    rid,
+    version,
+  };
+};

--- a/packages/widget.vite-plugin.unstable/src/common/PackageJson.ts
+++ b/packages/widget.vite-plugin.unstable/src/common/PackageJson.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface PackageJson {
+  name: string;
+  version: string;
+  osdk?: {
+    rid?: string;
+  };
+  dependencies?: {
+    [key: string]: string;
+  };
+}

--- a/packages/widget.vite-plugin.unstable/src/common/__tests__/visitNpmPackages.test.ts
+++ b/packages/widget.vite-plugin.unstable/src/common/__tests__/visitNpmPackages.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFile } from "fs/promises";
+import resolvePackagePath from "resolve-package-path";
+import { expect, test, vi } from "vitest";
+import type { PackageJson } from "../../common/PackageJson.js";
+import { visitNpmPackages } from "../visitNpmPackages.js";
+
+vi.mock("fs/promises");
+vi.mock("resolve-package-path");
+
+test("visitNpmPackages", async () => {
+  const packageJson1: PackageJson = {
+    name: "package1",
+    version: "0.1.0",
+    dependencies: {
+      "package2": "0.2.0",
+      "package3": "0.3.0",
+    },
+  };
+  const packageJson2: PackageJson = {
+    name: "package2",
+    version: "0.2.0",
+    dependencies: {
+      "package3": "0.3.0",
+    },
+  };
+  const packageJson3: PackageJson = {
+    name: "package3",
+    version: "0.3.0",
+  };
+
+  const packageJsonPaths: Record<string, string> = {
+    [packageJson1.name]: "/path/to/package.json",
+    [packageJson2.name]: "/path/to/node_modules/package2/package.json",
+    [packageJson3.name]: "/path/to/node_modules/package3/package.json",
+  } as const;
+  const packageJsons: Record<typeof packageJsonPaths[string], PackageJson> = {
+    [packageJsonPaths[packageJson1.name]]: packageJson1,
+    [packageJsonPaths[packageJson2.name]]: packageJson2,
+    [packageJsonPaths[packageJson3.name]]: packageJson3,
+  } as const;
+
+  vi.mocked(resolvePackagePath).mockImplementation((target) => {
+    const path = packageJsonPaths[target];
+    if (path == null) {
+      throw new Error(`Unexpected target: ${target}`);
+    }
+    return path;
+  });
+  vi.mocked(readFile).mockImplementation((path) => {
+    const packageJson = packageJsons[path.toString()];
+    if (packageJson == null) {
+      throw new Error(`Unexpected path: ${path.toString()}`);
+    }
+    return Promise.resolve(JSON.stringify(packageJson));
+  });
+
+  const onVisit = vi.fn();
+  await visitNpmPackages("/path/to/package.json", onVisit);
+
+  expect(onVisit).toHaveBeenCalledTimes(3);
+  expect(onVisit).toHaveBeenNthCalledWith(
+    1,
+    "/path/to/package.json",
+    packageJson1,
+  );
+  expect(onVisit).toHaveBeenNthCalledWith(
+    2,
+    "/path/to/node_modules/package2/package.json",
+    packageJson2,
+  );
+  expect(onVisit).toHaveBeenNthCalledWith(
+    3,
+    "/path/to/node_modules/package3/package.json",
+    packageJson3,
+  );
+});

--- a/packages/widget.vite-plugin.unstable/src/common/visitNpmPackages.ts
+++ b/packages/widget.vite-plugin.unstable/src/common/visitNpmPackages.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFile } from "fs/promises";
+import path from "path";
+import resolvePackagePath from "resolve-package-path";
+import type { PackageJson } from "./PackageJson.js";
+
+export async function visitNpmPackages(
+  rootPackageJsonPath: string,
+  onVisit: (packageJsonPath: string, packageJson: PackageJson) => void,
+): Promise<void> {
+  const visited = new Set<string>();
+
+  const visitNpmPackagesInternal = async function(
+    packageJsonPath: string,
+  ): Promise<void> {
+    if (visited.has(packageJsonPath)) {
+      return;
+    }
+
+    const packageJson = await parsePackageJson(packageJsonPath);
+    onVisit(
+      packageJsonPath,
+      packageJson,
+    );
+    visited.add(packageJsonPath);
+
+    const context = path.dirname(packageJsonPath);
+    const npmDependencies = Object.keys(packageJson.dependencies ?? {});
+    for (const childName of npmDependencies) {
+      const childPackageJsonPath = findPackageJsonPath(
+        childName,
+        context,
+      );
+      await visitNpmPackagesInternal(childPackageJsonPath);
+    }
+  };
+
+  return visitNpmPackagesInternal(rootPackageJsonPath);
+}
+
+export function findPackageJsonPath(
+  dependency: string,
+  baseDir: string,
+): string {
+  const packagePath = resolvePackagePath(dependency, baseDir);
+  if (packagePath == null) {
+    throw new Error(`Could not resolve ${dependency} from ${baseDir}`);
+  }
+  return packagePath;
+}
+
+export async function parsePackageJson(
+  packageJsonPath: string,
+): Promise<PackageJson> {
+  let packageJsonContent;
+  try {
+    packageJsonContent = await readFile(packageJsonPath, "utf-8");
+  } catch (err) {
+    throw new Error(
+      `Failed to read file at path. Does it exist?: "${packageJsonPath}"`,
+      { cause: err },
+    );
+  }
+  try {
+    return JSON.parse(packageJsonContent);
+  } catch (err) {
+    throw new Error(
+      `Failed to parse package.json content from file "${packageJsonPath}"`,
+      { cause: err },
+    );
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3832,6 +3832,9 @@ importers:
       react-dom:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
+      resolve-package-path:
+        specifier: ^4.0.3
+        version: 4.0.3
       ts-expect:
         specifier: ^1.3.0
         version: 1.3.0
@@ -5753,7 +5756,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.21.8':
     resolution: {integrity: sha512-gU+NlL/XS9r7LEfLhjDDKuv3jEtOh+rVnk/k7Lp8WrUwaMCoEGfmQpSqLXetFCCC4UFXSaj1cdMGoy2UBw4rew==}


### PR DESCRIPTION
Discover OSDK packages from widget set project's package.json dependencies and include these in the built widget set manifest. The package.json format is to be determined.