### PR TITLE
Fix styling of empty dropdown

### DIFF
--- a/.changeset/kind-books-chew.md
+++ b/.changeset/kind-books-chew.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Fix styling of empty dropdown

--- a/packages/react-components/src/object-table/EditableCell.module.css
+++ b/packages/react-components/src/object-table/EditableCell.module.css
@@ -137,6 +137,7 @@
 
 .readonlyDisplayCell {
   padding: calc(var(--osdk-surface-spacing) * 0.5) 0;
+  min-height: 1lh;
 }
 
 .nonEditableCellInEditMode {


### PR DESCRIPTION
Before

<img width="502" height="456" alt="Screenshot 2026-05-08 at 15 53 45" src="https://github.com/user-attachments/assets/ab097abb-5efd-48f2-87b8-7287927b103c" />


After
<img width="469" height="302" alt="Screenshot 2026-05-08 at 15 51 14" src="https://github.com/user-attachments/assets/22d9a4f2-9837-4e3d-ba5a-780971d5e3bb" />
