### PR TITLE
fix react-components vitest rpc timeout flake

### DIFF
--- a/.changeset/fix-react-components-test-flake.md
+++ b/.changeset/fix-react-components-test-flake.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Switch vitest pool from forks to threads to fix CI flake

--- a/packages/react-components/vitest.config.mts
+++ b/packages/react-components/vitest.config.mts
@@ -18,7 +18,7 @@ import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    pool: "forks",
+    pool: "threads",
     exclude: [...configDefaults.exclude, "**/build/**/*"],
     environment: "happy-dom",
     setupFiles: ["./src/test/setupPolyfills.ts"],


### PR DESCRIPTION
vitest worker -> main thread RPC (onTaskUpdate) times out after 60s under CI load, causing a false-positive unhandled-error failure even when all 713 tests pass

• switch react-components from pool: forks to pool: threads, which shares memory with the main process and avoids the cross-process IPC backpressure that triggers the timeout
• no change to test behavior or fake-timers config; threads pool is also slightly faster locally