### PR TITLE
add new cspell checker prepush hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,15 +4,3 @@ if [ "$(git config user.email)" = "checkpoint@cline.bot" ]; then
 fi
 
 TERM=dumb npx lint-staged
-
-# Run full cspell check to catch violations in generated files that lint-staged excludes
-echo "Running cspell check..."
-pnpm cspell:all
-if [ $? -ne 0 ]; then
-  echo ""
-  echo "cspell found spelling errors. Either:"
-  echo "  1. Fix the typo"
-  echo "  2. Add the word to a dictionary file in packages/monorepo.cspell/"
-  echo "  3. Add a cspell:ignore comment above the line"
-  exit 1
-fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,11 @@
+# Run full cspell check before pushing to catch violations that would fail CI
+echo "Running cspell check..."
+pnpm cspell:all
+if [ $? -ne 0 ]; then
+  echo ""
+  echo "cspell found spelling errors. Either:"
+  echo "  1. Fix the typo"
+  echo "  2. Add the word to a dictionary file in packages/monorepo.cspell/"
+  echo "  3. Add a cspell:ignore comment above the line"
+  exit 1
+fi


### PR DESCRIPTION
Adds a new cspell checker prepush hook.

Example: Successful commit (no violations)
$ git push
Running cspell check...


Example: Failed commit (cspell violation)
$ git push
Running cspell check...

> workspace-root@ cspell:all /Users/ksethi/projects/osdk-ts-main
> cspell . --quiet

packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/MwaltherPersonOt.ts:122:49 - Unknown word (IDPS)

cspell found spelling errors. Either:
  1. Fix the typo
  2. Add the word to a dictionary file in packages/monorepo.cspell/
  3. Add a cspell:ignore comment above the line

The git push would be blocked until you either fix the spelling, add the word to a dictionary file (like packages/monorepo.cspell/dict.wire-api-words.txt), or add a // cspell:ignore IDPS comment.