### PR TITLE
Update AggregationResultsWithoutGroups typing definition

### DIFF
--- a/packages/api/src/aggregate/AggregationResultsWithoutGroups.ts
+++ b/packages/api/src/aggregate/AggregationResultsWithoutGroups.ts
@@ -41,6 +41,6 @@ export type AggregationResultsWithoutGroups<
         MetricName extends "approximateDistinct" | "exactDistinct" ? number
           : OsdkObjectPropertyType<
             CompileTimeMetadata<Q>["properties"][PropName]
-          >;
-    };
+          > | undefined;
+    } | undefined;
 };


### PR DESCRIPTION
Updating the typing definition of AggregationResultsWithoutGroups. When an object set is empty, the result will be undefined, if the aggregation is on fields that are all undefined, then the output will be undefined.