### PR TITLE
improve login and move it to stable

### DIFF
--- a/.changeset/easy-ideas-ring.md
+++ b/.changeset/easy-ideas-ring.md
@@ -1,0 +1,6 @@
+---
+"@osdk/cli.common": patch
+"@osdk/cli": patch
+---
+
+move auth login to stable args and improve login flow

--- a/packages/cli.common/src/commands/auth/login/loginFlow.ts
+++ b/packages/cli.common/src/commands/auth/login/loginFlow.ts
@@ -22,6 +22,7 @@ import { exit } from "node:process";
 import { parse } from "node:url";
 import open from "open";
 import type { LoginArgs } from "./LoginArgs.js";
+import { successTemplate } from "./successTemplate.js";
 import type { TokenResponse, TokenSuccessResponse } from "./token.js";
 import { isTokenErrorResponse } from "./token.js";
 
@@ -40,7 +41,8 @@ export async function invokeLoginFlow(
 
   const server = createServer((req, res) => {
     const query = parse(req.url!, true).query;
-    res.end("Authenticated");
+    res.writeHead(200, { "Content-Type": "text/html" });
+    res.end(successTemplate);
     resolve(query["code"] as string);
   });
 

--- a/packages/cli.common/src/commands/auth/login/successTemplate.ts
+++ b/packages/cli.common/src/commands/auth/login/successTemplate.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const successTemplate = `
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Authentication Successful</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        min-height: 100vh;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+        background: #000000;
+      }
+      .container {
+        text-align: center;
+        padding: 3rem;
+        background: #1a1a1a;
+        border-radius: 0.5rem;
+        border: 1px solid #2d2d2d;
+        max-width: 500px;
+      }
+      h1 {
+        color: #ffffff;
+        margin: 0 0 1rem 0;
+        font-size: 1.75rem;
+        font-weight: 600;
+      }
+      p {
+        color: #a0a0a0;
+        font-size: 1rem;
+        margin: 0;
+        line-height: 1.6;
+      }
+      .icon {
+        font-size: 3rem;
+        margin-bottom: 1.5rem;
+        color: #00d4aa;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="icon">✓</div>
+      <h1>Authentication Successful</h1>
+      <p>You can now close this tab and return to the terminal.</p>
+    </div>
+  </body>
+</html>
+`;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -37,6 +37,7 @@ export async function cli(args: string[] = process.argv): Promise<
     return await base
       .command(site)
       .command(widgetSet)
+      .command(auth)
       .command({
         command: "unstable",
         aliases: ["experimental"],
@@ -44,7 +45,6 @@ export async function cli(args: string[] = process.argv): Promise<
         builder: (argv) => {
           return argv
             .command(typescript)
-            .command(auth)
             .demandCommand();
         },
         handler: (_args) => {},

--- a/packages/cli/src/commands/auth/login/index.ts
+++ b/packages/cli/src/commands/auth/login/index.ts
@@ -34,7 +34,11 @@ export const command: CommandModule<
   },
   handler: async (args) => {
     const command = await import("@osdk/cli.common/loginFlow");
-    await command.default(args);
+    const tokenResponse = await command.default(args);
+
+    // Print access token to stdout for capturing in scripts
+    // eslint-disable-next-line no-console
+    console.log(tokenResponse.access_token);
   },
 };
 


### PR DESCRIPTION
This PR moves the auth login to stable and print out the token so it can be used in downstream commands. 

```
export FOUNDRY_TOKEN=$(npx @osdk/cli unstable auth \
  --foundryUrl "https://example.palantirfoundry.com" \
  login \
  --clientId "dc2f997f34b4d256f03d2adf9f49a4ab")

claude mcp add tutorial-todo-app \
  -t http \
  -H "Authorization: Bearer $FOUNDRY_TOKEN" \
  -- https://example.palantirfoundry.com/mcp/third-party-application/ri.third-party-applications.main.application.74af02e1-7784-4feb-b366-1b4fb6c0804b
```

https://github.com/user-attachments/assets/ec304bc4-9d7e-4d50-b118-8a39ef0eea7c


