### PR TITLE
feat: adding keep alive parameter

### DIFF
--- a/.changeset/add-keepalive-observable-client.md
+++ b/.changeset/add-keepalive-observable-client.md
@@ -1,0 +1,6 @@
+---
+"@osdk/api": patch
+"@osdk/client": patch
+---
+
+Add keepAlive option to action calls to keep fetch requests alive on page unload

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -239,14 +239,17 @@ export type AndWhereClause<
 export type ApplyActionOptions = {
     	$returnEdits?: true
     	$validateOnly?: false
+    	keepAlive?: boolean
 } | {
     	$validateOnly?: true
     	$returnEdits?: false
+    	keepAlive?: boolean
 };
 
 // @public (undocumented)
 export type ApplyBatchActionOptions = {
     	$returnEdits?: boolean
+    	keepAlive?: boolean
 };
 
 // Warning: (ae-forgotten-export) The symbol "OrderByArg" needs to be exported by the entry point index.d.ts

--- a/packages/api/src/actions/Actions.ts
+++ b/packages/api/src/actions/Actions.ts
@@ -31,13 +31,17 @@ import type {
 import type { NULL_VALUE } from "./NullValue.js";
 
 export type ApplyActionOptions =
-  | { $returnEdits?: true; $validateOnly?: false }
+  | { $returnEdits?: true; $validateOnly?: false; keepAlive?: boolean }
   | {
     $validateOnly?: true;
     $returnEdits?: false;
+    keepAlive?: boolean;
   };
 
-export type ApplyBatchActionOptions = { $returnEdits?: boolean };
+export type ApplyBatchActionOptions = {
+  $returnEdits?: boolean;
+  keepAlive?: boolean;
+};
 
 /**
  * Helper types for converting action definition parameter types to typescript types

--- a/packages/client/src/actions/applyAction.ts
+++ b/packages/client/src/actions/applyAction.ts
@@ -128,9 +128,22 @@ export async function applyAction<
     augmentRequestContext(client, _ => ({ finalMethodCall: "applyAction" })),
     action,
   );
+
+  const effectiveClient = options?.keepAlive
+    ? {
+      ...clientWithHeaders,
+      fetch:
+        ((url: string, init?: RequestInit) =>
+          clientWithHeaders.fetch(url, {
+            ...init,
+            keepalive: true,
+          })) as typeof clientWithHeaders.fetch,
+    }
+    : clientWithHeaders;
+
   if (Array.isArray(parameters)) {
     const response = await Actions.applyBatch(
-      clientWithHeaders,
+      effectiveClient,
       await client.ontologyRid,
       action.unsanitizedApiName ?? action.apiName,
       {
@@ -156,7 +169,7 @@ export async function applyAction<
       : undefined) as ActionReturnTypeForOptions<Op>;
   } else {
     const response = await Actions.apply(
-      clientWithHeaders,
+      effectiveClient,
       await client.ontologyRid,
       action.unsanitizedApiName ?? action.apiName,
       {

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -61,6 +61,7 @@ import type { OptimisticBuilder } from "./OptimisticBuilder.js";
 export namespace ObservableClient {
   export interface ApplyActionOptions {
     optimisticUpdate?: (ctx: OptimisticBuilder) => void;
+    keepAlive?: boolean;
   }
 }
 

--- a/packages/client/src/observable/internal/Store.ts
+++ b/packages/client/src/observable/internal/Store.ts
@@ -82,6 +82,7 @@ import { WhereClauseCanonicalizer } from "./WhereClauseCanonicalizer.js";
 export namespace Store {
   export interface ApplyActionOptions {
     optimisticUpdate?: (ctx: OptimisticBuilder) => void;
+    keepAlive?: boolean;
   }
 }
 

--- a/packages/client/src/observable/internal/actions/ActionApplication.ts
+++ b/packages/client/src/observable/internal/actions/ActionApplication.ts
@@ -38,7 +38,7 @@ export class ActionApplication {
   ) => Promise<ActionEditResponse> = async (
     action,
     args,
-    { optimisticUpdate } = {},
+    { optimisticUpdate, keepAlive } = {},
   ) => {
     const logger = process.env.NODE_ENV !== "production"
       ? this.store.logger?.child({ methodName: "applyAction" })
@@ -59,7 +59,7 @@ export class ActionApplication {
             await this.store
               .client(action).batchApplyAction(
                 args,
-                { $returnEdits: true },
+                { $returnEdits: true, keepAlive },
               );
 
           await this.#invalidateActionEditResponse(results);
@@ -73,7 +73,7 @@ export class ActionApplication {
 
         const actionResults: ActionEditResponse = await this.store.client(
           action,
-        ).applyAction(args as any, { $returnEdits: true });
+        ).applyAction(args as any, { $returnEdits: true, keepAlive });
 
         if (process.env.NODE_ENV !== "production") {
           if (ACTION_DELAY > 0) {


### PR DESCRIPTION
## Summary

Add `keepAlive` option to `applyAction` and `batchApplyAction` so fetch requests survive page unloads (e.g. user navigates away or closes the tab while an action is in flight).

When `keepAlive: true` is passed, the client's `fetch` is wrapped to inject `keepAlive: true` into the `RequestInit`. This uses the [standard fetch keepAlive behavior](https://developer.mozilla.org/en-US/docs/Web/API/Request/keepAlive) — no backend changes required.

### Usage

```typescript
// Direct client
client(myAction).applyAction(params, { keepAlive: true });

// Batch
client(myAction).batchApplyAction(paramsList, { $returnEdits: true, keepAlive: true });

// Observable client
observableClient.applyAction(myAction, params, { keepAlive: true });
```

### Changes

- **`@osdk/api`**: Add `keepAlive?: boolean` to `ApplyActionOptions` and `ApplyBatchActionOptions`
- **`@osdk/client` (`applyAction.ts`)**: Wrap client fetch with `keepAlive: true` in `RequestInit` when option is set
- **`@osdk/client` (Observable client)**: Thread `keepAlive` through `Store.ApplyActionOptions`, `ObservableClient.ApplyActionOptions`, and `ActionApplication`