### PR TITLE
Filter for branches matching refs/heads/release/* instead of release/*

### DIFF
--- a/packages/tool.release/src/ciPublish.ts
+++ b/packages/tool.release/src/ciPublish.ts
@@ -74,7 +74,7 @@ async function getRemoteBranches(): Promise<string[]> {
     "ls-remote",
     "--heads",
     "origin",
-    "release/*",
+    "refs/heads/release/*",
   ], { cwd: repoRoot });
   return stdout.split("\n").filter(line => !!line).map(line => {
     const match = line.match(/release\/(.*)/);


### PR DESCRIPTION
Ran into a bug with our CI publishing step when trying to release 2.5.3 in https://github.com/palantir/osdk-ts/actions/runs/19976631766/job/57334001867#step:6:49

The error is
```
Error:  Invalid Version: release/2.6.0
  at new SemVer (node_modules/.pnpm/semver@7.7.2/node_modules/semver/classes/semver.js:40:13)
  at compare (node_modules/.pnpm/semver@7.7.2/node_modules/semver/functions/compare.js:5:32)
  at Object.gt (node_modules/.pnpm/semver@7.7.2/node_modules/semver/functions/gt.js:4:29)
  at packages/tool.release/build/esm/ciPublish.js:97:19
  at Array.reduce (<anonymous>)
  at findGreatestVersion (packages/tool.release/build/esm/ciPublish.js:89:26)
  at ciPublish (packages/tool.release/build/esm/ciPublish.js:43:29)
  at async packages/tool.release/build/esm/ciPublish.js:113:3
```

We have a Version Packages PR open right now (#2247) for 2.6.x RC that we held off on merging until Monday, so the changeset-release/release/2.6.x branch exists right now. The command used to list the branches is `git ls-remote --heads origin "release/*"` which also returns the changeset branch:
```
bryantp@bryantp1-mac osdk-ts % git ls-remote --heads origin "release/*" 
e9c82ce5cebb5b350acfae70a4b5a7bae646f3bb        refs/heads/changeset-release/release/2.6.x
32b79d11c33b8d4877d37c2184f979f52274c9d3        refs/heads/release/1.0.x
3813141ba39730ee3adcb61697da693da53ab2aa        refs/heads/release/1.1.x
3694515d044041919a0b7ffcab3e48da11d49025        refs/heads/release/1.2.x
24ff32e3950b2497b924af3a2e43bd9184524dee        refs/heads/release/1.3.x
25f6d797e2c1932039ae6ac273b7fe0f51013714        refs/heads/release/2.0.x
b9fac53b56ed9833d6f6cb3cdb2aa9b6d0423dbf        refs/heads/release/2.1.x
7001729eea96cb60e6f3918e03b628d15b2afb46        refs/heads/release/2.2.x
25152ad2b160058a11b3a557c5627f3597c9dee9        refs/heads/release/2.3.x
d2d113a66bb6e4fe95db185ec653a89f05c7a66d        refs/heads/release/2.4.x
f6140671c9e39a4196dc513a5c138d03a73873cb        refs/heads/release/2.5.x
5a9cd8f994da36dd3e34658da880c5ad2db29105        refs/heads/release/2.6.x
03fdbea9b08ccdf380c092333c291deed53baf5f        refs/heads/release/cli
```
We then strip out everything up to the release/ part with this regex: `^.*?release\/` which only strips out the first changeset-release/ so the semver is returned as release/2.6.0 instead of 2.6.0.

This PR modifies the command to filter against `refs/heads/release/*` instead of `release/*`, so changeset `release/` branches are not returned.