### PR TITLE
Prevent overlapping date range commits and fix backspace after invalid input revert

### DIFF
--- a/.changeset/gentle-ravens-fly.md
+++ b/.changeset/gentle-ravens-fly.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Prevent committing overlapping date ranges and fix backspace after invalid input revert

--- a/packages/react-components/src/action-form/__tests__/DateRangeInputField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/DateRangeInputField.test.tsx
@@ -225,6 +225,94 @@ describe("DateRangeInputField", () => {
       fireEvent.change(startInput, { target: { value: "2024-06-15" } });
       expect(startInput.getAttribute("aria-invalid")).not.toBe("true");
     });
+
+    it("reverts start input on blur when typed start would overlap end", () => {
+      const onChange = vi.fn();
+      render(
+        <DateRangeInputField
+          value={[new Date(2024, 0, 1), new Date(2024, 5, 15)]}
+          onChange={onChange}
+        />,
+      );
+      const startInput = screen.getByLabelText(
+        "Start date",
+      ) as HTMLInputElement;
+      fireEvent.focus(startInput);
+      fireEvent.change(startInput, { target: { value: "2024-12-01" } });
+      fireEvent.blur(startInput);
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(startInput.value).toBe("Jan 1, 2024");
+    });
+
+    it("reverts end input on blur when typed end would overlap start", () => {
+      const onChange = vi.fn();
+      render(
+        <DateRangeInputField
+          value={[new Date(2024, 5, 15), new Date(2024, 11, 31)]}
+          onChange={onChange}
+        />,
+      );
+      const endInput = screen.getByLabelText("End date") as HTMLInputElement;
+      fireEvent.focus(endInput);
+      fireEvent.change(endInput, { target: { value: "2024-01-01" } });
+      fireEvent.blur(endInput);
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(endInput.value).toBe("Dec 31, 2024");
+    });
+
+    it("reverts start input on Enter when typed start would overlap end", () => {
+      const onChange = vi.fn();
+      render(
+        <DateRangeInputField
+          value={[new Date(2024, 0, 1), new Date(2024, 5, 15)]}
+          onChange={onChange}
+        />,
+      );
+      const startInput = screen.getByLabelText(
+        "Start date",
+      ) as HTMLInputElement;
+      fireEvent.focus(startInput);
+      fireEvent.change(startInput, { target: { value: "2024-12-01" } });
+      fireEvent.keyDown(startInput, { key: "Enter" });
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("reverts end input on Enter when typed end would overlap start", () => {
+      const onChange = vi.fn();
+      render(
+        <DateRangeInputField
+          value={[new Date(2024, 5, 15), new Date(2024, 11, 31)]}
+          onChange={onChange}
+        />,
+      );
+      const endInput = screen.getByLabelText("End date") as HTMLInputElement;
+      fireEvent.focus(endInput);
+      fireEvent.change(endInput, { target: { value: "2024-01-01" } });
+      fireEvent.keyDown(endInput, { key: "Enter" });
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("reverts end input when same day and allowSingleDayRange is false", () => {
+      const onChange = vi.fn();
+      render(
+        <DateRangeInputField
+          value={[new Date(2024, 5, 15), new Date(2024, 11, 31)]}
+          onChange={onChange}
+          allowSingleDayRange={false}
+        />,
+      );
+      const endInput = screen.getByLabelText("End date") as HTMLInputElement;
+      fireEvent.focus(endInput);
+      fireEvent.change(endInput, { target: { value: "2024-06-15" } });
+      fireEvent.blur(endInput);
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(endInput.value).toBe("Dec 31, 2024");
+    });
   });
 
   describe("focus management", () => {

--- a/packages/react-components/src/action-form/__tests__/useDateEditState.test.ts
+++ b/packages/react-components/src/action-form/__tests__/useDateEditState.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   formatDateForDisplay,
   formatDateForInput,
@@ -42,11 +42,9 @@ describe("useDateEditState", () => {
       const { result } = renderHook(() => useDateEditState(makeConfig()));
 
       expect(result.current.isEditing).toBe(false);
-      expect(result.current.inputValue).toBe("");
       expect(result.current.displayedValue).toBe("");
       expect(result.current.inputError).toBeNull();
       expect(result.current.dateValue).toBeUndefined();
-      expect(result.current.validatedDate).toBeNull();
     });
 
     it("displays formatted value when not editing", () => {
@@ -75,7 +73,7 @@ describe("useDateEditState", () => {
   });
 
   describe("startEditing", () => {
-    it("enters editing mode and populates inputValue with editFormatFn", () => {
+    it("switches displayedValue from display format to edit format", () => {
       const { result } = renderHook(() =>
         useDateEditState(
           makeConfig({
@@ -94,13 +92,10 @@ describe("useDateEditState", () => {
       });
 
       expect(result.current.isEditing).toBe(true);
-      // Editing: inputValue uses editFormatFn
-      expect(result.current.inputValue).toBe("2024-01-15");
-      // displayedValue echoes inputValue while editing
       expect(result.current.displayedValue).toBe("2024-01-15");
     });
 
-    it("sets empty inputValue when value is null", () => {
+    it("sets empty displayedValue when value is null", () => {
       const { result } = renderHook(() => useDateEditState(makeConfig()));
 
       act(() => {
@@ -108,7 +103,7 @@ describe("useDateEditState", () => {
       });
 
       expect(result.current.isEditing).toBe(true);
-      expect(result.current.inputValue).toBe("");
+      expect(result.current.displayedValue).toBe("");
     });
   });
 
@@ -127,10 +122,13 @@ describe("useDateEditState", () => {
       expect(result.current.isEditing).toBe(false);
     });
 
-    it("resets inputValue to committed value's edit format", () => {
+    it("reverts displayedValue to the committed value", () => {
       const { result } = renderHook(() =>
         useDateEditState(
-          makeConfig({ value: new Date(2024, 0, 15) }),
+          makeConfig({
+            value: new Date(2024, 0, 15),
+            displayFormatFn: formatDateForDisplay,
+          }),
         )
       );
 
@@ -140,15 +138,115 @@ describe("useDateEditState", () => {
       act(() => {
         result.current.setInputValue("invalid-date");
       });
-      expect(result.current.inputValue).toBe("invalid-date");
+      expect(result.current.displayedValue).toBe("invalid-date");
 
       act(() => {
         result.current.stopEditing();
       });
 
-      // inputValue should be reset to the edit-formatted committed value,
-      // not retain the stale invalid text.
-      expect(result.current.inputValue).toBe("2024-01-15");
+      expect(result.current.displayedValue).toBe("Jan 15, 2024");
+    });
+
+    it("does not call onChange", () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useDateEditState(
+          makeConfig({ value: new Date(2024, 0, 15), onChange }),
+        )
+      );
+
+      act(() => {
+        result.current.startEditing();
+      });
+      act(() => {
+        result.current.setInputValue("2024-06-15");
+      });
+      act(() => {
+        result.current.stopEditing();
+      });
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("commitAndStopEditing", () => {
+    it("calls onChange with validated date for valid input", () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useDateEditState(makeConfig({ onChange }))
+      );
+
+      act(() => {
+        result.current.startEditing();
+      });
+      act(() => {
+        result.current.setInputValue("2024-06-15");
+      });
+      act(() => {
+        result.current.commitAndStopEditing();
+      });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange.mock.calls[0][0]).toEqual(new Date(2024, 5, 15));
+      expect(result.current.isEditing).toBe(false);
+    });
+
+    it("calls onChange with null for empty input", () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useDateEditState(
+          makeConfig({ value: new Date(2024, 0, 15), onChange }),
+        )
+      );
+
+      act(() => {
+        result.current.startEditing();
+      });
+      act(() => {
+        result.current.setInputValue("");
+      });
+      act(() => {
+        result.current.commitAndStopEditing();
+      });
+
+      expect(onChange).toHaveBeenCalledWith(null);
+      expect(result.current.isEditing).toBe(false);
+    });
+
+    it("does not call onChange for invalid input", () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useDateEditState(makeConfig({ onChange }))
+      );
+
+      act(() => {
+        result.current.startEditing();
+      });
+      act(() => {
+        result.current.setInputValue("garbage");
+      });
+      act(() => {
+        result.current.commitAndStopEditing();
+      });
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(result.current.isEditing).toBe(false);
+    });
+
+    it("does not throw when onChange is not provided", () => {
+      const { result } = renderHook(() => useDateEditState(makeConfig()));
+
+      act(() => {
+        result.current.startEditing();
+      });
+      act(() => {
+        result.current.setInputValue("2024-06-15");
+      });
+      act(() => {
+        result.current.commitAndStopEditing();
+      });
+
+      expect(result.current.isEditing).toBe(false);
     });
   });
 
@@ -163,7 +261,6 @@ describe("useDateEditState", () => {
         result.current.setInputValue("2024-06-15");
       });
 
-      expect(result.current.inputValue).toBe("2024-06-15");
       expect(result.current.displayedValue).toBe("2024-06-15");
     });
   });
@@ -186,7 +283,7 @@ describe("useDateEditState", () => {
         result.current.setDateValue(new Date(2024, 5, 15));
       });
 
-      expect(result.current.inputValue).toBe("2024-06-15");
+      expect(result.current.displayedValue).toBe("2024-06-15");
     });
   });
 
@@ -300,73 +397,6 @@ describe("useDateEditState", () => {
     });
   });
 
-  describe("validatedDate", () => {
-    it("is null when not editing", () => {
-      const { result } = renderHook(() =>
-        useDateEditState(makeConfig({ value: new Date(2024, 0, 15) }))
-      );
-      expect(result.current.validatedDate).toBeNull();
-    });
-
-    it("is null for empty input", () => {
-      const { result } = renderHook(() => useDateEditState(makeConfig()));
-
-      act(() => {
-        result.current.startEditing();
-      });
-
-      expect(result.current.validatedDate).toBeNull();
-    });
-
-    it("is null for invalid input", () => {
-      const { result } = renderHook(() => useDateEditState(makeConfig()));
-
-      act(() => {
-        result.current.startEditing();
-      });
-      act(() => {
-        result.current.setInputValue("garbage");
-      });
-
-      expect(result.current.validatedDate).toBeNull();
-    });
-
-    it("is null for out-of-range input", () => {
-      const { result } = renderHook(() =>
-        useDateEditState(
-          makeConfig({
-            min: new Date(2024, 0, 1),
-            max: new Date(2024, 11, 31),
-          }),
-        )
-      );
-
-      act(() => {
-        result.current.startEditing();
-      });
-      act(() => {
-        result.current.setInputValue("2025-06-15");
-      });
-
-      expect(result.current.validatedDate).toBeNull();
-    });
-
-    it("returns parsed date for valid in-range input", () => {
-      const { result } = renderHook(() => useDateEditState(makeConfig()));
-
-      act(() => {
-        result.current.startEditing();
-      });
-      act(() => {
-        result.current.setInputValue("2024-06-15");
-      });
-
-      expect(result.current.validatedDate).toBeInstanceOf(Date);
-      expect(result.current.validatedDate?.getMonth()).toBe(5);
-      expect(result.current.validatedDate?.getDate()).toBe(15);
-    });
-  });
-
   describe("external value sync", () => {
     it("updates displayedValue when external value changes while not editing", () => {
       const { result, rerender } = renderHook(
@@ -393,7 +423,7 @@ describe("useDateEditState", () => {
       expect(result.current.displayedValue).toBe("Jul 20, 2024");
     });
 
-    it("does not overwrite inputValue when external value changes during editing", () => {
+    it("does not overwrite user edits when external value changes during editing", () => {
       const { result, rerender } = renderHook(
         (config: UseDateEditStateConfig) => useDateEditState(config),
         { initialProps: makeConfig({ value: new Date(2024, 0, 15) }) },
@@ -407,11 +437,10 @@ describe("useDateEditState", () => {
       });
 
       // Intentional: user's unsaved edits are preserved when the parent
-      // value changes. The hook only syncs inputValue when not editing.
+      // value changes. The hook only syncs when not editing.
       rerender(makeConfig({ value: new Date(2024, 6, 20) }));
 
-      // inputValue should NOT be overwritten
-      expect(result.current.inputValue).toBe("2024-03-20");
+      expect(result.current.displayedValue).toBe("2024-03-20");
     });
   });
 });

--- a/packages/react-components/src/action-form/__tests__/useDateEditState.test.ts
+++ b/packages/react-components/src/action-form/__tests__/useDateEditState.test.ts
@@ -126,6 +126,30 @@ describe("useDateEditState", () => {
       });
       expect(result.current.isEditing).toBe(false);
     });
+
+    it("resets inputValue to committed value's edit format", () => {
+      const { result } = renderHook(() =>
+        useDateEditState(
+          makeConfig({ value: new Date(2024, 0, 15) }),
+        )
+      );
+
+      act(() => {
+        result.current.startEditing();
+      });
+      act(() => {
+        result.current.setInputValue("invalid-date");
+      });
+      expect(result.current.inputValue).toBe("invalid-date");
+
+      act(() => {
+        result.current.stopEditing();
+      });
+
+      // inputValue should be reset to the edit-formatted committed value,
+      // not retain the stale invalid text.
+      expect(result.current.inputValue).toBe("2024-01-15");
+    });
   });
 
   describe("setInputValue", () => {

--- a/packages/react-components/src/action-form/fields/DateRangeInputField.tsx
+++ b/packages/react-components/src/action-form/fields/DateRangeInputField.tsx
@@ -125,24 +125,22 @@ export const DateRangeInputField: React.NamedExoticComponent<
     max,
   });
 
-  // --- Cross-input error: overlapping range ---
+  // --- Cross-input error: overlapping range (live feedback while typing) ---
+  // Blur/Enter handlers prevent overlapping values from being committed,
+  // so this only fires during editing for immediate red-border feedback.
   const hasOverlapError = (() => {
     if (!isEditingStart && !isEditingEnd) return false;
-    const parsedStart = isEditingStart
+    const effectiveStart = isEditingStart
       ? startParsedValue
       : (startDate ?? undefined);
-    const parsedEnd = isEditingEnd ? endParsedValue : (endDate ?? undefined);
-    if (parsedStart == null || parsedEnd == null) return false;
-    if (!allowSingleDayRange && parsedEnd.getTime() === parsedStart.getTime()) {
-      return true;
-    }
-    return parsedEnd.getTime() < parsedStart.getTime();
+    const effectiveEnd = isEditingEnd
+      ? endParsedValue
+      : (endDate ?? undefined);
+    return isOverlapping(effectiveStart, effectiveEnd, allowSingleDayRange);
   })();
 
-  const startInvalid = isEditingStart
-    && (startInputError != null || hasOverlapError);
-  const endInvalid = isEditingEnd
-    && (endInputError != null || hasOverlapError);
+  const startInvalid = startInputError != null || hasOverlapError;
+  const endInvalid = endInputError != null || hasOverlapError;
 
   // --- Focus handlers ---
 
@@ -158,6 +156,48 @@ export const DateRangeInputField: React.NamedExoticComponent<
     setIsOpen(true);
   }, [beginEndEditing]);
 
+  // --- Commit helpers ---
+  // Shared by blur and Enter handlers. Commits the edited value if valid
+  // and non-overlapping, or silently reverts by skipping the onChange call.
+
+  const commitStartValue = useCallback(() => {
+    if (startInputRaw === "") {
+      onChange?.([null, endDate ?? null]);
+    } else if (
+      startCommittedValue != null
+      && !isOverlapping(startCommittedValue, endDate, allowSingleDayRange)
+    ) {
+      onChange?.([startCommittedValue, endDate ?? null]);
+    }
+    stopStartEditing();
+  }, [
+    startInputRaw,
+    startCommittedValue,
+    stopStartEditing,
+    endDate,
+    onChange,
+    allowSingleDayRange,
+  ]);
+
+  const commitEndValue = useCallback(() => {
+    if (endInputRaw === "") {
+      onChange?.([startDate ?? null, null]);
+    } else if (
+      endCommittedValue != null
+      && !isOverlapping(startDate, endCommittedValue, allowSingleDayRange)
+    ) {
+      onChange?.([startDate ?? null, endCommittedValue]);
+    }
+    stopEndEditing();
+  }, [
+    endInputRaw,
+    endCommittedValue,
+    stopEndEditing,
+    startDate,
+    onChange,
+    allowSingleDayRange,
+  ]);
+
   // --- Blur handlers ---
 
   const handleStartBlur = useCallback(
@@ -172,14 +212,9 @@ export const DateRangeInputField: React.NamedExoticComponent<
       if (endInputRef.current === related) {
         return;
       }
-      if (startInputRaw === "") {
-        onChange?.([null, endDate ?? null]);
-      } else if (startCommittedValue != null) {
-        onChange?.([startCommittedValue, endDate ?? null]);
-      }
-      stopStartEditing();
+      commitStartValue();
     },
-    [startInputRaw, startCommittedValue, stopStartEditing, endDate, onChange],
+    [commitStartValue],
   );
 
   const handleEndBlur = useCallback(
@@ -192,14 +227,9 @@ export const DateRangeInputField: React.NamedExoticComponent<
       if (startInputRef.current === related) {
         return;
       }
-      if (endInputRaw === "") {
-        onChange?.([startDate ?? null, null]);
-      } else if (endCommittedValue != null) {
-        onChange?.([startDate ?? null, endCommittedValue]);
-      }
-      stopEndEditing();
+      commitEndValue();
     },
