### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -176,6 +176,7 @@
     "hip-pans-bathe",
     "icy-items-run",
     "kind-things-fetch",
+    "lemon-results-fall",
     "metal-bugs-boil",
     "nasty-ties-stay",
     "plain-clubs-lie",

--- a/packages/osdk-docs-context/CHANGELOG.md
+++ b/packages/osdk-docs-context/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/osdk-docs-context
 
+## 0.3.0-beta.5
+
+### Minor Changes
+
+- dd8c385: Update upload media ontology edits docs
+
 ## 0.3.0-beta.4
 
 ### Minor Changes

--- a/packages/osdk-docs-context/package.json
+++ b/packages/osdk-docs-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/osdk-docs-context",
-  "version": "0.3.0-beta.4",
+  "version": "0.3.0-beta.5",
   "description": "OSDK Documentation Context utilities and examples registry",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/typescript-sdk-docs-examples/CHANGELOG.md
+++ b/packages/typescript-sdk-docs-examples/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/typescript-sdk-docs-examples
 
+## 0.3.0-beta.4
+
+### Minor Changes
+
+- dd8c385: Update upload media ontology edits docs
+
 ## 0.3.0-beta.3
 
 ### Minor Changes

--- a/packages/typescript-sdk-docs-examples/package.json
+++ b/packages/typescript-sdk-docs-examples/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/typescript-sdk-docs-examples",
   "private": true,
-  "version": "0.3.0-beta.3",
+  "version": "0.3.0-beta.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/typescript-sdk-docs/CHANGELOG.md
+++ b/packages/typescript-sdk-docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/typescript-sdk-docs
 
+## 0.5.0-beta.4
+
+### Minor Changes
+
+- dd8c385: Update upload media ontology edits docs
+
 ## 0.5.0-beta.3
 
 ### Minor Changes

--- a/packages/typescript-sdk-docs/package.json
+++ b/packages/typescript-sdk-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/typescript-sdk-docs",
-  "version": "0.5.0-beta.3",
+  "version": "0.5.0-beta.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/osdk-docs-context@0.3.0-beta.5

### Minor Changes

-   dd8c385: Update upload media ontology edits docs

## @osdk/typescript-sdk-docs@0.5.0-beta.4

### Minor Changes

-   dd8c385: Update upload media ontology edits docs

## @osdk/typescript-sdk-docs-examples@0.3.0-beta.4

### Minor Changes

-   dd8c385: Update upload media ontology edits docs
