### PR TITLE
Add scoped object select

### DIFF
--- a/.changeset/scoped-object-select.md
+++ b/.changeset/scoped-object-select.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Add object set scoping to ObjectSelectField.

--- a/packages/e2e.sandbox.peopleapp/src/app/form/page.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/form/page.tsx
@@ -218,10 +218,27 @@ export function FormPage() {
     () => $(Employee) as ObjectSet<ObjectTypeDefinition>,
     [],
   );
+  const marketingEmployees = useMemo(
+    () =>
+      $(Employee).where({ department: "Marketing" }) as ObjectSet<
+        ObjectTypeDefinition
+      >,
+    [],
+  );
 
   const allFormContent = useMemo(
     (): ReadonlyArray<FormContentItem> => [
       ...formContent,
+      field({
+        fieldKey: "marketingManager",
+        fieldComponent: "OBJECT_SELECT",
+        label: "Marketing manager",
+        placeholder: "Search Marketing employees…",
+        helperText: "This selector is scoped by an ObjectSet.",
+        fieldComponentProps: {
+          objectSet: marketingEmployees,
+        },
+      }),
       field({
         fieldKey: "team",
         fieldComponent: "OBJECT_SET",
@@ -231,7 +248,7 @@ export function FormPage() {
         },
       }),
     ],
-    [employeeObjectSet],
+    [employeeObjectSet, marketingEmployees],
   );
 
   return (

--- a/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
@@ -1702,6 +1702,74 @@ export const WithObjectSelect: Story = {
   },
 };
 
