### PR TITLE
Fix ir to full metadata in vite-plugin-oac

### DIFF
--- a/packages/vite-plugin-oac/src/generateOntologyAssets.ts
+++ b/packages/vite-plugin-oac/src/generateOntologyAssets.ts
@@ -101,7 +101,7 @@ async function ontologyIrToFullMetadata(
       encoding: "utf-8",
     });
     const blockData = JSON.parse(irContent)
-      .blockData as OntologyIrOntologyBlockDataV2;
+      .ontology as OntologyIrOntologyBlockDataV2;
 
     const fullMeta = OntologyIrToFullMetadataConverter.getFullMetadataFromIr(
       blockData,


### PR DESCRIPTION
Looks like the IR structure changed in https://github.com/palantir/osdk-ts/commit/04fe946409ab0739c7dd14b928631f4913f4cc1a#diff-021a6a086467cca37ab5d75173fcbd5097d05c54167f3076ea7b0af6ffd6e003R34, this PR updates the vite plugin to handle it.