### PR TITLE
Fix storybook and types

### DIFF
--- a/.changeset/nine-paws-sniff.md
+++ b/.changeset/nine-paws-sniff.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Fix type definitions in FilterList LinkedProperty and ObjectTable function column

--- a/.changeset/tidy-hoops-design.md
+++ b/.changeset/tidy-hoops-design.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components-storybook": minor
+---
+
+Clean up storybook mock data and update examples

--- a/packages/e2e.sandbox.peopleapp/src/app/employees/EmployeesTable.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/employees/EmployeesTable.tsx
@@ -39,13 +39,14 @@ const columnDefinitions: Array<
   // Function-backed column
   {
     locator: {
-      type: "function" as const,
-      id: "daysSinceStart" as const,
+      type: "function",
+      id: "daysSinceStart",
       queryDefinition: getEmployeeDaysSinceStart,
-      getFunctionParams: (objectSet: any) => ({ employees: objectSet }),
-      getKey: (obj: any) => `${obj.$objectType}:${obj.$primaryKey}`,
-      getValue: (data: { daysSinceStart: any }) => data?.daysSinceStart,
-    } as any,
+      getFunctionParams: (objectSet) => ({ employees: objectSet }),
+      getKey: (obj) => `${obj.$objectType}:${obj.$primaryKey}`,
+      getValue: (data) =>
+        (data as { daysSinceStart?: number } | undefined)?.daysSinceStart,
+    },
     columnName: "Days Since Start",
     width: 150,
   },

--- a/packages/e2e.sandbox.peopleapp/src/app/employees/EmployeesWithFilterList.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/employees/EmployeesWithFilterList.tsx
@@ -61,7 +61,7 @@ interface EmployeesWithFilterListProps {
   onSelect: (employee: Employee.OsdkInstance) => void;
 }
 
-const INITIAL_FILTER_DEFINITIONS: FilterDefinitionUnion<Employee>[] = [
+const INITIAL_FILTER_DEFINITIONS: Array<FilterDefinitionUnion<Employee>> = [
   {
     type: "PROPERTY",
     id: "department",
@@ -69,7 +69,20 @@ const INITIAL_FILTER_DEFINITIONS: FilterDefinitionUnion<Employee>[] = [
     label: "Department",
     filterComponent: "LISTOGRAM",
     filterState: { type: "EXACT_MATCH", values: [] },
-  } as FilterDefinitionUnion<Employee>,
+  },
+  {
+    type: "LINKED_PROPERTY",
+    id: "lead-department",
+    linkName: "lead",
+    linkedPropertyKey: "department",
+    linkedFilterComponent: "LISTOGRAM",
+    linkedFilterState: { type: "EXACT_MATCH", values: [] },
+    filterState: {
+      type: "linkedProperty",
+      linkedFilterState: { type: "EXACT_MATCH", values: [] },
+    },
+    label: "Lead's Department",
+  },
 ];
 
 export function EmployeesWithFilterList(props: EmployeesWithFilterListProps) {

--- a/packages/react-components-storybook/src/mocks/employeeData.ts
+++ b/packages/react-components-storybook/src/mocks/employeeData.ts
@@ -330,7 +330,7 @@ export const employeeData: BaseServerObject[] = [
         ],
       ],
     },
-    "__primaryKey": 657495097,
+    "__primaryKey": 657495039,
     "leadEmployeeNumber": 657495106,
     "firstFullTimeStartDate": "2024-02-23",
     "preferredNameLast": "Torres",

--- a/packages/react-components-storybook/src/mocks/fauxFoundry.ts
+++ b/packages/react-components-storybook/src/mocks/fauxFoundry.ts
@@ -251,6 +251,49 @@ export async function setupFauxFoundry(): Promise<void> {
     };
   });
 
+  // Register a function-backed column query type
+  fauxFoundry.getDefaultOntology().registerQueryType(
+    {
+      apiName: "getEmployeeSeniority",
+      version: "1.0.0",
+      displayName: "Get Employee Seniority",
+      description:
+        "Returns seniority level for each employee based on their start date",
+      rid: "ri.function-registry.main.function.seniority-query",
+      typeReferences: {},
+      parameters: {
+        employees: {
+          dataType: {
+            type: "objectSet",
+            objectApiName: "Employee",
+            objectTypeApiName: "Employee",
+          },
+        },
+      },
+      output: {
+        type: "string",
+      },
+    },
+    (req, fauxDataStore) => {
+      const objects = Array.from(
+        fauxDataStore.getObjectsOfType("Employee"),
+      );
+      const result: Record<string, string> = {};
+      for (const obj of objects) {
+        const pk = String(obj.employeeNumber);
+        const startDate = obj.firstFullTimeStartDate as string | undefined;
+        if (startDate) {
+          const years = (Date.now() - new Date(startDate).getTime())
+            / (365.25 * 24 * 60 * 60 * 1000);
+          result[pk] = years >= 2 ? "Senior" : years >= 1 ? "Mid" : "Junior";
+        } else {
+          result[pk] = "Unknown";
+        }
+      }
+      return { value: result };
+    },
+  );
+
   // Log registered objects for debugging
   // eslint-disable-next-line no-console
   console.log(

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
@@ -23,7 +23,6 @@ import type {
 } from "@osdk/react-components/experimental/filter-list";
 import { FilterList } from "@osdk/react-components/experimental/filter-list";
 import { ObjectTable } from "@osdk/react-components/experimental/object-table";
-import { useOsdkClient } from "@osdk/react/experimental";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useCallback, useMemo, useState } from "react";
 import { useArgs } from "storybook/preview-api";
@@ -1552,4 +1551,408 @@ export const FullFeatured: Story = {
       <FullFeaturedStory {...args} onCollapsedChange={handleCollapsedChange} />
     );
   },
