### PR TITLE
add resolveToObjectType support to useLinks

### DIFF
--- a/.changeset/resolve-to-object-type-links.md
+++ b/.changeset/resolve-to-object-type-links.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client": minor
+"@osdk/react": minor
+---
+
+extend resolveToObjectType support to useLinks for interface link targets

--- a/packages/client/src/observable/ObservableClient/ObserveLink.ts
+++ b/packages/client/src/observable/ObservableClient/ObserveLink.ts
@@ -47,6 +47,7 @@ export namespace ObserveLinks {
     orderBy?: OrderBy<CompileTimeMetadata<Q>["links"][L]["targetType"]>;
     invalidationMode?: InvalidationMode;
     expectedLength?: number;
+    resolveToObjectType?: boolean;
   }
 
   export interface CallbackArgs<

--- a/packages/client/src/observable/ObservableClient/ObserveLink.ts
+++ b/packages/client/src/observable/ObservableClient/ObserveLink.ts
@@ -54,6 +54,15 @@ export namespace ObserveLinks {
      * targets.
      */
     $includeAllBaseObjectProperties?: boolean;
+
+    /**
+     * When traversing to linked objects via an interface link target, return
+     * the full concrete object type instances instead of interface views.
+     * Has no effect when the link target is already an object type.
+     *
+     * @default false
+     */
+    resolveToObjectType?: boolean;
   }
 
   export interface CallbackArgs<

--- a/packages/client/src/observable/internal/links/LinksHelper.ts
+++ b/packages/client/src/observable/internal/links/LinksHelper.ts
@@ -95,6 +95,7 @@ export class LinksHelper extends AbstractHelper<
       canonWhere,
       canonOrderBy,
       canonSelect,
