### PR TITLE
Add Principal Type

### DIFF
--- a/.changeset/tired-frogs-jump.md
+++ b/.changeset/tired-frogs-jump.md
@@ -1,0 +1,5 @@
+---
+"@osdk/functions": patch
+---
+
+Add Principal Type

--- a/etc/functions.report.api.md
+++ b/etc/functions.report.api.md
@@ -161,10 +161,7 @@ export interface PlatformNotification {
 
 // @public (undocumented)
 export type Principal = {
-    	type: "user"
-    	id: string
-} | {
-    	type: "group"
+    	type: "user" | "group"
     	id: string
 };
 

--- a/etc/functions.report.api.md
+++ b/etc/functions.report.api.md
@@ -159,6 +159,12 @@ export interface PlatformNotification {
     links: NotificationLink[];
 }
 
+// Warning: (ae-forgotten-export) The symbol "UserId" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "GroupId" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type Principal = UserId | GroupId;
+
 export { Range_2 as Range }
 
 // @public (undocumented)

--- a/etc/functions.report.api.md
+++ b/etc/functions.report.api.md
@@ -161,8 +161,11 @@ export interface PlatformNotification {
 
 // @public (undocumented)
 export type Principal = {
-    	type: "user" | "group"
-    	id: string
+    type: "user"
+    id: string
+} | {
+    type: "group"
+    id: string
 };
 
 export { Range_2 as Range }

--- a/etc/functions.report.api.md
+++ b/etc/functions.report.api.md
@@ -159,11 +159,14 @@ export interface PlatformNotification {
     links: NotificationLink[];
 }
 
-// Warning: (ae-forgotten-export) The symbol "UserId" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "GroupId" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export type Principal = UserId | GroupId;
+export type Principal = {
+    	type: "user"
+    	id: string
+} | {
+    	type: "group"
+    	id: string
+};
 
 export { Range_2 as Range }
 

--- a/packages/functions/src/Principal.ts
+++ b/packages/functions/src/Principal.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type Principal = UserId | GroupId;
+
+type UserId = {
+  type: "user";
+  id: string;
+};
+
+type GroupId = {
+  type: "group";
+  id: string;
+};

--- a/packages/functions/src/Principal.ts
+++ b/packages/functions/src/Principal.ts
@@ -15,9 +15,6 @@
  */
 
 export type Principal = {
-  type: "user";
-  id: string;
-} | {
-  type: "group";
+  type: "user" | "group";
   id: string;
 };

--- a/packages/functions/src/Principal.ts
+++ b/packages/functions/src/Principal.ts
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-export type Principal = UserId | GroupId;
-
-type UserId = {
+export type Principal = {
   type: "user";
   id: string;
-};
-
-type GroupId = {
+} | {
   type: "group";
   id: string;
 };

--- a/packages/functions/src/Principal.ts
+++ b/packages/functions/src/Principal.ts
@@ -15,6 +15,9 @@
  */
 
 export type Principal = {
-  type: "user" | "group";
+  type: "user";
+  id: string;
+} | {
+  type: "group";
   id: string;
 };

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -44,3 +44,5 @@ export type {
   RidLinkTarget,
   UrlLinkTarget,
 } from "./Notification.js";
+
+export type { Principal } from "./Principal.ts";


### PR DESCRIPTION
Add a principal type exported from @osdk/functions to allow for runtime differentiation between userid and groupid types (string types imported from PSDK)
