### PR TITLE
Transpile @osdk/generator in createReleasePr.sh

### DIFF
--- a/scripts/createReleasePr.sh
+++ b/scripts/createReleasePr.sh
@@ -13,6 +13,7 @@ if [[ $(git rev-parse --abbrev-ref HEAD | sed -E 's/^changeset-release\/.*$/ABOR
     exit 1
 fi
 
-pnpm exec turbo transpile --filter "./packages/tool.release"
+# generator needed by turbo codegen in postVersionCmd
+pnpm exec turbo transpileEsm --filter "./packages/tool.release" --filter "@osdk/cli.cmd.typescript..."
 node ./packages/tool.release/build/esm/index.js --repo palantir/osdk-ts
 echo "WARNING: You are probably on the pr branch"


### PR DESCRIPTION
## Summary
- `runVersion` calls `pnpm run postVersionCmd`, which triggers `turbo codegen`. Many packages' `codegen` scripts invoke the `osdk-unstable-typescript` binary from `@osdk/cli.cmd.typescript`, and its ESM imports `@osdk/generator` at runtime.
- The previous filter (`./packages/tool.release`) left `@osdk/generator`'s `build/esm` unbuilt (`transpileEsm` has no `^` dep), so codegen would fail with a missing entrypoint.
- Switched to `transpileEsm` with `--filter "@osdk/cli.cmd.typescript..."` so the full ESM dep chain (including the generator) is produced before `tool.release` runs.

## Test plan
- [ ] Run `./scripts/createReleasePr.sh` locally from a clean state and verify codegen succeeds during postVersionCmd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)