+      options.resolveToObjectType ? true : undefined,
     );
 
     return this.store.queries.get(linkCacheKey, () => {

--- a/packages/client/src/observable/internal/links/LinksHelper.ts
+++ b/packages/client/src/observable/internal/links/LinksHelper.ts
@@ -96,6 +96,7 @@ export class LinksHelper extends AbstractHelper<
       canonOrderBy,
       canonSelect,
       options.$includeAllBaseObjectProperties ? true : undefined,
+      options.resolveToObjectType ? true : undefined,
     );
 
     return this.store.queries.get(linkCacheKey, () => {

--- a/packages/client/src/observable/internal/links/SpecificLinkCacheKey.ts
+++ b/packages/client/src/observable/internal/links/SpecificLinkCacheKey.ts
@@ -30,6 +30,7 @@ export const LINK_NAME_IDX = 4;
 export const WHERE_CLAUSE_IDX = 5;
 export const ORDER_BY_CLAUSE_IDX = 6;
 export const SELECT_IDX = 7;
+export const RESOLVE_TO_OBJECT_TYPE_IDX = 8;
 
 /**
  * Storage data format for link query cache entries, similar to ListStorageData
@@ -57,6 +58,7 @@ export interface SpecificLinkCacheKey extends
       whereClause: Canonical<SimpleWhereClause>,
       orderByClause: Canonical<Record<string, "asc" | "desc" | undefined>>,
       select?: Canonical<readonly string[]> | undefined,
+      resolveToObjectType?: true | undefined,
     ]
   >
 {

--- a/packages/client/src/observable/internal/links/SpecificLinkCacheKey.ts
+++ b/packages/client/src/observable/internal/links/SpecificLinkCacheKey.ts
@@ -31,6 +31,7 @@ export const WHERE_CLAUSE_IDX = 5;
 export const ORDER_BY_CLAUSE_IDX = 6;
 export const SELECT_IDX = 7;
 export const INCLUDE_ALL_BASE_PROPERTIES_IDX = 8;
+export const RESOLVE_TO_OBJECT_TYPE_IDX = 9;
 
 /**
  * Storage data format for link query cache entries, similar to ListStorageData
@@ -59,6 +60,7 @@ export interface SpecificLinkCacheKey extends
       orderByClause: Canonical<Record<string, "asc" | "desc" | undefined>>,
       select?: Canonical<readonly string[]> | undefined,
       includeAllBaseObjectProperties?: true | undefined,
+      resolveToObjectType?: true | undefined,
     ]
   >
 {

--- a/packages/client/src/observable/internal/links/SpecificLinkQuery.ts
+++ b/packages/client/src/observable/internal/links/SpecificLinkQuery.ts
@@ -43,7 +43,9 @@ import { OrderBySortingStrategy } from "../sorting/SortingStrategy.js";
 import type { Store } from "../Store.js";
 import type { SubjectPayload } from "../SubjectPayload.js";
 import { tombstone } from "../tombstone.js";
+import { reloadDataAsFullObjects } from "../utils/reloadDataAsFullObjects.js";
 import {
+  RESOLVE_TO_OBJECT_TYPE_IDX as LINK_RESOLVE_TO_OBJECT_TYPE_IDX,
   SELECT_IDX as LINK_SELECT_IDX,
   type SpecificLinkCacheKey,
 } from "./SpecificLinkCacheKey.js";
@@ -68,6 +70,7 @@ export class SpecificLinkQuery extends BaseListQuery<
   #whereClause: Canonical<SimpleWhereClause>;
   #orderBy: Canonical<Record<string, "asc" | "desc" | undefined>>;
   #select: Canonical<readonly string[]> | undefined;
+  #resolveToObjectType: boolean;
 
   protected override createPayload(
     params: CollectionConnectableParams,
@@ -121,6 +124,8 @@ export class SpecificLinkQuery extends BaseListQuery<
       this.#orderBy,
     ] = cacheKey.otherKeys;
     this.#select = cacheKey.otherKeys[LINK_SELECT_IDX];
+    this.#resolveToObjectType = !!cacheKey
+      .otherKeys[LINK_RESOLVE_TO_OBJECT_TYPE_IDX];
   }
 
   protected get rawSelect(): Canonical<readonly string[]> | undefined {
@@ -242,6 +247,14 @@ export class SpecificLinkQuery extends BaseListQuery<
 
     // Store the next page token for pagination
     this.nextPageToken = response.nextPageToken;
+
+    if (this.#resolveToObjectType && response.data.length > 0) {
+      const reloadedData = await reloadDataAsFullObjects(
+        this.store.client,
+        response.data,
+      );
+      return { ...response, data: reloadedData };
+    }
 
     return response;
   }

--- a/packages/client/src/observable/internal/links/SpecificLinkQuery.ts
+++ b/packages/client/src/observable/internal/links/SpecificLinkQuery.ts
@@ -44,8 +44,10 @@ import { OrderBySortingStrategy } from "../sorting/SortingStrategy.js";
 import type { Store } from "../Store.js";
 import type { SubjectPayload } from "../SubjectPayload.js";
 import { tombstone } from "../tombstone.js";
+import { reloadDataAsFullObjects } from "../utils/reloadDataAsFullObjects.js";
 import {
   INCLUDE_ALL_BASE_PROPERTIES_IDX as LINK_INCLUDE_ALL_BASE_PROPERTIES_IDX,
+  RESOLVE_TO_OBJECT_TYPE_IDX as LINK_RESOLVE_TO_OBJECT_TYPE_IDX,
   SELECT_IDX as LINK_SELECT_IDX,
   type SpecificLinkCacheKey,
 } from "./SpecificLinkCacheKey.js";
@@ -70,6 +72,7 @@ export class SpecificLinkQuery extends BaseListQuery<
   #whereClause: Canonical<SimpleWhereClause>;
   #orderBy: Canonical<Record<string, "asc" | "desc" | undefined>>;
   #select: Canonical<readonly string[]> | undefined;
+  #resolveToObjectType: boolean;
 
   protected override createPayload(
     params: CollectionConnectableParams,
@@ -123,6 +126,8 @@ export class SpecificLinkQuery extends BaseListQuery<
       this.#orderBy,
     ] = cacheKey.otherKeys;
     this.#select = cacheKey.otherKeys[LINK_SELECT_IDX];
+    this.#resolveToObjectType =
+      cacheKey.otherKeys[LINK_RESOLVE_TO_OBJECT_TYPE_IDX] === true;
   }
 
   protected get rawSelect(): Canonical<readonly string[]> | undefined {
@@ -156,7 +161,10 @@ export class SpecificLinkQuery extends BaseListQuery<
     const hasOrderBy = this.#orderBy
       && Object.keys(this.#orderBy).length > 0;
     let target: { apiName: string; kind: "object" | "interface" } | undefined;
-    if (hasOrderBy || this.includeAllBaseObjectProperties) {
+    if (
+      hasOrderBy || this.includeAllBaseObjectProperties
+      || this.#resolveToObjectType
+    ) {
       if (isInterface) {
         const interfaceMetadata = await ontologyProvider.getInterfaceDefinition(
           this.#sourceApiName,
@@ -272,6 +280,17 @@ export class SpecificLinkQuery extends BaseListQuery<
 
     // Store the next page token for pagination
     this.nextPageToken = response.nextPageToken;
+
+    // Honor resolveToObjectType only when the link target is an interface —
+    // for concrete object targets the data is already in object form.
+    if (
+      this.#resolveToObjectType
+      && target?.kind === "interface"
+      && response.data.length > 0
+    ) {
+      const fullData = await reloadDataAsFullObjects(client, response.data);
+      return { ...response, data: fullData };
+    }
 
     return response;
   }

--- a/packages/client/src/observable/internal/links/SpecificLinkQuery.ts
+++ b/packages/client/src/observable/internal/links/SpecificLinkQuery.ts
@@ -286,7 +286,6 @@ export class SpecificLinkQuery extends BaseListQuery<
     if (
       this.#resolveToObjectType
       && target?.kind === "interface"
-      && response.data.length > 0
     ) {
       const fullData = await reloadDataAsFullObjects(client, response.data);
       return { ...response, data: fullData };

--- a/packages/client/src/observable/internal/list/InterfaceListQuery.ts
+++ b/packages/client/src/observable/internal/list/InterfaceListQuery.ts
@@ -23,16 +23,7 @@ import type {
   Osdk,
   WhereClause,
 } from "@osdk/api";
-function groupBy<T>(arr: T[], fn: (item: T) => string): Record<string, T[]> {
-  const result: Record<string, T[]> = {};
-  for (const item of arr) {
-    const key = fn(item);
-    (result[key] ??= []).push(item);
-  }
-  return result;
-}
-import invariant from "tiny-invariant";
-import { additionalContext, type Client } from "../../../Client.js";
+import { additionalContext } from "../../../Client.js";
 import type { InterfaceHolder } from "../../../object/convertWireToOsdkObjects/InterfaceHolder.js";
 import { ObjectDefRef } from "../../../object/convertWireToOsdkObjects/InternalSymbols.js";
 import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
@@ -41,8 +32,8 @@ import type { CollectionConnectableParams } from "../base-list/BaseCollectionQue
 import type { Changes } from "../Changes.js";
 import type { PivotInfo } from "../PivotCanonicalizer.js";
 import type { Rdp } from "../RdpCanonicalizer.js";
-import type { SimpleWhereClause } from "../SimpleWhereClause.js";
 import type { Store } from "../Store.js";
+import { reloadDataAsFullObjects } from "../utils/reloadDataAsFullObjects.js";
 import { ListQuery, PIVOT_IDX, RDP_IDX, RIDS_IDX } from "./ListQuery.js";
 
 type ExtractRelevantObjectsResult = Record<
@@ -192,59 +183,4 @@ function createSourceSetForPivot(
     type: "object",
     apiName: pivotInfo.sourceType,
   } as ObjectTypeDefinition) as ObjectSet<ObjectOrInterfaceDefinition>;
-}
-
-// Hopefully this can go away when we can just request the full object properties on first load
-async function reloadDataAsFullObjects(
-  client: Client,
-  data: Osdk.Instance<any>[],
-) {
-  if (data.length === 0) {
-    return data;
-  }
-
-  const groups = groupBy(data, (x) => x.$objectType);
-  const objectTypeToPrimaryKeyToObject = Object.fromEntries(
-    await Promise.all(
-      Object.entries(groups).map<
-        Promise<
-          [
-            /** objectType **/ string,
-            Record<string | number, Osdk.Instance<ObjectTypeDefinition>>,
-          ]
-        >
-      >(async ([apiName, objects]) => {
-        // Interface query results don't have ObjectDefRef, so we fetch metadata to get primaryKeyApiName
-        const objectDef = await client.fetchMetadata({
-          type: "object",
-          apiName,
-        });
-        const where: SimpleWhereClause = {
-          [objectDef.primaryKeyApiName]: {
-            $in: objects.map((x) => x.$primaryKey),
-          },
-        };
-
-        const result = await client(objectDef as ObjectTypeDefinition)
-          .where(
-            where as Parameters<ObjectSet<ObjectTypeDefinition>["where"]>[0],
-          )
-          .fetchPage({ $includeRid: true });
-        return [
-          apiName,
-          Object.fromEntries(result.data.map((x) => [x.$primaryKey, x])),
-        ];
-      }),
-    ),
-  );
-
-  return data.map((obj) => {
-    const fullObject =
-      objectTypeToPrimaryKeyToObject[obj.$objectType][obj.$primaryKey];
-    invariant(
-      fullObject,
-      `Could not find object ${obj.$objectType} ${obj.$primaryKey}`,
-    );
-    return fullObject;
-  });
 }

