### PR TITLE
Fix dropped comma in OSDK docs object action parameters

### DIFF
--- a/.changeset/object-action-param-block-comment.md
+++ b/.changeset/object-action-param-block-comment.md
@@ -1,0 +1,6 @@
+---
+"@osdk/typescript-sdk-docs": patch
+"@osdk/react-sdk-docs": patch
+---
+
+Render the object-action-parameter alternative hint as a block comment so the trailing comma the template appends after non-last entries isn't swallowed by a line comment

--- a/packages/react-sdk-docs/src/docs.ts
+++ b/packages/react-sdk-docs/src/docs.ts
@@ -141,7 +141,7 @@ function renderType(
       return `"${offsetDate.toISOString()}"`;
     }
     case "object":
-      return `"primaryKeyValue" // or myObjectInstance`;
+      return `"primaryKeyValue" /* or myObjectInstance */`;
     case "objectSet":
       return `client(${type.objectTypeApiName}).where({ /* filter conditions */ })`;
     case "anonymousCustomType":

--- a/packages/typescript-sdk-docs/src/docs.ts
+++ b/packages/typescript-sdk-docs/src/docs.ts
@@ -374,7 +374,7 @@ function renderType(
         ? "\"primaryKeyValue\""
         : "primaryKeyValue";
       if (context === "actionParameter") {
-        return `${primaryKeyValue} // or myObjectInstance`;
+        return `${primaryKeyValue} /* or myObjectInstance */`;
       }
       return primaryKeyValue;
     case "objectSet":


### PR DESCRIPTION
Follow-up to https://github.com/palantir/osdk-ts/pull/2768: render the `or myObjectInstance` hint as a `/* */` block comment so the comma the template appends after non-last entries isn't swallowed by `//`, fixing copy-paste of multi-parameter action snippets.