### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -105,5 +105,25 @@
     "@osdk/tests.verify-esm-node16": "0.0.3",
     "@osdk/tests.verify-fallback-package-v2": "0.0.3"
   },
-  "changesets": []
+  "changesets": [
+    "@osdk-e2e.generated.1.1.x-simulatedRelease",
+    "@osdk-e2e.generated.api-namespace.dep-simulatedRelease",
+    "@osdk-e2e.generated.api-namespace.local-simulatedRelease",
+    "@osdk-e2e.generated.catchall-simulatedRelease",
+    "@osdk-e2e.sandbox.catchall-simulatedRelease",
+    "@osdk-e2e.sandbox.oauth-simulatedRelease",
+    "@osdk-e2e.sandbox.oauth.public.react-router-simulatedRelease",
+    "@osdk-e2e.sandbox.peopleapp-simulatedRelease",
+    "@osdk-e2e.sandbox.todoapp-simulatedRelease",
+    "@osdk-e2e.sandbox.todowidget-simulatedRelease",
+    "@osdk-e2e.test.foundry-sdk-generator-simulatedRelease",
+    "@osdk-monorepo.api-extractor-simulatedRelease",
+    "@osdk-monorepo.cspell-simulatedRelease",
+    "@osdk-monorepo.tool.transpile-simulatedRelease",
+    "@osdk-monorepo.tsconfig-simulatedRelease",
+    "@osdk-version-updater-simulatedRelease",
+    "hook-canonicalize-refactor",
+    "lazy-oranges-cheat",
+    "mock-object-set-rework"
+  ]
 }

--- a/benchmarks/tests/primary/CHANGELOG.md
+++ b/benchmarks/tests/primary/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/benchmarks.primary
 
+## 0.1.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [51ccca8]
+  - @osdk/client@2.8.1-beta.2
+
 ## 0.1.0
 
 ### Minor Changes

--- a/benchmarks/tests/primary/package.json
+++ b/benchmarks/tests/primary/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/benchmarks.primary",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.8.0';
+export type $ExpectedClientVersion = '2.8.1';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/api
 
+## 2.8.1-beta.2
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/api",
-  "version": "2.8.0",
+  "version": "2.8.1-beta.2",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/cli.cmd.typescript
 
+## 0.32.1-beta.0
+
+### Patch Changes
+
+- 40fe279: Fix cli by making referenced packages bundled
+- Updated dependencies [40fe279]
+  - @osdk/cli.common@0.32.1-beta.0
+  - @osdk/generator@2.8.1-beta.2
+
 ## 0.32.0
 
 ### Minor Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.32.0",
+  "version": "0.32.1-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli.common/CHANGELOG.md
+++ b/packages/cli.common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/cli.common
 
+## 0.32.1-beta.0
+
+### Patch Changes
+
+- 40fe279: Fix cli by making referenced packages bundled
+
 ## 0.32.0
 
 ### Minor Changes

--- a/packages/cli.common/package.json
+++ b/packages/cli.common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.common",
   "private": true,
-  "version": "0.32.0",
+  "version": "0.32.1-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/cli
 
+## 0.32.1-beta.0
+
+### Patch Changes
+
+- 40fe279: Fix cli by making referenced packages bundled
+  - @osdk/widget.api@3.5.1-beta.0
+
 ## 0.32.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.32.0",
+  "version": "0.32.1-beta.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client.test.ontology/CHANGELOG.md
+++ b/packages/client.test.ontology/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/client.test.ontology
 
+## 2.8.1-beta.0
+
+### Patch Changes
+
+- @osdk/api@2.8.1-beta.2
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/client.test.ontology/package.json
+++ b/packages/client.test.ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/client.test.ontology",
   "private": true,
-  "version": "2.8.0",
+  "version": "2.8.1-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.unstable/CHANGELOG.md
+++ b/packages/client.unstable/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/client.unstable
 
