### PR TITLE
support reactnode rendering in action form fields

### DIFF
--- a/.changeset/action-form-render-item.md
+++ b/.changeset/action-form-render-item.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+Action form fields now support rich `ReactNode` rendering for values. `DropdownField` and `ObjectSelectField` accept a `ReactNode`-returning `itemToStringLabel`, plus new `itemToSearchText` and `itemToAriaLabel` props for the combobox client-side filter and chip remove `aria-label`. `RadioButtonsField` now accepts `ReactNode` for `Option.label`; internal state identity moved from the label string to the option index so selection by `value` is unchanged. All changes are backward compatible — existing string callers see no behavior change.

--- a/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
@@ -1878,3 +1878,250 @@ export const WithGridSection: Story = {
     onSubmit: handleSubmit,
   },
 };
+
+// ---------------------------------------------------------------------------
+// ReactNode rendering stories (DropdownField / ObjectSelectField /
+// RadioButtonsField) — demonstrate JSX returned from `itemToStringLabel`
+// and JSX as `Option.label`.
+// ---------------------------------------------------------------------------
+
+const DEPARTMENT_SWATCH_COLORS: Record<string, string> = {
+  Engineering: "#3b82f6",
+  Marketing: "#f97316",
+  Sales: "#10b981",
+  Finance: "#a855f7",
+  Operations: "#0ea5e9",
+  Legal: "#ef4444",
+};
+
+function SwatchDot({ color }: { color: string }): React.ReactElement {
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        width: 10,
+        height: 10,
+        borderRadius: "50%",
+        marginRight: 8,
+        verticalAlign: "middle",
+        background: color,
+      }}
+    />
+  );
+}
+
+function DepartmentItem({ name }: { name: string }): React.ReactElement {
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center" }}>
+      <SwatchDot color={DEPARTMENT_SWATCH_COLORS[name] ?? "#94a3b8"} />
+      <span>{name}</span>
+    </span>
+  );
+}
+
+const renderItemDropdownFormContent: ReadonlyArray<FormContentItem> = [
+  field({
+    fieldKey: "department",
+    fieldComponent: "DROPDOWN",
+    label: "Department (JSX item)",
+    fieldComponentProps: {
+      items: DEPARTMENT_ITEMS,
+      isSearchable: true,
+      placeholder: "Select department...",
+      itemToStringLabel: (item) => <DepartmentItem name={String(item)} />,
+      itemToSearchText: (item) => String(item),
+    },
+  }),
+  field({
+    fieldKey: "departments",
+    fieldComponent: "DROPDOWN",
+    label: "Departments (multi, JSX chips)",
+    fieldComponentProps: {
+      items: DEPARTMENT_ITEMS,
+      isMultiple: true,
+      isSearchable: true,
+      placeholder: "Select multiple...",
+      itemToStringLabel: (item) => <DepartmentItem name={String(item)} />,
+      itemToSearchText: (item) => String(item),
+      itemToAriaLabel: (item) => `department ${String(item)}`,
+    },
+  }),
+];
+
+export const WithDropdownRenderItem: Story = {
+  args: {
+    formContent: renderItemDropdownFormContent,
+    onSubmit: handleSubmit,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`itemToStringLabel` may return any `ReactNode`. When it returns "
+          + "JSX, supply `itemToSearchText` (used for the combobox client-"
+          + "side filter) and optionally `itemToAriaLabel` (used on the "
+          + "multi-select chip remove button). String-returning callers "
+          + "see no behavior change.",
+      },
+      source: {
+        code: `const formContent = [
+  {
+    fieldKey: "department",
+    fieldComponent: "DROPDOWN",
+    label: "Department",
+    fieldComponentProps: {
+      items: DEPARTMENT_ITEMS,
+      isSearchable: true,
+      itemToStringLabel: (item) => <DepartmentItem name={item} />,
+      itemToSearchText: (item) => item,
+    },
+  },
+];`,
+      },
+    },
+  },
+};
+
+const renderItemRadioFormContent: ReadonlyArray<FormContentItem> = [
+  field({
+    fieldKey: "priority",
+    fieldComponent: "RADIO_BUTTONS",
+    label: "Priority (JSX labels)",
+    fieldComponentProps: {
+      options: [
+        {
+          label: (
+            <span style={{ display: "inline-flex", alignItems: "center" }}>
+              <SwatchDot color="#ef4444" />
+              High
+            </span>
+          ),
+          value: "high",
+        },
+        {
+          label: (
+            <span style={{ display: "inline-flex", alignItems: "center" }}>
+              <SwatchDot color="#f59e0b" />
+              Medium
+            </span>
+          ),
+          value: "medium",
+        },
+        {
+          label: (
+            <span style={{ display: "inline-flex", alignItems: "center" }}>
+              <SwatchDot color="#10b981" />
+              Low
+            </span>
+          ),
+          value: "low",
+        },
+      ],
+    },
+  }),
+];
+
+export const WithRadioButtonsRenderLabel: Story = {
+  args: {
+    formContent: renderItemRadioFormContent,
+    onSubmit: handleSubmit,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "`Option.label` accepts any `ReactNode` (string or JSX). The "
+          + "Radio's internal state identity is decoupled from the label "
+          + "(it uses the option's array index), so selection by `value` "
+          + "keeps working identically.",
+      },
+      source: {
+        code: `const options = [
+  { label: <><SwatchDot color="#ef4444" /> High</>, value: "high" },
+  { label: <><SwatchDot color="#f59e0b" /> Medium</>, value: "medium" },
+  { label: <><SwatchDot color="#10b981" /> Low</>, value: "low" },
+];`,
+      },
+    },
+  },
+};
+
+function EmployeeAvatar({ name }: { name: string }): React.ReactElement {
+  const initials = name
+    .split(" ")
+    .map((part) => part[0] ?? "")
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center" }}>
+      <span
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: 22,
+          height: 22,
+          borderRadius: "50%",
+          marginRight: 8,
+          background: "#e0e7ff",
+          color: "#3730a3",
+          fontSize: 11,
+          fontWeight: 600,
+        }}
+      >
+        {initials}
+      </span>
+      <span>{name}</span>
+    </span>
+  );
+}
+
+const renderItemObjectSelectFormContent: ReadonlyArray<FormContentItem> = [
+  field({
+    fieldKey: "employee",
+    fieldComponent: "OBJECT_SELECT",
+    label: "Employee (avatar + name)",
+    fieldComponentProps: {
+      objectType: Employee,
+      placeholder: "Search employees…",
+      itemToStringLabel: (obj) => (
+        <EmployeeAvatar
+          name={typeof obj.$title === "string"
+            ? obj.$title
+            : String(obj.$primaryKey)}
+        />
+      ),
+    },
+  }),
+];
+
+export const WithObjectSelectRenderItem: Story = {
+  args: {
+    formContent: renderItemObjectSelectFormContent,
+    onSubmit: handleSubmit,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "`ObjectSelectField` now exposes `itemToStringLabel`, "
+          + "`itemToSearchText`, and `itemToAriaLabel` for callers to "
+          + "override. When `itemToStringLabel` returns JSX, the OSDK "
+          + "server-side title search still uses the object's "
+          + "`titleProperty` — no client-side wiring needed.",
+      },
+      source: {
+        code: `const formContent = [
+  {
+    fieldKey: "employee",
+    fieldComponent: "OBJECT_SELECT",
+    label: "Employee",
+    fieldComponentProps: {
+      objectType: Employee,
+      itemToStringLabel: (obj) => <EmployeeAvatar name={obj.$title} />,
+    },
+  },
+];`,
+      },
+    },
+  },
+};

