### PR TITLE
Support interface namespace remapping for aggregations

### DIFF
--- a/.changeset/pretty-paws-laugh.md
+++ b/.changeset/pretty-paws-laugh.md
@@ -1,0 +1,6 @@
+---
+"@osdk/generator": patch
+"@osdk/client": patch
+---
+
+Support Interface Remapping for Aggregations

--- a/packages/client/src/internal/conversions/legacyToModernSingleAggregationResult.test.ts
+++ b/packages/client/src/internal/conversions/legacyToModernSingleAggregationResult.test.ts
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectOrInterfaceDefinition } from "@osdk/api";
+import { describe, expect, it } from "vitest";
+import {
+  legacyToModernSingleAggregationResult,
+  unqualifyPropName,
+} from "./legacyToModernSingleAggregationResult.js";
+
+describe("unqualifyPropName", () => {
+  describe("interfaces", () => {
+    it("removes namespace when it matches interface namespace", () => {
+      const T = {
+        type: "interface",
+        apiName: "a.Foo",
+        __DefinitionMetadata: {
+          type: "interface",
+          properties: {
+            "prop": { type: "integer" },
+          },
+          apiName: "a.Foo",
+          displayName: "",
+          links: {},
+          rid: "",
+          description: undefined,
+        },
+      } as const satisfies ObjectOrInterfaceDefinition;
+
+      expect(unqualifyPropName("a.prop", T)).toBe("prop");
+    });
+
+    it("does not remove namespace when it differs from interface namespace", () => {
+      const T = {
+        type: "interface",
+        apiName: "a.Foo",
+        __DefinitionMetadata: {
+          type: "interface",
+          properties: {
+            "b.prop": { type: "integer" },
+          },
+          apiName: "a.Foo",
+          displayName: "",
+          links: {},
+          rid: "",
+          description: undefined,
+        },
+      } as const satisfies ObjectOrInterfaceDefinition;
+
+      expect(unqualifyPropName("b.prop", T)).toBe("b.prop");
+    });
+
+    it("does not modify property when interface has no namespace", () => {
+      const T = {
+        type: "interface",
+        apiName: "Foo",
+        __DefinitionMetadata: {
+          type: "interface",
+          properties: {
+            "prop": { type: "integer" },
+          },
+          apiName: "Foo",
+          displayName: "",
+          links: {},
+          rid: "",
+          description: undefined,
+        },
+      } as const satisfies ObjectOrInterfaceDefinition;
+
+      expect(unqualifyPropName("prop", T)).toBe("prop");
+    });
+
+    it("does not modify property when property has no namespace", () => {
+      const T = {
+        type: "interface",
+        apiName: "a.Foo",
+        __DefinitionMetadata: {
+          type: "interface",
+          properties: {
+            "prop": { type: "integer" },
+          },
+          apiName: "a.Foo",
+          displayName: "",
+          links: {},
+          rid: "",
+          description: undefined,
+        },
+      } as const satisfies ObjectOrInterfaceDefinition;
+
+      expect(unqualifyPropName("prop", T)).toBe("prop");
+    });
+  });
+
+  describe("objects", () => {
+    it("does not modify property names for objects", () => {
+      const T = {
+        type: "object",
+        apiName: "a.Foo",
+      } as const;
+
+      expect(unqualifyPropName("prop", T as ObjectOrInterfaceDefinition))
+        .toBe("prop");
+      expect(unqualifyPropName("a.prop", T as ObjectOrInterfaceDefinition))
+        .toBe("a.prop");
+    });
+  });
+});
+
+describe(legacyToModernSingleAggregationResult, () => {
+  describe("api namespaces", () => {
+    describe("interfaces", () => {
+      it("properly unqualifies namespaced properties in result", () => {
+        const T = {
+          type: "interface",
+          apiName: "a.Foo",
+          __DefinitionMetadata: {
+            type: "interface",
+            properties: {
+              "prop": { type: "integer" },
+            },
+            apiName: "a.Foo",
+            displayName: "",
+            links: {},
+            rid: "",
+            description: undefined,
+          },
+        } as const satisfies ObjectOrInterfaceDefinition;
+
+        const entry = {
+          group: {},
+          metrics: [
+            { name: "a.prop.max", value: 100 },
+            { name: "a.prop.min", value: 5 },
+            { name: "count", value: 50 },
+          ],
+        };
+
+        const r = legacyToModernSingleAggregationResult(entry, T);
+
+        expect(r).toMatchInlineSnapshot(`
+          {
+            "prop": {
+              "max": 100,
+              "min": 5,
+            },
+          }
+        `);
+      });
+
+      it("properly does not unqualify when namespace differs", () => {
+        const T = {
+          type: "interface",
+          apiName: "a.Foo",
+          __DefinitionMetadata: {
+            type: "interface",
+            properties: {
+              "b.prop": { type: "integer" },
+            },
+            apiName: "a.Foo",
+            displayName: "",
+            links: {},
+            rid: "",
+            description: undefined,
+          },
+        } as const satisfies ObjectOrInterfaceDefinition;
+
+        const entry = {
+          group: {},
+          metrics: [
+            { name: "b.prop.max", value: 100 },
+          ],
+        };
+
+        const r = legacyToModernSingleAggregationResult(entry, T);
+
+        expect(r).toMatchInlineSnapshot(`
+          {
+            "b.prop": {
+              "max": 100,
+            },
+          }
+        `);
+      });
+
+      it("properly handles interface with no namespace", () => {
+        const T = {
+          type: "interface",
+          apiName: "Foo",
+          __DefinitionMetadata: {
+            type: "interface",
+            properties: {
+              "prop": { type: "integer" },
+            },
+            apiName: "Foo",
+            displayName: "",
+            links: {},
+            rid: "",
+            description: undefined,
+          },
+        } as const satisfies ObjectOrInterfaceDefinition;
+
+        const entry = {
+          group: {},
+          metrics: [
+            { name: "prop.max", value: 100 },
+          ],
+        };
+
+        const r = legacyToModernSingleAggregationResult(entry, T);
+
+        expect(r).toMatchInlineSnapshot(`
+          {
+            "prop": {
+              "max": 100,
+            },
+          }
+        `);
+      });
+    });
+
+    describe("objects", () => {
+      it("does not modify property names for objects", () => {
+        const T = {
+          type: "object",
+          apiName: "a.Foo",
+        } as const;
+
+        const entry = {
+          group: {},
+          metrics: [
+            { name: "prop.max", value: 100 },
+          ],
+        };
+
+        const r = legacyToModernSingleAggregationResult(
+          entry,
+          T as ObjectOrInterfaceDefinition,
+        );
+
+        expect(r).toMatchInlineSnapshot(`
+          {
+            "prop": {
+              "max": 100,
+            },
+          }
+        `);
+      });
+    });
+  });
+});

