### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -151,6 +151,7 @@
     "@osdk-widget.client.unstable-simulatedRelease",
     "@osdk-widget.vite-plugin.unstable-simulatedRelease",
     "chatty-eagles-argue",
-    "spicy-humans-joke"
+    "spicy-humans-joke",
+    "swift-goats-write"
   ]
 }

--- a/packages/maker/CHANGELOG.md
+++ b/packages/maker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/maker
 
+## 0.11.0-beta.3
+
+### Minor Changes
+
+- 3c840d9: Support array type SPTs in legacy OAC importing workflow
+
 ## 0.11.0-beta.2
 
 ### Minor Changes

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker",
-  "version": "0.11.0-beta.2",
+  "version": "0.11.0-beta.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/maker@0.11.0-beta.3

### Minor Changes

-   3c840d9: Support array type SPTs in legacy OAC importing workflow
