### PR TITLE
fix function-backed columns with wire objectSet

### DIFF
--- a/.changeset/fix-function-column-wire-objectset.md
+++ b/.changeset/fix-function-column-wire-objectset.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+fix function-backed columns by passing wire objectSet instead of composed ObjectSet with withProperties

--- a/.changeset/fix-function-column-wire-objectset.md
+++ b/.changeset/fix-function-column-wire-objectset.md
@@ -1,5 +1,5 @@
 ---
-"@osdk/react-components": patch
+"@osdk/client": patch
 ---
 
-fix function-backed columns by passing wire objectSet instead of composed ObjectSet with withProperties
+exclude withProperties from objectSet emitted in observable payload to fix function-backed column queries

--- a/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
@@ -55,6 +55,7 @@ export class ObjectSetQuery extends BaseListQuery<
   #baseObjectSetWire: string;
   #operations: Canonical<ObjectSetOperations>;
   #composedObjectSet: ObjectSet<any, any>;
+  #identityObjectSet: ObjectSet<any, any>;
   #objectTypes: Set<string>;
   #requiresServerEvaluation: boolean;
   #resultTypeApiName: string;
@@ -86,6 +87,7 @@ export class ObjectSetQuery extends BaseListQuery<
     this.#baseObjectSetWire = baseObjectSetWire;
     this.#operations = operations;
     this.#composedObjectSet = this.#composeObjectSet(opts);
+    this.#identityObjectSet = this.#composeIdentityObjectSet(opts);
 
     const baseWire: WireObjectSet = JSON.parse(baseObjectSetWire);
     this.#objectTypes = this.#extractObjectTypes(baseWire, opts);
@@ -131,6 +133,28 @@ export class ObjectSetQuery extends BaseListQuery<
     if (opts.withProperties) {
       result = result.withProperties(opts.withProperties);
     }
+    if (opts.where) {
+      result = result.where(opts.where);
+    }
+    if (opts.union && opts.union.length > 0) {
+      result = result.union(...opts.union);
+    }
+    if (opts.intersect && opts.intersect.length > 0) {
+      result = result.intersect(...opts.intersect);
+    }
+    if (opts.subtract && opts.subtract.length > 0) {
+      result = result.subtract(...opts.subtract);
+    }
+    if (opts.pivotTo) {
+      result = result.pivotTo(opts.pivotTo);
+    }
+
+    return result;
+  }
+
+  #composeIdentityObjectSet(opts: ObjectSetQueryOptions): ObjectSet<any, any> {
+    let result = opts.baseObjectSet;
+
     if (opts.where) {
       result = result.where(opts.where);
     }
@@ -484,7 +508,7 @@ export class ObjectSetQuery extends BaseListQuery<
       hasMore: this.nextPageToken != null,
       status: params.status,
       lastUpdated: params.lastUpdated,
-      objectSet: this.#composedObjectSet,
+      objectSet: this.#identityObjectSet,
       totalCount: params.totalCount,
     };
   }

--- a/packages/react-components/src/object-table/ObjectTableApi.ts
+++ b/packages/react-components/src/object-table/ObjectTableApi.ts
@@ -26,7 +26,12 @@ import type {
   SimplePropertyDef,
   WhereClause,
 } from "@osdk/api";
-import type { QueryParameterType } from "@osdk/client/unstable-do-not-use";
+import type {
+  getWireObjectSet,
+  QueryParameterType,
+} from "@osdk/client/unstable-do-not-use";
+
+type WireObjectSet = ReturnType<typeof getWireObjectSet>;
 import type * as React from "react";
 import type { CellEditInfo } from "./utils/types.js";
 
@@ -118,12 +123,13 @@ export interface FunctionColumnLocator<
   queryDefinition: FunctionColumns[keyof FunctionColumns];
 
   /**
-   * The function will be called with the current object set to get the input parameters for the function query.
-   * @param objectSet - The current object set.
+   * The function will be called with the wire representation of the current object set
+   * to get the input parameters for the function query.
+   * @param wireObjectSet - The wire representation of the current object set.
    * @returns - The function's input parameters including the object set.
    */
   getFunctionParams: (
-    objectSet: ObjectSet<Q, RDPs>,
+    wireObjectSet: WireObjectSet,
   ) => ExtractQueryParameters<FunctionColumns[keyof FunctionColumns]>;
 
   /**

--- a/packages/react-components/src/object-table/hooks/__tests__/useFunctionColumnsData.test.ts
+++ b/packages/react-components/src/object-table/hooks/__tests__/useFunctionColumnsData.test.ts
@@ -15,16 +15,18 @@
  */
 
 import type {
-  ObjectSet,
   ObjectTypeDefinition,
   Osdk,
   PropertyKeys,
   QueryDefinition,
 } from "@osdk/api";
