### PR TITLE
Use SPT api names for interface properties and improve interface action validation

### DIFF
--- a/.changeset/yummy-eels-try.md
+++ b/.changeset/yummy-eels-try.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker": patch
+---
+
+Improve interface action validation

--- a/packages/maker/src/api/defineAction.ts
+++ b/packages/maker/src/api/defineAction.ts
@@ -22,6 +22,7 @@ import {
   getAllInterfaceProperties,
 } from "./defineObject.js";
 import {
+  importedTypes,
   namespace,
   ontologyDefinition,
   updateOntology,
@@ -592,6 +593,79 @@ export function defineAction(actionDef: ActionTypeDefinition): ActionType {
         parameterIds.some(id => id === rule.deleteObjectRule.objectToDelete),
         `Object to delete parameter must be defined in parameters`,
       );
+    }
+    if (rule.type === "modifyInterfaceRule") {
+      // all referenced SPTs exist globally
+      Object.keys(rule.modifyInterfaceRule.sharedPropertyValues).forEach(
+        spt => {
+          invariant(
+            ontologyDefinition.SHARED_PROPERTY_TYPE[spt] !== undefined
+              || importedTypes.SHARED_PROPERTY_TYPE[spt] !== undefined,
+            `Shared property type ${spt} does not exist.
+            If this SPT was imported, you may need to use [spt.apiName] as the key so that it is qualified with the right namespace`,
+          );
+        },
+      );
+
+      // The there must be a parameter for the interface, and the interface there must exist
+      const interfaceParam = actionDef.parameters!.find(p =>
+        p.id === rule.modifyInterfaceRule.interfaceObjectToModifyParameter
+      );
+      invariant(
+        interfaceParam !== undefined && typeof interfaceParam.type === "object"
+          && (interfaceParam.type.type === "interfaceReference"
+            || interfaceParam.type.type === "interfaceReferenceList"),
+        `Interface object to modify parameter must be an interface reference`,
+      );
+      const interfaceReference =
+        interfaceParam.type.type === "interfaceReference"
+          ? interfaceParam.type.interfaceReference.interfaceTypeRid
+          : interfaceParam.type.interfaceReferenceList.interfaceTypeRid;
+      invariant(
+        ontologyDefinition.INTERFACE_TYPE[interfaceReference] !== undefined
+          || importedTypes.INTERFACE_TYPE[interfaceReference] !== undefined,
+        `Interface type ${interfaceReference} does not exist`,
+      );
+
+      // All referenced SPTs must exist on the interface
+      const interfaceType =
+        ontologyDefinition.INTERFACE_TYPE[interfaceReference];
+      Object.keys(rule.modifyInterfaceRule.sharedPropertyValues).forEach(
+        spt => {
+          invariant(
+            interfaceType.propertiesV2[spt] !== undefined,
+            `Shared property type ${spt} does not exist in interface type ${interfaceReference}`,
+          );
+        },
+      );
+    }
+    if (rule.type === "addInterfaceRule") {
+      // All referenced SPTs must exist globally
+      Object.keys(rule.addInterfaceRule.sharedPropertyValues).forEach(spt => {
+        invariant(
+          ontologyDefinition.SHARED_PROPERTY_TYPE[spt] !== undefined
+            || importedTypes.SHARED_PROPERTY_TYPE[spt] !== undefined,
+          `Shared property type ${spt} does not exist. 
+          If this SPT was imported, you may need to use [spt.apiName] as the key so that it is qualified with the right namespace`,
+        );
+      });
+
+      // The referenced interface must exist globally
+      const interfaceType = ontologyDefinition
+        .INTERFACE_TYPE[rule.addInterfaceRule.interfaceApiName]
+        ?? importedTypes.INTERFACE_TYPE[rule.addInterfaceRule.interfaceApiName];
+      invariant(
+        interfaceType !== undefined,
+        `Interface type ${rule.addInterfaceRule.interfaceApiName} does not exist`,
+      );
+
+      // All referenced SPTs must exist on the interface
+      Object.keys(rule.addInterfaceRule.sharedPropertyValues).forEach(spt => {
+        invariant(
+          interfaceType.propertiesV2[spt] !== undefined,
+          `Shared property type ${spt} does not exist in interface type ${interfaceType.apiName}`,
+        );
+      });
     }
   });
 