-    [endInputRaw, endCommittedValue, stopEndEditing, startDate, onChange],
+    [commitEndValue],
   );
 
   // --- Popover helpers ---
@@ -220,12 +250,7 @@ export const DateRangeInputField: React.NamedExoticComponent<
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === "Enter") {
         e.preventDefault();
-        if (startInputRaw === "") {
-          onChange?.([null, endDate ?? null]);
-        } else if (startCommittedValue != null) {
-          onChange?.([startCommittedValue, endDate ?? null]);
-        }
-        stopStartEditing();
+        commitStartValue();
         // Auto-advance to end
         endInputRef.current?.focus();
       } else if (e.key === "Escape") {
@@ -235,25 +260,14 @@ export const DateRangeInputField: React.NamedExoticComponent<
         setIsOpen(false);
       }
     },
-    [
-      startInputRaw,
-      startCommittedValue,
-      stopStartEditing,
-      closePopover,
-      endDate,
-      onChange,
-    ],
+    [commitStartValue, closePopover],
   );
 
   const handleEndKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === "Enter") {
         e.preventDefault();
-        if (endInputRaw === "") {
-          onChange?.([startDate ?? null, null]);
-        } else if (endCommittedValue != null) {
-          onChange?.([startDate ?? null, endCommittedValue]);
-        }
+        commitEndValue();
         closePopover();
       } else if (e.key === "Escape") {
         e.preventDefault();
@@ -271,14 +285,7 @@ export const DateRangeInputField: React.NamedExoticComponent<
         }
       }
     },
