### PR TITLE
fix useOsdkObject cache key collision with different $select

### DIFF
--- a/.changeset/fix-useosdkobject-select-cache-key.md
+++ b/.changeset/fix-useosdkobject-select-cache-key.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+fix useOsdkObject returning stale data when two hooks request the same object with different $select

--- a/packages/client/src/observable/internal/Store.test.ts
+++ b/packages/client/src/observable/internal/Store.test.ts
@@ -1356,6 +1356,89 @@ describe(Store, () => {
       });
     });
 
+    describe(".observeObject (independent variants per cache-key dimension)", () => {
+      const subFn1 = mockSingleSubCallback();
+      const subFn2 = mockSingleSubCallback();
+
+      beforeEach(() => {
+        for (const s of [subFn1, subFn2]) {
+          s.complete.mockClear();
+          s.next.mockClear();
+          s.error.mockClear();
+        }
+      });
+
+      // Two subscribers that share apiName + pk but differ in any cache-key
+      // dimension should observe independent fetches, not share a stale query.
+      // Add a new case here whenever a new dimension is added to ObjectCacheKey
+      // (currently: $select, $loadPropertySecurityMetadata, withProperties/Rdp).
+      // Cache-key uniqueness for dimensions the FauxFoundry can't fetch (e.g.
+      // $loadPropertySecurityMetadata) is unit-tested at the ObjectsHelper
+      // level instead.
+      const cases: Array<{
+        name: string;
+        optionsA: ObserveObjectOptions<typeof Employee>;
+        optionsB: ObserveObjectOptions<typeof Employee>;
+        // Optional dimension-specific assertion on subscriber B's loaded payload.
+        expectLoadedB?: (object: ObjectHolder | undefined) => void;
+      }> = [
+        {
+          name: "$select",
+          optionsA: {
+            apiName: Employee,
+            pk: JOHN_DOE_ID,
+            mode: "force",
+            select: ["fullName"],
+          },
+          optionsB: {
+            apiName: Employee,
+            pk: JOHN_DOE_ID,
+            mode: "force",
+            select: ["employeeId"],
+          },
+          expectLoadedB: (object) =>
+            expect(object).toEqual(
+              expect.objectContaining({
+                $primaryKey: JOHN_DOE_ID,
+                employeeId: JOHN_DOE_ID,
+              }),
+            ),
+        },
+      ];
+
+      it.each(cases)(
+        "subscribers differing in $name observe independent fetches",
+        async ({ optionsA, optionsB, expectLoadedB }) => {
+          // Subscriber A subscribes first and reaches "loaded".
+          defer(cache.objects.observe(optionsA, subFn1));
+          expectSingleObjectCallAndClear(subFn1, undefined!, "loading");
+          await waitForCall(subFn1);
+          const aLoaded = subFn1.next.mock.lastCall?.[0]!;
+          expect(aLoaded.object).toEqual(
+            expect.objectContaining({ $primaryKey: JOHN_DOE_ID }),
+          );
+          expect(aLoaded.status).toBe("loaded");
+          subFn1.next.mockClear();
+
+          // Subscriber B differs only in the cache-key dimension under test.
+          // Pre-fix, B would silently share A's query and its first emission
+          // would be A's already-loaded payload. Post-fix, B has its own
+          // query in init state, so its first emission is loading with no
+          // object yet — proving the queries are independent.
+          defer(cache.objects.observe(optionsB, subFn2));
+          expectSingleObjectCallAndClear(subFn2, undefined!, "loading");
+
+          await waitForCall(subFn2);
+          const bLoaded = subFn2.next.mock.lastCall?.[0]!;
+          expect(bLoaded.status).toBe("loaded");
+          expect(bLoaded.object).toEqual(
+            expect.objectContaining({ $primaryKey: JOHN_DOE_ID }),
+          );
+          expectLoadedB?.(bLoaded.object);
+        },
+      );
+    });
+
     describe(".observeObject (offline)", () => {
       const subFn = mockSingleSubCallback();
       let sub: Unsubscribable;

--- a/packages/client/src/observable/internal/object/ObjectCacheKey.ts
+++ b/packages/client/src/observable/internal/object/ObjectCacheKey.ts
@@ -25,7 +25,9 @@ import type { ObjectQuery } from "./ObjectQuery.js";
 export const API_NAME_IDX = 0;
 export const PK_IDX = 1;
 export const RDP_CONFIG_IDX = 2;
-export const INCLUDE_ALL_BASE_PROPERTIES_IDX = 3;
+export const SELECT_IDX = 3;
+export const LOAD_PROPERTY_SECURITY_IDX = 4;
+export const INCLUDE_ALL_BASE_PROPERTIES_IDX = 5;
 
 export interface ObjectCacheKey extends
   CacheKey<
@@ -36,6 +38,8 @@ export interface ObjectCacheKey extends
       apiName: string,
       pk: PrimaryKeyType<ObjectTypeDefinition>,
       rdpConfig?: Canonical<Rdp> | undefined,
+      select?: Canonical<readonly string[]> | undefined,
+      loadPropertySecurity?: true | undefined,
       includeAllBaseObjectProperties?: true | undefined,
     ]
   >

--- a/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
@@ -514,7 +514,7 @@ describe("Two variants with different RDP configs - GC of one should not affect 
   });
 });
 
