### PR TITLE
make useOsdkAction validation less restrictive

### DIFF
--- a/.changeset/green-towns-travel.md
+++ b/.changeset/green-towns-travel.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react": minor
+---
+
+Make useOsdkAction validate less restrictive

--- a/packages/react/src/new/useOsdkAction.ts
+++ b/packages/react/src/new/useOsdkAction.ts
@@ -135,7 +135,7 @@ export function useOsdkAction<Q extends ActionDefinition<any>>(
     try {
       // Check if action is being applied
       if (isPending) {
-        throw new Error("Cannot validate while action is pending");
+        return undefined;
       }
 
       // Abort any existing validation


### PR DESCRIPTION
Addresses https://github.com/palantir/osdk-ts/issues/1731

This PR makes useOsdkAction validation less restrictive by simply returning `undefined` instead of throwing an error if the action is being applied. It seems we actually don't need additional handling for returning undefined as our types handle this nicely so this should be sufficient