### PR TITLE
fix: fix agg template ts

### DIFF
--- a/.changeset/clever-waves-lead.md
+++ b/.changeset/clever-waves-lead.md
@@ -1,0 +1,5 @@
+---
+"@osdk/typescript-sdk-docs": patch
+---
+
+fix aggregation doc example

--- a/packages/typescript-sdk-docs/src/documentation.yml
+++ b/packages/typescript-sdk-docs/src/documentation.yml
@@ -1113,7 +1113,7 @@ versions:
             import { client } from "./client";
 
             const num{{objectType}} = await client({{objectType}})
-                .where({{property}}: { $isNull : false })
+                .where({{{property}}: { $isNull : false }})
                 .aggregate({
                     $select: { $count: "unordered" },
                     $groupBy: { name: "exact" },


### PR DESCRIPTION
Agg template TS is wrong

currently looks like

```
import { MyObject } from "@ontology/sdk";
// Edit this import if your client location differs
import { client } from "./client";

const numMyObjectSeriesid = await client(MyObject)
    .where(pk: { $isNull : false })
    .aggregate({
        $select: { $count: "unordered" },
        $groupBy: { name: "exact" },
    });
```

but should be 

```
import { MyObject } from "@ontology/sdk";
// Edit this import if your client location differs
import { client } from "./client";

const numMyObjectSeriesid = await client(MyObject)
    .where({pk: { $isNull : false }})
    .aggregate({
        $select: { $count: "unordered" },
        $groupBy: { name: "exact" },
    });
```