+};
+
+function WithLinkedPropertyFiltersStory(
+  args: Partial<EmployeeFilterListProps>,
+) {
+  const [filterClause, setFilterClause] = useState<
+    WhereClause<Employee> | undefined
+  >(undefined);
+
+  const filterDefinitions = useMemo(
+    (): FilterDefinitionUnion<Employee>[] => [
+      {
+        type: "HAS_LINK",
+        linkName: "lead",
+        label: "Has Manager",
+        filterState: { type: "hasLink", hasLink: false },
+      } as FilterDefinitionUnion<Employee>,
+      {
+        type: "LINKED_PROPERTY",
+        linkName: "peeps",
+        linkedPropertyKey: "department",
+        linkedFilterComponent: "LISTOGRAM",
+        linkedFilterState: { type: "EXACT_MATCH", values: [] },
+        filterState: {
+          type: "linkedProperty",
+          linkedFilterState: { type: "EXACT_MATCH", values: [] },
+        },
+        label: "Reports' Department",
+      } as FilterDefinitionUnion<Employee>,
+      {
+        type: "LINKED_PROPERTY",
+        linkName: "lead",
+        linkedPropertyKey: "locationCity",
+        linkedFilterComponent: "LISTOGRAM",
+        linkedFilterState: { type: "EXACT_MATCH", values: [] },
+        filterState: {
+          type: "linkedProperty",
+          linkedFilterState: { type: "EXACT_MATCH", values: [] },
+        },
+        label: "Manager's City",
+      } as FilterDefinitionUnion<Employee>,
+    ],
+    [],
+  );
+
+  return (
+    <div style={FLEX_ROW_STYLE}>
+      <div style={SIDEBAR_STYLE}>
+        <FilterList
+          objectType={Employee}
+          filterDefinitions={filterDefinitions}
+          filterClause={filterClause}
+          onFilterClauseChanged={setFilterClause}
+          {...args}
+        />
+      </div>
+      <div style={FLEX_FILL_STYLE}>
+        <strong>Filter Clause (JSON):</strong>
+        <pre style={PRE_STYLE}>
+          {filterClause
+            ? JSON.stringify(filterClause, null, 2)
+            : "(no active filters)"}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+export const WithLinkedPropertyFilters: Story = {
+  name: "Linked Property Filters",
+  parameters: {
+    docs: {
+      description: {
+        story: "Demonstrates filtering on properties of linked objects. "
+          + "HAS_LINK filters objects based on whether they have a linked object. "
+          + "LINKED_PROPERTY filters on a specific property of the linked objects. "
+          + "In this example, 'Reports' Department' filters employees by the department "
+          + "of their direct reports, and 'Manager's City' filters by the location of their manager.",
+      },
+      source: {
+        code: `const filterDefinitions = [
+  {
+    type: "HAS_LINK",
+    linkName: "lead",
+    label: "Has Manager",
+    filterState: { type: "hasLink", hasLink: false },
+  },
+  {
+    type: "LINKED_PROPERTY",
+    linkName: "peeps",
+    linkedPropertyKey: "department",
+    linkedFilterComponent: "LISTOGRAM",
+    linkedFilterState: { type: "EXACT_MATCH", values: [] },
+    filterState: {
+      type: "linkedProperty",
+      linkedFilterState: { type: "EXACT_MATCH", values: [] },
+    },
+    label: "Reports' Department",
+  },
+  {
+    type: "LINKED_PROPERTY",
+    linkName: "lead",
+    linkedPropertyKey: "locationCity",
+    linkedFilterComponent: "LISTOGRAM",
+    linkedFilterState: { type: "EXACT_MATCH", values: [] },
+    filterState: {
+      type: "linkedProperty",
+      linkedFilterState: { type: "EXACT_MATCH", values: [] },
+    },
+    label: "Manager's City",
+  },
+];
+
+<FilterList
+  objectType={Employee}
+  filterDefinitions={filterDefinitions}
+  filterClause={filterClause}
+  onFilterClauseChanged={setFilterClause}
+/>`,
+      },
+    },
+  },
+  render: (args) => <WithLinkedPropertyFiltersStory {...args} />,
+};
+
+function CustomNameContainsFilter({
+  filterState,
+  onFilterStateChanged,
+}: {
+  filterState: { type: "custom"; customState: { value: string } };
+  onFilterStateChanged: (
+    state: { type: "custom"; customState: { value: string } },
+  ) => void;
+}) {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      onFilterStateChanged({
+        type: "custom",
+        customState: { value },
+      });
+    },
+    [onFilterStateChanged],
+  );
+
+  const handleClear = useCallback(() => {
+    onFilterStateChanged({
+      type: "custom",
+      customState: { value: "" },
+    });
+  }, [onFilterStateChanged]);
+
+  return (
+    <div style={{ padding: "12px 0", display: "flex", gap: "8px" }}>
+      <input
+        type="text"
+        value={filterState.customState.value}
+        onChange={handleChange}
+        placeholder="Enter name substring..."
+        style={{
+          flex: 1,
+          padding: "6px 8px",
+          fontSize: "14px",
+          border: "1px solid #ccc",
+          borderRadius: "4px",
+        }}
+      />
+      {filterState.customState.value && (
+        <button
+          onClick={handleClear}
+          style={{
+            padding: "6px 12px",
+            fontSize: "12px",
+            backgroundColor: "#f5f5f5",
+            border: "1px solid #ccc",
+            borderRadius: "4px",
+            cursor: "pointer",
+          }}
+        >
+          Clear
+        </button>
+      )}
+    </div>
+  );
+}
+
+function CustomSeniorOnlyFilterItem({
+  filterState,
+  onFilterStateChanged,
+}: {
+  filterState: { type: "custom"; customState: { seniorOnly: boolean } };
+  onFilterStateChanged: (
+    state: { type: "custom"; customState: { seniorOnly: boolean } },
+  ) => void;
+}) {
+  const handleToggle = useCallback(() => {
+    onFilterStateChanged({
+      type: "custom",
+      customState: {
+        seniorOnly: !filterState.customState.seniorOnly,
+      },
+    });
+  }, [filterState, onFilterStateChanged]);
+
+  const isEnabled = filterState.customState.seniorOnly;
+
+  return (
+    <div
+      style={{
+        padding: "12px",
+        backgroundColor: isEnabled ? "#e8f4f8" : "#fafafa",
+        border: `2px solid ${isEnabled ? "#0066cc" : "#ddd"}`,
+        borderRadius: "6px",
+        cursor: "pointer",
+      }}
+      onClick={handleToggle}
+      role="button"
+      tabIndex={0}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "8px",
+          marginBottom: "6px",
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={isEnabled}
+          onChange={() => {}}
+          style={{ cursor: "pointer" }}
+        />
+        <strong>Senior Only</strong>
+      </div>
+      <p
+        style={{
+          margin: "0",
+          fontSize: "12px",
+          color: "#666",
+          lineHeight: "1.4",
+        }}
+      >
+        Show only employees with "Senior" in their job title
+      </p>
+    </div>
+  );
+}
+
+function WithCustomFiltersStory(args: Partial<EmployeeFilterListProps>) {
+  const [filterClause, setFilterClause] = useState<
+    WhereClause<Employee> | undefined
+  >(undefined);
+
+  const filterDefinitions = useMemo(
+    (): FilterDefinitionUnion<Employee>[] => [
+      {
+        type: "CUSTOM",
+        key: "custom-name-contains",
+        label: "Name Contains",
+        filterComponent: "CUSTOM",
+        filterState: { type: "custom", customState: { value: "" } },
+        renderInput: ({ filterState, onFilterStateChanged }) => (
+          <CustomNameContainsFilter
+            filterState={filterState as {
+              type: "custom";
+              customState: { value: string };
+            }}
+            onFilterStateChanged={onFilterStateChanged}
+          />
+        ),
+        toWhereClause: (state) => {
+          const value = (state.customState as { value?: string })?.value;
+          if (!value) return undefined;
+          return {
+            fullName: { $containsAnyTerm: value },
+          } as WhereClause<Employee>;
+        },
+      } as FilterDefinitionUnion<Employee>,
+      {
+        type: "CUSTOM",
+        key: "custom-senior-only",
+        label: "Senior Only",
+        filterComponent: "CUSTOM",
+        filterState: { type: "custom", customState: { seniorOnly: false } },
+        renderItem: ({ filterState, onFilterStateChanged }) => (
+          <CustomSeniorOnlyFilterItem
+            filterState={filterState as {
+              type: "custom";
+              customState: { seniorOnly: boolean };
+            }}
+            onFilterStateChanged={onFilterStateChanged}
+          />
+        ),
+        toWhereClause: (state) => {
+          const seniorOnly = (state.customState as { seniorOnly?: boolean })
+            ?.seniorOnly;
+          if (!seniorOnly) return undefined;
+          return {
+            jobTitle: { $containsAnyTerm: "Senior" },
+          } as WhereClause<Employee>;
+        },
+      } as FilterDefinitionUnion<Employee>,
+    ],
+    [],
+  );
+
+  return (
+    <div style={FLEX_ROW_STYLE}>
+      <div style={SIDEBAR_STYLE}>
+        <FilterList
+          objectType={Employee}
+          filterDefinitions={filterDefinitions}
+          filterClause={filterClause}
+          onFilterClauseChanged={setFilterClause}
+          {...args}
+        />
+      </div>
+      <div style={FLEX_FILL_STYLE}>
+        <strong>Filter Clause (JSON):</strong>
+        <pre style={PRE_STYLE}>
+          {filterClause
+            ? JSON.stringify(filterClause, null, 2)
+            : "(no active filters)"}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+export const WithCustomFilters: Story = {
+  name: "Custom Filters",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Custom filters provide full control over filtering logic and UI. "
+          + "The 'Name Contains' filter uses `renderInput` for a simple custom input. "
+          + "The 'Senior Only' filter uses `renderItem` for a fully custom styled component. "
+          + "Both convert their state to a WhereClause via the `toWhereClause` function.",
+      },
+      source: {
+        code: `// Custom filter with renderInput
+const nameContainsFilter = {
+  type: "CUSTOM",
+  key: "custom-name-contains",
+  label: "Name Contains",
+  filterComponent: "CUSTOM",
+  filterState: { type: "custom", customState: { value: "" } },
+  renderInput: ({ filterState, onFilterStateChanged }) => (
+    <input
+      type="text"
+      value={filterState.customState.value}
+      onChange={(e) =>
+        onFilterStateChanged({
+          type: "custom",
+          customState: { value: e.target.value },
+        })
+      }
+      placeholder="Enter name substring..."
+    />
+  ),
+  toWhereClause: (state) => {
+    const value = state.customState.value;
+    if (!value) return undefined;
+    return { fullName: { $containsAnyTerm: value } };
+  },
+};
+
+// Custom filter with renderItem (full control)
+const seniorOnlyFilter = {
+  type: "CUSTOM",
+  key: "custom-senior-only",
+  label: "Senior Only",
+  filterComponent: "CUSTOM",
+  filterState: { type: "custom", customState: { seniorOnly: false } },
+  renderItem: ({ filterState, onFilterStateChanged }) => (
+    <StyledCheckbox
+      checked={filterState.customState.seniorOnly}
+      onChange={(seniorOnly) =>
+        onFilterStateChanged({
+          type: "custom",
+          customState: { seniorOnly },
+        })
+      }
+      label="Show only senior employees"
+    />
+  ),
+  toWhereClause: (state) => {
+    if (!state.customState.seniorOnly) return undefined;
+    return { jobTitle: { $containsAnyTerm: "Senior" } };
+  },
+};
+
+<FilterList
+  objectType={Employee}
+  filterDefinitions={[nameContainsFilter, seniorOnlyFilter]}
+  filterClause={filterClause}
+  onFilterClauseChanged={setFilterClause}
+/>`,
+      },
+    },
+  },
+  render: (args) => <WithCustomFiltersStory {...args} />,
 };

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
@@ -38,7 +38,7 @@ const departmentFilter: FilterDefinitionUnion<Employee> = {
   label: "Department",
   filterComponent: "LISTOGRAM",
   filterState: { type: "EXACT_MATCH", values: [] },
-} as FilterDefinitionUnion<Employee>;
+};
 
 const teamFilter: FilterDefinitionUnion<Employee> = {
   type: "PROPERTY",
@@ -47,7 +47,7 @@ const teamFilter: FilterDefinitionUnion<Employee> = {
   label: "Team",
   filterComponent: "LISTOGRAM",
   filterState: { type: "EXACT_MATCH", values: [] },
-} as FilterDefinitionUnion<Employee>;
+};
 
 const fullNameFilter: FilterDefinitionUnion<Employee> = {
   type: "PROPERTY",
@@ -56,7 +56,7 @@ const fullNameFilter: FilterDefinitionUnion<Employee> = {
   label: "Full Name",
   filterComponent: "CONTAINS_TEXT",
   filterState: { type: "CONTAINS_TEXT" },
-} as FilterDefinitionUnion<Employee>;
+};
 
 const startDateFilter: FilterDefinitionUnion<Employee> = {
   type: "PROPERTY",
@@ -65,7 +65,7 @@ const startDateFilter: FilterDefinitionUnion<Employee> = {
   label: "Start Date",
   filterComponent: "DATE_RANGE",
   filterState: { type: "DATE_RANGE" },
-} as FilterDefinitionUnion<Employee>;
+};
 
 const employeeNumberFilter: FilterDefinitionUnion<Employee> = {
   type: "PROPERTY",
@@ -74,7 +74,7 @@ const employeeNumberFilter: FilterDefinitionUnion<Employee> = {
   label: "Employee Number",
   filterComponent: "NUMBER_RANGE",
   filterState: { type: "NUMBER_RANGE" },
-} as FilterDefinitionUnion<Employee>;
+};
 
 const locationCityFilter: FilterDefinitionUnion<Employee> = {
   type: "PROPERTY",
@@ -83,7 +83,7 @@ const locationCityFilter: FilterDefinitionUnion<Employee> = {
   label: "Location City",
   filterComponent: "LISTOGRAM",
   filterState: { type: "EXACT_MATCH", values: [] },
-} as FilterDefinitionUnion<Employee>;
+};
 
 const jobTitleMultiSelectFilter: FilterDefinitionUnion<Employee> = {
   type: "PROPERTY",
@@ -92,7 +92,7 @@ const jobTitleMultiSelectFilter: FilterDefinitionUnion<Employee> = {
   label: "Job Title",
   filterComponent: "MULTI_SELECT",
   filterState: { type: "SELECT", selectedValues: [] },
-} as FilterDefinitionUnion<Employee>;
+};
 
 const sharedFilterDefinitions: FilterDefinitionUnion<Employee>[] = [
   departmentFilter,
@@ -658,7 +658,7 @@ export const KeywordSearch: Story = {
           type: "KEYWORD_SEARCH",
           properties: ["fullName", "department", "jobTitle", "locationCity"],
           label: "Search",
-        } as FilterDefinitionUnion<Employee>,
+        },
         departmentFilter,
         locationCityFilter,
       ],
