### PR TITLE
Add Component Showcase story

### DIFF
--- a/packages/react-components-storybook/src/stories/ComponentShowcase/ComponentShowcase.module.css
+++ b/packages/react-components-storybook/src/stories/ComponentShowcase/ComponentShowcase.module.css
@@ -1,0 +1,94 @@
+.osdkShowcase {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+  background-color: var(--osdk-background-primary, #ffffff);
+  font-family: var(--osdk-typography-family-default, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif);
+}
+
+.osdkShowcaseTabs {
+  display: flex;
+  gap: 0;
+  padding-inline: 1.5rem;
+  border-block-end: 1px solid var(--osdk-surface-border-color-default, #e5e8eb);
+  flex-shrink: 0;
+}
+
+.osdkShowcaseTab {
+  padding: 0.75rem 1rem;
+  border: none;
+  background-color: transparent;
+  font-size: 0.875rem;
+  font-family: inherit;
+  color: var(--osdk-typography-color-muted, #5f6b7c);
+  cursor: pointer;
+  border-block-end: 2px solid transparent;
+  margin-block-end: -1px;
+}
+
+.osdkShowcaseTab:hover {
+  color: var(--osdk-typography-color-default-rest, #1c2127);
+}
+
+.osdkShowcaseTab[data-active="true"] {
+  color: var(--osdk-typography-color-default-rest, #1c2127);
+  font-weight: 600;
+  border-block-end-color: var(--osdk-typography-color-default-rest, #1c2127);
+}
+
+.osdkShowcaseBody {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 1.5rem;
+  background-color: var(--osdk-background-secondary, #f6f7f9);
+}
+
+/* Data tab: FilterList sidebar + Table */
+.osdkShowcaseDataLayout {
+  display: flex;
+  gap: 1rem;
+  height: 100%;
+}
+
+.osdkShowcaseDataSidebar {
+  width: 320px;
+  flex-shrink: 0;
+  overflow: auto;
+}
+
+.osdkShowcaseDataMain {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+}
+
+/* Card wrapper for components */
+.osdkShowcaseCard {
+  background-color: var(--osdk-background-primary, #ffffff);
+  border: 1px solid var(--osdk-surface-border-color-default, #e5e8eb);
+  border-radius: var(--osdk-surface-border-radius, 4px);
+  overflow: hidden;
+  height: 100%;
+}
+
+/* Form tab: responsive card grid */
+.osdkShowcaseFormGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+  gap: 1rem;
+  align-items: start;
+}
+
+.osdkShowcaseFormCard {
+  background-color: var(--osdk-background-primary, #ffffff);
+  border: 1px solid var(--osdk-surface-border-color-default, #e5e8eb);
+  border-radius: var(--osdk-surface-border-radius, 4px);
+  overflow: hidden;
+}
+
+/* PDF tab: full height card */
+.osdkShowcasePdfLayout {
+  height: 100%;
+}

--- a/packages/react-components-storybook/src/stories/ComponentShowcase/ComponentShowcase.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ComponentShowcase/ComponentShowcase.stories.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fauxFoundry } from "../../mocks/fauxFoundry.js";
+import { ComponentShowcase } from "./ComponentShowcase.js";
+
+const meta: Meta<typeof ComponentShowcase> = {
+  title: "Component Showcase",
+  component: ComponentShowcase,
+  parameters: {
+    layout: "fullscreen",
+    docs: { disable: true },
+    controls: { disable: true },
+    msw: {
+      handlers: fauxFoundry.handlers,
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/packages/react-components-storybook/src/stories/ComponentShowcase/ComponentShowcase.tsx
+++ b/packages/react-components-storybook/src/stories/ComponentShowcase/ComponentShowcase.tsx
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useCallback, useState } from "react";
+import styles from "./ComponentShowcase.module.css";
+import { ShowcaseFilterList } from "./ShowcaseFilterList.js";
+import {
+  ContactForm,
+  DateRangeForm,
+  SchedulingForm,
+  SettingsForm,
+  UploadForm,
+} from "./ShowcaseForm.js";
+import { ShowcasePdfViewer } from "./ShowcasePdfViewer.js";
+import { ShowcaseTable } from "./ShowcaseTable.js";
+
+const TABS = [
+  { id: "data", label: "Data" },
+  { id: "forms", label: "Forms" },
+  { id: "documents", label: "Documents" },
+] as const;
+
+type TabId = (typeof TABS)[number]["id"];
+
+export const ComponentShowcase = React.memo(
+  function ComponentShowcaseFn(): React.ReactElement {
+    const [activeTab, setActiveTab] = useState<TabId>("data");
+
+    return (
+      <div className={styles.osdkShowcase}>
+        <div className={styles.osdkShowcaseTabs}>
+          {TABS.map((tab) => (
+            <ShowcaseTab
+              key={tab.id}
+              tabId={tab.id}
+              label={tab.label}
+              isActive={tab.id === activeTab}
+              onSelect={setActiveTab}
+            />
+          ))}
+        </div>
+
+        <div className={styles.osdkShowcaseBody}>
+          {activeTab === "data" && <DataPanel />}
+          {activeTab === "forms" && <FormsPanel />}
+          {activeTab === "documents" && <DocumentsPanel />}
+        </div>
+      </div>
+    );
+  },
+);
+
+interface ShowcaseTabProps {
+  readonly tabId: TabId;
+  readonly label: string;
+  readonly isActive: boolean;
+  readonly onSelect: (tabId: TabId) => void;
+}
+
+const ShowcaseTab = React.memo(function ShowcaseTabFn(
+  { tabId, label, isActive, onSelect }: ShowcaseTabProps,
+): React.ReactElement {
+  const handleClick = useCallback(() => {
+    onSelect(tabId);
+  }, [tabId, onSelect]);
+
+  return (
+    <button
+      type="button"
+      className={styles.osdkShowcaseTab}
+      data-active={isActive}
+      onClick={handleClick}
+    >
+      {label}
+    </button>
+  );
+});
+
+const DataPanel = React.memo(function DataPanelFn(): React.ReactElement {
+  return (
+    <div className={styles.osdkShowcaseDataLayout}>
+      <div className={styles.osdkShowcaseDataSidebar}>
+        <div className={styles.osdkShowcaseCard}>
+          <ShowcaseFilterList />
+        </div>
+      </div>
+      <div className={styles.osdkShowcaseDataMain}>
+        <div className={styles.osdkShowcaseCard}>
+          <ShowcaseTable />
+        </div>
+      </div>
+    </div>
+  );
+});
+
+const FormsPanel = React.memo(function FormsPanelFn(): React.ReactElement {
+  return (
+    <div className={styles.osdkShowcaseFormGrid}>
+      <div className={styles.osdkShowcaseFormCard}>
+        <ContactForm />
+      </div>
+      <div className={styles.osdkShowcaseFormCard}>
+        <SettingsForm />
+      </div>
+      <div className={styles.osdkShowcaseFormCard}>
+        <SchedulingForm />
+      </div>
+      <div className={styles.osdkShowcaseFormCard}>
+        <UploadForm />
+      </div>
+      <div className={styles.osdkShowcaseFormCard}>
+        <DateRangeForm />
+      </div>
+    </div>
+  );
+});
+
+const DocumentsPanel = React.memo(
+  function DocumentsPanelFn(): React.ReactElement {
+    return (
+      <div className={styles.osdkShowcasePdfLayout}>
+        <div className={styles.osdkShowcaseCard}>
+          <ShowcasePdfViewer />
+        </div>
+      </div>
+    );
+  },
+);

--- a/packages/react-components-storybook/src/stories/ComponentShowcase/ShowcaseFilterList.tsx
+++ b/packages/react-components-storybook/src/stories/ComponentShowcase/ShowcaseFilterList.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { FilterDefinitionUnion } from "@osdk/react-components/experimental/filter-list";
+import { FilterList } from "@osdk/react-components/experimental/filter-list";
+import React from "react";
+import { Employee } from "../../types/Employee.js";
+
+const FILTER_DEFINITIONS: Array<FilterDefinitionUnion<Employee>> = [
+  {
+    type: "PROPERTY",
+    id: "department",
+    key: "department",
+    label: "Department",
+    filterComponent: "LISTOGRAM",
+    filterState: { type: "EXACT_MATCH", values: [] },
+  },
+  {
+    type: "PROPERTY",
+    id: "fullName",
+    key: "fullName",
+    label: "Full Name",
+    filterComponent: "CONTAINS_TEXT",
+    filterState: { type: "CONTAINS_TEXT" },
+  },
+];
+
+export const ShowcaseFilterList = React.memo(
+  function ShowcaseFilterListFn(): React.ReactElement {
+    return (
+      <FilterList
+        objectType={Employee}
+        filterDefinitions={FILTER_DEFINITIONS}
+      />
+    );
+  },
+);

--- a/packages/react-components-storybook/src/stories/ComponentShowcase/ShowcaseForm.tsx
+++ b/packages/react-components-storybook/src/stories/ComponentShowcase/ShowcaseForm.tsx
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { RendererFieldDefinition } from "@osdk/react-components/experimental";
+import { BaseForm } from "@osdk/react-components/experimental";
+import React from "react";
+
+function noop(_formState: Record<string, unknown>): void {
+  // Showcase-only — submissions are discarded
+}
+
+// -- Contact Form --
+
+const CONTACT_FIELDS: ReadonlyArray<RendererFieldDefinition> = [
+  {
+    fieldKey: "fullName",
+    fieldComponent: "TEXT_INPUT",
+    label: "Full Name",
+    isRequired: true,
+    fieldComponentProps: { placeholder: "Jane Doe" },
+  },
+  {
+    fieldKey: "email",
+    fieldComponent: "TEXT_INPUT",
+    label: "Email",
+    isRequired: true,
+    fieldComponentProps: { placeholder: "jane@example.com" },
+  },
+  {
+    fieldKey: "message",
+    fieldComponent: "TEXT_AREA",
+    label: "Message",
+    fieldComponentProps: { placeholder: "How can we help?", rows: 4 },
+  },
+];
+
+export const ContactForm = React.memo(
+  function ContactFormFn(): React.ReactElement {
+    return (
+      <BaseForm
+        formTitle="Contact Us"
+        fieldDefinitions={CONTACT_FIELDS}
+        onSubmit={noop}
+      />
+    );
+  },
+);
+
+// -- Settings Form --
+
+const DEPARTMENT_ITEMS = [
+  "Engineering",
+  "Marketing",
+  "Sales",
+  "Finance",
+  "Operations",
+  "Legal",
+];
+
+const ROLE_OPTIONS = [
+  { label: "Admin", value: "admin" },
+  { label: "Editor", value: "editor" },
+  { label: "Viewer", value: "viewer" },
+];
+
+const SETTINGS_FIELDS: ReadonlyArray<RendererFieldDefinition> = [
+  {
+    fieldKey: "displayName",
+    fieldComponent: "TEXT_INPUT",
+    label: "Display Name",
+    isRequired: true,
+    fieldComponentProps: { placeholder: "Enter display name" },
+  },
+  {
+    fieldKey: "department",
+    fieldComponent: "DROPDOWN",
+    label: "Department",
+    fieldComponentProps: {
+      items: DEPARTMENT_ITEMS,
+      isSearchable: true,
+      placeholder: "Search departments...",
+    },
+  },
+  {
+    fieldKey: "role",
+    fieldComponent: "RADIO_BUTTONS",
+    label: "Role",
+    fieldComponentProps: { options: ROLE_OPTIONS },
+  },
+  {
+    fieldKey: "maxItems",
+    fieldComponent: "NUMBER_INPUT",
+    label: "Max Items Per Page",
+    fieldComponentProps: { min: 10, max: 100, step: 10, placeholder: "25" },
+  },
+];
+
+export const SettingsForm = React.memo(
+  function SettingsFormFn(): React.ReactElement {
+    return (
+      <BaseForm
+        formTitle="User Settings"
+        fieldDefinitions={SETTINGS_FIELDS}
+        onSubmit={noop}
+      />
+    );
+  },
+);
+
+// -- Scheduling Form --
+
+const SCHEDULING_FIELDS: ReadonlyArray<RendererFieldDefinition> = [
+  {
+    fieldKey: "eventName",
+    fieldComponent: "TEXT_INPUT",
+    label: "Event Name",
+    isRequired: true,
+    fieldComponentProps: { placeholder: "Team standup" },
+  },
+  {
+    fieldKey: "scheduledAt",
+    fieldComponent: "DATETIME_PICKER",
+    label: "Date & Time",
+    fieldComponentProps: {
+      showTime: true,
+      placeholder: "Select date and time",
+    },
+  },
+  {
+    fieldKey: "description",
+    fieldComponent: "TEXT_AREA",
+    label: "Description",
+    fieldComponentProps: { placeholder: "Optional notes...", rows: 3 },
+  },
+];
+
+export const SchedulingForm = React.memo(
+  function SchedulingFormFn(): React.ReactElement {
+    return (
+      <BaseForm
+        formTitle="Schedule Event"
+        fieldDefinitions={SCHEDULING_FIELDS}
+        onSubmit={noop}
+      />
+    );
+  },
+);
+
+// -- Upload Form --
+
+const TAG_ITEMS = ["Urgent", "Review", "Follow-up", "Archived", "Pinned"];
+
+const UPLOAD_FIELDS: ReadonlyArray<RendererFieldDefinition> = [
+  {
+    fieldKey: "title",
+    fieldComponent: "TEXT_INPUT",
+    label: "Document Title",
+    isRequired: true,
+    fieldComponentProps: { placeholder: "Quarterly report" },
+  },
+  {
+    fieldKey: "tags",
+    fieldComponent: "DROPDOWN",
+    label: "Tags",
+    fieldComponentProps: {
+      items: TAG_ITEMS,
+      isMultiple: true,
+      isSearchable: true,
+      placeholder: "Select tags...",
+    },
+  },
+  {
+    fieldKey: "file",
+    fieldComponent: "FILE_PICKER",
+    label: "Attachment",
+    fieldComponentProps: { accept: ".pdf,.doc,.docx,.xlsx" },
+  },
+];
+
+export const UploadForm = React.memo(
+  function UploadFormFn(): React.ReactElement {
+    return (
+      <BaseForm
+        formTitle="Upload Document"
+        fieldDefinitions={UPLOAD_FIELDS}
+        onSubmit={noop}
+      />
+    );
+  },
+);
+
+// -- Date Range Form --
+
+const DATE_RANGE_FIELDS: ReadonlyArray<RendererFieldDefinition> = [
+  {
+    fieldKey: "reportName",
+    fieldComponent: "TEXT_INPUT",
+    label: "Report Name",
+    isRequired: true,
+    fieldComponentProps: { placeholder: "Monthly summary" },
+  },
+  {
+    fieldKey: "dateRange",
+    fieldComponent: "DATE_RANGE_INPUT",
+    label: "Date Range",
+    fieldComponentProps: {
+      placeholderStart: "Start date",
+      placeholderEnd: "End date",
+    },
+  },
+  {
+    fieldKey: "budget",
+    fieldComponent: "NUMBER_INPUT",
+    label: "Budget",
+    fieldComponentProps: { min: 0, step: 100, placeholder: "0" },
+  },
+];
+
+export const DateRangeForm = React.memo(
+  function DateRangeFormFn(): React.ReactElement {
+    return (
+      <BaseForm
+        formTitle="Generate Report"
+        fieldDefinitions={DATE_RANGE_FIELDS}
+        onSubmit={noop}
+      />
+    );
+  },
+);

--- a/packages/react-components-storybook/src/stories/ComponentShowcase/ShowcasePdfViewer.tsx
+++ b/packages/react-components-storybook/src/stories/ComponentShowcase/ShowcasePdfViewer.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BasePdfViewer } from "@osdk/react-components/experimental/pdf-viewer";
+import React from "react";
+
+// cspell:disable-next-line
+const PDF_SRC = `${import.meta.env.BASE_URL}compressed.tracemonkey-pldi-09.pdf`;
+
+export const ShowcasePdfViewer = React.memo(
+  function ShowcasePdfViewerFn(): React.ReactElement {
+    return (
+      <BasePdfViewer
+        src={PDF_SRC}
+        initialPage={1}
+        initialScale={1.0}
+      />
+    );
+  },
+);

--- a/packages/react-components-storybook/src/stories/ComponentShowcase/ShowcaseTable.tsx
+++ b/packages/react-components-storybook/src/stories/ComponentShowcase/ShowcaseTable.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BaseTable } from "@osdk/react-components/experimental/object-table";
+import type { SortingState } from "@tanstack/react-table";
+import {
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import React, { useState } from "react";
+
+interface Person {
+  id: number;
+  name: string;
+  email: string;
+  department: string;
+  startDate: string;
+}
+
+const MOCK_DATA: Person[] = [
+  {
+    id: 1,
+    name: "John Smith",
+    email: "john.smith@example.com",
+    department: "Engineering",
+    startDate: "2020-01-15",
+  },
+  {
+    id: 2,
+    name: "Sarah Johnson",
+    email: "sarah.johnson@example.com",
+    department: "Product",
+    startDate: "2019-06-22",
+  },
+  {
+    id: 3,
+    name: "Michael Chen",
+    email: "michael.chen@example.com",
+    department: "Engineering",
+    startDate: "2021-03-01",
+  },
+  {
+    id: 4,
+    name: "Emily Davis",
+    email: "emily.davis@example.com",
+    department: "Design",
+    startDate: "2020-11-30",
+  },
+  {
+    id: 5,
+    name: "Robert Wilson",
+    email: "robert.wilson@example.com",
+    department: "Sales",
+    startDate: "2018-09-15",
+  },
+];
+
+const COLUMNS = [
+  { accessorKey: "name" as const, header: "Name" },
+  { accessorKey: "email" as const, header: "Email" },
+  { accessorKey: "department" as const, header: "Department" },
+  { accessorKey: "startDate" as const, header: "Start Date" },
+];
+
+const HEADER_MENU_FLAGS = {
+  showSortingItems: true,
+} as const;
+
+export const ShowcaseTable = React.memo(
+  function ShowcaseTableFn(): React.ReactElement {
+    const [sorting, setSorting] = useState<SortingState>([]);
+
+    const table = useReactTable({
+      data: MOCK_DATA,
+      columns: COLUMNS,
+      getCoreRowModel: getCoreRowModel(),
+      getSortedRowModel: getSortedRowModel(),
+      state: { sorting },
+      enableSorting: true,
+      onSortingChange: setSorting,
+      columnResizeMode: "onChange",
+      columnResizeDirection: "ltr",
+    });
+
+    return (
+      <BaseTable
+        table={table}
+        headerMenuFeatureFlags={HEADER_MENU_FLAGS}
+      />
+    );
+  },
+);


### PR DESCRIPTION
## Summary
- Adds a fullscreen "Component Showcase" Storybook story with a tabbed layout
- **Data tab**: FilterList sidebar + BaseTable side by side in cards
- **Forms tab**: 5 form variations in a responsive card grid (Contact, Settings, Scheduling, Upload, Date Range) covering all field types
- **Documents tab**: Full-height BasePdfViewer with toolbar

## Test plan
- [ ] Open Storybook and navigate to "Component Showcase > Default"
- [ ] Verify all three tabs render correctly
- [ ] Interact with components (sort table, filter, fill forms, navigate PDF)