### PR TITLE
Add source export condition for dev-time HMR

### DIFF
--- a/.changeset/warm-pandas-dance.md
+++ b/.changeset/warm-pandas-dance.md
@@ -1,0 +1,7 @@
+---
+"@osdk/api": patch
+"@osdk/react": patch
+"@osdk/react-components": patch
+---
+
+Add source export condition for dev-time HMR in Vite consumers

--- a/.changeset/warm-pandas-dance.md
+++ b/.changeset/warm-pandas-dance.md
@@ -1,7 +1,11 @@
 ---
 "@osdk/api": patch
+"@osdk/client": patch
 "@osdk/react": patch
 "@osdk/react-components": patch
+"@osdk/functions": patch
+"@osdk/functions-testing.experimental": patch
+"@osdk/cbac-components": patch
 ---
 
 Add source export condition for dev-time HMR in Vite consumers

--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -84,13 +84,23 @@ const archetypeRules = archetypes(
     "checkApiPackages",
     [
       "@osdk/client",
-      "@osdk/api",
       "@osdk/functions",
       "@osdk/functions-testing.experimental",
     ],
     {
       ...LIBRARY_RULES,
       checkApi: true,
+    },
+  )
+  .addArchetype(
+    "checkApiPackagesWithSource",
+    [
+      "@osdk/api",
+    ],
+    {
+      ...LIBRARY_RULES,
+      checkApi: true,
+      source: true,
     },
   )
   .addArchetype(
@@ -342,12 +352,24 @@ const archetypeRules = archetypes(
     "reactLibraryWithCss",
     [
       "@osdk/cbac-components",
+    ],
+    {
+      ...LIBRARY_RULES,
+      react: true,
+      cssExport: true,
+      extraPublishFiles: ["AGENTS.md", "docs"],
+    },
+  )
+  .addArchetype(
+    "reactLibraryWithCssAndSource",
+    [
       "@osdk/react-components",
     ],
     {
       ...LIBRARY_RULES,
       react: true,
       cssExport: true,
+      source: true,
       extraPublishFiles: ["AGENTS.md", "docs"],
     },
   )
@@ -359,6 +381,7 @@ const archetypeRules = archetypes(
     {
       ...LIBRARY_RULES,
       react: true,
+      source: true,
       extraPublishFiles: ["AGENTS.md", "docs", "experimental"],
     },
   )
@@ -542,7 +565,8 @@ async function dirExists(dirPath) {
  * @type {import("@monorepolint/rules").RuleFactoryFn< {
  *   browser?: boolean,
  *   cjs?: boolean,
- *   cssExport?: boolean
+ *   cssExport?: boolean,
+ *   source?: boolean
  * }>}
  */
 const ourExportsConvention = createRuleFactory({
@@ -558,6 +582,7 @@ const ourExportsConvention = createRuleFactory({
     const expectedExports = {
       exports: {
         ".": {
+          ...(options.source ? { "source": "./src/index.ts" } : {}),
           "browser": options.browser
             ? "./build/browser/index.js"
             : undefined,
@@ -580,6 +605,9 @@ const ourExportsConvention = createRuleFactory({
 
     function makeExport(fileName) {
       return {
+        ...(options.source
+          ? { "source": `./src/public/${fileName}.ts` }
+          : {}),
         ...(options.browser
           ? { "browser": `./build/browser/public/${fileName}.js` }
           : {}),
@@ -979,6 +1007,7 @@ function standardPackageRules(shared, options) {
         cjs: !!options.output.cjs,
         browser: !!options.output.browser,
         cssExport: !!options.cssExport,
+        source: !!options.source,
       },
     }),
     packageEntry({

--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -84,18 +84,9 @@ const archetypeRules = archetypes(
     "checkApiPackages",
     [
       "@osdk/client",
+      "@osdk/api",
       "@osdk/functions",
       "@osdk/functions-testing.experimental",
-    ],
-    {
-      ...LIBRARY_RULES,
-      checkApi: true,
-    },
-  )
-  .addArchetype(
-    "checkApiPackagesWithSource",
-    [
-      "@osdk/api",
     ],
     {
       ...LIBRARY_RULES,
@@ -352,17 +343,6 @@ const archetypeRules = archetypes(
     "reactLibraryWithCss",
     [
       "@osdk/cbac-components",
-    ],
-    {
-      ...LIBRARY_RULES,
-      react: true,
-      cssExport: true,
-      extraPublishFiles: ["AGENTS.md", "docs"],
-    },
-  )
-  .addArchetype(
-    "reactLibraryWithCssAndSource",
-    [
       "@osdk/react-components",
     ],
     {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,6 +10,7 @@
   },
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "browser": "./build/browser/index.js",
       "import": {
         "types": "./build/types/index.d.ts",
@@ -19,6 +20,7 @@
       "default": "./build/browser/index.js"
     },
     "./shapes-internal": {
+      "source": "./src/public/shapes-internal.ts",
       "browser": "./build/browser/public/shapes-internal.js",
       "import": {
         "types": "./build/types/public/shapes-internal.d.ts",
@@ -28,6 +30,7 @@
       "default": "./build/browser/public/shapes-internal.js"
     },
     "./unstable": {
+      "source": "./src/public/unstable.ts",
       "browser": "./build/browser/public/unstable.js",
       "import": {
         "types": "./build/types/public/unstable.d.ts",
@@ -37,6 +40,7 @@
       "default": "./build/browser/public/unstable.js"
     },
     "./*": {
+      "source": "./src/public/*.ts",
       "browser": "./build/browser/public/*.js",
       "import": {
         "types": "./build/types/public/*.d.ts",

--- a/packages/cbac-components/package.json
+++ b/packages/cbac-components/package.json
@@ -8,6 +8,7 @@
   },
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "browser": "./build/browser/index.js",
       "import": {
         "types": "./build/types/index.d.ts",
@@ -17,6 +18,7 @@
       "default": "./build/browser/index.js"
     },
     "./experimental": {
+      "source": "./src/public/experimental.ts",
       "browser": "./build/browser/public/experimental.js",
       "import": {
         "types": "./build/types/public/experimental.d.ts",
@@ -27,6 +29,7 @@
     },
     "./styles.css": "./build/browser/styles.css",
     "./*": {
+      "source": "./src/public/*.ts",
       "browser": "./build/browser/public/*.js",
       "import": {
         "types": "./build/types/public/*.d.ts",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -10,6 +10,7 @@
   },
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "browser": "./build/browser/index.js",
       "import": {
         "types": "./build/types/index.d.ts",
@@ -19,6 +20,7 @@
       "default": "./build/browser/index.js"
     },
     "./internal-node": {
+      "source": "./src/public/internal-node.ts",
       "browser": "./build/browser/public/internal-node.js",
       "import": {
         "types": "./build/types/public/internal-node.d.ts",
@@ -28,6 +30,7 @@
       "default": "./build/browser/public/internal-node.js"
     },
     "./internal": {
+      "source": "./src/public/internal.ts",
       "browser": "./build/browser/public/internal.js",
       "import": {
         "types": "./build/types/public/internal.d.ts",
@@ -37,6 +40,7 @@
       "default": "./build/browser/public/internal.js"
     },
     "./unstable-do-not-use": {
+      "source": "./src/public/unstable-do-not-use.ts",
       "browser": "./build/browser/public/unstable-do-not-use.js",
       "import": {
         "types": "./build/types/public/unstable-do-not-use.d.ts",
@@ -46,6 +50,7 @@
       "default": "./build/browser/public/unstable-do-not-use.js"
     },
     "./*": {
+      "source": "./src/public/*.ts",
       "browser": "./build/browser/public/*.js",
       "import": {
         "types": "./build/types/public/*.d.ts",

--- a/packages/e2e.sandbox.peopleapp/vite.config.mts
+++ b/packages/e2e.sandbox.peopleapp/vite.config.mts
@@ -17,6 +17,9 @@ export default defineConfig(({ mode }) => {
       }) as unknown as PluginOption,
       tailwindcss(),
     ],
+    resolve: {
+      conditions: ["source"],
+    },
     server: {
       port: 8080,
       proxy: {

--- a/packages/e2e.sandbox.peopleapp/vite.config.mts
+++ b/packages/e2e.sandbox.peopleapp/vite.config.mts
@@ -17,9 +17,16 @@ export default defineConfig(({ mode }) => {
       }) as unknown as PluginOption,
       tailwindcss(),
     ],
+    // Resolve workspace packages to .ts source for instant HMR during dev.
+    // The "source" condition is a custom export condition defined in each package's
+    // package.json. It has no effect on production builds or npm consumers — only
+    // tooling that explicitly opts in via resolve.conditions will use it.
     resolve: {
       conditions: ["source"],
     },
+    // @osdk/client uses process.env.PACKAGE_VERSION and process.env.MODE which are
+    // normally injected by Babel during transpilation. When resolving to source via
+    // the "source" condition, Babel doesn't run, so we provide them here.
     define: {
       "process.env.PACKAGE_VERSION": JSON.stringify("dev"),
       "process.env.MODE": JSON.stringify("development"),

--- a/packages/e2e.sandbox.peopleapp/vite.config.mts
+++ b/packages/e2e.sandbox.peopleapp/vite.config.mts
@@ -20,6 +20,10 @@ export default defineConfig(({ mode }) => {
     resolve: {
       conditions: ["source"],
     },
+    define: {
+      "process.env.PACKAGE_VERSION": JSON.stringify("dev"),
+      "process.env.MODE": JSON.stringify("development"),
+    },
     server: {
       port: 8080,
       proxy: {

--- a/packages/functions-testing.experimental/package.json
+++ b/packages/functions-testing.experimental/package.json
@@ -10,6 +10,7 @@
   },
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "browser": "./build/browser/index.js",
       "import": {
         "types": "./build/types/index.d.ts",
@@ -19,6 +20,7 @@
       "default": "./build/browser/index.js"
     },
     "./experimental": {
+      "source": "./src/public/experimental.ts",
       "browser": "./build/browser/public/experimental.js",
       "import": {
         "types": "./build/types/public/experimental.d.ts",
@@ -28,6 +30,7 @@
       "default": "./build/browser/public/experimental.js"
     },
     "./*": {
+      "source": "./src/public/*.ts",
       "browser": "./build/browser/public/*.js",
       "import": {
         "types": "./build/types/public/*.d.ts",

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -10,6 +10,7 @@
   },
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "browser": "./build/browser/index.js",
       "import": {
         "types": "./build/types/index.d.ts",
@@ -19,6 +20,7 @@
       "default": "./build/browser/index.js"
     },
     "./experimental": {
+      "source": "./src/public/experimental.ts",
       "browser": "./build/browser/public/experimental.js",
       "import": {
         "types": "./build/types/public/experimental.d.ts",
@@ -28,6 +30,7 @@
       "default": "./build/browser/public/experimental.js"
     },
     "./internal": {
+      "source": "./src/public/internal.ts",
       "browser": "./build/browser/public/internal.js",
       "import": {
         "types": "./build/types/public/internal.d.ts",
@@ -37,6 +40,7 @@
       "default": "./build/browser/public/internal.js"
     },
     "./unstable-do-not-use": {
+      "source": "./src/public/unstable-do-not-use.ts",
       "browser": "./build/browser/public/unstable-do-not-use.js",
       "import": {
         "types": "./build/types/public/unstable-do-not-use.d.ts",
@@ -46,6 +50,7 @@
       "default": "./build/browser/public/unstable-do-not-use.js"
     },
     "./*": {
+      "source": "./src/public/*.ts",
       "browser": "./build/browser/public/*.js",
       "import": {
         "types": "./build/types/public/*.d.ts",

--- a/packages/react-components-storybook/.storybook/main.ts
+++ b/packages/react-components-storybook/.storybook/main.ts
@@ -49,6 +49,7 @@ const config: StorybookConfig = {
     // Ensure proper resolution of workspace packages
     config.resolve = {
       ...config.resolve,
+      conditions: ["source", ...(config.resolve?.conditions ?? [])],
       alias: {
         ...config.resolve?.alias,
         // Polyfill Node.js modules for browser

--- a/packages/react-components-storybook/.storybook/main.ts
+++ b/packages/react-components-storybook/.storybook/main.ts
@@ -68,6 +68,8 @@ const config: StorybookConfig = {
       ...config.define,
       "import.meta.env.SSR": false,
       global: "globalThis",
+      "process.env.PACKAGE_VERSION": JSON.stringify("dev"),
+      "process.env.MODE": JSON.stringify("development"),
     };
 
     // Configure build options

--- a/packages/react-components-storybook/.storybook/main.ts
+++ b/packages/react-components-storybook/.storybook/main.ts
@@ -46,7 +46,10 @@ const config: StorybookConfig = {
       config.base = "/osdk-ts/storybook/";
     }
 
-    // Ensure proper resolution of workspace packages
+    // Resolve workspace packages to .ts source for instant HMR during dev.
+    // The "source" condition is a custom export condition defined in each package's
+    // package.json. It has no effect on production builds or npm consumers — only
+    // tooling that explicitly opts in via resolve.conditions will use it.
     config.resolve = {
       ...config.resolve,
       conditions: ["source", ...(config.resolve?.conditions ?? [])],
@@ -68,6 +71,8 @@ const config: StorybookConfig = {
       ...config.define,
       "import.meta.env.SSR": false,
       global: "globalThis",
+      // @osdk/client uses these env vars via Babel transforms at build time.
+      // When resolving to source, Babel doesn't run, so we provide them here.
       "process.env.PACKAGE_VERSION": JSON.stringify("dev"),
       "process.env.MODE": JSON.stringify("development"),
     };

--- a/packages/react-components-storybook/README.md
+++ b/packages/react-components-storybook/README.md
@@ -4,14 +4,15 @@ This package contains Storybook stories showcasing the components from `@osdk/re
 
 ## Development
 
-To run the Storybook locally:
-
 ```bash
 pnpm install
+pnpm turbo transpileBrowser --filter=@osdk/react-components  # one-time, generates styles.css
 pnpm dev
 ```
 
 The Storybook will be available at http://localhost:6006
+
+Changes to `@osdk/react`, `@osdk/react-components`, and `@osdk/api` source files are picked up automatically via HMR.
 
 ## Features
 

--- a/packages/react-components-storybook/README.md
+++ b/packages/react-components-storybook/README.md
@@ -4,6 +4,8 @@ This package contains Storybook stories showcasing the components from `@osdk/re
 
 ## Development
 
+To run the Storybook locally:
+
 ```bash
 pnpm install
 pnpm turbo transpileBrowser --filter=@osdk/react-components  # one-time, generates styles.css
@@ -11,8 +13,6 @@ pnpm dev
 ```
 
 The Storybook will be available at http://localhost:6006
-
-Changes to `@osdk/react`, `@osdk/react-components`, and `@osdk/api` source files are picked up automatically via HMR.
 
 ## Features
 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -287,7 +287,7 @@ pnpm --filter @osdk/e2e.sandbox.peopleapp transpileAllDeps
 pnpm --filter @osdk/e2e.sandbox.peopleapp dev
 ```
 
-Changes to `@osdk/react`, `@osdk/react-components`, and `@osdk/api` source files are picked up automatically via HMR. Changes to `@osdk/client` require a manual rebuild (`pnpm turbo transpileBrowser --filter=@osdk/client`).
+Changes to `@osdk/react`, `@osdk/react-components`, `@osdk/api`, and `@osdk/client` source files are picked up automatically via HMR.
 
 ## Why this package?
 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -287,6 +287,8 @@ pnpm --filter @osdk/e2e.sandbox.peopleapp transpileAllDeps
 pnpm --filter @osdk/e2e.sandbox.peopleapp dev
 ```
 
+Changes to `@osdk/react`, `@osdk/react-components`, and `@osdk/api` source files are picked up automatically via HMR. Changes to `@osdk/client` require a manual rebuild (`pnpm turbo transpileBrowser --filter=@osdk/client`).
+
 ## Why this package?
 
 **OSDK-native.** These components understand Foundry concepts like Objects, Object Sets, and Actions. They are purpose-built for Ontology data.

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -287,8 +287,6 @@ pnpm --filter @osdk/e2e.sandbox.peopleapp transpileAllDeps
 pnpm --filter @osdk/e2e.sandbox.peopleapp dev
 ```
 
-Changes to `@osdk/react`, `@osdk/react-components`, `@osdk/api`, and `@osdk/client` source files are picked up automatically via HMR.
-
 ## Why this package?
 
 **OSDK-native.** These components understand Foundry concepts like Objects, Object Sets, and Actions. They are purpose-built for Ontology data.

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -8,6 +8,7 @@
   },
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "browser": "./build/browser/index.js",
       "import": {
         "types": "./build/types/index.d.ts",
@@ -17,6 +18,7 @@
       "default": "./build/browser/index.js"
     },
     "./experimental": {
+      "source": "./src/public/experimental.ts",
       "browser": "./build/browser/public/experimental.js",
       "import": {
         "types": "./build/types/public/experimental.d.ts",
@@ -26,6 +28,7 @@
       "default": "./build/browser/public/experimental.js"
     },
     "./primitives": {
+      "source": "./src/public/primitives.ts",
       "browser": "./build/browser/public/primitives.js",
       "import": {
         "types": "./build/types/public/primitives.d.ts",
@@ -36,6 +39,7 @@
     },
     "./styles.css": "./build/browser/styles.css",
     "./*": {
+      "source": "./src/public/*.ts",
       "browser": "./build/browser/public/*.js",
       "import": {
         "types": "./build/types/public/*.d.ts",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -8,6 +8,7 @@
   },
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "browser": "./build/browser/index.js",
       "import": {
         "types": "./build/types/index.d.ts",
@@ -17,6 +18,7 @@
       "default": "./build/browser/index.js"
     },
     "./experimental": {
+      "source": "./src/public/experimental.ts",
       "browser": "./build/browser/public/experimental.js",
       "import": {
         "types": "./build/types/public/experimental.d.ts",
@@ -26,6 +28,7 @@
       "default": "./build/browser/public/experimental.js"
     },
     "./experimental/admin": {
+      "source": "./src/public/experimental/admin.ts",
       "browser": "./build/browser/public/experimental/admin.js",
       "import": {
         "types": "./build/types/public/experimental/admin.d.ts",
@@ -35,6 +38,7 @@
       "default": "./build/browser/public/experimental/admin.js"
     },
     "./*": {
+      "source": "./src/public/*.ts",
       "browser": "./build/browser/public/*.js",
       "import": {
         "types": "./build/types/public/*.d.ts",


### PR DESCRIPTION
## Summary
- Add `"source"` export condition to `@osdk/react`, `@osdk/react-components`, `@osdk/api`, `@osdk/client`, `@osdk/functions`, `@osdk/functions-testing.experimental`, and `@osdk/cbac-components`
- Configure peopleapp and storybook Vite to use the `"source"` condition with `define` entries for `process.env.PACKAGE_VERSION` and `process.env.MODE` (used by `@osdk/client` via Babel transforms at build time)
- Changes to these packages are now picked up automatically via HMR — no manual rebuild or dev server restart needed

## Notes
I tried `turbo watch` first but I kept getting `failed to connect to daemon` and none of the approaches I tried [here](https://github.com/vercel/turborepo/issues/9394) worked. Upgrading turbo could be a solution here.

## Test plan
- [x] `pnpm turbo typecheck` passes for all modified packages
- [x] `check-mrl` passes with updated exports convention
- [x] Run `pnpm --filter @osdk/e2e.sandbox.peopleapp dev` and verify HMR on source changes
- [x] Run storybook `pnpm dev` and verify HMR on source changes