### PR TITLE
preserve object set data on rid change

### DIFF
--- a/packages/react/src/new/makeExternalStore.ts
+++ b/packages/react/src/new/makeExternalStore.ts
@@ -26,12 +26,13 @@ export type Snapshot<X> =
 
 export function makeExternalStore<X>(
   createObservation: (callback: Observer<X | undefined>) => Unsubscribable,
-  name?: string,
+  _name?: string,
+  initialValue?: Snapshot<X>,
 ): {
   subscribe: (notifyUpdate: () => void) => () => void;
   getSnapShot: () => Snapshot<X>;
 } {
-  let lastResult: Snapshot<X>;
+  let lastResult: Snapshot<X> = initialValue;
 
   function getSnapShot(): Snapshot<X> {
     return lastResult;

--- a/packages/react/src/new/useObjectSet.tsx
+++ b/packages/react/src/new/useObjectSet.tsx
@@ -30,7 +30,7 @@ import {
   type ObserveObjectSetArgs,
 } from "@osdk/client/unstable-do-not-use";
 import React from "react";
-import { makeExternalStore } from "./makeExternalStore.js";
+import { makeExternalStore, type Snapshot } from "./makeExternalStore.js";
 import { OsdkContext2 } from "./OsdkContext2.js";
 
 export interface UseObjectSetOptions<
@@ -185,6 +185,18 @@ export function useObjectSet<
 
   const { enabled = true, streamUpdates, ...otherOptions } = options;
 
+  // Track object type to detect when we switch to a different object type
+  const objectTypeKey = baseObjectSet.$objectSetInternals.def.apiName;
+  const previousObjectTypeRef = React.useRef<string>(objectTypeKey);
+  const previousPayloadRef = React.useRef<
+    Snapshot<ObserveObjectSetArgs<Q, RDPs>> | undefined
+  >();
+
+  const objectTypeChanged = previousObjectTypeRef.current !== objectTypeKey;
+  if (objectTypeChanged) {
+    previousObjectTypeRef.current = objectTypeKey;
+  }
+
   // Compute a stable cache key for the ObjectSet and options
   // dedupeIntervalMs and enabled are excluded as they don't affect the data
   const stableKey = computeObjectSetCacheKey(baseObjectSet, {
@@ -208,6 +220,11 @@ export function useObjectSet<
             : void 0,
         );
       }
+
+      const initialValue = objectTypeChanged
+        ? undefined
+        : previousPayloadRef.current;
+
       return makeExternalStore<ObserveObjectSetArgs<Q, RDPs>>(
         (observer) => {
           const subscription = observableClient.observeObjectSet(
@@ -232,12 +249,18 @@ export function useObjectSet<
         process.env.NODE_ENV !== "production"
           ? `objectSet ${stableKey}`
           : void 0,
+        initialValue,
       );
     },
-    [enabled, observableClient, stableKey, streamUpdates],
+    [enabled, observableClient, stableKey, streamUpdates, objectTypeChanged],
   );
 
   const payload = React.useSyncExternalStore(subscribe, getSnapShot);
+  React.useEffect(() => {
+    if (payload) {
+      previousPayloadRef.current = payload;
+    }
+  }, [payload]);
 
   return {
     data: payload?.resolvedList as Osdk.Instance<

--- a/packages/react/test/useObjectSet.enabled.test.tsx
+++ b/packages/react/test/useObjectSet.enabled.test.tsx
@@ -29,6 +29,7 @@ const MockObjectType = {
 const mockObjectSet = {
   $__EXPERIMENTAL_objectSet: true,
   type: MockObjectType,
+  $objectSetInternals: { def: MockObjectType },
 } as unknown as ObjectSet<typeof MockObjectType>;
 
 describe("useObjectSet enabled option", () => {


### PR DESCRIPTION
Only reset `useObjectSet` data when the underlying object type changes, not when parameters like RID change. This prevents UI flashing when things like Custom Widgets use temporary object set RIDs. This should have no change on existing usages and requires clients to pass an `initialValue` to `makeExternalStore`