### PR TITLE
add @osdk/gotham-utils package

### DIFF
--- a/packages/gotham-utils/package.json
+++ b/packages/gotham-utils/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@osdk/gotham-utils",
+  "version": "0.1.0-beta.0",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/palantir/osdk-ts.git"
+  },
+  "exports": {
+    ".": {
+      "browser": "./build/browser/index.js",
+      "import": {
+        "types": "./build/types/index.d.ts",
+        "default": "./build/esm/index.js"
+      },
+      "require": "./build/cjs/index.cjs",
+      "default": "./build/browser/index.js"
+    }
+  },
+  "scripts": {
+    "check-spelling": "cspell --quiet .",
+    "fix-lint": "eslint . --fix && dprint fmt --config $(find-up dprint.json)",
+    "lint": "eslint . && dprint check  --config $(find-up dprint.json)",
+    "transpile": "tsup",
+    "typecheck": "tsc-absolute --noEmit"
+  },
+  "dependencies": {
+    "@osdk/api": "workspace:~",
+    "@osdk/client": "workspace:~"
+  },
+  "devDependencies": {
+    "@osdk/monorepo.tsconfig": "workspace:~",
+    "typescript": "~5.9.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "build/cjs",
+    "build/esm",
+    "build/browser",
+    "build/types",
+    "CHANGELOG.md",
+    "package.json"
+  ],
+  "sideEffects": false,
+  "type": "module"
+}

--- a/packages/gotham-utils/src/buildInterfaceLinkMap.ts
+++ b/packages/gotham-utils/src/buildInterfaceLinkMap.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { InterfaceDefinition, InterfaceMetadata } from "@osdk/api";
+import type { Client } from "@osdk/client";
+
+/**
+ * A nested map: sourceInterfaceApiName → linkedInterfaceApiName → concrete link API name.
+ *
+ * Allows looking up the concrete link name for an interface link constraint
+ * when the source and target interface types are known.
+ */
+export type InterfaceLinkMap = ReadonlyMap<string, ReadonlyMap<string, string>>;
+
+interface InterfaceLinkEntry {
+  readonly sourceInterfaceApiName: string;
+  readonly linkConstraintApiName: string;
+  readonly targetInterfaceApiName: string;
+}
+
+/**
+ * Builds a nested map of interface link constraints from a set of interfaces.
+ * For each interface, reads its link metadata to discover which other interfaces
+ * it links to via link type constraints.
+ *
+ * This is useful when the ontology uses interfaces extensively and you need
+ * to map from interface link constraint names
+ * to understand the relationship graph between interface types.
+ *
+ * Note: For actually traversing these links at runtime, use
+ * `useOsdkObjects(InterfaceType, { pivotTo: "linkConstraintName" })` —
+ * the server resolves interface link constraints automatically.
+ * This utility is for introspection/metadata use cases.
+ *
+ * @example
+ * const linkMap = await buildInterfaceLinkMap(client, [InterfaceA, InterfaceB]);
+ * const linkName = linkMap.get("InterfaceA")?.get("InterfaceB");
+ */
+export async function buildInterfaceLinkMap(
+  client: Client,
+  interfaces: ReadonlyArray<InterfaceDefinition>,
+): Promise<InterfaceLinkMap> {
+  const metadataResults = await Promise.all(
+    interfaces.map(async (iface) => {
+      const metadata: InterfaceMetadata = await client.fetchMetadata(iface);
+      return { iface, metadata };
+    }),
+  );
+
+  const entries: InterfaceLinkEntry[] = [];
+  for (const { iface, metadata } of metadataResults) {
+    for (const [linkApiName, linkDef] of Object.entries(metadata.links)) {
+      if (linkDef.targetType === "interface") {
+        entries.push({
+          sourceInterfaceApiName: iface.apiName,
+          linkConstraintApiName: linkApiName,
+          targetInterfaceApiName: linkDef.targetTypeApiName,
+        });
+      }
+    }
+  }
+
+  const result = new Map<string, Map<string, string>>();
+  for (const entry of entries) {
+    let inner = result.get(entry.sourceInterfaceApiName);
+    if (inner == null) {
+      inner = new Map();
+      result.set(entry.sourceInterfaceApiName, inner);
+    }
+    inner.set(entry.targetInterfaceApiName, entry.linkConstraintApiName);
+  }
+
+  return result;
+}

