### PR TITLE
Attach SharedClientContext to mock client so platform fetches don't crash

### DIFF
--- a/.changeset/mock-client-platform-ctx.md
+++ b/.changeset/mock-client-platform-ctx.md
@@ -1,0 +1,5 @@
+---
+"@osdk/functions-testing.experimental": patch
+---
+
+Attach a `SharedClientContext` to the mock client so Foundry Platform API helpers (e.g. `Users.getCurrent(client)`) don't crash inside `foundryPlatformFetch` on an undefined `baseUrl` before a request is made. Callers mock the HTTP layer themselves (MSW, `vi.spyOn(globalThis, "fetch")`, etc.).

--- a/etc/functions-testing.experimental.report.api.md
+++ b/etc/functions-testing.experimental.report.api.md
@@ -6,7 +6,7 @@
 
 import type { Attachment } from '@osdk/api';
 import type { AttachmentMetadata } from '@osdk/api';
-import type { Client } from '@osdk/client';
+import { Client } from '@osdk/client';
 import type { CompileTimeMetadata } from '@osdk/api';
 import type { InterfaceDefinition } from '@osdk/api';
 import type { LinkedType } from '@osdk/api';

--- a/packages/functions-testing.experimental/package.json
+++ b/packages/functions-testing.experimental/package.json
@@ -66,9 +66,11 @@
     "@osdk/api": "workspace:~",
     "@osdk/client": "workspace:~",
     "@osdk/client.test.ontology": "workspace:~",
+    "@osdk/foundry.admin": "catalog:foundry-platform-typescript",
     "@osdk/functions": "workspace:~",
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
+    "msw": "^2.11.1",
     "typescript": "~5.5.4"
   },
   "publishConfig": {

--- a/packages/functions-testing.experimental/src/example-function-tests/platformApiWithMsw/platformApiWithMsw.test.ts
+++ b/packages/functions-testing.experimental/src/example-function-tests/platformApiWithMsw/platformApiWithMsw.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { getCurrent } from "@osdk/foundry.admin/User";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { createMockClient } from "../../mock/createMockClient.js";
+import { requireAdminUser } from "./platformApiWithMsw.js";
+
+type User = Awaited<ReturnType<typeof getCurrent>>;
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("platformApiWithMsw", () => {
+  it("resolves the current user when MSW handles the platform call", async () => {
+    server.use(
+      http.get(
+        "https://mock.invalid/api/v2/admin/users/getCurrent",
+        () =>
+          HttpResponse.json(
+            {
+              id: "user-1",
+              username: "alice@admin",
+              givenName: "Alice",
+              familyName: "Admin",
+              realm: "default",
+              status: "ACTIVE",
+              attributes: {},
+            } satisfies User,
+          ),
+      ),
+    );
+
+    const mockClient = createMockClient();
+    const username = await requireAdminUser(mockClient);
+
+    expect(username).toBe("alice@admin");
+  });
+
+  it("rejects when the user is not an admin", async () => {
+    server.use(
+      http.get(
+        "https://mock.invalid/api/v2/admin/users/getCurrent",
+        () =>
+          HttpResponse.json(
+            {
+              id: "user-2",
+              username: "bob@example.com",
+              givenName: "Bob",
+              familyName: "Example",
+              realm: "default",
+              status: "ACTIVE",
+              attributes: {},
+            } satisfies User,
+          ),
+      ),
+    );
+
+    const mockClient = createMockClient();
+
+    await expect(requireAdminUser(mockClient)).rejects.toThrow(
+      "User bob@example.com is not an admin",
+    );
+  });
+});

--- a/packages/functions-testing.experimental/src/example-function-tests/platformApiWithMsw/platformApiWithMsw.ts
+++ b/packages/functions-testing.experimental/src/example-function-tests/platformApiWithMsw/platformApiWithMsw.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Client } from "@osdk/client";
+import { Users } from "@osdk/foundry.admin";
+
+export async function requireAdminUser(
+  client: Client,
+): Promise<string> {
+  const user = await Users.getCurrent(client);
+  if (!user.username.endsWith("@admin")) {
+    throw new Error(`User ${user.username} is not an admin`);
+  }
+  return user.username;
+}

--- a/packages/functions-testing.experimental/src/mock/__tests__/createMockClient.test.ts
+++ b/packages/functions-testing.experimental/src/mock/__tests__/createMockClient.test.ts
@@ -238,6 +238,22 @@ describe("createMockClient", () => {
     });
   });
 
