### PR TITLE
filter-list: stop refetching aggregations when any filter changes

### DIFF
--- a/.changeset/filter-list-stable-render-input.md
+++ b/.changeset/filter-list-stable-render-input.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Stabilize per-filter where-clause references inside `useFilterListState` via deep-equality caching, so `FilterInput.memo` holds when the cross-filter context for a given filter is unchanged across selections. Eliminates redundant aggregation requests on every value selection. Internal-only — no public API changes.

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -123,6 +123,7 @@
     "@tanstack/react-virtual": "^3.13.13",
     "date-fns": "^2.28.0",
     "date-fns-tz": "^2.0.0",
+    "fast-deep-equal": "^3.1.3",
     "lodash-es": "^4.17.21",
     "pdfjs-dist": "~4.8.69",
     "react-day-picker": "^8.10.0",

--- a/packages/react-components/src/filter-list/hooks/__tests__/useFilterListState.test.tsx
+++ b/packages/react-components/src/filter-list/hooks/__tests__/useFilterListState.test.tsx
@@ -419,4 +419,102 @@ describe("useFilterListState", () => {
       $and: [{ name: "John" }, { active: true }],
     });
   });
+
+  describe("perFilterWhereClauses ref stability", () => {
+    it(
+      "preserves the entry reference for the just-changed filter (its excluding-self clause is unchanged)",
+      () => {
+        const nameDef = createPropertyFilterDef(
+          "name",
+          "LISTOGRAM",
+          createExactMatchState([]),
+        );
+        const activeDef = createPropertyFilterDef(
+          "active",
+          "TOGGLE",
+          createToggleState(false),
+        );
+        const props = createProps({
+          filterDefinitions: [nameDef, activeDef],
+        });
+        const { result } = renderHook(() => useFilterListState(props));
+        const nameKey = getFilterKey(nameDef);
+
+        const beforeName = result.current.perFilterWhereClauses.get(nameKey);
+        expect(beforeName).toBeDefined();
+
+        act(() => {
+          result.current.setFilterState(
+            nameKey,
+            createExactMatchState(["John"]),
+          );
+        });
+
+        const afterName = result.current.perFilterWhereClauses.get(nameKey);
+        expect(afterName).toBe(beforeName);
+      },
+    );
+
+    it(
+      "rebuilds the entry reference for sibling filters whose excluding-self clause content changed",
+      () => {
+        const nameDef = createPropertyFilterDef(
+          "name",
+          "LISTOGRAM",
+          createExactMatchState([]),
+        );
+        const activeDef = createPropertyFilterDef(
+          "active",
+          "TOGGLE",
+          createToggleState(false),
+        );
+        const props = createProps({
+          filterDefinitions: [nameDef, activeDef],
+        });
+        const { result } = renderHook(() => useFilterListState(props));
+        const nameKey = getFilterKey(nameDef);
+        const activeKey = getFilterKey(activeDef);
+
+        const beforeActive = result.current.perFilterWhereClauses.get(
+          activeKey,
+        );
+
+        act(() => {
+          result.current.setFilterState(
+            nameKey,
+            createExactMatchState(["John"]),
+          );
+        });
+
+        const afterActive = result.current.perFilterWhereClauses.get(activeKey);
+        expect(afterActive).not.toBe(beforeActive);
+        expect(afterActive).toEqual({ name: "John" });
+      },
+    );
+
+    it(
+      "preserves entry references when an unrelated re-render occurs without state changes",
+      () => {
+        const nameDef = createPropertyFilterDef(
+          "name",
+          "LISTOGRAM",
+          createExactMatchState([]),
+        );
+        const props = createProps({
+          filterDefinitions: [nameDef],
+        });
+        const { result, rerender } = renderHook(
+          () => useFilterListState(props),
+        );
+        const nameKey = getFilterKey(nameDef);
+
+        const before = result.current.perFilterWhereClauses.get(nameKey);
+
+        rerender();
+
+        const after = result.current.perFilterWhereClauses.get(nameKey);
+        expect(after).toBe(before);
+      },
+    );
+  });
 });

--- a/packages/react-components/src/filter-list/hooks/__tests__/useFilterListState.test.tsx
+++ b/packages/react-components/src/filter-list/hooks/__tests__/useFilterListState.test.tsx
@@ -491,30 +491,5 @@ describe("useFilterListState", () => {
         expect(afterActive).toEqual({ name: "John" });
       },
     );
-
-    it(
-      "preserves entry references when an unrelated re-render occurs without state changes",
-      () => {
-        const nameDef = createPropertyFilterDef(
-          "name",
-          "LISTOGRAM",
-          createExactMatchState([]),
-        );
-        const props = createProps({
-          filterDefinitions: [nameDef],
-        });
-        const { result, rerender } = renderHook(
-          () => useFilterListState(props),
-        );
-        const nameKey = getFilterKey(nameDef);
-
-        const before = result.current.perFilterWhereClauses.get(nameKey);
-
-        rerender();
-
-        const after = result.current.perFilterWhereClauses.get(nameKey);
-        expect(after).toBe(before);
-      },
-    );
   });
 });

