### PR TITLE
fix devtools: errors panel, compute, pause, ergonomics

### DIFF
--- a/.changeset/devtools-fixes.md
+++ b/.changeset/devtools-fixes.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+fix devtools: errors panel surfaces console.error, uncaught errors, and unhandled rejections; compute tab classifies success-without-usage as its own state instead of failure; pause network blocks all OSDK traffic regardless of recording; rename getCacheEntries to loadCacheEntries (deprecated alias kept); add OsdkAppErrorBoundary for production render-error capture; emit OSDK_PAUSE_BLOCK MonitorEvent.

--- a/.changeset/devtools-fixes.md
+++ b/.changeset/devtools-fixes.md
@@ -2,4 +2,4 @@
 "@osdk/react-devtools": patch
 ---
 
-fix devtools: errors panel surfaces console.error, uncaught errors, and unhandled rejections; compute tab classifies success-without-usage as its own state instead of failure; pause network blocks all OSDK traffic regardless of recording; rename getCacheEntries to loadCacheEntries (deprecated alias kept); add OsdkAppErrorBoundary for production render-error capture; emit OSDK_PAUSE_BLOCK MonitorEvent.
+fix devtools: errors panel surfaces console.error, uncaught errors, and unhandled rejections; compute tab classifies success-without-usage as its own state instead of failure; pause network blocks all OSDK traffic regardless of recording; rename getCacheEntries to loadCacheEntries (deprecated alias kept); add OsdkAppErrorBoundary for production render-error capture; emit OSDK_PAUSE_BLOCK MonitorEvent; bind unwrapped prototype methods on the wrapped ObservableClient so callers (e.g. canonicalizeOptions, which uses private fields) don't fail with "Receiver must be an instance of class ObservableClientImpl".

--- a/packages/e2e.sandbox.officenetwork/src/components/AggregationStatsPanel.tsx
+++ b/packages/e2e.sandbox.officenetwork/src/components/AggregationStatsPanel.tsx
@@ -78,9 +78,18 @@ export function AggregationStatsPanel() {
 
   return (
     <div className="bg-[var(--officenetwork-bg-surface)]/95 backdrop-blur border border-[var(--officenetwork-border-default)] rounded-lg shadow-xl min-w-56">
-      <button
+      <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={isExpanded}
         onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full flex items-center justify-between p-3 hover:bg-[var(--officenetwork-bg-elevated)]/50 transition-colors"
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setIsExpanded(!isExpanded);
+          }
+        }}
+        className="w-full flex items-center justify-between p-3 hover:bg-[var(--officenetwork-bg-elevated)]/50 transition-colors cursor-pointer"
       >
         <div className="flex items-center gap-2">
           <svg
