### PR TITLE
add tests for shapes store, batched store, and hooks

### DIFF
--- a/packages/react/src/new/shapes/__tests__/batchedDerivedLinksStore.test.ts
+++ b/packages/react/src/new/shapes/__tests__/batchedDerivedLinksStore.test.ts
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Client } from "@osdk/client";
+import type * as UnstableClient from "@osdk/client/unstable-do-not-use";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type ObservableClient = UnstableClient.ObservableClient;
+type Observer<T> = UnstableClient.Observer<T>;
+
+// Mock the async object-set builder so we don't need a real client ontology
+// provider. Shape transformation helpers stay real.
+vi.mock("@osdk/client/unstable-do-not-use", async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof UnstableClient;
+  return {
+    ...actual,
+    buildObjectSetFromLinkDefByType: vi.fn(() =>
+      Promise.resolve({ __fakeObjectSet: true })
+    ),
+  };
+});
+
+import { createBatchedDerivedLinksStore } from "../batchedDerivedLinksStore.js";
+import type { AnyShapeInstance } from "../types.js";
+
+function makeShape(derivedLinks: readonly unknown[]) {
+  const baseType = {
+    apiName: "Parent",
+    primaryKeyType: "string",
+    type: "object",
+  };
+  return {
+    __shapeId: "parent-shape",
+    __debugName: "ParentShape",
+    __baseType: baseType,
+    __baseTypeApiName: "Parent",
+    __props: Object.freeze({}),
+    __derivedLinks: Object.freeze(derivedLinks),
+    __selectedPropsType: {},
+    __derivedLinksType: {},
+  } as unknown as Parameters<typeof createBatchedDerivedLinksStore>[0];
+}
+
+function makeTargetShape() {
+  const baseType = {
+    apiName: "Child",
+    primaryKeyType: "string",
+    type: "object",
+  };
+  return {
+    __shapeId: "child-shape",
+    __debugName: "ChildShape",
+    __baseType: baseType,
+    __baseTypeApiName: "Child",
+    __props: Object.freeze({}),
+    __derivedLinks: Object.freeze([]),
+    __selectedPropsType: {},
+    __derivedLinksType: {},
+  };
+}
+
+function batchableLink(name: string) {
+  return {
+    name,
+    targetShape: makeTargetShape(),
+    objectSetDef: {
+      segments: [{ type: "pivotTo", linkName: name }],
+    },
+    config: {},
+  };
+}
+
+function nonBatchableLink(name: string) {
+  return {
+    name,
+    targetShape: makeTargetShape(),
+    objectSetDef: {
+      segments: [{ type: "pivotTo", linkName: name }],
+      where: { status: "active" },
+    },
+    config: {},
+  };
+}
+
+function makeInstance(pk: string) {
+  return { $primaryKey: pk, $apiName: "Parent" } as unknown as AnyShapeInstance;
+}
+
+describe("createBatchedDerivedLinksStore", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("routes batchable links through observeLinks and non-batchable through observeObjectSet", async () => {
+    const observeLinks = vi.fn(
+      (
+        _objs: unknown,
+        _linkName: unknown,
+        _opts: unknown,
+        _obs: Observer<unknown>,
+      ) => ({
+        unsubscribe: vi.fn(),
+      }),
+    );
+    const observeObjectSet = vi.fn(
+      (_os: unknown, _opts: unknown, _obs: Observer<unknown>) => ({
+        unsubscribe: vi.fn(),
+      }),
+    );
+
+    const observableClient = {
+      observeLinks,
+      observeObjectSet,
+    } as unknown as ObservableClient;
+
+    const shape = makeShape([
+      batchableLink("employees"),
+      nonBatchableLink("activeEmployees"),
+    ]);
+
+    const store = createBatchedDerivedLinksStore(
+      shape,
+      shape.__derivedLinks as Parameters<
+        typeof createBatchedDerivedLinksStore
+      >[1],
+      observableClient,
+      {} as Client,
+      {},
+    );
+
+    const unsubscribe = store.subscribe(() => {});
+    const sources = [makeInstance("pk-1"), makeInstance("pk-2")];
+    store.updateSourceObjects(sources as never, sources);
+
+    // Flush the async buildObjectSetFromLinkDefByType promises for non-batchable.
+    await vi.waitFor(() => {
+      expect(observeLinks).toHaveBeenCalledTimes(1);
+      expect(observeObjectSet).toHaveBeenCalledTimes(2);
+    });
+
+    expect(observeLinks.mock.calls[0][1]).toBe("employees");
+    unsubscribe();
+  });
+
+  it("restarts batched observation when source objects change", () => {
+    const unsubscribes: Array<ReturnType<typeof vi.fn>> = [];
+    const observeLinks = vi.fn(
+      (
+        _objs: unknown,
+        _linkName: unknown,
+        _opts: unknown,
+        _obs: Observer<unknown>,
+      ) => {
+        const unsub = vi.fn();
+        unsubscribes.push(unsub);
+        return { unsubscribe: unsub };
+      },
+    );
+
+    const observableClient = {
+      observeLinks,
+      observeObjectSet: vi.fn(),
+    } as unknown as ObservableClient;
+
+    const shape = makeShape([batchableLink("employees")]);
+
+    const store = createBatchedDerivedLinksStore(
+      shape,
+      shape.__derivedLinks as Parameters<
+        typeof createBatchedDerivedLinksStore
+      >[1],
+      observableClient,
+      {} as Client,
+      {},
+    );
+
+    store.subscribe(() => {});
+
+    store.updateSourceObjects([makeInstance("pk-1")] as never, [
+      makeInstance("pk-1"),
+    ]);
+    expect(observeLinks).toHaveBeenCalledTimes(1);
+
+    store.updateSourceObjects(
+      [makeInstance("pk-1"), makeInstance("pk-2")] as never,
+      [makeInstance("pk-1"), makeInstance("pk-2")],
+    );
+
+    expect(observeLinks).toHaveBeenCalledTimes(2);
+    expect(unsubscribes[0]).toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/new/shapes/__tests__/derivedLinksStore.test.ts
+++ b/packages/react/src/new/shapes/__tests__/derivedLinksStore.test.ts
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Client } from "@osdk/client";
+import type * as UnstableClient from "@osdk/client/unstable-do-not-use";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type ObservableClient = UnstableClient.ObservableClient;
+type Observer<T> = UnstableClient.Observer<T>;
+
+vi.mock("@osdk/client/unstable-do-not-use", async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof UnstableClient;
+  return {
+    ...actual,
+    buildObjectSetFromLinkDefByType: vi.fn(() =>
+      Promise.resolve({ __fakeObjectSet: true })
+    ),
+  };
+});
+
+import { createDerivedLinksStore } from "../derivedLinksStore.js";
+
+function makeShape(derivedLinks: readonly unknown[]) {
+  const baseType = {
+    apiName: "Parent",
+    primaryKeyType: "string",
+    type: "object",
+  };
+  return {
+    __shapeId: "parent-shape",
+    __debugName: "ParentShape",
+    __baseType: baseType,
+    __baseTypeApiName: "Parent",
+    __props: Object.freeze({}),
+    __derivedLinks: Object.freeze(derivedLinks),
+    __selectedPropsType: {},
+    __derivedLinksType: {},
+  } as unknown as Parameters<typeof createDerivedLinksStore>[0];
+}
+
+function leafTargetShape() {
+  const baseType = {
+    apiName: "Leaf",
+    primaryKeyType: "string",
+    type: "object",
+  };
+  return {
+    __shapeId: "leaf-shape",
+    __debugName: "LeafShape",
+    __baseType: baseType,
+    __baseTypeApiName: "Leaf",
+    __props: Object.freeze({}),
+    __derivedLinks: Object.freeze([]),
+    __selectedPropsType: {},
+    __derivedLinksType: {},
+  };
+}
+
+function nestingTargetShape(nestedLinks: readonly unknown[]) {
+  const baseType = {
+    apiName: "Child",
+    primaryKeyType: "string",
+    type: "object",
+  };
+  return {
+    __shapeId: "child-shape",
+    __debugName: "ChildShape",
+    __baseType: baseType,
+    __baseTypeApiName: "Child",
+    __props: Object.freeze({}),
+    __derivedLinks: Object.freeze(nestedLinks),
+    __selectedPropsType: {},
+    __derivedLinksType: {},
+  };
+}
+
+function linkDef(name: string, targetShape: unknown) {
+  return {
+    name,
+    targetShape,
+    objectSetDef: {
+      segments: [{ type: "pivotTo", linkName: name }],
+    },
+    config: {},
+  };
+}
+
+function rawInstance(apiName: string, pk: string): Record<string, unknown> {
+  const instance: Record<string, unknown> = {
+    $primaryKey: pk,
+    $apiName: apiName,
+    $objectType: apiName,
+  };
+  instance.$clone = () => instance;
+  return instance;
+}
+
+describe("createDerivedLinksStore", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("reflects loaded data in the snapshot after the observer emits", async () => {
+    const observers: Array<Observer<unknown>> = [];
+    const unsubscribes: Array<ReturnType<typeof vi.fn>> = [];
+
+    const observableClient = {
+      observeObjectSet: vi.fn(
+        (_os: unknown, _opts: unknown, obs: Observer<unknown>) => {
+          observers.push(obs);
+          const unsub = vi.fn();
+          unsubscribes.push(unsub);
+          return { unsubscribe: unsub };
+        },
+      ),
+    } as unknown as ObservableClient;
+
+    const shape = makeShape([linkDef("employees", leafTargetShape())]);
+    const sourceObject = rawInstance("Parent", "p1");
+    const store = createDerivedLinksStore(
+      shape,
+      sourceObject as never,
+      observableClient,
+      {} as Client,
+      {},
+    );
+
+    const notify = vi.fn();
+    const unsubscribe = store.subscribe(notify);
+
+    // The async build+observe pipeline needs the pending promise to settle.
+    await vi.waitFor(() => {
+      expect(observers).toHaveLength(1);
+    });
+
+    observers[0].next({
+      resolvedList: [rawInstance("Leaf", "l1"), rawInstance("Leaf", "l2")],
+      status: "loaded",
+      hasMore: false,
+      fetchMore: async () => {},
+      isOptimistic: false,
+    });
+
+    const snapshot = store.getSnapShot();
+    expect(snapshot.links.employees).toHaveLength(2);
+    const employeesStatus =
+      (snapshot.linkStatus as Record<string, { isLoading: boolean }>).employees;
+    expect(employeesStatus?.isLoading).toBe(false);
+    expect(snapshot.anyLoading).toBe(false);
+
+    unsubscribe();
+    expect(unsubscribes[0]).toHaveBeenCalled();
+  });
+
+  it("cascades cleanup through nested links when the store is destroyed", async () => {
+    const observers: Array<Observer<unknown>> = [];
+    const unsubscribes: Array<ReturnType<typeof vi.fn>> = [];
+
+    const observableClient = {
+      observeObjectSet: vi.fn(
+        (_os: unknown, _opts: unknown, obs: Observer<unknown>) => {
+          observers.push(obs);
+          const unsub = vi.fn();
+          unsubscribes.push(unsub);
+          return { unsubscribe: unsub };
+        },
+      ),
+    } as unknown as ObservableClient;
+
+    const tasksShape = leafTargetShape();
+    const employeesShape = nestingTargetShape([linkDef("tasks", tasksShape)]);
+    const shape = makeShape([linkDef("employees", employeesShape)]);
+
+    const sourceObject = rawInstance("Parent", "p1");
+    const store = createDerivedLinksStore(
+      shape,
+      sourceObject as never,
+      observableClient,
+      {} as Client,
+      {},
+    );
+
+    const unsubscribe = store.subscribe(() => {});
+    await vi.waitFor(() => {
+      expect(observers).toHaveLength(1);
+    });
+
+    // Emit two parent items so nested entries get queued.
+    observers[0].next({
+      resolvedList: [
+        rawInstance("Child", "c1"),
+        rawInstance("Child", "c2"),
+      ],
+      status: "loaded",
+      hasMore: false,
+      fetchMore: async () => {},
+      isOptimistic: false,
+    });
+
+    // Advance the 25 ms debounce, then let the nested buildObjectSet promises settle.
+    await vi.advanceTimersByTimeAsync(30);
+    await vi.waitFor(() => {
+      // 1 parent + 2 nested subscriptions
+      expect(observers).toHaveLength(3);
+    });
+
+    unsubscribe();
+
+    // All subscriptions (parent + both nested) should be torn down by destroy.
+    for (const unsub of unsubscribes) {
+      expect(unsub).toHaveBeenCalled();
+    }
+  });
+});

