### PR TITLE
Support array string inputs

### DIFF
--- a/.changeset/support-array-string-inputs.md
+++ b/.changeset/support-array-string-inputs.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Render string array action parameters as chip-based text inputs.

--- a/packages/react-components/src/action-form/ActionForm.tsx
+++ b/packages/react-components/src/action-form/ActionForm.tsx
@@ -110,7 +110,12 @@ export const ActionForm: <Q extends ActionDefinition<unknown>>(
     (rawState: Record<string, unknown>): Record<string, unknown> => {
       const coerced: Record<string, unknown> = {};
       for (const [key, value] of Object.entries(rawState)) {
-        coerced[key] = coerceFieldValue(parameters?.[key]?.type, value);
+        const parameter = parameters?.[key];
+        coerced[key] = coerceFieldValue(
+          parameter?.type,
+          value,
+          parameter?.multiplicity === true,
+        );
       }
       return coerced;
     },

--- a/packages/react-components/src/action-form/FormFieldApi.ts
+++ b/packages/react-components/src/action-form/FormFieldApi.ts
@@ -147,7 +147,7 @@ export interface FormFieldPropsByType {
   OBJECT_SET: ObjectSetFieldProps<ObjectTypeDefinition>;
   RADIO_BUTTONS: RadioButtonsFieldProps<unknown>;
   TEXT_AREA: TextAreaFieldProps;
-  TEXT_INPUT: TextInputFieldProps;
+  TEXT_INPUT: TextInputFieldProps<boolean>;
   CUSTOM: CustomFieldProps<unknown>;
 }
 
@@ -408,21 +408,27 @@ export interface TextAreaFieldProps extends
   placeholder?: string;
 }
 
-export interface TextInputFieldProps extends
-  BaseFormFieldProps<string>,
-  Pick<
-    React.InputHTMLAttributes<HTMLInputElement>,
-    /**
-     * If provided, this will be added to the field validation
-     */
-    | "minLength"
-    /**
-     * If provided, this will be added to the field validation
-     */
-    | "maxLength"
-  >
+export interface TextInputFieldProps<Multiple extends boolean = false>
+  extends
+    BaseFormFieldProps<Multiple extends true ? readonly string[] : string>,
+    Pick<
+      React.InputHTMLAttributes<HTMLInputElement>,
+      /**
+       * If provided, this will be added to the field validation
+       */
+      | "minLength"
+      /**
+       * If provided, this will be added to the field validation
+       */
+      | "maxLength"
+    >
 {
   placeholder?: string;
+
+  /**
+   * Whether this text input accepts multiple string values as chips.
+   */
+  isMultiple?: Multiple;
 }
 
 /**
@@ -589,6 +595,13 @@ export type ActionParameters<Q extends ActionDefinition<unknown>> =
  * TODO: Re-use `BaseType`
  */
 export type FieldValueType<
+  Q extends ActionDefinition<unknown>,
+  K extends keyof ActionParameters<Q> = keyof ActionParameters<Q>,
+> = ActionParameters<Q>[K] extends { multiplicity: true }
+  ? ReadonlyArray<FieldScalarValueType<Q, K>>
+  : FieldScalarValueType<Q, K>;
+
+type FieldScalarValueType<
   Q extends ActionDefinition<unknown>,
   K extends keyof ActionParameters<Q> = keyof ActionParameters<Q>,
 > = ActionParameters<Q>[K]["type"] extends

--- a/packages/react-components/src/action-form/__tests__/ActionForm.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/ActionForm.test.tsx
@@ -55,6 +55,24 @@ const TestAction: TestActionDef = {
   apiName: "TestAction",
 } as TestActionDef;
 
+interface ArrayActionDef extends ActionDefinition<unknown> {
+  __DefinitionMetadata: {
+    signatures: unknown;
+    parameters: {
+      tags: { type: "string"; multiplicity: true };
+    };
+    type: "action";
+    apiName: "ArrayAction";
+    status: "ACTIVE";
+    rid: string;
+  };
+}
+
+const ArrayAction: ArrayActionDef = {
+  type: "action",
+  apiName: "ArrayAction",
+} as ArrayActionDef;
+
 const mockApplyAction = vi.fn().mockResolvedValue({
   editedObjectTypes: [],
 });
