### PR TITLE
Fire and forget query metadata if no parameters

### DIFF
--- a/.changeset/calm-flowers-push.md
+++ b/.changeset/calm-flowers-push.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Fire and forget query metadata loads if no parameters

--- a/packages/client/src/queries/applyQuery.ts
+++ b/packages/client/src/queries/applyQuery.ts
@@ -25,6 +25,7 @@ import type {
   PrimaryKeyType,
   QueryDataTypeDefinition,
   QueryDefinition,
+  QueryMetadata,
   QueryParameterDefinition,
 } from "@osdk/api";
 import type { DataValue } from "@osdk/foundry.ontologies";
@@ -52,7 +53,8 @@ export async function applyQuery<
 ): Promise<
   QueryReturnType<CompileTimeMetadata<QD>["output"]>
 > {
-  const qd = await client.ontologyProvider.getQueryDefinition(
+  // We fire and forget so if a function has no parameters we don't unnecessarily load all metadata
+  const qd: Promise<QueryMetadata> = client.ontologyProvider.getQueryDefinition(
     query.apiName,
     query.isFixedVersion ? query.version : undefined,
   );
@@ -69,16 +71,20 @@ export async function applyQuery<
         ? await remapQueryParams(
           params as { [parameterId: string]: any },
           client,
-          qd.parameters,
+          (await qd).parameters,
         )
         : {},
     },
     { version: query.isFixedVersion ? query.version : undefined },
   );
-  const objectOutputDefs = await getRequiredDefinitions(qd.output, client);
+
+  const objectOutputDefs = await getRequiredDefinitions(
+    (await qd).output,
+    client,
+  );
   const remappedResponse = await remapQueryResponse(
     client,
-    qd.output,
+    (await qd).output,
     response.value,
     objectOutputDefs,
   );


### PR DESCRIPTION
We don't want to block on query metadata if we don't need to remap any parameters.