### PR TITLE
Include value type descriptions in generated property JSDoc

### DIFF
--- a/.changeset/smart-taxes-build.md
+++ b/.changeset/smart-taxes-build.md
@@ -1,0 +1,5 @@
+---
+"@osdk/generator": patch
+---
+
+Add value type descriptions to output object jsdoc

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/OsdkTestObject.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/OsdkTestObject.ts
@@ -33,7 +33,9 @@ export namespace OsdkTestObject {
      */
     readonly primaryKey_: $PropType['string'];
     /**
-     *   display name: 'String Property'
+     *   display name: 'String Property',
+     *
+     *   value type description: A value type for specific colors
      */
     readonly stringProperty: 'brown' | 'found.com' | 'it\'s "cool"' | undefined;
     /**
@@ -123,7 +125,9 @@ export interface OsdkTestObject extends $ObjectTypeDefinition {
        */
       primaryKey_: $PropertyDef<'string', 'non-nullable', 'single'>;
       /**
-       *   display name: 'String Property'
+       *   display name: 'String Property',
+       *
+       *   value type description: A value type for specific colors
        */
       stringProperty: $PropertyDef<'string', 'nullable', 'single'>;
       /**

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/OsdkTestObject.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/OsdkTestObject.ts
@@ -35,7 +35,7 @@ export namespace OsdkTestObject {
     /**
      *   display name: 'String Property',
      *
-     *   value type description: A value type for specific colors
+     *   value type description: 'A value type for specific colors'
      */
     readonly stringProperty: 'brown' | 'found.com' | 'it\'s "cool"' | undefined;
     /**
@@ -127,7 +127,7 @@ export interface OsdkTestObject extends $ObjectTypeDefinition {
       /**
        *   display name: 'String Property',
        *
-       *   value type description: A value type for specific colors
+       *   value type description: 'A value type for specific colors'
        */
       stringProperty: $PropertyDef<'string', 'nullable', 'single'>;
       /**

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/SotSensor.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/SotSensor.ts
@@ -23,7 +23,7 @@ export namespace SotSensor {
     /**
      *   display name: 'Is Enum',
      *
-     *   value type description: A value type for boolean values
+     *   value type description: 'A value type for boolean values'
      */
     readonly isEnum: true | undefined;
     /**
@@ -89,7 +89,7 @@ export interface SotSensor extends $ObjectTypeDefinition {
       /**
        *   display name: 'Is Enum',
        *
-       *   value type description: A value type for boolean values
+       *   value type description: 'A value type for boolean values'
        */
       isEnum: $PropertyDef<'boolean', 'nullable', 'single'>;
       /**

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/SotSensor.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/SotSensor.ts
@@ -21,7 +21,9 @@ export namespace SotSensor {
 
   export interface Props {
     /**
-     *   display name: 'Is Enum'
+     *   display name: 'Is Enum',
+     *
+     *   value type description: A value type for boolean values
      */
     readonly isEnum: true | undefined;
     /**
@@ -85,7 +87,9 @@ export interface SotSensor extends $ObjectTypeDefinition {
     primaryKeyType: 'string';
     properties: {
       /**
-       *   display name: 'Is Enum'
+       *   display name: 'Is Enum',
+       *
+       *   value type description: A value type for boolean values
        */
       isEnum: $PropertyDef<'boolean', 'nullable', 'single'>;
       /**

--- a/packages/generator/src/shared/propertyJsdoc.test.ts
+++ b/packages/generator/src/shared/propertyJsdoc.test.ts
@@ -32,7 +32,7 @@ describe(propertyJsdoc, () => {
       }),
     ).toMatchInlineSnapshot(`
       "/**
-       *   value type description: A value type for email addresses
+       *   value type description: 'A value type for email addresses'
        */
       "
     `);

--- a/packages/generator/src/shared/propertyJsdoc.test.ts
+++ b/packages/generator/src/shared/propertyJsdoc.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectMetadata } from "@osdk/api";
+import { describe, expect, it } from "vitest";
+import { propertyJsdoc } from "./propertyJsdoc.js";
+
+describe(propertyJsdoc, () => {
+  it("renders value type descriptions as property metadata", () => {
+    const property = {
+      type: "string",
+      valueTypeApiName: "emailValueType",
+    } satisfies ObjectMetadata.Property;
+
+    expect(
+      propertyJsdoc(property, undefined, {
+        apiName: "email",
+        valueTypeDescription: "A value type for email addresses",
+      }),
+    ).toMatchInlineSnapshot(`
+      "/**
+       *   value type description: A value type for email addresses
+       */
+      "
+    `);
+  });
+});

--- a/packages/generator/src/shared/propertyJsdoc.ts
+++ b/packages/generator/src/shared/propertyJsdoc.ts
@@ -20,13 +20,27 @@ import type { PropertyV2 } from "@osdk/foundry.ontologies";
 export function propertyJsdoc(
   property: ObjectMetadata.Property,
   rawPropertyMetadata: PropertyV2 | undefined,
-  { isInherited, apiName }: { isInherited?: boolean; apiName: string },
+  {
+    isInherited,
+    apiName,
+    valueTypeDescription,
+  }: {
+    isInherited?: boolean;
+    apiName: string;
+    valueTypeDescription?: string;
+  },
 ): string {
   const ret = [];
   const renderDisplayName = property.displayName
     && property.displayName !== apiName;
   const status = rawPropertyMetadata?.status;
-  if (isInherited || renderDisplayName || property.description || status) {
+  if (
+    isInherited
+    || renderDisplayName
+    || property.description
+    || valueTypeDescription
+    || status
+  ) {
     if (status) {
       let deprecationStatus = "";
       if (status.type === "deprecated") {
@@ -51,13 +65,16 @@ export function propertyJsdoc(
     if (renderDisplayName) {
       ret.push(
         ` *   display name: '${property.displayName}'${
-          property.description ? "," : ""
+          property.description || valueTypeDescription ? "," : ""
         }\n`,
       );
     }
 
     if (property.description) {
       ret.push(` *   description: ${property.description}\n`);
+    }
+    if (valueTypeDescription) {
+      ret.push(` *   value type description: ${valueTypeDescription}\n`);
     }
   } else {
     ret.push(` * (no ontology metadata)\n`);

--- a/packages/generator/src/shared/propertyJsdoc.ts
+++ b/packages/generator/src/shared/propertyJsdoc.ts
@@ -74,7 +74,9 @@ export function propertyJsdoc(
       ret.push(` *   description: ${property.description}\n`);
     }
     if (valueTypeDescription) {
-      ret.push(` *   value type description: ${valueTypeDescription}\n`);
+      ret.push(
+        ` *   value type description: '${valueTypeDescription}'\n`,
+      );
     }
   } else {
     ret.push(` * (no ontology metadata)\n`);

--- a/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.ts
+++ b/packages/generator/src/v2.0/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst.ts
@@ -199,7 +199,15 @@ ${
       
     }    
 
-    ${createDefinition(interfaceDef, ontology, interfaceDef.shortApiName, ids)}
+    ${
+      createDefinition(
+        interfaceDef,
+        ontology,
+        interfaceDef.shortApiName,
+        ids,
+        ontology.raw.valueTypes,
+      )
+    }
 
 `;
   }

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -853,7 +853,7 @@ describe("generator", () => {
 
           export interface Props {
             /**
-             *   value type description: A value type for email addresses
+             *   value type description: 'A value type for email addresses'
              */
             readonly email: 'osdk@palantir.com' | 'foundry@palantir.com';
           }
@@ -903,7 +903,7 @@ describe("generator", () => {
             primaryKeyType: 'string';
             properties: {
               /**
-               *   value type description: A value type for email addresses
+               *   value type description: 'A value type for email addresses'
                */
               email: $PropertyDef<'string', 'non-nullable', 'single'>;
             };
@@ -952,7 +952,7 @@ describe("generator", () => {
 
           export interface Props {
             /**
-             *   value type description: A value type for arrays of strings
+             *   value type description: 'A value type for arrays of strings'
              */
             readonly array: ('a' | 'b"c' | "d'e")[] | undefined;
             /**
@@ -1024,7 +1024,7 @@ describe("generator", () => {
             primaryKeyType: 'integer';
             properties: {
               /**
-               *   value type description: A value type for arrays of strings
+               *   value type description: 'A value type for arrays of strings'
                */
               array: $PropertyDef<'string', 'nullable', 'array'>;
               /**
@@ -1538,7 +1538,7 @@ describe("generator", () => {
 
           export interface Props {
             /**
-             *   value type description: A value type for email addresses
+             *   value type description: 'A value type for email addresses'
              */
             readonly email: 'osdk@palantir.com' | 'foundry@palantir.com';
           }
@@ -1588,7 +1588,7 @@ describe("generator", () => {
             primaryKeyType: 'string';
             properties: {
               /**
-               *   value type description: A value type for email addresses
+               *   value type description: 'A value type for email addresses'
                */
               email: $PropertyDef<'string', 'non-nullable', 'single'>;
             };
@@ -1637,7 +1637,7 @@ describe("generator", () => {
 
           export interface Props {
             /**
-             *   value type description: A value type for arrays of strings
+             *   value type description: 'A value type for arrays of strings'
              */
             readonly array: ('a' | 'b"c' | "d'e")[] | undefined;
             /**
@@ -1709,7 +1709,7 @@ describe("generator", () => {
             primaryKeyType: 'integer';
             properties: {
               /**
-               *   value type description: A value type for arrays of strings
+               *   value type description: 'A value type for arrays of strings'
                */
               array: $PropertyDef<'string', 'nullable', 'array'>;
               /**

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -644,20 +644,17 @@ describe("generator", () => {
             rid: 'ri.ontology.main.action-type.8f94017d-cf17-4fa8-84c3-8e01e5d594f2';
             status: 'ACTIVE';
             type: 'action';
-            unsanitizedApiName: 'deleteTodos';
 
             signatures: deleteTodos.Signatures;
           };
           apiName: 'deleteTodos';
           type: 'action';
-          unsanitizedApiName: 'deleteTodos';
           osdkMetadata: typeof $osdkMetadata;
         }
 
         export const deleteTodos: deleteTodos = {
           apiName: 'deleteTodos',
           type: 'action',
-          unsanitizedApiName: 'deleteTodos',
           osdkMetadata: $osdkMetadata,
         };
         ",
@@ -733,20 +730,17 @@ describe("generator", () => {
             rid: 'ri.ontology.main.action-type.9f84017d-cf17-4fa8-84c3-8e01e5d594f2';
             status: 'ACTIVE';
             type: 'action';
-            unsanitizedApiName: 'markTodoCompleted';
 
             signatures: markTodoCompleted.Signatures;
           };
           apiName: 'markTodoCompleted';
           type: 'action';
-          unsanitizedApiName: 'markTodoCompleted';
           osdkMetadata: typeof $osdkMetadata;
         }
 
         export const markTodoCompleted: markTodoCompleted = {
           apiName: 'markTodoCompleted',
           type: 'action',
-          unsanitizedApiName: 'markTodoCompleted',
           osdkMetadata: $osdkMetadata,
         };
         ",
@@ -859,7 +853,7 @@ describe("generator", () => {
 
           export interface Props {
             /**
-             * (no ontology metadata)
+             *   value type description: A value type for email addresses
              */
             readonly email: 'osdk@palantir.com' | 'foundry@palantir.com';
           }
@@ -909,7 +903,7 @@ describe("generator", () => {
             primaryKeyType: 'string';
             properties: {
               /**
-               * (no ontology metadata)
+               *   value type description: A value type for email addresses
                */
               email: $PropertyDef<'string', 'non-nullable', 'single'>;
             };
@@ -958,7 +952,7 @@ describe("generator", () => {
 
           export interface Props {
             /**
-             * (no ontology metadata)
+             *   value type description: A value type for arrays of strings
              */
             readonly array: ('a' | 'b"c' | "d'e")[] | undefined;
             /**
@@ -1030,7 +1024,7 @@ describe("generator", () => {
             primaryKeyType: 'integer';
             properties: {
               /**
-               * (no ontology metadata)
+               *   value type description: A value type for arrays of strings
                */
               array: $PropertyDef<'string', 'nullable', 'array'>;
               /**
@@ -1335,20 +1329,17 @@ describe("generator", () => {
             rid: 'ri.ontology.main.action-type.8f94017d-cf17-4fa8-84c3-8e01e5d594f2';
             status: 'ACTIVE';
             type: 'action';
-            unsanitizedApiName: 'foo.bar.deleteTodos';
 
             signatures: deleteTodos.Signatures;
           };
           apiName: 'foo.bar.deleteTodos';
           type: 'action';
-          unsanitizedApiName: 'foo.bar.deleteTodos';
           osdkMetadata: typeof $osdkMetadata;
         }
 
         export const deleteTodos: deleteTodos = {
           apiName: 'foo.bar.deleteTodos',
           type: 'action',
-          unsanitizedApiName: 'foo.bar.deleteTodos',
           osdkMetadata: $osdkMetadata,
         };
         ",
@@ -1424,20 +1415,17 @@ describe("generator", () => {
             rid: 'ri.ontology.main.action-type.9f84017d-cf17-4fa8-84c3-8e01e5d594f2';
             status: 'ACTIVE';
             type: 'action';
-            unsanitizedApiName: 'foo.bar.markTodoCompleted';
 
             signatures: markTodoCompleted.Signatures;
           };
           apiName: 'foo.bar.markTodoCompleted';
           type: 'action';
-          unsanitizedApiName: 'foo.bar.markTodoCompleted';
           osdkMetadata: typeof $osdkMetadata;
         }
 
         export const markTodoCompleted: markTodoCompleted = {
           apiName: 'foo.bar.markTodoCompleted',
           type: 'action',
-          unsanitizedApiName: 'foo.bar.markTodoCompleted',
           osdkMetadata: $osdkMetadata,
         };
         ",
@@ -1550,7 +1538,7 @@ describe("generator", () => {
 
           export interface Props {
             /**
-             * (no ontology metadata)
+             *   value type description: A value type for email addresses
              */
             readonly email: 'osdk@palantir.com' | 'foundry@palantir.com';
           }
@@ -1600,7 +1588,7 @@ describe("generator", () => {
             primaryKeyType: 'string';
             properties: {
               /**
-               * (no ontology metadata)
+               *   value type description: A value type for email addresses
                */
               email: $PropertyDef<'string', 'non-nullable', 'single'>;
             };
@@ -1649,7 +1637,7 @@ describe("generator", () => {
 
           export interface Props {
             /**
-             * (no ontology metadata)
+             *   value type description: A value type for arrays of strings
              */
             readonly array: ('a' | 'b"c' | "d'e")[] | undefined;
             /**
@@ -1721,7 +1709,7 @@ describe("generator", () => {
             primaryKeyType: 'integer';
             properties: {
               /**
-               * (no ontology metadata)
+               *   value type description: A value type for arrays of strings
                */
               array: $PropertyDef<'string', 'nullable', 'array'>;
               /**
@@ -2254,20 +2242,17 @@ describe("generator", () => {
               rid: 'ri.a.b.c.d';
               status: 'ACTIVE';
               type: 'action';
-              unsanitizedApiName: 'setTaskBody';
 
               signatures: setTaskBody.Signatures;
             };
             apiName: 'setTaskBody';
             type: 'action';
-            unsanitizedApiName: 'setTaskBody';
             osdkMetadata: typeof $osdkMetadata;
           }
 
           export const setTaskBody: setTaskBody = {
             apiName: 'setTaskBody',
             type: 'action',
-            unsanitizedApiName: 'setTaskBody',
             osdkMetadata: $osdkMetadata,
           };
           "

--- a/packages/generator/src/v2.0/wireObjectTypeV2ToSdkObjectConstV2.ts
+++ b/packages/generator/src/v2.0/wireObjectTypeV2ToSdkObjectConstV2.ts
@@ -37,6 +37,17 @@ import { stringUnionFrom } from "../util/stringUnionFrom.js";
 
 type PropertyApiNameUnion = PropertyApiName | SharedPropertyTypeApiName;
 
+function getValueTypeDescription(
+  propertyDefinition: Pick<ObjectMetadata.Property, "valueTypeApiName">,
+  valueTypeMetadata: Record<ValueTypeApiName, OntologyValueType>,
+): string | undefined {
+  if (propertyDefinition.valueTypeApiName == null) {
+    return undefined;
+  }
+
+  return valueTypeMetadata[propertyDefinition.valueTypeApiName]?.description;
+}
+
 /** @internal */
 export function wireObjectTypeV2ToSdkObjectConstV2(
   wireObject: ObjectTypeFullMetadata,
@@ -120,7 +131,15 @@ export function wireObjectTypeV2ToSdkObjectConstV2(
 
 
 
-    ${createDefinition(object, ontology, object.shortApiName, identifiers)}
+    ${
+      createDefinition(
+        object,
+        ontology,
+        object.shortApiName,
+        identifiers,
+        ontology.raw.valueTypes,
+      )
+    }
     `;
   }
 
@@ -251,6 +270,10 @@ ${
           `${
             propertyJsdoc(propertyDefinition, metadata, {
               apiName,
+              valueTypeDescription: getValueTypeDescription(
+                propertyDefinition,
+                valueTypeMetadata,
+              ),
             })
           }readonly "${maybeStripNamespace(type, apiName)}"`,
           (typeof propertyDefinition.type === "object"
@@ -285,6 +308,7 @@ export function createDefinition(
     osdkObjectStrictPropsIdentifier,
     osdkObjectLinksIdentifier,
   }: Identifiers,
+  valueTypeMetadata: Record<ValueTypeApiName, OntologyValueType>,
 ) {
   const definition = object.getCleanedUpDefinition(true);
   const propertyMetadata = object instanceof EnhancedObjectType
@@ -353,6 +377,10 @@ export function createDefinition(
                   ],
                   {
                     apiName,
+                    valueTypeDescription: getValueTypeDescription(
+                      propertyDefinition,
+                      valueTypeMetadata,
+                    ),
                   },
                 )
               }"${maybeStripNamespace(object, apiName)}"`,


### PR DESCRIPTION
 ## Summary
Include value type descriptions in generated TypeScript OSDK property JSDoc when an object or interface property references a value type with a description.

## Why
- Keeps value type semantics close to the property in generated SDK output
- Improves IDE hover/docs for humans
- Gives agents more ontology context directly from the generated type defs they are already reading

## What changed

- Extended `propertyJsdoc` to accept an optional value type description and render it as: `value type description: ...`
- Threaded value type metadata through object and interface code generation so the description is available when rendering:
  - `Props` 
  - `__DefinitionMetadata.properties`
- Added a focused unit test for `propertyJsdoc`
- Refreshed the affected generator snapshots and checked-in generated fixtures

## Example
Before:

```ts
  /**
   *   display name: 'String Property'
   */
  readonly stringProperty: 'brown' | 'found.com' | 'it\'s "cool"' | undefined;
```
After:
```ts
  /**
   *   display name: 'String Property',
   *
   *   value type description: 'A value type for specific colors'
   */
  readonly stringProperty: 'brown' | 'found.com' | 'it\'s "cool"' | undefined;
```