--- a/packages/react-components/src/filter-list/hooks/useFilterListState.ts
+++ b/packages/react-components/src/filter-list/hooks/useFilterListState.ts
@@ -193,11 +193,7 @@ export function useFilterListState<Q extends ObjectTypeDefinition>(
 
   const perFilterWhereClauses = useMemo(() => {
     const next = new Map<string, WhereClause<Q>>();
-    if (!filterDefinitions) {
-      previousClausesRef.current = next;
-      return next;
-    }
-    for (const definition of filterDefinitions) {
+    for (const definition of filterDefinitions ?? []) {
       const key = getFilterKey(definition);
       const fresh = buildWhereClause(
         filterDefinitions,
@@ -206,11 +202,7 @@ export function useFilterListState<Q extends ObjectTypeDefinition>(
         key,
       );
       const prev = previousClausesRef.current.get(key);
-      if (prev != null && isEqual(prev, fresh)) {
-        next.set(key, prev);
-      } else {
-        next.set(key, fresh);
-      }
+      next.set(key, prev != null && isEqual(prev, fresh) ? prev : fresh);
     }
     previousClausesRef.current = next;
     return next;

--- a/packages/react-components/src/filter-list/hooks/useFilterListState.ts
+++ b/packages/react-components/src/filter-list/hooks/useFilterListState.ts
@@ -16,6 +16,7 @@
 
 import type { ObjectTypeDefinition, WhereClause } from "@osdk/api";
 import { useOsdkMetadata } from "@osdk/react";
+import { isEqual } from "lodash-es";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { assertUnreachable } from "../../shared/assertUnreachable.js";
 import type { FilterListProps } from "../FilterListApi.js";
@@ -186,24 +187,33 @@ export function useFilterListState<Q extends ObjectTypeDefinition>(
     onFilterClauseChangedRef.current?.(whereClause);
   }, [whereClause]);
 
+  // Preserve per-key clause references when content hasn't changed so
+  // FilterInput.memo can hold and aggregations don't refetch unnecessarily.
+  const previousClausesRef = useRef<Map<string, WhereClause<Q>>>(new Map());
+
   const perFilterWhereClauses = useMemo(() => {
-    const map = new Map<string, WhereClause<Q>>();
+    const next = new Map<string, WhereClause<Q>>();
     if (!filterDefinitions) {
-      return map;
+      previousClausesRef.current = next;
+      return next;
     }
     for (const definition of filterDefinitions) {
       const key = getFilterKey(definition);
-      map.set(
+      const fresh = buildWhereClause(
+        filterDefinitions,
+        filterStates,
+        propertyTypes,
         key,
-        buildWhereClause(
-          filterDefinitions,
-          filterStates,
-          propertyTypes,
-          key,
-        ),
       );
+      const prev = previousClausesRef.current.get(key);
+      if (prev != null && isEqual(prev, fresh)) {
+        next.set(key, prev);
+      } else {
+        next.set(key, fresh);
+      }
     }
-    return map;
+    previousClausesRef.current = next;
+    return next;
   }, [filterDefinitions, filterStates, propertyTypes]);
 
   const activeFilterCount = useMemo(() => {

--- a/packages/react-components/src/filter-list/hooks/useFilterListState.ts
+++ b/packages/react-components/src/filter-list/hooks/useFilterListState.ts
@@ -16,7 +16,6 @@
 
 import type { ObjectTypeDefinition, WhereClause } from "@osdk/api";
 import { useOsdkMetadata } from "@osdk/react";
-import { isEqual } from "lodash-es";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { assertUnreachable } from "../../shared/assertUnreachable.js";
 import type { FilterListProps } from "../FilterListApi.js";
@@ -28,6 +27,7 @@ import {
 } from "../utils/filterStateToWhereClause.js";
 import { filterHasActiveState } from "../utils/filterValues.js";
 import { getFilterKey } from "../utils/getFilterKey.js";
+import { useStableMapEntries } from "./useStableMapEntries.js";
 
 export interface UseFilterListStateResult<Q extends ObjectTypeDefinition> {
   filterStates: Map<string, FilterState>;
@@ -189,24 +189,24 @@ export function useFilterListState<Q extends ObjectTypeDefinition>(
 
   // Preserve per-key clause references when content hasn't changed so
   // FilterInput.memo can hold and aggregations don't refetch unnecessarily.
-  const previousClausesRef = useRef<Map<string, WhereClause<Q>>>(new Map());
-
-  const perFilterWhereClauses = useMemo(() => {
-    const next = new Map<string, WhereClause<Q>>();
-    for (const definition of filterDefinitions ?? []) {
-      const key = getFilterKey(definition);
-      const fresh = buildWhereClause(
-        filterDefinitions,
-        filterStates,
-        propertyTypes,
-        key,
-      );
-      const prev = previousClausesRef.current.get(key);
-      next.set(key, prev != null && isEqual(prev, fresh) ? prev : fresh);
-    }
-    previousClausesRef.current = next;
-    return next;
-  }, [filterDefinitions, filterStates, propertyTypes]);
+  const perFilterWhereClauses = useStableMapEntries(
+    useMemo(() => {
+      const map = new Map<string, WhereClause<Q>>();
+      for (const definition of filterDefinitions ?? []) {
+        const key = getFilterKey(definition);
+        map.set(
+          key,
+          buildWhereClause(
+            filterDefinitions,
+            filterStates,
+            propertyTypes,
+            key,
+          ),
+        );
+      }
+      return map;
+    }, [filterDefinitions, filterStates, propertyTypes]),
+  );
 
   const activeFilterCount = useMemo(() => {
     let count = 0;

--- a/packages/react-components/src/filter-list/hooks/useStableMapEntries.ts
+++ b/packages/react-components/src/filter-list/hooks/useStableMapEntries.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import deepEqual from "fast-deep-equal";
+import { useRef } from "react";
+
+/**
+ * Returns a Map whose per-key values keep their previous reference when their
+ * contents are structurally equal to the prior frame. Lets memoized children
+ * keyed off individual entries skip work when only sibling entries changed.
+ */
+export function useStableMapEntries<K, V>(input: Map<K, V>): Map<K, V> {
+  const ref = useRef<Map<K, V>>(new Map());
+  const next = new Map<K, V>();
+  for (const [key, value] of input) {
+    const prev = ref.current.get(key);
+    next.set(key, prev !== undefined && deepEqual(prev, value) ? prev : value);
+  }
+  ref.current = next;
+  return next;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,10 +65,10 @@ importers:
         version: 7.1.17(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@19.1.1))(react@19.1.1)
       '@vitejs/plugin-react':
         specifier: ^4.7.0
-        version: 4.7.0(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.3)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.3))
+        version: 4.7.0(vite@8.0.8(@types/node@24.12.0)(esbuild@0.25.9)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.3))
       '@vitejs/plugin-vue':
         specifier: ^5.2.4
-        version: 5.2.4(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.3)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.3))(vue@3.5.21(typescript@5.5.4))
+        version: 5.2.4(vite@8.0.8(@types/node@24.12.0)(esbuild@0.25.9)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.3))(vue@3.5.21(typescript@5.5.4))
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
@@ -165,7 +165,7 @@ importers:
         version: 3.1.1(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.35.0(jiti@2.5.1))
@@ -286,13 +286,13 @@ importers:
     dependencies:
       '@docusaurus/core':
         specifier: 3.4.0
-        version: 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+        version: 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/plugin-content-docs':
         specifier: 3.4.0
-        version: 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+        version: 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/preset-classic':
         specifier: 3.4.0
-        version: 3.4.0(@algolia/client-search@5.46.0)(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.3)
+        version: 3.4.0(@algolia/client-search@5.46.0)(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.5.4)
       '@mdx-js/react':
         specifier: ^3.0.0
         version: 3.1.1(@types/react@18.3.24)(react@18.3.1)
@@ -311,10 +311,10 @@ importers:
     devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: 3.4.0
-        version: 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/types':
         specifier: 3.4.0
-        version: 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: ^18.3.24
         version: 18.3.24
@@ -405,7 +405,7 @@ importers:
         version: link:../../packages/e2e.generated.catchall
       '@osdk/foundry':
         specifier: latest
-        version: 2.57.0
+        version: 2.60.0-rc1
       '@osdk/oauth':
         specifier: workspace:*
         version: link:../../packages/oauth
@@ -541,7 +541,7 @@ importers:
         version: 8.0.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.35.0(jiti@2.5.1))
@@ -565,7 +565,7 @@ importers:
         version: 29.7.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.7.39)(@types/node@24.12.0)(typescript@5.5.4))
       jest-expo:
         specifier: ~52.0.6
-        version: 52.0.6(@babel/core@7.28.4)(canvas@2.11.2)(expo@52.0.47(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@expo/metro-runtime@4.0.1(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1)))(graphql@16.8.1)(react-native-webview@13.12.2(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1))(jest@29.7.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.7.39)(@types/node@24.12.0)(typescript@5.5.4)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+        version: 52.0.6(@babel/core@7.28.4)(canvas@2.11.2)(expo@52.0.47(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@expo/metro-runtime@4.0.1(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1)))(graphql@16.8.1)(react-native-webview@13.12.2(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1))(jest@29.7.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.7.39)(@types/node@24.12.0)(typescript@5.5.4)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
       react-test-renderer:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
@@ -595,7 +595,7 @@ importers:
         version: link:../../packages/client
       '@osdk/foundry':
         specifier: latest
-        version: 2.57.0
+        version: 2.60.0-rc1
       '@osdk/oauth':
         specifier: workspace:*
         version: link:../../packages/oauth
@@ -731,7 +731,7 @@ importers:
         version: 8.0.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.35.0(jiti@2.5.1))
@@ -755,7 +755,7 @@ importers:
         version: 29.7.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.7.39)(@types/node@24.12.0)(typescript@5.5.4))
       jest-expo:
         specifier: ~52.0.6
-        version: 52.0.6(@babel/core@7.28.4)(canvas@2.11.2)(expo@52.0.47(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@expo/metro-runtime@4.0.1(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1)))(graphql@16.8.1)(react-native-webview@13.12.2(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1))(jest@29.7.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.7.39)(@types/node@24.12.0)(typescript@5.5.4)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+        version: 52.0.6(@babel/core@7.28.4)(canvas@2.11.2)(expo@52.0.47(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@expo/metro-runtime@4.0.1(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1)))(graphql@16.8.1)(react-native-webview@13.12.2(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1))(jest@29.7.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.7.39)(@types/node@24.12.0)(typescript@5.5.4)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
       react-test-renderer:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
@@ -813,7 +813,7 @@ importers:
         version: 9.35.0(jiti@2.5.1)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.35.0(jiti@2.5.1))
@@ -858,7 +858,7 @@ importers:
         version: link:../../packages/e2e.generated.catchall
       '@osdk/foundry':
         specifier: latest
-        version: 2.57.0
+        version: 2.60.0-rc1
       '@osdk/oauth':
         specifier: workspace:*
         version: link:../../packages/oauth
@@ -913,7 +913,7 @@ importers:
         version: 9.35.0(jiti@2.5.1)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.35.0(jiti@2.5.1))
@@ -961,7 +961,7 @@ importers:
         version: link:../../packages/client
       '@osdk/foundry':
         specifier: latest
-        version: 2.57.0
+        version: 2.60.0-rc1
       '@osdk/oauth':
         specifier: workspace:*
         version: link:../../packages/oauth
@@ -1016,7 +1016,7 @@ importers:
         version: 9.35.0(jiti@2.5.1)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.35.0(jiti@2.5.1))
@@ -1092,7 +1092,7 @@ importers:
         version: 9.35.0(jiti@2.5.1)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.35.0(jiti@2.5.1))
@@ -1171,7 +1171,7 @@ importers:
         version: 9.35.0(jiti@2.5.1)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.35.0(jiti@2.5.1))
@@ -1241,7 +1241,7 @@ importers:
         version: 9.35.0(jiti@2.5.1)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.35.0(jiti@2.5.1))
@@ -1320,7 +1320,7 @@ importers:
         version: 9.35.0(jiti@2.5.1)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.35.0(jiti@2.5.1))
@@ -1387,7 +1387,7 @@ importers:
         version: link:../../packages/e2e.generated.catchall
       '@osdk/foundry':
         specifier: latest
-        version: 2.57.0
+        version: 2.60.0-rc1
       '@osdk/oauth':
         specifier: workspace:*
         version: link:../../packages/oauth
@@ -1424,7 +1424,7 @@ importers:
         version: link:../../packages/client
       '@osdk/foundry':
         specifier: latest
-        version: 2.57.0
+        version: 2.60.0-rc1
       '@osdk/oauth':
         specifier: workspace:*
         version: link:../../packages/oauth
@@ -1507,7 +1507,7 @@ importers:
         version: 9.35.0(jiti@2.5.1)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.35.0(jiti@2.5.1))
@@ -1595,7 +1595,7 @@ importers:
         version: 9.35.0(jiti@2.5.1)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.35.0(jiti@2.5.1))
