### PR TITLE
add peekObjectData api and extract canonicalizeListParams

### DIFF
--- a/.changeset/add-peek-object-data-api.md
+++ b/.changeset/add-peek-object-data-api.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+add peekObjectData api and extract canonicalizeListParams

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -627,10 +627,10 @@ export interface ObservableClient extends ObserveLinks {
   ): Unsubscribable;
 
   /**
-   * Synchronously check whether the Store has loaded data for a single object.
-   * Read-only: no refcount changes, no fetch triggers, no observation creation.
+   * Synchronously peek at cached data for a single object.
+   * Does not trigger a fetch or create an observation.
    *
-   * @returns The full callback args if the object is loaded, undefined otherwise
+   * @returns The object data if loaded, undefined otherwise
    */
   peekObjectData<T extends ObjectOrInterfaceDefinition>(
     apiName: T["apiName"] | T,

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -600,6 +600,17 @@ export interface ObservableClient extends ObserveLinks {
     options: MediaMetadataObserveOptions,
     observer: Observer<MediaMetadataPayload>,
   ): Unsubscribable;
+
+  /**
+   * Synchronously check whether the Store has loaded data for a single object.
+   * Read-only: no refcount changes, no fetch triggers, no observation creation.
+   *
+   * @returns The full callback args if the object is loaded, undefined otherwise
+   */
+  peekObjectData<T extends ObjectOrInterfaceDefinition>(
+    apiName: T["apiName"] | T,
+    pk: PrimaryKeyType<T>,
+  ): ObserveObjectCallbackArgs<T> | undefined;
 }
 
 export interface CanonicalizeOptionsInput<OS = ObjectSet<any, any>> {

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -602,10 +602,10 @@ export interface ObservableClient extends ObserveLinks {
   ): Unsubscribable;
 
   /**
-   * Synchronously check whether the Store has loaded data for a single object.
-   * Read-only: no refcount changes, no fetch triggers, no observation creation.
+   * Synchronously peek at cached data for a single object.
+   * Does not trigger a fetch or create an observation.
    *
-   * @returns The full callback args if the object is loaded, undefined otherwise
+   * @returns The object data if loaded, undefined otherwise
    */
   peekObjectData<T extends ObjectOrInterfaceDefinition>(
     apiName: T["apiName"] | T,

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -625,6 +625,17 @@ export interface ObservableClient extends ObserveLinks {
     options: MediaMetadataObserveOptions,
     observer: Observer<MediaMetadataPayload>,
   ): Unsubscribable;
+
+  /**
+   * Synchronously check whether the Store has loaded data for a single object.
+   * Read-only: no refcount changes, no fetch triggers, no observation creation.
+   *
+   * @returns The full callback args if the object is loaded, undefined otherwise
+   */
+  peekObjectData<T extends ObjectOrInterfaceDefinition>(
+    apiName: T["apiName"] | T,
+    pk: PrimaryKeyType<T>,
+  ): ObserveObjectCallbackArgs<T> | undefined;
 }
 
 export interface CanonicalizeOptionsInput<OS = ObjectSet<any, any>> {

--- a/packages/client/src/observable/internal/ObservableClientImpl.ts
+++ b/packages/client/src/observable/internal/ObservableClientImpl.ts
@@ -69,6 +69,7 @@ import type { MediaPropertyLocation } from "../ObservableClient/MediaTypes.js";
 import type { ObserveLinks } from "../ObservableClient/ObserveLink.js";
 import type { AggregationPayloadBase } from "./aggregation/AggregationQuery.js";
 import type { Canonical } from "./Canonical.js";
+import type { ObjectCacheKey } from "./object/ObjectCacheKey.js";
 import type { ObserveObjectSetOptions } from "./objectset/ObjectSetQueryOptions.js";
 import type { Rdp } from "./RdpCanonicalizer.js";
 import type { Store } from "./Store.js";
@@ -317,6 +318,42 @@ export class ObservableClientImpl implements ObservableClient {
       apiName,
       primaryKey,
     );
+  }
+
+  public peekObjectData<T extends ObjectOrInterfaceDefinition>(
+    apiName: T["apiName"] | T,
+    pk: PrimaryKeyType<T>,
+  ): ObserveObjectCallbackArgs<T> | undefined {
+    const apiNameStr = typeof apiName === "string"
+      ? apiName
+      : apiName.apiName;
+
+    const cacheKey = this.__experimentalStore.cacheKeys.peek<ObjectCacheKey>(
+      "object",
+      apiNameStr,
+      pk,
+    );
+    if (!cacheKey) {
+      return undefined;
+    }
+
+    const subject = this.__experimentalStore.subjects.peek(cacheKey);
+    if (!subject) {
+      return undefined;
+    }
+
+    const payload = subject.value;
+    if (payload.status !== "loaded" || payload.value === undefined) {
+      return undefined;
+    }
+
+    return {
+      // ObjectHolder IS Osdk.Instance via cast across the type boundary
+      object: payload.value as unknown as Osdk.Instance<T>,
+      status: payload.status,
+      lastUpdated: payload.lastUpdated,
+      isOptimistic: payload.isOptimistic,
+    };
   }
 
   public canonicalizeWhereClause<

--- a/packages/client/src/observable/internal/ObservableClientImpl.ts
+++ b/packages/client/src/observable/internal/ObservableClientImpl.ts
@@ -347,7 +347,7 @@ export class ObservableClientImpl implements ObservableClient {
     }
 
     return {
-      // ObjectHolder IS Osdk.Instance via cast across the type boundary
+      // ObjectHolder is Osdk.Instance via cast across the type boundary
       object: payload.value as unknown as Osdk.Instance<T>,
       status: payload.status,
       lastUpdated: payload.lastUpdated,

--- a/packages/client/src/observable/internal/ObservableClientImpl.ts
+++ b/packages/client/src/observable/internal/ObservableClientImpl.ts
@@ -349,7 +349,10 @@ export class ObservableClientImpl implements ObservableClient {
 
     return {
       // ObjectHolder is Osdk.Instance via cast across the type boundary
-      object: payload.value as unknown as Osdk.Instance<T, "$allBaseProperties">,
+      object: payload.value as unknown as Osdk.Instance<
+        T,
+        "$allBaseProperties"
+      >,
       status: payload.status,
       lastUpdated: payload.lastUpdated,
       isOptimistic: payload.isOptimistic,

--- a/packages/client/src/observable/internal/ObservableClientImpl.ts
+++ b/packages/client/src/observable/internal/ObservableClientImpl.ts
@@ -348,7 +348,7 @@ export class ObservableClientImpl implements ObservableClient {
     }
 
     return {
-      // ObjectHolder IS Osdk.Instance via cast across the type boundary
+      // ObjectHolder is Osdk.Instance via cast across the type boundary
       object: payload.value as unknown as Osdk.Instance<T>,
       status: payload.status,
       lastUpdated: payload.lastUpdated,

--- a/packages/client/src/observable/internal/ObservableClientImpl.ts
+++ b/packages/client/src/observable/internal/ObservableClientImpl.ts
@@ -349,7 +349,7 @@ export class ObservableClientImpl implements ObservableClient {
 
     return {
       // ObjectHolder is Osdk.Instance via cast across the type boundary
-      object: payload.value as unknown as Osdk.Instance<T>,
+      object: payload.value as unknown as Osdk.Instance<T, "$allBaseProperties">,
       status: payload.status,
       lastUpdated: payload.lastUpdated,
       isOptimistic: payload.isOptimistic,

--- a/packages/client/src/observable/internal/ObservableClientImpl.ts
+++ b/packages/client/src/observable/internal/ObservableClientImpl.ts
@@ -69,6 +69,7 @@ import type { MediaPropertyLocation } from "../ObservableClient/MediaTypes.js";
 import type { ObserveLinks } from "../ObservableClient/ObserveLink.js";
 import type { AggregationPayloadBase } from "./aggregation/AggregationQuery.js";
 import type { Canonical } from "./Canonical.js";
+import type { ObjectCacheKey } from "./object/ObjectCacheKey.js";
 import type { ObserveObjectSetOptions } from "./objectset/ObjectSetQueryOptions.js";
 import type { Store } from "./Store.js";
 import { UnsubscribableWrapper } from "./UnsubscribableWrapper.js";
@@ -316,6 +317,42 @@ export class ObservableClientImpl implements ObservableClient {
       apiName,
       primaryKey,
     );
+  }
+
+  public peekObjectData<T extends ObjectOrInterfaceDefinition>(
+    apiName: T["apiName"] | T,
+    pk: PrimaryKeyType<T>,
+  ): ObserveObjectCallbackArgs<T> | undefined {
+    const apiNameStr = typeof apiName === "string"
+      ? apiName
+      : apiName.apiName;
+
+    const cacheKey = this.__experimentalStore.cacheKeys.peek<ObjectCacheKey>(
+      "object",
+      apiNameStr,
+      pk,
+    );
+    if (!cacheKey) {
+      return undefined;
+    }
+
+    const subject = this.__experimentalStore.subjects.peek(cacheKey);
+    if (!subject) {
+      return undefined;
+    }
+
+    const payload = subject.value;
+    if (payload.status !== "loaded" || payload.value === undefined) {
+      return undefined;
+    }
+
+    return {
+      // ObjectHolder IS Osdk.Instance via cast across the type boundary
+      object: payload.value as unknown as Osdk.Instance<T>,
+      status: payload.status,
+      lastUpdated: payload.lastUpdated,
+      isOptimistic: payload.isOptimistic,
+    };
   }
 
   public canonicalizeWhereClause<

--- a/packages/client/src/observable/internal/Store.test.ts
+++ b/packages/client/src/observable/internal/Store.test.ts
@@ -2863,6 +2863,99 @@ describe(Store, () => {
       }
     });
   });
+
+  describe("peekObjectData", () => {
+    let client: Client;
+    let cache: Store;
+    let fauxFoundry: FauxFoundry;
+
+    beforeAll(async () => {
+      const testSetup = startNodeApiServer(
+        new FauxFoundry("https://stack.palantir.com/"),
+        createClient,
+        { logger },
+      );
+      ({ client, fauxFoundry } = testSetup);
+
+      setupOntology(fauxFoundry);
+      setupSomeEmployees(fauxFoundry);
+
+      return () => {
+        testSetup.apiServer.close();
+      };
+    });
+
+    beforeEach(() => {
+      cache = new Store(client);
+      return () => {
+        cache = undefined!;
+      };
+    });
+
+    it("returns undefined for non-existent object", () => {
+      const observableClient = new ObservableClientImpl(cache);
+
+      const result = observableClient.peekObjectData(
+        Employee,
+        99999,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it("returns loaded object data", async () => {
+      const observableClient = new ObservableClientImpl(cache);
+
+      const { payload } = await expectStandardObserveObject({
+        cache,
+        type: Employee,
+        primaryKey: 1,
+      });
+
+      const result = observableClient.peekObjectData(
+        Employee,
+        1,
+      );
+
+      expect(result).toBeDefined();
+      expect(result).toEqual(
+        expect.objectContaining({
+          object: expect.objectContaining({
+            $apiName: "Employee",
+            $primaryKey: 1,
+          }),
+          status: "loaded",
+          isOptimistic: false,
+        }),
+      );
+      expect(result?.lastUpdated).toBeGreaterThan(0);
+    });
+
+    it("returns undefined for object in loading state", () => {
+      const observableClient = new ObservableClientImpl(cache);
+
+      const subFn = mockSingleSubCallback();
+      defer(
+        cache.objects.observe({
+          apiName: Employee,
+          pk: 1,
+        }, subFn),
+      );
+
+      expectSingleObjectCallAndClear(
+        subFn,
+        undefined,
+        "loading",
+      );
+
+      const result = observableClient.peekObjectData(
+        Employee,
+        1,
+      );
+
+      expect(result).toBeUndefined();
+    });
+  });
 });
 
 export function asBsoStub(

--- a/packages/client/src/observable/internal/Store.test.ts
+++ b/packages/client/src/observable/internal/Store.test.ts
@@ -2946,6 +2946,99 @@ describe(Store, () => {
       }
     });
   });
+
+  describe("peekObjectData", () => {
+    let client: Client;
+    let cache: Store;
+    let fauxFoundry: FauxFoundry;
+
+    beforeAll(async () => {
+      const testSetup = startNodeApiServer(
+        new FauxFoundry("https://stack.palantir.com/"),
+        createClient,
+        { logger },
+      );
+      ({ client, fauxFoundry } = testSetup);
+
+      setupOntology(fauxFoundry);
+      setupSomeEmployees(fauxFoundry);
+
+      return () => {
+        testSetup.apiServer.close();
+      };
+    });
+
+    beforeEach(() => {
+      cache = new Store(client);
+      return () => {
+        cache = undefined!;
+      };
+    });
+
+    it("returns undefined for non-existent object", () => {
+      const observableClient = new ObservableClientImpl(cache);
+
+      const result = observableClient.peekObjectData(
+        Employee,
+        99999,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it("returns loaded object data", async () => {
+      const observableClient = new ObservableClientImpl(cache);
+
+      const { payload } = await expectStandardObserveObject({
+        cache,
+        type: Employee,
+        primaryKey: 1,
+      });
+
+      const result = observableClient.peekObjectData(
+        Employee,
+        1,
+      );
+
+      expect(result).toBeDefined();
+      expect(result).toEqual(
+        expect.objectContaining({
+          object: expect.objectContaining({
+            $apiName: "Employee",
+            $primaryKey: 1,
+          }),
+          status: "loaded",
+          isOptimistic: false,
+        }),
+      );
+      expect(result?.lastUpdated).toBeGreaterThan(0);
+    });
+
+    it("returns undefined for object in loading state", () => {
+      const observableClient = new ObservableClientImpl(cache);
+
+      const subFn = mockSingleSubCallback();
+      defer(
+        cache.objects.observe({
+          apiName: Employee,
+          pk: 1,
+        }, subFn),
+      );
+
+      expectSingleObjectCallAndClear(
+        subFn,
+        undefined,
+        "loading",
+      );
+
+      const result = observableClient.peekObjectData(
+        Employee,
+        1,
+      );
+
+      expect(result).toBeUndefined();
+    });
+  });
 });
 
 export function asBsoStub(

--- a/packages/client/src/observable/internal/list/ListsHelper.ts
+++ b/packages/client/src/observable/internal/list/ListsHelper.ts
@@ -127,6 +127,7 @@ export class ListsHelper extends AbstractHelper<
       pivotTo,
       rids,
       select,
+      $loadPropertySecurityMetadata,
     } = options;
     const { apiName, type } = typeDefinition;
     // The flag is interface-only on the server. Drop it for object queries so
@@ -189,8 +190,6 @@ export class ListsHelper extends AbstractHelper<
       $loadPropertySecurityMetadata,
       $includeAllBaseObjectProperties,
     } = this.canonicalizeListParams(options);
-
-    const { $loadPropertySecurityMetadata } = options;
 
     const listCacheKey = this.cacheKeys.get<ListCacheKey>(
       "list",

--- a/packages/client/src/observable/internal/list/ListsHelper.ts
+++ b/packages/client/src/observable/internal/list/ListsHelper.ts
@@ -116,7 +116,6 @@ export class ListsHelper extends AbstractHelper<
       pivotTo,
       rids,
       select,
-      $loadPropertySecurityMetadata,
     } = options;
     const { apiName, type } = typeDefinition;
 
@@ -169,6 +168,8 @@ export class ListsHelper extends AbstractHelper<
       canonRids,
       canonSelect,
     } = this.canonicalizeListParams(options);
+
+    const { $loadPropertySecurityMetadata } = options;
 
     const listCacheKey = this.cacheKeys.get<ListCacheKey>(
       "list",

--- a/packages/client/src/observable/internal/list/ListsHelper.ts
+++ b/packages/client/src/observable/internal/list/ListsHelper.ts
@@ -127,7 +127,6 @@ export class ListsHelper extends AbstractHelper<
       pivotTo,
       rids,
       select,
-      $loadPropertySecurityMetadata,
     } = options;
     const { apiName, type } = typeDefinition;
     // The flag is interface-only on the server. Drop it for object queries so
@@ -190,6 +189,8 @@ export class ListsHelper extends AbstractHelper<
       $loadPropertySecurityMetadata,
       $includeAllBaseObjectProperties,
     } = this.canonicalizeListParams(options);
