### PR TITLE
add docs and package infrastructure for cbac-components

### DIFF
--- a/.changeset/cbac-docs-infra.md
+++ b/.changeset/cbac-docs-infra.md
@@ -1,0 +1,5 @@
+---
+"@osdk/cbac-components": patch
+---
+
+add package documentation (CLAUDE.md, AGENTS.md, README.md, docs/CbacPicker.md)

--- a/.changeset/docusaurus-component-docs.md
+++ b/.changeset/docusaurus-component-docs.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+fix relative links in component docs for docusaurus compatibility

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -1,5 +1,5 @@
-import type { Config } from "@docusaurus/types";
 import type * as Preset from "@docusaurus/preset-classic";
+import type { Config } from "@docusaurus/types";
 
 const config: Config = {
   title: "OSDK TypeScript",
@@ -25,7 +25,13 @@ const config: Config = {
         docs: {
           path: ".",
           include: ["**/*.md", "**/*.mdx"],
-          exclude: ["**/node_modules/**", "**/build/**", "**/.docusaurus/**", "**/src/**", "**/static/**"],
+          exclude: [
+            "**/node_modules/**",
+            "**/build/**",
+            "**/.docusaurus/**",
+            "**/src/**",
+            "**/static/**",
+          ],
           routeBasePath: "/",
           sidebarPath: "./sidebars.ts",
           editUrl: "https://github.com/palantir/osdk-ts/tree/main/docs/",
@@ -35,6 +41,31 @@ const config: Config = {
           customCss: "./src/css/custom.css",
         },
       } satisfies Preset.Options,
+    ],
+  ],
+
+  plugins: [
+    [
+      "@docusaurus/plugin-content-docs",
+      {
+        id: "react-components",
+        path: "../packages/react-components/docs",
+        routeBasePath: "/react-components",
+        sidebarPath: "./sidebarsReactComponents.ts",
+        editUrl:
+          "https://github.com/palantir/osdk-ts/tree/main/packages/react-components/docs/",
+      },
+    ],
+    [
+      "@docusaurus/plugin-content-docs",
+      {
+        id: "cbac-components",
+        path: "../packages/cbac-components/docs",
+        routeBasePath: "/cbac-components",
+        sidebarPath: "./sidebarsCbacComponents.ts",
+        editUrl:
+          "https://github.com/palantir/osdk-ts/tree/main/packages/cbac-components/docs/",
+      },
     ],
   ],
 
@@ -52,6 +83,20 @@ const config: Config = {
           sidebarId: "docs",
           position: "left",
           label: "Docs",
+        },
+        {
+          type: "docSidebar",
+          sidebarId: "docs",
+          docsPluginId: "react-components",
+          position: "left",
+          label: "Components",
+        },
+        {
+          type: "docSidebar",
+          sidebarId: "docs",
+          docsPluginId: "cbac-components",
+          position: "left",
+          label: "CBAC",
         },
         {
           href: "https://github.com/palantir/osdk-ts",
@@ -88,7 +133,9 @@ const config: Config = {
           ],
         },
       ],
-      copyright: `Copyright © ${new Date().getFullYear()} Palantir Technologies.`,
+      copyright: `Copyright © ${
+        new Date().getFullYear()
+      } Palantir Technologies.`,
     },
   } satisfies Preset.ThemeConfig,
 };

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -20,6 +20,20 @@ React framework for building front-end applications with OSDK.
 - [Cache Management](/react/cache-management) - Cache behavior and invalidation
 - [Platform APIs](/react/platform-apis) - useCurrentFoundryUser, useFoundryUser, useFoundryUsersList
 
+### [@osdk/react-components](/react-components/ObjectTable)
+
+Pre-built, Ontology-aware React components with data loading, caching, and state management.
+
+- [ObjectTable](/react-components/ObjectTable) - Sortable, filterable table with inline editing
+- [FilterList](/react-components/FilterList) - Aggregation-based filter UI
+- [PdfViewer](/react-components/PdfViewer) - PDF viewer with annotations and search
+
+### [@osdk/cbac-components](/cbac-components/CbacPicker)
+
+CBAC (Classification-Based Access Control) components for managing classification markings.
+
+- [CbacPicker](/cbac-components/CbacPicker) - Marking picker, dialog, banner, and base components
+
 ### Other Guides
 
 - [Using OSDK with Vite](/guides/vite) - Fixing common Vite configuration issues

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "3.4.0",
+    "@docusaurus/plugin-content-docs": "3.4.0",
     "@docusaurus/preset-classic": "3.4.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",

--- a/docs/sidebarsCbacComponents.ts
+++ b/docs/sidebarsCbacComponents.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { SidebarsConfig } from "@docusaurus/plugin-content-docs";
+
+const sidebars: SidebarsConfig = {
+  docs: [
+    "CbacPicker",
+  ],
+};
+
+export default sidebars;

--- a/docs/sidebarsReactComponents.ts
+++ b/docs/sidebarsReactComponents.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { SidebarsConfig } from "@docusaurus/plugin-content-docs";
+
+const sidebars: SidebarsConfig = {
+  docs: [
+    "ObjectTable",
+    "FilterList",
+    "PdfViewer",
+  ],
+};
+
+export default sidebars;

--- a/packages/cbac-components/AGENTS.md
+++ b/packages/cbac-components/AGENTS.md
@@ -1,6 +1,6 @@
 # @osdk/cbac-components
 
