### PR TITLE
Improve URL handling

### DIFF
--- a/.changeset/cli-common-login-url-builder.md
+++ b/.changeset/cli-common-login-url-builder.md
@@ -1,0 +1,5 @@
+---
+"@osdk/cli.common": patch
+---
+
+Build OAuth authorize and token URLs via the URL constructor instead of `node:path/posix.join`, which is not URL-aware.

--- a/.changeset/cli-foundry-url-builder.md
+++ b/.changeset/cli-foundry-url-builder.md
@@ -1,0 +1,5 @@
+---
+"@osdk/cli": patch
+---
+
+Build API URLs in site and widgetset commands via the URL constructor. The `foundryUrl` argument coerce now ensures a trailing slash (previously stripped it), so base URLs with path prefixes resolve correctly.

--- a/.changeset/faux-multipass-url-builder.md
+++ b/.changeset/faux-multipass-url-builder.md
@@ -1,0 +1,5 @@
+---
+"@osdk/faux": patch
+---
+
+Build the multipass mock URL via the URL constructor for consistency with the other handlers.

--- a/.changeset/language-models-url-builder.md
+++ b/.changeset/language-models-url-builder.md
@@ -1,0 +1,5 @@
+---
+"@osdk/language-models": patch
+---
+
+Build Anthropic and OpenAI proxy URLs via the URL constructor so they work correctly regardless of whether `client.baseUrl` carries a trailing slash or a path prefix.

--- a/.changeset/normalize-platform-client-base-url.md
+++ b/.changeset/normalize-platform-client-base-url.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Normalize `baseUrl` in `createPlatformClient` to always end with `/`, matching `createMinimalClient` and enabling RFC 3986-correct URL resolution at call sites.

--- a/.changeset/normalize-platform-client-base-url.md
+++ b/.changeset/normalize-platform-client-base-url.md
@@ -1,5 +1,6 @@
 ---
+"@osdk/shared.client.impl": patch
 "@osdk/client": patch
 ---
 
-Normalize `baseUrl` in `createPlatformClient` to always end with `/`, matching `createMinimalClient` and enabling RFC 3986-correct URL resolution at call sites.
+Normalize `baseUrl` inside `createSharedClientContext` so it always ends with `/`, enabling RFC 3986-correct URL resolution at call sites. `createPlatformClient` and `createMinimalClient` rely on this normalization instead of duplicating it.

--- a/.changeset/widget-vite-plugin-url-builder.md
+++ b/.changeset/widget-vite-plugin-url-builder.md
@@ -1,0 +1,5 @@
+---
+"@osdk/widget.vite-plugin": patch
+---
+
+Build dev-mode settings and preview redirect URLs via the URL constructor so they handle any `foundryUrl` shape (with or without trailing slash, with path prefix).

--- a/packages/cli.common/src/commands/auth/login/loginFlow.ts
+++ b/packages/cli.common/src/commands/auth/login/loginFlow.ts
@@ -20,6 +20,7 @@ import { createServer } from "node:http";
 import { exit } from "node:process";
 import { parse } from "node:url";
 import open from "open";
+import { ensureTrailingSlash } from "../../../util/ensureTrailingSlash.js";
 import type { LoginArgs } from "./LoginArgs.js";
 import type { TokenResponse, TokenSuccessResponse } from "./token.js";
 import { isTokenErrorResponse } from "./token.js";
