### PR TITLE
Fix count aggregation for RDPs

### DIFF
--- a/packages/client/src/derivedProperties/derivedPropertyRuntimeMetadata.ts
+++ b/packages/client/src/derivedProperties/derivedPropertyRuntimeMetadata.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectMetadata } from "@osdk/api";
+import type { DerivedPropertyDefinition } from "@osdk/foundry.ontologies";
+
+export type DerivedPropertyRuntimeMetadata = Record<string, {
+  definition: DerivedPropertyDefinition;
+  propertyType: ObjectMetadata.Property | undefined;
+}>;

--- a/packages/client/src/object/convertWireToOsdkObjects.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.ts
@@ -25,6 +25,7 @@ import type {
   OntologyObjectV2,
 } from "@osdk/foundry.ontologies";
 import invariant from "tiny-invariant";
+import type { DerivedPropertyRuntimeMetadata } from "../derivedProperties/derivedPropertyRuntimeMetadata.js";
 import type { MinimalClient } from "../MinimalClientContext.js";
 import {
   type FetchedObjectTypeDefinition,
@@ -55,10 +56,7 @@ export async function convertWireToOsdkObjects(
   objects: OntologyObjectV2[],
   interfaceApiName: string | undefined,
   forceRemoveRid: boolean = false,
-  derivedPropertyTypesByName: Record<
-    string,
-    ObjectMetadata.Property
-  >,
+  derivedPropertyTypesByName: DerivedPropertyRuntimeMetadata,
   selectedProps?: ReadonlyArray<string>,
   strictNonNull: NullabilityAdherence = false,
 ): Promise<Array<ObjectHolder | InterfaceHolder>> {
@@ -129,10 +127,7 @@ export async function convertWireToOsdkObjects2(
   client: MinimalClient,
   objects: OntologyObjectV2[],
   interfaceApiName: string,
-  derivedPropertyTypeByName: Record<
-    string,
-    ObjectMetadata.Property
-  >,
+  derivedPropertyTypeByName: DerivedPropertyRuntimeMetadata,
   forceRemoveRid?: boolean,
   selectedProps?: ReadonlyArray<string>,
   strictNonNull?: NullabilityAdherence,
@@ -145,10 +140,7 @@ export async function convertWireToOsdkObjects2(
   client: MinimalClient,
   objects: OntologyObjectV2[],
   interfaceApiName: undefined,
-  derivedPropertyTypeByName: Record<
-    string,
-    ObjectMetadata.Property
-  >,
+  derivedPropertyTypeByName: DerivedPropertyRuntimeMetadata,
   forceRemoveRid?: boolean,
   selectedProps?: ReadonlyArray<string>,
   strictNonNull?: NullabilityAdherence,
@@ -161,10 +153,7 @@ export async function convertWireToOsdkObjects2(
   client: MinimalClient,
   objects: OntologyObjectV2[],
   interfaceApiName: string | undefined,
-  derivedPropertyTypeByName: Record<
-    string,
-    ObjectMetadata.Property
-  >,
+  derivedPropertyTypeByName: DerivedPropertyRuntimeMetadata,
   forceRemoveRid?: boolean,
   selectedProps?: ReadonlyArray<string>,
   strictNonNull?: NullabilityAdherence,
@@ -180,10 +169,7 @@ export async function convertWireToOsdkObjects2(
   client: MinimalClient,
   objects: OntologyObjectV2[],
   interfaceApiName: string | undefined,
-  derivedPropertyTypeByName: Record<
-    string,
-    ObjectMetadata.Property
-  >,
+  derivedPropertyTypeByName: DerivedPropertyRuntimeMetadata,
   forceRemoveRid: boolean = false,
   selectedProps?: ReadonlyArray<string>,
   strictNonNull: NullabilityAdherence = false,

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import type { ObjectMetadata } from "@osdk/api";
 import type { Attachment, ReferenceValue } from "@osdk/foundry.ontologies";
 import invariant from "tiny-invariant";
 import { GeotimeSeriesPropertyImpl } from "../../createGeotimeSeriesProperty.js";
 import { MediaReferencePropertyImpl } from "../../createMediaReferenceProperty.js";
 import { TimeSeriesPropertyImpl } from "../../createTimeseriesProperty.js";
+import type { DerivedPropertyRuntimeMetadata } from "../../derivedProperties/derivedPropertyRuntimeMetadata.js";
 import type { MinimalClient } from "../../MinimalClientContext.js";
 import type { FetchedObjectTypeDefinition } from "../../ontology/OntologyProvider.js";
 import { hydrateAttachmentFromRidInternal } from "../../public-utils/hydrateAttachmentFromRid.js";
@@ -110,7 +110,7 @@ export function createOsdkObject(
   client: MinimalClient,
   objectDef: FetchedObjectTypeDefinition,
   simpleOsdkProperties: SimpleOsdkProperties,
-  derivedPropertyTypeByName: Record<string, ObjectMetadata.Property> = {},
+  derivedPropertyTypeByName: DerivedPropertyRuntimeMetadata = {},
 ): ObjectHolder {
   // updates the object's "hidden class/map".
   const rawObj = simpleOsdkProperties as ObjectHolder;
@@ -142,11 +142,31 @@ export function createOsdkObject(
       );
     } else if (
       propKey in derivedPropertyTypeByName
-      && typeof (derivedPropertyTypeByName[propKey].type) === "string"
-      && specialPropertyTypes.has(derivedPropertyTypeByName[propKey].type)
+      && derivedPropertyTypeByName[propKey].definition.type === "selection"
+      && derivedPropertyTypeByName[propKey].definition.operation.type
+        === "count"
+    ) {
+      const num = Number(rawObj[propKey]);
+      invariant(
+        Number.isSafeInteger(num),
+        "Count aggregation for derived property " + propKey
+          + " returned a value larger than safe integer.",
+      );
+      rawObj[propKey] = num;
+    } // Some properties need to be deserialized specially when constructed with RDP
+    else if (
+      propKey in derivedPropertyTypeByName
+      && derivedPropertyTypeByName[propKey].propertyType != null
+      && typeof (derivedPropertyTypeByName[propKey].propertyType.type)
+        === "string"
+      && specialPropertyTypes.has(
+        derivedPropertyTypeByName[propKey].propertyType.type,
+      )
     ) {
       const rawValue = rawObj[propKey as any];
-      if (derivedPropertyTypeByName[propKey].type === "attachment") {
+      if (
+        derivedPropertyTypeByName[propKey].propertyType?.type === "attachment"
+      ) {
         if (Array.isArray(rawValue)) {
           rawObj[propKey] = rawValue.map(a =>
             hydrateAttachmentFromRidInternal(client, a.rid)

--- a/packages/client/src/objectSet/ObjectSet.test.ts
+++ b/packages/client/src/objectSet/ObjectSet.test.ts
@@ -915,6 +915,15 @@ describe("ObjectSet", () => {
       `,
       );
     });
+    it("correctly deserializes count", async () => {
+      const objectWithRdp = await client(Employee).withProperties({
+        "derivedPropertyName": (base) =>
+          base.pivotTo("lead").aggregate("$count"),
+      }).fetchOne(stubData.employee1.employeeId);
+
+      expectTypeOf(objectWithRdp.derivedPropertyName).toEqualTypeOf<number>();
+      expect(objectWithRdp.derivedPropertyName).toEqual(1);
+    });
   });
 
   // Can't run these tests because we can't load by primary key!

--- a/packages/client/src/util/extractRdpDefinition.test.ts
+++ b/packages/client/src/util/extractRdpDefinition.test.ts
@@ -87,7 +87,23 @@ describe("extractRdpDefinition", () => {
       `
       {
         "myRdp": {
-          "type": "attachment",
+          "definition": {
+            "objectSet": {
+              "link": "testLink2",
+              "objectSet": {
+                "type": "methodInput",
+              },
+              "type": "searchAround",
+            },
+            "operation": {
+              "selectedPropertyApiName": "testProperty",
+              "type": "get",
+            },
+            "type": "selection",
+          },
+          "propertyType": {
+            "type": "attachment",
+          },
         },
       }
     `,
@@ -136,13 +152,63 @@ describe("extractRdpDefinition", () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "myRdp": {
-          "type": "attachment",
+          "definition": {
+            "objectSet": {
+              "link": "testLink2",
+              "objectSet": {
+                "type": "methodInput",
+              },
+              "type": "searchAround",
+            },
+            "operation": {
+              "selectedPropertyApiName": "testProperty",
+              "type": "get",
+            },
+            "type": "selection",
+          },
+          "propertyType": {
+            "type": "attachment",
+          },
         },
         "rdp1": {
-          "type": "attachment",
+          "definition": {
+            "objectSet": {
+              "link": "testLink2",
+              "objectSet": {
+                "type": "methodInput",
+              },
+              "type": "searchAround",
+            },
+            "operation": {
+              "limit": 100,
+              "selectedPropertyApiName": "testProperty",
+              "type": "collectList",
+            },
+            "type": "selection",
+          },
+          "propertyType": {
+            "type": "attachment",
+          },
         },
         "rdp2": {
-          "type": "attachment",
+          "definition": {
+            "objectSet": {
+              "link": "testLink2",
+              "objectSet": {
+                "type": "methodInput",
+              },
+              "type": "searchAround",
+            },
+            "operation": {
+              "limit": 100,
+              "selectedPropertyApiName": "testProperty",
+              "type": "collectSet",
+            },
+            "type": "selection",
+          },
+          "propertyType": {
+            "type": "attachment",
+          },
         },
       }
     `);
@@ -190,7 +256,23 @@ describe("extractRdpDefinition", () => {
       `
       {
         "myRdp": {
-          "type": "attachment",
+          "definition": {
+            "objectSet": {
+              "link": "testLink2",
+              "objectSet": {
+                "type": "methodInput",
+              },
+              "type": "searchAround",
+            },
+            "operation": {
+              "selectedPropertyApiName": "testProperty",
+              "type": "get",
+            },
+            "type": "selection",
+          },
+          "propertyType": {
+            "type": "attachment",
+          },
         },
       }
     `,

--- a/packages/client/src/util/extractRdpDefinition.ts
+++ b/packages/client/src/util/extractRdpDefinition.ts
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import type { ObjectMetadata } from "@osdk/api";
 import type { ObjectSet } from "@osdk/foundry.ontologies";
 import invariant from "tiny-invariant";
+import type { DerivedPropertyRuntimeMetadata } from "../derivedProperties/derivedPropertyRuntimeMetadata.js";
 import type { MinimalClient } from "../MinimalClientContext.js";
 
 export async function extractRdpDefinition(
   clientCtx: MinimalClient,
   objectSet: ObjectSet,
 ): Promise<
-  Record<string, ObjectMetadata.Property>
+  DerivedPropertyRuntimeMetadata
 > {
   return (await extractRdpDefinitionInternal(
     clientCtx,
@@ -41,7 +41,7 @@ async function extractRdpDefinitionInternal(
   methodInputObjectType: string | undefined,
 ): Promise<
   {
-    definitions: Record<string, ObjectMetadata.Property>;
+    definitions: DerivedPropertyRuntimeMetadata;
     childObjectType?: string;
   }
 > {
@@ -83,6 +83,10 @@ async function extractRdpDefinitionInternal(
         const [name, definition] of Object.entries(objectSet.derivedProperties)
       ) {
         if (definition.type !== "selection") {
+          definitions[name] = {
+            propertyType: undefined,
+            definition,
+          };
           continue;
         }
 
@@ -107,11 +111,18 @@ async function extractRdpDefinitionInternal(
               operationLevelObjectType,
             );
 
-            definitions[name] =
-              objDef.properties[definition.operation.selectedPropertyApiName];
+            definitions[name] = {
+              propertyType:
+                objDef.properties[definition.operation.selectedPropertyApiName],
+              definition,
+            };
+            break;
 
           default:
-            continue;
+            definitions[name] = {
+              propertyType: undefined,
+              definition,
+            };
         }
       }
       return { definitions, childObjectType };

--- a/packages/shared.test/src/FauxFoundry/getObjectsFromSet.ts
+++ b/packages/shared.test/src/FauxFoundry/getObjectsFromSet.ts
@@ -251,6 +251,10 @@ function getDerivedPropertySelection(
         new Set(objs.map(o => o[operation.selectedPropertyApiName])),
       );
     }
+    case "count": {
+      const objs = getObjectsFromSet(ds, objectSet, obj);
+      return objs.length.toString();
+    }
   }
 }
 


### PR DESCRIPTION
Count aggregations return strings from the wire instead of numbers, We want to keep typing them as numbers, so we check the definition and convert the string to a number at runtime.