### PR TITLE
Enforce that struct, mediaReference, and GTSR type SPTs cannot have render hints

### DIFF
--- a/.changeset/clear-hairs-turn.md
+++ b/.changeset/clear-hairs-turn.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker": patch
+---
+
+Enforce that struct type SPTs cannot have type classes

--- a/.changeset/clear-hairs-turn.md
+++ b/.changeset/clear-hairs-turn.md
@@ -2,4 +2,4 @@
 "@osdk/maker": patch
 ---
 
-Enforce that struct type SPTs cannot have type classes
+Enforce that struct, mediaReference, and GTSR type SPTs cannot have render hints

--- a/packages/maker/src/api/defineSpt.ts
+++ b/packages/maker/src/api/defineSpt.ts
@@ -60,8 +60,10 @@ export function defineSharedPropertyType(
   const isStruct = typeof sptDef.type === "object"
     && sptDef.type.type === "struct";
   invariant(
-    !isStruct || (sptDef.typeClasses?.length ?? 0) === 0,
-    `Shared property type ${apiName} of type 'struct' cannot have type classes`,
+    !isStruct
+      || (sptDef.typeClasses ?? []).filter((tc) => tc.kind === "render_hint")
+          .length === 0,
+    `Shared property type ${apiName} of type 'struct' should not have render hints`,
   );
 
   const fullSpt: SharedPropertyType = {

--- a/packages/maker/src/api/defineSpt.ts
+++ b/packages/maker/src/api/defineSpt.ts
@@ -57,13 +57,19 @@ export function defineSharedPropertyType(
       === undefined,
     `Shared property type ${apiName} already exists`,
   );
+  const isStruct = typeof sptDef.type === "object"
+    && sptDef.type.type === "struct";
+  invariant(
+    !isStruct || (sptDef.typeClasses?.length ?? 0) === 0,
+    `Shared property type ${apiName} of type 'struct' cannot have type classes`,
+  );
 
   const fullSpt: SharedPropertyType = {
     ...sptDef,
     apiName,
     nonNameSpacedApiName: sptDef.apiName,
     displayName: sptDef.displayName ?? sptDef.apiName, // This way the non-namespaced api name is the display name (maybe not ideal)
-    typeClasses: sptDef.typeClasses ?? defaultTypeClasses,
+    typeClasses: sptDef.typeClasses ?? (isStruct ? [] : defaultTypeClasses),
     __type: OntologyEntityTypeEnum.SHARED_PROPERTY_TYPE,
   };
   updateOntology(fullSpt);

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -1324,16 +1324,7 @@ describe("Ontology Defining", () => {
                         },
                         "type": "struct",
                       },
-                      "typeClasses": [
-                        {
-                          "kind": "render_hint",
-                          "name": "SELECTABLE",
-                        },
-                        {
-                          "kind": "render_hint",
-                          "name": "SORTABLE",
-                        },
-                      ],
+                      "typeClasses": [],
                       "valueType": undefined,
                     },
                   },


### PR DESCRIPTION
Changes the default for struct, mediaReference, and geotimeSeriesReference types and adds an invariant to make it a build time error