+## 2.8.1-beta.2
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/client.unstable/package.json
+++ b/packages/client.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.unstable",
-  "version": "2.8.0",
+  "version": "2.8.1-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/client
 
+## 2.8.1-beta.2
+
+### Patch Changes
+
+- 51ccca8: Refactor hooks to use canonicalizeOptions for stable memo keys, add objectSet/hasMore/refetch to useOsdkObjects return, support undefined objectSet in useObjectSet
+  - @osdk/api@2.8.1-beta.2
+  - @osdk/client.unstable@2.8.1-beta.2
+  - @osdk/generator-converters@2.8.1-beta.2
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client",
-  "version": "2.8.0",
+  "version": "2.8.1-beta.2",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -97,7 +97,7 @@ export interface Client extends SharedClient, OldSharedClient {
 export const additionalContext: unique symbol = Symbol("additionalContext");
 
 // BEGIN: THIS IS GENERATED CODE. DO NOT EDIT.
-const MaxOsdkVersion = "2.8.0";
+const MaxOsdkVersion = "2.8.1";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 export type MaxOsdkVersion = typeof MaxOsdkVersion;
 const ErrorMessage: unique symbol = Symbol("ErrorMessage");

--- a/packages/create-app.template-packager/CHANGELOG.md
+++ b/packages/create-app.template-packager/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template-packager
 
+## 2.8.1-beta.2
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/create-app.template-packager/package.json
+++ b/packages/create-app.template-packager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template-packager",
   "private": true,
-  "version": "2.8.0",
+  "version": "2.8.1-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.expo.v2/CHANGELOG.md
+++ b/packages/create-app.template.expo.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.expo.v2
 
+## 2.8.1-beta.2
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/create-app.template.expo.v2/package.json
+++ b/packages/create-app.template.expo.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.expo.v2",
   "private": true,
-  "version": "2.8.0",
+  "version": "2.8.1-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react.beta/CHANGELOG.md
+++ b/packages/create-app.template.react.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.react
 
+## 2.8.1-beta.2
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/create-app.template.react.beta/package.json
+++ b/packages/create-app.template.react.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react.beta",
   "private": true,
-  "version": "2.8.0",
+  "version": "2.8.1-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react/CHANGELOG.md
+++ b/packages/create-app.template.react/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.react
 
+## 2.8.1-beta.2
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/create-app.template.react/package.json
+++ b/packages/create-app.template.react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react",
   "private": true,
-  "version": "2.8.0",
+  "version": "2.8.1-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-aip-app.beta
 
+## 2.8.1-beta.2
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app.beta",
   "private": true,
-  "version": "2.8.0",
+  "version": "2.8.1-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-aip-app
 
+## 2.8.1-beta.2
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-aip-app/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app",
   "private": true,
-  "version": "2.8.0",
+  "version": "2.8.1-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-app.beta/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-app.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-app.beta
 
+## 2.8.1-beta.2
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-app.beta/package.json
+++ b/packages/create-app.template.tutorial-todo-app.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app.beta",
   "private": true,
-  "version": "2.8.0",
+  "version": "2.8.1-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-app
 
+## 2.8.1-beta.2
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-app/package.json
+++ b/packages/create-app.template.tutorial-todo-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app",
   "private": true,
-  "version": "2.8.0",
+  "version": "2.8.1-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.vue.v2/CHANGELOG.md
+++ b/packages/create-app.template.vue.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.vue.v2
 
+## 2.8.1-beta.2
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/create-app.template.vue.v2/package.json
+++ b/packages/create-app.template.vue.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.vue.v2",
   "private": true,
-  "version": "2.8.0",
+  "version": "2.8.1-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.vue/CHANGELOG.md
+++ b/packages/create-app.template.vue/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.vue
 
+## 2.8.1-beta.2
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/create-app.template.vue/package.json
+++ b/packages/create-app.template.vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.vue",
   "private": true,
-  "version": "2.8.0",
+  "version": "2.8.1-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app
 
+## 2.8.1-beta.2
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-app",
-  "version": "2.8.0",
+  "version": "2.8.1-beta.2",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/create-widget.template.minimal-react.v2/CHANGELOG.md
+++ b/packages/create-widget.template.minimal-react.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-widget.template.react.v2
 
+## 3.5.1-beta.0
+
 ## 3.5.0
 
 ### Minor Changes

--- a/packages/create-widget.template.minimal-react.v2/package.json
+++ b/packages/create-widget.template.minimal-react.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-widget.template.minimal-react.v2",
   "private": true,
-  "version": "3.5.0",
+  "version": "3.5.1-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-widget.template.react.v2/CHANGELOG.md
+++ b/packages/create-widget.template.react.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-widget.template.react.v2
 
+## 3.5.1-beta.0
+
 ## 3.5.0
 
 ### Minor Changes

--- a/packages/create-widget.template.react.v2/package.json
+++ b/packages/create-widget.template.react.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-widget.template.react.v2",
   "private": true,
-  "version": "3.5.0",
+  "version": "3.5.1-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-widget/CHANGELOG.md
+++ b/packages/create-widget/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-widget
 
+## 3.5.1-beta.0
+
 ## 3.5.0
 
 ### Minor Changes

--- a/packages/create-widget/package.json
+++ b/packages/create-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-widget",
-  "version": "3.5.0",
+  "version": "3.5.1-beta.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.8.0';
+export type $ExpectedClientVersion = '2.8.1';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.dep';

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.8.0';
+export type $ExpectedClientVersion = '2.8.1';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.dep';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.8.0';
+export type $ExpectedClientVersion = '2.8.1';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';

--- a/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/OntologyMetadata.ts
+++ b/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.8.0';
+export type $ExpectedClientVersion = '2.8.1';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/OntologyMetadata.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.8.0';
+export type $ExpectedClientVersion = '2.8.1';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';

--- a/packages/example-generator/CHANGELOG.md
+++ b/packages/example-generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/example-generator
 
+## 0.16.1-beta.0
+
+### Patch Changes
+
+- @osdk/create-app@2.8.1-beta.2
+- @osdk/create-widget@3.5.1-beta.0
+
 ## 0.16.0
 
 ### Minor Changes

--- a/packages/example-generator/package.json
+++ b/packages/example-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/example-generator",
   "private": true,
-  "version": "0.16.0",
+  "version": "0.16.1-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/faux/CHANGELOG.md
+++ b/packages/faux/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/shared.test
 
+## 0.6.1-beta.0
+
+### Patch Changes
+
+- @osdk/api@2.8.1-beta.2
+- @osdk/generator-converters@2.8.1-beta.2
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/faux/package.json
+++ b/packages/faux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/faux",
-  "version": "0.6.0",
+  "version": "0.6.1-beta.0",
   "description": "",
   "access": "private",
   "license": "Apache-2.0",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/foundry-sdk-generator
 
+## 2.8.1-beta.2
+
+### Patch Changes
+
+- Updated dependencies [51ccca8]
+  - @osdk/client@2.8.1-beta.2
+  - @osdk/api@2.8.1-beta.2
+  - @osdk/client.unstable@2.8.1-beta.2
+  - @osdk/generator-utils@2.8.1-beta.2
+  - @osdk/generator@2.8.1-beta.2
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "2.8.0",
+  "version": "2.8.1-beta.2",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/functions-testing.experimental/CHANGELOG.md
+++ b/packages/functions-testing.experimental/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @osdk/functions-testing.experimental
 
+## 0.2.1-beta.0
+
+### Patch Changes
+
+- c08d97b: Rework mock client stubbing API: rename whenObjectSet to when, add standalone createMockObjectSet with whenObjectSet for registering stubs on object sets directly, and support ObjectSet as many-link value in createMockOsdkObject
+- Updated dependencies [51ccca8]
+  - @osdk/client@2.8.1-beta.2
+  - @osdk/functions@1.6.1-beta.0
+  - @osdk/api@2.8.1-beta.2
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/functions-testing.experimental/package.json
+++ b/packages/functions-testing.experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/functions-testing.experimental",
-  "version": "0.2.0",
+  "version": "0.2.1-beta.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/functions/CHANGELOG.md
+++ b/packages/functions/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/functions
 
+## 1.6.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [51ccca8]
+  - @osdk/client@2.8.1-beta.2
+
 ## 1.6.0
 
 ### Minor Changes

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/functions",
-  "version": "1.6.0",
+  "version": "1.6.1-beta.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-converters.ontologyir/CHANGELOG.md
+++ b/packages/generator-converters.ontologyir/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/generator-converters.ontologyir
 
+## 2.8.1-beta.2
+
+### Patch Changes
+
+- @osdk/client.unstable@2.8.1-beta.2
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/generator-converters.ontologyir/package.json
+++ b/packages/generator-converters.ontologyir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-converters.ontologyir",
-  "version": "2.8.0",
+  "version": "2.8.1-beta.2",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-converters.preview/CHANGELOG.md
+++ b/packages/generator-converters.preview/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/generator-converters.preview
 
+## 0.1.1-beta.0
+
+### Patch Changes
+
+- @osdk/client.unstable@2.8.1-beta.2
+- @osdk/generator-converters.ontologyir@2.8.1-beta.2
+- @osdk/generator@2.8.1-beta.2
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/generator-converters.preview/package.json
+++ b/packages/generator-converters.preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-converters.preview",
-  "version": "0.1.0",
+  "version": "0.1.1-beta.0",
   "description": "OSDK generator with support for Python and TSv2 discovered functions",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-converters/CHANGELOG.md
+++ b/packages/generator-converters/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/generator-converters
 
+## 2.8.1-beta.2
+
+### Patch Changes
+
+- @osdk/api@2.8.1-beta.2
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/generator-converters/package.json
+++ b/packages/generator-converters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-converters",
-  "version": "2.8.0",
+  "version": "2.8.1-beta.2",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-utils/CHANGELOG.md
+++ b/packages/generator-utils/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/generator-utils
 
+## 2.8.1-beta.2
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/generator-utils/package.json
+++ b/packages/generator-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-utils",
-  "version": "2.8.0",
+  "version": "2.8.1-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/generator
 
+## 2.8.1-beta.2
+
+### Patch Changes
+
+- @osdk/api@2.8.1-beta.2
+- @osdk/generator-converters@2.8.1-beta.2
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "2.8.0",
+  "version": "2.8.1-beta.2",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator/src/v2.0/generateMetadata.ts
+++ b/packages/generator/src/v2.0/generateMetadata.ts
@@ -19,7 +19,7 @@ import type { GenerateContext } from "../GenerateContext/GenerateContext.js";
 import { formatTs } from "../util/test/formatTs.js";
 
 // BEGIN: THIS IS GENERATED CODE. DO NOT EDIT.
-const ExpectedOsdkVersion = "2.8.0";
+const ExpectedOsdkVersion = "2.8.1";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 
 export async function generateOntologyMetadataFile(

--- a/packages/language-models/CHANGELOG.md
+++ b/packages/language-models/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/language-models
 
+## 0.2.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [51ccca8]
+  - @osdk/client@2.8.1-beta.2
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/language-models/package.json
+++ b/packages/language-models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/language-models",
-  "version": "0.2.0",
+  "version": "0.2.1-beta.0",
   "description": "Utility methods for calling language models through the Foundry proxy endpoint",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/maker-experimental/CHANGELOG.md
+++ b/packages/maker-experimental/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/maker-experimental
 
+## 0.6.1-beta.0
+
+### Patch Changes
+
+- @osdk/api@2.8.1-beta.2
+- @osdk/client.unstable@2.8.1-beta.2
+- @osdk/maker@0.16.1-beta.0
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/maker-experimental/package.json
+++ b/packages/maker-experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker-experimental",
-  "version": "0.6.0",
+  "version": "0.6.1-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/maker/CHANGELOG.md
+++ b/packages/maker/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/maker
 
+## 0.16.1-beta.0
+
+### Patch Changes
+
+- @osdk/api@2.8.1-beta.2
+- @osdk/generator-converters.ontologyir@2.8.1-beta.2
+
 ## 0.16.0
 
 ### Minor Changes

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker",
-  "version": "0.16.0",
+  "version": "0.16.1-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/osdk-docs-context-generator/CHANGELOG.md
+++ b/packages/osdk-docs-context-generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/osdk-docs-context-generator
 
+## 0.4.1-beta.0
+
+### Patch Changes
+
+- @osdk/typescript-sdk-docs-examples@0.5.1-beta.0
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/osdk-docs-context-generator/package.json
+++ b/packages/osdk-docs-context-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/osdk-docs-context-generator",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/react-components-storybook/CHANGELOG.md
+++ b/packages/react-components-storybook/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/react-components-storybook
 
+## 0.2.1-beta.0
+
+### Patch Changes
+
+- @osdk/faux@0.6.1-beta.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/react-components-storybook/package.json
+++ b/packages/react-components-storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/react-components-storybook",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -73,9 +73,9 @@
     "react-hook-form": "^7.54.0"
   },
   "peerDependencies": {
-    "@osdk/api": "^2.8.0",
-    "@osdk/client": "^2.8.0",
-    "@osdk/react": "^0.10.0",
+    "@osdk/api": "^2.8.0 || >=2.8.1-beta.0",
+    "@osdk/client": "^2.8.0 || >=2.8.1-beta.0",
+    "@osdk/react": "^0.10.0 || >=0.10.1-beta.0",
     "@types/react": "^17 || ^18 || ^19",
     "classnames": "^2.0.0",
     "react": "^17 || ^18 || ^19",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdkkit/react
 
+## 0.10.1-beta.0
+
+### Patch Changes
+
+- 51ccca8: Refactor hooks to use canonicalizeOptions for stable memo keys, add objectSet/hasMore/refetch to useOsdkObjects return, support undefined objectSet in useObjectSet
+- Updated dependencies [51ccca8]
+  - @osdk/client@2.8.1-beta.2
+  - @osdk/api@2.8.1-beta.2
+
 ## 0.10.0
 
 ### Minor Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/react",
-  "version": "0.10.0",
+  "version": "0.10.1-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -69,8 +69,8 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "peerDependencies": {
-    "@osdk/api": "^2.8.0",
-    "@osdk/client": "^2.8.0",
+    "@osdk/api": "^2.8.0 || >=2.8.1-beta.0",
+    "@osdk/client": "^2.8.0 || >=2.8.1-beta.0",
     "@osdk/foundry.admin": "*",
     "@osdk/foundry.core": "*",
     "@types/react": "^17 || ^18 || ^19",

--- a/packages/shared.test/CHANGELOG.md
+++ b/packages/shared.test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/shared.test
 
+## 2.8.1-beta.0
+
+### Patch Changes
+
+- @osdk/api@2.8.1-beta.2
+- @osdk/generator-converters@2.8.1-beta.2
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/shared.test/package.json
+++ b/packages/shared.test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/shared.test",
   "private": true,
-  "version": "2.8.0",
+  "version": "2.8.1-beta.0",
   "description": "",
   "access": "private",
   "license": "Apache-2.0",

--- a/packages/tool.generate-with-mock-ontology/CHANGELOG.md
+++ b/packages/tool.generate-with-mock-ontology/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/tool.generate-with-mock-ontology
 
+## 0.8.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [51ccca8]
+  - @osdk/client@2.8.1-beta.2
+  - @osdk/api@2.8.1-beta.2
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/tool.generate-with-mock-ontology/package.json
+++ b/packages/tool.generate-with-mock-ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/tool.generate-with-mock-ontology",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.8.1-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/typescript-sdk-docs-examples/CHANGELOG.md
+++ b/packages/typescript-sdk-docs-examples/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/typescript-sdk-docs-examples
 
+## 0.5.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [51ccca8]
+  - @osdk/client@2.8.1-beta.2
+  - @osdk/functions@1.6.1-beta.0
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/typescript-sdk-docs-examples/package.json
+++ b/packages/typescript-sdk-docs-examples/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/typescript-sdk-docs-examples",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/vite-plugin-oac/CHANGELOG.md
+++ b/packages/vite-plugin-oac/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/vite-plugin-oac
 
+## 0.6.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [40fe279]
+  - @osdk/cli@0.32.1-beta.0
+  - @osdk/api@2.8.1-beta.2
+  - @osdk/client.unstable@2.8.1-beta.2
+  - @osdk/generator-converters.ontologyir@2.8.1-beta.2
+  - @osdk/faux@0.6.1-beta.0
+  - @osdk/maker@0.16.1-beta.0
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/vite-plugin-oac/package.json
+++ b/packages/vite-plugin-oac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/vite-plugin-oac",
-  "version": "0.6.0",
+  "version": "0.6.1-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/widget.api/CHANGELOG.md
+++ b/packages/widget.api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/widget.api
 
+## 3.5.1-beta.0
+
+### Patch Changes
+
+- @osdk/api@2.8.1-beta.2
+
 ## 3.5.0
 
 ### Minor Changes

--- a/packages/widget.api/package.json
+++ b/packages/widget.api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget.api",
-  "version": "3.5.0",
+  "version": "3.5.1-beta.0",
   "description": "API contract between Foundry UIs that can embed custom widgets and the custom widgets themselves",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/widget.client-react/CHANGELOG.md
+++ b/packages/widget.client-react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/widget.client-react
 
+## 3.5.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [51ccca8]
+  - @osdk/client@2.8.1-beta.2
+  - @osdk/widget.client@3.5.1-beta.0
+
 ## 3.5.0
 
 ### Minor Changes

--- a/packages/widget.client-react/package.json
+++ b/packages/widget.client-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget.client-react",
-  "version": "3.5.0",
+  "version": "3.5.1-beta.0",
   "description": "Wrapper around @osdk/widget.client",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/widget.client/CHANGELOG.md
+++ b/packages/widget.client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/widget.client
 
+## 3.5.1-beta.0
+
+### Patch Changes
+
+- @osdk/widget.api@3.5.1-beta.0
+
 ## 3.5.0
 
 ### Minor Changes

--- a/packages/widget.client/package.json
+++ b/packages/widget.client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget.client",
-  "version": "3.5.0",
+  "version": "3.5.1-beta.0",
   "description": "Client that sets up listeners for the custom widgets embedded into Foundry, adhering to the contract laid out in @osdk/widget.api",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/widget.vite-plugin/CHANGELOG.md
+++ b/packages/widget.vite-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/widget.vite-plugin
 
+## 3.5.1-beta.0
+
+### Patch Changes
+
+- @osdk/widget.api@3.5.1-beta.0
+
 ## 3.5.0
 
 ### Minor Changes

--- a/packages/widget.vite-plugin/package.json
+++ b/packages/widget.vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget.vite-plugin",
-  "version": "3.5.0",
+  "version": "3.5.1-beta.0",
   "description": "A vite plugin that will extract parameter definitions from TS/JS files + entrypoint info into a manifest file to be uploaded to Foundry ",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in release/2.9.x, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`release/2.9.x` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `release/2.9.x`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/cli@0.32.1-beta.0

### Patch Changes

-   40fe279: Fix cli by making referenced packages bundled
    -   @osdk/widget.api@3.5.1-beta.0

## @osdk/client@2.8.1-beta.2

### Patch Changes

-   51ccca8: Refactor hooks to use canonicalizeOptions for stable memo keys, add objectSet/hasMore/refetch to useOsdkObjects return, support undefined objectSet in useObjectSet
    -   @osdk/api@2.8.1-beta.2
    -   @osdk/client.unstable@2.8.1-beta.2
    -   @osdk/generator-converters@2.8.1-beta.2

## @osdk/faux@0.6.1-beta.0

### Patch Changes

-   @osdk/api@2.8.1-beta.2
-   @osdk/generator-converters@2.8.1-beta.2

## @osdk/foundry-sdk-generator@2.8.1-beta.2

### Patch Changes

-   Updated dependencies [51ccca8]
    -   @osdk/client@2.8.1-beta.2
    -   @osdk/api@2.8.1-beta.2
    -   @osdk/client.unstable@2.8.1-beta.2
    -   @osdk/generator-utils@2.8.1-beta.2
    -   @osdk/generator@2.8.1-beta.2

## @osdk/functions@1.6.1-beta.0

### Patch Changes

-   Updated dependencies [51ccca8]
    -   @osdk/client@2.8.1-beta.2

## @osdk/functions-testing.experimental@0.2.1-beta.0

### Patch Changes

-   c08d97b: Rework mock client stubbing API: rename whenObjectSet to when, add standalone createMockObjectSet with whenObjectSet for registering stubs on object sets directly, and support ObjectSet as many-link value in createMockOsdkObject
-   Updated dependencies [51ccca8]
    -   @osdk/client@2.8.1-beta.2
    -   @osdk/functions@1.6.1-beta.0
    -   @osdk/api@2.8.1-beta.2

## @osdk/generator@2.8.1-beta.2

### Patch Changes

-   @osdk/api@2.8.1-beta.2
-   @osdk/generator-converters@2.8.1-beta.2

## @osdk/generator-converters@2.8.1-beta.2

### Patch Changes

-   @osdk/api@2.8.1-beta.2

## @osdk/generator-converters.ontologyir@2.8.1-beta.2

### Patch Changes

-   @osdk/client.unstable@2.8.1-beta.2

## @osdk/generator-converters.preview@0.1.1-beta.0

### Patch Changes

-   @osdk/client.unstable@2.8.1-beta.2
-   @osdk/generator-converters.ontologyir@2.8.1-beta.2
-   @osdk/generator@2.8.1-beta.2

## @osdk/language-models@0.2.1-beta.0

### Patch Changes

-   Updated dependencies [51ccca8]
    -   @osdk/client@2.8.1-beta.2

## @osdk/maker@0.16.1-beta.0

### Patch Changes

-   @osdk/api@2.8.1-beta.2
-   @osdk/generator-converters.ontologyir@2.8.1-beta.2

## @osdk/maker-experimental@0.6.1-beta.0

### Patch Changes

-   @osdk/api@2.8.1-beta.2
-   @osdk/client.unstable@2.8.1-beta.2
-   @osdk/maker@0.16.1-beta.0

## @osdk/react@0.10.1-beta.0

### Patch Changes

-   51ccca8: Refactor hooks to use canonicalizeOptions for stable memo keys, add objectSet/hasMore/refetch to useOsdkObjects return, support undefined objectSet in useObjectSet
-   Updated dependencies [51ccca8]
    -   @osdk/client@2.8.1-beta.2
    -   @osdk/api@2.8.1-beta.2

## @osdk/vite-plugin-oac@0.6.1-beta.0

### Patch Changes

-   Updated dependencies [40fe279]
    -   @osdk/cli@0.32.1-beta.0
    -   @osdk/api@2.8.1-beta.2
    -   @osdk/client.unstable@2.8.1-beta.2
    -   @osdk/generator-converters.ontologyir@2.8.1-beta.2
    -   @osdk/faux@0.6.1-beta.0
    -   @osdk/maker@0.16.1-beta.0

## @osdk/widget.api@3.5.1-beta.0

### Patch Changes

-   @osdk/api@2.8.1-beta.2

## @osdk/widget.client@3.5.1-beta.0

### Patch Changes

-   @osdk/widget.api@3.5.1-beta.0

## @osdk/widget.client-react@3.5.1-beta.0

### Patch Changes

-   Updated dependencies [51ccca8]
    -   @osdk/client@2.8.1-beta.2
    -   @osdk/widget.client@3.5.1-beta.0

## @osdk/widget.vite-plugin@3.5.1-beta.0

### Patch Changes

-   @osdk/widget.api@3.5.1-beta.0

## @osdk/api@2.8.1-beta.2



## @osdk/client.unstable@2.8.1-beta.2



## @osdk/create-app@2.8.1-beta.2



## @osdk/create-widget@3.5.1-beta.0



## @osdk/generator-utils@2.8.1-beta.2



## @osdk/benchmarks.primary@0.1.1-beta.0

### Patch Changes

-   Updated dependencies [51ccca8]
    -   @osdk/client@2.8.1-beta.2

## @osdk/cli.cmd.typescript@0.32.1-beta.0

### Patch Changes

-   40fe279: Fix cli by making referenced packages bundled
-   Updated dependencies [40fe279]
    -   @osdk/cli.common@0.32.1-beta.0
    -   @osdk/generator@2.8.1-beta.2

## @osdk/cli.common@0.32.1-beta.0

### Patch Changes

-   40fe279: Fix cli by making referenced packages bundled

## @osdk/client.test.ontology@2.8.1-beta.0

### Patch Changes

-   @osdk/api@2.8.1-beta.2

## @osdk/example-generator@0.16.1-beta.0

### Patch Changes

-   @osdk/create-app@2.8.1-beta.2
-   @osdk/create-widget@3.5.1-beta.0

## @osdk/osdk-docs-context-generator@0.4.1-beta.0

### Patch Changes

-   @osdk/typescript-sdk-docs-examples@0.5.1-beta.0

## @osdk/react-components-storybook@0.2.1-beta.0

### Patch Changes

-   @osdk/faux@0.6.1-beta.0

## @osdk/shared.test@2.8.1-beta.0

### Patch Changes

-   @osdk/api@2.8.1-beta.2
-   @osdk/generator-converters@2.8.1-beta.2

## @osdk/tool.generate-with-mock-ontology@0.8.1-beta.0

### Patch Changes

-   Updated dependencies [51ccca8]
    -   @osdk/client@2.8.1-beta.2
    -   @osdk/api@2.8.1-beta.2

## @osdk/typescript-sdk-docs-examples@0.5.1-beta.0

### Patch Changes

-   Updated dependencies [51ccca8]
    -   @osdk/client@2.8.1-beta.2
    -   @osdk/functions@1.6.1-beta.0

## @osdk/create-app.template-packager@2.8.1-beta.2



## @osdk/create-app.template.expo.v2@2.8.1-beta.2



## @osdk/create-app.template.react@2.8.1-beta.2



## @osdk/create-app.template.react.beta@2.8.1-beta.2



## @osdk/create-app.template.tutorial-todo-aip-app@2.8.1-beta.2



## @osdk/create-app.template.tutorial-todo-aip-app.beta@2.8.1-beta.2



## @osdk/create-app.template.tutorial-todo-app@2.8.1-beta.2



## @osdk/create-app.template.tutorial-todo-app.beta@2.8.1-beta.2



## @osdk/create-app.template.vue@2.8.1-beta.2



## @osdk/create-app.template.vue.v2@2.8.1-beta.2



## @osdk/create-widget.template.minimal-react.v2@3.5.1-beta.0



## @osdk/create-widget.template.react.v2@3.5.1-beta.0


