### PR TITLE
add cbac storybook demos and faux admin mocks

### DIFF
--- a/.changeset/cbac-storybook-demos.md
+++ b/.changeset/cbac-storybook-demos.md
@@ -1,0 +1,5 @@
+---
+"@osdk/cbac-components": patch
+---
+
+add cbac storybook demos and faux admin mocks

--- a/packages/faux/src/FauxFoundry/FauxAdmin.ts
+++ b/packages/faux/src/FauxFoundry/FauxAdmin.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import type { User } from "@osdk/foundry.admin";
+import type {
+  CbacBanner,
+  CbacMarkingRestrictions,
+  Marking,
+  MarkingCategory,
+  User,
+} from "@osdk/foundry.admin";
 import {
   CurrentUserPermissionDeniedError,
   GetInvalidPageTokenError,
@@ -26,9 +32,24 @@ import { OpenApiCallError } from "../handlers/util/handleOpenApiCall.js";
 
 type UserStatus = "ACTIVE" | "DELETED";
 
+interface BannerConfig {
+  classificationString: string;
+  textColor: string;
+  backgroundColors: string[];
+}
+
+type BannerResolver = (
+  markingIds: string[],
+  markings: Marking[],
+  categories: MarkingCategory[],
+) => BannerConfig;
+
 export class FauxAdmin {
   #users: User[] = [];
   #currentUserId: string | undefined;
+  #markings: Marking[] = [];
+  #markingCategories: MarkingCategory[] = [];
+  #bannerResolver: BannerResolver | undefined;
 
   registerUser(user: User): void {
     if (this.#users.some(({ id }) => id === user.id)) {
@@ -108,6 +129,59 @@ export class FauxAdmin {
     return {
       users: filteredUsers.slice(startIndex, startIndex + pageSize),
       nextPageToken: filteredUsers[startIndex + pageSize]?.id,
+    };
+  }
+
+  registerMarking(marking: Marking): void {
+    this.#markings.push(marking);
+  }
+
+  registerMarkingCategory(category: MarkingCategory): void {
+    this.#markingCategories.push(category);
+  }
+
+  setBannerResolver(resolver: BannerResolver): void {
+    this.#bannerResolver = resolver;
+  }
+
+  listMarkings(): { data: Marking[] } {
+    return { data: this.#markings };
+  }
+
+  listMarkingCategories(): { data: MarkingCategory[] } {
+    return { data: this.#markingCategories };
+  }
+
+  getCbacBanner(markingIds: string[]): CbacBanner {
+    if (this.#bannerResolver != null) {
+      const config = this.#bannerResolver(
+        markingIds,
+        this.#markings,
+        this.#markingCategories,
+      );
+      return {
+        classificationString: config.classificationString,
+        markings: markingIds,
+        textColor: config.textColor,
+        backgroundColors: config.backgroundColors,
+      };
+    }
+
+    return {
+      classificationString: markingIds.join(" // "),
+      markings: markingIds,
+      textColor: "#FFFFFF",
+      backgroundColors: ["#8F99A8"],
+    };
+  }
+
+  getCbacMarkingRestrictions(_markingIds: string[]): CbacMarkingRestrictions {
+    return {
+      disallowedMarkings: [],
+      impliedMarkings: [],
+      requiredMarkings: [],
+      userSatisfiesMarkings: true,
+      isValid: _markingIds.length > 0,
     };
   }
 }

--- a/packages/faux/src/handlers/createAdminHandlers.ts
+++ b/packages/faux/src/handlers/createAdminHandlers.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-import type { ListUsersResponse, User } from "@osdk/foundry.admin";
+import type {
+  CbacBanner,
+  CbacMarkingRestrictions,
+  ListMarkingCategoriesResponse,
+  ListMarkingsResponse,
+  ListUsersResponse,
+  User,
+} from "@osdk/foundry.admin";
 import { InvalidArgument, InvalidRequest } from "../errors.js";
 import { Admin } from "../mock/index.js";
 import type { FauxFoundryHandlersFactory } from "./createFauxFoundryHandlers.js";
@@ -24,6 +31,38 @@ export const createAdminHandlers: FauxFoundryHandlersFactory = (
   baseUrl,
   fauxFoundry,
 ) => [
+  Admin.Markings.applyListMarkings(
+    baseUrl,
+    (): ListMarkingsResponse => {
+      return fauxFoundry.getAdmin().listMarkings();
+    },
+  ),
+
+  Admin.MarkingCategories.applyListMarkingCategories(
+    baseUrl,
+    (): ListMarkingCategoriesResponse => {
+      return fauxFoundry.getAdmin().listMarkingCategories();
+    },
+  ),
+
+  Admin.CbacBanners.applyGetCbacBanner(
+    baseUrl,
+    ({ request }): CbacBanner => {
+      const url = new URL(request.url);
+      const markingIds = url.searchParams.getAll("markingIds");
+      return fauxFoundry.getAdmin().getCbacBanner(markingIds);
+    },
+  ),
+
+  Admin.CbacMarkingRestrictions.applyGetCbacMarkingRestrictions(
+    baseUrl,
+    ({ request }): CbacMarkingRestrictions => {
+      const url = new URL(request.url);
+      const markingIds = url.searchParams.getAll("markingIds");
+      return fauxFoundry.getAdmin().getCbacMarkingRestrictions(markingIds);
+    },
+  ),
+
   Admin.Users.applyGetCurrent(baseUrl, (): User => {
     return fauxFoundry.getAdmin().getCurrentUser();
   }),

--- a/packages/faux/src/mock/Admin/CbacBanners.ts
+++ b/packages/faux/src/mock/Admin/CbacBanners.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
-export * as CbacBanners from "./CbacBanners.js";
-export * as CbacMarkingRestrictions from "./CbacMarkingRestrictions.js";
-export * as MarkingCategories from "./MarkingCategories.js";
-export * as Markings from "./Markings.js";
-export * as Users from "./Users.js";
+import { CbacBanners } from "@osdk/foundry.admin";
+import type { CallFactory } from "../../handlers/util/handleOpenApiCall.js";
+import { handleOpenApiCall } from "../../handlers/util/handleOpenApiCall.js";
+
+export const applyGetCbacBanner: CallFactory<
+  never,
+  typeof CbacBanners.get
+> = handleOpenApiCall(CbacBanners.get, []);

--- a/packages/faux/src/mock/Admin/CbacMarkingRestrictions.ts
+++ b/packages/faux/src/mock/Admin/CbacMarkingRestrictions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
-export * as CbacBanners from "./CbacBanners.js";
-export * as CbacMarkingRestrictions from "./CbacMarkingRestrictions.js";
-export * as MarkingCategories from "./MarkingCategories.js";
-export * as Markings from "./Markings.js";
-export * as Users from "./Users.js";
+import { CbacMarkingRestrictionsObjects } from "@osdk/foundry.admin";
+import type { CallFactory } from "../../handlers/util/handleOpenApiCall.js";
+import { handleOpenApiCall } from "../../handlers/util/handleOpenApiCall.js";
+
+export const applyGetCbacMarkingRestrictions: CallFactory<
+  never,
+  typeof CbacMarkingRestrictionsObjects.get
+> = handleOpenApiCall(CbacMarkingRestrictionsObjects.get, []);

--- a/packages/faux/src/mock/Admin/MarkingCategories.ts
+++ b/packages/faux/src/mock/Admin/MarkingCategories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
-export * as CbacBanners from "./CbacBanners.js";
-export * as CbacMarkingRestrictions from "./CbacMarkingRestrictions.js";
-export * as MarkingCategories from "./MarkingCategories.js";
-export * as Markings from "./Markings.js";
-export * as Users from "./Users.js";
+import { MarkingCategories } from "@osdk/foundry.admin";
+import type { CallFactory } from "../../handlers/util/handleOpenApiCall.js";
+import { handleOpenApiCall } from "../../handlers/util/handleOpenApiCall.js";
+
+export const applyListMarkingCategories: CallFactory<
+  never,
+  typeof MarkingCategories.list
+> = handleOpenApiCall(MarkingCategories.list, []);

--- a/packages/faux/src/mock/Admin/Markings.ts
+++ b/packages/faux/src/mock/Admin/Markings.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
-export * as CbacBanners from "./CbacBanners.js";
-export * as CbacMarkingRestrictions from "./CbacMarkingRestrictions.js";
-export * as MarkingCategories from "./MarkingCategories.js";
-export * as Markings from "./Markings.js";
-export * as Users from "./Users.js";
+import { Markings } from "@osdk/foundry.admin";
+import type { CallFactory } from "../../handlers/util/handleOpenApiCall.js";
+import { handleOpenApiCall } from "../../handlers/util/handleOpenApiCall.js";
+
+export const applyListMarkings: CallFactory<
+  never,
+  typeof Markings.list
+> = handleOpenApiCall(Markings.list, []);

--- a/packages/react-components-storybook/.storybook/styles.css
+++ b/packages/react-components-storybook/.storybook/styles.css
@@ -2,5 +2,6 @@
 
 @import "../src/styles/storybook.css" layer(storybook);
 @import "@osdk/react-components/styles.css" layer(components);
+@import "@osdk/cbac-components/styles.css" layer(components);
 @import "@osdk/react-components-styles" layer(tokens);
 @import "./themes.css" layer(themes);

--- a/packages/react-components-storybook/src/mocks/fauxFoundry.ts
+++ b/packages/react-components-storybook/src/mocks/fauxFoundry.ts
@@ -77,6 +77,180 @@ export async function setupFauxFoundry(): Promise<void> {
     employeeDocuments: mediaRef,
   });
 
+  // Register CBAC marking categories and markings
+  const cbacCategories = [
+    {
+      id: "cat-classification",
+      name: "Classification Level",
+      description: "Overall classification level of the data",
+      categoryType: "DISJUNCTIVE" as const,
+      markingType: "MANDATORY" as const,
+      markings: [
+        "m-unclassified",
+        "m-confidential",
+        "m-secret",
+        "m-top-secret",
+      ],
+      createdTime: "2024-01-01T00:00:00Z",
+    },
+    {
+      id: "cat-compartment",
+      name: "Compartments",
+      description: "Compartmented information access controls",
+      categoryType: "CONJUNCTIVE" as const,
+      markingType: "CBAC" as const,
+      markings: ["m-alpha", "m-bravo", "m-charlie"],
+      createdTime: "2024-01-01T00:00:00Z",
+    },
+    {
+      id: "cat-releasability",
+      name: "Releasability",
+      description: "Release restrictions for data sharing",
+      categoryType: "CONJUNCTIVE" as const,
+      markingType: "CBAC" as const,
+      markings: ["m-rel-usa", "m-rel-allied", "m-no-foreign"],
+      createdTime: "2024-01-01T00:00:00Z",
+    },
+  ];
+
+  const cbacMarkings = [
+    {
+      id: "m-unclassified",
+      categoryId: "cat-classification",
+      name: "Unclassified",
+      createdTime: "2024-01-01T00:00:00Z",
+    },
+    {
+      id: "m-confidential",
+      categoryId: "cat-classification",
+      name: "Confidential",
+      createdTime: "2024-01-01T00:00:00Z",
+    },
+    {
+      id: "m-secret",
+      categoryId: "cat-classification",
+      name: "Secret",
+      createdTime: "2024-01-01T00:00:00Z",
+    },
+    {
+      id: "m-top-secret",
+      categoryId: "cat-classification",
+      name: "Top Secret",
+      createdTime: "2024-01-01T00:00:00Z",
+    },
+    {
+      id: "m-alpha",
+      categoryId: "cat-compartment",
+      name: "ALPHA",
+      createdTime: "2024-01-01T00:00:00Z",
+    },
+    {
+      id: "m-bravo",
+      categoryId: "cat-compartment",
+      name: "BRAVO",
+      createdTime: "2024-01-01T00:00:00Z",
+    },
+    {
+      id: "m-charlie",
+      categoryId: "cat-compartment",
+      name: "CHARLIE",
+      createdTime: "2024-01-01T00:00:00Z",
+    },
+    {
+      id: "m-rel-usa",
+      categoryId: "cat-releasability",
+      name: "REL USA",
+      createdTime: "2024-01-01T00:00:00Z",
+    },
+    {
+      id: "m-rel-allied",
+      categoryId: "cat-releasability",
+      name: "REL ALLIED",
+      createdTime: "2024-01-01T00:00:00Z",
+    },
+    {
+      id: "m-no-foreign",
+      categoryId: "cat-releasability",
+      name: "NO FOREIGN",
+      createdTime: "2024-01-01T00:00:00Z",
+    },
+  ];
+
+  const classificationColors: Record<
+    string,
+    { textColor: string; backgroundColors: string[] }
+  > = {
+    "m-unclassified": {
+      textColor: "#FFFFFF",
+      backgroundColors: ["#007A33"],
+    },
+    "m-confidential": {
+      textColor: "#FFFFFF",
+      backgroundColors: ["#0033A0"],
+    },
+    "m-secret": { textColor: "#FFFFFF", backgroundColors: ["#C8102E"] },
+    "m-top-secret": {
+      textColor: "#000000",
+      backgroundColors: ["#FF8C00"],
+    },
+  };
+
+  const admin = fauxFoundry.getAdmin();
+
+  for (const category of cbacCategories) {
+    admin.registerMarkingCategory(category);
+  }
+  for (const marking of cbacMarkings) {
+    admin.registerMarking(marking);
+  }
+
+  admin.setBannerResolver((markingIds, markings) => {
+    const markingMap = new Map(markings.map((m) => [m.id, m]));
+    const classificationId = markingIds.find(
+      (id) => markingMap.get(id)?.categoryId === "cat-classification",
+    );
+
+    if (classificationId == null) {
+      return {
+        classificationString: "UNMARKED",
+        textColor: "#FFFFFF",
+        backgroundColors: ["#8F99A8"],
+      };
+    }
+
+    const colors = classificationColors[classificationId] ?? {
+      textColor: "#FFFFFF",
+      backgroundColors: ["#8F99A8"],
+    };
+
+    const parts: string[] = [];
+    const classificationMarking = markingMap.get(classificationId);
+    if (classificationMarking != null) {
+      parts.push(classificationMarking.name.toUpperCase());
+    }
+
+    const compartments = markingIds
+      .filter((id) => markingMap.get(id)?.categoryId === "cat-compartment")
+      .map((id) => markingMap.get(id)?.name ?? id);
+
+    if (compartments.length > 0) {
+      parts.push(compartments.join(" / "));
+    }
+
+    const releasability = markingIds
+      .filter((id) => markingMap.get(id)?.categoryId === "cat-releasability")
+      .map((id) => markingMap.get(id)?.name ?? id);
+
+    if (releasability.length > 0) {
+      parts.push(releasability.join(", "));
+    }
+
+    return {
+      classificationString: parts.join(" // "),
+      ...colors,
+    };
+  });
+
   // Log registered objects for debugging
   // eslint-disable-next-line no-console
   console.log(

--- a/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.stories.tsx
+++ b/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.stories.tsx
@@ -17,9 +17,9 @@
 import {
   BaseCbacBanner,
   BaseCbacPicker,
-  BaseCbacPickerDialog,
+  CbacPicker,
+  CbacPickerDialog,
   computeMarkingStates,
-  toggleMarking,
 } from "@osdk/cbac-components/experimental";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useCallback, useMemo, useState } from "react";
@@ -53,8 +53,6 @@ const BANNER_ROW_STYLE = {
 } as const;
 
 const EMPTY_SELECTED: string[] = [];
-const EMPTY_IMPLIED: string[] = [];
-const EMPTY_DISALLOWED: string[] = [];
 
 function InteractivePicker(
   { initialSelection }: { initialSelection?: string[] },
@@ -63,31 +61,11 @@ function InteractivePicker(
     initialSelection ?? EMPTY_SELECTED,
   );
 
-  const markingStates = useMemo(
-    () =>
-      computeMarkingStates(
-        selectedIds,
-        EMPTY_IMPLIED,
-        EMPTY_DISALLOWED,
-      ),
-    [selectedIds],
-  );
-
-  const handleToggle = useCallback(
-    (markingId: string) => {
-      setSelectedIds((prev) =>
-        toggleMarking(markingId, prev, mockCategoryGroups)
-      );
-    },
-    [],
-  );
-
   return (
     <div style={PICKER_STYLE}>
-      <BaseCbacPicker
-        categories={mockCategoryGroups}
-        markingStates={markingStates}
-        onMarkingToggle={handleToggle}
+      <CbacPicker
+        initialMarkingIds={selectedIds}
+        onChange={setSelectedIds}
       />
     </div>
   );
@@ -106,25 +84,11 @@ export const WithInitialSelection: Story = {
 };
 
 function ReadOnlyPicker() {
-  const selectedIds = useMemo(() => ["m-secret", "m-alpha", "m-rel-usa"], []);
-  const markingStates = useMemo(
-    () =>
-      computeMarkingStates(
-        selectedIds,
-        EMPTY_IMPLIED,
-        EMPTY_DISALLOWED,
-      ),
-    [selectedIds],
-  );
-  const noop = useCallback(() => {}, []);
-
   return (
     <div style={PICKER_STYLE}>
-      <BaseCbacPicker
-        categories={mockCategoryGroups}
-        markingStates={markingStates}
-        banner={mockBannerSecret}
-        onMarkingToggle={noop}
+      <CbacPicker
+        initialMarkingIds={["m-secret", "m-alpha", "m-rel-usa"]}
+        onChange={() => {}}
         readOnly={true}
       />
     </div>
@@ -140,32 +104,11 @@ function WithBannerPicker() {
     ["m-top-secret", "m-alpha", "m-bravo", "m-no-foreign"],
   );
 
-  const markingStates = useMemo(
-    () =>
-      computeMarkingStates(
-        selectedIds,
-        EMPTY_IMPLIED,
-        EMPTY_DISALLOWED,
-      ),
-    [selectedIds],
-  );
-
-  const handleToggle = useCallback(
-    (markingId: string) => {
-      setSelectedIds((prev) =>
-        toggleMarking(markingId, prev, mockCategoryGroups)
-      );
-    },
-    [],
-  );
-
   return (
     <div style={PICKER_STYLE}>
-      <BaseCbacPicker
-        categories={mockCategoryGroups}
-        markingStates={markingStates}
-        banner={mockBannerTopSecret}
-        onMarkingToggle={handleToggle}
+      <CbacPicker
+        initialMarkingIds={selectedIds}
+        onChange={setSelectedIds}
       />
     </div>
   );
@@ -211,51 +154,25 @@ function InDialogPicker() {
   const [isOpen, setIsOpen] = useState(true);
   const [selectedIds, setSelectedIds] = useState<string[]>(EMPTY_SELECTED);
 
-  const markingStates = useMemo(
-    () =>
-      computeMarkingStates(
-        selectedIds,
-        EMPTY_IMPLIED,
-        EMPTY_DISALLOWED,
-      ),
-    [selectedIds],
-  );
+  const handleConfirm = useCallback((ids: string[]) => {
+    setSelectedIds(ids);
+    setIsOpen(false);
+  }, []);
 
-  const handleToggle = useCallback(
-    (markingId: string) => {
-      setSelectedIds((prev) =>
-        toggleMarking(markingId, prev, mockCategoryGroups)
-      );
-    },
-    [],
-  );
-
-  const handleOpenChange = useCallback(() => {
+  const handleOpen = useCallback(() => {
     setIsOpen((prev) => !prev);
-  }, []);
-
-  const handleConfirm = useCallback(() => {
-    setIsOpen(false);
-  }, []);
-
-  const handleCancel = useCallback(() => {
-    setSelectedIds(EMPTY_SELECTED);
-    setIsOpen(false);
   }, []);
 
   return (
     <div>
-      <button type="button" onClick={handleOpenChange}>
+      <button type="button" onClick={handleOpen}>
         Open Classification Picker
       </button>
-      <BaseCbacPickerDialog
+      <CbacPickerDialog
         isOpen={isOpen}
-        onOpenChange={handleOpenChange}
+        onOpenChange={setIsOpen}
         onConfirm={handleConfirm}
-        onCancel={handleCancel}
-        categories={mockCategoryGroups}
-        markingStates={markingStates}
-        onMarkingToggle={handleToggle}
+        initialMarkingIds={selectedIds}
       />
     </div>
   );

--- a/packages/react-components-storybook/src/stories/CbacPicker/mockData.ts
+++ b/packages/react-components-storybook/src/stories/CbacPicker/mockData.ts
@@ -56,20 +56,65 @@ export const mockMarkings: PickerMarking[] = [
     id: "m-unclassified",
     categoryId: "cat-classification",
     name: "Unclassified",
+    description: "Information that is not classified and can be freely shared.",
   },
   {
     id: "m-confidential",
     categoryId: "cat-classification",
     name: "Confidential",
+    description:
+      "Information that could cause damage to national security if disclosed.",
   },
-  { id: "m-secret", categoryId: "cat-classification", name: "Secret" },
-  { id: "m-top-secret", categoryId: "cat-classification", name: "Top Secret" },
-  { id: "m-alpha", categoryId: "cat-compartment", name: "ALPHA" },
-  { id: "m-bravo", categoryId: "cat-compartment", name: "BRAVO" },
-  { id: "m-charlie", categoryId: "cat-compartment", name: "CHARLIE" },
-  { id: "m-rel-usa", categoryId: "cat-releasability", name: "REL USA" },
-  { id: "m-rel-allied", categoryId: "cat-releasability", name: "REL ALLIED" },
-  { id: "m-no-foreign", categoryId: "cat-releasability", name: "NO FOREIGN" },
+  {
+    id: "m-secret",
+    categoryId: "cat-classification",
+    name: "Secret",
+    description:
+      "Information that could cause serious damage to national security if disclosed.",
+  },
+  {
+    id: "m-top-secret",
+    categoryId: "cat-classification",
+    name: "Top Secret",
+    description:
+      "Information that could cause exceptionally grave damage to national security if disclosed.",
+  },
+  {
+    id: "m-alpha",
+    categoryId: "cat-compartment",
+    name: "ALPHA",
+    description: "Access to ALPHA compartmented information.",
+  },
+  {
+    id: "m-bravo",
+    categoryId: "cat-compartment",
+    name: "BRAVO",
+    description: "Access to BRAVO compartmented information.",
+  },
+  {
+    id: "m-charlie",
+    categoryId: "cat-compartment",
+    name: "CHARLIE",
+    description: "Access to CHARLIE compartmented information.",
+  },
+  {
+    id: "m-rel-usa",
+    categoryId: "cat-releasability",
+    name: "REL USA",
+    description: "Releasable to United States personnel only.",
+  },
+  {
+    id: "m-rel-allied",
+    categoryId: "cat-releasability",
+    name: "REL ALLIED",
+    description: "Releasable to allied nation personnel.",
+  },
+  {
+    id: "m-no-foreign",
+    categoryId: "cat-releasability",
+    name: "NO FOREIGN",
+    description: "Not releasable to foreign nationals.",
+  },
 ];
 
 export const mockCategoryGroups: CategoryMarkingGroup[] = [

--- a/packages/react-components-styles/src/tokens/cbac-picker.css
+++ b/packages/react-components-styles/src/tokens/cbac-picker.css
@@ -24,6 +24,8 @@
   --osdk-cbac-banner-border-radius: var(--osdk-surface-border-radius);
 
   --osdk-cbac-banner-border-color: var(--osdk-surface-border-color-default);
+  --osdk-cbac-banner-placeholder-bg: var(--osdk-intent-default-disabled);
+  --osdk-cbac-banner-placeholder-color: var(--osdk-typography-color-default-rest);
 
   /* Marking Button */
   --osdk-cbac-marking-button-padding: calc(var(--osdk-surface-spacing) * 0.5)
@@ -117,6 +119,10 @@
   --osdk-cbac-skeleton-line-height: 16px;
   --osdk-cbac-skeleton-line-narrow-width: 80%;
 
+  /* Danger Callout */
+  --osdk-cbac-danger-callout-bg: var(--osdk-intent-danger-subtle-bg, #fde8e8);
+  --osdk-cbac-danger-callout-color: var(--osdk-intent-danger-rest, #c23030);
+
   /* Popover Warning Callout */
   --osdk-cbac-warning-callout-bg: var(--osdk-intent-warning-subtle);
   --osdk-cbac-warning-callout-color: var(--osdk-intent-warning-rest);
@@ -126,6 +132,20 @@
   --osdk-cbac-warning-callout-font-size: var(
     --osdk-typography-size-body-small
   );
+
+  /* Marking Tooltip */
+  --osdk-cbac-marking-tooltip-max-width: 280px;
+  --osdk-cbac-marking-tooltip-padding: calc(var(--osdk-surface-spacing) * 1.5);
+  --osdk-cbac-marking-tooltip-font-size: var(--osdk-typography-size-body-small);
+  --osdk-cbac-marking-tooltip-z-index: var(--osdk-surface-z-index-4);
+
+  /* Marking Button Selected Hover */
+  --osdk-cbac-marking-button-bg-selected-hover: var(
+    --osdk-cbac-marking-button-bg-selected
+  );
+
+  /* Expand Icon */
+  --osdk-cbac-expand-icon-color: var(--osdk-typography-color-muted);
 
   /* Disabled State */
   --osdk-cbac-disabled-opacity: 0.6;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39621,7 +39621,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
-      rollup: 4.40.1
+      rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 18.19.124
@@ -39642,7 +39642,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
-      rollup: 4.40.1
+      rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 20.19.13
@@ -39663,7 +39663,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
-      rollup: 4.40.1
+      rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 24.12.0
@@ -39684,7 +39684,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
-      rollup: 4.40.1
+      rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 24.3.1


### PR DESCRIPTION
add cbac classification panel to the officenetwork sandbox app for testing

• add CbacPanel component with inline picker, dialog picker, and banner preview
• add admin read scope to the oauth client for marking api access