### PR TITLE
Fix interface -> interface links

### DIFF
--- a/packages/client/src/util/extractObjectOrInterfaceType.test.ts
+++ b/packages/client/src/util/extractObjectOrInterfaceType.test.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { InterfaceMetadata, ObjectMetadata } from "@osdk/api";
+import type { ObjectSet } from "@osdk/foundry.ontologies";
+import { describe, expect, it } from "vitest";
+import type { MinimalClient } from "../MinimalClientContext.js";
+import { extractObjectOrInterfaceType } from "./extractObjectOrInterfaceType.js";
+
+describe("extractRdpDefinition", () => {
+  const mockClientCtx = {
+    ontologyProvider: {
+      getObjectDefinition: (objectType: string) => {
+        if (objectType === "BaseType") {
+          return {
+            links: {
+              testLink1: {
+                targetType: "SecondType",
+                "multiplicity": "many",
+              } satisfies ObjectMetadata.Link<any, any>,
+            },
+          };
+        } else if (objectType === "SecondType") {
+          return {
+            links: {
+              testLink2: {
+                targetType: "ThirdType",
+                "multiplicity": "many",
+              } satisfies ObjectMetadata.Link<any, any>,
+            },
+          };
+        } else if (objectType === "ThirdType") {
+          return {
+            properties: {
+              testProperty: {
+                type: "attachment",
+              } satisfies ObjectMetadata.Property,
+            },
+          };
+        } else {
+          throw new Error(`Missing definition for '${objectType}'`);
+        }
+      },
+      getInterfaceDefinition: (interfaceType: string) => {
+        if (interfaceType === "interface1") {
+          return {
+            links: {
+              linkToInterface2: {
+                targetType: "interface",
+                targetTypeApiName: "interface2",
+                multiplicity: false,
+              } satisfies InterfaceMetadata.Link<any, any>,
+            },
+          };
+        } else if (interfaceType === "interface1") {
+          return {
+            links: {
+              linkToInterface1: {
+                targetType: "interface",
+                targetTypeApiName: "interface1",
+                multiplicity: false,
+              } satisfies InterfaceMetadata.Link<any, any>,
+            },
+          };
+        } else {
+          throw new Error(`Missing definition for '${interfaceType}'`);
+        }
+      },
+    } as any,
+  } as MinimalClient;
+
+  const objectSetInterfaceToInterface: ObjectSet = {
+    type: "interfaceLinkSearchAround",
+    objectSet: {
+      type: "interfaceBase",
+      interfaceType: "interface1",
+    },
+    interfaceLink: "linkToInterface2",
+  };
+
+  it("handles 'withProperties' object set type", async () => {
+    const result = await extractObjectOrInterfaceType(
+      mockClientCtx,
+      objectSetInterfaceToInterface,
+    );
+
+    expect(result).toEqual({ apiName: "interface2", type: "interface" });
+  });
+
+  it("handles `intersection` object set type and nested static and reference object sets", async () => {
+    const intersectionObjectSet: ObjectSet = {
+      type: "intersect",
+      objectSets: [
+        {
+          type: "interfaceLinkSearchAround",
+          objectSet: {
+            type: "interfaceBase",
+            interfaceType: "interface1",
+          },
+          interfaceLink: "linkToInterface2",
+        },
+        { type: "static", "objects": ["object1", "object2"] },
+        { type: "reference", "reference": "rid.os.1234" },
+      ],
+    };
+
+    const result = await extractObjectOrInterfaceType(
+      mockClientCtx,
+      intersectionObjectSet,
+    );
+
+    expect(result).toEqual({ apiName: "interface2", type: "interface" });
+  });
+
+  it("throes with intersect, subtract, or union having different child object types", async () => {
+    const intersectionObjectSet: ObjectSet = {
+      type: "intersect",
+      objectSets: [
+        {
+          type: "interfaceLinkSearchAround",
+          objectSet: {
+            type: "interfaceBase",
+            interfaceType: "interface1",
+          },
+          interfaceLink: "linkToInterface2",
+        },
+        { type: "interfaceBase", interfaceType: "interface1" },
+      ],
+    };
+
+    await expect(
+      extractObjectOrInterfaceType(mockClientCtx, intersectionObjectSet),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: Invariant failed: Can only have one object type when doing intersects, subtract, union]`,
+    );
+  });
+});

--- a/packages/client/src/util/extractObjectOrInterfaceType.ts
+++ b/packages/client/src/util/extractObjectOrInterfaceType.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectOrInterfaceDefinition } from "@osdk/api";
+import type { ObjectSet } from "@osdk/foundry.ontologies";
+import invariant from "tiny-invariant";
+import type { MinimalClient } from "../MinimalClientContext.js";
+
+export async function extractObjectOrInterfaceType(
+  clientCtx: MinimalClient,
+  objectSet: ObjectSet,
+): Promise<
+  ObjectOrInterfaceDefinition | undefined
+> {
+  return (await extractObjectOrInterfaceTypeInternal(
+    clientCtx,
+    objectSet,
+  ));
+}
+
+/* @internal
+* Returns the resultant interface type of the object set, undefined if it's an object type
+*/
+async function extractObjectOrInterfaceTypeInternal(
+  clientCtx: MinimalClient,
+  objectSet: ObjectSet,
+): Promise<
+  ObjectOrInterfaceDefinition | undefined
+> {
+  switch (objectSet.type) {
+    case "searchAround": {
+      const def = await extractObjectOrInterfaceTypeInternal(
+        clientCtx,
+        objectSet.objectSet,
+      );
+      if (def === undefined) {
+        return undefined;
+      }
+      const objOrInterfaceDef = def.type === "object"
+        ? await clientCtx.ontologyProvider.getObjectDefinition(
+          def.apiName,
+        )
+        : await clientCtx.ontologyProvider.getInterfaceDefinition(
+          def.apiName,
+        );
+      const linkDef = objOrInterfaceDef.links[objectSet.link];
+      invariant(linkDef, `Missing link definition for '${objectSet.link}'`);
+
+      return objOrInterfaceDef.type === "object"
+        ? {
+          apiName: objOrInterfaceDef.links[objectSet.link].targetType,
+          type: "object",
+        }
+        : {
+          apiName: objOrInterfaceDef.links[objectSet.link].targetTypeApiName,
+          type: objOrInterfaceDef.links[objectSet.link].targetType,
+        };
+    }
+    case "withProperties": {
+      return extractObjectOrInterfaceTypeInternal(
+        clientCtx,
+        objectSet.objectSet,
+      );
+    }
+    case "methodInput":
+      return undefined;
+    case "base":
+      return { type: "object", apiName: objectSet.objectType };
+    case "interfaceBase":
+      return { type: "interface", apiName: objectSet.interfaceType };
+    case "filter":
+    case "asBaseObjectTypes":
+    case "asType":
+    case "nearestNeighbors":
+      return extractObjectOrInterfaceTypeInternal(
+        clientCtx,
+        objectSet.objectSet,
+      );
+    case "intersect":
+    case "subtract":
+    case "union":
+      const objectSets = objectSet.objectSets;
+      const objectSetTypes = await Promise.all(
+        objectSets.map((os) =>
+          extractObjectOrInterfaceTypeInternal(
+            clientCtx,
+            os,
+          )
+        ),
+      );
+
+      const filteredObjectTypes = objectSetTypes.filter(Boolean);
+      invariant(
+        filteredObjectTypes.length === 1,
+        "Can only have one object type when doing intersects, subtract, union",
+      );
+      return filteredObjectTypes[0];
+    case "static":
+    case "reference":
+      // Static and reference object sets are always intersected with a base object set, so we can just return undefined.
+      return undefined;
+    // We don't have to worry about new object sets being added and doing a runtime break and breaking people since the OSDK is always constructing these.
+    case "interfaceLinkSearchAround":
+      const def = await extractObjectOrInterfaceTypeInternal(
+        clientCtx,
+        objectSet.objectSet,
+      );
+      if (def === undefined) {
+        return undefined;
+      }
+      const objOrInterfaceDef = def.type === "object"
+        ? await clientCtx.ontologyProvider.getObjectDefinition(
+          def.apiName,
+        )
+        : await clientCtx.ontologyProvider.getInterfaceDefinition(
+          def.apiName,
+        );
+      const linkDef = objOrInterfaceDef.links[objectSet.interfaceLink];
+      invariant(
+        linkDef,
+        `Missing link definition for '${objectSet.interfaceLink}'`,
+      );
+      return objOrInterfaceDef.type === "object"
+        ? {
+          apiName: objOrInterfaceDef.links[objectSet.interfaceLink].targetType,
+          type: "object",
+        }
+        : {
+          apiName:
+            objOrInterfaceDef.links[objectSet.interfaceLink].targetTypeApiName,
+          type: objOrInterfaceDef.links[objectSet.interfaceLink].targetType,
+        };
+    default:
+      const _: never = objectSet;
+      invariant(
+        false,
+        `Unsupported object set type for Runtime Derived Properties`,
+      );
+  }
+}

--- a/packages/e2e.sandbox.catchall/src/runInterfacesTest2.ts
+++ b/packages/e2e.sandbox.catchall/src/runInterfacesTest2.ts
@@ -17,7 +17,7 @@
 import type { Osdk } from "@osdk/api";
 import {
   Athlete,
-  CollateralConcernList,
+  CollateralConcernCandidate,
   EsongInterfaceA,
   NbaPlayer,
 } from "@osdk/e2e.generated.catchall";
@@ -79,12 +79,14 @@ export async function runInterfacesTest2(): Promise<void> {
   });
 
   // interface to interface
-  const concernList = await dsClient(CollateralConcernList).pivotTo(
-    "com.palantir.pcl.civpro.collateral-concern-core.collateralConcernListToEntity",
+  const concernCandidates2 = await dsClient(CollateralConcernCandidate)
+    .fetchPage();
+  const concernList2 = await dsClient(CollateralConcernCandidate).pivotTo(
+    "com.palantir.pcl.civpro.collateral-concern-core.collateralConcernEntityToList",
   ).fetchPage();
 
-  // this will be empty because no implementations
-  console.log("linked entities", concernList.data);
+  console.log("concern candidates", concernCandidates2.data);
+  console.log("linked list entities", concernList2.data);
 
   // interface to object
   const pds = await dsClient(EsongInterfaceA).pivotTo("esongPds").fetchPage();


### PR DESCRIPTION
Before we had issues going between interfaces in links because we weren't keeping track of the resultant interface type. We unfortunately need this because we need to know what interface type to index into the interface -> object mapping 