### PR TITLE
CLI widgetset stable command

### DIFF
--- a/.changeset/afraid-zebras-send.md
+++ b/.changeset/afraid-zebras-send.md
@@ -1,0 +1,5 @@
+---
+"@osdk/cli": patch
+---
+
+Register "widgetset" CLI command out of unstable

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -45,6 +45,7 @@ export async function cli(args: string[] = process.argv): Promise<
           return argv
             .command(typescript)
             .command(auth)
+            // TODO: Remove copy of widgetset command from unstable once we've moved over templates
             .command(widgetSet)
             .demandCommand();
         },


### PR DESCRIPTION
Register the CLI `widgetset` command outside of `unstable`. The existing command under `unstable` remains until we move over the templates for some extra grace period. At some point dropping the `unstable` command will be a break for existing projects relying on using `@latest` or `@beta` in CI but given the limited places we'll work on migrating and the `unstable` prefix making a break is expected