### PR TITLE
fix package visibility for aip-core

### DIFF
--- a/.changeset/fix-package-visibility.md
+++ b/.changeset/fix-package-visibility.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-devtools": patch
----
-
-make package public so it ships to npm

--- a/.changeset/fix-package-visibility.md
+++ b/.changeset/fix-package-visibility.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+make package public so it ships to npm

--- a/.changeset/fix-package-visibility.md
+++ b/.changeset/fix-package-visibility.md
@@ -1,0 +1,5 @@
+---
+"@osdk/aip-core": patch
+---
+
+mark `@osdk/aip-core` as private to unblock the release pipeline; the package isn't ready to ship to npm yet

--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -118,6 +118,7 @@ const archetypeRules = archetypes(
   .addArchetype(
     "minimal packages",
     [
+      "@osdk/aip-core",
       "@osdk/e2e.generated.1.1.x",
       "@osdk/examples.*",
       "@psdk/examples.*",
@@ -134,7 +135,6 @@ const archetypeRules = archetypes(
   .addArchetype(
     "standardLibraries",
     [
-      "@osdk/aip-core",
       "@osdk/foundry-config-json",
       "@osdk/generator-converters",
       "@osdk/language-models",

--- a/packages/aip-core/package.json
+++ b/packages/aip-core/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@osdk/aip-core",
+  "private": true,
   "version": "0.2.0",
   "description": "Core building blocks for the AIP SDK: streaming chat completions, tool calling, and chat transports backed by the Foundry Language Model Service",
   "access": "public",

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -1,9 +1,7 @@
 {
   "name": "@osdk/react-devtools",
+  "private": true,
   "version": "0.4.0",
-  "publishConfig": {
-    "access": "public"
-  },
   "description": "Developer tools and debugging utilities for OSDK React Toolkit",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -1,7 +1,9 @@
 {
   "name": "@osdk/react-devtools",
-  "private": true,
   "version": "0.4.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "Developer tools and debugging utilities for OSDK React Toolkit",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
flip publish gating so aip-core stays internal until ready

• mark aip-core private so it's skipped by changesets and pnpm publish