@@ -126,7 +135,7 @@ export function AggregationStatsPanel() {
             </svg>
           </button>
         </div>
-      </button>
+      </div>
 
       {isExpanded && (
         <div className="px-3 pb-3 space-y-3">

--- a/packages/react-devtools/src/components/BubbleChart.tsx
+++ b/packages/react-devtools/src/components/BubbleChart.tsx
@@ -92,11 +92,13 @@ export const BubbleChart: React.FC<BubbleChartProps> = ({
         size: visitComputeRequest(request, {
           failed: () => 40,
           fulfilled: (req) => Math.max(1, req.computeUsage) * 20,
+          fulfilledWithoutUsage: () => 20,
           pending: () => 20,
         }),
         fill: visitComputeRequest(request, {
           failed: () => "#e05252",
           fulfilled: () => "#2d8cf0",
+          fulfilledWithoutUsage: () => "#7a8693",
           pending: () => "#6b7785",
         }),
         isSelected: selectedSet

--- a/packages/react-devtools/src/components/CacheInspectorTab.test.tsx
+++ b/packages/react-devtools/src/components/CacheInspectorTab.test.tsx
@@ -44,11 +44,11 @@ describe("CacheInspectorTab", () => {
     expect(screen.queryAllByRole("button").length).toBeGreaterThan(0);
   });
 
-  it("calls getCacheEntries on mount", () => {
+  it("calls loadCacheEntries on mount", () => {
     const store = createMockMonitorStore();
 
     render(<CacheInspectorTab monitorStore={store} />);
 
-    expect(store.getCacheEntries).toHaveBeenCalled();
+    expect(store.loadCacheEntries).toHaveBeenCalled();
   });
 });

--- a/packages/react-devtools/src/components/CacheInspectorTab.tsx
+++ b/packages/react-devtools/src/components/CacheInspectorTab.tsx
@@ -103,7 +103,7 @@ export const CacheInspectorTab: React.FC<CacheInspectorTabProps> = (
   const snapshotStore = React.useMemo(
     () =>
       createPollingStore(async () => {
-        const entries = await monitorStore.getCacheEntries();
+        const entries = await monitorStore.loadCacheEntries();
         const totalSize = entries.reduce(
           (sum: number, e: CacheEntry) => sum + e.metadata.size,
           0,

--- a/packages/react-devtools/src/components/ComputeTab.tsx
+++ b/packages/react-devtools/src/components/ComputeTab.tsx
@@ -77,6 +77,12 @@ export const ComputeTab: React.FC<ComputeTabProps> = ({ computeStore }) => {
         </span>
         <span className={styles.metricSubtext}>
           {metrics.requestCount} total
+          {metrics.fulfilledWithoutUsageCount > 0 && (
+            <>
+              {", "}
+              {metrics.fulfilledWithoutUsageCount} without usage data
+            </>
+          )}
         </span>
       </div>
     </div>
@@ -115,6 +121,7 @@ export const ComputeTab: React.FC<ComputeTabProps> = ({ computeStore }) => {
           onClick={() => computeStore.toggleNetworkPaused()}
           icon={isNetworkPaused ? "play" : "pause"}
           size="small"
+          title="Block all OSDK network requests"
         >
           {isNetworkPaused ? "Resume" : "Pause"} Network
         </Button>
@@ -162,6 +169,10 @@ export const ComputeTab: React.FC<ComputeTabProps> = ({ computeStore }) => {
 
 const REQUEST_DISPLAY: Record<string, { icon: string; class: string }> = {
   "fulfilled": { icon: "\u2713", class: styles.computeFulfilled },
+  "fulfilled-without-usage": {
+    icon: "\u00b7",
+    class: styles.computeFulfilledWithoutUsage,
+  },
   "failed": { icon: "\u00d7", class: styles.computeFailed },
   "pending": { icon: "\u22ef", class: styles.computePending },
 };
@@ -216,6 +227,16 @@ const ComputeRequestItem: React.FC<ComputeRequestItemProps> = ({
                 )}
               >
                 {formatNumber(request.computeUsage)} CU
+              </span>
+              <span className={styles.operationMetric}>
+                {formatBytes(request.responsePayloadBytes)}
+              </span>
+            </>
+          )}
+          {request.type === "fulfilled-without-usage" && (
+            <>
+              <span className={styles.operationMetric}>
+                no usage data
               </span>
               <span className={styles.operationMetric}>
                 {formatBytes(request.responsePayloadBytes)}

--- a/packages/react-devtools/src/components/DebuggingTab.test.tsx
+++ b/packages/react-devtools/src/components/DebuggingTab.test.tsx
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, render, screen, within } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ConsoleLogEntry } from "../store/ConsoleLogStore.js";
+import type { WindowErrorEntry } from "../store/WindowErrorStore.js";
+import { createMockMonitorStore } from "./testHelpers.js";
+
+const { DebuggingTab } = await import("./DebuggingTab.js");
+
+function consoleEntry(
+  partial: Partial<ConsoleLogEntry> & { args: readonly string[] },
+): ConsoleLogEntry {
+  return {
+    id: partial.id ?? "c1",
+    level: partial.level ?? "error",
+    args: partial.args,
+    timestamp: partial.timestamp ?? 1000,
+    ...(partial.source !== undefined ? { source: partial.source } : {}),
+  };
+}
+
+function windowError(
+  partial: Partial<WindowErrorEntry> & { message: string },
+): WindowErrorEntry {
+  return {
+    id: partial.id ?? "w1",
+    kind: partial.kind ?? "error",
+    message: partial.message,
+    timestamp: partial.timestamp ?? 1000,
+    ...(partial.stack !== undefined ? { stack: partial.stack } : {}),
+    ...(partial.filename !== undefined ? { filename: partial.filename } : {}),
+    ...(partial.lineno !== undefined ? { lineno: partial.lineno } : {}),
+    ...(partial.colno !== undefined ? { colno: partial.colno } : {}),
+  };
+}
+
+function getErrorsCount(): number {
+  const heading = screen.getByText(/^Errors$/).closest("div");
+  if (heading == null) {
+    return 0;
+  }
+  const countSpan = within(heading).getAllByText(/^\d+$/);
+  return Number.parseInt(countSpan[0].textContent ?? "0", 10);
+}
+
+describe("DebuggingTab", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("shows console.error entries in the Errors section", () => {
+    const store = createMockMonitorStore();
+    vi.mocked(store.getConsoleLogStore().getEntries).mockReturnValue([
+      consoleEntry({ id: "c1", args: ["boom-error"], timestamp: 1000 }),
+    ]);
+
+    render(<DebuggingTab monitorStore={store} />);
+
+    expect(getErrorsCount()).toBe(1);
+    expect(screen.getAllByText("boom-error").length).toBeGreaterThan(0);
+  });
+
+  it("shows uncaught errors in the Errors section", () => {
+    const store = createMockMonitorStore();
+    vi.mocked(store.getWindowErrorStore().getEntries).mockReturnValue([
+      windowError({
+        id: "w1",
+        kind: "error",
+        message: "thrown-from-handler",
+        timestamp: 2000,
+      }),
+    ]);
+
+    render(<DebuggingTab monitorStore={store} />);
+
+    expect(getErrorsCount()).toBe(1);
+    expect(screen.getAllByText("thrown-from-handler").length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it("shows unhandled rejections in the Errors section", () => {
+    const store = createMockMonitorStore();
+    vi.mocked(store.getWindowErrorStore().getEntries).mockReturnValue([
+      windowError({
+        id: "w1",
+        kind: "unhandledrejection",
+        message: "promise-rejected",
+        timestamp: 3000,
+      }),
+    ]);
+
+    render(<DebuggingTab monitorStore={store} />);
+
+    expect(getErrorsCount()).toBe(1);
+    expect(screen.getAllByText("promise-rejected").length).toBeGreaterThan(0);
+  });
+
+  it("deduplicates concurrent console.error and unhandledrejection within 100ms", () => {
+    const store = createMockMonitorStore();
+    vi.mocked(store.getWindowErrorStore().getEntries).mockReturnValue([
+      windowError({
+        id: "w1",
+        kind: "unhandledrejection",
+        message: "shared",
+        timestamp: 5000,
+      }),
+    ]);
+    vi.mocked(store.getConsoleLogStore().getEntries).mockReturnValue([
+      consoleEntry({ id: "c1", args: ["shared"], timestamp: 5050 }),
+    ]);
+
+    render(<DebuggingTab monitorStore={store} />);
+
+    expect(getErrorsCount()).toBe(1);
+  });
+
+  it("does not deduplicate when timestamps are >100ms apart", () => {
+    const store = createMockMonitorStore();
+    vi.mocked(store.getWindowErrorStore().getEntries).mockReturnValue([
+      windowError({
+        id: "w1",
+        kind: "unhandledrejection",
+        message: "shared",
+        timestamp: 5000,
+      }),
+    ]);
+    vi.mocked(store.getConsoleLogStore().getEntries).mockReturnValue([
+      consoleEntry({ id: "c1", args: ["shared"], timestamp: 5300 }),
+    ]);
+
+    render(<DebuggingTab monitorStore={store} />);
+
+    expect(getErrorsCount()).toBe(2);
+  });
+
+  it("deduplicates when window error and console.error straddle a 100ms bucket boundary", () => {
+    const store = createMockMonitorStore();
+    // window error at t=199 (bucket 1), console at t=200 (bucket 2): would
+    // miss with naive bucket dedup, must hit with ±100ms window dedup.
+    vi.mocked(store.getWindowErrorStore().getEntries).mockReturnValue([
+      windowError({
+        id: "w1",
+        kind: "error",
+        message: "boundary",
+        timestamp: 199,
+      }),
+    ]);
+    vi.mocked(store.getConsoleLogStore().getEntries).mockReturnValue([
+      consoleEntry({ id: "c1", args: ["boundary"], timestamp: 200 }),
+    ]);
+
+    render(<DebuggingTab monitorStore={store} />);
+
+    expect(getErrorsCount()).toBe(1);
+  });
+});

--- a/packages/react-devtools/src/components/DebuggingTab.tsx
+++ b/packages/react-devtools/src/components/DebuggingTab.tsx
@@ -73,6 +73,77 @@ function collectIssues(
     });
   }
 
+  const windowErrors = monitorStore.getWindowErrorStore().getEntries();
+  // Bucketed at 100ms granularity. The lookup checks the current bucket plus
+  // the two adjacent buckets so that any console.error within ±100ms of a
+  // window error collides regardless of where the timestamps fall.
+  const windowErrorBuckets = new Set<string>();
+  for (const we of windowErrors) {
+    const expandable: NonNullable<Issue["expandable"]> = {};
+    if (we.stack) {
+      expandable.stack = we.stack;
+    }
+    if (we.filename || we.lineno || we.colno) {
+      expandable.detailsJson = JSON.stringify(
+        {
+          filename: we.filename,
+          lineno: we.lineno,
+          colno: we.colno,
+        },
+        null,
+        2,
+      );
+    }
+    const hasExpandable = expandable.stack !== undefined
+      || expandable.detailsJson !== undefined;
+
+    issues.push({
+      id: `windowError-${we.id}`,
+      severity: "error",
+      category: we.kind === "unhandledrejection"
+        ? "unhandled rejection"
+        : "uncaught error",
+      title: we.kind === "unhandledrejection"
+        ? "Unhandled promise rejection"
+        : "Uncaught error",
+      message: we.message,
+      timestamp: we.timestamp,
+      ...(hasExpandable ? { expandable } : {}),
+    });
+
+    const bucket = Math.floor(we.timestamp / 100);
+    windowErrorBuckets.add(`${we.message}|${bucket}`);
+  }
+
+  for (const entry of monitorStore.getConsoleLogStore().getEntries()) {
+    if (entry.level !== "error") {
+      continue;
+    }
+    const messageText = entry.args.join(" ");
+    const bucket = Math.floor(entry.timestamp / 100);
+    if (
+      windowErrorBuckets.has(`${messageText}|${bucket - 1}`)
+      || windowErrorBuckets.has(`${messageText}|${bucket}`)
+      || windowErrorBuckets.has(`${messageText}|${bucket + 1}`)
+    ) {
+      continue;
+    }
+    const issue: Issue = {
+      id: `console-${entry.id}`,
+      severity: "error",
+      category: "console error",
+      title: "console.error",
+      message: messageText,
+      timestamp: entry.timestamp,
+    };
+    if (entry.source) {
+      issue.expandable = {
+        detailsJson: JSON.stringify({ source: entry.source }, null, 2),
+      };
+    }
+    issues.push(issue);
+  }
+
   for (const wr of monitorStore.getPropertyAccessTracker().getWastedRenders()) {
     issues.push({
       id: `wasted-${wr.componentId}-${wr.timestamp}`,
@@ -141,7 +212,7 @@ export const DebuggingTab: React.FC<DebuggingTabProps> = ({ monitorStore }) => {
     () =>
       createPollingStore(
         async () => {
-          const entries = await monitorStore.getCacheEntries();
+          const entries = await monitorStore.loadCacheEntries();
           return entries.length;
         },
         5000,

--- a/packages/react-devtools/src/components/MonitoringPanel.module.scss
+++ b/packages/react-devtools/src/components/MonitoringPanel.module.scss
@@ -486,6 +486,11 @@
   background: t.$green;
 }
 
+.computeFulfilledWithoutUsage {
+  background: t.$green;
+  opacity: 0.4;
+}
+
 .computeFailed {
   background: t.$red;
 }

--- a/packages/react-devtools/src/components/ObjectLoadingMetrics.tsx
+++ b/packages/react-devtools/src/components/ObjectLoadingMetrics.tsx
@@ -46,7 +46,7 @@ export const ObjectLoadingMetrics: React.FC<ObjectLoadingMetricsProps> = ({
   return (
     <>
       <div className={styles.metric}>
-        <span className={styles.metricLabel}>Inefficient Queries</span>
+        <span className={styles.metricLabel}>Inefficient Components</span>
         <span
           className={classNames(
             styles.metricValue,

--- a/packages/react-devtools/src/components/OsdkAppErrorBoundary.test.tsx
+++ b/packages/react-devtools/src/components/OsdkAppErrorBoundary.test.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMockMonitorStore } from "./testHelpers.js";
+
+const { OsdkAppErrorBoundary } = await import("./OsdkAppErrorBoundary.js");
+
+const Thrower: React.FC<{ message: string }> = ({ message }) => {
+  throw new Error(message);
+};
+
+describe("OsdkAppErrorBoundary", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders children when no error", () => {
+    const store = createMockMonitorStore();
+    render(
+      <OsdkAppErrorBoundary monitorStore={store}>
+        <div>healthy</div>
+      </OsdkAppErrorBoundary>,
+    );
+    expect(screen.getByText("healthy")).toBeDefined();
+  });
+
+  it("records caught render errors via WindowErrorStore.recordError", () => {
+    const store = createMockMonitorStore();
+    const recordError = store.getWindowErrorStore().recordError;
+    // React logs to console.error when an error boundary catches; silence to keep test output clean.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <OsdkAppErrorBoundary monitorStore={store}>
+        <Thrower message="render-explode" />
+      </OsdkAppErrorBoundary>,
+    );
+
+    expect(recordError).toHaveBeenCalledTimes(1);
+    const callArgs = vi.mocked(recordError).mock.calls[0];
+    expect((callArgs[0] as Error).message).toBe("render-explode");
+  });
+
+  it("renders default fallback with the error message", () => {
+    const store = createMockMonitorStore();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <OsdkAppErrorBoundary monitorStore={store}>
+        <Thrower message="visible-error" />
+      </OsdkAppErrorBoundary>,
+    );
+
+    expect(screen.getByRole("alert")).toBeDefined();
+    expect(screen.getByText("visible-error")).toBeDefined();
+  });
+
+  it("renders a function fallback when provided", () => {
+    const store = createMockMonitorStore();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <OsdkAppErrorBoundary
+        monitorStore={store}
+        fallback={(err, reset) => (
+          <div>
+            <span>custom-{err.message}</span>
+            <button type="button" onClick={reset}>retry</button>
+          </div>
+        )}
+      >
+        <Thrower message="x" />
+      </OsdkAppErrorBoundary>,
+    );
+
+    expect(screen.getByText("custom-x")).toBeDefined();
+    expect(screen.getByRole("button", { name: "retry" })).toBeDefined();
+  });
+
+  it("renders a node fallback when provided", () => {
+    const store = createMockMonitorStore();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <OsdkAppErrorBoundary
+        monitorStore={store}
+        fallback={<div>static-fallback</div>}
+      >
+        <Thrower message="x" />
+      </OsdkAppErrorBoundary>,
+    );
+
+    expect(screen.getByText("static-fallback")).toBeDefined();
+  });
+
+  it("reset button clears the error and re-renders children", () => {
+    const store = createMockMonitorStore();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    let shouldThrow = true;
+    const Toggle: React.FC = () => {
+      if (shouldThrow) {
+        throw new Error("once");
+      }
+      return <div>recovered</div>;
+    };
+
+    render(
+      <OsdkAppErrorBoundary monitorStore={store}>
+        <Toggle />
+      </OsdkAppErrorBoundary>,
+    );
+
+    expect(screen.getByText("once")).toBeDefined();
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole("button", { name: "Reset" }));
+
+    expect(screen.getByText("recovered")).toBeDefined();
+  });
+});

--- a/packages/react-devtools/src/components/OsdkAppErrorBoundary.tsx
+++ b/packages/react-devtools/src/components/OsdkAppErrorBoundary.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Boundary for *host app* code. Wraps a subtree so that render errors
+// surface in the devtools Errors panel via WindowErrorStore.recordError.
+// Production-safe: production React doesn't route render errors through
+// console.error, so the Errors panel relies on this boundary for those.
+
+import React from "react";
+import type { MonitorStore } from "../store/MonitorStore.js";
+
+export interface OsdkAppErrorBoundaryProps {
+  monitorStore: MonitorStore;
+  children: React.ReactNode;
+  fallback?:
+    | React.ReactNode
+    | ((error: Error, reset: () => void) => React.ReactNode);
+}
+
+interface OsdkAppErrorBoundaryState {
+  error: Error | null;
+}
+
+export class OsdkAppErrorBoundary extends React.Component<
+  OsdkAppErrorBoundaryProps,
+  OsdkAppErrorBoundaryState
+> {
+  constructor(props: OsdkAppErrorBoundaryProps) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): OsdkAppErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    const source = errorInfo.componentStack
+      ? errorInfo.componentStack.split("\n")[1]?.trim()
+      : undefined;
+    this.props.monitorStore.getWindowErrorStore().recordError(error, source);
+  }
+
+  reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): React.ReactNode {
+    const { error } = this.state;
+    if (error == null) {
+      return this.props.children;
+    }
+
+    const { fallback } = this.props;
+    if (typeof fallback === "function") {
+      return fallback(error, this.reset);
+    }
+    if (fallback !== undefined) {
+      return fallback;
+    }
+
+    return (
+      <div role="alert">
+        <p>Something went wrong.</p>
+        <pre>{error.message}</pre>
+        <button type="button" onClick={this.reset}>Reset</button>
+      </div>
+    );
+  }
+}

--- a/packages/react-devtools/src/components/PerformanceTab.tsx
+++ b/packages/react-devtools/src/components/PerformanceTab.tsx
@@ -73,7 +73,7 @@ export const PerformanceTab: React.FC<PerformanceTabProps> = (
   const enrichmentStore = React.useMemo(
     () =>
       createPollingStore(async () => {
-        const entries = await monitorStore.getCacheEntries();
+        const entries = await monitorStore.loadCacheEntries();
         const timeline = monitorStore.getEventTimeline();
         const actions = timeline.getEventsByType("ACTION_START");
         return {

--- a/packages/react-devtools/src/components/testHelpers.ts
+++ b/packages/react-devtools/src/components/testHelpers.ts
@@ -278,6 +278,18 @@ export function createMockMonitorStore(): MonitorStore {
       unsuppress: vi.fn(),
       dispose: vi.fn(),
     }),
+    getWindowErrorStore: vi.fn().mockReturnValue({
+      getEntries: vi.fn().mockReturnValue([]),
+      getSize: vi.fn().mockReturnValue(0),
+      clear: vi.fn(),
+      subscribe: vi.fn().mockReturnValue(() => {}),
+      install: vi.fn(),
+      uninstall: vi.fn(),
+      suppress: vi.fn(),
+      unsuppress: vi.fn(),
+      recordError: vi.fn(),
+      dispose: vi.fn(),
+    }),
     getPrototypeOverrideStore: vi.fn().mockReturnValue({
       setOverride: vi.fn(),
       getOverride: vi.fn().mockReturnValue(undefined),
@@ -292,6 +304,7 @@ export function createMockMonitorStore(): MonitorStore {
       subscribe: vi.fn().mockReturnValue(() => {}),
     }),
     getCacheEntries: vi.fn().mockResolvedValue([]),
+    loadCacheEntries: vi.fn().mockResolvedValue([]),
     getCacheSnapshot: vi.fn().mockResolvedValue({
       entries: [],
       stats: { totalEntries: 0, totalSize: 0, totalHits: 0 },

--- a/packages/react-devtools/src/index.ts
+++ b/packages/react-devtools/src/index.ts
@@ -25,6 +25,8 @@ export {
   SafeMonitoringPanel,
 } from "./components/MonitoringPanel.js";
 export type { MonitoringPanelProps } from "./components/MonitoringPanel.js";
+export { OsdkAppErrorBoundary } from "./components/OsdkAppErrorBoundary.js";
+export type { OsdkAppErrorBoundaryProps } from "./components/OsdkAppErrorBoundary.js";
 export { OsdkDevTools } from "./components/OsdkDevTools.js";
 
 export {

--- a/packages/react-devtools/src/store/ComputeStore.test.ts
+++ b/packages/react-devtools/src/store/ComputeStore.test.ts
@@ -398,15 +398,76 @@ describe("ComputeStore", () => {
     }
   });
 
-  it("should preserve no-compute-usage discriminant", () => {
+  it("fulfillWithoutUsage transitions pending to fulfilled-without-usage", () => {
     const id = store.createPendingRequest(createPendingRequestInput());
-    store.failRequest(id, { type: "no-compute-usage" });
+    store.fulfillWithoutUsage(id, {
+      responsePayloadBytes: 512,
+      responsePayloadHash: 99,
+      responsePayload: "{}",
+    });
 
     const requests = store.getRequests();
-    expect(requests[0].type).toBe("failed");
-    if (requests[0].type === "failed") {
-      expect(requests[0].error.type).toBe("no-compute-usage");
+    expect(requests).toHaveLength(1);
+    expect(requests[0].type).toBe("fulfilled-without-usage");
+
+    if (requests[0].type === "fulfilled-without-usage") {
+      expect(requests[0].responsePayloadBytes).toBe(512);
     }
+  });
+
+  it("fulfillWithoutUsage does not bump failedCount", () => {
+    const id = store.createPendingRequest(createPendingRequestInput());
+    store.fulfillWithoutUsage(id, {
+      responsePayloadBytes: 512,
+      responsePayloadHash: 99,
+      responsePayload: "{}",
+    });
+
+    const metrics = store.getMetrics();
+    expect(metrics.failedCount).toBe(0);
+    expect(metrics.fulfilledCount).toBe(0);
+    expect(metrics.fulfilledWithoutUsageCount).toBe(1);
+    expect(metrics.requestCount).toBe(1);
+  });
+
+  it("excludes no-usage requests from averageUsagePerRequest", () => {
+    const id1 = store.createPendingRequest(createPendingRequestInput());
+    store.fulfillRequest(id1, {
+      computeUsage: 100,
+      responsePayloadBytes: 1024,
+      responsePayloadHash: 1,
+      responsePayload: "{}",
+    });
+
+    const id2 = store.createPendingRequest(createPendingRequestInput());
+    store.fulfillWithoutUsage(id2, {
+      responsePayloadBytes: 1024,
+      responsePayloadHash: 2,
+      responsePayload: "{}",
+    });
+
+    const metrics = store.getMetrics();
+    expect(metrics.averageUsagePerRequest).toBe(100);
+  });
+
+  it("includes no-usage requests in averageResponseBytes", () => {
+    const id1 = store.createPendingRequest(createPendingRequestInput());
+    store.fulfillRequest(id1, {
+      computeUsage: 100,
+      responsePayloadBytes: 1000,
+      responsePayloadHash: 1,
+      responsePayload: "{}",
+    });
+
+    const id2 = store.createPendingRequest(createPendingRequestInput());
+    store.fulfillWithoutUsage(id2, {
+      responsePayloadBytes: 2000,
+      responsePayloadHash: 2,
+      responsePayload: "{}",
+    });
+
+    const metrics = store.getMetrics();
+    expect(metrics.averageResponseBytes).toBe(1500);
   });
 
   describe("referential stability", () => {

--- a/packages/react-devtools/src/store/ComputeStore.ts
+++ b/packages/react-devtools/src/store/ComputeStore.ts
@@ -43,6 +43,7 @@ export class ComputeStore extends SubscribableStore {
   private totalUsage = 0;
   private totalResponseBytes = 0;
   private fulfilledCount = 0;
+  private fulfilledWithoutUsageCount = 0;
   private failedCount = 0;
   private pendingCount = 0;
 
@@ -103,6 +104,38 @@ export class ComputeStore extends SubscribableStore {
     this.invalidate();
   }
 
+  fulfillWithoutUsage(
+    requestId: string,
+    responseInfo: {
+      responsePayloadBytes: number;
+      responsePayloadHash: number;
+      responsePayload: string;
+    },
+  ): void {
+    const pending = this.requestMap.get(requestId);
+
+    if (!pending || pending.type !== "pending") {
+      return;
+    }
+
+    const fulfilled: ComputeRequest = {
+      type: "fulfilled-without-usage",
+      id: pending.id,
+      requestTimestamp: pending.requestTimestamp,
+      requestUrl: pending.requestUrl,
+      requestPayload: pending.requestPayload,
+      requestPayloadHash: pending.requestPayloadHash,
+      responseTimestamp: new Date(),
+      ...responseInfo,
+    };
+
+    this.requestMap.set(requestId, fulfilled);
+    this.pendingCount--;
+    this.fulfilledWithoutUsageCount++;
+    this.totalResponseBytes += responseInfo.responsePayloadBytes;
+    this.invalidate();
+  }
+
   failRequest(requestId: string, error: ComputeRequestError): void {
     const pending = this.requestMap.get(requestId);
 
@@ -144,6 +177,7 @@ export class ComputeStore extends SubscribableStore {
       this.totalUsage = 0;
       this.totalResponseBytes = 0;
       this.fulfilledCount = 0;
+      this.fulfilledWithoutUsageCount = 0;
       this.failedCount = 0;
       this.pendingCount = 0;
     } else if (this.lastRecordingEvent?.type === "started") {
@@ -182,6 +216,7 @@ export class ComputeStore extends SubscribableStore {
     this.totalUsage = 0;
     this.totalResponseBytes = 0;
     this.fulfilledCount = 0;
+    this.fulfilledWithoutUsageCount = 0;
     this.failedCount = 0;
     this.pendingCount = 0;
     this.invalidate();
@@ -243,21 +278,25 @@ export class ComputeStore extends SubscribableStore {
       }
     }
 
-    const requestCount = this.fulfilledCount + this.failedCount
-      + this.pendingCount;
+    const requestCount = this.fulfilledCount + this.fulfilledWithoutUsageCount
+      + this.failedCount + this.pendingCount;
+
+    const completedWithResponseBytes = this.fulfilledCount
+      + this.fulfilledWithoutUsageCount;
 
     const newMetrics: ComputeMetrics = {
       totalUsage: Math.round(this.totalUsage),
       lastMinuteUsage: Math.round(lastMinuteUsage),
       requestCount,
       fulfilledCount: this.fulfilledCount,
+      fulfilledWithoutUsageCount: this.fulfilledWithoutUsageCount,
       failedCount: this.failedCount,
       pendingCount: this.pendingCount,
       averageUsagePerRequest: this.fulfilledCount > 0
         ? Math.round(this.totalUsage / this.fulfilledCount)
         : 0,
-      averageResponseBytes: this.fulfilledCount > 0
-        ? Math.round(this.totalResponseBytes / this.fulfilledCount)
+      averageResponseBytes: completedWithResponseBytes > 0
+        ? Math.round(this.totalResponseBytes / completedWithResponseBytes)
         : 0,
     };
 
@@ -282,6 +321,7 @@ export class ComputeStore extends SubscribableStore {
     this.totalUsage = 0;
     this.totalResponseBytes = 0;
     this.fulfilledCount = 0;
+    this.fulfilledWithoutUsageCount = 0;
     this.failedCount = 0;
     this.pendingCount = 0;
     this.lastSnapshot = null;
@@ -317,6 +357,7 @@ export class ComputeStore extends SubscribableStore {
       && a.lastMinuteUsage === b.lastMinuteUsage
       && a.requestCount === b.requestCount
       && a.fulfilledCount === b.fulfilledCount
+      && a.fulfilledWithoutUsageCount === b.fulfilledWithoutUsageCount
       && a.failedCount === b.failedCount
       && a.pendingCount === b.pendingCount
       && a.averageUsagePerRequest === b.averageUsagePerRequest

--- a/packages/react-devtools/src/store/ConsoleLogStore.test.ts
+++ b/packages/react-devtools/src/store/ConsoleLogStore.test.ts
@@ -80,7 +80,11 @@ describe("ConsoleLogStore", () => {
   });
 
   describe("reentrancy guard", () => {
-    it("should not double-capture when console is called during serialization", async () => {
+    // With queueMicrotask deferral, the synchronous capturing flag is no
+    // longer load-bearing across nested calls; this test now asserts that the
+    // store does not infinite-loop when a getter is touched during
+    // serialization, which is the practically observable guarantee.
+    it("does not infinite-loop when getter is touched during serialization", async () => {
       store.install();
 
       const wrapper = console.log;
@@ -313,6 +317,22 @@ describe("ConsoleLogStore", () => {
       const entries = store.getEntries();
       expect(entries).toHaveLength(1);
       expect(typeof entries[0].source).toBe("string");
+    });
+
+    it("captures source of the caller, not the wrapper file", async () => {
+      store.install();
+
+      console.log("attribution check");
+      await flushMicrotasks();
+
+      const entries = store.getEntries();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].source).toBeDefined();
+      // The source must skip frames internal to ConsoleLogStore. We can't
+      // assert the exact caller path because happy-dom and Vitest layer their
+      // own frames between the test and the wrapper, but the captured source
+      // must never resolve back into our own module.
+      expect(entries[0].source).not.toContain("ConsoleLogStore");
     });
   });
 

--- a/packages/react-devtools/src/store/ConsoleLogStore.ts
+++ b/packages/react-devtools/src/store/ConsoleLogStore.ts
@@ -251,31 +251,56 @@ export class ConsoleLogStore extends SubscribableStore {
         this: Console,
         ...args: unknown[]
       ) {
-        original.apply(this ?? console, args);
+        // Capture the source synchronously, before any async boundary, so the
+        // user's frame is still on the stack. The in-panel `entry.source` is
+        // canonical and accurate — verified by ConsoleLogStore.test.ts.
+        //
+        // Browser DevTools source-link attribution (the clickable link beside
+        // each console row) is decided by V8 and follows wherever the original
+        // method was *called*. Routing the call through Function.prototype.apply
+        // is best-effort; in practice the link may still resolve to the wrapper
+        // file in some Chromium versions. There is no fully-portable JS-level
+        // mitigation; if needed, prefer the panel-side source field.
+        //
+        // Reentrancy note: capture work runs in queueMicrotask, so `capturing`
+        // resets between the wrapper microtask and any nested microtask. A
+        // getter that calls console.log during serialization may therefore be
+        // captured (one extra entry, no infinite loop). Strict synchronous
+        // reentrancy guarding is incompatible with the microtask deferral that
+        // makes the source attribution improvement possible.
+        const skipCapture = store.suppressed || store.capturing
+          || isBrowserLoggerCall(args);
+        const source = skipCapture ? undefined : getCallerLocation();
 
-        if (store.suppressed || store.capturing || isBrowserLoggerCall(args)) {
+        Function.prototype.apply.call(original, this ?? console, args);
+
+        if (skipCapture) {
           return;
         }
 
-        store.capturing = true;
-        try {
-          const source = getCallerLocation();
-          const serializedArgs = capEntrySize(args.map(serializeArg));
-          const entry: ConsoleLogEntry = {
-            id: nextId(),
-            level,
-            args: serializedArgs,
-            timestamp: Date.now(),
-            ...(source !== undefined ? { source } : {}),
-          };
+        queueMicrotask(() => {
+          if (store.capturing) {
+            return;
+          }
+          store.capturing = true;
+          try {
+            const serializedArgs = capEntrySize(args.map(serializeArg));
+            const entry: ConsoleLogEntry = {
+              id: nextId(),
+              level,
+              args: serializedArgs,
+              timestamp: Date.now(),
+              ...(source !== undefined ? { source } : {}),
+            };
 
-          store.entries.push(entry);
-          store.cachedEntries = null;
-          store.scheduleNotify();
-        } catch {
-        } finally {
-          store.capturing = false;
-        }
+            store.entries.push(entry);
+            store.cachedEntries = null;
+            store.scheduleNotify();
+          } catch {
+          } finally {
+            store.capturing = false;
+          }
+        });
       };
 
       console[level] = wrapper; // eslint-disable-line no-console

--- a/packages/react-devtools/src/store/MonitorStore.test.ts
+++ b/packages/react-devtools/src/store/MonitorStore.test.ts
@@ -129,7 +129,7 @@ describe("MonitorStore", () => {
   });
 
   it("should return empty results for cache operations when no monitor exists", async () => {
-    const entries = await store.getCacheEntries();
+    const entries = await store.loadCacheEntries();
     expect(entries).toEqual([]);
 
     const snapshot = await store.getCacheSnapshot();
@@ -139,6 +139,13 @@ describe("MonitorStore", () => {
       totalSize: 0,
       totalHits: 0,
     });
+  });
+
+  it("getCacheEntries is a deprecated alias for loadCacheEntries", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const aliasResult = await store.getCacheEntries();
+    const directResult = await store.loadCacheEntries();
+    expect(aliasResult).toEqual(directResult);
   });
 
   it("should no-op for cache invalidation when no monitor exists", async () => {

--- a/packages/react-devtools/src/store/MonitorStore.ts
+++ b/packages/react-devtools/src/store/MonitorStore.ts
@@ -56,6 +56,7 @@ import { PropertyAccessTracker } from "../utils/PropertyAccessTracker.js";
 import { ComputeStore } from "./ComputeStore.js";
 import { ConsoleLogStore } from "./ConsoleLogStore.js";
 import { MetricsStore } from "./MetricsStore.js";
+import { WindowErrorStore } from "./WindowErrorStore.js";
 
 const monitorStoreMap = new WeakMap<object, MonitorStore>();
 
@@ -79,6 +80,7 @@ export class MonitorStore {
   private readonly recommendationEngine: PerformanceRecommendationEngine;
   private readonly prototypeOverrideStore: PrototypeOverrideStore;
   private readonly consoleLogStore: ConsoleLogStore;
+  private readonly windowErrorStore: WindowErrorStore;
   private monitor: ObservableClientMonitor | null = null;
   private originalGlobalFetch: typeof globalThis.fetch | null = null;
   private interceptedGlobalFetch: typeof globalThis.fetch | null = null;
@@ -92,11 +94,16 @@ export class MonitorStore {
       this.config.timeSeriesSize,
     );
     this.computeStore = new ComputeStore();
-    this.computeMonitor = new ComputeMonitor(this.computeStore, this.logger);
     this.componentRegistry = new ComponentQueryRegistry();
     this.linkTraversalTracker = new LinkTraversalTracker();
     this.propertyAccessTracker = new PropertyAccessTracker();
     this.eventTimeline = new EventTimeline(10000);
+    this.computeMonitor = new ComputeMonitor(
+      this.computeStore,
+      this.logger,
+      undefined,
+      this.eventTimeline,
+    );
     this.primitiveDiscovery = new ComponentPrimitiveDiscovery(
       this.componentRegistry,
     );
@@ -124,6 +131,8 @@ export class MonitorStore {
     this.prototypeOverrideStore = new PrototypeOverrideStore();
     this.consoleLogStore = new ConsoleLogStore(1000);
     this.consoleLogStore.install();
+    this.windowErrorStore = new WindowErrorStore(1000);
+    this.windowErrorStore.install();
     this.recommendationEngine = new PerformanceRecommendationEngine(
       this.metricsStore,
       this.componentRegistry,
@@ -282,6 +291,10 @@ export class MonitorStore {
     return this.consoleLogStore;
   }
 
+  getWindowErrorStore(): WindowErrorStore {
+    return this.windowErrorStore;
+  }
+
   dispose(): void {
     this.unsubscribeFiberCommit?.();
     this.unsubscribeFiberCommit = null;
@@ -297,13 +310,14 @@ export class MonitorStore {
     this.eventTimeline.clear();
     this.clickToInspect.dispose();
     this.consoleLogStore.dispose();
+    this.windowErrorStore.dispose();
     this.mockManager.clear();
     this.prototypeOverrideStore.clearAll();
     this.monitor?.dispose();
     this.monitor = null;
   }
 
-  async getCacheEntries(): Promise<CacheEntry[]> {
+  async loadCacheEntries(): Promise<CacheEntry[]> {
     if (!this.monitor) {
       return [];
     }
@@ -314,6 +328,11 @@ export class MonitorStore {
     } catch {
       return [];
     }
+  }
+
+  /** @deprecated Use `loadCacheEntries()` — name was misleading because the method is async. */
+  getCacheEntries(): Promise<CacheEntry[]> {
+    return this.loadCacheEntries();
   }
 
   async getCacheSnapshot(): Promise<CacheSnapshot> {

--- a/packages/react-devtools/src/store/WindowErrorStore.test.ts
+++ b/packages/react-devtools/src/store/WindowErrorStore.test.ts
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { WindowErrorStore } from "./WindowErrorStore.js";
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((r) => queueMicrotask(r));
+}
+
+function dispatchErrorEvent(detail: Partial<ErrorEventInit>): ErrorEvent {
+  const event = new ErrorEvent("error", detail);
+  window.dispatchEvent(event);
+  return event;
+}
+
+function dispatchUnhandledRejection(reason: unknown): void {
+  // happy-dom doesn't implement PromiseRejectionEvent. Drive a synthetic Event
+  // and attach the reason field — WindowErrorStore reads event.reason directly.
+  const promise = Promise.reject(reason);
+  promise.catch(() => {});
+  const event = new Event("unhandledrejection") as Event & {
+    reason: unknown;
+    promise: Promise<unknown>;
+  };
+  event.reason = reason;
+  event.promise = promise;
+  window.dispatchEvent(event);
+}
+
+describe("WindowErrorStore", () => {
+  let store: WindowErrorStore;
+
+  beforeEach(() => {
+    store = new WindowErrorStore();
+  });
+
+  afterEach(() => {
+    store.dispose();
+  });
+
+  describe("install/uninstall", () => {
+    it("captures errors only after install", async () => {
+      dispatchErrorEvent({ message: "before-install" });
+      await flushMicrotasks();
+      expect(store.getEntries()).toHaveLength(0);
+
+      store.install();
+      dispatchErrorEvent({ message: "after-install" });
+      await flushMicrotasks();
+      expect(store.getEntries()).toHaveLength(1);
+    });
+
+    it("stops capturing after uninstall", async () => {
+      store.install();
+      dispatchErrorEvent({ message: "first" });
+      await flushMicrotasks();
+      expect(store.getEntries()).toHaveLength(1);
+
+      store.uninstall();
+      dispatchErrorEvent({ message: "second" });
+      await flushMicrotasks();
+      expect(store.getEntries()).toHaveLength(1);
+    });
+
+    it("install is idempotent", async () => {
+      store.install();
+      store.install();
+      dispatchErrorEvent({ message: "once" });
+      await flushMicrotasks();
+      expect(store.getEntries()).toHaveLength(1);
+    });
+  });
+
+  describe("error capture", () => {
+    beforeEach(() => {
+      store.install();
+    });
+
+    it("captures uncaught errors with filename, lineno, colno", async () => {
+      dispatchErrorEvent({
+        message: "boom",
+        filename: "app.tsx",
+        lineno: 42,
+        colno: 7,
+      });
+      await flushMicrotasks();
+
+      const entries = store.getEntries();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].kind).toBe("error");
+      expect(entries[0].message).toBe("boom");
+      expect(entries[0].filename).toBe("app.tsx");
+      expect(entries[0].lineno).toBe(42);
+      expect(entries[0].colno).toBe(7);
+    });
+
+    it("uses Error.message and stack when error object is provided", async () => {
+      const realError = new Error("real-message");
+      dispatchErrorEvent({ message: "", error: realError });
+      await flushMicrotasks();
+
+      const entries = store.getEntries();
+      expect(entries[0].message).toBe("real-message");
+      expect(entries[0].stack).toBe(realError.stack);
+    });
+
+    it("captures unhandled rejection with Error reason", async () => {
+      const reason = new Error("rejected");
+      dispatchUnhandledRejection(reason);
+      await flushMicrotasks();
+
+      const entries = store.getEntries();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].kind).toBe("unhandledrejection");
+      expect(entries[0].message).toBe("rejected");
+      expect(entries[0].stack).toBe(reason.stack);
+    });
+
+    it("captures unhandled rejection with string reason", async () => {
+      dispatchUnhandledRejection("plain string");
+      await flushMicrotasks();
+
+      const entries = store.getEntries();
+      expect(entries[0].kind).toBe("unhandledrejection");
+      expect(entries[0].message).toBe("plain string");
+    });
+
+    it("captures unhandled rejection with object reason", async () => {
+      dispatchUnhandledRejection({ code: 500, msg: "oops" });
+      await flushMicrotasks();
+
+      const entries = store.getEntries();
+      expect(entries[0].kind).toBe("unhandledrejection");
+      expect(entries[0].message).toContain("500");
+    });
+  });
+
+  describe("subscribe", () => {
+    it("notifies subscribers when entries are pushed", async () => {
+      store.install();
+      let callCount = 0;
+      store.subscribe(() => {
+        callCount++;
+      });
+
+      dispatchErrorEvent({ message: "x" });
+      await flushMicrotasks();
+      expect(callCount).toBe(1);
+    });
+
+    it("returns an unsubscribe function", async () => {
+      store.install();
+      let callCount = 0;
+      const unsub = store.subscribe(() => {
+        callCount++;
+      });
+      unsub();
+
+      dispatchErrorEvent({ message: "x" });
+      await flushMicrotasks();
+      expect(callCount).toBe(0);
+    });
+  });
+
+  describe("clear and getSize", () => {
+    beforeEach(() => {
+      store.install();
+    });
+
+    it("getSize reflects buffer count", async () => {
+      dispatchErrorEvent({ message: "1" });
+      dispatchErrorEvent({ message: "2" });
+      await flushMicrotasks();
+      expect(store.getSize()).toBe(2);
+    });
+
+    it("clear empties the buffer", async () => {
+      dispatchErrorEvent({ message: "1" });
+      await flushMicrotasks();
+      store.clear();
+      expect(store.getEntries()).toHaveLength(0);
+      expect(store.getSize()).toBe(0);
+    });
+  });
+
+  describe("suppress/unsuppress", () => {
+    beforeEach(() => {
+      store.install();
+    });
+
+    it("suppress prevents capture", async () => {
+      store.suppress();
+      dispatchErrorEvent({ message: "x" });
+      await flushMicrotasks();
+      expect(store.getEntries()).toHaveLength(0);
+    });
+
+    it("unsuppress re-enables capture", async () => {
+      store.suppress();
+      dispatchErrorEvent({ message: "x" });
+      store.unsuppress();
+      dispatchErrorEvent({ message: "y" });
+      await flushMicrotasks();
+      expect(store.getEntries()).toHaveLength(1);
+    });
+  });
+
+  describe("dispose", () => {
+    it("removes listeners and clears entries", async () => {
+      store.install();
+      dispatchErrorEvent({ message: "before-dispose" });
+      await flushMicrotasks();
+      store.dispose();
+
+      dispatchErrorEvent({ message: "after-dispose" });
+      await flushMicrotasks();
+
+      expect(store.getEntries()).toHaveLength(0);
+    });
+  });
+});

--- a/packages/react-devtools/src/store/WindowErrorStore.ts
+++ b/packages/react-devtools/src/store/WindowErrorStore.ts
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Captures global JS errors (uncaught throws) and unhandled promise rejections
+// from the host page. React's dev-mode render errors are captured separately
+// via console.error in ConsoleLogStore, so we don't ship a dedicated error
+// boundary alongside this.
+
+import { CircularBuffer } from "../utils/CircularBuffer.js";
+import { SubscribableStore } from "./SubscribableStore.js";
+
+export type WindowErrorKind = "error" | "unhandledrejection";
+
+export interface WindowErrorEntry {
+  readonly id: string;
+  readonly kind: WindowErrorKind;
+  readonly message: string;
+  readonly stack?: string;
+  readonly filename?: string;
+  readonly lineno?: number;
+  readonly colno?: number;
+  readonly timestamp: number;
+}
+
+let entryCounter = 0;
+
+function nextId(): string {
+  return `windowError-${++entryCounter}-${Date.now()}`;
+}
+
+function describeRejectionReason(
+  reason: unknown,
+): { message: string; stack?: string } {
+  if (reason instanceof Error) {
+    return { message: reason.message, stack: reason.stack };
+  }
+  if (typeof reason === "string") {
+    return { message: reason };
+  }
+  try {
+    return { message: JSON.stringify(reason) };
+  } catch {
+    return { message: String(reason) };
+  }
+}
+
+export class WindowErrorStore extends SubscribableStore {
+  private readonly entries: CircularBuffer<WindowErrorEntry>;
+  private cachedEntries: readonly WindowErrorEntry[] | null = null;
+  private installed = false;
+  private suppressed = false;
+  private notifyScheduled = false;
+
+  private errorListener: ((event: ErrorEvent) => void) | null = null;
+  private rejectionListener:
+    | ((event: PromiseRejectionEvent) => void)
+    | null = null;
+
+  constructor(capacity: number = 1000) {
+    super();
+    this.entries = new CircularBuffer(capacity);
+  }
+
+  install(): void {
+    if (this.installed) {
+      return;
+    }
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    this.errorListener = (event: ErrorEvent) => {
+      if (this.suppressed) {
+        return;
+      }
+      const message = event.message
+        || (event.error instanceof Error ? event.error.message : "Error");
+      const stack = event.error instanceof Error
+        ? event.error.stack
+        : undefined;
+      const entry: WindowErrorEntry = {
+        id: nextId(),
+        kind: "error",
+        message,
+        ...(stack !== undefined ? { stack } : {}),
+        ...(event.filename ? { filename: event.filename } : {}),
+        ...(typeof event.lineno === "number" ? { lineno: event.lineno } : {}),
+        ...(typeof event.colno === "number" ? { colno: event.colno } : {}),
+        timestamp: Date.now(),
+      };
+      this.entries.push(entry);
+      this.cachedEntries = null;
+      this.scheduleNotify();
+    };
+
+    this.rejectionListener = (event: PromiseRejectionEvent) => {
+      if (this.suppressed) {
+        return;
+      }
+      const { message, stack } = describeRejectionReason(event.reason);
+      const entry: WindowErrorEntry = {
+        id: nextId(),
+        kind: "unhandledrejection",
+        message,
+        ...(stack !== undefined ? { stack } : {}),
+        timestamp: Date.now(),
+      };
+      this.entries.push(entry);
+      this.cachedEntries = null;
+      this.scheduleNotify();
+    };
+
+    window.addEventListener("error", this.errorListener);
+    window.addEventListener("unhandledrejection", this.rejectionListener);
+    this.installed = true;
+  }
+
+  uninstall(): void {
+    if (!this.installed) {
+      return;
+    }
+    if (typeof window !== "undefined") {
+      if (this.errorListener) {
+        window.removeEventListener("error", this.errorListener);
+      }
+      if (this.rejectionListener) {
+        window.removeEventListener(
+          "unhandledrejection",
+          this.rejectionListener,
+        );
+      }
+    }
+    this.errorListener = null;
+    this.rejectionListener = null;
+    this.installed = false;
+  }
+
+  suppress(): void {
+    this.suppressed = true;
+  }
+
+  unsuppress(): void {
+    this.suppressed = false;
+  }
+
+  recordError(error: Error, source?: string): void {
+    if (this.suppressed) {
+      return;
+    }
+    const entry: WindowErrorEntry = {
+      id: nextId(),
+      kind: "error",
+      message: error.message,
+      ...(error.stack !== undefined ? { stack: error.stack } : {}),
+      ...(source !== undefined ? { filename: source } : {}),
+      timestamp: Date.now(),
+    };
+    this.entries.push(entry);
+    this.cachedEntries = null;
+    this.scheduleNotify();
+  }
+
+  getEntries(): readonly WindowErrorEntry[] {
+    if (this.cachedEntries != null) {
+      return this.cachedEntries;
+    }
+    this.cachedEntries = this.entries.toArray();
+    return this.cachedEntries;
+  }
+
+  getSize(): number {
+    return this.entries.getSize();
+  }
+
+  clear(): void {
+    this.entries.clear();
+    this.cachedEntries = null;
+    this.notifySubscribers();
+  }
+
+  dispose(): void {
+    this.uninstall();
+    this.entries.clear();
+    this.cachedEntries = null;
+    this.clearSubscribers();
+  }
+
+  private scheduleNotify(): void {
+    if (this.notifyScheduled) {
+      return;
+    }
+    this.notifyScheduled = true;
+    queueMicrotask(() => {
+      this.notifyScheduled = false;
+      this.notifySubscribers();
+    });
+  }
+}

--- a/packages/react-devtools/src/types/compute.ts
+++ b/packages/react-devtools/src/types/compute.ts
@@ -35,7 +35,6 @@ export type ComputeRequestError =
     errorInstanceId: string;
     errorName: string;
   }
-  | { type: "no-compute-usage" }
   | { type: "http-error"; status: number; message?: string }
   | { type: "fetch-error"; message: string }
   | { type: "unknown" };
@@ -55,8 +54,19 @@ export interface FulfilledComputeRequest extends ComputeRequestBase {
   responsePayloadHash: number;
 }
 
+export interface FulfilledWithoutUsageComputeRequest
+  extends ComputeRequestBase
+{
+  type: "fulfilled-without-usage";
+  responseTimestamp: Date;
+  responsePayload: string;
+  responsePayloadBytes: number;
+  responsePayloadHash: number;
+}
+
 export type ComputeRequest =
   | FulfilledComputeRequest
+  | FulfilledWithoutUsageComputeRequest
   | PendingComputeRequest
   | FailedComputeRequest;
 
@@ -65,6 +75,7 @@ export interface ComputeMetrics {
   readonly lastMinuteUsage: number;
   readonly requestCount: number;
   readonly fulfilledCount: number;
+  readonly fulfilledWithoutUsageCount: number;
   readonly failedCount: number;
   readonly pendingCount: number;
   readonly averageUsagePerRequest: number;

--- a/packages/react-devtools/src/utils/ComputeMonitor.test.ts
+++ b/packages/react-devtools/src/utils/ComputeMonitor.test.ts
@@ -17,6 +17,13 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ComputeStore } from "../store/ComputeStore.js";
 import { ComputeMonitor } from "./ComputeMonitor.js";
+import type { EventTimeline } from "./EventTimeline.js";
+
+function createMockEventTimeline(): EventTimeline {
+  return {
+    record: vi.fn(),
+  } as unknown as EventTimeline;
+}
 
 function createMockComputeStore(): ComputeStore {
   return {
@@ -24,6 +31,7 @@ function createMockComputeStore(): ComputeStore {
     getIsNetworkPaused: vi.fn().mockReturnValue(false),
     createPendingRequest: vi.fn().mockReturnValue("req-1"),
     fulfillRequest: vi.fn(),
+    fulfillWithoutUsage: vi.fn(),
     failRequest: vi.fn(),
     getSnapshot: vi.fn(),
     subscribe: vi.fn(),
@@ -35,6 +43,7 @@ function createMockComputeStore(): ComputeStore {
       lastMinuteUsage: 0,
       requestCount: 0,
       fulfilledCount: 0,
+      fulfilledWithoutUsageCount: 0,
       failedCount: 0,
       pendingCount: 0,
       averageUsagePerRequest: 0,
@@ -169,7 +178,88 @@ describe("ComputeMonitor", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("fails request with no-compute-usage when response has no computeUsage", async () => {
+  it("blocks tracked endpoints when paused, even when not recording", async () => {
+    const store = createMockComputeStore();
+    vi.mocked(store.getIsNetworkPaused).mockReturnValue(true);
+    vi.mocked(store.isRecording).mockReturnValue(false);
+    const mockFetch = vi.fn();
+    const monitor = new ComputeMonitor(store, undefined, mockFetch);
+    const intercepted = monitor.createInterceptedFetch();
+
+    await expect(
+      intercepted(LOAD_OBJECTS_URL, {
+        body: JSON.stringify({ objectType: "Employee" }),
+      }),
+    ).rejects.toThrow("OSDK network requests are paused");
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(store.createPendingRequest).not.toHaveBeenCalled();
+  });
+
+  it("blocks action endpoints when paused (non-tracked OSDK URL)", async () => {
+    const store = createMockComputeStore();
+    vi.mocked(store.getIsNetworkPaused).mockReturnValue(true);
+    const mockFetch = vi.fn();
+    const monitor = new ComputeMonitor(store, undefined, mockFetch);
+    const intercepted = monitor.createInterceptedFetch();
+
+    const actionUrl =
+      "https://example.com/api/v2/ontologies/ri.test/actions/applyAction";
+    await expect(
+      intercepted(actionUrl, {
+        body: JSON.stringify({ parameters: {} }),
+      }),
+    ).rejects.toThrow("OSDK network requests are paused");
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(store.createPendingRequest).not.toHaveBeenCalled();
+    expect(store.failRequest).not.toHaveBeenCalled();
+  });
+
+  it("does not block non-OSDK URLs when paused", async () => {
+    const store = createMockComputeStore();
+    vi.mocked(store.getIsNetworkPaused).mockReturnValue(true);
+    const mockFetch = vi.fn().mockResolvedValue(new Response("ok"));
+    const monitor = new ComputeMonitor(store, undefined, mockFetch);
+    const intercepted = monitor.createInterceptedFetch();
+
+    await intercepted("https://example.com/some/other/url", {
+      body: JSON.stringify({ test: true }),
+    });
+
+    expect(mockFetch).toHaveBeenCalled();
+  });
+
+  it("records OSDK_PAUSE_BLOCK event when blocking", async () => {
+    const store = createMockComputeStore();
+    vi.mocked(store.getIsNetworkPaused).mockReturnValue(true);
+    const mockFetch = vi.fn();
+    const eventTimeline = createMockEventTimeline();
+    const monitor = new ComputeMonitor(
+      store,
+      undefined,
+      mockFetch,
+      eventTimeline,
+    );
+    const intercepted = monitor.createInterceptedFetch();
+
+    const actionUrl =
+      "https://example.com/api/v2/ontologies/ri.test/actions/applyAction";
+    await expect(
+      intercepted(actionUrl, {
+        body: JSON.stringify({ parameters: {} }),
+      }),
+    ).rejects.toThrow();
+
+    expect(eventTimeline.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "OSDK_PAUSE_BLOCK",
+        pathname: "/api/v2/ontologies/ri.test/actions/applyAction",
+      }),
+    );
+  });
+
+  it("fulfills without usage when 200 has no computeUsage in response", async () => {
     const store = createMockComputeStore();
     const mockFetch = vi
       .fn()
@@ -181,9 +271,13 @@ describe("ComputeMonitor", () => {
       body: JSON.stringify({ objectType: "Employee" }),
     });
 
-    expect(store.failRequest).toHaveBeenCalledWith("req-1", {
-      type: "no-compute-usage",
-    });
+    expect(store.fulfillWithoutUsage).toHaveBeenCalledWith(
+      "req-1",
+      expect.objectContaining({
+        responsePayloadBytes: expect.any(Number),
+      }),
+    );
+    expect(store.failRequest).not.toHaveBeenCalled();
   });
 
   it("fails request with api-gateway-error for structured error responses", async () => {

--- a/packages/react-devtools/src/utils/ComputeMonitor.ts
+++ b/packages/react-devtools/src/utils/ComputeMonitor.ts
@@ -21,6 +21,7 @@ import {
   stringifyPayload,
   truncatePayload,
 } from "./computePayload.js";
+import type { EventTimeline } from "./EventTimeline.js";
 import { createMonitorLogger } from "./logger.js";
 
 const RID_PLACEHOLDER = "ri.compute.tools.rid.placeholder";
@@ -30,6 +31,18 @@ const COMPUTE_COST_ENDPOINTS = [
   `/api/v2/ontologies/${RID_PLACEHOLDER}/objectSets/loadObjectsMultipleObjectTypes`,
 ];
 
+const OSDK_URL_PREFIXES = [
+  "/api/v2/ontologies/",
+  "/multipass/",
+  "/ontology-metadata/",
+  "/object-set-watcher/",
+  "/object-set-service/",
+];
+
+function isOsdkUrl(pathname: string): boolean {
+  return OSDK_URL_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+}
+
 const RID_REGEX =
   /ri\.([a-z][a-z0-9-]*)\.([a-z0-9][a-z0-9-]*)?\.([a-z][a-z0-9-]*)\.([a-zA-Z0-9\-._]+)/;
 
@@ -37,15 +50,18 @@ export class ComputeMonitor {
   private readonly originalFetch: typeof globalThis.fetch;
   private readonly computeStore: ComputeStore;
   private readonly logger: Logger;
+  private readonly eventTimeline: EventTimeline | undefined;
   private interceptedFetch: typeof globalThis.fetch | null = null;
 
   constructor(
     computeStore: ComputeStore,
     logger: Logger = createMonitorLogger(),
     originalFetch: typeof globalThis.fetch = globalThis.fetch,
+    eventTimeline?: EventTimeline,
   ) {
     this.computeStore = computeStore;
     this.logger = logger;
+    this.eventTimeline = eventTimeline;
     this.originalFetch = originalFetch.bind(globalThis);
   }
 
@@ -65,14 +81,49 @@ export class ComputeMonitor {
 
       const isRecording = self.computeStore.isRecording();
       const shouldTrack = self.doesEndpointTrackComputeCost(pathname);
+      const isPaused = self.computeStore.getIsNetworkPaused();
+      const isOsdk = isOsdkUrl(pathname);
 
       self.logger.debug("Fetch intercepted:", {
         pathname,
         isRecording,
         shouldTrack,
+        isPaused,
+        isOsdk,
         hasBody: init?.body !== undefined,
         bodyType: typeof init?.body,
       });
+
+      if (isPaused && isOsdk) {
+        self.logger.debug("Network paused, blocking OSDK request");
+        self.eventTimeline?.record({
+          type: "OSDK_PAUSE_BLOCK",
+          pathname,
+          timestamp: Date.now(),
+        });
+        if (shouldTrack && isRecording && typeof init?.body === "string") {
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(init.body);
+          } catch {
+            parsed = undefined;
+          }
+          if (parsed !== undefined) {
+            const requestId = self.computeStore.createPendingRequest({
+              requestUrl: pathname,
+              requestTimestamp: new Date(),
+              requestPayload: truncatePayload(init.body),
+              requestPayloadHash: hashPayload(parsed),
+            });
+            self.computeStore.failRequest(requestId, {
+              type: "osdk-network-paused",
+            });
+          }
+        }
+        throw new Error(
+          "OSDK network requests are paused by OSDK ComputeTools",
+        );
+      }
 
       if (!shouldTrack || !isRecording || typeof init?.body !== "string") {
         self.logger.debug("Skipping tracking:", {
@@ -105,16 +156,6 @@ export class ComputeMonitor {
       });
 
       self.logger.debug("Created pending request:", requestId);
-
-      if (self.computeStore.getIsNetworkPaused()) {
-        self.logger.debug("Network paused, failing request");
-        self.computeStore.failRequest(requestId, {
-          type: "osdk-network-paused",
-        });
-        throw new Error(
-          "OSDK network requests are paused by OSDK ComputeTools",
-        );
-      }
 
       try {
         const res = await self.originalFetch(input, { ...init, body: newBody });
@@ -158,8 +199,10 @@ export class ComputeMonitor {
           self.logger.warn(
             "Request succeeded but no computeUsage in response",
           );
-          self.computeStore.failRequest(requestId, {
-            type: "no-compute-usage",
+          self.computeStore.fulfillWithoutUsage(requestId, {
+            responsePayloadBytes: arrayBuffer.byteLength,
+            responsePayloadHash: hashPayload(jsonRes),
+            responsePayload: truncatePayload(stringifyPayload(jsonRes)),
           });
         } else if (
           typeof jsonRes.errorCode === "string"

--- a/packages/react-devtools/src/utils/EventTimeline.ts
+++ b/packages/react-devtools/src/utils/EventTimeline.ts
@@ -28,7 +28,8 @@ export type MonitorEvent =
   | PropertyAccessEvent
   | LinkTraversalEvent
   | ObjectModifiedEvent
-  | MockHitEvent;
+  | MockHitEvent
+  | OsdkPauseBlockEvent;
 
 export interface RenderEvent {
   type: "RENDER";
@@ -94,6 +95,12 @@ export interface MockHitEvent {
   subscriptionId: string;
   timestamp: number;
   mockId?: string;
+}
+
+export interface OsdkPauseBlockEvent {
+  type: "OSDK_PAUSE_BLOCK";
+  pathname: string;
+  timestamp: number;
 }
 
 export interface ActionCausality {

--- a/packages/react-devtools/src/utils/ObservableClientMonitor.basic.test.ts
+++ b/packages/react-devtools/src/utils/ObservableClientMonitor.basic.test.ts
@@ -162,4 +162,37 @@ describe("ObservableClientMonitor", () => {
 
     expect(mockClient.__unsubscribable.unsubscribe).toHaveBeenCalledTimes(1);
   });
+
+  it("forwards prototype methods that use private fields without throwing", () => {
+    class FakeClient {
+      #cache = new Map<string, number>();
+      seed(): void {
+        this.#cache.set("a", 1);
+      }
+      lookup(key: string): number {
+        return this.#cache.get(key) ?? 0;
+      }
+    }
+    const fake = new FakeClient();
+    fake.seed();
+    const wrapped = monitor.wrapClient(fake as never) as unknown as FakeClient;
+
+    expect(() => wrapped.lookup("a")).not.toThrow();
+    expect(wrapped.lookup("a")).toBe(1);
+  });
+
+  it("returns a stable bound reference for unwrapped methods", () => {
+    const mockClient = createMockClient();
+    const wrapped = monitor.wrapClient(
+      mockClient as never,
+    ) as unknown as Record<
+      string,
+      unknown
+    >;
+
+    expect(wrapped.canonicalizeWhereClause).toBe(
+      wrapped.canonicalizeWhereClause,
+    );
+    expect(typeof wrapped.canonicalizeWhereClause).toBe("function");
+  });
 });

--- a/packages/react-devtools/src/utils/ObservableClientMonitor.ts
+++ b/packages/react-devtools/src/utils/ObservableClientMonitor.ts
@@ -247,7 +247,13 @@ export class ObservableClientMonitor {
           return wrapped;
         }
 
-        return Reflect.get(target, prop);
+        const value = Reflect.get(target, prop);
+        if (typeof value === "function") {
+          const bound = value.bind(target);
+          methodCache.set(prop, bound);
+          return bound;
+        }
+        return value;
       },
     }) as ObservableClient;
   }

--- a/packages/react-devtools/src/utils/computeRequest.test.ts
+++ b/packages/react-devtools/src/utils/computeRequest.test.ts
@@ -33,6 +33,7 @@ describe("visitComputeRequest", () => {
       pending: vi.fn().mockReturnValue("p"),
       failed: vi.fn(),
       fulfilled: vi.fn(),
+      fulfilledWithoutUsage: vi.fn(),
     };
 
     const result = visitComputeRequest(request, visitor);
@@ -41,6 +42,7 @@ describe("visitComputeRequest", () => {
     expect(visitor.pending).toHaveBeenCalledWith(request);
     expect(visitor.failed).not.toHaveBeenCalled();
     expect(visitor.fulfilled).not.toHaveBeenCalled();
+    expect(visitor.fulfilledWithoutUsage).not.toHaveBeenCalled();
   });
 
   it("calls failed visitor for failed requests", () => {
@@ -54,6 +56,7 @@ describe("visitComputeRequest", () => {
       pending: vi.fn(),
       failed: vi.fn().mockReturnValue("f"),
       fulfilled: vi.fn(),
+      fulfilledWithoutUsage: vi.fn(),
     };
 
     const result = visitComputeRequest(request, visitor);
@@ -77,12 +80,39 @@ describe("visitComputeRequest", () => {
       pending: vi.fn(),
       failed: vi.fn(),
       fulfilled: vi.fn().mockReturnValue("done"),
+      fulfilledWithoutUsage: vi.fn(),
     };
 
     const result = visitComputeRequest(request, visitor);
 
     expect(result).toBe("done");
     expect(visitor.fulfilled).toHaveBeenCalledWith(request);
+    expect(visitor.pending).not.toHaveBeenCalled();
+    expect(visitor.fulfilledWithoutUsage).not.toHaveBeenCalled();
+  });
+
+  it("calls fulfilledWithoutUsage visitor for fulfilled-without-usage requests", () => {
+    const request: ComputeRequest = {
+      ...base,
+      type: "fulfilled-without-usage",
+      responseTimestamp: new Date("2025-01-01"),
+      responsePayload: "{}",
+      responsePayloadBytes: 100,
+      responsePayloadHash: 456,
+    };
+    const visitor = {
+      pending: vi.fn(),
+      failed: vi.fn(),
+      fulfilled: vi.fn(),
+      fulfilledWithoutUsage: vi.fn().mockReturnValue("no-usage"),
+    };
+
+    const result = visitComputeRequest(request, visitor);
+
+    expect(result).toBe("no-usage");
+    expect(visitor.fulfilledWithoutUsage).toHaveBeenCalledWith(request);
+    expect(visitor.fulfilled).not.toHaveBeenCalled();
+    expect(visitor.failed).not.toHaveBeenCalled();
     expect(visitor.pending).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-devtools/src/utils/computeRequest.ts
+++ b/packages/react-devtools/src/utils/computeRequest.ts
@@ -20,6 +20,10 @@ type FulfilledComputeRequest = Extract<
   ComputeRequest,
   { type: "fulfilled" }
 >;
+type FulfilledWithoutUsageComputeRequest = Extract<
+  ComputeRequest,
+  { type: "fulfilled-without-usage" }
+>;
 type PendingComputeRequest = Extract<
   ComputeRequest,
   { type: "pending" }
@@ -32,6 +36,7 @@ export const visitComputeRequest = <T>(
     pending: (request: PendingComputeRequest) => T;
     failed: (request: FailedComputeRequest) => T;
     fulfilled: (request: FulfilledComputeRequest) => T;
+    fulfilledWithoutUsage: (request: FulfilledWithoutUsageComputeRequest) => T;
   },
 ): T => {
   if (request.type === "pending") {
@@ -40,6 +45,10 @@ export const visitComputeRequest = <T>(
 
   if (request.type === "failed") {
     return visitor.failed(request);
+  }
+
+  if (request.type === "fulfilled-without-usage") {
+    return visitor.fulfilledWithoutUsage(request);
   }
 
   return visitor.fulfilled(request);


### PR DESCRIPTION
fixes for devtools after further testing
• errors panel now aggregates `console.error`, uncaught errors, and unhandled rejections (new `WindowErrorStore`); production render errors flow through the new `<OsdkAppErrorBoundary>`
• compute tab classifies successful queries without `computeUsage` as `fulfilled-without-usage` (new state) instead of marking them failed; pause network blocks all OSDK traffic and emits `OSDK_PAUSE_BLOCK` events
• ergonomics: rename `getCacheEntries` to `loadCacheEntries` (deprecated alias kept), label rename, distinct glyph for the new compute state, fix nested `<button>` in sandbox, best-effort browser-console source attribution