-    [
-      endInputRaw,
-      endCommittedValue,
-      closePopover,
-      startDate,
-      onChange,
-      isOpen,
-    ],
+    [commitEndValue, closePopover, isOpen],
   );
 
   // Called by base-ui when the popover opens or closes (e.g. click outside, Escape).
@@ -308,7 +315,11 @@ export const DateRangeInputField: React.NamedExoticComponent<
         stopStartEditing();
         setActiveBoundary("end");
         endInputRef.current?.focus();
-      } else if (newStart != null && newEnd != null && shouldCloseOnSelection) {
+      } else if (
+        newStart != null
+        && newEnd != null
+        && shouldCloseOnSelection
+      ) {
         // Full range selected — close and blur.
         closePopover();
       } else if (newStart != null && newEnd != null) {
@@ -425,8 +436,7 @@ export const DateRangeInputField: React.NamedExoticComponent<
           className={classnames(
             commonStyles.osdkDatePickerInputWrapper,
             styles.osdkDateRangeInputWrapper,
-            (startInvalid || hasOverlapError)
-              && commonStyles.osdkDatePickerInputWrapperError,
+            startInvalid && commonStyles.osdkDatePickerInputWrapperError,
           )}
         >
           <Input
@@ -448,8 +458,7 @@ export const DateRangeInputField: React.NamedExoticComponent<
           className={classnames(
             commonStyles.osdkDatePickerInputWrapper,
             styles.osdkDateRangeInputWrapper,
-            (endInvalid || hasOverlapError)
-              && commonStyles.osdkDatePickerInputWrapperError,
+            endInvalid && commonStyles.osdkDatePickerInputWrapperError,
           )}
         >
           <Input
@@ -505,3 +514,14 @@ export const DateRangeInputField: React.NamedExoticComponent<
     </Popover.Root>
   );
 });