@@ -687,7 +687,7 @@ function WithColorMapStory(args: Partial<EmployeeFilterListProps>) {
         label: "Department (default colors)",
         filterComponent: "LISTOGRAM",
         filterState: { type: "EXACT_MATCH", values: [] },
-      } as FilterDefinitionUnion<Employee>,
+      },
     ],
     [],
   );
@@ -706,7 +706,7 @@ function WithColorMapStory(args: Partial<EmployeeFilterListProps>) {
           Finance: "#3498db",
           Product: "#f39c12",
         },
-      } as FilterDefinitionUnion<Employee>,
+      },
     ],
     [],
   );
@@ -778,7 +778,7 @@ function WithRenderValueStory(args: Partial<EmployeeFilterListProps>) {
         label: "Department (default)",
         filterComponent: "LISTOGRAM",
         filterState: { type: "EXACT_MATCH", values: [] },
-      } as FilterDefinitionUnion<Employee>,
+      },
     ],
     [],
   );
@@ -792,7 +792,7 @@ function WithRenderValueStory(args: Partial<EmployeeFilterListProps>) {
         filterComponent: "LISTOGRAM",
         filterState: { type: "EXACT_MATCH", values: [] },
         renderValue: (value: string) => DEPARTMENT_LABELS[value] ?? value,
-      } as FilterDefinitionUnion<Employee>,
+      },
       {
         type: "PROPERTY",
         id: "team-custom",
@@ -801,7 +801,7 @@ function WithRenderValueStory(args: Partial<EmployeeFilterListProps>) {
         filterComponent: "MULTI_SELECT",
         filterState: { type: "SELECT", selectedValues: [] },
         renderValue: (value: string) => value.toUpperCase(),
-      } as FilterDefinitionUnion<Employee>,
+      },
     ],
     [],
   );
@@ -874,7 +874,7 @@ function WithListogramDisplayModesStory(
         filterComponent: "LISTOGRAM",
         filterState: { type: "EXACT_MATCH", values: [] },
         listogramConfig: { displayMode: "full" },
-      } as FilterDefinitionUnion<Employee>,
+      },
     ],
     [],
   );
@@ -888,7 +888,7 @@ function WithListogramDisplayModesStory(
         filterComponent: "LISTOGRAM",
         filterState: { type: "EXACT_MATCH", values: [] },
         listogramConfig: { displayMode: "count" },
-      } as FilterDefinitionUnion<Employee>,
+      },
     ],
     [],
   );
@@ -902,7 +902,7 @@ function WithListogramDisplayModesStory(
         filterComponent: "LISTOGRAM",
         filterState: { type: "EXACT_MATCH", values: [] },
         listogramConfig: { displayMode: "minimal" },
-      } as FilterDefinitionUnion<Employee>,
+      },
     ],
     [],
   );
@@ -963,7 +963,7 @@ function WithHiddenCountsStory(args: Partial<EmployeeFilterListProps>) {
         label: "Department (counts visible)",
         filterComponent: "LISTOGRAM",
         filterState: { type: "EXACT_MATCH", values: [] },
-      } as FilterDefinitionUnion<Employee>,
+      },
       {
         type: "PROPERTY",
         id: "team-with-count",
@@ -971,7 +971,7 @@ function WithHiddenCountsStory(args: Partial<EmployeeFilterListProps>) {
         label: "Team (counts visible)",
         filterComponent: "MULTI_SELECT",
         filterState: { type: "SELECT", selectedValues: [] },
-      } as FilterDefinitionUnion<Employee>,
+      },
     ],
     [],
   );
@@ -985,7 +985,7 @@ function WithHiddenCountsStory(args: Partial<EmployeeFilterListProps>) {
         filterComponent: "LISTOGRAM",
         filterState: { type: "EXACT_MATCH", values: [] },
         showCount: false,
-      } as FilterDefinitionUnion<Employee>,
+      },
       {
         type: "PROPERTY",
         id: "team-no-count",
@@ -994,7 +994,7 @@ function WithHiddenCountsStory(args: Partial<EmployeeFilterListProps>) {
         filterComponent: "MULTI_SELECT",
         filterState: { type: "SELECT", selectedValues: [] },
         showCount: false,
-      } as FilterDefinitionUnion<Employee>,
+      },
     ],
     [],
   );
@@ -1053,7 +1053,7 @@ function WithCheckboxStory(args: Partial<EmployeeFilterListProps>) {
         label: "Department",
         filterComponent: "LISTOGRAM",
         filterState: { type: "EXACT_MATCH", values: [] },
-      } as FilterDefinitionUnion<Employee>,
+      },
       {
         type: "PROPERTY",
         id: "team-checkbox",
@@ -1061,7 +1061,7 @@ function WithCheckboxStory(args: Partial<EmployeeFilterListProps>) {
         label: "Team",
         filterComponent: "LISTOGRAM",
         filterState: { type: "EXACT_MATCH", values: [] },
-      } as FilterDefinitionUnion<Employee>,
+      },
     ],
     [],
   );
@@ -1312,7 +1312,7 @@ function WithStaticValuesStory(args: Partial<EmployeeFilterListProps>) {
         values: ["Marketing", "Operations", "Finance", "Product"],
         filterState: { type: "EXACT_MATCH", values: [] },
         listogramConfig: { displayMode: "minimal" },
-      } as FilterDefinitionUnion<Employee>,
+      },
       {
         type: "STATIC_VALUES",
         key: "locationCity",
@@ -1320,7 +1320,7 @@ function WithStaticValuesStory(args: Partial<EmployeeFilterListProps>) {
         filterComponent: "SINGLE_SELECT",
         values: ["New York", "San Francisco", "London", "Tokyo"],
         filterState: { type: "SELECT", selectedValues: [] },
-      } as FilterDefinitionUnion<Employee>,
+      },
       {
         type: "STATIC_VALUES",
         key: "team",
@@ -1328,7 +1328,7 @@ function WithStaticValuesStory(args: Partial<EmployeeFilterListProps>) {
         filterComponent: "MULTI_SELECT",
         values: ["Alpha", "Beta", "Gamma", "Delta"],
         filterState: { type: "SELECT", selectedValues: [] },
-      } as FilterDefinitionUnion<Employee>,
+      },
       {
         type: "STATIC_VALUES",
         id: "custom-status",
@@ -1361,7 +1361,7 @@ function WithStaticValuesStory(args: Partial<EmployeeFilterListProps>) {
           }
           return undefined;
         },
