### PR TITLE
Fix create-widget templates workspace version dependency

### DIFF
--- a/.changeset/legal-papayas-pick.md
+++ b/.changeset/legal-papayas-pick.md
@@ -1,0 +1,6 @@
+---
+"@osdk/create-widget.template.minimal-react.v2": patch
+"@osdk/create-widget.template.react.v2": patch
+---
+
+Fix create-widget templates workspace dependency version

--- a/packages/create-widget.template.minimal-react.v2/templates/package.json.hbs
+++ b/packages/create-widget.template.minimal-react.v2/templates/package.json.hbs
@@ -11,10 +11,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@osdk/widget.client-react": "workspace:*",
-    "@osdk/widget.client": "workspace:*"
+    "@osdk/widget.client-react": "^2.1.0",
+    "@osdk/widget.client": "^2.1.0"
   },
   "devDependencies": {
-    "@osdk/widget.vite-plugin": "workspace:*"
+    "@osdk/widget.vite-plugin": "^2.1.0"
   }
 }

--- a/packages/create-widget.template.react.v2/templates/package.json.hbs
+++ b/packages/create-widget.template.react.v2/templates/package.json.hbs
@@ -13,10 +13,10 @@
   "dependencies": {
     "{{osdkPackage}}": "latest",
     "@osdk/client": "^2.0.0",
-    "@osdk/widget.client-react": "workspace:*",
-    "@osdk/widget.client": "workspace:*"
+    "@osdk/widget.client-react": "^2.1.0",
+    "@osdk/widget.client": "^2.1.0"
   },
   "devDependencies": {
-    "@osdk/widget.vite-plugin": "workspace:*"
+    "@osdk/widget.vite-plugin": "^2.1.0"
   }
 }


### PR DESCRIPTION
Fix a bug in https://github.com/palantir/osdk-ts/pull/1631 which switched the create-widget template version dependencies to workspace which is only valid in this repo. The examples packages swap this to workspace version through example-generator so the template version should be the public facing dependency range