### PR TITLE
fix $as on objects fetched with $loadPropertySecurityMetadata

### DIFF
--- a/.changeset/fix-as-with-property-securities.md
+++ b/.changeset/fix-as-with-property-securities.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+fix $as on objects fetched with $loadPropertySecurityMetadata

--- a/packages/client/src/object/convertWireToOsdkObjects.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.test.ts
@@ -36,7 +36,6 @@ import {
   convertWireToOsdkObjects,
   convertWireToOsdkObjects2,
 } from "./convertWireToOsdkObjects.js";
-import { UnderlyingOsdkObject } from "./convertWireToOsdkObjects/InternalSymbols.js";
 
 describe("convertWireToOsdkObjects", () => {
   let client: Client;
@@ -1389,12 +1388,8 @@ describe("convertWireToOsdkObjects", () => {
   });
 
   describe("with property securities", () => {
-    const wireSecurities: PropertySecurities[] = [
-      { disjunction: [{ type: "unsupportedPolicy" }] },
-    ];
-
-    function makeWireEmployee() {
-      return {
+    it("$as does not throw on objects loaded with property securities", async () => {
+      const wireEmployee = {
         __apiName: "Employee",
         __primaryKey: 50031,
         __title: "Jane Doe",
@@ -1402,59 +1397,11 @@ describe("convertWireToOsdkObjects", () => {
         fullName: { value: "Jane Doe", propertySecurityIndex: 0 },
         office: { value: "SEA", propertySecurityIndex: 0 },
       } as unknown as OntologyObjectV2;
-    }
 
-    it("$as does not throw and exposes the unwrapped mapped property", async () => {
-      const [holder] = await convertWireToOsdkObjects(
-        client[additionalContext],
-        [makeWireEmployee()],
-        undefined,
-        false,
-        {},
-        wireSecurities,
-      ) as unknown as Osdk.Instance<Employee>[];
+      const wireSecurities: PropertySecurities[] = [
+        { disjunction: [{ type: "unsupportedPolicy" }] },
+      ];
 
-      const asFoo = holder.$as(FooInterface);
-      expect(asFoo.$apiName).toBe("FooInterface");
-      expect(asFoo.fooSpt).toBe("Jane Doe");
-      expect(asFoo.fooIdp).toBe("SEA");
-    });
-
-    it("$propertySecurities resolves on both holder and interface view", async () => {
-      const [holder] = await convertWireToOsdkObjects(
-        client[additionalContext],
-        [makeWireEmployee()],
-        undefined,
-        false,
-        {},
-        wireSecurities,
-      ) as unknown as Osdk.Instance<Employee>[];
-
-      const expectedSecurities = {
-        fullName: [{ type: "unsupportedPolicy" }],
-        office: [{ type: "unsupportedPolicy" }],
-      };
-      expect(holder.$propertySecurities).toEqual(expectedSecurities);
-      expect(holder.$as(FooInterface).$propertySecurities).toEqual(
-        expectedSecurities,
-      );
-    });
-
-    it("$clone() preserves unwrapped property values", async () => {
-      const [holder] = await convertWireToOsdkObjects(
-        client[additionalContext],
-        [makeWireEmployee()],
-        undefined,
-        false,
-        {},
-        wireSecurities,
-      ) as unknown as Osdk.Instance<Employee>[];
-
-      expect(holder.$clone().fullName).toBe("Jane Doe");
-    });
-
-    it("mutates input in place — the wire object is the holder's underlying", async () => {
-      const wireEmployee = makeWireEmployee();
       const [holder] = await convertWireToOsdkObjects(
         client[additionalContext],
         [wireEmployee],
@@ -1464,58 +1411,8 @@ describe("convertWireToOsdkObjects", () => {
         wireSecurities,
       ) as unknown as Osdk.Instance<Employee>[];
 
-      expect((holder as any)[UnderlyingOsdkObject]).toBe(wireEmployee);
-    });
-
-    it("unwraps arrays of secured property values", async () => {
-      const arraySecurities: PropertySecurities[] = [
-        { disjunction: [{ type: "unsupportedPolicy" }] },
-        {
-          disjunction: [{
-            type: "propertyMarkingSummary",
-            conjunctive: [],
-            disjunctive: [],
-            containerConjunctive: [],
-            containerDisjunctive: [],
-          }],
-        },
-      ];
-
-      const wireObj = {
-        __apiName: "objectTypeWithAllPropertyTypes",
-        __primaryKey: 50032,
-        __title: "row 50032",
-        id: 50032,
-        stringArray: [
-          { value: "NYC", propertySecurityIndex: 0 },
-          { value: "SEA", propertySecurityIndex: 1 },
-        ],
-      } as unknown as OntologyObjectV2;
-
-      const [holder] = await convertWireToOsdkObjects(
-        client[additionalContext],
-        [wireObj],
-        undefined,
-        false,
-        {},
-        arraySecurities,
-      ) as unknown as Array<
-        Osdk.Instance<typeof objectTypeWithAllPropertyTypes>
-      >;
-
-      expect(holder.stringArray).toEqual(["NYC", "SEA"]);
-      expect(holder.$propertySecurities).toEqual({
-        stringArray: [
-          [{ type: "unsupportedPolicy" }],
-          [{
-            type: "propertyMarkings",
-            conjunctive: [],
-            disjunctive: [],
-            containerConjunctive: [],
-            containerDisjunctive: [],
-          }],
-        ],
-      });
+      const asFoo = holder.$as(FooInterface);
+      expect(asFoo.fooSpt).toBe("Jane Doe");
     });
   });
 });

--- a/packages/client/src/object/convertWireToOsdkObjects.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.test.ts
@@ -24,6 +24,7 @@ import {
 import type {
   InterfacePropertyTypeImplementation,
   OntologyObjectV2,
+  PropertySecurities,
 } from "@osdk/foundry.ontologies";
 import { createSharedClientContext } from "@osdk/shared.client.impl";
 import { LegacyFauxFoundry, startNodeApiServer } from "@osdk/shared.test";
@@ -35,6 +36,7 @@ import {
   convertWireToOsdkObjects,
   convertWireToOsdkObjects2,
 } from "./convertWireToOsdkObjects.js";
+import { UnderlyingOsdkObject } from "./convertWireToOsdkObjects/InternalSymbols.js";
 
 describe("convertWireToOsdkObjects", () => {
   let client: Client;
@@ -1382,6 +1384,137 @@ describe("convertWireToOsdkObjects", () => {
             objAsFoo2.$__EXPERIMENTAL__NOT_SUPPORTED_YET__metadata
               .InterfaceMetadata,
           );
+      });
+    });
+  });
+
+  describe("with property securities", () => {
+    const wireSecurities: PropertySecurities[] = [
+      { disjunction: [{ type: "unsupportedPolicy" }] },
+    ];
+
+    function makeWireEmployee() {
+      return {
+        __apiName: "Employee",
+        __primaryKey: 50031,
+        __title: "Jane Doe",
+        employeeId: 50031,
+        fullName: { value: "Jane Doe", propertySecurityIndex: 0 },
+        office: { value: "SEA", propertySecurityIndex: 0 },
+      } as unknown as OntologyObjectV2;
+    }
+
+    it("$as does not throw and exposes the unwrapped mapped property", async () => {
+      const [holder] = await convertWireToOsdkObjects(
+        client[additionalContext],
+        [makeWireEmployee()],
+        undefined,
+        false,
+        {},
+        wireSecurities,
+      ) as unknown as Osdk.Instance<Employee>[];
+
+      const asFoo = holder.$as(FooInterface);
+      expect(asFoo.$apiName).toBe("FooInterface");
+      expect(asFoo.fooSpt).toBe("Jane Doe");
+      expect(asFoo.fooIdp).toBe("SEA");
+    });
+
+    it("$propertySecurities resolves on both holder and interface view", async () => {
+      const [holder] = await convertWireToOsdkObjects(
+        client[additionalContext],
+        [makeWireEmployee()],
+        undefined,
+        false,
+        {},
+        wireSecurities,
+      ) as unknown as Osdk.Instance<Employee>[];
+
+      const expectedSecurities = {
+        fullName: [{ type: "unsupportedPolicy" }],
+        office: [{ type: "unsupportedPolicy" }],
+      };
+      expect(holder.$propertySecurities).toEqual(expectedSecurities);
+      expect(holder.$as(FooInterface).$propertySecurities).toEqual(
+        expectedSecurities,
+      );
+    });
+
+    it("$clone() preserves unwrapped property values", async () => {
+      const [holder] = await convertWireToOsdkObjects(
+        client[additionalContext],
+        [makeWireEmployee()],
+        undefined,
+        false,
+        {},
+        wireSecurities,
+      ) as unknown as Osdk.Instance<Employee>[];
+
+      expect(holder.$clone().fullName).toBe("Jane Doe");
+    });
+
+    it("mutates input in place — the wire object is the holder's underlying", async () => {
+      const wireEmployee = makeWireEmployee();
+      const [holder] = await convertWireToOsdkObjects(
+        client[additionalContext],
+        [wireEmployee],
+        undefined,
+        false,
+        {},
+        wireSecurities,
+      ) as unknown as Osdk.Instance<Employee>[];
+
+      expect((holder as any)[UnderlyingOsdkObject]).toBe(wireEmployee);
+    });
+
+    it("unwraps arrays of secured property values", async () => {
+      const arraySecurities: PropertySecurities[] = [
+        { disjunction: [{ type: "unsupportedPolicy" }] },
+        {
+          disjunction: [{
+            type: "propertyMarkingSummary",
+            conjunctive: [],
+            disjunctive: [],
+            containerConjunctive: [],
+            containerDisjunctive: [],
+          }],
+        },
+      ];
+
+      const wireObj = {
+        __apiName: "objectTypeWithAllPropertyTypes",
+        __primaryKey: 50032,
+        __title: "row 50032",
+        id: 50032,
+        stringArray: [
+          { value: "NYC", propertySecurityIndex: 0 },
+          { value: "SEA", propertySecurityIndex: 1 },
+        ],
+      } as unknown as OntologyObjectV2;
+
+      const [holder] = await convertWireToOsdkObjects(
+        client[additionalContext],
+        [wireObj],
+        undefined,
+        false,
+        {},
+        arraySecurities,
+      ) as unknown as Array<
+        Osdk.Instance<typeof objectTypeWithAllPropertyTypes>
+      >;
+
+      expect(holder.stringArray).toEqual(["NYC", "SEA"]);
+      expect(holder.$propertySecurities).toEqual({
+        stringArray: [
+          [{ type: "unsupportedPolicy" }],
+          [{
+            type: "propertyMarkings",
+            conjunctive: [],
+            disjunctive: [],
+            containerConjunctive: [],
+            containerDisjunctive: [],
+          }],
+        ],
       });
     });
   });

--- a/packages/client/src/object/convertWireToOsdkObjects.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.test.ts
@@ -1387,33 +1387,54 @@ describe("convertWireToOsdkObjects", () => {
     });
   });
 
-  describe("with property securities", () => {
-    it("$as does not throw on objects loaded with property securities", async () => {
-      const wireEmployee = {
-        __apiName: "Employee",
-        __primaryKey: 50031,
-        __title: "Jane Doe",
-        employeeId: 50031,
-        fullName: { value: "Jane Doe", propertySecurityIndex: 0 },
-        office: { value: "SEA", propertySecurityIndex: 0 },
-      } as unknown as OntologyObjectV2;
+  it("$as on an object loaded with $loadPropertySecurityMetadata produces the full interface view, threading $propertySecurities and the standard $* props", async () => {
+    const wireEmployee = {
+      __apiName: "Employee",
+      __primaryKey: 50031,
+      __title: "Jane Doe",
+      employeeId: 50031,
+      fullName: { value: "Jane Doe", propertySecurityIndex: 0 },
+      office: { value: "SEA", propertySecurityIndex: 0 },
+    } as unknown as OntologyObjectV2;
 
-      const wireSecurities: PropertySecurities[] = [
-        { disjunction: [{ type: "unsupportedPolicy" }] },
-      ];
+    const wireSecurities: PropertySecurities[] = [
+      { disjunction: [{ type: "unsupportedPolicy" }] },
+    ];
 
-      const [holder] = await convertWireToOsdkObjects(
-        client[additionalContext],
-        [wireEmployee],
-        undefined,
-        false,
-        {},
-        wireSecurities,
-      ) as unknown as Osdk.Instance<Employee>[];
+    const [holder] = await convertWireToOsdkObjects(
+      client[additionalContext],
+      [wireEmployee],
+      undefined,
+      false,
+      {},
+      wireSecurities,
+    ) as unknown as Osdk.Instance<Employee>[];
 
-      const asFoo = holder.$as(FooInterface);
-      expect(asFoo.fooSpt).toBe("Jane Doe");
-    });
+    const asFoo = holder.$as(FooInterface);
+
+    expect(asFoo).toMatchInlineSnapshot(`
+      {
+        "$apiName": "FooInterface",
+        "$objectSpecifier": "Employee:50031",
+        "$objectType": "Employee",
+        "$primaryKey": 50031,
+        "$propertySecurities": {
+          "fullName": [
+            {
+              "type": "unsupportedPolicy",
+            },
+          ],
+          "office": [
+            {
+              "type": "unsupportedPolicy",
+            },
+          ],
+        },
+        "$title": "Jane Doe",
+        "fooIdp": "SEA",
+        "fooSpt": "Jane Doe",
+      }
+    `);
   });
 });
 

--- a/packages/client/src/object/convertWireToOsdkObjects.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.test.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import type { Attachment, Media, Osdk, PropertyKeys } from "@osdk/api";
+import type {
+  Attachment,
+  Media,
+  Osdk,
+  PropertyKeys,
+  PropertySecurity,
+} from "@osdk/api";
 import {
   $ontologyRid,
   Employee,
@@ -1408,9 +1414,23 @@ describe("convertWireToOsdkObjects", () => {
       false,
       {},
       wireSecurities,
-    ) as unknown as Osdk.Instance<Employee>[];
+    ) as unknown as Osdk.Instance<Employee, "$propertySecurities">[];
 
     const asFoo = holder.$as(FooInterface);
+
+    expectTypeOf(asFoo).toEqualTypeOf<
+      Osdk.Instance<
+        FooInterface,
+        "$propertySecurities",
+        "fooSpt" | "fooIdp",
+        {}
+      >
+    >();
+
+    expectTypeOf(asFoo.$propertySecurities).toEqualTypeOf<{
+      fooIdp: PropertySecurity[];
+      fooSpt: PropertySecurity[];
+    }>();
 
     expect(asFoo).toMatchInlineSnapshot(`
       {
@@ -1419,12 +1439,12 @@ describe("convertWireToOsdkObjects", () => {
         "$objectType": "Employee",
         "$primaryKey": 50031,
         "$propertySecurities": {
-          "fullName": [
+          "fooIdp": [
             {
               "type": "unsupportedPolicy",
             },
           ],
-          "office": [
+          "fooSpt": [
             {
               "type": "unsupportedPolicy",
             },

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
@@ -267,40 +267,8 @@ describe(createOsdkInterface, () => {
     const client = {} as MinimalClient;
 
     type TestObj = Record<string, unknown> & {
-      $as: (name: string) => Record<string, unknown>;
       $clone: () => Record<string, unknown>;
     };
-
-    function makeObj() {
-      // fresh per call: createOsdkObject mutates input
-      const simpleProps = {
-        $apiName: "Obj",
-        $objectType: "Obj",
-        $primaryKey: 1,
-        $title: "hi mom",
-        id: 1,
-        foo: { value: "hi mom", propertySecurityIndex: 0 },
-      } as unknown as SimpleOsdkProperties;
-      return createOsdkObject(
-        client,
-        objectDef,
-        simpleProps,
-        {},
-        wireSecurities,
-      ) as unknown as TestObj;
-    }
-
-    it("$as does not throw and exposes the mapped (unwrapped) property", () => {
-      const obj = makeObj();
-      const iface = obj.$as("IFoo");
-      expect(iface.$apiName).toBe("IFoo");
-      expect(iface.asdf).toBe("hi mom");
-    });
-
-    it("$clone() preserves unwrapped property values", () => {
-      const obj = makeObj();
-      expect(obj.$clone().foo).toBe("hi mom");
-    });
 
     it("hydrates an attachment property that arrived wrapped in SecuredPropertyValue", () => {
       const attObjectDef: FetchedObjectTypeDefinition = {

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
@@ -297,25 +297,6 @@ describe(createOsdkInterface, () => {
       expect(iface.asdf).toBe("hi mom");
     });
 
-    it("$as'd interface exposes ObjectMetadata equal to the source objectDef", () => {
-      const obj = makeObj();
-      const iface = obj.$as("IFoo");
-      const metadata = iface
-        .$__EXPERIMENTAL__NOT_SUPPORTED_YET__metadata as {
-          ObjectMetadata: FetchedObjectTypeDefinition;
-        };
-      expect(metadata.ObjectMetadata).toBe(objectDef);
-    });
-
-    it("$propertySecurities resolves on both holder and interface view", () => {
-      const obj = makeObj();
-      const expectedSecurities = {
-        foo: [{ type: "unsupportedPolicy" }],
-      };
-      expect(obj.$propertySecurities).toEqual(expectedSecurities);
-      expect(obj.$as("IFoo").$propertySecurities).toEqual(expectedSecurities);
-    });
-
     it("$clone() preserves unwrapped property values", () => {
       const obj = makeObj();
       expect(obj.$clone().foo).toBe("hi mom");

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
@@ -264,18 +264,21 @@ describe(createOsdkInterface, () => {
       { disjunction: [{ type: "unsupportedPolicy" }] },
     ];
 
-    const simpleProps = {
-      $apiName: "Obj",
-      $objectType: "Obj",
-      $primaryKey: 1,
-      $title: "hi mom",
-      id: 1,
-      foo: { value: "hi mom", propertySecurityIndex: 0 },
-    } as unknown as SimpleOsdkProperties;
-
     const client = {} as MinimalClient;
 
+    // Construct fresh wire props per call — createOsdkObject mutates its
+    // input (see parseWhenSecuritiesLoaded and the special-property loop),
+    // so reusing the same reference across tests would fail to redefine
+    // already-installed internal symbols.
     function makeObj() {
+      const simpleProps = {
+        $apiName: "Obj",
+        $objectType: "Obj",
+        $primaryKey: 1,
+        $title: "hi mom",
+        id: 1,
+        foo: { value: "hi mom", propertySecurityIndex: 0 },
+      } as unknown as SimpleOsdkProperties;
       return createOsdkObject(
         client,
         objectDef,
@@ -317,6 +320,53 @@ describe(createOsdkInterface, () => {
     it("$clone() preserves unwrapped property values", () => {
       const obj = makeObj();
       expect(obj.$clone().foo).toBe("hi mom");
+    });
+
+    it("hydrates an attachment property that arrived wrapped in SecuredPropertyValue", () => {
+      const attObjectDef: FetchedObjectTypeDefinition = {
+        [InterfaceDefinitions]: {},
+        apiName: "Att",
+        displayName: "",
+        interfaceMap: {},
+        inverseInterfaceMap: {},
+        links: {},
+        pluralDisplayName: "",
+        primaryKeyApiName: "id",
+        primaryKeyType: "integer",
+        properties: {
+          id: { type: "integer" },
+          att: { type: "attachment" },
+        },
+        type: "object",
+        titleProperty: "id",
+        rid: "",
+        status: "ACTIVE",
+        icon: undefined,
+        visibility: undefined,
+        description: undefined,
+      };
+
+      const attProps = {
+        $apiName: "Att",
+        $objectType: "Att",
+        $primaryKey: 1,
+        $title: "1",
+        id: 1,
+        att: { value: { rid: "ri.attach.1" }, propertySecurityIndex: 0 },
+      } as unknown as SimpleOsdkProperties;
+
+      const obj = createOsdkObject(
+        client,
+        attObjectDef,
+        attProps,
+        {},
+        wireSecurities,
+      ) as unknown as Record<string, unknown> & {
+        $clone: () => Record<string, unknown>;
+      };
+
+      expect((obj.att as { rid: string }).rid).toBe("ri.attach.1");
+      expect((obj.$clone().att as { rid: string }).rid).toBe("ri.attach.1");
     });
   });
 });

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
@@ -14,12 +14,17 @@
  * limitations under the License.
  */
 
+import type { InterfaceMetadata } from "@osdk/api";
+import type { PropertySecurities } from "@osdk/foundry.ontologies";
 import { describe, expect, it } from "vitest";
+import type { MinimalClient } from "../../MinimalClientContext.js";
 import {
   type FetchedObjectTypeDefinition,
   InterfaceDefinitions,
 } from "../../ontology/OntologyProvider.js";
+import type { SimpleOsdkProperties } from "../SimpleOsdkProperties.js";
 import { createOsdkInterface } from "./createOsdkInterface.js";
+import { createOsdkObject } from "./createOsdkObject.js";
 import { ObjectDefRef } from "./InternalSymbols.js";
 
 describe(createOsdkInterface, () => {
@@ -216,5 +221,102 @@ describe(createOsdkInterface, () => {
         "b.asdf": "hi mom"
       }"
     `);
+  });
+
+  describe("with $loadPropertySecurityMetadata", () => {
+    const interfaceDef: InterfaceMetadata = {
+      apiName: "IFoo",
+      displayName: "",
+      links: {},
+      properties: { "asdf": { type: "string" } },
+      rid: "",
+      type: "interface",
+      implements: [],
+      description: undefined,
+    };
+
+    const objectDef: FetchedObjectTypeDefinition = {
+      [InterfaceDefinitions]: {
+        "IFoo": { def: interfaceDef },
+      },
+      apiName: "Obj",
+      displayName: "",
+      interfaceMap: { "IFoo": { "asdf": "foo" } },
+      inverseInterfaceMap: { "IFoo": { "foo": "asdf" } },
+      links: {},
+      pluralDisplayName: "",
+      primaryKeyApiName: "id",
+      primaryKeyType: "integer",
+      properties: {
+        id: { type: "integer" },
+        foo: { type: "string" },
+      },
+      type: "object",
+      titleProperty: "foo",
+      rid: "",
+      status: "ACTIVE",
+      icon: undefined,
+      visibility: undefined,
+      description: undefined,
+    };
+
+    const wireSecurities: PropertySecurities[] = [
+      { disjunction: [{ type: "unsupportedPolicy" }] },
+    ];
+
+    const simpleProps = {
+      $apiName: "Obj",
+      $objectType: "Obj",
+      $primaryKey: 1,
+      $title: "hi mom",
+      id: 1,
+      foo: { value: "hi mom", propertySecurityIndex: 0 },
+    } as unknown as SimpleOsdkProperties;
+
+    const client = {} as MinimalClient;
+
+    function makeObj() {
+      return createOsdkObject(
+        client,
+        objectDef,
+        simpleProps,
+        {},
+        wireSecurities,
+      ) as unknown as Record<string, unknown> & {
+        $as: (name: string) => Record<string, unknown>;
+        $clone: () => Record<string, unknown>;
+      };
+    }
+
+    it("$as does not throw and exposes the mapped (unwrapped) property", () => {
+      const obj = makeObj();
+      const iface = obj.$as("IFoo");
+      expect(iface.$apiName).toBe("IFoo");
+      expect(iface.asdf).toBe("hi mom");
+    });
+
+    it("$as'd interface exposes ObjectMetadata equal to the source objectDef", () => {
+      const obj = makeObj();
+      const iface = obj.$as("IFoo");
+      const metadata = iface
+        .$__EXPERIMENTAL__NOT_SUPPORTED_YET__metadata as {
+          ObjectMetadata: FetchedObjectTypeDefinition;
+        };
+      expect(metadata.ObjectMetadata).toBe(objectDef);
+    });
+
+    it("$propertySecurities resolves on both holder and interface view", () => {
+      const obj = makeObj();
+      const expectedSecurities = {
+        foo: [{ type: "unsupportedPolicy" }],
+      };
+      expect(obj.$propertySecurities).toEqual(expectedSecurities);
+      expect(obj.$as("IFoo").$propertySecurities).toEqual(expectedSecurities);
+    });
+
+    it("$clone() preserves unwrapped property values", () => {
+      const obj = makeObj();
+      expect(obj.$clone().foo).toBe("hi mom");
+    });
   });
 });

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
@@ -266,11 +266,13 @@ describe(createOsdkInterface, () => {
 
     const client = {} as MinimalClient;
 
-    // Construct fresh wire props per call — createOsdkObject mutates its
-    // input (see parseWhenSecuritiesLoaded and the special-property loop),
-    // so reusing the same reference across tests would fail to redefine
-    // already-installed internal symbols.
+    type TestObj = Record<string, unknown> & {
+      $as: (name: string) => Record<string, unknown>;
+      $clone: () => Record<string, unknown>;
+    };
+
     function makeObj() {
+      // fresh per call: createOsdkObject mutates input
       const simpleProps = {
         $apiName: "Obj",
         $objectType: "Obj",
@@ -285,10 +287,7 @@ describe(createOsdkInterface, () => {
         simpleProps,
         {},
         wireSecurities,
-      ) as unknown as Record<string, unknown> & {
-        $as: (name: string) => Record<string, unknown>;
-        $clone: () => Record<string, unknown>;
-      };
+      ) as unknown as TestObj;
     }
 
     it("$as does not throw and exposes the mapped (unwrapped) property", () => {
@@ -324,26 +323,16 @@ describe(createOsdkInterface, () => {
 
     it("hydrates an attachment property that arrived wrapped in SecuredPropertyValue", () => {
       const attObjectDef: FetchedObjectTypeDefinition = {
+        ...objectDef,
         [InterfaceDefinitions]: {},
         apiName: "Att",
-        displayName: "",
         interfaceMap: {},
         inverseInterfaceMap: {},
-        links: {},
-        pluralDisplayName: "",
-        primaryKeyApiName: "id",
-        primaryKeyType: "integer",
         properties: {
           id: { type: "integer" },
           att: { type: "attachment" },
         },
-        type: "object",
         titleProperty: "id",
-        rid: "",
-        status: "ACTIVE",
-        icon: undefined,
-        visibility: undefined,
-        description: undefined,
       };
 
       const attProps = {
@@ -361,9 +350,7 @@ describe(createOsdkInterface, () => {
         attProps,
         {},
         wireSecurities,
-      ) as unknown as Record<string, unknown> & {
-        $clone: () => Record<string, unknown>;
-      };
+      ) as unknown as TestObj;
 
       expect((obj.att as { rid: string }).rid).toBe("ri.attach.1");
       expect((obj.$clone().att as { rid: string }).rid).toBe("ri.attach.1");

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
@@ -14,17 +14,12 @@
  * limitations under the License.
  */
 
-import type { InterfaceMetadata } from "@osdk/api";
-import type { PropertySecurities } from "@osdk/foundry.ontologies";
 import { describe, expect, it } from "vitest";
-import type { MinimalClient } from "../../MinimalClientContext.js";
 import {
   type FetchedObjectTypeDefinition,
   InterfaceDefinitions,
 } from "../../ontology/OntologyProvider.js";
-import type { SimpleOsdkProperties } from "../SimpleOsdkProperties.js";
 import { createOsdkInterface } from "./createOsdkInterface.js";
-import { createOsdkObject } from "./createOsdkObject.js";
 import { ObjectDefRef } from "./InternalSymbols.js";
 
 describe(createOsdkInterface, () => {
@@ -221,88 +216,5 @@ describe(createOsdkInterface, () => {
         "b.asdf": "hi mom"
       }"
     `);
-  });
-
-  describe("with $loadPropertySecurityMetadata", () => {
-    const interfaceDef: InterfaceMetadata = {
-      apiName: "IFoo",
-      displayName: "",
-      links: {},
-      properties: { "asdf": { type: "string" } },
-      rid: "",
-      type: "interface",
-      implements: [],
-      description: undefined,
-    };
-
-    const objectDef: FetchedObjectTypeDefinition = {
-      [InterfaceDefinitions]: {
-        "IFoo": { def: interfaceDef },
-      },
-      apiName: "Obj",
-      displayName: "",
-      interfaceMap: { "IFoo": { "asdf": "foo" } },
-      inverseInterfaceMap: { "IFoo": { "foo": "asdf" } },
-      links: {},
-      pluralDisplayName: "",
-      primaryKeyApiName: "id",
-      primaryKeyType: "integer",
-      properties: {
-        id: { type: "integer" },
-        foo: { type: "string" },
-      },
-      type: "object",
-      titleProperty: "foo",
-      rid: "",
-      status: "ACTIVE",
-      icon: undefined,
-      visibility: undefined,
-      description: undefined,
-    };
-
-    const wireSecurities: PropertySecurities[] = [
-      { disjunction: [{ type: "unsupportedPolicy" }] },
-    ];
-
-    const client = {} as MinimalClient;
-
-    type TestObj = Record<string, unknown> & {
-      $clone: () => Record<string, unknown>;
-    };
-
-    it("hydrates an attachment property that arrived wrapped in SecuredPropertyValue", () => {
-      const attObjectDef: FetchedObjectTypeDefinition = {
-        ...objectDef,
-        [InterfaceDefinitions]: {},
-        apiName: "Att",
-        interfaceMap: {},
-        inverseInterfaceMap: {},
-        properties: {
-          id: { type: "integer" },
-          att: { type: "attachment" },
-        },
-        titleProperty: "id",
-      };
-
-      const attProps = {
-        $apiName: "Att",
-        $objectType: "Att",
-        $primaryKey: 1,
-        $title: "1",
-        id: 1,
-        att: { value: { rid: "ri.attach.1" }, propertySecurityIndex: 0 },
-      } as unknown as SimpleOsdkProperties;
-
-      const obj = createOsdkObject(
-        client,
-        attObjectDef,
-        attProps,
-        {},
-        wireSecurities,
-      ) as unknown as TestObj;
-
-      expect((obj.att as { rid: string }).rid).toBe("ri.attach.1");
-      expect((obj.$clone().att as { rid: string }).rid).toBe("ri.attach.1");
-    });
   });
 });

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { InterfaceMetadata } from "@osdk/api";
+import type { InterfaceMetadata, PropertySecurity } from "@osdk/api";
 import { extractNamespace } from "../../internal/conversions/extractNamespace.js";
 import type { FetchedObjectTypeDefinition } from "../../ontology/OntologyProvider.js";
 import { get$linkForInterface } from "./getDollarLink.js";
@@ -25,6 +25,10 @@ import {
   UnderlyingOsdkObject,
 } from "./InternalSymbols.js";
 import type { ObjectHolder } from "./ObjectHolder.js";
+
+type PropertySecuritiesMap = {
+  [propName: string]: PropertySecurity[] | PropertySecurity[][];
+};
 
 /** @internal */
 export function createOsdkInterface<
@@ -70,7 +74,14 @@ export function createOsdkInterface<
         enumerable: false,
       },
       "$propertySecurities": {
-        value: underlying.$propertySecurities,
+        value: remapPropertySecuritiesForInterface(
+          underlying.$propertySecurities as unknown as
+            | PropertySecuritiesMap
+            | undefined,
+          underlying[ObjectDefRef],
+          interfaceDef,
+          objApiNamespace,
+        ),
         enumerable: "$propertySecurities" in underlying,
       },
       "$__EXPERIMENTAL__NOT_SUPPORTED_YET__metadata": {
@@ -86,7 +97,7 @@ export function createOsdkInterface<
       },
 
       "$link": {
-        get: function(this: InterfaceHolder) {
+        get(this: InterfaceHolder) {
           return get$linkForInterface(this);
         },
       },
@@ -143,4 +154,26 @@ export function createOsdkInterface<
     }
     return [targetPropName, value];
   }
+}
+
+function remapPropertySecuritiesForInterface(
+  underlyingSecurities: PropertySecuritiesMap | undefined,
+  objDef: FetchedObjectTypeDefinition,
+  interfaceDef: InterfaceMetadata,
+  objApiNamespace: string | undefined,
+): PropertySecuritiesMap | undefined {
+  if (underlyingSecurities == null) return undefined;
+
+  const inverseMap = objDef.inverseInterfaceMap?.[interfaceDef.apiName] ?? {};
+  const remapped: PropertySecuritiesMap = {};
+
+  for (const objPropName of Object.keys(underlyingSecurities)) {
+    const interfacePropName = inverseMap[objPropName];
+    if (interfacePropName == null) continue;
+
+    const [apiNamespace, apiName] = extractNamespace(interfacePropName);
+    const key = apiNamespace === objApiNamespace ? apiName : interfacePropName;
+    remapped[key] = underlyingSecurities[objPropName];
+  }
+  return remapped;
 }

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -173,7 +173,7 @@ export function createOsdkObject(
     {
       [UnderlyingOsdkObject]: {
         enumerable: false,
-        value: rawObj,
+        value: simpleOsdkProperties,
       },
       [PropertySecuritiesRef]: {
         enumerable: false,
@@ -351,7 +351,6 @@ function parseWhenSecuritiesLoaded(
     return { parsedObject: rawObject, clientPropertySecurities: undefined };
   }
 
-  const parsedObject: SimpleOsdkProperties = { ...rawObject };
   const clientPropertySecurities: {
     [propName: string]: PropertySecurity[] | PropertySecurity[][];
   } = {};
@@ -389,17 +388,16 @@ function parseWhenSecuritiesLoaded(
               .map(wireToClientPropertySecurities),
           );
         });
-        parsedObject[propKey] = newVal;
+        rawObject[propKey] = newVal;
         clientPropertySecurities[propKey] = newSecurities;
-      } // Check if this is a secured property value object
-      else if (
+      } else if (
         typeof value === "object"
         && value != null
         && "value" in value
         && "propertySecurityIndex" in value
       ) {
         const securedValue = value as SecuredPropertyValue;
-        parsedObject[propKey] = securedValue.value;
+        rawObject[propKey] = securedValue.value;
 
         const securityIndex = securedValue.propertySecurityIndex;
         invariant(
@@ -413,14 +411,11 @@ function parseWhenSecuritiesLoaded(
         clientPropertySecurities[propKey] =
           wirePropertySecurities[securityIndex].disjunction
             .map(wireToClientPropertySecurities);
-      } else {
-        // Regular property without security
-        parsedObject[propKey] = value;
       }
     }
   }
 
-  return { parsedObject, clientPropertySecurities };
+  return { parsedObject: rawObject, clientPropertySecurities };
 }
 
 function wireToClientPropertySecurities(

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -62,17 +62,17 @@ const specialPropertyTypes = new Set(
 // every time an object is created.
 const basePropDefs = {
   "$as": {
-    get: function(this: ObjectHolder) {
+    get(this: ObjectHolder) {
       return get$as(this[ObjectDefRef]);
     },
   },
   "$link": {
-    get: function(this: ObjectHolder) {
+    get(this: ObjectHolder) {
       return get$link(this);
     },
   },
   "$clone": {
-    value: function(
+    value(
       this: ObjectHolder,
       update: Record<string, any> | undefined,
     ) {
@@ -102,7 +102,7 @@ const basePropDefs = {
     },
   },
   "$objectSpecifier": {
-    get: function(this: ObjectHolder) {
+    get(this: ObjectHolder) {
       const rawObj = this[UnderlyingOsdkObject];
       return createObjectSpecifierFromPrimaryKey(
         this[ObjectDefRef],
@@ -112,13 +112,13 @@ const basePropDefs = {
     enumerable: true,
   },
   "$propertySecurities": {
-    get: function(this: ObjectHolder) {
+    get(this: ObjectHolder) {
       return this[PropertySecuritiesRef];
     },
     enumerable: true,
   },
   "$__EXPERIMENTAL__NOT_SUPPORTED_YET__metadata": {
-    get: function(this: ObjectHolder) {
+    get(this: ObjectHolder) {
       return {
         ObjectMetadata: this[ObjectDefRef],
       };
@@ -126,7 +126,7 @@ const basePropDefs = {
     enumerable: false,
   },
   "$__EXPERIMENTAL__NOT_SUPPORTED_YET__getFormattedValue": {
-    value: function(
+    value(
       this: ObjectHolder,
       propertyApiName: string,
       options?: FormatPropertyOptions,
@@ -173,7 +173,7 @@ export function createOsdkObject(
     {
       [UnderlyingOsdkObject]: {
         enumerable: false,
-        value: simpleOsdkProperties,
+        value: rawObj,
       },
       [PropertySecuritiesRef]: {
         enumerable: false,

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -159,7 +159,7 @@ export function createOsdkObject(
   derivedPropertyTypeByName: DerivedPropertyRuntimeMetadata = {},
   wirePropertySecurities: PropertySecurities[] | undefined = [],
 ): ObjectHolder {
-  const { parsedObject, clientPropertySecurities } = parseWhenSecuritiesLoaded(
+  const clientPropertySecurities = unwrapSecuredValuesInPlace(
     wirePropertySecurities,
     simpleOsdkProperties,
     objectDef,
@@ -167,7 +167,7 @@ export function createOsdkObject(
   );
 
   // updates the object's "hidden class/map".
-  const rawObj = parsedObject as ObjectHolder;
+  const rawObj = simpleOsdkProperties as ObjectHolder;
   Object.defineProperties(
     rawObj,
     {
@@ -336,19 +336,17 @@ function createSpecialProperty(
   }
 }
 
-function parseWhenSecuritiesLoaded(
+function unwrapSecuredValuesInPlace(
   wirePropertySecurities: PropertySecurities[] | undefined,
   rawObject: SimpleOsdkProperties,
   objectDef: FetchedObjectTypeDefinition,
   derivedPropertyTypeByName: DerivedPropertyRuntimeMetadata = {},
-): {
-  parsedObject: SimpleOsdkProperties;
-  clientPropertySecurities:
-    | { [propName: string]: PropertySecurity[] | PropertySecurity[][] }
-    | undefined;
-} {
+):
+  | { [propName: string]: PropertySecurity[] | PropertySecurity[][] }
+  | undefined
+{
   if (wirePropertySecurities == null || wirePropertySecurities.length === 0) {
-    return { parsedObject: rawObject, clientPropertySecurities: undefined };
+    return undefined;
   }
 
   const clientPropertySecurities: {
@@ -415,7 +413,7 @@ function parseWhenSecuritiesLoaded(
     }
   }
 
-  return { parsedObject: rawObject, clientPropertySecurities };
+  return clientPropertySecurities;
 }
 
 function wireToClientPropertySecurities(

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -159,7 +159,7 @@ export function createOsdkObject(
   derivedPropertyTypeByName: DerivedPropertyRuntimeMetadata = {},
   wirePropertySecurities: PropertySecurities[] | undefined = [],
 ): ObjectHolder {
-  const clientPropertySecurities = unwrapSecuredValuesInPlace(
+  const { parsedObject, clientPropertySecurities } = parseWhenSecuritiesLoaded(
     wirePropertySecurities,
     simpleOsdkProperties,
     objectDef,
@@ -167,7 +167,7 @@ export function createOsdkObject(
   );
 
   // updates the object's "hidden class/map".
-  const rawObj = simpleOsdkProperties as ObjectHolder;
+  const rawObj = parsedObject as ObjectHolder;
   Object.defineProperties(
     rawObj,
     {
@@ -336,19 +336,22 @@ function createSpecialProperty(
   }
 }
 
-function unwrapSecuredValuesInPlace(
+function parseWhenSecuritiesLoaded(
   wirePropertySecurities: PropertySecurities[] | undefined,
   rawObject: SimpleOsdkProperties,
   objectDef: FetchedObjectTypeDefinition,
   derivedPropertyTypeByName: DerivedPropertyRuntimeMetadata = {},
-):
-  | { [propName: string]: PropertySecurity[] | PropertySecurity[][] }
-  | undefined
-{
+): {
+  parsedObject: SimpleOsdkProperties;
+  clientPropertySecurities:
+    | { [propName: string]: PropertySecurity[] | PropertySecurity[][] }
+    | undefined;
+} {
   if (wirePropertySecurities == null || wirePropertySecurities.length === 0) {
-    return undefined;
+    return { parsedObject: rawObject, clientPropertySecurities: undefined };
   }
 
+  const parsedObject: SimpleOsdkProperties = rawObject;
   const clientPropertySecurities: {
     [propName: string]: PropertySecurity[] | PropertySecurity[][];
   } = {};
@@ -386,16 +389,17 @@ function unwrapSecuredValuesInPlace(
               .map(wireToClientPropertySecurities),
           );
         });
-        rawObject[propKey] = newVal;
+        parsedObject[propKey] = newVal;
         clientPropertySecurities[propKey] = newSecurities;
-      } else if (
+      } // Check if this is a secured property value object
+      else if (
         typeof value === "object"
         && value != null
         && "value" in value
         && "propertySecurityIndex" in value
       ) {
         const securedValue = value as SecuredPropertyValue;
-        rawObject[propKey] = securedValue.value;
+        parsedObject[propKey] = securedValue.value;
 
         const securityIndex = securedValue.propertySecurityIndex;
         invariant(
@@ -409,11 +413,14 @@ function unwrapSecuredValuesInPlace(
         clientPropertySecurities[propKey] =
           wirePropertySecurities[securityIndex].disjunction
             .map(wireToClientPropertySecurities);
+      } else {
+        // Regular property without security
+        parsedObject[propKey] = value;
       }
     }
   }
 
-  return clientPropertySecurities;
+  return { parsedObject, clientPropertySecurities };
 }
 
 function wireToClientPropertySecurities(


### PR DESCRIPTION
calling $as on an object loaded with $loadPropertySecurityMetadata: true threw at createOsdkInterface because parseWhenSecuritiesLoaded returned a shallow copy, leaving the wire object the holder symbols still pointed at via [UnderlyingOsdkObject] without ObjectDefRef / ClientRef / PropertySecuritiesRef

• #2352 introduced a `{ ...rawObject }` shallow copy in parseWhenSecuritiesLoaded which broke the pre-existing invariant that holder[UnderlyingOsdkObject] === holder; downstream consumers (getDollarAs, get$linkForInterface, createOsdkInterface, $clone) silently saw undefined symbols
• drop the copy and mutate the input in place, matching the convention already established by fixObjectPropertiesInPlace; one less allocation per fetch and the divergent-state class of bug is gone