### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -184,6 +184,7 @@
     "rotten-bobcats-call",
     "rude-ravens-grab",
     "short-chefs-pull",
+    "short-cups-boil",
     "shy-lizards-smash",
     "silly-moons-march",
     "slick-views-eat",

--- a/packages/functions/CHANGELOG.md
+++ b/packages/functions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/functions
 
+## 1.4.0-beta.7
+
+### Minor Changes
+
+- f318daf: Use correct API gateway service name
+
 ## 1.4.0-beta.6
 
 ### Minor Changes

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/functions",
-  "version": "1.4.0-beta.6",
+  "version": "1.4.0-beta.7",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/functions@1.4.0-beta.7

### Minor Changes

-   f318daf: Use correct API gateway service name