+
+/** True when the end boundary is before (or same-day when disallowed) the start. */
+function isOverlapping(
+  start: Date | null | undefined,
+  end: Date | null | undefined,
+  allowSingleDayRange: boolean,
+): boolean {
+  if (start == null || end == null) return false;
+  if (!allowSingleDayRange && end.getTime() === start.getTime()) return true;
+  return end.getTime() < start.getTime();
+}

--- a/packages/react-components/src/action-form/fields/DateRangeInputField.tsx
+++ b/packages/react-components/src/action-form/fields/DateRangeInputField.tsx
@@ -86,15 +86,36 @@ export const DateRangeInputField: React.NamedExoticComponent<
   const parseFn = parseDate
     ?? (showTime ? parseDatetimeFromInput : parseDateFromInput);
 
+  // Wrap onChange to handle tuple construction and overlap rejection.
+  // Clearing (null) is always allowed; overlap is checked for non-null dates.
+  const startOnChange = useCallback(
+    (date: Date | null) => {
+      if (date != null && isOverlapping(date, endDate, allowSingleDayRange)) {
+        return;
+      }
+      onChange?.([date, endDate ?? null]);
+    },
+    [endDate, onChange, allowSingleDayRange],
+  );
+
+  const endOnChange = useCallback(
+    (date: Date | null) => {
+      if (date != null && isOverlapping(startDate, date, allowSingleDayRange)) {
+        return;
+      }
+      onChange?.([startDate ?? null, date]);
+    },
+    [startDate, onChange, allowSingleDayRange],
+  );
+
   const {
     isEditing: isEditingStart,
-    inputValue: startInputRaw,
     dateValue: startParsedValue,
     inputError: startInputError,
-    validatedDate: startCommittedValue,
     displayedValue: displayedStart,
     startEditing: beginStartEditing,
     stopEditing: stopStartEditing,
+    commitAndStopEditing: commitStartAndStopEditing,
     setInputValue: setStartInputValue,
     setDateValue: setStartDateValue,
   } = useDateEditState({
@@ -104,16 +125,16 @@ export const DateRangeInputField: React.NamedExoticComponent<
     parseFn,
     min,
     max,
+    onChange: startOnChange,
   });
   const {
     isEditing: isEditingEnd,
-    inputValue: endInputRaw,
     dateValue: endParsedValue,
     inputError: endInputError,
-    validatedDate: endCommittedValue,
     displayedValue: displayedEnd,
     startEditing: beginEndEditing,
     stopEditing: stopEndEditing,
+    commitAndStopEditing: commitEndAndStopEditing,
     setInputValue: setEndInputValue,
     setDateValue: setEndDateValue,
   } = useDateEditState({
@@ -123,6 +144,7 @@ export const DateRangeInputField: React.NamedExoticComponent<
     parseFn,
     min,
     max,
+    onChange: endOnChange,
   });
 
   // --- Cross-input error: overlapping range (live feedback while typing) ---
