### PR TITLE
add prerequisites page and storybook link to docs site

### DIFF
--- a/.changeset/docs-prereqs-storybook.md
+++ b/.changeset/docs-prereqs-storybook.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+add shared prerequisites page and storybook link to docusaurus site

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -92,13 +92,6 @@ const config: Config = {
           label: "Components",
         },
         {
-          type: "docSidebar",
-          sidebarId: "docs",
-          docsPluginId: "cbac-components",
-          position: "left",
-          label: "CBAC",
-        },
-        {
           href: "https://palantir.github.io/osdk-ts/storybook/",
           label: "Storybook",
           position: "right",

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -80,9 +80,15 @@ const config: Config = {
       items: [
         {
           type: "docSidebar",
-          sidebarId: "docs",
+          sidebarId: "general",
           position: "left",
           label: "Docs",
+        },
+        {
+          type: "docSidebar",
+          sidebarId: "react",
+          position: "left",
+          label: "osdk-react",
         },
         {
           type: "docSidebar",

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -99,6 +99,11 @@ const config: Config = {
           label: "CBAC",
         },
         {
+          href: "https://palantir.github.io/osdk-ts/storybook/",
+          label: "Storybook",
+          position: "right",
+        },
+        {
           href: "https://github.com/palantir/osdk-ts",
           label: "GitHub",
           position: "right",

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -7,34 +7,29 @@ sidebar_position: 1
 
 Documentation for the OSDK TypeScript packages.
 
-**[Prerequisites](/prerequisites)** — common setup (OSDK client, OsdkProvider2, CSS layers) required before using any component package.
-
 ## Packages
 
-### [@osdk/react](/react/getting-started)
+### [@osdk/react](/react/prerequisites)
 
-React framework for building front-end applications with OSDK.
+React hooks for building front-end applications with OSDK.
 
-- [Getting Started](/react/getting-started) - Installation, setup, first app
+- [Prerequisites](/react/prerequisites) - Installation and setup
+- [Getting Started](/react/getting-started) - First app walkthrough
 - [Querying Data](/react/querying-data) - useOsdkObjects, useOsdkObject, useLinks
 - [Actions](/react/actions) - useOsdkAction, validation, optimistic updates
 - [Advanced Queries](/react/advanced-queries) - useObjectSet, derived properties, aggregations
 - [Cache Management](/react/cache-management) - Cache behavior and invalidation
 - [Platform APIs](/react/platform-apis) - useCurrentFoundryUser, useFoundryUser, useFoundryUsersList
 
-### [@osdk/react-components](/react-components/ObjectTable)
+### [Components](/react-components/Prerequisites)
 
 Pre-built, Ontology-aware React components with data loading, caching, and state management.
 
+- [Prerequisites](/react-components/Prerequisites) - Installation, CSS layers, and theming setup
 - [ObjectTable](/react-components/ObjectTable) - Sortable, filterable table with inline editing
 - [FilterList](/react-components/FilterList) - Aggregation-based filter UI
 - [PdfViewer](/react-components/PdfViewer) - PDF viewer with annotations and search
-
-### [@osdk/cbac-components](/cbac-components/CbacPicker)
-
-CBAC (Classification-Based Access Control) components for managing classification markings.
-
-- [CbacPicker](/cbac-components/CbacPicker) - Marking picker, dialog, banner, and base components
+- [CbacPicker](/cbac-components/CbacPicker) - Classification marking picker, dialog, and banner
 
 ### Other Guides
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -7,6 +7,8 @@ sidebar_position: 1
 
 Documentation for the OSDK TypeScript packages.
 
+**[Prerequisites](/prerequisites)** — common setup (OSDK client, OsdkProvider2, CSS layers) required before using any component package.
+
 ## Packages
 
 ### [@osdk/react](/react/getting-started)

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -1,0 +1,101 @@
+---
+sidebar_position: 2
+---
+
+# Prerequisites
+
+Common setup required before using `@osdk/react-components` or `@osdk/cbac-components`.
+
+## Install dependencies
+
+```bash
+npm install @osdk/api@beta @osdk/client@beta @osdk/react@beta
+npm install @osdk/react-components@beta @osdk/react-components-styles@beta
+npm install @osdk/cbac-components@beta  # if using CBAC components
+npm install react react-dom classnames
+```
+
+## Configure the OSDK client
+
+Create an OSDK client and wrap your app with `OsdkProvider2`:
+
+```tsx
+import { createClient } from "@osdk/client";
+import { OsdkProvider2 } from "@osdk/react/experimental";
+
+const client = createClient(
+  "https://your-stack.palantirfoundry.com",
+  "ri.ontology.main.ontology.00000000-0000-0000-0000-000000000000",
+  async () => {
+    // return your auth token
+  },
+);
+
+function App() {
+  return <OsdkProvider2 client={client}>{/* your app */}</OsdkProvider2>;
+}
+```
+
+All OSDK components must be rendered inside an `OsdkProvider2`. Without it, data fetching hooks will throw.
+
+## CSS setup
+
+OSDK components use CSS [`@layer`](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer) for predictable theming. Add these imports to your application's entry CSS file (e.g., `index.css`).
+
+### Layers
+
+| Layer             | Purpose                                                    |
+| ----------------- | ---------------------------------------------------------- |
+| `osdk.tokens`     | Design tokens (colors, spacing, typography) — the defaults |
+| `osdk.components` | Component structural styles (layout, borders, sizing)      |
+
+Later layers always win when styles conflict, regardless of selector specificity.
+
+### Without Tailwind
+
+```css
+/* index.css */
+@layer osdk.tokens, osdk.components;
+
+@import "@osdk/react-components-styles" layer(osdk.tokens);
+@import "@osdk/react-components/styles.css" layer(osdk.components);
+@import "@osdk/cbac-components/styles.css" layer(osdk.components);
+```
+
+### With Tailwind CSS v4
+
+```css
+/* index.css */
+@layer tailwind, osdk.tokens, osdk.components;
+
+@import "tailwindcss" layer(tailwind);
+
+@import "@osdk/react-components-styles" layer(osdk.tokens);
+@import "@osdk/react-components/styles.css" layer(osdk.components);
+@import "@osdk/cbac-components/styles.css" layer(osdk.components);
+```
+
+### Custom theme overrides
+
+Add a custom layer after the OSDK layers to override any token:
+
+```css
+@layer osdk.tokens, osdk.components, user.brand;
+
+@import "@osdk/react-components-styles" layer(osdk.tokens);
+@import "@osdk/react-components/styles.css" layer(osdk.components);
+@import "@osdk/cbac-components/styles.css" layer(osdk.components);
+@import "./user-brand.css" layer(user.brand);
+```
+
+### Portal isolation (required)
+
+OSDK components use [Base UI](https://base-ui.com) portals, which require stacking context isolation:
+
+```css
+.root {
+  isolation: isolate;
+}
+```
+
+Apply this to your root element. See the [Base UI docs](https://base-ui.com/react/overview/quick-start#portals) for details.

--- a/docs/react/prerequisites.md
+++ b/docs/react/prerequisites.md
@@ -1,0 +1,37 @@
+---
+sidebar_position: 1
+---
+
+# Prerequisites
+
+Setup required before using `@osdk/react` hooks.
+
+## Install dependencies
+
+```bash
+npm install @osdk/api@beta @osdk/client@beta @osdk/react@beta
+npm install react react-dom
+```
+
+## Configure the OSDK client
+
+Create an OSDK client and wrap your app with `OsdkProvider2`:
+
+```tsx
+import { createClient } from "@osdk/client";
+import { OsdkProvider2 } from "@osdk/react/experimental";
+
+const client = createClient(
+  "https://your-stack.palantirfoundry.com",
+  "ri.ontology.main.ontology.00000000-0000-0000-0000-000000000000",
+  async () => {
+    // return your auth token
+  },
+);
+
+function App() {
+  return <OsdkProvider2 client={client}>{/* your app */}</OsdkProvider2>;
+}
+```
+
+All `@osdk/react` hooks must be called inside an `OsdkProvider2`. Without it, hooks will throw.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -17,26 +17,22 @@
 import type { SidebarsConfig } from "@docusaurus/plugin-content-docs";
 
 const sidebars: SidebarsConfig = {
-  docs: [
+  general: [
     "intro",
-    "prerequisites",
-    {
-      type: "category",
-      label: "@osdk/react",
-      items: [
-        "react/getting-started",
-        "react/querying-data",
-        "react/actions",
-        "react/advanced-queries",
-        "react/cache-management",
-        "react/platform-apis",
-      ],
-    },
     {
       type: "category",
       label: "Guides",
       items: ["guides/vite"],
     },
+  ],
+  react: [
+    "react/prerequisites",
+    "react/getting-started",
+    "react/querying-data",
+    "react/actions",
+    "react/advanced-queries",
+    "react/cache-management",
+    "react/platform-apis",
   ],
 };
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -19,6 +19,7 @@ import type { SidebarsConfig } from "@docusaurus/plugin-content-docs";
 const sidebars: SidebarsConfig = {
   docs: [
     "intro",
+    "prerequisites",
     {
       type: "category",
       label: "@osdk/react",

--- a/docs/sidebarsReactComponents.ts
+++ b/docs/sidebarsReactComponents.ts
@@ -18,9 +18,28 @@ import type { SidebarsConfig } from "@docusaurus/plugin-content-docs";
 
 const sidebars: SidebarsConfig = {
   docs: [
-    "ObjectTable",
-    "FilterList",
-    "PdfViewer",
+    {
+      type: "category",
+      label: "@osdk/react-components",
+      collapsed: false,
+      items: [
+        "ObjectTable",
+        "FilterList",
+        "PdfViewer",
+      ],
+    },
+    {
+      type: "category",
+      label: "@osdk/cbac-components",
+      collapsed: false,
+      items: [
+        {
+          type: "link",
+          label: "CbacPicker",
+          href: "/cbac-components/CbacPicker",
+        },
+      ],
+    },
   ],
 };
 

--- a/docs/sidebarsReactComponents.ts
+++ b/docs/sidebarsReactComponents.ts
@@ -18,6 +18,7 @@ import type { SidebarsConfig } from "@docusaurus/plugin-content-docs";
 
 const sidebars: SidebarsConfig = {
   docs: [
+    "Prerequisites",
     {
       type: "category",
       label: "@osdk/react-components",

--- a/packages/react-components/docs/Prerequisites.md
+++ b/packages/react-components/docs/Prerequisites.md
@@ -1,10 +1,10 @@
 ---
-sidebar_position: 2
+sidebar_position: 1
 ---
 
 # Prerequisites
 
-Common setup required before using `@osdk/react-components` or `@osdk/cbac-components`.
+Setup required before using `@osdk/react-components` or `@osdk/cbac-components`.
 
 ## Install dependencies
 
@@ -36,11 +36,11 @@ function App() {
 }
 ```
 
-All OSDK components must be rendered inside an `OsdkProvider2`. Without it, data fetching hooks will throw.
+All component packages require an `OsdkProvider2` wrapping your app. Without it, data fetching hooks will throw.
 
 ## CSS setup
 
-OSDK components use CSS [`@layer`](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer) for predictable theming. Add these imports to your application's entry CSS file (e.g., `index.css`).
+Components use CSS [`@layer`](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer) for predictable theming. Add these imports to your application's entry CSS file (e.g., `index.css`).
 
 ### Layers
 
@@ -90,7 +90,7 @@ Add a custom layer after the OSDK layers to override any token:
 
 ### Portal isolation (required)
 
-OSDK components use [Base UI](https://base-ui.com) portals, which require stacking context isolation:
+Components use [Base UI](https://base-ui.com) portals, which require stacking context isolation:
 
 ```css
 .root {


### PR DESCRIPTION
add shared setup instructions and storybook access to the docusaurus site

• add prerequisites page consolidating OSDK client config, OsdkProvider2, CSS layer setup, and portal isolation
• add storybook navbar link pointing to palantir.github.io/osdk-ts/storybook/
• link prerequisites from the intro page