### PR TITLE
Exit RC prerelease mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "rc",
   "initialVersions": {
     "@osdk/benchmarks.primary": "0.1.0-beta.75",


### PR DESCRIPTION
## Summary
- Exit RC prerelease mode by changing changeset pre.json mode from "pre" to "exit"

## Test plan
- [ ] CI passes
- [ ] Version packages workflow will now produce stable releases instead of RC releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)