### PR TITLE
internal plumbing for $includeAllBaseObjectProperties

### DIFF
--- a/.changeset/include-base-object-properties-foundation.md
+++ b/.changeset/include-base-object-properties-foundation.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+internal plumbing for upcoming `$includeAllBaseObjectProperties` option on observable hooks; no public behavior change. adds a no-op getter on `BaseListQuery` (subclasses opt in), threads the flag through `ObjectsHelper.storeOsdkInstances`, and exposes a `$includeAllBaseObjectProperties` field on `ObserveObjectOptions` that has no consumer yet.

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -106,6 +106,12 @@ export interface ObserveObjectOptions<
   pk: PrimaryKeyType<T>;
   select?: PropertyKeys<T>[];
   $loadPropertySecurityMetadata?: boolean;
+
+  /**
+   * When true, includes all properties of the underlying concrete object type
+   * for interface queries. Has no effect for non-interface queries.
+   */
+  $includeAllBaseObjectProperties?: boolean;
 }
 
 export type OrderBy<Q extends ObjectOrInterfaceDefinition> = {

--- a/packages/client/src/observable/internal/base-list/BaseListQuery.ts
+++ b/packages/client/src/observable/internal/base-list/BaseListQuery.ts
@@ -86,6 +86,15 @@ export abstract class BaseListQuery<
   /** RDP configuration for this collection. */
   public abstract get rdpConfig(): Canonical<Rdp> | undefined;
 
+  /**
+   * Whether this query requests all properties of underlying concrete object
+   * types for interface results. Subclasses that wire the option through
+   * their cache key tuple override this to read the value out.
+   */
+  public get includeAllBaseObjectProperties(): boolean {
+    return false;
+  }
+
   private _selectFieldSetMemo: ReadonlySet<string> | undefined;
 
   protected abstract get rawSelect(): Canonical<readonly string[]> | undefined;
@@ -157,6 +166,7 @@ export abstract class BaseListQuery<
         batch,
         this.rdpConfig,
         this.selectFieldSet,
+        this.includeAllBaseObjectProperties,
       );
     } else {
       // Items are already cache keys
@@ -510,6 +520,7 @@ export abstract class BaseListQuery<
           batch,
           this.rdpConfig,
           this.selectFieldSet,
+          this.includeAllBaseObjectProperties,
         );
 
         return this._updateList(
@@ -629,6 +640,7 @@ export abstract class BaseListQuery<
         batch,
         this.rdpConfig,
         this.selectFieldSet,
+        this.includeAllBaseObjectProperties,
       );
     } else {
       // Items are already cache keys
@@ -764,6 +776,8 @@ export abstract class BaseListQuery<
           [object as Osdk.Instance<ObjectTypeDefinition>],
           batch,
           this.rdpConfig, // Safe - null for queries without RDPs
+          undefined,
+          this.includeAllBaseObjectProperties,
         );
       });
     } else if (state === "REMOVED") {

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -89,11 +89,13 @@ export class ObjectsHelper extends AbstractHelper<
     batch: BatchContext,
     rdpConfig?: Canonical<Rdp> | null,
     selectFields?: ReadonlySet<string>,
+    includeAllBaseObjectProperties?: boolean,
   ): ObjectCacheKey[] {
     return values.map(v =>
       this.getQuery({
         apiName: v.$objectType ?? v.$apiName,
         pk: v.$primaryKey,
+        $includeAllBaseObjectProperties: includeAllBaseObjectProperties,
       }, rdpConfig).writeToStore(
         v as ObjectHolder,
         "loaded",


### PR DESCRIPTION
add internal plumbing for the upcoming `\$includeAllBaseObjectProperties` option without changing public behavior

• adds a no-op `includeAllBaseObjectProperties` getter on `BaseListQuery` that subclasses can override
• threads the flag through `ObjectsHelper.storeOsdkInstances` so list/link queries can pass it down
• adds a `\$includeAllBaseObjectProperties` field to `ObserveObjectOptions` (no consumer yet)

base for three sibling PRs that each expose the option on one react hook (useOsdkObject, useOsdkObjects, useLinks).