### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -181,6 +181,7 @@
     "dull-carrots-invent",
     "eager-views-pump",
     "early-coats-enjoy",
+    "eight-carrots-wish",
     "eight-worms-look",
     "expose-wire-object-set",
     "fancy-grapes-pull",

--- a/benchmarks/tests/primary/CHANGELOG.md
+++ b/benchmarks/tests/primary/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/benchmarks.primary
 
+## 0.1.0-beta.114
+
+### Patch Changes
+
+- Updated dependencies [dfc8019]
+  - @osdk/client@2.8.0-beta.15
+
 ## 0.1.0-beta.113
 
 ### Minor Changes

--- a/benchmarks/tests/primary/package.json
+++ b/benchmarks/tests/primary/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/benchmarks.primary",
   "private": true,
-  "version": "0.1.0-beta.113",
+  "version": "0.1.0-beta.114",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/api
 
+## 2.8.0-beta.15
+
 ## 2.8.0-beta.14
 
 ### Minor Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/api",
-  "version": "2.8.0-beta.14",
+  "version": "2.8.0-beta.15",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client.test.ontology/CHANGELOG.md
+++ b/packages/client.test.ontology/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/client.test.ontology
 
+## 2.8.0-beta.15
+
+### Patch Changes
+
+- @osdk/api@2.8.0-beta.15
+
 ## 2.8.0-beta.14
 
 ### Minor Changes

--- a/packages/client.test.ontology/package.json
+++ b/packages/client.test.ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/client.test.ontology",
   "private": true,
-  "version": "2.8.0-beta.14",
+  "version": "2.8.0-beta.15",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.unstable/CHANGELOG.md
+++ b/packages/client.unstable/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/client.unstable
 
+## 2.8.0-beta.15
+
 ## 2.8.0-beta.14
 
 ### Minor Changes

--- a/packages/client.unstable/package.json
+++ b/packages/client.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.unstable",
-  "version": "2.8.0-beta.14",
+  "version": "2.8.0-beta.15",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/client
 
+## 2.8.0-beta.15
+
+### Minor Changes
+
+- dfc8019: Preserve derived property values when subscription updates write to RDP cache keys
+
+### Patch Changes
+
+- @osdk/api@2.8.0-beta.15
+- @osdk/client.unstable@2.8.0-beta.15
+- @osdk/generator-converters@2.8.0-beta.15
+
 ## 2.8.0-beta.14
 
 ### Minor Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client",
-  "version": "2.8.0-beta.14",
+  "version": "2.8.0-beta.15",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/create-app.template-packager/CHANGELOG.md
+++ b/packages/create-app.template-packager/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template-packager
 
+## 2.8.0-beta.15
+
 ## 2.8.0-beta.14
 
 ### Minor Changes

--- a/packages/create-app.template-packager/package.json
+++ b/packages/create-app.template-packager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template-packager",
   "private": true,
-  "version": "2.8.0-beta.14",
+  "version": "2.8.0-beta.15",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.expo.v2/CHANGELOG.md
+++ b/packages/create-app.template.expo.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.expo.v2
 
+## 2.8.0-beta.15
+
 ## 2.8.0-beta.14
 
 ### Minor Changes

--- a/packages/create-app.template.expo.v2/package.json
+++ b/packages/create-app.template.expo.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.expo.v2",
   "private": true,
-  "version": "2.8.0-beta.14",
+  "version": "2.8.0-beta.15",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react.beta/CHANGELOG.md
+++ b/packages/create-app.template.react.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.react
 
+## 2.8.0-beta.15
+
 ## 2.8.0-beta.14
 
 ### Minor Changes

--- a/packages/create-app.template.react.beta/package.json
+++ b/packages/create-app.template.react.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react.beta",
   "private": true,
-  "version": "2.8.0-beta.14",
+  "version": "2.8.0-beta.15",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react/CHANGELOG.md
+++ b/packages/create-app.template.react/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.react
 
+## 2.8.0-beta.15
+
 ## 2.8.0-beta.14
 
 ### Minor Changes

--- a/packages/create-app.template.react/package.json
+++ b/packages/create-app.template.react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react",
   "private": true,
