### PR TITLE
add cipher text property support

### DIFF
--- a/.changeset/cipher-text-property-support.md
+++ b/.changeset/cipher-text-property-support.md
@@ -1,0 +1,9 @@
+---
+"@osdk/api": minor
+"@osdk/generator-converters": minor
+"@osdk/client": minor
+---
+
+add support for cipher text properties on objects
+
+Cipher text properties on object types are now hydrated into a `CipherText` value with a `decrypt()` helper that returns the plaintext, e.g. `await customer.ssn?.decrypt()`. Previously these properties were silently dropped from generated SDKs.

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -315,7 +315,15 @@ export interface BaseObjectSet<Q extends ObjectOrInterfaceDefinition> {
 }
 
 // @public (undocumented)
-export type BaseWirePropertyTypes = "string" | "datetime" | "double" | "boolean" | "integer" | "timestamp" | "short" | "long" | "float" | "decimal" | "byte" | "marking" | "mediaReference" | "numericTimeseries" | "stringTimeseries" | "sensorTimeseries" | "attachment" | "geopoint" | "geoshape" | "geotimeSeriesReference" | "vector";
+export type BaseWirePropertyTypes = "string" | "datetime" | "double" | "boolean" | "integer" | "timestamp" | "short" | "long" | "float" | "decimal" | "byte" | "marking" | "mediaReference" | "numericTimeseries" | "stringTimeseries" | "sensorTimeseries" | "attachment" | "cipherText" | "geopoint" | "geoshape" | "geotimeSeriesReference" | "vector";
+
+// @public (undocumented)
+export interface CipherText {
+    	// (undocumented)
+    ciphertext: string;
+    	// (undocumented)
+    decrypt(): Promise<string | undefined>;
+}
 
 // @public (undocumented)
 export type CompileTimeMetadata<T extends {
@@ -1575,6 +1583,8 @@ export interface PropertyValueWireToClient {
     boolean: boolean;
     	// (undocumented)
     byte: number;
+    	// (undocumented)
+    cipherText: CipherText;
     	// (undocumented)
     datetime: string;
     	// (undocumented)

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -71,6 +71,7 @@ export type {
   AttachmentMetadata,
   AttachmentUpload,
 } from "./object/Attachment.js";
+export type { CipherText } from "./object/CipherText.js";
 export type {
   AsyncIterArgs,
   Augment,

--- a/packages/api/src/mapping/PropertyValueMapping.ts
+++ b/packages/api/src/mapping/PropertyValueMapping.ts
@@ -15,6 +15,7 @@
  */
 
 import type { Attachment, AttachmentUpload } from "../object/Attachment.js";
+import type { CipherText } from "../object/CipherText.js";
 import type { Media, MediaReference } from "../object/Media.js";
 import type {
   GeotimeSeriesProperty,
@@ -28,6 +29,7 @@ export interface PropertyValueWireToClient {
   attachment: Attachment;
   boolean: boolean;
   byte: number;
+  cipherText: CipherText;
   datetime: string;
   decimal: string;
   double: number;
@@ -64,6 +66,7 @@ export interface PropertyValueClientToWire {
   attachment: string | AttachmentUpload | Blob & { readonly name: string };
   boolean: boolean;
   byte: number;
+  cipherText: never;
   datetime: string;
   decimal: string | number;
   double: number;
@@ -96,6 +99,7 @@ export interface PropertyValueWireToCreate {
   attachment: Attachment | string;
   boolean: boolean;
   byte: number;
+  cipherText: never;
   datetime: string;
   decimal: string;
   double: number;

--- a/packages/api/src/object/CipherText.ts
+++ b/packages/api/src/object/CipherText.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,30 +14,7 @@
  * limitations under the License.
  */
 
-export type WirePropertyTypes =
-  | BaseWirePropertyTypes
-  | Record<string, BaseWirePropertyTypes>;
-
-export type BaseWirePropertyTypes =
-  | "string"
-  | "datetime"
-  | "double"
-  | "boolean"
-  | "integer"
-  | "timestamp"
-  | "short"
-  | "long"
-  | "float"
-  | "decimal"
-  | "byte"
-  | "marking"
-  | "mediaReference"
-  | "numericTimeseries"
-  | "stringTimeseries"
-  | "sensorTimeseries"
-  | "attachment"
-  | "cipherText"
-  | "geopoint"
-  | "geoshape"
-  | "geotimeSeriesReference"
-  | "vector";
+export interface CipherText {
+  ciphertext: string;
+  decrypt(): Promise<string | undefined>;
+}

--- a/packages/client/src/createCipherTextProperty.ts
+++ b/packages/client/src/createCipherTextProperty.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { CipherText } from "@osdk/api";
+import * as CipherTextProperties from "@osdk/foundry.ontologies/CipherTextProperty";
+import type { MinimalClient } from "./MinimalClientContext.js";
+
+/** @internal */
+export function createCipherTextProperty(
+  client: MinimalClient,
+  objectApiName: string,
+  primaryKey: any,
+  propertyName: string,
+  ciphertext: string,
+): CipherText {
+  return {
+    ciphertext,
+    async decrypt() {
+      const result = await CipherTextProperties.decrypt(
+        client,
+        await client.ontologyRid,
+        objectApiName,
+        primaryKey,
+        propertyName,
+      );
+      return result.plaintext;
+    },
+  };
+}

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -24,6 +24,7 @@ import type {
   SecuredPropertyValue,
 } from "@osdk/foundry.ontologies";
 import invariant from "tiny-invariant";
+import { createCipherTextProperty } from "../../createCipherTextProperty.js";
 import { GeotimeSeriesPropertyImpl } from "../../createGeotimeSeriesProperty.js";
 import { MediaReferencePropertyImpl } from "../../createMediaReferenceProperty.js";
 import { TimeSeriesPropertyImpl } from "../../createTimeseriesProperty.js";
@@ -50,6 +51,7 @@ import type { ObjectHolder } from "./ObjectHolder.js";
 const specialPropertyTypes = new Set(
   [
     "attachment",
+    "cipherText",
     "geotimeSeriesReference",
     "mediaReference",
     "numericTimeseries",
@@ -288,6 +290,30 @@ function createSpecialProperty(
     return hydrateAttachmentFromRidInternal(
       client,
       (rawValue as Attachment).rid,
+    );
+  }
+
+  if (propDef.type === "cipherText") {
+    const objectApiName = objectDef.apiName;
+    const primaryKey = rawObject[objectDef.primaryKeyApiName as string];
+    const propertyName = p as string;
+    if (Array.isArray(rawValue)) {
+      return rawValue.map(c =>
+        createCipherTextProperty(
+          client,
+          objectApiName,
+          primaryKey,
+          propertyName,
+          c as string,
+        )
+      );
+    }
+    return createCipherTextProperty(
+      client,
+      objectApiName,
+      primaryKey,
+      propertyName,
+      rawValue as string,
     );
   }
 

--- a/packages/e2e.generated.catchall/ontology.json
+++ b/packages/e2e.generated.catchall/ontology.json
@@ -445,6 +445,63 @@
     }
   },
   "objectTypes": {
+    "CipherTextTest": {
+      "objectType": {
+        "apiName": "CipherTextTest",
+        "displayName": "Cipher Text Test",
+        "status": "EXPERIMENTAL",
+        "description": "",
+        "pluralDisplayName": "Cipher Text Tests",
+        "icon": {
+          "type": "blueprint",
+          "color": "#4C90F0",
+          "name": "cube"
+        },
+        "primaryKey": "primaryKey_",
+        "properties": {
+          "cipherText": {
+            "displayName": "Cipher text",
+            "dataType": {
+              "type": "cipherText"
+            },
+            "rid": "ri.ontology.main.property.16e12750-3299-41c2-a2fd-ce702833fea0",
+            "status": {
+              "type": "experimental"
+            },
+            "visibility": "NORMAL",
+            "typeClasses": []
+          },
+          "primaryKey_": {
+            "displayName": "Primary Key",
+            "dataType": {
+              "type": "string"
+            },
+            "rid": "ri.ontology.main.property.ac266be0-bb64-42c0-8475-4e8837954bca",
+            "status": {
+              "type": "experimental"
+            },
+            "visibility": "NORMAL",
+            "typeClasses": [
+              {
+                "kind": "render_hint",
+                "name": "SELECTABLE"
+              },
+              {
+                "kind": "render_hint",
+                "name": "SORTABLE"
+              }
+            ]
+          }
+        },
+        "rid": "ri.ontology.main.object-type.7782bd8f-954f-43cb-ba1a-b141d1638d6b",
+        "titleProperty": "primaryKey_",
+        "visibility": "NORMAL"
+      },
+      "linkTypes": [],
+      "implementsInterfaces": [],
+      "implementsInterfaces2": {},
+      "sharedPropertyTypeMapping": {}
+    },
     "MasonHeavyEquipment": {
       "objectType": {
         "apiName": "MasonHeavyEquipment",
@@ -6459,9 +6516,7 @@
       },
       "extendsInterfaces": [],
       "allExtendsInterfaces": [],
-      "implementedByObjectTypes": [
-        "MwaltherPersonOt"
-      ],
+      "implementedByObjectTypes": ["MwaltherPersonOt"],
       "links": {},
       "allLinks": {}
     },
@@ -6566,15 +6621,9 @@
           "requireImplementation": false
         }
       },
-      "extendsInterfaces": [
-        "MwaltherPersonV2"
-      ],
-      "allExtendsInterfaces": [
-        "MwaltherPersonV2"
-      ],
-      "implementedByObjectTypes": [
-        "MwaltherPersonOt"
-      ],
+      "extendsInterfaces": ["MwaltherPersonV2"],
+      "allExtendsInterfaces": ["MwaltherPersonV2"],
+      "implementedByObjectTypes": ["MwaltherPersonOt"],
       "links": {},
       "allLinks": {}
     },
@@ -6610,9 +6659,7 @@
       },
       "extendsInterfaces": [],
       "allExtendsInterfaces": [],
-      "implementedByObjectTypes": [
-        "MwaltherPersonOt"
-      ],
+      "implementedByObjectTypes": ["MwaltherPersonOt"],
       "links": {},
       "allLinks": {}
     }

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/index.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/index.ts
@@ -37,6 +37,7 @@ export {
   BgaoNflPlayer,
   BoundariesUsState,
   BuilderDeploymentState,
+  CipherTextTest,
   Country_1,
   DherlihyComplexObject,
   Employee,

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects.ts
@@ -1,6 +1,7 @@
 export { BgaoNflPlayer } from './objects/BgaoNflPlayer.js';
 export { BoundariesUsState } from './objects/BoundariesUsState.js';
 export { BuilderDeploymentState } from './objects/BuilderDeploymentState.js';
+export { CipherTextTest } from './objects/CipherTextTest.js';
 export { Country_1 } from './objects/Country_1.js';
 export { DherlihyComplexObject } from './objects/DherlihyComplexObject.js';
 export { Employee } from './objects/Employee.js';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/CipherTextTest.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/CipherTextTest.ts
@@ -1,0 +1,117 @@
+import type { PropertyDef as $PropertyDef } from '@osdk/client';
+import { $osdkMetadata } from '../../OntologyMetadata.js';
+import type { $ExpectedClientVersion } from '../../OntologyMetadata.js';
+import type {
+  PropertyKeys as $PropertyKeys,
+  ObjectTypeDefinition as $ObjectTypeDefinition,
+  ObjectMetadata as $ObjectMetadata,
+} from '@osdk/client';
+import type {
+  ObjectSet as $ObjectSet,
+  Osdk as $Osdk,
+  OsdkObject as $OsdkObject,
+  PropertyValueWireToClient as $PropType,
+  SingleLinkAccessor as $SingleLinkAccessor,
+} from '@osdk/client';
+
+export namespace CipherTextTest {
+  export type PropertyKeys = 'cipherText' | 'primaryKey_';
+
+  export type Links = {};
+
+  export interface Props {
+    /**
+     * @experimental
+     *
+     *   property status: experimental
+     *
+     *   display name: 'Cipher text'
+     */
+    readonly cipherText: $PropType['cipherText'] | undefined;
+    /**
+     * @experimental
+     *
+     *   property status: experimental
+     *
+     *   display name: 'Primary Key'
+     */
+    readonly primaryKey_: $PropType['string'];
+  }
+  export type StrictProps = Props;
+
+  export interface ObjectSet extends $ObjectSet<CipherTextTest, CipherTextTest.ObjectSet> {}
+
+  export type OsdkInstance<
+    OPTIONS extends never | '$rid' = never,
+    K extends keyof CipherTextTest.Props = keyof CipherTextTest.Props,
+  > = $Osdk.Instance<CipherTextTest, OPTIONS, K>;
+
+  /** @deprecated use OsdkInstance */
+  export type OsdkObject<
+    OPTIONS extends never | '$rid' = never,
+    K extends keyof CipherTextTest.Props = keyof CipherTextTest.Props,
+  > = OsdkInstance<OPTIONS, K>;
+}
+
+export interface CipherTextTest extends $ObjectTypeDefinition {
+  osdkMetadata: typeof $osdkMetadata;
+  type: 'object';
+  apiName: 'CipherTextTest';
+  primaryKeyApiName: 'primaryKey_';
+  primaryKeyType: 'string';
+  __DefinitionMetadata?: {
+    objectSet: CipherTextTest.ObjectSet;
+    props: CipherTextTest.Props;
+    linksType: CipherTextTest.Links;
+    strictProps: CipherTextTest.StrictProps;
+    apiName: 'CipherTextTest';
+    description: '';
+    displayName: 'Cipher Text Test';
+    icon: {
+      type: 'blueprint';
+      color: '#4C90F0';
+      name: 'cube';
+    };
+    implements: [];
+    interfaceMap: {};
+    inverseInterfaceMap: {};
+    links: {};
+    pluralDisplayName: 'Cipher Text Tests';
+    primaryKeyApiName: 'primaryKey_';
+    primaryKeyType: 'string';
+    properties: {
+      /**
+       * @experimental
+       *
+       *   property status: experimental
+       *
+       *   display name: 'Cipher text'
+       */
+      cipherText: $PropertyDef<'cipherText', 'nullable', 'single'>;
+      /**
+       * @experimental
+       *
+       *   property status: experimental
+       *
+       *   display name: 'Primary Key'
+       */
+      primaryKey_: $PropertyDef<'string', 'non-nullable', 'single'>;
+    };
+    rid: 'ri.ontology.main.object-type.7782bd8f-954f-43cb-ba1a-b141d1638d6b';
+    status: 'EXPERIMENTAL';
+    titleProperty: 'primaryKey_';
+    type: 'object';
+    visibility: 'NORMAL';
+  };
+}
+
+export const CipherTextTest = {
+  type: 'object',
+  apiName: 'CipherTextTest',
+  osdkMetadata: $osdkMetadata,
+  primaryKeyApiName: 'primaryKey_',
+  primaryKeyType: 'string',
+  internalDoNotUseMetadata: {
+    rid: 'ri.ontology.main.object-type.7782bd8f-954f-43cb-ba1a-b141d1638d6b',
+  },
+} satisfies CipherTextTest & { internalDoNotUseMetadata: { rid: string } } as CipherTextTest;

--- a/packages/e2e.sandbox.catchall/src/runCipherTextTest.ts
+++ b/packages/e2e.sandbox.catchall/src/runCipherTextTest.ts
@@ -1,0 +1,16 @@
+import type { CipherText } from "@osdk/api";
+import { CipherTextTest } from "@osdk/e2e.generated.catchall";
+import { client } from "./client.js";
+
+export async function runCipherTextTest(): Promise<void> {
+  const objects = await client(CipherTextTest).fetchPage();
+
+  const cipherText: CipherText | undefined = objects.data[0].cipherText;
+  const encrypted: string | undefined = cipherText?.ciphertext;
+  const decrypted: string | undefined = await cipherText?.decrypt();
+  console.log(cipherText);
+  console.log(encrypted);
+  console.log(decrypted);
+}
+
+void runCipherTextTest();

--- a/packages/generator-converters/src/wirePropertyV2ToSdkPropertyDefinition.ts
+++ b/packages/generator-converters/src/wirePropertyV2ToSdkPropertyDefinition.ts
@@ -53,6 +53,7 @@ export function wirePropertyV2ToSdkPropertyDefinition(
     case "boolean":
     case "date":
     case "attachment":
+    case "cipherText":
     case "mediaReference":
     case "geopoint":
     case "geoshape":
@@ -86,13 +87,6 @@ export function wirePropertyV2ToSdkPropertyDefinition(
           : undefined,
       };
     }
-    case "cipherText": {
-      log?.info(
-        `${JSON.stringify(input.dataType.type)} is not a supported dataType`,
-      );
-
-      return undefined;
-    }
 
     default:
       const _: never = input.dataType;
@@ -119,6 +113,7 @@ function objectPropertyTypeToSdkPropertyDefinition(
     case "short":
     case "boolean":
     case "attachment":
+    case "cipherText":
     case "geopoint":
     case "geoshape":
     case "timestamp":
@@ -148,13 +143,6 @@ function objectPropertyTypeToSdkPropertyDefinition(
         },
         {},
       );
-    }
-    case "cipherText": {
-      log?.info(
-        `${JSON.stringify(propertyType.type)} is not a supported propertyType`,
-      );
-
-      return undefined;
     }
     default: {
       const _: never = propertyType;

--- a/packages/monorepo.cspell/dict.foundry-words.txt
+++ b/packages/monorepo.cspell/dict.foundry-words.txt
@@ -1,6 +1,7 @@
 bellaso
 blockset
 CBAC
+ciphertext
 dicom
 efgh
 fforms


### PR DESCRIPTION
## Summary
- Hydrate cipher text properties on objects into a `CipherText` value with a `decrypt()` helper, e.g. `await customer.ssn?.decrypt()`. Previously these properties were silently dropped from generated SDKs (`wirePropertyV2ToSdkPropertyDefinition.ts` returned `undefined` for the `cipherText` branch).
- Add `cipherText` to `BaseWirePropertyTypes` and to `PropertyValueWireToClient` (mapped to `CipherText`). Mapped to `never` in `PropertyValueClientToWire` and `PropertyValueWireToCreate` since action inputs and create payloads can't accept cipher text — encryption is server-side via cipher channels, and there's no client-side encrypt API.
- Wire cipher text into `createOsdkObject` alongside `attachment`/`mediaReference` as a "special property", hydrating the wire string (e.g. `"CIPHER::ri.bellaso..."`) into a `{ ciphertext, decrypt() }` object via an internal `createCipherTextProperty` helper. Handles both single and array variants.

## Test plan
- [x] `pnpm turbo check` (38 tasks) and `pnpm turbo test --filter=@osdk/api --filter=@osdk/generator-converters --filter=@osdk/client` both pass.
- [x] API extractor regenerated (`etc/api.report.api.md` reflects the new `CipherText` interface and `cipherText` entries).
- [x] Codegen for `e2e.generated.catchall` produces the expected `Props.cipherText: $PropType['cipherText'] | undefined` and `properties.cipherText: $PropertyDef<'cipherText', ...>` for the new `CipherTextTest` object type.
- [x] `pnpm e2e runCipherTextTest` runs end-to-end: metadata fetch → object load → `decrypt()` call. The final API call fails with `ApiFeaturePreviewUsageOnly` because `@osdk/foundry.ontologies@2.57.0` bundles `decrypt` without a query-args slot — it can't pass `preview=true`. Will resolve when the upstream SDK exposes preview on the decrypt endpoint, or when the backend takes decrypt out of beta.

## Out of scope
- `generator-converters.ontologyir` and `maker-experimental` paths still drop `cipherText` (matches existing treatment of `mediaReference`, `vector`, etc.).
- RDP / derived-property cipher text handling (the `modifyRdpProperties` branch in `createOsdkObject.ts` still only supports `attachment`).
- Faux test-double support (`packages/faux/.../ToObjectTypeDefinition.ts` continues to exclude `cipherText` from its prop-type mapping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)