### PR TITLE
fix invalidateObjectType for queries with result type transformations

### DIFF
--- a/.changeset/fix-invalidate-object-type-result-type.md
+++ b/.changeset/fix-invalidate-object-type-result-type.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+fix invalidateObjectType to match queries where the result type differs from apiName (e.g. link traversal queries)

--- a/packages/client/src/observable/internal/Store.ts
+++ b/packages/client/src/observable/internal/Store.ts
@@ -420,10 +420,13 @@ export class Store {
     cacheKey: KnownCacheKey,
     changes: Changes,
   ): boolean {
-    if (cacheKey.type === "objectSet") {
+    if (cacheKey.type === "objectSet" || cacheKey.type === "list") {
       const query = this.queries.peek(cacheKey);
-      if (query) {
-        for (const objectType of query.objectTypes) {
+      if (query && "objectTypes" in query) {
+        for (
+          const objectType of (query as { objectTypes: ReadonlySet<string> })
+            .objectTypes
+        ) {
           if (this.#changesAffectObjectType(changes, objectType)) {
             return true;
           }

--- a/packages/client/src/observable/internal/Store.ts
+++ b/packages/client/src/observable/internal/Store.ts
@@ -422,6 +422,7 @@ export class Store {
   ): boolean {
     if (cacheKey.type === "objectSet" || cacheKey.type === "list") {
       const query = this.queries.peek(cacheKey);
+      // Both ObjectSetQuery and ListQuery expose objectTypes: ReadonlySet<string>
       if (query && "objectTypes" in query) {
         for (
           const objectType of (query as { objectTypes: ReadonlySet<string> })

--- a/packages/client/src/observable/internal/list/InterfaceListQuery.ts
+++ b/packages/client/src/observable/internal/list/InterfaceListQuery.ts
@@ -129,23 +129,9 @@ export class InterfaceListQuery extends ListQuery {
   protected createPayload(
     params: CollectionConnectableParams,
   ): ListPayload {
-    const resolvedList = params.resolvedData?.map((obj: ObjectHolder) => {
-      if (process.env.NODE_ENV !== "production") {
-        const missing = !obj || !(ObjectDefRef in obj);
-        if (missing) {
-          // eslint-disable-next-line no-console
-          console.error(
-            `[@osdk/client] InterfaceListQuery.createPayload: object missing ObjectDefRef`,
-            {
-              apiName: this.apiName,
-              objectType: (obj as ObjectHolder | undefined)?.$objectType,
-              primaryKey: (obj as ObjectHolder | undefined)?.$primaryKey,
-            },
-          );
-        }
-      }
-      return obj.$as(this.apiName);
-    });
+    const resolvedList = params.resolvedData?.map((obj: ObjectHolder) =>
+      obj.$as(this.apiName)
+    );
 
     return {
       ...super.createPayload(params),

--- a/packages/client/src/observable/internal/list/InterfaceListQuery.ts
+++ b/packages/client/src/observable/internal/list/InterfaceListQuery.ts
@@ -103,14 +103,20 @@ export class InterfaceListQuery extends ListQuery {
     return objectSet.where(this.canonicalWhere);
   }
 
-  async revalidateObjectType(apiName: string): Promise<void> {
-    const objectMetadata = await this.store.client.fetchMetadata({
-      type: "object",
-      apiName,
-    });
+  async revalidateObjectType(objectType: string): Promise<boolean> {
+    if (await super.revalidateObjectType(objectType)) return true;
 
-    if (this.apiName in objectMetadata.interfaceMap) {
-      await this.revalidate(/* force */ true);
+    // For interface queries: also check if the invalidated concrete type
+    // implements this query's interface. e.g. invalidating "Employee"
+    // should revalidate a query for "Assignable" if Employee implements it.
+    try {
+      const objectMetadata = await this.store.client.fetchMetadata({
+        type: "object",
+        apiName: objectType,
+      });
+      return this.apiName in objectMetadata.interfaceMap;
+    } catch {
+      return true;
     }
   }
 
@@ -123,9 +129,23 @@ export class InterfaceListQuery extends ListQuery {
   protected createPayload(
     params: CollectionConnectableParams,
   ): ListPayload {
-    const resolvedList = params.resolvedData?.map((obj: ObjectHolder) =>
-      obj.$as(this.apiName)
-    );
+    const resolvedList = params.resolvedData?.map((obj: ObjectHolder) => {
+      if (process.env.NODE_ENV !== "production") {
+        const missing = !obj || !(ObjectDefRef in obj);
+        if (missing) {
+          // eslint-disable-next-line no-console
+          console.error(
+            `[@osdk/client] InterfaceListQuery.createPayload: object missing ObjectDefRef`,
+            {
+              apiName: this.apiName,
+              objectType: (obj as ObjectHolder | undefined)?.$objectType,
+              primaryKey: (obj as ObjectHolder | undefined)?.$primaryKey,
+            },
+          );
+        }
+      }
+      return obj.$as(this.apiName);
+    });
 
     return {
       ...super.createPayload(params),

--- a/packages/client/src/observable/internal/list/ListQuery.ts
+++ b/packages/client/src/observable/internal/list/ListQuery.ts
@@ -411,17 +411,19 @@ export abstract class ListQuery extends BaseListQuery<
       && this.#fetchedObjectType !== this.apiName
     ) {
       const fetchedType = this.#fetchedObjectType;
-      const hasResultTypeChanges =
+      if (
         (changes.addedObjects.get(fetchedType)?.length ?? 0) > 0
         || (changes.modifiedObjects.get(fetchedType)?.length ?? 0) > 0
-        || Array.from(changes.deleted).some(
-          key =>
-            key.type === "object"
-            && key.otherKeys[OBJECT_API_NAME_IDX] === fetchedType,
-        );
-
-      if (hasResultTypeChanges) {
+      ) {
         return this.revalidate(true);
+      }
+      for (const key of changes.deleted) {
+        if (
+          key.type === "object"
+          && key.otherKeys[OBJECT_API_NAME_IDX] === fetchedType
+        ) {
+          return this.revalidate(true);
+        }
       }
     }
 

--- a/packages/client/src/observable/internal/list/ListQuery.ts
+++ b/packages/client/src/observable/internal/list/ListQuery.ts
@@ -148,6 +148,7 @@ export abstract class ListQuery extends BaseListQuery<
     this.#pivotInfo = cacheKey.otherKeys[PIVOT_IDX];
 
     this.#objectSet = this.createObjectSet(store);
+    this.#objectTypesCache = new Set([this.apiName]);
 
     // Only initialize the sorting strategy here if there's no pivotTo.
     // When pivotTo is used, the target type differs from apiName, so we
@@ -187,6 +188,13 @@ export abstract class ListQuery extends BaseListQuery<
     return this.#objectTypesCache ?? new Set([this.apiName]);
   }
 
+  #updateFetchedObjectType(fetchedApiName: string): void {
+    this.#fetchedObjectType = fetchedApiName;
+    this.#objectTypesCache = fetchedApiName !== this.apiName
+      ? new Set([this.apiName, fetchedApiName])
+      : new Set([this.apiName]);
+  }
+
   protected createPayload(
     params: CollectionConnectableParams,
   ): ListPayload {
@@ -219,10 +227,7 @@ export abstract class ListQuery extends BaseListQuery<
         wireObjectSet,
       );
 
-      this.#fetchedObjectType = resultType.apiName;
-      this.#objectTypesCache = this.#fetchedObjectType !== this.apiName
-        ? new Set([this.apiName, this.#fetchedObjectType])
-        : new Set([this.apiName]);
+      this.#updateFetchedObjectType(resultType.apiName);
 
       if (
         Object.keys(this.#orderBy).length > 0
@@ -282,13 +287,9 @@ export abstract class ListQuery extends BaseListQuery<
           this.store.client[additionalContext],
           wireObjectSet,
         );
-        this.#fetchedObjectType = resultType.apiName;
-        this.#objectTypesCache = this.#fetchedObjectType !== this.apiName
-          ? new Set([this.apiName, this.#fetchedObjectType])
-          : new Set([this.apiName]);
+        this.#updateFetchedObjectType(resultType.apiName);
       } catch {
-        this.#fetchedObjectType = this.apiName;
-        this.#objectTypesCache = new Set([this.apiName]);
+        this.#updateFetchedObjectType(this.apiName);
       }
     }
 

--- a/packages/client/src/observable/internal/list/ListQuery.ts
+++ b/packages/client/src/observable/internal/list/ListQuery.ts
@@ -43,7 +43,10 @@ import type { Canonical } from "../Canonical.js";
 import { type Changes, DEBUG_ONLY__changesToString } from "../Changes.js";
 import { getObjectTypesThatInvalidate } from "../getObjectTypesThatInvalidate.js";
 import type { Entry } from "../Layer.js";
-import { type ObjectCacheKey } from "../object/ObjectCacheKey.js";
+import {
+  API_NAME_IDX as OBJECT_API_NAME_IDX,
+  type ObjectCacheKey,
+} from "../object/ObjectCacheKey.js";
 import { objectSortaMatchesWhereClause as objectMatchesWhereClause } from "../objectMatchesWhereClause.js";
 import type { OptimisticId } from "../OptimisticId.js";
 import type { PivotInfo } from "../PivotCanonicalizer.js";
@@ -105,6 +108,7 @@ export abstract class ListQuery extends BaseListQuery<
   // For transformed queries (e.g. link traversal) it may differ -- e.g.
   // Employee.pivotTo(Office) has apiName "Employee" but fetches Office objects.
   #fetchedObjectType: string | undefined;
+  #objectTypesCache: ReadonlySet<string> | undefined;
 
   /**
    * Register changes to the cache specific to ListQuery
@@ -180,13 +184,7 @@ export abstract class ListQuery extends BaseListQuery<
   }
 
   get objectTypes(): ReadonlySet<string> {
-    if (
-      this.#fetchedObjectType != null
-      && this.#fetchedObjectType !== this.apiName
-    ) {
-      return new Set([this.apiName, this.#fetchedObjectType]);
-    }
-    return new Set([this.apiName]);
+    return this.#objectTypesCache ?? new Set([this.apiName]);
   }
 
   protected createPayload(
@@ -222,6 +220,9 @@ export abstract class ListQuery extends BaseListQuery<
       );
 
       this.#fetchedObjectType = resultType.apiName;
+      this.#objectTypesCache = this.#fetchedObjectType !== this.apiName
+        ? new Set([this.apiName, this.#fetchedObjectType])
+        : new Set([this.apiName]);
 
       if (
         Object.keys(this.#orderBy).length > 0
@@ -282,8 +283,12 @@ export abstract class ListQuery extends BaseListQuery<
           wireObjectSet,
         );
         this.#fetchedObjectType = resultType.apiName;
+        this.#objectTypesCache = this.#fetchedObjectType !== this.apiName
+          ? new Set([this.apiName, this.#fetchedObjectType])
+          : new Set([this.apiName]);
       } catch {
         this.#fetchedObjectType = this.apiName;
+        this.#objectTypesCache = new Set([this.apiName]);
       }
     }
 
@@ -404,10 +409,15 @@ export abstract class ListQuery extends BaseListQuery<
       this.#fetchedObjectType != null
       && this.#fetchedObjectType !== this.apiName
     ) {
+      const fetchedType = this.#fetchedObjectType;
       const hasResultTypeChanges =
-        (changes.addedObjects.get(this.#fetchedObjectType)?.length ?? 0) > 0
-        || (changes.modifiedObjects.get(this.#fetchedObjectType)?.length ?? 0)
-          > 0;
+        (changes.addedObjects.get(fetchedType)?.length ?? 0) > 0
+        || (changes.modifiedObjects.get(fetchedType)?.length ?? 0) > 0
+        || Array.from(changes.deleted).some(
+          key =>
+            key.type === "object"
+            && key.otherKeys[OBJECT_API_NAME_IDX] === fetchedType,
+        );
 
       if (hasResultTypeChanges) {
         return this.revalidate(true);

--- a/packages/client/src/observable/internal/list/ListQuery.ts
+++ b/packages/client/src/observable/internal/list/ListQuery.ts
@@ -100,6 +100,12 @@ export abstract class ListQuery extends BaseListQuery<
   #objectSet: ObjectSet<ObjectTypeDefinition>;
   #pivotIntersectApplied = false;
 
+  // The actual type of objects this query returns, resolved on first fetch
+  // via getObjectTypesThatInvalidate. For simple queries this equals apiName.
+  // For transformed queries (e.g. link traversal) it may differ -- e.g.
+  // Employee.pivotTo(Office) has apiName "Employee" but fetches Office objects.
+  #fetchedObjectType: string | undefined;
+
   /**
    * Register changes to the cache specific to ListQuery
    */
@@ -173,6 +179,16 @@ export abstract class ListQuery extends BaseListQuery<
     return this.#pivotInfo;
   }
 
+  get objectTypes(): ReadonlySet<string> {
+    if (
+      this.#fetchedObjectType != null
+      && this.#fetchedObjectType !== this.apiName
+    ) {
+      return new Set([this.apiName, this.#fetchedObjectType]);
+    }
+    return new Set([this.apiName]);
+  }
+
   protected createPayload(
     params: CollectionConnectableParams,
   ): ListPayload {
@@ -204,6 +220,8 @@ export abstract class ListQuery extends BaseListQuery<
         this.store.client[additionalContext],
         wireObjectSet,
       );
+
+      this.#fetchedObjectType = resultType.apiName;
 
       if (
         Object.keys(this.#orderBy).length > 0
@@ -248,6 +266,24 @@ export abstract class ListQuery extends BaseListQuery<
           ...intersectSets,
         );
         this.#pivotIntersectApplied = true;
+      }
+    }
+
+    // Resolve the actual result type on first fetch so revalidateObjectType
+    // can match against it. For simple queries this equals apiName; for
+    // transformed queries (link traversal, etc.) it may differ.
+    // Some ObjectSet types (static, reference) don't support result type
+    // resolution, so we fall back to apiName.
+    if (this.#fetchedObjectType == null) {
+      try {
+        const wireObjectSet = getWireObjectSet(this.#objectSet);
+        const { resultType } = await getObjectTypesThatInvalidate(
+          this.store.client[additionalContext],
+          wireObjectSet,
+        );
+        this.#fetchedObjectType = resultType.apiName;
+      } catch {
+        this.#fetchedObjectType = this.apiName;
       }
     }
 
@@ -304,13 +340,17 @@ export abstract class ListQuery extends BaseListQuery<
   }
 
   /**
-   * Will revalidate the list if its query is affected by invalidating the
-   * apiName of the object type passed in.
-   *
-   * @param apiName to invalidate
-   * @returns
+   * Determines if this query's results are affected by changes to the
+   * given object type. Base checks apiName (source type) and
+   * fetchedObjectType (actual result type when they differ).
+   * Subclasses override to add type-specific logic (e.g. interface
+   * implementation checks).
    */
-  abstract revalidateObjectType(apiName: string): Promise<void>;
+  async revalidateObjectType(objectType: string): Promise<boolean> {
+    return this.apiName === objectType
+      || (this.#fetchedObjectType != null
+        && this.#fetchedObjectType === objectType);
+  }
 
   /**
    * Postprocess fetched data.
@@ -323,8 +363,7 @@ export abstract class ListQuery extends BaseListQuery<
     objectType: string,
     changes: Changes | undefined,
   ): Promise<void> => {
-    if (this.apiName === objectType) {
-      // Only invalidate lists for the matching apiName
+    if (await this.revalidateObjectType(objectType)) {
       changes?.modified.add(this.cacheKey);
       return this.revalidate(true);
     }
@@ -356,6 +395,24 @@ export abstract class ListQuery extends BaseListQuery<
     if (changes.modified.has(this.cacheKey)) return;
     // mark ourselves as updated so we don't infinite recurse.
     changes.modified.add(this.cacheKey);
+
+    // When the fetched object type differs from apiName (e.g. a query that
+    // traverses a link), we can't locally evaluate whether result-type
+    // changes affect this query -- that depends on link relationships the
+    // client doesn't have. Fall back to a full server revalidation.
+    if (
+      this.#fetchedObjectType != null
+      && this.#fetchedObjectType !== this.apiName
+    ) {
+      const hasResultTypeChanges =
+        (changes.addedObjects.get(this.#fetchedObjectType)?.length ?? 0) > 0
+        || (changes.modifiedObjects.get(this.#fetchedObjectType)?.length ?? 0)
+          > 0;
+
+      if (hasResultTypeChanges) {
+        return this.revalidate(true);
+      }
+    }
 
     try {
       const relevantObjects = this._extractAndCategorizeRelevantObjects(

--- a/packages/client/src/observable/internal/list/ObjectListQuery.ts
+++ b/packages/client/src/observable/internal/list/ObjectListQuery.ts
@@ -135,12 +135,6 @@ export class ObjectListQuery extends ListQuery {
     return objectSet;
   }
 
-  async revalidateObjectType(apiName: string): Promise<void> {
-    if (this.apiName === apiName) {
-      await this.revalidate(/* force */ true);
-    }
-  }
-
   protected postProcessFetchedData(
     data: Osdk.Instance<any>[],
   ): Promise<Osdk.Instance<any>[]> {


### PR DESCRIPTION
invalidateObjectType wasn't matching queries where the result type differs from apiName

• wire up the existing revalidateObjectType method as the single decision point, resolving the actual fetched result type via getObjectTypesThatInvalidate so link-traversal queries match against the target type
• fix pre-existing bug where InterfaceListQuery.invalidateObjectType never checked if a concrete type implements the queried interface
• update Store change propagation and maybeUpdateAndRevalidate to use the new objectTypes getter