### PR TITLE
Bump @osdk/docs-spec-core to 0.6.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ catalogs:
       specifier: 0.6.0
       version: 0.6.0
     '@osdk/docs-spec-sdk':
-      specifier: ^0.16.0
+      specifier: 0.16.0
       version: 0.16.0
     '@osdk/foundry':
       specifier: 2.45.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ packages:
 catalogs:
   foundry-platform-typescript:
     "@osdk/docs-spec-core": 0.6.0
-    "@osdk/docs-spec-sdk": ^0.16.0
+    "@osdk/docs-spec-sdk": 0.16.0
     "@osdk/foundry": 2.45.0
     "@osdk/foundry.core": 2.45.0
     "@osdk/foundry.datasets": ~2.5.0


### PR DESCRIPTION
`@osdk/typescript-sdk-docs@0.6.0-beta.4` declares `@osdk/docs-spec-core: ^0.5.0` as a direct dependency, but also depends on `@osdk/docs-spec-sdk: ^0.16.0` which requires `@osdk/docs-spec-core@0.6.0`, causing type incompatibilities when consumers have both packages in their dependency tree.