-  "version": "2.8.0-beta.14",
+  "version": "2.8.0-beta.15",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-aip-app.beta
 
+## 2.8.0-beta.15
+
 ## 2.8.0-beta.14
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app.beta",
   "private": true,
-  "version": "2.8.0-beta.14",
+  "version": "2.8.0-beta.15",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-aip-app
 
+## 2.8.0-beta.15
+
 ## 2.8.0-beta.14
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-aip-app/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app",
   "private": true,
-  "version": "2.8.0-beta.14",
+  "version": "2.8.0-beta.15",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-app.beta/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-app.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-app.beta
 
+## 2.8.0-beta.15
+
 ## 2.8.0-beta.14
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-app.beta/package.json
+++ b/packages/create-app.template.tutorial-todo-app.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app.beta",
   "private": true,
-  "version": "2.8.0-beta.14",
+  "version": "2.8.0-beta.15",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-app
 
+## 2.8.0-beta.15
+
 ## 2.8.0-beta.14
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-app/package.json
+++ b/packages/create-app.template.tutorial-todo-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app",
   "private": true,
-  "version": "2.8.0-beta.14",
+  "version": "2.8.0-beta.15",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.vue.v2/CHANGELOG.md
+++ b/packages/create-app.template.vue.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.vue.v2
 
+## 2.8.0-beta.15
+
 ## 2.8.0-beta.14
 
 ### Minor Changes

--- a/packages/create-app.template.vue.v2/package.json
+++ b/packages/create-app.template.vue.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.vue.v2",
   "private": true,
-  "version": "2.8.0-beta.14",
+  "version": "2.8.0-beta.15",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.vue/CHANGELOG.md
+++ b/packages/create-app.template.vue/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.vue
 
+## 2.8.0-beta.15
+
 ## 2.8.0-beta.14
 
 ### Minor Changes

--- a/packages/create-app.template.vue/package.json
+++ b/packages/create-app.template.vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.vue",
   "private": true,
-  "version": "2.8.0-beta.14",
+  "version": "2.8.0-beta.15",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app
 
+## 2.8.0-beta.15
+
 ## 2.8.0-beta.14
 
 ### Minor Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-app",
-  "version": "2.8.0-beta.14",
+  "version": "2.8.0-beta.15",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/create-widget.template.minimal-react.v2/CHANGELOG.md
+++ b/packages/create-widget.template.minimal-react.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-widget.template.react.v2
 
+## 3.5.0-beta.15
+
 ## 3.5.0-beta.14
 
 ### Minor Changes

--- a/packages/create-widget.template.minimal-react.v2/package.json
+++ b/packages/create-widget.template.minimal-react.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-widget.template.minimal-react.v2",
   "private": true,
-  "version": "3.5.0-beta.14",
+  "version": "3.5.0-beta.15",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-widget.template.react.v2/CHANGELOG.md
+++ b/packages/create-widget.template.react.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-widget.template.react.v2
 
+## 3.5.0-beta.15
+
 ## 3.5.0-beta.14
 
 ### Minor Changes

--- a/packages/create-widget.template.react.v2/package.json
+++ b/packages/create-widget.template.react.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-widget.template.react.v2",
   "private": true,
-  "version": "3.5.0-beta.14",
+  "version": "3.5.0-beta.15",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-widget/CHANGELOG.md
+++ b/packages/create-widget/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-widget
 
+## 3.5.0-beta.15
+
 ## 3.5.0-beta.14
 
 ### Minor Changes

--- a/packages/create-widget/package.json
+++ b/packages/create-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-widget",
-  "version": "3.5.0-beta.14",
+  "version": "3.5.0-beta.15",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/foundry-sdk-generator
 
+## 2.8.0-beta.15
+
+### Patch Changes
+
+- Updated dependencies [dfc8019]
+  - @osdk/client@2.8.0-beta.15
+  - @osdk/api@2.8.0-beta.15
+  - @osdk/generator@2.8.0-beta.15
+
 ## 2.8.0-beta.14
 
 ### Minor Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "2.8.0-beta.14",
+  "version": "2.8.0-beta.15",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-converters.ontologyir/CHANGELOG.md
+++ b/packages/generator-converters.ontologyir/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/generator-converters.ontologyir
 