-      } as FilterDefinitionUnion<Employee>,
+      },
     ],
     [],
   );
@@ -1567,7 +1567,7 @@ function WithLinkedPropertyFiltersStory(
         linkName: "lead",
         label: "Has Manager",
         filterState: { type: "hasLink", hasLink: false },
-      } as FilterDefinitionUnion<Employee>,
+      },
       {
         type: "LINKED_PROPERTY",
         linkName: "peeps",
@@ -1579,7 +1579,7 @@ function WithLinkedPropertyFiltersStory(
           linkedFilterState: { type: "EXACT_MATCH", values: [] },
         },
         label: "Reports' Department",
-      } as FilterDefinitionUnion<Employee>,
+      },
       {
         type: "STATIC_VALUES",
         key: "managerCity",
@@ -1588,17 +1588,7 @@ function WithLinkedPropertyFiltersStory(
         values: ["New York", "San Francisco", "London", "Tokyo"],
         filterState: { type: "EXACT_MATCH", values: [] },
         listogramConfig: { displayMode: "minimal" },
-        toWhereClause: (state) => {
-          if (state.type !== "EXACT_MATCH" || state.values.length === 0) {
-            return undefined;
-          }
-          return {
-            $or: state.values.map((city) => ({
-              "lead->locationCity": city,
-            })),
-          } as WhereClause<Employee>;
-        },
-      } as FilterDefinitionUnion<Employee>,
+      },
     ],
     [],
   );

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
@@ -22,6 +22,7 @@ import type {
 } from "@osdk/react-components/experimental/filter-list";
 import { FilterList } from "@osdk/react-components/experimental/filter-list";
 import { ObjectTable } from "@osdk/react-components/experimental/object-table";
+import { useOsdkClient } from "@osdk/react/experimental";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useCallback, useMemo, useState } from "react";
 import { useArgs } from "storybook/preview-api";
@@ -289,6 +290,63 @@ export const Default: Story = {
       </div>
     );
   },
+};
+
+function WithObjectSetStory(args: Partial<EmployeeFilterListProps>) {
+  const client = useOsdkClient();
+  const objectSet = useMemo(
+    () =>
+      client(Employee).where({
+        department: "Marketing",
+      }),
+    [client],
+  );
+
+  const filterDefinitions = useMemo(
+    (): FilterDefinitionUnion<Employee>[] => [
+      teamFilter,
+      locationCityFilter,
+    ],
+    [],
+  );
+
+  return (
+    <div style={SIDEBAR_STYLE}>
+      <FilterList
+        objectType={Employee}
+        objectSet={objectSet}
+        filterDefinitions={filterDefinitions}
+        {...args}
+      />
+    </div>
+  );
+}
+
+export const WithObjectSet: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Pass an `objectSet` prop to scope filter aggregations to a subset of objects. "
+          + "Here the object set is filtered to Marketing department employees, "
+          + "so the listogram counts reflect only that subset.",
+      },
+      source: {
+        code: `const client = useOsdkClient();
+const objectSet = client(Employee).where({ department: "Marketing" });
+
+<FilterList
+  objectType={Employee}
+  objectSet={objectSet}
+  filterDefinitions={[
+    { type: "PROPERTY", key: "team", label: "Team", filterComponent: "LISTOGRAM", filterState: { type: "EXACT_MATCH", values: [] } },
+    { type: "PROPERTY", key: "locationCity", label: "Location City", filterComponent: "LISTOGRAM", filterState: { type: "EXACT_MATCH", values: [] } },
+  ]}
+/>`,
+      },
+    },
+  },
+  render: (args) => <WithObjectSetStory {...args} />,
 };
 
 function AddFilterModeStory(args: Partial<EmployeeFilterListProps>) {

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
@@ -1581,16 +1581,23 @@ function WithLinkedPropertyFiltersStory(
         label: "Reports' Department",
       } as FilterDefinitionUnion<Employee>,
       {
-        type: "LINKED_PROPERTY",
-        linkName: "lead",
-        linkedPropertyKey: "locationCity",
-        linkedFilterComponent: "LISTOGRAM",
-        linkedFilterState: { type: "EXACT_MATCH", values: [] },
-        filterState: {
-          type: "linkedProperty",
-          linkedFilterState: { type: "EXACT_MATCH", values: [] },
+        type: "STATIC_VALUES",
+        key: "managerCity",
+        label: "Manager's City (static example)",
+        filterComponent: "LISTOGRAM",
+        values: ["New York", "San Francisco", "London", "Tokyo"],
+        filterState: { type: "EXACT_MATCH", values: [] },
+        listogramConfig: { displayMode: "minimal" },
+        toWhereClause: (state) => {
+          if (state.type !== "EXACT_MATCH" || state.values.length === 0) {
+            return undefined;
+          }
+          return {
+            $or: state.values.map((city) => ({
+              "lead->locationCity": city,
+            })),
+          } as WhereClause<Employee>;
         },
-        label: "Manager's City",
       } as FilterDefinitionUnion<Employee>,
     ],
     [],
@@ -1627,11 +1634,13 @@ export const WithLinkedPropertyFilters: Story = {
         story: "Demonstrates filtering on properties of linked objects. "
           + "HAS_LINK filters objects based on whether they have a linked object. "
           + "LINKED_PROPERTY filters on a specific property of the linked objects. "
-          + "In this example, 'Reports' Department' filters employees by the department "
-          + "of their direct reports, and 'Manager's City' filters by the location of their manager.",
+          + "The 'Reports' Department' filter uses LINKED_PROPERTY to filter by the department of direct reports. "
+          + "The 'Manager's City' filter shows an equivalent using STATIC_VALUES with a custom toWhereClause. "
+          + "NOTE: In production, LINKED_PROPERTY with aggregation requires proper backend support for aggregation on pivoted object sets.",
       },
       source: {
-        code: `const filterDefinitions = [
+        code: `// HAS_LINK and LINKED_PROPERTY filter definitions
+const filterDefinitions = [
   {
     type: "HAS_LINK",
     linkName: "lead",
@@ -1639,8 +1648,9 @@ export const WithLinkedPropertyFilters: Story = {
     filterState: { type: "hasLink", hasLink: false },
   },
   {
+    // LINKED_PROPERTY: filters on properties of linked objects
     type: "LINKED_PROPERTY",
-    linkName: "peeps",
+    linkName: "peeps", // many-to-one: "who are my direct reports?"
     linkedPropertyKey: "department",
     linkedFilterComponent: "LISTOGRAM",
     linkedFilterState: { type: "EXACT_MATCH", values: [] },
@@ -1651,16 +1661,23 @@ export const WithLinkedPropertyFilters: Story = {
     label: "Reports' Department",
   },
   {
-    type: "LINKED_PROPERTY",
-    linkName: "lead",
-    linkedPropertyKey: "locationCity",
-    linkedFilterComponent: "LISTOGRAM",
-    linkedFilterState: { type: "EXACT_MATCH", values: [] },
-    filterState: {
-      type: "linkedProperty",
-      linkedFilterState: { type: "EXACT_MATCH", values: [] },
-    },
+    // Alternative: use STATIC_VALUES with toWhereClause for linked filtering
+    type: "STATIC_VALUES",
+    key: "managerCity",
     label: "Manager's City",
+    filterComponent: "LISTOGRAM",
+    values: ["New York", "San Francisco", "London", "Tokyo"],
+    filterState: { type: "EXACT_MATCH", values: [] },
+    toWhereClause: (state) => {
+      if (state.type !== "EXACT_MATCH" || state.values.length === 0) {
+        return undefined;
+      }
+      return {
+        $or: state.values.map((city) => ({
+          "lead->locationCity": city,
+        })),
+      };
+    },
   },
 ];
 
@@ -1827,33 +1844,9 @@ function WithCustomFiltersStory(args: Partial<EmployeeFilterListProps>) {
           if (!value) return undefined;
           return {
             fullName: { $containsAnyTerm: value },
-          } as WhereClause<Employee>;
+          };
         },
-      } as FilterDefinitionUnion<Employee>,
-      {
-        type: "CUSTOM",
-        key: "custom-senior-only",
-        label: "Senior Only",
-        filterComponent: "CUSTOM",
-        filterState: { type: "custom", customState: { seniorOnly: false } },
-        renderItem: ({ filterState, onFilterStateChanged }) => (
-          <CustomSeniorOnlyFilterItem
-            filterState={filterState as {
-              type: "custom";
-              customState: { seniorOnly: boolean };
-            }}
-            onFilterStateChanged={onFilterStateChanged}
-          />
-        ),
-        toWhereClause: (state) => {
-          const seniorOnly = (state.customState as { seniorOnly?: boolean })
-            ?.seniorOnly;
-          if (!seniorOnly) return undefined;
-          return {
-            jobTitle: { $containsAnyTerm: "Senior" },
-          } as WhereClause<Employee>;
-        },
-      } as FilterDefinitionUnion<Employee>,
+      },
     ],
     [],
   );
