### PR TITLE
Version Packages 2.17.0

### DIFF
--- a/.changeset/combobox-popup-max-height.md
+++ b/.changeset/combobox-popup-max-height.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-components": patch
----
-
-Cap the Combobox popup at 320px (configurable via `--osdk-combobox-popup-max-height`) with overflow scrolling. Long option lists no longer push other UI off-screen — they scroll inside the popup. A short browser window still gets a smaller cap because the rule resolves to `min(320px, var(--available-height))`.

--- a/.changeset/filter-list-no-value-label.md
+++ b/.changeset/filter-list-no-value-label.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-components": minor
----
-
-Standardize "No value" rendering in FilterList — introduce a shared `NoValueLabel` component (italic, muted) used by listogram buckets, single-select and multi-select dropdown options, multi-select chips, text-tag chips, and the `NullValueWrapper` include-null row. Adds an `isEmptyValue` helper. The `NullValueWrapper` include-null row's default visual flips from upright/default-color to italic/muted so it matches the dropdown and listogram surfaces. Legacy `--osdk-filter-listogram-empty-label-color`, `--osdk-filter-listogram-empty-label-font-style`, `--osdk-filter-null-label-color`, `--osdk-filter-null-label-font-family`, `--osdk-filter-null-label-font-size`, and `--osdk-filter-null-label-line-height` tokens are honored as opt-in overrides on the listogram and null-wrapper containers; consumers who explicitly set them continue to override the new italic-muted defaults.

--- a/.changeset/filter-list-stable-render-input.md
+++ b/.changeset/filter-list-stable-render-input.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-components": patch
----
-
-Stabilize per-filter where-clause references inside `useFilterListState` via deep-equality caching, so `FilterInput.memo` holds when the cross-filter context for a given filter is unchanged across selections. Eliminates redundant aggregation requests on every value selection. Internal-only — no public API changes.

--- a/.changeset/fix-fetch-page-by-rid-property-securities.md
+++ b/.changeset/fix-fetch-page-by-rid-property-securities.md
@@ -1,6 +1,0 @@
----
-"@osdk/api": patch
-"@osdk/client": patch
----
-
-fix typing so `$loadPropertySecurityMetadata: true` is accepted on the experimental `fetchPageByRid` client method, and `$propertySecurities` is properly typed on returned objects.

--- a/.changeset/object-table-no-spurious-edit-on-blur.md
+++ b/.changeset/object-table-no-spurious-edit-on-blur.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-components": patch
----
-
-ObjectTable: Fix bug when cell is marked edited on clicking into and out of an empty cell

--- a/.changeset/object-table-row-attrs-editable-fns.md
+++ b/.changeset/object-table-row-attrs-editable-fns.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-components": minor
----
-
-ObjectTable: support per-row edit configuration via `editable: (rowData) => boolean`, add `getRowAttributes` prop for conditional row styling via data attributes, replace `editFieldConfig.fieldComponentProps` with `editFieldConfig.getFieldComponentProps(rowData)` so editor configuration can vary per row, and add a `showEditFooter` prop to opt out of the built-in edit footer.

--- a/.changeset/soft-clocks-switch.md
+++ b/.changeset/soft-clocks-switch.md
@@ -1,8 +1,0 @@
----
-"@osdk/faux": patch
-"@osdk/react-components": patch
-"@osdk/react-components-styles": patch
-"@osdk/react-components-storybook": patch
----
-
-Polish ActionForm date/time controls, boolean switch fields, form submission, popup positioning, component tokens, and FauxFoundry action typings.

--- a/benchmarks/tests/primary/CHANGELOG.md
+++ b/benchmarks/tests/primary/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/benchmarks.primary
 
+## 0.10.0
+
+### Patch Changes
+
+- Updated dependencies [147166c]
+  - @osdk/client@2.17.0
+
 ## 0.9.0
 
 ### Patch Changes

--- a/benchmarks/tests/primary/package.json
+++ b/benchmarks/tests/primary/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/benchmarks.primary",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.16.0';
+export type $ExpectedClientVersion = '2.17.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/api
 
