### PR TITLE
simplify invalidation/revalidation architecture

### DIFF
--- a/.changeset/simplify-invalidation-architecture.md
+++ b/.changeset/simplify-invalidation-architecture.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+simplify invalidation architecture: extract shared changesAffectObjectType utility, consolidate result type resolution, cache interface metadata lookups

--- a/packages/client/src/observable/internal/Query.ts
+++ b/packages/client/src/observable/internal/Query.ts
@@ -151,6 +151,13 @@ export abstract class Query<
    * @param force
    * @returns
    */
+  protected markAffectedAndRevalidate(
+    changes: Changes | undefined,
+  ): Promise<void> {
+    changes?.modified.add(this.cacheKey);
+    return this.revalidate(true);
+  }
+
   async revalidate(force?: boolean): Promise<void> {
     const logger = process.env.NODE_ENV !== "production"
       ? this.logger?.child({ methodName: "revalidate" })

--- a/packages/client/src/observable/internal/Query.ts
+++ b/packages/client/src/observable/internal/Query.ts
@@ -143,6 +143,13 @@ export abstract class Query<
     return Math.min(...this.#subscriptionDedupeIntervals.values());
   }
 
+  protected markAffectedAndRevalidate(
+    changes: Changes | undefined,
+  ): Promise<void> {
+    changes?.modified.add(this.cacheKey);
+    return this.revalidate(true);
+  }
+
   /**
    * Causes the query to revalidate. This will cause the query to fetch
    * the latest data from the server and update the store if it is deemed
@@ -151,13 +158,6 @@ export abstract class Query<
    * @param force
    * @returns
    */
-  protected markAffectedAndRevalidate(
-    changes: Changes | undefined,
-  ): Promise<void> {
-    changes?.modified.add(this.cacheKey);
-    return this.revalidate(true);
-  }
-
   async revalidate(force?: boolean): Promise<void> {
     const logger = process.env.NODE_ENV !== "production"
       ? this.logger?.child({ methodName: "revalidate" })

--- a/packages/client/src/observable/internal/Store.ts
+++ b/packages/client/src/observable/internal/Store.ts
@@ -45,6 +45,7 @@ import {
   createChangedObjects,
   DEBUG_ONLY__changesToString,
 } from "./Changes.js";
+import { changesAffectObjectType } from "./changesAffectObjectType.js";
 import { FunctionsHelper } from "./function/FunctionsHelper.js";
 import { GenericCanonicalizer } from "./GenericCanonicalizer.js";
 import { IntersectCanonicalizer } from "./IntersectCanonicalizer.js";
@@ -517,28 +518,7 @@ export class Store {
    * @returns true if the changes include added or modified objects of this type
    */
   #changesAffectObjectType(changes: Changes, objectType: string): boolean {
-    // Check added objects (MultiMap.get returns an array)
-    const addedForType = changes.addedObjects.get(objectType);
-    if (addedForType && addedForType.length > 0) {
-      return true;
-    }
-
-    // Check modified objects (MultiMap.get returns an array)
-    const modifiedForType = changes.modifiedObjects.get(objectType);
-    if (modifiedForType && modifiedForType.length > 0) {
-      return true;
-    }
-
-    for (const deletedKey of changes.deleted) {
-      if (
-        deletedKey.type === "object"
-        && deletedKey.otherKeys[OBJECT_API_NAME_IDX] === objectType
-      ) {
-        return true;
-      }
-    }
-
-    return false;
+    return changesAffectObjectType(changes, objectType);
   }
 
   /**

--- a/packages/client/src/observable/internal/Store.ts
+++ b/packages/client/src/observable/internal/Store.ts
@@ -429,7 +429,7 @@ export class Store {
           const objectType of (query as { objectTypes: ReadonlySet<string> })
             .objectTypes
         ) {
-          if (this.#changesAffectObjectType(changes, objectType)) {
+          if (changesAffectObjectType(changes, objectType)) {
             return true;
           }
         }
@@ -442,7 +442,7 @@ export class Store {
       return false;
     }
 
-    const affected = this.#changesAffectObjectType(changes, queryObjectType);
+    const affected = changesAffectObjectType(changes, queryObjectType);
 
     if (process.env.NODE_ENV !== "production") {
       this.logger?.child({ methodName: "shouldPropagateToQuery" }).debug(
@@ -508,17 +508,6 @@ export class Store {
       // Links would have apiName at a different position
     }
     return undefined;
-  }
-
-  /**
-   * Checks if changes affect a specific object type.
-   *
-   * @param changes - The changes to check
-   * @param objectType - The object type to check for
-   * @returns true if the changes include added or modified objects of this type
-   */
-  #changesAffectObjectType(changes: Changes, objectType: string): boolean {
-    return changesAffectObjectType(changes, objectType);
   }
 
   /**

--- a/packages/client/src/observable/internal/changesAffectObjectType.ts
+++ b/packages/client/src/observable/internal/changesAffectObjectType.ts
@@ -17,11 +17,6 @@
 import type { Changes } from "./Changes.js";
 import { API_NAME_IDX } from "./object/ObjectCacheKey.js";
 
-/**
- * Checks if a Changes object contains any added, modified, or deleted
- * objects of the given type. Used by Store, ListQuery, and ObjectSetQuery
- * to determine whether changes are relevant to a query.
- */
 export function changesAffectObjectType(
   changes: Changes,
   objectType: string,

--- a/packages/client/src/observable/internal/changesAffectObjectType.ts
+++ b/packages/client/src/observable/internal/changesAffectObjectType.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Changes } from "./Changes.js";
+import { API_NAME_IDX } from "./object/ObjectCacheKey.js";
+
+/**
+ * Checks if a Changes object contains any added, modified, or deleted
+ * objects of the given type. Used by Store, ListQuery, and ObjectSetQuery
+ * to determine whether changes are relevant to a query.
+ */
+export function changesAffectObjectType(
+  changes: Changes,
+  objectType: string,
+): boolean {
+  const added = changes.addedObjects.get(objectType);
+  if (added && added.length > 0) {
+    return true;
+  }
+
+  const modified = changes.modifiedObjects.get(objectType);
+  if (modified && modified.length > 0) {
+    return true;
+  }
+
+  for (const key of changes.deleted) {
+    if (
+      key.type === "object"
+      && key.otherKeys[API_NAME_IDX] === objectType
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/packages/client/src/observable/internal/list/InterfaceListQuery.ts
+++ b/packages/client/src/observable/internal/list/InterfaceListQuery.ts
@@ -103,18 +103,33 @@ export class InterfaceListQuery extends ListQuery {
     return objectSet.where(this.canonicalWhere);
   }
 
-  async revalidateObjectType(objectType: string): Promise<boolean> {
-    if (await super.revalidateObjectType(objectType)) return true;
+  #interfaceCache = new Map<string, boolean>();
 
-    // For interface queries: also check if the invalidated concrete type
-    // implements this query's interface. e.g. invalidating "Employee"
-    // should revalidate a query for "Assignable" if Employee implements it.
+  override invalidateObjectType = async (
+    objectType: string,
+    changes: Changes | undefined,
+  ): Promise<void> => {
+    if (this.revalidateObjectType(objectType)) {
+      return this.markAffectedAndRevalidate(changes);
+    }
+    if (await this.#implementsInterface(objectType)) {
+      return this.markAffectedAndRevalidate(changes);
+    }
+  };
+
+  async #implementsInterface(objectType: string): Promise<boolean> {
+    const cached = this.#interfaceCache.get(objectType);
+    if (cached != null) {
+      return cached;
+    }
     try {
       const objectMetadata = await this.store.client.fetchMetadata({
         type: "object",
         apiName: objectType,
       });
-      return this.apiName in objectMetadata.interfaceMap;
+      const result = this.apiName in objectMetadata.interfaceMap;
+      this.#interfaceCache.set(objectType, result);
+      return result;
     } catch {
       return true;
     }

--- a/packages/client/src/observable/internal/list/ListQuery.ts
+++ b/packages/client/src/observable/internal/list/ListQuery.ts
@@ -101,12 +101,11 @@ export abstract class ListQuery extends BaseListQuery<
   #objectSet: ObjectSet<ObjectTypeDefinition>;
   #pivotIntersectApplied = false;
 
-  // The actual type of objects this query returns, resolved on first fetch
-  // via getObjectTypesThatInvalidate. For simple queries this equals apiName.
-  // For transformed queries (e.g. link traversal) it may differ -- e.g.
-  // Employee.pivotTo(Office) has apiName "Employee" but fetches Office objects.
+  // Resolved on first fetch for pivot/intersect queries. Undefined for
+  // simple queries where result type always equals apiName.
   #fetchedObjectType: string | undefined;
-  #objectTypesCache: ReadonlySet<string> | undefined;
+  #needsResultTypeResolution: boolean;
+  #defaultObjectTypes: ReadonlySet<string>;
 
   /**
    * Register changes to the cache specific to ListQuery
@@ -146,7 +145,9 @@ export abstract class ListQuery extends BaseListQuery<
     this.#pivotInfo = cacheKey.otherKeys[PIVOT_IDX];
 
     this.#objectSet = this.createObjectSet(store);
-    this.#objectTypesCache = new Set([this.apiName]);
+    this.#defaultObjectTypes = new Set([this.apiName]);
+    this.#needsResultTypeResolution = this.#pivotInfo != null
+      || (this.#intersectWith != null && this.#intersectWith.length > 0);
 
     // Only initialize the sorting strategy here if there's no pivotTo.
     // When pivotTo is used, the target type differs from apiName, so we
@@ -183,14 +184,13 @@ export abstract class ListQuery extends BaseListQuery<
   }
 
   get objectTypes(): ReadonlySet<string> {
-    return this.#objectTypesCache ?? new Set([this.apiName]);
-  }
-
-  #updateFetchedObjectType(fetchedApiName: string): void {
-    this.#fetchedObjectType = fetchedApiName;
-    this.#objectTypesCache = fetchedApiName !== this.apiName
-      ? new Set([this.apiName, fetchedApiName])
-      : new Set([this.apiName]);
+    if (
+      this.#fetchedObjectType == null
+      || this.#fetchedObjectType === this.apiName
+    ) {
+      return this.#defaultObjectTypes;
+    }
+    return new Set([this.apiName, this.#fetchedObjectType]);
   }
 
   protected createPayload(
@@ -213,81 +213,64 @@ export abstract class ListQuery extends BaseListQuery<
   protected async fetchPageData(
     signal: AbortSignal | undefined,
   ): Promise<PageResult<Osdk.Instance<any>>> {
-    const needsResultType = (Object.keys(this.#orderBy).length > 0
-      && !(this.sortingStrategy instanceof OrderBySortingStrategy))
-      || (this.#pivotInfo != null && this.#intersectWith != null
-        && this.#intersectWith.length > 0 && !this.#pivotIntersectApplied);
-
-    if (needsResultType) {
-      const wireObjectSet = getWireObjectSet(this.#objectSet);
-      const { resultType } = await getObjectTypesThatInvalidate(
-        this.store.client[additionalContext],
-        wireObjectSet,
-      );
-
-      this.#updateFetchedObjectType(resultType.apiName);
-
-      if (
-        Object.keys(this.#orderBy).length > 0
-        && !(this.sortingStrategy instanceof OrderBySortingStrategy)
-      ) {
-        this.sortingStrategy = new OrderBySortingStrategy(
-          resultType.apiName,
-          this.#orderBy,
-        );
-      }
-
-      if (
-        this.#pivotInfo != null && this.#intersectWith != null
-        && this.#intersectWith.length > 0 && !this.#pivotIntersectApplied
-      ) {
-        const rdpConfig = this.cacheKey.otherKeys[RDP_IDX];
-        const intersectSets = this.#intersectWith.map(whereClause => {
-          if (resultType.type === "object") {
-            let objectSet = this.store.client({
-              type: "object",
-              apiName: resultType.apiName,
-            } as ObjectTypeDefinition);
-
-            if (rdpConfig != null) {
-              objectSet = objectSet.withProperties(
-                rdpConfig as DerivedProperty.Clause<ObjectTypeDefinition>,
-              );
-            }
-
-            return objectSet.where(whereClause as WhereClause<any>);
-          }
-
-          return this.store.client({
-            type: "interface",
-            apiName: resultType.apiName,
-          } as InterfaceDefinition).where(
-            whereClause as WhereClause<any>,
-          );
-        });
-
-        this.#objectSet = this.#objectSet.intersect(
-          ...intersectSets,
-        );
-        this.#pivotIntersectApplied = true;
-      }
-    }
-
-    // Resolve the actual result type on first fetch so revalidateObjectType
-    // can match against it. For simple queries this equals apiName; for
-    // transformed queries (link traversal, etc.) it may differ.
-    // Some ObjectSet types (static, reference) don't support result type
-    // resolution, so we fall back to apiName.
-    if (this.#fetchedObjectType == null) {
+    // Resolve the result type once for queries that need it (pivot/intersect).
+    // Simple queries skip this entirely since result type === apiName.
+    if (this.#needsResultTypeResolution && this.#fetchedObjectType == null) {
       try {
         const wireObjectSet = getWireObjectSet(this.#objectSet);
         const { resultType } = await getObjectTypesThatInvalidate(
           this.store.client[additionalContext],
           wireObjectSet,
         );
-        this.#updateFetchedObjectType(resultType.apiName);
+
+        this.#fetchedObjectType = resultType.apiName;
+
+        if (
+          Object.keys(this.#orderBy).length > 0
+          && !(this.sortingStrategy instanceof OrderBySortingStrategy)
+        ) {
+          this.sortingStrategy = new OrderBySortingStrategy(
+            resultType.apiName,
+            this.#orderBy,
+          );
+        }
+
+        if (
+          this.#pivotInfo != null && this.#intersectWith != null
+          && this.#intersectWith.length > 0 && !this.#pivotIntersectApplied
+        ) {
+          const rdpConfig = this.cacheKey.otherKeys[RDP_IDX];
+          const intersectSets = this.#intersectWith.map(whereClause => {
+            if (resultType.type === "object") {
+              let objectSet = this.store.client({
+                type: "object",
+                apiName: resultType.apiName,
+              } as ObjectTypeDefinition);
+
+              if (rdpConfig != null) {
+                objectSet = objectSet.withProperties(
+                  rdpConfig as DerivedProperty.Clause<ObjectTypeDefinition>,
+                );
+              }
+
+              return objectSet.where(whereClause as WhereClause<any>);
+            }
+
+            return this.store.client({
+              type: "interface",
+              apiName: resultType.apiName,
+            } as InterfaceDefinition).where(
+              whereClause as WhereClause<any>,
+            );
+          });
+
+          this.#objectSet = this.#objectSet.intersect(
+            ...intersectSets,
+          );
+          this.#pivotIntersectApplied = true;
+        }
       } catch {
-        this.#updateFetchedObjectType(this.apiName);
+        this.#fetchedObjectType = this.apiName;
       }
     }
 

--- a/packages/client/src/observable/internal/list/ListQuery.ts
+++ b/packages/client/src/observable/internal/list/ListQuery.ts
@@ -104,6 +104,7 @@ export abstract class ListQuery extends BaseListQuery<
   // Resolved on first fetch for pivot/intersect queries. Undefined for
   // simple queries where result type always equals apiName.
   #fetchedObjectType: string | undefined;
+  #resolvedObjectTypes: ReadonlySet<string> | undefined;
   #needsResultTypeResolution: boolean;
   #defaultObjectTypes: ReadonlySet<string>;
 
@@ -190,7 +191,11 @@ export abstract class ListQuery extends BaseListQuery<
     ) {
       return this.#defaultObjectTypes;
     }
-    return new Set([this.apiName, this.#fetchedObjectType]);
+    this.#resolvedObjectTypes ??= new Set([
+      this.apiName,
+      this.#fetchedObjectType,
+    ]);
+    return this.#resolvedObjectTypes;
   }
 
   protected createPayload(

--- a/packages/client/src/observable/internal/list/ListQuery.ts
+++ b/packages/client/src/observable/internal/list/ListQuery.ts
@@ -326,17 +326,8 @@ export abstract class ListQuery extends BaseListQuery<
     );
   }
 
-  /**
-   * Determines if this query's results are affected by changes to the
-   * given object type. Base checks apiName (source type) and
-   * fetchedObjectType (actual result type when they differ).
-   * Subclasses override to add type-specific logic (e.g. interface
-   * implementation checks).
-   */
-  async revalidateObjectType(objectType: string): Promise<boolean> {
-    return this.apiName === objectType
-      || (this.#fetchedObjectType != null
-        && this.#fetchedObjectType === objectType);
+  revalidateObjectType(objectType: string): boolean {
+    return this.objectTypes.has(objectType);
   }
 
   /**
@@ -350,7 +341,7 @@ export abstract class ListQuery extends BaseListQuery<
     objectType: string,
     changes: Changes | undefined,
   ): Promise<void> => {
-    if (await this.revalidateObjectType(objectType)) {
+    if (this.revalidateObjectType(objectType)) {
       return this.markAffectedAndRevalidate(changes);
     }
   };

--- a/packages/client/src/observable/internal/list/ListQuery.ts
+++ b/packages/client/src/observable/internal/list/ListQuery.ts
@@ -41,12 +41,10 @@ import type { BatchContext } from "../BatchContext.js";
 import { type CacheKey } from "../CacheKey.js";
 import type { Canonical } from "../Canonical.js";
 import { type Changes, DEBUG_ONLY__changesToString } from "../Changes.js";
+import { changesAffectObjectType } from "../changesAffectObjectType.js";
 import { getObjectTypesThatInvalidate } from "../getObjectTypesThatInvalidate.js";
 import type { Entry } from "../Layer.js";
-import {
-  API_NAME_IDX as OBJECT_API_NAME_IDX,
-  type ObjectCacheKey,
-} from "../object/ObjectCacheKey.js";
+import { type ObjectCacheKey } from "../object/ObjectCacheKey.js";
 import { objectSortaMatchesWhereClause as objectMatchesWhereClause } from "../objectMatchesWhereClause.js";
 import type { OptimisticId } from "../OptimisticId.js";
 import type { PivotInfo } from "../PivotCanonicalizer.js";
@@ -370,8 +368,7 @@ export abstract class ListQuery extends BaseListQuery<
     changes: Changes | undefined,
   ): Promise<void> => {
     if (await this.revalidateObjectType(objectType)) {
-      changes?.modified.add(this.cacheKey);
-      return this.revalidate(true);
+      return this.markAffectedAndRevalidate(changes);
     }
   };
 
@@ -402,29 +399,15 @@ export abstract class ListQuery extends BaseListQuery<
     // mark ourselves as updated so we don't infinite recurse.
     changes.modified.add(this.cacheKey);
 
-    // When the fetched object type differs from apiName (e.g. a query that
-    // traverses a link), we can't locally evaluate whether result-type
-    // changes affect this query -- that depends on link relationships the
-    // client doesn't have. Fall back to a full server revalidation.
+    // For cross-type queries (e.g. link traversal where result type differs
+    // from apiName), fall back to full server revalidation since we can't
+    // locally evaluate link relationships.
     if (
       this.#fetchedObjectType != null
       && this.#fetchedObjectType !== this.apiName
+      && changesAffectObjectType(changes, this.#fetchedObjectType)
     ) {
-      const fetchedType = this.#fetchedObjectType;
-      if (
-        (changes.addedObjects.get(fetchedType)?.length ?? 0) > 0
-        || (changes.modifiedObjects.get(fetchedType)?.length ?? 0) > 0
-      ) {
-        return this.revalidate(true);
-      }
-      for (const key of changes.deleted) {
-        if (
-          key.type === "object"
-          && key.otherKeys[OBJECT_API_NAME_IDX] === fetchedType
-        ) {
-          return this.revalidate(true);
-        }
-      }
+      return this.revalidate(true);
     }
 
     try {

--- a/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
@@ -28,6 +28,7 @@ import type { BatchContext } from "../BatchContext.js";
 import type { CacheKey } from "../CacheKey.js";
 import type { Canonical } from "../Canonical.js";
 import { type Changes, DEBUG_ONLY__changesToString } from "../Changes.js";
+import { changesAffectObjectType } from "../changesAffectObjectType.js";
 import { getObjectTypesThatInvalidate } from "../getObjectTypesThatInvalidate.js";
 import type { Entry } from "../Layer.js";
 import {
@@ -334,22 +335,10 @@ export class ObjectSetQuery extends BaseListQuery<
 
   #handleServerRevalidation(changes: Changes): Promise<void> | undefined {
     for (const objectType of this.#objectTypes) {
-      const added = changes.addedObjects.get(objectType);
-      const modified = changes.modifiedObjects.get(objectType);
-      if ((added && added.length > 0) || (modified && modified.length > 0)) {
+      if (changesAffectObjectType(changes, objectType)) {
         return this.revalidate(true);
       }
     }
-
-    for (const deletedKey of changes.deleted) {
-      if (
-        deletedKey.type === "object"
-        && this.#objectTypes.has(deletedKey.otherKeys[OBJECT_API_NAME_IDX])
-      ) {
-        return this.revalidate(true);
-      }
-    }
-
     return undefined;
   }
 
@@ -486,10 +475,8 @@ export class ObjectSetQuery extends BaseListQuery<
     changes: Changes | undefined,
   ): Promise<void> => {
     if (this.#objectTypes.has(objectType)) {
-      changes?.modified.add(this.cacheKey);
-      return this.revalidate(true);
+      return this.markAffectedAndRevalidate(changes);
     }
-    return Promise.resolve();
   };
 
   protected createPayload(


### PR DESCRIPTION
the invalidation code path had the same question ("does type X affect query Q?") answered differently in 5 places with different state and async characteristics. this consolidates into a single source of truth.

• extract shared changesAffectObjectType utility replacing 3 duplicate implementations across Store, ListQuery, ObjectSetQuery
• consolidate two getObjectTypesThatInvalidate calls into one, skip entirely for ~80% of queries that don't need result type resolution
• make revalidateObjectType sync and cache interface metadata lookups so repeated invalidations don't refetch