### PR TITLE
fix link query refresh for per-pk invalidation and interface targets

### DIFF
--- a/.changeset/fix-link-invalidation-gaps.md
+++ b/.changeset/fix-link-invalidation-gaps.md
@@ -1,0 +1,9 @@
+---
+"@osdk/client": patch
+---
+
+fix link query refresh for per-pk invalidation and interface-typed targets
+
+- kick `specificLink` queries from `Store.invalidateObject` so per-pk invalidation refreshes link queries (was only handled at type-level)
+- fix `SpecificLinkQuery.invalidateObjectType` so interface-implementation matching on object-type targets isn't silently skipped
+- fix `BaseListQuery.rdpConfig` index collision (`SpecificLinkCacheKey.otherKeys[4]` is the link name, not the rdp config); make `rdpConfig` abstract with concrete overrides per subclass

--- a/packages/client/src/observable/internal/Store.invalidation.test.ts
+++ b/packages/client/src/observable/internal/Store.invalidation.test.ts
@@ -647,4 +647,80 @@ describe("Store Invalidation Type Isolation", () => {
       expect(empSubFn.next).not.toHaveBeenCalled();
     });
   });
+
+  describe("invalidateObject link kick", () => {
+    it("invalidateObject on the source type refreshes link queries", async () => {
+      const { payload: emp1Payload } = await expectStandardObserveObject({
+        cache,
+        type: Employee,
+        primaryKey: EMPLOYEE_1_ID,
+      });
+      const emp1 = emp1Payload?.object;
+      invariant(emp1);
+
+      const { linkSubFn: officeLinkSubFn } = await expectStandardObserveLink({
+        store: cache,
+        srcObject: emp1,
+        srcLinkName: "officeLink",
+        targetType: Office,
+        expected: [expect.objectContaining({ $primaryKey: OFFICE_1_ID })],
+      });
+      officeLinkSubFn.next.mockClear();
+
+      await cache.invalidateObject(Employee, EMPLOYEE_1_ID);
+
+      await vi.waitFor(() => {
+        expect(officeLinkSubFn.next).toHaveBeenCalled();
+      });
+    });
+
+    it("invalidateObject on the target type refreshes link queries", async () => {
+      const { payload: emp1Payload } = await expectStandardObserveObject({
+        cache,
+        type: Employee,
+        primaryKey: EMPLOYEE_1_ID,
+      });
+      const emp1 = emp1Payload?.object;
+      invariant(emp1);
+
+      const { linkSubFn: officeLinkSubFn } = await expectStandardObserveLink({
+        store: cache,
+        srcObject: emp1,
+        srcLinkName: "officeLink",
+        targetType: Office,
+        expected: [expect.objectContaining({ $primaryKey: OFFICE_1_ID })],
+      });
+      officeLinkSubFn.next.mockClear();
+
+      await cache.invalidateObject(Office, OFFICE_1_ID);
+
+      await vi.waitFor(() => {
+        expect(officeLinkSubFn.next).toHaveBeenCalled();
+      });
+    });
+
+    it("invalidateObject on an unrelated type does not refresh link queries", async () => {
+      const { payload: emp1Payload } = await expectStandardObserveObject({
+        cache,
+        type: Employee,
+        primaryKey: EMPLOYEE_1_ID,
+      });
+      const emp1 = emp1Payload?.object;
+      invariant(emp1);
+
+      const { linkSubFn: officeLinkSubFn } = await expectStandardObserveLink({
+        store: cache,
+        srcObject: emp1,
+        srcLinkName: "officeLink",
+        targetType: Office,
+        expected: [expect.objectContaining({ $primaryKey: OFFICE_1_ID })],
+      });
+      officeLinkSubFn.next.mockClear();
+
+      await cache.invalidateObject(Todo, TODO_1_ID);
+
+      await new Promise(resolve => setTimeout(resolve, 500));
+      expect(officeLinkSubFn.next).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/client/src/observable/internal/Store.ts
+++ b/packages/client/src/observable/internal/Store.ts
@@ -309,7 +309,41 @@ export class Store {
       }
     }
 
+    // Per-PK invalidation doesn't propagate to specificLink queries (they're
+    // keyed on srcType+srcPk+linkName, not the linked object's pk).
+    promises.push(this.invalidateLinkQueriesForType(apiName));
+
     return Promise.allSettled(promises);
+  }
+
+  /**
+   * Force every cached `specificLink` query to re-evaluate against the given
+   * apiName. Link queries are keyed on `(srcType, srcPk, linkName, ...)` rather
+   * than the linked object's pk, so per-object propagation never marks them
+   * as modified.
+   *
+   * TODO: make SpecificLinkQuery self-invalidate from per-type changes so
+   * callers don't need this manual kick.
+   */
+  public invalidateLinkQueriesForType(apiName: string): Promise<void> {
+    if (process.env.NODE_ENV !== "production") {
+      this.logger?.child({ methodName: "invalidateLinkQueriesForType" }).debug(
+        apiName,
+      );
+    }
+
+    const promises: Array<Promise<void>> = [];
+    for (const cacheKey of this.queries.keys()) {
+      if (cacheKey.type !== "specificLink") {
+        continue;
+      }
+      const query = this.queries.peek(cacheKey);
+      if (!query) {
+        continue;
+      }
+      promises.push(query.invalidateObjectType(apiName, undefined));
+    }
+    return Promise.allSettled(promises).then(() => void 0);
   }
 
   async #maybeRevalidateQueries(

--- a/packages/client/src/observable/internal/base-list/BaseListQuery.ts
+++ b/packages/client/src/observable/internal/base-list/BaseListQuery.ts
@@ -31,7 +31,6 @@ import { type CacheKey, DEBUG_ONLY__cacheKeysToString } from "../CacheKey.js";
 import type { Canonical } from "../Canonical.js";
 import { isObjectInstance } from "../isObjectInstance.js";
 import type { Entry } from "../Layer.js";
-import { RDP_IDX } from "../list/ListCacheKey.js";
 import { type ObjectCacheKey } from "../object/ObjectCacheKey.js";
 import { Query } from "../Query.js";
 import type { Rdp } from "../RdpCanonicalizer.js";
@@ -84,12 +83,8 @@ export abstract class BaseListQuery<
    */
   protected sortingStrategy: SortingStrategy = new NoOpSortingStrategy();
 
-  /**
-   * Get RDP configuration from the cache key
-   */
-  public get rdpConfig(): Canonical<Rdp> | null {
-    return this.cacheKey.otherKeys[RDP_IDX];
-  }
+  /** RDP configuration for this collection. */
+  public abstract get rdpConfig(): Canonical<Rdp> | undefined;
 
   private _selectFieldSetMemo: ReadonlySet<string> | undefined;
 

--- a/packages/client/src/observable/internal/links/SpecificLinkQuery.ts
+++ b/packages/client/src/observable/internal/links/SpecificLinkQuery.ts
@@ -38,6 +38,7 @@ import type { Canonical } from "../Canonical.js";
 import type { Changes } from "../Changes.js";
 import type { Entry } from "../Layer.js";
 import type { OptimisticId } from "../OptimisticId.js";
+import type { Rdp } from "../RdpCanonicalizer.js";
 import type { SimpleWhereClause } from "../SimpleWhereClause.js";
 import { OrderBySortingStrategy } from "../sorting/SortingStrategy.js";
 import type { Store } from "../Store.js";
@@ -125,6 +126,11 @@ export class SpecificLinkQuery extends BaseListQuery<
 
   protected get rawSelect(): Canonical<readonly string[]> | undefined {
     return this.#select;
+  }
+
+  // TODO: wire up RDP support for SpecificLinkCacheKey (needs its own slot).
+  public override get rdpConfig(): Canonical<Rdp> | undefined {
+    return undefined;
   }
 
   /**
@@ -328,21 +334,19 @@ export class SpecificLinkQuery extends BaseListQuery<
         }
 
         let targetTypeApiName: string | undefined;
-        let targetTypeKind: "object" | "interface" | undefined;
 
         if (this.#sourceTypeKind === "interface") {
           const interfaceMetadata = await ontologyProvider
             .getInterfaceDefinition(this.#sourceApiName);
-          const linkDef = interfaceMetadata.links?.[this.#linkName];
-          targetTypeApiName = linkDef?.targetTypeApiName;
-          targetTypeKind = linkDef?.targetType;
+          targetTypeApiName = interfaceMetadata.links?.[this.#linkName]
+            ?.targetTypeApiName;
         } else {
           const objectMetadata = await ontologyProvider
             .getObjectDefinition(this.#sourceApiName);
-          const linkDef = objectMetadata.links?.[this.#linkName];
-          // On object link defs, targetType is the target API name (not the kind)
-          targetTypeApiName = linkDef?.targetType;
-          targetTypeKind = "object";
+          // Object link def's `targetType` is the target API name; it can be
+          // either an object type or an interface name.
+          targetTypeApiName = objectMetadata.links?.[this.#linkName]
+            ?.targetType;
         }
 
         if (!targetTypeApiName) return;
@@ -352,14 +356,15 @@ export class SpecificLinkQuery extends BaseListQuery<
           return void await this.revalidate(true);
         }
 
-        if (targetTypeKind === "interface") {
-          const objectMetadata = await ontologyProvider.getObjectDefinition(
-            objectType,
-          );
-          if (targetTypeApiName in objectMetadata.interfaceMap) {
-            changes?.modified.add(this.cacheKey);
-            return void await this.revalidate(true);
-          }
+        // If the target is an interface, revalidate when objectType implements
+        // it. For object-typed targets, interfaceMap[objectTypeName] is always
+        // false, so this is a safe no-op.
+        const objectMetadata = await ontologyProvider.getObjectDefinition(
+          objectType,
+        );
+        if (targetTypeApiName in objectMetadata.interfaceMap) {
+          changes?.modified.add(this.cacheKey);
+          return void await this.revalidate(true);
         }
       } catch (e) {
         if (process.env.NODE_ENV !== "production") {

--- a/packages/client/src/observable/internal/list/ListQuery.ts
+++ b/packages/client/src/observable/internal/list/ListQuery.ts
@@ -50,6 +50,7 @@ import {
 import { objectSortaMatchesWhereClause as objectMatchesWhereClause } from "../objectMatchesWhereClause.js";
 import type { OptimisticId } from "../OptimisticId.js";
 import type { PivotInfo } from "../PivotCanonicalizer.js";
+import type { Rdp } from "../RdpCanonicalizer.js";
 import type { SimpleWhereClause } from "../SimpleWhereClause.js";
 import { OrderBySortingStrategy } from "../sorting/SortingStrategy.js";
 import type { Store } from "../Store.js";
@@ -109,6 +110,10 @@ export abstract class ListQuery extends BaseListQuery<
   // Employee.pivotTo(Office) has apiName "Employee" but fetches Office objects.
   #fetchedObjectType: string | undefined;
   #objectTypesCache: ReadonlySet<string> | undefined;
+
+  public override get rdpConfig(): Canonical<Rdp> | undefined {
+    return this.cacheKey.otherKeys[RDP_IDX];
+  }
 
   /**
    * Register changes to the cache specific to ListQuery

--- a/packages/client/src/observable/internal/objectset/ObjectSetHelper.test.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetHelper.test.ts
@@ -76,7 +76,7 @@ describe("ObjectSetHelper RDP canonicalization", () => {
 
     // The canonical RDP reference should be identical
     expect(query1.rdpConfig).toBe(query2.rdpConfig);
-    expect(query1.rdpConfig).not.toBeNull();
+    expect(query1.rdpConfig).toBeDefined();
   });
 
   it("getQuery returns distinct rdpConfig references for different withProperties", () => {
@@ -103,12 +103,12 @@ describe("ObjectSetHelper RDP canonicalization", () => {
     expect(queryA.rdpConfig).not.toBe(queryB.rdpConfig);
   });
 
-  it("getQuery returns null rdpConfig when withProperties is not specified", () => {
+  it("getQuery returns undefined rdpConfig when withProperties is not specified", () => {
     const query = store.objectSets.getQuery({
       baseObjectSet: client(Employee) as ObjectSet<any>,
       mode: "offline",
     });
 
-    expect(query.rdpConfig).toBeNull();
+    expect(query.rdpConfig).toBeUndefined();
   });
 });

--- a/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
@@ -115,8 +115,8 @@ export class ObjectSetQuery extends BaseListQuery<
     return this.#objectTypes;
   }
 
-  public override get rdpConfig(): Canonical<Rdp> | null {
-    return this.#operations.withProperties ?? null;
+  public override get rdpConfig(): Canonical<Rdp> | undefined {
+    return this.#operations.withProperties;
   }
 
   public get selectFields(): Canonical<readonly string[]> | undefined {


### PR DESCRIPTION
link queries weren't getting refreshed by per-pk invalidation, and interface-typed link targets were silently skipped during invalidation matching

• kick `specificLink` queries from `Store.invalidateObject` so per-pk invalidation refreshes link queries (previously only handled at type-level)
• fix `SpecificLinkQuery.invalidateObjectType` so interface-implementation matching on object-type targets isn't silently skipped
• fix `BaseListQuery.rdpConfig` index collision (`SpecificLinkCacheKey.otherKeys[4]` is the link name, not the rdp config); make `rdpConfig` abstract with concrete overrides per subclass