### PR TITLE
Bump CI Build and Test timeout from 25 to 30 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
 
   build:
     name: Build and Test
-    timeout-minutes: 25
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Raise the `Build and Test` job `timeout-minutes` in `.github/workflows/ci.yml` from 25 → 30 to give jobs more headroom before being killed.

## Test plan
- [ ] CI passes on this PR