### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -220,6 +220,7 @@
     "twenty-suits-yawn",
     "two-drinks-fall",
     "violet-lemons-raise",
+    "wicked-memes-greet",
     "wild-streets-sneeze",
     "wise-dingos-camp",
     "witty-beers-laugh"

--- a/packages/typescript-sdk-docs/CHANGELOG.md
+++ b/packages/typescript-sdk-docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/typescript-sdk-docs
 
+## 0.6.0-beta.4
+
+### Minor Changes
+
+- 3bfde5a: Add rendering support for objectSet action parameters
+
 ## 0.6.0-beta.3
 
 ### Minor Changes

--- a/packages/typescript-sdk-docs/package.json
+++ b/packages/typescript-sdk-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/typescript-sdk-docs",
-  "version": "0.6.0-beta.3",
+  "version": "0.6.0-beta.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/typescript-sdk-docs@0.6.0-beta.4

### Minor Changes

-   3bfde5a: Add rendering support for objectSet action parameters