@@ -156,48 +178,6 @@ export const DateRangeInputField: React.NamedExoticComponent<
     setIsOpen(true);
   }, [beginEndEditing]);
 
-  // --- Commit helpers ---
-  // Shared by blur and Enter handlers. Commits the edited value if valid
-  // and non-overlapping, or silently reverts by skipping the onChange call.
-
-  const commitStartValue = useCallback(() => {
-    if (startInputRaw === "") {
-      onChange?.([null, endDate ?? null]);
-    } else if (
-      startCommittedValue != null
-      && !isOverlapping(startCommittedValue, endDate, allowSingleDayRange)
-    ) {
-      onChange?.([startCommittedValue, endDate ?? null]);
-    }
-    stopStartEditing();
-  }, [
-    startInputRaw,
-    startCommittedValue,
-    stopStartEditing,
-    endDate,
-    onChange,
-    allowSingleDayRange,
-  ]);
-
-  const commitEndValue = useCallback(() => {
-    if (endInputRaw === "") {
-      onChange?.([startDate ?? null, null]);
-    } else if (
-      endCommittedValue != null
-      && !isOverlapping(startDate, endCommittedValue, allowSingleDayRange)
-    ) {
-      onChange?.([startDate ?? null, endCommittedValue]);
-    }
-    stopEndEditing();
-  }, [
-    endInputRaw,
-    endCommittedValue,
-    stopEndEditing,
-    startDate,
-    onChange,
-    allowSingleDayRange,
-  ]);
-
   // --- Blur handlers ---
 
   const handleStartBlur = useCallback(
@@ -212,9 +192,9 @@ export const DateRangeInputField: React.NamedExoticComponent<
       if (endInputRef.current === related) {
         return;
       }
-      commitStartValue();
+      commitStartAndStopEditing();
     },