--- a/packages/react-components/src/action-form/FormFieldApi.ts
+++ b/packages/react-components/src/action-form/FormFieldApi.ts
@@ -169,9 +169,19 @@ export interface DropdownFieldProps<V, Multiple extends boolean = false>
   items: V[];
 
   /**
-   * Converts an item to a display string. Defaults to `String()`.
+   * Converts an item to display content shown in dropdown items and chips.
+   * May return any `ReactNode` (e.g. JSX with avatars, icons, anchors).
+   * Defaults to `String(item)`, or `item.label` when items are objects with
+   * a string `.label` property.
+   *
+   * When this returns non-string JSX, `itemToSearchText` and
+   * `itemToAriaLabel` are used to derive the strings needed for the
+   * combobox's client-side filter and the multi-select chip remove
+   * button's `aria-label`. By default those fall back to `itemToKey?.(item)
+   * ?? String(item)` — set them explicitly when you want a meaningful
+   * search/aria experience alongside JSX rendering.
    */
-  itemToStringLabel?: (item: V) => string;
+  itemToStringLabel?: (item: V) => React.ReactNode;
 
   /**
    * Returns a unique string key for a list item. Used as the React `key`.
@@ -184,6 +194,22 @@ export interface DropdownFieldProps<V, Multiple extends boolean = false>
    * Required when items are objects to ensure correct selection matching.
    */
   isItemEqual?: (a: V, b: V) => boolean;
