### PR TITLE
Bump widget template dependency versions on widget libraries

### DIFF
--- a/.changeset/yellow-bats-tie.md
+++ b/.changeset/yellow-bats-tie.md
@@ -1,0 +1,6 @@
+---
+"@osdk/create-widget.template.minimal-react.v2": patch
+"@osdk/create-widget.template.react.v2": patch
+---
+
+Bump widget template dependency versions on widget libraries

--- a/packages/create-widget.template.minimal-react.v2/templates/package.json.hbs
+++ b/packages/create-widget.template.minimal-react.v2/templates/package.json.hbs
@@ -11,10 +11,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@osdk/widget.client-react": "^3.0.0",
-    "@osdk/widget.client": "^3.0.0"
+    "@osdk/widget.client-react": "^3.2.4",
+    "@osdk/widget.client": "^3.2.4"
   },
   "devDependencies": {
-    "@osdk/widget.vite-plugin": "^3.0.0"
+    "@osdk/widget.vite-plugin": "^3.2.4"
   }
 }

--- a/packages/create-widget.template.react.v2/templates/package.json.hbs
+++ b/packages/create-widget.template.react.v2/templates/package.json.hbs
@@ -13,10 +13,10 @@
   "dependencies": {
     "{{osdkPackage}}": "latest",
     "@osdk/client": "^2.0.0",
-    "@osdk/widget.client-react": "^3.0.0",
-    "@osdk/widget.client": "^3.0.0"
+    "@osdk/widget.client-react": "^3.2.4",
+    "@osdk/widget.client": "^3.2.4"
   },
   "devDependencies": {
-    "@osdk/widget.vite-plugin": "^3.0.0"
+    "@osdk/widget.vite-plugin": "^3.2.4"
   }
 }


### PR DESCRIPTION
Most of the time new projects will have the latest vite plugin if they resolve without a lockfile for the first time or they use in platform repo templates with the generated lockfile. This causes some confusion though when asking what vite plugin version people think they have and gives a stricter guarantee people are using the latest version we want them to.