### PR TITLE
Pin form footer in height-constrained containers

### DIFF
--- a/.changeset/gentle-clouds-drift.md
+++ b/.changeset/gentle-clouds-drift.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Pin form footer in height-constrained containers so fields scroll independently

--- a/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
@@ -1125,6 +1125,137 @@ export const InsideBlueprintDialog: Story = {
   },
 };
 
+const scrollableDialogFormContent: ReadonlyArray<FormContentItem> = [
+  field({
+    fieldKey: "name",
+    fieldComponent: "TEXT_INPUT",
+    label: "Full Name",
+    isRequired: true,
+    fieldComponentProps: { placeholder: "Enter full name" },
+  }),
+  field({
+    fieldKey: "email",
+    fieldComponent: "TEXT_INPUT",
+    label: "Email",
+    isRequired: true,
+    fieldComponentProps: { placeholder: "user@example.com" },
+  }),
+  field({
+    fieldKey: "department",
+    fieldComponent: "DROPDOWN",
+    label: "Department",
+    fieldComponentProps: {
+      items: DEPARTMENT_ITEMS,
+      placeholder: "Select department...",
+    },
+  }),
+  field({
+    fieldKey: "startDate",
+    fieldComponent: "DATETIME_PICKER",
+    label: "Start Date",
+    fieldComponentProps: { placeholder: "Select a date" },
+  }),
+  field({
+    fieldKey: "priority",
+    fieldComponent: "DROPDOWN",
+    label: "Priority",
+    fieldComponentProps: {
+      items: DROPDOWN_ITEMS,
+      placeholder: "Select priority",
+    },
+  }),
+  field({
+    fieldKey: "isActive",
+    fieldComponent: "RADIO_BUTTONS",
+    label: "Status",
+    fieldComponentProps: {
+      options: [
+        { label: "Active", value: true },
+        { label: "Inactive", value: false },
+      ],
+    },
+  }),
+  field({
+    fieldKey: "bio",
+    fieldComponent: "TEXT_AREA",
+    label: "Bio",
+    fieldComponentProps: { placeholder: "Tell us about yourself", rows: 3 },
+  }),
+  field({
+    fieldKey: "tags",
+    fieldComponent: "DROPDOWN",
+    label: "Tags",
+    fieldComponentProps: {
+      items: TAG_ITEMS,
+      isMultiple: true,
+      isSearchable: true,
+      placeholder: "Search tags...",
+    },
+  }),
+  field({
+    fieldKey: "document",
+    fieldComponent: "FILE_PICKER",
+    label: "Resume",
+    fieldComponentProps: { accept: ".pdf,.doc,.docx" },
+  }),
+  field({
+    fieldKey: "notes",
+    fieldComponent: "TEXT_AREA",
+    label: "Additional Notes",
+    fieldComponentProps: { placeholder: "Any extra details", rows: 2 },
+  }),
+];
+
+function ScrollableDialogBaseForm(): React.ReactElement {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleOpen = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  return (
+    <>
+      <Button text="Open dialog" onClick={handleOpen} />
+      <Dialog
+        className="osdkBlueprintDialogForm"
+        isOpen={isOpen}
+        onClose={handleClose}
+        title="New employee"
+      >
+        <BaseForm
+          formContent={scrollableDialogFormContent}
+          onSubmit={handleSubmit}
+        />
+      </Dialog>
+    </>
+  );
+}
+
+export const ScrollableDialogForm: Story = {
+  render: () => <ScrollableDialogBaseForm />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "When the form has many fields inside a height-constrained container like a dialog, the fields area scrolls while the footer stays pinned at the bottom.",
+      },
+      source: {
+        code:
+          `// The footer pins automatically when the form overflows its container.
+// No extra CSS or props needed — just place BaseForm inside a
+// height-constrained parent (dialog, panel, sidebar).
+<Dialog isOpen={true} title="New employee">
+  <BaseForm formContent={manyFields} onSubmit={handleSubmit} />
+</Dialog>`,
+      },
+    },
+  },
+};
+
 const dateRangeFormContent: ReadonlyArray<FormContentItem> = [
   field({
     fieldKey: "vacationDates",

--- a/packages/react-components-storybook/src/styles/storybook.css
+++ b/packages/react-components-storybook/src/styles/storybook.css
@@ -92,6 +92,7 @@ body {
   --osdk-form-content-padding-block: calc(var(--osdk-surface-spacing) * 4);
 
   width: min(480px, calc(100vw - calc(var(--osdk-surface-spacing) * 8)));
+  max-height: calc(100vh - calc(var(--osdk-surface-spacing) * 16));
 }
 
 .osdkCustomTextarea {

--- a/packages/react-components/src/action-form/BaseForm.module.css
+++ b/packages/react-components/src/action-form/BaseForm.module.css
@@ -18,6 +18,9 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  /* Override min-height:auto so the form can shrink inside flex parents
+     with constrained height (e.g. dialogs with max-height). */
+  min-height: 0;
 }
 
 .osdkFormFields {
@@ -26,6 +29,13 @@
   gap: var(--osdk-form-fields-gap);
   padding-block: var(--osdk-form-content-padding-block);
   padding-inline: var(--osdk-form-content-padding-inline);
+  /* When the form lives inside a height-constrained parent (dialog, panel),
+     the fields area shrinks and scrolls while the footer stays pinned.
+     flex-basis stays auto so the dialog sizes to content naturally;
+     min-height: 0 lets it shrink below content when constrained. */
+  flex-grow: 1;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .osdkFormFooter {
@@ -36,6 +46,7 @@
   padding-block: var(--osdk-form-content-padding-inline);
   padding-inline: var(--osdk-form-content-padding-inline);
   border-block-start: var(--osdk-surface-border-width) solid var(--osdk-form-footer-border-color);
+  flex-shrink: 0;
 }
 
 .osdkFormSubmitButton {


### PR DESCRIPTION
## Summary
- When BaseForm lives inside a flex parent with constrained height (dialog, panel, sidebar), the fields area now scrolls while the footer stays pinned at the bottom
- Purely CSS changes — no API or behavior changes for unconstrained contexts
- Added `ScrollableDialogForm` storybook story demonstrating the pinning behavior

## Test plan
- [x] Open Storybook **BaseForm > Default** — all fields render at natural height, no scrolling, no visual change
- [x] Open Storybook **BaseForm > Scrollable Dialog Form** — click "Open dialog", verify footer is pinned and fields scroll
- [x] Open Storybook **BaseForm > Inside Blueprint Dialog** — verify no regression

<img width="1506" height="830" alt="Screenshot 2026-05-11 at 13 50 40" src="https://github.com/user-attachments/assets/78ba45e5-ed9d-4701-ad0c-2bf07fe7af2e" />
