### PR TITLE
Update default scopes to include `api:use-ontologies-read/write`

### DIFF
--- a/.changeset/sour-avocados-work.md
+++ b/.changeset/sour-avocados-work.md
@@ -1,0 +1,5 @@
+---
+"@osdk/legacy-client": patch
+---
+
+Added use operations to the default scopes

--- a/packages/legacy-client/src/oauth-client/ConfidentialClient/ConfidentialClientAuth.ts
+++ b/packages/legacy-client/src/oauth-client/ConfidentialClient/ConfidentialClientAuth.ts
@@ -54,7 +54,12 @@ export class ConfidentialClientAuth implements Auth {
     }
 
     if (!options.scopes) {
-      options.scopes = ["api:read-data", "api:write-data"];
+      options.scopes = [
+        "api:read-data",
+        "api:write-data",
+        "api:use-ontologies-read",
+        "api:use-ontologies-write",
+      ];
     }
   }
 

--- a/packages/legacy-client/src/oauth-client/PublicClient/PublicClientAuth.ts
+++ b/packages/legacy-client/src/oauth-client/PublicClient/PublicClientAuth.ts
@@ -71,7 +71,12 @@ export class PublicClientAuth implements Auth {
     }
 
     if (!options.scopes) {
-      options.scopes = ["api:read-data", "api:write-data"];
+      options.scopes = [
+        "api:read-data",
+        "api:write-data",
+        "api:use-ontologies-read",
+        "api:use-ontologies-write",
+      ];
     }
   }
 


### PR DESCRIPTION
Now by default, we will request 

```
 options.scopes = [
        "api:read-data",
        "api:write-data",
        "api:use-ontologies-read",
        "api:use-ontologies-write",
      ];
```