### PR TITLE
Fix widget dev mode with tailwind causing project imports

### DIFF
--- a/.changeset/rare-glasses-dream.md
+++ b/.changeset/rare-glasses-dream.md
@@ -1,0 +1,5 @@
+---
+"@osdk/widget.vite-plugin": patch
+---
+
+Fix widget dev mode with tailwind causing project imports

--- a/packages/widget.vite-plugin/src/common/extractWidgetConfig.ts
+++ b/packages/widget.vite-plugin/src/common/extractWidgetConfig.ts
@@ -30,6 +30,17 @@ export async function extractWidgetConfig(
       throw new Error(`No default export found in ${moduleId}`);
     }
 
+    if (
+      typeof config !== "object"
+      || (config["id"] == null && config["name"] == null)
+    ) {
+      server.config.logger.warn(
+        `Config object does not look like a widget config: ${
+          JSON.stringify(config)
+        }`,
+      );
+    }
+
     validateWidgetConfig(config);
     return config as WidgetConfig<ParameterConfig>;
   } catch (error) {

--- a/packages/widget.vite-plugin/src/dev-plugin/FoundryWidgetDevPlugin.ts
+++ b/packages/widget.vite-plugin/src/dev-plugin/FoundryWidgetDevPlugin.ts
@@ -213,8 +213,11 @@ export function FoundryWidgetDevPlugin(): Plugin {
       }
 
       // Look for config files that are imported from an entrypoint file
+      // Also check the config file being imported is in src to avoid picking up imports for other
+      // project files like foundry.config.json / eslint.config.mjs when tailwind is used.
       if (
         standardizedSource.replace(/\.[^/.]+$/, "").endsWith(CONFIG_FILE_SUFFIX)
+        && standardizedSource.includes("/src/")
         && codeEntrypoints[standardizedImporter] != null
       ) {
         const fullSourcePath = standardizeFileExtension(


### PR DESCRIPTION
When adding tailwind to a project like this:

```
export default defineConfig({
  plugins: [react(), widgetManifestPlugin(), tailwindcss()],
  resolve: {
    alias: {
      "@": path.resolve(__dirname, "./src"),
    },
  },
```

This is for some reason causing project files to be imported in vite through the index.html:

```
(source, importer, standardizedSource, standardizedImporter)

/foundry.config.json /some/path/tailwind-repro/index.html /some/path/tailwind-repro/foundry.config.json /some/path/tailwind-repro/index.html

/eslint.config.mjs /some/path/tailwind-repro/index.html /some/path/tailwind-repro/eslint.config.mjs /some/path/tailwind-repro/index.html
```

These then become detected as widget config files as they end in `.config` and then fail as widget config json objects. This PR ignores these irrelevant imports from the project root by only setting config files if they're within `/src/` and also explicitly logs out the config object if it was added to the map but doesn't look correct when trying to extract widget config from it.

Before we would pick up extra "widget config" files
```
(codeEntrypoints, configFileToEntrypoint)

{
  '/some/path/tailwind-repro/src/main.js': '/src/main.tsx',
  '/some/path/tailwind-repro/some/path/tailwind-repro/src/main.config.js': '/some/path/tailwind-repro/src/main.config.js',
  '/some/path/tailwind-repro/tsconfig.node.json': '/tsconfig.node.json',
  '/some/path/tailwind-repro/index.html': '/index.html',
  '/some/path/tailwind-repro/.jemma/settings.sh': '/.jemma/settings.sh',
  '/some/path/tailwind-repro/.jemma/install-node.sh': '/.jemma/install-node.sh',
  '/some/path/tailwind-repro/.jemma/download-node.py': '/.jemma/download-node.py',
  '/some/path/tailwind-repro/.npmrc': '/.npmrc',
  '/some/path/tailwind-repro/README.md': '/README.md',
  '/some/path/tailwind-repro/foundry.config.json': '/foundry.config.json',
  '/some/path/tailwind-repro/package.json': '/package.json',
  '/some/path/tailwind-repro/tsconfig.json': '/tsconfig.json',
  '/some/path/tailwind-repro/templateConfig.json': '/templateConfig.json',
  '/some/path/tailwind-repro/vite.config.js': '/vite.config.ts',
  '/some/path/tailwind-repro/ci.yml': '/ci.yml',
  '/some/path/tailwind-repro/eslint.config.mjs': '/eslint.config.mjs',
  '/some/path/tailwind-repro/src/vite-env.d.js': '/src/vite-env.d.ts'
} {
  '/some/path/tailwind-repro/src/main.config.js': '/some/path/tailwind-repro/src/main.js',
  '/foundry.config.json': '/some/path/tailwind-repro/index.html',
  '/vite.config.js': '/some/path/tailwind-repro/index.html',
  '/eslint.config.mjs': '/some/path/tailwind-repro/index.html'
}
```

After we ignore the irrelevant ones being picked up from the project root
```
(codeEntrypoints, configFileToEntrypoint)

{
  '/some/path/tailwind-repro/src/main.js': '/src/main.tsx',
  '/some/path/tailwind-repro/some/path/tailwind-repro/src/main.config.js': '/some/path/tailwind-repro/src/main.config.js',
  '/some/path/tailwind-repro/tsconfig.node.json': '/tsconfig.node.json',
  '/some/path/tailwind-repro/index.html': '/index.html',
  '/some/path/tailwind-repro/.jemma/settings.sh': '/.jemma/settings.sh',
  '/some/path/tailwind-repro/.jemma/install-node.sh': '/.jemma/install-node.sh',
  '/some/path/tailwind-repro/.jemma/download-node.py': '/.jemma/download-node.py',
  '/some/path/tailwind-repro/.npmrc': '/.npmrc',
  '/some/path/tailwind-repro/README.md': '/README.md',
  '/some/path/tailwind-repro/foundry.config.json': '/foundry.config.json',
  '/some/path/tailwind-repro/package.json': '/package.json',
  '/some/path/tailwind-repro/tsconfig.json': '/tsconfig.json',
  '/some/path/tailwind-repro/templateConfig.json': '/templateConfig.json',
  '/some/path/tailwind-repro/vite.config.js': '/vite.config.ts',
  '/some/path/tailwind-repro/ci.yml': '/ci.yml',
  '/some/path/tailwind-repro/eslint.config.mjs': '/eslint.config.mjs',
  '/some/path/tailwind-repro/src/vite-env.d.js': '/src/vite-env.d.ts'
} {
  '/some/path/tailwind-repro/src/main.config.js': '/some/path/tailwind-repro/src/main.js'
}
```