### PR TITLE
Remove minimal widget template margin

### DIFF
--- a/.changeset/mean-rabbits-dig.md
+++ b/.changeset/mean-rabbits-dig.md
@@ -1,0 +1,5 @@
+---
+"@osdk/create-widget.template.minimal-react.v2": patch
+---
+
+Remove minimal widget template margin

--- a/examples/example-widget-minimal-react-sdk-2.x/src/Widget.module.css
+++ b/examples/example-widget-minimal-react-sdk-2.x/src/Widget.module.css
@@ -1,6 +1,5 @@
 .container {
-    margin: 8px;
-    padding: 15px;
+    padding: 20px;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/packages/create-widget.template.minimal-react.v2/templates/src/Widget.module.css
+++ b/packages/create-widget.template.minimal-react.v2/templates/src/Widget.module.css
@@ -1,6 +1,5 @@
 .container {
-    margin: 8px;
-    padding: 15px;
+    padding: 20px;
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
This is causing scrollbars with the default template in combination with height: 100%