### PR TITLE
warn and ignore streamupdates when combined with withproperties

### DIFF
--- a/.changeset/streamupdates-withproperties-throw.md
+++ b/.changeset/streamupdates-withproperties-throw.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+throw when streamUpdates is combined with withProperties

--- a/.changeset/streamupdates-withproperties-throw.md
+++ b/.changeset/streamupdates-withproperties-throw.md
@@ -2,4 +2,4 @@
 "@osdk/client": patch
 ---
 
-throw when streamUpdates is combined with withProperties
+warn and ignore streamUpdates when combined with withProperties

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -128,6 +128,10 @@ export interface ObserveListOptions<
    *
    * Cannot be combined with `pivotTo`. The server does not support
    * websocket subscriptions for link-traversal queries.
+   *
+   * Cannot be combined with `withProperties`. The server does not support
+   * websocket subscriptions for object sets that include derived properties;
+   * enabling both will throw at subscription time.
    */
   streamUpdates?: boolean;
   withProperties?: DerivedProperty.Clause<Q>;

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -131,7 +131,8 @@ export interface ObserveListOptions<
    *
    * Cannot be combined with `withProperties`. The server does not support
    * websocket subscriptions for object sets that include derived properties;
-   * enabling both will throw at subscription time.
+   * in that case `streamUpdates` is ignored and a warning is logged in
+   * development.
    */
   streamUpdates?: boolean;
   withProperties?: DerivedProperty.Clause<Q>;

