### PR TITLE
Update docs with new per-component experimental import paths

### DIFF
--- a/.changeset/update-docs-experimental-imports.md
+++ b/.changeset/update-docs-experimental-imports.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Update docs to use new per-component experimental import paths

--- a/packages/e2e.sandbox.officenetwork/src/components/EmployeeFilters.tsx
+++ b/packages/e2e.sandbox.officenetwork/src/components/EmployeeFilters.tsx
@@ -17,7 +17,7 @@
 import {
   type FilterDefinitionUnion,
   FilterList,
-} from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/filter-list";
 import React, { useCallback, useMemo, useState } from "react";
 import { Employee } from "../generatedNoCheck2/index.js";
 

--- a/packages/e2e.sandbox.peopleapp/src/app/employees/EmployeesTable.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/employees/EmployeesTable.tsx
@@ -1,6 +1,6 @@
 import type { DerivedProperty, Osdk } from "@osdk/api";
-import type { ColumnDefinition } from "@osdk/react-components/experimental";
-import { ObjectTable } from "@osdk/react-components/experimental";
+import type { ColumnDefinition } from "@osdk/react-components/experimental/object-table";
+import { ObjectTable } from "@osdk/react-components/experimental/object-table";
 import { useOsdkClient } from "@osdk/react/experimental";
 import React, { useCallback } from "react";
 import {

--- a/packages/e2e.sandbox.peopleapp/src/app/employees/EmployeesWithFilterList.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/employees/EmployeesWithFilterList.tsx
@@ -18,7 +18,7 @@ import type { WhereClause } from "@osdk/api";
 import {
   type FilterDefinitionUnion,
   FilterList,
-} from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/filter-list";
 import "@osdk/react-components/styles.css";
 import { useOsdkObjects } from "@osdk/react/experimental";
 import { useState } from "react";

--- a/packages/e2e.sandbox.peopleapp/src/app/form/page.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/form/page.tsx
@@ -1,9 +1,9 @@
 import type { ObjectSet, ObjectTypeDefinition } from "@osdk/api";
-import { BaseForm } from "@osdk/react-components/experimental";
+import { BaseForm } from "@osdk/react-components/experimental/action-form";
 import type {
   BaseFormFieldProps,
   RendererFieldDefinition,
-} from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/action-form";
 import { useCallback, useMemo, useState } from "react";
 import { $ } from "../../foundryClient.js";
 import { Employee } from "../../generatedNoCheck2/index.js";

--- a/packages/e2e.sandbox.peopleapp/src/app/offices/page.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/offices/page.tsx
@@ -1,4 +1,4 @@
-import { ObjectTable } from "@osdk/react-components/experimental";
+import { ObjectTable } from "@osdk/react-components/experimental/object-table";
 import { useState } from "react";
 import { Section } from "../../components/Section.js";
 import { Office } from "../../generatedNoCheck2/index.js";

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
@@ -15,12 +15,13 @@
  */
 
 import type { WhereClause } from "@osdk/api";
-import { FilterList, ObjectTable } from "@osdk/react-components/experimental";
 import type {
   FilterDefinitionUnion,
   FilterListProps,
   FilterState,
-} from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/filter-list";
+import { FilterList } from "@osdk/react-components/experimental/filter-list";
+import { ObjectTable } from "@osdk/react-components/experimental/object-table";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useCallback, useMemo, useState } from "react";
 import { useArgs } from "storybook/preview-api";

--- a/packages/react-components-storybook/src/stories/MarkdownRenderer/MarkdownRenderer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/MarkdownRenderer/MarkdownRenderer.stories.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import type { MarkdownRendererProps } from "@osdk/react-components/experimental";
-import { MarkdownRenderer } from "@osdk/react-components/experimental";
+import type { MarkdownRendererProps } from "@osdk/react-components/experimental/markdown-renderer";
+import { MarkdownRenderer } from "@osdk/react-components/experimental/markdown-renderer";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 const SAMPLE_MARKDOWN = `# Sample Document
@@ -39,7 +39,7 @@ This is a **sample markdown** document that demonstrates the *MarkdownRenderer* 
 ## Code Example
 
 \`\`\`typescript
-import { MarkdownRenderer } from "@osdk/react-components/experimental";
+import { MarkdownRenderer } from "@osdk/react-components/experimental/markdown-renderer";
 
 function App() {
   return <MarkdownRenderer content="# Hello World" />;
@@ -144,7 +144,7 @@ export const MinimalContent: Story = {
     docs: {
       source: {
         code:
-          `import { MarkdownRenderer } from "@osdk/react-components/experimental";
+          `import { MarkdownRenderer } from "@osdk/react-components/experimental/markdown-renderer";
 
 <MarkdownRenderer content="# Hello World\\n\\nA simple paragraph with **bold** and *italic*." />`,
       },

