### PR TITLE
Version Packages

### DIFF
--- a/.changeset/tough-cougars-fetch.md
+++ b/.changeset/tough-cougars-fetch.md
@@ -1,5 +1,0 @@
----
-"@osdk/legacy-client": patch
----
-
-update the legacy public oauth client to support refresh

--- a/packages/e2e.generated.1.1.x/package.json
+++ b/packages/e2e.generated.1.1.x/package.json
@@ -38,13 +38,13 @@
   },
   "peerDependencies": {
     "@osdk/api": "^1.9.3",
-    "@osdk/legacy-client": "^2.5.4"
+    "@osdk/legacy-client": "^2.5.5"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.2",
     "@osdk/api": "^1.9.3",
     "@osdk/cli.cmd.typescript": "workspace:~",
-    "@osdk/legacy-client": "^2.5.4",
+    "@osdk/legacy-client": "^2.5.5",
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
     "@osdk/monorepo.tsup": "workspace:~",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/foundry-sdk-generator
 
+## 1.3.15
+
+### Patch Changes
+
+- Updated dependencies [affbaf1]
+  - @osdk/legacy-client@2.5.5
+
 ## 1.3.14
 
 ### Patch Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/legacy-client/CHANGELOG.md
+++ b/packages/legacy-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/legacy-client
 
+## 2.5.5
+
+### Patch Changes
+
+- affbaf1: update the legacy public oauth client to support refresh
+
 ## 2.5.4
 
 ### Patch Changes

--- a/packages/legacy-client/package.json
+++ b/packages/legacy-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/legacy-client",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/1.3.x, this PR will be updated.


# Releases
## @osdk/foundry-sdk-generator@1.3.15

### Patch Changes

-   Updated dependencies [affbaf1]
    -   @osdk/legacy-client@2.5.5

## @osdk/legacy-client@2.5.5

### Patch Changes

-   affbaf1: update the legacy public oauth client to support refresh