-describe("ObjectsHelper.getQuery select + loadPropertySecurity in cache key", () => {
+describe("ObjectsHelper variant cache keys", () => {
   let client: Client;
   let store: Store;
   let emp: Osdk.Instance<Employee>;
@@ -632,10 +632,6 @@ describe("ObjectsHelper.getQuery select + loadPropertySecurity in cache key", ()
       queryA.writeToStore(emp as any, "loaded", batch, new Set(["fullName"]));
     });
 
-    // A separate fetch on variant B (employeeId only) writes through
-    // ObjectQuery.writeToStore which calls propagateWrite with selectFields.
-    // After propagation, A's cache entry must retain its existing fullName
-    // rather than being clobbered by B's partial data.
     store.batch({}, (batch) => {
       queryB.writeToStore(
         emp as any,

--- a/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
@@ -513,3 +513,148 @@ describe("Two variants with different RDP configs - GC of one should not affect 
     store.cacheKeys.release(queryA.cacheKey);
   });
 });
+
+describe("ObjectsHelper.getQuery select + loadPropertySecurity in cache key", () => {
+  let client: Client;
+  let store: Store;
+  let emp: Osdk.Instance<Employee>;
+
+  beforeAll(async () => {
+    const testSetup = startNodeApiServer(
+      new FauxFoundry("https://stack.palantir.com/"),
+      createClient,
+    );
+    client = testSetup.client;
+
+    const fauxOntology = testSetup.fauxFoundry.getDefaultOntology();
+    ontologies.addEmployeeOntology(fauxOntology);
+
+    testSetup.fauxFoundry.getDefaultDataStore().registerObject(Employee, {
+      employeeId: 1,
+      fullName: "Alice",
+    });
+
+    emp = await client(Employee).fetchOne(1, { $includeRid: true });
+
+    return () => {
+      testSetup.apiServer.close();
+    };
+  });
+
+  beforeEach(() => {
+    store = new Store(client);
+    return () => {
+      store = undefined!;
+    };
+  });
+
+  it("returns distinct queries for different selects on the same pk", () => {
+    const q1 = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+      select: ["fullName"],
+    });
+    const q2 = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+      select: ["employeeId"],
+    });
+
+    expect(q1).not.toBe(q2);
+    expect(q1.cacheKey).not.toBe(q2.cacheKey);
+  });
+
+  it("returns the same query for canonicalized-equal selects on the same pk", () => {
+    const q1 = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+      select: ["fullName", "employeeId"],
+    });
+    const q2 = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+      select: ["employeeId", "fullName"],
+    });
+
+    expect(q1).toBe(q2);
+    expect(q1.cacheKey).toBe(q2.cacheKey);
+  });
+
+  it("returns distinct queries for different $loadPropertySecurityMetadata on the same pk", () => {
+    const q1 = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+    });
+    const q2 = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+      $loadPropertySecurityMetadata: true,
+    });
+
+    expect(q1).not.toBe(q2);
+    expect(q1.cacheKey).not.toBe(q2.cacheKey);
+  });
+
+  it("treats no-select and empty-select as the same cache key", () => {
+    const qNone = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+    });
+    const qEmpty = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+      select: [],
+    });
+
+    expect(qNone).toBe(qEmpty);
+  });
+
+  it("propagateWrite preserves sibling-variant fields when a partial-select fetch propagates", () => {
+    const queryA = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+      select: ["fullName"],
+    });
+    const queryB = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+      select: ["employeeId"],
+    });
+
+    // Make both variants observed so propagation runs.
+    store.cacheKeys.retain(queryA.cacheKey);
+    store.cacheKeys.retain(queryB.cacheKey);
+    store.subjects.get(queryA.cacheKey).subscribe(() => {});
+    store.subjects.get(queryB.cacheKey).subscribe(() => {});
+
+    // Seed variant A with the loaded "fullName" view.
+    store.batch({}, (batch) => {
+      queryA.writeToStore(emp as any, "loaded", batch, new Set(["fullName"]));
+    });
+
+    // A separate fetch on variant B (employeeId only) writes through
+    // ObjectQuery.writeToStore which calls propagateWrite with selectFields.
+    // After propagation, A's cache entry must retain its existing fullName
+    // rather than being clobbered by B's partial data.
+    store.batch({}, (batch) => {
+      queryB.writeToStore(
+        emp as any,
+        "loaded",
+        batch,
+        new Set(["employeeId"]),
+      );
+    });
+
+    const valueA = store.getValue(queryA.cacheKey);
+    expect(valueA?.value).toEqual(
+      expect.objectContaining({
+        $primaryKey: 1,
+        fullName: "Alice",
+        employeeId: 1,
+      }),
+    );
+
+    store.cacheKeys.release(queryA.cacheKey);
+    store.cacheKeys.release(queryB.cacheKey);
+  });
+});

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -228,17 +228,15 @@ export class ObjectsHelper extends AbstractHelper<
           ? targetCurrentValue
           : undefined;
 
