### PR TITLE
[widgets] Use window.parent instead of window.top

### DIFF
--- a/packages/widget.client.unstable/src/client.ts
+++ b/packages/widget.client.unstable/src/client.ts
@@ -70,8 +70,8 @@ export interface FoundryWidgetClient<C extends WidgetConfig<C["parameters"]>> {
 export function createFoundryWidgetClient<
   C extends WidgetConfig<C["parameters"]>,
 >(): FoundryWidgetClient<C> {
-  invariant(window.top, "[FoundryWidgetClient] Must be run in an iframe");
-  const parentWindow = window.top;
+  invariant(window.parent, "[FoundryWidgetClient] Must be run in an iframe");
+  const parentWindow = window.parent;
   const metaTag = document.querySelector(
     `meta[name="${META_TAG_HOST_ORIGIN}"]`,
   );


### PR DESCRIPTION
`window.top` isn't actually the desired window for the widgets workflow (e.g. if we iframe a workshop containing a widget into some other page, we don't want the other page to start receiving the messages!)