--- a/packages/react-components-storybook/src/stories/ObjectTable/BaseTable.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/BaseTable.stories.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import type { BaseTableProps } from "@osdk/react-components/experimental";
-import { BaseTable } from "@osdk/react-components/experimental";
+import type { BaseTableProps } from "@osdk/react-components/experimental/object-table";
+import { BaseTable } from "@osdk/react-components/experimental/object-table";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type {
   ColumnPinningState,
@@ -189,7 +189,7 @@ export const Default: Story = {
     docs: {
       source: {
         code: `
-import { BaseTable } from "@osdk/react-components/experimental";
+import { BaseTable } from "@osdk/react-components/experimental/object-table";
 import { 
   getCoreRowModel,
   useReactTable,
@@ -250,7 +250,7 @@ export const WithSorting: Story = {
     docs: {
       source: {
         code: `
-import { BaseTable } from "@osdk/react-components/experimental";
+import { BaseTable } from "@osdk/react-components/experimental/object-table";
 import {
   getCoreRowModel,
   getSortedRowModel,
@@ -319,7 +319,7 @@ export const WithColumnPinning: Story = {
     docs: {
       source: {
         code: `
-import { BaseTable } from "@osdk/react-components/experimental";
+import { BaseTable } from "@osdk/react-components/experimental/object-table";
 import {
   getCoreRowModel,
   useReactTable,
@@ -389,7 +389,7 @@ export const WithColumnResizing: Story = {
     docs: {
       source: {
         code: `
-import { BaseTable } from "@osdk/react-components/experimental";
+import { BaseTable } from "@osdk/react-components/experimental/object-table";
 import {
   getCoreRowModel,
   useReactTable,
@@ -457,7 +457,7 @@ export const WithColumnConfig: Story = {
     docs: {
       source: {
         code: `
-import { BaseTable } from "@osdk/react-components/experimental";
+import { BaseTable } from "@osdk/react-components/experimental/object-table";
 import {
   getCoreRowModel,
   getSortedRowModel,

--- a/packages/react-components-storybook/src/stories/ObjectTable/ColumnConfigDialog.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/ColumnConfigDialog.stories.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import type { ColumnConfigDialogProps } from "@osdk/react-components/experimental";
-import { ColumnConfigDialog } from "@osdk/react-components/experimental";
+import type { ColumnConfigDialogProps } from "@osdk/react-components/experimental/object-table";
+import { ColumnConfigDialog } from "@osdk/react-components/experimental/object-table";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useCallback, useState } from "react";
 import { fn } from "storybook/test";
@@ -95,7 +95,7 @@ export const Default: Story = {
     docs: {
       source: {
         code:
-          `import { ColumnConfigDialog } from "@osdk/react-components/experimental";
+          `import { ColumnConfigDialog } from "@osdk/react-components/experimental/object-table";
 
 const [isOpen, setIsOpen] = useState(false);
 

--- a/packages/react-components-storybook/src/stories/ObjectTable/MultiColumnSortDialog.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/MultiColumnSortDialog.stories.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import type { MultiColumnSortDialogProps } from "@osdk/react-components/experimental";
-import { MultiColumnSortDialog } from "@osdk/react-components/experimental";
+import type { MultiColumnSortDialogProps } from "@osdk/react-components/experimental/object-table";
+import { MultiColumnSortDialog } from "@osdk/react-components/experimental/object-table";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
@@ -85,7 +85,7 @@ export const Default: Story = {
     docs: {
       source: {
         code:
-          `import { MultiColumnSortDialog } from "@osdk/react-components/experimental";
+          `import { MultiColumnSortDialog } from "@osdk/react-components/experimental/object-table";
 
 const [isOpen, setIsOpen] = useState(false);
 

--- a/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.stories.tsx
@@ -15,12 +15,12 @@
  */
 
 import type { DerivedProperty, Osdk } from "@osdk/api";
-import { ObjectTable } from "@osdk/react-components/experimental";
+import { ObjectTable } from "@osdk/react-components/experimental/object-table";
 import type {
   CellEditInfo,
   ColumnDefinition,
   ObjectTableProps,
-} from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/object-table";
 import { useOsdkClient } from "@osdk/react/experimental";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useCallback, useState } from "react";

--- a/packages/react-components-storybook/src/stories/ObjectTable/Recipes/WithColumnConfigDialog.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/Recipes/WithColumnConfigDialog.stories.tsx
@@ -17,11 +17,11 @@
 import {
   ColumnConfigDialog,
   ObjectTable,
-} from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/object-table";
 import type {
   ColumnDefinition,
   ObjectTableProps,
-} from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/object-table";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useCallback, useMemo, useState } from "react";
 import { fauxFoundry } from "../../../mocks/fauxFoundry.js";

--- a/packages/react-components-storybook/src/stories/PdfViewer/AnnotationLayer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/AnnotationLayer.stories.tsx
@@ -17,8 +17,8 @@
 import type {
   PdfAnnotation,
   PdfViewerAnnotationLayerProps,
-} from "@osdk/react-components/experimental";
-import { PdfViewerAnnotationLayer } from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/pdf-viewer";
+import { PdfViewerAnnotationLayer } from "@osdk/react-components/experimental/pdf-viewer";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 

--- a/packages/react-components-storybook/src/stories/PdfViewer/Content.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/Content.stories.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import type { PdfViewerContentProps } from "@osdk/react-components/experimental";
-import { PdfViewerContent } from "@osdk/react-components/experimental";
+import type { PdfViewerContentProps } from "@osdk/react-components/experimental/pdf-viewer";
+import { PdfViewerContent } from "@osdk/react-components/experimental/pdf-viewer";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 

--- a/packages/react-components-storybook/src/stories/PdfViewer/Features/PdfViewerFeatures.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/Features/PdfViewerFeatures.stories.tsx
@@ -21,8 +21,11 @@ import type {
   PdfTextHighlightEvent,
   PdfViewerMediaProps,
   PdfViewerProps,
-} from "@osdk/react-components/experimental";
-import { BasePdfViewer, PdfViewer } from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/pdf-viewer";
+import {
+  BasePdfViewer,
+  PdfViewer,
+} from "@osdk/react-components/experimental/pdf-viewer";
 import { useOsdkObject } from "@osdk/react/experimental";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { delay, http } from "msw";
@@ -152,7 +155,7 @@ export const WithPdfUrl: StoryObj<PdfViewerProps> = {
     docs: {
       source: {
         code:
-          `import { BasePdfViewer } from "@osdk/react-components/experimental";
+          `import { BasePdfViewer } from "@osdk/react-components/experimental/pdf-viewer";
 
 <BasePdfViewer src="/compressed.tracemonkey-pldi-09.pdf" />`,
       },
@@ -196,7 +199,8 @@ export const WithAnnotations: Story = {
   parameters: {
     docs: {
       source: {
-        code: `import { PdfViewer } from "@osdk/react-components/experimental";
+        code:
+          `import { PdfViewer } from "@osdk/react-components/experimental/pdf-viewer";
 
 <PdfViewer
   media={myMediaObject}
@@ -220,7 +224,8 @@ export const WithSidebar: Story = {
   parameters: {
     docs: {
       source: {
-        code: `import { PdfViewer } from "@osdk/react-components/experimental";
+        code:
+          `import { PdfViewer } from "@osdk/react-components/experimental/pdf-viewer";
 
 <PdfViewer media={myMediaObject} initialSidebarOpen />`,
       },
@@ -235,7 +240,8 @@ export const CustomScale: Story = {
   parameters: {
     docs: {
       source: {
-        code: `import { PdfViewer } from "@osdk/react-components/experimental";
+        code:
+          `import { PdfViewer } from "@osdk/react-components/experimental/pdf-viewer";
 
 <PdfViewer media={myMediaObject} initialScale={1.5} />`,
       },
@@ -250,7 +256,8 @@ export const WithDownload: Story = {
   parameters: {
     docs: {
       source: {
-        code: `import { PdfViewer } from "@osdk/react-components/experimental";
+        code:
+          `import { PdfViewer } from "@osdk/react-components/experimental/pdf-viewer";
 
 <PdfViewer media={myMediaObject} enableDownload />`,
       },
@@ -266,7 +273,8 @@ export const WithOutlineSidebar: Story = {
   parameters: {
     docs: {
       source: {
-        code: `import { PdfViewer } from "@osdk/react-components/experimental";
+        code:
+          `import { PdfViewer } from "@osdk/react-components/experimental/pdf-viewer";
 
 <PdfViewer media={myMediaObject} initialSidebarOpen sidebarMode="outline" />`,
       },
@@ -351,8 +359,8 @@ export const WithHighlightMode: StoryObj<PdfViewerProps> = {
     docs: {
       source: {
         code: `import { useState, useCallback } from "react";
-import { BasePdfViewer } from "@osdk/react-components/experimental";
-import type { PdfAnnotation, PdfTextHighlightEvent } from "@osdk/react-components/experimental";
+import { BasePdfViewer } from "@osdk/react-components/experimental/pdf-viewer";
+import type { PdfAnnotation, PdfTextHighlightEvent } from "@osdk/react-components/experimental/pdf-viewer";
 
 function MyPdfViewer({ src }: { src: string }) {
   const [annotations, setAnnotations] = useState<PdfAnnotation[]>([]);
@@ -412,7 +420,7 @@ export const InteractiveForm: StoryObj<PdfViewerProps> = {
     docs: {
       source: {
         code:
-          `import { BasePdfViewer } from "@osdk/react-components/experimental";
+          `import { BasePdfViewer } from "@osdk/react-components/experimental/pdf-viewer";
 
 <BasePdfViewer
   src="https://example.com/interactive-form.pdf"
@@ -444,7 +452,8 @@ export const WithOsdkMedia: Story = {
   parameters: {
     docs: {
       source: {
-        code: `import { PdfViewer } from "@osdk/react-components/experimental";
+        code:
+          `import { PdfViewer } from "@osdk/react-components/experimental/pdf-viewer";
 
 // Access media from an OSDK object's media reference property
 const employee = useOsdkObject(Employee, employeePk);

--- a/packages/react-components-storybook/src/stories/PdfViewer/OutlineSidebar.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/OutlineSidebar.stories.tsx
@@ -17,8 +17,8 @@
 import type {
   OutlineItem,
   PdfViewerOutlineSidebarProps,
-} from "@osdk/react-components/experimental";
-import { PdfViewerOutlineSidebar } from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/pdf-viewer";
+import { PdfViewerOutlineSidebar } from "@osdk/react-components/experimental/pdf-viewer";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 

--- a/packages/react-components-storybook/src/stories/PdfViewer/Recipes/AnnotationCreator/AnnotationCreator.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/Recipes/AnnotationCreator/AnnotationCreator.stories.tsx
@@ -19,8 +19,8 @@ import type {
   PdfRect,
   PdfViewerHandle,
   PdfViewerProps,
-} from "@osdk/react-components/experimental";
-import { BasePdfViewer } from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/pdf-viewer";
+import { BasePdfViewer } from "@osdk/react-components/experimental/pdf-viewer";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 

--- a/packages/react-components-storybook/src/stories/PdfViewer/Recipes/AnnotationExplorer/AnnotationExplorer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/Recipes/AnnotationExplorer/AnnotationExplorer.stories.tsx
@@ -21,7 +21,7 @@ import type {
   PdfAnnotationRenderProps,
   PdfCustomAnnotation,
   PdfViewerProps,
-} from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/pdf-viewer";
 import {
   BasePdfViewer,
   PdfViewerAnnotationLayer,
@@ -30,7 +30,7 @@ import {
   PdfViewerToolbar,
   usePdfViewerContext,
   usePdfViewerInstance,
-} from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/pdf-viewer";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import React, { useCallback, useMemo, useState } from "react";
 import { createPortal } from "react-dom";

--- a/packages/react-components-storybook/src/stories/PdfViewer/Recipes/CustomAnnotations/CustomAnnotations.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/Recipes/CustomAnnotations/CustomAnnotations.stories.tsx
@@ -18,8 +18,8 @@ import type {
   PdfAnnotation,
   PdfAnnotationRenderProps,
   PdfViewerProps,
-} from "@osdk/react-components/experimental";
-import { BasePdfViewer } from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/pdf-viewer";
+import { BasePdfViewer } from "@osdk/react-components/experimental/pdf-viewer";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
@@ -134,8 +134,8 @@ export const CustomAnnotation: Story = {
     docs: {
       source: {
         code:
-          `import type { PdfAnnotationRenderProps } from "@osdk/react-components/experimental";
-import { BasePdfViewer } from "@osdk/react-components/experimental";
+          `import type { PdfAnnotationRenderProps } from "@osdk/react-components/experimental/pdf-viewer";
+import { BasePdfViewer } from "@osdk/react-components/experimental/pdf-viewer";
 
 function TooltipAnnotation({ annotation }: PdfAnnotationRenderProps) {
   return (

--- a/packages/react-components-storybook/src/stories/PdfViewer/Recipes/InteractiveForm/InteractiveForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/Recipes/InteractiveForm/InteractiveForm.stories.tsx
@@ -19,8 +19,8 @@
 import type {
   PdfFormFieldValue,
   PdfViewerProps,
-} from "@osdk/react-components/experimental";
-import { BasePdfViewer } from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/pdf-viewer";
+import { BasePdfViewer } from "@osdk/react-components/experimental/pdf-viewer";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import {
   PDFCheckBox,
@@ -348,7 +348,7 @@ export const InteractiveForm: Story = {
         code: `// This story demonstrates using formData and onFormChange
 // to build a sidebar that tracks form values and loads presets.
 // Uses pdf-lib to download the filled PDF.
-import { BasePdfViewer } from "@osdk/react-components/experimental";
+import { BasePdfViewer } from "@osdk/react-components/experimental/pdf-viewer";
 import { PDFDocument } from "pdf-lib";
 
 const [formData, setFormData] = useState<Record<string, PdfFormFieldValue>>();

--- a/packages/react-components-storybook/src/stories/PdfViewer/SearchBar.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/SearchBar.stories.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import type { PdfViewerSearchBarProps } from "@osdk/react-components/experimental";
-import { PdfViewerSearchBar } from "@osdk/react-components/experimental";
+import type { PdfViewerSearchBarProps } from "@osdk/react-components/experimental/pdf-viewer";
+import { PdfViewerSearchBar } from "@osdk/react-components/experimental/pdf-viewer";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 

--- a/packages/react-components-storybook/src/stories/PdfViewer/ThumbnailSidebar.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/ThumbnailSidebar.stories.tsx
@@ -17,7 +17,7 @@
 import {
   PdfViewerSidebar,
   usePdfDocument,
-} from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/pdf-viewer";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 

--- a/packages/react-components-storybook/src/stories/PdfViewer/Toolbar.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/Toolbar.stories.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import type { PdfViewerToolbarProps } from "@osdk/react-components/experimental";
-import { PdfViewerToolbar } from "@osdk/react-components/experimental";
+import type { PdfViewerToolbarProps } from "@osdk/react-components/experimental/pdf-viewer";
+import { PdfViewerToolbar } from "@osdk/react-components/experimental/pdf-viewer";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 

--- a/packages/react-components-storybook/src/stories/TiffRenderer/TiffRendererFeatures.stories.tsx
+++ b/packages/react-components-storybook/src/stories/TiffRenderer/TiffRendererFeatures.stories.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import type { TiffRendererProps } from "@osdk/react-components/experimental";
-import { TiffRenderer } from "@osdk/react-components/experimental";
+import type { TiffRendererProps } from "@osdk/react-components/experimental/tiff-renderer";
+import { TiffRenderer } from "@osdk/react-components/experimental/tiff-renderer";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
@@ -139,7 +139,7 @@ export const Default: Story = {
     docs: {
       source: {
         code:
-          `import { TiffRenderer } from "@osdk/react-components/experimental";
+          `import { TiffRenderer } from "@osdk/react-components/experimental/tiff-renderer";
 
 <TiffRenderer content={tiffBytes} />`,
       },
@@ -155,7 +155,7 @@ export const WithErrorCallback: Story = {
     docs: {
       source: {
         code:
-          `import { TiffRenderer } from "@osdk/react-components/experimental";
+          `import { TiffRenderer } from "@osdk/react-components/experimental/tiff-renderer";
 
 <TiffRenderer content={tiffBytes} onError={() => console.error("TIFF render failed")} />`,
       },

--- a/packages/react-components/AGENTS.md
+++ b/packages/react-components/AGENTS.md
@@ -4,7 +4,13 @@ Pre-built, Ontology-aware React components. Pass in OSDK entities and they handl
 
 ## Components
 
-All components import from `@osdk/react-components/experimental`.
+Components are imported from their individual entry points under `@osdk/react-components/experimental/`:
+
+- `@osdk/react-components/experimental/object-table` — ObjectTable, BaseTable, ColumnConfigDialog
+- `@osdk/react-components/experimental/filter-list` — FilterList, BaseFilterList
+- `@osdk/react-components/experimental/pdf-viewer` — PdfViewer, BasePdfViewer, and building blocks/hooks
+- `@osdk/react-components/experimental/tiff-renderer` — TiffRenderer
+- `@osdk/react-components/experimental/markdown-renderer` — MarkdownRenderer
 
 | Component              | Description                                                                                                                                 |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -197,12 +197,18 @@ src/
 │   ├── utils/              # Helper utilities and types
 │   └── components/         # Supporting React components
 └── public/
-    └── experimental.ts     # Public API exports
+    └── experimental/       # Public API exports (one file per component)
+        ├── object-table.ts
+        ├── filter-list.ts
+        ├── pdf-viewer.ts
+        ├── markdown-renderer.ts
+        ├── tiff-renderer.ts
+        └── action-form.ts
 ```
 
 ### Export Strategy
 
-- **OSDK Components**: Exported through `experimental.ts` (e.g., `ObjectTable`, `FilterList`)
+- **OSDK Components**: Exported through individual entry points under `experimental/` (e.g., `experimental/object-table`, `experimental/filter-list`)
 - **Base Components**: Select base components are exported for advanced use cases (e.g., `BaseTable`, `BaseFilterList`)
 - **UI Primitives**: The `base-components/` folder contains internal UI primitives that are **NOT exported**
 
@@ -249,7 +255,7 @@ See the [CSS Variables Reference](./docs/CSSVariables.md) on how to apply custom
 ### Object Table
 
 ```ts
-import { ObjectTable } from "@osdk/react-components/experimental";
+import { ObjectTable } from "@osdk/react-components/experimental/object-table";
 import { Employee } from "@your-osdk-package";
 
 function EmployeeDirectory() {

--- a/packages/react-components/docs/FilterList.md
+++ b/packages/react-components/docs/FilterList.md
@@ -23,7 +23,7 @@ Before using FilterList, make sure you have completed the library setup describe
 ## Import
 
 ```typescript
-import { FilterList } from "@osdk/react-components/experimental";
+import { FilterList } from "@osdk/react-components/experimental/filter-list";
 ```
 
 ## Basic Usage
@@ -31,7 +31,7 @@ import { FilterList } from "@osdk/react-components/experimental";
 The simplest way to use FilterList is with an objectSet and a few filter definitions:
 
 ```typescript
-import { FilterList } from "@osdk/react-components/experimental";
+import { FilterList } from "@osdk/react-components/experimental/filter-list";
 import { Employee } from "@YourApp/sdk";
 import { $ } from "@YourApp/sdk";
 
@@ -157,7 +157,8 @@ Use controlled `filterClause` to connect FilterList and ObjectTable:
 
 ```typescript
 import type { WhereClause } from "@osdk/api";
-import { FilterList, ObjectTable } from "@osdk/react-components/experimental";
+import { FilterList } from "@osdk/react-components/experimental/filter-list";
+import { ObjectTable } from "@osdk/react-components/experimental/object-table";
 import { Employee } from "@YourApp/sdk";
 import { $ } from "@YourApp/sdk";
 import { useMemo, useState } from "react";
@@ -275,7 +276,7 @@ const handleFilterRemoved = (filterKey) => {
 Pass a `.where()` objectSet to scope filter dropdown values. For example, to only show Engineering employees:
 
 ```typescript
-import { FilterList } from "@osdk/react-components/experimental";
+import { FilterList } from "@osdk/react-components/experimental/filter-list";
 import { Employee } from "@YourApp/sdk";
 import { $ } from "@YourApp/sdk";
 import { useMemo } from "react";

--- a/packages/react-components/docs/MarkdownRenderer.md
+++ b/packages/react-components/docs/MarkdownRenderer.md
@@ -5,13 +5,13 @@ A React component for rendering markdown content using [react-markdown](https://
 ## Import
 
 ```tsx
-import { MarkdownRenderer } from "@osdk/react-components/experimental";
+import { MarkdownRenderer } from "@osdk/react-components/experimental/markdown-renderer";
 ```
 
 ## Usage
 
 ```tsx
-import { MarkdownRenderer } from "@osdk/react-components/experimental";
+import { MarkdownRenderer } from "@osdk/react-components/experimental/markdown-renderer";
 
 <MarkdownRenderer content="# Hello World\n\nThis is **bold** text." />;
 ```

--- a/packages/react-components/docs/ObjectTable.md
+++ b/packages/react-components/docs/ObjectTable.md
@@ -25,11 +25,11 @@ Before using ObjectTable, make sure you have completed the library setup describ
 ## Import
 
 ```typescript
-import { ObjectTable } from "@osdk/react-components/experimental";
+import { ObjectTable } from "@osdk/react-components/experimental/object-table";
 import type {
   ColumnDefinition,
   EditFieldConfig,
-} from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/object-table";
 ```
 
 ## Basic Usage
@@ -39,7 +39,7 @@ import type {
 The simplest way to use ObjectTable is with just an object type:
 
 ```typescript
-import { ObjectTable } from "@osdk/react-components/experimental";
+import { ObjectTable } from "@osdk/react-components/experimental/object-table";
 import { Office } from "@YourApp/sdk";
 
 function OfficesPage() {
@@ -275,7 +275,7 @@ Displays header and cell with the provided custom renderers.
 import {
   type ColumnDefinition,
   ObjectTable,
-} from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/object-table";
 import { Employee } from "@YourApp/sdk";
 
 const columnDefinitions: Array<ColumnDefinition<typeof Employee>> = [
@@ -309,7 +309,7 @@ function EmployeesTable() {
 ### Example 2: Table with Multiple Selection
 
 ```typescript
-import { ObjectTable } from "@osdk/react-components/experimental";
+import { ObjectTable } from "@osdk/react-components/experimental/object-table";
 import { Employee } from "@YourApp/sdk";
 
 function EmployeesTable() {
@@ -325,7 +325,7 @@ function EmployeesTable() {
 ### Example 3: Table with Default Sorting
 
 ```typescript
-import { ObjectTable } from "@osdk/react-components/experimental";
+import { ObjectTable } from "@osdk/react-components/experimental/object-table";
 import { Employee } from "@YourApp/sdk";
 
 function EmployeesTable() {
@@ -347,7 +347,7 @@ function EmployeesTable() {
 import {
   type ColumnDefinition,
   ObjectTable,
-} from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/object-table";
 import { Employee } from "@YourApp/sdk";
 
 const columnDefinitions: Array<ColumnDefinition<typeof Employee>> = [
@@ -384,7 +384,7 @@ function EmployeesTable() {
 import {
   type ColumnDefinition,
   ObjectTable,
-} from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/object-table";
 import { Employee } from "@YourApp/sdk";
 
 const columnDefinitions: Array<ColumnDefinition<typeof Employee>> = [
@@ -431,7 +431,7 @@ const columnDefinitions: Array<ColumnDefinition<typeof Employee>> = [
 ### Example 7: Context Menu on Cell Right-Click
 
 ```typescript
-import { ObjectTable } from "@osdk/react-components/experimental";
+import { ObjectTable } from "@osdk/react-components/experimental/object-table";
 import { Employee } from "@YourApp/sdk";
 
 function EmployeesTable() {
@@ -468,7 +468,7 @@ function EmployeesTable() {
 ### Example 8: Row Click Handler
 
 ```typescript
-import { ObjectTable } from "@osdk/react-components/experimental";
+import { ObjectTable } from "@osdk/react-components/experimental/object-table";
 import { Employee } from "@YourApp/sdk";
 import { useRouter } from "next/router";
 
@@ -497,7 +497,7 @@ import { DerivedProperty } from "@osdk/client";
 import {
   type ColumnDefinition,
   ObjectTable,
-} from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/object-table";
 import { Employee } from "@YourApp/sdk";
 
 type RDPs = {
@@ -541,7 +541,7 @@ function EmployeesWithManagerTable() {
 ### Example 10: Controlled Sorting
 
 ```typescript
-import { ObjectTable } from "@osdk/react-components/experimental";
+import { ObjectTable } from "@osdk/react-components/experimental/object-table";
 import { Employee } from "@YourApp/sdk";
 import { useState } from "react";
 
@@ -568,7 +568,7 @@ function EmployeesTable() {
 ### Example 11: Controlled Row Selection
 
 ```typescript
-import { ObjectTable } from "@osdk/react-components/experimental";
+import { ObjectTable } from "@osdk/react-components/experimental/object-table";
 import { Employee } from "@YourApp/sdk";
 import { useState } from "react";
 
@@ -624,7 +624,7 @@ In a custom column type, you can render anything in the column by passing in ren
 import {
   type ColumnDefinition,
   ObjectTable,
-} from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/object-table";
 import { Employee } from "@YourApp/sdk";
 
 const columnDefinitions: Array<ColumnDefinition<typeof Employee>> = [
@@ -665,7 +665,7 @@ import {
   type CellEditInfo,
   type ColumnDefinition,
   ObjectTable,
-} from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/object-table";
 import { Employee, updateMultipleEmployees } from "@YourApp/sdk";
 
 const columnDefinitions: Array<ColumnDefinition<typeof Employee>> = [
@@ -806,7 +806,7 @@ import {
   ColumnConfigDialog,
   type ColumnDefinition,
   ObjectTable,
-} from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/object-table";
 import { Employee } from "@YourApp/sdk";
 import { useCallback, useMemo, useState } from "react";
 
@@ -934,7 +934,7 @@ Display values computed by OSDK functions (queries) alongside regular property c
 import {
   type ColumnDefinition,
   ObjectTable,
-} from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/object-table";
 import { Employee, getEmployeeMetrics } from "@YourApp/sdk";
 
 // Define a type map for your function columns
@@ -1125,7 +1125,7 @@ Use TypeScript generics to ensure type safety:
 import {
   type ColumnDefinition,
   ObjectTable,
-} from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/object-table";
 import { Employee } from "@YourApp/sdk";
 
 type RDPs = {

--- a/packages/react-components/docs/PdfViewer.md
+++ b/packages/react-components/docs/PdfViewer.md
@@ -5,7 +5,7 @@ A React component for rendering PDF documents with text selection, custom annota
 ## Import
 
 ```tsx
-import { BasePdfViewer, PdfViewer } from "@osdk/react-components/experimental";
+import { BasePdfViewer, PdfViewer } from "@osdk/react-components/experimental/pdf-viewer";
 ```
 
 - **`PdfViewer`** — Primary component for OSDK usage. Accepts an OSDK `Media` object, handles fetching the PDF contents, and renders the viewer.
@@ -16,7 +16,7 @@ import { BasePdfViewer, PdfViewer } from "@osdk/react-components/experimental";
 ### With OSDK Media
 
 ```tsx
-import { PdfViewer } from "@osdk/react-components/experimental";
+import { PdfViewer } from "@osdk/react-components/experimental/pdf-viewer";
 
 <PdfViewer media={employee.employeeDocuments} />;
 ```
@@ -24,7 +24,7 @@ import { PdfViewer } from "@osdk/react-components/experimental";
 ### With a URL or ArrayBuffer
 
 ```tsx
-import { BasePdfViewer } from "@osdk/react-components/experimental";
+import { BasePdfViewer } from "@osdk/react-components/experimental/pdf-viewer";
 
 // From a URL
 <BasePdfViewer src="https://example.com/document.pdf" />
@@ -156,7 +156,7 @@ Tier 3: usePdfViewerState / usePdfViewerCore    ← custom everything
 
 ## Building blocks
 
-All building blocks are exported from `@osdk/react-components/experimental` for composing custom PDF viewer layouts. Use `PdfViewerContent` as the foundation and add whichever chrome you need.
+All building blocks are exported from `@osdk/react-components/experimental/pdf-viewer` for composing custom PDF viewer layouts. Use `PdfViewerContent` as the foundation and add whichever chrome you need.
 
 | Component                  | Description                                                        |
 | -------------------------- | ------------------------------------------------------------------ |
@@ -170,7 +170,7 @@ All building blocks are exported from `@osdk/react-components/experimental` for 
 ### Example: content-only viewer
 
 ```tsx
-import { PdfViewerContent } from "@osdk/react-components/experimental";
+import { PdfViewerContent } from "@osdk/react-components/experimental/pdf-viewer";
 
 <PdfViewerContent
   src="https://example.com/document.pdf"
@@ -214,7 +214,7 @@ import {
   PdfViewerSearchBar,
   PdfViewerToolbar,
   usePdfViewerState,
-} from "@osdk/react-components/experimental";
+} from "@osdk/react-components/experimental/pdf-viewer";
 import { createPortal } from "react-dom";
 
 function MyCustomViewer({ src }: { src: string }) {
@@ -259,7 +259,7 @@ function MyCustomViewer({ src }: { src: string }) {
 ### Example: minimal viewer with `usePdfViewerCore`
 
 ```tsx
-import { usePdfViewerCore } from "@osdk/react-components/experimental";
+import { usePdfViewerCore } from "@osdk/react-components/experimental/pdf-viewer";
 
 function MinimalViewer({ src }: { src: string }) {
   const { containerRef, viewerRef, loading, error, currentPage, numPages } =

--- a/packages/react-components/docs/PdfViewer.md
+++ b/packages/react-components/docs/PdfViewer.md
@@ -5,7 +5,10 @@ A React component for rendering PDF documents with text selection, custom annota
 ## Import
 
 ```tsx
-import { BasePdfViewer, PdfViewer } from "@osdk/react-components/experimental/pdf-viewer";
+import {
+  BasePdfViewer,
+  PdfViewer,
+} from "@osdk/react-components/experimental/pdf-viewer";
 ```
 
 - **`PdfViewer`** — Primary component for OSDK usage. Accepts an OSDK `Media` object, handles fetching the PDF contents, and renders the viewer.

--- a/packages/react-components/docs/TiffViewer.md
+++ b/packages/react-components/docs/TiffViewer.md
@@ -5,13 +5,13 @@ A React component for rendering TIFF images from raw byte arrays.
 ## Import
 
 ```tsx
-import { TiffRenderer } from "@osdk/react-components/experimental";
+import { TiffRenderer } from "@osdk/react-components/experimental/tiff-renderer";
 ```
 
 ## Usage
 
 ```tsx
-import { TiffRenderer } from "@osdk/react-components/experimental";
+import { TiffRenderer } from "@osdk/react-components/experimental/tiff-renderer";
 
 <TiffRenderer content={tiffBytes} />;
 ```


### PR DESCRIPTION
## Summary

- Updates all imports across the repo to use the new per-component import paths (`@osdk/react-components/experimental/{component}`) instead of the barrel export (`@osdk/react-components/experimental`)
- Prepares for a follow-up change that will remove the `/experimental` barrel export entirely

### New import paths

| Component | Import path |
|---|---|
| ObjectTable, BaseTable, ColumnConfigDialog | `@osdk/react-components/experimental/object-table` |
| FilterList, BaseFilterList | `@osdk/react-components/experimental/filter-list` |
| PdfViewer, BasePdfViewer, building blocks, hooks | `@osdk/react-components/experimental/pdf-viewer` |
| MarkdownRenderer | `@osdk/react-components/experimental/markdown-renderer` |
| TiffRenderer | `@osdk/react-components/experimental/tiff-renderer` |
| ActionForm, BaseForm | `@osdk/react-components/experimental/action-form` |

### Packages updated

- **`@osdk/react-components`** — docs (AGENTS.md, README.md, ObjectTable.md, PdfViewer.md, FilterList.md, MarkdownRenderer.md, TiffViewer.md)
- **`@osdk/react-components-storybook`** — all story files (ObjectTable, PdfViewer, FilterList, MarkdownRenderer, TiffRenderer)
- **`@osdk/e2e.sandbox.peopleapp`** — EmployeesTable, EmployeesWithFilterList, offices page, form page
- **`@osdk/e2e.sandbox.officenetwork`** — EmployeeFilters

### Not changed

- `tests/verify-webpack-bundling/src/entry.ts` — intentionally keeps the barrel import alongside individual imports since it tests all export paths

## Test plan

- [x] Typecheck passes for `@osdk/react-components-storybook` and `@osdk/e2e.sandbox.officenetwork`
- [x] Verify storybook builds and renders correctly
- [x] Confirm no remaining references to the old barrel export in source files (only `verify-webpack-bundling` intentionally retains it)