### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -161,6 +161,7 @@
     "@osdk-widget.vite-plugin-simulatedRelease",
     "all-worlds-wear",
     "angry-cloths-clap",
+    "better-results-admire",
     "bitter-suits-itch",
     "busy-rivers-battle",
     "chubby-memes-stare",
@@ -170,6 +171,7 @@
     "dark-yaks-hope",
     "dirty-papers-unite",
     "dry-spoons-burn",
+    "early-experts-brake",
     "easy-doodles-shop",
     "every-spoons-flash",
     "fix-link-association",
@@ -180,8 +182,10 @@
     "fresh-sites-drum",
     "fresh-worlds-wave",
     "funny-ants-drum",
+    "funny-kiwis-work",
     "green-towns-travel",
     "heavy-days-allow",
+    "hungry-teams-relax",
     "icy-jeans-jump",
     "large-jobs-tease",
     "late-houses-joke",
@@ -219,6 +223,7 @@
     "wide-boxes-care",
     "wise-cows-tie",
     "yellow-moments-open",
+    "young-otters-march",
     "yummy-eels-try"
   ]
 }

--- a/benchmarks/tests/primary/CHANGELOG.md
+++ b/benchmarks/tests/primary/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/benchmarks.primary
 
+## 0.1.0-beta.72
+
+### Patch Changes
+
+- Updated dependencies [85e8edb]
+  - @osdk/client@2.5.0-beta.12
+
 ## 0.1.0-beta.71
 
 ### Patch Changes

--- a/benchmarks/tests/primary/package.json
+++ b/benchmarks/tests/primary/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/benchmarks.primary",
   "private": true,
-  "version": "0.1.0-beta.71",
+  "version": "0.1.0-beta.72",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/api
 
+## 2.5.0-beta.12
+
 ## 2.5.0-beta.11
 
 ### Minor Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/api",
-  "version": "2.5.0-beta.11",
+  "version": "2.5.0-beta.12",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client.test.ontology/CHANGELOG.md
+++ b/packages/client.test.ontology/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/client.test.ontology
 
+## 2.5.0-beta.12
+
+### Patch Changes
+
+- @osdk/api@2.5.0-beta.12
+
 ## 2.5.0-beta.11
 
 ### Patch Changes

--- a/packages/client.test.ontology/package.json
+++ b/packages/client.test.ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/client.test.ontology",
   "private": true,
-  "version": "2.5.0-beta.11",
+  "version": "2.5.0-beta.12",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.unstable/CHANGELOG.md
+++ b/packages/client.unstable/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/client.unstable
 
+## 2.5.0-beta.12
+
 ## 2.5.0-beta.11
 
 ## 2.5.0-beta.10

--- a/packages/client.unstable/package.json
+++ b/packages/client.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.unstable",
-  "version": "2.5.0-beta.11",
+  "version": "2.5.0-beta.12",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/client
 
+## 2.5.0-beta.12
+
+### Minor Changes
+
+- 85e8edb: Fix unhandled promise rejection error.
+
+### Patch Changes
+
+- @osdk/api@2.5.0-beta.12
+- @osdk/client.unstable@2.5.0-beta.12
+- @osdk/generator-converters@2.5.0-beta.12
+
 ## 2.5.0-beta.11
 
 ### Minor Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client",
-  "version": "2.5.0-beta.11",
+  "version": "2.5.0-beta.12",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/create-app.template-packager/CHANGELOG.md
+++ b/packages/create-app.template-packager/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template-packager
 
+## 2.5.0-beta.12
+
 ## 2.5.0-beta.11
 
 ## 2.5.0-beta.10

--- a/packages/create-app.template-packager/package.json
+++ b/packages/create-app.template-packager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template-packager",
   "private": true,
-  "version": "2.5.0-beta.11",
+  "version": "2.5.0-beta.12",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.expo.v2/CHANGELOG.md
+++ b/packages/create-app.template.expo.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.expo.v2
 
+## 2.5.0-beta.12
+
 ## 2.5.0-beta.11
 
 ## 2.5.0-beta.10

--- a/packages/create-app.template.expo.v2/package.json
+++ b/packages/create-app.template.expo.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.expo.v2",
   "private": true,
-  "version": "2.5.0-beta.11",
+  "version": "2.5.0-beta.12",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react.beta/CHANGELOG.md
+++ b/packages/create-app.template.react.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.react
 
+## 2.5.0-beta.12
+
 ## 2.5.0-beta.11
 
 ## 2.5.0-beta.10

--- a/packages/create-app.template.react.beta/package.json
+++ b/packages/create-app.template.react.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react.beta",
   "private": true,
-  "version": "2.5.0-beta.11",
+  "version": "2.5.0-beta.12",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react/CHANGELOG.md
+++ b/packages/create-app.template.react/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.react
 
+## 2.5.0-beta.12
+
 ## 2.5.0-beta.11
 
 ## 2.5.0-beta.10

--- a/packages/create-app.template.react/package.json
+++ b/packages/create-app.template.react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react",
   "private": true,
-  "version": "2.5.0-beta.11",
+  "version": "2.5.0-beta.12",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-aip-app.beta
 
