### PR TITLE
combobox: cap popup max-height at 320px

### DIFF
--- a/.changeset/combobox-popup-max-height.md
+++ b/.changeset/combobox-popup-max-height.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Cap the Combobox popup at 320px (configurable via `--osdk-combobox-popup-max-height`) with overflow scrolling. Long option lists no longer push other UI off-screen — they scroll inside the popup. A short browser window still gets a smaller cap because the rule resolves to `min(320px, var(--available-height))`.

--- a/packages/react-components/src/base-components/combobox/Combobox.module.css
+++ b/packages/react-components/src/base-components/combobox/Combobox.module.css
@@ -303,7 +303,10 @@
   display: flex;
   flex-direction: column;
   min-width: var(--anchor-width);
-  max-height: var(--available-height);
+  max-height: min(
+    var(--osdk-combobox-popup-max-height, 320px),
+    var(--available-height)
+  );
   overflow-y: auto;
   padding: calc(
     var(--osdk-combobox-spacing, var(--osdk-surface-spacing)) * 1.5

--- a/packages/react-components/src/base-components/combobox/Combobox.module.css
+++ b/packages/react-components/src/base-components/combobox/Combobox.module.css
@@ -304,7 +304,7 @@
   flex-direction: column;
   min-width: var(--anchor-width);
   max-height: min(
-    var(--osdk-combobox-popup-max-height, 320px),
+    var(--osdk-combobox-popup-max-height),
     var(--available-height)
   );
   overflow-y: auto;

--- a/packages/react-components/src/tokens.css
+++ b/packages/react-components/src/tokens.css
@@ -6,6 +6,7 @@
 @import "./tokens/component-tokens/button.css";
 @import "./tokens/component-tokens/cbac-picker.css";
 @import "./tokens/component-tokens/checkbox.css";
+@import "./tokens/component-tokens/combobox.css";
 @import "./tokens/component-tokens/datetime-picker.css";
 @import "./tokens/component-tokens/dialog.css";
 @import "./tokens/component-tokens/draggable.css";

--- a/packages/react-components/src/tokens/component-tokens/combobox.css
+++ b/packages/react-components/src/tokens/component-tokens/combobox.css
@@ -1,0 +1,8 @@
+:root {
+  /* Combobox popup: cap the dropdown's max-height so very long option lists
+     scroll inside the popup instead of forcing the popup to grow tall enough
+     to push other UI off-screen. The actual `max-height` rule uses
+     `min(this token, --available-height)` so the cap is automatically lowered
+     on short viewports. */
+  --osdk-combobox-popup-max-height: 320px;
+}

--- a/packages/react-components/src/tokens/component-tokens/combobox.css
+++ b/packages/react-components/src/tokens/component-tokens/combobox.css
@@ -2,7 +2,8 @@
   /* Combobox popup: cap the dropdown's max-height so very long option lists
      scroll inside the popup instead of forcing the popup to grow tall enough
      to push other UI off-screen. The actual `max-height` rule uses
-     `min(this token, --available-height)` so the cap is automatically lowered
-     on short viewports. */
+     `min(this token, --available-height)` — `--available-height` is set
+     automatically by Base UI's `Combobox.Positioner` (same source as
+     `--anchor-width`) so the cap is automatically lowered on short viewports. */
   --osdk-combobox-popup-max-height: 320px;
 }


### PR DESCRIPTION
## Summary
• long option lists were pushing other UI off-screen because the popup grew to fill available viewport space
• combobox popup max-height now resolves to \`min(var(--osdk-combobox-popup-max-height, 320px), var(--available-height))\` so it stays viewport-aware
• default cap is themable via the new \`--osdk-combobox-popup-max-height\` token in tokens/component-tokens/combobox.css

## Test plan
- [ ] \`pnpm turbo typecheck --filter=@osdk/react-components\`
- [ ] storybook → any combobox with > ~10 options — popup caps at 320px and scrolls inside
- [ ] computed style on the popup shows max-height: 320px (or smaller if the viewport is shorter)