### PR TITLE
fix builds

### DIFF
--- a/packages/typescript-sdk-docs-examples/package.json
+++ b/packages/typescript-sdk-docs-examples/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@osdk/api": "workspace:~",
     "@osdk/cli.cmd.typescript": "workspace:~",
+    "@osdk/functions": "workspace:~",
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
     "@osdk/typescript-docs-example-generator": "workspace:~",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4725,9 +4725,6 @@ importers:
       '@osdk/client':
         specifier: workspace:~
         version: link:../client
-      '@osdk/functions':
-        specifier: workspace:~
-        version: link:../functions
     devDependencies:
       '@osdk/api':
         specifier: workspace:~
@@ -4735,6 +4732,9 @@ importers:
       '@osdk/cli.cmd.typescript':
         specifier: workspace:~
         version: link:../cli.cmd.typescript
+      '@osdk/functions':
+        specifier: workspace:~
+        version: link:../functions
       '@osdk/monorepo.api-extractor':
         specifier: workspace:~
         version: link:../monorepo.api-extractor


### PR DESCRIPTION
The create release PR was failing to build typescript-sdk-docs-examples, it was missing `osdk/functions` dev dependency. This PR fixes that.