### PR TITLE
Start tracking and injecting OAC dependencies

### DIFF
--- a/.changeset/thick-ways-smell.md
+++ b/.changeset/thick-ways-smell.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker": patch
+---
+
+Start tracking and injecting OAC dependencies

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -43,6 +43,7 @@
     "@osdk/api": "workspace:~",
     "consola": "^3.4.2",
     "jiti": "^2.0.0",
+    "semver-ts": "^1.0.0",
     "tiny-invariant": "^1.3.3",
     "ts-node": "^10.9.2",
     "yargs": "^17.7.2"

--- a/packages/maker/src/api/addDependency.ts
+++ b/packages/maker/src/api/addDependency.ts
@@ -17,7 +17,7 @@
 import { lt } from "semver-ts";
 import { dependencies } from "./defineOntology.js";
 
-export function importDependency(
+export function addDependency(
   namespace: string,
   version: string,
 ): void {

--- a/packages/maker/src/api/defineOntology.ts
+++ b/packages/maker/src/api/defineOntology.ts
@@ -82,6 +82,10 @@ export let ontologyDefinition: OntologyDefinition;
 /** @internal */
 export let importedTypes: OntologyDefinition;
 
+// namespace -> version
+/** @internal */
+export let dependencies: Record<string, string>;
+
 /** @internal */
 export let namespace: string;
 
@@ -114,8 +118,10 @@ export async function defineOntology(
   ns: string,
   body: () => void | Promise<void>,
   outputDir: string | undefined,
+  dependencyFile?: string,
 ): Promise<OntologyAndValueTypeIrs> {
   namespace = ns;
+  dependencies = {};
   ontologyDefinition = {
     OBJECT_TYPE: {},
     ACTION_TYPE: {},
@@ -145,6 +151,9 @@ export async function defineOntology(
 
   if (outputDir) {
     writeStaticObjects(outputDir);
+  }
+  if (dependencyFile) {
+    writeDependencyFile(dependencyFile);
   }
   return {
     ontology: convertToWireOntologyIr(ontologyDefinition),
@@ -224,7 +233,8 @@ export const ${entityFileNameBase}: ${entityTypeName} = wrapWithProxy(${entityFi
   );
 
   if (topLevelExportStatements.length > 0) {
-    const mainIndexContent = topLevelExportStatements.join("\n") + "\n";
+    const mainIndexContent = dependencyInjectionString()
+      + topLevelExportStatements.join("\n") + "\n";
     const mainIndexFilePath = path.join(outputDir, "index.ts");
     fs.writeFileSync(mainIndexFilePath, mainIndexContent, { flag: "w" });
   }
@@ -1207,4 +1217,20 @@ function getEntityTypeName(type: string): string {
     [OntologyEntityTypeEnum.ACTION_TYPE]: "ActionType",
     [OntologyEntityTypeEnum.VALUE_TYPE]: "ValueTypeDefinitionVersion",
   }[type]!;
+}
+
+function writeDependencyFile(dependencyFile: string): void {
+  fs.writeFileSync(dependencyFile, JSON.stringify(dependencies, null, 2));
+}
+
+function dependencyInjectionString(): string {
+  const namespaceNoDot: string = namespace.endsWith(".")
+    ? namespace.slice(0, -1)
+    : namespace;
+  const packageJson = JSON.parse(
+    fs.readFileSync("package.json", "utf-8"),
+  );
+  const currentPackageVersion: string = packageJson.version ?? "";
+
+  return `import { importDependency } from '@osdk/maker';\n\nimportDependency("${namespaceNoDot}", "${currentPackageVersion}");\n`;
 }

--- a/packages/maker/src/api/defineOntology.ts
+++ b/packages/maker/src/api/defineOntology.ts
@@ -1232,5 +1232,5 @@ function dependencyInjectionString(): string {
   );
   const currentPackageVersion: string = packageJson.version ?? "";
 
-  return `import { importDependency } from '@osdk/maker';\n\nimportDependency("${namespaceNoDot}", "${currentPackageVersion}");\n`;
+  return `import { addDependency } from '@osdk/maker';\n\naddDependency("${namespaceNoDot}", "${currentPackageVersion}");\n`;
 }

--- a/packages/maker/src/api/importDependency.ts
+++ b/packages/maker/src/api/importDependency.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { lt } from "semver-ts";
+import { dependencies } from "./defineOntology.js";
+
+export function importDependency(
+  namespace: string,
+  version: string,
+): void {
+  if (
+    version !== ""
+    && (dependencies[namespace] === undefined
+      || lt(dependencies[namespace], version))
+  ) {
+    dependencies[namespace] = version;
+  }
+}

--- a/packages/maker/src/cli/main.ts
+++ b/packages/maker/src/cli/main.ts
@@ -34,6 +34,7 @@ export default async function main(
     snapshotDir: string;
     valueTypesOutput: string;
     outputDir?: string;
+    dependencies?: string;
   } = await yargs(hideBin(args))
     .version(process.env.PACKAGE_VERSION ?? "")
     .wrap(Math.min(150, yargs().terminalWidth()))
@@ -78,6 +79,12 @@ export default async function main(
         default: "value-types.json",
         coerce: path.resolve,
       },
+      dependencies: {
+        describe: "File to write dependencies to",
+        type: "string",
+        default: "dependencies.json",
+        coerce: path.resolve,
+      },
     })
     .parseAsync();
   let apiNamespace = "";
@@ -97,6 +104,7 @@ export default async function main(
     commandLineOpts.input,
     apiNamespace,
     commandLineOpts.outputDir,
+    commandLineOpts.dependencies,
   );
 
   consola.info(`Saving ontology to ${commandLineOpts.output}`);
@@ -117,11 +125,13 @@ async function loadOntology(
   input: string,
   apiNamespace: string,
   outputDir: string | undefined,
+  dependencyFile: string | undefined,
 ) {
   const q = await defineOntology(
     apiNamespace,
     async () => await import(input),
     outputDir,
+    dependencyFile,
   );
   return q;
 }

--- a/packages/maker/src/cli/main.ts
+++ b/packages/maker/src/cli/main.ts
@@ -82,7 +82,6 @@ export default async function main(
       dependencies: {
         describe: "File to write dependencies to",
         type: "string",
-        default: "dependencies.json",
         coerce: path.resolve,
       },
     })

--- a/packages/maker/src/index.ts
+++ b/packages/maker/src/index.ts
@@ -16,6 +16,7 @@
 
 export { default as default } from "./cli/main.js";
 
+export { addDependency as importDependency } from "./api/addDependency.js";
 export {
   defineAction,
   defineCreateInterfaceObjectAction,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,252 +276,6 @@ importers:
         specifier: ^6.3.5
         version: 6.3.5(@types/node@22.13.0)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0)
 
-<<<<<<< HEAD
-||||||| parent of f01518eb6 (v0)
-  examples/example-advance-to-do-application:
-    dependencies:
-      '@osdk/api':
-        specifier: ^2.2.0-beta.18
-        version: 2.2.0-beta.18
-      '@osdk/client':
-        specifier: ^2.2.0-beta.18
-        version: 2.2.0-beta.18
-      '@osdk/foundry':
-        specifier: ^2.20.0
-        version: 2.20.0
-      '@osdk/foundry.admin':
-        specifier: ^2.20.0
-        version: 2.20.0
-      '@osdk/oauth':
-        specifier: ^1.1.1
-        version: 1.1.1
-      '@osdk/react':
-        specifier: ^0.3.0
-        version: 0.3.0(@osdk/api@2.2.0-beta.18)(@osdk/client@2.2.0-beta.18)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@tutorial-advance-to-do-application/sdk':
-        specifier: file:./tutorial-advance-to-do-application-sdk-0.9.0.tgz
-        version: file:examples/example-advance-to-do-application/tutorial-advance-to-do-application-sdk-0.9.0.tgz(@osdk/client@2.2.0-beta.18)
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
-      react:
-        specifier: ^18
-        version: 18.3.1
-      react-dom:
-        specifier: ^18
-        version: 18.3.1(react@18.3.1)
-      react-router-dom:
-        specifier: ^6.23.1
-        version: 6.23.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-tooltip:
-        specifier: ^5.28.0
-        version: 5.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      swr:
-        specifier: ^2.2.5
-        version: 2.2.5(react@18.3.1)
-    devDependencies:
-      '@eslint/compat':
-        specifier: ^1.2.1
-        version: 1.2.1(eslint@9.21.0(jiti@2.4.2))
-      '@eslint/js':
-        specifier: ^9.13.0
-        version: 9.21.0
-      '@types/eslint-plugin-jsx-a11y':
-        specifier: ^6.9.0
-        version: 6.9.0
-      '@types/lodash':
-        specifier: ^4.17.15
-        version: 4.17.16
-      '@types/node':
-        specifier: ^18.0.0
-        version: 18.19.97
-      '@types/react':
-        specifier: ^18
-        version: 18.3.12
-      '@types/react-dom':
-        specifier: ^18
-        version: 18.3.1
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^8.31.0
-        version: 8.32.1(@typescript-eslint/parser@8.32.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4))(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4)
-      '@typescript-eslint/parser':
-        specifier: ^8.31.0
-        version: 8.32.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4)
-      '@vitejs/plugin-react':
-        specifier: ^4.3.4
-        version: 4.4.1(vite@6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0))
-      eslint:
-        specifier: ^9.21.0
-        version: 9.21.0(jiti@2.4.2)
-      eslint-formatter-autolinkable-stylish:
-        specifier: ^1.4.0
-        version: 1.4.0(eslint@9.21.0(jiti@2.4.2))
-      eslint-import-resolver-typescript:
-        specifier: ^3.8.3
-        version: 3.8.3(eslint-plugin-import@2.31.0)(eslint@9.21.0(jiti@2.4.2))
-      eslint-plugin-header:
-        specifier: ^3.1.1
-        version: 3.1.1(eslint@9.21.0(jiti@2.4.2))
-      eslint-plugin-import:
-        specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4))(eslint-import-resolver-typescript@3.8.3(eslint-plugin-import@2.31.0)(eslint@9.21.0(jiti@2.4.2)))(eslint@9.21.0(jiti@2.4.2))
-      eslint-plugin-jsx-a11y:
-        specifier: ^6.10.1
-        version: 6.10.1(eslint@9.21.0(jiti@2.4.2))
-      eslint-plugin-prettier:
-        specifier: ^5.2.1
-        version: 5.2.1(@types/eslint@9.6.1)(eslint@9.21.0(jiti@2.4.2))(prettier@3.2.5)
-      eslint-plugin-react:
-        specifier: ^7.37.5
-        version: 7.37.5(eslint@9.21.0(jiti@2.4.2))
-      eslint-plugin-react-hooks:
-        specifier: ^5.0.0
-        version: 5.0.0(eslint@9.21.0(jiti@2.4.2))
-      eslint-plugin-react-refresh:
-        specifier: ^0.4.14
-        version: 0.4.14(eslint@9.21.0(jiti@2.4.2))
-      eslint-plugin-unused-imports:
-        specifier: ^4.1.4
-        version: 4.1.4(@typescript-eslint/eslint-plugin@8.32.1(@typescript-eslint/parser@8.32.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4))(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4))(eslint@9.21.0(jiti@2.4.2))
-      globals:
-        specifier: ^15.11.0
-        version: 15.15.0
-      typescript:
-        specifier: ~5.5.4
-        version: 5.5.4
-      typescript-eslint:
-        specifier: ^8.31.0
-        version: 8.32.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4)
-      vite:
-        specifier: ^6.3.5
-        version: 6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0)
-      vitest:
-        specifier: ^3.0.5
-        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
-
-=======
-  examples/example-advance-to-do-application:
-    dependencies:
-      '@osdk/api':
-        specifier: ^2.2.0-beta.18
-        version: 2.2.0-beta.18
-      '@osdk/client':
-        specifier: ^2.2.0-beta.18
-        version: 2.2.0-beta.18
-      '@osdk/foundry':
-        specifier: ^2.20.0
-        version: 2.20.0
-      '@osdk/foundry.admin':
-        specifier: ^2.20.0
-        version: 2.20.0
-      '@osdk/oauth':
-        specifier: ^1.1.1
-        version: 1.1.1
-      '@osdk/react':
-        specifier: ^0.3.0
-        version: 0.3.0(@osdk/api@2.2.0-beta.18)(@osdk/client@2.2.0-beta.18)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@tutorial-advance-to-do-application/sdk':
-        specifier: file:./tutorial-advance-to-do-application-sdk-0.9.0.tgz
-        version: file:examples/example-advance-to-do-application/tutorial-advance-to-do-application-sdk-0.9.0.tgz(@osdk/client@2.2.0-beta.18)
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
-      react:
-        specifier: ^18
-        version: 18.3.1
-      react-dom:
-        specifier: ^18
-        version: 18.3.1(react@18.3.1)
-      react-router-dom:
-        specifier: ^6.23.1
-        version: 6.23.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-tooltip:
-        specifier: ^5.28.0
-        version: 5.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      swr:
-        specifier: ^2.2.5
-        version: 2.2.5(react@18.3.1)
-    devDependencies:
-      '@eslint/compat':
-        specifier: ^1.2.1
-        version: 1.2.1(eslint@9.21.0(jiti@2.4.2))
-      '@eslint/js':
-        specifier: ^9.13.0
-        version: 9.21.0
-      '@types/eslint-plugin-jsx-a11y':
-        specifier: ^6.9.0
-        version: 6.9.0
-      '@types/lodash':
-        specifier: ^4.17.15
-        version: 4.17.16
-      '@types/node':
-        specifier: ^18.0.0
-        version: 18.19.97
-      '@types/react':
-        specifier: ^18
-        version: 18.3.12
-      '@types/react-dom':
-        specifier: ^18
-        version: 18.3.1
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^8.31.0
-        version: 8.32.1(@typescript-eslint/parser@8.32.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4))(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4)
-      '@typescript-eslint/parser':
-        specifier: ^8.31.0
-        version: 8.32.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4)
-      '@vitejs/plugin-react':
-        specifier: ^4.3.4
-        version: 4.4.1(vite@6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0))
-      eslint:
-        specifier: ^9.21.0
-        version: 9.21.0(jiti@2.4.2)
-      eslint-formatter-autolinkable-stylish:
-        specifier: ^1.4.0
-        version: 1.4.0(eslint@9.21.0(jiti@2.4.2))
-      eslint-import-resolver-typescript:
-        specifier: ^3.8.3
-        version: 3.8.3(eslint-plugin-import@2.31.0)(eslint@9.21.0(jiti@2.4.2))
-      eslint-plugin-header:
-        specifier: ^3.1.1
-        version: 3.1.1(eslint@9.21.0(jiti@2.4.2))
-      eslint-plugin-import:
-        specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4))(eslint-import-resolver-typescript@3.8.3(eslint-plugin-import@2.31.0)(eslint@9.21.0(jiti@2.4.2)))(eslint@9.21.0(jiti@2.4.2))
-      eslint-plugin-jsx-a11y:
-        specifier: ^6.10.1
-        version: 6.10.1(eslint@9.21.0(jiti@2.4.2))
-      eslint-plugin-prettier:
-        specifier: ^5.2.1
-        version: 5.2.1(@types/eslint@9.6.1)(eslint@9.21.0(jiti@2.4.2))(prettier@3.2.5)
-      eslint-plugin-react:
-        specifier: ^7.37.5
-        version: 7.37.5(eslint@9.21.0(jiti@2.4.2))
-      eslint-plugin-react-hooks:
-        specifier: ^5.0.0
-        version: 5.0.0(eslint@9.21.0(jiti@2.4.2))
-      eslint-plugin-react-refresh:
-        specifier: ^0.4.14
-        version: 0.4.14(eslint@9.21.0(jiti@2.4.2))
-      eslint-plugin-unused-imports:
-        specifier: ^4.1.4
-        version: 4.1.4(@typescript-eslint/eslint-plugin@8.32.1(@typescript-eslint/parser@8.32.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4))(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4))(eslint@9.21.0(jiti@2.4.2))
-      globals:
-        specifier: ^15.11.0
-        version: 15.15.0
-      typescript:
-        specifier: ~5.5.4
-        version: 5.5.4
-      typescript-eslint:
-        specifier: ^8.31.0
-        version: 8.32.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4)
-      vite:
-        specifier: ^6.3.5
-        version: 6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0)
-      vitest:
-        specifier: ^3.0.5
-        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
-
->>>>>>> f01518eb6 (v0)
   examples/example-expo-sdk-2.x:
     dependencies:
       '@babel/runtime':