+import type { getWireObjectSet } from "@osdk/client/unstable-do-not-use";
 import {
   useOsdkFunctions,
   type UseOsdkFunctionsResult,
 } from "@osdk/react/experimental";
+
+type WireObjectSet = ReturnType<typeof getWireObjectSet>;
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ColumnDefinition } from "../../ObjectTableApi.js";
@@ -68,7 +70,9 @@ type FunctionColumnDef = {
   timestampColumn?: MockQueryDef;
 };
 
-const mockObjectSet = {} as ObjectSet<TestObject>;
+const mockWireObjectSet = { type: "base", objectType: "TestObject" } as
+  & Record<string, string>
+  & WireObjectSet;
 
 const mockObject1 = {
   $objectType: "TestObject",
@@ -97,8 +101,8 @@ const columnDefinitions: ColumnDefinition<
       type: "function",
       id: "testColumn",
       queryDefinition: mockQueryDefinition,
-      getFunctionParams: ((objectSet: ObjectSet<TestObject>) => ({
-        [OBJ_SET_KEY]: objectSet,
+      getFunctionParams: ((wireObjectSet: WireObjectSet) => ({
+        [OBJ_SET_KEY]: wireObjectSet,
       })) as any,
       getKey: (obj) => `${obj.$objectType}:${obj.$primaryKey}`,
     },
@@ -128,7 +132,7 @@ describe("useFunctionColumnsData", () => {
     vi.mocked(useOsdkFunctions).mockReturnValue([]);
 
     const { result } = renderHook(
-      () => useFunctionColumnsData(mockObjectSet, [], undefined),
+      () => useFunctionColumnsData(mockWireObjectSet, [], undefined),
     );
 
     expect(result.current).toEqual({});
@@ -156,7 +160,11 @@ describe("useFunctionColumnsData", () => {
 
     const { result, rerender } = renderHook(
       () =>
-        useFunctionColumnsData(mockObjectSet, mockObjects, columnDefinitions),
+        useFunctionColumnsData(
+          mockWireObjectSet,
+          mockObjects,
+          columnDefinitions,
+        ),
     );
 
     // Initially shows isLoading state
@@ -212,7 +220,7 @@ describe("useFunctionColumnsData", () => {
           queryDefinition: mockQueryDefinition,
           options: {
             dedupeIntervalMs: DEFAULT_DEDUPE_INTERVAL_MS,
-            params: { [OBJ_SET_KEY]: mockObjectSet },
+            params: { [OBJ_SET_KEY]: mockWireObjectSet },
           },
         },
       ],
@@ -241,8 +249,8 @@ describe("useFunctionColumnsData", () => {
           type: "function",
           id: "testColumn",
           queryDefinition: mockQueryDefinition,
-          getFunctionParams: ((objectSet: ObjectSet<TestObject>) => ({
-            [OBJ_SET_KEY]: objectSet,
+          getFunctionParams: ((wireObjectSet: WireObjectSet) => ({
+            [OBJ_SET_KEY]: wireObjectSet,
           })) as any,
           getValue: (cellData) => (cellData as { status: string })?.status,
           getKey: (obj) => `${obj.$objectType}:${obj.$primaryKey}`,
@@ -261,7 +269,11 @@ describe("useFunctionColumnsData", () => {
 
     const { result } = renderHook(
       () =>
-        useFunctionColumnsData(mockObjectSet, mockOneObject, columnDefinitions),
+        useFunctionColumnsData(
+          mockWireObjectSet,
+          mockOneObject,
+          columnDefinitions,
+        ),
     );
 
     expect(result.current).toEqual({
@@ -303,8 +315,8 @@ describe("useFunctionColumnsData", () => {
           type: "function",
           id: "statusColumn",
           queryDefinition: mockQueryDefinition,
-          getFunctionParams: ((objectSet: ObjectSet<TestObject>) => ({
-            [OBJ_SET_KEY]: objectSet,
+          getFunctionParams: ((wireObjectSet: WireObjectSet) => ({
+            [OBJ_SET_KEY]: wireObjectSet,
           })) as any,
           getValue: (cellData) => (cellData as { status: string })?.status,
           getKey: (obj) => `${obj.$objectType}:${obj.$primaryKey}`,
@@ -315,8 +327,8 @@ describe("useFunctionColumnsData", () => {
           type: "function",
           id: "timestampColumn",
           queryDefinition: mockQueryDefinition,
-          getFunctionParams: ((objectSet: ObjectSet<TestObject>) => ({
-            [OBJ_SET_KEY]: objectSet,
+          getFunctionParams: ((wireObjectSet: WireObjectSet) => ({
+            [OBJ_SET_KEY]: wireObjectSet,
           })) as any,
           getValue: (cellData) =>
             (cellData as { timestamp: string })?.timestamp,
@@ -336,7 +348,11 @@ describe("useFunctionColumnsData", () => {
 
     const { result } = renderHook(
       () =>
-        useFunctionColumnsData(mockObjectSet, mockOneObject, columnDefinitions),
+        useFunctionColumnsData(
+          mockWireObjectSet,
+          mockOneObject,
+          columnDefinitions,
+        ),
     );
 
     expect(result.current).toEqual({
@@ -365,7 +381,7 @@ describe("useFunctionColumnsData", () => {
           queryDefinition: mockQueryDefinition,
           options: {
             dedupeIntervalMs: DEFAULT_DEDUPE_INTERVAL_MS,
-            params: { [OBJ_SET_KEY]: mockObjectSet },
+            params: { [OBJ_SET_KEY]: mockWireObjectSet },
           },
         },
       ],
@@ -382,7 +398,10 @@ describe("useFunctionColumnsData", () => {
       },
     ] as Osdk.Instance<TestObject, "$allBaseProperties", TestObjectKeys, {}>[];
 
-    const mockObjectSet = {} as ObjectSet<TestObject>;
+    const localMockWireObjectSet = {
+      type: "base",
+      objectType: "TestObject",
+    } as Record<string, string> & WireObjectSet;
 
     const mockResult1 = {
       "TestObject:obj1": {
@@ -410,8 +429,8 @@ describe("useFunctionColumnsData", () => {
           type: "function",
           id: "statusColumn",
           queryDefinition: mockQueryDefinition,
-          getFunctionParams: ((objectSet: ObjectSet<TestObject>) => ({
-            [OBJ_SET_KEY]: objectSet,
+          getFunctionParams: ((wireObjectSet: WireObjectSet) => ({
+            [OBJ_SET_KEY]: wireObjectSet,
           })) as any,
           getValue: (cellData) => (cellData as { status: string })?.status,
           getKey: (obj) => `${obj.$objectType}:${obj.$primaryKey}`,
@@ -422,8 +441,8 @@ describe("useFunctionColumnsData", () => {
           type: "function",
           id: "timestampColumn",
           queryDefinition: mockQueryDefinition2,
-          getFunctionParams: ((objectSet: ObjectSet<TestObject>) => ({
-            [OBJ_SET_KEY]: objectSet,
+          getFunctionParams: ((wireObjectSet: WireObjectSet) => ({
+            [OBJ_SET_KEY]: wireObjectSet,
           })) as any,
           getValue: (cellData) =>
             (cellData as { timestamp: string })?.timestamp,
@@ -449,7 +468,11 @@ describe("useFunctionColumnsData", () => {
 
     const { result } = renderHook(
       () =>
-        useFunctionColumnsData(mockObjectSet, mockObjects, columnDefinitions),
+        useFunctionColumnsData(
+          localMockWireObjectSet,
+          mockObjects,
+          columnDefinitions,
+        ),
     );
 
     expect(result.current).toEqual({
@@ -477,14 +500,14 @@ describe("useFunctionColumnsData", () => {
         {
           queryDefinition: mockQueryDefinition,
           options: {
-            params: { [OBJ_SET_KEY]: mockObjectSet },
+            params: { [OBJ_SET_KEY]: localMockWireObjectSet },
             dedupeIntervalMs: DEFAULT_DEDUPE_INTERVAL_MS,
           },
         },
         {
           queryDefinition: mockQueryDefinition2,
           options: {
-            params: { [OBJ_SET_KEY]: mockObjectSet },
+            params: { [OBJ_SET_KEY]: localMockWireObjectSet },
             dedupeIntervalMs: DEFAULT_DEDUPE_INTERVAL_MS,
           },
         },
@@ -525,7 +548,11 @@ describe("useFunctionColumnsData", () => {
 
     const { result } = renderHook(
       () =>
-        useFunctionColumnsData(mockObjectSet, mockObjects, columnDefinitions),
+        useFunctionColumnsData(
+          mockWireObjectSet,
+          mockObjects,
+          columnDefinitions,
+        ),
     );
 
     expect(result.current).toEqual({
@@ -560,7 +587,11 @@ describe("useFunctionColumnsData", () => {
 
     const { result } = renderHook(
       () =>
-        useFunctionColumnsData(mockObjectSet, mockObjects, columnDefinitions),
+        useFunctionColumnsData(
+          mockWireObjectSet,
+          mockObjects,
+          columnDefinitions,
+        ),
     );
 
     expect(result.current).toEqual({
@@ -595,7 +626,11 @@ describe("useFunctionColumnsData", () => {
 
     renderHook(
       () =>
-        useFunctionColumnsData(mockObjectSet, mockObjects, nonFunctionColumns),
+        useFunctionColumnsData(
+          mockWireObjectSet,
+          mockObjects,
+          nonFunctionColumns,
+        ),
     );
 
     expect(useOsdkFunctions).toHaveBeenCalledWith({
@@ -617,7 +652,11 @@ describe("useFunctionColumnsData", () => {
 
     const { result, rerender } = renderHook(
       () =>
-        useFunctionColumnsData(mockObjectSet, mockObjects, columnDefinitions),
+        useFunctionColumnsData(
+          mockWireObjectSet,
+          mockObjects,
+          columnDefinitions,
+        ),
     );
 
     // Check initial loading state

--- a/packages/react-components/src/object-table/hooks/__tests__/useObjectTableData.test.tsx
+++ b/packages/react-components/src/object-table/hooks/__tests__/useObjectTableData.test.tsx
@@ -53,6 +53,13 @@ interface MockReturnType extends UseOsdkListResult<TestObject> {
   };
 }
 
+vi.mock("@osdk/client/unstable-do-not-use", () => ({
+  getWireObjectSet: vi.fn((objectSet: unknown) => ({
+    type: "base",
+    objectType: (objectSet as any)?.$objectSetInternals?.def?.apiName,
+  })),
+}));
+
 vi.mock("@osdk/react/experimental", () => ({
   useOsdkObjects: vi.fn((objectType, options): MockReturnType => {
     return {
@@ -108,11 +115,20 @@ describe(useObjectTableData, () => {
   const fakeClient = {} as unknown as Client;
   const wrapper = createWrapper(fakeClient);
 
-  const mockObjectSet = {
-    $objectSetInternals: {
-      def: TestObjectType,
-    },
-  } as unknown as ObjectSet<TestObject>;
+  const createMockObjectSet = () => {
+    const os: Record<string, unknown> = {
+      $objectSetInternals: {
+        def: TestObjectType,
+      },
+    };
+    os.union = (..._args: unknown[]) => os;
+    os.intersect = (..._args: unknown[]) => os;
+    os.subtract = (..._args: unknown[]) => os;
+    os.where = (_arg: unknown) => os;
+    os.pivotTo = (_arg: unknown) => os;
+    return os as unknown as ObjectSet<TestObject>;
+  };
+  const mockObjectSet = createMockObjectSet();
 
   it("calls useOsdkObjects with filter clause and orderBy provided", () => {
     const filterClause = {
@@ -587,7 +603,7 @@ describe(useObjectTableData, () => {
     );
 
     expect(useFunctionColumnsData).toHaveBeenCalledWith(
-      mockObjectSet,
+      { type: "base", objectType: "TestObject" },
       mockBaseData,
       columnDefinitions,
     );

--- a/packages/react-components/src/object-table/hooks/useFunctionColumnsData.ts
+++ b/packages/react-components/src/object-table/hooks/useFunctionColumnsData.ts
@@ -16,16 +16,18 @@
 
 import type {
   ObjectOrInterfaceDefinition,
-  ObjectSet,
   Osdk,
   PropertyKeys,
   QueryDefinition,
   SimplePropertyDef,
 } from "@osdk/api";
+import type { getWireObjectSet } from "@osdk/client/unstable-do-not-use";
 import {
   type FunctionQueryParams,
   useOsdkFunctions,
 } from "@osdk/react/experimental";
+
+type WireObjectSet = ReturnType<typeof getWireObjectSet>;
 
 import { useMemo } from "react";
 import type {
@@ -49,7 +51,7 @@ type FunctionColumnConfig<
 > = {
   queryDefinition: QueryDefinition<unknown>;
   getParams: (
-    objectSet: ObjectSet<Q, RDPs>,
+    wireObjectSet: WireObjectSet,
   ) => unknown;
   columnIds: Array<{
     columnId: string;
@@ -73,7 +75,7 @@ export function useFunctionColumnsData<
     never
   >,
 >(
-  objectSet: ObjectSet<Q, RDPs> | undefined,
+  wireObjectSet: WireObjectSet | undefined,
   objects:
     | Osdk.Instance<Q, "$allBaseProperties", PropertyKeys<Q>, RDPs>[]
     | undefined,
@@ -88,10 +90,13 @@ export function useFunctionColumnsData<
   const stableObjects = useStableObjects(objects);
 
   // TODO: replace with useDeepEqual when it's added
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const stableObjectSet = useMemo(() => objectSet, [JSON.stringify(objectSet)]);
+  const stableWireObjectSet = useMemo(
+    () => wireObjectSet,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [JSON.stringify(wireObjectSet)],
+  );
 
-  const disabled = !stableObjectSet || !stableObjects?.length
+  const disabled = !stableWireObjectSet || !stableObjects?.length
     || functionColumnConfigs.length === 0;
 
   // Prepare queries for useOsdkFunctions
@@ -105,14 +110,14 @@ export function useFunctionColumnsData<
         (config): FunctionQueryParams<QueryDefinition<unknown>> => ({
           queryDefinition: config.queryDefinition,
           options: {
-            params: config.getParams(stableObjectSet),
+            params: config.getParams(stableWireObjectSet),
             dedupeIntervalMs: config.dedupeIntervalMs
               ?? DEFAULT_DEDUPE_INTERVAL_MS,
           } as FunctionQueryParams<QueryDefinition<unknown>>["options"],
         }),
       );
     },
-    [disabled, functionColumnConfigs, stableObjectSet],
+    [disabled, functionColumnConfigs, stableWireObjectSet],
   );
 
   const results = useOsdkFunctions(

--- a/packages/react-components/src/object-table/hooks/useObjectTableData.ts
+++ b/packages/react-components/src/object-table/hooks/useObjectTableData.ts
@@ -23,6 +23,7 @@ import type {
   SimplePropertyDef,
   WhereClause,
 } from "@osdk/api";
+import { getWireObjectSet } from "@osdk/client/unstable-do-not-use";
 import type { UseOsdkListResult } from "@osdk/react/experimental";
 import { useObjectSet, useOsdkObjects } from "@osdk/react/experimental";
 import type { SortingState } from "@tanstack/react-table";
@@ -150,9 +151,28 @@ export function useObjectTableData<
   // Get the result from the appropriate hook
   const baseResult = shouldUseObjectSet ? objectSetResult : osdkObjectsResult;
 
+  // Compose wire objectSet from base + set operations (omitting withProperties
+  // which causes errors when present in function query parameters)
+  const wireObjectSet = useMemo(() => {
+    if (!objectSet) {
+      return undefined;
+    }
+    let result: ObjectSet<Q> = objectSet as ObjectSet<Q>;
+    if (objectSetOptions?.union?.length) {
+      result = result.union(...objectSetOptions.union);
+    }
+    if (objectSetOptions?.intersect?.length) {
+      result = result.intersect(...objectSetOptions.intersect);
+    }
+    if (objectSetOptions?.subtract?.length) {
+      result = result.subtract(...objectSetOptions.subtract);
+    }
+    return getWireObjectSet(result);
+  }, [objectSet, objectSetOptions]);
+
   // Call useFunctionColumnsData to get function column data
   const functionColumnData = useFunctionColumnsData<Q, RDPs, FunctionColumns>(
-    objectSetResult.objectSet,
+    wireObjectSet,
     baseResult.data,
     columnDefinitions,
   );


### PR DESCRIPTION
function-backed columns were failing when the composed ObjectSet (with withProperties) was passed to query parameters

• compose wire objectSet from base + set operations only, omitting withProperties which is unsupported in function query params
• update useFunctionColumnsData to accept wire objectSet representation instead of client ObjectSet
• update FunctionColumnLocator.getFunctionParams to take wire objectSet