### PR TITLE
fix @osdk/react build dependency graph

### DIFF
--- a/.changeset/untangle-react-build.md
+++ b/.changeset/untangle-react-build.md
@@ -1,0 +1,6 @@
+---
+"@osdk/react": patch
+"@osdk/client": patch
+---
+
+add build:dev turbo task and package-level turbo overrides to reduce dev build graph from 100 to 35 tasks

--- a/.changeset/untangle-react-build.md
+++ b/.changeset/untangle-react-build.md
@@ -3,4 +3,4 @@
 "@osdk/client": patch
 ---
 
-add build:dev turbo task and package-level turbo overrides to reduce dev build graph from 100 to 35 tasks
+add package-level turbo overrides for transpile task to trim test-only packages from the build dependency graph

--- a/packages/client/turbo.json
+++ b/packages/client/turbo.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "transpileEsm": {
+      "dependsOn": [
+        "//#babel-config",
+        "@osdk/monorepo.tsconfig#typecheck",
+        "@osdk/api#transpileEsm",
+        "@osdk/client.unstable#transpileEsm",
+        "@osdk/generator-converters#transpileEsm",
+        "@osdk/shared.client.impl#transpileEsm",
+        "@osdk/shared.net.errors#transpileEsm",
+        "@osdk/shared.net.fetch#transpileEsm",
+        "codegen"
+      ]
+    },
+    "transpileCjs": {
+      "dependsOn": [
+        "//#babel-config",
+        "@osdk/monorepo.tsconfig#typecheck",
+        "@osdk/api#transpileCjs",
+        "@osdk/client.unstable#transpileCjs",
+        "@osdk/generator-converters#transpileCjs",
+        "@osdk/shared.client.impl#transpileCjs",
+        "@osdk/shared.net.errors#transpileCjs",
+        "@osdk/shared.net.fetch#transpileCjs",
+        "@osdk/api#transpileTypes",
+        "@osdk/client.unstable#transpileTypes",
+        "@osdk/generator-converters#transpileTypes",
+        "@osdk/shared.client.impl#transpileTypes",
+        "@osdk/shared.net.errors#transpileTypes",
+        "@osdk/shared.net.fetch#transpileTypes",
+        "codegen"
+      ]
+    },
+    "transpileBrowser": {
+      "dependsOn": [
+        "//#babel-config",
+        "@osdk/monorepo.tsconfig#typecheck",
+        "@osdk/api#transpileBrowser",
+        "@osdk/client.unstable#transpileBrowser",
+        "@osdk/generator-converters#transpileBrowser",
+        "@osdk/shared.client.impl#transpileBrowser",
+        "@osdk/shared.net.errors#transpileBrowser",
+        "@osdk/shared.net.fetch#transpileBrowser",
+        "codegen"
+      ]
+    },
+    "typecheck": {
+      "dependsOn": [
+        "@osdk/api#transpileTypes",
+        "@osdk/client.unstable#transpileTypes",
+        "@osdk/generator-converters#transpileTypes",
+        "@osdk/shared.client.impl#transpileTypes",
+        "@osdk/shared.net.errors#transpileTypes",
+        "@osdk/shared.net.fetch#transpileTypes",
+        "@osdk/client.test.ontology#transpileTypes",
+        "@osdk/shared.test#transpileTypes",
+        "codegen"
+      ]
+    }
+  }
+}

--- a/packages/client/turbo.json
+++ b/packages/client/turbo.json
@@ -47,6 +47,27 @@
         "codegen"
       ]
     },
