### PR TITLE
add explicit osdk/api dependency to custom widgets template

### DIFF
--- a/packages/create-widget.template.react.v2/templates/package.json.hbs
+++ b/packages/create-widget.template.react.v2/templates/package.json.hbs
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "{{osdkPackage}}": "latest",
+    "@osdk/api": "^2.0.0",
     "@osdk/client": "^2.0.0",
     "@osdk/widget.client-react": "^3.3.0",
     "@osdk/widget.client": "^3.3.0"


### PR DESCRIPTION
Custom widget users who use osdk/react to build their widgets often get duplicate @osdk/api installs causing TypeScript type incompatibility errors:
• @osdk/client publishes with an exact pin on @osdk/api (from workspace:*), while the generated SDK declares it as a peer dep with a caret. pnpm resolves these independently, creating another install when versions don't align
• adding @osdk/api as an explicit top-level dependency in the react.v2 widget template forces pnpm to hoist a single copy