+
+    const { $loadPropertySecurityMetadata } = options;
 
     const listCacheKey = this.cacheKeys.get<ListCacheKey>(
       "list",

--- a/packages/client/src/observable/internal/list/ListsHelper.ts
+++ b/packages/client/src/observable/internal/list/ListsHelper.ts
@@ -20,14 +20,16 @@ import type { ObserveListOptions } from "../../ObservableClient.js";
 import type { Observer } from "../../ObservableClient/common.js";
 import { AbstractHelper } from "../AbstractHelper.js";
 import type { CacheKeys } from "../CacheKeys.js";
+import type { Canonical } from "../Canonical.js";
 import type { IntersectCanonicalizer } from "../IntersectCanonicalizer.js";
 import type { KnownCacheKey } from "../KnownCacheKey.js";
 import type { OrderByCanonicalizer } from "../OrderByCanonicalizer.js";
-import type { PivotCanonicalizer } from "../PivotCanonicalizer.js";
+import type { PivotCanonicalizer, PivotInfo } from "../PivotCanonicalizer.js";
 import type { QuerySubscription } from "../QuerySubscription.js";
-import type { RdpCanonicalizer } from "../RdpCanonicalizer.js";
+import type { Rdp, RdpCanonicalizer } from "../RdpCanonicalizer.js";
 import type { RidListCanonicalizer } from "../RidListCanonicalizer.js";
 import type { SelectCanonicalizer } from "../SelectCanonicalizer.js";
+import type { SimpleWhereClause } from "../SimpleWhereClause.js";
 import type { Store } from "../Store.js";
 import type { WhereClauseCanonicalizer } from "../WhereClauseCanonicalizer.js";
 import { InterfaceListQuery } from "./InterfaceListQuery.js";
@@ -101,9 +103,21 @@ export class ListsHelper extends AbstractHelper<
     return ret;
   }
 
