### PR TITLE
update @osdk/react docs from bug bash feedback

### DIFF
--- a/docs/react/actions.md
+++ b/docs/react/actions.md
@@ -8,21 +8,21 @@ This guide covers executing actions, validation, optimistic updates, and debounc
 
 ## useOsdkAction
 
-*Experimental - import from `@osdk/react/experimental`*
+_Experimental - import from `@osdk/react/experimental`_
 
 Execute and validate actions with automatic state management.
 
 ### Basic Usage
 
 ```tsx
-import { $Actions, Todo } from "@my/osdk";
+import { completeTodo, Todo } from "@my/osdk";
 import { useOsdkAction, useOsdkObject } from "@osdk/react/experimental";
 import { useCallback } from "react";
 
 function TodoView({ todo }: { todo: Todo.OsdkInstance }) {
   const { isLoading } = useOsdkObject(todo);
   const { applyAction, data, error, isPending } = useOsdkAction(
-    $Actions.completeTodo,
+    completeTodo,
   );
 
   const onClick = useCallback(() => {
@@ -46,8 +46,8 @@ function TodoView({ todo }: { todo: Todo.OsdkInstance }) {
       </div>
       {error && (
         <div>
-          An error occurred:
-          <pre>{JSON.stringify(error, null, 2)}</pre>
+          An error occurred:{" "}
+          {error.actionValidation?.message ?? String(error.unknown)}
         </div>
       )}
     </div>
@@ -79,17 +79,18 @@ The `error` object has the following structure:
 ```
 
 `ActionValidationError` extends `Error` and has:
+
 - `message` - Error message string
 - `validation` - Full validation response from server
 
 Example:
 
 ```tsx
-import { $Actions, Todo } from "@my/osdk";
+import { completeTodo, Todo } from "@my/osdk";
 import { useOsdkAction } from "@osdk/react/experimental";
 
 function TodoActionWithErrorHandling({ todo }: { todo: Todo.OsdkInstance }) {
-  const { applyAction, error, isPending } = useOsdkAction($Actions.completeTodo);
+  const { applyAction, error, isPending } = useOsdkAction(completeTodo);
 
   const onClick = async () => {
     try {
@@ -106,13 +107,13 @@ function TodoActionWithErrorHandling({ todo }: { todo: Todo.OsdkInstance }) {
       </button>
 
       {error?.actionValidation && (
-        <div style={{ color: "red" }}>
-          Validation failed: {JSON.stringify(error.actionValidation.validation)}
+        <div className="error">
+          Validation failed: {error.actionValidation.message}
         </div>
       )}
 
       {error?.unknown && (
-        <div style={{ color: "red" }}>
+        <div className="error">
           An unexpected error occurred: {String(error.unknown)}
         </div>
       )}
@@ -128,7 +129,7 @@ function TodoActionWithErrorHandling({ todo }: { todo: Todo.OsdkInstance }) {
 Validate action parameters without executing using `validateAction`.
 
 ```tsx
-import { $Actions } from "@my/osdk";
+import { createTodo } from "@my/osdk";
 import { useOsdkAction } from "@osdk/react/experimental";
 import { useState } from "react";
 