@@ -1888,9 +1881,7 @@ export const WithCustomFilters: Story = {
       description: {
         story:
           "Custom filters provide full control over filtering logic and UI. "
-          + "The 'Name Contains' filter uses `renderInput` for a simple custom input. "
-          + "The 'Senior Only' filter uses `renderItem` for a fully custom styled component. "
-          + "Both convert their state to a WhereClause via the `toWhereClause` function.",
+          + "The 'Name Contains' filter uses `renderInput` for a simple custom input. ",
       },
       source: {
         code: `// Custom filter with renderInput
@@ -1920,34 +1911,9 @@ const nameContainsFilter = {
   },
 };
 
-// Custom filter with renderItem (full control)
-const seniorOnlyFilter = {
-  type: "CUSTOM",
-  key: "custom-senior-only",
-  label: "Senior Only",
-  filterComponent: "CUSTOM",
-  filterState: { type: "custom", customState: { seniorOnly: false } },
-  renderItem: ({ filterState, onFilterStateChanged }) => (
-    <StyledCheckbox
-      checked={filterState.customState.seniorOnly}
-      onChange={(seniorOnly) =>
-        onFilterStateChanged({
-          type: "custom",
-          customState: { seniorOnly },
-        })
-      }
-      label="Show only senior employees"
-    />
-  ),
-  toWhereClause: (state) => {
-    if (!state.customState.seniorOnly) return undefined;
-    return { jobTitle: { $containsAnyTerm: "Senior" } };
-  },
-};
-
 <FilterList
   objectType={Employee}
-  filterDefinitions={[nameContainsFilter, seniorOnlyFilter]}
+  filterDefinitions={[nameContainsFilter]}
   filterClause={filterClause}
   onFilterClauseChanged={setFilterClause}
 />`,

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
@@ -1568,27 +1568,6 @@ function WithLinkedPropertyFiltersStory(
         label: "Has Manager",
         filterState: { type: "hasLink", hasLink: false },
       },
-      {
-        type: "LINKED_PROPERTY",
-        linkName: "peeps",
-        linkedPropertyKey: "department",
-        linkedFilterComponent: "LISTOGRAM",
-        linkedFilterState: { type: "EXACT_MATCH", values: [] },
-        filterState: {
-          type: "linkedProperty",
-          linkedFilterState: { type: "EXACT_MATCH", values: [] },
-        },
-        label: "Reports' Department",
-      },
-      {
-        type: "STATIC_VALUES",
-        key: "managerCity",
-        label: "Manager's City (static example)",
-        filterComponent: "LISTOGRAM",
-        values: ["New York", "San Francisco", "London", "Tokyo"],
-        filterState: { type: "EXACT_MATCH", values: [] },
-        listogramConfig: { displayMode: "minimal" },
-      },
     ],
     [],
   );
@@ -1616,17 +1595,13 @@ function WithLinkedPropertyFiltersStory(
   );
 }
 
