### PR TITLE
Add `UserFacingError` to `@osdk/functions`

### DIFF
--- a/packages/functions/src/errors/UserFacingError.ts
+++ b/packages/functions/src/errors/UserFacingError.ts
@@ -14,23 +14,8 @@
  * limitations under the License.
  */
 
-export type {
-  DateISOString,
-  Double,
-  Float,
-  Integer,
-  Long,
-  TimestampISOString,
-} from "./PrimitiveTypes.js";
-
-export type {
-  Attachment,
-  Range,
-  ThreeDimensionalAggregation,
-  TwoDimensionalAggregation,
-} from "@osdk/client";
-
-export { createEditBatch } from "./edits/createEditBatch.js";
-export type { EditBatch } from "./edits/EditBatch.js";
-export type { Edits } from "./edits/types.js";
-export { UserFacingError } from "./errors/UserFacingError.js";
+export class UserFacingError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}


### PR DESCRIPTION
`UserFacingError` is a special kind of error that we have in TypeScript v1 which contains an error message that is intended to be propagated to end users. Please see the documentation in TSv1 for this error here: https://www.palantir.com/docs/foundry/functions/user-facing-error

We've gotten signal in a couple of threads that people need this in TS v2 as well, so I would like to contribute this to `@osdk/functions`.