### PR TITLE
ci: add ci-build umbrella job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,7 +319,7 @@ jobs:
     needs: [build, e2e, cspell]
     runs-on: ubuntu-latest
     steps:
-      - name: Verify dependencies succeeded
+      - name: Verify dependent jobs succeeded
         run: |
           if [[ "${{ needs.build.result }}" != "success" ]]; then
             echo "build did not succeed: ${{ needs.build.result }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,3 +312,24 @@ jobs:
           else
             gh pr comment "${{ github.event.pull_request.number }}" -F /tmp/comment.md
           fi
+
+  ci-build:
+    name: ci-build
+    if: ${{ always() }}
+    needs: [build, e2e, cspell]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify dependencies succeeded
+        run: |
+          if [[ "${{ needs.build.result }}" != "success" ]]; then
+            echo "build did not succeed: ${{ needs.build.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.e2e.result }}" != "success" ]]; then
+            echo "e2e did not succeed: ${{ needs.e2e.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.cspell.result }}" != "success" ]]; then
+            echo "cspell did not succeed: ${{ needs.cspell.result }}"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds a single `ci-build` umbrella job to `.github/workflows/ci.yml` that depends on `build`, `e2e`, and `cspell`
- Uses `if: \${{ always() }}` so it runs even when a dependency fails, and explicitly checks each `needs.<job>.result == "success"` so `skipped`/`cancelled`/`failure` all exit 1
- Excludes `changesets` (only meaningful on non-release PRs) and `bundle-size` (PR-only advisory comment)

## Follow-up
A companion change in `palantir/devtools/github-automation` will add:

```
"ci-build" = { required = true }
```

to this repo's `branch_protection` contexts so we can require one stable status check instead of enumerating every matrix leg.

Reference: palantir/foundry-platform-typescript#299 made the same change there.

## Test plan
- [ ] Workflow runs on this PR and the new `ci-build` job appears
- [ ] `ci-build` reports success once `build` (all matrix legs), `e2e`, and `cspell` succeed
- [ ] If any dependency fails, `ci-build` fails too (rather than being skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)