### PR TITLE
Fix: dropdown validated on click

### DIFF
--- a/.changeset/quiet-tigers-dance.md
+++ b/.changeset/quiet-tigers-dance.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Fix dropdown field triggering validation when popover opens

--- a/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
@@ -908,6 +908,7 @@ const multiSelectDropdownFormContent: ReadonlyArray<FormContentItem> = [
     fieldKey: "categories",
     fieldComponent: "DROPDOWN",
     label: "Categories (Select)",
+    isRequired: true,
     fieldComponentProps: {
       items: TAG_ITEMS,
       isMultiple: true,

--- a/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
@@ -410,7 +410,7 @@ describe("DropdownField", () => {
       expect(onBlur).not.toHaveBeenCalled();
     });
 
-    it("calls onBlur when popover closes via dismiss layer", async () => {
+    it("calls onBlur when popover closes", async () => {
       const onBlur = vi.fn();
       render(
         <DropdownField
@@ -426,14 +426,7 @@ describe("DropdownField", () => {
         expect(screen.getByRole("option", { name: "Alice" })).toBeDefined();
       });
 
-      const dismissLayer = document.querySelector(
-        "[data-osdk-portal-dismiss-layer]",
-      );
-      if (!(dismissLayer instanceof HTMLElement)) {
-        throw new Error("Expected dropdown dismiss layer to be rendered");
-      }
-
-      fireEvent.pointerDown(dismissLayer);
+      fireEvent.keyDown(screen.getByRole("combobox"), { key: "Escape" });
 
       await vi.waitFor(() => {
         expect(onBlur).toHaveBeenCalled();
@@ -465,7 +458,7 @@ describe("DropdownField", () => {
       });
     });
 
-    it("calls onBlur when searchable popover closes via dismiss layer", async () => {
+    it("calls onBlur when searchable popover closes", async () => {
       const onBlur = vi.fn();
       render(
         <DropdownField
@@ -476,20 +469,17 @@ describe("DropdownField", () => {
         />,
       );
 
-      fireEvent.click(screen.getByRole("combobox"));
+      const trigger = screen.getByRole("combobox");
+      fireEvent.click(trigger);
 
       await vi.waitFor(() => {
         expect(screen.getByRole("option", { name: "Alice" })).toBeDefined();
       });
 
-      const dismissLayer = document.querySelector(
-        "[data-osdk-portal-dismiss-layer]",
-      );
-      if (!(dismissLayer instanceof HTMLElement)) {
-        throw new Error("Expected dropdown dismiss layer to be rendered");
-      }
-
-      fireEvent.pointerDown(dismissLayer);
+      // Escape on the search input closes the popover
+      fireEvent.keyDown(screen.getByPlaceholderText("Search…"), {
+        key: "Escape",
+      });
 
       await vi.waitFor(() => {
         expect(onBlur).toHaveBeenCalled();

--- a/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
@@ -390,6 +390,140 @@ describe("DropdownField", () => {
     });
   });
 
+  describe("onBlur", () => {
+    it("does not call onBlur when popover opens", async () => {
+      const onBlur = vi.fn();
+      render(
+        <DropdownField
+          value={null}
+          items={STRING_ITEMS}
+          onBlur={onBlur}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("combobox"));
+
+      await vi.waitFor(() => {
+        expect(screen.getByRole("option", { name: "Alice" })).toBeDefined();
+      });
+
+      expect(onBlur).not.toHaveBeenCalled();
+    });
+
+    it("calls onBlur when popover closes via dismiss layer", async () => {
+      const onBlur = vi.fn();
+      render(
+        <DropdownField
+          value={null}
+          items={STRING_ITEMS}
+          onBlur={onBlur}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("combobox"));
+
+      await vi.waitFor(() => {
+        expect(screen.getByRole("option", { name: "Alice" })).toBeDefined();
+      });
+
+      const dismissLayer = document.querySelector(
+        "[data-osdk-portal-dismiss-layer]",
+      );
+      if (!(dismissLayer instanceof HTMLElement)) {
+        throw new Error("Expected dropdown dismiss layer to be rendered");
+      }
+
+      fireEvent.pointerDown(dismissLayer);
+
+      await vi.waitFor(() => {
+        expect(onBlur).toHaveBeenCalled();
+      });
+    });
+
+    it("calls onBlur when a value is selected in single-select", async () => {
+      const onBlur = vi.fn();
+      const onChange = vi.fn();
+      render(
+        <DropdownField
+          value={null}
+          items={STRING_ITEMS}
+          onChange={onChange}
+          onBlur={onBlur}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("combobox"));
+
+      await vi.waitFor(() => {
+        expect(screen.getByRole("option", { name: "Alice" })).toBeDefined();
+      });
+
+      fireEvent.click(screen.getByRole("option", { name: "Alice" }));
+
+      await vi.waitFor(() => {
+        expect(onBlur).toHaveBeenCalled();
+      });
+    });
+
+    it("calls onBlur when searchable popover closes via dismiss layer", async () => {
+      const onBlur = vi.fn();
+      render(
+        <DropdownField
+          value={null}
+          items={STRING_ITEMS}
+          isSearchable={true}
+          onBlur={onBlur}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("combobox"));
+
+      await vi.waitFor(() => {
+        expect(screen.getByRole("option", { name: "Alice" })).toBeDefined();
+      });
+
+      const dismissLayer = document.querySelector(
+        "[data-osdk-portal-dismiss-layer]",
+      );
+      if (!(dismissLayer instanceof HTMLElement)) {
+        throw new Error("Expected dropdown dismiss layer to be rendered");
+      }
+
+      fireEvent.pointerDown(dismissLayer);
+
+      await vi.waitFor(() => {
+        expect(onBlur).toHaveBeenCalled();
+      });
+    });
+
+    it("calls onBlur when a value is selected in multi-select", async () => {
+      const onBlur = vi.fn();
+      const onChange = vi.fn();
+      render(
+        <DropdownField<string, true>
+          value={[]}
+          items={STRING_ITEMS}
+          onChange={onChange}
+          isSearchable={true}
+          isMultiple={true}
+          onBlur={onBlur}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("combobox"));
+
+      await vi.waitFor(() => {
+        expect(screen.getByRole("option", { name: "Alice" })).toBeDefined();
+      });
+
+      fireEvent.click(screen.getByRole("option", { name: "Alice" }));
+
+      await vi.waitFor(() => {
+        expect(onBlur).toHaveBeenCalled();
+      });
+    });
+  });
+
   describe("clear button", () => {
     it("shows clear button in select when a value is selected", () => {
       render(<DropdownField value="Alice" items={STRING_ITEMS} />);

--- a/packages/react-components/src/action-form/fields/DropdownField.tsx
+++ b/packages/react-components/src/action-form/fields/DropdownField.tsx
@@ -69,7 +69,6 @@ export const DropdownField: <V, Multiple extends boolean = false>(
   disableClientSideFiltering,
   popupStatus,
   trailingItem,
-  onBlur,
   ...rest
 }: DropdownFieldProps<V, Multiple> & {
   onBlur?: () => void;
@@ -103,7 +102,6 @@ export const DropdownField: <V, Multiple extends boolean = false>(
         disableClientSideFiltering={disableClientSideFiltering}
         popupStatus={popupStatus}
         trailingItem={trailingItem}
-        onBlur={onBlur}
       />
     );
   }
@@ -115,7 +113,6 @@ export const DropdownField: <V, Multiple extends boolean = false>(
       value={normalizedValue}
       itemToStringLabel={resolvedItemToStringLabel}
       getKey={getKey}
-      onBlur={onBlur}
     />
   );
 });
@@ -140,14 +137,17 @@ const SelectDropdown = typedReactMemo(function SelectDropdownFn<
 
   const hasValue = value != null;
 
-  const handleOpenChange = useCallback((nextOpen: boolean) => {
-    setOpen(nextOpen);
-    // Mark the field as touched when the popover closes so RHF validates.
-    // Opening the popover does not trigger validation.
-    if (!nextOpen) {
-      onBlur?.();
-    }
-  }, [onBlur]);
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen);
+      // Mark the field as touched when the popover closes so RHF validates.
+      // Opening the popover does not trigger validation.
+      if (!nextOpen) {
+        onBlur?.();
+      }
+    },
+    [onBlur],
+  );
 
   const handleValueChange = useCallback(
     (...args: Parameters<NonNullable<typeof onChange>>) => {
@@ -252,12 +252,15 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
     ? Array.isArray(value) && value.length > 0
     : value != null;
 
-  const handleOpenChange = useCallback((nextOpen: boolean) => {
-    setOpen(nextOpen);
-    if (!nextOpen) {
-      onBlur?.();
-    }
-  }, [onBlur]);
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen);
+      if (!nextOpen) {
+        onBlur?.();
+      }
+    },
+    [onBlur],
+  );
 
   const handleClear = useCallback(() => {
     // TypeScript can't narrow the conditional type `Multiple extends true ? V[] : V`
@@ -406,9 +409,7 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
                 <Combobox.Empty>No results</Combobox.Empty>
               )}
               <Combobox.List>
-                <Combobox.Collection>
-                  {renderItem}
-                </Combobox.Collection>
+                <Combobox.Collection>{renderItem}</Combobox.Collection>
                 {trailingItem}
               </Combobox.List>
             </Combobox.Popup>

--- a/packages/react-components/src/action-form/fields/DropdownField.tsx
+++ b/packages/react-components/src/action-form/fields/DropdownField.tsx
@@ -41,6 +41,7 @@ interface InnerSelectProps<V, Multiple extends boolean>
   portalRef?: React.Ref<HTMLDivElement>;
   query?: string;
   onQueryChange?: (query: string) => void;
+  onBlur?: () => void;
 }
 
 interface InnerComboboxProps<V, Multiple extends boolean>
@@ -53,7 +54,7 @@ interface InnerComboboxProps<V, Multiple extends boolean>
 }
 
 export const DropdownField: <V, Multiple extends boolean = false>(
-  props: DropdownFieldProps<V, Multiple>,
+  props: DropdownFieldProps<V, Multiple> & { onBlur?: () => void },
 ) => React.ReactElement = typedReactMemo(function DropdownFieldFn<
   V,
   Multiple extends boolean = false,
@@ -68,8 +69,11 @@ export const DropdownField: <V, Multiple extends boolean = false>(
   disableClientSideFiltering,
   popupStatus,
   trailingItem,
+  onBlur,
   ...rest
-}: DropdownFieldProps<V, Multiple>): React.ReactElement {
+}: DropdownFieldProps<V, Multiple> & {
+  onBlur?: () => void;
+}): React.ReactElement {
   // Ensure always controlled from first render: multi-select needs [],
   // single-select needs null. Passing undefined switches Base UI from
   // uncontrolled to controlled and triggers a warning.
@@ -99,6 +103,7 @@ export const DropdownField: <V, Multiple extends boolean = false>(
         disableClientSideFiltering={disableClientSideFiltering}
         popupStatus={popupStatus}
         trailingItem={trailingItem}
+        onBlur={onBlur}
       />
     );
   }
@@ -110,6 +115,7 @@ export const DropdownField: <V, Multiple extends boolean = false>(
       value={normalizedValue}
       itemToStringLabel={resolvedItemToStringLabel}
       getKey={getKey}
+      onBlur={onBlur}
     />
   );
 });
@@ -128,28 +134,46 @@ const SelectDropdown = typedReactMemo(function SelectDropdownFn<
   placeholder,
   portalRef,
   portalContainer,
+  onBlur,
 }: InnerSelectProps<V, Multiple>): React.ReactElement {
   const [open, setOpen] = useState(false);
 
   const hasValue = value != null;
 
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen);
+    // Mark the field as touched when the popover closes so RHF validates.
+    // Opening the popover does not trigger validation.
+    if (!nextOpen) {
+      onBlur?.();
+    }
+  }, [onBlur]);
+
+  const handleValueChange = useCallback(
+    (...args: Parameters<NonNullable<typeof onChange>>) => {
+      onChange?.(...args);
+      onBlur?.();
+    },
+    [onChange, onBlur],
+  );
+
   const handleClear = useCallback(() => {
     // SelectDropdown is always single-select, so cleared value is null.
     (onChange as ((v: V | null) => void) | undefined)?.(null);
-    setOpen(false);
-  }, [onChange]);
+    handleOpenChange(false);
+  }, [onChange, handleOpenChange]);
 
   const handleDismiss = useCallback(() => {
-    setOpen(false);
-  }, []);
+    handleOpenChange(false);
+  }, [handleOpenChange]);
 
   return (
     <div>
       <Select.Root
         value={value}
-        onValueChange={onChange}
+        onValueChange={handleValueChange}
         open={open}
-        onOpenChange={setOpen}
+        onOpenChange={handleOpenChange}
         isItemEqualToValue={isItemEqual}
         itemToStringLabel={itemToStringLabel}
       >
@@ -220,6 +244,7 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
   disableClientSideFiltering,
   popupStatus,
   trailingItem,
+  onBlur,
 }: InnerComboboxProps<V, Multiple>): React.ReactElement {
   const [open, setOpen] = useState(false);
 
@@ -227,16 +252,24 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
     ? Array.isArray(value) && value.length > 0
     : value != null;
 
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      onBlur?.();
+    }
+  }, [onBlur]);
+
   const handleClear = useCallback(() => {
     // TypeScript can't narrow the conditional type `Multiple extends true ? V[] : V`
     // at runtime, so we cast through the known parameter type at this single call site.
     const cleared = isMultiple ? (EMPTY_ARRAY as V[]) : null;
     (onChange as ((v: V[] | V | null) => void) | undefined)?.(cleared);
+    onBlur?.();
     // Single-select: close after clearing. Multi-select: keep open for continued selection.
     if (!isMultiple) {
-      setOpen(false);
+      handleOpenChange(false);
     }
-  }, [isMultiple, onChange]);
+  }, [isMultiple, onChange, onBlur, handleOpenChange]);
 
   const handleRemoveItem = useCallback(
     (itemToRemove: V) => {
@@ -249,13 +282,25 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
           : v !== itemToRemove
       );
       (onChange as ((v: V[] | V | null) => void) | undefined)?.(next);
+      onBlur?.();
     },
