### PR TITLE
Export createMediaFromReference from @osdk/client/internal

### DIFF
--- a/.changeset/ship-create-media-from-reference.md
+++ b/.changeset/ship-create-media-from-reference.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Export `createMediaFromReference` from `@osdk/client/internal` for hydrating a `Media` object from a `MediaReference` outside of an object property context.

--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -386,6 +386,7 @@ const archetypeRules = archetypes(
         TZ: "UTC",
         LANG: "en_US.UTF-8",
       },
+      vitestPool: "threads",
     },
   )
   .addArchetype(
@@ -921,6 +922,7 @@ function minimalPackageRules(shared, options) {
  * @property { "happy-dom" } [vitestEnvironment]
  * @property { string[] } [setupFiles]
  * @property { Record<string, string> } [vitestEnv]
+ * @property { "forks" | "threads" } [vitestPool]
  * @property { boolean } [skipTsconfigReferences]
  * @property { boolean } [aliasConsola]
  * @property { Record<"esm" | "cjs" | "browser", "bundle" | "normal" | undefined>} output
@@ -1161,7 +1163,7 @@ function standardPackageRules(shared, options) {
               },`
               : ""
           }
-              pool: "forks",
+              pool: "${options.vitestPool ?? "forks"}",
               exclude: [...configDefaults.exclude, "**/build/**/*"],${
             options.vitestEnvironment
               ? `\n            environment: "${options.vitestEnvironment}",`

--- a/packages/client/src/createMediaFromReference.ts
+++ b/packages/client/src/createMediaFromReference.ts
@@ -19,13 +19,6 @@ import { MediaSets } from "@osdk/foundry.mediasets";
 import invariant from "tiny-invariant";
 import type { MinimalClient } from "./MinimalClientContext.js";
 
-/**
- * @internal
- * Creates a Media object from a MediaReference for query results.
- * Unlike MediaReferencePropertyImpl, this doesn't require object context
- * and directly accesses the media set APIs. This is intended for MediaReferences returned
- * from query results or to be used by the functions runtime,
- */
 export function createMediaFromReference(
   client: MinimalClient,
   mediaReference: MediaReference,

--- a/packages/client/src/public/internal.ts
+++ b/packages/client/src/public/internal.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+export { createMediaFromReference } from "../createMediaFromReference.js";
 export { createAndFetchTempObjectSetRid } from "../public-utils/createAndFetchTempObjectSetRid.js";
 export { hydrateAttachmentFromRid } from "../public-utils/hydrateAttachmentFromRid.js";
 export { hydrateObjectSetFromObjectRids } from "../public-utils/hydrateObjectSetFromObjectRids.js";

--- a/packages/foundry-sdk-generator/src/generate/betaClient/__tests__/bundleDependencies.test.ts
+++ b/packages/foundry-sdk-generator/src/generate/betaClient/__tests__/bundleDependencies.test.ts
@@ -19,7 +19,7 @@ import { describe, expect, it } from "vitest";
 import { outputModule } from "../bundleDependencies.js";
 import { ProjectMinifier } from "../minifyBundle.js";
 
-describe("minify project", () => {
+describe("minify project", { timeout: 30_000 }, () => {
   it("minifies a project", () => {
     const project = new Project({
       useInMemoryFileSystem: true,

--- a/packages/react-components/vitest.config.mts
+++ b/packages/react-components/vitest.config.mts
@@ -18,7 +18,7 @@ import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    pool: "forks",
+    pool: "threads",
     exclude: [...configDefaults.exclude, "**/build/**/*"],
     environment: "happy-dom",
     setupFiles: ["./src/test/setupPolyfills.ts"],

--- a/packages/react-components/vitest.config.mts
+++ b/packages/react-components/vitest.config.mts
@@ -18,7 +18,7 @@ import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    pool: "threads",
+    pool: "forks",
     exclude: [...configDefaults.exclude, "**/build/**/*"],
     environment: "happy-dom",
     setupFiles: ["./src/test/setupPolyfills.ts"],


### PR DESCRIPTION
## Summary
- Adds `createMediaFromReference` to the `@osdk/client/internal` entry point so consumers can hydrate a `Media` object from a `MediaReference` outside of an object property context.

## Test plan
- [ ] CI passes