-    [commitStartValue],
+    [commitStartAndStopEditing],
   );
 
   const handleEndBlur = useCallback(
@@ -227,9 +207,9 @@ export const DateRangeInputField: React.NamedExoticComponent<
       if (startInputRef.current === related) {
         return;
       }
-      commitEndValue();
+      commitEndAndStopEditing();
     },
-    [commitEndValue],
+    [commitEndAndStopEditing],
   );
 
   // --- Popover helpers ---
@@ -250,7 +230,7 @@ export const DateRangeInputField: React.NamedExoticComponent<
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === "Enter") {
         e.preventDefault();
-        commitStartValue();
+        commitStartAndStopEditing();
         // Auto-advance to end
         endInputRef.current?.focus();
       } else if (e.key === "Escape") {
@@ -260,14 +240,14 @@ export const DateRangeInputField: React.NamedExoticComponent<
         setIsOpen(false);
       }
     },
-    [commitStartValue, closePopover],
+    [commitStartAndStopEditing, closePopover],
   );
 
   const handleEndKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === "Enter") {
         e.preventDefault();
-        commitEndValue();
+        commitEndAndStopEditing();
         closePopover();
       } else if (e.key === "Escape") {
         e.preventDefault();
@@ -285,7 +265,7 @@ export const DateRangeInputField: React.NamedExoticComponent<
         }
       }
     },
