### PR TITLE
[Bug] Nested list fields are not supported

### DIFF
--- a/packages/generator/src/v2.0/generatePerQueryDataFiles.test.ts
+++ b/packages/generator/src/v2.0/generatePerQueryDataFiles.test.ts
@@ -253,6 +253,18 @@ describe("generatePerQueryDataFiles", () => {
                   foo: {
                     dataType: { type: "string" },
                   },
+                  listField: {
+                    dataType: { type: "array", "subType": { "type": "float" } },
+                  },
+                  nestedListField: {
+                    dataType: {
+                      type: "array",
+                      "subType": {
+                        "type": "array",
+                        "subType": { "type": "float" },
+                      },
+                    },
+                  },
                   paramStruct: {
                     dataType: {
                       type: "struct",
@@ -355,6 +367,16 @@ describe("generatePerQueryDataFiles", () => {
             /**
              * (no ontology metadata)
              */
+            readonly listField: ReadonlyArray<QueryParam.PrimitiveType<'float'>>;
+
+            /**
+             * (no ontology metadata)
+             */
+            readonly nestedListField: ReadonlyArray<ReadonlyArray<QueryParam.PrimitiveType<'float'>>>;
+
+            /**
+             * (no ontology metadata)
+             */
             readonly paramStruct: {
               readonly aDate: QueryParam.PrimitiveType<'datetime'>;
 
@@ -398,6 +420,18 @@ describe("generatePerQueryDataFiles", () => {
                 nullable: false;
                 type: 'string';
               };
+              /**
+               * (no ontology metadata)
+               */
+              listField: {
+                multiplicity: true;
+                nullable: false;
+                type: 'float';
+              };
+              /**
+               * (no ontology metadata)
+               */
+              nestedListField: TODO: I don't think this is currently representable..
               /**
                * (no ontology metadata)
                */


### PR DESCRIPTION
For a parameter that is a `list<list<primitive>>`, the generated query type is a `ReadonlyArray<primitive>` when it should be a `ReadonlyArray<ReadonlyArray<primitive>>`

```shell
pnpm vitest run -t "generates structs for queries" packages/generator/src/v2.0/generatePerQueryDataFiles.test.ts
```

<img width="832" height="361" alt="Screenshot 2025-09-30 at 3 47 42 PM" src="https://github.com/user-attachments/assets/cb4e3ba1-8296-4f89-99f5-29a336a3546d" />
