### PR TITLE
[Components] Fix shift click behavior, remove ontology action call in peopleapp, fix header menu styles

### DIFF
--- a/.changeset/warm-cycles-start.md
+++ b/.changeset/warm-cycles-start.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Fix shift click to select from last selected and header menu styles

--- a/packages/e2e.sandbox.peopleapp/src/app/employees/EmployeesTable.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/employees/EmployeesTable.tsx
@@ -1,6 +1,5 @@
 import type { DerivedProperty, Osdk } from "@osdk/api";
 import type {
-  CellIdentifier,
   CellValueState,
   ColumnDefinition,
 } from "@osdk/react-components/experimental";
@@ -90,32 +89,8 @@ export function EmployeesTable() {
 
   const handleSubmitEdits = useCallback(
     async (edits: Record<string, CellValueState>) => {
-      try {
-        // Process each edit and call modifyEmployee action
-        const editEntries = Object.entries(edits);
-        const rowEditsMap: Record<string, Partial<Employee>> = {};
-        const actionPromises: Promise<any>[] = [];
-        for (const [cellId, state] of editEntries) {
-          const cellIdentifier = JSON.parse(cellId) as CellIdentifier;
-          const { rowId, columnId } = cellIdentifier;
-
-          if (!rowEditsMap[rowId]) {
-            rowEditsMap[rowId] = {};
-          }
-          rowEditsMap[rowId][columnId as keyof Employee] = state
-            .newValue as never;
-        }
-        for (const [rowId, updatedFields] of Object.entries(rowEditsMap)) {
-          actionPromises.push(applyAction({
-            employee: Number(rowId),
-            ...updatedFields,
-          }));
-        }
-        await Promise.all(actionPromises);
-      } catch (error) {
-        console.error("Failed to submit edits:", error);
-        throw error;
-      }
+      console.log("Submitting edits:", edits);
+      return Promise.resolve();
     },
     [applyAction],
   );

--- a/packages/react-components/src/object-table/TableHeaderWithPopover.module.css
+++ b/packages/react-components/src/object-table/TableHeaderWithPopover.module.css
@@ -22,7 +22,7 @@
 
 .osdkContentGap {
   display: flex;
-  gap: var(--osdk-surface-spacing);
+  gap: calc(var(--osdk-surface-spacing) * 2);
 }
 
 .osdkHeaderContainer {
@@ -103,7 +103,7 @@
 
 .osdkHeaderMenuItem {
   justify-content: flex-start;
-  padding: var(--osdk-surface-spacing);
+  padding: var(--osdk-surface-spacing) calc(var(--osdk-surface-spacing) * 2);
   cursor: pointer;
 
   &:hover {

--- a/packages/react-components/src/object-table/hooks/__tests__/useRowSelection.test.tsx
+++ b/packages/react-components/src/object-table/hooks/__tests__/useRowSelection.test.tsx
@@ -355,6 +355,52 @@ describe("useRowSelection", () => {
         });
       });
 
+      it("shift-click after deselection should select from the last selected row", () => {
+        const data = createMockData(7);
+        const { result } = renderHook(() =>
+          useRowSelection({
+            selectionMode: "multiple",
+            data,
+          })
+        );
+
+        // Select rows 0, 1, 2
+        act(() => {
+          result.current.onToggleRow("item-0", 0);
+        });
+        act(() => {
+          result.current.onToggleRow("item-1", 1);
+        });
+        act(() => {
+          result.current.onToggleRow("item-2", 2);
+        });
+        expect(result.current.rowSelection).toEqual({
+          "item-0": true,
+          "item-1": true,
+          "item-2": true,
+        });
+
+        // Deselect row 1 (clears lastSelectedRowIndex)
+        act(() => {
+          result.current.onToggleRow("item-1", 1);
+        });
+        expect(result.current.rowSelection).toEqual({
+          "item-0": true,
+          "item-2": true,
+        });
+
+        // Shift-click row 4 - should select from row 2 to row 4
+        act(() => {
+          result.current.onToggleRow("item-4", 4, true);
+        });
+        expect(result.current.rowSelection).toEqual({
+          "item-0": true,
+          "item-2": true,
+          "item-3": true,
+          "item-4": true,
+        });
+      });
+
       it("toggles all rows", () => {
         const data = createMockData(3);
         const onRowSelection = vi.fn();

--- a/packages/react-components/src/object-table/hooks/useRowSelection.ts
+++ b/packages/react-components/src/object-table/hooks/useRowSelection.ts
@@ -119,7 +119,6 @@ export function useRowSelection<
           data,
           rowSelectionState,
         });
-        setLastSelectedRowIndex(rowIndex);
       } else {
         // Multiple selection mode
 
@@ -129,12 +128,18 @@ export function useRowSelection<
           newSelectedRows = getRangeSelectionRows(
             { rowId, rowIndex, data, lastSelectedRowIndex, rowSelectionState },
           );
+          setLastSelectedRowIndex(rowIndex);
         } else {
           newSelectedRows = getMultipleSelectionRows(
             { rowId, rowIndex, data, rowSelectionState },
           );
+          // Only update lastSelectedRowIndex if we're selecting (not deselecting)
+          if (
+            !isCurrentlySelected<Q, RDPs>({ rowIndex, data, rowSelectionState })
+          ) {
+            setLastSelectedRowIndex(rowIndex);
+          }
         }
-        setLastSelectedRowIndex(rowIndex);
       }
       if (!isControlled) {
         setInternalRowSelection(getRowSelectionState(newSelectedRows));
@@ -212,6 +217,20 @@ function getRangeSelectionRows<
   return [];
 }
 
