### PR TITLE
[Components] Fix stableObjectSet

### DIFF
--- a/.changeset/eighty-birds-happen.md
+++ b/.changeset/eighty-birds-happen.md
@@ -1,0 +1,6 @@
+---
+"@osdk/react-components": patch
+"@osdk/react": patch
+---
+
+Fix stableObjectSet by using a useStableObjectSet hook

--- a/packages/react-components/src/object-table/hooks/__tests__/useFunctionColumnsData.test.ts
+++ b/packages/react-components/src/object-table/hooks/__tests__/useFunctionColumnsData.test.ts
@@ -38,6 +38,7 @@ import { useFunctionColumnsData } from "../useFunctionColumnsData.js";
 vi.mock("@osdk/react/experimental", () => ({
   useOsdkFunctions: vi.fn(),
   useRegisterUserAgent: vi.fn(),
+  useStableObjectSet: vi.fn((objectSet: unknown) => objectSet),
 }));
 
 vi.mock("../../utils/addFilterClauseToObjectSet.js", () => ({

--- a/packages/react-components/src/object-table/hooks/useFunctionColumnsData.ts
+++ b/packages/react-components/src/object-table/hooks/useFunctionColumnsData.ts
@@ -27,6 +27,7 @@ import {
   type FunctionQueryParams,
   useOsdkFunctions,
   type UseOsdkFunctionsResult,
+  useStableObjectSet,
 } from "@osdk/react/experimental";
 import { chunk } from "lodash-es";
 import { useMemo, useRef } from "react";
@@ -88,9 +89,7 @@ export function useFunctionColumnsData<
   const prevDataRef = useRef<FunctionColumnData>({});
 
   const stableObjects = useStableObjects(objects);
-  // TODO: replace with useDeepEqual when it's added
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const stableObjectSet = useMemo(() => objectSet, [JSON.stringify(objectSet)]);
+  const stableObjectSet = useStableObjectSet(objectSet);
 
   const functionColDefs = useMemo(
     () => extractFunctionLocators<Q, RDPs, FunctionColumns>(columnDefinitions),

--- a/packages/react/src/new/core/useStableObjectSet.ts
+++ b/packages/react/src/new/core/useStableObjectSet.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  ObjectOrInterfaceDefinition,
+  ObjectSet,
+  SimplePropertyDef,
+} from "@osdk/api";
+import { getWireObjectSet } from "@osdk/client/unstable-do-not-use";
+import { useMemo } from "react";
+
+/**
+ * Returns a referentially stable ObjectSet that only changes when the
+ * wire representation changes. This uses `getWireObjectSet` which includes
+ * composed operations (where, union, intersect, etc.) in the serialized
+ * form, unlike plain `JSON.stringify(objectSet)` which may not capture them.
+ */
+export function useStableObjectSet<
+  Q extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef> = Record<string, never>,
+>(
+  objectSet: ObjectSet<Q, RDPs> | undefined,
+): ObjectSet<Q, RDPs> | undefined {
+  const wireKey = objectSet
+    ? JSON.stringify(getWireObjectSet(objectSet as ObjectSet<Q>))
+    : undefined;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useMemo(() => objectSet, [wireKey]);
+}

--- a/packages/react/src/new/useObjectSet.tsx
+++ b/packages/react/src/new/useObjectSet.tsx
@@ -244,7 +244,8 @@ export function useObjectSet<
   const previousCompletedPayloadRef = React.useRef<
     Snapshot<ObserveObjectSetArgs<Q, RDPs>> | undefined
   >();
-
+  // TODO: Is it expected to only clear the previousCompletedPayloadRef when the object type changes?
+  // What if the same object type is queried with different filters, should we also clear the cache?
   const objectTypeChanged = previousObjectTypeRef.current !== objectTypeKey;
   if (objectTypeChanged) {
     previousObjectTypeRef.current = objectTypeKey;

--- a/packages/react/src/public/experimental.ts
+++ b/packages/react/src/public/experimental.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+export { useStableObjectSet } from "../new/core/useStableObjectSet.js";
 export { OsdkProvider2 } from "../new/OsdkProvider2.js";
 export { useLinks } from "../new/useLinks.js";
 export { useObjectSet } from "../new/useObjectSet.js";


### PR DESCRIPTION
Created a useStableObjectSet hook to handle stabilising object set properly. 

Problem
Function-backed columns show data for only 1 row after: applying a filter to show only 1 row → switching tabs → returning → removing the filter. The remaining 49 rows have empty function columns.

Root Cause Analysis
We traced the data flow from ObjectTable → useObjectTableData → useObjectSet → useFunctionColumnsData → useOsdkFunctions → createCompositeExternalStore and identified three compounding bugs:

Bug 1: useObjectSet returns stale objectSet from previous payload
In useObjectSet.js, the returned objectSet comes from lastLoaded?.objectSet (the last completed payload). When query params change (filter removed), lastLoaded falls back to previousCompletedPayloadRef.current while the new subscription is loading. This payload has the old where clause baked into its objectSet structure. The returned objectSet should always reflect the current query intent, not the cached payload's objectSet.

Location: @osdk/react — useObjectSet.js: objectSet: lastLoaded?.objectSet

Bug 2: useFunctionColumnsData memoizes objectSet with JSON.stringify instead of getWireObjectSet
stableObjectSet is memoized via JSON.stringify(objectSet), but direct JSON serialization of an OSDK ObjectSet object does not include where clauses — only getWireObjectSet() produces the full wire representation. This means even if a corrected objectSet arrives (with different where), the memo key doesn't change, so stableObjectSet remains stale.


Bug 3 (consequence): Function queries sent to backend with stale filter
Because of bugs 1 and 2, buildPagedObjectSets receives the stale objectSet and constructs function query params that include the old filter. The backend function only returns results for the 1 row matching both the stale filter AND the $in clause, leaving all other rows empty.


**Fix: Added useStableObjectSet hook that uses getWireObjectSet for proper memoization, so objectSet changes involving where clauses are correctly detected.**

Upstream Fixes Needed
@osdk/react (useObjectSet): Look for a correct value to return in objectSet when the hook is loading. It's now only clearing the previousCompletedPayloadRef when objectType changed. Should we also check for changes in the options?