@@ -212,6 +230,37 @@ describe("ActionForm", () => {
 
       await vi.waitFor(() => {
         expect(onSuccess).toHaveBeenCalledWith(result);
+      });
+    });
+
+    it("submits multiplicity string parameters as arrays", async () => {
+      vi.mocked(useOsdkMetadata).mockReturnValue({
+        loading: false,
+        metadata: {
+          type: "action",
+          apiName: "ArrayAction",
+          displayName: "Array Action",
+          parameters: {
+            tags: {
+              type: "string",
+              nullable: false,
+              multiplicity: true,
+            },
+          },
+          status: "ACTIVE",
+          rid: "ri.ontology.main.action-type.array",
+        },
+      });
+
+      render(<ActionForm actionDefinition={ArrayAction} />);
+
+      const tagsInput = screen.getByRole("textbox", { name: /^tags/ });
+      fireEvent.input(tagsInput, { target: { value: "tag1" } });
+      fireEvent.keyDown(tagsInput, { key: "Enter" });
+      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+
+      await vi.waitFor(() => {
+        expect(mockApplyAction).toHaveBeenCalledWith({ tags: ["tag1"] });
       });
     });
 

--- a/packages/react-components/src/action-form/__tests__/BaseForm.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/BaseForm.test.tsx
@@ -154,6 +154,29 @@ describe("BaseForm", () => {
   });
 
   // TODO: expand this test to cover all field types
