### PR TITLE
feature: add source alias support

### DIFF
--- a/.changeset/source-alias-support.md
+++ b/.changeset/source-alias-support.md
@@ -1,0 +1,5 @@
+---
+"@osdk/functions": minor
+---
+
+Add `Aliases.source` API for resolving egress connection aliases

--- a/etc/functions.report.api.md
+++ b/etc/functions.report.api.md
@@ -28,7 +28,9 @@ declare namespace Aliases {
         custom,
         Custom,
         model,
-        Model
+        Model,
+        source,
+        Source
     }
 }
 
@@ -232,6 +234,15 @@ export interface RidLinkTarget {
     	// (undocumented)
     type: "rid";
 }
+
+// @public (undocumented)
+interface Source {
+    	// (undocumented)
+    rid: string;
+}
+
+// @public (undocumented)
+function source(alias: string): Source;
 
 export { ThreeDimensionalAggregation }
 

--- a/packages/functions/src/aliases/aliases.test.ts
+++ b/packages/functions/src/aliases/aliases.test.ts
@@ -24,6 +24,7 @@ import {
 } from "./environment.js";
 import { resetPublishedCache } from "./loaders.js";
 import { model } from "./model.js";
+import { source } from "./source.js";
 import { AliasEnvironment } from "./types.js";
 
 // Read test data before mocking fs - use node:fs which is not affected by vi.mock("fs")
@@ -119,7 +120,7 @@ describe("published mode aliases", () => {
     it("loads alias successfully and returns rid", () => {
       const result = model("myModelAlias");
       expect(result).toEqual({
-        rid: "ri.foundry-ml.main.model.12345678-1234-1234-1234-123456789012",
+        rid: "ri.foundry-ml.main.model.11111111-1111-1111-1111-111111111111",
       });
     });
 
@@ -133,10 +134,36 @@ describe("published mode aliases", () => {
       const result1 = model("myModelAlias");
       const result2 = model("anotherModelAlias");
       expect(result1.rid).toBe(
-        "ri.foundry-ml.main.model.12345678-1234-1234-1234-123456789012",
+        "ri.foundry-ml.main.model.11111111-1111-1111-1111-111111111111",
       );
       expect(result2.rid).toBe(
-        "ri.foundry-ml.main.model.87654321-4321-4321-4321-210987654321",
+        "ri.foundry-ml.main.model.22222222-2222-2222-2222-222222222222",
+      );
+    });
+  });
+
+  describe("source", () => {
+    it("loads alias successfully and returns rid", () => {
+      const result = source("mySourceAlias");
+      expect(result).toEqual({
+        rid: "ri.magritte..source.11111111-1111-1111-1111-111111111111",
+      });
+    });
+
+    it("throws on nonexistent alias", () => {
+      expect(() => source("nonexistent")).toThrow(
+        "Source alias 'nonexistent' not found. Available aliases: [mySourceAlias, anotherSourceAlias]",
+      );
+    });
+
+    it("selects correct alias from multiple", () => {
+      const result1 = source("mySourceAlias");
+      const result2 = source("anotherSourceAlias");
+      expect(result1.rid).toBe(
+        "ri.magritte..source.11111111-1111-1111-1111-111111111111",
+      );
+      expect(result2.rid).toBe(
+        "ri.magritte..source.22222222-2222-2222-2222-222222222222",
       );
     });
   });
