### PR TITLE
remap object set query responses using asType instead of intersect

### DIFF
--- a/packages/client/src/queries/applyQuery.ts
+++ b/packages/client/src/queries/applyQuery.ts
@@ -207,11 +207,9 @@ async function remapQueryResponse<
       }
       if (typeof responseValue === "string") {
         return createObjectSet(def, client, {
-          type: "intersect",
-          objectSets: [
-            { type: "base", objectType: responseDataType.objectSet },
-            { type: "reference", reference: responseValue },
-          ],
+          type: "asType",
+          entityType: responseDataType.objectSet,
+          objectSet: { type: "reference", reference: responseValue },
         }) as QueryReturnType<typeof responseDataType>;
       }
 

--- a/packages/client/src/queries/queries.test.ts
+++ b/packages/client/src/queries/queries.test.ts
@@ -28,6 +28,7 @@ import {
   queryAcceptsInterfaceObjectSet,
   queryAcceptsObject,
   queryAcceptsObjectSets,
+  queryReturnsObjectSetRid,
   queryTypeReturnsMap,
   returnsDate,
   returnsTimestamp,
@@ -410,6 +411,13 @@ describe("queries", () => {
 
     expectTypeOf<ObjectSet<Employee>>().toMatchTypeOf<typeof result>();
   });
+
+  it("returns objectSet from RID string", async () => {
+    const result = await client(queryReturnsObjectSetRid).executeFunction();
+
+    expectTypeOf<ObjectSet<Employee>>().toMatchTypeOf<typeof result>();
+    expect(result).toBeDefined();
+  });
   it("queries are enumerable", async () => {
     const queries = Object.keys($Queries);
     expect(queries).toStrictEqual([
@@ -423,6 +431,7 @@ describe("queries", () => {
       "queryAcceptsObject",
       "queryAcceptsObjectSets",
       "queryOutputsInterface",
+      "queryReturnsObjectSetRid",
       "queryTypeReturnsArray",
       "queryTypeReturnsMap",
       "returnsDate",

--- a/packages/shared.test/src/stubs/queries.ts
+++ b/packages/shared.test/src/stubs/queries.ts
@@ -36,6 +36,7 @@ import {
   queryTypeReturnsDate,
   queryTypeReturnsMap,
   queryTypeReturnsObject,
+  queryTypeReturnsObjectSetRid,
   queryTypeReturnsStruct,
   queryTypeReturnsTimestamp,
   queryTypeThreeDimensionalAggregation,
@@ -182,6 +183,10 @@ export const queryTypeAcceptsObjectSetResponse: ExecuteQueryResponse = {
   value: {
     objectSet: { type: "base", objectType: "Employee" },
   },
+};
+
+export const queryTypeReturnsObjectSetRidResponse: ExecuteQueryResponse = {
+  value: "ri.objectset.main.objectset.mock-employee-set-rid",
 };
 
 export const queryTypeThreeDimensionalAggregationResponse:
@@ -404,6 +409,11 @@ const queryRequestHandlers: {
         queryTypeAcceptsObjectSetResponse,
     },
   },
+  [queryTypeReturnsObjectSetRid.apiName]: {
+    [queryTypeReturnsObjectSetRid.version]: {
+      [emptyBody]: queryTypeReturnsObjectSetRidResponse,
+    },
+  },
   [queryTypeAcceptsTwoDimensionalAggregation.apiName]: {
     [queryTypeAcceptsTwoDimensionalAggregation.version]: {
       [JSON.stringify(queryTypeAcceptsTwoDimensionalAggregationRequest)]:
@@ -453,6 +463,7 @@ export function registerLazyQueries(fauxOntology: FauxOntology): void {
     queryTypeThreeDimensionalAggregation,
     queryTypeAcceptsObjects,
     queryTypeAcceptsObjectSets,
+    queryTypeReturnsObjectSetRid,
     queryTypeAcceptsTwoDimensionalAggregation,
     queryTypeAcceptsThreeDimensionalAggregation,
     queryTypeReturnsArray,

--- a/packages/shared.test/src/stubs/queryTypes.ts
+++ b/packages/shared.test/src/stubs/queryTypes.ts
@@ -479,6 +479,21 @@ export const queryTypeAcceptsObjectSets: QueryTypeV2 = {
   version: "0.11.0",
 };
 
+export const queryTypeReturnsObjectSetRid: QueryTypeV2 = {
+  apiName: "queryReturnsObjectSetRid",
+  description: "query that returns an objectSet as a RID string",
+  displayName: "QueryReturnsObjectSetRid",
+  parameters: {},
+  output: {
+    type: "objectSet",
+    objectApiName: "Employee",
+    objectTypeApiName: "Employee",
+  },
+  rid:
+    "ri.function-registry.main.function.8a44870a-63c7-4d48-8f06-9627c0805969",
+  version: "0.11.0",
+};
+
 export const queryTypeReturnsArray: QueryTypeV2 = {
   "apiName": "queryTypeReturnsArray",
   "output": {


### PR DESCRIPTION
Updates `applyQuery` `remapQueryResponse` behavior to map object set using `asType` instead of `intersect`.

This is a fix to a recent PDS where we failed to compute results for API Gateway queries. Unlike other SDKs, the Typescript SDK maps object sets via an intersect. This has the side effect of losing the relevancy ordering, something OSS relies upon in order to compute the right DataFrame.