### PR TITLE
add useObjectSetLinks, useObjectSetAggregation hooks and fix useObjectSet isLoading

### DIFF
--- a/.changeset/useobjectset-hooks.md
+++ b/.changeset/useobjectset-hooks.md
@@ -3,4 +3,4 @@
 "@osdk/client": patch
 ---
 
-Add useObjectSetLinks and useObjectSetAggregation hooks, fix useObjectSet isLoading when disabled
+Add useObjectSetLinks and useObjectSetAggregation hooks, fix useObjectSet isLoading when disabled, add objectSet/hasMore/refetch to useOsdkObjects

--- a/.changeset/useobjectset-hooks.md
+++ b/.changeset/useobjectset-hooks.md
@@ -1,0 +1,6 @@
+---
+"@osdk/react": patch
+"@osdk/client": patch
+---
+
+Add useObjectSetLinks and useObjectSetAggregation hooks, fix useObjectSet isLoading when disabled

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -150,6 +150,7 @@ export interface ObserveObjectsCallbackArgs<
   hasMore: boolean;
   status: Status;
   totalCount?: string;
+  objectSet: ObjectSet<T>;
 }
 
 export interface ObserveObjectSetArgs<

--- a/packages/client/src/observable/internal/Store.test.ts
+++ b/packages/client/src/observable/internal/Store.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { Osdk } from "@osdk/api";
+import type { ObjectSet, Osdk } from "@osdk/api";
 import {
   editTodo,
   Employee,
@@ -2356,6 +2356,168 @@ describe(Store, () => {
       );
 
       expect(sub.error).not.toHaveBeenCalled();
+    });
+
+    describe("ObjectSetQuery maybeUpdateAndRevalidate", () => {
+      it("should update list in-memory when strict-matching object is added", async () => {
+        fauxFoundry.getDefaultDataStore().clear();
+
+        fauxFoundry.getDefaultDataStore().registerObject(
+          Employee,
+          {
+            $apiName: "Employee",
+            employeeId: 100,
+            fullName: "Existing Employee",
+          },
+        );
+
+        const sub = mockObserver<ObjectSetPayload | undefined>();
+        defer(
+          store.objectSets.observe({
+            baseObjectSet: client(Employee) as ObjectSet<Employee>,
+          }, sub),
+        );
+
+        await vi.waitFor(
+          () => {
+            expect(sub.next).toHaveBeenLastCalledWith(
+              expect.objectContaining({
+                status: "loaded",
+              }),
+            );
+          },
+          { timeout: 5000 },
+        );
+
+        expect(sub.next).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            status: "loaded",
+            resolvedList: [
+              expect.objectContaining({ employeeId: 100 }),
+            ],
+          }),
+        );
+
+        fauxFoundry.getDefaultDataStore().registerObject(Employee, {
+          $apiName: "Employee",
+          employeeId: 200,
+          fullName: "New Employee",
+        });
+
+        await client(Employee).fetchOne(200, {
+          $includeRid: true,
+        });
+
+        sub.next.mockClear();
+
+        await store.invalidateObjectType(Employee, undefined);
+
+        await vi.waitFor(
+          () => {
+            expect(sub.next).toHaveBeenCalled();
+          },
+          { timeout: 5000 },
+        );
+
+        expect(sub.next).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            resolvedList: expect.arrayContaining([
+              expect.objectContaining({ employeeId: 100 }),
+              expect.objectContaining({ employeeId: 200 }),
+            ]),
+          }),
+        );
+      });
+
+      it("should trigger revalidation for complex ObjectSet with pivotTo", async () => {
+        fauxFoundry.getDefaultDataStore().clear();
+
+        const office = fauxFoundry.getDefaultDataStore().registerObject(
+          Office,
+          {
+            $apiName: "Office",
+            officeId: "office-pivot",
+            name: "Pivot Office",
+          },
+        );
+
+        const emp = fauxFoundry.getDefaultDataStore().registerObject(
+          Employee,
+          {
+            $apiName: "Employee",
+            employeeId: 300,
+            fullName: "Pivot Employee",
+          },
+        );
+
+        fauxFoundry.getDefaultDataStore().registerLink(
+          emp,
+          "officeLink",
+          office,
+          "occupants",
+        );
+
+        const sub = mockObserver<ObjectSetPayload | undefined>();
+        defer(
+          store.objectSets.observe({
+            baseObjectSet: client(Employee).pivotTo("officeLink"),
+          }, sub),
+        );
+
+        await vi.waitFor(
+          () => {
+            expect(sub.next).toHaveBeenLastCalledWith(
+              expect.objectContaining({
+                status: "loaded",
+              }),
+            );
+          },
+          { timeout: 5000 },
+        );
+
+        expect(sub.next).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            status: "loaded",
+            resolvedList: [
+              expect.objectContaining({ name: "Pivot Office" }),
+            ],
+          }),
+        );
+      });
+
+      it("should not modify list when no relevant object types changed", async () => {
+        fauxFoundry.getDefaultDataStore().clear();
+
+        fauxFoundry.getDefaultDataStore().registerObject(Employee, {
+          $apiName: "Employee",
+          employeeId: 400,
+          fullName: "Sole Employee",
+        });
+
+        const sub = mockObserver<ObjectSetPayload | undefined>();
+        defer(
+          store.objectSets.observe({
+            baseObjectSet: client(Employee) as ObjectSet<Employee>,
+          }, sub),
+        );
+
+        await vi.waitFor(
+          () => {
+            expect(sub.next).toHaveBeenLastCalledWith(
+              expect.objectContaining({
+                status: "loaded",
+              }),
+            );
+          },
+          { timeout: 5000 },
+        );
+
+        const callCountBefore = sub.next.mock.calls.length;
+
+        await store.invalidateObjectType(Office, undefined);
+
+        expect(sub.next.mock.calls.length).toBe(callCountBefore);
+      });
     });
   });
 

