### PR TITLE
Remove trailing comma from documentation and examples

### DIFF
--- a/.changeset/spicy-humans-joke.md
+++ b/.changeset/spicy-humans-joke.md
@@ -1,0 +1,8 @@
+---
+"@osdk/create-app.template.tutorial-todo-aip-app.beta": patch
+"@osdk/create-app.template.tutorial-todo-app.beta": patch
+"@osdk/create-app.template.react.beta": patch
+"@osdk/react": patch
+---
+
+Remove dangling comma in root render function

--- a/examples/example-advance-to-do-application/README.md
+++ b/examples/example-advance-to-do-application/README.md
@@ -83,7 +83,7 @@ const router = createBrowserRouter(
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <OsdkProvider client={client}>
-      <RouterProvider router={router} />,
+      <RouterProvider router={router} />
     </OsdkProvider>
   </StrictMode>
 );

--- a/examples/example-advance-to-do-application/src/main.tsx
+++ b/examples/example-advance-to-do-application/src/main.tsx
@@ -26,7 +26,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
   
   <StrictMode>
     <OsdkProvider client={client}>
-    <RouterProvider router={router} />,
+    <RouterProvider router={router} />
     </OsdkProvider>
   </StrictMode>
 );

--- a/examples/example-react-sdk-2.x/src/main.tsx
+++ b/examples/example-react-sdk-2.x/src/main.tsx
@@ -7,6 +7,6 @@ import { router } from "./router";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <OsdkProvider client={client}>
-    <RouterProvider router={router} />,
+    <RouterProvider router={router} />
   </OsdkProvider>,
 );

--- a/examples/example-tutorial-todo-aip-app-sdk-2.x/src/main.tsx
+++ b/examples/example-tutorial-todo-aip-app-sdk-2.x/src/main.tsx
@@ -25,7 +25,7 @@ const router = createBrowserRouter(
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <OsdkProvider client={client}>
-      <RouterProvider router={router} />,
+      <RouterProvider router={router} />
     </OsdkProvider>
   </StrictMode>,
 );

--- a/examples/example-tutorial-todo-app-sdk-2.x/src/main.tsx
+++ b/examples/example-tutorial-todo-app-sdk-2.x/src/main.tsx
@@ -25,7 +25,7 @@ const router = createBrowserRouter(
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <OsdkProvider client={client}>
-      <RouterProvider router={router} />,
+      <RouterProvider router={router} />
     </OsdkProvider>
   </StrictMode>,
 );

--- a/packages/create-app.template.react.beta/templates/src/main.tsx
+++ b/packages/create-app.template.react.beta/templates/src/main.tsx
@@ -7,6 +7,6 @@ import { router } from "./router";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <OsdkProvider client={client}>
-    <RouterProvider router={router} />,
+    <RouterProvider router={router} />
   </OsdkProvider>,
 );

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/main.tsx
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/main.tsx
@@ -25,7 +25,7 @@ const router = createBrowserRouter(
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <OsdkProvider client={client}>
-      <RouterProvider router={router} />,
+      <RouterProvider router={router} />
     </OsdkProvider>
   </StrictMode>,
 );

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/src/main.tsx
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/src/main.tsx
@@ -25,7 +25,7 @@ const router = createBrowserRouter(
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <OsdkProvider client={client}>
-      <RouterProvider router={router} />,
+      <RouterProvider router={router} />
     </OsdkProvider>
   </StrictMode>,
 );

--- a/packages/react/docs/getting_started.md
+++ b/packages/react/docs/getting_started.md
@@ -66,7 +66,7 @@ Then wrap your existing root components with `<OsdkProvider2 client={client}>`:
 ```ts
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <OsdkProvider2 client={client}>
-    <RouterProvider router={router} />,
+    <RouterProvider router={router} />
   </OsdkProvider2>,
 );
 ```


### PR DESCRIPTION
While scaffolding a new OSDK application in Foundry, I noticed that a trailing comma is rendered on the initial "Welcome to your Ontology SDK!" page.

I believe that the comma is a result of the root render method having a comma rendered (unintentionally) as JSX while inside the `OsdkProvider2` context providers.

```tsx
<OsdkProvider2 client={client}>
  <RouterProvider router={router} />, // comma here
</OsdkProvider2>
```