### PR TITLE
Write value type IR correctly

### DIFF
--- a/packages/maker/src/cli/main.ts
+++ b/packages/maker/src/cli/main.ts
@@ -126,10 +126,7 @@ export default async function main(
     await fs.writeFile(
       commandLineOpts.valueTypesOutput,
       JSON.stringify(
-        {
-          valueTypes: ontologyIr.valueTypes,
-          importedValueTypes: ontologyIr.importedValueTypes,
-        },
+        ontologyIr.valueTypes,
         null,
         2,
       ),


### PR DESCRIPTION
We don't need to write the imported value types because we don't have to create blocks for them.