### PR TITLE
fix promise chaining bug

### DIFF
--- a/packages/client/src/observable/internal/base-list/BaseListQuery.ts
+++ b/packages/client/src/observable/internal/base-list/BaseListQuery.ts
@@ -287,9 +287,11 @@ export abstract class BaseListQuery<
     }
 
     if (this.pendingFetch) {
-      this.pendingPageFetch = new Promise(async (res) => {
+      this.pendingPageFetch = (async () => {
         await this.pendingFetch;
-        res(this.fetchMore());
+        await this.fetchMore();
+      })().finally(() => {
+        this.pendingPageFetch = undefined;
       });
       return this.pendingPageFetch;
     }


### PR DESCRIPTION
Fixes a bug with `BaseListQuery`'s `fetchMore` where loading more data while a promise was already in flight results in an end user `TypeError: Chaining cycle detected for promise #<Promise>` 