### PR TITLE
Fix text allowed values on ontology IR

### DIFF
--- a/packages/maker/src/api/defineOntology.ts
+++ b/packages/maker/src/api/defineOntology.ts
@@ -1140,10 +1140,10 @@ function extractAllowedValues(
           text: {
             ...(minLength === undefined
               ? {}
-              : { minimumLength: minLength }),
+              : { minLength: minLength }),
             ...(maxLength === undefined
               ? {}
-              : { maximumLength: maxLength }),
+              : { maxLength: maxLength }),
             ...(regex === undefined
               ? {}
               : { regex: { regex: regex, failureMessage: "Invalid input" } }),


### PR DESCRIPTION
We used a different name for minLength and maxLength, so they weren't being deserialized in OMS