### PR TITLE
fix react.beta template regressions from #2770

### DIFF
--- a/.changeset/fix-react-beta-template-provider.md
+++ b/.changeset/fix-react-beta-template-provider.md
@@ -1,0 +1,5 @@
+---
+"@osdk/create-app.template.react.beta": patch
+---
+
+restore @osdk/react dep and OsdkProvider in main.tsx so the commented useOsdkClient example in Home.tsx works when uncommented

--- a/.changeset/fix-react-beta-template-provider.md
+++ b/.changeset/fix-react-beta-template-provider.md
@@ -1,5 +1,7 @@
 ---
 "@osdk/create-app.template.react.beta": patch
+"@osdk/create-widget.template.react.v2": patch
+"@osdk/create-widget.template.minimal-react.v2": patch
 ---
 
-restore @osdk/react dep and OsdkProvider in main.tsx so the commented useOsdkClient example in Home.tsx works when uncommented
+add @osdk/react dep and OsdkProvider wrapping in app and widget react templates so the commented useOsdkClient example works when uncommented

--- a/examples/example-react-sdk-2.x-no-osdk/package.json
+++ b/examples/example-react-sdk-2.x-no-osdk/package.json
@@ -23,6 +23,7 @@
     "@osdk/client": "workspace:*",
     "@osdk/foundry": "latest",
     "@osdk/oauth": "workspace:*",
+    "@osdk/react": "workspace:*",
     "normalize.css": "^8.0.1",
     "react": "^18",
     "react-dom": "^18",

--- a/examples/example-react-sdk-2.x-no-osdk/src/main.tsx
+++ b/examples/example-react-sdk-2.x-no-osdk/src/main.tsx
@@ -1,10 +1,10 @@
 import { Suspense } from "react";
 import ReactDOM from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
-import "./index.css";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import Loading from "@/components/Loading";
 import { router } from "@/router";
