### PR TITLE
Mark @osdk/react-devtools as private to unblock releases

### DIFF
--- a/.changeset/tasty-shoes-heal.md
+++ b/.changeset/tasty-shoes-heal.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+Make react-devtools package private

--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -412,6 +412,7 @@ const archetypeRules = archetypes(
       react: true,
       output: OUTPUT_ESM_ONLY,
       cssExport: ["styles.css"],
+      private: true,
     },
   )
   .addArchetype(
@@ -484,11 +485,10 @@ const disallowWorkspaceCaret = createRuleFactory({
                 // always refetch in fixer since another fixer may have already changed the file
                 let packageJson = context.getPackageJson();
                 if (packageJson[d]) {
-                  packageJson[d] = Object.assign(
-                    {},
-                    packageJson[d],
-                    { [dep]: expected },
-                  );
+                  packageJson[d] = {
+                    ...packageJson[d],
+                    [dep]: expected,
+                  };
 
                   context.host.writeJson(
                     context.getPackageJsonPath(),
@@ -509,11 +509,10 @@ const disallowWorkspaceCaret = createRuleFactory({
             fixer: () => {
               let packageJson = context.getPackageJson();
               if (packageJson[d]?.[dep] === "workspace:~") {
-                packageJson[d] = Object.assign(
-                  {},
-                  packageJson[d],
-                  { [dep]: "workspace:^" },
-                );
+                packageJson[d] = {
+                  ...packageJson[d],
+                  [dep]: "workspace:^",
+                };
 
                 context.host.writeJson(
                   context.getPackageJsonPath(),
@@ -538,11 +537,10 @@ const disallowWorkspaceCaret = createRuleFactory({
               // always refetch in fixer since another fixer may have already changed the file
               let packageJson = context.getPackageJson();
               if (packageJson[d]?.[dep] === "workspace:^") {
-                packageJson[d] = Object.assign(
-                  {},
-                  packageJson[d],
-                  { [dep]: "workspace:~" },
-                );
+                packageJson[d] = {
+                  ...packageJson[d],
+                  [dep]: "workspace:~",
+                };
 
                 context.host.writeJson(
                   context.getPackageJsonPath(),

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -96,14 +96,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "files": [
-    "build/esm",
-    "build/types",
-    "CHANGELOG.md",
-    "package.json",
-    "templates",
-    "*.d.ts"
-  ],
+  "files": [],
   "module": "./build/esm/index.js",
   "types": "./build/types/index.d.ts",
   "sideEffects": [

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@osdk/react-devtools",
+  "private": true,
   "version": "0.6.0",
   "description": "Developer tools and debugging utilities for OSDK React Toolkit",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- Marks `@osdk/react-devtools` as `"private": true` to unblock the release pipeline
- The package was made public in #3173 but the `@osdk/react-devtools` package doesn't exist on the npm registry yet, causing `npm publish` to fail with a 404
- No published packages depend on `@osdk/react-devtools` — only the private `e2e.sandbox.officenetwork` package uses it via `workspace:~`

## Test plan
- [ ] Release pipeline no longer fails on `@osdk/react-devtools` publish