### PR TITLE
Add api:use-ontologies-read/write to 2.x Client (cherry-pick)

### DIFF
--- a/.changeset/shaggy-lizards-beam.md
+++ b/.changeset/shaggy-lizards-beam.md
@@ -1,0 +1,7 @@
+---
+"@osdk/create-app.template.expo.v2": patch
+"@osdk/cli.common": patch
+"@osdk/oauth": patch
+---
+
+Added api:use-ontologies-read/write to the default scope initialization

--- a/examples/example-expo-sdk-2.x/app/(tabs)/login.tsx
+++ b/examples/example-expo-sdk-2.x/app/(tabs)/login.tsx
@@ -27,7 +27,12 @@ export default function Login() {
   const [request, response, promptAsync] = useAuthRequest(
     {
       clientId: CLIENT_ID,
-      scopes: ["api:read-data", "api:write-data"],
+      scopes: [
+        "api:read-data",
+        "api:write-data",
+        "api:use-ontologies-read",
+        "api:use-ontologies-write",
+      ],
       redirectUri,
       usePKCE: true,
     },

--- a/packages/cli.common/src/commands/auth/login/loginFlow.ts
+++ b/packages/cli.common/src/commands/auth/login/loginFlow.ts
@@ -112,8 +112,8 @@ export async function invokeLoginFlow(
 function generateRandomString(length = 128) {
   const characters =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
-  let output: string[] = [];
-  let array = new Uint8Array(1);
+  const output: string[] = [];
+  const array = new Uint8Array(1);
   const maxIndex = 256 - (256 % characters.length);
 
   while (output.length < length) {
@@ -158,7 +158,7 @@ function generateAuthorizeUrl(
   );
   queryParams.append(
     "scope",
-    ["offline_access", "api:read-data"].join(" "),
+    ["offline_access", "api:read-data", "api:use-ontologies-read"].join(" "),
   );
 
   return join(baseUrl, "multipass", "api", "oauth2", "authorize") + `?`

--- a/packages/create-app.template.expo.v2/templates/app/(tabs)/login.tsx
+++ b/packages/create-app.template.expo.v2/templates/app/(tabs)/login.tsx
@@ -27,7 +27,12 @@ export default function Login() {
   const [request, response, promptAsync] = useAuthRequest(
     {
       clientId: CLIENT_ID,
-      scopes: ["api:read-data", "api:write-data"],
+      scopes: [
+        "api:read-data",
+        "api:write-data",
+        "api:use-ontologies-read",
+        "api:use-ontologies-write",
+      ],
       redirectUri,
       usePKCE: true,
     },

--- a/packages/create-app/src/prompts/promptScopes.ts
+++ b/packages/create-app/src/prompts/promptScopes.ts
@@ -38,8 +38,10 @@ export async function promptScopes(
       "Enter the scopes to request during OAuth:",
       {
         type: "text",
-        placeholder: "api:read-data api:write-data",
-        default: "api:read-data api:write-data",
+        placeholder:
+          "api:read-data api:write-data api:use-ontologies-read api:use-ontologies-write",
+        default:
+          "api:read-data api:write-data api:use-ontologies-read api:use-ontologies-write",
       },
     );
     scopes = stringScopes.split(" ");

--- a/packages/e2e.sandbox.oauth.public.react-router/src/client.ts
+++ b/packages/e2e.sandbox.oauth.public.react-router/src/client.ts
@@ -36,7 +36,7 @@ export const publicOauthClient: PublicOauthClient = createPublicOauthClient(
   // where to redirect after login, defaults to "page before redirect"
   /* post login page */ undefined,
   //
-  // Scopes to use, defaults to: ["api:read-data", "api:write-data"],
+  // Scopes to use, defaults to: ["api:read-data", "api:write-data", "api:use-ontologies-read", "api:use-ontologies-write"],
   /* scopes */ undefined,
 );
 

--- a/packages/oauth/src/createConfidentialOauthClient.ts
+++ b/packages/oauth/src/createConfidentialOauthClient.ts
@@ -37,7 +37,12 @@ export function createConfidentialOauthClient(
   client_id: string,
   client_secret: string,
   url: string,
-  scopes: string[] = ["api:read-data", "api:write-data"],
+  scopes: string[] = [
+    "api:read-data",
+    "api:write-data",
+    "api:use-ontologies-read",
+    "api:use-ontologies-write",
+  ],
   fetchFn: typeof globalThis.fetch = globalThis.fetch,
   ctxPath: string = "multipass",
 ): ConfidentialOauthClient {

--- a/packages/oauth/src/createPublicOauthClient.ts
+++ b/packages/oauth/src/createPublicOauthClient.ts
@@ -65,7 +65,7 @@ export interface PublicOauthClientOptions {
   postLoginPage?: string;
 
   /**
-   * * @param {string[]} [scopes=[]] - OAuth scopes to request. If not provided, defaults to `["api:read-data", "api:write-data"]`
+   * * @param {string[]} [scopes=[]] - OAuth scopes to request. If not provided, defaults to `["api:read-data", "api:write-data", "api:use-ontologies-read", "api:use-ontologies-write"]`
    */
   scopes?: string[];
 
@@ -110,7 +110,7 @@ export function createPublicOauthClient(
  * @param {boolean} useHistory - If true, uses `history.replaceState()`, otherwise uses `window.location.assign()` (defaults to true)
  * @param {string} loginPage - Custom landing page URL prior to logging in
  * @param {string} postLoginPage - URL to return to after completed authentication cycle (defaults to `window.location.toString()`)
- * @param {string[]} scopes - OAuth scopes to request. If not provided, defaults to `["api:read-data", "api:write-data"]`
+ * @param {string[]} scopes - OAuth scopes to request. If not provided, defaults to `["api:read-data", "api:write-data", "api:use-ontologies-read", "api:use-ontologies-write"]`
  * @param {typeof globalThis.fetch} fetchFn - Custom fetch function to use for requests (defaults to `globalThis.fetch`)
  * @param {string} ctxPath - Context path for the authorization server (defaults to "multipass")
  * @returns {PublicOauthClient} A client that can be used as a token provider

--- a/packages/oauth/src/publicOauth.test.ts
+++ b/packages/oauth/src/publicOauth.test.ts
@@ -204,7 +204,13 @@ describe(createPublicOauthClient, () => {
         code_challenge_method: "S256",
         scope: [
           "offline_access",
-          ...(clientArgs.scopes ?? ["api:read-data", "api:write-data"].sort()),
+          ...(clientArgs.scopes
+            ?? [
+              "api:read-data",
+              "api:write-data",
+              "api:use-ontologies-read",
+              "api:use-ontologies-write",
+            ].sort()),
         ].join(" "),
         state: expect.any(String),
       }),
@@ -384,7 +390,12 @@ describe(createPublicOauthClient, () => {
         expect.any(Function),
         undefined,
         (clientArgs.scopes
-          ?? ["api:read-data", "api:write-data"]).sort().join(" "),
+          ?? [
+            "api:read-data",
+            "api:write-data",
+            "api:use-ontologies-read",
+            "api:use-ontologies-write",
+          ]).sort().join(" "),
       );
     });
 
@@ -395,7 +406,12 @@ describe(createPublicOauthClient, () => {
         localStorage: {
           refresh_token: "a-refresh-token",
           requestedScopes: (clientArgs.scopes
-            ?? ["api:read-data", "api:write-data"]).sort().join(" "),
+            ?? [
+              "api:read-data",
+              "api:write-data",
+              "api:use-ontologies-read",
+              "api:use-ontologies-write",
+            ]).sort().join(" "),
         },
         sessionStorage: {},
       },

--- a/packages/oauth/src/utils.ts
+++ b/packages/oauth/src/utils.ts
@@ -65,7 +65,15 @@ export function processOptionsAndAssignDefaults(
     useHistory: options.useHistory ?? true,
     loginPage: options.loginPage,
     postLoginPage: options.postLoginPage || window.location.toString(),
-    joinedScopes: [...options.scopes ?? ["api:read-data", "api:write-data"]]
+    joinedScopes: [
+      ...options.scopes
+        ?? [
+          "api:read-data",
+          "api:write-data",
+          "api:use-ontologies-read",
+          "api:use-ontologies-write",
+        ],
+    ]
       .sort().join(" "),
     fetchFn: options.fetchFn ?? globalThis.fetch,
     ctxPath: options.ctxPath ?? "multipass",


### PR DESCRIPTION
Now the default the client will request:
```
 options.scopes = [
        "api:read-data",
        "api:write-data",
        "api:use-ontologies-read",
        "api:use-ontologies-write",
      ];
```

Cherry picked from https://github.com/palantir/osdk-ts/pull/1517