+import "./index.css";
 
 const rootElement = document.getElementById("root");
 if (!rootElement) {

--- a/examples/example-react-sdk-2.x/package.json
+++ b/examples/example-react-sdk-2.x/package.json
@@ -24,6 +24,7 @@
     "@osdk/e2e.generated.catchall": "workspace:*",
     "@osdk/foundry": "latest",
     "@osdk/oauth": "workspace:*",
+    "@osdk/react": "workspace:*",
     "normalize.css": "^8.0.1",
     "react": "^18",
     "react-dom": "^18",

--- a/examples/example-react-sdk-2.x/src/main.tsx
+++ b/examples/example-react-sdk-2.x/src/main.tsx
@@ -1,10 +1,12 @@
 import { Suspense } from "react";
 import ReactDOM from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
-import "./index.css";
+import { OsdkProvider } from "@osdk/react";
+import client from "@/client";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import Loading from "@/components/Loading";
 import { router } from "@/router";
+import "./index.css";
 
 const rootElement = document.getElementById("root");
 if (!rootElement) {
@@ -14,7 +16,9 @@ if (!rootElement) {
 ReactDOM.createRoot(rootElement).render(
   <ErrorBoundary>
     <Suspense fallback={<Loading />}>
-      <RouterProvider router={router} />
+      <OsdkProvider client={client}>
+        <RouterProvider router={router} />
+      </OsdkProvider>
     </Suspense>
   </ErrorBoundary>,
 );

--- a/examples/example-widget-minimal-react-sdk-2.x/package.json
+++ b/examples/example-widget-minimal-react-sdk-2.x/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@blueprintjs/core": "^6.10.0",
+    "@osdk/react": "workspace:*",
     "@osdk/widget.client": "workspace:*",
     "@osdk/widget.client-react": "workspace:*",
     "clsx": "^2.1.1",

--- a/examples/example-widget-react-sdk-2.x/package.json
+++ b/examples/example-widget-react-sdk-2.x/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@osdk/client": "workspace:*",
     "@osdk/e2e.generated.catchall": "workspace:*",
+    "@osdk/react": "workspace:*",
     "@osdk/widget.client": "workspace:*",
     "@osdk/widget.client-react": "workspace:*",
     "@radix-ui/react-icons": "^1.3.2",

--- a/examples/example-widget-react-sdk-2.x/src/Widget.tsx
+++ b/examples/example-widget-react-sdk-2.x/src/Widget.tsx
@@ -15,10 +15,14 @@ import {
 import React, { useCallback, useState } from "react";
 import { useWidgetContext } from "./context.js";
 import { useDarkTheme } from "./useDarkTheme.js";
-// import { client } from "./client.js";
+// import { useOsdkClient } from "@osdk/react";
 // View the API documentation for your widget set to learn how to use the Ontology SDK.
 
 export const Widget: React.FC = () => {
+  // See Ontology and Platform SDK docs in Developer Console on how to
+  // use the client object to access Ontology resources and platform APIs
+  // const client = useOsdkClient();
+
   const { parameters, emitEvent } = useWidgetContext();
   const { headerText, todoItems } = parameters.values;
   const [newTodoItem, setNewTodoItem] = useState("");

--- a/examples/example-widget-react-sdk-2.x/src/main.tsx
+++ b/examples/example-widget-react-sdk-2.x/src/main.tsx
@@ -1,6 +1,7 @@
 import "@radix-ui/themes/styles.css";
 import "./main.css";
 
+import { OsdkProvider } from "@osdk/react";
 import { FoundryWidget } from "@osdk/widget.client-react";
 import { createRoot } from "react-dom/client";
 import { client } from "./client.js";
@@ -11,6 +12,8 @@ const root = document.getElementById("root")!;
 
 createRoot(root).render(
   <FoundryWidget config={MainConfig} client={client}>
-    <Widget />
+    <OsdkProvider client={client}>
+      <Widget />
+    </OsdkProvider>
   </FoundryWidget>,
 );

--- a/packages/create-app.template.react.beta/templates/package.json.osdk.hbs
+++ b/packages/create-app.template.react.beta/templates/package.json.osdk.hbs
@@ -18,6 +18,7 @@
     "@osdk/client": "{{clientVersion}}",
     "@osdk/foundry": "latest",
     "@osdk/oauth": "^1.1.0",
+    "@osdk/react": "^0.7.0",
     "@blueprintjs/core": "^6.8.1",
     "@blueprintjs/icons": "^6.6.0"
   },

--- a/packages/create-app.template.react.beta/templates/package.json.osdk.hbs
+++ b/packages/create-app.template.react.beta/templates/package.json.osdk.hbs
@@ -18,7 +18,7 @@
     "@osdk/client": "{{clientVersion}}",
     "@osdk/foundry": "latest",
     "@osdk/oauth": "^1.1.0",
-    "@osdk/react": "^0.7.0",
+    "@osdk/react": "^0.13.0",
     "@blueprintjs/core": "^6.8.1",
     "@blueprintjs/icons": "^6.6.0"
   },

--- a/packages/create-app.template.react.beta/templates/package.json.psdk.hbs
+++ b/packages/create-app.template.react.beta/templates/package.json.psdk.hbs
@@ -17,7 +17,7 @@
     "@osdk/client": "{{clientVersion}}",
     "@osdk/foundry": "latest",
     "@osdk/oauth": "^1.1.0",
-    "@osdk/react": "^0.7.0",
+    "@osdk/react": "^0.13.0",
     "@blueprintjs/core": "^6.8.1",
     "@blueprintjs/icons": "^6.6.0"
   },

--- a/packages/create-app.template.react.beta/templates/package.json.psdk.hbs
+++ b/packages/create-app.template.react.beta/templates/package.json.psdk.hbs
@@ -17,6 +17,7 @@
     "@osdk/client": "{{clientVersion}}",
     "@osdk/foundry": "latest",
     "@osdk/oauth": "^1.1.0",
+    "@osdk/react": "^0.7.0",
     "@blueprintjs/core": "^6.8.1",
     "@blueprintjs/icons": "^6.6.0"
   },

--- a/packages/create-app.template.react.beta/templates/src/main.tsx.hbs
+++ b/packages/create-app.template.react.beta/templates/src/main.tsx.hbs
@@ -1,10 +1,14 @@
 import { Suspense } from "react";
 import ReactDOM from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
-import "./index.css";
+{{#if osdkPackage}}
+import { OsdkProvider } from "@osdk/react";
+import client from "@/client";
+{{/if}}
 import ErrorBoundary from "@/components/ErrorBoundary";
 import Loading from "@/components/Loading";
 import { router } from "@/router";
+import "./index.css";
 
 const rootElement = document.getElementById("root");
 if (!rootElement) {
@@ -14,7 +18,13 @@ if (!rootElement) {
 ReactDOM.createRoot(rootElement).render(
   <ErrorBoundary>
     <Suspense fallback={<Loading />}>
+      {{#if osdkPackage}}
+      <OsdkProvider client={client}>
+        <RouterProvider router={router} />
+      </OsdkProvider>
+      {{else}}
       <RouterProvider router={router} />
+      {{/if}}
     </Suspense>
   </ErrorBoundary>,
 );

--- a/packages/create-widget.template.minimal-react.v2/templates/package.json.hbs
+++ b/packages/create-widget.template.minimal-react.v2/templates/package.json.hbs
@@ -11,6 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@osdk/react": "^0.13.0",
     "@osdk/widget.client-react": "^3.2.4",
     "@osdk/widget.client": "^3.2.4"
   },

--- a/packages/create-widget.template.react.v2/templates/package.json.hbs
+++ b/packages/create-widget.template.react.v2/templates/package.json.hbs
@@ -13,6 +13,7 @@
   "dependencies": {
     "{{osdkPackage}}": "latest",
     "@osdk/client": "^2.0.0",
+    "@osdk/react": "^0.13.0",
     "@osdk/widget.client-react": "^3.3.0",
     "@osdk/widget.client": "^3.3.0"
   },

--- a/packages/create-widget.template.react.v2/templates/src/Widget.tsx.hbs
+++ b/packages/create-widget.template.react.v2/templates/src/Widget.tsx.hbs
@@ -15,10 +15,14 @@ import {
 import React, { useCallback, useState } from "react";
 import { useWidgetContext } from "./context.js";
 import { useDarkTheme } from "./useDarkTheme.js";
-// import { client } from "./client.js";
+// import { useOsdkClient } from "@osdk/react";
 // View the API documentation for your widget set to learn how to use the Ontology SDK.
 
 export const Widget: React.FC = () => {
+  // See Ontology and Platform SDK docs in Developer Console on how to
+  // use the client object to access Ontology resources and platform APIs
+  // const client = useOsdkClient();
+
   const { parameters, emitEvent } = useWidgetContext();
   const { headerText, todoItems } = parameters.values;
   const [newTodoItem, setNewTodoItem] = useState("");

--- a/packages/create-widget.template.react.v2/templates/src/main.tsx
+++ b/packages/create-widget.template.react.v2/templates/src/main.tsx
@@ -1,6 +1,7 @@
 import "@radix-ui/themes/styles.css";
 import "./main.css";
 
+import { OsdkProvider } from "@osdk/react";
 import { FoundryWidget } from "@osdk/widget.client-react";
 import { createRoot } from "react-dom/client";
 import { client } from "./client.js";
@@ -11,6 +12,8 @@ const root = document.getElementById("root")!;
 
 createRoot(root).render(
   <FoundryWidget config={MainConfig} client={client}>
-    <Widget />
+    <OsdkProvider client={client}>
+      <Widget />
+    </OsdkProvider>
   </FoundryWidget>,
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -865,6 +865,9 @@ importers:
       '@osdk/oauth':
         specifier: workspace:*
         version: link:../../packages/oauth
+      '@osdk/react':
+        specifier: workspace:*
+        version: link:../../packages/react
       normalize.css:
         specifier: ^8.0.1
         version: 8.0.1
@@ -965,6 +968,9 @@ importers:
       '@osdk/oauth':
         specifier: workspace:*
         version: link:../../packages/oauth
+      '@osdk/react':
+        specifier: workspace:*
+        version: link:../../packages/react
       normalize.css:
         specifier: ^8.0.1
         version: 8.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1462,6 +1462,9 @@ importers:
       '@blueprintjs/core':
         specifier: ^6.10.0
         version: 6.11.3(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@osdk/react':
+        specifier: workspace:*
+        version: link:../../packages/react
       '@osdk/widget.client':
         specifier: workspace:*
         version: link:../../packages/widget.client
@@ -1544,6 +1547,9 @@ importers:
       '@osdk/e2e.generated.catchall':
         specifier: workspace:*
         version: link:../../packages/e2e.generated.catchall
+      '@osdk/react':
+        specifier: workspace:*
+        version: link:../../packages/react
       '@osdk/widget.client':
         specifier: workspace:*
         version: link:../../packages/widget.client


### PR DESCRIPTION
restore @osdk/react dep and OsdkProvider wrapping so the commented useOsdkClient example in Home.tsx works when uncommented

• add @osdk/react back to package.json.osdk.hbs, package.json.psdk.hbs, and both compiled examples (minimal + lohi)
• rename templates/src/main.tsx back to main.tsx.hbs with {{#if osdkPackage}} conditional OsdkProvider wrapping, preserving the ErrorBoundary/Suspense/Loading/path-alias improvements from #2770
• wrap RouterProvider in OsdkProvider in examples/example-react-sdk-2.x/src/main.tsx