+## 2.17.0
+
+### Minor Changes
+
+- 147166c: fix typing so `$loadPropertySecurityMetadata: true` is accepted on the experimental `fetchPageByRid` client method, and `$propertySecurities` is properly typed on returned objects.
+
 ## 2.16.0
 
 ### Minor Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/api",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/cli.cmd.typescript/CHANGELOG.md
+++ b/packages/cli.cmd.typescript/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/cli.cmd.typescript
 
+## 0.41.0
+
+### Patch Changes
+
+- @osdk/generator@2.17.0
+- @osdk/cli.common@0.41.0
+
 ## 0.40.0
 
 ### Minor Changes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.40.0",
+  "version": "0.41.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli.common/CHANGELOG.md
+++ b/packages/cli.common/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/cli.common
 
+## 0.41.0
+
 ## 0.40.0
 
 ### Minor Changes

--- a/packages/cli.common/package.json
+++ b/packages/cli.common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.common",
   "private": true,
-  "version": "0.40.0",
+  "version": "0.41.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/cli
 
+## 0.41.0
+
+### Patch Changes
+
+- @osdk/widget.api@3.14.0
+
 ## 0.40.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/cli",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client.test.ontology/CHANGELOG.md
+++ b/packages/client.test.ontology/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/client.test.ontology
 
+## 2.17.0
+
+### Patch Changes
+
+- Updated dependencies [147166c]
+  - @osdk/api@2.17.0
+
 ## 2.16.0
 
 ### Minor Changes

--- a/packages/client.test.ontology/package.json
+++ b/packages/client.test.ontology/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/client.test.ontology",
   "private": true,
-  "version": "2.16.0",
+  "version": "2.17.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client.unstable/CHANGELOG.md
+++ b/packages/client.unstable/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/client.unstable
 
+## 2.17.0
+
 ## 2.16.0
 
 ### Minor Changes

--- a/packages/client.unstable/package.json
+++ b/packages/client.unstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client.unstable",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/client
 
+## 2.17.0
+
+### Minor Changes
+
+- 147166c: fix typing so `$loadPropertySecurityMetadata: true` is accepted on the experimental `fetchPageByRid` client method, and `$propertySecurities` is properly typed on returned objects.
+
+### Patch Changes
+
+- Updated dependencies [147166c]
+  - @osdk/api@2.17.0
+  - @osdk/client.unstable@2.17.0
+  - @osdk/generator-converters@2.17.0
+
 ## 2.16.0
 
 ### Minor Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/client",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -168,7 +168,7 @@ export interface Client extends SharedClient, OldSharedClient {
 export const additionalContext: unique symbol = Symbol("additionalContext");
 
 // BEGIN: THIS IS GENERATED CODE. DO NOT EDIT.
-const MaxOsdkVersion = "2.16.0";
+const MaxOsdkVersion = "2.17.0";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 export type MaxOsdkVersion = typeof MaxOsdkVersion;
 const ErrorMessage: unique symbol = Symbol("ErrorMessage");

--- a/packages/create-app.template-packager/CHANGELOG.md
+++ b/packages/create-app.template-packager/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template-packager
 
+## 2.17.0
+
 ## 2.16.0
 
 ### Minor Changes

--- a/packages/create-app.template-packager/package.json
+++ b/packages/create-app.template-packager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template-packager",
   "private": true,
-  "version": "2.16.0",
+  "version": "2.17.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.expo.v2/CHANGELOG.md
+++ b/packages/create-app.template.expo.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.expo.v2
 
+## 2.17.0
+
 ## 2.16.0
 
 ### Minor Changes

--- a/packages/create-app.template.expo.v2/package.json
+++ b/packages/create-app.template.expo.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.expo.v2",
   "private": true,
-  "version": "2.16.0",
+  "version": "2.17.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react.beta/CHANGELOG.md
+++ b/packages/create-app.template.react.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.react
 
+## 2.17.0
+
 ## 2.16.0
 
 ### Minor Changes

--- a/packages/create-app.template.react.beta/package.json
+++ b/packages/create-app.template.react.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react.beta",
   "private": true,
-  "version": "2.16.0",
+  "version": "2.17.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.react/CHANGELOG.md
+++ b/packages/create-app.template.react/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.react
 
