### PR TITLE
fix dependent RDP query invalidation and add dependsOn api

### DIFF
--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -55,14 +55,10 @@ import type { ObserveLinks } from "./ObservableClient/ObserveLink.js";
 import type { OptimisticBuilder } from "./OptimisticBuilder.js";
 
 export namespace ObservableClient {
-  export interface AlsoInvalidatesOptions {
-    objectTypes?: Array<ObjectTypeDefinition | string>;
-    objects?: Array<Osdk.Instance<ObjectTypeDefinition>>;
-  }
-
   export interface ApplyActionOptions {
     optimisticUpdate?: (ctx: OptimisticBuilder) => void;
-    alsoInvalidates?: AlsoInvalidatesOptions;
+    dependsOn?: Array<ObjectTypeDefinition | string>;
+    dependsOnObjects?: Array<Osdk.Instance<ObjectTypeDefinition>>;
   }
 }
 

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -55,8 +55,14 @@ import type { ObserveLinks } from "./ObservableClient/ObserveLink.js";
 import type { OptimisticBuilder } from "./OptimisticBuilder.js";
 
 export namespace ObservableClient {
+  export interface AlsoInvalidatesOptions {
+    objectTypes?: Array<ObjectTypeDefinition | string>;
+    objects?: Array<Osdk.Instance<ObjectTypeDefinition>>;
+  }
+
   export interface ApplyActionOptions {
     optimisticUpdate?: (ctx: OptimisticBuilder) => void;
+    alsoInvalidates?: AlsoInvalidatesOptions;
   }
 }
 

--- a/packages/client/src/observable/internal/Store.ts
+++ b/packages/client/src/observable/internal/Store.ts
@@ -28,6 +28,7 @@ import invariant from "tiny-invariant";
 import type { ActionSignatureFromDef } from "../../actions/applyAction.js";
 import { additionalContext, type Client } from "../../Client.js";
 import { DEBUG_REFCOUNTS } from "../DebugFlags.js";
