### PR TITLE
Remove unnecessary observe override in LinksHelper

### DIFF
--- a/packages/client/src/observable/internal/links/LinksHelper.ts
+++ b/packages/client/src/observable/internal/links/LinksHelper.ts
@@ -63,16 +63,6 @@ export class LinksHelper extends AbstractHelper<
     this.orderByCanonicalizer = orderByCanonicalizer;
   }
 
-  observe<
-    T extends ObjectTypeDefinition,
-    L extends keyof CompileTimeMetadata<T>["links"] & string,
-  >(
-    options: ObserveLinks.Options<T, L>,
-    subFn: Observer<SpecificLinkPayload>,
-  ): QuerySubscription<SpecificLinkQuery> {
-    return super.observe(options, subFn);
-  }
-
   getQuery<
     T extends ObjectTypeDefinition,
     L extends keyof CompileTimeMetadata<T>["links"] & string,


### PR DESCRIPTION
Remove `LinksHelper.observe()` that only called `super.observe()` without actually doing anything.