### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -160,6 +160,7 @@
     "bright-dancers-wash",
     "chubby-buses-juggle",
     "clever-waves-lead",
+    "curvy-kings-mate",
     "dirty-needles-dream",
     "dry-donkeys-travel",
     "dull-parents-stare",

--- a/packages/oauth/CHANGELOG.md
+++ b/packages/oauth/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/oauth
 
+## 1.4.0-beta.2
+
+### Minor Changes
+
+- 8c8ecf0: Added Public Apps Support
+
 ## 1.2.0
 
 ### Patch Changes

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/oauth",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/oauth@1.4.0-beta.2

### Minor Changes

-   8c8ecf0: Added Public Apps Support
