### PR TITLE
filter state: add sibling-no-refetch regression tests for usefilterliststate

### DIFF
--- a/.changeset/filter-list-sibling-refetch-test.md
+++ b/.changeset/filter-list-sibling-refetch-test.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add regression tests for FilterList per-filter where-clause stability — covers reference preservation when setFilterState writes deep-equal content and when filterDefinitions is recreated as a fresh-but-equal array. No runtime behavior change.

--- a/packages/react-components/src/filter-list/hooks/__tests__/useFilterListState.test.tsx
+++ b/packages/react-components/src/filter-list/hooks/__tests__/useFilterListState.test.tsx
@@ -492,100 +492,90 @@ describe("useFilterListState", () => {
       },
     );
 
-    it(
-      "preserves every entry reference when setFilterState writes a deep-equal value",
-      () => {
-        const nameDef = createPropertyFilterDef(
-          "name",
-          "LISTOGRAM",
-          createExactMatchState([]),
+    it("preserves all entry refs when setFilterState writes an equal value", () => {
+      const nameDef = createPropertyFilterDef(
+        "name",
+        "LISTOGRAM",
+        createExactMatchState([]),
+      );
+      const activeDef = createPropertyFilterDef(
+        "active",
+        "TOGGLE",
+        createToggleState(false),
+      );
+      const props = createProps({
+        filterDefinitions: [nameDef, activeDef],
+      });
+      const { result } = renderHook(() => useFilterListState(props));
+      const nameKey = getFilterKey(nameDef);
+      const activeKey = getFilterKey(activeDef);
+
+      act(() => {
+        result.current.setFilterState(
+          nameKey,
+          createExactMatchState(["John"]),
         );
-        const activeDef = createPropertyFilterDef(
-          "active",
-          "TOGGLE",
-          createToggleState(false),
+      });
+
+      const beforeName = result.current.perFilterWhereClauses.get(nameKey);
+      const beforeActive = result.current.perFilterWhereClauses.get(activeKey);
+      expect(beforeName).toBeDefined();
+      expect(beforeActive).toBeDefined();
+
+      act(() => {
+        result.current.setFilterState(
+          nameKey,
+          createExactMatchState(["John"]),
         );
-        const props = createProps({
-          filterDefinitions: [nameDef, activeDef],
-        });
-        const { result } = renderHook(() => useFilterListState(props));
-        const nameKey = getFilterKey(nameDef);
-        const activeKey = getFilterKey(activeDef);
+      });
 
-        act(() => {
-          result.current.setFilterState(
-            nameKey,
-            createExactMatchState(["John"]),
-          );
-        });
+      const afterName = result.current.perFilterWhereClauses.get(nameKey);
+      const afterActive = result.current.perFilterWhereClauses.get(activeKey);
+      expect(afterName).toBe(beforeName);
+      expect(afterActive).toBe(beforeActive);
+    });
 
-        const beforeName = result.current.perFilterWhereClauses.get(nameKey);
-        const beforeActive = result.current.perFilterWhereClauses.get(
-          activeKey,
-        );
+    it("preserves all entry refs when filterDefinitions is a fresh array", () => {
+      const nameDef = createPropertyFilterDef(
+        "name",
+        "LISTOGRAM",
+        createExactMatchState(["John"]),
+      );
+      const activeDef = createPropertyFilterDef(
+        "active",
+        "TOGGLE",
+        createToggleState(false),
+      );
+      const { result, rerender } = renderHook(
+        (defs: FilterListProps<typeof MockObjectType>["filterDefinitions"]) =>
+          useFilterListState(createProps({ filterDefinitions: defs })),
+        { initialProps: [nameDef, activeDef] },
+      );
+      const nameKey = getFilterKey(nameDef);
+      const activeKey = getFilterKey(activeDef);
 
-        act(() => {
-          result.current.setFilterState(
-            nameKey,
-            createExactMatchState(["John"]),
-          );
-        });
+      const beforeName = result.current.perFilterWhereClauses.get(nameKey);
+      const beforeActive = result.current.perFilterWhereClauses.get(activeKey);
+      expect(beforeName).toBeDefined();
+      expect(beforeActive).toBeDefined();
 
-        const afterName = result.current.perFilterWhereClauses.get(nameKey);
-        const afterActive = result.current.perFilterWhereClauses.get(activeKey);
-        expect(afterName).toBe(beforeName);
-        expect(afterActive).toBe(beforeActive);
-      },
-    );
-
-    it(
-      "preserves every entry reference when filterDefinitions is a fresh array of equal definitions",
-      () => {
-        const initialNameDef = createPropertyFilterDef(
+      rerender([
+        createPropertyFilterDef(
           "name",
           "LISTOGRAM",
           createExactMatchState(["John"]),
-        );
-        const initialActiveDef = createPropertyFilterDef(
+        ),
+        createPropertyFilterDef(
           "active",
           "TOGGLE",
           createToggleState(false),
-        );
-        const { result, rerender } = renderHook(
-          (
-            definitions: FilterListProps<typeof MockObjectType>[
-              "filterDefinitions"
-            ],
-          ) =>
-            useFilterListState(createProps({ filterDefinitions: definitions })),
-          { initialProps: [initialNameDef, initialActiveDef] },
-        );
-        const nameKey = getFilterKey(initialNameDef);
-        const activeKey = getFilterKey(initialActiveDef);
+        ),
+      ]);
 
-        const beforeName = result.current.perFilterWhereClauses.get(nameKey);
-        const beforeActive = result.current.perFilterWhereClauses.get(
-          activeKey,
-        );
-
-        rerender([
-          createPropertyFilterDef(
-            "name",
-            "LISTOGRAM",
-            createExactMatchState(["John"]),
-          ),
-          createPropertyFilterDef(
-            "active",
-            "TOGGLE",
-            createToggleState(false),
-          ),
-        ]);
-
-        const afterName = result.current.perFilterWhereClauses.get(nameKey);
-        const afterActive = result.current.perFilterWhereClauses.get(activeKey);
-        expect(afterName).toBe(beforeName);
-        expect(afterActive).toBe(beforeActive);
-      },
-    );
+      const afterName = result.current.perFilterWhereClauses.get(nameKey);
+      const afterActive = result.current.perFilterWhereClauses.get(activeKey);
+      expect(afterName).toBe(beforeName);
+      expect(afterActive).toBe(beforeActive);
+    });
   });
 });

