### PR TITLE
Export LoadingCells as building blocks

### DIFF
--- a/.changeset/easy-apples-raise.md
+++ b/.changeset/easy-apples-raise.md
@@ -1,0 +1,6 @@
+---
+"@osdk/react-components-storybook": minor
+"@osdk/react-components": minor
+---
+
+Export LoadingCells as building blocks

--- a/packages/react-components-storybook/src/stories/ObjectTable/LoadingCell.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/LoadingCell.stories.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LoadingCell } from "@osdk/react-components/experimental/object-table";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta<typeof LoadingCell> = {
+  title: "Experimental/ObjectTable/Building Blocks/LoadingCell",
+  component: LoadingCell,
+  args: {
+    width: 200,
+  },
+  argTypes: {
+    width: {
+      description: "The width of the cell in pixels",
+      control: { type: "number", min: 50, max: 600 },
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "A full `<td>` element with a skeleton loading indicator. Use this when rendering a complete table cell in a custom row renderer.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <table>
+        <tbody>
+          <tr>
+            <Story />
+          </tr>
+        </tbody>
+      </table>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      source: {
+        code:
+          `import { LoadingCell } from "@osdk/react-components/experimental/object-table";
+
+<table>
+  <tbody>
+    <tr>
+      <LoadingCell width={200} />
+    </tr>
+  </tbody>
+</table>`,
+      },
+    },
+  },
+};

--- a/packages/react-components-storybook/src/stories/ObjectTable/LoadingCellContent.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/LoadingCellContent.stories.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LoadingCellContent } from "@osdk/react-components/experimental/object-table";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta<typeof LoadingCellContent> = {
+  title: "Experimental/ObjectTable/Building Blocks/LoadingCellContent",
+  component: LoadingCellContent,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "A skeleton loading indicator without a wrapping `<td>`. Use this when you need to show a loading state inside an existing table cell or any other container.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 200 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      source: {
+        code:
+          `import { LoadingCellContent } from "@osdk/react-components/experimental/object-table";
+
+<td>
+  <LoadingCellContent />
+</td>`,
+      },
+    },
+  },
+};

--- a/packages/react-components/src/public/experimental/object-table.ts
+++ b/packages/react-components/src/public/experimental/object-table.ts
@@ -50,3 +50,11 @@ export type {
   MultiColumnSortDialogProps,
   SortColumnItem,
 } from "../../object-table/MultiColumnSortDialog.js";
+
+// Loading cell components for custom column renderers.
+// Use `LoadingCell` when rendering a full `<td>` element (e.g. in a custom row renderer).
+// Use `LoadingCellContent` when rendering just the skeleton content inside an existing cell.
+export {
+  LoadingCell,
+  LoadingCellContent,
+} from "../../object-table/LoadingCell.js";


### PR DESCRIPTION
Export loading cell to make it easier for users to render custom cells

<img width="798" height="261" alt="Screenshot 2026-04-23 at 14 36 54" src="https://github.com/user-attachments/assets/26f7491c-9603-4ee9-b91b-2efb136cf287" />