--- a/packages/client/src/observable/internal/list/InterfaceListQuery.ts
+++ b/packages/client/src/observable/internal/list/InterfaceListQuery.ts
@@ -23,19 +23,7 @@ import type {
   Osdk,
   WhereClause,
 } from "@osdk/api";
-function groupBy<T>(
-  arr: T[],
-  fn: (item: T) => string,
-): Record<string, T[]> {
-  const result: Record<string, T[]> = {};
-  for (const item of arr) {
-    const key = fn(item);
-    (result[key] ??= []).push(item);
-  }
-  return result;
-}
-import invariant from "tiny-invariant";
-import { additionalContext, type Client } from "../../../Client.js";
+import { additionalContext } from "../../../Client.js";
 import type { InterfaceHolder } from "../../../object/convertWireToOsdkObjects/InterfaceHolder.js";
 import { ObjectDefRef } from "../../../object/convertWireToOsdkObjects/InternalSymbols.js";
 import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
@@ -44,8 +32,8 @@ import type { CollectionConnectableParams } from "../base-list/BaseCollectionQue
 import type { Changes } from "../Changes.js";
 import type { PivotInfo } from "../PivotCanonicalizer.js";
 import type { Rdp } from "../RdpCanonicalizer.js";
-import type { SimpleWhereClause } from "../SimpleWhereClause.js";
 import type { Store } from "../Store.js";
+import { reloadDataAsFullObjects } from "../utils/reloadDataAsFullObjects.js";
 import { ListQuery, PIVOT_IDX, RDP_IDX, RIDS_IDX } from "./ListQuery.js";
 
 type ExtractRelevantObjectsResult = Record<"added" | "modified", {
@@ -203,61 +191,4 @@ function createSourceSetForPivot(
     type: "object",
     apiName: pivotInfo.sourceType,
   } as ObjectTypeDefinition) as ObjectSet<ObjectOrInterfaceDefinition>;
-}
-
-// Hopefully this can go away when we can just request the full object properties on first load
-async function reloadDataAsFullObjects(
-  client: Client,
-  data: Osdk.Instance<any>[],
-) {
-  if (data.length === 0) {
-    return data;
-  }
-
-  const groups = groupBy(data, (x) => x.$objectType);
-  const objectTypeToPrimaryKeyToObject = Object.fromEntries(
-    await Promise.all(
-      Object.entries(groups).map<
-        Promise<
-          [
-            /** objectType **/ string,
-            Record<string | number, Osdk.Instance<ObjectTypeDefinition>>,
-          ]
-        >
-      >(async ([apiName, objects]) => {
-        // Interface query results don't have ObjectDefRef, so we fetch metadata to get primaryKeyApiName
-        const objectDef = await client.fetchMetadata({
-          type: "object",
-          apiName,
-        });
-        const where: SimpleWhereClause = {
-          [objectDef.primaryKeyApiName]: {
-            $in: objects.map(x => x.$primaryKey),
-          },
-        };
-
-        const result = await client(
-          objectDef as ObjectTypeDefinition,
-        ).where(
-          where as Parameters<ObjectSet<ObjectTypeDefinition>["where"]>[0],
-        ).fetchPage({ $includeRid: true });
-        return [
-          apiName,
-          Object.fromEntries(result.data.map(
-            x => [x.$primaryKey, x],
-          )),
-        ];
-      }),
-    ),
-  );
-
-  return data.map((obj) => {
-    const fullObject =
-      objectTypeToPrimaryKeyToObject[obj.$objectType][obj.$primaryKey];
-    invariant(
-      fullObject,
-      `Could not find object ${obj.$objectType} ${obj.$primaryKey}`,
-    );
-    return fullObject;
-  });
 }

--- a/packages/client/src/observable/internal/utils/reloadDataAsFullObjects.ts
+++ b/packages/client/src/observable/internal/utils/reloadDataAsFullObjects.ts
@@ -16,7 +16,7 @@
 
 import type { ObjectSet, ObjectTypeDefinition, Osdk } from "@osdk/api";
 import invariant from "tiny-invariant";
