### PR TITLE
Fix namespace undefined error in defineValueType

### DIFF
--- a/packages/maker/src/api/defineValueType.ts
+++ b/packages/maker/src/api/defineValueType.ts
@@ -148,7 +148,14 @@ export function defineValueType(
 
   const vt: ValueTypeDefinitionVersion = {
     apiName,
-    packageNamespace: namespace.substring(0, namespace.length - 1),
+    // Use getter to defer namespace resolution until it's accessed
+    get packageNamespace() {
+      invariant(
+        namespace !== undefined,
+        `defineValueType called for '${apiName}' before defineOntology has been invoked. The namespace must be set by calling defineOntology before defining value types.`,
+      );
+      return namespace.substring(0, namespace.length - 1);
+    },
     displayMetadata: {
       displayName: displayName,
       description: description ?? "",


### PR DESCRIPTION
## Problem

The `namespace` variable is declared globally but only initialized inside `defineOntology()`. When `.mjs` files call `defineValueType()` at module load time (before `defineOntology` runs), `namespace` is undefined, causing:

```
TypeError: Cannot read properties of undefined (reading 'substring')
    at defineValueType (.../@osdk/maker/build/esm/api/defineValueType.js:90:33)
```

This affects any ontology package that defines value types at the top level of its entry point file.

## Root Cause

In `defineOntology.ts`:
- Line 60: `export let namespace: string;` (declared but not initialized)
- Line 92: `namespace = ns;` (only initialized inside `defineOntology()` function)

In `defineValueType.ts`:
- Line 151: `packageNamespace: namespace.substring(0, namespace.length - 1)` (immediate access)

Module load timing:
1. Node.js loads the `.mjs` file
2. Top-level `defineValueType()` calls happen immediately
3. `defineOntology()` hasn't been invoked yet → `namespace` is undefined

## Solution

Use a getter to defer namespace resolution until `packageNamespace` is accessed:

```typescript
const vt: ValueTypeDefinitionVersion = {
  apiName,
  // Use getter to defer namespace resolution until it's accessed
  get packageNamespace() {
    invariant(
      namespace !== undefined,
      \`defineValueType called for '${apiName}' before defineOntology has been invoked. The namespace must be set by calling defineOntology before defining value types.\`,
    );
    return namespace.substring(0, namespace.length - 1);
  },
  // ... rest of fields
};
```

This ensures:
- The getter function isn't called until someone accesses `packageNamespace`
- By that time, `defineOntology()` has already set `namespace`
- Includes helpful error message if somehow it's still undefined

## Testing

- ✅ Compiles successfully with TypeScript/Babel in osdk-ts
- ✅ Branch: `fix/value-type-namespace-undefined`
- ✅ Commit: `4eb8263ec`

## Impact

This fix will allow defense ontology packages (and any other packages that define value types at module load time) to transpile successfully.