### PR TITLE
Use branch-specific npm tag for release/* branches

### DIFF
--- a/scripts/ci-publish.sh
+++ b/scripts/ci-publish.sh
@@ -10,7 +10,11 @@ JQ=$(checkCommand "jq" "jq" "Try 'brew install jq'")
 # Default value for pnpm
 TAG="latest"
 
-if [ -f "${SCRIPT_DIR}/../.changeset/pre.json" ]; then
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$BRANCH" == release/* ]]; then
+    VERSION="${BRANCH#release/}"
+    TAG="latest-${VERSION}"
+elif [ -f "${SCRIPT_DIR}/../.changeset/pre.json" ]; then
     MODE=$($JQ --raw-output .mode "${SCRIPT_DIR}/../.changeset/pre.json")
     
     if [ "$MODE" == "pre" ]; then

--- a/scripts/ci-publish.sh
+++ b/scripts/ci-publish.sh
@@ -10,19 +10,21 @@ JQ=$(checkCommand "jq" "jq" "Try 'brew install jq'")
 # Default value for pnpm
 TAG="latest"
 
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
-if [[ "$BRANCH" == release/* ]]; then
-    VERSION="${BRANCH#release/}"
-    TAG="latest-${VERSION}"
-elif [ -f "${SCRIPT_DIR}/../.changeset/pre.json" ]; then
+if [ -f "${SCRIPT_DIR}/../.changeset/pre.json" ]; then
     MODE=$($JQ --raw-output .mode "${SCRIPT_DIR}/../.changeset/pre.json")
-    
+
     if [ "$MODE" == "pre" ]; then
         TAG=$($JQ --raw-output .tag "${SCRIPT_DIR}/../.changeset/pre.json")
     else
         echo "Invalid mode for releasing: $MODE"
         exit 100
     fi
+fi
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$BRANCH" == release/* ]]; then
+    VERSION="${BRANCH#release/}"
+    TAG="latest-${VERSION}"
 fi
 
 echo "Publishing with tag: $TAG"


### PR DESCRIPTION
## Summary
- Prevents releases from `release/*` branches from overwriting the `latest` npm tag
- Instead publishes with `latest-{version}` (e.g. `latest-1.3.x` for `release/1.3.x`)
- No change to `main` branch behavior (still uses `latest`)

## Test plan
- [ ] Verify CI publish on `release/1.3.x` uses tag `latest-1.3.x`
- [ ] Verify `main` branch still publishes with `latest` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)