-import { type Client } from "../../../Client.js";
+import type { Client } from "../../../Client.js";
 import type { SimpleWhereClause } from "../SimpleWhereClause.js";
 
 function groupBy<T>(arr: T[], fn: (item: T) => string): Record<string, T[]> {

--- a/packages/client/src/observable/internal/utils/reloadDataAsFullObjects.ts
+++ b/packages/client/src/observable/internal/utils/reloadDataAsFullObjects.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectSet, ObjectTypeDefinition, Osdk } from "@osdk/api";
+import invariant from "tiny-invariant";
+import { type Client } from "../../../Client.js";
+import type { SimpleWhereClause } from "../SimpleWhereClause.js";
+
+function groupBy<T>(arr: T[], fn: (item: T) => string): Record<string, T[]> {
+  const result: Record<string, T[]> = {};
+  for (const item of arr) {
+    const key = fn(item);
+    (result[key] ??= []).push(item);
+  }
+  return result;
+}
+
+// Hopefully this can go away when we can just request the full object properties on first load
+export async function reloadDataAsFullObjects(
+  client: Client,
+  data: Osdk.Instance<any>[],
+): Promise<Osdk.Instance<any>[]> {
+  if (data.length === 0) {
+    return data;
+  }
+
+  const groups = groupBy(data, (x) => x.$objectType);
+  const objectTypeToPrimaryKeyToObject = Object.fromEntries(
+    await Promise.all(
+      Object.entries(groups).map<
+        Promise<
+          [
+            /** objectType **/ string,
+            Record<string | number, Osdk.Instance<ObjectTypeDefinition>>,
+          ]
+        >
+      >(async ([apiName, objects]) => {
+        // Interface query results don't have ObjectDefRef, so we fetch metadata to get primaryKeyApiName
+        const objectDef = await client.fetchMetadata({
+          type: "object",
+          apiName,
+        });
+        const where: SimpleWhereClause = {
+          [objectDef.primaryKeyApiName]: {
+            $in: objects.map((x) => x.$primaryKey),
+          },
+        };
+
+        const result = await client(objectDef as ObjectTypeDefinition)
+          .where(
+            where as Parameters<ObjectSet<ObjectTypeDefinition>["where"]>[0],
+          )
+          .fetchPage({ $includeRid: true });
+        return [
+          apiName,
+          Object.fromEntries(result.data.map((x) => [x.$primaryKey, x])),
+        ];
+      }),
+    ),
+  );
+
+  return data.map((obj) => {
+    const fullObject =
+      objectTypeToPrimaryKeyToObject[obj.$objectType][obj.$primaryKey];
+    invariant(
+      fullObject,
+      `Could not find object ${obj.$objectType} ${obj.$primaryKey}`,
+    );
+    return fullObject;
+  });
+}

--- a/packages/client/src/observable/internal/utils/reloadDataAsFullObjects.ts
+++ b/packages/client/src/observable/internal/utils/reloadDataAsFullObjects.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectSet, ObjectTypeDefinition, Osdk } from "@osdk/api";
+import invariant from "tiny-invariant";
+import type { Client } from "../../../Client.js";
+import type { SimpleWhereClause } from "../SimpleWhereClause.js";
+
+function groupBy<T>(
+  arr: T[],
+  fn: (item: T) => string,
+): Record<string, T[]> {
+  const result: Record<string, T[]> = {};
+  for (const item of arr) {
+    const key = fn(item);
+    (result[key] ??= []).push(item);
+  }
+  return result;
+}
+
+// Hopefully this can go away when we can just request the full object properties on first load
+export async function reloadDataAsFullObjects(
+  client: Client,
+  data: Osdk.Instance<any>[],
+): Promise<Osdk.Instance<any>[]> {
+  if (data.length === 0) {
+    return data;
+  }
+
+  const groups = groupBy(data, (x) => x.$objectType);
+  const objectTypeToPrimaryKeyToObject = Object.fromEntries(
+    await Promise.all(
+      Object.entries(groups).map<
+        Promise<
+          [
+            /** objectType **/ string,
+            Record<string | number, Osdk.Instance<ObjectTypeDefinition>>,
+          ]
+        >
+      >(async ([apiName, objects]) => {
+        // Interface query results don't have ObjectDefRef, so we fetch metadata to get primaryKeyApiName
+        const objectDef = await client.fetchMetadata({
+          type: "object",
+          apiName,
+        });
+        const where: SimpleWhereClause = {
+          [objectDef.primaryKeyApiName]: {
+            $in: objects.map(x => x.$primaryKey),
+          },
+        };
+
+        const result = await client(
+          objectDef as ObjectTypeDefinition,
+        ).where(
+          where as Parameters<ObjectSet<ObjectTypeDefinition>["where"]>[0],
+        ).fetchPage({ $includeRid: true });
+        return [
+          apiName,
+          Object.fromEntries(result.data.map(
+            x => [x.$primaryKey, x],
+          )),
+        ];
+      }),
+    ),
+  );
+
+  return data.map((obj) => {
+    const fullObject =
+      objectTypeToPrimaryKeyToObject[obj.$objectType][obj.$primaryKey];
+    invariant(
+      fullObject,
+      `Could not find object ${obj.$objectType} ${obj.$primaryKey}`,
+    );
+    return fullObject;
+  });
+}

--- a/packages/react/src/new/useLinks.ts
+++ b/packages/react/src/new/useLinks.ts
@@ -97,6 +97,10 @@ export interface UseLinksOptions<
    * With `resolveToObjectType: true`, objects are re-fetched by their
    * concrete object type to include all properties.
    *
+   * Pass an ObjectTypeDefinition to narrow the return type:
+   * `resolveToObjectType: Laptop` types results as `Osdk.Instance<Laptop>`.
+   * This is an unchecked assertion — the runtime does not filter by type.
+   *
    * @default false
    */
   resolveToObjectType?: boolean | ObjectTypeDefinition;
@@ -239,7 +243,7 @@ export function useLinks<
       otherOptions.mode,
       otherOptions.dedupeIntervalMs,
       canonOptions.$select,
-      resolveToObjectType,
+      !!resolveToObjectType,
     ],
   );
 

--- a/packages/react/src/new/useLinks.ts
+++ b/packages/react/src/new/useLinks.ts
@@ -87,6 +87,18 @@ export interface UseLinksOptions<
    * });
    */
   enabled?: boolean;