+  describe("multi text input field", () => {
+    it("renders default string array values as chips", () => {
+      render(
+        <BaseForm
+          formContent={[
+            field({
+              fieldKey: "tags",
+              label: "Tags",
+              fieldComponent: "TEXT_INPUT" as const,
+              fieldComponentProps: {
+                isMultiple: true,
+                defaultValue: ["existing"],
+              },
+            }),
+          ]}
+          onSubmit={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByText("existing")).toBeDefined();
+    });
+  });
+
   describe("dropdown field", () => {
     it("renders dropdown from formContent", () => {
       render(

--- a/packages/react-components/src/action-form/__tests__/TextInputField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/TextInputField.test.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TextInputField } from "../fields/TextInputField.js";
+
+describe("TextInputField", () => {
+  afterEach(cleanup);
+
+  describe("multi-value input", () => {
+    it("adds the typed value as a chip when Enter is pressed", () => {
+      const onChange = vi.fn();
+
+      render(
+        <TextInputField
+          value={["existing"]}
+          onChange={onChange}
+          isMultiple={true}
+        />,
+      );
+
+      const input = screen.getByRole("textbox");
+      fireEvent.change(input, { target: { value: "new tag" } });
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(screen.getByText("existing")).toBeDefined();
+      expect(onChange).toHaveBeenCalledWith(["existing", "new tag"]);
+      expect(input).toHaveProperty("value", "");
+    });
+
+    it("removes an existing chip when its remove button is clicked", () => {
+      const onChange = vi.fn();
+
+      render(
+        <TextInputField
+          value={["first", "second"]}
+          onChange={onChange}
+          isMultiple={true}
+        />,
+      );
+
+      fireEvent.click(screen.getByLabelText("Remove first"));
+
+      expect(onChange).toHaveBeenCalledWith(["second"]);
+    });
+
+    it("commits typed text on blur so in-progress values are not lost", () => {
+      const onChange = vi.fn();
+
+      render(
+        <TextInputField value={[]} onChange={onChange} isMultiple={true} />,
+      );
+
+      const input = screen.getByRole("textbox");
+      fireEvent.change(input, { target: { value: "pending" } });
+      fireEvent.blur(input);
+
+      expect(onChange).toHaveBeenCalledWith(["pending"]);
+    });
+  });
+});

--- a/packages/react-components/src/action-form/fields/BaseInput.module.css
+++ b/packages/react-components/src/action-form/fields/BaseInput.module.css
@@ -59,3 +59,85 @@
     border-color: var(--osdk-input-border-color-error);
   }
 }
+
+.osdkBaseMultiInput {
+  display: flex;
+  width: 100%;
+  min-height: var(--osdk-input-min-height);
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--osdk-surface-spacing);
+  padding-block: var(--osdk-surface-spacing);
+  padding-inline: calc(var(--osdk-surface-spacing) * 2);
+  border-radius: var(--osdk-input-border-radius);
+  border: var(--osdk-input-border-width) solid var(--osdk-input-border-color);
+  box-shadow: var(--osdk-input-shadow);
+  background-color: var(--osdk-input-bg);
+  color: var(--osdk-input-color);
+  font-family: var(--osdk-input-font-family);
+  font-size: var(--osdk-input-font-size);
+  line-height: var(
+    --osdk-input-line-height,
+    var(--osdk-typography-line-height-default)
+  );
+  transition:
+    background-color var(--osdk-input-transition-duration)
+      var(--osdk-input-transition-ease),
+    border-color var(--osdk-input-transition-duration)
+      var(--osdk-input-transition-ease);
+
+  &:hover {
+    background-color: var(--osdk-input-bg-hover);
+  }
+
+  &:focus-within {
+    outline: var(--osdk-input-focus-width) solid var(--osdk-input-focus-color);
+    outline-offset: var(--osdk-input-focus-offset);
+    border-color: var(--osdk-input-border-color-focus);
+  }
+
+  &[aria-invalid] {
+    border-color: var(--osdk-input-border-color-error);
+  }
+}
+
+.osdkBaseMultiInputChip {
+  display: inline-flex;
+  min-height: var(--osdk-input-min-height);
+  align-items: center;
+  gap: var(--osdk-surface-spacing);
+  padding-inline: calc(var(--osdk-surface-spacing) * 1.5)
+    var(--osdk-surface-spacing);
+  border-radius: var(--osdk-surface-border-radius);
+  background-color: var(--osdk-surface-background-color-default-hover);
+  color: var(--osdk-input-color);
+}
+
+.osdkBaseMultiInputChipRemove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding-block: 0;
+  padding-inline: 0;
+  border-width: 0;
+  background-color: transparent;
+  color: var(--osdk-iconography-color-muted);
+  cursor: pointer;
+}
+
+.osdkBaseMultiInputInput {
+  min-width: 12ch;
+  flex-basis: 12ch;
+  flex-grow: 1;
+  border-width: 0;
+  outline-width: 0;
+  background-color: transparent;
+  color: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+
+  &::placeholder {
+    color: var(--osdk-input-placeholder-color);
+  }
+}

--- a/packages/react-components/src/action-form/fields/FormFieldRenderer.tsx
+++ b/packages/react-components/src/action-form/fields/FormFieldRenderer.tsx
@@ -35,6 +35,8 @@ import { RadioButtonsField } from "./RadioButtonsField.js";
 import { TextAreaField } from "./TextAreaField.js";
 import { TextInputField } from "./TextInputField.js";
 
+const EMPTY_STRING_ARRAY: readonly string[] = [];
+
 export interface FormFieldRendererProps {
   fieldDefinition: RendererFieldDefinition;
   value: unknown;
@@ -104,7 +106,10 @@ function renderFieldComponent(
       return (
         <TextInputField
           id={fieldDefinition.fieldKey}
-          value={value != null ? String(value) : ""}
+          value={coerceToTextInputValue(
+            value,
+            fieldDefinition.fieldComponentProps.isMultiple === true,
+          )}
           onChange={onChange}
           placeholder={fieldDefinition.placeholder}
           error={error}
@@ -232,6 +237,21 @@ function resolvePortalContainer(
   return Object.hasOwn(fieldComponentProps, "portalContainer")
     ? fieldComponentProps.portalContainer
     : formPortalContainer;
+}
+
+function coerceToTextInputValue(
+  value: unknown,
+  isMultiple: boolean,
+): string | readonly string[] {
+  if (isMultiple) {
+    if (!Array.isArray(value)) {
+      return EMPTY_STRING_ARRAY;
+    }
+    return value.every((item) => typeof item === "string")
+      ? value
+      : value.map(String);
+  }
+  return value != null ? String(value) : "";
 }
 
 function coerceToDateRange(value: unknown): DateRange {

--- a/packages/react-components/src/action-form/fields/MultiTextInputField.tsx
+++ b/packages/react-components/src/action-form/fields/MultiTextInputField.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Input } from "@base-ui/react/input";
+import { SmallCross } from "@blueprintjs/icons";
+import React, { memo, useCallback, useState } from "react";
+import styles from "./BaseInput.module.css";
+
+export interface MultiTextInputFieldProps {
+  id?: string;
+  value: readonly string[];
+  onChange?: (value: readonly string[] | null) => void;
+  error?: string;
+  placeholder?: string;
+  minLength?: number;
+  maxLength?: number;
+}
+
+export const MultiTextInputField: React.NamedExoticComponent<
+  MultiTextInputFieldProps
+> = memo(function MultiTextInputFieldFn({
+  id,
+  value,
+  onChange,
+  error,
+  placeholder,
+  minLength,
+  maxLength,
+}: MultiTextInputFieldProps): React.ReactElement {
+  const [draftValue, setDraftValue] = useState("");
+
+  const commitDraftValue = useCallback(() => {
+    const trimmedValue = draftValue.trim();
+    if (trimmedValue === "") {
+      return;
+    }
+    onChange?.([...value, trimmedValue]);
+    setDraftValue("");
+  }, [draftValue, onChange, value]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "Enter" || event.key === ",") {
+        // Keep the browser from submitting the form or typing the delimiter;
+        // the delimiter means "turn the current text into a chip" here.
+        event.preventDefault();
+        commitDraftValue();
+      }
+    },
+    [commitDraftValue],
+  );
+
+  const handleRemoveValue = useCallback(
+    (indexToRemove: number) => {
+      onChange?.(value.filter((_, index) => index !== indexToRemove));
+    },
+    [onChange, value],
+  );
+
+  return (
+    <div
+      className={styles.osdkBaseMultiInput}
+      aria-invalid={error != null || undefined}
+    >
+      {value.map((selectedValue, index) => (
+        <span
+          key={`${selectedValue}-${index}`}
+          className={styles.osdkBaseMultiInputChip}
+        >
+          <span>{selectedValue}</span>
+          <button
+            type="button"
+            aria-label={`Remove ${selectedValue}`}
+            className={styles.osdkBaseMultiInputChipRemove}
+            onClick={() => handleRemoveValue(index)}
+          >
+            <SmallCross />
+          </button>
+        </span>
+      ))}
+      <Input
+        id={id}
+        className={styles.osdkBaseMultiInputInput}
+        type="text"
+        value={draftValue}
+        onValueChange={setDraftValue}
+        onKeyDown={handleKeyDown}
+        onBlur={commitDraftValue}
+        placeholder={value.length === 0 ? placeholder : undefined}
+        minLength={minLength}
+        maxLength={maxLength}
+        aria-invalid={error != null || undefined}
+      />
+    </div>
+  );
+});

--- a/packages/react-components/src/action-form/fields/TextInputField.tsx
+++ b/packages/react-components/src/action-form/fields/TextInputField.tsx
@@ -15,11 +15,20 @@
  */
 
 import { Input } from "@base-ui/react/input";
-import React from "react";
+import React, { memo } from "react";
 import type { TextInputFieldProps } from "../FormFieldApi.js";
 import styles from "./BaseInput.module.css";
+import { MultiTextInputField } from "./MultiTextInputField.js";
 
-export function TextInputField({
+const EMPTY_STRING_ARRAY: readonly string[] = [];
+
+type TextInputFieldRuntimeProps = TextInputFieldProps<boolean> & {
+  id?: string;
+};
+
+export const TextInputField: React.NamedExoticComponent<
+  TextInputFieldRuntimeProps
+> = memo(function TextInputFieldFn({
   id,
   value,
   onChange,
@@ -27,18 +36,35 @@ export function TextInputField({
   placeholder,
   minLength,
   maxLength,
-}: TextInputFieldProps & { id?: string }): React.ReactElement {
+  isMultiple,
+}: TextInputFieldRuntimeProps): React.ReactElement {
+  if (isMultiple) {
+    return (
+      <MultiTextInputField
+        id={id}
+        value={Array.isArray(value) ? value : EMPTY_STRING_ARRAY}
+        onChange={onChange as
+          | ((value: readonly string[] | null) => void)
+          | undefined}
+        error={error}
+        placeholder={placeholder}
+        minLength={minLength}
+        maxLength={maxLength}
+      />
+    );
+  }
+
   return (
     <Input
       id={id}
       className={styles.osdkBaseInput}
       type="text"
-      value={value ?? ""}
-      onValueChange={onChange}
+      value={typeof value === "string" ? value : ""}
+      onValueChange={onChange as ((value: string) => void) | undefined}
       placeholder={placeholder}
       minLength={minLength}
       maxLength={maxLength}
       aria-invalid={error != null || undefined}
     />
   );
-}
+});

--- a/packages/react-components/src/action-form/utils/__tests__/coerceFieldValue.test.ts
+++ b/packages/react-components/src/action-form/utils/__tests__/coerceFieldValue.test.ts
@@ -33,6 +33,16 @@ describe("coerceFieldValue", () => {
     });
   });
 
+  describe("multi-value fields", () => {
+    it("coerces each array item when multiplicity is true", () => {
+      expect(coerceFieldValue("string", ["a", 2], true)).toEqual(["a", "2"]);
+    });
+
+    it("preserves an empty array when multiplicity is true", () => {
+      expect(coerceFieldValue("string", [], true)).toEqual([]);
+    });
+  });
+
   describe("string types", () => {
     it("passes through strings for string type", () => {
       expect(coerceFieldValue("string", "hello")).toBe("hello");

--- a/packages/react-components/src/action-form/utils/__tests__/getDefaultFieldDefinitions.test.ts
+++ b/packages/react-components/src/action-form/utils/__tests__/getDefaultFieldDefinitions.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ActionMetadata } from "@osdk/api";
+import { describe, expect, it } from "vitest";
+import { getDefaultFieldDefinitions } from "../getDefaultFieldDefinitions.js";
+
+function makeMetadata(
+  parameter: ActionMetadata.Parameter,
+): ActionMetadata {
+  return {
+    type: "action",
+    apiName: "TestAction",
+    displayName: "Test action",
+    parameters: { tags: parameter },
+    status: "ACTIVE",
+    rid: "ri.action.test",
+  };
+}
+
+describe("getDefaultFieldDefinitions", () => {
+  it("renders multiplicity string parameters as multi-value text inputs", () => {
+    const [fieldDefinition] = getDefaultFieldDefinitions(makeMetadata({
+      type: "string",
+      nullable: false,
+      multiplicity: true,
+    }));
+
+    expect(fieldDefinition).toMatchObject({
+      fieldKey: "tags",
+      fieldComponent: "TEXT_INPUT",
+      fieldComponentProps: { isMultiple: true },
+    });
+  });
+});

--- a/packages/react-components/src/action-form/utils/coerceFieldValue.ts
+++ b/packages/react-components/src/action-form/utils/coerceFieldValue.ts
@@ -27,6 +27,7 @@ import type { FieldType } from "../FormFieldApi.js";
 export function coerceFieldValue(
   parameterType: FieldType | undefined,
   rawValue: unknown,
+  isMultiple = false,
 ): unknown {
   if (rawValue == null) {
     return undefined;
@@ -36,6 +37,23 @@ export function coerceFieldValue(
     return rawValue;
   }
 
+  if (isMultiple) {
+    if (!Array.isArray(rawValue)) {
+      return undefined;
+    }
+    const coercedValues = rawValue.map((value) =>
+      coerceSingleFieldValue(parameterType, value)
+    );
+    return coercedValues.includes(undefined) ? undefined : coercedValues;
+  }
+
+  return coerceSingleFieldValue(parameterType, rawValue);
+}
+
+function coerceSingleFieldValue(
+  parameterType: FieldType,
+  rawValue: unknown,
+): unknown {
   // TODO: Handle complex object types later
   if (typeof parameterType === "object") {
     return rawValue;

--- a/packages/react-components/src/action-form/utils/getDefaultFieldDefinitions.ts
+++ b/packages/react-components/src/action-form/utils/getDefaultFieldDefinitions.ts
@@ -50,6 +50,7 @@ function buildFieldDefinition(
   };
 
   const paramType = param.type;
+  const isMultiple = param.multiplicity === true;
 
   if (typeof paramType === "object") {
     switch (paramType.type) {
@@ -90,6 +91,11 @@ function buildFieldDefinition(
 
   switch (paramType) {
     case "string":
+      return {
+        ...base,
+        fieldComponent: "TEXT_INPUT",
+        fieldComponentProps: isMultiple ? { isMultiple: true } : {},
+      };
     case "marking":
     case "geohash":
     case "geoshape":


### PR DESCRIPTION
## Summary
- render string action parameters with multiplicity as chip-based text inputs
- preserve array values through field rendering and submit coercion
- add tests and changeset for @osdk/react-components

## Test plan
- pnpm turbo test --filter=@osdk/react-components
- pnpm turbo typecheck --filter=@osdk/react-components
- pnpm turbo transpile --filter=@osdk/react-components
- pnpm turbo check-api --filter=@osdk/react-components