### PR TITLE
add suspense support for useOsdkObject and useOsdkObjects

### DIFF
--- a/.changeset/add-react-suspense-hooks.md
+++ b/.changeset/add-react-suspense-hooks.md
@@ -1,5 +1,4 @@
 ---
-"@osdk/client": patch
 "@osdk/react": patch
 ---
 

--- a/.changeset/add-react-suspense-hooks.md
+++ b/.changeset/add-react-suspense-hooks.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client": patch
+"@osdk/react": patch
+---
+
+add suspense support to useOsdkObject and useOsdkObjects via { suspense: true } option

--- a/packages/react/src/new/useOsdkObject.ts
+++ b/packages/react/src/new/useOsdkObject.ts
@@ -306,7 +306,7 @@ export function useOsdkObject<
 
   const suspenseStore = React.useMemo(
     () =>
-      cacheKey === null
+      cacheKey == null
         ? undefined
         : getSuspenseExternalStore<ObserveObjectCallbackArgs<Q>>(
           cacheKey,

--- a/packages/react/src/new/useOsdkObject.ts
+++ b/packages/react/src/new/useOsdkObject.ts
@@ -27,6 +27,7 @@ import type {
   Unsubscribable,
 } from "@osdk/client/unstable-do-not-use";
 import React from "react";
+import type { Snapshot } from "./makeExternalStore.js";
 import {
   devToolsMetadata,
   extractPayloadError,
@@ -286,7 +287,7 @@ export function useOsdkObject<
     : null;
 
   const hasObjectData = (
-    p: ObserveObjectCallbackArgs<Q> | undefined,
+    p: Snapshot<ObserveObjectCallbackArgs<Q>>,
   ): boolean => p?.object != null;
 
   const suspenseStore = React.useMemo(() => {

--- a/packages/react/src/new/useOsdkObject.ts
+++ b/packages/react/src/new/useOsdkObject.ts
@@ -20,10 +20,63 @@ import type {
   PrimaryKeyType,
   PropertyKeys,
 } from "@osdk/api";
-import type { ObserveObjectCallbackArgs } from "@osdk/client/observable";
+import type {
+  ObservableClient,
+  ObserveObjectCallbackArgs,
+  Observer,
+  Unsubscribable,
+} from "@osdk/client/observable";
 import React from "react";
-import { devToolsMetadata, makeExternalStore } from "./makeExternalStore.js";
+import { extractPayloadError } from "./hookUtils.js";
+import {
+  devToolsMetadata,
+  makeExternalStore,
+  type Snapshot,
+} from "./makeExternalStore.js";
+import {
+  getClientId,
+  getSuspenseExternalStore,
+  isSuspenseOption,
+  throwIfSuspenseNeeded,
+} from "./makeSuspenseExternalStore.js";
 import { OsdkContext } from "./OsdkContext.js";
+import { parseObjectArgs } from "./parseObjectArgs.js";
+
+/** @internal */
+export function _createObjectObservation<
+  Q extends ObjectOrInterfaceDefinition,
+>(
+  observableClient: ObservableClient,
+  typeOrApiName: Q["apiName"] | Q,
+  primaryKey: PrimaryKeyType<Q>,
+  options: {
+    mode?: "offline" | "force";
+    select?: readonly PropertyKeys<Q>[];
+    $loadPropertySecurityMetadata?: boolean;
+    $includeAllBaseObjectProperties?: boolean;
+  },
+): (
+  observer: Observer<ObserveObjectCallbackArgs<Q> | undefined>,
+) => Unsubscribable {
+  return (observer) =>
+    observableClient.observeObject<Q>(
+      typeOrApiName,
+      primaryKey,
+      {
+        mode: options.mode,
+        $includeAllBaseObjectProperties:
+          options.$includeAllBaseObjectProperties,
+        ...(options.select ? { select: options.select } : {}),
+        ...(options.$loadPropertySecurityMetadata
+          ? {
+            $loadPropertySecurityMetadata:
+              options.$loadPropertySecurityMetadata,
+          }
+          : {}),
+      },
+      observer,
+    );
+}
 
 export interface UseOsdkObjectResult<
   Q extends ObjectOrInterfaceDefinition,
@@ -54,6 +107,39 @@ export interface UseOsdkObjectOptions<
   $includeAllBaseObjectProperties?: boolean;
 }
 
+export interface UseOsdkObjectSuspenseResult<
+  Q extends ObjectOrInterfaceDefinition,
+> {
+  object: Osdk.Instance<Q, "$allBaseProperties">;
+  isOptimistic: boolean;
+}
+
+/**
+ * Loads an object or interface instance with Suspense support.
+ *
+ * @param obj an existing `Osdk.Instance` object to get metadata for.
+ * @param options Options with `suspense: true` to enable Suspense mode
+ */
+export function useOsdkObject<
+  Q extends ObjectOrInterfaceDefinition,
+>(
+  obj: Osdk.Instance<Q>,
+  options: { suspense: true },
+): UseOsdkObjectSuspenseResult<Q>;
+/**
+ * Loads an object or interface instance by type and primary key with Suspense support.
+ *
+ * @param type The object type or interface definition
+ * @param primaryKey The primary key of the object
+ * @param options Options including $select and `suspense: true`
+ */
+export function useOsdkObject<
+  Q extends ObjectOrInterfaceDefinition,
+>(
+  type: Q,
+  primaryKey: PrimaryKeyType<Q>,
+  options: { $select?: readonly PropertyKeys<Q>[]; suspense: true },
+): UseOsdkObjectSuspenseResult<Q>;
 /**
  * @param obj an existing `Osdk.Instance` object to get metadata for.
  * @param enabled Enable or disable the query (defaults to true)
@@ -101,100 +187,70 @@ export function useOsdkObject<
 >(
   ...args:
     | [obj: Osdk.Instance<Q>, enabled?: boolean]
+    | [obj: Osdk.Instance<Q>, options: { suspense: true }]
     | [type: Q, primaryKey: PrimaryKeyType<Q>, enabled?: boolean]
     | [
       type: Q,
       primaryKey: PrimaryKeyType<Q>,
       options?: UseOsdkObjectOptions<Q>,
     ]
-): UseOsdkObjectResult<Q> {
+    | [
+      type: Q,
+      primaryKey: PrimaryKeyType<Q>,
+      options: { $select?: readonly PropertyKeys<Q>[]; suspense: true },
+    ]
+): UseOsdkObjectResult<Q> | UseOsdkObjectSuspenseResult<Q> {
   const { observableClient } = React.useContext(OsdkContext);
 
-  // Check if first arg is an instance to discriminate signatures
-  // TypeScript cannot narrow rest parameter unions with optional parameters,
-  // so we must use type assertions after runtime discrimination
+  const { typeOrApiName, primaryKey, mode, selectArg, apiNameString } =
+    parseObjectArgs<Q>(args);
+
   const isInstanceSignature = "$objectType" in args[0];
 
-  // Extract options object if provided (3rd arg is an object with $select or enabled)
+  const isSuspense = isInstanceSignature
+    ? isSuspenseOption(args[1])
+    : isSuspenseOption(args[2]);
+
   const optionsArg = !isInstanceSignature
       && args[2] != null
       && typeof args[2] === "object"
-    ? args[2]
+    ? args[2] as UseOsdkObjectOptions<Q>
     : undefined;
 
-  // Extract enabled flag - 2nd param for instance signature, 3rd for type signature
-  const enabled = isInstanceSignature
+  const enabled = isSuspense
+    ? true
+    : isInstanceSignature
     ? (typeof args[1] === "boolean" ? args[1] : true)
     : optionsArg
     ? (optionsArg.enabled ?? true)
     : (typeof args[2] === "boolean" ? args[2] : true);
 
-  const selectArg = optionsArg?.$select;
   const loadPropertySecurityMetadata = optionsArg
     ?.$loadPropertySecurityMetadata;
   const includeAllBaseObjectProperties = optionsArg
     ?.$includeAllBaseObjectProperties;
-
-  const mode = isInstanceSignature ? "offline" : undefined;
-
-  const typeOrApiName = isInstanceSignature
-    ? (args[0] as Osdk.Instance<Q>).$objectType
-    : (args[0] as Q);
-
-  const primaryKey = isInstanceSignature
-    ? (args[0] as Osdk.Instance<Q>).$primaryKey
-    : (args[1] as PrimaryKeyType<Q>);
-
-  const apiNameString = typeof typeOrApiName === "string"
-    ? typeOrApiName
-    : typeOrApiName.apiName;
 
   const stableSelect = React.useMemo(
     () => selectArg,
     [JSON.stringify(selectArg)],
   );
 
-  const { subscribe, getSnapShot } = React.useMemo(
-    () => {
-      if (!enabled) {
-        return makeExternalStore<ObserveObjectCallbackArgs<Q>>(
-          () => ({ unsubscribe: () => {} }),
-          devToolsMetadata({
-            hookType: "useOsdkObject",
-            objectType: apiNameString,
-            primaryKey: String(primaryKey),
-          }),
-        );
-      }
-      return makeExternalStore<ObserveObjectCallbackArgs<Q>>(
-        (observer) =>
-          observableClient.observeObject<Q>(
-            typeOrApiName,
-            primaryKey,
-            {
-              mode,
-              $includeAllBaseObjectProperties: includeAllBaseObjectProperties,
-              ...(stableSelect ? { select: stableSelect } : {}),
-              ...(loadPropertySecurityMetadata
-                ? {
-                  $loadPropertySecurityMetadata: loadPropertySecurityMetadata,
-                }
-                : {}),
-            },
-            observer,
-          ),
-        devToolsMetadata({
-          hookType: "useOsdkObject",
-          objectType: apiNameString,
-          primaryKey: String(primaryKey),
-        }),
-      );
-    },
+  const observationFactory = React.useMemo(
+    () =>
+      _createObjectObservation<Q>(
+        observableClient,
+        typeOrApiName,
+        primaryKey,
+        {
+          mode,
+          select: stableSelect,
+          $loadPropertySecurityMetadata: loadPropertySecurityMetadata,
+          $includeAllBaseObjectProperties: includeAllBaseObjectProperties,
+        },
+      ),
     [
-      enabled,
       observableClient,
       typeOrApiName,
-      apiNameString,
       primaryKey,
       mode,
       stableSelect,
@@ -203,6 +259,78 @@ export function useOsdkObject<
     ],
   );
 
+  const baseStore = React.useMemo(
+    () => {
+      const metadata = devToolsMetadata({
+        hookType: "useOsdkObject",
+        objectType: apiNameString,
+        primaryKey: String(primaryKey),
+      });
+      if (isSuspense || !enabled) {
+        return makeExternalStore<ObserveObjectCallbackArgs<Q>>(
+          () => ({ unsubscribe: () => {} }),
+          metadata,
+        );
+      }
+      return makeExternalStore<ObserveObjectCallbackArgs<Q>>(
+        observationFactory,
+        metadata,
+      );
+    },
+    [
+      isSuspense,
+      enabled,
+      observationFactory,
+      apiNameString,
+      primaryKey,
+    ],
+  );
+
+  const cacheKey = isSuspense
+    ? JSON.stringify([
+      getClientId(observableClient),
+      "obj",
+      apiNameString,
+      primaryKey,
+      mode ?? null,
+      stableSelect ?? null,
+      loadPropertySecurityMetadata ?? null,
+      includeAllBaseObjectProperties ?? null,
+    ])
+    : null;
+
+  const hasObjectData = React.useCallback(
+    (p: Snapshot<ObserveObjectCallbackArgs<Q>>) => p?.object != null,
+    [],
+  );
+
+  const suspenseStore = React.useMemo(
+    () =>
+      cacheKey === null
+        ? undefined
+        : getSuspenseExternalStore<ObserveObjectCallbackArgs<Q>>(
+          cacheKey,
+          observationFactory,
+          hasObjectData,
+          observableClient.peekObjectData<Q>(typeOrApiName, primaryKey),
+        ),
+    [
+      cacheKey,
+      observationFactory,
+      hasObjectData,
+      observableClient,
+      typeOrApiName,
+      primaryKey,
+    ],
+  );
+
+  if (suspenseStore !== undefined) {
+    throwIfSuspenseNeeded(suspenseStore, hasObjectData);
+  }
+
+  const subscribe = suspenseStore?.subscribe ?? baseStore.subscribe;
+  const getSnapShot = suspenseStore?.getSnapShot ?? baseStore.getSnapShot;
+
   const payload = React.useSyncExternalStore(subscribe, getSnapShot);
 
   const forceUpdate = React.useCallback(() => {
@@ -210,13 +338,20 @@ export function useOsdkObject<
   }, []);
 
   return React.useMemo(() => {
-    let error: Error | undefined;
-    if (payload && "error" in payload && payload.error) {
-      error = payload.error;
-    } else if (payload?.status === "error") {
-      error = new Error("Failed to load object");
+    if (isSuspense) {
+      const obj = payload?.object;
+      if (obj == null) {
+        throw new Error(
+          "useOsdkObject: object is undefined after Suspense resolved",
+        );
+      }
+      return {
+        object: obj as Osdk.Instance<Q, "$allBaseProperties">,
+        isOptimistic: !!payload?.isOptimistic,
+      };
     }
 
+    const error = extractPayloadError(payload, "Failed to load object");
     return {
       object: payload?.object,
       // Errors take precedence over loading state.
@@ -228,5 +363,5 @@ export function useOsdkObject<
       error,
       forceUpdate,
     };
-  }, [payload, enabled, forceUpdate]);
+  }, [payload, enabled, forceUpdate, isSuspense]);
 }

--- a/packages/react/src/new/useOsdkObject.ts
+++ b/packages/react/src/new/useOsdkObject.ts
@@ -34,8 +34,9 @@ import {
 } from "./makeExternalStore.js";
 import {
   getClientId,
+  getSuspenseExternalStore,
   isSuspenseOption,
-  setupSuspenseStore,
+  throwIfSuspenseNeeded,
 } from "./makeSuspenseExternalStore.js";
 import { OsdkContext2 } from "./OsdkContext2.js";
 import { parseObjectArgs } from "./parseObjectArgs.js";
@@ -272,9 +273,8 @@ export function useOsdkObject<
     ],
   );
 
-  let { subscribe, getSnapShot } = baseStore;
-  if (isSuspense) {
-    const cacheKey = JSON.stringify([
+  const cacheKey = isSuspense
+    ? JSON.stringify([
       getClientId(observableClient),
       "obj",
       apiNameString,
@@ -282,15 +282,29 @@ export function useOsdkObject<
       mode ?? null,
       stableSelect ?? null,
       loadPropertySecurityMetadata ?? null,
-    ]);
-    ({ subscribe, getSnapShot } = setupSuspenseStore<
-      ObserveObjectCallbackArgs<Q>
-    >(
+    ])
+    : null;
+
+  const hasObjectData = (
+    p: ObserveObjectCallbackArgs<Q> | undefined,
+  ): boolean => p?.object != null;
+
+  const suspenseStore = React.useMemo(() => {
+    if (cacheKey === null) {
+      return undefined;
+    }
+    return getSuspenseExternalStore<ObserveObjectCallbackArgs<Q>>(
       cacheKey,
       observationFactory,
+      hasObjectData,
       observableClient.peekObjectData<Q>(typeOrApiName, primaryKey),
-      (p) => p?.object != null,
-    ));
+    );
+  }, [cacheKey]);
+
+  let { subscribe, getSnapShot } = baseStore;
+  if (suspenseStore) {
+    throwIfSuspenseNeeded(suspenseStore, hasObjectData);
+    ({ subscribe, getSnapShot } = suspenseStore);
   }
 
   const payload = React.useSyncExternalStore(subscribe, getSnapShot);

--- a/packages/react/src/new/useOsdkObject.ts
+++ b/packages/react/src/new/useOsdkObject.ts
@@ -274,10 +274,15 @@ export function useOsdkObject<
 
   let { subscribe, getSnapShot } = baseStore;
   if (isSuspense) {
-    const selectKey = stableSelect ? JSON.stringify(stableSelect) : "";
-    const cacheKey = `${
-      getClientId(observableClient)
-    }:obj:${apiNameString}:${primaryKey}:${mode ?? ""}:${selectKey}`;
+    const cacheKey = JSON.stringify([
+      getClientId(observableClient),
+      "obj",
+      apiNameString,
+      primaryKey,
+      mode ?? null,
+      stableSelect ?? null,
+      loadPropertySecurityMetadata ?? null,
+    ]);
     ({ subscribe, getSnapShot } = setupSuspenseStore<
       ObserveObjectCallbackArgs<Q>
     >(

--- a/packages/react/src/new/useOsdkObject.ts
+++ b/packages/react/src/new/useOsdkObject.ts
@@ -20,10 +20,58 @@ import type {
   PrimaryKeyType,
   PropertyKeys,
 } from "@osdk/api";
-import type { ObserveObjectCallbackArgs } from "@osdk/client/unstable-do-not-use";
+import type {
+  ObservableClient,
+  ObserveObjectCallbackArgs,
+  Observer,
+  Unsubscribable,
+} from "@osdk/client/unstable-do-not-use";
 import React from "react";
-import { devToolsMetadata, makeExternalStore } from "./makeExternalStore.js";
+import {
+  devToolsMetadata,
+  extractPayloadError,
+  makeExternalStore,
+} from "./makeExternalStore.js";
+import {
+  getClientId,
+  isSuspenseOption,
+  setupSuspenseStore,
+} from "./makeSuspenseExternalStore.js";
 import { OsdkContext2 } from "./OsdkContext2.js";
+import { parseObjectArgs } from "./parseObjectArgs.js";
+
+/** @internal */
+export function _createObjectObservation<
+  Q extends ObjectOrInterfaceDefinition,
+>(
+  observableClient: ObservableClient,
+  typeOrApiName: Q["apiName"] | Q,
+  primaryKey: PrimaryKeyType<Q>,
+  options: {
+    mode?: "offline" | "force";
+    select?: readonly PropertyKeys<Q>[];
+    $loadPropertySecurityMetadata?: boolean;
+  },
+): (
+  observer: Observer<ObserveObjectCallbackArgs<Q> | undefined>,
+) => Unsubscribable {
+  return (observer) =>
+    observableClient.observeObject(
+      typeOrApiName,
+      primaryKey,
+      {
+        mode: options.mode,
+        ...(options.select ? { select: options.select } : {}),
+        ...(options.$loadPropertySecurityMetadata
+          ? {
+            $loadPropertySecurityMetadata:
+              options.$loadPropertySecurityMetadata,
+          }
+          : {}),
+      },
+      observer,
+    );
+}
 
 export interface UseOsdkObjectResult<
   Q extends ObjectOrInterfaceDefinition,
@@ -40,6 +88,39 @@ export interface UseOsdkObjectResult<
   forceUpdate: () => void;
 }
 
+export interface UseOsdkObjectSuspenseResult<
+  Q extends ObjectOrInterfaceDefinition,
+> {
+  object: Osdk.Instance<Q>;
+  isOptimistic: boolean;
+}
+
+/**
+ * Loads an object or interface instance with Suspense support.
+ *
+ * @param obj an existing `Osdk.Instance` object to get metadata for.
+ * @param options Options with `suspense: true` to enable Suspense mode
+ */
+export function useOsdkObject<
+  Q extends ObjectOrInterfaceDefinition,
+>(
+  obj: Osdk.Instance<Q>,
+  options: { suspense: true },
+): UseOsdkObjectSuspenseResult<Q>;
+/**
+ * Loads an object or interface instance by type and primary key with Suspense support.
+ *
+ * @param type The object type or interface definition
+ * @param primaryKey The primary key of the object
+ * @param options Options including $select and `suspense: true`
+ */
+export function useOsdkObject<
+  Q extends ObjectOrInterfaceDefinition,
+>(
+  type: Q,
+  primaryKey: PrimaryKeyType<Q>,
+  options: { $select?: readonly PropertyKeys<Q>[]; suspense: true },
+): UseOsdkObjectSuspenseResult<Q>;
 /**
  * @param obj an existing `Osdk.Instance` object to get metadata for.
  * @param enabled Enable or disable the query (defaults to true)
@@ -90,6 +171,7 @@ export function useOsdkObject<
 >(
   ...args:
     | [obj: Osdk.Instance<Q>, enabled?: boolean]
+    | [obj: Osdk.Instance<Q>, options: { suspense: true }]
     | [type: Q, primaryKey: PrimaryKeyType<Q>, enabled?: boolean]
     | [
       type: Q,
@@ -100,101 +182,111 @@ export function useOsdkObject<
         $loadPropertySecurityMetadata?: boolean;
       },
     ]
-): UseOsdkObjectResult<Q> {
+    | [
+      type: Q,
+      primaryKey: PrimaryKeyType<Q>,
+      options: { $select?: readonly PropertyKeys<Q>[]; suspense: true },
+    ]
+): UseOsdkObjectResult<Q> | UseOsdkObjectSuspenseResult<Q> {
   const { observableClient } = React.useContext(OsdkContext2);
 
-  // Check if first arg is an instance to discriminate signatures
-  // TypeScript cannot narrow rest parameter unions with optional parameters,
-  // so we must use type assertions after runtime discrimination
+  const { typeOrApiName, primaryKey, mode, selectArg, apiNameString } =
+    parseObjectArgs<Q>(args);
+
   const isInstanceSignature = "$objectType" in args[0];
 
-  // Extract options object if provided (3rd arg is an object with $select or enabled)
+  const isSuspense = isInstanceSignature
+    ? isSuspenseOption(args[1])
+    : isSuspenseOption(args[2]);
+
   const optionsArg = !isInstanceSignature
       && args[2] != null
       && typeof args[2] === "object"
     ? args[2] as {
-      $select?: readonly string[];
       enabled?: boolean;
       $loadPropertySecurityMetadata?: boolean;
     }
     : undefined;
-
-  // Extract enabled flag - 2nd param for instance signature, 3rd for type signature
-  const enabled = isInstanceSignature
+  const enabled = isSuspense
+    ? true
+    : isInstanceSignature
     ? (typeof args[1] === "boolean" ? args[1] : true)
     : optionsArg
     ? (optionsArg.enabled ?? true)
     : (typeof args[2] === "boolean" ? args[2] : true);
 
-  const selectArg = optionsArg?.$select;
   const loadPropertySecurityMetadata = optionsArg
     ?.$loadPropertySecurityMetadata;
-
-  const mode = isInstanceSignature ? "offline" : undefined;
-
-  const typeOrApiName = isInstanceSignature
-    ? (args[0] as Osdk.Instance<Q>).$objectType
-    : (args[0] as Q);
-
-  const primaryKey = isInstanceSignature
-    ? (args[0] as Osdk.Instance<Q>).$primaryKey
-    : (args[1] as PrimaryKeyType<Q>);
-
-  const apiNameString = typeof typeOrApiName === "string"
-    ? typeOrApiName
-    : typeOrApiName.apiName;
 
   const stableSelect = React.useMemo(
     () => selectArg,
     [JSON.stringify(selectArg)],
   );
 
-  const { subscribe, getSnapShot } = React.useMemo(
-    () => {
-      if (!enabled) {
-        return makeExternalStore<ObserveObjectCallbackArgs<Q>>(
-          () => ({ unsubscribe: () => {} }),
-          devToolsMetadata({
-            hookType: "useOsdkObject",
-            objectType: apiNameString,
-            primaryKey: String(primaryKey),
-          }),
-        );
-      }
-      return makeExternalStore<ObserveObjectCallbackArgs<Q>>(
-        (observer) =>
-          observableClient.observeObject(
-            typeOrApiName,
-            primaryKey,
-            {
-              mode,
-              ...(stableSelect ? { select: stableSelect } : {}),
-              ...(loadPropertySecurityMetadata
-                ? {
-                  $loadPropertySecurityMetadata: loadPropertySecurityMetadata,
-                }
-                : {}),
-            },
-            observer,
-          ),
-        devToolsMetadata({
-          hookType: "useOsdkObject",
-          objectType: apiNameString,
-          primaryKey: String(primaryKey),
-        }),
-      );
-    },
+  const observationFactory = React.useMemo(
+    () =>
+      _createObjectObservation<Q>(
+        observableClient,
+        typeOrApiName,
+        primaryKey,
+        {
+          mode,
+          select: stableSelect,
+          $loadPropertySecurityMetadata: loadPropertySecurityMetadata,
+        },
+      ),
     [
-      enabled,
       observableClient,
       typeOrApiName,
-      apiNameString,
       primaryKey,
       mode,
       stableSelect,
       loadPropertySecurityMetadata,
     ],
   );
+
+  const baseStore = React.useMemo(
+    () => {
+      const metadata = devToolsMetadata({
+        hookType: "useOsdkObject",
+        objectType: apiNameString,
+        primaryKey: String(primaryKey),
+      });
+      if (isSuspense || !enabled) {
+        return makeExternalStore<ObserveObjectCallbackArgs<Q>>(
+          () => ({ unsubscribe: () => {} }),
+          metadata,
+        );
+      }
+      return makeExternalStore<ObserveObjectCallbackArgs<Q>>(
+        observationFactory,
+        metadata,
+      );
+    },
+    [
+      isSuspense,
+      enabled,
+      observationFactory,
+      apiNameString,
+      primaryKey,
+    ],
+  );
+
+  let { subscribe, getSnapShot } = baseStore;
+  if (isSuspense) {
+    const selectKey = stableSelect ? JSON.stringify(stableSelect) : "";
+    const cacheKey = `${
+      getClientId(observableClient)
+    }:obj:${apiNameString}:${primaryKey}:${mode ?? ""}:${selectKey}`;
+    ({ subscribe, getSnapShot } = setupSuspenseStore<
+      ObserveObjectCallbackArgs<Q>
+    >(
+      cacheKey,
+      observationFactory,
+      observableClient.peekObjectData<Q>(typeOrApiName, primaryKey),
+      (p) => p?.object != null,
+    ));
+  }
 
   const payload = React.useSyncExternalStore(subscribe, getSnapShot);
 
@@ -203,11 +295,17 @@ export function useOsdkObject<
   }, []);
 
   return React.useMemo(() => {
-    let error: Error | undefined;
-    if (payload && "error" in payload && payload.error) {
-      error = payload.error;
-    } else if (payload?.status === "error") {
-      error = new Error("Failed to load object");
+    if (isSuspense) {
+      const obj = payload?.object;
+      if (obj == null) {
+        throw new Error(
+          "useOsdkObject: object is undefined after Suspense resolved",
+        );
+      }
+      return {
+        object: obj as Osdk.Instance<Q>,
+        isOptimistic: !!payload?.isOptimistic,
+      };
     }
 
     return {
@@ -217,8 +315,8 @@ export function useOsdkObject<
           || !payload)
         : false,
       isOptimistic: !!payload?.isOptimistic,
-      error,
+      error: extractPayloadError(payload, "Failed to load object"),
       forceUpdate,
     };
-  }, [payload, enabled, forceUpdate]);
+  }, [payload, enabled, forceUpdate, isSuspense]);
 }

--- a/packages/react/src/new/useOsdkObjects.ts
+++ b/packages/react/src/new/useOsdkObjects.ts
@@ -33,6 +33,7 @@ import type {
 } from "@osdk/client/unstable-do-not-use";
 import React from "react";
 import { extractPayloadError, isPayloadLoading } from "./hookUtils.js";
+import type { Snapshot } from "./makeExternalStore.js";
 import { devToolsMetadata, makeExternalStore } from "./makeExternalStore.js";
 import {
   getClientId,
@@ -522,7 +523,7 @@ export function useOsdkObjects<
     : null;
 
   const hasListData = (
-    p: ObserveObjectsCallbackArgs<Q, RDPs> | undefined,
+    p: Snapshot<ObserveObjectsCallbackArgs<Q, RDPs>>,
   ): boolean => p?.resolvedList != null;
 
   const suspenseStore = React.useMemo(() => {

--- a/packages/react/src/new/useOsdkObjects.ts
+++ b/packages/react/src/new/useOsdkObjects.ts
@@ -25,11 +25,75 @@ import type {
   SimplePropertyDef,
   WhereClause,
 } from "@osdk/api";
-import type { ObserveObjectsCallbackArgs } from "@osdk/client/unstable-do-not-use";
+import type {
+  ObservableClient,
+  ObserveObjectsCallbackArgs,
+  Observer,
+  Unsubscribable,
+} from "@osdk/client/unstable-do-not-use";
 import React from "react";
 import { extractPayloadError, isPayloadLoading } from "./hookUtils.js";
 import { devToolsMetadata, makeExternalStore } from "./makeExternalStore.js";
+import {
+  getClientId,
+  isSuspenseOption,
+  setupSuspenseStore,
+} from "./makeSuspenseExternalStore.js";
 import { OsdkContext2 } from "./OsdkContext2.js";
+
+/** @internal */
+export interface _CreateListObservationOptions<
+  Q extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef> = {},
+> {
+  type: Pick<Q, "apiName" | "type">;
+  rids?: readonly string[];
+  where?: WhereClause<Q, RDPs>;
+  dedupeInterval: number;
+  pageSize?: number;
+  orderBy?: { [K in PropertyKeys<Q>]?: "asc" | "desc" };
+  streamUpdates?: boolean;
+  withProperties?: DerivedProperty.Clause<Q>;
+  autoFetchMore?: boolean | number;
+  intersectWith?: Array<{ where: WhereClause<Q, RDPs> }>;
+  pivotTo?: LinkNames<Q>;
+  select?: readonly PropertyKeys<Q>[];
+  $loadPropertySecurityMetadata?: boolean;
+}
+
+/** @internal */
+export function _createListObservation<
+  Q extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef> = {},
+>(
+  observableClient: ObservableClient,
+  options: _CreateListObservationOptions<Q, RDPs>,
+): (
+  observer: Observer<ObserveObjectsCallbackArgs<Q, RDPs> | undefined>,
+) => Unsubscribable {
+  return (observer) =>
+    observableClient.observeList({
+      type: options.type,
+      rids: options.rids,
+      where: options.where,
+      dedupeInterval: options.dedupeInterval,
+      pageSize: options.pageSize,
+      orderBy: options.orderBy,
+      streamUpdates: options.streamUpdates,
+      withProperties: options.withProperties,
+      autoFetchMore: options.autoFetchMore,
+      ...(options.intersectWith
+        ? { intersectWith: options.intersectWith }
+        : {}),
+      ...(options.pivotTo ? { pivotTo: options.pivotTo } : {}),
+      ...(options.select ? { select: options.select } : {}),
+      ...(options.$loadPropertySecurityMetadata
+        ? {
+          $loadPropertySecurityMetadata: options.$loadPropertySecurityMetadata,
+        }
+        : {}),
+    }, observer);
+}
 
 export interface UseOsdkObjectsOptions<
   T extends ObjectOrInterfaceDefinition,
@@ -205,6 +269,64 @@ export interface UseOsdkListResult<
   refetch: () => Promise<void>;
 }
 
+export interface UseOsdkListSuspenseResult<
+  T extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef> = {},
+  EXTRA_OPTIONS extends never | "$rid" = never,
+> {
+  data: Osdk.Instance<
+    T,
+    "$allBaseProperties" | EXTRA_OPTIONS,
+    PropertyKeys<T>,
+    RDPs
+  >[];
+  fetchMore: (() => Promise<void>) | undefined;
+  isOptimistic: boolean;
+  totalCount?: string;
+}
+
+// Suspense pivotTo overloads
+export function useOsdkObjects<
+  Q extends ObjectOrInterfaceDefinition,
+  L extends LinkNames<Q>,
+>(
+  type: Q,
+  options:
+    & Omit<UseOsdkObjectsOptions<Q>, "enabled">
+    & { suspense: true; pivotTo: L; rids: readonly string[] },
+): UseOsdkListSuspenseResult<LinkedType<Q, L>, {}, "$rid">;
+
+export function useOsdkObjects<
+  Q extends ObjectOrInterfaceDefinition,
+  L extends LinkNames<Q>,
+>(
+  type: Q,
+  options:
+    & Omit<UseOsdkObjectsOptions<Q>, "enabled">
+    & { suspense: true; pivotTo: L },
+): UseOsdkListSuspenseResult<LinkedType<Q, L>>;
+
+// Suspense non-pivotTo overloads
+export function useOsdkObjects<
+  Q extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef> = {},
+>(
+  type: Q,
+  options:
+    & Omit<UseOsdkObjectsOptions<Q, RDPs>, "enabled">
+    & { suspense: true; rids: readonly string[] },
+): UseOsdkListSuspenseResult<Q, RDPs, "$rid">;
+
+export function useOsdkObjects<
+  Q extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef> = {},
+>(
+  type: Q,
+  options:
+    & Omit<UseOsdkObjectsOptions<Q, RDPs>, "enabled">
+    & { suspense: true },
+): UseOsdkListSuspenseResult<Q, RDPs>;
+
 // pivotTo overloads: streamUpdates is forbidden (the server does not support
 // websocket subscriptions for link-traversal queries).
 export function useOsdkObjects<
@@ -253,20 +375,27 @@ export function useOsdkObjects<
   RDPs extends Record<string, SimplePropertyDef> = {},
 >(
   type: Q,
-  options?: UseOsdkObjectsOptions<Q, RDPs>,
+  options?:
+    | UseOsdkObjectsOptions<Q, RDPs>
+    | (Omit<UseOsdkObjectsOptions<Q, RDPs>, "enabled"> & { suspense: true }),
 ):
   | UseOsdkListResult<Q, RDPs>
   | UseOsdkListResult<Q, RDPs, "$rid">
   | UseOsdkListResult<LinkedType<Q, LinkNames<Q>>>
   | UseOsdkListResult<LinkedType<Q, LinkNames<Q>>, {}, "$rid">
+  | UseOsdkListSuspenseResult<Q, RDPs>
+  | UseOsdkListSuspenseResult<Q, RDPs, "$rid">
+  | UseOsdkListSuspenseResult<LinkedType<Q, LinkNames<Q>>>
+  | UseOsdkListSuspenseResult<LinkedType<Q, LinkNames<Q>>, {}, "$rid">
 {
   const { observableClient } = React.useContext(OsdkContext2);
+
+  const isSuspense = isSuspenseOption(options);
 
   const {
     pageSize,
     dedupeIntervalMs,
     withProperties,
-    enabled = true,
     rids,
     where,
     orderBy,
@@ -277,6 +406,12 @@ export function useOsdkObjects<
     $select,
     $loadPropertySecurityMetadata,
   } = options ?? {};
+
+  const enabled = isSuspense
+    ? true
+    : (options != null && "enabled" in options
+      ? options.enabled ?? true
+      : true);
 
   const canonOptions = observableClient.canonicalizeOptions({
     where,
@@ -291,54 +426,24 @@ export function useOsdkObjects<
     [JSON.stringify(rids)],
   );
 
-  const { subscribe, getSnapShot } = React.useMemo(
-    () => {
-      if (!enabled) {
-        return makeExternalStore<
-          ObserveObjectsCallbackArgs<Q, RDPs>
-        >(
-          () => ({ unsubscribe: () => {} }),
-          devToolsMetadata({
-            hookType: "useOsdkObjects",
-            objectType: type.apiName,
-          }),
-        );
-      }
-
-      return makeExternalStore<
-        ObserveObjectsCallbackArgs<Q, RDPs>
-      >(
-        (observer) =>
-          observableClient.observeList({
-            type,
-            rids: stableRids,
-            where: canonOptions.where,
-            dedupeInterval: dedupeIntervalMs ?? 2_000,
-            pageSize,
-            orderBy: canonOptions.orderBy,
-            streamUpdates,
-            withProperties: canonOptions.withProperties,
-            autoFetchMore,
-            ...(canonOptions.intersectWith
-              ? { intersectWith: canonOptions.intersectWith }
-              : {}),
-            ...(pivotTo ? { pivotTo } : {}),
-            ...(canonOptions.$select ? { select: canonOptions.$select } : {}),
-            ...($loadPropertySecurityMetadata
-              ? { $loadPropertySecurityMetadata }
-              : {}),
-          }, observer),
-        devToolsMetadata({
-          hookType: "useOsdkObjects",
-          objectType: type.apiName,
-          where: canonOptions.where,
-          orderBy: canonOptions.orderBy,
-          pageSize,
-        }),
-      );
-    },
+  const observationFactory = React.useMemo(
+    () =>
+      _createListObservation<Q, RDPs>(observableClient, {
+        type,
+        rids: stableRids,
+        where: canonOptions.where,
+        dedupeInterval: dedupeIntervalMs ?? 2_000,
+        pageSize,
+        orderBy: canonOptions.orderBy,
+        streamUpdates,
+        withProperties: canonOptions.withProperties,
+        autoFetchMore,
+        intersectWith: canonOptions.intersectWith,
+        pivotTo,
+        select: canonOptions.$select,
+        $loadPropertySecurityMetadata,
+      }),
     [
-      enabled,
       observableClient,
       type.apiName,
       type.type,
@@ -357,21 +462,94 @@ export function useOsdkObjects<
     ],
   );
 
+  const baseStore = React.useMemo(
+    () => {
+      if (isSuspense || !enabled) {
+        return makeExternalStore<
+          ObserveObjectsCallbackArgs<Q, RDPs>
+        >(
+          () => ({ unsubscribe: () => {} }),
+          devToolsMetadata({
+            hookType: "useOsdkObjects",
+            objectType: type.apiName,
+          }),
+        );
+      }
+
+      return makeExternalStore<
+        ObserveObjectsCallbackArgs<Q, RDPs>
+      >(
+        observationFactory,
+        devToolsMetadata({
+          hookType: "useOsdkObjects",
+          objectType: type.apiName,
+          where: canonOptions.where,
+          orderBy: canonOptions.orderBy,
+          pageSize,
+        }),
+      );
+    },
+    [
+      isSuspense,
+      enabled,
+      observationFactory,
+      type.apiName,
+      canonOptions.where,
+      canonOptions.orderBy,
+      pageSize,
+    ],
+  );
+
+  let { subscribe, getSnapShot } = baseStore;
+  if (isSuspense) {
+    const cacheKey =
+      `${getClientId(observableClient)}:list:${type.apiName}:${
+        JSON.stringify(canonOptions.where)
+      }`
+      + `:${JSON.stringify(stableRids ?? null)}`
+      + `:${pageSize ?? ""}:${dedupeIntervalMs ?? ""}`
+      + `:${JSON.stringify(canonOptions.orderBy ?? null)}`
+      + `:${streamUpdates ?? ""}:${JSON.stringify(autoFetchMore ?? null)}`
+      + `:${JSON.stringify(canonOptions.withProperties ?? null)}`
+      + `:${JSON.stringify(canonOptions.intersectWith ?? null)}`
+      + `:${pivotTo ?? ""}:${JSON.stringify(canonOptions.$select ?? null)}`;
+
+    ({ subscribe, getSnapShot } = setupSuspenseStore<
+      ObserveObjectsCallbackArgs<Q, RDPs>
+    >(
+      cacheKey,
+      observationFactory,
+      undefined,
+      (p) => p?.resolvedList != null,
+    ));
+  }
+
   const listPayload = React.useSyncExternalStore(subscribe, getSnapShot);
 
   const refetch = React.useCallback(async () => {
     await observableClient.invalidateObjectType(type.apiName);
   }, [observableClient, type.apiName]);
 
-  return React.useMemo(() => ({
-    fetchMore: listPayload?.hasMore ? listPayload.fetchMore : undefined,
-    error: extractPayloadError(listPayload, "Failed to load objects"),
-    data: listPayload?.resolvedList,
-    isLoading: isPayloadLoading(listPayload, enabled),
-    isOptimistic: listPayload?.isOptimistic ?? false,
-    totalCount: listPayload?.totalCount,
-    hasMore: listPayload?.hasMore ?? false,
-    objectSet: listPayload?.objectSet,
-    refetch,
-  }), [listPayload, enabled, refetch]);
+  return React.useMemo(() => {
+    if (isSuspense) {
+      return {
+        fetchMore: listPayload?.hasMore ? listPayload.fetchMore : undefined,
+        data: listPayload?.resolvedList ?? [],
+        isOptimistic: listPayload?.isOptimistic ?? false,
+        totalCount: listPayload?.totalCount,
+      };
+    }
+
+    return {
+      fetchMore: listPayload?.hasMore ? listPayload.fetchMore : undefined,
+      error: extractPayloadError(listPayload, "Failed to load objects"),
+      data: listPayload?.resolvedList,
+      isLoading: isPayloadLoading(listPayload, enabled),
+      isOptimistic: listPayload?.isOptimistic ?? false,
+      totalCount: listPayload?.totalCount,
+      hasMore: listPayload?.hasMore ?? false,
+      objectSet: listPayload?.objectSet,
+      refetch,
+    };
+  }, [listPayload, enabled, refetch, isSuspense]);
 }

--- a/packages/react/src/new/useOsdkObjects.ts
+++ b/packages/react/src/new/useOsdkObjects.ts
@@ -36,8 +36,9 @@ import { extractPayloadError, isPayloadLoading } from "./hookUtils.js";
 import { devToolsMetadata, makeExternalStore } from "./makeExternalStore.js";
 import {
   getClientId,
+  getSuspenseExternalStore,
   isSuspenseOption,
-  setupSuspenseStore,
+  throwIfSuspenseNeeded,
 } from "./makeSuspenseExternalStore.js";
 import { OsdkContext2 } from "./OsdkContext2.js";
 
@@ -500,9 +501,8 @@ export function useOsdkObjects<
     ],
   );
 
-  let { subscribe, getSnapShot } = baseStore;
-  if (isSuspense) {
-    const cacheKey = JSON.stringify([
+  const cacheKey = isSuspense
+    ? JSON.stringify([
       getClientId(observableClient),
       "list",
       type.apiName,
@@ -518,16 +518,28 @@ export function useOsdkObjects<
       pivotTo ?? null,
       canonOptions.$select ?? null,
       $loadPropertySecurityMetadata ?? null,
-    ]);
+    ])
+    : null;
 
-    ({ subscribe, getSnapShot } = setupSuspenseStore<
-      ObserveObjectsCallbackArgs<Q, RDPs>
-    >(
+  const hasListData = (
+    p: ObserveObjectsCallbackArgs<Q, RDPs> | undefined,
+  ): boolean => p?.resolvedList != null;
+
+  const suspenseStore = React.useMemo(() => {
+    if (cacheKey === null) {
+      return undefined;
+    }
+    return getSuspenseExternalStore<ObserveObjectsCallbackArgs<Q, RDPs>>(
       cacheKey,
       observationFactory,
-      undefined,
-      (p) => p?.resolvedList != null,
-    ));
+      hasListData,
+    );
+  }, [cacheKey]);
+
+  let { subscribe, getSnapShot } = baseStore;
+  if (suspenseStore) {
+    throwIfSuspenseNeeded(suspenseStore, hasListData);
+    ({ subscribe, getSnapShot } = suspenseStore);
   }
 
   const listPayload = React.useSyncExternalStore(subscribe, getSnapShot);

--- a/packages/react/src/new/useOsdkObjects.ts
+++ b/packages/react/src/new/useOsdkObjects.ts
@@ -558,7 +558,7 @@ export function useOsdkObjects<
 
   const suspenseStore = React.useMemo(
     () =>
-      cacheKey === null
+      cacheKey == null
         ? undefined
         : getSuspenseExternalStore<ObserveObjectsCallbackArgs<Q, RDPs>>(
           cacheKey,

--- a/packages/react/src/new/useOsdkObjects.ts
+++ b/packages/react/src/new/useOsdkObjects.ts
@@ -25,11 +25,82 @@ import type {
   SimplePropertyDef,
   WhereClause,
 } from "@osdk/api";
-import type { ObserveObjectsCallbackArgs } from "@osdk/client/observable";
+import type {
+  ObservableClient,
+  ObserveObjectsCallbackArgs,
+  Observer,
+  Unsubscribable,
+} from "@osdk/client/observable";
 import React from "react";
 import { extractPayloadError, isPayloadLoading } from "./hookUtils.js";
-import { devToolsMetadata, makeExternalStore } from "./makeExternalStore.js";
+import {
+  devToolsMetadata,
+  makeExternalStore,
+  type Snapshot,
+} from "./makeExternalStore.js";
+import {
+  getClientId,
+  getSuspenseExternalStore,
+  isSuspenseOption,
+  throwIfSuspenseNeeded,
+} from "./makeSuspenseExternalStore.js";
 import { OsdkContext } from "./OsdkContext.js";
+
+/** @internal */
+export interface _CreateListObservationOptions<
+  Q extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef> = {},
+> {
+  type: Pick<Q, "apiName" | "type">;
+  rids?: readonly string[];
+  where?: WhereClause<Q, RDPs>;
+  dedupeInterval: number;
+  pageSize?: number;
+  orderBy?: { [K in PropertyKeys<Q>]?: "asc" | "desc" };
+  streamUpdates?: boolean;
+  withProperties?: DerivedProperty.Clause<Q>;
+  autoFetchMore?: boolean | number;
+  intersectWith?: Array<{ where: WhereClause<Q, RDPs> }>;
+  pivotTo?: LinkNames<Q>;
+  select?: readonly PropertyKeys<Q>[];
+  $loadPropertySecurityMetadata?: boolean;
+  $includeAllBaseObjectProperties?: boolean;
+}
+
+/** @internal */
+export function _createListObservation<
+  Q extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef> = {},
+>(
+  observableClient: ObservableClient,
+  options: _CreateListObservationOptions<Q, RDPs>,
+): (
+  observer: Observer<ObserveObjectsCallbackArgs<Q, RDPs> | undefined>,
+) => Unsubscribable {
+  return (observer) =>
+    observableClient.observeList<Q, RDPs>({
+      type: options.type,
+      rids: options.rids,
+      where: options.where,
+      dedupeInterval: options.dedupeInterval,
+      pageSize: options.pageSize,
+      orderBy: options.orderBy,
+      streamUpdates: options.streamUpdates,
+      withProperties: options.withProperties,
+      autoFetchMore: options.autoFetchMore,
+      $includeAllBaseObjectProperties: options.$includeAllBaseObjectProperties,
+      ...(options.intersectWith
+        ? { intersectWith: options.intersectWith }
+        : {}),
+      ...(options.pivotTo ? { pivotTo: options.pivotTo } : {}),
+      ...(options.select ? { select: options.select } : {}),
+      ...(options.$loadPropertySecurityMetadata
+        ? {
+          $loadPropertySecurityMetadata: options.$loadPropertySecurityMetadata,
+        }
+        : {}),
+    }, observer);
+}
 
 export interface UseOsdkObjectsOptions<
   T extends ObjectOrInterfaceDefinition,
@@ -217,6 +288,66 @@ export interface UseOsdkListResult<
   refetch: () => Promise<void>;
 }
 
+export interface UseOsdkListSuspenseResult<
+  T extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef> = {},
+  EXTRA_OPTIONS extends never | "$rid" = never,
+> {
+  data: Osdk.Instance<
+    T,
+    "$allBaseProperties" | EXTRA_OPTIONS,
+    PropertyKeys<T>,
+    RDPs
+  >[];
+  fetchMore: (() => Promise<void>) | undefined;
+  isOptimistic: boolean;
+  totalCount?: string;
+}
+
+// Suspense pivotTo overloads
+export function useOsdkObjects<
+  Q extends ObjectOrInterfaceDefinition,
+  L extends LinkNames<Q>,
+  RDPs extends Record<string, SimplePropertyDef> = {},
+>(
+  type: Q,
+  options:
+    & Omit<UseOsdkObjectsOptions<Q, RDPs>, "enabled">
+    & { suspense: true; pivotTo: L; rids: readonly string[] },
+): UseOsdkListSuspenseResult<LinkedType<Q, L>, {}, "$rid">;
+
+export function useOsdkObjects<
+  Q extends ObjectOrInterfaceDefinition,
+  L extends LinkNames<Q>,
+  RDPs extends Record<string, SimplePropertyDef> = {},
+>(
+  type: Q,
+  options:
+    & Omit<UseOsdkObjectsOptions<Q, RDPs>, "enabled">
+    & { suspense: true; pivotTo: L },
+): UseOsdkListSuspenseResult<LinkedType<Q, L>>;
+
+// Suspense non-pivotTo overloads
+export function useOsdkObjects<
+  Q extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef> = {},
+>(
+  type: Q,
+  options:
+    & Omit<UseOsdkObjectsOptions<Q, RDPs>, "enabled">
+    & { suspense: true; rids: readonly string[] },
+): UseOsdkListSuspenseResult<Q, RDPs, "$rid">;
+
+export function useOsdkObjects<
+  Q extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef> = {},
+>(
+  type: Q,
+  options:
+    & Omit<UseOsdkObjectsOptions<Q, RDPs>, "enabled">
+    & { suspense: true },
+): UseOsdkListSuspenseResult<Q, RDPs>;
+
 // pivotTo overloads: streamUpdates is forbidden (the server does not support
 // websocket subscriptions for link-traversal queries).
 export function useOsdkObjects<
@@ -270,20 +401,27 @@ export function useOsdkObjects<
   RDPs extends Record<string, SimplePropertyDef> = {},
 >(
   type: Q,
-  options?: UseOsdkObjectsOptions<Q, RDPs>,
+  options?:
+    | UseOsdkObjectsOptions<Q, RDPs>
+    | (Omit<UseOsdkObjectsOptions<Q, RDPs>, "enabled"> & { suspense: true }),
 ):
   | UseOsdkListResult<Q, RDPs>
   | UseOsdkListResult<Q, RDPs, "$rid">
   | UseOsdkListResult<LinkedType<Q, LinkNames<Q>>, {}>
   | UseOsdkListResult<LinkedType<Q, LinkNames<Q>>, {}, "$rid">
+  | UseOsdkListSuspenseResult<Q, RDPs>
+  | UseOsdkListSuspenseResult<Q, RDPs, "$rid">
+  | UseOsdkListSuspenseResult<LinkedType<Q, LinkNames<Q>>>
+  | UseOsdkListSuspenseResult<LinkedType<Q, LinkNames<Q>>, {}, "$rid">
 {
   const { observableClient } = React.useContext(OsdkContext);
+
+  const isSuspense = isSuspenseOption(options);
 
   const {
     pageSize,
     dedupeIntervalMs,
     withProperties,
-    enabled = true,
     rids,
     where,
     orderBy,
@@ -295,6 +433,12 @@ export function useOsdkObjects<
     $loadPropertySecurityMetadata,
     $includeAllBaseObjectProperties,
   } = options ?? {};
+
+  const enabled = isSuspense
+    ? true
+    : (options != null && "enabled" in options
+      ? options.enabled ?? true
+      : true);
 
   const canonOptions = observableClient.canonicalizeOptions({
     where,
@@ -309,51 +453,25 @@ export function useOsdkObjects<
     [JSON.stringify(rids)],
   );
 
-  const { subscribe, getSnapShot } = React.useMemo(
-    () => {
-      if (!enabled) {
-        return makeExternalStore<ObserveObjectsCallbackArgs<Q, RDPs>>(
-          () => ({ unsubscribe: () => {} }),
-          devToolsMetadata({
-            hookType: "useOsdkObjects",
-            objectType: type.apiName,
-          }),
-        );
-      }
-
-      return makeExternalStore<ObserveObjectsCallbackArgs<Q, RDPs>>(
-        (observer) =>
-          observableClient.observeList<Q, RDPs>({
-            type,
-            rids: stableRids,
-            where: canonOptions.where,
-            dedupeInterval: dedupeIntervalMs ?? 2_000,
-            pageSize,
-            orderBy: canonOptions.orderBy,
-            streamUpdates,
-            withProperties: canonOptions.withProperties,
-            autoFetchMore,
-            $includeAllBaseObjectProperties,
-            ...(canonOptions.intersectWith
-              ? { intersectWith: canonOptions.intersectWith }
-              : {}),
-            ...(pivotTo ? { pivotTo } : {}),
-            ...(canonOptions.$select ? { select: canonOptions.$select } : {}),
-            ...($loadPropertySecurityMetadata
-              ? { $loadPropertySecurityMetadata }
-              : {}),
-          }, observer),
-        devToolsMetadata({
-          hookType: "useOsdkObjects",
-          objectType: type.apiName,
-          where: canonOptions.where,
-          orderBy: canonOptions.orderBy,
-          pageSize,
-        }),
-      );
-    },
+  const observationFactory = React.useMemo(
+    () =>
+      _createListObservation<Q, RDPs>(observableClient, {
+        type,
+        rids: stableRids,
+        where: canonOptions.where,
+        dedupeInterval: dedupeIntervalMs ?? 2_000,
+        pageSize,
+        orderBy: canonOptions.orderBy,
+        streamUpdates,
+        withProperties: canonOptions.withProperties,
+        autoFetchMore,
+        intersectWith: canonOptions.intersectWith,
+        pivotTo,
+        select: canonOptions.$select,
+        $loadPropertySecurityMetadata,
+        $includeAllBaseObjectProperties,
+      }),
     [
-      enabled,
       observableClient,
       type.apiName,
       type.type,
@@ -373,14 +491,107 @@ export function useOsdkObjects<
     ],
   );
 
+  const baseStore = React.useMemo(
+    () => {
+      if (isSuspense || !enabled) {
+        return makeExternalStore<
+          ObserveObjectsCallbackArgs<Q, RDPs>
+        >(
+          () => ({ unsubscribe: () => {} }),
+          devToolsMetadata({
+            hookType: "useOsdkObjects",
+            objectType: type.apiName,
+          }),
+        );
+      }
+
+      return makeExternalStore<
+        ObserveObjectsCallbackArgs<Q, RDPs>
+      >(
+        observationFactory,
+        devToolsMetadata({
+          hookType: "useOsdkObjects",
+          objectType: type.apiName,
+          where: canonOptions.where,
+          orderBy: canonOptions.orderBy,
+          pageSize,
+        }),
+      );
+    },
+    [
+      isSuspense,
+      enabled,
+      observationFactory,
+      type.apiName,
+      canonOptions.where,
+      canonOptions.orderBy,
+      pageSize,
+    ],
+  );
+
+  const cacheKey = isSuspense
+    ? JSON.stringify([
+      getClientId(observableClient),
+      "list",
+      type.apiName,
+      stableRids ?? null,
+      canonOptions.where ?? null,
+      pageSize ?? null,
+      dedupeIntervalMs ?? null,
+      canonOptions.orderBy ?? null,
+      streamUpdates ?? null,
+      autoFetchMore ?? null,
+      canonOptions.withProperties ?? null,
+      canonOptions.intersectWith ?? null,
+      pivotTo ?? null,
+      canonOptions.$select ?? null,
+      $loadPropertySecurityMetadata ?? null,
+      $includeAllBaseObjectProperties ?? null,
+    ])
+    : null;
+
+  const hasListData = React.useCallback(
+    (p: Snapshot<ObserveObjectsCallbackArgs<Q, RDPs>>) =>
+      p?.resolvedList != null,
+    [],
+  );
+
+  const suspenseStore = React.useMemo(
+    () =>
+      cacheKey === null
+        ? undefined
+        : getSuspenseExternalStore<ObserveObjectsCallbackArgs<Q, RDPs>>(
+          cacheKey,
+          observationFactory,
+          hasListData,
+        ),
+    [cacheKey, observationFactory, hasListData],
+  );
+
+  if (suspenseStore !== undefined) {
+    throwIfSuspenseNeeded(suspenseStore, hasListData);
+  }
+
+  const subscribe = suspenseStore?.subscribe ?? baseStore.subscribe;
+  const getSnapShot = suspenseStore?.getSnapShot ?? baseStore.getSnapShot;
+
   const listPayload = React.useSyncExternalStore(subscribe, getSnapShot);
 
   const refetch = React.useCallback(async () => {
     await observableClient.invalidateObjectType(type.apiName);
   }, [observableClient, type.apiName]);
 
-  return React.useMemo<UseOsdkListResult<Q, RDPs>>(
-    () => ({
+  return React.useMemo(() => {
+    if (isSuspense) {
+      return {
+        fetchMore: listPayload?.hasMore ? listPayload.fetchMore : undefined,
+        data: listPayload?.resolvedList ?? [],
+        isOptimistic: listPayload?.isOptimistic ?? false,
+        totalCount: listPayload?.totalCount,
+      };
+    }
+
+    return {
       fetchMore: listPayload?.hasMore ? listPayload.fetchMore : undefined,
       error: extractPayloadError(listPayload, "Failed to load objects"),
       data: listPayload?.resolvedList,
@@ -390,7 +601,6 @@ export function useOsdkObjects<
       hasMore: listPayload?.hasMore ?? false,
       objectSet: listPayload?.objectSet,
       refetch,
-    }),
-    [listPayload, enabled, refetch],
-  );
+    };
+  }, [listPayload, enabled, refetch, isSuspense]);
 }

--- a/packages/react/src/new/useOsdkObjects.ts
+++ b/packages/react/src/new/useOsdkObjects.ts
@@ -502,17 +502,23 @@ export function useOsdkObjects<
 
   let { subscribe, getSnapShot } = baseStore;
   if (isSuspense) {
-    const cacheKey =
-      `${getClientId(observableClient)}:list:${type.apiName}:${
-        JSON.stringify(canonOptions.where)
-      }`
-      + `:${JSON.stringify(stableRids ?? null)}`
-      + `:${pageSize ?? ""}:${dedupeIntervalMs ?? ""}`
-      + `:${JSON.stringify(canonOptions.orderBy ?? null)}`
-      + `:${streamUpdates ?? ""}:${JSON.stringify(autoFetchMore ?? null)}`
-      + `:${JSON.stringify(canonOptions.withProperties ?? null)}`
-      + `:${JSON.stringify(canonOptions.intersectWith ?? null)}`
-      + `:${pivotTo ?? ""}:${JSON.stringify(canonOptions.$select ?? null)}`;
+    const cacheKey = JSON.stringify([
+      getClientId(observableClient),
+      "list",
+      type.apiName,
+      canonOptions.where ?? null,
+      stableRids ?? null,
+      pageSize ?? null,
+      dedupeIntervalMs ?? null,
+      canonOptions.orderBy ?? null,
+      streamUpdates ?? null,
+      autoFetchMore ?? null,
+      canonOptions.withProperties ?? null,
+      canonOptions.intersectWith ?? null,
+      pivotTo ?? null,
+      canonOptions.$select ?? null,
+      $loadPropertySecurityMetadata ?? null,
+    ]);
 
     ({ subscribe, getSnapShot } = setupSuspenseStore<
       ObserveObjectsCallbackArgs<Q, RDPs>

--- a/packages/react/src/public/experimental.ts
+++ b/packages/react/src/public/experimental.ts
@@ -65,11 +65,15 @@ export type {
 } from "../new/useOsdkFunctions.js";
 
 /** @deprecated Import from `@osdk/react` instead. */
+export type { UseOsdkObjectSuspenseResult } from "../new/useOsdkObject.js";
+
+/** @deprecated Import from `@osdk/react` instead. */
 export { useOsdkObject } from "../new/useOsdkObject.js";
 
 /** @deprecated Import from `@osdk/react` instead. */
 export type {
   UseOsdkListResult,
+  UseOsdkListSuspenseResult,
   UseOsdkObjectsOptions,
 } from "../new/useOsdkObjects.js";
 

--- a/packages/react/src/public/experimental.ts
+++ b/packages/react/src/public/experimental.ts
@@ -33,9 +33,11 @@ export type {
   UseOsdkFunctionsProps,
   UseOsdkFunctionsResult,
 } from "../new/useOsdkFunctions.js";
+export type { UseOsdkObjectSuspenseResult } from "../new/useOsdkObject.js";
 export { useOsdkObject } from "../new/useOsdkObject.js";
 export type {
   UseOsdkListResult,
+  UseOsdkListSuspenseResult,
   UseOsdkObjectsOptions,
 } from "../new/useOsdkObjects.js";
 export { useOsdkObjects } from "../new/useOsdkObjects.js";

--- a/packages/react/test/suspenseTestUtils.ts
+++ b/packages/react/test/suspenseTestUtils.ts
@@ -134,6 +134,7 @@ export function createMockObservableClient(
     observeList: vitest.fn(() => ({ unsubscribe: vitest.fn() })),
     peekObjectData: vitest.fn(() => undefined),
     canonicalizeWhereClause: vitest.fn((w: unknown) => w),
+    canonicalizeOptions: vitest.fn((opts: Record<string, unknown>) => opts),
     ...overrides,
   };
 }

--- a/packages/react/test/useOsdkObjectSuspense.test.tsx
+++ b/packages/react/test/useOsdkObjectSuspense.test.tsx
@@ -16,13 +16,14 @@
 
 import type { ObjectTypeDefinition } from "@osdk/api";
 import type { Observer } from "@osdk/client/unstable-do-not-use";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import * as React from "react";
 import { afterEach, beforeEach, describe, expect, it, vitest } from "vitest";
 import { useOsdkObject } from "../src/new/useOsdkObject.js";
 import {
   cleanupSuspenseTests,
   createMockObservableClient,
+  mockObjectPayload,
   TestSuspenseWrapper,
 } from "./suspenseTestUtils.js";
 
@@ -86,16 +87,7 @@ describe("useOsdkObject with { suspense: true }", () => {
     expect(screen.getByTestId("loading")).toBeDefined();
 
     act(() => {
-      capturedObserver?.next({
-        object: {
-          name: "Test Object",
-          $objectType: "MockObject",
-          $primaryKey: "pk-1",
-        },
-        status: "loaded",
-        isOptimistic: false,
-        lastUpdated: Date.now(),
-      });
+      capturedObserver?.next(mockObjectPayload("Test Object", "pk-1"));
     });
 
     const el = await screen.findByTestId("object");
@@ -119,151 +111,5 @@ describe("useOsdkObject with { suspense: true }", () => {
 
     const el = await screen.findByTestId("error");
     expect(el.textContent).toBe("Network failure");
-  });
-
-  it("should re-suspend when primary key changes", async () => {
-    const client = createObservableClient();
-    let secondObserver:
-      | Observer<Record<string, unknown> | undefined>
-      | undefined;
-
-    mockObserveObject.mockImplementation(
-      (
-        _type: unknown,
-        pk: unknown,
-        _opts: unknown,
-        observer: Observer<Record<string, unknown> | undefined>,
-      ) => {
-        if (pk === "pk-1") {
-          capturedObserver = observer;
-        } else {
-          secondObserver = observer;
-        }
-        return { unsubscribe: vitest.fn() };
-      },
-    );
-
-    const { rerender } = render(
-      React.createElement(
-        TestSuspenseWrapper,
-        { observableClient: client },
-        React.createElement(ObjectComponent, { pk: "pk-1" }),
-      ),
-    );
-
-    act(() => {
-      capturedObserver?.next({
-        object: {
-          name: "Object 1",
-          $objectType: "MockObject",
-          $primaryKey: "pk-1",
-        },
-        status: "loaded",
-        isOptimistic: false,
-        lastUpdated: Date.now(),
-      });
-    });
-
-    const el1 = await screen.findByTestId("object");
-    expect(el1.textContent).toBe("Object 1");
-
-    rerender(
-      React.createElement(
-        TestSuspenseWrapper,
-        { observableClient: client },
-        React.createElement(ObjectComponent, { pk: "pk-2" }),
-      ),
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId("loading")).toBeDefined();
-    });
-
-    await act(async () => {
-      secondObserver?.next({
-        object: {
-          name: "Object 2",
-          $objectType: "MockObject",
-          $primaryKey: "pk-2",
-        },
-        status: "loaded",
-        isOptimistic: false,
-        lastUpdated: Date.now(),
-      });
-    });
-
-    const el2 = await screen.findByTestId("object");
-    expect(el2.textContent).toBe("Object 2");
-  });
-
-  it("should survive StrictMode double-render without duplicate subscriptions", async () => {
-    const client = createObservableClient();
-
-    render(
-      React.createElement(
-        React.StrictMode,
-        null,
-        React.createElement(
-          TestSuspenseWrapper,
-          { observableClient: client },
-          React.createElement(ObjectComponent, { pk: "pk-strict" }),
-        ),
-      ),
-    );
-
-    expect(screen.getByTestId("loading")).toBeDefined();
-    expect(mockObserveObject).toHaveBeenCalledTimes(1);
-
-    act(() => {
-      capturedObserver?.next({
-        object: {
-          name: "StrictMode Object",
-          $objectType: "MockObject",
-          $primaryKey: "pk-strict",
-        },
-        status: "loaded",
-        isOptimistic: false,
-        lastUpdated: Date.now(),
-      });
-    });
-
-    const el = await screen.findByTestId("object");
-    expect(el.textContent).toBe("StrictMode Object");
-    expect(mockObserveObject).toHaveBeenCalledTimes(1);
-  });
-
-  it("should show error boundary when error occurs after data was loaded", async () => {
-    const client = createObservableClient();
-
-    render(
-      React.createElement(
-        TestSuspenseWrapper,
-        { observableClient: client },
-        React.createElement(ObjectComponent, { pk: "pk-1" }),
-      ),
-    );
-
-    act(() => {
-      capturedObserver?.next({
-        object: {
-          name: "Loaded Object",
-          $objectType: "MockObject",
-          $primaryKey: "pk-1",
-        },
-        status: "loaded",
-        isOptimistic: false,
-        lastUpdated: Date.now(),
-      });
-    });
-
-    const el = await screen.findByTestId("object");
-    expect(el.textContent).toBe("Loaded Object");
-
-    act(() => {
-      capturedObserver?.error(new Error("revalidation failed"));
-    });
-
-    const errorEl = await screen.findByTestId("error");
-    expect(errorEl.textContent).toBe("revalidation failed");
   });
 });

--- a/packages/react/test/useOsdkObjectSuspense.test.tsx
+++ b/packages/react/test/useOsdkObjectSuspense.test.tsx
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectTypeDefinition } from "@osdk/api";
+import type { Observer } from "@osdk/client/unstable-do-not-use";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, beforeEach, describe, expect, it, vitest } from "vitest";
+import { useOsdkObject } from "../src/new/useOsdkObject.js";
+import {
+  cleanupSuspenseTests,
+  createMockObservableClient,
+  TestSuspenseWrapper,
+} from "./suspenseTestUtils.js";
+
+const MockObjectType = {
+  apiName: "MockObject",
+  primaryKeyType: "string",
+} as unknown as ObjectTypeDefinition;
+
+describe("useOsdkObject with { suspense: true }", () => {
+  let mockObserveObject: ReturnType<typeof vitest.fn>;
+  let capturedObserver:
+    | Observer<Record<string, unknown> | undefined>
+    | undefined;
+  let mockPeekObjectData: ReturnType<typeof vitest.fn>;
+
+  beforeEach(() => {
+    capturedObserver = undefined;
+    mockObserveObject = vitest.fn(
+      (
+        _type: unknown,
+        _pk: unknown,
+        _opts: unknown,
+        observer: Observer<Record<string, unknown> | undefined>,
+      ) => {
+        capturedObserver = observer;
+        return { unsubscribe: vitest.fn() };
+      },
+    );
+    mockPeekObjectData = vitest.fn(() => undefined);
+  });
+
+  afterEach(cleanupSuspenseTests);
+
+  function createObservableClient() {
+    return createMockObservableClient({
+      observeObject: mockObserveObject,
+      peekObjectData: mockPeekObjectData,
+    });
+  }
+
+  function ObjectComponent({ pk }: { pk: string }) {
+    const { object } = useOsdkObject(MockObjectType, pk, { suspense: true });
+    return React.createElement(
+      "div",
+      { "data-testid": "object" },
+      (object as Record<string, unknown>).name as string,
+    );
+  }
+
+  it("should render object data after loading completes", async () => {
+    const client = createObservableClient();
+
+    render(
+      React.createElement(
+        TestSuspenseWrapper,
+        { observableClient: client },
+        React.createElement(ObjectComponent, { pk: "pk-1" }),
+      ),
+    );
+
+    expect(screen.getByTestId("loading")).toBeDefined();
+
+    act(() => {
+      capturedObserver?.next({
+        object: {
+          name: "Test Object",
+          $objectType: "MockObject",
+          $primaryKey: "pk-1",
+        },
+        status: "loaded",
+        isOptimistic: false,
+        lastUpdated: Date.now(),
+      });
+    });
+
+    const el = await screen.findByTestId("object");
+    expect(el.textContent).toBe("Test Object");
+  });
+
+  it("should show error boundary when error occurs", async () => {
+    const client = createObservableClient();
+
+    render(
+      React.createElement(
+        TestSuspenseWrapper,
+        { observableClient: client },
+        React.createElement(ObjectComponent, { pk: "pk-1" }),
+      ),
+    );
+
+    act(() => {
+      capturedObserver?.error(new Error("Network failure"));
+    });
+
+    const el = await screen.findByTestId("error");
+    expect(el.textContent).toBe("Network failure");
+  });
+
+  it("should re-suspend when primary key changes", async () => {
+    const client = createObservableClient();
+    let secondObserver:
+      | Observer<Record<string, unknown> | undefined>
+      | undefined;
+
+    mockObserveObject.mockImplementation(
+      (
+        _type: unknown,
+        pk: unknown,
+        _opts: unknown,
+        observer: Observer<Record<string, unknown> | undefined>,
+      ) => {
+        if (pk === "pk-1") {
+          capturedObserver = observer;
+        } else {
+          secondObserver = observer;
+        }
+        return { unsubscribe: vitest.fn() };
+      },
+    );
+
+    const { rerender } = render(
+      React.createElement(
+        TestSuspenseWrapper,
+        { observableClient: client },
+        React.createElement(ObjectComponent, { pk: "pk-1" }),
+      ),
+    );
+
+    act(() => {
+      capturedObserver?.next({
+        object: {
+          name: "Object 1",
+          $objectType: "MockObject",
+          $primaryKey: "pk-1",
+        },
+        status: "loaded",
+        isOptimistic: false,
+        lastUpdated: Date.now(),
+      });
+    });
+
+    const el1 = await screen.findByTestId("object");
+    expect(el1.textContent).toBe("Object 1");
+
+    rerender(
+      React.createElement(
+        TestSuspenseWrapper,
+        { observableClient: client },
+        React.createElement(ObjectComponent, { pk: "pk-2" }),
+      ),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toBeDefined();
+    });
+
+    await act(async () => {
+      secondObserver?.next({
+        object: {
+          name: "Object 2",
+          $objectType: "MockObject",
+          $primaryKey: "pk-2",
+        },
+        status: "loaded",
+        isOptimistic: false,
+        lastUpdated: Date.now(),
+      });
+    });
+
+    const el2 = await screen.findByTestId("object");
+    expect(el2.textContent).toBe("Object 2");
+  });
+
+  it("should survive StrictMode double-render without duplicate subscriptions", async () => {
+    const client = createObservableClient();
+
+    render(
+      React.createElement(
+        React.StrictMode,
+        null,
+        React.createElement(
+          TestSuspenseWrapper,
+          { observableClient: client },
+          React.createElement(ObjectComponent, { pk: "pk-strict" }),
+        ),
+      ),
+    );
+
+    expect(screen.getByTestId("loading")).toBeDefined();
+    expect(mockObserveObject).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      capturedObserver?.next({
+        object: {
+          name: "StrictMode Object",
+          $objectType: "MockObject",
+          $primaryKey: "pk-strict",
+        },
+        status: "loaded",
+        isOptimistic: false,
+        lastUpdated: Date.now(),
+      });
+    });
+
+    const el = await screen.findByTestId("object");
+    expect(el.textContent).toBe("StrictMode Object");
+    expect(mockObserveObject).toHaveBeenCalledTimes(1);
+  });
+
+  it("should show error boundary when error occurs after data was loaded", async () => {
+    const client = createObservableClient();
+
+    render(
+      React.createElement(
+        TestSuspenseWrapper,
+        { observableClient: client },
+        React.createElement(ObjectComponent, { pk: "pk-1" }),
+      ),
+    );
+
+    act(() => {
+      capturedObserver?.next({
+        object: {
+          name: "Loaded Object",
+          $objectType: "MockObject",
+          $primaryKey: "pk-1",
+        },
+        status: "loaded",
+        isOptimistic: false,
+        lastUpdated: Date.now(),
+      });
+    });
+
+    const el = await screen.findByTestId("object");
+    expect(el.textContent).toBe("Loaded Object");
+
+    act(() => {
+      capturedObserver?.error(new Error("revalidation failed"));
+    });
+
+    const errorEl = await screen.findByTestId("error");
+    expect(errorEl.textContent).toBe("revalidation failed");
+  });
+});

