### PR TITLE
extend peer-dep major-bump fix to changeset config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -53,5 +53,9 @@
   "snapshot": {
     "useCalculatedVersion": true,
     "prereleaseTemplate": "{tag}-{commit}"
+  },
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true,
+    "updateInternalDependents": "out-of-range"
   }
 }


### PR DESCRIPTION
Mirrors the peer-dep escalation fix from #2031 into `.changeset/config.json` so the snapshot/canary release path stops force-bumping the fixed group to a major when a peer dependent has a minor changeset

#2031 added these flags to `packages/tool.release/src/runVersion.ts` to prevent changesets' default behavior of escalating any minor changeset on a package with peer dependents into a major bump on those dependents. That fix however only applies to the stable release flow for creating release PRs. The snapshot job in `.github/workflows/release.yml` though uses the stock `pnpm exec changeset version --snapshot` CLI, which reads `.changeset/config.json` directly and gets the broken default / major computed bumps. That's why next-main canaries computed `3.0.0-main-...` for the entire @osdk/api / client / react fixed group when @osdk/react had a minor bump and `shouldBumpMajor` triggered on @osdk/react, moving the entire group forward in lockstep for snapshot/canary path.

• add `___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange` and `updateInternalDependents` to `.changeset/config.json` mirroring exactly what `runVersion.ts` already sets
• verified locally: `pnpm exec changeset version --snapshot main` now produces `2.15.0-main-...` for @osdk/api / client / react instead of `3.0.0-main-...`
• no behavior change for stable releases since our release code was already overriding with the same values