### PR TITLE
expose $includeAllBaseObjectProperties on useOsdkObject

### DIFF
--- a/.changeset/include-base-object-properties-foundation.md
+++ b/.changeset/include-base-object-properties-foundation.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+internal plumbing for upcoming `$includeAllBaseObjectProperties` option on observable hooks; no public behavior change. adds a no-op getter on `BaseListQuery` (subclasses opt in), threads the flag through `ObjectsHelper.storeOsdkInstances`, and exposes a `$includeAllBaseObjectProperties` field on `ObserveObjectOptions` that has no consumer yet.

--- a/.changeset/include-base-object-properties-use-osdk-object.md
+++ b/.changeset/include-base-object-properties-use-osdk-object.md
@@ -1,0 +1,6 @@
+---
+"@osdk/react": minor
+"@osdk/client": minor
+---
+
+expose `$includeAllBaseObjectProperties` on `useOsdkObject` and on the underlying `ObservableClient.observeObject`. When set against an interface query, the server returns the underlying concrete object's full property set so `obj.$as(ConcreteType)` yields a fully-populated concrete object. The flag is dropped for non-interface queries and does not narrow the returned `Osdk.Instance` type.

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -104,7 +104,7 @@ export interface ObserveObjectOptions<
 > extends ObserveOptions {
   apiName: T["apiName"] | T;
   pk: PrimaryKeyType<T>;
-  select?: PropertyKeys<T>[];
+  select?: readonly PropertyKeys<T>[];
   $loadPropertySecurityMetadata?: boolean;
 
   /**
@@ -207,7 +207,7 @@ export interface ObserveListOptions<
 export interface ObserveObjectCallbackArgs<
   T extends ObjectOrInterfaceDefinition,
 > {
-  object: Osdk.Instance<T> | undefined;
+  object: Osdk.Instance<T, "$allBaseProperties"> | undefined;
   isOptimistic: boolean;
   status: Status;
   lastUpdated: number;
@@ -381,7 +381,9 @@ export interface ObservableClient extends ObserveLinks {
   observeObject<T extends ObjectOrInterfaceDefinition>(
     apiName: T["apiName"] | T,
     pk: PrimaryKeyType<T>,
-    options: ObserveOptions,
+    options:
+      & ObserveOptions
+      & Omit<ObserveObjectOptions<T>, "apiName" | "pk">,
     subFn: Observer<ObserveObjectCallbackArgs<T>>,
   ): Unsubscribable;
 

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -106,6 +106,12 @@ export interface ObserveObjectOptions<
   pk: PrimaryKeyType<T>;
   select?: PropertyKeys<T>[];
   $loadPropertySecurityMetadata?: boolean;
+
+  /**
+   * When true, includes all properties of the underlying concrete object type
+   * for interface queries. Has no effect for non-interface queries.
+   */
+  $includeAllBaseObjectProperties?: boolean;
 }
 
 export type OrderBy<Q extends ObjectOrInterfaceDefinition> = {

--- a/packages/client/src/observable/internal/BulkObjectLoader.test.ts
+++ b/packages/client/src/observable/internal/BulkObjectLoader.test.ts
@@ -324,5 +324,125 @@ describe(BulkObjectLoader, () => {
       await expect(loadPromise).resolves.toMatchObject({ $primaryKey: 1 });
       vi.useRealTimers();
     });
+
+    it("splits interface fetches into separate batches when $includeAllBaseObjectProperties differs", async () => {
+      const loader = new BulkObjectLoader(client, 25, 100);
+      vi.useFakeTimers();
+
+      const interfaceMeta: InterfaceMetadata = {
+        type: "interface",
+        implementedBy: ["Employee"],
+        links: {},
+        apiName: "FooInterface",
+        displayName: "FooInterface",
+        description: undefined,
+        properties: {},
+        rid: "ri.test",
+      };
+      const objectMeta = { primaryKeyApiName: "employeeId" } as ObjectMetadata;
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(client.fetchMetadata).mockImplementation(
+        (def: { type?: string }) =>
+          Promise.resolve(
+            def.type === "interface"
+              ? interfaceMeta as ObjectMetadata
+              : objectMeta,
+          ),
+      );
+
+      const capturedArgs: Array<Record<string, unknown>> = [];
+      const captureMockSet = (data: unknown[]) => {
+        const os: ObjectSet<ObjectTypeDefinition> = {
+          where: () => os,
+          fetchPage: vi.fn((args: Record<string, unknown>) => {
+            capturedArgs.push(args);
+            return Promise.resolve({ data });
+          }),
+        } as Pick<
+          ObjectSet<ObjectTypeDefinition>,
+          "fetchPage" | "where"
+        > as ObjectSet<ObjectTypeDefinition>;
+        return os;
+      };
+
+      client.mockImplementation(() =>
+        captureMockSet([employees[0], employees[1]])
+      );
+
+      const without = loader.fetch(
+        "FooInterface",
+        0,
+        "interface",
+        undefined,
+        false,
+        undefined,
+      );
+      const withFlag = loader.fetch(
+        "FooInterface",
+        1,
+        "interface",
+        undefined,
+        false,
+        true,
+      );
+
+      vi.advanceTimersByTime(26);
+      await Promise.all([without, withFlag]);
+
+      expect(capturedArgs).toHaveLength(2);
+      const flagValues = capturedArgs
+        .map(a => a.$includeAllBaseObjectProperties)
+        .sort((a, b) => String(a).localeCompare(String(b)));
+      expect(flagValues).toEqual([true, undefined]);
+
+      vi.useRealTimers();
+    });
+  });
+
+  it("gates $includeAllBaseObjectProperties for object fetches: drops the flag and batches into a single fetchPage", async () => {
+    const loader = new BulkObjectLoader(client, 25, 100);
+    vi.useFakeTimers();
+
+    const capturedArgs: Array<Record<string, unknown>> = [];
+    const mockObjectSet: ObjectSet<ObjectTypeDefinition> = {
+      where: () => mockObjectSet,
+      fetchPage: vi.fn((args: Record<string, unknown>) => {
+        capturedArgs.push(args);
+        return Promise.resolve({
+          data: [employees[0], employees[1]],
+          nextPageToken: undefined,
+          totalCount: "2",
+        });
+      }),
+    } as Pick<
+      ObjectSet<ObjectTypeDefinition>,
+      "fetchPage" | "where"
+    > as ObjectSet<ObjectTypeDefinition>;
+    client.mockReturnValueOnce(mockObjectSet);
+
+    const without = loader.fetch(
+      "Employee",
+      0,
+      "object",
+      undefined,
+      false,
+      false,
+    );
+    const withFlag = loader.fetch(
+      "Employee",
+      1,
+      "object",
+      undefined,
+      false,
+      true,
+    );
+
+    vi.advanceTimersByTime(26);
+    await Promise.all([without, withFlag]);
+
+    expect(capturedArgs).toHaveLength(1);
+    expect(capturedArgs[0].$includeAllBaseObjectProperties).toBeUndefined();
+
+    vi.useRealTimers();
   });
 });

