### PR TITLE
Improve emit event types

### DIFF
--- a/.changeset/six-rabbits-sing.md
+++ b/.changeset/six-rabbits-sing.md
@@ -1,0 +1,6 @@
+---
+"@osdk/widget.client": patch
+"@osdk/widget.api": patch
+---
+
+Improve widget client emitEvent types to more correctly extract event parameters

--- a/packages/widget.api/src/config.ts
+++ b/packages/widget.api/src/config.ts
@@ -121,9 +121,15 @@ export type EventParameterIdList<
 export type EventParameterValueMap<
   C extends WidgetConfig<C["parameters"]>,
   K extends EventId<C>,
-> = {
-  [P in EventParameterIdList<C, K>[number]]: ParameterValueMap<C>[P];
-};
+> = NotEmptyObject<
+  {
+    [P in EventParameterIdList<C, K>[number]]: ParameterValueMap<C>[P];
+  }
+>;
+
+type NotEmptyObject<T extends Record<string, any>> = T extends
+  Record<string, never> ? Record<string, never>
+  : T;
 
 export function defineConfig<const C extends WidgetConfig<any>>(c: C): C {
   return c as any;

--- a/packages/widget.client/src/client.test.ts
+++ b/packages/widget.client/src/client.test.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineConfig } from "@osdk/widget.api";
+import { describe, it } from "vitest";
+import type { FoundryWidgetClient } from "./client.js";
+
+describe("FoundryWidgetClient", () => {
+  const config = defineConfig({
+    id: "widgetId",
+    name: "Widget Name",
+    description: "Widget Description",
+    type: "workshop",
+    parameters: {
+      myString: {
+        displayName: "My string",
+        type: "string",
+      },
+      myNumber: {
+        displayName: "My number",
+        type: "number",
+      },
+      myBoolean: {
+        displayName: "My boolean",
+        type: "boolean",
+      },
+    },
+    events: {
+      noParameters: {
+        displayName: "No parameters",
+        parameterUpdateIds: [],
+      },
+      oneParameter: {
+        displayName: "One parameter",
+        parameterUpdateIds: ["myString"],
+      },
+      twoParameters: {
+        displayName: "Two parameters",
+        parameterUpdateIds: ["myNumber", "myBoolean"],
+      },
+    },
+  });
+
+  const emitEvent: FoundryWidgetClient<typeof config>["emitEvent"] = (
+    _eventId,
+    _payload,
+  ) => {};
+
+  it("should narrow the emit event type when no parameters", () => {
+    emitEvent("noParameters", {
+      // @ts-expect-error
+      parameterUpdates: [],
+    });
+    emitEvent("noParameters", {
+      // @ts-expect-error
+      parameterUpdates: { myString: "string" },
+    });
+
+    emitEvent("noParameters", {
+      parameterUpdates: {},
+    });
+  });
+
+  it("should narrow the emit event type with one parameter", () => {
+    emitEvent("oneParameter", {
+      // @ts-expect-error
+      parameterUpdates: [],
+    });
+    emitEvent("oneParameter", {
+      // @ts-expect-error
+      parameterUpdates: {},
+    });
+    emitEvent("oneParameter", {
+      // @ts-expect-error
+      parameterUpdates: { myNumber: 123 },
+    });
+    emitEvent("twoParameters", {
+      // @ts-expect-error
+      parameterUpdates: { myString: "string", myNumber: 123 },
+    });
+
+    emitEvent("oneParameter", {
+      parameterUpdates: { myString: "string" },
+    });
+  });
+
+  it("should narrow the emit event type with two parameters", () => {
+    emitEvent("twoParameters", {
+      // @ts-expect-error
+      parameterUpdates: [],
+    });
+    emitEvent("twoParameters", {
+      // @ts-expect-error
+      parameterUpdates: {},
+    });
+    emitEvent("twoParameters", {
+      // @ts-expect-error
+      parameterUpdates: { myString: "string" },
+    });
+    emitEvent("twoParameters", {
+      // @ts-expect-error
+      parameterUpdates: { myNumber: 123 },
+    });
+    emitEvent("twoParameters", {
+      // @ts-expect-error
+      parameterUpdates: { myNumber: 123, myBoolean: true, myString: "string" },
+    });
+
+    emitEvent("twoParameters", {
+      parameterUpdates: { myNumber: 123, myBoolean: true },
+    });
+  });
+
+  it("should not allow emit event type with an unknown event id", () => {
+    // @ts-expect-error
+    emitEvent("someOtherEventId", {});
+  });
+});

