### PR TITLE
Sort arrays in generator-converters for stable output

### DIFF
--- a/.changeset/sorted-arrays-stabilize.md
+++ b/.changeset/sorted-arrays-stabilize.md
@@ -1,0 +1,6 @@
+---
+"@osdk/generator-converters": patch
+"@osdk/generator": patch
+---
+
+Ensure stable ordering of arrays in code generation for object types and interface types. Sort `implements`, `implementedBy` and `linkTypes` arrays alphabetically for consistent output.

--- a/packages/client/src/object/convertWireToOsdkObjects.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.test.ts
@@ -68,9 +68,9 @@ describe("convertWireToOsdkObjects", () => {
 
     expect(Object.keys(employee.$as)).toEqual([]);
     expect(Object.keys(employee.$link)).toEqual([
-      "peeps",
       "lead",
       "officeLink",
+      "peeps",
     ]);
   });
 

--- a/packages/generator-converters/src/__UNSTABLE_wireInterfaceTypeV2ToSdkObjectDefinition.test.ts
+++ b/packages/generator-converters/src/__UNSTABLE_wireInterfaceTypeV2ToSdkObjectDefinition.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { __UNSTABLE_wireInterfaceTypeV2ToSdkObjectDefinition } from "./__UNSTABLE_wireInterfaceTypeV2ToSdkObjectDefinition.js";
+
+describe("__UNSTABLE_wireInterfaceTypeV2ToSdkObjectDefinition", () => {
+  it("sorts the implements array for stable output", () => {
+    const result = __UNSTABLE_wireInterfaceTypeV2ToSdkObjectDefinition({
+      apiName: "TestInterface",
+      rid: "testRid",
+      displayName: "Test Interface",
+      description: "A test interface",
+      properties: {},
+      allProperties: {},
+      extendsInterfaces: ["ParentZ", "ParentA", "ParentC"],
+      allExtendsInterfaces: ["ParentZ", "ParentA", "ParentC"],
+      implementedByObjectTypes: [],
+      links: {},
+      allLinks: {},
+    }, true);
+
+    expect(result.implements).toEqual(["ParentA", "ParentC", "ParentZ"]);
+  });
+
+  it("sorts the implementedBy array for stable output", () => {
+    const result = __UNSTABLE_wireInterfaceTypeV2ToSdkObjectDefinition({
+      apiName: "TestInterface",
+      rid: "testRid",
+      displayName: "Test Interface",
+      description: "A test interface",
+      properties: {},
+      allProperties: {},
+      extendsInterfaces: [],
+      allExtendsInterfaces: [],
+      implementedByObjectTypes: ["ObjectZ", "ObjectA", "ObjectC"],
+      links: {},
+      allLinks: {},
+    }, true);
+
+    expect(result.implementedBy).toEqual(["ObjectA", "ObjectC", "ObjectZ"]);
+  });
+});

--- a/packages/generator-converters/src/__UNSTABLE_wireInterfaceTypeV2ToSdkObjectDefinition.test.ts
+++ b/packages/generator-converters/src/__UNSTABLE_wireInterfaceTypeV2ToSdkObjectDefinition.test.ts
@@ -53,4 +53,24 @@ describe("__UNSTABLE_wireInterfaceTypeV2ToSdkObjectDefinition", () => {
 
     expect(result.implementedBy).toEqual(["ObjectA", "ObjectC", "ObjectZ"]);
   });
+
+  it("preserves empty arrays", () => {
+    const result = __UNSTABLE_wireInterfaceTypeV2ToSdkObjectDefinition({
+      apiName: "TestInterface",
+      rid: "testRid",
+      displayName: "Test Interface",
+      description: "A test interface",
+      properties: {},
+      allProperties: {},
+      extendsInterfaces: [],
+      allExtendsInterfaces: [],
+      implementedByObjectTypes: [],
+      links: {},
+      allLinks: {},
+    }, true);
+
+    // Empty arrays should remain as empty arrays
+    expect(result.implements).toEqual([]);
+    expect(result.implementedBy).toEqual([]);
+  });
 });

--- a/packages/generator-converters/src/__UNSTABLE_wireInterfaceTypeV2ToSdkObjectDefinition.ts
+++ b/packages/generator-converters/src/__UNSTABLE_wireInterfaceTypeV2ToSdkObjectDefinition.ts
@@ -35,7 +35,7 @@ export function __UNSTABLE_wireInterfaceTypeV2ToSdkObjectDefinition(
       )
       : interfaceType.extendsInterfaces
       ? [...interfaceType.extendsInterfaces].sort((a, b) => a.localeCompare(b))
