### PR TITLE
Fix dependency injection

### DIFF
--- a/.changeset/five-lands-press.md
+++ b/.changeset/five-lands-press.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker": patch
+---
+
+Fix dependency injection

--- a/packages/maker/src/api/defineOntology.ts
+++ b/packages/maker/src/api/defineOntology.ts
@@ -49,6 +49,7 @@ import type {
 import * as fs from "fs";
 import * as path from "path";
 import invariant from "tiny-invariant";
+import { fileURLToPath } from "url";
 import { isExotic } from "./defineObject.js";
 import {
   convertNullabilityToDataConstraint,
@@ -1245,8 +1246,16 @@ function dependencyInjectionString(): string {
   const namespaceNoDot: string = namespace.endsWith(".")
     ? namespace.slice(0, -1)
     : namespace;
+
+  const currentFilePath = fileURLToPath(import.meta.url);
+  let packageJsonDirPath = path.join(currentFilePath, "..", "..", "..");
+  if (!currentFilePath.endsWith(".ts")) {
+    packageJsonDirPath = path.join(packageJsonDirPath, "..");
+  }
+  const packageJsonFilePath = path.join(packageJsonDirPath, "package.json");
+
   const packageJson = JSON.parse(
-    fs.readFileSync("package.json", "utf-8"),
+    fs.readFileSync(packageJsonFilePath, "utf-8"),
   );
   const currentPackageVersion: string = packageJson.version ?? "";
 


### PR DESCRIPTION
I thought the cli would always execute in the package home directory, but I guess that's not the case. 

Got `Error: ENOENT: no such file or directory, open 'package.json'` in CI for consumers because of this.

Now, we find the package.json relative to the defineOntology file, differentiating between TS (unit tests) and JS (production) cases.