### PR TITLE
Remove NullValue type from generation

### DIFF
--- a/.changeset/two-lemons-nail.md
+++ b/.changeset/two-lemons-nail.md
@@ -1,0 +1,5 @@
+---
+"@osdk/generator": patch
+---
+
+Temporarily remove NullValue type from codegen

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/actions/createOffice.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/actions/createOffice.ts
@@ -44,17 +44,17 @@ export namespace createOffice {
     /**
      * The office's physical address (not necessarily shipping address)
      */
-    readonly address?: ActionParam.PrimitiveType<'string'> | ActionParam.NullValueType;
+    readonly address?: ActionParam.PrimitiveType<'string'>;
     /**
      * The maximum seated-at-desk capacity of the office (maximum fire-safe capacity may be higher)
      */
-    readonly capacity?: ActionParam.PrimitiveType<'integer'> | ActionParam.NullValueType;
+    readonly capacity?: ActionParam.PrimitiveType<'integer'>;
 
     readonly officeId: ActionParam.PrimitiveType<'string'>;
     /**
      * A list of all office names
      */
-    readonly officeNames?: ReadonlyArray<ActionParam.PrimitiveType<'string'>> | ActionParam.NullValueType;
+    readonly officeNames?: ReadonlyArray<ActionParam.PrimitiveType<'string'>>;
   }
 
   // Represents a fqn of the action

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/actions/createOfficeAndEmployee.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/actions/createOfficeAndEmployee.ts
@@ -50,11 +50,11 @@ export namespace createOfficeAndEmployee {
     /**
      * The office's physical address (not necessarily shipping address)
      */
-    readonly address?: ActionParam.PrimitiveType<'string'> | ActionParam.NullValueType;
+    readonly address?: ActionParam.PrimitiveType<'string'>;
     /**
      * The maximum seated-at-desk capacity of the office (maximum fire-safe capacity may be higher)
      */
-    readonly capacity?: ActionParam.PrimitiveType<'integer'> | ActionParam.NullValueType;
+    readonly capacity?: ActionParam.PrimitiveType<'integer'>;
     /**
      * New employee Id
      */
@@ -64,7 +64,7 @@ export namespace createOfficeAndEmployee {
     /**
      * A list of all office names
      */
-    readonly officeNames?: ReadonlyArray<ActionParam.PrimitiveType<'string'>> | ActionParam.NullValueType;
+    readonly officeNames?: ReadonlyArray<ActionParam.PrimitiveType<'string'>>;
   }
 
   // Represents a fqn of the action

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/actions/moveOffice.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/actions/moveOffice.ts
@@ -44,17 +44,17 @@ export namespace moveOffice {
     /**
      * The office's new physical address (not necessarily shipping address)
      */
-    readonly newAddress?: ActionParam.PrimitiveType<'string'> | ActionParam.NullValueType;
+    readonly newAddress?: ActionParam.PrimitiveType<'string'>;
     /**
      * The maximum seated-at-desk capacity of the new office (maximum fire-safe capacity may be higher)
      */
-    readonly newCapacity?: ActionParam.PrimitiveType<'integer'> | ActionParam.NullValueType;
+    readonly newCapacity?: ActionParam.PrimitiveType<'integer'>;
 
     readonly officeId: ActionParam.PrimitiveType<'string'>;
     /**
      * A list of all office names
      */
-    readonly officeNames?: ReadonlyArray<ActionParam.PrimitiveType<'integer'>> | ActionParam.NullValueType;
+    readonly officeNames?: ReadonlyArray<ActionParam.PrimitiveType<'integer'>>;
   }
 
   // Represents a fqn of the action

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/actionTakesAllParameterTypes.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/actionTakesAllParameterTypes.ts
@@ -57,11 +57,11 @@ export namespace actionTakesAllParameterTypes {
   export interface Params {
     readonly attachmentArray: ReadonlyArray<ActionParam.PrimitiveType<'attachment'>>;
 
-    readonly dateArray?: ReadonlyArray<ActionParam.PrimitiveType<'datetime'>> | ActionParam.NullValueType;
+    readonly dateArray?: ReadonlyArray<ActionParam.PrimitiveType<'datetime'>>;
     /**
      * A person Object
      */
-    readonly object?: ActionParam.ObjectType<Person> | ActionParam.NullValueType;
+    readonly object?: ActionParam.ObjectType<Person>;
 
     readonly objectSet: ActionParam.ObjectSetType<Todo>;
 

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createStructPerson.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createStructPerson.ts
@@ -29,7 +29,7 @@ export namespace createStructPerson {
    * Create a struct
    */
   export interface Params {
-    readonly address?: ActionParam.StructType<{ city: 'string'; state: 'string' }> | ActionParam.NullValueType;
+    readonly address?: ActionParam.StructType<{ city: 'string'; state: 'string' }>;
 
     readonly name: ActionParam.PrimitiveType<'string'>;
   }

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createStructPersonOpiTeam.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createStructPersonOpiTeam.ts
@@ -35,9 +35,7 @@ export namespace createStructPersonOpiTeam {
    * Create a struct person on the OPI team
    */
   export interface Params {
-    readonly address?:
-      | ActionParam.StructType<{ city: 'string'; state: 'string'; zipcode: 'integer' }>
-      | ActionParam.NullValueType;
+    readonly address?: ActionParam.StructType<{ city: 'string'; state: 'string'; zipcode: 'integer' }>;
 
     readonly age: ActionParam.PrimitiveType<'integer'>;
 

--- a/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/ontology/actions/modifyEmployee.ts
+++ b/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/ontology/actions/modifyEmployee.ts
@@ -29,7 +29,7 @@ export namespace modifyEmployee {
   export interface Params {
     readonly employee: ActionParam.ObjectType<Employee>;
 
-    readonly primary_office_id?: ActionParam.PrimitiveType<'string'> | ActionParam.NullValueType;
+    readonly primary_office_id?: ActionParam.PrimitiveType<'string'>;
   }
 
   // Represents a fqn of the action

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/ontology/actions/createTodo.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/ontology/actions/createTodo.ts
@@ -37,7 +37,7 @@ export namespace createTodo {
   export interface Params {
     readonly is_complete: ActionParam.PrimitiveType<'boolean'>;
 
-    readonly location?: ActionParam.PrimitiveType<'string'> | ActionParam.NullValueType;
+    readonly location?: ActionParam.PrimitiveType<'string'>;
 
     readonly Todo: ActionParam.PrimitiveType<'string'>;
   }

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -586,7 +586,7 @@ describe("generator", () => {
             /**
              * Todo(s) to be deleted
              */
-            readonly object?: ReadonlyArray<ActionParam.ObjectType<Todo>> | ActionParam.NullValueType;
+            readonly object?: ReadonlyArray<ActionParam.ObjectType<Todo>>;
           }
 
           // Represents a fqn of the action
@@ -662,7 +662,7 @@ describe("generator", () => {
             /**
              * A Todo to mark completed
              */
-            readonly object?: ActionParam.ObjectType<Todo> | ActionParam.NullValueType;
+            readonly object?: ActionParam.ObjectType<Todo>;
           }
 
           // Represents a fqn of the action
@@ -1243,7 +1243,7 @@ describe("generator", () => {
             /**
              * Todo(s) to be deleted
              */
-            readonly object?: ReadonlyArray<ActionParam.ObjectType<Todo>> | ActionParam.NullValueType;
+            readonly object?: ReadonlyArray<ActionParam.ObjectType<Todo>>;
           }
 
           // Represents a fqn of the action
@@ -1319,7 +1319,7 @@ describe("generator", () => {
             /**
              * A Todo to mark completed
              */
-            readonly object?: ActionParam.ObjectType<Todo> | ActionParam.NullValueType;
+            readonly object?: ActionParam.ObjectType<Todo>;
           }
 
           // Represents a fqn of the action

--- a/packages/generator/src/v2.0/generatePerActionDataFiles.ts
+++ b/packages/generator/src/v2.0/generatePerActionDataFiles.ts
@@ -172,10 +172,9 @@ export async function generatePerActionDataFiles(
               const key = `${getDescriptionIfPresent(ogValue.description)}
                   readonly "${ogKey}"${ogValue.nullable ? "?" : ""}`;
 
-              const value = (ogValue.multiplicity
+              const value = ogValue.multiplicity
                 ? `ReadonlyArray<${getActionParamType(ogValue.type)}>`
-                : `${getActionParamType(ogValue.type)}`)
-                + (ogValue.nullable ? " | ActionParam.NullValueType" : "");
+                : `${getActionParamType(ogValue.type)}`;
               jsDocBlock.push(
                 `* @param {${getActionParamType(ogValue.type)}} ${
                   ogValue.nullable ? `[${ogKey}]` : ogKey


### PR DESCRIPTION
Temporarily removing NullValue type from generated code to circumvent some compile issue we see in some packages.