@@ -2340,7 +2340,7 @@ importers:
         version: 8.0.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.35.0(jiti@2.5.1))
@@ -2364,7 +2364,7 @@ importers:
         version: 29.7.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.7.39)(@types/node@24.12.0)(typescript@5.5.4))
       jest-expo:
         specifier: ~52.0.6
-        version: 52.0.6(@babel/core@7.28.4)(canvas@2.11.2)(expo@52.0.47(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@expo/metro-runtime@4.0.1(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1)))(graphql@16.8.1)(react-native-webview@13.12.2(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1))(jest@29.7.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.7.39)(@types/node@24.12.0)(typescript@5.5.4)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+        version: 52.0.6(@babel/core@7.28.4)(canvas@2.11.2)(expo@52.0.47(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@expo/metro-runtime@4.0.1(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1)))(graphql@16.8.1)(react-native-webview@13.12.2(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1))(jest@29.7.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.7.39)(@types/node@24.12.0)(typescript@5.5.4)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
       react-test-renderer:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
@@ -2428,7 +2428,7 @@ importers:
         version: 9.35.0(jiti@2.5.1)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.35.0(jiti@2.5.1))
@@ -2519,7 +2519,7 @@ importers:
         version: 9.35.0(jiti@2.5.1)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.35.0(jiti@2.5.1))
@@ -2598,7 +2598,7 @@ importers:
         version: 9.35.0(jiti@2.5.1)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.35.0(jiti@2.5.1))
@@ -2674,7 +2674,7 @@ importers:
         version: 9.35.0(jiti@2.5.1)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.35.0(jiti@2.5.1))
@@ -2750,7 +2750,7 @@ importers:
         version: 9.35.0(jiti@2.5.1)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.35.0(jiti@2.5.1))
@@ -2826,7 +2826,7 @@ importers:
         version: 9.35.0(jiti@2.5.1)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.35.0(jiti@2.5.1))
@@ -3031,7 +3031,7 @@ importers:
         version: 9.35.0(jiti@2.5.1)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.35.0(jiti@2.5.1))
@@ -3110,7 +3110,7 @@ importers:
         version: 9.35.0(jiti@2.5.1)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.35.0(jiti@2.5.1))
@@ -4692,6 +4692,9 @@ importers:
       date-fns-tz:
         specifier: ^2.0.0
         version: 2.0.1(date-fns@2.30.0)
+      fast-deep-equal:
+        specifier: ^3.1.3
+        version: 3.1.3
       lodash-es:
         specifier: ^4.17.21
         version: 4.18.1
@@ -5764,7 +5767,7 @@ importers:
         version: 5.5.4
       webpack:
         specifier: ^5.97.0
-        version: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)(webpack-cli@6.0.1)
+        version: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)(webpack-cli@6.0.1)
       webpack-cli:
         specifier: ^6.0.0
         version: 6.0.1(webpack@5.106.1)
