### PR TITLE
Link id sanitation for OAC

### DIFF
--- a/.changeset/cuddly-stars-take.md
+++ b/.changeset/cuddly-stars-take.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker": patch
+---
+
+link id sanitation

--- a/packages/maker/src/api/defineOntology.ts
+++ b/packages/maker/src/api/defineOntology.ts
@@ -763,7 +763,8 @@ function convertLink(
 function cleanAndValidateLinkTypeId(apiName: string): string {
   // Insert a dash before any uppercase letter that follows a lowercase letter or digit
   const step1 = apiName.replace(/([a-z0-9])([A-Z])/g, "$1-$2");
-  // Insert a dash after a sequence of uppercase letters when followed by a lowercase letter, and convert to lowercase
+  // Insert a dash after a sequence of uppercase letters when followed by a lowercase letter
+  // then convert the whole string to lowercase
   // e.g., apiName, APIname, and apiNAME will all be converted to api-name
   const linkTypeId = step1.replace(/([A-Z])([A-Z][a-z])/g, "$1-$2")
     .toLowerCase();

--- a/packages/maker/src/api/defineOntology.ts
+++ b/packages/maker/src/api/defineOntology.ts
@@ -761,10 +761,18 @@ function convertLink(
 }
 
 function cleanAndValidateLinkTypeId(apiName: string): string {
-  const linkTypeId = apiName.toLowerCase();
+  // Insert a dash before any uppercase letter that follows a lowercase letter or digit
+  const step1 = apiName.replace(/([a-z0-9])([A-Z])/g, "$1-$2");
+  // Insert a dash after a sequence of uppercase letters when followed by a lowercase letter, and convert to lowercase
+  // e.g., apiName, APIname, and apiNAME will all be converted to api-name
+  const linkTypeId = step1.replace(/([A-Z])([A-Z][a-z])/g, "$1-$2")
+    .toLowerCase();
+
   const VALIDATION_PATTERN = /^([a-z][a-z0-9\-]*)$/;
   if (!VALIDATION_PATTERN.test(linkTypeId)) {
-    throw new Error(`LinkType id '${linkTypeId}' does not match required pattern`);
+    throw new Error(
+      `LinkType id '${linkTypeId}' must be lower case with dashes.`,
+    );
   }
   return linkTypeId;
 }

--- a/packages/maker/src/api/defineOntology.ts
+++ b/packages/maker/src/api/defineOntology.ts
@@ -749,7 +749,7 @@ function convertLink(
   return {
     linkType: {
       definition: definition,
-      id: linkType.apiName,
+      id: cleanAndValidateLinkTypeId(linkType.apiName),
       status: linkType.status ?? { type: "active", active: {} },
       redacted: linkType.redacted ?? false,
     },
@@ -758,6 +758,15 @@ function convertLink(
       arePatchesEnabled: linkType.editsEnabled ?? false,
     },
   };
+}
+
+function cleanAndValidateLinkTypeId(apiName: string): string {
+  const linkTypeId = apiName.toLowerCase();
+  const VALIDATION_PATTERN = /^([a-z][a-z0-9\-]*)$/;
+  if (!VALIDATION_PATTERN.test(linkTypeId)) {
+    throw new Error(`LinkType id '${linkTypeId}' does not match required pattern`);
+  }
+  return linkTypeId;
 }
 
 function convertInterface(

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -2086,7 +2086,7 @@ describe("Ontology Defining", () => {
                   },
                   "type": "oneToMany",
                 },
-                "id": "fizzToFoo",
+                "id": "fizztofoo",
                 "redacted": false,
                 "status": {
                   "active": {},
@@ -2491,7 +2491,7 @@ describe("Ontology Defining", () => {
                   },
                   "type": "manyToMany",
                 },
-                "id": "fizzToFoo",
+                "id": "fizztofoo",
                 "redacted": false,
                 "status": {
                   "active": {},

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+// cspell:disable
+
 import * as fs from "fs";
 import path from "path";
 import { beforeEach, describe, expect, it } from "vitest";

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-// cspell:disable
-
 import * as fs from "fs";
 import path from "path";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -2088,7 +2086,7 @@ describe("Ontology Defining", () => {
                   },
                   "type": "oneToMany",
                 },
-                "id": "fizztofoo",
+                "id": "fizz-to-foo",
                 "redacted": false,
                 "status": {
                   "active": {},
@@ -2493,7 +2491,7 @@ describe("Ontology Defining", () => {
                   },
                   "type": "manyToMany",
                 },
-                "id": "fizztofoo",
+                "id": "fizz-to-foo",
                 "redacted": false,
                 "status": {
                   "active": {},


### PR DESCRIPTION
OMS requires that link IDs conform to [this pattern](https://github.palantir.build/foundry/ontology-metadata-service/blob/70503a47c1773e4acb04ce83e2b9447068aa8705/ontology-metadata-common/src/main/java/com/palantir/ontology/metadata/utils/OntologyIdentifiers.java#L13)

Previously, link definitions would fail during install due to this validation error. Now, OAC lowercases link IDs + adds dashes between uppercase and lowercase characters. If the id still does not conform, it errors in OAC instead of during install.