+
+  /**
+   * Returns the plain string used by the combobox's client-side filter
+   * when the user types a query. Defaults to `itemToStringLabel(item)`
+   * when that function returns a string, otherwise `itemToKey?.(item) ??
+   * String(item)`. Provide this explicitly when `itemToStringLabel`
+   * returns JSX and you want search to match against a meaningful label.
+   */
+  itemToSearchText?: (item: V) => string;
+
+  /**
+   * Returns the plain string used as the `aria-label` on the multi-select
+   * chip's remove button (e.g. `Remove ${itemToAriaLabel(item)}`).
+   * Defaults to `itemToSearchText(item)`.
+   */
+  itemToAriaLabel?: (item: V) => string;
 
   /**
    * Whether the dropdown allows searching/filtering.
@@ -382,10 +408,15 @@ export interface RadioButtonsFieldProps<V> extends BaseFormFieldProps<V> {
 export type SwitchFieldProps = BaseFormFieldProps<boolean>;
 
 /**
- * Option interface for radio button options
+ * Option interface for radio button options.
+ *
+ * `label` may be either a plain `string` or any `ReactNode` (e.g. JSX with
+ * an icon + text). When `label` is a string it is also used as the radio's
+ * accessible name; when it is JSX, ensure the rendered content provides
+ * its own accessible text (or is preceded by a visible field label).
  */
 export interface Option<V> {
-  label: string;
+  label: string | React.ReactNode;
   value: V;
 }
 
@@ -435,7 +466,6 @@ export type ObjectSelectFieldProps<
   & Omit<
     DropdownFieldProps<Osdk.Instance<Q>>,
     | "items"
-    | "itemToStringLabel"
     | "itemToKey"
     | "isItemEqual"
     | "isSearchable"

--- a/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
@@ -594,4 +594,137 @@ describe("DropdownField", () => {
       expect(screen.queryByLabelText("Clear")).toBeNull();
     });
   });
