### PR TITLE
fix peer dep ranges for osdk packages

### DIFF
--- a/.changeset/peer-dep-ranges.md
+++ b/.changeset/peer-dep-ranges.md
@@ -1,0 +1,6 @@
+---
+"@osdk/react": patch
+"@osdk/react-components": patch
+---
+
+auto-compute peer dependency ranges from changelog history for react and react-components

--- a/packages/react-components-styles/package.json
+++ b/packages/react-components-styles/package.json
@@ -13,7 +13,7 @@
     "check-spelling": "cspell --quiet ."
   },
   "peerDependencies": {
-    "@blueprintjs/core": "^5.19.1 || ^6.7.0"
+    "@blueprintjs/core": "^6.8.1"
   },
   "devDependencies": {
     "@blueprintjs/core": "^6.8.1"

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -73,9 +73,9 @@
     "react-hook-form": "^7.54.0"
   },
   "peerDependencies": {
-    "@osdk/api": "*",
-    "@osdk/client": "*",
-    "@osdk/react": "*",
+    "@osdk/api": ">=2.8.0-beta.0",
+    "@osdk/client": ">=2.8.0-beta.0",
+    "@osdk/react": ">=0.10.0-beta.0",
     "@types/react": "^17 || ^18 || ^19",
     "classnames": "^2.0.0",
     "react": "^17 || ^18 || ^19",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -60,8 +60,8 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "peerDependencies": {
-    "@osdk/api": "*",
-    "@osdk/client": "*",
+    "@osdk/api": ">=2.8.0-beta.0",
+    "@osdk/client": ">=2.8.0-beta.0",
     "@osdk/foundry.admin": "*",
     "@osdk/foundry.core": "*",
     "@types/react": "^17 || ^18 || ^19",

--- a/packages/version-updater/scripts/determineMinVersion.mjs
+++ b/packages/version-updater/scripts/determineMinVersion.mjs
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+import * as semver from "semver";
+
+/**
+ * @typedef {import('./parseChangelog.mjs').VersionMapping} VersionMapping
+ */
+
+/**
+ * Determines the minimum compatible version of a peer dependency for a given
+ * package version by analyzing the version history.
+ *
+ * The algorithm finds the oldest peer dep version that was paired with
+ * any package version in the same version series. For 0.x versions,
+ * the minor version is treated as the series boundary. For >=1.x,
+ * the major version is the series boundary.
+ *
+ * @param {VersionMapping[]} mappings - Version mappings from CHANGELOG
+ * @param {string} currentPackageVersion - Current version of the package
+ * @param {string} peerPackageName - Name of the peer dependency to find min for
+ * @returns {string | undefined} Minimum compatible peer dep version
+ */
+export function determineMinVersion(
+  mappings,
+  currentPackageVersion,
+  peerPackageName,
+) {
+  const currentParsed = semver.parse(currentPackageVersion);
+  if (!currentParsed) {
+    return undefined;
+  }
+
+  const currentMajor = currentParsed.major;
+  const currentMinor = currentParsed.minor;
+
+  const sameSeriesMappings = mappings.filter((m) => {
+    const parsed = semver.parse(m.packageVersion);
+    if (!parsed) {
+      return false;
+    }
+
+    if (currentMajor === 0) {
+      return parsed.major === 0 && parsed.minor === currentMinor;
+    }
+    return parsed.major === currentMajor;
+  });
+
+  const peerVersions = sameSeriesMappings
+    .map((m) => m.peerVersions[peerPackageName])
+    .filter((v) => v != null);
+
+  if (peerVersions.length === 0) {
+    return undefined;
+  }
+
+  return peerVersions.sort(semver.compare)[0];
+}

--- a/packages/version-updater/scripts/generatePeerRange.mjs
+++ b/packages/version-updater/scripts/generatePeerRange.mjs
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+import * as semver from "semver";
+
+/**
+ * Generates an appropriate semver peer dependency range.
+ *
+ * For prerelease peer versions where the min is on the same
+ * major.minor.patch tuple, uses `>=major.minor.patch-beta.0`.
+ *
+ * For prerelease peer versions where the min is on a different tuple,
+ * produces `^minClean || >=major.minor.patch-beta.0` so that both
+ * stable releases from the min series AND betas on the current tuple
+ * are accepted. This is necessary because npm semver does not match
+ * prereleases against ranges without a prerelease on the same
+ * major.minor.patch.
+ *
+ * For stable peer versions, uses `^minVersion` (with any prerelease tag
+ * stripped from the min so the range is clean).
+ *
+ * @param {string} minVersion - Minimum compatible version from changelog analysis
+ * @param {string} currentPeerVersion - Current version of the peer dependency package
+ * @returns {string} Semver range string for peer dependency
+ */
+export function generatePeerRange(minVersion, currentPeerVersion) {
+  const peerParsed = semver.parse(currentPeerVersion);
+
+  if (!peerParsed) {
+    throw new Error(`Invalid currentPeerVersion: ${currentPeerVersion}`);
+  }
+
+  if (peerParsed.prerelease && peerParsed.prerelease.length > 0) {
+    const betaRange =
+      `>=${peerParsed.major}.${peerParsed.minor}.${peerParsed.patch}-beta.0`;
+    const minParsed = semver.parse(minVersion);
+    if (!minParsed) {
+      throw new Error(`Invalid minVersion: ${minVersion}`);
+    }
+    const minClean = `${minParsed.major}.${minParsed.minor}.${minParsed.patch}`;
+    const peerClean =
+      `${peerParsed.major}.${peerParsed.minor}.${peerParsed.patch}`;
+
+    if (minClean === peerClean) {
+      return betaRange;
+    }
+    return `^${minClean} || ${betaRange}`;
+  }
+
+  const minParsed = semver.parse(minVersion);
+  if (minParsed) {
+    return `^${minParsed.major}.${minParsed.minor}.${minParsed.patch}`;
+  }
+
+  return `^${minVersion}`;
+}

--- a/packages/version-updater/scripts/parseChangelog.mjs
+++ b/packages/version-updater/scripts/parseChangelog.mjs
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * @typedef {Object} VersionMapping
+ * @property {string} packageVersion
+ * @property {Record<string, string>} peerVersions
+ */
+
+/**
+ * Parses a CHANGELOG.md file to extract version mappings between a package
+ * and its peer dependencies.
+ *
+ * @param {string} content - The raw CHANGELOG.md content
+ * @param {string[]} peerPackageNames - Package names to extract versions for (e.g. ["@osdk/client", "@osdk/api"])
+ * @returns {VersionMapping[]} Array of version mappings
+ */
+export function parseChangelog(content, peerPackageNames) {
+  const versionBlocks = content.split(/^## /m).slice(1);
+
+  return versionBlocks
+    .map((block) => {
+      const versionMatch = block.match(/^(\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?)/);
+      if (!versionMatch) {
+        return undefined;
+      }
+
+      /** @type {Record<string, string>} */
+      const peerVersions = {};
+      for (const peerName of peerPackageNames) {
+        const escaped = peerName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const match = block.match(
+          new RegExp(`${escaped}@(\\d+\\.\\d+\\.\\d+(-[a-zA-Z0-9.]+)?)`),
+        );
+        if (match) {
+          peerVersions[peerName] = match[1];
+        }
+      }
+
+      if (Object.keys(peerVersions).length === 0) {
+        return undefined;
+      }
+
+      return {
+        packageVersion: versionMatch[1],
+        peerVersions,
+      };
+    })
+    .filter(
+      /** @returns {m is VersionMapping} */
+      (m) => m != null,
+    );
+}

--- a/packages/version-updater/scripts/peerDepUtils.test.mjs
+++ b/packages/version-updater/scripts/peerDepUtils.test.mjs
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { determineMinVersion } from "./determineMinVersion.mjs";
+import { generatePeerRange } from "./generatePeerRange.mjs";
+import { parseChangelog } from "./parseChangelog.mjs";
+
+describe("parseChangelog", () => {
+  const SAMPLE_CHANGELOG = `# @osdk/widget.client-react
+
+## 3.5.0-beta.11
+
+### Patch Changes
+
+- Updated dependencies [642be5f]
+- Updated dependencies [525f277]
+  - @osdk/client@2.8.0-beta.11
+  - @osdk/widget.client@3.5.0-beta.11
+
+## 3.5.0-beta.10
+
+### Patch Changes
+
+- Updated dependencies [27a5902]
+  - @osdk/client@2.8.0-beta.10
+  - @osdk/widget.client@3.5.0-beta.10
+
+## 3.4.0-beta.2
+
+### Patch Changes
+
+- Updated dependencies [03db734]
+  - @osdk/client@2.7.0-beta.2
+  - @osdk/api@2.7.0-beta.2
+
+## 3.3.0-beta.2
+
+### Minor Changes
+
+- 4d37e98: Improved support
+
+### Patch Changes
+
+- @osdk/widget.client@3.3.0-beta.2
+`;
+
+  it("extracts version mappings for a single peer", () => {
+    const mappings = parseChangelog(SAMPLE_CHANGELOG, ["@osdk/client"]);
+    expect(mappings).toEqual([
+      {
+        packageVersion: "3.5.0-beta.11",
+        peerVersions: { "@osdk/client": "2.8.0-beta.11" },
+      },
+      {
+        packageVersion: "3.5.0-beta.10",
+        peerVersions: { "@osdk/client": "2.8.0-beta.10" },
+      },
+      {
+        packageVersion: "3.4.0-beta.2",
+        peerVersions: { "@osdk/client": "2.7.0-beta.2" },
+      },
+    ]);
+  });
+
+  it("extracts version mappings for multiple peers", () => {
+    const mappings = parseChangelog(SAMPLE_CHANGELOG, [
+      "@osdk/client",
+      "@osdk/api",
+    ]);
+    expect(mappings).toEqual([
+      {
+        packageVersion: "3.5.0-beta.11",
+        peerVersions: { "@osdk/client": "2.8.0-beta.11" },
+      },
+      {
+        packageVersion: "3.5.0-beta.10",
+        peerVersions: { "@osdk/client": "2.8.0-beta.10" },
+      },
+      {
+        packageVersion: "3.4.0-beta.2",
+        peerVersions: {
+          "@osdk/client": "2.7.0-beta.2",
+          "@osdk/api": "2.7.0-beta.2",
+        },
+      },
+    ]);
+  });
+
+  it("excludes entries with no matching peer versions", () => {
+    const mappings = parseChangelog(SAMPLE_CHANGELOG, ["@osdk/api"]);
+    expect(mappings).toEqual([
+      {
+        packageVersion: "3.4.0-beta.2",
+        peerVersions: { "@osdk/api": "2.7.0-beta.2" },
+      },
+    ]);
+  });
+
+  it("returns empty array for empty changelog", () => {
+    expect(parseChangelog("", ["@osdk/client"])).toEqual([]);
+  });
+
+  it("handles stable versions", () => {
+    const changelog = `# @osdk/functions
+
+## 1.3.0
+
+### Patch Changes
+
+- Updated dependencies [322c5bc]
+  - @osdk/client@2.5.0
+`;
+    const mappings = parseChangelog(changelog, ["@osdk/client"]);
+    expect(mappings).toEqual([
+      {
+        packageVersion: "1.3.0",
+        peerVersions: { "@osdk/client": "2.5.0" },
+      },
+    ]);
+  });
+});
+
+describe("determineMinVersion", () => {
+  it("finds the oldest client version in a 0.x minor series", () => {
+    const mappings = [
+      {
+        packageVersion: "0.10.0-beta.5",
+        peerVersions: { "@osdk/client": "2.8.0-beta.11" },
+      },
+      {
+        packageVersion: "0.10.0-beta.4",
+        peerVersions: { "@osdk/client": "2.8.0-beta.6" },
+      },
+      {
+        packageVersion: "0.10.0-beta.2",
+        peerVersions: { "@osdk/client": "2.8.0-beta.3" },
+      },
+      {
+        packageVersion: "0.9.0-beta.10",
+        peerVersions: { "@osdk/client": "2.7.0-beta.14" },
+      },
+    ];
+
+    const min = determineMinVersion(
+      mappings,
+      "0.10.0-beta.5",
+      "@osdk/client",
+    );
+    expect(min).toBe("2.8.0-beta.3");
+  });
+
+  it("does not include versions from a different 0.x minor series", () => {
+    const mappings = [
+      {
+        packageVersion: "0.2.0-beta.3",
+        peerVersions: { "@osdk/client": "2.8.0-beta.6" },
+      },
+      {
+        packageVersion: "0.1.0-beta.5",
+        peerVersions: { "@osdk/client": "2.7.0-beta.14" },
+      },
+    ];
+
+    const min = determineMinVersion(
+      mappings,
+      "0.2.0-beta.3",
+      "@osdk/client",
+    );
+    expect(min).toBe("2.8.0-beta.6");
+  });
+
+  it("finds the oldest client version in a >=1.x major series", () => {
+    const mappings = [
+      {
+        packageVersion: "1.6.0-beta.2",
+        peerVersions: { "@osdk/client": "2.8.0-beta.8" },
+      },
+      {
+        packageVersion: "1.3.0",
+        peerVersions: { "@osdk/client": "2.5.0" },
+      },
+      {
+        packageVersion: "1.0.0-beta.11",
+        peerVersions: { "@osdk/client": "2.2.0-beta.18" },
+      },
+    ];
+
+    const min = determineMinVersion(
+      mappings,
+      "1.6.0-beta.2",
+      "@osdk/client",
+    );
+    expect(min).toBe("2.2.0-beta.18");
+  });
+
+  it("returns undefined when no mappings match the series", () => {
+    const mappings = [
+      {
+        packageVersion: "2.0.0",
+        peerVersions: { "@osdk/client": "3.0.0" },
+      },
+    ];
+
+    const min = determineMinVersion(
+      mappings,
+      "1.0.0",
+      "@osdk/client",
+    );
+    expect(min).toBeUndefined();
+  });
+
+  it("returns undefined for invalid version string", () => {
+    const min = determineMinVersion([], "not-a-version", "@osdk/client");
+    expect(min).toBeUndefined();
+  });
+
+  it("returns undefined when peer is missing from all same-series mappings", () => {
+    const mappings = [
+      {
+        packageVersion: "1.0.0",
+        peerVersions: { "@osdk/api": "2.0.0" },
+      },
+    ];
+
+    const min = determineMinVersion(mappings, "1.0.0", "@osdk/client");
+    expect(min).toBeUndefined();
+  });
+});
+
+describe("generatePeerRange", () => {
+  it("uses beta-only range when min and peer are on the same tuple", () => {
+    expect(generatePeerRange("2.8.0-beta.3", "2.8.0-beta.12")).toBe(
+      ">=2.8.0-beta.0",
+    );
+  });
+
+  it("produces OR range when min is on a different tuple than peer", () => {
+    expect(generatePeerRange("2.7.0-beta.5", "2.8.0-beta.12")).toBe(
+      "^2.7.0 || >=2.8.0-beta.0",
+    );
+  });
+
+  it("produces OR range when min is stable and peer is prerelease", () => {
+    expect(generatePeerRange("2.5.0", "2.8.0-beta.12")).toBe(
+      "^2.5.0 || >=2.8.0-beta.0",
+    );
+  });
+
+  it("strips prerelease from min in OR range", () => {
+    expect(generatePeerRange("2.2.0-beta.18", "2.8.0-beta.11")).toBe(
+      "^2.2.0 || >=2.8.0-beta.0",
+    );
+  });
+
+  it("produces caret range for stable peer versions", () => {
+    expect(generatePeerRange("2.2.0", "2.8.0")).toBe("^2.2.0");
+  });
+
+  it("strips prerelease from min when peer is stable", () => {
+    expect(generatePeerRange("2.2.0-beta.18", "2.8.0")).toBe("^2.2.0");
+  });
+
+  it("throws for invalid peer version", () => {
+    expect(() => generatePeerRange("2.0.0", "not-a-version")).toThrow(
+      "Invalid currentPeerVersion",
+    );
+  });
+
+  it("throws for invalid min version when peer is prerelease", () => {
+    expect(() => generatePeerRange("not-a-version", "2.8.0-beta.12")).toThrow(
+      "Invalid minVersion",
+    );
+  });
+});

--- a/packages/version-updater/scripts/postVersioning.mjs
+++ b/packages/version-updater/scripts/postVersioning.mjs
@@ -23,6 +23,27 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import * as semver from "semver";
+import { determineMinVersion } from "./determineMinVersion.mjs";
+import { generatePeerRange } from "./generatePeerRange.mjs";
+import { parseChangelog } from "./parseChangelog.mjs";
+
+const PEER_DEP_PACKAGES = [
+  {
+    dir: "react",
+    peers: {
+      "@osdk/client": { strategy: "changelog" },
+      "@osdk/api": { strategy: "changelog" },
+    },
+  },
+  {
+    dir: "react-components",
+    peers: {
+      "@osdk/client": { strategy: "changelog" },
+      "@osdk/api": { strategy: "changelog" },
+      "@osdk/react": { strategy: "changelog" },
+    },
+  },
+];
 
 const workspaceDirPath = getWorkspaceDirPath();
 const clientPackageVersion = getClientPackageVersion();
@@ -51,6 +72,52 @@ updateConstVariable(
   "ExpectedOsdkVersion",
   clientPackageVersion,
 );
+
+for (const pkg of PEER_DEP_PACKAGES) {
+  updatePeerDependencies(pkg.dir, pkg.peers);
+}
+
+/**
+ * @param {string} packageDir
+ * @param {string} peerName
+ * @param {string} range
+ */
+function applyLoosePeerDep(packageDir, peerName, range) {
+  const packageJsonPath = path.join(
+    workspaceDirPath,
+    "packages",
+    packageDir,
+    "package.json",
+  );
+
+  if (!fs.existsSync(packageJsonPath)) {
+    consola.warn(
+      `packages/${packageDir}/package.json not found, skipping loose peer dep`,
+    );
+    return;
+  }
+
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+  if (!packageJson.peerDependencies) {
+    packageJson.peerDependencies = {};
+  }
+
+  if (packageJson.peerDependencies[peerName] === range) {
+    consola.info(
+      `No changes needed for ${packageDir} ${peerName} peer dep (already ${range})`,
+    );
+    return;
+  }
+
+  packageJson.peerDependencies[peerName] = range;
+  fs.writeFileSync(
+    packageJsonPath,
+    JSON.stringify(packageJson, null, 2) + "\n",
+  );
+  consola.info(
+    `Updated ${packageDir} ${peerName} peer dep to "${range}" (loose)`,
+  );
+}
 
 /**
  * @param {string} filePath
@@ -136,4 +203,135 @@ function getClientPackageVersion() {
   }
 
   return `${major}.${minor}.${patch}`;
+}
+
+/**
+ * @param {string} packageName - Scoped package name (e.g. "@osdk/client")
+ * @returns {string | undefined}
+ */
+function getPeerPackageVersion(packageName) {
+  const dirName = packageName.replace("@osdk/", "");
+  const pkgJsonPath = path.join(
+    workspaceDirPath,
+    "packages",
+    dirName,
+    "package.json",
+  );
+  if (!fs.existsSync(pkgJsonPath)) {
+    return undefined;
+  }
+  return JSON.parse(fs.readFileSync(pkgJsonPath, "utf8")).version;
+}
+
+/**
+ * @param {string} packageDir - Directory name under packages/ (e.g. "react", "widget.client-react")
+ * @param {Record<string, { strategy: string, range?: string }>} peersConfig - Per-peer strategy config
+ */
+function updatePeerDependencies(packageDir, peersConfig) {
+  const loosePeers = Object.entries(peersConfig)
+    .filter(([, cfg]) => cfg.strategy === "loose");
+  const changelogPeers = Object.entries(peersConfig)
+    .filter(([, cfg]) => cfg.strategy === "changelog")
+    .map(([name]) => name);
+
+  // loose peers must be applied before changelog peers because
+  // applyLoosePeerDep writes package.json independently, while the
+  // changelog path reads it fresh and writes once at the end
+  for (const [peerName, cfg] of loosePeers) {
+    applyLoosePeerDep(packageDir, peerName, cfg.range ?? "*");
+  }
+
+  if (changelogPeers.length === 0) {
+    return;
+  }
+
+  const packageJsonPath = path.join(
+    workspaceDirPath,
+    "packages",
+    packageDir,
+    "package.json",
+  );
+  const changelogPath = path.join(
+    workspaceDirPath,
+    "packages",
+    packageDir,
+    "CHANGELOG.md",
+  );
+
+  if (!fs.existsSync(packageJsonPath)) {
+    consola.warn(
+      `packages/${packageDir}/package.json not found, skipping peer dependency update`,
+    );
+    return;
+  }
+
+  if (!fs.existsSync(changelogPath)) {
+    consola.warn(
+      `packages/${packageDir}/CHANGELOG.md not found, skipping peer dependency update`,
+    );
+    return;
+  }
+
+  const changelog = fs.readFileSync(changelogPath, "utf8");
+  const versionMappings = parseChangelog(changelog, changelogPeers);
+
+  if (versionMappings.length === 0) {
+    consola.warn(
+      `No version mappings found in packages/${packageDir}/CHANGELOG.md`,
+    );
+    return;
+  }
+
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+  const currentPackageVersion = packageJson.version;
+
+  if (!packageJson.peerDependencies) {
+    packageJson.peerDependencies = {};
+  }
+
+  let changed = false;
+  for (const peerName of changelogPeers) {
+    const minVersion = determineMinVersion(
+      versionMappings,
+      currentPackageVersion,
+      peerName,
+    );
+
+    if (!minVersion) {
+      consola.warn(
+        `Could not determine minimum ${peerName} version for ${packageDir}@${currentPackageVersion}`,
+      );
+      continue;
+    }
+
+    const currentPeerVersion = getPeerPackageVersion(peerName);
+    if (!currentPeerVersion) {
+      consola.warn(
+        `Could not read version for ${peerName}, skipping`,
+      );
+      continue;
+    }
+
+    const peerRange = generatePeerRange(minVersion, currentPeerVersion);
+    const currentPeerDep = packageJson.peerDependencies?.[peerName];
+
+    if (currentPeerDep === peerRange) {
+      consola.info(
+        `No changes needed for ${packageDir} ${peerName} peer dep (already ${peerRange})`,
+      );
+    } else {
+      packageJson.peerDependencies[peerName] = peerRange;
+      changed = true;
+      consola.info(
+        `Updated ${packageDir} ${peerName} peer dep to "${peerRange}" (min: ${minVersion})`,
+      );
+    }
+  }
+
+  if (changed) {
+    fs.writeFileSync(
+      packageJsonPath,
+      JSON.stringify(packageJson, null, 2) + "\n",
+    );
+  }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -123,11 +123,23 @@
     "@osdk/version-updater#postVersioning": {
       "inputs": [
         "scripts/postVersioning.mjs",
+        "scripts/parseChangelog.mjs",
+        "scripts/determineMinVersion.mjs",
+        "scripts/generatePeerRange.mjs",
         "../client/package.json",
         "../client/src/Client.ts",
-        "../generator/src/v2.0/generateMetadata.ts"
+        "../generator/src/v2.0/generateMetadata.ts",
+        "../react/CHANGELOG.md",
+        "../react/package.json",
+        "../react-components/CHANGELOG.md",
+        "../react-components/package.json"
       ],
-      "outputs": ["../client/src/Client.ts", "../generator/src/v2.0/generateMetadata.ts"]
+      "outputs": [
+        "../client/src/Client.ts",
+        "../generator/src/v2.0/generateMetadata.ts",
+        "../react/package.json",
+        "../react-components/package.json"
+      ]
     },
 
     "@osdk/monorepo.tsconfig#typecheck": {


### PR DESCRIPTION
peer deps for @osdk/client and @osdk/api were hardcoded to `*` or `workspace:^`, giving no signal when versions drift apart. additionally, npm semver does not match prereleases against ranges without a prerelease on the same major.minor.patch tuple, so `^2.7.0` rejects `2.8.0-beta.12` and users are forced to use `--legacy-peer-deps`

• parse changelogs to extract which client/api version shipped with each package version, then compute the oldest compatible peer for the current version series
• fix `generatePeerRange` to produce an or range (`^minClean || >=X.Y.Z-beta.0`) when the minimum version is on a different major.minor.patch tuple than the current prerelease peer, so both stable and beta versions are accepted
• package.json files keep workspace protocol / `*` for local dev, postVersioning computes real ranges during publish

### the bug in `generatePeerRange`
for ex: when `currentPeer` is `2.8.0-beta.12` and `min` is `2.7.0-beta.5`:
- **before:** produces `>=2.8.0-beta.0` which doen't match `2.7.0`, `2.7.1`, etc.
- **after:** produces `^2.7.0 || >=2.8.0-beta.0` which matches both stable 2.7.x+ and 2.8.0 betas

### compatibility table

| min | currentPeer | output | matches |
|-----|-------------|--------|---------|
| `2.7.0-beta.5` | `2.8.0-beta.12` | `^2.7.0 \|\| >=2.8.0-beta.0` | 2.7.0, 2.7.1, 2.8.0-beta.x, 2.8.0+ |
| `2.8.0-beta.3` | `2.8.0-beta.12` | `>=2.8.0-beta.0` | 2.8.0-beta.x, 2.8.0+ |
| `2.5.0` | `2.8.0-beta.12` | `^2.5.0 \|\| >=2.8.0-beta.0` | 2.5.0+, 2.8.0-beta.x |
| `2.2.0` | `2.8.0` | `^2.2.0` | 2.2.0+ (stable only, no change) |