### PR TITLE
Add more descriptive error for invalid parameter ordering in OAC

### DIFF
--- a/.changeset/nasty-crews-melt.md
+++ b/.changeset/nasty-crews-melt.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker": patch
+---
+
+Better error message for invalid parameter ordering on actions

--- a/packages/maker/src/api/defineAction.ts
+++ b/packages/maker/src/api/defineAction.ts
@@ -1304,6 +1304,6 @@ function validateParameterOrdering(
   invariant(
     extraneousParameters.length === 0
       && missingParameters.length === 0,
-    `Action parameter ordering for ${actionApiName} does not match expected parameters. Extraneous parameter in ordering: {${extraneousParameters}}, Missing parameters in ordering: {${missingParameters}}`,
+    `Action parameter ordering for ${actionApiName} does not match expected parameters. Extraneous parameters in ordering: {${extraneousParameters}}, Missing parameters in ordering: {${missingParameters}}`,
   );
 }

--- a/packages/maker/src/api/defineAction.ts
+++ b/packages/maker/src/api/defineAction.ts
@@ -173,15 +173,15 @@ export function defineCreateObjectAction(
   Object.keys(def.parameterConfiguration ?? {}).forEach(param =>
     parameterNames.add(param)
   );
+  const actionApiName = def.apiName
+    ?? `create-object-${
+      kebab(def.objectType.apiName.split(".").pop() ?? def.objectType.apiName)
+    }`;
   if (def.parameterOrdering) {
-    const sortedOrdering = [...def.parameterOrdering].sort();
-    const sortedParameterNames = [...parameterNames].sort();
-    invariant(
-      sortedOrdering.length === sortedParameterNames.length
-        && sortedOrdering.every((name, index) =>
-          name === sortedParameterNames[index]
-        ),
-      `Action parameter ordering for ${def.objectType.apiName} does not match non-excluded properties`,
+    validateParameterOrdering(
+      def.parameterOrdering,
+      parameterNames,
+      actionApiName,
     );
   }
   const parameters = createParameters(def, parameterNames, true);
@@ -192,10 +192,7 @@ export function defineCreateObjectAction(
   );
 
   return defineAction({
-    apiName: def.apiName
-      ?? `create-object-${
-        kebab(def.objectType.apiName.split(".").pop() ?? def.objectType.apiName)
-      }`,
+    apiName: actionApiName,
     displayName: def.displayName ?? `Create ${def.objectType.displayName}`,
     parameters: parameters,
     status: def.status ?? "active",
@@ -357,6 +354,10 @@ export function defineModifyObjectAction(
     parameterNames.add(param)
   );
   parameterNames.add(MODIFY_OBJECT_PARAMETER);
+  const actionApiName = def.apiName
+    ?? `modify-object-${
+      kebab(def.objectType.apiName.split(".").pop() ?? def.objectType.apiName)
+    }`;
   if (def.parameterOrdering) {
     if (!def.parameterOrdering.includes(MODIFY_OBJECT_PARAMETER)) {
       def.parameterOrdering = [
@@ -364,14 +365,10 @@ export function defineModifyObjectAction(
         ...def.parameterOrdering,
       ];
     }
-    const sortedOrdering = [...def.parameterOrdering].sort();
-    const sortedParameterNames = [...parameterNames].sort();
-    invariant(
-      sortedOrdering.length === sortedParameterNames.length
-        && sortedOrdering.every((name, index) =>
-          name === sortedParameterNames[index]
-        ),
-      `Action parameter ordering for ${def.objectType.apiName} does not match non-excluded properties`,
+    validateParameterOrdering(
+      def.parameterOrdering,
+      parameterNames,
+      actionApiName,
     );
   }
   const parameters = createParameters(def, parameterNames, false);
@@ -396,10 +393,7 @@ export function defineModifyObjectAction(
   );
 
   return defineAction({
-    apiName: def.apiName
-      ?? `modify-object-${
-        kebab(def.objectType.apiName.split(".").pop() ?? def.objectType.apiName)
-      }`,
+    apiName: actionApiName,
     displayName: def.displayName ?? `Modify ${def.objectType.displayName}`,
     parameters: parameters,
     status: def.status ?? "active",
@@ -503,7 +497,8 @@ export function defineCreateOrModifyObjectAction(
   const propertyParameters = Object.keys(def.objectType.properties ?? {})
     .filter(
       id =>
-        !def.excludedProperties?.includes(id)
+        !Object.keys(def.nonParameterMappings ?? {}).includes(id)
+        && !def.excludedProperties?.includes(id)
         && !isStruct(def.objectType.properties?.[id].type!)
         && id !== def.objectType.primaryKeyPropertyApiName,
     );
@@ -512,6 +507,10 @@ export function defineCreateOrModifyObjectAction(
     parameterNames.add(param)
   );
   parameterNames.add(CREATE_OR_MODIFY_OBJECT_PARAMETER);
+  const actionApiName = def.apiName
+    ?? `create-or-modify-${
+      kebab(def.objectType.apiName.split(".").pop() ?? def.objectType.apiName)
+    }`;
   if (def.parameterOrdering) {
     if (!def.parameterOrdering.includes(CREATE_OR_MODIFY_OBJECT_PARAMETER)) {
       def.parameterOrdering = [
@@ -519,14 +518,10 @@ export function defineCreateOrModifyObjectAction(
         ...def.parameterOrdering,
       ];
     }
-    const sortedOrdering = [...def.parameterOrdering].sort();
-    const sortedParameterNames = [...parameterNames].sort();
-    invariant(
-      sortedOrdering.length === sortedParameterNames.length
-        && sortedOrdering.every((name, index) =>
-          name === sortedParameterNames[index]
-        ),
-      `Action parameter ordering for ${def.objectType.apiName} does not match non-excluded properties`,
+    validateParameterOrdering(
+      def.parameterOrdering,
+      parameterNames,
+      actionApiName,
     );
   }
   const parameters = createParameters(def, parameterNames, false);
@@ -553,10 +548,7 @@ export function defineCreateOrModifyObjectAction(
   );
 
   return defineAction({
-    apiName: def.apiName
-      ?? `create-or-modify-${
-        kebab(def.objectType.apiName.split(".").pop() ?? def.objectType.apiName)
-      }`,
+    apiName: actionApiName,
     displayName: def.displayName
       ?? `Create or Modify ${def.objectType.displayName}`,
     parameters: parameters,
@@ -1295,4 +1287,23 @@ function createDefaultParameterOrdering(
       !def.parameterConfiguration?.[id] && parameters.some(p => p.id === id)
     ),
   ];
+}
+
+function validateParameterOrdering(
+  parameterOrdering: string[],
+  parameterSet: Set<string>,
+  actionApiName: string,
+): void {
+  const orderingSet = new Set(parameterOrdering);
+  const missingParameters = [...parameterSet].filter(
+    param => !orderingSet.has(param),
+  );
+  const extraneousParameters = parameterOrdering.filter(param =>
+    !parameterSet.has(param)
+  );
+  invariant(
+    extraneousParameters.length === 0
+      && missingParameters.length === 0,
+    `Action parameter ordering for ${actionApiName} does not match expected parameters. Extraneous parameter in ordering: {${extraneousParameters}}, Missing parameters in ordering: {${missingParameters}}`,
+  );
 }

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -8167,79 +8167,6 @@ describe("Ontology Defining", () => {
                         },
                       },
                       "parameterValidations": {
-                        "buzz": {
-                          "conditionalOverrides": [],
-                          "defaultValidation": {
-                            "display": {
-                              "prefill": {
-                                "objectParameterPropertyValue": {
-                                  "parameterId": "objectToCreateOrModifyParameter",
-                                  "propertyTypeId": "buzz",
-                                },
-                                "type": "objectParameterPropertyValue",
-                              },
-                              "renderHint": {
-                                "dateTimePicker": {},
-                                "type": "dateTimePicker",
-                              },
-                              "visibility": {
-                                "editable": {},
-                                "type": "editable",
-                              },
-                            },
-                            "validation": {
-                              "allowedValues": {
-                                "datetime": {
-                                  "datetime": {
-                                    "maximum": undefined,
-                                    "minimum": undefined,
-                                  },
-                                  "type": "datetime",
-                                },
-                                "type": "datetime",
-                              },
-                              "required": {
-                                "notRequired": {},
-                                "type": "notRequired",
-                              },
-                            },
-                          },
-                        },
-                        "fizz": {
-                          "conditionalOverrides": [],
-                          "defaultValidation": {
-                            "display": {
-                              "prefill": {
-                                "objectParameterPropertyValue": {
-                                  "parameterId": "objectToCreateOrModifyParameter",
-                                  "propertyTypeId": "fizz",
-                                },
-                                "type": "objectParameterPropertyValue",
-                              },
-                              "renderHint": {
-                                "textInput": {},
-                                "type": "textInput",
-                              },
-                              "visibility": {
-                                "editable": {},
-                                "type": "editable",
-                              },
-                            },
-                            "validation": {
-                              "allowedValues": {
-                                "text": {
-                                  "text": {},
-                                  "type": "text",
-                                },
-                                "type": "text",
-                              },
-                              "required": {
-                                "notRequired": {},
-                                "type": "notRequired",
-                              },
-                            },
-                          },
-                        },
                         "objectToCreateOrModifyParameter": {
                           "conditionalOverrides": [],
                           "defaultValidation": {
@@ -8311,34 +8238,8 @@ describe("Ontology Defining", () => {
                     "formContentOrdering": [],
                     "parameterOrdering": [
                       "objectToCreateOrModifyParameter",
-                      "fizz",
-                      "buzz",
                     ],
                     "parameters": {
-                      "buzz": {
-                        "displayMetadata": {
-                          "description": "",
-                          "displayName": "Buzz",
-                          "typeClasses": [],
-                        },
-                        "id": "buzz",
-                        "type": {
-                          "timestamp": {},
-                          "type": "timestamp",
-                        },
-                      },
-                      "fizz": {
-                        "displayMetadata": {
-                          "description": "",
-                          "displayName": "Fizz",
-                          "typeClasses": [],
-                        },
-                        "id": "fizz",
-                        "type": {
-                          "string": {},
-                          "type": "string",
-                        },
-                      },
                       "objectToCreateOrModifyParameter": {
                         "displayMetadata": {
                           "description": "",
@@ -12713,11 +12614,71 @@ describe("Ontology Defining", () => {
       expect(() => {
         const createBadAction = defineCreateObjectAction({
           objectType: sampleObject,
-          parameterOrdering: ["foo", "name", "id"],
+          parameterOrdering: ["foo", "id"],
           excludedProperties: ["id"],
         });
       }).toThrowErrorMatchingInlineSnapshot(
-        `[Error: Invariant failed: Action parameter ordering for com.palantir.sampleObject does not match non-excluded properties]`,
+        `[Error: Invariant failed: Action parameter ordering for create-object-sample-object does not match expected parameters. Extraneous parameter in ordering: {id}, Missing parameters in ordering: {name}]`,
+      );
+      expect(() => {
+        const createBadAction = defineModifyObjectAction({
+          objectType: sampleObject,
+          // primary keys should not be in modify action orderings
+          parameterOrdering: ["foo", "id"],
+        });
+      }).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Action parameter ordering for modify-object-sample-object does not match expected parameters. Extraneous parameter in ordering: {id}, Missing parameters in ordering: {name}]`,
+      );
+      expect(() => {
+        const createBadAction = defineCreateOrModifyObjectAction({
+          objectType: sampleObject,
+          // primary keys should not be in create-or-modify action orderings
+          parameterOrdering: ["foo", "id"],
+        });
+      }).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Action parameter ordering for create-or-modify-sample-object does not match expected parameters. Extraneous parameter in ordering: {id}, Missing parameters in ordering: {name}]`,
+      );
+      expect(() => {
+        const createBadAction = defineCreateObjectAction({
+          objectType: sampleObject,
+          nonParameterMappings: {
+            "foo": {
+              type: "currentUser",
+            },
+          },
+          // non-parameter mapped properties should not be in action orderings
+          parameterOrdering: ["foo", "id"],
+        });
+      }).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Action parameter ordering for create-object-sample-object does not match expected parameters. Extraneous parameter in ordering: {foo}, Missing parameters in ordering: {name}]`,
+      );
+      expect(() => {
+        const createBadAction = defineModifyObjectAction({
+          objectType: sampleObject,
+          nonParameterMappings: {
+            "foo": {
+              type: "currentUser",
+            },
+          },
+          // non-parameter mapped properties should not be in action orderings
+          parameterOrdering: ["foo", "id"],
+        });
+      }).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Action parameter ordering for modify-object-sample-object does not match expected parameters. Extraneous parameter in ordering: {foo,id}, Missing parameters in ordering: {name}]`,
+      );
+      expect(() => {
+        const createBadAction = defineCreateOrModifyObjectAction({
+          objectType: sampleObject,
+          nonParameterMappings: {
+            "foo": {
+              type: "currentUser",
+            },
+          },
+          // non-parameter mapped properties should not be in action orderings
+          parameterOrdering: ["foo", "id"],
+        });
+      }).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Action parameter ordering for create-or-modify-sample-object does not match expected parameters. Extraneous parameter in ordering: {foo,id}, Missing parameters in ordering: {name}]`,
       );
       const createAction = defineCreateObjectAction({
         objectType: sampleObject,

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -12618,7 +12618,7 @@ describe("Ontology Defining", () => {
           excludedProperties: ["id"],
         });
       }).toThrowErrorMatchingInlineSnapshot(
-        `[Error: Invariant failed: Action parameter ordering for create-object-sample-object does not match expected parameters. Extraneous parameter in ordering: {id}, Missing parameters in ordering: {name}]`,
+        `[Error: Invariant failed: Action parameter ordering for create-object-sample-object does not match expected parameters. Extraneous parameters in ordering: {id}, Missing parameters in ordering: {name}]`,
       );
       expect(() => {
         const createBadAction = defineModifyObjectAction({
@@ -12627,7 +12627,7 @@ describe("Ontology Defining", () => {
           parameterOrdering: ["foo", "id"],
         });
       }).toThrowErrorMatchingInlineSnapshot(
-        `[Error: Invariant failed: Action parameter ordering for modify-object-sample-object does not match expected parameters. Extraneous parameter in ordering: {id}, Missing parameters in ordering: {name}]`,
+        `[Error: Invariant failed: Action parameter ordering for modify-object-sample-object does not match expected parameters. Extraneous parameters in ordering: {id}, Missing parameters in ordering: {name}]`,
       );
       expect(() => {
         const createBadAction = defineCreateOrModifyObjectAction({
@@ -12636,7 +12636,7 @@ describe("Ontology Defining", () => {
           parameterOrdering: ["foo", "id"],
         });
       }).toThrowErrorMatchingInlineSnapshot(
-        `[Error: Invariant failed: Action parameter ordering for create-or-modify-sample-object does not match expected parameters. Extraneous parameter in ordering: {id}, Missing parameters in ordering: {name}]`,
+        `[Error: Invariant failed: Action parameter ordering for create-or-modify-sample-object does not match expected parameters. Extraneous parameters in ordering: {id}, Missing parameters in ordering: {name}]`,
       );
       expect(() => {
         const createBadAction = defineCreateObjectAction({
@@ -12650,7 +12650,7 @@ describe("Ontology Defining", () => {
           parameterOrdering: ["foo", "id"],
         });
       }).toThrowErrorMatchingInlineSnapshot(
-        `[Error: Invariant failed: Action parameter ordering for create-object-sample-object does not match expected parameters. Extraneous parameter in ordering: {foo}, Missing parameters in ordering: {name}]`,
+        `[Error: Invariant failed: Action parameter ordering for create-object-sample-object does not match expected parameters. Extraneous parameters in ordering: {foo}, Missing parameters in ordering: {name}]`,
       );
       expect(() => {
         const createBadAction = defineModifyObjectAction({
@@ -12664,7 +12664,7 @@ describe("Ontology Defining", () => {
           parameterOrdering: ["foo", "id"],
         });
       }).toThrowErrorMatchingInlineSnapshot(
-        `[Error: Invariant failed: Action parameter ordering for modify-object-sample-object does not match expected parameters. Extraneous parameter in ordering: {foo,id}, Missing parameters in ordering: {name}]`,
+        `[Error: Invariant failed: Action parameter ordering for modify-object-sample-object does not match expected parameters. Extraneous parameters in ordering: {foo,id}, Missing parameters in ordering: {name}]`,
       );
       expect(() => {
         const createBadAction = defineCreateOrModifyObjectAction({
@@ -12678,7 +12678,7 @@ describe("Ontology Defining", () => {
           parameterOrdering: ["foo", "id"],
         });
       }).toThrowErrorMatchingInlineSnapshot(
-        `[Error: Invariant failed: Action parameter ordering for create-or-modify-sample-object does not match expected parameters. Extraneous parameter in ordering: {foo,id}, Missing parameters in ordering: {name}]`,
+        `[Error: Invariant failed: Action parameter ordering for create-or-modify-sample-object does not match expected parameters. Extraneous parameters in ordering: {foo,id}, Missing parameters in ordering: {name}]`,
       );
       const createAction = defineCreateObjectAction({
         objectType: sampleObject,


### PR DESCRIPTION
1. The provided parameter ordering for actions should match the expected set of parameters. This can get complicated for bigger actions, and the old error was completely useless in debugging this
2.  Bug fix to create-or-modify actions where non-parameter mappings were not being excluded from parameter set (the old snapshot test was also wrong)