### PR TITLE
[Bug] Fix stable queries key

### DIFF
--- a/.changeset/stable-queries-key.md
+++ b/.changeset/stable-queries-key.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react": patch
+---
+
+Extract stable queries key logic into a dedicated function for better maintainability

--- a/.changeset/stable-queries-key.md
+++ b/.changeset/stable-queries-key.md
@@ -2,4 +2,4 @@
 "@osdk/react": patch
 ---
 
-Extract stable queries key logic into a dedicated function for better maintainability
+Fixed function column not reloaded when where clause changes by updating the stable queries key to get wire object set.

--- a/packages/react/src/new/__tests__/getStableQueriesKey.test.ts
+++ b/packages/react/src/new/__tests__/getStableQueriesKey.test.ts
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { QueryDefinition } from "@osdk/api";
+import { getWireObjectSet } from "@osdk/client";
+import { describe, expect, it, vi } from "vitest";
+import { getStableQueriesKey } from "../getStableQueriesKey.js";
+import type { UseOsdkFunctionOptions } from "../useOsdkFunction.js";
+
+vi.mock("@osdk/client", () => ({
+  isObjectSet: (v: unknown): boolean =>
+    typeof v === "object" && v != null && "__isObjectSet" in v,
+  getWireObjectSet: vi.fn().mockImplementation((v) => ({
+    WIRED: v.__wire,
+  })),
+}));
+
+const QUERY_A: QueryDefinition<unknown> = {
+  type: "query",
+  apiName: "queryA",
+  version: "1.0.0",
+};
+
+const QUERY_B: QueryDefinition<unknown> = {
+  type: "query",
+  apiName: "queryB",
+  version: "1.0.0",
+};
+
+function fakeObjectSet(wire: unknown): object {
+  return { __isObjectSet: true, __wire: wire };
+}
+
+describe("getStableQueriesKey", () => {
+  it("returns the same key for queries with structurally equal options", () => {
+    const a = getStableQueriesKey([
+      {
+        queryDefinition: QUERY_A,
+        options: { params: { x: 1 } } as unknown as UseOsdkFunctionOptions<
+          typeof QUERY_A
+        >,
+      },
+    ]);
+    const b = getStableQueriesKey([
+      {
+        queryDefinition: QUERY_A,
+        options: { params: { x: 1 } } as unknown as UseOsdkFunctionOptions<
+          typeof QUERY_A
+        >,
+      },
+    ]);
+    expect(a).toBe(b);
+  });
+
+  it("changes when the api name changes", () => {
+    const a = getStableQueriesKey([{ queryDefinition: QUERY_A }]);
+    const b = getStableQueriesKey([{ queryDefinition: QUERY_B }]);
+    expect(a).not.toBe(b);
+  });
+
+  it("changes when a primitive param changes", () => {
+    const a = getStableQueriesKey([
+      {
+        queryDefinition: QUERY_A,
+        options: { params: { x: 1 } } as unknown as UseOsdkFunctionOptions<
+          typeof QUERY_A
+        >,
+      },
+    ]);
+    const b = getStableQueriesKey([
+      {
+        queryDefinition: QUERY_A,
+        options: { params: { x: 2 } } as unknown as UseOsdkFunctionOptions<
+          typeof QUERY_A
+        >,
+      },
+    ]);
+    expect(a).not.toBe(b);
+  });
+
+  it("substitutes ObjectSet in params with its wire representation", () => {
+    const wire = { type: "base", objectType: "Employee" };
+    const objectSet = fakeObjectSet(wire);
+    const key = getStableQueriesKey([
+      {
+        queryDefinition: QUERY_A,
+        options: {
+          params: { employees: objectSet },
+        } as unknown as UseOsdkFunctionOptions<
+          typeof QUERY_A
+        >,
+      },
+    ]);
+    expect(getWireObjectSet).toHaveBeenCalled();
+    expect(key).toContain("WIRED");
+  });
+
+  it("returns the same key when ObjectSets share an identical wire representation", () => {
+    const wire = {
+      type: "filter",
+      objectSet: { type: "base", objectType: "Employee" },
+      where: { type: "eq", field: "department", value: "eng" },
+    };
+    const a = getStableQueriesKey([
+      {
+        queryDefinition: QUERY_A,
+        options: {
+          params: { os: fakeObjectSet(wire) },
+        } as unknown as UseOsdkFunctionOptions<
+          typeof QUERY_A
+        >,
+      },
+    ]);
+    const b = getStableQueriesKey([
+      {
+        queryDefinition: QUERY_A,
+        options: {
+          params: { os: fakeObjectSet(wire) },
+        } as unknown as UseOsdkFunctionOptions<
+          typeof QUERY_A
+        >,
+      },
+    ]);
+    expect(a).toBe(b);
+  });
+
+  it("returns a different key when the ObjectSet's wire representation differs", () => {
+    const baseWire = { type: "base", objectType: "Employee" };
+    const filteredWire = {
+      type: "filter",
+      objectSet: baseWire,
+      where: { type: "eq", field: "department", value: "eng" },
+    };
+    const a = getStableQueriesKey([
+      {
+        queryDefinition: QUERY_A,
+        options: {
+          params: { os: fakeObjectSet(baseWire) },
+        } as unknown as UseOsdkFunctionOptions<
+          typeof QUERY_A
+        >,
+      },
+    ]);
+    const b = getStableQueriesKey([
+      {
+        queryDefinition: QUERY_A,
+        options: {
+          params: { os: fakeObjectSet(filteredWire) },
+        } as unknown as UseOsdkFunctionOptions<
+          typeof QUERY_A
+        >,
+      },
+    ]);
+    expect(a).not.toBe(b);
+  });
+
+  it("detects ObjectSets nested inside arrays and objects in params", () => {
+    const wireA = { type: "base", objectType: "Employee" };
+    const wireB = { type: "base", objectType: "Project" };
+    const a = getStableQueriesKey([
+      {
+        queryDefinition: QUERY_A,
+        options: {
+          params: {
+            nested: { sets: [fakeObjectSet(wireA), fakeObjectSet(wireB)] },
+          } as never,
+        } as unknown as UseOsdkFunctionOptions<typeof QUERY_A>,
+      },
+    ]);
+    const b = getStableQueriesKey([
+      {
+        queryDefinition: QUERY_A,
+        options: {
+          params: {
+            nested: { sets: [fakeObjectSet(wireA), fakeObjectSet(wireB)] },
+          } as never,
+        } as unknown as UseOsdkFunctionOptions<typeof QUERY_A>,
+      },
+    ]);
+    expect(a).toBe(b);
+    expect(a).toContain("\"objectType\":\"Employee\"");
+    expect(a).toContain("\"objectType\":\"Project\"");
+  });
+
+  it("changes when query order changes", () => {
+    const a = getStableQueriesKey([
+      { queryDefinition: QUERY_A },
+      { queryDefinition: QUERY_B },
+    ]);
+    const b = getStableQueriesKey([
+      { queryDefinition: QUERY_B },
+      { queryDefinition: QUERY_A },
+    ]);
+    expect(a).not.toBe(b);
+  });
+});

