### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -163,6 +163,7 @@
     "cuddly-stars-take",
     "cyan-ears-reply",
     "deep-mammals-behave",
+    "eighty-lies-chew",
     "eighty-rules-kick",
     "empty-clocks-relax",
     "famous-dodos-fall",

--- a/packages/maker/CHANGELOG.md
+++ b/packages/maker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/maker
 
+## 0.11.0-beta.13
+
+### Minor Changes
+
+- 402aa94: Use namespaced api names for interface properties
+
 ## 0.11.0-beta.12
 
 ### Minor Changes

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker",
-  "version": "0.11.0-beta.12",
+  "version": "0.11.0-beta.13",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/maker@0.11.0-beta.13

### Minor Changes

-   402aa94: Use namespaced api names for interface properties
