### PR TITLE
Fix dropdown scroll blocking in editable ObjectTable

### DIFF
--- a/.changeset/fix-dropdown-scroll-blocking.md
+++ b/.changeset/fix-dropdown-scroll-blocking.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Fix page scroll being blocked when opening a dropdown in an editable ObjectTable

--- a/packages/react-components/src/action-form/FormFieldApi.ts
+++ b/packages/react-components/src/action-form/FormFieldApi.ts
@@ -246,6 +246,15 @@ export interface DropdownFieldProps<V, Multiple extends boolean = false>
    * Use for infinite scroll sentinels, "load more" buttons, etc.
    */
   trailingItem?: React.ReactNode;
+
+  /**
+   * Whether the dropdown renders a full-viewport dismiss layer.
+   * Set to `false` when the dropdown is not inside a `<label>` to avoid
+   * blocking scroll on the page.
+   *
+   * @default true
+   */
+  modal?: boolean;
 }
 
 export interface FilePickerProps extends BaseFormFieldProps<File | File[]> {

--- a/packages/react-components/src/action-form/FormFieldApi.ts
+++ b/packages/react-components/src/action-form/FormFieldApi.ts
@@ -248,9 +248,9 @@ export interface DropdownFieldProps<V, Multiple extends boolean = false>
   trailingItem?: React.ReactNode;
 
   /**
-   * Whether the dropdown renders a full-viewport dismiss layer.
-   * Set to `false` when the dropdown is not inside a `<label>` to avoid
-   * blocking scroll on the page.
+   * Whether the dropdown locks page scroll and renders a full-viewport
+   * dismiss layer when open. Set to `false` when the dropdown is not
+   * inside a `<label>` to allow normal page scrolling.
    *
    * @default true
    */

--- a/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
@@ -130,6 +130,22 @@ describe("DropdownField", () => {
         expect(screen.queryByRole("option", { name: "Alice" })).toBeNull();
       });
     });
+
+    it("does not render the portal dismiss layer when modal is false", async () => {
+      render(
+        <DropdownField value={null} items={STRING_ITEMS} modal={false} />,
+      );
+
+      fireEvent.click(screen.getByRole("combobox"));
+
+      await vi.waitFor(() => {
+        expect(screen.getByRole("option", { name: "Alice" })).toBeDefined();
+      });
+
+      expect(
+        document.querySelector("[data-osdk-portal-dismiss-layer]"),
+      ).toBeNull();
+    });
   });
 
   describe("multi select (Select variant)", () => {

--- a/packages/react-components/src/action-form/fields/DropdownField.tsx
+++ b/packages/react-components/src/action-form/fields/DropdownField.tsx
@@ -335,7 +335,6 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
         inputValue={query}
         onInputValueChange={onQueryChange}
         filter={disableClientSideFiltering ? null : undefined}
-        modal={modal}
       >
         <Combobox.Trigger
           id={id}

--- a/packages/react-components/src/action-form/fields/DropdownField.tsx
+++ b/packages/react-components/src/action-form/fields/DropdownField.tsx
@@ -42,6 +42,7 @@ interface InnerSelectProps<V, Multiple extends boolean>
   query?: string;
   onQueryChange?: (query: string) => void;
   onBlur?: () => void;
+  modal?: boolean;
 }
 
 interface InnerComboboxProps<V, Multiple extends boolean>
@@ -69,6 +70,7 @@ export const DropdownField: <V, Multiple extends boolean = false>(
   disableClientSideFiltering,
   popupStatus,
   trailingItem,
+  modal = true,
   ...rest
 }: DropdownFieldProps<V, Multiple> & {
   onBlur?: () => void;
@@ -102,6 +104,7 @@ export const DropdownField: <V, Multiple extends boolean = false>(
         disableClientSideFiltering={disableClientSideFiltering}
         popupStatus={popupStatus}
         trailingItem={trailingItem}
+        modal={modal}
       />
     );
   }
@@ -113,6 +116,7 @@ export const DropdownField: <V, Multiple extends boolean = false>(
       value={normalizedValue}
       itemToStringLabel={resolvedItemToStringLabel}
       getKey={getKey}
+      modal={modal}
     />
   );
 });
@@ -132,6 +136,7 @@ const SelectDropdown = typedReactMemo(function SelectDropdownFn<
   portalRef,
   portalContainer,
   onBlur,
+  modal = true,
 }: InnerSelectProps<V, Multiple>): React.ReactElement {
   const [open, setOpen] = useState(false);
 
@@ -168,6 +173,7 @@ const SelectDropdown = typedReactMemo(function SelectDropdownFn<
         onOpenChange={handleOpenChange}
         isItemEqualToValue={isItemEqual}
         itemToStringLabel={itemToStringLabel}
+        modal={modal}
       >
         <Select.Trigger id={id} placeholder={placeholder}>
           <div className={selectStyles.osdkSelectValueContainer}>
@@ -194,7 +200,7 @@ const SelectDropdown = typedReactMemo(function SelectDropdownFn<
           </span>
         </Select.Trigger>
         <Select.Portal ref={portalRef} container={portalContainer}>
-          {open && (
+          {open && modal && (
             <PortalDismissLayer
               className={dropdownStyles.osdkSelectDismissLayer}
               onDismiss={handleDismiss}
@@ -237,6 +243,7 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
   popupStatus,
   trailingItem,
   onBlur,
+  modal = true,
 }: InnerComboboxProps<V, Multiple>): React.ReactElement {
   const [open, setOpen] = useState(false);
 
@@ -328,6 +335,7 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
         inputValue={query}
         onInputValueChange={onQueryChange}
         filter={disableClientSideFiltering ? null : undefined}
+        modal={modal}
       >
         <Combobox.Trigger
           id={id}
@@ -385,7 +393,7 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
           </Combobox.Icon>
         </Combobox.Trigger>
         <Combobox.Portal ref={portalRef} container={portalContainer}>
-          {open && (
+          {open && modal && (
             <PortalDismissLayer
               className={dropdownStyles.osdkComboboxDismissLayer}
               onDismiss={handleDismiss}

--- a/packages/react-components/src/object-table/components/DropdownCellField.tsx
+++ b/packages/react-components/src/object-table/components/DropdownCellField.tsx
@@ -65,6 +65,7 @@ function DropdownCellFieldInner({
         portalRef={portalRef}
         value={inputValue}
         onChange={onChange}
+        modal={false}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

- Base UI's `Select.Root` defaults `modal=true`, which locks document scroll when the select popup is open
- Added a `modal` prop to `DropdownField` (defaulting `true` to preserve action-form behavior)
- Pass `modal={false}` from `DropdownCellField` in the object-table so dropdowns don't block page scrolling
- The `PortalDismissLayer` overlay is also gated on `modal` to avoid rendering a full-viewport overlay unnecessarily

## Demo

<!-- TODO: Add demo video here -->

https://github.com/user-attachments/assets/6a926d38-e3dd-447b-8a8e-29046de3adc5

## Test plan

- [x] Open a dropdown in an editable ObjectTable row — verify the page/table scrolls while the dropdown is open
- [x] Verify clicking outside the dropdown still dismisses it
- [x] Verify action-form dropdowns (inside `<label>`s) still work correctly with scroll lock and dismiss layer