### PR TITLE
expose $includeAllBaseObjectProperties on useOsdkObjects

### DIFF
--- a/.changeset/include-base-object-properties-foundation.md
+++ b/.changeset/include-base-object-properties-foundation.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+internal plumbing for upcoming `$includeAllBaseObjectProperties` option on observable hooks; no public behavior change. adds a no-op getter on `BaseListQuery` (subclasses opt in), threads the flag through `ObjectsHelper.storeOsdkInstances`, and exposes a `$includeAllBaseObjectProperties` field on `ObserveObjectOptions` that has no consumer yet.

--- a/.changeset/include-base-object-properties-use-osdk-objects.md
+++ b/.changeset/include-base-object-properties-use-osdk-objects.md
@@ -1,0 +1,6 @@
+---
+"@osdk/react": minor
+"@osdk/client": minor
+---
+
+expose `$includeAllBaseObjectProperties` on `useOsdkObjects` and on the underlying `ObservableClient.observeList`. When set against an interface query, the server returns the underlying concrete object's full property set so `obj.$as(ConcreteType)` yields a fully-populated concrete object. The flag is dropped for non-interface queries and does not narrow the returned `Osdk.Instance` type.

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -177,6 +177,12 @@ export interface ObserveListOptions<
   $loadPropertySecurityMetadata?: boolean;
 
   /**
+   * When true, includes all properties of the underlying concrete object type
+   * for interface queries. Has no effect for non-interface queries.
+   */
+  $includeAllBaseObjectProperties?: boolean;
+
+  /**
    * Automatically fetch additional pages on initial load.
    *
    * - `true`: Fetch all available pages automatically
@@ -221,9 +227,7 @@ export interface ObserveObjectsCallbackArgs<
   > = {},
 > {
   resolvedList:
-    | Array<
-      Osdk.Instance<T, "$allBaseProperties", PropertyKeys<T>, RDPs>
-    >
+    | Array<Osdk.Instance<T, "$allBaseProperties", PropertyKeys<T>, RDPs>>
     | undefined;
   isOptimistic: boolean;
   lastUpdated: number;
@@ -231,7 +235,7 @@ export interface ObserveObjectsCallbackArgs<
   hasMore: boolean;
   status: Status;
   totalCount?: string;
-  objectSet: ObjectSet<T>;
+  objectSet: ObjectSet<T, RDPs>;
 }
 
 export interface ObserveObjectSetArgs<

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -106,6 +106,12 @@ export interface ObserveObjectOptions<
   pk: PrimaryKeyType<T>;
   select?: PropertyKeys<T>[];
   $loadPropertySecurityMetadata?: boolean;
+
+  /**
+   * When true, includes all properties of the underlying concrete object type
+   * for interface queries. Has no effect for non-interface queries.
+   */
+  $includeAllBaseObjectProperties?: boolean;
 }
 
 export type OrderBy<Q extends ObjectOrInterfaceDefinition> = {

--- a/packages/client/src/observable/internal/base-list/BaseListQuery.ts
+++ b/packages/client/src/observable/internal/base-list/BaseListQuery.ts
@@ -86,6 +86,15 @@ export abstract class BaseListQuery<
   /** RDP configuration for this collection. */
   public abstract get rdpConfig(): Canonical<Rdp> | undefined;
 
+  /**
+   * Whether this query requests all properties of underlying concrete object
+   * types for interface results. Subclasses that wire the option through
+   * their cache key tuple override this to read the value out.
+   */
+  public get includeAllBaseObjectProperties(): boolean {
+    return false;
+  }
+
   private _selectFieldSetMemo: ReadonlySet<string> | undefined;
 
   protected abstract get rawSelect(): Canonical<readonly string[]> | undefined;
@@ -157,6 +166,7 @@ export abstract class BaseListQuery<
         batch,
         this.rdpConfig,
         this.selectFieldSet,
+        this.includeAllBaseObjectProperties,
       );
     } else {
       // Items are already cache keys
@@ -510,6 +520,7 @@ export abstract class BaseListQuery<
           batch,
           this.rdpConfig,
           this.selectFieldSet,
+          this.includeAllBaseObjectProperties,
         );
 
         return this._updateList(
@@ -629,6 +640,7 @@ export abstract class BaseListQuery<
         batch,
         this.rdpConfig,
         this.selectFieldSet,
+        this.includeAllBaseObjectProperties,
       );
     } else {
       // Items are already cache keys
@@ -764,6 +776,8 @@ export abstract class BaseListQuery<
           [object as Osdk.Instance<ObjectTypeDefinition>],
           batch,
           this.rdpConfig, // Safe - null for queries without RDPs
+          undefined,
+          this.includeAllBaseObjectProperties,
         );
       });
     } else if (state === "REMOVED") {

--- a/packages/client/src/observable/internal/list/ListCacheKey.ts
+++ b/packages/client/src/observable/internal/list/ListCacheKey.ts
@@ -33,6 +33,7 @@ export const PIVOT_IDX = 6;
 export const RIDS_IDX = 7;
 export const SELECT_IDX = 8;
 export const LOAD_PROPERTY_SECURITY_IDX = 9;
+export const INCLUDE_ALL_BASE_PROPERTIES_IDX = 10;
 
 export interface ListStorageData extends CollectionStorageData {}
 
@@ -54,6 +55,7 @@ export interface ListCacheKey extends
       rids?: Canonical<string[]> | undefined,
       select?: Canonical<readonly string[]> | undefined,
       loadPropertySecurity?: true | undefined,
+      includeAllBaseObjectProperties?: true | undefined,
     ]
   >
 {

--- a/packages/client/src/observable/internal/list/ListQuery.ts
+++ b/packages/client/src/observable/internal/list/ListQuery.ts
@@ -56,6 +56,7 @@ import { OrderBySortingStrategy } from "../sorting/SortingStrategy.js";
 import type { Store } from "../Store.js";
 import type { SubjectPayload } from "../SubjectPayload.js";
 import {
+  INCLUDE_ALL_BASE_PROPERTIES_IDX,
   INTERSECT_IDX,
   type ListCacheKey,
   ORDER_BY_IDX,
@@ -66,6 +67,7 @@ import {
 } from "./ListCacheKey.js";
 export {
   API_NAME_IDX,
+  INCLUDE_ALL_BASE_PROPERTIES_IDX,
   INTERSECT_IDX,
   PIVOT_IDX,
   RDP_IDX,
@@ -187,6 +189,10 @@ export abstract class ListQuery extends BaseListQuery<
 
   get canonicalPivotInfo(): Canonical<PivotInfo> | undefined {
     return this.#pivotInfo;
+  }
+
+  public override get includeAllBaseObjectProperties(): boolean {
+    return this.cacheKey.otherKeys[INCLUDE_ALL_BASE_PROPERTIES_IDX] === true;
   }
 
   get objectTypes(): ReadonlySet<string> {
@@ -313,6 +319,9 @@ export abstract class ListQuery extends BaseListQuery<
         : {}),
       ...(this.options.$loadPropertySecurityMetadata
         ? { $loadPropertySecurityMetadata: true }
+        : {}),
+      ...(this.includeAllBaseObjectProperties
+        ? { $includeAllBaseObjectProperties: true }
         : {}),
     });
 
@@ -589,6 +598,8 @@ export abstract class ListQuery extends BaseListQuery<
           [object as Osdk.Instance<any>],
           batch,
           this.rdpConfig,
+          undefined,
+          this.includeAllBaseObjectProperties,
         );
       });
     } else if (state === "REMOVED") {
@@ -657,9 +668,6 @@ export abstract class ListQuery extends BaseListQuery<
     });
   }
 