+
+  /**
+   * When the link target is an interface type, return full concrete
+   * object type instances instead of interface-narrowed views.
+   *
+   * By default, link queries return objects as provided by the API.
+   * With `resolveToObjectType: true`, objects are re-fetched by their
+   * concrete object type to include all properties.
+   *
+   * @default false
+   */
+  resolveToObjectType?: boolean;
 }
 
 export interface UseLinksResult<
@@ -144,7 +156,7 @@ export function useLinks<
 ): UseLinksResult<LinkedType<T, L>> {
   const { observableClient } = React.useContext(OsdkContext2);
 
-  const { enabled = true, ...otherOptions } = options;
+  const { enabled = true, resolveToObjectType, ...otherOptions } = options;
 
   const canonOptions = observableClient.canonicalizeOptions({
     where: otherOptions.where,
@@ -188,6 +200,7 @@ export function useLinks<
               mode: otherOptions.mode,
               dedupeInterval: otherOptions.dedupeIntervalMs ?? 2_000,
               ...(canonOptions.$select ? { select: canonOptions.$select } : {}),
+              ...(resolveToObjectType ? { resolveToObjectType } : {}),
             },
             observer,
           ),
@@ -206,6 +219,7 @@ export function useLinks<
       otherOptions.mode,
       otherOptions.dedupeIntervalMs,
       canonOptions.$select,
+      resolveToObjectType,
     ],
   );
 

--- a/packages/react/src/new/useLinks.ts
+++ b/packages/react/src/new/useLinks.ts
@@ -18,6 +18,7 @@ import type {
   LinkedType,
   LinkNames,
   ObjectOrInterfaceDefinition,
+  ObjectTypeDefinition,
 } from "@osdk/api";
 import type { Osdk, PropertyKeys, WhereClause } from "@osdk/client";
 import type { ObserveLinks } from "@osdk/client/unstable-do-not-use";
@@ -98,7 +99,7 @@ export interface UseLinksOptions<
    *
    * @default false
    */
-  resolveToObjectType?: boolean;
+  resolveToObjectType?: boolean | ObjectTypeDefinition;
 }
 
 export interface UseLinksResult<
@@ -149,11 +150,30 @@ const emptyMap: ReadonlyMap<string | number, ReadonlyArray<never>> = new Map();
 export function useLinks<
   T extends ObjectOrInterfaceDefinition,
   L extends LinkNames<T>,
+  R extends ObjectTypeDefinition,
+>(
+  objects: Osdk.Instance<T> | Array<Osdk.Instance<T>> | undefined,
+  linkName: L,
+  options: UseLinksOptions<LinkedType<T, L>> & { resolveToObjectType: R },
+): UseLinksResult<R>;
+
+export function useLinks<
+  T extends ObjectOrInterfaceDefinition,
+  L extends LinkNames<T>,
+>(
+  objects: Osdk.Instance<T> | Array<Osdk.Instance<T>> | undefined,
+  linkName: L,
+  options?: UseLinksOptions<LinkedType<T, L>>,
+): UseLinksResult<LinkedType<T, L>>;
+
+export function useLinks<
+  T extends ObjectOrInterfaceDefinition,
+  L extends LinkNames<T>,
 >(
   objects: Osdk.Instance<T> | Array<Osdk.Instance<T>> | undefined,
   linkName: L,
   options: UseLinksOptions<LinkedType<T, L>> = {},
-): UseLinksResult<LinkedType<T, L>> {
+): UseLinksResult<LinkedType<T, L>> | UseLinksResult<ObjectTypeDefinition> {
   const { observableClient } = React.useContext(OsdkContext2);
 
   const { enabled = true, resolveToObjectType, ...otherOptions } = options;
@@ -200,7 +220,7 @@ export function useLinks<
               mode: otherOptions.mode,
               dedupeInterval: otherOptions.dedupeIntervalMs ?? 2_000,
               ...(canonOptions.$select ? { select: canonOptions.$select } : {}),
-              ...(resolveToObjectType ? { resolveToObjectType } : {}),
+              ...(resolveToObjectType ? { resolveToObjectType: true } : {}),
             },
             observer,
           ),

--- a/packages/react/src/new/useLinks.ts
+++ b/packages/react/src/new/useLinks.ts
@@ -215,7 +215,7 @@ export function useLinks<
               mode: otherOptions.mode,
               dedupeInterval: otherOptions.dedupeIntervalMs ?? 2_000,
               $includeAllBaseObjectProperties,
-              ...(resolveToObjectType ? { resolveToObjectType: true } : {}),
+              resolveToObjectType,
               ...(canonOptions.$select ? { select: canonOptions.$select } : {}),
             },
             observer,

--- a/packages/react/src/new/useLinks.ts
+++ b/packages/react/src/new/useLinks.ts
@@ -18,6 +18,7 @@ import type {
   LinkedType,
   LinkNames,
   ObjectOrInterfaceDefinition,
+  ObjectTypeDefinition,
 } from "@osdk/api";
 import type { Osdk, PropertyKeys, WhereClause } from "@osdk/client";
 import type { ObserveLinks } from "@osdk/client/observable";
@@ -96,6 +97,21 @@ export interface UseLinksOptions<
    * object type.
    */
   $includeAllBaseObjectProperties?: boolean;