@@ -710,7 +464,7 @@ importers:
         version: 6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0)
       vitest:
         specifier: ^3.0.5
-        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
 
   examples/example-react-sdk-1.x:
     dependencies:
@@ -868,7 +622,7 @@ importers:
         version: 6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0)
       vitest:
         specifier: ^3.0.5
-        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
 
   examples/example-tutorial-todo-aip-app-sdk-1.x:
     dependencies:
@@ -1228,7 +982,7 @@ importers:
         version: 6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0)
       vitest:
         specifier: ^3.0.5
-        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
       vue-tsc:
         specifier: ^2.1.6
         version: 2.1.6(typescript@5.5.4)
@@ -2081,7 +1835,7 @@ importers:
         version: 6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0)
       vitest:
         specifier: ^3.0.5
-        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
 
   packages/create-app.template.react:
     dependencies:
@@ -2242,7 +1996,7 @@ importers:
         version: 6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0)
       vitest:
         specifier: ^3.0.5
-        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
 
   packages/create-app.template.tutorial-todo-aip-app:
     dependencies:
@@ -3439,7 +3193,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^3.0.5
-        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
 
   packages/generator-converters:
     dependencies:
@@ -3953,7 +3707,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^3.0.5
-        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
 
   packages/typescript-sdk-docs:
     dependencies:
