### PR TITLE
override react-server-dom-webpack to avoid rce vuln exposure

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
       "cookie@0.7.1": "0.7.2",
       "esbuild@^0.23.0": "^0.25.0",
       "esbuild@^0.24.0": "^0.25.0",
-      "react-server-dom-webpack": "^19.0.1"
+      "react-server-dom-webpack": ">=19.2.1"
     }
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   cookie@0.7.1: 0.7.2
   esbuild@^0.23.0: ^0.25.0
   esbuild@^0.24.0: ^0.25.0
-  react-server-dom-webpack: ^19.0.1
+  react-server-dom-webpack: '>=19.2.1'
 
 pnpmfileChecksum: fbzgb6marujyerj542wrbmpzym
 


### PR DESCRIPTION
Context:

`react-server-dom-webpack` is currently affected by a CVE allowing RCE in server components. We don't use server components nor Next.js and this package is included transitively but we should override to avoid having it included. It's required by `jest-expo` which hasn't currently bumped things on their end.

https://vercel.com/changelog/cve-2025-55182
https://react.dev/blog/2025/12/03/critical-security-vulnerability-in-react-server-components