### PR TITLE
Add a flag to not update package json for cli generation

### DIFF
--- a/.changeset/nice-dryers-mix.md
+++ b/.changeset/nice-dryers-mix.md
@@ -1,0 +1,5 @@
+---
+"@osdk/cli.cmd.typescript": patch
+---
+
+Add a flag to skip updating the package json

--- a/packages/cli.cmd.typescript/src/generate/TypescriptGenerateArgs.ts
+++ b/packages/cli.cmd.typescript/src/generate/TypescriptGenerateArgs.ts
@@ -30,4 +30,5 @@ export interface TypescriptGenerateArgs {
   internal: boolean;
   externalObjects: Map<string, string>;
   externalInterfaces: Map<string, string>;
+  skipPackageJsonUpdate?: boolean;
 }

--- a/packages/cli.cmd.typescript/src/generate/generate.ts
+++ b/packages/cli.cmd.typescript/src/generate/generate.ts
@@ -123,6 +123,11 @@ export const generateCommand: CommandModule<
             },
             default: "",
           },
+          skipPackageJsonUpdate: {
+            type: "boolean",
+            description: "Skip updating package.json with OSDK dependencies",
+            default: false,
+          },
         } as const,
       ).group(
         ["ontologyPath", "outDir", "version"],

--- a/packages/cli.cmd.typescript/src/generate/handleGenerate.mts
+++ b/packages/cli.cmd.typescript/src/generate/handleGenerate.mts
@@ -186,50 +186,52 @@ async function generateClientSdk(
     if (!args.asPackage) {
       await generateSourceFiles(args, ontology, minimalFs);
 
-      const packageJsonPath = await findUp("package.json", {
-        cwd: args.outDir,
-      });
+      if (!args.skipPackageJsonUpdate) {
+        const packageJsonPath = await findUp("package.json", {
+          cwd: args.outDir,
+        });
 
-      if (!packageJsonPath) {
-        return true;
-      }
-      const packageJsonOriginal = JSON.parse(
-        await fs.promises.readFile(packageJsonPath, "utf-8"),
-      );
-      const packageJson = JSON.parse(
-        await fs.promises.readFile(packageJsonPath, "utf-8"),
-      );
-
-      const dependencyVersions = await getDependencyVersions();
-      if (args.internal) {
-        dependencyVersions.osdkApiVersion = "workspace:~";
-        dependencyVersions.osdkClientVersion = "workspace:~";
-        dependencyVersions.osdkLegacyClientVersion = "workspace:~";
-      }
-
-      const expectedDeps = getExpectedDependencies(
-        dependencyVersions,
-      );
-
-      for (const [type, deps] of Object.entries(expectedDeps)) {
-        if (!(type in packageJson)) {
-          packageJson[type] = deps;
-        } else {
-          Object.assign(packageJson[type], deps);
+        if (!packageJsonPath) {
+          return true;
         }
-      }
-
-      updateVersionsIfTheyExist(packageJson, {
-        "@osdk/client": dependencyVersions.osdkClientVersion,
-        "@osdk/api": dependencyVersions.osdkApiVersion,
-      });
-
-      // only write if changed
-      if (!deepEqual(packageJsonOriginal, packageJson)) {
-        await fs.promises.writeFile(
-          packageJsonPath,
-          JSON.stringify(packageJson, undefined, 2) + "\n",
+        const packageJsonOriginal = JSON.parse(
+          await fs.promises.readFile(packageJsonPath, "utf-8"),
         );
+        const packageJson = JSON.parse(
+          await fs.promises.readFile(packageJsonPath, "utf-8"),
+        );
+
+        const dependencyVersions = await getDependencyVersions();
+        if (args.internal) {
+          dependencyVersions.osdkApiVersion = "workspace:~";
+          dependencyVersions.osdkClientVersion = "workspace:~";
+          dependencyVersions.osdkLegacyClientVersion = "workspace:~";
+        }
+
+        const expectedDeps = getExpectedDependencies(
+          dependencyVersions,
+        );
+
+        for (const [type, deps] of Object.entries(expectedDeps)) {
+          if (!(type in packageJson)) {
+            packageJson[type] = deps;
+          } else {
+            Object.assign(packageJson[type], deps);
+          }
+        }
+
+        updateVersionsIfTheyExist(packageJson, {
+          "@osdk/client": dependencyVersions.osdkClientVersion,
+          "@osdk/api": dependencyVersions.osdkApiVersion,
+        });
+
+        // only write if changed
+        if (!deepEqual(packageJsonOriginal, packageJson)) {
+          await fs.promises.writeFile(
+            packageJsonPath,
+            JSON.stringify(packageJson, undefined, 2) + "\n",
+          );
+        }
       }
 
       return true;


### PR DESCRIPTION
This will enable us to generate packages without having the package json version auto bumped if we want to keep it the same or the versions are managed elsewhere