--- a/packages/client/src/observable/internal/Store.ts
+++ b/packages/client/src/observable/internal/Store.ts
@@ -394,6 +394,18 @@ export class Store {
     cacheKey: KnownCacheKey,
     changes: Changes,
   ): boolean {
+    if (cacheKey.type === "objectSet") {
+      const query = this.queries.peek(cacheKey);
+      if (query) {
+        for (const objectType of query.objectTypes) {
+          if (this.#changesAffectObjectType(changes, objectType)) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+
     const queryObjectType = this.#getQueryObjectType(cacheKey);
     if (!queryObjectType) {
       return false;

--- a/packages/client/src/observable/internal/list/InterfaceListQuery.ts
+++ b/packages/client/src/observable/internal/list/InterfaceListQuery.ts
@@ -118,12 +118,8 @@ export class InterfaceListQuery extends ListQuery {
     );
 
     return {
+      ...super.createPayload(params),
       resolvedList,
-      isOptimistic: params.isOptimistic,
-      fetchMore: this.fetchMore,
-      hasMore: this.nextPageToken != null,
-      status: params.status,
-      lastUpdated: params.lastUpdated,
     };
   }
 

--- a/packages/client/src/observable/internal/list/ListQuery.ts
+++ b/packages/client/src/observable/internal/list/ListQuery.ts
@@ -35,6 +35,7 @@ import type {
 import { getWireObjectSet } from "../../../objectSet/createObjectSet.js";
 import type { ListPayload } from "../../ListPayload.js";
 import type { Status } from "../../ObservableClient/common.js";
+import type { CollectionConnectableParams } from "../base-list/BaseCollectionQuery.js";
 import { BaseListQuery } from "../base-list/BaseListQuery.js";
 import type { BatchContext } from "../BatchContext.js";
 import { type CacheKey } from "../CacheKey.js";
@@ -167,6 +168,15 @@ export abstract class ListQuery extends BaseListQuery<
 
   get canonicalPivotInfo(): Canonical<PivotInfo> | undefined {
     return this.#pivotInfo;
+  }
+
+  protected createPayload(
+    params: CollectionConnectableParams,
+  ): ListPayload {
+    return {
+      ...super.createPayload(params),
+      objectSet: this.#objectSet,
+    } as ListPayload;
   }
 
   protected abstract createObjectSet(

--- a/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
@@ -15,18 +15,26 @@
  */
 
 import type { ObjectSet, Osdk, PageResult } from "@osdk/api";
+import type { ObjectSet as WireObjectSet } from "@osdk/foundry.ontologies";
 import type { Observable, Subscription } from "rxjs";
 import { additionalContext } from "../../../Client.js";
+import type { InterfaceHolder } from "../../../object/convertWireToOsdkObjects/InterfaceHolder.js";
+import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
 import { getWireObjectSet } from "../../../objectSet/createObjectSet.js";
 import type { ObjectSetPayload } from "../../ObjectSetPayload.js";
 import type { Status } from "../../ObservableClient/common.js";
 import { BaseListQuery } from "../base-list/BaseListQuery.js";
 import type { BatchContext } from "../BatchContext.js";
+import type { CacheKey } from "../CacheKey.js";
 import type { Canonical } from "../Canonical.js";
-import type { Changes } from "../Changes.js";
+import { type Changes, DEBUG_ONLY__changesToString } from "../Changes.js";
 import { getObjectTypesThatInvalidate } from "../getObjectTypesThatInvalidate.js";
 import type { Entry } from "../Layer.js";
+import type { ObjectCacheKey } from "../object/ObjectCacheKey.js";
+import { objectSortaMatchesWhereClause as objectMatchesWhereClause } from "../objectMatchesWhereClause.js";
+import type { OptimisticId } from "../OptimisticId.js";
 import type { Rdp } from "../RdpCanonicalizer.js";
+import type { SimpleWhereClause } from "../SimpleWhereClause.js";
 import { OrderBySortingStrategy } from "../sorting/SortingStrategy.js";
 import type { Store } from "../Store.js";
 import type { SubjectPayload } from "../SubjectPayload.js";
@@ -45,6 +53,8 @@ export class ObjectSetQuery extends BaseListQuery<
   #operations: Canonical<ObjectSetOperations>;
   #composedObjectSet: ObjectSet<any, any>;
   #objectTypes: Set<string>;
+  #isComplex: boolean;
+  #resultTypeApiName: string;
 
   constructor(
     store: Store,
@@ -74,6 +84,18 @@ export class ObjectSetQuery extends BaseListQuery<
     this.#operations = operations;
     this.#composedObjectSet = this.#composeObjectSet(opts);
     this.#objectTypes = this.#extractObjectTypes(opts);
+
+    this.#isComplex = !!(
+      operations.pivotTo
+      || (operations.union && operations.union.length > 0)
+      || (operations.intersect && operations.intersect.length > 0)
+      || (operations.subtract && operations.subtract.length > 0)
+    );
+
+    const baseWire = JSON.parse(baseObjectSetWire);
+    this.#resultTypeApiName = baseWire.objectType ?? baseWire.interfaceType
+      ?? "";
+
     if (opts.autoFetchMore === true) {
       this.minResultsToLoad = Number.MAX_SAFE_INTEGER;
     } else if (typeof opts.autoFetchMore === "number") {
@@ -81,6 +103,10 @@ export class ObjectSetQuery extends BaseListQuery<
     } else {
       this.minResultsToLoad = opts.pageSize || 0;
     }
+  }
+
+  get objectTypes(): ReadonlySet<string> {
+    return this.#objectTypes;
   }
 
   public override get rdpConfig(): Canonical<Rdp> | null {
@@ -115,38 +141,59 @@ export class ObjectSetQuery extends BaseListQuery<
   #extractObjectTypes(opts: ObjectSetQueryOptions): Set<string> {
     const types = new Set<string>();
     const baseWire = JSON.parse(this.#baseObjectSetWire);
-    if (baseWire.type) {
-      types.add(baseWire.type);
+    const baseTypeName = ObjectSetQuery.#extractTypeFromWireObjectSet(
+      baseWire as WireObjectSet,
+    );
+    if (baseTypeName) {
+      types.add(baseTypeName);
     }
 
     if (opts.union) {
       for (const os of opts.union) {
-        const wire = getWireObjectSet(os);
-        if (wire.type) {
-          types.add(wire.type);
+        const typeName = ObjectSetQuery.#extractTypeFromWireObjectSet(
+          getWireObjectSet(os),
+        );
+        if (typeName) {
+          types.add(typeName);
         }
       }
     }
 
     if (opts.intersect) {
       for (const os of opts.intersect) {
-        const wire = getWireObjectSet(os);
-        if (wire.type) {
-          types.add(wire.type);
+        const typeName = ObjectSetQuery.#extractTypeFromWireObjectSet(
+          getWireObjectSet(os),
+        );
+        if (typeName) {
+          types.add(typeName);
         }
       }
     }
 
     if (opts.subtract) {
       for (const os of opts.subtract) {
-        const wire = getWireObjectSet(os);
-        if (wire.type) {
-          types.add(wire.type);
+        const typeName = ObjectSetQuery.#extractTypeFromWireObjectSet(
+          getWireObjectSet(os),
+        );
+        if (typeName) {
+          types.add(typeName);
         }
       }
     }
 
     return types;
+  }
+
+  static #extractTypeFromWireObjectSet(
+    wire: WireObjectSet,
+  ): string | undefined {
+    if (wire.type === "base") {
+      return wire.objectType;
+    }
+    if (wire.type === "interfaceBase") {
+      return wire.interfaceType;
+    }
+    return undefined;
   }
 
   /**
@@ -221,6 +268,183 @@ export class ObjectSetQuery extends BaseListQuery<
       this.#composedObjectSet,
       sub,
       "observeObjectSet",
+    );
+  }
+
+  maybeUpdateAndRevalidate = (
+    changes: Changes,
+    optimisticId: OptimisticId | undefined,
+  ): Promise<void> | undefined => {
+    if (process.env.NODE_ENV !== "production") {
+      this.logger?.child({ methodName: "maybeUpdateAndRevalidate" }).debug(
+        DEBUG_ONLY__changesToString(changes),
+      );
+      this.logger?.child({ methodName: "maybeUpdateAndRevalidate" }).debug(
+        `Already in changes? ${changes.modified.has(this.cacheKey)}`,
+      );
+    }
+
+    if (changes.modified.has(this.cacheKey)) {
+      return;
+    }
+    changes.modified.add(this.cacheKey);
+
+    try {
+      if (this.#isComplex) {
+        return this.#handleComplexObjectSet(changes);
+      }
+      return this.#handleSimpleObjectSet(changes, optimisticId);
+    } finally {
+      if (process.env.NODE_ENV !== "production") {
+        this.logger?.child({ methodName: "maybeUpdateAndRevalidate" })
+          .debug("in finally");
+      }
+    }
+  };
+
+  #handleComplexObjectSet(changes: Changes): Promise<void> | undefined {
+    for (const objectType of this.#objectTypes) {
+      const added = changes.addedObjects.get(objectType);
+      const modified = changes.modifiedObjects.get(objectType);
+      if ((added && added.length > 0) || (modified && modified.length > 0)) {
+        return this.revalidate(true);
+      }
+    }
+    return undefined;
+  }
+
+  #handleSimpleObjectSet(
+    changes: Changes,
+    optimisticId: OptimisticId | undefined,
+  ): Promise<void> | undefined {
+    const resultApiName = this.#resultTypeApiName;
+    const whereClause = this.#operations.where as
+      | Canonical<SimpleWhereClause>
+      | undefined;
+    const emptyWhere: Canonical<SimpleWhereClause> = {} as Canonical<
+      SimpleWhereClause
+    >;
+    const effectiveWhere = whereClause ?? emptyWhere;
+
+    const addedAll = changes.addedObjects.get(resultApiName) ?? [];
+    const modifiedAll = changes.modifiedObjects.get(resultApiName) ?? [];
+
+    if (addedAll.length === 0 && modifiedAll.length === 0) {
+      return undefined;
+    }
+
+    const addedStrictMatches = new Set<ObjectHolder | InterfaceHolder>();
+    const addedSortaMatches = new Set<ObjectHolder | InterfaceHolder>();
+    const modifiedStrictMatches = new Set<ObjectHolder | InterfaceHolder>();
+    const modifiedSortaMatches = new Set<ObjectHolder | InterfaceHolder>();
+
+    for (const obj of addedAll) {
+      const matchType = this.#matchType(obj, effectiveWhere);
+      if (matchType === "strict") {
+        addedStrictMatches.add(obj);
+      } else if (matchType === "sorta") {
+        addedSortaMatches.add(obj);
+      }
+    }
+
+    for (const obj of modifiedAll) {
+      const matchType = this.#matchType(obj, effectiveWhere);
+      if (matchType === "strict") {
+        modifiedStrictMatches.add(obj);
+      } else if (matchType === "sorta") {
+        modifiedSortaMatches.add(obj);
+      }
+    }
+
+    const status = optimisticId
+        || addedSortaMatches.size > 0
+        || modifiedSortaMatches.size > 0
+      ? "loading"
+      : "loaded";
+
+    const newList: Array<ObjectCacheKey> = [];
+
+    let needsRevalidation = false;
+    this.store.batch({ optimisticId, changes }, (batch) => {
+      const existingList = new Set(
+        batch.read(this.cacheKey)?.value?.data,
+      );
+
+      const toAdd = new Set<ObjectHolder | InterfaceHolder>(
+        addedStrictMatches,
+      );
+
+      const toRemove = new Set<CacheKey>(changes.deleted);
+
+      for (const obj of modifiedAll) {
+        if (modifiedStrictMatches.has(obj)) {
+          const objectCacheKey = this.#getObjectCacheKey(obj);
+
+          if (!existingList.has(objectCacheKey)) {
+            toAdd.add(obj);
+          }
+          continue;
+        } else if (batch.optimisticWrite) {
+          continue;
+        } else {
+          const existingObjectCacheKey = this.#getObjectCacheKey(obj);
+
+          toRemove.add(existingObjectCacheKey);
+
+          if (modifiedSortaMatches.has(obj)) {
+            needsRevalidation = true;
+          }
+        }
+      }
+
+      for (const key of existingList) {
+        if (toRemove.has(key)) {
+          continue;
+        }
+        newList.push(key);
+      }
+      for (const obj of toAdd) {
+        newList.push(this.#getObjectCacheKey(obj));
+      }
+
+      const existingTotalCount = batch.read(this.cacheKey)?.value?.totalCount;
+      this._updateList(
+        newList,
+        status,
+        batch,
+        false,
+        existingTotalCount,
+      );
+    });
+
+    if (needsRevalidation) {
+      return this.revalidate(true);
+    }
+    return undefined;
+  }
+
+  #matchType(
+    obj: ObjectHolder | InterfaceHolder,
+    whereClause: Canonical<SimpleWhereClause>,
+  ): false | "strict" | "sorta" {
+    if (objectMatchesWhereClause(obj, whereClause, true)) {
+      return "strict";
+    }
+    if (objectMatchesWhereClause(obj, whereClause, false)) {
+      return "sorta";
+    }
+    return false;
+  }
+
+  #getObjectCacheKey(
+    obj: { $objectType: string; $primaryKey: string | number | boolean },
+  ): ObjectCacheKey {
+    const pk = obj.$primaryKey as string | number;
+    return this.cacheKeys.get<ObjectCacheKey>(
+      "object",
+      obj.$objectType,
+      pk,
+      this.rdpConfig ?? undefined,
     );
   }
 

--- a/packages/client/src/observable/internal/testUtils.ts
+++ b/packages/client/src/observable/internal/testUtils.ts
@@ -586,6 +586,7 @@ export function listPayloadContaining(
     isOptimistic: expect.any(Boolean),
     status: x.status ?? expect.anything(),
     lastUpdated: x.lastUpdated ?? expect.anything(),
+    objectSet: x.objectSet ?? expect.anything(),
   };
 }
 

--- a/packages/e2e.sandbox.officenetwork/src/components/OfficePanel.tsx
+++ b/packages/e2e.sandbox.officenetwork/src/components/OfficePanel.tsx
@@ -1,6 +1,13 @@
-import { useLinks, useOsdkAggregation } from "@osdk/react/experimental";
-import { Employee } from "../generatedNoCheck2/index.js";
-import type { Office } from "../generatedNoCheck2/index.js";
+import {
+  useLinks,
+  useObjectSetAggregation,
+  useObjectSetLinks,
+  useOsdkAggregation,
+  useOsdkClient,
+} from "@osdk/react/experimental";
+import React from "react";
+import { Employee, Office } from "../generatedNoCheck2/index.js";
+import type { Office as OfficeType } from "../generatedNoCheck2/index.js";
 import {
   getHierarchyLevel,
   HIERARCHY_COLORS,
@@ -9,7 +16,7 @@ import {
 import { LoadingIndicator } from "./LoadingIndicator.js";
 
 interface OfficePanelProps {
-  office: Office.OsdkInstance;
+  office: OfficeType.OsdkInstance;
   onSelectEmployee: (employee: Employee.OsdkInstance) => void;
   onClose: () => void;
 }
@@ -33,6 +40,32 @@ export function OfficePanel(
   });
 
   const aggregatedCount = occupantAgg?.$count;
+
+  const client = useOsdkClient();
+
+  const employeeSet = React.useMemo(() => client(Employee), [client]);
+  const {
+    data: osAggData,
+    isLoading: osAggLoading,
+    error: osAggError,
+  } = useObjectSetAggregation(employeeSet, {
+    where: { primaryOfficeId: office.primaryKey_ },
+    aggregate: {
+      $select: { $count: "unordered" },
+    },
+  });
+
+  const officeSet = React.useMemo(
+    () => client(Office).where({ primaryKey_: office.primaryKey_ }),
+    [client, office.primaryKey_],
+  );
+  const {
+    data: osLinks,
+    isLoading: osLinksLoading,
+    error: osLinksError,
+  } = useObjectSetLinks(officeSet, "occupants", {
+    orderBy: { fullName: "asc" },
+  });
 
   const coords = office.location
     ? `${office.location.coordinates[1].toFixed(4)}, ${
@@ -93,6 +126,77 @@ export function OfficePanel(
           </div>
           {isLoading && <LoadingIndicator size="sm" />}
           {error && (
+            <span className="officenetwork-badge officenetwork-badge-error">
+              Error
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* useObjectSetAggregation Stats */}
+      <div className="p-4 border-b border-[var(--officenetwork-border-default)]">
+        <div className="flex items-center gap-3">
+          <div className="text-2xl font-semibold tabular-nums text-[var(--officenetwork-accent-cyan)]">
+            {osAggData?.$count ?? 0}
+          </div>
+          <div>
+            <div className="text-xs text-[var(--officenetwork-text-secondary)]">
+              Employees
+            </div>
+            <div className="text-[10px] text-[var(--officenetwork-text-muted)] officenetwork-mono">
+              useObjectSetAggregation
+            </div>
+          </div>
+          {osAggLoading && <LoadingIndicator size="sm" />}
+          {osAggError && (
+            <span className="officenetwork-badge officenetwork-badge-error">
+              Error
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* useObjectSetLinks List */}
+      <div className="flex-1 overflow-auto">
+        <div className="p-2">
+          <div className="officenetwork-section-label px-2 py-2">
+            Occupants (useObjectSetLinks)
+          </div>
+          {osLinks && osLinks.length > 0
+            ? (
+              <div className="space-y-px">
+                {osLinks.map((emp) => {
+                  const level = getHierarchyLevel(emp.jobTitle);
+                  return (
+                    <div
+                      key={emp.employeeNumber}
+                      className="px-3 py-2 rounded flex items-center gap-3"
+                    >
+                      <div
+                        className="size-2 rounded-sm shrink-0"
+                        style={{ backgroundColor: HIERARCHY_COLORS[level] }}
+                      />
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm text-[var(--officenetwork-text-primary)] truncate">
+                          {emp.fullName ?? `Employee #${emp.employeeNumber}`}
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )
+            : !osLinksLoading
+            ? (
+              <div className="px-3 py-4 text-center">
+                <div className="text-sm text-[var(--officenetwork-text-muted)]">
+                  No employees
+                </div>
+              </div>
+            )
+            : null}
+          {osLinksLoading && <LoadingIndicator size="sm" />}
+          {osLinksError && (
             <span className="officenetwork-badge officenetwork-badge-error">
               Error
             </span>

--- a/packages/e2e.sandbox.todoapp/src/App.tsx
+++ b/packages/e2e.sandbox.todoapp/src/App.tsx
@@ -9,6 +9,7 @@ import { Section } from "./Section.js";
 import { SpecificTodo } from "./SpecificTodo.js";
 import { SpecificTodoViaInterface } from "./SpecificTodoViaInterface.js";
 import TodoList from "./TodoList.js";
+import { TodoStats } from "./TodoStats.js";
 import ValidateActionDemo from "./ValidateActionDemo.js";
 
 function App() {
@@ -19,6 +20,10 @@ function App() {
   return (
     <main className="flex min-h-screen flex-col items-center p-24">
       <H1>Todos App</H1>
+
+      <Section>
+        <TodoStats />
+      </Section>
 
       <div className="flex flex-row items-start text-left">
         <div className="min-w-80 mr-8">

--- a/packages/e2e.sandbox.todoapp/src/TodoStats.tsx
+++ b/packages/e2e.sandbox.todoapp/src/TodoStats.tsx
@@ -1,0 +1,41 @@
+import {
+  useObjectSetAggregation,
+  useOsdkClient,
+} from "@osdk/react/experimental";
+import React from "react";
+import { Todo } from "./generatedNoCheck2/index.js";
+
+export function TodoStats() {
+  const client = useOsdkClient();
+  const todoSet = React.useMemo(() => client(Todo), [client]);
+
+  const { data: totalData, isLoading: totalLoading } = useObjectSetAggregation(
+    todoSet,
+    {
+      aggregate: { $select: { $count: "unordered" } },
+    },
+  );
+
+  const completedSet = React.useMemo(
+    () => client(Todo).where({ isComplete: true }),
+    [client],
+  );
+  const { data: completedData, isLoading: completedLoading } =
+    useObjectSetAggregation(completedSet, {
+      aggregate: { $select: { $count: "unordered" } },
+    });
+
+  const totalCount = totalData?.$count ?? 0;
+  const completedCount = completedData?.$count ?? 0;
+  const isLoading = totalLoading || completedLoading;
+
+  return (
+    <div className="text-sm text-gray-600">
+      <strong>Stats (useObjectSetAggregation)</strong>
+      <div>
+        {`${totalCount} total, ${completedCount} completed`}
+        {isLoading && " (loading...)"}
+      </div>
+    </div>
+  );
+}

--- a/packages/react/src/new/useObjectSet.tsx
+++ b/packages/react/src/new/useObjectSet.tsx
@@ -146,9 +146,19 @@ export interface UseObjectSetResult<
   error: Error | undefined;
 
   /**
+   * Whether the current data reflects an optimistic update
+   */
+  isOptimistic: boolean;
+
+  /**
    * Function to fetch more pages (undefined if no more pages)
    */
   fetchMore: (() => Promise<void>) | undefined;
+
+  /**
+   * Whether there are more pages available to fetch
+   */
+  hasMore: boolean;
 
   /**
    * The final ObjectSet after all transformations
@@ -159,6 +169,11 @@ export interface UseObjectSetResult<
    * The total count of objects matching the query (if available from the API)
    */
   totalCount?: string;
+
+  /**
+   * Refetch data by invalidating the object type cache
+   */
+  refetch: () => void;
 }
 
 declare const process: {
@@ -271,6 +286,12 @@ export function useObjectSet<
     }
   }, [payload]);
 
+  const type = baseObjectSet.$objectSetInternals.def as Q;
+
+  const refetch = React.useCallback(async () => {
+    await observableClient.invalidateObjectType(type.apiName);
+  }, [observableClient, type.apiName]);
+
   return React.useMemo(() => ({
     data: payload?.resolvedList as Osdk.Instance<
       Q,
@@ -278,12 +299,18 @@ export function useObjectSet<
       PropertyKeys<Q>,
       RDPs
     >[],
-    isLoading: payload?.status === "loading" || (!payload && true) || false,
+    isLoading: enabled
+      ? (payload?.status === "loading" || payload?.status === "init"
+        || !payload)
+      : false,
     error: payload && "error" in payload
       ? payload.error
       : undefined,
+    isOptimistic: payload?.isOptimistic ?? false,
     fetchMore: payload?.hasMore ? payload.fetchMore : undefined,
+    hasMore: payload?.hasMore ?? false,
     objectSet: payload?.objectSet as ObjectSet<Q, RDPs> || baseObjectSet,
     totalCount: payload?.totalCount,
-  }), [payload, baseObjectSet]);
+    refetch,
+  }), [payload, baseObjectSet, refetch, enabled]);
 }

--- a/packages/react/src/new/useObjectSetAggregation.ts
+++ b/packages/react/src/new/useObjectSetAggregation.ts
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  AggregateOpts,
+  AggregationsResults,
+  DerivedProperty,
+  ObjectSet,
+  ObjectTypeDefinition,
+  SimplePropertyDef,
+  WhereClause,
+} from "@osdk/api";
+import type { ObserveAggregationArgs } from "@osdk/client/unstable-do-not-use";
+import { computeObjectSetCacheKey } from "@osdk/client/unstable-do-not-use";
+import React from "react";
+import { makeExternalStoreAsync } from "./makeExternalStore.js";
+import { OsdkContext2 } from "./OsdkContext2.js";
+
+export interface UseObjectSetAggregationOptions<
+  Q extends ObjectTypeDefinition,
+  A extends AggregateOpts<Q>,
+  RDPs extends Record<string, SimplePropertyDef> = {},
+> {
+  where?: WhereClause<Q, RDPs>;
+
+  withProperties?: { [K in keyof RDPs]: DerivedProperty.Creator<Q, RDPs[K]> };
+
+  intersectWith?: Array<{
+    where: WhereClause<Q, RDPs>;
+  }>;
+
+  aggregate: A;
+
+  dedupeIntervalMs?: number;
+
+  enabled?: boolean;
+}
+
+export interface UseObjectSetAggregationResult<
+  Q extends ObjectTypeDefinition,
+  A extends AggregateOpts<Q>,
+> {
+  data: AggregationsResults<Q, A> | undefined;
+  isLoading: boolean;
+  error: Error | undefined;
+  refetch: () => void;
+}
+
+declare const process: {
+  env: {
+    NODE_ENV: "development" | "production";
+  };
+};
+
+export function useObjectSetAggregation<
+  Q extends ObjectTypeDefinition,
+  const A extends AggregateOpts<Q>,
+  RDPs extends Record<string, SimplePropertyDef> = {},
+>(
+  objectSet: ObjectSet<Q>,
+  options: UseObjectSetAggregationOptions<Q, A, RDPs>,
+): UseObjectSetAggregationResult<Q, A> {
+  const {
+    where,
+    withProperties,
+    intersectWith,
+    aggregate,
+    dedupeIntervalMs,
+    enabled = true,
+  } = options;
+
+  const { observableClient } = React.useContext(OsdkContext2);
+
+  const type = objectSet.$objectSetInternals.def as Q;
+
+  const canonWhere = observableClient.canonicalizeWhereClause<Q>(where ?? {});
+
+  const stableCanonWhere = React.useMemo(
+    () => canonWhere,
+    [JSON.stringify(canonWhere)],
+  );
+
+  const objectSetRef = React.useRef(objectSet);
+  objectSetRef.current = objectSet;
+
+  const objectSetKeyString = computeObjectSetCacheKey(objectSet);
+
+  const stableWithProperties = React.useMemo(
+    () => withProperties,
+    [JSON.stringify(withProperties)],
+  );
+
+  const stableAggregate = React.useMemo(
+    () => aggregate,
+    [JSON.stringify(aggregate)],
+  );
+
+  const stableIntersectWith = React.useMemo(
+    () => intersectWith,
+    [JSON.stringify(intersectWith)],
+  );
+
+  const { subscribe, getSnapShot } = React.useMemo(
+    () => {
+      if (!enabled) {
+        return makeExternalStoreAsync<ObserveAggregationArgs<Q, A>>(
+          () => Promise.resolve({ unsubscribe: () => {} }),
+          process.env.NODE_ENV !== "production"
+            ? `objectSetAggregation ${type.apiName} ${objectSetKeyString} [DISABLED]`
+            : void 0,
+        );
+      }
+
+      return makeExternalStoreAsync<ObserveAggregationArgs<Q, A>>(
+        (observer) =>
+          observableClient.observeAggregation(
+            {
+              type: type,
+              objectSet: objectSetRef.current,
+              where: stableCanonWhere,
+              withProperties: stableWithProperties,
+              intersectWith: stableIntersectWith,
+              aggregate: stableAggregate,
+              dedupeInterval: dedupeIntervalMs ?? 2_000,
+            },
+            observer,
+          ),
+        process.env.NODE_ENV !== "production"
+          ? `objectSetAggregation ${type.apiName} ${objectSetKeyString} ${
+            JSON.stringify(stableCanonWhere)
+          }`
+          : void 0,
+      );
+    },
+    [
+      enabled,
+      observableClient,
+      type.apiName,
+      objectSetKeyString,
+      stableCanonWhere,
+      stableWithProperties,
+      stableIntersectWith,
+      stableAggregate,
+      dedupeIntervalMs,
+    ],
+  );
+
+  const payload = React.useSyncExternalStore(subscribe, getSnapShot);
+
+  const refetch = React.useCallback(async () => {
+    await observableClient.invalidateObjectType(type.apiName);
+  }, [observableClient, type.apiName]);
+
+  return React.useMemo(() => {
+    let error: Error | undefined;
+    if (payload && "error" in payload && payload.error) {
+      error = payload.error;
+    } else if (payload?.status === "error") {
+      error = new Error("Failed to execute aggregation");
+    }
+
+    return {
+      data: payload?.result as AggregationsResults<Q, A> | undefined,
+      isLoading: enabled
+        ? (payload?.status === "loading" || payload?.status === "init"
+          || !payload)
+        : false,
+      error,
+      refetch,
+    };
+  }, [payload, refetch, enabled]);
+}

--- a/packages/react/src/new/useObjectSetLinks.ts
+++ b/packages/react/src/new/useObjectSetLinks.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  LinkedType,
+  LinkNames,
+  ObjectOrInterfaceDefinition,
+  ObjectSet,
+  ObjectTypeDefinition,
+  Osdk,
+  PropertyKeys,
+  WhereClause,
+} from "@osdk/api";
+import {
+  computeObjectSetCacheKey,
+  type ObserveObjectSetArgs,
+} from "@osdk/client/unstable-do-not-use";
+import React from "react";
+import { makeExternalStore } from "./makeExternalStore.js";
+import { OsdkContext2 } from "./OsdkContext2.js";
+
+export interface UseObjectSetLinksOptions<
+  T extends ObjectOrInterfaceDefinition,
+> {
+  where?: WhereClause<T>;
+
+  pageSize?: number;
+
+  orderBy?: { [K in PropertyKeys<T>]?: "asc" | "desc" };
+
+  dedupeIntervalMs?: number;
+
+  enabled?: boolean;
+
+  autoFetchMore?: boolean | number;
+
+  streamUpdates?: boolean;
+}
+
+export interface UseObjectSetLinksResult<
+  T extends ObjectOrInterfaceDefinition,
+> {
+  data: Osdk.Instance<T>[] | undefined;
+  isLoading: boolean;
+  error: Error | undefined;
+  isOptimistic: boolean;
+  fetchMore: (() => Promise<void>) | undefined;
+  hasMore: boolean;
+  objectSet: ObjectSet<T> | undefined;
+  totalCount?: string;
+  refetch: () => void;
+}
+
+declare const process: {
+  env: {
+    NODE_ENV: "development" | "production";
+  };
+};
+
+export function useObjectSetLinks<
+  Q extends ObjectTypeDefinition,
+  L extends LinkNames<Q>,
+>(
+  objectSet: ObjectSet<Q>,
+  linkName: L,
+  options: UseObjectSetLinksOptions<LinkedType<Q, L>> = {},
+): UseObjectSetLinksResult<LinkedType<Q, L>> {
+  const { observableClient } = React.useContext(OsdkContext2);
+
+  const { enabled = true, streamUpdates, ...otherOptions } = options;
+
+  const objectSetRef = React.useRef(objectSet);
+  objectSetRef.current = objectSet;
+
+  const stableKey = computeObjectSetCacheKey(objectSet, {
+    pivotTo: linkName,
+    where: otherOptions.where,
+    pageSize: otherOptions.pageSize,
+    orderBy: otherOptions.orderBy,
+  });
+
+  const stableWhere = React.useMemo(
+    () => otherOptions.where,
+    [JSON.stringify(otherOptions.where)],
+  );
+
+  const stableOrderBy = React.useMemo(
+    () => otherOptions.orderBy,
+    [JSON.stringify(otherOptions.orderBy)],
+  );
+
+  const { subscribe, getSnapShot } = React.useMemo(
+    () => {
+      if (!enabled) {
+        return makeExternalStore<ObserveObjectSetArgs<Q>>(
+          () => ({ unsubscribe: () => {} }),
+          process.env.NODE_ENV !== "production"
+            ? `objectSetLinks ${stableKey} [DISABLED]`
+            : void 0,
+        );
+      }
+
+      return makeExternalStore<ObserveObjectSetArgs<Q>>(
+        (observer) => {
+          return observableClient.observeObjectSet(
+            objectSetRef.current,
+            {
+              pivotTo: linkName,
+              where: stableWhere,
+              pageSize: otherOptions.pageSize,
+              orderBy: stableOrderBy,
+              dedupeInterval: otherOptions.dedupeIntervalMs ?? 2_000,
+              autoFetchMore: otherOptions.autoFetchMore,
+              streamUpdates,
+            },
+            observer,
+          );
+        },
+        process.env.NODE_ENV !== "production"
+          ? `objectSetLinks ${stableKey}`
+          : void 0,
+      );
+    },
+    [
+      enabled,
+      observableClient,
+      stableKey,
+      linkName,
+      stableWhere,
+      otherOptions.pageSize,
+      stableOrderBy,
+      streamUpdates,
+      otherOptions.dedupeIntervalMs,
+      otherOptions.autoFetchMore,
+    ],
+  );
+
+  const payload = React.useSyncExternalStore(subscribe, getSnapShot);
+
+  const refetch = React.useCallback(async () => {
+    await observableClient.invalidateObjectType(
+      objectSet.$objectSetInternals.def.apiName,
+    );
+  }, [observableClient, objectSet.$objectSetInternals.def.apiName]);
+
+  return React.useMemo(() => {
+    let error: Error | undefined;
+    if (payload && "error" in payload && payload.error) {
+      error = payload.error;
+    } else if (payload?.status === "error") {
+      error = new Error("Failed to fetch linked objects");
+    }
+
+    return {
+      data: payload?.resolvedList as
+        | Osdk.Instance<LinkedType<Q, L>>[]
+        | undefined,
+      isLoading: enabled
+        ? (payload?.status === "loading" || payload?.status === "init"
+          || !payload)
+        : false,
+      error,
+      isOptimistic: payload?.isOptimistic ?? false,
+      fetchMore: payload?.hasMore ? payload.fetchMore : undefined,
+      hasMore: payload?.hasMore ?? false,
+      objectSet: payload?.objectSet as ObjectSet<LinkedType<Q, L>> | undefined,
+      totalCount: payload?.totalCount,
+      refetch,
+    };
+  }, [payload, enabled, refetch]);
+}

--- a/packages/react/src/new/useOsdkObjects.ts
+++ b/packages/react/src/new/useOsdkObjects.ts
@@ -19,6 +19,7 @@ import type {
   LinkedType,
   LinkNames,
   ObjectOrInterfaceDefinition,
+  ObjectSet,
   Osdk,
   PropertyKeys,
   SimplePropertyDef,
@@ -168,6 +169,21 @@ export interface UseOsdkListResult<
    * The total count of objects matching the query (if available from the API)
    */
   totalCount?: string;
+
+  /**
+   * Whether there are more pages available to fetch
+   */
+  hasMore: boolean;
+
+  /**
+   * The underlying ObjectSet for composition with useObjectSetLinks or useObjectSetAggregation
+   */
+  objectSet: ObjectSet<T, RDPs> | undefined;
+
+  /**
+   * Refetch data by invalidating the object type cache
+   */
+  refetch: () => void;
 }
 
 const EMPTY_WHERE = {};
@@ -327,6 +343,10 @@ export function useOsdkObjects<
 
   const listPayload = React.useSyncExternalStore(subscribe, getSnapShot);
 
+  const refetch = React.useCallback(async () => {
+    await observableClient.invalidateObjectType(type.apiName);
+  }, [observableClient, type.apiName]);
+
   return React.useMemo(() => {
     let error: Error | undefined;
     if (listPayload && "error" in listPayload && listPayload.error) {
@@ -345,6 +365,9 @@ export function useOsdkObjects<
         : false,
       isOptimistic: listPayload?.isOptimistic ?? false,
       totalCount: listPayload?.totalCount,
+      hasMore: listPayload?.hasMore ?? false,
+      objectSet: listPayload?.objectSet,
+      refetch,
     };
-  }, [listPayload, enabled]);
+  }, [listPayload, enabled, refetch]);
 }

--- a/packages/react/src/public/experimental.ts
+++ b/packages/react/src/public/experimental.ts
@@ -20,6 +20,16 @@ export { useFoundryUser } from "../new/platform-apis/admin/useFoundryUser.js";
 export { useFoundryUsersList } from "../new/platform-apis/admin/useFoundryUsersList.js";
 export { useLinks } from "../new/useLinks.js";
 export { useObjectSet } from "../new/useObjectSet.js";
+export { useObjectSetAggregation } from "../new/useObjectSetAggregation.js";
+export type {
+  UseObjectSetAggregationOptions,
+  UseObjectSetAggregationResult,
+} from "../new/useObjectSetAggregation.js";
+export { useObjectSetLinks } from "../new/useObjectSetLinks.js";
+export type {
+  UseObjectSetLinksOptions,
+  UseObjectSetLinksResult,
+} from "../new/useObjectSetLinks.js";
 export { useOsdkAction } from "../new/useOsdkAction.js";
 export type { UseOsdkAggregationResult } from "../new/useOsdkAggregation.js";
 export { useOsdkAggregation } from "../new/useOsdkAggregation.js";

--- a/packages/react/test/useObjectSet.test.tsx
+++ b/packages/react/test/useObjectSet.test.tsx
@@ -46,11 +46,13 @@ describe(useObjectSet, () => {
     error: (err: any) => void;
   } | null = null;
   const mockObserveObjectSet = vitest.fn();
+  const mockInvalidateObjectType = vitest.fn();
 
   const createWrapper = () => {
     const observableClient = {
       observeObjectSet: mockObserveObjectSet,
       canonicalizeWhereClause: vitest.fn((w) => w),
+      invalidateObjectType: mockInvalidateObjectType,
     } as any;
 
     return ({ children }: React.PropsWithChildren) => (
@@ -63,6 +65,8 @@ describe(useObjectSet, () => {
   beforeEach(() => {
     capturedObserver = null;
     mockObserveObjectSet.mockClear();
+    mockInvalidateObjectType.mockClear();
+    mockInvalidateObjectType.mockResolvedValue(undefined);
     mockObserveObjectSet.mockImplementation((_os, _opts, observer) => {
       capturedObserver = observer;
       return { unsubscribe: vitest.fn() };
@@ -97,6 +101,17 @@ describe(useObjectSet, () => {
       rerender({ enabled: true });
 
       expect(mockObserveObjectSet).toHaveBeenCalledTimes(1);
+    });
+
+    it("should return isLoading false when enabled is false", () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () => useObjectSet(mockObjectSet, { enabled: false }),
+        { wrapper },
+      );
+
+      expect(result.current.isLoading).toBe(false);
     });
   });
 
@@ -242,6 +257,99 @@ describe(useObjectSet, () => {
       });
 
       expect(result.current.fetchMore).toBeUndefined();
+    });
+
+    it("should return isOptimistic from payload", () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () => useObjectSet(mockObjectSet),
+        { wrapper },
+      );
+
+      act(() => {
+        capturedObserver?.next({
+          resolvedList: [{ $primaryKey: "1" }],
+          status: "loaded",
+          isOptimistic: true,
+          hasMore: false,
+        });
+      });
+
+      expect(result.current.isOptimistic).toBe(true);
+    });
+
+    it("should default isOptimistic to false when not in payload", () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () => useObjectSet(mockObjectSet),
+        { wrapper },
+      );
+
+      act(() => {
+        capturedObserver?.next({
+          resolvedList: [{ $primaryKey: "1" }],
+          status: "loaded",
+        });
+      });
+
+      expect(result.current.isOptimistic).toBe(false);
+    });
+
+    it("should return hasMore from payload", () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () => useObjectSet(mockObjectSet),
+        { wrapper },
+      );
+
+      act(() => {
+        capturedObserver?.next({
+          resolvedList: [{ $primaryKey: "1" }],
+          status: "loaded",
+          hasMore: true,
+          fetchMore: vitest.fn(),
+        });
+      });
+
+      expect(result.current.hasMore).toBe(true);
+    });
+
+    it("should default hasMore to false when not in payload", () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () => useObjectSet(mockObjectSet),
+        { wrapper },
+      );
+
+      act(() => {
+        capturedObserver?.next({
+          resolvedList: [{ $primaryKey: "1" }],
+          status: "loaded",
+        });
+      });
+
+      expect(result.current.hasMore).toBe(false);
+    });
+  });
+
+  describe("refetch", () => {
+    it("should call invalidateObjectType on refetch", async () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () => useObjectSet(mockObjectSet),
+        { wrapper },
+      );
+
+      await act(async () => {
+        result.current.refetch();
+      });
+
+      expect(mockInvalidateObjectType).toHaveBeenCalledWith("MockObject");
     });
   });
 

