### PR TITLE
Fixes for custom widgets Vite plugin in Code Workspaces mode

### DIFF
--- a/.changeset/upset-houses-serve.md
+++ b/.changeset/upset-houses-serve.md
@@ -1,0 +1,5 @@
+---
+"@osdk/widget.vite-plugin.unstable": patch
+---
+
+Fixes for custom widgets Vite plugin in Code Workspaces mode

--- a/packages/widget.vite-plugin.unstable/src/dev-plugin/FoundryWidgetDevPlugin.ts
+++ b/packages/widget.vite-plugin.unstable/src/dev-plugin/FoundryWidgetDevPlugin.ts
@@ -33,11 +33,8 @@ import {
 import { extractWidgetConfig } from "../common/extractWidgetConfig.js";
 import { getInputHtmlEntrypoints } from "../common/getInputHtmlEntrypoints.js";
 import { standardizeFileExtension } from "../common/standardizeFileExtension.js";
-import {
-  getCodeWorkspacesBaseHref,
-  isCodeWorkspacesMode,
-} from "./codeWorkspacesMode.js";
 import { extractInjectedScripts } from "./extractInjectedScripts.js";
+import { getBaseHref } from "./getBaseHref.js";
 import { getFoundryToken } from "./getFoundryToken.js";
 import { getWidgetIdOverrideMap } from "./getWidgetIdOverrideMap.js";
 import { publishDevModeSettings } from "./publishDevModeSettings.js";
@@ -157,7 +154,7 @@ export function FoundryWidgetDevPlugin(): Plugin {
             codeEntrypoints,
             configFileToEntrypoint,
             configFiles,
-            getLocalhostUrl(server),
+            getBaseHref(server),
           );
           await publishDevModeSettings(
             server,
@@ -237,20 +234,6 @@ export function FoundryWidgetDevPlugin(): Plugin {
   };
 }
 
-function getLocalhostUrl(server: ViteDevServer): string {
-  return `${
-    server.config.server.https ? "https" : "http"
-  }://localhost:${server.config.server.port}`;
-}
-
-function getBaseHref(
-  server: ViteDevServer,
-): string {
-  return isCodeWorkspacesMode(server.config.mode)
-    ? getCodeWorkspacesBaseHref()
-    : `${getLocalhostUrl(server)}${server.config.base}`;
-}
-
 /**
  * During the resolution phase source are given as relative paths to the importer
  */
@@ -263,8 +246,7 @@ function serverPath(server: ViteDevServer, subPath: string): string {
 }
 
 function printSetupPageUrl(server: ViteDevServer) {
-  const localhostUrl = getLocalhostUrl(server);
-  const setupRoute = `${localhostUrl}${serverPath(server, SETUP_PATH)}/`;
+  const setupRoute = `${getBaseHref(server)}${SETUP_PATH}/`;
   server.config.logger.info(
     `  ${color.green("➜")}  ${
       color.bold("Click to enter developer mode for your widget set")

--- a/packages/widget.vite-plugin.unstable/src/dev-plugin/__tests__/codeWorkspacesMode.test.ts
+++ b/packages/widget.vite-plugin.unstable/src/dev-plugin/__tests__/codeWorkspacesMode.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from "fs";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import * as codeWorkspacesMode from "../codeWorkspacesMode.js";
+
+const FOUNDRY_PROXY_URL = "foundry.proxy.url";
+const DEV_SERVER_DOMAIN = "workspace.stack.com";
+const DEV_SERVER_BASE_PATH = "/proxy/path";
+const FOUNDRY_PROXY_TOKEN = "/tmp/token.txt";
+const MOCK_TOKEN = "token-value";
+
+describe("codeWorkspacesMode", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("isCodeWorkspacesMode", () => {
+    test("returns true for 'code-workspaces' mode", () => {
+      expect(codeWorkspacesMode.isCodeWorkspacesMode("code-workspaces")).toBe(
+        true,
+      );
+    });
+
+    test("returns false for other modes", () => {
+      expect(codeWorkspacesMode.isCodeWorkspacesMode("dev")).toBe(false);
+      expect(codeWorkspacesMode.isCodeWorkspacesMode(undefined)).toBe(false);
+    });
+  });
+
+  describe("getCodeWorkspacesFoundryUrl", () => {
+    test("returns correct URL when env is set", () => {
+      vi.stubEnv("FOUNDRY_PROXY_URL", FOUNDRY_PROXY_URL);
+      expect(codeWorkspacesMode.getCodeWorkspacesFoundryUrl()).toBe(
+        `https://${FOUNDRY_PROXY_URL}`,
+      );
+    });
+
+    test("throws if env is missing", () => {
+      vi.stubEnv("FOUNDRY_PROXY_URL", undefined);
+      expect(() => codeWorkspacesMode.getCodeWorkspacesFoundryUrl()).toThrow();
+    });
+  });
+
+  describe("getCodeWorkspacesBaseHref", () => {
+    test("returns correct base href when env is set", () => {
+      vi.stubEnv("DEV_SERVER_DOMAIN", DEV_SERVER_DOMAIN);
+      vi.stubEnv("DEV_SERVER_BASE_PATH", DEV_SERVER_BASE_PATH);
+      expect(codeWorkspacesMode.getCodeWorkspacesBaseHref()).toBe(
+        `https://${DEV_SERVER_DOMAIN}${DEV_SERVER_BASE_PATH}`,
+      );
+    });
+
+    test("throws if DEV_SERVER_DOMAIN is missing", () => {
+      vi.stubEnv("DEV_SERVER_DOMAIN", undefined);
+      vi.stubEnv("DEV_SERVER_BASE_PATH", DEV_SERVER_BASE_PATH);
+      expect(() => codeWorkspacesMode.getCodeWorkspacesBaseHref()).toThrow();
+    });
+
+    test("throws if DEV_SERVER_BASE_PATH is missing", () => {
+      vi.stubEnv("DEV_SERVER_DOMAIN", DEV_SERVER_DOMAIN);
+      vi.stubEnv("DEV_SERVER_BASE_PATH", undefined);
+      expect(() => codeWorkspacesMode.getCodeWorkspacesBaseHref()).toThrow();
+    });
+  });
+
+  describe("getCodeWorkspacesFoundryToken", () => {
+    test("returns token from file when env and file are set", () => {
+      vi.stubEnv("FOUNDRY_PROXY_TOKEN", FOUNDRY_PROXY_TOKEN);
+      vi.spyOn(fs, "readFileSync").mockReturnValue(MOCK_TOKEN);
+      expect(codeWorkspacesMode.getCodeWorkspacesFoundryToken()).toBe(
+        MOCK_TOKEN,
+      );
+    });
+
+    test("throws if env is missing", () => {
+      vi.stubEnv("FOUNDRY_PROXY_TOKEN", undefined);
+      expect(() => codeWorkspacesMode.getCodeWorkspacesFoundryToken())
+        .toThrow();
+    });
+
+    test("throws if file read fails", () => {
+      vi.stubEnv("FOUNDRY_PROXY_TOKEN", FOUNDRY_PROXY_TOKEN);
+      vi.spyOn(fs, "readFileSync").mockImplementation(() => {
+        throw new Error("fail");
+      });
+      expect(() => codeWorkspacesMode.getCodeWorkspacesFoundryToken())
+        .toThrow();
+    });
+  });
+});

