### PR TITLE
Remove import/dep from codegen

### DIFF
--- a/.changeset/green-walls-look.md
+++ b/.changeset/green-walls-look.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker": patch
+---
+
+Remove import/dep from codegen

--- a/packages/maker/src/api/addDependency.ts
+++ b/packages/maker/src/api/addDependency.ts
@@ -20,7 +20,10 @@ import { dependencies } from "./defineOntology.js";
 
 const MAX_SEARCH_DEPTH = 5;
 
-export function addDependency(namespace: string, fileInPackage: string): void {
+export function addDependency(
+  namespaceNoDot: string,
+  fileInPackage: string,
+): void {
   let dir = path.dirname(fileInPackage);
   let packageJsonPath = null;
 
@@ -42,5 +45,5 @@ export function addDependency(namespace: string, fileInPackage: string): void {
   }
 
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
-  dependencies[namespace] = packageJson.version ?? "";
+  dependencies[namespaceNoDot] = packageJson.version ?? "";
 }

--- a/packages/maker/src/api/defineOntology.ts
+++ b/packages/maker/src/api/defineOntology.ts
@@ -1249,10 +1249,8 @@ function dependencyInjectionString(): string {
     ? namespace.slice(0, -1)
     : namespace;
 
-  return `
-import { fileURLToPath } from "url";
-import { addDependency } from "@osdk/maker";
+  return `import { addDependency } from "@osdk/maker";
 
-addDependency("${namespaceNoDot}", fileURLToPath(import.meta.url));
+addDependency("${namespaceNoDot}", new URL(import.meta.url).pathname);
 `;
 }

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -7922,7 +7922,7 @@ describe("Ontology Defining", () => {
         fs.readFileSync(path.join(generatedDir, "index.ts"), "utf8"),
       )
         .toContain(
-          `addDependency("com.palantir", fileURLToPath(import.meta.url));`,
+          `addDependency("com.palantir", new URL(import.meta.url).pathname);`,
         );
 
       fs.rmSync(path.join(generatedDir, ".."), {


### PR DESCRIPTION
Currently, consumers need `@types/node` for the dep codegen to work. This removes that dependency.