### PR TITLE
Add experimental withFetch to scope a custom fetch per derived client

### DIFF
--- a/.changeset/scoped-fetch-experiment.md
+++ b/.changeset/scoped-fetch-experiment.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": minor
+---
+
+Add experimental `__EXPERIMENTAL__NOT_SUPPORTED_YET__withFetch` to scope a custom fetch to a derived client. The user-supplied fetch sits at the base of the wrap chain, so OSDK's auth, retry, and header layers still apply on top. Enables per-request `keepAlive`, `AbortSignal`, and custom headers without affecting the parent client.

--- a/etc/client.report.api.md
+++ b/etc/client.report.api.md
@@ -107,7 +107,7 @@ export interface Client extends SharedClient, OldSharedClient {
     // (undocumented)
     <Q extends QueryDefinition<any>>(o: Q): QuerySignatureFromDef<Q>;
     	// (undocumented)
-    <Q extends Experiment<"2.0.8"> | Experiment<"2.1.0"> | Experiment<"2.2.0"> | Experiment<"2.8.0">>(experiment: Q): ExperimentFns<Q>;
+    <Q extends Experiment<"2.0.8"> | Experiment<"2.1.0"> | Experiment<"2.2.0"> | Experiment<"2.8.0"> | Experiment<"2.13.0">>(experiment: Q): ExperimentFns<Q>;
     	// (undocumented)
     fetchMetadata<Q extends (ObjectTypeDefinition | InterfaceDefinition | ActionDefinition<any> | QueryDefinition<any>)>(o: Q): Promise<Q extends ObjectTypeDefinition ? ObjectMetadata : Q extends InterfaceDefinition ? InterfaceMetadata : Q extends ActionDefinition<any> ? ActionMetadata : Q extends QueryDefinition<any> ? QueryMetadata : never>;
 }

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -74,7 +74,8 @@ export interface Client extends SharedClient, OldSharedClient {
       | Experiment<"2.0.8">
       | Experiment<"2.1.0">
       | Experiment<"2.2.0">
-      | Experiment<"2.8.0">,
+      | Experiment<"2.8.0">
+      | Experiment<"2.13.0">,
   >(
     experiment: Q,
   ): ExperimentFns<Q>;

--- a/packages/client/src/MinimalClientContext.ts
+++ b/packages/client/src/MinimalClientContext.ts
@@ -50,6 +50,8 @@ export interface MinimalClient extends SharedClientContext {
   clientCacheKey: ClientCacheKey;
   requestContext: RequestContext;
   narrowTypeInterfaceOrObjectMapping: Record<string, "object" | "interface">;
+  /** @internal */
+  withFetch: (fetchFn: typeof globalThis.fetch) => MinimalClient;
 }
 
 export type MinimalClientParams = {

--- a/packages/client/src/createClient.ts
+++ b/packages/client/src/createClient.ts
@@ -50,6 +50,7 @@ import type { ActionSignatureFromDef } from "./actions/applyAction.js";
 import { applyAction } from "./actions/applyAction.js";
 import { additionalContext, type Client } from "./Client.js";
 import { createMinimalClient } from "./createMinimalClient.js";
+import { __EXPERIMENTAL__NOT_SUPPORTED_YET__withFetch } from "./experimental/withFetch.js";
 import { fetchMetadataInternal } from "./fetchMetadata.js";
 import { makeMediaTransformation } from "./internal/conversions/makeMediaTransformation.js";
 import { MinimalLogger } from "./logger/MinimalLogger.js";
@@ -162,13 +163,17 @@ export function createClientFromContext(clientCtx: MinimalClient) {
       | QueryDefinition<any>
       | Experiment<"2.0.8">
       | Experiment<"2.1.0">
-      | Experiment<"2.8.0">,
+      | Experiment<"2.8.0">
+      | Experiment<"2.13.0">,
   >(o: T): T extends ObjectTypeDefinition ? ObjectSet<T>
     : T extends InterfaceDefinition ? MinimalObjectSet<T>
     : T extends ActionDefinition<any> ? ActionSignatureFromDef<T>
     : T extends QueryDefinition<any> ? QuerySignatureFromDef<T>
-    : T extends Experiment<"2.0.8"> | Experiment<"2.1.0"> | Experiment<"2.8.0">
-      ? { invoke: ExperimentFns<T> }
+    : T extends
+      | Experiment<"2.0.8">
+      | Experiment<"2.1.0">
+      | Experiment<"2.8.0">
+      | Experiment<"2.13.0"> ? { invoke: ExperimentFns<T> }
     : never
   {
     if (o.type === "object" || o.type === "interface") {
@@ -318,6 +323,14 @@ export function createClientFromContext(clientCtx: MinimalClient) {
                 args.options,
               );
             },
+          } as any;
+
+        case __EXPERIMENTAL__NOT_SUPPORTED_YET__withFetch.name:
+          // Caches are not shared amongst newly created clients, which
+          // can lead to duplicated metadata calls amongst repeated calls
+          return {
+            withFetch: (fetchFn: typeof globalThis.fetch): Client =>
+              createClientFromContext(clientCtx.withFetch(fetchFn)),
           } as any;
       }
 

--- a/packages/client/src/createMinimalClient.ts
+++ b/packages/client/src/createMinimalClient.ts
@@ -85,6 +85,16 @@ export function createMinimalClient(
     requestContext: {},
     branch: options.branch,
     narrowTypeInterfaceOrObjectMapping: {},
+    withFetch: (newFetchFn) =>
+      createMinimalClient(
+        metadata,
+        baseUrl,
+        tokenProvider,
+        options,
+        newFetchFn,
+        objectSetFactory,
+        createOntologyProviderFactory,
+      ),
   } satisfies Omit<
     MinimalClient,
     "ontologyProvider"

--- a/packages/client/src/experimental/withFetch.test.ts
+++ b/packages/client/src/experimental/withFetch.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BarInterface } from "@osdk/client.test.ontology";
+import type { MockedFunction } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Client } from "../Client.js";
+import { createClient } from "../createClient.js";
+import { mockFetchResponse } from "../createClient.test.js";
+import { __EXPERIMENTAL__NOT_SUPPORTED_YET__withFetch } from "./withFetch.js";
+
+describe(__EXPERIMENTAL__NOT_SUPPORTED_YET__withFetch.name, () => {
+  let parentFetch: MockedFunction<typeof globalThis.fetch>;
+  let client: Client;
+
+  beforeEach(() => {
+    parentFetch = vi.fn();
+    client = createClient(
+      "https://mock.com",
+      "ri.not.important",
+      async () => "Token",
+      undefined,
+      parentFetch,
+    );
+  });
+
+  it("routes scoped calls through the user-supplied fetch", async () => {
+    const scopedFetch = vi.fn<typeof globalThis.fetch>();
+    mockFetchResponse(scopedFetch, { data: [] });
+
+    const { withFetch } = client(__EXPERIMENTAL__NOT_SUPPORTED_YET__withFetch);
+    const scoped = withFetch(scopedFetch);
+
+    await scoped(BarInterface).fetchPage();
+
+    expect(scopedFetch).toHaveBeenCalledTimes(1);
+    expect(parentFetch).not.toHaveBeenCalled();
+  });
+
+  it("preserves auth and user-agent headers when wrapping", async () => {
+    const scopedFetch = vi.fn<typeof globalThis.fetch>();
+    mockFetchResponse(scopedFetch, { data: [] });
+
+    const { withFetch } = client(__EXPERIMENTAL__NOT_SUPPORTED_YET__withFetch);
+    await withFetch(scopedFetch)(BarInterface).fetchPage();
+
+    const headers = scopedFetch.mock.calls[0][1]?.headers as Headers;
+    expect(headers.get("Authorization")).toBe("Bearer Token");
+    expect(headers.get("Fetch-User-Agent")).toBeTruthy();
+  });
+
+  it("does not affect the parent client", async () => {
+    const scopedFetch = vi.fn<typeof globalThis.fetch>();
+    const { withFetch } = client(__EXPERIMENTAL__NOT_SUPPORTED_YET__withFetch);
+    withFetch(scopedFetch);
+
+    mockFetchResponse(parentFetch, { data: [] });
+    await client(BarInterface).fetchPage();
+
+    expect(parentFetch).toHaveBeenCalledTimes(1);
+    expect(scopedFetch).not.toHaveBeenCalled();
+  });
+
+  it("lets the user fetch inject RequestInit fields like signal and keepAlive", async () => {
+    const ctrl = new AbortController();
+    const baseFetch = vi.fn<typeof globalThis.fetch>();
+    mockFetchResponse(baseFetch, { data: [] });
+
+    const { withFetch } = client(__EXPERIMENTAL__NOT_SUPPORTED_YET__withFetch);
+    const scoped = withFetch((url, init) =>
+      baseFetch(url, { ...init, signal: ctrl.signal, keepalive: true })
+    );
+
+    await scoped(BarInterface).fetchPage();
+
+    const seenInit = baseFetch.mock.calls[0][1];
+    expect(seenInit?.signal).toBe(ctrl.signal);
+    expect(seenInit?.keepalive).toBe(true);
+  });
+});

