### PR TITLE
add suspense store infrastructure and utilities

### DIFF
--- a/.changeset/add-suspense-store-infra.md
+++ b/.changeset/add-suspense-store-infra.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react": patch
+---
+
+add suspense store infrastructure and error boundary

--- a/packages/react-components/src/OsdkErrorBoundary.tsx
+++ b/packages/react-components/src/OsdkErrorBoundary.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+import { clearSuspenseErrors } from "@osdk/react/experimental";
 import React from "react";
-import { _clearErroredSuspenseEntries } from "./makeSuspenseExternalStore.js";
 
 export interface OsdkErrorBoundaryProps {
   children: React.ReactNode;
@@ -23,6 +23,7 @@ export interface OsdkErrorBoundaryProps {
     | React.ReactNode
     | ((error: Error, retry: () => void) => React.ReactNode);
   onError?: (error: Error) => void;
+  onRetry?: () => void;
 }
 
 interface OsdkErrorBoundaryState {
@@ -51,7 +52,7 @@ export class OsdkErrorBoundary
   }
 
   private retry = (): void => {
-    _clearErroredSuspenseEntries();
+    (this.props.onRetry ?? clearSuspenseErrors)();
     this.setState({ error: undefined });
   };
 

--- a/packages/react-components/src/public/experimental.ts
+++ b/packages/react-components/src/public/experimental.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+export { OsdkErrorBoundary } from "../OsdkErrorBoundary.js";
+export type { OsdkErrorBoundaryProps } from "../OsdkErrorBoundary.js";
 export * from "./experimental/action-form.js";
 export * from "./experimental/filter-list.js";
 export * from "./experimental/markdown-renderer.js";
 export * from "./experimental/object-table.js";
 export * from "./experimental/pdf-viewer.js";
 export * from "./experimental/tiff-renderer.js";
-export { OsdkErrorBoundary } from "../OsdkErrorBoundary.js";
-export type { OsdkErrorBoundaryProps } from "../OsdkErrorBoundary.js";

--- a/packages/react-components/src/public/experimental.ts
+++ b/packages/react-components/src/public/experimental.ts
@@ -20,3 +20,5 @@ export * from "./experimental/markdown-renderer.js";
 export * from "./experimental/object-table.js";
 export * from "./experimental/pdf-viewer.js";
 export * from "./experimental/tiff-renderer.js";
+export { OsdkErrorBoundary } from "../OsdkErrorBoundary.js";
+export type { OsdkErrorBoundaryProps } from "../OsdkErrorBoundary.js";

--- a/packages/react/src/new/OsdkErrorBoundary.tsx
+++ b/packages/react/src/new/OsdkErrorBoundary.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from "react";
+import { _clearErroredSuspenseEntries } from "./makeSuspenseExternalStore.js";
 
 export interface OsdkErrorBoundaryProps {
   children: React.ReactNode;
@@ -50,6 +51,7 @@ export class OsdkErrorBoundary
   }
 
   private retry = (): void => {
+    _clearErroredSuspenseEntries();
     this.setState({ error: undefined });
   };
 

--- a/packages/react/src/new/OsdkErrorBoundary.tsx
+++ b/packages/react/src/new/OsdkErrorBoundary.tsx
@@ -61,30 +61,32 @@ export class OsdkErrorBoundary
       if (this.props.fallback !== undefined) {
         return this.props.fallback;
       }
-      return React.createElement(
-        "div",
-        {
-          style: {
+      return (
+        <div
+          style={{
             padding: "16px",
             border: "1px solid #e53e3e",
             borderRadius: "4px",
             backgroundColor: "#fff5f5",
-          },
-        },
-        React.createElement("p", {
-          style: { color: "#c53030", margin: "0 0 8px 0" },
-        }, this.state.error.message),
-        React.createElement("button", {
-          onClick: this.retry,
-          style: {
-            padding: "4px 12px",
-            border: "1px solid #c53030",
-            borderRadius: "4px",
-            backgroundColor: "white",
-            color: "#c53030",
-            cursor: "pointer",
-          },
-        }, "Retry"),
+          }}
+        >
+          <p style={{ color: "#c53030", margin: "0 0 8px 0" }}>
+            {this.state.error.message}
+          </p>
+          <button
+            onClick={this.retry}
+            style={{
+              padding: "4px 12px",
+              border: "1px solid #c53030",
+              borderRadius: "4px",
+              backgroundColor: "white",
+              color: "#c53030",
+              cursor: "pointer",
+            }}
+          >
+            Retry
+          </button>
+        </div>
       );
     }
 

--- a/packages/react/src/new/OsdkErrorBoundary.tsx
+++ b/packages/react/src/new/OsdkErrorBoundary.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+
+export interface OsdkErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback?:
+    | React.ReactNode
+    | ((error: Error, retry: () => void) => React.ReactNode);
+  onError?: (error: Error) => void;
+}
+
+interface OsdkErrorBoundaryState {
+  error: Error | undefined;
+}
+
+export class OsdkErrorBoundary
+  extends React.Component<OsdkErrorBoundaryProps, OsdkErrorBoundaryState>
+{
+  constructor(props: OsdkErrorBoundaryProps) {
+    super(props);
+    this.state = { error: undefined };
+  }
+
+  static getDerivedStateFromError(error: unknown): OsdkErrorBoundaryState {
+    return {
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
+
+  componentDidCatch(error: unknown): void {
+    const normalizedError = error instanceof Error
+      ? error
+      : new Error(String(error));
+    this.props.onError?.(normalizedError);
+  }
+
+  private retry = (): void => {
+    this.setState({ error: undefined });
+  };
+
+  render(): React.ReactNode {
+    if (this.state.error) {
+      if (typeof this.props.fallback === "function") {
+        return this.props.fallback(this.state.error, this.retry);
+      }
+      if (this.props.fallback !== undefined) {
+        return this.props.fallback;
+      }
+      return React.createElement(
+        "div",
+        {
+          style: {
+            padding: "16px",
+            border: "1px solid #e53e3e",
+            borderRadius: "4px",
+            backgroundColor: "#fff5f5",
+          },
+        },
+        React.createElement("p", {
+          style: { color: "#c53030", margin: "0 0 8px 0" },
+        }, this.state.error.message),
+        React.createElement("button", {
+          onClick: this.retry,
+          style: {
+            padding: "4px 12px",
+            border: "1px solid #c53030",
+            borderRadius: "4px",
+            backgroundColor: "white",
+            color: "#c53030",
+            cursor: "pointer",
+          },
+        }, "Retry"),
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/packages/react/src/new/makeExternalStore.ts
+++ b/packages/react/src/new/makeExternalStore.ts
@@ -71,7 +71,7 @@ export type Snapshot<X> =
 
 export function extractPayloadError(
   payload: { error?: Error; status?: string } | undefined,
-  fallbackMessage = "Failed to load data",
+  fallbackMessage: string,
 ): Error | undefined {
   if (payload == null) {
     return undefined;

--- a/packages/react/src/new/makeExternalStore.ts
+++ b/packages/react/src/new/makeExternalStore.ts
@@ -68,7 +68,7 @@ export type Snapshot<X> =
 
 export function extractPayloadError(
   payload: { error?: Error; status?: string } | undefined,
-  fallbackMessage = "Failed to load data",
+  fallbackMessage: string,
 ): Error | undefined {
   if (payload == null) {
     return undefined;

--- a/packages/react/src/new/makeExternalStore.ts
+++ b/packages/react/src/new/makeExternalStore.ts
@@ -66,6 +66,22 @@ export type Snapshot<X> =
   | (Partial<X> & { error?: Error })
   | undefined;
 
+export function extractPayloadError(
+  payload: { error?: Error; status?: string } | undefined,
+  fallbackMessage = "Failed to load data",
+): Error | undefined {
+  if (payload == null) {
+    return undefined;
+  }
+  if (payload.error) {
+    return payload.error;
+  }
+  if (payload.status === "error") {
+    return new Error(fallbackMessage);
+  }
+  return undefined;
+}
+
 export function makeExternalStore<X>(
   createObservation: (callback: Observer<X | undefined>) => Unsubscribable,
   _metadata?: OsdkStoreMetadata,

--- a/packages/react/src/new/makeExternalStore.ts
+++ b/packages/react/src/new/makeExternalStore.ts
@@ -69,6 +69,22 @@ export type Snapshot<X> =
   | (Partial<X> & { error?: Error })
   | undefined;
 
+export function extractPayloadError(
+  payload: { error?: Error; status?: string } | undefined,
+  fallbackMessage = "Failed to load data",
+): Error | undefined {
+  if (payload == null) {
+    return undefined;
+  }
+  if (payload.error) {
+    return payload.error;
+  }
+  if (payload.status === "error") {
+    return new Error(fallbackMessage);
+  }
+  return undefined;
+}
+
 export function makeExternalStore<X>(
   createObservation: (callback: Observer<X | undefined>) => Unsubscribable,
   _metadata?: OsdkStoreMetadata,

--- a/packages/react/src/new/makeSuspenseExternalStore.ts
+++ b/packages/react/src/new/makeSuspenseExternalStore.ts
@@ -270,8 +270,8 @@ export function setupSuspenseStore<X>(
   return suspenseStore;
 }
 
-/** @internal - called by OsdkErrorBoundary retry to clear errored entries */
-export function _clearErroredSuspenseEntries(): void {
+/** Clear all errored suspense cache entries so error boundary retry starts fresh. */
+export function clearSuspenseErrors(): void {
   for (const [key, entry] of suspenseCache) {
     if (entry.hasErrored) {
       entry.observation?.unsubscribe();

--- a/packages/react/src/new/makeSuspenseExternalStore.ts
+++ b/packages/react/src/new/makeSuspenseExternalStore.ts
@@ -24,7 +24,6 @@ interface SuspenseCacheEntry<X> {
   lastResult: Snapshot<X>;
   hasLoadedOnce: boolean;
   hasErrored: boolean;
-  errorThrown: boolean;
   pendingPromise: Promise<void> | undefined;
   resolvePending: (() => void) | undefined;
   observation: Unsubscribable | undefined;
@@ -82,18 +81,7 @@ function getOrCreateEntry<X>(
 ): SuspenseCacheEntry<X> {
   const existing = suspenseCache.get(cacheKey);
   if (existing) {
-    // Errored entries whose error was already thrown to an error boundary
-    // (errorThrown) and have no active subscribers are stale. Delete and
-    // recreate so that error boundary retry starts a fresh observation.
-    if (
-      existing.hasErrored && existing.errorThrown
-      && existing.subscriberCount <= 0
-    ) {
-      existing.observation?.unsubscribe();
-      suspenseCache.delete(cacheKey);
-    } else {
-      return existing as SuspenseCacheEntry<X>;
-    }
+    return existing as SuspenseCacheEntry<X>;
   }
 
   const hasPeekData = peekResult !== undefined;
@@ -102,7 +90,6 @@ function getOrCreateEntry<X>(
     lastResult: peekResult,
     hasLoadedOnce: hasPeekData,
     hasErrored: false,
-    errorThrown: false,
     pendingPromise: undefined,
     resolvePending: undefined,
     observation: undefined,
@@ -220,7 +207,6 @@ export function getSuspenseExternalStore<X>(
     getError() {
       const result = entry.lastResult;
       if (result != null && "error" in result && result.error) {
-        entry.errorThrown = true;
         return result.error;
       }
       return undefined;
@@ -282,6 +268,16 @@ export function setupSuspenseStore<X>(
     hasDataCheck,
   );
   return suspenseStore;
+}
+
+/** @internal - called by OsdkErrorBoundary retry to clear errored entries */
+export function _clearErroredSuspenseEntries(): void {
+  for (const [key, entry] of suspenseCache) {
+    if (entry.hasErrored) {
+      entry.observation?.unsubscribe();
+      suspenseCache.delete(key);
+    }
+  }
 }
 
 /** @internal - exported for testing */

--- a/packages/react/src/new/makeSuspenseExternalStore.ts
+++ b/packages/react/src/new/makeSuspenseExternalStore.ts
@@ -24,6 +24,7 @@ interface SuspenseCacheEntry<X> {
   lastResult: Snapshot<X>;
   hasLoadedOnce: boolean;
   hasErrored: boolean;
+  errorThrown: boolean;
   pendingPromise: Promise<void> | undefined;
   resolvePending: (() => void) | undefined;
   observation: Unsubscribable | undefined;
@@ -81,10 +82,18 @@ function getOrCreateEntry<X>(
 ): SuspenseCacheEntry<X> {
   const existing = suspenseCache.get(cacheKey);
   if (existing) {
-    // The cache stores SuspenseCacheEntry<unknown> but the key guarantees
-    // the same observation shape. This cast is safe when callers use
-    // consistent type parameters per cache key.
-    return existing as SuspenseCacheEntry<X>;
+    // Errored entries whose error was already thrown to an error boundary
+    // (errorThrown) and have no active subscribers are stale. Delete and
+    // recreate so that error boundary retry starts a fresh observation.
+    if (
+      existing.hasErrored && existing.errorThrown
+      && existing.subscriberCount <= 0
+    ) {
+      existing.observation?.unsubscribe();
+      suspenseCache.delete(cacheKey);
+    } else {
+      return existing as SuspenseCacheEntry<X>;
+    }
   }
 
   const hasPeekData = peekResult !== undefined;
@@ -93,6 +102,7 @@ function getOrCreateEntry<X>(
     lastResult: peekResult,
     hasLoadedOnce: hasPeekData,
     hasErrored: false,
+    errorThrown: false,
     pendingPromise: undefined,
     resolvePending: undefined,
     observation: undefined,
@@ -210,6 +220,7 @@ export function getSuspenseExternalStore<X>(
     getError() {
       const result = entry.lastResult;
       if (result != null && "error" in result && result.error) {
+        entry.errorThrown = true;
         return result.error;
       }
       return undefined;

--- a/packages/react/src/new/makeSuspenseExternalStore.ts
+++ b/packages/react/src/new/makeSuspenseExternalStore.ts
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  Observer,
+  Unsubscribable,
+} from "@osdk/client/unstable-do-not-use";
+import type { Snapshot } from "./makeExternalStore.js";
+
+interface SuspenseCacheEntry<X> {
+  lastResult: Snapshot<X>;
+  hasLoadedOnce: boolean;
+  hasErrored: boolean;
+  pendingPromise: Promise<void> | undefined;
+  resolvePending: (() => void) | undefined;
+  observation: Unsubscribable | undefined;
+  listeners: Set<() => void>;
+  subscriberCount: number;
+  createdAt: number;
+  transferred: boolean;
+}
+
+const suspenseCache = new Map<string, SuspenseCacheEntry<unknown>>();
+
+let clientIdCounter = 0;
+const clientIds = new WeakMap<object, number>();
+
+export function getClientId(client: object): number {
+  let id = clientIds.get(client);
+  if (id === undefined) {
+    id = clientIdCounter++;
+    clientIds.set(client, id);
+  }
+  return id;
+}
+
+const ORPHAN_CLEANUP_INTERVAL_MS = 60_000;
+const ORPHAN_MAX_AGE_MS = 60_000;
+
+let cleanupTimerId: ReturnType<typeof setInterval> | undefined;
+
+function ensureOrphanCleanup(): void {
+  if (cleanupTimerId !== undefined) {
+    return;
+  }
+  cleanupTimerId = setInterval(() => {
+    const now = Date.now();
+    for (const [key, entry] of suspenseCache) {
+      if (!entry.transferred && now - entry.createdAt >= ORPHAN_MAX_AGE_MS) {
+        entry.observation?.unsubscribe();
+        suspenseCache.delete(key);
+      }
+    }
+    if (suspenseCache.size === 0) {
+      clearInterval(cleanupTimerId);
+      cleanupTimerId = undefined;
+    }
+  }, ORPHAN_CLEANUP_INTERVAL_MS);
+  // Prevent timer from blocking Node.js process exit (tests, SSR)
+  (cleanupTimerId as unknown as { unref?(): void }).unref?.();
+}
+
+function getOrCreateEntry<X>(
+  cacheKey: string,
+  createObservation: (callback: Observer<X | undefined>) => Unsubscribable,
+  hasDataCheck: (p: Snapshot<X>) => boolean,
+  peekResult: Snapshot<X>,
+): SuspenseCacheEntry<X> {
+  const existing = suspenseCache.get(cacheKey);
+  if (existing) {
+    // The cache stores SuspenseCacheEntry<unknown> but the key guarantees
+    // the same observation shape. This cast is safe when callers use
+    // consistent type parameters per cache key.
+    return existing as SuspenseCacheEntry<X>;
+  }
+
+  const hasPeekData = peekResult !== undefined;
+
+  const entry: SuspenseCacheEntry<X> = {
+    lastResult: peekResult,
+    hasLoadedOnce: hasPeekData,
+    hasErrored: false,
+    pendingPromise: undefined,
+    resolvePending: undefined,
+    observation: undefined,
+    listeners: new Set(),
+    subscriberCount: 0,
+    createdAt: Date.now(),
+    transferred: false,
+  };
+
+  function resolveIfPending(): void {
+    if (entry.resolvePending) {
+      entry.resolvePending();
+      entry.resolvePending = undefined;
+      entry.pendingPromise = undefined;
+    }
+  }
+
+  entry.observation = createObservation({
+    next: (payload) => {
+      entry.lastResult = payload as Snapshot<X>;
+      if (hasDataCheck(entry.lastResult)) {
+        entry.hasLoadedOnce = true;
+        entry.hasErrored = false;
+        resolveIfPending();
+      }
+      for (const listener of entry.listeners) {
+        listener();
+      }
+    },
+    error: (error: unknown) => {
+      entry.lastResult = {
+        ...(entry.lastResult ?? {}),
+        error: error instanceof Error ? error : new Error(String(error)),
+      } as Snapshot<X>;
+      entry.hasErrored = true;
+      resolveIfPending();
+      for (const listener of entry.listeners) {
+        listener();
+      }
+    },
+    complete: () => {},
+  });
+
+  suspenseCache.set(cacheKey, entry as SuspenseCacheEntry<unknown>);
+  ensureOrphanCleanup();
+  return entry;
+}
+
+/**
+ * Suspense-aware store that survives React 18's hook state reset on Suspense
+ * retry.
+ *
+ * Uses an external cache keyed by `cacheKey` so the observation and its data
+ * persist even when React discards and re-creates hook state during suspension.
+ *
+ * The observation starts eagerly on first access. `subscribe`/`getSnapShot`
+ * are compatible with `useSyncExternalStore` for ongoing updates after the
+ * component exits suspension and commits.
+ *
+ * `subscriberCount` is only modified in `subscribe`/cleanup (commit phase),
+ * never during render, so it is not inflated by Suspense retries or
+ * StrictMode double-renders.
+ *
+ * When `peekResult` is provided (Store already has loaded data), the entry
+ * starts with `hasLoadedOnce: true` and uses the peek data as the initial
+ * snapshot, skipping suspension. The eager observation immediately delivers
+ * the full payload via BehaviorSubject, replacing the peek snapshot.
+ */
+export function getSuspenseExternalStore<X>(
+  cacheKey: string,
+  createObservation: (callback: Observer<X | undefined>) => Unsubscribable,
+  hasDataCheck: (p: Snapshot<X>) => boolean,
+  peekResult?: Snapshot<X>,
+): {
+  subscribe: (notifyUpdate: () => void) => () => void;
+  getSnapShot: () => Snapshot<X>;
+  getSuspensePromise: () => Promise<void> | undefined;
+  getError: () => Error | undefined;
+} {
+  const entry = getOrCreateEntry<X>(
+    cacheKey,
+    createObservation,
+    hasDataCheck,
+    peekResult,
+  );
+
+  return {
+    subscribe(notifyUpdate: () => void) {
+      entry.subscriberCount++;
+      entry.transferred = true;
+      entry.listeners.add(notifyUpdate);
+      return () => {
+        entry.listeners.delete(notifyUpdate);
+        entry.subscriberCount--;
+        if (entry.subscriberCount <= 0) {
+          entry.observation?.unsubscribe();
+          suspenseCache.delete(cacheKey);
+        }
+      };
+    },
+    getSnapShot() {
+      return entry.lastResult;
+    },
+    getSuspensePromise() {
+      if (entry.hasLoadedOnce || entry.hasErrored) {
+        return undefined;
+      }
+      if (entry.pendingPromise === undefined) {
+        entry.pendingPromise = new Promise<void>((resolve) => {
+          entry.resolvePending = resolve;
+        });
+      }
+      return entry.pendingPromise;
+    },
+    getError() {
+      const result = entry.lastResult;
+      if (result != null && "error" in result && result.error) {
+        return result.error;
+      }
+      return undefined;
+    },
+  };
+}
+
+/**
+ * Check the suspense store and throw if the component should suspend or error.
+ *
+ * Safe to call after hooks — React's Suspense retry discards all hook state
+ * and re-renders from scratch.
+ */
+export function throwIfSuspenseNeeded<X>(
+  store: {
+    getSuspensePromise: () => Promise<void> | undefined;
+    getError: () => Error | undefined;
+    getSnapShot: () => Snapshot<X>;
+  },
+  hasDataCheck: (p: Snapshot<X>) => boolean,
+): void {
+  const error = store.getError();
+  if (error) {
+    throw error;
+  }
+
+  if (!hasDataCheck(store.getSnapShot())) {
+    const promise = store.getSuspensePromise();
+    if (promise) {
+      throw promise;
+    }
+  }
+}
+
+export function isSuspenseOption(
+  value: unknown,
+): value is { suspense: true } {
+  return typeof value === "object" && value != null
+    && "suspense" in value && value.suspense === true;
+}
+
+export function setupSuspenseStore<X>(
+  cacheKey: string,
+  createObservation: (callback: Observer<X | undefined>) => Unsubscribable,
+  peekResult: Snapshot<X>,
+  hasDataCheck: (p: Snapshot<X>) => boolean,
+): {
+  subscribe: (notifyUpdate: () => void) => () => void;
+  getSnapShot: () => Snapshot<X>;
+} {
+  const suspenseStore = getSuspenseExternalStore<X>(
+    cacheKey,
+    createObservation,
+    hasDataCheck,
+    peekResult,
+  );
+  throwIfSuspenseNeeded<X>(
+    suspenseStore,
+    hasDataCheck,
+  );
+  return suspenseStore;
+}
+
+/** @internal - exported for testing */
+export function _clearSuspenseCache(): void {
+  for (const entry of suspenseCache.values()) {
+    entry.observation?.unsubscribe();
+  }
+  suspenseCache.clear();
+  if (cleanupTimerId !== undefined) {
+    clearInterval(cleanupTimerId);
+    cleanupTimerId = undefined;
+  }
+}

--- a/packages/react/src/new/parseObjectArgs.ts
+++ b/packages/react/src/new/parseObjectArgs.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  ObjectOrInterfaceDefinition,
+  Osdk,
+  PrimaryKeyType,
+  PropertyKeys,
+} from "@osdk/api";
+
+export type ObjectHookArgs<Q extends ObjectOrInterfaceDefinition> =
+  | [Osdk.Instance<Q>, (boolean | { suspense: true } | undefined)?]
+  | [
+    Q,
+    PrimaryKeyType<Q>,
+    (
+      | boolean
+      | { $select?: readonly PropertyKeys<Q>[]; enabled?: boolean }
+      | { $select?: readonly PropertyKeys<Q>[]; suspense: true }
+      | undefined
+    )?,
+  ];
+
+export interface ParsedObjectArgs<Q extends ObjectOrInterfaceDefinition> {
+  typeOrApiName: Q["apiName"] | Q;
+  primaryKey: PrimaryKeyType<Q>;
+  mode: "offline" | undefined;
+  selectArg: readonly PropertyKeys<Q>[] | undefined;
+  apiNameString: string;
+}
+
+export function parseObjectArgs<Q extends ObjectOrInterfaceDefinition>(
+  args: ObjectHookArgs<Q>,
+): ParsedObjectArgs<Q> {
+  const isInstanceSignature = "$objectType" in args[0];
+
+  const optionsArg = !isInstanceSignature
+      && args[2] != null
+      && typeof args[2] === "object"
+    ? args[2] as { $select?: readonly PropertyKeys<Q>[] }
+    : undefined;
+
+  const selectArg = optionsArg?.$select;
+  const mode = isInstanceSignature ? "offline" as const : undefined;
+
+  const typeOrApiName: Q["apiName"] | Q = isInstanceSignature
+    ? (args[0] as Osdk.Instance<Q>).$objectType as Q["apiName"]
+    : args[0] as Q;
+
+  const primaryKey: PrimaryKeyType<Q> = isInstanceSignature
+    ? (args[0] as Osdk.Instance<Q>).$primaryKey as PrimaryKeyType<Q>
+    : args[1] as PrimaryKeyType<Q>;
+
+  const apiNameString = typeof typeOrApiName === "string"
+    ? typeOrApiName
+    : typeOrApiName.apiName;
+
+  return { typeOrApiName, primaryKey, mode, selectArg, apiNameString };
+}

--- a/packages/react/src/public/experimental.ts
+++ b/packages/react/src/public/experimental.ts
@@ -20,6 +20,7 @@
  * entry will be removed in a future major.
  */
 
+export { clearSuspenseErrors } from "../new/makeSuspenseExternalStore.js";
 /** @deprecated Import from `@osdk/react` instead. */
 export { useStableObjectSet } from "../new/core/useStableObjectSet.js";
 

--- a/packages/react/src/public/experimental.ts
+++ b/packages/react/src/public/experimental.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+export { clearSuspenseErrors } from "../new/makeSuspenseExternalStore.js";
 export { useStableObjectSet } from "../new/core/useStableObjectSet.js";
 export { OsdkProvider2 } from "../new/OsdkProvider2.js";
 export { useLinks } from "../new/useLinks.js";

--- a/packages/react/test/makeSuspenseExternalStore.test.tsx
+++ b/packages/react/test/makeSuspenseExternalStore.test.tsx
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Observer } from "@osdk/client/unstable-do-not-use";
+import { afterEach, describe, expect, it, vitest } from "vitest";
+import {
+  _clearSuspenseCache,
+  getSuspenseExternalStore,
+} from "../src/new/makeSuspenseExternalStore.js";
+
+interface MockPayload {
+  object: { id: string } | undefined;
+  status: "init" | "loading" | "loaded" | "error";
+  isOptimistic: boolean;
+  lastUpdated: number;
+}
+
+afterEach(() => {
+  _clearSuspenseCache();
+});
+
+describe("getSuspenseExternalStore", () => {
+  function createStore(key = "test-key") {
+    let capturedObserver: Observer<MockPayload | undefined> | undefined;
+    const mockUnsubscribe = vitest.fn();
+
+    const store = getSuspenseExternalStore<MockPayload>(
+      key,
+      (observer) => {
+        capturedObserver = observer;
+        return { unsubscribe: mockUnsubscribe };
+      },
+      (p) => p?.object != null,
+    );
+
+    return {
+      store,
+      get observer() {
+        if (capturedObserver === undefined) {
+          throw new Error("Observer not captured");
+        }
+        return capturedObserver;
+      },
+      mockUnsubscribe,
+    };
+  }
+
+  it("should suspend until data arrives, then resolve", async () => {
+    const { store, observer } = createStore();
+
+    expect(store.getSnapShot()).toBeUndefined();
+    const promise = store.getSuspensePromise();
+    expect(promise).toBeInstanceOf(Promise);
+    expect(store.getSuspensePromise()).toBe(promise);
+
+    const payload: MockPayload = {
+      object: { id: "1" },
+      status: "loaded",
+      isOptimistic: false,
+      lastUpdated: Date.now(),
+    };
+    observer.next(payload);
+
+    await expect(promise).resolves.toBeUndefined();
+    expect(store.getSuspensePromise()).toBeUndefined();
+    expect(store.getSnapShot()).toEqual(payload);
+  });
+
+  it("should not re-suspend when data is already loaded (stale-while-revalidate)", () => {
+    const { store, observer } = createStore();
+
+    observer.next({
+      object: { id: "1" },
+      status: "loaded",
+      isOptimistic: false,
+      lastUpdated: Date.now(),
+    });
+
+    expect(store.getSuspensePromise()).toBeUndefined();
+
+    observer.next({
+      object: { id: "1" },
+      status: "loading",
+      isOptimistic: false,
+      lastUpdated: Date.now(),
+    });
+
+    expect(store.getSuspensePromise()).toBeUndefined();
+  });
+
+  it("should skip suspension when peekResult is provided", () => {
+    const peekData: MockPayload = {
+      object: { id: "1" },
+      status: "loaded",
+      isOptimistic: false,
+      lastUpdated: 100,
+    };
+
+    let capturedObs: Observer<MockPayload | undefined> | undefined;
+    const store = getSuspenseExternalStore<MockPayload>(
+      "peek-key",
+      (observer) => {
+        capturedObs = observer;
+        return { unsubscribe: vitest.fn() };
+      },
+      (p) => p?.object != null,
+      peekData,
+    );
+
+    expect(store.getSuspensePromise()).toBeUndefined();
+    expect(store.getSnapShot()).toEqual(peekData);
+
+    const fullData: MockPayload = {
+      object: { id: "1" },
+      status: "loaded",
+      isOptimistic: false,
+      lastUpdated: 200,
+    };
+    capturedObs?.next(fullData);
+    expect(store.getSnapShot()).toEqual(fullData);
+  });
+});

--- a/packages/react/test/parseObjectArgs.test.tsx
+++ b/packages/react/test/parseObjectArgs.test.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectOrInterfaceDefinition, Osdk } from "@osdk/api";
+import { describe, expect, it } from "vitest";
+import type { ObjectHookArgs } from "../src/new/parseObjectArgs.js";
+import { parseObjectArgs } from "../src/new/parseObjectArgs.js";
+
+type MockQ = ObjectOrInterfaceDefinition;
+
+const MockObjectType = {
+  apiName: "MockObject",
+  primaryKeyType: "string",
+} as MockQ;
+
+const mockInstance = {
+  $objectType: "MockObject",
+  $primaryKey: "pk-123",
+  name: "Test",
+} as Osdk.Instance<MockQ>;
+
+describe("parseObjectArgs", () => {
+  it("should parse type + primaryKey and return the type def", () => {
+    const result = parseObjectArgs<MockQ>(
+      [MockObjectType, "pk-1"] as ObjectHookArgs<MockQ>,
+    );
+    expect(result.typeOrApiName).toBe(MockObjectType);
+    expect(result.primaryKey).toBe("pk-1");
+    expect(result.mode).toBeUndefined();
+  });
+
+  it("should parse instance and return apiName string with offline mode", () => {
+    const result = parseObjectArgs<MockQ>(
+      [mockInstance] as ObjectHookArgs<MockQ>,
+    );
+    expect(result.typeOrApiName).toBe("MockObject");
+    expect(result.primaryKey).toBe("pk-123");
+    expect(result.mode).toBe("offline");
+  });
+
+  it("should extract $select from options", () => {
+    const result = parseObjectArgs<MockQ>(
+      [MockObjectType, "pk-1", { $select: ["name", "age"] }] as ObjectHookArgs<
+        MockQ
+      >,
+    );
+    expect(result.selectArg).toEqual(["name", "age"]);
+  });
+
+  it("should return undefined selectArg when no options", () => {
+    const result = parseObjectArgs<MockQ>(
+      [MockObjectType, "pk-1"] as ObjectHookArgs<MockQ>,
+    );
+    expect(result.selectArg).toBeUndefined();
+  });
+
+  it("should derive apiNameString for both signatures", () => {
+    const typeResult = parseObjectArgs<MockQ>(
+      [MockObjectType, "pk-1"] as ObjectHookArgs<MockQ>,
+    );
+    expect(typeResult.apiNameString).toBe("MockObject");
+
+    const instanceResult = parseObjectArgs<MockQ>(
+      [mockInstance] as ObjectHookArgs<MockQ>,
+    );
+    expect(instanceResult.apiNameString).toBe("MockObject");
+  });
+});

--- a/packages/react/test/suspenseTestUtils.ts
+++ b/packages/react/test/suspenseTestUtils.ts
@@ -21,6 +21,34 @@ import { _clearSuspenseCache } from "../src/new/makeSuspenseExternalStore.js";
 import { OsdkContext2 } from "../src/new/OsdkContext2.js";
 import { OsdkErrorBoundary } from "../src/new/OsdkErrorBoundary.js";
 
+export function mockObjectPayload(name: string, pk: string) {
+  return {
+    object: { name, $objectType: "MockObject", $primaryKey: pk },
+    status: "loaded" as const,
+    isOptimistic: false,
+    lastUpdated: Date.now(),
+  };
+}
+
+export function mockListPayload(
+  items: Array<{ name: string; pk: string }>,
+  extra?: Record<string, unknown>,
+) {
+  return {
+    resolvedList: items.map(i => ({
+      name: i.name,
+      $objectType: "MockObject",
+      $primaryKey: i.pk,
+    })),
+    status: "loaded" as const,
+    isOptimistic: false,
+    lastUpdated: Date.now(),
+    hasMore: false,
+    fetchMore: vitest.fn(),
+    ...extra,
+  };
+}
+
 export function TestSuspenseWrapper(
   { children, observableClient }: {
     children: React.ReactNode;

--- a/packages/react/test/suspenseTestUtils.ts
+++ b/packages/react/test/suspenseTestUtils.ts
@@ -21,7 +21,7 @@ import {
   _clearSuspenseCache,
   clearSuspenseErrors,
 } from "../src/new/makeSuspenseExternalStore.js";
-import { OsdkContext2 } from "../src/new/OsdkContext2.js";
+import { OsdkContext } from "../src/new/OsdkContext.js";
 
 export function mockObjectPayload(name: string, pk: string) {
   return {
@@ -94,7 +94,7 @@ export function TestSuspenseWrapper(
   },
 ) {
   return React.createElement(
-    OsdkContext2.Provider,
+    OsdkContext.Provider,
     // @ts-expect-error - test mock provides only observableClient, not client
     { value: { observableClient } },
     React.createElement(

--- a/packages/react/test/suspenseTestUtils.ts
+++ b/packages/react/test/suspenseTestUtils.ts
@@ -17,9 +17,11 @@
 import { cleanup } from "@testing-library/react";
 import * as React from "react";
 import { vitest } from "vitest";
-import { _clearSuspenseCache } from "../src/new/makeSuspenseExternalStore.js";
+import {
+  _clearSuspenseCache,
+  clearSuspenseErrors,
+} from "../src/new/makeSuspenseExternalStore.js";
 import { OsdkContext2 } from "../src/new/OsdkContext2.js";
-import { OsdkErrorBoundary } from "../src/new/OsdkErrorBoundary.js";
 
 export function mockObjectPayload(name: string, pk: string) {
   return {
@@ -49,6 +51,42 @@ export function mockListPayload(
   };
 }
 
+interface TestErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback: (error: Error, retry: () => void) => React.ReactNode;
+}
+
+interface TestErrorBoundaryState {
+  error: Error | undefined;
+}
+
+class TestErrorBoundary
+  extends React.Component<TestErrorBoundaryProps, TestErrorBoundaryState>
+{
+  constructor(props: TestErrorBoundaryProps) {
+    super(props);
+    this.state = { error: undefined };
+  }
+
+  static getDerivedStateFromError(error: unknown): TestErrorBoundaryState {
+    return {
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
+
+  private retry = (): void => {
+    clearSuspenseErrors();
+    this.setState({ error: undefined });
+  };
+
+  render(): React.ReactNode {
+    if (this.state.error) {
+      return this.props.fallback(this.state.error, this.retry);
+    }
+    return this.props.children;
+  }
+}
+
 export function TestSuspenseWrapper(
   { children, observableClient }: {
     children: React.ReactNode;
@@ -60,7 +98,7 @@ export function TestSuspenseWrapper(
     // @ts-expect-error - test mock provides only observableClient, not client
     { value: { observableClient } },
     React.createElement(
-      OsdkErrorBoundary,
+      TestErrorBoundary,
       {
         fallback: (error: Error, _retry: () => void) =>
           React.createElement(

--- a/packages/react/test/suspenseTestUtils.ts
+++ b/packages/react/test/suspenseTestUtils.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup } from "@testing-library/react";
+import * as React from "react";
+import { vitest } from "vitest";
+import { _clearSuspenseCache } from "../src/new/makeSuspenseExternalStore.js";
+import { OsdkContext2 } from "../src/new/OsdkContext2.js";
+import { OsdkErrorBoundary } from "../src/new/OsdkErrorBoundary.js";
+
+export function TestSuspenseWrapper(
+  { children, observableClient }: {
+    children: React.ReactNode;
+    observableClient: Record<string, unknown>;
+  },
+) {
+  return React.createElement(
+    OsdkContext2.Provider,
+    // @ts-expect-error - test mock provides only observableClient, not client
+    { value: { observableClient } },
+    React.createElement(
+      OsdkErrorBoundary,
+      {
+        fallback: (error: Error, _retry: () => void) =>
+          React.createElement(
+            "div",
+            null,
+            React.createElement(
+              "span",
+              { "data-testid": "error" },
+              error.message,
+            ),
+          ),
+      },
+      React.createElement(
+        React.Suspense,
+        {
+          fallback: React.createElement(
+            "div",
+            { "data-testid": "loading" },
+            "Loading...",
+          ),
+        },
+        children,
+      ),
+    ),
+  );
+}
+
+export function createMockObservableClient(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    observeObject: vitest.fn(() => ({ unsubscribe: vitest.fn() })),
+    observeList: vitest.fn(() => ({ unsubscribe: vitest.fn() })),
+    peekObjectData: vitest.fn(() => undefined),
+    canonicalizeWhereClause: vitest.fn((w: unknown) => w),
+    ...overrides,
+  };
+}
+
+export function cleanupSuspenseTests(): void {
+  cleanup();
+  _clearSuspenseCache();
+}


### PR DESCRIPTION
suspense-aware external store and supporting utilities for react hooks

• add makeSuspenseExternalStore with cache lifecycle, orphan cleanup, and stale-while-revalidate
• add OsdkErrorBoundary component with retry support and default error UI
• extract parseObjectArgs utility and extractPayloadError for shared use across hooks