@@ -7383,7 +7386,7 @@ packages:
     resolution: {integrity: sha512-etDqA/4jYvOGBM6yfKCOsEXfH96BKztZdgGmGqKi2xHnDe0ILIBraRspwgYatJH9JsCZ5HCGoCst8w18EKOAdg==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
-      postcss: ^8.4
+      postcss: ^8.5.6
 
   '@discoveryjs/json-ext@0.5.7':
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
@@ -8170,7 +8173,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.22.26':
     resolution: {integrity: sha512-I689wc8Fn/AX7aUGiwrh3HnssiORMJtR2fpksX+JIe8Cj/EDleblYMSwRPd0025wrwOV9UN1KM/RuEt/QjCS3Q==}
@@ -8842,17 +8845,32 @@ packages:
   '@osdk/foundry.admin@2.57.0':
     resolution: {integrity: sha512-LyR85rpQ52EacoTHGsd4GSfiA6SfWp97rlSIdr8XN9NiBEmmaTyhXezAH6Sc/F0SIL4YLmxfmjqa9IT+mMI/hw==}
 
+  '@osdk/foundry.admin@2.59.0':
+    resolution: {integrity: sha512-y9Bavh3Wwdx2pwQga/rgrs0v89jlkErqJrHod4hxXZNTq45t2ej65LBNfKE/f4OBU9VzE4DrqGbxD+MR6dpSnw==}
+
   '@osdk/foundry.aipagents@2.57.0':
     resolution: {integrity: sha512-oTkP+E1XylusVPtBDQYfZDj5eUjsnq+EzEaPrm9hE7eQnhfRRrzEzE1jKSh3+f/7mVPdT58PbC3J7Kc2VPZ+ag==}
+
+  '@osdk/foundry.aipagents@2.59.0':
+    resolution: {integrity: sha512-wA+fLZuzPEboyTh490iEQO5X1VwfBUnCKlNkExSF0aiNxxYHE36+dmsI9fSruqzYCZlsTEMtgZBl8ulkZRl91A==}
 
   '@osdk/foundry.audit@2.57.0':
     resolution: {integrity: sha512-jA3HlLI0sRQaXZ+4G6N74s5kho+SUNN2sfVNYWo4TE1lTPKZleLmIdZ/1eS+3jLYwjHmK1cjd4SsCNg7CiQe6g==}
 
+  '@osdk/foundry.audit@2.59.0':
+    resolution: {integrity: sha512-rXyhxEHGJ0KxOvfEpcE2BaDB9w9zEsfRFil8TP7D+R6VWdjh0NvwZngW6Fnp8lmyOze3gnxFJezzZu8BjJ0eCw==}
+
   '@osdk/foundry.checkpoints@2.57.0':
     resolution: {integrity: sha512-hg8172mUUS8fbXCVph6Z6NXd3TwfDSCw6p9y9iLgcTJ1BeLHhx/mJb51FeUfTee1j+/McCGpRpGyKApPPeM4aQ==}
 
+  '@osdk/foundry.checkpoints@2.59.0':
+    resolution: {integrity: sha512-bPusDbHau8FoFJZ02OZi756NgXl3Lcf5L4SoDUIgQf9UyFFZBGr31UWTksoy2QdKJQT4Fi9QxelbgYo6zD74Rw==}
+
   '@osdk/foundry.connectivity@2.57.0':
     resolution: {integrity: sha512-n1DxUk9JJLqo2MLDs5oWDAKmuhEdJNjVBjlntLJM9EPPsDgP/SS5UQFjETHWNuPW9kk3b0GR59qs6/Si2wmsQA==}
+
+  '@osdk/foundry.connectivity@2.59.0':
+    resolution: {integrity: sha512-ILwLxSOmRtkwTke7RbuCpgksGY0f7E5AH0Z02ZPopbzWgVySywrZ9oXbMjZ9/X9sCjA8ooRzdAcKW7xWd42OHA==}
 
   '@osdk/foundry.core@2.44.0':
     resolution: {integrity: sha512-fdDAm2pdf67DWo32sXBcfwujAxb7YOKI4iUQ99C1JW92SQRqNBbQZQlM10RJYQ7LMq6S9P1Gz6Gx7KRV7I5Zpw==}
@@ -8863,8 +8881,14 @@ packages:
   '@osdk/foundry.core@2.57.0':
     resolution: {integrity: sha512-5oNC5ey1hcLt6OlpmgR3En9RpMJbQXnD4tj3T/Qkp7Q3SWJLSrIei9Jc4Qg0wGOH4anhU07U1uB2hyEAs3i4Ew==}
 
+  '@osdk/foundry.core@2.59.0':
+    resolution: {integrity: sha512-/KzlqwTWWoYA2Ia5FGSUjRbGPlExLA+0a19YZBXFbLNjj0xMJwybb48Z2A3l9CSzs16q6Rb9KePKuMNvoh/JKQ==}
+
   '@osdk/foundry.datahealth@2.57.0':
     resolution: {integrity: sha512-jWIrdph//86mG3jwSQSDQuZO/2FP4tWdWDyNzPbr4JDi3gRVD5psSv3aHg+nqYoLjIHxkq81yuzSY+4ef+HxpA==}
+
+  '@osdk/foundry.datahealth@2.59.0':
+    resolution: {integrity: sha512-aPv/kx4T0dGOEz4gsGTx4OVR4ExCM7sGG/F6KY9vnr/P8pEoDMeiUmFJRVKf0Et1Kz5y8LUT3l4+hLlC8PsYUg==}
 
   '@osdk/foundry.datasets@2.5.0':
     resolution: {integrity: sha512-W82xleLQgQFUTVnAQS54n26xUFEALayotl1f3LGeRLN6r+2G1dNp+UgRU7/IHc/xzOqgulEOGwwr6ENFcsNP2A==}
@@ -8872,14 +8896,23 @@ packages:
   '@osdk/foundry.datasets@2.57.0':
     resolution: {integrity: sha512-ECizSkpjQFsIHVjASCHWB9cpbgsKOIdcYwZCIcQaZ+cIpmA7StGWcRASvEm0osRzd2dThuo9ZdeXowYXJWGvTA==}
 
+  '@osdk/foundry.datasets@2.59.0':
+    resolution: {integrity: sha512-Zj4/2Y3VZQQtwLKBxViBAXq/JloWKqEazmA9eyPClNGgOKlpGm+PRUtizl5eQjK87wrG9K7noFdw5dJMDvFfOA==}
+
   '@osdk/foundry.filesystem@2.5.0':
     resolution: {integrity: sha512-SJKZSfBc7CroyoIVW3D2SpVyaCCnhv8onzIwHcJWOnufFgSbQ3kqyWoqNiStGlymmnoSbniK3rfUFFYeUbxhDQ==}
 
   '@osdk/foundry.filesystem@2.57.0':
     resolution: {integrity: sha512-bEt1HZP05farbpyhrQKamjeXeZhB4TtwYaF+GRodY3If7LldMgoJgeTx/09NFX9HQPeZ2JxoBJ1GYEjABbgdOg==}
 
+  '@osdk/foundry.filesystem@2.59.0':
+    resolution: {integrity: sha512-HUzvUX4NvuSjoDhJKoCiUHwCM4I1k3dxlZR/YMH5tylxJ6jeFmcCP2FRNq22TWz+BwQREn6XlO87RPKUhGw//w==}
+
   '@osdk/foundry.functions@2.57.0':
     resolution: {integrity: sha512-abssxEIVODRh2goWm7LZQckjjP3lpxgSIYyhjqPV//gUBFCA7XBNTHPba/+/ka+qmSRZbJ+1ONOUIAO0/X1brA==}
+
+  '@osdk/foundry.functions@2.59.0':
+    resolution: {integrity: sha512-Iw+YHeCz9etpkG5xMpr3ZHOlWmUj+it+xeqXrq7Hhkze+9J5+RTLdSoUNb8aEEYsNpFMLl4qSL9lak1/IkPgBw==}
 
   '@osdk/foundry.geo@2.44.0':
     resolution: {integrity: sha512-eXiBR2YAesPJe5amQy6G/pz0i4kmgJXiCAocMSYsgVKm/8kuMaqDUn5UJIFYo7EdjLVJueiMAFyCdN0wpK3SZA==}
@@ -8890,11 +8923,20 @@ packages:
   '@osdk/foundry.geo@2.57.0':
     resolution: {integrity: sha512-zXw8vOdOa0duHopZJV9N9WGx5ApRhj2QSGWjY+dYOS+Xw5xyOXJ7m5gEtlFzJCXTJsi8rqwMRFvq5SI2oYpOsw==}
 
+  '@osdk/foundry.geo@2.59.0':
+    resolution: {integrity: sha512-rSfpx/RxRjKuohpJpyNFkp5mrS6pmGxjXI7XZXFdIVBbSsSIfP7OMClD9XnmVCNtmA3oufi5XnvIYEkjOHJAoA==}
+
   '@osdk/foundry.geojson@2.57.0':
     resolution: {integrity: sha512-7uzWBKJXCkJRGadQrKyj01Vu6nUrUQgdO8nVbUHbRKd+jwZRSN+tjwo62Xen7o20cL3AJv1gZE633/ow+zi4lQ==}
 
+  '@osdk/foundry.geojson@2.59.0':
+    resolution: {integrity: sha512-h5pplI6UTvUEhgsHM/e1gdPYoypMmsocLRSKvXGvaRFenDNKaBwP2mQ9LBcajWdSxsWxjG+ZoQNQWDxI25uTDQ==}
+
   '@osdk/foundry.languagemodels@2.57.0':
     resolution: {integrity: sha512-Ag11jyPDeooq/pfoVAI2IeAH4E2/JTnCmpmEj3PMeNYEd7ps0eh/O60WpEdZ9SDye3FSSLZluQ+PrYEDmfTwqg==}
+
+  '@osdk/foundry.languagemodels@2.59.0':
+    resolution: {integrity: sha512-AY0PL0pxTK8S8sXhiplKqsyTZuT+Vk80R1SbxfOjHGJBZ+UqPYm3qTTdLc2cxDLI0YenIU/6tMWdsPsSPaACXw==}
 
   '@osdk/foundry.mediasets@2.44.0':
     resolution: {integrity: sha512-l378lxKUdIMmb1txFs/hOKyPO3bc10OWU4BvaP/LMZjXLbUZPNI/DYAmKrzKTeSMGBnZ2luhqEyfPfZYMGmrhw==}
@@ -8902,11 +8944,20 @@ packages:
   '@osdk/foundry.mediasets@2.57.0':
     resolution: {integrity: sha512-VU5G5sRN2/454KX80Nr+rtq2mO697hTD8Az4w7pwgklaBi9Wky+asHJBH9PZ7wvDwYOQVKpRc+3BnNd49MzhyQ==}
 
+  '@osdk/foundry.mediasets@2.59.0':
+    resolution: {integrity: sha512-KSl1MO6Isl5n3z6zZ/ErE8q87PUOoy+PMN5/UjBMfIisQIIT27l/AaxXEzImyxIJ6XgQ5E29FI6hGRHIPKOeHw==}
+
   '@osdk/foundry.models@2.57.0':
     resolution: {integrity: sha512-CwL1urLk76TAtxGydA1Ssv5BomYeTUPqq1QtxIlPsX2dLP2SZ2hQHdFBk/5JbJBkQk75kX0V7WzF2KeyOdR2iA==}
 
+  '@osdk/foundry.models@2.59.0':
+    resolution: {integrity: sha512-7HVlqcEWuarDsV9xrNCzAA8ED1/AfP+46mPAjM0/drVaVwt9/klA3hfQ4i6TDuzrRQAQx4P6/exutlPRhobJvw==}
+
   '@osdk/foundry.notepad@2.57.0':
     resolution: {integrity: sha512-BAA7LXsJmFTZss2jBhoPYe3gsUaxqupBfAhJLtkAYZirJXKzlJm53DFzD64ck61TBxLGT1OxbNZPr4Wltgl+cw==}
+
+  '@osdk/foundry.notepad@2.59.0':
+    resolution: {integrity: sha512-KsFCylfpcFbt+L3yX/C/YtxHy/s43JJlvtO1tnPAmKWD8tPlNEoOUcz7ytN6vKDYeOWQuP9vcbJHNd5qTXuKcw==}
 
   '@osdk/foundry.ontologies@2.44.0':
     resolution: {integrity: sha512-A74NrG3tDiLNC5VW+plchrrMDf5gLekavrdyVnmVqQAkcBc6Z8/Jl+92rJbQ/v6TJnXWpCwuCkc+QQXaYlhHKQ==}
@@ -8914,32 +8965,62 @@ packages:
   '@osdk/foundry.ontologies@2.57.0':
     resolution: {integrity: sha512-yAQqEY1EhtVg7tEAW7tqVikNr2EMjDEdDX3ApSTXTU0vCB3FqYL0q4++p/nbnZ+9BbSus1WkrqBclGEhe6G+/w==}
 
+  '@osdk/foundry.ontologies@2.59.0':
+    resolution: {integrity: sha512-i0F7yWmPXOTk1G1NBBQiUKonuDJ6aSr1J5TK19CDFz64Yn36WNcwXcJmvw1HRmDWPJIHg0LVTWGtTqPHS+NDsA==}
+
   '@osdk/foundry.operations@2.57.0':
     resolution: {integrity: sha512-MPheImqC/sU3XvHakyTN36A+Dg6aIr9aN9CHne7/BLoQuUczp0+z2mlBDz9nJ2E3v7UVJQQquckIU6SpeLN8CA==}
+
+  '@osdk/foundry.operations@2.59.0':
+    resolution: {integrity: sha512-NJ0OBic7R8UCVFOSoCjGWhtKepveY+Wfz+D3hE70+xxsR+nUgrE+mqV9u4gASf1lQklQPpVLphMmDY6BYO8izQ==}
 
   '@osdk/foundry.orchestration@2.57.0':
     resolution: {integrity: sha512-+pLuT+CxrEJqziAcieQzOOAD8+2Q+GJsB29W812wpXhnByo1epRWkD/irlSUgtQCzgnFwbusV3tFk0RrUb4TKQ==}
 
+  '@osdk/foundry.orchestration@2.59.0':
+    resolution: {integrity: sha512-KpinDZuiDHOm65tFWFS8B/qJTX0OMNjEIqA7YamD+zk2C2NIIqS/uJz3YaZ3VYpHi3Ll4UyTPbxB2DjGTFycMA==}
+
   '@osdk/foundry.pack@2.57.0':
     resolution: {integrity: sha512-jeSpPpgxzkrlmk4sIicpRazALG44CghdAuB1v9k+L9fWmauuVGmbmgloid5j1HpicQnXPf6UKw7+zoAyyydvIg==}
+
+  '@osdk/foundry.pack@2.59.0':
+    resolution: {integrity: sha512-Ca5alq/ps3uJoDjiSOdq32Hlb+UuJalbKIG0DqevM6bfK8K65sNLyVSUeiJys9qCAg6i7gkvfstYQpfg4RMORA==}
 
   '@osdk/foundry.publicapis@2.57.0':
     resolution: {integrity: sha512-80vRswyI0pOmgvdxCwkigtdE9SWj96UT5X8u7Xe0UDcNxUtG7xGBNUWfCCdoWnIUTn+poZcZG/q99xV4L15Hpg==}
 
+  '@osdk/foundry.publicapis@2.59.0':
+    resolution: {integrity: sha512-if2uCzTze5DCi0m6oYE6qKGVMCLp0VC4QaIMfwCXmsjVUEoK8rcyz0/1moaDoTxWldfxnH2jQH3b/Gvx/e2tnw==}
+
   '@osdk/foundry.sqlqueries@2.57.0':
     resolution: {integrity: sha512-44iSHaaFBLUPcrFsXqagn4XK5CajGMzXsFj7YQH/cQAhgNhoXnoNT0t64RxKL2XFwjrBMxL/qYiTF8t9AxQP9Q==}
+
+  '@osdk/foundry.sqlqueries@2.59.0':
+    resolution: {integrity: sha512-fhDunZPAdIutTRrvI48Zs7dJQoTxEcj0B6idpIy81NSt5C5i/XRKM7n35sMcolhJnyqoLZ/joyO+CkfT5ZfKJA==}
 
   '@osdk/foundry.streams@2.57.0':
     resolution: {integrity: sha512-yjuDeuSRjtDRqrTEbBmA6vicl+L7OY4+p6FSo5r5KjFQB92QVN6o97bxXITdkzLFdPoK6ErKepwqa3skUEGARw==}
 
+  '@osdk/foundry.streams@2.59.0':
+    resolution: {integrity: sha512-cDGj3bgsac5n8nFFwO6GbQgmBE7Oe1lNZmaPrvYqqsCXBw9lBPDo+2LHhHdrtywN2MMUTYbsOUWeJzEZuQwAKg==}
+
   '@osdk/foundry.thirdpartyapplications@2.57.0':
     resolution: {integrity: sha512-zzkG1iLJL+OQ+9c3RcwyP7FD+mgq41v8eWPmHFGCVgfpHmIUMDMN1/sChYHe5R12wTpbY0jgYyHfdGaSjpoo0w==}
+
+  '@osdk/foundry.thirdpartyapplications@2.59.0':
+    resolution: {integrity: sha512-jPQ+lp8WFkjZNXp6psZqE/z63RFgepEdOpeg3C39ngpVZrgjrTSpOawpj2fKPqLcPDSxZJJye0QyL6gfGHJDbQ==}
 
   '@osdk/foundry.widgets@2.57.0':
     resolution: {integrity: sha512-YaTROCzrp5TpCcslN2hJOholsc68VEtN1YawiAOQo9TuksKBDHdcw74/mDdr7ZjAuGtlwhcrNVaQ1plmIf2qWQ==}
 
+  '@osdk/foundry.widgets@2.59.0':
+    resolution: {integrity: sha512-OsMndIFM02TGf/A0Xq9fLvI0k5QKUuKKBuxXTFbC54tTkUNL6MePFJeOWiQOt/rG4NB2SKB8O7a8OQPZaY/g3Q==}
+
   '@osdk/foundry@2.57.0':
     resolution: {integrity: sha512-vnp1iOm3CQDD0BQHPRQ1N8C6iT915K/8/EFXz6OdTJCnFlEaK0znm41MRRbhMQP6afj9rWXdAfJuhle4Q9cW7w==}
+
+  '@osdk/foundry@2.60.0-rc1':
+    resolution: {integrity: sha512-Y9xLHEhmoRphbZiEM7WpSCdrURJU0g4gFKClp+IdyriXv2iadqAL/xsA3/AQWumcMkaNuOWfHlwJ/ULuPFK4rA==}
 
   '@osdk/gateway@2.4.2':
     resolution: {integrity: sha512-A2WmRHxzCiZKyviYKAQEq9KZwL5DEkhXADLt36lMn2tGixO5qOTU7rLsE+OAA4va+evmd44TfzipJs8ieffP6g==}
@@ -11982,6 +12063,7 @@ packages:
   '@xmldom/xmldom@0.8.12':
     resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -14899,7 +14981,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -23478,7 +23560,7 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@docusaurus/core@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/core@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/generator': 7.28.3
@@ -23492,12 +23574,12 @@ snapshots:
       '@babel/traverse': 7.28.4
       '@docusaurus/cssnano-preset': 3.4.0
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)
       autoprefixer: 10.4.22(postcss@8.5.6)
-      babel-loader: 9.2.1(@babel/core@7.28.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      babel-loader: 9.2.1(@babel/core@7.28.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
       babel-plugin-dynamic-import-node: 2.3.3
       boxen: 6.2.1
       chalk: 4.1.2
@@ -23506,34 +23588,34 @@ snapshots:
       cli-table3: 0.6.5
       combine-promises: 1.2.0
       commander: 5.1.0
-      copy-webpack-plugin: 11.0.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      copy-webpack-plugin: 11.0.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
       core-js: 3.45.1
-      css-loader: 6.11.0(@rspack/core@1.6.7)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
-      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.27.3)(lightningcss@1.32.0)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      css-loader: 6.11.0(@rspack/core@1.6.7)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
+      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.25.9)(lightningcss@1.32.0)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
       cssnano: 6.1.2(postcss@8.5.6)
       del: 6.1.1
       detect-port: 1.6.1
       escape-html: 1.0.3
       eta: 2.2.0
       eval: 0.1.8
-      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
       fs-extra: 11.3.1
       html-minifier-terser: 7.2.0
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.5(@rspack/core@1.6.7)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      html-webpack-plugin: 5.6.5(@rspack/core@1.6.7)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
       leven: 3.1.0
       lodash: 4.18.1
-      mini-css-extract-plugin: 2.9.4(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      mini-css-extract-plugin: 2.9.4(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
       p-map: 4.0.0
       postcss: 8.5.6
-      postcss-loader: 7.3.4(postcss@8.5.6)(typescript@5.8.3)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      postcss-loader: 7.3.4(postcss@8.5.6)(typescript@5.5.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
       prompts: 2.4.2
       react: 18.3.1
-      react-dev-utils: 12.0.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      react-dev-utils: 12.0.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.3.1)'
-      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@6.0.0(react@18.3.1))(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@6.0.0(react@18.3.1))(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
       react-router: 5.3.4(react@18.3.1)
       react-router-config: 5.1.1(react-router@5.3.4(react@18.3.1))(react@18.3.1)
       react-router-dom: 5.3.4(react@18.3.1)
@@ -23541,15 +23623,15 @@ snapshots:
       semver: 7.7.2
       serve-handler: 6.1.6
       shelljs: 0.8.5
-      terser-webpack-plugin: 5.3.14(@swc/core@1.7.39)(esbuild@0.27.3)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      terser-webpack-plugin: 5.3.14(@swc/core@1.7.39)(esbuild@0.25.9)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
       tslib: 2.8.1
       update-notifier: 6.0.2
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)))(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)))(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 4.15.2(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      webpack-dev-server: 4.15.2(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
       webpack-merge: 5.10.0
-      webpackbar: 7.0.0(@rspack/core@1.6.7)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      webpackbar: 7.0.0(@rspack/core@1.6.7)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
     transitivePeerDependencies:
       - '@docusaurus/types'
       - '@parcel/css'
@@ -23581,16 +23663,16 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.8.1
 
-  '@docusaurus/mdx-loader@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/mdx-loader@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)
       '@mdx-js/mdx': 3.1.1
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.5.0
-      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
       fs-extra: 11.3.1
       image-size: 1.2.1
       mdast-util-mdx: 3.0.0
@@ -23606,9 +23688,9 @@ snapshots:
       tslib: 2.8.1
       unified: 11.0.5
       unist-util-visit: 5.0.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)))(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)))(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
       vfile: 6.0.3
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
     transitivePeerDependencies:
       - '@docusaurus/types'
       - '@swc/core'
@@ -23618,9 +23700,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@docusaurus/module-type-aliases@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/history': 4.7.11
       '@types/react': 18.3.24
       '@types/react-router-config': 5.0.11
@@ -23636,15 +23718,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-content-blog@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)
       cheerio: 1.0.0-rc.12
       feed: 4.2.2
       fs-extra: 11.3.1
