### PR TITLE
fix(templates): add string[] type annotation to scopes array

### DIFF
--- a/packages/create-app.template.react.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.react.beta/templates/src/client.ts.hbs
@@ -30,21 +30,17 @@ const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 const ontologyRid = getMetaTagContent("osdk-ontologyRid");
 {{/if}}
 
-{{#if scopes}}
-const scopes = [
-  {{#each scopes}}
+const scopes: string[] = [
+{{#each scopes}}
   "{{this}}",
-  {{/each}}
+{{/each}}
 ];
-{{/if}}
 
 export const auth: PublicOauthClient = createPublicOauthClient(
   clientId,
   foundryUrl,
   redirectUrl,
-  {{#if scopes}}
-  { scopes }
-  {{/if}}
+  { scopes },
 );
 
 {{#if osdkPackage}}

--- a/packages/create-app.template.react/templates/src/client.ts.hbs
+++ b/packages/create-app.template.react/templates/src/client.ts.hbs
@@ -22,13 +22,11 @@ const url = getMetaTagContent("osdk-foundryUrl");
 const clientId = getMetaTagContent("osdk-clientId");
 const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 
-{{#if scopes}}
-const scopes = [
-  {{#each scopes}}
+const scopes: string[] = [
+{{#each scopes}}
   "{{this}}",
-  {{/each}}
+{{/each}}
 ];
-{{/if}}
 
 /**
  * Initialize the client to interact with the Ontology and Platform SDKs
@@ -39,9 +37,7 @@ const client = new FoundryClient({
     clientId,
     url,
     redirectUrl,
-    {{#if scopes}}
     scopes,
-    {{/if}}
   }),
 });
 

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/client.ts.hbs
@@ -24,21 +24,17 @@ const clientId = getMetaTagContent("osdk-clientId");
 const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 const ontologyRid = getMetaTagContent("osdk-ontologyRid");
 
-{{#if scopes}}
-const scopes = [
-  {{#each scopes}}
+const scopes: string[] = [
+{{#each scopes}}
   "{{this}}",
-  {{/each}}
+{{/each}}
 ];
-{{/if}}
 
 export const auth: PublicOauthClient = createPublicOauthClient(
   clientId,
   foundryUrl,
   redirectUrl,
-  {{#if scopes}}
-  { scopes }
-  {{/if}}
+  { scopes },
 );
 
 /**

--- a/packages/create-app.template.tutorial-todo-aip-app/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app/templates/src/client.ts.hbs
@@ -22,13 +22,11 @@ const url = getMetaTagContent("osdk-foundryUrl");
 const clientId = getMetaTagContent("osdk-clientId");
 const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 
-{{#if scopes}}
-const scopes = [
-  {{#each scopes}}
+const scopes: string[] = [
+{{#each scopes}}
   "{{this}}",
-  {{/each}}
+{{/each}}
 ];
-{{/if}}
 
 /**
  * Initialize the client to interact with the Ontology and Platform SDKs
@@ -39,9 +37,7 @@ const client = new FoundryClient({
     clientId,
     url,
     redirectUrl,
-    {{#if scopes}}
     scopes,
-    {{/if}}
   }),
 });
 

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/src/client.ts.hbs
@@ -24,21 +24,17 @@ const clientId = getMetaTagContent("osdk-clientId");
 const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 const ontologyRid = getMetaTagContent("osdk-ontologyRid");
 
-{{#if scopes}}
-const scopes = [
-  {{#each scopes}}
+const scopes: string[] = [
+{{#each scopes}}
   "{{this}}",
-  {{/each}}
+{{/each}}
 ];
-{{/if}}
 
 export const auth: PublicOauthClient = createPublicOauthClient(
   clientId,
   foundryUrl,
   redirectUrl,
-  {{#if scopes}}
-  { scopes }
-  {{/if}}
+  { scopes },
 );
 
 /**

--- a/packages/create-app.template.tutorial-todo-app/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-app/templates/src/client.ts.hbs
@@ -22,13 +22,11 @@ const url = getMetaTagContent("osdk-foundryUrl");
 const clientId = getMetaTagContent("osdk-clientId");
 const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 
-{{#if scopes}}
-const scopes = [
-  {{#each scopes}}
+const scopes: string[] = [
+{{#each scopes}}
   "{{this}}",
-  {{/each}}
+{{/each}}
 ];
-{{/if}}
 
 /**
  * Initialize the client to interact with the Ontology and Platform SDKs
@@ -39,9 +37,7 @@ const client = new FoundryClient({
     clientId,
     url,
     redirectUrl,
-    {{#if scopes}}
     scopes,
-    {{/if}}
   }),
 });
 

--- a/packages/create-app.template.vue.v2/templates/src/client.ts.hbs
+++ b/packages/create-app.template.vue.v2/templates/src/client.ts.hbs
@@ -30,21 +30,17 @@ const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 const ontologyRid = getMetaTagContent("osdk-ontologyRid");
 {{/if}}
 
-{{#if scopes}}
-const scopes = [
-  {{#each scopes}}
+const scopes: string[] = [
+{{#each scopes}}
   "{{this}}",
-  {{/each}}
+{{/each}}
 ];
-{{/if}}
 
 export const auth: PublicOauthClient = createPublicOauthClient(
   clientId,
   foundryUrl,
   redirectUrl,
-  {{#if scopes}}
-  { scopes }
-  {{/if}}
+  { scopes },
 );
 
 {{#if osdkPackage}}

--- a/packages/create-app.template.vue/templates/src/client.ts.hbs
+++ b/packages/create-app.template.vue/templates/src/client.ts.hbs
@@ -22,13 +22,11 @@ const url = getMetaTagContent("osdk-foundryUrl");
 const clientId = getMetaTagContent("osdk-clientId");
 const redirectUrl = getMetaTagContent("osdk-redirectUrl");
 
-{{#if scopes}}
-const scopes = [
-  {{#each scopes}}
+const scopes: string[] = [
+{{#each scopes}}
   "{{this}}",
-  {{/each}}
+{{/each}}
 ];
-{{/if}}
 
 /**
  * Initialize the client to interact with the Ontology and Platform SDKs
@@ -39,9 +37,7 @@ const client = new FoundryClient({
     clientId,
     url,
     redirectUrl,
-    {{#if scopes}}
     scopes,
-    {{/if}}
   }),
 });
 


### PR DESCRIPTION
## Summary

Always define the `scopes` variable with an explicit `string[]` type annotation in all client templates, ensuring users can modify the array without encountering TypeScript errors.

## Problem

When creating an OSDK app without specifying scopes, the generated `client.ts` contains:

```typescript
const scopes = [];
```

TypeScript infers this empty array as `never[]`. This causes frustrating type errors when users later try to:

1. **Add scopes to the array:**
   ```typescript
   const scopes = [];
   scopes.push("api:read"); // ❌ Argument of type 'string' is not assignable to parameter of type 'never'
   ```

2. **Manually populate the array:**
   ```typescript
   const scopes = [];
   // Later changed to:
   const scopes = ["api:read"]; // ❌ Type 'string' is not assignable to type 'never'
   ```

3. **Pass to OAuth client options:**
   ```typescript
   createPublicOauthClient(clientId, url, redirectUrl, { scopes }); 
   // ❌ Type 'never[]' is not assignable to type 'string[]'
   ```

## Solution

Update all 8 client templates to always output an explicitly typed scopes array:

```typescript
const scopes: string[] = [
  // populated with values if scopes were provided during app creation
];
```

And always pass `scopes` to the OAuth client configuration, even when empty—since an empty array is semantically valid (requests default/no additional scopes).

### Templates Updated

| Template | Auth Pattern |
|----------|--------------|
| `create-app.template.vue.v2` | `createPublicOauthClient` |
| `create-app.template.react.beta` | `createPublicOauthClient` |
| `create-app.template.tutorial-todo-app.beta` | `createPublicOauthClient` |
| `create-app.template.tutorial-todo-aip-app.beta` | `createPublicOauthClient` |
| `create-app.template.vue` | `PublicClientAuth` (legacy) |
| `create-app.template.react` | `PublicClientAuth` (legacy) |
| `create-app.template.tutorial-todo-app` | `PublicClientAuth` (legacy) |
| `create-app.template.tutorial-todo-aip-app` | `PublicClientAuth` (legacy) |

## Test Plan

- [ ] Generate app without scopes → verify `const scopes: string[] = []` in output
- [ ] Generate app with scopes → verify `const scopes: string[] = ["scope1", ...]` in output
- [ ] Verify no TypeScript errors in generated code for both cases
- [ ] Verify OAuth flow works correctly with empty scopes array

🤖 Generated with [Claude Code](https://claude.com/claude-code)