### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -95,7 +95,8 @@
     "@osdk/react-components-styles": "0.1.0",
     "@osdk/e2e.sandbox.officenetwork": "0.0.1",
     "@osdk/generator-converters.preview": "0.1.0-beta.0",
-    "@osdk/functions-testing.experimental": "0.1.0"
+    "@osdk/functions-testing.experimental": "0.1.0",
+    "@osdk/react-components-storybook": "0.1.0"
   },
   "changesets": [
     "@osdk-api-simulatedRelease",
@@ -180,11 +181,14 @@
     "five-baboons-check",
     "fix-page-view",
     "flat-mammals-arrive",
+    "flat-news-sleep",
     "flat-waves-hear",
     "full-dolls-pull",
     "fuzzy-dogs-serve",
     "good-hoops-sing",
     "hip-sheep-tie",
+    "large-dodos-relate",
+    "lazy-pants-drive",
     "little-candles-poke",
     "loud-pens-taste",
     "major-spiders-repair",

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/cli.cmd.typescript
 
+## 0.32.0-beta.2
+
+### Patch Changes
+
+- @osdk/cli.common@0.32.0-beta.2
+
 ## 0.31.0-beta.2
 
 ### Minor Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.32.0-beta.1",
+  "version": "0.32.0-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli.common/CHANGELOG.md
+++ b/packages/cli.common/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/cli.common
 
+## 0.32.0-beta.2
+
 ## 0.31.0-beta.2
 
 ## 0.30.0-beta.5

--- a/packages/cli.common/package.json
+++ b/packages/cli.common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.common",
   "private": true,
-  "version": "0.32.0-beta.1",
+  "version": "0.32.0-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/cli
 
+## 0.32.0-beta.2
+
+### Minor Changes
+
+- ef0cd72: Handle ScanningInProgress error for site deploy command
+
 ## 0.31.0-beta.2
 
 ## 0.30.0-beta.5

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.32.0-beta.1",
+  "version": "0.32.0-beta.2",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/functions-testing.experimental/CHANGELOG.md
+++ b/packages/functions-testing.experimental/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/functions-testing.experimental
 
+## 0.2.0-beta.1
+
+### Minor Changes
+
+- 48e1409: Add basic utils for OSDK Testing
+
 ## 0.2.0-beta.0
 
 ### Minor Changes

--- a/packages/functions-testing.experimental/package.json
+++ b/packages/functions-testing.experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/functions-testing.experimental",
-  "version": "0.2.0-beta.0",
+  "version": "0.2.0-beta.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/react-components-storybook/CHANGELOG.md
+++ b/packages/react-components-storybook/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @osdk/react-components-storybook
+
+## 0.2.0-beta.0
+
+### Minor Changes
+
+- 9893b41: Add storybook

--- a/packages/react-components-storybook/package.json
+++ b/packages/react-components-storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/react-components-storybook",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/react-components-styles/CHANGELOG.md
+++ b/packages/react-components-styles/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/react-components-styles
 
+## 0.2.0-beta.6
+
+### Minor Changes
+
+- 9893b41: Add storybook
+
 ## 0.2.0-beta.5
 
 ### Minor Changes

--- a/packages/react-components-styles/package.json
+++ b/packages/react-components-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/react-components-styles",
-  "version": "0.2.0-beta.5",
+  "version": "0.2.0-beta.6",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/react-components
 
+## 0.2.0-beta.6
+
+### Minor Changes
+
+- 9893b41: Add storybook
+
 ## 0.2.0-beta.5
 
 ### Minor Changes

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/react-components",
-  "version": "0.2.0-beta.5",
+  "version": "0.2.0-beta.6",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/vite-plugin-oac/CHANGELOG.md
+++ b/packages/vite-plugin-oac/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/vite-plugin-oac
 
+## 0.6.0-beta.10
+
+### Patch Changes
+
+- Updated dependencies [ef0cd72]
+  - @osdk/cli@0.32.0-beta.2
+
 ## 0.6.0-beta.9
 
 ### Patch Changes

--- a/packages/vite-plugin-oac/package.json
+++ b/packages/vite-plugin-oac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/vite-plugin-oac",
-  "version": "0.6.0-beta.9",
+  "version": "0.6.0-beta.10",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/cli@0.32.0-beta.2

### Minor Changes

-   ef0cd72: Handle ScanningInProgress error for site deploy command

## @osdk/functions-testing.experimental@0.2.0-beta.1

### Minor Changes

-   48e1409: Add basic utils for OSDK Testing

## @osdk/react-components@0.2.0-beta.6

### Minor Changes

-   9893b41: Add storybook

## @osdk/react-components-styles@0.2.0-beta.6

### Minor Changes

-   9893b41: Add storybook

## @osdk/vite-plugin-oac@0.6.0-beta.10

### Patch Changes

-   Updated dependencies [ef0cd72]
    -   @osdk/cli@0.32.0-beta.2

## @osdk/react-components-storybook@0.2.0-beta.0

### Minor Changes

-   9893b41: Add storybook

## @osdk/cli.cmd.typescript@0.32.0-beta.2

### Patch Changes

-   @osdk/cli.common@0.32.0-beta.2

## @osdk/cli.common@0.32.0-beta.2


