### PR TITLE
[FilterList] Call onFilterClauseChanged when initialFilterStates is set

### DIFF
--- a/.changeset/thirty-signs-hug.md
+++ b/.changeset/thirty-signs-hug.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+Consolidate onFilterClauseChanged into a single useEffect on whereClause, fixing missing callback when initialFilterStates is set and a stale closure bug in clearFilterState

--- a/packages/react-components/src/filter-list/hooks/__tests__/useFilterListState.test.tsx
+++ b/packages/react-components/src/filter-list/hooks/__tests__/useFilterListState.test.tsx
@@ -135,7 +135,7 @@ describe("useFilterListState", () => {
     expect(result.current.whereClause).toEqual({ name: "John" });
   });
 
-  it("does not call onFilterClauseChanged on mount", () => {
+  it("calls onFilterClauseChanged on mount with initial where clause", () => {
     const onFilterClauseChanged = vi.fn();
     const nameDef = createPropertyFilterDef(
       "name",
@@ -147,10 +147,31 @@ describe("useFilterListState", () => {
       onFilterClauseChanged,
     });
     renderHook(() => useFilterListState(props));
-    expect(onFilterClauseChanged).not.toHaveBeenCalled();
+    expect(onFilterClauseChanged).toHaveBeenCalledTimes(1);
+    expect(onFilterClauseChanged).toHaveBeenCalledWith({});
   });
 
-  it("calls onFilterClauseChanged synchronously on setFilterState", () => {
+  it("calls onFilterClauseChanged on mount when initialFilterStates has active filters", () => {
+    const onFilterClauseChanged = vi.fn();
+    const nameDef = createPropertyFilterDef(
+      "name",
+      "LISTOGRAM",
+      createExactMatchState([]),
+    );
+    const initialFilterStates = new Map([
+      [getFilterKey(nameDef), createExactMatchState(["John"])],
+    ]);
+    const props = createProps({
+      filterDefinitions: [nameDef],
+      onFilterClauseChanged,
+      initialFilterStates,
+    });
+    renderHook(() => useFilterListState(props));
+    expect(onFilterClauseChanged).toHaveBeenCalledTimes(1);
+    expect(onFilterClauseChanged).toHaveBeenCalledWith({ name: "John" });
+  });
+
+  it("calls onFilterClauseChanged on setFilterState", () => {
     const onFilterClauseChanged = vi.fn();
     const nameDef = createPropertyFilterDef(
       "name",
@@ -162,6 +183,7 @@ describe("useFilterListState", () => {
       onFilterClauseChanged,
     });
     const { result } = renderHook(() => useFilterListState(props));
+    onFilterClauseChanged.mockClear();
     act(() => {
       result.current.setFilterState(
         getFilterKey(nameDef),
@@ -194,7 +216,6 @@ describe("useFilterListState", () => {
     act(() => {
       result.current.reset();
     });
-    expect(onFilterClauseChanged).toHaveBeenCalledTimes(1);
     expect(onFilterClauseChanged).toHaveBeenCalledWith({});
   });
 

--- a/packages/react-components/src/filter-list/hooks/useFilterListState.ts
+++ b/packages/react-components/src/filter-list/hooks/useFilterListState.ts
@@ -16,7 +16,7 @@
 
 import type { ObjectTypeDefinition, WhereClause } from "@osdk/api";
 import { useOsdkMetadata } from "@osdk/react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { assertUnreachable } from "../../shared/assertUnreachable.js";
 import type { FilterListProps } from "../FilterListApi.js";
 import type { FilterState } from "../FilterListItemApi.js";
@@ -103,6 +103,8 @@ export function useFilterListState<Q extends ObjectTypeDefinition>(
     initialFilterStates,
   } = props;
   const { metadata } = useOsdkMetadata(objectType);
+  const onFilterClauseChangedRef = useRef(onFilterClauseChanged);
+  onFilterClauseChangedRef.current = onFilterClauseChanged;
 
   const propertyTypes = useMemo(() => {
     const map = new Map<string, PropertyTypeInfo>();
@@ -174,8 +176,8 @@ export function useFilterListState<Q extends ObjectTypeDefinition>(
   );
 
   useEffect(() => {
-    onFilterClauseChanged?.(whereClause);
-  }, [whereClause, onFilterClauseChanged]);
+    onFilterClauseChangedRef.current?.(whereClause);
+  }, [whereClause]);
 
   const perFilterWhereClauses = useMemo(() => {
     const map = new Map<string, WhereClause<Q>>();

--- a/packages/react-components/src/filter-list/hooks/useFilterListState.ts
+++ b/packages/react-components/src/filter-list/hooks/useFilterListState.ts
@@ -16,7 +16,7 @@
 
 import type { ObjectTypeDefinition, WhereClause } from "@osdk/api";
 import { useOsdkMetadata } from "@osdk/react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { assertUnreachable } from "../../shared/assertUnreachable.js";
 import type { FilterListProps } from "../FilterListApi.js";
 import type { FilterState } from "../FilterListItemApi.js";
@@ -133,24 +133,12 @@ export function useFilterListState<Q extends ObjectTypeDefinition>(
 
   const setFilterState = useCallback(
     (filterKey: string, state: FilterState) => {
-      let newWhereClause: WhereClause<Q> | undefined;
-
       setFilterStates((prev) => {
         const next = new Map(prev);
         next.set(filterKey, state);
-
-        newWhereClause = buildWhereClause(
-          filterDefinitions,
-          next,
-          propertyTypes,
-        );
-
         return next;
       });
 
-      if (newWhereClause !== undefined) {
-        onFilterClauseChanged?.(newWhereClause);
-      }
       const definition = filterDefinitions?.find(
         (d) => getFilterKey(d) === filterKey,
       );
@@ -160,27 +148,19 @@ export function useFilterListState<Q extends ObjectTypeDefinition>(
     },
     [
       filterDefinitions,
-      propertyTypes,
-      onFilterClauseChanged,
       onFilterStateChanged,
     ],
   );
 
   const clearFilterState = useCallback(
     (filterKey: string) => {
-      const clearedStates = new Map(filterStates);
-      clearedStates.delete(filterKey);
-
-      setFilterStates(clearedStates);
-
-      const newWhereClause = buildWhereClause(
-        filterDefinitions,
-        clearedStates,
-        propertyTypes,
-      );
-      onFilterClauseChanged?.(newWhereClause);
+      setFilterStates((prev) => {
+        const next = new Map(prev);
+        next.delete(filterKey);
+        return next;
+      });
     },
-    [filterStates, filterDefinitions, propertyTypes, onFilterClauseChanged],
+    [],
   );
 
   const whereClause = useMemo(
@@ -192,6 +172,10 @@ export function useFilterListState<Q extends ObjectTypeDefinition>(
       ),
     [filterDefinitions, filterStates, propertyTypes],
   );
+
+  useEffect(() => {
+    onFilterClauseChanged?.(whereClause);
+  }, [whereClause, onFilterClauseChanged]);
 
   const perFilterWhereClauses = useMemo(() => {
     const map = new Map<string, WhereClause<Q>>();
@@ -224,16 +208,8 @@ export function useFilterListState<Q extends ObjectTypeDefinition>(
   }, [filterStates]);
 
   const reset = useCallback(() => {
-    const initialStates = buildInitialStates(filterDefinitions);
-    setFilterStates(initialStates);
-
-    const newWhereClause = buildWhereClause(
-      filterDefinitions,
-      initialStates,
-      propertyTypes,
-    );
-    onFilterClauseChanged?.(newWhereClause);
-  }, [filterDefinitions, propertyTypes, onFilterClauseChanged]);
+    setFilterStates(buildInitialStates(filterDefinitions));
+  }, [filterDefinitions]);
 
   return useMemo(() => ({
     filterStates,


### PR DESCRIPTION
Previously, onFilterClauseChanged was called manually in setFilterState, clearFilterState, and reset — but was missing from the initialFilterStates code path, causing consumers to be out of sync on mount.

This replaces the scattered manual calls with a single useEffect that watches the derived whereClause. This:

- Fixes the initialFilterStates bug (callback now fires on mount)
- Also fires onFilterClauseChanged on mount for all cases, so consumers always receive the initial where clause without computing it themselves
- Eliminates the class of bug where new mutation paths forget to notify
- Fixes a stale closure bug in clearFilterState (now uses functional state updater)
- Simplifies setFilterState, clearFilterState, and reset

The useEffect approach is the correct React pattern here: onFilterClauseChanged is a side effect derived from state, so it belongs in an effect rather than being manually interleaved with state updates.