### PR TITLE
Fix Action Form popovers in dialogs

### DIFF
--- a/.changeset/fuzzy-dialogs-close.md
+++ b/.changeset/fuzzy-dialogs-close.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Fix Action Form popover dismissal inside dialog portals.

--- a/packages/react-components-storybook/.storybook/styles.css
+++ b/packages/react-components-storybook/.storybook/styles.css
@@ -1,5 +1,6 @@
 @layer storybook, osdk.styles, cbac.components, themes;
 
+@import "@blueprintjs/core/lib/css/blueprint.css" layer(storybook);
 @import "../src/styles/storybook.css" layer(storybook);
 @import "@osdk/react-components/styles.css" layer(osdk.styles);
 @import "@osdk/cbac-components/styles.css" layer(cbac.components);

--- a/packages/react-components-storybook/package.json
+++ b/packages/react-components-storybook/package.json
@@ -21,6 +21,7 @@
     "msw-storybook-addon": "^2.0.0"
   },
   "devDependencies": {
+    "@blueprintjs/core": "^6.10.0",
     "@osdk/api": "workspace:*",
     "@osdk/cbac-components": "workspace:*",
     "@osdk/client": "workspace:*",

--- a/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
@@ -1036,7 +1036,7 @@ const blueprintDialogFormContent: ReadonlyArray<FormContentItem> = [
 ];
 
 function BlueprintDialogBaseForm(): React.ReactElement {
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
   const portalContainerRef = useRef<HTMLDivElement>(null);
 
   const handleOpen = useCallback(() => {

--- a/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Button, Dialog } from "@blueprintjs/core";
 import type { ObjectSet, ObjectTypeDefinition } from "@osdk/api";
 import type {
   FormContentItem,
@@ -22,7 +23,7 @@ import type {
 import { BaseForm } from "@osdk/react-components/experimental";
 import { useOsdkClient } from "@osdk/react/experimental";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import { fn } from "storybook/test";
 import { fauxFoundry } from "../../mocks/fauxFoundry.js";
 import { Employee } from "../../types/Employee.js";
@@ -979,6 +980,114 @@ export const WithDateTimePicker: Story = {
   formContent={formContent}
   onSubmit={(formState) => console.log("Submitted:", formState)}
 />`,
+      },
+    },
+  },
+};
+
+const blueprintDialogFormContent: ReadonlyArray<FormContentItem> = [
+  field({
+    fieldKey: "scheduledAt",
+    fieldComponent: "DATETIME_PICKER",
+    label: "Scheduled At",
+    fieldComponentProps: {
+      showTime: true,
+      placeholder: "Select date and time",
+    },
+  }),
+  field({
+    fieldKey: "deadline",
+    fieldComponent: "DATETIME_PICKER",
+    label: "Deadline",
+    fieldComponentProps: {
+      placeholder: "Select date",
+    },
+  }),
+  field({
+    fieldKey: "meetingWindow",
+    fieldComponent: "DATE_RANGE_INPUT",
+    label: "Meeting Window",
+    fieldComponentProps: {
+      showTime: true,
+      placeholderStart: "Start",
+      placeholderEnd: "End",
+    },
+  }),
+  field({
+    fieldKey: "department",
+    fieldComponent: "DROPDOWN",
+    label: "Department",
+    isRequired: true,
+    fieldComponentProps: {
+      items: DEPARTMENT_ITEMS,
+      placeholder: "Select department...",
+    },
+  }),
+  field({
+    fieldKey: "team",
+    fieldComponent: "DROPDOWN",
+    label: "Team",
+    fieldComponentProps: {
+      items: DEPARTMENT_ITEMS,
+      isSearchable: true,
+      placeholder: "Search teams...",
+    },
+  }),
+];
+
+function BlueprintDialogBaseForm(): React.ReactElement {
+  const [isOpen, setIsOpen] = useState(true);
+  const portalContainerRef = useRef<HTMLDivElement>(null);
+
+  const handleOpen = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  return (
+    <>
+      <Button text="Open dialog" onClick={handleOpen} />
+      <Dialog
+        className="osdkBlueprintDialogForm"
+        isOpen={isOpen}
+        onClose={handleClose}
+        title="Action form"
+      >
+        <div ref={portalContainerRef}>
+          <BaseForm
+            formContent={blueprintDialogFormContent}
+            onSubmit={handleSubmit}
+            portalContainer={portalContainerRef}
+          />
+        </div>
+      </Dialog>
+    </>
+  );
+}
+
+export const InsideBlueprintDialog: Story = {
+  render: () => <BlueprintDialogBaseForm />,
+  parameters: {
+    docs: {
+      source: {
+        code: `function BlueprintDialogBaseForm() {
+  const portalContainerRef = useRef(null);
+
+  return (
+    <Dialog isOpen={true} title="Action form">
+      <div ref={portalContainerRef}>
+        <BaseForm
+          formContent={formContent}
+          onSubmit={handleSubmit}
+          portalContainer={portalContainerRef}
+        />
+      </div>
+    </Dialog>
+  );
+}`,
       },
     },
   },

--- a/packages/react-components-storybook/src/styles/storybook.css
+++ b/packages/react-components-storybook/src/styles/storybook.css
@@ -85,6 +85,10 @@ body {
   margin-bottom: calc(var(--osdk-surface-spacing) * 4);
 }
 
+.osdkBlueprintDialogForm {
+  width: min(480px, calc(100vw - calc(var(--osdk-surface-spacing) * 8)));
+}
+
 .osdkCustomTextarea {
   width: 100%;
   min-height: calc(var(--osdk-surface-spacing) * 15);

--- a/packages/react-components/src/action-form/ActionForm.tsx
+++ b/packages/react-components/src/action-form/ActionForm.tsx
@@ -47,6 +47,7 @@ export const ActionForm: <Q extends ActionDefinition<unknown>>(
   onValidationResponse: _onValidationResponse,
   onSuccess,
   onError,
+  portalContainer,
 }: ActionFormProps<Q>): React.ReactElement {
   const { applyAction: osdkApplyAction, isPending } = useOsdkAction(
     actionDefinition,
@@ -160,6 +161,7 @@ export const ActionForm: <Q extends ActionDefinition<unknown>>(
     isPending,
     isLoading: metadataLoading,
     onFieldValueChange: handleFieldValueChange,
+    portalContainer,
   };
 
   if (!isControlled) {

--- a/packages/react-components/src/action-form/ActionFormApi.ts
+++ b/packages/react-components/src/action-form/ActionFormApi.ts
@@ -25,6 +25,7 @@ import type {
   FieldKey,
   FieldValueType,
   FormFieldDefinition,
+  PortalContainer,
   RendererFieldDefinition,
 } from "./FormFieldApi.js";
 
@@ -49,7 +50,11 @@ export type ActionFormProps<Q extends ActionDefinition<unknown>> =
   });
 
 interface ActionFormConfigProps<Q extends ActionDefinition<unknown>>
-  extends Pick<BaseFormProps, "formTitle" | "isSubmitDisabled">
+  extends
+    Pick<
+      BaseFormProps,
+      "formTitle" | "isSubmitDisabled" | "portalContainer"
+    >
 {
   actionDefinition: Q;
 
@@ -170,4 +175,10 @@ interface BaseFormCommonProps {
   submitButtonText?: string;
   /** Visual variant of the submit button. Default `"primary"`. */
   submitButtonVariant?: "primary" | "secondary";
+  /**
+   * Element that receives popover/dropdown portals for fields rendered by this
+   * form. Use this when rendering inside modal dialogs so popups stay in the
+   * dialog's stacking and focus context.
+   */
+  portalContainer?: PortalContainer;
 }

--- a/packages/react-components/src/action-form/BaseForm.tsx
+++ b/packages/react-components/src/action-form/BaseForm.tsx
@@ -41,6 +41,7 @@ export const BaseForm: React.FC<BaseFormProps> = memo(function BaseFormFn({
   className,
   submitButtonText = "Submit",
   submitButtonVariant = "primary",
+  portalContainer,
 }: BaseFormProps): React.ReactElement {
   const isControlled = controlledFormState != null;
 
@@ -151,6 +152,7 @@ export const BaseForm: React.FC<BaseFormProps> = memo(function BaseFormFn({
                 fieldDef={item.definition}
                 control={control}
                 onExternalChange={handleFieldChange}
+                portalContainer={portalContainer}
               />
             );
           }
@@ -170,6 +172,7 @@ export const BaseForm: React.FC<BaseFormProps> = memo(function BaseFormFn({
                   fieldDef={fieldDef}
                   control={control}
                   onExternalChange={handleFieldChange}
+                  portalContainer={portalContainer}
                 />
               ))}
             </FormSection>

--- a/packages/react-components/src/action-form/FormFieldApi.ts
+++ b/packages/react-components/src/action-form/FormFieldApi.ts
@@ -26,6 +26,12 @@ import type {
 } from "@osdk/api";
 import type React from "react";
 
+export type PortalContainer =
+  | HTMLElement
+  | ShadowRoot
+  | null
+  | React.RefObject<HTMLElement | ShadowRoot | null>;
+
 /**
  * A form field definition specifies configuration for a single field
  */
@@ -199,6 +205,13 @@ export interface DatetimePickerFieldProps extends BaseFormFieldProps<Date> {
    * Used to track portaled content for click-outside detection.
    */
   portalRef?: React.Ref<HTMLDivElement>;
+
+  /**
+   * Element that receives the date picker portal. Use this when rendering
+   * inside modal dialogs so popovers stay in the dialog's stacking and focus
+   * context instead of being appended directly to document.body.
+   */
+  portalContainer?: PortalContainer;
 }
 
 /**
@@ -242,6 +255,13 @@ export interface DateRangeInputFieldProps
 
   /** Parses a user-typed string back into a Date. */
   parseDate?: (text: string) => Date | undefined;
+
+  /**
+   * Element that receives the date range picker portal. Use this when rendering
+   * inside modal dialogs so popovers stay in the dialog's stacking and focus
+   * context instead of being appended directly to document.body.
+   */
+  portalContainer?: PortalContainer;
 }
 
 /**
@@ -294,6 +314,13 @@ export interface DropdownFieldProps<V, Multiple extends boolean = false>
    * Used to track portaled content for click-outside detection.
    */
   portalRef?: React.Ref<HTMLDivElement>;
+
+  /**
+   * Element that receives the dropdown portal. Use this when rendering inside
+   * modal dialogs so popups stay in the dialog's stacking and focus context
+   * instead of being appended directly to document.body.
+   */
+  portalContainer?: PortalContainer;
 
   /**
    * Controlled search input value. Must be provided together with `onQueryChange`.

--- a/packages/react-components/src/action-form/__tests__/BaseForm.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/BaseForm.test.tsx
@@ -174,6 +174,42 @@ describe("BaseForm", () => {
 
       expect(screen.getByRole("combobox")).toBeDefined();
     });
+
+    it("renders dropdown portals inside the form-level portal container", async () => {
+      const portalContainer = document.createElement("div");
+      document.body.append(portalContainer);
+
+      try {
+        render(
+          <BaseForm
+            formContent={[
+              field({
+                fieldKey: "color",
+                label: "Color",
+                fieldComponent: "DROPDOWN" as const,
+                fieldComponentProps: {
+                  items: ["Red", "Blue", "Green"],
+                },
+              }),
+            ]}
+            portalContainer={portalContainer}
+            onSubmit={vi.fn()}
+          />,
+        );
+
+        fireEvent.click(screen.getByRole("combobox"));
+
+        await waitFor(() => {
+          expect(
+            portalContainer.contains(screen.getByRole("option", {
+              name: "Red",
+            })),
+          ).toBe(true);
+        });
+      } finally {
+        portalContainer.remove();
+      }
+    });
   });
 
   describe("helper text", () => {

--- a/packages/react-components/src/action-form/__tests__/DateRangeInputField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/DateRangeInputField.test.tsx
@@ -412,7 +412,7 @@ describe("DateRangeInputField", () => {
       expect(screen.queryByRole("dialog")).toBeNull();
     });
 
-    it("blurs inputs when tabbing past end of popover", () => {
+    it("returns focus to the active input when tabbing past end of popover", () => {
       render(
         <DateRangeInputField
           value={[new Date(2024, 0, 15), null]}
@@ -434,9 +434,34 @@ describe("DateRangeInputField", () => {
       // Simulate Tab reaching the sentinel from inside the popover.
       fireEvent.focus(endSentinel, { relatedTarget: dialog });
 
-      expect(document.activeElement).not.toBe(startInput);
-      const endInput = screen.getByLabelText("End date");
-      expect(document.activeElement).not.toBe(endInput);
+      expect(document.activeElement).toBe(startInput);
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+
+    it("does not reopen the popover on the next Tab after boundary exit", () => {
+      render(
+        <DateRangeInputField
+          value={[new Date(2024, 0, 15), null]}
+          onChange={vi.fn()}
+        />,
+      );
+      const endInput = screen.getByLabelText("End date") as HTMLInputElement;
+      endInput.focus();
+      fireEvent.focus(endInput);
+      expect(document.activeElement).toBe(endInput);
+
+      const dialog = screen.getByRole("dialog");
+      const endSentinel = dialog.querySelector(
+        "[aria-label='End of date range picker dialog']",
+      ) as HTMLElement;
+
+      fireEvent.focus(endSentinel, { relatedTarget: dialog });
+      expect(document.activeElement).toBe(endInput);
+      expect(screen.queryByRole("dialog")).toBeNull();
+
+      fireEvent.keyDown(endInput, { key: "Tab" });
+
+      expect(screen.queryByRole("dialog")).toBeNull();
     });
 
     it("closes popover on Escape from end input", () => {

--- a/packages/react-components/src/action-form/__tests__/DateRangeInputField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/DateRangeInputField.test.tsx
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DateRangeInputField } from "../fields/DateRangeInputField.js";
 
@@ -90,6 +96,42 @@ describe("DateRangeInputField", () => {
       fireEvent.focus(endInput);
       expect(endInput.getAttribute("aria-expanded")).toBe("true");
       expect(screen.getByRole("dialog")).toBeDefined();
+    });
+
+    it("closes when clicking inside the portal container but outside the popover", async () => {
+      const portalContainer = document.createElement("div");
+      const outsideButton = document.createElement("button");
+      outsideButton.textContent = "Outside popover";
+      portalContainer.append(outsideButton);
+      document.body.append(portalContainer);
+
+      try {
+        render(
+          <DateRangeInputField
+            value={[null, null]}
+            onChange={vi.fn()}
+            portalContainer={portalContainer}
+          />,
+        );
+
+        fireEvent.focus(screen.getByLabelText("Start date"));
+        expect(screen.getByRole("dialog")).toBeDefined();
+
+        const dismissLayer = portalContainer.querySelector(
+          "[data-osdk-portal-dismiss-layer]",
+        );
+        if (!(dismissLayer instanceof HTMLElement)) {
+          throw new Error("Expected date picker dismiss layer to be rendered");
+        }
+
+        fireEvent.pointerDown(dismissLayer);
+
+        await waitFor(() => {
+          expect(screen.queryByRole("dialog")).toBeNull();
+        });
+      } finally {
+        portalContainer.remove();
+      }
     });
   });
 

--- a/packages/react-components/src/action-form/__tests__/DatetimePickerField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/DatetimePickerField.test.tsx
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DatetimePickerField } from "../fields/DatetimePickerField.js";
 
@@ -94,6 +100,65 @@ describe("DatetimePickerField", () => {
       expect(onChange).toHaveBeenCalledTimes(1);
       const calledDate: Date = onChange.mock.calls[0][0];
       expect(calledDate).toEqual(new Date(2024, 0, 20));
+    });
+
+    it("renders the popover portal inside the provided container", () => {
+      const portalContainer = document.createElement("div");
+      document.body.append(portalContainer);
+
+      try {
+        render(
+          <DatetimePickerField
+            value={new Date(2024, 0, 15)}
+            onChange={vi.fn()}
+            portalContainer={portalContainer}
+          />,
+        );
+
+        fireEvent.focus(screen.getByRole("combobox"));
+
+        expect(portalContainer.contains(screen.getByRole("dialog"))).toBe(
+          true,
+        );
+      } finally {
+        portalContainer.remove();
+      }
+    });
+
+    it("closes when clicking inside the portal container but outside the popover", async () => {
+      const portalContainer = document.createElement("div");
+      const outsideButton = document.createElement("button");
+      outsideButton.textContent = "Outside popover";
+      portalContainer.append(outsideButton);
+      document.body.append(portalContainer);
+
+      try {
+        render(
+          <DatetimePickerField
+            value={new Date(2024, 0, 15)}
+            onChange={vi.fn()}
+            portalContainer={portalContainer}
+          />,
+        );
+
+        fireEvent.focus(screen.getByRole("combobox"));
+        expect(screen.getByRole("dialog")).toBeDefined();
+
+        const dismissLayer = portalContainer.querySelector(
+          "[data-osdk-portal-dismiss-layer]",
+        );
+        if (!(dismissLayer instanceof HTMLElement)) {
+          throw new Error("Expected date picker dismiss layer to be rendered");
+        }
+
+        fireEvent.pointerDown(dismissLayer);
+
+        await waitFor(() => {
+          expect(screen.queryByRole("dialog")).toBeNull();
+        });
+      } finally {
+        portalContainer.remove();
+      }
     });
 
     it("preserves time when selecting a calendar day with showTime", () => {

--- a/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
@@ -311,6 +311,62 @@ describe("DropdownField", () => {
       });
     });
 
+    it("filters items to matching subset when searching", async () => {
+      render(
+        <DropdownField value={null} items={STRING_ITEMS} isSearchable={true} />,
+      );
+
+      fireEvent.click(screen.getByRole("combobox"));
+
+      await vi.waitFor(() => {
+        expect(screen.getByPlaceholderText("Search…")).toBeDefined();
+      });
+
+      fireEvent.change(screen.getByPlaceholderText("Search…"), {
+        target: { value: "Al" },
+      });
+
+      await vi.waitFor(() => {
+        expect(screen.getByRole("option", { name: "Alice" })).toBeDefined();
+        expect(screen.queryByRole("option", { name: "Bob" })).toBeNull();
+        expect(screen.queryByRole("option", { name: "Charlie" })).toBeNull();
+      });
+    });
+
+    it("filters items when portalContainer is set", async () => {
+      const portalContainer = document.createElement("div");
+      document.body.append(portalContainer);
+
+      try {
+        render(
+          <DropdownField
+            value={null}
+            items={STRING_ITEMS}
+            isSearchable={true}
+            portalContainer={portalContainer}
+          />,
+        );
+
+        fireEvent.click(screen.getByRole("combobox"));
+
+        await vi.waitFor(() => {
+          expect(screen.getByPlaceholderText("Search…")).toBeDefined();
+        });
+
+        fireEvent.change(screen.getByPlaceholderText("Search…"), {
+          target: { value: "Al" },
+        });
+
+        await vi.waitFor(() => {
+          expect(screen.getByRole("option", { name: "Alice" })).toBeDefined();
+          expect(screen.queryByRole("option", { name: "Bob" })).toBeNull();
+          expect(screen.queryByRole("option", { name: "Charlie" })).toBeNull();
+        });
+      } finally {
+        portalContainer.remove();
+      }
+    });
+
     it("marks selected items with aria-selected in multi-select", async () => {
       render(
         <DropdownField<string, true>

--- a/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
@@ -80,6 +80,56 @@ describe("DropdownField", () => {
 
       expect(screen.getByRole("combobox").textContent).toContain("Alice");
     });
+
+    it("renders the popup portal inside the provided container", async () => {
+      const portalContainer = document.createElement("div");
+      document.body.append(portalContainer);
+
+      try {
+        render(
+          <DropdownField
+            value={null}
+            items={STRING_ITEMS}
+            portalContainer={portalContainer}
+          />,
+        );
+
+        fireEvent.click(screen.getByRole("combobox"));
+
+        await vi.waitFor(() => {
+          expect(
+            portalContainer.contains(screen.getByRole("option", {
+              name: "Alice",
+            })),
+          ).toBe(true);
+        });
+      } finally {
+        portalContainer.remove();
+      }
+    });
+
+    it("closes when pressing the portal dismiss layer", async () => {
+      render(<DropdownField value={null} items={STRING_ITEMS} />);
+
+      fireEvent.click(screen.getByRole("combobox"));
+
+      await vi.waitFor(() => {
+        expect(screen.getByRole("option", { name: "Alice" })).toBeDefined();
+      });
+
+      const dismissLayer = document.querySelector(
+        "[data-osdk-portal-dismiss-layer]",
+      );
+      if (!(dismissLayer instanceof HTMLElement)) {
+        throw new Error("Expected dropdown dismiss layer to be rendered");
+      }
+
+      fireEvent.pointerDown(dismissLayer);
+
+      await vi.waitFor(() => {
+        expect(screen.queryByRole("option", { name: "Alice" })).toBeNull();
+      });
+    });
   });
 
   describe("multi select (Select variant)", () => {
@@ -171,6 +221,31 @@ describe("DropdownField", () => {
 
       await vi.waitFor(() => {
         expect(screen.getByPlaceholderText("Search…")).toBeDefined();
+      });
+    });
+
+    it("closes searchable popup when pressing the portal dismiss layer", async () => {
+      render(
+        <DropdownField value={null} items={STRING_ITEMS} isSearchable={true} />,
+      );
+
+      fireEvent.click(screen.getByRole("combobox"));
+
+      await vi.waitFor(() => {
+        expect(screen.getByRole("option", { name: "Alice" })).toBeDefined();
+      });
+
+      const dismissLayer = document.querySelector(
+        "[data-osdk-portal-dismiss-layer]",
+      );
+      if (!(dismissLayer instanceof HTMLElement)) {
+        throw new Error("Expected dropdown dismiss layer to be rendered");
+      }
+
+      fireEvent.pointerDown(dismissLayer);
+
+      await vi.waitFor(() => {
+        expect(screen.queryByRole("option", { name: "Alice" })).toBeNull();
       });
     });
 

--- a/packages/react-components/src/action-form/fields/DatePickerCommon.module.css
+++ b/packages/react-components/src/action-form/fields/DatePickerCommon.module.css
@@ -25,7 +25,17 @@
   }
 }
 
+.osdkDatePickerDismissLayer {
+  --osdk-portal-dismiss-layer-z-index: var(--osdk-datetime-popover-z-index);
+}
+
 /* Popover container */
+.osdkDatePickerPositioner {
+  /* Match the dismiss layer's dialog stack level so the later positioner stays
+     clickable above it without escalating z-index values. */
+  z-index: var(--osdk-datetime-popover-z-index);
+}
+
 .osdkDatePickerPopover {
   background: var(--osdk-datetime-popover-bg);
   padding: var(--osdk-datetime-popover-padding);

--- a/packages/react-components/src/action-form/fields/DateRangeInputField.tsx
+++ b/packages/react-components/src/action-form/fields/DateRangeInputField.tsx
@@ -33,6 +33,7 @@ import { stopPropagation } from "./calendarShared.js";
 import commonStyles from "./DatePickerCommon.module.css";
 import styles from "./DateRangeInputField.module.css";
 import { LazyDateRangeCalendar } from "./LazyDateRangeCalendar.js";
+import { PortalDismissLayer } from "./PortalDismissLayer.js";
 import { TimePicker } from "./TimePicker.js";
 import { useDateEditState } from "./useDateEditState.js";
 
@@ -63,6 +64,7 @@ export const DateRangeInputField: React.NamedExoticComponent<
   showTime = false,
   formatDate,
   parseDate,
+  portalContainer,
 }: DateRangeInputFieldProps) {
   const shouldCloseOnSelection = !showTime;
   const popoverId = useId();
@@ -407,7 +409,13 @@ export const DateRangeInputField: React.NamedExoticComponent<
   };
 
   return (
-    <Popover.Root open={isOpen} onOpenChange={handleOpenChange}>
+    <Popover.Root
+      open={isOpen}
+      onOpenChange={handleOpenChange}
+      // Uses pointer-down outside dismissal so the click that opens the picker
+      // is not reinterpreted after the portal dismiss layer appears.
+      modal="trap-focus"
+    >
       <Popover.Trigger
         nativeButton={false}
         render={<div className={styles.osdkDateRangeContainer} />}
@@ -457,8 +465,15 @@ export const DateRangeInputField: React.NamedExoticComponent<
           />
         </div>
       </Popover.Trigger>
-      <Popover.Portal>
-        <Popover.Positioner sideOffset={4}>
+      <Popover.Portal container={portalContainer}>
+        <PortalDismissLayer
+          className={commonStyles.osdkDatePickerDismissLayer}
+          onDismiss={closePopover}
+        />
+        <Popover.Positioner
+          className={commonStyles.osdkDatePickerPositioner}
+          sideOffset={4}
+        >
           <Popover.Popup
             ref={popoverRef}
             className={commonStyles.osdkDatePickerPopover}

--- a/packages/react-components/src/action-form/fields/DateRangeInputField.tsx
+++ b/packages/react-components/src/action-form/fields/DateRangeInputField.tsx
@@ -73,6 +73,10 @@ export const DateRangeInputField: React.NamedExoticComponent<
   const popoverRef = useRef<HTMLDivElement>(null);
 
   const [isOpen, setIsOpen] = useState(false);
+  // When focus returns to an input after Tab exits the popover boundary, the
+  // next input focus should not reopen the calendar before native Tab can
+  // continue to the following form field.
+  const skipReopenRef = useRef(false);
   // Tracks which input (start/end) owns the shared calendar popover.
   // Used to restore focus to the correct input when Tab-cycling through
   // focus boundaries and when the calendar selects a range endpoint.
@@ -168,17 +172,50 @@ export const DateRangeInputField: React.NamedExoticComponent<
 
   // --- Focus handlers ---
 
+  const getActiveInputRef = useCallback(
+    () => activeBoundary === "start" ? startInputRef : endInputRef,
+    [activeBoundary],
+  );
+
+  const beginEditing = useCallback(
+    (boundary: ActiveBoundary) => {
+      if (boundary === "start") {
+        beginStartEditing();
+      } else {
+        beginEndEditing();
+      }
+      setActiveBoundary(boundary);
+    },
+    [beginStartEditing, beginEndEditing],
+  );
+
+  const handleInputFocus = useCallback(
+    (boundary: ActiveBoundary) => {
+      beginEditing(boundary);
+      if (skipReopenRef.current) {
+        skipReopenRef.current = false;
+        return;
+      }
+      setIsOpen(true);
+    },
+    [beginEditing],
+  );
+
   const handleStartFocus = useCallback(() => {
-    beginStartEditing();
-    setActiveBoundary("start");
-    setIsOpen(true);
-  }, [beginStartEditing]);
+    handleInputFocus("start");
+  }, [handleInputFocus]);
 
   const handleEndFocus = useCallback(() => {
-    beginEndEditing();
-    setActiveBoundary("end");
-    setIsOpen(true);
-  }, [beginEndEditing]);
+    handleInputFocus("end");
+  }, [handleInputFocus]);
+
+  const closePopoverForBoundaryExit = useCallback(() => {
+    skipReopenRef.current = true;
+    setIsOpen(false);
+    stopStartEditing();
+    stopEndEditing();
+    getActiveInputRef().current?.focus();
+  }, [getActiveInputRef, stopStartEditing, stopEndEditing]);
 
   // --- Blur handlers ---
 
@@ -354,20 +391,20 @@ export const DateRangeInputField: React.NamedExoticComponent<
   // Start boundary (top): Shift+Tab past the first calendar element redirects
   // focus to whichever input is currently active.
   const handleStartFocusBoundary = useCallback(() => {
-    const activeRef = activeBoundary === "start" ? startInputRef : endInputRef;
-    activeRef.current?.focus();
-  }, [activeBoundary]);
+    getActiveInputRef().current?.focus();
+  }, [getActiveInputRef]);
 
   // End boundary (bottom): Two cases —
   // (1) Tab past the last calendar element (focus came from inside the popover)
-  //     → close the popover and blur both inputs.
+  //     → close the popover and return focus to the active input so the next
+  //       native Tab continues to the next form field.
   // (2) Focus entered from outside the popover (e.g. reverse Tab from the page)
   //     → redirect to the last interactive element inside the popover.
   const handleEndFocusBoundary = useCallback(
     (e: React.FocusEvent<HTMLDivElement>) => {
       const related = e.relatedTarget ?? document.activeElement;
       if (popoverRef.current?.contains(related as Node)) {
-        closePopover();
+        closePopoverForBoundaryExit();
       } else {
         const buttons = popoverRef.current?.querySelectorAll<HTMLElement>(
           "button, select",
@@ -376,7 +413,7 @@ export const DateRangeInputField: React.NamedExoticComponent<
         lastButton?.focus();
       }
     },
-    [closePopover],
+    [closePopoverForBoundaryExit],
   );
 
   // --- Calendar selected range ---

--- a/packages/react-components/src/action-form/fields/DatetimePickerField.tsx
+++ b/packages/react-components/src/action-form/fields/DatetimePickerField.tsx
@@ -32,6 +32,7 @@ import { stopPropagation } from "./calendarShared.js";
 import commonStyles from "./DatePickerCommon.module.css";
 import styles from "./DatetimePickerField.module.css";
 import { LazyDateCalendar } from "./LazyDateCalendar.js";
+import { PortalDismissLayer } from "./PortalDismissLayer.js";
 import { TimePicker } from "./TimePicker.js";
 import { useDateEditState } from "./useDateEditState.js";
 
@@ -50,6 +51,7 @@ export const DatetimePickerField: React.NamedExoticComponent<
   showTime = false,
   closeOnSelection,
   portalRef,
+  portalContainer,
 }: DatetimePickerFieldProps) {
   const shouldCloseOnSelection = closeOnSelection ?? !showTime;
   const popoverId = useId();
@@ -261,7 +263,13 @@ export const DatetimePickerField: React.NamedExoticComponent<
   );
 
   return (
-    <Popover.Root open={isOpen} onOpenChange={handleOpenChange}>
+    <Popover.Root
+      open={isOpen}
+      onOpenChange={handleOpenChange}
+      // Uses pointer-down outside dismissal so the click that opens the picker
+      // is not reinterpreted after the portal dismiss layer appears.
+      modal="trap-focus"
+    >
       <Popover.Trigger
         nativeButton={false}
         render={<div className={wrapperClassName} tabIndex={-1} />}
@@ -285,8 +293,15 @@ export const DatetimePickerField: React.NamedExoticComponent<
           aria-haspopup="dialog"
         />
       </Popover.Trigger>
-      <Popover.Portal ref={portalRef}>
-        <Popover.Positioner sideOffset={4}>
+      <Popover.Portal ref={portalRef} container={portalContainer}>
+        <PortalDismissLayer
+          className={commonStyles.osdkDatePickerDismissLayer}
+          onDismiss={closePopover}
+        />
+        <Popover.Positioner
+          className={commonStyles.osdkDatePickerPositioner}
+          sideOffset={4}
+        >
           <Popover.Popup
             ref={popoverRef}
             className={commonStyles.osdkDatePickerPopover}

--- a/packages/react-components/src/action-form/fields/DropdownField.module.css
+++ b/packages/react-components/src/action-form/fields/DropdownField.module.css
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.osdkSelectDismissLayer {
+  --osdk-portal-dismiss-layer-z-index: var(
+    --osdk-select-z-index,
+    var(--osdk-surface-z-index-3)
+  );
+}
+
+.osdkComboboxDismissLayer {
+  --osdk-portal-dismiss-layer-z-index: var(
+    --osdk-combobox-z-index,
+    var(--osdk-surface-z-index-3)
+  );
+}

--- a/packages/react-components/src/action-form/fields/DropdownField.tsx
+++ b/packages/react-components/src/action-form/fields/DropdownField.tsx
@@ -22,6 +22,8 @@ import { Select } from "../../base-components/select/Select.js";
 import selectStyles from "../../base-components/select/Select.module.css";
 import { typedReactMemo } from "../../shared/typedMemo.js";
 import type { DropdownFieldProps } from "../FormFieldApi.js";
+import dropdownStyles from "./DropdownField.module.css";
+import { PortalDismissLayer } from "./PortalDismissLayer.js";
 
 const EMPTY_ARRAY: [] = [];
 
@@ -125,6 +127,7 @@ const SelectDropdown = typedReactMemo(function SelectDropdownFn<
   isItemEqual,
   placeholder,
   portalRef,
+  portalContainer,
 }: InnerSelectProps<V, Multiple>): React.ReactElement {
   const [open, setOpen] = useState(false);
 
@@ -135,6 +138,10 @@ const SelectDropdown = typedReactMemo(function SelectDropdownFn<
     (onChange as ((v: V | null) => void) | undefined)?.(null);
     setOpen(false);
   }, [onChange]);
+
+  const handleDismiss = useCallback(() => {
+    setOpen(false);
+  }, []);
 
   return (
     <div>
@@ -170,7 +177,13 @@ const SelectDropdown = typedReactMemo(function SelectDropdownFn<
             <CaretDown />
           </span>
         </Select.Trigger>
-        <Select.Portal ref={portalRef}>
+        <Select.Portal ref={portalRef} container={portalContainer}>
+          {open && (
+            <PortalDismissLayer
+              className={dropdownStyles.osdkSelectDismissLayer}
+              onDismiss={handleDismiss}
+            />
+          )}
           <Select.Positioner>
             <Select.Popup>
               {items.map((item) => (
@@ -201,6 +214,7 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
   isSearchable,
   placeholder,
   portalRef,
+  portalContainer,
   query,
   onQueryChange,
   disableClientSideFiltering,
@@ -238,6 +252,10 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
     },
     [isMultiple, value, onChange, isItemEqual],
   );
+
+  const handleDismiss = useCallback(() => {
+    setOpen(false);
+  }, []);
 
   const renderItem = useCallback(
     (item: V) => (
@@ -323,7 +341,13 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
             <CaretDown />
           </Combobox.Icon>
         </Combobox.Trigger>
-        <Combobox.Portal ref={portalRef}>
+        <Combobox.Portal ref={portalRef} container={portalContainer}>
+          {open && (
+            <PortalDismissLayer
+              className={dropdownStyles.osdkComboboxDismissLayer}
+              onDismiss={handleDismiss}
+            />
+          )}
           <Combobox.Positioner>
             <Combobox.Popup>
               {isSearchable && (

--- a/packages/react-components/src/action-form/fields/DropdownField.tsx
+++ b/packages/react-components/src/action-form/fields/DropdownField.tsx
@@ -361,7 +361,9 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
                 <Combobox.Empty>No results</Combobox.Empty>
               )}
               <Combobox.List>
-                {items.map(renderItem)}
+                <Combobox.Collection>
+                  {renderItem}
+                </Combobox.Collection>
                 {trailingItem}
               </Combobox.List>
             </Combobox.Popup>

--- a/packages/react-components/src/action-form/fields/FieldBridge.tsx
+++ b/packages/react-components/src/action-form/fields/FieldBridge.tsx
@@ -19,6 +19,7 @@ import type { Control } from "react-hook-form";
 import { useController } from "react-hook-form";
 import type {
   FieldComponent,
+  PortalContainer,
   RendererFieldDefinition,
 } from "../FormFieldApi.js";
 import { extractValidationRules } from "../utils/extractValidationRules.js";
@@ -28,6 +29,7 @@ export interface FieldBridgeProps {
   fieldDef: RendererFieldDefinition;
   control: Control<Record<string, unknown>>;
   onExternalChange?: (fieldKey: string, value: unknown) => void;
+  portalContainer?: PortalContainer;
 }
 const SELECT_LIKE_FIELDS: ReadonlySet<FieldComponent> = new Set<FieldComponent>(
   [
@@ -41,6 +43,7 @@ export const FieldBridge: React.FC<FieldBridgeProps> = memo(
     fieldDef,
     control,
     onExternalChange,
+    portalContainer,
   }: FieldBridgeProps): React.ReactElement {
     const rules = useMemo(
       () => extractValidationRules(fieldDef),
@@ -92,6 +95,7 @@ export const FieldBridge: React.FC<FieldBridgeProps> = memo(
         onFieldValueChange={handleChange}
         onBlur={handleBlur}
         error={fieldError?.message}
+        portalContainer={portalContainer}
       />
     );
   },

--- a/packages/react-components/src/action-form/fields/FormFieldRenderer.tsx
+++ b/packages/react-components/src/action-form/fields/FormFieldRenderer.tsx
@@ -229,10 +229,7 @@ function resolvePortalContainer(
 ): PortalContainer | undefined {
   // A field-level value, including null, is an explicit override. That lets a
   // single field opt out of a form-level dialog portal when needed.
-  return Object.prototype.hasOwnProperty.call(
-      fieldComponentProps,
-      "portalContainer",
-    )
+  return Object.hasOwn(fieldComponentProps, "portalContainer")
     ? fieldComponentProps.portalContainer
     : formPortalContainer;
 }

--- a/packages/react-components/src/action-form/fields/FormFieldRenderer.tsx
+++ b/packages/react-components/src/action-form/fields/FormFieldRenderer.tsx
@@ -20,6 +20,7 @@ import { FormField } from "../FormField.js";
 import {
   type DateRange,
   EMPTY_RANGE,
+  type PortalContainer,
   type RendererFieldDefinition,
 } from "../FormFieldApi.js";
 import { CustomField } from "./CustomField.js";
@@ -40,6 +41,7 @@ export interface FormFieldRendererProps {
   onFieldValueChange: (value: unknown) => void;
   onBlur: (e: React.FocusEvent<HTMLDivElement>) => void;
   error: string | undefined;
+  portalContainer?: PortalContainer;
 }
 
 export const FormFieldRenderer: React.FC<FormFieldRendererProps> = memo(
@@ -49,6 +51,7 @@ export const FormFieldRenderer: React.FC<FormFieldRendererProps> = memo(
     onFieldValueChange,
     onBlur,
     error,
+    portalContainer,
   }: FormFieldRendererProps): React.ReactElement {
     const { label, isRequired, helperText, helperTextPlacement } =
       fieldDefinition;
@@ -68,6 +71,7 @@ export const FormFieldRenderer: React.FC<FormFieldRendererProps> = memo(
           value,
           onFieldValueChange,
           error,
+          portalContainer,
         )}
       </FormField>
     );
@@ -79,6 +83,7 @@ function renderFieldComponent(
   value: unknown,
   onChange: (value: unknown) => void,
   error: string | undefined,
+  portalContainer: PortalContainer | undefined,
 ): React.ReactElement {
   switch (fieldDefinition.fieldComponent) {
     case "DATE_RANGE_INPUT":
@@ -89,6 +94,10 @@ function renderFieldComponent(
           onChange={onChange}
           placeholderStart={fieldDefinition.placeholder}
           {...fieldDefinition.fieldComponentProps}
+          portalContainer={resolvePortalContainer(
+            fieldDefinition.fieldComponentProps,
+            portalContainer,
+          )}
         />
       );
     case "TEXT_INPUT":
@@ -122,6 +131,10 @@ function renderFieldComponent(
           placeholder={fieldDefinition.placeholder}
           error={error}
           {...fieldDefinition.fieldComponentProps}
+          portalContainer={resolvePortalContainer(
+            fieldDefinition.fieldComponentProps,
+            portalContainer,
+          )}
         />
       );
     }
@@ -135,6 +148,10 @@ function renderFieldComponent(
           onChange={onChange}
           error={error}
           {...fieldDefinition.fieldComponentProps}
+          portalContainer={resolvePortalContainer(
+            fieldDefinition.fieldComponentProps,
+            portalContainer,
+          )}
         />
       );
     case "RADIO_BUTTONS":
@@ -188,6 +205,10 @@ function renderFieldComponent(
           placeholder={fieldDefinition.placeholder}
           error={error}
           {...fieldDefinition.fieldComponentProps}
+          portalContainer={resolvePortalContainer(
+            fieldDefinition.fieldComponentProps,
+            portalContainer,
+          )}
         />
       );
     case "OBJECT_SET":
@@ -200,6 +221,20 @@ function renderFieldComponent(
     default:
       return assertUnreachableFieldComponent(fieldDefinition);
   }
+}
+
+function resolvePortalContainer(
+  fieldComponentProps: { portalContainer?: PortalContainer },
+  formPortalContainer: PortalContainer | undefined,
+): PortalContainer | undefined {
+  // A field-level value, including null, is an explicit override. That lets a
+  // single field opt out of a form-level dialog portal when needed.
+  return Object.prototype.hasOwnProperty.call(
+      fieldComponentProps,
+      "portalContainer",
+    )
+    ? fieldComponentProps.portalContainer
+    : formPortalContainer;
 }
 
 function coerceToDateRange(value: unknown): DateRange {

--- a/packages/react-components/src/action-form/fields/ObjectSelectField.tsx
+++ b/packages/react-components/src/action-form/fields/ObjectSelectField.tsx
@@ -43,6 +43,7 @@ export const ObjectSelectField: React.NamedExoticComponent<
   placeholder,
   isMultiple,
   portalRef,
+  portalContainer,
 }): React.ReactElement {
   // Tracks the user's search text. Cleared on selection so the selected
   // label (managed by base-ui) doesn't trigger a server-side search.
@@ -106,6 +107,7 @@ export const ObjectSelectField: React.NamedExoticComponent<
       placeholder={placeholder ?? "Search…"}
       isMultiple={isMultiple}
       portalRef={portalRef}
+      portalContainer={portalContainer}
       onQueryChange={setQuery}
       isLoading={isLoading}
       isSearching={debouncedQuery.trim() !== "" && isLoading}

--- a/packages/react-components/src/action-form/fields/PortalDismissLayer.module.css
+++ b/packages/react-components/src/action-form/fields/PortalDismissLayer.module.css
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.osdkPortalDismissLayer {
+  position: fixed;
+  inset-block-end: 0;
+  inset-block-start: 0;
+  inset-inline-end: 0;
+  inset-inline-start: 0;
+  z-index: var(
+    --osdk-portal-dismiss-layer-z-index,
+    var(--osdk-surface-z-index-3)
+  );
+  background-color: transparent;
+}

--- a/packages/react-components/src/action-form/fields/PortalDismissLayer.tsx
+++ b/packages/react-components/src/action-form/fields/PortalDismissLayer.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from "classnames";
+import React, { useCallback } from "react";
+import styles from "./PortalDismissLayer.module.css";
+
+interface PortalDismissLayerProps {
+  className?: string;
+  onDismiss: () => void;
+}
+
+export const PortalDismissLayer: React.NamedExoticComponent<
+  PortalDismissLayerProps
+> = React.memo(function PortalDismissLayer({
+  className,
+  onDismiss,
+}: PortalDismissLayerProps) {
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      // The layer exists only to close the popup; prevent label-triggered
+      // focus/click behavior from immediately reopening it.
+      event.preventDefault();
+      onDismiss();
+    },
+    [onDismiss],
+  );
+
+  return (
+    <div
+      aria-hidden="true"
+      className={classNames(styles.osdkPortalDismissLayer, className)}
+      data-osdk-portal-dismiss-layer=""
+      onPointerDown={handlePointerDown}
+    />
+  );
+});

--- a/packages/react-components/src/base-components/combobox/Combobox.tsx
+++ b/packages/react-components/src/base-components/combobox/Combobox.tsx
@@ -333,6 +333,7 @@ export const Combobox: {
   List: typeof ComboboxList;
   Item: typeof ComboboxItem;
   ItemIndicator: typeof ComboboxItemIndicator;
+  Collection: typeof BaseUICombobox.Collection;
   Chips: typeof ComboboxChips;
   Chip: typeof ComboboxChip;
   ChipRemove: typeof ComboboxChipRemove;
@@ -351,6 +352,7 @@ export const Combobox: {
   List: ComboboxList,
   Item: ComboboxItem,
   ItemIndicator: ComboboxItemIndicator,
+  Collection: BaseUICombobox.Collection,
   Chips: ComboboxChips,
   Chip: ComboboxChip,
   ChipRemove: ComboboxChipRemove,

--- a/packages/react-components/src/public/experimental/action-form.ts
+++ b/packages/react-components/src/public/experimental/action-form.ts
@@ -45,6 +45,7 @@ export type {
   NumberInputFieldProps,
   ObjectSetFieldProps,
   Option,
+  PortalContainer,
   RadioButtonsFieldProps,
   RendererFieldDefinition,
   TextAreaFieldProps,

--- a/packages/react-components/src/public/experimental/action-form.ts
+++ b/packages/react-components/src/public/experimental/action-form.ts
@@ -45,7 +45,6 @@ export type {
   NumberInputFieldProps,
   ObjectSetFieldProps,
   Option,
-  PortalContainer,
   RadioButtonsFieldProps,
   RendererFieldDefinition,
   TextAreaFieldProps,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4708,6 +4708,9 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0
     devDependencies:
+      '@blueprintjs/core':
+        specifier: ^6.10.0
+        version: 6.11.3(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@osdk/api':
         specifier: workspace:*
         version: link:../api

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4708,9 +4708,6 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0
     devDependencies:
-      '@blueprintjs/core':
-        specifier: ^6.10.0
-        version: 6.11.3(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@osdk/api':
         specifier: workspace:*
         version: link:../api
@@ -4772,6 +4769,9 @@ importers:
         specifier: ^2.0.0
         version: 2.0.6(msw@2.11.1(@types/node@20.19.13)(typescript@5.5.4))
     devDependencies:
+      '@blueprintjs/core':
+        specifier: ^6.10.0
+        version: 6.11.3(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@osdk/api':
         specifier: workspace:*
         version: link:../api


### PR DESCRIPTION
## Summary
- Thread Action Form portal containers through fields rendered inside Blueprint dialogs.
- Add a shared portal dismiss layer for date pickers and dropdowns so internal dialog clicks close popovers without reopening them.
- Extend the dialog Storybook story to cover date range picker behavior.

## Verification
- pnpm --filter @osdk/react-components test -- src/action-form/__tests__/DropdownField.test.tsx src/action-form/__tests__/DatetimePickerField.test.tsx src/action-form/__tests__/DateRangeInputField.test.tsx src/action-form/__tests__/BaseForm.test.tsx
- pnpm --filter @osdk/react-components lint
- pnpm --filter @osdk/react-components transpileBrowser
- Storybook and Playwright checks for dialog popup dismissal