### PR TITLE
Add api name validation for object types

### DIFF
--- a/.changeset/large-jobs-tease.md
+++ b/.changeset/large-jobs-tease.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker": patch
+---
+
+Add api name validation for object types

--- a/packages/maker/src/api/defineObject.ts
+++ b/packages/maker/src/api/defineObject.ts
@@ -42,6 +42,8 @@ const ISO_8601_DURATION =
 const ISO_8601_DATETIME =
   /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?)?$/;
 
+const API_NAME_PATTERN = /^([a-zA-Z][a-zA-Z0-9\\-]*)$/;
+
 export function defineObject(
   objectDef: ObjectTypeDefinition,
 ): ObjectTypeDefinition {
@@ -57,6 +59,10 @@ export function defineObject(
       `Object type with apiName ${objectDef.apiName} is already defined`,
     );
   }
+  invariant(
+    API_NAME_PATTERN.test(objectDef.apiName),
+    `Invalid API name ${objectDef.apiName}. API names must match the regex ${API_NAME_PATTERN}.`,
+  );
   invariant(
     propertyApiNames.includes(objectDef.titlePropertyApiName),
     `Title property ${objectDef.titlePropertyApiName} is not defined on object ${objectDef.apiName}`,

--- a/packages/maker/src/api/overall.test.ts
+++ b/packages/maker/src/api/overall.test.ts
@@ -1584,6 +1584,20 @@ describe("Ontology Defining", () => {
   });
 
   describe("Objects", () => {
+    it("Fails if the api name is invalid", () => {
+      expect(() => {
+        defineObject({
+          titlePropertyApiName: "bar",
+          displayName: "Foo",
+          pluralDisplayName: "Foo",
+          apiName: "foo_with_underscores",
+          primaryKeyPropertyApiName: "bar",
+          properties: { "bar": { type: "string" } },
+        });
+      }).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Invalid API name foo_with_underscores. API names must match the regex /^([a-zA-Z][a-zA-Z0-9\\\\-]*)$/.]`,
+      );
+    });
     it("Fails if any property reference does not exist", () => {
       const spt = defineSharedPropertyType({
         apiName: "foo",


### PR DESCRIPTION
OMS was failing ObjectTypeId validation in marketplace because someone used underscores in their api name. This should make that a build-time error instead of a marketplace error