### PR TITLE
Propagate interface extension to static objects

### DIFF
--- a/.changeset/mean-hairs-smell.md
+++ b/.changeset/mean-hairs-smell.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker": patch
+---
+
+Propagate interface extension to static objects

--- a/packages/maker/src/api/defineInterface.ts
+++ b/packages/maker/src/api/defineInterface.ts
@@ -52,7 +52,7 @@ export type InterfaceTypeDefinition = {
     string,
     PropertyBase | PropertyWithOptional
   >;
-  extends?: InterfaceType | InterfaceType[] | string | string[];
+  extends?: InterfaceType | InterfaceType[];
 };
 
 export function defineInterface(
@@ -93,23 +93,11 @@ export function defineInterface(
     ),
   );
 
-  let extendsInterfaces: string[] = [];
-  if (interfaceDef.extends) {
-    if (typeof interfaceDef.extends === "string") {
-      extendsInterfaces = [interfaceDef.extends];
-    } else if (
-      Array.isArray(interfaceDef.extends)
-      && interfaceDef.extends.every(item => typeof item === "string")
-    ) {
-      extendsInterfaces = interfaceDef.extends;
-    } else if ((interfaceDef.extends as InterfaceType).apiName !== undefined) {
-      extendsInterfaces = [(interfaceDef.extends as InterfaceType).apiName];
-    } else {
-      extendsInterfaces = (interfaceDef.extends as InterfaceType[]).map(item =>
-        item.apiName
-      );
-    }
-  }
+  const extendsInterfaces = interfaceDef.extends
+    ? (Array.isArray(interfaceDef.extends)
+      ? interfaceDef.extends
+      : [interfaceDef.extends])
+    : [];
 
   const status: InterfaceTypeStatus = mapSimplifiedStatusToInterfaceTypeStatus(
     interfaceDef.status ?? { type: "active" },
@@ -137,7 +125,7 @@ export function defineInterface(
         }
         : undefined,
     },
-    extendsInterfaces: extendsInterfaces,
+    extendsInterfaces,
     links: [],
     status,
     propertiesV2: properties,

--- a/packages/maker/src/api/defineObject.ts
+++ b/packages/maker/src/api/defineObject.ts
@@ -154,12 +154,8 @@ export function defineObject(
     )
       .map<ValidationResult>(validateProperty);
     const extendsValidations = interfaceImpl.implements.extendsInterfaces
-      .flatMap(interfaceApiName =>
-        Object.entries(
-          ontologyDefinition[OntologyEntityTypeEnum.INTERFACE_TYPE][
-            interfaceApiName
-          ].propertiesV2 as Record<string, InterfacePropertyType>,
-        ).map(validateProperty)
+      .flatMap(interfaceType =>
+        Object.entries(interfaceType.propertiesV2).map(validateProperty)
       );
 
     const allFailedValidations = baseValidations.concat(

--- a/packages/maker/src/api/defineOntology.ts
+++ b/packages/maker/src/api/defineOntology.ts
@@ -763,6 +763,7 @@ function convertInterface(
           sharedPropertyType: convertSpt(spt.sharedPropertyType),
         }]),
     ),
