### PR TITLE
Better syntax for parameter matching

### DIFF
--- a/.changeset/flat-numbers-arrive.md
+++ b/.changeset/flat-numbers-arrive.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker": patch
+---
+
+parameter matching condition

--- a/packages/maker/src/api/defineAction.ts
+++ b/packages/maker/src/api/defineAction.ts
@@ -25,12 +25,14 @@ import {
 import { convertConditionDefinition } from "./ontologyUtils.js";
 import {
   type ActionLevelValidationDefinition,
+  type ActionParameter,
   type ActionParameterAllowedValues,
   type ActionParameterType,
   type ActionParameterTypePrimitive,
   type ActionType,
   type ActionTypeDefinition,
   type ActionValidationRule,
+  type ConditionDefinition,
   type InterfaceType,
   type ObjectPropertyType,
   type ObjectType,
@@ -421,6 +423,7 @@ export function defineAction(actionDef: ActionTypeDefinition): ActionType {
     apiName: apiName,
     __type: OntologyEntityTypeEnum.ACTION_TYPE,
   } as ActionType;
+  validateActionValidation(fullAction);
   updateOntology(fullAction);
   return fullAction;
 }
@@ -669,4 +672,71 @@ function convertValidationRule(
       typeClasses: [],
     },
   };
+}
+
+function validateActionValidation(action: ActionType): void {
+  const seenParameterIds = new Set<ParameterId>();
+  action.parameters?.forEach(param => {
+    param.validation.conditionalOverrides?.forEach(override => {
+      validateActionCondition(
+        override.condition,
+        param.id,
+        seenParameterIds,
+        action.parameters,
+      );
+    });
+    seenParameterIds.add(param.id);
+  });
+}
+
+function validateActionCondition(
+  condition: ConditionDefinition,
+  currentParameterId: ParameterId,
+  seenParameterIds: Set<ParameterId>,
+  parameters?: ActionParameter[],
+): void {
+  switch (condition.type) {
+    case "parameter":
+      const overrideParamId = condition.parameterId;
+      invariant(
+        parameters?.some(p => p.id === overrideParamId),
+        `Parameter condition on ${currentParameterId} is referencing unknown parameter ${overrideParamId}`,
+      );
+      invariant(
+        overrideParamId !== currentParameterId,
+        `Parameter condition on ${currentParameterId} is referencing itself`,
+      );
+      invariant(
+        seenParameterIds.has(overrideParamId),
+        `Parameter condition on ${currentParameterId} is referencing later parameter ${overrideParamId}`,
+      );
+      break;
+    case "and":
+      // this will not catch the niche edge case where users use the full syntax for unions
+      if ("conditions" in condition) {
+        condition.conditions.forEach(c =>
+          validateActionCondition(
+            c,
+            currentParameterId,
+            seenParameterIds,
+            parameters,
+          )
+        );
+      }
+      break;
+    case "or":
+      if ("conditions" in condition) {
+        condition.conditions.forEach(c =>
+          validateActionCondition(
+            c,
+            currentParameterId,
+            seenParameterIds,
+            parameters,
+          )
+        );
+      }
+      break;
+    default:
+      break;
+  }
 }

--- a/packages/maker/src/api/defineAction.ts
+++ b/packages/maker/src/api/defineAction.ts
@@ -736,7 +736,17 @@ function validateActionCondition(
         );
       }
       break;
-    default:
+    case "comparison":
+    case "group":
+    case "not":
+    case "markings":
+    case "regex":
+    case "redacted":
+    case "true":
       break;
+    default:
+      throw new Error(
+        `Unknown condition type on parameter ${currentParameterId}`,
+      );
   }
 }

--- a/packages/maker/src/api/ontologyUtils.ts
+++ b/packages/maker/src/api/ontologyUtils.ts
@@ -178,6 +178,20 @@ export function convertConditionDefinition(
           },
         },
       };
+    // TODO(ethan): there are some complex validations that we can perform on this.
+    // Enforce that referenced parameters are listed later than the parameter that this validation belongs to in the parameters array
+    case "parameter":
+      return {
+        type: "comparison",
+        comparison: {
+          operator: "EQUALS",
+          left: {
+            type: "parameterId",
+            parameterId: condition.parameterId,
+          },
+          right: condition.matches,
+        },
+      };
     default:
       return condition;
   }

--- a/packages/maker/src/api/ontologyUtils.ts
+++ b/packages/maker/src/api/ontologyUtils.ts
@@ -178,8 +178,6 @@ export function convertConditionDefinition(
           },
         },
       };
