### PR TITLE
Fix bundleDependencies test timeout flake

### DIFF
--- a/.changeset/fix-bundle-deps-test-flake.md
+++ b/.changeset/fix-bundle-deps-test-flake.md
@@ -1,0 +1,5 @@
+---
+"@osdk/foundry-sdk-generator": patch
+---
+
+Bump test timeout for bundleDependencies tests to 30s to fix CI flake.

--- a/packages/foundry-sdk-generator/src/generate/betaClient/__tests__/bundleDependencies.test.ts
+++ b/packages/foundry-sdk-generator/src/generate/betaClient/__tests__/bundleDependencies.test.ts
@@ -19,7 +19,7 @@ import { describe, expect, it } from "vitest";
 import { outputModule } from "../bundleDependencies.js";
 import { ProjectMinifier } from "../minifyBundle.js";
 
-describe("minify project", () => {
+describe("minify project", { timeout: 30_000 }, () => {
   it("minifies a project", () => {
     const project = new Project({
       useInMemoryFileSystem: true,


### PR DESCRIPTION
## Summary

- Bump suite-level timeout in `packages/foundry-sdk-generator/src/generate/betaClient/__tests__/bundleDependencies.test.ts` from the 5s vitest default to 30s.
- The "minifies a project" test runs synchronous ts-morph type checking and was clocking ~4s on Node 22 / ~2.7s on Node 18 on recent successful main runs — close enough to the 5s default that CI noise tips it over (#3107 hit it).

## Test plan

- [x] All 5 tests in the file pass locally (567ms total)
- [ ] CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)