### PR TITLE
Bump CI build timeout to 25 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
   build:
     name: Build and Test
-    timeout-minutes: 20
+    timeout-minutes: 25
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Increase the timeout for the Build and Test job from 20 to 25 minutes to provide additional headroom for CI runs

## Test plan
- [ ] Verify CI workflow runs successfully with the new timeout setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)