### PR TITLE
Export extractPrimaryKeyFromObjectSpecifier handler

### DIFF
--- a/.changeset/yellow-terms-stare.md
+++ b/.changeset/yellow-terms-stare.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Export extractPrimaryKetFromObjectSpecifier from client

--- a/etc/client.report.api.md
+++ b/etc/client.report.api.md
@@ -143,6 +143,11 @@ export const extractDateInLocalTime: (date: Date) => string;
 // @public
 export const extractDateInUTC: (date: Date) => string;
 
+// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+//
+// @public
+export function extractPrimaryKeyFromObjectSpecifier(ObjectSpecifier: ObjectSpecifier<any>): string;
+
 export { InterfaceDefinition }
 
 export { InterfaceMetadata }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -70,4 +70,7 @@ export {
   extractDateInUTC,
 } from "./util/datetimeConverters.js";
 
-export { createObjectSpecifierFromPrimaryKey } from "./util/objectSpecifierUtils.js";
+export {
+  createObjectSpecifierFromPrimaryKey,
+  extractPrimaryKeyFromObjectSpecifier,
+} from "./util/objectSpecifierUtils.js";


### PR DESCRIPTION
Users want to be able to use the object specifier to filter their object sets. Theres no good way to go from object specifier to object reference without this, unless they manually split by themselves.