### PR TITLE
Fix vite plugin resolve-package-path dependency

### DIFF
--- a/.changeset/dry-spoons-burn.md
+++ b/.changeset/dry-spoons-burn.md
@@ -1,0 +1,5 @@
+---
+"@osdk/widget.vite-plugin": patch
+---
+
+Fix @osdk/widget.vite-plugin dependency on resolve-package-path in devDependencies rather than dependencies

--- a/packages/widget.vite-plugin/package.json
+++ b/packages/widget.vite-plugin/package.json
@@ -44,6 +44,7 @@
     "fs-extra": "^11.3.0",
     "parse5": "^7.2.1",
     "picocolors": "^1.1.1",
+    "resolve-package-path": "^4.0.3",
     "sirv": "^3.0.0"
   },
   "peerDependencies": {
@@ -60,7 +61,6 @@
     "@vitejs/plugin-react": "^4.2.0",
     "react": "^18",
     "react-dom": "^18",
-    "resolve-package-path": "^4.0.3",
     "ts-expect": "^1.3.0",
     "typescript": "~5.5.4",
     "vite": "^6.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -467,7 +467,7 @@ importers:
         version: 6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0)
       vitest:
         specifier: ^3.0.5
-        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
 
   examples/example-react-sdk-1.x:
     dependencies:
@@ -625,7 +625,7 @@ importers:
         version: 6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0)
       vitest:
         specifier: ^3.0.5
-        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
 
   examples/example-tutorial-todo-aip-app-sdk-1.x:
     dependencies:
@@ -985,7 +985,7 @@ importers:
         version: 6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0)
       vitest:
         specifier: ^3.0.5
-        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
       vue-tsc:
         specifier: ^2.1.6
         version: 2.1.6(typescript@5.5.4)
@@ -1838,7 +1838,7 @@ importers:
         version: 6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0)
       vitest:
         specifier: ^3.0.5
-        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
 
   packages/create-app.template.react:
     dependencies:
@@ -1999,7 +1999,7 @@ importers:
         version: 6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0)
       vitest:
         specifier: ^3.0.5
-        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
 
   packages/create-app.template.tutorial-todo-aip-app:
     dependencies:
@@ -3375,7 +3375,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^3.0.5
-        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
 
   packages/generator-converters:
     dependencies:
@@ -3954,7 +3954,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^3.0.5
-        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
+        version: 3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0)
 
   packages/typescript-sdk-docs:
     dependencies:
@@ -4150,6 +4150,9 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+      resolve-package-path:
+        specifier: ^4.0.3
+        version: 4.0.3
       sirv:
         specifier: ^3.0.0
         version: 3.0.0
@@ -4184,9 +4187,6 @@ importers:
       react-dom:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
-      resolve-package-path:
-        specifier: ^4.0.3
-        version: 4.0.3
       ts-expect:
         specifier: ^1.3.0
         version: 1.3.0
@@ -5628,7 +5628,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.21.8':
     resolution: {integrity: sha512-gU+NlL/XS9r7LEfLhjDDKuv3jEtOh+rVnk/k7Lp8WrUwaMCoEGfmQpSqLXetFCCC4UFXSaj1cdMGoy2UBw4rew==}
@@ -26796,7 +26796,7 @@ snapshots:
       terser: 5.39.2
       yaml: 2.8.0
 
-  vitest@3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0):
+  vitest@3.0.7(@types/node@18.19.97)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.29.1)(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(terser@5.39.2)(yaml@2.8.0):
     dependencies:
       '@vitest/expect': 3.0.7
       '@vitest/mocker': 3.0.7(msw@2.7.3(@types/node@18.19.97)(typescript@5.5.4))(vite@6.3.5(@types/node@18.19.97)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.2)(yaml@2.8.0))


### PR DESCRIPTION
https://github.com/palantir/osdk-ts/pull/1460 incorrectly added resolve-package-path in devDependencies rather than dependencies so using beta versions of the vite plugin are failing to run dev server

```
error when starting dev server:
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'resolve-package-path' imported from /Users/tleung/Projects/tleung-search-repository/node_modules/@osdk/widget.vite-plugin/build/esm/common/visitNpmPackages.js
    at packageResolve (node:internal/modules/esm/resolve:857:9)
    at moduleResolve (node:internal/modules/esm/resolve:926:18)
    at defaultResolve (node:internal/modules/esm/resolve:1056:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:654:12)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:603:25)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:586:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:242:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:135:49)
```