### PR TITLE
noop unreleasable packages in release pipeline and add pr check

### DIFF
--- a/.changeset/skip-unreleasable-packages.md
+++ b/.changeset/skip-unreleasable-packages.md
@@ -1,0 +1,5 @@
+---
+"@osdk/tool.release": patch
+---
+
+Skip public packages that have no versions on npm during release so a new package added without trusted-publishing setup no longer blocks the pipeline, and add a PR check that fails when an unreleasable package would be merged.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
         run: pnpm exec turbo transpile --filter=@osdk/tool.release
 
       - name: Check for new unreleasable packages
+        continue-on-error: true
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,46 @@ jobs:
           git fetch origin main:main
           pnpm exec changeset status --since=origin/main
 
+  new-package-check:
+    name: New package check
+    if: ${{ github.event_name == 'pull_request' }}
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Cache Turbo
+        uses: actions/cache@v5
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Transpile tool.release
+        run: pnpm exec turbo transpile --filter=@osdk/tool.release
+
+      - name: Check for new unreleasable packages
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+        run: |
+          git fetch origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
+          node ./packages/tool.release/build/esm/checkPublishable.js --base "origin/$BASE_REF"
+
 
   build:
     name: Build and Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,14 +91,6 @@ jobs:
           node-version: 22
           cache: "pnpm"
 
-      - name: Cache Turbo
-        uses: actions/cache@v5
-        with:
-          path: .turbo/cache
-          key: turbo-${{ runner.os }}-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ runner.os }}-
-
       - name: Install dependencies
         run: pnpm install
 
@@ -112,7 +104,6 @@ jobs:
         run: |
           git fetch origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
           node ./packages/tool.release/build/esm/checkPublishable.js --base "origin/$BASE_REF"
-
 
   build:
     name: Build and Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,7 @@ jobs:
         run: pnpm install
 
       - name: Mark unreleasable packages private
+        continue-on-error: true
         run: |
           pnpm exec turbo transpile --filter=@osdk/tool.release
           node ./packages/tool.release/build/esm/markUnreleasablePrivate.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Mark unreleasable packages private
+        run: |
+          pnpm exec turbo transpile --filter=@osdk/tool.release
+          node ./packages/tool.release/build/esm/markUnreleasablePrivate.js
+
       - name: Build code
         run: pnpm exec turbo run build
 

--- a/packages/monorepo.cspell/dict.normal-dev-words.txt
+++ b/packages/monorepo.cspell/dict.normal-dev-words.txt
@@ -44,6 +44,8 @@ uncapitalize
 unevaluable
 ungroup
 unioned
+unparseable
+unreleasable
 unresolve
 Unsubscribable
 webapi

--- a/packages/tool.release/src/checkPublishable.ts
+++ b/packages/tool.release/src/checkPublishable.ts
@@ -22,11 +22,11 @@ import { basename, dirname, join, resolve } from "node:path";
 import yargs from "yargs";
 import { findUnreleasablePackagesFromList } from "./findUnreleasablePackages.js";
 
-type OffenseKind = "new-package-in-pr" | "no-npm-versions";
+type UnpublishableReason = "new-package" | "no-npm-version";
 
 interface Offense {
   name: string;
-  kind: OffenseKind;
+  kind: UnpublishableReason;
   file?: string;
 }
 