--- a/packages/client/src/observable/internal/list/ListsHelper.ts
+++ b/packages/client/src/observable/internal/list/ListsHelper.ts
@@ -76,6 +76,13 @@ export class ListsHelper extends AbstractHelper<
     const ret = super.observe(options, subFn);
 
     if (options.streamUpdates) {
+      if (options.withProperties) {
+        throw new Error(
+          "[@osdk/client] streamUpdates is not supported with withProperties. "
+            + "The server does not support websocket subscriptions for "
+            + "object sets that include derived properties.",
+        );
+      }
       if (options.pivotTo) {
         if (process.env.NODE_ENV !== "production") {
           // eslint-disable-next-line no-console

--- a/packages/client/src/observable/internal/list/ListsHelper.ts
+++ b/packages/client/src/observable/internal/list/ListsHelper.ts
@@ -76,13 +76,6 @@ export class ListsHelper extends AbstractHelper<
     const ret = super.observe(options, subFn);
 
     if (options.streamUpdates) {
-      if (options.withProperties) {
-        throw new Error(
-          "[@osdk/client] streamUpdates is not supported with withProperties. "
-            + "The server does not support websocket subscriptions for "
-            + "object sets that include derived properties.",
-        );
-      }
       if (options.pivotTo) {
         if (process.env.NODE_ENV !== "production") {
           // eslint-disable-next-line no-console
@@ -90,6 +83,15 @@ export class ListsHelper extends AbstractHelper<
             "[@osdk/client] streamUpdates is not supported with pivotTo. "
               + "The server does not support websocket subscriptions for "
               + "link-traversal queries. Ignoring streamUpdates.",
+          );
+        }
+      } else if (options.withProperties) {
+        if (process.env.NODE_ENV !== "production") {
+          // eslint-disable-next-line no-console
+          console.warn(
+            "[@osdk/client] streamUpdates is not supported with withProperties. "
+              + "The server does not support websocket subscriptions for "
+              + "object sets that include derived properties. Ignoring streamUpdates.",
           );
         }
       } else {

--- a/packages/client/src/observable/internal/objectset/ObjectSetHelper.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetHelper.ts
@@ -15,6 +15,7 @@
  */
 
 import { getWireObjectSet } from "../../../objectSet/createObjectSet.js";
+import { hasWithProperties } from "../../../util/extractRdpDefinition.js";
 import type { ObjectSetPayload } from "../../ObjectSetPayload.js";
 import type { Observer } from "../../ObservableClient/common.js";
 import { AbstractHelper } from "../AbstractHelper.js";
@@ -70,6 +71,16 @@ export class ObjectSetHelper extends AbstractHelper<
     const ret = super.observe(options, subFn);
 
     if (options.streamUpdates) {
+      if (
+        options.withProperties
+        || hasWithProperties(getWireObjectSet(options.baseObjectSet))
+      ) {
+        throw new Error(
+          "[@osdk/client] streamUpdates is not supported with withProperties. "
+            + "The server does not support websocket subscriptions for "
+            + "object sets that include derived properties.",
+        );
+      }
       if (options.pivotTo) {
         if (process.env.NODE_ENV !== "production") {
           // eslint-disable-next-line no-console

--- a/packages/client/src/observable/internal/objectset/ObjectSetHelper.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetHelper.ts
@@ -71,16 +71,6 @@ export class ObjectSetHelper extends AbstractHelper<
     const ret = super.observe(options, subFn);
 
     if (options.streamUpdates) {
-      if (
-        options.withProperties
-        || hasWithProperties(getWireObjectSet(options.baseObjectSet))
-      ) {
-        throw new Error(
-          "[@osdk/client] streamUpdates is not supported with withProperties. "
-            + "The server does not support websocket subscriptions for "
-            + "object sets that include derived properties.",
-        );
-      }
       if (options.pivotTo) {
         if (process.env.NODE_ENV !== "production") {
           // eslint-disable-next-line no-console
@@ -88,6 +78,18 @@ export class ObjectSetHelper extends AbstractHelper<
             "[@osdk/client] streamUpdates is not supported with pivotTo. "
               + "The server does not support websocket subscriptions for "
               + "link-traversal queries. Ignoring streamUpdates.",
+          );
+        }
+      } else if (
+        options.withProperties
+        || hasWithProperties(getWireObjectSet(options.baseObjectSet))
+      ) {
+        if (process.env.NODE_ENV !== "production") {
+          // eslint-disable-next-line no-console
+          console.warn(
+            "[@osdk/client] streamUpdates is not supported with withProperties. "
+              + "The server does not support websocket subscriptions for "
+              + "object sets that include derived properties. Ignoring streamUpdates.",
           );
         }
       } else {

--- a/packages/client/src/observable/internal/objectset/ObjectSetQueryOptions.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQueryOptions.ts
@@ -71,6 +71,11 @@ export interface ObserveObjectSetOptions<
    * Cannot be combined with `pivotTo`. The server does not support
    * websocket subscriptions for link-traversal queries.
    *
+   * Cannot be combined with `withProperties` (or a `baseObjectSet` that already
+   * has derived properties applied). The server does not support websocket
+   * subscriptions for object sets that include derived properties; enabling
+   * both will throw at subscription time.
+   *
    * @default false
    */
   streamUpdates?: boolean;

--- a/packages/client/src/observable/internal/objectset/ObjectSetQueryOptions.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQueryOptions.ts
@@ -73,8 +73,8 @@ export interface ObserveObjectSetOptions<
    *
    * Cannot be combined with `withProperties` (or a `baseObjectSet` that already
    * has derived properties applied). The server does not support websocket
-   * subscriptions for object sets that include derived properties; enabling
-   * both will throw at subscription time.
+   * subscriptions for object sets that include derived properties; in that
+   * case `streamUpdates` is ignored and a warning is logged in development.
    *
    * @default false
    */

--- a/packages/client/src/util/extractRdpDefinition.ts
+++ b/packages/client/src/util/extractRdpDefinition.ts
@@ -35,7 +35,7 @@ export async function extractRdpDefinition(
   )).definitions;
 }
 
-function hasWithProperties(objectSet: ObjectSet): boolean {
+export function hasWithProperties(objectSet: ObjectSet): boolean {
   if (objectSet.type === "withProperties") {
     return true;
   }


### PR DESCRIPTION
combining streamUpdates with withProperties currently produces a silently broken subscription because the server does not support websocket subscriptions for object sets that include derived properties

• in ObjectSetHelper.observe, skip registerStreamUpdates when options.withProperties is set or the baseObjectSet wire already carries withProperties, matching the pivotTo warn-and-ignore pattern
• in ListsHelper.observe, same warn-and-ignore when streamUpdates is combined with withProperties
• document the incompatibility on the streamUpdates JSDoc