### PR TITLE
Improve error visibility during widgets vite dev mode

### DIFF
--- a/.changeset/curly-hands-prove.md
+++ b/.changeset/curly-hands-prove.md
@@ -1,0 +1,5 @@
+---
+"@osdk/widget.vite-plugin": patch
+---
+
+Improve error visibility during widgets vite dev mode

--- a/packages/widget.vite-plugin/src/client/entrypointIframe.tsx
+++ b/packages/widget.vite-plugin/src/client/entrypointIframe.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect, useRef } from "react";
+
+export const EntrypointIframe: React.FC<{ src: string }> = ({ src }) => {
+  // We expect the widget to not load properly as we don't provide the proper runtime.
+  // These errors are not useful to the user as we just put this iframe on the page to
+  // trigger vite to load the entrypoints.
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  useEffect(() => {
+    if (iframeRef.current?.contentWindow != null) {
+      const iframeWindow = iframeRef.current.contentWindow as Window & {
+        console: Console;
+      };
+      iframeWindow.console.log = () => {};
+      iframeWindow.console.warn = () => {};
+      iframeWindow.console.error = () => {};
+      iframeWindow.onerror = () => {
+        return true;
+      };
+    }
+  }, []);
+  return <iframe ref={iframeRef} src={src} />;
+};

--- a/packages/widget.vite-plugin/src/dev-plugin/publishDevModeSettings.ts
+++ b/packages/widget.vite-plugin/src/dev-plugin/publishDevModeSettings.ts
@@ -16,6 +16,7 @@
 
 import { loadFoundryConfig } from "@osdk/foundry-config-json";
 import type { ServerResponse } from "node:http";
+import { inspect } from "node:util";
 import type { ViteDevServer } from "vite";
 import {
   getCodeWorkspacesFoundryUrl,
@@ -86,14 +87,13 @@ export async function publishDevModeSettings(
         : `${foundryUrl}/workspace/custom-widgets/preview/${widgetSetRid}`,
     }));
   } catch (error: unknown) {
-    // Note, this can't be server.config.logger.error as that method throws and prevents a response being sent
-    server.config.logger.warn(
-      `Failed to start dev mode: ${(error as Error).message}`,
+    server.config.logger.error(
+      `Failed to start dev mode: ${(error as Error)}\n\n${inspect(error)}`,
     );
     res.setHeader("Content-Type", "application/json");
     res.statusCode = 500;
     res.end(
-      JSON.stringify({ status: "failed", error: (error as Error).message }),
+      JSON.stringify({ status: "error", error: inspect(error) }),
     );
   }
 }


### PR DESCRIPTION
- Silence the iframe errors from adding the widget entrypoints in iframes as these just lead to confusion for the user and aren't relevant
- Fix "failed" -> "error" response payload type
- Include full deep error information in both the dev mode terminal output and the browser app non ideal state + console

| Before | After |
|-|-|
<img width="2560" height="611" alt="before1" src="https://github.com/user-attachments/assets/b11585cf-0cc1-4ed3-978b-bc7bb48bfd71" /> | <img width="2540" height="993" alt="after1" src="https://github.com/user-attachments/assets/03a9216d-8719-4672-adbe-73a016146b9b" />
<img width="853" height="209" alt="before2" src="https://github.com/user-attachments/assets/59766d46-3005-4514-b58a-32e046cdc683" /> | <img width="1110" height="314" alt="after2" src="https://github.com/user-attachments/assets/71cd29a1-c63a-471d-95b5-d2699215c36b" />