--- a/packages/gotham-utils/src/combineLoadingStates.ts
+++ b/packages/gotham-utils/src/combineLoadingStates.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface LoadingState {
+  isLoading: boolean;
+  error: Error | undefined;
+}
+
+/**
+ * Combines multiple loading states into a single state. First error wins;
+ * loading is true if any input is loading. Data stays on each individual
+ * hook result — this only merges the loading/error signals.
+ *
+ * @example
+ * const listA = useOsdkObjects(MyType, { rids: [rid] });
+ * const listB = useOsdkObjects(MyType, { pivotTo: "relatedObjects" });
+ * const linksResult = useLinks(objects, "linkedItems");
+ *
+ * const { isLoading, error } = combineLoadingStates(listA, listB, linksResult);
+ */
+export function combineLoadingStates(...states: LoadingState[]): LoadingState {
+  return {
+    error: states.find((s) => s.error != null)?.error,
+    isLoading: states.some((s) => s.isLoading),
+  };
+}

--- a/packages/gotham-utils/src/index.ts
+++ b/packages/gotham-utils/src/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { buildInterfaceLinkMap, type InterfaceLinkMap } from "./buildInterfaceLinkMap.js";
+export { toRidMap } from "./toRidMap.js";
+export { combineLoadingStates, type LoadingState } from "./combineLoadingStates.js";

--- a/packages/gotham-utils/src/toRidMap.ts
+++ b/packages/gotham-utils/src/toRidMap.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const EMPTY_MAP: ReadonlyMap<string, never> = new Map();
+
+/**
+ * Converts an array of OSDK objects with `$rid` into a `Map<string, T>` keyed
+ * by RID, ensuring deduplication. Pure function — consumers should wrap in
+ * `useMemo` for React usage.
+ *
+ * The type constraint ensures only objects with `$rid` are accepted (i.e.,
+ * loaded via `rids` option or from shapes).
+ *
+ * @example
+ * const { data } = useOsdkObjects(MyType, { rids });
+ * const objectByRid = useMemo(() => toRidMap(data), [data]);
+ */
+export function toRidMap<T extends { $rid: string }>(data: readonly T[] | undefined): ReadonlyMap<string, T> {
+  if (data == null || data.length === 0) {
+    return EMPTY_MAP;
+  }
+  const map = new Map<string, T>();
+  for (const obj of data) {
+    map.set(obj.$rid, obj);
+  }
+  return map;
+}

--- a/packages/gotham-utils/tsconfig.json
+++ b/packages/gotham-utils/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@osdk/monorepo.tsconfig/base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build/esm"
+  },
+  "include": [
+    "./src/**/*"
+  ],
+  "references": []
+}

--- a/packages/gotham-utils/vitest.config.mts
+++ b/packages/gotham-utils/vitest.config.mts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { configDefaults, defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    pool: "forks",
+    exclude: [...configDefaults.exclude, "**/build/**/*"],
+  },
+});


### PR DESCRIPTION
## Summary

new package with utilities for Gotham-specific OSDK patterns

• `toRidMap` — convert array of OSDK objects (with $rid) to `Map<string, T>` keyed by RID
• `combineLoadingStates` — merge multiple `{ isLoading, error }` states into one combined state
• `buildInterfaceLinkMap` — build nested map of interface link constraints from interface metadata (parallelized)

## Test plan

- unit tests TBD (package scaffold, utilities are pure functions)
- verified types compile via tsc