### PR TITLE
add useOsdkMedia hook

### DIFF
--- a/.changeset/media-hook.md
+++ b/.changeset/media-hook.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react": patch
+---
+
+add useOsdkMedia hook

--- a/packages/client/src/observable/internal/media/MediaContentObservable.test.ts
+++ b/packages/client/src/observable/internal/media/MediaContentObservable.test.ts
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { MediaMetadata } from "@osdk/api";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Observer } from "../../ObservableClient/common.js";
+import type { MediaContentPayload } from "../../ObservableClient/MediaObservableTypes.js";
+import type { MediaPropertyLocation } from "../../ObservableClient/MediaTypes.js";
+import type { BlobMemoryManager } from "./BlobMemoryManager.js";
+import { createBlobMemoryManager } from "./BlobMemoryManager.js";
+import { createMediaContentObservable } from "./MediaContentObservable.js";
+
+function createMockDeps(blobManager: BlobMemoryManager) {
+  const mockMetadata: MediaMetadata = {
+    path: "test.jpg",
+    sizeBytes: 1024,
+    mediaType: "image/jpeg",
+  };
+
+  return {
+    fetchContent: vi.fn().mockResolvedValue(
+      new Blob(["test content"], { type: "text/plain" }),
+    ),
+    fetchMetadata: vi.fn().mockResolvedValue(mockMetadata),
+    blobManager,
+    getCacheKey: vi.fn().mockReturnValue("test-cache-key"),
+  };
+}
+
+function createMockObserver(): Observer<MediaContentPayload> & {
+  payloads: MediaContentPayload[];
+} {
+  const payloads: MediaContentPayload[] = [];
+  return {
+    payloads,
+    next: vi.fn((payload: MediaContentPayload) => {
+      payloads.push(payload);
+    }),
+    error: vi.fn(),
+    complete: vi.fn(),
+  };
+}
+
+describe("MediaContentObservable", () => {
+  let blobManager: BlobMemoryManager;
+  const coords: MediaPropertyLocation = {
+    objectType: "TestObject",
+    primaryKey: 123,
+    propertyName: "media",
+  };
+
+  beforeEach(() => {
+    blobManager = createBlobMemoryManager();
+  });
+
+  afterEach(() => {
+    blobManager.dispose();
+  });
+
+  it("fetches content on first subscribe and emits loaded state", async () => {
+    const mockBlob = new Blob(["test content"], { type: "text/plain" });
+    const deps = createMockDeps(blobManager);
+    deps.fetchContent.mockResolvedValue(mockBlob);
+
+    const observable = createMediaContentObservable(deps, coords, {});
+    const observer = createMockObserver();
+
+    observable.subscribe(observer);
+
+    // First emission is init state
+    expect(observer.payloads[0].status).toBe("init");
+
+    await vi.waitFor(() => {
+      const lastPayload = observer.payloads[observer.payloads.length - 1];
+      expect(lastPayload.status).toBe("loaded");
+    });
+
+    const loadedPayload = observer.payloads.find(p => p.status === "loaded");
+    expect(loadedPayload?.content).toBe(mockBlob);
+    expect(loadedPayload?.url).toMatch(/^blob:/);
+    expect(loadedPayload?.isStale).toBe(false);
+
+    observable.dispose();
+  });
+
+  it("emits error state on fetch failure", async () => {
+    const deps = createMockDeps(blobManager);
+    deps.fetchContent.mockRejectedValue(new Error("Network error"));
+
+    const observable = createMediaContentObservable(deps, coords, {});
+    const observer = createMockObserver();
+
+    observable.subscribe(observer);
+
+    await vi.waitFor(() => {
+      const lastPayload = observer.payloads[observer.payloads.length - 1];
+      expect(lastPayload.status).toBe("error");
+    });
+
+    const errorPayload = observer.payloads.find(p => p.status === "error");
+    expect(errorPayload?.error?.message).toBe("Network error");
+
+    observable.dispose();
+  });
+
+  it("supports SWR on invalidation", async () => {
+    const blob1 = new Blob(["content v1"], { type: "text/plain" });
+    const blob2 = new Blob(["content v2"], { type: "text/plain" });
+    const deps = createMockDeps(blobManager);
+
+    let fetchCount = 0;
+    deps.fetchContent.mockImplementation(() => {
+      fetchCount++;
+      return Promise.resolve(fetchCount === 1 ? blob1 : blob2);
+    });
+
+    const observable = createMediaContentObservable(deps, coords, {});
+    const observer = createMockObserver();
+
+    observable.subscribe(observer);
+
+    await vi.waitFor(() => {
+      const lastPayload = observer.payloads[observer.payloads.length - 1];
+      expect(lastPayload.status).toBe("loaded");
+    });
+
+    observable.invalidate();
+
+    const stalePayload = observer.payloads.find(p => p.isStale);
+    expect(stalePayload).toBeDefined();
+
+    await vi.waitFor(() => {
+      const lastPayload = observer.payloads[observer.payloads.length - 1];
+      expect(lastPayload.content).toBe(blob2);
+      expect(lastPayload.isStale).toBe(false);
+    });
+
+    observable.dispose();
+  });
+
+  it("shares state across multiple subscribers", async () => {
+    const deps = createMockDeps(blobManager);
+    const observable = createMediaContentObservable(deps, coords, {});
+
+    const observer1 = createMockObserver();
+    const observer2 = createMockObserver();
+
+    observable.subscribe(observer1);
+
+    await vi.waitFor(() => {
+      const lastPayload = observer1.payloads[observer1.payloads.length - 1];
+      expect(lastPayload.status).toBe("loaded");
+    });
+
+    observable.subscribe(observer2);
+
+    const lastPayload2 = observer2.payloads[observer2.payloads.length - 1];
+    expect(lastPayload2.status).toBe("loaded");
+    expect(deps.fetchContent).toHaveBeenCalledTimes(1);
+
+    observable.dispose();
+  });
+
+  it("uses cached content from blobManager", async () => {
+    const cachedBlob = new Blob(["cached"], { type: "text/plain" });
+    blobManager.add("test-cache-key", cachedBlob);
+
+    const deps = createMockDeps(blobManager);
+    const observable = createMediaContentObservable(deps, coords, {});
+    const observer = createMockObserver();
+
+    observable.subscribe(observer);
+
+    await vi.waitFor(() => {
+      const lastPayload = observer.payloads[observer.payloads.length - 1];
+      expect(lastPayload.status).toBe("loaded");
+    });
+
+    expect(deps.fetchContent).not.toHaveBeenCalled();
+
+    const loadedPayload = observer.payloads.find(p => p.status === "loaded");
+    expect(loadedPayload?.content).toBe(cachedBlob);
+
+    observable.dispose();
+  });
+});