+function isCurrentlySelected<
+  Q extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef> = Record<string, never>,
+>(
+  { rowIndex, data, rowSelectionState }: Pick<
+    GetSelectedRowsProps<Q, RDPs>,
+    "rowIndex" | "data" | "rowSelectionState"
+  >,
+): boolean {
+  const primaryKey = data[rowIndex].$primaryKey;
+  const currentlySelected = getSelectedPrimaryKeys(rowSelectionState, data);
+  return currentlySelected.includes(primaryKey);
+}
+
 function getMultipleSelectionRows<
   Q extends ObjectOrInterfaceDefinition,
   RDPs extends Record<string, SimplePropertyDef> = Record<string, never>,
@@ -221,9 +240,10 @@ function getMultipleSelectionRows<
   const primaryKey = data[rowIndex].$primaryKey;
   const currentlySelected = getSelectedPrimaryKeys(rowSelectionState, data);
   // Handles single row toggle in multiple selection mode
-  const newSelectedRows = currentlySelected.includes(primaryKey)
-    ? currentlySelected.filter(i => i !== primaryKey)
-    : [...currentlySelected, primaryKey];
+  const newSelectedRows =
+    isCurrentlySelected<Q, RDPs>({ rowIndex, data, rowSelectionState })
+      ? currentlySelected.filter(i => i !== primaryKey)
+      : [...currentlySelected, primaryKey];
   return newSelectedRows;
 }
 


### PR DESCRIPTION
- Removed action call on edit as the ObjectType is used in Java OSDK testing.
- Fixed header menu style:
Before
<img width="218" height="197" alt="Screenshot 2026-02-26 at 11 09 06" src="https://github.com/user-attachments/assets/a1c1815c-d6aa-4ba5-addb-68ca41d2c38d" />

After
<img width="283" height="217" alt="Screenshot 2026-02-26 at 11 08 58" src="https://github.com/user-attachments/assets/3eefc4ff-1de2-4353-b603-079fbc266ea2" />

- Fixed shift click behavior:

Bug: When user deselects a checkbox and shift click the next one, it selects the range from the **deselected** checkbox.

https://github.com/user-attachments/assets/eb546af9-eebf-445c-8326-9f786adfc83b


Fix: Select from the last selected checkbox

https://github.com/user-attachments/assets/0edee7c5-d8e9-4636-b838-f39755b253e4