@@ -25787,7 +25541,7 @@ snapshots:
       terser: 5.39.2
       yaml: 2.8.0
 
-  vitest@3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0):
+  vitest@3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0):
     dependencies:
       '@vitest/expect': 3.0.7
       '@vitest/mocker': 3.0.7(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(vite@6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,6 +276,252 @@ importers:
         specifier: ^6.3.5
         version: 6.3.5(@types/node@22.13.0)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0)
 
+<<<<<<< HEAD
+||||||| parent of f01518eb6 (v0)
+  examples/example-advance-to-do-application:
+    dependencies:
+      '@osdk/api':
+        specifier: ^2.2.0-beta.18
+        version: 2.2.0-beta.18
+      '@osdk/client':
+        specifier: ^2.2.0-beta.18
+        version: 2.2.0-beta.18
+      '@osdk/foundry':
+        specifier: ^2.20.0
+        version: 2.20.0
+      '@osdk/foundry.admin':
+        specifier: ^2.20.0
+        version: 2.20.0
+      '@osdk/oauth':
+        specifier: ^1.1.1
+        version: 1.1.1
+      '@osdk/react':
+        specifier: ^0.3.0
+        version: 0.3.0(@osdk/api@2.2.0-beta.18)(@osdk/client@2.2.0-beta.18)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tutorial-advance-to-do-application/sdk':
+        specifier: file:./tutorial-advance-to-do-application-sdk-0.9.0.tgz
+        version: file:examples/example-advance-to-do-application/tutorial-advance-to-do-application-sdk-0.9.0.tgz(@osdk/client@2.2.0-beta.18)
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+      react:
+        specifier: ^18
+        version: 18.3.1
+      react-dom:
+        specifier: ^18
+        version: 18.3.1(react@18.3.1)
+      react-router-dom:
+        specifier: ^6.23.1
+        version: 6.23.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-tooltip:
+        specifier: ^5.28.0
+        version: 5.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      swr:
+        specifier: ^2.2.5
+        version: 2.2.5(react@18.3.1)
+    devDependencies:
+      '@eslint/compat':
+        specifier: ^1.2.1
+        version: 1.2.1(eslint@9.21.0(jiti@2.4.2))
+      '@eslint/js':
+        specifier: ^9.13.0
+        version: 9.21.0
+      '@types/eslint-plugin-jsx-a11y':
+        specifier: ^6.9.0
+        version: 6.9.0
+      '@types/lodash':
+        specifier: ^4.17.15
+        version: 4.17.16
+      '@types/node':
+        specifier: ^18.0.0
+        version: 18.19.97
+      '@types/react':
+        specifier: ^18
+        version: 18.3.12
+      '@types/react-dom':
+        specifier: ^18
+        version: 18.3.1
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.31.0
+        version: 8.32.1(@typescript-eslint/parser@8.32.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4))(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4)
+      '@typescript-eslint/parser':
+        specifier: ^8.31.0
+        version: 8.32.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.4.1(vite@6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0))
+      eslint:
+        specifier: ^9.21.0
+        version: 9.21.0(jiti@2.4.2)
+      eslint-formatter-autolinkable-stylish:
+        specifier: ^1.4.0
+        version: 1.4.0(eslint@9.21.0(jiti@2.4.2))
+      eslint-import-resolver-typescript:
+        specifier: ^3.8.3
+        version: 3.8.3(eslint-plugin-import@2.31.0)(eslint@9.21.0(jiti@2.4.2))
+      eslint-plugin-header:
+        specifier: ^3.1.1
+        version: 3.1.1(eslint@9.21.0(jiti@2.4.2))
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4))(eslint-import-resolver-typescript@3.8.3(eslint-plugin-import@2.31.0)(eslint@9.21.0(jiti@2.4.2)))(eslint@9.21.0(jiti@2.4.2))
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.10.1
+        version: 6.10.1(eslint@9.21.0(jiti@2.4.2))
+      eslint-plugin-prettier:
+        specifier: ^5.2.1
+        version: 5.2.1(@types/eslint@9.6.1)(eslint@9.21.0(jiti@2.4.2))(prettier@3.2.5)
+      eslint-plugin-react:
+        specifier: ^7.37.5
+        version: 7.37.5(eslint@9.21.0(jiti@2.4.2))
+      eslint-plugin-react-hooks:
+        specifier: ^5.0.0
+        version: 5.0.0(eslint@9.21.0(jiti@2.4.2))
+      eslint-plugin-react-refresh:
+        specifier: ^0.4.14
+        version: 0.4.14(eslint@9.21.0(jiti@2.4.2))
+      eslint-plugin-unused-imports:
+        specifier: ^4.1.4
+        version: 4.1.4(@typescript-eslint/eslint-plugin@8.32.1(@typescript-eslint/parser@8.32.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4))(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4))(eslint@9.21.0(jiti@2.4.2))
+      globals:
+        specifier: ^15.11.0
+        version: 15.15.0
+      typescript:
+        specifier: ~5.5.4
+        version: 5.5.4
+      typescript-eslint:
+        specifier: ^8.31.0
+        version: 8.32.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4)
+      vite:
+        specifier: ^6.3.5
+        version: 6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0)
+      vitest:
+        specifier: ^3.0.5
+        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+
+=======
+  examples/example-advance-to-do-application:
+    dependencies:
+      '@osdk/api':
+        specifier: ^2.2.0-beta.18
+        version: 2.2.0-beta.18
+      '@osdk/client':
+        specifier: ^2.2.0-beta.18
+        version: 2.2.0-beta.18
+      '@osdk/foundry':
+        specifier: ^2.20.0
+        version: 2.20.0
+      '@osdk/foundry.admin':
+        specifier: ^2.20.0
+        version: 2.20.0
+      '@osdk/oauth':
+        specifier: ^1.1.1
+        version: 1.1.1
+      '@osdk/react':
+        specifier: ^0.3.0
+        version: 0.3.0(@osdk/api@2.2.0-beta.18)(@osdk/client@2.2.0-beta.18)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tutorial-advance-to-do-application/sdk':
+        specifier: file:./tutorial-advance-to-do-application-sdk-0.9.0.tgz
+        version: file:examples/example-advance-to-do-application/tutorial-advance-to-do-application-sdk-0.9.0.tgz(@osdk/client@2.2.0-beta.18)
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+      react:
+        specifier: ^18
+        version: 18.3.1
+      react-dom:
+        specifier: ^18
+        version: 18.3.1(react@18.3.1)
+      react-router-dom:
+        specifier: ^6.23.1
+        version: 6.23.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-tooltip:
+        specifier: ^5.28.0
+        version: 5.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      swr:
+        specifier: ^2.2.5
+        version: 2.2.5(react@18.3.1)
+    devDependencies:
+      '@eslint/compat':
+        specifier: ^1.2.1
+        version: 1.2.1(eslint@9.21.0(jiti@2.4.2))
+      '@eslint/js':
+        specifier: ^9.13.0
+        version: 9.21.0
+      '@types/eslint-plugin-jsx-a11y':
+        specifier: ^6.9.0
+        version: 6.9.0
+      '@types/lodash':
+        specifier: ^4.17.15
+        version: 4.17.16
+      '@types/node':
+        specifier: ^18.0.0
+        version: 18.19.97
+      '@types/react':
+        specifier: ^18
+        version: 18.3.12
+      '@types/react-dom':
+        specifier: ^18
+        version: 18.3.1
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.31.0
+        version: 8.32.1(@typescript-eslint/parser@8.32.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4))(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4)
+      '@typescript-eslint/parser':
+        specifier: ^8.31.0
+        version: 8.32.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.4.1(vite@6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0))
+      eslint:
+        specifier: ^9.21.0
+        version: 9.21.0(jiti@2.4.2)
+      eslint-formatter-autolinkable-stylish:
+        specifier: ^1.4.0
+        version: 1.4.0(eslint@9.21.0(jiti@2.4.2))
+      eslint-import-resolver-typescript:
+        specifier: ^3.8.3
+        version: 3.8.3(eslint-plugin-import@2.31.0)(eslint@9.21.0(jiti@2.4.2))
+      eslint-plugin-header:
+        specifier: ^3.1.1
+        version: 3.1.1(eslint@9.21.0(jiti@2.4.2))
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4))(eslint-import-resolver-typescript@3.8.3(eslint-plugin-import@2.31.0)(eslint@9.21.0(jiti@2.4.2)))(eslint@9.21.0(jiti@2.4.2))
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.10.1
+        version: 6.10.1(eslint@9.21.0(jiti@2.4.2))
+      eslint-plugin-prettier:
+        specifier: ^5.2.1
+        version: 5.2.1(@types/eslint@9.6.1)(eslint@9.21.0(jiti@2.4.2))(prettier@3.2.5)
+      eslint-plugin-react:
+        specifier: ^7.37.5
+        version: 7.37.5(eslint@9.21.0(jiti@2.4.2))
+      eslint-plugin-react-hooks:
+        specifier: ^5.0.0
+        version: 5.0.0(eslint@9.21.0(jiti@2.4.2))
+      eslint-plugin-react-refresh:
+        specifier: ^0.4.14
+        version: 0.4.14(eslint@9.21.0(jiti@2.4.2))
+      eslint-plugin-unused-imports:
+        specifier: ^4.1.4
+        version: 4.1.4(@typescript-eslint/eslint-plugin@8.32.1(@typescript-eslint/parser@8.32.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4))(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4))(eslint@9.21.0(jiti@2.4.2))
+      globals:
+        specifier: ^15.11.0
+        version: 15.15.0
+      typescript:
+        specifier: ~5.5.4
+        version: 5.5.4
+      typescript-eslint:
+        specifier: ^8.31.0
+        version: 8.32.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.5.4)
+      vite:
+        specifier: ^6.3.5
+        version: 6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0)
+      vitest:
+        specifier: ^3.0.5
+        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+
+>>>>>>> f01518eb6 (v0)
   examples/example-expo-sdk-2.x:
     dependencies:
       '@babel/runtime':
