### PR TITLE
Fix field name mismatch: change requireImplementation to required

### DIFF
--- a/packages/maker/src/conversion/toMarketplace/convertInterfacePropertyType.ts
+++ b/packages/maker/src/conversion/toMarketplace/convertInterfacePropertyType.ts
@@ -31,7 +31,7 @@ export function convertInterfaceProperty(
     return [prop.sharedPropertyType.apiName, {
       type: "sharedPropertyBasedPropertyType",
       sharedPropertyBasedPropertyType: {
-        requireImplementation: prop.required,
+        required: prop.required,
         sharedPropertyType: convertSpt(prop.sharedPropertyType),
       },
     }];
@@ -55,7 +55,7 @@ export function convertInterfaceProperty(
           : propertyTypeTypeToOntologyIrInterfaceType(prop.type),
         constraints: {
           primaryKeyConstraint: prop.primaryKeyConstraint ?? "NO_RESTRICTION",
-          requireImplementation: prop.required ?? true,
+          required: prop.required ?? true,
           indexedForSearch: true,
           typeClasses: prop.typeClasses ?? [],
           dataConstraints: convertNullabilityToDataConstraint({


### PR DESCRIPTION
## Summary
Fixes compatibility issue with foundry-as-code-gradle 0.267.0 which expects 'required' field instead of 'requireImplementation' in OntologyIrInterfaceSharedPropertyType.

This fixes the error 'Error resolving implemented interface property types' when generating block sets.

## Changes
- Line 34: Changed requireImplementation to required in sharedPropertyBasedPropertyType
- Line 58: Changed requireImplementation to required in interfaceDefinedPropertyType constraints

## Test plan
- [x] Verified the change fixes the build error in defense-ontology repo
- [x] Confirmed the field name matches what foundry-as-code-gradle 0.267.0 expects

## Related
This is needed for defense-ontology to work with foundry-as-code-gradle 0.267.0 and @osdk/maker 0.15.0-beta.9+