+import type { ObservableClient } from "../ObservableClient.js";
 import type { OptimisticBuilder } from "../OptimisticBuilder.js";
 import { ActionApplication } from "./actions/ActionApplication.js";
 import {
@@ -71,10 +72,7 @@ import type { Subjects } from "./Subjects.js";
 import { WhereClauseCanonicalizer } from "./WhereClauseCanonicalizer.js";
 
 export namespace Store {
-  export interface AlsoInvalidatesOptions {
-    objectTypes?: Array<ObjectTypeDefinition | string>;
-    objects?: Array<Osdk.Instance<ObjectTypeDefinition>>;
-  }
+  export type AlsoInvalidatesOptions = ObservableClient.AlsoInvalidatesOptions;
 
   export interface ApplyActionOptions {
     optimisticUpdate?: (ctx: OptimisticBuilder) => void;

--- a/packages/client/src/observable/internal/Store.ts
+++ b/packages/client/src/observable/internal/Store.ts
@@ -72,11 +72,10 @@ import type { Subjects } from "./Subjects.js";
 import { WhereClauseCanonicalizer } from "./WhereClauseCanonicalizer.js";
 
 export namespace Store {
-  export type AlsoInvalidatesOptions = ObservableClient.AlsoInvalidatesOptions;
-
   export interface ApplyActionOptions {
     optimisticUpdate?: (ctx: OptimisticBuilder) => void;
-    alsoInvalidates?: AlsoInvalidatesOptions;
+    dependsOn?: ObservableClient.ApplyActionOptions["dependsOn"];
+    dependsOnObjects?: ObservableClient.ApplyActionOptions["dependsOnObjects"];
   }
 }
 

--- a/packages/client/src/observable/internal/Store.ts
+++ b/packages/client/src/observable/internal/Store.ts
@@ -71,8 +71,14 @@ import type { Subjects } from "./Subjects.js";
 import { WhereClauseCanonicalizer } from "./WhereClauseCanonicalizer.js";
 
 export namespace Store {
+  export interface AlsoInvalidatesOptions {
+    objectTypes?: Array<ObjectTypeDefinition | string>;
+    objects?: Array<Osdk.Instance<ObjectTypeDefinition>>;
+  }
+
   export interface ApplyActionOptions {
     optimisticUpdate?: (ctx: OptimisticBuilder) => void;
+    alsoInvalidates?: AlsoInvalidatesOptions;
   }
 }
 

--- a/packages/client/src/observable/internal/list/ListQuery.ts
+++ b/packages/client/src/observable/internal/list/ListQuery.ts
@@ -91,6 +91,9 @@ export abstract class ListQuery extends BaseListQuery<
   #pivotInfo: Canonical<PivotInfo> | undefined;
   #objectSet: ObjectSet<ObjectTypeDefinition>;
 
+  // Object types that should trigger invalidation of this query (computed from RDP/pivot dependencies)
+  #invalidationTypes: Set<string> | undefined;
+
   /**
    * Register changes to the cache specific to ListQuery
    */
@@ -176,10 +179,33 @@ export abstract class ListQuery extends BaseListQuery<
   protected async fetchPageData(
     signal: AbortSignal | undefined,
   ): Promise<PageResult<Osdk.Instance<any>>> {
-    if (
+    // Compute invalidation types if not already computed
+    // This determines which object types should trigger revalidation of this query
+    if (this.#invalidationTypes === undefined) {
+      const wireObjectSet = getWireObjectSet(this.#objectSet);
+      const { resultType, invalidationSet } =
+        await getObjectTypesThatInvalidate(
+          this.store.client[additionalContext],
+          wireObjectSet,
+        );
+      this.#invalidationTypes = invalidationSet;
+
+      // Initialize sorting strategy if needed (for pivot queries)
+      if (
+        Object.keys(this.#orderBy).length > 0
+        && !(this.sortingStrategy instanceof OrderBySortingStrategy)
+      ) {
+        this.sortingStrategy = new OrderBySortingStrategy(
+          resultType.apiName,
+          this.#orderBy,
+        );
+      }
+    } else if (
       Object.keys(this.#orderBy).length > 0
       && !(this.sortingStrategy instanceof OrderBySortingStrategy)
     ) {
+      // Fallback: compute just the result type if invalidation types were already computed
+      // but sorting strategy wasn't initialized (shouldn't happen in practice)
       const wireObjectSet = getWireObjectSet(this.#objectSet);
       const { resultType } = await getObjectTypesThatInvalidate(
         this.store.client[additionalContext],
@@ -251,8 +277,15 @@ export abstract class ListQuery extends BaseListQuery<
     objectType: string,
     changes: Changes | undefined,
   ): Promise<void> => {
+    // Direct type match - the query's primary object type was invalidated
     if (this.apiName === objectType) {
-      // Only invalidate lists for the matching apiName
+      changes?.modified.add(this.cacheKey);
+      return this.revalidate(true);
+    }
+
+    // Check RDP/pivot dependencies - if this query depends on the invalidated type
+    // through derived properties or pivots, we need to revalidate
+    if (this.#invalidationTypes?.has(objectType)) {
       changes?.modified.add(this.cacheKey);
       return this.revalidate(true);
     }

--- a/packages/react/src/new/useOsdkAction.ts
+++ b/packages/react/src/new/useOsdkAction.ts
@@ -49,7 +49,11 @@ function mergeInvalidations(
   if (objectTypes.length === 0 && objects.length === 0) {
     return undefined;
   }
-  return { objectTypes, objects };
+
+  return {
+    ...(objectTypes.length > 0 && { objectTypes }),
+    ...(objects.length > 0 && { objects }),
+  };
 }
 
 type ApplyActionParams<Q extends ActionDefinition<any>> =
@@ -148,7 +152,7 @@ export function useOsdkAction<Q extends ActionDefinition<any>>(
 
         const r = await observableClient.applyAction(actionDef, args, {
           optimisticUpdate: $optimisticUpdate,
-          alsoInvalidates: $alsoInvalidates,
+          alsoInvalidates: mergeInvalidations([$alsoInvalidates]),
         });
         setData(r);
         return r;

--- a/packages/react/test/useOsdkAction.test.tsx
+++ b/packages/react/test/useOsdkAction.test.tsx
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ActionDefinition, ObjectTypeDefinition, Osdk } from "@osdk/api";
+import type { ObservableClient } from "@osdk/client/unstable-do-not-use";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import * as React from "react";
+import { beforeEach, describe, expect, it, vitest } from "vitest";
+import { OsdkContext2 } from "../src/new/OsdkContext2.js";
+import { useOsdkAction } from "../src/new/useOsdkAction.js";
+
+const MockActionDef: ActionDefinition<any> = {
+  type: "action",
+  apiName: "mockAction",
+  parameters: {},
+  modifiedEntities: {},
+  opiVersion: undefined,
+};
+
+const MockObjectType: ObjectTypeDefinition = {
+  type: "object",
+  apiName: "MockObject",
+  primaryKeyApiName: "id",
+  primaryKeyType: "string",
+  properties: {},
+  links: {},
+};
+
+const AnotherObjectType: ObjectTypeDefinition = {
+  type: "object",
+  apiName: "AnotherObject",
+  primaryKeyApiName: "id",
+  primaryKeyType: "string",
+  properties: {},
+  links: {},
+};
+
+describe("useOsdkAction", () => {
+  const mockApplyAction = vitest.fn();
+  const mockValidateAction = vitest.fn();
+
+  const createWrapper = () => {
+    const observableClient: Partial<ObservableClient> = {
+      applyAction: mockApplyAction,
+      validateAction: mockValidateAction,
+    };
+
+    return ({ children }: React.PropsWithChildren) => (
+      <OsdkContext2.Provider
+        value={{ observableClient: observableClient as ObservableClient }}
+      >
+        {children}
+      </OsdkContext2.Provider>
+    );
+  };
+
+  beforeEach(() => {
+    mockApplyAction.mockClear();
+    mockValidateAction.mockClear();
+    mockApplyAction.mockResolvedValue({ type: "edits" });
+    mockValidateAction.mockResolvedValue({ result: "VALID" });
+  });
+
+  it("should call applyAction with $alsoInvalidates for single call", async () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(() => useOsdkAction(MockActionDef), {
+      wrapper,
+    });
+
+    const mockObject: Osdk.Instance<ObjectTypeDefinition> = {
+      $apiName: "MockObject",
+      $primaryKey: "pk-123",
+      $objectType: "MockObject",
+      $title: "Mock Object",
+    };
+
+    await act(async () => {
+      await result.current.applyAction({
+        someParam: "value",
+        $alsoInvalidates: {
+          objectTypes: [MockObjectType],
+          objects: [mockObject],
+        },
+      });
+    });
+
+    expect(mockApplyAction).toHaveBeenCalledTimes(1);
+    expect(mockApplyAction).toHaveBeenCalledWith(
+      MockActionDef,
+      { someParam: "value" },
+      expect.objectContaining({
+        alsoInvalidates: {
+          objectTypes: [MockObjectType],
+          objects: [mockObject],
+        },
+      }),
+    );
+  });
+
+  it("should call applyAction with $alsoInvalidates using string api name", async () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(() => useOsdkAction(MockActionDef), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.applyAction({
+        someParam: "value",
+        $alsoInvalidates: {
+          objectTypes: ["MockObject", "AnotherObject"],
+        },
+      });
+    });
+
+    expect(mockApplyAction).toHaveBeenCalledTimes(1);
+    expect(mockApplyAction).toHaveBeenCalledWith(
+      MockActionDef,
+      { someParam: "value" },
+      expect.objectContaining({
+        alsoInvalidates: {
+          objectTypes: ["MockObject", "AnotherObject"],
+        },
+      }),
+    );
+  });
+
+  it("should merge $alsoInvalidates for batch calls", async () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(() => useOsdkAction(MockActionDef), {
+      wrapper,
+    });
+
+    const mockObject1: Osdk.Instance<ObjectTypeDefinition> = {
+      $apiName: "MockObject",
+      $primaryKey: "pk-1",
+      $objectType: "MockObject",
+      $title: "Object 1",
+    };
+
+    const mockObject2: Osdk.Instance<ObjectTypeDefinition> = {
+      $apiName: "MockObject",
+      $primaryKey: "pk-2",
+      $objectType: "MockObject",
+      $title: "Object 2",
+    };
+
+    await act(async () => {
+      await result.current.applyAction([
+        {
+          someParam: "value1",
+          $alsoInvalidates: {
+            objectTypes: [MockObjectType],
+            objects: [mockObject1],
+          },
+        },
+        {
+          someParam: "value2",
+          $alsoInvalidates: {
+            objectTypes: [AnotherObjectType],
+            objects: [mockObject2],
+          },
+        },
+      ]);
+    });
+
+    expect(mockApplyAction).toHaveBeenCalledTimes(1);
+    expect(mockApplyAction).toHaveBeenCalledWith(
+      MockActionDef,
+      [{ someParam: "value1" }, { someParam: "value2" }],
+      expect.objectContaining({
+        alsoInvalidates: {
+          objectTypes: [MockObjectType, AnotherObjectType],
+          objects: [mockObject1, mockObject2],
+        },
+      }),
+    );
+  });
+
+  it("should not include alsoInvalidates when not provided", async () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(() => useOsdkAction(MockActionDef), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.applyAction({ someParam: "value" });
+    });
+
+    expect(mockApplyAction).toHaveBeenCalledTimes(1);
+    expect(mockApplyAction).toHaveBeenCalledWith(
+      MockActionDef,
+      { someParam: "value" },
+      expect.objectContaining({
+        alsoInvalidates: undefined,
+      }),
+    );
+  });
+
+  it("should return undefined for merged alsoInvalidates when batch has no invalidations", async () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(() => useOsdkAction(MockActionDef), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.applyAction([
+        { someParam: "value1" },
+        { someParam: "value2" },
+      ]);
+    });
+
+    expect(mockApplyAction).toHaveBeenCalledTimes(1);
+    expect(mockApplyAction).toHaveBeenCalledWith(
+      MockActionDef,
+      [{ someParam: "value1" }, { someParam: "value2" }],
+      expect.objectContaining({
+        alsoInvalidates: undefined,
+      }),
+    );
+  });
+
+  it("should set isPending while action is in progress", async () => {
+    const wrapper = createWrapper();
+
+    let resolveAction: (value: unknown) => void;
+    mockApplyAction.mockImplementation(
+      () =>
+        new Promise(resolve => {
+          resolveAction = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() => useOsdkAction(MockActionDef), {
+      wrapper,
+    });
+
+    expect(result.current.isPending).toBe(false);
+
+    let actionPromise: Promise<unknown>;
+    act(() => {
+      actionPromise = result.current.applyAction({ someParam: "value" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(true);
+    });
+
+    await act(async () => {
+      resolveAction!({ type: "edits" });
+      await actionPromise;
+    });
+
+    expect(result.current.isPending).toBe(false);
+  });
+});

--- a/packages/react/test/useOsdkAction.test.tsx
+++ b/packages/react/test/useOsdkAction.test.tsx
@@ -237,6 +237,32 @@ describe("useOsdkAction", () => {
     );
   });
 
+  it("should omit empty arrays from alsoInvalidates", async () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(() => useOsdkAction(MockActionDef), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.applyAction({
+        someParam: "value",
+        $alsoInvalidates: {
+          objectTypes: [MockObjectType],
+          objects: [],
+        },
+      });
+    });
+
+    expect(mockApplyAction).toHaveBeenCalledTimes(1);
+    const callArgs = mockApplyAction.mock.calls[0];
+    const options = callArgs[2];
+    expect(options.alsoInvalidates).toEqual({
+      objectTypes: [MockObjectType],
+    });
+    expect(options.alsoInvalidates).not.toHaveProperty("objects");
+  });
+
   it("should set isPending while action is in progress", async () => {
     const wrapper = createWrapper();
 


### PR DESCRIPTION
queries with derived properties weren't revalidating when their pivot targets changed

• precompute rdp dependencies at query creation and check them during invalidation
• rename alsoInvalidates to dependsOn/dependsOnObjects to match useOsdkFunction
• wire up dependsOn in useOsdkAction hook