@@ -464,7 +710,7 @@ importers:
         version: 6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0)
       vitest:
         specifier: ^3.0.5
-        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
 
   examples/example-react-sdk-1.x:
     dependencies:
@@ -622,7 +868,7 @@ importers:
         version: 6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0)
       vitest:
         specifier: ^3.0.5
-        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
 
   examples/example-tutorial-todo-aip-app-sdk-1.x:
     dependencies:
@@ -982,7 +1228,7 @@ importers:
         version: 6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0)
       vitest:
         specifier: ^3.0.5
-        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
       vue-tsc:
         specifier: ^2.1.6
         version: 2.1.6(typescript@5.5.4)
@@ -1835,7 +2081,7 @@ importers:
         version: 6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0)
       vitest:
         specifier: ^3.0.5
-        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
 
   packages/create-app.template.react:
     dependencies:
@@ -1996,7 +2242,7 @@ importers:
         version: 6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0)
       vitest:
         specifier: ^3.0.5
-        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
 
   packages/create-app.template.tutorial-todo-aip-app:
     dependencies:
@@ -3193,7 +3439,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^3.0.5
-        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
 
   packages/generator-converters:
     dependencies:
@@ -3259,6 +3505,9 @@ importers:
       jiti:
         specifier: ^2.0.0
         version: 2.4.2
