### PR TITLE
Add thenThrow to whenQuery stub builder

### DIFF
--- a/.changeset/mock-query-then-throw.md
+++ b/.changeset/mock-query-then-throw.md
@@ -1,0 +1,5 @@
+---
+"@osdk/functions-testing.experimental": patch
+---
+
+Add `thenThrow(error)` to `whenQuery(...)` stub builder. Lets tests explicitly configure a query's `executeFunction` to reject with a specific error, instead of only being able to exercise the implicit "no stub registered" error path.

--- a/etc/functions-testing.experimental.report.api.md
+++ b/etc/functions-testing.experimental.report.api.md
@@ -6,7 +6,7 @@
 
 import type { Attachment } from '@osdk/api';
 import type { AttachmentMetadata } from '@osdk/api';
-import type { Client } from '@osdk/client';
+import { Client } from '@osdk/client';
 import type { CompileTimeMetadata } from '@osdk/api';
 import type { InterfaceDefinition } from '@osdk/api';
 import type { LinkedType } from '@osdk/api';
@@ -82,6 +82,8 @@ export interface MockOsdkObjectOptions<Q extends ObjectTypeDefinition = ObjectTy
 export interface QueryStubBuilder<T> {
     	// (undocumented)
     thenReturn(result: T): void;
+    	// (undocumented)
+    thenThrow(error: Error): void;
 }
 
 // Warning: (ae-forgotten-export) The symbol "IsOsdkObject" needs to be exported by the entry point index.d.ts

--- a/etc/functions-testing.experimental.report.api.md
+++ b/etc/functions-testing.experimental.report.api.md
@@ -6,7 +6,7 @@
 
 import type { Attachment } from '@osdk/api';
 import type { AttachmentMetadata } from '@osdk/api';
-import { Client } from '@osdk/client';
+import type { Client } from '@osdk/client';
 import type { CompileTimeMetadata } from '@osdk/api';
 import type { InterfaceDefinition } from '@osdk/api';
 import type { LinkedType } from '@osdk/api';

--- a/packages/functions-testing.experimental/src/mock/__tests__/createMockClient.test.ts
+++ b/packages/functions-testing.experimental/src/mock/__tests__/createMockClient.test.ts
@@ -321,6 +321,35 @@ describe("createMockClient", () => {
         mockClient(addOne).executeFunction({ n: 5 }),
       ).rejects.toThrow("No stub for query 'addOne'");
     });
+
+    it("thenThrow: executeFunction rejects with the configured error", async () => {
+      const mockClient = createMockClient();
+      const err = new Error("rate limited");
+
+      mockClient.whenQuery(addOne, { n: 5 }).thenThrow(err);
+
+      await expect(
+        mockClient(addOne).executeFunction({ n: 5 }),
+      ).rejects.toBe(err);
+    });
+
+    it("thenThrow: only the matching params trigger the error", async () => {
+      const mockClient = createMockClient();
+      mockClient.whenQuery(addOne, { n: 1 }).thenThrow(new Error("boom"));
+      mockClient.whenQuery(addOne, { n: 2 }).thenReturn(99);
+
+      await expect(mockClient(addOne).executeFunction({ n: 1 })).rejects
+        .toThrow("boom");
+      expect(await mockClient(addOne).executeFunction({ n: 2 })).toBe(99);
+    });
+
+    it("thenThrow: unrelated params still surface the default 'No stub' error", async () => {
+      const mockClient = createMockClient();
+      mockClient.whenQuery(addOne, { n: 1 }).thenThrow(new Error("boom"));
+
+      await expect(mockClient(addOne).executeFunction({ n: 99 })).rejects
+        .toThrow("No stub for query 'addOne'");
+    });
   });
 
   describe("whenObjectSet (standalone mock object set)", () => {

--- a/packages/functions-testing.experimental/src/mock/createMockClient.ts
+++ b/packages/functions-testing.experimental/src/mock/createMockClient.ts
@@ -36,7 +36,12 @@ import {
 
 type ClientStub = Stub & { objectType: string };
 
-type QueryStub = { queryApiName: string; params: unknown; value: unknown };
+type QueryStub = {
+  queryApiName: string;
+  params: unknown;
+  value?: unknown;
+  error?: Error;
+};
 
 type IsOsdkObject<T> = T extends { $apiName: string } ? true : false;
 
@@ -59,6 +64,13 @@ export interface AggregateStubBuilder<T> {
 
 export interface QueryStubBuilder<T> {
   thenReturn(result: T): void;
+  /**
+   * Register an error to be thrown when a matching query call is made.
+   * `executeFunction` will reject with the provided error, rather than the
+   * generic "No stub for query" fallback that fires when no stub is
+   * registered at all.
+   */
+  thenThrow(error: Error): void;
 }
 
 export type StubBuilderFor<T> = T extends PageResult<infer U>
@@ -113,6 +125,9 @@ export function createMockClient(): MockClient {
     for (const stub of queryStubs) {
       if (stub.queryApiName !== queryApiName) continue;
       if (deepEqual(stub.params, params)) {
+        if (stub.error !== undefined) {
+          throw stub.error;
+        }
         return stub.value;
       }
     }
@@ -214,6 +229,13 @@ export function createMockClient(): MockClient {
           queryApiName: query.apiName,
           params,
           value: result,
+        });
+      },
+      thenThrow: (error: Error) => {
+        queryStubs.push({
+          queryApiName: query.apiName,
+          params,
+          error,
         });
       },
     };

--- a/packages/functions-testing.experimental/src/mock/createMockClient.ts
+++ b/packages/functions-testing.experimental/src/mock/createMockClient.ts
@@ -64,12 +64,6 @@ export interface AggregateStubBuilder<T> {
 
 export interface QueryStubBuilder<T> {
   thenReturn(result: T): void;
-  /**
-   * Register an error to be thrown when a matching query call is made.
-   * `executeFunction` will reject with the provided error, rather than the
-   * generic "No stub for query" fallback that fires when no stub is
-   * registered at all.
-   */
   thenThrow(error: Error): void;
 }
 


### PR DESCRIPTION
Adds `thenThrow(error)` to `whenQuery(...)` in `@osdk/functions-testing.experimental` so tests can explicitly configure the error a query's `executeFunction` rejects with.

- Previously the only way to hit the rejected-promise branch was to not register a stub at all (which produces the generic "No stub for query '<name>'" error)
- `thenThrow` rejects with the exact Error instance the test passed in, making error-branch coverage easy
- Only matching params trigger the thrown error; unrelated params still surface the default "No stub" message