### PR TITLE
allow client() to accept ObjectOrInterfaceDefinition union

### DIFF
--- a/.changeset/fix-interface-overload-resolution.md
+++ b/.changeset/fix-interface-overload-resolution.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+allow client() to accept ObjectOrInterfaceDefinition union type

--- a/packages/api/src/objectSet/ObjectSet.ts
+++ b/packages/api/src/objectSet/ObjectSet.ts
@@ -103,6 +103,7 @@ type SubSelectRDPs<
 > = [RDPs] extends [never] ? never
   : NOOP<{ [K in SubSelectRDPsHelper<X, string & keyof RDPs>]: RDPs[K] }>;
 
+/** @deprecated Use `ObjectSet` instead. Interfaces now support full object set operations. */
 export interface MinimalObjectSet<
   Q extends ObjectOrInterfaceDefinition,
   RDPs extends Record<string, SimplePropertyDef> = {},
@@ -655,6 +656,7 @@ interface ObjectSetCleanedTypes<
   MERGED extends ObjectOrInterfaceDefinition & Q,
   ORDER_BY_OPTIONS extends ObjectSetArgs.OrderByOptions<PropertyKeys<Q>> = {},
 > extends
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   MinimalObjectSet<Q, D, ORDER_BY_OPTIONS>,
   WithProperties<Q, D>,
   Aggregate<MERGED>,

--- a/packages/api/src/objectSet/ObjectSet.ts
+++ b/packages/api/src/objectSet/ObjectSet.ts
@@ -103,7 +103,6 @@ type SubSelectRDPs<
 > = [RDPs] extends [never] ? never
   : NOOP<{ [K in SubSelectRDPsHelper<X, string & keyof RDPs>]: RDPs[K] }>;
 
-/** @deprecated Use `ObjectSet` instead. Interfaces now support full object set operations. */
 export interface MinimalObjectSet<
   Q extends ObjectOrInterfaceDefinition,
   RDPs extends Record<string, SimplePropertyDef> = {},
@@ -656,7 +655,6 @@ interface ObjectSetCleanedTypes<
   MERGED extends ObjectOrInterfaceDefinition & Q,
   ORDER_BY_OPTIONS extends ObjectSetArgs.OrderByOptions<PropertyKeys<Q>> = {},
 > extends
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
   MinimalObjectSet<Q, D, ORDER_BY_OPTIONS>,
   WithProperties<Q, D>,
   Aggregate<MERGED>,

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -21,17 +21,14 @@ import type {
   InterfaceDefinition,
   InterfaceMetadata,
   ObjectMetadata,
+  ObjectOrInterfaceDefinition,
   ObjectSet,
   ObjectTypeDefinition,
   QueryDefinition,
   QueryMetadata,
   VersionBound,
 } from "@osdk/api";
-import type {
-  Experiment,
-  ExperimentFns,
-  MinimalObjectSet,
-} from "@osdk/api/unstable";
+import type { Experiment, ExperimentFns } from "@osdk/api/unstable";
 import type { SharedClient } from "@osdk/shared.client2";
 import type { ActionSignatureFromDef } from "./actions/applyAction.js";
 import type { MinimalClient } from "./MinimalClientContext.js";
@@ -56,9 +53,14 @@ export interface Client extends SharedClient, OldSharedClient {
   ): unknown extends CompileTimeMetadata<Q>["objectSet"] ? ObjectSet<Q>
     : CompileTimeMetadata<Q>["objectSet"];
 
-  <Q extends (InterfaceDefinition)>(
+  <Q extends InterfaceDefinition>(
     o: Q,
-  ): unknown extends CompileTimeMetadata<Q>["objectSet"] ? MinimalObjectSet<Q>
+  ): unknown extends CompileTimeMetadata<Q>["objectSet"] ? ObjectSet<Q>
+    : CompileTimeMetadata<Q>["objectSet"];
+
+  <Q extends ObjectOrInterfaceDefinition>(
+    o: Q,
+  ): unknown extends CompileTimeMetadata<Q>["objectSet"] ? ObjectSet<Q>
     : CompileTimeMetadata<Q>["objectSet"];
 
   <Q extends ActionDefinition<any>>(

--- a/packages/client/src/createClient.ts
+++ b/packages/client/src/createClient.ts
@@ -17,7 +17,6 @@
 import type {
   ActionDefinition,
   FetchPageArgs,
-  InterfaceDefinition,
   Logger,
   NullabilityAdherence,
   ObjectOrInterfaceDefinition,
@@ -29,11 +28,7 @@ import type {
   QueryDefinition,
   SelectArg,
 } from "@osdk/api";
-import type {
-  Experiment,
-  ExperimentFns,
-  MinimalObjectSet,
-} from "@osdk/api/unstable";
+import type { Experiment, ExperimentFns } from "@osdk/api/unstable";
 import {
   __EXPERIMENTAL__NOT_SUPPORTED_YET__createMediaReference,
   __EXPERIMENTAL__NOT_SUPPORTED_YET__fetchOneByRid,
@@ -153,8 +148,7 @@ export function createClientFromContext(clientCtx: MinimalClient) {
       | QueryDefinition<any>
       | Experiment<"2.0.8">
       | Experiment<"2.1.0">,
-  >(o: T): T extends ObjectTypeDefinition ? ObjectSet<T>
-    : T extends InterfaceDefinition ? MinimalObjectSet<T>
+  >(o: T): T extends ObjectOrInterfaceDefinition ? ObjectSet<T>
     : T extends ActionDefinition<any> ? ActionSignatureFromDef<T>
     : T extends QueryDefinition<any> ? QuerySignatureFromDef<T>
     : T extends Experiment<"2.0.8"> | Experiment<"2.1.0">


### PR DESCRIPTION
calling client() with an ObjectOrInterfaceDefinition union type failed because TypeScript couldn't resolve which overload to use

• add a third overload on Client for ObjectOrInterfaceDefinition that returns ObjectSet
• simplify createClient conditional return type to use a single ObjectOrInterfaceDefinition branch
• deprecate MinimalObjectSet since interfaces now support full object set operations