### PR TITLE
Set up trusted publishing for osdk packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
@@ -39,8 +40,6 @@ jobs:
 
       - name: Publish packages
         run: pnpm ci:publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Save publish data
         uses: actions/upload-artifact@v7
@@ -53,6 +52,9 @@ jobs:
     needs: release
     if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
@@ -84,5 +86,3 @@ jobs:
 
       - name: Publish results
         run: pnpm exec changeset publish --no-git-tag --tag next-${GITHUB_REF_NAME//\//__}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR sets up trusted publishing for OSDK packages from this repo. Configuration on npm side to make our github release.yml as a trusted publisher for each package has already been completed.