--- a/packages/client/src/observable/internal/BulkObjectLoader.ts
+++ b/packages/client/src/observable/internal/BulkObjectLoader.ts
@@ -35,12 +35,17 @@ interface InternalValue {
   deferred: DeferredPromise<ObjectHolder>;
 }
 
-interface Accumulator {
-  data: InternalValue[];
-  timer?: ReturnType<typeof setTimeout>;
-  defType?: DefType;
+interface LoadParams {
+  apiName: string;
+  defType: DefType;
   select?: readonly string[];
   loadPropertySecurityMetadata?: boolean;
+  includeAllBaseObjectProperties: true | undefined;
+}
+
+interface Accumulator extends Partial<LoadParams> {
+  data: InternalValue[];
+  timer?: ReturnType<typeof setTimeout>;
 }
 
 const weakCache = new DefaultWeakMap<Client, BulkObjectLoader>(c =>
@@ -75,13 +80,24 @@ export class BulkObjectLoader {
     defType: DefType = "object",
     select?: readonly string[],
     loadPropertySecurityMetadata?: boolean,
+    includeAllBaseObjectProperties?: boolean,
   ): Promise<ObjectHolder> {
+    const params: LoadParams = {
+      apiName,
+      defType,
+      select,
+      loadPropertySecurityMetadata,
+      // The flag is interface-only on the server. Drop it for object fetches
+      // so they don't fragment batches or the cache.
+      includeAllBaseObjectProperties:
+        defType === "interface" && includeAllBaseObjectProperties
+          ? true
+          : undefined,
+    };
+
     const deferred = pDefer<ObjectHolder>();
 
-    const securitySuffix = loadPropertySecurityMetadata ? "\0sec" : "";
-    const selectKey = select && select.length > 0
-      ? `${apiName}\0${[...select].sort().join(",")}${securitySuffix}`
-      : `${apiName}${securitySuffix}`;
+    const selectKey = this.#buildSelectKey(params);
     const entry = this.#m.get(selectKey);
     entry.data.push({
       primaryKey: primaryKey as string,
@@ -89,9 +105,12 @@ export class BulkObjectLoader {
     });
 
     if (entry.defType === undefined) {
-      entry.defType = defType;
-      entry.select = select;
-      entry.loadPropertySecurityMetadata = loadPropertySecurityMetadata;
+      entry.apiName = params.apiName;
+      entry.defType = params.defType;
+      entry.select = params.select;
+      entry.loadPropertySecurityMetadata = params.loadPropertySecurityMetadata;
+      entry.includeAllBaseObjectProperties =
+        params.includeAllBaseObjectProperties;
     } else if (entry.defType !== defType) {
       deferred.reject(
         new PalantirApiError(
@@ -101,58 +120,36 @@ export class BulkObjectLoader {
       return deferred.promise;
     }
 
+    const fire = () => this.#loadObjects(entry.data, params);
+
     if (!entry.timer) {
-      entry.timer = setTimeout(() => {
-        this.#loadObjects(
-          apiName,
-          entry.data,
-          entry.defType ?? "object",
-          entry.select,
-          entry.loadPropertySecurityMetadata,
-        );
-      }, this.#maxWait);
+      entry.timer = setTimeout(fire, this.#maxWait);
     }
 
     if (entry.data.length >= this.#maxEntries) {
       clearTimeout(entry.timer);
-      this.#loadObjects(
-        apiName,
-        entry.data,
-        entry.defType ?? "object",
-        entry.select,
-        entry.loadPropertySecurityMetadata,
-      );
+      fire();
     }
 
     return await deferred.promise;
   }
 
-  #loadObjects(
-    apiName: string,
-    arr: InternalValue[],
-    defType: DefType,
-    select?: readonly string[],
-    loadPropertySecurityMetadata?: boolean,
-  ) {
-    const securitySuffix = loadPropertySecurityMetadata ? "\0sec" : "";
-    const selectKey = select && select.length > 0
-      ? `${apiName}\0${[...select].sort().join(",")}${securitySuffix}`
-      : `${apiName}${securitySuffix}`;
-    this.#m.delete(selectKey);
+  #buildSelectKey(params: LoadParams): string {
+    const securitySuffix = params.loadPropertySecurityMetadata ? "\0sec" : "";
+    const baseSuffix = params.includeAllBaseObjectProperties ? "\0base" : "";
+    return params.select && params.select.length > 0
+      ? `${params.apiName}\0${
+        [...params.select].sort().join(",")
+      }${securitySuffix}${baseSuffix}`
+      : `${params.apiName}${securitySuffix}${baseSuffix}`;
+  }
 
-    const loadFn = defType === "interface"
-      ? this.#loadInterfaceObjects(
-        apiName,
-        arr,
-        select,
-        loadPropertySecurityMetadata,
-      )
-      : this.#loadObjectTypeObjects(
-        apiName,
-        arr,
-        select,
-        loadPropertySecurityMetadata,
-      );
+  #loadObjects(arr: InternalValue[], params: LoadParams) {
+    this.#m.delete(this.#buildSelectKey(params));
+
+    const loadFn = params.defType === "interface"
+      ? this.#loadInterfaceObjects(arr, params)
+      : this.#loadObjectTypeObjects(arr, params);
 
     loadFn.catch((e: unknown) => {
       this.#logger?.error("Unhandled exception", e);
@@ -160,20 +157,18 @@ export class BulkObjectLoader {
         const errorMessage = e instanceof Error ? e.message : String(e);
         deferred.reject(
           new PalantirApiError(
-            `Failed to load ${apiName} with pk ${primaryKey}: ${errorMessage}`,
+            `Failed to load ${params.apiName} with pk ${primaryKey}: ${errorMessage}`,
           ),
         );
       }
     });
   }
 
-  async #loadObjectTypeObjects(
-    apiName: string,
-    arr: InternalValue[],
-    select?: readonly string[],
-    loadPropertySecurityMetadata?: boolean,
-  ) {
-    const objectDef = { type: "object", apiName } as ObjectTypeDefinition;
+  async #loadObjectTypeObjects(arr: InternalValue[], params: LoadParams) {
+    const objectDef = {
+      type: "object",
+      apiName: params.apiName,
+    } as ObjectTypeDefinition;
     const objMetadata = await this.#client.fetchMetadata(objectDef);
 
     const pks = arr.map(x => x.primaryKey);
@@ -188,10 +183,14 @@ export class BulkObjectLoader {
       .where(whereClause).fetchPage({
         $pageSize: pks.length,
         $includeRid: true,
-        ...(select && select.length > 0
-          ? { $select: select }
+        ...(params.select && params.select.length > 0
+          ? { $select: params.select }
           : {}),
-        $loadPropertySecurityMetadata: loadPropertySecurityMetadata ?? false,
+        $loadPropertySecurityMetadata: params.loadPropertySecurityMetadata
+          ?? false,
+        ...(params.includeAllBaseObjectProperties
+          ? { $includeAllBaseObjectProperties: true }
+          : {}),
       });
 
     for (const { primaryKey, deferred } of arr) {
@@ -208,17 +207,12 @@ export class BulkObjectLoader {
     }
   }
 
-  async #loadInterfaceObjects(
-    apiName: string,
-    arr: InternalValue[],
-    select?: readonly string[],
-    loadPropertySecurityMetadata?: boolean,
-  ) {
+  async #loadInterfaceObjects(arr: InternalValue[], params: LoadParams) {
     const pks = arr.map(x => x.primaryKey);
 
     const interfaceDef = {
       type: "interface",
-      apiName,
+      apiName: params.apiName,
     } as InterfaceDefinition;
 
     const interfaceMetadata = await this.#client.fetchMetadata(interfaceDef);
@@ -245,11 +239,14 @@ export class BulkObjectLoader {
       const { data } = await this.#client(objectDef)
         .where(whereClause).fetchPage({
           $pageSize: remainingPks.length,
-          ...(select && select.length > 0
-            ? { $select: select }
+          ...(params.select && params.select.length > 0
+            ? { $select: params.select }
             : {}),
           $loadPropertySecurityMetadata:
-            (loadPropertySecurityMetadata ?? false) as boolean,
+            (params.loadPropertySecurityMetadata ?? false) as boolean,
+          ...(params.includeAllBaseObjectProperties
+            ? { $includeAllBaseObjectProperties: true }
+            : {}),
         });
 
       for (const obj of data) {
@@ -264,7 +261,7 @@ export class BulkObjectLoader {
       } else {
         deferred.reject(
           new PalantirApiError(
-            `Interface ${apiName} object not found: ${primaryKey}`,
+            `Interface ${params.apiName} object not found: ${primaryKey}`,
           ),
         );
       }

--- a/packages/client/src/observable/internal/base-list/BaseListQuery.ts
+++ b/packages/client/src/observable/internal/base-list/BaseListQuery.ts
@@ -86,6 +86,15 @@ export abstract class BaseListQuery<
   /** RDP configuration for this collection. */
   public abstract get rdpConfig(): Canonical<Rdp> | undefined;
 
+  /**
+   * Whether this query requests all properties of underlying concrete object
+   * types for interface results. Subclasses that wire the option through
+   * their cache key tuple override this to read the value out.
+   */
+  public get includeAllBaseObjectProperties(): boolean {
+    return false;
+  }
+
   private _selectFieldSetMemo: ReadonlySet<string> | undefined;
 
   protected abstract get rawSelect(): Canonical<readonly string[]> | undefined;
@@ -157,6 +166,7 @@ export abstract class BaseListQuery<
         batch,
         this.rdpConfig,
         this.selectFieldSet,
+        this.includeAllBaseObjectProperties,
       );
     } else {
       // Items are already cache keys
@@ -510,6 +520,7 @@ export abstract class BaseListQuery<
           batch,
           this.rdpConfig,
           this.selectFieldSet,
+          this.includeAllBaseObjectProperties,
         );
 
         return this._updateList(
@@ -629,6 +640,7 @@ export abstract class BaseListQuery<
         batch,
         this.rdpConfig,
         this.selectFieldSet,
+        this.includeAllBaseObjectProperties,
       );
     } else {
       // Items are already cache keys
@@ -764,6 +776,8 @@ export abstract class BaseListQuery<
           [object as Osdk.Instance<ObjectTypeDefinition>],
           batch,
           this.rdpConfig, // Safe - null for queries without RDPs
+          undefined,
+          this.includeAllBaseObjectProperties,
         );
       });
     } else if (state === "REMOVED") {

--- a/packages/client/src/observable/internal/object/ObjectCacheKey.test.ts
+++ b/packages/client/src/observable/internal/object/ObjectCacheKey.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { CacheKeys } from "../CacheKeys.js";
+import type { ObjectCacheKey } from "./ObjectCacheKey.js";
+
+describe("ObjectCacheKey", () => {
+  it("partitions by includeAllBaseObjectProperties", () => {
+    const cacheKeys = new CacheKeys<ObjectCacheKey>({});
+
+    const keyWithoutFlag = cacheKeys.get<ObjectCacheKey>(
+      "object",
+      "Employee",
+      1,
+      undefined,
+    );
+    const keyWithFlag = cacheKeys.get<ObjectCacheKey>(
+      "object",
+      "Employee",
+      1,
+      undefined,
+      true,
+    );
+
+    expect(keyWithoutFlag).not.toBe(keyWithFlag);
+  });
+
+  it("treats omitted and undefined includeAllBaseObjectProperties as the same key", () => {
+    const cacheKeys = new CacheKeys<ObjectCacheKey>({});
+
+    const keyOmitted = cacheKeys.get<ObjectCacheKey>(
+      "object",
+      "Employee",
+      1,
+      undefined,
+    );
+    const keyExplicitUndefined = cacheKeys.get<ObjectCacheKey>(
+      "object",
+      "Employee",
+      1,
+      undefined,
+      undefined,
+    );
+
+    expect(keyOmitted).toBe(keyExplicitUndefined);
+  });
+});

--- a/packages/client/src/observable/internal/object/ObjectCacheKey.ts
+++ b/packages/client/src/observable/internal/object/ObjectCacheKey.ts
@@ -25,6 +25,7 @@ import type { ObjectQuery } from "./ObjectQuery.js";
 export const API_NAME_IDX = 0;
 export const PK_IDX = 1;
 export const RDP_CONFIG_IDX = 2;
+export const INCLUDE_ALL_BASE_PROPERTIES_IDX = 3;
 
 export interface ObjectCacheKey extends
   CacheKey<
@@ -35,6 +36,7 @@ export interface ObjectCacheKey extends
       apiName: string,
       pk: PrimaryKeyType<ObjectTypeDefinition>,
       rdpConfig?: Canonical<Rdp> | undefined,
+      includeAllBaseObjectProperties?: true | undefined,
     ]
   >
 {

--- a/packages/client/src/observable/internal/object/ObjectQuery.ts
+++ b/packages/client/src/observable/internal/object/ObjectQuery.ts
@@ -50,6 +50,7 @@ export class ObjectQuery extends Query<
   #defType: DefType;
   #select: readonly string[] | undefined;
   #loadPropertySecurityMetadata: boolean;
+  #includeAllBaseObjectProperties: boolean;
   #implementingTypes: Set<string> | undefined;
 
   constructor(
@@ -62,6 +63,7 @@ export class ObjectQuery extends Query<
     defType: DefType = "object",
     select?: readonly string[],
     loadPropertySecurityMetadata?: boolean,
+    includeAllBaseObjectProperties?: boolean,
   ) {
     super(
       store,
@@ -83,6 +85,8 @@ export class ObjectQuery extends Query<
     this.#defType = defType;
     this.#select = select;
     this.#loadPropertySecurityMetadata = loadPropertySecurityMetadata ?? false;
+    this.#includeAllBaseObjectProperties = includeAllBaseObjectProperties
+      ?? false;
   }
 
   protected _createConnectable(
@@ -145,6 +149,9 @@ export class ObjectQuery extends Query<
               : {}),
             $loadPropertySecurityMetadata: this
               .#loadPropertySecurityMetadata,
+            ...(this.#includeAllBaseObjectProperties
+              ? { $includeAllBaseObjectProperties: true }
+              : {}),
           },
         );
       obj = fetched as ObjectHolder;
@@ -157,6 +164,7 @@ export class ObjectQuery extends Query<
           this.#defType,
           this.#select,
           this.#loadPropertySecurityMetadata,
+          this.#includeAllBaseObjectProperties,
         );
     }
 

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -89,11 +89,13 @@ export class ObjectsHelper extends AbstractHelper<
     batch: BatchContext,
     rdpConfig?: Canonical<Rdp> | null,
     selectFields?: ReadonlySet<string>,
