### PR TITLE
Fix subscribeToObjectSetInstructions formatting

### DIFF
--- a/packages/typescript-sdk-docs/src/documentation.yml
+++ b/packages/typescript-sdk-docs/src/documentation.yml
@@ -1780,7 +1780,7 @@ versions:
             import { {{objectType}} } from "{{{packageName}}}";
             // Edit this import if your client location differs
             import { client } from "./client";
-            
+
             const maxObjectsInList = 75; // Adjust this value as needed between 1 and 100
             const sum{{objectType}} = await client({{objectType}})
                 .withProperties({
@@ -1949,75 +1949,44 @@ versions:
                 return obj.{{property}}.getLatestValue();
             }
       subscribeToObjectSetInstructions:
-        - template: "import { {{objectOrInterfaceApiName}} } from \"{{{packageName}}}\";
-
+        - template: |-
+            import { {{objectOrInterfaceApiName}} } from "{{{packageName}}}";
             // Edit this import if your client location differs
-
-            import { client } from \"./client\";
-
+            import { client } from "./client";
 
             // A map of primary keys to objects loaded through the SDK
-
             const objects: { [key: string]: {{objectOrInterfaceApiName}}.OsdkInstance } = ...
 
-
             const subscription = client({{objectOrInterfaceApiName}}).subscribe(
-            \        {
+                {
+                    onChange(update) {
+                        if (update.state === "ADDED_OR_UPDATED") {
+                            // An object has received an update or an object was added to the object set
+                            const currentObject = objects[update.object.$primaryKey];
+                            if (currentObject !== undefined) {
+                                currentObject["<propertyName>"] = update.object["<propertyName>"] ?? currentObject["<propertyName>"];
+                            }
+                        }
+                        else if (update.state === "REMOVED") {
+                            // The object was removed from the object set, which could mean it was deleted or no longer meets the filter criteria
+                            delete objects[update.object.$primaryKey];
+                        }
+                    },
+                    onSuccessfulSubscription() {
+                        // The subscription was successful and you can expect to receive updates
+                    },
+                    onError(err) {
+                        // There was an error with the subscription and you will not receive any more updates
+                        console.error(err);
+                    },
+                    onOutOfDate() {
+                        // We could not keep track of all changes. Please reload the objects in your set.
+                    },
+                },
+                { properties: [ {{#propertyNames}}"{{.}}", {{/propertyNames}}\b\b] }
+            );
 
-            \            onChange(update) {
-
-            \                if (update.state === \"ADDED_OR_UPDATED\") {
-
-            \                    // An object has received an update or an object was added to the object set
-
-            \                    const currentObject = objects[update.object.$primaryKey];
-
-            \                    if (currentObject !== undefined) {
-
-            \                        currentObject[\"<propertyName>\"] = update.object[\"<propertyName>\"] ?? currentObject[\"<propertyName>\"];
-
-            \                    }
-
-            \                }
-
-            \                else if (update.state === \"REMOVED\") {
-
-            \                    // The object was removed from the object set, which could mean it was deleted or no longer meets the filter criteria
-
-            \                    delete objects[update.object.$primaryKey];
-
-            \                }
-
-            \            },
-
-            \            onSuccessfulSubscription() {
-
-            \                // The subscription was successful and you can expect to receive updates
-
-            \            },
-
-            \            onError(err) {
-
-            \                // There was an error with the subscription and you will not receive any more updates
-
-            \                console.error(err);
-
-            \            },
-
-            \            onOutOfDate() {
-
-            \                // We could not keep track of all changes. Please reload the objects in your set.
-
-            \            },
-
-            \        },
-
-            \        { properties: [ {{#propertyNames}}\"{{.}}\", {{/propertyNames}}\b\b]}
-
-            \    );
-
-
-            subscription.unsubscribe();"
+            subscription.unsubscribe();
       uploadMedia:
         - template: |-
             import { __EXPERIMENTAL__NOT_SUPPORTED_YET__createMediaReference } from "@osdk/api/unstable";


### PR DESCRIPTION
Currently the "Subscribe to object sets" section of the Developer Console documentation looks a bit off with a lot of added spacing.

<img width="544" height="655" alt="Screenshot 2025-08-21 at 5 46 01 PM" src="https://github.com/user-attachments/assets/f9b45676-a98d-4166-8b81-1bd41ba4fe33" />


Looking at the `documentation.yml`, it also seems like it is not using the `|-` convention that every other documentation string uses. 

There might be some historical reason for that that I'm missing but wanted to float a potential fix to address the formatting issue and hopefully make it look uniformed with the other docs!