### PR TITLE
Fix changeset for 2.5.x release (minor -> patch)

### DIFF
--- a/.changeset/silly-moons-march.md
+++ b/.changeset/silly-moons-march.md
@@ -1,6 +1,6 @@
 ---
-"@osdk/widget.client-react": minor
-"@osdk/widget.api": minor
+"@osdk/widget.client-react": patch
+"@osdk/widget.api": patch
 ---
 
 Improved support for object set parameters in widget.client-react


### PR DESCRIPTION
Got this error when trying to release on 2.5.x

```
 ERROR  Unable to create a release for the stable branch.                                                                                        8:27:48 AM

Our branching model requires that we only release patch changes on a stable branch to avoid version number collisions with main and the other release branches. Problems:

.changeset/silly-moons-march.md:
  - @osdk/widget.client-react: minor
  - @osdk/widget.api: minor
```