### PR TITLE
[Components] Use custom renderCell when table is not in edit mode

### DIFF
--- a/.changeset/editable-cell-respects-render-cell.md
+++ b/.changeset/editable-cell-respects-render-cell.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+ObjectTable: when a column has both `renderCell` and `editable: true`, use `renderCell` while not in edit mode and the editable cell only after entering edit mode (relevant for `editMode: "manual"`). Previously `renderCell` always took precedence and editable cells never appeared.

--- a/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.stories.tsx
@@ -1353,6 +1353,15 @@ export const EditableTable: Story = {
       {
         locator: { type: "property", id: "firstInternStartDate" },
         editable: true,
+        renderCell: (object: Osdk.Instance<Employee>) => {
+          return (
+            <div>
+              {object.firstInternStartDate
+                ? new Date(object.firstInternStartDate).toISOString()
+                : "No value"}
+            </div>
+          );
+        },
       },
       {
         locator: { type: "property", id: "firstFullTimeStartDate" },
@@ -1366,7 +1375,7 @@ export const EditableTable: Story = {
         },
       },
     ],
-    editMode: "always" as const,
+    editMode: "manual" as const,
     onCellValueChanged: fn(),
   } as EmployeeTableProps,
   parameters: {

--- a/packages/react-components/src/object-table/DefaultCellRenderer.tsx
+++ b/packages/react-components/src/object-table/DefaultCellRenderer.tsx
@@ -20,6 +20,7 @@ import { AsyncValueCell } from "./components/AsyncValueCell.js";
 import { EditableCell } from "./EditableCell.js";
 import { isAsyncCellData } from "./utils/AsyncCellData.js";
 import { getCellId } from "./utils/getCellId.js";
+import { shouldShowEditableCell } from "./utils/shouldShowEditableCell.js";
 
 export function renderDefaultCell<TData extends RowData>(
   cellContext: CellContext<TData, unknown>,
@@ -39,7 +40,14 @@ export function renderDefaultCell<TData extends RowData>(
     return <AsyncValueCell {...asyncCellData} />;
   }
 
-  if (!columnMeta?.editable || !meta?.onCellEdit || !meta?.isInEditMode) {
+  if (
+    !meta?.onCellEdit // Type guard
+    || !shouldShowEditableCell(
+      columnMeta?.editable,
+      meta?.onCellEdit,
+      meta?.isInEditMode,
+    )
+  ) {
     return <>{cellValue}</>;
   }
 

--- a/packages/react-components/src/object-table/ObjectTableApi.ts
+++ b/packages/react-components/src/object-table/ObjectTableApi.ts
@@ -69,6 +69,19 @@ interface SharedColumnDefinition<
   orderable?: boolean;
   filterable?: boolean;
 
+  /**
+   * Custom renderer for the cell value.
+   *
+   * Interaction with `editable` columns:
+   * - When `editMode: "manual"` (default), `renderCell` is used while the
+   *   table is read-only (Edit Table button visible) and the editable cell
+   *   takes over once the user enters edit mode.
+   * - When `editMode: "always"`, the editable cell always wins on editable
+   *   columns and `renderCell` is ignored — `editMode: "always"` opts the
+   *   column into a permanently-editable surface, leaving no read-only
+   *   state for `renderCell` to render. Use `editMode: "manual"` if you
+   *   need a custom display alongside editing.
+   */
   renderCell?: (
     object: Osdk.Instance<Q, "$allBaseProperties", PropertyKeys<Q>, RDPs>,
     locator: ColumnDefinitionLocator<Q, RDPs, FunctionColumns>,

--- a/packages/react-components/src/object-table/hooks/__tests__/useColumnDefs.test.tsx
+++ b/packages/react-components/src/object-table/hooks/__tests__/useColumnDefs.test.tsx
@@ -376,6 +376,8 @@ describe(useColumnDefs, () => {
       const mockCellContext = {
         row: { original: mockObject },
         getValue: () => "John",
+        table: { options: { meta: {} } },
+        column: { columnDef: { meta: {} } },
       };
 
       if (typeof nameColumn.cell === "function") {
@@ -389,6 +391,125 @@ describe(useColumnDefs, () => {
         { type: "property", id: "name" },
       );
     });
+
+    it(
+      "uses custom renderCell when column is editable but table is not in edit mode",
+      async () => {
+        const deferred = pDefer();
+        const fakeClient = {
+          fetchMetadata: vitest.fn(() => deferred.promise),
+        } as unknown as Client;
+
+        const wrapper = createWrapper(fakeClient);
+
+        const customRenderCell = vitest.fn((
+          object: Osdk.Instance<TestObject>,
+        ) => <div>Custom: {(object as unknown as { name: string }).name}</div>);
+
+        const columnDefinitions: Array<ColumnDefinition<TestObject, {}, {}>> = [
+          {
+            locator: { type: "property", id: "name" as TestObjectKeys },
+            editable: true,
+            renderCell: customRenderCell,
+          },
+        ];
+
+        const { result } = renderHook(
+          () => useColumnDefs(TestObjectType, columnDefinitions),
+          { wrapper },
+        );
+
+        deferred.resolve(mockMetadata);
+
+        await waitFor(() => {
+          expect(result.current.loading).toBe(false);
+        });
+
+        const nameColumn = result.current.columns[0];
+        const mockObject = { name: "John" } as unknown as Osdk.Instance<
+          TestObject
+        >;
+        const mockCellContext = {
+          row: { original: mockObject },
+          getValue: () => "John",
+          table: {
+            options: {
+              meta: { onCellEdit: vitest.fn(), isInEditMode: false },
+            },
+          },
+          column: { columnDef: { meta: { editable: true } } },
+        };
+
+        if (typeof nameColumn.cell === "function") {
+          (nameColumn.cell as unknown as (
+            ctx: typeof mockCellContext,
+          ) => unknown)(mockCellContext);
+        }
+
+        expect(customRenderCell).toHaveBeenCalledWith(
+          mockObject,
+          { type: "property", id: "name" },
+        );
+      },
+    );
+
+    it(
+      "skips renderCell and renders editable cell when in edit mode",
+      async () => {
+        const deferred = pDefer();
+        const fakeClient = {
+          fetchMetadata: vitest.fn(() => deferred.promise),
+        } as unknown as Client;
+
+        const wrapper = createWrapper(fakeClient);
+
+        const customRenderCell = vitest.fn((
+          object: Osdk.Instance<TestObject>,
+        ) => <div>Custom: {(object as unknown as { name: string }).name}</div>);
+
+        const columnDefinitions: Array<ColumnDefinition<TestObject, {}, {}>> = [
+          {
+            locator: { type: "property", id: "name" as TestObjectKeys },
+            editable: true,
+            renderCell: customRenderCell,
+          },
+        ];
+
+        const { result } = renderHook(
+          () => useColumnDefs(TestObjectType, columnDefinitions),
+          { wrapper },
+        );
+
+        deferred.resolve(mockMetadata);
+
+        await waitFor(() => {
+          expect(result.current.loading).toBe(false);
+        });
+
+        const nameColumn = result.current.columns[0];
+        const mockObject = { name: "John" } as unknown as Osdk.Instance<
+          TestObject
+        >;
+        const mockCellContext = {
+          row: { original: mockObject, id: "row-0" },
+          column: { id: "name", columnDef: { meta: { editable: true } } },
+          getValue: () => "John",
+          table: {
+            options: {
+              meta: { onCellEdit: vitest.fn(), isInEditMode: true },
+            },
+          },
+        };
+
+        if (typeof nameColumn.cell === "function") {
+          (nameColumn.cell as unknown as (
+            ctx: typeof mockCellContext,
+          ) => unknown)(mockCellContext);
+        }
+
+        expect(customRenderCell).not.toHaveBeenCalled();
+      },
+    );
 
     it("defaults to getValue when renderCell is not provided", async () => {
       const deferred = pDefer();

--- a/packages/react-components/src/object-table/hooks/useColumnDefs.ts
+++ b/packages/react-components/src/object-table/hooks/useColumnDefs.ts
@@ -27,6 +27,7 @@ import type { AccessorColumnDef } from "@tanstack/react-table";
 import { useMemo } from "react";
 import { renderDefaultCell } from "../DefaultCellRenderer.js";
 import type { ColumnDefinition } from "../ObjectTableApi.js";
+import { shouldShowEditableCell } from "../utils/shouldShowEditableCell.js";
 
 interface UseColumnDefsResult<
   Q extends ObjectOrInterfaceDefinition,
@@ -156,7 +157,14 @@ function getColumnsFromColumnDefinitions<
           RDPs
         > = cellContext.row.original;
 
-        if (renderCell) {
+        const meta = cellContext.table.options.meta;
+        const isEditable = shouldShowEditableCell(
+          editable,
+          meta?.onCellEdit,
+          meta?.isInEditMode,
+        );
+
+        if (renderCell && !isEditable) {
           return renderCell(object, locator);
         }
 

--- a/packages/react-components/src/object-table/utils/shouldShowEditableCell.ts
+++ b/packages/react-components/src/object-table/utils/shouldShowEditableCell.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Determines if a cell should be rendered as editable
+ *
+ * @param editable - Whether the column is marked as editable
+ * @param onCellEdit - The onCellEdit callback from table meta (indicates edit handlers exist)
+ * @param isInEditMode - Whether the table is currently in edit mode
+ * @returns true if the cell should be rendered with edit controls
+ */
+export function shouldShowEditableCell(
+  editable: boolean | undefined,
+  onCellEdit: unknown,
+  isInEditMode: boolean | undefined,
+): boolean {
+  return editable === true
+    && onCellEdit != null
+    && isInEditMode === true;
+}


### PR DESCRIPTION
Bug: if renderCell is provided with editable = true, the cell is not editable. The intention was for user to handle editable cell rendering fully.

Fix: Call renderCell when not in edit mode (only works for editMode = manual). In edit mode, the default editable cell will be rendered.