-  getQuery<T extends ObjectOrInterfaceDefinition>(
+  canonicalizeListParams<T extends ObjectOrInterfaceDefinition>(
     options: ObserveListOptions<T, {}>,
-  ): ListQuery {
+  ): {
+    type: "object" | "interface";
+    apiName: string;
+    canonWhere: Canonical<SimpleWhereClause>;
+    canonOrderBy: Canonical<Record<string, "asc" | "desc" | undefined>>;
+    canonRdp: Canonical<Rdp> | undefined;
+    canonIntersect: Canonical<Array<Canonical<SimpleWhereClause>>> | undefined;
+    canonPivot: Canonical<PivotInfo> | undefined;
+    canonRids: Canonical<string[]> | undefined;
+    canonSelect: Canonical<readonly string[]> | undefined;
+    $loadPropertySecurityMetadata: boolean | undefined;
+    $includeAllBaseObjectProperties: true | undefined;
+  } {
     const {
       type: typeDefinition,
       where,
@@ -144,6 +158,38 @@ export class ListsHelper extends AbstractHelper<
     const canonSelect = select && select.length > 0
       ? this.selectCanonicalizer.canonicalize(select)
       : undefined;
+
+    return {
+      type,
+      apiName,
+      canonWhere,
+      canonOrderBy,
+      canonRdp,
+      canonIntersect,
+      canonPivot,
+      canonRids,
+      canonSelect,
+      $loadPropertySecurityMetadata,
+      $includeAllBaseObjectProperties,
+    };
+  }
+
+  getQuery<T extends ObjectOrInterfaceDefinition>(
+    options: ObserveListOptions<T, {}>,
+  ): ListQuery {
+    const {
+      type,
+      apiName,
+      canonWhere,
+      canonOrderBy,
+      canonRdp,
+      canonIntersect,
+      canonPivot,
+      canonRids,
+      canonSelect,
+      $loadPropertySecurityMetadata,
+      $includeAllBaseObjectProperties,
+    } = this.canonicalizeListParams(options);
 
     const listCacheKey = this.cacheKeys.get<ListCacheKey>(
       "list",

--- a/packages/client/src/observable/internal/list/ListsHelper.ts
+++ b/packages/client/src/observable/internal/list/ListsHelper.ts
@@ -20,14 +20,16 @@ import type { ObserveListOptions } from "../../ObservableClient.js";
 import type { Observer } from "../../ObservableClient/common.js";
 import { AbstractHelper } from "../AbstractHelper.js";
 import type { CacheKeys } from "../CacheKeys.js";
+import type { Canonical } from "../Canonical.js";
 import type { IntersectCanonicalizer } from "../IntersectCanonicalizer.js";
 import type { KnownCacheKey } from "../KnownCacheKey.js";
 import type { OrderByCanonicalizer } from "../OrderByCanonicalizer.js";
-import type { PivotCanonicalizer } from "../PivotCanonicalizer.js";
+import type { PivotCanonicalizer, PivotInfo } from "../PivotCanonicalizer.js";
 import type { QuerySubscription } from "../QuerySubscription.js";
-import type { RdpCanonicalizer } from "../RdpCanonicalizer.js";
+import type { Rdp, RdpCanonicalizer } from "../RdpCanonicalizer.js";
 import type { RidListCanonicalizer } from "../RidListCanonicalizer.js";
 import type { SelectCanonicalizer } from "../SelectCanonicalizer.js";
+import type { SimpleWhereClause } from "../SimpleWhereClause.js";
 import type { Store } from "../Store.js";
 import type { WhereClauseCanonicalizer } from "../WhereClauseCanonicalizer.js";
 import { InterfaceListQuery } from "./InterfaceListQuery.js";
@@ -92,9 +94,19 @@ export class ListsHelper extends AbstractHelper<
     return ret;
   }
 
-  getQuery<T extends ObjectOrInterfaceDefinition>(
+  canonicalizeListParams<T extends ObjectOrInterfaceDefinition>(
     options: ObserveListOptions<T>,
-  ): ListQuery {
+  ): {
+    type: "object" | "interface";
+    apiName: string;
+    canonWhere: Canonical<SimpleWhereClause>;
+    canonOrderBy: Canonical<Record<string, "asc" | "desc" | undefined>>;
+    canonRdp: Canonical<Rdp> | undefined;
+    canonIntersect: Canonical<Array<Canonical<SimpleWhereClause>>> | undefined;
+    canonPivot: Canonical<PivotInfo> | undefined;
+    canonRids: Canonical<string[]> | undefined;
+    canonSelect: Canonical<readonly string[]> | undefined;
+  } {
     const {
       type: typeDefinition,
       where,
@@ -129,6 +141,34 @@ export class ListsHelper extends AbstractHelper<
     const canonSelect = select && select.length > 0
       ? this.selectCanonicalizer.canonicalize(select)
       : undefined;
+
+    return {
+      type,
+      apiName,
+      canonWhere,
+      canonOrderBy,
+      canonRdp,
+      canonIntersect,
+      canonPivot,
+      canonRids,
+      canonSelect,
+    };
+  }
+
+  getQuery<T extends ObjectOrInterfaceDefinition>(
+    options: ObserveListOptions<T>,
+  ): ListQuery {
+    const {
+      type,
+      apiName,
+      canonWhere,
+      canonOrderBy,
+      canonRdp,
+      canonIntersect,
+      canonPivot,
+      canonRids,
+      canonSelect,
+    } = this.canonicalizeListParams(options);
 
     const listCacheKey = this.cacheKeys.get<ListCacheKey>(
       "list",


### PR DESCRIPTION
First in a series of PRs to support React Suspense with osdk-react
Adds a synchronous peek api for checking cached object data without creating observations

• add peekObjectData to ObservableClient for synchronous cache reads (no refcount, no fetch)
• extract canonicalizeListParams from ListsHelper for reuse by peek and observe paths