### PR TITLE
add and update CLAUDE.md files for root, client, react, and observable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ OSDK TypeScript monorepo. Provides a type-safe SDK for Palantir Foundry ontologi
 
 ### Building specific packages
 
-Always use `--filter` to avoid rebuilding the whole monorepo:
+This monorepo has many packages. NEVER run unfiltered `pnpm turbo build` or `pnpm turbo transpile` unless explicitly asked -- it rebuilds everything and takes a long time. Always use `--filter` to target only the packages you're working on:
 - **Typecheck only**: `pnpm turbo typecheck --filter=@osdk/client`
 - **Transpile types** (generates `.d.ts` into `build/types/`): `pnpm turbo transpileTypes --filter=@osdk/client`
 - **Transpile ESM** (generates JS into `build/esm/`): `pnpm turbo transpileEsm --filter=@osdk/client`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,22 @@
+## Project Overview
+
+OSDK TypeScript monorepo (~82 packages). Provides a type-safe SDK for Palantir Foundry ontologies: code generation, client runtime, React hooks, CLI tooling, and widget framework.
+
+- **Package manager**: pnpm 10.27.0 (enforced via `engines` and `packageManager` in root `package.json`)
+- **Node.js**: >=18.19.0. CI tests on Node 18, 20, 22, and 24
+- **Workspace layout**: `packages/*`, `examples/*`, `examples-extra/*`, `tests/*`, `benchmarks/*/*`, `docs/`
+
+## Build System
+
+- Turbo orchestrates all tasks. `pnpm check` runs everything CI runs (lint, transpile, typecheck, test, check-attw, check-api, check-spelling)
+- Each published package produces 3 output formats: ESM (`build/esm`), CJS (`build/cjs`), Browser (`build/browser`), plus type declarations (`build/types`)
+- Transpilation uses `@osdk/monorepo.tool.transpile` (tsup + babel with dead-code elimination for `process.env.NODE_ENV` guards)
+
+## License Headers
+
+- Every `.ts`/`.tsx` source file must have the Apache 2.0 license header block comment
+- ESLint enforces this via `eslint-plugin-header` -- run `eslint . --fix` in a package to add missing headers
+
 ## TypeScript Best Practices
 
 - NEVER use `any` without asking the user first. If you think you need `any`, you probably don't understand the problem
@@ -69,3 +88,21 @@
 - Common breakages: new variants in `QueryDataType` discriminated unions (find exhaustive switches via `const _: never`), new required fields on types like `QueryTypeV2` in test stubs, and fields becoming optional
 - After fixing types, update snapshots with `pnpm vitest run --update` in affected packages
 - Validate with `pnpm check` before finalizing the PR
+
+## Additional Linting
+
+- **cspell**: Spell checking. Run per-package: `pnpm turbo check-spelling --filter=@osdk/the-package`
+- **monorepolint**: Enforces consistent package.json structure, tsconfig, and export maps. Config in `.monorepolint.config.mjs`
+- **ESLint flat config**: Root `eslint.config.mjs`. Key rules: `no-console` is an error (use a logger), `import/no-default-export` warns, `@typescript-eslint/consistent-type-imports` enforces `import type`
+- **attw** (`@arethetypeswrong/cli`): Validates package exports resolve correctly for ESM, CJS, and bundler consumers
+
+## Export Conventions
+
+- Published packages use conditional exports in `package.json`: `browser` -> `import` (with `types` subpath) -> `require` -> `default`
+- Internal sub-paths follow patterns: `./internal`, `./unstable-do-not-use`, `./experimental`, `./*` (wildcard)
+- Public API surface files live in `src/public/` and map to the `package.json` `exports` entries
+
+## Release Process
+
+- Changesets with fixed version groups defined in `.changeset/config.json`
+- Snapshot releases publish on merges to the `next` branch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 ## Project Overview
 
-OSDK TypeScript monorepo (~82 packages). Provides a type-safe SDK for Palantir Foundry ontologies: code generation, client runtime, React hooks, CLI tooling, and widget framework.
+OSDK TypeScript monorepo. Provides a type-safe SDK for Palantir Foundry ontologies: code generation, client runtime, React hooks, CLI tooling, and widget framework.
 
 - **Package manager**: pnpm 10.27.0 (enforced via `engines` and `packageManager` in root `package.json`)
 - **Node.js**: >=18.19.0. CI tests on Node 18, 20, 22, and 24
