### PR TITLE
wire shapes into existing hooks, add test utilities and shape tests

### DIFF
--- a/.changeset/shapes-integration.md
+++ b/.changeset/shapes-integration.md
@@ -1,5 +1,6 @@
 ---
 "@osdk/react": patch
+"@osdk/client": patch
 ---
 
 wire shapes into existing hooks and add test utilities

--- a/.changeset/shapes-integration.md
+++ b/.changeset/shapes-integration.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react": patch
+---
+
+wire shapes into existing hooks and add test utilities

--- a/.changeset/shapes-integration.md
+++ b/.changeset/shapes-integration.md
@@ -1,0 +1,6 @@
+---
+"@osdk/react": patch
+"@osdk/client": patch
+---
+
+wire shapes into existing hooks and add test utilities

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -45,6 +45,15 @@
       "require": "./build/cjs/public/unstable-do-not-use.cjs",
       "default": "./build/browser/public/unstable-do-not-use.js"
     },
+    "./unstable": {
+      "browser": "./build/browser/public/unstable.js",
+      "import": {
+        "types": "./build/types/public/unstable.d.ts",
+        "default": "./build/esm/public/unstable.js"
+      },
+      "require": "./build/cjs/public/unstable.cjs",
+      "default": "./build/browser/public/unstable.js"
+    },
     "./*": {
       "browser": "./build/browser/public/*.js",
       "import": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -45,15 +45,6 @@
       "require": "./build/cjs/public/unstable-do-not-use.cjs",
       "default": "./build/browser/public/unstable-do-not-use.js"
     },
-    "./unstable": {
-      "browser": "./build/browser/public/unstable.js",
-      "import": {
-        "types": "./build/types/public/unstable.d.ts",
-        "default": "./build/esm/public/unstable.js"
-      },
-      "require": "./build/cjs/public/unstable.cjs",
-      "default": "./build/browser/public/unstable.js"
-    },
     "./*": {
       "browser": "./build/browser/public/*.js",
       "import": {

--- a/packages/react/src/new/useOsdkObject.ts
+++ b/packages/react/src/new/useOsdkObject.ts
@@ -16,14 +16,28 @@
 
 import type {
   ObjectOrInterfaceDefinition,
+  ObjectTypeDefinition,
   Osdk,
   PrimaryKeyType,
   PropertyKeys,
 } from "@osdk/api";
+import type {
+  InferShapeDefinition,
+  InlineShapeConfig,
+  LinkLoadConfig,
+  LinkStatus,
+  NullabilityViolation,
+  ShapeDefinition,
+  ShapeDerivedLinks,
+  ShapeInstance,
+} from "@osdk/api/unstable";
+import { configToShapeDefinition } from "@osdk/api/unstable";
 import type { ObserveObjectCallbackArgs } from "@osdk/client/observable";
 import React from "react";
 import { devToolsMetadata, makeExternalStore } from "./makeExternalStore.js";
 import { OsdkContext } from "./OsdkContext.js";
+import type { UseShapeResult } from "./shapes/useShape.js";
+import { useShapeSingle } from "./shapes/useShape.js";
 
 export interface UseOsdkObjectResult<
   Q extends ObjectOrInterfaceDefinition,
@@ -37,7 +51,48 @@ export interface UseOsdkObjectResult<
    * Refers to whether the object is optimistic or not.
    */
   isOptimistic: boolean;
-  forceUpdate: () => void;
+}
+
+/**
+ * Options for useOsdkObject with inline shape config.
+ */
+export interface UseOsdkObjectShapeOptions<
+  Q extends ObjectTypeDefinition,
+  C extends InlineShapeConfig<Q>,
+> {
+  shape: C;
+  enabled?: boolean;
+  links?: Partial<Record<string, LinkLoadConfig>>;
+}
+
+/**
+ * Result type for useOsdkObject with inline shape config.
+ */
+export interface UseOsdkObjectShapeResult<
+  Q extends ObjectTypeDefinition,
+  C extends InlineShapeConfig<Q>,
+> {
+  data: ShapeInstance<InferShapeDefinition<Q, C>> | undefined;
+  shape: InferShapeDefinition<Q, C>;
+  isLoading: boolean;
+  error: Error | undefined;
+  isOptimistic: boolean;
+  droppedDueToNullability: boolean;
+  nullabilityViolations: readonly NullabilityViolation[];
+  linkStatus: Partial<
+    {
+      [K in keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>]: LinkStatus;
+    }
+  >;
+  loadDeferred: (
+    linkName: keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>,
+  ) => void;
+  retry: (
+    linkName?: keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>,
+  ) => void;
+  invalidate: (
+    linkName?: keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>,
+  ) => void;
 }
 
 export interface UseOsdkObjectOptions<
@@ -93,11 +148,44 @@ export function useOsdkObject<
   primaryKey: PrimaryKeyType<Q>,
   options?: UseOsdkObjectOptions<Q>,
 ): UseOsdkObjectResult<Q>;
+/**
+ * Loads an object by type and primary key with an inline shape config.
+ * The shape defines nullability constraints, defaults, transforms, and derived links.
+ *
+ * @param type
+ * @param primaryKey
+ * @param options Options including the inline shape config
+ */
+export function useOsdkObject<
+  Q extends ObjectTypeDefinition,
+  const C extends InlineShapeConfig<Q>,
+>(
+  type: Q,
+  primaryKey: PrimaryKeyType<Q>,
+  options: UseOsdkObjectShapeOptions<Q, C>,
+): UseOsdkObjectShapeResult<Q, C>;
+/**
+ * Loads an object by type and primary key with a pre-built ShapeDefinition.
+ */
+export function useOsdkObject<
+  S extends ShapeDefinition<ObjectTypeDefinition>,
+>(
+  type: S extends ShapeDefinition<infer Q> ? Q : ObjectTypeDefinition,
+  primaryKey: PrimaryKeyType<
+    S extends ShapeDefinition<infer Q> ? Q : ObjectTypeDefinition
+  >,
+  options: {
+    shape: S;
+    enabled?: boolean;
+    links?: Partial<Record<string, LinkLoadConfig>>;
+  },
+): UseShapeResult<S>;
 /*
     Implementation of useOsdkObject
  */
 export function useOsdkObject<
   Q extends ObjectOrInterfaceDefinition,
+  C extends InlineShapeConfig<Q> = InlineShapeConfig<Q>,
 >(
   ...args:
     | [obj: Osdk.Instance<Q>, enabled?: boolean]
@@ -107,22 +195,167 @@ export function useOsdkObject<
       primaryKey: PrimaryKeyType<Q>,
       options?: UseOsdkObjectOptions<Q>,
     ]
+    | [
+      type: Q,
+      primaryKey: PrimaryKeyType<Q>,
+      options: UseOsdkObjectShapeOptions<
+        Q & ObjectTypeDefinition,
+        C & InlineShapeConfig<Q & ObjectTypeDefinition>
+      >,
+    ]
+    | [
+      type: Q,
+      primaryKey: PrimaryKeyType<Q>,
+      options: {
+        shape: ShapeDefinition<Q>;
+        enabled?: boolean;
+        links?: Partial<Record<string, LinkLoadConfig>>;
+      },
+    ]
+):
+  | UseOsdkObjectResult<Q>
+  | UseOsdkObjectShapeResult<
+    Q & ObjectTypeDefinition,
+    C & InlineShapeConfig<Q & ObjectTypeDefinition>
+  >
+  | UseShapeResult<ShapeDefinition<Q>>
+{
+  const isInstanceSignature = "$objectType" in args[0];
+
+  const hasShapeOptions = !isInstanceSignature
+    && args.length >= 3
+    && typeof args[2] === "object"
+    && args[2] != null
+    && "shape" in args[2];
+
+  const modeRef = React.useRef(hasShapeOptions);
+  if (modeRef.current !== hasShapeOptions) {
+    throw new Error(
+      "useOsdkObject: cannot switch between shape/non-shape mode",
+    );
+  }
+
+  if (hasShapeOptions) {
+    return useOsdkObjectWithShape(
+      args[0] as Q,
+      args[1] as PrimaryKeyType<Q>,
+      args[2] as {
+        shape: C | ShapeDefinition<Q>;
+        enabled?: boolean;
+        links?: Partial<Record<string, LinkLoadConfig>>;
+      },
+    );
+  }
+
+  // Original overloads (instance or type+pk)
+
+  return useOsdkObjectBase(
+    args as
+      | [obj: Osdk.Instance<Q>, enabled?: boolean]
+      | [type: Q, primaryKey: PrimaryKeyType<Q>, enabled?: boolean]
+      | [
+        type: Q,
+        primaryKey: PrimaryKeyType<Q>,
+        options?: UseOsdkObjectOptions<Q>,
+      ],
+  );
+}
+
+function useOsdkObjectWithShape<
+  Q extends ObjectOrInterfaceDefinition,
+  C extends InlineShapeConfig<Q> = InlineShapeConfig<Q>,
+>(
+  type: Q,
+  primaryKey: PrimaryKeyType<Q>,
+  options: {
+    shape: C | ShapeDefinition<Q>;
+    enabled?: boolean;
+    links?: Partial<Record<string, LinkLoadConfig>>;
+  },
+):
+  | UseOsdkObjectShapeResult<
+    Q & ObjectTypeDefinition,
+    C & InlineShapeConfig<Q & ObjectTypeDefinition>
+  >
+  | UseShapeResult<ShapeDefinition<Q>>
+{
+  const rawShape = options.shape;
+
+  const isPreBuilt = typeof rawShape === "object" && rawShape != null
+    && "__shapeId" in rawShape;
+
+  const configRef = React.useRef(rawShape);
+
+  const shapeDef = React.useMemo(() => {
+    const c = configRef.current;
+    if (typeof c === "object" && c != null && "__shapeId" in c) {
+      return c as ShapeDefinition<Q>;
+    }
+    return configToShapeDefinition(type, c as InlineShapeConfig<Q>);
+  }, [type]);
+
+  const result = useShapeSingle(
+    shapeDef,
+    primaryKey,
+    { enabled: options.enabled, links: options.links },
+  );
+
+  if (isPreBuilt) {
+    return result;
+  }
+
+  type ResolvedC = C & InlineShapeConfig<Q & ObjectTypeDefinition>;
+  type ResolvedQ = Q & ObjectTypeDefinition;
+
+  return {
+    data: result.data as
+      | ShapeInstance<InferShapeDefinition<ResolvedQ, ResolvedC>>
+      | undefined,
+    shape: shapeDef as InferShapeDefinition<ResolvedQ, ResolvedC>,
+    isLoading: result.isLoading,
+    error: result.error,
+    isOptimistic: result.isOptimistic,
+    droppedDueToNullability: result.droppedDueToNullability,
+    nullabilityViolations: result.nullabilityViolations,
+    linkStatus: result.linkStatus as UseOsdkObjectShapeResult<
+      ResolvedQ,
+      ResolvedC
+    >["linkStatus"],
+    loadDeferred: result.loadDeferred as UseOsdkObjectShapeResult<
+      ResolvedQ,
+      ResolvedC
+    >["loadDeferred"],
+    retry: result.retry as UseOsdkObjectShapeResult<
+      ResolvedQ,
+      ResolvedC
+    >["retry"],
+    invalidate: result.invalidate as UseOsdkObjectShapeResult<
+      ResolvedQ,
+      ResolvedC
+    >["invalidate"],
+  };
+}
+
+function useOsdkObjectBase<Q extends ObjectOrInterfaceDefinition>(
+  args:
+    | [obj: Osdk.Instance<Q>, enabled?: boolean]
+    | [type: Q, primaryKey: PrimaryKeyType<Q>, enabled?: boolean]
+    | [
+      type: Q,
+      primaryKey: PrimaryKeyType<Q>,
+      options?: UseOsdkObjectOptions<Q>,
+    ],
 ): UseOsdkObjectResult<Q> {
   const { observableClient } = React.useContext(OsdkContext);
 
-  // Check if first arg is an instance to discriminate signatures
-  // TypeScript cannot narrow rest parameter unions with optional parameters,
-  // so we must use type assertions after runtime discrimination
   const isInstanceSignature = "$objectType" in args[0];
 
-  // Extract options object if provided (3rd arg is an object with $select or enabled)
   const optionsArg = !isInstanceSignature
       && args[2] != null
       && typeof args[2] === "object"
     ? args[2]
     : undefined;
 
-  // Extract enabled flag - 2nd param for instance signature, 3rd for type signature
   const enabled = isInstanceSignature
     ? (typeof args[1] === "boolean" ? args[1] : true)
     : optionsArg
@@ -205,10 +438,6 @@ export function useOsdkObject<
 
   const payload = React.useSyncExternalStore(subscribe, getSnapShot);
 
-  const forceUpdate = React.useCallback(() => {
-    throw new Error("not implemented");
-  }, []);
-
   return React.useMemo(() => {
     let error: Error | undefined;
     if (payload && "error" in payload && payload.error) {
@@ -226,7 +455,6 @@ export function useOsdkObject<
         : false,
       isOptimistic: !!payload?.isOptimistic,
       error,
-      forceUpdate,
     };
-  }, [payload, enabled, forceUpdate]);
+  }, [payload, enabled]);
 }

