### PR TITLE
Pass cross-filter whereClause to DateRange and NumberRange filter inputs

### DIFF
--- a/.changeset/clever-owls-beam.md
+++ b/.changeset/clever-owls-beam.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Pass cross-filter whereClause to DateRange and NumberRange filter inputs so histograms and null counts update when other filters are applied

--- a/packages/react-components/src/filter-list/__tests__/DateRangeFilterInput.test.tsx
+++ b/packages/react-components/src/filter-list/__tests__/DateRangeFilterInput.test.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { WhereClause } from "@osdk/api";
+import { useOsdkAggregation } from "@osdk/react/experimental";
+import { cleanup, render } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DateRangeFilterInput } from "../inputs/DateRangeFilterInput.js";
+import { MockObjectType } from "./testUtils.js";
+
+vi.mock("@osdk/react/experimental", () => ({
+  useOsdkAggregation: vi.fn().mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("DateRangeFilterInput", () => {
+  it("passes whereClause to the histogram aggregation query", () => {
+    const whereClause = { name: "Engineering" } as WhereClause<
+      typeof MockObjectType
+    >;
+
+    render(
+      <DateRangeFilterInput
+        objectType={MockObjectType}
+        propertyKey="createdAt"
+        filterState={undefined}
+        onFilterStateChanged={vi.fn()}
+        whereClause={whereClause}
+      />,
+    );
+
+    const calls = vi.mocked(useOsdkAggregation).mock.calls;
+    // Find the histogram call by its $groupBy aggregate shape
+    const histogramCall = calls.find(
+      (c) => (c[1].aggregate as Record<string, unknown>).$groupBy != null,
+    );
+    expect(histogramCall).toBeDefined();
+    expect(histogramCall![1]).toHaveProperty("where", whereClause);
+  });
+
+  it("combines whereClause with null-check in the null count query", () => {
+    const whereClause = { name: "Engineering" } as WhereClause<
+      typeof MockObjectType
+    >;
+
+    render(
+      <DateRangeFilterInput
+        objectType={MockObjectType}
+        propertyKey="createdAt"
+        filterState={undefined}
+        onFilterStateChanged={vi.fn()}
+        whereClause={whereClause}
+      />,
+    );
+
+    const calls = vi.mocked(useOsdkAggregation).mock.calls;
+    // Find the null count call by its lack of $groupBy
+    const nullCountCall = calls.find(
+      (c) => (c[1].aggregate as Record<string, unknown>).$groupBy == null,
+    );
+    expect(nullCountCall).toBeDefined();
+    const nullCountWhere = nullCountCall![1].where;
+
+    expect(nullCountWhere).toHaveProperty("$and");
+    const andClauses = (nullCountWhere as { $and: unknown[] }).$and;
+    expect(andClauses).toContainEqual({ createdAt: { $isNull: true } });
+    expect(andClauses).toContainEqual(whereClause);
+  });
+});

--- a/packages/react-components/src/filter-list/__tests__/NumberRangeFilterInput.test.tsx
+++ b/packages/react-components/src/filter-list/__tests__/NumberRangeFilterInput.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { WhereClause } from "@osdk/api";
+import { useOsdkAggregation } from "@osdk/react/experimental";
+import { cleanup, render } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NumberRangeFilterInput } from "../inputs/NumberRangeFilterInput.js";
+import { MockObjectType } from "./testUtils.js";
+
+vi.mock("@osdk/react/experimental", () => ({
+  useOsdkAggregation: vi.fn().mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("NumberRangeFilterInput", () => {
+  it("passes whereClause to the histogram aggregation query", () => {
+    const whereClause = { name: "Engineering" } as WhereClause<
+      typeof MockObjectType
+    >;
+
+    render(
+      <NumberRangeFilterInput
+        objectType={MockObjectType}
+        propertyKey="score"
+        filterState={undefined}
+        onFilterStateChanged={vi.fn()}
+        whereClause={whereClause}
+      />,
+    );
+
+    const calls = vi.mocked(useOsdkAggregation).mock.calls;
+    const histogramCall = calls.find(
+      (c) => (c[1].aggregate as Record<string, unknown>).$groupBy != null,
+    );
+    expect(histogramCall).toBeDefined();
+    expect(histogramCall![1]).toHaveProperty("where", whereClause);
+  });
+
+  it("combines whereClause with null-check in the null count query", () => {
+    const whereClause = { name: "Engineering" } as WhereClause<
+      typeof MockObjectType
+    >;
+
+    render(
+      <NumberRangeFilterInput
+        objectType={MockObjectType}
+        propertyKey="score"
+        filterState={undefined}
+        onFilterStateChanged={vi.fn()}
+        whereClause={whereClause}
+      />,
+    );
+
+    const calls = vi.mocked(useOsdkAggregation).mock.calls;
+    const nullCountCall = calls.find(
+      (c) => (c[1].aggregate as Record<string, unknown>).$groupBy == null,
+    );
+    expect(nullCountCall).toBeDefined();
+    const nullCountWhere = nullCountCall![1].where;
+
+    expect(nullCountWhere).toHaveProperty("$and");
+    const andClauses = (nullCountWhere as { $and: unknown[] }).$and;
+    expect(andClauses).toContainEqual({ score: { $isNull: true } });
+    expect(andClauses).toContainEqual(whereClause);
+  });
+});

--- a/packages/react-components/src/filter-list/inputs/DateRangeFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/DateRangeFilterInput.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ObjectSet, ObjectTypeDefinition } from "@osdk/api";
+import type { ObjectSet, ObjectTypeDefinition, WhereClause } from "@osdk/api";
 import { useOsdkAggregation } from "@osdk/react/experimental";
 import React, { memo, useCallback, useMemo } from "react";
 import { DateRangeInput } from "../base/inputs/DateRangeInput.js";
@@ -32,6 +32,7 @@ interface DateRangeFilterInputProps<Q extends ObjectTypeDefinition> {
   propertyKey: string;
   filterState: FilterState | undefined;
   onFilterStateChanged: (state: FilterState) => void;
+  whereClause: WhereClause<Q>;
 }
 
 function DateRangeFilterInputInner<Q extends ObjectTypeDefinition>({
@@ -40,6 +41,7 @@ function DateRangeFilterInputInner<Q extends ObjectTypeDefinition>({
   propertyKey,
   filterState,
   onFilterStateChanged,
+  whereClause,
 }: DateRangeFilterInputProps<Q>): React.ReactElement {
   const dateRangeState = filterState?.type === "DATE_RANGE"
     ? filterState
@@ -78,9 +80,9 @@ function DateRangeFilterInputInner<Q extends ObjectTypeDefinition>({
   const histogramArgs = useMemo(
     () =>
       objectSet != null
-        ? { aggregate: aggregateOptions, objectSet }
-        : { aggregate: aggregateOptions },
-    [aggregateOptions, objectSet],
+        ? { aggregate: aggregateOptions, objectSet, where: whereClause }
+        : { aggregate: aggregateOptions, where: whereClause },
+    [aggregateOptions, objectSet, whereClause],
   );
 
   const { data: aggregateData, isLoading: histLoading } = useOsdkAggregation(
@@ -115,21 +117,29 @@ function DateRangeFilterInputInner<Q extends ObjectTypeDefinition>({
     [],
   );
 
-  const nullWhereClause = useMemo(
-    () => createNullWhereClause<Q>(propertyKey),
-    [propertyKey],
+  // Combine null-check with cross-filter where clause so the null count
+  // reflects the filtered dataset, not the full dataset
+  const nullCountWhereClause = useMemo(
+    () =>
+      ({
+        $and: [createNullWhereClause<Q>(propertyKey), whereClause],
+      }) as WhereClause<Q>,
+    [propertyKey, whereClause],
   );
 
   const nullCountArgs = useMemo(
     () =>
       objectSet != null
         ? {
-          where: nullWhereClause,
+          where: nullCountWhereClause,
           aggregate: nullCountAggregateOptions,
           objectSet,
         }
-        : { where: nullWhereClause, aggregate: nullCountAggregateOptions },
-    [nullWhereClause, nullCountAggregateOptions, objectSet],
+        : {
+          where: nullCountWhereClause,
+          aggregate: nullCountAggregateOptions,
+        },
+    [nullCountWhereClause, nullCountAggregateOptions, objectSet],
   );
 
   const {

--- a/packages/react-components/src/filter-list/inputs/NumberRangeFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/NumberRangeFilterInput.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ObjectSet, ObjectTypeDefinition } from "@osdk/api";
+import type { ObjectSet, ObjectTypeDefinition, WhereClause } from "@osdk/api";
 import { useOsdkAggregation } from "@osdk/react/experimental";
 import React, { memo, useCallback, useMemo } from "react";
 import { NullValueWrapper } from "../base/inputs/NullValueWrapper.js";
@@ -32,6 +32,7 @@ interface NumberRangeFilterInputProps<Q extends ObjectTypeDefinition> {
   propertyKey: string;
   filterState: FilterState | undefined;
   onFilterStateChanged: (state: FilterState) => void;
+  whereClause: WhereClause<Q>;
 }
 
 function NumberRangeFilterInputInner<Q extends ObjectTypeDefinition>({
@@ -40,6 +41,7 @@ function NumberRangeFilterInputInner<Q extends ObjectTypeDefinition>({
   propertyKey,
   filterState,
   onFilterStateChanged,
+  whereClause,
 }: NumberRangeFilterInputProps<Q>): React.ReactElement {
   const numberRangeState = filterState?.type === "NUMBER_RANGE"
     ? filterState
@@ -82,9 +84,9 @@ function NumberRangeFilterInputInner<Q extends ObjectTypeDefinition>({
   const histogramArgs = useMemo(
     () =>
       objectSet != null
-        ? { aggregate: aggregateOptions, objectSet }
-        : { aggregate: aggregateOptions },
-    [aggregateOptions, objectSet],
+        ? { aggregate: aggregateOptions, objectSet, where: whereClause }
+        : { aggregate: aggregateOptions, where: whereClause },
+    [aggregateOptions, objectSet, whereClause],
   );
 
   const { data: aggregateData, isLoading: histLoading } = useOsdkAggregation(
@@ -119,21 +121,29 @@ function NumberRangeFilterInputInner<Q extends ObjectTypeDefinition>({
     [],
   );
 
-  const nullWhereClause = useMemo(
-    () => createNullWhereClause<Q>(propertyKey),
-    [propertyKey],
+  // Combine null-check with cross-filter where clause so the null count
+  // reflects the filtered dataset, not the full dataset
+  const nullCountWhereClause = useMemo(
+    () =>
+      ({
+        $and: [createNullWhereClause<Q>(propertyKey), whereClause],
+      }) as WhereClause<Q>,
+    [propertyKey, whereClause],
   );
 
   const nullCountArgs = useMemo(
     () =>
       objectSet != null
         ? {
-          where: nullWhereClause,
+          where: nullCountWhereClause,
           aggregate: nullCountAggregateOptions,
           objectSet,
         }
-        : { where: nullWhereClause, aggregate: nullCountAggregateOptions },
-    [nullWhereClause, nullCountAggregateOptions, objectSet],
+        : {
+          where: nullCountWhereClause,
+          aggregate: nullCountAggregateOptions,
+        },
+    [nullCountWhereClause, nullCountAggregateOptions, objectSet],
   );
 
   const {

--- a/packages/react-components/src/filter-list/inputs/PropertyFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/PropertyFilterInput.tsx
@@ -84,6 +84,7 @@ function PropertyFilterInputInner<Q extends ObjectTypeDefinition>({
           propertyKey={definition.key}
           filterState={filterState}
           onFilterStateChanged={onFilterStateChanged}
+          whereClause={whereClause}
         />
       );
 
@@ -95,6 +96,7 @@ function PropertyFilterInputInner<Q extends ObjectTypeDefinition>({
           propertyKey={definition.key}
           filterState={filterState}
           onFilterStateChanged={onFilterStateChanged}
+          whereClause={whereClause}
         />
       );
 


### PR DESCRIPTION
## Summary

- DateRangeFilterInput and NumberRangeFilterInput did not receive the cross-filter `whereClause`, so their histograms and null counts always showed unfiltered data
- Thread `whereClause` through PropertyFilterInput into both components
- Histogram aggregation queries now include the cross-filter where clause
- Null count queries combine `$isNull` with the cross-filter where clause via `$and`

## Test plan

- [x] New tests for DateRangeFilterInput verify whereClause flows to histogram and null count queries
- [x] New tests for NumberRangeFilterInput verify the same
- [x] Storybook: selecting a department filter should update date/number histograms and null counts