### PR TITLE
[FilterList] Add STATIC_VALUES filter definition type

### DIFF
--- a/.changeset/static-values-filter.md
+++ b/.changeset/static-values-filter.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+Add STATIC_VALUES filter definition type for providing fixed value lists without OSDK aggregation

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
@@ -19,6 +19,7 @@ import { FilterList, ObjectTable } from "@osdk/react-components/experimental";
 import type {
   FilterDefinitionUnion,
   FilterListProps,
+  FilterState,
 } from "@osdk/react-components/experimental";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useCallback, useMemo, useState } from "react";
@@ -1075,6 +1076,154 @@ const handleFilterRemoved = (filterKey) => {
     },
   },
   render: (args) => <WithRemovableFiltersStory {...args} />,
+};
+
+function WithStaticValuesStory(args: Partial<EmployeeFilterListProps>) {
+  const [filterClause, setFilterClause] = useState<
+    WhereClause<Employee> | undefined
+  >(undefined);
+
+  const filterDefinitions = useMemo(
+    (): FilterDefinitionUnion<Employee>[] => [
+      {
+        type: "STATIC_VALUES",
+        key: "department",
+        label: "Department (static)",
+        filterComponent: "LISTOGRAM",
+        values: ["Marketing", "Operations", "Finance", "Product"],
+        filterState: { type: "EXACT_MATCH", values: [] },
+        listogramConfig: { displayMode: "minimal" },
+      } as FilterDefinitionUnion<Employee>,
+      {
+        type: "STATIC_VALUES",
+        key: "locationCity",
+        label: "Office Location",
+        filterComponent: "SINGLE_SELECT",
+        values: ["New York", "San Francisco", "London", "Tokyo"],
+        filterState: { type: "SELECT", selectedValues: [] },
+      } as FilterDefinitionUnion<Employee>,
+      {
+        type: "STATIC_VALUES",
+        key: "team",
+        label: "Team (multi-select)",
+        filterComponent: "MULTI_SELECT",
+        values: ["Alpha", "Beta", "Gamma", "Delta"],
+        filterState: { type: "SELECT", selectedValues: [] },
+      } as FilterDefinitionUnion<Employee>,
+      {
+        type: "STATIC_VALUES",
+        id: "custom-status",
+        key: "status",
+        label: "Status (custom clause)",
+        filterComponent: "LISTOGRAM",
+        values: ["Active", "Inactive"],
+        filterState: { type: "EXACT_MATCH", values: [] },
+        listogramConfig: { displayMode: "minimal" },
+        toWhereClause: (state: FilterState) => {
+          if (state.type !== "EXACT_MATCH" || state.values.length === 0) {
+            return undefined;
+          }
+          const values = state.values as string[];
+          if (values.includes("Active") && !values.includes("Inactive")) {
+            return { employeeStatus: "Active" } as WhereClause<Employee>;
+          }
+          if (values.includes("Inactive") && !values.includes("Active")) {
+            return { employeeStatus: "Inactive" } as WhereClause<Employee>;
+          }
+          return undefined;
+        },
+      } as FilterDefinitionUnion<Employee>,
+    ],
+    [],
+  );
+
+  return (
+    <div style={FLEX_ROW_STYLE}>
+      <div style={SIDEBAR_STYLE}>
+        <FilterList
+          objectType={Employee}
+          filterDefinitions={filterDefinitions}
+          filterClause={filterClause}
+          onFilterClauseChanged={setFilterClause}
+          {...args}
+        />
+      </div>
+      <div style={FLEX_FILL_STYLE}>
+        <strong>Filter Clause (JSON):</strong>
+        <pre style={PRE_STYLE}>
+          {filterClause
+            ? JSON.stringify(filterClause, null, 2)
+            : "(no active filters)"}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+export const WithStaticValues: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use `STATIC_VALUES` filter definitions to provide a fixed list of values "
+          + "instead of fetching from OSDK aggregation. Supports LISTOGRAM, SINGLE_SELECT, "
+          + "MULTI_SELECT, and TEXT_TAGS components. Optionally provide a `toWhereClause` "
+          + "function for custom clause generation.",
+      },
+      source: {
+        code: `const filterDefinitions = [
+  {
+    type: "STATIC_VALUES",
+    key: "department",
+    label: "Department",
+    filterComponent: "LISTOGRAM",
+    values: ["Marketing", "Operations", "Finance", "Product"],
+    filterState: { type: "EXACT_MATCH", values: [] },
+    listogramConfig: { displayMode: "minimal" },
+  },
+  {
+    type: "STATIC_VALUES",
+    key: "locationCity",
+    label: "Office Location",
+    filterComponent: "SINGLE_SELECT",
+    values: ["New York", "San Francisco", "London", "Tokyo"],
+    filterState: { type: "SELECT", selectedValues: [] },
+  },
+  {
+    type: "STATIC_VALUES",
+    key: "team",
+    label: "Team",
+    filterComponent: "MULTI_SELECT",
+    values: ["Alpha", "Beta", "Gamma", "Delta"],
+    filterState: { type: "SELECT", selectedValues: [] },
+  },
+  {
+    type: "STATIC_VALUES",
+    key: "status",
+    label: "Status",
+    filterComponent: "LISTOGRAM",
+    values: ["Active", "Inactive"],
+    filterState: { type: "EXACT_MATCH", values: [] },
+    toWhereClause: (state) => {
+      // Custom WHERE clause mapping
+      if (state.type === "EXACT_MATCH" && state.values.includes("Active")) {
+        return { employeeStatus: "Active" };
+      }
+      return undefined;
+    },
+  },
+];
+
+<FilterList
+  objectType={Employee}
+  filterDefinitions={filterDefinitions}
+  filterClause={filterClause}
+  onFilterClauseChanged={setFilterClause}
+/>`,
+      },
+    },
+  },
+  render: (args) => <WithStaticValuesStory {...args} />,
 };
 
 function FullFeaturedStory(

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
@@ -1124,10 +1124,20 @@ function WithStaticValuesStory(args: Partial<EmployeeFilterListProps>) {
             return undefined;
           }
           const values = state.values as string[];
-          if (values.includes("Active") && !values.includes("Inactive")) {
+          const hasActive = values.includes("Active");
+          const hasInactive = values.includes("Inactive");
+          if (hasActive && hasInactive) {
+            return {
+              $or: [
+                { employeeStatus: "Active" },
+                { employeeStatus: "Inactive" },
+              ],
+            } as WhereClause<Employee>;
+          }
+          if (hasActive) {
             return { employeeStatus: "Active" } as WhereClause<Employee>;
           }
-          if (values.includes("Inactive") && !values.includes("Active")) {
+          if (hasInactive) {
             return { employeeStatus: "Inactive" } as WhereClause<Employee>;
           }
           return undefined;

--- a/packages/react-components/src/filter-list/FilterInput.tsx
+++ b/packages/react-components/src/filter-list/FilterInput.tsx
@@ -22,6 +22,7 @@ import type { FilterDefinitionUnion } from "./FilterListApi.js";
 import type { FilterState } from "./FilterListItemApi.js";
 import { LinkedPropertyInput } from "./inputs/LinkedPropertyInput.js";
 import { PropertyFilterInput } from "./inputs/PropertyFilterInput.js";
+import { StaticValuesFilterInput } from "./inputs/StaticValuesFilterInput.js";
 
 interface FilterInputProps<Q extends ObjectTypeDefinition> {
   objectType: Q;
@@ -133,6 +134,17 @@ function FilterInputContent<Q extends ObjectTypeDefinition>({
           filterState={filterState}
           onFilterStateChanged={onFilterStateChanged}
           whereClause={whereClause}
+          searchQuery={searchQuery}
+          excludeRowOpen={excludeRowOpen}
+        />
+      );
+
+    case "STATIC_VALUES":
+      return (
+        <StaticValuesFilterInput
+          definition={definition}
+          filterState={filterState}
+          onFilterStateChanged={onFilterStateChanged}
           searchQuery={searchQuery}
           excludeRowOpen={excludeRowOpen}
         />

--- a/packages/react-components/src/filter-list/FilterListApi.ts
+++ b/packages/react-components/src/filter-list/FilterListApi.ts
@@ -32,6 +32,7 @@ import type {
   HasLinkFilterDefinition,
   LinkedPropertyFilterDefinition,
 } from "./types/LinkedFilterTypes.js";
+import type { StaticValuesFilterDefinition } from "./types/StaticValuesTypes.js";
 
 /**
  * Union type of all filter definition types
@@ -41,7 +42,8 @@ export type FilterDefinitionUnion<Q extends ObjectTypeDefinition> =
   | HasLinkFilterDefinition<Q>
   | LinkedPropertyFilterDefinition<Q, LinkNames<Q>>
   | KeywordSearchFilterDefinition<Q>
-  | CustomFilterDefinition<Q>;
+  | CustomFilterDefinition<Q>
+  | StaticValuesFilterDefinition<Q>;
 
 /**
  * Extract the key from a filter definition union

--- a/packages/react-components/src/filter-list/__tests__/filterStateToWhereClause.test.ts
+++ b/packages/react-components/src/filter-list/__tests__/filterStateToWhereClause.test.ts
@@ -540,6 +540,20 @@ describe("buildWhereClause", () => {
     expect(result).toEqual({ team: { $in: ["Alpha", "Beta"] } });
   });
 
+  it("builds $in for STATIC_VALUES TEXT_TAGS", () => {
+    const def = createStaticValuesFilterDef(
+      "tags",
+      "TEXT_TAGS",
+      ["urgent", "blocked", "ready"],
+      { type: "EXACT_MATCH", values: [] },
+    );
+    const filterStates = stateMap(
+      [def, { type: "EXACT_MATCH", values: ["urgent", "blocked"] }],
+    );
+    const result = buildWhereClause([def], filterStates);
+    expect(result).toEqual({ tags: { $in: ["urgent", "blocked"] } });
+  });
+
   it("calls toWhereClause for STATIC_VALUES when provided", () => {
     const def = createStaticValuesFilterDef(
       "status",

--- a/packages/react-components/src/filter-list/__tests__/filterStateToWhereClause.test.ts
+++ b/packages/react-components/src/filter-list/__tests__/filterStateToWhereClause.test.ts
@@ -29,6 +29,7 @@ import {
   createNumberRangeState,
   createPropertyFilterDef,
   createSelectState,
+  createStaticValuesFilterDef,
   createToggleState,
 } from "./testUtils.js";
 
@@ -451,6 +452,134 @@ describe("buildWhereClause", () => {
     );
     const result = buildWhereClause([def], filterStates);
     expect(result).toEqual({ name: { $isNull: true } });
+  });
+
+  // --- STATIC_VALUES filter tests ---
+
+  it("builds $in clause for STATIC_VALUES with EXACT_MATCH", () => {
+    const def = createStaticValuesFilterDef(
+      "status",
+      "LISTOGRAM",
+      ["Active", "Inactive"],
+      { type: "EXACT_MATCH", values: [] },
+    );
+    const filterStates = stateMap(
+      [def, { type: "EXACT_MATCH", values: ["Active", "Inactive"] }],
+    );
+    const result = buildWhereClause([def], filterStates);
+    expect(result).toEqual({ status: { $in: ["Active", "Inactive"] } });
+  });
+
+  it("builds single value clause for STATIC_VALUES with one selected", () => {
+    const def = createStaticValuesFilterDef(
+      "status",
+      "LISTOGRAM",
+      ["Active", "Inactive"],
+      { type: "EXACT_MATCH", values: [] },
+    );
+    const filterStates = stateMap(
+      [def, { type: "EXACT_MATCH", values: ["Active"] }],
+    );
+    const result = buildWhereClause([def], filterStates);
+    expect(result).toEqual({ status: "Active" });
+  });
+
+  it("returns empty object for STATIC_VALUES with no selections", () => {
+    const def = createStaticValuesFilterDef(
+      "status",
+      "LISTOGRAM",
+      ["Active", "Inactive"],
+      { type: "EXACT_MATCH", values: [] },
+    );
+    const filterStates = stateMap(
+      [def, { type: "EXACT_MATCH", values: [] }],
+    );
+    const result = buildWhereClause([def], filterStates);
+    expect(result).toEqual({});
+  });
+
+  it("wraps with $not for STATIC_VALUES with isExcluding", () => {
+    const def = createStaticValuesFilterDef(
+      "status",
+      "LISTOGRAM",
+      ["Active", "Inactive"],
+      { type: "EXACT_MATCH", values: [] },
+    );
+    const filterStates = stateMap(
+      [def, { type: "EXACT_MATCH", values: ["Active"], isExcluding: true }],
+    );
+    const result = buildWhereClause([def], filterStates);
+    expect(result).toEqual({ $not: { status: "Active" } });
+  });
+
+  it("builds SELECT clause for STATIC_VALUES SINGLE_SELECT", () => {
+    const def = createStaticValuesFilterDef(
+      "priority",
+      "SINGLE_SELECT",
+      ["High", "Medium", "Low"],
+      { type: "SELECT", selectedValues: [] },
+    );
+    const filterStates = stateMap(
+      [def, createSelectState(["High"])],
+    );
+    const result = buildWhereClause([def], filterStates);
+    expect(result).toEqual({ priority: "High" });
+  });
+
+  it("builds $in for STATIC_VALUES MULTI_SELECT", () => {
+    const def = createStaticValuesFilterDef(
+      "team",
+      "MULTI_SELECT",
+      ["Alpha", "Beta", "Gamma"],
+      { type: "SELECT", selectedValues: [] },
+    );
+    const filterStates = stateMap(
+      [def, createSelectState(["Alpha", "Beta"])],
+    );
+    const result = buildWhereClause([def], filterStates);
+    expect(result).toEqual({ team: { $in: ["Alpha", "Beta"] } });
+  });
+
+  it("calls toWhereClause for STATIC_VALUES when provided", () => {
+    const def = createStaticValuesFilterDef(
+      "status",
+      "LISTOGRAM",
+      ["Yes", "No"],
+      { type: "EXACT_MATCH", values: [] },
+      {
+        toWhereClause: (state) => {
+          if (
+            state.type === "EXACT_MATCH"
+            && (state.values as string[]).includes("Yes")
+          ) {
+            return { active: true };
+          }
+          return undefined;
+        },
+      },
+    );
+    const filterStates = stateMap(
+      [def, { type: "EXACT_MATCH", values: ["Yes"] }],
+    );
+    const result = buildWhereClause([def], filterStates);
+    expect(result).toEqual({ active: true });
+  });
+
+  it("returns empty for STATIC_VALUES toWhereClause returning undefined", () => {
+    const def = createStaticValuesFilterDef(
+      "status",
+      "LISTOGRAM",
+      ["Yes", "No"],
+      { type: "EXACT_MATCH", values: [] },
+      {
+        toWhereClause: () => undefined,
+      },
+    );
+    const filterStates = stateMap(
+      [def, { type: "EXACT_MATCH", values: ["Yes"] }],
+    );
+    const result = buildWhereClause([def], filterStates);
+    expect(result).toEqual({});
   });
 
   it("preserves state when filters are reordered", () => {

--- a/packages/react-components/src/filter-list/__tests__/getFilterKey.test.ts
+++ b/packages/react-components/src/filter-list/__tests__/getFilterKey.test.ts
@@ -24,6 +24,7 @@ import {
   createKeywordSearchFilterDef,
   createLinkedPropertyFilterDef,
   createPropertyFilterDef,
+  createStaticValuesFilterDef,
 } from "./testUtils.js";
 
 describe("getFilterKey", () => {
@@ -71,5 +72,28 @@ describe("getFilterKey", () => {
   it("returns key for custom filter", () => {
     const definition = createCustomFilterDef("myCustomFilter");
     expect(getFilterKey(definition)).toBe("myCustomFilter");
+  });
+
+  it("returns key for static values filter", () => {
+    const definition = createStaticValuesFilterDef(
+      "status",
+      "LISTOGRAM",
+      ["Active", "Inactive"],
+      { type: "EXACT_MATCH", values: [] },
+    );
+    expect(getFilterKey(definition)).toBe("status");
+  });
+
+  it("returns id over key for static values filter when id is set", () => {
+    const definition = {
+      ...createStaticValuesFilterDef(
+        "status",
+        "LISTOGRAM",
+        ["Active", "Inactive"],
+        { type: "EXACT_MATCH", values: [] },
+      ),
+      id: "status-filter-1",
+    } as FilterDefinitionUnion<typeof MockObjectType>;
+    expect(getFilterKey(definition)).toBe("status-filter-1");
   });
 });

--- a/packages/react-components/src/filter-list/__tests__/testUtils.ts
+++ b/packages/react-components/src/filter-list/__tests__/testUtils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ObjectTypeDefinition } from "@osdk/api";
+import type { ObjectTypeDefinition, WhereClause } from "@osdk/api";
 import type { FilterDefinitionUnion } from "../FilterListApi.js";
 import type {
   ContainsTextFilterState,
@@ -214,7 +214,9 @@ export function createStaticValuesFilterDef(
   values: string[],
   filterState: FilterState,
   options?: {
-    toWhereClause?: (state: FilterState) => Record<string, unknown> | undefined;
+    toWhereClause?: (
+      state: FilterState,
+    ) => WhereClause<typeof MockObjectType> | undefined;
   },
 ): FilterDefinitionUnion<typeof MockObjectType> {
   return {

--- a/packages/react-components/src/filter-list/__tests__/testUtils.ts
+++ b/packages/react-components/src/filter-list/__tests__/testUtils.ts
@@ -25,6 +25,7 @@ import type {
   SelectFilterState,
   ToggleFilterState,
 } from "../FilterListItemApi.js";
+import type { StaticValuesComponentType } from "../types/StaticValuesTypes.js";
 
 export const MockObjectType = {
   apiName: "TestObject",
@@ -202,4 +203,26 @@ export function createDateRangeState(
     includeNull: options?.includeNull,
     isExcluding: options?.isExcluding,
   };
+}
+
+/**
+ * Create a static values filter definition for testing
+ */
+export function createStaticValuesFilterDef(
+  key: string,
+  filterComponent: StaticValuesComponentType,
+  values: string[],
+  filterState: FilterState,
+  options?: {
+    toWhereClause?: (state: FilterState) => Record<string, unknown> | undefined;
+  },
+): FilterDefinitionUnion<typeof MockObjectType> {
+  return {
+    type: "STATIC_VALUES",
+    key,
+    filterComponent,
+    values,
+    filterState,
+    toWhereClause: options?.toWhereClause,
+  } as FilterDefinitionUnion<typeof MockObjectType>;
 }

--- a/packages/react-components/src/filter-list/hooks/useFilterListState.ts
+++ b/packages/react-components/src/filter-list/hooks/useFilterListState.ts
@@ -73,6 +73,13 @@ function buildInitialStates<Q extends ObjectTypeDefinition>(
         }
         break;
       }
+      case "STATIC_VALUES": {
+        const state = definition.filterState;
+        if (state) {
+          states.set(key, state);
+        }
+        break;
+      }
       case "LINKED_PROPERTY": {
         const innerState = definition.defaultLinkedFilterState;
         if (innerState) {

--- a/packages/react-components/src/filter-list/inputs/StaticValuesFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/StaticValuesFilterInput.tsx
@@ -16,6 +16,7 @@
 
 import type { ObjectTypeDefinition } from "@osdk/api";
 import React, { memo, useCallback, useMemo } from "react";
+import { assertUnreachable } from "../../shared/assertUnreachable.js";
 import { FilterInputExcludeRow } from "../base/FilterInputExcludeRow.js";
 import { ListogramInput } from "../base/inputs/ListogramInput.js";
 import { MultiSelectInput } from "../base/inputs/MultiSelectInput.js";
@@ -255,6 +256,9 @@ function StaticValuesFilterInputInner<Q extends ObjectTypeDefinition>({
           />
         </FilterInputExcludeRow>
       );
+
+    default:
+      return assertUnreachable(definition.filterComponent);
   }
 }
 

--- a/packages/react-components/src/filter-list/inputs/StaticValuesFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/StaticValuesFilterInput.tsx
@@ -30,10 +30,15 @@ import {
 } from "../utils/coerceFilterValue.js";
 
 interface StaticValuesFilterInputProps<Q extends ObjectTypeDefinition> {
+  /** The static values filter definition containing values and component config */
   definition: StaticValuesFilterDefinition<Q>;
+  /** Current filter state, or undefined if no selection has been made */
   filterState: FilterState | undefined;
+  /** Callback fired when the user changes the filter selection */
   onFilterStateChanged: (state: FilterState) => void;
+  /** Search term for filtering displayed values within the filter input */
   searchQuery?: string;
+  /** Whether the exclude/include toggle row is expanded */
   excludeRowOpen?: boolean;
 }
 

--- a/packages/react-components/src/filter-list/inputs/StaticValuesFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/StaticValuesFilterInput.tsx
@@ -1,0 +1,388 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectTypeDefinition } from "@osdk/api";
+import React, { memo, useCallback, useMemo } from "react";
+import { FilterInputExcludeRow } from "../base/FilterInputExcludeRow.js";
+import { ListogramInput } from "../base/inputs/ListogramInput.js";
+import { MultiSelectInput } from "../base/inputs/MultiSelectInput.js";
+import { SingleSelectInput } from "../base/inputs/SingleSelectInput.js";
+import { TextTagsInput } from "../base/inputs/TextTagsInput.js";
+import type { FilterState } from "../FilterListItemApi.js";
+import type { PropertyAggregationValue } from "../types/AggregationTypes.js";
+import type { StaticValuesFilterDefinition } from "../types/StaticValuesTypes.js";
+import {
+  coerceToString,
+  coerceToStringArray,
+} from "../utils/coerceFilterValue.js";
+
+interface StaticValuesFilterInputProps<Q extends ObjectTypeDefinition> {
+  definition: StaticValuesFilterDefinition<Q>;
+  filterState: FilterState | undefined;
+  onFilterStateChanged: (state: FilterState) => void;
+  searchQuery?: string;
+  excludeRowOpen?: boolean;
+}
+
+function StaticValuesFilterInputInner<Q extends ObjectTypeDefinition>({
+  definition,
+  filterState,
+  onFilterStateChanged,
+  searchQuery,
+  excludeRowOpen,
+}: StaticValuesFilterInputProps<Q>): React.ReactElement {
+  const aggregationValues: PropertyAggregationValue[] = useMemo(
+    () => definition.values.map((value) => ({ value, count: 0 })),
+    [definition.values],
+  );
+
+  const isExcluding = filterState?.isExcluding ?? false;
+
+  switch (definition.filterComponent) {
+    case "LISTOGRAM":
+      return (
+        <StaticListogramInput
+          values={aggregationValues}
+          filterState={filterState}
+          onFilterStateChanged={onFilterStateChanged}
+          isExcluding={isExcluding}
+          colorMap={definition.colorMap}
+          displayMode={definition.listogramConfig?.displayMode}
+          maxVisibleItems={definition.listogramConfig?.maxVisibleItems ?? 5}
+          searchQuery={searchQuery}
+          excludeRowOpen={excludeRowOpen}
+          renderValue={definition.renderValue}
+        />
+      );
+
+    case "SINGLE_SELECT":
+      return (
+        <StaticSingleSelectInput
+          values={aggregationValues}
+          filterState={filterState}
+          onFilterStateChanged={onFilterStateChanged}
+          isExcluding={isExcluding}
+          excludeRowOpen={excludeRowOpen}
+          filterKey={definition.key}
+          renderValue={definition.renderValue}
+        />
+      );
+
+    case "MULTI_SELECT":
+      return (
+        <StaticMultiSelectInput
+          values={aggregationValues}
+          filterState={filterState}
+          onFilterStateChanged={onFilterStateChanged}
+          isExcluding={isExcluding}
+          excludeRowOpen={excludeRowOpen}
+          filterKey={definition.key}
+          renderValue={definition.renderValue}
+        />
+      );
+
+    case "TEXT_TAGS":
+      return (
+        <StaticTextTagsInput
+          values={aggregationValues}
+          filterState={filterState}
+          onFilterStateChanged={onFilterStateChanged}
+          isExcluding={isExcluding}
+          excludeRowOpen={excludeRowOpen}
+        />
+      );
+  }
+}
+
+export const StaticValuesFilterInput: typeof StaticValuesFilterInputInner =
+  memo(
+    StaticValuesFilterInputInner,
+  ) as typeof StaticValuesFilterInputInner;
+
+// --- Sub-components for each filter component type ---
+
+interface StaticListogramInputProps {
+  values: PropertyAggregationValue[];
+  filterState: FilterState | undefined;
+  onFilterStateChanged: (state: FilterState) => void;
+  isExcluding: boolean;
+  colorMap?: Record<string, string>;
+  displayMode?: "full" | "count" | "minimal";
+  maxVisibleItems: number;
+  searchQuery?: string;
+  excludeRowOpen?: boolean;
+  renderValue?: (value: string) => string;
+}
+
+const StaticListogramInput = memo(function StaticListogramInput({
+  values,
+  filterState,
+  onFilterStateChanged,
+  isExcluding,
+  colorMap,
+  displayMode,
+  maxVisibleItems,
+  searchQuery,
+  excludeRowOpen,
+  renderValue,
+}: StaticListogramInputProps): React.ReactElement {
+  const selectedValues = useMemo(
+    () =>
+      filterState?.type === "EXACT_MATCH"
+        ? coerceToStringArray(filterState.values)
+        : [],
+    [filterState],
+  );
+
+  const handleClearAll = useCallback(() => {
+    onFilterStateChanged({
+      type: "EXACT_MATCH",
+      values: [],
+      isExcluding,
+    });
+  }, [onFilterStateChanged, isExcluding]);
+
+  const handleChange = useCallback(
+    (values: string[]) => {
+      onFilterStateChanged({
+        type: "EXACT_MATCH",
+        values,
+        isExcluding,
+      });
+    },
+    [onFilterStateChanged, isExcluding],
+  );
+
+  return (
+    <FilterInputExcludeRow
+      excludeRowOpen={excludeRowOpen}
+      filterState={filterState}
+      onFilterStateChanged={onFilterStateChanged}
+      totalValueCount={values.length}
+      onClearAll={handleClearAll}
+    >
+      <ListogramInput
+        values={values}
+        maxCount={0}
+        isLoading={false}
+        error={null}
+        selectedValues={selectedValues}
+        onChange={handleChange}
+        colorMap={colorMap}
+        displayMode={displayMode}
+        isExcluding={isExcluding}
+        maxVisibleItems={maxVisibleItems}
+        searchQuery={searchQuery}
+        renderValue={renderValue}
+      />
+    </FilterInputExcludeRow>
+  );
+});
+
+interface StaticSingleSelectInputProps {
+  values: PropertyAggregationValue[];
+  filterState: FilterState | undefined;
+  onFilterStateChanged: (state: FilterState) => void;
+  isExcluding: boolean;
+  excludeRowOpen?: boolean;
+  filterKey: string;
+  renderValue?: (value: string) => string;
+}
+
+const StaticSingleSelectInput = memo(function StaticSingleSelectInput({
+  values,
+  filterState,
+  onFilterStateChanged,
+  isExcluding,
+  excludeRowOpen,
+  filterKey,
+  renderValue,
+}: StaticSingleSelectInputProps): React.ReactElement {
+  const selectedValue = useMemo(
+    () =>
+      filterState?.type === "SELECT"
+        ? coerceToString(filterState.selectedValues[0])
+        : undefined,
+    [filterState],
+  );
+
+  const handleClearAll = useCallback(() => {
+    onFilterStateChanged({
+      type: "SELECT",
+      selectedValues: [],
+      isExcluding,
+    });
+  }, [onFilterStateChanged, isExcluding]);
+
+  const handleChange = useCallback(
+    (value: string | undefined) => {
+      onFilterStateChanged({
+        type: "SELECT",
+        selectedValues: value !== undefined ? [value] : [],
+        isExcluding,
+      });
+    },
+    [onFilterStateChanged, isExcluding],
+  );
+
+  return (
+    <FilterInputExcludeRow
+      excludeRowOpen={excludeRowOpen}
+      filterState={filterState}
+      onFilterStateChanged={onFilterStateChanged}
+      totalValueCount={values.length}
+      onClearAll={handleClearAll}
+    >
+      <SingleSelectInput
+        values={values}
+        isLoading={false}
+        error={null}
+        selectedValue={selectedValue}
+        onChange={handleChange}
+        ariaLabel={`Select ${filterKey}`}
+        renderValue={renderValue}
+      />
+    </FilterInputExcludeRow>
+  );
+});
+
+interface StaticMultiSelectInputProps {
+  values: PropertyAggregationValue[];
+  filterState: FilterState | undefined;
+  onFilterStateChanged: (state: FilterState) => void;
+  isExcluding: boolean;
+  excludeRowOpen?: boolean;
+  filterKey: string;
+  renderValue?: (value: string) => string;
+}
+
+const StaticMultiSelectInput = memo(function StaticMultiSelectInput({
+  values,
+  filterState,
+  onFilterStateChanged,
+  isExcluding,
+  excludeRowOpen,
+  filterKey,
+  renderValue,
+}: StaticMultiSelectInputProps): React.ReactElement {
+  const selectedValues = useMemo(
+    () =>
+      filterState?.type === "SELECT"
+        ? coerceToStringArray(filterState.selectedValues)
+        : [],
+    [filterState],
+  );
+
+  const handleClearAll = useCallback(() => {
+    onFilterStateChanged({
+      type: "SELECT",
+      selectedValues: [],
+      isExcluding,
+    });
+  }, [onFilterStateChanged, isExcluding]);
+
+  const handleChange = useCallback(
+    (selectedValues: string[]) => {
+      onFilterStateChanged({
+        type: "SELECT",
+        selectedValues,
+        isExcluding,
+      });
+    },
+    [onFilterStateChanged, isExcluding],
+  );
+
+  return (
+    <FilterInputExcludeRow
+      excludeRowOpen={excludeRowOpen}
+      filterState={filterState}
+      onFilterStateChanged={onFilterStateChanged}
+      totalValueCount={values.length}
+      onClearAll={handleClearAll}
+    >
+      <MultiSelectInput
+        values={values}
+        isLoading={false}
+        error={null}
+        selectedValues={selectedValues}
+        onChange={handleChange}
+        ariaLabel={`Search ${filterKey} values`}
+        renderValue={renderValue}
+      />
+    </FilterInputExcludeRow>
+  );
+});
+
+interface StaticTextTagsInputProps {
+  values: PropertyAggregationValue[];
+  filterState: FilterState | undefined;
+  onFilterStateChanged: (state: FilterState) => void;
+  isExcluding: boolean;
+  excludeRowOpen?: boolean;
+}
+
+const StaticTextTagsInput = memo(function StaticTextTagsInput({
+  values,
+  filterState,
+  onFilterStateChanged,
+  isExcluding,
+  excludeRowOpen,
+}: StaticTextTagsInputProps): React.ReactElement {
+  const tags = useMemo(
+    () =>
+      filterState?.type === "EXACT_MATCH"
+        ? coerceToStringArray(filterState.values)
+        : [],
+    [filterState],
+  );
+
+  const handleClearAll = useCallback(() => {
+    onFilterStateChanged({
+      type: "EXACT_MATCH",
+      values: [],
+      isExcluding,
+    });
+  }, [onFilterStateChanged, isExcluding]);
+
+  const handleChange = useCallback(
+    (values: string[]) => {
+      onFilterStateChanged({
+        type: "EXACT_MATCH",
+        values,
+        isExcluding,
+      });
+    },
+    [onFilterStateChanged, isExcluding],
+  );
+
+  return (
+    <FilterInputExcludeRow
+      excludeRowOpen={excludeRowOpen}
+      filterState={filterState}
+      onFilterStateChanged={onFilterStateChanged}
+      totalValueCount={values.length}
+      onClearAll={handleClearAll}
+    >
+      <TextTagsInput
+        suggestions={values}
+        isLoading={false}
+        error={null}
+        tags={tags}
+        onChange={handleChange}
+      />
+    </FilterInputExcludeRow>
+  );
+});

--- a/packages/react-components/src/filter-list/inputs/StaticValuesFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/StaticValuesFilterInput.tsx
@@ -37,108 +37,14 @@ interface StaticValuesFilterInputProps<Q extends ObjectTypeDefinition> {
   excludeRowOpen?: boolean;
 }
 
-function StaticValuesFilterInputInner<Q extends ObjectTypeDefinition>({
-  definition,
-  filterState,
-  onFilterStateChanged,
-  searchQuery,
-  excludeRowOpen,
-}: StaticValuesFilterInputProps<Q>): React.ReactElement {
-  const aggregationValues: PropertyAggregationValue[] = useMemo(
-    () => definition.values.map((value) => ({ value, count: 0 })),
-    [definition.values],
-  );
-
-  const isExcluding = filterState?.isExcluding ?? false;
-
-  switch (definition.filterComponent) {
-    case "LISTOGRAM":
-      return (
-        <StaticListogramInput
-          values={aggregationValues}
-          filterState={filterState}
-          onFilterStateChanged={onFilterStateChanged}
-          isExcluding={isExcluding}
-          colorMap={definition.colorMap}
-          displayMode={definition.listogramConfig?.displayMode}
-          maxVisibleItems={definition.listogramConfig?.maxVisibleItems ?? 5}
-          searchQuery={searchQuery}
-          excludeRowOpen={excludeRowOpen}
-          renderValue={definition.renderValue}
-        />
-      );
-
-    case "SINGLE_SELECT":
-      return (
-        <StaticSingleSelectInput
-          values={aggregationValues}
-          filterState={filterState}
-          onFilterStateChanged={onFilterStateChanged}
-          isExcluding={isExcluding}
-          excludeRowOpen={excludeRowOpen}
-          filterKey={definition.key}
-          renderValue={definition.renderValue}
-        />
-      );
-
-    case "MULTI_SELECT":
-      return (
-        <StaticMultiSelectInput
-          values={aggregationValues}
-          filterState={filterState}
-          onFilterStateChanged={onFilterStateChanged}
-          isExcluding={isExcluding}
-          excludeRowOpen={excludeRowOpen}
-          filterKey={definition.key}
-          renderValue={definition.renderValue}
-        />
-      );
-
-    case "TEXT_TAGS":
-      return (
-        <StaticTextTagsInput
-          values={aggregationValues}
-          filterState={filterState}
-          onFilterStateChanged={onFilterStateChanged}
-          isExcluding={isExcluding}
-          excludeRowOpen={excludeRowOpen}
-        />
-      );
-  }
-}
-
-export const StaticValuesFilterInput: typeof StaticValuesFilterInputInner =
-  memo(
-    StaticValuesFilterInputInner,
-  ) as typeof StaticValuesFilterInputInner;
-
-// --- Sub-components for each filter component type ---
-
-interface StaticListogramInputProps {
-  values: PropertyAggregationValue[];
-  filterState: FilterState | undefined;
-  onFilterStateChanged: (state: FilterState) => void;
-  isExcluding: boolean;
-  colorMap?: Record<string, string>;
-  displayMode?: "full" | "count" | "minimal";
-  maxVisibleItems: number;
-  searchQuery?: string;
-  excludeRowOpen?: boolean;
-  renderValue?: (value: string) => string;
-}
-
-const StaticListogramInput = memo(function StaticListogramInput({
-  values,
-  filterState,
-  onFilterStateChanged,
-  isExcluding,
-  colorMap,
-  displayMode,
-  maxVisibleItems,
-  searchQuery,
-  excludeRowOpen,
-  renderValue,
-}: StaticListogramInputProps): React.ReactElement {
+/**
+ * Hooks for EXACT_MATCH state management (used by LISTOGRAM and TEXT_TAGS).
+ */
+function useExactMatchState(
+  filterState: FilterState | undefined,
+  onFilterStateChanged: (state: FilterState) => void,
+  isExcluding: boolean,
+) {
   const selectedValues = useMemo(
     () =>
       filterState?.type === "EXACT_MATCH"
@@ -166,51 +72,17 @@ const StaticListogramInput = memo(function StaticListogramInput({
     [onFilterStateChanged, isExcluding],
   );
 
-  return (
-    <FilterInputExcludeRow
-      excludeRowOpen={excludeRowOpen}
-      filterState={filterState}
-      onFilterStateChanged={onFilterStateChanged}
-      totalValueCount={values.length}
-      onClearAll={handleClearAll}
-    >
-      <ListogramInput
-        values={values}
-        maxCount={0}
-        isLoading={false}
-        error={null}
-        selectedValues={selectedValues}
-        onChange={handleChange}
-        colorMap={colorMap}
-        displayMode={displayMode}
-        isExcluding={isExcluding}
-        maxVisibleItems={maxVisibleItems}
-        searchQuery={searchQuery}
-        renderValue={renderValue}
-      />
-    </FilterInputExcludeRow>
-  );
-});
-
-interface StaticSingleSelectInputProps {
-  values: PropertyAggregationValue[];
-  filterState: FilterState | undefined;
-  onFilterStateChanged: (state: FilterState) => void;
-  isExcluding: boolean;
-  excludeRowOpen?: boolean;
-  filterKey: string;
-  renderValue?: (value: string) => string;
+  return { selectedValues, handleClearAll, handleChange };
 }
 
-const StaticSingleSelectInput = memo(function StaticSingleSelectInput({
-  values,
-  filterState,
-  onFilterStateChanged,
-  isExcluding,
-  excludeRowOpen,
-  filterKey,
-  renderValue,
-}: StaticSingleSelectInputProps): React.ReactElement {
+/**
+ * Hooks for SELECT state management (used by SINGLE_SELECT and MULTI_SELECT).
+ */
+function useSelectState(
+  filterState: FilterState | undefined,
+  onFilterStateChanged: (state: FilterState) => void,
+  isExcluding: boolean,
+) {
   const selectedValue = useMemo(
     () =>
       filterState?.type === "SELECT"
@@ -219,65 +91,6 @@ const StaticSingleSelectInput = memo(function StaticSingleSelectInput({
     [filterState],
   );
 
-  const handleClearAll = useCallback(() => {
-    onFilterStateChanged({
-      type: "SELECT",
-      selectedValues: [],
-      isExcluding,
-    });
-  }, [onFilterStateChanged, isExcluding]);
-
-  const handleChange = useCallback(
-    (value: string | undefined) => {
-      onFilterStateChanged({
-        type: "SELECT",
-        selectedValues: value !== undefined ? [value] : [],
-        isExcluding,
-      });
-    },
-    [onFilterStateChanged, isExcluding],
-  );
-
-  return (
-    <FilterInputExcludeRow
-      excludeRowOpen={excludeRowOpen}
-      filterState={filterState}
-      onFilterStateChanged={onFilterStateChanged}
-      totalValueCount={values.length}
-      onClearAll={handleClearAll}
-    >
-      <SingleSelectInput
-        values={values}
-        isLoading={false}
-        error={null}
-        selectedValue={selectedValue}
-        onChange={handleChange}
-        ariaLabel={`Select ${filterKey}`}
-        renderValue={renderValue}
-      />
-    </FilterInputExcludeRow>
-  );
-});
-
-interface StaticMultiSelectInputProps {
-  values: PropertyAggregationValue[];
-  filterState: FilterState | undefined;
-  onFilterStateChanged: (state: FilterState) => void;
-  isExcluding: boolean;
-  excludeRowOpen?: boolean;
-  filterKey: string;
-  renderValue?: (value: string) => string;
-}
-
-const StaticMultiSelectInput = memo(function StaticMultiSelectInput({
-  values,
-  filterState,
-  onFilterStateChanged,
-  isExcluding,
-  excludeRowOpen,
-  filterKey,
-  renderValue,
-}: StaticMultiSelectInputProps): React.ReactElement {
   const selectedValues = useMemo(
     () =>
       filterState?.type === "SELECT"
@@ -294,7 +107,18 @@ const StaticMultiSelectInput = memo(function StaticMultiSelectInput({
     });
   }, [onFilterStateChanged, isExcluding]);
 
-  const handleChange = useCallback(
+  const handleSingleChange = useCallback(
+    (value: string | undefined) => {
+      onFilterStateChanged({
+        type: "SELECT",
+        selectedValues: value !== undefined ? [value] : [],
+        isExcluding,
+      });
+    },
+    [onFilterStateChanged, isExcluding],
+  );
+
+  const handleMultiChange = useCallback(
     (selectedValues: string[]) => {
       onFilterStateChanged({
         type: "SELECT",
@@ -305,84 +129,131 @@ const StaticMultiSelectInput = memo(function StaticMultiSelectInput({
     [onFilterStateChanged, isExcluding],
   );
 
-  return (
-    <FilterInputExcludeRow
-      excludeRowOpen={excludeRowOpen}
-      filterState={filterState}
-      onFilterStateChanged={onFilterStateChanged}
-      totalValueCount={values.length}
-      onClearAll={handleClearAll}
-    >
-      <MultiSelectInput
-        values={values}
-        isLoading={false}
-        error={null}
-        selectedValues={selectedValues}
-        onChange={handleChange}
-        ariaLabel={`Search ${filterKey} values`}
-        renderValue={renderValue}
-      />
-    </FilterInputExcludeRow>
-  );
-});
-
-interface StaticTextTagsInputProps {
-  values: PropertyAggregationValue[];
-  filterState: FilterState | undefined;
-  onFilterStateChanged: (state: FilterState) => void;
-  isExcluding: boolean;
-  excludeRowOpen?: boolean;
+  return {
+    selectedValue,
+    selectedValues,
+    handleClearAll,
+    handleSingleChange,
+    handleMultiChange,
+  };
 }
 
-const StaticTextTagsInput = memo(function StaticTextTagsInput({
-  values,
+function StaticValuesFilterInputInner<Q extends ObjectTypeDefinition>({
+  definition,
   filterState,
   onFilterStateChanged,
-  isExcluding,
+  searchQuery,
   excludeRowOpen,
-}: StaticTextTagsInputProps): React.ReactElement {
-  const tags = useMemo(
-    () =>
-      filterState?.type === "EXACT_MATCH"
-        ? coerceToStringArray(filterState.values)
-        : [],
-    [filterState],
+}: StaticValuesFilterInputProps<Q>): React.ReactElement {
+  const aggregationValues: PropertyAggregationValue[] = useMemo(
+    () => definition.values.map((value) => ({ value, count: 0 })),
+    [definition.values],
   );
 
-  const handleClearAll = useCallback(() => {
-    onFilterStateChanged({
-      type: "EXACT_MATCH",
-      values: [],
-      isExcluding,
-    });
-  }, [onFilterStateChanged, isExcluding]);
+  const isExcluding = filterState?.isExcluding ?? false;
 
-  const handleChange = useCallback(
-    (values: string[]) => {
-      onFilterStateChanged({
-        type: "EXACT_MATCH",
-        values,
-        isExcluding,
-      });
-    },
-    [onFilterStateChanged, isExcluding],
+  const exactMatch = useExactMatchState(
+    filterState,
+    onFilterStateChanged,
+    isExcluding,
+  );
+  const select = useSelectState(
+    filterState,
+    onFilterStateChanged,
+    isExcluding,
   );
 
-  return (
-    <FilterInputExcludeRow
-      excludeRowOpen={excludeRowOpen}
-      filterState={filterState}
-      onFilterStateChanged={onFilterStateChanged}
-      totalValueCount={values.length}
-      onClearAll={handleClearAll}
-    >
-      <TextTagsInput
-        suggestions={values}
-        isLoading={false}
-        error={null}
-        tags={tags}
-        onChange={handleChange}
-      />
-    </FilterInputExcludeRow>
-  );
-});
+  switch (definition.filterComponent) {
+    case "LISTOGRAM":
+      return (
+        <FilterInputExcludeRow
+          excludeRowOpen={excludeRowOpen}
+          filterState={filterState}
+          onFilterStateChanged={onFilterStateChanged}
+          totalValueCount={aggregationValues.length}
+          onClearAll={exactMatch.handleClearAll}
+        >
+          <ListogramInput
+            values={aggregationValues}
+            maxCount={0}
+            isLoading={false}
+            error={null}
+            selectedValues={exactMatch.selectedValues}
+            onChange={exactMatch.handleChange}
+            colorMap={definition.colorMap}
+            displayMode={definition.listogramConfig?.displayMode}
+            isExcluding={isExcluding}
+            maxVisibleItems={definition.listogramConfig?.maxVisibleItems ?? 5}
+            searchQuery={searchQuery}
+            renderValue={definition.renderValue}
+          />
+        </FilterInputExcludeRow>
+      );
+
+    case "SINGLE_SELECT":
+      return (
+        <FilterInputExcludeRow
+          excludeRowOpen={excludeRowOpen}
+          filterState={filterState}
+          onFilterStateChanged={onFilterStateChanged}
+          totalValueCount={aggregationValues.length}
+          onClearAll={select.handleClearAll}
+        >
+          <SingleSelectInput
+            values={aggregationValues}
+            isLoading={false}
+            error={null}
+            selectedValue={select.selectedValue}
+            onChange={select.handleSingleChange}
+            ariaLabel={`Select ${definition.key}`}
+            renderValue={definition.renderValue}
+          />
+        </FilterInputExcludeRow>
+      );
+
+    case "MULTI_SELECT":
+      return (
+        <FilterInputExcludeRow
+          excludeRowOpen={excludeRowOpen}
+          filterState={filterState}
+          onFilterStateChanged={onFilterStateChanged}
+          totalValueCount={aggregationValues.length}
+          onClearAll={select.handleClearAll}
+        >
+          <MultiSelectInput
+            values={aggregationValues}
+            isLoading={false}
+            error={null}
+            selectedValues={select.selectedValues}
+            onChange={select.handleMultiChange}
+            ariaLabel={`Search ${definition.key} values`}
+            renderValue={definition.renderValue}
+          />
+        </FilterInputExcludeRow>
+      );
+
+    case "TEXT_TAGS":
+      return (
+        <FilterInputExcludeRow
+          excludeRowOpen={excludeRowOpen}
+          filterState={filterState}
+          onFilterStateChanged={onFilterStateChanged}
+          totalValueCount={aggregationValues.length}
+          onClearAll={exactMatch.handleClearAll}
+        >
+          <TextTagsInput
+            suggestions={aggregationValues}
+            isLoading={false}
+            error={null}
+            tags={exactMatch.selectedValues}
+            onChange={exactMatch.handleChange}
+          />
+        </FilterInputExcludeRow>
+      );
+  }
+}
+
+export const StaticValuesFilterInput: typeof StaticValuesFilterInputInner =
+  memo(
+    StaticValuesFilterInputInner,
+  ) as typeof StaticValuesFilterInputInner;

--- a/packages/react-components/src/filter-list/types/StaticValuesTypes.ts
+++ b/packages/react-components/src/filter-list/types/StaticValuesTypes.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectTypeDefinition, WhereClause } from "@osdk/api";
+import type {
+  FilterState,
+  FilterStateByComponentType,
+} from "../FilterListItemApi.js";
+
+/**
+ * Component types that support static values.
+ * These components can display a fixed list of string values without OSDK aggregation.
+ */
+export type StaticValuesComponentType =
+  | "LISTOGRAM"
+  | "SINGLE_SELECT"
+  | "MULTI_SELECT"
+  | "TEXT_TAGS";
+
+/**
+ * Filter definition for static (non-OSDK) value lists.
+ * Renders built-in filter components with user-provided values instead of
+ * fetching values via OSDK aggregation queries.
+ */
+export interface StaticValuesFilterDefinition<
+  Q extends ObjectTypeDefinition,
+  C extends StaticValuesComponentType = StaticValuesComponentType,
+> {
+  type: "STATIC_VALUES";
+
+  /**
+   * Optional unique identifier for stable keying across filter reorders.
+   * If provided, takes precedence over `key` for state keying.
+   */
+  id?: string;
+
+  /**
+   * Key used for state management and auto WHERE clause generation.
+   * When `toWhereClause` is not provided, this is used as the property key
+   * in the generated WHERE clause.
+   */
+  key: string;
+
+  /**
+   * Display label for the filter
+   */
+  label?: string;
+
+  /**
+   * The filter component type to render
+   */
+  filterComponent: C;
+
+  /**
+   * The current state of the filter
+   */
+  filterState: FilterStateByComponentType[C];
+
+  /**
+   * The static list of values to display in the filter component.
+   * These are rendered directly without OSDK aggregation.
+   */
+  values: string[];
+
+  /**
+   * Custom display function for filter values.
+   * Replaces the default string display in dropdown items, chips, and listogram rows.
+   */
+  renderValue?: (value: string) => string;
+
+  /**
+   * Maps filter values to colors for visual differentiation.
+   * Used by LISTOGRAM (per-row bar colors).
+   */
+  colorMap?: Record<string, string>;
+
+  /**
+   * Configuration for LISTOGRAM display mode.
+   * Only applies when filterComponent is "LISTOGRAM".
+   */
+  listogramConfig?: {
+    displayMode?: "full" | "count" | "minimal";
+    /**
+     * Number of items shown before "View all" link appears
+     * @default 5
+     */
+    maxVisibleItems?: number;
+  };
+
+  /**
+   * Optional custom WHERE clause generator.
+   * When provided, this is used instead of auto-generating a WHERE clause
+   * from the `key` and filter state.
+   */
+  toWhereClause?: (state: FilterState) => WhereClause<Q> | undefined;
+
+  /**
+   * Controls whether this filter is rendered.
+   * When false, the filter is hidden but its state is preserved.
+   * @default true
+   */
+  isVisible?: boolean;
+}

--- a/packages/react-components/src/filter-list/types/index.ts
+++ b/packages/react-components/src/filter-list/types/index.ts
@@ -17,3 +17,4 @@
 export * from "./CustomRendererTypes.js";
 export * from "./KeywordSearchTypes.js";
 export * from "./LinkedFilterTypes.js";
+export * from "./StaticValuesTypes.js";

--- a/packages/react-components/src/filter-list/utils/filterStateToWhereClause.ts
+++ b/packages/react-components/src/filter-list/utils/filterStateToWhereClause.ts
@@ -382,6 +382,42 @@ export function buildWhereClause<Q extends ObjectTypeDefinition>(
         break;
       }
 
+      case "STATIC_VALUES": {
+        if (definition.toWhereClause) {
+          const staticClause = definition.toWhereClause(state);
+          if (staticClause && Object.keys(staticClause).length > 0) {
+            clauses.push(staticClause as Record<string, unknown>);
+          }
+        } else {
+          const filter = filterStateToPropertyFilter(state);
+          if (filter !== undefined) {
+            const isExcluding = "isExcluding" in state && state.isExcluding;
+            if (isCompoundFilter(filter)) {
+              const fieldClauses = filter.conditions.map(c => ({
+                [definition.key]: c,
+              }));
+              let rangeClause: Record<string, unknown> =
+                fieldClauses.length === 1
+                  ? fieldClauses[0]
+                  : { $and: fieldClauses };
+              if (filter.includeNull) {
+                rangeClause = {
+                  $or: [
+                    rangeClause,
+                    { [definition.key]: { $isNull: true } },
+                  ],
+                };
+              }
+              clauses.push(isExcluding ? { $not: rangeClause } : rangeClause);
+            } else {
+              const clause = { [definition.key]: filter };
+              clauses.push(isExcluding ? { $not: clause } : clause);
+            }
+          }
+        }
+        break;
+      }
+
       default:
         assertUnreachable(definition);
     }

--- a/packages/react-components/src/filter-list/utils/filterStateToWhereClause.ts
+++ b/packages/react-components/src/filter-list/utils/filterStateToWhereClause.ts
@@ -215,6 +215,39 @@ function filterStateToPropertyFilter(
  * cannot verify that the constructed clause structure matches the generic Q's
  * expected shape, but the structure is guaranteed to be valid by construction.
  */
+/**
+ * Builds a WHERE clause fragment for a single property key from filter state.
+ * Shared by PROPERTY and STATIC_VALUES filter types.
+ */
+function buildPropertyKeyClause(
+  key: string,
+  state: FilterState,
+  propertyType?: string,
+): Record<string, unknown> | undefined {
+  const filter = filterStateToPropertyFilter(state, propertyType);
+  if (filter === undefined) {
+    return undefined;
+  }
+  const isExcluding = "isExcluding" in state && state.isExcluding;
+  if (isCompoundFilter(filter)) {
+    const fieldClauses = filter.conditions.map(c => ({
+      [key]: c,
+    }));
+    let rangeClause: Record<string, unknown> = fieldClauses.length === 1
+      ? fieldClauses[0]
+      : { $and: fieldClauses };
+    if (filter.includeNull) {
+      rangeClause = {
+        $or: [rangeClause, { [key]: { $isNull: true } }],
+      };
+    }
+    return isExcluding ? { $not: rangeClause } : rangeClause;
+  } else {
+    const clause = { [key]: filter };
+    return isExcluding ? { $not: clause } : clause;
+  }
+}
+
 export interface PropertyTypeInfo {
   type: string;
   multiplicity: boolean;
@@ -247,26 +280,13 @@ export function buildWhereClause<Q extends ObjectTypeDefinition>(
       case "PROPERTY": {
         const propertyType = propertyTypes?.get(definition.key as string)
           ?.type;
-        const filter = filterStateToPropertyFilter(state, propertyType);
-        if (filter !== undefined) {
-          const isExcluding = "isExcluding" in state && state.isExcluding;
-          if (isCompoundFilter(filter)) {
-            const fieldClauses = filter.conditions.map(c => ({
-              [definition.key]: c,
-            }));
-            let rangeClause: Record<string, unknown> = fieldClauses.length === 1
-              ? fieldClauses[0]
-              : { $and: fieldClauses };
-            if (filter.includeNull) {
-              rangeClause = {
-                $or: [rangeClause, { [definition.key]: { $isNull: true } }],
-              };
-            }
-            clauses.push(isExcluding ? { $not: rangeClause } : rangeClause);
-          } else {
-            const clause = { [definition.key]: filter };
-            clauses.push(isExcluding ? { $not: clause } : clause);
-          }
+        const clause = buildPropertyKeyClause(
+          definition.key as string,
+          state,
+          propertyType,
+        );
+        if (clause !== undefined) {
+          clauses.push(clause);
         }
         break;
       }
@@ -389,30 +409,9 @@ export function buildWhereClause<Q extends ObjectTypeDefinition>(
             clauses.push(staticClause as Record<string, unknown>);
           }
         } else {
-          const filter = filterStateToPropertyFilter(state);
-          if (filter !== undefined) {
-            const isExcluding = "isExcluding" in state && state.isExcluding;
-            if (isCompoundFilter(filter)) {
-              const fieldClauses = filter.conditions.map(c => ({
-                [definition.key]: c,
-              }));
-              let rangeClause: Record<string, unknown> =
-                fieldClauses.length === 1
-                  ? fieldClauses[0]
-                  : { $and: fieldClauses };
-              if (filter.includeNull) {
-                rangeClause = {
-                  $or: [
-                    rangeClause,
-                    { [definition.key]: { $isNull: true } },
-                  ],
-                };
-              }
-              clauses.push(isExcluding ? { $not: rangeClause } : rangeClause);
-            } else {
-              const clause = { [definition.key]: filter };
-              clauses.push(isExcluding ? { $not: clause } : clause);
-            }
+          const clause = buildPropertyKeyClause(definition.key, state);
+          if (clause !== undefined) {
+            clauses.push(clause);
           }
         }
         break;

--- a/packages/react-components/src/filter-list/utils/getFilterKey.ts
+++ b/packages/react-components/src/filter-list/utils/getFilterKey.ts
@@ -38,6 +38,8 @@ export function getFilterKey<Q extends ObjectTypeDefinition>(
         }`;
     case "CUSTOM":
       return definition.id ?? definition.key;
+    case "STATIC_VALUES":
+      return definition.id ?? definition.key;
     default:
       return assertUnreachable(definition);
   }

--- a/packages/react-components/src/filter-list/utils/getFilterLabel.ts
+++ b/packages/react-components/src/filter-list/utils/getFilterLabel.ts
@@ -35,6 +35,8 @@ export function getFilterLabel<Q extends ObjectTypeDefinition>(
       return "Search";
     case "CUSTOM":
       return definition.key;
+    case "STATIC_VALUES":
+      return definition.key;
     default:
       return assertUnreachable(definition);
   }


### PR DESCRIPTION
## Summary

- Adds a new `STATIC_VALUES` filter definition type that allows consumers to provide a fixed list of string values instead of fetching them via OSDK aggregation queries
- Supports `LISTOGRAM`, `SINGLE_SELECT`, `MULTI_SELECT`, and `TEXT_TAGS` filter components
- Auto-generates WHERE clauses from the `key` property, with an optional `toWhereClause` override for custom mapping (e.g. mapping "Yes"/"No" to `{ active: true/false }`)
- Includes storybook story demonstrating all four component types and custom WHERE clause generation

## Motivation

Currently all filter values must come from OSDK aggregation. This makes it impossible to use filters with fixed/known values like "Yes"/"No", "Active"/"Inactive", or custom categories without a backing property aggregation. `STATIC_VALUES` fills this gap.

## Usage

```typescript
{
  type: "STATIC_VALUES",
  key: "priority",
  label: "Priority",
  filterComponent: "LISTOGRAM",
  values: ["High", "Medium", "Low"],
  filterState: { type: "EXACT_MATCH", values: [] },
}
```

## Screenshots

<!-- Add screenshots of the storybook examples here -->

<img width="1456" height="1768" alt="image" src="https://github.com/user-attachments/assets/21940134-15d5-4674-abd4-6c80abc3ed3c" />

<img width="646" height="295" alt="image" src="https://github.com/user-attachments/assets/a3c71c59-b821-4b59-9640-6a2022f1f763" />


## Test plan

- [x] Unit tests for `getFilterKey` with STATIC_VALUES definitions (key and id override)
- [x] Unit tests for `buildWhereClause` covering EXACT_MATCH, SELECT, isExcluding, toWhereClause override, and empty state
- [x] All 46 existing + new tests pass
- [x] Verify storybook `WithStaticValues` story renders correctly
- [x] Verify WHERE clause JSON output updates when selecting static values