### PR TITLE
Fix dependency injection to use OAC version and not maker version

### DIFF
--- a/.changeset/tidy-banks-matter.md
+++ b/.changeset/tidy-banks-matter.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker": patch
+---
+
+Fix dependency injection to use OAC version and not maker version

--- a/packages/maker/src/api/defineOntology.ts
+++ b/packages/maker/src/api/defineOntology.ts
@@ -49,7 +49,6 @@ import type {
 import * as fs from "fs";
 import * as path from "path";
 import invariant from "tiny-invariant";
-import { fileURLToPath } from "url";
 import { isExotic } from "./defineObject.js";
 import {
   convertNullabilityToDataConstraint,
@@ -1247,17 +1246,10 @@ function dependencyInjectionString(): string {
     ? namespace.slice(0, -1)
     : namespace;
 
-  const currentFilePath = fileURLToPath(import.meta.url);
-  let packageJsonDirPath = path.join(currentFilePath, "..", "..", "..");
-  if (!currentFilePath.endsWith(".ts")) {
-    packageJsonDirPath = path.join(packageJsonDirPath, "..");
-  }
-  const packageJsonFilePath = path.join(packageJsonDirPath, "package.json");
+  return `
+import { fileURLToPath } from "url";
+import { addDependency } from '@osdk/maker';
 
-  const packageJson = JSON.parse(
-    fs.readFileSync(packageJsonFilePath, "utf-8"),
-  );
-  const currentPackageVersion: string = packageJson.version ?? "";
-
-  return `import { addDependency } from '@osdk/maker';\n\naddDependency("${namespaceNoDot}", "${currentPackageVersion}");\n`;
+addDependency("${namespaceNoDot}", fileURLToPath(import.meta.url));
+`;
 }


### PR DESCRIPTION
In the codegen, we were accidentally writing the version of `osdk/maker` used instead of the version of the actual OAC package. Now, we pass in a `fileInPackage` and look for a package.json file recursively (up to 5 parents up) and extract the version from there.