--- a/packages/react/src/new/useOsdkObject.ts
+++ b/packages/react/src/new/useOsdkObject.ts
@@ -16,14 +16,28 @@
 
 import type {
   ObjectOrInterfaceDefinition,
+  ObjectTypeDefinition,
   Osdk,
   PrimaryKeyType,
   PropertyKeys,
 } from "@osdk/api";
+import type {
+  InferShapeDefinition,
+  InlineShapeConfig,
+  LinkLoadConfig,
+  LinkStatus,
+  NullabilityViolation,
+  ShapeDefinition,
+  ShapeDerivedLinks,
+  ShapeInstance,
+} from "@osdk/api/shapes";
+import { configToShapeDefinition } from "@osdk/api/shapes";
 import type { ObserveObjectCallbackArgs } from "@osdk/client/unstable-do-not-use";
 import React from "react";
 import { devToolsMetadata, makeExternalStore } from "./makeExternalStore.js";
 import { OsdkContext2 } from "./OsdkContext2.js";
+import type { UseShapeResult } from "./shapes/useShape.js";
+import { useShapeSingleInternal } from "./shapes/useShapeInternal.js";
 
 export interface UseOsdkObjectResult<
   Q extends ObjectOrInterfaceDefinition,
@@ -37,7 +51,48 @@ export interface UseOsdkObjectResult<
    * Refers to whether the object is optimistic or not.
    */
   isOptimistic: boolean;
-  forceUpdate: () => void;
+}
+
+/**
+ * Options for useOsdkObject with inline shape config.
+ */
+export interface UseOsdkObjectShapeOptions<
+  Q extends ObjectTypeDefinition,
+  C extends InlineShapeConfig<Q>,
+> {
+  shape: C;
+  enabled?: boolean;
+  links?: Partial<Record<string, LinkLoadConfig>>;
+}
+
+/**
+ * Result type for useOsdkObject with inline shape config.
+ */
+export interface UseOsdkObjectShapeResult<
+  Q extends ObjectTypeDefinition,
+  C extends InlineShapeConfig<Q>,
+> {
+  data: ShapeInstance<InferShapeDefinition<Q, C>> | undefined;
+  shape: InferShapeDefinition<Q, C>;
+  isLoading: boolean;
+  error: Error | undefined;
+  isOptimistic: boolean;
+  droppedDueToNullability: boolean;
+  nullabilityViolations: readonly NullabilityViolation[];
+  linkStatus: Partial<
+    {
+      [K in keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>]: LinkStatus;
+    }
+  >;
+  loadDeferred: (
+    linkName: keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>,
+  ) => Promise<void>;
+  retry: (
+    linkName?: keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>,
+  ) => void;
+  invalidate: (
+    linkName?: keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>,
+  ) => void;
 }
 
 /**
@@ -82,11 +137,44 @@ export function useOsdkObject<
     $loadPropertySecurityMetadata?: boolean;
   },
 ): UseOsdkObjectResult<Q>;
+/**
+ * Loads an object by type and primary key with an inline shape config.
+ * The shape defines nullability constraints, defaults, transforms, and derived links.
+ *
+ * @param type
+ * @param primaryKey
+ * @param options Options including the inline shape config
+ */
+export function useOsdkObject<
+  Q extends ObjectTypeDefinition,
+  const C extends InlineShapeConfig<Q>,
+>(
+  type: Q,
+  primaryKey: PrimaryKeyType<Q>,
+  options: UseOsdkObjectShapeOptions<Q, C>,
+): UseOsdkObjectShapeResult<Q, C>;
+/**
+ * Loads an object by type and primary key with a pre-built ShapeDefinition.
+ */
+export function useOsdkObject<
+  S extends ShapeDefinition<ObjectTypeDefinition>,
+>(
+  type: S extends ShapeDefinition<infer Q> ? Q : ObjectTypeDefinition,
+  primaryKey: PrimaryKeyType<
+    S extends ShapeDefinition<infer Q> ? Q : ObjectTypeDefinition
+  >,
+  options: {
+    shape: S;
+    enabled?: boolean;
+    links?: Partial<Record<string, LinkLoadConfig>>;
+  },
+): UseShapeResult<S>;
 /*
     Implementation of useOsdkObject
  */
 export function useOsdkObject<
   Q extends ObjectOrInterfaceDefinition,
+  C extends InlineShapeConfig<Q> = InlineShapeConfig<Q>,
 >(
   ...args:
     | [obj: Osdk.Instance<Q>, enabled?: boolean]
@@ -100,15 +188,151 @@ export function useOsdkObject<
         $loadPropertySecurityMetadata?: boolean;
       },
     ]
+    | [
+      type: Q,
+      primaryKey: PrimaryKeyType<Q>,
+      options: UseOsdkObjectShapeOptions<
+        Q & ObjectTypeDefinition,
+        C & InlineShapeConfig<Q & ObjectTypeDefinition>
+      >,
+    ]
+    | [
+      type: Q,
+      primaryKey: PrimaryKeyType<Q>,
+      options: {
+        shape: ShapeDefinition<Q>;
+        enabled?: boolean;
+        links?: Partial<Record<string, LinkLoadConfig>>;
+      },
+    ]
+):
+  | UseOsdkObjectResult<Q>
+  | UseOsdkObjectShapeResult<
+    Q & ObjectTypeDefinition,
+    C & InlineShapeConfig<Q & ObjectTypeDefinition>
+  >
+  | UseShapeResult<ShapeDefinition<Q>>
+{
+  const isInstanceSignature = "$objectType" in args[0];
+
+  const hasShapeOptions = !isInstanceSignature
+    && args.length >= 3
+    && typeof args[2] === "object"
+    && args[2] != null
+    && "shape" in args[2];
+
+  const modeRef = React.useRef(hasShapeOptions);
+  if (process.env.NODE_ENV !== "production") {
+    if (modeRef.current !== hasShapeOptions) {
+      throw new Error(
+        "useOsdkObject: cannot switch between shape/non-shape mode",
+      );
+    }
+  }
+
+  if (hasShapeOptions) {
+    const type = args[0] as Q;
+    const primaryKey = args[1] as PrimaryKeyType<Q>;
+    const rawShape = (args[2] as { shape: unknown }).shape;
+    const opts = args[2] as {
+      enabled?: boolean;
+      links?: Partial<Record<string, LinkLoadConfig>>;
+    };
+
+    if (process.env.NODE_ENV !== "production") {
+      const prevConfig = React.useRef(rawShape);
+      if (prevConfig.current !== rawShape) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          "useOsdkObject: shape config changed between renders. Shape configs should be static.",
+        );
+        prevConfig.current = rawShape;
+      }
+    }
+
+    const isPreBuilt = typeof rawShape === "object" && rawShape != null
+      && "__shapeId" in rawShape;
+
+    const configRef = React.useRef(rawShape);
+
+    const shapeDef = React.useMemo(() => {
+      const c = configRef.current;
+      if (typeof c === "object" && c != null && "__shapeId" in c) {
+        return c as ShapeDefinition<Q>;
+      }
+      return configToShapeDefinition(type, c as InlineShapeConfig<Q>);
+    }, [type]);
+
+    const result = useShapeSingleInternal(
+      shapeDef,
+      primaryKey,
+      { enabled: opts.enabled, links: opts.links },
+    );
+
+    if (isPreBuilt) {
+      return result;
+    }
+
+    type ResolvedC = C & InlineShapeConfig<Q & ObjectTypeDefinition>;
+    type ResolvedQ = Q & ObjectTypeDefinition;
+
+    return {
+      data: result.data as
+        | ShapeInstance<InferShapeDefinition<ResolvedQ, ResolvedC>>
+        | undefined,
+      shape: shapeDef as InferShapeDefinition<ResolvedQ, ResolvedC>,
+      isLoading: result.isLoading,
+      error: result.error,
+      isOptimistic: result.isOptimistic,
+      droppedDueToNullability: result.droppedDueToNullability,
+      nullabilityViolations: result.nullabilityViolations,
+      linkStatus: result.linkStatus as UseOsdkObjectShapeResult<
+        ResolvedQ,
+        ResolvedC
+      >["linkStatus"],
+      loadDeferred: result.loadDeferred as UseOsdkObjectShapeResult<
+        ResolvedQ,
+        ResolvedC
+      >["loadDeferred"],
+      retry: result.retry as UseOsdkObjectShapeResult<
+        ResolvedQ,
+        ResolvedC
+      >["retry"],
+      invalidate: result.invalidate as UseOsdkObjectShapeResult<
+        ResolvedQ,
+        ResolvedC
+      >["invalidate"],
+    };
+  }
+
+  // Original overloads (instance or type+pk)
+
+  return useOsdkObjectBase(
+    args as
+      | [obj: Osdk.Instance<Q>, enabled?: boolean]
+      | [type: Q, primaryKey: PrimaryKeyType<Q>, enabled?: boolean]
+      | [
+        type: Q,
+        primaryKey: PrimaryKeyType<Q>,
+        options?: { $select?: readonly PropertyKeys<Q>[]; enabled?: boolean },
+      ],
+  );
+}
+
+function useOsdkObjectBase<Q extends ObjectOrInterfaceDefinition>(
+  args:
+    | [obj: Osdk.Instance<Q>, enabled?: boolean]
+    | [type: Q, primaryKey: PrimaryKeyType<Q>, enabled?: boolean]
+    | [
+      type: Q,
+      primaryKey: PrimaryKeyType<Q>,
+      options?: { $select?: readonly PropertyKeys<Q>[]; enabled?: boolean },
+    ],
 ): UseOsdkObjectResult<Q> {
   const { observableClient } = React.useContext(OsdkContext2);
 
-  // Check if first arg is an instance to discriminate signatures
-  // TypeScript cannot narrow rest parameter unions with optional parameters,
-  // so we must use type assertions after runtime discrimination
   const isInstanceSignature = "$objectType" in args[0];
 
-  // Extract options object if provided (3rd arg is an object with $select or enabled)
   const optionsArg = !isInstanceSignature
       && args[2] != null
       && typeof args[2] === "object"
@@ -119,7 +343,6 @@ export function useOsdkObject<
     }
     : undefined;
 