+## 2.8.0-beta.15
+
+### Patch Changes
+
+- @osdk/client.unstable@2.8.0-beta.15
+
 ## 2.8.0-beta.14
 
 ### Minor Changes

--- a/packages/generator-converters.ontologyir/package.json
+++ b/packages/generator-converters.ontologyir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-converters.ontologyir",
-  "version": "2.8.0-beta.14",
+  "version": "2.8.0-beta.15",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-converters/CHANGELOG.md
+++ b/packages/generator-converters/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/generator-converters
 
+## 2.8.0-beta.15
+
+### Patch Changes
+
+- @osdk/api@2.8.0-beta.15
+
 ## 2.8.0-beta.14
 
 ### Minor Changes

--- a/packages/generator-converters/package.json
+++ b/packages/generator-converters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-converters",
-  "version": "2.8.0-beta.14",
+  "version": "2.8.0-beta.15",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-utils/CHANGELOG.md
+++ b/packages/generator-utils/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/generator-utils
 
+## 2.8.0-beta.15
+
 ## 2.8.0-beta.14
 
 ### Minor Changes

--- a/packages/generator-utils/package.json
+++ b/packages/generator-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-utils",
-  "version": "2.8.0-beta.14",
+  "version": "2.8.0-beta.15",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/generator
 
+## 2.8.0-beta.15
+
+### Patch Changes
+
+- @osdk/api@2.8.0-beta.15
+- @osdk/generator-converters@2.8.0-beta.15
+
 ## 2.8.0-beta.14
 
 ### Minor Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "2.8.0-beta.14",
+  "version": "2.8.0-beta.15",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/vite-plugin-oac/CHANGELOG.md
+++ b/packages/vite-plugin-oac/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/vite-plugin-oac
 
+## 0.6.0-beta.16
+
+### Patch Changes
+
+- @osdk/api@2.8.0-beta.15
+- @osdk/client.unstable@2.8.0-beta.15
+- @osdk/generator-converters.ontologyir@2.8.0-beta.15
+
 ## 0.6.0-beta.15
 
 ### Minor Changes

--- a/packages/vite-plugin-oac/package.json
+++ b/packages/vite-plugin-oac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/vite-plugin-oac",
-  "version": "0.6.0-beta.15",
+  "version": "0.6.0-beta.16",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/widget.api/CHANGELOG.md
+++ b/packages/widget.api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/widget.api
 
+## 3.5.0-beta.15
+
+### Patch Changes
+
+- @osdk/api@2.8.0-beta.15
+
 ## 3.5.0-beta.14
 
 ### Minor Changes

--- a/packages/widget.api/package.json
+++ b/packages/widget.api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget.api",
-  "version": "3.5.0-beta.14",
+  "version": "3.5.0-beta.15",
   "description": "API contract between Foundry UIs that can embed custom widgets and the custom widgets themselves",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/widget.client-react/CHANGELOG.md
+++ b/packages/widget.client-react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/widget.client-react
 
+## 3.5.0-beta.15
+
+### Patch Changes
+
+- Updated dependencies [dfc8019]
+  - @osdk/client@2.8.0-beta.15
+  - @osdk/widget.client@3.5.0-beta.15
+
 ## 3.5.0-beta.14
 
 ### Minor Changes

--- a/packages/widget.client-react/package.json
+++ b/packages/widget.client-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget.client-react",
-  "version": "3.5.0-beta.14",
+  "version": "3.5.0-beta.15",
   "description": "Wrapper around @osdk/widget.client",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/widget.client/CHANGELOG.md
+++ b/packages/widget.client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/widget.client
 
+## 3.5.0-beta.15
+
+### Patch Changes
+
+- @osdk/widget.api@3.5.0-beta.15
+
 ## 3.5.0-beta.14
 
 ### Minor Changes

--- a/packages/widget.client/package.json
+++ b/packages/widget.client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget.client",
-  "version": "3.5.0-beta.14",
+  "version": "3.5.0-beta.15",
   "description": "Client that sets up listeners for the custom widgets embedded into Foundry, adhering to the contract laid out in @osdk/widget.api",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/widget.vite-plugin/CHANGELOG.md
