### PR TITLE
feat: allow keepAlive on individual actions via Observable client

### DIFF
--- a/.changeset/add-keepalive-observable-client.md
+++ b/.changeset/add-keepalive-observable-client.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Add keepAlive option to Observable client action interfaces

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -61,6 +61,7 @@ import type { OptimisticBuilder } from "./OptimisticBuilder.js";
 export namespace ObservableClient {
   export interface ApplyActionOptions {
     optimisticUpdate?: (ctx: OptimisticBuilder) => void;
+    keepAlive?: boolean;
   }
 }
 

--- a/packages/client/src/observable/internal/Store.ts
+++ b/packages/client/src/observable/internal/Store.ts
@@ -82,6 +82,7 @@ import { WhereClauseCanonicalizer } from "./WhereClauseCanonicalizer.js";
 export namespace Store {
   export interface ApplyActionOptions {
     optimisticUpdate?: (ctx: OptimisticBuilder) => void;
+    keepAlive?: boolean;
   }
 }
 


### PR DESCRIPTION
Thread keepAlive option through the Observable client so users can specify it per-action call:

  observableClient.applyAction(action, args, { keepAlive: true })

Changes:
- Add keepAlive?: boolean to ApplyActionOptions and ApplyBatchActionOptions
- Pass keepAlive through direct client applyAction
- Add keepAlive to Store.ApplyActionOptions and ObservableClient.ApplyActionOptions
- Thread keepAlive in ActionApplication for both single and batch calls