### PR TITLE
Fix boolean properties rendering as empty in ObjectTable

### DIFF
--- a/.changeset/object-table-boolean-fix.md
+++ b/.changeset/object-table-boolean-fix.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Fix boolean properties rendering as empty in ObjectTable

--- a/packages/react-components/src/object-table/DefaultCellRenderer.tsx
+++ b/packages/react-components/src/object-table/DefaultCellRenderer.tsx
@@ -24,6 +24,13 @@ import { isCellEditable } from "./utils/editableUtils.js";
 import { getCellId } from "./utils/getCellId.js";
 import { shouldShowEditableCell } from "./utils/shouldShowEditableCell.js";
 
+function toDisplayValue(value: unknown): React.ReactNode {
+  if (typeof value === "boolean") {
+    return String(value);
+  }
+  return value as React.ReactNode;
+}
+
 export function renderDefaultCell<TData extends RowData>(
   cellContext: CellContext<TData, unknown>,
 ): React.ReactNode {
@@ -57,12 +64,12 @@ export function renderDefaultCell<TData extends RowData>(
     if (meta?.isInEditMode) {
       return (
         <span className={styles.nonEditableCellInEditMode}>
-          {cellValue as React.ReactNode}
+          {toDisplayValue(cellValue)}
         </span>
       );
     }
 
-    return <>{cellValue}</>;
+    return <>{toDisplayValue(cellValue)}</>;
   }
 
   const rowId = cellContext.row.id;

--- a/packages/react-components/src/object-table/__tests__/DefaultCellRenderer.test.tsx
+++ b/packages/react-components/src/object-table/__tests__/DefaultCellRenderer.test.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { CellContext } from "@tanstack/react-table";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { renderDefaultCell } from "../DefaultCellRenderer.js";
+
+function createCellContext(
+  value: unknown,
+): CellContext<unknown, unknown> {
+  return {
+    getValue: () => value,
+    table: { options: { meta: undefined } },
+    column: { columnDef: { meta: undefined } },
+    row: { original: {}, id: "row-0" },
+  } as unknown as CellContext<unknown, unknown>;
+}
+
+describe("renderDefaultCell", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("should render boolean true as 'true'", () => {
+    const result = renderDefaultCell(createCellContext(true));
+    render(<div data-testid="cell">{result}</div>);
+    expect(screen.getByTestId("cell").textContent).toBe("true");
+  });
+
+  it("should render boolean false as 'false'", () => {
+    const result = renderDefaultCell(createCellContext(false));
+    render(<div data-testid="cell">{result}</div>);
+    expect(screen.getByTestId("cell").textContent).toBe("false");
+  });
+
+  it("should render string values", () => {
+    const result = renderDefaultCell(createCellContext("hello"));
+    render(<div data-testid="cell">{result}</div>);
+    expect(screen.getByTestId("cell").textContent).toBe("hello");
+  });
+
+  it("should render number values", () => {
+    const result = renderDefaultCell(createCellContext(42));
+    render(<div data-testid="cell">{result}</div>);
+    expect(screen.getByTestId("cell").textContent).toBe("42");
+  });
+
+  it("should render null as empty", () => {
+    const result = renderDefaultCell(createCellContext(null));
+    render(<div data-testid="cell">{result}</div>);
+    expect(screen.getByTestId("cell").textContent).toBe("");
+  });
+
+  it("should render undefined as empty", () => {
+    const result = renderDefaultCell(createCellContext(undefined));
+    render(<div data-testid="cell">{result}</div>);
+    expect(screen.getByTestId("cell").textContent).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

- Boolean property columns in `ObjectTable` rendered as empty because React does not render boolean values (`true`/`false`) as JSX children
- Added a `toDisplayValue` helper in `DefaultCellRenderer.tsx` that converts booleans to their string representation before passing to JSX
- Affects both normal read-only cells and non-editable cells in edit mode

## Root Cause

`DefaultCellRenderer` was returning `<>{cellValue}</>` directly. When `cellValue` is a boolean, React silently ignores it (this is by design — it's how `{condition && <Component />}` avoids rendering "false"). The editable cell path already handled this correctly via its `valueToString` helper, but the read-only path did not.

## Test plan

- [x] Added `DefaultCellRenderer.test.tsx` covering boolean true/false, string, number, null, and undefined values
- [x] `pnpm turbo typecheck --filter=@osdk/react-components` passes
- [x] `pnpm turbo test --filter=@osdk/react-components` — all tests pass
- [x] Manual verification: render an `ObjectTable` with a boolean property column and confirm values display as "true"/"false"