### PR TITLE
Fix hydrateObjectSetFromObjectRids for interfaces

### DIFF
--- a/.changeset/twelve-results-unite.md
+++ b/.changeset/twelve-results-unite.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Fix hydrate method for object rids to work with interfaces.

--- a/packages/client/src/public-utils/hydrateObjectSetFromObjectRids.ts
+++ b/packages/client/src/public-utils/hydrateObjectSetFromObjectRids.ts
@@ -32,10 +32,12 @@ export function hydrateObjectSetFromObjectRids<
   return createObjectSet(definition, client[additionalContext], {
     type: "intersect",
     objectSets: [
-      {
-        type: "base",
-        objectType: definition.apiName,
-      },
+      definition.type === "interface"
+        ? { type: "interfaceBase", interfaceType: definition.apiName }
+        : {
+          type: "base",
+          objectType: definition.apiName,
+        },
       {
         type: "static",
         objects: asMutableArray(rids),


### PR DESCRIPTION
Fixes this to support interface base object sets as well.