### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -85,7 +85,8 @@
     "@osdk/tests.verify-cjs-node10": "0.0.3",
     "@osdk/tests.verify-cjs-node16": "0.0.3",
     "@osdk/tests.verify-esm-node16": "0.0.3",
-    "@osdk/tests.verify-fallback-package-v2": "0.0.3"
+    "@osdk/tests.verify-fallback-package-v2": "0.0.3",
+    "@osdk/osdk-docs-context-generator": "0.1.0"
   },
   "changesets": [
     "@osdk-api-simulatedRelease",
@@ -155,6 +156,8 @@
     "@osdk-widget.client-react-simulatedRelease",
     "@osdk-widget.client-simulatedRelease",
     "@osdk-widget.vite-plugin-simulatedRelease",
+    "dull-flies-call",
+    "rare-wings-jog",
     "shy-lizards-smash"
   ]
 }

--- a/packages/maker/CHANGELOG.md
+++ b/packages/maker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/maker
 
+## 0.14.0-beta.3
+
+### Minor Changes
+
+- 995064b: Make tests run synchronously
+
 ## 0.14.0-beta.2
 
 ### Minor Changes

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker",
-  "version": "0.14.0-beta.2",
+  "version": "0.14.0-beta.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/osdk-docs-context-generator/CHANGELOG.md
+++ b/packages/osdk-docs-context-generator/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @osdk/osdk-docs-context-generator
+
+## 0.2.0-beta.0
+
+### Minor Changes
+
+- 9f3455d: Add a separate generator package for osdk docs context to make it independent from example package

--- a/packages/osdk-docs-context-generator/package.json
+++ b/packages/osdk-docs-context-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/osdk-docs-context-generator",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/osdk-docs-context/CHANGELOG.md
+++ b/packages/osdk-docs-context/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/osdk-docs-context
 
+## 0.3.0-beta.2
+
+### Minor Changes
+
+- 9f3455d: Add a separate generator package for osdk docs context to make it independent from example package
+
 ## 0.2.0-beta.0
 
 ### Minor Changes

--- a/packages/osdk-docs-context/package.json
+++ b/packages/osdk-docs-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/osdk-docs-context",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0-beta.2",
   "description": "OSDK Documentation Context utilities and examples registry",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/maker@0.14.0-beta.3

### Minor Changes

-   995064b: Make tests run synchronously

## @osdk/osdk-docs-context@0.3.0-beta.2

### Minor Changes

-   9f3455d: Add a separate generator package for osdk docs context to make it independent from example package

## @osdk/osdk-docs-context-generator@0.2.0-beta.0

### Minor Changes

-   9f3455d: Add a separate generator package for osdk docs context to make it independent from example package
