### PR TITLE
Version Packages

### DIFF
--- a/.changeset/brave-taxes-allow.md
+++ b/.changeset/brave-taxes-allow.md
@@ -1,5 +1,0 @@
----
-"@osdk/create-widget.template.react.v2": patch
----
-
-Use createFoundryWidgetTokenProvider in widget template

--- a/.changeset/icy-eyes-stand.md
+++ b/.changeset/icy-eyes-stand.md
@@ -1,5 +1,0 @@
----
-"@osdk/widget.vite-plugin": patch
----
-
-Show hint for WidgetIdNotFound errors

--- a/.changeset/ninety-plums-tan.md
+++ b/.changeset/ninety-plums-tan.md
@@ -1,5 +1,0 @@
----
-"@osdk/widget.client-react": patch
----
-
-Improved object set write path

--- a/packages/create-widget.template.minimal-react.v2/CHANGELOG.md
+++ b/packages/create-widget.template.minimal-react.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-widget.template.react.v2
 
+## 3.3.1
+
 ## 3.3.0
 
 ### Patch Changes

--- a/packages/create-widget.template.minimal-react.v2/package.json
+++ b/packages/create-widget.template.minimal-react.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-widget.template.minimal-react.v2",
   "private": true,
-  "version": "3.3.0",
+  "version": "3.3.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-widget.template.react.v2/CHANGELOG.md
+++ b/packages/create-widget.template.react.v2/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/create-widget.template.react.v2
 
+## 3.3.1
+
+### Patch Changes
+
+- 6b85da5: Use createFoundryWidgetTokenProvider in widget template
+
 ## 3.3.0
 
 ### Patch Changes

--- a/packages/create-widget.template.react.v2/package.json
+++ b/packages/create-widget.template.react.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-widget.template.react.v2",
   "private": true,
-  "version": "3.3.0",
+  "version": "3.3.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-widget/CHANGELOG.md
+++ b/packages/create-widget/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-widget
 
+## 3.3.1
+
 ## 3.3.0
 
 ### Patch Changes

--- a/packages/create-widget/package.json
+++ b/packages/create-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-widget",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/widget.api/CHANGELOG.md
+++ b/packages/widget.api/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/widget.api
 
+## 3.3.1
+
 ## 3.3.0
 
 ### Patch Changes

--- a/packages/widget.api/package.json
+++ b/packages/widget.api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget.api",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "API contract between Foundry UIs that can embed custom widgets and the custom widgets themselves",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/widget.client-react/CHANGELOG.md
+++ b/packages/widget.client-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/widget.client-react
 
+## 3.3.1
+
+### Patch Changes
+
+- 14fca1c: Improved object set write path
+  - @osdk/widget.client@3.3.1
+
 ## 3.3.0
 
 ### Patch Changes

--- a/packages/widget.client-react/package.json
+++ b/packages/widget.client-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget.client-react",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Wrapper around @osdk/widget.client",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/widget.client/CHANGELOG.md
+++ b/packages/widget.client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/widget.client
 
+## 3.3.1
+
+### Patch Changes
+
+- @osdk/widget.api@3.3.1
+
 ## 3.3.0
 
 ### Patch Changes

--- a/packages/widget.client/package.json
+++ b/packages/widget.client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget.client",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Client that sets up listeners for the custom widgets embedded into Foundry, adhering to the contract laid out in @osdk/widget.api",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/widget.vite-plugin/CHANGELOG.md
+++ b/packages/widget.vite-plugin/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/widget.vite-plugin
 
+## 3.3.1
+
+### Patch Changes
+
+- 275b70d: Show hint for WidgetIdNotFound errors
+  - @osdk/widget.api@3.3.1
+
 ## 3.3.0
 
 ### Patch Changes

--- a/packages/widget.vite-plugin/package.json
+++ b/packages/widget.vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget.vite-plugin",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "A vite plugin that will extract parameter definitions from TS/JS files + entrypoint info into a manifest file to be uploaded to Foundry ",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/2.6.x, this PR will be updated.


# Releases
## @osdk/widget.client@3.3.1

### Patch Changes

-   @osdk/widget.api@3.3.1

## @osdk/widget.client-react@3.3.1

### Patch Changes

-   14fca1c: Improved object set write path
    -   @osdk/widget.client@3.3.1

## @osdk/widget.vite-plugin@3.3.1

### Patch Changes

-   275b70d: Show hint for WidgetIdNotFound errors
    -   @osdk/widget.api@3.3.1

## @osdk/create-widget@3.3.1



## @osdk/widget.api@3.3.1



## @osdk/create-widget.template.react.v2@3.3.1

### Patch Changes

-   6b85da5: Use createFoundryWidgetTokenProvider in widget template

## @osdk/create-widget.template.minimal-react.v2@3.3.1