-  // Extract enabled flag - 2nd param for instance signature, 3rd for type signature
   const enabled = isInstanceSignature
     ? (typeof args[1] === "boolean" ? args[1] : true)
     : optionsArg

--- a/packages/react/src/new/useOsdkObject.ts
+++ b/packages/react/src/new/useOsdkObject.ts
@@ -30,8 +30,8 @@ import type {
   ShapeDefinition,
   ShapeDerivedLinks,
   ShapeInstance,
-} from "@osdk/api/shapes";
-import { configToShapeDefinition } from "@osdk/api/shapes";
+} from "@osdk/api/unstable";
+import { configToShapeDefinition } from "@osdk/api/unstable";
 import type { ObserveObjectCallbackArgs } from "@osdk/client/unstable-do-not-use";
 import React from "react";
 import { devToolsMetadata, makeExternalStore } from "./makeExternalStore.js";

--- a/packages/react/src/new/useOsdkObject.ts
+++ b/packages/react/src/new/useOsdkObject.ts
@@ -274,17 +274,6 @@ function useOsdkObjectWithShape<
 {
   const rawShape = options.shape;
 
-  const prevConfig = React.useRef(rawShape);
-  if (process.env.NODE_ENV !== "production") {
-    if (prevConfig.current !== rawShape) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        "useOsdkObject: shape config changed between renders. Shape configs should be static.",
-      );
-      prevConfig.current = rawShape;
-    }
-  }
-
   const isPreBuilt = typeof rawShape === "object" && rawShape != null
     && "__shapeId" in rawShape;
 

--- a/packages/react/src/new/useOsdkObject.ts
+++ b/packages/react/src/new/useOsdkObject.ts
@@ -37,7 +37,7 @@ import React from "react";
 import { devToolsMetadata, makeExternalStore } from "./makeExternalStore.js";
 import { OsdkContext2 } from "./OsdkContext2.js";
 import type { UseShapeResult } from "./shapes/useShape.js";
-import { useShapeSingleInternal } from "./shapes/useShapeInternal.js";
+import { useShapeSingle } from "./shapes/useShape.js";
 
 export interface UseOsdkObjectResult<
   Q extends ObjectOrInterfaceDefinition,
@@ -298,7 +298,7 @@ function useOsdkObjectWithShape<
     return configToShapeDefinition(type, c as InlineShapeConfig<Q>);
   }, [type]);
 
-  const result = useShapeSingleInternal(
+  const result = useShapeSingle(
     shapeDef,
     primaryKey,
     { enabled: options.enabled, links: options.links },

--- a/packages/react/src/new/useOsdkObject.ts
+++ b/packages/react/src/new/useOsdkObject.ts
@@ -231,78 +231,15 @@ export function useOsdkObject<
   }
 
   if (hasShapeOptions) {
-    const type = args[0] as Q;
-    const primaryKey = args[1] as PrimaryKeyType<Q>;
-    const rawShape = (args[2] as { shape: unknown }).shape;
-    const opts = args[2] as {
-      enabled?: boolean;
-      links?: Partial<Record<string, LinkLoadConfig>>;
-    };
-
-    const prevConfig = React.useRef(rawShape);
-    if (process.env.NODE_ENV !== "production") {
-      if (prevConfig.current !== rawShape) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          "useOsdkObject: shape config changed between renders. Shape configs should be static.",
-        );
-        prevConfig.current = rawShape;
-      }
-    }
-
-    const isPreBuilt = typeof rawShape === "object" && rawShape != null
-      && "__shapeId" in rawShape;
-
-    const configRef = React.useRef(rawShape);
-
-    const shapeDef = React.useMemo(() => {
-      const c = configRef.current;
-      if (typeof c === "object" && c != null && "__shapeId" in c) {
-        return c as ShapeDefinition<Q>;
-      }
-      return configToShapeDefinition(type, c as InlineShapeConfig<Q>);
-    }, [type]);
-
-    const result = useShapeSingleInternal(
-      shapeDef,
-      primaryKey,
-      { enabled: opts.enabled, links: opts.links },
+    return useOsdkObjectWithShape(
+      args[0] as Q,
+      args[1] as PrimaryKeyType<Q>,
+      args[2] as {
+        shape: C | ShapeDefinition<Q>;
+        enabled?: boolean;
+        links?: Partial<Record<string, LinkLoadConfig>>;
+      },
     );
-
-    if (isPreBuilt) {
-      return result;
-    }
-
-    type ResolvedC = C & InlineShapeConfig<Q & ObjectTypeDefinition>;
-    type ResolvedQ = Q & ObjectTypeDefinition;
-
-    return {
-      data: result.data as
-        | ShapeInstance<InferShapeDefinition<ResolvedQ, ResolvedC>>
-        | undefined,
-      shape: shapeDef as InferShapeDefinition<ResolvedQ, ResolvedC>,
-      isLoading: result.isLoading,
-      error: result.error,
-      isOptimistic: result.isOptimistic,
-      droppedDueToNullability: result.droppedDueToNullability,
-      nullabilityViolations: result.nullabilityViolations,
-      linkStatus: result.linkStatus as UseOsdkObjectShapeResult<
-        ResolvedQ,
-        ResolvedC
-      >["linkStatus"],
-      loadDeferred: result.loadDeferred as UseOsdkObjectShapeResult<
-        ResolvedQ,
-        ResolvedC
-      >["loadDeferred"],
-      retry: result.retry as UseOsdkObjectShapeResult<
-        ResolvedQ,
-        ResolvedC
-      >["retry"],
-      invalidate: result.invalidate as UseOsdkObjectShapeResult<
-        ResolvedQ,
-        ResolvedC
-      >["invalidate"],
-    };
   }
 
   // Original overloads (instance or type+pk)
@@ -317,6 +254,92 @@ export function useOsdkObject<
         options?: { $select?: readonly PropertyKeys<Q>[]; enabled?: boolean },
       ],
   );
