### PR TITLE
export useOsdkMetadata, add error handling

### DIFF
--- a/.changeset/pretty-snails-shave.md
+++ b/.changeset/pretty-snails-shave.md
@@ -1,5 +1,0 @@
----
-"@osdk/react": patch
----
-
-update useOsdkAction to use abort controller, export hook

--- a/.changeset/pretty-snails-shave.md
+++ b/.changeset/pretty-snails-shave.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react": patch
+---
+
+update useOsdkAction to use abort controller, export hook

--- a/.changeset/rare-taxis-retire.md
+++ b/.changeset/rare-taxis-retire.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react": patch
+---
+
+Export useOsdkMetadata hook experimentally

--- a/packages/react/src/public/experimental.ts
+++ b/packages/react/src/public/experimental.ts
@@ -22,4 +22,3 @@ export type { UseOsdkListResult } from "../new/useOsdkObjects.js";
 export { useOsdkObjects } from "../new/useOsdkObjects.js";
 export { useOsdkClient } from "../useOsdkClient.js";
 export { useOsdkMetadata } from "../useOsdkMetadata.js";
-export type { UseOsdkMetadataResult } from "../useOsdkMetadata.js";

--- a/packages/react/src/public/experimental.ts
+++ b/packages/react/src/public/experimental.ts
@@ -21,3 +21,5 @@ export { useOsdkObject } from "../new/useOsdkObject.js";
 export type { UseOsdkListResult } from "../new/useOsdkObjects.js";
 export { useOsdkObjects } from "../new/useOsdkObjects.js";
 export { useOsdkClient } from "../useOsdkClient.js";
+export { useOsdkMetadata } from "../useOsdkMetadata.js";
+export type { UseOsdkMetadataResult } from "../useOsdkMetadata.js";

--- a/packages/react/src/public/experimental.ts
+++ b/packages/react/src/public/experimental.ts
@@ -22,3 +22,4 @@ export type { UseOsdkListResult } from "../new/useOsdkObjects.js";
 export { useOsdkObjects } from "../new/useOsdkObjects.js";
 export { useOsdkClient } from "../useOsdkClient.js";
 export { useOsdkMetadata } from "../useOsdkMetadata.js";
+export type { UseOsdkMetadataResult } from "../useOsdkMetadata.js";

--- a/packages/react/src/useOsdkMetadata.ts
+++ b/packages/react/src/useOsdkMetadata.ts
@@ -29,26 +29,32 @@ type MetadataFor<T extends ObjectOrInterfaceDefinition> = T extends
   : T extends ObjectTypeDefinition ? ObjectMetadata
   : never;
 
-export function useOsdkMetadata<T extends ObjectOrInterfaceDefinition>(
-  type: T,
-): {
+export interface UseOsdkMetadataResult<T extends ObjectOrInterfaceDefinition> {
   loading: boolean;
   metadata?: MetadataFor<T>;
-} {
+  error?: string;
+}
+
+export function useOsdkMetadata<T extends ObjectOrInterfaceDefinition>(
+  type: T,
+): UseOsdkMetadataResult<T> {
   const client = useOsdkClient();
   const [metadata, setMetadata] = React.useState<
     MetadataFor<T> | undefined
   >(undefined);
+  const [error, setError] = React.useState<UseOsdkMetadataResult<T>["error"]>();
 
-  if (!metadata) {
+  if (!metadata && !error) {
     client.fetchMetadata(type).then((fetchedMetadata) => {
       setMetadata(fetchedMetadata as MetadataFor<T>);
     }).catch((error: unknown) => {
-      // eslint-disable-next-line no-console
-      console.error("Failed to fetch metadata", error);
+      const errorMessage = error instanceof Error
+        ? error.message
+        : String(error);
+      setError(errorMessage);
     });
     return { loading: true };
   }
 
-  return { loading: false, metadata };
+  return { loading: false, metadata, error };
 }

--- a/packages/react/src/useOsdkMetadata.ts
+++ b/packages/react/src/useOsdkMetadata.ts
@@ -29,65 +29,26 @@ type MetadataFor<T extends ObjectOrInterfaceDefinition> = T extends
   : T extends ObjectTypeDefinition ? ObjectMetadata
   : never;
 
-export interface UseOsdkMetadataResult<T extends ObjectOrInterfaceDefinition> {
-  loading: boolean;
-  metadata?: MetadataFor<T>;
-  error?: string;
-}
-
 export function useOsdkMetadata<T extends ObjectOrInterfaceDefinition>(
   type: T,
-): UseOsdkMetadataResult<T> {
+): {
+  loading: boolean;
+  metadata?: MetadataFor<T>;
+} {
   const client = useOsdkClient();
-  const [loading, setLoading] = React.useState(true);
   const [metadata, setMetadata] = React.useState<
     MetadataFor<T> | undefined
   >(undefined);
-  const [error, setError] = React.useState<UseOsdkMetadataResult<T>["error"]>();
-  const abortControllerRef = React.useRef<AbortController | null>(null);
 
-  const typeApiName = type.apiName;
-  const cachedMetadata = React.useRef<MetadataFor<T> | undefined>();
-  const lastTypeApiName = React.useRef<string>();
-
-  if (lastTypeApiName.current !== typeApiName) {
-    lastTypeApiName.current = typeApiName;
-    cachedMetadata.current = undefined;
-
-    // Abort any existing fetch
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-    }
-
-    const abortController = new AbortController();
-    abortControllerRef.current = abortController;
-
-    setLoading(true);
-    setError(undefined);
-
-    client.fetchMetadata(type)
-      .then((fetchedMetadata) => {
-        // Check if aborted
-        if (abortController.signal.aborted) {
-          return;
-        }
-        const result = fetchedMetadata as MetadataFor<T>;
-        cachedMetadata.current = result;
-        setMetadata(result);
-        setLoading(false);
-      })
-      .catch((error: unknown) => {
-        // Check if it was aborted
-        if (abortController.signal.aborted) {
-          return;
-        }
-        const errorMessage = error instanceof Error
-          ? error.message
-          : String(error);
-        setError(errorMessage);
-        setLoading(false);
-      });
+  if (!metadata) {
+    client.fetchMetadata(type).then((fetchedMetadata) => {
+      setMetadata(fetchedMetadata as MetadataFor<T>);
+    }).catch((error: unknown) => {
+      // eslint-disable-next-line no-console
+      console.error("Failed to fetch metadata", error);
+    });
+    return { loading: true };
   }
 
-  return { loading, metadata, error };
+  return { loading: false, metadata };
 }

--- a/packages/react/src/useOsdkMetadata.ts
+++ b/packages/react/src/useOsdkMetadata.ts
@@ -43,7 +43,7 @@ export function useOsdkMetadata<T extends ObjectOrInterfaceDefinition>(
   const [metadata, setMetadata] = React.useState<
     MetadataFor<T> | undefined
   >(undefined);
-  const [error, setError] = React.useState<string | undefined>();
+  const [error, setError] = React.useState<UseOsdkMetadataResult<T>["error"]>();
   const abortControllerRef = React.useRef<AbortController | null>(null);
 
   const typeApiName = type.apiName;


### PR DESCRIPTION
`useOsdkMetadata`  currently isn't exported and doesn't have proper error handling (errors were only logged to console instead of being returned to consumers)


This PR fixes these concerns by and exporting the hook and adding error handling

 