### PR TITLE
Fix StubBuilderFor resolution and Error as link stub value

### DIFF
--- a/.changeset/move-api-types-to-api-dir.md
+++ b/.changeset/move-api-types-to-api-dir.md
@@ -1,0 +1,5 @@
+---
+"@osdk/functions-testing.experimental": patch
+---
+
+Move user-facing types (`MockClient`, `StubClient`, `StubBuilderFor`, `FetchPageStubBuilder`, `FetchOneStubBuilder`, `AggregateStubBuilder`, `QueryStubBuilder`, `MockOsdkObjectOptions`) to dedicated files under `src/api/`. No public API changes.

--- a/.changeset/robust-fetch-with-errors-stubs.md
+++ b/.changeset/robust-fetch-with-errors-stubs.md
@@ -1,0 +1,5 @@
+---
+"@osdk/functions-testing.experimental": minor
+---
+
+Fix `StubBuilderFor<T>` so `fetchOneWithErrors` / `fetchPageWithErrors` / `asyncIter` resolve to the correct stub builders instead of falling through to `AggregateStubBuilder`. Allow `Error` as a single-link stub value in `createMockOsdkObject` so link `fetchOne` rejects and `fetchOneWithErrors` returns `{ error }` (previously wrapped the Error in `{ value: ... }`, making `isOk` always true).

--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -386,6 +386,7 @@ const archetypeRules = archetypes(
         TZ: "UTC",
         LANG: "en_US.UTF-8",
       },