-      : [],
+      : undefined,
     properties: Object.fromEntries(
       Object.entries(interfaceType.allProperties ?? interfaceType.properties)
         .map((
@@ -56,6 +56,6 @@ export function __UNSTABLE_wireInterfaceTypeV2ToSdkObjectDefinition(
       ? [...interfaceType.implementedByObjectTypes].sort((a, b) =>
         a.localeCompare(b)
       )
-      : [],
+      : interfaceType.implementedByObjectTypes,
   };
 }

--- a/packages/generator-converters/src/__UNSTABLE_wireInterfaceTypeV2ToSdkObjectDefinition.ts
+++ b/packages/generator-converters/src/__UNSTABLE_wireInterfaceTypeV2ToSdkObjectDefinition.ts
@@ -30,7 +30,12 @@ export function __UNSTABLE_wireInterfaceTypeV2ToSdkObjectDefinition(
     displayName: interfaceType.displayName,
     description: interfaceType.description,
     implements: interfaceType.allExtendsInterfaces
-      ?? interfaceType.extendsInterfaces,
+      ? [...interfaceType.allExtendsInterfaces].sort((a, b) =>
+        a.localeCompare(b)
+      )
+      : interfaceType.extendsInterfaces
+      ? [...interfaceType.extendsInterfaces].sort((a, b) => a.localeCompare(b))
+      : [],
     properties: Object.fromEntries(
       Object.entries(interfaceType.allProperties ?? interfaceType.properties)
         .map((
@@ -44,9 +49,13 @@ export function __UNSTABLE_wireInterfaceTypeV2ToSdkObjectDefinition(
               log,
             ),
           ];
-        }).filter(([key, value]) => value != null),
+        }).filter(([_, value]) => value != null),
     ),
     links: {},
-    implementedBy: interfaceType.implementedByObjectTypes,
+    implementedBy: interfaceType.implementedByObjectTypes
+      ? [...interfaceType.implementedByObjectTypes].sort((a, b) =>
+        a.localeCompare(b)
+      )
+      : [],
   };
 }

--- a/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectMetadata.test.ts
+++ b/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectMetadata.test.ts
@@ -127,4 +127,92 @@ describe(wireObjectTypeFullMetadataToSdkObjectMetadata, () => {
     expect(result.visibility).toBeUndefined();
     expect(result.icon).toBeUndefined();
   });
+
+  it("sorts the implements array for stable output", () => {
+    const result = wireObjectTypeFullMetadataToSdkObjectMetadata({
+      implementsInterfaces: ["InterfaceZ", "InterfaceA", "InterfaceC"],
+      implementsInterfaces2: {
+        "InterfaceZ": { properties: {} },
+        "InterfaceA": { properties: {} },
+        "InterfaceC": { properties: {} },
+      },
+      linkTypes: [],
+      objectType: {
+        apiName: "apiName",
+        description: "description",
+        displayName: "displayName",
+        pluralDisplayName: "displayNames",
+        icon: { type: "blueprint", name: "blueprint", color: "blue" },
+        primaryKey: "primaryKey",
+        properties: {
+          primaryKey: { dataType: { type: "string" }, "rid": "rid" },
+        },
+        rid: "rid",
+        status: "ACTIVE",
+        titleProperty: "primaryKey",
+      },
+      sharedPropertyTypeMapping: {},
+    }, true);
+
+    // Check that the array is sorted alphabetically
+    expect(result.implements).toEqual([
+      "InterfaceA",
+      "InterfaceC",
+      "InterfaceZ",
+    ]);
+  });
+
+  it("sorts the linkTypes array for stable output", () => {
+    const result = wireObjectTypeFullMetadataToSdkObjectMetadata({
+      implementsInterfaces: [],
+      implementsInterfaces2: {},
+      linkTypes: [
+        {
+          apiName: "linkZ",
+          cardinality: "ONE",
+          objectTypeApiName: "TargetZ",
+          displayName: "LinkZ",
+          status: "ACTIVE",
+          linkTypeRid: "ridZ",
+        },
+        {
+          apiName: "linkA",
+          cardinality: "MANY",
+          objectTypeApiName: "TargetA",
+          displayName: "LinkA",
+          status: "ACTIVE",
+          linkTypeRid: "ridA",
+        },
+        {
+          apiName: "linkC",
+          cardinality: "ONE",
+          objectTypeApiName: "TargetC",
+          displayName: "LinkC",
+          status: "ACTIVE",
+          linkTypeRid: "ridC",
+        },
+      ],
+      objectType: {
+        apiName: "apiName",
+        description: "description",
+        displayName: "displayName",
+        pluralDisplayName: "displayNames",
+        icon: { type: "blueprint", name: "blueprint", color: "blue" },
+        primaryKey: "primaryKey",
+        properties: {
+          primaryKey: { dataType: { type: "string" }, "rid": "rid" },
+        },
+        rid: "rid",
+        status: "ACTIVE",
+        titleProperty: "primaryKey",
+      },
+      sharedPropertyTypeMapping: {},
+    }, true);
+
+    // Get the link keys in the order they appear in the result
+    const linkKeys = Object.keys(result.links);
+
+    // Check that the links are sorted alphabetically by apiName
+    expect(linkKeys).toEqual(["linkA", "linkC", "linkZ"]);
+  });
 });

--- a/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectMetadata.test.ts
+++ b/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectMetadata.test.ts
@@ -215,4 +215,30 @@ describe(wireObjectTypeFullMetadataToSdkObjectMetadata, () => {
     // Check that the links are sorted alphabetically by apiName
     expect(linkKeys).toEqual(["linkA", "linkC", "linkZ"]);
   });
