### PR TITLE
Improve mock link error behavior in createMockOsdkObject

### DIFF
--- a/.changeset/mock-link-errors.md
+++ b/.changeset/mock-link-errors.md
@@ -1,0 +1,5 @@
+---
+"@osdk/functions-testing.experimental": patch
+---
+
+Accessing a link that wasn't configured on a `createMockOsdkObject` mock no longer silently returns `undefined`. The accessor now exists, and its `fetchOne()` rejects / `fetchOneWithErrors()` resolves with a descriptive error naming the link, object type, and primary key.

--- a/packages/functions-testing.experimental/src/mock/__tests__/createMockOsdkObject.test.ts
+++ b/packages/functions-testing.experimental/src/mock/__tests__/createMockOsdkObject.test.ts
@@ -181,12 +181,41 @@ describe("createMockOsdkObject", () => {
   });
 
   describe("$link", () => {
-    it("returns undefined when $link is accessed without configuration", () => {
+    it("missing link: accessor exists, fetchOne rejects, fetchOneWithErrors returns error", async () => {
       const mockEmployee = createMockOsdkObject(Employee, {
         employeeId: 1,
       });
 
-      expect(mockEmployee.$link).toBeUndefined();
+      expect(mockEmployee.$link.officeLink).toBeDefined();
+
+      await expect(mockEmployee.$link.officeLink.fetchOne()).rejects.toThrow(
+        /Link "officeLink" was not configured on mock Employee/,
+      );
+
+      const result = await mockEmployee.$link.officeLink
+        .fetchOneWithErrors();
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.error!.message).toMatch(
+        /Link "officeLink" was not configured on mock Employee/,
+      );
+      expect(result.value).toBeUndefined();
+    });
+
+    it("missing link is isolated: other configured links still work", async () => {
+      const mockOffice = createMockOsdkObject(Office, {
+        officeId: "nyc",
+        name: "New York Office",
+      });
+      const mockEmployee = createMockOsdkObject(
+        Employee,
+        { employeeId: 1 },
+        { links: { officeLink: mockOffice } },
+      );
+
+      expect(await mockEmployee.$link.officeLink.fetchOne()).toBe(mockOffice);
+      await expect(mockEmployee.$link.lead.fetchOne()).rejects.toThrow(
+        /Link "lead" was not configured on mock Employee/,
+      );
     });
 
     describe("single links", () => {

--- a/packages/functions-testing.experimental/src/mock/createMockOsdkObject.ts
+++ b/packages/functions-testing.experimental/src/mock/createMockOsdkObject.ts
@@ -44,6 +44,37 @@ function createSingleLinkStub<T extends ObjectTypeDefinition>(
   };
 }
 
+function createMissingLinkStub(
+  linkName: string,
+  objectApiName: string,
+  primaryKey: string,
+): {
+  fetchOne: () => Promise<never>;
+  fetchOneWithErrors: () => Promise<{ error: Error; value?: never }>;
+  fetchPage: () => Promise<never>;
+  asyncIter: () => never;
+  aggregate: () => never;
+} {
+  const makeError = () =>
+    new Error(
+      `Link "${linkName}" was not configured on mock ${objectApiName} `
+        + `object with primary key ${primaryKey}. `
+        + `Pass it via the \`links\` option on createMockOsdkObject, or `
+        + `pass an Error instance to simulate a link failure.`,
+    );
+  return {
+    fetchOne: () => Promise.reject(makeError()),
+    fetchOneWithErrors: () => Promise.resolve({ error: makeError() }),
+    fetchPage: () => Promise.reject(makeError()),
+    asyncIter: () => {
+      throw makeError();
+    },
+    aggregate: () => {
+      throw makeError();
+    },
+  };
+}
+
 function createManyLinkStub<T extends ObjectTypeDefinition>(
   linkedObjects: Array<Osdk.Instance<T>>,
 ): {
@@ -205,11 +236,8 @@ export function createMockOsdkObject<
 
   Object.defineProperty(mockObject, "$link", {
     get() {
-      if (links == null) {
-        return undefined;
-      }
       const linkAccessors: Record<string, unknown> = {};
-      for (const [linkName, linkValue] of Object.entries(links)) {
+      for (const [linkName, linkValue] of Object.entries(links ?? {})) {
         if (linkValue == null) {
           continue;
         }
@@ -225,7 +253,18 @@ export function createMockOsdkObject<
           );
         }
       }
-      return linkAccessors;
+      return new Proxy(linkAccessors, {
+        get(target, prop) {
+          if (typeof prop === "symbol" || prop in target) {
+            return target[prop as string];
+          }
+          return createMissingLinkStub(
+            prop,
+            objectType.apiName,
+            String($primaryKey),
+          );
+        },
+      });
     },
     enumerable: true,
   });


### PR DESCRIPTION
Improves the error paths on `$link` accessors in `createMockOsdkObject` so tests can exercise link failure branches.

Accessing a link that wasn't set up no longer silently returns `undefined` — the accessor is returned and surfaces a descriptive error (link name + object type + primary key) via `fetchOne` rejection / `fetchOneWithErrors` result