### PR TITLE
Validate widget sets before building their manifest

### DIFF
--- a/.changeset/cold-hairs-fall.md
+++ b/.changeset/cold-hairs-fall.md
@@ -1,0 +1,5 @@
+---
+"@osdk/widget.vite-plugin": minor
+---
+
+Validate widget sets before building their manifest

--- a/packages/widget.vite-plugin/src/build-plugin/__tests__/validateWidgetSet.test.ts
+++ b/packages/widget.vite-plugin/src/build-plugin/__tests__/validateWidgetSet.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { WidgetBuildOutputs } from "../getWidgetBuildOutputs.js";
+import { validateWidgetSet } from "../validateWidgetSet.js";
+
+describe("validateWidgetSet", () => {
+  describe("validateWidgetIds", () => {
+    it("should not throw when all widget IDs are unique", () => {
+      const widgetBuilds: WidgetBuildOutputs[] = [
+        createWidgetBuild("widget1"),
+        createWidgetBuild("widget2"),
+        createWidgetBuild("widget3"),
+      ];
+
+      expect(() => validateWidgetSet(widgetBuilds)).not.toThrow();
+    });
+
+    it("should throw when duplicate widget IDs are found", () => {
+      const widgetBuilds: WidgetBuildOutputs[] = [
+        createWidgetBuild("widget1"),
+        createWidgetBuild("widget2"),
+        createWidgetBuild("widget1"),
+      ];
+
+      expect(() => validateWidgetSet(widgetBuilds)).toThrow(
+        "Duplicate widget ID: widget1. Each widget must have a unique ID.",
+      );
+    });
+  });
+});
+
+function createWidgetBuild(id: string): WidgetBuildOutputs {
+  return {
+    widgetConfig: {
+      id,
+      name: `Widget ${id}`,
+      type: "workshop",
+      parameters: {},
+      events: {},
+    },
+    scripts: [],
+    stylesheets: [],
+  };
+}

--- a/packages/widget.vite-plugin/src/build-plugin/buildWidgetSetManifest.ts
+++ b/packages/widget.vite-plugin/src/build-plugin/buildWidgetSetManifest.ts
@@ -22,6 +22,7 @@ import type {
   WidgetSetManifest,
 } from "@osdk/widget.api";
 import type { WidgetBuildOutputs } from "./getWidgetBuildOutputs.js";
+import { validateWidgetSet } from "./validateWidgetSet.js";
 
 export function buildWidgetSetManifest(
   widgetSetRid: string,
@@ -29,6 +30,7 @@ export function buildWidgetSetManifest(
   widgetBuilds: WidgetBuildOutputs[],
   widgetSetInputSpec: WidgetSetInputSpec,
 ): WidgetSetManifest {
+  validateWidgetSet(widgetBuilds);
   return {
     manifestVersion: "1.0.0",
     widgetSet: {

--- a/packages/widget.vite-plugin/src/build-plugin/validateWidgetSet.ts
+++ b/packages/widget.vite-plugin/src/build-plugin/validateWidgetSet.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { WidgetBuildOutputs } from "./getWidgetBuildOutputs.js";
+
+export function validateWidgetSet(widgetBuilds: WidgetBuildOutputs[]): void {
+  validateWidgetIds(widgetBuilds);
+}
+
+function validateWidgetIds(widgetBuilds: WidgetBuildOutputs[]): void {
+  const widgetIds = new Set<string>();
+  for (const widgetBuild of widgetBuilds) {
+    const widgetConfigId = widgetBuild.widgetConfig.id;
+    if (widgetIds.has(widgetConfigId)) {
+      throw new Error(
+        `Duplicate widget ID: ${widgetConfigId}. Each widget must have a unique ID.`,
+      );
+    }
+    widgetIds.add(widgetConfigId);
+  }
+}


### PR DESCRIPTION
Add a validation step when constructing the build manifest for a custom widget. Widget ids will be checked to confirm there are no duplicates.