### PR TITLE
feat(react): Add OsdkContext support to OsdkProvider2 for backward co…

### DIFF
--- a/.changeset/loose-socks-like.md
+++ b/.changeset/loose-socks-like.md
@@ -1,0 +1,7 @@
+---
+"@osdk/react": patch
+---
+
+Add backward compatibility to OsdkProvider2 by also providing OsdkContext
+
+OsdkProvider2 now provides both OsdkContext2 and the original OsdkContext, enabling existing hooks like useOsdkClient and useOsdkMetadata to work with OsdkProvider2. This allows OsdkProvider2 to serve as a complete replacement for OsdkProvider while maintaining backward compatibility.

--- a/packages/react/src/new/OsdkProvider2.tsx
+++ b/packages/react/src/new/OsdkProvider2.tsx
@@ -20,6 +20,7 @@ import {
   type ObservableClient,
 } from "@osdk/client/unstable-do-not-use";
 import React, { useMemo } from "react";
+import { OsdkContext } from "../OsdkContext.js";
 import { OsdkContext2 } from "./OsdkContext2.js";
 
 interface OsdkProviderOptions {
@@ -39,7 +40,9 @@ export function OsdkProvider2({
   );
   return (
     <OsdkContext2.Provider value={{ client, observableClient }}>
-      {children}
+      <OsdkContext.Provider value={{ client }}>
+        {children}
+      </OsdkContext.Provider>
     </OsdkContext2.Provider>
   );
 }


### PR DESCRIPTION
…mpatibility

- Wrap children with both OsdkContext2.Provider and OsdkContext.Provider
- Enables useOsdkClient and useOsdkMetadata to work with OsdkProvider2
- Maintains compatibility with all existing hooks while supporting new observable features