### PR TITLE
Make old importing workflow backward compatible

### DIFF
--- a/.changeset/chatty-eagles-argue.md
+++ b/.changeset/chatty-eagles-argue.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker": patch
+---
+
+Support old importing workflow

--- a/packages/maker/src/api/defineImportSpt.ts
+++ b/packages/maker/src/api/defineImportSpt.ts
@@ -15,6 +15,7 @@
  */
 
 import invariant from "tiny-invariant";
+import { importOntologyEntity } from "./importOntologyEntity.js";
 import {
   OntologyEntityTypeEnum,
   type PropertyTypeType,
@@ -32,6 +33,9 @@ export function importSharedPropertyType(
   },
 ): SharedPropertyType {
   const { apiName, packageName, typeHint } = opts;
+  const fullApiName = packageName === undefined
+    ? apiName
+    : `${packageName}.${apiName}`;
   if (packageName !== undefined) {
     invariant(
       !packageName.endsWith("."),
@@ -42,18 +46,13 @@ export function importSharedPropertyType(
       packageName.match("[A-Z]") == null,
       "Package name includes upper case characters",
     );
-
-    return {
-      apiName: packageName + "." + apiName,
-      type: typeHint,
-      nonNameSpacedApiName: apiName,
-      __type: OntologyEntityTypeEnum.SHARED_PROPERTY_TYPE,
-    };
   }
-  return {
-    apiName: apiName,
+  const spt: SharedPropertyType = {
+    apiName: fullApiName,
     type: typeHint,
     nonNameSpacedApiName: apiName,
     __type: OntologyEntityTypeEnum.SHARED_PROPERTY_TYPE,
   };
+  importOntologyEntity(spt);
+  return spt;
 }

--- a/packages/maker/src/api/defineOntology.ts
+++ b/packages/maker/src/api/defineOntology.ts
@@ -208,7 +208,7 @@ export const ${entityFileNameBase}: ${entityTypeName} = wrapWithProxy(${entityFi
 
       for (const entityModuleName of entityModuleNames) {
         topLevelExportStatements.push(
-          `export { ${entityModuleName} } from './codegen/${typeDirName}/${entityModuleName}.js';`,
+          `export { ${entityModuleName} } from "./codegen/${typeDirName}/${entityModuleName}.js";`,
         );
       }
     },


### PR DESCRIPTION
We weren't using the new importing workflow in `importSharedPropertyType`.

Also includes a formatting nit for the codegen