### PR TITLE
add install and version compat guidance to @osdk/react agents.md files

### DIFF
--- a/.changeset/agents-md-install-compat.md
+++ b/.changeset/agents-md-install-compat.md
@@ -1,0 +1,6 @@
+---
+"@osdk/react": patch
+"@osdk/react-components": patch
+---
+
+document @osdk/client version compat and install-time error recovery in AGENTS.md

--- a/packages/react-components/AGENTS.md
+++ b/packages/react-components/AGENTS.md
@@ -4,7 +4,7 @@ Pre-built, Ontology-aware React components. Pass in OSDK entities and they handl
 
 ## Installing
 
-Requires `@osdk/react` AND `@osdk/client` AND `@osdk/api` together. Versions must line up tighter than the declared peer ranges. `@osdk/react-components` transitively depends on the unstable `@osdk/client` surface via `@osdk/react`.
+Requires `@osdk/react` AND `@osdk/client` AND `@osdk/api` together. Versions must line up tighter than the declared peer ranges. Both `@osdk/react-components` and `@osdk/react` import from the unstable `@osdk/client` surface, which moves between releases without deprecation.
 
 - **Stable `@osdk/react-components`** → latest stable `@osdk/react`, `@osdk/client`, and `@osdk/api`.
 - **Prerelease `@osdk/react-components`** → MUST use matching prerelease versions of all three peers. Mismatches will break at build time.
@@ -25,12 +25,12 @@ See `@osdk/react`'s `AGENTS.md` for optional peers (`@osdk/foundry.admin`, `@osd
 
 ## Install-time errors
 
-| Error                                                                             | Cause                                                                                              | Fix                                                                                                  |
-| --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `"<name>" is not exported by @osdk/client/.../unstable-do-not-use.js`             | `@osdk/client` or `@osdk/react` version mismatches what `@osdk/react-components` was built against | Follow the CHANGELOG recipe in `## Installing` and pin all three peers to the exact versions listed. |
-| `"<name>" is not exported by @osdk/react/...`                                     | `@osdk/react` version mismatches what `@osdk/react-components` was built against                   | Same — CHANGELOG recipe, pin `@osdk/react` to the exact version.                                     |
-| `Rollup failed to resolve import "@osdk/foundry.admin"` (or `@osdk/foundry.core`) | Transitive import from `@osdk/react/experimental/admin` without the optional peers                 | Install `@osdk/foundry.admin` + `@osdk/foundry.core`, OR avoid surfaces that use the admin hooks.    |
-| pnpm/npm peer warning about `@osdk/client` or `@osdk/react` range                 | Declared peer ranges are broad; prerelease coupling is tighter                                     | Follow the CHANGELOG recipe; pin to exact versions.                                                  |
+| Error                                                                                      | Cause                                                                                                             | Fix                                                                                                                                                  |
+| ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"<name>" is not exported by @osdk/client/.../unstable-do-not-use.js` (or `@osdk/api/...`) | `@osdk/client` or `@osdk/api` or `@osdk/react` version mismatches what `@osdk/react-components` was built against | Do NOT delete the import or downgrade silently. Follow the CHANGELOG recipe in `## Installing` and pin all three peers to the exact versions listed. |
+| `"<name>" is not exported by @osdk/react/...`                                              | `@osdk/react` version mismatches what `@osdk/react-components` was built against                                  | Do NOT delete the import or downgrade silently. Follow the CHANGELOG recipe in `## Installing` and pin `@osdk/react` to the exact version listed.    |
+| `Rollup failed to resolve import "@osdk/foundry.admin"` (or `@osdk/foundry.core`)          | Transitive import from `@osdk/react/experimental/admin` without the optional peers                                | Install `@osdk/foundry.admin` + `@osdk/foundry.core`, OR avoid surfaces that use the admin hooks.                                                    |
+| pnpm/npm peer warning about `@osdk/client` or `@osdk/react` range                          | Declared peer ranges are broad; prerelease coupling is tighter                                                    | Follow the CHANGELOG recipe; pin to exact versions.                                                                                                  |
 
 ## Components
 