+      vitestPool: "threads",
     },
   )
   .addArchetype(
@@ -921,6 +922,7 @@ function minimalPackageRules(shared, options) {
  * @property { "happy-dom" } [vitestEnvironment]
  * @property { string[] } [setupFiles]
  * @property { Record<string, string> } [vitestEnv]
+ * @property { "forks" | "threads" } [vitestPool]
  * @property { boolean } [skipTsconfigReferences]
  * @property { boolean } [aliasConsola]
  * @property { Record<"esm" | "cjs" | "browser", "bundle" | "normal" | undefined>} output
@@ -1161,7 +1163,7 @@ function standardPackageRules(shared, options) {
               },`
               : ""
           }
-              pool: "forks",
+              pool: "${options.vitestPool ?? "forks"}",
               exclude: [...configDefaults.exclude, "**/build/**/*"],${
             options.vitestEnvironment
               ? `\n            environment: "${options.vitestEnvironment}",`

--- a/etc/functions-testing.experimental.report.api.md
+++ b/etc/functions-testing.experimental.report.api.md
@@ -6,7 +6,7 @@
 
 import type { Attachment } from '@osdk/api';
 import type { AttachmentMetadata } from '@osdk/api';
-import { Client } from '@osdk/client';
+import type { Client } from '@osdk/client';
 import type { CompileTimeMetadata } from '@osdk/api';
 import type { InterfaceDefinition } from '@osdk/api';
 import type { LinkedType } from '@osdk/api';

--- a/etc/functions-testing.experimental.report.api.md
+++ b/etc/functions-testing.experimental.report.api.md
@@ -89,7 +89,16 @@ export interface QueryStubBuilder<T> {
 // Warning: (ae-forgotten-export) The symbol "IsOsdkObject" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export type StubBuilderFor<T> = T extends PageResult<infer U> ? FetchPageStubBuilder<U> : IsOsdkObject<T> extends true ? FetchOneStubBuilder<T> : AggregateStubBuilder<T>;
+export type StubBuilderFor<T> = T extends Promise<infer R> ? StubBuilderFor<R> : T extends AsyncIterableIterator<infer U> ? FetchPageStubBuilder<U> : T extends PageResult<infer U> ? FetchPageStubBuilder<U> : T extends {
+    	value: PageResult<infer U>
+    	error?: never
+} ? FetchPageStubBuilder<U> : T extends {
+    	value: infer U
+    	error?: never
+} ? (IsOsdkObject<U> extends true ? FetchOneStubBuilder<U> : AggregateStubBuilder<U>) : T extends {
+    	error: Error
+    	value?: never
+} ? never : IsOsdkObject<T> extends true ? FetchOneStubBuilder<T> : AggregateStubBuilder<T>;
 
 // @public (undocumented)
 export type StubClient = {

--- a/packages/functions-testing.experimental/src/api/MockClient.ts
+++ b/packages/functions-testing.experimental/src/api/MockClient.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  CompileTimeMetadata,
+  ObjectOrInterfaceDefinition,
+  ObjectSet,
+  QueryDefinition,
+} from "@osdk/api";
+import type { Client } from "@osdk/client";
+import type { QueryStubBuilder, StubBuilderFor } from "./StubBuilders.js";
+import type { StubClient } from "./StubClient.js";
+
+type QueryReturnTypeFromDef<Q extends QueryDefinition> = ReturnType<
+  CompileTimeMetadata<Q>["signature"]
+> extends Promise<infer R> ? R : never;
+
+type QueryParamsFromDef<Q extends QueryDefinition> =
+  Parameters<CompileTimeMetadata<Q>["signature"]> extends [infer P] ? P
+    : undefined;
+
+export type StubPatternCallback<T> = (client: StubClient) => T;
+
+export type ObjectSetStubCallback<Q extends ObjectOrInterfaceDefinition, T> = (
+  os: ObjectSet<Q>,
+) => T;
+
+export interface MockClient extends Client {
+  when<T>(callback: StubPatternCallback<T>): StubBuilderFor<T>;
+  whenObjectSet<Q extends ObjectOrInterfaceDefinition, T>(
+    objectSet: ObjectSet<Q>,
+    callback: ObjectSetStubCallback<Q, T>,
+  ): StubBuilderFor<T>;
+  whenQuery<Q extends QueryDefinition>(
+    query: Q,
+    params?: QueryParamsFromDef<Q>,
+  ): QueryStubBuilder<QueryReturnTypeFromDef<Q>>;
+  clearStubs(): void;
+}

--- a/packages/functions-testing.experimental/src/api/MockOsdkObjectOptions.ts
+++ b/packages/functions-testing.experimental/src/api/MockOsdkObjectOptions.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  CompileTimeMetadata,
+  LinkedType,
+  LinkNames,
+  ObjectSet,
+  ObjectTypeDefinition,
+  Osdk,
+} from "@osdk/api";
+
+type LinkStubs<Q extends ObjectTypeDefinition> = {
+  [LINK_NAME in LinkNames<Q>]?:
+    CompileTimeMetadata<Q>["links"][LINK_NAME]["multiplicity"] extends true ?
+        | Array<Osdk.Instance<LinkedType<Q, LINK_NAME>>>
+        | ObjectSet<LinkedType<Q, LINK_NAME>>
+      : Osdk.Instance<LinkedType<Q, LINK_NAME>> | Error;
+};
+
+/**
+ * Options for customizing mock object creation.
+ */
+export interface MockOsdkObjectOptions<
+  Q extends ObjectTypeDefinition = ObjectTypeDefinition,
+> {
+  /** Objects linked to this object by API name */
+  links?: LinkStubs<Q>;
+  /** The API name of the title property (optional, required for $title) */
+  titlePropertyApiName?: string;
+  /** Override the generated $rid */
+  $rid?: string;
+}

--- a/packages/functions-testing.experimental/src/api/StubBuilders.ts
+++ b/packages/functions-testing.experimental/src/api/StubBuilders.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { PageResult } from "@osdk/api";
+
+export interface FetchPageStubBuilder<T> {
+  thenReturnObjects(objects: T[]): void;
+}
+
+export interface FetchOneStubBuilder<T> {
+  thenReturnObject(object: T): void;
+}
+
+export interface AggregateStubBuilder<T> {
+  thenReturnAggregation(result: T): void;
+}
+
+export interface QueryStubBuilder<T> {
+  thenReturn(result: T): void;
+  thenThrow(error: Error): void;
+}
+
+type IsOsdkObject<T> = T extends { $apiName: string } ? true : false;
+
+export type StubBuilderFor<T> = T extends Promise<infer R> ? StubBuilderFor<R>
+  : T extends AsyncIterableIterator<infer U> ? FetchPageStubBuilder<U>
+  : T extends PageResult<infer U> ? FetchPageStubBuilder<U>
+  : T extends { value: PageResult<infer U>; error?: never }
+    ? FetchPageStubBuilder<U>
+  : T extends { value: infer U; error?: never }
+    ? (IsOsdkObject<U> extends true ? FetchOneStubBuilder<U>
+      : AggregateStubBuilder<U>)
+  : T extends { error: Error; value?: never } ? never
+  : IsOsdkObject<T> extends true ? FetchOneStubBuilder<T>
+  : AggregateStubBuilder<T>;

--- a/packages/functions-testing.experimental/src/api/StubClient.ts
+++ b/packages/functions-testing.experimental/src/api/StubClient.ts
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-export type {
-  AggregateStubBuilder,
-  FetchOneStubBuilder,
-  FetchPageStubBuilder,
-  QueryStubBuilder,
-  StubBuilderFor,
-} from "../api/index.js";
-export { createMockAttachment } from "../mock/createMockAttachment.js";
-export { createMockClient } from "../mock/createMockClient.js";
-export { createMockObjectSet } from "../mock/createMockObjectSet.js";
-export { createMockOsdkObject } from "../mock/createMockOsdkObject.js";
+import type {
+  InterfaceDefinition,
+  ObjectSet,
+  ObjectTypeDefinition,
+} from "@osdk/api";
+
+export type StubClient = {
+  <Q extends ObjectTypeDefinition>(o: Q): ObjectSet<Q>;
+  <Q extends InterfaceDefinition>(o: Q): ObjectSet<Q>;
+};

--- a/packages/functions-testing.experimental/src/api/index.ts
+++ b/packages/functions-testing.experimental/src/api/index.ts
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
+export type { MockClient } from "./MockClient.js";
+export type { MockOsdkObjectOptions } from "./MockOsdkObjectOptions.js";
 export type {
   AggregateStubBuilder,
   FetchOneStubBuilder,
   FetchPageStubBuilder,
   QueryStubBuilder,
   StubBuilderFor,
-} from "../api/index.js";
-export { createMockAttachment } from "../mock/createMockAttachment.js";
-export { createMockClient } from "../mock/createMockClient.js";
-export { createMockObjectSet } from "../mock/createMockObjectSet.js";
-export { createMockOsdkObject } from "../mock/createMockOsdkObject.js";
+} from "./StubBuilders.js";
+export type { StubClient } from "./StubClient.js";

--- a/packages/functions-testing.experimental/src/index.ts
+++ b/packages/functions-testing.experimental/src/index.ts
@@ -14,22 +14,18 @@
  * limitations under the License.
  */
 
+export type {
+  AggregateStubBuilder,
+  FetchOneStubBuilder,
+  FetchPageStubBuilder,
+  MockClient,
+  MockOsdkObjectOptions,
+  QueryStubBuilder,
+  StubBuilderFor,
+  StubClient,
+} from "./api/index.js";
+
 export { createMockAttachment } from "./mock/createMockAttachment.js";
-
-export {
-  createMockOsdkObject,
-  type MockOsdkObjectOptions,
-} from "./mock/createMockOsdkObject.js";
-
-export {
-  type AggregateStubBuilder,
-  createMockClient,
-  type FetchOneStubBuilder,
-  type FetchPageStubBuilder,
-  type MockClient,
-  type QueryStubBuilder,
-  type StubBuilderFor,
-  type StubClient,
-} from "./mock/createMockClient.js";
-
+export { createMockClient } from "./mock/createMockClient.js";
 export { createMockObjectSet } from "./mock/createMockObjectSet.js";
+export { createMockOsdkObject } from "./mock/createMockOsdkObject.js";

--- a/packages/functions-testing.experimental/src/mock/__tests__/createMockClient.test.ts
+++ b/packages/functions-testing.experimental/src/mock/__tests__/createMockClient.test.ts
@@ -20,7 +20,8 @@ import {
   Office,
   queryTypeReturnsArray,
 } from "@osdk/client.test.ontology";
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
+
 import { createMockClient } from "../createMockClient.js";
 import { createMockObjectSet } from "../createMockObjectSet.js";
 import { createMockOsdkObject } from "../createMockOsdkObject.js";
@@ -98,6 +99,14 @@ describe("createMockClient", () => {
         mockClient(Employee).where({ office: { $eq: "LA" } }).fetchPage(),
       ).rejects.toThrow();
     });
+
+    it("types: when((c) => c(T).fetchPage()) → FetchPageStubBuilder", () => {
+      const mockClient = createMockClient();
+      const builder = mockClient.when((c) => c(Employee).fetchPage());
+      expectTypeOf(builder).toHaveProperty("thenReturnObjects");
+      expectTypeOf(builder).not.toHaveProperty("thenReturnObject");
+      expectTypeOf(builder).not.toHaveProperty("thenReturnAggregation");
+    });
   });
 
   describe("fetchOne", () => {
@@ -116,6 +125,156 @@ describe("createMockClient", () => {
       expect(result.employeeId).toBe(123);
       expect(result.fullName).toBe("John");
     });
+
+    it("types: when((c) => c(T).fetchOne(pk)) → FetchOneStubBuilder", () => {
+      const mockClient = createMockClient();
+      const builder = mockClient.when((c) => c(Employee).fetchOne(1));
+      expectTypeOf(builder).toHaveProperty("thenReturnObject");
+      expectTypeOf(builder).not.toHaveProperty("thenReturnObjects");
+      expectTypeOf(builder).not.toHaveProperty("thenReturnAggregation");
+    });
+  });
+
+  describe("fetchPageWithErrors", () => {
+    it("returns ok on success and error when no stub", async () => {
+      const mockClient = createMockClient();
+      const emp = createMockOsdkObject(Employee, { employeeId: 1 });
+
+      mockClient.when((c) => c(Employee).fetchPage())
+        .thenReturnObjects([emp]);
+
+      const okResult = await mockClient(Employee).fetchPageWithErrors();
+      expect(okResult.error).toBeUndefined();
+      expect(okResult.value?.data[0]).toEqual(emp);
+
+      const errorResult = await mockClient(Office).fetchPageWithErrors();
+      expect(errorResult.error).toBeDefined();
+    });
+
+    it("accepts thenReturnObjects directly on a fetchPageWithErrors pattern", async () => {
+      const mockClient = createMockClient();
+      const emp = createMockOsdkObject(Employee, {
+        employeeId: 5,
+        fullName: "Zara",
+      });
+
+      mockClient
+        .when((c) => c(Employee).fetchPageWithErrors({ $pageSize: 10 }))
+        .thenReturnObjects([emp]);
+
+      const result = await mockClient(Employee).fetchPageWithErrors({
+        $pageSize: 10,
+      });
+      expect(result.value?.data).toEqual([emp]);
+      expect(result.error).toBeUndefined();
+    });
+
+    it("types: when((c) => c(T).fetchPageWithErrors()) → FetchPageStubBuilder (not Aggregate)", () => {
+      const mockClient = createMockClient();
+      const builder = mockClient.when((c) => c(Employee).fetchPageWithErrors());
+      expectTypeOf(builder).toHaveProperty("thenReturnObjects");
+      expectTypeOf(builder).not.toHaveProperty("thenReturnAggregation");
+      expectTypeOf(builder).not.toHaveProperty("thenReturnObject");
+    });
+  });
+
+  describe("fetchOneWithErrors", () => {
+    it("returns ok on success and error when no stub", async () => {
+      const mockClient = createMockClient();
+      const emp = createMockOsdkObject(Employee, { employeeId: 1 });
+
+      mockClient.when((c) => c(Employee).fetchOne(1)).thenReturnObject(
+        emp,
+      );
+
+      const okResult = await mockClient(Employee).fetchOneWithErrors(1);
+      expect(okResult.value).toEqual(emp);
+
+      const errorResult = await mockClient(Employee).fetchOneWithErrors(999);
+      expect(errorResult.error).toBeDefined();
+    });
+
+    it("accepts thenReturnObject directly on a fetchOneWithErrors pattern", async () => {
+      const mockClient = createMockClient();
+      const emp = createMockOsdkObject(Employee, {
+        employeeId: 7,
+        fullName: "Grace",
+      });
+
+      mockClient
+        .when((c) => c(Employee).fetchOneWithErrors(7))
+        .thenReturnObject(emp);
+
+      const result = await mockClient(Employee).fetchOneWithErrors(7);
+      expect(result.value).toEqual(emp);
+      expect(result.error).toBeUndefined();
+    });
+
+    it("surfaces stubs registered via fetchOne through fetchOneWithErrors", async () => {
+      const mockClient = createMockClient();
+      const emp = createMockOsdkObject(Employee, { employeeId: 3 });
+
+      mockClient.when((c) => c(Employee).fetchOne(3)).thenReturnObject(emp);
+
+      const result = await mockClient(Employee).fetchOneWithErrors(3);
+      expect(result.value).toEqual(emp);
+    });
+
+    it("types: when((c) => c(T).fetchOneWithErrors(pk)) → FetchOneStubBuilder (not Aggregate)", () => {
+      const mockClient = createMockClient();
+      const builder = mockClient.when((c) => c(Employee).fetchOneWithErrors(1));
+      expectTypeOf(builder).toHaveProperty("thenReturnObject");
+      expectTypeOf(builder).not.toHaveProperty("thenReturnAggregation");
+      expectTypeOf(builder).not.toHaveProperty("thenReturnObjects");
+    });
+  });
+
+  describe("asyncIter", () => {
+    it("accepts thenReturnObjects on an asyncIter pattern without casting", async () => {
+      const mockClient = createMockClient();
+      const emp1 = createMockOsdkObject(Employee, { employeeId: 1 });
+      const emp2 = createMockOsdkObject(Employee, { employeeId: 2 });
+
+      mockClient
+        .when((c) => c(Employee).asyncIter())
+        .thenReturnObjects([emp1, emp2]);
+
+      const collected: Array<{ employeeId: number | undefined }> = [];
+      for await (const emp of mockClient(Employee).asyncIter()) {
+        collected.push({ employeeId: emp.employeeId });
+      }
+
+      expect(collected).toEqual([{ employeeId: 1 }, { employeeId: 2 }]);
+    });
+
+    it("supports where + asyncIter pattern matching", async () => {
+      const mockClient = createMockClient();
+      const emp = createMockOsdkObject(Employee, {
+        employeeId: 1,
+        office: "NYC",
+      });
+
+      mockClient
+        .when((c) => c(Employee).where({ office: { $eq: "NYC" } }).asyncIter())
+        .thenReturnObjects([emp]);
+
+      const out: number[] = [];
+      for await (
+        const e of mockClient(Employee)
+          .where({ office: { $eq: "NYC" } })
+          .asyncIter()
+      ) {
+        out.push(e.employeeId!);
+      }
+      expect(out).toEqual([1]);
+    });
+
+    it("types: when((c) => c(T).asyncIter()) → FetchPageStubBuilder", () => {
+      const mockClient = createMockClient();
+      const builder = mockClient.when((c) => c(Employee).asyncIter());
+      expectTypeOf(builder).toHaveProperty("thenReturnObjects");
+      expectTypeOf(builder).not.toHaveProperty("thenReturnAggregation");
+    });
   });
 
   describe("aggregate", () => {
@@ -133,6 +292,16 @@ describe("createMockClient", () => {
       });
 
       expect(result.$count).toBe(42);
+    });
+
+    it("types: when((c) => c(T).aggregate(...)) → AggregateStubBuilder", () => {
+      const mockClient = createMockClient();
+      const builder = mockClient.when((c) =>
+        c(Employee).aggregate({ $select: { $count: "unordered" } })
+      );
+      expectTypeOf(builder).toHaveProperty("thenReturnAggregation");
+      expectTypeOf(builder).not.toHaveProperty("thenReturnObject");
+      expectTypeOf(builder).not.toHaveProperty("thenReturnObjects");
     });
   });
 
@@ -192,40 +361,6 @@ describe("createMockClient", () => {
       mockClient.clearStubs();
 
       await expect(mockClient(Employee).fetchPage()).rejects.toThrow();
-    });
-  });
-
-  describe("fetchPageWithErrors", () => {
-    it("returns ok on success and error when no stub", async () => {
-      const mockClient = createMockClient();
-      const emp = createMockOsdkObject(Employee, { employeeId: 1 });
-
-      mockClient.when((c) => c(Employee).fetchPage())
-        .thenReturnObjects([emp]);
-
-      const okResult = await mockClient(Employee).fetchPageWithErrors();
-      expect(okResult.error).toBeUndefined();
-      expect(okResult.value?.data[0]).toEqual(emp);
-
-      const errorResult = await mockClient(Office).fetchPageWithErrors();
-      expect(errorResult.error).toBeDefined();
-    });
-  });
-
-  describe("fetchOneWithErrors", () => {
-    it("returns ok on success and error when no stub", async () => {
-      const mockClient = createMockClient();
-      const emp = createMockOsdkObject(Employee, { employeeId: 1 });
-
-      mockClient.when((c) => c(Employee).fetchOne(1)).thenReturnObject(
-        emp,
-      );
-
-      const okResult = await mockClient(Employee).fetchOneWithErrors(1);
-      expect(okResult.value).toEqual(emp);
-
-      const errorResult = await mockClient(Employee).fetchOneWithErrors(999);
-      expect(errorResult.error).toBeDefined();
     });
   });
 

--- a/packages/functions-testing.experimental/src/mock/__tests__/createMockOsdkObject.test.ts
+++ b/packages/functions-testing.experimental/src/mock/__tests__/createMockOsdkObject.test.ts
@@ -219,6 +219,33 @@ describe("createMockOsdkObject", () => {
 
         const result = await mockEmployee.$link.officeLink.fetchOneWithErrors();
         expect(result.value).toBe(mockOffice);
+        expect(result.error).toBeUndefined();
+      });
+
+      it("fetchOne rejects when link value is an Error", async () => {
+        const error = new Error("link missing");
+        const mockEmployee = createMockOsdkObject(
+          Employee,
+          { employeeId: 3 },
+          { links: { officeLink: error } },
+        );
+
+        await expect(mockEmployee.$link.officeLink.fetchOne()).rejects.toBe(
+          error,
+        );
+      });
+
+      it("simulates link failure where fetchOneWithErrors returns { error } (isOk === false)", async () => {
+        const boom = new Error("link missing");
+        const mockEmployee = createMockOsdkObject(
+          Employee,
+          { employeeId: 4 },
+          { links: { officeLink: boom } },
+        );
+
+        const result = await mockEmployee.$link.officeLink.fetchOneWithErrors();
+        expect(result.error).toBe(boom);
+        expect(result.value).toBeUndefined();
       });
     });
 

--- a/packages/functions-testing.experimental/src/mock/createMockClient.ts
+++ b/packages/functions-testing.experimental/src/mock/createMockClient.ts
@@ -67,8 +67,15 @@ export interface QueryStubBuilder<T> {
   thenThrow(error: Error): void;
 }
 
-export type StubBuilderFor<T> = T extends PageResult<infer U>
-  ? FetchPageStubBuilder<U>
+export type StubBuilderFor<T> = T extends Promise<infer R> ? StubBuilderFor<R>
+  : T extends AsyncIterableIterator<infer U> ? FetchPageStubBuilder<U>
+  : T extends PageResult<infer U> ? FetchPageStubBuilder<U>
+  : T extends { value: PageResult<infer U>; error?: never }
+    ? FetchPageStubBuilder<U>
+  : T extends { value: infer U; error?: never }
+    ? (IsOsdkObject<U> extends true ? FetchOneStubBuilder<U>
+      : AggregateStubBuilder<U>)
+  : T extends { error: Error; value?: never } ? never
   : IsOsdkObject<T> extends true ? FetchOneStubBuilder<T>
   : AggregateStubBuilder<T>;
 
@@ -85,11 +92,11 @@ export type StubClient = {
   <Q extends InterfaceDefinition>(o: Q): ObjectSet<Q>;
 };
 
-export type StubPatternCallback<T> = (client: StubClient) => Promise<T>;
+export type StubPatternCallback<T> = (client: StubClient) => T;
 
 export type ObjectSetStubCallback<Q extends ObjectOrInterfaceDefinition, T> = (
   os: ObjectSet<Q>,
-) => Promise<T>;
+) => T;
 
 export interface MockClient extends Client {
   when<T>(callback: StubPatternCallback<T>): StubBuilderFor<T>;

--- a/packages/functions-testing.experimental/src/mock/createMockClient.ts
+++ b/packages/functions-testing.experimental/src/mock/createMockClient.ts
@@ -16,15 +16,19 @@
 
 import type {
   CompileTimeMetadata,
-  InterfaceDefinition,
   ObjectOrInterfaceDefinition,
   ObjectSet,
-  ObjectTypeDefinition,
-  PageResult,
   QueryDefinition,
 } from "@osdk/api";
-import { type Client, createPlatformClient } from "@osdk/client";
+import { createPlatformClient } from "@osdk/client";
 import invariant from "tiny-invariant";
+import type {
+  MockClient,
+  ObjectSetStubCallback,
+  StubPatternCallback,
+} from "../api/MockClient.js";
+import type { QueryStubBuilder, StubBuilderFor } from "../api/StubBuilders.js";
+import type { StubClient } from "../api/StubClient.js";
 import { type MockObjectSetBranded } from "./createMockObjectSet.js";
 import {
   type Call,
@@ -43,42 +47,6 @@ type QueryStub = {
   error?: Error;
 };
 
-type IsOsdkObject<T> = T extends { $apiName: string } ? true : false;
-
-// Well-known string key used by Foundry Platform APIs to pull the
-// SharedClientContext (baseUrl, tokenProvider, fetch) off a client. Matches
-// the value of `symbolClientContext` in `@osdk/shared.client2`.
-const SYMBOL_CLIENT_CONTEXT = "__osdkClientContext";
-
-export interface FetchPageStubBuilder<T> {
-  thenReturnObjects(objects: T[]): void;
-}
-
-export interface FetchOneStubBuilder<T> {
-  thenReturnObject(object: T): void;
-}
-
-export interface AggregateStubBuilder<T> {
-  thenReturnAggregation(result: T): void;
-}
-
-export interface QueryStubBuilder<T> {
-  thenReturn(result: T): void;
-  thenThrow(error: Error): void;
-}
-
-export type StubBuilderFor<T> = T extends Promise<infer R> ? StubBuilderFor<R>
-  : T extends AsyncIterableIterator<infer U> ? FetchPageStubBuilder<U>
-  : T extends PageResult<infer U> ? FetchPageStubBuilder<U>
-  : T extends { value: PageResult<infer U>; error?: never }
-    ? FetchPageStubBuilder<U>
-  : T extends { value: infer U; error?: never }
-    ? (IsOsdkObject<U> extends true ? FetchOneStubBuilder<U>
-      : AggregateStubBuilder<U>)
-  : T extends { error: Error; value?: never } ? never
-  : IsOsdkObject<T> extends true ? FetchOneStubBuilder<T>
-  : AggregateStubBuilder<T>;
-
 type QueryReturnTypeFromDef<Q extends QueryDefinition> = ReturnType<
   CompileTimeMetadata<Q>["signature"]
 > extends Promise<infer R> ? R : never;
@@ -87,29 +55,10 @@ type QueryParamsFromDef<Q extends QueryDefinition> =
   Parameters<CompileTimeMetadata<Q>["signature"]> extends [infer P] ? P
     : undefined;
 
-export type StubClient = {
-  <Q extends ObjectTypeDefinition>(o: Q): ObjectSet<Q>;
-  <Q extends InterfaceDefinition>(o: Q): ObjectSet<Q>;
-};
-
-export type StubPatternCallback<T> = (client: StubClient) => T;
-
-export type ObjectSetStubCallback<Q extends ObjectOrInterfaceDefinition, T> = (
-  os: ObjectSet<Q>,
-) => T;
-
-export interface MockClient extends Client {
-  when<T>(callback: StubPatternCallback<T>): StubBuilderFor<T>;
-  whenObjectSet<Q extends ObjectOrInterfaceDefinition, T>(
-    objectSet: ObjectSet<Q>,
-    callback: ObjectSetStubCallback<Q, T>,
-  ): StubBuilderFor<T>;
-  whenQuery<Q extends QueryDefinition>(
-    query: Q,
-    params?: QueryParamsFromDef<Q>,
-  ): QueryStubBuilder<QueryReturnTypeFromDef<Q>>;
-  clearStubs(): void;
-}
+// Well-known string key used by Foundry Platform APIs to pull the
+// SharedClientContext (baseUrl, tokenProvider, fetch) off a client. Matches
+// the value of `symbolClientContext` in `@osdk/shared.client2`.
+const SYMBOL_CLIENT_CONTEXT = "__osdkClientContext";
 
 export function createMockClient(): MockClient {
   const stubs: ClientStub[] = [];

--- a/packages/functions-testing.experimental/src/mock/createMockOsdkObject.ts
+++ b/packages/functions-testing.experimental/src/mock/createMockOsdkObject.ts
@@ -16,39 +16,15 @@
 
 import type {
   CompileTimeMetadata,
-  LinkedType,
-  LinkNames,
-  ObjectSet,
   ObjectTypeDefinition,
   Osdk,
   Result,
 } from "@osdk/api";
 import invariant from "tiny-invariant";
+import type { MockOsdkObjectOptions } from "../api/MockOsdkObjectOptions.js";
 import { isMockObjectSet } from "./createMockObjectSet.js";
 
-/**
- * Options for customizing mock object creation.
- */
-export interface MockOsdkObjectOptions<
-  Q extends ObjectTypeDefinition = ObjectTypeDefinition,
-> {
-  /** Objects linked to this object by API name */
-  links?: LinkStubs<Q>;
-  /** The API name of the title property (optional, required for $title) */
-  titlePropertyApiName?: string;
-  /** Override the generated $rid */
-  $rid?: string;
-}
-
 // TODO: Add support for RDPs
-
-type LinkStubs<Q extends ObjectTypeDefinition> = {
-  [LINK_NAME in LinkNames<Q>]?:
-    CompileTimeMetadata<Q>["links"][LINK_NAME]["multiplicity"] extends true ?
-        | Array<Osdk.Instance<LinkedType<Q, LINK_NAME>>>
-        | ObjectSet<LinkedType<Q, LINK_NAME>>
-      : Osdk.Instance<LinkedType<Q, LINK_NAME>> | Error;
-};
 
 function createSingleLinkStub<T extends ObjectTypeDefinition>(
   linked: Osdk.Instance<T> | Error,

--- a/packages/functions-testing.experimental/src/mock/createMockOsdkObject.ts
+++ b/packages/functions-testing.experimental/src/mock/createMockOsdkObject.ts
@@ -21,6 +21,7 @@ import type {
   ObjectSet,
   ObjectTypeDefinition,
   Osdk,
+  Result,
 } from "@osdk/api";
 import invariant from "tiny-invariant";
 import { isMockObjectSet } from "./createMockObjectSet.js";
@@ -46,18 +47,24 @@ type LinkStubs<Q extends ObjectTypeDefinition> = {
     CompileTimeMetadata<Q>["links"][LINK_NAME]["multiplicity"] extends true ?
         | Array<Osdk.Instance<LinkedType<Q, LINK_NAME>>>
         | ObjectSet<LinkedType<Q, LINK_NAME>>
-      : Osdk.Instance<LinkedType<Q, LINK_NAME>>;
+      : Osdk.Instance<LinkedType<Q, LINK_NAME>> | Error;
 };
 
 function createSingleLinkStub<T extends ObjectTypeDefinition>(
-  linkedObject: Osdk.Instance<T>,
+  linked: Osdk.Instance<T> | Error,
 ): {
   fetchOne: () => Promise<Osdk.Instance<T>>;
-  fetchOneWithErrors: () => Promise<{ value: Osdk.Instance<T> }>;
+  fetchOneWithErrors: () => Promise<Result<Osdk.Instance<T>>>;
 } {
+  if (linked instanceof Error) {
+    return {
+      fetchOne: () => Promise.reject(linked),
+      fetchOneWithErrors: () => Promise.resolve({ error: linked }),
+    };
+  }
   return {
-    fetchOne: () => Promise.resolve(linkedObject),
-    fetchOneWithErrors: () => Promise.resolve({ value: linkedObject }),
+    fetchOne: () => Promise.resolve(linked),
+    fetchOneWithErrors: () => Promise.resolve({ value: linked }),
   };
 }
 
@@ -238,7 +245,7 @@ export function createMockOsdkObject<
           );
         } else {
           linkAccessors[linkName] = createSingleLinkStub(
-            linkValue as Osdk.Instance<ObjectTypeDefinition>,
+            linkValue as Osdk.Instance<ObjectTypeDefinition> | Error,
           );
         }
       }


### PR DESCRIPTION
## Summary
- Fix \`StubBuilderFor<T>\` so \`fetchOneWithErrors\` / \`fetchPageWithErrors\` / \`asyncIter\` resolve to the correct stub builders instead of falling through to \`AggregateStubBuilder\`.
- Allow \`Error\` as a single-link stub value in \`createMockOsdkObject\` so link \`fetchOne\` rejects and \`fetchOneWithErrors\` returns \`{ error }\` (previously wrapped the \`Error\` in \`{ value: ... }\`, making \`isOk\` always true).
- Expand test coverage accordingly.

## Test plan
- [x] \`pnpm turbo typecheck --filter=@osdk/functions-testing.experimental\`
- [x] \`pnpm turbo test --filter=@osdk/functions-testing.experimental\`
- [x] \`pnpm turbo check-api --filter=@osdk/functions-testing.experimental\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)