-    [commitEndValue, closePopover, isOpen],
+    [commitEndAndStopEditing, closePopover, isOpen],
   );
 
   // Called by base-ui when the popover opens or closes (e.g. click outside, Escape).

--- a/packages/react-components/src/action-form/fields/DatetimePickerField.tsx
+++ b/packages/react-components/src/action-form/fields/DatetimePickerField.tsx
@@ -67,12 +67,11 @@ export const DatetimePickerField: React.NamedExoticComponent<
     ?? (showTime ? parseDatetimeFromInput : parseDateFromInput);
 
   const {
-    inputValue,
     displayedValue,
     inputError,
-    validatedDate,
     startEditing,
     stopEditing,
+    commitAndStopEditing,
     setInputValue,
     setDateValue,
   } = useDateEditState({
@@ -82,6 +81,7 @@ export const DatetimePickerField: React.NamedExoticComponent<
     parseFn,
     min,
     max,
+    onChange,
   });
 
   // --- Input event handlers ---
@@ -93,8 +93,6 @@ export const DatetimePickerField: React.NamedExoticComponent<
 
   const handleBlur = useCallback(
     (e: React.FocusEvent<HTMLInputElement>) => {
-      // If focus moved to the popover (e.g. clicking a calendar day), skip —
-      // the calendar's onSelect handler owns the onChange call in that case.
       const relatedTarget = e.relatedTarget ?? document.activeElement;
       if (popoverRef.current?.contains(relatedTarget as Node)) {
         // Focus moved into the popover portal (e.g. clicking a calendar day).
@@ -103,18 +101,15 @@ export const DatetimePickerField: React.NamedExoticComponent<
         e.stopPropagation();
         return;
       }
-      if (inputValue === "") {
-        onChange?.(null);
-      } else if (validatedDate != null) {
-        onChange?.(validatedDate);
-      }
-      stopEditing();
+      commitAndStopEditing();
     },
-    [inputValue, validatedDate, stopEditing, onChange],
+    [commitAndStopEditing],
   );
 
   // Shared close sequence: dismiss the popover, reset editing state, and
   // blur the input so focus doesn't linger after the calendar disappears.
+  // Uses stopEditing (not commitAndStopEditing) to avoid double-firing
+  // onChange when called from calendar-select or after Enter already committed.
   const closePopover = useCallback(() => {
     setIsOpen(false);
     stopEditing();
@@ -125,12 +120,9 @@ export const DatetimePickerField: React.NamedExoticComponent<
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === "Enter") {
         e.preventDefault();
-        if (inputValue === "") {
-          onChange?.(null);
-        } else if (validatedDate != null) {
-          onChange?.(validatedDate);
-        }
-        closePopover();
+        commitAndStopEditing();
+        setIsOpen(false);
+        inputRef.current?.blur();
       } else if (e.key === "Escape") {
         e.preventDefault();
         closePopover();
@@ -149,7 +141,7 @@ export const DatetimePickerField: React.NamedExoticComponent<
         setIsOpen(false);
       }
     },
-    [inputValue, validatedDate, closePopover, isOpen, onChange],
+    [commitAndStopEditing, closePopover, isOpen],
   );
 
   // --- Popover handlers ---

