### PR TITLE
fix filter-list combobox flash on sibling refetch

### DIFF
--- a/.changeset/filter-list-select-stable-data.md
+++ b/.changeset/filter-list-select-stable-data.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Fix layout flash in FilterList multi-select and single-select inputs during sibling-aggregation refetch. Previously, when a listogram checkbox toggled and triggered a refetch in sibling filters, MULTI_SELECT and SINGLE_SELECT inputs briefly stacked "Loading options..." and "Updating..." above the combobox, pushing the panel layout down and snapping back when the fetch completed. Both inputs now use the same useStableData pattern already used by ListogramInput and RangeInput: the last non-loading values are preserved across refetch so the combobox stays mounted with its prior options and chips, with no inline loading hint. The "Loading options..." empty-state still shows on genuine first load; "No options available" still shows when the aggregation resolves to empty.

--- a/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.tsx
@@ -22,6 +22,7 @@ import { isEmptyValue } from "../../utils/filterValues.js";
 import styles from "./MultiSelectInput.module.css";
 import { NoValueLabel } from "./NoValueLabel.js";
 import sharedStyles from "./shared.module.css";
+import { useStableData } from "./useStableData.js";
 
 interface MultiSelectInputProps {
   values: PropertyAggregationValue[];
@@ -57,14 +58,16 @@ function MultiSelectInputInner({
     [onChange],
   );
 
+  const stableValues = useStableData(values, isLoading);
+
   const items = useMemo(
-    () => values.map(({ value }) => value),
-    [values],
+    () => stableValues.map(({ value }) => value),
+    [stableValues],
   );
 
   const countByValue = useMemo(
-    () => new Map(values.map(({ value, count }) => [value, count])),
-    [values],
+    () => new Map(stableValues.map(({ value, count }) => [value, count])),
+    [stableValues],
   );
 
   const comboboxFilter = useMemo(
@@ -128,7 +131,7 @@ function MultiSelectInputInner({
     <div
       className={classnames(styles.multiSelect, className)}
       style={style}
-      data-loading={isLoading}
+      data-loading={isLoading && stableValues.length > 0}
     >
       {error && (
         <div className={sharedStyles.errorMessage}>
@@ -136,13 +139,13 @@ function MultiSelectInputInner({
         </div>
       )}
 
-      {!error && values.length === 0 && (
+      {!error && stableValues.length === 0 && (
         <div className={sharedStyles.emptyMessage}>
           {isLoading ? "Loading options..." : "No options available"}
         </div>
       )}
 
-      {(values.length > 0 || isLoading) && (
+      {stableValues.length > 0 && (
         <Combobox.Root<string, true>
           multiple={true}
           value={selectedValues}
@@ -150,12 +153,6 @@ function MultiSelectInputInner({
           items={items}
           filter={comboboxFilter}
         >
-          {isLoading && (
-            <div className={sharedStyles.loadingMessage}>
-              Updating...
-            </div>
-          )}
-
           <Combobox.Chips>
             <Combobox.Value>{renderChips}</Combobox.Value>
           </Combobox.Chips>

--- a/packages/react-components/src/filter-list/base/inputs/SingleSelectInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/SingleSelectInput.tsx
@@ -22,6 +22,7 @@ import { isEmptyValue } from "../../utils/filterValues.js";
 import { NoValueLabel } from "./NoValueLabel.js";
 import sharedStyles from "./shared.module.css";
 import styles from "./SingleSelectInput.module.css";
+import { useStableData } from "./useStableData.js";
 
 interface SingleSelectInputProps {
   values: PropertyAggregationValue[];
@@ -59,14 +60,16 @@ function SingleSelectInputInner({
     [onChange],
   );
 
+  const stableValues = useStableData(values, isLoading);
+
   const items = useMemo(
-    () => values.map(({ value }) => value),
-    [values],
+    () => stableValues.map(({ value }) => value),
+    [stableValues],
   );
 
   const countByValue = useMemo(
-    () => new Map(values.map(({ value, count }) => [value, count])),
-    [values],
+    () => new Map(stableValues.map(({ value, count }) => [value, count])),
+    [stableValues],
   );
 
   const comboboxFilter = useMemo(
@@ -104,27 +107,21 @@ function SingleSelectInputInner({
     <div
       className={classnames(styles.singleSelect, className)}
       style={style}
-      data-loading={isLoading}
+      data-loading={isLoading && stableValues.length > 0}
     >
-      {isLoading && (
-        <div className={sharedStyles.loadingMessage}>
-          Loading options...
-        </div>
-      )}
-
       {error && (
         <div className={sharedStyles.errorMessage}>
           Error loading options: {error.message}
         </div>
       )}
 
-      {!isLoading && !error && values.length === 0 && (
+      {!error && stableValues.length === 0 && (
         <div className={sharedStyles.emptyMessage}>
-          No options available
+          {isLoading ? "Loading options..." : "No options available"}
         </div>
       )}
 
-      {(values.length > 0 || isLoading) && (
+      {stableValues.length > 0 && (
         <div className={styles.selectContainer}>
           <Combobox.Root<string>
             value={selectedValue ?? null}

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/stableData.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/stableData.test.tsx
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PropertyAggregationValue } from "../../../types/AggregationTypes.js";
+import { MultiSelectInput } from "../MultiSelectInput.js";
+import { SingleSelectInput } from "../SingleSelectInput.js";
+
+afterEach(cleanup);
+
+const mockValues: PropertyAggregationValue[] = [
+  { value: "Engineering", count: 42 },
+  { value: "Sales", count: 18 },
+];
+
+describe("MultiSelectInput stableData", () => {
+  it("preserves selected chips when values drop during a refetch", () => {
+    const { container, rerender } = render(
+      <MultiSelectInput
+        values={mockValues}
+        isLoading={false}
+        error={null}
+        selectedValues={["Engineering"]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Engineering")).toBeDefined();
+
+    rerender(
+      <MultiSelectInput
+        values={[]}
+        isLoading={true}
+        error={null}
+        selectedValues={["Engineering"]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Engineering")).toBeDefined();
+    expect(container.querySelector("input")).not.toBeNull();
+    expect(screen.queryByText("Loading options...")).toBeNull();
+  });
+
+  it("shows loading message on first load with no data", () => {
+    const { rerender } = render(
+      <MultiSelectInput
+        values={[]}
+        isLoading={true}
+        error={null}
+        selectedValues={[]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Loading options...")).toBeDefined();
+
+    rerender(
+      <MultiSelectInput
+        values={[]}
+        isLoading={false}
+        error={null}
+        selectedValues={[]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("No options available")).toBeDefined();
+    expect(screen.queryByText("Loading options...")).toBeNull();
+  });
+
+  it("transitions to empty-state when refetch resolves to no data", () => {
+    const { rerender } = render(
+      <MultiSelectInput
+        values={mockValues}
+        isLoading={false}
+        error={null}
+        selectedValues={[]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    rerender(
+      <MultiSelectInput
+        values={[]}
+        isLoading={false}
+        error={null}
+        selectedValues={[]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("No options available")).toBeDefined();
+    expect(screen.queryByText("Engineering")).toBeNull();
+  });
+});
+
+describe("SingleSelectInput stableData", () => {
+  it("keeps the combobox mounted when values drop during a refetch", () => {
+    const { container, rerender } = render(
+      <SingleSelectInput
+        values={mockValues}
+        isLoading={false}
+        error={null}
+        selectedValue={undefined}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(container.querySelector("input")).not.toBeNull();
+
+    rerender(
+      <SingleSelectInput
+        values={[]}
+        isLoading={true}
+        error={null}
+        selectedValue={undefined}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(container.querySelector("input")).not.toBeNull();
+    expect(screen.queryByText("Loading options...")).toBeNull();
+  });
+
+  it("shows loading message on first load with no data", () => {
+    const { rerender } = render(
+      <SingleSelectInput
+        values={[]}
+        isLoading={true}
+        error={null}
+        selectedValue={undefined}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Loading options...")).toBeDefined();
+
+    rerender(
+      <SingleSelectInput
+        values={[]}
+        isLoading={false}
+        error={null}
+        selectedValue={undefined}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("No options available")).toBeDefined();
+    expect(screen.queryByText("Loading options...")).toBeNull();
+  });
+
+  it("transitions to empty-state when refetch resolves to no data", () => {
+    const { container, rerender } = render(
+      <SingleSelectInput
+        values={mockValues}
+        isLoading={false}
+        error={null}
+        selectedValue={undefined}
+        onChange={vi.fn()}
+      />,
+    );
+
+    rerender(
+      <SingleSelectInput
+        values={[]}
+        isLoading={false}
+        error={null}
+        selectedValue={undefined}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("No options available")).toBeDefined();
+    expect(container.querySelector("input")).toBeNull();
+  });
+});


### PR DESCRIPTION
combobox filters in a filter list collapsed and re-expanded on every checkbox toggle because their data dropped during the sibling-aggregation refetch and they rendered redundant loading text in its place

• apply the existing useStableData hook (already used by ListogramInput and RangeInput) to MultiSelectInput and SingleSelectInput so prior values stay rendered during refetch
• remove the redundant "Updating..." overlay in MultiSelectInput and the unconditional "Loading options..." block in SingleSelectInput, folding the loading message into the empty-state slot
• gate data-loading on stableValues.length > 0 to match ListogramInput so the attribute only signals refetch-over-stable-data, not first-load