### PR TITLE
add streaming support to useOsdkObject

### DIFF
--- a/.changeset/seven-breads-sneeze.md
+++ b/.changeset/seven-breads-sneeze.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client": patch
+"@osdk/react": patch
+---
+
+add streaming support to useOsdkObject

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -66,6 +66,7 @@ export interface ObserveObjectOptions<
   apiName: T["apiName"] | T;
   pk: PrimaryKeyType<T>;
   select?: PropertyKeys<T>[];
+  streamUpdates?: boolean;
 }
 
 export type OrderBy<Q extends ObjectTypeDefinition | InterfaceDefinition> = {
@@ -267,7 +268,7 @@ export interface ObservableClient extends ObserveLinks {
   observeObject<T extends ObjectTypeDefinition>(
     apiName: T["apiName"] | T,
     pk: PrimaryKeyType<T>,
-    options: ObserveOptions,
+    options: Omit<ObserveObjectOptions<T>, "apiName" | "pk">,
     subFn: Observer<ObserveObjectCallbackArgs<T>>,
   ): Unsubscribable;
 

--- a/packages/client/src/observable/internal/Query.ts
+++ b/packages/client/src/observable/internal/Query.ts
@@ -340,9 +340,8 @@ export abstract class Query<
         websocketSubscription.unsubscribe();
       });
     } catch (error) {
-      if (this.logger) {
-        this.logger.child({ methodName })
-          .error("Failed to register stream updates", error);
+      if (logger) {
+        logger.error("Failed to register stream updates", error);
       }
       this.onOswError({ subscriptionClosed: true, error });
     }

--- a/packages/client/src/observable/internal/Query.ts
+++ b/packages/client/src/observable/internal/Query.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { Logger } from "@osdk/api";
+import type { Logger, ObjectSet, ObjectTypeDefinition } from "@osdk/api";
 import type {
   Connectable,
   Observable,
@@ -35,6 +35,7 @@ import type { Entry } from "./Layer.js";
 import type { OptimisticId } from "./OptimisticId.js";
 import type { Store } from "./Store.js";
 import type { SubjectPayload } from "./SubjectPayload.js";
+import type { ObjectUpdate } from "./types/ObjectUpdate.js";
 
 export abstract class Query<
   KEY extends KnownCacheKey,
@@ -298,4 +299,99 @@ export abstract class Query<
     objectType: string,
     changes: Changes | undefined,
   ): Promise<void>;
+
+  //
+  // Websocket Subscription Methods
+  //
+
+  /**
+   * Create standard websocket subscription handlers for an ObjectSet.
+   * Subclasses can override individual handlers for custom behavior.
+   *
+   * @param objectSet The ObjectSet to subscribe to
+   * @param sub The parent subscription to add cleanup to
+   * @param methodName The method name for logging purposes
+   */
+  protected createWebsocketSubscription(
+    objectSet: ObjectSet<ObjectTypeDefinition>,
+    sub: Subscription,
+    methodName: string = "registerStreamUpdates",
+  ): void {
+    const logger = process.env.NODE_ENV !== "production"
+      ? this.logger?.child({ methodName })
+      : this.logger;
+
+    if (process.env.NODE_ENV !== "production") {
+      logger?.info("Subscribing to websocket");
+    }
+
+    try {
+      const websocketSubscription = objectSet.subscribe({
+        onChange: this.onOswChange.bind(this),
+        onError: this.onOswError.bind(this),
+        onOutOfDate: this.onOswOutOfDate.bind(this),
+        onSuccessfulSubscription: this.onOswSuccessfulSubscription.bind(this),
+      });
+
+      sub.add(() => {
+        if (process.env.NODE_ENV !== "production") {
+          logger?.info("Unsubscribing from websocket");
+        }
+        websocketSubscription.unsubscribe();
+      });
+    } catch (error) {
+      if (this.logger) {
+        this.logger.child({ methodName })
+          .error("Failed to register stream updates", error);
+      }
+      this.onOswError({ subscriptionClosed: true, error });
+    }
+  }
+
+  /**
+   * Handler called when websocket subscription is successfully established.
+   */
+  protected onOswSuccessfulSubscription(): void {
+    if (process.env.NODE_ENV !== "production") {
+      this.logger?.child({ methodName: "onSuccessfulSubscription" }).debug("");
+    }
+  }
+
+  /**
+   * Handler called when subscribed data becomes out of date.
+   * Default implementation triggers revalidation.
+   */
+  protected onOswOutOfDate(): void {
+    if (process.env.NODE_ENV !== "production") {
+      this.logger?.child({ methodName: "onOutOfDate" }).debug("");
+    }
+    this.revalidate(true).catch((e: unknown) => {
+      if (process.env.NODE_ENV !== "production") {
+        this.logger?.error("Error revalidating after onOutOfDate", e);
+      }
+    });
+  }
+
+  /**
+   * Handler called when websocket subscription encounters an error.
+   */
+  protected onOswError(errors: {
+    subscriptionClosed: boolean;
+    error: unknown;
+  }): void {
+    if (this.logger) {
+      this.logger?.child({ methodName: "onError" }).error(
+        "subscription errors",
+        errors,
+      );
+    }
+  }
+
+  /**
+   * Handler called when an object in the subscribed set changes.
+   * Default implementation does nothing - subclasses should override.
+   */
+  protected onOswChange(
+    _update: ObjectUpdate<ObjectTypeDefinition, string>,
+  ): void {}
 }

