### PR TITLE
fix list rdp-traversal invalidation after action edits a related type

### DIFF
--- a/.changeset/list-rdp-invalidation.md
+++ b/.changeset/list-rdp-invalidation.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+lists with derived properties that traverse a linked object type now revalidate when an action edits that linked type

--- a/packages/client/src/observable/internal/Store.ts
+++ b/packages/client/src/observable/internal/Store.ts
@@ -666,12 +666,6 @@ export class Store {
     return this.functions.invalidateFunctionsByObject(apiName, primaryKey);
   }
 
-  public async invalidateFunctionsByObjectType(
-    apiName: string,
-  ): Promise<void> {
-    return this.functions.invalidateFunctionsByObjectType(apiName);
-  }
-
   #sizeCache: WeakMap<object, number> | undefined;
 
   public getCacheSnapshot(): CacheSnapshot {

--- a/packages/client/src/observable/internal/actions/ActionApplication.test.ts
+++ b/packages/client/src/observable/internal/actions/ActionApplication.test.ts
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 
-import { addOne, editTodo, Employee, Todo } from "@osdk/client.test.ontology";
+import type { DerivedProperty } from "@osdk/api";
+import {
+  addOne,
+  editTodo,
+  Employee,
+  moveOffice,
+  Office,
+  Todo,
+} from "@osdk/client.test.ontology";
 import {
   FauxFoundry,
   ontologies,
@@ -34,8 +42,10 @@ import {
 import type { Client } from "../../../Client.js";
 import { createClient } from "../../../createClient.js";
 import type { FunctionPayload } from "../../FunctionPayload.js";
+import type { ListPayload } from "../../ListPayload.js";
 import type { Observer } from "../../ObservableClient/common.js";
 import { Store } from "../Store.js";
+import { mockObserver } from "../testUtils.js";
 
 function mockFunctionSubCallback(): MockedObject<
   Observer<FunctionPayload | undefined>
@@ -78,6 +88,13 @@ describe("ActionApplication invalidation", () => {
         b.modifyObject<typeof Todo>(Todo.apiName, id, { ...other });
       },
     );
+    fauxOntology.registerActionType(stubData.MoveOffice, (b, payload) => {
+      b.modifyObject<typeof Office>(
+        Office.apiName,
+        payload.parameters.officeId as string,
+        { capacity: payload.parameters.newCapacity as number },
+      );
+    });
     stubData.registerLazyQueries(fauxOntology);
 
     return () => {
@@ -86,17 +103,31 @@ describe("ActionApplication invalidation", () => {
   });
 
   beforeEach(() => {
-    fauxFoundry.getDefaultDataStore().clear();
-    fauxFoundry.getDefaultDataStore().registerObject(Todo, {
+    const dataStore = fauxFoundry.getDefaultDataStore();
+    dataStore.clear();
+    dataStore.registerObject(Todo, {
       $apiName: "Todo",
       id: 0,
       text: "original",
     });
-    fauxFoundry.getDefaultDataStore().registerObject(Todo, {
+    dataStore.registerObject(Todo, {
       $apiName: "Todo",
       id: 1,
       text: "second",
     });
+
+    const officeA = dataStore.registerObject(Office, {
+      $apiName: "Office",
+      officeId: "office-a",
+      name: "Alpha Office",
+    });
+    const emp1 = dataStore.registerObject(Employee, {
+      $apiName: "Employee",
+      employeeId: 1,
+      fullName: "Alice",
+    });
+    dataStore.registerLink(emp1, "officeLink", officeA, "occupants");
+
     store = new Store(client);
   });
 
@@ -215,6 +246,40 @@ describe("ActionApplication invalidation", () => {
     subscription.unsubscribe();
   });
 
+  it("revalidates a list whose RDP traverses an edited object type", async () => {
+    const subFn = mockObserver<ListPayload | undefined>();
+
+    const withProperties: DerivedProperty.Clause<typeof Employee> = {
+      officeName: (b) => b.pivotTo("officeLink").selectProperty("name"),
+    };
+    const subscription = store.lists.observe(
+      { type: Employee, withProperties, dedupeInterval: 0 },
+      subFn,
+    );
+
+    // Wait for initial loaded emission.
+    await vi.waitFor(() => {
+      expect(subFn.next).toHaveBeenCalled();
+      const last = subFn.next.mock.lastCall?.[0];
+      expect(last?.status).toBe("loaded");
+    });
+    subFn.next.mockClear();
+
+    // Edit Office (NOT Employee). RDP traverses officeLink → Office; the list
+    // must refetch even though no Employee was edited.
+    await store.applyAction(moveOffice, {
+      officeId: "office-a",
+      newCapacity: 99,
+      newAddress: "new-address",
+    });
+
+    await vi.waitFor(() => {
+      expect(subFn.next).toHaveBeenCalled();
+    });
+
+    subscription.unsubscribe();
+  });
+
   it("does not fan out per-type invalidation when an action throws", async () => {
     const subFn = mockFunctionSubCallback();
 
@@ -237,7 +302,7 @@ describe("ActionApplication invalidation", () => {
       store.applyAction(editTodo, { id: 999, text: "fail" }),
     ).rejects.toBeDefined();
 
-    // No actionResults were assigned, so #invalidatePerTypeFunctionEdits is
+    // No actionResults were assigned, so #invalidatePerTypeEdits is
     // never reached. The dependsOn sub stays silent — no fan-out occurred.
     expect(subFn.next).not.toHaveBeenCalled();
 

--- a/packages/client/src/observable/internal/actions/ActionApplication.ts
+++ b/packages/client/src/observable/internal/actions/ActionApplication.ts
@@ -16,6 +16,7 @@
 
 import type { ActionDefinition, ActionEditResponse } from "@osdk/api";
 import type { ActionSignatureFromDef } from "../../../actions/applyAction.js";
+import { API_NAME_IDX } from "../list/ListCacheKey.js";
 import type { Store } from "../Store.js";
 import { runOptimisticJob } from "./OptimisticJob.js";
 
@@ -85,8 +86,8 @@ export class ActionApplication {
       await removeOptimisticResult();
     }
 
-    // After optimistic removal so the function refetch sees post-action state.
-    await this.#invalidatePerTypeFunctionEdits(actionResults);
+    // After optimistic removal so the refetch sees post-action server state.
+    await this.#invalidatePerTypeEdits(actionResults);
     return actionResults;
   };
 
@@ -127,30 +128,58 @@ export class ActionApplication {
     await Promise.all(promisesToWait);
   };
 
-  #invalidatePerTypeFunctionEdits = async (
+  #invalidatePerTypeEdits = async (
     actionEditResponse: ActionEditResponse | undefined,
   ): Promise<void> => {
     if (actionEditResponse == null) {
       return;
     }
+
+    const editedObjectTypeSet = new Set<string>();
     if (actionEditResponse.type === "edits") {
       const { deletedObjects, modifiedObjects, addedObjects } =
         actionEditResponse;
-      const editedObjectTypeSet = new Set<string>();
       for (const list of [deletedObjects, modifiedObjects, addedObjects]) {
         for (const obj of list ?? []) {
           editedObjectTypeSet.add(obj.objectType);
         }
       }
-      await Promise.allSettled(
-        [...editedObjectTypeSet].map(apiName =>
-          this.store.invalidateFunctionsByObjectType(apiName)
-        ),
-      );
     } else {
       for (const apiName of actionEditResponse.editedObjectTypes) {
-        await this.store.invalidateObjectType(apiName as string, undefined);
+        editedObjectTypeSet.add(apiName as string);
       }
     }
+
+    if (editedObjectTypeSet.size === 0) {
+      return;
+    }
+
+    // Walk the cache once and dispatch per (query, editedType) pair. The two
+    // skips below mean each query is touched at most once on the path that's
+    // right for it: ObjectQueries via the per-PK pass, primary-type lists via
+    // Subject reactions from that refetch, and everything else (RDP-traversed
+    // lists, FunctionQueries with dependsOn) via this walk.
+    const isEditsBranch = actionEditResponse.type === "edits";
+    const promises: Promise<unknown>[] = [];
+    for (const cacheKey of this.store.queries.keys()) {
+      if (isEditsBranch && cacheKey.type === "object") {
+        continue;
+      }
+      const query = this.store.queries.peek(cacheKey);
+      if (!query) {
+        continue;
+      }
+      for (const apiName of editedObjectTypeSet) {
+        if (
+          isEditsBranch
+          && cacheKey.type === "list"
+          && cacheKey.otherKeys[API_NAME_IDX] === apiName
+        ) {
+          continue;
+        }
+        promises.push(query.invalidateObjectType(apiName, undefined));
+      }
+    }
+    await Promise.allSettled(promises);
   };
 }

--- a/packages/client/src/observable/internal/function/FunctionsHelper.ts
+++ b/packages/client/src/observable/internal/function/FunctionsHelper.ts
@@ -137,14 +137,4 @@ export class FunctionsHelper extends AbstractHelper<
     }
     await Promise.allSettled(promises);
   }
-
-  async invalidateFunctionsByObjectType(
-    apiName: string,
-  ): Promise<void> {
-    const promises: Array<Promise<void>> = [];
-    for (const query of this.#functionQueries()) {
-      promises.push(query.invalidateObjectType(apiName, undefined));
-    }
-    await Promise.allSettled(promises);
-  }
 }

--- a/packages/client/src/observable/internal/list/ListQuery.ts
+++ b/packages/client/src/observable/internal/list/ListQuery.ts
@@ -113,6 +113,10 @@ export abstract class ListQuery extends BaseListQuery<
   #fetchedObjectType: string | undefined;
   #objectTypesCache: ReadonlySet<string> | undefined;
 
+  // Object types this query's RDPs traverse; an edit to any of these triggers
+  // revalidation. Undefined for ObjectSets the walker doesn't support.
+  #rdpInvalidationSet: ReadonlySet<string> | undefined;
+
   public override get rdpConfig(): Canonical<Rdp> | undefined {
     return this.cacheKey.otherKeys[RDP_IDX];
   }
@@ -233,12 +237,14 @@ export abstract class ListQuery extends BaseListQuery<
 
     if (needsResultType) {
       const wireObjectSet = getWireObjectSet(this.#objectSet);
-      const { resultType } = await getObjectTypesThatInvalidate(
-        this.store.client[additionalContext],
-        wireObjectSet,
-      );
+      const { resultType, invalidationSet } =
+        await getObjectTypesThatInvalidate(
+          this.store.client[additionalContext],
+          wireObjectSet,
+        );
 
       this.#updateFetchedObjectType(resultType.apiName);
+      this.#rdpInvalidationSet = invalidationSet;
 
       if (
         Object.keys(this.#orderBy).length > 0
@@ -294,11 +300,13 @@ export abstract class ListQuery extends BaseListQuery<
     if (this.#fetchedObjectType == null) {
       try {
         const wireObjectSet = getWireObjectSet(this.#objectSet);
-        const { resultType } = await getObjectTypesThatInvalidate(
-          this.store.client[additionalContext],
-          wireObjectSet,
-        );
+        const { resultType, invalidationSet } =
+          await getObjectTypesThatInvalidate(
+            this.store.client[additionalContext],
+            wireObjectSet,
+          );
         this.#updateFetchedObjectType(resultType.apiName);
+        this.#rdpInvalidationSet = invalidationSet;
       } catch {
         this.#updateFetchedObjectType(this.apiName);
       }
@@ -369,7 +377,8 @@ export abstract class ListQuery extends BaseListQuery<
   async revalidateObjectType(objectType: string): Promise<boolean> {
     return this.apiName === objectType
       || (this.#fetchedObjectType != null
-        && this.#fetchedObjectType === objectType);
+        && this.#fetchedObjectType === objectType)
+      || (this.#rdpInvalidationSet?.has(objectType) ?? false);
   }
 
   /**


### PR DESCRIPTION
## Summary

lists with derived properties that pivot through linked types weren't refetching when an action edited the linked type, leaving derived columns stale (cc-optica's `AdmittedPatientsTable` `overdueTasksCount` / `assignedCareService` etc.)

• capture `invalidationSet` from `getObjectTypesThatInvalidate` on `ListQuery` and check it in `revalidateObjectType`
• replace per-type fan-out with a single-pass walk in `ActionApplication` that skips per-pk-handled objects and primary-type lists
• drop unused `Store.invalidateFunctionsByObjectType` helper

stacked on #3193

## Test plan

- [x] `pnpm turbo typecheck --filter=@osdk/client` — pass
- [x] `npx dprint check` on touched files — pass
- [x] `Store.test.ts` — 46 pass, including `properly invalidates objects` and `produces proper results with optimistic updates and rollback`
- [x] `ActionApplication.test.ts` — 6 pass, including new `revalidates a list whose RDP traverses an edited object type`
- [ ] cc-optica end-to-end: derived columns refresh after `EditChecklistTask`/`AddPatientStatus` without page reload (post-release)