+      semver-ts:
+        specifier: ^1.0.0
+        version: 1.0.3
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3
@@ -3704,7 +3953,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^3.0.5
-        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
 
   packages/typescript-sdk-docs:
     dependencies:
@@ -12348,6 +12597,10 @@ packages:
   selfsigned@2.4.1:
     resolution: {integrity: sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==}
     engines: {node: '>=10'}
+
+  semver-ts@1.0.3:
+    resolution: {integrity: sha512-RMf2+Nbd0Hiq5u8LADzqnSRb09Vu1UKOLFw9P9nm8XY3JPeFjv3DLVYBZjPWFHUxBVz7ktIVGR3xFjYilHlXng==}
+    engines: {node: '>=0.10.0'}
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -24269,6 +24522,8 @@ snapshots:
       '@types/node-forge': 1.3.11
       node-forge: 1.3.1
 
+  semver-ts@1.0.3: {}
+
   semver@5.7.2: {}
 
   semver@6.3.1: {}
@@ -25532,7 +25787,7 @@ snapshots:
       terser: 5.39.2
       yaml: 2.8.0
 
-  vitest@3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0):
+  vitest@3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0):
     dependencies:
       '@vitest/expect': 3.0.7
       '@vitest/mocker': 3.0.7(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(vite@6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0))


### PR DESCRIPTION
When you import something from an OAC library, that library will add it's namespace and version to the global state of dependencies. Then (if the flag is provided) that mapping will be written to an output file for later consumption.