### PR TITLE
Use absolute paths in OAC test

### DIFF
--- a/.changeset/bright-walls-shout.md
+++ b/.changeset/bright-walls-shout.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker": patch
+---
+
+Use absolute paths in OAC test

--- a/packages/maker/.gitignore
+++ b/packages/maker/.gitignore
@@ -1,1 +1,1 @@
-src/generated
+src/generatedNoCheck

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -5249,7 +5249,7 @@ describe("Ontology Defining", () => {
       const generatedDir = path.join(
         __dirname,
         "..",
-        "generated",
+        "generatedNoCheck",
         "export_files_are_generated_correctly",
       );
       await defineOntology("com.my.package.", () => {

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -5246,12 +5246,12 @@ describe("Ontology Defining", () => {
       `);
     });
     it("Export files are generated correctly", async () => {
-      const generatedDir = path.join(
+      const generatedDir = path.resolve(path.join(
         __dirname,
         "..",
         "generatedNoCheck",
         "export_files_are_generated_correctly",
-      );
+      ));
       await defineOntology("com.my.package.", () => {
         const mySpt = defineSharedPropertyType({
           apiName: "mySpt",
@@ -5435,7 +5435,10 @@ describe("Ontology Defining", () => {
         export const mySpt: SharedPropertyType = wrapWithProxy(mySpt_base);
                 "
       `);
-      fs.rmSync(generatedDir, { recursive: true, force: true });
+      fs.rmSync(path.resolve(path.join(generatedDir, "..")), {
+        recursive: true,
+        force: true,
+      });
     });
   });
 });

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -5435,6 +5435,7 @@ describe("Ontology Defining", () => {
         export const mySpt: SharedPropertyType = wrapWithProxy(mySpt_base);
                 "
       `);
+      fs.rmSync(generatedDir, { recursive: true, force: true });
     });
   });
 });

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -15,6 +15,7 @@
  */
 
 import * as fs from "fs";
+import path from "path";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   defineAction,
@@ -5245,6 +5246,12 @@ describe("Ontology Defining", () => {
       `);
     });
     it("Export files are generated correctly", async () => {
+      const generatedDir = path.join(
+        __dirname,
+        "..",
+        "generated",
+        "export_files_are_generated_correctly",
+      );
       await defineOntology("com.my.package.", () => {
         const mySpt = defineSharedPropertyType({
           apiName: "mySpt",
@@ -5268,11 +5275,11 @@ describe("Ontology Defining", () => {
             propertyMapping: [{ interfaceProperty: "mySpt", mapsTo: "bar" }],
           }],
         });
-      }, "src/generated/export_files_are_generated_correctly");
+      }, generatedDir);
 
       expect(
         fs.readFileSync(
-          "src/generated/export_files_are_generated_correctly/codegen/interface-types/myInterface.ts",
+          path.join(generatedDir, "codegen/interface-types/myInterface.ts"),
           "utf8",
         ),
       ).toMatchInlineSnapshot(`
@@ -5323,7 +5330,7 @@ describe("Ontology Defining", () => {
 
       expect(
         fs.readFileSync(
-          "src/generated/export_files_are_generated_correctly/codegen/object-types/myObject.ts",
+          path.join(generatedDir, "codegen/object-types/myObject.ts"),
           "utf8",
         ),
       ).toMatchInlineSnapshot(`
@@ -5399,7 +5406,7 @@ describe("Ontology Defining", () => {
 
       expect(
         fs.readFileSync(
-          "src/generated/export_files_are_generated_correctly/codegen/shared-property-types/mySpt.ts",
+          path.join(generatedDir, "codegen/shared-property-types/mySpt.ts"),
           "utf8",
         ),
       ).toMatchInlineSnapshot(`


### PR DESCRIPTION
Relative paths might have been messing up local builds in some cases