### PR TITLE
fix(faux): Fix strict link association between different object types

### DIFF
--- a/.changeset/fix-link-association.md
+++ b/.changeset/fix-link-association.md
@@ -1,0 +1,5 @@
+---
+"@osdk/faux": patch
+---
+
+Fixes strict link association between different object types and improves error messages.


### PR DESCRIPTION
## Summary
- Fixes critical bug in FauxDataStore where wrong object type apiName was used when setting up links between different object types
- Improves error messages for link removal failures with detailed JSON information
- Changes registerObject to return the frozen BaseServerObject for better API consistency

## Problem
The `ea.observe-links` branch contains a large feature implementation that includes critical fixes for the `@osdk/faux` package. These fixes address a bug where the wrong object type apiName is used when setting up links between different object types, causing tests to fail with errors like:
```
Invariant failed: Failed to remove link: expected "Project:b" but found "Employee:b" for link owner on "Project:p1"
```

## Solution
This PR extracts only the critical bug fixes from the larger feature branch:

1. **Fixed critical link association bug** - Changed from `dstSide.objectTypeApiName` to `linkDef.objectTypeApiName` in three places in `replaceObjectOrThrow` method
2. **Enhanced error messages** - Added detailed JSON serialization in error messages for easier debugging
3. **API improvement** - `registerObject` now returns the frozen BaseServerObject
4. **Comprehensive tests** - Added test cases for cross-type linking between Employee and Project objects

## Test plan
- [x] All existing tests pass
- [x] Added comprehensive test case for cross-type linking
- [x] TypeScript compilation succeeds
- [x] Tests cover ONE and MANY cardinality links, ownership changes, and foreign key updates