### PR TITLE
Version Packages

### DIFF
--- a/.changeset/large-dodos-relate.md
+++ b/.changeset/large-dodos-relate.md
@@ -1,5 +1,0 @@
----
-"@osdk/cli": patch
----
-
-Handle ScanningInProgress error for site deploy command

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/cli.cmd.typescript
 
+## 0.31.1
+
+### Patch Changes
+
+- @osdk/cli.common@0.31.1
+
 ## 0.31.0
 
 ### Patch Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.31.0",
+  "version": "0.31.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli.common/CHANGELOG.md
+++ b/packages/cli.common/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/cli.common
 
+## 0.31.1
+
 ## 0.31.0
 
 ### Patch Changes

--- a/packages/cli.common/package.json
+++ b/packages/cli.common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.common",
   "private": true,
-  "version": "0.31.0",
+  "version": "0.31.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/cli
 
+## 0.31.1
+
+### Patch Changes
+
+- 5c265e4: Handle ScanningInProgress error for site deploy command
+
 ## 0.31.0
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/vite-plugin-oac/CHANGELOG.md
+++ b/packages/vite-plugin-oac/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/vite-plugin-oac
 
+## 0.5.2
+
+### Patch Changes
+
+- Updated dependencies [5c265e4]
+  - @osdk/cli@0.31.1
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/vite-plugin-oac/package.json
+++ b/packages/vite-plugin-oac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/vite-plugin-oac",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/2.7.x, this PR will be updated.


# Releases
## @osdk/cli@0.31.1

### Patch Changes

-   5c265e4: Handle ScanningInProgress error for site deploy command

## @osdk/vite-plugin-oac@0.5.2

### Patch Changes

-   Updated dependencies [5c265e4]
    -   @osdk/cli@0.31.1

## @osdk/cli.cmd.typescript@0.31.1

### Patch Changes

-   @osdk/cli.common@0.31.1

## @osdk/cli.common@0.31.1


