### PR TITLE
Add Array.fromAsync docs for fetching all objects

### DIFF
--- a/.changeset/fresh-chefs-follow.md
+++ b/.changeset/fresh-chefs-follow.md
@@ -1,0 +1,5 @@
+---
+"@osdk/typescript-sdk-docs": patch
+---
+
+Update load all objects snippet

--- a/packages/typescript-sdk-docs/src/documentation.yml
+++ b/packages/typescript-sdk-docs/src/documentation.yml
@@ -1070,12 +1070,19 @@ versions:
             import { client } from "./client";
             import type { Osdk } from "@osdk/client";
 
-            const objects: Osdk.Instance<{{objectType}}>[]= [];
+            async function getAll(): Promise<Array<Osdk.Instance<{{objectType}}>>> {
+                const objects: Osdk.Instance<{{objectType}}>[]= [];
+                for await(const obj of client({{objectType}}).asyncIter()) {
+                    objects.push(obj);
+                }
 
-            for await(const obj of client({{objectType}}).asyncIter()) {
-                objects.push(obj);
+                return objects;
             }
-            const object = objects[0];
+
+            // If Array.fromAsync() is available in your target environment
+            function getAllFromAsync(): Promise<Array<Osdk.Instance<{{objectType}}>>> {
+                return Array.fromAsync(client({{objectType}}).asyncIter());
+            }
       loadLinkedObjectReference:
         - template: |-
             import { {{sourceObjectType}}, {{linkedObjectType}} } from "{{{packageName}}}";


### PR DESCRIPTION
Modify snippet to add example of using `Array.fromAsync(..)`. Callout that it may not be available in all environments.