### PR TITLE
Fix broken CSS custom property references

### DIFF
--- a/.changeset/fix-broken-design-tokens.md
+++ b/.changeset/fix-broken-design-tokens.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Fix broken CSS custom property references that used non-existent token names

--- a/packages/react-components/src/action-form/fields/RadioButtonsField.module.css
+++ b/packages/react-components/src/action-form/fields/RadioButtonsField.module.css
@@ -80,9 +80,9 @@
 }
 
 .osdkRadioLabel {
-  font-family: var(--osdk-typography-font-family);
-  font-size: var(--osdk-typography-font-size-default);
+  font-family: var(--osdk-typography-family-default);
+  font-size: var(--osdk-typography-size-body-medium);
   line-height: var(--osdk-typography-line-height-default);
-  color: var(--osdk-typography-color-default);
+  color: var(--osdk-typography-color-default-rest);
   cursor: pointer;
 }

--- a/packages/react-components/src/pdf-viewer/PdfViewer.module.css
+++ b/packages/react-components/src/pdf-viewer/PdfViewer.module.css
@@ -76,7 +76,7 @@
 /* PDFViewer page overrides */
 :global(.pdfViewer .page) {
   box-shadow: var(--osdk-pdf-viewer-page-shadow);
-  background-color: var(--osdk-palette-white);
+  background-color: var(--osdk-background-primary);
   margin: 0 auto var(--osdk-pdf-viewer-page-gap);
 }
 

--- a/packages/react-components/src/pdf-viewer/components/PdfViewerOutlineSidebar.module.css
+++ b/packages/react-components/src/pdf-viewer/components/PdfViewerOutlineSidebar.module.css
@@ -24,7 +24,7 @@
   cursor: pointer;
   font-family: var(--osdk-typography-family-default);
   font-size: var(--osdk-typography-size-body-small);
-  color: var(--osdk-typography-color-default);
+  color: var(--osdk-typography-color-default-rest);
   text-decoration: none;
   border: none;
   background: none;
@@ -46,8 +46,8 @@
 
 .outlineItemActive {
   background-color: var(--osdk-pdf-viewer-outline-item-active-bg, rgba(45, 114, 210, 0.1));
-  color: var(--osdk-pdf-viewer-outline-item-active-color, var(--osdk-intent-primary));
-  font-weight: var(--osdk-typography-weight-semibold);
+  color: var(--osdk-pdf-viewer-outline-item-active-color, var(--osdk-intent-primary-rest));
+  font-weight: var(--osdk-typography-weight-bold);
 }
 
 .outlineItemBold {

--- a/packages/react-components/src/pdf-viewer/components/PdfViewerSidebarHeader.module.css
+++ b/packages/react-components/src/pdf-viewer/components/PdfViewerSidebarHeader.module.css
@@ -62,7 +62,7 @@
 
 .modeButton[data-pressed] {
   background-color: var(--osdk-pdf-viewer-outline-item-active-bg, rgba(45, 114, 210, 0.1));
-  color: var(--osdk-pdf-viewer-outline-item-active-color, var(--osdk-intent-primary));
+  color: var(--osdk-pdf-viewer-outline-item-active-color, var(--osdk-intent-primary-rest));
 }
 
 .modeButton[data-pressed]:hover {

--- a/packages/react-components/src/tokens/component-tokens/datetime-picker.css
+++ b/packages/react-components/src/tokens/component-tokens/datetime-picker.css
@@ -29,7 +29,7 @@
     --osdk-typography-size-body-x-small
   );
 
-  --osdk-datetime-calendar-day-color: var(--osdk-typography-color-default);
+  --osdk-datetime-calendar-day-color: var(--osdk-typography-color-default-rest);
   --osdk-datetime-calendar-day-hover-bg: var(
     --osdk-surface-background-color-default-hover
   );


### PR DESCRIPTION
## Summary
Fix 10 instances of non-existent CSS custom property names that silently resolved to nothing, causing invisible text in dark mode themes.

| Broken Token | Correct Token | Files |
|---|---|---|
| `--osdk-typography-color-default` | `--osdk-typography-color-default-rest` | RadioButtonsField, PdfViewerOutlineSidebar, datetime-picker |
| `--osdk-typography-font-family` | `--osdk-typography-family-default` | RadioButtonsField |
| `--osdk-typography-font-size-default` | `--osdk-typography-size-body-medium` | RadioButtonsField |
| `--osdk-typography-weight-semibold` | `--osdk-typography-weight-bold` | PdfViewerOutlineSidebar |
| `--osdk-intent-primary` | `--osdk-intent-primary-rest` | PdfViewerOutlineSidebar, PdfViewerSidebarHeader |
| `--osdk-palette-white` | `--osdk-background-primary` | PdfViewer |

## Test plan
- [ ] Verify radio button labels are visible in dark mode themes
- [ ] Verify PDF viewer outline sidebar text is visible in dark mode
- [ ] Verify datetime picker calendar day text is visible in dark mode
- [ ] Verify PDF page background adapts to theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)