### PR TITLE
Gate off ONE direction for link and unlink ontology edits

### DIFF
--- a/.changeset/funny-kiwis-work.md
+++ b/.changeset/funny-kiwis-work.md
@@ -1,0 +1,5 @@
+---
+"@osdk/functions": patch
+---
+
+Add compile check to prevent link and unlink edits when traversing a One direction

--- a/packages/client/src/definitions/LinkDefinitions.test.ts
+++ b/packages/client/src/definitions/LinkDefinitions.test.ts
@@ -44,6 +44,7 @@ describe("LinkDefinitions", () => {
             readonly lead: SingleLinkAccessor<Employee>;
             readonly officeLink: SingleLinkAccessor<Office>;
             readonly peeps: ObjectSet<Employee>;
+            readonly visitedOffices: ObjectSet<Office>;
           }
         >();
     });

--- a/packages/client/src/fetchMetadata.test.ts
+++ b/packages/client/src/fetchMetadata.test.ts
@@ -87,6 +87,10 @@ describe("FetchMetadata", () => {
             "multiplicity": true,
             "targetType": "Employee",
           },
+          "visitedOffices": {
+            "multiplicity": true,
+            "targetType": "Office",
+          },
         },
         "pluralDisplayName": "Employees",
         "primaryKeyApiName": "employeeId",

--- a/packages/client/src/object/convertWireToOsdkObjects.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.test.ts
@@ -71,6 +71,7 @@ describe("convertWireToOsdkObjects", () => {
       "lead",
       "officeLink",
       "peeps",
+      "visitedOffices",
     ]);
 
     const asFoo = employee.$as(FooInterface);

--- a/packages/client/src/object/convertWireToOsdkObjects.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.test.ts
@@ -854,6 +854,10 @@ describe("convertWireToOsdkObjects", () => {
                   "multiplicity": true,
                   "targetType": "Employee",
                 },
+                "visitedOffices": {
+                  "multiplicity": true,
+                  "targetType": "Office",
+                },
               },
               "pluralDisplayName": "Employees",
               "primaryKeyApiName": "employeeId",

--- a/packages/functions/src/edits/EditBatch.ts
+++ b/packages/functions/src/edits/EditBatch.ts
@@ -61,7 +61,7 @@ export type AddLinkTargets<
   ? (X extends AddLink<infer OTD, A>
     ? (CompileTimeMetadata<OTD>["links"][A]["multiplicity"] extends true
       ? Array<X["target"]> | X["target"]
-      : X["target"])
+      : never)
     : never)
   : never;
 
@@ -83,7 +83,7 @@ export type RemoveLinkTargets<
   ? (X extends RemoveLink<infer OTD, A>
     ? (CompileTimeMetadata<OTD>["links"][A]["multiplicity"] extends true
       ? Array<X["target"]> | X["target"]
-      : X["target"])
+      : never)
     : never)
   : never;
 

--- a/packages/functions/src/edits/createEditBatch.test.ts
+++ b/packages/functions/src/edits/createEditBatch.test.ts
@@ -34,6 +34,7 @@ type TestEditScope =
   | Edits.Link<Task, "RP">
   | Edits.Link<Task, "Todos">
   | Edits.Link<Office, "occupants">
