### PR TITLE
allow filter list renderValue to return a reactnode

### DIFF
--- a/.changeset/filter-list-render-value-react-node.md
+++ b/.changeset/filter-list-render-value-react-node.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+Widen `renderValue` return type on FilterList property and static-values filter definitions from `string` to `ReactNode` so callers can render custom React components (e.g. avatars, anchors) for filter values. When `renderValue` returns a non-string `ReactNode`, search matching falls back to the raw value.

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
@@ -893,6 +893,110 @@ const filterDefinitions = [
   render: (args) => <WithRenderValueStory {...args} />,
 };
 
+const DEPARTMENT_SWATCHES: Record<string, string> = {
+  Marketing: "#f97316",
+  Operations: "#3b82f6",
+  Finance: "#10b981",
+  Product: "#a855f7",
+};
+
+const SWATCH_ROW_STYLE = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 8,
+} as const;
+
+const SWATCH_DOT_BASE_STYLE = {
+  display: "inline-block",
+  width: 10,
+  height: 10,
+  borderRadius: "50%",
+  flexShrink: 0,
+} as const;
+
+function DepartmentSwatch({ value }: { value: string }) {
+  const color = DEPARTMENT_SWATCHES[value] ?? "#94a3b8";
+  return (
+    <span style={SWATCH_ROW_STYLE}>
+      <span style={{ ...SWATCH_DOT_BASE_STYLE, background: color }} />
+      <span>{DEPARTMENT_LABELS[value] ?? value}</span>
+    </span>
+  );
+}
+
+function WithRenderValueReactNodeStory(args: Partial<EmployeeFilterListProps>) {
+  const filterDefinitions = useMemo(
+    (): FilterDefinitionUnion<Employee>[] => [
+      {
+        type: "PROPERTY",
+        id: "department-swatch",
+        key: "department",
+        label: "Department (JSX)",
+        filterComponent: "LISTOGRAM",
+        filterState: { type: "EXACT_MATCH", values: [] },
+        renderValue: (value) => <DepartmentSwatch value={value} />,
+      },
+      {
+        type: "PROPERTY",
+        id: "team-link",
+        key: "team",
+        label: "Team (anchor JSX)",
+        filterComponent: "MULTI_SELECT",
+        filterState: { type: "SELECT", selectedValues: [] },
+        renderValue: (value) => (
+          <a
+            href={`#/team/${encodeURIComponent(value)}`}
+            onClick={(event) => event.preventDefault()}
+            style={{ color: "#2563eb", textDecoration: "underline" }}
+          >
+            {value}
+          </a>
+        ),
+      },
+    ],
+    [],
+  );
+
+  return (
+    <div style={SIDEBAR_STYLE}>
+      <FilterList
+        objectType={Employee}
+        filterDefinitions={filterDefinitions}
+        {...args}
+      />
+    </div>
+  );
+}
+
+export const WithRenderValueAsReactNode: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "`renderValue` may return any `ReactNode`, not just a string. "
+          + "Use this to render avatars, anchors, status pills, or any "
+          + "custom JSX inside listogram rows, dropdown items, and chips. "
+          + "When the function returns non-string JSX, search matching "
+          + "falls back to the raw value.",
+      },
+      source: {
+        code: `const filterDefinitions = [
+  {
+    type: "PROPERTY",
+    key: "department",
+    label: "Department",
+    filterComponent: "LISTOGRAM",
+    filterState: { type: "EXACT_MATCH", values: [] },
+    renderValue: (value) => <DepartmentSwatch value={value} />,
+  },
+];
+
+<FilterList objectType={Employee} filterDefinitions={filterDefinitions} />`,
+      },
+    },
+  },
+  render: (args) => <WithRenderValueReactNodeStory {...args} />,
+};
+
 function WithListogramDisplayModesStory(
   args: Partial<EmployeeFilterListProps>,
 ) {

--- a/packages/react-components/src/filter-list/FilterListItemApi.ts
+++ b/packages/react-components/src/filter-list/FilterListItemApi.ts
@@ -21,6 +21,7 @@ import type {
   PropertyKeys,
   WirePropertyTypes,
 } from "@osdk/api";
+import type { ReactNode } from "react";
 import type { CustomFilterState } from "./types/CustomRendererTypes.js";
 import type { KeywordSearchFilterState } from "./types/KeywordSearchTypes.js";
 import type {
@@ -297,9 +298,11 @@ interface PropertyFilterDefinitionBase<
   /**
    * Custom display function for filter values.
    * Replaces the default string display in dropdown items, chips, and listogram rows.
-   * The returned string is also used for search matching within filter dropdowns.
+   * When the function returns a string, that string is also used for search matching
+   * within filter dropdowns. When it returns a non-string `ReactNode`, search falls
+   * back to the raw value.
    */
-  renderValue?: (value: string) => string;
+  renderValue?: (value: string) => ReactNode;
 
   /**
    * Show aggregation counts next to filter option values.

--- a/packages/react-components/src/filter-list/base/inputs/ListogramInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/ListogramInput.tsx
@@ -47,7 +47,7 @@ interface ListogramInputProps {
   style?: React.CSSProperties;
   maxVisibleItems?: number;
   searchQuery?: string;
-  renderValue?: (value: string) => string;
+  renderValue?: (value: string) => React.ReactNode;
 }
 
 function ListogramInputInner({
@@ -89,7 +89,10 @@ function ListogramInputInner({
       return filterValuesBySearch(
         stableValues,
         searchQuery,
-        (v) => renderValue?.(v.value) ?? v.value,
+        (v) => {
+          const rendered = renderValue?.(v.value);
+          return typeof rendered === "string" ? rendered : v.value;
+        },
       );
     }
     return stableValues;

--- a/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.tsx
@@ -20,6 +20,7 @@ import { Combobox } from "../../../base-components/combobox/Combobox.js";
 import type { PropertyAggregationValue } from "../../types/AggregationTypes.js";
 import { isEmptyValue } from "../../utils/filterValues.js";
 import { useFilterListBoundary } from "../FilterListBoundaryContext.js";
+import { createRenderValueFilter } from "./comboboxFilter.js";
 import { MultiSelectDropdownLayout } from "./MultiSelectDropdownLayout.js";
 import { MultiSelectInlineLayout } from "./MultiSelectInlineLayout.js";
 import styles from "./MultiSelectInput.module.css";
@@ -88,16 +89,7 @@ function MultiSelectInputInner({
   );
 
   const comboboxFilter = useMemo(
-    () =>
-      renderValue
-        ? (itemValue: string, query: string) => {
-          const rendered = renderValue(itemValue);
-          const searchText = typeof rendered === "string"
-            ? rendered
-            : itemValue;
-          return searchText.toLowerCase().includes(query.toLowerCase());
-        }
-        : undefined,
+    () => renderValue ? createRenderValueFilter(renderValue) : undefined,
     [renderValue],
   );
 

--- a/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.tsx
@@ -48,7 +48,7 @@ interface MultiSelectInputProps {
   placeholder?: string;
   showCounts?: boolean;
   ariaLabel?: string;
-  renderValue?: (value: string) => string;
+  renderValue?: (value: string) => React.ReactNode;
   layout?: MultiSelectInputLayout;
 }
 
@@ -90,8 +90,13 @@ function MultiSelectInputInner({
   const comboboxFilter = useMemo(
     () =>
       renderValue
-        ? (itemValue: string, query: string) =>
-          renderValue(itemValue).toLowerCase().includes(query.toLowerCase())
+        ? (itemValue: string, query: string) => {
+          const rendered = renderValue(itemValue);
+          const searchText = typeof rendered === "string"
+            ? rendered
+            : itemValue;
+          return searchText.toLowerCase().includes(query.toLowerCase());
+        }
         : undefined,
     [renderValue],
   );

--- a/packages/react-components/src/filter-list/base/inputs/SingleSelectInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/SingleSelectInput.tsx
@@ -37,7 +37,7 @@ interface SingleSelectInputProps {
   showClearButton?: boolean;
   showCounts?: boolean;
   ariaLabel?: string;
-  renderValue?: (value: string) => string;
+  renderValue?: (value: string) => React.ReactNode;
 }
 
 function SingleSelectInputInner({
@@ -78,8 +78,13 @@ function SingleSelectInputInner({
   const comboboxFilter = useMemo(
     () =>
       renderValue
-        ? (itemValue: string, query: string) =>
-          renderValue(itemValue).toLowerCase().includes(query.toLowerCase())
+        ? (itemValue: string, query: string) => {
+          const rendered = renderValue(itemValue);
+          const searchText = typeof rendered === "string"
+            ? rendered
+            : itemValue;
+          return searchText.toLowerCase().includes(query.toLowerCase());
+        }
         : undefined,
     [renderValue],
   );

--- a/packages/react-components/src/filter-list/base/inputs/SingleSelectInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/SingleSelectInput.tsx
@@ -20,6 +20,7 @@ import { Combobox } from "../../../base-components/combobox/Combobox.js";
 import type { PropertyAggregationValue } from "../../types/AggregationTypes.js";
 import { isEmptyValue } from "../../utils/filterValues.js";
 import { useFilterListBoundary } from "../FilterListBoundaryContext.js";
+import { createRenderValueFilter } from "./comboboxFilter.js";
 import { NoValueLabel } from "./NoValueLabel.js";
 import sharedStyles from "./shared.module.css";
 import styles from "./SingleSelectInput.module.css";
@@ -76,16 +77,7 @@ function SingleSelectInputInner({
   );
 
   const comboboxFilter = useMemo(
-    () =>
-      renderValue
-        ? (itemValue: string, query: string) => {
-          const rendered = renderValue(itemValue);
-          const searchText = typeof rendered === "string"
-            ? rendered
-            : itemValue;
-          return searchText.toLowerCase().includes(query.toLowerCase());
-        }
-        : undefined,
+    () => renderValue ? createRenderValueFilter(renderValue) : undefined,
     [renderValue],
   );
 

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/renderValue.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/renderValue.test.tsx
@@ -159,6 +159,49 @@ describe("MultiSelectInput renderValue", () => {
   });
 });
 
+describe("ListogramInput renderValue (ReactNode)", () => {
+  const renderValueAsNode = (value: string): React.ReactNode => (
+    <a href={`/user/${value}`} data-testid={`anchor-${value}`}>
+      {LABELS[value] ?? value}
+    </a>
+  );
+
+  it("renders JSX returned from renderValue", () => {
+    render(
+      <ListogramInput
+        values={mockValues}
+        maxCount={7}
+        isLoading={false}
+        error={null}
+        selectedValues={[]}
+        onChange={vi.fn()}
+        renderValue={renderValueAsNode}
+      />,
+    );
+
+    expect(screen.getByTestId("anchor-abc-123")).toBeDefined();
+    expect(screen.getByText("Alice Smith")).toBeDefined();
+  });
+
+  it("falls back to raw value for search when renderValue returns JSX", () => {
+    render(
+      <ListogramInput
+        values={mockValues}
+        maxCount={7}
+        isLoading={false}
+        error={null}
+        selectedValues={[]}
+        onChange={vi.fn()}
+        renderValue={renderValueAsNode}
+        searchQuery="abc"
+      />,
+    );
+
+    expect(screen.getByTestId("anchor-abc-123")).toBeDefined();
+    expect(screen.queryByTestId("anchor-def-456")).toBeNull();
+  });
+});
+
 describe("SingleSelectInput renderValue", () => {
   // SingleSelectInput renders dropdown items inside a Combobox portal
   // which only mounts when opened — not testable in jsdom without

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/renderValue.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/renderValue.test.tsx
@@ -18,6 +18,7 @@ import { cleanup, render, screen } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PropertyAggregationValue } from "../../../types/AggregationTypes.js";
+import { createRenderValueFilter } from "../comboboxFilter.js";
 import { ListogramInput } from "../ListogramInput.js";
 import { MultiSelectInput } from "../MultiSelectInput.js";
 import { SingleSelectInput } from "../SingleSelectInput.js";
@@ -202,11 +203,61 @@ describe("ListogramInput renderValue (ReactNode)", () => {
   });
 });
 
+describe("MultiSelectInput renderValue (ReactNode)", () => {
+  it("renders JSX returned from renderValue inside a selected chip", () => {
+    const renderValueAsNode = (value: string): React.ReactNode => (
+      <a href={`/user/${value}`} data-testid={`chip-anchor-${value}`}>
+        {LABELS[value] ?? value}
+      </a>
+    );
+
+    render(
+      <MultiSelectInput
+        values={mockValues}
+        isLoading={false}
+        error={null}
+        selectedValues={["abc-123"]}
+        onChange={vi.fn()}
+        renderValue={renderValueAsNode}
+      />,
+    );
+
+    expect(screen.getByTestId("chip-anchor-abc-123")).toBeDefined();
+    expect(screen.getByText("Alice Smith")).toBeDefined();
+  });
+});
+
+describe("createRenderValueFilter", () => {
+  // Covers the search-fallback behavior shared by MultiSelectInput and
+  // SingleSelectInput's `comboboxFilter`. Dropdown items live in a Combobox
+  // portal that jsdom can't mount, so the filter is tested directly.
+
+  it("matches against the rendered string when renderValue returns a string", () => {
+    const filter = createRenderValueFilter(
+      (value) => LABELS[value] ?? value,
+    );
+
+    expect(filter("abc-123", "alice")).toBe(true);
+    expect(filter("def-456", "alice")).toBe(false);
+  });
+
+  it("falls back to the raw value when renderValue returns JSX", () => {
+    const filter = createRenderValueFilter(
+      (value) => <a href={`/user/${value}`}>{LABELS[value] ?? value}</a>,
+    );
+
+    expect(filter("abc-123", "abc")).toBe(true);
+    expect(filter("abc-123", "alice")).toBe(false);
+  });
+});
+
 describe("SingleSelectInput renderValue", () => {
   // SingleSelectInput renders dropdown items inside a Combobox portal
   // which only mounts when opened — not testable in jsdom without
-  // full browser event sequences. These tests verify the component
-  // accepts the prop and renders without errors.
+  // full browser event sequences. Filter behavior (including the
+  // ReactNode fallback) is covered by the `createRenderValueFilter`
+  // tests above. These tests verify the component accepts the prop
+  // and renders without errors.
 
   it("mounts with renderValue without error", () => {
     const { container } = render(

--- a/packages/react-components/src/filter-list/base/inputs/comboboxFilter.ts
+++ b/packages/react-components/src/filter-list/base/inputs/comboboxFilter.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ReactNode } from "react";
+
+/**
+ * Build a Combobox `filter` function that searches by `renderValue(item)` when
+ * it returns a string, and falls back to the raw item value when it returns
+ * non-string JSX. Comparison is case-insensitive.
+ */
+export function createRenderValueFilter(
+  renderValue: (value: string) => ReactNode,
+): (itemValue: string, query: string) => boolean {
+  return (itemValue, query) => {
+    const rendered = renderValue(itemValue);
+    const searchText = typeof rendered === "string" ? rendered : itemValue;
+    return searchText.toLowerCase().includes(query.toLowerCase());
+  };
+}

--- a/packages/react-components/src/filter-list/inputs/ListogramFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/ListogramFilterInput.tsx
@@ -40,7 +40,7 @@ interface ListogramFilterInputProps<Q extends ObjectTypeDefinition> {
   maxVisibleItems?: number;
   searchQuery?: string;
   excludeRowOpen?: boolean;
-  renderValue?: (value: string) => string;
+  renderValue?: (value: string) => React.ReactNode;
 }
 
 function ListogramFilterInputInner<Q extends ObjectTypeDefinition>({

--- a/packages/react-components/src/filter-list/inputs/MultiSelectFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/MultiSelectFilterInput.tsx
@@ -38,7 +38,7 @@ interface MultiSelectFilterInputProps<Q extends ObjectTypeDefinition> {
   onFilterStateChanged: (state: FilterState) => void;
   whereClause: WhereClause<Q>;
   excludeRowOpen?: boolean;
-  renderValue?: (value: string) => string;
+  renderValue?: (value: string) => React.ReactNode;
   showCount?: boolean;
   layout?: MultiSelectInputLayout;
 }

--- a/packages/react-components/src/filter-list/inputs/SingleSelectFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/SingleSelectFilterInput.tsx
@@ -35,7 +35,7 @@ interface SingleSelectFilterInputProps<Q extends ObjectTypeDefinition> {
   onFilterStateChanged: (state: FilterState) => void;
   whereClause: WhereClause<Q>;
   excludeRowOpen?: boolean;
-  renderValue?: (value: string) => string;
+  renderValue?: (value: string) => React.ReactNode;
   showCount?: boolean;
 }
 

--- a/packages/react-components/src/filter-list/types/StaticValuesTypes.ts
+++ b/packages/react-components/src/filter-list/types/StaticValuesTypes.ts
@@ -15,6 +15,7 @@
  */
 
 import type { ObjectTypeDefinition, WhereClause } from "@osdk/api";
+import type { ReactNode } from "react";
 import type {
   FilterState,
   FilterStateByComponentType,
@@ -78,8 +79,11 @@ export interface StaticValuesFilterDefinition<
   /**
    * Custom display function for filter values.
    * Replaces the default string display in dropdown items, chips, and listogram rows.
+   * When the function returns a string, that string is also used for search matching
+   * within filter dropdowns. When it returns a non-string `ReactNode`, search falls
+   * back to the raw value.
    */
-  renderValue?: (value: string) => string;
+  renderValue?: (value: string) => ReactNode;
 
   /**
    * Show aggregation counts next to filter option values.


### PR DESCRIPTION
widen `renderValue` return type on filter list property and static-values filter definitions from `string` to `ReactNode` so callers can render rich content (e.g. `<SmartUserAnchor>`) for filter values

• update `renderValue` type on `PropertyFilterDefinition` and `StaticValuesFilterDefinition`, plus propagation through `ListogramInput`, `MultiSelectInput`, `SingleSelectInput` and their wrappers
• search matching uses the rendered value when it's a string (existing behavior) and falls back to the raw value when renderValue returns non-string jsx