### PR TITLE
fix @osdk/react missing foundry.admin and foundry.core dependencies

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -53,9 +53,19 @@
   "peerDependencies": {
     "@osdk/api": "*",
     "@osdk/client": "*",
+    "@osdk/foundry.admin": "*",
+    "@osdk/foundry.core": "*",
     "@types/react": "^17 || ^18 || ^19",
     "react": "^17 || ^18 || ^19",
     "react-dom": "^17 || ^18 || ^19"
+  },
+  "peerDependenciesMeta": {
+    "@osdk/foundry.admin": {
+      "optional": true
+    },
+    "@osdk/foundry.core": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@osdk/api": "workspace:*",


### PR DESCRIPTION
fix @osdk/react missing foundry.admin and foundry.core dependencies

these packages were listed as devDependencies but are imported by the experimental
platform api hooks (useCurrentFoundryUser, useFoundryUser, useFoundryUsersList).
devDependencies are not installed for consumers, so the imports failed at runtime.

moved them to optional peerDependencies so consumers know to install them when using
the experimental foundry user hooks.