@@ -23656,7 +23738,7 @@ snapshots:
       tslib: 2.8.1
       unist-util-visit: 5.0.0
       utility-types: 3.11.0
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -23675,16 +23757,16 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-content-docs@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/module-type-aliases': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/module-type-aliases': 3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.1
@@ -23694,7 +23776,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
       utility-types: 3.11.0
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -23713,18 +23795,18 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-content-pages@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)
       fs-extra: 11.3.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -23743,11 +23825,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-debug@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)
       fs-extra: 11.3.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -23771,11 +23853,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-google-analytics@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
@@ -23797,11 +23879,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-google-gtag@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)
       '@types/gtag.js': 0.0.12
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -23824,11 +23906,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-google-tag-manager@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
@@ -23850,14 +23932,14 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-sitemap@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)
       fs-extra: 11.3.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -23881,21 +23963,21 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.4.0(@algolia/client-search@5.46.0)(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.3)':
+  '@docusaurus/preset-classic@3.4.0(@algolia/client-search@5.46.0)(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-content-blog': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-content-pages': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-debug': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-google-analytics': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-google-gtag': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-google-tag-manager': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-sitemap': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/theme-classic': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/theme-search-algolia': 3.4.0(@algolia/client-search@5.46.0)(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.3)
-      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-blog': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-pages': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-debug': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-google-analytics': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-google-gtag': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-google-tag-manager': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-sitemap': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/theme-classic': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/theme-search-algolia': 3.4.0(@algolia/client-search@5.46.0)(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.5.4)
+      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
@@ -23924,20 +24006,20 @@ snapshots:
       '@types/react': 18.3.24
       react: 18.3.1
 
