### PR TITLE
Improve monorepolint error message for private dependencies

### DIFF
--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -542,9 +542,13 @@ const allLocalDepsMustNotBePrivate = createRuleFactory({
         if (theirPackageJson.private) {
           const message =
             `${dep} is private and cannot be used as a regular dependency for this package`;
+          const longMessage = `${message}. To fix this, either:
+  1. Move ${dep} to devDependencies if it's only used at build time
+  2. Make ${dep} public by removing its "private: true" field
+  3. Make this package (${packageJson.name}) private by adding "private: true"`;
           context.addError({
             message,
-            longMessage: message,
+            longMessage,
             file: context.getPackageJsonPath(),
           });
         }


### PR DESCRIPTION
## Summary
- Enhanced the `allLocalDepsMustNotBePrivate` rule error message to provide actionable suggestions
- Developers now get clear guidance on how to resolve the issue when a public package depends on a private package

## Context
The previous error message only stated the problem without offering solutions. This left developers unsure about how to fix the issue.

## Changes
Updated the error message to include three specific solutions:
1. Move the dependency to devDependencies if it's only used at build time
2. Make the dependency public by removing its "private: true" field  
3. Make the dependent package private by adding "private: true"

## Test plan
- [x] Ran monorepolint locally to verify the improved error message format
- [x] Test that the error message appears correctly when the rule is triggered