### PR TITLE
Fix assignability of struct fields

### DIFF
--- a/.changeset/public-results-attack.md
+++ b/.changeset/public-results-attack.md
@@ -1,0 +1,5 @@
+---
+"@osdk/api": patch
+---
+
+Fix assignability for creating struct fields.

--- a/packages/api/src/mapping/PropertyValueMapping.ts
+++ b/packages/api/src/mapping/PropertyValueMapping.ts
@@ -122,5 +122,5 @@ export type GetCreatePropertyValueFromWire<
     | Record<string, keyof PropertyValueWireToCreate>,
 > = T extends keyof PropertyValueWireToCreate ? PropertyValueWireToCreate[T]
   : T extends Record<string, keyof PropertyValueWireToCreate>
-    ? { [K in keyof T]: PropertyValueWireToCreate[T[K]] }
+    ? { [K in keyof T]: PropertyValueWireToCreate[T[K]] | undefined }
   : never;


### PR DESCRIPTION
Struct fields are nullable by default, so when using them for editbatch, need to make sure we make each individual field potentially undefined as well.

We are not modifying code gen so that we can have more flexibility once value types become more heavily used. 