### PR TITLE
add validateAction support to useOsdkAction hook

### DIFF
--- a/.changeset/validate-action-feature.md
+++ b/.changeset/validate-action-feature.md
@@ -1,0 +1,41 @@
+---
+"@osdk/client": minor
+"@osdk/react": minor
+---
+
+Add validateAction support to useOsdkAction hook
+
+The `useOsdkAction` hook in `@osdk/react` now provides a `validateAction` function that allows you to check if an action is valid without executing it. This is useful for providing real-time validation feedback to users before they commit to performing an action.
+
+### New features:
+
+- **validateAction**: A new async function that validates action parameters without executing the action
+- **isValidating**: A boolean state that indicates when validation is in progress
+- **validationResult**: Contains the validation response from the server, including whether the action is valid and any validation errors
+
+### Example usage:
+
+```tsx
+const {
+  applyAction,
+  validateAction,
+  isValidating,
+  validationResult,
+} = useOsdkAction(myAction);
+
+// Validate without executing
+await validateAction({ param1: "value" });
+
+// Check validation result
+if (validationResult?.result === "VALID") {
+  console.log("Action is valid!");
+} else {
+  console.log("Validation failed:", validationResult);
+}
+```
+
+### Implementation details:
+
+- Multiple validation calls can be made - new calls automatically cancel previous pending validations
+- Validation and action execution are mutually exclusive - you cannot validate while an action is being applied and vice versa
+- The underlying `ObservableClient` in `@osdk/client` has been extended with a `validateAction` method to support this functionality

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -16,6 +16,7 @@
 
 import type {
   ActionDefinition,
+  ActionValidationResponse,
   InterfaceDefinition,
   ObjectTypeDefinition,
   Osdk,
@@ -115,6 +116,11 @@ export interface ObservableClient {
       | Array<Parameters<ActionSignatureFromDef<Q>["applyAction"]>[0]>,
     opts?: ObservableClient.ApplyActionOptions,
   ) => Promise<unknown>;
+
+  validateAction: <Q extends ActionDefinition<any>>(
+    action: Q,
+    args: Parameters<ActionSignatureFromDef<Q>["applyAction"]>[0],
+  ) => Promise<ActionValidationResponse>;
 
   canonicalizeWhereClause: <
     T extends ObjectTypeDefinition | InterfaceDefinition,

--- a/packages/client/src/observable/internal/ObservableClientImpl.ts
+++ b/packages/client/src/observable/internal/ObservableClientImpl.ts
@@ -16,6 +16,7 @@
 
 import type {
   ActionDefinition,
+  ActionValidationResponse,
   InterfaceDefinition,
   ObjectTypeDefinition,
   PrimaryKeyType,
@@ -48,6 +49,7 @@ export class ObservableClientImpl implements ObservableClient {
     ) as typeof this.observeObject;
     this.observeList = store.observeList.bind(store) as typeof this.observeList;
     this.applyAction = store.applyAction.bind(store);
+    this.validateAction = store.validateAction.bind(store);
     this.canonicalizeWhereClause = store.canonicalizeWhereClause.bind(
       store,
     ) as typeof this.canonicalizeWhereClause;
@@ -70,6 +72,11 @@ export class ObservableClientImpl implements ObservableClient {
     args: Parameters<ActionSignatureFromDef<Q>["applyAction"]>[0],
     opts?: ObservableClient.ApplyActionOptions,
   ) => Promise<unknown>;
+
+  public validateAction: <Q extends ActionDefinition<any>>(
+    action: Q,
+    args: Parameters<ActionSignatureFromDef<Q>["applyAction"]>[0],
+  ) => Promise<ActionValidationResponse>;
 
   public canonicalizeWhereClause: <
     T extends ObjectTypeDefinition | InterfaceDefinition,

--- a/packages/client/src/observable/internal/Store.ts
+++ b/packages/client/src/observable/internal/Store.ts
@@ -17,6 +17,7 @@
 import type {
   ActionDefinition,
   ActionEditResponse,
+  ActionValidationResponse,
   InterfaceDefinition,
   Logger,
   ObjectTypeDefinition,
@@ -250,6 +251,17 @@ export class Store {
     opts?: Store.ApplyActionOptions,
   ) => Promise<ActionEditResponse> = async (action, args, opts) => {
     return await new ActionApplication(this).applyAction(action, args, opts);
+  };
+
+  validateAction: <Q extends ActionDefinition<any>>(
+    action: Q,
+    args: Parameters<ActionSignatureFromDef<Q>["applyAction"]>[0],
+  ) => Promise<ActionValidationResponse> = async (action, args) => {
+    const result = await this.client(action).applyAction(args as any, {
+      $validateOnly: true,
+      $returnEdits: false,
+    });
+    return result as ActionValidationResponse;
   };
 
   removeLayer(layerId: OptimisticId): void {

--- a/packages/e2e.sandbox.todoapp/src/App.tsx
+++ b/packages/e2e.sandbox.todoapp/src/App.tsx
@@ -7,6 +7,7 @@ import type { TodoLike } from "./generatedNoCheck2/index.js";
 import { H1 } from "./H2.js";
 import { Section } from "./Section.js";
 import TodoList from "./TodoList.js";
+import ValidateActionDemo from "./ValidateActionDemo.js";
 
 function App() {
   const [whereClause, setWhereClause] = React.useState<WhereClause<TodoLike>>(
@@ -29,11 +30,9 @@ function App() {
             <CreateTodoForm />
           </Section>
 
-          {
-            /* <Section>
-            <SpecificTodo />
-          </Section> */
-          }
+          <Section>
+            <ValidateActionDemo />
+          </Section>
 
           <Section>
             <FilterSelector
@@ -41,12 +40,6 @@ function App() {
               heading="<-- Filter"
             />
           </Section>
-          {
-            /*
-          <Section>
-            <SpecificTodo />
-          </Section> */
-          }
         </div>
       </div>
     </main>

--- a/packages/e2e.sandbox.todoapp/src/ValidateActionDemo.tsx
+++ b/packages/e2e.sandbox.todoapp/src/ValidateActionDemo.tsx
@@ -1,0 +1,183 @@
+import { useOsdkAction } from "@osdk/react/experimental";
+import React from "react";
+import { Button } from "./Button.js";
+import { $Actions, Todo } from "./generatedNoCheck2/index.js";
+import { H2 } from "./H2.js";
+import { InlineSpinner } from "./InlineSpinner.js";
+
+export default function ValidateActionDemo() {
+  const [todoTitle, setTodoTitle] = React.useState("");
+  const [validationMessage, setValidationMessage] = React.useState<string>("");
+
+  const {
+    applyAction,
+    isPending,
+    error,
+    isValidating,
+    validateAction,
+    validationResult,
+  } = useOsdkAction($Actions.createTodo);
+
+  // Use effect to update message when validation result changes
+  React.useEffect(() => {
+    if (validationResult) {
+      if (validationResult.result === "VALID") {
+        setValidationMessage("✅ Action is valid!");
+      } else if (validationResult.result === "INVALID") {
+        const failedParams: string[] = [];
+        for (
+          const [name, constraint] of Object.entries(
+            validationResult.parameters || {},
+          )
+        ) {
+          if (constraint.result === "INVALID") {
+            failedParams.push(name);
+          }
+        }
+
+        const failedCriteria = validationResult.submissionCriteria
+          ?.filter(criteria => criteria.result === "INVALID")
+          .map(criteria =>
+            criteria.configuredFailureMessage || "Failed criteria"
+          )
+          || [];
+
+        setValidationMessage(
+          `❌ Validation failed: ${
+            [...failedParams, ...failedCriteria].join(", ") || "Invalid action"
+          }`,
+        );
+      }
+    }
+  }, [validationResult]);
+
+  const handleValidate = React.useCallback(async () => {
+    setValidationMessage("Validating...");
+
+    try {
+      await validateAction({
+        is_complete: false,
+        Todo: todoTitle,
+        location: "0,0",
+      });
+    } catch (err) {
+      setValidationMessage(`❌ Validation error: ${err}`);
+    }
+  }, [todoTitle, validateAction]);
+
+  const handleSubmit = React.useCallback(async () => {
+    if (!todoTitle.trim()) {
+      setValidationMessage("❌ Title cannot be empty");
+      return;
+    }
+
+    try {
+      await applyAction({
+        is_complete: false,
+        Todo: todoTitle,
+        location: "0,0",
+        $optimisticUpdate: (b) => {
+          const id = "TMP " + window.crypto.randomUUID();
+          b.createObject(Todo, id, {
+            title: todoTitle,
+            id,
+            isComplete: false,
+            location: undefined,
+          });
+        },
+      });
+
+      // Reset on success
+      setTodoTitle("");
+      setValidationMessage("✅ Todo created successfully!");
+    } catch (err) {
+      setValidationMessage(`❌ Error creating todo: ${err}`);
+    }
+  }, [todoTitle, applyAction]);
+
+  return (
+    <>
+      <H2>
+        Validate Action Demo
+        <InlineSpinner isLoading={isPending || isValidating} />
+      </H2>
+
+      <div className="mb-4">
+        <input
+          type="text"
+          value={todoTitle}
+          onChange={(e) => {
+            setTodoTitle(e.target.value);
+            setValidationMessage(""); // Clear message on input change
+          }}
+          placeholder="Enter todo title"
+          disabled={isPending || isValidating}
+          aria-disabled={isPending || isValidating}
+          className="py-2 px-2 mr-4 mb-2 border-gray-500 rounded-lg text-sm border-2 w-full
+            disabled:opacity-90
+            disabled:pointer-events-none 
+            disabled:border-gray-200
+            focus:border-blue-500 focus:ring-blue-500"
+        />
+
+        <div className="flex gap-2 mb-2">
+          <Button
+            onClick={handleValidate}
+            disabled={isPending || isValidating || !todoTitle.trim()}
+          >
+            {isValidating ? "Validating..." : "Validate"}
+          </Button>
+
+          <Button
+            onClick={handleSubmit}
+            disabled={isPending || isValidating || !todoTitle.trim()}
+          >
+            {isPending ? "Creating..." : "Create Todo"}
+          </Button>
+        </div>
+
+        {validationMessage && (
+          <div
+            className={`text-sm ${
+              validationMessage.includes("✅")
+                ? "text-green-600"
+                : "text-red-600"
+            }`}
+          >
+            {validationMessage}
+          </div>
+        )}
+
+        {error && (
+          <div className="error mt-2">
+            <pre className="text-xs">{JSON.stringify(error, null, 2)}</pre>
+          </div>
+        )}
+
+        {validationResult && (
+          <div className="mt-2 p-2 bg-gray-100 rounded text-xs">
+            <strong>Validation Result:</strong>
+            <pre>{JSON.stringify(validationResult, null, 2)}</pre>
+          </div>
+        )}
+      </div>
+
+      <div className="text-xs text-gray-600 mt-4">
+        <p>This demo shows the new validateAction functionality:</p>
+        <ul className="list-disc list-inside mt-1">
+          <li>
+            Enter a todo title and click &quot;Validate&quot; to check if the
+            action is valid
+          </li>
+          <li>The validation runs without performing the action</li>
+          <li>isValidating state shows when validation is in progress</li>
+          <li>validationResult contains the validation response</li>
+          <li>
+            Multiple validations can be triggered - new ones cancel previous
+            ones
+          </li>
+        </ul>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
- Add validateAction method to ObservableClient in @osdk/client
- Implement validateAction, isValidating, and validationResult in useOsdkAction hook
- Support action validation without execution for real-time feedback
- Add automatic cancellation for multiple validation requests
- Ensure mutual exclusion between validation and action execution
- Add comprehensive documentation and demo component
- Update React package getting started guide with validation examples

BREAKING CHANGE: None - this is a backwards-compatible addition

This feature allows developers to validate action parameters before execution, providing better UX through real-time validation feedback without performing the actual action.