### PR TITLE
Allow createFoundryWidgetClient to use new message API

### DIFF
--- a/.changeset/puny-rabbits-walk.md
+++ b/.changeset/puny-rabbits-walk.md
@@ -2,4 +2,4 @@
 "@osdk/widget.client.unstable": patch
 ---
 
-createFoundryWidgetClient tries to use window.__PALANTIR_WIDGET_API__
+createFoundryWidgetClient tries to use `window.__PALANTIR_WIDGET_API__`

--- a/packages/widget.client.unstable/src/client.ts
+++ b/packages/widget.client.unstable/src/client.ts
@@ -64,7 +64,7 @@ export function createFoundryWidgetClient<
   C extends WidgetConfig<C["parameters"]>,
 >(): FoundryWidgetClient<C> {
   if ("__PALANTIR_WIDGET_API__" in window) {
-    return _createFoundryWidgetClient(
+    return _createFoundryWidgetClient<C>(
       window.__PALANTIR_WIDGET_API__ as PalantirWidgetApi<C>,
     );
   }


### PR DESCRIPTION
`createFoundryWidgetClient` now tries to use `window.__PALANTIR_WIDGET_API__` if available, and if not, falls back to the current implementation. Eventually we can delete the legacy code.