@@ -11,6 +11,23 @@ OSDK TypeScript monorepo (~82 packages). Provides a type-safe SDK for Palantir F
 - Turbo orchestrates all tasks. `pnpm check` runs everything CI runs (lint, transpile, typecheck, test, check-attw, check-api, check-spelling)
 - Each published package produces 3 output formats: ESM (`build/esm`), CJS (`build/cjs`), Browser (`build/browser`), plus type declarations (`build/types`)
 - Transpilation uses `@osdk/monorepo.tool.transpile` (tsup + babel with dead-code elimination for `process.env.NODE_ENV` guards)
+
+### Building specific packages
+
+Always use `--filter` to avoid rebuilding the whole monorepo:
+- **Typecheck only**: `pnpm turbo typecheck --filter=@osdk/client`
+- **Transpile types** (generates `.d.ts` into `build/types/`): `pnpm turbo transpileTypes --filter=@osdk/client`
+- **Transpile ESM** (generates JS into `build/esm/`): `pnpm turbo transpileEsm --filter=@osdk/client`
+- **Transpile all formats** (ESM + CJS + Browser): `pnpm turbo transpile --filter=@osdk/client`
+- **Full build** (transpile + types + typecheck): `pnpm turbo build --filter=@osdk/client`
+
+Turbo handles dependency ordering automatically -- if `@osdk/react` depends on `@osdk/client`, filtering to react will build client first.
+
+**When to use which**:
+- Iterating on types: `transpileTypes` (fastest, just generates `.d.ts`)
+- Need to run tests or check runtime: `transpileEsm` (generates runnable JS)
+- Before pushing: `pnpm turbo transpile` globally to catch cross-package issues
+- Checking API report changes: `pnpm turbo check-api --filter=@osdk/the-package` (depends on `transpileTypes`)
 
 ## License Headers
 
@@ -104,4 +121,3 @@ OSDK TypeScript monorepo (~82 packages). Provides a type-safe SDK for Palantir F
 ## Release Process
 
 - Changesets with fixed version groups defined in `.changeset/config.json`
-- Snapshot releases publish on merges to the `next` branch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ OSDK TypeScript monorepo. Provides a type-safe SDK for Palantir Foundry ontologi
 
 This monorepo has many packages. Use `--filter` during development for fast iteration.
 
-Use `--filter` to target only packages you're working on:
+**During development** -- use `--filter` to target only packages you're working on:
 - **Typecheck only**: `pnpm turbo typecheck --filter=@osdk/client`
 - **Transpile types** (generates `.d.ts` into `build/types/`): `pnpm turbo transpileTypes --filter=@osdk/client`
 - **Transpile ESM** (generates JS into `build/esm/`): `pnpm turbo transpileEsm --filter=@osdk/client`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,20 +14,19 @@ OSDK TypeScript monorepo. Provides a type-safe SDK for Palantir Foundry ontologi
 
 ### Building specific packages
 
-This monorepo has many packages. NEVER run unfiltered `pnpm turbo build` or `pnpm turbo transpile` unless explicitly asked -- it rebuilds everything and takes a long time. Always use `--filter` to target only the packages you're working on:
+This monorepo has many packages. Use `--filter` during development for fast iteration, then validate the full repo before pushing.
+
+**During development** -- use `--filter` to target only packages you're working on:
 - **Typecheck only**: `pnpm turbo typecheck --filter=@osdk/client`
 - **Transpile types** (generates `.d.ts` into `build/types/`): `pnpm turbo transpileTypes --filter=@osdk/client`
 - **Transpile ESM** (generates JS into `build/esm/`): `pnpm turbo transpileEsm --filter=@osdk/client`
 - **Transpile all formats** (ESM + CJS + Browser): `pnpm turbo transpile --filter=@osdk/client`
 - **Full build** (transpile + types + typecheck): `pnpm turbo build --filter=@osdk/client`
