### PR TITLE
Fix bug when cell is marked edited withou tedits

### DIFF
--- a/.changeset/object-table-no-spurious-edit-on-blur.md
+++ b/.changeset/object-table-no-spurious-edit-on-blur.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+ObjectTable: Fix bug when cell is marked edited on clicking into and out of an empty cell

--- a/packages/react-components-storybook/src/mocks/employeeData.ts
+++ b/packages/react-components-storybook/src/mocks/employeeData.ts
@@ -347,7 +347,7 @@ export const employeeData: BaseServerObject[] = [
     "businessTitle": "Operations Manager",
     "locationCountry": "Germany",
     "businessArea": "Operations",
-    "emailPrimaryWork": "yuki.torres97@example.com",
+    "emailPrimaryWork": null,
     "__apiName": "Employee",
     "locationRegion": "Berlin",
     "team": "Compliance",

--- a/packages/react-components/src/object-table/EditableCell.tsx
+++ b/packages/react-components/src/object-table/EditableCell.tsx
@@ -217,9 +217,14 @@ function EditableCellInner<TData extends RowData, CellValue = unknown>({
       return;
     }
 
+    // No-op when the input wasn't actually changed by the user
+    if (inputValue === valueToString(currentValue)) {
+      return;
+    }
+
     const parsedValue = parseValueByType(inputValue, dataType) as CellValue;
     commitEdit(parsedValue);
-  }, [inputValue, dataType, commitEdit]);
+  }, [inputValue, currentValue, dataType, commitEdit]);
 
   const handleInputChange = useCallback((value: string) => {
     // Cancel any in-flight validation

--- a/packages/react-components/src/object-table/__tests__/EditableCell.test.tsx
+++ b/packages/react-components/src/object-table/__tests__/EditableCell.test.tsx
@@ -124,6 +124,32 @@ describe("EditableCell", () => {
     );
   });
 
+  it.each([
+    { name: "null", value: null },
+    { name: "undefined", value: undefined },
+    { name: "empty string", value: "" },
+  ])(
+    "should not commit edit when focusing/blurring a field whose value is $name without typing",
+    ({ value }) => {
+      const onCellEdit = vi.fn();
+
+      render(
+        <EditableCell
+          {...defaultProps}
+          initialValue={value}
+          currentValue={value}
+          onCellEdit={onCellEdit}
+        />,
+      );
+
+      const input = screen.getByRole("textbox");
+      fireEvent.focus(input);
+      fireEvent.blur(input);
+
+      expect(onCellEdit).not.toHaveBeenCalled();
+    },
+  );
+
   it("should not show error if validation is cancelled due to component unmount", async () => {
     vi.useFakeTimers();
     const onCellValidationError = vi.fn();


### PR DESCRIPTION
Bug: clicking into and out of an editable cell whose value is `null`, `undefined`, or `""` no longer marks the cell as edited.

Before:

https://github.com/user-attachments/assets/126b0db3-771c-4eca-988d-d6fc230edd08

After:


https://github.com/user-attachments/assets/1b0643a3-f2d3-4fb7-b42c-fc8e05f390c6

