### PR TITLE
Add docs for @osdk/functions-testing.experimental

### DIFF
--- a/.changeset/proud-months-speak.md
+++ b/.changeset/proud-months-speak.md
@@ -1,0 +1,5 @@
+---
+"@osdk/functions-testing.experimental": patch
+---
+
+Documentation for functions testing library

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -108,16 +108,16 @@ const config: Config = {
         },
         {
           type: "docSidebar",
-          sidebarId: "functionsTesting",
-          position: "left",
-          label: "Functions Testing",
-        },
-        {
-          type: "docSidebar",
           sidebarId: "docs",
           docsPluginId: "react-components",
           position: "left",
           label: "Components",
+        },
+        {
+          type: "docSidebar",
+          sidebarId: "functionsTesting",
+          position: "left",
+          label: "Functions Testing",
         },
         {
           href: "https://palantir.github.io/osdk-ts/storybook/",

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import type * as Preset from "@docusaurus/preset-classic";
 import type { Config } from "@docusaurus/types";
 
@@ -89,6 +105,12 @@ const config: Config = {
           sidebarId: "react",
           position: "left",
           label: "osdk-react",
+        },
+        {
+          type: "docSidebar",
+          sidebarId: "functionsTesting",
+          position: "left",
+          label: "Functions Testing",
         },
         {
           type: "docSidebar",

--- a/docs/functions-testing/getting-started.md
+++ b/docs/functions-testing/getting-started.md
@@ -1,0 +1,111 @@
+---
+sidebar_position: 1
+---
+
+# Getting Started
+
+`@osdk/functions-testing.experimental` lets you unit-test code that takes an OSDK `Client` — including Foundry Functions — without hitting a real Foundry. It gives you:
+
+- **`createMockClient`** — a `Client` you stub with fluent `.when` / `.whenObjectSet` / `.whenQuery` matchers.
+- **`createMockOsdkObject`** — construct fully-shaped `Osdk.Instance` values (`$primaryKey`, `$title`, `$rid`, `$link`, `$clone`).
+- **`createMockObjectSet`** — a standalone `ObjectSet` you can pass anywhere a real one would go (or use as a many-link target for aggregates).
+- **`createMockAttachment`** — a stand-in for attachment values.
+
+:::warning Experimental
+The package is published as `@osdk/functions-testing.experimental` and only exports through the `/experimental` subpath. The surface may evolve before promotion to a stable name.
+:::
+
+## Install
+
+```bash
+npm install --save-dev @osdk/functions-testing.experimental
+```
+
+The package has the following peer dependencies — they should already be in your project:
+
+- `@osdk/api`
+- `@osdk/client`
+- `@osdk/functions`
+
+It uses `vitest` internally for example tests; you can use any test runner in your own code.
+
+## Import
+
+Everything is exported from the `/experimental` subpath:
+
+```ts
+import {
+  createMockAttachment,
+  createMockClient,
+  createMockObjectSet,
+  createMockOsdkObject,
+} from "@osdk/functions-testing.experimental/experimental";
+
+import type {
+  AggregateStubBuilder,
+  FetchOneStubBuilder,
+  FetchPageStubBuilder,
+  QueryStubBuilder,
+  StubBuilderFor,
+} from "@osdk/functions-testing.experimental/experimental";
+```
+
+## Your first test
+
+Suppose you have a Foundry Function that reads the first `Employee` from a page:
+
+```ts
+import type { Osdk } from "@osdk/api";
+import type { Client } from "@osdk/client";
+import { Employee } from "your-app-sdk";
+
+export async function basicFetchPage(
+  client: Client,
+): Promise<Osdk.Instance<Employee>> {
+  const objects = await client(Employee).fetchPage();
+  const object = objects.data[0];
+  if (object == null) throw new Error("No objects returned");
+  return object;
+}
+```
+
+A unit test with the mock client looks like this:
+
+```ts
+import {
+  createMockClient,
+  createMockOsdkObject,
+} from "@osdk/functions-testing.experimental/experimental";
+import { describe, expect, it } from "vitest";
+import { Employee } from "your-app-sdk";
+import { basicFetchPage } from "./basicFetchPage.js";
+
+describe("basicFetchPage", () => {
+  it("returns the first Employee", async () => {
+    const mockClient = createMockClient();
+    const mockEmployee = createMockOsdkObject(Employee, {
+      employeeId: 1,
+      fullName: "John",
+    });
+
+    mockClient
+      .when((stub) => stub(Employee).fetchPage())
+      .thenReturnObjects([mockEmployee]);
+
+    const actual = await basicFetchPage(mockClient);
+    expect(actual).toEqual(mockEmployee);
+  });
+});
+```
+
+Three things are happening:
+
+1. **`createMockClient()`** returns a `MockClient` that satisfies the `Client` interface — pass it anywhere your code expects a real client.
+2. **`createMockOsdkObject(Employee, { ... })`** builds a real-shaped instance.
+3. **`mockClient.when(stub => stub(Employee).fetchPage()).thenReturnObjects([...])`** records a stub. The `stub` argument is a `Client`-like factory; you re-build the same call chain your code will execute.
+
+## Where to next
+
+- **[Mock objects and links](./mock-objects.md)** — single/many links, simulating link errors, and using a `MockObjectSet` for aggregate calls on a link.
+- **[Stubbing client calls](./stubbing-client-calls.md)** — `when`, `whenObjectSet`, `whenQuery`, and which `.thenReturn*` matcher applies to each call shape.
+- **[Platform APIs with MSW](./platform-apis-with-msw.md)** — testing functions that call `@osdk/foundry.*` (admin, etc.).

--- a/docs/functions-testing/mock-objects.md
+++ b/docs/functions-testing/mock-objects.md
@@ -1,0 +1,241 @@
+---
+sidebar_position: 2
+---
+
+# Mock objects and links
+
+`createMockOsdkObject` builds a fully-shaped `Osdk.Instance<T>` that you can pass to your code under test or stash inside a `.thenReturnObjects([...])` stub. This page covers the object shape, the `links` option (single, many, errors, mock object sets), and `createMockAttachment`.
+
+## Arguments
+
+`createMockOsdkObject` takes three arguments:
+
+```ts
+createMockOsdkObject(objectType, properties, options);
+```
+
+1. **`objectType`** — the generated object type constant from your SDK (e.g. `Employee`). The mock reads its `apiName` and `primaryKeyApiName` from this.
+2. **`properties`** — the property values you want on the mock. Must include the primary key property; everything else is optional and only matters if your code reads it.
+3. **`options`** — three optional fields:
+   - **`links`** — mock data for the object's `$link` accessor. See [Links](#links) below.
+   - **`titlePropertyApiName`** — the API name of the property that should back `$title`. See [Setting `$title`](#setting-title) below.
+   - **`$rid`** — override the auto-generated `$rid`. Default is `"ri.mock.main.object.<apiName>.<primaryKey>"`.
+
+The returned mock has the same shape as a real OSDK instance:
+
+| Field                     | What it holds                                                             |
+| ------------------------- | ------------------------------------------------------------------------- |
+| `$apiName`, `$objectType` | The object type's API name.                                               |
+| `$primaryKey`             | The value of the primary key property in `properties`.                    |
+| `$title`                  | The value of the `titlePropertyApiName` property; `undefined` if not set. |
+| `$rid`                    | `options.$rid` if provided, otherwise an auto-generated mock RID.         |
+| `$objectSpecifier`        | `"<apiName>:<primaryKey>"`.                                               |
+| `$link`                   | A proxy backed by `options.links`.                                        |
+| `$clone(updates?)`        | Returns a fresh mock with merged property values.                         |
+
+`$as` and the `$__EXPERIMENTAL__NOT_SUPPORTED_YET__*` accessors throw — they are not modelled in mocks.
+
+## Basic usage
+
+```ts
+import { createMockOsdkObject } from "@osdk/functions-testing.experimental/experimental";
+import { Employee } from "your-app-sdk";
+
+const emp = createMockOsdkObject(
+  Employee,
+  { employeeId: 1, fullName: "John Doe" },
+  { titlePropertyApiName: "fullName" },
+);
+
+emp.$primaryKey; // 1
+emp.$title; // "John Doe"
+emp.$objectSpecifier; // "Employee:1"
+```
+
+The primary key property is required. `createMockOsdkObject` reads `objectType.primaryKeyApiName` and throws if that key isn't present in `properties`.
+
+## Setting `$title` {#setting-title}
+
+OSDK doesn't know which property on a given object type is its "title" — that mapping lives in the ontology, not in the generated TypeScript. So if your code under test reads `obj.$title`, you have to tell the mock which property to surface there by passing `titlePropertyApiName`:
+
+```ts
+const emp = createMockOsdkObject(
+  Employee,
+  { employeeId: 1, fullName: "John Doe" },
+  { titlePropertyApiName: "fullName" },
+);
+
+emp.$title; // "John Doe"
+```
+
+`titlePropertyApiName` must name a property you actually included in `properties` — `createMockOsdkObject` throws if it's missing. If you omit `titlePropertyApiName` entirely, `$title` is `undefined`.
+
+## Links
+
+The `links` option mirrors the link API names from the object type. Each value can be:
+
+| Link multiplicity | Allowed values                                                                                                         |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Single            | A mock object &nbsp; or &nbsp; an `Error`                                                                              |
+| Many              | An array of mock objects &nbsp; or &nbsp; a `MockObjectSet` (see [Mock object sets](#mock-object-sets) for the latter) |
+
+### Single link — happy path
+
+```ts
+const office = createMockOsdkObject(Office, {
+  officeId: "nyc",
+  name: "New York Office",
+});
+
+const employee = createMockOsdkObject(
+  Employee,
+  { employeeId: 1, fullName: "John Doe" },
+  { links: { officeLink: office } },
+);
+
+await employee.$link.officeLink.fetchOne();
+// → office
+
+(await employee.$link.officeLink.fetchOneWithErrors()).value;
+// → office
+```
+
+### Single link — error path
+
+Pass an `Error` instance to drive the failure branch of the calling code. `fetchOne()` rejects with the error, and `fetchOneWithErrors()` resolves to `{ error }`:
+
+```ts
+const employee = createMockOsdkObject(
+  Employee,
+  { employeeId: 1 },
+  { links: { officeLink: new Error("link unavailable") } },
+);
+
+await expect(employee.$link.officeLink.fetchOne()).rejects.toThrow(
+  "link unavailable",
+);
+
+const result = await employee.$link.officeLink.fetchOneWithErrors();
+result.error; // the Error
+result.value; // undefined
+```
+
+### Missing links throw a descriptive error
+
+If your code reaches for `$link.someLink` and you didn't configure it, the accessor still exists — its `fetchOne` rejects (and `fetchOneWithErrors` resolves with `{ error }`) carrying the link name, object type, and primary key:
+
+```ts
+const employee = createMockOsdkObject(Employee, { employeeId: 1 });
+
+await employee.$link.officeLink.fetchOne();
+// rejects
+```
+
+### Many link — array
+
+Pass an array; the `$link` accessor exposes the same call shapes a real many-link does:
+
+```ts
+const peep1 = createMockOsdkObject(Employee, {
+  employeeId: 10,
+  fullName: "Alice",
+});
+const peep2 = createMockOsdkObject(Employee, {
+  employeeId: 11,
+  fullName: "Bob",
+});
+
+const employee = createMockOsdkObject(
+  Employee,
+  { employeeId: 1 },
+  { links: { peeps: [peep1, peep2] } },
+);
+
+(await employee.$link.peeps.fetchPage()).data;
+// → [peep1, peep2]
+
+await employee.$link.peeps.fetchOne(11);
+// → peep2 (matched by $primaryKey)
+
+for await (const peep of employee.$link.peeps.asyncIter()) {
+  // peep1, peep2
+}
+```
+
+`fetchOne(primaryKey)` throws when no array element has a matching `$primaryKey`. `aggregate()` is **not** supported on the array form — pass a [`MockObjectSet`](#mock-object-sets) instead.
+
+### Many link — passing a `MockObjectSet`
+
+A many-link can also be backed by a `MockObjectSet` instead of an array. Use this when your code calls `aggregate()`, `where()`, or other object-set methods on the link:
+
+```ts
+const employee = createMockOsdkObject(
+  Employee,
+  { employeeId: 1 },
+  { links: { peeps: peepsSet } },
+);
+```
+
+See [Mock object sets](#mock-object-sets) below for how to build `peepsSet` and stub calls on it.
+
+## Mock object sets {#mock-object-sets}
+
+`createMockObjectSet(objectType)` returns an `ObjectSet<T>` you can pass anywhere a real one would go — directly into a function under test, or as the value of a many-link in `createMockOsdkObject`. By itself the mock object set holds no data; you wire up its behavior by registering stubs against it on a `MockClient`.
+
+```ts
+import {
+  createMockClient,
+  createMockObjectSet,
+  createMockOsdkObject,
+} from "@osdk/functions-testing.experimental/experimental";
+
+const mockClient = createMockClient();
+const peepsSet = createMockObjectSet(Employee);
+
+mockClient
+  .whenObjectSet(
+    peepsSet,
+    (os) => os.aggregate({ $select: { $count: "unordered" } }),
+  )
+  .thenReturnAggregation({ $count: 7 });
+```
+
+Now `peepsSet.aggregate(...)` resolves to `{ $count: 7 }`. You can attach the same set to a parent mock object as a many-link:
+
+```ts
+const employee = createMockOsdkObject(
+  Employee,
+  { employeeId: 1 },
+  { links: { peeps: peepsSet } },
+);
+
+const result = await employee.$link.peeps.aggregate({
+  $select: { $count: "unordered" },
+});
+result.$count; // 7
+```
+
+You can register `fetchPage`, `where`, and other call shapes on the same set the same way — see [Stubbing client calls](./stubbing-client-calls.md#when-object-set) for the full builder reference.
+
+## `createMockAttachment`
+
+For function inputs of type `Attachment`, `createMockAttachment` returns a stand-in value with the surface your code can call against. Use it the same way you'd use `createMockOsdkObject`:
+
+```ts
+import { createMockAttachment } from "@osdk/functions-testing.experimental/experimental";
+
+const att = createMockAttachment({
+  rid: "ri.attachments.main.attachment.abc",
+  filename: "report.pdf",
+});
+```
+
+## Cloning and updates
+
+`$clone` is supported and returns a fresh frozen mock with merged properties. Updating the primary key to a different value throws.
+
+```ts
+const updated = employee.$clone({ fullName: "Jane Doe" });
+updated.$primaryKey; // unchanged
+updated.fullName; // "Jane Doe"
+```

--- a/docs/functions-testing/platform-apis-with-msw.md
+++ b/docs/functions-testing/platform-apis-with-msw.md
@@ -1,0 +1,156 @@
+---
+sidebar_position: 4
+---
+
+# Platform APIs with MSW
+
+`createMockClient` only stubs ontology calls (object types, queries, object sets). It does **not** intercept the Foundry Platform APIs in `@osdk/foundry.*` and `@osdk/internal.foundry.*` — those go through the regular `fetch` path. To keep them off the network in tests, intercept them with [MSW](https://mswjs.io/).
+
+## How it works
+
+The mock client allows users to stub platform SDK requests using a network request stubbing library. It uses a placeholder base URL:
+
+```
+https://mock.invalid/
+```
+
+Every platform call your code makes will resolve against that origin. Your job in tests is to give MSW handlers for the specific paths your function hits.
+
+## Setup
+
+Install MSW as a dev dependency:
+
+```bash
+npm install --save-dev msw
+```
+
+Stand up a Node server in your test file. The standard MSW lifecycle hooks reset handlers between tests so each `it` is isolated:
+
+```ts
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll } from "vitest";
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+```
+
+`onUnhandledRequest: "error"` is recommended — it surfaces accidental platform calls without a handler instead of letting them fall through.
+
+## Example
+
+A function that loads the current user and gates on a username suffix:
+
+```ts
+import type { Client } from "@osdk/client";
+import { Users } from "@osdk/foundry.admin";
+
+export async function requireAdminUser(client: Client): Promise<string> {
+  const user = await Users.getCurrent(client);
+  if (!user.username.endsWith("@admin")) {
+    throw new Error(`User ${user.username} is not an admin`);
+  }
+  return user.username;
+}
+```
+
+The test stubs the platform endpoint with MSW and uses `createMockClient()` for the `Client`:
+
+```ts
+import type { getCurrent } from "@osdk/foundry.admin/User";
+import { createMockClient } from "@osdk/functions-testing.experimental/experimental";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { requireAdminUser } from "./requireAdminUser.js";
+
+type User = Awaited<ReturnType<typeof getCurrent>>;
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("requireAdminUser", () => {
+  it("resolves when the current user is an admin", async () => {
+    server.use(
+      http.get(
+        "https://mock.invalid/api/v2/admin/users/getCurrent",
+        () =>
+          HttpResponse.json(
+            {
+              id: "user-1",
+              username: "alice@admin",
+              givenName: "Alice",
+              familyName: "Admin",
+              realm: "default",
+              status: "ACTIVE",
+              attributes: {},
+            } satisfies User,
+          ),
+      ),
+    );
+
+    const mockClient = createMockClient();
+    expect(await requireAdminUser(mockClient)).toBe("alice@admin");
+  });
+
+  it("rejects when the user is not an admin", async () => {
+    server.use(
+      http.get(
+        "https://mock.invalid/api/v2/admin/users/getCurrent",
+        () =>
+          HttpResponse.json(
+            {
+              id: "user-2",
+              username: "bob@example.com",
+              givenName: "Bob",
+              familyName: "Example",
+              realm: "default",
+              status: "ACTIVE",
+              attributes: {},
+            } satisfies User,
+          ),
+      ),
+    );
+
+    const mockClient = createMockClient();
+    await expect(requireAdminUser(mockClient)).rejects.toThrow(
+      "User bob@example.com is not an admin",
+    );
+  });
+});
+```
+
+:::tip Type your fixtures against the real platform type
+The MSW response body is just a JSON literal, so it's easy for it to drift from the actual `@osdk/foundry.*` shape (a renamed field, a new required property, etc.) and only blow up at runtime.
+
+To keep the fixture tied to the real type, derive it from the platform function itself:
+
+```ts
+import type { somePlatformFn } from "@osdk/foundry.<service>/<Resource>";
+
+type ResponseShape = Awaited<ReturnType<typeof somePlatformFn>>;
+```
+
+Then assert the response body with `satisfies ResponseShape`:
+
+```ts
+HttpResponse.json(
+  {/* ...response fields... */} satisfies ResponseShape,
+);
+```
+
+`Awaited<ReturnType<typeof fn>>` unwraps the `Promise<T>` returned by an `async` function, giving you `T` directly. The next time `@osdk/foundry.*` ships a breaking change, your fixture fails to compile rather than your test hanging on a malformed response.
+
+In the example above, the concrete instance of this pattern is `type User = Awaited<ReturnType<typeof getCurrent>>` — name the alias after whatever the endpoint returns.
+:::
+
+## Tips
+
+- **Use `onUnhandledRequest: "error"`.** Easier to spot a missing handler than to debug a hung test.
+- **One server, many handlers.** `setupServer()` once at module scope; `server.use(...)` inside each `it` for the per-test handler. `afterEach(server.resetHandlers)` clears them.
+- **Mixing with ontology stubs.** A single `mockClient` handles both kinds of call simultaneously — ontology calls go through `when` / `whenObjectSet` / `whenQuery`, platform calls go through MSW.

--- a/docs/functions-testing/stubbing-client-calls.md
+++ b/docs/functions-testing/stubbing-client-calls.md
@@ -1,0 +1,143 @@
+---
+sidebar_position: 3
+---
+
+# Stubbing client calls
+
+`createMockClient()` returns a value that satisfies the OSDK `Client` interface, plus four extra methods for setting up stubs:
+
+- **`client.when(callback)`** — stub a call rooted at the client. Pass a callback that re-builds the chain your code under test will make (`stub(Employee).where(...).fetchPage()`, etc.). Returns a builder whose `.thenReturn*` matcher depends on the call shape.
+- **`client.whenObjectSet(set, callback)`** — stub a call on a specific `MockObjectSet` (from `createMockObjectSet`). Use this when your code is handed an object set directly, or for a many-link backed by a mock object set.
+- **`client.whenQuery(query, params?)`** — stub a query call (a generated function on the ontology). Returns a builder with `.thenReturn(value)` and `.thenThrow(error)`.
+- **`client.clearStubs()`** — remove every stub registered on this client.
+
+Each registrar is covered in turn below.
+
+## `when` — ontology calls rooted at the client
+
+Re-build the call chain your code under test will make. The argument is a `Client`-like factory; chain `where`, `aggregate`, `fetchPage`, `fetchOne`, etc. on it just as your code would.
+
+### `fetchPage` → `thenReturnObjects`
+
+```ts
+const mockClient = createMockClient();
+const emp = createMockOsdkObject(Employee, { employeeId: 1, fullName: "John" });
+
+mockClient
+  .when((stub) => stub(Employee).fetchPage())
+  .thenReturnObjects([emp]);
+
+const page = await mockClient(Employee).fetchPage();
+page.data; // [emp]
+```
+
+`thenReturnObjects` also wires up `asyncIter` — if your code iterates instead of paginating, the same stub serves both.
+
+### `fetchOne` → `thenReturnObject`
+
+```ts
+mockClient
+  .when((stub) => stub(Employee).fetchOne(1))
+  .thenReturnObject(emp);
+```
+
+### `aggregate` → `thenReturnAggregation`
+
+```ts
+mockClient
+  .when((stub) =>
+    stub(Employee)
+      .where({ employeeId: { $eq: 5 } })
+      .aggregate({ $select: { "employeeLocation:exactDistinct": "asc" } })
+  )
+  .thenReturnAggregation({ employeeLocation: { exactDistinct: 3 } });
+```
+
+Stub `$groupBy` aggregations the same way — return an array of group rows:
+
+```ts
+mockClient
+  .when((stub) =>
+    stub(Employee).aggregate({
+      $select: { "employeeId:max": "unordered" },
+      $groupBy: { employeeId: "exact" },
+    })
+  )
+  .thenReturnAggregation([
+    { $group: { employeeId: 5 }, employeeId: { max: 5 } },
+  ]);
+```
+
+### Multiple stubs on the same client
+
+You can register as many stubs as you want. They're matched against the calls your code makes; the order you register them in doesn't matter beyond that.
+
+## `whenObjectSet` — calls on a `MockObjectSet` {#when-object-set}
+
+When code receives an `ObjectSet` directly (not built from `client(Type)`) — or when you're stubbing aggregate/fetch behavior for a many-link backed by a `MockObjectSet` — register stubs against the set itself.
+
+```ts
+import { createMockObjectSet } from "@osdk/functions-testing.experimental/experimental";
+
+const empSet = createMockObjectSet(Employee);
+const emp1 = createMockOsdkObject(Employee, {
+  employeeId: 1,
+  fullName: "Alice",
+});
+const emp2 = createMockOsdkObject(Employee, { employeeId: 2, fullName: "Bob" });
+
+mockClient
+  .whenObjectSet(empSet, (os) => os.fetchPage())
+  .thenReturnObjects([emp1, emp2]);
+
+mockClient
+  .whenObjectSet(
+    empSet,
+    (os) => os.aggregate({ $select: { $count: "unordered" } }),
+  )
+  .thenReturnAggregation({ $count: 42 });
+```
+
+The same `empSet` can then be passed wherever your code expects an `ObjectSet<Employee>` — to a function under test, or as a many-link target on a parent mock object.
+
+## `whenQuery` — Foundry queries
+
+Queries (functions on the ontology) have a dedicated registrar:
+
+```ts
+import { addOne } from "your-app-sdk";
+
+mockClient.whenQuery(addOne, { n: 5 }).thenReturn(6);
+mockClient.whenQuery(addOne, { n: 99 }).thenThrow(new Error("boom"));
+```
+
+`thenReturn(value)` resolves the query promise to `value`; `thenThrow(error)` rejects it. Different param objects can be stubbed independently:
+
+```ts
+mockClient.whenQuery(addOne, { n: 10 }).thenReturn(11);
+mockClient.whenQuery(addOne, { n: 20 }).thenReturn(21);
+```
+
+Queries with array params follow the same pattern — match the params your code passes:
+
+```ts
+mockClient
+  .whenQuery(queryTypeReturnsArray, { people: ["Alice", "Bob"] })
+  .thenReturn(["Alice - processed", "Bob - processed"]);
+```
+
+## How stub builders are picked
+
+The matcher you call (`thenReturnObjects` / `thenReturnObject` / `thenReturnAggregation`) is determined by the type of expression inside the `when` callback. Roughly:
+
+| Expression returns                                                            | Builder                   | Matcher                        |
+| ----------------------------------------------------------------------------- | ------------------------- | ------------------------------ |
+| `Promise<PageResult<T>>`, `AsyncIterableIterator<T>`, `Result<PageResult<T>>` | `FetchPageStubBuilder<T>` | `thenReturnObjects(items)`     |
+| `Promise<Osdk.Instance<T>>`, `Result<Osdk.Instance<T>>`                       | `FetchOneStubBuilder<T>`  | `thenReturnObject(obj)`        |
+| Anything else (aggregations, scalars)                                         | `AggregateStubBuilder<T>` | `thenReturnAggregation(value)` |
+
+The result-wrapped variants (`fetchPageWithErrors`, `fetchOneWithErrors`, etc.) resolve to the same builder as their non-`WithErrors` cousins — they carry the success branch through and are typed accordingly.
+
+## Resetting between tests
+
+`mockClient.clearStubs()` removes every stub registered on the client. Useful if you reuse a client across multiple `it` blocks; otherwise just construct a fresh `createMockClient()` per test for isolation.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -34,6 +34,12 @@ const sidebars: SidebarsConfig = {
     "react/cache-management",
     "react/platform-apis",
   ],
+  functionsTesting: [
+    "functions-testing/getting-started",
+    "functions-testing/mock-objects",
+    "functions-testing/stubbing-client-calls",
+    "functions-testing/platform-apis-with-msw",
+  ],
 };
 
 export default sidebars;


### PR DESCRIPTION
## Summary
- New "Functions Testing" navbar section on the Docusaurus site
- Pages: getting started, mock objects & links, stubbing client calls, platform APIs with MSW

## Test plan
- [x] `pnpm --filter @osdk/docs build` passes (no new broken anchors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)