--- a/packages/react/src/new/getStableQueriesKey.ts
+++ b/packages/react/src/new/getStableQueriesKey.ts
@@ -21,10 +21,9 @@ import type { FunctionQueryParams } from "./useOsdkFunctions.js";
 /**
  * Builds a stable string key for an array of function queries.
  *
- * Uses a JSON.stringify replacer to substitute any ObjectSet (at any depth,
- * typically nested under `options.params`) with its wire representation,
+ * Uses a JSON.stringify replacer to substitute any ObjectSet with its wire representation,
  * so composed operations (where/union/intersect) participate in the key
- * — plain JSON.stringify would not capture them.
+ * - plain JSON.stringify would not capture them.
  */
 export function getStableQueriesKey(
   queries: ReadonlyArray<FunctionQueryParams<QueryDefinition<unknown>>>,

--- a/packages/react/src/new/getStableQueriesKey.ts
+++ b/packages/react/src/new/getStableQueriesKey.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { QueryDefinition } from "@osdk/api";
+import { getWireObjectSet, isObjectSet } from "@osdk/client";
+import type { FunctionQueryParams } from "./useOsdkFunctions.js";
+
+/**
+ * Builds a stable string key for an array of function queries.
+ *
+ * Uses a JSON.stringify replacer to substitute any ObjectSet (at any depth,
+ * typically nested under `options.params`) with its wire representation,
+ * so composed operations (where/union/intersect) participate in the key
+ * — plain JSON.stringify would not capture them.
+ */
+export function getStableQueriesKey(
+  queries: ReadonlyArray<FunctionQueryParams<QueryDefinition<unknown>>>,
+): string {
+  return JSON.stringify(
+    queries.map(q => ({
+      apiName: q.queryDefinition.apiName,
+      ...q.options,
+    })),
+    (_key, value) => isObjectSet(value) ? getWireObjectSet(value) : value,
+  );
+}

--- a/packages/react/src/new/useOsdkFunctions.ts
+++ b/packages/react/src/new/useOsdkFunctions.ts
@@ -20,6 +20,7 @@ import {
   createCompositeExternalStore,
   EMPTY_STORE,
 } from "./createCompositeExternalStore.js";
+import { getStableQueriesKey } from "./getStableQueriesKey.js";
 import { OsdkContext } from "./OsdkContext.js";
 import type {
   UseOsdkFunctionOptions,
@@ -81,10 +82,7 @@ export function useOsdkFunctions(
 ): UseOsdkFunctionsResult {
   const { observableClient } = React.useContext(OsdkContext);
 
-  const stableQueriesKey = JSON.stringify(queries.map(q => ({
-    apiName: q.queryDefinition.apiName,
-    ...q.options,
-  })));
+  const stableQueriesKey = getStableQueriesKey(queries);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const stableQueries = React.useMemo(() => queries, [stableQueriesKey]);


### PR DESCRIPTION
Fixed function column not reloaded when where clause changes by updating the stable queries key to get wire object set.