### PR TITLE
Add @osdk/client/experimental with createClientFromWriteableClient

### DIFF
--- a/.changeset/client-experimental-from-writeable.md
+++ b/.changeset/client-experimental-from-writeable.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": minor
+---
+
+Add `@osdk/client/experimental` entry point exposing `createClientWithTransaction` and a new `createClientFromWriteableClient` that clones a writeable client's base URL, ontology, token provider, and transaction id while discarding its fetch implementation.

--- a/packages/client/experimental.d.ts
+++ b/packages/client/experimental.d.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from "./build/cjs/experimental.cjs";

--- a/packages/client/experimental.d.ts
+++ b/packages/client/experimental.d.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export * from "./build/cjs/experimental.cjs";
+export * from "./build/cjs/public/experimental.cjs";

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -18,6 +18,15 @@
       "require": "./build/cjs/index.cjs",
       "default": "./build/browser/index.js"
     },
+    "./experimental": {
+      "browser": "./build/browser/public/experimental.js",
+      "import": {
+        "types": "./build/types/public/experimental.d.ts",
+        "default": "./build/esm/public/experimental.js"
+      },
+      "require": "./build/cjs/public/experimental.cjs",
+      "default": "./build/browser/public/experimental.js"
+    },
     "./internal-node": {
       "browser": "./build/browser/public/internal-node.js",
       "import": {

--- a/packages/client/src/createClientFromWriteableClient.ts
+++ b/packages/client/src/createClientFromWriteableClient.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { additionalContext, type Client } from "./Client.js";
+import { createClientWithTransaction } from "./createClient.js";
+
+export function createClientFromWriteableClient(
+  writeableClient: Client,
+): Client {
+  const ctx = writeableClient[additionalContext];
+
+  if (ctx.transactionId === undefined || ctx.flushEdits === undefined) {
+    throw new Error(
+      "createClientFromWriteableClient: provided client has no active transaction",
+    );
+  }
+
+  return createClientWithTransaction(
+    ctx.transactionId,
+    ctx.flushEdits,
+    ctx.baseUrl,
+    ctx.ontologyRid,
+    ctx.tokenProvider,
+  );
+}

--- a/packages/client/src/public/experimental.ts
+++ b/packages/client/src/public/experimental.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { createClientWithTransaction } from "../createClient.js";
+export { createClientFromWriteableClient } from "../createClientFromWriteableClient.js";


### PR DESCRIPTION
## Summary
- New `@osdk/client/experimental` entry point.
- Exports `createClientWithTransaction` (previously only in `/unstable-do-not-use`).
- Adds `createClientFromWriteableClient(writeableClient)` which clones a writeable client's `baseUrl`, `ontologyRid`, `tokenProvider`, `transactionId`, and `flushEdits` (read off the internal `additionalContext`) and re-creates a transactional client. The original fetch implementation is intentionally not propagated — the resulting client uses the default `globalThis.fetch`. Throws if the input has no active transaction.

## Test plan
- [ ] \`pnpm turbo typecheck --filter=@osdk/client\` passes
- [ ] \`pnpm turbo check-api --filter=@osdk/client\` passes
- [ ] \`pnpm turbo transpile --filter=@osdk/client\` produces \`build/esm/public/experimental.js\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)