@@ -32,6 +33,7 @@ export async function invokeLoginFlow(
   consola.start(`Authenticating using application id: ${args.clientId}`);
   const redirectUrl = "http://localhost:8080/auth/callback";
   const port = parse(redirectUrl).port;
+  const foundryUrl = ensureTrailingSlash(args.foundryUrl);
   let resolve: (value: string) => void;
   const authCode: Promise<string> = new Promise((_res) => {
     resolve = _res;
@@ -60,7 +62,7 @@ export async function invokeLoginFlow(
   const codeChallenge = await generateCodeChallenge(codeVerifier);
 
   const authorizeUrl = generateAuthorizeUrl(
-    args.foundryUrl,
+    foundryUrl,
     clientId,
     state,
     redirectUrl,
@@ -91,7 +93,7 @@ export async function invokeLoginFlow(
     clientId,
     redirectUrl,
     code,
-    args.foundryUrl,
+    foundryUrl,
     codeVerifier,
   );
 
@@ -145,8 +147,7 @@ function generateAuthorizeUrl(
   redirectUrl: string,
   codeChallenge: { codeChallenge: string; codeChallengeMethod: string },
 ) {
-  const base = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
-  const url = new URL("multipass/api/oauth2/authorize", base);
+  const url = new URL("multipass/api/oauth2/authorize", baseUrl);
   url.searchParams.set("client_id", clientId);
   url.searchParams.set("response_type", "code");
   url.searchParams.set("state", state);
@@ -177,8 +178,7 @@ async function getTokenWithCodeVerifier(
   body.append("redirect_uri", redirectUrl);
   body.append("code_verifier", codeVerifier);
 
-  const base = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
-  const tokenUrlObj = new URL("multipass/api/oauth2/token", base);
+  const tokenUrlObj = new URL("multipass/api/oauth2/token", baseUrl);
   tokenUrlObj.searchParams.set("state", codeVerifier);
   const tokenUrl = tokenUrlObj.toString();
   try {

--- a/packages/cli.common/src/commands/auth/login/loginFlow.ts
+++ b/packages/cli.common/src/commands/auth/login/loginFlow.ts
@@ -17,7 +17,6 @@
 import consola from "consola";
 import { getRandomValues, subtle } from "node:crypto";
 import { createServer } from "node:http";
-import { join } from "node:path/posix";
 import { exit } from "node:process";
 import { parse } from "node:url";
 import open from "open";
@@ -41,7 +40,7 @@ export async function invokeLoginFlow(
   const server = createServer((req, res) => {
     const query = parse(req.url!, true).query;
     res.end("Authenticated");
-    resolve(query["code"] as string);
+    resolve(query.code as string);
   });
 
   server.on("error", (e) => {
@@ -146,23 +145,22 @@ function generateAuthorizeUrl(
   redirectUrl: string,
   codeChallenge: { codeChallenge: string; codeChallengeMethod: string },
 ) {
-  const queryParams = new URLSearchParams();
-  queryParams.append("client_id", clientId);
-  queryParams.append("response_type", "code");
-  queryParams.append("state", state);
-  queryParams.append("redirect_uri", redirectUrl);
-  queryParams.append("code_challenge", codeChallenge.codeChallenge);
-  queryParams.append(
+  const base = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
+  const url = new URL("multipass/api/oauth2/authorize", base);
+  url.searchParams.set("client_id", clientId);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("state", state);
+  url.searchParams.set("redirect_uri", redirectUrl);
+  url.searchParams.set("code_challenge", codeChallenge.codeChallenge);
+  url.searchParams.set(
     "code_challenge_method",
     codeChallenge.codeChallengeMethod,
   );
-  queryParams.append(
+  url.searchParams.set(
     "scope",
     ["offline_access", "api:read-data", "api:use-ontologies-read"].join(" "),
   );
-
-  return join(baseUrl, "multipass", "api", "oauth2", "authorize") + `?`
-    + queryParams.toString();
+  return url.toString();
 }
 
 async function getTokenWithCodeVerifier(
@@ -179,8 +177,10 @@ async function getTokenWithCodeVerifier(
   body.append("redirect_uri", redirectUrl);
   body.append("code_verifier", codeVerifier);
 
-  const tokenUrl = join(baseUrl, "multipass", "api", "oauth2", "token")
-    + `?state=${codeVerifier}`;
+  const base = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
+  const tokenUrlObj = new URL("multipass/api/oauth2/token", base);
+  tokenUrlObj.searchParams.set("state", codeVerifier);
+  const tokenUrl = tokenUrlObj.toString();
   try {
     const response = await fetch(tokenUrl, {
       body: body.toString(),

--- a/packages/cli.common/src/util/ensureTrailingSlash.ts
+++ b/packages/cli.common/src/util/ensureTrailingSlash.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-export type { CliCommonArgs } from "./CliCommonArgs.js";
-export type { CommonAuthArgs } from "./commands/auth/CommonAuthArgs.js";
-export type { LoginArgs } from "./commands/auth/login/LoginArgs.js";
-export { ExitProcessError } from "./ExitProcessError.js";
-export { getYargsBase } from "./getYargsBase.js";
-export { ensureTrailingSlash } from "./util/ensureTrailingSlash.js";
-export { isValidSemver } from "./util/isValidSemver.js";
-export { YargsCheckError } from "./YargsCheckError.js";
+export function ensureTrailingSlash(input: string): string {
+  return input.endsWith("/") ? input : input + "/";
+}

--- a/packages/cli/src/commands/site/index.ts
+++ b/packages/cli/src/commands/site/index.ts
@@ -15,7 +15,7 @@
  */
 
 import type { CliCommonArgs } from "@osdk/cli.common";
-import { YargsCheckError } from "@osdk/cli.common";
+import { ensureTrailingSlash, YargsCheckError } from "@osdk/cli.common";
 import type { CommandModule } from "yargs";
 import type { ThirdPartyAppRid } from "../../net/ThirdPartyAppRid.js";
 import configLoader from "../../util/configLoader.js";
@@ -43,8 +43,7 @@ const command: CommandModule<CliCommonArgs, CommonSiteArgs> = {
           description: "Application resource identifier (rid)",
         },
         foundryUrl: {
-          coerce: (foundryUrl) =>
-            foundryUrl.endsWith("/") ? foundryUrl : foundryUrl + "/",
+          coerce: ensureTrailingSlash,
           type: "string",
           ...foundryUrl
             ? { default: foundryUrl }

--- a/packages/cli/src/commands/site/index.ts
+++ b/packages/cli/src/commands/site/index.ts
@@ -43,7 +43,8 @@ const command: CommandModule<CliCommonArgs, CommonSiteArgs> = {
           description: "Application resource identifier (rid)",
         },
         foundryUrl: {
-          coerce: (foundryUrl) => foundryUrl.replace(/\/$/, ""),
+          coerce: (foundryUrl) =>
+            foundryUrl.endsWith("/") ? foundryUrl : foundryUrl + "/",
           type: "string",
           ...foundryUrl
             ? { default: foundryUrl }

--- a/packages/cli/src/commands/widgetset/index.ts
+++ b/packages/cli/src/commands/widgetset/index.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { type CliCommonArgs, YargsCheckError } from "@osdk/cli.common";
+import {
+  type CliCommonArgs,
+  ensureTrailingSlash,
+  YargsCheckError,
+} from "@osdk/cli.common";
 import type { CommandModule } from "yargs";
 import type { WidgetSetRid } from "../../net/WidgetSetRid.js";
 import configLoader from "../../util/configLoader.js";
@@ -41,8 +45,7 @@ const command: CommandModule<CliCommonArgs, CommonWidgetSetArgs> = {
         description: "Widget set resource identifier (rid)",
       },
       foundryUrl: {
-        coerce: (foundryUrl) =>
-          foundryUrl.endsWith("/") ? foundryUrl : foundryUrl + "/",
+        coerce: ensureTrailingSlash,
         type: "string",
         ...foundryUrl
           ? { default: foundryUrl }

--- a/packages/cli/src/commands/widgetset/index.ts
+++ b/packages/cli/src/commands/widgetset/index.ts
@@ -41,7 +41,8 @@ const command: CommandModule<CliCommonArgs, CommonWidgetSetArgs> = {
         description: "Widget set resource identifier (rid)",
       },
       foundryUrl: {
-        coerce: (foundryUrl) => foundryUrl.replace(/\/$/, ""),
+        coerce: (foundryUrl) =>
+          foundryUrl.endsWith("/") ? foundryUrl : foundryUrl + "/",
         type: "string",
         ...foundryUrl
           ? { default: foundryUrl }

--- a/packages/cli/src/net/third-party-applications/deleteVersion.mts
+++ b/packages/cli/src/net/third-party-applications/deleteVersion.mts
@@ -24,10 +24,14 @@ export async function deleteVersion(
   version: string,
 ): Promise<void> {
   const fetch = createFetch(ctx.tokenProvider);
-  const url =
-    `${ctx.foundryUrl}/api/v2/thirdPartyApplications/${thirdPartyAppRid}/website/versions/${
+  const urlObj = new URL(
+    `api/v2/thirdPartyApplications/${thirdPartyAppRid}/website/versions/${
       encodeURIComponent(version)
-    }?preview=true`;
+    }`,
+    ctx.foundryUrl,
+  );
+  urlObj.searchParams.set("preview", "true");
+  const url = urlObj.toString();
 
   await fetch(
     url,

--- a/packages/cli/src/net/third-party-applications/deployWebsite.mts
+++ b/packages/cli/src/net/third-party-applications/deployWebsite.mts
@@ -26,8 +26,12 @@ export async function deployWebsite(
   request: DeployWebsiteRequest,
 ): Promise<Website> {
   const fetch = createFetch(ctx.tokenProvider);
-  const url =
-    `${ctx.foundryUrl}/api/v2/thirdPartyApplications/${thirdPartyAppRid}/website/deploy?preview=true`;
+  const urlObj = new URL(
+    `api/v2/thirdPartyApplications/${thirdPartyAppRid}/website/deploy`,
+    ctx.foundryUrl,
+  );
+  urlObj.searchParams.set("preview", "true");
+  const url = urlObj.toString();
 
   const result = await fetch(
     url,

--- a/packages/cli/src/net/third-party-applications/getWebsite.mts
+++ b/packages/cli/src/net/third-party-applications/getWebsite.mts
@@ -26,8 +26,12 @@ export async function getWebsite(
   thirdPartyAppRid: ThirdPartyAppRid,
 ): Promise<Website | undefined> {
   const fetch = createFetch(ctx.tokenProvider);
-  const url =
-    `${ctx.foundryUrl}/api/v2/thirdPartyApplications/${thirdPartyAppRid}/website?preview=true`;
+  const urlObj = new URL(
+    `api/v2/thirdPartyApplications/${thirdPartyAppRid}/website`,
+    ctx.foundryUrl,
+  );
+  urlObj.searchParams.set("preview", "true");
+  const url = urlObj.toString();
 
   try {
     const result = await fetch(url);

--- a/packages/cli/src/net/third-party-applications/listVersions.mts
+++ b/packages/cli/src/net/third-party-applications/listVersions.mts
@@ -24,8 +24,12 @@ export async function listVersions(
   thirdPartyAppRid: ThirdPartyAppRid,
 ): Promise<ListVersionsResponse> {
   const fetch = createFetch(ctx.tokenProvider);
-  const url =
-    `${ctx.foundryUrl}/api/v2/thirdPartyApplications/${thirdPartyAppRid}/website/versions?preview=true`;
+  const urlObj = new URL(
+    `api/v2/thirdPartyApplications/${thirdPartyAppRid}/website/versions`,
+    ctx.foundryUrl,
+  );
+  urlObj.searchParams.set("preview", "true");
+  const url = urlObj.toString();
 
   const result = await fetch(url);
   return result.json();

--- a/packages/cli/src/net/third-party-applications/undeployWebsite.mts
+++ b/packages/cli/src/net/third-party-applications/undeployWebsite.mts
@@ -23,8 +23,12 @@ export async function undeployWebsite(
   thirdPartyAppRid: ThirdPartyAppRid,
 ): Promise<void> {
   const fetch = createFetch(ctx.tokenProvider);
-  const url =
-    `${ctx.foundryUrl}/api/v2/thirdPartyApplications/${thirdPartyAppRid}/website/undeploy?preview=true`;
+  const urlObj = new URL(
+    `api/v2/thirdPartyApplications/${thirdPartyAppRid}/website/undeploy`,
+    ctx.foundryUrl,
+  );
+  urlObj.searchParams.set("preview", "true");
+  const url = urlObj.toString();
 
   await fetch(
     url,

--- a/packages/cli/src/net/third-party-applications/uploadSnapshotVersion.mts
+++ b/packages/cli/src/net/third-party-applications/uploadSnapshotVersion.mts
@@ -27,14 +27,16 @@ export async function uploadSnapshotVersion(
   zipFile: ReadableStream | Blob | BufferSource,
 ): Promise<Version> {
   const fetch = createFetch(ctx.tokenProvider);
-  const url =
-    `${ctx.foundryUrl}/api/v2/thirdPartyApplications/${thirdPartyAppRid}/website/versions/uploadSnapshot?version=${
-      encodeURIComponent(version)
-    }&preview=true${
-      snapshotId !== ""
-        ? `&snapshotIdentifier=${encodeURIComponent(snapshotId)}`
-        : ""
-    }`;
+  const urlObj = new URL(
+    `api/v2/thirdPartyApplications/${thirdPartyAppRid}/website/versions/uploadSnapshot`,
+    ctx.foundryUrl,
+  );
+  urlObj.searchParams.set("version", version);
+  urlObj.searchParams.set("preview", "true");
+  if (snapshotId !== "") {
+    urlObj.searchParams.set("snapshotIdentifier", snapshotId);
+  }
+  const url = urlObj.toString();
 
   const result = await fetch(
     url,

--- a/packages/cli/src/net/third-party-applications/uploadVersion.mts
+++ b/packages/cli/src/net/third-party-applications/uploadVersion.mts
@@ -26,10 +26,13 @@ export async function uploadVersion(
   zipFile: ReadableStream | Blob | BufferSource,
 ): Promise<Version> {
   const fetch = createFetch(ctx.tokenProvider);
-  const url =
-    `${ctx.foundryUrl}/api/v2/thirdPartyApplications/${thirdPartyAppRid}/website/versions/upload?version=${
-      encodeURIComponent(version)
-    }&preview=true`;
+  const urlObj = new URL(
+    `api/v2/thirdPartyApplications/${thirdPartyAppRid}/website/versions/upload`,
+    ctx.foundryUrl,
+  );
+  urlObj.searchParams.set("version", version);
+  urlObj.searchParams.set("preview", "true");
+  const url = urlObj.toString();
 
   const result = await fetch(
     url,

--- a/packages/cli/src/net/widget-registry/deleteRelease.mts
+++ b/packages/cli/src/net/widget-registry/deleteRelease.mts
@@ -24,8 +24,12 @@ export async function deleteRelease(
   releaseVersion: string,
 ): Promise<void> {
   const fetch = createFetch(ctx.tokenProvider);
-  const url =
-    `${ctx.foundryUrl}/api/v2/widgets/widgetSets/${widgetSetRid}/releases/${releaseVersion}?preview=true`;
+  const urlObj = new URL(
+    `api/v2/widgets/widgetSets/${widgetSetRid}/releases/${releaseVersion}`,
+    ctx.foundryUrl,
+  );
+  urlObj.searchParams.set("preview", "true");
+  const url = urlObj.toString();
   await fetch(
     url,
     {

--- a/packages/cli/src/net/widget-registry/getRelease.mts
+++ b/packages/cli/src/net/widget-registry/getRelease.mts
@@ -25,8 +25,12 @@ export async function getRelease(
   releaseVersion: string,
 ): Promise<Release> {
   const fetch = createFetch(ctx.tokenProvider);
-  const url =
-    `${ctx.foundryUrl}/api/v2/widgets/widgetSets/${widgetSetRid}/releases/${releaseVersion}?preview=true`;
+  const urlObj = new URL(
+    `api/v2/widgets/widgetSets/${widgetSetRid}/releases/${releaseVersion}`,
+    ctx.foundryUrl,
+  );
+  urlObj.searchParams.set("preview", "true");
+  const url = urlObj.toString();
   const response = await fetch(url);
   return response.json();
 }

--- a/packages/cli/src/net/widget-registry/listReleases.mts
+++ b/packages/cli/src/net/widget-registry/listReleases.mts
@@ -24,8 +24,12 @@ export async function listReleases(
   widgetSetRid: WidgetSetRid,
 ): Promise<ListReleasesResponse> {
   const fetch = createFetch(ctx.tokenProvider);
-  const url =
-    `${ctx.foundryUrl}/api/v2/widgets/widgetSets/${widgetSetRid}/releases?preview=true`;
+  const urlObj = new URL(
+    `api/v2/widgets/widgetSets/${widgetSetRid}/releases`,
+    ctx.foundryUrl,
+  );
+  urlObj.searchParams.set("preview", "true");
+  const url = urlObj.toString();
   const response = await fetch(url);
   return response.json();
 }

--- a/packages/cli/src/net/widget-registry/publishRelease.mts
+++ b/packages/cli/src/net/widget-registry/publishRelease.mts
@@ -26,8 +26,13 @@ export async function publishRelease(
   zipFile: ReadableStream | Blob | BufferSource,
 ): Promise<void> {
   const fetch = createFetch(ctx.tokenProvider);
-  const url =
-    `${ctx.foundryUrl}/api/v2/widgets/repositories/${repositoryRid}/publish?preview=true&repositoryVersion=${repositoryVersion}`;
+  const urlObj = new URL(
+    `api/v2/widgets/repositories/${repositoryRid}/publish`,
+    ctx.foundryUrl,
+  );
+  urlObj.searchParams.set("preview", "true");
+  urlObj.searchParams.set("repositoryVersion", repositoryVersion);
+  const url = urlObj.toString();
 
   await fetch(
     url,

--- a/packages/client/src/createClient.test.ts
+++ b/packages/client/src/createClient.test.ts
@@ -122,7 +122,7 @@ describe(createClient, () => {
         undefined,
         fetchFunction,
       );
-      expect(spy.mock.calls[0][0]).toBe("https://mock.com/");
+      expect(spy.mock.results[0].value.baseUrl).toBe("https://mock.com/");
 
       createClient(
         "https://mock1.com/",
@@ -131,7 +131,7 @@ describe(createClient, () => {
         undefined,
         fetchFunction,
       );
-      expect(spy.mock.calls[1][0]).toBe("https://mock1.com/");
+      expect(spy.mock.results[1].value.baseUrl).toBe("https://mock1.com/");
 
       createClient(
         "https://mock2.com/stuff/first/foo",
@@ -140,7 +140,9 @@ describe(createClient, () => {
         undefined,
         fetchFunction,
       );
-      expect(spy.mock.calls[2][0]).toBe("https://mock2.com/stuff/first/foo/");
+      expect(spy.mock.results[2].value.baseUrl).toBe(
+        "https://mock2.com/stuff/first/foo/",
+      );
 
       createClient(
         "https://mock3.com/stuff/first/foo/",
@@ -149,7 +151,9 @@ describe(createClient, () => {
         undefined,
         fetchFunction,
       );
-      expect(spy.mock.calls[3][0]).toBe("https://mock3.com/stuff/first/foo/");
+      expect(spy.mock.results[3].value.baseUrl).toBe(
+        "https://mock3.com/stuff/first/foo/",
+      );
 
       const conjureContextSpy = vi.spyOn(
         MakeConjureContext,

--- a/packages/client/src/createMinimalClient.ts
+++ b/packages/client/src/createMinimalClient.ts
@@ -67,13 +67,9 @@ export function createMinimalClient(
       throw new Error(`Invalid stack URL: ${baseUrl}${hint}`);
     }
   }
-  const processedBaseUrl = new URL(baseUrl);
-  processedBaseUrl.pathname += processedBaseUrl.pathname.endsWith("/")
-    ? ""
-    : "/";
   const minimalClient: MinimalClient = {
     ...createSharedClientContext(
-      processedBaseUrl.toString(),
+      baseUrl,
       tokenProvider,
       USER_AGENT,
       fetchFn,

--- a/packages/client/src/createPlatformClient.ts
+++ b/packages/client/src/createPlatformClient.ts
@@ -38,12 +38,8 @@ export function createPlatformClient(
   options: undefined = undefined,
   fetchFn: typeof globalThis.fetch = fetch,
 ): PlatformClient {
-  const processedBaseUrl = new URL(baseUrl);
-  processedBaseUrl.pathname += processedBaseUrl.pathname.endsWith("/")
-    ? ""
-    : "/";
   return createSharedClientContext(
-    processedBaseUrl.toString(),
+    baseUrl,
     tokenProvider,
     USER_AGENT,
     fetchFn,

--- a/packages/client/src/createPlatformClient.ts
+++ b/packages/client/src/createPlatformClient.ts
@@ -38,8 +38,12 @@ export function createPlatformClient(
   options: undefined = undefined,
   fetchFn: typeof globalThis.fetch = fetch,
 ): PlatformClient {
+  const processedBaseUrl = new URL(baseUrl);
+  processedBaseUrl.pathname += processedBaseUrl.pathname.endsWith("/")
+    ? ""
+    : "/";
   return createSharedClientContext(
-    baseUrl,
+    processedBaseUrl.toString(),
     tokenProvider,
     USER_AGENT,
     fetchFn,

--- a/packages/faux/src/handlers/createMultipassServerHandlers.ts
+++ b/packages/faux/src/handlers/createMultipassServerHandlers.ts
@@ -22,7 +22,10 @@ export const createMultipassServerHandlers: FauxFoundryHandlersFactory = (
   fauxFoundry,
 ) => [
   http.post(
-    `${baseUrl}/multipass/api/oauth2/token`,
+    new URL(
+      "multipass/api/oauth2/token",
+      baseUrl.endsWith("/") ? baseUrl : baseUrl + "/",
+    ).toString(),
     async (req) => {
       const body = await req.request.text();
       const parsedBody = new URLSearchParams(body);

--- a/packages/language-models/src/utils.test.ts
+++ b/packages/language-models/src/utils.test.ts
@@ -62,11 +62,31 @@ describe("getAnthropicBaseUrl", () => {
       "https://example.palantirfoundry.com/api/v2/llm/proxy/anthropic",
     );
   });
+
+  it("returns the Anthropic proxy URL when baseUrl has a trailing slash", () => {
+    const client = createMockClient({
+      baseUrl: "https://example.palantirfoundry.com/",
+    });
+
+    expect(getAnthropicBaseUrl(client)).toBe(
+      "https://example.palantirfoundry.com/api/v2/llm/proxy/anthropic",
+    );
+  });
 });
 
 describe("getOpenAiBaseUrl", () => {
   it("returns the OpenAI proxy URL", () => {
     const client = createMockClient();
+
+    expect(getOpenAiBaseUrl(client)).toBe(
+      "https://example.palantirfoundry.com/api/v2/llm/proxy/openai/v1",
+    );
+  });
+
+  it("returns the OpenAI proxy URL when baseUrl has a trailing slash", () => {
+    const client = createMockClient({
+      baseUrl: "https://example.palantirfoundry.com/",
+    });
 
     expect(getOpenAiBaseUrl(client)).toBe(
       "https://example.palantirfoundry.com/api/v2/llm/proxy/openai/v1",

--- a/packages/language-models/src/utils.ts
+++ b/packages/language-models/src/utils.ts
@@ -74,7 +74,7 @@ export async function getFoundryToken(
  * ```
  */
 export function getAnthropicBaseUrl(client: PlatformClient): string {
-  return `${client.baseUrl}/api/v2/llm/proxy/anthropic`;
+  return new URL("api/v2/llm/proxy/anthropic", client.baseUrl).toString();
 }
 
 /**
@@ -90,5 +90,5 @@ export function getAnthropicBaseUrl(client: PlatformClient): string {
  * ```
  */
 export function getOpenAiBaseUrl(client: PlatformClient): string {
-  return `${client.baseUrl}/api/v2/llm/proxy/openai/v1`;
+  return new URL("api/v2/llm/proxy/openai/v1", client.baseUrl).toString();
 }

--- a/packages/shared.client.impl/src/createSharedClientContext.ts
+++ b/packages/shared.client.impl/src/createSharedClientContext.ts
@@ -37,6 +37,12 @@ export function createSharedClientContext(
     throw new Error("baseUrl cannot be empty");
   }
 
+  const parsedBaseUrl = new URL(baseUrl);
+  if (!parsedBaseUrl.pathname.endsWith("/")) {
+    parsedBaseUrl.pathname += "/";
+  }
+  const normalizedBaseUrl = parsedBaseUrl.toString();
+
   const retryingFetchWithAuthOrThrow = createFetchHeaderMutator(
     createRetryingFetch(createFetchOrThrow(fetchFn)),
     async (headers) => {
@@ -95,7 +101,7 @@ export function createSharedClientContext(
   };
 
   return {
-    baseUrl,
+    baseUrl: normalizedBaseUrl,
     fetch: fetchWrapper,
     tokenProvider,
   };

--- a/packages/widget.vite-plugin/src/dev-plugin/network.ts
+++ b/packages/widget.vite-plugin/src/dev-plugin/network.ts
@@ -45,11 +45,13 @@ export function setWidgetSetSettings(
       ] as const),
     ),
   );
-  const base = foundryUrl.endsWith("/") ? foundryUrl : foundryUrl + "/";
-  const url = new URL("api/v2/widgets/devModeSettings/setWidgetSetById", base);
+  const url = new URL(
+    "api/v2/widgets/devModeSettings/setWidgetSetById",
+    foundryUrl,
+  );
   url.searchParams.set("preview", "true");
   return fetch(
-    url.toString(),
+    url,
     {
       body: JSON.stringify({
         widgetSetRid,
@@ -72,11 +74,10 @@ export function enableDevMode(
   foundryUrl: string,
   viteMode: string | undefined,
 ): Promise<Response> {
-  const base = foundryUrl.endsWith("/") ? foundryUrl : foundryUrl + "/";
-  const url = new URL("api/v2/widgets/devModeSettings/enable", base);
+  const url = new URL("api/v2/widgets/devModeSettings/enable", foundryUrl);
   url.searchParams.set("preview", "true");
   return fetch(
-    url.toString(),
+    url,
     {
       method: "POST",
       headers: {

--- a/packages/widget.vite-plugin/src/dev-plugin/network.ts
+++ b/packages/widget.vite-plugin/src/dev-plugin/network.ts
@@ -45,8 +45,11 @@ export function setWidgetSetSettings(
       ] as const),
     ),
   );
+  const base = foundryUrl.endsWith("/") ? foundryUrl : foundryUrl + "/";
+  const url = new URL("api/v2/widgets/devModeSettings/setWidgetSetById", base);
+  url.searchParams.set("preview", "true");
   return fetch(
-    `${foundryUrl}/api/v2/widgets/devModeSettings/setWidgetSetById?preview=true`,
+    url.toString(),
     {
       body: JSON.stringify({
         widgetSetRid,
@@ -69,8 +72,11 @@ export function enableDevMode(
   foundryUrl: string,
   viteMode: string | undefined,
 ): Promise<Response> {
+  const base = foundryUrl.endsWith("/") ? foundryUrl : foundryUrl + "/";
+  const url = new URL("api/v2/widgets/devModeSettings/enable", base);
+  url.searchParams.set("preview", "true");
   return fetch(
-    `${foundryUrl}/api/v2/widgets/devModeSettings/enable?preview=true`,
+    url.toString(),
     {
       method: "POST",
       headers: {

--- a/packages/widget.vite-plugin/src/dev-plugin/publishDevModeSettings.ts
+++ b/packages/widget.vite-plugin/src/dev-plugin/publishDevModeSettings.ts
@@ -123,7 +123,10 @@ export async function publishDevModeSettings(
       // In Code Workspaces the preview UI automatically handles this redirect
       redirectUrl: isCodeWorkspacesMode(server.config.mode)
         ? null
-        : `${foundryUrl}/workspace/custom-widgets/preview/${widgetSetRid}`,
+        : new URL(
+          `workspace/custom-widgets/preview/${widgetSetRid}`,
+          foundryUrl.endsWith("/") ? foundryUrl : foundryUrl + "/",
+        ).toString(),
     }));
   } catch (error: unknown) {
     server.config.logger.error(

--- a/packages/widget.vite-plugin/src/dev-plugin/publishDevModeSettings.ts
+++ b/packages/widget.vite-plugin/src/dev-plugin/publishDevModeSettings.ts
@@ -77,9 +77,12 @@ export async function publishDevModeSettings(
         "foundry.config.json file not found.",
       );
     }
-    const foundryUrl = isCodeWorkspacesMode(server.config.mode)
+    const rawFoundryUrl = isCodeWorkspacesMode(server.config.mode)
       ? getCodeWorkspacesFoundryUrl()
       : foundryConfig.foundryConfig.foundryUrl;
+    const foundryUrl = rawFoundryUrl.endsWith("/")
+      ? rawFoundryUrl
+      : rawFoundryUrl + "/";
 
     const widgetSetRid = foundryConfig.foundryConfig.widgetSet.rid;
     const settingsResponse = await setWidgetSetSettings(
@@ -125,7 +128,7 @@ export async function publishDevModeSettings(
         ? null
         : new URL(
           `workspace/custom-widgets/preview/${widgetSetRid}`,
-          foundryUrl.endsWith("/") ? foundryUrl : foundryUrl + "/",
+          foundryUrl,
         ).toString(),
     }));
   } catch (error: unknown) {


### PR DESCRIPTION
Prior to this PR, there were a bunch of cases in our code where we constructed a URL...
- ...with POSIX joins
- ...with string concatentations

This is not a pattern that should be used. String concatenations in particular are error prone, particularly in cases where, for example we have something like `${baseUrl}/api/...`. If `baseUrl` contains a trailing `/`, this breaks since we end up with a path like `https://baseUrl.foo//api`, which is invalid and breaks calls. This happened in practice for users of the `language-models` package, if they were to use the `baseUrl` from the OSDK client:
```ts
async function createAnthropicClient(
  client: Client
): Promise<Anthropic> {
  const clientContext: SharedClientContext = osdkClient[symbolClientContext]

  return new Anthropic({
    authToken: await getFoundryToken(clientContext),
    baseURL: getAnthropicBaseUrl(clientContext),
    fetch: createFetch(clientContext),
  });
}
```

We should use the JS-built-in [`URL`](https://datatracker.ietf.org/doc/html/rfc3986) builder to construct URLs. Since this is strictly [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) compliant, we need to ensure that each `baseUrl` carries a trailing `/`. This is already done today in the widely-used [`createMinimalClient`](https://github.com/palantir/osdk-ts/blob/da434c9adc015453696d5a2c37dc7f65bef25b41/packages/client/src/createMinimalClient.ts#L70-L73) (which is also used within [`createClient`](https://github.com/palantir/osdk-ts/blob/da434c9adc015453696d5a2c37dc7f65bef25b41/packages/client/src/createClient.ts#L136), hence causing the issue mentioned above).

This PR introduces this pattern throughout the codebase. It
- Ensures trailing `/` always exist on base URLs
- Uses URL builders where possible
- Migrates manual query parameter addition to use built-in functionality of `URL`