--- a/packages/client/src/observable/internal/base-list/BaseListQuery.ts
+++ b/packages/client/src/observable/internal/base-list/BaseListQuery.ts
@@ -644,6 +644,17 @@ export abstract class BaseListQuery<
   //
 
   /**
+   * Override onOswOutOfDate to be a no-op for list queries.
+   * List queries should not revalidate on out-of-date since they handle
+   * individual object updates via onOswChange instead.
+   */
+  protected override onOswOutOfDate(): void {
+    if (process.env.NODE_ENV !== "production") {
+      this.logger?.child({ methodName: "onOutOfDate" }).debug("");
+    }
+  }
+
+  /**
    * Handler called when an object in the subscribed set is added or updated.
    * Stores the object with RDP config and handles removal via onOswRemoved.
    *

--- a/packages/client/src/observable/internal/object/ObjectQuery.ts
+++ b/packages/client/src/observable/internal/object/ObjectQuery.ts
@@ -199,9 +199,7 @@ export class ObjectQuery extends Query<
 
   registerStreamUpdates(sub: Subscription): void {
     this.#setupStreamUpdates(sub).catch((error: unknown) => {
-      if (process.env.NODE_ENV !== "production") {
-        this.logger?.error("Failed to setup stream updates", error);
-      }
+      this.logger?.error("Failed to setup stream updates", error);
     });
   }
 
@@ -220,10 +218,10 @@ export class ObjectQuery extends Query<
     const objDef = await this.store.client[additionalContext].ontologyProvider
       .getObjectDefinition(this.#apiName);
 
-    const objectType = {
-      type: "object" as const,
+    const objectType: ObjectTypeDefinition = {
+      type: "object",
       apiName: this.#apiName,
-    } as ObjectTypeDefinition;
+    };
 
     return this.store.client(objectType).where({
       [objDef.primaryKeyApiName]: this.#pk,

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -42,7 +42,13 @@ export class ObjectsHelper extends AbstractHelper<
     options: ObserveObjectOptions<T>,
     subFn: Observer<ObjectPayload>,
   ): QuerySubscription<ObjectQuery> {
-    return super.observe(options, subFn);
+    const ret = super.observe(options, subFn);
+
+    if (options.streamUpdates) {
+      ret.query.registerStreamUpdates(ret.subscription);
+    }
+
+    return ret;
   }
 
   getQuery<T extends ObjectTypeDefinition | InterfaceDefinition>(

--- a/packages/react/src/new/useOsdkObject.ts
+++ b/packages/react/src/new/useOsdkObject.ts
@@ -80,9 +80,14 @@ export function useOsdkObject<Q extends ObjectTypeDefinition>(
   const isInstanceSignature = "$objectType" in args[0];
 
   // Extract options - 2nd param for instance signature, 3rd for type signature
-  const options: UseOsdkObjectOptions = isInstanceSignature
-    ? (args[1] as UseOsdkObjectOptions | undefined) ?? {}
-    : (args[2] as UseOsdkObjectOptions | undefined) ?? {};
+  // Support both boolean (legacy) and object signatures for backwards compatibility
+  const rawOptions: UseOsdkObjectOptions | boolean | undefined =
+    isInstanceSignature
+      ? (args[1] as UseOsdkObjectOptions | boolean | undefined)
+      : (args[2] as UseOsdkObjectOptions | boolean | undefined);
+  const options: UseOsdkObjectOptions = typeof rawOptions === "boolean"
+    ? { enabled: rawOptions }
+    : rawOptions ?? {};
 
   const enabled = options.enabled ?? true;
   const streamUpdates = options.streamUpdates ?? false;

--- a/packages/react/src/new/useOsdkObject.ts
+++ b/packages/react/src/new/useOsdkObject.ts
@@ -33,33 +33,44 @@ export interface UseOsdkObjectResult<Q extends ObjectTypeDefinition> {
   forceUpdate: () => void;
 }
 
+export interface UseOsdkObjectOptions {
+  /**
+   * Enable or disable the query (defaults to true)
+   */
+  enabled?: boolean;
+  /**
+   * Enable real-time updates via WebSocket subscription (defaults to false)
+   */
+  streamUpdates?: boolean;
+}
+
 /**
  * @param obj an existing `Osdk.Instance` object to get metadata for.
- * @param enabled Enable or disable the query (defaults to true)
+ * @param options Options including enabled and streamUpdates
  */
 export function useOsdkObject<Q extends ObjectTypeDefinition>(
   obj: Osdk.Instance<Q>,
-  enabled?: boolean,
+  options?: UseOsdkObjectOptions,
 ): UseOsdkObjectResult<Q>;
 /**
  * Loads an object by type and primary key.
  *
  * @param type
  * @param primaryKey
- * @param enabled Enable or disable the query (defaults to true)
+ * @param options Options including enabled and streamUpdates
  */
 export function useOsdkObject<Q extends ObjectTypeDefinition>(
   type: Q,
   primaryKey: PrimaryKeyType<Q>,
-  enabled?: boolean,
+  options?: UseOsdkObjectOptions,
 ): UseOsdkObjectResult<Q>;
 /*
     Implementation of useOsdkObject
  */
 export function useOsdkObject<Q extends ObjectTypeDefinition>(
   ...args:
-    | [obj: Osdk.Instance<Q>, enabled?: boolean]
-    | [type: Q, primaryKey: PrimaryKeyType<Q>, enabled?: boolean]
+    | [obj: Osdk.Instance<Q>, options?: UseOsdkObjectOptions]
+    | [type: Q, primaryKey: PrimaryKeyType<Q>, options?: UseOsdkObjectOptions]
 ): UseOsdkObjectResult<Q> {
   const { observableClient } = React.useContext(OsdkContext2);
 
@@ -68,10 +79,13 @@ export function useOsdkObject<Q extends ObjectTypeDefinition>(
   // so we must use type assertions after runtime discrimination
   const isInstanceSignature = "$objectType" in args[0];
 
-  // Extract enabled flag - 2nd param for instance signature, 3rd for type signature
-  const enabled = isInstanceSignature
-    ? (typeof args[1] === "boolean" ? args[1] : true)
-    : (typeof args[2] === "boolean" ? args[2] : true);
+  // Extract options - 2nd param for instance signature, 3rd for type signature
+  const options: UseOsdkObjectOptions = isInstanceSignature
+    ? (args[1] as UseOsdkObjectOptions | undefined) ?? {}
+    : (args[2] as UseOsdkObjectOptions | undefined) ?? {};
+
+  const enabled = options.enabled ?? true;
+  const streamUpdates = options.streamUpdates ?? false;
 
   // TODO: Figure out what the correct default behavior is for the various scenarios
   const mode = isInstanceSignature ? "offline" : undefined;
@@ -97,13 +111,14 @@ export function useOsdkObject<Q extends ObjectTypeDefinition>(
             primaryKey,
             {
               mode,
+              streamUpdates,
             },
             observer,
           ),
         `object ${objectType} ${primaryKey}`,
       );
     },
