### PR TITLE
filter derived property keys in websocket subscribe to prevent client crash

### DIFF
--- a/.changeset/filter-derived-websocket-props.md
+++ b/.changeset/filter-derived-websocket-props.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Filter derived property keys from websocket object set subscriptions

--- a/packages/client/src/objectSet/ObjectSetListenerWebsocket.ts
+++ b/packages/client/src/objectSet/ObjectSetListenerWebsocket.ts
@@ -209,8 +209,8 @@ export class ObjectSetListenerWebsocket {
     }
 
     objectProperties = properties.filter((p) =>
-      !(p in objOrInterfaceDef.properties)
-      || objOrInterfaceDef.properties[p].type !== "geotimeSeriesReference"
+      p in objOrInterfaceDef.properties
+      && objOrInterfaceDef.properties[p].type !== "geotimeSeriesReference"
     );
 
     referenceProperties = properties.filter((p) =>


### PR DESCRIPTION
subscribe method crashes when derived property keys appear in the properties array because they don't exist in objOrInterfaceDef.properties

• filter out property keys not present in the object/interface definition before the geotime type check in ObjectSetListenerWebsocket
• derived properties are resolved server-side from the plan, so they don't need to be in the client's propertySet