### PR TITLE
Version Packages

### DIFF
--- a/.changeset/tame-peaches-walk.md
+++ b/.changeset/tame-peaches-walk.md
@@ -1,5 +1,0 @@
----
-"@osdk/oauth": patch
----
-
-Added the ability to re-create the refresh token if the operation scopes change

--- a/packages/e2e.sandbox.oauth/CHANGELOG.md
+++ b/packages/e2e.sandbox.oauth/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/e2e.sandbox.oauth
 
+## 0.2.4
+
+### Patch Changes
+
+- Updated dependencies [75711ff]
+  - @osdk/oauth@0.3.1
+
 ## 0.2.3
 
 ### Patch Changes

--- a/packages/e2e.sandbox.oauth/package.json
+++ b/packages/e2e.sandbox.oauth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.sandbox.oauth",
   "private": true,
-  "version": "0.2.3",
+  "version": "0.2.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/e2e.sandbox.todoapp/CHANGELOG.md
+++ b/packages/e2e.sandbox.todoapp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/e2e.sandbox.todoappapp
 
+## 2.0.4
+
+### Patch Changes
+
+- Updated dependencies [75711ff]
+  - @osdk/oauth@0.3.1
+
 ## 2.0.3
 
 ### Patch Changes

--- a/packages/e2e.sandbox.todoapp/package.json
+++ b/packages/e2e.sandbox.todoapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/e2e.sandbox.todoapp",
   "private": true,
-  "version": "2.0.3",
+  "version": "2.0.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/oauth/CHANGELOG.md
+++ b/packages/oauth/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/oauth
 
+## 0.3.1
+
+### Patch Changes
+
+- 75711ff: Added the ability to re-create the refresh token if the operation scopes change
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/oauth",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/1.3.x, this PR will be updated.


# Releases
## @osdk/oauth@0.3.1

### Patch Changes

-   75711ff: Added the ability to re-create the refresh token if the operation scopes change

## @osdk/e2e.sandbox.oauth@0.2.4

### Patch Changes

-   Updated dependencies [75711ff]
    -   @osdk/oauth@0.3.1

## @osdk/e2e.sandbox.todoapp@2.0.4

### Patch Changes

-   Updated dependencies [75711ff]
    -   @osdk/oauth@0.3.1
