### PR TITLE
Remove unused react-router-dom dependency from widget templates

### DIFF
--- a/.changeset/orange-schools-punch.md
+++ b/.changeset/orange-schools-punch.md
@@ -1,0 +1,6 @@
+---
+"@osdk/create-widget.template.minimal-react.v2": patch
+"@osdk/create-widget.template.react.v2": patch
+---
+
+Remove unused react-router-dom dependency from widget templates

--- a/examples/example-widget-minimal-react-sdk-2.x/package.json
+++ b/examples/example-widget-minimal-react-sdk-2.x/package.json
@@ -20,8 +20,7 @@
     "@osdk/widget.client-react": "workspace:*",
     "clsx": "^2.1.1",
     "react": "^18",
-    "react-dom": "^18",
-    "react-router-dom": "^6.30.1"
+    "react-dom": "^18"
   },
   "devDependencies": {
     "@eslint/compat": "^1.3.2",

--- a/examples/example-widget-react-sdk-2.x/package.json
+++ b/examples/example-widget-react-sdk-2.x/package.json
@@ -22,8 +22,7 @@
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/themes": "^3.2.1",
     "react": "^18",
-    "react-dom": "^18",
-    "react-router-dom": "^6.30.1"
+    "react-dom": "^18"
   },
   "devDependencies": {
     "@eslint/compat": "^1.3.2",

--- a/packages/create-widget.template.minimal-react.v2/package.json
+++ b/packages/create-widget.template.minimal-react.v2/package.json
@@ -37,8 +37,7 @@
     "@blueprintjs/core": "^5.19.1",
     "clsx": "^2.1.1",
     "react": "^18",
-    "react-dom": "^18",
-    "react-router-dom": "^6.30.1"
+    "react-dom": "^18"
   },
   "devDependencies": {
     "@eslint/compat": "^1.3.2",

--- a/packages/create-widget.template.react.v2/package.json
+++ b/packages/create-widget.template.react.v2/package.json
@@ -37,8 +37,7 @@
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/themes": "^3.2.1",
     "react": "^18",
-    "react-dom": "^18",
-    "react-router-dom": "^6.30.1"
+    "react-dom": "^18"
   },
   "devDependencies": {
     "@eslint/compat": "^1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1425,9 +1425,6 @@ importers:
       react-dom:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
-      react-router-dom:
-        specifier: ^6.30.1
-        version: 6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@eslint/compat':
         specifier: ^1.3.2
@@ -1513,9 +1510,6 @@ importers:
       react-dom:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
-      react-router-dom:
-        specifier: ^6.30.1
-        version: 6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@eslint/compat':
         specifier: ^1.3.2
@@ -2860,9 +2854,6 @@ importers:
       react-dom:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
-      react-router-dom:
-        specifier: ^6.30.1
-        version: 6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@eslint/compat':
         specifier: ^1.3.2
@@ -2942,9 +2933,6 @@ importers:
       react-dom:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
-      react-router-dom:
-        specifier: ^6.30.1
-        version: 6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@eslint/compat':
         specifier: ^1.3.2


### PR DESCRIPTION
These are likely copied from app templates which have different routes