### PR TITLE
Add Refresh to the Actual Legacy Client

### DIFF
--- a/.changeset/tough-cougars-fetch.md
+++ b/.changeset/tough-cougars-fetch.md
@@ -1,0 +1,5 @@
+---
+"@osdk/legacy-client": patch
+---
+
+update the legacy public oauth client to support refresh

--- a/packages/foundry-sdk-generator/src/generate/GeneratePackageCommand.test.ts
+++ b/packages/foundry-sdk-generator/src/generate/GeneratePackageCommand.test.ts
@@ -149,7 +149,7 @@ describe(GeneratePackageCommand, () => {
       [
         {
           "file": "/not-real/index.d.ts",
-          "line": 6858,
+          "line": 6859,
           "message": "Module '"internal/@osdk/api"' has no exported member 'notARealThing'.",
         },
       ]

--- a/packages/legacy-client/src/oauth-client/PublicClient/PublicClientAuth.ts
+++ b/packages/legacy-client/src/oauth-client/PublicClient/PublicClientAuth.ts
@@ -122,6 +122,10 @@ export class PublicClientAuth implements Auth {
         const didRefresh = await this.tryRefreshToken(refreshToken);
         if (didRefresh) {
           shouldMakeAuthRequest = false;
+          localStorage.setItem(
+            this.palantirRefreshTokenScopes,
+            clientScopes,
+          );
         }
       } else {
         // Scopes don't match - remove refresh token and force re-authentication
@@ -264,6 +268,7 @@ export class PublicClientAuth implements Auth {
       // Scopes don't match - remove refresh token and force re-authentication
       localStorage.removeItem(this.palantirRefreshToken);
       localStorage.removeItem(this.palantirRefreshTokenScopes);
+      sessionStorage.removeItem(this.palantirPkce);
       throw new Error(
         "Stored scopes don't match current scopes. Please sign in again.",
       );

--- a/packages/legacy-client/src/oauth-client/PublicClient/PublicClientAuth.ts
+++ b/packages/legacy-client/src/oauth-client/PublicClient/PublicClientAuth.ts
@@ -33,6 +33,7 @@ import {
 
 export class PublicClientAuth implements Auth {
   private palantirRefreshToken = "palantir_refresh_token" as const;
+  private palantirRefreshTokenScopes = "palantir_refresh_token_scopes" as const;
   private palantirPkce = "palantir_pkce" as const;
 
   private nextSubscriberId = 0;
@@ -108,13 +109,25 @@ export class PublicClientAuth implements Auth {
    */
   public async signIn(): Promise<SignInResponse> {
     let shouldMakeAuthRequest = true;
+    const clientScopes = this.options.scopes?.join(" ") ?? "";
 
-    // 1. Check if we have a refresh token in local storage
+    // 1. Check if we have a refresh token in local storage. If the scopes match, we can use it to get a new token
+    // If the scopes don't match, we need to re-authenticate
     const refreshToken = localStorage.getItem(this.palantirRefreshToken);
+    const storedScopes = localStorage.getItem(this.palantirRefreshTokenScopes);
+
     if (refreshToken) {
-      const didRefresh = await this.tryRefreshToken(refreshToken);
-      if (didRefresh) {
-        shouldMakeAuthRequest = false;
+      // Check if stored scopes match current client scopes
+      if (storedScopes && storedScopes === clientScopes) {
+        const didRefresh = await this.tryRefreshToken(refreshToken);
+        if (didRefresh) {
+          shouldMakeAuthRequest = false;
+        }
+      } else {
+        // Scopes don't match - remove refresh token and force re-authentication
+        localStorage.removeItem(this.palantirRefreshToken);
+        localStorage.removeItem(this.palantirRefreshTokenScopes);
+        sessionStorage.removeItem(this.palantirPkce);
       }
     }
 
@@ -136,6 +149,10 @@ export class PublicClientAuth implements Auth {
           localStorage.setItem(
             this.palantirRefreshToken,
             this.token.refreshToken,
+          );
+          localStorage.setItem(
+            this.palantirRefreshTokenScopes,
+            clientScopes,
           );
         }
         shouldMakeAuthRequest = false;
@@ -219,6 +236,7 @@ export class PublicClientAuth implements Auth {
     // Clean up local storage
     sessionStorage.removeItem(this.palantirPkce);
     localStorage.removeItem(this.palantirRefreshToken);
+    localStorage.removeItem(this.palantirRefreshTokenScopes);
 
     // Remove all references to this token
     this.token = null;
@@ -236,6 +254,19 @@ export class PublicClientAuth implements Auth {
     const refreshToken = localStorage.getItem(this.palantirRefreshToken);
     if (!refreshToken) {
       throw new Error("No refresh token found");
+    }
+
+    // Check if stored scopes match current client scopes
+    const storedScopes = localStorage.getItem(this.palantirRefreshTokenScopes);
+    const clientScopes = this.options.scopes?.join(" ") ?? "";
+
+    if (storedScopes !== clientScopes) {
+      // Scopes don't match - remove refresh token and force re-authentication
+      localStorage.removeItem(this.palantirRefreshToken);
+      localStorage.removeItem(this.palantirRefreshTokenScopes);
+      throw new Error(
+        "Stored scopes don't match current scopes. Please sign in again.",
+      );
     }
 
     const didRefresh = await this.tryRefreshToken(refreshToken);
@@ -318,6 +349,11 @@ export class PublicClientAuth implements Auth {
           this.palantirRefreshToken,
           this.token.refreshToken,
         );
+        const clientScopes = this.options.scopes?.join(" ") ?? "";
+        localStorage.setItem(
+          this.palantirRefreshTokenScopes,
+          clientScopes,
+        );
       }
       return true;
     } catch (e) {
@@ -327,6 +363,7 @@ export class PublicClientAuth implements Auth {
         e,
       );
       localStorage.removeItem(this.palantirRefreshToken);
+      localStorage.removeItem(this.palantirRefreshTokenScopes);
       return false;
     }
   }


### PR DESCRIPTION
We added the ability to force a re-auth when our client scopes change on the publicOauth legacy client. Now if the developer changes their client scopes, we will clear our local storage and force a re-authentication to ensure that there are not breaks when new versions of the SDK are pushed