### PR TITLE
Perf fix

### DIFF
--- a/.changeset/proud-aliens-pull.md
+++ b/.changeset/proud-aliens-pull.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Parallelize network request for getting object metadata when doing simple object fetches.

--- a/packages/client/src/createClient.test.ts
+++ b/packages/client/src/createClient.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Task } from "@osdk/client.test.ontology";
+import { BarInterface } from "@osdk/client.test.ontology";
 import * as SharedClientContext from "@osdk/shared.client.impl";
 import type { MockedFunction } from "vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -71,12 +71,12 @@ describe(createClient, () => {
     }
 
     it("works for objects", async () => {
-      await client(Task).fetchPage();
+      await client(BarInterface).fetchPage();
       expect(fetchFunction).toHaveBeenCalledTimes(1);
 
       const parts = getUserAgentPartsFromMockedFetch();
       expect(parts).toEqual([
-        ...Task.osdkMetadata!
+        ...BarInterface.osdkMetadata!
           .extraUserAgent
           .split(" "),
         USER_AGENT,

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -321,6 +321,7 @@ export async function fetchObjectPage<
   objectSet: ObjectSet,
   useSnapshot: boolean = false,
 ): Promise<FetchPageResult<Q, L, R, S, T>> {
+  void client.ontologyProvider.getObjectDefinition(objectType.apiName);
   const r = await OntologiesV2.OntologyObjectSets.load(
     addUserAgentAndRequestContextHeaders(client, objectType),
     await client.ontologyRid,

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -321,7 +321,12 @@ export async function fetchObjectPage<
   objectSet: ObjectSet,
   useSnapshot: boolean = false,
 ): Promise<FetchPageResult<Q, L, R, S, T>> {
+  // For simple object fetches, since we know the object type up front
+  // we can parallelize network requests for loading metadata and loading the actual objects
+  // In our object factory we await and block on loading the metadata, which if this call finishes, should already be cached on the client
+
   void client.ontologyProvider.getObjectDefinition(objectType.apiName);
+
   const r = await OntologiesV2.OntologyObjectSets.load(
     addUserAgentAndRequestContextHeaders(client, objectType),
     await client.ontologyRid,

--- a/packages/client/src/observable/internal/Store.test.ts
+++ b/packages/client/src/observable/internal/Store.test.ts
@@ -1034,6 +1034,9 @@ describe(Store, () => {
     it("properly fires error handler for a list", async () => {
       const sub = mockListSubCallback();
 
+      // ignores unhandled rejection, like one we will get from fire-and-forget metadata call
+      process.on("unhandledRejection", () => {});
+
       store.observeList({
         type: { apiName: "notReal", type: "object" },
         orderBy: {},

--- a/packages/client/src/ontology/StandardOntologyProvider.test.ts
+++ b/packages/client/src/ontology/StandardOntologyProvider.test.ts
@@ -49,8 +49,8 @@ describe(createStandardOntologyProviderFactory, () => {
 
     // first load should lookup employee and its link types
     expect(loads).toEqual([
-      "/api/v2/ontologies/ri.ontology.main.ontology.698267cc-6b48-4d98-beff-29beb24e9361/objectSets/loadObjects",
       "/api/v2/ontologies/ri.ontology.main.ontology.698267cc-6b48-4d98-beff-29beb24e9361/objectTypes/Employee/fullMetadata",
+      "/api/v2/ontologies/ri.ontology.main.ontology.698267cc-6b48-4d98-beff-29beb24e9361/objectSets/loadObjects",
       "/api/v2/ontologies/ri.ontology.main.ontology.698267cc-6b48-4d98-beff-29beb24e9361/interfaceTypes/FooInterface",
     ]);
 


### PR DESCRIPTION
When doing simple object fetches, we should be able to parallelize network requests to load object definition beforehand because we know the object type the user is asking for up front.

Since we cache metadata results on the client, if we fire it off first and it finishes, it should be ready to use in the cache.