-  '@docusaurus/theme-classic@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/theme-classic@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/module-type-aliases': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-blog': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-content-pages': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/module-type-aliases': 3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-blog': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-pages': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/theme-translations': 3.4.0
-      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)
       '@mdx-js/react': 3.1.1(@types/react@18.3.24)(react@18.3.1)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.2
@@ -23972,15 +24054,15 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-common@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/theme-common@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/module-type-aliases': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-blog': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-content-pages': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/module-type-aliases': 3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-blog': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-pages': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@types/history': 4.7.11
       '@types/react': 18.3.24
       '@types/react-router-config': 5.0.11
@@ -24010,16 +24092,16 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.4.0(@algolia/client-search@5.46.0)(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.3)':
+  '@docusaurus/theme-search-algolia@3.4.0(@algolia/client-search@5.46.0)(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.5.4)':
     dependencies:
       '@docsearch/react': 3.9.0(@algolia/client-search@5.46.0)(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.25.9)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/theme-translations': 3.4.0
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)
       algoliasearch: 4.25.3
       algoliasearch-helper: 3.26.1(algoliasearch@4.25.3)
       clsx: 2.1.1
@@ -24057,7 +24139,7 @@ snapshots:
       fs-extra: 11.3.1
       tslib: 2.8.1
 
-  '@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@types/history': 4.7.11
@@ -24068,7 +24150,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       utility-types: 3.11.0
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -24077,17 +24159,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@docusaurus/utils-common@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       tslib: 2.8.1
     optionalDependencies:
-      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@docusaurus/utils-validation@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)':
+  '@docusaurus/utils-validation@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)':
     dependencies:
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       fs-extra: 11.3.1
       joi: 17.13.3
       js-yaml: 4.1.1
@@ -24102,13 +24184,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)':
+  '@docusaurus/utils@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.25.9)(typescript@5.5.4)':
     dependencies:
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@svgr/webpack': 8.1.0(typescript@5.8.3)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@svgr/webpack': 8.1.0(typescript@5.5.4)
       escape-string-regexp: 4.0.0
-      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
       fs-extra: 11.3.1
       github-slugger: 1.5.0
       globby: 11.1.0
@@ -24121,11 +24203,11 @@ snapshots:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)))(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)))(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
       utility-types: 3.11.0
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
     optionalDependencies:
-      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -25877,11 +25959,27 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
+  '@osdk/foundry.admin@2.59.0':
+    dependencies:
+      '@osdk/foundry.core': 2.59.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
   '@osdk/foundry.aipagents@2.57.0':
     dependencies:
       '@osdk/foundry.core': 2.57.0
       '@osdk/foundry.functions': 2.57.0
       '@osdk/foundry.ontologies': 2.57.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
+  '@osdk/foundry.aipagents@2.59.0':
+    dependencies:
+      '@osdk/foundry.core': 2.59.0
+      '@osdk/foundry.functions': 2.59.0
+      '@osdk/foundry.ontologies': 2.59.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -25893,9 +25991,23 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
+  '@osdk/foundry.audit@2.59.0':
+    dependencies:
+      '@osdk/foundry.core': 2.59.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
   '@osdk/foundry.checkpoints@2.57.0':
     dependencies:
       '@osdk/foundry.core': 2.57.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
+  '@osdk/foundry.checkpoints@2.59.0':
+    dependencies:
+      '@osdk/foundry.core': 2.59.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -25904,6 +26016,14 @@ snapshots:
     dependencies:
       '@osdk/foundry.core': 2.57.0
       '@osdk/foundry.filesystem': 2.57.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
+  '@osdk/foundry.connectivity@2.59.0':
+    dependencies:
+      '@osdk/foundry.core': 2.59.0
+      '@osdk/foundry.filesystem': 2.59.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -25929,9 +26049,23 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
+  '@osdk/foundry.core@2.59.0':
+    dependencies:
+      '@osdk/foundry.geo': 2.59.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
   '@osdk/foundry.datahealth@2.57.0':
     dependencies:
       '@osdk/foundry.core': 2.57.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
+  '@osdk/foundry.datahealth@2.59.0':
+    dependencies:
+      '@osdk/foundry.core': 2.59.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -25953,6 +26087,15 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
+  '@osdk/foundry.datasets@2.59.0':
+    dependencies:
+      '@osdk/foundry.core': 2.59.0
+      '@osdk/foundry.datahealth': 2.59.0
+      '@osdk/foundry.filesystem': 2.59.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
   '@osdk/foundry.filesystem@2.5.0':
     dependencies:
       '@osdk/foundry.core': 2.5.0
@@ -25967,10 +26110,25 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
+  '@osdk/foundry.filesystem@2.59.0':
+    dependencies:
+      '@osdk/foundry.core': 2.59.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
   '@osdk/foundry.functions@2.57.0':
     dependencies:
       '@osdk/foundry.core': 2.57.0
       '@osdk/foundry.ontologies': 2.57.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
+  '@osdk/foundry.functions@2.59.0':
+    dependencies:
+      '@osdk/foundry.core': 2.59.0
+      '@osdk/foundry.ontologies': 2.59.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -25993,7 +26151,19 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
+  '@osdk/foundry.geo@2.59.0':
+    dependencies:
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
   '@osdk/foundry.geojson@2.57.0':
+    dependencies:
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
+  '@osdk/foundry.geojson@2.59.0':
     dependencies:
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
@@ -26002,6 +26172,13 @@ snapshots:
   '@osdk/foundry.languagemodels@2.57.0':
     dependencies:
       '@osdk/foundry.core': 2.57.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
+  '@osdk/foundry.languagemodels@2.59.0':
+    dependencies:
+      '@osdk/foundry.core': 2.59.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26020,6 +26197,13 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
+  '@osdk/foundry.mediasets@2.59.0':
+    dependencies:
+      '@osdk/foundry.core': 2.59.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
   '@osdk/foundry.models@2.57.0':
     dependencies:
       '@osdk/foundry.core': 2.57.0
@@ -26029,11 +26213,30 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
+  '@osdk/foundry.models@2.59.0':
+    dependencies:
+      '@osdk/foundry.core': 2.59.0
+      '@osdk/foundry.filesystem': 2.59.0
+      '@osdk/foundry.ontologies': 2.59.0
+      '@osdk/foundry.orchestration': 2.59.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
   '@osdk/foundry.notepad@2.57.0':
     dependencies:
       '@osdk/foundry.core': 2.57.0
       '@osdk/foundry.filesystem': 2.57.0
       '@osdk/foundry.ontologies': 2.57.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
+  '@osdk/foundry.notepad@2.59.0':
+    dependencies:
+      '@osdk/foundry.core': 2.59.0
+      '@osdk/foundry.filesystem': 2.59.0
+      '@osdk/foundry.ontologies': 2.59.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26054,9 +26257,24 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
+  '@osdk/foundry.ontologies@2.59.0':
+    dependencies:
+      '@osdk/foundry.core': 2.59.0
+      '@osdk/foundry.geo': 2.59.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
   '@osdk/foundry.operations@2.57.0':
     dependencies:
       '@osdk/foundry.ontologies': 2.57.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
+  '@osdk/foundry.operations@2.59.0':
+    dependencies:
+      '@osdk/foundry.ontologies': 2.59.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26070,10 +26288,27 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
+  '@osdk/foundry.orchestration@2.59.0':
+    dependencies:
+      '@osdk/foundry.core': 2.59.0
+      '@osdk/foundry.datasets': 2.59.0
+      '@osdk/foundry.filesystem': 2.59.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
   '@osdk/foundry.pack@2.57.0':
     dependencies:
       '@osdk/foundry.core': 2.57.0
       '@osdk/foundry.filesystem': 2.57.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
+  '@osdk/foundry.pack@2.59.0':
+    dependencies:
+      '@osdk/foundry.core': 2.59.0
+      '@osdk/foundry.filesystem': 2.59.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26085,10 +26320,25 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
+  '@osdk/foundry.publicapis@2.59.0':
+    dependencies:
+      '@osdk/foundry.core': 2.59.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
   '@osdk/foundry.sqlqueries@2.57.0':
     dependencies:
       '@osdk/foundry.core': 2.57.0
       '@osdk/foundry.datasets': 2.57.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
+  '@osdk/foundry.sqlqueries@2.59.0':
+    dependencies:
+      '@osdk/foundry.core': 2.59.0
+      '@osdk/foundry.datasets': 2.59.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26102,6 +26352,15 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
+  '@osdk/foundry.streams@2.59.0':
+    dependencies:
+      '@osdk/foundry.core': 2.59.0
+      '@osdk/foundry.datasets': 2.59.0
+      '@osdk/foundry.filesystem': 2.59.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
   '@osdk/foundry.thirdpartyapplications@2.57.0':
     dependencies:
       '@osdk/foundry.core': 2.57.0
@@ -26109,9 +26368,23 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
+  '@osdk/foundry.thirdpartyapplications@2.59.0':
+    dependencies:
+      '@osdk/foundry.core': 2.59.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
   '@osdk/foundry.widgets@2.57.0':
     dependencies:
       '@osdk/foundry.core': 2.57.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
+  '@osdk/foundry.widgets@2.59.0':
+    dependencies:
+      '@osdk/foundry.core': 2.59.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26143,6 +26416,37 @@ snapshots:
       '@osdk/foundry.streams': 2.57.0
       '@osdk/foundry.thirdpartyapplications': 2.57.0
       '@osdk/foundry.widgets': 2.57.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
+  '@osdk/foundry@2.60.0-rc1':
+    dependencies:
+      '@osdk/foundry.admin': 2.59.0
+      '@osdk/foundry.aipagents': 2.59.0
+      '@osdk/foundry.audit': 2.59.0
+      '@osdk/foundry.checkpoints': 2.59.0
+      '@osdk/foundry.connectivity': 2.59.0
+      '@osdk/foundry.core': 2.59.0
+      '@osdk/foundry.datahealth': 2.59.0
+      '@osdk/foundry.datasets': 2.59.0
+      '@osdk/foundry.filesystem': 2.59.0
+      '@osdk/foundry.functions': 2.59.0
+      '@osdk/foundry.geo': 2.59.0
+      '@osdk/foundry.geojson': 2.59.0
+      '@osdk/foundry.languagemodels': 2.59.0
+      '@osdk/foundry.mediasets': 2.59.0
+      '@osdk/foundry.models': 2.59.0
+      '@osdk/foundry.notepad': 2.59.0
+      '@osdk/foundry.ontologies': 2.59.0
+      '@osdk/foundry.operations': 2.59.0
+      '@osdk/foundry.orchestration': 2.59.0
+      '@osdk/foundry.pack': 2.59.0
+      '@osdk/foundry.publicapis': 2.59.0
+      '@osdk/foundry.sqlqueries': 2.59.0
+      '@osdk/foundry.streams': 2.59.0
+      '@osdk/foundry.thirdpartyapplications': 2.59.0
+      '@osdk/foundry.widgets': 2.59.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -28082,17 +28386,6 @@ snapshots:
       - supports-color
       - typescript
 
-  '@svgr/core@8.1.0(typescript@5.8.3)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.28.4)
-      camelcase: 6.3.0
-      cosmiconfig: 8.3.6(typescript@5.8.3)
-      snake-case: 3.0.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   '@svgr/hast-util-to-babel-ast@8.0.0':
     dependencies:
       '@babel/types': 7.28.4
@@ -28108,16 +28401,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.8.3))':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.28.4)
-      '@svgr/core': 8.1.0(typescript@5.8.3)
-      '@svgr/hast-util-to-babel-ast': 8.0.0
-      svg-parser: 2.0.4
-    transitivePeerDependencies:
-      - supports-color
-
   '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.5.4))(typescript@5.5.4)':
     dependencies:
       '@svgr/core': 8.1.0(typescript@5.5.4)