--- a/packages/react/test/useOsdkObjects.test.tsx
+++ b/packages/react/test/useOsdkObjects.test.tsx
@@ -15,11 +15,23 @@
  */
 
 import type { ObjectTypeDefinition } from "@osdk/api";
-import { act, renderHook } from "@testing-library/react";
+import type { Observer } from "@osdk/client/unstable-do-not-use";
+import {
+  act,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import * as React from "react";
-import { beforeEach, describe, expect, it, vitest } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vitest } from "vitest";
 import { OsdkContext2 } from "../src/new/OsdkContext2.js";
 import { useOsdkObjects } from "../src/new/useOsdkObjects.js";
+import {
+  cleanupSuspenseTests,
+  createMockObservableClient,
+  TestSuspenseWrapper,
+} from "./suspenseTestUtils.js";
 
 const MockObjectType = {
   apiName: "MockObject",
@@ -222,5 +234,195 @@ describe("useOsdkObjects enabled option", () => {
     });
 
     expect(mockInvalidateObjectType).toHaveBeenCalledWith("MockObject");
+  });
+});
+
+const MockObjectTypeWithType = {
+  apiName: "MockObject",
+  primaryKeyType: "string",
+  type: "object",
+} as unknown as ObjectTypeDefinition;
+
+describe("useOsdkObjects with { suspense: true }", () => {
+  let mockObserveList: ReturnType<typeof vitest.fn>;
+  let capturedObserver:
+    | Observer<Record<string, unknown> | undefined>
+    | undefined;
+
+  beforeEach(() => {
+    capturedObserver = undefined;
+    mockObserveList = vitest.fn(
+      (
+        _opts: unknown,
+        observer: Observer<Record<string, unknown> | undefined>,
+      ) => {
+        capturedObserver = observer;
+        return { unsubscribe: vitest.fn() };
+      },
+    );
+  });
+
+  afterEach(cleanupSuspenseTests);
+
+  function createObservableClient() {
+    return createMockObservableClient({
+      observeList: mockObserveList,
+    });
+  }
+
+  function ListComponent({ where }: { where?: Record<string, string> }) {
+    const { data, fetchMore, totalCount } = useOsdkObjects(
+      MockObjectTypeWithType,
+      where
+        ? { where, suspense: true as const }
+        : { suspense: true as const },
+    );
+
+    return React.createElement(
+      "div",
+      null,
+      React.createElement(
+        "div",
+        { "data-testid": "count" },
+        String(data.length),
+      ),
+      totalCount != null
+        ? React.createElement(
+          "div",
+          { "data-testid": "total" },
+          totalCount,
+        )
+        : null,
+      data.map((item, i) =>
+        React.createElement(
+          "div",
+          { key: i, "data-testid": `item-${i}` },
+          (item as Record<string, unknown>).name as string,
+        )
+      ),
+      fetchMore
+        ? React.createElement(
+          "button",
+          { "data-testid": "fetch-more", onClick: fetchMore },
+          "Load More",
+        )
+        : null,
+    );
+  }
+
+  it("should suspend then render list data after loading", async () => {
+    const client = createObservableClient();
+
+    render(
+      React.createElement(
+        TestSuspenseWrapper,
+        { observableClient: client },
+        React.createElement(ListComponent, {}),
+      ),
+    );
+
+    expect(screen.getByTestId("loading")).toBeDefined();
+    expect(mockObserveList).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      capturedObserver?.next({
+        resolvedList: [
+          { name: "Item A", $objectType: "MockObject", $primaryKey: "1" },
+          { name: "Item B", $objectType: "MockObject", $primaryKey: "2" },
+        ],
+        status: "loaded",
+        isOptimistic: false,
+        lastUpdated: Date.now(),
+        hasMore: false,
+        fetchMore: vitest.fn(),
+        totalCount: "2",
+      });
+    });
+
+    const count = await screen.findByTestId("count");
+    expect(count.textContent).toBe("2");
+    expect(screen.getByTestId("item-0").textContent).toBe("Item A");
+    expect(screen.getByTestId("item-1").textContent).toBe("Item B");
+    expect(screen.getByTestId("total").textContent).toBe("2");
+  });
+
+  it("should re-suspend when where clause changes", async () => {
+    const client = createObservableClient();
+    let secondObserver:
+      | Observer<Record<string, unknown> | undefined>
+      | undefined;
+
+    mockObserveList.mockImplementation(
+      (
+        opts: Record<string, unknown>,
+        observer: Observer<Record<string, unknown> | undefined>,
+      ) => {
+        const where = opts.where as Record<string, string> | undefined;
+        if (where?.status === "active") {
+          capturedObserver = observer;
+        } else {
+          secondObserver = observer;
+        }
+        return { unsubscribe: vitest.fn() };
+      },
+    );
+
+    const { rerender } = render(
+      React.createElement(
+        TestSuspenseWrapper,
+        { observableClient: client },
+        React.createElement(ListComponent, { where: { status: "active" } }),
+      ),
+    );
+
+    act(() => {
+      capturedObserver?.next({
+        resolvedList: [
+          { name: "Active Item", $objectType: "MockObject", $primaryKey: "1" },
+        ],
+        status: "loaded",
+        isOptimistic: false,
+        lastUpdated: Date.now(),
+        hasMore: false,
+        fetchMore: vitest.fn(),
+      });
+    });
+
+    const item0 = await screen.findByTestId("item-0");
+    expect(item0.textContent).toBe("Active Item");
+
+    rerender(
+      React.createElement(
+        TestSuspenseWrapper,
+        { observableClient: client },
+        React.createElement(ListComponent, {
+          where: { status: "inactive" },
+        }),
+      ),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toBeDefined();
+    });
+
+    await act(async () => {
+      secondObserver?.next({
+        resolvedList: [
+          {
+            name: "Inactive Item",
+            $objectType: "MockObject",
+            $primaryKey: "2",
+          },
+        ],
+        status: "loaded",
+        isOptimistic: false,
+        lastUpdated: Date.now(),
+        hasMore: false,
+        fetchMore: vitest.fn(),
+      });
+    });
+
+    const newItem = await screen.findByTestId("item-0");
+    expect(newItem.textContent).toBe("Inactive Item");
   });
 });

