### PR TITLE
Version Packages

### DIFF
--- a/.changeset/all-walls-sit.md
+++ b/.changeset/all-walls-sit.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-components": patch
----
-
-Add BaseForm storybook

--- a/.changeset/clever-foxes-wave.md
+++ b/.changeset/clever-foxes-wave.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-components": patch
----
-
-Add horizontal orientation support to RadioButtonsField

--- a/.changeset/easy-apples-raise.md
+++ b/.changeset/easy-apples-raise.md
@@ -1,6 +1,0 @@
----
-"@osdk/react-components-storybook": minor
-"@osdk/react-components": minor
----
-
-Export LoadingCells as building blocks

--- a/.changeset/eighty-birds-happen.md
+++ b/.changeset/eighty-birds-happen.md
@@ -1,6 +1,0 @@
----
-"@osdk/react-components": patch
-"@osdk/react": patch
----
-
-Fix stableObjectSet by using a useStableObjectSet hook

--- a/packages/react-components-storybook/CHANGELOG.md
+++ b/packages/react-components-storybook/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/react-components-storybook
 
+## 0.5.0
+
+### Minor Changes
+
+- 83993d7: Export LoadingCells as building blocks
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/react-components-storybook/package.json
+++ b/packages/react-components-storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/react-components-storybook",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/react-components-styles/CHANGELOG.md
+++ b/packages/react-components-styles/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/react-components-styles
 
+## 0.7.0
+
 ## 0.6.0
 
 ## 0.5.0

--- a/packages/react-components-styles/package.json
+++ b/packages/react-components-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/react-components-styles",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @osdk/react-components
 
+## 0.7.0
+
+### Minor Changes
+
+- 594df08: Add BaseForm storybook
+- 22b4e35: Add horizontal orientation support to RadioButtonsField
+- 83993d7: Export LoadingCells as building blocks
+- 5a45dc0: Fix stableObjectSet by using a useStableObjectSet hook
+
+### Patch Changes
+
+- Updated dependencies [5a45dc0]
+  - @osdk/react@0.14.0
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/react-components",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -134,7 +134,7 @@
   "peerDependencies": {
     "@osdk/api": "^2.8.0",
     "@osdk/client": "^2.8.0",
-    "@osdk/react": "^0.13.0",
+    "@osdk/react": "^0.14.0",
     "@types/react": "^17 || ^18 || ^19",
     "classnames": "^2.0.0",
     "react": "^17 || ^18 || ^19",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdkkit/react
 
+## 0.14.0
+
+### Minor Changes
+
+- 5a45dc0: Fix stableObjectSet by using a useStableObjectSet hook
+
 ## 0.13.0
 
 ### Minor Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/react",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.


# Releases
## @osdk/react@0.14.0

### Minor Changes

-   5a45dc0: Fix stableObjectSet by using a useStableObjectSet hook

## @osdk/react-components@0.7.0

### Minor Changes

-   594df08: Add BaseForm storybook
-   22b4e35: Add horizontal orientation support to RadioButtonsField
-   83993d7: Export LoadingCells as building blocks
-   5a45dc0: Fix stableObjectSet by using a useStableObjectSet hook

### Patch Changes

-   Updated dependencies [5a45dc0]
    -   @osdk/react@0.14.0

## @osdk/react-components-styles@0.7.0



## @osdk/react-components-storybook@0.5.0

### Minor Changes

-   83993d7: Export LoadingCells as building blocks
