### PR TITLE
add devtools interfaces to @osdk/react and @osdk/client

### DIFF
--- a/.changeset/devtools-integration.md
+++ b/.changeset/devtools-integration.md
@@ -1,0 +1,6 @@
+---
+"@osdk/react": patch
+"@osdk/client": patch
+---
+
+add devtools interfaces and hook metadata for react-devtools integration

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -64,6 +64,39 @@ export namespace ObservableClient {
   }
 }
 
+export interface CacheSnapshot {
+  entries: CacheEntry[];
+  stats: {
+    totalEntries: number;
+    totalSize: number;
+    totalHits?: number;
+  };
+}
+
+interface CacheEntryMetadata {
+  timestamp: number;
+  status: "init" | "loading" | "loaded" | "error";
+  hitCount?: number;
+  size: number;
+  isOptimistic?: boolean;
+}
+
+interface CacheEntryBase {
+  key: string;
+  objectType: string;
+  metadata: CacheEntryMetadata;
+  data?: unknown;
+}
+
+export type CacheEntry =
+  | CacheEntryBase & { type: "object"; queryParams?: undefined }
+  | CacheEntryBase & {
+    type: "list";
+    queryParams?: { where?: unknown; orderBy?: unknown; pageSize?: number };
+  }
+  | CacheEntryBase & { type: "link"; queryParams?: { linkName?: string } }
+  | CacheEntryBase & { type: "objectSet"; queryParams?: undefined };
+
 export interface ObserveObjectOptions<
   T extends ObjectOrInterfaceDefinition,
 > extends ObserveOptions {
@@ -533,6 +566,8 @@ export interface ObservableClient extends ObserveLinks {
     apiName: string,
     primaryKey: string | number,
   ): Promise<void>;
+
+  getCacheSnapshot(): Promise<CacheSnapshot>;
 
   canonicalizeWhereClause: <
     T extends ObjectOrInterfaceDefinition,

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -89,13 +89,15 @@ interface CacheEntryBase {
 }
 
 export type CacheEntry =
-  | CacheEntryBase & { type: "object"; queryParams?: undefined }
+  | CacheEntryBase & { type: "object" }
   | CacheEntryBase & {
     type: "list";
-    queryParams?: { where?: unknown; orderBy?: unknown; pageSize?: number };
+    where?: unknown;
+    orderBy?: unknown;
+    pageSize?: number;
   }
-  | CacheEntryBase & { type: "link"; queryParams?: { linkName?: string } }
-  | CacheEntryBase & { type: "objectSet"; queryParams?: undefined };
+  | CacheEntryBase & { type: "link"; linkName?: string }
+  | CacheEntryBase & { type: "objectSet" };
 
 export interface ObserveObjectOptions<
   T extends ObjectOrInterfaceDefinition,

--- a/packages/client/src/observable/internal/ObservableClientImpl.ts
+++ b/packages/client/src/observable/internal/ObservableClientImpl.ts
@@ -44,6 +44,7 @@ import type { ListPayload } from "../ListPayload.js";
 import type { ObjectPayload } from "../ObjectPayload.js";
 import type { ObjectSetPayload } from "../ObjectSetPayload.js";
 import type {
+  CacheSnapshot,
   CanonicalizedOptions,
   CanonicalizeOptionsInput,
   ObservableClient,
@@ -400,6 +401,10 @@ export class ObservableClientImpl implements ObservableClient {
       observer,
     );
   }
+
+  public async getCacheSnapshot(): Promise<CacheSnapshot> {
+    return this.__experimentalStore.getCacheSnapshot();
+  }
 }
 
 function observeSingleLink(
@@ -415,7 +420,7 @@ function observeSingleLink(
       linkedObjectsBySourcePrimaryKey: new Map(),
       isOptimistic: false,
       lastUpdated: 0,
-      fetchMore: () => Promise.resolve(),
+      fetchMore: async () => {},
       hasMore: false,
       status: "loaded",
       totalCount: "0",
@@ -513,7 +518,7 @@ function observeMultiLinks(
       lastUpdated: latestUpdated,
       fetchMore: hasMore
         ? () => Promise.all(fetchMores.map(fn => fn())).then(() => {})
-        : () => Promise.resolve(),
+        : async () => {},
       hasMore,
       status: loading
         ? "loading"

--- a/packages/client/src/observable/internal/Store.ts
+++ b/packages/client/src/observable/internal/Store.ts
@@ -28,6 +28,7 @@ import invariant from "tiny-invariant";
 import type { ActionSignatureFromDef } from "../../actions/applyAction.js";
 import { additionalContext, type Client } from "../../Client.js";
 import { DEBUG_REFCOUNTS } from "../DebugFlags.js";
+import type { CacheEntry, CacheSnapshot } from "../ObservableClient.js";
 import type { OptimisticBuilder } from "../OptimisticBuilder.js";
 import { ActionApplication } from "./actions/ActionApplication.js";
 import {
@@ -51,6 +52,9 @@ import type { KnownCacheKey } from "./KnownCacheKey.js";
 import type { Entry } from "./Layer.js";
 import { Layers } from "./Layers.js";
 import { LinksHelper } from "./links/LinksHelper.js";
+import {
+  SOURCE_API_NAME_IDX as LINK_API_NAME_IDX,
+} from "./links/SpecificLinkCacheKey.js";
 import {
   API_NAME_IDX as LIST_API_NAME_IDX,
   RDP_IDX as LIST_RDP_IDX,
@@ -86,6 +90,9 @@ export namespace Store {
     - Subjects are one per type per store (by cache key)
     - Data is one per layer per cache key
 */
+
+const __DEV__ = typeof process === "undefined"
+  || process.env.NODE_ENV !== "production";
 
 /**
  * Central data store with layered cache architecture.
@@ -614,5 +621,92 @@ export class Store {
     primaryKey: string | number,
   ): Promise<void> {
     return this.functions.invalidateFunctionsByObject(apiName, primaryKey);
+  }
+
+  #sizeCache: WeakMap<object, number> | undefined;
+
+  public getCacheSnapshot(): CacheSnapshot {
+    if (__DEV__) {
+      const sizeCache = this.#sizeCache ??= new WeakMap<object, number>();
+      const entries: CacheEntry[] = [];
+      let totalSize = 0;
+
+      for (const cacheKey of this.layers.truth.keys()) {
+        const entry = this.layers.top.get(cacheKey);
+        if (!entry) {
+          continue;
+        }
+
+        let entryType: CacheEntry["type"] | undefined;
+        let objectType = "";
+
+        if (cacheKey.type === "object") {
+          entryType = "object";
+          objectType = cacheKey.otherKeys[OBJECT_API_NAME_IDX];
+        } else if (cacheKey.type === "list") {
+          entryType = "list";
+          objectType = cacheKey.otherKeys[LIST_API_NAME_IDX];
+        } else if (cacheKey.type === "specificLink") {
+          entryType = "link";
+          objectType = cacheKey.otherKeys[LINK_API_NAME_IDX];
+        } else if (cacheKey.type === "objectSet") {
+          entryType = "objectSet";
+          objectType = "";
+        }
+
+        if (!entryType) {
+          continue;
+        }
+
+        let estimatedSize = 0;
+        if (entry.value != null && typeof entry.value === "object") {
+          const objectValue = entry.value;
+          const cached = sizeCache.get(objectValue);
+          if (cached !== undefined) {
+            estimatedSize = cached;
+          } else {
+            try {
+              estimatedSize = JSON.stringify(entry.value).length * 2;
+            } catch {
+              // TODO: surface unserializable entries to devtools users
+              estimatedSize = 0;
+            }
+            sizeCache.set(objectValue, estimatedSize);
+          }
+        } else if (entry.value != null) {
+          try {
+            estimatedSize = JSON.stringify(entry.value).length * 2;
+          } catch {
+            estimatedSize = 0;
+          }
+        }
+        totalSize += estimatedSize;
+
+        entries.push({
+          key: DEBUG_ONLY__cacheKeyToString(cacheKey),
+          type: entryType,
+          objectType,
+          metadata: {
+            timestamp: entry.lastUpdated,
+            status: entry.status,
+            size: estimatedSize,
+          },
+          data: entry.value,
+        });
+      }
+
+      return {
+        entries,
+        stats: {
+          totalEntries: entries.length,
+          totalSize,
+        },
+      };
+    }
+
+    return {
+      entries: [],
+      stats: { totalEntries: 0, totalSize: 0 },
+    };
   }
 }

--- a/packages/client/src/public/unstable-do-not-use.ts
+++ b/packages/client/src/public/unstable-do-not-use.ts
@@ -21,6 +21,8 @@ export { getWireObjectSet, isObjectSet } from "../objectSet/createObjectSet.js";
 export type { ActionSignatureFromDef } from "../actions/applyAction.js";
 export { createObservableClient } from "../observable/ObservableClient.js";
 export type {
+  CacheEntry,
+  CacheSnapshot,
   CanonicalizedOptions,
   CanonicalizeOptionsInput,
   ObservableClient,

--- a/packages/react/devtools-registry.d.ts
+++ b/packages/react/devtools-registry.d.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from "./build/cjs/public/devtools-registry.cjs";

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -16,6 +16,15 @@
       "require": "./build/cjs/index.cjs",
       "default": "./build/browser/index.js"
     },
+    "./devtools-registry": {
+      "browser": "./build/browser/public/devtools-registry.js",
+      "import": {
+        "types": "./build/types/public/devtools-registry.d.ts",
+        "default": "./build/esm/public/devtools-registry.js"
+      },
+      "require": "./build/cjs/public/devtools-registry.cjs",
+      "default": "./build/browser/public/devtools-registry.js"
+    },
     "./experimental": {
       "browser": "./build/browser/public/experimental.js",
       "import": {

--- a/packages/react/src/new/OsdkContext2.ts
+++ b/packages/react/src/new/OsdkContext2.ts
@@ -55,10 +55,12 @@ interface OsdkContextContents {
   // in the future we can just make
   // this `client: ObservableClient`
   observableClient: ObservableClient;
+  devtoolsEnabled: boolean;
 }
 
 export const OsdkContext2: React.Context<OsdkContextContents> = React
   .createContext<OsdkContextContents>({
     client: fakeClient,
     observableClient: fakeObservableClient,
+    devtoolsEnabled: false,
   });

--- a/packages/react/src/new/OsdkProvider2.tsx
+++ b/packages/react/src/new/OsdkProvider2.tsx
@@ -21,27 +21,53 @@ import {
 } from "@osdk/client/unstable-do-not-use";
 import React, { useMemo } from "react";
 import { OsdkContext } from "../OsdkContext.js";
+import { getRegisteredDevTools } from "../public/devtools-registry.js";
 import { OsdkContext2 } from "./OsdkContext2.js";
+import { useDevToolsClient } from "./useDevToolsClient.js";
+
+declare const process: { env: { NODE_ENV: string } };
+const __DEV__ = typeof process === "undefined"
+  || process.env.NODE_ENV !== "production";
 
 interface OsdkProviderOptions {
   children: React.ReactNode;
   client: Client;
   observableClient?: ObservableClient;
+  enableDevTools?: boolean;
 }
 
 export function OsdkProvider2({
   children,
   client,
   observableClient,
+  enableDevTools,
 }: OsdkProviderOptions): React.JSX.Element {
-  observableClient = useMemo(
+  const devtoolsEnabled = __DEV__
+    && (enableDevTools ?? getRegisteredDevTools() != null);
+
+  const baseObservableClient = useMemo(
     () => observableClient ?? createObservableClient(client),
     [client, observableClient],
   );
+
+  const { client: devToolsClient, wrapChildren } = useDevToolsClient(
+    baseObservableClient,
+    devtoolsEnabled,
+  );
+
+  const content = wrapChildren?.(children) ?? children;
+
+  const contextValue = useMemo(
+    () => ({ client, observableClient: devToolsClient, devtoolsEnabled }),
+    [client, devToolsClient, devtoolsEnabled],
+  );
+
   return (
-    <OsdkContext2.Provider value={{ client, observableClient }}>
+    <OsdkContext2.Provider
+      value={contextValue}
+    >
       <OsdkContext.Provider value={{ client }}>
-        {children}
+        {content}
       </OsdkContext.Provider>
     </OsdkContext2.Provider>
   );

--- a/packages/react/src/new/__tests__/useOsdkAction.test.tsx
+++ b/packages/react/src/new/__tests__/useOsdkAction.test.tsx
@@ -52,7 +52,11 @@ function createWrapper(observableClient: ObservableClient) {
   return function Wrapper({ children }: { children: React.ReactNode }) {
     return (
       <OsdkContext2.Provider
-        value={{ client: {} as never, observableClient }}
+        value={{
+          client: {} as never,
+          observableClient,
+          devtoolsEnabled: false,
+        }}
       >
         {children}
       </OsdkContext2.Provider>

--- a/packages/react/src/new/__tests__/useOsdkFunctions.test.tsx
+++ b/packages/react/src/new/__tests__/useOsdkFunctions.test.tsx
@@ -57,7 +57,11 @@ function createWrapper(observableClient: ObservableClient) {
   return function Wrapper({ children }: { children: React.ReactNode }) {
     return (
       <OsdkContext2.Provider
-        value={{ client: {} as Client, observableClient }}
+        value={{
+          client: {} as Client,
+          observableClient,
+          devtoolsEnabled: false,
+        }}
       >
         {children}
       </OsdkContext2.Provider>

--- a/packages/react/src/new/makeExternalStore.ts
+++ b/packages/react/src/new/makeExternalStore.ts
@@ -18,6 +18,51 @@ import type {
   Observer,
   Unsubscribable,
 } from "@osdk/client/unstable-do-not-use";
+import React from "react";
+
+declare const process: { env: { NODE_ENV: string } };
+const __DEV__ = typeof process === "undefined"
+  || process.env.NODE_ENV !== "production";
+
+export const OSDK_HOOK_METADATA: symbol = Symbol.for(
+  "__OSDK_HOOK_METADATA__",
+);
+
+export interface OsdkStoreMetadata {
+  hookType: string;
+  objectType?: string;
+  primaryKey?: string;
+  actionName?: string;
+  sourceObjectType?: string;
+  linkName?: string;
+  where?: unknown;
+  orderBy?: unknown;
+  pageSize?: number;
+  aggregate?: unknown;
+}
+
+export const devToolsMetadata: (
+  meta: OsdkStoreMetadata,
+) => OsdkStoreMetadata | undefined = __DEV__
+  ? (meta) => meta
+  : (_meta) => undefined;
+
+export function useDevToolsMetadata(
+  devtoolsEnabled: boolean,
+  hookType: string,
+  key: string,
+): void {
+  const ref = React.useRef<
+    { [k: symbol]: true; hookType: string; key: string } | null
+  >(null);
+  if (devtoolsEnabled) {
+    if (ref.current == null || ref.current.key !== key) {
+      ref.current = { [OSDK_HOOK_METADATA]: true, hookType, key };
+    }
+  } else if (ref.current != null) {
+    ref.current = null;
+  }
+}
 
 export type Snapshot<X> =
   | X & { error?: Error }
@@ -26,7 +71,7 @@ export type Snapshot<X> =
 
 export function makeExternalStore<X>(
   createObservation: (callback: Observer<X | undefined>) => Unsubscribable,
-  _name?: string,
+  _metadata?: OsdkStoreMetadata,
   initialValue?: Snapshot<X>,
 ): {
   subscribe: (notifyUpdate: () => void) => () => void;
@@ -59,10 +104,14 @@ export function makeExternalStore<X>(
     };
   }
 
-  return {
-    subscribe,
-    getSnapShot,
-  };
+  const store = { subscribe, getSnapShot };
+  if (__DEV__ && _metadata != null) {
+    Object.defineProperty(store, OSDK_HOOK_METADATA, {
+      value: _metadata,
+      enumerable: false,
+    });
+  }
+  return store;
 }
 
 /**
@@ -76,7 +125,7 @@ export function makeExternalStoreAsync<X>(
   createObservation: (
     callback: Observer<X | undefined>,
   ) => Promise<Unsubscribable>,
-  _name?: string,
+  _metadata?: OsdkStoreMetadata,
   initialValue?: Snapshot<X>,
 ): {
   subscribe: (notifyUpdate: () => void) => () => void;
@@ -135,8 +184,12 @@ export function makeExternalStoreAsync<X>(
     };
   }
 
-  return {
-    subscribe,
-    getSnapShot,
-  };
+  const store = { subscribe, getSnapShot };
+  if (__DEV__ && _metadata != null) {
+    Object.defineProperty(store, OSDK_HOOK_METADATA, {
+      value: _metadata,
+      enumerable: false,
+    });
+  }
+  return store;
 }

--- a/packages/react/src/new/useDevToolsClient.ts
+++ b/packages/react/src/new/useDevToolsClient.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObservableClient } from "@osdk/client/unstable-do-not-use";
+import type React from "react";
+import { useMemo, useRef } from "react";
+import {
+  type DevToolsRegistry,
+  getRegisteredDevTools,
+} from "../public/devtools-registry.js";
+
+export function useDevToolsClient(
+  baseClient: ObservableClient,
+  enabled: boolean,
+): {
+  client: ObservableClient;
+  wrapChildren: ((children: React.ReactNode) => React.ReactNode) | null;
+} {
+  const stateRef = useRef<
+    {
+      base: ObservableClient;
+      monitored: ObservableClient;
+      devTools: DevToolsRegistry;
+    } | null
+  >(null);
+
+  const prev = stateRef.current;
+
+  let wrappedClient: ObservableClient;
+  if (!enabled) {
+    stateRef.current = null;
+    wrappedClient = baseClient;
+  } else {
+    const devTools = getRegisteredDevTools();
+    if (devTools == null) {
+      stateRef.current = null;
+      wrappedClient = baseClient;
+    } else if (
+      prev != null && prev.base === baseClient && prev.devTools === devTools
+    ) {
+      wrappedClient = prev.monitored;
+    } else {
+      const monitored = devTools.wrapClient(baseClient);
+      stateRef.current = { base: baseClient, monitored, devTools };
+      wrappedClient = monitored;
+    }
+  }
+
+  const currentState = stateRef.current;
+  const wrapChildren = useMemo(
+    () =>
+      currentState != null
+        ? (children: React.ReactNode): React.ReactNode =>
+          currentState.devTools.wrapChildren(children, currentState.monitored)
+        : null,
+    [currentState],
+  );
+
+  return { client: wrappedClient, wrapChildren };
+}

--- a/packages/react/src/new/useLinks.ts
+++ b/packages/react/src/new/useLinks.ts
@@ -23,7 +23,7 @@ import type { Osdk, PropertyKeys, WhereClause } from "@osdk/client";
 import type { ObserveLinks } from "@osdk/client/unstable-do-not-use";
 import React from "react";
 import { extractPayloadError, isPayloadLoading } from "./hookUtils.js";
-import { makeExternalStore } from "./makeExternalStore.js";
+import { devToolsMetadata, makeExternalStore } from "./makeExternalStore.js";
 import { OsdkContext2 } from "./OsdkContext2.js";
 
 export interface UseLinksOptions<
@@ -172,7 +172,11 @@ export function useLinks<
       if (!enabled) {
         return makeExternalStore<ObserveLinks.CallbackArgs<T>>(
           () => ({ unsubscribe: () => {} }),
-          `links ${linkName} for ${objectsKey} [DISABLED]`,
+          devToolsMetadata({
+            hookType: "useLinks",
+            sourceObjectType: objectsArray[0]?.$apiName,
+            linkName,
+          }),
         );
       }
       return makeExternalStore<ObserveLinks.CallbackArgs<T>>(
@@ -191,7 +195,11 @@ export function useLinks<
             },
             observer,
           ),
-        `links ${linkName} for ${objectsKey}`,
+        devToolsMetadata({
+          hookType: "useLinks",
+          sourceObjectType: objectsArray[0]?.$apiName,
+          linkName,
+        }),
       );
     },
     [

--- a/packages/react/src/new/useObjectSet.tsx
+++ b/packages/react/src/new/useObjectSet.tsx
@@ -31,7 +31,11 @@ import {
 } from "@osdk/client/unstable-do-not-use";
 import React from "react";
 import { extractPayloadError } from "./hookUtils.js";
-import { makeExternalStore, type Snapshot } from "./makeExternalStore.js";
+import {
+  devToolsMetadata,
+  makeExternalStore,
+  type Snapshot,
+} from "./makeExternalStore.js";
 import { OsdkContext2 } from "./OsdkContext2.js";
 
 export interface UseObjectSetOptions<
@@ -175,12 +179,6 @@ export interface UseObjectSetResult<
   refetch: () => Promise<void>;
 }
 
-declare const process: {
-  env: {
-    NODE_ENV: "development" | "production";
-  };
-};
-
 const OBJECT_TYPE_PLACEHOLDER = "$__OBJECT__TYPE__PLACEHOLDER";
 /**
  * React hook for observing and interacting with OSDK object sets.
@@ -249,9 +247,10 @@ export function useObjectSet<
       if (!enabled) {
         return makeExternalStore<ObserveObjectSetArgs<Q, RDPs>>(
           () => ({ unsubscribe: () => {} }),
-          process.env.NODE_ENV !== "production"
-            ? `objectSet [DISABLED]`
-            : void 0,
+          devToolsMetadata({
+            hookType: "useObjectSet",
+            objectType: objectTypeKey,
+          }),
         );
       }
 
@@ -284,9 +283,10 @@ export function useObjectSet<
           );
           return subscription;
         },
-        process.env.NODE_ENV !== "production"
-          ? `objectSet ${objectTypeKey}`
-          : void 0,
+        devToolsMetadata({
+          hookType: "useObjectSet",
+          objectType: objectTypeKey,
+        }),
         initialValue,
       );
     },

--- a/packages/react/src/new/useOsdkAction.ts
+++ b/packages/react/src/new/useOsdkAction.ts
@@ -25,6 +25,7 @@ import type {
   ObservableClient,
 } from "@osdk/client/unstable-do-not-use";
 import React from "react";
+import { useDevToolsMetadata } from "./makeExternalStore.js";
 import { OsdkContext2 } from "./OsdkContext2.js";
 
 type ApplyActionParams<Q extends ActionDefinition<any>> =
@@ -67,7 +68,8 @@ export interface UseOsdkActionResult<Q extends ActionDefinition<any>> {
 export function useOsdkAction<Q extends ActionDefinition<any>>(
   actionDef: Q,
 ): UseOsdkActionResult<Q> {
-  const { observableClient } = React.useContext(OsdkContext2);
+  const { observableClient, devtoolsEnabled } = React.useContext(OsdkContext2);
+  useDevToolsMetadata(devtoolsEnabled, "useOsdkAction", actionDef.apiName);
   const [error, setError] = React.useState<UseOsdkActionResult<Q>["error"]>();
   const [data, setData] = React.useState<ActionEditResponse | undefined>();
   const [isPending, setPending] = React.useState(false);

--- a/packages/react/src/new/useOsdkAggregation.ts
+++ b/packages/react/src/new/useOsdkAggregation.ts
@@ -31,6 +31,7 @@ import {
 import React from "react";
 import { extractPayloadError, isPayloadLoading } from "./hookUtils.js";
 import {
+  devToolsMetadata,
   makeExternalStore,
   makeExternalStoreAsync,
 } from "./makeExternalStore.js";
@@ -101,12 +102,6 @@ export interface UseOsdkAggregationResult<
   error: Error | undefined;
   refetch: () => Promise<void>;
 }
-
-declare const process: {
-  env: {
-    NODE_ENV: "development" | "production";
-  };
-};
 
 /**
  * React hook for performing aggregations on OSDK object sets.
@@ -209,11 +204,12 @@ export function useOsdkAggregation<
               },
               observer,
             ),
-          process.env.NODE_ENV !== "production"
-            ? `aggregation ${type.apiName} ${
-              JSON.stringify(canonOptions.where)
-            }`
-            : void 0,
+          devToolsMetadata({
+            hookType: "useOsdkAggregation",
+            objectType: type.apiName,
+            where: canonOptions.where,
+            aggregate: canonOptions.aggregate,
+          }),
         );
       }
       return makeExternalStore<ObserveAggregationArgs<Q, A>>(
@@ -230,9 +226,12 @@ export function useOsdkAggregation<
             },
             observer,
           ),
-        process.env.NODE_ENV !== "production"
-          ? `aggregation ${type.apiName} ${JSON.stringify(canonOptions.where)}`
-          : void 0,
+        devToolsMetadata({
+          hookType: "useOsdkAggregation",
+          objectType: type.apiName,
+          where: canonOptions.where,
+          aggregate: canonOptions.aggregate,
+        }),
       );
     },
     [

--- a/packages/react/src/new/useOsdkFunction.ts
+++ b/packages/react/src/new/useOsdkFunction.ts
@@ -27,7 +27,7 @@ import type {
 } from "@osdk/client/unstable-do-not-use";
 import { getWireObjectSet } from "@osdk/client/unstable-do-not-use";
 import React from "react";
-import { makeExternalStore } from "./makeExternalStore.js";
+import { devToolsMetadata, makeExternalStore } from "./makeExternalStore.js";
 import { OsdkContext2 } from "./OsdkContext2.js";
 
 export interface UseOsdkFunctionOptions<Q extends QueryDefinition<unknown>> {
@@ -130,12 +130,6 @@ export interface UseOsdkFunctionResult<Q extends QueryDefinition<unknown>> {
   refetch: () => Promise<void>;
 }
 
-declare const process: {
-  env: {
-    NODE_ENV: "development" | "production";
-  };
-};
-
 /**
  * React hook for executing and observing OSDK functions.
  *
@@ -211,11 +205,10 @@ export function useOsdkFunction<Q extends QueryDefinition<unknown>>(
       if (!enabled) {
         return makeExternalStore<ObserveFunctionCallbackArgs<Q>>(
           () => ({ unsubscribe: () => {} }),
-          process.env.NODE_ENV !== "production"
-            ? `function ${queryDef.apiName} ${
-              JSON.stringify(stableParams)
-            } [DISABLED]`
-            : void 0,
+          devToolsMetadata({
+            hookType: "useOsdkFunction",
+            objectType: queryDef.apiName,
+          }),
         );
       }
       return makeExternalStore<ObserveFunctionCallbackArgs<Q>>(
@@ -230,9 +223,10 @@ export function useOsdkFunction<Q extends QueryDefinition<unknown>>(
             },
             observer,
           ),
-        process.env.NODE_ENV !== "production"
-          ? `function ${queryDef.apiName} ${JSON.stringify(stableParams)}`
-          : void 0,
+        devToolsMetadata({
+          hookType: "useOsdkFunction",
+          objectType: queryDef.apiName,
+        }),
       );
     },
     [

--- a/packages/react/src/new/useOsdkObject.ts
+++ b/packages/react/src/new/useOsdkObject.ts
@@ -22,7 +22,7 @@ import type {
 } from "@osdk/api";
 import type { ObserveObjectCallbackArgs } from "@osdk/client/unstable-do-not-use";
 import React from "react";
-import { makeExternalStore } from "./makeExternalStore.js";
+import { devToolsMetadata, makeExternalStore } from "./makeExternalStore.js";
 import { OsdkContext2 } from "./OsdkContext2.js";
 
 export interface UseOsdkObjectResult<
@@ -154,7 +154,11 @@ export function useOsdkObject<
       if (!enabled) {
         return makeExternalStore<ObserveObjectCallbackArgs<Q>>(
           () => ({ unsubscribe: () => {} }),
-          `object ${apiNameString} ${primaryKey} [DISABLED]`,
+          devToolsMetadata({
+            hookType: "useOsdkObject",
+            objectType: apiNameString,
+            primaryKey: String(primaryKey),
+          }),
         );
       }
       return makeExternalStore<ObserveObjectCallbackArgs<Q>>(
@@ -173,7 +177,11 @@ export function useOsdkObject<
             },
             observer,
           ),
-        `object ${apiNameString} ${primaryKey}`,
+        devToolsMetadata({
+          hookType: "useOsdkObject",
+          objectType: apiNameString,
+          primaryKey: String(primaryKey),
+        }),
       );
     },
     [

--- a/packages/react/src/new/useOsdkObjects.ts
+++ b/packages/react/src/new/useOsdkObjects.ts
@@ -28,7 +28,7 @@ import type {
 import type { ObserveObjectsCallbackArgs } from "@osdk/client/unstable-do-not-use";
 import React from "react";
 import { extractPayloadError, isPayloadLoading } from "./hookUtils.js";
-import { makeExternalStore } from "./makeExternalStore.js";
+import { devToolsMetadata, makeExternalStore } from "./makeExternalStore.js";
 import { OsdkContext2 } from "./OsdkContext2.js";
 
 export interface UseOsdkObjectsOptions<
@@ -196,12 +196,6 @@ export interface UseOsdkListResult<
   refetch: () => Promise<void>;
 }
 
-declare const process: {
-  env: {
-    NODE_ENV: "development" | "production";
-  };
-};
-
 export function useOsdkObjects<
   Q extends ObjectOrInterfaceDefinition,
   L extends LinkNames<Q>,
@@ -284,9 +278,10 @@ export function useOsdkObjects<
           ObserveObjectsCallbackArgs<Q, RDPs>
         >(
           () => ({ unsubscribe: () => {} }),
-          process.env.NODE_ENV !== "production"
-            ? `list ${type.apiName} [DISABLED]`
-            : void 0,
+          devToolsMetadata({
+            hookType: "useOsdkObjects",
+            objectType: type.apiName,
+          }),
         );
       }
 
@@ -313,11 +308,13 @@ export function useOsdkObjects<
               ? { $loadPropertySecurityMetadata }
               : {}),
           }, observer),
-        process.env.NODE_ENV !== "production"
-          ? `list ${type.apiName} ${
-            stableRids ? `[${stableRids.length} rids]` : ""
-          } ${JSON.stringify(canonOptions.where)}`
-          : void 0,
+        devToolsMetadata({
+          hookType: "useOsdkObjects",
+          objectType: type.apiName,
+          where: canonOptions.where,
+          orderBy: canonOptions.orderBy,
+          pageSize,
+        }),
       );
     },
     [

--- a/packages/react/src/public/devtools-registry.ts
+++ b/packages/react/src/public/devtools-registry.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObservableClient } from "@osdk/client/unstable-do-not-use";
+import type { ReactNode } from "react";
+
+export interface DevToolsRegistry {
+  wrapClient: (client: ObservableClient) => ObservableClient;
+  wrapChildren: (children: ReactNode, client: ObservableClient) => ReactNode;
+}
+
+const GLOBAL_KEY = "__OSDK_DEVTOOLS_REGISTRY__";
+
+function getGlobal(): Record<string, unknown> {
+  if (typeof globalThis !== "undefined") {
+    return globalThis as Record<string, unknown>;
+  }
+  if (typeof window !== "undefined") {
+    return window as unknown as Record<string, unknown>;
+  }
+  return {};
+}
+
+export function registerDevTools(tools: DevToolsRegistry): void {
+  getGlobal()[GLOBAL_KEY] = tools;
+}
+
+export function getRegisteredDevTools(): DevToolsRegistry | null {
+  return (getGlobal()[GLOBAL_KEY] as DevToolsRegistry | undefined) ?? null;
+}

--- a/packages/react/src/public/experimental.ts
+++ b/packages/react/src/public/experimental.ts
@@ -41,3 +41,8 @@ export { useOsdkClient } from "../useOsdkClient.js";
 export { useOsdkMetadata } from "../useOsdkMetadata.js";
 export type { UseOsdkMetadataResult } from "../useOsdkMetadata.js";
 export { useDebouncedCallback } from "../utils/useDebouncedCallback.js";
+export type { DevToolsRegistry } from "./devtools-registry.js";
+export {
+  getRegisteredDevTools,
+  registerDevTools,
+} from "./devtools-registry.js";

--- a/packages/react/src/utils/usePlatformQuery.ts
+++ b/packages/react/src/utils/usePlatformQuery.ts
@@ -16,7 +16,10 @@
 
 import type { Observer } from "@osdk/client/unstable-do-not-use";
 import React from "react";
-import { makeExternalStore } from "../new/makeExternalStore.js";
+import {
+  devToolsMetadata,
+  makeExternalStore,
+} from "../new/makeExternalStore.js";
 
 export interface UseQueryOptions<T> {
   /**
@@ -80,9 +83,10 @@ export function usePlatformQuery<T>(
       if (!enabled) {
         return makeExternalStore<QueryPayload<T>>(
           () => ({ unsubscribe: () => {} }),
-          process.env.NODE_ENV !== "production"
-            ? `${queryName} Query [DISABLED]`
-            : undefined,
+          devToolsMetadata({
+            hookType: "usePlatformQuery",
+            objectType: queryName,
+          }),
         );
       }
 
@@ -96,7 +100,10 @@ export function usePlatformQuery<T>(
             },
           };
         },
-        queryName,
+        devToolsMetadata({
+          hookType: "usePlatformQuery",
+          objectType: queryName,
+        }),
       );
     },
     [enabled, queryName, handleQuery],

--- a/packages/react/test/useLinks.enabled.test.tsx
+++ b/packages/react/test/useLinks.enabled.test.tsx
@@ -42,7 +42,9 @@ describe("useLinks enabled option", () => {
     } as any;
 
     return ({ children }: React.PropsWithChildren) => (
-      <OsdkContext2.Provider value={{ observableClient }}>
+      <OsdkContext2.Provider
+        value={{ observableClient, devtoolsEnabled: false }}
+      >
         {children}
       </OsdkContext2.Provider>
     );

--- a/packages/react/test/useObjectSet.test.tsx
+++ b/packages/react/test/useObjectSet.test.tsx
@@ -72,7 +72,9 @@ describe(useObjectSet, () => {
     } as any;
 
     return ({ children }: React.PropsWithChildren) => (
-      <OsdkContext2.Provider value={{ observableClient }}>
+      <OsdkContext2.Provider
+        value={{ observableClient, devtoolsEnabled: false }}
+      >
         {children}
       </OsdkContext2.Provider>
     );

--- a/packages/react/test/useOsdkFunction.test.tsx
+++ b/packages/react/test/useOsdkFunction.test.tsx
@@ -52,7 +52,10 @@ describe("useOsdkFunction", () => {
 
     return ({ children }: React.PropsWithChildren) => (
       <OsdkContext2.Provider
-        value={{ observableClient: observableClient as ObservableClient }}
+        value={{
+          observableClient: observableClient as ObservableClient,
+          devtoolsEnabled: false,
+        }}
       >
         {children}
       </OsdkContext2.Provider>

--- a/packages/react/test/useOsdkObject.enabled.test.tsx
+++ b/packages/react/test/useOsdkObject.enabled.test.tsx
@@ -44,7 +44,9 @@ describe("useOsdkObject enabled option", () => {
     } as any;
 
     return ({ children }: React.PropsWithChildren) => (
-      <OsdkContext2.Provider value={{ observableClient }}>
+      <OsdkContext2.Provider
+        value={{ observableClient, devtoolsEnabled: false }}
+      >
         {children}
       </OsdkContext2.Provider>
     );

--- a/packages/react/test/useOsdkObjects.enabled.test.tsx
+++ b/packages/react/test/useOsdkObjects.enabled.test.tsx
@@ -37,7 +37,9 @@ describe("useOsdkObjects enabled option", () => {
     } as any;
 
     return ({ children }: React.PropsWithChildren) => (
-      <OsdkContext2.Provider value={{ observableClient }}>
+      <OsdkContext2.Provider
+        value={{ observableClient, devtoolsEnabled: false }}
+      >
         {children}
       </OsdkContext2.Provider>
     );

--- a/packages/react/test/useOsdkObjects.test.tsx
+++ b/packages/react/test/useOsdkObjects.test.tsx
@@ -38,7 +38,9 @@ describe("useOsdkObjects enabled option", () => {
     } as any;
 
     return ({ children }: React.PropsWithChildren) => (
-      <OsdkContext2.Provider value={{ observableClient }}>
+      <OsdkContext2.Provider
+        value={{ observableClient, devtoolsEnabled: false }}
+      >
         {children}
       </OsdkContext2.Provider>
     );


### PR DESCRIPTION
wire up devtools metadata in all hooks and add cache snapshot API to client

• add DevToolsRegistry interface, registerDevTools, and devtools-metadata symbol to @osdk/react
• add getCacheSnapshot, __devtoolsSignature, and registerListHook/registerObjectHook to ObservableClient
• attach metadata and override system to all hooks with NODE_ENV gating