### PR TITLE
add enabled field for lazy queries

### DIFF
--- a/packages/react/src/new/useObjectSet.tsx
+++ b/packages/react/src/new/useObjectSet.tsx
@@ -83,6 +83,27 @@ export interface UseObjectSetOptions<
    * Minimum time between fetch requests in milliseconds (defaults to 2000ms)
    */
   dedupeIntervalMs?: number;
+
+  /**
+   * Enable or disable the query.
+   *
+   * When `false`, the query will not automatically execute. It will still
+   * return any cached data, but will not fetch from the server.
+   *
+   * This is useful for:
+   * - Lazy/on-demand queries that should wait for user interaction
+   * - Dependent queries that need data from another query first
+   * - Conditional queries based on component state
+   *
+   * @default true
+   * @example
+   * // Dependent query - wait for filter selection
+   * const { data: filteredObjects } = useObjectSet(MyObject.all(), {
+   *   where: { status: selectedStatus },
+   *   enabled: !!selectedStatus
+   * });
+   */
+  enabled?: boolean;
 }
 
 export interface UseObjectSetResult<
@@ -144,35 +165,45 @@ export function useObjectSet<
 ): UseObjectSetResult<Q, RDPs> {
   const { observableClient } = React.useContext(OsdkContext2);
 
+  const { enabled = true, ...otherOptions } = options;
+
   // Compute a stable cache key for the ObjectSet and options
-  // dedupeIntervalMs is excluded as it doesn't affect the data, only the refresh rate
+  // dedupeIntervalMs and enabled are excluded as they don't affect the data
   const stableKey = computeObjectSetCacheKey(baseObjectSet, {
-    where: options.where,
-    withProperties: options.withProperties,
-    union: options.union,
-    intersect: options.intersect,
-    subtract: options.subtract,
-    pivotTo: options.pivotTo,
-    pageSize: options.pageSize,
-    orderBy: options.orderBy,
+    where: otherOptions.where,
+    withProperties: otherOptions.withProperties,
+    union: otherOptions.union,
+    intersect: otherOptions.intersect,
+    subtract: otherOptions.subtract,
+    pivotTo: otherOptions.pivotTo,
+    pageSize: otherOptions.pageSize,
+    orderBy: otherOptions.orderBy,
   });
 
   const { subscribe, getSnapShot } = React.useMemo(
     () => {
+      if (!enabled) {
+        return makeExternalStore<ObserveObjectSetArgs<Q, RDPs>>(
+          () => ({ unsubscribe: () => {} }),
+          process.env.NODE_ENV !== "production"
+            ? `objectSet ${stableKey} [DISABLED]`
+            : void 0,
+        );
+      }
       return makeExternalStore<ObserveObjectSetArgs<Q, RDPs>>(
         (observer) => {
           const subscription = observableClient.observeObjectSet(
             baseObjectSet as ObjectSet<Q>,
             {
-              where: options.where,
-              withProperties: options.withProperties,
-              union: options.union,
-              intersect: options.intersect,
-              subtract: options.subtract,
-              pivotTo: options.pivotTo,
-              pageSize: options.pageSize,
-              orderBy: options.orderBy,
-              dedupeInterval: options.dedupeIntervalMs ?? 2_000,
+              where: otherOptions.where,
+              withProperties: otherOptions.withProperties,
+              union: otherOptions.union,
+              intersect: otherOptions.intersect,
+              subtract: otherOptions.subtract,
+              pivotTo: otherOptions.pivotTo,
+              pageSize: otherOptions.pageSize,
+              orderBy: otherOptions.orderBy,
+              dedupeInterval: otherOptions.dedupeIntervalMs ?? 2_000,
             },
             observer,
           );
@@ -183,7 +214,7 @@ export function useObjectSet<
           : void 0,
       );
     },
-    [observableClient, stableKey],
+    [enabled, observableClient, stableKey],
   );
 
   const payload = React.useSyncExternalStore(subscribe, getSnapShot);

--- a/packages/react/test/useLinks.enabled.test.tsx
+++ b/packages/react/test/useLinks.enabled.test.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectTypeDefinition, Osdk } from "@osdk/api";
+import { renderHook } from "@testing-library/react";
+import * as React from "react";
+import { beforeEach, describe, expect, it, vitest } from "vitest";
+import { OsdkContext2 } from "../src/new/OsdkContext2.js";
+import { useLinks } from "../src/new/useLinks.js";
+
+const MockObjectType = {
+  apiName: "MockObject",
+  primaryKeyType: "string",
+} as unknown as ObjectTypeDefinition;
+
+const mockObject: Osdk.Instance<typeof MockObjectType> = {
+  $objectType: "MockObject",
+  $primaryKey: "obj-123",
+  $apiName: "MockObject",
+} as any;
+
+describe("useLinks enabled option", () => {
+  const mockObserveLinks = vitest.fn();
+
+  const createWrapper = () => {
+    const observableClient = {
+      observeLinks: mockObserveLinks,
+      canonicalizeWhereClause: vitest.fn((w) => w),
+    } as any;
+
+    return ({ children }: React.PropsWithChildren) => (
+      <OsdkContext2.Provider value={{ observableClient }}>
+        {children}
+      </OsdkContext2.Provider>
+    );
+  };
+
+  beforeEach(() => {
+    mockObserveLinks.mockClear();
+    mockObserveLinks.mockReturnValue({ unsubscribe: vitest.fn() });
+  });
+
+  it("should NOT call observeLinks when enabled is false", () => {
+    const wrapper = createWrapper();
+
+    renderHook(
+      () => useLinks(mockObject, "relatedObjects", { enabled: false }),
+      { wrapper },
+    );
+
+    expect(mockObserveLinks).not.toHaveBeenCalled();
+  });
+
+  it("should start observing when enabled changes from false to true", () => {
+    const wrapper = createWrapper();
+
+    const { rerender } = renderHook(
+      ({ enabled }) => useLinks(mockObject, "relatedObjects", { enabled }),
+      {
+        wrapper,
+        initialProps: { enabled: false },
+      },
+    );
+
+    expect(mockObserveLinks).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+
+    expect(mockObserveLinks).toHaveBeenCalledTimes(1);
+  });
+
+  it("should enable links query when parent object becomes available", () => {
+    const wrapper = createWrapper();
+
+    const { rerender } = renderHook(
+      ({ obj }) => useLinks(obj, "relatedObjects", { enabled: !!obj }),
+      {
+        wrapper,
+        initialProps: { obj: undefined as typeof mockObject | undefined },
+      },
+    );
+
+    expect(mockObserveLinks).not.toHaveBeenCalled();
+
+    rerender({ obj: mockObject });
+
+    expect(mockObserveLinks).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/test/useObjectSet.enabled.test.tsx
+++ b/packages/react/test/useObjectSet.enabled.test.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectSet, ObjectTypeDefinition } from "@osdk/api";
+import { renderHook } from "@testing-library/react";
+import * as React from "react";
+import { beforeEach, describe, expect, it, vitest } from "vitest";
+import { OsdkContext2 } from "../src/new/OsdkContext2.js";
+import { useObjectSet } from "../src/new/useObjectSet.js";
+
+const MockObjectType = {
+  apiName: "MockObject",
+  primaryKeyType: "string",
+} as unknown as ObjectTypeDefinition;
+
+const mockObjectSet = {
+  $__EXPERIMENTAL_objectSet: true,
+  type: MockObjectType,
+} as unknown as ObjectSet<typeof MockObjectType>;
+
+describe("useObjectSet enabled option", () => {
+  const mockObserveObjectSet = vitest.fn();
+
+  const createWrapper = () => {
+    const observableClient = {
+      observeObjectSet: mockObserveObjectSet,
+      canonicalizeWhereClause: vitest.fn((w) => w),
+    } as any;
+
+    return ({ children }: React.PropsWithChildren) => (
+      <OsdkContext2.Provider value={{ observableClient }}>
+        {children}
+      </OsdkContext2.Provider>
+    );
+  };
+
+  beforeEach(() => {
+    mockObserveObjectSet.mockClear();
+    mockObserveObjectSet.mockReturnValue({ unsubscribe: vitest.fn() });
+  });
+
+  it("should NOT call observeObjectSet when enabled is false", () => {
+    const wrapper = createWrapper();
+
+    renderHook(
+      () => useObjectSet(mockObjectSet, { enabled: false }),
+      { wrapper },
+    );
+
+    expect(mockObserveObjectSet).not.toHaveBeenCalled();
+  });
+
+  it("should start observing when enabled changes from false to true", () => {
+    const wrapper = createWrapper();
+
+    const { rerender } = renderHook(
+      ({ enabled }) => useObjectSet(mockObjectSet, { enabled }),
+      {
+        wrapper,
+        initialProps: { enabled: false },
+      },
+    );
+
+    expect(mockObserveObjectSet).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+
+    expect(mockObserveObjectSet).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/test/useOsdkObject.enabled.test.tsx
+++ b/packages/react/test/useOsdkObject.enabled.test.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectTypeDefinition, Osdk } from "@osdk/api";
+import { renderHook } from "@testing-library/react";
+import * as React from "react";
+import { beforeEach, describe, expect, it, vitest } from "vitest";
+import { OsdkContext2 } from "../src/new/OsdkContext2.js";
+import { useOsdkObject } from "../src/new/useOsdkObject.js";
+
+// Mock object type definition
+const MockObjectType = {
+  apiName: "MockObject",
+  primaryKeyType: "string",
+} as unknown as ObjectTypeDefinition;
+
+// Mock OSDK instance
+const mockInstance: Osdk.Instance<typeof MockObjectType> = {
+  $objectType: "MockObject",
+  $primaryKey: "instance-123",
+  $apiName: "MockObject",
+} as any;
+
+describe("useOsdkObject enabled option", () => {
+  const mockObserveObject = vitest.fn();
+
+  const createWrapper = () => {
+    const observableClient = {
+      observeObject: mockObserveObject,
+      canonicalizeWhereClause: vitest.fn((w) => w),
+    } as any;
+
+    return ({ children }: React.PropsWithChildren) => (
+      <OsdkContext2.Provider value={{ observableClient }}>
+        {children}
+      </OsdkContext2.Provider>
+    );
+  };
+
+  beforeEach(() => {
+    mockObserveObject.mockClear();
+    mockObserveObject.mockReturnValue({ unsubscribe: vitest.fn() });
+  });
+
+  it("should NOT call observeObject when enabled is false (instance signature)", () => {
+    const wrapper = createWrapper();
+
+    renderHook(
+      () => useOsdkObject(mockInstance, false),
+      { wrapper },
+    );
+
+    expect(mockObserveObject).not.toHaveBeenCalled();
+  });
+
+  it("should NOT call observeObject when enabled is false (type signature)", () => {
+    const wrapper = createWrapper();
+
+    renderHook(
+      () => useOsdkObject(MockObjectType, "pk-000", false),
+      { wrapper },
+    );
+
+    expect(mockObserveObject).not.toHaveBeenCalled();
+  });
+
+  it("should use offline mode for instance signature", () => {
+    const wrapper = createWrapper();
+
+    renderHook(
+      () => useOsdkObject(mockInstance),
+      { wrapper },
+    );
+
+    expect(mockObserveObject).toHaveBeenCalledWith(
+      "MockObject",
+      "instance-123",
+      { mode: "offline" },
+      expect.any(Object),
+    );
+  });
+
+  it("should NOT use offline mode for type signature", () => {
+    const wrapper = createWrapper();
+
+    renderHook(
+      () => useOsdkObject(MockObjectType, "pk-222"),
+      { wrapper },
+    );
+
+    expect(mockObserveObject).toHaveBeenCalledWith(
+      "MockObject",
+      "pk-222",
+      { mode: undefined },
+      expect.any(Object),
+    );
+  });
+
+  it("should start observing when enabled changes from false to true", () => {
+    const wrapper = createWrapper();
+
+    const { rerender } = renderHook(
+      ({ enabled }) => useOsdkObject(mockInstance, enabled),
+      {
+        wrapper,
+        initialProps: { enabled: false },
+      },
+    );
+
+    expect(mockObserveObject).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+
+    expect(mockObserveObject).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/test/useOsdkObjects.enabled.test.tsx
+++ b/packages/react/test/useOsdkObjects.enabled.test.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectTypeDefinition } from "@osdk/api";
+import { renderHook } from "@testing-library/react";
+import * as React from "react";
+import { beforeEach, describe, expect, it, vitest } from "vitest";
+import { OsdkContext2 } from "../src/new/OsdkContext2.js";
+import { useOsdkObjects } from "../src/new/useOsdkObjects.js";
+
+const MockObjectType = {
+  apiName: "MockObject",
+  primaryKeyType: "string",
+} as unknown as ObjectTypeDefinition;
+
+describe("useOsdkObjects enabled option", () => {
+  const mockObserveList = vitest.fn();
+
+  const createWrapper = () => {
+    const observableClient = {
+      observeList: mockObserveList,
+      canonicalizeWhereClause: vitest.fn((w) => w),
+    } as any;
+
+    return ({ children }: React.PropsWithChildren) => (
+      <OsdkContext2.Provider value={{ observableClient }}>
+        {children}
+      </OsdkContext2.Provider>
+    );
+  };
+
+  beforeEach(() => {
+    mockObserveList.mockClear();
+    mockObserveList.mockReturnValue({ unsubscribe: vitest.fn() });
+  });
+
+  it("should NOT call observeList when enabled is false", () => {
+    const wrapper = createWrapper();
+
+    renderHook(
+      () => useOsdkObjects(MockObjectType, { enabled: false }),
+      { wrapper },
+    );
+
+    expect(mockObserveList).not.toHaveBeenCalled();
+  });
+
+  it("should start observing when enabled changes from false to true", () => {
+    const wrapper = createWrapper();
+
+    const { rerender } = renderHook(
+      ({ enabled }) => useOsdkObjects(MockObjectType, { enabled }),
+      {
+        wrapper,
+        initialProps: { enabled: false },
+      },
+    );
+
+    expect(mockObserveList).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+
+    expect(mockObserveList).toHaveBeenCalledTimes(1);
+  });
+
+  it("should work with where clause when enabled is true", () => {
+    const wrapper = createWrapper();
+
+    renderHook(
+      () =>
+        useOsdkObjects(MockObjectType, {
+          where: { id: "123" },
+          pageSize: 50,
+          enabled: true,
+        }),
+      { wrapper },
+    );
+
+    expect(mockObserveList).toHaveBeenCalledTimes(1);
+    expect(mockObserveList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MockObjectType,
+        where: { id: "123" },
+        pageSize: 50,
+      }),
+      expect.any(Object),
+    );
+  });
+});


### PR DESCRIPTION
Adds a new `enabled` field to support lazy / dependent queries. This comes from trying to migrate a users app to use the React Toolkit and discovering they make heavy use of dependent queries for their FE.