### PR TITLE
Fix As Type Object Set Type

### DIFF
--- a/.changeset/rotten-bobcats-call.md
+++ b/.changeset/rotten-bobcats-call.md
@@ -1,0 +1,5 @@
+---
+"@osdk/api": patch
+---
+
+Fix asType types to accept any interface when casting from an interface with no implementing object types

--- a/packages/api/src/objectSet/ObjectSet.test.ts
+++ b/packages/api/src/objectSet/ObjectSet.test.ts
@@ -1467,6 +1467,13 @@ describe("ObjectSet", () => {
 
       // @ts-expect-error
       objectSet.asType({ type: "object", apiName: "NotImplemented" });
+
+      // Interfaces that don't have any implementedBy fields should still accept any interface
+      const objectSet2 = { asType: () => {} } as unknown as $ObjectSet<
+        FooInterfaceApiTest & { __DefinitionMetadata: { implementedBy: [] } }
+      >;
+
+      objectSet2.asType({ type: "interface", apiName: "NotImplemented" });
     });
     it("restricts casting from object type to interface", () => {
       const objectSet = {} as $ObjectSet<EmployeeApiTest>;

--- a/packages/api/src/objectSet/ObjectSet.ts
+++ b/packages/api/src/objectSet/ObjectSet.ts
@@ -580,11 +580,9 @@ type ExtractImplementedInterfaces<T extends ObjectTypeDefinition> =
 
 type ExtractImplementingTypes<T extends InterfaceDefinition> =
   CompileTimeMetadata<T> extends
-    { implementedBy: ReadonlyArray<infer API_NAME> }
-    ? API_NAME extends string
-      ? (ObjectTypeDefinition & { apiName: API_NAME }) | InterfaceDefinition
-    : never
-    : never;
+    { implementedBy: ReadonlyArray<infer API_NAME extends string> }
+    ? (ObjectTypeDefinition & { apiName: API_NAME }) | InterfaceDefinition
+    : InterfaceDefinition;
 
 interface ObjectSetCleanedTypes<
   Q extends ObjectOrInterfaceDefinition,


### PR DESCRIPTION
The previous type didn't accept any interfaces if there were no implementing object types. This PR adds a non-breaking type change to fix that and a test