+
+  /**
+   * When traversing to linked objects via an interface link target, return
+   * the full concrete object type instances instead of interface views.
+   *
+   * Pass an ObjectTypeDefinition to narrow the return type to
+   * `Osdk.Instance<R>`. This is an unchecked assertion — the runtime does
+   * not filter by type.
+   *
+   * Only has an effect when the link target is an interface; for concrete
+   * object link targets this option is a no-op.
+   *
+   * @default false
+   */
+  resolveToObjectType?: boolean | ObjectTypeDefinition;
 }
 
 export interface UseLinksResult<Q extends ObjectOrInterfaceDefinition> {
@@ -133,6 +149,29 @@ export interface UseLinksResult<Q extends ObjectOrInterfaceDefinition> {
 const emptyArray = Object.freeze([]);
 const emptyMap: ReadonlyMap<string | number, ReadonlyArray<never>> = new Map();
 
+// resolveToObjectType overload: when an ObjectTypeDefinition is passed,
+// narrow the return type to Osdk.Instance<R>.
+export function useLinks<
+  T extends ObjectOrInterfaceDefinition,
+  L extends LinkNames<T>,
+  R extends ObjectTypeDefinition,
+>(
+  objects: Osdk.Instance<T> | Array<Osdk.Instance<T>> | undefined,
+  linkName: L,
+  options: UseLinksOptions<LinkedType<T, L>> & {
+    resolveToObjectType: R;
+  },
+): UseLinksResult<R>;
+
+export function useLinks<
+  T extends ObjectOrInterfaceDefinition,
+  L extends LinkNames<T>,
+>(
+  objects: Osdk.Instance<T> | Array<Osdk.Instance<T>> | undefined,
+  linkName: L,
+  options?: UseLinksOptions<LinkedType<T, L>>,
+): UseLinksResult<LinkedType<T, L>>;
+
 /**
  * Hook to observe links from an object or array of objects.
  *
@@ -151,8 +190,12 @@ export function useLinks<
 ): UseLinksResult<LinkedType<T, L>> {
   const { observableClient } = React.useContext(OsdkContext);
 
-  const { enabled = true, $includeAllBaseObjectProperties, ...otherOptions } =
-    options;
+  const {
+    enabled = true,
+    $includeAllBaseObjectProperties,
+    resolveToObjectType,
+    ...otherOptions
+  } = options;
 
   const canonOptions = observableClient.canonicalizeOptions({
     where: otherOptions.where,
@@ -204,6 +247,7 @@ export function useLinks<
               mode: otherOptions.mode,
               dedupeInterval: otherOptions.dedupeIntervalMs ?? 2_000,
               $includeAllBaseObjectProperties,
+              ...(resolveToObjectType ? { resolveToObjectType: true } : {}),
               ...(canonOptions.$select ? { select: canonOptions.$select } : {}),
             },
             observer,
@@ -228,6 +272,7 @@ export function useLinks<
       otherOptions.dedupeIntervalMs,
       canonOptions.$select,
       $includeAllBaseObjectProperties,
+      !!resolveToObjectType,
     ],
   );
 

--- a/packages/react/src/new/useLinks.ts
+++ b/packages/react/src/new/useLinks.ts
@@ -18,7 +18,6 @@ import type {
   LinkedType,
   LinkNames,
   ObjectOrInterfaceDefinition,
-  ObjectTypeDefinition,
 } from "@osdk/api";
 import type { Osdk, PropertyKeys, WhereClause } from "@osdk/client";
 import type { ObserveLinks } from "@osdk/client/observable";
@@ -26,8 +25,15 @@ import React from "react";
 import { extractPayloadError, isPayloadLoading } from "./hookUtils.js";
 import { devToolsMetadata, makeExternalStore } from "./makeExternalStore.js";
 import { OsdkContext } from "./OsdkContext.js";
+import type { ResolveToObjectTypeOption } from "./useOsdkObjects.js";
 
-export interface UseLinksOptions<
+export type UseLinksOptions<
+  T extends ObjectOrInterfaceDefinition,
+> =
+  & UseLinksBaseOptions<T>
+  & ResolveToObjectTypeOption<T>;
+
+interface UseLinksBaseOptions<
   T extends ObjectOrInterfaceDefinition,
 > {
   /**
@@ -97,21 +103,6 @@ export interface UseLinksOptions<
    * object type.
    */
   $includeAllBaseObjectProperties?: boolean;
-
-  /**
-   * When traversing to linked objects via an interface link target, return
-   * the full concrete object type instances instead of interface views.
-   *
-   * Pass an ObjectTypeDefinition to narrow the return type to
-   * `Osdk.Instance<R>`. This is an unchecked assertion — the runtime does
-   * not filter by type.
-   *
-   * Only has an effect when the link target is an interface; for concrete
-   * object link targets this option is a no-op.
-   *
-   * @default false
-   */
-  resolveToObjectType?: boolean | ObjectTypeDefinition;
 }
 
 export interface UseLinksResult<Q extends ObjectOrInterfaceDefinition> {
@@ -148,29 +139,6 @@ export interface UseLinksResult<Q extends ObjectOrInterfaceDefinition> {
 
 const emptyArray = Object.freeze([]);
 const emptyMap: ReadonlyMap<string | number, ReadonlyArray<never>> = new Map();
-
-// resolveToObjectType overload: when an ObjectTypeDefinition is passed,
-// narrow the return type to Osdk.Instance<R>.
-export function useLinks<
-  T extends ObjectOrInterfaceDefinition,
-  L extends LinkNames<T>,
-  R extends ObjectTypeDefinition,
->(
-  objects: Osdk.Instance<T> | Array<Osdk.Instance<T>> | undefined,
-  linkName: L,
-  options: UseLinksOptions<LinkedType<T, L>> & {
-    resolveToObjectType: R;
-  },
-): UseLinksResult<R>;
-
-export function useLinks<
-  T extends ObjectOrInterfaceDefinition,
-  L extends LinkNames<T>,
->(
-  objects: Osdk.Instance<T> | Array<Osdk.Instance<T>> | undefined,
-  linkName: L,
-  options?: UseLinksOptions<LinkedType<T, L>>,
-): UseLinksResult<LinkedType<T, L>>;
 
 /**
  * Hook to observe links from an object or array of objects.

--- a/packages/react/test/useLinks.enabled.test.tsx
+++ b/packages/react/test/useLinks.enabled.test.tsx
@@ -264,5 +264,30 @@ describe("useLinks enabled option", () => {
       // both are truthy so dep array entry !!resolveToObjectType is stable
       expect(mockObserveLinks).toHaveBeenCalledTimes(1);
     });
+
+    it("should resubscribe when resolveToObjectType toggles between truthy and falsy", () => {
+      const wrapper = createWrapper();
+
+      const { rerender } = renderHook(
+        ({ resolve }) =>
+          useLinks(mockObject, "relatedObjects", {
+            resolveToObjectType: resolve,
+          }),
+        {
+          wrapper,
+          initialProps: {
+            resolve: true as boolean | ObjectTypeDefinition | undefined,
+          },
+        },
+      );
+
+      expect(mockObserveLinks).toHaveBeenCalledTimes(1);
+
+      rerender({ resolve: undefined });
+
+      expect(mockObserveLinks).toHaveBeenCalledTimes(2);
+      const lastCallOptions = mockObserveLinks.mock.calls[1][2];
+      expect(lastCallOptions.resolveToObjectType).toBeUndefined();
+    });
   });
 });

--- a/packages/react/test/useLinks.enabled.test.tsx
+++ b/packages/react/test/useLinks.enabled.test.tsx
@@ -26,6 +26,12 @@ const MockObjectType = {
   primaryKeyType: "string",
 } as unknown as ObjectTypeDefinition;
 
+const ConcreteTargetType = {
+  apiName: "ConcreteTarget",
+  type: "object",
+  primaryKeyType: "string",
+} as unknown as ObjectTypeDefinition;
+
 const mockObject: Osdk.Instance<typeof MockObjectType> = {
   $objectType: "MockObject",
   $primaryKey: "obj-123",
@@ -187,5 +193,76 @@ describe("useLinks enabled option", () => {
     expect(mockObserveLinks).toHaveBeenCalledTimes(1);
     const options = mockObserveLinks.mock.calls[0][2];
     expect(options.$includeAllBaseObjectProperties).toBe(true);
+  });
+
+  describe("resolveToObjectType", () => {
+    it("should pass resolveToObjectType: true to observeLinks when true", () => {
+      const wrapper = createWrapper();
+
+      renderHook(
+        () =>
+          useLinks(mockObject, "relatedObjects", {
+            resolveToObjectType: true,
+          }),
+        { wrapper },
+      );
+
+      expect(mockObserveLinks).toHaveBeenCalledTimes(1);
+      const options = mockObserveLinks.mock.calls[0][2];
+      expect(options.resolveToObjectType).toBe(true);
+    });
+
+    it("should pass resolveToObjectType: true to observeLinks when an ObjectTypeDefinition is provided", () => {
+      const wrapper = createWrapper();
+
+      renderHook(
+        () =>
+          useLinks(mockObject, "relatedObjects", {
+            resolveToObjectType: ConcreteTargetType,
+          }),
+        { wrapper },
+      );
+
+      expect(mockObserveLinks).toHaveBeenCalledTimes(1);
+      const options = mockObserveLinks.mock.calls[0][2];
+      expect(options.resolveToObjectType).toBe(true);
+    });
+
+    it("should not include resolveToObjectType when not set", () => {
+      const wrapper = createWrapper();
+
+      renderHook(
+        () => useLinks(mockObject, "relatedObjects"),
+        { wrapper },
+      );
+
+      expect(mockObserveLinks).toHaveBeenCalledTimes(1);
+      const options = mockObserveLinks.mock.calls[0][2];
+      expect(options.resolveToObjectType).toBeUndefined();
+    });
+
+    it("should not resubscribe when resolveToObjectType reference changes but its truthiness is stable", () => {
+      const wrapper = createWrapper();
+
+      const { rerender } = renderHook(
+        ({ resolve }) =>
+          useLinks(mockObject, "relatedObjects", {
+            resolveToObjectType: resolve,
+          }),
+        {
+          wrapper,
+          initialProps: {
+            resolve: true as boolean | ObjectTypeDefinition,
+          },
+        },
+      );
+
+      expect(mockObserveLinks).toHaveBeenCalledTimes(1);
+
+      rerender({ resolve: ConcreteTargetType });
+
+      // both are truthy so dep array entry !!resolveToObjectType is stable
+      expect(mockObserveLinks).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/react/test/useLinks.enabled.test.tsx
+++ b/packages/react/test/useLinks.enabled.test.tsx
@@ -26,12 +26,6 @@ const MockObjectType = {
   primaryKeyType: "string",
 } as unknown as ObjectTypeDefinition;
 
-const ConcreteTargetType = {
-  apiName: "ConcreteTarget",
-  type: "object",
-  primaryKeyType: "string",
-} as unknown as ObjectTypeDefinition;
-
 const mockObject: Osdk.Instance<typeof MockObjectType> = {
   $objectType: "MockObject",
   $primaryKey: "obj-123",
@@ -212,22 +206,6 @@ describe("useLinks enabled option", () => {
       expect(options.resolveToObjectType).toBe(true);
     });
 
-    it("should pass resolveToObjectType: true to observeLinks when an ObjectTypeDefinition is provided", () => {
-      const wrapper = createWrapper();
-
-      renderHook(
-        () =>
-          useLinks(mockObject, "relatedObjects", {
-            resolveToObjectType: ConcreteTargetType,
-          }),
-        { wrapper },
-      );
-
-      expect(mockObserveLinks).toHaveBeenCalledTimes(1);
-      const options = mockObserveLinks.mock.calls[0][2];
-      expect(options.resolveToObjectType).toBe(true);
-    });
-
     it("should not include resolveToObjectType when not set", () => {
       const wrapper = createWrapper();
 
@@ -241,30 +219,6 @@ describe("useLinks enabled option", () => {
       expect(options.resolveToObjectType).toBeUndefined();
     });
 
-    it("should not resubscribe when resolveToObjectType reference changes but its truthiness is stable", () => {
-      const wrapper = createWrapper();
-
-      const { rerender } = renderHook(
-        ({ resolve }) =>
-          useLinks(mockObject, "relatedObjects", {
-            resolveToObjectType: resolve,
-          }),
-        {
-          wrapper,
-          initialProps: {
-            resolve: true as boolean | ObjectTypeDefinition,
-          },
-        },
-      );
-
-      expect(mockObserveLinks).toHaveBeenCalledTimes(1);
-
-      rerender({ resolve: ConcreteTargetType });
-
-      // both are truthy so dep array entry !!resolveToObjectType is stable
-      expect(mockObserveLinks).toHaveBeenCalledTimes(1);
-    });
-
     it("should resubscribe when resolveToObjectType toggles between truthy and falsy", () => {
       const wrapper = createWrapper();
 
@@ -276,7 +230,7 @@ describe("useLinks enabled option", () => {
         {
           wrapper,
           initialProps: {
-            resolve: true as boolean | ObjectTypeDefinition | undefined,
+            resolve: true as boolean | undefined,
           },
         },
       );

--- a/packages/react/test/useLinks.enabled.test.tsx
+++ b/packages/react/test/useLinks.enabled.test.tsx
@@ -218,30 +218,5 @@ describe("useLinks enabled option", () => {
       const options = mockObserveLinks.mock.calls[0][2];
       expect(options.resolveToObjectType).toBeUndefined();
     });
-
-    it("should resubscribe when resolveToObjectType toggles between truthy and falsy", () => {
-      const wrapper = createWrapper();
-
-      const { rerender } = renderHook(
-        ({ resolve }) =>
-          useLinks(mockObject, "relatedObjects", {
-            resolveToObjectType: resolve,
-          }),
-        {
-          wrapper,
-          initialProps: {
-            resolve: true as boolean | undefined,
-          },
-        },
-      );
-
-      expect(mockObserveLinks).toHaveBeenCalledTimes(1);
-
-      rerender({ resolve: undefined });
-
-      expect(mockObserveLinks).toHaveBeenCalledTimes(2);
-      const lastCallOptions = mockObserveLinks.mock.calls[1][2];
-      expect(lastCallOptions.resolveToObjectType).toBeUndefined();
-    });
   });
 });

--- a/packages/react/test/useLinks.resolveToObjectType.test.tsx
+++ b/packages/react/test/useLinks.resolveToObjectType.test.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectTypeDefinition, Osdk } from "@osdk/api";
+import { renderHook } from "@testing-library/react";
+import * as React from "react";
+import { beforeEach, describe, expect, it, vitest } from "vitest";
+import { OsdkContext2 } from "../src/new/OsdkContext2.js";
+import { useLinks } from "../src/new/useLinks.js";
+
+const MockObjectType = {
+  apiName: "MockObject",
+  primaryKeyType: "string",
+} as unknown as ObjectTypeDefinition;
+
+const mockObject: Osdk.Instance<typeof MockObjectType> = {
+  $objectType: "MockObject",
+  $primaryKey: "obj-123",
+  $apiName: "MockObject",
+} as any;
+
+describe("useLinks with resolveToObjectType", () => {
+  const mockObserveLinks = vitest.fn();
+
+  const createWrapper = () => {
+    const observableClient = {
+      observeLinks: mockObserveLinks,
+      canonicalizeWhereClause: vitest.fn((w) => w),
+    } as any;
+
+    return ({ children }: React.PropsWithChildren) => (
+      <OsdkContext2.Provider value={{ observableClient }}>
+        {children}
+      </OsdkContext2.Provider>
+    );
+  };
+
+  beforeEach(() => {
+    mockObserveLinks.mockClear();
+    mockObserveLinks.mockReturnValue({ unsubscribe: vitest.fn() });
+  });
+
+  it("should pass resolveToObjectType to observeLinks", () => {
+    const wrapper = createWrapper();
+
+    renderHook(
+      () =>
+        useLinks(mockObject, "relatedObjects", {
+          resolveToObjectType: true,
+        }),
+      { wrapper },
+    );
+
+    expect(mockObserveLinks).toHaveBeenCalledTimes(1);
+    const options = mockObserveLinks.mock.calls[0][2];
+    expect(options.resolveToObjectType).toBe(true);
+  });
+
+  it("should not include resolveToObjectType when not set", () => {
+    const wrapper = createWrapper();
+
+    renderHook(
+      () => useLinks(mockObject, "relatedObjects"),
+      { wrapper },
+    );
+
+    expect(mockObserveLinks).toHaveBeenCalledTimes(1);
+    const options = mockObserveLinks.mock.calls[0][2];
+    expect(options.resolveToObjectType).toBeUndefined();
+  });
+});

--- a/packages/react/test/useLinks.resolveToObjectType.test.tsx
+++ b/packages/react/test/useLinks.resolveToObjectType.test.tsx
@@ -23,6 +23,13 @@ import { useLinks } from "../src/new/useLinks.js";
 
 const MockObjectType = {
   apiName: "MockObject",
+  type: "object",
+  primaryKeyType: "string",
+} as unknown as ObjectTypeDefinition;
+
+const ConcreteTargetType = {
+  apiName: "ConcreteTarget",
+  type: "object",
   primaryKeyType: "string",
 } as unknown as ObjectTypeDefinition;
 
@@ -60,6 +67,22 @@ describe("useLinks with resolveToObjectType", () => {
       () =>
         useLinks(mockObject, "relatedObjects", {
           resolveToObjectType: true,
+        }),
+      { wrapper },
+    );
+
+    expect(mockObserveLinks).toHaveBeenCalledTimes(1);
+    const options = mockObserveLinks.mock.calls[0][2];
+    expect(options.resolveToObjectType).toBe(true);
+  });
+
+  it("should normalize ObjectTypeDefinition to true in observeLinks", () => {
+    const wrapper = createWrapper();
+
+    renderHook(
+      () =>
+        useLinks(mockObject, "relatedObjects", {
+          resolveToObjectType: ConcreteTargetType,
         }),
       { wrapper },
     );


### PR DESCRIPTION
extends resolveToObjectType to the useLinks hook for interface link targets

• extract reloadDataAsFullObjects to shared utility used by both InterfaceListQuery and SpecificLinkQuery
• thread resolveToObjectType through ObserveLinks.Options, cache key, LinksHelper, and SpecificLinkQuery
• add option to useLinks hook with pass-through to observeLinks