+## 2.17.0
+
 ## 2.16.0
 
 ### Minor Changes

--- a/packages/create-app.template.react/package.json
+++ b/packages/create-app.template.react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.react",
   "private": true,
-  "version": "2.16.0",
+  "version": "2.17.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-aip-app.beta
 
+## 2.17.0
+
 ## 2.16.0
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app.beta",
   "private": true,
-  "version": "2.16.0",
+  "version": "2.17.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-aip-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-aip-app
 
+## 2.17.0
+
 ## 2.16.0
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-aip-app/package.json
+++ b/packages/create-app.template.tutorial-todo-aip-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-aip-app",
   "private": true,
-  "version": "2.16.0",
+  "version": "2.17.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-app.beta/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-app.beta/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-app.beta
 
+## 2.17.0
+
 ## 2.16.0
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-app.beta/package.json
+++ b/packages/create-app.template.tutorial-todo-app.beta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app.beta",
   "private": true,
-  "version": "2.16.0",
+  "version": "2.17.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
+++ b/packages/create-app.template.tutorial-todo-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.tutorial-todo-app
 
+## 2.17.0
+
 ## 2.16.0
 
 ### Minor Changes

--- a/packages/create-app.template.tutorial-todo-app/package.json
+++ b/packages/create-app.template.tutorial-todo-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.tutorial-todo-app",
   "private": true,
-  "version": "2.16.0",
+  "version": "2.17.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.vue.v2/CHANGELOG.md
+++ b/packages/create-app.template.vue.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.vue.v2
 
+## 2.17.0
+
 ## 2.16.0
 
 ### Minor Changes

--- a/packages/create-app.template.vue.v2/package.json
+++ b/packages/create-app.template.vue.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.vue.v2",
   "private": true,
-  "version": "2.16.0",
+  "version": "2.17.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app.template.vue/CHANGELOG.md
+++ b/packages/create-app.template.vue/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-app.template.vue
 
+## 2.17.0
+
 ## 2.16.0
 
 ### Minor Changes

--- a/packages/create-app.template.vue/package.json
+++ b/packages/create-app.template.vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-app.template.vue",
   "private": true,
-  "version": "2.16.0",
+  "version": "2.17.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/create-app
 
+## 2.17.0
+
+### Patch Changes
+
+- @osdk/generator-utils@2.17.0
+
 ## 2.16.0
 
 ### Minor Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-app",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/create-widget.template.minimal-react.v2/CHANGELOG.md
+++ b/packages/create-widget.template.minimal-react.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-widget.template.react.v2
 
+## 3.14.0
+
 ## 3.13.0
 
 ### Minor Changes

--- a/packages/create-widget.template.minimal-react.v2/package.json
+++ b/packages/create-widget.template.minimal-react.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-widget.template.minimal-react.v2",
   "private": true,
-  "version": "3.13.0",
+  "version": "3.14.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-widget.template.react.v2/CHANGELOG.md
+++ b/packages/create-widget.template.react.v2/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/create-widget.template.react.v2
 
+## 3.14.0
+
 ## 3.13.0
 
 ### Minor Changes

--- a/packages/create-widget.template.react.v2/package.json
+++ b/packages/create-widget.template.react.v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/create-widget.template.react.v2",
   "private": true,
-  "version": "3.13.0",
+  "version": "3.14.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/create-widget/CHANGELOG.md
+++ b/packages/create-widget/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/create-widget
 
+## 3.14.0
+
+### Patch Changes
+
+- @osdk/generator-utils@2.17.0
+
 ## 3.13.0
 
 ### Minor Changes

--- a/packages/create-widget/package.json
+++ b/packages/create-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/create-widget",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.16.0';
+export type $ExpectedClientVersion = '2.17.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.dep';

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.16.0';
+export type $ExpectedClientVersion = '2.17.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.dep';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.16.0';
+export type $ExpectedClientVersion = '2.17.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';

--- a/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/OntologyMetadata.ts
+++ b/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.16.0';
+export type $ExpectedClientVersion = '2.17.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/OntologyMetadata.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.16.0';
+export type $ExpectedClientVersion = '2.17.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';

