### PR TITLE
Write site details to jemma custom metadata file

### DIFF
--- a/.changeset/clever-friends-read.md
+++ b/.changeset/clever-friends-read.md
@@ -1,0 +1,5 @@
+---
+"@osdk/cli": patch
+---
+
+Write site url to Jemma custom metadata file when present

--- a/packages/cli/src/util/maybeUpdateJemmaCustomMetadata.test.ts
+++ b/packages/cli/src/util/maybeUpdateJemmaCustomMetadata.test.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fs from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { maybeUpdateJemmaCustomMetadata } from "./maybeUpdateJemmaCustomMetadata.js";
+
+vi.mock("node:fs");
+vi.mock("consola", () => ({
+  consola: {
+    error: vi.fn(),
+  },
+}));
+
+describe("maybeUpdateJemmaCustomMetadata", () => {
+  const TEST_FILE_PATH = "/test/metadata.json";
+  const TEST_SITE_LINK = "https://example.com";
+  const TEST_SITE_VERSION = "1.0.0";
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("should not write to file when environment variable is not set", () => {
+    maybeUpdateJemmaCustomMetadata({
+      siteLink: TEST_SITE_LINK,
+      siteVersion: TEST_SITE_VERSION,
+    });
+    expect(fs.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it("should create new file with site link when file does not exist", () => {
+    vi.stubEnv("JEMMA_JOB_CUSTOM_METADATA_PATH", TEST_FILE_PATH);
+    vi.mocked(fs.readFileSync).mockImplementation(() => {
+      throw new Error("File not found");
+    });
+
+    maybeUpdateJemmaCustomMetadata({
+      siteLink: TEST_SITE_LINK,
+      siteVersion: TEST_SITE_VERSION,
+    });
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      TEST_FILE_PATH,
+      JSON.stringify(
+        { siteLink: TEST_SITE_LINK, siteVersion: TEST_SITE_VERSION },
+        null,
+        2,
+      ),
+    );
+  });
+
+  it("should write to file when it exists but is empty", () => {
+    vi.stubEnv("JEMMA_JOB_CUSTOM_METADATA_PATH", TEST_FILE_PATH);
+    vi.mocked(fs.readFileSync).mockReturnValue("{}");
+
+    maybeUpdateJemmaCustomMetadata({
+      siteLink: TEST_SITE_LINK,
+      siteVersion: TEST_SITE_VERSION,
+    });
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      TEST_FILE_PATH,
+      JSON.stringify(
+        { siteLink: TEST_SITE_LINK, siteVersion: TEST_SITE_VERSION },
+        null,
+        2,
+      ),
+    );
+  });
+
+  it("should override existing values in file", () => {
+    vi.stubEnv("JEMMA_JOB_CUSTOM_METADATA_PATH", TEST_FILE_PATH);
+    const existingData = {
+      someOtherKey: "value",
+      siteLink: "old-link.com",
+      siteVersion: "0.0.1",
+    };
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(existingData));
+
+    maybeUpdateJemmaCustomMetadata({
+      siteLink: TEST_SITE_LINK,
+      siteVersion: TEST_SITE_VERSION,
+    });
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      TEST_FILE_PATH,
+      JSON.stringify(
+        {
+          ...existingData,
+          siteLink: TEST_SITE_LINK,
+          siteVersion: TEST_SITE_VERSION,
+        },
+        null,
+        2,
+      ),
+    );
+  });
+
+  it("should write to the file even if it contains invalid JSON", () => {
+    vi.stubEnv("JEMMA_JOB_CUSTOM_METADATA_PATH", TEST_FILE_PATH);
+    vi.mocked(fs.readFileSync).mockReturnValue("invalid json");
+
+    maybeUpdateJemmaCustomMetadata({
+      siteLink: TEST_SITE_LINK,
+      siteVersion: TEST_SITE_VERSION,
+    });
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      TEST_FILE_PATH,
+      JSON.stringify(
+        { siteLink: TEST_SITE_LINK, siteVersion: TEST_SITE_VERSION },
+        null,
+        2,
+      ),
+    );
+  });
+});

--- a/packages/cli/src/util/maybeUpdateJemmaCustomMetadata.ts
+++ b/packages/cli/src/util/maybeUpdateJemmaCustomMetadata.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { consola } from "consola";
+
+import * as fs from "node:fs";
+
+// Environment variable names
+const JEMMA_JOB_CUSTOM_METADATA_PATH = "JEMMA_JOB_CUSTOM_METADATA_PATH";
+
+/**
+ * Writes the site link to the custom metadata file (if the path is provided by the JEMMA_JOB_CUSTOM_METADATA_PATH environment variable).
+ *
+ * The custom metadata file will be updated with the following format:
+ *
+ * {
+ *   "siteLink": "https://example.com",
+ *   "siteVersion": "1.0.0"
+ * }
+ *
+ * @param siteLink The site link to write to the custom metadata file.
+ * @param siteVersion The site version to write to the custom metadata file.
+ */
+export function maybeUpdateJemmaCustomMetadata({
+  siteLink,
+  siteVersion,
+}: {
+  siteLink: string;
+  siteVersion: string;
+}): void {
+  const jemmaCustomMetadataFilePath = getJemmaCustomMetadataFilePath();
+  if (jemmaCustomMetadataFilePath == null) {
+    return;
+  }
+
+  try {
+    // Read or create the custom metadata file
+    const customMetadata = getOrCreateCustomMetadata(
+      jemmaCustomMetadataFilePath,
+    );
+
+    // Set the site link in the custom metadata
+    customMetadata.siteLink = siteLink;
+    customMetadata.siteVersion = siteVersion;
+
+    // Write the custom metadata to the file
+    writeCustomMetadata(jemmaCustomMetadataFilePath, customMetadata);
+  } catch (err) {
+    consola.error(
+      `Failed to update custom metadata file at ${jemmaCustomMetadataFilePath}`,
+    );
+  }
+}
+
+function getJemmaCustomMetadataFilePath(): string | undefined {
+  return process.env[JEMMA_JOB_CUSTOM_METADATA_PATH];
+}
+
+function getOrCreateCustomMetadata(jemmaCustomMetadataFilePath: string): {
+  [key: string]: unknown;
+} {
+  try {
+    const parsedValue = JSON.parse(
+      fs.readFileSync(jemmaCustomMetadataFilePath, "utf-8"),
+    );
+    return typeof parsedValue === "object" && parsedValue != null
+      ? parsedValue
+      : {};
+  } catch (e) {
+    return {};
+  }
+}
+
+function writeCustomMetadata(
+  jemmaCustomMetadataFilePath: string,
+  customMetadata: { [key: string]: unknown },
+) {
+  fs.writeFileSync(
+    jemmaCustomMetadataFilePath,
+    JSON.stringify(customMetadata, null, 2),
+  );
+}

--- a/packages/monorepo.cspell/dict.foundry-words.txt
+++ b/packages/monorepo.cspell/dict.foundry-words.txt
@@ -10,3 +10,5 @@ writeback
 geohash
 mediasets
 efgh
+jemma
+JEMMA


### PR DESCRIPTION
We write the `siteUrl` and `siteVersion` to the job custom metadata file so we can later re-use it.