### PR TITLE
Set default tooltip trigger delay to 200ms

### DIFF
--- a/.changeset/bright-foxes-glow.md
+++ b/.changeset/bright-foxes-glow.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Set default tooltip trigger delay to 200ms in TooltipTrigger

--- a/packages/react-components/src/action-form/BaseForm.tsx
+++ b/packages/react-components/src/action-form/BaseForm.tsx
@@ -27,9 +27,6 @@ import { FieldBridge } from "./fields/FieldBridge.js";
 import type { RendererFieldDefinition } from "./FormFieldApi.js";
 import { FormHeader } from "./FormHeader.js";
 
-// Using a lower trigger delay for tooltips in forms so the user can see the errors quickly
-const TOOLTIP_TRIGGER_DELAY_MS = 200;
-
 export const BaseForm: React.FC<BaseFormProps> = memo(function BaseFormFn({
   formTitle,
   fieldDefinitions,
@@ -201,7 +198,7 @@ const SubmitButton = memo(function SubmitButtonFn({
 
   return (
     <Tooltip.Root defaultOpen={true}>
-      <Tooltip.Trigger delay={TOOLTIP_TRIGGER_DELAY_MS}>
+      <Tooltip.Trigger>
         {button}
       </Tooltip.Trigger>
       <Tooltip.Portal>
@@ -232,7 +229,7 @@ function ErrorIndicator({
 
   return (
     <Tooltip.Root>
-      <Tooltip.Trigger delay={TOOLTIP_TRIGGER_DELAY_MS}>
+      <Tooltip.Trigger>
         <span className={styles.osdkFormErrorIndicator}>
           <ErrorIcon size={14} />
           {count === 1 ? "1 issue" : `${count} issues`}

--- a/packages/react-components/src/base-components/tooltip/Tooltip.tsx
+++ b/packages/react-components/src/base-components/tooltip/Tooltip.tsx
@@ -28,15 +28,8 @@ import styles from "./Tooltip.module.css";
 
 export interface TooltipProps extends Omit<TooltipRootProps, "className"> {}
 
-function TooltipRoot({
-  children,
-  ...rest
-}: TooltipProps): React.ReactElement {
-  return (
-    <BaseUITooltip.Root {...rest}>
-      {children}
-    </BaseUITooltip.Root>
-  );
+function TooltipRoot({ children, ...rest }: TooltipProps): React.ReactElement {
+  return <BaseUITooltip.Root {...rest}>{children}</BaseUITooltip.Root>;
 }
 
 interface TooltipProviderComponentProps
@@ -49,13 +42,7 @@ function TooltipProvider({
   children,
   ...rest
 }: TooltipProviderComponentProps): React.ReactElement {
-  return (
-    <BaseUITooltip.Provider
-      {...rest}
-    >
-      {children}
-    </BaseUITooltip.Provider>
-  );
+  return <BaseUITooltip.Provider {...rest}>{children}</BaseUITooltip.Provider>;
 }
 
 interface TooltipTriggerComponentProps
@@ -64,14 +51,19 @@ interface TooltipTriggerComponentProps
   className?: string;
 }
 
+// Base UI defaults to 600ms which feels too slow
+const TOOLTIP_TRIGGER_DELAY_MS = 200;
+
 function TooltipTrigger({
   className,
   children,
+  delay = TOOLTIP_TRIGGER_DELAY_MS,
   ...rest
 }: TooltipTriggerComponentProps): React.ReactElement {
   return (
     <BaseUITooltip.Trigger
       className={classnames(styles.osdkTooltipTrigger, className)}
+      delay={delay}
       {...rest}
     >
       {children}


### PR DESCRIPTION
## Summary
- Move `TOOLTIP_TRIGGER_DELAY_MS` (200ms) into `TooltipTrigger` as the default `delay` prop, replacing Base UI's 600ms default
- Remove the per-site `delay` overrides from `BaseForm.tsx`

## Test plan
- [x] Verify tooltips in BaseForm (submit button error, error indicator) appear after ~200ms