-  /**
-   * Get cache key for object.
-   */
   private getObjectCacheKey(
     obj: { $objectType: string; $primaryKey: string | number },
   ): ObjectCacheKey {

--- a/packages/client/src/observable/internal/list/ListQueryOptions.ts
+++ b/packages/client/src/observable/internal/list/ListQueryOptions.ts
@@ -36,4 +36,5 @@ export interface ListQueryOptions<
   }>;
   pivotTo?: string;
   $loadPropertySecurityMetadata?: boolean;
+  $includeAllBaseObjectProperties?: boolean;
 }

--- a/packages/client/src/observable/internal/list/ListsHelper.ts
+++ b/packages/client/src/observable/internal/list/ListsHelper.ts
@@ -37,7 +37,7 @@ import { ObjectListQuery } from "./ObjectListQuery.js";
 
 export class ListsHelper extends AbstractHelper<
   ListQuery,
-  ObserveListOptions<ObjectOrInterfaceDefinition>
+  ObserveListOptions<ObjectOrInterfaceDefinition, {}>
 > {
   whereCanonicalizer: WhereClauseCanonicalizer;
   orderByCanonicalizer: OrderByCanonicalizer;
@@ -70,7 +70,7 @@ export class ListsHelper extends AbstractHelper<
   }
 
   observe<T extends ObjectOrInterfaceDefinition>(
-    options: ObserveListOptions<T>,
+    options: ObserveListOptions<T, {}>,
     subFn: Observer<ListPayload>,
   ): QuerySubscription<ListQuery> {
     const ret = super.observe(options, subFn);
@@ -102,7 +102,7 @@ export class ListsHelper extends AbstractHelper<
   }
 
   getQuery<T extends ObjectOrInterfaceDefinition>(
-    options: ObserveListOptions<T>,
+    options: ObserveListOptions<T, {}>,
   ): ListQuery {
     const {
       type: typeDefinition,
@@ -116,6 +116,12 @@ export class ListsHelper extends AbstractHelper<
       $loadPropertySecurityMetadata,
     } = options;
     const { apiName, type } = typeDefinition;
+    // The flag is interface-only on the server. Drop it for object queries so
+    // they don't fragment the cache.
+    const $includeAllBaseObjectProperties =
+      type === "interface" && options.$includeAllBaseObjectProperties
+        ? true
+        : undefined;
 
     const canonWhere = this.whereCanonicalizer.canonicalize(where ?? {});
     const canonOrderBy = this.orderByCanonicalizer.canonicalize(orderBy ?? {});
@@ -151,6 +157,7 @@ export class ListsHelper extends AbstractHelper<
       canonRids,
       canonSelect,
       $loadPropertySecurityMetadata ? true : undefined,
+      $includeAllBaseObjectProperties,
     );
 
     return this.store.queries.get(listCacheKey, () => {

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -89,11 +89,13 @@ export class ObjectsHelper extends AbstractHelper<
     batch: BatchContext,
     rdpConfig?: Canonical<Rdp> | null,
     selectFields?: ReadonlySet<string>,
+    includeAllBaseObjectProperties?: boolean,
   ): ObjectCacheKey[] {
     return values.map(v =>
       this.getQuery({
         apiName: v.$objectType ?? v.$apiName,
         pk: v.$primaryKey,
+        $includeAllBaseObjectProperties: includeAllBaseObjectProperties,
       }, rdpConfig).writeToStore(
         v as ObjectHolder,
         "loaded",

--- a/packages/e2e.sandbox.officenetwork/src/components/EmployeePanel.tsx
+++ b/packages/e2e.sandbox.officenetwork/src/components/EmployeePanel.tsx
@@ -139,6 +139,7 @@ export function EmployeePanel({
     {
       where: { employeeNumber: employee.employeeNumber },
       pageSize: 1,
+      $includeAllBaseObjectProperties: true,
     },
   );
   const worker = workerData?.[0];
@@ -148,6 +149,7 @@ export function EmployeePanel({
     {
       where: { employeeNumber: employee.employeeNumber },
       pageSize: 1,
+      $includeAllBaseObjectProperties: true,
     },
   );
   const person = personData?.[0];
@@ -614,8 +616,23 @@ export function EmployeePanel({
                       {person?.employeeNumber ?? "—"}
                     </span>
                   </div>
+                  <div className="grid grid-cols-4 gap-1 text-[10px]">
+                    <span className="text-[var(--officenetwork-text-muted)] officenetwork-mono">
+                      jobTitle
+                    </span>
+                    <span className="text-[var(--officenetwork-text-secondary)] truncate">
+                      {employee.jobTitle ?? "—"}
+                    </span>
+                    <span className="text-[var(--officenetwork-accent-teal)] truncate">
+                      {worker?.$as(Employee).jobTitle ?? "—"}
+                    </span>
+                    <span className="text-[var(--officenetwork-status-ready)] truncate">
+                      {person?.$as(Employee).jobTitle ?? "—"}
+                    </span>
+                  </div>
                   <div className="mt-2 text-[9px] text-[var(--officenetwork-text-muted)] italic">
-                    Same data accessed via 3 different views
+                    Worker/Person columns use $includeAllBaseObjectProperties to
+                    expose concrete fields (jobTitle) via $as(Employee)
                   </div>
                 </div>
               )}

--- a/packages/react/src/new/useOsdkObjects.ts
+++ b/packages/react/src/new/useOsdkObjects.ts
@@ -150,6 +150,12 @@ export interface UseOsdkObjectsOptions<
    * populated with conjunctive/disjunctive marking requirements per property.
    */
   $loadPropertySecurityMetadata?: boolean;
+
+  /**
+   * When true, includes all properties of the underlying concrete object type
+   * for interface queries. Has no effect for non-interface queries.
+   */
+  $includeAllBaseObjectProperties?: boolean;
 }
 
 export interface UseOsdkListResult<
@@ -212,7 +218,7 @@ export function useOsdkObjects<
   L extends LinkNames<Q>,
 >(
   type: Q,
-  options: UseOsdkObjectsOptions<Q> & {
+  options: UseOsdkObjectsOptions<Q, {}> & {
     pivotTo: L;
     rids: readonly string[];
     streamUpdates?: never;
@@ -224,8 +230,11 @@ export function useOsdkObjects<
   L extends LinkNames<Q>,
 >(
   type: Q,
-  options: UseOsdkObjectsOptions<Q> & { pivotTo: L; streamUpdates?: never },
-): UseOsdkListResult<LinkedType<Q, L>>;
+  options: UseOsdkObjectsOptions<Q, {}> & {
+    pivotTo: L;
+    streamUpdates?: never;
+  },
+): UseOsdkListResult<LinkedType<Q, L>, {}>;
 
 // Non-pivotTo overloads: pivotTo is forbidden to prevent fallthrough from the
 // pivotTo overloads above (which would give the wrong return type).
@@ -245,7 +254,9 @@ export function useOsdkObjects<
   RDPs extends Record<string, SimplePropertyDef> = {},
 >(
   type: Q,
-  options?: UseOsdkObjectsOptions<Q, RDPs> & { pivotTo?: never },
+  options?:
+    & UseOsdkObjectsOptions<Q, RDPs>
+    & { pivotTo?: never },
 ): UseOsdkListResult<Q, RDPs>;
 
 export function useOsdkObjects<
@@ -257,7 +268,7 @@ export function useOsdkObjects<
 ):
   | UseOsdkListResult<Q, RDPs>
   | UseOsdkListResult<Q, RDPs, "$rid">
-  | UseOsdkListResult<LinkedType<Q, LinkNames<Q>>>
+  | UseOsdkListResult<LinkedType<Q, LinkNames<Q>>, {}>
   | UseOsdkListResult<LinkedType<Q, LinkNames<Q>>, {}, "$rid">
 {
   const { observableClient } = React.useContext(OsdkContext2);
@@ -276,6 +287,7 @@ export function useOsdkObjects<
     pivotTo,
     $select,
     $loadPropertySecurityMetadata,
+    $includeAllBaseObjectProperties,
   } = options ?? {};
 
   const canonOptions = observableClient.canonicalizeOptions({
@@ -294,9 +306,7 @@ export function useOsdkObjects<
   const { subscribe, getSnapShot } = React.useMemo(
     () => {
       if (!enabled) {
-        return makeExternalStore<
-          ObserveObjectsCallbackArgs<Q, RDPs>
-        >(
+        return makeExternalStore<ObserveObjectsCallbackArgs<Q, RDPs>>(
           () => ({ unsubscribe: () => {} }),
           devToolsMetadata({
             hookType: "useOsdkObjects",
@@ -305,11 +315,9 @@ export function useOsdkObjects<
         );
       }
 
-      return makeExternalStore<
-        ObserveObjectsCallbackArgs<Q, RDPs>
-      >(
+      return makeExternalStore<ObserveObjectsCallbackArgs<Q, RDPs>>(
         (observer) =>
-          observableClient.observeList({
+          observableClient.observeList<Q, RDPs>({
             type,
             rids: stableRids,
             where: canonOptions.where,
@@ -319,6 +327,7 @@ export function useOsdkObjects<
             streamUpdates,
             withProperties: canonOptions.withProperties,
             autoFetchMore,
+            $includeAllBaseObjectProperties,
             ...(canonOptions.intersectWith
               ? { intersectWith: canonOptions.intersectWith }
               : {}),
@@ -354,6 +363,7 @@ export function useOsdkObjects<
       pivotTo,
       canonOptions.$select,
       $loadPropertySecurityMetadata,
+      $includeAllBaseObjectProperties,
     ],
   );
 
@@ -363,15 +373,18 @@ export function useOsdkObjects<
     await observableClient.invalidateObjectType(type.apiName);
   }, [observableClient, type.apiName]);
 
-  return React.useMemo(() => ({
-    fetchMore: listPayload?.hasMore ? listPayload.fetchMore : undefined,
-    error: extractPayloadError(listPayload, "Failed to load objects"),
-    data: listPayload?.resolvedList,
-    isLoading: isPayloadLoading(listPayload, enabled),
-    isOptimistic: listPayload?.isOptimistic ?? false,
-    totalCount: listPayload?.totalCount,
-    hasMore: listPayload?.hasMore ?? false,
-    objectSet: listPayload?.objectSet,
-    refetch,
-  }), [listPayload, enabled, refetch]);
+  return React.useMemo<UseOsdkListResult<Q, RDPs>>(
+    () => ({
+      fetchMore: listPayload?.hasMore ? listPayload.fetchMore : undefined,
+      error: extractPayloadError(listPayload, "Failed to load objects"),
+      data: listPayload?.resolvedList,
+      isLoading: isPayloadLoading(listPayload, enabled),
+      isOptimistic: listPayload?.isOptimistic ?? false,
+      totalCount: listPayload?.totalCount,
+      hasMore: listPayload?.hasMore ?? false,
+      objectSet: listPayload?.objectSet,
+      refetch,
+    }),
+    [listPayload, enabled, refetch],
+  );
 }

--- a/packages/react/test/useOsdkObjects.test.tsx
+++ b/packages/react/test/useOsdkObjects.test.tsx
@@ -224,6 +224,27 @@ describe("useOsdkObjects enabled option", () => {
     expect(mockInvalidateObjectType).toHaveBeenCalledWith("MockObject");
   });
 
+  it("should pass $includeAllBaseObjectProperties to observeList when true", () => {
+    const wrapper = createWrapper();
+
+    renderHook(
+      () =>
+        useOsdkObjects(MockObjectType, {
+          $includeAllBaseObjectProperties: true,
+        }),
+      { wrapper },
+    );
+
+    expect(mockObserveList).toHaveBeenCalledTimes(1);
+    expect(mockObserveList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MockObjectType,
+        $includeAllBaseObjectProperties: true,
+      }),
+      expect.any(Object),
+    );
+  });
+
   it("should not resubscribe when rerendered with a new inline withProperties of the same shape", () => {
     const canonicalWithProperties = { leadName: () => {} };
     const observableClient = {


### PR DESCRIPTION
exposes \`\$includeAllBaseObjectProperties\` on \`useOsdkObjects\` and on the underlying \`ObservableClient.observeList\`

when set against an interface query, the server returns the underlying concrete object's full property set so \`obj.\$as(ConcreteType)\` yields a fully-populated concrete object

• overrides BaseListQuery's includeAllBaseObjectProperties getter on ListQuery to read from cache key
• partitions ListCacheKey by the flag, gated to interface queries in ListsHelper
• threads the flag through observeList signature and useOsdkObjects hook + tests
• wires the demo column in officenetwork EmployeePanel via \$as(Employee).jobTitle