### PR TITLE
Add turbo watch to peopleapp + storybook dev script

### DIFF
--- a/.changeset/fuzzy-moose-grin.md
+++ b/.changeset/fuzzy-moose-grin.md
@@ -1,6 +1,2 @@
 ---
-"@osdk/e2e.sandbox.peopleapp": patch
-"@osdk/react-components-storybook": patch
 ---
-
-Add turbo watch to dev scripts for automatic upstream rebuilds

--- a/.changeset/fuzzy-moose-grin.md
+++ b/.changeset/fuzzy-moose-grin.md
@@ -1,0 +1,6 @@
+---
+"@osdk/e2e.sandbox.peopleapp": patch
+"@osdk/react-components-storybook": patch
+---
+
+Add turbo watch to dev scripts for automatic upstream rebuilds

--- a/packages/e2e.sandbox.peopleapp/package.json
+++ b/packages/e2e.sandbox.peopleapp/package.json
@@ -29,7 +29,7 @@
     "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
     "codegen": "rm -rf src/generatedNoCheck2/* &&  osdk-unstable-typescript generate --outDir src/generatedNoCheck2 --ontologyPath ontology.json --version dev --internal --packageType module",
     "codegen-from-server": "rm -rf src/generatedNoCheck2/* && osdk-unstable-typescript generate --stack ${FOUNDRY_URL} --clientId ${FOUNDRY_CLIENT_ID} --outDir src/generatedNoCheck2 --ontologyWritePath ontology.json --version dev --internal --beta --packageType module",
-    "dev": "pnpm turbo watch transpileBrowser --filter='@osdk/e2e.sandbox.peopleapp^...' & vite",
+    "dev": "trap 'kill 0' EXIT; pnpm turbo watch transpileBrowser --filter='@osdk/e2e.sandbox.peopleapp^...' & vite",
     "fix-lint": "eslint . --fix && dprint fmt --config $(find-up dprint.json)",
     "lint": "eslint . && dprint check  --config $(find-up dprint.json)",
     "preview": "vite preview",

--- a/packages/e2e.sandbox.peopleapp/package.json
+++ b/packages/e2e.sandbox.peopleapp/package.json
@@ -29,7 +29,7 @@
     "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
     "codegen": "rm -rf src/generatedNoCheck2/* &&  osdk-unstable-typescript generate --outDir src/generatedNoCheck2 --ontologyPath ontology.json --version dev --internal --packageType module",
     "codegen-from-server": "rm -rf src/generatedNoCheck2/* && osdk-unstable-typescript generate --stack ${FOUNDRY_URL} --clientId ${FOUNDRY_CLIENT_ID} --outDir src/generatedNoCheck2 --ontologyWritePath ontology.json --version dev --internal --beta --packageType module",
-    "dev": "vite",
+    "dev": "pnpm turbo watch transpileBrowser --filter='@osdk/e2e.sandbox.peopleapp^...' & vite",
     "fix-lint": "eslint . --fix && dprint fmt --config $(find-up dprint.json)",
     "lint": "eslint . && dprint check  --config $(find-up dprint.json)",
     "preview": "vite preview",

--- a/packages/e2e.sandbox.peopleapp/vite.config.mts
+++ b/packages/e2e.sandbox.peopleapp/vite.config.mts
@@ -19,6 +19,9 @@ export default defineConfig(({ mode }) => {
     ],
     server: {
       port: 8080,
+      hmr: {
+        overlay: false,
+      },
       proxy: {
         "/api/v2/ontologySubscriptions": {
           ws: true,

--- a/packages/e2e.sandbox.peopleapp/vite.config.mts
+++ b/packages/e2e.sandbox.peopleapp/vite.config.mts
@@ -19,6 +19,9 @@ export default defineConfig(({ mode }) => {
     ],
     server: {
       port: 8080,
+      // Turbo watch rebuilds upstream packages on change, which briefly
+      // produces incomplete builds that Vite picks up as errors. The overlay
+      // flashes on every rebuild cycle, so we disable it.
       hmr: {
         overlay: false,
       },

--- a/packages/react-components-storybook/.storybook/main.ts
+++ b/packages/react-components-storybook/.storybook/main.ts
@@ -69,6 +69,14 @@ const config: StorybookConfig = {
       global: "globalThis",
     };
 
+    // Turbo watch rebuilds upstream packages on change, which briefly
+    // produces incomplete builds that Vite picks up as errors. The overlay
+    // flashes on every rebuild cycle, so we disable it.
+    config.server = {
+      ...config.server,
+      hmr: { overlay: false },
+    };
+
     // Configure build options
     config.build = {
       ...config.build,

--- a/packages/react-components-storybook/package.json
+++ b/packages/react-components-storybook/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "storybook build",
-    "dev": "storybook dev -p 6006",
+    "dev": "trap 'kill 0' EXIT; pnpm turbo watch transpileBrowser --filter='@osdk/react-components-storybook^...' & storybook dev -p 6006",
     "fix-lint": "eslint . --fix && dprint fmt --config $(find-up dprint.json)",
     "lint": "eslint . && dprint check --config $(find-up dprint.json)",
     "transpileAllDeps": "pnpm --filter @osdk/* transpileBrowser",


### PR DESCRIPTION
## Summary
- Adds `turbo watch transpileBrowser` to `dev` scripts in peopleapp and storybook so upstream package changes are automatically rebuilt during local development
- Disables the Vite HMR error overlay in both apps — turbo watch rebuilds briefly produce incomplete builds that Vite picks up as errors, causing the overlay to flash on every cycle
- Uses `trap 'kill 0' EXIT` to cleanly kill the turbo watch process when the dev server exits

## Important
Updates aren't instant, unlike what we have [here](https://github.com/palantir/osdk-ts/pull/2984). But at least we're using the build outputs like our users would. Couldn't find a quick way to make this smoother, punting for now.

## Test plan
- [x] Run `pnpm dev` in peopleapp and verify turbo watch starts alongside vite
- [x] Run `pnpm dev` in react-components-storybook and verify turbo watch starts alongside storybook
- [x] Edit an upstream package and verify the change is picked up without manual rebuild
- [x] Ctrl+C the dev server and verify the turbo watch process is also killed