+- **API report changes**: `pnpm turbo check-api --filter=@osdk/the-package` (depends on `transpileTypes`)
 
-Turbo handles dependency ordering automatically -- if `@osdk/react` depends on `@osdk/client`, filtering to react will build client first.
+Turbo handles dependency ordering automatically -- filtering to `@osdk/react` will build `@osdk/client` first if needed.
 
-**When to use which**:
-- Iterating on types: `transpileTypes` (fastest, just generates `.d.ts`)
-- Need to run tests or check runtime: `transpileEsm` (generates runnable JS)
-- Before pushing: `pnpm turbo transpile` globally to catch cross-package issues
-- Checking API report changes: `pnpm turbo check-api --filter=@osdk/the-package` (depends on `transpileTypes`)
+**Before pushing** -- run `pnpm check` on the whole repo. This runs lint, transpile, typecheck, test, check-attw, check-api, and check-spelling across all packages. Do not skip this step.
 
 ## License Headers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,6 @@ OSDK TypeScript monorepo (~82 packages). Provides a type-safe SDK for Palantir F
 
 ## Additional Linting
 
-- **cspell**: Spell checking. Run per-package: `pnpm turbo check-spelling --filter=@osdk/the-package`
 - **monorepolint**: Enforces consistent package.json structure, tsconfig, and export maps. Config in `.monorepolint.config.mjs`
 - **ESLint flat config**: Root `eslint.config.mjs`. Key rules: `no-console` is an error (use a logger), `import/no-default-export` warns, `@typescript-eslint/consistent-type-imports` enforces `import type`
 - **attw** (`@arethetypeswrong/cli`): Validates package exports resolve correctly for ESM, CJS, and bundler consumers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,9 +14,9 @@ OSDK TypeScript monorepo. Provides a type-safe SDK for Palantir Foundry ontologi
 
 ### Building specific packages
 
-This monorepo has many packages. Use `--filter` during development for fast iteration, then validate the full repo before pushing.
+This monorepo has many packages. Use `--filter` during development for fast iteration.
 
-**During development** -- use `--filter` to target only packages you're working on:
+Use `--filter` to target only packages you're working on:
 - **Typecheck only**: `pnpm turbo typecheck --filter=@osdk/client`
 - **Transpile types** (generates `.d.ts` into `build/types/`): `pnpm turbo transpileTypes --filter=@osdk/client`
 - **Transpile ESM** (generates JS into `build/esm/`): `pnpm turbo transpileEsm --filter=@osdk/client`
@@ -25,8 +25,6 @@ This monorepo has many packages. Use `--filter` during development for fast iter
 - **API report changes**: `pnpm turbo check-api --filter=@osdk/the-package` (depends on `transpileTypes`)
 
 Turbo handles dependency ordering automatically -- filtering to `@osdk/react` will build `@osdk/client` first if needed.
-
-**Before pushing** -- run `pnpm check` on the whole repo. This runs lint, transpile, typecheck, test, check-attw, check-api, and check-spelling across all packages. Do not skip this step.
 
 ## License Headers
 