-    [isMultiple, value, onChange, isItemEqual],
+    [isMultiple, value, onChange, isItemEqual, onBlur],
   );
 
   const handleDismiss = useCallback(() => {
-    setOpen(false);
-  }, []);
+    handleOpenChange(false);
+  }, [handleOpenChange]);
+
+  // Mark the field as touched on every value change so RHF revalidates
+  // immediately — especially important for multi-select where the popup
+  // stays open after toggling an item.
+  const handleValueChange: typeof onChange = useCallback(
+    (...args: Parameters<NonNullable<typeof onChange>>) => {
+      onChange?.(...args);
+      onBlur?.();
+    },
+    [onChange, onBlur],
+  );
 
   const renderItem = useCallback(
     (item: V) => (
@@ -275,9 +320,9 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
     <div>
       <Combobox.Root
         value={value}
-        onValueChange={onChange}
+        onValueChange={handleValueChange}
         open={open}
-        onOpenChange={setOpen}
+        onOpenChange={handleOpenChange}
         multiple={isMultiple}
         itemToStringLabel={itemToStringLabel}
         isItemEqualToValue={isItemEqual}

--- a/packages/react-components/src/action-form/fields/DropdownField.tsx
+++ b/packages/react-components/src/action-form/fields/DropdownField.tsx
@@ -149,14 +149,6 @@ const SelectDropdown = typedReactMemo(function SelectDropdownFn<
     [onBlur],
   );
 
-  const handleValueChange = useCallback(
-    (...args: Parameters<NonNullable<typeof onChange>>) => {
-      onChange?.(...args);
-      onBlur?.();
-    },
-    [onChange, onBlur],
-  );
-
   const handleClear = useCallback(() => {
     // SelectDropdown is always single-select, so cleared value is null.
     (onChange as ((v: V | null) => void) | undefined)?.(null);
@@ -171,7 +163,7 @@ const SelectDropdown = typedReactMemo(function SelectDropdownFn<
     <div>
       <Select.Root
         value={value}
-        onValueChange={handleValueChange}
+        onValueChange={onChange}
         open={open}
         onOpenChange={handleOpenChange}
         isItemEqualToValue={isItemEqual}
@@ -262,17 +254,32 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
     [onBlur],
   );
 
+  // Mark the field as touched on every value change so RHF revalidates
+  // immediately — especially important for multi-select where the popup
+  // stays open after toggling an item.
+  const handleValueChange: typeof onChange = useCallback(
+    (...args: Parameters<NonNullable<typeof onChange>>) => {
+      onChange?.(...args);
+      // Multi-select: popover stays open, so fire onBlur directly.
+      // Single-select: popover closes on selection, handleOpenChange(false)
+      // already fires onBlur.
+      if (isMultiple) {
+        onBlur?.();
+      }
+    },
+    [onChange, onBlur, isMultiple],
+  );
+
   const handleClear = useCallback(() => {
     // TypeScript can't narrow the conditional type `Multiple extends true ? V[] : V`
     // at runtime, so we cast through the known parameter type at this single call site.
     const cleared = isMultiple ? (EMPTY_ARRAY as V[]) : null;
-    (onChange as ((v: V[] | V | null) => void) | undefined)?.(cleared);
-    onBlur?.();
+    (handleValueChange as (v: V[] | V | null) => void)(cleared);
     // Single-select: close after clearing. Multi-select: keep open for continued selection.
     if (!isMultiple) {
       handleOpenChange(false);
     }
-  }, [isMultiple, onChange, onBlur, handleOpenChange]);
+  }, [isMultiple, handleValueChange, handleOpenChange]);
 
   const handleRemoveItem = useCallback(
     (itemToRemove: V) => {
@@ -284,26 +291,14 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
           ? !isItemEqual(v, itemToRemove)
           : v !== itemToRemove
       );
-      (onChange as ((v: V[] | V | null) => void) | undefined)?.(next);
-      onBlur?.();
+      (handleValueChange as (v: V[] | V | null) => void)(next);
     },
-    [isMultiple, value, onChange, isItemEqual, onBlur],
+    [isMultiple, value, handleValueChange, isItemEqual],
   );
 
   const handleDismiss = useCallback(() => {
     handleOpenChange(false);
   }, [handleOpenChange]);
-
-  // Mark the field as touched on every value change so RHF revalidates
-  // immediately — especially important for multi-select where the popup
-  // stays open after toggling an item.
-  const handleValueChange: typeof onChange = useCallback(
-    (...args: Parameters<NonNullable<typeof onChange>>) => {
-      onChange?.(...args);
-      onBlur?.();
-    },
-    [onChange, onBlur],
-  );
 
   const renderItem = useCallback(
     (item: V) => (

--- a/packages/react-components/src/action-form/fields/FieldBridge.tsx
+++ b/packages/react-components/src/action-form/fields/FieldBridge.tsx
@@ -34,7 +34,6 @@ export interface FieldBridgeProps {
 const SELECT_LIKE_FIELDS: ReadonlySet<FieldComponent> = new Set<FieldComponent>(
   [
     "RADIO_BUTTONS",
-    "DROPDOWN",
     "SWITCH",
   ],
 );
@@ -61,6 +60,7 @@ export const FieldBridge: React.FC<FieldBridgeProps> = memo(
     });
 
     const isSelectLike = SELECT_LIKE_FIELDS.has(fieldDef.fieldComponent);
+    const isDropdown = fieldDef.fieldComponent === "DROPDOWN";
 
     const handleChange = useCallback(
       (newValue: unknown) => {
@@ -94,7 +94,11 @@ export const FieldBridge: React.FC<FieldBridgeProps> = memo(
         value={value}
         fieldDefinition={fieldDef}
         onFieldValueChange={handleChange}
-        onBlur={handleBlur}
+        // Dropdown fields own their blur signal because their popover renders
+        // in a portal outside the container div — the container-level blur
+        // would fire prematurely when the popover opens.
+        onBlur={isDropdown ? undefined : handleBlur}
+        onFieldBlur={isDropdown ? onBlur : undefined}
         error={fieldError?.message}
         portalContainer={portalContainer}
       />

--- a/packages/react-components/src/action-form/fields/FormFieldRenderer.tsx
+++ b/packages/react-components/src/action-form/fields/FormFieldRenderer.tsx
@@ -40,7 +40,9 @@ export interface FormFieldRendererProps {
   fieldDefinition: RendererFieldDefinition;
   value: unknown;
   onFieldValueChange: (value: unknown) => void;
-  onBlur: (e: React.FocusEvent<HTMLDivElement>) => void;
+  onBlur?: (e: React.FocusEvent<HTMLDivElement>) => void;
+  /** Field-level blur for fields that own their touched state (e.g. dropdowns). */
+  onFieldBlur?: () => void;
   error: string | undefined;
   portalContainer?: PortalContainer;
 }
@@ -51,6 +53,7 @@ export const FormFieldRenderer: React.FC<FormFieldRendererProps> = memo(
     value,
     onFieldValueChange,
     onBlur,
+    onFieldBlur,
     error,
     portalContainer,
   }: FormFieldRendererProps): React.ReactElement {
@@ -73,6 +76,7 @@ export const FormFieldRenderer: React.FC<FormFieldRendererProps> = memo(
           onFieldValueChange,
           error,
           portalContainer,
+          onFieldBlur,
         )}
       </FormField>
     );
@@ -85,6 +89,7 @@ function renderFieldComponent(
   onChange: (value: unknown) => void,
   error: string | undefined,
   portalContainer: PortalContainer | undefined,
+  onFieldBlur: (() => void) | undefined,
 ): React.ReactElement {
   switch (fieldDefinition.fieldComponent) {
     case "DATE_RANGE_INPUT":
@@ -136,6 +141,7 @@ function renderFieldComponent(
             fieldDefinition.fieldComponentProps,
             portalContainer,
           )}
+          onBlur={onFieldBlur}
         />
       );
     }


### PR DESCRIPTION
## Summary

- **DropdownField** now owns its blur/touched signal instead of relying on the container div's `onBlur` handler
- When a dropdown popover opens in a portal, focus leaves the container div, causing `FieldBridge`'s `handleBlur` to fire prematurely and trigger RHF validation before the user interacts
- Removed `DROPDOWN` from `SELECT_LIKE_FIELDS` in `FieldBridge` — dropdown fields receive RHF's `onBlur` directly via a new `onFieldBlur` prop threaded through `FormFieldRenderer`
- `DropdownField` calls `onBlur` on popover close and on value change (selection, clear, chip removal)
- Non-dropdown fields are unchanged

## Notes

FLUP to come to pass the `onBlur` to all fields and delegate calling to them, so we avoid special cases inside `FieldBridge`.

## Test plan

- Added tests: no blur on open, blur on dismiss, blur on selection (single/multi), blur on searchable dismiss
- Existing BaseForm validation tests pass unchanged