+  | Edits.Link<Employee, "visitedOffices">
   | Edits.Interface<FooInterface>;
 
 describe(createEditBatch, () => {
@@ -103,19 +104,23 @@ describe(createEditBatch, () => {
     }, { fooSpt: "fooSpt2" });
     editBatch.delete(fooInterfaceInstance);
 
-    editBatch.link({ $apiName: "Task", $primaryKey: 0 }, "RP", {
-      $apiName: "Person",
-      $primaryKey: 0,
+    editBatch.link({ $apiName: "Employee", $primaryKey: 0 }, "visitedOffices", {
+      $apiName: "Office",
+      $primaryKey: "Seattle",
     });
-    editBatch.link({ $apiName: "Task", $primaryKey: 0 }, "RP", {
-      $apiName: "Person",
-      $primaryKey: 1,
+    editBatch.link({ $apiName: "Employee", $primaryKey: 0 }, "visitedOffices", {
+      $apiName: "Office",
+      $primaryKey: "Palo Alto",
     });
-    editBatch.link(taskInstance, "RP", personInstance);
-    editBatch.unlink({ $apiName: "Task", $primaryKey: 0 }, "RP", {
-      $apiName: "Person",
-      $primaryKey: 1,
-    });
+    editBatch.link(employeeInstance, "visitedOffices", officeInstance);
+    editBatch.unlink(
+      { $apiName: "Employee", $primaryKey: 0 },
+      "visitedOffices",
+      {
+        $apiName: "Office",
+        $primaryKey: "New York",
+      },
+    );
     editBatch.link(taskInstance, "Todos", { $apiName: "Todo", $primaryKey: 0 });
     editBatch.link(taskInstance, "Todos", [
       { $apiName: "Todo", $primaryKey: 1 },
@@ -297,8 +302,9 @@ describe(createEditBatch, () => {
       taskInstance,
       "RP",
       // @ts-expect-error
-      [personInstance],
-    ); // Using list for non-multiplicity link
+      personInstance,
+    );
+    // Trying to traverse ONE direction
 
     editBatch.link(
       { $apiName: "Task", $primaryKey: 2 },

--- a/packages/functions/src/edits/createEditBatch.test.ts
+++ b/packages/functions/src/edits/createEditBatch.test.ts
@@ -132,7 +132,7 @@ describe(createEditBatch, () => {
     });
     editBatch.link(officeInstance, "occupants", employeeInstance);
     editBatch.unlink(
-      { $apiName: "Office", $primaryKey: "2" },
+      { $apiName: "Office", $primaryKey: "Denver" },
       "occupants",
       [employeeInstance, { $apiName: "Employee", $primaryKey: 3 }],
     );
@@ -227,27 +227,27 @@ describe(createEditBatch, () => {
       },
       {
         type: "addLink",
-        apiName: "RP",
-        source: { $apiName: "Task", $primaryKey: 0 },
-        target: { $apiName: "Person", $primaryKey: 0 },
+        apiName: "visitedOffices",
+        source: { $apiName: "Employee", $primaryKey: 0 },
+        target: { $apiName: "Office", $primaryKey: "Seattle" },
       },
       {
         type: "addLink",
-        apiName: "RP",
-        source: { $apiName: "Task", $primaryKey: 0 },
-        target: { $apiName: "Person", $primaryKey: 1 },
+        apiName: "visitedOffices",
+        source: { $apiName: "Employee", $primaryKey: 0 },
+        target: { $apiName: "Office", $primaryKey: "Palo Alto" },
       },
       {
         type: "addLink",
-        apiName: "RP",
-        source: { $apiName: "Task", $primaryKey: 2 },
-        target: { $apiName: "Person", $primaryKey: 2 },
+        apiName: "visitedOffices",
+        source: { $apiName: "Employee", $primaryKey: 2 },
+        target: { $apiName: "Office", $primaryKey: "2" },
       },
       {
         type: "removeLink",
-        apiName: "RP",
-        source: { $apiName: "Task", $primaryKey: 0 },
-        target: { $apiName: "Person", $primaryKey: 1 },
+        apiName: "visitedOffices",
+        source: { $apiName: "Employee", $primaryKey: 0 },
+        target: { $apiName: "Office", $primaryKey: "New York" },
       },
       {
         type: "addLink",
@@ -282,13 +282,13 @@ describe(createEditBatch, () => {
       {
         type: "removeLink",
         apiName: "occupants",
-        source: { $apiName: "Office", $primaryKey: "2" },
+        source: { $apiName: "Office", $primaryKey: "Denver" },
         target: { $apiName: "Employee", $primaryKey: 2 },
       },
       {
         type: "removeLink",
         apiName: "occupants",
-        source: { $apiName: "Office", $primaryKey: "2" },
+        source: { $apiName: "Office", $primaryKey: "Denver" },
         target: { $apiName: "Employee", $primaryKey: 3 },
       },
     ]);

--- a/packages/monorepo.cspell/dict.osdk.txt
+++ b/packages/monorepo.cspell/dict.osdk.txt
@@ -7,6 +7,7 @@ mwalther
 Nativewind
 osdk
 palantirfoundry
+Palo
 paperplane
 Pivotable
 Pressable

--- a/packages/shared.test/src/stubs/linkTypes.ts
+++ b/packages/shared.test/src/stubs/linkTypes.ts
@@ -40,6 +40,15 @@ export const leadLinkType: LinkTypeSideV2 = {
   foreignKeyPropertyApiName: "leadId",
 };
 
+export const visitedOffices: LinkTypeSideV2 = {
+  apiName: "visitedOffices",
+  status: "EXPERIMENTAL",
+  objectTypeApiName: officeObjectType.apiName,
+  cardinality: "MANY",
+  displayName: "Visited Offices",
+  linkTypeRid: "ri.a.b.c.visitedOffices",
+};
+
 export const officeLinkType: LinkTypeSideV2 = {
   apiName: "officeLink",
   status: "EXPERIMENTAL",

--- a/packages/shared.test/src/stubs/objectTypesWithLinkTypes.ts
+++ b/packages/shared.test/src/stubs/objectTypesWithLinkTypes.ts
@@ -21,6 +21,7 @@ import {
   occupants,
   officeLinkType,
   peepsLinkType,
+  visitedOffices,
 } from "./linkTypes.js";
 import {
   BGaoNflPlayerObjectType,
@@ -36,7 +37,7 @@ import {
 
 export const employeeObjectWithLinkTypes: ObjectTypeFullMetadata = {
   objectType: employeeObjectType,
-  linkTypes: [peepsLinkType, leadLinkType, officeLinkType],
+  linkTypes: [peepsLinkType, leadLinkType, officeLinkType, visitedOffices],
   implementsInterfaces: ["FooInterface"],
   implementsInterfaces2: {
     FooInterface: {


### PR DESCRIPTION
It is not currently allowed to use link and unlink edits with any one to many backed link type. We don't have the metadata available to provide compile time checks for any link going in the 1 -> M direction, but we do know that any link going in a 1 direction, i.e. M -> 1 or 1 -> 1 must be backed by a one to many backed link type