### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -192,6 +192,7 @@
     "swift-goats-write",
     "thick-ways-smell",
     "three-tigers-matter",
+    "tidy-banks-matter",
     "tiny-days-dance",
     "tough-cougars-rule",
     "twelve-clocks-cough",

--- a/packages/maker/CHANGELOG.md
+++ b/packages/maker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/maker
 
+## 0.11.0-beta.10
+
+### Minor Changes
+
+- 99b90af: Fix dependency injection to use OAC version and not maker version
+
 ## 0.11.0-beta.9
 
 ### Minor Changes

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker",
-  "version": "0.11.0-beta.9",
+  "version": "0.11.0-beta.10",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/maker@0.11.0-beta.10

### Minor Changes

-   99b90af: Fix dependency injection to use OAC version and not maker version
