### PR TITLE
[typescript-sdk-docs] Export function for adding computed variables to snippets

### DIFF
--- a/.changeset/shaky-pears-cut.md
+++ b/.changeset/shaky-pears-cut.md
@@ -1,0 +1,5 @@
+---
+"@osdk/typescript-sdk-docs": minor
+---
+
+export function for adding computed variables to sdk snippets

--- a/packages/typescript-sdk-docs/src/docs.ts
+++ b/packages/typescript-sdk-docs/src/docs.ts
@@ -29,8 +29,12 @@ import { snippets } from "./generatedNoCheck/docsNoComputedVariables.js";
 
 const indentedNewLine = (spacesCount: number) => `\n${" ".repeat(spacesCount)}`;
 
-export const TYPESCRIPT_OSDK_SNIPPETS: SdkSnippets<typeof OSDK_SNIPPETS_SPEC> =
-  {
+export type SdkSnippetsSpec = SdkSnippets<typeof OSDK_SNIPPETS_SPEC>;
+
+export function addComputedVariablesToSnippets(
+  snippets: SdkSnippetsSpec,
+): SdkSnippetsSpec {
+  return {
     ...snippets,
     computedVariables: {
       functionInputValuesV1: handleFunctionInputValuesV1,
@@ -51,6 +55,10 @@ export const TYPESCRIPT_OSDK_SNIPPETS: SdkSnippets<typeof OSDK_SNIPPETS_SPEC> =
       linkedPrimaryKeyPropertyV2: handleLinkedPrimaryKeyPropertyV2,
     },
   };
+}
+
+export const TYPESCRIPT_OSDK_SNIPPETS: SdkSnippetsSpec =
+  addComputedVariablesToSnippets(snippets);
 
 // SDK major version enum
 enum SdkMajorVersion {

--- a/packages/typescript-sdk-docs/src/index.ts
+++ b/packages/typescript-sdk-docs/src/index.ts
@@ -14,4 +14,8 @@
  * limitations under the License.
  */
 
-export { TYPESCRIPT_OSDK_SNIPPETS } from "./docs.js";
+export {
+  addComputedVariablesToSnippets,
+  TYPESCRIPT_OSDK_SNIPPETS,
+} from "./docs.js";
+export type { SdkSnippetsSpec } from "./docs.js";


### PR DESCRIPTION
As a FLUP from here: https://github.palantir.build/foundry/forge/pull/173158

To be used similar to here, but without having to copy all the helper functions over: https://github.palantir.build/foundry/forge/pull/173166/files

Should have no change to the existing functionality of this package.