### PR TITLE
feat: add document-component agent skill (1/3)

### DIFF
--- a/.claude/skills/document-component/README.md
+++ b/.claude/skills/document-component/README.md
@@ -1,0 +1,159 @@
+# document-component Skill
+
+Automatically generates comprehensive documentation for React components, hooks, and utilities in the osdk-ts project.
+
+## Usage
+
+Invoke the skill with the component name or file path:
+
+```bash
+/document-component useLinks
+/document-component useOsdkAggregation
+/document-component packages/react/src/new/useObjectSet.tsx
+/document-component createMinimalClient
+```
+
+## What It Does
+
+The skill will:
+
+1. **Read the source code** to understand parameters, return values, and behavior
+2. **Check for existing documentation** to maintain consistency
+3. **Generate or update documentation** following Docusaurus conventions:
+   - Frontmatter with sidebar position
+   - Clear basic usage examples
+   - Parameters and return value tables
+   - Multiple usage examples (simple → advanced)
+   - Best practices with do's and don'ts
+   - Troubleshooting section
+   - Related documentation links
+
+4. **Optionally add interactive examples** to the doc app (for visual components):
+   - Following shadcn/ui's "show, don't tell" approach
+   - Live demos that users can interact with
+   - Code examples with copy buttons
+   - Progressive disclosure from simple to advanced
+   - Located at [examples-extra/docs_example](../../examples-extra/docs_example)
+
+5. **Update the component registry** at `docs/component-registry.json`:
+   - Machine-readable JSON registry for LLM discovery
+   - Includes metadata, import paths, usage examples
+   - Enables LLMs to understand all available components
+   - Tracks relationships and dependencies
+
+6. **Follow project conventions** from [CLAUDE.md](../../CLAUDE.md):
+   - TypeScript/ESM syntax
+   - Never use `any`
+   - React hooks best practices (no conditional calls)
+   - Keep components rendering during loading states
+
+## Output Location
+
+Documentation is created in:
+- React hooks: `/docs/react/[topic].md`
+- Client APIs: `/docs/client/[topic].md`
+- General guides: `/docs/guides/[topic].md`
+
+Code examples in the documentation demonstrate components using the **doc app** located at [examples-extra/docs_example](../../examples-extra/docs_example). This is a living example application that showcases OSDK React components and patterns in a real-world context.
+
+## Documentation Style
+
+The skill follows these patterns:
+
+### Structure
+1. Title and brief description
+2. Stability status (Stable/Experimental/Beta)
+3. Basic usage with simple example
+4. Parameters table
+5. Return value documentation
+6. Multiple examples covering common cases
+7. Advanced usage patterns
+8. Best practices with callouts
+9. Troubleshooting common issues
+10. Related documentation links
+
+### Code Examples
+- TypeScript with TSX syntax
+- Full imports shown
+- Realistic use cases (not toy examples)
+- Both simple and advanced patterns
+- Comments explaining non-obvious code
+
+### Callouts
+- `:::info` - Stability, version notes
+- `:::warning` - Anti-patterns, gotchas
+- `:::tip` - Best practices, recommendations
+- `:::note` - Additional context
+
+## Component Registry
+
+The skill automatically maintains a **machine-readable component registry** at `docs/component-registry.json`.
+
+### Why a Registry?
+
+LLMs can use this registry to:
+- **Discover** all available components, hooks, and utilities
+- **Understand** parameters, return types, and usage patterns
+- **Navigate** relationships between components
+- **Search** by tags, categories, or functionality
+- **Reference** correct import paths and stability levels
+
+### Registry Format
+
+See [registry-schema.json](registry-schema.json) for the complete JSON schema.
+
+Example entry:
+
+```json
+{
+  "name": "useOsdkObjects",
+  "type": "hook",
+  "package": "@osdk/react",
+  "importPath": "@osdk/react/experimental",
+  "stability": "experimental",
+  "description": "Retrieve and observe collections of objects with automatic cache management",
+  "docPath": "docs/react/querying-data.md#useosdkobjects",
+  "sourcePath": "packages/react/src/new/useOsdkObjects.ts",
+  "category": "queries",
+  "tags": ["query", "collection", "caching"],
+  "usageExample": "const { data } = useOsdkObjects(Todo);",
+  "parameters": [...],
+  "returnValue": {...},
+  "relatedComponents": ["useOsdkObject"],
+  "requires": ["OsdkProvider2"]
+}
+```
+
+See [registry-example.json](registry-example.json) for a complete example with multiple components.
+
+## Supporting Files
+
+- **[SKILL.md](SKILL.md)** - Main skill instructions (what Claude sees)
+- **[reference.md](reference.md)** - Detailed patterns and formatting guide
+- **[examples.md](examples.md)** - Sample documentation for different component types
+- **[registry-schema.json](registry-schema.json)** - JSON schema for the component registry
+- **[registry-example.json](registry-example.json)** - Example registry with documented components
+
+## Examples
+
+See [examples.md](examples.md) for complete documentation samples:
+- React hook documentation (useOsdkObject)
+- Provider component documentation (OsdkProvider2)
+- Utility function documentation (createClient)
+
+## When to Use
+
+Use this skill when you need to:
+- Document a new component or hook
+- Update existing documentation for consistency
+- Create docs for undocumented features
+- Generate API reference documentation
+
+## Next Steps
+
+After generating documentation:
+1. Review the generated content for accuracy
+2. Add any project-specific context or examples
+3. Test code examples to ensure they work
+4. Add links to/from related documentation
+5. Update sidebar position if needed

