### PR TITLE
Update OAC codegen

### DIFF
--- a/.changeset/light-eagles-allow.md
+++ b/.changeset/light-eagles-allow.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker": patch
+---
+
+Update OAC codegen

--- a/packages/maker/src/api/defineOntology.ts
+++ b/packages/maker/src/api/defineOntology.ts
@@ -199,7 +199,7 @@ const ${entityFileNameBase}_base: ${entityTypeName} = ${
               : entityJSON
           } as unknown as ${entityTypeName};
         
-export const ${entityFileNameBase} = wrapWithProxy(${entityFileNameBase}_base);
+export const ${entityFileNameBase}: ${entityTypeName} = wrapWithProxy(${entityFileNameBase}_base);
         `;
           fs.writeFileSync(filePath, content, { flag: "w" });
           entityModuleNames.push(entityFileNameBase);

--- a/packages/maker/src/api/defineOntology.ts
+++ b/packages/maker/src/api/defineOntology.ts
@@ -144,7 +144,7 @@ export async function defineOntology(
 }
 
 export function writeStaticObjects(outputDir: string): void {
-  const outputBuildDir = path.resolve(outputDir, "build");
+  const codegenDir = path.resolve(outputDir, "codegen");
   const typeDirs = {
     [OntologyEntityTypeEnum.SHARED_PROPERTY_TYPE]: "shared-property-types",
     [OntologyEntityTypeEnum.ACTION_TYPE]: "action-types",
@@ -154,12 +154,12 @@ export function writeStaticObjects(outputDir: string): void {
     [OntologyEntityTypeEnum.VALUE_TYPE]: "value-types",
   };
 
-  if (!fs.existsSync(outputBuildDir)) {
-    fs.mkdirSync(outputBuildDir, { recursive: true });
+  if (!fs.existsSync(codegenDir)) {
+    fs.mkdirSync(codegenDir, { recursive: true });
   }
 
   Object.values(typeDirs).forEach(typeDirNameFromMap => {
-    const currentTypeDirPath = path.join(outputBuildDir, typeDirNameFromMap);
+    const currentTypeDirPath = path.join(codegenDir, typeDirNameFromMap);
     if (fs.existsSync(currentTypeDirPath)) {
       fs.rmSync(currentTypeDirPath, { recursive: true, force: true });
     }
@@ -173,40 +173,43 @@ export function writeStaticObjects(outputDir: string): void {
       const typeDirName =
         typeDirs[ontologyTypeEnumKey as OntologyEntityTypeEnum];
 
-      const typeDirPath = path.join(outputBuildDir, typeDirName);
+      const typeDirPath = path.join(codegenDir, typeDirName);
       const entityModuleNames: string[] = [];
 
-      Object.entries(entities).forEach(([apiName, entity]) => {
-        const entityFileNameBase = camel(withoutNamespace(apiName))
-          + (ontologyTypeEnumKey as OntologyEntityTypeEnum
-              === OntologyEntityTypeEnum.VALUE_TYPE
-            ? "ValueType"
-            : "");
-        const filePath = path.join(typeDirPath, `${entityFileNameBase}.ts`);
-        const content = `
-import { importOntologyEntity } from '@osdk/maker';
-
-export const ${entityFileNameBase} = ${
-          JSON.stringify(entity, null, 2)
-        } as const;
-        
-importOntologyEntity(${entityFileNameBase});
-        `;
-        fs.writeFileSync(filePath, content, { flag: "w" });
-        entityModuleNames.push(entityFileNameBase);
-      });
-
-      if (entityModuleNames.length > 0) {
-        const typeIndexContent = entityModuleNames
-          .map(name => `export * from './${name}';`)
-          .join("\n") + "\n";
-        const typeIndexFilePath = path.join(typeDirPath, "index.ts");
-        fs.writeFileSync(typeIndexFilePath, typeIndexContent, { flag: "w" });
-        for (const entityModuleName of entityModuleNames) {
-          topLevelExportStatements.push(
-            `export { ${entityModuleName} } from './build/${typeDirName}/${entityModuleName}.ts';`,
+      Object.entries(entities).forEach(
+        ([apiName, entity]: [string, OntologyEntityType]) => {
+          const entityFileNameBase = camel(withoutNamespace(apiName))
+            + (ontologyTypeEnumKey as OntologyEntityTypeEnum
+                === OntologyEntityTypeEnum.VALUE_TYPE
+              ? "ValueType"
+              : "");
+          const filePath = path.join(typeDirPath, `${entityFileNameBase}.ts`);
+          const entityTypeName = getEntityTypeName(ontologyTypeEnumKey);
+          const entityJSON = JSON.stringify(entity, null, 2).replace(
+            /("__type"\s*:\s*)"([^"]*)"/g,
+            (_, prefix, value) => `${prefix}OntologyEntityTypeEnum.${value}`,
           );
-        }
+          const content = `
+import { wrapWithProxy, OntologyEntityTypeEnum } from '@osdk/maker';
+import type { ${entityTypeName} } from '@osdk/maker';
+
+const ${entityFileNameBase}_base: ${entityTypeName} = ${
+            ontologyTypeEnumKey === "VALUE_TYPE"
+              ? entityJSON.slice(1, -2)
+              : entityJSON
+          } as unknown as ${entityTypeName};
+        
+export const ${entityFileNameBase} = wrapWithProxy(${entityFileNameBase}_base);
+        `;
+          fs.writeFileSync(filePath, content, { flag: "w" });
+          entityModuleNames.push(entityFileNameBase);
+        },
+      );
+
+      for (const entityModuleName of entityModuleNames) {
+        topLevelExportStatements.push(
+          `export { ${entityModuleName} } from './codegen/${typeDirName}/${entityModuleName}.js';`,
+        );
       }
     },
   );
@@ -1279,4 +1282,18 @@ function camel(str: string): string {
   let result = str.replace(/[-_]+(.)?/g, (_, c) => (c ? c.toUpperCase() : ""));
   result = result.charAt(0).toLowerCase() + result.slice(1);
   return result;
+}
+
+/**
+ * Gets the TypeScript type name corresponding to an OntologyEntityTypeEnum value
+ */
+function getEntityTypeName(type: string): string {
+  return {
+    [OntologyEntityTypeEnum.OBJECT_TYPE]: "ObjectType",
+    [OntologyEntityTypeEnum.LINK_TYPE]: "LinkType",
+    [OntologyEntityTypeEnum.INTERFACE_TYPE]: "InterfaceType",
+    [OntologyEntityTypeEnum.SHARED_PROPERTY_TYPE]: "SharedPropertyType",
+    [OntologyEntityTypeEnum.ACTION_TYPE]: "ActionType",
+    [OntologyEntityTypeEnum.VALUE_TYPE]: "ValueTypeDefinitionVersion",
+  }[type]!;
 }

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -5272,7 +5272,7 @@ describe("Ontology Defining", () => {
 
       expect(
         fs.readFileSync(
-          "src/generated/export_files_are_generated_correctly/build/interface-types/myInterface.ts",
+          "src/generated/export_files_are_generated_correctly/codegen/interface-types/myInterface.ts",
           "utf8",
         ),
       ).toMatchInlineSnapshot(`