--- a/packages/react/test/useObjectSetAggregation.test.tsx
+++ b/packages/react/test/useObjectSetAggregation.test.tsx
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectSet, ObjectTypeDefinition } from "@osdk/api";
+import { act, renderHook } from "@testing-library/react";
+import * as React from "react";
+import { beforeEach, describe, expect, it, vitest } from "vitest";
+import { OsdkContext2 } from "../src/new/OsdkContext2.js";
+import { useObjectSetAggregation } from "../src/new/useObjectSetAggregation.js";
+
+const MockObjectType = {
+  apiName: "MockObject",
+  primaryKeyType: "string",
+} as unknown as ObjectTypeDefinition;
+
+const createMockObjectSet = (type: ObjectTypeDefinition) =>
+  ({
+    $__EXPERIMENTAL_objectSet: true,
+    type,
+    $objectSetInternals: { def: type },
+  }) as unknown as ObjectSet<typeof type>;
+
+const mockObjectSet = createMockObjectSet(MockObjectType);
+
+const defaultAggregate = {
+  $select: { $count: "unordered" as const },
+};
+
+describe(useObjectSetAggregation, () => {
+  let capturedObserver: {
+    next: (value: unknown) => void;
+    error: (err: unknown) => void;
+  } | null = null;
+  let mockObserveAggregation: ReturnType<typeof vitest.fn>;
+  let mockInvalidateObjectType: ReturnType<typeof vitest.fn>;
+
+  const createWrapper = () => {
+    const observableClient = {
+      observeAggregation: mockObserveAggregation,
+      canonicalizeWhereClause: vitest.fn((w: unknown) => w),
+      invalidateObjectType: mockInvalidateObjectType,
+    } as any;
+
+    return ({ children }: React.PropsWithChildren) => (
+      <OsdkContext2.Provider value={{ observableClient }}>
+        {children}
+      </OsdkContext2.Provider>
+    );
+  };
+
+  beforeEach(() => {
+    capturedObserver = null;
+    mockObserveAggregation = vitest.fn()
+      .mockImplementation(
+        (_opts: unknown, observer: typeof capturedObserver) => {
+          capturedObserver = observer;
+          return Promise.resolve({ unsubscribe: vitest.fn() });
+        },
+      );
+    mockInvalidateObjectType = vitest.fn().mockResolvedValue(undefined);
+  });
+
+  describe("data flow", () => {
+    it("should return loading state initially", () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () =>
+          useObjectSetAggregation(mockObjectSet, {
+            aggregate: defaultAggregate,
+          }),
+        { wrapper },
+      );
+
+      expect(result.current.data).toBeUndefined();
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.error).toBeUndefined();
+    });
+
+    it("should return aggregation data when loaded", () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () =>
+          useObjectSetAggregation(mockObjectSet, {
+            aggregate: defaultAggregate,
+          }),
+        { wrapper },
+      );
+
+      act(() => {
+        capturedObserver?.next({
+          result: { $count: 5 },
+          status: "loaded",
+        });
+      });
+
+      expect(result.current.data).toEqual({ $count: 5 });
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeUndefined();
+    });
+
+    it("should call observeAggregation with correct args", () => {
+      const wrapper = createWrapper();
+
+      renderHook(
+        () =>
+          useObjectSetAggregation(mockObjectSet, {
+            aggregate: defaultAggregate,
+          }),
+        { wrapper },
+      );
+
+      expect(mockObserveAggregation).toHaveBeenCalledTimes(1);
+      const args = mockObserveAggregation.mock.calls[0][0];
+      expect(args.type).toBe(MockObjectType);
+      expect(args.objectSet).toBe(mockObjectSet);
+      expect(args.aggregate).toEqual(defaultAggregate);
+      expect(args.dedupeInterval).toBe(2_000);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should return error from observer.error", () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () =>
+          useObjectSetAggregation(mockObjectSet, {
+            aggregate: defaultAggregate,
+          }),
+        { wrapper },
+      );
+
+      const testError = new Error("aggregation failed");
+
+      act(() => {
+        capturedObserver?.error(testError);
+      });
+
+      expect(result.current.error).toBe(testError);
+    });
+
+    it("should return synthetic error for status 'error'", () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () =>
+          useObjectSetAggregation(mockObjectSet, {
+            aggregate: defaultAggregate,
+          }),
+        { wrapper },
+      );
+
+      act(() => {
+        capturedObserver?.next({ status: "error" });
+      });
+
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.error?.message).toBe(
+        "Failed to execute aggregation",
+      );
+    });
+  });
+
+  describe("refetch", () => {
+    it("should call invalidateObjectType on refetch", async () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () =>
+          useObjectSetAggregation(mockObjectSet, {
+            aggregate: defaultAggregate,
+          }),
+        { wrapper },
+      );
+
+      await act(async () => {
+        result.current.refetch();
+      });
+
+      expect(mockInvalidateObjectType).toHaveBeenCalledWith("MockObject");
+    });
+  });
+
+  describe("options", () => {
+    it("should use default dedupeIntervalMs of 2000", () => {
+      const wrapper = createWrapper();
+
+      renderHook(
+        () =>
+          useObjectSetAggregation(mockObjectSet, {
+            aggregate: defaultAggregate,
+          }),
+        { wrapper },
+      );
+
+      expect(mockObserveAggregation).toHaveBeenCalledTimes(1);
+      const args = mockObserveAggregation.mock.calls[0][0];
+      expect(args.dedupeInterval).toBe(2_000);
+    });
+
+    it("should pass custom dedupeIntervalMs", () => {
+      const wrapper = createWrapper();
+
+      renderHook(
+        () =>
+          useObjectSetAggregation(mockObjectSet, {
+            aggregate: defaultAggregate,
+            dedupeIntervalMs: 5000,
+          }),
+        { wrapper },
+      );
+
+      expect(mockObserveAggregation).toHaveBeenCalledTimes(1);
+      const args = mockObserveAggregation.mock.calls[0][0];
+      expect(args.dedupeInterval).toBe(5000);
+    });
+
+    it("should NOT call observeAggregation when enabled is false", () => {
+      const wrapper = createWrapper();
+
+      renderHook(
+        () =>
+          useObjectSetAggregation(mockObjectSet, {
+            aggregate: defaultAggregate,
+            enabled: false,
+          }),
+        { wrapper },
+      );
+
+      expect(mockObserveAggregation).not.toHaveBeenCalled();
+    });
+
+    it("should return isLoading false when enabled is false", () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () =>
+          useObjectSetAggregation(mockObjectSet, {
+            aggregate: defaultAggregate,
+            enabled: false,
+          }),
+        { wrapper },
+      );
+
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it("should start observing when enabled changes to true", () => {
+      const wrapper = createWrapper();
+
+      const { rerender } = renderHook(
+        ({ enabled }) =>
+          useObjectSetAggregation(mockObjectSet, {
+            aggregate: defaultAggregate,
+            enabled,
+          }),
+        {
+          wrapper,
+          initialProps: { enabled: false },
+        },
+      );
+
+      expect(mockObserveAggregation).not.toHaveBeenCalled();
+
+      rerender({ enabled: true });
+
+      expect(mockObserveAggregation).toHaveBeenCalledTimes(1);
+    });
+
+    it("should pass where clause to observeAggregation", () => {
+      const wrapper = createWrapper();
+      const whereClause = { name: "test" };
+
+      renderHook(
+        () =>
+          useObjectSetAggregation(mockObjectSet, {
+            aggregate: defaultAggregate,
+            where: whereClause as any,
+          }),
+        { wrapper },
+      );
+
+      expect(mockObserveAggregation).toHaveBeenCalledTimes(1);
+      const args = mockObserveAggregation.mock.calls[0][0];
+      expect(args.where).toEqual(whereClause);
+    });
+  });
+});

