### PR TITLE
align FilterList API with ObjectTable: objectType required, objectSet optional

### DIFF
--- a/.changeset/filter-list-objectset-api.md
+++ b/.changeset/filter-list-objectset-api.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+align FilterList API with ObjectTable: add required `objectType` prop, make `objectSet` optional

--- a/packages/e2e.sandbox.officenetwork/src/components/EmployeeFilters.tsx
+++ b/packages/e2e.sandbox.officenetwork/src/components/EmployeeFilters.tsx
@@ -19,7 +19,6 @@ import {
   FilterList,
 } from "@osdk/react-components/experimental";
 import React, { useCallback, useMemo, useState } from "react";
-import { $ } from "../foundryClient.js";
 import { Employee } from "../generatedNoCheck2/index.js";
 
 const ALL_FILTER_DEFINITIONS: FilterDefinitionUnion<Employee>[] = [
@@ -194,7 +193,7 @@ export function EmployeeFilters({
   return (
     <div style={containerStyle}>
       <FilterList
-        objectSet={$(Employee)}
+        objectType={Employee}
         filterDefinitions={filterDefinitions}
         onFilterClauseChanged={onFilterClauseChanged}
         onFilterRemoved={handleRemoveFilter}

--- a/packages/e2e.sandbox.peopleapp/src/app/employees/EmployeesWithFilterList.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/employees/EmployeesWithFilterList.tsx
@@ -25,7 +25,6 @@ import { useState } from "react";
 
 import { List } from "../../components/List.js";
 import { ListItem } from "../../components/ListItem.js";
-import { $ } from "../../foundryClient.js";
 import { Employee } from "../../generatedNoCheck2/index.js";
 
 interface EmployeeListItemProps {
@@ -87,7 +86,7 @@ export function EmployeesWithFilterList(props: EmployeesWithFilterListProps) {
       <div style={{ display: "flex", gap: "16px", height: "100%" }}>
         <div>
           <FilterList
-            objectSet={$(Employee)}
+            objectType={Employee}
             filterDefinitions={INITIAL_FILTER_DEFINITIONS}
             onFilterClauseChanged={setWhereClause}
             enableSorting={true}

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
@@ -15,7 +15,6 @@
  */
 
 import type { WhereClause } from "@osdk/api";
-import { useOsdkClient } from "@osdk/react";
 import { FilterList, ObjectTable } from "@osdk/react-components/experimental";
 import type {
   FilterDefinitionUnion,
@@ -28,11 +27,6 @@ import { fauxFoundry } from "../../mocks/fauxFoundry.js";
 import { Employee } from "../../types/Employee.js";
 
 type EmployeeFilterListProps = FilterListProps<typeof Employee>;
-
-function useEmployeeObjectSet() {
-  const client = useOsdkClient();
-  return useMemo(() => client(Employee), [client]);
-}
 
 const departmentFilter: FilterDefinitionUnion<Employee> = {
   type: "PROPERTY",
@@ -151,8 +145,12 @@ const meta: Meta<EmployeeFilterListProps> = {
     },
   },
   argTypes: {
+    objectType: {
+      description: "The object type definition for the objects being filtered",
+      control: false,
+    },
     objectSet: {
-      description: "The object set to filter",
+      description: "Optional object set to scope aggregation queries",
       control: false,
     },
     filterDefinitions: {
@@ -261,7 +259,7 @@ export const Default: Story = {
     docs: {
       source: {
         code: `<FilterList
-  objectSet={client(Employee)}
+  objectType={Employee}
   filterDefinitions={[
     { type: "PROPERTY", key: "department", label: "Department", filterComponent: "LISTOGRAM", filterState: { type: "EXACT_MATCH", values: [] } },
     { type: "PROPERTY", key: "locationCity", label: "Location City", filterComponent: "LISTOGRAM", filterState: { type: "EXACT_MATCH", values: [] } },
@@ -270,8 +268,7 @@ export const Default: Story = {
       },
     },
   },
-  render: ({ objectSet: _os, ...args }) => {
-    const objectSet = useEmployeeObjectSet();
+  render: ({ objectType: _ot, objectSet: _os, ...args }) => {
     const filterDefinitions = useMemo(
       (): FilterDefinitionUnion<Employee>[] => [
         departmentFilter,
@@ -282,7 +279,7 @@ export const Default: Story = {
     return (
       <div style={SIDEBAR_STYLE}>
         <FilterList
-          objectSet={objectSet}
+          objectType={Employee}
           filterDefinitions={filterDefinitions}
           {...args}
         />
@@ -292,7 +289,6 @@ export const Default: Story = {
 };
 
 function AddFilterModeStory(args: Partial<EmployeeFilterListProps>) {
-  const objectSet = useEmployeeObjectSet();
   const filterDefinitions = useMemo(
     (): FilterDefinitionUnion<Employee>[] => [
       departmentFilter,
@@ -316,7 +312,7 @@ function AddFilterModeStory(args: Partial<EmployeeFilterListProps>) {
   return (
     <div style={SIDEBAR_STYLE}>
       <FilterList
-        objectSet={objectSet}
+        objectType={Employee}
         filterDefinitions={filterDefinitions}
         addFilterMode="uncontrolled"
         {...args}
@@ -342,7 +338,7 @@ export const AddFilterMode: Story = {
 ];
 
 <FilterList
-  objectSet={client(Employee)}
+  objectType={Employee}
   filterDefinitions={filterDefinitions}
   addFilterMode="uncontrolled"
   showResetButton={true}
@@ -354,7 +350,6 @@ export const AddFilterMode: Story = {
 };
 
 function WithAllFilterTypesStory(args: Partial<EmployeeFilterListProps>) {
-  const objectSet = useEmployeeObjectSet();
   const [filterClause, setFilterClause] = useState<
     WhereClause<Employee> | undefined
   >(undefined);
@@ -363,7 +358,7 @@ function WithAllFilterTypesStory(args: Partial<EmployeeFilterListProps>) {
     <div style={FLEX_ROW_STYLE}>
       <div style={SIDEBAR_STYLE}>
         <FilterList
-          objectSet={objectSet}
+          objectType={Employee}
           filterDefinitions={sharedFilterDefinitions}
           filterClause={filterClause}
           onFilterClauseChanged={setFilterClause}
@@ -391,7 +386,7 @@ export const WithAllFilterTypes: Story = {
       },
       source: {
         code: `<FilterList
-  objectSet={client(Employee)}
+  objectType={Employee}
   filterDefinitions={filterDefinitions}
   filterClause={filterClause}
   onFilterClauseChanged={setFilterClause}
@@ -410,7 +405,7 @@ export const WithTitleAndIcon: Story = {
     docs: {
       source: {
         code: `<FilterList
-  objectSet={client(Employee)}
+  objectType={Employee}
   filterDefinitions={filterDefinitions}
   title="Employee Filters"
   titleIcon={<svg>...</svg>}
@@ -418,12 +413,11 @@ export const WithTitleAndIcon: Story = {
       },
     },
   },
-  render: ({ objectSet: _os, ...args }) => {
-    const objectSet = useEmployeeObjectSet();
+  render: ({ objectType: _ot, objectSet: _os, ...args }) => {
     return (
       <div style={SIDEBAR_STYLE}>
         <FilterList
-          objectSet={objectSet}
+          objectType={Employee}
           filterDefinitions={sharedFilterDefinitions}
           titleIcon={FILTER_ICON}
           {...args}
@@ -434,7 +428,6 @@ export const WithTitleAndIcon: Story = {
 };
 
 function WithResetButtonStory(args: Partial<EmployeeFilterListProps>) {
-  const objectSet = useEmployeeObjectSet();
   const handleReset = useCallback(() => {
     // eslint-disable-next-line no-console
     console.log("Reset clicked");
@@ -443,7 +436,7 @@ function WithResetButtonStory(args: Partial<EmployeeFilterListProps>) {
   return (
     <div style={SIDEBAR_STYLE}>
       <FilterList
-        objectSet={objectSet}
+        objectType={Employee}
         filterDefinitions={sharedFilterDefinitions}
         onReset={handleReset}
         {...args}
@@ -460,7 +453,7 @@ export const WithResetButton: Story = {
     docs: {
       source: {
         code: `<FilterList
-  objectSet={client(Employee)}
+  objectType={Employee}
   filterDefinitions={filterDefinitions}
   showResetButton={true}
   onReset={() => console.log("Reset clicked")}
@@ -479,19 +472,18 @@ export const WithActiveFilterCount: Story = {
     docs: {
       source: {
         code: `<FilterList
-  objectSet={client(Employee)}
+  objectType={Employee}
   filterDefinitions={filterDefinitions}
   showActiveFilterCount={true}
 />`,
       },
     },
   },
-  render: ({ objectSet: _os, ...args }) => {
-    const objectSet = useEmployeeObjectSet();
+  render: ({ objectType: _ot, objectSet: _os, ...args }) => {
     return (
       <div style={SIDEBAR_STYLE}>
         <FilterList
-          objectSet={objectSet}
+          objectType={Employee}
           filterDefinitions={sharedFilterDefinitions}
           {...args}
         />
@@ -508,19 +500,18 @@ export const WithSorting: Story = {
     docs: {
       source: {
         code: `<FilterList
-  objectSet={client(Employee)}
+  objectType={Employee}
   filterDefinitions={filterDefinitions}
   enableSorting={true}
 />`,
       },
     },
   },
-  render: ({ objectSet: _os, ...args }) => {
-    const objectSet = useEmployeeObjectSet();
+  render: ({ objectType: _ot, objectSet: _os, ...args }) => {
     return (
       <div style={SIDEBAR_STYLE}>
         <FilterList
-          objectSet={objectSet}
+          objectType={Employee}
           filterDefinitions={sharedFilterDefinitions}
           {...args}
         />
@@ -534,12 +525,10 @@ function CollapsiblePanelStory(
     onCollapsedChange?: (collapsed: boolean) => void;
   },
 ) {
-  const objectSet = useEmployeeObjectSet();
-
   return (
     <div style={SIDEBAR_STYLE}>
       <FilterList
-        objectSet={objectSet}
+        objectType={Employee}
         filterDefinitions={sharedFilterDefinitions}
         {...args}
       />
@@ -562,7 +551,7 @@ export const CollapsiblePanel: Story = {
         code: `const [collapsed, setCollapsed] = useState(false);
 
 <FilterList
-  objectSet={client(Employee)}
+  objectType={Employee}
   filterDefinitions={filterDefinitions}
   title="Employee Filters"
   collapsed={collapsed}
@@ -597,12 +586,11 @@ export const KeywordSearch: Story = {
   { type: "PROPERTY", key: "locationCity", label: "Location City", filterComponent: "LISTOGRAM", filterState: { type: "EXACT_MATCH", values: [] } },
 ];
 
-<FilterList objectSet={client(Employee)} filterDefinitions={filterDefinitions} />`,
+<FilterList objectType={Employee} filterDefinitions={filterDefinitions} />`,
       },
     },
   },
-  render: ({ objectSet: _os, ...args }) => {
-    const objectSet = useEmployeeObjectSet();
+  render: ({ objectType: _ot, objectSet: _os, ...args }) => {
     const filterDefinitions = useMemo(
       (): FilterDefinitionUnion<Employee>[] => [
         {
@@ -619,7 +607,7 @@ export const KeywordSearch: Story = {
     return (
       <div style={SIDEBAR_STYLE}>
         <FilterList
-          objectSet={objectSet}
+          objectType={Employee}
           filterDefinitions={filterDefinitions}
           {...args}
         />
@@ -629,7 +617,6 @@ export const KeywordSearch: Story = {
 };
 
 function WithColorMapStory(args: Partial<EmployeeFilterListProps>) {
-  const objectSet = useEmployeeObjectSet();
   const withoutColorMap = useMemo(
     (): FilterDefinitionUnion<Employee>[] => [
       {
@@ -667,14 +654,14 @@ function WithColorMapStory(args: Partial<EmployeeFilterListProps>) {
     <div style={FLEX_ROW_STYLE}>
       <div style={SIDEBAR_STYLE}>
         <FilterList
-          objectSet={objectSet}
+          objectType={Employee}
           filterDefinitions={withoutColorMap}
           {...args}
         />
       </div>
       <div style={SIDEBAR_STYLE}>
         <FilterList
-          objectSet={objectSet}
+          objectType={Employee}
           filterDefinitions={withColorMap}
           {...args}
         />
@@ -706,7 +693,7 @@ const filterDefinitions = [
   },
 ];
 
-<FilterList objectSet={client(Employee)} filterDefinitions={filterDefinitions} />`,
+<FilterList objectType={Employee} filterDefinitions={filterDefinitions} />`,
       },
     },
   },
@@ -716,7 +703,6 @@ const filterDefinitions = [
 function WithListogramDisplayModesStory(
   args: Partial<EmployeeFilterListProps>,
 ) {
-  const objectSet = useEmployeeObjectSet();
   const fullDefs = useMemo(
     (): FilterDefinitionUnion<Employee>[] => [
       {
@@ -764,21 +750,21 @@ function WithListogramDisplayModesStory(
     <div style={FLEX_ROW_STYLE}>
       <div style={SIDEBAR_STYLE}>
         <FilterList
-          objectSet={objectSet}
+          objectType={Employee}
           filterDefinitions={fullDefs}
           {...args}
         />
       </div>
       <div style={SIDEBAR_STYLE}>
         <FilterList
-          objectSet={objectSet}
+          objectType={Employee}
           filterDefinitions={countDefs}
           {...args}
         />
       </div>
       <div style={SIDEBAR_STYLE}>
         <FilterList
-          objectSet={objectSet}
+          objectType={Employee}
           filterDefinitions={minimalDefs}
           {...args}
         />
@@ -807,7 +793,6 @@ const filterDefinitions = [
 };
 
 function WithCheckboxStory(args: Partial<EmployeeFilterListProps>) {
-  const objectSet = useEmployeeObjectSet();
   const filterDefinitions = useMemo(
     (): FilterDefinitionUnion<Employee>[] => [
       {
@@ -833,7 +818,7 @@ function WithCheckboxStory(args: Partial<EmployeeFilterListProps>) {
   return (
     <div style={SIDEBAR_STYLE}>
       <FilterList
-        objectSet={objectSet}
+        objectType={Employee}
         filterDefinitions={filterDefinitions}
         {...args}
       />
@@ -851,7 +836,7 @@ export const WithCheckbox: Story = {
       },
       source: {
         code: `<FilterList
-  objectSet={client(Employee)}
+  objectType={Employee}
   filterDefinitions={[
     { type: "PROPERTY", key: "department", label: "Department", filterComponent: "LISTOGRAM", filterState: { type: "EXACT_MATCH", values: [] } },
     { type: "PROPERTY", key: "team", label: "Team", filterComponent: "LISTOGRAM", filterState: { type: "EXACT_MATCH", values: [] } },
@@ -866,7 +851,6 @@ export const WithCheckbox: Story = {
 function CombinedWithObjectTableStory(
   args: Partial<EmployeeFilterListProps>,
 ) {
-  const objectSet = useEmployeeObjectSet();
   const [filterClause, setFilterClause] = useState<
     WhereClause<Employee> | undefined
   >(undefined);
@@ -880,7 +864,7 @@ function CombinedWithObjectTableStory(
     <div style={COMBINED_LAYOUT_STYLE}>
       <div style={SIDEBAR_FIXED_STYLE}>
         <FilterList
-          objectSet={objectSet}
+          objectType={Employee}
           filterDefinitions={sharedFilterDefinitions}
           onFilterRemoved={handleFilterRemoved}
           filterClause={filterClause}
@@ -910,7 +894,7 @@ export const CombinedWithObjectTable: Story = {
 <div style={{ display: "flex", gap: 16, height: 600 }}>
   <div style={{ width: 320 }}>
     <FilterList
-      objectSet={client(Employee)}
+      objectType={Employee}
       filterDefinitions={filterDefinitions}
       title="Employee Filters"
       showResetButton={true}
@@ -932,7 +916,6 @@ export const CombinedWithObjectTable: Story = {
 };
 
 function WithRemovableFiltersStory(args: Partial<EmployeeFilterListProps>) {
-  const objectSet = useEmployeeObjectSet();
   const [definitions, setDefinitions] = useState<
     FilterDefinitionUnion<Employee>[]
   >(sharedFilterDefinitions);
@@ -951,7 +934,7 @@ function WithRemovableFiltersStory(args: Partial<EmployeeFilterListProps>) {
   return (
     <div style={SIDEBAR_STYLE}>
       <FilterList
-        objectSet={objectSet}
+        objectType={Employee}
         filterDefinitions={definitions}
         onFilterRemoved={handleFilterRemoved}
         {...args}
@@ -982,7 +965,7 @@ const handleFilterRemoved = (filterKey) => {
 };
 
 <FilterList
-  objectSet={client(Employee)}
+  objectType={Employee}
   filterDefinitions={definitions}
   onFilterRemoved={handleFilterRemoved}
   title="Removable Filters"
@@ -998,7 +981,6 @@ function FullFeaturedStory(
     onCollapsedChange?: (collapsed: boolean) => void;
   },
 ) {
-  const objectSet = useEmployeeObjectSet();
   const [filterClause, setFilterClause] = useState<
     WhereClause<Employee> | undefined
   >(undefined);
@@ -1025,7 +1007,7 @@ function FullFeaturedStory(
     <div style={COMBINED_LAYOUT_STYLE}>
       <div style={SIDEBAR_FIXED_STYLE}>
         <FilterList
-          objectSet={objectSet}
+          objectType={Employee}
           filterDefinitions={definitions}
           titleIcon={FILTER_ICON}
           onReset={handleReset}
@@ -1063,7 +1045,7 @@ export const FullFeatured: Story = {
           `// All features combined: collapse, sort, search, exclude, remove, reset
 
 <FilterList
-  objectSet={client(Employee)}
+  objectType={Employee}
   filterDefinitions={definitions}
   title="Employee Filters"
   titleIcon={<FilterIcon />}

--- a/packages/react-components/src/filter-list/FilterInput.tsx
+++ b/packages/react-components/src/filter-list/FilterInput.tsx
@@ -25,7 +25,7 @@ import { PropertyFilterInput } from "./inputs/PropertyFilterInput.js";
 
 interface FilterInputProps<Q extends ObjectTypeDefinition> {
   objectType: Q;
-  objectSet: ObjectSet<Q>;
+  objectSet?: ObjectSet<Q>;
   definition: FilterDefinitionUnion<Q>;
   filterState: FilterState | undefined;
   onFilterStateChanged: (state: FilterState) => void;
@@ -79,7 +79,10 @@ function FilterInputContent<Q extends ObjectTypeDefinition>({
         />
       );
 
-    case "LINKED_PROPERTY":
+    case "LINKED_PROPERTY": {
+      if (objectSet == null) {
+        return <></>;
+      }
       return (
         <LinkedPropertyInput
           objectSet={objectSet}
@@ -89,6 +92,7 @@ function FilterInputContent<Q extends ObjectTypeDefinition>({
           searchQuery={searchQuery}
         />
       );
+    }
 
     case "KEYWORD_SEARCH":
       return (
@@ -111,6 +115,7 @@ function FilterInputContent<Q extends ObjectTypeDefinition>({
       return (
         <>
           {definition.renderInput({
+            objectType,
             objectSet,
             filterState: customFilterState,
             onFilterStateChanged: (state) => onFilterStateChanged(state),

--- a/packages/react-components/src/filter-list/FilterList.tsx
+++ b/packages/react-components/src/filter-list/FilterList.tsx
@@ -33,6 +33,7 @@ export function FilterList<Q extends ObjectTypeDefinition>(
   props: FilterListProps<Q>,
 ): React.ReactElement {
   const {
+    objectType,
     objectSet,
     title,
     titleIcon,
@@ -49,8 +50,6 @@ export function FilterList<Q extends ObjectTypeDefinition>(
     onFilterRemoved,
     renderAddFilterButton,
   } = props;
-
-  const objectType = objectSet.$objectSetInternals.def;
 
   const {
     filterStates,

--- a/packages/react-components/src/filter-list/FilterListApi.ts
+++ b/packages/react-components/src/filter-list/FilterListApi.ts
@@ -72,9 +72,17 @@ export type FilterStatesMap<Q extends ObjectTypeDefinition> = Map<
 
 export interface FilterListProps<Q extends ObjectTypeDefinition> {
   /**
-   * The set of objects to be filtered
+   * The object type definition for the objects being filtered.
+   * Used for metadata resolution (property types, display names).
    */
-  objectSet: ObjectSet<Q>;
+  objectType: Q;
+
+  /**
+   * Optional object set to scope aggregation queries.
+   * When provided, filter aggregations (e.g. listogram counts) are scoped to this set.
+   * When omitted, aggregations run against the full object type.
+   */
+  objectSet?: ObjectSet<Q>;
 
   /**
    * Optional title to display in the filter list header

--- a/packages/react-components/src/filter-list/hooks/__tests__/useFilterListState.test.tsx
+++ b/packages/react-components/src/filter-list/hooks/__tests__/useFilterListState.test.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import type { ObjectSet } from "@osdk/api";
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -37,19 +36,11 @@ import type { FilterListProps } from "../../FilterListApi.js";
 import { getFilterKey } from "../../utils/getFilterKey.js";
 import { useFilterListState } from "../useFilterListState.js";
 
-function createMockObjectSet(): ObjectSet<typeof MockObjectType> {
-  return {
-    $objectSetInternals: {
-      def: MockObjectType,
-    },
-  } as ObjectSet<typeof MockObjectType>;
-}
-
 function createProps(
   overrides: Partial<FilterListProps<typeof MockObjectType>> = {},
 ): FilterListProps<typeof MockObjectType> {
   return {
-    objectSet: createMockObjectSet(),
+    objectType: MockObjectType,
     ...overrides,
   };
 }
@@ -351,6 +342,31 @@ describe("useFilterListState", () => {
       );
       expect(result.current.activeFilterCount).toBe(1);
     });
+  });
+
+  it("works without objectSet (objectType only)", () => {
+    const nameDef = createPropertyFilterDef(
+      "name",
+      "LISTOGRAM",
+      createExactMatchState([]),
+    );
+    const props = createProps({
+      filterDefinitions: [nameDef],
+    });
+    expect(props.objectSet).toBeUndefined();
+    const { result } = renderHook(() => useFilterListState(props));
+    expect(result.current.filterStates.size).toBe(1);
+    act(() => {
+      result.current.setFilterState(
+        getFilterKey(nameDef),
+        createExactMatchState(["John"]),
+      );
+    });
+    expect(result.current.whereClause).toEqual({ name: "John" });
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.whereClause).toEqual({});
   });
 
   it("handles multiple filter definitions", () => {

--- a/packages/react-components/src/filter-list/hooks/useFilterListState.ts
+++ b/packages/react-components/src/filter-list/hooks/useFilterListState.ts
@@ -96,14 +96,12 @@ export function useFilterListState<Q extends ObjectTypeDefinition>(
   props: FilterListProps<Q>,
 ): UseFilterListStateResult<Q> {
   const {
-    objectSet,
+    objectType,
     filterDefinitions,
     onFilterStateChanged,
     onFilterClauseChanged,
     initialFilterStates,
   } = props;
-
-  const objectType = objectSet.$objectSetInternals.def;
   const { metadata } = useOsdkMetadata(objectType);
 
   const propertyTypes = useMemo(() => {

--- a/packages/react-components/src/filter-list/hooks/usePropertyAggregation.ts
+++ b/packages/react-components/src/filter-list/hooks/usePropertyAggregation.ts
@@ -50,7 +50,7 @@ export function usePropertyAggregation<
 >(
   objectType: Q,
   propertyKey: K,
-  objectSet: ObjectSet<Q>,
+  objectSet: ObjectSet<Q> | undefined,
   options?: UsePropertyAggregationOptions<Q>,
 ): UsePropertyAggregationResult {
   // AggregateOpts requires specific property keys from Q, but we're dynamically
@@ -68,11 +68,18 @@ export function usePropertyAggregation<
     [propertyKey],
   );
 
-  const { data: countData, isLoading, error } = useOsdkAggregation(objectType, {
-    aggregate: aggregateOptions,
-    where: options?.where,
-    objectSet,
-  });
+  const aggregationArgs = useMemo(
+    () =>
+      objectSet != null
+        ? { aggregate: aggregateOptions, where: options?.where, objectSet }
+        : { aggregate: aggregateOptions, where: options?.where },
+    [aggregateOptions, options?.where, objectSet],
+  );
+
+  const { data: countData, isLoading, error } = useOsdkAggregation(
+    objectType,
+    aggregationArgs,
+  );
 
   const result = useMemo(
     (): { data: PropertyAggregationValue[]; maxCount: number } => {

--- a/packages/react-components/src/filter-list/inputs/DateRangeFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/DateRangeFilterInput.tsx
@@ -28,7 +28,7 @@ import {
 
 interface DateRangeFilterInputProps<Q extends ObjectTypeDefinition> {
   objectType: Q;
-  objectSet: ObjectSet<Q>;
+  objectSet?: ObjectSet<Q>;
   propertyKey: string;
   filterState: FilterState | undefined;
   onFilterStateChanged: (state: FilterState) => void;
@@ -76,7 +76,10 @@ function DateRangeFilterInputInner<Q extends ObjectTypeDefinition>({
   );
 
   const histogramArgs = useMemo(
-    () => ({ aggregate: aggregateOptions, objectSet }),
+    () =>
+      objectSet != null
+        ? { aggregate: aggregateOptions, objectSet }
+        : { aggregate: aggregateOptions },
     [aggregateOptions, objectSet],
   );
 
@@ -118,11 +121,14 @@ function DateRangeFilterInputInner<Q extends ObjectTypeDefinition>({
   );
 
   const nullCountArgs = useMemo(
-    () => ({
-      where: nullWhereClause,
-      aggregate: nullCountAggregateOptions,
-      objectSet,
-    }),
+    () =>
+      objectSet != null
+        ? {
+          where: nullWhereClause,
+          aggregate: nullCountAggregateOptions,
+          objectSet,
+        }
+        : { where: nullWhereClause, aggregate: nullCountAggregateOptions },
     [nullWhereClause, nullCountAggregateOptions, objectSet],
   );
 

--- a/packages/react-components/src/filter-list/inputs/ListogramFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/ListogramFilterInput.tsx
@@ -29,7 +29,7 @@ import { coerceToStringArray } from "../utils/coerceFilterValue.js";
 
 interface ListogramFilterInputProps<Q extends ObjectTypeDefinition> {
   objectType: Q;
-  objectSet: ObjectSet<Q>;
+  objectSet?: ObjectSet<Q>;
   propertyKey: string;
   filterState: FilterState | undefined;
   onFilterStateChanged: (state: FilterState) => void;

--- a/packages/react-components/src/filter-list/inputs/MultiSelectFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/MultiSelectFilterInput.tsx
@@ -29,7 +29,7 @@ import { coerceToStringArray } from "../utils/coerceFilterValue.js";
 
 interface MultiSelectFilterInputProps<Q extends ObjectTypeDefinition> {
   objectType: Q;
-  objectSet: ObjectSet<Q>;
+  objectSet?: ObjectSet<Q>;
   propertyKey: string;
   filterState: FilterState | undefined;
   onFilterStateChanged: (state: FilterState) => void;

--- a/packages/react-components/src/filter-list/inputs/NumberRangeFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/NumberRangeFilterInput.tsx
@@ -28,7 +28,7 @@ import {
 
 interface NumberRangeFilterInputProps<Q extends ObjectTypeDefinition> {
   objectType: Q;
-  objectSet: ObjectSet<Q>;
+  objectSet?: ObjectSet<Q>;
   propertyKey: string;
   filterState: FilterState | undefined;
   onFilterStateChanged: (state: FilterState) => void;
@@ -80,7 +80,10 @@ function NumberRangeFilterInputInner<Q extends ObjectTypeDefinition>({
   );
 
   const histogramArgs = useMemo(
-    () => ({ aggregate: aggregateOptions, objectSet }),
+    () =>
+      objectSet != null
+        ? { aggregate: aggregateOptions, objectSet }
+        : { aggregate: aggregateOptions },
     [aggregateOptions, objectSet],
   );
 
@@ -122,11 +125,14 @@ function NumberRangeFilterInputInner<Q extends ObjectTypeDefinition>({
   );
 
   const nullCountArgs = useMemo(
-    () => ({
-      where: nullWhereClause,
-      aggregate: nullCountAggregateOptions,
-      objectSet,
-    }),
+    () =>
+      objectSet != null
+        ? {
+          where: nullWhereClause,
+          aggregate: nullCountAggregateOptions,
+          objectSet,
+        }
+        : { where: nullWhereClause, aggregate: nullCountAggregateOptions },
     [nullWhereClause, nullCountAggregateOptions, objectSet],
   );
 

--- a/packages/react-components/src/filter-list/inputs/PropertyFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/PropertyFilterInput.tsx
@@ -33,7 +33,7 @@ import { ToggleFilterInput } from "./ToggleFilterInput.js";
 
 interface PropertyFilterInputProps<Q extends ObjectTypeDefinition> {
   objectType: Q;
-  objectSet: ObjectSet<Q>;
+  objectSet?: ObjectSet<Q>;
   definition: Extract<FilterDefinitionUnion<Q>, { type: "PROPERTY" }>;
   filterState: FilterState | undefined;
   onFilterStateChanged: (state: FilterState) => void;

--- a/packages/react-components/src/filter-list/inputs/SingleSelectFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/SingleSelectFilterInput.tsx
@@ -29,7 +29,7 @@ import { coerceToString } from "../utils/coerceFilterValue.js";
 
 interface SingleSelectFilterInputProps<Q extends ObjectTypeDefinition> {
   objectType: Q;
-  objectSet: ObjectSet<Q>;
+  objectSet?: ObjectSet<Q>;
   propertyKey: string;
   filterState: FilterState | undefined;
   onFilterStateChanged: (state: FilterState) => void;

--- a/packages/react-components/src/filter-list/inputs/TextTagsFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/TextTagsFilterInput.tsx
@@ -29,7 +29,7 @@ import { coerceToStringArray } from "../utils/coerceFilterValue.js";
 
 interface TextTagsFilterInputProps<Q extends ObjectTypeDefinition> {
   objectType: Q;
-  objectSet: ObjectSet<Q>;
+  objectSet?: ObjectSet<Q>;
   propertyKey: string;
   filterState: FilterState | undefined;
   onFilterStateChanged: (state: FilterState) => void;

--- a/packages/react-components/src/filter-list/types/CustomRendererTypes.ts
+++ b/packages/react-components/src/filter-list/types/CustomRendererTypes.ts
@@ -35,7 +35,8 @@ export interface CustomFilterInputRendererProps<
   Q extends ObjectTypeDefinition,
   State extends BaseFilterState,
 > {
-  objectSet: ObjectSet<Q>;
+  objectType: Q;
+  objectSet?: ObjectSet<Q>;
   filterState: State;
   onFilterStateChanged: (newState: State) => void;
 }


### PR DESCRIPTION
FilterList required objectSet as the sole data-source prop, diverging from ObjectTable's pattern

• add objectType as the primary required prop for metadata resolution, make objectSet optional for scoping aggregation queries
• conditionally pass objectSet to useOsdkAggregation so aggregations fall back to the full type when no objectSet is provided
• update stories, example app, and tests to use the new API