### PR TITLE
Fix query map responses throwing for falsy values

### DIFF
--- a/.changeset/dirty-papers-unite.md
+++ b/.changeset/dirty-papers-unite.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Falsy values other than undefined or null do not throw for query map responses

--- a/packages/client/src/queries/applyQuery.ts
+++ b/packages/client/src/queries/applyQuery.ts
@@ -238,8 +238,8 @@ async function remapQueryResponse<
 
       invariant(Array.isArray(responseValue), "Expected array entry");
       for (const entry of responseValue) {
-        invariant(entry.key, "Expected key");
-        invariant(entry.value, "Expected value");
+        invariant(entry.key != null, "Expected key");
+        invariant(entry.value != null, "Expected value");
         const key = responseDataType.keyType.type === "object"
           ? getObjectSpecifier(
             entry.key,


### PR DESCRIPTION
Falsy values other than undefined or null do not throw for query map responses
