### PR TITLE
Strip time from onChange when showTime=false + small UI update

### DIFF
--- a/.changeset/gentle-moons-dance.md
+++ b/.changeset/gentle-moons-dance.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Strip time to local midnight in DatetimePickerField onChange when showTime is false

--- a/packages/react-components/src/action-form/__tests__/DatetimePickerField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/DatetimePickerField.test.tsx
@@ -161,6 +161,55 @@ describe("DatetimePickerField", () => {
       expect(onChange).not.toHaveBeenCalled();
     });
 
+    it("enables Today button when max is today at midnight", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2024, 6, 4, 9, 30));
+      const onChange = vi.fn();
+      render(
+        <DatetimePickerField
+          value={null}
+          onChange={onChange}
+          max={new Date(2024, 6, 4)}
+        />,
+      );
+      fireEvent.focus(screen.getByRole("combobox"));
+
+      const todayButton = screen.getByRole("button", {
+        name: "Today",
+      }) as HTMLButtonElement;
+      // max is today's date — the button should be enabled even though
+      // the current wall-clock time (9:30am) is after midnight.
+      expect(todayButton.disabled).toBe(false);
+      fireEvent.click(todayButton);
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange.mock.calls[0][0]).toEqual(new Date(2024, 6, 4));
+    });
+
+    it("preserves wall-clock time when selecting today with showTime", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2024, 6, 4, 9, 30));
+      const onChange = vi.fn();
+      render(
+        <DatetimePickerField
+          value={null}
+          onChange={onChange}
+          showTime={true}
+        />,
+      );
+      fireEvent.focus(screen.getByRole("combobox"));
+
+      fireEvent.click(screen.getByRole("button", { name: "Today" }));
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const calledDate: Date = onChange.mock.calls[0][0];
+      expect(calledDate.getFullYear()).toBe(2024);
+      expect(calledDate.getMonth()).toBe(6);
+      expect(calledDate.getDate()).toBe(4);
+      expect(calledDate.getHours()).toBe(9);
+      expect(calledDate.getMinutes()).toBe(30);
+    });
+
     it("clears the selected date from the calendar action bar", () => {
       const onChange = vi.fn();
       render(

--- a/packages/react-components/src/action-form/fields/DateCalendar.module.css
+++ b/packages/react-components/src/action-form/fields/DateCalendar.module.css
@@ -81,7 +81,7 @@
 }
 
 .calendarDayButton.calendarToday {
-  font-weight: var(--osdk-datetime-calendar-today-font-weight);
+  border: var(--osdk-datetime-calendar-today-border);
 }
 
 .calendarDayButton.calendarOutside {

--- a/packages/react-components/src/action-form/fields/DateCalendar.tsx
+++ b/packages/react-components/src/action-form/fields/DateCalendar.tsx
@@ -101,13 +101,13 @@ export default function DateCalendar({
 
   const fromYear = min != null ? min.getFullYear() : DEFAULT_FROM_YEAR;
   const toYear = max != null ? max.getFullYear() : DEFAULT_TO_YEAR;
-  const today = getLocalToday();
+  const today = new Date();
   const isTodaySelectable = isDateInRange(today, min, max);
   const handleTodayClick = useCallback(() => {
     if (!isTodaySelectable) {
       return;
     }
-    onSelect(getLocalToday());
+    onSelect(new Date());
   }, [isTodaySelectable, onSelect]);
 
   const calendarFooter = (
@@ -125,11 +125,7 @@ export default function DateCalendar({
           {todayButtonText}
         </ActionButton>
         {onClear != null && (
-          <ActionButton
-            type="button"
-            appearance="minimal"
-            onClick={onClear}
-          >
+          <ActionButton type="button" appearance="minimal" onClick={onClear}>
             {clearButtonText}
           </ActionButton>
         )}
@@ -159,12 +155,4 @@ export default function DateCalendar({
       fixedWeeks={true}
     />
   );
-}
-
-function getLocalToday(): Date {
-  const today = new Date();
-  // Date-only picker actions should match calendar-day selection, which emits
-  // local midnight rather than the current wall-clock time.
-  today.setHours(0, 0, 0, 0);
-  return today;
 }

--- a/packages/react-components/src/action-form/fields/DateCalendar.tsx
+++ b/packages/react-components/src/action-form/fields/DateCalendar.tsx
@@ -102,7 +102,14 @@ export default function DateCalendar({
   const fromYear = min != null ? min.getFullYear() : DEFAULT_FROM_YEAR;
   const toYear = max != null ? max.getFullYear() : DEFAULT_TO_YEAR;
   const today = new Date();
-  const isTodaySelectable = isDateInRange(today, min, max);
+  // Compare at midnight so the Today button stays enabled when min/max are
+  // set to today's date at midnight (the common case for date-only bounds).
+  const todayMidnight = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate(),
+  );
+  const isTodaySelectable = isDateInRange(todayMidnight, min, max);
   const handleTodayClick = useCallback(() => {
     if (!isTodaySelectable) {
       return;

--- a/packages/react-components/src/action-form/fields/DatetimePickerField.tsx
+++ b/packages/react-components/src/action-form/fields/DatetimePickerField.tsx
@@ -82,6 +82,29 @@ export const DatetimePickerField: React.NamedExoticComponent<
   const parseFn = parseDate
     ?? (showTime ? parseDatetimeFromInput : parseDateFromInput);
 
+  // Single normalization gate: when the time picker is hidden, strip
+  // hours/minutes/seconds so consumers receive a pure calendar date (local
+  // midnight). Defined before useDateEditState so the hook's commit path also
+  // goes through this gate.
+  const handleChange = useCallback(
+    (date: Date | null) => {
+      if (onChange == null) {
+        return;
+      }
+      if (date != null && !showTime) {
+        const dateOnly = new Date(
+          date.getFullYear(),
+          date.getMonth(),
+          date.getDate(),
+        );
+        onChange(dateOnly);
+      } else {
+        onChange(date);
+      }
+    },
+    [onChange, showTime],
+  );
+
   const {
     isEditing,
     displayedValue,
@@ -99,7 +122,7 @@ export const DatetimePickerField: React.NamedExoticComponent<
     parseFn,
     min,
     max,
-    onChange,
+    onChange: handleChange,
   });
 
   // --- Input event handlers ---
@@ -205,7 +228,7 @@ export const DatetimePickerField: React.NamedExoticComponent<
   const handleCalendarSelect = useCallback(
     (selected: Date | undefined) => {
       if (selected == null) {
-        onChange?.(null);
+        handleChange(null);
         setInputValue("");
         return;
       }
@@ -215,7 +238,7 @@ export const DatetimePickerField: React.NamedExoticComponent<
         date.setHours(value.getHours(), value.getMinutes());
       }
 
-      onChange?.(date);
+      handleChange(date);
       setDateValue(date);
       setVisibleCalendarMonth(date);
 
@@ -224,7 +247,7 @@ export const DatetimePickerField: React.NamedExoticComponent<
       }
     },
     [
-      onChange,
+      handleChange,
       showTime,
       value,
       shouldCloseOnSelection,
@@ -236,16 +259,16 @@ export const DatetimePickerField: React.NamedExoticComponent<
 
   const handleTimeChange = useCallback(
     (time: Date) => {
-      onChange?.(time);
+      handleChange(time);
       setDateValue(time);
     },
-    [onChange, setDateValue],
+    [handleChange, setDateValue],
   );
 
   const handleCalendarClear = useCallback(() => {
-    onChange?.(null);
+    handleChange(null);
     setDateValue(null);
-  }, [onChange, setDateValue]);
+  }, [handleChange, setDateValue]);
 
   // --- Focus boundary handlers ---
   // Visually-hidden elements at the start/end of the popover that trap Tab

--- a/packages/react-components/src/tokens/component-tokens/datetime-picker.css
+++ b/packages/react-components/src/tokens/component-tokens/datetime-picker.css
@@ -49,9 +49,8 @@
   --osdk-datetime-calendar-selected-hover-bg: var(--osdk-intent-primary-hover);
 
   /* Calendar today */
-  --osdk-datetime-calendar-today-font-weight: var(
-    --osdk-typography-weight-bold
-  );
+  --osdk-datetime-calendar-today-border: 1px solid
+    var(--osdk-input-border-color);
 
   /* Calendar range middle (days between start and end) */
   --osdk-datetime-calendar-range-middle-bg: color-mix(


### PR DESCRIPTION
## Summary

- Move time-stripping responsibility from `DateCalendar` (`getLocalToday`) into `DatetimePickerField` via a single `handleChange` normalization gate
- When `showTime=false`, all `onChange` paths now emit dates at local midnight regardless of source (calendar click, Today button, typed input)
- When `showTime=true`, time is preserved as before
- Use border vs bolder font to highlight today like in Blueprint

## Test plan

- [ ] Existing `DatetimePickerField` tests pass
- [ ] "Today" button emits midnight when `showTime=false`
- [ ] Calendar day selection emits midnight when `showTime=false`
- [ ] Time is preserved when `showTime=true` and a calendar day is selected
- [ ] Verify in Storybook that date-only and datetime pickers behave correctly

<img width="592" height="553" alt="Screenshot 2026-05-11 at 12 51 16" src="https://github.com/user-attachments/assets/2b8f3c96-f828-4088-8a8e-9febbcb5b6bf" />

