### PR TITLE
Add output dir CLI flag

### DIFF
--- a/.changeset/funny-emus-attend.md
+++ b/.changeset/funny-emus-attend.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker": patch
+---
+
+Add output dir CLI flag

--- a/packages/maker/src/api/defineOntology.ts
+++ b/packages/maker/src/api/defineOntology.ts
@@ -113,7 +113,7 @@ export function updateOntology<
 export async function defineOntology(
   ns: string,
   body: () => void | Promise<void>,
-  outputDir: string,
+  outputDir: string | undefined,
 ): Promise<OntologyAndValueTypeIrs> {
   namespace = ns;
   ontologyDefinition = {
@@ -143,7 +143,9 @@ export async function defineOntology(
     throw e;
   }
 
-  writeStaticObjects(outputDir);
+  if (outputDir) {
+    writeStaticObjects(outputDir);
+  }
   return {
     ontology: convertToWireOntologyIr(ontologyDefinition),
     valueType: convertOntologyToValueTypeIr(ontologyDefinition),

--- a/packages/maker/src/cli/main.ts
+++ b/packages/maker/src/cli/main.ts
@@ -93,12 +93,10 @@ export default async function main(
   }
   consola.info(`Loading ontology from ${commandLineOpts.input}`);
 
-  const outputDirForOntology = commandLineOpts.outputDir;
-
   const ontology = await loadOntology(
     commandLineOpts.input,
     apiNamespace,
-    outputDirForOntology,
+    commandLineOpts.outputDir,
   );
 
   consola.info(`Saving ontology to ${commandLineOpts.output}`);

--- a/packages/maker/src/cli/main.ts
+++ b/packages/maker/src/cli/main.ts
@@ -95,16 +95,6 @@ export default async function main(
 
   const outputDirForOntology = commandLineOpts.outputDir;
 
-  if (outputDirForOntology) {
-    consola.info(
-      `Using ontology processing directory: ${outputDirForOntology}`,
-    );
-  } else {
-    consola.info(
-      `No output directory specified for ontology processing. Static objects will not be written.`,
-    );
-  }
-
   const ontology = await loadOntology(
     commandLineOpts.input,
     apiNamespace,

--- a/packages/maker/src/cli/main.ts
+++ b/packages/maker/src/cli/main.ts
@@ -68,8 +68,7 @@ export default async function main(
       },
       outputDir: {
         alias: "d",
-        describe:
-          "Directory for ontology processing artifacts. If not specified, it's derived from the input path.",
+        describe: "Directory for generated ontology entities",
         type: "string",
         coerce: path.resolve,
       },


### PR DESCRIPTION
Provide the `-d` flag with a path to write importable objects to that directory. If not provided, no objects will be written.