### PR TITLE
Use relative paths in AGENTS.md for local doc resolution

### DIFF
--- a/.changeset/agents-md-local-docs.md
+++ b/.changeset/agents-md-local-docs.md
@@ -1,0 +1,4 @@
+---
+---
+
+Ship docs folder in npm package and use relative paths in AGENTS.md

--- a/.changeset/agents-md-local-docs.md
+++ b/.changeset/agents-md-local-docs.md
@@ -1,4 +1,5 @@
 ---
+"@osdk/react-components": patch
 ---
 
 Ship docs folder in npm package and use relative paths in AGENTS.md

--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -348,7 +348,7 @@ const archetypeRules = archetypes(
       ...LIBRARY_RULES,
       react: true,
       cssExport: true,
-      extraPublishFiles: ["AGENTS.md"],
+      extraPublishFiles: ["AGENTS.md", "docs"],
     },
   )
   .addArchetype(

--- a/packages/cbac-components/package.json
+++ b/packages/cbac-components/package.json
@@ -78,6 +78,7 @@
   },
   "files": [
     "AGENTS.md",
+    "docs",
     "build/cjs",
     "build/esm",
     "build/browser",

--- a/packages/react-components/AGENTS.md
+++ b/packages/react-components/AGENTS.md
@@ -18,9 +18,9 @@ All components import from `@osdk/react-components/experimental`.
 
 ## Documentation
 
-Before using any component, read the relevant doc:
+Before using any component, read the relevant doc from this package:
 
-- **Setup & installation**: Read [README.md](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/README.md) for provider, CSS layers, and peer dependencies
-- **ObjectTable**: Read [docs/ObjectTable.md](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/ObjectTable.md) for props, column definitions, examples, theming, and troubleshooting
-- **PdfViewer**: Read [docs/PdfViewer.md](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/PdfViewer.md) for props, annotations, building blocks, hooks, examples, and theming
-- **FilterList**: Read [docs/FilterList.md](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/FilterList.md) for props, examples, and usage
+- **Setup & installation**: Read [README.md](./README.md) for provider, CSS layers, and peer dependencies
+- **ObjectTable**: Read [docs/ObjectTable.md](./docs/ObjectTable.md) for props, column definitions, examples, theming, and troubleshooting
+- **PdfViewer**: Read [docs/PdfViewer.md](./docs/PdfViewer.md) for props, annotations, building blocks, hooks, examples, and theming
+- **FilterList**: Read [docs/FilterList.md](./docs/FilterList.md) for props, examples, and usage

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -108,6 +108,7 @@
     "build/browser",
     "build/types",
     "CHANGELOG.md",
+    "docs",
     "package.json",
     "templates",
     "*.d.ts"

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -103,12 +103,12 @@
   },
   "files": [
     "AGENTS.md",
+    "docs",
     "build/cjs",
     "build/esm",
     "build/browser",
     "build/types",
     "CHANGELOG.md",
-    "docs",
     "package.json",
     "templates",
     "*.d.ts"


### PR DESCRIPTION
### What this PR changes

Previously, AGENTS.md linked to GitHub URLs for documentation. This meant AI agents needed network access to fetch docs, and the links could drift from the installed version. By switching to relative paths (`./docs/ObjectTable.md` instead of a GitHub URL), any tool that reads `AGENTS.md` from `node_modules/` can follow the links locally — no network required, always version-matched.

## Summary
- Switch AGENTS.md doc links from GitHub URLs to relative paths (`./README.md`, `./docs/*.md`) so AI agents can read them directly from `node_modules/@osdk/react-components/`
- Add `docs` to the `files` field in package.json so the docs folder ships with the npm package

## Test plan
- [ ] Verify `npm pack` includes `docs/` folder and `AGENTS.md`
- [ ] Confirm relative links resolve correctly on GitHub
- [ ] Confirm relative links resolve from `node_modules/` after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)