--- a/packages/react-components/src/filter-list/hooks/__tests__/useFilterListState.test.tsx
+++ b/packages/react-components/src/filter-list/hooks/__tests__/useFilterListState.test.tsx
@@ -491,5 +491,101 @@ describe("useFilterListState", () => {
         expect(afterActive).toEqual({ name: "John" });
       },
     );
+
+    it(
+      "preserves every entry reference when setFilterState writes a deep-equal value",
+      () => {
+        const nameDef = createPropertyFilterDef(
+          "name",
+          "LISTOGRAM",
+          createExactMatchState([]),
+        );
+        const activeDef = createPropertyFilterDef(
+          "active",
+          "TOGGLE",
+          createToggleState(false),
+        );
+        const props = createProps({
+          filterDefinitions: [nameDef, activeDef],
+        });
+        const { result } = renderHook(() => useFilterListState(props));
+        const nameKey = getFilterKey(nameDef);
+        const activeKey = getFilterKey(activeDef);
+
+        act(() => {
+          result.current.setFilterState(
+            nameKey,
+            createExactMatchState(["John"]),
+          );
+        });
+
+        const beforeName = result.current.perFilterWhereClauses.get(nameKey);
+        const beforeActive = result.current.perFilterWhereClauses.get(
+          activeKey,
+        );
+
+        act(() => {
+          result.current.setFilterState(
+            nameKey,
+            createExactMatchState(["John"]),
+          );
+        });
+
+        const afterName = result.current.perFilterWhereClauses.get(nameKey);
+        const afterActive = result.current.perFilterWhereClauses.get(activeKey);
+        expect(afterName).toBe(beforeName);
+        expect(afterActive).toBe(beforeActive);
+      },
+    );
+
+    it(
+      "preserves every entry reference when filterDefinitions is a fresh array of equal definitions",
+      () => {
+        const initialNameDef = createPropertyFilterDef(
+          "name",
+          "LISTOGRAM",
+          createExactMatchState(["John"]),
+        );
+        const initialActiveDef = createPropertyFilterDef(
+          "active",
+          "TOGGLE",
+          createToggleState(false),
+        );
+        const { result, rerender } = renderHook(
+          (
+            definitions: FilterListProps<typeof MockObjectType>[
+              "filterDefinitions"
+            ],
+          ) =>
+            useFilterListState(createProps({ filterDefinitions: definitions })),
+          { initialProps: [initialNameDef, initialActiveDef] },
+        );
+        const nameKey = getFilterKey(initialNameDef);
+        const activeKey = getFilterKey(initialActiveDef);
+
+        const beforeName = result.current.perFilterWhereClauses.get(nameKey);
+        const beforeActive = result.current.perFilterWhereClauses.get(
+          activeKey,
+        );
+
+        rerender([
+          createPropertyFilterDef(
+            "name",
+            "LISTOGRAM",
+            createExactMatchState(["John"]),
+          ),
+          createPropertyFilterDef(
+            "active",
+            "TOGGLE",
+            createToggleState(false),
+          ),
+        ]);
+
+        const afterName = result.current.perFilterWhereClauses.get(nameKey);
+        const afterActive = result.current.perFilterWhereClauses.get(activeKey);
+        expect(afterName).toBe(beforeName);
+        expect(afterActive).toBe(beforeActive);
+      },
+    );
   });
 });


### PR DESCRIPTION
follow-up to #3177 — that PR shipped the per-filter where-clause stability mechanism but the test coverage only verifies clause shape. add tests that exercise the cache itself

• preserve every entry reference when setFilterState writes a deep-equal value
• preserve every entry reference when filterDefinitions is a fresh array of equal definitions (catches inline-array consumers that were the original regression mode)

no runtime behavior change — pure test additions inside the existing useFilterListState describe block