+++ b/packages/widget.vite-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/widget.vite-plugin
 
+## 3.5.0-beta.15
+
+### Patch Changes
+
+- @osdk/widget.api@3.5.0-beta.15
+
 ## 3.5.0-beta.14
 
 ### Minor Changes

--- a/packages/widget.vite-plugin/package.json
+++ b/packages/widget.vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget.vite-plugin",
-  "version": "3.5.0-beta.14",
+  "version": "3.5.0-beta.15",
   "description": "A vite plugin that will extract parameter definitions from TS/JS files + entrypoint info into a manifest file to be uploaded to Foundry ",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/client@2.8.0-beta.15

### Minor Changes

-   dfc8019: Preserve derived property values when subscription updates write to RDP cache keys

### Patch Changes

-   @osdk/api@2.8.0-beta.15
-   @osdk/client.unstable@2.8.0-beta.15
-   @osdk/generator-converters@2.8.0-beta.15

## @osdk/foundry-sdk-generator@2.8.0-beta.15

### Patch Changes

-   Updated dependencies [dfc8019]
    -   @osdk/client@2.8.0-beta.15
    -   @osdk/api@2.8.0-beta.15
    -   @osdk/generator@2.8.0-beta.15

## @osdk/generator@2.8.0-beta.15

### Patch Changes

-   @osdk/api@2.8.0-beta.15
-   @osdk/generator-converters@2.8.0-beta.15

## @osdk/generator-converters@2.8.0-beta.15

### Patch Changes

-   @osdk/api@2.8.0-beta.15

## @osdk/generator-converters.ontologyir@2.8.0-beta.15

### Patch Changes

-   @osdk/client.unstable@2.8.0-beta.15

## @osdk/vite-plugin-oac@0.6.0-beta.16

### Patch Changes

-   @osdk/api@2.8.0-beta.15
-   @osdk/client.unstable@2.8.0-beta.15
-   @osdk/generator-converters.ontologyir@2.8.0-beta.15

## @osdk/widget.api@3.5.0-beta.15

### Patch Changes

-   @osdk/api@2.8.0-beta.15

## @osdk/widget.client@3.5.0-beta.15

### Patch Changes

-   @osdk/widget.api@3.5.0-beta.15

## @osdk/widget.client-react@3.5.0-beta.15

### Patch Changes

-   Updated dependencies [dfc8019]
    -   @osdk/client@2.8.0-beta.15
    -   @osdk/widget.client@3.5.0-beta.15

## @osdk/widget.vite-plugin@3.5.0-beta.15

### Patch Changes

-   @osdk/widget.api@3.5.0-beta.15

## @osdk/api@2.8.0-beta.15



## @osdk/client.unstable@2.8.0-beta.15



## @osdk/create-app@2.8.0-beta.15



## @osdk/create-widget@3.5.0-beta.15



## @osdk/generator-utils@2.8.0-beta.15



## @osdk/benchmarks.primary@0.1.0-beta.114

### Patch Changes

-   Updated dependencies [dfc8019]
    -   @osdk/client@2.8.0-beta.15

## @osdk/client.test.ontology@2.8.0-beta.15

### Patch Changes

-   @osdk/api@2.8.0-beta.15

## @osdk/create-app.template-packager@2.8.0-beta.15



## @osdk/create-app.template.expo.v2@2.8.0-beta.15



## @osdk/create-app.template.react@2.8.0-beta.15



## @osdk/create-app.template.react.beta@2.8.0-beta.15



## @osdk/create-app.template.tutorial-todo-aip-app@2.8.0-beta.15



## @osdk/create-app.template.tutorial-todo-aip-app.beta@2.8.0-beta.15



## @osdk/create-app.template.tutorial-todo-app@2.8.0-beta.15



## @osdk/create-app.template.tutorial-todo-app.beta@2.8.0-beta.15



## @osdk/create-app.template.vue@2.8.0-beta.15



## @osdk/create-app.template.vue.v2@2.8.0-beta.15



## @osdk/create-widget.template.minimal-react.v2@3.5.0-beta.15



## @osdk/create-widget.template.react.v2@3.5.0-beta.15