--- a/packages/widget.client/src/client.ts
+++ b/packages/widget.client/src/client.ts
@@ -32,9 +32,15 @@ export interface FoundryWidgetClient<C extends WidgetConfig<C["parameters"]>> {
   /**
    * Emits an event with the given ID and payload
    */
-  emitEvent: <M extends WidgetMessage.EmitEvent<C>>(
-    eventId: M["payload"]["eventId"],
-    payload: Omit<M["payload"], "eventId">,
+  emitEvent: <
+    M extends WidgetMessage.EmitEvent<C>,
+    ID extends M["payload"]["eventId"],
+  >(
+    eventId: ID,
+    payload: Omit<
+      ExtractEmitEventPayload<M, ID>,
+      "eventId"
+    >,
   ) => void;
 
   /**
@@ -58,6 +64,14 @@ export interface FoundryWidgetClient<C extends WidgetConfig<C["parameters"]>> {
    */
   hostEventTarget: FoundryHostEventTarget<C>;
 }
+
+type ExtractEmitEventPayload<
+  M extends WidgetMessage.EmitEvent<any>,
+  ID extends M["payload"]["eventId"],
+> = Extract<
+  M["payload"],
+  { eventId: ID }
+>;
 
 interface PalantirWidgetApiEvents<C extends WidgetConfig<C["parameters"]>> {
   message: CustomEvent<HostMessage<C>>;


### PR DESCRIPTION
## Changes

- Map the `EventParameterValueMap` to an empty record when the event has empty `parameterUpdateIds`
- Improve `emitEvent` to constrain the payload type based on the event id type

## Problem

Given a test config like the following:

```
type TestConfig = {
  readonly id: "signatureWidget";
  readonly name: "Signature Widget";
  readonly description: "An example custom widget implementation";
  readonly type: "workshop";
  readonly parameters: {
    readonly createdBy: {
      readonly displayName: "Created by";
      readonly type: "string";
    };
    readonly note: {
      readonly displayName: "Note";
      readonly type: "string";
    };
    readonly counterValue: {
      readonly displayName: "Counter value";
      readonly type: "number";
    };
  };
  readonly events: {
    readonly newSignatureCreated: {
      readonly displayName: "New signature created";
      readonly parameterUpdateIds: [];
    };
    readonly noteUpdated: {
      readonly displayName: "Note updated";
      readonly parameterUpdateIds: ["note"];
    };
    readonly setCounterValue: {
      readonly displayName: "Set counter value";
      readonly parameterUpdateIds: ["counterValue"];
    };
  };
};
```

There are two problems with the types for the widget client emitEvent:

1. When there are no parameterUpdateIds the mapped type `EventParameterValueMap<TestConfig, "newSignatureCreated">` is `{}` which is [assignable to anything except null/undefined](https://stackoverflow.com/a/77569292)
2. The emitEvent mapped types restrict the `eventId` parameter to the union of eventIds in the config and the `payload` parameter to the union of all payloads of events in the config `EventParameterValueMap<TestConfig, "newSignatureCreated"> | EventParameterValueMap<TestConfig, "noteUpdated"> | EventParameterValueMap<TestConfig, "setCounterValue">` but don't narrow any further
  a. This means that two valid payloads and event ids from different events do not throw a type error when incorrectly paired together

The combination of these two mean that if you have both an event with empty `parameterUpdateIds` and other events which do have parameter update ids the type checking is essentially broken as almost any payload is accepted like `[]` or `123` (the valid payload for no parameters).

## Testing

I tested with some types locally and added some tests to with `// @ts-expect-error`

| Before | After |
|-|-|
<img width="1389" height="155" alt="Screenshot 2025-08-18 at 15 10 42" src="https://github.com/user-attachments/assets/39119581-0813-43ce-bebd-472f3bb77421" /> | <img width="1267" height="403" alt="Screenshot 2025-08-18 at 15 10 06" src="https://github.com/user-attachments/assets/c7232b22-99ab-4949-b9ce-6bd95f7af81e" />
<img width="518" height="120" alt="Screenshot 2025-08-18 at 15 10 47" src="https://github.com/user-attachments/assets/d0814079-2789-4fea-a951-88d6653af9f0" /> | <img width="530" height="140" alt="Screenshot 2025-08-18 at 15 10 13" src="https://github.com/user-attachments/assets/04011e06-ea37-4678-bd2a-22e97f171ed5" />

