### PR TITLE
Backport: CLI widgetset stable command (#1622)

### DIFF
--- a/.changeset/afraid-zebras-send.md
+++ b/.changeset/afraid-zebras-send.md
@@ -1,0 +1,5 @@
+---
+"@osdk/cli": patch
+---
+
+Register "widgetset" CLI command out of unstable

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -36,6 +36,7 @@ export async function cli(args: string[] = process.argv): Promise<
   try {
     return await base
       .command(site)
+      .command(widgetSet)
       .command({
         command: "unstable",
         aliases: ["experimental"],
@@ -44,6 +45,7 @@ export async function cli(args: string[] = process.argv): Promise<
           return argv
             .command(typescript)
             .command(auth)
+            // TODO: Remove copy of widgetset command from unstable once we've moved over templates
             .command(widgetSet)
             .demandCommand();
         },


### PR DESCRIPTION
To release latest tag version with widgetset command without unstable prefix in CLI