### PR TITLE
Existing object types as action parameters in OAC (maker-experimental)

### DIFF
--- a/.changeset/fifty-bugs-bathe.md
+++ b/.changeset/fifty-bugs-bathe.md
@@ -1,0 +1,6 @@
+---
+"@osdk/maker-experimental": patch
+"@osdk/maker": patch
+---
+
+Existing OTs as action parameters in OAC

--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -126,6 +126,7 @@ const archetypeRules = archetypes(
       "@osdk/generator-utils",
       "@osdk/generator",
       "@osdk/maker",
+      "@osdk/maker-experimental",
       "@osdk/oauth",
       "@osdk/shared.client.impl",
       "@osdk/shared.net.errors",

--- a/packages/maker-experimental/.gitignore
+++ b/packages/maker-experimental/.gitignore
@@ -1,0 +1,1 @@
+src/generatedNoCheck

--- a/packages/maker-experimental/README.md
+++ b/packages/maker-experimental/README.md
@@ -1,0 +1,3 @@
+# OSDK Maker-Experimental Package
+
+The Maker-Experimental package provides experimental functions relating to programmatically defining ontologies (see the @osdk/maker package). These functions are unstable and may have unexpected behavior. 

--- a/packages/maker-experimental/README.md
+++ b/packages/maker-experimental/README.md
@@ -1,3 +1,3 @@
 # OSDK Maker-Experimental Package
 
-The Maker-Experimental package provides experimental functions relating to programmatically defining ontologies (see the @osdk/maker package). These functions are unstable and may have unexpected behavior. 
+The Maker-Experimental package provides experimental functions relating to programmatically defining ontologies (see the @osdk/maker package). These functions are unstable and may have unexpected behavior.

--- a/packages/maker-experimental/package.json
+++ b/packages/maker-experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker-experimental",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/maker-experimental/package.json
+++ b/packages/maker-experimental/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@osdk/maker-experimental",
+  "version": "0.0.0",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/palantir/osdk-ts.git"
+  },
+  "exports": {
+    ".": {
+      "browser": "./build/browser/index.js",
+      "import": {
+        "types": "./build/types/index.d.ts",
+        "default": "./build/esm/index.js"
+      },
+      "require": "./build/cjs/index.cjs",
+      "default": "./build/browser/index.js"
+    },
+    "./*": {
+      "browser": "./build/browser/public/*.js",
+      "import": {
+        "types": "./build/types/public/*.d.ts",
+        "default": "./build/esm/public/*.js"
+      },
+      "require": "./build/cjs/public/*.cjs",
+      "default": "./build/browser/public/*.js"
+    }
+  },
+  "scripts": {
+    "check-attw": "attw --pack .",
+    "check-spelling": "cspell --quiet .",
+    "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
+    "fix-lint": "eslint . --fix && dprint fmt --config $(find-up dprint.json)",
+    "lint": "eslint . && dprint check  --config $(find-up dprint.json)",
+    "test": "vitest run",
+    "transpileBrowser": "monorepo.tool.transpile -f esm -m normal -t browser",
+    "transpileCjs": "monorepo.tool.transpile -f cjs -m bundle -t node",
+    "transpileEsm": "monorepo.tool.transpile -f esm -m normal -t node",
+    "transpileTypes": "monorepo.tool.transpile -f esm -m types -t node",
+    "typecheck": "tsc --noEmit --emitDeclarationOnly false"
+  },
+  "dependencies": {
+    "@osdk/api": "workspace:~",
+    "tiny-invariant": "^1.3.3"
+  },
+  "devDependencies": {
+    "@osdk/client.unstable": "workspace:~",
+    "@osdk/maker": "workspace:~",
+    "@osdk/monorepo.api-extractor": "workspace:~",
+    "@osdk/monorepo.tsconfig": "workspace:~",
+    "typescript": "~5.5.4",
+    "vitest": "^3.0.5"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "build/cjs",
+    "build/esm",
+    "build/browser",
+    "build/types",
+    "CHANGELOG.md",
+    "package.json",
+    "templates",
+    "*.d.ts"
+  ],
+  "main": "./build/cjs/index.cjs",
+  "module": "./build/esm/index.js",
+  "types": "./build/cjs/index.d.cts",
+  "type": "module"
+}

--- a/packages/maker-experimental/src/api/importObjectType.ts
+++ b/packages/maker-experimental/src/api/importObjectType.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function importObjectType(): void {
+  return;
+}

