### PR TITLE
Version Packages

### DIFF
--- a/.changeset/mock-query-then-throw.md
+++ b/.changeset/mock-query-then-throw.md
@@ -1,5 +1,0 @@
----
-"@osdk/functions-testing.experimental": patch
----
-
-Add `thenThrow(error)` to `whenQuery(...)` stub builder. Lets tests explicitly configure a query's `executeFunction` to reject with a specific error, instead of only being able to exercise the implicit "no stub registered" error path.

--- a/.changeset/update-docs-experimental-imports.md
+++ b/.changeset/update-docs-experimental-imports.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-components": patch
----
-
-Update docs to use new per-component experimental import paths

--- a/packages/functions-testing.experimental/CHANGELOG.md
+++ b/packages/functions-testing.experimental/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/functions-testing.experimental
 
+## 0.6.0
+
+### Minor Changes
+
+- 8e4472c: Add `thenThrow(error)` to `whenQuery(...)` stub builder. Lets tests explicitly configure a query's `executeFunction` to reject with a specific error, instead of only being able to exercise the implicit "no stub registered" error path.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/functions-testing.experimental/package.json
+++ b/packages/functions-testing.experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/functions-testing.experimental",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/react-components-styles/CHANGELOG.md
+++ b/packages/react-components-styles/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/react-components-styles
 
+## 0.6.0
+
 ## 0.5.0
 
 ## 0.4.0

--- a/packages/react-components-styles/package.json
+++ b/packages/react-components-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/react-components-styles",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/react-components
 
+## 0.6.0
+
+### Minor Changes
+
+- 4f3c57c: Update docs to use new per-component experimental import paths
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/react-components",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.


# Releases
## @osdk/functions-testing.experimental@0.6.0

### Minor Changes

-   8e4472c: Add `thenThrow(error)` to `whenQuery(...)` stub builder. Lets tests explicitly configure a query's `executeFunction` to reject with a specific error, instead of only being able to exercise the implicit "no stub registered" error path.

## @osdk/react-components@0.6.0

### Minor Changes

-   4f3c57c: Update docs to use new per-component experimental import paths

## @osdk/react-components-styles@0.6.0