--- a/packages/maker/src/api/defineInterface.ts
+++ b/packages/maker/src/api/defineInterface.ts
@@ -18,6 +18,7 @@ import invariant from "tiny-invariant";
 import {
   namespace,
   ontologyDefinition,
+  sanitize,
   updateOntology,
   withoutNamespace,
 } from "./defineOntology.js";
@@ -70,23 +71,39 @@ export function defineInterface(
     Object.entries(interfaceDef.properties ?? {}).map<
       [string, { required: boolean; sharedPropertyType: SharedPropertyType }]
     >(
-      ([propApiName, type]) => {
+      ([unNamespacedPropApiName, type]) => {
         if (typeof type === "object" && "propertyDefinition" in type) {
-          return [namespace + propApiName, {
+          // If the property is an imported SPT, use the SPT's apiName
+          const apiName = sanitize(
+            namespace,
+            typeof type.propertyDefinition === "object"
+              && "apiName" in type.propertyDefinition
+              ? type.propertyDefinition.apiName
+              : unNamespacedPropApiName,
+          );
+
+          return [apiName, {
             required: type.required,
             sharedPropertyType: unifyBasePropertyDefinition(
               namespace,
-              propApiName,
+              unNamespacedPropApiName,
               type.propertyDefinition,
             ),
           }];
         }
 
-        return [namespace + propApiName, {
+        // If the property is an imported SPT, use the SPT's apiName
+        const apiName = sanitize(
+          namespace,
+          typeof type === "object" && "apiName" in type
+            ? type.apiName
+            : unNamespacedPropApiName,
+        );
+        return [apiName, {
           required: true,
           sharedPropertyType: unifyBasePropertyDefinition(
             namespace,
-            propApiName,
+            unNamespacedPropApiName,
             type,
           ),
         }];

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -4089,6 +4089,11 @@ describe("Ontology Defining", () => {
 
   describe("Actions", () => {
     it("Interface actions are properly defined", () => {
+      const foo = defineInterface({
+        apiName: "foo",
+        displayName: "foo",
+        properties: {},
+      });
       const exampleAction = defineAction({
         apiName: "foo",
         displayName: "exampleAction",
@@ -4242,7 +4247,28 @@ describe("Ontology Defining", () => {
               "linkTypes": {},
               "objectTypes": {},
             },
-            "interfaceTypes": {},
+            "interfaceTypes": {
+              "com.palantir.foo": {
+                "interfaceType": {
+                  "apiName": "com.palantir.foo",
+                  "displayMetadata": {
+                    "description": "foo",
+                    "displayName": "foo",
+                    "icon": undefined,
+                  },
+                  "extendsInterfaces": [],
+                  "links": [],
+                  "properties": [],
+                  "propertiesV2": {},
+                  "propertiesV3": {},
+                  "searchable": true,
+                  "status": {
+                    "active": {},
+                    "type": "active",
+                  },
+                },
+              },
+            },
             "linkTypes": {},
             "objectTypes": {},
             "sharedPropertyTypes": {},
@@ -10605,6 +10631,166 @@ describe("Ontology Defining", () => {
           },
         }
       `);
+    });
+    it("Interface actions validate SPT existence globally", () => {
+      expect(() => {
+        const spt = defineSharedPropertyType({
+          apiName: "spt",
+          type: "string",
+        });
+        const pulseRepetitionIntervalSecs: SharedPropertyType = {
+          "apiName": "com.palantir.other.ontology.pulseRepetitionIntervalSecs",
+          "displayName": "Pulse Repetition Interval (s)",
+          "description": "Pulse Repetition Interval in seconds.",
+          "type": "double",
+          "nonNameSpacedApiName": "pulseRepetitionIntervalSecs",
+          "typeClasses": [],
+          "__type": OntologyEntityTypeEnum.SHARED_PROPERTY_TYPE,
+        } as unknown as SharedPropertyType;
+        importOntologyEntity(pulseRepetitionIntervalSecs);
+        const interfaceType = defineInterface({
+          apiName: "interfaceType",
+          properties: {
+            spt,
+            pulseRepetitionIntervalSecs,
+          },
+        });
+        const action = defineAction({
+          apiName: "action",
+          displayName: "action",
+          status: "active",
+          parameters: [{
+            id: "interfaceObjectToModifyParameter",
+            displayName: "Interface object to modify",
+            type: {
+              type: "interfaceReference",
+              interfaceReference: {
+                interfaceTypeRid: interfaceType.apiName,
+              },
+            },
+            validation: {
+              required: true,
+              allowedValues: { type: "interfaceObjectQuery" },
+            },
+          }, {
+            id: "sptParameter",
+            displayName: "SPT",
+            type: "string",
+            validation: {
+              required: true,
+              allowedValues: { type: "text" },
+            },
+          }, {
+            id: "otherParameter",
+            displayName: "Other parameter",
+            type: "string",
+            validation: {
+              required: true,
+              allowedValues: { type: "text" },
+            },
+          }],
+          rules: [{
+            type: "modifyInterfaceRule",
+            modifyInterfaceRule: {
+              interfaceObjectToModifyParameter:
+                "interfaceObjectToModifyParameter",
+              sharedPropertyValues: {
+                spt: {
+                  type: "parameterId",
+                  parameterId: "sptParameter",
+                },
+                [pulseRepetitionIntervalSecs.apiName]: {
+                  type: "staticValue",
+                  staticValue: {
+                    type: "double",
+                    double: 4,
+                  },
+                },
+                other: {
+                  type: "parameterId",
+                  parameterId: "otherParameter",
+                },
+              },
+            },
+          }],
+        });
+      }).toThrowErrorMatchingInlineSnapshot(`
+        [Error: Invariant failed: Shared property type com.palantir.other does not exist.
+                    If this SPT was imported, you may need to use [spt.apiName] as the key so that it is qualified with the right namespace]
+      `);
+    });
+    it("Interface actions validate SPT existence on the interface", () => {
+      expect(() => {
+        const spt = defineSharedPropertyType({
+          apiName: "spt",
+          type: "string",
+        });
+        const pulseRepetitionIntervalSecs: SharedPropertyType = {
+          "apiName": "com.palantir.other.ontology.pulseRepetitionIntervalSecs",
+          "displayName": "Pulse Repetition Interval (s)",
+          "description": "Pulse Repetition Interval in seconds.",
+          "type": "double",
+          "nonNameSpacedApiName": "pulseRepetitionIntervalSecs",
+          "typeClasses": [],
+          "__type": OntologyEntityTypeEnum.SHARED_PROPERTY_TYPE,
+        } as unknown as SharedPropertyType;
+        importOntologyEntity(pulseRepetitionIntervalSecs);
+        const interfaceType = defineInterface({
+          apiName: "interfaceType",
+          properties: {
+            spt,
+          },
+        });
+        const action = defineAction({
+          apiName: "action",
+          displayName: "action",
+          status: "active",
+          parameters: [{
+            id: "interfaceObjectToModifyParameter",
+            displayName: "Interface object to modify",
+            type: {
+              type: "interfaceReference",
+              interfaceReference: {
+                interfaceTypeRid: interfaceType.apiName,
+              },
+            },
+            validation: {
+              required: true,
+              allowedValues: { type: "interfaceObjectQuery" },
+            },
+          }, {
+            id: "sptParameter",
+            displayName: "SPT",
+            type: "string",
+            validation: {
+              required: true,
+              allowedValues: { type: "text" },
+            },
+          }],
+          rules: [{
+            type: "modifyInterfaceRule",
+            modifyInterfaceRule: {
+              interfaceObjectToModifyParameter:
+                "interfaceObjectToModifyParameter",
+              sharedPropertyValues: {
+                spt: {
+                  type: "parameterId",
+                  parameterId: "sptParameter",
+                },
+                [pulseRepetitionIntervalSecs.apiName]: {
+                  type: "staticValue",
+                  staticValue: {
+                    type: "double",
+                    double: 4,
+                  },
+                },
+              },
+            },
+          }],
+        });
+      }).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Shared property type com.palantir.other.ontology.pulseRepetitionIntervalSecs does not exist in interface type com.palantir.interfaceType]`,
+      );
     });
   });
   describe("Imports", () => {


### PR DESCRIPTION
Interfaces have a `propertiesV2` field that's a map from API name to SPT. Before this PR, the API name of the SPT did not always match the key. Specifically, when an SPT was imported, the key would use the main namespace, and the SPT would use it's original namespace. I don't think this should break anything, since anything trying to use the key as a reference would break anyways. 

The improved interface action invariants are to validate that the referenced interfaces and SPTs exist, and the SPTs exist on the interface. Without this PR, using the non-namespaced API name as a key to the `sharedPropertyTypes` in the action rule would cause a hard-to-spot bug that only manifested in marketplace validation/installation.