### PR TITLE
make fetchOneByRid typing accept interfaces

### DIFF
--- a/packages/api/src/experimental/fetchOneByRid.ts
+++ b/packages/api/src/experimental/fetchOneByRid.ts
@@ -19,13 +19,15 @@ import type {
   SelectArg,
 } from "../object/FetchPageArgs.js";
 
-import type { PropertyKeys } from "../ontology/ObjectOrInterface.js";
-import type { ObjectTypeDefinition } from "../ontology/ObjectTypeDefinition.js";
+import type {
+  ObjectOrInterfaceDefinition,
+  PropertyKeys,
+} from "../ontology/ObjectOrInterface.js";
 import type { ExtractOptions, Osdk } from "../OsdkObjectFrom.js";
 import type { Experiment } from "./Experiment.js";
 
 type fetchOneByRidFn = <
-  Q extends ObjectTypeDefinition,
+  Q extends ObjectOrInterfaceDefinition,
   const L extends PropertyKeys<Q>,
   const R extends boolean,
   const S extends false | "throw" = NullabilityAdherence.Default,

--- a/packages/client/src/createClient.ts
+++ b/packages/client/src/createClient.ts
@@ -185,7 +185,7 @@ export function createClientFromContext(clientCtx: MinimalClient) {
         case __EXPERIMENTAL__NOT_SUPPORTED_YET__fetchOneByRid.name:
           return {
             fetchOneByRid: async <
-              Q extends ObjectTypeDefinition,
+              Q extends ObjectOrInterfaceDefinition,
               const L extends PropertyKeys<Q>,
               const R extends boolean,
               const S extends false | "throw" = NullabilityAdherence.Default,


### PR DESCRIPTION
Users would like to pass interfaces to `__EXPERIMENTAL__NOT_SUPPORTED_YET__fetchOneByRid` and are currently doing so (the underlying code works with interfaces) and using `as any` to get around typing issues. To remove the need for the `as any` this PR widens the typing to accept `ObjectOrInterfaceDefinition` instead of `ObjectTypeDefinition`