### PR TITLE
Fix extractObjectTypes

### DIFF
--- a/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
@@ -111,15 +111,15 @@ export class ObjectSetQuery extends BaseListQuery<
   #extractObjectTypes(opts: ObjectSetQueryOptions): Set<string> {
     const types = new Set<string>();
     const baseWire = JSON.parse(this.#baseObjectSetWire);
-    if (baseWire.type) {
-      types.add(baseWire.type);
+    if (baseWire.type === "base") {
+      types.add(baseWire.objectType);
     }
 
     if (opts.union) {
       for (const os of opts.union) {
         const wire = getWireObjectSet(os);
-        if (wire.type) {
-          types.add(wire.type);
+        if (wire.type === "base") {
+          types.add(wire.objectType);
         }
       }
     }
@@ -127,8 +127,8 @@ export class ObjectSetQuery extends BaseListQuery<
     if (opts.intersect) {
       for (const os of opts.intersect) {
         const wire = getWireObjectSet(os);
-        if (wire.type) {
-          types.add(wire.type);
+        if (wire.type === "base") {
+          types.add(wire.objectType);
         }
       }
     }
@@ -136,8 +136,8 @@ export class ObjectSetQuery extends BaseListQuery<
     if (opts.subtract) {
       for (const os of opts.subtract) {
         const wire = getWireObjectSet(os);
-        if (wire.type) {
-          types.add(wire.type);
+        if (wire.type === "base") {
+          types.add(wire.objectType);
         }
       }
     }


### PR DESCRIPTION
The value of ObjectSetQuery.#objectTypes is "base", while it should be "Employee". I noticed this when I got this error from useObjectSet with orderBy option. The error is now fixed by the [PR](https://github.com/palantir/osdk-ts/pull/2238/files#) to fix sorting strategy however the #objectTypes value is still wrong.

```ObjectSetQuery<"{\"type\":\"base\",\"objectType\":\"Employee\"}", {"orderBy":{"fullName":"asc"},"pageSize":50}> .fetchPageAndUpdate() Error fetching data Error: Object does not implement interface 'base'.
    at Object.<anonymous> (getDollarAs.ts:75:15)
    at SortingStrategy.ts:82:33
    at Array.sort (<anonymous>)
    at OrderBySortingStrategy.sortCacheKeys (SortingStrategy.ts:79:28)
    at ObjectSetQuery._sortCacheKeys (BaseListQuery.ts:484:33)
    at ObjectSetQuery._updateList (BaseListQuery.ts:130:28)
    at BaseListQuery.ts:414:21
    at Layers.batch (Layers.ts:128:20)
    at Store.batch (Store.ts:228:24)
    at ObjectSetQuery.fetchPageAndUpdate (BaseListQuery.ts:404:37)
```

<img width="922" height="335" alt="Screenshot 2026-01-15 at 13 24 05" src="https://github.com/user-attachments/assets/9caeadd6-7282-4a58-b1d5-9ab3aa621e74" />


Not sure how to handle when the wire type is not base though.