-Pre-built CBAC (Classification-Based Access Control) React components for managing classification markings. Pass in marking IDs and they handle data loading, restriction computation, and banner display automatically. Requires `@osdk/react` (see the `@osdk/react` package's `AGENTS.md` for hooks and provider setup).
+React components for [classification-based access control (CBAC)](https://www.palantir.com/docs/foundry/security/classification-based-access-controls/). CBAC markings control who can access data — users select markings from categories (disjunctive = pick one, conjunctive = pick many) and the server computes restrictions (implied, disallowed, required markings) and resolves a classification banner. Pass in marking IDs and these components handle all of that automatically. Requires `@osdk/react` (see the `@osdk/react` package's `AGENTS.md` for hooks and provider setup).
 
 ## Components
 

--- a/packages/cbac-components/AGENTS.md
+++ b/packages/cbac-components/AGENTS.md
@@ -1,0 +1,41 @@
+# @osdk/cbac-components
+
+Pre-built CBAC (Classification-Based Access Control) React components for managing classification markings. Pass in marking IDs and they handle data loading, restriction computation, and banner display automatically. Requires `@osdk/react` (see the `@osdk/react` package's `AGENTS.md` for hooks and provider setup).
+
+## Components
+
+All components import from `@osdk/cbac-components/experimental`.
+
+| Component                | Description                                                                                                              |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| **CbacPicker**           | Inline CBAC marking picker with OSDK data fetching, selection state, restriction enforcement, and classification banner. |
+| **CbacPickerDialog**     | Dialog wrapper for CbacPicker with confirm/cancel actions and validation.                                                |
+| **BaseCbacPicker**       | OSDK-agnostic base picker — use when building custom data fetching on top of the picker UI.                              |
+| **BaseCbacBanner**       | OSDK-agnostic classification banner display with customizable colors and text.                                           |
+| **BaseCbacPickerDialog** | OSDK-agnostic dialog wrapper for BaseCbacPicker with confirm/cancel actions.                                             |
+
+## Utilities
+
+| Export                    | Description                                                                          |
+| ------------------------- | ------------------------------------------------------------------------------------ |
+| `toggleMarking`           | Toggle a marking in a selection, respecting category type (CONJUNCTIVE/DISJUNCTIVE). |
+| `computeMarkingStates`    | Compute the state (SELECTED, IMPLIED, DISALLOWED, etc.) for each marking.            |
+| `groupMarkingsByCategory` | Organize markings into groups by their category.                                     |
+
+## Types
+
+| Type                    | Description                                                                      |
+| ----------------------- | -------------------------------------------------------------------------------- |
+| `MarkingSelectionState` | Union: "NONE" \| "SELECTED" \| "IMPLIED" \| "DISALLOWED" \| "IMPLIED_DISALLOWED" |
+| `CbacBannerData`        | Classification string, text color, background colors, marking IDs.               |
+| `PickerMarkingCategory` | Category metadata (id, name, description, type).                                 |
+| `PickerMarking`         | Marking metadata (id, categoryId, name, description).                            |
+| `CategoryMarkingGroup`  | Pairing of a category with its markings.                                         |
+| `RequiredMarkingGroup`  | Group of marking names that must be selected together.                           |
+
+## Documentation
+
+Before using any component, read the relevant doc from this package:
+
+- **Setup & installation**: Read [README.md](./README.md) for provider, CSS, and peer dependencies
+- **CbacPicker**: Read [docs/CbacPicker.md](./docs/CbacPicker.md) for props, examples, base components, and troubleshooting

--- a/packages/cbac-components/CLAUDE.md
+++ b/packages/cbac-components/CLAUDE.md
@@ -1,0 +1,43 @@
+This documentation provides guidance for developing in `@osdk/cbac-components`.
+
+## TypeScript Best Practices
+
+- NEVER use `any` without asking the user first. If you think you need `any`, you probably don't understand the problem
+- Projects are ESM/TypeScript - look for `.ts`/`.tsx` files, not `.js`
+- To check compilation: `cd packages/the-package && pnpm turbo typecheck`
+
+## React Best Practices
+
+- Always put new components in their own file and create separate components instead of inline functions
+- NEVER conditionally call React hooks
+- ALWAYS keep components rendering during loading/error states. Don't use early returns like `if (isLoading) return <LoadingMessage />`. Show loading/error indicators while rendering existing data to prevent UI flashing
+- ALWAYS memoize non-primitive values passed to component props with useCallback or useMemo
+- ALWAYS combine classnames with the classnames function. NEVER use string literal.
+- NEVER use empty arrays `[]` or empty objects `{}` directly in component bodies as they create new references on every render, causing infinite re-renders. Always extract them as constants outside the component or memoize them. For example, instead of `const defaultValue = []`, use `const EMPTY_ARRAY: [] = []` outside the component or `const defaultValue = useMemo(() => [], [])`.
+
+## OSDK Component Architecture
+
+- The outermost component, e.g. CbacPicker, should handle data fetching from Foundry using @osdk/react hooks.
+- The base component should contain all component interactions and styling. Ideally, it should be an OSDK-agnostic component. The outer component should process OSDK data and pass to the base component. This will enable users to build on top of the base component with their own data fetching.
+
+## CSS Styling Best Practices
+
+- Do not hardcode CSS colors and pixel values.
+- ALWAYS use CSS variables to enable theming.
+- ALWAYS try to use --bp tokens first before using any hardcoded value. The --bp tokens used should always be mapped from a --osdk token.
+
+## Project Management
+
+- This project uses pnpm. DO NOT use npm
+
+## Security Best Practices
+
+- NEVER disable gpg signing unless explicitly requested
+
+## Repository Best Practices
+
+- Monorepo: run tests from individual packages, not root
+
+## Code Maintenance Best Practices
+
+- Do not fix diagnostic warnings in old code

--- a/packages/cbac-components/CLAUDE.md
+++ b/packages/cbac-components/CLAUDE.md
@@ -17,7 +17,7 @@ This documentation provides guidance for developing in `@osdk/cbac-components`.
 
 ## OSDK Component Architecture
 
-- The outermost component, e.g. CbacPicker, should handle data fetching from Foundry using @osdk/react hooks.
+- The outermost component, e.g. CbacPicker, should handle data fetching using @osdk/react hooks.
 - The base component should contain all component interactions and styling. Ideally, it should be an OSDK-agnostic component. The outer component should process OSDK data and pass to the base component. This will enable users to build on top of the base component with their own data fetching.
 
 ## CSS Styling Best Practices

--- a/packages/cbac-components/README.md
+++ b/packages/cbac-components/README.md
@@ -1,6 +1,6 @@
 # @osdk/cbac-components
 
-React components for managing Classification-Based Access Control (CBAC) markings in Foundry applications. These components are OSDK-aware — pass in marking IDs, and they handle data loading, restriction computation, and banner display automatically.
+React components for managing Classification-Based Access Control (CBAC) markings. These components are OSDK-aware — pass in marking IDs, and they handle data loading, restriction computation, and banner display automatically.
 
 Built on top of [@osdk/react](../react), these components use OSDK hooks internally to fetch marking categories, compute restrictions, and resolve classification banners.
 

--- a/packages/cbac-components/README.md
+++ b/packages/cbac-components/README.md
@@ -1,0 +1,108 @@
+# @osdk/cbac-components
+
+React components for managing Classification-Based Access Control (CBAC) markings in Foundry applications. These components are OSDK-aware — pass in marking IDs, and they handle data loading, restriction computation, and banner display automatically.
+
+Built on top of [@osdk/react](../react), these components use OSDK hooks internally to fetch marking categories, compute restrictions, and resolve classification banners.
+
+## Installation
+
+```sh
+npm install @osdk/cbac-components@beta
+```
+
+**Peer Dependencies:**
+
+```sh
+npm install react react-dom classnames @osdk/react @osdk/react-components
+```
+
+- `react`, `@types/react`, `react-dom` - React 17, 18, or 19
+- `classnames` - Utility for conditionally joining CSS class names
+- `@osdk/react` - OSDK React hooks for data fetching
+- `@osdk/react-components` - Shared primitives (Dialog)
+
+**Prerequisites:**
+
+- A configured OSDK client
+- An OsdkProvider2 wrapping your application
+
+## Setup
+
+### App Setup
+
+**REQUIRED:** Wrap app with OsdkProvider2:
+
+```tsx
+import { createClient } from "@osdk/client";
+import { OsdkProvider2 } from "@osdk/react/experimental";
+
+const client = createClient(/* config */);
+
+function App() {
+  return <OsdkProvider2 client={client}>{/* components */}</OsdkProvider2>;
+}
+```
+
+### CSS Setup
+
+Add the CBAC component styles to your application's entry CSS file:
+
+```css
+@import "@osdk/cbac-components/styles.css";
+```
+
+If using CSS layers with `@osdk/react-components`:
+
+```css
+@layer osdk.tokens, osdk.components;
+
+@import "@osdk/react-components-styles" layer(osdk.tokens);
+@import "@osdk/react-components/styles.css" layer(osdk.components);
+@import "@osdk/cbac-components/styles.css" layer(osdk.components);
+```
+
+## Components
+
+| Component          | Description                                                                   | Documentation                 |
+| ------------------ | ----------------------------------------------------------------------------- | ----------------------------- |
+| `CbacPicker`       | Inline marking picker with selection, restrictions, and classification banner | [Guide](./docs/CbacPicker.md) |
+| `CbacPickerDialog` | Dialog wrapper for the picker with confirm/cancel and validation              | [Guide](./docs/CbacPicker.md) |
+
+## Component Architecture
+
+This package follows the same layered architecture as `@osdk/react-components`:
+
+### OSDK Component Layer (e.g., `CbacPicker`, `CbacPickerDialog`)
+
+- Handles data fetching using `@osdk/react` hooks (`useMarkingCategories`, `useMarkings`, `useCbacBanner`, `useCbacMarkingRestrictions`)
+- Computes derived state (marking states, validation, required groups)
+- Passes primitive data to the base component
+
+### Base Component Layer (e.g., `BaseCbacPicker`, `BaseCbacBanner`, `BaseCbacPickerDialog`)
+
+- Pure components with no OSDK imports
+- Contains all UI interactions and styling
+- Accepts primitive props (strings, arrays, Maps)
+- Can be reused with custom data fetching
+
+## Quick Example
+
+```tsx
+import { CbacPicker } from "@osdk/cbac-components/experimental";
+import { useState } from "react";
+
+function ClassificationForm() {
+  const [markingIds, setMarkingIds] = useState<string[]>([]);
+
+  return (
+    <CbacPicker
+      initialMarkingIds={markingIds}
+      onChange={setMarkingIds}
+    />
+  );
+}
+```
+
+## License
+
+Apache 2.0

--- a/packages/cbac-components/README.md
+++ b/packages/cbac-components/README.md
@@ -1,8 +1,10 @@
 # @osdk/cbac-components
 
-React components for managing Classification-Based Access Control (CBAC) markings. These components are OSDK-aware — pass in marking IDs, and they handle data loading, restriction computation, and banner display automatically.
+> **Beta Release**: This package is currently in beta. Please use the latest beta version for the most up-to-date features and fixes.
 
-Built on top of [@osdk/react](../react), these components use OSDK hooks internally to fetch marking categories, compute restrictions, and resolve classification banners.
+React components for managing [classification-based access control (CBAC)](https://www.palantir.com/docs/foundry/security/classification-based-access-controls/) markings. CBAC markings control who can access data — each piece of data can be tagged with markings from different categories, and the combination determines its access restrictions.
+
+These components are OSDK-aware — pass in marking IDs, and they handle data loading, restriction computation, and banner display automatically. Built on top of [@osdk/react](../react).
 
 ## Installation
 

--- a/packages/cbac-components/docs/CbacPicker.md
+++ b/packages/cbac-components/docs/CbacPicker.md
@@ -1,6 +1,8 @@
 # CbacPicker
 
-A comprehensive guide for using the CBAC (Classification-Based Access Control) components from `@osdk/cbac-components`.
+Components for managing [classification-based access control (CBAC)](https://www.palantir.com/docs/foundry/security/classification-based-access-controls/) markings. CBAC markings control who can access data — each piece of data can be tagged with markings from different categories, and the combination determines its access restrictions.
+
+The picker lets users select markings grouped by category. Some categories are **disjunctive** (pick exactly one, like a sensitivity level) and others are **conjunctive** (pick any combination, like access groups). The server enforces which combinations are valid, which markings are implied by others, and which are disallowed.
 
 ## Prerequisites
 
@@ -55,7 +57,7 @@ function ClassificationForm() {
 }
 ```
 
-This renders a marking picker that fetches categories and markings via the OSDK, displays them grouped by category, shows a classification banner, and enforces marking restrictions (implied, disallowed, required markings).
+This renders a marking picker that fetches categories and markings via the OSDK, displays them grouped by category, and shows a classification banner. The server enforces marking restrictions automatically — the picker reflects which markings are implied, disallowed, or required based on the current selection.
 
 ### Picker in a Dialog
 
@@ -114,7 +116,9 @@ The dialog title automatically adjusts: "Add classification" when no initial mar
 
 ## Base Components
 
-The base components are OSDK-agnostic — they accept primitive data directly instead of fetching from the OSDK. Use these when you want to supply your own data or build a custom data fetching layer.
+Most users should use `CbacPicker` or `CbacPickerDialog` above — they handle all data fetching automatically.
+
+The base components below are for advanced use cases where you need to supply your own marking data (e.g., you already have the data from a different source, or you're building a custom integration). They accept primitive props and have no OSDK dependency.
 
 ### BaseCbacPicker
 
@@ -367,7 +371,6 @@ import {
   BaseCbacPicker,
   type CategoryMarkingGroup,
   computeMarkingStates,
-  type MarkingSelectionState,
   toggleMarking,
 } from "@osdk/cbac-components/experimental";
 import { useCallback, useMemo, useState } from "react";
@@ -429,11 +432,9 @@ function CustomClassificationPicker() {
 
 ## Architecture
 
-`@osdk/cbac-components` follows the same two-layer architecture as `@osdk/react-components`:
+### What the server controls
 
-### Server-Computed vs Client-Side
-
-The following data is **computed server-side** and cannot be customized on the frontend:
+The following data is **computed server-side** and cannot be changed by the frontend:
 
 - **Implied markings** — which markings are automatically included based on the current selection
 - **Disallowed markings** — which markings are blocked based on the current selection
@@ -443,41 +444,12 @@ The following data is **computed server-side** and cannot be customized on the f
 
 The frontend handles **only UI concerns**: toggling selections (respecting conjunctive/disjunctive category types), grouping markings by category for display, and computing visual states (SELECTED, IMPLIED, DISALLOWED) from the server-provided data.
 
-### OSDK Component Layer
+### Two-layer architecture
 
-Components like `CbacPicker` and `CbacPickerDialog` handle data fetching using `@osdk/react` hooks:
+`@osdk/cbac-components` follows the same pattern as `@osdk/react-components`:
 
-- `useMarkingCategories()` — fetches all marking categories
-- `useMarkings()` — fetches all markings
-- `useCbacBanner({ markingIds })` — resolves the classification string and colors (server-computed)
-- `useCbacMarkingRestrictions({ markingIds })` — fetches implied, disallowed, and required markings (server-computed)
-
-These components convert OSDK data into primitive props and pass them to the base layer.
-
-### Base Component Layer
-
-Components like `BaseCbacPicker`, `BaseCbacBanner`, and `BaseCbacPickerDialog` are pure UI components with no OSDK imports. They accept primitive data (strings, arrays, Maps) and handle all rendering, interactions, and styling.
-
-### Data Flow
-
-```
-  useCbacPickerState (hook)
-  ├── useMarkingCategories() → categories
-  ├── useMarkings() → markings
-  ├── useCbacBanner() → banner data
-  └── useCbacMarkingRestrictions() → implied, disallowed, required
-
-  useCbacSelection (hook)
-  ├── manages selectedIds state
-  ├── calls useCbacPickerState
-  └── provides toggle, dismiss, reset callbacks
-
-  CbacPicker / CbacPickerDialog (OSDK layer)
-  └── BaseCbacPicker / BaseCbacPickerDialog (base layer)
-      ├── CategoryMarkingGroup → MarkingButton
-      ├── BaseCbacBanner
-      └── ValidationWarning
-```
+- **OSDK layer** (`CbacPicker`, `CbacPickerDialog`) — fetches data using `@osdk/react` hooks, converts it to primitive props, passes to the base layer
+- **Base layer** (`BaseCbacPicker`, `BaseCbacBanner`, `BaseCbacPickerDialog`) — pure UI with no OSDK dependency, accepts primitive data directly
 
 ## Troubleshooting
 

--- a/packages/cbac-components/docs/CbacPicker.md
+++ b/packages/cbac-components/docs/CbacPicker.md
@@ -6,7 +6,7 @@ The picker lets users select markings grouped by category. Some categories are *
 
 ## Prerequisites
 
-Before using CBAC components, make sure you have completed the library setup described in the [README](../README.md#setup), including:
+Before using CBAC components, make sure you have completed the library setup described in the [README](https://github.com/palantir/osdk-ts/blob/main/packages/cbac-components/README.md#setup), including:
 
 - Installing the required dependencies
 - Wrapping your app with `OsdkProvider2`
@@ -351,11 +351,13 @@ interface ClassificationViewerProps {
   markingIds: string[];
 }
 
+const NOOP = () => {};
+
 function ClassificationViewer({ markingIds }: ClassificationViewerProps) {
   return (
     <CbacPicker
       initialMarkingIds={markingIds}
-      onChange={() => {}}
+      onChange={NOOP}
       readOnly={true}
     />
   );
@@ -486,8 +488,8 @@ The frontend handles **only UI concerns**: toggling selections (respecting conju
 
 ## Additional Resources
 
-- [CbacPicker Implementation](../src/cbac-picker/CbacPicker.tsx)
-- [CbacPickerDialog Implementation](../src/cbac-picker/CbacPickerDialog.tsx)
-- [Selection Logic](../src/cbac-picker/utils/selectionLogic.ts)
-- [Type Definitions](../src/cbac-picker/types.ts)
-- [@osdk/react Documentation](../../docs/react/getting-started.md)
+- [CbacPicker Implementation](https://github.com/palantir/osdk-ts/blob/main/packages/cbac-components/src/cbac-picker/CbacPicker.tsx)
+- [CbacPickerDialog Implementation](https://github.com/palantir/osdk-ts/blob/main/packages/cbac-components/src/cbac-picker/CbacPickerDialog.tsx)
+- [Selection Logic](https://github.com/palantir/osdk-ts/blob/main/packages/cbac-components/src/cbac-picker/utils/selectionLogic.ts)
+- [Type Definitions](https://github.com/palantir/osdk-ts/blob/main/packages/cbac-components/src/cbac-picker/types.ts)
+- [@osdk/react Documentation](https://github.com/palantir/osdk-ts/blob/main/docs/react/getting-started.md)

--- a/packages/cbac-components/docs/CbacPicker.md
+++ b/packages/cbac-components/docs/CbacPicker.md
@@ -55,7 +55,7 @@ function ClassificationForm() {
 }
 ```
 
-This renders a marking picker that fetches categories and markings from the OSDK, displays them grouped by category, shows a classification banner, and enforces marking restrictions (implied, disallowed, required markings).
+This renders a marking picker that fetches categories and markings via the OSDK, displays them grouped by category, shows a classification banner, and enforces marking restrictions (implied, disallowed, required markings).
 
 ### Picker in a Dialog
 
@@ -111,27 +111,6 @@ function ClassificationDialog() {
 | `initialMarkingIds` | `string[]`                       | No       | `[]`    | Initial set of selected marking IDs             |
 
 The dialog title automatically adjusts: "Add classification" when no initial markings are provided, "Edit classification" when editing existing markings. The confirm button is disabled with a tooltip when the selection is invalid (e.g., missing required markings).
-
-### CbacBanner (internal)
-
-> **Note:** `CbacBanner` and `CbacBannerPopover` are internal OSDK-aware components not currently exported from `./experimental`. They are documented here for reference but cannot be imported by consumers. Classification banner display is available via the exported `BaseCbacBanner` component.
-
-| Prop         | Type         | Required | Default | Description                                         |
-| ------------ | ------------ | -------- | ------- | --------------------------------------------------- |
-| `markingIds` | `string[]`   | Yes      | -       | Marking IDs to resolve into a classification banner |
-| `onClick`    | `() => void` | No       | -       | Called when the banner is clicked                   |
-| `onDismiss`  | `() => void` | No       | -       | Called when the dismiss button is clicked           |
-| `className`  | `string`     | No       | -       | CSS class for the banner                            |
-
-### CbacBannerPopover (internal)
-
-> **Note:** Not exported. The popover wraps a `CbacBanner` with a dropdown showing applied markings and an "Edit classification" button that opens a `CbacPickerDialog`.
-
-| Prop         | Type                             | Required | Default | Description                                                    |
-| ------------ | -------------------------------- | -------- | ------- | -------------------------------------------------------------- |
-| `markingIds` | `string[]`                       | Yes      | -       | Current marking IDs                                            |
-| `onChange`   | `(markingIds: string[]) => void` | Yes      | -       | Called when markings are changed via the popover's edit dialog |
-| `className`  | `string`                         | No       | -       | CSS class for the popover                                      |
 
 ## Base Components
 
@@ -452,14 +431,26 @@ function CustomClassificationPicker() {
 
 `@osdk/cbac-components` follows the same two-layer architecture as `@osdk/react-components`:
 
+### Server-Computed vs Client-Side
+
+The following data is **computed server-side** and cannot be customized on the frontend:
+
+- **Implied markings** — which markings are automatically included based on the current selection
+- **Disallowed markings** — which markings are blocked based on the current selection
+- **Required marking groups** — which additional markings must be selected for the classification to be valid
+- **Validation (`isValid`)** — whether the current selection satisfies all constraints
+- **Banner data** — the classification string, text color, and background colors
+
+The frontend handles **only UI concerns**: toggling selections (respecting conjunctive/disjunctive category types), grouping markings by category for display, and computing visual states (SELECTED, IMPLIED, DISALLOWED) from the server-provided data.
+
 ### OSDK Component Layer
 
 Components like `CbacPicker` and `CbacPickerDialog` handle data fetching using `@osdk/react` hooks:
 
 - `useMarkingCategories()` — fetches all marking categories
 - `useMarkings()` — fetches all markings
-- `useCbacBanner({ markingIds })` — resolves the classification string and colors
-- `useCbacMarkingRestrictions({ markingIds })` — computes implied, disallowed, and required markings
+- `useCbacBanner({ markingIds })` — resolves the classification string and colors (server-computed)
+- `useCbacMarkingRestrictions({ markingIds })` — fetches implied, disallowed, and required markings (server-computed)
 
 These components convert OSDK data into primitive props and pass them to the base layer.
 
@@ -498,7 +489,7 @@ Components like `BaseCbacPicker`, `BaseCbacBanner`, and `BaseCbacPickerDialog` a
 
 ### No markings appear
 
-- Confirm that marking categories and markings are configured in your Foundry environment
+- Confirm that marking categories and markings are configured in your environment
 - Check that the OSDK client's authentication token has the necessary permissions
 
 ### Banner shows default colors

--- a/packages/cbac-components/docs/CbacPicker.md
+++ b/packages/cbac-components/docs/CbacPicker.md
@@ -1,0 +1,530 @@
+# CbacPicker
+
+A comprehensive guide for using the CBAC (Classification-Based Access Control) components from `@osdk/cbac-components`.
+
+## Prerequisites
+
+Before using CBAC components, make sure you have completed the library setup described in the [README](../README.md#setup), including:
+
+- Installing the required dependencies
+- Wrapping your app with `OsdkProvider2`
+- Adding the CSS imports
+
+## Table of Contents
+
+- [Basic Usage](#basic-usage)
+- [Props Reference](#props-reference)
+- [Base Components](#base-components)
+- [Types Reference](#types-reference)
+- [Selection Logic Utilities](#selection-logic-utilities)
+- [Examples](#examples)
+- [Architecture](#architecture)
+- [Troubleshooting](#troubleshooting)
+
+## Import
+
+```typescript
+import {
+  BaseCbacBanner,
+  BaseCbacPicker,
+  BaseCbacPickerDialog,
+  CbacPicker,
+  CbacPickerDialog,
+} from "@osdk/cbac-components/experimental";
+```
+
+## Basic Usage
+
+### Inline Picker
+
+The simplest way to use the CBAC picker is inline with `CbacPicker`:
+
+```typescript
+import { CbacPicker } from "@osdk/cbac-components/experimental";
+import { useState } from "react";
+
+function ClassificationForm() {
+  const [markingIds, setMarkingIds] = useState<string[]>([]);
+
+  return (
+    <CbacPicker
+      initialMarkingIds={markingIds}
+      onChange={setMarkingIds}
+    />
+  );
+}
+```
+
+This renders a marking picker that fetches categories and markings from the OSDK, displays them grouped by category, shows a classification banner, and enforces marking restrictions (implied, disallowed, required markings).
+
+### Picker in a Dialog
+
+For modal workflows, use `CbacPickerDialog`:
+
+```typescript
+import { CbacPickerDialog } from "@osdk/cbac-components/experimental";
+import { useState } from "react";
+
+function ClassificationDialog() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [markingIds, setMarkingIds] = useState<string[]>([]);
+
+  const handleConfirm = (newMarkingIds: string[]) => {
+    setMarkingIds(newMarkingIds);
+    setIsOpen(false);
+  };
+
+  return (
+    <>
+      <button onClick={() => setIsOpen(true)}>
+        Set Classification
+      </button>
+      <CbacPickerDialog
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        onConfirm={handleConfirm}
+        initialMarkingIds={markingIds}
+      />
+    </>
+  );
+}
+```
+
+## Props Reference
+
+### CbacPicker
+
+| Prop                | Type                             | Required | Default | Description                          |
+| ------------------- | -------------------------------- | -------- | ------- | ------------------------------------ |
+| `initialMarkingIds` | `string[]`                       | No       | `[]`    | Initial set of selected marking IDs  |
+| `onChange`          | `(markingIds: string[]) => void` | Yes      | -       | Called when the selection changes    |
+| `readOnly`          | `boolean`                        | No       | `false` | Disables marking toggle interactions |
+| `className`         | `string`                         | No       | -       | CSS class for the picker container   |
+
+### CbacPickerDialog
+
+| Prop                | Type                             | Required | Default | Description                                     |
+| ------------------- | -------------------------------- | -------- | ------- | ----------------------------------------------- |
+| `isOpen`            | `boolean`                        | Yes      | -       | Controls dialog visibility                      |
+| `onOpenChange`      | `(open: boolean) => void`        | Yes      | -       | Called when dialog open state changes           |
+| `onConfirm`         | `(markingIds: string[]) => void` | Yes      | -       | Called with the selected marking IDs on confirm |
+| `initialMarkingIds` | `string[]`                       | No       | `[]`    | Initial set of selected marking IDs             |
+
+The dialog title automatically adjusts: "Add classification" when no initial markings are provided, "Edit classification" when editing existing markings. The confirm button is disabled with a tooltip when the selection is invalid (e.g., missing required markings).
+
+### CbacBanner (internal)
+
+> **Note:** `CbacBanner` and `CbacBannerPopover` are internal OSDK-aware components not currently exported from `./experimental`. They are documented here for reference but cannot be imported by consumers. Classification banner display is available via the exported `BaseCbacBanner` component.
+
+| Prop         | Type         | Required | Default | Description                                         |
+| ------------ | ------------ | -------- | ------- | --------------------------------------------------- |
+| `markingIds` | `string[]`   | Yes      | -       | Marking IDs to resolve into a classification banner |
+| `onClick`    | `() => void` | No       | -       | Called when the banner is clicked                   |
+| `onDismiss`  | `() => void` | No       | -       | Called when the dismiss button is clicked           |
+| `className`  | `string`     | No       | -       | CSS class for the banner                            |
+
+### CbacBannerPopover (internal)
+
+> **Note:** Not exported. The popover wraps a `CbacBanner` with a dropdown showing applied markings and an "Edit classification" button that opens a `CbacPickerDialog`.
+
+| Prop         | Type                             | Required | Default | Description                                                    |
+| ------------ | -------------------------------- | -------- | ------- | -------------------------------------------------------------- |
+| `markingIds` | `string[]`                       | Yes      | -       | Current marking IDs                                            |
+| `onChange`   | `(markingIds: string[]) => void` | Yes      | -       | Called when markings are changed via the popover's edit dialog |
+| `className`  | `string`                         | No       | -       | CSS class for the popover                                      |
+
+## Base Components
+
+The base components are OSDK-agnostic — they accept primitive data directly instead of fetching from the OSDK. Use these when you want to supply your own data or build a custom data fetching layer.
+
+### BaseCbacPicker
+
+| Prop                    | Type                                  | Required | Default | Description                                       |
+| ----------------------- | ------------------------------------- | -------- | ------- | ------------------------------------------------- |
+| `categories`            | `CategoryMarkingGroup[]`              | Yes      | -       | Marking categories with their markings            |
+| `markingStates`         | `Map<string, MarkingSelectionState>`  | Yes      | -       | State for each marking (SELECTED, IMPLIED, etc.)  |
+| `banner`                | `CbacBannerData`                      | No       | -       | Banner data (classification string, colors)       |
+| `onMarkingToggle`       | `(markingId: string) => void`         | Yes      | -       | Called when a marking button is clicked           |
+| `onDismissBanner`       | `() => void`                          | No       | -       | Called when the banner dismiss button is clicked  |
+| `showInfoBanner`        | `boolean`                             | No       | -       | Show the "implied markings" info banner           |
+| `requiredMarkingGroups` | `ReadonlyArray<RequiredMarkingGroup>` | No       | -       | Groups of markings that must be selected together |
+| `isValid`               | `boolean`                             | No       | -       | Whether the current selection is valid            |
+| `readOnly`              | `boolean`                             | No       | -       | Disable marking interactions                      |
+| `isLoading`             | `boolean`                             | No       | -       | Show loading skeleton                             |
+| `error`                 | `Error`                               | No       | -       | Show error message                                |
+| `className`             | `string`                              | No       | -       | CSS class for the container                       |
+
+### BaseCbacBanner
+
+| Prop                   | Type         | Required | Default | Description                                          |
+| ---------------------- | ------------ | -------- | ------- | ---------------------------------------------------- |
+| `classificationString` | `string`     | Yes      | -       | Text displayed in the banner                         |
+| `textColor`            | `string`     | Yes      | -       | Banner text color                                    |
+| `backgroundColors`     | `string[]`   | Yes      | -       | Background colors (rendered as gradient if multiple) |
+| `onClick`              | `() => void` | No       | -       | Makes banner clickable                               |
+| `onDismiss`            | `() => void` | No       | -       | Shows a dismiss button                               |
+| `className`            | `string`     | No       | -       | CSS class for the banner                             |
+
+### BaseCbacPickerDialog
+
+Extends all `BaseCbacPickerProps` plus:
+
+| Prop                   | Type                      | Required | Default                   | Description                           |
+| ---------------------- | ------------------------- | -------- | ------------------------- | ------------------------------------- |
+| `isOpen`               | `boolean`                 | Yes      | -                         | Controls dialog visibility            |
+| `onOpenChange`         | `(open: boolean) => void` | Yes      | -                         | Called when dialog open state changes |
+| `onConfirm`            | `() => void`              | Yes      | -                         | Called when confirm button is clicked |
+| `onCancel`             | `() => void`              | Yes      | -                         | Called when cancel button is clicked  |
+| `title`                | `string`                  | No       | `"Select classification"` | Dialog title                          |
+| `submitDisabledReason` | `string`                  | No       | -                         | Tooltip on disabled submit button     |
+
+## Types Reference
+
+### MarkingSelectionState
+
+```typescript
+type MarkingSelectionState =
+  | "NONE"
+  | "SELECTED"
+  | "IMPLIED"
+  | "DISALLOWED"
+  | "IMPLIED_DISALLOWED";
+```
+
+| State                  | Description                                                      |
+| ---------------------- | ---------------------------------------------------------------- |
+| `"NONE"`               | Default state — marking is available but not selected            |
+| `"SELECTED"`           | Marking is explicitly selected by the user                       |
+| `"IMPLIED"`            | Marking is automatically included due to other selected markings |
+| `"DISALLOWED"`         | Marking cannot be selected due to restrictions                   |
+| `"IMPLIED_DISALLOWED"` | Marking is both implied and disallowed by the current selection  |
+
+### CbacBannerData
+
+```typescript
+interface CbacBannerData {
+  classificationString: string;
+  textColor: string;
+  backgroundColors: string[];
+  markingIds: string[];
+}
+```
+
+Returned by the `useCbacBanner` hook. Contains the resolved classification string and the display colors for the banner.
+
+### PickerMarkingCategory
+
+```typescript
+interface PickerMarkingCategory {
+  id: string;
+  name: string;
+  description: string;
+  categoryType: "CONJUNCTIVE" | "DISJUNCTIVE";
+  markingType: "MANDATORY" | "CBAC";
+}
+```
+
+| Field          | Description                                                                                                                          |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `categoryType` | `"CONJUNCTIVE"` = multiple markings can be selected (checkbox-style). `"DISJUNCTIVE"` = only one marking per category (radio-style). |
+| `markingType`  | `"MANDATORY"` = always present on all objects. `"CBAC"` = user-selectable.                                                           |
+
+### PickerMarking
+
+```typescript
+interface PickerMarking {
+  id: string;
+  categoryId: string;
+  name: string;
+  description?: string;
+}
+```
+
+### CategoryMarkingGroup
+
+```typescript
+interface CategoryMarkingGroup {
+  category: PickerMarkingCategory;
+  markings: PickerMarking[];
+}
+```
+
+A category paired with all markings that belong to it.
+
+### RequiredMarkingGroup
+
+```typescript
+interface RequiredMarkingGroup {
+  markingNames: string[];
+}
+```
+
+A group of marking names that must be selected together for the classification to be valid.
+
+## Selection Logic Utilities
+
+These pure functions handle marking selection logic without any React or OSDK dependencies. Use them when building custom picker implementations.
+
+### toggleMarking
+
+```typescript
+function toggleMarking(
+  markingId: string,
+  currentSelection: string[],
+  categories: CategoryMarkingGroup[],
+): string[];
+```
+
+Toggles a marking in the selection, respecting category type:
+
+- **Conjunctive** categories: adds or removes the marking (checkbox behavior)
+- **Disjunctive** categories: replaces the existing selection in that category (radio behavior)
+
+### computeMarkingStates
+
+```typescript
+function computeMarkingStates(
+  selectedIds: string[],
+  impliedIds: string[],
+  disallowedIds: string[],
+): Map<string, MarkingSelectionState>;
+```
+
+Computes the display state for each marking based on the current selection, implied markings, and disallowed markings.
+
+### groupMarkingsByCategory
+
+```typescript
+function groupMarkingsByCategory(
+  markings: PickerMarking[],
+  categories: PickerMarkingCategory[],
+): CategoryMarkingGroup[];
+```
+
+Groups a flat list of markings into `CategoryMarkingGroup` arrays, ordered by category.
+
+## Examples
+
+### Example 1: Basic Inline Picker
+
+```typescript
+import { CbacPicker } from "@osdk/cbac-components/experimental";
+import { useState } from "react";
+
+function ClassificationForm() {
+  const [markingIds, setMarkingIds] = useState<string[]>([]);
+
+  return (
+    <div>
+      <h3>Classification</h3>
+      <CbacPicker
+        initialMarkingIds={markingIds}
+        onChange={setMarkingIds}
+      />
+      <p>Selected markings: {markingIds.join(", ") || "None"}</p>
+    </div>
+  );
+}
+```
+
+### Example 2: Picker in a Dialog with Confirmation
+
+```typescript
+import { CbacPickerDialog } from "@osdk/cbac-components/experimental";
+import { useState } from "react";
+
+function DocumentClassification() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [markingIds, setMarkingIds] = useState<string[]>([]);
+
+  const handleConfirm = (newMarkingIds: string[]) => {
+    setMarkingIds(newMarkingIds);
+    setIsOpen(false);
+    // Save to your backend
+  };
+
+  return (
+    <div>
+      <button onClick={() => setIsOpen(true)}>
+        {markingIds.length > 0 ? "Edit Classification" : "Add Classification"}
+      </button>
+      <CbacPickerDialog
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        onConfirm={handleConfirm}
+        initialMarkingIds={markingIds}
+      />
+    </div>
+  );
+}
+```
+
+### Example 3: Read-Only Classification Display
+
+```typescript
+import { CbacPicker } from "@osdk/cbac-components/experimental";
+
+interface ClassificationViewerProps {
+  markingIds: string[];
+}
+
+function ClassificationViewer({ markingIds }: ClassificationViewerProps) {
+  return (
+    <CbacPicker
+      initialMarkingIds={markingIds}
+      onChange={() => {}}
+      readOnly={true}
+    />
+  );
+}
+```
+
+### Example 4: Custom Data Fetching with BaseCbacPicker
+
+Use `BaseCbacPicker` when you want to supply your own marking data instead of fetching from the OSDK:
+
+```typescript
+import {
+  BaseCbacPicker,
+  type CategoryMarkingGroup,
+  computeMarkingStates,
+  type MarkingSelectionState,
+  toggleMarking,
+} from "@osdk/cbac-components/experimental";
+import { useCallback, useMemo, useState } from "react";
+
+const CATEGORIES: CategoryMarkingGroup[] = [
+  {
+    category: {
+      id: "cat-1",
+      name: "Classification Level",
+      description: "Overall classification",
+      categoryType: "DISJUNCTIVE",
+      markingType: "CBAC",
+    },
+    markings: [
+      { id: "m-low", categoryId: "cat-1", name: "LOW" },
+      { id: "m-medium", categoryId: "cat-1", name: "MEDIUM" },
+      { id: "m-high", categoryId: "cat-1", name: "HIGH" },
+    ],
+  },
+  {
+    category: {
+      id: "cat-2",
+      name: "Access Groups",
+      description: "Who can see this",
+      categoryType: "CONJUNCTIVE",
+      markingType: "CBAC",
+    },
+    markings: [
+      { id: "m-internal", categoryId: "cat-2", name: "INTERNAL" },
+      { id: "m-external", categoryId: "cat-2", name: "EXTERNAL" },
+    ],
+  },
+];
+
+function CustomClassificationPicker() {
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+
+  const markingStates = useMemo(
+    () => computeMarkingStates(selectedIds, [], []),
+    [selectedIds],
+  );
+
+  const handleToggle = useCallback(
+    (markingId: string) => {
+      setSelectedIds((prev) => toggleMarking(markingId, prev, CATEGORIES));
+    },
+    [],
+  );
+
+  return (
+    <BaseCbacPicker
+      categories={CATEGORIES}
+      markingStates={markingStates}
+      onMarkingToggle={handleToggle}
+    />
+  );
+}
+```
+
+## Architecture
+
+`@osdk/cbac-components` follows the same two-layer architecture as `@osdk/react-components`:
+
+### OSDK Component Layer
+
+Components like `CbacPicker` and `CbacPickerDialog` handle data fetching using `@osdk/react` hooks:
+
+- `useMarkingCategories()` — fetches all marking categories
+- `useMarkings()` — fetches all markings
+- `useCbacBanner({ markingIds })` — resolves the classification string and colors
+- `useCbacMarkingRestrictions({ markingIds })` — computes implied, disallowed, and required markings
+
+These components convert OSDK data into primitive props and pass them to the base layer.
+
+### Base Component Layer
+
+Components like `BaseCbacPicker`, `BaseCbacBanner`, and `BaseCbacPickerDialog` are pure UI components with no OSDK imports. They accept primitive data (strings, arrays, Maps) and handle all rendering, interactions, and styling.
+
+### Data Flow
+
+```
+  useCbacPickerState (hook)
+  ├── useMarkingCategories() → categories
+  ├── useMarkings() → markings
+  ├── useCbacBanner() → banner data
+  └── useCbacMarkingRestrictions() → implied, disallowed, required
+
+  useCbacSelection (hook)
+  ├── manages selectedIds state
+  ├── calls useCbacPickerState
+  └── provides toggle, dismiss, reset callbacks
+
+  CbacPicker / CbacPickerDialog (OSDK layer)
+  └── BaseCbacPicker / BaseCbacPickerDialog (base layer)
+      ├── CategoryMarkingGroup → MarkingButton
+      ├── BaseCbacBanner
+      └── ValidationWarning
+```
+
+## Troubleshooting
+
+### Picker shows "Loading..." indefinitely
+
+- Ensure your app is wrapped with `OsdkProvider2` with a properly configured OSDK client
+- Check that the OSDK client has access to the marking categories and markings APIs
+- Verify network requests in browser DevTools for errors
+
+### No markings appear
+
+- Confirm that marking categories and markings are configured in your Foundry environment
+- Check that the OSDK client's authentication token has the necessary permissions
+
+### Banner shows default colors
+
+- The banner resolves colors from the OSDK. If no marking IDs are provided, or the banner API returns no data, fallback colors are used
+- Verify that the `useCbacBanner` hook is receiving the correct marking IDs
+
+### Validation errors: "Selected markings do not include all required markings"
+
+- Some marking combinations require additional markings. The `requiredMarkingGroups` in the picker state show which markings need to be added
+- The confirm button in `CbacPickerDialog` is disabled with a tooltip when the selection is invalid
+
+### CSS not applied
+
+- Ensure you've imported `@osdk/cbac-components/styles.css` in your CSS entry file
+- If using CSS layers, verify the layer order includes the cbac styles
+
+### Type errors with imports
+
+- All components and types should be imported from `@osdk/cbac-components/experimental`
+- Ensure your `@osdk/react` and `@osdk/react-components` peer dependencies are installed
+
+## Additional Resources
+
+- [CbacPicker Implementation](../src/cbac-picker/CbacPicker.tsx)
+- [CbacPickerDialog Implementation](../src/cbac-picker/CbacPickerDialog.tsx)
+- [Selection Logic](../src/cbac-picker/utils/selectionLogic.ts)
+- [Type Definitions](../src/cbac-picker/types.ts)
+- [@osdk/react Documentation](../../docs/react/getting-started.md)

--- a/packages/react-components/docs/FilterList.md
+++ b/packages/react-components/docs/FilterList.md
@@ -4,7 +4,7 @@ A comprehensive guide for using the FilterList component from `@osdk/react-compo
 
 ## Prerequisites
 
-Before using FilterList, make sure you have completed the library setup described in the [README](../README.md#setup), including:
+Before using FilterList, make sure you have completed the library setup described in the [README](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/README.md#setup), including:
 
 - Installing the required dependencies
 - Wrapping your app with `OsdkProvider2`
@@ -465,7 +465,7 @@ Use the `className` prop for scoped styling:
 />
 ```
 
-For a full reference of CSS tokens, see the [@osdk/react-components-styles documentation](../../react-components-styles/README.md).
+For a full reference of CSS tokens, see the [@osdk/react-components-styles documentation](https://github.com/palantir/osdk-ts/blob/main/packages/react-components-styles/README.md).
 
 ## Best Practices
 

--- a/packages/react-components/docs/ObjectTable.md
+++ b/packages/react-components/docs/ObjectTable.md
@@ -4,7 +4,7 @@ A comprehensive guide for using the ObjectTable component from `@osdk/react-comp
 
 ## Prerequisites
 
-Before using ObjectTable, make sure you have completed the library setup described in the [README](../README.md#setup), including:
+Before using ObjectTable, make sure you have completed the library setup described in the [README](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/README.md#setup), including:
 
 - Installing the required dependencies
 - Wrapping your app with `OsdkProvider2`
@@ -1270,8 +1270,8 @@ Apply custom styles to specific ObjectTable instances using the `className` prop
 
 For a complete reference of all available CSS tokens for theming, see:
 
-- [@osdk/react-components-styles CSS Variables Documentation](../../react-components-styles/CSS_VARIABLES.md)
-- [@osdk/react-components-styles README](../../react-components-styles/README.md)
+- [@osdk/react-components-styles CSS Variables Documentation](https://github.com/palantir/osdk-ts/blob/main/packages/react-components-styles/CSS_VARIABLES.md)
+- [@osdk/react-components-styles README](https://github.com/palantir/osdk-ts/blob/main/packages/react-components-styles/README.md)
 
 ### Accessibility Note
 
@@ -1285,7 +1285,7 @@ The default tokens are designed to meet WCAG AA standards.
 
 ## Additional Resources
 
-- [ObjectTable API Reference](../src/object-table/ObjectTableApi.ts)
-- [ObjectTable Implementation](../src/object-table/ObjectTable.tsx)
-- [PeopleApp Examples](../../e2e.sandbox.peopleapp/src/app/employees/EmployeesTable.tsx)
-- [@osdk/react Documentation](../../docs/react/getting-started.md)
+- [ObjectTable API Reference](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/src/object-table/ObjectTableApi.ts)
+- [ObjectTable Implementation](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/src/object-table/ObjectTable.tsx)
+- [PeopleApp Examples](https://github.com/palantir/osdk-ts/blob/main/packages/e2e.sandbox.peopleapp/src/app/employees/EmployeesTable.tsx)
+- [@osdk/react Documentation](https://github.com/palantir/osdk-ts/blob/main/docs/react/getting-started.md)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,6 +286,9 @@ importers:
       '@docusaurus/core':
         specifier: 3.4.0
         version: 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-content-docs':
+        specifier: 3.4.0
+        version: 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/preset-classic':
         specifier: 3.4.0
         version: 3.4.0(@algolia/client-search@5.46.0)(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.3)


### PR DESCRIPTION
docs-only changes to bring @osdk/cbac-components to parity with @osdk/react-components

• add CLAUDE.md, AGENTS.md, README.md mirroring react-components patterns
• add docs/CbacPicker.md with props reference, types, 4 examples, architecture, and troubleshooting
• all notional data uses generic terms (LOW/MEDIUM/HIGH, INTERNAL/EXTERNAL)