--- a/packages/react/test/useOsdkObjects.test.tsx
+++ b/packages/react/test/useOsdkObjects.test.tsx
@@ -30,6 +30,7 @@ import { useOsdkObjects } from "../src/new/useOsdkObjects.js";
 import {
   cleanupSuspenseTests,
   createMockObservableClient,
+  mockListPayload,
   TestSuspenseWrapper,
 } from "./suspenseTestUtils.js";
 
@@ -271,7 +272,7 @@ describe("useOsdkObjects with { suspense: true }", () => {
   }
 
   function ListComponent({ where }: { where?: Record<string, string> }) {
-    const { data, fetchMore, totalCount } = useOsdkObjects(
+    const { data } = useOsdkObjects(
       MockObjectTypeWithType,
       where
         ? { where, suspense: true as const }
@@ -286,13 +287,6 @@ describe("useOsdkObjects with { suspense: true }", () => {
         { "data-testid": "count" },
         String(data.length),
       ),
-      totalCount != null
-        ? React.createElement(
-          "div",
-          { "data-testid": "total" },
-          totalCount,
-        )
-        : null,
       data.map((item, i) =>
         React.createElement(
           "div",
@@ -300,13 +294,6 @@ describe("useOsdkObjects with { suspense: true }", () => {
           (item as Record<string, unknown>).name as string,
         )
       ),
-      fetchMore
-        ? React.createElement(
-          "button",
-          { "data-testid": "fetch-more", onClick: fetchMore },
-          "Load More",
-        )
-        : null,
     );
   }
 
@@ -325,25 +312,16 @@ describe("useOsdkObjects with { suspense: true }", () => {
     expect(mockObserveList).toHaveBeenCalledTimes(1);
 
     act(() => {
-      capturedObserver?.next({
-        resolvedList: [
-          { name: "Item A", $objectType: "MockObject", $primaryKey: "1" },
-          { name: "Item B", $objectType: "MockObject", $primaryKey: "2" },
-        ],
-        status: "loaded",
-        isOptimistic: false,
-        lastUpdated: Date.now(),
-        hasMore: false,
-        fetchMore: vitest.fn(),
-        totalCount: "2",
-      });
+      capturedObserver?.next(mockListPayload([
+        { name: "Item A", pk: "1" },
+        { name: "Item B", pk: "2" },
+      ]));
     });
 
     const count = await screen.findByTestId("count");
     expect(count.textContent).toBe("2");
     expect(screen.getByTestId("item-0").textContent).toBe("Item A");
     expect(screen.getByTestId("item-1").textContent).toBe("Item B");
-    expect(screen.getByTestId("total").textContent).toBe("2");
   });
 
   it("should re-suspend when where clause changes", async () => {
@@ -376,16 +354,9 @@ describe("useOsdkObjects with { suspense: true }", () => {
     );
 
     act(() => {
-      capturedObserver?.next({
-        resolvedList: [
-          { name: "Active Item", $objectType: "MockObject", $primaryKey: "1" },
-        ],
-        status: "loaded",
-        isOptimistic: false,
-        lastUpdated: Date.now(),
-        hasMore: false,
-        fetchMore: vitest.fn(),
-      });
+      capturedObserver?.next(
+        mockListPayload([{ name: "Active Item", pk: "1" }]),
+      );
     });
 
     const item0 = await screen.findByTestId("item-0");
@@ -406,20 +377,9 @@ describe("useOsdkObjects with { suspense: true }", () => {
     });
 
     await act(async () => {
-      secondObserver?.next({
-        resolvedList: [
-          {
-            name: "Inactive Item",
-            $objectType: "MockObject",
-            $primaryKey: "2",
-          },
-        ],
-        status: "loaded",
-        isOptimistic: false,
-        lastUpdated: Date.now(),
-        hasMore: false,
-        fetchMore: vitest.fn(),
-      });
+      secondObserver?.next(
+        mockListPayload([{ name: "Inactive Item", pk: "2" }]),
+      );
     });
 
     const newItem = await screen.findByTestId("item-0");

--- a/packages/react/test/useOsdkObjects.test.tsx
+++ b/packages/react/test/useOsdkObjects.test.tsx
@@ -30,6 +30,7 @@ import { useOsdkObjects } from "../src/new/useOsdkObjects.js";
 import {
   cleanupSuspenseTests,
   createMockObservableClient,
+  mockListPayload,
   TestSuspenseWrapper,
 } from "./suspenseTestUtils.js";
 
@@ -331,7 +332,7 @@ describe("useOsdkObjects with { suspense: true }", () => {
   }
 
   function ListComponent({ where }: { where?: Record<string, string> }) {
-    const { data, fetchMore, totalCount } = useOsdkObjects(
+    const { data } = useOsdkObjects(
       MockObjectTypeWithType,
       where
         ? { where, suspense: true as const }
@@ -346,13 +347,6 @@ describe("useOsdkObjects with { suspense: true }", () => {
         { "data-testid": "count" },
         String(data.length),
       ),
-      totalCount != null
-        ? React.createElement(
-          "div",
-          { "data-testid": "total" },
-          totalCount,
-        )
-        : null,
       data.map((item, i) =>
         React.createElement(
           "div",
@@ -360,13 +354,6 @@ describe("useOsdkObjects with { suspense: true }", () => {
           (item as Record<string, unknown>).name as string,
         )
       ),
-      fetchMore
-        ? React.createElement(
-          "button",
-          { "data-testid": "fetch-more", onClick: fetchMore },
-          "Load More",
-        )
-        : null,
     );
   }
 
@@ -385,25 +372,16 @@ describe("useOsdkObjects with { suspense: true }", () => {
     expect(mockObserveList).toHaveBeenCalledTimes(1);
 
     act(() => {
-      capturedObserver?.next({
-        resolvedList: [
-          { name: "Item A", $objectType: "MockObject", $primaryKey: "1" },
-          { name: "Item B", $objectType: "MockObject", $primaryKey: "2" },
-        ],
-        status: "loaded",
-        isOptimistic: false,
-        lastUpdated: Date.now(),
-        hasMore: false,
-        fetchMore: vitest.fn(),
-        totalCount: "2",
-      });
+      capturedObserver?.next(mockListPayload([
+        { name: "Item A", pk: "1" },
+        { name: "Item B", pk: "2" },
+      ]));
     });
 
     const count = await screen.findByTestId("count");
     expect(count.textContent).toBe("2");
     expect(screen.getByTestId("item-0").textContent).toBe("Item A");
     expect(screen.getByTestId("item-1").textContent).toBe("Item B");
-    expect(screen.getByTestId("total").textContent).toBe("2");
   });
 
   it("should re-suspend when where clause changes", async () => {
@@ -436,16 +414,9 @@ describe("useOsdkObjects with { suspense: true }", () => {
     );
 
     act(() => {
-      capturedObserver?.next({
-        resolvedList: [
-          { name: "Active Item", $objectType: "MockObject", $primaryKey: "1" },
-        ],
-        status: "loaded",
-        isOptimistic: false,
-        lastUpdated: Date.now(),
-        hasMore: false,
-        fetchMore: vitest.fn(),
-      });
+      capturedObserver?.next(
+        mockListPayload([{ name: "Active Item", pk: "1" }]),
+      );
     });
 
     const item0 = await screen.findByTestId("item-0");
@@ -466,20 +437,9 @@ describe("useOsdkObjects with { suspense: true }", () => {
     });
 
     await act(async () => {
-      secondObserver?.next({
-        resolvedList: [
-          {
-            name: "Inactive Item",
-            $objectType: "MockObject",
-            $primaryKey: "2",
-          },
-        ],
-        status: "loaded",
-        isOptimistic: false,
-        lastUpdated: Date.now(),
-        hasMore: false,
-        fetchMore: vitest.fn(),
-      });
+      secondObserver?.next(
+        mockListPayload([{ name: "Inactive Item", pk: "2" }]),
+      );
     });
 
     const newItem = await screen.findByTestId("item-0");

--- a/packages/react/test/useOsdkObjects.test.tsx
+++ b/packages/react/test/useOsdkObjects.test.tsx
@@ -15,11 +15,23 @@
  */
 
 import type { ObjectTypeDefinition } from "@osdk/api";
-import { act, renderHook } from "@testing-library/react";
+import type { Observer } from "@osdk/client/unstable-do-not-use";
+import {
+  act,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import * as React from "react";
-import { beforeEach, describe, expect, it, vitest } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vitest } from "vitest";
 import { OsdkContext } from "../src/new/OsdkContext.js";
 import { useOsdkObjects } from "../src/new/useOsdkObjects.js";
+import {
+  cleanupSuspenseTests,
+  createMockObservableClient,
+  TestSuspenseWrapper,
+} from "./suspenseTestUtils.js";
 
 const MockObjectType = {
   apiName: "MockObject",
@@ -282,5 +294,195 @@ describe("useOsdkObjects enabled option", () => {
     rerender({ withProperties: { leadName: () => "a" } });
 
     expect(mockObserveList).toHaveBeenCalledTimes(1);
+  });
+});
+
+const MockObjectTypeWithType = {
+  apiName: "MockObject",
+  primaryKeyType: "string",
+  type: "object",
+} as unknown as ObjectTypeDefinition;
+
+describe("useOsdkObjects with { suspense: true }", () => {
+  let mockObserveList: ReturnType<typeof vitest.fn>;
+  let capturedObserver:
+    | Observer<Record<string, unknown> | undefined>
+    | undefined;
+
+  beforeEach(() => {
+    capturedObserver = undefined;
+    mockObserveList = vitest.fn(
+      (
+        _opts: unknown,
+        observer: Observer<Record<string, unknown> | undefined>,
+      ) => {
+        capturedObserver = observer;
+        return { unsubscribe: vitest.fn() };
+      },
+    );
+  });
+
+  afterEach(cleanupSuspenseTests);
+
+  function createObservableClient() {
+    return createMockObservableClient({
+      observeList: mockObserveList,
+    });
+  }
+
+  function ListComponent({ where }: { where?: Record<string, string> }) {
+    const { data, fetchMore, totalCount } = useOsdkObjects(
+      MockObjectTypeWithType,
+      where
+        ? { where, suspense: true as const }
+        : { suspense: true as const },
+    );
+
+    return React.createElement(
+      "div",
+      null,
+      React.createElement(
+        "div",
+        { "data-testid": "count" },
+        String(data.length),
+      ),
+      totalCount != null
+        ? React.createElement(
+          "div",
+          { "data-testid": "total" },
+          totalCount,
+        )
+        : null,
+      data.map((item, i) =>
+        React.createElement(
+          "div",
+          { key: i, "data-testid": `item-${i}` },
+          (item as Record<string, unknown>).name as string,
+        )
+      ),
+      fetchMore
+        ? React.createElement(
+          "button",
+          { "data-testid": "fetch-more", onClick: fetchMore },
+          "Load More",
+        )
+        : null,
+    );
+  }
+
+  it("should suspend then render list data after loading", async () => {
+    const client = createObservableClient();
+
+    render(
+      React.createElement(
+        TestSuspenseWrapper,
+        { observableClient: client },
+        React.createElement(ListComponent, {}),
+      ),
+    );
+
+    expect(screen.getByTestId("loading")).toBeDefined();
+    expect(mockObserveList).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      capturedObserver?.next({
+        resolvedList: [
+          { name: "Item A", $objectType: "MockObject", $primaryKey: "1" },
+          { name: "Item B", $objectType: "MockObject", $primaryKey: "2" },
+        ],
+        status: "loaded",
+        isOptimistic: false,
+        lastUpdated: Date.now(),
+        hasMore: false,
+        fetchMore: vitest.fn(),
+        totalCount: "2",
+      });
+    });
+
+    const count = await screen.findByTestId("count");
+    expect(count.textContent).toBe("2");
+    expect(screen.getByTestId("item-0").textContent).toBe("Item A");
+    expect(screen.getByTestId("item-1").textContent).toBe("Item B");
+    expect(screen.getByTestId("total").textContent).toBe("2");
+  });
+
+  it("should re-suspend when where clause changes", async () => {
+    const client = createObservableClient();
+    let secondObserver:
+      | Observer<Record<string, unknown> | undefined>
+      | undefined;
+
+    mockObserveList.mockImplementation(
+      (
+        opts: Record<string, unknown>,
+        observer: Observer<Record<string, unknown> | undefined>,
+      ) => {
+        const where = opts.where as Record<string, string> | undefined;
+        if (where?.status === "active") {
+          capturedObserver = observer;
+        } else {
+          secondObserver = observer;
+        }
+        return { unsubscribe: vitest.fn() };
+      },
+    );
+
+    const { rerender } = render(
+      React.createElement(
+        TestSuspenseWrapper,
+        { observableClient: client },
+        React.createElement(ListComponent, { where: { status: "active" } }),
+      ),
+    );
+
+    act(() => {
+      capturedObserver?.next({
+        resolvedList: [
+          { name: "Active Item", $objectType: "MockObject", $primaryKey: "1" },
+        ],
+        status: "loaded",
+        isOptimistic: false,
+        lastUpdated: Date.now(),
+        hasMore: false,
+        fetchMore: vitest.fn(),
+      });
+    });
+
+    const item0 = await screen.findByTestId("item-0");
+    expect(item0.textContent).toBe("Active Item");
+
+    rerender(
+      React.createElement(
+        TestSuspenseWrapper,
+        { observableClient: client },
+        React.createElement(ListComponent, {
+          where: { status: "inactive" },
+        }),
+      ),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toBeDefined();
+    });
+
+    await act(async () => {
+      secondObserver?.next({
+        resolvedList: [
+          {
+            name: "Inactive Item",
+            $objectType: "MockObject",
+            $primaryKey: "2",
+          },
+        ],
+        status: "loaded",
+        isOptimistic: false,
+        lastUpdated: Date.now(),
+        hasMore: false,
+        fetchMore: vitest.fn(),
+      });
+    });
+
+    const newItem = await screen.findByTestId("item-0");
+    expect(newItem.textContent).toBe("Inactive Item");
   });
 });


### PR DESCRIPTION
add { suspense: true } option to useOsdkObject and useOsdkObjects hooks

• add suspense overloads that throw promises for React.Suspense and errors for ErrorBoundary
• return non-nullable data types in suspense mode (object/data guaranteed present after mount)
• skip wasteful base store creation in suspense path with shared observation factory