--- a/packages/react-components/AGENTS.md
+++ b/packages/react-components/AGENTS.md
@@ -2,6 +2,36 @@
 
 Pre-built, Ontology-aware React components. Pass in OSDK entities and they handle data loading, caching, and state management automatically. Requires `@osdk/react` (see the `@osdk/react` package's `AGENTS.md` for hooks and provider setup).
 
+## Installing
+
+Requires `@osdk/react` AND `@osdk/client` AND `@osdk/api` together. Versions must line up tighter than the declared peer ranges. `@osdk/react-components` transitively depends on the unstable `@osdk/client` surface via `@osdk/react`.
+
+- **Stable `@osdk/react-components`** → latest stable `@osdk/react`, `@osdk/client`, and `@osdk/api`.
+- **Prerelease `@osdk/react-components`** → MUST use matching prerelease versions of all three peers. Mismatches will break at build time.
+
+To find the exact compatible peer versions:
+
+1. Open `node_modules/@osdk/react-components/CHANGELOG.md`
+2. Find the heading matching your installed `@osdk/react-components` version
+3. If that entry has an `Updated dependencies` section, install the exact versions it lists for `@osdk/react`, `@osdk/client`, and `@osdk/api`
+4. If it does NOT, walk backwards to the most recent prior entry that does, and use those versions
+
+**Worked example** — installed `@osdk/react-components@0.2.0-beta.26`:
+
+- Entry lists `@osdk/client@2.8.0-beta.29`, `@osdk/api@2.8.0-beta.29`, `@osdk/react@0.10.0-beta.14`
+- Run: `pnpm add @osdk/client@2.8.0-beta.29 @osdk/api@2.8.0-beta.29 @osdk/react@0.10.0-beta.14`
+
+See `@osdk/react`'s `AGENTS.md` for optional peers (`@osdk/foundry.admin`, `@osdk/foundry.core`) used by the admin hooks.
+
+## Install-time errors
+
+| Error                                                                             | Cause                                                                                              | Fix                                                                                                  |
+| --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `"<name>" is not exported by @osdk/client/.../unstable-do-not-use.js`             | `@osdk/client` or `@osdk/react` version mismatches what `@osdk/react-components` was built against | Follow the CHANGELOG recipe in `## Installing` and pin all three peers to the exact versions listed. |
+| `"<name>" is not exported by @osdk/react/...`                                     | `@osdk/react` version mismatches what `@osdk/react-components` was built against                   | Same — CHANGELOG recipe, pin `@osdk/react` to the exact version.                                     |
+| `Rollup failed to resolve import "@osdk/foundry.admin"` (or `@osdk/foundry.core`) | Transitive import from `@osdk/react/experimental/admin` without the optional peers                 | Install `@osdk/foundry.admin` + `@osdk/foundry.core`, OR avoid surfaces that use the admin hooks.    |
+| pnpm/npm peer warning about `@osdk/client` or `@osdk/react` range                 | Declared peer ranges are broad; prerelease coupling is tighter                                     | Follow the CHANGELOG recipe; pin to exact versions.                                                  |
+
 ## Components
 
 Components are imported from their individual entry points under `@osdk/react-components/experimental/`:

--- a/packages/react-components/AGENTS.md
+++ b/packages/react-components/AGENTS.md
@@ -4,6 +4,8 @@ Pre-built, Ontology-aware React components. Pass in OSDK entities and they handl
 
 ## Installing
 
+**Default: `pnpm add @osdk/react-components@latest @osdk/react@latest`** — use prereleases only if you specifically need an unreleased feature. Everything below is for when you are NOT on the latest stable.
+
 Requires `@osdk/react` AND `@osdk/client` AND `@osdk/api` together. Versions must line up tighter than the declared peer ranges. Both `@osdk/react-components` and `@osdk/react` import from the unstable `@osdk/client` surface, which moves between releases without deprecation.
 
 - **Stable `@osdk/react-components`** → latest stable `@osdk/react`, `@osdk/client`, and `@osdk/api`.

--- a/packages/react/AGENTS.md
+++ b/packages/react/AGENTS.md
@@ -1,5 +1,37 @@
 # @osdk/react
 
+## Installing
+
+Must install `@osdk/react` AND `@osdk/client` together, and versions must line up tighter than the declared peer range. `@osdk/react` imports unstable APIs from `@osdk/client/unstable-do-not-use` that move between releases without deprecation.
+
+- **Stable `@osdk/react`** (e.g. `0.14.x`) → latest stable `@osdk/client` (`2.x`).
+- **Prerelease `@osdk/react`** (e.g. `0.10.0-beta.15`) → MUST use a prerelease `@osdk/client` from the same line. Stable clients will break.
+
+To find the exact compatible `@osdk/client` for any installed `@osdk/react`:
+
+1. Open `node_modules/@osdk/react/CHANGELOG.md`
+2. Find the heading matching your installed `@osdk/react` version
+3. If that entry has an `Updated dependencies` section, install the exact `@osdk/client@X.Y.Z` it lists
+4. If it does NOT, walk backwards to the most recent prior entry that does, and use that version
+
+**Worked example** — installed `@osdk/react@0.10.0-beta.15`:
+
+- `0.10.0-beta.15` has no `Updated dependencies` section → walk back
+- `0.10.0-beta.14` lists `@osdk/client@2.8.0-beta.29`
+- Run: `pnpm add @osdk/client@2.8.0-beta.29`
+
+**Optional peers** (install only if you import from the matching surface):
+
+- `@osdk/foundry.admin` + `@osdk/foundry.core`: required ONLY for `@osdk/react/experimental/admin` hooks (`useFoundryUser`, `useFoundryUsersList`, `useCurrentFoundryUser`, marking hooks). Otherwise omit.
+
+## Install-time errors
+
+| Error                                                                             | Cause                                                                                                                                                                         | Fix                                                                                                                                                                                            |
+| --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"<name>" is not exported by @osdk/client/.../unstable-do-not-use.js`             | `@osdk/client` is on a different release line than the one `@osdk/react` was built against — usually a beta `@osdk/react` paired with a stable `@osdk/client` (or vice versa) | Do NOT delete the import or downgrade `@osdk/react` silently. Follow the CHANGELOG recipe in `## Installing` to find the exact `@osdk/client` version, then `pnpm add @osdk/client@<version>`. |
+| `Rollup failed to resolve import "@osdk/foundry.admin"` (or `@osdk/foundry.core`) | Imported from `@osdk/react/experimental/admin` without installing the optional peers                                                                                          | Install `@osdk/foundry.admin` + `@osdk/foundry.core`, OR stop importing from `/experimental/admin`.                                                                                            |
+| pnpm/npm peer warning about `@osdk/client` range                                  | Declared peer range is deliberately broad; prerelease coupling is tighter than the range expresses                                                                            | Follow the CHANGELOG recipe; pin to the exact `@osdk/client` version.                                                                                                                          |
+
 ## Rules
 
 1. **Use `OsdkProvider2`**, not `OsdkProvider`. All modern hooks require it.

--- a/packages/react/AGENTS.md
+++ b/packages/react/AGENTS.md
@@ -2,35 +2,35 @@
 
 ## Installing
 
-Must install `@osdk/react` AND `@osdk/client` together, and versions must line up tighter than the declared peer range. `@osdk/react` imports unstable APIs from `@osdk/client/unstable-do-not-use` that move between releases without deprecation.
+Must install `@osdk/react` AND `@osdk/client` AND `@osdk/api` together, and versions must line up tighter than the declared peer ranges. `@osdk/react` imports unstable APIs from `@osdk/client/unstable-do-not-use` that move between releases without deprecation.
 
-- **Stable `@osdk/react`** (e.g. `0.14.x`) → latest stable `@osdk/client` (`2.x`).
-- **Prerelease `@osdk/react`** (e.g. `0.10.0-beta.15`) → MUST use a prerelease `@osdk/client` from the same line. Stable clients will break.
+- **Stable `@osdk/react`** (e.g. `0.14.x`) → latest stable `@osdk/client` and `@osdk/api` (`2.x`).
+- **Prerelease `@osdk/react`** (e.g. `0.10.0-beta.15`) → MUST use prerelease `@osdk/client` and `@osdk/api` from the same line. Stable releases will break.
 
-To find the exact compatible `@osdk/client` for any installed `@osdk/react`:
+To find the exact compatible `@osdk/client` and `@osdk/api` for any installed `@osdk/react`:
 
 1. Open `node_modules/@osdk/react/CHANGELOG.md`
 2. Find the heading matching your installed `@osdk/react` version
-3. If that entry has an `Updated dependencies` section, install the exact `@osdk/client@X.Y.Z` it lists
-4. If it does NOT, walk backwards to the most recent prior entry that does, and use that version
+3. If that entry has an `Updated dependencies` section, install the exact `@osdk/client@X.Y.Z` AND `@osdk/api@X.Y.Z` it lists
+4. If it does NOT, walk backwards to the most recent prior entry that does, and use those versions
 
 **Worked example** — installed `@osdk/react@0.10.0-beta.15`:
 
 - `0.10.0-beta.15` has no `Updated dependencies` section → walk back
-- `0.10.0-beta.14` lists `@osdk/client@2.8.0-beta.29`
-- Run: `pnpm add @osdk/client@2.8.0-beta.29`
+- `0.10.0-beta.14` lists `@osdk/client@2.8.0-beta.29` and `@osdk/api@2.8.0-beta.29`
+- Run: `pnpm add @osdk/client@2.8.0-beta.29 @osdk/api@2.8.0-beta.29`
 
 **Optional peers** (install only if you import from the matching surface):
 
-- `@osdk/foundry.admin` + `@osdk/foundry.core`: required ONLY for `@osdk/react/experimental/admin` hooks (`useFoundryUser`, `useFoundryUsersList`, `useCurrentFoundryUser`, marking hooks). Otherwise omit.
+- `@osdk/foundry.admin` + `@osdk/foundry.core`: required ONLY for any hook from `@osdk/react/experimental/admin`. Otherwise omit.
 
 ## Install-time errors
 
-| Error                                                                             | Cause                                                                                                                                                                         | Fix                                                                                                                                                                                            |
-| --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `"<name>" is not exported by @osdk/client/.../unstable-do-not-use.js`             | `@osdk/client` is on a different release line than the one `@osdk/react` was built against — usually a beta `@osdk/react` paired with a stable `@osdk/client` (or vice versa) | Do NOT delete the import or downgrade `@osdk/react` silently. Follow the CHANGELOG recipe in `## Installing` to find the exact `@osdk/client` version, then `pnpm add @osdk/client@<version>`. |
-| `Rollup failed to resolve import "@osdk/foundry.admin"` (or `@osdk/foundry.core`) | Imported from `@osdk/react/experimental/admin` without installing the optional peers                                                                                          | Install `@osdk/foundry.admin` + `@osdk/foundry.core`, OR stop importing from `/experimental/admin`.                                                                                            |
-| pnpm/npm peer warning about `@osdk/client` range                                  | Declared peer range is deliberately broad; prerelease coupling is tighter than the range expresses                                                                            | Follow the CHANGELOG recipe; pin to the exact `@osdk/client` version.                                                                                                                          |
+| Error                                                                                      | Cause                                                                                                                                                                             | Fix                                                                                                                                                                                                                                 |
+| ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"<name>" is not exported by @osdk/client/.../unstable-do-not-use.js` (or `@osdk/api/...`) | `@osdk/client` or `@osdk/api` is on a different release line than the one `@osdk/react` was built against — usually a beta `@osdk/react` paired with stable peers (or vice versa) | Do NOT delete the import or downgrade `@osdk/react` silently. Follow the CHANGELOG recipe in `## Installing` to find the exact `@osdk/client` and `@osdk/api` versions, then `pnpm add @osdk/client@<version> @osdk/api@<version>`. |
+| `Rollup failed to resolve import "@osdk/foundry.admin"` (or `@osdk/foundry.core`)          | Imported from `@osdk/react/experimental/admin` without installing the optional peers                                                                                              | Install `@osdk/foundry.admin` + `@osdk/foundry.core`, OR stop importing from `/experimental/admin`.                                                                                                                                 |
+| pnpm/npm peer warning about `@osdk/client` or `@osdk/api` range                            | Declared peer ranges are deliberately broad; prerelease coupling is tighter than the ranges express                                                                               | Follow the CHANGELOG recipe; pin to the exact `@osdk/client` and `@osdk/api` versions.                                                                                                                                              |
 
 ## Rules
 

--- a/packages/react/AGENTS.md
+++ b/packages/react/AGENTS.md
@@ -2,6 +2,8 @@
 
 ## Installing
 
+**Default: `pnpm add @osdk/react@latest`** — use a prerelease only if you specifically need an unreleased feature. Everything below is for when you are NOT on the latest stable.
+
 Must install `@osdk/react` AND `@osdk/client` AND `@osdk/api` together, and versions must line up tighter than the declared peer ranges. `@osdk/react` imports unstable APIs from `@osdk/client/unstable-do-not-use` that move between releases without deprecation.
 
 - **Stable `@osdk/react`** (e.g. `0.14.x`) → latest stable `@osdk/client` and `@osdk/api` (`2.x`).


### PR DESCRIPTION
llm coding agents installing @osdk/react have been hitting version-mismatch errors (eg `computeObjectSetCacheKey is not exported by @osdk/client/.../unstable-do-not-use.js`) that they can't self-diagnose because the peer range is loose and the CHANGELOG recipe isn't spelled out anywhere the agent reads.

• add `## Installing` section to @osdk/react and @osdk/react-components AGENTS.md with a walk-backwards CHANGELOG recipe and a worked example for 0.10.0-beta.15
• add `## Install-time errors` tables mapping the common rollup errors (missing unstable symbol, unresolved @osdk/foundry.admin, peer warnings) to concrete pnpm commands
• cover the optional-peer case so experimental/admin imports stop tripping bundlers silently