+
+  describe("itemToStringLabel as ReactNode", () => {
+    it("renders JSX returned from itemToStringLabel in select items", async () => {
+      render(
+        <DropdownField<string>
+          value={null}
+          items={STRING_ITEMS}
+          itemToStringLabel={(v) => <span data-testid={`item-${v}`}>★ {v}
+          </span>}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("combobox"));
+
+      await vi.waitFor(() => {
+        expect(screen.getByTestId("item-Alice")).toBeDefined();
+        expect(screen.getByTestId("item-Bob")).toBeDefined();
+      });
+    });
+
+    it("renders JSX in multi-select chips", () => {
+      render(
+        <DropdownField<string, true>
+          value={["Alice"]}
+          items={STRING_ITEMS}
+          isMultiple={true}
+          itemToStringLabel={(v) => <span data-testid={`chip-${v}`}>★ {v}
+          </span>}
+        />,
+      );
+
+      expect(screen.getByTestId("chip-Alice")).toBeDefined();
+    });
+
+    it("uses itemToAriaLabel for chip remove button aria-label", () => {
+      render(
+        <DropdownField<string, true>
+          value={["Alice"]}
+          items={STRING_ITEMS}
+          isMultiple={true}
+          itemToStringLabel={(v) => <span>★ {v}</span>}
+          itemToAriaLabel={(v) => `user ${v}`}
+        />,
+      );
+
+      expect(screen.getByLabelText("Remove user Alice")).toBeDefined();
+    });
+
+    it(
+      "falls back to itemToSearchText for chip aria-label when itemToAriaLabel absent",
+      () => {
+        render(
+          <DropdownField<string, true>
+            value={["Alice"]}
+            items={STRING_ITEMS}
+            isMultiple={true}
+            itemToStringLabel={(v) => <span>★ {v}</span>}
+            itemToSearchText={(v) => `search-${v}`}
+          />,
+        );
+
+        expect(screen.getByLabelText("Remove search-Alice")).toBeDefined();
+      },
+    );
+
+    it(
+      "string-returning itemToStringLabel still drives chip aria-label when no overrides",
+      () => {
+        render(
+          <DropdownField<string, true>
+            value={["Alice"]}
+            items={STRING_ITEMS}
+            isMultiple={true}
+            itemToStringLabel={(v) => v}
+          />,
+        );
+
+        expect(screen.getByLabelText("Remove Alice")).toBeDefined();
+      },
+    );
+
+    it(
+      "combobox client-side filter uses itemToSearchText when itemToStringLabel returns JSX",
+      async () => {
+        render(
+          <DropdownField<string>
+            value={null}
+            items={STRING_ITEMS}
+            isSearchable={true}
+            itemToStringLabel={(v) => (
+              <span data-testid={`item-${v}`}>★ {v}</span>
+            )}
+            itemToSearchText={(v) => v.toLowerCase()}
+          />,
+        );
+
+        fireEvent.click(screen.getByRole("combobox"));
+
+        const searchInput = await screen.findByPlaceholderText("Search…");
+        fireEvent.change(searchInput, { target: { value: "ali" } });
+
+        await vi.waitFor(() => {
+          expect(screen.queryByTestId("item-Alice")).toBeDefined();
+          expect(screen.queryByTestId("item-Bob")).toBeNull();
+          expect(screen.queryByTestId("item-Charlie")).toBeNull();
+        });
+      },
+    );
+
+    it(
+      "search falls back to string return of itemToStringLabel when no itemToSearchText",
+      async () => {
+        render(
+          <DropdownField<string>
+            value={null}
+            items={STRING_ITEMS}
+            isSearchable={true}
+            itemToStringLabel={(v) => v}
+          />,
+        );
+
+        fireEvent.click(screen.getByRole("combobox"));
+
+        const searchInput = await screen.findByPlaceholderText("Search…");
+        fireEvent.change(searchInput, { target: { value: "Bob" } });
+
+        await vi.waitFor(() => {
+          expect(screen.queryByRole("option", { name: /Bob/ })).toBeDefined();
+          expect(screen.queryByRole("option", { name: /Alice/ })).toBeNull();
+        });
+      },
+    );
+  });
 });

--- a/packages/react-components/src/action-form/__tests__/ObjectSelectField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/ObjectSelectField.test.tsx
@@ -327,6 +327,53 @@ describe("ObjectSelectField", () => {
       expect(popup?.textContent).toContain("99");
     });
   });
+
+  describe("itemToStringLabel as ReactNode", () => {
+    it("renders JSX returned from user-provided itemToStringLabel", async () => {
+      mockLoadedState();
+      renderObjectSelect({
+        itemToStringLabel: (obj) => (
+          <span data-testid={`obj-${obj.$primaryKey}`}>
+            ★ {obj.$title}
+          </span>
+        ),
+      });
+      await openCombobox();
+
+      await vi.waitFor(() => {
+        expect(screen.getByTestId("obj-1")).toBeDefined();
+        expect(screen.getByTestId("obj-2")).toBeDefined();
+      });
+    });
+
+    it(
+      "server-side title search still uses the title property when itemToStringLabel returns JSX",
+      async () => {
+        vi.useFakeTimers();
+        try {
+          mockLoadedState();
+          renderObjectSelect({
+            itemToStringLabel: (obj) => <span>★ {obj.$title}</span>,
+          });
+          await openCombobox();
+
+          const searchInput = screen.getByPlaceholderText("Search…");
+          fireEvent.change(searchInput, { target: { value: "Ali" } });
+
+          vi.advanceTimersByTime(300);
+
+          await vi.waitFor(() => {
+            const latestCall = mockUseOsdkObjects.mock.calls.at(-1);
+            expect(latestCall?.[1]?.where).toEqual({
+              fullName: { $containsAllTermsInOrder: "Ali" },
+            });
+          });
+        } finally {
+          vi.useRealTimers();
+        }
+      },
+    );
+  });
 });
 
 function mockMetadataLoaded(titleProperty: string = "fullName"): void {

--- a/packages/react-components/src/action-form/__tests__/RadioButtonsField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/RadioButtonsField.test.tsx
@@ -125,4 +125,74 @@ describe("RadioButtonsField", () => {
       expect(onChange).toHaveBeenCalledWith({ id: 2, name: "banana" });
     });
   });