-      // When a partial-select fetch propagates to a sibling variant that
-      // already has its own data, preserve fields outside the source's select
-      // set so different-select variants converge to the union of fetched
-      // fields rather than clobbering each other.
-      const valueForTarget =
-        selectFields && selectFields.size > 0 && targetHolder
-          ? mergeSelectFields(value, selectFields, targetHolder)
-          : value;
-
-      const merged = this.mergeForTarget(
-        valueForTarget,
+      // Preserve target-only fields when a partial-select fetch propagates
+      // to a sibling variant, so different-select variants converge to the
+      // union rather than clobbering each other.
+      let merged = value;
+      if (selectFields?.size && targetHolder) {
+        merged = mergeSelectFields(merged, selectFields, targetHolder);
+      }
+      merged = this.mergeForTarget(
+        merged,
         targetHolder,
         sourceCacheKey,
         targetKey,

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -67,11 +67,17 @@ export class ObjectsHelper extends AbstractHelper<
       ? true
       : undefined;
 
+    const canonSelect = select && select.length > 0
+      ? this.store.selectCanonicalizer.canonicalize(select)
+      : undefined;
+
     const objectCacheKey = this.cacheKeys.get<ObjectCacheKey>(
       "object",
       apiName,
       pk,
       rdpConfig ?? undefined,
+      canonSelect,
+      $loadPropertySecurityMetadata ? true : undefined,
       $includeAllBaseObjectProperties,
     );
 
@@ -217,11 +223,23 @@ export class ObjectsHelper extends AbstractHelper<
       }
 
       const targetCurrentValue = batch.read(targetKey)?.value;
-      const merged = this.mergeForTarget(
-        value,
+      const targetHolder =
         targetCurrentValue && this.isObjectHolder(targetCurrentValue)
           ? targetCurrentValue
-          : undefined,
+          : undefined;
+
+      // When a partial-select fetch propagates to a sibling variant that
+      // already has its own data, preserve fields outside the source's select
+      // set so different-select variants converge to the union of fetched
+      // fields rather than clobbering each other.
+      const valueForTarget =
+        selectFields && selectFields.size > 0 && targetHolder
+          ? mergeSelectFields(value, selectFields, targetHolder)
+          : value;
+
+      const merged = this.mergeForTarget(
+        valueForTarget,
+        targetHolder,
         sourceCacheKey,
         targetKey,
       );

--- a/packages/react/src/new/__tests__/useOsdkObject.test.tsx
+++ b/packages/react/src/new/__tests__/useOsdkObject.test.tsx
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Osdk } from "@osdk/api";
+import type { Client } from "@osdk/client";
+import { Employee } from "@osdk/client.test.ontology";
+import type { ObservableClient } from "@osdk/client/unstable-do-not-use";
+import { act, renderHook } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OsdkContext2 } from "../OsdkContext2.js";
+import { useOsdkObject } from "../useOsdkObject.js";
+
+type Observer = {
+  next: (payload: unknown) => void;
+  error: (err: unknown) => void;
+  complete: () => void;
+};
+
+type ObserveObjectCall = {
+  type: unknown;
+  primaryKey: unknown;
+  options: {
+    select?: readonly string[];
+    $loadPropertySecurityMetadata?: boolean;
+    mode?: string;
+  };
+  observer: Observer;
+};
+
+function createMockObservableClient(): {
+  client: ObservableClient;
+  calls: ObserveObjectCall[];
+} {
+  const calls: ObserveObjectCall[] = [];
+  const client = {
+    observeObject: vi
+      .fn()
+      .mockImplementation(
+        (
+          type: unknown,
+          primaryKey: unknown,
+          options: ObserveObjectCall["options"],
+          observer: Observer,
+        ) => {
+          calls.push({ type, primaryKey, options, observer });
+          return { unsubscribe: vi.fn() };
+        },
+      ),
+  } as unknown as ObservableClient;
+  return { client, calls };
+}
+
+function createWrapper(observableClient: ObservableClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <OsdkContext2.Provider
+        value={{
+          client: {} as Client,
+          observableClient,
+          devtoolsEnabled: false,
+        }}
+      >
+        {children}
+      </OsdkContext2.Provider>
+    );
+  };
+}
+
+describe("useOsdkObject", () => {
+  let observableClient: ObservableClient;
+  let calls: ObserveObjectCall[];
+
+  beforeEach(() => {
+    ({ client: observableClient, calls } = createMockObservableClient());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("forwards each hook's options to observeObject independently when two hooks share a primary key", () => {
+    function useTwoHooks() {
+      const a = useOsdkObject(Employee, 1, {
+        $select: ["fullName"],
+      });
+      const b = useOsdkObject(Employee, 1, {
+        $select: ["employeeId"],
+      });
+      return { a, b };
+    }
+
+    const { result } = renderHook(useTwoHooks, {
+      wrapper: createWrapper(observableClient),
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0].primaryKey).toBe(1);
+    expect(calls[1].primaryKey).toBe(1);
+    expect(calls[0].options.select).toEqual(["fullName"]);
+    expect(calls[1].options.select).toEqual(["employeeId"]);
+    expect(result.current.a.isLoading).toBe(true);
+    expect(result.current.b.isLoading).toBe(true);
+  });
+
+  it("returns each hook's own loaded object when two hooks share a primary key but observe different selects", () => {
+    function useTwoHooks() {
+      const a = useOsdkObject(Employee, 1, {
+        $select: ["fullName"],
+      });
+      const b = useOsdkObject(Employee, 1, {
+        $select: ["employeeId"],
+      });
+      return { a, b };
+    }
+
+    const { result } = renderHook(useTwoHooks, {
+      wrapper: createWrapper(observableClient),
+    });
+
+    const objectA = {
+      $apiName: "Employee",
+      $primaryKey: 1,
+      fullName: "Alice",
+    } as unknown as Osdk.Instance<typeof Employee>;
+    const objectB = {
+      $apiName: "Employee",
+      $primaryKey: 1,
+      employeeId: 1,
+    } as unknown as Osdk.Instance<typeof Employee>;
+
+    act(() => {
+      calls[0].observer.next({
+        status: "loaded",
+        object: objectA,
+        lastUpdated: 1,
+        isOptimistic: false,
+      });
+      calls[1].observer.next({
+        status: "loaded",
+        object: objectB,
+        lastUpdated: 2,
+        isOptimistic: false,
+      });
+    });
+
+    expect(result.current.a.object).toBe(objectA);
+    expect(result.current.b.object).toBe(objectB);
+    expect(result.current.a.isLoading).toBe(false);
+    expect(result.current.b.isLoading).toBe(false);
+  });
+
+  it("forwards $loadPropertySecurityMetadata to observeObject when set", () => {
+    renderHook(
+      () =>
+        useOsdkObject(Employee, 1, {
+          $loadPropertySecurityMetadata: true,
+        }),
+      { wrapper: createWrapper(observableClient) },
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].options.$loadPropertySecurityMetadata).toBe(true);
+  });
+});

--- a/packages/react/src/new/__tests__/useOsdkObject.test.tsx
+++ b/packages/react/src/new/__tests__/useOsdkObject.test.tsx
@@ -162,17 +162,4 @@ describe("useOsdkObject", () => {
     expect(result.current.a.isLoading).toBe(false);
     expect(result.current.b.isLoading).toBe(false);
   });
-
-  it("forwards $loadPropertySecurityMetadata to observeObject when set", () => {
-    renderHook(
-      () =>
-        useOsdkObject(Employee, 1, {
-          $loadPropertySecurityMetadata: true,
-        }),
-      { wrapper: createWrapper(observableClient) },
-    );
-
-    expect(calls).toHaveLength(1);
-    expect(calls[0].options.$loadPropertySecurityMetadata).toBe(true);
-  });
 });


### PR DESCRIPTION
two `useOsdkObject` hooks on the same primary key with different `$select` arrays would silently share one query, so the second hook never fetched and returned the first hook's fields

• include `select` and `$loadPropertySecurityMetadata` in `ObjectCacheKey` so each variant gets its own query, mirroring `ListCacheKey`
• canonicalize `select` in `ObjectsHelper.getQuery` via the existing `selectCanonicalizer`
• make variant propagation in `propagateWrite` select-aware so a partial-select fetch merges into sibling variants instead of clobbering them