@@ -5323,7 +5323,7 @@ describe("Ontology Defining", () => {
 
       expect(
         fs.readFileSync(
-          "src/generated/export_files_are_generated_correctly/build/object-types/myObject.ts",
+          "src/generated/export_files_are_generated_correctly/codegen/object-types/myObject.ts",
           "utf8",
         ),
       ).toMatchInlineSnapshot(`
@@ -5399,7 +5399,7 @@ describe("Ontology Defining", () => {
 
       expect(
         fs.readFileSync(
-          "src/generated/export_files_are_generated_correctly/build/shared-property-types/mySpt.ts",
+          "src/generated/export_files_are_generated_correctly/codegen/shared-property-types/mySpt.ts",
           "utf8",
         ),
       ).toMatchInlineSnapshot(`

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -5277,9 +5277,10 @@ describe("Ontology Defining", () => {
         ),
       ).toMatchInlineSnapshot(`
         "
-        import { importOntologyEntity } from '@osdk/maker';
+        import { wrapWithProxy, OntologyEntityTypeEnum } from '@osdk/maker';
+        import type { InterfaceType } from '@osdk/maker';
 
-        export const myInterface = {
+        const myInterface_base: InterfaceType = {
           "apiName": "com.my.package.myInterface",
           "displayMetadata": {
             "displayName": "myInterface",
@@ -5309,14 +5310,14 @@ describe("Ontology Defining", () => {
                     "name": "SORTABLE"
                   }
                 ],
-                "__type": "SHARED_PROPERTY_TYPE"
+                "__type": OntologyEntityTypeEnum.SHARED_PROPERTY_TYPE
               }
             }
           },
-          "__type": "INTERFACE_TYPE"
-        } as const;
+          "__type": OntologyEntityTypeEnum.INTERFACE_TYPE
+        } as unknown as InterfaceType;
                 
-        importOntologyEntity(myInterface);
+        export const myInterface = wrapWithProxy(myInterface_base);
                 "
       `);
 
@@ -5327,9 +5328,10 @@ describe("Ontology Defining", () => {
         ),
       ).toMatchInlineSnapshot(`
         "
-        import { importOntologyEntity } from '@osdk/maker';
+        import { wrapWithProxy, OntologyEntityTypeEnum } from '@osdk/maker';
+        import type { ObjectType } from '@osdk/maker';
 
-        export const myObject = {
+        const myObject_base: ObjectType = {
           "titlePropertyApiName": "bar",
           "displayName": "My Object",
           "pluralDisplayName": "myObjects",
@@ -5374,11 +5376,11 @@ describe("Ontology Defining", () => {
                           "name": "SORTABLE"
                         }
                       ],
-                      "__type": "SHARED_PROPERTY_TYPE"
+                      "__type": OntologyEntityTypeEnum.SHARED_PROPERTY_TYPE
                     }
                   }
                 },
-                "__type": "INTERFACE_TYPE"
+                "__type": OntologyEntityTypeEnum.INTERFACE_TYPE
               },
               "propertyMapping": [
                 {
@@ -5388,10 +5390,10 @@ describe("Ontology Defining", () => {
               ]
             }
           ],
-          "__type": "OBJECT_TYPE"
-        } as const;
+          "__type": OntologyEntityTypeEnum.OBJECT_TYPE
+        } as unknown as ObjectType;
                 
-        importOntologyEntity(myObject);
+        export const myObject = wrapWithProxy(myObject_base);
                 "
       `);
 
@@ -5402,9 +5404,10 @@ describe("Ontology Defining", () => {
         ),
       ).toMatchInlineSnapshot(`
         "
-        import { importOntologyEntity } from '@osdk/maker';
+        import { wrapWithProxy, OntologyEntityTypeEnum } from '@osdk/maker';
+        import type { SharedPropertyType } from '@osdk/maker';
 
-        export const mySpt = {
+        const mySpt_base: SharedPropertyType = {
           "apiName": "com.my.package.mySpt",
           "type": "string",
           "nonNameSpacedApiName": "mySpt",
@@ -5419,10 +5422,10 @@ describe("Ontology Defining", () => {
               "name": "SORTABLE"
             }
           ],
-          "__type": "SHARED_PROPERTY_TYPE"
-        } as const;
+          "__type": OntologyEntityTypeEnum.SHARED_PROPERTY_TYPE
+        } as unknown as SharedPropertyType;
                 
-        importOntologyEntity(mySpt);
+        export const mySpt = wrapWithProxy(mySpt_base);
                 "
       `);
     });

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -5317,7 +5317,7 @@ describe("Ontology Defining", () => {
           "__type": OntologyEntityTypeEnum.INTERFACE_TYPE
         } as unknown as InterfaceType;
                 
-        export const myInterface = wrapWithProxy(myInterface_base);
+        export const myInterface: InterfaceType = wrapWithProxy(myInterface_base);
                 "
       `);
 
@@ -5393,7 +5393,7 @@ describe("Ontology Defining", () => {
           "__type": OntologyEntityTypeEnum.OBJECT_TYPE
         } as unknown as ObjectType;
                 
-        export const myObject = wrapWithProxy(myObject_base);
+        export const myObject: ObjectType = wrapWithProxy(myObject_base);
                 "
       `);
 
@@ -5425,7 +5425,7 @@ describe("Ontology Defining", () => {
           "__type": OntologyEntityTypeEnum.SHARED_PROPERTY_TYPE
         } as unknown as SharedPropertyType;
                 
-        export const mySpt = wrapWithProxy(mySpt_base);
+        export const mySpt: SharedPropertyType = wrapWithProxy(mySpt_base);
                 "
       `);
     });

--- a/packages/maker/src/api/wrapWithProxy.ts
+++ b/packages/maker/src/api/wrapWithProxy.ts
@@ -14,22 +14,20 @@
  * limitations under the License.
  */
 
-import { importedTypes } from "./defineOntology.js";
+import { importOntologyEntity } from "./importOntologyEntity.js";
 import type { OntologyEntityBase } from "./types.js";
-import { OntologyEntityTypeEnum } from "./types.js";
 
-export function importOntologyEntity<T extends OntologyEntityBase>(e: T): void {
-  if (e.__type !== OntologyEntityTypeEnum.VALUE_TYPE) {
-    importedTypes[e.__type][e.apiName] = e as any;
-    return;
-  }
-  // value types are a special case
-  if (
-    importedTypes[OntologyEntityTypeEnum.VALUE_TYPE][e.apiName]
-      === undefined
-  ) {
-    importedTypes[OntologyEntityTypeEnum.VALUE_TYPE][e.apiName] = [];
-  }
-  importedTypes[OntologyEntityTypeEnum.VALUE_TYPE][e.apiName]
-    .push(e as any);
+/**
+ * Wraps an OntologyEntityType with a Proxy that calls importOntologyEntity when properties are accessed.
+ *
+ * @param entity - The OntologyEntityType to wrap with a Proxy
+ * @returns A Proxy that imports the entity when properties are accessed
+ */
+export function wrapWithProxy<T extends OntologyEntityBase>(entity: T): T {
+  return new Proxy(entity, {
+    get(target, prop, receiver) {
+      importOntologyEntity(target);
+      return Reflect.get(target, prop, receiver);
+    },
+  });
 }

--- a/packages/maker/src/index.ts
+++ b/packages/maker/src/index.ts
@@ -33,3 +33,13 @@ export { defineOntology } from "./api/defineOntology.js";
 export { defineSharedPropertyType } from "./api/defineSpt.js";
 export { defineValueType } from "./api/defineValueType.js";
 export { importOntologyEntity } from "./api/importOntologyEntity.js";
+export type {
+  ActionType,
+  InterfaceType,
+  LinkType,
+  ObjectType,
+  SharedPropertyType,
+  ValueTypeDefinitionVersion,
+} from "./api/types.js";
+export { OntologyEntityTypeEnum } from "./api/types.js";
+export { wrapWithProxy } from "./api/wrapWithProxy.js";


### PR DESCRIPTION
There were a couple of issues with the codegen 
- We didn't wrap with a proxy, so everything got imported -- this wasn't caught because we weren't actually importing from a package during testing (because we didn't publish a package) 
- Enums are weird -- strings couldn't be cast into the enum for typechecking purposes, so we use the actual enum
- The way conjure defines optionals, e.g. `failureMessage: string | undefined` instead of `failureMessage?: string` meant that something like `JSON.stringify(myValueType) as ValueType` would fail because `failureMessage` didn't exist in the stringified version
- Some other misc things