--- a/packages/faux/CHANGELOG.md
+++ b/packages/faux/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/shared.test
 
+## 0.14.0
+
+### Minor Changes
+
+- 9be8339: Polish ActionForm date/time controls, boolean switch fields, form submission, popup positioning, component tokens, and FauxFoundry action typings.
+
+### Patch Changes
+
+- Updated dependencies [147166c]
+  - @osdk/api@2.17.0
+  - @osdk/generator-converters@2.17.0
+
 ## 0.13.0
 
 ### Minor Changes

--- a/packages/faux/package.json
+++ b/packages/faux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/faux",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "",
   "access": "private",
   "license": "Apache-2.0",

--- a/packages/foundry-sdk-generator/CHANGELOG.md
+++ b/packages/foundry-sdk-generator/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/foundry-sdk-generator
 
+## 2.17.0
+
+### Patch Changes
+
+- Updated dependencies [147166c]
+  - @osdk/api@2.17.0
+  - @osdk/client@2.17.0
+  - @osdk/client.unstable@2.17.0
+  - @osdk/generator-utils@2.17.0
+  - @osdk/generator@2.17.0
+
 ## 2.16.0
 
 ### Minor Changes

--- a/packages/foundry-sdk-generator/package.json
+++ b/packages/foundry-sdk-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry-sdk-generator",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-converters.ontologyir/CHANGELOG.md
+++ b/packages/generator-converters.ontologyir/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/generator-converters.ontologyir
 
+## 2.17.0
+
+### Patch Changes
+
+- @osdk/client.unstable@2.17.0
+
 ## 2.16.0
 
 ### Minor Changes

--- a/packages/generator-converters.ontologyir/package.json
+++ b/packages/generator-converters.ontologyir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-converters.ontologyir",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-converters/CHANGELOG.md
+++ b/packages/generator-converters/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/generator-converters
 
+## 2.17.0
+
+### Patch Changes
+
+- Updated dependencies [147166c]
+  - @osdk/api@2.17.0
+
 ## 2.16.0
 
 ### Minor Changes

--- a/packages/generator-converters/package.json
+++ b/packages/generator-converters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-converters",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator-utils/CHANGELOG.md
+++ b/packages/generator-utils/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/generator-utils
 
+## 2.17.0
+
 ## 2.16.0
 
 ### Minor Changes

--- a/packages/generator-utils/package.json
+++ b/packages/generator-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator-utils",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/generator
 
+## 2.17.0
+
+### Patch Changes
+
+- Updated dependencies [147166c]
+  - @osdk/api@2.17.0
+  - @osdk/generator-converters@2.17.0
+
 ## 2.16.0
 
 ### Minor Changes

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/generator",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/generator/src/v2.0/generateMetadata.ts
+++ b/packages/generator/src/v2.0/generateMetadata.ts
@@ -19,7 +19,7 @@ import type { GenerateContext } from "../GenerateContext/GenerateContext.js";
 import { formatTs } from "../util/test/formatTs.js";
 
 // BEGIN: THIS IS GENERATED CODE. DO NOT EDIT.
