### PR TITLE
expose $includeAllBaseObjectProperties on useLinks

### DIFF
--- a/.changeset/include-base-object-properties-foundation.md
+++ b/.changeset/include-base-object-properties-foundation.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+internal plumbing for upcoming `$includeAllBaseObjectProperties` option on observable hooks; no public behavior change. adds a no-op getter on `BaseListQuery` (subclasses opt in), threads the flag through `ObjectsHelper.storeOsdkInstances`, and exposes a `$includeAllBaseObjectProperties` field on `ObserveObjectOptions` that has no consumer yet.

--- a/.changeset/include-base-object-properties-use-links.md
+++ b/.changeset/include-base-object-properties-use-links.md
@@ -1,0 +1,6 @@
+---
+"@osdk/react": minor
+"@osdk/client": minor
+---
+
+expose `$includeAllBaseObjectProperties` on `useLinks` and on the underlying `ObservableClient.observeLinks`. When set against a link whose target is an interface, the server returns the underlying concrete object's full property set so `obj.$as(ConcreteType)` yields a fully-populated concrete object. The flag is dropped at fetch time when the link target is an object type and does not narrow the returned `Osdk.Instance` type.

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -339,10 +339,10 @@ export interface ObserveFunctionCallbackArgs<
 export interface ObserveLinkCallbackArgs<
   T extends ObjectOrInterfaceDefinition,
 > {
-  resolvedList: Osdk.Instance<T>[] | undefined;
+  resolvedList: Osdk.Instance<T, "$allBaseProperties">[] | undefined;
   linkedObjectsBySourcePrimaryKey: ReadonlyMap<
     string | number,
-    ReadonlyArray<Osdk.Instance<T>>
+    ReadonlyArray<Osdk.Instance<T, "$allBaseProperties">>
   >;
   isOptimistic: boolean;
   lastUpdated: number;

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -106,6 +106,12 @@ export interface ObserveObjectOptions<
   pk: PrimaryKeyType<T>;
   select?: PropertyKeys<T>[];
   $loadPropertySecurityMetadata?: boolean;
+
+  /**
+   * When true, includes all properties of the underlying concrete object type
+   * for interface queries. Has no effect for non-interface queries.
+   */
+  $includeAllBaseObjectProperties?: boolean;
 }
 
 export type OrderBy<Q extends ObjectOrInterfaceDefinition> = {

--- a/packages/client/src/observable/ObservableClient/ObserveLink.ts
+++ b/packages/client/src/observable/ObservableClient/ObserveLink.ts
@@ -47,15 +47,22 @@ export namespace ObserveLinks {
     orderBy?: OrderBy<CompileTimeMetadata<Q>["links"][L]["targetType"]>;
     invalidationMode?: InvalidationMode;
     expectedLength?: number;
+
+    /**
+     * When true, includes all properties of the underlying concrete object type
+     * when the link target is an interface. Has no effect for non-interface
+     * targets.
+     */
+    $includeAllBaseObjectProperties?: boolean;
   }
 
   export interface CallbackArgs<
     T extends ObjectTypeDefinition | InterfaceDefinition,
   > {
-    resolvedList: Osdk.Instance<T>[] | undefined;
+    resolvedList: Osdk.Instance<T, "$allBaseProperties">[] | undefined;
     linkedObjectsBySourcePrimaryKey: ReadonlyMap<
       string | number,
-      ReadonlyArray<Osdk.Instance<T>>
+      ReadonlyArray<Osdk.Instance<T, "$allBaseProperties">>
     >;
     isOptimistic: boolean;
     lastUpdated: number;

--- a/packages/client/src/observable/internal/base-list/BaseListQuery.ts
+++ b/packages/client/src/observable/internal/base-list/BaseListQuery.ts
@@ -86,6 +86,15 @@ export abstract class BaseListQuery<
   /** RDP configuration for this collection. */
   public abstract get rdpConfig(): Canonical<Rdp> | undefined;
 
+  /**
+   * Whether this query requests all properties of underlying concrete object
+   * types for interface results. Subclasses that wire the option through
+   * their cache key tuple override this to read the value out.
+   */
+  public get includeAllBaseObjectProperties(): boolean {
+    return false;
+  }
+
   private _selectFieldSetMemo: ReadonlySet<string> | undefined;
 
   protected abstract get rawSelect(): Canonical<readonly string[]> | undefined;
@@ -157,6 +166,7 @@ export abstract class BaseListQuery<
         batch,
         this.rdpConfig,
         this.selectFieldSet,
+        this.includeAllBaseObjectProperties,
       );
     } else {
       // Items are already cache keys
@@ -510,6 +520,7 @@ export abstract class BaseListQuery<
           batch,
           this.rdpConfig,
           this.selectFieldSet,
+          this.includeAllBaseObjectProperties,
         );
 
         return this._updateList(
@@ -629,6 +640,7 @@ export abstract class BaseListQuery<
         batch,
         this.rdpConfig,
         this.selectFieldSet,
+        this.includeAllBaseObjectProperties,
       );
     } else {
       // Items are already cache keys
@@ -764,6 +776,8 @@ export abstract class BaseListQuery<
           [object as Osdk.Instance<ObjectTypeDefinition>],
           batch,
           this.rdpConfig, // Safe - null for queries without RDPs
+          undefined,
+          this.includeAllBaseObjectProperties,
         );
       });
     } else if (state === "REMOVED") {

--- a/packages/client/src/observable/internal/links/LinksHelper.ts
+++ b/packages/client/src/observable/internal/links/LinksHelper.ts
@@ -95,6 +95,7 @@ export class LinksHelper extends AbstractHelper<
       canonWhere,
       canonOrderBy,
       canonSelect,
+      options.$includeAllBaseObjectProperties ? true : undefined,
     );
 
     return this.store.queries.get(linkCacheKey, () => {

--- a/packages/client/src/observable/internal/links/SpecificLinkCacheKey.ts
+++ b/packages/client/src/observable/internal/links/SpecificLinkCacheKey.ts
@@ -30,6 +30,7 @@ export const LINK_NAME_IDX = 4;
 export const WHERE_CLAUSE_IDX = 5;
 export const ORDER_BY_CLAUSE_IDX = 6;
 export const SELECT_IDX = 7;
+export const INCLUDE_ALL_BASE_PROPERTIES_IDX = 8;
 
 /**
  * Storage data format for link query cache entries, similar to ListStorageData
@@ -57,6 +58,7 @@ export interface SpecificLinkCacheKey extends
       whereClause: Canonical<SimpleWhereClause>,
       orderByClause: Canonical<Record<string, "asc" | "desc" | undefined>>,
       select?: Canonical<readonly string[]> | undefined,
+      includeAllBaseObjectProperties?: true | undefined,
     ]
   >
 {

--- a/packages/client/src/observable/internal/links/SpecificLinkQuery.ts
+++ b/packages/client/src/observable/internal/links/SpecificLinkQuery.ts
@@ -45,6 +45,7 @@ import type { Store } from "../Store.js";
 import type { SubjectPayload } from "../SubjectPayload.js";
 import { tombstone } from "../tombstone.js";
 import {
+  INCLUDE_ALL_BASE_PROPERTIES_IDX as LINK_INCLUDE_ALL_BASE_PROPERTIES_IDX,
   SELECT_IDX as LINK_SELECT_IDX,
   type SpecificLinkCacheKey,
 } from "./SpecificLinkCacheKey.js";
@@ -133,6 +134,12 @@ export class SpecificLinkQuery extends BaseListQuery<
     return undefined;
   }
 
+  public override get includeAllBaseObjectProperties(): boolean {
+    return (
+      this.cacheKey.otherKeys[LINK_INCLUDE_ALL_BASE_PROPERTIES_IDX] === true
+    );
+  }
+
   /**
    * Implements fetchPageData from the BaseCollectionQuery template method pattern
    */
@@ -143,9 +150,13 @@ export class SpecificLinkQuery extends BaseListQuery<
     const ontologyProvider = client[additionalContext].ontologyProvider;
     const isInterface = this.#sourceTypeKind === "interface";
 
-    if (this.#orderBy && Object.keys(this.#orderBy).length > 0) {
-      let targetTypeApiName: string;
-
+    // Resolve the link target's apiName + kind once if needed for sorting or
+    // for gating the $includeAllBaseObjectProperties param. The ontology
+    // provider caches its lookups, so calling it here is cheap.
+    const hasOrderBy = this.#orderBy
+      && Object.keys(this.#orderBy).length > 0;
+    let target: { apiName: string; kind: "object" | "interface" } | undefined;
+    if (hasOrderBy || this.includeAllBaseObjectProperties) {
       if (isInterface) {
         const interfaceMetadata = await ontologyProvider.getInterfaceDefinition(
           this.#sourceApiName,
@@ -156,7 +167,10 @@ export class SpecificLinkQuery extends BaseListQuery<
             `Missing link definition for link '${this.#linkName}' on interface '${this.#sourceApiName}'`,
           );
         }
-        targetTypeApiName = linkDef.targetTypeApiName;
+        target = {
+          apiName: linkDef.targetTypeApiName,
+          kind: linkDef.targetType,
+        };
       } else {
         const objectMetadata = await ontologyProvider.getObjectDefinition(
           this.#sourceApiName,
@@ -167,11 +181,14 @@ export class SpecificLinkQuery extends BaseListQuery<
             `Missing link definition or targetType for link '${this.#linkName}' on object type '${this.#sourceApiName}'`,
           );
         }
-        targetTypeApiName = linkDef.targetType;
+        // Object link defs always target an object type.
+        target = { apiName: linkDef.targetType, kind: "object" };
       }
+    }
 
+    if (target && hasOrderBy) {
       this.sortingStrategy = new OrderBySortingStrategy(
-        targetTypeApiName,
+        target.apiName,
         this.#orderBy,
       );
     }
@@ -226,6 +243,7 @@ export class SpecificLinkQuery extends BaseListQuery<
       $orderBy?: Record<string, "asc" | "desc" | undefined>;
       $where?: Record<string, unknown>;
       $select?: readonly string[];
+      $includeAllBaseObjectProperties?: true;
     } = {
       $pageSize: this.getEffectiveFetchPageSize(),
       $nextPageToken: this.nextPageToken,
@@ -242,6 +260,12 @@ export class SpecificLinkQuery extends BaseListQuery<
 
     if (this.#whereClause && Object.keys(this.#whereClause).length > 0) {
       queryParams.$where = this.#whereClause;
+    }
+
+    // Only forward $includeAllBaseObjectProperties when the link target is an
+    // interface — for object targets the flag is a no-op on the server.
+    if (target?.kind === "interface") {
+      queryParams.$includeAllBaseObjectProperties = true;
     }
 
     const response = await linkQuery.fetchPage(queryParams);

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -89,11 +89,13 @@ export class ObjectsHelper extends AbstractHelper<
     batch: BatchContext,
     rdpConfig?: Canonical<Rdp> | null,
     selectFields?: ReadonlySet<string>,
+    includeAllBaseObjectProperties?: boolean,
   ): ObjectCacheKey[] {
     return values.map(v =>
       this.getQuery({
         apiName: v.$objectType ?? v.$apiName,
         pk: v.$primaryKey,
+        $includeAllBaseObjectProperties: includeAllBaseObjectProperties,
       }, rdpConfig).writeToStore(
         v as ObjectHolder,
         "loaded",

--- a/packages/react/src/new/useLinks.ts
+++ b/packages/react/src/new/useLinks.ts
@@ -87,12 +87,17 @@ export interface UseLinksOptions<
    * });
    */
   enabled?: boolean;
+
+  /**
+   * When true, includes all properties of the underlying concrete object type
+   * for interface link targets. Has no effect when the link target is a plain
+   * object type.
+   */
+  $includeAllBaseObjectProperties?: boolean;
 }
 
-export interface UseLinksResult<
-  Q extends ObjectOrInterfaceDefinition,
-> {
-  links: Osdk.Instance<Q>[] | undefined;
+export interface UseLinksResult<Q extends ObjectOrInterfaceDefinition> {
+  links: Osdk.Instance<Q, "$allBaseProperties">[] | undefined;
 
   /**
    * Maps each source object's primary key to its linked object instances.
@@ -101,7 +106,7 @@ export interface UseLinksResult<
    */
   linkedObjectsBySourcePrimaryKey: ReadonlyMap<
     string | number,
-    ReadonlyArray<Osdk.Instance<Q>>
+    ReadonlyArray<Osdk.Instance<Q, "$allBaseProperties">>
   >;
 
   isLoading: boolean;
@@ -144,7 +149,8 @@ export function useLinks<
 ): UseLinksResult<LinkedType<T, L>> {
   const { observableClient } = React.useContext(OsdkContext2);
 
-  const { enabled = true, ...otherOptions } = options;
+  const { enabled = true, $includeAllBaseObjectProperties, ...otherOptions } =
+    options;
 
   const canonOptions = observableClient.canonicalizeOptions({
     where: otherOptions.where,
@@ -170,7 +176,9 @@ export function useLinks<
   const { subscribe, getSnapShot } = React.useMemo(
     () => {
       if (!enabled) {
-        return makeExternalStore<ObserveLinks.CallbackArgs<T>>(
+        return makeExternalStore<
+          ObserveLinks.CallbackArgs<LinkedType<T, L>>
+        >(
           () => ({ unsubscribe: () => {} }),
           devToolsMetadata({
             hookType: "useLinks",
@@ -179,9 +187,11 @@ export function useLinks<
           }),
         );
       }
-      return makeExternalStore<ObserveLinks.CallbackArgs<T>>(
+      return makeExternalStore<
+        ObserveLinks.CallbackArgs<LinkedType<T, L>>
+      >(
         (observer) =>
-          observableClient.observeLinks(
+          observableClient.observeLinks<T, L>(
             objectsArray,
             linkName,
             {
@@ -191,6 +201,7 @@ export function useLinks<
               orderBy: canonOptions.orderBy,
               mode: otherOptions.mode,
               dedupeInterval: otherOptions.dedupeIntervalMs ?? 2_000,
+              $includeAllBaseObjectProperties,
               ...(canonOptions.$select ? { select: canonOptions.$select } : {}),
             },
             observer,
@@ -214,6 +225,7 @@ export function useLinks<
       otherOptions.mode,
       otherOptions.dedupeIntervalMs,
       canonOptions.$select,
+      $includeAllBaseObjectProperties,
     ],
   );
 

--- a/packages/react/test/useLinks.enabled.test.tsx
+++ b/packages/react/test/useLinks.enabled.test.tsx
@@ -172,4 +172,20 @@ describe("useLinks enabled option", () => {
     expect(result.current.linkedObjectsBySourcePrimaryKey.get("obj-123"))
       .toEqual([linkedObj]);
   });
+
+  it("should forward $includeAllBaseObjectProperties to observeLinks", () => {
+    const wrapper = createWrapper();
+
+    renderHook(
+      () =>
+        useLinks(mockObject, "relatedObjects", {
+          $includeAllBaseObjectProperties: true,
+        }),
+      { wrapper },
+    );
+
+    expect(mockObserveLinks).toHaveBeenCalledTimes(1);
+    const options = mockObserveLinks.mock.calls[0][2];
+    expect(options.$includeAllBaseObjectProperties).toBe(true);
+  });
 });


### PR DESCRIPTION
exposes \`\$includeAllBaseObjectProperties\` on \`useLinks\` and on the underlying \`ObservableClient.observeLinks\`

when set against a link whose target is an interface, the server returns the underlying concrete object's full property set so \`obj.\$as(ConcreteType)\` yields a fully-populated concrete object

• overrides BaseListQuery's includeAllBaseObjectProperties getter on SpecificLinkQuery to read from cache key
• partitions SpecificLinkCacheKey by the flag in LinksHelper
• gates the flag at fetch time in SpecificLinkQuery.fetchPageData: only forwarded to the server when the link target kind is interface