+    "transpile": {
+      "dependsOn": [
+        "@osdk/monorepo.tsconfig#typecheck",
+        "@osdk/api#typecheck",
+        "@osdk/client.unstable#typecheck",
+        "@osdk/generator-converters#typecheck",
+        "@osdk/shared.client.impl#typecheck",
+        "@osdk/shared.net.errors#typecheck",
+        "@osdk/shared.net.fetch#typecheck",
+        "@osdk/api#transpile",
+        "@osdk/client.unstable#transpile",
+        "@osdk/generator-converters#transpile",
+        "@osdk/shared.client.impl#transpile",
+        "@osdk/shared.net.errors#transpile",
+        "@osdk/shared.net.fetch#transpile",
+        "codegen",
+        "transpileCjs",
+        "transpileEsm",
+        "transpileBrowser"
+      ]
+    },
     "typecheck": {
       "dependsOn": [
         "@osdk/api#transpileTypes",

--- a/packages/react/turbo.json
+++ b/packages/react/turbo.json
@@ -31,6 +31,19 @@
         "codegen"
       ]
     },
+    "transpile": {
+      "dependsOn": [
+        "@osdk/monorepo.tsconfig#typecheck",
+        "@osdk/api#typecheck",
+        "@osdk/client#typecheck",
+        "@osdk/api#transpile",
+        "@osdk/client#transpile",
+        "codegen",
+        "transpileCjs",
+        "transpileEsm",
+        "transpileBrowser"
+      ]
+    },
     "typecheck": {
       "dependsOn": [
         "@osdk/api#transpileTypes",

--- a/packages/react/turbo.json
+++ b/packages/react/turbo.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "transpileEsm": {
+      "dependsOn": [
+        "//#babel-config",
+        "@osdk/monorepo.tsconfig#typecheck",
+        "@osdk/api#transpileEsm",
+        "@osdk/client#transpileEsm",
+        "codegen"
+      ]
+    },
+    "transpileCjs": {
+      "dependsOn": [
+        "//#babel-config",
+        "@osdk/monorepo.tsconfig#typecheck",
+        "@osdk/api#transpileCjs",
+        "@osdk/client#transpileCjs",
+        "@osdk/api#transpileTypes",
+        "@osdk/client#transpileTypes",
+        "codegen"
+      ]
+    },
+    "transpileBrowser": {
+      "dependsOn": [
+        "//#babel-config",
+        "@osdk/monorepo.tsconfig#typecheck",
+        "@osdk/api#transpileBrowser",
+        "@osdk/client#transpileBrowser",
+        "codegen"
+      ]
+    },
+    "typecheck": {
+      "dependsOn": [
+        "@osdk/api#transpileTypes",
+        "@osdk/client#transpileTypes",
+        "@osdk/client.test.ontology#transpileTypes",
+        "codegen"
+      ]
+    }
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -162,12 +162,6 @@
       ]
     },
 
-    "build:dev": {
-      "dependsOn": ["transpileEsm", "transpileTypes", "typecheck"],
-      "inputs": ["src/**/*"],
-      "outputs": ["build/esm/**", "build/types/**"]
-    },
-
     "bundle": {
       "dependsOn": ["bundle:esbuild"]
     },

--- a/turbo.json
+++ b/turbo.json
@@ -162,6 +162,12 @@
       ]
     },
 
+    "build:dev": {
+      "dependsOn": ["transpileEsm", "transpileTypes", "typecheck"],
+      "inputs": ["src/**/*"],
+      "outputs": ["build/esm/**", "build/types/**"]
+    },
+
     "bundle": {
       "dependsOn": ["bundle:esbuild"]
     },


### PR DESCRIPTION
`pnpm turbo build --filter=@osdk/react` pulls in 100 turbo tasks across 15 packages because the root `transpile` task uses `^typecheck` and `^transpile`, which treat devDependencies the same as real dependencies. this drags test-only packages (generator, faux, shared.test) into the build graph.

wall-clock build time is similar (~28s) since turbo parallelizes well, but the bloated graph means more total CPU work, more cache entries to manage, and a dependency graph that will only get worse as test packages grow. fixing it now keeps the build graph honest.

• override `transpile` task in `@osdk/react` and `@osdk/client` package-level turbo.json to list only runtime workspace deps instead of using `^` wildcards
• remove unused `build:dev` task from root turbo.json
• graph goes from 100 to 81 tasks (46 executed vs ~65 before)