-export const WithLinkedPropertyFilters: Story = {
+export const WithHasLinkFilter: Story = {
   name: "Linked Property Filters",
   parameters: {
     docs: {
       description: {
         story: "Demonstrates filtering on properties of linked objects. "
-          + "HAS_LINK filters objects based on whether they have a linked object. "
-          + "LINKED_PROPERTY filters on a specific property of the linked objects. "
-          + "The 'Reports' Department' filter uses LINKED_PROPERTY to filter by the department of direct reports. "
-          + "The 'Manager's City' filter shows an equivalent using STATIC_VALUES with a custom toWhereClause. "
-          + "NOTE: In production, LINKED_PROPERTY with aggregation requires proper backend support for aggregation on pivoted object sets.",
+          + "HAS_LINK filters objects based on whether they have a linked object. ",
       },
       source: {
         code: `// HAS_LINK and LINKED_PROPERTY filter definitions
@@ -1636,38 +1611,6 @@ const filterDefinitions = [
     linkName: "lead",
     label: "Has Manager",
     filterState: { type: "hasLink", hasLink: false },
-  },
-  {
-    // LINKED_PROPERTY: filters on properties of linked objects
-    type: "LINKED_PROPERTY",
-    linkName: "peeps", // many-to-one: "who are my direct reports?"
-    linkedPropertyKey: "department",
-    linkedFilterComponent: "LISTOGRAM",
-    linkedFilterState: { type: "EXACT_MATCH", values: [] },
-    filterState: {
-      type: "linkedProperty",
-      linkedFilterState: { type: "EXACT_MATCH", values: [] },
-    },
-    label: "Reports' Department",
-  },
-  {
-    // Alternative: use STATIC_VALUES with toWhereClause for linked filtering
-    type: "STATIC_VALUES",
-    key: "managerCity",
-    label: "Manager's City",
-    filterComponent: "LISTOGRAM",
-    values: ["New York", "San Francisco", "London", "Tokyo"],
-    filterState: { type: "EXACT_MATCH", values: [] },
-    toWhereClause: (state) => {
-      if (state.type !== "EXACT_MATCH" || state.values.length === 0) {
-        return undefined;
-      }
-      return {
-        $or: state.values.map((city) => ({
-          "lead->locationCity": city,
-        })),
-      };
-    },
   },
 ];
 

--- a/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.stories.tsx
@@ -19,6 +19,7 @@ import type {
   ObjectSet,
   Osdk,
   QueryDefinition,
+  WhereClause,
 } from "@osdk/api";
 import { ObjectTable } from "@osdk/react-components/experimental/object-table";
 import type {
@@ -373,74 +374,11 @@ export const WithInterfaceType: Story = {
   ),
 };
 
-export const WithDerivedProperty: Story = {
-  args: {
-    objectType: Employee,
-    columnDefinitions: [
-      { locator: { type: "property", id: "fullName" } },
-      { locator: { type: "property", id: "department" } },
-      {
-        locator: {
-          type: "rdp",
-          id: "managerName",
-          creator: (baseObjectSet: DerivedProperty.Builder<Employee, false>) =>
-            baseObjectSet.pivotTo("lead").selectProperty("fullName"),
-        },
-        renderHeader: () => "Manager",
-        renderCell: (object: Osdk.Instance<Employee>) => {
-          if ("managerName" in object) {
-            return <span>{object.managerName as string}</span>;
-          }
-          return <span style={{ color: "#999" }}>No Manager</span>;
-        },
-      },
-    ] as ColumnDefinition<Employee>[],
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "Use derived property (RDP) columns to display data from linked objects. "
-          + "The 'Manager' column uses `pivotTo` to follow the lead link and select the fullName property.",
-      },
-      source: {
-        code: `type RDPs = { managerName: "string" };
-
-const columnDefinitions: ColumnDefinition<Employee, RDPs>[] = [
-  { locator: { type: "property", id: "fullName" } },
-  { locator: { type: "property", id: "department" } },
-  {
-    locator: {
-      type: "rdp",
-      id: "managerName",
-      creator: (baseObjectSet) =>
-        baseObjectSet.pivotTo("lead").selectProperty("fullName"),
-    },
-    renderHeader: () => "Manager",
-    renderCell: (object) => {
-      if ("managerName" in object) {
-        return <span>{object["managerName"]}</span>;
-      }
-      return <span style={{ color: "#999" }}>No Manager</span>;
-    },
-  },
-];
-
-<ObjectTable objectType={Employee} columnDefinitions={columnDefinitions} />`,
-      },
-    },
-  },
-  render: (args) => (
-    <div className="object-table-container" style={{ height: "600px" }}>
-      <ObjectTable {...args} />
-    </div>
-  ),
-};
-
 export const WithDerivedPropertyOrderingAndFilter: Story = {
-  args: {
-    objectType: Employee,
-    columnDefinitions: [
+  render: () => {
+    type RDPs = { managerName: "string" };
+
+    const columnDefinitions: ColumnDefinition<Employee, RDPs>[] = [
       { locator: { type: "property", id: "fullName" } },
       { locator: { type: "property", id: "department" } },
       {
@@ -458,21 +396,29 @@ export const WithDerivedPropertyOrderingAndFilter: Story = {
           return <span style={{ color: "#999" }}>No Manager</span>;
         },
       },
-    ] as ColumnDefinition<Employee>[],
-    defaultOrderBy: [{
-      property: "fullName",
-      direction: "asc",
-    }],
-    filter: {
-      department: "Marketing",
-    } as EmployeeTableProps["filter"],
+    ];
+
+    const filter: WhereClause<Employee, RDPs> = {
+      managerName: { $in: ["Ahmed Williams", "Fatima Zhang"] },
+    };
+
+    return (
+      <div className="object-table-container" style={{ height: "600px" }}>
+        <ObjectTable
+          objectType={Employee}
+          columnDefinitions={columnDefinitions}
+          defaultOrderBy={[{ property: "managerName", direction: "asc" }]}
+          filter={filter}
+        />
+      </div>
+    );
   },
   parameters: {
     docs: {
       description: {
         story:
           "Combines derived property columns with `defaultOrderBy` and `filter`. "
-          + "The table is pre-sorted by fullName ascending and filtered to the Marketing department.",
+          + "Demonstrates sorting by an RDP (managerName) and filtering the derived property.",
       },
       source: {
         code: `type RDPs = { managerName: "string" };
@@ -497,20 +443,19 @@ const columnDefinitions: ColumnDefinition<Employee, RDPs>[] = [
   },
 ];
 
+const filter: WhereClause<Employee, RDPs> = {
+  managerName: { $in: ["Ahmed Williams", "Fatima Zhang"] },
+};
+
 <ObjectTable
   objectType={Employee}
   columnDefinitions={columnDefinitions}
-  defaultOrderBy={[{ property: "fullName", direction: "asc" }]}
-  filter={{ department: "Marketing" }}
+  defaultOrderBy={[{ property: "managerName", direction: "asc" }]}
+  filter={filter}
 />`,
       },
     },
   },
-  render: (args) => (
-    <div className="object-table-container" style={{ height: "600px" }}>
-      <ObjectTable {...args} />
-    </div>
-  ),
 };
 
 export const WithFunctionColumn: Story = {

--- a/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.stories.tsx
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import type { DerivedProperty, Osdk } from "@osdk/api";
+import type {
+  DerivedProperty,
+  ObjectSet,
+  Osdk,
+  QueryDefinition,
+} from "@osdk/api";
 import { ObjectTable } from "@osdk/react-components/experimental/object-table";
 import type {
   CellEditInfo,
@@ -26,6 +31,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useCallback, useState } from "react";
 import { fauxFoundry } from "../../mocks/fauxFoundry.js";
 import { Employee } from "../../types/Employee.js";
+import { WorkerInterface } from "../../types/WorkerInterface.js";
 
 // Create a concrete type for Storybook to parse more easily
 type EmployeeTableProps = ObjectTableProps<typeof Employee>;
@@ -198,41 +204,59 @@ const meta: Meta<EmployeeTableProps> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+// Used by stories that don't define their own columnDefinitions.
+const defaultEmployeeColumns: ColumnDefinition<Employee>[] = [
+  { locator: { type: "property", id: "fullName" } },
+  { locator: { type: "property", id: "emailPrimaryWork" } },
+  { locator: { type: "property", id: "jobProfile" } },
+  { locator: { type: "property", id: "jobTitle" } },
+  { locator: { type: "property", id: "department" } },
+  { locator: { type: "property", id: "businessTitle" } },
+  { locator: { type: "property", id: "businessArea" } },
+  { locator: { type: "property", id: "team" } },
+  { locator: { type: "property", id: "workerType" } },
+  { locator: { type: "property", id: "locationName" } },
+  { locator: { type: "property", id: "locationCity" } },
+  { locator: { type: "property", id: "locationCountry" } },
+  { locator: { type: "property", id: "locationRegion" } },
+  { locator: { type: "property", id: "locationType" } },
+  { locator: { type: "property", id: "firstFullTimeStartDate" } },
+  { locator: { type: "property", id: "firstInternStartDate" } },
+  { locator: { type: "property", id: "employeeNumber" } },
+  { locator: { type: "property", id: "adUsername" } },
+  { locator: { type: "property", id: "primaryOfficeId" } },
+  { locator: { type: "property", id: "preferredNameFirst" } },
+  { locator: { type: "property", id: "preferredNameLast" } },
+  { locator: { type: "property", id: "leadEmployeeNumber" } },
+  { locator: { type: "property", id: "mentorEmployeeNumber" } },
+];
+
+// Query definition for the function-backed column
+const getEmployeeSeniority: QueryDefinition<Employee> = {
+  type: "query",
+  apiName: "getEmployeeSeniority",
+  version: "1.0.0",
+  osdkMetadata: undefined as never,
+};
+
+type SeniorityFunctions = {
+  seniority: typeof getEmployeeSeniority;
+};
+
 // Define column definitions similar to the e2e example
 type RDPs = {
   managerName: "string";
 };
 
-const columnDefinitions: ColumnDefinition<Employee, RDPs, {}>[] = [
+const columnDefinitions: ColumnDefinition<
+  Employee,
+  RDPs,
+  SeniorityFunctions
+>[] = [
   {
     locator: {
       type: "property",
       id: "fullName",
-    },
-  },
-  {
-    locator: { type: "property", id: "emailPrimaryWork" },
-    renderHeader: () => "Email",
-  },
-  {
-    locator: { type: "property", id: "jobTitle" },
-    isVisible: false,
-  },
-  {
-    locator: { type: "property", id: "department" },
-  },
-  {
-    locator: { type: "property", id: "firstFullTimeStartDate" },
-    width: 200,
-    renderHeader: () => "Start Date",
-    renderCell: (object: Osdk.Instance<Employee>) => {
-      return (
-        <div>
-          {object.firstFullTimeStartDate
-            ? new Date(object.firstFullTimeStartDate).toLocaleDateString()
-            : "No date"}
-        </div>
-      );
     },
   },
   {
@@ -250,14 +274,32 @@ const columnDefinitions: ColumnDefinition<Employee, RDPs, {}>[] = [
       return <span style={{ color: "#999" }}>No Manager</span>;
     },
   },
+  {
+    locator: {
+      type: "function",
+      id: "seniority",
+      queryDefinition: getEmployeeSeniority,
+      getFunctionParams: (objectSet: ObjectSet<Employee>) =>
+        ({ employees: objectSet }) as never,
+      getKey: (object: Osdk.Instance<Employee>) => String(object.$primaryKey),
+      getValue: (cellData?: unknown) => cellData,
+    },
+    renderHeader: () => "Seniority",
+    width: 120,
+  },
 ];
 
 export const Default: Story = {
   args: {
     objectType: Employee,
+    columnDefinitions: defaultEmployeeColumns,
   },
   parameters: {
     docs: {
+      description: {
+        story:
+          "Minimal setup showing Employee data with default column definitions.",
+      },
       source: {
         code: `<ObjectTable objectType={Employee} />`,
       },
@@ -273,6 +315,7 @@ export const Default: Story = {
 export const WithObjectSet: Story = {
   args: {
     objectType: Employee,
+    columnDefinitions: defaultEmployeeColumns,
   },
   parameters: {
     docs: {
@@ -304,43 +347,68 @@ return <ObjectTable objectType={Employee} objectSet={employeeObjectSet} />`,
   },
 };
 
-export const WithColumnDefinitions: Story = {
+export const WithInterfaceType: Story = {
   args: {
-    objectType: Employee,
-    columnDefinitions: columnDefinitions as ColumnDefinition<Employee>[],
+    objectType: WorkerInterface as unknown as typeof Employee,
   },
   parameters: {
     docs: {
+      description: {
+        story:
+          "Pass an interface type instead of an object type. The table shows the interface's "
+          + "properties (email, name, employeeNumber) and any object implementing the interface "
+          + "will be displayed.",
+      },
       source: {
-        code: `const columnDefinitions = [
-  {
-    locator: { type: "property", id: "fullName" },
-  },
-  {
-    locator: { type: "property", id: "emailPrimaryWork" },
-    renderHeader: () => "Email",
-  },
-  {
-    locator: { type: "property", id: "jobTitle" },
-    isVisible: false,
-  },
-  {
-    locator: { type: "property", id: "department" },
-  },
-  {
-    locator: { type: "property", id: "firstFullTimeStartDate" },
-    width: 200,
-    renderHeader: () => "Start Date",
-    renderCell: (object) => {
-      return (
-        <div>
-          {object["firstFullTimeStartDate"]
-            ? new Date(object["firstFullTimeStartDate"]).toLocaleDateString()
-            : "No date"}
-        </div>
-      );
+        code: `import { WorkerInterface } from "./types/WorkerInterface";
+
+<ObjectTable objectType={WorkerInterface} />`,
+      },
     },
   },
+  render: (args) => (
+    <div className="object-table-container" style={{ height: "600px" }}>
+      <ObjectTable {...args} />
+    </div>
+  ),
+};
+
+export const WithDerivedProperty: Story = {
+  args: {
+    objectType: Employee,
+    columnDefinitions: [
+      { locator: { type: "property", id: "fullName" } },
+      { locator: { type: "property", id: "department" } },
+      {
+        locator: {
+          type: "rdp",
+          id: "managerName",
+          creator: (baseObjectSet: DerivedProperty.Builder<Employee, false>) =>
+            baseObjectSet.pivotTo("lead").selectProperty("fullName"),
+        },
+        renderHeader: () => "Manager",
+        renderCell: (object: Osdk.Instance<Employee>) => {
+          if ("managerName" in object) {
+            return <span>{object.managerName as string}</span>;
+          }
+          return <span style={{ color: "#999" }}>No Manager</span>;
+        },
+      },
+    ] as ColumnDefinition<Employee>[],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use derived property (RDP) columns to display data from linked objects. "
+          + "The 'Manager' column uses `pivotTo` to follow the lead link and select the fullName property.",
+      },
+      source: {
+        code: `type RDPs = { managerName: "string" };
+
+const columnDefinitions: ColumnDefinition<Employee, RDPs>[] = [
+  { locator: { type: "property", id: "fullName" } },
+  { locator: { type: "property", id: "department" } },
   {
     locator: {
       type: "rdp",
@@ -369,9 +437,149 @@ export const WithColumnDefinitions: Story = {
   ),
 };
 
+export const WithDerivedPropertyOrderingAndFilter: Story = {
+  args: {
+    objectType: Employee,
+    columnDefinitions: [
+      { locator: { type: "property", id: "fullName" } },
+      { locator: { type: "property", id: "department" } },
+      {
+        locator: {
+          type: "rdp",
+          id: "managerName",
+          creator: (baseObjectSet: DerivedProperty.Builder<Employee, false>) =>
+            baseObjectSet.pivotTo("lead").selectProperty("fullName"),
+        },
+        renderHeader: () => "Manager",
+        renderCell: (object: Osdk.Instance<Employee>) => {
+          if ("managerName" in object) {
+            return <span>{object.managerName as string}</span>;
+          }
+          return <span style={{ color: "#999" }}>No Manager</span>;
+        },
+      },
+    ] as ColumnDefinition<Employee>[],
+    defaultOrderBy: [{
+      property: "fullName",
+      direction: "asc",
+    }],
+    filter: {
+      department: "Marketing",
+    } as EmployeeTableProps["filter"],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Combines derived property columns with `defaultOrderBy` and `filter`. "
+          + "The table is pre-sorted by fullName ascending and filtered to the Marketing department.",
+      },
+      source: {
+        code: `type RDPs = { managerName: "string" };
+
+const columnDefinitions: ColumnDefinition<Employee, RDPs>[] = [
+  { locator: { type: "property", id: "fullName" } },
+  { locator: { type: "property", id: "department" } },
+  {
+    locator: {
+      type: "rdp",
+      id: "managerName",
+      creator: (baseObjectSet) =>
+        baseObjectSet.pivotTo("lead").selectProperty("fullName"),
+    },
+    renderHeader: () => "Manager",
+    renderCell: (object) => {
+      if ("managerName" in object) {
+        return <span>{object["managerName"]}</span>;
+      }
+      return <span style={{ color: "#999" }}>No Manager</span>;
+    },
+  },
+];
+
+<ObjectTable
+  objectType={Employee}
+  columnDefinitions={columnDefinitions}
+  defaultOrderBy={[{ property: "fullName", direction: "asc" }]}
+  filter={{ department: "Marketing" }}
+/>`,
+      },
+    },
+  },
+  render: (args) => (
+    <div className="object-table-container" style={{ height: "600px" }}>
+      <ObjectTable {...args} />
+    </div>
+  ),
+};
+
+export const WithFunctionColumn: Story = {
+  args: {
+    objectType: Employee,
+    columnDefinitions: [
+      { locator: { type: "property", id: "fullName" } },
+      { locator: { type: "property", id: "department" } },
+      {
+        locator: {
+          type: "function",
+          id: "seniority",
+          queryDefinition: getEmployeeSeniority,
+          getFunctionParams: (objectSet: ObjectSet<Employee>) =>
+            ({ employees: objectSet }) as never,
+          getKey: (object: Osdk.Instance<Employee>) =>
+            String(object.$primaryKey),
+          getValue: (cellData?: unknown) => cellData,
+        },
+        renderHeader: () => "Seniority",
+        width: 120,
+      },
+    ] as ColumnDefinition<Employee>[],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use function-backed columns to display computed values from a Foundry query. "
+          + "The 'Seniority' column calls `getEmployeeSeniority` with the current object set "
+          + "and maps each result back to the corresponding row.",
+      },
+      source: {
+        code: `import { getEmployeeSeniority } from "./ontology/queries";
+
+type SeniorityFunctions = { seniority: typeof getEmployeeSeniority };
+
+const columnDefinitions: ColumnDefinition<Employee, {}, SeniorityFunctions>[] = [
+  { locator: { type: "property", id: "fullName" } },
+  { locator: { type: "property", id: "department" } },
+  {
+    locator: {
+      type: "function",
+      id: "seniority",
+      queryDefinition: getEmployeeSeniority,
+      getFunctionParams: (objectSet) => ({ employees: objectSet }),
+      getKey: (object) => String(object.$primaryKey),
+      getValue: (cellData) => cellData,
+    },
+    renderHeader: () => "Seniority",
+    width: 120,
+  },
+];
+
+<ObjectTable objectType={Employee} columnDefinitions={columnDefinitions} />`,
+      },
+    },
+  },
+  render: (args) => (
+    <div className="object-table-container" style={{ height: "600px" }}>
+      <ObjectTable {...args} />
+    </div>
+  ),
+};
+
 export const SingleSelection: Story = {
   args: {
     objectType: Employee,
+    columnDefinitions: defaultEmployeeColumns,
     selectionMode: "single",
   },
   parameters: {
@@ -391,6 +599,7 @@ export const SingleSelection: Story = {
 export const MultipleSelection: Story = {
   args: {
     objectType: Employee,
+    columnDefinitions: defaultEmployeeColumns,
     selectionMode: "multiple",
   },
   parameters: {
@@ -410,6 +619,7 @@ export const MultipleSelection: Story = {
 export const WithContextMenu: Story = {
   args: {
     objectType: Employee,
+    columnDefinitions: defaultEmployeeColumns,
     renderCellContextMenu: (_: any, cellValue: unknown) => {
       return (
         <div
@@ -478,6 +688,7 @@ export const CustomColumnWidths: Story = {
 export const WithDefaultSorting: Story = {
   args: {
     objectType: Employee,
+    columnDefinitions: defaultEmployeeColumns,
     defaultOrderBy: [{
       property: "fullName",
       direction: "desc",
@@ -647,6 +858,7 @@ export const WithCustomColumn: Story = {
 export const WithRowClickHandler: Story = {
   args: {
     objectType: Employee,
+    columnDefinitions: defaultEmployeeColumns,
     onRowClick: (employee: any) => {
       alert(`Clicked on ${employee.fullName}`);
     },
@@ -707,6 +919,7 @@ return (
         <div className="object-table-container" style={{ height: "600px" }}>
           <ObjectTable
             objectType={Employee}
+            columnDefinitions={defaultEmployeeColumns}
             orderBy={orderBy}
             onOrderByChanged={setOrderBy}
           />
@@ -777,6 +990,7 @@ return (
         <div className="object-table-container" style={{ height: "600px" }}>
           <ObjectTable
             objectType={Employee}
+            columnDefinitions={defaultEmployeeColumns}
             selectionMode="multiple"
             selectedRows={selectedRows}
             onRowSelection={handleRowSelection}
@@ -790,6 +1004,7 @@ return (
 export const DisableAllHeaderMenuFeatures: Story = {
   args: {
     objectType: Employee,
+    columnDefinitions: defaultEmployeeColumns,
     enableOrdering: false,
     enableColumnPinning: false,
     enableColumnResizing: false,
@@ -818,6 +1033,7 @@ export const DisableAllHeaderMenuFeatures: Story = {
 export const CustomRowHeight: Story = {
   args: {
     objectType: Employee,
+    columnDefinitions: defaultEmployeeColumns,
     rowHeight: 56,
   },
   parameters: {

--- a/packages/react-components-storybook/src/stories/ObjectTable/Recipes/WithConfigureColumnsButton.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/Recipes/WithConfigureColumnsButton.stories.tsx
@@ -42,7 +42,7 @@ const meta: Meta<EmployeeTableProps> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const WithColumnConfigDialog: Story = {
+export const WithConfigureColumnsButton: Story = {
   parameters: {
     docs: {
       source: {

--- a/packages/react-components-storybook/src/types/WorkerInterface.ts
+++ b/packages/react-components-storybook/src/types/WorkerInterface.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  InterfaceDefinition,
+  ObjectSet as $ObjectSet,
+  Osdk as $Osdk,
+  PropertyDef as $PropertyDef,
+  PropertyValueWireToClient as $PropType,
+} from "@osdk/api";
+
+export namespace WorkerInterface {
+  export type PropertyKeys =
+    | "email"
+    | "name"
+    | "employeeNumber";
+
+  export interface Props {
+    readonly email: $PropType["string"] | undefined;
+    readonly name: $PropType["string"] | undefined;
+    readonly employeeNumber: $PropType["integer"] | undefined;
+  }
+
+  export interface StrictProps {
+    readonly email: $PropType["string"] | undefined;
+    readonly name: $PropType["string"] | undefined;
+    readonly employeeNumber: $PropType["integer"] | undefined;
+  }
+
+  export interface ObjectSet
+    extends $ObjectSet<WorkerInterface, WorkerInterface.ObjectSet>
+  {}
+
+  export type OsdkInstance<
+    OPTIONS extends never | "$rid" = never,
+    K extends PropertyKeys = PropertyKeys,
+  > = $Osdk.Instance<WorkerInterface, OPTIONS, K>;
+}
+
+export interface WorkerInterface extends InterfaceDefinition {
+  type: "interface";
+  apiName: "Worker";
+  __DefinitionMetadata?: {
+    objectSet: WorkerInterface.ObjectSet;
+    props: WorkerInterface.Props;
+    linksType: {};
+    strictProps: WorkerInterface.StrictProps;
+    apiName: "Worker";
+    description: "A worker interface";
+    displayName: "Worker";
+    rid: "ri.ontology.main.interface.777ffb22-9b3c-4fb6-908f-56d23c3a5198";
+    properties: {
+      email: $PropertyDef<"string", "nullable", "single">;
+      name: $PropertyDef<"string", "nullable", "single">;
+      employeeNumber: $PropertyDef<"integer", "nullable", "single">;
+    };
+    links: Record<string, never>;
+    type: "interface";
+    implementedBy: ["Employee"];
+  };
+}
+
+export const WorkerInterface = {
+  type: "interface",
+  apiName: "Worker",
+} satisfies WorkerInterface as WorkerInterface;

--- a/packages/react-components/src/filter-list/FilterListApi.ts
+++ b/packages/react-components/src/filter-list/FilterListApi.ts
@@ -35,12 +35,21 @@ import type {
 import type { StaticValuesFilterDefinition } from "./types/StaticValuesTypes.js";
 
 /**
+ * Distributes LinkedPropertyFilterDefinition over each link name individually,
+ * so that LinkedQ/LinkedK/LinkedC defaults resolve correctly per link.
+ */
+type DistributeLinkedProperty<
+  Q extends ObjectTypeDefinition,
+  L extends LinkNames<Q>,
+> = L extends LinkNames<Q> ? LinkedPropertyFilterDefinition<Q, L> : never;
+
+/**
  * Union type of all filter definition types
  */
 export type FilterDefinitionUnion<Q extends ObjectTypeDefinition> =
   | PropertyFilterDefinition<Q>
   | HasLinkFilterDefinition<Q>
-  | LinkedPropertyFilterDefinition<Q, LinkNames<Q>>
+  | DistributeLinkedProperty<Q, LinkNames<Q>>
   | KeywordSearchFilterDefinition<Q>
   | CustomFilterDefinition<Q>
   | StaticValuesFilterDefinition<Q>;
@@ -48,20 +57,22 @@ export type FilterDefinitionUnion<Q extends ObjectTypeDefinition> =
 /**
  * Extract the key from a filter definition union
  */
-export type FilterKey<Q extends ObjectTypeDefinition> =
-  FilterDefinitionUnion<Q> extends infer D ? D extends { key: infer K } ? K
-    : D extends { linkName: infer L } ? L
-    : never
-    : never;
+type ExtractFilterKey<D> = D extends { key: infer K } ? K
+  : D extends { linkName: infer L } ? L
+  : never;
+
+export type FilterKey<Q extends ObjectTypeDefinition> = ExtractFilterKey<
+  FilterDefinitionUnion<Q>
+>;
 
 /**
  * Extract the filter state from a filter definition union
  */
-export type FilterState<Q extends ObjectTypeDefinition> =
-  FilterDefinitionUnion<Q> extends infer D
-    ? D extends { filterState: infer S } ? S
-    : never
-    : never;
+type ExtractFilterState<D> = D extends { filterState: infer S } ? S : never;
+
+export type FilterState<Q extends ObjectTypeDefinition> = ExtractFilterState<
+  FilterDefinitionUnion<Q>
+>;
 
 /**
  * Map from filter definition objects to their current state.

--- a/packages/react-components/src/filter-list/inputs/PropertyFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/PropertyFilterInput.tsx
@@ -17,8 +17,10 @@
 import type { ObjectSet, ObjectTypeDefinition, WhereClause } from "@osdk/api";
 import React, { memo } from "react";
 import { FilterInputExcludeRow } from "../base/FilterInputExcludeRow.js";
-import type { FilterDefinitionUnion } from "../FilterListApi.js";
-import type { FilterState } from "../FilterListItemApi.js";
+import type {
+  FilterState,
+  PropertyFilterDefinition,
+} from "../FilterListItemApi.js";
 import { ContainsTextFilterInput } from "./ContainsTextFilterInput.js";
 import { DateRangeFilterInput } from "./DateRangeFilterInput.js";
 import { ListogramFilterInput } from "./ListogramFilterInput.js";
@@ -34,7 +36,7 @@ import { ToggleFilterInput } from "./ToggleFilterInput.js";
 interface PropertyFilterInputProps<Q extends ObjectTypeDefinition> {
   objectType: Q;
   objectSet?: ObjectSet<Q>;
-  definition: Extract<FilterDefinitionUnion<Q>, { type: "PROPERTY" }>;
+  definition: PropertyFilterDefinition<Q>;
   filterState: FilterState | undefined;
   onFilterStateChanged: (state: FilterState) => void;
   whereClause: WhereClause<Q>;

--- a/packages/react-components/src/object-table/ObjectTableApi.ts
+++ b/packages/react-components/src/object-table/ObjectTableApi.ts
@@ -362,7 +362,7 @@ export interface ObjectTableProps<
    * If both orderBy and defaultOrderBy are provided, orderBy takes precedence.
    */
   defaultOrderBy?: Array<{
-    property: PropertyKeys<Q>;
+    property: PropertyKeys<Q> | keyof RDPs;
     direction: "asc" | "desc";
   }>;
 
@@ -372,7 +372,7 @@ export interface ObjectTableProps<
    * If both orderBy and defaultOrderBy are provided, orderBy takes precedence.
    */
   orderBy?: Array<{
-    property: PropertyKeys<Q>;
+    property: PropertyKeys<Q> | keyof RDPs;
     direction: "asc" | "desc";
   }>;
 
@@ -384,7 +384,7 @@ export interface ObjectTableProps<
    */
   onOrderByChanged?: (
     newOrderBy: Array<{
-      property: PropertyKeys<Q>;
+      property: PropertyKeys<Q> | keyof RDPs;
       direction: "asc" | "desc";
     }>,
   ) => void;

--- a/packages/react-components/src/object-table/ObjectTableApi.ts
+++ b/packages/react-components/src/object-table/ObjectTableApi.ts
@@ -155,21 +155,23 @@ export interface PropertyColumnLocator<Q extends ObjectOrInterfaceDefinition> {
   id: PropertyKeys<Q>;
 }
 
-export interface FunctionColumnLocator<
+/**
+ * Concrete function column locator for a single key K.
+ * Correlates the id, queryDefinition, and getFunctionParams types.
+ */
+interface FunctionColumnLocatorForKey<
   Q extends ObjectOrInterfaceDefinition,
-  RDPs extends Record<string, SimplePropertyDef> = Record<string, never>,
-  FunctionColumns extends Record<string, QueryDefinition<{}>> = Record<
-    string,
-    never
-  >,
+  RDPs extends Record<string, SimplePropertyDef>,
+  FunctionColumns extends Record<string, QueryDefinition<{}>>,
+  K extends keyof FunctionColumns,
 > {
   /**
    * This is equivalent to workshop's function-backed columns.
    * The function needs to meet the specifications stated in https://www.palantir.com/docs/foundry/workshop/widgets-object-table/#function-backed-columns
    */
   type: "function";
-  id: keyof FunctionColumns;
-  queryDefinition: FunctionColumns[keyof FunctionColumns];
+  id: K;
+  queryDefinition: FunctionColumns[K];
 
   /**
    * The function will be called with the current object set to get the input parameters for the function query.
@@ -178,7 +180,7 @@ export interface FunctionColumnLocator<
    */
   getFunctionParams: (
     objectSet: ObjectSet<Q, RDPs>,
-  ) => ExtractQueryParameters<FunctionColumns[keyof FunctionColumns]>;
+  ) => ExtractQueryParameters<FunctionColumns[K]>;
 
   /**
    * Function to generate keys for looking up results in the FunctionsMap.
@@ -206,6 +208,23 @@ export interface FunctionColumnLocator<
    */
   dedupeIntervalMs?: number;
 }
+
+/**
+ * Distributes over each key in FunctionColumns so that id, queryDefinition,
+ * and getFunctionParams are correlated per key.
+ */
+export type FunctionColumnLocator<
+  Q extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef> = Record<string, never>,
+  FunctionColumns extends Record<string, QueryDefinition<{}>> = Record<
+    string,
+    never
+  >,
+> = keyof FunctionColumns extends infer K
+  ? K extends keyof FunctionColumns
+    ? FunctionColumnLocatorForKey<Q, RDPs, FunctionColumns, K>
+  : never
+  : never;
 
 export interface RdpColumnLocator<
   Q extends ObjectOrInterfaceDefinition,


### PR DESCRIPTION
- Fixed storybook displaying "object Object"
- Added more stories 
- FilterList stories - withObjectSet, HasLink filter, Custom filter
- ObjectTable stories - derived properties example with defaultOrderBy and filter, function column, interface type stories
- Fixed FilterList types that need casting
- Fixed ObjectTable orderBy type to accept RDP properties

Before:
<img width="1724" height="660" alt="Screenshot 2026-04-24 at 14 02 54" src="https://github.com/user-attachments/assets/6dbba94e-5ab9-4b71-b399-82a5ab30ff6c" />

After:
<img width="1723" height="1039" alt="Screenshot 2026-04-24 at 14 02 41" src="https://github.com/user-attachments/assets/bf3175a5-feb9-402a-bda1-82068c9f0deb" />
