### PR TITLE
[Public Apps] Export the Authless Client

### DIFF
--- a/.changeset/new-pandas-judge.md
+++ b/.changeset/new-pandas-judge.md
@@ -1,0 +1,5 @@
+---
+"@osdk/oauth": patch
+---
+
+Add Supported Client for Public Apps

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -16,6 +16,7 @@
 
 export type { TokenStorageType } from "./common.js";
 export type { ConfidentialOauthClient } from "./ConfidentialOauthClient.js";
+export { createAuthlessClient } from "./createAuthlessClient.js";
 export { createConfidentialOauthClient } from "./createConfidentialOauthClient.js";
 export {
   createPublicOauthClient,


### PR DESCRIPTION
For Public Application Development, we want to export the authlessClient so that consumers can use unauthenticated endpoints.

```
const client: Client = createClient(
  foundryUrl,
  $ontologyRid,
  createAuthlessClient()
)
```