--- a/packages/maker-experimental/src/api/importObjectType.ts
+++ b/packages/maker-experimental/src/api/importObjectType.ts
@@ -19,6 +19,7 @@ import type {
   OntologyIrImportedPropertyType,
 } from "@osdk/client.unstable";
 import {
+  addNamespaceIfNone,
   convertToDisplayName,
   convertToPluralDisplayName,
   convertType,
@@ -27,6 +28,7 @@ import {
   type ObjectType,
   OntologyEntityTypeEnum,
 } from "@osdk/maker";
+import invariant from "tiny-invariant";
 import type { importObjectDefinition } from "./types.js";
 
 /*
@@ -37,6 +39,10 @@ import type { importObjectDefinition } from "./types.js";
 export function defineImportObject(
   objectDef: importObjectDefinition,
 ): OntologyIrImportedObjectType {
+  invariant(
+    !objectDef.apiName.includes("."),
+    `Remove namespace or periods from imported object type ${objectDef.apiName}`,
+  );
   const properties: Array<ObjectPropertyType> = Object.entries(
     objectDef.properties ?? {},
   ).map(([apiName, type]) => ({
@@ -45,7 +51,7 @@ export function defineImportObject(
     type: type.type,
   }));
   const finalObject: ObjectType = {
-    ...objectDef,
+    apiName: addNamespaceIfNone(objectDef.apiName),
     properties: properties,
     __type: OntologyEntityTypeEnum.OBJECT_TYPE,
 
@@ -67,6 +73,7 @@ export function defineImportObject(
     }));
   const ontologyImportObject: OntologyIrImportedObjectType = {
     ...objectDef,
+    apiName: addNamespaceIfNone(objectDef.apiName),
     displayName: objectDef.displayName
       ?? convertToDisplayName(objectDef.apiName),
     propertyTypes: importPropertyTypes,

--- a/packages/maker-experimental/src/api/importObjectType.ts
+++ b/packages/maker-experimental/src/api/importObjectType.ts
@@ -27,7 +27,7 @@ import {
   type ObjectType,
   OntologyEntityTypeEnum,
 } from "@osdk/maker";
-import type { importObjectDefinition } from "./types.js";
+import type { ImportObjectDefinition } from "./types.js";
 
 /*
  * Takes in the minimal object definition to create an input shape.
@@ -35,7 +35,7 @@ import type { importObjectDefinition } from "./types.js";
  * then converts it to an OntologyIrImportedObjectType that is safe to use elsewhere.
  */
 export function defineImportObject(
-  objectDef: importObjectDefinition,
+  objectDef: ImportObjectDefinition,
 ): OntologyIrImportedObjectType {
   const properties: Array<ObjectPropertyType> = Object.entries(
     objectDef.properties ?? {},

--- a/packages/maker-experimental/src/api/importObjectType.ts
+++ b/packages/maker-experimental/src/api/importObjectType.ts
@@ -14,6 +14,41 @@
  * limitations under the License.
  */
 
-export function importObjectType(): void {
-  return;
+import {
+  convertToDisplayName,
+  convertToPluralDisplayName,
+  importOntologyEntity,
+  type ObjectPropertyType,
+  type ObjectType,
+  OntologyEntityTypeEnum,
+} from "@osdk/maker";
+import type { importObjectDefinition } from "./types.js";
+
+export function defineImportObject(
+  objectDef: importObjectDefinition,
+): ObjectType {
+  const properties: Array<ObjectPropertyType> = Object.entries(
+    objectDef.properties ?? {},
+  ).map(([apiName, type]) => ({
+    apiName: apiName,
+    displayName: convertToDisplayName(apiName),
+    type: type,
+  }));
+  const finalObject: ObjectType = {
+    ...objectDef,
+    properties: properties,
+    __type: OntologyEntityTypeEnum.OBJECT_TYPE,
+
+    // the rest don't matter for now
+    displayName: objectDef.displayName
+      ?? convertToDisplayName(objectDef.apiName),
+    pluralDisplayName: objectDef.pluralDisplayName
+      ?? convertToPluralDisplayName(objectDef.apiName),
+    primaryKeyPropertyApiName: objectDef.primaryKeyPropertyApiName
+      ?? properties[0]?.apiName,
+    titlePropertyApiName: objectDef.titlePropertyApiName
+      ?? properties[0]?.apiName,
+  };
+  importOntologyEntity(finalObject);
+  return finalObject;
 }

--- a/packages/maker-experimental/src/api/importObjectType.ts
+++ b/packages/maker-experimental/src/api/importObjectType.ts
@@ -19,7 +19,6 @@ import type {
   OntologyIrImportedPropertyType,
 } from "@osdk/client.unstable";
 import {
-  addNamespaceIfNone,
   convertToDisplayName,
   convertToPluralDisplayName,
   convertType,
@@ -28,7 +27,6 @@ import {
   type ObjectType,
   OntologyEntityTypeEnum,
 } from "@osdk/maker";
-import invariant from "tiny-invariant";
 import type { importObjectDefinition } from "./types.js";
 
 /*
@@ -39,10 +37,6 @@ import type { importObjectDefinition } from "./types.js";
 export function defineImportObject(
   objectDef: importObjectDefinition,
 ): OntologyIrImportedObjectType {
-  invariant(
-    !objectDef.apiName.includes("."),
-    `Remove namespace or periods from imported object type ${objectDef.apiName}`,
-  );
   const properties: Array<ObjectPropertyType> = Object.entries(
     objectDef.properties ?? {},
   ).map(([apiName, type]) => ({
@@ -51,7 +45,7 @@ export function defineImportObject(
     type: type.type,
   }));
   const finalObject: ObjectType = {
-    apiName: addNamespaceIfNone(objectDef.apiName),
+    apiName: objectDef.apiName,
     properties: properties,
     __type: OntologyEntityTypeEnum.OBJECT_TYPE,
 
@@ -73,7 +67,6 @@ export function defineImportObject(
     }));
   const ontologyImportObject: OntologyIrImportedObjectType = {
     ...objectDef,
-    apiName: addNamespaceIfNone(objectDef.apiName),
     displayName: objectDef.displayName
       ?? convertToDisplayName(objectDef.apiName),
     propertyTypes: importPropertyTypes,

--- a/packages/maker-experimental/src/api/overall.test.ts
+++ b/packages/maker-experimental/src/api/overall.test.ts
@@ -33,8 +33,8 @@ describe("Experimental Test Suite", () => {
       const importedObject = defineImportObject({
         apiName: "myImport",
         properties: {
-          id: "string",
-          name: "string",
+          id: { type: "string" },
+          name: { type: "string" },
         },
       });
       const foo = defineObject({

--- a/packages/maker-experimental/src/api/overall.test.ts
+++ b/packages/maker-experimental/src/api/overall.test.ts
@@ -546,7 +546,7 @@ describe("Experimental Test Suite", () => {
             "linkTypes": [],
             "objectTypes": [
               {
-                "apiName": "myImport",
+                "apiName": "com.palantir.myImport",
                 "description": undefined,
                 "displayName": "MyImport",
                 "propertyTypes": [

--- a/packages/maker-experimental/src/api/overall.test.ts
+++ b/packages/maker-experimental/src/api/overall.test.ts
@@ -1,0 +1,593 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  defineCreateObjectAction,
+  defineObject,
+  defineOntology,
+  dumpOntologyFullMetadata,
+} from "@osdk/maker";
+import { beforeEach, describe, expect, it } from "vitest";
+import { defineImportObject } from "./importObjectType.js";
+
+describe("Experimental Test Suite", () => {
+  beforeEach(async () => {
+    await defineOntology("com.palantir.", () => {}, "/tmp/");
+  });
+
+  describe("Imports", () => {
+    it("Imported object types as action parameters are properly defined", () => {
+      const importedObject = defineImportObject({
+        apiName: "myImport",
+        properties: {
+          id: "string",
+          name: "string",
+        },
+      });
+      const foo = defineObject({
+        apiName: "foo",
+        displayName: "Foo",
+        pluralDisplayName: "Foos",
+        titlePropertyApiName: "id",
+        primaryKeyPropertyApiName: "id",
+        properties: {
+          "id": { type: "string" },
+          "date": { type: "date" },
+          "team": { type: "string" },
+        },
+      });
+      defineCreateObjectAction({
+        objectType: foo,
+        parameterOrdering: ["ref", "team", "id", "date"],
+        parameterConfiguration: {
+          "ref": {
+            customParameterType: {
+              type: "objectReference",
+              objectReference: {
+                objectTypeId: importedObject.apiName,
+              },
+            },
+          },
+          "team": {
+            defaultValue: {
+              type: "objectParameterPropertyValue",
+              objectParameterPropertyValue: {
+                parameterId: "ref",
+                propertyTypeId: "foo",
+              },
+            },
+          },
+        },
+      });
+      expect(dumpOntologyFullMetadata().blockData).toMatchInlineSnapshot(`
+          {
+            "actionTypes": {
+              "com.palantir.create-object-foo": {
+                "actionType": {
+                  "actionTypeLogic": {
+                    "logic": {
+                      "rules": [
+                        {
+                          "addObjectRule": {
+                            "objectTypeId": "com.palantir.foo",
+                            "propertyValues": {
+                              "date": {
+                                "parameterId": "date",
+                                "type": "parameterId",
+                              },
+                              "id": {
+                                "parameterId": "id",
+                                "type": "parameterId",
+                              },
+                              "team": {
+                                "parameterId": "team",
+                                "type": "parameterId",
+                              },
+                            },
+                            "structFieldValues": {},
+                          },
+                          "type": "addObjectRule",
+                        },
+                      ],
+                    },
+                    "validation": {
+                      "actionTypeLevelValidation": {
+                        "rules": {
+                          "0": {
+                            "condition": {
+                              "true": {},
+                              "type": "true",
+                            },
+                            "displayMetadata": {
+                              "failureMessage": "",
+                              "typeClasses": [],
+                            },
+                          },
+                        },
+                      },
+                      "parameterValidations": {
+                        "date": {
+                          "conditionalOverrides": [],
+                          "defaultValidation": {
+                            "display": {
+                              "renderHint": {
+                                "dateTimePicker": {},
+                                "type": "dateTimePicker",
+                              },
+                              "visibility": {
+                                "editable": {},
+                                "type": "editable",
+                              },
+                            },
+                            "validation": {
+                              "allowedValues": {
+                                "datetime": {
+                                  "datetime": {
+                                    "maximum": undefined,
+                                    "minimum": undefined,
+                                  },
+                                  "type": "datetime",
+                                },
+                                "type": "datetime",
+                              },
+                              "required": {
+                                "required": {},
+                                "type": "required",
+                              },
+                            },
+                          },
+                        },
+                        "id": {
+                          "conditionalOverrides": [],
+                          "defaultValidation": {
+                            "display": {
+                              "renderHint": {
+                                "textInput": {},
+                                "type": "textInput",
+                              },
+                              "visibility": {
+                                "editable": {},
+                                "type": "editable",
+                              },
+                            },
+                            "validation": {
+                              "allowedValues": {
+                                "text": {
+                                  "text": {},
+                                  "type": "text",
+                                },
+                                "type": "text",
+                              },
+                              "required": {
+                                "required": {},
+                                "type": "required",
+                              },
+                            },
+                          },
+                        },
+                        "ref": {
+                          "conditionalOverrides": [],
+                          "defaultValidation": {
+                            "display": {
+                              "renderHint": {
+                                "dropdown": {},
+                                "type": "dropdown",
+                              },
+                              "visibility": {
+                                "editable": {},
+                                "type": "editable",
+                              },
+                            },
+                            "validation": {
+                              "allowedValues": {
+                                "objectQuery": {
+                                  "objectQuery": {},
+                                  "type": "objectQuery",
+                                },
+                                "type": "objectQuery",
+                              },
+                              "required": {
+                                "required": {},
+                                "type": "required",
+                              },
+                            },
+                          },
+                        },
+                        "team": {
+                          "conditionalOverrides": [],
+                          "defaultValidation": {
+                            "display": {
+                              "prefill": {
+                                "objectParameterPropertyValue": {
+                                  "parameterId": "ref",
+                                  "propertyTypeId": "foo",
+                                },
+                                "type": "objectParameterPropertyValue",
+                              },
+                              "renderHint": {
+                                "textInput": {},
+                                "type": "textInput",
+                              },
+                              "visibility": {
+                                "editable": {},
+                                "type": "editable",
+                              },
+                            },
+                            "validation": {
+                              "allowedValues": {
+                                "text": {
+                                  "text": {},
+                                  "type": "text",
+                                },
+                                "type": "text",
+                              },
+                              "required": {
+                                "required": {},
+                                "type": "required",
+                              },
+                            },
+                          },
+                        },
+                      },
+                      "sectionValidations": {},
+                    },
+                  },
+                  "metadata": {
+                    "apiName": "com.palantir.create-object-foo",
+                    "displayMetadata": {
+                      "configuration": {
+                        "defaultLayout": "FORM",
+                        "displayAndFormat": {
+                          "table": {
+                            "columnWidthByParameterRid": {},
+                            "enableFileImport": true,
+                            "fitHorizontally": false,
+                            "frozenColumnCount": 0,
+                            "rowHeightInLines": 1,
+                          },
+                        },
+                        "enableLayoutUserSwitch": false,
+                      },
+                      "description": "",
+                      "displayName": "Create Foo",
+                      "icon": {
+                        "blueprint": {
+                          "color": "#000000",
+                          "locator": "edit",
+                        },
+                        "type": "blueprint",
+                      },
+                      "successMessage": [],
+                      "typeClasses": [],
+                    },
+                    "entities": {
+                      "affectedInterfaceTypes": [],
+                      "affectedLinkTypes": [],
+                      "affectedObjectTypes": [
+                        "com.palantir.foo",
+                      ],
+                      "typeGroups": [],
+                    },
+                    "formContentOrdering": [],
+                    "parameterOrdering": [
+                      "ref",
+                      "team",
+                      "id",
+                      "date",
+                    ],
+                    "parameters": {
+                      "date": {
+                        "displayMetadata": {
+                          "description": "",
+                          "displayName": "Date",
+                          "typeClasses": [],
+                        },
+                        "id": "date",
+                        "type": {
+                          "date": {},
+                          "type": "date",
+                        },
+                      },
+                      "id": {
+                        "displayMetadata": {
+                          "description": "",
+                          "displayName": "Id",
+                          "typeClasses": [],
+                        },
+                        "id": "id",
+                        "type": {
+                          "string": {},
+                          "type": "string",
+                        },
+                      },
+                      "ref": {
+                        "displayMetadata": {
+                          "description": "",
+                          "displayName": "Ref",
+                          "typeClasses": [],
+                        },
+                        "id": "ref",
+                        "type": {
+                          "objectReference": {
+                            "objectTypeId": "com.palantir.myImport",
+                          },
+                          "type": "objectReference",
+                        },
+                      },
+                      "team": {
+                        "displayMetadata": {
+                          "description": "",
+                          "displayName": "Team",
+                          "typeClasses": [],
+                        },
+                        "id": "team",
+                        "type": {
+                          "string": {},
+                          "type": "string",
+                        },
+                      },
+                    },
+                    "sections": {},
+                    "status": {
+                      "active": {},
+                      "type": "active",
+                    },
+                  },
+                },
+              },
+            },
+            "blockPermissionInformation": {
+              "actionTypes": {},
+              "linkTypes": {},
+              "objectTypes": {},
+            },
+            "interfaceTypes": {},
+            "linkTypes": {},
+            "objectTypes": {
+              "com.palantir.foo": {
+                "datasources": [
+                  {
+                    "datasource": {
+                      "datasetV2": {
+                        "datasetRid": "com.palantir.foo",
+                        "propertyMapping": {
+                          "date": {
+                            "column": "date",
+                            "type": "column",
+                          },
+                          "id": {
+                            "column": "id",
+                            "type": "column",
+                          },
+                          "team": {
+                            "column": "team",
+                            "type": "column",
+                          },
+                        },
+                      },
+                      "type": "datasetV2",
+                    },
+                    "editsConfiguration": {
+                      "onlyAllowPrivilegedEdits": false,
+                    },
+                    "redacted": false,
+                    "rid": "ri.ontology.main.datasource.com.palantir.foo",
+                  },
+                ],
+                "entityMetadata": {
+                  "arePatchesEnabled": false,
+                },
+                "objectType": {
+                  "allImplementsInterfaces": {},
+                  "apiName": "com.palantir.foo",
+                  "displayMetadata": {
+                    "description": undefined,
+                    "displayName": "Foo",
+                    "groupDisplayName": undefined,
+                    "icon": {
+                      "blueprint": {
+                        "color": "#2D72D2",
+                        "locator": "cube",
+                      },
+                      "type": "blueprint",
+                    },
+                    "pluralDisplayName": "Foos",
+                    "visibility": "NORMAL",
+                  },
+                  "implementsInterfaces2": [],
+                  "primaryKeys": [
+                    "id",
+                  ],
+                  "propertyTypes": {
+                    "date": {
+                      "apiName": "date",
+                      "baseFormatter": undefined,
+                      "dataConstraints": undefined,
+                      "displayMetadata": {
+                        "description": undefined,
+                        "displayName": "Date",
+                        "visibility": "NORMAL",
+                      },
+                      "indexedForSearch": true,
+                      "inlineAction": undefined,
+                      "ruleSetBinding": undefined,
+                      "sharedPropertyTypeApiName": undefined,
+                      "sharedPropertyTypeRid": undefined,
+                      "status": {
+                        "active": {},
+                        "type": "active",
+                      },
+                      "type": {
+                        "date": {},
+                        "type": "date",
+                      },
+                      "typeClasses": [
+                        {
+                          "kind": "render_hint",
+                          "name": "SELECTABLE",
+                        },
+                        {
+                          "kind": "render_hint",
+                          "name": "SORTABLE",
+                        },
+                      ],
+                      "valueType": undefined,
+                    },
+                    "id": {
+                      "apiName": "id",
+                      "baseFormatter": undefined,
+                      "dataConstraints": undefined,
+                      "displayMetadata": {
+                        "description": undefined,
+                        "displayName": "Id",
+                        "visibility": "NORMAL",
+                      },
+                      "indexedForSearch": true,
+                      "inlineAction": undefined,
+                      "ruleSetBinding": undefined,
+                      "sharedPropertyTypeApiName": undefined,
+                      "sharedPropertyTypeRid": undefined,
+                      "status": {
+                        "active": {},
+                        "type": "active",
+                      },
+                      "type": {
+                        "string": {
+                          "analyzerOverride": undefined,
+                          "enableAsciiFolding": undefined,
+                          "isLongText": false,
+                          "supportsEfficientLeadingWildcard": false,
+                          "supportsExactMatching": true,
+                        },
+                        "type": "string",
+                      },
+                      "typeClasses": [
+                        {
+                          "kind": "render_hint",
+                          "name": "SELECTABLE",
+                        },
+                        {
+                          "kind": "render_hint",
+                          "name": "SORTABLE",
+                        },
+                      ],
+                      "valueType": undefined,
+                    },
+                    "team": {
+                      "apiName": "team",
+                      "baseFormatter": undefined,
+                      "dataConstraints": undefined,
+                      "displayMetadata": {
+                        "description": undefined,
+                        "displayName": "Team",
+                        "visibility": "NORMAL",
+                      },
+                      "indexedForSearch": true,
+                      "inlineAction": undefined,
+                      "ruleSetBinding": undefined,
+                      "sharedPropertyTypeApiName": undefined,
+                      "sharedPropertyTypeRid": undefined,
+                      "status": {
+                        "active": {},
+                        "type": "active",
+                      },
+                      "type": {
+                        "string": {
+                          "analyzerOverride": undefined,
+                          "enableAsciiFolding": undefined,
+                          "isLongText": false,
+                          "supportsEfficientLeadingWildcard": false,
+                          "supportsExactMatching": true,
+                        },
+                        "type": "string",
+                      },
+                      "typeClasses": [
+                        {
+                          "kind": "render_hint",
+                          "name": "SELECTABLE",
+                        },
+                        {
+                          "kind": "render_hint",
+                          "name": "SORTABLE",
+                        },
+                      ],
+                      "valueType": undefined,
+                    },
+                  },
+                  "redacted": false,
+                  "status": {
+                    "active": {},
+                    "type": "active",
+                  },
+                  "titlePropertyTypeRid": "id",
+                },
+              },
+            },
+            "sharedPropertyTypes": {},
+          }
+        `);
+      expect(dumpOntologyFullMetadata().importedTypes).toMatchInlineSnapshot(`
+          {
+            "actionTypes": [],
+            "interfaceTypes": [],
+            "linkTypes": [],
+            "objectTypes": [
+              {
+                "apiName": "myImport",
+                "description": undefined,
+                "displayName": "MyImport",
+                "propertyTypes": [
+                  {
+                    "apiName": "id",
+                    "description": undefined,
+                    "displayName": "Id",
+                    "sharedPropertyType": undefined,
+                    "type": {
+                      "string": {
+                        "analyzerOverride": undefined,
+                        "enableAsciiFolding": undefined,
+                        "isLongText": false,
+                        "supportsEfficientLeadingWildcard": false,
+                        "supportsExactMatching": true,
+                      },
+                      "type": "string",
+                    },
+                  },
+                  {
+                    "apiName": "name",
+                    "description": undefined,
+                    "displayName": "Name",
+                    "sharedPropertyType": undefined,
+                    "type": {
+                      "string": {
+                        "analyzerOverride": undefined,
+                        "enableAsciiFolding": undefined,
+                        "isLongText": false,
+                        "supportsEfficientLeadingWildcard": false,
+                        "supportsExactMatching": true,
+                      },
+                      "type": "string",
+                    },
+                  },
+                ],
+              },
+            ],
+            "sharedPropertyTypes": [],
+          }
+        `);
+    });
+  });
+});

--- a/packages/maker-experimental/src/api/overall.test.ts
+++ b/packages/maker-experimental/src/api/overall.test.ts
@@ -322,7 +322,7 @@ describe("Experimental Test Suite", () => {
                         "id": "ref",
                         "type": {
                           "objectReference": {
-                            "objectTypeId": "com.palantir.myImport",
+                            "objectTypeId": "myImport",
                           },
                           "type": "objectReference",
                         },
@@ -546,7 +546,7 @@ describe("Experimental Test Suite", () => {
             "linkTypes": [],
             "objectTypes": [
               {
-                "apiName": "com.palantir.myImport",
+                "apiName": "myImport",
                 "description": undefined,
                 "displayName": "MyImport",
                 "propertyTypes": [

--- a/packages/maker-experimental/src/api/types.ts
+++ b/packages/maker-experimental/src/api/types.ts
@@ -17,14 +17,14 @@
 import type { PropertyTypeType } from "@osdk/maker";
 
 // basically a user friendly OntologyIrImportedActionType wrapper
-export type importObjectDefinition = {
+export type ImportObjectDefinition = {
   apiName: string;
-  properties: Record<string, importPropertyTypeDefinition>;
+  properties: Record<string, ImportPropertyTypeDefinition>;
   displayName?: string;
   description?: string;
 };
 
-export type importPropertyTypeDefinition = {
+export type ImportPropertyTypeDefinition = {
   type: PropertyTypeType;
   displayName?: string;
   description?: string;

--- a/packages/maker-experimental/src/api/types.ts
+++ b/packages/maker-experimental/src/api/types.ts
@@ -14,4 +14,14 @@
  * limitations under the License.
  */
 
-export type importObject = {};
+import type { PropertyTypeType } from "@osdk/maker";
+
+// minimal info needed to generate objectType input shape
+export type importObjectDefinition = {
+  apiName: string;
+  properties: Record<string, PropertyTypeType>;
+  displayName?: string;
+  pluralDisplayName?: string;
+  titlePropertyApiName?: string;
+  primaryKeyPropertyApiName?: string;
+};

--- a/packages/maker-experimental/src/api/types.ts
+++ b/packages/maker-experimental/src/api/types.ts
@@ -16,12 +16,17 @@
 
 import type { PropertyTypeType } from "@osdk/maker";
 
-// minimal info needed to generate objectType input shape
+// basically a user friendly OntologyIrImportedActionType wrapper
 export type importObjectDefinition = {
   apiName: string;
-  properties: Record<string, PropertyTypeType>;
+  properties: Record<string, importPropertyTypeDefinition>;
   displayName?: string;
-  pluralDisplayName?: string;
-  titlePropertyApiName?: string;
-  primaryKeyPropertyApiName?: string;
+  description?: string;
+};
+
+export type importPropertyTypeDefinition = {
+  type: PropertyTypeType;
+  displayName?: string;
+  description?: string;
+  sharedPropertyType?: string;
 };

--- a/packages/maker-experimental/src/api/types.ts
+++ b/packages/maker-experimental/src/api/types.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type importObject = {};

--- a/packages/maker-experimental/src/index.ts
+++ b/packages/maker-experimental/src/index.ts
@@ -16,6 +16,6 @@
 
 export { defineImportObject } from "./api/importObjectType.js";
 export type {
-  importObjectDefinition,
-  importPropertyTypeDefinition,
+  ImportObjectDefinition,
+  ImportPropertyTypeDefinition,
 } from "./api/types.js";

--- a/packages/maker-experimental/src/index.ts
+++ b/packages/maker-experimental/src/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export {};

--- a/packages/maker-experimental/src/index.ts
+++ b/packages/maker-experimental/src/index.ts
@@ -15,3 +15,7 @@
  */
 
 export { defineImportObject } from "./api/importObjectType.js";
+export type {
+  importObjectDefinition,
+  importPropertyTypeDefinition,
+} from "./api/types.js";

--- a/packages/maker-experimental/src/index.ts
+++ b/packages/maker-experimental/src/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export {};
+export { defineImportObject } from "./api/importObjectType.js";

--- a/packages/maker-experimental/tsconfig.json
+++ b/packages/maker-experimental/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@osdk/monorepo.tsconfig/base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build/esm"
+  },
+  "include": [
+    "./src/**/*"
+  ],
+  "references": []
+}

--- a/packages/maker-experimental/vitest.config.mts
+++ b/packages/maker-experimental/vitest.config.mts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { configDefaults, defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    pool: "forks",
+    exclude: [...configDefaults.exclude, "**/build/**/*"],
+    fakeTimers: {
+      toFake: ["setTimeout", "clearTimeout", "Date"],
+    },
+  },
+});

--- a/packages/maker/src/api/defineAction.ts
+++ b/packages/maker/src/api/defineAction.ts
@@ -683,20 +683,7 @@ function createParameters(
   defaultRequired: boolean,
 ): Array<ActionParameter> {
   const targetParam: Array<ActionParameter> = [];
-  // prefix objectReference parameters with the namespace
   parameterSet.forEach(name => {
-    if (
-      typeof def.parameterConfiguration?.[name]?.customParameterType
-        === "object"
-      && def.parameterConfiguration?.[name]?.customParameterType.type
-        === "objectReference"
-    ) {
-      def.parameterConfiguration[name].customParameterType.objectReference
-        .objectTypeId = sanitize(
-          def.parameterConfiguration[name].customParameterType.objectReference
-            .objectTypeId,
-        );
-    }
     if (name === MODIFY_OBJECT_PARAMETER) {
       targetParam.push({
         id: MODIFY_OBJECT_PARAMETER,

--- a/packages/maker/src/cli/main.ts
+++ b/packages/maker/src/cli/main.ts
@@ -15,7 +15,6 @@
  */
 
 import { consola } from "consola";
-import { createJiti } from "jiti";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import invariant from "tiny-invariant";
@@ -129,16 +128,7 @@ async function loadOntology(
 ) {
   const q = await defineOntology(
     apiNamespace,
-    async () => {
-      const jiti = createJiti(import.meta.filename, {
-        moduleCache: true,
-        debug: false,
-        importMeta: import.meta,
-      });
-      const module = await jiti.import(input);
-
-      // await import(input);
-    },
+    async () => await import(input),
     outputDir,
     dependencyFile,
   );

--- a/packages/maker/src/cli/main.ts
+++ b/packages/maker/src/cli/main.ts
@@ -15,6 +15,7 @@
  */
 
 import { consola } from "consola";
+import { createJiti } from "jiti";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import invariant from "tiny-invariant";
@@ -128,7 +129,16 @@ async function loadOntology(
 ) {
   const q = await defineOntology(
     apiNamespace,
-    async () => await import(input),
+    async () => {
+      const jiti = createJiti(import.meta.filename, {
+        moduleCache: true,
+        debug: false,
+        importMeta: import.meta,
+      });
+      const module = await jiti.import(input);
+
+      // await import(input);
+    },
     outputDir,
     dependencyFile,
   );

--- a/packages/maker/src/index.ts
+++ b/packages/maker/src/index.ts
@@ -30,8 +30,15 @@ export { importSharedPropertyType } from "./api/defineImportSpt.js";
 export { defineInterface } from "./api/defineInterface.js";
 export { defineInterfaceLinkConstraint } from "./api/defineInterfaceLinkConstraint.js";
 export { defineLink } from "./api/defineLink.js";
-export { defineObject } from "./api/defineObject.js";
-export { defineOntology } from "./api/defineOntology.js";
+export {
+  convertToDisplayName,
+  convertToPluralDisplayName,
+  defineObject,
+} from "./api/defineObject.js";
+export {
+  defineOntology,
+  dumpOntologyFullMetadata,
+} from "./api/defineOntology.js";
 export { defineSharedPropertyType } from "./api/defineSpt.js";
 export { defineValueType } from "./api/defineValueType.js";
 export { importOntologyEntity } from "./api/importOntologyEntity.js";
@@ -49,7 +56,9 @@ export type {
   InterfaceType,
   LinkType,
   MappingValue,
+  ObjectPropertyType,
   ObjectType,
+  PropertyTypeType,
   SectionConditionalOverride,
   SharedPropertyType,
   UuidMappingValue,

--- a/packages/maker/src/index.ts
+++ b/packages/maker/src/index.ts
@@ -42,6 +42,7 @@ export {
 export { defineSharedPropertyType } from "./api/defineSpt.js";
 export { defineValueType } from "./api/defineValueType.js";
 export { importOntologyEntity } from "./api/importOntologyEntity.js";
+export { convertType } from "./api/propertyConversionUtils.js";
 export type {
   ActionParameterAllowedValues,
   ActionParameterConditionalOverride,

--- a/packages/maker/src/index.ts
+++ b/packages/maker/src/index.ts
@@ -36,6 +36,7 @@ export {
   defineObject,
 } from "./api/defineObject.js";
 export {
+  addNamespaceIfNone,
   defineOntology,
   dumpOntologyFullMetadata,
 } from "./api/defineOntology.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3401,6 +3401,34 @@ importers:
         specifier: ^3.0.5
         version: 3.0.7(@types/node@20.17.47)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@20.17.47)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
 
+  packages/maker-experimental:
+    dependencies:
+      '@osdk/api':
+        specifier: workspace:~
+        version: link:../api
+      tiny-invariant:
+        specifier: ^1.3.3
+        version: 1.3.3
+    devDependencies:
+      '@osdk/client.unstable':
+        specifier: workspace:~
+        version: link:../client.unstable
+      '@osdk/maker':
+        specifier: workspace:~
+        version: link:../maker
+      '@osdk/monorepo.api-extractor':
+        specifier: workspace:~
+        version: link:../monorepo.api-extractor
+      '@osdk/monorepo.tsconfig':
+        specifier: workspace:~
+        version: link:../monorepo.tsconfig
+      typescript:
+        specifier: ~5.5.4
+        version: 5.5.4
+      vitest:
+        specifier: ^3.0.5
+        version: 3.0.7(@types/node@24.0.3)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@24.0.3)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+
   packages/monorepo.api-extractor: {}
 
   packages/monorepo.cspell:


### PR DESCRIPTION
The goal is to support existing OTs as action parameters in OAC. I created an importOntologyEntity wrapper that takes in the minimal information needed to produce input shapes. We need a more complete definition to actually call importOntologyEntity, so I produced that with some inferred fields (primary key, title key, etc.). The actual type returned by this wrapper only contains fields that are safe to use and not inferred (it's just a OntologyIrImportedObjectType).
The test shows how this feature is supposed to be used.

This is pretty hacky overall, but that was the expectation going into this FR. We've made a maker-experimental package to reflect this