+## 2.5.0-beta.12
+
 ## 2.5.0-beta.11
 
 ## 2.5.0-beta.10

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app.beta",
   "private": true,
-  "version": "2.5.0-beta.11",
+  "version": "2.5.0-beta.12",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-aip-app
 
+## 2.5.0-beta.12
+
 ## 2.5.0-beta.11
 
 ## 2.5.0-beta.10

--- a/packages/create-app.template.tutorial-todo-aip-app/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app",
   "private": true,
-  "version": "2.5.0-beta.11",
+  "version": "2.5.0-beta.12",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-app.beta/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-app.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-app.beta
 
+## 2.5.0-beta.12
+
 ## 2.5.0-beta.11
 
 ## 2.5.0-beta.10

--- a/packages/create-app.template.tutorial-todo-app.beta/package.json
+++ b/packages/create-app.template.tutorial-todo-app.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app.beta",
   "private": true,
-  "version": "2.5.0-beta.11",
+  "version": "2.5.0-beta.12",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-app
 
+## 2.5.0-beta.12
+
 ## 2.5.0-beta.11
 
 ## 2.5.0-beta.10

--- a/packages/create-app.template.tutorial-todo-app/package.json
+++ b/packages/create-app.template.tutorial-todo-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app",
   "private": true,
-  "version": "2.5.0-beta.11",
+  "version": "2.5.0-beta.12",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.vue.v2/CHANGELOG.md
+++ b/packages/create-app.template.vue.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.vue.v2
 
+## 2.5.0-beta.12
+
 ## 2.5.0-beta.11
 
 ## 2.5.0-beta.10

--- a/packages/create-app.template.vue.v2/package.json
+++ b/packages/create-app.template.vue.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.vue.v2",
   "private": true,
-  "version": "2.5.0-beta.11",
+  "version": "2.5.0-beta.12",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.vue/CHANGELOG.md
+++ b/packages/create-app.template.vue/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.vue
 
+## 2.5.0-beta.12
+
 ## 2.5.0-beta.11
 
 ## 2.5.0-beta.10

--- a/packages/create-app.template.vue/package.json
+++ b/packages/create-app.template.vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.vue",
   "private": true,
-  "version": "2.5.0-beta.11",
+  "version": "2.5.0-beta.12",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app
 
+## 2.5.0-beta.12
+
 ## 2.5.0-beta.11
 
 ## 2.5.0-beta.10

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-app",
-  "version": "2.5.0-beta.11",
+  "version": "2.5.0-beta.12",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/foundry-sdk-generator
 
+## 2.5.0-beta.12
+
+### Patch Changes
+
+- Updated dependencies [4b4a458]
+- Updated dependencies [85e8edb]
+  - @osdk/generator@2.5.0-beta.12
+  - @osdk/client@2.5.0-beta.12
+  - @osdk/api@2.5.0-beta.12
+
 ## 2.5.0-beta.11
 
 ### Patch Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "2.5.0-beta.11",
+  "version": "2.5.0-beta.12",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/functions/CHANGELOG.md
+++ b/packages/functions/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/functions
 
+## 1.3.0-beta.7
+
+### Minor Changes
+
+- 9bbe664: Add compile check to prevent link and unlink edits when traversing a One direction
+
+### Patch Changes
+
+- Updated dependencies [85e8edb]
+  - @osdk/client@2.5.0-beta.12
+
 ## 1.3.0-beta.6
 
 ### Minor Changes

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/functions",
-  "version": "1.3.0-beta.6",
+  "version": "1.3.0-beta.7",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-converters.ontologyir/CHANGELOG.md
+++ b/packages/generator-converters.ontologyir/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/generator-converters.ontologyir
 
+## 2.5.0-beta.12
+
+### Patch Changes
+
+- @osdk/client.unstable@2.5.0-beta.12
+
 ## 2.5.0-beta.11
 
 ### Patch Changes

--- a/packages/generator-converters.ontologyir/package.json
+++ b/packages/generator-converters.ontologyir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-converters.ontologyir",
-  "version": "2.5.0-beta.11",
+  "version": "2.5.0-beta.12",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-converters/CHANGELOG.md
+++ b/packages/generator-converters/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/generator-converters
 
+## 2.5.0-beta.12
+
+### Patch Changes
+
+- @osdk/api@2.5.0-beta.12
+
 ## 2.5.0-beta.11
 
 ### Patch Changes

--- a/packages/generator-converters/package.json
+++ b/packages/generator-converters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-converters",
-  "version": "2.5.0-beta.11",
+  "version": "2.5.0-beta.12",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-utils/CHANGELOG.md
+++ b/packages/generator-utils/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/generator-utils
 
+## 2.5.0-beta.12
+
 ## 2.5.0-beta.11
 
 ## 2.5.0-beta.10

--- a/packages/generator-utils/package.json
+++ b/packages/generator-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-utils",
-  "version": "2.5.0-beta.11",
+  "version": "2.5.0-beta.12",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/generator
 
