### PR TITLE
[Functions] Filter $ prefixed properties in writeable client edits

### DIFF
--- a/.changeset/filter-dollar-properties.md
+++ b/.changeset/filter-dollar-properties.md
@@ -1,0 +1,5 @@
+---
+"@osdk/functions": patch
+---
+
+Filter out $ prefixed properties when creating or updating objects in writeable client

--- a/packages/functions/src/transactions/createWriteableClient.ts
+++ b/packages/functions/src/transactions/createWriteableClient.ts
@@ -134,6 +134,7 @@ export function createWriteableClient<
         ): Promise<void> {
           const propertyMap: { [propertyName: string]: unknown } = {};
           for (const [key, value] of Object.entries(properties)) {
+            if (key.startsWith("$")) continue;
             propertyMap[key] = toPropertyDataValue(value);
           }
           return editRequestManager.postEdit({
@@ -153,6 +154,7 @@ export function createWriteableClient<
         ): Promise<void> {
           const propertyMap: { [propertyName: string]: unknown } = {};
           for (const [key, value] of Object.entries(properties)) {
+            if (key.startsWith("$")) continue;
             propertyMap[key] = toPropertyDataValue(value);
           }
           return editRequestManager.postEdit({


### PR DESCRIPTION
## Summary
- Skip OSDK metadata properties (like `$apiName`, `$primaryKey`, `$objectType`) when creating or updating objects via the writeable client
- The endpoint expects only actual object properties, not OSDK metadata fields

## Test plan
- [ ] Manual testing with OSDK objects containing $ prefixed properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)