+
+  describe("Option.label as ReactNode", () => {
+    const JSX_OPTIONS = [
+      {
+        label: <span data-testid="opt-red">★ Red</span>,
+        value: "red",
+      },
+      {
+        label: <span data-testid="opt-green">★ Green</span>,
+        value: "green",
+      },
+    ];
+
+    it("renders JSX labels", () => {
+      render(<RadioButtonsField value="red" options={JSX_OPTIONS} />);
+
+      expect(screen.getByTestId("opt-red")).toBeDefined();
+      expect(screen.getByTestId("opt-green")).toBeDefined();
+    });
+
+    it("selection by value still resolves correctly with JSX labels", () => {
+      render(<RadioButtonsField value="green" options={JSX_OPTIONS} />);
+
+      const greenRadio = screen.getByTestId("opt-green")
+        .closest("label")!
+        .querySelector("[role='radio']")!;
+      expect(greenRadio.getAttribute("aria-checked")).toBe("true");
+    });
+
+    it("onChange fires with the option value when JSX-labeled radio is clicked", () => {
+      const onChange = vi.fn();
+      render(
+        <RadioButtonsField
+          value="red"
+          options={JSX_OPTIONS}
+          onChange={onChange}
+        />,
+      );
+
+      const radios = screen.getAllByRole("radio");
+      fireEvent.click(radios[1]);
+
+      expect(onChange).toHaveBeenCalledWith("green");
+    });
+
+    it("two options with identical .value remain distinguishable by index", () => {
+      // Index-based identity means duplicate values can each render as their
+      // own selectable radio; selection by external `value` lands on the
+      // first match (findIndex semantics), but each radio is independently
+      // clickable in its own slot.
+      const dupOptions = [
+        { label: <span data-testid="dup-a">A</span>, value: "x" },
+        { label: <span data-testid="dup-b">B</span>, value: "x" },
+      ];
+      const onChange = vi.fn();
+      render(
+        <RadioButtonsField
+          value={null}
+          options={dupOptions}
+          onChange={onChange}
+        />,
+      );
+
+      const radios = screen.getAllByRole("radio");
+      expect(radios).toHaveLength(2);
+
+      fireEvent.click(radios[1]);
+      expect(onChange).toHaveBeenCalledWith("x");
+    });
+  });
 });

--- a/packages/react-components/src/action-form/fields/DropdownField.tsx
+++ b/packages/react-components/src/action-form/fields/DropdownField.tsx
@@ -15,7 +15,7 @@
  */
 
 import { CaretDown, Cross, SmallCross, Tick } from "@blueprintjs/icons";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { Combobox } from "../../base-components/combobox/Combobox.js";
 import comboboxStyles from "../../base-components/combobox/Combobox.module.css";
 import { Select } from "../../base-components/select/Select.js";
