### PR TITLE
Backport: Fix query remapping for arrays of objects (#2380)

### DIFF
--- a/.changeset/strong-foxes-relate.md
+++ b/.changeset/strong-foxes-relate.md
@@ -1,0 +1,6 @@
+---
+"@osdk/shared.test": patch
+"@osdk/client": patch
+---
+
+Fix queries that return arrays of objects.

--- a/packages/client/src/queries/applyQuery.ts
+++ b/packages/client/src/queries/applyQuery.ts
@@ -313,6 +313,13 @@ async function getRequiredDefinitions(
       result.set(dataType.objectSet, objectDef);
       break;
     }
+    case "interfaceObjectSet": {
+      const interfaceDef = await client.ontologyProvider.getInterfaceDefinition(
+        dataType.objectSet,
+      );
+      result.set(dataType.objectSet, interfaceDef);
+      break;
+    }
     case "object": {
       const objectDef = await client.ontologyProvider.getObjectDefinition(
         dataType.object,
@@ -331,6 +338,9 @@ async function getRequiredDefinitions(
 
     case "set": {
       return getRequiredDefinitions(dataType.set, client);
+    }
+    case "array": {
+      return getRequiredDefinitions(dataType.array, client);
     }
 
     case "map": {
@@ -375,6 +385,10 @@ async function getRequiredDefinitions(
     case "twoDimensionalAggregation":
     case "union":
       break;
+    default: {
+      const _: never = dataType;
+      break;
+    }
   }
 
   return result;

--- a/packages/client/src/queries/queries.test.ts
+++ b/packages/client/src/queries/queries.test.ts
@@ -28,6 +28,7 @@ import {
   queryAcceptsInterfaceObjectSet,
   queryAcceptsObject,
   queryAcceptsObjectSets,
+  queryTypeReturnsArrayOfObjects,
   queryTypeReturnsMap,
   returnsDate,
   returnsTimestamp,
@@ -183,6 +184,22 @@ describe("queries", () => {
     });
 
     expectTypeOf<ObjectSet<Employee>>().toMatchTypeOf<typeof result>();
+  });
+
+  it("returns array of objects", async () => {
+    const result = await client(queryTypeReturnsArrayOfObjects).executeFunction(
+      {
+        people: ["Brad", "George", "Ryan"],
+      },
+    );
+
+    expect(result).toEqual([{
+      $apiName: "Employee",
+      $objectSpecifier: "Employee:50030",
+      $objectType: "Employee",
+      $primaryKey: 50030,
+      $title: undefined,
+    }]);
   });
 
   it("no params work", async () => {
@@ -424,6 +441,7 @@ describe("queries", () => {
       "queryAcceptsObjectSets",
       "queryOutputsInterface",
       "queryTypeReturnsArray",
+      "queryTypeReturnsArrayOfObjects",
       "queryTypeReturnsMap",
       "returnsDate",
       "returnsObject",

--- a/packages/shared.test/src/stubs/queries.ts
+++ b/packages/shared.test/src/stubs/queries.ts
@@ -32,6 +32,7 @@ import {
   queryTypeAcceptsTwoDimensionalAggregation,
   queryTypeOutputsInterfaceObjectSet,
   queryTypeReturnsArray,
+  queryTypeReturnsArrayOfObjects,
   queryTypeReturnsComplexStruct,
   queryTypeReturnsDate,
   queryTypeReturnsMap,
@@ -328,6 +329,12 @@ export const queryTypeReturnsMapResponse: ExecuteQueryResponse = {
   value: [{ key: "50030", value: "bye" }],
 };
 
+export const queryTypeReturnsArrayOfObjectsResponse: ExecuteQueryResponse = {
+  value: [
+    employee1.__primaryKey,
+  ],
+};
+
 export const emptyBody: string = JSON.stringify({
   parameters: {},
 });
@@ -422,6 +429,12 @@ const queryRequestHandlers: {
         queryTypeReturnsArrayResponse,
     },
   },
+  [queryTypeReturnsArrayOfObjects.apiName]: {
+    [queryTypeReturnsArrayOfObjects.version]: {
+      [JSON.stringify(queryTypeReturnsArrayRequest)]:
+        queryTypeReturnsArrayOfObjectsResponse,
+    },
+  },
   [queryTypeReturnsMap.apiName]: {
     [queryTypeReturnsMap.version]: {
       [JSON.stringify(queryTypeReturnsMapRequest)]: queryTypeReturnsMapResponse,
@@ -461,6 +474,7 @@ export function registerLazyQueries(fauxOntology: FauxOntology): void {
     queryTypeAcceptsInterfaces,
     queryTypeAcceptsInterfaceObjectSet,
     queryTypeOutputsInterfaceObjectSet,
+    queryTypeReturnsArrayOfObjects,
   ];
 
   for (const queryType of Object.values(queryTypes)) {

--- a/packages/shared.test/src/stubs/queryTypes.ts
+++ b/packages/shared.test/src/stubs/queryTypes.ts
@@ -498,6 +498,29 @@ export const queryTypeReturnsArray: QueryTypeV2 = {
   "version": "0.1.1",
 };
 
+export const queryTypeReturnsArrayOfObjects: QueryTypeV2 = {
+  "apiName": "queryTypeReturnsArrayOfObjects",
+  "output": {
+    "type": "array",
+    "subType": {
+      type: "object",
+      objectApiName: "Employee",
+      objectTypeApiName: "Employee",
+    },
+  },
+  "parameters": {
+    "people": {
+      "dataType": {
+        "type": "array",
+        "subType": { "type": "string" },
+      },
+    },
+  },
+  "rid":
+    "ri.function-registry.main.function.c3e58d52-8430-44ee-9f0b-3785d9a9bdda",
+  "version": "0.1.1",
+};
+
 export const queryTypeReturnsMap: QueryTypeV2 = {
   "apiName": "queryTypeReturnsMap",
   "output": {


### PR DESCRIPTION
## Summary
- Backport of #2380 to release/2.6.x
- Fixes query functions that returned arrays of objects failing because object type definitions could not be loaded for the response type
- Adds support for unpacking array definitions that are nested, and for interface object sets

## Test plan
- CI should pass
- Original PR was tested and merged to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)