+function ScopedObjectSelectStory(): React.ReactElement {
+  const client = useOsdkClient();
+  const marketingEmployees = useMemo(
+    () =>
+      client(Employee).where({ department: "Marketing" }) as ObjectSet<
+        ObjectTypeDefinition
+      >,
+    [client],
+  );
+  const scopedObjectSelectFormContent = useMemo(
+    (): ReadonlyArray<FormContentItem> => [
+      field({
+        fieldKey: "employee",
+        fieldComponent: "OBJECT_SELECT",
+        label: "Marketing employee",
+        helperText: "This selector is scoped by an ObjectSet.",
+        fieldComponentProps: {
+          objectSet: marketingEmployees,
+          placeholder: "Search Marketing employees…",
+        },
+      }),
+    ],
+    [marketingEmployees],
+  );
+
+  return (
+    <BaseForm
+      formContent={scopedObjectSelectFormContent}
+      onSubmit={handleSubmit}
+    />
+  );
+}
+
+export const WithScopedObjectSelect: Story = {
+  render: () => <ScopedObjectSelectStory />,
+  parameters: {
+    docs: {
+      source: {
+        code: `function ScopedEmployeeForm() {
+  const client = useOsdkClient();
+  const marketingEmployees = useMemo(
+    () => client(Employee).where({ department: "Marketing" }),
+    [client],
+  );
+
+  const formContent = [
+    {
+      type: "field",
+      definition: {
+        fieldKey: "employee",
+        fieldComponent: "OBJECT_SELECT",
+        label: "Marketing employee",
+        helperText: "This selector is scoped by an ObjectSet.",
+        fieldComponentProps: {
+          objectSet: marketingEmployees,
+          placeholder: "Search Marketing employees…",
+        },
+      },
+    },
+  ];
+
+  return <BaseForm formContent={formContent} onSubmit={handleSubmit} />;
+}`,
+      },
+    },
+  },
+};
+
 export const WithSections: Story = {
   args: {
     formContent: sectionFormContent,

--- a/packages/react-components/docs/ActionForm.md
+++ b/packages/react-components/docs/ActionForm.md
@@ -97,7 +97,7 @@ const fields = [
 
 ### Scoped object select fields
 
-`OBJECT_SELECT` can load options from either an object type or a pre-scoped object set. Pass `objectType` for an unfiltered selector, or pass `objectSet` to limit selectable options. Do not pass both. Search text is applied within the object set, and the current value is not automatically cleared when it is outside that set.
+`OBJECT_SELECT` can load options from either an object type or a pre-scoped object set. Pass `objectType` for an unfiltered selector, or pass `objectSet` to limit selectable options. The two are mutually exclusive. Search text is applied within the object set, and the current value is not automatically cleared when it is outside that set.
 
 ```tsx
 import { $, Employee, updateEmployee } from "@YourApp/sdk";

--- a/packages/react-components/docs/ActionForm.md
+++ b/packages/react-components/docs/ActionForm.md
@@ -95,6 +95,41 @@ const fields = [
 <ActionForm actionDefinition={updateEmployee} formFieldDefinitions={fields} />;
 ```
 
+### Scoped object select fields
+
+`OBJECT_SELECT` can load options from either an object type or a pre-scoped object set. Pass `objectType` for an unfiltered selector, or pass `objectSet` to limit selectable options. Do not pass both. Search text is applied within the object set, and the current value is not automatically cleared when it is outside that set.
+
+```tsx
+import { $, Employee, updateEmployee } from "@YourApp/sdk";
+import { useMemo } from "react";
+
+function UpdateEmployeeForm() {
+  const marketingEmployees = useMemo(
+    () => $(Employee).where({ department: "Marketing" }),
+    [],
+  );
+
+  const fields = [
+    {
+      fieldKey: "manager",
+      label: "Marketing manager",
+      fieldComponent: "OBJECT_SELECT",
+      fieldComponentProps: {
+        objectSet: marketingEmployees,
+        placeholder: "Search Marketing employees…",
+      },
+    },
+  ] satisfies Array<FormFieldDefinition<typeof updateEmployee>>;
+
+  return (
+    <ActionForm
+      actionDefinition={updateEmployee}
+      formFieldDefinitions={fields}
+    />
+  );
+}
+```
+
 For a completely custom field, use `fieldComponent: "CUSTOM"` and provide `customRenderer`:
 
 ```tsx

--- a/packages/react-components/src/action-form/FormFieldApi.ts
+++ b/packages/react-components/src/action-form/FormFieldApi.ts
@@ -118,7 +118,7 @@ export type FormFieldDefinition<
        * The component props for the form field.
        * Excludes runtime props (value, onChange) which are managed by ActionForm.
        */
-      fieldComponentProps: Omit<
+      fieldComponentProps: DistributiveOmit<
         FormFieldPropsByType[C],
         FormManagedProps<C>
       >;
@@ -394,6 +394,25 @@ export interface ObjectSetFieldProps<T extends ObjectTypeDefinition>
   emptyMessage?: string;
 }
 
+type ObjectSelectDataSource<Q extends ObjectTypeDefinition> =
+  | {
+    /**
+     * The object type definition to search across.
+     */
+    objectType: Q;
+    objectSet?: never;
+  }
+  | {
+    /**
+     * A pre-scoped object set to search within.
+     *
+     * Use this when selectable options should be limited to a subset of
+     * objects. User-entered search text is applied within this set.
+     */
+    objectSet: ObjectSet<Q>;
+    objectType?: never;
+  };
+
 /**
  * Object select field props for selecting object instances from the ontology.
  * Used for action parameters that accept a single object or multiple objects.
@@ -401,10 +420,10 @@ export interface ObjectSetFieldProps<T extends ObjectTypeDefinition>
  * Extends DropdownFieldProps with props that ObjectSelectField
  * manages internally (items, search, filtering) omitted from the public surface.
  */
-export interface ObjectSelectFieldProps<
+export type ObjectSelectFieldProps<
   Q extends ObjectTypeDefinition = ObjectTypeDefinition,
-> extends
-  Omit<
+> =
+  & Omit<
     DropdownFieldProps<Osdk.Instance<Q>>,
     | "items"
     | "itemToStringLabel"
@@ -416,12 +435,7 @@ export interface ObjectSelectFieldProps<
     | "disableClientSideFiltering"
     | "renderItemList"
   >
-{
-  /**
-   * The object type definition to search within.
-   */
-  objectType: Q;
-}
+  & ObjectSelectDataSource<Q>;
 
 /**
  * Custom field props for user-defined renderers
@@ -559,6 +573,12 @@ type FormManagedProps<K extends FieldComponent> = "onChange" extends
   keyof FormFieldPropsByType[K] ? "value" | "onChange"
   : "onChange";
 
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<
+    T,
+    Extract<keyof T, K>
+  >
+  : never;
+
 /**
  * An OSDK-agnostic field definition used by BaseForm and FormFieldRenderer.
  * Contains only the information needed to render a single field — no generics,
@@ -579,7 +599,10 @@ export type RendererFieldDefinition = {
     helperTextPlacement?: "bottom" | "tooltip";
     validate?: (value: unknown) => Promise<string | undefined>;
     onValidationError?: (error: ValidationError) => string | undefined;
-    fieldComponentProps: Omit<FormFieldPropsByType[K], FormManagedProps<K>>;
+    fieldComponentProps: DistributiveOmit<
+      FormFieldPropsByType[K],
+      FormManagedProps<K>
+    >;
   };
 }[FieldComponent];
 

--- a/packages/react-components/src/action-form/__tests__/ObjectSelectField.test-d.ts
+++ b/packages/react-components/src/action-form/__tests__/ObjectSelectField.test-d.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  ActionDefinition,
+  ActionMetadata,
+  ObjectSet,
+  ObjectTypeDefinition,
+} from "@osdk/api";
+import type {
+  FormFieldDefinition,
+  ObjectSelectFieldProps,
+} from "../../public/experimental/action-form.js";
+
+const EMPLOYEE_TYPE = {
+  type: "object",
+  apiName: "Employee",
+} satisfies ObjectTypeDefinition;
+
+const employeeObjectSet = {
+  $objectSetInternals: { def: EMPLOYEE_TYPE },
+} as ObjectSet<typeof EMPLOYEE_TYPE>;
+
+interface AssignManagerAction extends ActionDefinition<unknown> {
+  __DefinitionMetadata: {
+    signatures: unknown;
+    parameters: {
+      manager: {
+        type: ActionMetadata.DataType.Object<typeof EMPLOYEE_TYPE>;
+      };
+    };
+    type: "action";
+    apiName: "AssignManager";
+    status: "ACTIVE";
+    rid: string;
+  };
+}
+
+const objectTypeOnly: ObjectSelectFieldProps<typeof EMPLOYEE_TYPE> = {
+  objectType: EMPLOYEE_TYPE,
+  value: null,
+};
+objectTypeOnly satisfies ObjectSelectFieldProps<typeof EMPLOYEE_TYPE>;
+
+const objectSetOnly: ObjectSelectFieldProps<typeof EMPLOYEE_TYPE> = {
+  objectSet: employeeObjectSet,
+  value: null,
+};
+objectSetOnly satisfies ObjectSelectFieldProps<typeof EMPLOYEE_TYPE>;
+
+// @ts-expect-error objectType and objectSet are mutually exclusive
+const bothSources: ObjectSelectFieldProps<typeof EMPLOYEE_TYPE> = {
+  objectType: EMPLOYEE_TYPE,
+  objectSet: employeeObjectSet,
+  value: null,
+};
+bothSources satisfies ObjectSelectFieldProps<typeof EMPLOYEE_TYPE>;
+
+// @ts-expect-error one source is required
+const neitherSource: ObjectSelectFieldProps<typeof EMPLOYEE_TYPE> = {
+  value: null,
+};
+neitherSource satisfies ObjectSelectFieldProps<typeof EMPLOYEE_TYPE>;
+
+const formFieldObjectTypeOnly: FormFieldDefinition<AssignManagerAction> = {
+  fieldKey: "manager",
+  fieldComponent: "OBJECT_SELECT",
+  label: "Manager",
+  fieldComponentProps: { objectType: EMPLOYEE_TYPE },
+};
+formFieldObjectTypeOnly satisfies FormFieldDefinition<AssignManagerAction>;
+
+const formFieldObjectSetOnly: FormFieldDefinition<AssignManagerAction> = {
+  fieldKey: "manager",
+  fieldComponent: "OBJECT_SELECT",
+  label: "Manager",
+  fieldComponentProps: { objectSet: employeeObjectSet },
+};
+formFieldObjectSetOnly satisfies FormFieldDefinition<AssignManagerAction>;
+
+const formFieldBothSources: FormFieldDefinition<AssignManagerAction> = {
+  fieldKey: "manager",
+  fieldComponent: "OBJECT_SELECT",
+  label: "Manager",
+  fieldComponentProps: {
+    objectType: EMPLOYEE_TYPE,
+    // @ts-expect-error objectType and objectSet are mutually exclusive
+    objectSet: employeeObjectSet,
+  },
+};
+formFieldBothSources satisfies FormFieldDefinition<AssignManagerAction>;
+
+const formFieldNeitherSource: FormFieldDefinition<AssignManagerAction> = {
+  fieldKey: "manager",
+  fieldComponent: "OBJECT_SELECT",
+  label: "Manager",
+  // @ts-expect-error one source is required
+  fieldComponentProps: {},
+};
+formFieldNeitherSource satisfies FormFieldDefinition<AssignManagerAction>;

--- a/packages/react-components/src/action-form/__tests__/ObjectSelectField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/ObjectSelectField.test.tsx
@@ -209,45 +209,6 @@ describe("ObjectSelectField", () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  it("prefers the object set when malformed props include both sources", () => {
-    const objectSet = createMockObjectSet();
-    mockLoadedState();
-    const props = {
-      objectType: DIFFERENT_TYPE,
-      objectSet,
-      value: null,
-      onChange: vi.fn(),
-    } as unknown as Parameters<typeof ObjectSelectField>[0];
-    render(<ObjectSelectField {...props} />);
-
-    expect(mockUseObjectSet).toHaveBeenCalledWith(
-      objectSet,
-      expect.objectContaining({
-        enabled: true,
-      }),
-    );
-    expect(mockUseOsdkObjects).toHaveBeenCalledWith(
-      EMPLOYEE_TYPE,
-      expect.objectContaining({
-        enabled: false,
-      }),
-    );
-    expect(mockUseOsdkMetadata).toHaveBeenCalledWith(EMPLOYEE_TYPE);
-  });
-
-  it("renders no options when malformed props omit both sources", () => {
-    mockLoadedState();
-    const props = {
-      value: null,
-      onChange: vi.fn(),
-    } as unknown as Parameters<typeof ObjectSelectField>[0];
-    render(<ObjectSelectField {...props} />);
-
-    expect(mockUseObjectSet).not.toHaveBeenCalled();
-    expect(mockUseOsdkObjects).not.toHaveBeenCalled();
-    expect(mockUseOsdkMetadata).not.toHaveBeenCalled();
-  });
-
   it("displays object titles as dropdown items", async () => {
     mockLoadedState();
     renderObjectSelect();
@@ -388,7 +349,6 @@ function makeMockObject(primaryKey: number, title?: string) {
 
 /** Minimal ObjectTypeDefinition shape — useOsdkObjects only reads type + apiName at runtime. */
 const EMPLOYEE_TYPE = { type: "object" as const, apiName: "Employee" };
-const DIFFERENT_TYPE = { type: "object" as const, apiName: "Office" };
 
 function createMockObjectSet(): ObjectSet<typeof EMPLOYEE_TYPE> {
   return {

--- a/packages/react-components/src/action-form/__tests__/ObjectSelectField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/ObjectSelectField.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { ObjectSet } from "@osdk/api";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ObjectSelectField } from "../fields/ObjectSelectField.js";
@@ -62,11 +63,15 @@ vi.stubGlobal(
 );
 
 vi.mock("@osdk/react", () => ({
+  useObjectSet: vi.fn(),
   useOsdkMetadata: vi.fn(),
   useOsdkObjects: vi.fn(),
 }));
 
-const { useOsdkMetadata, useOsdkObjects } = await import("@osdk/react");
+const { useObjectSet, useOsdkMetadata, useOsdkObjects } = await import(
+  "@osdk/react"
+);
+const mockUseObjectSet = vi.mocked(useObjectSet);
 const mockUseOsdkMetadata = vi.mocked(useOsdkMetadata);
 const mockUseOsdkObjects = vi.mocked(useOsdkObjects);
 
@@ -94,7 +99,7 @@ function mockLoadedState(
 ) {
   // The mock return must satisfy UseOsdkListResult which has complex generics.
   // We construct the minimal shape needed by the component at runtime.
-  mockUseOsdkObjects.mockReturnValue({
+  const loadedState = {
     data,
     isLoading: false,
     isOptimistic: false,
@@ -104,14 +109,143 @@ function mockLoadedState(
     refetch: vi.fn(),
     objectSet: undefined,
     ...overrides,
-  } as never);
+  } as never;
+  mockUseOsdkObjects.mockReturnValue(loadedState);
+  mockUseObjectSet.mockReturnValue(loadedState);
 }
 
 describe("ObjectSelectField", () => {
   beforeEach(() => {
+    mockUseObjectSet.mockReset();
     mockUseOsdkObjects.mockReset();
     mockUseOsdkMetadata.mockReset();
     mockMetadataLoaded();
+  });
+
+  it("uses the object type data source by default", () => {
+    mockLoadedState();
+    renderObjectSelect();
+
+    expect(mockUseOsdkObjects).toHaveBeenCalledWith(
+      EMPLOYEE_TYPE,
+      expect.objectContaining({
+        enabled: true,
+        pageSize: 50,
+      }),
+    );
+    expect(mockUseObjectSet).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({
+        enabled: false,
+        pageSize: 50,
+      }),
+    );
+  });
+
+  it("uses an object set data source when provided", () => {
+    const objectSet = createMockObjectSet();
+    mockLoadedState();
+    renderObjectSelect({ objectSet });
+
+    expect(mockUseObjectSet).toHaveBeenCalledWith(
+      objectSet,
+      expect.objectContaining({
+        enabled: true,
+        pageSize: 50,
+      }),
+    );
+    expect(mockUseOsdkObjects).toHaveBeenCalledWith(
+      EMPLOYEE_TYPE,
+      expect.objectContaining({
+        enabled: false,
+        pageSize: 50,
+      }),
+    );
+    expect(mockUseOsdkMetadata).toHaveBeenCalledWith(EMPLOYEE_TYPE);
+  });
+
+  it("applies debounced search within an object set data source", async () => {
+    vi.useFakeTimers();
+    try {
+      const objectSet = createMockObjectSet();
+      mockLoadedState();
+      renderObjectSelect({ objectSet });
+      await openCombobox();
+
+      const searchInput = screen.getByPlaceholderText("Search…");
+      fireEvent.change(searchInput, { target: { value: "Ali" } });
+
+      const firstCall = mockUseObjectSet.mock.calls.at(-1);
+      expect(firstCall?.[1]?.where).toBeUndefined();
+
+      vi.advanceTimersByTime(300);
+
+      await vi.waitFor(() => {
+        const latestCall = mockUseObjectSet.mock.calls.at(-1);
+        expect(latestCall?.[1]?.where).toEqual({
+          fullName: { $containsAllTermsInOrder: "Ali" },
+        });
+      });
+      expect(mockUseOsdkObjects).toHaveBeenLastCalledWith(
+        EMPLOYEE_TYPE,
+        expect.objectContaining({
+          enabled: false,
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not clear a current value outside the object set results", () => {
+    const onChange = vi.fn();
+    mockLoadedState(MOCK_EMPLOYEES);
+    renderObjectSelect({
+      objectSet: createMockObjectSet(),
+      value: makeMockObject(999, "Outside Scope") as never,
+      onChange,
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("prefers the object set when malformed props include both sources", () => {
+    const objectSet = createMockObjectSet();
+    mockLoadedState();
+    const props = {
+      objectType: DIFFERENT_TYPE,
+      objectSet,
+      value: null,
+      onChange: vi.fn(),
+    } as unknown as Parameters<typeof ObjectSelectField>[0];
+    render(<ObjectSelectField {...props} />);
+
+    expect(mockUseObjectSet).toHaveBeenCalledWith(
+      objectSet,
+      expect.objectContaining({
+        enabled: true,
+      }),
+    );
+    expect(mockUseOsdkObjects).toHaveBeenCalledWith(
+      EMPLOYEE_TYPE,
+      expect.objectContaining({
+        enabled: false,
+      }),
+    );
+    expect(mockUseOsdkMetadata).toHaveBeenCalledWith(EMPLOYEE_TYPE);
+  });
+
+  it("renders no options when malformed props omit both sources", () => {
+    mockLoadedState();
+    const props = {
+      value: null,
+      onChange: vi.fn(),
+    } as unknown as Parameters<typeof ObjectSelectField>[0];
+    render(<ObjectSelectField {...props} />);
+
+    expect(mockUseObjectSet).not.toHaveBeenCalled();
+    expect(mockUseOsdkObjects).not.toHaveBeenCalled();
+    expect(mockUseOsdkMetadata).not.toHaveBeenCalled();
   });
 
   it("displays object titles as dropdown items", async () => {
@@ -254,16 +388,33 @@ function makeMockObject(primaryKey: number, title?: string) {
 
 /** Minimal ObjectTypeDefinition shape — useOsdkObjects only reads type + apiName at runtime. */
 const EMPLOYEE_TYPE = { type: "object" as const, apiName: "Employee" };
+const DIFFERENT_TYPE = { type: "object" as const, apiName: "Office" };
+
+function createMockObjectSet(): ObjectSet<typeof EMPLOYEE_TYPE> {
+  return {
+    $objectSetInternals: { def: EMPLOYEE_TYPE },
+  } as ObjectSet<typeof EMPLOYEE_TYPE>;
+}
 
 function renderObjectSelect(
   overrides: Partial<Parameters<typeof ObjectSelectField>[0]> = {},
 ) {
+  const props = ("objectSet" in overrides && overrides.objectSet != null)
+    ? {
+      value: null,
+      onChange: vi.fn(),
+      ...overrides,
+    }
+    : {
+      objectType: EMPLOYEE_TYPE,
+      value: null,
+      onChange: vi.fn(),
+      ...overrides,
+    };
+
   return render(
     <ObjectSelectField
-      objectType={EMPLOYEE_TYPE}
-      value={null}
-      onChange={vi.fn()}
-      {...overrides}
+      {...(props as Parameters<typeof ObjectSelectField>[0])}
     />,
   );
 }

--- a/packages/react-components/src/action-form/fields/FormFieldRenderer.tsx
+++ b/packages/react-components/src/action-form/fields/FormFieldRenderer.tsx
@@ -216,21 +216,15 @@ function renderFieldComponent(
           {...fieldDefinition.fieldComponentProps}
         />
       );
-    case "OBJECT_SELECT":
-      return (
-        <ObjectSelectField
-          id={fieldDefinition.fieldKey}
-          value={narrowToOsdkObject(value)}
-          onChange={onChange}
-          placeholder={fieldDefinition.placeholder}
-          error={error}
-          {...fieldDefinition.fieldComponentProps}
-          portalContainer={resolvePortalContainer(
-            fieldDefinition.fieldComponentProps,
-            portalContainer,
-          )}
-        />
+    case "OBJECT_SELECT": {
+      return renderObjectSelectField(
+        fieldDefinition,
+        value,
+        onChange,
+        error,
+        portalContainer,
       );
+    }
     case "OBJECT_SET":
       return (
         <ObjectSetField
@@ -241,6 +235,49 @@ function renderFieldComponent(
     default:
       return assertUnreachableFieldComponent(fieldDefinition);
   }
+}
+
+function renderObjectSelectField(
+  fieldDefinition: Extract<
+    RendererFieldDefinition,
+    { fieldComponent: "OBJECT_SELECT" }
+  >,
+  value: unknown,
+  onChange: (value: unknown) => void,
+  error: string | undefined,
+  portalContainer: PortalContainer | undefined,
+): React.ReactElement {
+  const resolvedPortalContainer = resolvePortalContainer(
+    fieldDefinition.fieldComponentProps,
+    portalContainer,
+  );
+  const sharedProps = {
+    id: fieldDefinition.fieldKey,
+    value: narrowToOsdkObject(value),
+    onChange,
+    placeholder: fieldDefinition.placeholder,
+    error,
+  };
+
+  // Keep the two source branches separate so TypeScript preserves the
+  // objectType/objectSet exclusivity when the renderer-managed props are added.
+  if ("objectSet" in fieldDefinition.fieldComponentProps) {
+    return (
+      <ObjectSelectField
+        {...sharedProps}
+        {...fieldDefinition.fieldComponentProps}
+        portalContainer={resolvedPortalContainer}
+      />
+    );
+  }
+
+  return (
+    <ObjectSelectField
+      {...sharedProps}
+      {...fieldDefinition.fieldComponentProps}
+      portalContainer={resolvedPortalContainer}
+    />
+  );
 }
 
 function resolvePortalContainer(

--- a/packages/react-components/src/action-form/fields/FormFieldRenderer.tsx
+++ b/packages/react-components/src/action-form/fields/FormFieldRenderer.tsx
@@ -216,15 +216,21 @@ function renderFieldComponent(
           {...fieldDefinition.fieldComponentProps}
         />
       );
-    case "OBJECT_SELECT": {
-      return renderObjectSelectField(
-        fieldDefinition,
-        value,
-        onChange,
-        error,
-        portalContainer,
+    case "OBJECT_SELECT":
+      return (
+        <ObjectSelectField
+          id={fieldDefinition.fieldKey}
+          value={narrowToOsdkObject(value)}
+          onChange={onChange}
+          placeholder={fieldDefinition.placeholder}
+          error={error}
+          {...fieldDefinition.fieldComponentProps}
+          portalContainer={resolvePortalContainer(
+            fieldDefinition.fieldComponentProps,
+            portalContainer,
+          )}
+        />
       );
-    }
     case "OBJECT_SET":
       return (
         <ObjectSetField
@@ -235,49 +241,6 @@ function renderFieldComponent(
     default:
       return assertUnreachableFieldComponent(fieldDefinition);
   }
-}
-
-function renderObjectSelectField(
-  fieldDefinition: Extract<
-    RendererFieldDefinition,
-    { fieldComponent: "OBJECT_SELECT" }
-  >,
-  value: unknown,
-  onChange: (value: unknown) => void,
-  error: string | undefined,
-  portalContainer: PortalContainer | undefined,
-): React.ReactElement {
-  const resolvedPortalContainer = resolvePortalContainer(
-    fieldDefinition.fieldComponentProps,
-    portalContainer,
-  );
-  const sharedProps = {
-    id: fieldDefinition.fieldKey,
-    value: narrowToOsdkObject(value),
-    onChange,
-    placeholder: fieldDefinition.placeholder,
-    error,
-  };
-
-  // Keep the two source branches separate so TypeScript preserves the
-  // objectType/objectSet exclusivity when the renderer-managed props are added.
-  if ("objectSet" in fieldDefinition.fieldComponentProps) {
-    return (
-      <ObjectSelectField
-        {...sharedProps}
-        {...fieldDefinition.fieldComponentProps}
-        portalContainer={resolvedPortalContainer}
-      />
-    );
-  }
-
-  return (
-    <ObjectSelectField
-      {...sharedProps}
-      {...fieldDefinition.fieldComponentProps}
-      portalContainer={resolvedPortalContainer}
-    />
-  );
 }
 
 function resolvePortalContainer(

--- a/packages/react-components/src/action-form/fields/ObjectSelectField.tsx
+++ b/packages/react-components/src/action-form/fields/ObjectSelectField.tsx
@@ -40,27 +40,22 @@ export const ObjectSelectField: React.NamedExoticComponent<
   ObjectSelectFieldProps
 > = memo(function ObjectSelectFieldFn(props): React.ReactElement {
   const source = resolveObjectSelectSource(props);
-
-  if (source == null) {
-    return <ObjectSelectUnavailableField {...props} />;
-  }
-
-  return <ObjectSelectAvailableField {...props} source={source} />;
+  return <ObjectSelectInner {...props} source={source} />;
 });
 
 type ResolvedObjectSelectSource<Q extends ObjectTypeDefinition> =
   | { kind: "objectType"; objectType: Q; objectSet?: undefined }
   | { kind: "objectSet"; objectType: Q; objectSet: ObjectSet<Q> };
 
-type ObjectSelectAvailableFieldProps<Q extends ObjectTypeDefinition> =
+type ObjectSelectInnerProps<Q extends ObjectTypeDefinition> =
   & ObjectSelectFieldProps<Q>
   & {
     source: ResolvedObjectSelectSource<Q>;
   };
 
-const ObjectSelectAvailableField: React.NamedExoticComponent<
-  ObjectSelectAvailableFieldProps<ObjectTypeDefinition>
-> = memo(function ObjectSelectAvailableFieldFn({
+const ObjectSelectInner: React.NamedExoticComponent<
+  ObjectSelectInnerProps<ObjectTypeDefinition>
+> = memo(function ObjectSelectInnerFn({
   source,
   value,
   onChange,
@@ -153,52 +148,9 @@ const ObjectSelectAvailableField: React.NamedExoticComponent<
   );
 });
 
-const ObjectSelectUnavailableField: React.NamedExoticComponent<
-  ObjectSelectFieldProps<ObjectTypeDefinition>
-> = memo(function ObjectSelectUnavailableFieldFn({
-  value,
-  onChange,
-  error,
-  id,
-  placeholder,
-  isMultiple,
-  portalRef,
-  portalContainer,
-}): React.ReactElement {
-  const handleChange = useCallback(
-    (newValue: ObjectSelectOsdkObject | null) => {
-      onChange?.(newValue);
-    },
-    [onChange],
-  );
-
-  const handleFetchMore = useCallback(() => {}, []);
-
-  return (
-    <AsyncDropdownField
-      id={id}
-      value={value}
-      onChange={handleChange}
-      error={error}
-      items={EMPTY_OBJECT_SELECT_ITEMS}
-      itemToStringLabel={itemToStringLabel}
-      itemToKey={itemToKey}
-      isItemEqual={isItemEqual}
-      placeholder={placeholder ?? "Search…"}
-      isMultiple={isMultiple}
-      portalRef={portalRef}
-      portalContainer={portalContainer}
-      isLoading={false}
-      isSearching={false}
-      hasMore={false}
-      onFetchMore={handleFetchMore}
-    />
-  );
-});
-
 function resolveObjectSelectSource(
   props: ObjectSelectFieldProps<ObjectTypeDefinition>,
-): ResolvedObjectSelectSource<ObjectTypeDefinition> | undefined {
+): ResolvedObjectSelectSource<ObjectTypeDefinition> {
   if ("objectSet" in props && props.objectSet != null) {
     return {
       kind: "objectSet",
@@ -207,11 +159,7 @@ function resolveObjectSelectSource(
     };
   }
 
-  if ("objectType" in props && props.objectType != null) {
-    return { kind: "objectType", objectType: props.objectType };
-  }
-
-  return undefined;
+  return { kind: "objectType", objectType: props.objectType };
 }
 
 function itemToStringLabel(obj: ObjectSelectOsdkObject): string {

--- a/packages/react-components/src/action-form/fields/ObjectSelectField.tsx
+++ b/packages/react-components/src/action-form/fields/ObjectSelectField.tsx
@@ -14,8 +14,13 @@
  * limitations under the License.
  */
 
-import type { ObjectTypeDefinition, Osdk, WhereClause } from "@osdk/api";
-import { useOsdkMetadata, useOsdkObjects } from "@osdk/react";
+import type {
+  ObjectSet,
+  ObjectTypeDefinition,
+  Osdk,
+  WhereClause,
+} from "@osdk/api";
+import { useObjectSet, useOsdkMetadata, useOsdkObjects } from "@osdk/react";
 import React, { memo, useCallback, useMemo, useState } from "react";
 import { useDebouncedValue } from "../../shared/hooks/useDebouncedValue.js";
 import type { ObjectSelectFieldProps } from "../FormFieldApi.js";
@@ -26,15 +31,37 @@ const SEARCH_DEBOUNCE_MS = 300;
 /** Number of objects fetched per page from the OSDK. */
 const PAGE_SIZE = 50;
 
-type OsdkObject = Osdk.Instance<ObjectTypeDefinition>;
+type ObjectSelectOsdkObject = Osdk.Instance<ObjectTypeDefinition>;
 
 /** Stable empty array so the component doesn't re-render when data is undefined. */
-const EMPTY_ITEMS: OsdkObject[] = [];
+const EMPTY_OBJECT_SELECT_ITEMS: ObjectSelectOsdkObject[] = [];
 
 export const ObjectSelectField: React.NamedExoticComponent<
   ObjectSelectFieldProps
-> = memo(function ObjectSelectFieldFn({
-  objectType,
+> = memo(function ObjectSelectFieldFn(props): React.ReactElement {
+  const source = resolveObjectSelectSource(props);
+
+  if (source == null) {
+    return <ObjectSelectUnavailableField {...props} />;
+  }
+
+  return <ObjectSelectAvailableField {...props} source={source} />;
+});
+
+type ResolvedObjectSelectSource<Q extends ObjectTypeDefinition> =
+  | { kind: "objectType"; objectType: Q; objectSet?: undefined }
+  | { kind: "objectSet"; objectType: Q; objectSet: ObjectSet<Q> };
+
+type ObjectSelectAvailableFieldProps<Q extends ObjectTypeDefinition> =
+  & ObjectSelectFieldProps<Q>
+  & {
+    source: ResolvedObjectSelectSource<Q>;
+  };
+
+const ObjectSelectAvailableField: React.NamedExoticComponent<
+  ObjectSelectAvailableFieldProps<ObjectTypeDefinition>
+> = memo(function ObjectSelectAvailableFieldFn({
+  source,
   value,
   onChange,
   error,
@@ -50,14 +77,14 @@ export const ObjectSelectField: React.NamedExoticComponent<
   const debouncedQuery = useDebouncedValue(query, SEARCH_DEBOUNCE_MS);
 
   const handleChange = useCallback(
-    (newValue: OsdkObject | null) => {
+    (newValue: ObjectSelectOsdkObject | null) => {
       onChange?.(newValue);
       setQuery("");
     },
     [onChange],
   );
 
-  const { metadata } = useOsdkMetadata(objectType);
+  const { metadata } = useOsdkMetadata(source.objectType);
   const titleProperty = typeof metadata?.titleProperty === "string"
     ? metadata.titleProperty
     : undefined;
@@ -76,18 +103,27 @@ export const ObjectSelectField: React.NamedExoticComponent<
     } as WhereClause<ObjectTypeDefinition>;
   }, [debouncedQuery, titleProperty]);
 
+  const objectSetResult = useObjectSet(source.objectSet, {
+    where,
+    pageSize: PAGE_SIZE,
+    enabled: source.kind === "objectSet",
+  });
+
+  const objectTypeResult = useOsdkObjects(source.objectType, {
+    where,
+    pageSize: PAGE_SIZE,
+    enabled: source.kind === "objectType",
+  });
+
   const {
     data,
     isLoading,
     error: fetchError,
     fetchMore,
     hasMore,
-  } = useOsdkObjects(objectType, {
-    where,
-    pageSize: PAGE_SIZE,
-  });
+  } = source.kind === "objectSet" ? objectSetResult : objectTypeResult;
 
-  const items = data ?? EMPTY_ITEMS;
+  const items = data ?? EMPTY_OBJECT_SELECT_ITEMS;
 
   const handleFetchMore = useCallback(() => {
     void fetchMore?.();
@@ -117,14 +153,78 @@ export const ObjectSelectField: React.NamedExoticComponent<
   );
 });
 
-function itemToStringLabel(obj: OsdkObject): string {
+const ObjectSelectUnavailableField: React.NamedExoticComponent<
+  ObjectSelectFieldProps<ObjectTypeDefinition>
+> = memo(function ObjectSelectUnavailableFieldFn({
+  value,
+  onChange,
+  error,
+  id,
+  placeholder,
+  isMultiple,
+  portalRef,
+  portalContainer,
+}): React.ReactElement {
+  const handleChange = useCallback(
+    (newValue: ObjectSelectOsdkObject | null) => {
+      onChange?.(newValue);
+    },
+    [onChange],
+  );
+
+  const handleFetchMore = useCallback(() => {}, []);
+
+  return (
+    <AsyncDropdownField
+      id={id}
+      value={value}
+      onChange={handleChange}
+      error={error}
+      items={EMPTY_OBJECT_SELECT_ITEMS}
+      itemToStringLabel={itemToStringLabel}
+      itemToKey={itemToKey}
+      isItemEqual={isItemEqual}
+      placeholder={placeholder ?? "Search…"}
+      isMultiple={isMultiple}
+      portalRef={portalRef}
+      portalContainer={portalContainer}
+      isLoading={false}
+      isSearching={false}
+      hasMore={false}
+      onFetchMore={handleFetchMore}
+    />
+  );
+});
+
+function resolveObjectSelectSource(
+  props: ObjectSelectFieldProps<ObjectTypeDefinition>,
+): ResolvedObjectSelectSource<ObjectTypeDefinition> | undefined {
+  if ("objectSet" in props && props.objectSet != null) {
+    return {
+      kind: "objectSet",
+      objectSet: props.objectSet,
+      objectType: props.objectSet.$objectSetInternals.def,
+    };
+  }
+
+  if ("objectType" in props && props.objectType != null) {
+    return { kind: "objectType", objectType: props.objectType };
+  }
+
+  return undefined;
+}
+
+function itemToStringLabel(obj: ObjectSelectOsdkObject): string {
   return obj.$title ?? String(obj.$primaryKey);
 }
 
-function itemToKey(obj: OsdkObject): string {
+function itemToKey(obj: ObjectSelectOsdkObject): string {
   return String(obj.$primaryKey);
 }
 
-function isItemEqual(a: OsdkObject, b: OsdkObject): boolean {
+function isItemEqual(
+  a: ObjectSelectOsdkObject,
+  b: ObjectSelectOsdkObject,
+): boolean {
   return a.$primaryKey === b.$primaryKey;
 }

--- a/packages/react-components/src/public/experimental/action-form.ts
+++ b/packages/react-components/src/public/experimental/action-form.ts
@@ -40,6 +40,7 @@ export type {
   FormFieldDefinition,
   FormFieldPropsByType,
   NumberInputFieldProps,
+  ObjectSelectFieldProps,
   ObjectSetFieldProps,
   Option,
   PortalContainer,


### PR DESCRIPTION
## Summary
- add `objectSet` as an alternative data source for `OBJECT_SELECT`
- make `objectType` and `objectSet` mutually exclusive in the public props and form definitions
- add runtime coverage, type coverage, docs, Storybook example, sandbox demo, and changeset

## Verification
- `pnpm vitest run src/action-form/__tests__/ObjectSelectField.test.tsx`
- `pnpm turbo typecheck --filter=@osdk/react-components --filter=@osdk/e2e.sandbox.peopleapp --filter=@osdk/react-components-storybook`
- `pnpm turbo check-api --filter=@osdk/react-components`
- `DPRINT_CACHE_DIR=/private/tmp/dprint-cache pnpm exec dprint check ...`

<img width="1504" height="829" alt="Screenshot 2026-05-12 at 15 54 00" src="https://github.com/user-attachments/assets/4323bb29-c788-4bb7-985d-92342c8d67ab" />