--- a/packages/react/test/useObjectSetLinks.test.tsx
+++ b/packages/react/test/useObjectSetLinks.test.tsx
@@ -1,0 +1,408 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectSet, ObjectTypeDefinition } from "@osdk/api";
+import { act, renderHook } from "@testing-library/react";
+import * as React from "react";
+import { beforeEach, describe, expect, it, vitest } from "vitest";
+import { OsdkContext2 } from "../src/new/OsdkContext2.js";
+import { useObjectSetLinks } from "../src/new/useObjectSetLinks.js";
+
+const MockObjectType = {
+  apiName: "MockObject",
+  primaryKeyType: "string",
+} as unknown as ObjectTypeDefinition;
+
+const createMockObjectSet = (type: ObjectTypeDefinition) =>
+  ({
+    $__EXPERIMENTAL_objectSet: true,
+    type,
+    $objectSetInternals: { def: type },
+  }) as unknown as ObjectSet<typeof type>;
+
+const mockObjectSet = createMockObjectSet(MockObjectType);
+
+describe(useObjectSetLinks, () => {
+  let capturedObserver: {
+    next: (value: unknown) => void;
+    error: (err: unknown) => void;
+  } | null = null;
+  let mockObserveObjectSet: ReturnType<typeof vitest.fn>;
+  let mockInvalidateObjectType: ReturnType<typeof vitest.fn>;
+
+  const createWrapper = () => {
+    const observableClient = {
+      observeObjectSet: mockObserveObjectSet,
+      canonicalizeWhereClause: vitest.fn((w: unknown) => w),
+      invalidateObjectType: mockInvalidateObjectType,
+    } as any;
+
+    return ({ children }: React.PropsWithChildren) => (
+      <OsdkContext2.Provider value={{ observableClient }}>
+        {children}
+      </OsdkContext2.Provider>
+    );
+  };
+
+  beforeEach(() => {
+    capturedObserver = null;
+    mockObserveObjectSet = vitest.fn()
+      .mockImplementation(
+        (_os: unknown, _opts: unknown, observer: typeof capturedObserver) => {
+          capturedObserver = observer;
+          return { unsubscribe: vitest.fn() };
+        },
+      );
+    mockInvalidateObjectType = vitest.fn().mockResolvedValue(undefined);
+  });
+
+  describe("data flow", () => {
+    it("should return loading state initially", () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () => useObjectSetLinks(mockObjectSet as any, "testLink" as any),
+        { wrapper },
+      );
+
+      expect(result.current.data).toBeUndefined();
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.error).toBeUndefined();
+    });
+
+    it("should return links when loaded", () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () => useObjectSetLinks(mockObjectSet as any, "testLink" as any),
+        { wrapper },
+      );
+
+      const mockLinks = [
+        { $primaryKey: "1", name: "Link 1" },
+        { $primaryKey: "2", name: "Link 2" },
+      ];
+
+      act(() => {
+        capturedObserver?.next({
+          resolvedList: mockLinks,
+          status: "loaded",
+          hasMore: false,
+          isOptimistic: false,
+        });
+      });
+
+      expect(result.current.data).toEqual(mockLinks);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeUndefined();
+    });
+
+    it("should pass pivotTo to observeObjectSet", () => {
+      const wrapper = createWrapper();
+
+      renderHook(
+        () => useObjectSetLinks(mockObjectSet as any, "testLink" as any),
+        { wrapper },
+      );
+
+      expect(mockObserveObjectSet).toHaveBeenCalledTimes(1);
+      const opts = mockObserveObjectSet.mock.calls[0][1];
+      expect(opts.pivotTo).toBe("testLink");
+    });
+
+    it("should return fetchMore when hasMore is true", () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () => useObjectSetLinks(mockObjectSet as any, "testLink" as any),
+        { wrapper },
+      );
+
+      const mockFetchMore = vitest.fn();
+
+      act(() => {
+        capturedObserver?.next({
+          resolvedList: [{ $primaryKey: "1" }],
+          status: "loaded",
+          hasMore: true,
+          isOptimistic: false,
+          fetchMore: mockFetchMore,
+        });
+      });
+
+      expect(result.current.fetchMore).toBe(mockFetchMore);
+      expect(result.current.hasMore).toBe(true);
+    });
+
+    it("should not return fetchMore when hasMore is false", () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () => useObjectSetLinks(mockObjectSet as any, "testLink" as any),
+        { wrapper },
+      );
+
+      act(() => {
+        capturedObserver?.next({
+          resolvedList: [{ $primaryKey: "1" }],
+          status: "loaded",
+          hasMore: false,
+          isOptimistic: false,
+          fetchMore: vitest.fn(),
+        });
+      });
+
+      expect(result.current.fetchMore).toBeUndefined();
+    });
+
+    it("should return isOptimistic from payload", () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () => useObjectSetLinks(mockObjectSet as any, "testLink" as any),
+        { wrapper },
+      );
+
+      act(() => {
+        capturedObserver?.next({
+          resolvedList: [{ $primaryKey: "1" }],
+          status: "loaded",
+          hasMore: false,
+          isOptimistic: true,
+        });
+      });
+
+      expect(result.current.isOptimistic).toBe(true);
+    });
+
+    it("should return totalCount from payload", () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () => useObjectSetLinks(mockObjectSet as any, "testLink" as any),
+        { wrapper },
+      );
+
+      act(() => {
+        capturedObserver?.next({
+          resolvedList: [{ $primaryKey: "1" }],
+          status: "loaded",
+          hasMore: false,
+          isOptimistic: false,
+          totalCount: "42",
+        });
+      });
+
+      expect(result.current.totalCount).toBe("42");
+    });
+
+    it("should return objectSet from payload", () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () => useObjectSetLinks(mockObjectSet as any, "testLink" as any),
+        { wrapper },
+      );
+
+      const mockLinkedObjectSet = { type: "linked" };
+
+      act(() => {
+        capturedObserver?.next({
+          resolvedList: [{ $primaryKey: "1" }],
+          status: "loaded",
+          hasMore: false,
+          isOptimistic: false,
+          objectSet: mockLinkedObjectSet,
+        });
+      });
+
+      expect(result.current.objectSet).toBe(mockLinkedObjectSet);
+    });
+
+    it("should return undefined objectSet before payload arrives", () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () => useObjectSetLinks(mockObjectSet as any, "testLink" as any),
+        { wrapper },
+      );
+
+      expect(result.current.objectSet).toBeUndefined();
+    });
+  });
+
+  describe("refetch", () => {
+    it("should call invalidateObjectType on refetch", async () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () => useObjectSetLinks(mockObjectSet as any, "testLink" as any),
+        { wrapper },
+      );
+
+      await act(async () => {
+        result.current.refetch();
+      });
+
+      expect(mockInvalidateObjectType).toHaveBeenCalledWith("MockObject");
+    });
+  });
+
+  describe("enabled option", () => {
+    it("should NOT call observeObjectSet when enabled is false", () => {
+      const wrapper = createWrapper();
+
+      renderHook(
+        () =>
+          useObjectSetLinks(mockObjectSet as any, "testLink" as any, {
+            enabled: false,
+          }),
+        { wrapper },
+      );
+
+      expect(mockObserveObjectSet).not.toHaveBeenCalled();
+    });
+
+    it("should start observing when enabled changes to true", () => {
+      const wrapper = createWrapper();
+
+      const { rerender } = renderHook(
+        ({ enabled }) =>
+          useObjectSetLinks(mockObjectSet as any, "testLink" as any, {
+            enabled,
+          }),
+        {
+          wrapper,
+          initialProps: { enabled: false },
+        },
+      );
+
+      expect(mockObserveObjectSet).not.toHaveBeenCalled();
+
+      rerender({ enabled: true });
+
+      expect(mockObserveObjectSet).toHaveBeenCalledTimes(1);
+    });
+
+    it("should return isLoading false when disabled", () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () =>
+          useObjectSetLinks(mockObjectSet as any, "testLink" as any, {
+            enabled: false,
+          }),
+        { wrapper },
+      );
+
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should return error from observer.error", () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () => useObjectSetLinks(mockObjectSet as any, "testLink" as any),
+        { wrapper },
+      );
+
+      const testError = new Error("link fetch failed");
+
+      act(() => {
+        capturedObserver?.error(testError);
+      });
+
+      expect(result.current.error).toBe(testError);
+    });
+
+    it("should return synthetic error for status 'error'", () => {
+      const wrapper = createWrapper();
+
+      const { result } = renderHook(
+        () => useObjectSetLinks(mockObjectSet as any, "testLink" as any),
+        { wrapper },
+      );
+
+      act(() => {
+        capturedObserver?.next({ status: "error" });
+      });
+
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.error?.message).toBe(
+        "Failed to fetch linked objects",
+      );
+    });
+  });
+
+  describe("options", () => {
+    it("should pass where, orderBy, pageSize, autoFetchMore, streamUpdates to observeObjectSet", () => {
+      const wrapper = createWrapper();
+      const where = { name: "test" };
+      const orderBy = { name: "asc" as const };
+
+      renderHook(
+        () =>
+          useObjectSetLinks(mockObjectSet as any, "testLink" as any, {
+            where: where as any,
+            orderBy: orderBy as any,
+            pageSize: 50,
+            autoFetchMore: true,
+            streamUpdates: true,
+          }),
+        { wrapper },
+      );
+
+      expect(mockObserveObjectSet).toHaveBeenCalledTimes(1);
+      const opts = mockObserveObjectSet.mock.calls[0][1];
+      expect(opts.where).toEqual(where);
+      expect(opts.orderBy).toEqual(orderBy);
+      expect(opts.pageSize).toBe(50);
+      expect(opts.autoFetchMore).toBe(true);
+      expect(opts.streamUpdates).toBe(true);
+    });
+
+    it("should default dedupeIntervalMs to 2000", () => {
+      const wrapper = createWrapper();
+
+      renderHook(
+        () => useObjectSetLinks(mockObjectSet as any, "testLink" as any),
+        { wrapper },
+      );
+
+      expect(mockObserveObjectSet).toHaveBeenCalledTimes(1);
+      const opts = mockObserveObjectSet.mock.calls[0][1];
+      expect(opts.dedupeInterval).toBe(2_000);
+    });
+
+    it("should pass custom dedupeIntervalMs", () => {
+      const wrapper = createWrapper();
+
+      renderHook(
+        () =>
+          useObjectSetLinks(mockObjectSet as any, "testLink" as any, {
+            dedupeIntervalMs: 5000,
+          }),
+        { wrapper },
+      );
+
+      expect(mockObserveObjectSet).toHaveBeenCalledTimes(1);
+      const opts = mockObserveObjectSet.mock.calls[0][1];
+      expect(opts.dedupeInterval).toBe(5000);
+    });
+  });
+});

