### PR TITLE
Fix RC releases on release branches

### DIFF
--- a/packages/tool.release/src/mutateReleasePlan.test.ts
+++ b/packages/tool.release/src/mutateReleasePlan.test.ts
@@ -203,5 +203,65 @@ describe(mutateReleasePlan, () => {
         ]
       `);
     });
+    it("allows minor bump to prerelease with patch 0", () => {
+      const plan: ReleasePlan = {
+        changesets: [
+          {
+            id: "rc-minor",
+            releases: [
+              { name: "foo", type: "minor" },
+            ],
+            summary: "foo summary",
+          },
+        ],
+        preState: undefined,
+        releases: [
+          {
+            changesets: ["rc-minor"],
+            oldVersion: "2.1.0",
+            newVersion: "2.2.0-rc.0",
+            name: "foo",
+            type: "minor",
+          },
+        ],
+      };
+
+      mutateReleasePlan("/faux/cwd", plan, "release branch");
+    });
+    it("disallows minor bump to prerelease with non-zero patch", () => {
+      const plan: ReleasePlan = {
+        changesets: [
+          {
+            id: "rc-minor",
+            releases: [
+              { name: "foo", type: "minor" },
+            ],
+            summary: "foo summary",
+          },
+        ],
+        preState: undefined,
+        releases: [
+          {
+            changesets: ["rc-minor"],
+            oldVersion: "2.1.0",
+            newVersion: "2.2.1-rc.0",
+            name: "foo",
+            type: "minor",
+          },
+        ],
+      };
+
+      expect(() => {
+        mutateReleasePlan("/faux/cwd", plan, "release branch");
+      }).toThrowErrorMatchingInlineSnapshot(`
+        [FailedWithUserMessage: Unable to create a release for the stable branch.
+
+        Our branching model requires that we only release patch changes on a stable branch to avoid version number collisions with main and the other release branches. Problems:
+
+        .changeset/rc-minor.md:
+          - foo: minor
+        ]
+      `);
+    });
   });
 });

--- a/packages/tool.release/src/mutateReleasePlan.ts
+++ b/packages/tool.release/src/mutateReleasePlan.ts
@@ -36,6 +36,16 @@ function isFirstMinorRelease(oldVersion: string, newVersion: string): boolean {
   );
 }
 
+function isPrereleaseWithPatchZero(newVersion: string): boolean {
+  const newSemver = parse(newVersion);
+  if (newSemver == null) {
+    throw new FailedWithUserMessage(
+      `Invalid version: ${newVersion}`,
+    );
+  }
+  return newSemver.prerelease.length > 0 && newSemver.patch === 0;
+}
+
 /**
  * Checks that a release for a given changeset is valid.
  * @param releasePlan The entire release plan
@@ -61,7 +71,8 @@ function isPatchVersionOrFirstMinorRelease(
       );
     }
     const release = matchingReleases[0];
-    return isFirstMinorRelease(release.oldVersion, release.newVersion);
+    return isFirstMinorRelease(release.oldVersion, release.newVersion)
+      || isPrereleaseWithPatchZero(release.newVersion);
   }
   return false;
 }


### PR DESCRIPTION
Allow minor bumps when releasing prereleases with patch version 0.