### PR TITLE
extend faux aggregate handler with sum/avg/min/max/distinct

### DIFF
--- a/.changeset/faux-aggregate-metrics.md
+++ b/.changeset/faux-aggregate-metrics.md
@@ -1,0 +1,5 @@
+---
+"@osdk/faux": minor
+---
+
+extend faux aggregate handler to support sum, avg, min, max, approximateDistinct, and exactDistinct metrics in addition to count, with consistent behavior in both the no-groupBy and exact-groupBy paths

--- a/packages/faux/src/handlers/createObjectSetHandlers.ts
+++ b/packages/faux/src/handlers/createObjectSetHandlers.ts
@@ -18,6 +18,7 @@ import type { RequestHandler } from "msw";
 import type { FauxFoundry } from "../FauxFoundry/FauxFoundry.js";
 import { getObjectsFromSet } from "../FauxFoundry/getObjectsFromSet.js";
 import { OntologiesV2 } from "../mock/index.js";
+import { computeAggregationMetric } from "./util/computeAggregationMetric.js";
 
 export const createObjectSetHandlers = (
   baseUrl: string,
@@ -57,12 +58,12 @@ export const createObjectSetHandlers = (
       }
 
       if (exactGroupBys.length === 0) {
+        const metrics = body.aggregation.map(agg =>
+          computeAggregationMetric(agg, objects)
+        );
         return {
           accuracy: "ACCURATE",
-          data: [{
-            group: {},
-            metrics: [{ name: "count", value: objects.length }],
-          }],
+          data: [{ group: {}, metrics }],
         };
       }
 
@@ -82,7 +83,11 @@ export const createObjectSetHandlers = (
           "FauxFoundry aggregate: exact groupBy requires a field",
         );
       }
-      const groups = new Map<string | null, number>();
+
+      const groupedObjects = new Map<
+        string | null,
+        Array<typeof objects[number]>
+      >();
 
       for (const obj of objects) {
         const rawValue = obj[groupField];
@@ -92,13 +97,20 @@ export const createObjectSetHandlers = (
           continue;
         }
 
-        groups.set(key, (groups.get(key) ?? 0) + 1);
+        const bucket = groupedObjects.get(key);
+        if (bucket) {
+          bucket.push(obj);
+        } else {
+          groupedObjects.set(key, [obj]);
+        }
       }
 