--- a/packages/client/src/experimental/withFetch.ts
+++ b/packages/client/src/experimental/withFetch.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Experiment } from "@osdk/api/unstable";
+import type { Client } from "../Client.js";
+
+/**
+ * @experimental This feature is experimental and might change in the future.
+ *
+ * Returns a new {@link Client} whose injected `fetch` is the supplied function.
+ * The user-supplied fetch sits at the **base** of the wrap chain — OSDK's auth,
+ * retry, and header wrappers still run on top before delegating to it.
+ *
+ * Use this to apply per-request behavior without mutating the parent client:
+ * `keepAlive`, `AbortSignal`, custom headers, etc.
+ *
+ * @example
+ * ```ts
+ * const { withFetch } = client(__EXPERIMENTAL__NOT_SUPPORTED_YET__withFetch);
+ *
+ * const ctrl = new AbortController();
+ * const scoped = withFetch((url, init) =>
+ *   fetch(url, { ...init, signal: ctrl.signal }),
+ * );
+ * scoped(MyAction).applyAction(args);
+ * ctrl.abort();
+ * ```
+ */
+type withFetchFn = (fetchFn: typeof globalThis.fetch) => Client;
+
+export const __EXPERIMENTAL__NOT_SUPPORTED_YET__withFetch: Experiment<
+  "2.13.0",
+  "__EXPERIMENTAL__NOT_SUPPORTED_YET__withFetch",
+  { withFetch: withFetchFn }
+> = {
+  name: "__EXPERIMENTAL__NOT_SUPPORTED_YET__withFetch",
+  type: "experiment",
+  version: "2.13.0",
+};

