### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -156,6 +156,7 @@
     "@osdk-widget.client-react-simulatedRelease",
     "@osdk-widget.client-simulatedRelease",
     "@osdk-widget.vite-plugin-simulatedRelease",
+    "all-dragons-give",
     "dull-flies-call",
     "flat-dolls-drive",
     "fluffy-webs-return",
@@ -167,9 +168,11 @@
     "rare-wings-jog",
     "short-chefs-pull",
     "shy-lizards-smash",
+    "sour-buckets-happen",
     "stale-pigs-bake",
     "tasty-cases-double",
     "ten-dryers-dress",
+    "tired-peaches-arrive",
     "weak-crabs-hammer"
   ]
 }

--- a/packages/maker/CHANGELOG.md
+++ b/packages/maker/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/maker
 
+## 0.14.0-beta.6
+
+### Minor Changes
+
+- 04bfbfc: Add default format and table config options to OAC interface actions
+- 6ddabf4: Fix bug with action level validation on interface actions
+
 ## 0.14.0-beta.5
 
 ### Minor Changes

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker",
-  "version": "0.14.0-beta.5",
+  "version": "0.14.0-beta.6",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/osdk-docs-context/CHANGELOG.md
+++ b/packages/osdk-docs-context/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/osdk-docs-context
 
+## 0.3.0-beta.3
+
+### Minor Changes
+
+- 8fe0df0: Add generated context to git
+
 ## 0.3.0-beta.2
 
 ### Minor Changes

--- a/packages/osdk-docs-context/package.json
+++ b/packages/osdk-docs-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/osdk-docs-context",
-  "version": "0.3.0-beta.2",
+  "version": "0.3.0-beta.3",
   "description": "OSDK Documentation Context utilities and examples registry",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/maker@0.14.0-beta.6

### Minor Changes

-   04bfbfc: Add default format and table config options to OAC interface actions
-   6ddabf4: Fix bug with action level validation on interface actions

## @osdk/osdk-docs-context@0.3.0-beta.3

### Minor Changes

-   8fe0df0: Add generated context to git
