### PR TITLE
filter-list: horizontal orientation

### DIFF
--- a/.changeset/combobox-popup-max-height.md
+++ b/.changeset/combobox-popup-max-height.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Cap the Combobox popup at 320px (configurable via `--osdk-combobox-popup-max-height`) with overflow scrolling. Long option lists no longer push other UI off-screen — they scroll inside the popup. A short browser window still gets a smaller cap because the rule resolves to `min(320px, var(--available-height))`.

--- a/.changeset/filter-list-click-to-filter.md
+++ b/.changeset/filter-list-click-to-filter.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+Add `clickToFilter` to `DATE_RANGE` and `NUMBER_RANGE` property filter definitions in FilterList. When set to true, clicking a bar in the histogram replaces the filter range with that bucket's `[min, max]`. Off by default; clicking a second bar replaces the previous selection (multi-bucket / shift+click union not supported in v1).

--- a/.changeset/filter-list-format-date.md
+++ b/.changeset/filter-list-format-date.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+Add per-property `formatDate` and `parseDate` callbacks to date-typed property filter definitions in `FilterList`. When provided, `formatDate` is used by the date-range histogram tooltip, multi-date chip text, and timeline labels. The HTML `<input type="date">` value attribute is unaffected and always uses ISO `YYYY-MM-DD`. The conditional intersection type `PropertyFilterDateExtras` gates `formatDate` / `parseDate` to `datetime` and `timestamp` properties only — setting them on number- or string-typed property filters is a TypeScript error.

--- a/.changeset/filter-list-horizontal-orientation.md
+++ b/.changeset/filter-list-horizontal-orientation.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+Add `orientation="horizontal"` to FilterList. In horizontal mode, filters render as a row of label-left inputs. Compact filters (`CONTAINS_TEXT`, `SINGLE_DATE`, `TOGGLE`) render inline; tall filters collapse into a button trigger that opens the existing input UI in a popover. New `HorizontalFilterTrigger` component, new `summarizeFilterValue` helper for the trigger label, and dnd-kit switches to `horizontalListSortingStrategy` for drag-reorder. The popover content only mounts when opened so aggregation queries don't fire until the user interacts with the filter.

--- a/.changeset/filter-list-no-value-label.md
+++ b/.changeset/filter-list-no-value-label.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+Standardize "No value" rendering in FilterList — introduce a shared `NoValueLabel` component (italic, muted) used by listogram buckets, single-select and multi-select dropdown options, multi-select chips, text-tag chips, and the `NullValueWrapper` include-null row. Adds an `isEmptyValue` helper. Legacy `--osdk-filter-listogram-empty-label-*` and `--osdk-filter-null-label-color` tokens remain as forwarders onto the canonical `--osdk-filter-no-value-color` / `--osdk-filter-no-value-font-style` tokens so existing theme overrides continue to work.

--- a/.changeset/filter-list-stable-render-input.md
+++ b/.changeset/filter-list-stable-render-input.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Stop FilterList from re-rendering every filter on each value selection. The internal `renderInput` callback no longer closes over `perFilterWhereClauses`, so its identity stays stable across selections and `FilterListItem`'s memoization holds for filters whose own props did not change. The per-filter where clause is now plumbed down to each item via a new optional `whereClauseForFilter` arg on the render-input call (additive — existing custom `renderInput` consumers are unaffected).

--- a/.changeset/filter-list-svg-histogram.md
+++ b/.changeset/filter-list-svg-histogram.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+Replace the div-based date and number range histograms in FilterList with SVG that adds y-axis grid lines at "nice" tick values, count labels above each non-empty bar, x-axis tick labels (per-bucket for date histograms; first/last only for number histograms), and a period subtitle for date ranges that fit inside one calendar period. New `createDateHistogramBuckets` helper picks day/month/year granularity from the data span and snaps bucket boundaries to calendar starts. Date histograms route their subtitle through `formatDate` (Item 5) when provided.

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
@@ -1904,3 +1904,51 @@ export const NoValueRendering: Story = {
     </div>
   ),
 };
+
+const LONG_DROPDOWN_VALUES = Array.from(
+  { length: 100 },
+  (_, i) => `Option ${String(i + 1).padStart(3, "0")}`,
+);
+
+const LONG_DROPDOWN_FILTERS: FilterDefinitionUnion<Employee>[] = [
+  {
+    type: "STATIC_VALUES",
+    key: "department",
+    label: "Long single-select",
+    filterComponent: "SINGLE_SELECT",
+    values: LONG_DROPDOWN_VALUES,
+    filterState: { type: "SELECT", selectedValues: [] },
+  },
+  {
+    type: "STATIC_VALUES",
+    key: "team",
+    label: "Long multi-select",
+    filterComponent: "MULTI_SELECT",
+    values: LONG_DROPDOWN_VALUES,
+    filterState: { type: "SELECT", selectedValues: [] },
+  },
+];
+
+export const LongDropdown: Story = {
+  name: "Long dropdown (popup max-height)",
+  parameters: {
+    docs: {
+      description: {
+        story: "Combobox popup is capped at 320px (configurable via "
+          + "`--osdk-combobox-popup-max-height`). With 100 options, the popup "
+          + "becomes scrollable instead of growing tall enough to push other "
+          + "UI off-screen. When the available browser height is less than "
+          + "320px, the cap is lowered automatically because the rule "
+          + "resolves to `min(320px, var(--available-height))`.",
+      },
+    },
+  },
+  render: () => (
+    <div style={SIDEBAR_STYLE}>
+      <FilterList
+        objectType={Employee}
+        filterDefinitions={LONG_DROPDOWN_FILTERS}
+      />
+    </div>
+  ),
+};

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
@@ -1952,3 +1952,83 @@ export const LongDropdown: Story = {
     </div>
   ),
 };
+
+const slashDate = (d: Date): string =>
+  `${String(d.getMonth() + 1).padStart(2, "0")}/${
+    String(d.getDate()).padStart(2, "0")
+  }/${d.getFullYear()}`;
+
+const slashDateParse = (text: string): Date | undefined => {
+  const match = text.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+  if (!match) return undefined;
+  return new Date(
+    Number(match[3]),
+    Number(match[1]) - 1,
+    Number(match[2]),
+  );
+};
+
+const FORMAT_DATE_FILTERS: FilterDefinitionUnion<Employee>[] = [
+  {
+    type: "PROPERTY",
+    id: "startDate-range",
+    key: "firstFullTimeStartDate",
+    label: "Start date (range)",
+    filterComponent: "DATE_RANGE",
+    filterState: { type: "DATE_RANGE" },
+    formatDate: slashDate,
+    parseDate: slashDateParse,
+  },
+  {
+    type: "PROPERTY",
+    id: "startDate-multi",
+    key: "firstFullTimeStartDate",
+    label: "Start date (multi)",
+    filterComponent: "MULTI_DATE",
+    filterState: {
+      type: "SELECT",
+      selectedValues: [new Date(2020, 4, 1), new Date(2021, 8, 15)],
+    },
+    formatDate: slashDate,
+    parseDate: slashDateParse,
+  },
+  {
+    type: "PROPERTY",
+    id: "startDate-timeline",
+    key: "firstFullTimeStartDate",
+    label: "Start date (timeline)",
+    filterComponent: "TIMELINE",
+    filterState: {
+      type: "TIMELINE",
+      startDate: new Date(2020, 0, 1),
+      endDate: new Date(2024, 11, 31),
+    },
+    formatDate: slashDate,
+    parseDate: slashDateParse,
+  },
+];
+
+export const FormatDate: Story = {
+  name: "Per-property formatDate",
+  parameters: {
+    docs: {
+      description: {
+        story: "Date-typed property filter definitions accept optional "
+          + "`formatDate` and `parseDate` callbacks (see `PropertyFilterDateExtras`). "
+          + "When provided, `formatDate` is used for the date-range histogram "
+          + "tooltip, multi-date chip text, and timeline labels. The HTML "
+          + "`<input type=\"date\">` value attribute is unaffected and always "
+          + "uses ISO `YYYY-MM-DD`. `parseDate` is plumbed through for "
+          + "completeness; the built-in HTML date inputs do not invoke it.",
+      },
+    },
+  },
+  render: () => (
+    <div style={SIDEBAR_STYLE}>
+      <FilterList
+        objectType={Employee}
+        filterDefinitions={FORMAT_DATE_FILTERS}
+      />
+    </div>
+  ),
+};

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
@@ -2054,6 +2054,50 @@ const CLICK_TO_FILTER_DEFINITIONS: FilterDefinitionUnion<Employee>[] = [
   },
 ];
 
+const HORIZONTAL_FILTERS: FilterDefinitionUnion<Employee>[] = [
+  fullNameFilter,
+  departmentFilter,
+  jobTitleMultiSelectFilter,
+  startDateFilter,
+  employeeNumberFilter,
+  locationCityFilter,
+];
+
+const HORIZONTAL_BAR_STYLE = {
+  width: "100%",
+  maxWidth: 1000,
+  border: "1px solid #e5e7eb",
+  borderRadius: 6,
+  background: "#fff",
+} as const;
+
+export const Horizontal: Story = {
+  name: "Horizontal orientation",
+  parameters: {
+    docs: {
+      description: {
+        story: "When `orientation=\"horizontal\"`, FilterList renders as a "
+          + "row of label-left filters. Compact filters (`CONTAINS_TEXT`, "
+          + "`SINGLE_DATE`, `TOGGLE`) render inline; tall filters collapse "
+          + "into a button trigger that opens the existing input UI in a "
+          + "popover. The popover content only mounts when opened, so "
+          + "aggregation queries don't fire until the user interacts with "
+          + "the filter.",
+      },
+    },
+  },
+  render: () => (
+    <div style={HORIZONTAL_BAR_STYLE}>
+      <FilterList
+        objectType={Employee}
+        title="Filters"
+        filterDefinitions={HORIZONTAL_FILTERS}
+        orientation="horizontal"
+      />
+    </div>
+  ),
+};
+
 export const ClickToFilter: Story = {
   name: "Click bar to set range",
   parameters: {

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
@@ -1855,3 +1855,52 @@ const nameContainsFilter = {
   },
   render: (args) => <WithCustomFiltersStory {...args} />,
 };
+
+const departmentMultiSelectFilter: FilterDefinitionUnion<Employee> = {
+  type: "PROPERTY",
+  id: "department-multi",
+  key: "department",
+  label: "Department",
+  filterComponent: "MULTI_SELECT",
+  filterState: { type: "SELECT", selectedValues: [] },
+};
+
+const departmentSingleSelectFilter: FilterDefinitionUnion<Employee> = {
+  type: "PROPERTY",
+  id: "department-single",
+  key: "department",
+  label: "Department (single)",
+  filterComponent: "SINGLE_SELECT",
+  filterState: { type: "SELECT", selectedValues: [] },
+};
+
+const NO_VALUE_FILTER_DEFINITIONS: FilterDefinitionUnion<Employee>[] = [
+  departmentFilter,
+  departmentMultiSelectFilter,
+  departmentSingleSelectFilter,
+  employeeNumberFilter,
+];
+
+export const NoValueRendering: Story = {
+  name: "No value rendering",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Empty/null filter values render via the canonical `<NoValueLabel />` "
+          + "component — italic, muted, with the literal text 'No value' — across "
+          + "listogram buckets, single-select dropdown options, multi-select dropdown "
+          + "options, and multi-select chips. The mock dataset includes one Employee "
+          + "with `department: \"\"` so the No value row is visible in the listogram.",
+      },
+    },
+  },
+  render: () => (
+    <div style={SIDEBAR_STYLE}>
+      <FilterList
+        objectType={Employee}
+        filterDefinitions={NO_VALUE_FILTER_DEFINITIONS}
+      />
+    </div>
+  ),
+};

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
@@ -2032,3 +2032,48 @@ export const FormatDate: Story = {
     </div>
   ),
 };
+
+const CLICK_TO_FILTER_DEFINITIONS: FilterDefinitionUnion<Employee>[] = [
+  {
+    type: "PROPERTY",
+    id: "startDate-click",
+    key: "firstFullTimeStartDate",
+    label: "Start date (click bars)",
+    filterComponent: "DATE_RANGE",
+    filterState: { type: "DATE_RANGE" },
+    clickToFilter: true,
+  },
+  {
+    type: "PROPERTY",
+    id: "employeeNumber-click",
+    key: "employeeNumber",
+    label: "Employee number (click bars)",
+    filterComponent: "NUMBER_RANGE",
+    filterState: { type: "NUMBER_RANGE" },
+    clickToFilter: true,
+  },
+];
+
+export const ClickToFilter: Story = {
+  name: "Click bar to set range",
+  parameters: {
+    docs: {
+      description: {
+        story: "When `clickToFilter: true` is set on a `DATE_RANGE` or "
+          + "`NUMBER_RANGE` property filter definition, clicking a bar in "
+          + "the histogram replaces the filter range with that bucket's "
+          + "`[min, max]`. Clicking a second bar replaces the previous "
+          + "selection — multi-bucket / shift+click union is not supported "
+          + "in v1.",
+      },
+    },
+  },
+  render: () => (
+    <div style={SIDEBAR_STYLE}>
+      <FilterList
+        objectType={Employee}
+        filterDefinitions={CLICK_TO_FILTER_DEFINITIONS}
+      />
+    </div>
+  ),
+};

--- a/packages/react-components/src/base-components/combobox/Combobox.module.css
+++ b/packages/react-components/src/base-components/combobox/Combobox.module.css
@@ -303,7 +303,10 @@
   display: flex;
   flex-direction: column;
   min-width: var(--anchor-width);