@@ -36,7 +36,7 @@ function emitGithubError(message: string, file?: string): void {
 }
 
 function messageForOffense(offense: Offense): string {
-  if (offense.kind === "new-package-in-pr") {
+  if (offense.kind === "new-package") {
     return `New public package ${offense.name} cannot be merged: it has no `
       + `versions on npm. Talk to the OSDK release team to manually publish a `
       + `placeholder version and configure trusted publishing before merging `
@@ -86,7 +86,7 @@ async function findNewlyAddedNonPrivatePackages(
       continue;
     }
     offenses.push({
-      kind: "new-package-in-pr",
+      kind: "new-package",
       name: parsed.name,
       file: relPath,
     });
@@ -98,7 +98,7 @@ function dedupeOffenses(offenses: Offense[]): Offense[] {
   const byName = new Map<string, Offense>();
   for (const offense of offenses) {
     const existing = byName.get(offense.name);
-    if (!existing || offense.kind === "new-package-in-pr") {
+    if (!existing || offense.kind === "new-package") {
       byName.set(offense.name, offense);
     }
   }
@@ -132,7 +132,7 @@ async function main(): Promise<void> {
   const offenses = dedupeOffenses([
     ...newPkgOffenses,
     ...unreleasable.map((pkg): Offense => ({
-      kind: "no-npm-versions",
+      kind: "no-npm-version",
       name: pkg.name,
     })),
   ]);

--- a/packages/tool.release/src/checkPublishable.ts
+++ b/packages/tool.release/src/checkPublishable.ts
@@ -152,6 +152,9 @@ async function main(): Promise<void> {
 }
 
 main().catch((err: unknown) => {
-  consola.error(err);
-  process.exit(1);
+  // Internal script failure should not make the (non-blocking) PR check
+  // look like a real offense. Intentional offense exits stay at 1 inside
+  // main(); anything bubbling out here is unexpected and we noop.
+  consola.warn(`checkPublishable crashed; treating as no-op: ${String(err)}`);
+  process.exit(0);
 });

--- a/packages/tool.release/src/checkPublishable.ts
+++ b/packages/tool.release/src/checkPublishable.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getPackages } from "@manypkg/get-packages";
+import { consola } from "consola";
+import { execa } from "execa";
+import { readFile } from "node:fs/promises";
+import { basename, dirname, join, resolve } from "node:path";
+import yargs from "yargs";
+import { findUnreleasablePackagesFromList } from "./findUnreleasablePackages.js";
+
+type OffenseKind = "new-package-in-pr" | "no-npm-versions";
+
+interface Offense {
+  name: string;
+  kind: OffenseKind;
+  file?: string;
+}
+
+function emitGithubError(message: string, file?: string): void {
+  const fileArg = file ? `file=${file}::` : "";
+  process.stdout.write(`::error ${fileArg}${message}\n`);
+}
+
+function messageForOffense(offense: Offense): string {
+  if (offense.kind === "new-package-in-pr") {
+    return `New public package ${offense.name} cannot be merged: it has no `
+      + `versions on npm. Talk to the OSDK release team to manually publish a `
+      + `placeholder version and configure trusted publishing before merging `
+      + `this PR.`;
+  }
+  return `Package ${offense.name} exists in the repo but has never been `
+    + `published to npm, so the release pipeline cannot ship changes that `
+    + `bump it. A maintainer must manually publish a placeholder version and `
+    + `configure trusted publishing.`;
+}
+
+async function findNewlyAddedNonPrivatePackages(
+  cwd: string,
+  base: string,
+  workspacePackageDirs: Set<string>,
+): Promise<Offense[]> {
+  const { stdout } = await execa(
+    "git",
+    ["diff", "--name-only", "--diff-filter=A", `${base}...HEAD`],
+    { cwd },
+  );
+  const addedFiles = stdout.split("\n").filter((line) =>
+    basename(line) === "package.json"
+  );
+
+  const offenses: Offense[] = [];
+  for (const relPath of addedFiles) {
+    const absPath = join(cwd, relPath);
+    const absDir = resolve(dirname(absPath));
+    if (!workspacePackageDirs.has(absDir)) {
+      continue;
+    }
+    let parsed: { name?: string; private?: boolean };
+    try {
+      parsed = JSON.parse(await readFile(absPath, "utf-8"));
+    } catch (e) {
+      if (e instanceof SyntaxError) {
+        consola.warn(`Skipping unparseable package.json at ${relPath}`);
+        continue;
+      }
+      throw e;
+    }
+    if (parsed.private) {
+      continue;
+    }
+    if (!parsed.name) {
+      continue;
+    }
+    offenses.push({
+      kind: "new-package-in-pr",
+      name: parsed.name,
+      file: relPath,
+    });
+  }
+  return offenses;
+}
+
+function dedupeOffenses(offenses: Offense[]): Offense[] {
+  const byName = new Map<string, Offense>();
+  for (const offense of offenses) {
+    const existing = byName.get(offense.name);
+    if (!existing || offense.kind === "new-package-in-pr") {
+      byName.set(offense.name, offense);
+    }
+  }
+  return [...byName.values()];
+}
+
+async function main(): Promise<void> {
+  const args = await yargs(process.argv.slice(2))
+    .options({
+      base: {
+        type: "string",
+        default: "origin/main",
+        description: "Base git ref to diff against",
+      },
+      cwd: {
+        type: "string",
+        description: "Working directory (defaults to process.cwd())",
+      },
+    })
+    .parseAsync();
+
+  const cwd = args.cwd ?? process.cwd();
+  const { packages } = await getPackages(cwd);
+  const workspacePackageDirs = new Set(packages.map((p) => resolve(p.dir)));
+
+  const [newPkgOffenses, unreleasable] = await Promise.all([
+    findNewlyAddedNonPrivatePackages(cwd, args.base, workspacePackageDirs),
+    findUnreleasablePackagesFromList(packages),
+  ]);
+
+  const offenses = dedupeOffenses([
+    ...newPkgOffenses,
+    ...unreleasable.map((pkg): Offense => ({
+      kind: "no-npm-versions",
+      name: pkg.name,
+    })),
+  ]);
+
+  if (offenses.length === 0) {
+    consola.success("No unreleasable packages detected");
+    return;
+  }
+
+  for (const offense of offenses) {
+    const message = messageForOffense(offense);
+    emitGithubError(message, offense.file);
+    consola.error(message);
+  }
+
+  process.exit(1);
+}
+
+main().catch((err: unknown) => {
+  consola.error(err);
+  process.exit(1);
+});

--- a/packages/tool.release/src/ciPublish.ts
+++ b/packages/tool.release/src/ciPublish.ts
@@ -59,9 +59,9 @@ async function ciPublish(): Promise<void> {
       cwd: repoRoot,
     });
 
-    const unreleasable = await findUnreleasablePackages(repoRoot);
-    if (unreleasable.length > 0) {
-      await markPackagesPrivate(unreleasable);
+    const unreleasablePackages = await findUnreleasablePackages(repoRoot);
+    if (unreleasablePackages.length > 0) {
+      await markPackagesPrivate(unreleasablePackages);
     }
 
     await execa(

--- a/packages/tool.release/src/ciPublish.ts
+++ b/packages/tool.release/src/ciPublish.ts
@@ -20,6 +20,10 @@ import { existsSync } from "fs";
 import { readFile } from "fs/promises";
 import { join } from "path";
 import semver from "semver";
+import {
+  findUnreleasablePackages,
+  markPackagesPrivate,
+} from "./findUnreleasablePackages.js";
 
 async function ciPublish(): Promise<void> {
   let tag = "latest";
@@ -54,6 +58,12 @@ async function ciPublish(): Promise<void> {
       stdio: "inherit",
       cwd: repoRoot,
     });
+
+    const unreleasable = await findUnreleasablePackages(repoRoot);
+    if (unreleasable.length > 0) {
+      await markPackagesPrivate(unreleasable);
+    }
+
     await execa(
       "pnpm",
       ["publish", "--no-git-checks", "-r", "--report-summary", "--tag", tag],

--- a/packages/tool.release/src/ciPublish.ts
+++ b/packages/tool.release/src/ciPublish.ts
@@ -59,9 +59,18 @@ async function ciPublish(): Promise<void> {
       cwd: repoRoot,
     });
 
-    const unreleasablePackages = await findUnreleasablePackages(repoRoot);
-    if (unreleasablePackages.length > 0) {
-      await markPackagesPrivate(unreleasablePackages);
+    try {
+      const unreleasablePackages = await findUnreleasablePackages(repoRoot);
+      if (unreleasablePackages.length > 0) {
+        await markPackagesPrivate(unreleasablePackages);
+      }
+    } catch (error) {
+      // The unreleasable check is a best-effort safety net. If it fails for
+      // any reason, fall back to the pre-existing publish behavior rather
+      // than blocking the release.
+      consola.warn(
+        `Failed to mark unreleasable packages; continuing with publish: ${error}`,
+      );
     }
 
     await execa(

--- a/packages/tool.release/src/findUnreleasablePackages.test.ts
+++ b/packages/tool.release/src/findUnreleasablePackages.test.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Package } from "@manypkg/get-packages";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  findUnreleasablePackagesFromList,
+  markPackagesPrivate,
+} from "./findUnreleasablePackages.js";
+
+function mkPkg(
+  name: string,
+  opts: { private?: boolean; version?: string; dir?: string } = {},
+): Package {
+  return {
+    dir: opts.dir ?? `/faux/${name}`,
+    packageJson: {
+      name,
+      version: opts.version ?? "1.0.0",
+      private: opts.private,
+    },
+  };
+}
+
+describe("findUnreleasablePackagesFromList", () => {
+  it("skips packages marked private", async () => {
+    const packages = [
+      mkPkg("@osdk/private-thing", { private: true }),
+    ];
+    const lookup = async () => new Set<string>();
+
+    const result = await findUnreleasablePackagesFromList(packages, lookup);
+
+    expect(result).toEqual([]);
+  });
+
+  it("skips public packages that already have npm versions", async () => {
+    const packages = [mkPkg("@osdk/published")];
+    const lookup = async () => new Set(["1.0.0", "0.9.0"]);
+
+    const result = await findUnreleasablePackagesFromList(packages, lookup);
+
+    expect(result).toEqual([]);
+  });
+
+  it("flags public packages with no npm versions", async () => {
+    const packages = [
+      mkPkg("@osdk/brand-new", { dir: "/faux/brand-new", version: "0.1.0" }),
+    ];
+    const lookup = async () => new Set<string>();
+
+    const result = await findUnreleasablePackagesFromList(packages, lookup);
+
+    expect(result).toEqual([
+      { name: "@osdk/brand-new", dir: "/faux/brand-new", version: "0.1.0" },
+    ]);
+  });
+
+  it("partitions a mixed set correctly", async () => {
+    const packages = [
+      mkPkg("@osdk/published"),
+      mkPkg("@osdk/private-thing", { private: true }),
+      mkPkg("@osdk/brand-new", { dir: "/faux/brand-new", version: "0.1.0" }),
+    ];
+    const lookup = async (name: string) =>
+      name === "@osdk/published" ? new Set(["1.0.0"]) : new Set<string>();
+
+    const result = await findUnreleasablePackagesFromList(packages, lookup);
+
+    expect(result.map((p) => p.name)).toEqual(["@osdk/brand-new"]);
+  });
+
+  it("treats transient lookup errors as assume-published (does not flag)", async () => {
+    const packages = [mkPkg("@osdk/registry-flaky")];
+    const lookup = async () => {
+      throw new Error("ECONNRESET");
+    };
+
+    const result = await findUnreleasablePackagesFromList(packages, lookup);
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("markPackagesPrivate", () => {
+  let tmpRoot: string;
+
+  beforeEach(async () => {
+    tmpRoot = await mkdtemp(join(tmpdir(), "find-unreleasable-test-"));
+  });
+
+  it("rewrites package.json with private: true and preserves trailing newline", async () => {
+    const pkgJsonPath = join(tmpRoot, "package.json");
+    const initial = JSON.stringify(
+      { name: "@osdk/brand-new", version: "0.1.0" },
+      null,
+      2,
+    ) + "\n";
+    await writeFile(pkgJsonPath, initial);
+
+    await markPackagesPrivate([
+      { name: "@osdk/brand-new", dir: tmpRoot, version: "0.1.0" },
+    ]);
+
+    const rewritten = await readFile(pkgJsonPath, "utf-8");
+    expect(rewritten.endsWith("\n")).toBe(true);
+    expect(JSON.parse(rewritten)).toEqual({
+      name: "@osdk/brand-new",
+      version: "0.1.0",
+      private: true,
+    });
+  });
+
+  it("preserves the absence of a trailing newline", async () => {
+    const pkgJsonPath = join(tmpRoot, "package.json");
+    const initial = JSON.stringify(
+      { name: "@osdk/brand-new", version: "0.1.0" },
+      null,
+      2,
+    );
+    await writeFile(pkgJsonPath, initial);
+
+    await markPackagesPrivate([
+      { name: "@osdk/brand-new", dir: tmpRoot, version: "0.1.0" },
+    ]);
+
+    const rewritten = await readFile(pkgJsonPath, "utf-8");
+    expect(rewritten.endsWith("\n")).toBe(false);
+  });
+});

--- a/packages/tool.release/src/findUnreleasablePackages.ts
+++ b/packages/tool.release/src/findUnreleasablePackages.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Package } from "@manypkg/get-packages";
+import { getPackages } from "@manypkg/get-packages";
+import { consola } from "consola";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import pMap from "p-map";
+import { packageVersionsOrEmptySet } from "./publishPackages.js";
+
+export interface UnreleasablePackage {
+  name: string;
+  dir: string;
+  version: string;
+}
+
+export type LookupVersions = (name: string) => Promise<Set<string>>;
+
+const NPM_LOOKUP_CONCURRENCY = 4;
+
+export async function findUnreleasablePackagesFromList(
+  packages: Package[],
+  lookupVersions: LookupVersions = packageVersionsOrEmptySet,
+): Promise<UnreleasablePackage[]> {
+  const publicPackages = packages.filter((pkg) => !pkg.packageJson.private);
+  const results = await pMap(publicPackages, async (pkg) => {
+    const { name, version } = pkg.packageJson;
+    let versions: Set<string>;
+    try {
+      versions = await lookupVersions(name);
+    } catch (e) {
+      // Transient registry failure: assume the package is published so we
+      // don't mark it private (release) or fail the PR check on flaky npm.
+      consola.warn(
+        `Could not check npm versions for ${name} (${
+          String(e)
+        }); assuming published`,
+      );
+      return null;
+    }
+    if (versions.size > 0) {
+      return null;
+    }
+    return { name, dir: pkg.dir, version };
+  }, { concurrency: NPM_LOOKUP_CONCURRENCY });
+  return results.filter((r): r is UnreleasablePackage => r != null);
+}
+
+export async function findUnreleasablePackages(
+  cwd: string,
+  lookupVersions: LookupVersions = packageVersionsOrEmptySet,
+): Promise<UnreleasablePackage[]> {
+  const { packages } = await getPackages(cwd);
+  return findUnreleasablePackagesFromList(packages, lookupVersions);
+}
+
+export async function markPackagesPrivate(
+  packages: UnreleasablePackage[],
+): Promise<void> {
+  for (const pkg of packages) {
+    const pkgJsonPath = path.join(pkg.dir, "package.json");
+    const raw = await fs.readFile(pkgJsonPath, "utf-8");
+    const trailingNewline = raw.endsWith("\n") ? "\n" : "";
+    const parsed = JSON.parse(raw);
+    parsed.private = true;
+    await fs.writeFile(
+      pkgJsonPath,
+      JSON.stringify(parsed, null, 2) + trailingNewline,
+    );
+    consola.warn(
+      `Skipping unreleasable package ${pkg.name}: no versions found on npm. `
+        + `A maintainer must manually publish a placeholder version and configure `
+        + `trusted publishing before this package can release.`,
+    );
+  }
+}

--- a/packages/tool.release/src/markUnreleasablePrivate.ts
+++ b/packages/tool.release/src/markUnreleasablePrivate.ts
@@ -22,16 +22,16 @@ import {
 
 async function main(): Promise<void> {
   const cwd = process.cwd();
-  const unreleasable = await findUnreleasablePackages(cwd);
+  const unreleasablePackages = await findUnreleasablePackages(cwd);
 
-  if (unreleasable.length === 0) {
+  if (unreleasablePackages.length === 0) {
     consola.info("No unreleasable packages detected");
     return;
   }
 
-  await markPackagesPrivate(unreleasable);
+  await markPackagesPrivate(unreleasablePackages);
   consola.info(
-    `Marked ${unreleasable.length} unreleasable package(s) as private so publish steps skip them`,
+    `Marked ${unreleasablePackages.length} unreleasable package(s) as private so publish steps skip them`,
   );
 }
 

--- a/packages/tool.release/src/markUnreleasablePrivate.ts
+++ b/packages/tool.release/src/markUnreleasablePrivate.ts
@@ -36,6 +36,8 @@ async function main(): Promise<void> {
 }
 
 main().catch((err: unknown) => {
-  consola.error(err);
-  process.exit(1);
+  // Noop on script failure: the release pipeline is the source of truth,
+  // and failing this safety-net step would itself create a release outage.
+  consola.warn(`markUnreleasablePrivate failed; continuing: ${String(err)}`);
+  process.exit(0);
 });

--- a/packages/tool.release/src/markUnreleasablePrivate.ts
+++ b/packages/tool.release/src/markUnreleasablePrivate.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { consola } from "consola";
+import {
+  findUnreleasablePackages,
+  markPackagesPrivate,
+} from "./findUnreleasablePackages.js";
+
+async function main(): Promise<void> {
+  const cwd = process.cwd();
+  const unreleasable = await findUnreleasablePackages(cwd);
+
+  if (unreleasable.length === 0) {
+    consola.info("No unreleasable packages detected");
+    return;
+  }
+
+  await markPackagesPrivate(unreleasable);
+  consola.info(
+    `Marked ${unreleasable.length} unreleasable package(s) as private so publish steps skip them`,
+  );
+}
+
+main().catch((err: unknown) => {
+  consola.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
release pipeline fails entirely when a new public package isn't yet set up on npm with trusted publishing because one bad package tanks the whole pnpm publish -r run

• detect public packages with no versions on npm and flip them to private before publish so the rest of the release proceeds, applied in both ciPublish and the snapshot path before changeset publish
• transient registry errors are treated as assume-published with a warn log so npm flakiness no longer aborts the release
• non-blocking pr check surfaces a github error annotation when a new public package would land or any public workspace package is still unreleasable, prompting the contributor to coordinate npm and trusted publishing setup with the release team