-const ExpectedOsdkVersion = "2.16.0";
+const ExpectedOsdkVersion = "2.17.0";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 
 export async function generateOntologyMetadataFile(

--- a/packages/react-components-storybook/CHANGELOG.md
+++ b/packages/react-components-storybook/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/react-components-storybook
 
+## 0.11.0
+
+### Minor Changes
+
+- 9be8339: Polish ActionForm date/time controls, boolean switch fields, form submission, popup positioning, component tokens, and FauxFoundry action typings.
+
+### Patch Changes
+
+- Updated dependencies [9be8339]
+  - @osdk/faux@0.14.0
+
 ## 0.10.0
 
 ### Minor Changes

--- a/packages/react-components-storybook/package.json
+++ b/packages/react-components-storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/react-components-storybook",
   "private": true,
-  "version": "0.10.0",
+  "version": "0.11.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/react-components-styles/CHANGELOG.md
+++ b/packages/react-components-styles/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/react-components-styles
 
+## 0.13.0
+
+### Minor Changes
+
+- 9be8339: Polish ActionForm date/time controls, boolean switch fields, form submission, popup positioning, component tokens, and FauxFoundry action typings.
+
 ## 0.12.0
 
 ## 0.11.0

--- a/packages/react-components-styles/package.json
+++ b/packages/react-components-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/react-components-styles",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/react-components
 
+## 0.13.0
+
+### Minor Changes
+
+- 53e5f4f: Cap the Combobox popup at 320px (configurable via `--osdk-combobox-popup-max-height`) with overflow scrolling. Long option lists no longer push other UI off-screen — they scroll inside the popup. A short browser window still gets a smaller cap because the rule resolves to `min(320px, var(--available-height))`.
+- aca2466: Standardize "No value" rendering in FilterList — introduce a shared `NoValueLabel` component (italic, muted) used by listogram buckets, single-select and multi-select dropdown options, multi-select chips, text-tag chips, and the `NullValueWrapper` include-null row. Adds an `isEmptyValue` helper. The `NullValueWrapper` include-null row's default visual flips from upright/default-color to italic/muted so it matches the dropdown and listogram surfaces. Legacy `--osdk-filter-listogram-empty-label-color`, `--osdk-filter-listogram-empty-label-font-style`, `--osdk-filter-null-label-color`, `--osdk-filter-null-label-font-family`, `--osdk-filter-null-label-font-size`, and `--osdk-filter-null-label-line-height` tokens are honored as opt-in overrides on the listogram and null-wrapper containers; consumers who explicitly set them continue to override the new italic-muted defaults.
+- fe39be0: Stabilize per-filter where-clause references inside `useFilterListState` via deep-equality caching, so `FilterInput.memo` holds when the cross-filter context for a given filter is unchanged across selections. Eliminates redundant aggregation requests on every value selection. Internal-only — no public API changes.
+- 76ab0a3: ObjectTable: Fix bug when cell is marked edited on clicking into and out of an empty cell
+- 72e928b: ObjectTable: support per-row edit configuration via `editable: (rowData) => boolean`, add `getRowAttributes` prop for conditional row styling via data attributes, replace `editFieldConfig.fieldComponentProps` with `editFieldConfig.getFieldComponentProps(rowData)` so editor configuration can vary per row, and add a `showEditFooter` prop to opt out of the built-in edit footer.
+- 9be8339: Polish ActionForm date/time controls, boolean switch fields, form submission, popup positioning, component tokens, and FauxFoundry action typings.
+
 ## 0.12.0
 
 ### Minor Changes

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/react-components",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdkkit/react
 
+## 2.17.0
+
 ## 2.16.0
 
 ### Minor Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/react",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/vite-plugin-oac/CHANGELOG.md
+++ b/packages/vite-plugin-oac/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/vite-plugin-oac
 
+## 0.15.0
+
+### Patch Changes
+
+- Updated dependencies [147166c]
+- Updated dependencies [9be8339]
+  - @osdk/api@2.17.0
+  - @osdk/faux@0.14.0
+  - @osdk/cli@0.41.0
+  - @osdk/client.unstable@2.17.0
+  - @osdk/generator-converters.ontologyir@2.17.0
+
 ## 0.14.0
 
 ### Minor Changes

--- a/packages/vite-plugin-oac/package.json
+++ b/packages/vite-plugin-oac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/vite-plugin-oac",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/widget.api/CHANGELOG.md
+++ b/packages/widget.api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/widget.api
 
+## 3.14.0
+
+### Patch Changes
+
+- Updated dependencies [147166c]
+  - @osdk/api@2.17.0
+
 ## 3.13.0
 
 ### Minor Changes

--- a/packages/widget.api/package.json
+++ b/packages/widget.api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget.api",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "description": "API contract between Foundry UIs that can embed custom widgets and the custom widgets themselves",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/widget.client-react/CHANGELOG.md
+++ b/packages/widget.client-react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/widget.client-react
 
+## 3.14.0
+
+### Patch Changes
+
+- Updated dependencies [147166c]
+  - @osdk/client@2.17.0
+  - @osdk/widget.client@3.14.0
+
 ## 3.13.0
 
 ### Minor Changes

--- a/packages/widget.client-react/package.json
+++ b/packages/widget.client-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget.client-react",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "description": "Wrapper around @osdk/widget.client",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/widget.client/CHANGELOG.md
+++ b/packages/widget.client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/widget.client
 
+## 3.14.0
+
+### Patch Changes
+
+- @osdk/widget.api@3.14.0
+
 ## 3.13.0
 
 ### Minor Changes

--- a/packages/widget.client/package.json
+++ b/packages/widget.client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget.client",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "description": "Client that sets up listeners for the custom widgets embedded into Foundry, adhering to the contract laid out in @osdk/widget.api",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/widget.vite-plugin/CHANGELOG.md
+++ b/packages/widget.vite-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/widget.vite-plugin
 
+## 3.14.0
+
+### Patch Changes
+
+- @osdk/widget.api@3.14.0
+
 ## 3.13.0
 
 ### Minor Changes

--- a/packages/widget.vite-plugin/package.json
+++ b/packages/widget.vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/widget.vite-plugin",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "description": "A vite plugin that will extract parameter definitions from TS/JS files + entrypoint info into a manifest file to be uploaded to Foundry ",
   "access": "public",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.


# Releases
## @osdk/api@2.17.0

### Minor Changes

-   147166c: fix typing so `$loadPropertySecurityMetadata: true` is accepted on the experimental `fetchPageByRid` client method, and `$propertySecurities` is properly typed on returned objects.

## @osdk/client@2.17.0

### Minor Changes

-   147166c: fix typing so `$loadPropertySecurityMetadata: true` is accepted on the experimental `fetchPageByRid` client method, and `$propertySecurities` is properly typed on returned objects.

### Patch Changes

-   Updated dependencies [147166c]
    -   @osdk/api@2.17.0
    -   @osdk/client.unstable@2.17.0
    -   @osdk/generator-converters@2.17.0

## @osdk/faux@0.14.0

### Minor Changes

-   9be8339: Polish ActionForm date/time controls, boolean switch fields, form submission, popup positioning, component tokens, and FauxFoundry action typings.

### Patch Changes

-   Updated dependencies [147166c]
    -   @osdk/api@2.17.0
    -   @osdk/generator-converters@2.17.0

## @osdk/react-components@0.13.0

### Minor Changes

-   53e5f4f: Cap the Combobox popup at 320px (configurable via `--osdk-combobox-popup-max-height`) with overflow scrolling. Long option lists no longer push other UI off-screen — they scroll inside the popup. A short browser window still gets a smaller cap because the rule resolves to `min(320px, var(--available-height))`.
-   aca2466: Standardize "No value" rendering in FilterList — introduce a shared `NoValueLabel` component (italic, muted) used by listogram buckets, single-select and multi-select dropdown options, multi-select chips, text-tag chips, and the `NullValueWrapper` include-null row. Adds an `isEmptyValue` helper. The `NullValueWrapper` include-null row's default visual flips from upright/default-color to italic/muted so it matches the dropdown and listogram surfaces. Legacy `--osdk-filter-listogram-empty-label-color`, `--osdk-filter-listogram-empty-label-font-style`, `--osdk-filter-null-label-color`, `--osdk-filter-null-label-font-family`, `--osdk-filter-null-label-font-size`, and `--osdk-filter-null-label-line-height` tokens are honored as opt-in overrides on the listogram and null-wrapper containers; consumers who explicitly set them continue to override the new italic-muted defaults.
-   fe39be0: Stabilize per-filter where-clause references inside `useFilterListState` via deep-equality caching, so `FilterInput.memo` holds when the cross-filter context for a given filter is unchanged across selections. Eliminates redundant aggregation requests on every value selection. Internal-only — no public API changes.
-   76ab0a3: ObjectTable: Fix bug when cell is marked edited on clicking into and out of an empty cell
-   72e928b: ObjectTable: support per-row edit configuration via `editable: (rowData) => boolean`, add `getRowAttributes` prop for conditional row styling via data attributes, replace `editFieldConfig.fieldComponentProps` with `editFieldConfig.getFieldComponentProps(rowData)` so editor configuration can vary per row, and add a `showEditFooter` prop to opt out of the built-in edit footer.
-   9be8339: Polish ActionForm date/time controls, boolean switch fields, form submission, popup positioning, component tokens, and FauxFoundry action typings.

## @osdk/react-components-styles@0.13.0

### Minor Changes

-   9be8339: Polish ActionForm date/time controls, boolean switch fields, form submission, popup positioning, component tokens, and FauxFoundry action typings.

## @osdk/cli@0.41.0

### Patch Changes

-   @osdk/widget.api@3.14.0

## @osdk/create-app@2.17.0

### Patch Changes

-   @osdk/generator-utils@2.17.0

## @osdk/create-widget@3.14.0

### Patch Changes

-   @osdk/generator-utils@2.17.0

## @osdk/foundry-sdk-generator@2.17.0

### Patch Changes

-   Updated dependencies [147166c]
    -   @osdk/api@2.17.0
    -   @osdk/client@2.17.0
    -   @osdk/client.unstable@2.17.0
    -   @osdk/generator-utils@2.17.0
    -   @osdk/generator@2.17.0

## @osdk/generator@2.17.0

### Patch Changes

-   Updated dependencies [147166c]
    -   @osdk/api@2.17.0
    -   @osdk/generator-converters@2.17.0

## @osdk/generator-converters@2.17.0

### Patch Changes

-   Updated dependencies [147166c]
    -   @osdk/api@2.17.0

## @osdk/generator-converters.ontologyir@2.17.0

### Patch Changes

-   @osdk/client.unstable@2.17.0

## @osdk/vite-plugin-oac@0.15.0

### Patch Changes

-   Updated dependencies [147166c]
-   Updated dependencies [9be8339]
    -   @osdk/api@2.17.0
    -   @osdk/faux@0.14.0
    -   @osdk/cli@0.41.0
    -   @osdk/client.unstable@2.17.0
    -   @osdk/generator-converters.ontologyir@2.17.0

## @osdk/widget.api@3.14.0

### Patch Changes

-   Updated dependencies [147166c]
    -   @osdk/api@2.17.0

## @osdk/widget.client@3.14.0

### Patch Changes

-   @osdk/widget.api@3.14.0

## @osdk/widget.client-react@3.14.0

### Patch Changes

-   Updated dependencies [147166c]
    -   @osdk/client@2.17.0
    -   @osdk/widget.client@3.14.0

## @osdk/widget.vite-plugin@3.14.0

### Patch Changes

-   @osdk/widget.api@3.14.0

## @osdk/client.unstable@2.17.0



## @osdk/generator-utils@2.17.0



## @osdk/react@2.17.0



## @osdk/react-components-storybook@0.11.0

### Minor Changes

-   9be8339: Polish ActionForm date/time controls, boolean switch fields, form submission, popup positioning, component tokens, and FauxFoundry action typings.

### Patch Changes

-   Updated dependencies [9be8339]
    -   @osdk/faux@0.14.0

## @osdk/benchmarks.primary@0.10.0

### Patch Changes

-   Updated dependencies [147166c]
    -   @osdk/client@2.17.0

## @osdk/cli.cmd.typescript@0.41.0

### Patch Changes

-   @osdk/generator@2.17.0
-   @osdk/cli.common@0.41.0

## @osdk/client.test.ontology@2.17.0

### Patch Changes

-   Updated dependencies [147166c]
    -   @osdk/api@2.17.0

## @osdk/cli.common@0.41.0



## @osdk/create-app.template-packager@2.17.0



## @osdk/create-app.template.expo.v2@2.17.0



## @osdk/create-app.template.react@2.17.0



## @osdk/create-app.template.react.beta@2.17.0



## @osdk/create-app.template.tutorial-todo-aip-app@2.17.0



## @osdk/create-app.template.tutorial-todo-aip-app.beta@2.17.0



## @osdk/create-app.template.tutorial-todo-app@2.17.0



## @osdk/create-app.template.tutorial-todo-app.beta@2.17.0



## @osdk/create-app.template.vue@2.17.0



## @osdk/create-app.template.vue.v2@2.17.0



## @osdk/create-widget.template.minimal-react.v2@3.14.0



## @osdk/create-widget.template.react.v2@3.14.0


