### PR TITLE
storybook: show single grey experimental badge at component level

### DIFF
--- a/.changeset/storybook-experimental-badge.md
+++ b/.changeset/storybook-experimental-badge.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-storybook-only: drop the addon's default tag-badge spread so the custom grey "Experimental" badge shows on story sidebar entries instead of the addon's purple default.
+storybook-only: drop the addon's default tag-badge spread so the custom grey "Experimental" badge shows once at the component level (e.g. on FilterList) instead of the addon's purple default on every story.

--- a/.changeset/storybook-experimental-badge.md
+++ b/.changeset/storybook-experimental-badge.md
@@ -1,0 +1,4 @@
+---
+---
+
+storybook-only: drop the addon's default tag-badge spread so the custom grey "Experimental" badge shows on story sidebar entries instead of the addon's purple default.

--- a/.changeset/storybook-experimental-badge.md
+++ b/.changeset/storybook-experimental-badge.md
@@ -1,4 +1,0 @@
----
----
-
-storybook-only: drop the addon's default tag-badge spread so the custom grey "Experimental" badge shows once at the component level (e.g. on FilterList) instead of the addon's purple default on every story.

--- a/packages/react-components-storybook/.storybook/manager.ts
+++ b/packages/react-components-storybook/.storybook/manager.ts
@@ -31,8 +31,6 @@ addons.setConfig({
       },
       display: {
         sidebar: [
-          { type: "story", skipInherited: true },
-          { type: "docs", skipInherited: true },
           { type: "component", skipInherited: false },
           { type: "group", skipInherited: false },
         ],

--- a/packages/react-components-storybook/.storybook/manager.ts
+++ b/packages/react-components-storybook/.storybook/manager.ts
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  defaultConfig,
-  type TagBadgeParameters,
-} from "storybook-addon-tag-badges/manager-helpers";
+import type { TagBadgeParameters } from "storybook-addon-tag-badges/manager-helpers";
 import { addons } from "storybook/manager-api";
 
 addons.setConfig({
@@ -34,13 +31,14 @@ addons.setConfig({
       },
       display: {
         sidebar: [
+          { type: "story", skipInherited: true },
+          { type: "docs", skipInherited: true },
           { type: "component", skipInherited: false },
           { type: "group", skipInherited: false },
         ],
         toolbar: true,
       },
     },
-    ...defaultConfig,
   ] satisfies TagBadgeParameters,
 });
 


### PR DESCRIPTION
the addon was spreading its purple `defaultConfig` on top of the custom grey "Experimental" badge config, so the addon's purple chip was winning across every story sidebar entry.

• drop `...defaultConfig` so the custom grey badge renders instead of the addon's purple default
• limit `display.sidebar` to component + group so the pill shows once at the component level (e.g. on FilterList) rather than on every story