@@ -143,7 +144,7 @@ function TodoForm() {
     validationResult,
     isPending,
     error,
-  } = useOsdkAction($Actions.createTodo);
+  } = useOsdkAction(createTodo);
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newTitle = e.target.value;
@@ -182,20 +183,19 @@ function TodoForm() {
       {isValidating && <span>Validating...</span>}
 
       {validationResult?.result === "INVALID" && (
-        <div style={{ color: "red" }}>
-          Invalid: {JSON.stringify(validationResult)}
-        </div>
+        <div className="error">Invalid: please check required fields</div>
       )}
 
       <button
         type="submit"
-        disabled={isPending || isValidating || validationResult?.result !== "VALID"}
+        disabled={isPending || isValidating
+          || validationResult?.result !== "VALID"}
       >
         Create Todo
       </button>
 
       {error?.actionValidation && (
-        <div style={{ color: "red" }}>
+        <div className="error">
           Validation error: {error.actionValidation.message}
         </div>
       )}
@@ -219,12 +219,12 @@ Key features:
 Apply the same action to multiple items in a single call:
 
 ```tsx
-import { $Actions, Todo } from "@my/osdk";
+import { completeTodo, Todo } from "@my/osdk";
 import { useOsdkAction } from "@osdk/react/experimental";
 import { useCallback } from "react";
 
 function BulkCompleteButton({ todos }: { todos: Todo.OsdkInstance[] }) {
-  const { applyAction, isPending } = useOsdkAction($Actions.completeTodo);
+  const { applyAction, isPending } = useOsdkAction(completeTodo);
 
   const onClick = useCallback(() => {
     applyAction(
@@ -250,13 +250,13 @@ function BulkCompleteButton({ todos }: { todos: Todo.OsdkInstance[] }) {
 Apply changes to the cache immediately while waiting for the server response.
 
 ```tsx
-import { $Actions, Todo } from "@my/osdk";
+import { completeTodo, Todo } from "@my/osdk";
 import { useOsdkAction, useOsdkObject } from "@osdk/react/experimental";
 import { useCallback } from "react";
 
 function TodoView({ todo }: { todo: Todo.OsdkInstance }) {
   const { isLoading, isOptimistic } = useOsdkObject(todo);
-  const { applyAction, error, isPending } = useOsdkAction($Actions.completeTodo);
+  const { applyAction, error, isPending } = useOsdkAction(completeTodo);
 
   const onClick = useCallback(() => {
     applyAction({
@@ -279,7 +279,7 @@ function TodoView({ todo }: { todo: Todo.OsdkInstance }) {
       {isLoading && "(Loading)"}
       {isOptimistic && "(Optimistic)"}
       {error && (
-        <div style={{ color: "red" }}>
+        <div className="error">
           {error.actionValidation?.message ?? String(error.unknown)}
         </div>
       )}
@@ -319,13 +319,14 @@ const updatedTodo = todo.$clone({
   priority: "high",
 });
 ```
+
 :::
 
 ---
 
 ## useDebouncedCallback
 
-*Experimental - import from `@osdk/react/experimental`*
+_Experimental - import from `@osdk/react/experimental`_
 
 Debounce callback functions for auto-save patterns or expensive operations.
 
@@ -363,13 +364,13 @@ function SearchableList({ onSearch }: { onSearch: (query: string) => void }) {
 Combine with actions for auto-saving:
 
 ```tsx
-import { $Actions, Todo } from "@my/osdk";
+import { Todo, updateTodo } from "@my/osdk";
 import { useDebouncedCallback, useOsdkAction } from "@osdk/react/experimental";
 import { useState } from "react";
 
 function AutoSaveTodo({ todo }: { todo: Todo.OsdkInstance }) {
   const [title, setTitle] = useState(todo.title);
-  const { applyAction } = useOsdkAction($Actions.updateTodo);
+  const { applyAction } = useOsdkAction(updateTodo);
 
   const debouncedSave = useDebouncedCallback((newTitle: string) => {
     applyAction({

--- a/docs/react/actions.md
+++ b/docs/react/actions.md
@@ -46,8 +46,8 @@ function TodoView({ todo }: { todo: Todo.OsdkInstance }) {
       </div>
       {error && (
         <div>
-          An error occurred:{" "}
-          {error.actionValidation?.message ?? String(error.unknown)}
+          An error occurred: {error.actionValidation?.message
+            ?? (error.unknown ? String(error.unknown) : "Unknown error")}
         </div>
       )}
     </div>
@@ -280,7 +280,8 @@ function TodoView({ todo }: { todo: Todo.OsdkInstance }) {
       {isOptimistic && "(Optimistic)"}
       {error && (
         <div className="error">
-          {error.actionValidation?.message ?? String(error.unknown)}
+          {error.actionValidation?.message
+            ?? (error.unknown ? String(error.unknown) : "Unknown error")}
         </div>
       )}
     </div>

--- a/docs/react/advanced-queries.md
+++ b/docs/react/advanced-queries.md
@@ -8,24 +8,23 @@ This guide covers advanced querying patterns including useObjectSet, derived pro
 
 ## useObjectSet
 
-*Experimental - import from `@osdk/react/experimental`*
+_Experimental - import from `@osdk/react/experimental`_
 
 Advanced querying with set operations, derived properties, and link traversal.
 
 ### When to Use useObjectSet vs useOsdkObjects
 
-Both hooks support where, orderBy, pagination, withProperties, pivotTo, autoFetchMore, and streamUpdates. Note that `pivotTo` and `streamUpdates` cannot be combined, see the note below.
+Both hooks support filtering, sorting, pagination, derived properties, pivoting, and streaming updates. They differ in their **starting point**.
 
-**Use useOsdkObjects when:**
-- Passing an ObjectType or Interface directly (`Todo`)
+**Use `useOsdkObjects(Type, options)` when** your query starts from an object type or interface — this is most queries.
 
-**Use useObjectSet when:**
-- Starting from an ObjectSet instance (`$(Todo)`)
-- Need set operations (`union`, `intersect`, `subtract`) with other ObjectSets
+**Use `useObjectSet(objectSet, options)` when** you already hold an `ObjectSet` instance you want to observe — typically because:
 
-:::note
-`useOsdkObjects` is in active development to reach full OSDK TypeScript client parity as it has more performance enhancements. `useObjectSet` currently supports everything and should be used if a feature you need isn't present in `useOsdkObjects`. Check the JSDoc for current feature support.
-:::
+- You composed sets with `union` / `intersect` / `subtract`
+- You received an `ObjectSet` from another hook (e.g. `useOsdkObjects(...).objectSet`) and want to observe a transformation of it
+- You need to memoize a complex composed ObjectSet across renders
+
+If both hooks would work, prefer `useOsdkObjects`. Note that `pivotTo` and `streamUpdates` cannot be combined — see the note below.
 
 ```tsx
 import { $, Todo } from "@my/osdk";
@@ -110,23 +109,19 @@ Find objects that exist in all sets:
 import { $, Employee } from "@my/osdk";
 import { useObjectSet } from "@osdk/react/experimental";
 
-function SharedProjects({ employee1, employee2 }: {
-  employee1: Employee.OsdkInstance;
-  employee2: Employee.OsdkInstance;
-}) {
-  const set1 = $(Employee).where({ id: employee1.id });
-  const set2 = $(Employee).where({ id: employee2.id });
+function HighEarningEngineers() {
+  const engineers = $(Employee).where({ department: "Engineering" });
+  const highEarners = $(Employee).where({ salary: { $gte: 150000 } });
 
-  const { data } = useObjectSet(set1, {
-    pivotTo: "projects",
-    intersect: [set2.$pivotTo("projects")],
+  const { data } = useObjectSet(engineers, {
+    intersect: [highEarners],
   });
 
   return (
     <div>
-      <h3>Shared Projects</h3>
-      {data?.map(project => (
-        <div key={project.$primaryKey}>{project.name}</div>
+      <h3>Engineers earning over $150k</h3>
+      {data?.map(employee => (
+        <div key={employee.$primaryKey}>{employee.fullName}</div>
       ))}
     </div>
   );
@@ -165,8 +160,8 @@ function ComplexTodoQuery() {
   const completedTodos = $(Todo).where({ isComplete: true });
 
   const { data } = useObjectSet(highPriorityTodos, {
-    union: [urgentTodos],        // High priority OR urgent
-    subtract: [completedTodos],  // But not completed
+    union: [urgentTodos], // High priority OR urgent
+    subtract: [completedTodos], // But not completed
   });
 
   return <div>High priority or urgent (but not completed): {data?.length}</div>;
@@ -181,7 +176,9 @@ Navigate to linked objects:
 import { $, Employee } from "@my/osdk";
 import { useObjectSet } from "@osdk/react/experimental";
 
-function EmployeeDepartments({ employee }: { employee: Employee.OsdkInstance }) {
+function EmployeeDepartments(
+  { employee }: { employee: Employee.OsdkInstance },
+) {
   const employeeSet = $(Employee).where({ id: employee.id });
 
   const { data } = useObjectSet(employeeSet, {
@@ -204,8 +201,8 @@ import { useObjectSet } from "@osdk/react/experimental";
 
 const { data, isLoading } = useObjectSet($(Todo), {
   where: { isComplete: false },
-  autoFetchMore: 200,     // Fetch at least 200 items
-  streamUpdates: true,    // Real-time WebSocket updates
+  autoFetchMore: 200, // Fetch at least 200 items
+  streamUpdates: true, // Real-time WebSocket updates
 });
 ```
 
@@ -217,18 +214,19 @@ still fetch data normally but won't receive real-time updates.
 
 ### All Options
 
-- `where` - Filter objects
-- `withProperties` - Add derived/computed properties
-- `union` - Combine with other ObjectSets
-- `intersect` - Find common objects with other ObjectSets
-- `subtract` - Remove objects that exist in other ObjectSets
-- `pivotTo` - Traverse to linked objects (changes result type). Cannot be combined with `streamUpdates`.
-- `pageSize` - Number of objects per page
-- `orderBy` - Sort order
-- `dedupeIntervalMs` - Minimum time between re-fetches (default: 2000ms)
-- `streamUpdates` - Enable real-time websocket updates (default: false). Cannot be combined with `pivotTo`.
-- `autoFetchMore` - Auto-fetch additional pages
-- `enabled` - Enable/disable the query
+- `where` — Filter objects
+- `withProperties` — Add derived/computed properties
+- `$select` — Restrict which properties are returned for each object
+- `union` — Combine with other ObjectSets
+- `intersect` — Find common objects with other ObjectSets
+- `subtract` — Remove objects that exist in other ObjectSets
+- `pivotTo` — Traverse to linked objects (changes result type). Cannot be combined with `streamUpdates`.
+- `pageSize` — Number of objects per page
+- `orderBy` — Sort order
+- `dedupeIntervalMs` — Minimum time between re-fetches (default: 2000ms)
+- `streamUpdates` — Enable real-time websocket updates (default: false). Cannot be combined with `pivotTo` or `withProperties`.
+- `autoFetchMore` — Auto-fetch additional pages
+- `enabled` — Enable/disable the query
 
 ### Return Values
 
@@ -242,7 +240,7 @@ still fetch data normally but won't receive real-time updates.
 
 ## Derived Properties
 
-*Available in both useOsdkObjects and useObjectSet*
+_Available in both useOsdkObjects and useObjectSet_
 
 Add computed properties calculated server-side using the builder pattern.
 
@@ -251,8 +249,8 @@ Add computed properties calculated server-side using the builder pattern.
 Derived properties use a builder function that receives a `DerivedProperty.Builder`:
 
 ```tsx
-import type { DerivedProperty } from "@osdk/client";
 import { Employee } from "@my/osdk";
+import type { DerivedProperty } from "@osdk/client";
 import { useOsdkObjects } from "@osdk/react/experimental";
 
 const { data } = useOsdkObjects(Employee, {
@@ -273,10 +271,19 @@ const { data } = useOsdkObjects(Employee, {
 
 The builder provides these methods:
 
-- `.pivotTo(linkName)` - Navigate to linked objects
-- `.selectProperty(propertyName)` - Select a property value
-- `.aggregate(aggregation)` - Aggregate values (`"$count"`, `"propertyName:$avg"`, etc.)
-- `.where(clause)` - Filter before aggregating
+- `.pivotTo(linkName)` — Navigate to linked objects
+- `.selectProperty(propertyName)` — Select a property value
+- `.aggregate(specifier)` — Aggregate values; specifier is `"$count"` or `"propertyName:metric"` (see [Aggregation Syntax](#aggregation-syntax) for the full list)
+- `.where(clause)` — Filter before aggregating
+- `.constant.{double|integer|long|datetime|timestamp}(value)` — Lift a literal into the builder
+
+#### What does `DerivedProperty.Builder<Employee, false>` mean?
+
+The second type parameter is `CONSTRAINED extends boolean`. At the top level it is `false`, meaning the builder can navigate links and select properties freely. Pivoting through a one-to-many link returns a _constrained_ builder (`true`) that must call `.aggregate()` rather than `.selectProperty()`, because there is no single value to select. In practice you can drop the annotation entirely and let inference do the work — TypeScript flips the flag for you as you chain.
+
+#### When an aggregate has no data
+
+For numeric aggregates (`sum`, `avg`, `min`, `max`) over an empty result set, the property resolves to `null` rather than a number. `$count` resolves to `0`. Plan your UI for these cases when filtering can produce empty groups.
 
 ### Advanced Examples
 
@@ -292,11 +299,9 @@ const { data } = useOsdkObjects(Employee, {
         .pivotTo("reports")
         .aggregate("$count"),
 
-    // Aggregate a specific property
+    // Aggregate a specific property — `propertyName:metric` keys
     avgReportSalary: (base: DerivedProperty.Builder<Employee, false>) =>
-      base.pivotTo("reports")
-        .selectProperty("salary")
-        .aggregate("$avg"),
+      base.pivotTo("reports").aggregate("salary:avg"),
   },
 });
 ```
@@ -324,7 +329,7 @@ const { data } = useOsdkObjects(Employee, {
 
 ## useOsdkFunction
 
-*Experimental - import from `@osdk/react/experimental`*
+_Experimental - import from `@osdk/react/experimental`_
 
 Execute and observe functions with request deduplication and configurable dependency tracking for automatic refetching.
 
@@ -466,7 +471,7 @@ function ConditionalReport({ employeeId }: { employeeId: string }) {
 
 ## useOsdkAggregation
 
-*Experimental - import from `@osdk/react/experimental`*
+_Experimental - import from `@osdk/react/experimental`_
 
 Server-side grouping and aggregation.
 
@@ -574,6 +579,7 @@ function HighPriorityStats() {
 The `$select` object uses a special key format where each key is a metric and each value is an ordering directive (`"unordered"`, `"asc"`, or `"desc"`). When using `$groupBy`, the ordering determines the order results are returned.
 
 **Key formats:**
+
 - `$count` - Count of objects
 - `"propertyName:sum"` - Sum of a numeric property
 - `"propertyName:avg"` - Average of a numeric property
@@ -602,7 +608,7 @@ The `$select` object uses a special key format where each key is a metric and ea
 
 ## useOsdkMetadata
 
-*Stable - import from `@osdk/react`*
+_Stable - import from `@osdk/react`_
 
 Fetch metadata about object types or interfaces.
 

--- a/docs/react/advanced-queries.md
+++ b/docs/react/advanced-queries.md
@@ -14,17 +14,16 @@ Advanced querying with set operations, derived properties, and link traversal.
 
 ### When to Use useObjectSet vs useOsdkObjects
 
-Both hooks support filtering, sorting, pagination, derived properties, pivoting, and streaming updates. They differ in their **starting point**.
+Prefer `useOsdkObjects` when both hooks would work. Both support filtering, sorting, pagination, derived properties, pivoting, and streaming updates — they differ in their **starting point**.
 
-**Use `useOsdkObjects(Type, options)` when** your query starts from an object type or interface — this is most queries.
+**Use `useOsdkObjects(Type, options)`** when your query starts from an object type or interface.
 
-**Use `useObjectSet(objectSet, options)` when** you already hold an `ObjectSet` instance you want to observe — typically because:
+**Use `useObjectSet(objectSet, options)`** when you already hold an `ObjectSet` instance you want to observe — typically because:
 
 - You composed sets with `union` / `intersect` / `subtract`
 - You received an `ObjectSet` from another hook (e.g. `useOsdkObjects(...).objectSet`) and want to observe a transformation of it
-- You need to memoize a complex composed ObjectSet across renders
 
-If both hooks would work, prefer `useOsdkObjects`. Note that `pivotTo` and `streamUpdates` cannot be combined — see the note below.
+Note that `pivotTo` and `streamUpdates` cannot be combined — see the note below.
 
 ```tsx
 import { $, Todo } from "@my/osdk";
@@ -279,7 +278,7 @@ The builder provides these methods:
 
 #### What does `DerivedProperty.Builder<Employee, false>` mean?
 
-The second type parameter is `CONSTRAINED extends boolean`. At the top level it is `false`, meaning the builder can navigate links and select properties freely. Pivoting through a one-to-many link returns a _constrained_ builder (`true`) that must call `.aggregate()` rather than `.selectProperty()`, because there is no single value to select. In practice you can drop the annotation entirely and let inference do the work — TypeScript flips the flag for you as you chain.
+You usually don't need this annotation — TypeScript infers it. The flag flips from `false` to `true` after pivoting through a one-to-many link, where you must call `.aggregate()` instead of `.selectProperty()` because there's no single value to select.
 
 #### When an aggregate has no data
 

--- a/docs/react/advanced-queries.md
+++ b/docs/react/advanced-queries.md
@@ -105,23 +105,21 @@ function CombinedTodoQuery() {
 Find objects that exist in all sets:
 
 ```tsx
-import { $, Employee } from "@my/osdk";
+import { $, Todo } from "@my/osdk";
 import { useObjectSet } from "@osdk/react/experimental";
 
-function HighEarningEngineers() {
-  const engineers = $(Employee).where({ department: "Engineering" });
-  const highEarners = $(Employee).where({ salary: { $gte: 150000 } });
+function StarredAndIncompleteTodos() {
+  const starred = $(Todo).where({ isStarred: true });
+  const incomplete = $(Todo).where({ isComplete: false });
 
-  const { data } = useObjectSet(engineers, {
-    intersect: [highEarners],
+  const { data } = useObjectSet(starred, {
+    intersect: [incomplete],
   });
 
   return (
     <div>
-      <h3>Engineers earning over $150k</h3>
-      {data?.map(employee => (
-        <div key={employee.$primaryKey}>{employee.fullName}</div>
-      ))}
+      <h3>Starred todos that are still open</h3>
+      {data?.map(todo => <div key={todo.$primaryKey}>{todo.title}</div>)}
     </div>
   );
 }

--- a/docs/react/cache-management.md
+++ b/docs/react/cache-management.md
@@ -6,18 +6,46 @@ sidebar_position: 5
 
 This guide covers how the OSDK React cache system works and how to manually control it.
 
+:::info Single source of truth
+We recommend using the OSDK React cache as the **only** source of truth for OSDK data in your app. Mixing it with another cache (Redux, TanStack Query, component state) makes invalidation and optimistic updates hard to reason about, because two systems must stay in sync.
+:::
+
+## Why use @osdk/react?
+
+You can call the OSDK client directly from event handlers or roll your own TanStack Query / SWR layer — but `@osdk/react` is purpose-built for OSDK and gives you behavior that is hard to reproduce by hand:
+
+- **Normalized object cache.** Every `Todo:1` is stored once. When an action edits it, every list, link, and detail view referencing it updates in lock-step — no manual key invalidation.
+- **Action-driven invalidation.** Action responses tell the cache exactly which objects were added, modified, or deleted. Lists are re-evaluated against their `where` clauses automatically.
+- **Optimistic updates with rollback.** `$optimisticUpdate` layers your changes on top of the truth layer; on failure they are removed without bookkeeping.
+- **Real-time via WebSockets.** `streamUpdates: true` keeps lists current without polling.
+- **Function dependency tracking.** Functions declare `dependsOn` / `dependsOnObjects` and re-run when those objects change.
+
+If you build your own cache, you re-implement all of the above and diverge from the model OSDK actions assume.
+
 ## How the Cache Works
 
 The `OsdkProvider2` creates an `ObservableClient` that maintains a normalized cache of all queries and their results.
 
 ### What Gets Cached
 
-| Data Type | Cache Key Based On |
-|-----------|-------------------|
-| **Objects** | Object type + primary key |
-| **Lists** | Object type + where clause + orderBy |
-| **Links** | Source object + link name + filters |
-| **Aggregations** | Object type + where clause + aggregate definition |
+| Data Type            | Cache Key Based On                                                       |
+| -------------------- | ------------------------------------------------------------------------ |
+| **Objects**          | Object type + primary key                                                |
+| **Lists**            | Object type + where clause + orderBy                                     |
+| **ObjectSets**       | Base object type + transforms (where, withProperties, pivotTo, set ops)  |
+| **Links**            | Source object + link name + filters                                      |
+| **Aggregations**     | Object type + where clause + aggregate definition (+ optional ObjectSet) |
+| **Function queries** | Function apiName + canonicalized parameters                              |
+| **Media metadata**   | Object instance + media property name                                    |
+
+Per-property security metadata is loaded alongside objects when `$loadPropertySecurityMetadata: true` is passed to `useOsdkObject` / `useOsdkObjects`.
+
+### How the cache stays in sync
+
+- **Action responses.** When an action completes, the response specifies added / modified / deleted objects. The cache applies those changes and re-evaluates lists against their where clauses.
+- **`streamUpdates: true`.** Opens a WebSocket subscription for the matching list. Updates are pushed sub-second and applied to the cache. Not available for queries that use `pivotTo` or `withProperties`.
+- **Function dependencies.** Functions registered with `dependsOn` (object types) or `dependsOnObjects` (instances) are automatically re-fetched when matching objects change after an action.
+- **Reference counting.** Cache entries are released when the last subscriber unmounts; data shared across components is not re-fetched.
 
 ### Cache Sharing
 
@@ -58,7 +86,7 @@ With `$optimisticUpdate`:
 
 ### Real-time Updates
 
-With `streamUpdates: true`, the cache receives WebSocket updates and applies them automatically.
+With `streamUpdates: true`, the cache receives WebSocket updates and applies them automatically. Not available for queries that use `pivotTo` or `withProperties`.
 
 ## When Manual Invalidation is Needed
 
@@ -73,7 +101,7 @@ The `ObservableClient` provides methods to manually invalidate cached data.
 
 ### Setup
 
-To use invalidation methods, create an `ObservableClient` and pass it to `OsdkProvider2`:
+`OsdkProvider2` creates its own `ObservableClient` internally — you only need to construct one yourself if you want to call invalidation methods (`invalidateObjects`, `invalidateObjectType`, `invalidateFunction`, …) from outside the React tree (for example, from a WebSocket handler in `client.ts`). In that case, create one and pass it explicitly so React and your handler share the same cache:
 
 ```tsx
 // client.ts
@@ -110,24 +138,24 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
 
 #### Object Invalidation
 
-| Method | Effect | Use Case |
-|--------|--------|----------|
-| `invalidateObjects([obj1, obj2])` | Re-fetches specific objects | You know exactly which objects are stale |
-| `invalidateObjectType(Todo)` | Re-fetches all objects and lists of that type | External bulk update |
-| `invalidateAll()` | Re-fetches everything | Last resort |
+| Method                            | Effect                                        | Use Case                                 |
+| --------------------------------- | --------------------------------------------- | ---------------------------------------- |
+| `invalidateObjects([obj1, obj2])` | Re-fetches specific objects                   | You know exactly which objects are stale |
+| `invalidateObjectType(Todo)`      | Re-fetches all objects and lists of that type | External bulk update                     |
+| `invalidateAll()`                 | Re-fetches everything                         | Last resort                              |
 
 #### Function Invalidation
 
-| Method | Effect | Use Case |
-|--------|--------|----------|
-| `invalidateFunction(queryDef, params)` | Re-fetches a specific function query | You know which function call is stale |
-| `invalidateFunction(queryDef)` | Re-fetches ALL queries for that function | External change affecting all calls |
-| `invalidateFunctionsByObject(apiName, pk)` | Re-fetches functions depending on a specific object | Object changed outside action flow |
+| Method                                     | Effect                                              | Use Case                              |
+| ------------------------------------------ | --------------------------------------------------- | ------------------------------------- |
+| `invalidateFunction(queryDef, params)`     | Re-fetches a specific function query                | You know which function call is stale |
+| `invalidateFunction(queryDef)`             | Re-fetches ALL queries for that function            | External change affecting all calls   |
+| `invalidateFunctionsByObject(apiName, pk)` | Re-fetches functions depending on a specific object | Object changed outside action flow    |
 
 ### Usage
 
 ```tsx
-import { Todo, getEmployeeMetrics } from "@my/osdk";
+import { getEmployeeMetrics, Todo } from "@my/osdk";
 import { observableClient } from "./client";
 
 // Invalidate specific objects
@@ -137,7 +165,9 @@ await observableClient.invalidateObjects([todo1, todo2]);
 await observableClient.invalidateObjectType(Todo);
 
 // Invalidate a specific function query
-await observableClient.invalidateFunction(getEmployeeMetrics, { departmentId: "sales" });
+await observableClient.invalidateFunction(getEmployeeMetrics, {
+  departmentId: "sales",
+});
 
 // Invalidate ALL queries for a function
 await observableClient.invalidateFunction(getEmployeeMetrics);
@@ -171,7 +201,10 @@ const { data } = useOsdkFunction(getEmployeeReport, {
 });
 
 // You can invalidate it by calling:
-await observableClient.invalidateFunctionsByObject("Employee", employee.$primaryKey);
+await observableClient.invalidateFunctionsByObject(
+  "Employee",
+  employee.$primaryKey,
+);
 ```
 
 This is useful when you know a specific object has changed outside of the normal action flow.
@@ -179,12 +212,12 @@ This is useful when you know a specific object has changed outside of the normal
 ## Cache with Optimistic Updates
 
 ```tsx
-import { $Actions, Todo } from "@my/osdk";
+import { completeTodo, Todo } from "@my/osdk";
 import { useOsdkAction, useOsdkObject } from "@osdk/react/experimental";
 
 function TodoView({ todo }: { todo: Todo.OsdkInstance }) {
   const { isOptimistic } = useOsdkObject(todo);
-  const { applyAction } = useOsdkAction($Actions.completeTodo);
+  const { applyAction } = useOsdkAction(completeTodo);
 
   const handleComplete = () => {
     applyAction({
@@ -208,6 +241,9 @@ function TodoView({ todo }: { todo: Todo.OsdkInstance }) {
 
 ## Best Practices
 
-1. **Be specific**: Use `invalidateObjects` when you know what data specifically changed
-2. **Use type-level invalidation**: `invalidateObjectType` for external bulk changes
-3. **Avoid multiple sources of truth**: Coordinating side effects between multiple systems is tricky; we recommend solely using the OSDK React cache when possible for data loading
+1. **Reuse query parameters.** Two components that pass identical `where` / `orderBy` / `withProperties` share one cache entry. Hoist the parameter object to a module-level constant or memoize it so React doesn't construct a new one each render.
+2. **Prefer object-level invalidation.** `invalidateObjects([todo])` is cheaper than `invalidateObjectType(Todo)`, which is cheaper than `invalidateAll()`. Reach for the broadest only when you cannot identify the affected rows.
+3. **Let actions drive invalidation.** If the change comes from an OSDK action, the cache updates automatically — do not call `invalidate*` afterward. Manual invalidation is for changes that bypass the action flow (external system, scheduled job, direct REST call).
+4. **Use `dependsOn` / `dependsOnObjects` on functions.** Declare what your function reads so the cache can re-run it after relevant actions, instead of invalidating it manually.
+5. **Avoid second sources of truth.** Don't copy OSDK data into Redux, TanStack Query, or local component state — you'll fight optimistic updates and lose normalization.
+6. **Don't `invalidateAll()` on mount.** That defeats caching and triggers a full refetch every time the component tree mounts. If you need a fresh load, scope it to a specific type.

--- a/docs/react/cache-management.md
+++ b/docs/react/cache-management.md
@@ -14,9 +14,7 @@ This guide covers how the OSDK React cache system works and how to manually cont
 - **Action-driven invalidation.** Action responses specify which objects were added, modified, or deleted. Lists are re-evaluated against their `where` clauses without manual invalidation.
 - **Optimistic updates with rollback.** `$optimisticUpdate` layers your changes on top of the truth layer; on failure they're rolled back.
 - **Real-time updates.** `streamUpdates: true` keeps lists current via WebSocket without polling.
-- **Function dependency tracking.** Functions declare `dependsOn` / `dependsOnObjects` and re-run when those objects change.
-
-Action responses also assume the OSDK cache, so a bring-your-own cache will fight the action flow.
+- **Function dependency tracking with `useOsdkFunction`.** Pass `dependsOn: [ObjectType]` to refetch when any object of that type changes, or `dependsOnObjects: [instance]` to refetch only when specific instances change. The cache wires the dependencies so your function reruns automatically after relevant actions.
 
 ## How the Cache Works
 
@@ -32,16 +30,8 @@ The `OsdkProvider2` creates an `ObservableClient` that maintains a normalized ca
 | **Links**            | Source object + link name + filters                                      |
 | **Aggregations**     | Object type + where clause + aggregate definition (+ optional ObjectSet) |
 | **Function queries** | Function apiName + canonicalized parameters                              |
-| **Media metadata**   | Object instance + media property name                                    |
 
 Per-property security metadata is loaded alongside objects when `$loadPropertySecurityMetadata: true` is passed to `useOsdkObject` / `useOsdkObjects`.
-
-### How the cache stays in sync
-
-- **Action responses.** When an action completes, the response specifies added / modified / deleted objects. The cache applies those changes and re-evaluates lists against their where clauses.
-- **`streamUpdates: true`.** Opens a WebSocket subscription for the matching list and applies updates as the server emits them. Not available for queries that use `pivotTo` or `withProperties`.
-- **Function dependencies.** Functions registered with `dependsOn` (object types) or `dependsOnObjects` (instances) are automatically re-fetched when matching objects change after an action.
-- **Reference counting.** Cache entries are released when the last subscriber unmounts; data shared across components is not re-fetched.
 
 ### Cache Sharing
 

--- a/docs/react/cache-management.md
+++ b/docs/react/cache-management.md
@@ -6,21 +6,17 @@ sidebar_position: 5
 
 This guide covers how the OSDK React cache system works and how to manually control it.
 
-:::info Single source of truth
-We recommend using the OSDK React cache as the **only** source of truth for OSDK data in your app. Mixing it with another cache (Redux, TanStack Query, component state) makes invalidation and optimistic updates hard to reason about, because two systems must stay in sync.
-:::
-
 ## Why use @osdk/react?
 
-You can call the OSDK client directly from event handlers or roll your own TanStack Query / SWR layer — but `@osdk/react` is purpose-built for OSDK and gives you behavior that is hard to reproduce by hand:
+`@osdk/react` gives you behavior that is hard to reproduce with a generic data layer like TanStack Query:
 
-- **Normalized object cache.** Every `Todo:1` is stored once. When an action edits it, every list, link, and detail view referencing it updates in lock-step — no manual key invalidation.
-- **Action-driven invalidation.** Action responses tell the cache exactly which objects were added, modified, or deleted. Lists are re-evaluated against their `where` clauses automatically.
-- **Optimistic updates with rollback.** `$optimisticUpdate` layers your changes on top of the truth layer; on failure they are removed without bookkeeping.
-- **Real-time via WebSockets.** `streamUpdates: true` keeps lists current without polling.
+- **Normalized object cache.** Every `Todo:1` is stored once. When an action edits it, every list, link, and detail view referencing it updates automatically.
+- **Action-driven invalidation.** Action responses specify which objects were added, modified, or deleted. Lists are re-evaluated against their `where` clauses without manual invalidation.
+- **Optimistic updates with rollback.** `$optimisticUpdate` layers your changes on top of the truth layer; on failure they're rolled back.
+- **Real-time updates.** `streamUpdates: true` keeps lists current via WebSocket without polling.
 - **Function dependency tracking.** Functions declare `dependsOn` / `dependsOnObjects` and re-run when those objects change.
 
-If you build your own cache, you re-implement all of the above and diverge from the model OSDK actions assume.
+Action responses also assume the OSDK cache, so a bring-your-own cache will fight the action flow.
 
 ## How the Cache Works
 
@@ -43,7 +39,7 @@ Per-property security metadata is loaded alongside objects when `$loadPropertySe
 ### How the cache stays in sync
 
 - **Action responses.** When an action completes, the response specifies added / modified / deleted objects. The cache applies those changes and re-evaluates lists against their where clauses.
-- **`streamUpdates: true`.** Opens a WebSocket subscription for the matching list. Updates are pushed sub-second and applied to the cache. Not available for queries that use `pivotTo` or `withProperties`.
+- **`streamUpdates: true`.** Opens a WebSocket subscription for the matching list and applies updates as the server emits them. Not available for queries that use `pivotTo` or `withProperties`.
 - **Function dependencies.** Functions registered with `dependsOn` (object types) or `dependsOnObjects` (instances) are automatically re-fetched when matching objects change after an action.
 - **Reference counting.** Cache entries are released when the last subscriber unmounts; data shared across components is not re-fetched.
 

--- a/docs/react/getting-started.md
+++ b/docs/react/getting-started.md
@@ -194,7 +194,8 @@ function CompleteTodoButton({ todo }: { todo: Todo.OsdkInstance }) {
       </button>
       {error && (
         <div>
-          Error: {error.actionValidation?.message ?? String(error.unknown)}
+          Error: {error.actionValidation?.message
+            ?? (error.unknown ? String(error.unknown) : "Unknown error")}
         </div>
       )}
     </div>

--- a/docs/react/getting-started.md
+++ b/docs/react/getting-started.md
@@ -30,6 +30,7 @@ All `@osdk/*` packages must use **compatible versions**. Mismatched versions (e.
   }
 }
 ```
+
 :::
 
 You can find the latest versions on npm:
@@ -66,9 +67,9 @@ If you haven't generated an SDK yet:
 | ----------------- | --------------------------- | --------------------------------------------- |
 | **Use when**      | You only need client access | You want reactive data hooks (most apps)      |
 | **Features**      | Client provider, metadata   | Queries, actions, caching, optimistic updates |
-| **API stability** | Stable                      | APIs may change between releases              |
+| **API stability** | Stable                      | Surface may evolve before promotion           |
 
-**We recommend starting with experimental.** The "experimental" label indicates the API surface may evolve, not that the features are unstable or buggy. Most applications benefit from the reactive hooks, automatic caching, and optimistic update support.
+**We recommend starting with experimental.** Despite the label, the hooks are production-ready and where new development is happening. They live under `/experimental` because the surface may still evolve before being promoted to `@osdk/react`.
 
 ### Stable Features (`@osdk/react`)
 
@@ -100,7 +101,7 @@ Stable exports (use with `OsdkProvider`):
 For reactive data management, cache, and optimistic updates.
 
 :::tip About Experimental Hooks
-The hooks in `@osdk/react/experimental` are production-ready and recommended for new projects. They are labeled "experimental" because they represent a newer architecture that is under active development. Once stabilized, these hooks will be promoted to the main `@osdk/react` package.
+The hooks in `@osdk/react/experimental` are production-ready and where new development is happening. The "experimental" label means the API surface may still evolve before being promoted to `@osdk/react`; it does not mean the features are unstable. New apps should use these hooks.
 :::
 
 ```tsx
@@ -160,7 +161,7 @@ function TodoList() {
   }
 
   if (error) {
-    return <div>Error: {JSON.stringify(error)}</div>;
+    return <div>Error: {error.message}</div>;
   }
 
   return (
@@ -176,13 +177,11 @@ See [Querying Data](/react/querying-data) for filtering, pagination, real-time u
 ## First Action
 
 ```tsx
-import { $Actions, Todo } from "@my/osdk";
+import { completeTodo, Todo } from "@my/osdk";
 import { useOsdkAction } from "@osdk/react/experimental";
 
 function CompleteTodoButton({ todo }: { todo: Todo.OsdkInstance }) {
-  const { applyAction, isPending, error } = useOsdkAction(
-    $Actions.completeTodo,
-  );
+  const { applyAction, isPending, error } = useOsdkAction(completeTodo);
 
   const handleClick = () => {
     applyAction({ todo, isComplete: true });
@@ -193,7 +192,11 @@ function CompleteTodoButton({ todo }: { todo: Todo.OsdkInstance }) {
       <button onClick={handleClick} disabled={isPending}>
         {isPending ? "Saving..." : "Complete"}
       </button>
-      {error && <div>Error: {JSON.stringify(error)}</div>}
+      {error && (
+        <div>
+          Error: {error.actionValidation?.message ?? String(error.unknown)}
+        </div>
+      )}
     </div>
   );
 }

--- a/docs/react/platform-apis.md
+++ b/docs/react/platform-apis.md
@@ -6,6 +6,37 @@ sidebar_position: 6
 
 This guide covers available platform APIs that can used with OSDK React hooks.
 
+## Handling errors with PalantirApiError
+
+All platform-API hooks return errors as plain `Error` instances; when the failure originates from a Foundry API call, the error is a `PalantirApiError` (re-exported from `@osdk/client`). Narrow with `instanceof` to access the structured fields:
+
+| Field              | Type     | Use                                                 |
+| ------------------ | -------- | --------------------------------------------------- |
+| `errorName`        | `string` | Stable machine identifier (e.g. `UserNotFound`)     |
+| `errorCode`        | `string` | HTTP-style code (e.g. `NOT_FOUND`)                  |
+| `errorDescription` | `string` | Human-readable message                              |
+| `statusCode`       | `number` | HTTP status                                         |
+| `errorInstanceId`  | `string` | Server-side correlation ID — include in bug reports |
+| `parameters`       | `object` | Server-supplied context (e.g. `{ userId }`)         |
+
+Switch on `errorName` for branching behavior; show `errorInstanceId` to support engineers when surfacing an opaque failure.
+
+```tsx
+import { PalantirApiError } from "@osdk/client";
+
+function describe(error: Error): string {
+  if (!(error instanceof PalantirApiError)) {
+    return error.message;
+  }
+  if (error.errorName === "UserNotFound") {
+    return "We couldn't find that user.";
+  }
+  return `${error.errorDescription} (id: ${error.errorInstanceId})`;
+}
+```
+
+---
+
 ## useFoundryUser
 
 Retrieves a specific Foundry user by their user ID.

--- a/docs/react/platform-apis.md
+++ b/docs/react/platform-apis.md
@@ -8,16 +8,16 @@ This guide covers available platform APIs that can used with OSDK React hooks.
 
 ## Handling errors with PalantirApiError
 
-All platform-API hooks return errors as plain `Error` instances; when the failure originates from a Foundry API call, the error is a `PalantirApiError` (re-exported from `@osdk/client`). Narrow with `instanceof` to access the structured fields:
+All platform-API hooks return errors as plain `Error` instances; when the failure originates from a Foundry API call, the error is a `PalantirApiError` (re-exported from `@osdk/client`). Narrow with `instanceof` to access the structured fields. All fields below are optional — narrow before you use them:
 
-| Field              | Type     | Use                                                 |
-| ------------------ | -------- | --------------------------------------------------- |
-| `errorName`        | `string` | Stable machine identifier (e.g. `UserNotFound`)     |
-| `errorCode`        | `string` | HTTP-style code (e.g. `NOT_FOUND`)                  |
-| `errorDescription` | `string` | Human-readable message                              |
-| `statusCode`       | `number` | HTTP status                                         |
-| `errorInstanceId`  | `string` | Server-side correlation ID — include in bug reports |
-| `parameters`       | `object` | Server-supplied context (e.g. `{ userId }`)         |
+| Field              | Type      | Use                                                 |
+| ------------------ | --------- | --------------------------------------------------- |
+| `errorName`        | `string?` | Stable machine identifier (e.g. `UserNotFound`)     |
+| `errorCode`        | `string?` | HTTP-style code (e.g. `NOT_FOUND`)                  |
+| `errorDescription` | `string?` | Human-readable message                              |
+| `statusCode`       | `number?` | HTTP status                                         |
+| `errorInstanceId`  | `string?` | Server-side correlation ID — include in bug reports |
+| `parameters`       | `object?` | Server-supplied context (e.g. `{ userId }`)         |
 
 Switch on `errorName` for branching behavior; show `errorInstanceId` to support engineers when surfacing an opaque failure.
 

--- a/docs/react/querying-data.md
+++ b/docs/react/querying-data.md
@@ -8,7 +8,7 @@ This guide covers all the ways to fetch data from the server using OSDK React ho
 
 ## useOsdkObjects
 
-*Experimental - import from `@osdk/react/experimental`*
+_Experimental - import from `@osdk/react/experimental`_
 
 Retrieve and observe collections of objects with automatic cache management.
 
@@ -45,11 +45,15 @@ function TodoList() {
 
 ### Return Values
 
-- `data` - Array of objects matching the query (undefined while initially loading)
-- `isLoading` - True while fetching data from server (can be true while `data` exists during revalidation)
-- `isOptimistic` - True if the list order is affected by optimistic updates (see note below)
-- `fetchMore` - Function to load next page (undefined when no more pages available)
-- `error` - Error object if fetch failed
+- `data` — Array of objects matching the query (undefined while initially loading)
+- `isLoading` — True while fetching data from server (can be true while `data` exists during revalidation)
+- `isOptimistic` — True if the list order is affected by optimistic updates (see note below)
+- `fetchMore` — Function to load next page (undefined when no more pages available)
+- `hasMore` — True if more pages can be fetched
+- `totalCount` — Total count of matching objects, when available from the API
+- `objectSet` — The transformed `ObjectSet` after pivots / set ops; useful as input to a subsequent `useObjectSet` or `useOsdkAggregation`
+- `refetch` — Function to manually invalidate this object type and refetch
+- `error` — Error object if fetch failed
 
 :::note About isOptimistic
 `isOptimistic` refers to whether the **ordered list of objects** (considering only primary keys) is optimistic. To check if individual object contents are optimistic, use `useOsdkObject` on each object.
@@ -94,6 +98,10 @@ const { data, isLoading } = useOsdkObjects(Todo, {
 
 OSDK provides several text search operators for string properties. Understanding the differences helps you choose the right one for your use case.
 
+:::warning Term matching, not substring
+`$containsAnyTerm`, `$containsAllTerms`, and `$containsAllTermsInOrder` match whole tokens against the indexed text. Searching for `"iel"` will **not** match `"Daniel"` — the token in the index is `Daniel`. For prefix matching use `$startsWith`; for arbitrary substrings, filter client-side or model the data differently. Tokenization rules (case-folding, stemming, punctuation handling) come from the property's search-index configuration in the ontology.
+:::
+
 #### `$startsWith`
 
 Matches strings that begin with the specified prefix.
@@ -121,7 +129,9 @@ With fuzzy matching enabled, minor typos are tolerated:
 
 ```ts
 const { data } = useOsdkObjects(Article, {
-  where: { content: { $containsAnyTerm: { term: "react", fuzzySearch: true } } },
+  where: {
+    content: { $containsAnyTerm: { term: "react", fuzzySearch: true } },
+  },
 });
 // Fuzzy matching handles common typos automatically
 ```
@@ -143,7 +153,9 @@ With fuzzy matching:
 
 ```ts
 const { data } = useOsdkObjects(Article, {
-  where: { content: { $containsAllTerms: { term: "react hooks", fuzzySearch: true } } },
+  where: {
+    content: { $containsAllTerms: { term: "react hooks", fuzzySearch: true } },
+  },
 });
 ```
 
@@ -161,12 +173,14 @@ const { data } = useOsdkObjects(Document, {
 
 #### Search Filter Comparison
 
-| Filter | Match Requirement | Use Case |
-|--------|-------------------|----------|
-| `$startsWith` | Begins with prefix | Autocomplete, prefix search |
-| `$containsAnyTerm` | Any term present | Broad keyword search |
-| `$containsAllTerms` | All terms present (any order) | Precise multi-keyword search |
-| `$containsAllTermsInOrder` | All terms in exact order | Phrase/exact match search |
+| Filter                     | Match Requirement             | Fuzzy | Use Case                     |
+| -------------------------- | ----------------------------- | ----- | ---------------------------- |
+| `$startsWith`              | Begins with prefix            | no    | Autocomplete, prefix search  |
+| `$containsAnyTerm`         | Any term present              | yes   | Broad keyword search         |
+| `$containsAllTerms`        | All terms present (any order) | yes   | Precise multi-keyword search |
+| `$containsAllTermsInOrder` | All terms in exact order      | no    | Phrase / exact match search  |
+
+Fuzzy search is unavailable for `$containsAllTermsInOrder` because phrase matching requires exact token order.
 
 #### Search Example: Building a Search Box
 
@@ -180,7 +194,9 @@ function ArticleSearch() {
 
   const { data, isLoading } = useOsdkObjects(Article, {
     where: searchQuery
-      ? { title: { $containsAnyTerm: { term: searchQuery, fuzzySearch: true } } }
+      ? {
+        title: { $containsAnyTerm: { term: searchQuery, fuzzySearch: true } },
+      }
       : undefined,
     enabled: searchQuery.length >= 2,
   });
@@ -317,7 +333,11 @@ function LiveTodoList() {
       {data?.map(todo => (
         <div key={todo.$primaryKey}>
           <span>{todo.title}</span>
-          {isLoading && <span style={{ fontSize: "0.8em" }}>(Updating...)</span>}
+          {isLoading && (
+            <span style={{ fontSize: "0.8em" }}>
+              (Updating...)
+            </span>
+          )}
         </div>
       ))}
     </div>
@@ -325,10 +345,15 @@ function LiveTodoList() {
 }
 ```
 
-:::note
-`streamUpdates` cannot be used together with `pivotTo`. The server does not support
-websocket subscriptions for link-traversal queries. Queries using `pivotTo` will
-still fetch data normally but won't receive real-time updates.
+#### How streamUpdates works
+
+- **Initial fetch is HTTP.** The first page (and any subsequent paginated pages) still go through normal HTTP requests. Only invalidations after that come over the WebSocket.
+- **Latency is sub-second.** Once the subscription is open, updates typically apply to the cache within a second of the server-side change.
+- **Server-side filter match.** Updates only fire when the server-side filter match for your query changes. If a `where: { isComplete: false }` query is open and an action flips an object to `isComplete: true`, the cache removes it from this list.
+- **Use it for:** live dashboards, ticker-like UIs, multi-user editing, anywhere users expect to see other people's changes. Avoid it for one-shot tables, modal lookups, or large lists where the constant invalidations cost more than the freshness is worth.
+
+:::note Limitations
+`streamUpdates` cannot be used together with `pivotTo` or `withProperties`. The server does not support websocket subscriptions for link-traversal or derived-property queries. Those queries still fetch data normally but won't receive real-time updates.
 :::
 
 ### Set Intersections with `intersectWith`
@@ -385,9 +410,8 @@ function ManagerReports() {
   return (
     <div>
       <h3>John Smith's Direct Reports ({data?.length})</h3>
-      {data?.map(report => (
-        <div key={report.$primaryKey}>{report.fullName}</div>
-      ))}
+      {data?.map(report => <div key={report.$primaryKey}>{report.fullName}
+      </div>)}
     </div>
   );
 }
@@ -396,21 +420,26 @@ function ManagerReports() {
 ### All Options
 
 ```ts
-const { data, isLoading, isOptimistic, fetchMore, error } = useOsdkObjects(
-  Todo,
-  {
-    rids: ["ri.phonograph2-objects.main.object.abc123", "ri.phonograph2-objects.main.object.def456"],
-    where: { isComplete: false },
-    pageSize: 20,
-    orderBy: { createdAt: "desc" },
-    dedupeIntervalMs: 5000,
-    streamUpdates: true,
-    autoFetchMore: 100,
-    enabled: true,
-    intersectWith: [{ where: { priority: "high" } }],
-    withProperties: { /* see advanced-queries */ },
+const result = useOsdkObjects(Todo, {
+  rids: [
+    "ri.phonograph2-objects.main.object.abc123",
+    "ri.phonograph2-objects.main.object.def456",
+  ],
+  where: { isComplete: false },
+  pageSize: 20,
+  orderBy: { createdAt: "desc" },
+  dedupeIntervalMs: 5000,
+  streamUpdates: true,
+  autoFetchMore: 100,
+  enabled: true,
+  intersectWith: [{ where: { priority: "high" } }],
+  pivotTo: "assignee",
+  $select: ["title", "isComplete"],
+  $loadPropertySecurityMetadata: true,
+  withProperties: {
+    /* see https://palantir.github.io/osdk-ts/react/advanced-queries#derived-properties */
   },
-);
+});
 ```
 
 :::note
@@ -423,7 +452,7 @@ still fetch data normally but won't receive real-time updates.
 
 ## useOsdkObject
 
-*Experimental - import from `@osdk/react/experimental`*
+_Experimental - import from `@osdk/react/experimental`_
 
 Retrieve and observe a single object.
 
@@ -476,18 +505,38 @@ function TodoLoader({ todoId }: { todoId: string }) {
 }
 ```
 
+### Loading with options
+
+A third argument lets you restrict properties or load per-property security metadata:
+
+```tsx
+const { object } = useOsdkObject(Todo, todoId, {
+  $select: ["title", "isComplete"],
+  $loadPropertySecurityMetadata: true,
+});
+```
+
+Or pass a boolean to disable the query:
+
+```tsx
+const { object } = useOsdkObject(Todo, todoId, false);
+```
+
+`useOsdkObject` also accepts `undefined` as the first argument, which short-circuits to a no-op result without subscribing — useful when an instance is conditionally available.
+
 ### Return Values
 
-- `object` - The object instance (may be undefined while loading)
-- `isLoading` - True while fetching from server
-- `isOptimistic` - True if object has optimistic updates applied
-- `error` - Error object if fetch failed
+- `object` — The object instance (may be undefined while loading)
+- `isLoading` — True while fetching from server
+- `isOptimistic` — True if object has optimistic updates applied
+- `error` — Error object if fetch failed (cleared once a fresh successful fetch lands)
+- `forceUpdate` — Manually trigger a re-fetch of this object
 
 ---
 
 ## useLinks
 
-*Experimental - import from `@osdk/react/experimental`*
+_Experimental - import from `@osdk/react/experimental`_
 
 Observe and navigate relationships between objects.
 
@@ -551,7 +600,9 @@ import { Employee } from "@my/osdk";
 import { useLinks } from "@osdk/react/experimental";
 import { useState } from "react";
 
-function OptionalReportsList({ employee }: { employee: Employee.OsdkInstance }) {
+function OptionalReportsList(
+  { employee }: { employee: Employee.OsdkInstance },
+) {
   const [showReports, setShowReports] = useState(false);
 
   const { links, isLoading } = useLinks(employee, "reports", {
@@ -611,7 +662,7 @@ const { links } = useLinks(employee, "reports", {
 
 ## useOsdkClient
 
-*Stable - available from both `@osdk/react` and `@osdk/react/experimental`*
+_Stable - available from both `@osdk/react` and `@osdk/react/experimental`_
 
 Access the OSDK client directly for custom queries.
 

--- a/docs/react/querying-data.md
+++ b/docs/react/querying-data.md
@@ -98,10 +98,6 @@ const { data, isLoading } = useOsdkObjects(Todo, {
 
 OSDK provides several text search operators for string properties. Understanding the differences helps you choose the right one for your use case.
 
-:::warning Term matching, not substring
-`$containsAnyTerm`, `$containsAllTerms`, and `$containsAllTermsInOrder` match whole tokens against the indexed text. Searching for `"iel"` will **not** match `"Daniel"` — the token in the index is `Daniel`. For prefix matching use `$startsWith`; for arbitrary substrings, filter client-side or model the data differently. Tokenization rules (case-folding, stemming, punctuation handling) come from the property's search-index configuration in the ontology.
-:::
-
 #### `$startsWith`
 
 Matches strings that begin with the specified prefix.
@@ -212,9 +208,8 @@ function ArticleSearch() {
 
       {isLoading && <div>Searching...</div>}
 
-      {data?.map(article => (
-        <div key={article.$primaryKey}>{article.title}</div>
-      ))}
+      {data?.map(article => <div key={article.$primaryKey}>{article.title}
+      </div>)}
     </div>
   );
 }
@@ -344,13 +339,6 @@ function LiveTodoList() {
   );
 }
 ```
-
-#### How streamUpdates works
-
-- **Initial fetch is HTTP.** The first page (and any subsequent paginated pages) still go through normal HTTP requests. Only invalidations after that come over the WebSocket.
-- **Server-side filter match.** Updates only fire when the server-side filter match for your query changes. If a `where: { isComplete: false }` query is open and an action flips an object to `isComplete: true`, the cache removes it from this list.
-- **Use it for** live dashboards, ticker-like UIs, multi-user editing — anywhere users expect to see other people's changes.
-- **Avoid it for** one-shot tables, modal lookups, or large lists where the constant invalidations cost more than the freshness is worth.
 
 :::note Limitations
 `streamUpdates` cannot be used together with `pivotTo` or `withProperties`. The server does not support websocket subscriptions for link-traversal or derived-property queries. Those queries still fetch data normally but won't receive real-time updates.

--- a/docs/react/querying-data.md
+++ b/docs/react/querying-data.md
@@ -50,7 +50,7 @@ function TodoList() {
 - `isOptimistic` — True if the list order is affected by optimistic updates (see note below)
 - `fetchMore` — Function to load next page (undefined when no more pages available)
 - `hasMore` — True if more pages can be fetched
-- `totalCount` — Total count of matching objects, when available from the API
+- `totalCount` — Total count of matching objects when available from the API. Returned as a string; parse with `Number(totalCount)` if you need arithmetic
 - `objectSet` — The transformed `ObjectSet` after pivots / set ops; useful as input to a subsequent `useObjectSet` or `useOsdkAggregation`
 - `refetch` — Function to manually invalidate this object type and refetch
 - `error` — Error object if fetch failed
@@ -348,9 +348,9 @@ function LiveTodoList() {
 #### How streamUpdates works
 
 - **Initial fetch is HTTP.** The first page (and any subsequent paginated pages) still go through normal HTTP requests. Only invalidations after that come over the WebSocket.
-- **Latency is sub-second.** Once the subscription is open, updates typically apply to the cache within a second of the server-side change.
 - **Server-side filter match.** Updates only fire when the server-side filter match for your query changes. If a `where: { isComplete: false }` query is open and an action flips an object to `isComplete: true`, the cache removes it from this list.
-- **Use it for:** live dashboards, ticker-like UIs, multi-user editing, anywhere users expect to see other people's changes. Avoid it for one-shot tables, modal lookups, or large lists where the constant invalidations cost more than the freshness is worth.
+- **Use it for** live dashboards, ticker-like UIs, multi-user editing — anywhere users expect to see other people's changes.
+- **Avoid it for** one-shot tables, modal lookups, or large lists where the constant invalidations cost more than the freshness is worth.
 
 :::note Limitations
 `streamUpdates` cannot be used together with `pivotTo` or `withProperties`. The server does not support websocket subscriptions for link-traversal or derived-property queries. Those queries still fetch data normally but won't receive real-time updates.
@@ -433,14 +433,15 @@ const result = useOsdkObjects(Todo, {
   autoFetchMore: 100,
   enabled: true,
   intersectWith: [{ where: { priority: "high" } }],
-  pivotTo: "assignee",
   $select: ["title", "isComplete"],
   $loadPropertySecurityMetadata: true,
   withProperties: {
-    /* see https://palantir.github.io/osdk-ts/react/advanced-queries#derived-properties */
+    /* see /react/advanced-queries#derived-properties */
   },
 });
 ```
+
+`streamUpdates` and `pivotTo` cannot be combined — see the note above.
 
 :::note
 `streamUpdates` and `pivotTo` cannot be used together. The server does not support
@@ -522,15 +523,12 @@ Or pass a boolean to disable the query:
 const { object } = useOsdkObject(Todo, todoId, false);
 ```
 
-`useOsdkObject` also accepts `undefined` as the first argument, which short-circuits to a no-op result without subscribing — useful when an instance is conditionally available.
-
 ### Return Values
 
 - `object` — The object instance (may be undefined while loading)
 - `isLoading` — True while fetching from server
 - `isOptimistic` — True if object has optimistic updates applied
 - `error` — Error object if fetch failed (cleared once a fresh successful fetch lands)
-- `forceUpdate` — Manually trigger a re-fetch of this object
 
 ---
 


### PR DESCRIPTION
addresses items from internal bug bash about stale, incomplete, and unclear @osdk/react docs

• replace $Actions namespace with concrete action imports, fix error rendering examples to use error.message
• restructure cache-management with a why-use-this section, what gets cached table, expanded best practices, and observableClient-is-optional clarification
• add term-matching warning for $containsAnyTerm, fuzzy column to search comparison, expanded streamUpdates explanation, and PalantirApiError field reference