### PR TITLE
Use latest rather than beta for widget READMEs

### DIFF
--- a/.changeset/few-cases-camp.md
+++ b/.changeset/few-cases-camp.md
@@ -1,0 +1,6 @@
+---
+"@osdk/create-widget.template.minimal-react.v2": patch
+"@osdk/create-widget.template.react.v2": patch
+---
+
+Use latest rather than beta tags for widget template README commands referencing @osdk/cli

--- a/packages/create-widget.template.minimal-react.v2/templates/README.md.hbs
+++ b/packages/create-widget.template.minimal-react.v2/templates/README.md.hbs
@@ -26,7 +26,7 @@ A `.palantir/widgets.config.json` manifest file containing metadata about your w
 Run the following command or equivalent with your preferred package manager to deploy the production build of your widgets:
 
 ```sh
-npx @osdk/cli@beta unstable widgetset deploy
+npx @osdk/cli@latest unstable widgetset deploy
 ```
 
 By default the `package-json` strategy is used for determining the version for your widgets from the `version` field in this project's `package.json` file. Remember to update this field and rerun the build command to update the manifest file when deploying a new version.

--- a/packages/create-widget.template.minimal-react.v2/templates/README.md.hbs
+++ b/packages/create-widget.template.minimal-react.v2/templates/README.md.hbs
@@ -26,7 +26,7 @@ A `.palantir/widgets.config.json` manifest file containing metadata about your w
 Run the following command or equivalent with your preferred package manager to deploy the production build of your widgets:
 
 ```sh
-npx @osdk/cli@latest unstable widgetset deploy
+npx @osdk/cli@latest widgetset deploy
 ```
 
 By default the `package-json` strategy is used for determining the version for your widgets from the `version` field in this project's `package.json` file. Remember to update this field and rerun the build command to update the manifest file when deploying a new version.

--- a/packages/create-widget.template.react.v2/templates/README.md.hbs
+++ b/packages/create-widget.template.react.v2/templates/README.md.hbs
@@ -26,7 +26,7 @@ A `.palantir/widgets.config.json` manifest file containing metadata about your w
 Run the following command or equivalent with your preferred package manager to deploy the production build of your widgets:
 
 ```sh
-npx @osdk/cli@beta unstable widgetset deploy
+npx @osdk/cli@latest unstable widgetset deploy
 ```
 
 By default the `package-json` strategy is used for determining the version for your widgets from the `version` field in this project's `package.json` file. Remember to update this field and rerun the build command to update the manifest file when deploying a new version.

--- a/packages/create-widget.template.react.v2/templates/README.md.hbs
+++ b/packages/create-widget.template.react.v2/templates/README.md.hbs
@@ -26,7 +26,7 @@ A `.palantir/widgets.config.json` manifest file containing metadata about your w
 Run the following command or equivalent with your preferred package manager to deploy the production build of your widgets:
 
 ```sh
-npx @osdk/cli@latest unstable widgetset deploy
+npx @osdk/cli@latest widgetset deploy
 ```
 
 By default the `package-json` strategy is used for determining the version for your widgets from the `version` field in this project's `package.json` file. Remember to update this field and rerun the build command to update the manifest file when deploying a new version.


### PR DESCRIPTION
Now that we've moved the `widgetset` command out of unstable we should also use the latest rather than beta tag in the README commands for widget templates