+}
+
+function useOsdkObjectWithShape<
+  Q extends ObjectOrInterfaceDefinition,
+  C extends InlineShapeConfig<Q> = InlineShapeConfig<Q>,
+>(
+  type: Q,
+  primaryKey: PrimaryKeyType<Q>,
+  options: {
+    shape: C | ShapeDefinition<Q>;
+    enabled?: boolean;
+    links?: Partial<Record<string, LinkLoadConfig>>;
+  },
+):
+  | UseOsdkObjectShapeResult<
+    Q & ObjectTypeDefinition,
+    C & InlineShapeConfig<Q & ObjectTypeDefinition>
+  >
+  | UseShapeResult<ShapeDefinition<Q>>
+{
+  const rawShape = options.shape;
+
+  const prevConfig = React.useRef(rawShape);
+  if (process.env.NODE_ENV !== "production") {
+    if (prevConfig.current !== rawShape) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "useOsdkObject: shape config changed between renders. Shape configs should be static.",
+      );
+      prevConfig.current = rawShape;
+    }
+  }
+
+  const isPreBuilt = typeof rawShape === "object" && rawShape != null
+    && "__shapeId" in rawShape;
+
+  const configRef = React.useRef(rawShape);
+
+  const shapeDef = React.useMemo(() => {
+    const c = configRef.current;
+    if (typeof c === "object" && c != null && "__shapeId" in c) {
+      return c as ShapeDefinition<Q>;
+    }
+    return configToShapeDefinition(type, c as InlineShapeConfig<Q>);
+  }, [type]);
+
+  const result = useShapeSingleInternal(
+    shapeDef,
+    primaryKey,
+    { enabled: options.enabled, links: options.links },
+  );
+
+  if (isPreBuilt) {
+    return result;
+  }
+
+  type ResolvedC = C & InlineShapeConfig<Q & ObjectTypeDefinition>;
+  type ResolvedQ = Q & ObjectTypeDefinition;
+
+  return {
+    data: result.data as
+      | ShapeInstance<InferShapeDefinition<ResolvedQ, ResolvedC>>
+      | undefined,
+    shape: shapeDef as InferShapeDefinition<ResolvedQ, ResolvedC>,
+    isLoading: result.isLoading,
+    error: result.error,
+    isOptimistic: result.isOptimistic,
+    droppedDueToNullability: result.droppedDueToNullability,
+    nullabilityViolations: result.nullabilityViolations,
+    linkStatus: result.linkStatus as UseOsdkObjectShapeResult<
+      ResolvedQ,
+      ResolvedC
+    >["linkStatus"],
+    loadDeferred: result.loadDeferred as UseOsdkObjectShapeResult<
+      ResolvedQ,
+      ResolvedC
+    >["loadDeferred"],
+    retry: result.retry as UseOsdkObjectShapeResult<
+      ResolvedQ,
+      ResolvedC
+    >["retry"],
+    invalidate: result.invalidate as UseOsdkObjectShapeResult<
+      ResolvedQ,
+      ResolvedC
+    >["invalidate"],
+  };
 }
 
 function useOsdkObjectBase<Q extends ObjectOrInterfaceDefinition>(

--- a/packages/react/src/new/useOsdkObject.ts
+++ b/packages/react/src/new/useOsdkObject.ts
@@ -222,12 +222,10 @@ export function useOsdkObject<
     && "shape" in args[2];
 
   const modeRef = React.useRef(hasShapeOptions);
-  if (process.env.NODE_ENV !== "production") {
-    if (modeRef.current !== hasShapeOptions) {
-      throw new Error(
-        "useOsdkObject: cannot switch between shape/non-shape mode",
-      );
-    }
+  if (modeRef.current !== hasShapeOptions) {
+    throw new Error(
+      "useOsdkObject: cannot switch between shape/non-shape mode",
+    );
   }
 
   if (hasShapeOptions) {

--- a/packages/react/src/new/useOsdkObject.ts
+++ b/packages/react/src/new/useOsdkObject.ts
@@ -86,7 +86,7 @@ export interface UseOsdkObjectShapeResult<
   >;
   loadDeferred: (
     linkName: keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>,
-  ) => Promise<void>;
+  ) => void;
   retry: (
     linkName?: keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>,
   ) => void;

--- a/packages/react/src/new/useOsdkObject.ts
+++ b/packages/react/src/new/useOsdkObject.ts
@@ -239,8 +239,8 @@ export function useOsdkObject<
       links?: Partial<Record<string, LinkLoadConfig>>;
     };
 
+    const prevConfig = React.useRef(rawShape);
     if (process.env.NODE_ENV !== "production") {
-      const prevConfig = React.useRef(rawShape);
       if (prevConfig.current !== rawShape) {
         // eslint-disable-next-line no-console
         console.warn(
@@ -421,10 +421,6 @@ function useOsdkObjectBase<Q extends ObjectOrInterfaceDefinition>(
 
   const payload = React.useSyncExternalStore(subscribe, getSnapShot);
 
-  const forceUpdate = React.useCallback(() => {
-    throw new Error("not implemented");
-  }, []);
-
   return React.useMemo(() => {
     let error: Error | undefined;
     if (payload && "error" in payload && payload.error) {
@@ -441,7 +437,6 @@ function useOsdkObjectBase<Q extends ObjectOrInterfaceDefinition>(
         : false,
       isOptimistic: !!payload?.isOptimistic,
       error,
-      forceUpdate,
     };
-  }, [payload, enabled, forceUpdate]);
+  }, [payload, enabled]);
 }

--- a/packages/react/src/new/useOsdkObjects.ts
+++ b/packages/react/src/new/useOsdkObjects.ts
@@ -25,11 +25,23 @@ import type {
   SimplePropertyDef,
   WhereClause,
 } from "@osdk/api";
+import type {
+  InferShapeDefinition,
+  InlineShapeConfig,
+  LinkStatus,
+  NullabilityViolation,
+  ShapeDefinition,
+  ShapeDerivedLinks,
+  ShapeInstance,
+} from "@osdk/api/shapes";
+import { configToShapeDefinition } from "@osdk/api/shapes";
 import type { ObserveObjectsCallbackArgs } from "@osdk/client/unstable-do-not-use";
 import React from "react";
 import { extractPayloadError, isPayloadLoading } from "./hookUtils.js";
 import { devToolsMetadata, makeExternalStore } from "./makeExternalStore.js";
 import { OsdkContext2 } from "./OsdkContext2.js";
+import type { PerItemLinkStatus } from "./shapes/useShape.js";
+import { useShapeListInternal } from "./shapes/useShapeInternal.js";
 
 export interface UseOsdkObjectsOptions<
   T extends ObjectOrInterfaceDefinition,
@@ -205,6 +217,39 @@ export interface UseOsdkListResult<
   refetch: () => Promise<void>;
 }
 
+export interface UseOsdkObjectsShapeResult<
+  Q extends ObjectOrInterfaceDefinition,
+  C extends InlineShapeConfig<Q>,
+> {
+  data: ShapeInstance<InferShapeDefinition<Q, C>>[] | undefined;
+  shape: InferShapeDefinition<Q, C>;
+  isLoading: boolean;
+  error: Error | undefined;
+  isOptimistic: boolean;
+  fetchMore: (() => Promise<void>) | undefined;
+  droppedCount: number;
+  nullabilityViolations: readonly NullabilityViolation[];
+  itemLinkStatus: PerItemLinkStatus<InferShapeDefinition<Q, C>>;
+  linkStatus: Partial<
+    {
+      [K in keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>]: LinkStatus;
+    }
+  >;
+  loadDeferred: (
+    primaryKey: string | number,
+    linkName: keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>,
+  ) => Promise<void>;
+  retry: (
+    primaryKey?: string | number,
+    linkName?: keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>,
+  ) => void;
+  invalidate: (
+    linkName?: keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>,
+  ) => void;
+}
+
+const EMPTY_WHERE = {};
+
 // pivotTo overloads: streamUpdates is forbidden (the server does not support
 // websocket subscriptions for link-traversal queries).
 export function useOsdkObjects<
@@ -224,7 +269,11 @@ export function useOsdkObjects<
   L extends LinkNames<Q>,
 >(
   type: Q,
+<<<<<<< HEAD
   options: UseOsdkObjectsOptions<Q> & { pivotTo: L; streamUpdates?: never },
+=======
+  options: UseOsdkObjectsOptions<Q> & { pivotTo: L; shape?: never },
+>>>>>>> 50861f5d5 (wire shapes into existing hooks, add test utilities and shape tests)
 ): UseOsdkListResult<LinkedType<Q, L>>;
 
 // Non-pivotTo overloads: pivotTo is forbidden to prevent fallthrough from the
@@ -242,6 +291,19 @@ export function useOsdkObjects<
 
 export function useOsdkObjects<
   Q extends ObjectOrInterfaceDefinition,
+  const C extends InlineShapeConfig<Q>,
+>(
+  type: Q,
+  options:
+    & Omit<
+      UseOsdkObjectsOptions<Q>,
+      "pivotTo" | "withProperties" | "rids" | "intersectWith"
+    >
+    & { shape: C; pivotTo?: never },
+): UseOsdkObjectsShapeResult<Q, C>;
+
+export function useOsdkObjects<
+  Q extends ObjectOrInterfaceDefinition,
   RDPs extends Record<string, SimplePropertyDef> = {},
 >(
   type: Q,
@@ -249,6 +311,42 @@ export function useOsdkObjects<
 ): UseOsdkListResult<Q, RDPs>;
 
 export function useOsdkObjects<
+  Q extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef> = {},
+  C extends InlineShapeConfig<Q> = InlineShapeConfig<Q>,
+>(
+  type: Q,
+  options?: UseOsdkObjectsOptions<Q, RDPs> & { shape?: C },
+):
+  | UseOsdkListResult<Q, RDPs>
+  | UseOsdkListResult<Q, RDPs, "$rid">
+  | UseOsdkListResult<LinkedType<Q, LinkNames<Q>>>
+  | UseOsdkListResult<LinkedType<Q, LinkNames<Q>>, {}, "$rid">
+  | UseOsdkObjectsShapeResult<Q, C>
+{
+  const hasShape = options !== undefined && "shape" in options
+    && options.shape !== undefined;
+
+  const modeRef = React.useRef(hasShape);
+  if (process.env.NODE_ENV !== "production") {
+    if (modeRef.current !== hasShape) {
+      throw new Error(
+        "useOsdkObjects: cannot switch between shape/non-shape mode",
+      );
+    }
+  }
+
+  if (hasShape) {
+    return useOsdkObjectsWithShape(
+      type,
+      options as UseOsdkObjectsOptions<Q> & { shape: C },
+    );
+  }
+
+  return useOsdkObjectsBase(type, options);
+}
+
+function useOsdkObjectsBase<
   Q extends ObjectOrInterfaceDefinition,
   RDPs extends Record<string, SimplePropertyDef> = {},
 >(
@@ -263,11 +361,11 @@ export function useOsdkObjects<
   const { observableClient } = React.useContext(OsdkContext2);
 
   const {
+    rids,
     pageSize,
     dedupeIntervalMs,
     withProperties,
     enabled = true,
-    rids,
     where,
     orderBy,
     streamUpdates,
@@ -374,4 +472,70 @@ export function useOsdkObjects<
     objectSet: listPayload?.objectSet,
     refetch,
   }), [listPayload, enabled, refetch]);
+}
+
+function useOsdkObjectsWithShape<
+  Q extends ObjectOrInterfaceDefinition,
+  C extends InlineShapeConfig<Q>,
+>(
+  type: Q,
+  options: UseOsdkObjectsOptions<Q> & { shape: C },
+): UseOsdkObjectsShapeResult<Q, C> {
+  type S = InferShapeDefinition<Q, C>;
+
+  if (process.env.NODE_ENV !== "production") {
+    const prevConfig = React.useRef(options.shape);
+    if (prevConfig.current !== options.shape) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "useOsdkObjects: shape config changed between renders. Shape configs should be static.",
+      );
+      prevConfig.current = options.shape;
+    }
+  }
+
+  const configRef = React.useRef(options.shape);
+  const shapeDef = React.useMemo(
+    () => configToShapeDefinition(type, configRef.current),
+    [type],
+  ) as S;
+
+  const result = useShapeListInternal(
+    shapeDef as ShapeDefinition<Q>,
+    {
+      where: options.where,
+      pageSize: options.pageSize,
+      orderBy: options.orderBy,
+      autoFetchMore: options.autoFetchMore,
+      dedupeIntervalMs: options.dedupeIntervalMs,
+      streamUpdates: options.streamUpdates,
+      enabled: options.enabled,
+      links: undefined,
+    },
+  );
+
+  return {
+    data: result.data as ShapeInstance<S>[] | undefined,
+    shape: shapeDef,
+    isLoading: result.isLoading,
+    error: result.error,
+    isOptimistic: result.isOptimistic,
+    fetchMore: result.fetchMore,
+    droppedCount: result.droppedCount,
+    nullabilityViolations: result.nullabilityViolations,
+    itemLinkStatus: result.itemLinkStatus as PerItemLinkStatus<S>,
+    linkStatus: result.linkStatus as UseOsdkObjectsShapeResult<
+      Q,
+      C
+    >["linkStatus"],
+    loadDeferred: result.loadDeferred as UseOsdkObjectsShapeResult<
+      Q,
+      C
+    >["loadDeferred"],
+    retry: result.retry as UseOsdkObjectsShapeResult<Q, C>["retry"],
+    invalidate: result.invalidate as UseOsdkObjectsShapeResult<
+      Q,
+      C
+    >["invalidate"],
+  };
 }

--- a/packages/react/src/new/useOsdkObjects.ts
+++ b/packages/react/src/new/useOsdkObjects.ts
@@ -41,7 +41,7 @@ import { extractPayloadError, isPayloadLoading } from "./hookUtils.js";
 import { devToolsMetadata, makeExternalStore } from "./makeExternalStore.js";
 import { OsdkContext2 } from "./OsdkContext2.js";
 import type { PerItemLinkStatus } from "./shapes/useShape.js";
-import { useShapeListInternal } from "./shapes/useShapeInternal.js";
+import { useShapeList } from "./shapes/useShape.js";
 
 export interface UseOsdkObjectsOptions<
   T extends ObjectOrInterfaceDefinition,
@@ -498,7 +498,7 @@ function useOsdkObjectsWithShape<
     [type],
   ) as S;
 