-      const data = Array.from(groups.entries()).map(
-        ([key, count]: [string | null, number]) => ({
+      const data = Array.from(groupedObjects.entries()).map(
+        ([key, bucketObjects]) => ({
           group: { [groupField]: key },
-          metrics: [{ name: "count", value: count }],
+          metrics: body.aggregation.map(agg =>
+            computeAggregationMetric(agg, bucketObjects)
+          ),
         }),
       );
 

--- a/packages/faux/src/handlers/util/computeAggregationMetric.test.ts
+++ b/packages/faux/src/handlers/util/computeAggregationMetric.test.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { computeAggregationMetric } from "./computeAggregationMetric.js";
+
+const planes = [
+  { tailNumber: "N1", capacity: 100, manufacturer: "Boeing" },
+  { tailNumber: "N2", capacity: 200, manufacturer: "Airbus" },
+  { tailNumber: "N3", capacity: 150, manufacturer: "Boeing" },
+  { tailNumber: "N4", capacity: null, manufacturer: "Bombardier" },
+  { tailNumber: "N5", manufacturer: "Boeing" }, // capacity undefined
+] as const;
+
+describe("computeAggregationMetric", () => {
+  it("count returns the object count and ignores fields", () => {
+    expect(
+      computeAggregationMetric({ type: "count", name: "count" }, planes),
+    ).toEqual({ name: "count", value: 5 });
+  });
+
+  it("count defaults the metric name to 'count' when omitted", () => {
+    expect(
+      computeAggregationMetric({ type: "count" }, planes),
+    ).toEqual({ name: "count", value: 5 });
+  });
+
+  it("sum reduces over a numeric field, skipping nulls and undefined", () => {
+    expect(
+      computeAggregationMetric(
+        { type: "sum", field: "capacity", name: "capacity.sum" },
+        planes,
+      ),
+    ).toEqual({ name: "capacity.sum", value: 100 + 200 + 150 });
+  });
+
+  it("avg divides by non-null count, not the total object count", () => {
+    expect(
+      computeAggregationMetric(
+        { type: "avg", field: "capacity", name: "capacity.avg" },
+        planes,
+      ),
+    ).toEqual({ name: "capacity.avg", value: (100 + 200 + 150) / 3 });
+  });
+
+  it("avg returns 0 when all values are null", () => {
+    expect(
+      computeAggregationMetric(
+        { type: "avg", field: "capacity", name: "capacity.avg" },
+        [{ capacity: null }],
+      ),
+    ).toEqual({ name: "capacity.avg", value: 0 });
+  });
+
+  it("min/max reduce over numeric fields", () => {
+    expect(
+      computeAggregationMetric(
+        { type: "min", field: "capacity", name: "capacity.min" },
+        planes,
+      ),
+    ).toEqual({ name: "capacity.min", value: 100 });
+
+    expect(
+      computeAggregationMetric(
+        { type: "max", field: "capacity", name: "capacity.max" },
+        planes,
+      ),
+    ).toEqual({ name: "capacity.max", value: 200 });
+  });
+
+  it("min/max return undefined when no non-null values exist", () => {
+    expect(
+      computeAggregationMetric(
+        { type: "min", field: "capacity", name: "capacity.min" },
+        [{ capacity: null }, { capacity: undefined }],
+      ),
+    ).toEqual({ name: "capacity.min", value: undefined });
+  });
+
+  it("approximateDistinct counts unique non-null values", () => {
+    expect(
+      computeAggregationMetric(
+        {
+          type: "approximateDistinct",
+          field: "manufacturer",
+          name: "manufacturer.approximateDistinct",
+        },
+        planes,
+      ),
+    ).toEqual({
+      name: "manufacturer.approximateDistinct",
+      value: 3,
+    });
+  });
+
+  it("exactDistinct counts unique non-null values", () => {
+    expect(
+      computeAggregationMetric(
+        {
+          type: "exactDistinct",
+          field: "manufacturer",
+          name: "manufacturer.exactDistinct",
+        },
+        planes,
+      ),
+    ).toEqual({
+      name: "manufacturer.exactDistinct",
+      value: 3,
+    });
+  });
+
+  it("sum/avg/min/max throw with a clear message on non-numeric values", () => {
+    expect(() =>
+      computeAggregationMetric(
+        { type: "sum", field: "manufacturer", name: "manufacturer.sum" },
+        planes,
+      )
+    ).toThrowError(/sum on field "manufacturer" requires numeric values/);
+  });
+
+  it("throws when sum/avg/min/max omit field and propertyIdentifier", () => {
+    expect(() =>
+      computeAggregationMetric(
+        { type: "sum", name: "capacity.sum" },
+        planes,
+      )
+    ).toThrowError(/sum requires a field/);
+  });
+
+  it("supports propertyIdentifier as the field source", () => {
+    expect(
+      computeAggregationMetric(
+        {
+          type: "sum",
+          propertyIdentifier: { type: "property", apiName: "capacity" },
+          name: "capacity.sum",
+        },
+        planes,
+      ),
+    ).toEqual({ name: "capacity.sum", value: 450 });
+  });
+
+  it("derives the metric name when omitted", () => {
+    expect(
+      computeAggregationMetric(
+        { type: "sum", field: "capacity" },
+        planes,
+      ),
+    ).toEqual({ name: "capacity.sum", value: 450 });
+  });
+});

--- a/packages/faux/src/handlers/util/computeAggregationMetric.ts
+++ b/packages/faux/src/handlers/util/computeAggregationMetric.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { AggregationV2 } from "@osdk/foundry.ontologies";
+
+export interface AggregationInput {
+  readonly [key: string]: unknown;
+}
+
+export interface AggregationMetric {
+  name: string;
+  value: unknown;
+}
+
+/**
+ * Compute a single aggregation metric over a collection of objects.
+ *
+ * Supports the request types emitted by the OSDK client: count, sum, avg,
+ * min, max, approximateDistinct, exactDistinct.
+ *
+ * The response's `name` is echoed from the request so the OSDK can split it
+ * back into `${property}.${metric}` when assembling the typed result.
+ *
+ * Numeric reductions (sum/avg/min/max) skip null/undefined values and
+ * throw when a non-null value is present that cannot be coerced to a number,
+ * naming the offending field — that surfaces fixture mistakes instead of
+ * silently producing NaN.
+ */
+export function computeAggregationMetric(
+  agg: AggregationV2,
+  objects: ReadonlyArray<AggregationInput>,
+): AggregationMetric {
+  switch (agg.type) {
+    case "count": {
+      return { name: agg.name ?? "count", value: objects.length };
+    }
+    case "sum": {
+      const { name, numbers } = collectNumeric(agg, objects);
+      return { name, value: numbers.reduce((s, v) => s + v, 0) };
+    }
+    case "avg": {
+      const { name, numbers } = collectNumeric(agg, objects);
+      const avg = numbers.length === 0
+        ? 0
+        : numbers.reduce((s, v) => s + v, 0) / numbers.length;
+      return { name, value: avg };
+    }
+    case "min": {
+      const { name, numbers } = collectNumeric(agg, objects);
+      return {
+        name,
+        value: numbers.length === 0 ? undefined : Math.min(...numbers),
+      };
+    }
+    case "max": {
+      const { name, numbers } = collectNumeric(agg, objects);
+      return {
+        name,
+        value: numbers.length === 0 ? undefined : Math.max(...numbers),
+      };
+    }
+    case "approximateDistinct":
+    case "exactDistinct": {
+      const { name, values } = collectFieldValues(agg, objects);
+      return { name, value: new Set(values).size };
+    }
+    case "approximatePercentile": {
+      throw new Error(
+        "FauxFoundry aggregate: approximatePercentile is not implemented",
+      );
+    }
+    default: {
+      const exhaustive: never = agg;
+      throw new Error(
+        `FauxFoundry aggregate: unsupported aggregation type ${
+          (exhaustive as { type: string }).type
+        }`,
+      );
+    }
+  }
+}
+
+function collectFieldValues(
+  agg: Exclude<AggregationV2, { type: "count" | "approximatePercentile" }>,
+  objects: ReadonlyArray<AggregationInput>,
+): { name: string; values: unknown[] } {
+  const field = resolveField(agg);
+  return {
+    name: agg.name ?? `${field}.${agg.type}`,
+    values: objects.map(o => o[field]).filter(v => v != null),
+  };
+}
+
+function collectNumeric(
+  agg: Extract<AggregationV2, { type: "sum" | "avg" | "min" | "max" }>,
+  objects: ReadonlyArray<AggregationInput>,
+): { name: string; numbers: number[] } {
+  const { name, values } = collectFieldValues(agg, objects);
+  const field = resolveField(agg);
+  const numbers: number[] = [];
+  for (const value of values) {
+    if (typeof value !== "number") {
+      throw new Error(
+        `FauxFoundry aggregate: ${agg.type} on field "${field}" requires `
+          + `numeric values; got ${typeof value} (${JSON.stringify(value)})`,
+      );
+    }
+    numbers.push(value);
+  }
+  return { name, numbers };
+}
+
+function resolveField(
+  agg: Exclude<AggregationV2, { type: "count" | "approximatePercentile" }>,
+): string {
+  const fromField = agg.field;
+  const fromIdentifier = agg.propertyIdentifier?.type === "property"
+    ? agg.propertyIdentifier.apiName
+    : undefined;
+  const field = fromField ?? fromIdentifier;
+  if (field == null) {
+    throw new Error(
+      `FauxFoundry aggregate: ${agg.type} requires a field`,
+    );
+  }
+  return field;
+}


### PR DESCRIPTION
faux's `/objectSets/aggregate` handler hard-coded `count` for every metric, so any non-count aggregation returned the count value under the wrong key — `result.capacity.sum` was always undefined at runtime even though the type-level request shape was accepted

• `computeAggregationMetric` dispatches on `agg.type` to support count, sum, avg, min, max, approximateDistinct, exactDistinct; null/undefined values are skipped, non-numeric values throw with the field name
• both no-groupBy and exact-groupBy paths now emit one metric per requested aggregation, echoing the request's `name` so the OSDK splits it back into `${property}.${metric}`
• approximatePercentile throws not-implemented; collectList/collectSet aren't part of `AggregationV2` (those are SelectedPropertyAggregation in `withProperties`) so they're untouched