### PR TITLE
update pre push hook to only spellcheck changed files

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,7 +1,27 @@
-# Run full cspell check before pushing to catch violations that would fail CI
-echo "Running cspell check..."
-pnpm cspell:all
-if [ $? -ne 0 ]; then
+# Run cspell check on changed files before pushing
+REMOTE_REF=$(git merge-base HEAD @{upstream} 2>/dev/null || true)
+
+if [ -z "$REMOTE_REF" ]; then
+  REMOTE_REF=$(git merge-base HEAD main 2>/dev/null || true)
+fi
+
+CSPELL_EXIT=0
+if [ -z "$REMOTE_REF" ]; then
+  echo "Could not determine base ref, running full cspell check..."
+  pnpm cspell:all
+  CSPELL_EXIT=$?
+else
+  FILECOUNT=$(git diff --name-only --diff-filter=ACMR "$REMOTE_REF" HEAD | wc -l)
+  if [ "$FILECOUNT" -eq 0 ]; then
+    echo "No changed files to spellcheck."
+    exit 0
+  fi
+  echo "Running cspell on changed files..."
+  git diff --name-only --diff-filter=ACMR -z "$REMOTE_REF" HEAD | xargs -0 pnpm exec cspell
+  CSPELL_EXIT=$?
+fi
+
+if [ "$CSPELL_EXIT" -ne 0 ]; then
   echo ""
   echo "cspell found spelling errors. Either:"
   echo "  1. Fix the typo"

--- a/packages/monorepo.cspell/dict.normal-dev-words.txt
+++ b/packages/monorepo.cspell/dict.normal-dev-words.txt
@@ -44,3 +44,4 @@ unioned
 unresolve
 Unsubscribable
 webapi
+ACMR


### PR DESCRIPTION
the pre-push hook was running cspell against all local files including those not staged to be pushed. This PR scopes cspell to only files changed on the branch vs upstream or main


