### PR TITLE
Version Packages

### DIFF
--- a/.changeset/eleven-views-travel.md
+++ b/.changeset/eleven-views-travel.md
@@ -1,5 +1,0 @@
----
-"@osdk/legacy-client": patch
----
-
-Prevent multiple calls for queries that return arrays of objects

--- a/.changeset/sour-avocados-work.md
+++ b/.changeset/sour-avocados-work.md
@@ -1,5 +1,0 @@
----
-"@osdk/legacy-client": patch
----
-
-Added use operations to the default scopes

--- a/packages/e2e.generated.1.1.x/package.json
+++ b/packages/e2e.generated.1.1.x/package.json
@@ -38,13 +38,13 @@
   },
   "peerDependencies": {
     "@osdk/api": "^1.9.3",
-    "@osdk/legacy-client": "^2.5.5"
+    "@osdk/legacy-client": "^2.5.6"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.2",
     "@osdk/api": "^1.9.3",
     "@osdk/cli.cmd.typescript": "workspace:~",
-    "@osdk/legacy-client": "^2.5.5",
+    "@osdk/legacy-client": "^2.5.6",
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
     "@osdk/monorepo.tsup": "workspace:~",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/foundry-sdk-generator
 
+## 1.3.16
+
+### Patch Changes
+
+- Updated dependencies [45eee43]
+- Updated dependencies [f5b2487]
+  - @osdk/legacy-client@2.5.6
+
 ## 1.3.15
 
 ### Patch Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/legacy-client/CHANGELOG.md
+++ b/packages/legacy-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/legacy-client
 
+## 2.5.6
+
+### Patch Changes
+
+- 45eee43: Prevent multiple calls for queries that return arrays of objects
+- f5b2487: Added use operations to the default scopes
+
 ## 2.5.5
 
 ### Patch Changes

--- a/packages/legacy-client/package.json
+++ b/packages/legacy-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/legacy-client",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/1.3.x, this PR will be updated.


# Releases
## @osdk/foundry-sdk-generator@1.3.16

### Patch Changes

-   Updated dependencies [45eee43]
-   Updated dependencies [f5b2487]
    -   @osdk/legacy-client@2.5.6

## @osdk/legacy-client@2.5.6

### Patch Changes

-   45eee43: Prevent multiple calls for queries that return arrays of objects
-   f5b2487: Added use operations to the default scopes