--- a/packages/client/src/observable/internal/testUtils.ts
+++ b/packages/client/src/observable/internal/testUtils.ts
@@ -220,6 +220,7 @@ export function createClientMockHelper(): MockClientHelper {
     requestContext: {},
     logger,
     narrowTypeInterfaceOrObjectMapping: {},
+    withFetch: vitest.fn(),
   };
   client.fetchMetadata = vitest.fn();
 

--- a/packages/client/src/public/unstable-do-not-use.ts
+++ b/packages/client/src/public/unstable-do-not-use.ts
@@ -24,6 +24,7 @@ export {
 export type { OsdkConfig } from "../public-utils/osdkConfig.js";
 
 export { createClientWithTransaction } from "../createClient.js";
+export { __EXPERIMENTAL__NOT_SUPPORTED_YET__withFetch } from "../experimental/withFetch.js";
 
 export {
   applyShapeTransformations,


### PR DESCRIPTION
## Summary
- New `__EXPERIMENTAL__NOT_SUPPORTED_YET__withFetch` exported from `@osdk/client/unstable-do-not-use`. `client(__EXPERIMENTAL__NOT_SUPPORTED_YET__withFetch).withFetch(fn)` returns a derived `Client` whose injected fetch wraps OSDK's auth/retry/header layers — the user fetch sits at the **base** of the chain.
- Enables per-request `keepAlive`, `AbortSignal`, custom headers etc. without affecting the parent client. Subsumes the motivating asks for a per-action `keepAlive` flag and per-request cancellation.
- Implementation: adds a `withFetch` field to `MinimalClient` that recursively rebuilds via `createMinimalClient` with the new fetch as base. Each scoped client is independent — caches (ontology metadata, observable state, `clientCacheKey`) are not shared with the parent. Acceptable for an experimental API; cache sharing is a follow-up.

## Test plan
- [x] `pnpm turbo typecheck --filter=@osdk/client --filter=@osdk/api` passes
- [x] `pnpm turbo transpile` (all 237 tasks) passes
- [x] `pnpm turbo check-api --filter=@osdk/client --filter=@osdk/api` regenerates report, only the `Experiment<"2.13.0">` overload appears
- [x] New test file `packages/client/src/experimental/withFetch.test.ts` covers: scoped routing, auth/user-agent header preservation, parent isolation, RequestInit injection (signal + keepAlive)
- [x] Full client test suite (770 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)