-    // TODO(ethan): there are some complex validations that we can perform on this.
-    // Enforce that referenced parameters are listed later than the parameter that this validation belongs to in the parameters array
     case "parameter":
       return {
         type: "comparison",

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -5124,6 +5124,10 @@ describe("Ontology Defining", () => {
                 type: "parameterId",
                 parameterId: "param1",
               },
+              "foo": {
+                type: "parameterId",
+                parameterId: "param2",
+              },
             },
             structFieldValues: {},
           },
@@ -5140,11 +5144,36 @@ describe("Ontology Defining", () => {
               {
                 type: "visibility",
                 condition: {
-                  type: "group",
-                  name: "myGroup",
+                  type: "and",
+                  conditions: [
+                    {
+                      type: "group",
+                      name: "myGroup",
+                    },
+                    {
+                      type: "parameter",
+                      parameterId: "param2",
+                      matches: {
+                        type: "staticValue",
+                        staticValue: {
+                          type: "string",
+                          string: "foobar",
+                        },
+                      },
+                    },
+                  ],
                 },
               },
             ],
+          },
+        }, {
+          id: "param2",
+          displayName: "param2",
+          type: "string",
+          validation: {
+            required: true,
+            allowedValues: { type: "text" },
+            defaultVisibility: "editable",
           },
         }, {
           id: "objectToModifyParameter",
@@ -5173,6 +5202,10 @@ describe("Ontology Defining", () => {
                             "propertyValues": {
                               "bar": {
                                 "parameterId": "param1",
+                                "type": "parameterId",
+                              },
+                              "foo": {
+                                "parameterId": "param2",
                                 "type": "parameterId",
                               },
                             },
@@ -5232,34 +5265,58 @@ describe("Ontology Defining", () => {
                           "conditionalOverrides": [
                             {
                               "condition": {
-                                "comparison": {
-                                  "left": {
-                                    "type": "userProperty",
-                                    "userProperty": {
-                                      "propertyValue": {
-                                        "groupIds": {},
-                                        "type": "groupIds",
+                                "and": {
+                                  "conditions": [
+                                    {
+                                      "comparison": {
+                                        "left": {
+                                          "type": "userProperty",
+                                          "userProperty": {
+                                            "propertyValue": {
+                                              "groupIds": {},
+                                              "type": "groupIds",
+                                            },
+                                            "userId": {
+                                              "currentUser": {},
+                                              "type": "currentUser",
+                                            },
+                                          },
+                                        },
+                                        "operator": "INTERSECTS",
+                                        "right": {
+                                          "staticValue": {
+                                            "stringList": {
+                                              "strings": [
+                                                "myGroup",
+                                              ],
+                                            },
+                                            "type": "stringList",
+                                          },
+                                          "type": "staticValue",
+                                        },
                                       },
-                                      "userId": {
-                                        "currentUser": {},
-                                        "type": "currentUser",
-                                      },
+                                      "type": "comparison",
                                     },
-                                  },
-                                  "operator": "INTERSECTS",
-                                  "right": {
-                                    "staticValue": {
-                                      "stringList": {
-                                        "strings": [
-                                          "myGroup",
-                                        ],
+                                    {
+                                      "comparison": {
+                                        "left": {
+                                          "parameterId": "param2",
+                                          "type": "parameterId",
+                                        },
+                                        "operator": "EQUALS",
+                                        "right": {
+                                          "staticValue": {
+                                            "string": "foobar",
+                                            "type": "string",
+                                          },
+                                          "type": "staticValue",
+                                        },
                                       },
-                                      "type": "stringList",
+                                      "type": "comparison",
                                     },
-                                    "type": "staticValue",
-                                  },
+                                  ],
                                 },
-                                "type": "comparison",
+                                "type": "and",
                               },
                               "parameterBlockOverrides": [
                                 {
@@ -5292,6 +5349,34 @@ describe("Ontology Defining", () => {
                                   "type": "boolean",
                                 },
                                 "type": "boolean",
+                              },
+                              "required": {
+                                "required": {},
+                                "type": "required",
+                              },
+                            },
+                          },
+                        },
+                        "param2": {
+                          "conditionalOverrides": [],
+                          "defaultValidation": {
+                            "display": {
+                              "renderHint": {
+                                "textInput": {},
+                                "type": "textInput",
+                              },
+                              "visibility": {
+                                "editable": {},
+                                "type": "editable",
+                              },
+                            },
+                            "validation": {
+                              "allowedValues": {
+                                "text": {
+                                  "text": {},
+                                  "type": "text",
+                                },
+                                "type": "text",
                               },
                               "required": {
                                 "required": {},
@@ -5334,6 +5419,7 @@ describe("Ontology Defining", () => {
                     "formContentOrdering": [],
                     "parameterOrdering": [
                       "param1",
+                      "param2",
                       "objectToModifyParameter",
                     ],
                     "parameters": {
@@ -5359,6 +5445,18 @@ describe("Ontology Defining", () => {
                         "type": {
                           "boolean": {},
                           "type": "boolean",
+                        },
+                      },
+                      "param2": {
+                        "displayMetadata": {
+                          "description": "",
+                          "displayName": "param2",
+                          "typeClasses": [],
+                        },
+                        "id": "param2",
+                        "type": {
+                          "string": {},
+                          "type": "string",
                         },
                       },
                     },

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -5133,6 +5133,15 @@ describe("Ontology Defining", () => {
           },
         }],
         parameters: [{
+          id: "param2",
+          displayName: "param2",
+          type: "string",
+          validation: {
+            required: true,
+            allowedValues: { type: "text" },
+            defaultVisibility: "editable",
+          },
+        }, {
           id: "param1",
           displayName: "param1",
           type: "boolean",
@@ -5165,15 +5174,6 @@ describe("Ontology Defining", () => {
                 },
               },
             ],
-          },
-        }, {
-          id: "param2",
-          displayName: "param2",
-          type: "string",
-          validation: {
-            required: true,
-            allowedValues: { type: "text" },
-            defaultVisibility: "editable",
           },
         }, {
           id: "objectToModifyParameter",
@@ -5418,8 +5418,8 @@ describe("Ontology Defining", () => {
                     },
                     "formContentOrdering": [],
                     "parameterOrdering": [
-                      "param1",
                       "param2",
+                      "param1",
                       "objectToModifyParameter",
                     ],
                     "parameters": {
@@ -5488,6 +5488,257 @@ describe("Ontology Defining", () => {
           },
         }
       `);
+    });
+
+    it("Parameter conditions are correctly validated on actions", () => {
+      expect(() =>
+        defineAction({
+          apiName: "foo",
+          displayName: "exampleAction",
+          status: "active",
+          rules: [{
+            type: "modifyObjectRule",
+            modifyObjectRule: {
+              objectToModify: "objectToModifyParameter",
+              propertyValues: {
+                "bar": {
+                  type: "parameterId",
+                  parameterId: "param1",
+                },
+                "foo": {
+                  type: "parameterId",
+                  parameterId: "param2",
+                },
+              },
+              structFieldValues: {},
+            },
+          }],
+          parameters: [{
+            id: "param1",
+            displayName: "param1",
+            type: "boolean",
+            validation: {
+              required: true,
+              allowedValues: { type: "boolean" },
+              defaultVisibility: "editable",
+              conditionalOverrides: [
+                {
+                  type: "visibility",
+                  condition: {
+                    type: "and",
+                    conditions: [
+                      {
+                        type: "group",
+                        name: "myGroup",
+                      },
+                      {
+                        type: "parameter",
+                        parameterId: "param2",
+                        matches: {
+                          type: "staticValue",
+                          staticValue: {
+                            type: "string",
+                            string: "foobar",
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          }, {
+            id: "param2",
+            displayName: "param2",
+            type: "string",
+            validation: {
+              required: true,
+              allowedValues: { type: "text" },
+              defaultVisibility: "editable",
+            },
+          }, {
+            id: "objectToModifyParameter",
+            displayName: "objectToModifyParameter",
+            type: "objectTypeReference",
+            validation: {
+              required: true,
+              allowedValues: {
+                type: "objectTypeReference",
+                interfaceTypes: [],
+              },
+              defaultVisibility: "editable",
+            },
+          }],
+        })
+      ).toThrowError(
+        `Invariant failed: Parameter condition on param1 is referencing later parameter param2`,
+      );
+
+      expect(() =>
+        defineAction({
+          apiName: "foo",
+          displayName: "exampleAction",
+          status: "active",
+          rules: [{
+            type: "modifyObjectRule",
+            modifyObjectRule: {
+              objectToModify: "objectToModifyParameter",
+              propertyValues: {
+                "bar": {
+                  type: "parameterId",
+                  parameterId: "param1",
+                },
+                "foo": {
+                  type: "parameterId",
+                  parameterId: "param2",
+                },
+              },
+              structFieldValues: {},
+            },
+          }],
+          parameters: [{
+            id: "param1",
+            displayName: "param1",
+            type: "boolean",
+            validation: {
+              required: true,
+              allowedValues: { type: "boolean" },
+              defaultVisibility: "editable",
+              conditionalOverrides: [
+                {
+                  type: "visibility",
+                  condition: {
+                    type: "and",
+                    conditions: [
+                      {
+                        type: "group",
+                        name: "myGroup",
+                      },
+                      {
+                        type: "parameter",
+                        parameterId: "param1",
+                        matches: {
+                          type: "staticValue",
+                          staticValue: {
+                            type: "string",
+                            string: "foobar",
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          }, {
+            id: "param2",
+            displayName: "param2",
+            type: "string",
+            validation: {
+              required: true,
+              allowedValues: { type: "text" },
+              defaultVisibility: "editable",
+            },
+          }, {
+            id: "objectToModifyParameter",
+            displayName: "objectToModifyParameter",
+            type: "objectTypeReference",
+            validation: {
+              required: true,
+              allowedValues: {
+                type: "objectTypeReference",
+                interfaceTypes: [],
+              },
+              defaultVisibility: "editable",
+            },
+          }],
+        })
+      ).toThrowError(
+        `Invariant failed: Parameter condition on param1 is referencing itself`,
+      );
+
+      expect(() =>
+        defineAction({
+          apiName: "foo",
+          displayName: "exampleAction",
+          status: "active",
+          rules: [{
+            type: "modifyObjectRule",
+            modifyObjectRule: {
+              objectToModify: "objectToModifyParameter",
+              propertyValues: {
+                "bar": {
+                  type: "parameterId",
+                  parameterId: "param1",
+                },
+                "foo": {
+                  type: "parameterId",
+                  parameterId: "param2",
+                },
+              },
+              structFieldValues: {},
+            },
+          }],
+          parameters: [{
+            id: "param1",
+            displayName: "param1",
+            type: "boolean",
+            validation: {
+              required: true,
+              allowedValues: { type: "boolean" },
+              defaultVisibility: "editable",
+              conditionalOverrides: [
+                {
+                  type: "visibility",
+                  condition: {
+                    type: "and",
+                    conditions: [
+                      {
+                        type: "group",
+                        name: "myGroup",
+                      },
+                      {
+                        type: "parameter",
+                        parameterId: "unknownParam",
+                        matches: {
+                          type: "staticValue",
+                          staticValue: {
+                            type: "string",
+                            string: "foobar",
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          }, {
+            id: "param2",
+            displayName: "param2",
+            type: "string",
+            validation: {
+              required: true,
+              allowedValues: { type: "text" },
+              defaultVisibility: "editable",
+            },
+          }, {
+            id: "objectToModifyParameter",
+            displayName: "objectToModifyParameter",
+            type: "objectTypeReference",
+            validation: {
+              required: true,
+              allowedValues: {
+                type: "objectTypeReference",
+                interfaceTypes: [],
+              },
+              defaultVisibility: "editable",
+            },
+          }],
+        })
+      ).toThrowError(
+        `Invariant failed: Parameter condition on param1 is referencing unknown parameter unknownParam`,
+      );
     });
 
     it("Simple concrete actions are properly defined", () => {

--- a/packages/maker/src/api/types.ts
+++ b/packages/maker/src/api/types.ts
@@ -153,7 +153,8 @@ export interface ActionParameterValidation {
 export type ConditionDefinition =
   | UnionCondition
   | OntologyIrCondition
-  | GroupValidationRule;
+  | GroupValidationRule
+  | ParameterValidationRule;
 
 export type UnionCondition = {
   type: "and" | "or";
@@ -241,6 +242,12 @@ export type ActionLevelValidationDefinition = {
 export type GroupValidationRule = {
   type: "group";
   name: string;
+};
+
+export type ParameterValidationRule = {
+  type: "parameter";
+  parameterId: string;
+  matches: OntologyIrConditionValue;
 };
 
 export type ActionStatus =


### PR DESCRIPTION
Goal is to provide a more intuitive syntax for the commonly used parameter matching condition:
<img width="440" height="186" alt="Screenshot 2025-07-10 at 4 23 32 PM" src="https://github.com/user-attachments/assets/9a9e959d-08fd-48ae-ac19-c70062f6eedf" />

```
{
  type: "parameter",
  parameterId: "param",
  matches: {
    type: "staticValue",
    staticValue: {
      type: "string",
      string: "foobar",
    }
  }
}
```