--- a/packages/client/src/internal/conversions/legacyToModernSingleAggregationResult.ts
+++ b/packages/client/src/internal/conversions/legacyToModernSingleAggregationResult.ts
@@ -22,6 +22,29 @@ import type {
 import type { AggregateObjectsResponseV2 } from "@osdk/foundry.ontologies";
 import invariant from "tiny-invariant";
 import type { ArrayElement } from "../../util/ArrayElement.js";
+import { extractNamespace } from "./extractNamespace.js";
+
+/**
+ * Un-qualifies a property name for interfaces by removing the namespace if it
+ * matches the interface's namespace.
+ * @internal
+ */
+export function unqualifyPropName(
+  fieldName: string,
+  objectOrInterface: ObjectOrInterfaceDefinition | undefined,
+): string {
+  if (objectOrInterface?.type !== "interface") {
+    return fieldName;
+  }
+
+  const [objApiNamespace] = extractNamespace(objectOrInterface.apiName);
+  if (objApiNamespace == null) {
+    return fieldName;
+  }
+
+  const [fieldApiNamespace, fieldShortName] = extractNamespace(fieldName);
+  return fieldApiNamespace === objApiNamespace ? fieldShortName : fieldName;
+}
 
 /** @internal */
 export function legacyToModernSingleAggregationResult<
@@ -29,6 +52,7 @@ export function legacyToModernSingleAggregationResult<
   AC extends AggregationClause<Q>,
 >(
   entry: ArrayElement<AggregateObjectsResponseV2["data"]>,
+  objectOrInterface?: ObjectOrInterfaceDefinition,
 ): AggregationResultsWithoutGroups<Q, AC> {
   return entry.metrics.reduce(
     (accumulator: AggregationResultsWithoutGroups<Q, AC>, curValue) => {
@@ -36,16 +60,27 @@ export function legacyToModernSingleAggregationResult<
       if (parts[0] === "count") {
         return accumulator;
       }
+
+      // For interfaces with namespaces, the property name may be "a.prop.metric"
+      // where "a" is the namespace, "prop" is the property, and "metric" is the aggregation type
+      // We need to reconstruct the full property name and then un-qualify it
+      const metricType = parts[parts.length - 1];
+      const property = parts.slice(0, -1).join(".");
+
       invariant(
-        parts.length === 2,
+        property.length > 0,
         "assumed we were getting a `${key}.${type}`",
       );
-      const property = parts[0] as keyof AggregationResultsWithoutGroups<Q, AC>;
-      const metricType = parts[1];
-      if (!(property in accumulator)) {
-        accumulator[property] = {} as any; // fixme?
+
+      const unqualifiedProperty = unqualifyPropName(
+        property,
+        objectOrInterface,
+      ) as keyof AggregationResultsWithoutGroups<Q, AC>;
+
+      if (!(unqualifiedProperty in accumulator)) {
+        accumulator[unqualifiedProperty] = {} as any; // fixme?
       }
-      (accumulator[property] as any)[metricType] = curValue.value; // fixme?
+      (accumulator[unqualifiedProperty] as any)[metricType] = curValue.value; // fixme?
 
       return accumulator;
     },

--- a/packages/client/src/internal/conversions/modernToLegacyAggregationClause.test.ts
+++ b/packages/client/src/internal/conversions/modernToLegacyAggregationClause.test.ts
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectOrInterfaceDefinition } from "@osdk/api";
+import { describe, expect, it } from "vitest";
+import { modernToLegacyAggregationClause } from "./modernToLegacyAggregationClause.js";
+
+describe(modernToLegacyAggregationClause, () => {
+  describe("api namespaces", () => {
+    describe("interfaces", () => {
+      it("properly converts shortname to fqApiName for aggregation", () => {
+        const T = {
+          type: "interface",
+          apiName: "a.Foo",
+          __DefinitionMetadata: {
+            type: "interface",
+            properties: {
+              "prop": { type: "integer" },
+            },
+            apiName: "a.Foo",
+            displayName: "",
+            links: {},
+            rid: "",
+            description: undefined,
+          },
+        } as const satisfies ObjectOrInterfaceDefinition;
+
+        const r = modernToLegacyAggregationClause({
+          "prop:max": "unordered",
+          "prop:min": "asc",
+          "$count": "desc",
+        }, T);
+
+        expect(r).toMatchInlineSnapshot(`
+          [
+            {
+              "direction": undefined,
+              "field": "a.prop",
+              "name": "a.prop.max",
+              "type": "max",
+            },
+            {
+              "direction": "ASC",
+              "field": "a.prop",
+              "name": "a.prop.min",
+              "type": "min",
+            },
+            {
+              "direction": "DESC",
+              "name": "count",
+              "type": "count",
+            },
+          ]
+        `);
+      });
+
+      it("properly does not convert when interface has no apiNamespace", () => {
+        const T = {
+          type: "interface",
+          apiName: "Foo",
+          __DefinitionMetadata: {
+            type: "interface",
+            properties: {
+              "prop": { type: "integer" },
+            },
+            apiName: "Foo",
+            displayName: "",
+            links: {},
+            rid: "",
+            description: undefined,
+          },
+        } as const satisfies ObjectOrInterfaceDefinition;
+
+        const r = modernToLegacyAggregationClause({
+          "prop:sum": "unordered",
+        }, T);
+
+        expect(r).toMatchInlineSnapshot(`
+          [
+            {
+              "direction": undefined,
+              "field": "prop",
+              "name": "prop.sum",
+              "type": "sum",
+            },
+          ]
+        `);
+      });
+
+      it("gracefully handles redundant apiNamespace in property", () => {
+        const T = {
+          type: "interface",
+          apiName: "a.Foo",
+          __DefinitionMetadata: {
+            type: "interface",
+            properties: {
+              "a.prop": { type: "integer" },
+            },
+            apiName: "a.Foo",
+            displayName: "",
+            links: {},
+            rid: "",
+            description: undefined,
+          },
+        } as const satisfies ObjectOrInterfaceDefinition;
+
+        const r = modernToLegacyAggregationClause({
+          "a.prop:avg": "unordered",
+        }, T);
+
+        expect(r).toMatchInlineSnapshot(`
+          [
+            {
+              "direction": undefined,
+              "field": "a.prop",
+              "name": "a.prop.avg",
+              "type": "avg",
+            },
+          ]
+        `);
+      });
+
+      it("properly does not convert different apiNamespaces", () => {
+        const T = {
+          type: "interface",
+          apiName: "a.Foo",
+          __DefinitionMetadata: {
+            type: "interface",
+            properties: {
+              "b.prop": { type: "integer" },
+            },
+            apiName: "a.Foo",
+            displayName: "",
+            links: {},
+            rid: "",
+            description: undefined,
+          },
+        } as const satisfies ObjectOrInterfaceDefinition;
+
+        const r = modernToLegacyAggregationClause({
+          "b.prop:exactDistinct": "unordered",
+        }, T);
+
+        expect(r).toMatchInlineSnapshot(`
+          [
+            {
+              "direction": undefined,
+              "field": "b.prop",
+              "name": "b.prop.exactDistinct",
+              "type": "exactDistinct",
+            },
+          ]
+        `);
+      });
+    });
+
+    describe("objects", () => {
+      it("does not convert object short property names to fq", () => {
+        const T = {
+          type: "object",
+          apiName: "a.Foo",
+        } as const;
+
+        const r = modernToLegacyAggregationClause({
+          "prop:approximateDistinct": "unordered",
+        }, T as ObjectOrInterfaceDefinition);
+
+        expect(r).toMatchInlineSnapshot(`
+          [
+            {
+              "direction": undefined,
+              "field": "prop",
+              "name": "prop.approximateDistinct",
+              "type": "approximateDistinct",
+            },
+          ]
+        `);
+      });
+    });
+  });
+});

--- a/packages/client/src/internal/conversions/modernToLegacyGroupByClause.test.ts
+++ b/packages/client/src/internal/conversions/modernToLegacyGroupByClause.test.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectOrInterfaceDefinition } from "@osdk/api";
+import { describe, expect, it } from "vitest";
+import { modernToLegacyGroupByClause } from "./modernToLegacyGroupByClause.js";
+
+describe(modernToLegacyGroupByClause, () => {
+  describe("api namespaces", () => {
+    describe("interfaces", () => {
+      it("properly converts shortname to fqApiName for groupBy", () => {
+        const T = {
+          type: "interface",
+          apiName: "a.Foo",
+          __DefinitionMetadata: {
+            type: "interface",
+            properties: {
+              "prop": { type: "string" },
+              "prop2": { type: "integer" },
+            },
+            apiName: "a.Foo",
+            displayName: "",
+            links: {},
+            rid: "",
+            description: undefined,
+          },
+        } as const satisfies ObjectOrInterfaceDefinition;
+
+        const r = modernToLegacyGroupByClause({
+          prop: "exact",
+          prop2: { $exactWithLimit: 10 },
+        }, T);
+
+        expect(r).toMatchInlineSnapshot(`
+          [
+            {
+              "field": "a.prop",
+              "type": "exact",
+            },
+            {
+              "field": "a.prop2",
+              "maxGroupCount": 10,
+              "type": "exact",
+            },
+          ]
+        `);
+      });
+
+      it("properly does not convert when interface has no apiNamespace", () => {
+        const T = {
+          type: "interface",
+          apiName: "Foo",
+          __DefinitionMetadata: {
+            type: "interface",
+            properties: {
+              "prop": { type: "string" },
+            },
+            apiName: "Foo",
+            displayName: "",
+            links: {},
+            rid: "",
+            description: undefined,
+          },
+        } as const satisfies ObjectOrInterfaceDefinition;
+
+        const r = modernToLegacyGroupByClause({
+          prop: "exact",
+        }, T);
+
+        expect(r).toMatchInlineSnapshot(`
+          [
+            {
+              "field": "prop",
+              "type": "exact",
+            },
+          ]
+        `);
+      });
+
+      it("gracefully handles redundant apiNamespace in property", () => {
+        const T = {
+          type: "interface",
+          apiName: "a.Foo",
+          __DefinitionMetadata: {
+            type: "interface",
+            properties: {
+              "a.prop": { type: "string" },
+            },
+            apiName: "a.Foo",
+            displayName: "",
+            links: {},
+            rid: "",
+            description: undefined,
+          },
+        } as const satisfies ObjectOrInterfaceDefinition;
+
+        const r = modernToLegacyGroupByClause({
+          "a.prop": "exact",
+        }, T);
+
+        expect(r).toMatchInlineSnapshot(`
+          [
+            {
+              "field": "a.prop",
+              "type": "exact",
+            },
+          ]
+        `);
+      });
+
+      it("properly does not convert different apiNamespaces", () => {
+        const T = {
+          type: "interface",
+          apiName: "a.Foo",
+          __DefinitionMetadata: {
+            type: "interface",
+            properties: {
+              "b.prop": { type: "string" },
+            },
+            apiName: "a.Foo",
+            displayName: "",
+            links: {},
+            rid: "",
+            description: undefined,
+          },
+        } as const satisfies ObjectOrInterfaceDefinition;
+
+        const r = modernToLegacyGroupByClause({
+          "b.prop": "exact",
+        }, T);
+
+        expect(r).toMatchInlineSnapshot(`
+          [
+            {
+              "field": "b.prop",
+              "type": "exact",
+            },
+          ]
+        `);
+      });
+
+      it("properly converts with $exact options", () => {
+        const T = {
+          type: "interface",
+          apiName: "a.Foo",
+          __DefinitionMetadata: {
+            type: "interface",
+            properties: {
+              "prop": { type: "string" },
+            },
+            apiName: "a.Foo",
+            displayName: "",
+            links: {},
+            rid: "",
+            description: undefined,
+          },
+        } as const satisfies ObjectOrInterfaceDefinition;
+
+        const r = modernToLegacyGroupByClause({
+          prop: { $exact: { $limit: 100, $defaultValue: "default" } },
+        }, T);
+
+        expect(r).toMatchInlineSnapshot(`
+          [
+            {
+              "defaultValue": "default",
+              "field": "a.prop",
+              "includeNullValues": undefined,
+              "maxGroupCount": 100,
+              "type": "exact",
+            },
+          ]
+        `);
+      });
+    });
+
+    describe("objects", () => {
+      it("does not convert object short property names to fq", () => {
+        const T = {
+          type: "object",
+          apiName: "a.Foo",
+        } as const;
+
+        const r = modernToLegacyGroupByClause({
+          "prop": "exact",
+        }, T as ObjectOrInterfaceDefinition);
+
+        expect(r).toMatchInlineSnapshot(`
+          [
+            {
+              "field": "prop",
+              "type": "exact",
+            },
+          ]
+        `);
+      });
+    });
+  });
+});

--- a/packages/e2e.sandbox.catchall/src/runInterfacesTest2.ts
+++ b/packages/e2e.sandbox.catchall/src/runInterfacesTest2.ts
@@ -186,6 +186,14 @@ export async function runInterfacesTest2(): Promise<void> {
     myFilteredInterfaceIdpData.data[0].idpAge,
     myFilteredInterfaceIdpData.data[1].mwaltherName,
   );
+
+  // Aggregations
+  const aggResult = await ontologyClient(MwaltherTestIdp).aggregate({
+    $groupBy: { mwaltherName: "exact" },
+    $select: { "idpAge:min": "desc" },
+  });
+
+  console.log(aggResult[0].$group.mwaltherName);
 }
 
 void runInterfacesTest2();

--- a/packages/monorepo.cspell/dict.osdk.txt
+++ b/packages/monorepo.cspell/dict.osdk.txt
@@ -25,3 +25,5 @@ widgetregistry
 widgetset
 dsmtClient
 sidc
+unqualifies
+unqualify


### PR DESCRIPTION
Adds interface namespace remapping for aggregations. Previously, we did not remap the request so all aggregations failed. This PR remaps the request and response.