### PR TITLE
improve useOsdkObject, useOsdkObjects error handling

### DIFF
--- a/.changeset/metal-poets-shine.md
+++ b/.changeset/metal-poets-shine.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react": patch
+---
+
+improve useOsdkObject, useOsdkObjects error handling

--- a/packages/react/src/new/useOsdkObject.ts
+++ b/packages/react/src/new/useOsdkObject.ts
@@ -81,11 +81,18 @@ export function useOsdkObject<Q extends ObjectTypeDefinition>(
 
   const payload = React.useSyncExternalStore(subscribe, getSnapShot);
 
+  let error: Error | undefined;
+  if (payload && "error" in payload && payload.error) {
+    error = payload.error;
+  } else if (payload?.status === "error") {
+    error = new Error("Failed to load object");
+  }
+
   return {
     object: payload?.object as Osdk.Instance<Q> | undefined,
     isLoading: payload?.status === "loading",
     isOptimistic: !!payload?.isOptimistic,
-    error: payload && "error" in payload ? payload.error : undefined,
+    error,
     forceUpdate: () => {
       throw "not implemented";
     },

--- a/packages/react/src/new/useOsdkObjects.ts
+++ b/packages/react/src/new/useOsdkObjects.ts
@@ -97,8 +97,6 @@ export interface UseOsdkListResult<
   fetchMore: (() => Promise<unknown>) | undefined;
   data: Osdk.Instance<T>[] | undefined;
   isLoading: boolean;
-
-  // FIXME populate error!
   error: Error | undefined;
 
   /**
@@ -157,12 +155,17 @@ export function useOsdkObjects<
   );
 
   const listPayload = React.useSyncExternalStore(subscribe, getSnapShot);
-  // TODO: we need to expose the error in the result
+
+  let error: Error | undefined;
+  if (listPayload && "error" in listPayload && listPayload.error) {
+    error = listPayload.error;
+  } else if (listPayload?.status === "error") {
+    error = new Error("Failed to load objects");
+  }
+
   return {
     fetchMore: listPayload?.fetchMore,
-    error: listPayload && "error" in listPayload
-      ? listPayload?.error
-      : undefined,
+    error,
     data: listPayload?.resolvedList as Osdk.Instance<Q>[],
     isLoading: listPayload?.status === "loading",
     isOptimistic: listPayload?.isOptimistic ?? false,


### PR DESCRIPTION
Improves useOsdkObject, useOsdkObjects error handling. TODOs / FIXMEs appeared to be incorrect (errors were being piped through), but it seems we weren't checking the status so I added a check for that.