@@ -145,6 +172,7 @@ describe("published mode aliases", () => {
     it("reads file only once across multiple lookups", () => {
       custom("myCustomAlias");
       model("myModelAlias");
+      source("mySourceAlias");
       custom("anotherCustomAlias");
 
       expect(fs.readFileSync).toHaveBeenCalledTimes(1);
@@ -231,6 +259,38 @@ describe("live preview mode aliases", () => {
     it("excludes models with null or missing alias", () => {
       expect(() => model("some-random-lookup")).toThrow(
         "Available aliases: [previewModelAlias, anotherPreviewModel]",
+      );
+    });
+  });
+
+  describe("source", () => {
+    it("loads alias successfully and returns rid", () => {
+      const result = source("previewSourceAlias");
+      expect(result).toEqual({
+        rid: "ri.magritte..source.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      });
+    });
+
+    it("throws on nonexistent alias", () => {
+      expect(() => source("nonexistent")).toThrow(
+        "Source alias 'nonexistent' not found. Available aliases: [previewSourceAlias, anotherPreviewSource]",
+      );
+    });
+
+    it("selects correct alias from multiple", () => {
+      const result1 = source("previewSourceAlias");
+      const result2 = source("anotherPreviewSource");
+      expect(result1.rid).toBe(
+        "ri.magritte..source.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      );
+      expect(result2.rid).toBe(
+        "ri.magritte..source.bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+      );
+    });
+
+    it("excludes sources with null or missing alias", () => {
+      expect(() => source("some-random-lookup")).toThrow(
+        "Available aliases: [previewSourceAlias, anotherPreviewSource]",
       );
     });
   });

--- a/packages/functions/src/aliases/loaders.ts
+++ b/packages/functions/src/aliases/loaders.ts
@@ -23,10 +23,14 @@ import {
 import { AliasEnvironment } from "./types.js";
 import type {
   AliasesFile,
+  EgressConnection,
+  EgressConnectionValue,
   Model,
   ModelResource,
+  ModelValue,
   ResolvedAliases,
   ResourcesFile,
+  Source,
 } from "./types.js";
 
 let cachedPublishedAliases: ResolvedAliases | undefined;
@@ -44,12 +48,9 @@ function loadPublishedAliases(): ResolvedAliases {
   const aliasesFile = JSON.parse(data) as AliasesFile;
 
   cachedPublishedAliases = {
-    custom: aliasesFile.defaults.custom,
-    models: Object.fromEntries<Model>(
-      Object.entries(aliasesFile.defaults.models).map((
-        [alias, { id: identifier }],
-      ) => [alias, identifier]),
-    ),
+    custom: loadCustom(aliasesFile.defaults.custom),
+    models: loadPublishedModels(aliasesFile.defaults.models),
+    sources: loadPublishedSources(aliasesFile.defaults.egressConnections),
   };
   return cachedPublishedAliases;
 }
@@ -64,15 +65,62 @@ function loadPreviewAliases(): ResolvedAliases {
   const resourcesFile = JSON.parse(data) as ResourcesFile;
 
   return {
-    custom: resourcesFile.resources.custom,
-    models: Object.fromEntries<Model>(
-      resourcesFile.resources.models
-        .filter((model): model is ModelResource & { alias: string } =>
-          model.alias != null
-        )
-        .map(({ alias, identifier }) => [alias, identifier]),
-    ),
+    custom: loadCustom(resourcesFile.resources.custom),
+    models: loadPreviewModels(resourcesFile.resources.models),
+    sources: loadPreviewSources(resourcesFile.egress.connections),
   };
+}
+
+function loadCustom(
+  custom: Record<string, string>,
+): Record<string, string> {
+  return custom;
+}
+
+function loadPublishedModels(
+  models: Record<string, ModelValue>,
+): Record<string, Model> {
+  return Object.fromEntries<Model>(
+    Object.entries(models).map((
+      [alias, { id: identifier }],
+    ) => [alias, identifier]),
+  );
+}
+
+function loadPublishedSources(
+  egressConnections: Record<string, EgressConnectionValue>,
+): Record<string, Source> {
+  return Object.fromEntries<Source>(
+    Object.entries(egressConnections).map((
+      [alias, { id: identifier }],
+    ) => [alias, identifier]),
+  );
+}
+
+function loadPreviewModels(
+  models: ModelResource[],
+): Record<string, Model> {
+  return Object.fromEntries<Model>(
+    models
+      .filter((model): model is ModelResource & { alias: string } =>
+        model.alias != null
+      )
+      .map(({ alias, identifier }) => [alias, identifier]),
+  );
+}
+
+function loadPreviewSources(
+  connections: EgressConnection[],
+): Record<string, Source> {
+  return Object.fromEntries<Source>(
+    connections
+      .filter((
+        connection,
+      ): connection is EgressConnection & { alias: string } =>
+        connection.alias != null
+      )
+      .map(({ alias, rid }) => [alias, { rid }]),
+  );
 }
 
 export function resetPublishedCache(): void {

--- a/packages/functions/src/aliases/source.ts
+++ b/packages/functions/src/aliases/source.ts
@@ -14,6 +14,21 @@
  * limitations under the License.
  */
 
-export * from "./custom.js";
-export * from "./model.js";
-export * from "./source.js";
+import { loadResolvedAliases } from "./loaders.js";
+import type { Source } from "./types.js";
+export type { Source } from "./types.js";
+
+export function source(alias: string): Source {
+  const resolvedAliases = loadResolvedAliases();
+
+  if (!(alias in resolvedAliases.sources)) {
+    const available = Object.keys(resolvedAliases.sources);
+    throw new Error(
+      `Source alias '${alias}' not found. Available aliases: [${
+        available.join(", ")
+      }]`,
+    );
+  }
+
+  return resolvedAliases.sources[alias];
+}

--- a/packages/functions/src/aliases/test-data/aliases.json
+++ b/packages/functions/src/aliases/test-data/aliases.json
@@ -7,12 +7,24 @@
     "models": {
       "myModelAlias": {
         "id": {
-          "rid": "ri.foundry-ml.main.model.12345678-1234-1234-1234-123456789012"
+          "rid": "ri.foundry-ml.main.model.11111111-1111-1111-1111-111111111111"
         }
       },
       "anotherModelAlias": {
         "id": {
-          "rid": "ri.foundry-ml.main.model.87654321-4321-4321-4321-210987654321"
+          "rid": "ri.foundry-ml.main.model.22222222-2222-2222-2222-222222222222"
+        }
+      }
+    },
+    "egressConnections": {
+      "mySourceAlias": {
+        "id": {
+          "rid": "ri.magritte..source.11111111-1111-1111-1111-111111111111"
+        }
+      },
+      "anotherSourceAlias": {
+        "id": {
+          "rid": "ri.magritte..source.22222222-2222-2222-2222-222222222222"
         }
       }
     }

--- a/packages/functions/src/aliases/test-data/resources.json
+++ b/packages/functions/src/aliases/test-data/resources.json
@@ -35,6 +35,22 @@
     }
   },
   "egress": {
-    "connections": []
+    "connections": [
+      {
+        "rid": "ri.magritte..source.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "alias": "previewSourceAlias"
+      },
+      {
+        "rid": "ri.magritte..source.bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        "alias": "anotherPreviewSource"
+      },
+      {
+        "rid": "ri.magritte..source.cccccccc-cccc-cccc-cccc-cccccccccccc",
+        "alias": null
+      },
+      {
+        "rid": "ri.magritte..source.dddddddd-dddd-dddd-dddd-dddddddddddd"
+      }
+    ]
   }
 }

--- a/packages/functions/src/aliases/types.ts
+++ b/packages/functions/src/aliases/types.ts
@@ -22,9 +22,14 @@ export interface Model {
   rid: string;
 }
 
+export interface Source {
+  rid: string;
+}
+
 export interface ResolvedAliases {
   custom: Record<string, string>;
   models: Record<string, Model>;
+  sources: Record<string, Source>;
 }
 
 // Environment
@@ -42,13 +47,23 @@ export interface ModelResource {
   alias?: string | null;
 }
 
+export interface EgressConnection {
+  rid: string;
+  alias?: string | null;
+}
+
 export interface ResourceScopes {
   custom: Record<string, string>;
   models: ModelResource[];
 }
 
+export interface FunctionEgress {
+  connections: EgressConnection[];
+}
+
 export interface ResourcesFile {
   resources: ResourceScopes;
+  egress: FunctionEgress;
 }
 
 // Published mode types (aliases.json)
@@ -61,9 +76,18 @@ export interface ModelValue {
   id: ModelIdentifier;
 }
 
+export interface ConnectionIdentifier {
+  rid: string;
+}
+
+export interface EgressConnectionValue {
+  id: ConnectionIdentifier;
+}
+
 export interface DefaultAliases {
   custom: Record<string, string>;
   models: Record<string, ModelValue>;
+  egressConnections: Record<string, EgressConnectionValue>;
 }
 
 export interface AliasesFile {


### PR DESCRIPTION
## Overview

This PR adds an `Aliases.getSource(...)` function util to access sources by an alias. This format allows sources to be used in marketplace installed functions seamlessly even when their api names differ. Example usage is below:

```typescript
import { getSource, getHttpsConnection, getFetch } from "@palantir/functions-sources";
import { Aliases } from "@osdk/functions"


export const config = {
    sources: [Aliases.source("mySource").rid];
}


export default async function useSource(): Promise<string> {
    const sourceInfo = Aliases.source("mySource");
    const source = await getSource(sourceInfo.rid);

    const { url } = getHttpsConnection(source)!;
    const fetch = await getFetch(source);

    const response = await fetch(`${url}/api/v2/pokemon/bulbasaur`);
    const json = await response.json() as any;

    return JSON.stringify(json);
}
```

## Testing
Unit tests + Manual testing with the utils in a repo