### PR TITLE
[Components] Fix ObjectTable zebra row colors flipping

### DIFF
--- a/.changeset/fix-zebra-row-virtualized.md
+++ b/.changeset/fix-zebra-row-virtualized.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+fix ObjectTable zebra row colors flipping while scrolling — striping is now keyed off the row's data index instead of its DOM position

--- a/packages/e2e.sandbox.peopleapp/src/app/employees/EmployeesTable.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/employees/EmployeesTable.tsx
@@ -133,7 +133,6 @@ export function EmployeesTable() {
         }]}
         onSubmitEdits={handleSubmitEdits}
         editMode="manual"
-        pageSize={5}
       />
     </div>
   );

--- a/packages/react-components/src/object-table/TableRow.module.css
+++ b/packages/react-components/src/object-table/TableRow.module.css
@@ -27,8 +27,8 @@
     border-bottom: var(--osdk-table-border);
   }
 
-  /* Zebra rows */
-  &:nth-child(even) {
+  /* Zebra rows — keyed off data index, not DOM position, because rows are virtualized */
+  &[data-row-parity="odd"] {
     background-color: var(
       --osdk-table-row-bg-alternate,
       var(--osdk-table-row-bg-default)

--- a/packages/react-components/src/object-table/TableRow.tsx
+++ b/packages/react-components/src/object-table/TableRow.tsx
@@ -58,6 +58,7 @@ export function TableRow<TData extends RowData>({
     <tr
       data-selected={row.getIsSelected()}
       data-focused={isFocused}
+      data-row-parity={virtualRow.index % 2 === 0 ? "even" : "odd"}
       className={styles.osdkTableRow}
       style={{
         height: `${virtualRow.size}px`,


### PR DESCRIPTION
Before
https://github.com/user-attachments/assets/309d2387-cb3a-4f34-9cff-ec7a97f0795a

After
https://github.com/user-attachments/assets/8068fa5d-95dd-49d2-bb31-a727c52763d5