+  describe("platform client context", () => {
+    it("exposes a SharedClientContext so platform fetches don't crash", async () => {
+      const mockClient = createMockClient();
+      const ctx = (mockClient as any).__osdkClientContext;
+
+      expect(ctx).toBeDefined();
+      expect(typeof ctx.baseUrl).toBe("string");
+      expect(ctx.baseUrl.length).toBeGreaterThan(0);
+      // foundryPlatformFetch reads `ctx.baseUrl.endsWith("/")` — verify it doesn't throw.
+      expect(() => ctx.baseUrl.endsWith("/")).not.toThrow();
+      expect(typeof ctx.fetch).toBe("function");
+      expect(typeof ctx.tokenProvider).toBe("function");
+      await expect(ctx.tokenProvider()).resolves.toBeTypeOf("string");
+    });
+  });
+
   describe("query stubbing", () => {
     it("returns stubbed query result with parameters", async () => {
       const mockClient = createMockClient();

--- a/packages/functions-testing.experimental/src/mock/createMockClient.ts
+++ b/packages/functions-testing.experimental/src/mock/createMockClient.ts
@@ -23,7 +23,7 @@ import type {
   PageResult,
   QueryDefinition,
 } from "@osdk/api";
-import type { Client } from "@osdk/client";
+import { type Client, createPlatformClient } from "@osdk/client";
 import invariant from "tiny-invariant";
 import { type MockObjectSetBranded } from "./createMockObjectSet.js";
 import {
@@ -39,6 +39,11 @@ type ClientStub = Stub & { objectType: string };
 type QueryStub = { queryApiName: string; params: unknown; value: unknown };
 
 type IsOsdkObject<T> = T extends { $apiName: string } ? true : false;
+
+// Well-known string key used by Foundry Platform APIs to pull the
+// SharedClientContext (baseUrl, tokenProvider, fetch) off a client. Matches
+// the value of `symbolClientContext` in `@osdk/shared.client2`.
+const SYMBOL_CLIENT_CONTEXT = "__osdkClientContext";
 
 export interface FetchPageStubBuilder<T> {
   thenReturnObjects(objects: T[]): void;
@@ -222,6 +227,18 @@ export function createMockClient(): MockClient {
   mockClient.fetchMetadata = async () => {
     invariant(false, "fetchMetadata is not supported in mocks");
   };
+
+  // Attach a SharedClientContext so Foundry Platform API helpers
+  // (e.g. `Users.getCurrent(client)`) don't crash inside `foundryPlatformFetch`
+  // on an undefined `baseUrl` before any request is made. Callers intercept the
+  // actual HTTP layer themselves (MSW, vi.spyOn(globalThis, "fetch"), etc.).
+  Object.defineProperty(mockClient, SYMBOL_CLIENT_CONTEXT, {
+    value: createPlatformClient(
+      "https://mock.invalid/",
+      async () => "mock-token",
+    ),
+    enumerable: false,
+  });
 
   // TODO: Implement WriteableClient operations
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3950,6 +3950,9 @@ importers:
       '@osdk/client.test.ontology':
         specifier: workspace:~
         version: link:../client.test.ontology
+      '@osdk/foundry.admin':
+        specifier: catalog:foundry-platform-typescript
+        version: 2.57.0
       '@osdk/functions':
         specifier: workspace:~
         version: link:../functions
@@ -3959,6 +3962,9 @@ importers:
       '@osdk/monorepo.tsconfig':
         specifier: workspace:~
         version: link:../monorepo.tsconfig
+      msw:
+        specifier: ^2.11.1
+        version: 2.11.1(@types/node@24.12.0)(typescript@5.5.4)
       typescript:
         specifier: ~5.5.4
         version: 5.5.4
@@ -22363,7 +22369,7 @@ snapshots:
 
   '@bundled-es-modules/statuses@1.0.1':
     dependencies:
-      statuses: 2.0.1
+      statuses: 2.0.2
 
   '@changesets/apply-release-plan@7.0.13':
     dependencies:


### PR DESCRIPTION
## Summary
- Platform API helpers (e.g. `Users.getCurrent(client)`) read `ctx.baseUrl` off the client before making a request. `createMockClient()` never populated that context, so platform calls crashed inside `foundryPlatformFetch` on `ctx.baseUrl.endsWith(...)` before the fetch mock could see them.
- Attach a minimal `SharedClientContext` (baseUrl=`https://mock.invalid/`, stub token provider, `globalThis.fetch`) via the `__osdkClientContext` symbol so callers can intercept with MSW / `vi.spyOn(globalThis, "fetch")` / etc. as they would for any other fetch.
- No options exposed — mocks never actually hit the network, so there's nothing for the caller to configure.

## Test plan
- [x] `pnpm check --filter=@osdk/functions-testing.experimental` passes (lint, typecheck, test, check-attw, check-api, check-spelling).
- [x] New unit test verifies the context shape (baseUrl, fetch, tokenProvider) is attached and `.endsWith` doesn't throw.
- [x] New example test `platformApiWithMsw` drives `Users.getCurrent(mockClient)` end-to-end through MSW.

🤖 Generated with [Claude Code](https://claude.com/claude-code)