### PR TITLE
Add intermediate OSDK generation to CLI

### DIFF
--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -41,7 +41,9 @@
   },
   "dependencies": {
     "@osdk/api": "workspace:~",
+    "@osdk/generator-converters.ontologyir": "workspace:*",
     "consola": "^3.4.2",
+    "execa": "^9.6.0",
     "jiti": "^2.0.0",
     "semver-ts": "^1.0.0",
     "tiny-invariant": "^1.3.3",

--- a/packages/maker/src/cli/main.ts
+++ b/packages/maker/src/cli/main.ts
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+import { OntologyIrToFullMetadataConverter } from "@osdk/generator-converters.ontologyir";
 import { consola } from "consola";
+import { execa } from "execa";
 import { createJiti } from "jiti";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
@@ -36,6 +38,7 @@ export default async function main(
     valueTypesOutput: string;
     outputDir?: string;
     dependencies?: string;
+    generateFunctionsOsdk?: string;
   } = await yargs(hideBin(args))
     .version(process.env.PACKAGE_VERSION ?? "")
     .wrap(Math.min(150, yargs().terminalWidth()))
@@ -85,6 +88,11 @@ export default async function main(
         type: "string",
         coerce: path.resolve,
       },
+      generateFunctionsOsdk: {
+        describe: "Output folder for generated OSDK for functions",
+        type: "string",
+        coerce: path.resolve,
+      },
     })
     .parseAsync();
   let apiNamespace = "";
@@ -119,6 +127,23 @@ export default async function main(
       JSON.stringify(ontology.valueType, null, 2),
     );
   }
+
+  if (commandLineOpts.generateFunctionsOsdk !== undefined) {
+    // Generate full ontology metadata for functions OSDK
+    const fullMetadata = OntologyIrToFullMetadataConverter
+      .getFullMetadataFromIr(ontology.ontology.blockData);
+    const fullMetadataOutputDir = path.join(
+      commandLineOpts.generateFunctionsOsdk,
+      ".ontology.json",
+    );
+    consola.info(`Saving full ontology metadata to ${fullMetadataOutputDir}`);
+    await fs.writeFile(
+      fullMetadataOutputDir,
+      JSON.stringify(fullMetadata, null, 2),
+    );
+
+    await fullMetadataToOsdk(commandLineOpts.generateFunctionsOsdk);
+  }
 }
 
 async function loadOntology(
@@ -143,4 +168,61 @@ async function loadOntology(
     dependencyFile,
   );
   return q;
+}
+
+async function fullMetadataToOsdk(
+  workDir: string,
+): Promise<void> {
+  // First create a clean temporary directory to generate the SDK into
+  const functionOsdkDir = path.join(
+    workDir,
+    ".osdkFunctions",
+    "src",
+  );
+  await fs.rm(functionOsdkDir, { recursive: true, force: true });
+  await fs.mkdir(functionOsdkDir, { recursive: true });
+
+  // The osdk cli currently mutes package.json files which we don't want in this case
+  // so we give it a fake package.json file
+  // await fs.writeFile(
+  //   path.join(functionOsdkDir, "..", "package.json"),
+  //   JSON.stringify({}, null, 2),
+  //   { encoding: "utf-8" },
+  // );
+
+  try {
+    // Then generate the source code for the osdk
+    const srcDir = path.join(functionOsdkDir, "src");
+    const { stdout, stderr, exitCode } = await execa("pnpm", [
+      "exec",
+      "osdk",
+      "unstable",
+      "typescript",
+      "generate",
+      "--outDir",
+      srcDir,
+      "--ontologyPath",
+      path.join(workDir, ".ontology.json"),
+      "--beta",
+      "true",
+      "--packageType",
+      "module",
+      "--version",
+      "dev",
+    ]);
+  } catch (error) {
+    // Make sure to clean up temp directory even if there's an error
+    await fs.rm(functionOsdkDir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+async function compileOsdk() {
+  const { stdout, stderr, exitCode } = await execa("pnpm", [
+    "exec",
+    "tsc",
+  ], {
+    cwd: ".osdk",
+  });
+  return exitCode;
 }

--- a/packages/maker/src/cli/main.ts
+++ b/packages/maker/src/cli/main.ts
@@ -130,19 +130,25 @@ export default async function main(
 
   if (commandLineOpts.generateFunctionsOsdk !== undefined) {
     // Generate full ontology metadata for functions OSDK
+    const functionsOsdkRootDir = path.resolve(
+      commandLineOpts.generateFunctionsOsdk,
+      "functionsCodegen",
+    );
     const fullMetadata = OntologyIrToFullMetadataConverter
       .getFullMetadataFromIr(ontology.ontology.blockData);
     const fullMetadataOutputDir = path.join(
       commandLineOpts.generateFunctionsOsdk,
+      "functionsCodegen",
       ".ontology.json",
     );
     consola.info(`Saving full ontology metadata to ${fullMetadataOutputDir}`);
+    await fs.mkdir(functionsOsdkRootDir, { recursive: true });
     await fs.writeFile(
       fullMetadataOutputDir,
       JSON.stringify(fullMetadata, null, 2),
     );
 
-    await fullMetadataToOsdk(commandLineOpts.generateFunctionsOsdk);
+    await fullMetadataToOsdk(functionsOsdkRootDir);
   }
 }
 
@@ -176,8 +182,7 @@ async function fullMetadataToOsdk(
   // First create a clean temporary directory to generate the SDK into
   const functionOsdkDir = path.join(
     workDir,
-    ".osdkFunctions",
-    "src",
+    ".functionsOsdk",
   );
   await fs.rm(functionOsdkDir, { recursive: true, force: true });
   await fs.mkdir(functionOsdkDir, { recursive: true });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3351,9 +3351,15 @@ importers:
       '@osdk/api':
         specifier: workspace:~
         version: link:../api
+      '@osdk/generator-converters.ontologyir':
+        specifier: workspace:*
+        version: link:../generator-converters.ontologyir
       consola:
         specifier: ^3.4.2
         version: 3.4.2
+      execa:
+        specifier: ^9.6.0
+        version: 9.6.0
       jiti:
         specifier: ^2.0.0
         version: 2.4.2


### PR DESCRIPTION
Add a flag to the maker CLI to generate intermediate OSDK that can be consumed by functions. 