### PR TITLE
fix vue-sdk-1.x build: add ^typecheck to build task deps

### DIFF
--- a/.changeset/fix-vue-build.md
+++ b/.changeset/fix-vue-build.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix vue-sdk-1.x build by adding ^typecheck to build task deps

--- a/turbo.json
+++ b/turbo.json
@@ -93,7 +93,7 @@
     },
 
     "build": {
-      "dependsOn": ["transpile", "transpileTypes"],
+      "dependsOn": ["transpile", "transpileTypes", "^typecheck"],
       "inputs": [
         "src/**/*",
 


### PR DESCRIPTION
#2987 removed `typecheck` from the `build` task's `dependsOn` in turbo.json, which broke the vue example build

• `e2e.generated.1.1.x` emits `.d.ts` files during its `typecheck` task (via `typecheck.sh`), not during `transpileTypes`
• the vue example's `build` runs `vue-tsc` which needs those `.d.ts` files, but without `^typecheck` in the dependency chain they were never generated before `build` ran
• adds `^typecheck` to the `build` task so dependency type declarations are available when `build` runs `tsc`/`vue-tsc`