### PR TITLE
fix useOsdkObject to use $eq for single fetches

### DIFF
--- a/packages/client/src/observable/internal/BulkObjectLoader.ts
+++ b/packages/client/src/observable/internal/BulkObjectLoader.ts
@@ -100,10 +100,14 @@ export class BulkObjectLoader {
 
     const pks = arr.map(x => x.primaryKey);
 
+    // Use $eq for single object fetches (this is for public app compatibility)
+    // Use $in for batch fetches
+    const whereClause = pks.length === 1
+      ? { [objMetadata.primaryKeyApiName]: { $eq: pks[0] } }
+      : { [objMetadata.primaryKeyApiName]: { $in: pks } };
+
     const { data } = await this.#client(miniDef)
-      .where({
-        [objMetadata.primaryKeyApiName]: { $in: pks },
-      }).fetchPage({
+      .where(whereClause).fetchPage({
         $pageSize: pks.length,
       });
 


### PR DESCRIPTION
Fixes https://github.com/palantir/osdk-ts/issues/2107

`useOsdkObject` currently does not fetch by id it uses `in` instead of `eq`. This proves to be an issue when building a public app via [#ws-public-apps](https://palantir.enterprise.slack.com/archives/C08H1B98NFK) as filtering via `in` is explicitly disallowed. To fix this we use `eq`. 

This may apply to `useOsdkObjects` but for now fixing this is fine until I confirm this is a blocker for `useOsdkObjects` or other hooks.