### PR TITLE
Use vite server origin and base in vite-plugin-oac

### DIFF
--- a/packages/vite-plugin-oac/src/OacContext.ts
+++ b/packages/vite-plugin-oac/src/OacContext.ts
@@ -29,9 +29,12 @@ export class OacContext extends OacConfig {
   constructor(config: OacConfig, resolvedConfig: ResolvedConfig) {
     super(config);
 
-    this.serverUrl = `http${
+    const localhostOrigin = `http${
       resolvedConfig.server.https ? "s" : ""
     }://localhost:${resolvedConfig.server.port}`;
+    const origin = resolvedConfig.server.origin
+      ?? localhostOrigin;
+    this.serverUrl = origin + resolvedConfig.base;
     this.defaultOntologyRid =
       `ri.ontology.main.ontology.00000000-0000-0000-0000-000000000000`;
     this.workDir = path.join("node_modules", ".osdk", ".oac");


### PR DESCRIPTION
Use vite server origin and base in vite-plugin-oac when available. This is necessary for development workflows in in-platform code workspaces. Kept the localhost origin as a fallback when origin isn't provided.

As an example, the dev server is available at url in the form of `https://{stack}-containers.palantirfoundry.com/foundry-container-service/proxy/{rid}/port8082/`.