-    [enabled, observableClient, objectType, primaryKey, mode],
+    [enabled, observableClient, objectType, primaryKey, mode, streamUpdates],
   );
 
   const payload = React.useSyncExternalStore(subscribe, getSnapShot);

--- a/packages/react/src/public/experimental.ts
+++ b/packages/react/src/public/experimental.ts
@@ -28,6 +28,10 @@ export type {
   UseOsdkFunctionResult,
 } from "../new/useOsdkFunction.js";
 export { useOsdkFunction } from "../new/useOsdkFunction.js";
+export type {
+  UseOsdkObjectOptions,
+  UseOsdkObjectResult,
+} from "../new/useOsdkObject.js";
 export { useOsdkObject } from "../new/useOsdkObject.js";
 export type {
   UseOsdkListResult,

--- a/packages/react/test/useOsdkObject.enabled.test.tsx
+++ b/packages/react/test/useOsdkObject.enabled.test.tsx
@@ -59,7 +59,7 @@ describe("useOsdkObject enabled option", () => {
     const wrapper = createWrapper();
 
     renderHook(
-      () => useOsdkObject(mockInstance, false),
+      () => useOsdkObject(mockInstance, { enabled: false }),
       { wrapper },
     );
 
@@ -70,7 +70,7 @@ describe("useOsdkObject enabled option", () => {
     const wrapper = createWrapper();
 
     renderHook(
-      () => useOsdkObject(MockObjectType, "pk-000", false),
+      () => useOsdkObject(MockObjectType, "pk-000", { enabled: false }),
       { wrapper },
     );
 
@@ -88,7 +88,7 @@ describe("useOsdkObject enabled option", () => {
     expect(mockObserveObject).toHaveBeenCalledWith(
       "MockObject",
       "instance-123",
-      { mode: "offline" },
+      { mode: "offline", streamUpdates: false },
       expect.any(Object),
     );
   });
@@ -104,7 +104,7 @@ describe("useOsdkObject enabled option", () => {
     expect(mockObserveObject).toHaveBeenCalledWith(
       "MockObject",
       "pk-222",
-      { mode: undefined },
+      { mode: undefined, streamUpdates: false },
       expect.any(Object),
     );
   });
@@ -113,7 +113,7 @@ describe("useOsdkObject enabled option", () => {
     const wrapper = createWrapper();
 
     const { rerender } = renderHook(
-      ({ enabled }) => useOsdkObject(mockInstance, enabled),
+      ({ enabled }) => useOsdkObject(mockInstance, { enabled }),
       {
         wrapper,
         initialProps: { enabled: false },
@@ -125,5 +125,79 @@ describe("useOsdkObject enabled option", () => {
     rerender({ enabled: true });
 
     expect(mockObserveObject).toHaveBeenCalledTimes(1);
+  });
+
+  it("should support legacy boolean enabled parameter (instance signature)", () => {
+    const wrapper = createWrapper();
+
+    renderHook(
+      () => useOsdkObject(mockInstance, false),
+      { wrapper },
+    );
+
+    expect(mockObserveObject).not.toHaveBeenCalled();
+  });
+
+  it("should support legacy boolean enabled parameter (type signature)", () => {
+    const wrapper = createWrapper();
+
+    renderHook(
+      () => useOsdkObject(MockObjectType, "pk-123", false),
+      { wrapper },
+    );
+
+    expect(mockObserveObject).not.toHaveBeenCalled();
+  });
+
+  it("should pass streamUpdates option to observeObject", () => {
+    const wrapper = createWrapper();
+
+    renderHook(
+      () => useOsdkObject(MockObjectType, "pk-123", { streamUpdates: true }),
+      { wrapper },
+    );
+
+    expect(mockObserveObject).toHaveBeenCalledWith(
+      "MockObject",
+      "pk-123",
+      { mode: undefined, streamUpdates: true },
+      expect.any(Object),
+    );
+  });
+
+  it("should default streamUpdates to false", () => {
+    const wrapper = createWrapper();
+
+    renderHook(
+      () => useOsdkObject(MockObjectType, "pk-123"),
+      { wrapper },
+    );
+
+    expect(mockObserveObject).toHaveBeenCalledWith(
+      "MockObject",
+      "pk-123",
+      { mode: undefined, streamUpdates: false },
+      expect.any(Object),
+    );
+  });
+
+  it("should support both enabled and streamUpdates options together", () => {
+    const wrapper = createWrapper();
+
+    renderHook(
+      () =>
+        useOsdkObject(MockObjectType, "pk-123", {
+          enabled: true,
+          streamUpdates: true,
+        }),
+      { wrapper },
+    );
+
+    expect(mockObserveObject).toHaveBeenCalledWith(
+      "MockObject",
+      "pk-123",
+      { mode: undefined, streamUpdates: true },
+      expect.any(Object),
+    );
   });
 });


### PR DESCRIPTION
Adds the ability to stream updates to useOsdkObject, so changes to the object are reflected in real-time without needing to refetch.