### PR TITLE
Support asymmetric matchers in mock stub argument matching

### DIFF
--- a/.changeset/mock-asymmetric-matchers.md
+++ b/.changeset/mock-asymmetric-matchers.md
@@ -1,0 +1,5 @@
+---
+"@osdk/functions-testing.experimental": patch
+---
+
+`deepEqual` (used to match stub args in `when` / `whenQuery`) now recognizes Vitest/Jest asymmetric matchers (`expect.any(...)`, `expect.anything()`, `expect.stringContaining(...)`, `expect.objectContaining(...)`, etc.). Previously matchers were compared by raw object shape and silently never matched.

--- a/packages/functions-testing.experimental/src/mock/__tests__/createMockClient.test.ts
+++ b/packages/functions-testing.experimental/src/mock/__tests__/createMockClient.test.ts
@@ -254,6 +254,56 @@ describe("createMockClient", () => {
     });
   });
 
+  describe("asymmetric matchers", () => {
+    it("matches whenQuery params with expect.any(...)", async () => {
+      const mockClient = createMockClient();
+
+      mockClient
+        .whenQuery(addOne, { n: expect.any(Number) as unknown as number })
+        .thenReturn(42);
+
+      expect(await mockClient(addOne).executeFunction({ n: 1 })).toBe(42);
+      expect(await mockClient(addOne).executeFunction({ n: 99 })).toBe(42);
+    });
+
+    it("matches where clauses with expect.objectContaining(...)", async () => {
+      const mockClient = createMockClient();
+      const emp = createMockOsdkObject(Employee, { employeeId: 7 });
+
+      mockClient
+        .when((c) =>
+          c(Employee)
+            .where(
+              expect.objectContaining({ office: { $eq: "NYC" } }) as any,
+            )
+            .fetchPage()
+        )
+        .thenReturnObjects([emp]);
+
+      const result = await mockClient(Employee)
+        .where({ office: { $eq: "NYC" } })
+        .fetchPage();
+
+      expect(result.data).toHaveLength(1);
+    });
+
+    it("matches whenQuery params with expect.anything()", async () => {
+      const mockClient = createMockClient();
+
+      mockClient
+        .whenQuery(queryTypeReturnsArray, {
+          people: expect.anything() as unknown as string[],
+        })
+        .thenReturn(["ok"]);
+
+      expect(
+        await mockClient(queryTypeReturnsArray).executeFunction({
+          people: ["whatever"],
+        }),
+      ).toEqual(["ok"]);
+    });
+  });
+
   describe("query stubbing", () => {
     it("returns stubbed query result with parameters", async () => {
       const mockClient = createMockClient();

--- a/packages/functions-testing.experimental/src/mock/createMockObjectSetWithResolver.ts
+++ b/packages/functions-testing.experimental/src/mock/createMockObjectSetWithResolver.ts
@@ -138,6 +138,14 @@ export function resolveStub(
 
 export function deepEqual(a: unknown, b: unknown): boolean {
   if (a === b) return true;
+
+  // Support Vitest / Jest asymmetric matchers (e.g. expect.any(String),
+  // expect.anything(), expect.stringContaining(...), expect.objectContaining(...))
+  // in either position. Without this check, matchers would be compared by their
+  // raw object shape and silently never match stub params.
+  if (isAsymmetricMatcher(a)) return a.asymmetricMatch(b);
+  if (isAsymmetricMatcher(b)) return b.asymmetricMatch(a);
+
   if (a == null || b == null) return a === b;
   if (typeof a !== typeof b) return false;
   if (Array.isArray(a) && Array.isArray(b)) {
@@ -153,4 +161,13 @@ export function deepEqual(a: unknown, b: unknown): boolean {
     );
   }
   return false;
+}
+
+function isAsymmetricMatcher(
+  x: unknown,
+): x is { asymmetricMatch: (other: unknown) => boolean } {
+  return x != null
+    && typeof x === "object"
+    && typeof (x as { asymmetricMatch?: unknown }).asymmetricMatch
+      === "function";
 }


### PR DESCRIPTION
`deepEqual` in `@osdk/functions-testing.experimental` now recognizes Vitest/Jest asymmetric matchers so they can be used as stub parameters.

- `expect.any(...)`, `expect.anything()`, `expect.stringContaining(...)`, `expect.objectContaining(...)` etc. now match against stub args
- Previously matchers were compared by raw object shape and silently never matched
- Works in either position (matcher on the stub side or on the actual-arg side)