### PR TITLE
Fix field name mismatch: change requireImplementation to required

### DIFF
--- a/packages/maker/src/conversion/toMarketplace/convertInterfacePropertyType.ts
+++ b/packages/maker/src/conversion/toMarketplace/convertInterfacePropertyType.ts
@@ -31,7 +31,7 @@ export function convertInterfaceProperty(
     return [prop.sharedPropertyType.apiName, {
       type: "sharedPropertyBasedPropertyType",
       sharedPropertyBasedPropertyType: {
-        requireImplementation: prop.required,
+        required: prop.required,
         sharedPropertyType: convertSpt(prop.sharedPropertyType),
       },
     }];
@@ -55,7 +55,7 @@ export function convertInterfaceProperty(
           : propertyTypeTypeToOntologyIrInterfaceType(prop.type),
         constraints: {
           primaryKeyConstraint: prop.primaryKeyConstraint ?? "NO_RESTRICTION",
-          requireImplementation: prop.required ?? true,
+          required: prop.required ?? true,
           indexedForSearch: true,
           typeClasses: prop.typeClasses ?? [],
           dataConstraints: convertNullabilityToDataConstraint({


### PR DESCRIPTION
Fixes compatibility issue with foundry-as-code-gradle 0.260.0 which expects `required` field instead of `requireImplementation` in OntologyIrInterfaceSharedPropertyType.

This fixes the error `Some required fields have not been set: {missingFields=[required]}` when generating block sets.

## Changes
- Line 34: Changed `requireImplementation` to `required` in `sharedPropertyBasedPropertyType`
- Line 58: Changed `requireImplementation` to `required` in `interfaceDefinedPropertyType` constraints

## Context
This is needed to support the upgrade to foundry-as-code-gradle 0.260.0, which updated the Conjure API contract to expect the `required` field name.