### PR TITLE
Move @osdk/client.test.ontology from peerDeps to devDeps

### DIFF
--- a/.changeset/move-test-ontology-to-devdeps.md
+++ b/.changeset/move-test-ontology-to-devdeps.md
@@ -1,0 +1,6 @@
+---
+"@osdk/react": patch
+"@osdk/client": patch
+---
+
+Move @osdk/client.test.ontology from peerDependencies to devDependencies to fix npm resolution errors in consuming repos

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -94,13 +94,9 @@
     "ws": "^8.18.3"
   },
   "peerDependencies": {
-    "@osdk/client.test.ontology": "workspace:^",
     "@osdk/shared.test": "workspace:^"
   },
   "peerDependenciesMeta": {
-    "@osdk/client.test.ontology": {
-      "optional": true
-    },
     "@osdk/shared.test": {
       "optional": true
     }
@@ -108,6 +104,7 @@
   "devDependencies": {
     "@microsoft/api-documenter": "^7.26.32",
     "@microsoft/api-extractor": "^7.52.11",
+    "@osdk/client.test.ontology": "workspace:*",
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
     "@types/geojson": "^7946.0.14",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -71,7 +71,6 @@
   "peerDependencies": {
     "@osdk/api": "^2.8.0",
     "@osdk/client": "^2.8.0",
-    "@osdk/client.test.ontology": "workspace:*",
     "@osdk/foundry.admin": "*",
     "@osdk/foundry.core": "*",
     "@types/react": "^17 || ^18 || ^19",
@@ -79,9 +78,6 @@
     "react-dom": "^17 || ^18 || ^19"
   },
   "peerDependenciesMeta": {
-    "@osdk/client.test.ontology": {
-      "optional": true
-    },
     "@osdk/foundry.admin": {
       "optional": true
     },
@@ -92,6 +88,7 @@
   "devDependencies": {
     "@osdk/api": "workspace:*",
     "@osdk/client": "workspace:*",
+    "@osdk/client.test.ontology": "workspace:*",
     "@osdk/foundry.admin": "catalog:foundry-platform-typescript",
     "@osdk/foundry.core": "catalog:foundry-platform-typescript",
     "@osdk/monorepo.api-extractor": "workspace:~",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1859,9 +1859,6 @@ importers:
       '@osdk/api':
         specifier: workspace:~
         version: link:../api
-      '@osdk/client.test.ontology':
-        specifier: workspace:^
-        version: link:../client.test.ontology
       '@osdk/client.unstable':
         specifier: workspace:*
         version: link:../client.unstable
@@ -1932,6 +1929,9 @@ importers:
       '@microsoft/api-extractor':
         specifier: ^7.52.11
         version: 7.52.11(@types/node@24.12.0)
+      '@osdk/client.test.ontology':
+        specifier: workspace:*
+        version: link:../client.test.ontology
       '@osdk/monorepo.api-extractor':
         specifier: workspace:~
         version: link:../monorepo.api-extractor
@@ -4477,9 +4477,6 @@ importers:
 
   packages/react:
     dependencies:
-      '@osdk/client.test.ontology':
-        specifier: workspace:*
-        version: link:../client.test.ontology
       react-dom:
         specifier: ^17 || ^18 || ^19
         version: 18.3.1(react@18.3.1)
@@ -4490,6 +4487,9 @@ importers:
       '@osdk/client':
         specifier: workspace:*
         version: link:../client
+      '@osdk/client.test.ontology':
+        specifier: workspace:*
+        version: link:../client.test.ontology
       '@osdk/foundry.admin':
         specifier: catalog:foundry-platform-typescript
         version: 2.57.0


### PR DESCRIPTION
## Summary

- Moves `@osdk/client.test.ontology` from `peerDependencies` to `devDependencies` in `@osdk/react` and `@osdk/client`
- `client.test.ontology` is a private, unpublished test package — it should never appear in published dependency metadata
- When published with `workspace:*` in peerDeps, it resolves to an exact version (e.g., `2.10.0`) that npm 7+ tries to install and fails on, since the package doesn't exist on the registry

## Problem

Installing `@osdk/react` in an external repo produces:

```
npm error ERESOLVE unable to resolve dependency tree
npm error Could not resolve dependency:
npm error peerOptional @osdk/client.test.ontology@"2.10.0" from @osdk/react@0.12.0
```

Even though the peer dep is marked `optional`, npm 7+ still attempts to resolve it and errors when it finds `@osdk/client.test.ontology@undefined`.

## Fix

Move `client.test.ontology` to `devDependencies` so it's available for in-repo type testing but doesn't appear in the published package metadata.

## Test plan

- [x] `pnpm install` succeeds
- [x] `pnpm turbo typecheck --filter=@osdk/react` passes
- [x] `pnpm turbo typecheck --filter=@osdk/client` passes
- [x] `pnpm turbo test --filter=@osdk/react` passes
- [x] `pnpm turbo test --filter=@osdk/client` passes