### PR TITLE
Create foundryWidgetTokenProvider helper

### DIFF
--- a/.changeset/wild-streets-sneeze.md
+++ b/.changeset/wild-streets-sneeze.md
@@ -2,4 +2,4 @@
 "@osdk/widget.client": patch
 ---
 
-Create foundryWidgetTokenProvider helper
+Create createFoundryWidgetTokenProvider helper

--- a/packages/widget.client/src/index.ts
+++ b/packages/widget.client/src/index.ts
@@ -38,4 +38,4 @@ export {
 export { createFoundryWidgetClient } from "./client.js";
 export type { FoundryWidgetClient } from "./client.js";
 export { FoundryHostEventTarget } from "./host.js";
-export { foundryWidgetTokenProvider } from "./tokenProvider.js";
+export { createFoundryWidgetTokenProvider } from "./tokenProvider.js";

--- a/packages/widget.client/src/tokenProvider.ts
+++ b/packages/widget.client/src/tokenProvider.ts
@@ -19,6 +19,6 @@
  * runtime environment. It resolves to a placeholder value which is replaced
  * on the actual request.
  */
-export function foundryWidgetTokenProvider(): Promise<string> {
-  return Promise.resolve("widgets-auth");
+export function createFoundryWidgetTokenProvider(): () => Promise<string> {
+  return () => Promise.resolve("widgets-auth");
 }


### PR DESCRIPTION
Currently it is expected for the user code to provide a dummy token provider when constructing OSDK clients:

```
import { createClient } from "@osdk/client";
import { $ontologyRid } from "@custom-widget/sdk";

const client = createClient(
    window.location.origin,
    $ontologyRid,
    () => Promise.resolve("widgets-auth"),
);
```

This PR provides a helper as some syntax sugar to avoid user code needing to be aware of this:

```
import { createClient } from "@osdk/client";
import { createFoundryWidgetTokenProvider } from "@osdk/widget.client";
import { $ontologyRid } from "@custom-widget/sdk";

const client = createClient(
    window.location.origin,
    $ontologyRid,
    createFoundryWidgetTokenProvider(),
);
```

Before this can be used in the templates it'll need to be released