### PR TITLE
Add jiti back to maker

### DIFF
--- a/packages/maker/src/cli/main.ts
+++ b/packages/maker/src/cli/main.ts
@@ -15,6 +15,7 @@
  */
 
 import { consola } from "consola";
+import { createJiti } from "jiti";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import invariant from "tiny-invariant";
@@ -139,7 +140,14 @@ async function loadOntology(
 ) {
   const q = await defineOntology(
     apiNamespace,
-    async () => await import(input),
+    async () => {
+      const jiti = createJiti(import.meta.filename, {
+        moduleCache: true,
+        debug: false,
+        importMeta: import.meta,
+      });
+      await jiti.import(input);
+    },
     outputDir,
     dependencyFile,
   );


### PR DESCRIPTION
Add jiti back to maker. It was removed in https://github.com/palantir/osdk-ts/pull/1801, but after a quick chat w/ @aep000 sounds like this didn't actually fix the issue at hand, and without jiti as can't run the maker-cli directly against an ontology TS file.