### PR TITLE
filter-list: match no-value row gap to regular row gap

### DIFF
--- a/.changeset/filter-list-no-value-gap.md
+++ b/.changeset/filter-list-no-value-gap.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+filter-list: match "No value" row gap to regular row gap so it doesn't look visually tighter than its neighbors

--- a/packages/react-components/docs/CSSVariables.md
+++ b/packages/react-components/docs/CSSVariables.md
@@ -906,7 +906,7 @@ Canonical "No value" styling used by the shared `NoValueLabel` component across 
 | `--osdk-filter-null-wrapper-gap`       | `var(--osdk-surface-spacing)`               | Null wrapper gap       |
 | `--osdk-filter-null-row-padding`       | `calc(var(--osdk-surface-spacing) * 1) 0`   | Null row padding       |
 | `--osdk-filter-null-row-border-top`    | `none`                                      | Null row top border    |
-| `--osdk-filter-null-label-gap`         | `var(--osdk-surface-spacing)`               | Null label gap         |
+| `--osdk-filter-null-label-gap`         | `calc(var(--osdk-surface-spacing) * 2)`     | Null label gap         |
 | `--osdk-filter-null-label-font-family` | `var(--osdk-typography-family-default)`     | Null label font family |
 | `--osdk-filter-null-label-font-size`   | `var(--osdk-typography-size-body-medium)`   | Null label font size   |
 | `--osdk-filter-null-label-line-height` | `1.4`                                       | Null label line height |

--- a/packages/react-components/src/tokens/component-tokens/filter-list.css
+++ b/packages/react-components/src/tokens/component-tokens/filter-list.css
@@ -309,7 +309,7 @@
   --osdk-filter-null-wrapper-gap: var(--osdk-surface-spacing);
   --osdk-filter-null-row-padding: calc(var(--osdk-surface-spacing) * 1) 0;
   --osdk-filter-null-row-border-top: none;
-  --osdk-filter-null-label-gap: var(--osdk-surface-spacing);
+  --osdk-filter-null-label-gap: calc(var(--osdk-surface-spacing) * 2);
   --osdk-filter-null-count-font-family: var(--osdk-typography-family-default);
   --osdk-filter-null-count-font-size: var(--osdk-typography-size-body-small);
   --osdk-filter-null-count-color: var(--osdk-typography-color-muted);


### PR DESCRIPTION
the "No value" row was rendering with half the gap between checkbox and label compared to regular rows, making it look visually tighter than its neighbors in both the listogram and the trailing null wrapper

• bump `--osdk-filter-null-label-gap` default from `surface-spacing` to `surface-spacing * 2` so it matches `--osdk-filter-listogram-row-gap`
• covers both call sites (ListogramInput's `data-empty` row and NullValueWrapper's `nullLabel`) in one token change
• update CSSVariables.md to match