### PR TITLE
Use root id rather than body for widgets react-dom

### DIFF
--- a/examples/example-widget-minimal-react-sdk-2.x/index.html
+++ b/examples/example-widget-minimal-react-sdk-2.x/index.html
@@ -6,6 +6,7 @@
     <title>Minimal React Custom Widget</title>
   </head>
   <body>
+    <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/examples/example-widget-minimal-react-sdk-2.x/src/Widget.module.css
+++ b/examples/example-widget-minimal-react-sdk-2.x/src/Widget.module.css
@@ -1,4 +1,5 @@
 .container {
+    margin: 8px;
     padding: 15px;
     display: flex;
     flex-direction: column;

--- a/examples/example-widget-minimal-react-sdk-2.x/src/main.tsx
+++ b/examples/example-widget-minimal-react-sdk-2.x/src/main.tsx
@@ -1,14 +1,15 @@
 import "@blueprintjs/core/lib/css/blueprint.css";
+import "./main.css";
 
 import { FoundryWidget } from "@osdk/widget.client-react";
 import { createRoot } from "react-dom/client";
 import MainConfig from "./main.config.js";
 import { Widget } from "./Widget.js";
 
-const root = document.querySelector("body")!;
+const root = document.getElementById("root")!;
 
 createRoot(root).render(
   <FoundryWidget config={MainConfig}>
     <Widget />
-  </FoundryWidget>,
+  </FoundryWidget>
 );

--- a/examples/example-widget-react-sdk-2.x/index.html
+++ b/examples/example-widget-react-sdk-2.x/index.html
@@ -6,6 +6,7 @@
     <title>Widget: Ontology SDK + React</title>
   </head>
   <body>
+    <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/examples/example-widget-react-sdk-2.x/src/main.tsx
+++ b/examples/example-widget-react-sdk-2.x/src/main.tsx
@@ -7,12 +7,12 @@ import { createRoot } from "react-dom/client";
 import MainConfig from "./main.config.js";
 import { Widget } from "./Widget.js";
 
-const root = document.querySelector("body")!;
+const root = document.getElementById("root")!;
 
 createRoot(root).render(
   <Theme>
     <FoundryWidget config={MainConfig}>
       <Widget />
     </FoundryWidget>
-  </Theme>,
+  </Theme>
 );

--- a/packages/create-widget.template.minimal-react.v2/templates/index.html
+++ b/packages/create-widget.template.minimal-react.v2/templates/index.html
@@ -6,6 +6,7 @@
     <title>Minimal React Custom Widget</title>
   </head>
   <body>
+    <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/packages/create-widget.template.minimal-react.v2/templates/src/Widget.module.css
+++ b/packages/create-widget.template.minimal-react.v2/templates/src/Widget.module.css
@@ -1,4 +1,5 @@
 .container {
+    margin: 8px;
     padding: 15px;
     display: flex;
     flex-direction: column;

--- a/packages/create-widget.template.minimal-react.v2/templates/src/main.tsx
+++ b/packages/create-widget.template.minimal-react.v2/templates/src/main.tsx
@@ -1,14 +1,15 @@
 import "@blueprintjs/core/lib/css/blueprint.css";
+import "./main.css";
 
 import { FoundryWidget } from "@osdk/widget.client-react";
 import { createRoot } from "react-dom/client";
 import MainConfig from "./main.config.js";
 import { Widget } from "./Widget.js";
 
-const root = document.querySelector("body")!;
+const root = document.getElementById("root")!;
 
 createRoot(root).render(
   <FoundryWidget config={MainConfig}>
     <Widget />
-  </FoundryWidget>,
+  </FoundryWidget>
 );

--- a/packages/create-widget.template.react.v2/templates/index.html
+++ b/packages/create-widget.template.react.v2/templates/index.html
@@ -6,6 +6,7 @@
     <title>Widget: Ontology SDK + React</title>
   </head>
   <body>
+    <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/packages/create-widget.template.react.v2/templates/src/main.tsx
+++ b/packages/create-widget.template.react.v2/templates/src/main.tsx
@@ -7,12 +7,12 @@ import { createRoot } from "react-dom/client";
 import MainConfig from "./main.config.js";
 import { Widget } from "./Widget.js";
 
-const root = document.querySelector("body")!;
+const root = document.getElementById("root")!;
 
 createRoot(root).render(
   <Theme>
     <FoundryWidget config={MainConfig}>
       <Widget />
     </FoundryWidget>
-  </Theme>,
+  </Theme>
 );

--- a/packages/widget.vite-plugin/index.html
+++ b/packages/widget.vite-plugin/index.html
@@ -6,9 +6,7 @@
     <title>Palantir: Widget dev mode setup</title>
   </head>
   <body>
-    <div id="root-container">
-      <div id="root"></div>
-    </div>
+    <div id="root"></div>
     <script type="module" src="/src/client/main.tsx"></script>
   </body>
 </html>

--- a/packages/widget.vite-plugin/src/client/main.tsx
+++ b/packages/widget.vite-plugin/src/client/main.tsx
@@ -20,8 +20,6 @@ import "./main.css";
 import { createRoot } from "react-dom/client";
 import { App } from "./app.js";
 
-const root = document.querySelector("body")!;
+const root = document.getElementById("root")!;
 
-createRoot(root).render(
-  <App />,
-);
+createRoot(root).render(<App />);


### PR DESCRIPTION
Updates the following:

- Widget minimal template
- Widget OSDK template
- Widget vite plugin

To use the root id element rather than body for react-dom. This cleans up some console errors and may help prevent interference if other libraries directly inject more elements into the body element