+
+  it("preserves empty arrays", () => {
+    const result = wireObjectTypeFullMetadataToSdkObjectMetadata({
+      implementsInterfaces: [],
+      implementsInterfaces2: {},
+      linkTypes: [],
+      objectType: {
+        apiName: "apiName",
+        description: "description",
+        displayName: "displayName",
+        pluralDisplayName: "displayNames",
+        icon: { type: "blueprint", name: "blueprint", color: "blue" },
+        primaryKey: "primaryKey",
+        properties: {
+          primaryKey: { dataType: { type: "string" }, "rid": "rid" },
+        },
+        rid: "rid",
+        status: "ACTIVE",
+        titleProperty: "primaryKey",
+      },
+      sharedPropertyTypeMapping: {},
+    }, true);
+
+    // Check that empty array is preserved
+    expect(result.implements).toEqual([]);
+  });
 });

--- a/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectMetadata.ts
+++ b/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectMetadata.ts
@@ -68,12 +68,16 @@ export function wireObjectTypeFullMetadataToSdkObjectMetadata(
       objectTypeWithLink.objectType
         .properties[objectTypeWithLink.objectType.primaryKey],
     ),
-    links: Object.fromEntries(objectTypeWithLink.linkTypes.map(linkType => {
-      return [linkType.apiName, {
-        multiplicity: linkType.cardinality === "MANY",
-        targetType: linkType.objectTypeApiName,
-      }];
-    })),
+    links: Object.fromEntries(
+      [...objectTypeWithLink.linkTypes].sort((a, b) =>
+        a.apiName.localeCompare(b.apiName)
+      ).map(linkType => {
+        return [linkType.apiName, {
+          multiplicity: linkType.cardinality === "MANY",
+          targetType: linkType.objectTypeApiName,
+        }];
+      }),
+    ),
     properties: Object.fromEntries(
       Object.entries(objectTypeWithLink.objectType.properties).map((
         [key, value],
@@ -84,9 +88,13 @@ export function wireObjectTypeFullMetadataToSdkObjectMetadata(
           !(v2 && objectTypeWithLink.objectType.primaryKey === key),
           log,
         ),
-      ]).filter(([key, value]) => value != null),
+      ]).filter(([_, value]) => value != null),
     ),
-    implements: objectTypeWithLink.implementsInterfaces as string[],
+    implements: objectTypeWithLink.implementsInterfaces
+      ? [...objectTypeWithLink.implementsInterfaces].sort((a, b) =>
+        a.localeCompare(b)
+      )
+      : [],
     interfaceMap,
     inverseInterfaceMap: Object.fromEntries(
       Object.entries(interfaceMap).map((

--- a/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectMetadata.ts
+++ b/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectMetadata.ts
@@ -94,7 +94,7 @@ export function wireObjectTypeFullMetadataToSdkObjectMetadata(
       ? [...objectTypeWithLink.implementsInterfaces].sort((a, b) =>
         a.localeCompare(b)
       )
-      : [],
+      : objectTypeWithLink.implementsInterfaces,
     interfaceMap,
     inverseInterfaceMap: Object.fromEntries(
       Object.entries(interfaceMap).map((

--- a/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.test.ts
+++ b/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.test.ts
@@ -502,4 +502,43 @@ describe(__UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst, () => {
       "
     `);
   });
+
+  it("sorts the implements array for stable output", async () => {
+    // Test with multiple parent interfaces in non-alphabetical order
+    const ontology = enhanceOntology({
+      sanitized: simpleOntology("ontology", [
+        simpleInterface("Child", [simpleSpt("child")], [
+          "ParentZ",
+          "ParentA",
+          "ParentC",
+        ]),
+        simpleInterface("ParentZ", [simpleSpt("z")], []),
+        simpleInterface("ParentA", [simpleSpt("a")], []),
+        simpleInterface("ParentC", [simpleSpt("c")], []),
+      ]),
+      importExt: "",
+    });
+
+    const formattedCode = await format(
+      __UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst(
+        ontology.interfaceTypes.Child as EnhancedInterfaceType,
+        ontology,
+        true,
+        true,
+      ),
+      {
+        parser: "typescript",
+      },
+    );
+
+    // Extract the implements array from the generated code
+    const implementsMatch = formattedCode.match(/implements:\s*\[([^\]]+)\]/s);
+    expect(implementsMatch).not.toBeNull();
+
+    if (implementsMatch) {
+      const implementsStr = implementsMatch[1];
+      // Check that the array is sorted alphabetically
+      expect(implementsStr).toContain("\"ParentA\", \"ParentC\", \"ParentZ\"");
+    }
+  });
 });


### PR DESCRIPTION
- Sort implements arrays in both interface types and object types
- Sort implementedBy arrays in interface types
- Sort linkTypes arrays in object types
- Add comprehensive tests for all sorting behaviors
- Fix unused variable TypeScript warnings

These changes ensure more stable and deterministic code generation, avoiding unnecessary differences in generated code when nothing significant has changed.