--- a/packages/react/test/useOsdkObjects.test.tsx
+++ b/packages/react/test/useOsdkObjects.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import type { ObjectTypeDefinition } from "@osdk/api";
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import * as React from "react";
 import { beforeEach, describe, expect, it, vitest } from "vitest";
 import { OsdkContext2 } from "../src/new/OsdkContext2.js";
@@ -28,10 +28,12 @@ const MockObjectType = {
 
 describe("useOsdkObjects enabled option", () => {
   const mockObserveList = vitest.fn();
+  const mockInvalidateObjectType = vitest.fn().mockResolvedValue(undefined);
 
   const createWrapper = () => {
     const observableClient = {
       observeList: mockObserveList,
+      invalidateObjectType: mockInvalidateObjectType,
       canonicalizeWhereClause: vitest.fn((w) => w),
     } as any;
 
@@ -44,6 +46,7 @@ describe("useOsdkObjects enabled option", () => {
 
   beforeEach(() => {
     mockObserveList.mockClear();
+    mockInvalidateObjectType.mockClear();
     mockObserveList.mockReturnValue({ unsubscribe: vitest.fn() });
   });
 
@@ -149,5 +152,54 @@ describe("useOsdkObjects enabled option", () => {
       }),
       expect.any(Object),
     );
+  });
+
+  it("should return hasMore as false before data loads", () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () => useOsdkObjects(MockObjectType),
+      { wrapper },
+    );
+
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it("should return objectSet as undefined before data loads", () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () => useOsdkObjects(MockObjectType),
+      { wrapper },
+    );
+
+    expect(result.current.objectSet).toBeUndefined();
+  });
+
+  it("should return refetch as a function", () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () => useOsdkObjects(MockObjectType),
+      { wrapper },
+    );
+
+    expect(typeof result.current.refetch).toBe("function");
+  });
+
+  it("should call invalidateObjectType when refetch is invoked", async () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () => useOsdkObjects(MockObjectType),
+      { wrapper },
+    );
+
+    await act(async () => {
+      result.current.refetch();
+    });
+
+    expect(mockInvalidateObjectType).toHaveBeenCalledTimes(1);
+    expect(mockInvalidateObjectType).toHaveBeenCalledWith("MockObject");
   });
 });


### PR DESCRIPTION
Adds new object-set native hooks for osdk-react

• useObjectSet returned isLoading: true when enabled was false, inconsistent with the new sibling hooks
• add useObjectSetLinks and useObjectSetAggregation hooks with consistent return shapes
• fix useObjectSet isLoading to gate on enabled flag, matching the pattern in sibling hooks
• add missing test coverage for isOptimistic, hasMore, refetch, and disabled isLoading in useObjectSet