--- a/packages/react/src/new/shapes/__tests__/useShape.test.tsx
+++ b/packages/react/src/new/shapes/__tests__/useShape.test.tsx
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectTypeDefinition } from "@osdk/api";
+import type { ShapePropertyConfig } from "@osdk/api/shapes-internal";
+import type { ShapeDefinition } from "@osdk/api/unstable";
+import { ShapeNullabilityError } from "@osdk/api/unstable";
+import type {
+  ObservableClient,
+  Observer,
+} from "@osdk/client/unstable-do-not-use";
+import { act, renderHook } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OsdkContext2 } from "../../OsdkContext2.js";
+import { useShapeList, useShapeSingle } from "../useShape.js";
+
+const MockObjectType = {
+  apiName: "MockObject",
+  primaryKeyType: "string",
+} as unknown as ObjectTypeDefinition;
+
+function makeShape(
+  props: Record<string, ShapePropertyConfig>,
+): ShapeDefinition<typeof MockObjectType> {
+  return {
+    __shapeId: "test-shape-id",
+    __debugName: "TestShape",
+    __baseType: MockObjectType,
+    __baseTypeApiName: "MockObject",
+    __props: Object.freeze(props),
+    __derivedLinks: Object.freeze([]),
+    __selectedPropsType: {},
+    __derivedLinksType: {},
+  } as unknown as ShapeDefinition<typeof MockObjectType>;
+}
+
+function makeInstance(data: Record<string, unknown>): Record<string, unknown> {
+  const instance: Record<string, unknown> = {
+    ...data,
+    $objectType: MockObjectType.apiName,
+    $apiName: MockObjectType.apiName,
+  };
+  instance.$clone = (patch: Record<string, unknown>) =>
+    makeInstance({ ...data, ...patch });
+  return instance;
+}
+
+interface MockClientHandle {
+  observableClient: ObservableClient;
+  emitObjectLoaded: (object: Record<string, unknown>) => void;
+  observeObject: ReturnType<typeof vi.fn>;
+  observeList: ReturnType<typeof vi.fn>;
+  invalidateObjectType: ReturnType<typeof vi.fn>;
+}
+
+function createMockClient(): MockClientHandle {
+  let activeObjectObserver: Observer<unknown> | undefined;
+  let activeListObserver: Observer<unknown> | undefined;
+
+  const observeObject = vi.fn((
+    _type: unknown,
+    _pk: unknown,
+    _options: unknown,
+    observer: Observer<unknown>,
+  ) => {
+    activeObjectObserver = observer;
+    observer.next({ status: "loading", object: undefined });
+    return { unsubscribe: vi.fn() };
+  });
+
+  const observeList = vi.fn((
+    _options: unknown,
+    observer: Observer<unknown>,
+  ) => {
+    activeListObserver = observer;
+    observer.next({
+      status: "loading",
+      resolvedList: undefined,
+      hasMore: false,
+      fetchMore: async () => {},
+      isOptimistic: false,
+    });
+    return { unsubscribe: vi.fn() };
+  });
+
+  const invalidateObjectType = vi.fn(async () => {});
+
+  const observableClient = {
+    observeObject,
+    observeList,
+    canonicalizeWhereClause: (w: unknown) => w,
+    invalidateObjectType,
+  } as unknown as ObservableClient;
+
+  return {
+    observableClient,
+    emitObjectLoaded: (object) => {
+      activeObjectObserver?.next({ status: "loaded", object });
+    },
+    observeObject,
+    observeList,
+    invalidateObjectType,
+  };
+}
+
+function wrap(observableClient: ObservableClient) {
+  return ({ children }: React.PropsWithChildren) =>
+    React.createElement(
+      OsdkContext2.Provider,
+      { value: { observableClient, client: {} } as never },
+      children,
+    );
+}
+
+describe("useShapeSingle / useShapeList", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("starts in loading state and reflects loaded data once the observer emits", () => {
+    const shape = makeShape({
+      name: { nullabilityOp: { type: "select" } },
+    });
+    const mock = createMockClient();
+    const { result } = renderHook(
+      () => useShapeSingle(shape, "pk-1"),
+      { wrapper: wrap(mock.observableClient) },
+    );
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+    expect(mock.observeObject).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      mock.emitObjectLoaded(
+        makeInstance({ $primaryKey: "pk-1", name: "Alice" }),
+      );
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toMatchObject({
+      $primaryKey: "pk-1",
+      name: "Alice",
+    });
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it("surfaces ShapeNullabilityError when a required property is missing", () => {
+    const shape = makeShape({
+      name: { nullabilityOp: { type: "require" } },
+    });
+    const mock = createMockClient();
+    const { result } = renderHook(
+      () => useShapeSingle(shape, "pk-1"),
+      { wrapper: wrap(mock.observableClient) },
+    );
+
+    act(() => {
+      mock.emitObjectLoaded(makeInstance({ $primaryKey: "pk-1", name: null }));
+    });
+
+    expect(result.current.error).toBeInstanceOf(ShapeNullabilityError);
+    expect(result.current.data).toBeUndefined();
+    const violation = result.current.nullabilityViolations[0];
+    expect(violation?.property).toBe("name");
+    expect(violation?.constraint).toBe("require");
+  });
+
+  it("does not observe when enabled is false", () => {
+    const shape = makeShape({
+      name: { nullabilityOp: { type: "select" } },
+    });
+    const mock = createMockClient();
+    renderHook(
+      () => useShapeList(shape, { enabled: false }),
+      { wrapper: wrap(mock.observableClient) },
+    );
+
+    expect(mock.observeList).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/new/shapes/__tests__/useShape.test.tsx
+++ b/packages/react/src/new/shapes/__tests__/useShape.test.tsx
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectTypeDefinition } from "@osdk/api";
+import type { ShapePropertyConfig } from "@osdk/api/shapes-internal";
+import type { ShapeDefinition } from "@osdk/api/unstable";
+import { ShapeNullabilityError } from "@osdk/api/unstable";
+import type { ObservableClient, Observer } from "@osdk/client/observable";
+import { act, renderHook } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OsdkContext } from "../../OsdkContext.js";
+import { useShapeList, useShapeSingle } from "../useShape.js";
+
+const MockObjectType = {
+  apiName: "MockObject",
+  primaryKeyType: "string",
+} as unknown as ObjectTypeDefinition;
+
+function makeShape(
+  props: Record<string, ShapePropertyConfig>,
+): ShapeDefinition<typeof MockObjectType> {
+  return {
+    __shapeId: "test-shape-id",
+    __debugName: "TestShape",
+    __baseType: MockObjectType,
+    __baseTypeApiName: "MockObject",
+    __props: Object.freeze(props),
+    __derivedLinks: Object.freeze([]),
+    __selectedPropsType: {},
+    __derivedLinksType: {},
+  } as unknown as ShapeDefinition<typeof MockObjectType>;
+}
+
+function makeInstance(data: Record<string, unknown>): Record<string, unknown> {
+  const instance: Record<string, unknown> = {
+    ...data,
+    $objectType: MockObjectType.apiName,
+    $apiName: MockObjectType.apiName,
+  };
+  instance.$clone = (patch: Record<string, unknown>) =>
+    makeInstance({ ...data, ...patch });
+  return instance;
+}
+
+interface MockClientHandle {
+  observableClient: ObservableClient;
+  emitObjectLoaded: (object: Record<string, unknown>) => void;
+  observeObject: ReturnType<typeof vi.fn>;
+  observeList: ReturnType<typeof vi.fn>;
+  invalidateObjectType: ReturnType<typeof vi.fn>;
+}
+
+function createMockClient(): MockClientHandle {
+  let activeObjectObserver: Observer<unknown> | undefined;
+  let activeListObserver: Observer<unknown> | undefined;
+
+  const observeObject = vi.fn((
+    _type: unknown,
+    _pk: unknown,
+    _options: unknown,
+    observer: Observer<unknown>,
+  ) => {
+    activeObjectObserver = observer;
+    observer.next({ status: "loading", object: undefined });
+    return { unsubscribe: vi.fn() };
+  });
+
+  const observeList = vi.fn((
+    _options: unknown,
+    observer: Observer<unknown>,
+  ) => {
+    activeListObserver = observer;
+    observer.next({
+      status: "loading",
+      resolvedList: undefined,
+      hasMore: false,
+      fetchMore: async () => {},
+      isOptimistic: false,
+    });
+    return { unsubscribe: vi.fn() };
+  });
+
+  const invalidateObjectType = vi.fn(async () => {});
+
+  const observableClient = {
+    observeObject,
+    observeList,
+    canonicalizeWhereClause: (w: unknown) => w,
+    invalidateObjectType,
+  } as unknown as ObservableClient;
+
+  return {
+    observableClient,
+    emitObjectLoaded: (object) => {
+      activeObjectObserver?.next({ status: "loaded", object });
+    },
+    observeObject,
+    observeList,
+    invalidateObjectType,
+  };
+}
+
+function wrap(observableClient: ObservableClient) {
+  return ({ children }: React.PropsWithChildren) =>
+    React.createElement(
+      OsdkContext.Provider,
+      { value: { observableClient, client: {} } as never },
+      children,
+    );
+}
+
+describe("useShapeSingle / useShapeList", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("starts in loading state and reflects loaded data once the observer emits", () => {
+    const shape = makeShape({
+      name: { nullabilityOp: { type: "select" } },
+    });
+    const mock = createMockClient();
+    const { result } = renderHook(
+      () => useShapeSingle(shape, "pk-1"),
+      { wrapper: wrap(mock.observableClient) },
+    );
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+    expect(mock.observeObject).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      mock.emitObjectLoaded(
+        makeInstance({ $primaryKey: "pk-1", name: "Alice" }),
+      );
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toMatchObject({
+      $primaryKey: "pk-1",
+      name: "Alice",
+    });
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it("surfaces ShapeNullabilityError when a required property is missing", () => {
+    const shape = makeShape({
+      name: { nullabilityOp: { type: "require" } },
+    });
+    const mock = createMockClient();
+    const { result } = renderHook(
+      () => useShapeSingle(shape, "pk-1"),
+      { wrapper: wrap(mock.observableClient) },
+    );
+
+    act(() => {
+      mock.emitObjectLoaded(makeInstance({ $primaryKey: "pk-1", name: null }));
+    });
+
+    expect(result.current.error).toBeInstanceOf(ShapeNullabilityError);
+    expect(result.current.data).toBeUndefined();
+    const violation = result.current.nullabilityViolations[0];
+    expect(violation?.property).toBe("name");
+    expect(violation?.constraint).toBe("require");
+  });
+
+  it("does not observe when enabled is false", () => {
+    const shape = makeShape({
+      name: { nullabilityOp: { type: "select" } },
+    });
+    const mock = createMockClient();
+    renderHook(
+      () => useShapeList(shape, { enabled: false }),
+      { wrapper: wrap(mock.observableClient) },
+    );
+
+    expect(mock.observeList).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds core-workflow tests for each shape abstraction introduced in the stack. Before this PR, only the integration layer (`useOsdkObject` shape overload) had tests.

## What's covered

• `createDerivedLinksStore`: snapshot reflects loaded data; destroy cascades unsubscribes through nested links
• `createBatchedDerivedLinksStore`: routing for batchable vs non-batchable links; restart on updateSourceObjects
• `useShapeSingle` / `useShapeList`: loading → loaded, required-property violations surface as ShapeNullabilityError, enabled:false skips observation

## Test plan
- [x] `pnpm --dir packages/react vitest run src/new/shapes/__tests__` passes all 7 new tests
- [x] Full react suite passes (115 tests, up from 108)
- [x] Typecheck green