### PR TITLE
Backport: Fix create-widget templates workspace version dependency (#1639)

### DIFF
--- a/.changeset/legal-papayas-pick.md
+++ b/.changeset/legal-papayas-pick.md
@@ -1,0 +1,6 @@
+---
+"@osdk/create-widget.template.minimal-react.v2": patch
+"@osdk/create-widget.template.react.v2": patch
+---
+
+Fix create-widget templates workspace dependency version

--- a/packages/create-widget.template.minimal-react.v2/templates/package.json.hbs
+++ b/packages/create-widget.template.minimal-react.v2/templates/package.json.hbs
@@ -11,10 +11,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@osdk/widget.client-react": "workspace:*",
-    "@osdk/widget.client": "workspace:*"
+    "@osdk/widget.client-react": "^2.1.0",
+    "@osdk/widget.client": "^2.1.0"
   },
   "devDependencies": {
-    "@osdk/widget.vite-plugin": "workspace:*"
+    "@osdk/widget.vite-plugin": "^2.1.0"
   }
 }

--- a/packages/create-widget.template.react.v2/templates/package.json.hbs
+++ b/packages/create-widget.template.react.v2/templates/package.json.hbs
@@ -13,10 +13,10 @@
   "dependencies": {
     "{{osdkPackage}}": "latest",
     "@osdk/client": "^2.0.0",
-    "@osdk/widget.client-react": "workspace:*",
-    "@osdk/widget.client": "workspace:*"
+    "@osdk/widget.client-react": "^2.1.0",
+    "@osdk/widget.client": "^2.1.0"
   },
   "devDependencies": {
-    "@osdk/widget.vite-plugin": "workspace:*"
+    "@osdk/widget.vite-plugin": "^2.1.0"
   }
 }


### PR DESCRIPTION
To depend on non-workspace versions in create-widget generated projects