--- a/packages/react-components/src/action-form/fields/useDateEditState.ts
+++ b/packages/react-components/src/action-form/fields/useDateEditState.ts
@@ -37,13 +37,17 @@ export interface UseDateEditStateConfig {
   min?: Date;
   /** Latest selectable date (inclusive). */
   max?: Date;
+  /**
+   * Called by `commitAndStopEditing` with the validated date, or null when the
+   * field is cleared. Not called when the input is invalid (silent revert) or
+   * when `stopEditing` is used directly (Escape/cancel).
+   */
+  onChange?: (date: Date | null) => void;
 }
 
 export interface UseDateEditState {
   /** Whether the user is currently typing in the input. */
   isEditing: boolean;
-  /** The raw text in the input during editing. */
-  inputValue: string;
   /** The value to show in the input: raw text when editing, formatted date otherwise. */
   displayedValue: string;
   /** Validation error for the current input text: null when valid or not editing. */
@@ -54,17 +58,12 @@ export interface UseDateEditState {
    * Used for cross-input validation (e.g. DateRangeInputField's overlapping check).
    */
   dateValue: Date | undefined;
-  /**
-   * The validated date ready to commit on blur/Enter: the parsed date when valid
-   * and in range, null otherwise (invalid, out-of-range, or empty input).
-   * Callers use this directly in blur/Enter handlers instead of manually checking
-   * dateValue + inputError.
-   */
-  validatedDate: Date | null;
   /** Enter editing mode: sets isEditing=true and populates inputValue from the current value. */
   startEditing: () => void;
-  /** Exit editing mode without committing. */
+  /** Exit editing mode without committing (Escape/cancel). */
   stopEditing: () => void;
+  /** Commit the current input via onChange, then exit editing mode (blur/Enter). */
+  commitAndStopEditing: () => void;
   /** Update the raw input text (stable useState setter). */
   setInputValue: (value: string) => void;
   /**
@@ -88,6 +87,7 @@ export function useDateEditState({
   parseFn,
   min,
   max,
+  onChange,
 }: UseDateEditStateConfig): UseDateEditState {
   const [isEditing, setIsEditing] = useState(false);
   const [inputValue, setInputValue] = useState("");
@@ -145,15 +145,31 @@ export function useDateEditState({
     setDateValue(value);
   }, [value, setDateValue]);
 
+  // Refs so commitAndStopEditing reads the latest derived values without
+  // closing over inputValue/validatedDate (which change every keystroke).
+  const inputValueRef = useRef(inputValue);
+  inputValueRef.current = inputValue;
+  const validatedDateRef = useRef(validatedDate);
+  validatedDateRef.current = validatedDate;
+
+  const commitAndStopEditing = useCallback(() => {
+    if (inputValueRef.current === "") {
+      onChange?.(null);
+    } else if (validatedDateRef.current != null) {
+      onChange?.(validatedDateRef.current);
+    }
+    setIsEditing(false);
+    setDateValue(value);
+  }, [onChange, setDateValue, value]);
+
   return {
     isEditing,
-    inputValue,
     displayedValue,
     inputError,
     dateValue,
-    validatedDate,
     startEditing,
     stopEditing,
+    commitAndStopEditing,
     setInputValue,
     setDateValue,
   };

--- a/packages/react-components/src/action-form/fields/useDateEditState.ts
+++ b/packages/react-components/src/action-form/fields/useDateEditState.ts
@@ -128,25 +128,22 @@ export function useDateEditState({
     ? dateValue
     : null;
 
-  const startEditing = useCallback(() => {
-    setIsEditing(true);
-    setInputValue(value != null ? editFormatFn(value) : "");
-  }, [value, editFormatFn]);
-
-  const stopEditing = useCallback(() => {
-    setIsEditing(false);
-    // Reset inputValue to match the committed value so re-entering editing
-    // mode doesn't cause a controlled-input value mismatch that can swallow
-    // the first keystroke (e.g. backspace after an invalid-input revert).
-    setInputValue(value != null ? editFormatFn(value) : "");
-  }, [value, editFormatFn]);
-
   const setDateValue = useCallback(
     (date: Date | null) => {
       setInputValue(date != null ? editFormatFn(date) : "");
     },
     [editFormatFn],
   );
+
+  const startEditing = useCallback(() => {
+    setIsEditing(true);
+    setDateValue(value);
+  }, [value, setDateValue]);
+
+  const stopEditing = useCallback(() => {
+    setIsEditing(false);
+    setDateValue(value);
+  }, [value, setDateValue]);
 
   return {
     isEditing,

--- a/packages/react-components/src/action-form/fields/useDateEditState.ts
+++ b/packages/react-components/src/action-form/fields/useDateEditState.ts
@@ -135,7 +135,11 @@ export function useDateEditState({
 
   const stopEditing = useCallback(() => {
     setIsEditing(false);
-  }, []);
+    // Reset inputValue to match the committed value so re-entering editing
+    // mode doesn't cause a controlled-input value mismatch that can swallow
+    // the first keystroke (e.g. backspace after an invalid-input revert).
+    setInputValue(value != null ? editFormatFn(value) : "");
+  }, [value, editFormatFn]);
 
   const setDateValue = useCallback(
     (date: Date | null) => {


### PR DESCRIPTION
## Summary
- Prevent committing overlapping date ranges (end < start) in `DateRangeInputField` — blur/Enter handlers reject overlapping values and revert to the previous committed date (Blueprint-style)
- Fix backspace not responding after invalid input revert by resetting `inputValue` in `useDateEditState.stopEditing`
- Extract `commitStartValue`/`commitEndValue` helpers to deduplicate commit logic across blur and Enter handlers
- Extract `isOverlapping` helper for reuse across render-time feedback and commit guards

## Test plan
- [x] `pnpm turbo test --filter=@osdk/react-components` — tests pass
- [x] Manual: type end date before start, blur — input reverts
- [x] Manual: type invalid date, blur, refocus, press backspace — input responds