@@ -28127,25 +28410,16 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.8.3))(typescript@5.8.3)':
-    dependencies:
-      '@svgr/core': 8.1.0(typescript@5.8.3)
-      cosmiconfig: 8.3.6(typescript@5.8.3)
-      deepmerge: 4.3.1
-      svgo: 3.3.3
-    transitivePeerDependencies:
-      - typescript
-
-  '@svgr/webpack@8.1.0(typescript@5.8.3)':
+  '@svgr/webpack@8.1.0(typescript@5.5.4)':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-transform-react-constant-elements': 7.27.1(@babel/core@7.28.4)
       '@babel/preset-env': 7.26.0(@babel/core@7.28.4)
       '@babel/preset-react': 7.25.9(@babel/core@7.28.4)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.4)
-      '@svgr/core': 8.1.0(typescript@5.8.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))(typescript@5.8.3)
+      '@svgr/core': 8.1.0(typescript@5.5.4)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.5.4))
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.5.4))(typescript@5.5.4)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -29305,7 +29579,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.3)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.3))':
+  '@vitejs/plugin-react@4.7.0(vite@8.0.8(@types/node@24.12.0)(esbuild@0.25.9)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.4)
@@ -29313,7 +29587,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 8.0.8(@types/node@24.12.0)(esbuild@0.27.3)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@24.12.0)(esbuild@0.25.9)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -29322,9 +29596,9 @@ snapshots:
       vite: 7.3.2(@types/node@24.12.0)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.3)
       vue: 3.5.21(typescript@5.5.4)
 
-  '@vitejs/plugin-vue@5.2.4(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.3)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.3))(vue@3.5.21(typescript@5.5.4))':
+  '@vitejs/plugin-vue@5.2.4(vite@8.0.8(@types/node@24.12.0)(esbuild@0.25.9)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.3))(vue@3.5.21(typescript@5.5.4))':
     dependencies:
-      vite: 8.0.8(@types/node@24.12.0)(esbuild@0.27.3)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@24.12.0)(esbuild@0.25.9)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.3)
       vue: 3.5.21(typescript@5.5.4)
 
   '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(happy-dom@20.8.9)(jiti@2.5.1)(jsdom@20.0.3(canvas@2.11.2))(less@4.5.1)(lightningcss@1.32.0)(msw@2.11.1(@types/node@24.12.0)(typescript@5.5.4))(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.3))':
@@ -29621,17 +29895,17 @@ snapshots:
 
   '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.106.1)':
     dependencies:
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)(webpack-cli@6.0.1)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack@5.106.1)
 
   '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.106.1)':
     dependencies:
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)(webpack-cli@6.0.1)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack@5.106.1)
 
   '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack@5.106.1)':
     dependencies:
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)(webpack-cli@6.0.1)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack@5.106.1)
 
   '@wry/trie@0.5.0':
@@ -30087,12 +30361,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.2.1(@babel/core@7.28.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  babel-loader@9.2.1(@babel/core@7.28.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)):
     dependencies:
       '@babel/core': 7.28.4
       find-cache-dir: 4.0.0
       schema-utils: 4.3.2
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
 
   babel-plugin-dev-expression@0.2.3(@babel/core@7.28.4):
     dependencies:
@@ -30927,7 +31201,7 @@ snapshots:
 
   copy-text-to-clipboard@3.2.2: {}
 
-  copy-webpack-plugin@11.0.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  copy-webpack-plugin@11.0.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)):
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
@@ -30935,7 +31209,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.2
       serialize-javascript: 6.0.2
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
 
   core-js-compat@3.45.1:
     dependencies:
@@ -30970,15 +31244,6 @@ snapshots:
       path-type: 4.0.0
     optionalDependencies:
       typescript: 5.5.4
-
-  cosmiconfig@8.3.6(typescript@5.8.3):
-    dependencies:
-      import-fresh: 3.3.1
-      js-yaml: 4.1.1
-      parse-json: 5.2.0
-      path-type: 4.0.0
-    optionalDependencies:
-      typescript: 5.8.3
 
   crc-32@1.2.2: {}
 
@@ -31145,7 +31410,7 @@ snapshots:
     dependencies:
       hyphenate-style-name: 1.1.0
 
-  css-loader@6.11.0(@rspack/core@1.6.7)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  css-loader@6.11.0(@rspack/core@1.6.7)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.9)
       postcss: 8.5.9
@@ -31157,7 +31422,7 @@ snapshots:
       semver: 7.7.4
     optionalDependencies:
       '@rspack/core': 1.6.7
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
 
   css-loader@7.1.4(@rspack/core@1.6.7)(webpack@5.106.1):
     dependencies:
@@ -31171,9 +31436,9 @@ snapshots:
       semver: 7.7.4
     optionalDependencies:
       '@rspack/core': 1.6.7
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)(webpack-cli@6.0.1)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)(webpack-cli@6.0.1)
 
-  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.27.3)(lightningcss@1.32.0)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.25.9)(lightningcss@1.32.0)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.30
       cssnano: 6.1.2(postcss@8.5.9)
@@ -31181,10 +31446,10 @@ snapshots:
       postcss: 8.5.9
       schema-utils: 4.3.2
       serialize-javascript: 6.0.2
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
     optionalDependencies:
       clean-css: 5.3.3
-      esbuild: 0.27.3
+      esbuild: 0.25.9
       lightningcss: 1.32.0
 
   css-prefers-color-scheme@11.0.0(postcss@8.5.6):