--- a/.claude/skills/document-component/SKILL.md
+++ b/.claude/skills/document-component/SKILL.md
@@ -1,0 +1,343 @@
+---
+name: document-component
+description: Documents React components, hooks, or client utilities in osdk-ts following project conventions. Use when asked to create or update documentation for components.
+allowed-tools: Read, Grep, Glob, Write, Edit
+argument-hint: [component-name or file-path]
+---
+
+# Document Component Skill
+
+Generate comprehensive documentation for osdk-ts components following the project's Docusaurus conventions.
+
+## Your Task
+
+Document the component/hook/utility specified in: **$ARGUMENTS**
+
+## Documentation Location
+
+- React hooks: `docs/react/[topic].md`
+- Client APIs: `docs/client/[topic].md`
+- General guides: `docs/guides/[topic].md`
+
+**Important:** Code examples should demonstrate components using the **doc app** at `examples-extra/docs_example`. This is a living example application that showcases OSDK components in real-world usage.
+
+## Process
+
+### 1. Read the Source Code
+- Locate the component/hook file
+- Read the implementation to understand:
+  - Parameters and their types
+  - Return values and structure
+  - Key behaviors and state management
+  - Dependencies and context requirements
+
+### 2. Check for Existing Documentation
+- Look in `docs/` for existing docs on this component
+- Check if the component is mentioned in other docs
+- Review related documentation for style consistency
+
+### 3. Generate Documentation
+
+Follow this structure (see [reference.md](reference.md) for detailed patterns):
+
+```markdown
+---
+sidebar_position: [number]
+---
+
+# [Component/Hook Name]
+
+Brief description (1-2 sentences) of what it does and when to use it.
+
+:::info Stability
+[Stable/Experimental/Beta] - Note the package export location
+:::
+
+## Basic Usage
+
+```tsx
+// Simple, clear example showing the most common use case
+import { useExampleHook } from "@osdk/react/experimental";
+
+function MyComponent() {
+  const { data, isLoading } = useExampleHook(params);
+
+  return <div>{data}</div>;
+}
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `param1` | `Type` | Yes | What it does |
+| `param2` | `Type` | No | What it does (default: value) |
+
+## Return Value
+
+The hook returns an object with:
+
+- `data` - The result data
+- `isLoading` - Loading state indicator
+- `error` - Error object if request failed
+- `refetch` - Function to manually refetch
+
+## Examples
+
+### [Common Use Case 1]
+
+```tsx
+// Example with explanation
+```
+
+### [Common Use Case 2]
+
+```tsx
+// Example with explanation
+```
+
+## Advanced Usage
+
+### [Advanced Pattern 1]
+
+Explanation...
+
+```tsx
+// Code example
+```
+
+## Best Practices
+
+:::tip
+✓ DO: Follow this pattern...
+:::
+
+:::warning
+✗ DON'T: Avoid this anti-pattern...
+:::
+
+## Troubleshooting
+
+### Common Issue 1
+
+**Problem:** Description of the issue
+
+**Solution:** How to fix it
+
+```tsx
+// Fixed code example
+```
+
+## Related
+
+- [Related Doc](./related-doc.md)
+- [Another Related Doc](./another-doc.md)
+```
+
+### 4. Include Real Examples
+- **Prefer examples from the doc app** at `examples-extra/docs_example`
+- This app demonstrates OSDK components in a real application context
+- Search for usage in `examples/` or test files as alternatives
+- Use actual code from the codebase when possible
+- Show both simple and advanced patterns
+
+### 5. Follow Project Conventions
+
+**From CLAUDE.md:**
+- This is a TypeScript/ESM project
+- Never use `any` without justification
+- For React hooks: NEVER conditionally call hooks
+- For React components: Keep components rendering during loading/error states
+- This project uses pnpm (not npm)
+
+**Documentation Style:**
+- Use Docusaurus frontmatter with `sidebar_position`
+- Use `:::info`, `:::warning`, `:::tip` callouts
+- Include code examples inline
+- Document return values as bullet lists
+- Progressive disclosure: simple → advanced
+- Include troubleshooting section
+- Cross-reference related docs
+
+### 6. Validate
+- Ensure all code examples are TypeScript
+- Check that import paths are correct
+- Verify the component/hook actually exports what you document
+- Make sure examples follow React best practices from CLAUDE.md
+
+### 7. Handle Errors and Edge Cases
+If you encounter issues during documentation:
+
+**Source file not found:**
+- Search the codebase with Glob/Grep to locate the file
+- Check if the component was renamed or moved
+- Ask the user for clarification if you cannot locate it
+
+**Missing or incomplete TypeScript types:**
+- Document what you can determine from the source
+- Note in the documentation that types may be incomplete
+- Suggest to the user that types should be improved
+
+**Existing docs conflict with source code:**
+- Prioritize the source code as the source of truth
+- Update existing documentation to match the current implementation
+- Add a note about what changed if it's a significant breaking change
+
+## Output
+
+### Documentation File
+Create or update the documentation file in the appropriate location. If updating existing docs, use the Edit tool to preserve the structure.
+
+### Component Registry
+After creating/updating documentation, **update or create the component registry** at:
+`docs/component-registry.json`
+
+This registry allows LLMs to discover and understand all documented components. See [registry-example.json](registry-example.json) for the structure.
+
+**Important:** After updating the registry, validate it against [registry-schema.json](registry-schema.json) to ensure correctness. The registry must be valid JSON that conforms to the schema.
+
+For each documented component, add or update its registry entry with:
+
+```json
+{
+  "name": "useOsdkObjects",
+  "type": "hook",
+  "package": "@osdk/react",
+  "importPath": "@osdk/react/experimental",
+  "stability": "experimental",
+  "description": "Brief description",
+  "docPath": "docs/react/querying-data.md#useosdkobjects",
+  "sourcePath": "packages/react/src/new/useOsdkObjects.ts",
+  "category": "queries",
+  "tags": ["query", "collection", "caching"],
+  "usageExample": "const { data } = useOsdkObjects(Todo);",
+  "parameters": [
+    {
+      "name": "objectType",
+      "type": "OsdkObjectType<T>",
+      "required": true,
+      "description": "The object type to query"
+    }
+  ],
+  "returnValue": {
+    "type": "UseOsdkListResult<T>",
+    "description": "Object with data, isLoading, error, fetchMore"
+  },
+  "relatedComponents": ["useOsdkObject", "useObjectSet"],
+  "requires": ["OsdkProvider2"]
+}
+```
+
+**Registry Fields:**
+- `name` - Component/hook name
+- `type` - One of: hook, component, provider, utility, function
+- `package` - NPM package (e.g., "@osdk/react")
+- `importPath` - Full import path
+- `stability` - stable, experimental, beta, deprecated
+- `description` - Brief description
+- `docPath` - Relative path to documentation
+- `sourcePath` - Relative path to source file
+- `category` - Group (queries, actions, setup, platform-apis)
+- `tags` - Searchable keywords
+- `usageExample` - One-line code example
+- `parameters` - Array of parameter objects
+- `returnValue` - Type and description
+- `relatedComponents` - Array of related component names
+- `requires` - Array of dependencies (e.g., ["OsdkProvider2"])
+
+### Doc App Integration
+
+Following shadcn/ui's approach, consider adding an **interactive live example** to the doc app at `examples-extra/docs_example/src/App.tsx`.
+
+**When doc app integration is REQUIRED:**
+- Visual components (tables, dialogs, forms, etc.) - users need to see them in action
+- Complex components with multiple states or variants
+- Components marked as stable (not experimental)
+
+**When doc app integration is OPTIONAL:**
+- Simple hooks without visual output
+- Utility functions or helpers
+- Low-level APIs that are building blocks for other components
+- Experimental features still under development
+
+**When to skip doc app integration:**
+- Internal/private APIs not meant for external use
+- Deprecated components
+
+**Pattern to follow (inspired by shadcn):**
+
+1. **Add navigation item** to the doc app's navigation structure
+2. **Create page component** with these sections in order:
+   - **Title & description** - What the component does
+   - **Live demo first** - Working example users can interact with
+   - **Installation section** - Import statement with copy button
+   - **Props/API table** - Structured documentation
+   - **Multiple examples** - Variations (sizes, states, etc.)
+3. **Use real data** - Connect to actual OSDK objects (like Employee)
+4. **Add code blocks** - Show source with copy buttons
+
+**Example structure:**
+```tsx
+function ObjectTablePage() {
+  return (
+    <div className="space-y-8">
+      {/* Title & Description */}
+      <div>
+        <h1>Object Table</h1>
+        <p>A high-scale table component...</p>
+      </div>
+
+      {/* Installation */}
+      <div>
+        <h2>Installation</h2>
+        <CodeBlock code={`import { ObjectTable } from "@osdk/react-components/experimental";`} />
+      </div>
+
+      {/* Live Demo */}
+      <div>
+        <h2>Live Preview</h2>
+        <div className="border rounded-lg" style={{ height: "500px" }}>
+          <ObjectTable objectType={Employee} />
+        </div>
+      </div>
+
+      {/* Props Table */}
+      <div>
+        <h2>Props / API</h2>
+        <PropsTable props={objectTableProps} />
+      </div>
+
+      {/* Examples */}
+      <div>
+        <h2>Usage Examples</h2>
+        <h3>Basic Usage</h3>
+        <CodeBlock code={`<ObjectTable objectType={Employee} />`} />
+      </div>
+    </div>
+  );
+}
+```
+
+**Key principles from shadcn:**
+- Show, don't just tell - live demo comes early
+- Interactive before technical - let users see it working
+- Progressive disclosure - basic → advanced examples
+- Copy-paste ready - all code has copy buttons
+
+**After adding to doc app:**
+- Update the navigation array to include the new page
+- Test that the live component works with real data
+- Ensure the doc app still builds and runs
+
+### Summary
+After documenting, provide a summary showing:
+1. What was documented
+2. Where the file was created/updated
+3. Registry entry added/updated
+4. Whether interactive example was added to doc app
+5. Key features highlighted
+6. Any gaps or questions that remain
+
+## Examples
+
+See [examples.md](examples.md) for sample documentation outputs and [registry-example.json](registry-example.json) for registry structure.

--- a/.claude/skills/document-component/examples.md
+++ b/.claude/skills/document-component/examples.md
@@ -1,0 +1,707 @@
+# Documentation Examples
+
+This file shows complete documentation examples for different types of components.
+
+## Example 1: React Hook Documentation
+
+This shows how to document a React hook like `useOsdkObject`.
+
+---
+
+````markdown
+---
+sidebar_position: 3
+---
+
+# useOsdkObject
+
+Fetch and observe a single object by its primary key with automatic cache management and real-time updates.
+
+*Experimental - import from `@osdk/react/experimental`*
+
+## Basic Usage
+
+```tsx
+import { Employee } from "@my/osdk";
+import { useOsdkObject } from "@osdk/react/experimental";
+
+function EmployeeProfile({ employeeId }: { employeeId: string }) {
+  const { data, isLoading, error } = useOsdkObject(Employee, employeeId);
+
+  if (!data && isLoading) {
+    return <div>Loading employee...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  return (
+    <div>
+      <h1>{data.fullName}</h1>
+      <p>Email: {data.email}</p>
+      <p>Department: {data.department}</p>
+    </div>
+  );
+}
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `objectType` | `OsdkObjectType<T>` | Yes | The object type (from your generated SDK) |
+| `primaryKey` | `string \| number` | Yes | The primary key of the object to fetch |
+| `options` | `UseOsdkObjectOptions` | No | Additional query options |
+
+### Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `enabled` | `boolean` | Whether to execute the query (default: true) |
+| `select` | `string[]` | Specific properties to fetch (fetches all by default) |
+
+## Return Value
+
+The hook returns an object with:
+
+- `data` - The fetched object (undefined while initially loading)
+- `isLoading` - True while fetching from server
+- `isOptimistic` - True if the object has pending optimistic updates
+- `error` - Error object if fetch failed
+- `refetch` - Function to manually refetch the object
+
+## Examples
+
+### Conditional Fetching
+
+Only fetch when a primary key is available:
+
+```tsx
+function UserProfile({ userId }: { userId: string | null }) {
+  const { data: user } = useOsdkObject(User, userId ?? "", {
+    enabled: userId !== null,
+  });
+
+  if (!userId) {
+    return <div>Select a user to view profile</div>;
+  }
+
+  return <div>{user?.name}</div>;
+}
+```
+
+### Selecting Specific Properties
+
+Fetch only the properties you need:
+
+```tsx
+const { data: employee } = useOsdkObject(Employee, employeeId, {
+  select: ["fullName", "email", "department"],
+});
+
+// Only these properties are available on `employee`
+console.log(employee?.fullName, employee?.email);
+```
+
+### Manual Refetching
+
+```tsx
+function ProductDetail({ productId }: { productId: string }) {
+  const { data: product, refetch, isLoading } = useOsdkObject(
+    Product,
+    productId,
+  );
+
+  return (
+    <div>
+      <h1>{product?.name}</h1>
+      <button onClick={refetch} disabled={isLoading}>
+        {isLoading ? "Refreshing..." : "Refresh"}
+      </button>
+    </div>
+  );
+}
+```
+
+## Real-time Updates
+
+The hook automatically revalidates when:
+- An action modifies the object
+- The object is deleted
+- Related objects change (via links)
+
+Changes appear instantly with optimistic updates, then sync with the server.
+
+```tsx
+function EmployeeCard({ employeeId }: { employeeId: string }) {
+  const { data: employee, isOptimistic } = useOsdkObject(Employee, employeeId);
+  const { applyAction } = useOsdkAction($Actions.promoteEmployee);
+
+  const handlePromote = () => {
+    // Optimistic update happens instantly
+    applyAction({ employee });
+  };
+
+  return (
+    <div>
+      <h2>{employee.title}</h2>
+      {isOptimistic && <Badge>Saving...</Badge>}
+      <button onClick={handlePromote}>Promote</button>
+    </div>
+  );
+}
+```
+
+## Best Practices
+
+:::tip
+✓ DO: Keep components rendering during loading states
+
+```tsx
+// Show loading indicator while displaying cached data
+function Profile({ userId }: { userId: string }) {
+  const { data, isLoading } = useOsdkObject(User, userId);
+
+  return (
+    <div>
+      {isLoading && <LoadingSpinner />}
+      {data && <UserDetails user={data} />}
+    </div>
+  );
+}
+```
+:::
+
+:::warning
+✗ DON'T: Use conditional hook calls
+
+```tsx
+// WRONG - violates Rules of Hooks
+if (userId) {
+  const { data } = useOsdkObject(User, userId);
+}
+
+// CORRECT - use enabled option
+const { data } = useOsdkObject(User, userId ?? "", {
+  enabled: userId !== null,
+});
+```
+:::
+
+:::tip
+✓ DO: Use select when you only need specific properties
+
+```tsx
+// More efficient - only fetches needed properties
+const { data } = useOsdkObject(Employee, id, {
+  select: ["fullName", "email"],
+});
+```
+:::
+
+## Troubleshooting
+
+### Data is undefined after loading
+
+**Problem:** `data` remains undefined even when `isLoading` is false
+
+**Possible causes:**
+1. Object doesn't exist
+2. Object was deleted
+3. User lacks permission to view the object
+
+**Solution:** Check the `error` property for details:
+
+```tsx
+const { data, error, isLoading } = useOsdkObject(Employee, employeeId);
+
+if (!data && !isLoading) {
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+  return <div>Employee not found</div>;
+}
+```
+
+### "Cannot read property of undefined" errors
+
+**Problem:** Trying to access properties on undefined data
+
+**Solution:** Use optional chaining or check for data first:
+
+```tsx
+// Wrong - crashes if data is undefined
+<h1>{data.fullName}</h1>
+
+// Correct - safely handles undefined
+<h1>{data?.fullName ?? "Loading..."}</h1>
+
+// Or conditional rendering
+{data && <h1>{data.fullName}</h1>}
+```
+
+## Related
+
+- [useOsdkObjects](/react/querying-data#useosdkobjects) - Query collections of objects
+- [useOsdkAction](/react/actions) - Modify objects
+- [useLinks](/react/querying-data#uselinks) - Navigate object relationships
+````
+
+---
+
+## Example 2: Provider Component Documentation
+
+This shows how to document a provider component like `OsdkProvider2`.
+
+---
+
+````markdown
+---
+sidebar_position: 1
+---
+
+# OsdkProvider2
+
+Context provider that enables experimental OSDK React hooks throughout your application.
+
+*Experimental - import from `@osdk/react/experimental`*
+
+:::tip Recommended
+Use `OsdkProvider2` for new applications to access modern features like reactive queries, automatic caching, and optimistic updates.
+:::
+
+## Basic Usage
+
+```tsx
+import { OsdkProvider2 } from "@osdk/react/experimental";
+import { createClient } from "@osdk/client";
+import ReactDOM from "react-dom/client";
+
+// Create client once
+const client = createClient(
+  "https://your-stack.palantirfoundry.com",
+  () => getAuthToken(),
+);
+
+// Wrap your app
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <OsdkProvider2 client={client}>
+    <App />
+  </OsdkProvider2>,
+);
+```
+
+## Props
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `client` | `Client` | Yes | OSDK client instance from `createClient()` |
+| `children` | `ReactNode` | Yes | Your application components |
+
+## Features Enabled
+
+When wrapped in `OsdkProvider2`, components can use:
+
+- **Query Hooks**
+  - `useOsdkObjects` - Query collections
+  - `useOsdkObject` - Fetch single objects
+  - `useLinks` - Navigate relationships
+  - `useObjectSet` - Advanced set operations
+  - `useOsdkAggregation` - Server-side aggregations
+
+- **Action Hooks**
+  - `useOsdkAction` - Execute actions with validation and optimistic updates
+
+- **Function Hooks**
+  - `useOsdkFunction` - Execute OSDK functions
+
+- **Platform API Hooks**
+  - `useCurrentFoundryUser` - Get current user
+  - `useFoundryUser` - Fetch specific user
+  - `useFoundryUsersList` - Query users
+
+- **Utilities**
+  - `useOsdkClient` - Direct client access
+  - `useOsdkMetadata` - Type metadata
+  - `useDebouncedCallback` - Debouncing
+
+## Complete Setup Example
+
+```tsx
+// client.ts - Create client once
+import { createClient } from "@osdk/client";
+import { $ontologyRid } from "@my/osdk";
+
+export const client = createClient(
+  import.meta.env.VITE_FOUNDRY_URL,
+  $ontologyRid,
+  async () => {
+    // Your auth token logic
+    return localStorage.getItem("auth_token") ?? "";
+  },
+);
+
+// main.tsx - Setup provider
+import { OsdkProvider2 } from "@osdk/react/experimental";
+import { client } from "./client";
+import App from "./App";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <OsdkProvider2 client={client}>
+      <App />
+    </OsdkProvider2>
+  </React.StrictMode>,
+);
+
+// App.tsx - Use hooks anywhere
+import { Todo } from "@my/osdk";
+import { useOsdkObjects } from "@osdk/react/experimental";
+
+function App() {
+  const { data: todos } = useOsdkObjects(Todo);
+
+  return (
+    <div>
+      {todos?.map(todo => (
+        <div key={todo.$primaryKey}>{todo.title}</div>
+      ))}
+    </div>
+  );
+}
+```
+
+## Best Practices
+
+:::tip
+✓ DO: Create the client once and reuse it
+
+```tsx
+// client.ts
+export const client = createClient(/* ... */);
+
+// main.tsx
+import { client } from "./client";
+<OsdkProvider2 client={client}>
+```
+:::
+
+:::warning
+✗ DON'T: Create a new client on each render
+
+```tsx
+// WRONG - creates new client every render
+<OsdkProvider2 client={createClient(/* ... */)}>
+```
+:::
+
+:::tip
+✓ DO: Place OsdkProvider2 at the root of your application
+
+```tsx
+// main.tsx or index.tsx
+ReactDOM.render(
+  <OsdkProvider2 client={client}>
+    <App /> {/* All components can use hooks */}
+  </OsdkProvider2>
+);
+```
+:::
+
+:::warning
+✗ DON'T: Place OsdkProvider2 inside your components
+
+```tsx
+// WRONG - components outside can't use hooks
+function App() {
+  return (
+    <>
+      <Header /> {/* Can't use OSDK hooks! */}
+      <OsdkProvider2 client={client}>
+        <Content /> {/* Only this can use hooks */}
+      </OsdkProvider2>
+    </>
+  );
+}
+```
+:::
+
+## Comparison with OsdkProvider
+
+| Feature | OsdkProvider (stable) | OsdkProvider2 (experimental) |
+|---------|----------------------|------------------------------|
+| Client access | ✓ `useOsdkClient` | ✓ `useOsdkClient` |
+| Metadata | ✓ `useOsdkMetadata` | ✓ `useOsdkMetadata` |
+| Reactive queries | ✗ | ✓ `useOsdkObjects`, `useOsdkObject` |
+| Actions | ✗ | ✓ `useOsdkAction` |
+| Automatic caching | ✗ | ✓ Built-in |
+| Optimistic updates | ✗ | ✓ Built-in |
+| Real-time subscriptions | ✗ | ✓ Automatic |
+
+## Troubleshooting
+
+### "Cannot read property 'observableClient' of undefined"
+
+**Problem:** A component using experimental hooks is not wrapped in `OsdkProvider2`
+
+**Solution:** Ensure `OsdkProvider2` is at the root of your app:
+
+```tsx
+// Wrong
+ReactDOM.render(<App />); // Missing provider!
+
+// Correct
+ReactDOM.render(
+  <OsdkProvider2 client={client}>
+    <App />
+  </OsdkProvider2>
+);
+```
+
+### "Property 'store' is missing in type"
+
+**Problem:** Version mismatch between `@osdk/client` and `@osdk/react`
+
+**Solution:** Ensure all OSDK packages use compatible versions:
+
+```bash
+pnpm install @osdk/client@beta @osdk/react@beta @osdk/api@beta
+```
+
+### Hooks return stale data
+
+**Problem:** Creating a new client instance on each render
+
+**Solution:** Create the client once outside your components:
+
+```tsx
+// Wrong - new client every render
+function App() {
+  const client = createClient(/* ... */); // DON'T DO THIS
+  return <OsdkProvider2 client={client}>...</OsdkProvider2>;
+}
+
+// Correct - client created once
+const client = createClient(/* ... */);
+function App() {
+  return <OsdkProvider2 client={client}>...</OsdkProvider2>;
+}
+```
+
+## Related
+
+- [Getting Started](/react/getting-started) - Full setup guide
+- [useOsdkObjects](/react/querying-data#useosdkobjects) - Query collections
+- [useOsdkAction](/react/actions) - Execute actions
+````
+
+---
+
+## Example 3: Utility Function Documentation
+
+This shows how to document a utility function like `createClient`.
+
+---
+
+````markdown
+---
+sidebar_position: 1
+---
+
+# createClient
+
+Creates an OSDK client instance for interacting with your Foundry ontology.
+
+*Stable - import from `@osdk/client`*
+
+## Basic Usage
+
+```ts
+import { createClient } from "@osdk/client";
+import { $ontologyRid } from "@my/osdk";
+
+const client = createClient(
+  "https://your-stack.palantirfoundry.com",
+  $ontologyRid,
+  async () => {
+    // Return a valid auth token
+    return await getAuthToken();
+  },
+);
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `url` | `string` | Yes | Your Foundry stack URL |
+| `ontologyRid` | `string` | Yes | RID of your ontology (from generated SDK) |
+| `auth` | `() => string \| Promise<string>` | Yes | Function that returns an auth token |
+| `options` | `ClientOptions` | No | Additional configuration |
+
+### ClientOptions
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `logger` | `Logger` | Custom logger for debugging |
+| `fetch` | `typeof fetch` | Custom fetch implementation |
+
+## Return Value
+
+Returns a `Client` instance with methods for:
+- Querying objects
+- Executing actions
+- Fetching metadata
+- Managing subscriptions
+
+## Examples
+
+### With Environment Variables
+
+```ts
+const client = createClient(
+  import.meta.env.VITE_FOUNDRY_URL,
+  $ontologyRid,
+  async () => localStorage.getItem("token") ?? "",
+);
+```
+
+### With OAuth
+
+```ts
+import { createClient } from "@osdk/client";
+import { createPublicOauthClient } from "@osdk/oauth";
+
+const auth = createPublicOauthClient(
+  "your-client-id",
+  "https://your-stack.palantirfoundry.com",
+  "https://localhost:8080/auth/callback",
+);
+
+const client = createClient(
+  "https://your-stack.palantirfoundry.com",
+  $ontologyRid,
+  () => auth.getTokenOrUndefined() ?? "",
+);
+```
+
+### With Custom Logger
+
+```ts
+import { createClient, Logger } from "@osdk/client";
+
+const logger: Logger = {
+  debug: console.debug,
+  info: console.info,
+  warn: console.warn,
+  error: console.error,
+};
+
+const client = createClient(
+  foundryUrl,
+  $ontologyRid,
+  authProvider,
+  { logger },
+);
+```
+
+## Usage with React
+
+Create the client once and pass to `OsdkProvider2`:
+
+```tsx
+// client.ts
+import { createClient } from "@osdk/client";
+import { $ontologyRid } from "@my/osdk";
+
+export const client = createClient(
+  import.meta.env.VITE_FOUNDRY_URL,
+  $ontologyRid,
+  async () => localStorage.getItem("token") ?? "",
+);
+
+// main.tsx
+import { OsdkProvider2 } from "@osdk/react/experimental";
+import { client } from "./client";
+
+ReactDOM.render(
+  <OsdkProvider2 client={client}>
+    <App />
+  </OsdkProvider2>
+);
+```
+
+## Best Practices
+
+:::tip
+✓ DO: Create the client once at the module level
+
+```ts
+// client.ts
+export const client = createClient(/* ... */);
+```
+:::
+
+:::warning
+✗ DON'T: Create a new client for each request
+
+```ts
+// WRONG - inefficient and breaks caching
+function fetchData() {
+  const client = createClient(/* ... */);
+  return client(MyObject).fetchPage();
+}
+```
+:::
+
+:::tip
+✓ DO: Use environment variables for URLs
+
+```ts
+const client = createClient(
+  import.meta.env.VITE_FOUNDRY_URL,
+  $ontologyRid,
+  authProvider,
+);
+```
+:::
+
+## Troubleshooting
+
+### "Invalid auth token" errors
+
+**Problem:** Auth function returns an empty or expired token
+
+**Solution:** Ensure your auth provider returns a valid token:
+
+```ts
+const client = createClient(
+  foundryUrl,
+  $ontologyRid,
+  async () => {
+    const token = await getAuthToken();
+    if (!token) {
+      throw new Error("No auth token available");
+    }
+    return token;
+  },
+);
+```
+
+### TypeScript errors about client type
+
+**Problem:** Generated SDK version doesn't match client version
+
+**Solution:** Regenerate your SDK with matching versions:
+
+1. Update `@osdk/client` to latest beta
+2. Regenerate your SDK in Developer Console
+3. Ensure all `@osdk/*` packages use compatible versions
+
+## Related
+
+- [createMinimalClient](/client/create-minimal-client) - Lightweight client
+- [OAuth Setup](/client/oauth) - OAuth authentication
+- [OsdkProvider2](/react/getting-started#osdkprovider2) - React integration
+````

--- a/.claude/skills/document-component/reference.md
+++ b/.claude/skills/document-component/reference.md
@@ -1,0 +1,472 @@
+# Documentation Reference Guide
+
+This file provides detailed patterns and examples for documenting osdk-ts components.
+
+## Frontmatter Format
+
+All Docusaurus pages require YAML frontmatter:
+
+```yaml
+---
+sidebar_position: 2
+---
+```
+
+- `sidebar_position` - Number that controls ordering in the sidebar (lower = earlier)
+- Use sequential numbering within each section
+
+## Callout Boxes
+
+Use Docusaurus callouts to highlight important information:
+
+### Info Box
+```markdown
+:::info Stability
+This is a beta feature in `@osdk/react/experimental`
+:::
+```
+
+### Warning Box
+```markdown
+:::warning Version Compatibility
+All `@osdk/*` packages must use compatible versions.
+:::
+```
+
+### Tip Box
+```markdown
+:::tip Best Practice
+✓ DO: Keep components rendering during loading states
+:::
+```
+
+### Note Box
+```markdown
+:::note
+Throughout this documentation, `@my/osdk` refers to your generated SDK package.
+:::
+```
+
+## Code Block Format
+
+Use TypeScript with TSX syntax highlighting:
+
+````markdown
+```tsx
+import { useOsdkObjects } from "@osdk/react/experimental";
+import { Todo } from "@my/osdk";
+
+function TodoList() {
+  const { data, isLoading } = useOsdkObjects(Todo);
+
+  return <div>{data?.map(t => t.title)}</div>;
+}
+```
+````
+
+## Component Documentation Structure
+
+### 1. Title and Description
+
+```markdown
+# useOsdkObjects
+
+Retrieve and observe collections of objects with automatic cache management.
+```
+
+- Start with clear, concise description (1-2 sentences)
+- Focus on what it does and when to use it
+
+### 2. Stability Status
+
+```markdown
+*Experimental - import from `@osdk/react/experimental`*
+
+:::info Beta Release
+This feature is in beta. The API may change between releases.
+:::
+```
+
+### 3. Basic Usage
+
+Show the simplest working example first:
+
+````markdown
+### Basic Usage
+
+```tsx
+import { Todo } from "@my/osdk";
+import { useOsdkObjects } from "@osdk/react/experimental";
+
+function TodoList() {
+  const { data, isLoading, error } = useOsdkObjects(Todo);
+
+  if (!data && isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  return (
+    <div>
+      {data?.map(todo => <div key={todo.$primaryKey}>{todo.title}</div>)}
+    </div>
+  );
+}
+```
+````
+
+### 4. Parameters Table
+
+Document all parameters in a table:
+
+```markdown
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `objectType` | `OsdkObjectType<T>` | Yes | The object type to query (from your generated SDK) |
+| `options` | `UseOsdkObjectsOptions<T>` | No | Query options (filters, pagination, sorting) |
+
+### Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `where` | `WhereClause<T>` | Filter criteria for the query |
+| `orderBy` | `OrderBy<T>` | Sorting configuration |
+| `$pageSize` | `number` | Number of objects per page (default: 100) |
+| `enabled` | `boolean` | Whether to execute the query (default: true) |
+| `rids` | `string[]` | Fetch specific objects by RID |
+```
+
+### 5. Return Value
+
+Document the return type structure:
+
+```markdown
+## Return Value
+
+The hook returns an object with:
+
+- `data` - Array of objects matching the query (undefined while initially loading)
+- `isLoading` - True while fetching data from server
+- `isOptimistic` - True if data includes optimistic updates
+- `fetchMore` - Function to load next page (undefined when no more pages)
+- `error` - Error object if fetch failed
+```
+
+### 6. Examples Section
+
+Provide multiple examples covering common use cases:
+
+```markdown
+## Examples
+
+### Filtering Data
+
+```tsx
+const { data } = useOsdkObjects(Todo, {
+  where: { isComplete: false },
+});
+```
+
+### Pagination
+
+```tsx
+function PaginatedList() {
+  const { data, fetchMore } = useOsdkObjects(Todo, {
+    $pageSize: 20,
+  });
+
+  return (
+    <div>
+      {data?.map(todo => <TodoItem key={todo.$primaryKey} todo={todo} />)}
+      {fetchMore && <button onClick={fetchMore}>Load More</button>}
+    </div>
+  );
+}
+```
+
+### Conditional Queries
+
+```tsx
+const { data } = useOsdkObjects(Employee, {
+  where: { department: selectedDepartment },
+  enabled: selectedDepartment !== null,
+});
+```
+```
+
+### 7. Advanced Usage
+
+Document more complex patterns:
+
+```markdown
+## Advanced Usage
+
+### Combining Multiple Filters
+
+```tsx
+const { data } = useOsdkObjects(Employee, {
+  where: {
+    $and: [
+      { department: "Engineering" },
+      { yearsOfExperience: { $gte: 5 } },
+      { status: "active" }
+    ]
+  },
+  orderBy: { lastName: "asc" }
+});
+```
+
+### Real-time Updates
+
+The hook automatically subscribes to object changes and updates when:
+- An action modifies matching objects
+- Objects are created that match the filter
+- Objects are deleted from the result set
+
+No additional code is needed - just render the data.
+```
+
+### 8. Best Practices
+
+Use callouts to show do's and don'ts:
+
+```markdown
+## Best Practices
+
+:::tip
+✓ DO: Keep components rendering during loading states
+```tsx
+// Show loading indicator while keeping existing data visible
+<div>
+  {isLoading && <LoadingSpinner />}
+  {data?.map(item => <Item key={item.$primaryKey} item={item} />)}
+</div>
+```
+:::
+
+:::warning
+✗ DON'T: Use conditional returns that hide existing data
+```tsx
+// This causes UI flashing when revalidating
+if (isLoading) return <LoadingMessage />;
+```
+:::
+
+:::warning
+✗ DON'T: Conditionally call hooks
+```tsx
+// WRONG - violates Rules of Hooks
+if (shouldFetch) {
+  const { data } = useOsdkObjects(Todo);
+}
+
+// CORRECT - use enabled option
+const { data } = useOsdkObjects(Todo, {
+  enabled: shouldFetch
+});
+```
+:::
+```
+
+### 9. Troubleshooting
+
+Address common issues:
+
+```markdown
+## Troubleshooting
+
+### Hook returns undefined data
+
+**Problem:** `data` is always undefined even after loading completes
+
+**Solution:** Ensure `OsdkProvider2` wraps your component tree:
+
+```tsx
+// Wrong - provider missing
+ReactDOM.render(<App />);
+
+// Correct - provider at root
+ReactDOM.render(
+  <OsdkProvider2 client={client}>
+    <App />
+  </OsdkProvider2>
+);
+```
+
+### "Hooks cannot be conditionally called" error
+
+**Problem:** You're calling the hook inside a condition or loop
+
+**Solution:** Use the `enabled` option instead:
+
+```tsx
+// Wrong
+if (userId) {
+  const { data } = useOsdkObject(User, userId);
+}
+
+// Correct
+const { data } = useOsdkObject(User, userId, {
+  enabled: userId !== null
+});
+```
+```
+
+### 10. Related Documentation
+
+Link to related pages:
+
+```markdown
+## Related
+
+- [Actions](/react/actions) - Modify objects with useOsdkAction
+- [Advanced Queries](/react/advanced-queries) - useObjectSet and aggregations
+- [Cache Management](/react/cache-management) - Understanding cache behavior
+```
+
+## Table Formatting
+
+Use markdown tables for parameters, options, and comparisons:
+
+```markdown
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `param1` | `string` | Yes | Description here |
+| `param2` | `number` | No | Optional param (default: 10) |
+```
+
+## Import Examples
+
+Always show the full import path:
+
+```markdown
+```tsx
+import { useOsdkObjects } from "@osdk/react/experimental";
+import { Todo } from "@my/osdk";
+```
+```
+
+## Type References
+
+Reference TypeScript types inline with backticks:
+
+```markdown
+The `data` property returns `Array<OsdkInstance<T>> | undefined`
+```
+
+## Cross-References
+
+Link to other documentation pages:
+
+```markdown
+See [Querying Data](/react/querying-data) for more details.
+```
+
+Use relative paths for internal links:
+- Same directory: `[Actions](./actions.md)`
+- Different directory: `[Guides](/guides/vite.md)`
+
+## Progressive Disclosure
+
+Structure content from simple to complex:
+
+1. **Basic Usage** - Simplest working example
+2. **Common Patterns** - Typical use cases (filtering, pagination)
+3. **Advanced Usage** - Complex scenarios (combining features)
+4. **Edge Cases** - Unusual but valid patterns
+5. **Troubleshooting** - Common problems and solutions
+
+## Code Comments
+
+Use comments to explain non-obvious code:
+
+```tsx
+// Fetch employees in chunks of 50
+const { data, fetchMore } = useOsdkObjects(Employee, {
+  $pageSize: 50,
+});
+
+// Enable query only when department is selected
+const enabled = selectedDepartment !== null;
+```
+
+## Stability Labels
+
+Mark experimental features consistently:
+
+```markdown
+*Experimental - import from `@osdk/react/experimental`*
+```
+
+Mark stable features:
+
+```markdown
+*Stable - import from `@osdk/react`*
+```
+
+## Version Notes
+
+Call out version-specific behavior:
+
+```markdown
+:::info Version 2.8+
+This feature requires `@osdk/client` version 2.8.0 or higher.
+:::
+```
+
+## Anti-Patterns
+
+Explicitly document what NOT to do:
+
+````markdown
+:::warning Anti-Pattern
+DON'T use early returns that hide data during loading:
+
+```tsx
+// BAD - causes UI flashing
+if (isLoading) return <Spinner />;
+return <DataDisplay data={data} />;
+
+// GOOD - show both
+return (
+  <div>
+    {isLoading && <Spinner />}
+    <DataDisplay data={data} />
+  </div>
+);
+```
+:::
+````
+
+## Real-World Examples
+
+Prefer realistic examples over toy examples:
+
+```tsx
+// Less useful - too abstract
+const { data } = useOsdkObjects(MyType);
+
+// More useful - shows real use case
+function EmployeeDirectory() {
+  const { data: employees, isLoading } = useOsdkObjects(Employee, {
+    where: { department: "Engineering", status: "active" },
+    orderBy: { lastName: "asc" }
+  });
+
+  return (
+    <div className="directory">
+      {employees?.map(emp => (
+        <EmployeeCard
+          key={emp.$primaryKey}
+          employee={emp}
+        />
+      ))}
+    </div>
+  );
+}
+```

--- a/.claude/skills/document-component/registry-example.json
+++ b/.claude/skills/document-component/registry-example.json
@@ -1,0 +1,288 @@
+{
+  "$schema": "./registry-schema.json",
+  "version": "0.1.0",
+  "components": [
+    {
+      "name": "useOsdkObjects",
+      "type": "hook",
+      "package": "@osdk/react",
+      "importPath": "@osdk/react/experimental",
+      "stability": "experimental",
+      "description": "Retrieve and observe collections of objects with automatic cache management",
+      "docPath": "docs/react/querying-data.md#useosdkobjects",
+      "sourcePath": "packages/react/src/new/useOsdkObjects.ts",
+      "category": "queries",
+      "tags": ["query", "collection", "list", "filtering", "pagination", "caching"],
+      "usageExample": "const { data, isLoading } = useOsdkObjects(Todo, { where: { isComplete: false } });",
+      "parameters": [
+        {
+          "name": "objectType",
+          "type": "OsdkObjectType<T>",
+          "required": true,
+          "description": "The object type to query (from your generated SDK)"
+        },
+        {
+          "name": "options",
+          "type": "UseOsdkObjectsOptions<T>",
+          "required": false,
+          "description": "Query options (filters, pagination, sorting)"
+        }
+      ],
+      "returnValue": {
+        "type": "UseOsdkListResult<T>",
+        "description": "Object containing data array, loading state, error, and fetchMore function"
+      },
+      "relatedComponents": ["useOsdkObject", "useObjectSet", "useOsdkAggregation"],
+      "requires": ["OsdkProvider2"]
+    },
+    {
+      "name": "useOsdkObject",
+      "type": "hook",
+      "package": "@osdk/react",
+      "importPath": "@osdk/react/experimental",
+      "stability": "experimental",
+      "description": "Fetch and observe a single object by its primary key with automatic cache management",
+      "docPath": "docs/react/querying-data.md#useosdkobject",
+      "sourcePath": "packages/react/src/new/useOsdkObject.ts",
+      "category": "queries",
+      "tags": ["query", "single", "fetch", "caching", "real-time"],
+      "usageExample": "const { data, isLoading } = useOsdkObject(Employee, employeeId);",
+      "parameters": [
+        {
+          "name": "objectType",
+          "type": "OsdkObjectType<T>",
+          "required": true,
+          "description": "The object type (from your generated SDK)"
+        },
+        {
+          "name": "primaryKey",
+          "type": "string | number",
+          "required": true,
+          "description": "The primary key of the object to fetch"
+        },
+        {
+          "name": "options",
+          "type": "UseOsdkObjectOptions",
+          "required": false,
+          "description": "Additional query options (enabled, select)"
+        }
+      ],
+      "returnValue": {
+        "type": "UseOsdkObjectResult<T>",
+        "description": "Object containing data, loading state, error, refetch, and isOptimistic"
+      },
+      "relatedComponents": ["useOsdkObjects", "useLinks", "useOsdkAction"],
+      "requires": ["OsdkProvider2"]
+    },
+    {
+      "name": "useOsdkAction",
+      "type": "hook",
+      "package": "@osdk/react",
+      "importPath": "@osdk/react/experimental",
+      "stability": "experimental",
+      "description": "Execute and validate actions with optimistic updates and automatic cache invalidation",
+      "docPath": "docs/react/actions.md",
+      "sourcePath": "packages/react/src/new/useOsdkAction.ts",
+      "category": "actions",
+      "tags": ["action", "mutation", "optimistic", "validation"],
+      "usageExample": "const { applyAction, isPending } = useOsdkAction($Actions.createTodo);",
+      "parameters": [
+        {
+          "name": "action",
+          "type": "Action<P, R>",
+          "required": true,
+          "description": "The action to execute (from your generated SDK)"
+        },
+        {
+          "name": "options",
+          "type": "UseOsdkActionOptions",
+          "required": false,
+          "description": "Action options (onSuccess, onError, optimistic)"
+        }
+      ],
+      "returnValue": {
+        "type": "UseOsdkActionResult<P, R>",
+        "description": "Object containing applyAction function, isPending state, and error"
+      },
+      "relatedComponents": ["useOsdkObject", "useOsdkObjects"],
+      "requires": ["OsdkProvider2"]
+    },
+    {
+      "name": "OsdkProvider2",
+      "type": "provider",
+      "package": "@osdk/react",
+      "importPath": "@osdk/react/experimental",
+      "stability": "experimental",
+      "description": "Context provider that enables experimental OSDK React hooks throughout your application",
+      "docPath": "docs/react/getting-started.md#osdkprovider2",
+      "sourcePath": "packages/react/src/new/OsdkProvider2.tsx",
+      "category": "setup",
+      "tags": ["provider", "context", "setup", "initialization"],
+      "usageExample": "<OsdkProvider2 client={client}><App /></OsdkProvider2>",
+      "parameters": [
+        {
+          "name": "client",
+          "type": "Client",
+          "required": true,
+          "description": "OSDK client instance from createClient()"
+        },
+        {
+          "name": "children",
+          "type": "ReactNode",
+          "required": true,
+          "description": "Your application components"
+        }
+      ],
+      "returnValue": {
+        "type": "JSX.Element",
+        "description": "React context provider component"
+      },
+      "relatedComponents": ["useOsdkClient", "createClient"],
+      "requires": []
+    },
+    {
+      "name": "createClient",
+      "type": "function",
+      "package": "@osdk/client",
+      "importPath": "@osdk/client",
+      "stability": "stable",
+      "description": "Creates an OSDK client instance for interacting with your Foundry ontology",
+      "docPath": "docs/client/create-client.md",
+      "sourcePath": "packages/client/src/createClient.ts",
+      "category": "setup",
+      "tags": ["client", "initialization", "authentication", "setup"],
+      "usageExample": "const client = createClient(foundryUrl, ontologyRid, authProvider);",
+      "parameters": [
+        {
+          "name": "url",
+          "type": "string",
+          "required": true,
+          "description": "Your Foundry stack URL"
+        },
+        {
+          "name": "ontologyRid",
+          "type": "string",
+          "required": true,
+          "description": "RID of your ontology (from generated SDK)"
+        },
+        {
+          "name": "auth",
+          "type": "() => string | Promise<string>",
+          "required": true,
+          "description": "Function that returns an auth token"
+        },
+        {
+          "name": "options",
+          "type": "ClientOptions",
+          "required": false,
+          "description": "Additional configuration (logger, fetch)"
+        }
+      ],
+      "returnValue": {
+        "type": "Client",
+        "description": "OSDK client instance for queries, actions, and metadata"
+      },
+      "relatedComponents": ["createMinimalClient", "OsdkProvider2"],
+      "requires": []
+    },
+    {
+      "name": "useLinks",
+      "type": "hook",
+      "package": "@osdk/react",
+      "importPath": "@osdk/react/experimental",
+      "stability": "experimental",
+      "description": "Navigate object relationships and fetch linked objects with automatic loading states",
+      "docPath": "docs/react/querying-data.md#uselinks",
+      "sourcePath": "packages/react/src/new/useLinks.ts",
+      "category": "queries",
+      "tags": ["links", "relationships", "navigation", "related"],
+      "usageExample": "const { data: employees } = useLinks(department, 'employees');",
+      "parameters": [
+        {
+          "name": "object",
+          "type": "OsdkInstance<T>",
+          "required": true,
+          "description": "The source object"
+        },
+        {
+          "name": "linkName",
+          "type": "string",
+          "required": true,
+          "description": "Name of the link property"
+        },
+        {
+          "name": "options",
+          "type": "UseLinksOptions",
+          "required": false,
+          "description": "Query options (filters, pagination)"
+        }
+      ],
+      "returnValue": {
+        "type": "UseLinksResult<T>",
+        "description": "Object containing linked objects, loading state, and pagination"
+      },
+      "relatedComponents": ["useOsdkObject", "useOsdkObjects"],
+      "requires": ["OsdkProvider2"]
+    },
+    {
+      "name": "useObjectSet",
+      "type": "hook",
+      "package": "@osdk/react",
+      "importPath": "@osdk/react/experimental",
+      "stability": "experimental",
+      "description": "Advanced object set operations including union, intersect, subtract, and pivot",
+      "docPath": "docs/react/advanced-queries.md#useobjectset",
+      "sourcePath": "packages/react/src/new/useObjectSet.tsx",
+      "category": "queries",
+      "tags": ["advanced", "set-operations", "union", "intersect", "pivot"],
+      "usageExample": "const { data } = useObjectSet(Todo).union(setA, setB);",
+      "parameters": [
+        {
+          "name": "objectType",
+          "type": "OsdkObjectType<T>",
+          "required": true,
+          "description": "The object type for set operations"
+        }
+      ],
+      "returnValue": {
+        "type": "ObjectSetOperations<T>",
+        "description": "Object with methods for union, intersect, subtract, and pivot operations"
+      },
+      "relatedComponents": ["useOsdkObjects", "useOsdkAggregation"],
+      "requires": ["OsdkProvider2"]
+    },
+    {
+      "name": "useOsdkAggregation",
+      "type": "hook",
+      "package": "@osdk/react",
+      "importPath": "@osdk/react/experimental",
+      "stability": "experimental",
+      "description": "Server-side aggregations with groupBy and select for computing statistics",
+      "docPath": "docs/react/advanced-queries.md#useosdkaggregation",
+      "sourcePath": "packages/react/src/new/useOsdkAggregation.ts",
+      "category": "queries",
+      "tags": ["aggregation", "groupby", "statistics", "analytics"],
+      "usageExample": "const { data } = useOsdkAggregation(Employee, { groupBy: ['department'], select: { count: true } });",
+      "parameters": [
+        {
+          "name": "objectType",
+          "type": "OsdkObjectType<T>",
+          "required": true,
+          "description": "The object type to aggregate"
+        },
+        {
+          "name": "options",
+          "type": "AggregationOptions<T>",
+          "required": true,
+          "description": "Aggregation configuration (groupBy, select)"
+        }
+      ],
+      "returnValue": {
+        "type": "UseOsdkAggregationResult",
+        "description": "Object containing aggregated data and loading state"
+      },
+      "relatedComponents": ["useOsdkObjects", "useObjectSet"],
+      "requires": ["OsdkProvider2"]
+    }
+  ]
+}

--- a/.claude/skills/document-component/registry-schema.json
+++ b/.claude/skills/document-component/registry-schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OSDK Component Registry",
+  "description": "Machine-readable registry of documented OSDK components, hooks, and utilities for LLM consumption",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON Schema reference"
+    },
+    "version": {
+      "type": "string",
+      "description": "Registry version (semver)"
+    },
+    "components": {
+      "type": "array",
+      "description": "List of documented components",
+      "items": {
+        "$ref": "#/definitions/component"
+      }
+    }
+  },
+  "required": ["version", "components"],
+  "definitions": {
+    "component": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Component/hook/utility name"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["hook", "component", "provider", "utility", "function"],
+          "description": "Type of the item"
+        },
+        "package": {
+          "type": "string",
+          "description": "NPM package name (e.g., '@osdk/react', '@osdk/client')"
+        },
+        "importPath": {
+          "type": "string",
+          "description": "Full import path (e.g., '@osdk/react/experimental')"
+        },
+        "stability": {
+          "type": "string",
+          "enum": ["stable", "experimental", "beta", "deprecated"],
+          "description": "API stability level"
+        },
+        "description": {
+          "type": "string",
+          "description": "Brief description of what it does"
+        },
+        "docPath": {
+          "type": "string",
+          "description": "Relative path to documentation file"
+        },
+        "sourcePath": {
+          "type": "string",
+          "description": "Relative path to source code file"
+        },
+        "category": {
+          "type": "string",
+          "description": "Category for grouping (e.g., 'queries', 'actions', 'platform-apis')"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Searchable tags"
+        },
+        "usageExample": {
+          "type": "string",
+          "description": "Brief code snippet showing basic usage"
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/parameter"
+          },
+          "description": "Function/hook parameters"
+        },
+        "returnValue": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "Return type"
+            },
+            "description": {
+              "type": "string",
+              "description": "What it returns"
+            }
+          }
+        },
+        "relatedComponents": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Names of related components"
+        },
+        "requires": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Required setup (e.g., 'OsdkProvider2')"
+        }
+      },
+      "required": ["name", "type", "package", "importPath", "stability", "description", "docPath"]
+    },
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string"
+        },
+        "default": {
+          "type": "string"
+        }
+      },
+      "required": ["name", "type", "required", "description"]
+    }
+  }
+}

--- a/.claude/skills/split-large-pr.md
+++ b/.claude/skills/split-large-pr.md
@@ -1,0 +1,261 @@
+# Split Large PR Skill
+
+**Description:** Automatically split a large, hard-to-review PR into multiple smaller, focused PRs that are easier to review and merge.
+
+**When to use:**
+- PR has 1,000+ lines of changes
+- PR touches many unrelated areas
+- Reviewers are struggling with the size
+- You want to reduce merge risk
+
+**Usage:**
+```
+/split-pr <branch-name>
+```
+
+## How It Works
+
+### Step 1: Analyze the PR
+1. Check current branch and compare to main
+2. Run `git diff --stat main...current-branch` to see file changes
+3. Run `git diff --numstat main...current-branch | sort -rn -k1` to find largest files
+4. Categorize changes:
+   - Infrastructure/setup files
+   - Core functionality
+   - Examples/demos
+   - Tests
+   - Documentation
+   - Dependencies (package.json, lock files)
+
+### Step 2: Plan the Split
+Based on analysis, propose 3-4 logical groupings:
+- **PR 1**: Core infrastructure (smallest, foundational)
+- **PR 2**: Main functionality
+- **PR 3**: Additional features/examples
+- **PR 4**: Documentation + dependencies
+
+**Key principles:**
+- Each PR should be independently reviewable
+- PRs should build on each other (chain dependencies)
+- Smallest PR first, largest last
+- Lock files go in the last PR
+- Each PR should be <1,000 lines (excluding lock files)
+
+**IMPORTANT: Ask user for approval of the split plan before proceeding!**
+
+### Step 3: Create Branch Series
+**IMPORTANT: Before committing each branch, show the user what will be committed and ask for confirmation!**
+```bash
+# Start from main
+git checkout main && git pull
+
+# PR 1: Core
+git checkout -b user/feature-1-core
+# Cherry-pick or copy specific files
+git add [core files]
+git commit -m "feat: [feature] - core infrastructure (1/N)"
+git push -u origin user/feature-1-core
+
+# PR 2: Build on PR 1
+git checkout -b user/feature-2-main user/feature-1-core
+# Add more files
+git add [main files]
+git commit -m "feat: [feature] - main functionality (2/N)"
+git push -u origin user/feature-2-main
+
+# PR 3: Build on PR 2
+git checkout -b user/feature-3-examples user/feature-2-main
+# Add examples
+git add [example files]
+git commit -m "feat: [feature] - examples (3/N)"
+git push -u origin user/feature-3-examples
+
+# PR 4: Build on PR 3
+git checkout -b user/feature-4-docs user/feature-3-examples
+# Add docs and lock files
+git add [doc files and pnpm-lock.yaml]
+git commit -m "feat: [feature] - documentation and dependencies (4/N)"
+git push -u origin user/feature-4-docs
+```
+
+### Step 4: Create PRs with Clear Descriptions
+
+Each PR description should have:
+
+**Header:**
+```markdown
+## Summary
+This is **part X of N PRs** that implement [feature].
+Builds on #PREVIOUS_PR (if applicable).
+
+This PR focuses on [specific aspect].
+```
+
+**Body:**
+```markdown
+## What's in this PR (~X lines)
+
+### [Main Section]
+- Item 1
+- Item 2
+
+## File Structure
+```
+path/to/files/
+├── file1.ts (X lines)
+└── file2.ts (X lines)
+```
+
+## PR Dependencies
+- **Depends on:** #PREV_PR (if applicable)
+- **Blocks:** Next PR in series
+
+## Review Focus
+1. [What reviewers should focus on]
+2. [What can be skipped]
+
+## Testing Checklist
+- [ ] Test 1
+- [ ] Test 2
+
+## Next Steps
+After this merges:
+- Next PR will add [what's coming]
+```
+
+### Step 5: Add Context to Original PR
+
+Update the original large PR with:
+```markdown
+# ⚠️ THIS PR HAS BEEN SUPERSEDED
+
+This PR was **too large for effective review** (~X lines).
+
+It has been **split into N smaller PRs** for easier review:
+
+## 📦 New PR Series (Recommended)
+
+| PR | Title | Size | Status | Link |
+|----|-------|------|--------|------|
+| **1/N** | Core | ~X lines | ✅ Ready | [#XXX](link) |
+| **2/N** | Main | ~X lines | ✅ Ready | [#XXX](link) |
+| **3/N** | Examples | ~X lines | ✅ Ready | [#XXX](link) |
+| **4/N** | Docs | ~X lines | ✅ Ready | [#XXX](link) |
+
+## Why Split?
+- ✅ Easier to review
+- ✅ Lower merge risk
+- ✅ Clearer scope per PR
+
+## Merge Order
+1. #XXX (Core)
+2. #XXX (Main)
+3. #XXX (Examples)
+4. #XXX (Docs)
+
+**Please review the split PRs instead.**
+```
+
+## Example Split Strategy
+
+### Common Patterns
+
+**For a feature with examples:**
+1. Core infrastructure + basic example
+2. Additional examples + utilities
+3. Theming/customization
+4. Documentation + dependencies
+
+**For a refactoring:**
+1. Infrastructure changes
+2. Core refactoring
+3. Cascade updates
+4. Tests + documentation
+
+**For a new library:**
+1. Core types + minimal implementation
+2. Main functionality
+3. Additional features
+4. Examples + docs
+
+## Tips for Success
+
+✅ **DO:**
+- **Ask user for approval before committing** (split plan and each commit)
+- Keep each PR focused on one aspect
+- Write clear, descriptive commit messages
+- Include "part X of N" in titles
+- Test each PR independently
+- Make PRs build on each other (chain)
+- Put lock files in the last PR
+- Give size estimates in descriptions
+- Highlight what to review vs skip
+
+❌ **DON'T:**
+- **Commit without user approval** - always confirm first
+- Create parallel PRs that conflict
+- Make PRs depend on multiple previous PRs
+- Split mid-feature (each PR should be cohesive)
+- Forget to exclude .env or local files
+- Skip writing good descriptions
+- Create >10 PRs (too many splits is confusing)
+
+## Review Time Estimates
+
+| PR Size | Review Time |
+|---------|-------------|
+| 100-300 lines | 5-10 min |
+| 300-500 lines | 10-15 min |
+| 500-800 lines | 15-20 min |
+| 800-1000 lines | 20-30 min |
+| 1000+ lines | 30+ min |
+
+**Target:** Keep each PR in the 300-800 line range for optimal review.
+
+## Troubleshooting
+
+**Problem:** PRs have conflicts when merged in order
+**Solution:** Rebase each PR on the previous one after merging
+
+**Problem:** Lock file changes in multiple PRs
+**Solution:** Move all lock file changes to the final PR
+
+**Problem:** Tests fail in early PRs
+**Solution:** Each PR should be functional on its own. Add minimal tests in early PRs.
+
+**Problem:** Too many PRs (>5)
+**Solution:** Combine related changes. Aim for 3-4 PRs.
+
+---
+
+## Template Commands
+
+```bash
+# Analyze current PR
+git diff --stat main..HEAD
+git diff --numstat main..HEAD | sort -rn -k1 | head -20
+
+# Create split series
+git checkout main && git pull
+git checkout -b user/feature-1-core
+# ... add files ...
+git commit -m "feat: [feature] - core (1/4)"
+git push -u origin user/feature-1-core
+gh pr create --title "feat: [feature] - core (1/4)" --body "[description]" --base main
+
+# Repeat for PRs 2-4, each based on previous
+git checkout -b user/feature-2-main user/feature-1-core
+# ... add files ...
+git commit -m "feat: [feature] - main functionality (2/4)"
+git push -u origin user/feature-2-main
+gh pr create --title "feat: [feature] - main functionality (2/4)" --body "[description]" --base user/feature-1-core
+```
+
+---
+
+**Created by:** Claude Code
+**Version:** 1.1
+**Last updated:** 2026-02-11
+**Changelog:**
+- v1.1: Added user confirmation requirement before committing
+- v1.0: Initial version

--- a/packages/monorepo.cspell/dict.normal-dev-words.txt
+++ b/packages/monorepo.cspell/dict.normal-dev-words.txt
@@ -9,6 +9,12 @@ commitish
 Cpath
 Csvg
 devx
+frontmatter
+Frontmatter
+myapp
+numstat
+shadcn
+useosdkobjects
 Discoverability
 duplicative
 gantt


### PR DESCRIPTION
## Summary
This is **part 1 of 3 PRs** that implement agent skills for Claude Code.

This PR focuses on adding the `document-component` skill for documenting React components, hooks, and client utilities following osdk-ts project conventions.

## What's in this PR (~2,110 lines)

### Document Component Skill
- **SKILL.md** - Complete skill documentation and agent instructions
- **README.md** - Usage guide and examples
- **examples.md** - Comprehensive examples of generated documentation
- **reference.md** - Complete reference guide for documentation patterns
- **registry-schema.json** - JSON schema for component registry
- **registry-example.json** - Example component registry

### Supporting Changes
- Dictionary updates for new terms (frontmatter, shadcn, useosdkobjects)

## File Structure
```
.claude/skills/document-component/
├── README.md (159 lines)
├── SKILL.md (343 lines)
├── examples.md (707 lines)
├── reference.md (472 lines)
├── registry-example.json (288 lines)
└── registry-schema.json (136 lines)

packages/monorepo.cspell/
└── dict.normal-dev-words.txt (+5 words)
```

## PR Dependencies
- **Depends on:** None (can merge independently)
- **Blocks:** PR 2/3 (osdk-react-patterns core)

## Review Focus
1. ✅ Skill documentation structure and completeness
2. ✅ Example quality and comprehensiveness
3. ✅ JSON schema correctness
4. ⚠️ Can skip detailed line-by-line review of examples.md (just verify format)

## Testing Checklist
- [x] All files pass cspell checks
- [x] JSON files are valid (schema and example)
- [x] Documentation follows markdown conventions

## Next Steps
After this merges:
- **PR 2/3** will add osdk-react-patterns skill core infrastructure
- **PR 3/3** will add individual best practice rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)