--- a/packages/widget.vite-plugin.unstable/src/dev-plugin/__tests__/getBaseHref.test.ts
+++ b/packages/widget.vite-plugin.unstable/src/dev-plugin/__tests__/getBaseHref.test.ts
@@ -25,8 +25,6 @@ describe("getBaseHref", () => {
   });
 
   test("returns localhost URLs in local mode", () => {
-    vi.spyOn(codeWorkspacesMode, "isCodeWorkspacesMode").mockReturnValue(false);
-
     const server = {
       config: {
         mode: "",
@@ -40,7 +38,6 @@ describe("getBaseHref", () => {
   });
 
   test("returns code workspaces URLs in code workspaces mode", () => {
-    vi.spyOn(codeWorkspacesMode, "isCodeWorkspacesMode").mockReturnValue(true);
     // Representative value when running dev mode in Code Workspaces mode
     vi.spyOn(codeWorkspacesMode, "getCodeWorkspacesBaseHref").mockReturnValue(
       "https://workspace.stack.com/proxy/path",

--- a/packages/widget.vite-plugin.unstable/src/dev-plugin/__tests__/getBaseHref.test.ts
+++ b/packages/widget.vite-plugin.unstable/src/dev-plugin/__tests__/getBaseHref.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ViteDevServer } from "vite";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import * as codeWorkspacesMode from "../codeWorkspacesMode.js";
+import { getBaseHref } from "../getBaseHref.js";
+
+describe("getBaseHref", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("returns localhost URLs in local mode", () => {
+    vi.spyOn(codeWorkspacesMode, "isCodeWorkspacesMode").mockReturnValue(false);
+
+    const server = {
+      config: {
+        mode: "",
+        base: "/",
+        server: { https: false, port: 5173 },
+      },
+    } as unknown as ViteDevServer;
+
+    const result = getBaseHref(server);
+    expect(result).toEqual("http://localhost:5173/");
+  });
+
+  test("returns code workspaces URLs in code workspaces mode", () => {
+    vi.spyOn(codeWorkspacesMode, "isCodeWorkspacesMode").mockReturnValue(true);
+    // Representative value when running dev mode in Code Workspaces mode
+    vi.spyOn(codeWorkspacesMode, "getCodeWorkspacesBaseHref").mockReturnValue(
+      "https://workspace.stack.com/proxy/path",
+    );
+
+    const server = {
+      config: { mode: "code-workspaces" },
+    } as unknown as ViteDevServer;
+
+    const result = getBaseHref(server);
+    expect(result).toEqual("https://workspace.stack.com/proxy/path/");
+  });
+});

--- a/packages/widget.vite-plugin.unstable/src/dev-plugin/__tests__/getWidgetIdOverrideMap.test.ts
+++ b/packages/widget.vite-plugin.unstable/src/dev-plugin/__tests__/getWidgetIdOverrideMap.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ParameterConfig, WidgetConfig } from "@osdk/widget.api.unstable";
+import type { ViteDevServer } from "vite";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import * as extractInjectedScriptsModule from "../extractInjectedScripts.js";
+import { getWidgetIdOverrideMap } from "../getWidgetIdOverrideMap.js";
+
+const MOCK_SERVER = {} as ViteDevServer;
+const MOCK_CODE_ENTRYPOINTS = { "entry.ts": `/entry.js` };
+const MOCK_CONFIG_FILE_TO_ENTRYPOINT = { "widget.config.ts": "entry.ts" };
+const MOCK_CONFIG_FILES = {
+  "widget.config.ts": { id: "widgetId" } as WidgetConfig<ParameterConfig>,
+};
+
+describe("getWidgetIdOverrideMap", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("localhost dev server URLs", async () => {
+    vi.spyOn(extractInjectedScriptsModule, "extractInjectedScripts")
+      .mockResolvedValue({
+        // Extracted scripts sources start with the base path
+        scriptSources: ["/@vite/client"],
+        inlineScripts: [],
+      });
+    const baseHref = `http://localhost:5173/`;
+
+    const result = await getWidgetIdOverrideMap(
+      MOCK_SERVER,
+      MOCK_CODE_ENTRYPOINTS,
+      MOCK_CONFIG_FILE_TO_ENTRYPOINT,
+      MOCK_CONFIG_FILES,
+      baseHref,
+    );
+
+    expect(result).toEqual({
+      "widgetId": [
+        `${baseHref}.palantir/vite-injections.js`,
+        `${baseHref}@vite/client`,
+        `${baseHref}entry.js`,
+      ],
+    });
+  });
+
+  test("remote server URLs", async () => {
+    // Representative values when running dev mode in Code Workspaces mode
+    vi.spyOn(extractInjectedScriptsModule, "extractInjectedScripts")
+      .mockResolvedValue({
+        // Extracted scripts sources start with the base path
+        scriptSources: [`/proxy/path/@vite/client`],
+        inlineScripts: [],
+      });
+    const baseHref = `https://worksapce.stack.com/proxy/path/`;
+
+    const result = await getWidgetIdOverrideMap(
+      MOCK_SERVER,
+      MOCK_CODE_ENTRYPOINTS,
+      MOCK_CONFIG_FILE_TO_ENTRYPOINT,
+      MOCK_CONFIG_FILES,
+      baseHref,
+    );
+
+    expect(result).toEqual({
+      "widgetId": [
+        `${baseHref}.palantir/vite-injections.js`,
+        `${baseHref}@vite/client`,
+        `${baseHref}entry.js`,
+      ],
+    });
+  });
+});

--- a/packages/widget.vite-plugin.unstable/src/dev-plugin/codeWorkspacesMode.ts
+++ b/packages/widget.vite-plugin.unstable/src/dev-plugin/codeWorkspacesMode.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
+import fs from "fs";
 import { safeGetEnvVar } from "../common/safeGetEnvVar.js";
 
 const CODE_WORKSPACES = "code-workspaces";
 
 // Environment variable names
-export const CODE_WORKSPACES_TOKEN = "FOUNDRY_PROXY_TOKEN";
+const CODE_WORKSPACES_TOKEN_PATH = "FOUNDRY_PROXY_TOKEN";
 const FOUNDRY_PROXY_URL = "FOUNDRY_PROXY_URL";
 const DEV_SERVER_DOMAIN = "DEV_SERVER_DOMAIN";
 const DEV_SERVER_BASE_PATH = "DEV_SERVER_BASE_PATH";
@@ -50,4 +51,25 @@ export function getCodeWorkspacesBaseHref(): string {
     "This value is required when running dev mode in Code Workspaces mode.",
   );
   return `https://${devServerDomain}${devServerPath}`;
+}
+
+/**
+ * Read the token value from the file specified in the environment variable. The value within this
+ * file could change over the lifetime of the workspace container.
+ */
+export function getCodeWorkspacesFoundryToken(): string {
+  const tokenFilePath = safeGetEnvVar(
+    process.env,
+    CODE_WORKSPACES_TOKEN_PATH,
+    "This value is required when running dev mode in Code Workspaces mode.",
+  );
+  try {
+    return fs.readFileSync(tokenFilePath, "utf8");
+  } catch (err) {
+    throw new Error(
+      `Failed to read Foundry token from '${tokenFilePath}': ${
+        (err as Error).message
+      }`,
+    );
+  }
 }

--- a/packages/widget.vite-plugin.unstable/src/dev-plugin/getBaseHref.ts
+++ b/packages/widget.vite-plugin.unstable/src/dev-plugin/getBaseHref.ts
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-import { safeGetEnvVar } from "../common/safeGetEnvVar.js";
+import type { ViteDevServer } from "vite";
 import {
-  getCodeWorkspacesFoundryToken,
+  getCodeWorkspacesBaseHref,
   isCodeWorkspacesMode,
 } from "./codeWorkspacesMode.js";
 
-// User token environment variable name
-const FOUNDRY_TOKEN = "FOUNDRY_TOKEN";
+export function getBaseHref(server: ViteDevServer): string {
+  const baseHref = isCodeWorkspacesMode(server.config.mode)
+    ? getCodeWorkspacesBaseHref()
+    : getLocalhostBaseHref(server);
+  // Ensure that all URLs end with a trailing slash for consistency
+  return baseHref.replace(/\/?$/, "/");
+}
 
-export function getFoundryToken(mode: string | undefined): string {
-  if (isCodeWorkspacesMode(mode)) {
-    return getCodeWorkspacesFoundryToken();
-  }
-  return safeGetEnvVar(
-    process.env,
-    FOUNDRY_TOKEN,
-    "This value is required to run dev mode.",
-  );
+function getLocalhostBaseHref(server: ViteDevServer): string {
+  return `${
+    server.config.server.https ? "https" : "http"
+  }://localhost:${server.config.server.port}${server.config.base}`;
 }


### PR DESCRIPTION
Consolidated some of the logic around usage of the `baseHref` value and started using this value in `getWidgetIdOverrideMap`, where previously there was still usage of a localhost prefix even if running in Code Workspaces mode. I've tested this in a workspace and added tests based on representative example data in order to validate the changes.

Also corrected the usage of the `FOUNDRY_PROXY_TOKEN` environment variable, which points to a file to be read instead of containing the token value directly.