### PR TITLE
downgrade react-ga changeset from major to minor

### DIFF
--- a/.changeset/react-ga.md
+++ b/.changeset/react-ga.md
@@ -1,5 +1,5 @@
 ---
-"@osdk/react": major
+"@osdk/react": minor
 "@osdk/client": minor
 "@osdk/react-components": patch
 "@osdk/react-devtools": patch
@@ -13,20 +13,20 @@ GA: promote modern hooks from `@osdk/react/experimental` to the main entry, rena
 - new stable entry point `@osdk/client/observable` exposes `createObservableClient`, `ObservableClient` (and its `CacheEntry`, `CacheSnapshot`, `CanonicalizedOptions`, `CanonicalizeOptionsInput`, `Observer`, `ObserveLinks`, `ObserveAggregationArgs`, `ObserveFunctionCallbackArgs`, `ObserveFunctionOptions`, `ObserveObjectCallbackArgs`, `ObserveObjectsCallbackArgs`, `ObserveObjectSetArgs`, `Unsubscribable` types), and the supporting `ActionSignatureFromDef`, `QueryParameterType`, `QueryReturnType` types
 - these symbols are still re-exported from `@osdk/client/unstable-do-not-use` as `@deprecated` shims; new code should import from `@osdk/client/observable`
 
-#### `@osdk/react` (major)
+#### `@osdk/react` (minor)
 
 - `OsdkProvider`, `useOsdkObjects`, `useOsdkObject`, `useOsdkAction`, `useLinks`, `useObjectSet`, `useOsdkAggregation`, `useOsdkFunction`, `useOsdkFunctions`, `useStableObjectSet`, `useRegisterUserAgent`, `useDebouncedCallback`, devtools registry re-exports are now exported directly from `@osdk/react`
 - admin / CBAC platform hooks (`useFoundryUser`, `useCurrentFoundryUser`, `useFoundryUsersList`, `useMarkings`, `useMarkingCategories`, `useUserViewMarkings`, `useCbacBanner`, `useCbacMarkingRestrictions`) now live at `@osdk/react/platform-apis` and still require the optional `@osdk/foundry.admin` + `@osdk/foundry.core` peers
 - the previous `OsdkProvider2` is now just `OsdkProvider`. The legacy `OsdkProvider` body is gone, but `useOsdkClient` and `useOsdkMetadata` keep working since the new provider supplies the same `client` shape
 - `<OsdkProvider>` no longer accepts an `observableClient` prop. The provider always derives its `ObservableClient` from `client` so the two cannot diverge. Tests that need to stub the observable layer should import `TestOsdkProvider` from `@osdk/react/testing`. `OsdkProvider2` (the deprecated alias) inherits this — it also no longer accepts `observableClient`
 - `useOsdkClient2` is unified into `useOsdkClient`; the unified hook now reads from the modern context (same `client` shape)
-- `peerDependencies` on `@osdk/api` and `@osdk/client` bump from `^2.8.0` to `^2.14.0` so `@osdk/react@1.0` cannot install against a `@osdk/client` that lacks the new `./observable` entry
+- `peerDependencies` on `@osdk/api` and `@osdk/client` resolve to `^2.15.0` so `@osdk/react@2.15` cannot install against a `@osdk/client` that lacks the new `./observable` entry
 
 #### `@osdk/react-components` (patch)
 
 - update internal imports for `@osdk/react` GA — `@osdk/react/experimental` → `@osdk/react` and `@osdk/react/experimental/admin` → `@osdk/react/platform-apis`
 - update `QueryParameterType` import from `@osdk/client/unstable-do-not-use` → `@osdk/client/observable`
-- bump `@osdk/react` peer range to `^1.0.0`
+- bump `@osdk/react` peer range to `^2.15.0`
 
 #### `@osdk/react-devtools` (patch)
 
@@ -38,7 +38,7 @@ GA: promote modern hooks from `@osdk/react/experimental` to the main entry, rena
 
 #### Compatibility shims
 
-These keep working in `@osdk/react@1.0` and `@osdk/client@2.14`, marked `@deprecated` so editors surface a strikethrough:
+These keep working in `@osdk/react@2.15` and `@osdk/client@2.15`, marked `@deprecated` so editors surface a strikethrough:
 
 - `import { ... } from "@osdk/react/experimental"` re-exports everything now exported from `@osdk/react`, plus `OsdkProvider as OsdkProvider2` and `useOsdkClient as useOsdkClient2`
 - `import { ... } from "@osdk/react/experimental/admin"` re-exports everything now exported from `@osdk/react/platform-apis`
@@ -56,7 +56,7 @@ For consumers upgrading from `@osdk/react@0.x`:
 - `<OsdkProvider2 ...>` → `<OsdkProvider ...>` (the modern provider takes the bare name)
 - if you were passing `observableClient={...}` to `<OsdkProvider>` or `<OsdkProvider2>` (in tests), import `TestOsdkProvider` from `@osdk/react/testing` and use that instead — production code does not need to change
 - `useOsdkClient2()` → `useOsdkClient()` (the unified hook reads from the modern context — same `client` shape, no API change at the call site)
-- bump `@osdk/client` and `@osdk/api` to `^2.14.0` to satisfy the new peer ranges
+- bump `@osdk/client` and `@osdk/api` to `^2.15.0` to satisfy the new peer ranges
 
 For consumers reaching directly into `@osdk/client/unstable-do-not-use` for observable APIs:
 


### PR DESCRIPTION
react-ga changeset declared @osdk/react as major, which combined with @osdk/react being in the @osdk/client fixed group dragged the whole group to 3.0.0 for future releases

• change @osdk/react bump in .changeset/react-ga.md from major to minor so the fixed group lands at 2.15.0 instead of 3.0.0
• update stale version references in the changeset body (^1.0.0 / ^2.14.0 / @osdk/react@1.0) to ^2.15.0 / @osdk/react@2.15

we will unpublish the errant 3.0.0 as well