+    extendsInterfaces: interfaceType.extendsInterfaces.map(i => i.apiName),
     // these are omitted from our internal types but we need to re-add them for the final json
     allExtendsInterfaces: [],
     allLinks: [],

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -782,7 +782,7 @@ describe("Ontology Defining", () => {
         properties: {
           property2: "string",
         },
-        extends: ["parentInterface"],
+        extends: parentInterface,
       });
 
       expect(dumpOntologyFullMetadata().blockData).toMatchInlineSnapshot(`
@@ -807,7 +807,7 @@ describe("Ontology Defining", () => {
                   "icon": undefined,
                 },
                 "extendsInterfaces": [
-                  "parentInterface",
+                  "com.palantir.parentInterface",
                 ],
                 "links": [],
                 "properties": [],
@@ -6900,6 +6900,119 @@ describe("Ontology Defining", () => {
         recursive: true,
         force: true,
       });
+    });
+    it("Extended interfaces are propagated to the static objects", async () => {
+      const generatedDir = path.resolve(path.join(
+        __dirname,
+        "..",
+        "generatedNoCheck",
+        "extended_interfaces_are_propagated_to_the_static_objects",
+      ));
+      await defineOntology("com.palantir.", () => {
+        const parentInterface = defineInterface({
+          apiName: "parentInterface",
+          properties: {
+            property1: "string",
+          },
+        });
+        const childInterface = defineInterface({
+          apiName: "childInterface",
+          properties: {
+            property2: "string",
+          },
+          extends: [parentInterface],
+        });
+      }, generatedDir);
+
+      expect(
+        fs.readFileSync(
+          path.join(generatedDir, "codegen/interface-types/childInterface.ts"),
+          "utf8",
+        ),
+      ).toMatchInlineSnapshot(`
+        "
+        import { wrapWithProxy, OntologyEntityTypeEnum } from '@osdk/maker';
+        import type { InterfaceType } from '@osdk/maker';
+
+        const childInterface_base: InterfaceType = {
+          "apiName": "com.palantir.childInterface",
+          "displayMetadata": {
+            "displayName": "childInterface",
+            "description": "childInterface"
+          },
+          "extendsInterfaces": [
+            {
+              "apiName": "com.palantir.parentInterface",
+              "displayMetadata": {
+                "displayName": "parentInterface",
+                "description": "parentInterface"
+              },
+              "extendsInterfaces": [],
+              "links": [],
+              "status": {
+                "type": "active",
+                "active": {}
+              },
+              "propertiesV2": {
+                "property1": {
+                  "required": true,
+                  "sharedPropertyType": {
+                    "apiName": "com.palantir.property1",
+                    "displayName": "property1",
+                    "type": "string",
+                    "array": false,
+                    "nonNameSpacedApiName": "property1",
+                    "typeClasses": [
+                      {
+                        "kind": "render_hint",
+                        "name": "SELECTABLE"
+                      },
+                      {
+                        "kind": "render_hint",
+                        "name": "SORTABLE"
+                      }
+                    ],
+                    "__type": OntologyEntityTypeEnum.SHARED_PROPERTY_TYPE
+                  }
+                }
+              },
+              "__type": OntologyEntityTypeEnum.INTERFACE_TYPE
+            }
+          ],
+          "links": [],
+          "status": {
+            "type": "active",
+            "active": {}
+          },
+          "propertiesV2": {
+            "property2": {
+              "required": true,
+              "sharedPropertyType": {
+                "apiName": "com.palantir.property2",
+                "displayName": "property2",
+                "type": "string",
+                "array": false,
+                "nonNameSpacedApiName": "property2",
+                "typeClasses": [
+                  {
+                    "kind": "render_hint",
+                    "name": "SELECTABLE"
+                  },
+                  {
+                    "kind": "render_hint",
+                    "name": "SORTABLE"
+                  }
+                ],
+                "__type": OntologyEntityTypeEnum.SHARED_PROPERTY_TYPE
+              }
+            }
+          },
+          "__type": OntologyEntityTypeEnum.INTERFACE_TYPE
+        } as unknown as InterfaceType;
+                
+        export const childInterface: InterfaceType = wrapWithProxy(childInterface_base);
+                "
+      `);
     });
   });
 });

--- a/packages/maker/src/api/types.ts
+++ b/packages/maker/src/api/types.ts
@@ -319,12 +319,14 @@ export interface InterfaceType extends
     // these things don't need to exist as the system works fine without them (I'm told)
     | "allProperties"
     | "allLinks"
+    | "extendsInterfaces"
     | "allExtendsInterfaces"
     | "propertiesV2"
     | "allPropertiesV2"
   >
 {
   propertiesV2: Record<string, InterfacePropertyType>;
+  extendsInterfaces: Array<InterfaceType>;
   status: InterfaceTypeStatus;
   __type: OntologyEntityTypeEnum.INTERFACE_TYPE;
 }


### PR DESCRIPTION
Before, we'd just carry the api names of the extended interfaces around, but that would break when someone imported a child interface and tried to make an object type that implements it, since the extendee doesn't live in the current global state, so we can't inspect any data about it. 

Now, we just carry the InterfaceTypes all the way through. This does mean that a long chain of extended interfaces means a big object because this will be recursive. Maybe in the future, we have the static objects import the interfaces they extend instead of copy, but that could lead to a long chain of dependencies, which may not be better.