### PR TITLE
Prevent minor changesets from bumping packages that take a peer dependency

### DIFF
--- a/packages/tool.release/src/runVersion.ts
+++ b/packages/tool.release/src/runVersion.ts
@@ -150,6 +150,10 @@ export async function runVersion({
     // Disable committing when in snapshot mode
     commit: snapshot || !runGitCommands ? false : config.commit,
     changelog: ["@changesets/changelog-git", null],
+    ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
+      onlyUpdatePeerDependentsWhenOutOfRange: true,
+      updateInternalDependents: "out-of-range",
+    },
   };
 
   const releasePlan = assembleReleasePlan(


### PR DESCRIPTION
When a package takes a peer dependency on a release that has a minor changeset, changeset by default thinks it should bump the major version. These settings prevent that from happening unless the version constraint changes. See this code in changesets that determines when to bump [major versions](https://github.com/changesets/changesets/blob/9657b268d44645f7b55dcd6724578e0438415e95/packages/assemble-release-plan/src/determine-dependents.ts#L84).