### PR TITLE
fix fetchPage hover: split into with/without $applyModifiers overloads

### DIFF
--- a/.changeset/fetchpage-overload-split-for-hover.md
+++ b/.changeset/fetchpage-overload-split-for-hover.md
@@ -1,0 +1,5 @@
+---
+"@osdk/api": patch
+---
+
+Split `fetchPage` and `fetchPageWithErrors` into two overloads (with/without `$applyModifiers`) so the common no-modifier hover output renders as `Osdk.Instance<Q, …, PropertyKeys<Q>, {}>` instead of an expanded property union with a spurious `| undefined` (and the new struct/array properties incorrectly excluded).

--- a/packages/api/src/OsdkObjectFrom.test.ts
+++ b/packages/api/src/OsdkObjectFrom.test.ts
@@ -838,16 +838,16 @@ describe("ExtractOptions", () => {
       it("disallows invalid modifiers in fetchPage args", async () => {
         const objectSet = createMockObjectSet<EmployeeApiTest>();
 
+        // @ts-expect-error invalid modifier value
         await objectSet.fetchPage({
           $applyModifiers: {
-            // @ts-expect-error invalid modifier value
             addressStruct: "invalidModifier",
           },
         });
 
+        // @ts-expect-error invalid modifier key
         await objectSet.fetchPage({
           $applyModifiers: {
-            // @ts-expect-error invalid modifier key
             invalidProp: "applyMainValue",
           },
         });

--- a/packages/api/src/__quickinfo_snapshot__/__snapshots__/objectSet.snap
+++ b/packages/api/src/__quickinfo_snapshot__/__snapshots__/objectSet.snap
@@ -117,29 +117,7 @@ type objectSet_fetchPageWithErrors_result =
   | ErrorResult
   | OkResult<
     PageResult<
-      | Osdk.Instance<
-        EmployeeApiTest,
-        never,
-        | "employeeId"
-        | "fullName"
-        | "class"
-        | "mediaReference"
-        | "attachment"
-        | "geopoint"
-        | "geotimeSeriesReference"
-        | "timeseries"
-        | "isActive"
-        | "yearsOfExperience"
-        | "rank"
-        | "performanceScore"
-        | "hourlyRate"
-        | "dateOfJoining"
-        | "lastUpdated"
-        | "skillSet"
-        | "skillSetEmbedding"
-        | undefined,
-        {}
-      >
+      | Osdk.Instance<EmployeeApiTest, never, PropertyKeys<EmployeeApiTest>, {}>
       | (
         & ObjectIdentifiers<EmployeeApiTest>
         & {
@@ -162,24 +140,7 @@ type objectSet_fetchPageWithErrors_result =
             ConvertProps<
               EmployeeApiTest,
               NEW_Q,
-              | "employeeId"
-              | "fullName"
-              | "class"
-              | "mediaReference"
-              | "attachment"
-              | "geopoint"
-              | "geotimeSeriesReference"
-              | "timeseries"
-              | "isActive"
-              | "yearsOfExperience"
-              | "rank"
-              | "performanceScore"
-              | "hourlyRate"
-              | "dateOfJoining"
-              | "lastUpdated"
-              | "skillSet"
-              | "skillSetEmbedding"
-              | undefined,
+              PropertyKeys<EmployeeApiTest>,
               never
             >,
             {}
@@ -192,25 +153,7 @@ type objectSet_fetchPageWithErrors_result =
           ) => Osdk.Instance<
             EmployeeApiTest,
             never,
-            | "employeeId"
-            | "fullName"
-            | "class"
-            | "mediaReference"
-            | "attachment"
-            | "geopoint"
-            | "geotimeSeriesReference"
-            | "timeseries"
-            | "isActive"
-            | "yearsOfExperience"
-            | "rank"
-            | "performanceScore"
-            | "hourlyRate"
-            | "dateOfJoining"
-            | "lastUpdated"
-            | "skillSet"
-            | "skillSetEmbedding"
-            | NEW_PROPS
-            | undefined,
+            PropertyKeys<EmployeeApiTest> | NEW_PROPS,
             {}
           >;
           readonly $__EXPERIMENTAL__NOT_SUPPORTED_YET__metadata: {
@@ -230,29 +173,7 @@ type objectSet_fetchPageWithErrors_result =
 
 /** The awaited result of objectSet.fetchPage(). */
 type objectSet_fetchPage_result = PageResult<
-  | Osdk.Instance<
-    EmployeeApiTest,
-    never,
-    | "employeeId"
-    | "fullName"
-    | "class"
-    | "mediaReference"
-    | "attachment"
-    | "geopoint"
-    | "geotimeSeriesReference"
-    | "timeseries"
-    | "isActive"
-    | "yearsOfExperience"
-    | "rank"
-    | "performanceScore"
-    | "hourlyRate"
-    | "dateOfJoining"
-    | "lastUpdated"
-    | "skillSet"
-    | "skillSetEmbedding"
-    | undefined,
-    {}
-  >
+  | Osdk.Instance<EmployeeApiTest, never, PropertyKeys<EmployeeApiTest>, {}>
   | (
     & ObjectIdentifiers<EmployeeApiTest>
     & {
@@ -275,24 +196,7 @@ type objectSet_fetchPage_result = PageResult<
         ConvertProps<
           EmployeeApiTest,
           NEW_Q,
-          | "employeeId"
-          | "fullName"
-          | "class"
-          | "mediaReference"
-          | "attachment"
-          | "geopoint"
-          | "geotimeSeriesReference"
-          | "timeseries"
-          | "isActive"
-          | "yearsOfExperience"
-          | "rank"
-          | "performanceScore"
-          | "hourlyRate"
-          | "dateOfJoining"
-          | "lastUpdated"
-          | "skillSet"
-          | "skillSetEmbedding"
-          | undefined,
+          PropertyKeys<EmployeeApiTest>,
           never
         >,
         {}
@@ -305,25 +209,7 @@ type objectSet_fetchPage_result = PageResult<
       ) => Osdk.Instance<
         EmployeeApiTest,
         never,
-        | "employeeId"
-        | "fullName"
-        | "class"
-        | "mediaReference"
-        | "attachment"
-        | "geopoint"
-        | "geotimeSeriesReference"
-        | "timeseries"
-        | "isActive"
-        | "yearsOfExperience"
-        | "rank"
-        | "performanceScore"
-        | "hourlyRate"
-        | "dateOfJoining"
-        | "lastUpdated"
-        | "skillSet"
-        | "skillSetEmbedding"
-        | NEW_PROPS
-        | undefined,
+        PropertyKeys<EmployeeApiTest> | NEW_PROPS,
         {}
       >;
       readonly $__EXPERIMENTAL__NOT_SUPPORTED_YET__metadata: {

--- a/packages/api/src/objectSet/ObjectSet.ts
+++ b/packages/api/src/objectSet/ObjectSet.ts
@@ -193,6 +193,54 @@ interface FetchPageSignature<
   RDPs extends Record<string, SimplePropertyDef> = {},
 > {
   /**
+   * Gets a page of objects of this type, applying property modifiers to
+   * selected fields (e.g., reducing array properties or extracting main
+   * values from struct properties).
+   * @param args - Args including a `$applyModifiers` map keyed by property name
+   */
+  <
+    L extends PropertyKeys<Q> | (string & keyof RDPs),
+    R extends boolean,
+    const A extends Augments,
+    S extends NullabilityAdherence = NullabilityAdherence.Default,
+    T extends boolean = false,
+    ORDER_BY_OPTIONS extends ObjectSetArgs.OrderByOptions<L> = {},
+    PROPERTY_SECURITIES extends boolean = false,
+    MODIFIERS extends ApplyModifiersArg<Q> = {},
+  >(
+    args:
+      & FetchPageArgs<
+        Q,
+        L,
+        R,
+        A,
+        S,
+        T,
+        never,
+        ORDER_BY_OPTIONS,
+        PROPERTY_SECURITIES,
+        MODIFIERS
+      >
+      & { $applyModifiers: MODIFIERS },
+  ): Promise<
+    PageResult<
+      MaybeScore<
+        Osdk.Instance<
+          Q,
+          ExtractOptions<R, S, T, PROPERTY_SECURITIES>,
+          | Exclude<
+            NoInfer<SubSelectKeys<Q, NonNullable<typeof args>>>,
+            keyof MODIFIERS
+          >
+          | ModifiersToSelectStrings<MODIFIERS>,
+          SubSelectRDPs<RDPs, NonNullable<typeof args>>
+        >,
+        ORDER_BY_OPTIONS
+      >
+    >
+  >;
+
+  /**
    * Gets a page of objects of this type, with a result wrapper
    * @param args - Args to specify next page token and page size, if applicable
    * @example
@@ -213,31 +261,27 @@ interface FetchPageSignature<
     T extends boolean = false,
     ORDER_BY_OPTIONS extends ObjectSetArgs.OrderByOptions<L> = {},
     PROPERTY_SECURITIES extends boolean = false,
-    MODIFIERS extends ApplyModifiersArg<Q> = {},
   >(
-    args?: FetchPageArgs<
-      Q,
-      L,
-      R,
-      A,
-      S,
-      T,
-      never,
-      ORDER_BY_OPTIONS,
-      PROPERTY_SECURITIES,
-      MODIFIERS
-    >,
+    args?:
+      & FetchPageArgs<
+        Q,
+        L,
+        R,
+        A,
+        S,
+        T,
+        never,
+        ORDER_BY_OPTIONS,
+        PROPERTY_SECURITIES
+      >
+      & { $applyModifiers?: never },
   ): Promise<
     PageResult<
       MaybeScore<
         Osdk.Instance<
           Q,
           ExtractOptions<R, S, T, PROPERTY_SECURITIES>,
-          | Exclude<
-            NoInfer<SubSelectKeys<Q, NonNullable<typeof args>>>,
-            keyof MODIFIERS
-          >
-          | ModifiersToSelectStrings<MODIFIERS>,
+          NoInfer<SubSelectKeys<Q, NonNullable<typeof args>>>,
           SubSelectRDPs<RDPs, NonNullable<typeof args>>
         >,
         ORDER_BY_OPTIONS
@@ -277,6 +321,55 @@ interface FetchPageWithErrorsSignature<
   PROPERTY_SECURITIES extends boolean = false,
 > {
   /**
+   * Gets a page of objects of this type with a Result wrapper, applying
+   * property modifiers to selected fields (e.g., reducing array properties
+   * or extracting main values from struct properties).
+   * @param args - Args including a `$applyModifiers` map keyed by property name
+   */
+  <
+    L extends PropertyKeys<Q> | (string & keyof RDPs),
+    R extends boolean,
+    const A extends Augments,
+    S extends NullabilityAdherence = NullabilityAdherence.Default,
+    T extends boolean = false,
+    ORDER_BY_OPTIONS extends ObjectSetArgs.OrderByOptions<L> = {},
+    const MODIFIERS extends ApplyModifiersArg<Q> = {},
+  >(
+    args:
+      & FetchPageArgs<
+        Q,
+        L,
+        R,
+        A,
+        S,
+        T,
+        never,
+        ORDER_BY_OPTIONS,
+        PROPERTY_SECURITIES,
+        MODIFIERS
+      >
+      & { $applyModifiers: MODIFIERS },
+  ): Promise<
+    Result<
+      PageResult<
+        MaybeScore<
+          Osdk.Instance<
+            Q,
+            ExtractOptions<R, S, T, PROPERTY_SECURITIES>,
+            | Exclude<
+              NoInfer<SubSelectKeys<Q, NonNullable<typeof args>>>,
+              keyof MODIFIERS
+            >
+            | ModifiersToSelectStrings<MODIFIERS>,
+            SubSelectRDPs<RDPs, NonNullable<typeof args>>
+          >,
+          ORDER_BY_OPTIONS
+        >
+      >
+    >
+  >;
+
+  /**
    * Gets a page of objects of this type, with a result wrapper
    * @param args - Args to specify next page token and page size, if applicable
    * @example
@@ -299,20 +392,20 @@ interface FetchPageWithErrorsSignature<
     S extends NullabilityAdherence = NullabilityAdherence.Default,
     T extends boolean = false,
     ORDER_BY_OPTIONS extends ObjectSetArgs.OrderByOptions<L> = {},
-    const MODIFIERS extends ApplyModifiersArg<Q> = {},
   >(
-    args?: FetchPageArgs<
-      Q,
-      L,
-      R,
-      A,
-      S,
-      T,
-      never,
-      ORDER_BY_OPTIONS,
-      PROPERTY_SECURITIES,
-      MODIFIERS
-    >,
+    args?:
+      & FetchPageArgs<
+        Q,
+        L,
+        R,
+        A,
+        S,
+        T,
+        never,
+        ORDER_BY_OPTIONS,
+        PROPERTY_SECURITIES
+      >
+      & { $applyModifiers?: never },
   ): Promise<
     Result<
       PageResult<
@@ -320,11 +413,7 @@ interface FetchPageWithErrorsSignature<
           Osdk.Instance<
             Q,
             ExtractOptions<R, S, T, PROPERTY_SECURITIES>,
-            | Exclude<
-              NoInfer<SubSelectKeys<Q, NonNullable<typeof args>>>,
-              keyof MODIFIERS
-            >
-            | ModifiersToSelectStrings<MODIFIERS>,
+            NoInfer<SubSelectKeys<Q, NonNullable<typeof args>>>,
             SubSelectRDPs<RDPs, NonNullable<typeof args>>
           >,
           ORDER_BY_OPTIONS


### PR DESCRIPTION
## Summary

- Splits `fetchPage` and `fetchPageWithErrors` into two overloads — one that requires `$applyModifiers` and keeps the modifier-aware return type, one without `$applyModifiers` that uses the original `NoInfer<SubSelectKeys<…>>` shape. Declared in that order, so TypeScript picks the clean overload for hover / `ReturnType` / `Parameters` probes while resolving the modifier-aware one at concrete call sites that actually pass `$applyModifiers`.
- Fixes a hover regression introduced in #2657 ("Array Reducers and Struct Main Values"): the new `MODIFIERS extends ApplyModifiersArg<Q> = {}` parameter, combined with `Exclude<…, keyof MODIFIERS> | ModifiersToSelectStrings<MODIFIERS>`, rendered `fetchPage`'s return type as an expanded property union missing the modifier-eligible properties (`addressStruct`, `salaryHistory`, `bonusHistory`) and gaining a phantom `| undefined`. Caused by TS substituting `MODIFIERS` with its constraint, not its default, at type-probe time.
- Updates the `objectSet.snap` quickinfo snapshot accordingly — `Osdk.Instance<EmployeeApiTest, never, PropertyKeys<EmployeeApiTest>, {}>` everywhere `fetchPage` appears (~120 lines removed).

Stacked above #3153 (`td/hover-types-test`).

## Test plan

- [x] `pnpm turbo typecheck --filter=@osdk/api` — passes
- [x] `pnpm turbo typecheck --filter=@osdk/client --filter=@osdk/react --filter=@osdk/foundry-sdk-generator --filter=@osdk/cli` — passes (no downstream regressions)
- [x] `pnpm vitest run` in `@osdk/api` — 210 passed, 2 todo
- [x] Quickinfo snapshot regenerated; diff is the expected `fetchPage` / `fetchPageWithErrors` cleanup
- [x] Two `disallows invalid modifiers` tests still pass; `@ts-expect-error` markers hoisted to the outer call line (the overload-resolution "no overload matches" error reports at the call site rather than the offending property)
- [x] `pnpm turbo check-api --filter=@osdk/api` — passes (only pre-existing release-tag warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)