### PR TITLE
Clean up JSDoc rendering and TSDoc warnings in api, client, react

### DIFF
--- a/.changeset/wrap-example-code-blocks.md
+++ b/.changeset/wrap-example-code-blocks.md
@@ -1,0 +1,7 @@
+---
+"@osdk/api": patch
+"@osdk/client": patch
+"@osdk/react": patch
+---
+
+Wrap `@example` JSDoc blocks in fenced ts/tsx code blocks so VS Code's Markdown renderer preserves whitespace and applies syntax highlighting.

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -722,14 +722,8 @@ export interface GeoFilterOptions {
 
 // @public (undocumented)
 export interface GeotimeSeriesProperty<T extends GeoJSON.Point> {
-    	// Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-    // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-    // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-    // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-    readonly asyncIterValues: (query?: TimeSeriesQuery) => AsyncGenerator<TimeSeriesPoint<T>>;
-    	// Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-    // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-    readonly getAllValues: (query?: TimeSeriesQuery) => Promise<Array<TimeSeriesPoint<T>>>;
+    	readonly asyncIterValues: (query?: TimeSeriesQuery) => AsyncGenerator<TimeSeriesPoint<T>>;
+    	readonly getAllValues: (query?: TimeSeriesQuery) => Promise<Array<TimeSeriesPoint<T>>>;
     	readonly getLatestValue: () => Promise<TimeSeriesPoint<T> | undefined>;
     	readonly lastFetchedValue: TimeSeriesPoint<T> | undefined;
 }
@@ -1899,14 +1893,8 @@ export interface TimeSeriesPoint<T extends string | number | GeoJSON.Point> {
 
 // @public (undocumented)
 export interface TimeSeriesProperty<T extends number | string> {
-    	// Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-    // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-    // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-    // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-    readonly asyncIterPoints: (query?: TimeSeriesQuery) => AsyncGenerator<TimeSeriesPoint<T>>;
-    	// Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-    // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-    readonly getAllPoints: (query?: TimeSeriesQuery) => Promise<Array<TimeSeriesPoint<T>>>;
+    	readonly asyncIterPoints: (query?: TimeSeriesQuery) => AsyncGenerator<TimeSeriesPoint<T>>;
+    	readonly getAllPoints: (query?: TimeSeriesQuery) => Promise<Array<TimeSeriesPoint<T>>>;
     	readonly getFirstPoint: () => Promise<TimeSeriesPoint<T>>;
     	readonly getLastPoint: () => Promise<TimeSeriesPoint<T>>;
 }

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -1526,8 +1526,6 @@ export interface PropertyNumberFormattingRule {
 // @public (undocumented)
 export type PropertyNumberFormattingRuleType = NumberFormatStandard | NumberFormatFixedValues | NumberFormatCurrency | NumberFormatStandardUnit | NumberFormatCustomUnit | NumberFormatAffix | NumberFormatDuration | NumberFormatScale | NumberFormatRatio;
 
-// Warning: (tsdoc-undefined-tag) The TSDoc tag "@discriminator" is not defined in this configuration
-//
 // @public
 export type PropertySecurity = ({
     	type: "propertyMarkings"

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -1395,12 +1395,6 @@ export type OsdkObject<N extends string> = {
     	readonly $primaryKey: PropertyValueWireToClient[PrimaryKeyTypes]
 };
 
-// Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// Warning: (tsdoc-param-tag-with-invalid-name) The @param block should be followed by a valid parameter name: The identifier cannot non-word characters
-// Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-// Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
 // Warning: (ae-forgotten-export) The symbol "MaybeArray" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "GetCreatePropertyValueFromWire" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "MaybeNullable" needs to be exported by the entry point index.d.ts
@@ -1417,12 +1411,6 @@ export type OsdkObjectCreatePropertyType<
 // @public
 export type OsdkObjectLinksObject<O extends ObjectOrInterfaceDefinition> = ObjectTypeLinkKeysFrom2<O> extends never ? never : { readonly [L in ObjectTypeLinkKeysFrom2<O>] : OsdkObjectLinksEntry<O, L> };
 
-// Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// Warning: (tsdoc-param-tag-with-invalid-name) The @param block should be followed by a valid parameter name: The identifier cannot non-word characters
-// Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-// Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
 // Warning: (ae-forgotten-export) The symbol "GetClientPropertyValueFromWire" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -1968,10 +1956,6 @@ export type WirePropertyTypes = BaseWirePropertyTypes | Record<string, BaseWireP
 
 // Warnings were encountered during analysis:
 //
-// src/Definitions.ts:42:52 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/Definitions.ts:42:52 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/Definitions.ts:42:52 - (tsdoc-param-tag-with-invalid-name) The @param block should be followed by a valid parameter name: The identifier cannot non-word characters
-// src/Definitions.ts:42:52 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
 // src/OsdkObjectFrom.ts:273:49 - (ae-forgotten-export) The symbol "ObjectPropertySecurities" needs to be exported by the entry point index.d.ts
 // src/aggregate/AggregateOpts.ts:25:3 - (ae-forgotten-export) The symbol "UnorderedAggregationClause" needs to be exported by the entry point index.d.ts
 // src/aggregate/AggregateOpts.ts:25:3 - (ae-forgotten-export) The symbol "OrderedAggregationClause" needs to be exported by the entry point index.d.ts

--- a/etc/client.report.api.md
+++ b/etc/client.report.api.md
@@ -127,33 +127,20 @@ export const createClient: (baseUrl: string, ontologyRid: string | Promise<strin
 // @public
 export function createObjectSpecifierFromPrimaryKey<Q extends ObjectTypeDefinition>(objectDef: Q, primaryKey: PrimaryKeyType<Q>): ObjectSpecifier<Q>;
 
-// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-//
 // @public
 export function createPlatformClient(baseUrl: string, tokenProvider: () => Promise<string>, options?: undefined, fetchFn?: typeof globalThis.fetch): PlatformClient;
 
 export { DerivedProperty }
 
-// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-//
 // @public
 export const extractDate: (dateTime: string) => string;
 
-// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-//
 // @public
 export const extractDateInLocalTime: (date: Date) => string;
 
-// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-//
 // @public
 export const extractDateInUTC: (date: Date) => string;
 
-// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-//
 // @public
 export function extractPrimaryKeyFromObjectSpecifier(ObjectSpecifier: ObjectSpecifier<any>): string;
 

--- a/packages/api/src/Definitions.ts
+++ b/packages/api/src/Definitions.ts
@@ -28,8 +28,8 @@ type MaybeNullable<T extends ObjectMetadata.Property, U> = T["nullable"] extends
   : U;
 
 /**
- * @param {T} ObjectMetadata.Property in literal form
- * @param {STRICTLY_ENFORCE_NULLABLE}  S for strict. If false, always `|undefined`
+ * @param T - ObjectMetadata.Property in literal form
+ * @param STRICTLY_ENFORCE_NULLABLE - S for strict. If false, always `|undefined`
  */
 export type OsdkObjectPropertyType<
   T extends ObjectMetadata.Property,
@@ -43,15 +43,15 @@ export type OsdkObjectPropertyType<
   >;
 
 /**
- * @param {T} ObjectMetadata.Property in literal form
+ * @param T - ObjectMetadata.Property in literal form
  */
 export type OsdkObjectPropertyTypeNotUndefined<
   T extends ObjectMetadata.Property,
 > = MaybeArray<T, GetClientPropertyValueFromWire<T["type"]>>;
 
 /**
- * @param {T} ObjectMetadata.Property in literal form
- * @param {STRICTLY_ENFORCE_NULLABLE}  S for strict. If false, always `|undefined`
+ * @param T - ObjectMetadata.Property in literal form
+ * @param STRICTLY_ENFORCE_NULLABLE - S for strict. If false, always `|undefined`
  */
 export type OsdkObjectCreatePropertyType<
   T extends ObjectMetadata.Property,

--- a/packages/api/src/object/PropertySecurity.ts
+++ b/packages/api/src/object/PropertySecurity.ts
@@ -17,7 +17,7 @@
 /**
  * A discriminated union representing different types of property security outcomes.
  *
- * @discriminator type - The type field determines which security outcome is represented:
+ * The type field determines which security outcome is represented:
  *   - "propertyMarkings": Successfully computed security markings for the property
  *   - "unsupportedPolicy": The property is backed by a restricted view that doesn't support property securities
  *   - "errorComputingSecurity": The server was unable to load the securities of the property

--- a/packages/api/src/objectSet/ObjectSet.ts
+++ b/packages/api/src/objectSet/ObjectSet.ts
@@ -178,12 +178,13 @@ interface FetchPageSignature<
    * Gets a page of objects of this type, with a result wrapper
    * @param args - Args to specify next page token and page size, if applicable
    * @example
-   *  const myObjs = await objectSet.fetchPage({
-      $pageSize: 10,
-      $nextPageToken: "nextPage"
-    });
-     const myObjsResult = myObjs.data;
-
+   * ```ts
+   * const myObjs = await objectSet.fetchPage({
+   *   $pageSize: 10,
+   *   $nextPageToken: "nextPage",
+   * });
+   * const myObjsResult = myObjs.data;
+   * ```
    * @returns a page of objects
    */
   <
@@ -251,14 +252,16 @@ interface FetchPageWithErrorsSignature<
    * Gets a page of objects of this type, with a result wrapper
    * @param args - Args to specify next page token and page size, if applicable
    * @example
-   *  const myObjs = await objectSet.fetchPage({
-      $pageSize: 10,
-      $nextPageToken: "nextPage"
-    });
-
-     if(isOk(myObjs)){
-     const myObjsResult = myObjs.value.data;
-    }
+   * ```ts
+   * const myObjs = await objectSet.fetchPage({
+   *   $pageSize: 10,
+   *   $nextPageToken: "nextPage",
+   * });
+   *
+   * if (isOk(myObjs)) {
+   *   const myObjsResult = myObjs.value.data;
+   * }
+   * ```
    * @returns a page of objects, wrapped in a result wrapper
    */
   <
@@ -303,15 +306,17 @@ interface Where<
   RDPs extends Record<string, SimplePropertyDef> = {},
 > {
   /**
- * Allows you to filter an object set with a given clause
- * @param clause - Takes a filter clause
- * @example
- * await client(Office).where({
-    meetingRooms: { $contains: "Grand Central" },
-    meetingRoomCapacities: { $contains: 30 },
-});
-* @returns an objectSet
-  */
+   * Allows you to filter an object set with a given clause
+   * @param clause - Takes a filter clause
+   * @example
+   * ```ts
+   * await client(Office).where({
+   *   meetingRooms: { $contains: "Grand Central" },
+   *   meetingRoomCapacities: { $contains: 30 },
+   * });
+   * ```
+   * @returns an objectSet
+   */
   readonly where: (
     clause: WhereClause<MergeObjectSet<Q, RDPs>>,
   ) => this;
@@ -326,9 +331,11 @@ interface AsyncIterSignature<
   /**
    * Returns an async iterator to load all objects of this type
    * @example
-   * for await (const obj of myObjectSet.asyncIter()){
-   * // Handle obj
+   * ```ts
+   * for await (const obj of myObjectSet.asyncIter()) {
+   *   // Handle obj
    * }
+   * ```
    * @returns an async iterator to load all objects
    */
   <X extends ValidAsyncIterArgs<Q, RDPs> = never>(
@@ -345,9 +352,11 @@ interface AsyncIterSignature<
   /**
    * Returns an async iterator to load all objects of this type
    * @example
-   * for await (const obj of myObjectSet.asyncIter()){
-   * // Handle obj
+   * ```ts
+   * for await (const obj of myObjectSet.asyncIter()) {
+   *   // Handle obj
    * }
+   * ```
    * @returns an async iterator to load all objects
    */
   <
@@ -433,22 +442,23 @@ interface Aggregate<
    * @param req - an aggregation request where you can select fields and choose how to aggregate, e.g., max, min, avg, and also choose
    * whether or not you order your results. You can also specify a groupBy field to group your aggregations
    * @example
+   * ```ts
    * const testAggregateCountWithGroups = await client(BoundariesUsState)
-    .aggregate({
-      $select: {
-        $count: "unordered",
-        "latitude:max": "unordered",
-        "latitude:min": "unordered",
-        "latitude:avg": "unordered",
-      },
-      $groupBy: {
-        usState: "exact",
-        longitude: {
-          $fixedWidth: 10,
-        },
-      },
-    });
-
+   *   .aggregate({
+   *     $select: {
+   *       $count: "unordered",
+   *       "latitude:max": "unordered",
+   *       "latitude:min": "unordered",
+   *       "latitude:avg": "unordered",
+   *     },
+   *     $groupBy: {
+   *       usState: "exact",
+   *       longitude: {
+   *         $fixedWidth: 10,
+   *       },
+   *     },
+   *   });
+   * ```
    * @returns aggregation results, sorted in the groups based on the groupBy clause (if applicable)
    */
   readonly aggregate: <AO extends AggregateOpts<Q>>(
@@ -464,9 +474,11 @@ interface SetArithmetic<
    * Unions object sets together
    * @param objectSets - objectSets you want to union with
    * @example
+   * ```ts
    * const unionObjectSet = complexFilteredEmployeeObjectSet.union(
-    simpleFilteredEmployeeObjectSet,
-  );
+   *   simpleFilteredEmployeeObjectSet,
+   * );
+   * ```
    * @returns the unioned object set
    */
   readonly union: (
@@ -477,9 +489,11 @@ interface SetArithmetic<
    * Computes the intersection of object sets
    * @param objectSets - objectSets you want to intersect with
    * @example
+   * ```ts
    * const intersectedObjectSet = complexFilteredEmployeeObjectSet.intersect(
-    simpleFilteredEmployeeObjectSet,
-  );
+   *   simpleFilteredEmployeeObjectSet,
+   * );
+   * ```
    * @returns the intersected object set
    */
   readonly intersect: (
@@ -490,9 +504,11 @@ interface SetArithmetic<
    * Computes the subtraction of object sets
    * @param objectSets - objectSets you want to subtract from
    * @example
+   * ```ts
    * const subtractObjectSet = complexFilteredEmployeeObjectSet.subtract(
-    simpleFilteredEmployeeObjectSet,
-  );
+   *   simpleFilteredEmployeeObjectSet,
+   * );
+   * ```
    * @returns the subtract object set
    */
   readonly subtract: (

--- a/packages/api/src/timeseries/timeseries.ts
+++ b/packages/api/src/timeseries/timeseries.ts
@@ -100,30 +100,34 @@ export interface TimeSeriesProperty<T extends number | string> {
    */
   readonly getLastPoint: () => Promise<TimeSeriesPoint<T>>;
   /**
-     * Loads all points, within the given time range if that's provided
-     * @param query - a query representing either an absolute or relative range of time
-     * @example
-     *  const points = await employee.employeeStatus?.getAllPoints({
-        $after: 1,
-        $unit: "month",
-      });
-     */
+   * Loads all points, within the given time range if that's provided
+   * @param query - a query representing either an absolute or relative range of time
+   * @example
+   * ```ts
+   * const points = await employee.employeeStatus?.getAllPoints({
+   *   $after: 1,
+   *   $unit: "month",
+   * });
+   * ```
+   */
   readonly getAllPoints: (
     query?: TimeSeriesQuery,
   ) => Promise<Array<TimeSeriesPoint<T>>>;
   /**
-     * Returns an async iterator to load all points
-     * within the given time range if that's provided
-     * @param query - a query representing either an absolute or relative range of time
-     * @example
-     *  const iterator = employee.employeeStatus?.asyncIter({
-        $after: 1,
-        $unit: "month",
-      });
-      for await (const point of iterator) {
-          // Handle time series point
-      }
-     */
+   * Returns an async iterator to load all points
+   * within the given time range if that's provided
+   * @param query - a query representing either an absolute or relative range of time
+   * @example
+   * ```ts
+   * const iterator = employee.employeeStatus?.asyncIter({
+   *   $after: 1,
+   *   $unit: "month",
+   * });
+   * for await (const point of iterator) {
+   *   // Handle time series point
+   * }
+   * ```
+   */
   readonly asyncIterPoints: (
     query?: TimeSeriesQuery,
   ) => AsyncGenerator<TimeSeriesPoint<T>>;
@@ -135,30 +139,34 @@ export interface GeotimeSeriesProperty<T extends GeoJSON.Point> {
    */
   readonly getLatestValue: () => Promise<TimeSeriesPoint<T> | undefined>;
   /**
-     * Loads all points, within the given time range if that's provided
-     * @param query - a query representing either an absolute or relative range of time
-     * @example
-     *  const points = await employee.employeeStatus?.getAllPoints({
-        $after: 1,
-        $unit: "month",
-      });
-     */
+   * Loads all points, within the given time range if that's provided
+   * @param query - a query representing either an absolute or relative range of time
+   * @example
+   * ```ts
+   * const points = await employee.employeeStatus?.getAllPoints({
+   *   $after: 1,
+   *   $unit: "month",
+   * });
+   * ```
+   */
   readonly getAllValues: (
     query?: TimeSeriesQuery,
   ) => Promise<Array<TimeSeriesPoint<T>>>;
   /**
-     * Returns an async iterator to load all points
-     * within the given time range if that's provided
-     * @param query - a query representing either an absolute or relative range of time
-     * @example
-     *  const iterator = employee.employeeStatus?.asyncIter({
-        $after: 1,
-        $unit: "month",
-      });
-      for await (const point of iterator) {
-          // Handle time series point
-      }
-     */
+   * Returns an async iterator to load all points
+   * within the given time range if that's provided
+   * @param query - a query representing either an absolute or relative range of time
+   * @example
+   * ```ts
+   * const iterator = employee.employeeStatus?.asyncIter({
+   *   $after: 1,
+   *   $unit: "month",
+   * });
+   * for await (const point of iterator) {
+   *   // Handle time series point
+   * }
+   * ```
+   */
   readonly asyncIterValues: (
     query?: TimeSeriesQuery,
   ) => AsyncGenerator<TimeSeriesPoint<T>>;

--- a/packages/client/src/createPlatformClient.ts
+++ b/packages/client/src/createPlatformClient.ts
@@ -26,11 +26,7 @@ export interface PlatformClient extends SharedClientContext {}
  * If you already have an OSDK Client (from `createClient`), you do not need to
  * create one of these - those clients can be used with Platform APIs as well.
  *
- * @param baseUrl
- * @param tokenProvider
- * @param options Currently unused, reserved for future use.
- * @param fetchFn
- * @returns
+ * @param options - Currently unused, reserved for future use.
  */
 export function createPlatformClient(
   baseUrl: string,

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -143,16 +143,20 @@ export interface ObserveListOptions<
    * Can be combined with `where` to filter the RID set, and with `orderBy` to sort results.
    *
    * @example
+   * ```ts
    * // Fetch specific objects by RID
-   * observeList({ type: Employee, rids: ['ri.foo.123', 'ri.foo.456'] }, observer)
+   * observeList({ type: Employee, rids: ['ri.foo.123', 'ri.foo.456'] }, observer);
+   * ```
    *
    * @example
+   * ```ts
    * // Fetch specific objects by RID, filtered by status
    * observeList({
    *   type: Employee,
    *   rids: ['ri.foo.123', 'ri.foo.456', 'ri.foo.789'],
-   *   where: { status: 'active' }
-   * }, observer)
+   *   where: { status: 'active' },
+   * }, observer);
+   * ```
    */
   rids?: readonly string[];
 
@@ -178,12 +182,16 @@ export interface ObserveListOptions<
    * - `undefined` (default): Only fetch the first page, user must call fetchMore()
    *
    * @example
+   * ```ts
    * // Fetch all todos at once
-   * observeList({ type: Todo, autoFetchMore: true }, observer)
+   * observeList({ type: Todo, autoFetchMore: true }, observer);
+   * ```
    *
    * @example
+   * ```ts
    * // Fetch at least 100 todos
-   * observeList({ type: Todo, autoFetchMore: 100, pageSize: 25 }, observer)
+   * observeList({ type: Todo, autoFetchMore: 100, pageSize: 25 }, observer);
+   * ```
    */
   autoFetchMore?: boolean | number;
   intersectWith?: Array<{

--- a/packages/client/src/util/datetimeConverters.ts
+++ b/packages/client/src/util/datetimeConverters.ts
@@ -22,7 +22,7 @@ const isoRegex =
 /**
  * Extracts the date from a ISO 8601 formatted date time string. Throws if the input is not in the correct format.
  *
- * @param dateTime An ISO 8601 formatted date time string
+ * @param dateTime - An ISO 8601 formatted date time string
  * @returns The date part of the input string
  */
 export const extractDate = (dateTime: string): string => {
@@ -40,7 +40,6 @@ export const extractDate = (dateTime: string): string => {
 /**
  * Generates a string representation of the input date (YYYY-MM-DD). The resulting date string reflects the given date in UTC time.
  *
- * @param date
  * @returns The date part of a ISO 8601 formatted date time string
  */
 export const extractDateInUTC = (date: Date): string => {
@@ -50,7 +49,6 @@ export const extractDateInUTC = (date: Date): string => {
 /**
  * Generates a string representation of the input date (YYYY-MM-DD). The resulting date string reflects the given date in the local time zone.
  *
- * @param date
  * @returns The date part of a ISO 8601 formatted date time string
  */
 export const extractDateInLocalTime = (date: Date): string => {

--- a/packages/client/src/util/objectSpecifierUtils.ts
+++ b/packages/client/src/util/objectSpecifierUtils.ts
@@ -60,7 +60,6 @@ export function createObjectSpecifierFromInterfaceSpecifier<
 /**
  * Extracts the primary key from an ObjectSpecifier on an OSDK object.
  *
- * @param ObjectSpecifier
  * @returns A string representing the primary key
  */
 export function extractPrimaryKeyFromObjectSpecifier(
@@ -72,7 +71,6 @@ export function extractPrimaryKeyFromObjectSpecifier(
 /**
  * Extracts the object type from an ObjectSpecifier on an OSDK object.
  *
- * @param ObjectSpecifier
  * @returns The object type extracted from the ObjectSpecifier
  */
 export function extractObjectTypeFromObjectSpecifier(

--- a/packages/react/src/new/useLinks.ts
+++ b/packages/react/src/new/useLinks.ts
@@ -80,11 +80,13 @@ export interface UseLinksOptions<
    *
    * @default true
    * @example
+   * ```tsx
    * // Dependent query - wait for employee data
    * const { object: employee } = useOsdkObject(Employee, employeeId);
    * const { links: reports } = useLinks(employee, "reports", {
-   *   enabled: !!employee
+   *   enabled: !!employee,
    * });
+   * ```
    */
   enabled?: boolean;
 }

--- a/packages/react/src/new/useObjectSet.tsx
+++ b/packages/react/src/new/useObjectSet.tsx
@@ -133,11 +133,13 @@ export interface UseObjectSetOptions<
    *
    * @default true
    * @example
+   * ```tsx
    * // Dependent query - wait for filter selection
    * const { data: filteredObjects } = useObjectSet(MyObject.all(), {
    *   where: { status: selectedStatus },
-   *   enabled: !!selectedStatus
+   *   enabled: !!selectedStatus,
    * });
+   * ```
    */
   enabled?: boolean;
 }

--- a/packages/react/src/new/useOsdkObjects.ts
+++ b/packages/react/src/new/useOsdkObjects.ts
@@ -41,15 +41,19 @@ export interface UseOsdkObjectsOptions<
    * Can be combined with `where` to filter the RID set, and with `orderBy` to sort results.
    *
    * @example
+   * ```tsx
    * // Fetch specific objects by RID
-   * useOsdkObjects(Employee, { rids: ['ri.foo.123', 'ri.foo.456'] })
+   * useOsdkObjects(Employee, { rids: ['ri.foo.123', 'ri.foo.456'] });
+   * ```
    *
    * @example
+   * ```tsx
    * // Fetch specific objects by RID, filtered by status
    * useOsdkObjects(Employee, {
    *   rids: ['ri.foo.123', 'ri.foo.456', 'ri.foo.789'],
-   *   where: { status: 'active' }
-   * })
+   *   where: { status: 'active' },
+   * });
+   * ```
    */
   rids?: readonly string[];
 
@@ -139,8 +143,10 @@ export interface UseOsdkObjectsOptions<
    * reducing payload sizes for list views.
    *
    * @example
+   * ```tsx
    * // Only fetch name and status properties
-   * useOsdkObjects(Employee, { $select: ["name", "status"] })
+   * useOsdkObjects(Employee, { $select: ["name", "status"] });
+   * ```
    */
   $select?: readonly PropertyKeys<T>[];
 


### PR DESCRIPTION
## Summary

Clean up JSDoc comments across `@osdk/api`, `@osdk/client`, and `@osdk/react`.

### What changed

**`@example` blocks wrapped in fenced ts/tsx code blocks** — VS Code's Markdown renderer (what you see on hover) collapses leading whitespace and flattens multi-line code unless it's inside a triple-backtick fence. Wrapped 13 unfenced blocks across the three packages. Where lines were missing the leading `*` JSDoc prefix (which silently broke comment continuation), added them. Result: hover tooltips now preserve indentation and apply syntax highlighting.

**TSDoc `@param` cleanup** — fixed mechanical warnings from api-extractor:
- `packages/api/src/Definitions.ts`: replaced JSDoc-style `@param {T} foo` with TSDoc-style `@param T - foo` (5 sites).
- `packages/client/src/createPlatformClient.ts`, `util/datetimeConverters.ts`, `util/objectSpecifierUtils.ts`: added missing `-` separators where descriptions exist; dropped `@param X` lines that carried no description (parameter name alone is no-op metadata).

**Dropped unrecognized `@discriminator` tag** in `PropertySecurity.ts` — not part of TSDoc spec, so api-extractor warned. Converted to plain prose under the summary.

**Regenerated api-extractor reports** in `etc/api.report.api.md` and `etc/client.report.api.md` to reflect the cleaned-up comments.

## Test plan

- [x] CI passes — typecheck, api-extractor, bundle size, e2e
- [x] Use tsserver to confirm code examples render with preserved indentation and syntax highlighting

🤖 Generated with [Claude Code](https://claude.com/claude-code)