### PR TITLE
Fix typings for `__EXPERIMENTAL__NOT_SUPPORTED_YET__metadata`

### DIFF
--- a/packages/api/src/OsdkObjectFrom.ts
+++ b/packages/api/src/OsdkObjectFrom.ts
@@ -226,14 +226,10 @@ export namespace Osdk {
           },
       ) => Osdk.Instance<Q, OPTIONS, P | NEW_PROPS>;
 
-      readonly $__EXPERIMENTAL__NOT_SUPPORTED_YET__metadata: Q extends
-        ObjectTypeDefinition ? {
-          ObjectMetadata: Q;
-        }
-        : {
-          ObjectMetadata: ObjectMetadata;
-          InterfaceMetadata: InterfaceMetadata;
-        };
+      readonly $__EXPERIMENTAL__NOT_SUPPORTED_YET__metadata: {
+        ObjectMetadata: ObjectMetadata;
+        InterfaceMetadata: InterfaceMetadata;
+      };
     }
     // We are hiding the $rid field if it wasn't requested as we want to discourage its use
     & (IsNever<OPTIONS> extends true ? {}


### PR DESCRIPTION
Related to https://github.com/palantir/osdk-ts/pull/1548

`Q` only has `ObjectTypeDefinition` types, which means we just end up reducing to

<img width="761" height="141" alt="image" src="https://github.com/user-attachments/assets/2277a4d7-6458-465d-9cd4-7cdeb1b82814" />

even when there's more state available at runtime


<img width="1587" height="164" alt="image" src="https://github.com/user-attachments/assets/712073bb-a720-42c4-9b99-d99643f22759" />


```
Property 'properties' does not exist on type 'ObjectTypeDefinition | ObjectMetadata'.
  Property 'properties' does not exist on type 'ObjectTypeDefinition'
```



Another option is to try to intersect `Q & ObjectMetadata`, but I'm not sure that's actually correct either, since it removes our ability to introspect `InterfaceMetadata`, which I _think_ should also be there at runtime (even if it's empty).