### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -93,7 +93,10 @@
     "@osdk/generator-converters.ontologyir": "2.4.0",
     "@osdk/vite-plugin-oac": "0.2.0",
     "@osdk/maker-experimental": "0.2.0",
-    "@osdk/e2e.sandbox.peopleapp": "3.3.0-beta.1"
+    "@osdk/e2e.sandbox.peopleapp": "3.3.0-beta.1",
+    "@osdk/osdk-docs-context": "0.1.0",
+    "@osdk/typescript-docs-example-generator": "0.1.0",
+    "@osdk/typescript-sdk-docs-examples": "0.1.0"
   },
   "changesets": [
     "@osdk-api-simulatedRelease",
@@ -227,11 +230,13 @@
     "tall-dots-ask",
     "ten-guests-study",
     "thin-bats-play",
+    "thin-owls-refuse",
     "tired-frogs-jump",
     "two-lemons-nail",
     "warm-ends-drive",
     "wide-boxes-care",
     "wise-cows-tie",
+    "yellow-geese-like",
     "yellow-moments-open",
     "yellow-terms-stare",
     "young-otters-march",

--- a/packages/maker/CHANGELOG.md
+++ b/packages/maker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/maker
 
+## 0.13.0-beta.17
+
+### Minor Changes
+
+- 58e9f56: Add condition validations for oac actions
+
 ## 0.13.0-beta.16
 
 ### Minor Changes

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker",
-  "version": "0.13.0-beta.16",
+  "version": "0.13.0-beta.17",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/osdk-docs-context/CHANGELOG.md
+++ b/packages/osdk-docs-context/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @osdk/osdk-docs-context
+
+## 0.2.0-beta.0
+
+### Minor Changes
+
+- 81af4c8: A set of compiled examples based on the documentation YAML

--- a/packages/osdk-docs-context/package.json
+++ b/packages/osdk-docs-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/osdk-docs-context",
-  "version": "0.1.0",
+  "version": "0.2.0-beta.0",
   "description": "OSDK Documentation Context utilities and examples registry",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/typescript-docs-example-generator/CHANGELOG.md
+++ b/packages/typescript-docs-example-generator/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @osdk/typescript-docs-example-generator
+
+## 0.2.0-beta.0
+
+### Minor Changes
+
+- 81af4c8: A set of compiled examples based on the documentation YAML
+
+### Patch Changes
+
+- Updated dependencies [81af4c8]
+  - @osdk/typescript-sdk-docs@0.4.0-beta.6

--- a/packages/typescript-docs-example-generator/package.json
+++ b/packages/typescript-docs-example-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/typescript-docs-example-generator",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/typescript-sdk-docs-examples/CHANGELOG.md
+++ b/packages/typescript-sdk-docs-examples/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @osdk/typescript-sdk-docs-examples
+
+## 0.2.0-beta.0
+
+### Minor Changes
+
+- 81af4c8: A set of compiled examples based on the documentation YAML

--- a/packages/typescript-sdk-docs-examples/package.json
+++ b/packages/typescript-sdk-docs-examples/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/typescript-sdk-docs-examples",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -36,8 +36,7 @@
     "transpileTypes": "monorepo.tool.transpile -f esm -m types -t node",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "peerDependencies": {
     "@osdk/client": "workspace:~"
   },

--- a/packages/typescript-sdk-docs/CHANGELOG.md
+++ b/packages/typescript-sdk-docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/typescript-sdk-docs
 
+## 0.4.0-beta.6
+
+### Minor Changes
+
+- 81af4c8: A set of compiled examples based on the documentation YAML
+
 ## 0.4.0-beta.5
 
 ### Minor Changes

--- a/packages/typescript-sdk-docs/package.json
+++ b/packages/typescript-sdk-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/typescript-sdk-docs",
-  "version": "0.4.0-beta.5",
+  "version": "0.4.0-beta.6",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/maker@0.13.0-beta.17

### Minor Changes

-   58e9f56: Add condition validations for oac actions

## @osdk/osdk-docs-context@0.2.0-beta.0

### Minor Changes

-   81af4c8: A set of compiled examples based on the documentation YAML

## @osdk/typescript-sdk-docs@0.4.0-beta.6

### Minor Changes

-   81af4c8: A set of compiled examples based on the documentation YAML

## @osdk/typescript-docs-example-generator@0.2.0-beta.0

### Minor Changes

-   81af4c8: A set of compiled examples based on the documentation YAML

### Patch Changes

-   Updated dependencies [81af4c8]
    -   @osdk/typescript-sdk-docs@0.4.0-beta.6

## @osdk/typescript-sdk-docs-examples@0.2.0-beta.0

### Minor Changes

-   81af4c8: A set of compiled examples based on the documentation YAML
