### PR TITLE
[Backport] Improved support for object set parameters in widget.client-react (#2104)

### DIFF
--- a/.changeset/silly-moons-march.md
+++ b/.changeset/silly-moons-march.md
@@ -1,0 +1,6 @@
+---
+"@osdk/widget.client-react": minor
+"@osdk/widget.api": minor
+---
+
+Improved support for object set parameters in widget.client-react

--- a/packages/widget.api/package.json
+++ b/packages/widget.api/package.json
@@ -41,8 +41,10 @@
     "transpileTypes": "monorepo.tool.transpile -f esm -m types -t node",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
+  "dependencies": {
+    "@osdk/api": "workspace:*"
+  },
   "devDependencies": {
-    "@osdk/api": "workspace:~",
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
     "ts-expect": "^1.3.0",

--- a/packages/widget.api/src/index.ts
+++ b/packages/widget.api/src/index.ts
@@ -44,7 +44,7 @@ export {
   visitWidgetMessage,
 } from "./messages/widgetMessages.js";
 export type { WidgetMessage } from "./messages/widgetMessages.js";
-export type { ParameterValue } from "./parameters.js";
+export type { ObjectType, ParameterValue } from "./parameters.js";
 export type {
   AsyncFailedValue,
   AsyncLoadedValue,

--- a/packages/widget.api/src/parameters.ts
+++ b/packages/widget.api/src/parameters.ts
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
+import type { ObjectTypeDefinition } from "@osdk/api";
 import type { AsyncValue } from "./utils/asyncValue.js";
 
-export type ObjectType = {
-  type: "object";
-  apiName: string;
+export interface ObjectType extends ObjectTypeDefinition {
   internalDoNotUseMetadata?: {
     rid: string;
   };
-};
+}
 
 /**
  * Map of the name of the type to the corresponding JavaScript type.

--- a/packages/widget.client-react/package.json
+++ b/packages/widget.client-react/package.json
@@ -52,6 +52,7 @@
     "@osdk/client": "workspace:~",
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
+    "@osdk/widget.api": "workspace:~",
     "@osdk/widget.client": "workspace:~",
     "@types/react": "^18.3.24",
     "@types/react-dom": "^18.3.7",

--- a/packages/widget.client-react/src/utils/extendParametersWithObjectSets.test.ts
+++ b/packages/widget.client-react/src/utils/extendParametersWithObjectSets.test.ts
@@ -1,0 +1,483 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Client, ObjectSet } from "@osdk/client";
+import { hydrateObjectSetFromRid } from "@osdk/client/internal";
+import type { AsyncParameterValueMap, ObjectType } from "@osdk/widget.api";
+import { defineConfig } from "@osdk/widget.client";
+import type { Mock } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { extendParametersWithObjectSets } from "./extendParametersWithObjectSets.js";
+
+vi.mock("@osdk/client/internal", () => ({
+  hydrateObjectSetFromRid: vi.fn(),
+}));
+
+describe("extendParametersWithObjectSets", () => {
+  const client = vi.fn() as Mock<Client> & Client;
+  const cache = new Map<
+    string,
+    { objectSetRid: string; objectSet: ObjectSet }
+  >();
+
+  // Test helpers
+  const createMockObjectType = (rid = "ri.object-type.123"): ObjectType => ({
+    apiName: "MyObjectType",
+    type: "object",
+    internalDoNotUseMetadata: { rid },
+  });
+
+  const createLoadedValue = <T>(value: T) => ({
+    type: "loaded" as const,
+    value,
+  });
+
+  const createObjectSetParam = (rid: string) => ({
+    type: "objectSet" as const,
+    value: createLoadedValue({ objectSetRid: rid }),
+  });
+
+  const createStringParam = (value: string) => ({
+    type: "string" as const,
+    value: createLoadedValue(value),
+  });
+
+  const createNumberParam = (value: number) => ({
+    type: "number" as const,
+    value: createLoadedValue(value),
+  });
+
+  const createMockObjectSet = (name = "MockObjectSet") =>
+    Symbol(name) as unknown as ObjectSet;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cache.clear();
+  });
+
+  it("should hydrate an object set for a valid objectSetRid", () => {
+    const config = defineConfig({
+      id: "testWidget",
+      name: "Test Widget",
+      type: "workshop",
+      parameters: {
+        myObjectSet: {
+          displayName: "My Object Set",
+          type: "objectSet",
+          objectType: createMockObjectType(),
+        },
+        myString: {
+          displayName: "My String",
+          type: "string",
+        },
+      },
+      events: {},
+    });
+
+    const parameters: AsyncParameterValueMap<typeof config> = {
+      myString: createStringParam("test string"),
+      myObjectSet: createObjectSetParam("ri.object-set.123"),
+    };
+
+    const mockObjectSet = createMockObjectSet();
+    vi.mocked(hydrateObjectSetFromRid).mockReturnValue(mockObjectSet);
+
+    const result = extendParametersWithObjectSets(
+      client,
+      config,
+      parameters,
+      cache,
+    );
+
+    expect(result).toEqual({
+      myString: parameters.myString,
+      myObjectSet: {
+        ...parameters.myObjectSet,
+        value: {
+          ...parameters.myObjectSet.value,
+          value: {
+            objectSetRid: "ri.object-set.123",
+            objectSet: mockObjectSet,
+          },
+        },
+      },
+    });
+  });
+
+  it("should pass-through a config with no object set parameters", () => {
+    const config = defineConfig({
+      id: "testWidget",
+      name: "Test Widget",
+      type: "workshop",
+      parameters: {
+        myNumber: {
+          displayName: "My Number",
+          type: "number",
+        },
+        myString: {
+          displayName: "My String",
+          type: "string",
+        },
+      },
+      events: {},
+    });
+
+    const parameters: AsyncParameterValueMap<typeof config> = {
+      myString: createStringParam("test string"),
+      myNumber: createNumberParam(123),
+    };
+
+    const result = extendParametersWithObjectSets(
+      undefined,
+      config,
+      parameters,
+      cache,
+    );
+
+    expect(result).toEqual(parameters);
+    expect(hydrateObjectSetFromRid).not.toHaveBeenCalled();
+  });
+
+  it("should handle multiple object set parameters independently", () => {
+    const mockObjectType = createMockObjectType();
+    const config = defineConfig({
+      id: "testWidget",
+      name: "Test Widget",
+      type: "workshop",
+      parameters: {
+        objectsA: {
+          displayName: "Object Set A",
+          type: "objectSet",
+          objectType: mockObjectType,
+        },
+        objectsB: {
+          displayName: "Object Set B",
+          type: "objectSet",
+          objectType: mockObjectType,
+        },
+      },
+      events: {},
+    });
+
+    // Setup initial parameters
+    const mockObjectSetA = createMockObjectSet("MockObjectSetA");
+    const mockObjectSetB = createMockObjectSet("MockObjectSetB");
+
+    vi.mocked(hydrateObjectSetFromRid)
+      .mockReturnValueOnce(mockObjectSetA)
+      .mockReturnValueOnce(mockObjectSetB);
+
+    let parameters: AsyncParameterValueMap<typeof config> = {
+      objectsA: createObjectSetParam("ri.object-set.123"),
+      objectsB: createObjectSetParam("ri.object-set.456"),
+    };
+
+    const result = extendParametersWithObjectSets(
+      client,
+      config,
+      parameters,
+      cache,
+    );
+
+    // Helper to create expected result with hydrated object set
+    const expectHydratedParam = (rid: string, objectSet: ObjectSet) => ({
+      type: "objectSet",
+      value: createLoadedValue({
+        objectSetRid: rid,
+        objectSet,
+      }),
+    });
+
+    expect(result).toEqual({
+      objectsA: expectHydratedParam("ri.object-set.123", mockObjectSetA),
+      objectsB: expectHydratedParam("ri.object-set.456", mockObjectSetB),
+    });
+
+    // Test parameter update
+    const mockObjectSetB2 = createMockObjectSet("MockObjectSetB2");
+    vi.mocked(hydrateObjectSetFromRid).mockReturnValueOnce(mockObjectSetB2);
+
+    parameters = {
+      ...parameters,
+      objectsB: createObjectSetParam("ri.object-set.789"),
+    };
+
+    const result2 = extendParametersWithObjectSets(
+      client,
+      config,
+      parameters,
+      cache,
+    );
+
+    expect(result2).toEqual({
+      objectsA: expectHydratedParam("ri.object-set.123", mockObjectSetA),
+      objectsB: expectHydratedParam("ri.object-set.789", mockObjectSetB2),
+    });
+
+    // Verify cache updated correctly
+    expect(cache.get("objectsB")).toMatchObject({
+      objectSetRid: "ri.object-set.789",
+      objectSet: mockObjectSetB2,
+    });
+  });
+
+  it("should clear cache and provide no object set when parameter transitions to failed state", () => {
+    const config = defineConfig({
+      id: "testWidget",
+      name: "Test Widget",
+      type: "workshop",
+      parameters: {
+        myObjectSet: {
+          displayName: "My Object Set",
+          type: "objectSet",
+          objectType: createMockObjectType(),
+        },
+        myString: {
+          displayName: "My String",
+          type: "string",
+        },
+      },
+      events: {},
+    });
+
+    // Initially load an object set successfully
+    const mockObjectSet = createMockObjectSet();
+    vi.mocked(hydrateObjectSetFromRid).mockReturnValue(mockObjectSet);
+
+    const initialParameters: AsyncParameterValueMap<typeof config> = {
+      myString: createStringParam("test string"),
+      myObjectSet: createObjectSetParam("ri.object-set.123"),
+    };
+
+    const initialResult = extendParametersWithObjectSets(
+      client,
+      config,
+      initialParameters,
+      cache,
+    );
+
+    // Verify initial state - object set is loaded and cached
+    expect(initialResult.myObjectSet.value.value).toMatchObject({
+      objectSetRid: "ri.object-set.123",
+      objectSet: mockObjectSet,
+    });
+    expect(cache.get("myObjectSet")).toMatchObject({
+      objectSetRid: "ri.object-set.123",
+      objectSet: mockObjectSet,
+    });
+
+    // Transition to failed state and omit value
+    const failedParameters: AsyncParameterValueMap<typeof config> = {
+      myString: createStringParam("test string"),
+      myObjectSet: {
+        type: "objectSet",
+        value: {
+          type: "failed",
+          error: new Error("Failed to load object set"),
+          value: undefined,
+        },
+      },
+    };
+
+    const failedResult = extendParametersWithObjectSets(
+      client,
+      config,
+      failedParameters,
+      cache,
+    );
+
+    // Verify failed state - no object set in result and cache is cleared
+    expect(failedResult).toEqual(failedParameters);
+    expect(cache.has("myObjectSet")).toBe(false);
+
+    // Verify hydrateObjectSetFromRid was not called again for the failed state
+    expect(hydrateObjectSetFromRid).toHaveBeenCalledTimes(1);
+  });
+
+  it("should throw an error when osdkClient is undefined but object set parameters used", () => {
+    const config = defineConfig({
+      id: "testWidget",
+      name: "Test Widget",
+      type: "workshop",
+      parameters: {
+        myObjectSet: {
+          displayName: "My Object Set",
+          type: "objectSet",
+          objectType: createMockObjectType(),
+        },
+      },
+      events: {},
+    });
+
+    const parameters: AsyncParameterValueMap<typeof config> = {
+      myObjectSet: createObjectSetParam("ri.object-set.123"),
+    };
+
+    expect(() =>
+      extendParametersWithObjectSets(
+        undefined,
+        config,
+        parameters,
+        cache,
+      )
+    ).toThrow("Not provided an OSDK client");
+  });
+
+  it("should pass through loading state without hydration", () => {
+    const config = defineConfig({
+      id: "testWidget",
+      name: "Test Widget",
+      type: "workshop",
+      parameters: {
+        myObjectSet: {
+          displayName: "My Object Set",
+          type: "objectSet",
+          objectType: createMockObjectType(),
+        },
+      },
+      events: {},
+    });
+
+    const parameters: AsyncParameterValueMap<typeof config> = {
+      myObjectSet: {
+        type: "objectSet",
+        value: {
+          type: "loading",
+          value: undefined,
+        },
+      },
+    };
+
+    const result = extendParametersWithObjectSets(
+      client,
+      config,
+      parameters,
+      cache,
+    );
+
+    expect(result).toEqual(parameters);
+    expect(hydrateObjectSetFromRid).not.toHaveBeenCalled();
+  });
+
+  it("should handle transition from loaded to reloading to loaded with new rid", () => {
+    const config = defineConfig({
+      id: "testWidget",
+      name: "Test Widget",
+      type: "workshop",
+      parameters: {
+        myObjectSet: {
+          displayName: "My Object Set",
+          type: "objectSet",
+          objectType: createMockObjectType(),
+        },
+      },
+      events: {},
+    });
+
+    // Step 1: Initial loaded state
+    const mockObjectSet1 = createMockObjectSet("InitialObjectSet");
+    vi.mocked(hydrateObjectSetFromRid).mockReturnValue(mockObjectSet1);
+
+    const initialParameters: AsyncParameterValueMap<typeof config> = {
+      myObjectSet: createObjectSetParam("ri.object-set.123"),
+    };
+
+    const initialResult = extendParametersWithObjectSets(
+      client,
+      config,
+      initialParameters,
+      cache,
+    );
+
+    // Verify initial state
+    expect(initialResult.myObjectSet.value.value).toMatchObject({
+      objectSetRid: "ri.object-set.123",
+      objectSet: mockObjectSet1,
+    });
+    expect(cache.get("myObjectSet")).toMatchObject({
+      objectSetRid: "ri.object-set.123",
+      objectSet: mockObjectSet1,
+    });
+    expect(hydrateObjectSetFromRid).toHaveBeenCalledTimes(1);
+    expect(hydrateObjectSetFromRid).toHaveBeenCalledWith(
+      client,
+      expect.anything(),
+      "ri.object-set.123",
+    );
+
+    // Step 2: Transition to reloading state (value persists during reload)
+    const reloadingParameters: AsyncParameterValueMap<typeof config> = {
+      myObjectSet: {
+        type: "objectSet",
+        value: {
+          type: "reloading",
+          value: {
+            objectSetRid: "ri.object-set.123",
+          },
+        },
+      },
+    };
+
+    const reloadingResult = extendParametersWithObjectSets(
+      client,
+      config,
+      reloadingParameters,
+      cache,
+    );
+
+    // During reloading, the cached objectSet should be reused (no new hydration)
+    expect(reloadingResult.myObjectSet.value.value).toMatchObject({
+      objectSetRid: "ri.object-set.123",
+      objectSet: mockObjectSet1, // Same object set from cache
+    });
+    expect(cache.get("myObjectSet")).toMatchObject({
+      objectSetRid: "ri.object-set.123",
+      objectSet: mockObjectSet1,
+    });
+    expect(hydrateObjectSetFromRid).toHaveBeenCalledTimes(1); // Still only 1 call
+
+    // Step 3: Transition back to loaded with new rid
+    const mockObjectSet2 = createMockObjectSet("UpdatedObjectSet");
+    vi.mocked(hydrateObjectSetFromRid).mockReturnValue(mockObjectSet2);
+
+    const newLoadedParameters: AsyncParameterValueMap<typeof config> = {
+      myObjectSet: createObjectSetParam("ri.object-set.456"),
+    };
+
+    const newLoadedResult = extendParametersWithObjectSets(
+      client,
+      config,
+      newLoadedParameters,
+      cache,
+    );
+
+    // Verify new state - new object set hydrated and cache updated
+    expect(newLoadedResult.myObjectSet.value.value).toMatchObject({
+      objectSetRid: "ri.object-set.456",
+      objectSet: mockObjectSet2,
+    });
+    expect(cache.get("myObjectSet")).toMatchObject({
+      objectSetRid: "ri.object-set.456",
+      objectSet: mockObjectSet2,
+    });
+    expect(hydrateObjectSetFromRid).toHaveBeenCalledTimes(2);
+    expect(hydrateObjectSetFromRid).toHaveBeenLastCalledWith(
+      client,
+      expect.anything(),
+      "ri.object-set.456",
+    );
+  });
+});

--- a/packages/widget.client-react/src/utils/extendParametersWithObjectSets.ts
+++ b/packages/widget.client-react/src/utils/extendParametersWithObjectSets.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Client, ObjectSet, ObjectTypeDefinition } from "@osdk/client";
+import { hydrateObjectSetFromRid } from "@osdk/client/internal";
+import type { AsyncParameterValueMap, WidgetConfig } from "@osdk/widget.api";
+import type { ExtendedAsyncParameterValueMap } from "../context.js";
+
+/**
+ * Patches parameter values with hydrated object sets for object set parameters.
+ *
+ * The cache is used to avoid redundant hydration of the same object set RID, which
+ * can cause unnecessary re-renders in React components consuming the parameters.
+ */
+export function extendParametersWithObjectSets<
+  C extends WidgetConfig<C["parameters"]>,
+>(
+  osdkClient: Client | undefined,
+  config: C,
+  parameters: AsyncParameterValueMap<C>,
+  cache: Map<string, { objectSetRid: string; objectSet: ObjectSet }>,
+): ExtendedAsyncParameterValueMap<C> {
+  const extendedParameters = {
+    ...parameters,
+  } as ExtendedAsyncParameterValueMap<C>;
+
+  for (const parameterId of Object.keys(extendedParameters)) {
+    const param = config.parameters[parameterId];
+    if (
+      param.type === "objectSet"
+      && extendedParameters[parameterId].type === "objectSet"
+    ) {
+      const parameterValue = extendedParameters[parameterId].value.value;
+      if (parameterValue != null) {
+        if (
+          typeof parameterValue === "object"
+          && "objectSetRid" in parameterValue
+          && typeof parameterValue.objectSetRid === "string"
+        ) {
+          const objectSetRid = parameterValue.objectSetRid;
+          const objectSet = getOrHydrateObjectSet(
+            osdkClient,
+            cache,
+            parameterId,
+            objectSetRid,
+            param.objectType as ObjectTypeDefinition,
+          );
+          (parameterValue as any).objectSet = objectSet;
+        } else {
+          throw new Error(
+            `Invalid object set parameter value for parameter "${parameterId}"`,
+          );
+        }
+      } else {
+        cache.delete(parameterId);
+      }
+    }
+  }
+
+  return extendedParameters;
+}
+
+function getOrHydrateObjectSet<T extends ObjectTypeDefinition>(
+  osdkClient: Client | undefined,
+  cache: Map<string, { objectSetRid: string; objectSet: ObjectSet<T> }>,
+  paramKey: string,
+  objectSetRid: string,
+  definition: T,
+) {
+  if (osdkClient == null) {
+    throw new Error("Not provided an OSDK client");
+  }
+  const cached = cache.get(paramKey);
+  if (cached?.objectSetRid === objectSetRid) {
+    return cached.objectSet;
+  }
+  const objectSet = hydrateObjectSetFromRid(
+    osdkClient,
+    definition,
+    objectSetRid,
+  );
+  cache.set(paramKey, { objectSetRid, objectSet });
+  return objectSet;
+}

--- a/packages/widget.client-react/src/utils/initializeParameters.ts
+++ b/packages/widget.client-react/src/utils/initializeParameters.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import type { AsyncParameterValueMap, WidgetConfig } from "@osdk/widget.client";
+import type { WidgetConfig } from "@osdk/widget.client";
+import type { ExtendedAsyncParameterValueMap } from "../context.js";
 
 /**
  * Utility function to initialize a map of parameter values to either a loading or not-started loading state
@@ -22,11 +23,11 @@ import type { AsyncParameterValueMap, WidgetConfig } from "@osdk/widget.client";
 export function initializeParameters<C extends WidgetConfig<C["parameters"]>>(
   config: C,
   initialLoadingState: "loading" | "not-started",
-): AsyncParameterValueMap<C> {
+): ExtendedAsyncParameterValueMap<C> {
   return Object.fromEntries(
     Object.entries(config.parameters).map(([key, parameterConfig]) => [
       key,
       { type: parameterConfig.type, value: { type: initialLoadingState } },
     ]),
-  ) as AsyncParameterValueMap<C>;
+  ) as ExtendedAsyncParameterValueMap<C>;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4070,10 +4070,11 @@ importers:
         version: 5.5.4
 
   packages/widget.api:
-    devDependencies:
+    dependencies:
       '@osdk/api':
-        specifier: workspace:~
+        specifier: workspace:*
         version: link:../api
+    devDependencies:
       '@osdk/monorepo.api-extractor':
         specifier: workspace:~
         version: link:../monorepo.api-extractor
@@ -4123,6 +4124,9 @@ importers:
       '@osdk/monorepo.tsconfig':
         specifier: workspace:~
         version: link:../monorepo.tsconfig
+      '@osdk/widget.api':
+        specifier: workspace:~
+        version: link:../widget.api
       '@osdk/widget.client':
         specifier: workspace:~
         version: link:../widget.client


### PR DESCRIPTION
* Object set parameter usage

* Restructure

* Add docstring

* Changeset

* Take a real dep on @osdk/api