### PR TITLE
Remove widgetset unstable command copy

### DIFF
--- a/.changeset/legal-nights-do.md
+++ b/.changeset/legal-nights-do.md
@@ -1,0 +1,5 @@
+---
+"@osdk/cli": minor
+---
+
+Remove @osdk/cli widgetset unstable command. The widgetset command is available without the unstable subcommand.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -45,8 +45,6 @@ export async function cli(args: string[] = process.argv): Promise<
           return argv
             .command(typescript)
             .command(auth)
-            // TODO: Remove copy of widgetset command from unstable once we've moved over templates
-            .command(widgetSet)
             .demandCommand();
         },
         handler: (_args) => {},


### PR DESCRIPTION
The `widgetset` command has been available without the `unstable` subcommand since https://github.com/palantir/osdk-ts/pull/1622

Removing the copy of the command under the `unstable` subcommand now that we are no longer supporting this under `unstable`