-  max-height: var(--available-height);
+  max-height: min(
+    var(--osdk-combobox-popup-max-height, 320px),
+    var(--available-height)
+  );
   overflow-y: auto;
   padding: calc(
     var(--osdk-combobox-spacing, var(--osdk-surface-spacing)) * 1.5

--- a/packages/react-components/src/filter-list/FilterList.tsx
+++ b/packages/react-components/src/filter-list/FilterList.tsx
@@ -153,11 +153,11 @@ export function FilterList<Q extends ObjectTypeDefinition>(
     (
       {
         definition,
-        filterKey,
         filterState,
         onFilterStateChanged,
         searchQuery,
         excludeRowOpen,
+        whereClauseForFilter,
       },
     ) => (
       <FilterInput
@@ -166,13 +166,13 @@ export function FilterList<Q extends ObjectTypeDefinition>(
         definition={definition}
         filterState={filterState}
         onFilterStateChanged={onFilterStateChanged}
-        whereClause={perFilterWhereClauses.get(filterKey)
+        whereClause={(whereClauseForFilter as WhereClause<Q> | undefined)
           ?? ({} as WhereClause<Q>)}
         searchQuery={searchQuery}
         excludeRowOpen={excludeRowOpen}
       />
     ),
-    [objectType, objectSet, perFilterWhereClauses],
+    [objectType, objectSet],
   );
 
   return (
@@ -196,6 +196,7 @@ export function FilterList<Q extends ObjectTypeDefinition>(
       onFilterRemoved={effectiveOnFilterRemoved}
       className={className}
       renderAddFilterButton={effectiveRenderAddFilterButton}
+      perFilterWhereClauses={perFilterWhereClauses}
     />
   );
 }

--- a/packages/react-components/src/filter-list/FilterList.tsx
+++ b/packages/react-components/src/filter-list/FilterList.tsx
@@ -24,10 +24,14 @@ import type {
   FilterDefinitionUnion,
   FilterListProps,
 } from "./FilterListApi.js";
+import type { FilterState } from "./FilterListItemApi.js";
 import { useFilterListState } from "./hooks/useFilterListState.js";
 import { useFilterVisibility } from "./hooks/useFilterVisibility.js";
 import { getFilterKey } from "./utils/getFilterKey.js";
-import { getFilterLabel } from "./utils/getFilterLabel.js";
+import {
+  getFilterLabel,
+  summarizeFilterValue,
+} from "./utils/getFilterLabel.js";
 
 export function FilterList<Q extends ObjectTypeDefinition>(
   props: FilterListProps<Q>,
@@ -49,6 +53,7 @@ export function FilterList<Q extends ObjectTypeDefinition>(
     onFilterAdded,
     onFilterRemoved,
     renderAddFilterButton,
+    orientation = "vertical",
   } = props;
 
   const {
@@ -149,6 +154,32 @@ export function FilterList<Q extends ObjectTypeDefinition>(
     ? handleFilterRemoved
     : onFilterRemoved;
 
+  const getFilterRenderMode = useCallback(
+    (def: FilterDefinitionUnion<Q>): "inline" | "trigger" => {
+      // Compact filters render inline next to their label; everything
+      // else collapses into a trigger that opens its UI in a popover.
+      if (def.type === "PROPERTY" || def.type === "STATIC_VALUES") {
+        const fc = def.filterComponent;
+        if (
+          fc === "CONTAINS_TEXT" || fc === "SINGLE_DATE" || fc === "TOGGLE"
+        ) {
+          return "inline";
+        }
+      }
+      if (def.type === "HAS_LINK") return "inline";
+      return "trigger";
+    },
+    [],
+  );
+
+  const summarize = useCallback(
+    (
+      def: FilterDefinitionUnion<Q>,
+      filterState: FilterState | undefined,
+    ): React.ReactNode => summarizeFilterValue(def, filterState),
+    [],
+  );
+
   const renderInput = useCallback<RenderFilterInput<FilterDefinitionUnion<Q>>>(
     (
       {
@@ -197,6 +228,9 @@ export function FilterList<Q extends ObjectTypeDefinition>(
       className={className}
       renderAddFilterButton={effectiveRenderAddFilterButton}
       perFilterWhereClauses={perFilterWhereClauses}
+      orientation={orientation}
+      getFilterRenderMode={getFilterRenderMode}
+      summarizeFilterValue={summarize}
     />
   );
 }

--- a/packages/react-components/src/filter-list/FilterListApi.ts
+++ b/packages/react-components/src/filter-list/FilterListApi.ts
@@ -230,4 +230,15 @@ export interface FilterListProps<Q extends ObjectTypeDefinition> {
    *   The consumer is responsible for all add-filter behavior.
    */
   renderAddFilterButton?: () => React.ReactNode;
+
+  /**
+   * Layout orientation. When `"horizontal"`, filters render as a row of
+   * label-left inputs. Compact inputs (`CONTAINS_TEXT`, `SINGLE_DATE`,
+   * `TOGGLE`) render inline; tall/complex inputs collapse into a button
+   * trigger that opens the existing input UI in a popover. Defaults to
+   * `"vertical"`.
+   *
+   * @default "vertical"
+   */
+  orientation?: "vertical" | "horizontal";
 }

--- a/packages/react-components/src/filter-list/FilterListItemApi.ts
+++ b/packages/react-components/src/filter-list/FilterListItemApi.ts
@@ -208,13 +208,38 @@ export interface ToggleFilterState extends BaseFilterState {
 }
 
 /**
- * A property filter definition specifies configuration for filtering on a single property
+ * Optional date formatting/parsing callbacks. Mixed into
+ * `PropertyFilterDefinition` only when the property is `datetime` or
+ * `timestamp` — see {@link PropertyFilterDateExtras}.
  *
- * The component type C must be compatible with the property type derived from the key.
- * For example, boolean properties can only use LISTOGRAM or SINGLE_SELECT,
- * while string properties can use LISTOGRAM, TEXT_TAGS, CONTAINS_TEXT, SINGLE_SELECT, or MULTI_SELECT.
+ * Display surfaces (date-range histogram tooltip, multi-date chip text,
+ * timeline labels) call `formatDate` when provided; otherwise dates render
+ * via the default locale-aware formatter.
+ *
+ * `parseDate` is the inverse of `formatDate`. It is plumbed through for
+ * consumers that build text-based date inputs but is not invoked by the
+ * built-in HTML `<input type="date">` controls (the browser handles those).
+ *
+ * Both functions receive/return `Date` instances in local time. If the
+ * property is a UTC ISO string and you want a different timezone, do that
+ * conversion inside your callback.
  */
-export interface PropertyFilterDefinition<
+export interface DateFormattingProps {
+  formatDate?: (date: Date) => string;
+  parseDate?: (text: string) => Date | undefined;
+}
+
+/**
+ * Conditionally adds `formatDate` / `parseDate` to a property filter
+ * definition only for `datetime` / `timestamp` properties. For other
+ * property types these fields are typed as `never` so attempting to set
+ * them is a TypeScript error.
+ */
+export type PropertyFilterDateExtras<P extends WirePropertyTypes> = P extends
+  "datetime" | "timestamp" ? DateFormattingProps
+  : { formatDate?: never; parseDate?: never };
+
+interface PropertyFilterDefinitionBase<
   Q extends ObjectTypeDefinition,
   K extends PropertyKeys<Q> = PropertyKeys<Q>,
   C extends ValidComponentsForPropertyType<
@@ -295,16 +320,36 @@ export interface PropertyFilterDefinition<
 }
 
 /**
- * Props for a single filter list item component.
- * Extends PropertyFilterDefinition with runtime props for rendering.
+ * A property filter definition specifies configuration for filtering on a single property
+ *
+ * The component type C must be compatible with the property type derived from the key.
+ * For example, boolean properties can only use LISTOGRAM or SINGLE_SELECT,
+ * while string properties can use LISTOGRAM, TEXT_TAGS, CONTAINS_TEXT, SINGLE_SELECT, or MULTI_SELECT.
+ *
+ * Date and datetime properties may additionally specify `formatDate` and `parseDate` — see
+ * {@link PropertyFilterDateExtras}.
  */
-export interface FilterListItemProps<
+export type PropertyFilterDefinition<
   Q extends ObjectTypeDefinition,
   K extends PropertyKeys<Q> = PropertyKeys<Q>,
   C extends ValidComponentsForPropertyType<
     PropertyTypeFromKey<Q, K>
   > = ValidComponentsForPropertyType<PropertyTypeFromKey<Q, K>>,
-> extends PropertyFilterDefinition<Q, K, C> {
+> =
+  & PropertyFilterDefinitionBase<Q, K, C>
+  & PropertyFilterDateExtras<PropertyTypeFromKey<Q, K>>;
+
+/**
+ * Props for a single filter list item component.
+ * Extends PropertyFilterDefinition with runtime props for rendering.
+ */
+export type FilterListItemProps<
+  Q extends ObjectTypeDefinition,
+  K extends PropertyKeys<Q> = PropertyKeys<Q>,
+  C extends ValidComponentsForPropertyType<
+    PropertyTypeFromKey<Q, K>
+  > = ValidComponentsForPropertyType<PropertyTypeFromKey<Q, K>>,
+> = PropertyFilterDefinition<Q, K, C> & {
   objectSet: ObjectSet<Q>;
 
   /**
@@ -314,4 +359,4 @@ export interface FilterListItemProps<
   onFilterStateChanged: (state: FilterStateByComponentType[C]) => void;
 
   onFilterRemoved?: (key: PropertyKeys<Q>) => void;
-}
+};

--- a/packages/react-components/src/filter-list/FilterListItemApi.ts
+++ b/packages/react-components/src/filter-list/FilterListItemApi.ts
@@ -312,6 +312,20 @@ interface PropertyFilterDefinitionBase<
   showCount?: boolean;
 
   /**
+   * When true, clicking a bar in the histogram replaces the filter range
+   * with that bucket's `[min, max]`. Only applies to histogram-rendering
+   * filter components (`NUMBER_RANGE` and `DATE_RANGE`); ignored on other
+   * component types.
+   *
+   * Click replaces the current range — clicking a second bar discards the
+   * previous selection. Multi-bucket selection / shift+click union is NOT
+   * supported in v1.
+   *
+   * @default false
+   */
+  clickToFilter?: boolean;
+
+  /**
    * Controls whether this filter is rendered.
    * When false, the filter is hidden but its state is preserved.
    * @default true

--- a/packages/react-components/src/filter-list/__tests__/FilterListMemoization.test.tsx
+++ b/packages/react-components/src/filter-list/__tests__/FilterListMemoization.test.tsx
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, render } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RenderFilterInput } from "../base/BaseFilterListApi.js";
+import { FilterListContent } from "../base/FilterListContent.js";
+import type { FilterDefinitionUnion } from "../FilterListApi.js";
+import type { FilterState } from "../FilterListItemApi.js";
+import { getFilterKey } from "../utils/getFilterKey.js";
+import { getFilterLabel } from "../utils/getFilterLabel.js";
+import type { MockObjectType } from "./testUtils.js";
+import { createPropertyFilterDef } from "./testUtils.js";
+
+afterEach(cleanup);
+
+type TestDef = FilterDefinitionUnion<typeof MockObjectType>;
+
+function buildDefinitions(): TestDef[] {
+  return [
+    createPropertyFilterDef("name", "CONTAINS_TEXT", {
+      type: "CONTAINS_TEXT",
+    }),
+    createPropertyFilterDef("age", "NUMBER_RANGE", {
+      type: "NUMBER_RANGE",
+      minValue: undefined,
+      maxValue: undefined,
+    }),
+    createPropertyFilterDef("active", "TOGGLE", {
+      type: "TOGGLE",
+      enabled: false,
+    }),
+  ];
+}
+
+function buildStates(defs: TestDef[]): Map<string, FilterState> {
+  const states = new Map<string, FilterState>();
+  for (const def of defs) {
+    if (def.type === "PROPERTY" && def.filterState) {
+      states.set(getFilterKey(def), def.filterState);
+    }
+  }
+  return states;
+}
+
+describe("FilterListContent memoization", () => {
+  it(
+    "does not re-render filter inputs whose state has not changed when another filter's state changes",
+    () => {
+      const definitions = buildDefinitions();
+      const renderCounts: Record<string, number> = {};
+
+      // Stable handler refs — mimics what FilterList.tsx provides via
+      // useCallback. Without these, FilterListItem.memo would bust on every
+      // parent render and the assertion below would always fail regardless
+      // of the perFilterWhereClauses fix.
+      const onFilterStateChanged = vi.fn();
+      const renderInput: RenderFilterInput<TestDef> = ({ filterKey }) => {
+        renderCounts[filterKey] = (renderCounts[filterKey] ?? 0) + 1;
+        return <div data-testid={`input-${filterKey}`} />;
+      };
+
+      function Harness({ states }: { states: Map<string, FilterState> }) {
+        return (
+          <FilterListContent
+            filterDefinitions={definitions}
+            filterStates={states}
+            onFilterStateChanged={onFilterStateChanged}
+            renderInput={renderInput}
+            getFilterKey={getFilterKey}
+            getFilterLabel={getFilterLabel}
+          />
+        );
+      }
+
+      const initialStates = buildStates(definitions);
+      const { rerender } = render(<Harness states={initialStates} />);
+
+      expect(renderCounts.name).toBe(1);
+      expect(renderCounts.age).toBe(1);
+      expect(renderCounts.active).toBe(1);
+
+      // Mutate ONLY the `name` filter's state. Build a new Map so the parent
+      // re-renders (matches what useFilterListState's setFilterState does).
+      const nextStates = new Map(initialStates);
+      nextStates.set("name", { type: "CONTAINS_TEXT", value: "anne" });
+
+      rerender(<Harness states={nextStates} />);
+
+      // Only the changed filter should re-render. Other filters' memoized
+      // outputs hold because all of their props are referentially equal
+      // across renders.
+      expect(renderCounts.name).toBe(2);
+      expect(renderCounts.age).toBe(1);
+      expect(renderCounts.active).toBe(1);
+    },
+  );
+
+  it(
+    "does not bust memoization when perFilterWhereClauses changes shape but a filter's own clause is unchanged",
+    () => {
+      const definitions = buildDefinitions();
+      const renderCounts: Record<string, number> = {};
+      const onFilterStateChanged = vi.fn();
+      const renderInput: RenderFilterInput<TestDef> = ({ filterKey }) => {
+        renderCounts[filterKey] = (renderCounts[filterKey] ?? 0) + 1;
+        return <div data-testid={`input-${filterKey}`} />;
+      };
+
+      function Harness(
+        { perFilterWhereClauses, states }: {
+          perFilterWhereClauses: ReadonlyMap<string, unknown>;
+          states: Map<string, FilterState>;
+        },
+      ) {
+        return (
+          <FilterListContent
+            filterDefinitions={definitions}
+            filterStates={states}
+            onFilterStateChanged={onFilterStateChanged}
+            renderInput={renderInput}
+            getFilterKey={getFilterKey}
+            getFilterLabel={getFilterLabel}
+            perFilterWhereClauses={perFilterWhereClauses}
+          />
+        );
+      }
+
+      const states = buildStates(definitions);
+      const ageClause = { age: { $gt: 30 } };
+      const activeClause = { active: true };
+
+      const initialClauses = new Map<string, unknown>([
+        ["name", { name: "anne" }],
+        ["age", ageClause],
+        ["active", activeClause],
+      ]);
+
+      const { rerender } = render(
+        <Harness states={states} perFilterWhereClauses={initialClauses} />,
+      );
+
+      expect(renderCounts.name).toBe(1);
+      expect(renderCounts.age).toBe(1);
+      expect(renderCounts.active).toBe(1);
+
+      // Selecting a value on `name` rebuilds the whole perFilterWhereClauses
+      // Map. The `name` clause changes; `age` and `active` clauses keep their
+      // existing references (passed by identity, not deep-cloned).
+      const nextClauses = new Map<string, unknown>([
+        ["name", { name: "anne smith" }],
+        ["age", ageClause],
+        ["active", activeClause],
+      ]);
+
+      rerender(
+        <Harness states={states} perFilterWhereClauses={nextClauses} />,
+      );
+
+      // The age and active filters got the SAME whereClauseForFilter
+      // reference, plus all their other props are stable. So they MUST stay
+      // memoized. This is the core invariant Item 4 protects.
+      expect(renderCounts.name).toBe(2);
+      expect(renderCounts.age).toBe(1);
+      expect(renderCounts.active).toBe(1);
+    },
+  );
+
+  it(
+    "forwards whereClauseForFilter from perFilterWhereClauses for each filter",
+    () => {
+      const definitions = buildDefinitions();
+      const states = buildStates(definitions);
+
+      const observedClauses: Record<string, unknown> = {};
+      const renderInput: RenderFilterInput<TestDef> = (
+        { filterKey, whereClauseForFilter },
+      ) => {
+        observedClauses[filterKey] = whereClauseForFilter;
+        return <div data-testid={`input-${filterKey}`} />;
+      };
+
+      const perFilterWhereClauses = new Map<string, unknown>([
+        ["name", { name: "anne" }],
+        ["age", { age: { $gt: 30 } }],
+        ["active", { active: true }],
+      ]);
+
+      render(
+        <FilterListContent
+          filterDefinitions={definitions}
+          filterStates={states}
+          onFilterStateChanged={vi.fn()}
+          renderInput={renderInput}
+          getFilterKey={getFilterKey}
+          getFilterLabel={getFilterLabel}
+          perFilterWhereClauses={perFilterWhereClauses}
+        />,
+      );
+
+      expect(observedClauses.name).toEqual({ name: "anne" });
+      expect(observedClauses.age).toEqual({ age: { $gt: 30 } });
+      expect(observedClauses.active).toEqual({ active: true });
+    },
+  );
+
+  it(
+    "passes undefined to whereClauseForFilter when perFilterWhereClauses is omitted",
+    () => {
+      const definitions = buildDefinitions();
+      const states = buildStates(definitions);
+
+      const observedClauses: Record<string, unknown> = {};
+      const renderInput: RenderFilterInput<TestDef> = (
+        { filterKey, whereClauseForFilter },
+      ) => {
+        observedClauses[filterKey] = whereClauseForFilter;
+        return <div data-testid={`input-${filterKey}`} />;
+      };
+
+      render(
+        <FilterListContent
+          filterDefinitions={definitions}
+          filterStates={states}
+          onFilterStateChanged={vi.fn()}
+          renderInput={renderInput}
+          getFilterKey={getFilterKey}
+          getFilterLabel={getFilterLabel}
+        />,
+      );
+
+      expect(observedClauses.name).toBeUndefined();
+      expect(observedClauses.age).toBeUndefined();
+      expect(observedClauses.active).toBeUndefined();
+    },
+  );
+});

--- a/packages/react-components/src/filter-list/__tests__/Horizontal.test.tsx
+++ b/packages/react-components/src/filter-list/__tests__/Horizontal.test.tsx
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RenderFilterInput } from "../base/BaseFilterListApi.js";
+import { FilterListContent } from "../base/FilterListContent.js";
+import type { FilterDefinitionUnion } from "../FilterListApi.js";
+import type { FilterState } from "../FilterListItemApi.js";
+import { getFilterKey } from "../utils/getFilterKey.js";
+import {
+  getFilterLabel,
+  summarizeFilterValue,
+} from "../utils/getFilterLabel.js";
+import type { MockObjectType } from "./testUtils.js";
+import { createPropertyFilterDef } from "./testUtils.js";
+
+afterEach(cleanup);
+
+type TestDef = FilterDefinitionUnion<typeof MockObjectType>;
+
+const stubRenderInput: RenderFilterInput<TestDef> = ({ filterKey }) => (
+  <input data-testid={`input-${filterKey}`} />
+);
+
+function buildDefinitions(): TestDef[] {
+  return [
+    createPropertyFilterDef("name", "CONTAINS_TEXT", {
+      type: "CONTAINS_TEXT",
+    }),
+    createPropertyFilterDef("age", "NUMBER_RANGE", {
+      type: "NUMBER_RANGE",
+    }),
+    createPropertyFilterDef("active", "TOGGLE", {
+      type: "TOGGLE",
+      enabled: false,
+    }),
+  ];
+}
+
+function buildStates(defs: TestDef[]): Map<string, FilterState> {
+  const states = new Map<string, FilterState>();
+  for (const def of defs) {
+    if (def.type === "PROPERTY" && def.filterState) {
+      states.set(getFilterKey(def), def.filterState);
+    }
+  }
+  return states;
+}
+
+const inlineByComponent: Record<string, "inline" | "trigger"> = {
+  CONTAINS_TEXT: "inline",
+  SINGLE_DATE: "inline",
+  TOGGLE: "inline",
+};
+
+const getRenderMode = (def: TestDef): "inline" | "trigger" => {
+  if (def.type !== "PROPERTY") return "trigger";
+  return inlineByComponent[def.filterComponent] ?? "trigger";
+};
+
+describe("FilterListContent horizontal orientation", () => {
+  it(
+    "applies the horizontal class to the container in horizontal mode",
+    () => {
+      const definitions = buildDefinitions();
+      const { container } = render(
+        <FilterListContent
+          filterDefinitions={definitions}
+          filterStates={buildStates(definitions)}
+          onFilterStateChanged={vi.fn()}
+          renderInput={stubRenderInput}
+          getFilterKey={getFilterKey}
+          getFilterLabel={getFilterLabel}
+          orientation="horizontal"
+          getFilterRenderMode={getRenderMode}
+        />,
+      );
+      const root = container.querySelector("[class*='horizontal']");
+      expect(root).not.toBeNull();
+    },
+  );
+
+  it("vertical default produces no horizontal class", () => {
+    const definitions = buildDefinitions();
+    const { container } = render(
+      <FilterListContent
+        filterDefinitions={definitions}
+        filterStates={buildStates(definitions)}
+        onFilterStateChanged={vi.fn()}
+        renderInput={stubRenderInput}
+        getFilterKey={getFilterKey}
+        getFilterLabel={getFilterLabel}
+      />,
+    );
+    const root = container.firstElementChild;
+    expect(root?.className.includes("horizontal")).toBe(false);
+  });
+
+  it(
+    "renders inline filters with their input directly (no popover trigger)",
+    () => {
+      const definitions = buildDefinitions();
+      const { container } = render(
+        <FilterListContent
+          filterDefinitions={definitions}
+          filterStates={buildStates(definitions)}
+          onFilterStateChanged={vi.fn()}
+          renderInput={stubRenderInput}
+          getFilterKey={getFilterKey}
+          getFilterLabel={getFilterLabel}
+          orientation="horizontal"
+          getFilterRenderMode={getRenderMode}
+        />,
+      );
+      // CONTAINS_TEXT, TOGGLE → inline. The actual input is in the DOM
+      // (no trigger button wrapping it).
+      expect(screen.getByTestId("input-name")).toBeDefined();
+      expect(screen.getByTestId("input-active")).toBeDefined();
+      // NUMBER_RANGE → trigger. Its input is NOT in the DOM until the
+      // popover opens.
+      expect(screen.queryByTestId("input-age")).toBeNull();
+    },
+  );
+
+  it(
+    "renders tall filters as <button> triggers in horizontal mode",
+    () => {
+      const definitions = buildDefinitions();
+      const { container } = render(
+        <FilterListContent
+          filterDefinitions={definitions}
+          filterStates={buildStates(definitions)}
+          onFilterStateChanged={vi.fn()}
+          renderInput={stubRenderInput}
+          getFilterKey={getFilterKey}
+          getFilterLabel={getFilterLabel}
+          orientation="horizontal"
+          getFilterRenderMode={getRenderMode}
+        />,
+      );
+      // The age filter (NUMBER_RANGE → trigger) should render as a
+      // button trigger.
+      const triggers = container.querySelectorAll("button[class*='trigger']");
+      expect(triggers.length).toBeGreaterThan(0);
+    },
+  );
+});
+
+describe("summarizeFilterValue", () => {
+  const def: TestDef = createPropertyFilterDef("status", "SINGLE_SELECT", {
+    type: "SELECT",
+    selectedValues: [],
+  });
+
+  it("returns empty string for an empty filter state", () => {
+    expect(summarizeFilterValue(def, undefined)).toBe("");
+  });
+
+  it("returns the single selected value as a string", () => {
+    const summary = summarizeFilterValue(def, {
+      type: "SELECT",
+      selectedValues: ["Active"],
+    });
+    expect(summary).toBe("Active");
+  });
+
+  it("returns 'N selected' for multi-value SELECT", () => {
+    const summary = summarizeFilterValue(def, {
+      type: "SELECT",
+      selectedValues: ["Active", "Inactive", "Archived"],
+    });
+    expect(summary).toBe("3 selected");
+  });
+
+  it("returns 'min – max' for NUMBER_RANGE", () => {
+    const numDef = createPropertyFilterDef("age", "NUMBER_RANGE", {
+      type: "NUMBER_RANGE",
+    });
+    const summary = summarizeFilterValue(numDef, {
+      type: "NUMBER_RANGE",
+      minValue: 18,
+      maxValue: 65,
+    });
+    expect(summary).toBe("18 – 65");
+  });
+
+  it("returns the search term for CONTAINS_TEXT", () => {
+    const textDef = createPropertyFilterDef("name", "CONTAINS_TEXT", {
+      type: "CONTAINS_TEXT",
+    });
+    const summary = summarizeFilterValue(textDef, {
+      type: "CONTAINS_TEXT",
+      value: "anne",
+    });
+    expect(summary).toBe("anne");
+  });
+
+  it(
+    "uses formatDate for date-typed property when provided in definition",
+    () => {
+      const dateDef = {
+        ...createPropertyFilterDef("createdAt", "DATE_RANGE", {
+          type: "DATE_RANGE",
+        }),
+        formatDate: (d: Date) => `D=${d.getFullYear()}`,
+      } as TestDef;
+      const summary = summarizeFilterValue(dateDef, {
+        type: "DATE_RANGE",
+        minValue: new Date(2024, 0, 1),
+        maxValue: new Date(2024, 11, 31),
+      });
+      expect(summary).toBe("D=2024 – D=2024");
+    },
+  );
+});

--- a/packages/react-components/src/filter-list/__tests__/PropertyFilterDateExtras.test-d.ts
+++ b/packages/react-components/src/filter-list/__tests__/PropertyFilterDateExtras.test-d.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Type-only tests for {@link PropertyFilterDateExtras}. These do not run at
+ * runtime — `tsc --noEmit` (the package's typecheck step) verifies that
+ * `// @ts-expect-error` lines actually error. If the conditional intersection
+ * stops gating `formatDate` to date-typed properties, the
+ * `@ts-expect-error` will become a "no error" mismatch and typecheck fails.
+ */
+
+import type { PropertyFilterDateExtras } from "../FilterListItemApi.js";
+
+/**
+ * For datetime / timestamp, the extras include `formatDate` and `parseDate`
+ * with the documented callback signatures.
+ */
+const dateExtras: PropertyFilterDateExtras<"timestamp"> = {
+  formatDate: (d) => d.toISOString(),
+  parseDate: (text) => {
+    const t = new Date(text);
+    return isNaN(t.getTime()) ? undefined : t;
+  },
+};
+void dateExtras;
+
+const datetimeExtras: PropertyFilterDateExtras<"datetime"> = {
+  formatDate: (d) => d.toISOString(),
+};
+void datetimeExtras;
+
+// For non-date property types, `formatDate` and `parseDate` are typed as
+// `never`. Attempting to set them to a function must be a TS error.
+const numberExtras: PropertyFilterDateExtras<"integer"> = {
+  // @ts-expect-error formatDate is `never` for number-typed properties
+  formatDate: (d: Date): string => d.toISOString(),
+};
+void numberExtras;
+
+const stringExtras: PropertyFilterDateExtras<"string"> = {
+  // @ts-expect-error parseDate is `never` for string-typed properties
+  parseDate: (text: string): Date | undefined => new Date(text),
+};
+void stringExtras;
+
+// Empty object literals are still allowed — both fields are optional on
+// all property types (since the extras either provide them or type them
+// as optional `never`).
+const numberEmpty: PropertyFilterDateExtras<"integer"> = {};
+void numberEmpty;
+const stringEmpty: PropertyFilterDateExtras<"string"> = {};
+void stringEmpty;

--- a/packages/react-components/src/filter-list/base/BaseFilterList.tsx
+++ b/packages/react-components/src/filter-list/base/BaseFilterList.tsx
@@ -41,6 +41,7 @@ export function BaseFilterList<D>(
     onReset,
     onFilterAdded,
     onFilterRemoved,
+    perFilterWhereClauses,
     showResetButton = false,
     showActiveFilterCount = false,
     hasVisibilityChanges,
@@ -108,6 +109,7 @@ export function BaseFilterList<D>(
             getFilterKey={getFilterKey}
             getFilterLabel={getFilterLabel}
             enableSorting={enableSorting}
+            perFilterWhereClauses={perFilterWhereClauses}
           />
         </div>
 

--- a/packages/react-components/src/filter-list/base/BaseFilterList.tsx
+++ b/packages/react-components/src/filter-list/base/BaseFilterList.tsx
@@ -48,10 +48,15 @@ export function BaseFilterList<D>(
     enableSorting,
     className,
     renderAddFilterButton,
+    orientation = "vertical",
+    getFilterRenderMode,
+    summarizeFilterValue,
   } = props;
 
-  const showHeader = title || titleIcon || showResetButton
-    || showActiveFilterCount || onCollapsedChange;
+  const isHorizontal = orientation === "horizontal";
+  const showHeader = !isHorizontal
+    && (title || titleIcon || showResetButton
+      || showActiveFilterCount || onCollapsedChange);
 
   const showAddButton = renderAddFilterButton != null || onFilterAdded != null;
 
@@ -81,10 +86,16 @@ export function BaseFilterList<D>(
       <div
         className={classnames(
           styles.expandedContent,
+          isHorizontal && styles.horizontal,
           isCollapsed && styles.hiddenContent,
         )}
         data-active-count={activeFilterCount}
+        data-orientation={orientation}
       >
+        {isHorizontal && title && (
+          <span className={styles.horizontalTitle}>{title}</span>
+        )}
+
         {showHeader && (
           <FilterListHeader
             title={title}
@@ -110,11 +121,19 @@ export function BaseFilterList<D>(
             getFilterLabel={getFilterLabel}
             enableSorting={enableSorting}
             perFilterWhereClauses={perFilterWhereClauses}
+            orientation={orientation}
+            getFilterRenderMode={getFilterRenderMode}
+            summarizeFilterValue={summarizeFilterValue}
           />
         </div>
 
         {showAddButton && (
-          <div className={styles.addButtonContainer}>
+          <div
+            className={classnames(
+              styles.addButtonContainer,
+              isHorizontal && styles.horizontalAddButton,
+            )}
+          >
             {renderAddFilterButton
               ? renderAddFilterButton()
               : (
@@ -122,8 +141,9 @@ export function BaseFilterList<D>(
                   type="button"
                   className={styles.addButton}
                   onClick={onFilterAdded}
+                  aria-label={isHorizontal ? "Add filter" : undefined}
                 >
-                  + Add filter
+                  {isHorizontal ? "+" : "+ Add filter"}
                 </Button>
               )}
           </div>

--- a/packages/react-components/src/filter-list/base/BaseFilterList.tsx
+++ b/packages/react-components/src/filter-list/base/BaseFilterList.tsx
@@ -92,10 +92,6 @@ export function BaseFilterList<D>(
         data-active-count={activeFilterCount}
         data-orientation={orientation}
       >
-        {isHorizontal && title && (
-          <span className={styles.horizontalTitle}>{title}</span>
-        )}
-
         {showHeader && (
           <FilterListHeader
             title={title}

--- a/packages/react-components/src/filter-list/base/BaseFilterListApi.ts
+++ b/packages/react-components/src/filter-list/base/BaseFilterListApi.ts
@@ -64,4 +64,26 @@ export interface BaseFilterListProps<D> {
   enableSorting?: boolean;
   className?: string;
   renderAddFilterButton?: () => React.ReactNode;
+  /**
+   * Layout orientation. When `"horizontal"`, the filter list arranges its
+   * items as a row instead of a column. Default `"vertical"`.
+   */
+  orientation?: "vertical" | "horizontal";
+  /**
+   * In horizontal mode, classifies each filter as either an inline input
+   * (rendered directly next to its label) or a popover trigger (rendered
+   * as a button that opens the input UI in a popover). Ignored in
+   * vertical mode where everything renders inline.
+   */
+  getFilterRenderMode?: (definition: D) => "inline" | "trigger";
+  /**
+   * In horizontal mode, the trigger label shown above the filter's
+   * popover. Receives the filter definition and current state and returns
+   * a short summary like "Status: Active" or "Sites: 3 selected". Ignored
+   * for `"inline"` filters.
+   */
+  summarizeFilterValue?: (
+    definition: D,
+    filterState: FilterState | undefined,
+  ) => React.ReactNode;
 }

--- a/packages/react-components/src/filter-list/base/BaseFilterListApi.ts
+++ b/packages/react-components/src/filter-list/base/BaseFilterListApi.ts
@@ -24,6 +24,15 @@ export type RenderFilterInput<D> = (props: {
   onFilterStateChanged: (state: FilterState) => void;
   searchQuery?: string;
   excludeRowOpen?: boolean;
+  /**
+   * Per-filter where clause supplied by `FilterList`'s internal pipeline.
+   *
+   * Type-erased here so this OSDK-agnostic base does not depend on
+   * `WhereClause<Q>`. The FilterList wrapper casts it back to the typed
+   * shape before passing it to `FilterInput`. Consumers passing their own
+   * `renderInput` function can ignore this field.
+   */
+  whereClauseForFilter?: unknown;
 }) => React.ReactNode;
 
 export interface BaseFilterListProps<D> {
@@ -37,6 +46,13 @@ export interface BaseFilterListProps<D> {
   onReset?: () => void;
   onFilterAdded?: () => void;
   onFilterRemoved?: (filterKey: string) => void;
+  /**
+   * Per-filter where clauses keyed by `filterKey`. Forwarded down to each
+   * `FilterListItem` so the internal `renderInput` can read its filter's
+   * clause without closing over the whole map (which would invalidate
+   * memoization on every selection).
+   */
+  perFilterWhereClauses?: ReadonlyMap<string, unknown>;
 
   collapsed?: boolean;
   onCollapsedChange?: (collapsed: boolean) => void;

--- a/packages/react-components/src/filter-list/base/FilterList.module.css
+++ b/packages/react-components/src/filter-list/base/FilterList.module.css
@@ -64,15 +64,6 @@
   overflow: visible;
 }
 
-.horizontalTitle {
-  flex-shrink: 0;
-  font-family: var(--osdk-filter-header-font-family);
-  font-size: var(--osdk-filter-header-font-size);
-  font-weight: var(--osdk-filter-header-font-weight);
-  color: var(--osdk-filter-header-color);
-  margin-right: calc(var(--osdk-surface-spacing) * 1);
-}
-
 .horizontalAddButton {
   flex-shrink: 0;
   padding: 0;

--- a/packages/react-components/src/filter-list/base/FilterList.module.css
+++ b/packages/react-components/src/filter-list/base/FilterList.module.css
@@ -46,6 +46,47 @@
   gap: var(--osdk-filter-list-gap);
 }
 
+/* Horizontal mode: arrange the header, content, and add-filter areas as a
+   single row. The content area itself becomes the scrollable axis. */
+.expandedContent.horizontal {
+  flex-direction: row;
+  align-items: center;
+  height: auto;
+  overflow: visible;
+  padding: calc(var(--osdk-surface-spacing) * 1)
+    calc(var(--osdk-surface-spacing) * 2);
+  gap: var(--osdk-filter-horizontal-gap, calc(var(--osdk-surface-spacing) * 1));
+}
+
+.expandedContent.horizontal .scrollableContent {
+  flex: 1;
+  min-width: 0;
+  overflow: visible;
+}
+
+.horizontalTitle {
+  flex-shrink: 0;
+  font-family: var(--osdk-filter-header-font-family);
+  font-size: var(--osdk-filter-header-font-size);
+  font-weight: var(--osdk-filter-header-font-weight);
+  color: var(--osdk-filter-header-color);
+  margin-right: calc(var(--osdk-surface-spacing) * 1);
+}
+
+.horizontalAddButton {
+  flex-shrink: 0;
+  padding: 0;
+  border-top: none;
+  background: transparent;
+  margin-left: auto;
+}
+
+.horizontalAddButton .addButton {
+  min-height: var(--osdk-filter-horizontal-trigger-min-height, 30px);
+  padding: calc(var(--osdk-surface-spacing) * 1)
+    calc(var(--osdk-surface-spacing) * 2);
+}
+
 .scrollableContent {
   display: flex;
   flex-direction: column;

--- a/packages/react-components/src/filter-list/base/FilterListContent.module.css
+++ b/packages/react-components/src/filter-list/base/FilterListContent.module.css
@@ -20,17 +20,19 @@
   gap: var(--osdk-filter-list-content-gap);
 }
 
-/* Horizontal mode: filters render side-by-side with horizontal scroll
-   for overflow. */
+/* Horizontal mode: filters render side-by-side. Both axes need to stay
+   visible so popovers (the per-filter popup, the add-filter menu) can
+   pop above without clipping. Consumers wrap FilterList in their own
+   scroller if the row gets too long. */
 .content.horizontal {
   flex-direction: row;
   gap: var(
     --osdk-filter-horizontal-gap,
     calc(var(--osdk-surface-spacing) * 1)
   );
-  overflow-x: auto;
-  overflow-y: visible;
+  overflow: visible;
   align-items: center;
+  flex-wrap: wrap;
 }
 
 .emptyMessage {

--- a/packages/react-components/src/filter-list/base/FilterListContent.module.css
+++ b/packages/react-components/src/filter-list/base/FilterListContent.module.css
@@ -20,6 +20,19 @@
   gap: var(--osdk-filter-list-content-gap);
 }
 
+/* Horizontal mode: filters render side-by-side with horizontal scroll
+   for overflow. */
+.content.horizontal {
+  flex-direction: row;
+  gap: var(
+    --osdk-filter-horizontal-gap,
+    calc(var(--osdk-surface-spacing) * 1)
+  );
+  overflow-x: auto;
+  overflow-y: visible;
+  align-items: center;
+}
+
 .emptyMessage {
   margin: 0;
   color: var(--osdk-filter-list-empty-text-color);

--- a/packages/react-components/src/filter-list/base/FilterListContent.tsx
+++ b/packages/react-components/src/filter-list/base/FilterListContent.tsx
@@ -33,6 +33,7 @@ import {
 } from "@dnd-kit/core";
 import {
   arrayMove,
+  horizontalListSortingStrategy,
   SortableContext,
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
@@ -50,8 +51,14 @@ const restrictToVerticalAxis: Modifier = ({ transform }) => ({
   x: 0,
 });
 
+const restrictToHorizontalAxis: Modifier = ({ transform }) => ({
+  ...transform,
+  y: 0,
+});
+
 const POINTER_ACTIVATION_CONSTRAINT = { distance: 8 } as const;
-const MODIFIERS: Modifier[] = [restrictToVerticalAxis];
+const MODIFIERS_VERTICAL: Modifier[] = [restrictToVerticalAxis];
+const MODIFIERS_HORIZONTAL: Modifier[] = [restrictToHorizontalAxis];
 
 const DRAG_OVERLAY_HANDLE_ATTRIBUTES: DraggableAttributes = {
   role: "button",
@@ -77,6 +84,12 @@ interface FilterListContentProps<D> {
   perFilterWhereClauses?: ReadonlyMap<string, unknown>;
   className?: string;
   style?: React.CSSProperties;
+  orientation?: "vertical" | "horizontal";
+  getFilterRenderMode?: (definition: D) => "inline" | "trigger";
+  summarizeFilterValue?: (
+    definition: D,
+    filterState: FilterState | undefined,
+  ) => React.ReactNode;
 }
 
 export function FilterListContent<D>({
@@ -91,7 +104,11 @@ export function FilterListContent<D>({
   perFilterWhereClauses,
   className,
   style,
+  orientation = "vertical",
+  getFilterRenderMode,
+  summarizeFilterValue,
 }: FilterListContentProps<D>): React.ReactElement {
+  const isHorizontal = orientation === "horizontal";
   const [dragOrder, setDragOrder] = useState<string[] | null>(null);
   const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
 
@@ -215,23 +232,36 @@ export function FilterListContent<D>({
   if (!renderDefinitions || renderDefinitions.length === 0) {
     return (
       <div
-        className={classnames(styles.content, className)}
+        className={classnames(
+          styles.content,
+          isHorizontal && styles.horizontal,
+          className,
+        )}
         style={style}
         data-empty="true"
       />
     );
   }
 
+  const resolveRenderMode = (def: D): "inline" | "trigger" => {
+    if (!isHorizontal) return "inline";
+    return getFilterRenderMode ? getFilterRenderMode(def) : "trigger";
+  };
+
   if (enableSorting) {
     return (
       <div
-        className={classnames(styles.content, className)}
+        className={classnames(
+          styles.content,
+          isHorizontal && styles.horizontal,
+          className,
+        )}
         style={style}
       >
         <DndContext
           sensors={sensors}
           collisionDetection={closestCenter}
-          modifiers={MODIFIERS}
+          modifiers={isHorizontal ? MODIFIERS_HORIZONTAL : MODIFIERS_VERTICAL}
           onDragStart={handleDragStart}
           onDragEnd={handleDragEnd}
           onDragCancel={handleDragCancel}
@@ -239,7 +269,9 @@ export function FilterListContent<D>({
         >
           <SortableContext
             items={sortableIds}
-            strategy={verticalListSortingStrategy}
+            strategy={isHorizontal
+              ? horizontalListSortingStrategy
+              : verticalListSortingStrategy}
           >
             {renderDefinitions.map((definition, index) => {
               const id = sortableIds[index];
@@ -249,6 +281,7 @@ export function FilterListContent<D>({
               const whereClauseForFilter = perFilterWhereClauses?.get(
                 filterKey,
               );
+              const renderMode = resolveRenderMode(definition);
 
               return (
                 <SortableFilterListItem
@@ -262,6 +295,12 @@ export function FilterListContent<D>({
                   onFilterRemoved={onFilterRemoved}
                   renderInput={renderInput}
                   whereClauseForFilter={whereClauseForFilter}
+                  orientation={orientation}
+                  renderMode={renderMode}
+                  triggerSummary={renderMode === "trigger"
+                      && summarizeFilterValue
+                    ? summarizeFilterValue(definition, state)
+                    : undefined}
                 />
               );
             })}
@@ -284,6 +323,16 @@ export function FilterListContent<D>({
                   activeFilterKey,
                 )}
                 dragHandleAttributes={DRAG_OVERLAY_HANDLE_ATTRIBUTES}
+                orientation={orientation}
+                renderMode={resolveRenderMode(activeDefinition)}
+                triggerSummary={resolveRenderMode(activeDefinition)
+                      === "trigger"
+                    && summarizeFilterValue
+                  ? summarizeFilterValue(
+                    activeDefinition,
+                    filterStates.get(activeFilterKey),
+                  )
+                  : undefined}
               />
             )}
           </DragOverlay>
@@ -294,13 +343,18 @@ export function FilterListContent<D>({
 
   return (
     <div
-      className={classnames(styles.content, className)}
+      className={classnames(
+        styles.content,
+        isHorizontal && styles.horizontal,
+        className,
+      )}
       style={style}
     >
       {renderDefinitions.map((definition) => {
         const filterKey = getFilterKey(definition);
         const state = filterStates.get(filterKey);
         const whereClauseForFilter = perFilterWhereClauses?.get(filterKey);
+        const renderMode = resolveRenderMode(definition);
 
         return (
           <FilterListItem
@@ -313,6 +367,11 @@ export function FilterListContent<D>({
             onFilterRemoved={onFilterRemoved}
             renderInput={renderInput}
             whereClauseForFilter={whereClauseForFilter}
+            orientation={orientation}
+            renderMode={renderMode}
+            triggerSummary={renderMode === "trigger" && summarizeFilterValue
+              ? summarizeFilterValue(definition, state)
+              : undefined}
           />
         );
       })}

--- a/packages/react-components/src/filter-list/base/FilterListContent.tsx
+++ b/packages/react-components/src/filter-list/base/FilterListContent.tsx
@@ -74,6 +74,7 @@ interface FilterListContentProps<D> {
   getFilterKey: (definition: D) => string;
   getFilterLabel: (definition: D) => string;
   enableSorting?: boolean;
+  perFilterWhereClauses?: ReadonlyMap<string, unknown>;
   className?: string;
   style?: React.CSSProperties;
 }
@@ -87,6 +88,7 @@ export function FilterListContent<D>({
   getFilterKey,
   getFilterLabel,
   enableSorting,
+  perFilterWhereClauses,
   className,
   style,
 }: FilterListContentProps<D>): React.ReactElement {
@@ -244,6 +246,9 @@ export function FilterListContent<D>({
               const filterKey = getFilterKey(definition);
               const label = getFilterLabel(definition);
               const state = filterStates.get(filterKey);
+              const whereClauseForFilter = perFilterWhereClauses?.get(
+                filterKey,
+              );
 
               return (
                 <SortableFilterListItem
@@ -256,6 +261,7 @@ export function FilterListContent<D>({
                   onFilterStateChanged={onFilterStateChanged}
                   onFilterRemoved={onFilterRemoved}
                   renderInput={renderInput}
+                  whereClauseForFilter={whereClauseForFilter}
                 />
               );
             })}
@@ -274,6 +280,9 @@ export function FilterListContent<D>({
                 onFilterStateChanged={onFilterStateChanged}
                 onFilterRemoved={onFilterRemoved}
                 renderInput={renderInput}
+                whereClauseForFilter={perFilterWhereClauses?.get(
+                  activeFilterKey,
+                )}
                 dragHandleAttributes={DRAG_OVERLAY_HANDLE_ATTRIBUTES}
               />
             )}
@@ -291,6 +300,7 @@ export function FilterListContent<D>({
       {renderDefinitions.map((definition) => {
         const filterKey = getFilterKey(definition);
         const state = filterStates.get(filterKey);
+        const whereClauseForFilter = perFilterWhereClauses?.get(filterKey);
 
         return (
           <FilterListItem
@@ -302,6 +312,7 @@ export function FilterListContent<D>({
             onFilterStateChanged={onFilterStateChanged}
             onFilterRemoved={onFilterRemoved}
             renderInput={renderInput}
+            whereClauseForFilter={whereClauseForFilter}
           />
         );
       })}

--- a/packages/react-components/src/filter-list/base/FilterListItem.module.css
+++ b/packages/react-components/src/filter-list/base/FilterListItem.module.css
@@ -44,10 +44,36 @@
   min-height: var(--osdk-filter-horizontal-trigger-min-height, 28px);
   display: flex;
   align-items: center;
+  border-radius: var(--osdk-surface-border-radius);
+  border: var(--osdk-surface-border-width) solid
+    var(--osdk-surface-border-color-default);
+  background: transparent;
+  padding: 0 calc(var(--osdk-surface-spacing) * 1);
+  transition: border-color var(--osdk-emphasis-transition-duration)
+    var(--osdk-emphasis-ease-default);
+}
+
+.horizontalInlineInput:hover {
+  border-color: var(--osdk-typography-color-muted);
+}
+
+.horizontalInlineInput:focus-within {
+  border-color: var(--osdk-intent-primary-rest);
 }
 
 .horizontalInlineInput > * {
   width: 100%;
+}
+
+/* Zero out the inner input's own border / focus ring — the wrapper's
+   border is the single source of truth for the focus visual. */
+.horizontalInlineInput input,
+.horizontalInlineInput [class*="osdkInput"],
+.horizontalInlineInput [class*="ContainsTextInput"] {
+  border: none;
+  outline: none;
+  background: transparent;
+  box-shadow: none;
 }
 
 .itemHeader {

--- a/packages/react-components/src/filter-list/base/FilterListItem.module.css
+++ b/packages/react-components/src/filter-list/base/FilterListItem.module.css
@@ -22,6 +22,32 @@
   padding: var(--osdk-filter-item-padding);
 }
 
+/* Horizontal mode: label sits left of the input, padding is tighter. */
+.filterItem.horizontal {
+  flex-direction: row;
+  align-items: center;
+  padding: 0;
+  gap: calc(var(--osdk-surface-spacing) * 1);
+  flex-shrink: 0;
+}
+
+.filterItem.horizontal .itemHeader {
+  display: contents;
+}
+
+.filterItem.horizontal .itemLabel {
+  flex: 0 0 auto;
+  font-weight: var(--osdk-filter-item-label-font-weight);
+}
+
+.filterItem.horizontal .itemContent {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  min-width: 0;
+  overflow: visible;
+}
+
 .itemHeader {
   display: flex;
   align-items: center;

--- a/packages/react-components/src/filter-list/base/FilterListItem.module.css
+++ b/packages/react-components/src/filter-list/base/FilterListItem.module.css
@@ -22,30 +22,32 @@
   padding: var(--osdk-filter-item-padding);
 }
 
-/* Horizontal mode: label sits left of the input, padding is tighter. */
-.filterItem.horizontal {
-  flex-direction: row;
+/* Horizontal mode, "inline" render — plain label sibling next to the
+   existing inline input, constrained to the same width as the popover
+   trigger so the row reads evenly. */
+.horizontalInline {
+  display: inline-flex;
   align-items: center;
-  padding: 0;
   gap: calc(var(--osdk-surface-spacing) * 1);
   flex-shrink: 0;
 }
 
-.filterItem.horizontal .itemHeader {
-  display: contents;
+.horizontalInlineLabel {
+  font-family: var(--osdk-typography-family-default);
+  font-size: var(--osdk-typography-size-body-small);
+  color: var(--osdk-typography-color-muted);
+  white-space: nowrap;
 }
 
-.filterItem.horizontal .itemLabel {
-  flex: 0 0 auto;
-  font-weight: var(--osdk-filter-item-label-font-weight);
-}
-
-.filterItem.horizontal .itemContent {
+.horizontalInlineInput {
+  width: var(--osdk-filter-horizontal-trigger-width, 160px);
+  min-height: var(--osdk-filter-horizontal-trigger-min-height, 28px);
   display: flex;
-  flex-direction: row;
   align-items: center;
-  min-width: 0;
-  overflow: visible;
+}
+
+.horizontalInlineInput > * {
+  width: 100%;
 }
 
 .itemHeader {

--- a/packages/react-components/src/filter-list/base/FilterListItem.tsx
+++ b/packages/react-components/src/filter-list/base/FilterListItem.tsx
@@ -188,6 +188,27 @@ function FilterListItemInner<D>({
     );
   }
 
+  if (isHorizontal && renderMode === "inline") {
+    return (
+      <span className={classnames(styles.horizontalInline, className)}>
+        <span className={styles.horizontalInlineLabel}>{label}</span>
+        <div className={styles.horizontalInlineInput}>
+          <ErrorBoundary errorMessage="Error loading filter">
+            {renderInput({
+              definition,
+              filterKey,
+              filterState,
+              onFilterStateChanged: handleFilterStateChanged,
+              searchQuery: undefined,
+              excludeRowOpen: false,
+              whereClauseForFilter,
+            })}
+          </ErrorBoundary>
+        </div>
+      </span>
+    );
+  }
+
   return (
     <div
       className={classnames(

--- a/packages/react-components/src/filter-list/base/FilterListItem.tsx
+++ b/packages/react-components/src/filter-list/base/FilterListItem.tsx
@@ -24,11 +24,16 @@ import classnames from "classnames";
 import React, { memo, useCallback, useState } from "react";
 import { ErrorBoundary } from "../../shared/ErrorBoundary.js";
 import type { FilterState } from "../FilterListItemApi.js";
-import { supportsExcluding, supportsSearch } from "../utils/filterValues.js";
+import {
+  filterHasActiveState,
+  supportsExcluding,
+  supportsSearch,
+} from "../utils/filterValues.js";
 import type { RenderFilterInput } from "./BaseFilterListApi.js";
 import { DragHandleIcon } from "./DragHandleIcon.js";
 import { OverflowMenuIcon, RemoveIcon, SearchIcon } from "./FilterIcons.js";
 import styles from "./FilterListItem.module.css";
+import { HorizontalFilterTrigger } from "./inputs/HorizontalFilterTrigger.js";
 
 function hasActiveSelection(filterState: FilterState | undefined): boolean {
   if (filterState == null) {
@@ -78,6 +83,16 @@ interface FilterListItemProps<D> {
   dragHandleListeners?: DraggableSyntheticListeners;
   className?: string;
   style?: React.CSSProperties;
+  /** Layout orientation. Defaults to "vertical". */
+  orientation?: "vertical" | "horizontal";
+  /**
+   * In horizontal mode, classifies this filter as either inline (input
+   * renders next to label) or trigger (popover-collapsed). Ignored in
+   * vertical mode. Defaults to "inline".
+   */
+  renderMode?: "inline" | "trigger";
+  /** Summary text shown inside the trigger when `renderMode === "trigger"`. */
+  triggerSummary?: React.ReactNode;
 }
 
 function FilterListItemInner<D>({
@@ -93,6 +108,9 @@ function FilterListItemInner<D>({
   dragHandleListeners,
   className,
   style,
+  orientation = "vertical",
+  renderMode = "inline",
+  triggerSummary,
 }: FilterListItemProps<D>): React.ReactElement {
   const [searchState, setSearchState] = useState<
     { type: "closed" } | { type: "open"; query: string }
@@ -145,9 +163,38 @@ function FilterListItemInner<D>({
     ? searchState.query
     : undefined;
 
+  const isHorizontal = orientation === "horizontal";
+
+  if (isHorizontal && renderMode === "trigger") {
+    return (
+      <HorizontalFilterTrigger
+        label={label}
+        summary={triggerSummary}
+        isActive={filterHasActiveState(filterState)}
+        onRemove={onFilterRemoved ? handleRemove : undefined}
+      >
+        <ErrorBoundary errorMessage="Error loading filter">
+          {renderInput({
+            definition,
+            filterKey,
+            filterState,
+            onFilterStateChanged: handleFilterStateChanged,
+            searchQuery: undefined,
+            excludeRowOpen: false,
+            whereClauseForFilter,
+          })}
+        </ErrorBoundary>
+      </HorizontalFilterTrigger>
+    );
+  }
+
   return (
     <div
-      className={classnames(styles.filterItem, className)}
+      className={classnames(
+        styles.filterItem,
+        isHorizontal && styles.horizontal,
+        className,
+      )}
       style={style}
       data-has-selection={hasActiveSelection(filterState) || undefined}
     >

--- a/packages/react-components/src/filter-list/base/FilterListItem.tsx
+++ b/packages/react-components/src/filter-list/base/FilterListItem.tsx
@@ -73,6 +73,7 @@ interface FilterListItemProps<D> {
   ) => void;
   onFilterRemoved?: (filterKey: string) => void;
   renderInput: RenderFilterInput<D>;
+  whereClauseForFilter?: unknown;
   dragHandleAttributes?: DraggableAttributes;
   dragHandleListeners?: DraggableSyntheticListeners;
   className?: string;
@@ -87,6 +88,7 @@ function FilterListItemInner<D>({
   onFilterStateChanged,
   onFilterRemoved,
   renderInput,
+  whereClauseForFilter,
   dragHandleAttributes,
   dragHandleListeners,
   className,
@@ -229,6 +231,7 @@ function FilterListItemInner<D>({
             onFilterStateChanged: handleFilterStateChanged,
             searchQuery: searchQueryForInput,
             excludeRowOpen,
+            whereClauseForFilter,
           })}
         </ErrorBoundary>
       </div>

--- a/packages/react-components/src/filter-list/base/SortableFilterListItem.tsx
+++ b/packages/react-components/src/filter-list/base/SortableFilterListItem.tsx
@@ -36,6 +36,9 @@ interface SortableFilterListItemProps<D> {
   onFilterRemoved?: (filterKey: string) => void;
   renderInput: RenderFilterInput<D>;
   whereClauseForFilter?: unknown;
+  orientation?: "vertical" | "horizontal";
+  renderMode?: "inline" | "trigger";
+  triggerSummary?: React.ReactNode;
 }
 
 function SortableFilterListItemInner<D>({
@@ -48,6 +51,9 @@ function SortableFilterListItemInner<D>({
   onFilterRemoved,
   renderInput,
   whereClauseForFilter,
+  orientation,
+  renderMode,
+  triggerSummary,
 }: SortableFilterListItemProps<D>): React.ReactElement {
   const {
     attributes,
@@ -80,6 +86,9 @@ function SortableFilterListItemInner<D>({
         whereClauseForFilter={whereClauseForFilter}
         dragHandleAttributes={attributes}
         dragHandleListeners={listeners}
+        orientation={orientation}
+        renderMode={renderMode}
+        triggerSummary={triggerSummary}
       />
     </div>
   );

--- a/packages/react-components/src/filter-list/base/SortableFilterListItem.tsx
+++ b/packages/react-components/src/filter-list/base/SortableFilterListItem.tsx
@@ -35,6 +35,7 @@ interface SortableFilterListItemProps<D> {
   ) => void;
   onFilterRemoved?: (filterKey: string) => void;
   renderInput: RenderFilterInput<D>;
+  whereClauseForFilter?: unknown;
 }
 
 function SortableFilterListItemInner<D>({
@@ -46,6 +47,7 @@ function SortableFilterListItemInner<D>({
   onFilterStateChanged,
   onFilterRemoved,
   renderInput,
+  whereClauseForFilter,
 }: SortableFilterListItemProps<D>): React.ReactElement {
   const {
     attributes,
@@ -75,6 +77,7 @@ function SortableFilterListItemInner<D>({
         onFilterStateChanged={onFilterStateChanged}
         onFilterRemoved={onFilterRemoved}
         renderInput={renderInput}
+        whereClauseForFilter={whereClauseForFilter}
         dragHandleAttributes={attributes}
         dragHandleListeners={listeners}
       />

--- a/packages/react-components/src/filter-list/base/inputs/DateRangeInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/DateRangeInput.tsx
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import React, { memo } from "react";
+import React, { memo, useMemo } from "react";
 import {
   formatDateForInput,
   parseDateFromInput,
 } from "../../../shared/dateUtils.js";
 import { RangeInput, type RangeInputConfig } from "./RangeInput.js";
 
-const dateConfig: RangeInputConfig<Date> = {
+const defaultDateConfig: RangeInputConfig<Date> = {
   inputType: "date",
   formatValue: formatDateForInput,
   parseValue: parseDateFromInput,
@@ -44,12 +44,39 @@ interface DateRangeInputProps {
   showHistogram?: boolean;
   className?: string;
   style?: React.CSSProperties;
+  /**
+   * Optional callback used for tooltip + display text. The HTML
+   * `<input type="date">` value attribute is unaffected — it always uses
+   * ISO `YYYY-MM-DD`.
+   */
+  formatDate?: (date: Date) => string;
+  /**
+   * Optional inverse of `formatDate`. Plumbed through `RangeInputConfig`
+   * for completeness; the built-in HTML date inputs do not invoke it
+   * because the browser controls parsing of `<input type="date">` values.
+   */
+  parseDate?: (text: string) => Date | undefined;
 }
 
-function DateRangeInputInner(
-  props: DateRangeInputProps,
-): React.ReactElement {
-  return <RangeInput {...props} config={dateConfig} />;
+function DateRangeInputInner({
+  formatDate,
+  parseDate,
+  ...rest
+}: DateRangeInputProps): React.ReactElement {
+  const config = useMemo<RangeInputConfig<Date>>(
+    () =>
+      formatDate || parseDate
+        ? {
+          ...defaultDateConfig,
+          formatTooltip: (min, max, count) =>
+            `${formatDate ? formatDate(min) : formatDateForInput(min)} - ${
+              formatDate ? formatDate(max) : formatDateForInput(max)
+            }: ${count.toLocaleString()}`,
+        }
+        : defaultDateConfig,
+    [formatDate, parseDate],
+  );
+  return <RangeInput {...rest} config={config} />;
 }
 
 export const DateRangeInput = memo(

--- a/packages/react-components/src/filter-list/base/inputs/DateRangeInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/DateRangeInput.tsx
@@ -57,6 +57,7 @@ interface DateRangeInputProps {
    * because the browser controls parsing of `<input type="date">` values.
    */
   parseDate?: (text: string) => Date | undefined;
+  clickToFilter?: boolean;
 }
 
 function DateRangeInputInner({

--- a/packages/react-components/src/filter-list/base/inputs/DateRangeInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/DateRangeInput.tsx
@@ -19,6 +19,7 @@ import {
   formatDateForInput,
   parseDateFromInput,
 } from "../../../shared/dateUtils.js";
+import { createDateHistogramBuckets } from "./createDateHistogramBuckets.js";
 import { RangeInput, type RangeInputConfig } from "./RangeInput.js";
 
 const defaultDateConfig: RangeInputConfig<Date> = {
@@ -61,6 +62,7 @@ interface DateRangeInputProps {
 function DateRangeInputInner({
   formatDate,
   parseDate,
+  valueCountPairs,
   ...rest
 }: DateRangeInputProps): React.ReactElement {
   const config = useMemo<RangeInputConfig<Date>>(
@@ -76,7 +78,33 @@ function DateRangeInputInner({
         : defaultDateConfig,
     [formatDate, parseDate],
   );
-  return <RangeInput {...rest} config={config} />;
+
+  const histogramData = useMemo(() => {
+    if (valueCountPairs.length === 0) return undefined;
+    let minMs = Infinity;
+    let maxMs = -Infinity;
+    for (const { value } of valueCountPairs) {
+      const t = value.getTime();
+      if (t < minMs) minMs = t;
+      if (t > maxMs) maxMs = t;
+    }
+    if (!Number.isFinite(minMs) || !Number.isFinite(maxMs)) return undefined;
+    const { buckets, subtitle } = createDateHistogramBuckets(
+      valueCountPairs,
+      { min: new Date(minMs), max: new Date(maxMs) },
+      formatDate,
+    );
+    return { buckets, subtitle };
+  }, [valueCountPairs, formatDate]);
+
+  return (
+    <RangeInput
+      {...rest}
+      valueCountPairs={valueCountPairs}
+      config={config}
+      histogramData={histogramData}
+    />
+  );
 }
 
 export const DateRangeInput = memo(

--- a/packages/react-components/src/filter-list/base/inputs/HorizontalFilterTrigger.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/HorizontalFilterTrigger.module.css
@@ -14,35 +14,45 @@
  * limitations under the License.
  */
 
-.trigger {
+.fieldGroup {
   display: inline-flex;
   align-items: center;
   gap: calc(var(--osdk-surface-spacing) * 1);
-  min-height: var(--osdk-filter-horizontal-trigger-min-height, 30px);
-  max-width: var(--osdk-filter-horizontal-trigger-max-width, 240px);
-  padding: calc(var(--osdk-surface-spacing) * 1)
-    calc(var(--osdk-surface-spacing) * 2);
+  position: relative;
+  flex-shrink: 0;
+}
+
+.label {
+  font-family: var(--osdk-typography-family-default);
+  font-size: var(--osdk-typography-size-body-small);
+  color: var(--osdk-typography-color-muted);
+  white-space: nowrap;
+}
+
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  width: var(--osdk-filter-horizontal-trigger-width, 160px);
+  min-height: var(--osdk-filter-horizontal-trigger-min-height, 28px);
+  padding: 0 calc(var(--osdk-surface-spacing) * 2);
   border-radius: var(--osdk-surface-border-radius);
   border: var(--osdk-surface-border-width) solid
     var(--osdk-surface-border-color-default);
-  background: var(--osdk-filter-horizontal-trigger-bg, transparent);
+  background: transparent;
   color: var(--osdk-typography-color-default-rest);
   font-family: var(--osdk-typography-family-default);
   font-size: var(--osdk-typography-size-body-small);
   cursor: pointer;
-  transition: background-color var(--osdk-emphasis-transition-duration)
+  transition: border-color var(--osdk-emphasis-transition-duration)
     var(--osdk-emphasis-ease-default);
+  text-align: left;
 }
 
 .trigger:hover {
-  background: var(--osdk-surface-background-color-default-hover);
+  border-color: var(--osdk-typography-color-muted);
 }
 
 .trigger[data-active="true"] {
-  background: var(
-    --osdk-filter-horizontal-trigger-active-bg,
-    var(--osdk-surface-layer-primary)
-  );
   border-color: var(--osdk-intent-primary-rest);
 }
 
@@ -52,17 +62,49 @@
   outline-offset: var(--osdk-emphasis-focus-offset);
 }
 
-.label {
-  font-weight: var(--osdk-typography-weight-bold);
-  white-space: nowrap;
-}
-
 .summary {
-  color: var(--osdk-typography-color-muted);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   min-width: 0;
+  flex: 1;
+}
+
+.placeholder {
+  color: var(--osdk-typography-color-muted);
+}
+
+.removeButton {
+  position: absolute;
+  top: 50%;
+  right: calc(var(--osdk-surface-spacing) * 0.5);
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: calc(var(--osdk-surface-spacing) * 3);
+  height: calc(var(--osdk-surface-spacing) * 3);
+  padding: 0;
+  border: none;
+  background: var(--osdk-background-primary);
+  cursor: pointer;
+  color: var(--osdk-typography-color-muted);
+  border-radius: var(--osdk-surface-border-radius);
+  opacity: 0;
+  transition: opacity var(--osdk-emphasis-transition-duration)
+    var(--osdk-emphasis-ease-default);
+  pointer-events: none;
+}
+
+.fieldGroup:hover .removeButton,
+.fieldGroup:focus-within .removeButton {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.removeButton:hover {
+  color: var(--osdk-typography-color-default-rest);
+  background: var(--osdk-custom-color-gray-1);
 }
 
 .popup {
@@ -74,22 +116,4 @@
   min-width: 280px;
   max-width: 480px;
   z-index: var(--osdk-surface-z-index-3, 1000);
-}
-
-.removeButton {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  margin-left: calc(var(--osdk-surface-spacing) * 0.5);
-  padding: calc(var(--osdk-surface-spacing) * 0.5);
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  color: var(--osdk-typography-color-muted);
-  border-radius: var(--osdk-surface-border-radius);
-}
-
-.removeButton:hover {
-  color: var(--osdk-typography-color-default-rest);
-  background: var(--osdk-custom-color-gray-1);
 }

--- a/packages/react-components/src/filter-list/base/inputs/HorizontalFilterTrigger.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/HorizontalFilterTrigger.module.css
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: calc(var(--osdk-surface-spacing) * 1);
+  min-height: var(--osdk-filter-horizontal-trigger-min-height, 30px);
+  max-width: var(--osdk-filter-horizontal-trigger-max-width, 240px);
+  padding: calc(var(--osdk-surface-spacing) * 1)
+    calc(var(--osdk-surface-spacing) * 2);
+  border-radius: var(--osdk-surface-border-radius);
+  border: var(--osdk-surface-border-width) solid
+    var(--osdk-surface-border-color-default);
+  background: var(--osdk-filter-horizontal-trigger-bg, transparent);
+  color: var(--osdk-typography-color-default-rest);
+  font-family: var(--osdk-typography-family-default);
+  font-size: var(--osdk-typography-size-body-small);
+  cursor: pointer;
+  transition: background-color var(--osdk-emphasis-transition-duration)
+    var(--osdk-emphasis-ease-default);
+}
+
+.trigger:hover {
+  background: var(--osdk-surface-background-color-default-hover);
+}
+
+.trigger[data-active="true"] {
+  background: var(
+    --osdk-filter-horizontal-trigger-active-bg,
+    var(--osdk-surface-layer-primary)
+  );
+  border-color: var(--osdk-intent-primary-rest);
+}
+
+.trigger:focus-visible {
+  outline: var(--osdk-emphasis-focus-width) solid
+    var(--osdk-emphasis-focus-color);
+  outline-offset: var(--osdk-emphasis-focus-offset);
+}
+
+.label {
+  font-weight: var(--osdk-typography-weight-bold);
+  white-space: nowrap;
+}
+
+.summary {
+  color: var(--osdk-typography-color-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.popup {
+  background: var(--osdk-background-primary);
+  border: var(--osdk-surface-border);
+  border-radius: var(--osdk-surface-border-radius);
+  box-shadow: var(--osdk-surface-shadow-2);
+  padding: calc(var(--osdk-surface-spacing) * 2);
+  min-width: 280px;
+  max-width: 480px;
+  z-index: var(--osdk-surface-z-index-3, 1000);
+}
+
+.removeButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: calc(var(--osdk-surface-spacing) * 0.5);
+  padding: calc(var(--osdk-surface-spacing) * 0.5);
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: var(--osdk-typography-color-muted);
+  border-radius: var(--osdk-surface-border-radius);
+}
+
+.removeButton:hover {
+  color: var(--osdk-typography-color-default-rest);
+  background: var(--osdk-custom-color-gray-1);
+}

--- a/packages/react-components/src/filter-list/base/inputs/HorizontalFilterTrigger.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/HorizontalFilterTrigger.module.css
@@ -18,8 +18,8 @@
   display: inline-flex;
   align-items: center;
   gap: calc(var(--osdk-surface-spacing) * 1);
-  position: relative;
   flex-shrink: 0;
+  position: relative;
 }
 
 .label {
@@ -30,11 +30,13 @@
 }
 
 .trigger {
+  position: relative;
   display: inline-flex;
   align-items: center;
   width: var(--osdk-filter-horizontal-trigger-width, 160px);
   min-height: var(--osdk-filter-horizontal-trigger-min-height, 28px);
-  padding: 0 calc(var(--osdk-surface-spacing) * 2);
+  padding: 0 calc(var(--osdk-surface-spacing) * 6)
+    0 calc(var(--osdk-surface-spacing) * 2);
   border-radius: var(--osdk-surface-border-radius);
   border: var(--osdk-surface-border-width) solid
     var(--osdk-surface-border-color-default);
@@ -74,19 +76,21 @@
   color: var(--osdk-typography-color-muted);
 }
 
+/* Anchored INSIDE the trigger so the × never overlaps the next filter. The
+   trigger reserves right padding to leave space for the icon. */
 .removeButton {
   position: absolute;
   top: 50%;
-  right: calc(var(--osdk-surface-spacing) * 0.5);
+  right: calc(var(--osdk-surface-spacing) * 0.75);
   transform: translateY(-50%);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: calc(var(--osdk-surface-spacing) * 3);
-  height: calc(var(--osdk-surface-spacing) * 3);
+  width: calc(var(--osdk-surface-spacing) * 4);
+  height: calc(var(--osdk-surface-spacing) * 4);
   padding: 0;
   border: none;
-  background: var(--osdk-background-primary);
+  background: transparent;
   cursor: pointer;
   color: var(--osdk-typography-color-muted);
   border-radius: var(--osdk-surface-border-radius);
@@ -116,4 +120,11 @@
   min-width: 280px;
   max-width: 480px;
   z-index: var(--osdk-surface-z-index-3, 1000);
+}
+
+/* Hide the histogram inside horizontal-mode popovers — the SVG renders
+   cramped at the popover width. The numeric/date inputs below the
+   histogram still work normally. */
+.popup [class*="histogramSvg"] {
+  display: none;
 }

--- a/packages/react-components/src/filter-list/base/inputs/HorizontalFilterTrigger.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/HorizontalFilterTrigger.tsx
@@ -32,12 +32,15 @@ interface HorizontalFilterTriggerProps {
    */
   children: React.ReactNode;
   className?: string;
+  /** Placeholder text shown inside the trigger when no value is selected. */
+  placeholder?: string;
 }
 
 /**
- * Button trigger for horizontal-mode filter rows. The trigger shows the
- * filter label and a summary of the current value; clicking it opens a
- * popover with the existing input UI.
+ * Horizontal-mode filter pair: a plain label sitting next to a
+ * thin-bordered input-shaped popover trigger. Clicking the trigger opens
+ * the existing input UI in a Base UI Popover; the × remove button
+ * absolute-positions over the trigger and is hidden until hover/focus.
  *
  * @internal
  */
@@ -49,6 +52,7 @@ export function HorizontalFilterTrigger(
     onRemove,
     children,
     className,
+    placeholder = "Search…",
   }: HorizontalFilterTriggerProps,
 ): React.ReactElement {
   const [open, setOpen] = useState(false);
@@ -64,15 +68,21 @@ export function HorizontalFilterTrigger(
 
   return (
     <Popover.Root open={open} onOpenChange={setOpen}>
-      <Popover.Trigger
-        className={classnames(styles.trigger, className)}
-        data-active={isActive}
-      >
-        <span className={styles.label}>
-          {label}
-          {summaryHasValue ? ":" : ""}
-        </span>
-        {summaryHasValue && <span className={styles.summary}>{summary}</span>}
+      <span className={classnames(styles.fieldGroup, className)}>
+        <span className={styles.label}>{label}</span>
+        <Popover.Trigger
+          className={styles.trigger}
+          data-active={isActive || undefined}
+        >
+          <span
+            className={classnames(
+              styles.summary,
+              !summaryHasValue && styles.placeholder,
+            )}
+          >
+            {summaryHasValue ? summary : placeholder}
+          </span>
+        </Popover.Trigger>
         {onRemove && (
           <button
             type="button"
@@ -83,7 +93,7 @@ export function HorizontalFilterTrigger(
             <RemoveIcon />
           </button>
         )}
-      </Popover.Trigger>
+      </span>
       <Popover.Portal>
         <Popover.Positioner sideOffset={4}>
           <Popover.Popup className={styles.popup}>

--- a/packages/react-components/src/filter-list/base/inputs/HorizontalFilterTrigger.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/HorizontalFilterTrigger.tsx
@@ -95,7 +95,7 @@ export function HorizontalFilterTrigger(
         )}
       </span>
       <Popover.Portal>
-        <Popover.Positioner sideOffset={4}>
+        <Popover.Positioner sideOffset={4} align="start">
           <Popover.Popup className={styles.popup}>
             {children}
           </Popover.Popup>

--- a/packages/react-components/src/filter-list/base/inputs/HorizontalFilterTrigger.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/HorizontalFilterTrigger.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Popover } from "@base-ui/react/popover";
+import classnames from "classnames";
+import React, { useCallback, useState } from "react";
+import { RemoveIcon } from "../FilterIcons.js";
+import styles from "./HorizontalFilterTrigger.module.css";
+
+interface HorizontalFilterTriggerProps {
+  label: string;
+  summary: React.ReactNode;
+  isActive: boolean;
+  onRemove?: () => void;
+  /**
+   * Children are rendered inside the popover when it opens. Inputs that
+   * fetch aggregations don't fire any network requests until the popover
+   * is opened, satisfying Item 1 AC #7.
+   */
+  children: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * Button trigger for horizontal-mode filter rows. The trigger shows the
+ * filter label and a summary of the current value; clicking it opens a
+ * popover with the existing input UI.
+ *
+ * @internal
+ */
+export function HorizontalFilterTrigger(
+  {
+    label,
+    summary,
+    isActive,
+    onRemove,
+    children,
+    className,
+  }: HorizontalFilterTriggerProps,
+): React.ReactElement {
+  const [open, setOpen] = useState(false);
+  const handleRemove = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onRemove?.();
+    },
+    [onRemove],
+  );
+
+  const summaryHasValue = summary != null && summary !== "";
+
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Trigger
+        className={classnames(styles.trigger, className)}
+        data-active={isActive}
+      >
+        <span className={styles.label}>
+          {label}
+          {summaryHasValue ? ":" : ""}
+        </span>
+        {summaryHasValue && <span className={styles.summary}>{summary}</span>}
+        {onRemove && (
+          <button
+            type="button"
+            onClick={handleRemove}
+            className={styles.removeButton}
+            aria-label={`Remove ${label} filter`}
+          >
+            <RemoveIcon />
+          </button>
+        )}
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Positioner sideOffset={4}>
+          <Popover.Popup className={styles.popup}>
+            {children}
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}

--- a/packages/react-components/src/filter-list/base/inputs/ListogramInput.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/ListogramInput.module.css
@@ -18,6 +18,14 @@
   display: flex;
   flex-direction: column;
   transition: opacity var(--osdk-filter-content-fade-duration);
+
+  /* Forward the legacy listogram-specific empty-label tokens onto the
+     canonical no-value tokens so old theme overrides keep working
+     (NoValueLabel reads --osdk-filter-no-value-*). */
+  --osdk-filter-no-value-color: var(--osdk-filter-listogram-empty-label-color);
+  --osdk-filter-no-value-font-style: var(
+    --osdk-filter-listogram-empty-label-font-style
+  );
 }
 
 .listogram[data-loading="true"] {
@@ -75,11 +83,6 @@
 
 .label[data-excluding] {
   text-decoration: line-through;
-}
-
-.emptyLabel {
-  color: var(--osdk-filter-listogram-empty-label-color);
-  font-style: var(--osdk-filter-listogram-empty-label-font-style);
 }
 
 .bar {

--- a/packages/react-components/src/filter-list/base/inputs/ListogramInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/ListogramInput.tsx
@@ -68,7 +68,28 @@ function ListogramInputInner({
 }: ListogramInputProps): React.ReactElement {
   const [isExpanded, setIsExpanded] = useState(false);
 
-  const stableValues = useStableData(values, isLoading);
+  // Aggregations may return separate rows for each empty-ish value
+  // (e.g. "" and undefined). Merge them into a single "No value" row so
+  // the listogram doesn't render duplicate placeholder labels.
+  const dedupedValues = useMemo(() => {
+    const out: PropertyAggregationValue[] = [];
+    let emptyCount = 0;
+    let sawEmpty = false;
+    for (const v of values) {
+      if (isEmptyValue(v.value)) {
+        emptyCount += v.count;
+        sawEmpty = true;
+      } else {
+        out.push(v);
+      }
+    }
+    if (sawEmpty) {
+      out.push({ value: "", count: emptyCount, isNull: true });
+    }
+    return out;
+  }, [values]);
+
+  const stableValues = useStableData(dedupedValues, isLoading);
 
   const selectedSet = useMemo(() => new Set(selectedValues), [selectedValues]);
 

--- a/packages/react-components/src/filter-list/base/inputs/ListogramInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/ListogramInput.tsx
@@ -19,9 +19,13 @@ import classnames from "classnames";
 import React, { memo, useCallback, useMemo, useState } from "react";
 import { Checkbox } from "../../../base-components/checkbox/Checkbox.js";
 import type { PropertyAggregationValue } from "../../types/AggregationTypes.js";
-import { filterValuesBySearch } from "../../utils/filterValues.js";
+import {
+  filterValuesBySearch,
+  isEmptyValue,
+} from "../../utils/filterValues.js";
 import styles from "./ListogramInput.module.css";
 import { ListogramSkeleton } from "./ListogramSkeleton.js";
+import { NoValueLabel } from "./NoValueLabel.js";
 import sharedStyles from "./shared.module.css";
 import { useStableData } from "./useStableData.js";
 
@@ -128,10 +132,7 @@ function ListogramInputInner({
           {displayValues.map(({ value, count }) => {
             const percentage = maxCount > 0 ? (count / maxCount) * 100 : 0;
             const perRowColor = colorMap?.[value];
-            const isEmpty = value === "";
-            const displayLabel = isEmpty
-              ? "No value"
-              : (renderValue?.(value) ?? value);
+            const isEmpty = isEmptyValue(value);
 
             return (
               <Button
@@ -163,14 +164,13 @@ function ListogramInputInner({
                   />
                 </span>
                 <span
-                  className={classnames(
-                    styles.label,
-                    isEmpty && styles.emptyLabel,
-                  )}
+                  className={styles.label}
                   data-excluding={(isExcluding && selectedSet.has(value))
                     || undefined}
                 >
-                  {displayLabel}
+                  {isEmpty
+                    ? <NoValueLabel />
+                    : (renderValue?.(value) ?? value)}
                 </span>
                 {showCount && displayMode !== "minimal" && (
                   <span className={styles.count}>{count.toLocaleString()}</span>

--- a/packages/react-components/src/filter-list/base/inputs/MultiDateInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/MultiDateInput.tsx
@@ -34,6 +34,10 @@ interface MultiDateInputProps {
   minDate?: Date;
   maxDate?: Date;
   showClearAll?: boolean;
+  /** Optional callback used for chip text. */
+  formatDate?: (date: Date) => string;
+  /** Reserved for future custom text-entry inputs; not invoked by the built-in HTML `<input type="date">`. */
+  parseDate?: (text: string) => Date | undefined;
 }
 
 function MultiDateInputInner({
@@ -44,7 +48,9 @@ function MultiDateInputInner({
   minDate,
   maxDate,
   showClearAll = true,
+  formatDate,
 }: MultiDateInputProps): React.ReactElement {
+  const renderDate = formatDate ?? formatDateForDisplay;
   const addDate = useCallback(
     (date: Date) => {
       const dateStr = formatDateForInput(date);
@@ -91,12 +97,12 @@ function MultiDateInputInner({
         <div className={sharedStyles.tagContainer}>
           {selectedDates.map((date) => (
             <span key={date.toISOString()} className={sharedStyles.tag}>
-              {formatDateForDisplay(date)}
+              {renderDate(date)}
               <Button
                 className={sharedStyles.tagRemove}
                 onClick={() =>
                   removeDate(date)}
-                aria-label={`Remove ${formatDateForDisplay(date)}`}
+                aria-label={`Remove ${renderDate(date)}`}
               >
                 ×
               </Button>

--- a/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.tsx
@@ -18,7 +18,9 @@ import classnames from "classnames";
 import React, { memo, useCallback, useMemo } from "react";
 import { Combobox } from "../../../base-components/combobox/Combobox.js";
 import type { PropertyAggregationValue } from "../../types/AggregationTypes.js";
+import { isEmptyValue } from "../../utils/filterValues.js";
 import styles from "./MultiSelectInput.module.css";
+import { NoValueLabel } from "./NoValueLabel.js";
 import sharedStyles from "./shared.module.css";
 
 interface MultiSelectInputProps {
@@ -75,34 +77,44 @@ function MultiSelectInputInner({
   );
 
   const renderItem = useCallback(
-    (value: string) => (
-      <Combobox.Item key={value} value={value}>
-        <Combobox.ItemIndicator />
-        <span className={styles.itemLabel}>
-          {renderValue ? renderValue(value) : value}
-        </span>
-        {showCounts && (
-          <span className={styles.itemCount}>
-            ({(countByValue.get(value) ?? 0).toLocaleString()})
+    (value: string) => {
+      const isEmpty = isEmptyValue(value);
+      return (
+        <Combobox.Item key={value} value={value}>
+          <Combobox.ItemIndicator />
+          <span className={styles.itemLabel}>
+            {isEmpty
+              ? <NoValueLabel />
+              : (renderValue ? renderValue(value) : value)}
           </span>
-        )}
-      </Combobox.Item>
-    ),
+          {showCounts && (
+            <span className={styles.itemCount}>
+              ({(countByValue.get(value) ?? 0).toLocaleString()})
+            </span>
+          )}
+        </Combobox.Item>
+      );
+    },
     [countByValue, showCounts, renderValue],
   );
 
   const renderChips = useCallback(
     (selectedItems: string[]) => (
       <>
-        {selectedItems.map((value) => (
-          <Combobox.Chip
-            key={value}
-            aria-label={value}
-          >
-            {renderValue ? renderValue(value) : value}
-            <Combobox.ChipRemove />
-          </Combobox.Chip>
-        ))}
+        {selectedItems.map((value) => {
+          const isEmpty = isEmptyValue(value);
+          return (
+            <Combobox.Chip
+              key={value}
+              aria-label={isEmpty ? "No value" : value}
+            >
+              {isEmpty
+                ? <NoValueLabel />
+                : (renderValue ? renderValue(value) : value)}
+              <Combobox.ChipRemove />
+            </Combobox.Chip>
+          );
+        })}
         <Combobox.Input
           placeholder={selectedItems.length > 0 ? "" : placeholder}
           aria-label={ariaLabel}

--- a/packages/react-components/src/filter-list/base/inputs/NoValueLabel.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/NoValueLabel.module.css
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.noValue {
+  color: var(--osdk-filter-no-value-color);
+  font-style: var(--osdk-filter-no-value-font-style);
+}

--- a/packages/react-components/src/filter-list/base/inputs/NoValueLabel.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/NoValueLabel.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classnames from "classnames";
+import React from "react";
+import styles from "./NoValueLabel.module.css";
+
+interface NoValueLabelProps {
+  className?: string;
+}
+
+/**
+ * Canonical "No value" rendering for empty/null filter values.
+ * Italic, muted span used in dropdowns, listogram buckets, NullValueWrapper,
+ * and horizontal-trigger summaries.
+ *
+ * Style is configurable via the `--osdk-filter-no-value-color` and
+ * `--osdk-filter-no-value-font-style` CSS variables.
+ */
+export function NoValueLabel(
+  { className }: NoValueLabelProps,
+): React.ReactElement {
+  return (
+    <span className={classnames(styles.noValue, className)}>
+      No value
+    </span>
+  );
+}

--- a/packages/react-components/src/filter-list/base/inputs/NullValueWrapper.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/NullValueWrapper.module.css
@@ -18,6 +18,11 @@
   display: flex;
   flex-direction: column;
   gap: var(--osdk-filter-null-wrapper-gap);
+
+  /* Forward the legacy null-label-color token onto the canonical no-value
+     token so old theme overrides keep working. NoValueLabel reads
+     --osdk-filter-no-value-color directly. */
+  --osdk-filter-no-value-color: var(--osdk-filter-null-label-color);
 }
 
 .nullValueRow {
@@ -33,13 +38,6 @@
   align-items: center;
   gap: var(--osdk-filter-null-label-gap);
   cursor: pointer;
-}
-
-.nullLabelText {
-  font-family: var(--osdk-filter-null-label-font-family);
-  font-size: var(--osdk-filter-null-label-font-size);
-  line-height: var(--osdk-filter-null-label-line-height);
-  color: var(--osdk-filter-null-label-color);
 }
 
 .count {

--- a/packages/react-components/src/filter-list/base/inputs/NullValueWrapper.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/NullValueWrapper.tsx
@@ -17,6 +17,7 @@
 import classnames from "classnames";
 import React, { memo, useCallback } from "react";
 import { Checkbox } from "../../../base-components/checkbox/Checkbox.js";
+import { NoValueLabel } from "./NoValueLabel.js";
 import styles from "./NullValueWrapper.module.css";
 import sharedStyles from "./shared.module.css";
 
@@ -58,7 +59,7 @@ function NullValueWrapperInner({
       >
         <label className={styles.nullLabel}>
           <Checkbox checked={includeNull} onCheckedChange={handleToggle} />
-          <span className={styles.nullLabelText}>No value</span>
+          <NoValueLabel />
         </label>
         {showNullCount && !error && (
           <span className={styles.count}>

--- a/packages/react-components/src/filter-list/base/inputs/NumberRangeInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/NumberRangeInput.tsx
@@ -38,8 +38,21 @@ const numberConfig: RangeInputConfig<number> = {
   formatTooltip: (min, max, count) =>
     `${min.toFixed(1)} - ${max.toFixed(1)}: ${count.toLocaleString()}`,
   formatPlaceholder: (value) => value.toFixed(0),
+  // Numeric histograms only render the first/last x-axis ticks (the data
+  // min and max) — see Item 7 AC #8: "x-axis labels are min/max only".
+  formatTick: (value) => formatTickNumber(value),
   inputProps: { step: "any" },
 };
+
+function formatTickNumber(value: number): string {
+  if (Number.isInteger(value) && Math.abs(value) < 10_000) {
+    return String(value);
+  }
+  return value.toLocaleString(undefined, {
+    maximumFractionDigits: 1,
+    notation: Math.abs(value) >= 10_000 ? "compact" : "standard",
+  });
+}
 
 interface NumberRangeInputProps {
   valueCountPairs: Array<{ value: number; count: number }>;

--- a/packages/react-components/src/filter-list/base/inputs/NumberRangeInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/NumberRangeInput.tsx
@@ -63,6 +63,7 @@ interface NumberRangeInputProps {
   showHistogram?: boolean;
   className?: string;
   style?: React.CSSProperties;
+  clickToFilter?: boolean;
 }
 
 function NumberRangeInputInner(

--- a/packages/react-components/src/filter-list/base/inputs/RangeInput.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/RangeInput.module.css
@@ -26,25 +26,54 @@
   opacity: 0.5;
 }
 
-.histogramContainer {
-  display: flex;
-  align-items: flex-end;
+.histogramSvg {
+  display: block;
+  width: 100%;
   height: var(--osdk-filter-range-histogram-height);
-  gap: var(--osdk-filter-range-histogram-bar-gap);
-  padding-bottom: var(--osdk-filter-range-histogram-padding-bottom);
-  padding-inline: var(--osdk-filter-range-histogram-padding-inline);
-  overflow: hidden;
+  overflow: visible;
 }
 
+/* Empty rules — exist purely so postcss-modules emits matching hashed
+ * class names for the SVG layer groups. The groups themselves don't need
+ * their own visual style; the children (.axisLine / .countLabel / etc.)
+ * carry the actual styling. */
+.axisLines,
+.bars,
+.countLabels,
+.xTicks {}
+
 .histogramBar {
-  flex: 1;
-  background: var(--osdk-filter-range-histogram-bar-color);
-  min-width: var(--osdk-filter-range-histogram-bar-min-width);
-  transition: background-color var(--osdk-filter-range-histogram-bar-transition);
+  fill: var(--osdk-filter-range-histogram-bar-color);
+  transition: fill var(--osdk-filter-range-histogram-bar-transition);
 }
 
 .histogramBar[data-in-range="true"] {
-  background: var(--osdk-filter-range-histogram-bar-active-color);
+  fill: var(--osdk-filter-range-histogram-bar-active-color);
+}
+
+.axisLine {
+  stroke: var(--osdk-filter-range-histogram-axisLine-color);
+  stroke-width: 1;
+  stroke-dasharray: 2 2;
+}
+
+.yAxisLabel,
+.xTickLabel {
+  fill: var(--osdk-filter-range-histogram-axis-color);
+  font-family: var(--osdk-filter-range-label-font-family);
+  font-size: var(--osdk-filter-range-histogram-axis-font-size);
+}
+
+.countLabel {
+  fill: var(--osdk-filter-range-histogram-label-color);
+  font-family: var(--osdk-filter-range-label-font-family);
+  font-size: var(--osdk-filter-range-histogram-label-font-size);
+}
+
+.subtitle {
+  fill: var(--osdk-filter-range-histogram-subtitle-color);
+  font-family: var(--osdk-filter-range-label-font-family);
+  font-size: var(--osdk-filter-range-histogram-subtitle-font-size);
 }
 
 .rangeInputs {

--- a/packages/react-components/src/filter-list/base/inputs/RangeInput.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/RangeInput.module.css
@@ -51,6 +51,14 @@
   fill: var(--osdk-filter-range-histogram-bar-active-color);
 }
 
+.histogramBar[data-click-to-filter="true"] {
+  cursor: pointer;
+}
+
+.histogramBar[data-click-to-filter="true"]:hover {
+  fill: var(--osdk-filter-range-histogram-bar-active-color);
+}
+
 .axisLine {
   stroke: var(--osdk-filter-range-histogram-axisLine-color);
   stroke-width: 1;

--- a/packages/react-components/src/filter-list/base/inputs/RangeInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/RangeInput.tsx
@@ -91,6 +91,11 @@ export interface RangeInputProps<T> {
     buckets: Array<HistogramBucket<T>>;
     subtitle?: string;
   };
+  /**
+   * When true, clicking a histogram bar replaces the filter range with
+   * that bucket's `[min, max]`. Default `false` (no behavior change).
+   */
+  clickToFilter?: boolean;
 }
 
 function RangeInputInner<T>({
@@ -104,6 +109,7 @@ function RangeInputInner<T>({
   style,
   config,
   histogramData,
+  clickToFilter = false,
 }: RangeInputProps<T>): React.ReactElement {
   const minInputId = useId();
   const maxInputId = useId();
@@ -221,6 +227,14 @@ function RangeInputInner<T>({
     [buckets.length],
   );
 
+  const handleBucketClick = useCallback(
+    (bucket: HistogramBucket<T>) => {
+      if (!clickToFilter) return;
+      onChangeRef.current(bucket.min, bucket.max);
+    },
+    [clickToFilter],
+  );
+
   const handleMinChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const newValue = e.target.value;
@@ -305,10 +319,15 @@ function RangeInputInner<T>({
                   key={index}
                   className={styles.histogramBar}
                   data-in-range={isInRange}
+                  data-click-to-filter={clickToFilter || undefined}
                   x={x}
                   y={y}
                   width={Math.max(barW, 0.5)}
                   height={barH}
+                  onClick={clickToFilter
+                     
+                    ? () => handleBucketClick(bucket)
+                    : undefined}
                 >
                   <title>
                     {config.formatTooltip(bucket.min, bucket.max, bucket.count)}

--- a/packages/react-components/src/filter-list/base/inputs/RangeInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/RangeInput.tsx
@@ -227,10 +227,54 @@ function RangeInputInner<T>({
     [buckets.length],
   );
 
-  const handleBucketClick = useCallback(
-    (bucket: HistogramBucket<T>) => {
+  // Drag range tracked in a ref so synchronous read/write across
+  // mousedown → mousemove → mouseup is reliable. A separate state value
+  // mirrors the ref so the SVG re-renders to highlight the dragged range
+  // while the user is dragging.
+  const dragRangeRef = useRef<{ start: number; end: number } | null>(null);
+  const [dragRange, setDragRange] = useState<
+    { start: number; end: number } | null
+  >(null);
+
+  const bucketsRef = useRef(buckets);
+  bucketsRef.current = buckets;
+
+  const commitDragRange = useCallback((start: number, end: number) => {
+    const currentBuckets = bucketsRef.current;
+    const lo = Math.min(start, end);
+    const hi = Math.max(start, end);
+    const minBucket = currentBuckets[lo];
+    const maxBucket = currentBuckets[hi];
+    if (minBucket == null || maxBucket == null) return;
+    onChangeRef.current(minBucket.min, maxBucket.max);
+  }, []);
+
+  const handleBucketMouseDown = useCallback(
+    (index: number, e: React.MouseEvent) => {
       if (!clickToFilter) return;
-      onChangeRef.current(bucket.min, bucket.max);
+      e.preventDefault();
+      dragRangeRef.current = { start: index, end: index };
+      setDragRange(dragRangeRef.current);
+      const handleUp = () => {
+        document.removeEventListener("mouseup", handleUp);
+        const current = dragRangeRef.current;
+        if (current != null) {
+          commitDragRange(current.start, current.end);
+        }
+        dragRangeRef.current = null;
+        setDragRange(null);
+      };
+      document.addEventListener("mouseup", handleUp);
+    },
+    [clickToFilter, commitDragRange],
+  );
+
+  const handleBucketMouseEnter = useCallback(
+    (index: number) => {
+      if (!clickToFilter) return;
+      if (dragRangeRef.current == null) return;
+      dragRangeRef.current = { ...dragRangeRef.current, end: index };
+      setDragRange(dragRangeRef.current);
     },
     [clickToFilter],
   );
@@ -314,19 +358,27 @@ function RangeInputInner<T>({
                 || config.toNumber(bucket.max) >= config.toNumber(minValue))
                 && (maxValue === undefined
                   || config.toNumber(bucket.min) <= config.toNumber(maxValue));
+              const isInDragRange = dragRange != null
+                && index >= Math.min(dragRange.start, dragRange.end)
+                && index <= Math.max(dragRange.start, dragRange.end);
               return (
                 <rect
                   key={index}
                   className={styles.histogramBar}
-                  data-in-range={isInRange}
+                  data-in-range={isInRange || isInDragRange}
                   data-click-to-filter={clickToFilter || undefined}
+                  data-dragging={isInDragRange || undefined}
                   x={x}
                   y={y}
                   width={Math.max(barW, 0.5)}
                   height={barH}
-                  onClick={clickToFilter
-                     
-                    ? () => handleBucketClick(bucket)
+                   
+                  onMouseDown={clickToFilter
+                    ? (e) => handleBucketMouseDown(index, e)
+                    : undefined}
+                   
+                  onMouseEnter={clickToFilter
+                    ? () => handleBucketMouseEnter(index)
                     : undefined}
                 >
                   <title>

--- a/packages/react-components/src/filter-list/base/inputs/RangeInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/RangeInput.tsx
@@ -30,12 +30,25 @@ import {
   createHistogramBuckets,
   getMaxBucketCount,
   type HistogramBucket,
+  niceTicks,
 } from "./createHistogramBuckets.js";
 import styles from "./RangeInput.module.css";
 import sharedStyles from "./shared.module.css";
 import { useStableData } from "./useStableData.js";
 
 const DEBOUNCE_MS = 300;
+
+/** SVG viewBox. The bars/axisLines stretch with the container; text font
+ *  size is in viewBox units so it stays readable across container widths. */
+const SVG_W = 400;
+const SVG_H = 140;
+const PAD_LEFT = 30;
+const PAD_RIGHT = 10;
+const PAD_TOP = 16;
+const PAD_BOTTOM = 32;
+const PLOT_W = SVG_W - PAD_LEFT - PAD_RIGHT;
+const PLOT_H = SVG_H - PAD_TOP - PAD_BOTTOM;
+const BAR_GAP = 2;
 
 export interface RangeInputConfig<T> {
   inputType: "number" | "date";
@@ -47,6 +60,13 @@ export interface RangeInputConfig<T> {
   maxLabel: string;
   formatTooltip: (min: T, max: T, count: number) => string;
   formatPlaceholder?: (value: T) => string;
+  /**
+   * Optional formatter for x-axis tick labels. If a bucket's
+   * `tickLabel` is already populated (e.g. by the date bucketer) that
+   * takes precedence. Numeric histograms typically only render the
+   * first/last tick — supply a formatter and `xAxisMode: "endpoints"`.
+   */
+  formatTick?: (value: T) => string;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
 }
 
@@ -60,6 +80,17 @@ export interface RangeInputProps<T> {
   className?: string;
   style?: React.CSSProperties;
   config: RangeInputConfig<T>;
+  /**
+   * Optional pre-computed histogram. If provided, `RangeInput` skips its
+   * built-in bucketer and uses these buckets verbatim. Use this when the
+   * caller has domain knowledge that improves on uniform numeric bucketing
+   * — e.g. `createDateHistogramBuckets` snaps to calendar boundaries and
+   * supplies per-bucket tick labels.
+   */
+  histogramData?: {
+    buckets: Array<HistogramBucket<T>>;
+    subtitle?: string;
+  };
 }
 
 function RangeInputInner<T>({
@@ -72,6 +103,7 @@ function RangeInputInner<T>({
   className,
   style,
   config,
+  histogramData,
 }: RangeInputProps<T>): React.ReactElement {
   const minInputId = useId();
   const maxInputId = useId();
@@ -148,6 +180,7 @@ function RangeInputInner<T>({
   }), [computedRange.min, computedRange.max]);
 
   const buckets = useMemo<Array<HistogramBucket<T>>>(() => {
+    if (histogramData) return histogramData.buckets;
     if (
       !showHistogram
       || displayPairs.length === 0
@@ -156,16 +189,37 @@ function RangeInputInner<T>({
     ) {
       return [];
     }
-
     return createHistogramBuckets(
       displayPairs,
       { min: computedRange.min, max: computedRange.max },
       config.toNumber,
       config.fromNumber,
     );
-  }, [showHistogram, displayPairs, computedRange, config]);
+  }, [
+    histogramData,
+    showHistogram,
+    displayPairs,
+    computedRange,
+    config,
+  ]);
+
+  const subtitle = histogramData?.subtitle ?? "";
 
   const maxBucketCount = useMemo(() => getMaxBucketCount(buckets), [buckets]);
+  const yTicks = useMemo(() => niceTicks(maxBucketCount), [maxBucketCount]);
+  const yTopValue = yTicks[yTicks.length - 1] || maxBucketCount || 1;
+
+  // Skip count labels when there are too many bars to fit them readably.
+  // Threshold of 10 matches the PRD heuristic.
+  const COUNT_LABEL_THRESHOLD = 10;
+  const skipCountLabel = useCallback(
+    (i: number) => {
+      if (buckets.length <= COUNT_LABEL_THRESHOLD) return false;
+      const stride = Math.ceil(buckets.length / COUNT_LABEL_THRESHOLD);
+      return i % stride !== 0;
+    },
+    [buckets.length],
+  );
 
   const handleMinChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -198,29 +252,139 @@ function RangeInputInner<T>({
       )}
 
       {showHistogram && buckets.length > 0 && (
-        <div className={styles.histogramContainer}>
-          {buckets.map((bucket, index) => {
-            const height = (bucket.count / maxBucketCount) * 100;
-            const isInRange = (minValue === undefined
-              || config.toNumber(bucket.max) >= config.toNumber(minValue))
-              && (maxValue === undefined
-                || config.toNumber(bucket.min) <= config.toNumber(maxValue));
+        <svg
+          className={styles.histogramSvg}
+          viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+          preserveAspectRatio="none"
+          role="img"
+          aria-label="Histogram of value counts"
+        >
+          <g className={styles.axisLines}>
+            {yTicks.map((tickValue) => {
+              const yFrac = yTopValue > 0 ? tickValue / yTopValue : 0;
+              const y = PAD_TOP + PLOT_H - yFrac * PLOT_H;
+              return (
+                <g key={tickValue}>
+                  <line
+                    className={styles.axisLine}
+                    x1={PAD_LEFT}
+                    x2={SVG_W - PAD_RIGHT}
+                    y1={y}
+                    y2={y}
+                    vectorEffect="non-scaling-stroke"
+                  />
+                  <text
+                    className={styles.yAxisLabel}
+                    x={PAD_LEFT - 4}
+                    y={y + 3}
+                    textAnchor="end"
+                  >
+                    {tickValue}
+                  </text>
+                </g>
+              );
+            })}
+          </g>
 
-            return (
-              <div
-                key={index}
-                className={styles.histogramBar}
-                data-in-range={isInRange}
-                style={{ height: `${Math.max(height, 2)}%` }}
-                title={config.formatTooltip(
-                  bucket.min,
-                  bucket.max,
-                  bucket.count,
-                )}
-              />
-            );
-          })}
-        </div>
+          <g className={styles.bars}>
+            {buckets.map((bucket, index) => {
+              const barW = (PLOT_W - BAR_GAP * (buckets.length - 1))
+                / buckets.length;
+              const x = PAD_LEFT + index * (barW + BAR_GAP);
+              const heightFrac = yTopValue > 0
+                ? bucket.count / yTopValue
+                : 0;
+              const barH = Math.max(0, heightFrac * PLOT_H);
+              const y = PAD_TOP + PLOT_H - barH;
+              const isInRange = (minValue === undefined
+                || config.toNumber(bucket.max) >= config.toNumber(minValue))
+                && (maxValue === undefined
+                  || config.toNumber(bucket.min) <= config.toNumber(maxValue));
+              return (
+                <rect
+                  key={index}
+                  className={styles.histogramBar}
+                  data-in-range={isInRange}
+                  x={x}
+                  y={y}
+                  width={Math.max(barW, 0.5)}
+                  height={barH}
+                >
+                  <title>
+                    {config.formatTooltip(bucket.min, bucket.max, bucket.count)}
+                  </title>
+                </rect>
+              );
+            })}
+          </g>
+
+          <g className={styles.countLabels}>
+            {buckets.map((bucket, index) => {
+              if (bucket.count === 0) return null;
+              if (skipCountLabel(index)) return null;
+              const barW = (PLOT_W - BAR_GAP * (buckets.length - 1))
+                / buckets.length;
+              const cx = PAD_LEFT + index * (barW + BAR_GAP) + barW / 2;
+              const heightFrac = yTopValue > 0
+                ? bucket.count / yTopValue
+                : 0;
+              const barH = heightFrac * PLOT_H;
+              const y = PAD_TOP + PLOT_H - barH - 2;
+              return (
+                <text
+                  key={index}
+                  className={styles.countLabel}
+                  x={cx}
+                  y={y}
+                  textAnchor="middle"
+                >
+                  {bucket.count.toLocaleString()}
+                </text>
+              );
+            })}
+          </g>
+
+          <g className={styles.xTicks}>
+            {buckets.map((bucket, index) => {
+              const tickLabel = bucket.tickLabel
+                ?? renderEndpointTick(buckets, index, config);
+              if (!tickLabel) return null;
+              if (
+                buckets.length > COUNT_LABEL_THRESHOLD
+                && bucket.tickLabel
+                && skipCountLabel(index)
+              ) {
+                return null;
+              }
+              const barW = (PLOT_W - BAR_GAP * (buckets.length - 1))
+                / buckets.length;
+              const cx = PAD_LEFT + index * (barW + BAR_GAP) + barW / 2;
+              const y = PAD_TOP + PLOT_H + 12;
+              return (
+                <text
+                  key={index}
+                  className={styles.xTickLabel}
+                  x={cx}
+                  y={y}
+                  textAnchor="middle"
+                >
+                  {tickLabel}
+                </text>
+              );
+            })}
+          </g>
+
+          {subtitle && (
+            <text
+              className={styles.subtitle}
+              x={SVG_W / 2}
+              y={SVG_H - 4}
+              textAnchor="middle"
+            >
+              {subtitle}
+            </text>
+          )}
+        </svg>
       )}
 
       <div className={styles.rangeInputs}>
@@ -266,6 +430,24 @@ function RangeInputInner<T>({
       </div>
     </div>
   );
+}
+
+/**
+ * Numeric histograms only render the first and last x-axis ticks — per
+ * AC #8 of Item 7: "x-axis labels are min/max only — no per-bucket
+ * numeric labels".
+ */
+function renderEndpointTick<T>(
+  buckets: ReadonlyArray<HistogramBucket<T>>,
+  index: number,
+  config: RangeInputConfig<T>,
+): string | undefined {
+  if (!config.formatTick) return undefined;
+  if (index === 0) return config.formatTick(buckets[0].min);
+  if (index === buckets.length - 1) {
+    return config.formatTick(buckets[buckets.length - 1].max);
+  }
+  return undefined;
 }
 
 export const RangeInput = memo(RangeInputInner) as typeof RangeInputInner;

--- a/packages/react-components/src/filter-list/base/inputs/SingleSelectInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/SingleSelectInput.tsx
@@ -18,6 +18,8 @@ import classnames from "classnames";
 import React, { memo, useCallback, useMemo } from "react";
 import { Combobox } from "../../../base-components/combobox/Combobox.js";
 import type { PropertyAggregationValue } from "../../types/AggregationTypes.js";
+import { isEmptyValue } from "../../utils/filterValues.js";
+import { NoValueLabel } from "./NoValueLabel.js";
 import sharedStyles from "./shared.module.css";
 import styles from "./SingleSelectInput.module.css";
 
@@ -77,19 +79,24 @@ function SingleSelectInputInner({
   );
 
   const renderItem = useCallback(
-    (value: string) => (
-      <Combobox.Item key={value} value={value}>
-        <Combobox.ItemIndicator />
-        <span className={styles.itemLabel}>
-          {renderValue ? renderValue(value) : value}
-        </span>
-        {showCounts && (
-          <span className={styles.itemCount}>
-            ({(countByValue.get(value) ?? 0).toLocaleString()})
+    (value: string) => {
+      const isEmpty = isEmptyValue(value);
+      return (
+        <Combobox.Item key={value} value={value}>
+          <Combobox.ItemIndicator />
+          <span className={styles.itemLabel}>
+            {isEmpty
+              ? <NoValueLabel />
+              : (renderValue ? renderValue(value) : value)}
           </span>
-        )}
-      </Combobox.Item>
-    ),
+          {showCounts && (
+            <span className={styles.itemCount}>
+              ({(countByValue.get(value) ?? 0).toLocaleString()})
+            </span>
+          )}
+        </Combobox.Item>
+      );
+    },
     [countByValue, showCounts, renderValue],
   );
 

--- a/packages/react-components/src/filter-list/base/inputs/TextTagsInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/TextTagsInput.tsx
@@ -19,6 +19,8 @@ import classnames from "classnames";
 import React, { memo, useCallback, useMemo, useState } from "react";
 import { Combobox } from "../../../base-components/combobox/Combobox.js";
 import type { PropertyAggregationValue } from "../../types/AggregationTypes.js";
+import { isEmptyValue } from "../../utils/filterValues.js";
+import { NoValueLabel } from "./NoValueLabel.js";
 import sharedStyles from "./shared.module.css";
 import styles from "./TextTagsInput.module.css";
 
@@ -34,14 +36,17 @@ const TagItem = memo(function TagItem({ tag, onRemove }: TagItemProps) {
     onRemove(tag);
   }, [tag, onRemove]);
 
+  const isEmpty = isEmptyValue(tag);
+  const displayLabel = isEmpty ? "No value" : tag;
+
   return (
     <span className={sharedStyles.tag}>
-      {tag}
+      {isEmpty ? <NoValueLabel /> : tag}
       <Button
         type="button"
         className={sharedStyles.tagRemove}
         onClick={handleRemove}
-        aria-label={`Remove ${tag}`}
+        aria-label={`Remove ${displayLabel}`}
       >
         ×
       </Button>

--- a/packages/react-components/src/filter-list/base/inputs/TimelineInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/TimelineInput.tsx
@@ -32,6 +32,13 @@ interface TimelineInputProps {
   className?: string;
   minDate?: Date;
   maxDate?: Date;
+  /**
+   * Optional callback used for the period subtitle labels above the date
+   * inputs. The HTML `<input type="date">` value attribute is unaffected.
+   */
+  formatDate?: (date: Date) => string;
+  /** Reserved for future custom text inputs; not invoked by the built-in HTML `<input type="date">`. */
+  parseDate?: (text: string) => Date | undefined;
 }
 
 function TimelineInputInner({
@@ -41,7 +48,14 @@ function TimelineInputInner({
   className,
   minDate,
   maxDate,
+  formatDate,
 }: TimelineInputProps): React.ReactElement {
+  const renderDate = (date: Date | undefined, fallback: string): string =>
+    date == null
+      ? fallback
+      : formatDate
+      ? formatDate(date)
+      : formatDateForDisplay(date, fallback);
   const handleStartChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const date = parseDateFromInput(e.target.value);
@@ -74,9 +88,9 @@ function TimelineInputInner({
   return (
     <div className={classnames(styles.timeline, className)}>
       <div className={styles.labels}>
-        <span>{formatDateForDisplay(startDate, "—")}</span>
+        <span>{renderDate(startDate, "—")}</span>
         <span>to</span>
-        <span>{formatDateForDisplay(endDate, "—")}</span>
+        <span>{renderDate(endDate, "—")}</span>
         {(startDate || endDate) && (
           <Button
             type="button"

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/Histogram.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/Histogram.test.tsx
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, render } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDateHistogramBuckets } from "../createDateHistogramBuckets.js";
+import { niceTicks } from "../createHistogramBuckets.js";
+import { DateRangeInput } from "../DateRangeInput.js";
+import { NumberRangeInput } from "../NumberRangeInput.js";
+
+afterEach(cleanup);
+
+describe("niceTicks", () => {
+  it("returns [0] for non-positive max", () => {
+    expect(niceTicks(0)).toEqual([0]);
+    expect(niceTicks(-5)).toEqual([0]);
+  });
+
+  it("returns 0..max for small integers (1, 2, 3)", () => {
+    expect(niceTicks(1)).toEqual([0, 1]);
+    expect(niceTicks(2)).toEqual([0, 1, 2]);
+    expect(niceTicks(3)).toEqual([0, 1, 2, 3]);
+  });
+
+  it("rounds to 1/2/5 × 10^n for larger values", () => {
+    const t10 = niceTicks(10);
+    expect(t10[0]).toBe(0);
+    expect(t10[t10.length - 1]).toBe(10);
+    // step is 2, so ticks are 0,2,4,6,8,10
+    expect(t10).toEqual([0, 2, 4, 6, 8, 10]);
+
+    const t27 = niceTicks(27);
+    expect(t27[0]).toBe(0);
+    expect(t27[t27.length - 1]).toBeGreaterThanOrEqual(27);
+
+    const t1000 = niceTicks(1000);
+    expect(t1000[0]).toBe(0);
+    expect(t1000[t1000.length - 1]).toBe(1000);
+    // Step rounds to a nice 1/2/5 × 10^n value
+    const step = t1000[1] - t1000[0];
+    expect([100, 200, 250, 500].includes(step)).toBe(true);
+  });
+});
+
+describe("createDateHistogramBuckets", () => {
+  it("returns empty when there are no value pairs", () => {
+    const result = createDateHistogramBuckets([], {
+      min: new Date(2020, 0, 1),
+      max: new Date(2020, 0, 31),
+    });
+    expect(result.buckets).toEqual([]);
+    expect(result.subtitle).toBe("");
+  });
+
+  it("uses daily buckets within a single month", () => {
+    const pairs = [
+      { value: new Date(2020, 4, 1), count: 1 },
+      { value: new Date(2020, 4, 15), count: 3 },
+      { value: new Date(2020, 4, 31), count: 2 },
+    ];
+    const result = createDateHistogramBuckets(pairs, {
+      min: new Date(2020, 4, 1),
+      max: new Date(2020, 4, 31),
+    });
+    expect(result.granularity).toBe("day");
+    expect(result.buckets).toHaveLength(31);
+    expect(result.subtitle).toBe("May 2020");
+    // Bucket for May 15 should have count 3
+    expect(result.buckets[14].count).toBe(3);
+    expect(result.buckets[14].tickLabel).toBe("15");
+  });
+
+  it("uses monthly buckets when span is < 1 year", () => {
+    const pairs = [
+      { value: new Date(2020, 0, 15), count: 5 },
+      { value: new Date(2020, 5, 10), count: 7 },
+      { value: new Date(2020, 11, 31), count: 2 },
+    ];
+    const result = createDateHistogramBuckets(pairs, {
+      min: new Date(2020, 0, 1),
+      max: new Date(2020, 11, 31),
+    });
+    expect(result.granularity).toBe("month");
+    expect(result.buckets).toHaveLength(12);
+    expect(result.subtitle).toBe("2020");
+    expect(result.buckets[5].tickLabel).toBe("Jun");
+    expect(result.buckets[5].count).toBe(7);
+  });
+
+  it("uses yearly buckets when span > 1 year", () => {
+    const pairs = [
+      { value: new Date(2018, 4, 15), count: 4 },
+      { value: new Date(2020, 5, 10), count: 8 },
+      { value: new Date(2024, 11, 31), count: 1 },
+    ];
+    const result = createDateHistogramBuckets(pairs, {
+      min: new Date(2018, 0, 1),
+      max: new Date(2024, 11, 31),
+    });
+    expect(result.granularity).toBe("year");
+    expect(result.buckets).toHaveLength(7);
+    expect(result.buckets[0].tickLabel).toBe("2018");
+    expect(result.buckets[0].count).toBe(4);
+  });
+
+  it("uses formatDate for the subtitle when provided", () => {
+    const pairs = [{ value: new Date(2020, 4, 15), count: 1 }];
+    const result = createDateHistogramBuckets(
+      pairs,
+      { min: new Date(2020, 4, 1), max: new Date(2020, 4, 31) },
+      (d) => `custom-${d.getFullYear()}`,
+    );
+    expect(result.subtitle).toBe("custom-2020");
+  });
+});
+
+describe("RangeInput SVG histogram", () => {
+  // 10-day span keeps every bucket below the count-label-skipping
+  // threshold so all labels render — easier to assert against.
+  const dateBuckets = [
+    { value: new Date(2020, 4, 1), count: 5 },
+    { value: new Date(2020, 4, 5), count: 8 },
+    { value: new Date(2020, 4, 10), count: 2 },
+  ];
+
+  it("renders the histogram as an <svg> element", () => {
+    const { container } = render(
+      <DateRangeInput
+        valueCountPairs={dateBuckets}
+        isLoading={false}
+        minValue={undefined}
+        maxValue={undefined}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(container.querySelector("svg")).toBeDefined();
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("renders one <rect> per bucket", () => {
+    const { container } = render(
+      <DateRangeInput
+        valueCountPairs={dateBuckets}
+        isLoading={false}
+        minValue={undefined}
+        maxValue={undefined}
+        onChange={vi.fn()}
+      />,
+    );
+    const rects = container.querySelectorAll("svg rect");
+    // Daily bucketer for May 1–10 → 10 buckets
+    expect(rects.length).toBe(10);
+  });
+
+  it("renders bar count <text> labels for buckets with count > 0", () => {
+    const { container } = render(
+      <DateRangeInput
+        valueCountPairs={dateBuckets}
+        isLoading={false}
+        minValue={undefined}
+        maxValue={undefined}
+        onChange={vi.fn()}
+      />,
+    );
+    const countLabels = container.querySelectorAll(
+      "g[class*=\"countLabels\"] text",
+    );
+    expect(countLabels.length).toBeGreaterThan(0);
+    const rendered = Array.from(countLabels).map((t) => t.textContent);
+    expect(rendered).toContain("8");
+  });
+
+  it("renders x-axis tick <text> labels for date histograms", () => {
+    const { container } = render(
+      <DateRangeInput
+        valueCountPairs={dateBuckets}
+        isLoading={false}
+        minValue={undefined}
+        maxValue={undefined}
+        onChange={vi.fn()}
+      />,
+    );
+    const tickLabels = container.querySelectorAll("g[class*=\"xTicks\"] text");
+    expect(tickLabels.length).toBeGreaterThan(0);
+  });
+
+  it("renders the subtitle <text> below the histogram", () => {
+    const { container } = render(
+      <DateRangeInput
+        valueCountPairs={dateBuckets}
+        isLoading={false}
+        minValue={undefined}
+        maxValue={undefined}
+        onChange={vi.fn()}
+      />,
+    );
+    const subtitle = container.querySelector("text[class*=\"subtitle\"]");
+    expect(subtitle?.textContent).toBe("May 2020");
+  });
+
+  it("renders y-axis axisLines + numeric tick labels", () => {
+    const { container } = render(
+      <DateRangeInput
+        valueCountPairs={dateBuckets}
+        isLoading={false}
+        minValue={undefined}
+        maxValue={undefined}
+        onChange={vi.fn()}
+      />,
+    );
+    const axisLines = container.querySelectorAll("line[class*=\"axisLine\"]");
+    const yLabels = container.querySelectorAll("text[class*=\"yAxisLabel\"]");
+    expect(axisLines.length).toBeGreaterThan(1);
+    expect(yLabels.length).toBeGreaterThan(1);
+    const yValues = Array.from(yLabels).map((l) => l.textContent);
+    expect(yValues).toContain("0");
+  });
+
+  it("does not stretch to nice round ticks when max ≤ 3", () => {
+    const tinyBuckets = [
+      { value: new Date(2020, 4, 1), count: 1 },
+      { value: new Date(2020, 4, 15), count: 3 },
+    ];
+    const { container } = render(
+      <DateRangeInput
+        valueCountPairs={tinyBuckets}
+        isLoading={false}
+        minValue={undefined}
+        maxValue={undefined}
+        onChange={vi.fn()}
+      />,
+    );
+    const yValues = Array.from(
+      container.querySelectorAll("text[class*=\"yAxisLabel\"]"),
+    ).map((l) => l.textContent);
+    // niceTicks(3) → [0, 1, 2, 3] — must NOT round to 5/10
+    expect(yValues).toEqual(["0", "1", "2", "3"]);
+  });
+
+  it(
+    "numeric histogram renders axisLines + bar count labels (parity with date)",
+    () => {
+      const numericPairs = [
+        { value: 10, count: 2 },
+        { value: 50, count: 5 },
+        { value: 90, count: 3 },
+      ];
+      const { container } = render(
+        <NumberRangeInput
+          valueCountPairs={numericPairs}
+          isLoading={false}
+          minValue={undefined}
+          maxValue={undefined}
+          onChange={vi.fn()}
+        />,
+      );
+      const svg = container.querySelector("svg");
+      expect(svg).not.toBeNull();
+      const axisLines = container.querySelectorAll(
+        "line[class*=\"axisLine\"]",
+      );
+      expect(axisLines.length).toBeGreaterThan(1);
+      const countLabels = container.querySelectorAll(
+        "g[class*=\"countLabels\"] text",
+      );
+      expect(countLabels.length).toBeGreaterThan(0);
+    },
+  );
+
+  it(
+    "numeric histogram x-axis ticks are min/max only — no per-bucket numeric labels",
+    () => {
+      const numericPairs = [
+        { value: 10, count: 2 },
+        { value: 50, count: 5 },
+        { value: 90, count: 3 },
+      ];
+      const { container } = render(
+        <NumberRangeInput
+          valueCountPairs={numericPairs}
+          isLoading={false}
+          minValue={undefined}
+          maxValue={undefined}
+          onChange={vi.fn()}
+        />,
+      );
+      const tickLabels = container.querySelectorAll(
+        "g[class*=\"xTicks\"] text",
+      );
+      // niceNum-style helper rounds to 5/10 etc., but the bucketer creates
+      // 20 evenly-spaced buckets across [10, 90]. We only render ticks at
+      // the first and last buckets — exactly 2 tick texts.
+      expect(tickLabels.length).toBe(2);
+    },
+  );
+});

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/Histogram.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/Histogram.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDateHistogramBuckets } from "../createDateHistogramBuckets.js";
@@ -281,7 +281,12 @@ describe("RangeInput SVG histogram", () => {
     },
   );
 
-  describe("clickToFilter", () => {
+  describe("clickToFilter (drag-to-select range)", () => {
+    const fireMouseDown = (el: Element) => fireEvent.mouseDown(el);
+    const fireMouseEnter = (el: Element) => fireEvent.mouseEnter(el);
+    const fireDocumentMouseUp = () =>
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
     it("does not invoke onChange when clickToFilter is omitted", () => {
       const onChange = vi.fn();
       const { container } = render(
@@ -297,14 +302,13 @@ describe("RangeInput SVG histogram", () => {
         "rect[class*=\"histogramBar\"]",
       );
       expect(rects.length).toBeGreaterThan(0);
-      (rects[0] as SVGRectElement).dispatchEvent(
-        new MouseEvent("click", { bubbles: true }),
-      );
+      fireMouseDown(rects[0]);
+      fireDocumentMouseUp();
       expect(onChange).not.toHaveBeenCalled();
     });
 
     it(
-      "invokes onChange with the bucket's [min, max] when clicked",
+      "single mousedown+mouseup on one bar sets the range to that bucket",
       () => {
         const onChange = vi.fn();
         const { container } = render(
@@ -320,21 +324,47 @@ describe("RangeInput SVG histogram", () => {
         const rects = container.querySelectorAll(
           "rect[class*=\"histogramBar\"]",
         );
-        const firstBar = rects[0] as SVGRectElement;
-        firstBar.dispatchEvent(
-          new MouseEvent("click", { bubbles: true }),
-        );
+        fireMouseDown(rects[0]);
+        fireDocumentMouseUp();
         expect(onChange).toHaveBeenCalledTimes(1);
         const [min, max] = onChange.mock.calls[0];
-        expect(min).toBeInstanceOf(Date);
-        expect(max).toBeInstanceOf(Date);
-        // First bar is May 1; daily granularity → bucket [May 1, May 2]
         expect((min as Date).getDate()).toBe(1);
         expect((max as Date).getDate()).toBe(2);
       },
     );
 
-    it("replaces (not unions) when a second bar is clicked", () => {
+    it(
+      "drag from bar 0 to bar 3 commits a range covering all four buckets",
+      () => {
+        const onChange = vi.fn();
+        const { container } = render(
+          <DateRangeInput
+            valueCountPairs={dateBuckets}
+            isLoading={false}
+            minValue={undefined}
+            maxValue={undefined}
+            onChange={onChange}
+            clickToFilter={true}
+          />,
+        );
+        const rects = container.querySelectorAll(
+          "rect[class*=\"histogramBar\"]",
+        );
+        fireMouseDown(rects[0]);
+        fireMouseEnter(rects[1]);
+        fireMouseEnter(rects[2]);
+        fireMouseEnter(rects[3]);
+        fireDocumentMouseUp();
+        expect(onChange).toHaveBeenCalledTimes(1);
+        const [min, max] = onChange.mock.calls[0];
+        // Daily buckets May 1..10; bucket 0 is [May 1, May 2], bucket 3 is
+        // [May 4, May 5] → committed range = [May 1, May 5]
+        expect((min as Date).getDate()).toBe(1);
+        expect((max as Date).getDate()).toBe(5);
+      },
+    );
+
+    it("drag in reverse (bar 3 → bar 0) still commits with min < max", () => {
       const onChange = vi.fn();
       const { container } = render(
         <DateRangeInput
@@ -349,16 +379,15 @@ describe("RangeInput SVG histogram", () => {
       const rects = container.querySelectorAll(
         "rect[class*=\"histogramBar\"]",
       );
-      const firstBar = rects[0] as SVGRectElement;
-      const secondBar = rects[2] as SVGRectElement;
-      firstBar.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-      secondBar.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-      expect(onChange).toHaveBeenCalledTimes(2);
-      // Second call must be the third bucket's range, not a union with
-      // the first.
-      const [min2, max2] = onChange.mock.calls[1];
-      expect((min2 as Date).getDate()).toBe(3);
-      expect((max2 as Date).getDate()).toBe(4);
+      fireMouseDown(rects[3]);
+      fireMouseEnter(rects[2]);
+      fireMouseEnter(rects[1]);
+      fireMouseEnter(rects[0]);
+      fireDocumentMouseUp();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const [min, max] = onChange.mock.calls[0];
+      expect((min as Date).getDate()).toBe(1);
+      expect((max as Date).getDate()).toBe(5);
     });
 
     it("sets data-click-to-filter=\"true\" on rects when enabled", () => {

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/Histogram.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/Histogram.test.tsx
@@ -281,6 +281,126 @@ describe("RangeInput SVG histogram", () => {
     },
   );
 
+  describe("clickToFilter", () => {
+    it("does not invoke onChange when clickToFilter is omitted", () => {
+      const onChange = vi.fn();
+      const { container } = render(
+        <DateRangeInput
+          valueCountPairs={dateBuckets}
+          isLoading={false}
+          minValue={undefined}
+          maxValue={undefined}
+          onChange={onChange}
+        />,
+      );
+      const rects = container.querySelectorAll(
+        "rect[class*=\"histogramBar\"]",
+      );
+      expect(rects.length).toBeGreaterThan(0);
+      (rects[0] as SVGRectElement).dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it(
+      "invokes onChange with the bucket's [min, max] when clicked",
+      () => {
+        const onChange = vi.fn();
+        const { container } = render(
+          <DateRangeInput
+            valueCountPairs={dateBuckets}
+            isLoading={false}
+            minValue={undefined}
+            maxValue={undefined}
+            onChange={onChange}
+            clickToFilter={true}
+          />,
+        );
+        const rects = container.querySelectorAll(
+          "rect[class*=\"histogramBar\"]",
+        );
+        const firstBar = rects[0] as SVGRectElement;
+        firstBar.dispatchEvent(
+          new MouseEvent("click", { bubbles: true }),
+        );
+        expect(onChange).toHaveBeenCalledTimes(1);
+        const [min, max] = onChange.mock.calls[0];
+        expect(min).toBeInstanceOf(Date);
+        expect(max).toBeInstanceOf(Date);
+        // First bar is May 1; daily granularity → bucket [May 1, May 2]
+        expect((min as Date).getDate()).toBe(1);
+        expect((max as Date).getDate()).toBe(2);
+      },
+    );
+
+    it("replaces (not unions) when a second bar is clicked", () => {
+      const onChange = vi.fn();
+      const { container } = render(
+        <DateRangeInput
+          valueCountPairs={dateBuckets}
+          isLoading={false}
+          minValue={undefined}
+          maxValue={undefined}
+          onChange={onChange}
+          clickToFilter={true}
+        />,
+      );
+      const rects = container.querySelectorAll(
+        "rect[class*=\"histogramBar\"]",
+      );
+      const firstBar = rects[0] as SVGRectElement;
+      const secondBar = rects[2] as SVGRectElement;
+      firstBar.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      secondBar.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      expect(onChange).toHaveBeenCalledTimes(2);
+      // Second call must be the third bucket's range, not a union with
+      // the first.
+      const [min2, max2] = onChange.mock.calls[1];
+      expect((min2 as Date).getDate()).toBe(3);
+      expect((max2 as Date).getDate()).toBe(4);
+    });
+
+    it("sets data-click-to-filter=\"true\" on rects when enabled", () => {
+      const { container } = render(
+        <DateRangeInput
+          valueCountPairs={dateBuckets}
+          isLoading={false}
+          minValue={undefined}
+          maxValue={undefined}
+          onChange={vi.fn()}
+          clickToFilter={true}
+        />,
+      );
+      const rects = container.querySelectorAll(
+        "rect[class*=\"histogramBar\"]",
+      );
+      const allEnabled = Array.from(rects).every(
+        (r) => r.getAttribute("data-click-to-filter") === "true",
+      );
+      expect(allEnabled).toBe(true);
+    });
+
+    it("does NOT set data-click-to-filter when disabled", () => {
+      const { container } = render(
+        <DateRangeInput
+          valueCountPairs={dateBuckets}
+          isLoading={false}
+          minValue={undefined}
+          maxValue={undefined}
+          onChange={vi.fn()}
+        />,
+      );
+      const rects = container.querySelectorAll(
+        "rect[class*=\"histogramBar\"]",
+      );
+      const noneEnabled = Array.from(rects).every(
+        (r) => !r.hasAttribute("data-click-to-filter"),
+      );
+      expect(noneEnabled).toBe(true);
+    });
+  });
+
   it(
     "numeric histogram x-axis ticks are min/max only — no per-bucket numeric labels",
     () => {

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/NoValueLabel.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/NoValueLabel.test.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { isEmptyValue } from "../../../utils/filterValues.js";
+import { NoValueLabel } from "../NoValueLabel.js";
+
+afterEach(cleanup);
+
+describe("NoValueLabel", () => {
+  it("renders the literal text 'No value'", () => {
+    render(<NoValueLabel />);
+    expect(screen.getByText("No value")).toBeDefined();
+  });
+
+  it("uses a span element so it composes inside other inline contexts", () => {
+    const { container } = render(<NoValueLabel />);
+    const node = container.firstElementChild;
+    expect(node?.tagName).toBe("SPAN");
+  });
+
+  it("applies the noValue class so theme tokens take effect", () => {
+    const { container } = render(<NoValueLabel />);
+    const node = container.firstElementChild;
+    expect(node?.className.includes("noValue")).toBe(true);
+  });
+
+  it("forwards a custom className alongside the noValue class", () => {
+    const { container } = render(<NoValueLabel className="extra" />);
+    const node = container.firstElementChild;
+    expect(node?.className.includes("noValue")).toBe(true);
+    expect(node?.className.includes("extra")).toBe(true);
+  });
+});
+
+describe("isEmptyValue", () => {
+  it("treats null and undefined as empty", () => {
+    expect(isEmptyValue(null)).toBe(true);
+    expect(isEmptyValue(undefined)).toBe(true);
+  });
+
+  it("treats empty and whitespace-only strings as empty", () => {
+    expect(isEmptyValue("")).toBe(true);
+    expect(isEmptyValue("   ")).toBe(true);
+    expect(isEmptyValue("\t\n")).toBe(true);
+  });
+
+  it("treats non-empty strings as non-empty", () => {
+    expect(isEmptyValue("Active")).toBe(false);
+    expect(isEmptyValue("0")).toBe(false);
+    expect(isEmptyValue(" a ")).toBe(false);
+  });
+
+  it("treats numbers and booleans as non-empty", () => {
+    expect(isEmptyValue(0)).toBe(false);
+    expect(isEmptyValue(false)).toBe(false);
+  });
+});

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/dateFormatting.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/dateFormatting.test.tsx
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DateRangeInput } from "../DateRangeInput.js";
+import { MultiDateInput } from "../MultiDateInput.js";
+import { TimelineInput } from "../TimelineInput.js";
+
+afterEach(cleanup);
+
+const isoFormat = (d: Date): string =>
+  `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${
+    String(d.getDate()).padStart(2, "0")
+  }`;
+
+const slashFormat = (d: Date): string =>
+  `${String(d.getMonth() + 1).padStart(2, "0")}/${
+    String(d.getDate()).padStart(2, "0")
+  }/${d.getFullYear()}`;
+
+const slashParse = (text: string): Date | undefined => {
+  const match = text.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+  if (!match) return undefined;
+  return new Date(
+    Number(match[3]),
+    Number(match[1]) - 1,
+    Number(match[2]),
+  );
+};
+
+describe("formatDate / parseDate plumbing", () => {
+  describe("MultiDateInput", () => {
+    it("renders chip text via formatDate when provided", () => {
+      const dates = [new Date(2024, 0, 15), new Date(2024, 5, 30)];
+      render(
+        <MultiDateInput
+          selectedDates={dates}
+          onChange={vi.fn()}
+          formatDate={slashFormat}
+        />,
+      );
+      expect(screen.getByText("01/15/2024")).toBeDefined();
+      expect(screen.getByText("06/30/2024")).toBeDefined();
+    });
+
+    it(
+      "uses the default locale-aware display when formatDate is omitted",
+      () => {
+        const dates = [new Date(2024, 0, 15)];
+        render(
+          <MultiDateInput
+            selectedDates={dates}
+            onChange={vi.fn()}
+          />,
+        );
+        // Default formatDateForDisplay uses toLocaleDateString with month: "short"
+        // — the rendered string should NOT match the slash format.
+        expect(screen.queryByText("01/15/2024")).toBeNull();
+        // It should mention the year so we know the date rendered
+        const node = document.body.textContent ?? "";
+        expect(node).toContain("2024");
+      },
+    );
+
+    it("forwards the formatted text to the chip's aria-label", () => {
+      const dates = [new Date(2024, 0, 15)];
+      render(
+        <MultiDateInput
+          selectedDates={dates}
+          onChange={vi.fn()}
+          formatDate={slashFormat}
+        />,
+      );
+      const removeButton = screen.getByLabelText("Remove 01/15/2024");
+      expect(removeButton).toBeDefined();
+    });
+  });
+
+  describe("TimelineInput", () => {
+    it(
+      "renders the start and end labels via formatDate when provided",
+      () => {
+        const start = new Date(2024, 4, 1);
+        const end = new Date(2024, 4, 31);
+        render(
+          <TimelineInput
+            startDate={start}
+            endDate={end}
+            onChange={vi.fn()}
+            formatDate={slashFormat}
+          />,
+        );
+        expect(screen.getByText("05/01/2024")).toBeDefined();
+        expect(screen.getByText("05/31/2024")).toBeDefined();
+      },
+    );
+
+    it("falls back to the default formatter when formatDate is omitted", () => {
+      const start = new Date(2024, 4, 1);
+      render(
+        <TimelineInput
+          startDate={start}
+          endDate={undefined}
+          onChange={vi.fn()}
+        />,
+      );
+      // Default uses month: "short" — so "May" appears, not "05/01/2024".
+      expect(screen.queryByText("05/01/2024")).toBeNull();
+      const node = document.body.textContent ?? "";
+      expect(node).toContain("2024");
+    });
+
+    it(
+      "keeps the underlying HTML <input type=\"date\"> value as ISO YYYY-MM-DD",
+      () => {
+        const start = new Date(2024, 4, 1);
+        render(
+          <TimelineInput
+            startDate={start}
+            endDate={undefined}
+            onChange={vi.fn()}
+            formatDate={slashFormat}
+          />,
+        );
+        const input = screen.getByLabelText(
+          "Start date",
+        ) as HTMLInputElement;
+        expect(input.type).toBe("date");
+        expect(input.value).toBe("2024-05-01");
+      },
+    );
+  });
+
+  describe("DateRangeInput", () => {
+    const buckets = [
+      { value: new Date(2024, 0, 1), count: 5 },
+      { value: new Date(2024, 5, 30), count: 7 },
+    ];
+
+    it(
+      "uses formatDate for the histogram bar tooltip when provided",
+      () => {
+        render(
+          <DateRangeInput
+            valueCountPairs={buckets}
+            isLoading={false}
+            minValue={undefined}
+            maxValue={undefined}
+            onChange={vi.fn()}
+            formatDate={slashFormat}
+          />,
+        );
+        // The histogram bar's title attribute is set from
+        // config.formatTooltip(min, max, count) — when formatDate is
+        // provided, the dates inside the title use the slash format.
+        const bars = document.querySelectorAll("[title]");
+        const titles = Array.from(bars).map((b) => b.getAttribute("title"));
+        // At least one tooltip should match the MM/DD/YYYY shape.
+        expect(
+          titles.some((t) => t != null && /\d{2}\/\d{2}\/\d{4}/.test(t)),
+        ).toBe(true);
+      },
+    );
+
+    it(
+      "keeps the HTML <input type=\"date\"> value as ISO regardless of formatDate",
+      () => {
+        const min = new Date(2024, 0, 15);
+        render(
+          <DateRangeInput
+            valueCountPairs={buckets}
+            isLoading={false}
+            minValue={min}
+            maxValue={undefined}
+            onChange={vi.fn()}
+            formatDate={slashFormat}
+          />,
+        );
+        const input = screen.getByLabelText("From") as HTMLInputElement;
+        expect(input.type).toBe("date");
+        expect(input.value).toBe("2024-01-15");
+      },
+    );
+
+    it(
+      "uses the default tooltip format when formatDate is omitted",
+      () => {
+        render(
+          <DateRangeInput
+            valueCountPairs={buckets}
+            isLoading={false}
+            minValue={undefined}
+            maxValue={undefined}
+            onChange={vi.fn()}
+          />,
+        );
+        const bars = document.querySelectorAll("[title]");
+        const titles = Array.from(bars).map((b) => b.getAttribute("title"));
+        // ISO format only when formatDate is omitted.
+        expect(
+          titles.every((t) => t == null || /^\d{4}-\d{2}-\d{2}/.test(t)),
+        ).toBe(true);
+      },
+    );
+  });
+
+  describe("parseDate roundtrip", () => {
+    it("recovers the original date from a formatDate output", () => {
+      const original = new Date(2024, 5, 30);
+      const text = slashFormat(original);
+      const parsed = slashParse(text);
+      expect(parsed).toBeDefined();
+      expect(parsed?.getFullYear()).toBe(2024);
+      expect(parsed?.getMonth()).toBe(5);
+      expect(parsed?.getDate()).toBe(30);
+    });
+
+    it("returns undefined when the input does not match the format", () => {
+      expect(slashParse("not a date")).toBeUndefined();
+      expect(slashParse("")).toBeUndefined();
+      // Wrong separator
+      expect(slashParse("06-30-2024")).toBeUndefined();
+    });
+
+    it("reproduces the formatted string after parse → format", () => {
+      const text = "06/30/2024";
+      const parsed = slashParse(text);
+      expect(parsed).toBeDefined();
+      const reformatted = slashFormat(parsed!);
+      expect(reformatted).toBe(text);
+    });
+  });
+
+  describe("ISO format helper sanity", () => {
+    it("produces ISO format identical to what HTML date inputs accept", () => {
+      const date = new Date(2024, 0, 15);
+      expect(isoFormat(date)).toBe("2024-01-15");
+    });
+  });
+});

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/dateFormatting.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/dateFormatting.test.tsx
@@ -165,14 +165,14 @@ describe("formatDate / parseDate plumbing", () => {
             formatDate={slashFormat}
           />,
         );
-        // The histogram bar's title attribute is set from
-        // config.formatTooltip(min, max, count) — when formatDate is
-        // provided, the dates inside the title use the slash format.
-        const bars = document.querySelectorAll("[title]");
-        const titles = Array.from(bars).map((b) => b.getAttribute("title"));
-        // At least one tooltip should match the MM/DD/YYYY shape.
+        // The histogram bar's tooltip is an SVG `<title>` child of each
+        // `<rect>`. When formatDate is provided, the dates inside the
+        // title text use the slash format.
+        const titleEls = document.querySelectorAll("rect > title");
+        const titles = Array.from(titleEls).map((t) => t.textContent ?? "");
+        expect(titles.length).toBeGreaterThan(0);
         expect(
-          titles.some((t) => t != null && /\d{2}\/\d{2}\/\d{4}/.test(t)),
+          titles.some((t) => /\d{2}\/\d{2}\/\d{4}/.test(t)),
         ).toBe(true);
       },
     );
@@ -209,11 +209,12 @@ describe("formatDate / parseDate plumbing", () => {
             onChange={vi.fn()}
           />,
         );
-        const bars = document.querySelectorAll("[title]");
-        const titles = Array.from(bars).map((b) => b.getAttribute("title"));
-        // ISO format only when formatDate is omitted.
+        const titleEls = document.querySelectorAll("rect > title");
+        const titles = Array.from(titleEls).map((t) => t.textContent ?? "");
+        expect(titles.length).toBeGreaterThan(0);
+        // ISO format when formatDate is omitted.
         expect(
-          titles.every((t) => t == null || /^\d{4}-\d{2}-\d{2}/.test(t)),
+          titles.every((t) => /^\d{4}-\d{2}-\d{2}/.test(t)),
         ).toBe(true);
       },
     );

--- a/packages/react-components/src/filter-list/base/inputs/createDateHistogramBuckets.ts
+++ b/packages/react-components/src/filter-list/base/inputs/createDateHistogramBuckets.ts
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  addDays,
+  addMonths,
+  addYears,
+  differenceInCalendarDays,
+  format,
+  startOfDay,
+  startOfMonth,
+  startOfYear,
+} from "date-fns";
+import type { HistogramBucket } from "./createHistogramBuckets.js";
+
+export type DateHistogramGranularity = "day" | "month" | "year";
+
+export interface DateHistogramData {
+  buckets: Array<HistogramBucket<Date>>;
+  /** Period label rendered as the bottom-center subtitle (e.g. "May 2020"). */
+  subtitle: string;
+  granularity: DateHistogramGranularity;
+}
+
+interface ValueCountPair {
+  value: Date;
+  count: number;
+}
+
+/**
+ * Picks calendar-aligned histogram buckets for a date series.
+ *
+ * Granularity is chosen from the data span:
+ *   span ≤ 31 days   → daily buckets, ticks "1" / "2" / ... / "31"
+ *   span ≤ 365 days  → monthly buckets, ticks "Jan" / "Feb" / ...
+ *   span >  365 days → yearly buckets, ticks "2020" / "2021" / ...
+ *
+ * The subtitle reflects the surrounding calendar context — e.g. "May 2020"
+ * for a daily histogram inside one month, "2020" for a monthly histogram
+ * inside one year. When the data straddles multiple periods (e.g. monthly
+ * histogram across multiple years) the subtitle is empty so the per-bucket
+ * tick labels stay self-describing.
+ *
+ * @param formatDate Optional callback used for the subtitle text in place of
+ * the default date-fns format. Per-bucket `tickLabel` strings stay short
+ * (number-only or 3-letter month) regardless of `formatDate`.
+ */
+export function createDateHistogramBuckets(
+  pairs: ReadonlyArray<ValueCountPair>,
+  range: { min: Date; max: Date },
+  formatDate?: (date: Date) => string,
+): DateHistogramData {
+  if (pairs.length === 0) {
+    return { buckets: [], subtitle: "", granularity: "day" };
+  }
+
+  const span = Math.max(
+    0,
+    differenceInCalendarDays(range.max, range.min),
+  );
+
+  const granularity: DateHistogramGranularity = span <= 31
+    ? "day"
+    : span <= 365
+    ? "month"
+    : "year";
+
+  const buckets: Array<HistogramBucket<Date>> = [];
+
+  if (granularity === "day") {
+    const start = startOfDay(range.min);
+    const dayCount = span + 1;
+    const counts = new Array<number>(dayCount).fill(0);
+    for (const { value, count } of pairs) {
+      const idx = differenceInCalendarDays(value, start);
+      if (idx >= 0 && idx < dayCount) {
+        counts[idx] += count;
+      }
+    }
+    for (let i = 0; i < dayCount; i++) {
+      const min = addDays(start, i);
+      const max = addDays(start, i + 1);
+      buckets.push({
+        min,
+        max,
+        count: counts[i],
+        tickLabel: format(min, "d"),
+      });
+    }
+  } else if (granularity === "month") {
+    const start = startOfMonth(range.min);
+    const end = startOfMonth(range.max);
+    const months: Date[] = [];
+    let cursor = start;
+    while (cursor.getTime() <= end.getTime()) {
+      months.push(cursor);
+      cursor = addMonths(cursor, 1);
+    }
+    const counts = new Array<number>(months.length).fill(0);
+    for (const { value, count } of pairs) {
+      const monthStart = startOfMonth(value).getTime();
+      const idx = months.findIndex((m) => m.getTime() === monthStart);
+      if (idx >= 0) counts[idx] += count;
+    }
+    for (let i = 0; i < months.length; i++) {
+      buckets.push({
+        min: months[i],
+        max: addMonths(months[i], 1),
+        count: counts[i],
+        tickLabel: format(months[i], "MMM"),
+      });
+    }
+  } else {
+    const start = startOfYear(range.min);
+    const end = startOfYear(range.max);
+    const years: Date[] = [];
+    let cursor = start;
+    while (cursor.getTime() <= end.getTime()) {
+      years.push(cursor);
+      cursor = addYears(cursor, 1);
+    }
+    const counts = new Array<number>(years.length).fill(0);
+    for (const { value, count } of pairs) {
+      const yearStart = startOfYear(value).getTime();
+      const idx = years.findIndex((y) => y.getTime() === yearStart);
+      if (idx >= 0) counts[idx] += count;
+    }
+    for (let i = 0; i < years.length; i++) {
+      buckets.push({
+        min: years[i],
+        max: addYears(years[i], 1),
+        count: counts[i],
+        tickLabel: format(years[i], "yyyy"),
+      });
+    }
+  }
+
+  const subtitle = computeSubtitle(
+    range.min,
+    range.max,
+    granularity,
+    formatDate,
+  );
+  return { buckets, subtitle, granularity };
+}
+
+function computeSubtitle(
+  rangeMin: Date,
+  rangeMax: Date,
+  granularity: DateHistogramGranularity,
+  formatDate?: (date: Date) => string,
+): string {
+  if (granularity === "day") {
+    // Daily within one month: "May 2020". Across months: just the year(s).
+    const sameMonth = rangeMin.getFullYear() === rangeMax.getFullYear()
+      && rangeMin.getMonth() === rangeMax.getMonth();
+    if (sameMonth) {
+      return formatDate ? formatDate(rangeMin) : format(rangeMin, "MMMM yyyy");
+    }
+    const sameYear = rangeMin.getFullYear() === rangeMax.getFullYear();
+    if (sameYear) {
+      return formatDate ? formatDate(rangeMin) : format(rangeMin, "yyyy");
+    }
+    return "";
+  }
+  if (granularity === "month") {
+    const sameYear = rangeMin.getFullYear() === rangeMax.getFullYear();
+    if (sameYear) {
+      return formatDate ? formatDate(rangeMin) : format(rangeMin, "yyyy");
+    }
+    return "";
+  }
+  return "";
+}

--- a/packages/react-components/src/filter-list/base/inputs/createHistogramBuckets.ts
+++ b/packages/react-components/src/filter-list/base/inputs/createHistogramBuckets.ts
@@ -20,6 +20,47 @@ export interface HistogramBucket<T> {
   min: T;
   max: T;
   count: number;
+  /**
+   * Optional short label shown beneath the bucket on the SVG x-axis.
+   * Date histograms populate this with day/month/year text; numeric
+   * histograms leave it unset (the SVG renders min/max only).
+   */
+  tickLabel?: string;
+}
+
+/**
+ * Returns "nice" tick positions covering the [0, max] range — values that
+ * round to 1/2/5 × 10^n so the tick labels read cleanly. Used for
+ * y-axis axis lines on the histogram.
+ *
+ * Edge cases:
+ *  - max ≤ 0          → returns [0]
+ *  - max ≤ 1/2/3      → returns [0, ..., max] without rounding to 5/10
+ *  - otherwise        → between 3 and 6 ticks aligned on a nice step
+ */
+export function niceTicks(max: number, desiredCount = 5): number[] {
+  if (!Number.isFinite(max) || max <= 0) return [0];
+  if (max <= 3) {
+    const out: number[] = [];
+    for (let i = 0; i <= Math.ceil(max); i++) out.push(i);
+    return out;
+  }
+  const rough = max / desiredCount;
+  const exponent = Math.floor(Math.log10(rough));
+  const fraction = rough / Math.pow(10, exponent);
+  const niceFraction = fraction <= 1
+    ? 1
+    : fraction <= 2
+    ? 2
+    : fraction <= 5
+    ? 5
+    : 10;
+  const step = niceFraction * Math.pow(10, exponent);
+  const ticks: number[] = [];
+  for (let v = 0; v <= max + step / 2; v += step) {
+    ticks.push(Math.round(v / step) * step);
+  }
+  return ticks;
 }
 
 interface ValueCountPair<T> {

--- a/packages/react-components/src/filter-list/inputs/DateRangeFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/DateRangeFilterInput.tsx
@@ -33,6 +33,8 @@ interface DateRangeFilterInputProps<Q extends ObjectTypeDefinition> {
   filterState: FilterState | undefined;
   onFilterStateChanged: (state: FilterState) => void;
   whereClause: WhereClause<Q>;
+  formatDate?: (date: Date) => string;
+  parseDate?: (text: string) => Date | undefined;
 }
 
 function DateRangeFilterInputInner<Q extends ObjectTypeDefinition>({
@@ -42,6 +44,8 @@ function DateRangeFilterInputInner<Q extends ObjectTypeDefinition>({
   filterState,
   onFilterStateChanged,
   whereClause,
+  formatDate,
+  parseDate,
 }: DateRangeFilterInputProps<Q>): React.ReactElement {
   const dateRangeState = filterState?.type === "DATE_RANGE"
     ? filterState
@@ -167,6 +171,8 @@ function DateRangeFilterInputInner<Q extends ObjectTypeDefinition>({
         minValue={dateRangeState?.minValue}
         maxValue={dateRangeState?.maxValue}
         onChange={handleRangeChange}
+        formatDate={formatDate}
+        parseDate={parseDate}
       />
     </NullValueWrapper>
   );

--- a/packages/react-components/src/filter-list/inputs/DateRangeFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/DateRangeFilterInput.tsx
@@ -35,6 +35,7 @@ interface DateRangeFilterInputProps<Q extends ObjectTypeDefinition> {
   whereClause: WhereClause<Q>;
   formatDate?: (date: Date) => string;
   parseDate?: (text: string) => Date | undefined;
+  clickToFilter?: boolean;
 }
 
 function DateRangeFilterInputInner<Q extends ObjectTypeDefinition>({
@@ -46,6 +47,7 @@ function DateRangeFilterInputInner<Q extends ObjectTypeDefinition>({
   whereClause,
   formatDate,
   parseDate,
+  clickToFilter,
 }: DateRangeFilterInputProps<Q>): React.ReactElement {
   const dateRangeState = filterState?.type === "DATE_RANGE"
     ? filterState
@@ -173,6 +175,7 @@ function DateRangeFilterInputInner<Q extends ObjectTypeDefinition>({
         onChange={handleRangeChange}
         formatDate={formatDate}
         parseDate={parseDate}
+        clickToFilter={clickToFilter}
       />
     </NullValueWrapper>
   );

--- a/packages/react-components/src/filter-list/inputs/MultiDateFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/MultiDateFilterInput.tsx
@@ -21,11 +21,15 @@ import type { FilterState } from "../FilterListItemApi.js";
 interface MultiDateFilterInputProps {
   filterState: FilterState | undefined;
   onFilterStateChanged: (state: FilterState) => void;
+  formatDate?: (date: Date) => string;
+  parseDate?: (text: string) => Date | undefined;
 }
 
 function MultiDateFilterInputInner({
   filterState,
   onFilterStateChanged,
+  formatDate,
+  parseDate,
 }: MultiDateFilterInputProps): React.ReactElement {
   const selectedDates = useMemo(
     () =>
@@ -48,7 +52,12 @@ function MultiDateFilterInputInner({
   );
 
   return (
-    <MultiDateInput selectedDates={selectedDates} onChange={handleChange} />
+    <MultiDateInput
+      selectedDates={selectedDates}
+      onChange={handleChange}
+      formatDate={formatDate}
+      parseDate={parseDate}
+    />
   );
 }
 

--- a/packages/react-components/src/filter-list/inputs/NumberRangeFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/NumberRangeFilterInput.tsx
@@ -33,6 +33,7 @@ interface NumberRangeFilterInputProps<Q extends ObjectTypeDefinition> {
   filterState: FilterState | undefined;
   onFilterStateChanged: (state: FilterState) => void;
   whereClause: WhereClause<Q>;
+  clickToFilter?: boolean;
 }
 
 function NumberRangeFilterInputInner<Q extends ObjectTypeDefinition>({
@@ -42,6 +43,7 @@ function NumberRangeFilterInputInner<Q extends ObjectTypeDefinition>({
   filterState,
   onFilterStateChanged,
   whereClause,
+  clickToFilter,
 }: NumberRangeFilterInputProps<Q>): React.ReactElement {
   const numberRangeState = filterState?.type === "NUMBER_RANGE"
     ? filterState
@@ -171,6 +173,7 @@ function NumberRangeFilterInputInner<Q extends ObjectTypeDefinition>({
         minValue={numberRangeState?.minValue}
         maxValue={numberRangeState?.maxValue}
         onChange={handleRangeChange}
+        clickToFilter={clickToFilter}
       />
     </NullValueWrapper>
   );

--- a/packages/react-components/src/filter-list/inputs/PropertyFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/PropertyFilterInput.tsx
@@ -99,6 +99,8 @@ function PropertyFilterInputInner<Q extends ObjectTypeDefinition>({
           filterState={filterState}
           onFilterStateChanged={onFilterStateChanged}
           whereClause={whereClause}
+          formatDate={definition.formatDate}
+          parseDate={definition.parseDate}
         />
       );
 
@@ -137,6 +139,8 @@ function PropertyFilterInputInner<Q extends ObjectTypeDefinition>({
         <SingleDateFilterInput
           filterState={filterState}
           onFilterStateChanged={onFilterStateChanged}
+          formatDate={definition.formatDate}
+          parseDate={definition.parseDate}
         />
       );
 
@@ -145,6 +149,8 @@ function PropertyFilterInputInner<Q extends ObjectTypeDefinition>({
         <MultiDateFilterInput
           filterState={filterState}
           onFilterStateChanged={onFilterStateChanged}
+          formatDate={definition.formatDate}
+          parseDate={definition.parseDate}
         />
       );
 
@@ -190,6 +196,8 @@ function PropertyFilterInputInner<Q extends ObjectTypeDefinition>({
           <TimelineFilterInput
             filterState={filterState}
             onFilterStateChanged={onFilterStateChanged}
+            formatDate={definition.formatDate}
+            parseDate={definition.parseDate}
           />
         </FilterInputExcludeRow>
       );

--- a/packages/react-components/src/filter-list/inputs/PropertyFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/PropertyFilterInput.tsx
@@ -87,6 +87,7 @@ function PropertyFilterInputInner<Q extends ObjectTypeDefinition>({
           filterState={filterState}
           onFilterStateChanged={onFilterStateChanged}
           whereClause={whereClause}
+          clickToFilter={definition.clickToFilter}
         />
       );
 
@@ -101,6 +102,7 @@ function PropertyFilterInputInner<Q extends ObjectTypeDefinition>({
           whereClause={whereClause}
           formatDate={definition.formatDate}
           parseDate={definition.parseDate}
+          clickToFilter={definition.clickToFilter}
         />
       );
 

--- a/packages/react-components/src/filter-list/inputs/SingleDateFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/SingleDateFilterInput.tsx
@@ -21,6 +21,13 @@ import type { FilterState } from "../FilterListItemApi.js";
 interface SingleDateFilterInputProps {
   filterState: FilterState | undefined;
   onFilterStateChanged: (state: FilterState) => void;
+  /**
+   * Plumbed for API parity with the other date filter inputs. SingleDateInput
+   * renders only the HTML `<input type="date">` whose value attribute must be
+   * ISO `YYYY-MM-DD`, so `formatDate` has no display surface in v1.
+   */
+  formatDate?: (date: Date) => string;
+  parseDate?: (text: string) => Date | undefined;
 }
 
 function SingleDateFilterInputInner({

--- a/packages/react-components/src/filter-list/inputs/TimelineFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/TimelineFilterInput.tsx
@@ -21,11 +21,15 @@ import type { FilterState } from "../FilterListItemApi.js";
 interface TimelineFilterInputProps {
   filterState: FilterState | undefined;
   onFilterStateChanged: (state: FilterState) => void;
+  formatDate?: (date: Date) => string;
+  parseDate?: (text: string) => Date | undefined;
 }
 
 function TimelineFilterInputInner({
   filterState,
   onFilterStateChanged,
+  formatDate,
+  parseDate,
 }: TimelineFilterInputProps): React.ReactElement {
   const { startDate, endDate } = useMemo(
     () =>
@@ -53,6 +57,8 @@ function TimelineFilterInputInner({
       startDate={startDate}
       endDate={endDate}
       onChange={handleChange}
+      formatDate={formatDate}
+      parseDate={parseDate}
     />
   );
 }

--- a/packages/react-components/src/filter-list/utils/filterValues.ts
+++ b/packages/react-components/src/filter-list/utils/filterValues.ts
@@ -68,6 +68,18 @@ export function supportsExcluding(state: FilterState | undefined): boolean {
   }
 }
 
+/**
+ * Returns true if the given value should render as a "No value" placeholder
+ * in dropdown options, listogram buckets, tag chips, and trigger summaries.
+ *
+ * Treats null, undefined, and empty/whitespace strings as empty.
+ */
+export function isEmptyValue(value: unknown): boolean {
+  if (value == null) return true;
+  if (typeof value === "string") return value.trim() === "";
+  return false;
+}
+
 /** Case-insensitive substring filter for search functionality. */
 export function filterValuesBySearch<T>(
   values: T[],

--- a/packages/react-components/src/filter-list/utils/getFilterLabel.ts
+++ b/packages/react-components/src/filter-list/utils/getFilterLabel.ts
@@ -15,8 +15,12 @@
  */
 
 import type { ObjectTypeDefinition } from "@osdk/api";
+import React from "react";
 import { assertUnreachable } from "../../shared/assertUnreachable.js";
+import { NoValueLabel } from "../base/inputs/NoValueLabel.js";
 import type { FilterDefinitionUnion } from "../FilterListApi.js";
+import type { FilterState } from "../FilterListItemApi.js";
+import { isEmptyValue } from "./filterValues.js";
 
 export function getFilterLabel<Q extends ObjectTypeDefinition>(
   definition: FilterDefinitionUnion<Q>,
@@ -39,5 +43,99 @@ export function getFilterLabel<Q extends ObjectTypeDefinition>(
       return definition.key;
     default:
       return assertUnreachable(definition);
+  }
+}
+
+/**
+ * Returns a short summary of the filter's current value, suitable for the
+ * label inside a horizontal filter trigger. Examples:
+ *   empty  → ""
+ *   single → "Active"
+ *   multi  → "3 selected"
+ *   range  → "May 1 – May 31"
+ *
+ * The caller wraps this with the filter label (e.g. `Status: Active`).
+ */
+export function summarizeFilterValue<Q extends ObjectTypeDefinition>(
+  definition: FilterDefinitionUnion<Q>,
+  state: FilterState | undefined,
+): React.ReactNode {
+  if (state == null) return "";
+  switch (state.type) {
+    case "EXACT_MATCH": {
+      const values = state.values;
+      if (values.length === 0) return "";
+      if (values.length === 1) {
+        const v = values[0];
+        return isEmptyValue(v)
+          ? React.createElement(NoValueLabel)
+          : String(v);
+      }
+      return `${values.length} selected`;
+    }
+    case "SELECT": {
+      const values = state.selectedValues;
+      if (values.length === 0) return "";
+      if (values.length === 1) {
+        const v = values[0];
+        if (v instanceof Date) {
+          const formatDate = "formatDate" in definition && definition.formatDate
+            ? (definition.formatDate as (d: Date) => string)
+            : undefined;
+          return formatDate ? formatDate(v) : v.toLocaleDateString();
+        }
+        return isEmptyValue(v)
+          ? React.createElement(NoValueLabel)
+          : String(v);
+      }
+      return `${values.length} selected`;
+    }
+    case "CONTAINS_TEXT":
+      return state.value && state.value.length > 0 ? state.value : "";
+    case "NUMBER_RANGE": {
+      const { minValue, maxValue } = state;
+      if (minValue == null && maxValue == null) return "";
+      const fmt = (n: number) => String(n);
+      return `${minValue != null ? fmt(minValue) : "−∞"} – ${
+        maxValue != null ? fmt(maxValue) : "∞"
+      }`;
+    }
+    case "DATE_RANGE": {
+      const { minValue, maxValue } = state;
+      if (minValue == null && maxValue == null) return "";
+      const formatDate = "formatDate" in definition && definition.formatDate
+        ? (definition.formatDate as (d: Date) => string)
+        : (d: Date) => d.toLocaleDateString();
+      return `${minValue != null ? formatDate(minValue) : "—"} – ${
+        maxValue != null ? formatDate(maxValue) : "—"
+      }`;
+    }
+    case "TIMELINE": {
+      const { startDate, endDate } = state;
+      if (startDate == null && endDate == null) return "";
+      const formatDate = "formatDate" in definition && definition.formatDate
+        ? (definition.formatDate as (d: Date) => string)
+        : (d: Date) => d.toLocaleDateString();
+      return `${startDate != null ? formatDate(startDate) : "—"} – ${
+        endDate != null ? formatDate(endDate) : "—"
+      }`;
+    }
+    case "TOGGLE":
+      return state.enabled ? "On" : "";
+    case "hasLink":
+      return state.hasLink ? "Has link" : "";
+    case "linkedProperty":
+      return summarizeFilterValue(definition, state.linkedFilterState);
+    case "keywordSearch":
+      return state.searchTerm && state.searchTerm.length > 0
+        ? state.searchTerm
+        : "";
+    case "custom":
+      return "Active";
+    default: {
+      const _exhaustive: never = state;
+      void _exhaustive;
+      return "";
+    }
   }
 }

--- a/packages/react-components/src/tokens.css
+++ b/packages/react-components/src/tokens.css
@@ -6,6 +6,7 @@
 @import "./tokens/component-tokens/button.css";
 @import "./tokens/component-tokens/cbac-picker.css";
 @import "./tokens/component-tokens/checkbox.css";
+@import "./tokens/component-tokens/combobox.css";
 @import "./tokens/component-tokens/datetime-picker.css";
 @import "./tokens/component-tokens/dialog.css";
 @import "./tokens/component-tokens/draggable.css";

--- a/packages/react-components/src/tokens/component-tokens/combobox.css
+++ b/packages/react-components/src/tokens/component-tokens/combobox.css
@@ -1,0 +1,8 @@
+:root {
+  /* Combobox popup: cap the dropdown's max-height so very long option lists
+     scroll inside the popup instead of forcing the popup to grow tall enough
+     to push other UI off-screen. The actual `max-height` rule uses
+     `min(this token, --available-height)` so the cap is automatically lowered
+     on short viewports. */
+  --osdk-combobox-popup-max-height: 320px;
+}

--- a/packages/react-components/src/tokens/component-tokens/filter-list.css
+++ b/packages/react-components/src/tokens/component-tokens/filter-list.css
@@ -257,6 +257,15 @@
       --osdk-emphasis-transition-duration
     )
     var(--osdk-emphasis-ease-default);
+  --osdk-filter-range-histogram-axis-line-color: var(--osdk-palette-gray-100);
+  --osdk-filter-range-histogram-axis-color: var(--osdk-typography-color-muted);
+  --osdk-filter-range-histogram-axis-font-size: 9px;
+  --osdk-filter-range-histogram-label-color: var(--osdk-typography-color-muted);
+  --osdk-filter-range-histogram-label-font-size: 9px;
+  --osdk-filter-range-histogram-subtitle-color: var(
+    --osdk-typography-color-default-rest
+  );
+  --osdk-filter-range-histogram-subtitle-font-size: 10px;
   --osdk-filter-range-inputs-gap: calc(var(--osdk-surface-spacing) * 0.5);
   --osdk-filter-range-input-wrapper-gap: var(--osdk-surface-spacing);
   --osdk-filter-range-label-font-family: var(--osdk-typography-family-default);

--- a/packages/react-components/src/tokens/component-tokens/filter-list.css
+++ b/packages/react-components/src/tokens/component-tokens/filter-list.css
@@ -448,13 +448,8 @@
   --osdk-filter-skeleton-count-width: calc(var(--osdk-surface-spacing) * 2.5);
 
   /* Horizontal Mode */
-  --osdk-filter-horizontal-gap: calc(var(--osdk-surface-spacing) * 1);
-  --osdk-filter-horizontal-trigger-min-height: calc(
-    var(--osdk-surface-spacing) * 7
-  );
-  --osdk-filter-horizontal-trigger-max-width: calc(
-    var(--osdk-surface-spacing) * 60
-  );
+  --osdk-filter-horizontal-gap: calc(var(--osdk-surface-spacing) * 4);
+  --osdk-filter-horizontal-trigger-min-height: 28px;
+  --osdk-filter-horizontal-trigger-width: 160px;
   --osdk-filter-horizontal-trigger-bg: transparent;
-  --osdk-filter-horizontal-trigger-active-bg: var(--osdk-surface-layer-primary);
 }

--- a/packages/react-components/src/tokens/component-tokens/filter-list.css
+++ b/packages/react-components/src/tokens/component-tokens/filter-list.css
@@ -446,4 +446,15 @@
   /* Skeleton Loading */
   --osdk-filter-skeleton-text-height: calc(var(--osdk-surface-spacing) * 1.5);
   --osdk-filter-skeleton-count-width: calc(var(--osdk-surface-spacing) * 2.5);
+
+  /* Horizontal Mode */
+  --osdk-filter-horizontal-gap: calc(var(--osdk-surface-spacing) * 1);
+  --osdk-filter-horizontal-trigger-min-height: calc(
+    var(--osdk-surface-spacing) * 7
+  );
+  --osdk-filter-horizontal-trigger-max-width: calc(
+    var(--osdk-surface-spacing) * 60
+  );
+  --osdk-filter-horizontal-trigger-bg: transparent;
+  --osdk-filter-horizontal-trigger-active-bg: var(--osdk-surface-layer-primary);
 }

--- a/packages/react-components/src/tokens/component-tokens/filter-list.css
+++ b/packages/react-components/src/tokens/component-tokens/filter-list.css
@@ -259,13 +259,13 @@
     var(--osdk-emphasis-ease-default);
   --osdk-filter-range-histogram-axis-line-color: var(--osdk-palette-gray-100);
   --osdk-filter-range-histogram-axis-color: var(--osdk-typography-color-muted);
-  --osdk-filter-range-histogram-axis-font-size: 9px;
+  --osdk-filter-range-histogram-axis-font-size: 11px;
   --osdk-filter-range-histogram-label-color: var(--osdk-typography-color-muted);
-  --osdk-filter-range-histogram-label-font-size: 9px;
+  --osdk-filter-range-histogram-label-font-size: 11px;
   --osdk-filter-range-histogram-subtitle-color: var(
     --osdk-typography-color-default-rest
   );
-  --osdk-filter-range-histogram-subtitle-font-size: 10px;
+  --osdk-filter-range-histogram-subtitle-font-size: 12px;
   --osdk-filter-range-inputs-gap: calc(var(--osdk-surface-spacing) * 0.5);
   --osdk-filter-range-input-wrapper-gap: var(--osdk-surface-spacing);
   --osdk-filter-range-label-font-family: var(--osdk-typography-family-default);

--- a/packages/react-components/src/tokens/component-tokens/filter-list.css
+++ b/packages/react-components/src/tokens/component-tokens/filter-list.css
@@ -207,8 +207,18 @@
   --osdk-filter-listogram-label-color: var(
     --osdk-typography-color-default-rest
   );
-  --osdk-filter-listogram-empty-label-color: var(--osdk-typography-color-muted);
-  --osdk-filter-listogram-empty-label-font-style: italic;
+
+  /* Canonical "No value" tokens (Item 2). Used by NoValueLabel everywhere. */
+  --osdk-filter-no-value-color: var(--osdk-typography-color-muted);
+  --osdk-filter-no-value-font-style: italic;
+
+  /* Legacy aliases — kept so existing theme overrides continue to work.
+     Each one defaults to the canonical no-value token; consumers may
+     override the legacy token to scope a different style to listogram. */
+  --osdk-filter-listogram-empty-label-color: var(--osdk-filter-no-value-color);
+  --osdk-filter-listogram-empty-label-font-style: var(
+    --osdk-filter-no-value-font-style
+  );
   --osdk-filter-listogram-bar-height: calc(var(--osdk-surface-spacing) * 2);
   --osdk-filter-listogram-bar-width: calc(var(--osdk-surface-spacing) * 12.5);
   --osdk-filter-listogram-bar-bg: var(--osdk-palette-gray-100);
@@ -286,10 +296,11 @@
   --osdk-filter-null-row-padding: calc(var(--osdk-surface-spacing) * 1) 0;
   --osdk-filter-null-row-border-top: none;
   --osdk-filter-null-label-gap: var(--osdk-surface-spacing);
-  --osdk-filter-null-label-font-family: var(--osdk-typography-family-default);
-  --osdk-filter-null-label-font-size: var(--osdk-typography-size-body-medium);
-  --osdk-filter-null-label-line-height: 1.4;
-  --osdk-filter-null-label-color: var(--osdk-typography-color-default-rest);
+  /* Legacy null-label-color is now an alias for the canonical no-value token
+     so NullValueWrapper matches dropdown/listogram by default. Consumers
+     can still override --osdk-filter-null-label-color to scope a different
+     color to NullValueWrapper. */
+  --osdk-filter-null-label-color: var(--osdk-filter-no-value-color);
   --osdk-filter-null-count-font-family: var(--osdk-typography-family-default);
   --osdk-filter-null-count-font-size: var(--osdk-typography-size-body-small);
   --osdk-filter-null-count-color: var(--osdk-typography-color-muted);


### PR DESCRIPTION
## Summary
• new \`orientation="horizontal"\` prop on FilterList arranges filters as a row of label-left inputs instead of a column
• compact filters (CONTAINS_TEXT, SINGLE_DATE, TOGGLE) render inline; tall filters collapse into a button trigger that opens the existing input UI in a base ui popover
• each trigger reads as a thin-bordered "Search…" input pill — × remove button is hidden until hover and anchored inside the trigger
• new HorizontalFilterTrigger component, summarizeFilterValue helper for trigger summaries (Status: Active / Sites: 3 selected / Date: May 1 – May 31), dnd-kit horizontalListSortingStrategy for drag-reorder

## Depends on
- #3176 (NoValueLabel — used by summarizeFilterValue for null values)
- #3177 (whereClauseForFilter — horizontal item uses the prop chain)
- #3179 (formatDate — used by summarizeFilterValue for date-range trigger summaries)

After #3176 + #3177 + #3179 land, this PR auto-rebases to ~1000 LOC of horizontal-specific code only.

## Test plan
- [ ] \`pnpm turbo typecheck --filter=@osdk/react-components\`
- [ ] \`pnpm vitest run src/filter-list/\` — all tests pass
- [ ] storybook → Experimental / FilterList / Horizontal orientation — row of label-left triggers, no "Filters" pill, × shows on hover, click trigger opens popover with existing input