+    includeAllBaseObjectProperties?: boolean,
   ): ObjectCacheKey[] {
     return values.map(v =>
       this.getQuery({
         apiName: v.$objectType ?? v.$apiName,
         pk: v.$primaryKey,
+        $includeAllBaseObjectProperties: includeAllBaseObjectProperties,
       }, rdpConfig).writeToStore(
         v as ObjectHolder,
         "loaded",

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -53,15 +53,26 @@ export class ObjectsHelper extends AbstractHelper<
     const apiName = typeof options.apiName === "string"
       ? options.apiName
       : options.apiName.apiName;
-    const { pk, select, $loadPropertySecurityMetadata } = options;
+    const {
+      pk,
+      select,
+      $loadPropertySecurityMetadata,
+    } = options;
 
     const defType = getDefType(options.apiName);
+    // The flag is interface-only on the server. Drop it for object queries so
+    // they don't fragment the cache.
+    const $includeAllBaseObjectProperties = defType === "interface"
+        && options.$includeAllBaseObjectProperties
+      ? true
+      : undefined;
 
     const objectCacheKey = this.cacheKeys.get<ObjectCacheKey>(
       "object",
       apiName,
       pk,
       rdpConfig ?? undefined,
+      $includeAllBaseObjectProperties,
     );
 
     return this.store.queries.get(objectCacheKey, () =>
@@ -75,6 +86,7 @@ export class ObjectsHelper extends AbstractHelper<
         defType,
         select,
         $loadPropertySecurityMetadata,
+        $includeAllBaseObjectProperties,
       ));
   }
 

--- a/packages/react/src/new/useOsdkObject.ts
+++ b/packages/react/src/new/useOsdkObject.ts
@@ -28,7 +28,7 @@ import { OsdkContext2 } from "./OsdkContext2.js";
 export interface UseOsdkObjectResult<
   Q extends ObjectOrInterfaceDefinition,
 > {
-  object: Osdk.Instance<Q> | undefined;
+  object: Osdk.Instance<Q, "$allBaseProperties"> | undefined;
   isLoading: boolean;
 
   error: Error | undefined;
@@ -38,6 +38,20 @@ export interface UseOsdkObjectResult<
    */
   isOptimistic: boolean;
   forceUpdate: () => void;
+}
+
+export interface UseOsdkObjectOptions<
+  Q extends ObjectOrInterfaceDefinition,
+> {
+  $select?: readonly PropertyKeys<Q>[];
+  enabled?: boolean;
+  $loadPropertySecurityMetadata?: boolean;
+
+  /**
+   * When true, includes all properties of the underlying concrete object type
+   * for interface queries. Has no effect for non-interface queries.
+   */
+  $includeAllBaseObjectProperties?: boolean;
 }
 
 /**
@@ -69,18 +83,15 @@ export function useOsdkObject<
  *
  * @param type The object type or interface definition
  * @param primaryKey The primary key of the object
- * @param options Options including $select, enabled, and $loadPropertySecurityMetadata
+ * @param options Options including $select, enabled, $loadPropertySecurityMetadata,
+ *                and $includeAllBaseObjectProperties
  */
 export function useOsdkObject<
   Q extends ObjectOrInterfaceDefinition,
 >(
   type: Q,
   primaryKey: PrimaryKeyType<Q>,
-  options?: {
-    $select?: readonly PropertyKeys<Q>[];
-    enabled?: boolean;
-    $loadPropertySecurityMetadata?: boolean;
-  },
+  options?: UseOsdkObjectOptions<Q>,
 ): UseOsdkObjectResult<Q>;
 /*
     Implementation of useOsdkObject
@@ -94,11 +105,7 @@ export function useOsdkObject<
     | [
       type: Q,
       primaryKey: PrimaryKeyType<Q>,
-      options?: {
-        $select?: readonly PropertyKeys<Q>[];
-        enabled?: boolean;
-        $loadPropertySecurityMetadata?: boolean;
-      },
+      options?: UseOsdkObjectOptions<Q>,
     ]
 ): UseOsdkObjectResult<Q> {
   const { observableClient } = React.useContext(OsdkContext2);
@@ -112,11 +119,7 @@ export function useOsdkObject<
   const optionsArg = !isInstanceSignature
       && args[2] != null
       && typeof args[2] === "object"
-    ? args[2] as {
-      $select?: readonly string[];
-      enabled?: boolean;
-      $loadPropertySecurityMetadata?: boolean;
-    }
+    ? args[2]
     : undefined;
 
   // Extract enabled flag - 2nd param for instance signature, 3rd for type signature
@@ -129,6 +132,8 @@ export function useOsdkObject<
   const selectArg = optionsArg?.$select;
   const loadPropertySecurityMetadata = optionsArg
     ?.$loadPropertySecurityMetadata;
+  const includeAllBaseObjectProperties = optionsArg
+    ?.$includeAllBaseObjectProperties;
 
   const mode = isInstanceSignature ? "offline" : undefined;
 
@@ -163,11 +168,12 @@ export function useOsdkObject<
       }
       return makeExternalStore<ObserveObjectCallbackArgs<Q>>(
         (observer) =>
-          observableClient.observeObject(
+          observableClient.observeObject<Q>(
             typeOrApiName,
             primaryKey,
             {
               mode,
+              $includeAllBaseObjectProperties: includeAllBaseObjectProperties,
               ...(stableSelect ? { select: stableSelect } : {}),
               ...(loadPropertySecurityMetadata
                 ? {
@@ -193,6 +199,7 @@ export function useOsdkObject<
       mode,
       stableSelect,
       loadPropertySecurityMetadata,
+      includeAllBaseObjectProperties,
     ],
   );
 
@@ -211,7 +218,7 @@ export function useOsdkObject<
     }
 
     return {
-      object: payload?.object as Osdk.Instance<Q> | undefined,
+      object: payload?.object,
       // Errors take precedence over loading state.
       isLoading: enabled && error == null
         ? (payload?.status === "loading" || payload?.status === "init"

--- a/packages/react/test/useOsdkObject.enabled.test.tsx
+++ b/packages/react/test/useOsdkObject.enabled.test.tsx
@@ -128,4 +128,20 @@ describe("useOsdkObject enabled option", () => {
 
     expect(mockObserveObject).toHaveBeenCalledTimes(1);
   });
+
+  it("should forward $includeAllBaseObjectProperties to observeObject", () => {
+    const wrapper = createWrapper();
+
+    renderHook(
+      () =>
+        useOsdkObject(MockObjectType, "pk-777", {
+          $includeAllBaseObjectProperties: true,
+        }),
+      { wrapper },
+    );
+
+    expect(mockObserveObject).toHaveBeenCalledTimes(1);
+    const options = mockObserveObject.mock.calls[0][2];
+    expect(options.$includeAllBaseObjectProperties).toBe(true);
+  });
 });


### PR DESCRIPTION
exposes \`\$includeAllBaseObjectProperties\` on \`useOsdkObject\` and on the underlying \`ObservableClient.observeObject\`

when set against an interface query, the server returns the underlying concrete object's full property set so \`obj.\$as(ConcreteType)\` yields a fully-populated concrete object

• threads the flag through ObjectsHelper.getQuery → ObjectQuery → BulkObjectLoader.fetch
• partitions ObjectCacheKey by the flag so with-flag and without-flag callers don't share entries
• gates the flag at fetch time: dropped for non-interface queries