--- a/packages/client/CLAUDE.md
+++ b/packages/client/CLAUDE.md
@@ -52,7 +52,5 @@ To add one: create a helper file in `src/intellisense.test.helpers/{testName}.ts
 
 ## Key Architectural Decisions
 
-- The `Client` is stateless -- it holds configuration but no cache. State lives in `ObservableClient`'s `Store`
-- `sideEffects: false` in package.json -- all code must be tree-shakeable
+- The `Client` caches ontology metadata but does not cache object data. Object/list caching lives in `ObservableClient`'s `Store` (see `src/observable/`)
 - Uses `conjure-lite` for Foundry API communication, not raw fetch
-- `@wry/trie` powers efficient canonicalization of query parameters in the observable layer

--- a/packages/client/CLAUDE.md
+++ b/packages/client/CLAUDE.md
@@ -4,15 +4,13 @@ Runtime client for Foundry ontology access. Creates typed clients that execute O
 
 ## Related Documentation
 
-- [`architecture_observable_client.md`](./architecture_observable_client.md) -- deep dive into Store internals, Layer system, CacheKeys via `@wry/trie`, batch updates, and optimistic mutation flow
 - [`src/CLAUDE.md`](./src/CLAUDE.md) -- code style (prefer functions over classes)
-- [`src/observable/CLAUDE.md`](./src/observable/CLAUDE.md) -- observable client architecture with links to sub-directory docs
+- [`src/observable/CLAUDE.md`](./src/observable/CLAUDE.md) -- observable client architecture and related docs
 
 ## Entry Points
 
 - `createClient(url, ontologyRid, tokenProvider)` -- standard client for ontology CRUD
 - `createPlatformClient(url, tokenProvider)` -- client for non-ontology Foundry platform APIs
-- `createObservableClient(client)` -- reactive wrapper (see `src/observable/`)
 
 ## Export Paths
 
@@ -21,7 +19,7 @@ Runtime client for Foundry ontology access. Creates typed clients that execute O
 | `@osdk/client` | Public stable API: `createClient`, `createPlatformClient` |
 | `@osdk/client/internal` | Semi-public internals (used by other `@osdk/*` packages) |
 | `@osdk/client/internal-node` | Node-specific internals |
-| `@osdk/client/unstable-do-not-use` | ObservableClient and types consumed by `@osdk/react` |
+| `@osdk/client/unstable-do-not-use` | Experimental APIs consumed by `@osdk/react` |
 | `@osdk/client/*` (wildcard) | Maps to `src/public/*.ts` |
 
 When adding new public API, add a barrel export in the appropriate `src/public/*.ts` file and update `package.json` exports if adding a new sub-path.
@@ -52,5 +50,5 @@ To add one: create a helper file in `src/intellisense.test.helpers/{testName}.ts
 
 ## Key Architectural Decisions
 
-- The `Client` caches ontology metadata but does not cache object data. Object/list caching lives in `ObservableClient`'s `Store` (see `src/observable/`)
+- The `Client` caches ontology metadata but does not cache object data
 - Uses `conjure-lite` for Foundry API communication, not raw fetch

--- a/packages/client/CLAUDE.md
+++ b/packages/client/CLAUDE.md
@@ -1,0 +1,41 @@
+# @osdk/client
+
+Runtime client for Foundry ontology access. Creates typed clients that execute OSDK operations (object reads, actions, queries) against a Foundry stack.
+
+## Entry Points
+
+- `createClient(url, ontologyRid, tokenProvider)` -- standard client for ontology CRUD
+- `createPlatformClient(url, tokenProvider)` -- client for non-ontology Foundry platform APIs
+- `createObservableClient(client)` -- reactive wrapper (see `src/observable/`)
+
+## Export Paths
+
+| Path | Purpose |
+|------|---------|
+| `@osdk/client` | Public stable API: `createClient`, `createPlatformClient` |
+| `@osdk/client/internal` | Semi-public internals (used by other `@osdk/*` packages) |
+| `@osdk/client/internal-node` | Node-specific internals |
+| `@osdk/client/unstable-do-not-use` | ObservableClient and types consumed by `@osdk/react` |
+| `@osdk/client/*` (wildcard) | Maps to `src/public/*.ts` |
+
+When adding new public API, add a barrel export in the appropriate `src/public/*.ts` file and update `package.json` exports if adding a new sub-path.
+
+## Code Style
+
+- **Prefer functions over classes** for tree-shaking (see `src/CLAUDE.md`)
+- **`process.env.NODE_ENV` guards**: Debug/logging code MUST be wrapped in `if (process.env.NODE_ENV !== "production")` blocks. Babel strips these in production builds. Do NOT extract these checks into helper functions or the dead-code elimination will break
+- **No `console.log`**: ESLint errors on it. Use the pino-based logger pattern in `src/logger/`
+
+## Testing
+
+- `vitest` with `pool: "forks"` (NOT threads -- required for process isolation)
+- Fake timers enabled for `setTimeout`, `clearTimeout`, `Date`
+- Run: `pnpm turbo test --filter=@osdk/client` or `pnpm --dir packages/client vitest run`
+- Test ontology stubs: `@osdk/client.test.ontology` package provides mock ontology definitions
+
+## Key Architectural Decisions
+
+- The `Client` is stateless -- it holds configuration but no cache. State lives in `ObservableClient`'s `Store`
+- `sideEffects: false` in package.json -- all code must be tree-shakeable
+- Uses `conjure-lite` for Foundry API communication, not raw fetch
+- `@wry/trie` powers efficient canonicalization of query parameters in the observable layer

--- a/packages/client/CLAUDE.md
+++ b/packages/client/CLAUDE.md
@@ -2,6 +2,12 @@
 
 Runtime client for Foundry ontology access. Creates typed clients that execute OSDK operations (object reads, actions, queries) against a Foundry stack.
 
+## Related Documentation
+
+- [`architecture_observable_client.md`](./architecture_observable_client.md) -- deep dive into Store internals, Layer system, CacheKeys via `@wry/trie`, batch updates, and optimistic mutation flow
+- [`src/CLAUDE.md`](./src/CLAUDE.md) -- code style (prefer functions over classes)
+- [`src/observable/CLAUDE.md`](./src/observable/CLAUDE.md) -- observable client architecture with links to sub-directory docs
+
 ## Entry Points
 
 - `createClient(url, ontologyRid, tokenProvider)` -- standard client for ontology CRUD
@@ -32,6 +38,17 @@ When adding new public API, add a barrel export in the appropriate `src/public/*
 - Fake timers enabled for `setTimeout`, `clearTimeout`, `Date`
 - Run: `pnpm turbo test --filter=@osdk/client` or `pnpm --dir packages/client vitest run`
 - Test ontology stubs: `@osdk/client.test.ontology` package provides mock ontology definitions
+
+## Intellisense Tests
+
+`src/intellisense.test.ts` verifies that TypeScript IDE hints and completions work correctly (hover docs, completion suggestions, etc.). Each test case has a corresponding helper file in `src/intellisense.test.helpers/`.
+
+When to add a new intellisense test:
+- You change the public API types (new properties, changed generics, renamed fields)
+- You add new type-level features (orderBy suggestions, property docs, query parameter hints)
+- You want to ensure JSDoc comments surface correctly in IDE hover
+
+To add one: create a helper file in `src/intellisense.test.helpers/{testName}.ts` with sample code, then add a test case in `intellisense.test.ts` that opens the helper and asserts on QuickInfo/Completions at specific positions.
 
 ## Key Architectural Decisions
 

--- a/packages/client/src/observable/CLAUDE.md
+++ b/packages/client/src/observable/CLAUDE.md
@@ -20,6 +20,7 @@ we want it to stay in that form.
 
 ## Related Documentation
 
+- [`architecture_observable_client.md`](../../architecture_observable_client.md) -- deep dive into Store internals, Layer system, CacheKeys, batch updates, and optimistic mutation flow
 - [`ObservableClient/CLAUDE.md`](./ObservableClient/CLAUDE.md) -- type definitions reference (Status, Observer, CommonObserveOptions, ObserveLink types)
 - [`internal/CLAUDE.md`](./internal/CLAUDE.md) -- Store architecture, Layer system, Query hierarchy, and cache key patterns
 - [`internal/links/CLAUDE.md`](./internal/links/CLAUDE.md) -- link observation implementation details, pivot queries, and link storage patterns
@@ -77,14 +78,6 @@ All observe methods accept `Observer<T>` with `next`, `error`, `complete` callba
 ## Canonicalization System
 
 Query parameters (where, orderBy, select, etc.) are canonicalized via specialized canonicalizers in `internal/` (`WhereClauseCanonicalizer`, `OrderByCanonicalizer`, `SelectCanonicalizer`, etc.). Two queries with different object identity but equivalent values share the same cache entry. Always compare canonicalized forms, never raw inputs.
-
-## Debug Flags
-
-In `DebugFlags.ts`, two flags default to `false`:
-- `DEBUG_REFCOUNTS` -- logs reference count changes for cache entries
-- `DEBUG_CACHE_KEYS` -- logs cache key creation and lookups
-
-Enable by changing `&& false` to `&& true`. Stripped in production builds.
 
 ## BatchContext
 

--- a/packages/client/src/observable/CLAUDE.md
+++ b/packages/client/src/observable/CLAUDE.md
@@ -48,6 +48,11 @@ we want it to stay in that form.
 - Use object cloning with `$clone()` to create immutable optimistic objects
 - On success, server data replaces optimistic update; on failure, automatically rolled back
 
+## Key Implementation Details
+
+- `sideEffects: false` in package.json -- all code must be tree-shakeable
+- `@wry/trie` powers efficient canonicalization of query parameters for cache key deduplication
+
 ## Best Practices
 
 - Reuse query parameters when possible to leverage cache

--- a/packages/client/src/observable/CLAUDE.md
+++ b/packages/client/src/observable/CLAUDE.md
@@ -68,10 +68,6 @@ Payloads emit with a `status` field: `init` -> `loading` -> `loaded`. On failure
 - `loaded`: Data available
 - `error`: Fetch failed (payload may still contain stale data from a previous load)
 
-## Observer Interface
-
-All observe methods accept `Observer<T>` with `next`, `error`, `complete` callbacks following the RxJS observer pattern. RxJS is used internally (e.g. `BehaviorSubject` for streams).
-
 ## Observation Options
 
 - `mode: "offline"` -- only use cached data, never fetch

--- a/packages/client/src/observable/CLAUDE.md
+++ b/packages/client/src/observable/CLAUDE.md
@@ -18,6 +18,13 @@ if (process.env.NODE_ENV !== "production") {
 
 we want it to stay in that form.
 
+## Related Documentation
+
+- [`ObservableClient/CLAUDE.md`](./ObservableClient/CLAUDE.md) -- type definitions reference (Status, Observer, CommonObserveOptions, ObserveLink types)
+- [`internal/CLAUDE.md`](./internal/CLAUDE.md) -- Store architecture, Layer system, Query hierarchy, and cache key patterns
+- [`internal/links/CLAUDE.md`](./internal/links/CLAUDE.md) -- link observation implementation details, pivot queries, and link storage patterns
+- [`internal/testUtils/CLAUDE.md`](./internal/testUtils/CLAUDE.md) -- test utilities reference (mock helpers, matchers, standard test flows)
+
 ## Core Concepts
 
 ### ObservableClient Methods
@@ -46,3 +53,51 @@ we want it to stay in that form.
 - Understand that data is shared across components with the same query
 - When invalidating object types, only queries and links related to that specific object type will be invalidated
 - Use fine-grained subscriptions to minimize data transfer and processing
+
+## Status Lifecycle
+
+Payloads emit with a `status` field: `init` -> `loading` -> `loaded`. On failure: `error`.
+- `init`: Before any fetch (subscriber just attached)
+- `loading`: Network request in flight
+- `loaded`: Data available
+- `error`: Fetch failed (payload may still contain stale data from a previous load)
+
+## Observer Interface
+
+All observe methods accept `Observer<T>` with `next`, `error`, `complete` callbacks. This follows the RxJS convention but the observable system does NOT use RxJS internally.
+
+## Observation Options
+
+- `mode: "offline"` -- only use cached data, never fetch
+- `mode: "force"` -- always fetch from server, ignore cache
+- `mode: undefined` (default) -- use cache if available, fetch if stale/missing
+- `dedupeInterval` -- milliseconds to deduplicate emissions (React hooks default to 2000ms)
+- `invalidationMode`: `"in-place"` | `"wait"` | `"reset"` -- controls UI behavior during cache invalidation
+
+## Canonicalization System
+
+Query parameters (where, orderBy, select, etc.) are canonicalized via specialized canonicalizers in `internal/` (`WhereClauseCanonicalizer`, `OrderByCanonicalizer`, `SelectCanonicalizer`, etc.). Two queries with different object identity but equivalent values share the same cache entry. Always compare canonicalized forms, never raw inputs.
+
+## Debug Flags
+
+In `DebugFlags.ts`, two flags default to `false`:
+- `DEBUG_REFCOUNTS` -- logs reference count changes for cache entries
+- `DEBUG_CACHE_KEYS` -- logs cache key creation and lookups
+
+Enable by changing `&& false` to `&& true`. Stripped in production builds.
+
+## BatchContext
+
+Cache mutations must occur within a `BatchContext` (see `internal/BatchContext.ts`). This ensures atomic changes, on-demand optimistic layer creation, and proper change tracking for notifications.
+
+## File Organization
+
+- `ObservableClient.ts` -- public interface and `createObservableClient` factory
+- `ObservableClient/` subdirectory -- type definitions (common.ts, ObserveLink.ts)
+- `internal/ObservableClientImpl.ts` -- actual implementation
+- `internal/Store.ts` -- central cache store
+- `internal/Layer.ts` / `Layers.ts` -- truth + optimistic layer stack
+- `internal/*Canonicalizer.ts` -- query parameter normalization
+- `internal/base-list/` -- shared logic for list-like queries
+- `internal/links/`, `internal/object/`, `internal/objectset/`, `internal/function/`, `internal/aggregation/` -- domain-specific observation implementations
+- `internal/testUtils/` -- test helpers (see its own CLAUDE.md)

--- a/packages/client/src/observable/CLAUDE.md
+++ b/packages/client/src/observable/CLAUDE.md
@@ -70,7 +70,7 @@ Payloads emit with a `status` field: `init` -> `loading` -> `loaded`. On failure
 
 ## Observer Interface
 
-All observe methods accept `Observer<T>` with `next`, `error`, `complete` callbacks. This follows the RxJS convention but the observable system does NOT use RxJS internally.
+All observe methods accept `Observer<T>` with `next`, `error`, `complete` callbacks following the RxJS observer pattern. RxJS is used internally (e.g. `BehaviorSubject` for streams).
 
 ## Observation Options
 

--- a/packages/monorepo.cspell/cspell.config.js
+++ b/packages/monorepo.cspell/cspell.config.js
@@ -127,7 +127,7 @@ const cspell = {
     "oauth",
     "css",
   ],
-  words: ["REFCOUNTS", "todoapp"],
+  words: ["todoapp"],
   suggestWords: [],
   ignoreWords: [],
   import: [],

--- a/packages/monorepo.cspell/cspell.config.js
+++ b/packages/monorepo.cspell/cspell.config.js
@@ -127,7 +127,7 @@ const cspell = {
     "oauth",
     "css",
   ],
-  words: ["todoapp"],
+  words: ["REFCOUNTS", "todoapp"],
   suggestWords: [],
   ignoreWords: [],
   import: [],

--- a/packages/react/CLAUDE.md
+++ b/packages/react/CLAUDE.md
@@ -1,0 +1,62 @@
+# @osdk/react
+
+React hooks for type-safe Foundry ontology access. Wraps `ObservableClient` from `@osdk/client/unstable-do-not-use`.
+
+This file covers development-time guidance only.
+
+## Related Documentation
+
+- [`AGENTS.md`](./AGENTS.md) -- hook usage rules, correct patterns, anti-patterns, and export listings. Read this first when working with hooks as a consumer
+- [`CHANGELOG.md`](./CHANGELOG.md) -- version history and feature additions
+- Observable client internals: [`packages/client/src/observable/CLAUDE.md`](../client/src/observable/CLAUDE.md) -- architecture of the subscription/cache layer that powers all hooks
+
+## Architecture
+
+All hooks follow the same pattern:
+1. Get `observableClient` from `OsdkContext2` via `React.useContext`
+2. Create a subscription via `makeExternalStore()` which bridges Observer -> `useSyncExternalStore`
+3. Return memoized result object
+
+**Two provider systems exist**:
+- `OsdkProvider` (legacy, `src/OsdkContext.ts`) -- only provides `Client`, no observable support
+- `OsdkProvider2` (new, `src/new/OsdkContext2.ts`) -- provides both `Client` and `ObservableClient`
+
+New hooks go in `src/new/`. Do NOT add hooks to the root `src/` directory.
+
+## Export Path Rules
+
+| Import path | What belongs here | Stability |
+|-------------|-------------------|-----------|
+| `@osdk/react` | Legacy only: `OsdkProvider`, `useOsdkClient` | Stable |
+| `@osdk/react/experimental` | All new hooks | Experimental |
+| `@osdk/react/unstable-do-not-use` | Internal plumbing | Unstable |
+| `@osdk/react/experimental/admin` | Platform API hooks (requires `@osdk/foundry.admin`) | Experimental |
+
+When adding a new hook:
+1. Create the hook file in `src/new/`
+2. Export it from `src/public/experimental.ts`
+3. Do NOT export from `src/index.ts` (that is the legacy entry point)
+
+## Testing
+
+- `vitest` with `pool: "forks"`, `happy-dom` environment
+- Fake timers: `setTimeout`, `clearTimeout`, `Date`
+- Use `@testing-library/react` with `renderHook`, `act`, and `waitFor`
+- Mock `ObservableClient` with `vi.fn()`, wrap in `OsdkContext2.Provider`:
+  ```tsx
+  const mockClient = { applyAction: vi.fn(), ... } as unknown as ObservableClient;
+  const wrapper = ({ children }) => (
+    <OsdkContext2.Provider value={{ client: {} as never, observableClient: mockClient }}>
+      {children}
+    </OsdkContext2.Provider>
+  );
+  renderHook(() => useYourHook(...), { wrapper });
+  ```
+
+## Critical Conventions
+
+- **No `useEffect`** -- use `useMemo` + `useSyncExternalStore` for subscriptions
+- **No early returns for loading** -- always render through loading states (see root CLAUDE.md React section)
+- **`enabled` parameter disables hooks** -- do NOT conditionally call hooks
+- **Canonicalize options** -- hooks like `useOsdkObjects` call `observableClient.canonicalizeOptions()` to stabilize where/orderBy references, preventing unnecessary re-subscriptions
+- **`makeExternalStoreAsync`** exists for subscriptions returning `Promise<Unsubscribable>` (e.g., `observeAggregation` with objectSet). Uses an `isActive` flag to handle cleanup-before-resolve race conditions

--- a/packages/react/CLAUDE.md
+++ b/packages/react/CLAUDE.md
@@ -9,6 +9,7 @@ This file covers development-time guidance only.
 - [`AGENTS.md`](./AGENTS.md) -- hook usage rules, correct patterns, anti-patterns, and export listings. Read this first when working with hooks as a consumer
 - [`CHANGELOG.md`](./CHANGELOG.md) -- version history and feature additions
 - Observable client internals: [`packages/client/src/observable/CLAUDE.md`](../client/src/observable/CLAUDE.md) -- architecture of the subscription/cache layer that powers all hooks
+- Observable client deep dive: [`packages/client/architecture_observable_client.md`](../client/architecture_observable_client.md) -- Store, Layer system, CacheKeys, batch updates, and optimistic mutation flow
 
 ## Architecture
 
@@ -52,6 +53,17 @@ When adding a new hook:
   );
   renderHook(() => useYourHook(...), { wrapper });
   ```
+
+## Intellisense Tests
+
+`src/intellisense.test.ts` verifies that TypeScript IDE completions and type hints work correctly for the React hooks. Each test case has a corresponding helper file in `src/intellisense.test.helpers/`.
+
+When to add a new intellisense test:
+- You add or change hook return types or option types
+- You change generic constraints that affect what users see in autocomplete
+- You add new hooks with complex type signatures (pivot, withProperties, etc.)
+
+To add one: create a helper file in `src/intellisense.test.helpers/{testName}.ts` with sample hook usage, then add a test case in `intellisense.test.ts` that opens the helper and asserts on QuickInfo/Completions at specific positions.
 
 ## Critical Conventions
 


### PR DESCRIPTION
add CLAUDE.md files to key packages and enhance existing ones for better AI-assisted development

generated via Claude's /init command

• add project overview, build system, license headers, linting, export conventions, and release process sections to root CLAUDE.md
• create new CLAUDE.md for packages/client covering entry points, export paths, code style, testing, and architecture
• create new CLAUDE.md for packages/react covering hook architecture, providers, export paths, testing patterns, and conventions
• enhance packages/client/src/observable/CLAUDE.md with status lifecycle, observer interface, observation options, canonicalization, debug flags, batch context, file organization, and cross-references to sub-directory docs