-  const result = useShapeListInternal(
+  const result = useShapeList(
     shapeDef as ShapeDefinition<Q>,
     {
       where: options.where,

--- a/packages/react/src/new/useOsdkObjects.ts
+++ b/packages/react/src/new/useOsdkObjects.ts
@@ -269,11 +269,11 @@ export function useOsdkObjects<
   L extends LinkNames<Q>,
 >(
   type: Q,
-<<<<<<< HEAD
-  options: UseOsdkObjectsOptions<Q> & { pivotTo: L; streamUpdates?: never },
-=======
-  options: UseOsdkObjectsOptions<Q> & { pivotTo: L; shape?: never },
->>>>>>> 50861f5d5 (wire shapes into existing hooks, add test utilities and shape tests)
+  options: UseOsdkObjectsOptions<Q> & {
+    pivotTo: L;
+    streamUpdates?: never;
+    shape?: never;
+  },
 ): UseOsdkListResult<LinkedType<Q, L>>;
 
 // Non-pivotTo overloads: pivotTo is forbidden to prevent fallthrough from the

--- a/packages/react/src/new/useOsdkObjects.ts
+++ b/packages/react/src/new/useOsdkObjects.ts
@@ -238,7 +238,7 @@ export interface UseOsdkObjectsShapeResult<
   loadDeferred: (
     primaryKey: string | number,
     linkName: keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>,
-  ) => Promise<void>;
+  ) => void;
   retry: (
     primaryKey?: string | number,
     linkName?: keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>,

--- a/packages/react/src/new/useOsdkObjects.ts
+++ b/packages/react/src/new/useOsdkObjects.ts
@@ -481,17 +481,6 @@ function useOsdkObjectsWithShape<
 ): UseOsdkObjectsShapeResult<Q, C> {
   type S = InferShapeDefinition<Q, C>;
 
-  const prevConfig = React.useRef(options.shape);
-  if (process.env.NODE_ENV !== "production") {
-    if (prevConfig.current !== options.shape) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        "useOsdkObjects: shape config changed between renders. Shape configs should be static.",
-      );
-      prevConfig.current = options.shape;
-    }
-  }
-
   const configRef = React.useRef(options.shape);
   const shapeDef = React.useMemo(
     () => configToShapeDefinition(type, configRef.current),

--- a/packages/react/src/new/useOsdkObjects.ts
+++ b/packages/react/src/new/useOsdkObjects.ts
@@ -33,8 +33,8 @@ import type {
   ShapeDefinition,
   ShapeDerivedLinks,
   ShapeInstance,
-} from "@osdk/api/shapes";
-import { configToShapeDefinition } from "@osdk/api/shapes";
+} from "@osdk/api/unstable";
+import { configToShapeDefinition } from "@osdk/api/unstable";
 import type { ObserveObjectsCallbackArgs } from "@osdk/client/unstable-do-not-use";
 import React from "react";
 import { extractPayloadError, isPayloadLoading } from "./hookUtils.js";

--- a/packages/react/src/new/useOsdkObjects.ts
+++ b/packages/react/src/new/useOsdkObjects.ts
@@ -483,8 +483,8 @@ function useOsdkObjectsWithShape<
 ): UseOsdkObjectsShapeResult<Q, C> {
   type S = InferShapeDefinition<Q, C>;
 
+  const prevConfig = React.useRef(options.shape);
   if (process.env.NODE_ENV !== "production") {
-    const prevConfig = React.useRef(options.shape);
     if (prevConfig.current !== options.shape) {
       // eslint-disable-next-line no-console
       console.warn(

--- a/packages/react/src/new/useOsdkObjects.ts
+++ b/packages/react/src/new/useOsdkObjects.ts
@@ -328,12 +328,10 @@ export function useOsdkObjects<
     && options.shape !== undefined;
 
   const modeRef = React.useRef(hasShape);
-  if (process.env.NODE_ENV !== "production") {
-    if (modeRef.current !== hasShape) {
-      throw new Error(
-        "useOsdkObjects: cannot switch between shape/non-shape mode",
-      );
-    }
+  if (modeRef.current !== hasShape) {
+    throw new Error(
+      "useOsdkObjects: cannot switch between shape/non-shape mode",
+    );
   }
 
   if (hasShape) {

--- a/packages/react/src/new/useOsdkObjects.ts
+++ b/packages/react/src/new/useOsdkObjects.ts
@@ -25,11 +25,23 @@ import type {
   SimplePropertyDef,
   WhereClause,
 } from "@osdk/api";
+import type {
+  InferShapeDefinition,
+  InlineShapeConfig,
+  LinkStatus,
+  NullabilityViolation,
+  ShapeDefinition,
+  ShapeDerivedLinks,
+  ShapeInstance,
+} from "@osdk/api/unstable";
+import { configToShapeDefinition } from "@osdk/api/unstable";
 import type { ObserveObjectsCallbackArgs } from "@osdk/client/observable";
 import React from "react";
 import { extractPayloadError, isPayloadLoading } from "./hookUtils.js";
 import { devToolsMetadata, makeExternalStore } from "./makeExternalStore.js";
 import { OsdkContext } from "./OsdkContext.js";
+import type { PerItemLinkStatus } from "./shapes/useShape.js";
+import { useShapeList } from "./shapes/useShape.js";
 
 /**
  * Restricts `resolveToObjectType` to interface queries only.
@@ -232,6 +244,39 @@ export interface UseOsdkListResult<
   refetch: () => Promise<void>;
 }
 
+export interface UseOsdkObjectsShapeResult<
+  Q extends ObjectOrInterfaceDefinition,
+  C extends InlineShapeConfig<Q>,
+> {
+  data: ShapeInstance<InferShapeDefinition<Q, C>>[] | undefined;
+  shape: InferShapeDefinition<Q, C>;
+  isLoading: boolean;
+  error: Error | undefined;
+  isOptimistic: boolean;
+  fetchMore: (() => Promise<void>) | undefined;
+  droppedCount: number;
+  nullabilityViolations: readonly NullabilityViolation[];
+  itemLinkStatus: PerItemLinkStatus<InferShapeDefinition<Q, C>>;
+  linkStatus: Partial<
+    {
+      [K in keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>]: LinkStatus;
+    }
+  >;
+  loadDeferred: (
+    primaryKey: string | number,
+    linkName: keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>,
+  ) => void;
+  retry: (
+    primaryKey?: string | number,
+    linkName?: keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>,
+  ) => void;
+  invalidate: (
+    linkName?: keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>,
+  ) => void;
+}
+
+const EMPTY_WHERE = {};
+
 // pivotTo overloads: streamUpdates is forbidden (the server does not support
 // websocket subscriptions for link-traversal queries).
 export function useOsdkObjects<
@@ -254,6 +299,7 @@ export function useOsdkObjects<
   options: UseOsdkObjectsOptions<Q, {}> & {
     pivotTo: L;
     streamUpdates?: never;
+    shape?: never;
   },
 ): UseOsdkListResult<LinkedType<Q, L>, {}>;
 
@@ -272,6 +318,19 @@ export function useOsdkObjects<
 
 export function useOsdkObjects<
   Q extends ObjectOrInterfaceDefinition,
+  const C extends InlineShapeConfig<Q>,
+>(
+  type: Q,
+  options:
+    & Omit<
+      UseOsdkObjectsOptions<Q>,
+      "pivotTo" | "withProperties" | "rids" | "intersectWith"
+    >
+    & { shape: C; pivotTo?: never },
+): UseOsdkObjectsShapeResult<Q, C>;
+
+export function useOsdkObjects<
+  Q extends ObjectOrInterfaceDefinition,
   RDPs extends Record<string, SimplePropertyDef> = {},
 >(
   type: Q,
@@ -281,6 +340,40 @@ export function useOsdkObjects<
 ): UseOsdkListResult<Q, RDPs>;
 
 export function useOsdkObjects<
+  Q extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef> = {},
+  C extends InlineShapeConfig<Q> = InlineShapeConfig<Q>,
+>(
+  type: Q,
+  options?: UseOsdkObjectsOptions<Q, RDPs> & { shape?: C },
+):
+  | UseOsdkListResult<Q, RDPs>
+  | UseOsdkListResult<Q, RDPs, "$rid">
+  | UseOsdkListResult<LinkedType<Q, LinkNames<Q>>>
+  | UseOsdkListResult<LinkedType<Q, LinkNames<Q>>, {}, "$rid">
+  | UseOsdkObjectsShapeResult<Q, C>
+{
+  const hasShape = options !== undefined && "shape" in options
+    && options.shape !== undefined;
+
+  const modeRef = React.useRef(hasShape);
+  if (modeRef.current !== hasShape) {
+    throw new Error(
+      "useOsdkObjects: cannot switch between shape/non-shape mode",
+    );
+  }
+
+  if (hasShape) {
+    return useOsdkObjectsWithShape(
+      type,
+      options as UseOsdkObjectsOptions<Q> & { shape: C },
+    );
+  }
+
+  return useOsdkObjectsBase(type, options);
+}
+
+function useOsdkObjectsBase<
   Q extends ObjectOrInterfaceDefinition,
   RDPs extends Record<string, SimplePropertyDef> = {},
 >(
@@ -295,11 +388,11 @@ export function useOsdkObjects<
   const { observableClient } = React.useContext(OsdkContext);
 
   const {
+    rids,
     pageSize,
     dedupeIntervalMs,
     withProperties,
     enabled = true,
-    rids,
     where,
     orderBy,
     streamUpdates,
@@ -411,4 +504,59 @@ export function useOsdkObjects<
     }),
     [listPayload, enabled, refetch],
   );
+}
+
+function useOsdkObjectsWithShape<
+  Q extends ObjectOrInterfaceDefinition,
+  C extends InlineShapeConfig<Q>,
+>(
+  type: Q,
+  options: UseOsdkObjectsOptions<Q> & { shape: C },
+): UseOsdkObjectsShapeResult<Q, C> {
+  type S = InferShapeDefinition<Q, C>;
+
+  const configRef = React.useRef(options.shape);
+  const shapeDef = React.useMemo(
+    () => configToShapeDefinition(type, configRef.current),
+    [type],
+  ) as S;
+
+  const result = useShapeList(
+    shapeDef as ShapeDefinition<Q>,
+    {
+      where: options.where,
+      pageSize: options.pageSize,
+      orderBy: options.orderBy,
+      autoFetchMore: options.autoFetchMore,
+      dedupeIntervalMs: options.dedupeIntervalMs,
+      streamUpdates: options.streamUpdates,
+      enabled: options.enabled,
+      links: undefined,
+    },
+  );
+
+  return {
+    data: result.data as ShapeInstance<S>[] | undefined,
+    shape: shapeDef,
+    isLoading: result.isLoading,
+    error: result.error,
+    isOptimistic: result.isOptimistic,
+    fetchMore: result.fetchMore,
+    droppedCount: result.droppedCount,
+    nullabilityViolations: result.nullabilityViolations,
+    itemLinkStatus: result.itemLinkStatus as PerItemLinkStatus<S>,
+    linkStatus: result.linkStatus as UseOsdkObjectsShapeResult<
+      Q,
+      C
+    >["linkStatus"],
+    loadDeferred: result.loadDeferred as UseOsdkObjectsShapeResult<
+      Q,
+      C
+    >["loadDeferred"],
+    retry: result.retry as UseOsdkObjectsShapeResult<Q, C>["retry"],
+    invalidate: result.invalidate as UseOsdkObjectsShapeResult<
+      Q,
+      C
+    >["invalidate"],
+  };
 }

--- a/packages/react/src/public/experimental.ts
+++ b/packages/react/src/public/experimental.ts
@@ -34,8 +34,14 @@ export type {
 } from "../new/useOsdkFunctions.js";
 export { useOsdkObject } from "../new/useOsdkObject.js";
 export type {
+  UseOsdkObjectResult,
+  UseOsdkObjectShapeOptions,
+  UseOsdkObjectShapeResult,
+} from "../new/useOsdkObject.js";
+export type {
   UseOsdkListResult,
   UseOsdkObjectsOptions,
+  UseOsdkObjectsShapeResult,
 } from "../new/useOsdkObjects.js";
 export { useOsdkObjects } from "../new/useOsdkObjects.js";
 export { useRegisterUserAgent } from "../new/useRegisterUserAgent.js";

--- a/packages/react/src/public/experimental.ts
+++ b/packages/react/src/public/experimental.ts
@@ -68,8 +68,14 @@ export { useOsdkObject } from "../new/useOsdkObject.js";
 
 /** @deprecated Import from `@osdk/react` instead. */
 export type {
+  UseOsdkObjectResult,
+  UseOsdkObjectShapeOptions,
+  UseOsdkObjectShapeResult,
+} from "../new/useOsdkObject.js";
+export type {
   UseOsdkListResult,
   UseOsdkObjectsOptions,
+  UseOsdkObjectsShapeResult,
 } from "../new/useOsdkObjects.js";
 
 /** @deprecated Import from `@osdk/react` instead. */

--- a/packages/react/src/testing/createMockObservableClient.ts
+++ b/packages/react/src/testing/createMockObservableClient.ts
@@ -258,7 +258,15 @@ export function createMockObservableClient(
 
     observeLinks: ((_objects, _linkName, _options, subFn): Unsubscribable => {
       setTimeout(() => {
-        (subFn as Observer<unknown>).next(makeListPayload("loaded"));
+        (subFn as Observer<unknown>).next({
+          linkedObjectsBySourcePrimaryKey: new Map(),
+          resolvedList: [],
+          isOptimistic: false,
+          status: "loaded",
+          lastUpdated: Date.now(),
+          fetchMore: NOOP_ASYNC,
+          hasMore: false,
+        });
       }, delay);
       return { unsubscribe: () => {} };
     }) as ObservableClient["observeLinks"],

--- a/packages/react/src/testing/createMockObservableClient.ts
+++ b/packages/react/src/testing/createMockObservableClient.ts
@@ -290,6 +290,8 @@ export function createMockObservableClient(
     invalidateFunction: NOOP_ASYNC as ObservableClient["invalidateFunction"],
     invalidateFunctionsByObject:
       NOOP_ASYNC as ObservableClient["invalidateFunctionsByObject"],
+    canonicalizeOptions:
+      ((options) => options) as ObservableClient["canonicalizeOptions"],
   };
 
   return mockClient;

--- a/packages/react/src/testing/createMockObservableClient.ts
+++ b/packages/react/src/testing/createMockObservableClient.ts
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  ObjectTypeDefinition,
+  Osdk,
+  PrimaryKeyType,
+  WhereClause,
+} from "@osdk/api";
+import type {
+  ObservableClient,
+  Observer,
+  Unsubscribable,
+} from "@osdk/client/observable";
+
+export interface MockObjectConfig<
+  T extends ObjectTypeDefinition = ObjectTypeDefinition,
+> {
+  objectType: T;
+  primaryKey: PrimaryKeyType<T>;
+  data: Partial<Osdk.Instance<T>>;
+}
+
+export interface MockObservableClientConfig {
+  objects?: MockObjectConfig[];
+  delay?: number;
+}
+
+export interface MockObservableClient extends ObservableClient {
+  setObjectResponse<T extends ObjectTypeDefinition>(
+    objectType: T["apiName"],
+    primaryKey: PrimaryKeyType<T>,
+    data: Partial<Osdk.Instance<T>>,
+  ): void;
+
+  setObjectError<T extends ObjectTypeDefinition>(
+    objectType: T["apiName"],
+    primaryKey: PrimaryKeyType<T>,
+    error: Error,
+  ): void;
+
+  setListResponse<T extends ObjectTypeDefinition>(
+    objectType: T["apiName"],
+    data: Array<Partial<Osdk.Instance<T>>>,
+    where?: WhereClause<T>,
+  ): void;
+
+  emitObjectUpdate<T extends ObjectTypeDefinition>(
+    objectType: T["apiName"],
+    primaryKey: PrimaryKeyType<T>,
+    data: Partial<Osdk.Instance<T>>,
+  ): void;
+
+  getActiveSubscriptions(): { type: string; key: string }[];
+}
+
+interface Subscription {
+  type: "object" | "list";
+  key: string;
+  observer: Observer<unknown>;
+}
+
+const NOOP_ASYNC = async () => {};
+
+function makeListPayload(
+  status: "init" | "loading" | "loaded" | "error",
+  data: object[] = [],
+  extra?: object,
+): object {
+  return {
+    resolvedList: data,
+    isOptimistic: false,
+    status,
+    lastUpdated: Date.now(),
+    fetchMore: NOOP_ASYNC,
+    hasMore: false,
+    ...extra,
+  };
+}
+
+function makeObjectPayload(
+  status: "init" | "loading" | "loaded" | "error",
+  object?: object,
+): object {
+  return { object, isOptimistic: false, status, lastUpdated: Date.now() };
+}
+
+export function createMockObservableClient(
+  config?: MockObservableClientConfig,
+): MockObservableClient {
+  const { delay = 0 } = config ?? {};
+
+  const objectStore = new Map<string, { data: object; error?: Error }>();
+  const listStore = new Map<string, { data: object[]; error?: Error }>();
+  const subscriptions: Subscription[] = [];
+
+  function objectKey(objectType: string, primaryKey: unknown): string {
+    return `${objectType}:${String(primaryKey)}`;
+  }
+
+  function listKey(objectType: string, where?: unknown): string {
+    return `${objectType}:${JSON.stringify(where ?? {})}`;
+  }
+
+  function trackSub(
+    type: "object" | "list",
+    key: string,
+    observer: Observer<unknown>,
+  ): Unsubscribable {
+    const sub: Subscription = { type, key, observer };
+    subscriptions.push(sub);
+    return {
+      unsubscribe: () => {
+        const idx = subscriptions.indexOf(sub);
+        if (idx >= 0) {
+          subscriptions.splice(idx, 1);
+        }
+      },
+    };
+  }
+
+  if (config?.objects) {
+    for (const obj of config.objects) {
+      objectStore.set(
+        objectKey(obj.objectType.apiName, obj.primaryKey),
+        { data: obj.data as object },
+      );
+    }
+  }
+
+  const mockClient: MockObservableClient = {
+    setObjectResponse(objectType, primaryKey, data) {
+      objectStore.set(objectKey(objectType, primaryKey), {
+        data: data as object,
+      });
+    },
+
+    setObjectError(objectType, primaryKey, error) {
+      objectStore.set(objectKey(objectType, primaryKey), {
+        data: {},
+        error,
+      });
+    },
+
+    setListResponse(objectType, data, where) {
+      listStore.set(listKey(objectType, where), { data: data as object[] });
+    },
+
+    emitObjectUpdate(objectType, primaryKey, data) {
+      const key = objectKey(objectType, primaryKey);
+      objectStore.set(key, { data: data as object });
+      for (const sub of subscriptions) {
+        if (sub.type === "object" && sub.key === key) {
+          sub.observer.next(makeObjectPayload("loaded", data as object));
+        }
+      }
+    },
+
+    getActiveSubscriptions() {
+      return subscriptions.map((s) => ({ type: s.type, key: s.key }));
+    },
+
+    observeObject(apiName, pk, _options, subFn): Unsubscribable {
+      const key = objectKey(
+        typeof apiName === "string" ? apiName : apiName.apiName,
+        pk,
+      );
+      const unsub = trackSub("object", key, subFn as Observer<unknown>);
+
+      (subFn as Observer<unknown>).next(makeObjectPayload("loading"));
+      setTimeout(() => {
+        const stored = objectStore.get(key);
+        if (stored?.error) {
+          subFn.error(stored.error);
+        } else {
+          (subFn as Observer<unknown>).next(
+            makeObjectPayload("loaded", stored?.data),
+          );
+        }
+      }, delay);
+
+      return unsub;
+    },
+
+    observeList(options, subFn): Unsubscribable {
+      const key = listKey(options.type.apiName, options.where);
+      const obs = subFn as Observer<unknown>;
+      const unsub = trackSub("list", key, obs);
+
+      obs.next(makeListPayload("loading"));
+      setTimeout(() => {
+        const stored = listStore.get(key);
+        if (stored?.error) {
+          obs.error(stored.error);
+        } else {
+          obs.next(makeListPayload("loaded", stored?.data ?? []));
+        }
+      }, delay);
+
+      return unsub;
+    },
+
+    observeObjectSet(objectSet, _options, subFn): Unsubscribable {
+      const obs = subFn as Observer<unknown>;
+      const unsub = trackSub(
+        "list",
+        `objectSet:${JSON.stringify(objectSet)}`,
+        obs,
+      );
+
+      obs.next(makeListPayload("loading", [], { objectSet }));
+      setTimeout(() => {
+        obs.next(makeListPayload("loaded", [], { objectSet }));
+      }, delay);
+
+      return unsub;
+    },
+
+    observeAggregation(
+      _options: unknown,
+      subFn: unknown,
+    ): Unsubscribable & Promise<Unsubscribable> {
+      setTimeout(() => {
+        (subFn as Observer<unknown>).next({
+          data: {},
+          isOptimistic: false,
+          status: "loaded",
+          lastUpdated: Date.now(),
+        });
+      }, delay);
+      const unsub: Unsubscribable = { unsubscribe: () => {} };
+      return Object.assign(Promise.resolve(unsub), unsub) as
+        & Unsubscribable
+        & Promise<Unsubscribable>;
+    },
+
+    observeFunction(_queryDef, _params, _options, subFn): Unsubscribable {
+      setTimeout(() => {
+        (subFn as Observer<unknown>).next({
+          data: undefined,
+          isOptimistic: false,
+          status: "loaded",
+          lastUpdated: Date.now(),
+        });
+      }, delay);
+      return { unsubscribe: () => {} };
+    },
+
+    observeLinks: ((_objects, _linkName, _options, subFn): Unsubscribable => {
+      setTimeout(() => {
+        (subFn as Observer<unknown>).next({
+          linkedObjectsBySourcePrimaryKey: new Map(),
+          resolvedList: [],
+          isOptimistic: false,
+          status: "loaded",
+          lastUpdated: Date.now(),
+          fetchMore: NOOP_ASYNC,
+          hasMore: false,
+        });
+      }, delay);
+      return { unsubscribe: () => {} };
+    }) as ObservableClient["observeLinks"],
+
+    applyAction: (async () => ({}) as never) as ObservableClient["applyAction"],
+    validateAction:
+      (async () => ({ result: "VALID" }) as never) as ObservableClient[
+        "validateAction"
+      ],
+    canonicalizeWhereClause: ((where) =>
+      where as ReturnType<
+        ObservableClient["canonicalizeWhereClause"]
+      >) as ObservableClient["canonicalizeWhereClause"],
+    invalidateObjectType:
+      NOOP_ASYNC as ObservableClient["invalidateObjectType"],
+    invalidateObjects: NOOP_ASYNC as ObservableClient["invalidateObjects"],
+    invalidateAll: NOOP_ASYNC as ObservableClient["invalidateAll"],
+    invalidateFunction: NOOP_ASYNC as ObservableClient["invalidateFunction"],
+    invalidateFunctionsByObject:
+      NOOP_ASYNC as ObservableClient["invalidateFunctionsByObject"],
+    canonicalizeOptions:
+      ((options) => options) as ObservableClient["canonicalizeOptions"],
+    getCacheSnapshot: () =>
+      Promise.resolve({
+        entries: [],
+        stats: { totalEntries: 0, totalSize: 0 },
+      }),
+    observeMediaMetadata: ((
+      _coords,
+      _options,
+      _observer,
+    ) => ({
+      unsubscribe: () => {},
+    })) as ObservableClient["observeMediaMetadata"],
+  };
+
+  return mockClient;
+}

--- a/packages/react/src/testing/createMockObservableClient.ts
+++ b/packages/react/src/testing/createMockObservableClient.ts
@@ -76,7 +76,7 @@ interface Subscription {
 const NOOP_ASYNC = async () => {};
 
 function makeListPayload(
-  status: string,
+  status: "init" | "loading" | "loaded" | "error",
   data: object[] = [],
   extra?: object,
 ): object {
@@ -91,7 +91,10 @@ function makeListPayload(
   };
 }
 
-function makeObjectPayload(status: string, object?: object): object {
+function makeObjectPayload(
+  status: "init" | "loading" | "loaded" | "error",
+  object?: object,
+): object {
   return { object, isOptimistic: false, status, lastUpdated: Date.now() };
 }
 

--- a/packages/react/src/testing/createMockObservableClient.ts
+++ b/packages/react/src/testing/createMockObservableClient.ts
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  ObjectTypeDefinition,
+  Osdk,
+  PrimaryKeyType,
+  WhereClause,
+} from "@osdk/api";
+import type {
+  ObservableClient,
+  Observer,
+  Unsubscribable,
+} from "@osdk/client/unstable-do-not-use";
+
+export interface MockObjectConfig<
+  T extends ObjectTypeDefinition = ObjectTypeDefinition,
+> {
+  objectType: T;
+  primaryKey: PrimaryKeyType<T>;
+  data: Partial<Osdk.Instance<T>>;
+}
+
+export interface MockObservableClientConfig {
+  objects?: MockObjectConfig[];
+  delay?: number;
+}
+
+export interface MockObservableClient extends ObservableClient {
+  setObjectResponse<T extends ObjectTypeDefinition>(
+    objectType: T["apiName"],
+    primaryKey: PrimaryKeyType<T>,
+    data: Partial<Osdk.Instance<T>>,
+  ): void;
+
+  setObjectError<T extends ObjectTypeDefinition>(
+    objectType: T["apiName"],
+    primaryKey: PrimaryKeyType<T>,
+    error: Error,
+  ): void;
+
+  setListResponse<T extends ObjectTypeDefinition>(
+    objectType: T["apiName"],
+    data: Array<Partial<Osdk.Instance<T>>>,
+    where?: WhereClause<T>,
+  ): void;
+
+  emitObjectUpdate<T extends ObjectTypeDefinition>(
+    objectType: T["apiName"],
+    primaryKey: PrimaryKeyType<T>,
+    data: Partial<Osdk.Instance<T>>,
+  ): void;
+
+  getActiveSubscriptions(): { type: string; key: string }[];
+}
+
+interface Subscription {
+  type: "object" | "list";
+  key: string;
+  observer: Observer<unknown>;
+}
+
+const NOOP_ASYNC = async () => {};
+
+function makeListPayload(
+  status: string,
+  data: object[] = [],
+  extra?: object,
+): object {
+  return {
+    resolvedList: data,
+    isOptimistic: false,
+    status,
+    lastUpdated: Date.now(),
+    fetchMore: NOOP_ASYNC,
+    hasMore: false,
+    ...extra,
+  };
+}
+
+function makeObjectPayload(status: string, object?: object): object {
+  return { object, isOptimistic: false, status, lastUpdated: Date.now() };
+}
+
+export function createMockObservableClient(
+  config?: MockObservableClientConfig,
+): MockObservableClient {
+  const { delay = 0 } = config ?? {};
+
+  const objectStore = new Map<string, { data: object; error?: Error }>();
+  const listStore = new Map<string, { data: object[]; error?: Error }>();
+  const subscriptions: Subscription[] = [];
+
+  function objectKey(objectType: string, primaryKey: unknown): string {
+    return `${objectType}:${String(primaryKey)}`;
+  }
+
+  function listKey(objectType: string, where?: unknown): string {
+    return `${objectType}:${JSON.stringify(where ?? {})}`;
+  }
+
+  function trackSub(
+    type: "object" | "list",
+    key: string,
+    observer: Observer<unknown>,
+  ): Unsubscribable {
+    const sub: Subscription = { type, key, observer };
+    subscriptions.push(sub);
+    return {
+      unsubscribe: () => {
+        const idx = subscriptions.indexOf(sub);
+        if (idx >= 0) {
+          subscriptions.splice(idx, 1);
+        }
+      },
+    };
+  }
+
+  if (config?.objects) {
+    for (const obj of config.objects) {
+      objectStore.set(
+        objectKey(obj.objectType.apiName, obj.primaryKey),
+        { data: obj.data as object },
+      );
+    }
+  }
+
+  const mockClient: MockObservableClient = {
+    setObjectResponse(objectType, primaryKey, data) {
+      objectStore.set(objectKey(objectType, primaryKey), {
+        data: data as object,
+      });
+    },
+
+    setObjectError(objectType, primaryKey, error) {
+      objectStore.set(objectKey(objectType, primaryKey), {
+        data: {},
+        error,
+      });
+    },
+
+    setListResponse(objectType, data, where) {
+      listStore.set(listKey(objectType, where), { data: data as object[] });
+    },
+
+    emitObjectUpdate(objectType, primaryKey, data) {
+      const key = objectKey(objectType, primaryKey);
+      objectStore.set(key, { data: data as object });
+      for (const sub of subscriptions) {
+        if (sub.type === "object" && sub.key === key) {
+          sub.observer.next(makeObjectPayload("loaded", data as object));
+        }
+      }
+    },
+
+    getActiveSubscriptions() {
+      return subscriptions.map((s) => ({ type: s.type, key: s.key }));
+    },
+
+    observeObject(apiName, pk, _options, subFn): Unsubscribable {
+      const key = objectKey(
+        typeof apiName === "string" ? apiName : apiName.apiName,
+        pk,
+      );
+      const unsub = trackSub("object", key, subFn as Observer<unknown>);
+
+      (subFn as Observer<unknown>).next(makeObjectPayload("loading"));
+      setTimeout(() => {
+        const stored = objectStore.get(key);
+        if (stored?.error) {
+          subFn.error(stored.error);
+        } else {
+          (subFn as Observer<unknown>).next(
+            makeObjectPayload("loaded", stored?.data),
+          );
+        }
+      }, delay);
+
+      return unsub;
+    },
+
+    observeList(options, subFn): Unsubscribable {
+      const key = listKey(options.type.apiName, options.where);
+      const obs = subFn as Observer<unknown>;
+      const unsub = trackSub("list", key, obs);
+
+      obs.next(makeListPayload("loading"));
+      setTimeout(() => {
+        const stored = listStore.get(key);
+        if (stored?.error) {
+          obs.error(stored.error);
+        } else {
+          obs.next(makeListPayload("loaded", stored?.data ?? []));
+        }
+      }, delay);
+
+      return unsub;
+    },
+
+    observeObjectSet(objectSet, _options, subFn): Unsubscribable {
+      const obs = subFn as Observer<unknown>;
+      const unsub = trackSub(
+        "list",
+        `objectSet:${JSON.stringify(objectSet)}`,
+        obs,
+      );
+
+      obs.next(makeListPayload("loading", [], { objectSet }));
+      setTimeout(() => {
+        obs.next(makeListPayload("loaded", [], { objectSet }));
+      }, delay);
+
+      return unsub;
+    },
+
+    observeAggregation(
+      _options: unknown,
+      subFn: unknown,
+    ): Unsubscribable & Promise<Unsubscribable> {
+      setTimeout(() => {
+        (subFn as Observer<unknown>).next({
+          data: {},
+          isOptimistic: false,
+          status: "loaded",
+          lastUpdated: Date.now(),
+        });
+      }, delay);
+      const unsub: Unsubscribable = { unsubscribe: () => {} };
+      return Object.assign(Promise.resolve(unsub), unsub) as
+        & Unsubscribable
+        & Promise<Unsubscribable>;
+    },
+
+    observeFunction(_queryDef, _params, _options, subFn): Unsubscribable {
+      setTimeout(() => {
+        (subFn as Observer<unknown>).next({
+          data: undefined,
+          isOptimistic: false,
+          status: "loaded",
+          lastUpdated: Date.now(),
+        });
+      }, delay);
+      return { unsubscribe: () => {} };
+    },
+
+    observeLinks: ((_objects, _linkName, _options, subFn): Unsubscribable => {
+      setTimeout(() => {
+        (subFn as Observer<unknown>).next(makeListPayload("loaded"));
+      }, delay);
+      return { unsubscribe: () => {} };
+    }) as ObservableClient["observeLinks"],
+
+    applyAction: (async () => ({}) as never) as ObservableClient["applyAction"],
+    validateAction:
+      (async () => ({ result: "VALID" }) as never) as ObservableClient[
+        "validateAction"
+      ],
+    canonicalizeWhereClause: ((where) =>
+      where as ReturnType<
+        ObservableClient["canonicalizeWhereClause"]
+      >) as ObservableClient["canonicalizeWhereClause"],
+    invalidateObjectType:
+      NOOP_ASYNC as ObservableClient["invalidateObjectType"],
+    invalidateObjects: NOOP_ASYNC as ObservableClient["invalidateObjects"],
+    invalidateAll: NOOP_ASYNC as ObservableClient["invalidateAll"],
+    invalidateFunction: NOOP_ASYNC as ObservableClient["invalidateFunction"],
+    invalidateFunctionsByObject:
+      NOOP_ASYNC as ObservableClient["invalidateFunctionsByObject"],
+  };
+
+  return mockClient;
+}

--- a/packages/react/src/testing/createMockObservableClient.ts
+++ b/packages/react/src/testing/createMockObservableClient.ts
@@ -292,6 +292,18 @@ export function createMockObservableClient(
       NOOP_ASYNC as ObservableClient["invalidateFunctionsByObject"],
     canonicalizeOptions:
       ((options) => options) as ObservableClient["canonicalizeOptions"],
+    getCacheSnapshot: () =>
+      Promise.resolve({
+        entries: [],
+        stats: { totalEntries: 0, totalSize: 0 },
+      }),
+    observeMediaMetadata: ((
+      _coords,
+      _options,
+      _observer,
+    ) => ({
+      unsubscribe: () => {},
+    })) as ObservableClient["observeMediaMetadata"],
   };
 
   return mockClient;

--- a/packages/react/src/testing/index.ts
+++ b/packages/react/src/testing/index.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @module @osdk/react/testing
+ *
+ * Testing utilities for OSDK React hooks.
+ *
+ * @example
+ * ```typescript
+ * import { createMockObservableClient } from "@osdk/react/testing";
+ * import { renderHook } from "@testing-library/react";
+ *
+ * const mockClient = createMockObservableClient({
+ *   objects: [
+ *     {
+ *       objectType: Player,
+ *       primaryKey: "player-1",
+ *       data: { name: "John", age: 25, $primaryKey: "player-1", $apiName: "Player" },
+ *     },
+ *   ],
+ * });
+ *
+ * // Use in tests
+ * const wrapper = ({ children }) => (
+ *   <OsdkProvider2 observableClient={mockClient}>
+ *     {children}
+ *   </OsdkProvider2>
+ * );
+ *
+ * const { result } = renderHook(() => useOsdkObject(Player, "player-1", { shape: SlimPlayer }), { wrapper });
+ * ```
+ */
+
+export {
+  createMockObservableClient,
+  type MockObjectConfig,
+  type MockObservableClient,
+  type MockObservableClientConfig,
+} from "./createMockObservableClient.js";

--- a/packages/react/test/useOsdkObject.shape.test.tsx
+++ b/packages/react/test/useOsdkObject.shape.test.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectTypeDefinition } from "@osdk/api";
+import type { ShapeDefinition, ShapePropertyConfig } from "@osdk/api/shapes";
+import { renderHook } from "@testing-library/react";
+import * as React from "react";
+import { beforeEach, describe, expect, it, vitest } from "vitest";
+import { OsdkContext2 } from "../src/new/OsdkContext2.js";
+import { useOsdkObject } from "../src/new/useOsdkObject.js";
+
+const MockObjectType = {
+  apiName: "MockObject",
+  primaryKeyType: "string",
+} as unknown as ObjectTypeDefinition;
+
+function makeMockShapeDefinition(
+  props: Record<string, ShapePropertyConfig>,
+): ShapeDefinition<typeof MockObjectType> {
+  return {
+    __shapeId: "test-shape-id",
+    __debugName: "TestShape",
+    __baseType: MockObjectType,
+    __baseTypeApiName: "MockObject",
+    __props: Object.freeze(props),
+    __derivedLinks: Object.freeze([]),
+    __selectedPropsType: {},
+    __derivedLinksType: {},
+  } as ShapeDefinition<typeof MockObjectType>;
+}
+
+describe("useOsdkObject with pre-built ShapeDefinition", () => {
+  const mockObserveObject = vitest.fn();
+
+  const createWrapper = () => {
+    const observableClient = {
+      observeObject: mockObserveObject,
+      canonicalizeWhereClause: vitest.fn((w: unknown) => w),
+      invalidateObjectType: vitest.fn(),
+    };
+
+    return ({ children }: React.PropsWithChildren) => (
+      <OsdkContext2.Provider
+        value={{ observableClient, client: {} } as never}
+      >
+        {children}
+      </OsdkContext2.Provider>
+    );
+  };
+
+  beforeEach(() => {
+    mockObserveObject.mockClear();
+    mockObserveObject.mockReturnValue({ unsubscribe: vitest.fn() });
+  });
+
+  it("should call observeObject with select for shape properties", () => {
+    const shape = makeMockShapeDefinition({
+      name: { nullabilityOp: { type: "require" } },
+      age: { nullabilityOp: { type: "select" } },
+    });
+    const wrapper = createWrapper();
+
+    renderHook(
+      () => useOsdkObject(MockObjectType, "pk-1", { shape }),
+      { wrapper },
+    );
+
+    expect(mockObserveObject).toHaveBeenCalledWith(
+      "MockObject",
+      "pk-1",
+      { select: expect.arrayContaining(["name", "age"]) },
+      expect.any(Object),
+    );
+  });
+
+  it("should return loading state initially", () => {
+    const shape = makeMockShapeDefinition({
+      name: { nullabilityOp: { type: "select" } },
+    });
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () => useOsdkObject(MockObjectType, "pk-1", { shape }),
+      { wrapper },
+    );
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("should NOT call observeObject when enabled is false", () => {
+    const shape = makeMockShapeDefinition({
+      name: { nullabilityOp: { type: "select" } },
+    });
+    const wrapper = createWrapper();
+
+    renderHook(
+      () =>
+        useOsdkObject(MockObjectType, "pk-1", {
+          shape,
+          enabled: false,
+        }),
+      { wrapper },
+    );
+
+    expect(mockObserveObject).not.toHaveBeenCalled();
+  });
+
+  it("should return shape result fields (not plain object result)", () => {
+    const shape = makeMockShapeDefinition({
+      name: { nullabilityOp: { type: "select" } },
+    });
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () => useOsdkObject(MockObjectType, "pk-1", { shape }),
+      { wrapper },
+    );
+
+    expect(result.current).toHaveProperty("data");
+    expect(result.current).toHaveProperty("isLoading");
+    expect(result.current).toHaveProperty("droppedDueToNullability");
+    expect(result.current).toHaveProperty("nullabilityViolations");
+    expect(result.current).toHaveProperty("linkStatus");
+    expect(result.current).toHaveProperty("loadDeferred");
+    expect(result.current).toHaveProperty("retry");
+    expect(result.current).toHaveProperty("invalidate");
+    // Pre-built shapes should NOT have a `shape` field (that's for inline configs)
+    expect(result.current).not.toHaveProperty("shape");
+  });
+});

--- a/packages/react/test/useOsdkObject.shape.test.tsx
+++ b/packages/react/test/useOsdkObject.shape.test.tsx
@@ -67,7 +67,7 @@ describe("useOsdkObject with pre-built ShapeDefinition", () => {
     mockObserveObject.mockReturnValue({ unsubscribe: vitest.fn() });
   });
 
-  it("should call observeObject for shape properties", () => {
+  it("should call observeObject with select for shape properties", () => {
     const shape = makeMockShapeDefinition({
       name: { nullabilityOp: { type: "require" } },
       age: { nullabilityOp: { type: "select" } },
@@ -82,7 +82,7 @@ describe("useOsdkObject with pre-built ShapeDefinition", () => {
     expect(mockObserveObject).toHaveBeenCalledWith(
       "MockObject",
       "pk-1",
-      {},
+      { mode: undefined, select: expect.arrayContaining(["name", "age"]) },
       expect.any(Object),
     );
   });

--- a/packages/react/test/useOsdkObject.shape.test.tsx
+++ b/packages/react/test/useOsdkObject.shape.test.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectTypeDefinition } from "@osdk/api";
+import type { ShapePropertyConfig } from "@osdk/api/shapes-internal";
+import type { ShapeDefinition } from "@osdk/api/unstable";
+import { renderHook } from "@testing-library/react";
+import * as React from "react";
+import { beforeEach, describe, expect, it, vitest } from "vitest";
+import { OsdkContext } from "../src/new/OsdkContext.js";
+import { useOsdkObject } from "../src/new/useOsdkObject.js";
+
+const MockObjectType = {
+  apiName: "MockObject",
+  primaryKeyType: "string",
+} as unknown as ObjectTypeDefinition;
+
+function makeMockShapeDefinition(
+  props: Record<string, ShapePropertyConfig>,
+): ShapeDefinition<typeof MockObjectType> {
+  return {
+    __shapeId: "test-shape-id",
+    __debugName: "TestShape",
+    __baseType: MockObjectType,
+    __baseTypeApiName: "MockObject",
+    __props: Object.freeze(props),
+    __derivedLinks: Object.freeze([]),
+    __selectedPropsType: {},
+    __derivedLinksType: {},
+  } as ShapeDefinition<typeof MockObjectType>;
+}
+
+describe("useOsdkObject with pre-built ShapeDefinition", () => {
+  const mockObserveObject = vitest.fn();
+
+  const createWrapper = () => {
+    const observableClient = {
+      observeObject: mockObserveObject,
+      canonicalizeWhereClause: vitest.fn((w: unknown) => w),
+      invalidateObjectType: vitest.fn(),
+    };
+
+    return ({ children }: React.PropsWithChildren) => (
+      <OsdkContext.Provider
+        value={{ observableClient, client: {} } as never}
+      >
+        {children}
+      </OsdkContext.Provider>
+    );
+  };
+
+  beforeEach(() => {
+    mockObserveObject.mockClear();
+    mockObserveObject.mockReturnValue({ unsubscribe: vitest.fn() });
+  });
+
+  it("should call observeObject with select for shape properties", () => {
+    const shape = makeMockShapeDefinition({
+      name: { nullabilityOp: { type: "require" } },
+      age: { nullabilityOp: { type: "select" } },
+    });
+    const wrapper = createWrapper();
+
+    renderHook(
+      () => useOsdkObject(MockObjectType, "pk-1", { shape }),
+      { wrapper },
+    );
+
+    expect(mockObserveObject).toHaveBeenCalledWith(
+      "MockObject",
+      "pk-1",
+      { mode: undefined, select: expect.arrayContaining(["name", "age"]) },
+      expect.any(Object),
+    );
+  });
+
+  it("should return loading state initially", () => {
+    const shape = makeMockShapeDefinition({
+      name: { nullabilityOp: { type: "select" } },
+    });
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () => useOsdkObject(MockObjectType, "pk-1", { shape }),
+      { wrapper },
+    );
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("should NOT call observeObject when enabled is false", () => {
+    const shape = makeMockShapeDefinition({
+      name: { nullabilityOp: { type: "select" } },
+    });
+    const wrapper = createWrapper();
+
+    renderHook(
+      () =>
+        useOsdkObject(MockObjectType, "pk-1", {
+          shape,
+          enabled: false,
+        }),
+      { wrapper },
+    );
+
+    expect(mockObserveObject).not.toHaveBeenCalled();
+  });
+
+  it("should return shape result fields (not plain object result)", () => {
+    const shape = makeMockShapeDefinition({
+      name: { nullabilityOp: { type: "select" } },
+    });
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () => useOsdkObject(MockObjectType, "pk-1", { shape }),
+      { wrapper },
+    );
+
+    expect(result.current).toHaveProperty("data");
+    expect(result.current).toHaveProperty("isLoading");
+    expect(result.current).toHaveProperty("droppedDueToNullability");
+    expect(result.current).toHaveProperty("nullabilityViolations");
+    expect(result.current).toHaveProperty("linkStatus");
+    expect(result.current).toHaveProperty("loadDeferred");
+    expect(result.current).toHaveProperty("retry");
+    expect(result.current).toHaveProperty("invalidate");
+    // Pre-built shapes should NOT have a `shape` field (that's for inline configs)
+    expect(result.current).not.toHaveProperty("shape");
+  });
+});

--- a/packages/react/test/useOsdkObject.shape.test.tsx
+++ b/packages/react/test/useOsdkObject.shape.test.tsx
@@ -67,7 +67,7 @@ describe("useOsdkObject with pre-built ShapeDefinition", () => {
     mockObserveObject.mockReturnValue({ unsubscribe: vitest.fn() });
   });
 
-  it("should call observeObject with select for shape properties", () => {
+  it("should call observeObject for shape properties", () => {
     const shape = makeMockShapeDefinition({
       name: { nullabilityOp: { type: "require" } },
       age: { nullabilityOp: { type: "select" } },
@@ -82,7 +82,7 @@ describe("useOsdkObject with pre-built ShapeDefinition", () => {
     expect(mockObserveObject).toHaveBeenCalledWith(
       "MockObject",
       "pk-1",
-      { select: expect.arrayContaining(["name", "age"]) },
+      {},
       expect.any(Object),
     );
   });

--- a/packages/react/test/useOsdkObject.shape.test.tsx
+++ b/packages/react/test/useOsdkObject.shape.test.tsx
@@ -15,7 +15,8 @@
  */
 
 import type { ObjectTypeDefinition } from "@osdk/api";
-import type { ShapeDefinition, ShapePropertyConfig } from "@osdk/api/shapes";
+import type { ShapePropertyConfig } from "@osdk/api/shapes-internal";
+import type { ShapeDefinition } from "@osdk/api/unstable";
 import { renderHook } from "@testing-library/react";
 import * as React from "react";
 import { beforeEach, describe, expect, it, vitest } from "vitest";


### PR DESCRIPTION
integrate shapes into useOsdkObject and useOsdkObjects with inline config overloads

• shape overloads on useOsdkObject and useOsdkObjects with inline and pre-built configs
• createMockObservableClient test utility with correct observeLinks payload shape
• useOsdkObject.shape.test.tsx covering single object shape observation