### PR TITLE
filter derived property keys in subscribe to prevent client crash

### DIFF
--- a/packages/client/src/objectSet/ObjectSetListenerSSE.ts
+++ b/packages/client/src/objectSet/ObjectSetListenerSSE.ts
@@ -116,6 +116,8 @@ export class ObjectSetListenerSSE {
 
     if (properties.length === 0) {
       properties = Object.keys(objOrInterfaceDef.properties) as Array<P>;
+    } else {
+      properties = properties.filter((p) => p in objOrInterfaceDef.properties);
     }
 
     const objectProperties = properties.filter((p) =>

--- a/packages/client/src/objectSet/ObjectSetListenerWebsocket.ts
+++ b/packages/client/src/objectSet/ObjectSetListenerWebsocket.ts
@@ -213,6 +213,8 @@ export class ObjectSetListenerWebsocket {
 
     if (properties.length === 0) {
       properties = Object.keys(objOrInterfaceDef.properties) as Array<P>;
+    } else {
+      properties = properties.filter((p) => p in objOrInterfaceDef.properties);
     }
 
     objectProperties = properties.filter((p) =>


### PR DESCRIPTION
subscribe methods crash when derived property keys appear in the properties array because they don't exist in objOrInterfaceDef.properties

• filter out property keys not present in the object/interface definition before the geotime type check in both ObjectSetListenerSSE and ObjectSetListenerWebsocket
• derived properties are resolved server-side from the plan, so they don't need to be in the client's propertySet