+## 2.5.0-beta.12
+
+### Minor Changes
+
+- 4b4a458: Allow exporting rid for object types
+
+### Patch Changes
+
+- @osdk/api@2.5.0-beta.12
+- @osdk/generator-converters@2.5.0-beta.12
+
 ## 2.5.0-beta.11
 
 ### Patch Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "2.5.0-beta.11",
+  "version": "2.5.0-beta.12",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/maker/CHANGELOG.md
+++ b/packages/maker/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/maker
 
+## 0.13.0-beta.12
+
+### Minor Changes
+
+- f025f30: Fix semantic merge conflict
+- 7f0ad5c: Check extended interfaces when verifying interface actions
+
+### Patch Changes
+
+- @osdk/api@2.5.0-beta.12
+
 ## 0.13.0-beta.11
 
 ### Minor Changes

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker",
-  "version": "0.13.0-beta.11",
+  "version": "0.13.0-beta.12",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/vite-plugin-oac/CHANGELOG.md
+++ b/packages/vite-plugin-oac/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/vite-plugin-oac
 
+## 0.3.0-beta.12
+
+### Patch Changes
+
+- Updated dependencies [f025f30]
+- Updated dependencies [7f0ad5c]
+  - @osdk/maker@0.13.0-beta.12
+  - @osdk/api@2.5.0-beta.12
+  - @osdk/client.unstable@2.5.0-beta.12
+  - @osdk/generator-converters.ontologyir@2.5.0-beta.12
+
 ## 0.3.0-beta.11
 
 ### Patch Changes

--- a/packages/vite-plugin-oac/package.json
+++ b/packages/vite-plugin-oac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/vite-plugin-oac",
-  "version": "0.3.0-beta.11",
+  "version": "0.3.0-beta.12",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/client@2.5.0-beta.12

### Minor Changes

-   85e8edb: Fix unhandled promise rejection error.

### Patch Changes

-   @osdk/api@2.5.0-beta.12
-   @osdk/client.unstable@2.5.0-beta.12
-   @osdk/generator-converters@2.5.0-beta.12

## @osdk/functions@1.3.0-beta.7

### Minor Changes

-   9bbe664: Add compile check to prevent link and unlink edits when traversing a One direction

### Patch Changes

-   Updated dependencies [85e8edb]
    -   @osdk/client@2.5.0-beta.12

## @osdk/generator@2.5.0-beta.12

### Minor Changes

-   4b4a458: Allow exporting rid for object types

### Patch Changes

-   @osdk/api@2.5.0-beta.12
-   @osdk/generator-converters@2.5.0-beta.12

## @osdk/maker@0.13.0-beta.12

### Minor Changes

-   f025f30: Fix semantic merge conflict
-   7f0ad5c: Check extended interfaces when verifying interface actions

### Patch Changes

-   @osdk/api@2.5.0-beta.12

## @osdk/foundry-sdk-generator@2.5.0-beta.12

### Patch Changes

-   Updated dependencies [4b4a458]
-   Updated dependencies [85e8edb]
    -   @osdk/generator@2.5.0-beta.12
    -   @osdk/client@2.5.0-beta.12
    -   @osdk/api@2.5.0-beta.12

## @osdk/generator-converters@2.5.0-beta.12

### Patch Changes

-   @osdk/api@2.5.0-beta.12

## @osdk/generator-converters.ontologyir@2.5.0-beta.12

### Patch Changes

-   @osdk/client.unstable@2.5.0-beta.12

## @osdk/vite-plugin-oac@0.3.0-beta.12

### Patch Changes

-   Updated dependencies [f025f30]
-   Updated dependencies [7f0ad5c]
    -   @osdk/maker@0.13.0-beta.12
    -   @osdk/api@2.5.0-beta.12
    -   @osdk/client.unstable@2.5.0-beta.12
    -   @osdk/generator-converters.ontologyir@2.5.0-beta.12

## @osdk/api@2.5.0-beta.12



## @osdk/client.unstable@2.5.0-beta.12



## @osdk/create-app@2.5.0-beta.12



## @osdk/generator-utils@2.5.0-beta.12



## @osdk/benchmarks.primary@0.1.0-beta.72

### Patch Changes

-   Updated dependencies [85e8edb]
    -   @osdk/client@2.5.0-beta.12

## @osdk/client.test.ontology@2.5.0-beta.12

### Patch Changes

-   @osdk/api@2.5.0-beta.12

## @osdk/create-app.template-packager@2.5.0-beta.12



## @osdk/create-app.template.expo.v2@2.5.0-beta.12



## @osdk/create-app.template.react@2.5.0-beta.12



## @osdk/create-app.template.react.beta@2.5.0-beta.12



## @osdk/create-app.template.tutorial-todo-aip-app@2.5.0-beta.12



## @osdk/create-app.template.tutorial-todo-aip-app.beta@2.5.0-beta.12



## @osdk/create-app.template.tutorial-todo-app@2.5.0-beta.12



## @osdk/create-app.template.tutorial-todo-app.beta@2.5.0-beta.12



## @osdk/create-app.template.vue@2.5.0-beta.12



## @osdk/create-app.template.vue.v2@2.5.0-beta.12