@@ -32004,7 +32269,7 @@ snapshots:
       eslint: 9.35.0(jiti@2.5.1)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-expo: 0.1.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-react: 7.37.5(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-react-hooks: 4.6.2(eslint@9.35.0(jiti@2.5.1))
     transitivePeerDependencies:
@@ -32038,11 +32303,11 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -32066,7 +32331,7 @@ snapshots:
     dependencies:
       eslint: 9.35.0(jiti@2.5.1)
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -32077,7 +32342,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.35.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -32838,11 +33103,11 @@ snapshots:
     dependencies:
       flat-cache: 5.0.0
 
-  file-loader@6.2.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  file-loader@6.2.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
 
   filesize@8.0.7: {}
 
@@ -32983,7 +33248,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)):
     dependencies:
       '@babel/code-frame': 7.27.1
       '@types/json-schema': 7.0.15
@@ -32998,8 +33263,8 @@ snapshots:
       schema-utils: 2.7.0
       semver: 7.7.4
       tapable: 1.1.3
-      typescript: 5.8.3
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      typescript: 5.5.4
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
     optionalDependencies:
       eslint: 9.35.0(jiti@2.5.1)
 
@@ -33564,7 +33829,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.5(@rspack/core@1.6.7)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  html-webpack-plugin@5.6.5(@rspack/core@1.6.7)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -33573,7 +33838,7 @@ snapshots:
       tapable: 2.2.3
     optionalDependencies:
       '@rspack/core': 1.6.7
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -34279,7 +34544,7 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  jest-expo@52.0.6(@babel/core@7.28.4)(canvas@2.11.2)(expo@52.0.47(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@expo/metro-runtime@4.0.1(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1)))(graphql@16.8.1)(react-native-webview@13.12.2(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1))(jest@29.7.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.7.39)(@types/node@24.12.0)(typescript@5.5.4)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  jest-expo@52.0.6(@babel/core@7.28.4)(canvas@2.11.2)(expo@52.0.47(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@expo/metro-runtime@4.0.1(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1)))(graphql@16.8.1)(react-native-webview@13.12.2(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1))(jest@29.7.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.7.39)(@types/node@24.12.0)(typescript@5.5.4)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)):
     dependencies:
       '@expo/config': 10.0.11
       '@expo/json-file': 9.1.5
@@ -34296,7 +34561,7 @@ snapshots:
       json5: 2.2.3
       lodash: 4.18.1
       react-native: 0.76.3(@babel/core@7.28.4)(@babel/preset-env@7.26.0(@babel/core@7.28.4))(@types/react@18.3.24)(react@18.3.1)
-      react-server-dom-webpack: 19.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      react-server-dom-webpack: 19.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
       react-test-renderer: 18.3.1(react@18.3.1)
       server-only: 0.0.1
       stacktrace-js: 2.0.2
@@ -35893,11 +36158,11 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  mini-css-extract-plugin@2.9.4(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.3
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
 
   minimalistic-assert@1.0.1: {}
 
@@ -37033,13 +37298,13 @@ snapshots:
       tsx: 4.20.5
       yaml: 2.8.3
 
-  postcss-loader@7.3.4(postcss@8.5.6)(typescript@5.8.3)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  postcss-loader@7.3.4(postcss@8.5.6)(typescript@5.5.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)):
     dependencies:
-      cosmiconfig: 8.3.6(typescript@5.8.3)
+      cosmiconfig: 8.3.6(typescript@5.5.4)
       jiti: 1.21.7
       postcss: 8.5.6
       semver: 7.7.4
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
     transitivePeerDependencies:
       - typescript
 
@@ -37749,7 +38014,7 @@ snapshots:
       date-fns: 2.30.0
       react: 18.3.1
 
-  react-dev-utils@12.0.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  react-dev-utils@12.0.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)):
     dependencies:
       '@babel/code-frame': 7.27.1
       address: 1.2.2
@@ -37760,7 +38025,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -37775,9 +38040,9 @@ snapshots:
       shell-quote: 1.8.3
       strip-ansi: 6.0.1
       text-table: 0.2.0
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.5.4
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -37856,11 +38121,11 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@18.3.1))(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@18.3.1))(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)):
     dependencies:
       '@babel/runtime': 7.28.4
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.3.1)'
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
 
   react-map-gl@8.0.4(maplibre-gl@5.7.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -38168,13 +38433,13 @@ snapshots:
       '@remix-run/router': 1.23.0
       react: 18.3.1
 
-  react-server-dom-webpack@19.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  react-server-dom-webpack@19.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)):
     dependencies:
       acorn-loose: 8.4.0
       neo-async: 2.6.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
       webpack-sources: 3.3.3
 
   react-shallow-renderer@16.15.0(react@18.3.1):
@@ -39784,17 +40049,17 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser-webpack-plugin@5.3.14(@swc/core@1.7.39)(esbuild@0.27.3)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  terser-webpack-plugin@5.3.14(@swc/core@1.7.39)(esbuild@0.25.9)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.30
       jest-worker: 27.5.1
       schema-utils: 4.3.2
       serialize-javascript: 6.0.2
       terser: 5.44.0
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
     optionalDependencies:
       '@swc/core': 1.7.39
-      esbuild: 0.27.3
+      esbuild: 0.25.9
 
   terser-webpack-plugin@5.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)):
     dependencies:
@@ -39806,29 +40071,17 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.7.39
       esbuild: 0.25.9
-    optional: true
 
-  terser-webpack-plugin@5.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  terser-webpack-plugin@5.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(webpack@5.106.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.30
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.44.0
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)(webpack-cli@6.0.1)
     optionalDependencies:
       '@swc/core': 1.7.39
-      esbuild: 0.27.3
-
-  terser-webpack-plugin@5.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(webpack@5.106.1):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.30
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.44.0
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)(webpack-cli@6.0.1)
-    optionalDependencies:
-      '@swc/core': 1.7.39
-      esbuild: 0.27.3
+      esbuild: 0.25.9
 
   terser@5.44.0:
     dependencies:
@@ -40000,7 +40253,7 @@ snapshots:
       semver: 7.7.4
       source-map: 0.7.4
       typescript: 5.5.4
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)(webpack-cli@6.0.1)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)(webpack-cli@6.0.1)
 
   ts-morph@19.0.0:
     dependencies:
@@ -40324,7 +40577,8 @@ snapshots:
 
   typescript@5.8.2: {}
 
-  typescript@5.8.3: {}
+  typescript@5.8.3:
+    optional: true
 
   typewise-core@1.2.0: {}
 
@@ -40555,14 +40809,14 @@ snapshots:
 
   uri-template-matcher@1.1.2: {}
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)))(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)))(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
 
   url-parse@1.5.10:
     dependencies:
@@ -40899,7 +41153,7 @@ snapshots:
       tsx: 4.20.5
       yaml: 2.8.3
 
-  vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.3)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.3):
+  vite@8.0.8(@types/node@24.12.0)(esbuild@0.25.9)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -40908,7 +41162,7 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 24.12.0
-      esbuild: 0.27.3
+      esbuild: 0.25.9
       fsevents: 2.3.3
       jiti: 2.5.1
       less: 4.5.1
@@ -41232,19 +41486,19 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)(webpack-cli@6.0.1)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)(webpack-cli@6.0.1)
       webpack-merge: 6.0.1
 
-  webpack-dev-middleware@5.3.4(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  webpack-dev-middleware@5.3.4(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.3.3
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
 
-  webpack-dev-server@4.15.2(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  webpack-dev-server@4.15.2(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -41274,10 +41528,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 5.3.4(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      webpack-dev-middleware: 5.3.4(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9))
       ws: 8.18.3
     optionalDependencies:
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -41333,9 +41587,8 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
-    optional: true
 
-  webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3):
+  webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)(webpack-cli@6.0.1):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -41359,39 +41612,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.2
-      terser-webpack-plugin: 5.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
-      watchpack: 2.5.1
-      webpack-sources: 3.3.4
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)(webpack-cli@6.0.1):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.1
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.20.1
-      es-module-lexer: 2.0.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.2
-      terser-webpack-plugin: 5.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(webpack@5.106.1)
+      terser-webpack-plugin: 5.4.0(@swc/core@1.7.39)(esbuild@0.25.9)(webpack@5.106.1)
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     optionalDependencies:
@@ -41401,7 +41622,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpackbar@7.0.0(@rspack/core@1.6.7)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  webpackbar@7.0.0(@rspack/core@1.6.7)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)):
     dependencies:
       ansis: 3.17.0
       consola: 3.4.2
@@ -41409,7 +41630,7 @@ snapshots:
       std-env: 3.9.0
     optionalDependencies:
       '@rspack/core': 1.6.7
-      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
+      webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.25.9)
 
   websocket-driver@0.7.4:
     dependencies:


### PR DESCRIPTION
selecting a value in one filter was refetching every other filter's aggregation because per-filter where-clause references churned on every render

• stabilize per-key where-clause refs in useFilterListState with a deep-equal cache
• add useStableMapEntries helper for per-entry structural memoization
• unchanged filters keep their previous clause reference and skip refetching