### PR TITLE
Break uploadMedia to return a Media object

### DIFF
--- a/.changeset/stupid-lizards-ask.md
+++ b/.changeset/stupid-lizards-ask.md
@@ -1,0 +1,6 @@
+---
+"@osdk/functions": patch
+"@osdk/client": patch
+---
+
+Modify uploadMedia to return a Media object

--- a/etc/functions.report.api.md
+++ b/etc/functions.report.api.md
@@ -10,6 +10,7 @@ import type { CompileTimeMetadata } from '@osdk/client';
 import { Geometry } from 'geojson';
 import type { GroupId as GroupId_2 } from '@osdk/foundry.core';
 import type { InterfaceDefinition } from '@osdk/client';
+import type { Media } from '@osdk/client';
 import { MediaReference } from '@osdk/client';
 import { MediaUpload } from '@osdk/client';
 import type { ObjectMetadata } from '@osdk/client';
@@ -254,7 +255,7 @@ export type TimestampISOString<T extends string = string> = T & {
 export { TwoDimensionalAggregation }
 
 // @public (undocumented)
-export function uploadMedia(client: Client, mediaUpload: MediaUpload): Promise<MediaReference>;
+export function uploadMedia(client: Client, mediaUpload: MediaUpload): Promise<Media>;
 
 // @public (undocumented)
 export interface UrlLinkTarget {

--- a/packages/client/src/createMediaFromReference.ts
+++ b/packages/client/src/createMediaFromReference.ts
@@ -17,10 +17,10 @@
 import type { Media, MediaMetadata, MediaReference } from "@osdk/api";
 import { MediaSets } from "@osdk/foundry.mediasets";
 import invariant from "tiny-invariant";
-import type { MinimalClient } from "./MinimalClientContext.js";
+import type { Client } from "./Client.js";
 
 export function createMediaFromReference(
-  client: MinimalClient,
+  client: Client,
   mediaReference: MediaReference,
 ): Media {
   const { mediaSetRid, mediaItemRid } =

--- a/packages/client/src/createMediaFromReference.ts
+++ b/packages/client/src/createMediaFromReference.ts
@@ -18,9 +18,21 @@ import type { Media, MediaMetadata, MediaReference } from "@osdk/api";
 import { MediaSets } from "@osdk/foundry.mediasets";
 import invariant from "tiny-invariant";
 import type { Client } from "./Client.js";
+import { additionalContext } from "./Client.js";
+import type { MinimalClient } from "./MinimalClientContext.js";
 
 export function createMediaFromReference(
   client: Client,
+  mediaReference: MediaReference,
+): Media {
+  return createMediaFromReferenceInternal(
+    client[additionalContext],
+    mediaReference,
+  );
+}
+
+export function createMediaFromReferenceInternal(
+  client: MinimalClient,
   mediaReference: MediaReference,
 ): Media {
   const { mediaSetRid, mediaItemRid } =

--- a/packages/client/src/queries/applyQuery.ts
+++ b/packages/client/src/queries/applyQuery.ts
@@ -31,7 +31,7 @@ import type {
 import type { DataValue } from "@osdk/foundry.ontologies";
 import * as Queries from "@osdk/foundry.ontologies/Query";
 import invariant from "tiny-invariant";
-import { createMediaFromReference } from "../createMediaFromReference.js";
+import { createMediaFromReferenceInternal } from "../createMediaFromReference.js";
 import type { MinimalClient } from "../MinimalClientContext.js";
 import { createObjectSet } from "../objectSet/createObjectSet.js";
 import { hydrateAttachmentFromRidInternal } from "../public-utils/hydrateAttachmentFromRid.js";
@@ -175,7 +175,7 @@ async function remapQueryResponse<
     }
 
     case "mediaReference": {
-      return createMediaFromReference(
+      return createMediaFromReferenceInternal(
         client,
         responseValue,
       ) as unknown as QueryReturnType<

--- a/packages/functions/src/helpers/uploadMedia.ts
+++ b/packages/functions/src/helpers/uploadMedia.ts
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-import type { Client, MediaReference, MediaUpload } from "@osdk/client";
+import type { Client, Media, MediaUpload } from "@osdk/client";
+import { createMediaFromReference } from "@osdk/client/internal";
 import { MediaSets } from "@osdk/foundry.mediasets";
 
 export async function uploadMedia(
   client: Client,
   mediaUpload: MediaUpload,
-): Promise<MediaReference> {
+): Promise<Media> {
   const gatewayMediaRef = await MediaSets.uploadMedia(
     client,
     mediaUpload.data,
@@ -30,7 +31,7 @@ export async function uploadMedia(
     },
   );
 
-  return {
+  return createMediaFromReference(client, {
     mimeType: gatewayMediaRef.mimeType,
     reference: {
       type: "mediaSetViewItem",
@@ -43,5 +44,5 @@ export async function uploadMedia(
         readToken: gatewayMediaRef.reference.mediaSetViewItem.token,
       },
     },
-  };
+  });
 }


### PR DESCRIPTION
uploadMedia helper used to return a MediaReference object. We wanted to update this to return a Media object.