### PR TITLE
Export BrowserPermission object as well as type

### DIFF
--- a/.changeset/sour-donuts-yawn.md
+++ b/.changeset/sour-donuts-yawn.md
@@ -1,0 +1,5 @@
+---
+"@osdk/widget.api": patch
+---
+
+Export BrowserPermission object as well as type

--- a/packages/widget.api/src/index.ts
+++ b/packages/widget.api/src/index.ts
@@ -49,7 +49,7 @@ export type {
   AllowedObjectSetParameterType,
   ParameterValue,
 } from "./parameters.js";
-export type { BrowserPermission } from "./permissions.js";
+export { BrowserPermission } from "./permissions.js";
 export type {
   AsyncFailedValue,
   AsyncLoadedValue,


### PR DESCRIPTION
Only type was exported which is still fine for type safety but having the object exported as well is nice for convenience to reference `BrowserPermission.CAMERA` if preferred over string literals like "camera"