### PR TITLE
Fix filter list dropdown positioning and visibility

### DIFF
--- a/.changeset/fix-filter-dropdown-positioning.md
+++ b/.changeset/fix-filter-dropdown-positioning.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Fix filter list dropdown positioning: flip above trigger when near container bottom, hide when anchor scrolls out of view

--- a/packages/react-components/src/base-components/combobox/Combobox.module.css
+++ b/packages/react-components/src/base-components/combobox/Combobox.module.css
@@ -312,6 +312,13 @@
      navigation. Keep visible focus on the trigger/input or highlighted option
      instead of drawing a browser-default ring around this wrapper. */
   outline: none;
+
+  /* Hide the popup when its anchor scrolls out of view (e.g. inside a
+     scrollable sidebar). @base-ui/react sets this attribute automatically
+     via floating-ui's hide middleware. */
+  &[data-anchor-hidden] {
+    visibility: hidden;
+  }
 }
 
 .osdkComboboxPopup {

--- a/packages/react-components/src/base-components/searchable-menu/SearchableMenu.module.css
+++ b/packages/react-components/src/base-components/searchable-menu/SearchableMenu.module.css
@@ -16,6 +16,10 @@
 
 .positioner {
   z-index: var(--osdk-surface-z-index-3);
+
+  &[data-anchor-hidden] {
+    visibility: hidden;
+  }
 }
 
 .popup {

--- a/packages/react-components/src/base-components/searchable-menu/SearchableMenu.tsx
+++ b/packages/react-components/src/base-components/searchable-menu/SearchableMenu.tsx
@@ -34,6 +34,7 @@ interface SearchableMenuProps {
   searchPlaceholder?: string;
   emptyMessage?: string;
   className?: string;
+  collisionBoundary?: Element | Element[] | "clipping-ancestors";
 }
 
 function SearchableMenuInner({
@@ -45,6 +46,7 @@ function SearchableMenuInner({
   searchPlaceholder = "Search",
   emptyMessage = "No matching items",
   className,
+  collisionBoundary,
 }: SearchableMenuProps): React.ReactElement {
   const [searchQuery, setSearchQuery] = useState("");
 
@@ -86,6 +88,7 @@ function SearchableMenuInner({
         <Menu.Positioner
           className={classnames(styles.positioner, className)}
           sideOffset={4}
+          collisionBoundary={collisionBoundary}
         >
           <Menu.Popup className={styles.popup}>
             <SearchBar

--- a/packages/react-components/src/base-components/select/Select.module.css
+++ b/packages/react-components/src/base-components/select/Select.module.css
@@ -214,6 +214,10 @@
      navigation. Keep the visual focus affordance on the active option instead
      of drawing a browser-default ring around this non-interactive wrapper. */
   outline: none;
+
+  &[data-anchor-hidden] {
+    visibility: hidden;
+  }
 }
 
 .osdkSelectPopup {

--- a/packages/react-components/src/filter-list/base/AddFilterPopover.tsx
+++ b/packages/react-components/src/filter-list/base/AddFilterPopover.tsx
@@ -17,6 +17,7 @@
 import React, { memo } from "react";
 import { SearchableMenu } from "../../base-components/searchable-menu/SearchableMenu.js";
 import styles from "./AddFilterPopover.module.css";
+import { useFilterListBoundary } from "./FilterListBoundaryContext.js";
 
 interface HiddenFilterItem {
   key: string;
@@ -34,6 +35,8 @@ function AddFilterPopoverInner({
   onShowFilter,
   renderTrigger,
 }: AddFilterPopoverProps): React.ReactElement {
+  const collisionBoundary = useFilterListBoundary();
+
   return (
     <SearchableMenu
       items={hiddenDefinitions}
@@ -42,6 +45,7 @@ function AddFilterPopoverInner({
       triggerClassName={renderTrigger == null ? styles.trigger : undefined}
       searchPlaceholder="Search filters"
       emptyMessage="No matching filters"
+      collisionBoundary={collisionBoundary}
     />
   );
 }

--- a/packages/react-components/src/filter-list/base/BaseFilterList.tsx
+++ b/packages/react-components/src/filter-list/base/BaseFilterList.tsx
@@ -16,10 +16,11 @@
 
 import { Button } from "@base-ui/react/button";
 import classnames from "classnames";
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import type { BaseFilterListProps } from "./BaseFilterListApi.js";
 import { ExpandIcon } from "./FilterIcons.js";
 import styles from "./FilterList.module.css";
+import { FilterListBoundaryProvider } from "./FilterListBoundaryContext.js";
 import { FilterListContent } from "./FilterListContent.js";
 import { FilterListHeader } from "./FilterListHeader.js";
 
@@ -50,6 +51,10 @@ export function BaseFilterList<D>(
     renderAddFilterButton,
   } = props;
 
+  const [boundaryElement, setBoundaryElement] = useState<HTMLDivElement | null>(
+    null,
+  );
+
   const showHeader = title || titleIcon || showResetButton
     || showActiveFilterCount || onCollapsedChange;
 
@@ -79,55 +84,58 @@ export function BaseFilterList<D>(
         </div>
       )}
       <div
+        ref={setBoundaryElement}
         className={classnames(
           styles.expandedContent,
           isCollapsed && styles.hiddenContent,
         )}
         data-active-count={activeFilterCount}
       >
-        {showHeader && (
-          <FilterListHeader
-            title={title}
-            titleIcon={titleIcon}
-            collapsed={collapsed}
-            onCollapsedChange={onCollapsedChange}
-            showResetButton={showResetButton}
-            onReset={onReset}
-            showActiveFilterCount={showActiveFilterCount}
-            activeFilterCount={activeFilterCount}
-            hasVisibilityChanges={hasVisibilityChanges}
-          />
-        )}
+        <FilterListBoundaryProvider value={boundaryElement}>
+          {showHeader && (
+            <FilterListHeader
+              title={title}
+              titleIcon={titleIcon}
+              collapsed={collapsed}
+              onCollapsedChange={onCollapsedChange}
+              showResetButton={showResetButton}
+              onReset={onReset}
+              showActiveFilterCount={showActiveFilterCount}
+              activeFilterCount={activeFilterCount}
+              hasVisibilityChanges={hasVisibilityChanges}
+            />
+          )}
 
-        <div className={styles.scrollableContent}>
-          <FilterListContent
-            filterDefinitions={filterDefinitions}
-            filterStates={filterStates}
-            onFilterStateChanged={onFilterStateChanged}
-            onFilterRemoved={onFilterRemoved}
-            onOrderChange={onOrderChange}
-            renderInput={renderInput}
-            getFilterKey={getFilterKey}
-            getFilterLabel={getFilterLabel}
-            enableSorting={enableSorting}
-          />
-        </div>
-
-        {showAddButton && (
-          <div className={styles.addButtonContainer}>
-            {renderAddFilterButton
-              ? renderAddFilterButton()
-              : (
-                <Button
-                  type="button"
-                  className={styles.addButton}
-                  onClick={onFilterAdded}
-                >
-                  + Add filter
-                </Button>
-              )}
+          <div className={styles.scrollableContent}>
+            <FilterListContent
+              filterDefinitions={filterDefinitions}
+              filterStates={filterStates}
+              onFilterStateChanged={onFilterStateChanged}
+              onFilterRemoved={onFilterRemoved}
+              onOrderChange={onOrderChange}
+              renderInput={renderInput}
+              getFilterKey={getFilterKey}
+              getFilterLabel={getFilterLabel}
+              enableSorting={enableSorting}
+            />
           </div>
-        )}
+
+          {showAddButton && (
+            <div className={styles.addButtonContainer}>
+              {renderAddFilterButton
+                ? renderAddFilterButton()
+                : (
+                  <Button
+                    type="button"
+                    className={styles.addButton}
+                    onClick={onFilterAdded}
+                  >
+                    + Add filter
+                  </Button>
+                )}
+            </div>
+          )}
+        </FilterListBoundaryProvider>
       </div>
     </div>
   );

--- a/packages/react-components/src/filter-list/base/ExcludeDropdown.module.css
+++ b/packages/react-components/src/filter-list/base/ExcludeDropdown.module.css
@@ -50,6 +50,10 @@
 
 .positioner {
   z-index: var(--osdk-surface-z-index-3);
+
+  &[data-anchor-hidden] {
+    visibility: hidden;
+  }
 }
 
 .popup {

--- a/packages/react-components/src/filter-list/base/ExcludeDropdown.tsx
+++ b/packages/react-components/src/filter-list/base/ExcludeDropdown.tsx
@@ -18,6 +18,7 @@ import { Menu } from "@base-ui/react/menu";
 import React, { memo, useCallback } from "react";
 import styles from "./ExcludeDropdown.module.css";
 import { CheckIcon, ChevronDownIcon, ExcludeIcon } from "./FilterIcons.js";
+import { useFilterListBoundary } from "./FilterListBoundaryContext.js";
 
 interface ExcludeDropdownProps {
   isExcluding: boolean;
@@ -28,6 +29,7 @@ function ExcludeDropdownInner({
   isExcluding,
   onToggleExclude,
 }: ExcludeDropdownProps): React.ReactElement {
+  const collisionBoundary = useFilterListBoundary();
   const label = isExcluding ? "Excluding" : "Keeping";
 
   const handleSelectKeeping = useCallback(() => {
@@ -57,7 +59,11 @@ function ExcludeDropdownInner({
           <ChevronDownIcon />
         </Menu.Trigger>
         <Menu.Portal>
-          <Menu.Positioner className={styles.positioner} sideOffset={4}>
+          <Menu.Positioner
+            className={styles.positioner}
+            sideOffset={4}
+            collisionBoundary={collisionBoundary}
+          >
             <Menu.Popup className={styles.popup}>
               <Menu.Item
                 className={styles.menuItem}

--- a/packages/react-components/src/filter-list/base/FilterListBoundaryContext.ts
+++ b/packages/react-components/src/filter-list/base/FilterListBoundaryContext.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext, useContext } from "react";
+
+/**
+ * Provides the filter list container element so that dropdown positioners
+ * inside the filter list can use it as their collision boundary, flipping
+ * above the trigger when space below is insufficient within the sidebar.
+ */
+const FilterListBoundaryContext = createContext<Element | null>(null);
+
+export const FilterListBoundaryProvider = FilterListBoundaryContext.Provider;
+
+export function useFilterListBoundary(): Element | undefined {
+  return useContext(FilterListBoundaryContext) ?? undefined;
+}

--- a/packages/react-components/src/filter-list/base/FilterListBoundaryContext.ts
+++ b/packages/react-components/src/filter-list/base/FilterListBoundaryContext.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type React from "react";
 import { createContext, useContext } from "react";
 
 /**
@@ -23,7 +24,8 @@ import { createContext, useContext } from "react";
  */
 const FilterListBoundaryContext = createContext<Element | null>(null);
 
-export const FilterListBoundaryProvider = FilterListBoundaryContext.Provider;
+export const FilterListBoundaryProvider: React.Provider<Element | null> =
+  FilterListBoundaryContext.Provider;
 
 export function useFilterListBoundary(): Element | undefined {
   return useContext(FilterListBoundaryContext) ?? undefined;

--- a/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.tsx
@@ -19,6 +19,7 @@ import React, { memo, useCallback, useMemo } from "react";
 import { Combobox } from "../../../base-components/combobox/Combobox.js";
 import type { PropertyAggregationValue } from "../../types/AggregationTypes.js";
 import { isEmptyValue } from "../../utils/filterValues.js";
+import { useFilterListBoundary } from "../FilterListBoundaryContext.js";
 import styles from "./MultiSelectInput.module.css";
 import { NoValueLabel } from "./NoValueLabel.js";
 import sharedStyles from "./shared.module.css";
@@ -50,6 +51,8 @@ function MultiSelectInputInner({
   ariaLabel = "Search values",
   renderValue,
 }: MultiSelectInputProps): React.ReactElement {
+  const collisionBoundary = useFilterListBoundary();
+
   const handleValueChange = useCallback(
     (newValues: string[] | null) => {
       onChange(newValues ?? []);
@@ -161,7 +164,7 @@ function MultiSelectInputInner({
           </Combobox.Chips>
 
           <Combobox.Portal>
-            <Combobox.Positioner>
+            <Combobox.Positioner collisionBoundary={collisionBoundary}>
               <Combobox.Popup>
                 <Combobox.Empty>No matching options</Combobox.Empty>
                 <Combobox.List>{renderItem}</Combobox.List>

--- a/packages/react-components/src/filter-list/base/inputs/SingleSelectInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/SingleSelectInput.tsx
@@ -19,6 +19,7 @@ import React, { memo, useCallback, useMemo } from "react";
 import { Combobox } from "../../../base-components/combobox/Combobox.js";
 import type { PropertyAggregationValue } from "../../types/AggregationTypes.js";
 import { isEmptyValue } from "../../utils/filterValues.js";
+import { useFilterListBoundary } from "../FilterListBoundaryContext.js";
 import { NoValueLabel } from "./NoValueLabel.js";
 import sharedStyles from "./shared.module.css";
 import styles from "./SingleSelectInput.module.css";
@@ -52,6 +53,8 @@ function SingleSelectInputInner({
   ariaLabel = "Select value",
   renderValue,
 }: SingleSelectInputProps): React.ReactElement {
+  const collisionBoundary = useFilterListBoundary();
+
   const handleValueChange = useCallback(
     (value: string | null) => {
       onChange(value ?? undefined);
@@ -140,7 +143,7 @@ function SingleSelectInputInner({
               <Combobox.Clear className={styles.clearButton} />
             )}
             <Combobox.Portal>
-              <Combobox.Positioner>
+              <Combobox.Positioner collisionBoundary={collisionBoundary}>
                 <Combobox.Popup>
                   <Combobox.Empty>No matching options</Combobox.Empty>
                   <Combobox.List>{renderItem}</Combobox.List>

--- a/packages/react-components/src/filter-list/base/inputs/TextTagsInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/TextTagsInput.tsx
@@ -20,6 +20,7 @@ import React, { memo, useCallback, useMemo, useState } from "react";
 import { Combobox } from "../../../base-components/combobox/Combobox.js";
 import type { PropertyAggregationValue } from "../../types/AggregationTypes.js";
 import { isEmptyValue } from "../../utils/filterValues.js";
+import { useFilterListBoundary } from "../FilterListBoundaryContext.js";
 import { NoValueLabel } from "./NoValueLabel.js";
 import sharedStyles from "./shared.module.css";
 import styles from "./TextTagsInput.module.css";
@@ -81,6 +82,7 @@ function TextTagsInputInner({
   suggestionLimit = 10,
   ariaLabel = "Add tag",
 }: TextTagsInputProps): React.ReactElement {
+  const collisionBoundary = useFilterListBoundary();
   const [inputValue, setInputValue] = useState("");
 
   const filteredSuggestions = useMemo(() => {
@@ -198,7 +200,7 @@ function TextTagsInputInner({
         />
 
         <Combobox.Portal>
-          <Combobox.Positioner>
+          <Combobox.Positioner collisionBoundary={collisionBoundary}>
             <Combobox.Popup>
               {filteredSuggestions.length === 0
                 ? (


### PR DESCRIPTION
## Summary

- **Flip dropdowns above trigger** when there isn't enough space below within the filter sidebar container. Previously, portaled popups used the viewport as their collision boundary, so they'd overflow the sidebar without flipping.
- **Hide dropdowns when anchor scrolls out of view** — when the filter input scrolls off-screen inside the sidebar's scrollable area, the dropdown disappears via `visibility: hidden` (leveraging `@base-ui/react`'s built-in `data-anchor-hidden` attribute).

### How it works

**Flipping:** A `FilterListBoundaryContext` provides the sidebar's `.expandedContent` element as a custom `collisionBoundary` to all dropdown positioners within the filter list. This tells `@base-ui/react`'s positioning engine to flip based on the sidebar boundary instead of the viewport.

**Hiding:** Added `&[data-anchor-hidden] { visibility: hidden }` to positioner CSS for Combobox, Select, SearchableMenu, and ExcludeDropdown. `@base-ui/react` already detects when the anchor scrolls out of its clipping ancestors and sets this attribute — we just needed to style it.

## Demo

<!-- Drop a screen recording here showing the flip + hide behavior -->

https://github.com/user-attachments/assets/1dde52af-53cd-44a2-aa71-9971b1f13151

## Test plan

- [x] Open filter sidebar with several filters visible
- [x] Expand a filter near the bottom of the sidebar — dropdown should flip above the trigger
- [x] Scroll the sidebar while a dropdown is open — dropdown should disappear when the input scrolls out of view
- [x] Verify filters near the top still open downward normally
- [x] Verify the "Add filter" popover and Exclude/Keep dropdown also flip and hide correctly