### PR TITLE
Fix casting support for object -> interface

### DIFF
--- a/.changeset/yellow-moments-open.md
+++ b/.changeset/yellow-moments-open.md
@@ -1,0 +1,5 @@
+---
+"@osdk/api": patch
+---
+
+Fix casting types with fully qualified property names.

--- a/packages/api/src/OsdkObjectFrom.test.ts
+++ b/packages/api/src/OsdkObjectFrom.test.ts
@@ -472,7 +472,7 @@ describe("ExtractOptions", () => {
   });
 
   describe("Interface casting works as intended", () => {
-    it("mapping as works", async () => {
+    it("mapping as with fqn property names works", async () => {
       expectTypeOf<
         MapPropNamesToInterface<
           quickerAndDirtier,

--- a/packages/api/src/OsdkObjectFrom.test.ts
+++ b/packages/api/src/OsdkObjectFrom.test.ts
@@ -17,7 +17,13 @@
 import { describe, expectTypeOf, it } from "vitest";
 import type { NullabilityAdherence } from "./object/FetchPageArgs.js";
 import { createMockObjectSet } from "./objectSet/ObjectSet.test.js";
-import type { ExtractOptions, Osdk } from "./OsdkObjectFrom.js";
+import type { PropertyKeys } from "./ontology/ObjectOrInterface.js";
+import type {
+  ConvertProps,
+  ExtractOptions,
+  MapPropNamesToInterface,
+  Osdk,
+} from "./OsdkObjectFrom.js";
 
 describe("ExtractOptions", () => {
   describe("NullabilityAdherence Generic", () => {
@@ -135,6 +141,108 @@ describe("ExtractOptions", () => {
     };
   };
 
+  type quickerAndDirtier = {
+    apiName: "Bar";
+    type: "object";
+    __DefinitionMetadata: {
+      props: {
+        name: string;
+        foo: number | undefined;
+        birthday: string;
+      };
+      strictProps: {
+        name: string;
+        foo: number;
+        birthday: string;
+      };
+      apiName: "Foo";
+      displayName: "";
+      interfaceMap: {
+        "com.my.obscure.namespace.FooBarInterface": {
+          "com.my.obscure.namespace.fooInterface": "foo";
+          "com.my.obscure.namespace.id": "name";
+          "com.my.even.more.obscure.namespace.originDate": "birthday";
+        };
+      };
+      inverseInterfaceMap: {
+        "com.my.obscure.namespace.FooBarInterface": {
+          "foo": "com.my.obscure.namespace.fooInterface";
+          "name": "com.my.obscure.namespace.id";
+          "birthday": "com.my.even.more.obscure.namespace.originDate";
+        };
+      };
+      links: {};
+      pluralDisplayName: "";
+      primaryKeyApiName: "";
+      primaryKeyType: "string";
+      properties: {
+        name: {
+          type: "string";
+          description: "";
+        };
+        foo: {
+          type: "integer";
+          description: "";
+        };
+        birthday: {
+          type: "string";
+          description: "";
+        };
+      };
+      rid: "";
+      status: "ACTIVE";
+      titleProperty: "name";
+      type: "object";
+      icon: undefined;
+      visibility: undefined;
+      description: "";
+    };
+  };
+
+  type quickerAndDirtierInterface = {
+    apiName: "com.my.obscure.namespace.FooBarInterface";
+    type: "interface";
+    __DefinitionMetadata: {
+      props: {
+        id: string;
+        "com.my.even.more.obscure.namespace.originDate": string | undefined;
+        fooInterface: number;
+      };
+      strictProps: {
+        id: string;
+        "com.my.even.more.obscure.namespace.originDate": string;
+        fooInterface: number;
+      };
+      apiName: "com.my.obscure.namespace.FooBarInterface";
+      displayName: "";
+      implements: [];
+      implementedBy: ["Bar"];
+      links: {};
+      pluralDisplayName: "";
+      primaryKeyApiName: "";
+      properties: {
+        id: {
+          type: "string";
+          description: "";
+        };
+        "com.my.even.more.obscure.namespace.originDate": {
+          type: "string";
+          description: "";
+        };
+        fooInterface: {
+          type: "integer";
+          description: "";
+        };
+      };
+      rid: "";
+      status: "ACTIVE";
+      titleProperty: "name";
+      type: "interface";
+      icon: undefined;
+      visibility: undefined;
+      description: "";
+    };
+  };
   describe("Osdk.Instance", () => {
     it("defaults to second argument never if omitted", () => {
       type toCheck = Osdk.Instance<quickAndDirty>;
@@ -359,6 +467,48 @@ describe("ExtractOptions", () => {
       expectTypeOf<typeof page["data"]>().branded
         .toEqualTypeOf<
           Osdk.Instance<quickAndDirty>[]
+        >();
+    });
+  });
+
+  describe("Interface casting works as intended", () => {
+    it("mapping as works", async () => {
+      expectTypeOf<
+        MapPropNamesToInterface<
+          quickerAndDirtier,
+          quickerAndDirtierInterface,
+          PropertyKeys<quickerAndDirtier>
+        >
+      >().toEqualTypeOf<PropertyKeys<quickerAndDirtierInterface>>;
+
+      expectTypeOf<
+        ConvertProps<
+          quickerAndDirtier,
+          quickerAndDirtierInterface,
+          PropertyKeys<quickerAndDirtier>,
+          never
+        >
+      >().toEqualTypeOf<PropertyKeys<quickerAndDirtierInterface>>;
+
+      expectTypeOf<
+        Osdk.Instance<
+          quickerAndDirtierInterface,
+          never,
+          PropertyKeys<quickerAndDirtierInterface>,
+          {}
+        >
+      >()
+        .toExtend<
+          Osdk.Instance<
+            quickerAndDirtierInterface,
+            never,
+            ConvertProps<
+              quickerAndDirtier,
+              quickerAndDirtierInterface,
+              PropertyKeys<quickerAndDirtier>,
+              never
+            >
+          >
         >();
     });
   });

--- a/packages/api/src/OsdkObjectFrom.ts
+++ b/packages/api/src/OsdkObjectFrom.ts
@@ -87,6 +87,16 @@ export type MapPropNamesToObjectType<
     TO
   >[JustProps<FROM, P> & keyof PropMapToObject<FROM, TO>];
 
+type NamespaceOf<S extends string> = S extends `${infer Before}.${infer After}`
+  ? After extends `${string}.${string}` ? `${Before}.${NamespaceOf<After>}`
+  : Before
+  : never;
+
+type MaybeStripNamespaces<S extends string, TO extends InterfaceDefinition> =
+  S extends `${NamespaceOf<S>}.${infer Rest}`
+    ? NamespaceOf<S> extends NamespaceOf<ApiNameAsString<TO>> ? Rest : S
+    : S;
+
 export type PropMapToInterface<
   FROM extends ObjectTypeDefinition,
   TO extends InterfaceDefinition,
@@ -98,10 +108,13 @@ export type MapPropNamesToInterface<
   FROM extends ObjectTypeDefinition,
   TO extends InterfaceDefinition,
   P extends ValidOsdkPropParams<FROM>,
-> = PropMapToInterface<
-  FROM,
+> = MaybeStripNamespaces<
+  PropMapToInterface<
+    FROM,
+    TO
+  >[JustProps<FROM, P> & keyof PropMapToInterface<FROM, TO>],
   TO
->[JustProps<FROM, P> & keyof PropMapToInterface<FROM, TO>];
+>;
 /**
  * Older version of this helper that allows for `$rid` and co in
  * the properties field.


### PR DESCRIPTION
We had a bug when using `$as` in our types.

Let's say we had an interface called: `apiName: "com.my.obscure.namespace.FooBarInterface";`
And it had properties:
```
 id: string;
 "com.my.even.more.obscure.namespace.originDate": string | undefined;
 fooInterface: number;
```

Because of the way OSDK strips namespaces on properties if they match the namespace of the interface, `id` and `fooInterface` are technically `com.my.obscure.namespace.id` and `com.my.obscure.namespace.fooInterface`. This is fine for ergonomics, but becomes tricky with casting.

For casting, we rely on the inverse interface map OSS gives us which maps interface props to object props, and these props all have things fully qualified. E.g.:
```
inverseInterfaceMap: {
        "com.my.obscure.namespace.FooBarInterface": {
          "foo": "com.my.obscure.namespace.fooInterface";
          "name": "com.my.obscure.namespace.id";
          "birthday": "com.my.even.more.obscure.namespace.originDate";
        };
      };
```

Before this fix, our `$as` type would not strip the namespace so we'd think there was a type mismatch because we get back `"com.my.obscure.namespace.id"` when we really need `id` . 

We now fix this by stripping the namespace from the key of the map if it matches the namespace of the overall interface!