--- a/packages/client/src/observable/internal/media/MediaContentObservable.ts
+++ b/packages/client/src/observable/internal/media/MediaContentObservable.ts
@@ -1,0 +1,343 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Attachment, Media, MediaMetadata } from "@osdk/api";
+import type { Observer } from "../../ObservableClient/common.js";
+import type {
+  MediaContentObserveOptions,
+  MediaContentPayload,
+} from "../../ObservableClient/MediaObservableTypes.js";
+import type { MediaPropertyLocation } from "../../ObservableClient/MediaTypes.js";
+import type { BlobMemoryManager } from "./BlobMemoryManager.js";
+
+type MediaSource = Media | Attachment | MediaPropertyLocation;
+
+export interface MediaContentObservableDeps {
+  fetchContent: (
+    source: MediaSource,
+    options?: { preview?: boolean },
+  ) => Promise<Blob>;
+  fetchMetadata: (
+    source: MediaSource,
+    options?: { preview?: boolean },
+  ) => Promise<MediaMetadata>;
+  blobManager: BlobMemoryManager;
+  getCacheKey: (source: MediaSource) => string;
+}
+
+export interface MediaContentObservable {
+  subscribe(
+    observer: Observer<MediaContentPayload>,
+  ): { unsubscribe: () => void };
+  invalidate(): void;
+  dispose(): void;
+  subscriberCount(): number;
+}
+
+async function extractImageDimensions(
+  blob: Blob,
+): Promise<{ width: number; height: number } | undefined> {
+  if (!blob.type.startsWith("image/")) {
+    return undefined;
+  }
+
+  try {
+    const bitmap = await createImageBitmap(blob);
+    const dims = { width: bitmap.width, height: bitmap.height };
+    bitmap.close();
+    return dims;
+  } catch {
+    return undefined;
+  }
+}
+
+export function createMediaContentObservable(
+  deps: MediaContentObservableDeps,
+  source: MediaSource,
+  options: MediaContentObserveOptions,
+): MediaContentObservable {
+  const observers = new Set<Observer<MediaContentPayload>>();
+  const cacheKey = deps.getCacheKey(source);
+  const preview = options.preview ?? true;
+  const placeholder = options.placeholder ?? "none";
+  const staleTime = options.staleTime ?? 0;
+
+  let state: MediaContentPayload = {
+    metadata: undefined,
+    content: undefined,
+    url: undefined,
+    previewUrl: undefined,
+    dimensions: undefined,
+    status: "init",
+    isStale: false,
+    isPreview: false,
+    lastUpdated: 0,
+    error: undefined,
+  };
+
+  let fetchGeneration = 0;
+  let disposed = false;
+
+  function emit(): void {
+    const snapshot = { ...state };
+    for (const obs of observers) {
+      obs.next(snapshot);
+    }
+  }
+
+  function updateState(patch: Partial<MediaContentPayload>): void {
+    state = { ...state, ...patch };
+    emit();
+  }
+
+  async function loadContent(
+    gen: number,
+    isRevalidation: boolean,
+  ): Promise<void> {
+    if (disposed) {
+      return;
+    }
+
+    if (!isRevalidation) {
+      updateState({
+        status: "loading",
+        error: undefined,
+      });
+    }
+
+    try {
+      if (placeholder === "preview" && !isRevalidation) {
+        await loadWithPreview(gen);
+      } else {
+        await loadDirect(gen, preview);
+      }
+    } catch (err) {
+      if (gen !== fetchGeneration || disposed) {
+        return;
+      }
+
+      const error = err instanceof Error ? err : new Error(String(err));
+      updateState({
+        status: "error",
+        error,
+        isStale: false,
+      });
+    }
+  }
+
+  async function loadWithPreview(gen: number): Promise<void> {
+    const previewBlob = await deps.fetchContent(source, { preview: true });
+    if (gen !== fetchGeneration || disposed) {
+      return;
+    }
+
+    const previewBlobKey = `${cacheKey}:preview`;
+    deps.blobManager.add(previewBlobKey, previewBlob);
+    const previewUrl = deps.blobManager.createBlobUrl(previewBlobKey);
+
+    const previewDimensions = await extractImageDimensions(previewBlob);
+    if (gen !== fetchGeneration || disposed) {
+      return;
+    }
+
+    const previewMeta = await deps.fetchMetadata(source).catch(() => undefined);
+    if (gen !== fetchGeneration || disposed) {
+      return;
+    }
+
+    updateState({
+      content: previewBlob,
+      url: previewUrl,
+      previewUrl,
+      metadata: previewMeta ?? state.metadata,
+      dimensions: previewDimensions ?? state.dimensions,
+      status: "loaded",
+      isPreview: true,
+      lastUpdated: Date.now(),
+      error: undefined,
+    });
+
+    const fullBlob = await deps.fetchContent(source, { preview: false });
+    if (gen !== fetchGeneration || disposed) {
+      return;
+    }
+
+    deps.blobManager.add(cacheKey, fullBlob);
+    const fullUrl = deps.blobManager.createBlobUrl(cacheKey);
+    const fullDimensions = await extractImageDimensions(fullBlob);
+    if (gen !== fetchGeneration || disposed) {
+      return;
+    }
+
+    // Release preview blob URL
+    deps.blobManager.releaseBlobUrl(previewBlobKey);
+
+    updateState({
+      content: fullBlob,
+      url: fullUrl,
+      previewUrl: undefined,
+      dimensions: fullDimensions ?? state.dimensions,
+      status: "loaded",
+      isPreview: false,
+      lastUpdated: Date.now(),
+      error: undefined,
+    });
+  }
+
+  async function loadDirect(gen: number, usePreview: boolean): Promise<void> {
+    const [blob, metadata] = await Promise.all([
+      deps.fetchContent(source, { preview: usePreview }),
+      deps.fetchMetadata(source).catch(() => undefined),
+    ]);
+    if (gen !== fetchGeneration || disposed) {
+      return;
+    }
+
+    deps.blobManager.add(cacheKey, blob);
+    const url = deps.blobManager.createBlobUrl(cacheKey);
+    const dimensions = await extractImageDimensions(blob);
+    if (gen !== fetchGeneration || disposed) {
+      return;
+    }
+
+    updateState({
+      content: blob,
+      url,
+      metadata: metadata ?? state.metadata,
+      dimensions: dimensions ?? state.dimensions,
+      status: "loaded",
+      isStale: false,
+      isPreview: false,
+      lastUpdated: Date.now(),
+      error: undefined,
+    });
+  }
+
+  function startFetching(): void {
+    fetchGeneration++;
+    const gen = fetchGeneration;
+
+    // Check cache
+    const cachedBlob = deps.blobManager.get(cacheKey);
+    if (cachedBlob) {
+      const url = deps.blobManager.createBlobUrl(cacheKey);
+
+      if (
+        staleTime > 0 && state.lastUpdated > 0
+        && (Date.now() - state.lastUpdated) < staleTime
+      ) {
+        updateState({
+          content: cachedBlob,
+          url,
+          status: "loaded",
+          isStale: false,
+        });
+        return;
+      }
+
+      updateState({
+        content: cachedBlob,
+        url,
+        status: "loaded",
+      });
+
+      void extractImageDimensions(cachedBlob).then(dims => {
+        if (gen === fetchGeneration && dims && !disposed) {
+          updateState({ dimensions: dims });
+        }
+      });
+
+      return;
+    }
+
+    void loadContent(gen, false);
+  }
+
+  function invalidate(): void {
+    if (disposed) {
+      return;
+    }
+
+    fetchGeneration++;
+    const gen = fetchGeneration;
+
+    // SWR: keep current url, mark as stale
+    updateState({
+      isStale: true,
+    });
+
+    // Remove cached blobs so refetch hits network
+    deps.blobManager.remove(cacheKey);
+    deps.blobManager.remove(`${cacheKey}:preview`);
+
+    // Background refetch
+    void loadContent(gen, true);
+  }
+
+  function subscribe(
+    observer: Observer<MediaContentPayload>,
+  ): { unsubscribe: () => void } {
+    observers.add(observer);
+    observer.next({ ...state });
+
+    if (observers.size === 1 && state.status === "init") {
+      startFetching();
+    }
+
+    return {
+      unsubscribe: () => {
+        observers.delete(observer);
+      },
+    };
+  }
+
+  function dispose(): void {
+    disposed = true;
+    fetchGeneration++;
+    observers.clear();
+
+    if (state.url) {
+      deps.blobManager.releaseBlobUrl(cacheKey);
+    }
+    if (state.previewUrl && state.previewUrl !== state.url) {
+      deps.blobManager.releaseBlobUrl(`${cacheKey}:preview`);
+    }
+
+    state = {
+      metadata: undefined,
+      content: undefined,
+      url: undefined,
+      previewUrl: undefined,
+      dimensions: undefined,
+      status: "init",
+      isStale: false,
+      isPreview: false,
+      lastUpdated: 0,
+      error: undefined,
+    };
+  }
+
+  function subscriberCount(): number {
+    return observers.size;
+  }
+
+  return {
+    subscribe,
+    invalidate,
+    dispose,
+    subscriberCount,
+  };
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -36,6 +36,8 @@ export type {
   UseOsdkFunctionsProps,
   UseOsdkFunctionsResult,
 } from "./new/useOsdkFunctions.js";
+export { useOsdkMedia } from "./new/useOsdkMedia.js";
+export type { UseOsdkMediaResult } from "./new/useOsdkMedia.js";
 export { useOsdkMediaUpload } from "./new/useOsdkMediaUpload.js";
 export type { UseOsdkMediaUploadResult } from "./new/useOsdkMediaUpload.js";
 export { useOsdkObject } from "./new/useOsdkObject.js";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -37,7 +37,10 @@ export type {
   UseOsdkFunctionsResult,
 } from "./new/useOsdkFunctions.js";
 export { useOsdkMedia } from "./new/useOsdkMedia.js";
-export type { UseOsdkMediaResult } from "./new/useOsdkMedia.js";
+export type {
+  UseOsdkMediaOptions,
+  UseOsdkMediaResult,
+} from "./new/useOsdkMedia.js";
 export { useOsdkMediaUpload } from "./new/useOsdkMediaUpload.js";
 export type { UseOsdkMediaUploadResult } from "./new/useOsdkMediaUpload.js";
 export { useOsdkObject } from "./new/useOsdkObject.js";

--- a/packages/react/src/new/useOsdkMedia.ts
+++ b/packages/react/src/new/useOsdkMedia.ts
@@ -18,7 +18,6 @@ import type { Attachment, Media, MediaMetadata } from "@osdk/api";
 import type {
   MediaContentObserveOptions,
   MediaContentPayload,
-  MediaPropertyLocation,
 } from "@osdk/client/unstable-do-not-use";
 import React from "react";
 import { makeExternalStore } from "./makeExternalStore.js";
@@ -48,7 +47,7 @@ export interface UseOsdkMediaResult {
 }
 
 export function useOsdkMedia(
-  source?: Media | Attachment | MediaPropertyLocation,
+  source?: Media | Attachment,
   options: UseOsdkMediaOptions = {},
 ): UseOsdkMediaResult {
   const { observableClient } = React.useContext(OsdkContext2);
@@ -95,9 +94,6 @@ export function useOsdkMedia(
   const sourceKey = React.useMemo(() => {
     if (!source) {
       return undefined;
-    }
-    if ("objectType" in source) {
-      return `media ${source.objectType} ${source.primaryKey} ${source.propertyName}`;
     }
     if ("rid" in source) {
       return `attachment ${source.rid}`;

--- a/packages/react/src/new/useOsdkMedia.ts
+++ b/packages/react/src/new/useOsdkMedia.ts
@@ -77,6 +77,7 @@ export function useOsdkMedia(
         ([entry]) => {
           if (entry.isIntersecting) {
             setIsVisible(true);
+            observerRef.current?.disconnect();
           }
         },
         { rootMargin: "200px" },

--- a/packages/react/src/new/useOsdkMedia.ts
+++ b/packages/react/src/new/useOsdkMedia.ts
@@ -92,12 +92,20 @@ export function useOsdkMedia(
   const sourceRef = React.useRef(source);
   sourceRef.current = source;
 
-  const cacheKey = React.useMemo(() => {
+  const sourceKey = React.useMemo(() => {
     if (!source) {
       return undefined;
     }
-    return observableClient.media.getCacheKey(source);
-  }, [observableClient, source]);
+    if ("objectType" in source) {
+      return `media ${source.objectType} ${source.primaryKey} ${source.propertyName}`;
+    }
+    if ("rid" in source) {
+      return `attachment ${source.rid}`;
+    }
+    const ref2 = source.getMediaReference();
+    const vi = ref2.reference.mediaSetViewItem;
+    return `media ${vi.mediaSetRid} ${vi.mediaSetViewRid} ${vi.mediaItemRid}`;
+  }, [source]);
 
   const observeOpts = React.useMemo((): MediaContentObserveOptions => ({
     dedupeInterval: dedupeIntervalMs,
@@ -108,7 +116,7 @@ export function useOsdkMedia(
   }), [dedupeIntervalMs, preview, placeholder, priority, staleTime]);
 
   const { subscribe, getSnapShot } = React.useMemo(() => {
-    if (!cacheKey || !effectiveEnabled) {
+    if (!sourceKey || !effectiveEnabled) {
       return makeExternalStore<MediaContentPayload>(
         () => ({ unsubscribe: () => {} }),
         `media [DISABLED]`,
@@ -124,9 +132,9 @@ export function useOsdkMedia(
     return makeExternalStore<MediaContentPayload>(
       (observer) =>
         observableClient.observeMedia(currentSource, observeOpts, observer),
-      `media ${cacheKey}`,
+      `media ${sourceKey}`,
     );
-  }, [observableClient, cacheKey, effectiveEnabled, observeOpts]);
+  }, [observableClient, sourceKey, effectiveEnabled, observeOpts]);
 
   const payload = React.useSyncExternalStore(subscribe, getSnapShot);
 
@@ -140,7 +148,7 @@ export function useOsdkMedia(
     url: payload?.url,
     metadata: payload?.metadata,
     content: payload?.content,
-    isLoading: effectiveEnabled && cacheKey != null
+    isLoading: effectiveEnabled && sourceKey != null
       ? (payload?.status === "loading" || payload?.status === "init"
         || !payload)
       : false,
@@ -150,5 +158,5 @@ export function useOsdkMedia(
     error: payload?.error,
     refetch,
     ref,
-  }), [payload, effectiveEnabled, cacheKey, refetch, ref]);
+  }), [payload, effectiveEnabled, sourceKey, refetch, ref]);
 }

--- a/packages/react/src/new/useOsdkMedia.ts
+++ b/packages/react/src/new/useOsdkMedia.ts
@@ -21,7 +21,7 @@ import type {
 } from "@osdk/client/unstable-do-not-use";
 import React from "react";
 import { devToolsMetadata, makeExternalStore } from "./makeExternalStore.js";
-import { OsdkContext2 } from "./OsdkContext2.js";
+import { OsdkContext } from "./OsdkContext.js";
 
 export interface UseOsdkMediaOptions {
   enabled?: boolean;
@@ -50,7 +50,7 @@ export function useOsdkMedia(
   source?: Media | Attachment,
   options: UseOsdkMediaOptions = {},
 ): UseOsdkMediaResult {
-  const { observableClient } = React.useContext(OsdkContext2);
+  const { observableClient } = React.useContext(OsdkContext);
   const {
     enabled = true,
     preview = true,

--- a/packages/react/src/new/useOsdkMedia.ts
+++ b/packages/react/src/new/useOsdkMedia.ts
@@ -88,6 +88,9 @@ export function useOsdkMedia(
 
   const effectiveEnabled = enabled && isVisible;
 
+  const sourceRef = React.useRef(source);
+  sourceRef.current = source;
+
   const cacheKey = React.useMemo(() => {
     if (!source) {
       return undefined;
@@ -104,7 +107,14 @@ export function useOsdkMedia(
   }), [dedupeIntervalMs, preview, placeholder, priority, staleTime]);
 
   const { subscribe, getSnapShot } = React.useMemo(() => {
-    if (!source || !effectiveEnabled) {
+    if (!cacheKey || !effectiveEnabled) {
+      return makeExternalStore<MediaContentPayload>(
+        () => ({ unsubscribe: () => {} }),
+        `media [DISABLED]`,
+      );
+    }
+    const currentSource = sourceRef.current;
+    if (!currentSource) {
       return makeExternalStore<MediaContentPayload>(
         () => ({ unsubscribe: () => {} }),
         `media [DISABLED]`,
@@ -112,24 +122,24 @@ export function useOsdkMedia(
     }
     return makeExternalStore<MediaContentPayload>(
       (observer) =>
-        observableClient.observeMedia(source, observeOpts, observer),
+        observableClient.observeMedia(currentSource, observeOpts, observer),
       `media ${cacheKey}`,
     );
-  }, [observableClient, source, cacheKey, effectiveEnabled, observeOpts]);
+  }, [observableClient, cacheKey, effectiveEnabled, observeOpts]);
 
   const payload = React.useSyncExternalStore(subscribe, getSnapShot);
 
   const refetch = React.useCallback(() => {
-    if (source) {
-      observableClient.invalidateMedia(source);
+    if (sourceRef.current) {
+      observableClient.invalidateMedia(sourceRef.current);
     }
-  }, [observableClient, source]);
+  }, [observableClient]);
 
   return React.useMemo((): UseOsdkMediaResult => ({
     url: payload?.url,
     metadata: payload?.metadata,
     content: payload?.content,
-    isLoading: effectiveEnabled && source != null
+    isLoading: effectiveEnabled && cacheKey != null
       ? (payload?.status === "loading" || payload?.status === "init"
         || !payload)
       : false,
@@ -139,5 +149,5 @@ export function useOsdkMedia(
     error: payload?.error,
     refetch,
     ref,
-  }), [payload, effectiveEnabled, refetch, ref]);
+  }), [payload, effectiveEnabled, cacheKey, refetch, ref]);
 }

--- a/packages/react/src/new/useOsdkMedia.ts
+++ b/packages/react/src/new/useOsdkMedia.ts
@@ -20,7 +20,7 @@ import type {
   MediaContentPayload,
 } from "@osdk/client/unstable-do-not-use";
 import React from "react";
-import { makeExternalStore } from "./makeExternalStore.js";
+import { devToolsMetadata, makeExternalStore } from "./makeExternalStore.js";
 import { OsdkContext2 } from "./OsdkContext2.js";
 
 export interface UseOsdkMediaOptions {
@@ -115,20 +115,20 @@ export function useOsdkMedia(
     if (!sourceKey || !effectiveEnabled) {
       return makeExternalStore<MediaContentPayload>(
         () => ({ unsubscribe: () => {} }),
-        `media [DISABLED]`,
+        devToolsMetadata({ hookType: "useOsdkMedia" }),
       );
     }
     const currentSource = sourceRef.current;
     if (!currentSource) {
       return makeExternalStore<MediaContentPayload>(
         () => ({ unsubscribe: () => {} }),
-        `media [DISABLED]`,
+        devToolsMetadata({ hookType: "useOsdkMedia" }),
       );
     }
     return makeExternalStore<MediaContentPayload>(
       (observer) =>
         observableClient.observeMedia(currentSource, observeOpts, observer),
-      `media ${sourceKey}`,
+      devToolsMetadata({ hookType: "useOsdkMedia" }),
     );
   }, [observableClient, sourceKey, effectiveEnabled, observeOpts]);
 

--- a/packages/react/src/new/useOsdkMedia.ts
+++ b/packages/react/src/new/useOsdkMedia.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Attachment, Media, MediaMetadata } from "@osdk/api";
+import type {
+  MediaContentObserveOptions,
+  MediaContentPayload,
+  MediaPropertyLocation,
+} from "@osdk/client/unstable-do-not-use";
+import React from "react";
+import { makeExternalStore } from "./makeExternalStore.js";
+import { OsdkContext2 } from "./OsdkContext2.js";
+
+export interface UseOsdkMediaOptions {
+  enabled?: boolean;
+  preview?: boolean;
+  dedupeIntervalMs?: number;
+  lazy?: boolean;
+  placeholder?: "preview" | "none";
+  priority?: "high" | "low";
+  staleTime?: number;
+}
+
+export interface UseOsdkMediaResult {
+  url: string | undefined;
+  metadata: MediaMetadata | undefined;
+  content: Blob | undefined;
+  isLoading: boolean;
+  isStale: boolean;
+  isPreview: boolean;
+  dimensions: { width: number; height: number } | undefined;
+  error: Error | undefined;
+  refetch: () => void;
+  ref: React.RefCallback<Element>;
+}
+
+export function useOsdkMedia(
+  source?: Media | Attachment | MediaPropertyLocation,
+  options: UseOsdkMediaOptions = {},
+): UseOsdkMediaResult {
+  const { observableClient } = React.useContext(OsdkContext2);
+  const {
+    enabled = true,
+    preview = true,
+    dedupeIntervalMs,
+    lazy = false,
+    placeholder = "none",
+    priority,
+    staleTime,
+  } = options;
+
+  const [isVisible, setIsVisible] = React.useState(
+    !lazy || priority === "high",
+  );
+  const observerRef = React.useRef<IntersectionObserver>();
+
+  const ref: React.RefCallback<Element> = React.useCallback(
+    (node: Element | null) => {
+      observerRef.current?.disconnect();
+      if (!node || !lazy || priority === "high") {
+        return;
+      }
+      observerRef.current = new IntersectionObserver(
+        ([entry]) => {
+          if (entry.isIntersecting) {
+            setIsVisible(true);
+          }
+        },
+        { rootMargin: "200px" },
+      );
+      observerRef.current.observe(node);
+    },
+    [lazy, priority],
+  );
+
+  const effectiveEnabled = enabled && isVisible;
+
+  const cacheKey = React.useMemo(() => {
+    if (!source) {
+      return undefined;
+    }
+    return observableClient.media.getCacheKey(source);
+  }, [observableClient, source]);
+
+  const observeOpts = React.useMemo((): MediaContentObserveOptions => ({
+    dedupeInterval: dedupeIntervalMs,
+    preview,
+    placeholder,
+    priority,
+    staleTime,
+  }), [dedupeIntervalMs, preview, placeholder, priority, staleTime]);
+
+  const { subscribe, getSnapShot } = React.useMemo(() => {
+    if (!source || !effectiveEnabled) {
+      return makeExternalStore<MediaContentPayload>(
+        () => ({ unsubscribe: () => {} }),
+        `media [DISABLED]`,
+      );
+    }
+    return makeExternalStore<MediaContentPayload>(
+      (observer) =>
+        observableClient.observeMedia(source, observeOpts, observer),
+      `media ${cacheKey}`,
+    );
+  }, [observableClient, source, cacheKey, effectiveEnabled, observeOpts]);
+
+  const payload = React.useSyncExternalStore(subscribe, getSnapShot);
+
+  const refetch = React.useCallback(() => {
+    if (source) {
+      observableClient.invalidateMedia(source);
+    }
+  }, [observableClient, source]);
+
+  return React.useMemo((): UseOsdkMediaResult => ({
+    url: payload?.url,
+    metadata: payload?.metadata,
+    content: payload?.content,
+    isLoading: effectiveEnabled && source != null
+      ? (payload?.status === "loading" || payload?.status === "init"
+        || !payload)
+      : false,
+    isStale: payload?.isStale ?? false,
+    isPreview: payload?.isPreview ?? false,
+    dimensions: payload?.dimensions,
+    error: payload?.error,
+    refetch,
+    ref,
+  }), [payload, effectiveEnabled, refetch, ref]);
+}

--- a/packages/react/src/public/experimental.ts
+++ b/packages/react/src/public/experimental.ts
@@ -64,6 +64,10 @@ export type {
 } from "../new/useOsdkFunctions.js";
 
 /** @deprecated Import from `@osdk/react` instead. */
+export { useOsdkMedia } from "../new/useOsdkMedia.js";
+/** @deprecated Import from `@osdk/react` instead. */
+export type { UseOsdkMediaResult } from "../new/useOsdkMedia.js";
+/** @deprecated Import from `@osdk/react` instead. */
 export { useOsdkMediaUpload } from "../new/useOsdkMediaUpload.js";
 /** @deprecated Import from `@osdk/react` instead. */
 export type { UseOsdkMediaUploadResult } from "../new/useOsdkMediaUpload.js";

--- a/packages/react/src/public/experimental.ts
+++ b/packages/react/src/public/experimental.ts
@@ -66,7 +66,10 @@ export type {
 /** @deprecated Import from `@osdk/react` instead. */
 export { useOsdkMedia } from "../new/useOsdkMedia.js";
 /** @deprecated Import from `@osdk/react` instead. */
-export type { UseOsdkMediaResult } from "../new/useOsdkMedia.js";
+export type {
+  UseOsdkMediaOptions,
+  UseOsdkMediaResult,
+} from "../new/useOsdkMedia.js";
 /** @deprecated Import from `@osdk/react` instead. */
 export { useOsdkMediaUpload } from "../new/useOsdkMediaUpload.js";
 /** @deprecated Import from `@osdk/react` instead. */

--- a/packages/react/src/public/experimental.ts
+++ b/packages/react/src/public/experimental.ts
@@ -32,6 +32,8 @@ export type {
   UseOsdkFunctionsProps,
   UseOsdkFunctionsResult,
 } from "../new/useOsdkFunctions.js";
+export { useOsdkMedia } from "../new/useOsdkMedia.js";
+export type { UseOsdkMediaResult } from "../new/useOsdkMedia.js";
 export { useOsdkMediaUpload } from "../new/useOsdkMediaUpload.js";
 export type { UseOsdkMediaUploadResult } from "../new/useOsdkMediaUpload.js";
 export { useOsdkObject } from "../new/useOsdkObject.js";

--- a/packages/react/src/public/experimental.ts
+++ b/packages/react/src/public/experimental.ts
@@ -33,7 +33,10 @@ export type {
   UseOsdkFunctionsResult,
 } from "../new/useOsdkFunctions.js";
 export { useOsdkMedia } from "../new/useOsdkMedia.js";
-export type { UseOsdkMediaResult } from "../new/useOsdkMedia.js";
+export type {
+  UseOsdkMediaOptions,
+  UseOsdkMediaResult,
+} from "../new/useOsdkMedia.js";
 export { useOsdkMediaUpload } from "../new/useOsdkMediaUpload.js";
 export type { UseOsdkMediaUploadResult } from "../new/useOsdkMediaUpload.js";
 export { useOsdkObject } from "../new/useOsdkObject.js";

--- a/packages/react/test/useOsdkMedia.test.tsx
+++ b/packages/react/test/useOsdkMedia.test.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+import type { Media } from "@osdk/api";
 import type { Client } from "@osdk/client";
 import type {
   MediaContentPayload,
-  MediaPropertyLocation,
   ObservableClient,
   Observer,
 } from "@osdk/client/unstable-do-not-use";
@@ -27,11 +27,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { OsdkProvider2 } from "../src/new/OsdkProvider2.js";
 import { useOsdkMedia } from "../src/new/useOsdkMedia.js";
 
-const coords: MediaPropertyLocation = {
-  objectType: "TestObject",
-  primaryKey: 123,
-  propertyName: "media",
-};
+const fakeMedia = {
+  getMediaReference: () => ({
+    mimeType: "image/jpeg",
+    reference: {
+      type: "mediaSetViewItem" as const,
+      mediaSetViewItem: {
+        mediaSetRid: "set1",
+        mediaSetViewRid: "view1",
+        mediaItemRid: "item1",
+      },
+    },
+  }),
+} as unknown as Media;
 
 function createMockClient(): Client {
   return { fetchMetadata: vi.fn() } as Partial<Client> as Client;
@@ -80,7 +88,7 @@ function createMockObservableClient(
 
 function renderMediaHook(
   mockObservableClient: ObservableClient,
-  source?: MediaPropertyLocation,
+  source?: Media,
   options?: Parameters<typeof useOsdkMedia>[1],
 ) {
   const mockClient = createMockClient();
@@ -128,7 +136,7 @@ describe("useOsdkMedia", () => {
 
     const { result: disabledResult } = renderMediaHook(
       mockObservableClient,
-      coords,
+      fakeMedia,
       { enabled: false },
     );
 
@@ -149,10 +157,10 @@ describe("useOsdkMedia", () => {
   it("subscribes to observeMedia when enabled", () => {
     const mockObservableClient = createMockObservableClient();
 
-    renderMediaHook(mockObservableClient, coords);
+    renderMediaHook(mockObservableClient, fakeMedia);
 
     expect(mockObservableClient.observeMedia).toHaveBeenCalledWith(
-      coords,
+      fakeMedia,
       expect.objectContaining({ preview: true }),
       expect.any(Object),
     );
@@ -162,7 +170,7 @@ describe("useOsdkMedia", () => {
     const { mockObservableClient, getCapturedObserver } =
       createCapturingObservableClient();
 
-    const { result } = renderMediaHook(mockObservableClient, coords);
+    const { result } = renderMediaHook(mockObservableClient, fakeMedia);
 
     const mockBlob = new Blob(["content"], { type: "image/jpeg" });
 
@@ -200,7 +208,7 @@ describe("useOsdkMedia", () => {
     const { mockObservableClient, getCapturedObserver } =
       createCapturingObservableClient();
 
-    const { result } = renderMediaHook(mockObservableClient, coords);
+    const { result } = renderMediaHook(mockObservableClient, fakeMedia);
 
     act(() => {
       getCapturedObserver()?.next({
@@ -225,7 +233,7 @@ describe("useOsdkMedia", () => {
     const { mockObservableClient, getCapturedObserver } =
       createCapturingObservableClient();
 
-    const { result } = renderMediaHook(mockObservableClient, coords);
+    const { result } = renderMediaHook(mockObservableClient, fakeMedia);
 
     act(() => {
       getCapturedObserver()?.next({
@@ -250,13 +258,15 @@ describe("useOsdkMedia", () => {
   it("calls invalidateMedia on refetch", () => {
     const mockObservableClient = createMockObservableClient();
 
-    const { result } = renderMediaHook(mockObservableClient, coords);
+    const { result } = renderMediaHook(mockObservableClient, fakeMedia);
 
     act(() => {
       result.current.refetch();
     });
 
-    expect(mockObservableClient.invalidateMedia).toHaveBeenCalledWith(coords);
+    expect(mockObservableClient.invalidateMedia).toHaveBeenCalledWith(
+      fakeMedia,
+    );
   });
 
   it("unsubscribes on unmount", () => {
@@ -267,7 +277,7 @@ describe("useOsdkMedia", () => {
       }),
     });
 
-    const { unmount } = renderMediaHook(mockObservableClient, coords);
+    const { unmount } = renderMediaHook(mockObservableClient, fakeMedia);
 
     unmount();
 

--- a/packages/react/test/useOsdkMedia.test.tsx
+++ b/packages/react/test/useOsdkMedia.test.tsx
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Client } from "@osdk/client";
+import type {
+  MediaContentPayload,
+  MediaPropertyLocation,
+  ObservableClient,
+  Observer,
+} from "@osdk/client/unstable-do-not-use";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OsdkProvider2 } from "../src/new/OsdkProvider2.js";
+import { useOsdkMedia } from "../src/new/useOsdkMedia.js";
+
+const coords: MediaPropertyLocation = {
+  objectType: "TestObject",
+  primaryKey: 123,
+  propertyName: "media",
+};
+
+function createMockClient(): Client {
+  return { fetchMetadata: vi.fn() } as Partial<Client> as Client;
+}
+
+function createMockObservableClient(
+  overrides: Partial<ObservableClient> = {},
+): ObservableClient {
+  const mockClient: Partial<ObservableClient> = {
+    media: {
+      getCacheKey: vi.fn().mockReturnValue("test-cache-key"),
+      fetchMetadata: vi.fn().mockResolvedValue({
+        path: "test-image.jpg",
+        mediaType: "image/jpeg",
+        sizeBytes: 1024,
+      }),
+      getCachedMetadata: vi.fn().mockReturnValue(undefined),
+      fetchContent: vi.fn().mockResolvedValue(
+        new Blob(["test content"], { type: "image/jpeg" }),
+      ),
+      getCachedContent: vi.fn().mockReturnValue(undefined),
+      createBlobUrl: vi.fn().mockReturnValue("blob:mock-url-123"),
+      releaseBlobUrl: vi.fn(),
+      clearCache: vi.fn(),
+      uploadMedia: vi.fn().mockResolvedValue({
+        mimeType: "image/jpeg",
+        reference: {
+          type: "mediaSetViewItem",
+          mediaSetViewItem: {
+            mediaItemRid: "item1",
+            mediaSetRid: "set1",
+            mediaSetViewRid: "view1",
+          },
+        },
+      }),
+      prefetch: vi.fn().mockResolvedValue(undefined),
+    },
+    observeMetadata: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
+    observeMedia: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
+    invalidateMedia: vi.fn(),
+    ...overrides,
+  };
+
+  return mockClient as ObservableClient;
+}
+
+function renderMediaHook(
+  mockObservableClient: ObservableClient,
+  source?: MediaPropertyLocation,
+  options?: Parameters<typeof useOsdkMedia>[1],
+) {
+  const mockClient = createMockClient();
+  const wrapper = ({ children }: React.PropsWithChildren) => (
+    <OsdkProvider2
+      client={mockClient}
+      observableClient={mockObservableClient}
+    >
+      {children}
+    </OsdkProvider2>
+  );
+
+  return renderHook(
+    () => useOsdkMedia(source, options),
+    { wrapper },
+  );
+}
+
+function createCapturingObservableClient() {
+  let capturedObserver: Observer<MediaContentPayload> | undefined;
+  const mockObservableClient = createMockObservableClient({
+    observeMedia: vi.fn().mockImplementation((_source, _options, obs) => {
+      capturedObserver = obs;
+      return { unsubscribe: vi.fn() };
+    }),
+  });
+  return {
+    mockObservableClient,
+    getCapturedObserver: () => capturedObserver,
+  };
+}
+
+describe("useOsdkMedia", () => {
+  beforeEach(() => {
+    global.URL.createObjectURL = vi.fn(() => "blob:mock-url-123");
+    global.URL.revokeObjectURL = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns empty state when disabled or no source", () => {
+    const mockObservableClient = createMockObservableClient();
+
+    const { result: disabledResult } = renderMediaHook(
+      mockObservableClient,
+      coords,
+      { enabled: false },
+    );
+
+    expect(disabledResult.current.metadata).toBeUndefined();
+    expect(disabledResult.current.content).toBeUndefined();
+    expect(disabledResult.current.url).toBeUndefined();
+    expect(disabledResult.current.isLoading).toBe(false);
+
+    const { result: noSourceResult } = renderMediaHook(
+      mockObservableClient,
+      undefined,
+    );
+
+    expect(noSourceResult.current.isLoading).toBe(false);
+    expect(mockObservableClient.observeMedia).not.toHaveBeenCalled();
+  });
+
+  it("subscribes to observeMedia when enabled", () => {
+    const mockObservableClient = createMockObservableClient();
+
+    renderMediaHook(mockObservableClient, coords);
+
+    expect(mockObservableClient.observeMedia).toHaveBeenCalledWith(
+      coords,
+      expect.objectContaining({ preview: true }),
+      expect.any(Object),
+    );
+  });
+
+  it("receives content updates from observable", async () => {
+    const { mockObservableClient, getCapturedObserver } =
+      createCapturingObservableClient();
+
+    const { result } = renderMediaHook(mockObservableClient, coords);
+
+    const mockBlob = new Blob(["content"], { type: "image/jpeg" });
+
+    act(() => {
+      getCapturedObserver()?.next({
+        metadata: {
+          path: "photo.jpg",
+          mediaType: "image/jpeg",
+          sizeBytes: 2048,
+        },
+        content: mockBlob,
+        url: "blob:loaded-url",
+        previewUrl: undefined,
+        dimensions: { width: 800, height: 600 },
+        status: "loaded",
+        isStale: false,
+        isPreview: false,
+        lastUpdated: Date.now(),
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.url).toBe("blob:loaded-url");
+      expect(result.current.content).toBe(mockBlob);
+      expect(result.current.metadata?.path).toBe("photo.jpg");
+      expect(result.current.dimensions).toEqual({
+        width: 800,
+        height: 600,
+      });
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  it("shows loading state", async () => {
+    const { mockObservableClient, getCapturedObserver } =
+      createCapturingObservableClient();
+
+    const { result } = renderMediaHook(mockObservableClient, coords);
+
+    act(() => {
+      getCapturedObserver()?.next({
+        metadata: undefined,
+        content: undefined,
+        url: undefined,
+        previewUrl: undefined,
+        dimensions: undefined,
+        status: "loading",
+        isStale: false,
+        isPreview: false,
+        lastUpdated: 0,
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(true);
+    });
+  });
+
+  it("handles error from observable", async () => {
+    const { mockObservableClient, getCapturedObserver } =
+      createCapturingObservableClient();
+
+    const { result } = renderMediaHook(mockObservableClient, coords);
+
+    act(() => {
+      getCapturedObserver()?.next({
+        metadata: undefined,
+        content: undefined,
+        url: undefined,
+        previewUrl: undefined,
+        dimensions: undefined,
+        status: "error",
+        isStale: false,
+        isPreview: false,
+        lastUpdated: Date.now(),
+        error: new Error("Failed to load"),
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.error?.message).toBe("Failed to load");
+    });
+  });
+
+  it("calls invalidateMedia on refetch", () => {
+    const mockObservableClient = createMockObservableClient();
+
+    const { result } = renderMediaHook(mockObservableClient, coords);
+
+    act(() => {
+      result.current.refetch();
+    });
+
+    expect(mockObservableClient.invalidateMedia).toHaveBeenCalledWith(coords);
+  });
+
+  it("unsubscribes on unmount", () => {
+    const unsubscribeFn = vi.fn();
+    const mockObservableClient = createMockObservableClient({
+      observeMedia: vi.fn().mockReturnValue({
+        unsubscribe: unsubscribeFn,
+      }),
+    });
+
+    const { unmount } = renderMediaHook(mockObservableClient, coords);
+
+    unmount();
+
+    expect(unsubscribeFn).toHaveBeenCalled();
+  });
+});

--- a/packages/react/test/useOsdkMedia.test.tsx
+++ b/packages/react/test/useOsdkMedia.test.tsx
@@ -24,7 +24,7 @@ import type {
 import { act, renderHook, waitFor } from "@testing-library/react";
 import * as React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { OsdkProvider2 } from "../src/new/OsdkProvider2.js";
+import { OsdkContext } from "../src/new/OsdkContext.js";
 import { useOsdkMedia } from "../src/new/useOsdkMedia.js";
 
 const fakeMedia = {
@@ -91,14 +91,15 @@ function renderMediaHook(
   source?: Media,
   options?: Parameters<typeof useOsdkMedia>[1],
 ) {
-  const mockClient = createMockClient();
   const wrapper = ({ children }: React.PropsWithChildren) => (
-    <OsdkProvider2
-      client={mockClient}
-      observableClient={mockObservableClient}
+    <OsdkContext.Provider
+      value={{
+        observableClient: mockObservableClient,
+        devtoolsEnabled: false,
+      }}
     >
       {children}
-    </OsdkProvider2>
+    </OsdkContext.Provider>
   );
 
   return renderHook(


### PR DESCRIPTION
add useOsdkMedia hook for reactive media content observation

• useSyncExternalStore-based hook with IntersectionObserver lazy loading
• progressive preview-to-full loading with SWR invalidation support
• export useOsdkMedia and UseOsdkMediaResult from experimental