@@ -36,7 +36,9 @@ const EMPTY_ARRAY: [] = [];
 interface InnerSelectProps<V, Multiple extends boolean>
   extends Omit<DropdownFieldProps<V, Multiple>, "isSearchable">
 {
-  itemToStringLabel: (item: V) => string;
+  itemToStringLabel: (item: V) => React.ReactNode;
+  itemToSearchText: (item: V) => string;
+  itemToAriaLabel: (item: V) => string;
   getKey: (item: V) => string;
   portalRef?: React.Ref<HTMLDivElement>;
   query?: string;
@@ -64,6 +66,8 @@ export const DropdownField: <V, Multiple extends boolean = false>(
   isMultiple,
   itemToStringLabel,
   itemToKey,
+  itemToSearchText,
+  itemToAriaLabel,
   value,
   query,
   onQueryChange,
@@ -84,9 +88,29 @@ export const DropdownField: <V, Multiple extends boolean = false>(
   const resolvedItemToStringLabel = itemToStringLabel
     ?? defaultItemToStringLabel;
 
+  const resolvedItemToSearchText = useCallback(
+    (item: V): string => {
+      if (itemToSearchText) {
+        return itemToSearchText(item);
+      }
+      const rendered = resolvedItemToStringLabel(item);
+      if (typeof rendered === "string") {
+        return rendered;
+      }
+      return itemToKey?.(item) ?? String(item);
+    },
+    [itemToSearchText, resolvedItemToStringLabel, itemToKey],
+  );
+
+  const resolvedItemToAriaLabel = useCallback(
+    (item: V): string =>
+      itemToAriaLabel?.(item) ?? resolvedItemToSearchText(item),
+    [itemToAriaLabel, resolvedItemToSearchText],
+  );
+
   const getKey = useCallback(
-    (item: V) => itemToKey?.(item) ?? resolvedItemToStringLabel(item),
-    [itemToKey, resolvedItemToStringLabel],
+    (item: V) => itemToKey?.(item) ?? resolvedItemToSearchText(item),
+    [itemToKey, resolvedItemToSearchText],
   );
 
   // Multi-select always uses Combobox for the chip-based UI because it looks better
@@ -97,6 +121,8 @@ export const DropdownField: <V, Multiple extends boolean = false>(
         isMultiple={isMultiple}
         value={normalizedValue}
         itemToStringLabel={resolvedItemToStringLabel}
+        itemToSearchText={resolvedItemToSearchText}
+        itemToAriaLabel={resolvedItemToAriaLabel}
         getKey={getKey}
         isSearchable={isSearchable}
         query={query}
@@ -115,6 +141,8 @@ export const DropdownField: <V, Multiple extends boolean = false>(
       {...rest}
       value={normalizedValue}
       itemToStringLabel={resolvedItemToStringLabel}
+      itemToSearchText={resolvedItemToSearchText}
+      itemToAriaLabel={resolvedItemToAriaLabel}
       getKey={getKey}
       modal={modal}
     />
@@ -130,6 +158,7 @@ const SelectDropdown = typedReactMemo(function SelectDropdownFn<
   onChange,
   items,
   itemToStringLabel,
+  itemToSearchText,
   getKey,
   isItemEqual,
   placeholder,
@@ -172,7 +201,7 @@ const SelectDropdown = typedReactMemo(function SelectDropdownFn<
         open={open}
         onOpenChange={handleOpenChange}
         isItemEqualToValue={isItemEqual}
-        itemToStringLabel={itemToStringLabel}
+        itemToStringLabel={itemToSearchText}
         modal={modal}
       >
         <Select.Trigger id={id} placeholder={placeholder}>
@@ -230,6 +259,8 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
   onChange,
   items,
   itemToStringLabel,
+  itemToSearchText,
+  itemToAriaLabel,
   getKey,
   isItemEqual,
   isMultiple,
@@ -321,6 +352,19 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
     [getKey, isMultiple, itemToStringLabel],
   );
 
+  const comboboxFilter = useMemo(
+    () => {
+      if (disableClientSideFiltering) {
+        return null;
+      }
+      return (itemValue: V, searchQuery: string) =>
+        itemToSearchText(itemValue).toLowerCase().includes(
+          searchQuery.toLowerCase(),
+        );
+    },
+    [disableClientSideFiltering, itemToSearchText],
+  );
+
   return (
     <div>
       <Combobox.Root
@@ -329,12 +373,12 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
         open={open}
         onOpenChange={handleOpenChange}
         multiple={isMultiple}
-        itemToStringLabel={itemToStringLabel}
+        itemToStringLabel={itemToSearchText}
         isItemEqualToValue={isItemEqual}
         items={items}
         inputValue={query}
         onInputValueChange={onQueryChange}
-        filter={disableClientSideFiltering ? null : undefined}
+        filter={comboboxFilter}
       >
         <Combobox.Trigger
           id={id}
@@ -354,7 +398,7 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
                       {itemToStringLabel(item)}
                       <span
                         role="button"
-                        aria-label={`Remove ${itemToStringLabel(item)}`}
+                        aria-label={`Remove ${itemToAriaLabel(item)}`}
                         className={comboboxStyles.osdkComboboxTriggerChipRemove}
                         onMouseDown={preventTriggerOpen}
                         onClick={() => handleRemoveItem(item)}
@@ -429,7 +473,7 @@ function preventTriggerOpen(e: React.MouseEvent): void {
   e.preventDefault();
 }
 
-function defaultItemToStringLabel<V>(item: V): string {
+function defaultItemToStringLabel<V>(item: V): React.ReactNode {
   if (item == null || typeof item !== "object") {
     return String(item);
   }

--- a/packages/react-components/src/action-form/fields/ObjectSelectField.tsx
+++ b/packages/react-components/src/action-form/fields/ObjectSelectField.tsx
@@ -65,6 +65,9 @@ const ObjectSelectInner: React.NamedExoticComponent<
   isMultiple,
   portalRef,
   portalContainer,
+  itemToStringLabel: itemToStringLabelProp,
+  itemToSearchText: itemToSearchTextProp,
+  itemToAriaLabel: itemToAriaLabelProp,
 }): React.ReactElement {
   // Tracks the user's search text. Cleared on selection so the selected
   // label (managed by base-ui) doesn't trigger a server-side search.
@@ -131,7 +134,9 @@ const ObjectSelectInner: React.NamedExoticComponent<
       onChange={handleChange}
       error={error}
       items={items}
-      itemToStringLabel={itemToStringLabel}
+      itemToStringLabel={itemToStringLabelProp ?? defaultItemToStringLabel}
+      itemToSearchText={itemToSearchTextProp ?? defaultItemToStringLabel}
+      itemToAriaLabel={itemToAriaLabelProp ?? defaultItemToStringLabel}
       itemToKey={itemToKey}
       isItemEqual={isItemEqual}
       placeholder={placeholder ?? "Search…"}
@@ -162,7 +167,7 @@ function resolveObjectSelectSource(
   return { kind: "objectType", objectType: props.objectType };
 }
 
-function itemToStringLabel(obj: ObjectSelectOsdkObject): string {
+function defaultItemToStringLabel(obj: ObjectSelectOsdkObject): string {
   return obj.$title ?? String(obj.$primaryKey);
 }
 

--- a/packages/react-components/src/action-form/fields/RadioButtonsField.tsx
+++ b/packages/react-components/src/action-form/fields/RadioButtonsField.tsx
@@ -30,17 +30,24 @@ export const RadioButtonsField: <V>(
   options,
   orientation,
 }: RadioButtonsFieldProps<V>): React.ReactElement {
-  const selectedLabel = useMemo(
-    () =>
-      value != null
-        ? options.find((opt) => opt.value === value)?.label
-        : undefined,
+  // Internal state identity uses the option's array index (stringified) so
+  // that `option.label` can be any ReactNode without breaking RadioGroup's
+  // string-typed `value` contract.
+  const selectedIndex = useMemo(
+    () => {
+      if (value == null) {
+        return undefined;
+      }
+      const idx = options.findIndex((opt) => opt.value === value);
+      return idx >= 0 ? String(idx) : undefined;
+    },
     [options, value],
   );
 
   const handleValueChange = useCallback(
-    (nextLabel: unknown) => {
-      const match = options.find((opt) => opt.label === nextLabel);
+    (nextIndex: unknown) => {
+      const idx = typeof nextIndex === "string" ? Number(nextIndex) : NaN;
+      const match = Number.isInteger(idx) ? options[idx] : undefined;
       onChange?.(match?.value ?? null);
     },
     [options, onChange],
@@ -51,11 +58,11 @@ export const RadioButtonsField: <V>(
       id={id}
       className={styles.osdkRadioGroup}
       data-orientation={orientation ?? "vertical"}
-      value={selectedLabel}
+      value={selectedIndex}
       onValueChange={handleValueChange}
     >
-      {options.map((option) => (
-        <RadioItem key={option.label} option={option} />
+      {options.map((option, idx) => (
+        <RadioItem key={idx} option={option} idx={idx} />
       ))}
     </RadioGroup>
   );
@@ -63,13 +70,15 @@ export const RadioButtonsField: <V>(
 
 const RadioItem = memo(function RadioItemFn({
   option,
+  idx,
 }: {
   option: Option<unknown>;
+  idx: number;
 }): React.ReactElement {
   return (
     <label className={styles.osdkRadioItem}>
       <Radio.Root
-        value={option.label}
+        value={String(idx)}
         className={styles.osdkRadioRoot}
       >
         <Radio.Indicator className={styles.osdkRadioIndicator} />


### PR DESCRIPTION
action form fields now accept reactnode for value rendering — dropdown, object select, and radio buttons can render avatars, icons, and other rich content in place of plain strings

• `DropdownField.itemToStringLabel` returns `ReactNode`; new `itemToSearchText` (combobox client-side filter) and `itemToAriaLabel` (chip remove aria-label) keep accessibility and search working
• `ObjectSelectField` no longer omits these props from its public surface — overrides pass through to the underlying combobox; server-side title search on the object's `titleProperty` is unchanged
• `RadioButtonsField` widens `Option.label` to `ReactNode`; internal state identity moved from the label string to the option array index, so selection by `value` is byte-for-byte identical