### PR TITLE
Remove dead Constant<Q> type from DerivedProperty.ts

### DIFF
--- a/.changeset/remove-dead-constant-type.md
+++ b/.changeset/remove-dead-constant-type.md
@@ -1,0 +1,5 @@
+---
+"@osdk/api": patch
+---
+
+Remove the unused internal `Constant<Q>` type from `DerivedProperty.ts`. Disconnected from the `Builder` chain in #2858 (Remove RDP Literals); never exported, no consumers. No public-API change.

--- a/packages/api/src/derivedProperties/DerivedProperty.ts
+++ b/packages/api/src/derivedProperties/DerivedProperty.ts
@@ -124,43 +124,6 @@ type Pivotable<
     : DerivedProperty.SelectPropertyBuilder<LinkedType<Q, L>, false>;
 };
 
-type Constant<Q extends ObjectOrInterfaceDefinition> = {
-  readonly constant: {
-    readonly double: (
-      value: number,
-    ) => DerivedProperty.NumericPropertyDefinition<
-      SimplePropertyDef.Make<"double", "non-nullable", "single">,
-      Q
-    >;
-
-    readonly integer: (
-      value: number,
-    ) => DerivedProperty.NumericPropertyDefinition<
-      SimplePropertyDef.Make<"integer", "non-nullable", "single">,
-      Q
-    >;
-    readonly long: (
-      value: string,
-    ) => DerivedProperty.NumericPropertyDefinition<
-      SimplePropertyDef.Make<"long", "non-nullable", "single">,
-      Q
-    >;
-
-    readonly datetime: (
-      value: string,
-    ) => DerivedProperty.DatetimePropertyDefinition<
-      SimplePropertyDef.Make<"datetime", "non-nullable", "single">,
-      Q
-    >;
-    readonly timestamp: (
-      value: string,
-    ) => DerivedProperty.DatetimePropertyDefinition<
-      SimplePropertyDef.Make<"timestamp", "non-nullable", "single">,
-      Q
-    >;
-  };
-};
-
 type Aggregatable<
   Q extends ObjectOrInterfaceDefinition,
 > = {


### PR DESCRIPTION
## Summary

Removes the orphaned `Constant<Q>` helper type from `packages/api/src/derivedProperties/DerivedProperty.ts`.

`Constant<Q>` defined `.constant.{double,integer,long,datetime,timestamp}` accessors on the derived-property `Builder`. It was disconnected from the `Builder extends ...` clause in #2858 ("Remove RDP Literals"), and the same PR removed the runtime implementation in `createWithPropertiesObjectSet.ts` and the related tests in `ObjectSet.test.ts`. The type itself was left orphaned in the file.

Verified before deleting:
- Non-exported (declared with `type`, not `export type`)
- Zero references in the monorepo besides its own definition
- Not present in `etc/api.report.api.md`

So this is a pure cleanup with no public-API impact.

## Test plan

- [x] `pnpm turbo typecheck --filter=@osdk/api` passes
- [x] `pnpm turbo check-api --filter=@osdk/api` passes (no API report change)
- [x] `pnpm turbo transpile --filter=@osdk/client` passes (the closest published consumer of `@osdk/api`)
- [x] `npx dprint check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)