### PR TITLE
Fix websocket subscription management

### DIFF
--- a/.changeset/better-cloths-bake.md
+++ b/.changeset/better-cloths-bake.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+fix ListQuery websocket subscription management

--- a/packages/client/src/observable/internal/list/ListQuery.ts
+++ b/packages/client/src/observable/internal/list/ListQuery.ts
@@ -46,6 +46,7 @@ import type { Entry } from "../Layer.js";
 import { type ObjectCacheKey } from "../object/ObjectCacheKey.js";
 import { objectSortaMatchesWhereClause as objectMatchesWhereClause } from "../objectMatchesWhereClause.js";
 import type { OptimisticId } from "../OptimisticId.js";
+import { RefCounts } from "../RefCounts.js";
 import type { SimpleWhereClause } from "../SimpleWhereClause.js";
 import { OrderBySortingStrategy } from "../sorting/SortingStrategy.js";
 import type { Store } from "../Store.js";
@@ -85,6 +86,16 @@ export class ListQuery extends BaseListQuery<
   // Using base class minResultsToLoad instead of a private property
   #orderBy: Canonical<Record<string, "asc" | "desc" | undefined>>;
   #objectSet: ObjectSet<ObjectTypeDefinition>;
+  #websocketSubscription: { unsubscribe: () => void } | null = null;
+  #subscriptionRefCounts = new RefCounts<"websocket">(
+    process.env.NODE_ENV !== "production" ? 2000 : 5000,
+    () => {
+      if (this.#websocketSubscription) {
+        this.#websocketSubscription.unsubscribe();
+        this.#websocketSubscription = null;
+      }
+    },
+  );
 
   /**
    * Register changes to the cache specific to ListQuery
@@ -459,15 +470,17 @@ export class ListQuery extends BaseListQuery<
       );
     }
 
-    // FIXME: We should only do this once. If we already have one we should probably
-    // just reuse it.
+    if (!this.#websocketSubscription) {
+      this.#websocketSubscription = this.#objectSet.subscribe({
+        onChange: this.#onOswChange.bind(this),
+        onError: this.#onOswError.bind(this),
+        onOutOfDate: this.#onOswOutOfDate.bind(this),
+        onSuccessfulSubscription: this.#onOswSuccessfulSubscription.bind(this),
+      });
+      this.#subscriptionRefCounts.register("websocket");
+    }
 
-    const websocketSubscription = this.#objectSet.subscribe({
-      onChange: this.#onOswChange.bind(this),
-      onError: this.#onOswError.bind(this),
-      onOutOfDate: this.#onOswOutOfDate.bind(this),
-      onSuccessfulSubscription: this.#onOswSuccessfulSubscription.bind(this),
-    });
+    this.#subscriptionRefCounts.retain("websocket");
 
     sub.add(() => {
       if (process.env.NODE_ENV !== "production") {
@@ -476,7 +489,8 @@ export class ListQuery extends BaseListQuery<
         );
       }
 
-      websocketSubscription.unsubscribe();
+      this.#subscriptionRefCounts.release("websocket");
+      this.#subscriptionRefCounts.gc();
     });
   }
 


### PR DESCRIPTION
Fixes websocket subscription management issue where multiple subscriptions were being created and causing us to handle that downstream. We should arguably (perhaps in a FLUP) clean that up, but for now being defensive isn't bad. 

