### PR TITLE
fix rdp staleness on cross-variant base-field write

### DIFF
--- a/.changeset/rdp-staleness-fix.md
+++ b/.changeset/rdp-staleness-fix.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Refetch rdp variants instead of stitching stale derived values when a sibling write changes base fields

--- a/.changeset/rdp-staleness-repro.md
+++ b/.changeset/rdp-staleness-repro.md
@@ -1,5 +1,0 @@
----
-"@osdk/client": patch
----
-
-Add reproduction for stale rdp on cross-variant write

--- a/.changeset/rdp-staleness-repro.md
+++ b/.changeset/rdp-staleness-repro.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Add reproduction for stale rdp on cross-variant write

--- a/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
@@ -595,6 +595,68 @@ describe("ObjectsHelper variant cache keys", () => {
     expect(q1.cacheKey).not.toBe(q2.cacheKey);
   });
 
+  it("STALENESS REPRO: RDP-less variant write preserves variant A's old derived value even after non-RDP state changes", () => {
+    // Reproduces the suspected staleness bug:
+    //   - Component 1: fetches an object WITH a derived property (variant A)
+    //   - Component 2: fetches the same object WITHOUT derived properties (variant B)
+    //   - Server state changes between the two fetches
+    //   - B's fresh write propagates to A; A's derived field is preserved
+    //     from A's prior cache value, which was computed against the OLD non-RDP state.
+    //   - Result: A's view ends up with FRESH non-RDP fields + STALE derived value.
+    //
+    // We treat "office" as the derived field to stand in for a `withProperties` RDP.
+    const rdpConfig = createFakeRdpConfig("office");
+
+    const queryA = store.objects.getQuery(
+      { apiName: Employee, pk: 1 },
+      rdpConfig,
+    );
+    const queryB = store.objects.getQuery({ apiName: Employee, pk: 1 });
+
+    // Both variants observed so propagation runs.
+    store.cacheKeys.retain(queryA.cacheKey);
+    store.cacheKeys.retain(queryB.cacheKey);
+    store.subjects.get(queryA.cacheKey).subscribe(() => {});
+    store.subjects.get(queryB.cacheKey).subscribe(() => {});
+
+    // Variant A's initial fetch: derived "office" was computed against fullName "Alice".
+    const aPayload = emp.$clone({
+      fullName: "Alice",
+      office: "derived-from-Alice",
+    });
+    store.batch({}, (batch) => {
+      queryA.writeToStore(aPayload as any, "loaded", batch);
+    });
+
+    expect(store.getValue(queryA.cacheKey)?.value).toEqual(
+      expect.objectContaining({
+        fullName: "Alice",
+        office: "derived-from-Alice",
+      }),
+    );
+
+    // Server state changes: fullName goes Alice -> Bob.
+    // Variant B fetches fresh non-RDP data. Critically, B doesn't fetch any
+    // derived field, so the payload has no fresh "office" value.
+    const bPayload = emp.$clone({ fullName: "Bob" });
+    store.batch({}, (batch) => {
+      queryB.writeToStore(bPayload as any, "loaded", batch);
+    });
+
+    const valueA = store.getValue(queryA.cacheKey);
+
+    // Non-RDP fields refresh from B (this is the propagation working as intended).
+    expect(valueA?.value).toEqual(expect.objectContaining({ fullName: "Bob" }));
+
+    // The bug: derived field carries A's pre-update value, now inconsistent
+    // with fullName="Bob". A real fix would either drop it (forcing refetch)
+    // or refresh it. Today the cache silently surfaces this inconsistency.
+    expect((valueA?.value as any)?.office).toBe("derived-from-Alice");
+
+    store.cacheKeys.release(queryA.cacheKey);
+    store.cacheKeys.release(queryB.cacheKey);
+  });
+
   it("treats no-select and empty-select as the same cache key", () => {
     const qNone = store.objects.getQuery({
       apiName: Employee,

--- a/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
@@ -222,7 +222,7 @@ describe("ObjectsHelper.isKeyActive", () => {
     };
   });
 
-  it("propagateWrite propagates to a variant key with pending cleanup", () => {
+  it("propagateWrite reaches a variant key with pending cleanup", () => {
     const rdpConfig = createFakeRdpConfig("derivedAddress");
 
     // Seed key A (no RDP)
@@ -249,19 +249,15 @@ describe("ObjectsHelper.isKeyActive", () => {
     // Simulate pending cleanup (React unmount-remount cycle)
     store.pendingCleanup.set(queryB.cacheKey, 1);
 
-    // Write through key A — should propagate to B due to pending cleanup
+    // Write through key A — should reach B (refetch triggered) due to pending cleanup
     const updated = emp.$clone({ fullName: "Bob" });
     updateObject(store, updated);
 
-    // Key B should have the propagated write
+    // Key B's RDP variant gets a refetch trigger, not a direct write, so its
+    // status flips to "loading" while the cached value remains its prior data.
     const valueB = store.getValue(queryB.cacheKey);
     expect(valueB).toBeDefined();
-    expect(valueB?.value).toEqual(
-      expect.objectContaining({
-        $primaryKey: 1,
-        fullName: "Bob",
-      }),
-    );
+    expect(valueB?.status).toBe("loading");
   });
 
   it("propagateWrite skips variant key that is neither observed nor pending cleanup", () => {
@@ -320,23 +316,25 @@ describe("ObjectsHelper.isKeyActive", () => {
     subB.unsubscribe();
     store.pendingCleanup.set(queryB.cacheKey, 1);
 
-    // Should propagate while pending cleanup is active
+    // Should reach K_B while pending cleanup is active — triggers refetch on
+    // the RDP variant, which flips status to "loading" while preserving value.
     updateObject(store, emp.$clone({ fullName: "Bob" }));
+    expect(store.getValue(queryB.cacheKey)?.status).toBe("loading");
     expect(store.getValue(queryB.cacheKey)?.value).toEqual(
-      expect.objectContaining({ fullName: "Bob" }),
+      expect.objectContaining({ fullName: "Alice" }),
     );
 
     // Simulate cleanup microtask completing
     store.pendingCleanup.delete(queryB.cacheKey);
 
-    // Should NOT propagate after cleanup ran
+    // Should NOT reach K_B after cleanup ran. K_B's value remains untouched.
     updateObject(store, emp.$clone({ fullName: "Charlie" }));
     expect(store.getValue(queryB.cacheKey)?.value).toEqual(
-      expect.objectContaining({ fullName: "Bob" }),
+      expect.objectContaining({ fullName: "Alice" }),
     );
   });
 
-  it("re-subscribing before microtask flush receives latest data", async () => {
+  it("re-subscribing before microtask flush sees loading status from triggered refetch", async () => {
     const rdpConfig = createFakeRdpConfig("derivedAddress");
 
     // Seed both keys
@@ -355,10 +353,12 @@ describe("ObjectsHelper.isKeyActive", () => {
     sub1.unsubscribe();
     store.pendingCleanup.set(queryB.cacheKey, 1);
 
-    // Write new data while pending cleanup is active
+    // Write new base data while pending cleanup is active. With the RDP-variant
+    // staleness fix, this triggers a refetch on K_B instead of writing through.
     updateObject(store, emp.$clone({ fullName: "Updated" }));
 
-    // Re-subscribe (remount) — should see updated data
+    // Re-subscribe (remount) — should see a payload, with status reflecting
+    // the in-flight refetch.
     const subFn = mockSingleSubCallback();
     store.cacheKeys.retain(queryB.cacheKey);
     const sub2 = subjectB.subscribe(
@@ -367,11 +367,7 @@ describe("ObjectsHelper.isKeyActive", () => {
 
     await waitForCall(subFn);
     expect(subFn.next).toHaveBeenCalledWith(
-      expect.objectContaining({
-        value: expect.objectContaining({
-          fullName: "Updated",
-        }),
-      }),
+      expect.objectContaining({ status: "loading" }),
     );
 
     sub2.unsubscribe();
@@ -471,7 +467,7 @@ describe("Two variants with different RDP configs - GC of one should not affect 
     expect(variants.has(queryB.cacheKey)).toBe(false);
   });
 
-  it("propagateWrite still works for A after B is GC'd", () => {
+  it("propagateWrite still reaches A after B is GC'd", () => {
     const rdpConfigA = createFakeRdpConfig("fieldA");
     const rdpConfigAB = createFakeRdpConfig("fieldA", "fieldB");
 
@@ -502,13 +498,12 @@ describe("Two variants with different RDP configs - GC of one should not affect 
       1,
     )).toBe(1);
 
-    // Update via base variant — should still propagate to A
+    // Update via base variant — propagation should reach A (RDP variant) and
+    // trigger a refetch since the base field changed.
     updateObject(store, emp.$clone({ fullName: "Bob" }));
 
     const valueA = store.getValue(queryA.cacheKey);
-    expect(valueA?.value).toEqual(
-      expect.objectContaining({ $primaryKey: 1, fullName: "Bob" }),
-    );
+    expect(valueA?.status).toBe("loading");
 
     store.cacheKeys.release(queryA.cacheKey);
   });
@@ -595,16 +590,11 @@ describe("ObjectsHelper variant cache keys", () => {
     expect(q1.cacheKey).not.toBe(q2.cacheKey);
   });
 
-  it("STALENESS REPRO: RDP-less variant write preserves variant A's old derived value even after non-RDP state changes", () => {
-    // Reproduces the suspected staleness bug:
-    //   - Component 1: fetches an object WITH a derived property (variant A)
-    //   - Component 2: fetches the same object WITHOUT derived properties (variant B)
-    //   - Server state changes between the two fetches
-    //   - B's fresh write propagates to A; A's derived field is preserved
-    //     from A's prior cache value, which was computed against the OLD non-RDP state.
-    //   - Result: A's view ends up with FRESH non-RDP fields + STALE derived value.
-    //
-    // We treat "office" as the derived field to stand in for a `withProperties` RDP.
+  it("triggers refetch on rdp variant when sibling write changes base fields", () => {
+    // "office" stands in for a withProperties RDP. A holds the derived value
+    // computed against fullName="Alice". When B writes fullName="Bob" without
+    // a derived value, propagation must refetch A rather than stitch B's fresh
+    // fullName onto A's stale derived value.
     const rdpConfig = createFakeRdpConfig("office");
 
     const queryA = store.objects.getQuery(
@@ -613,13 +603,51 @@ describe("ObjectsHelper variant cache keys", () => {
     );
     const queryB = store.objects.getQuery({ apiName: Employee, pk: 1 });
 
-    // Both variants observed so propagation runs.
     store.cacheKeys.retain(queryA.cacheKey);
     store.cacheKeys.retain(queryB.cacheKey);
     store.subjects.get(queryA.cacheKey).subscribe(() => {});
     store.subjects.get(queryB.cacheKey).subscribe(() => {});
 
-    // Variant A's initial fetch: derived "office" was computed against fullName "Alice".
+    const aPayload = emp.$clone({
+      fullName: "Alice",
+      office: "derived-from-Alice",
+    });
+    store.batch({}, (batch) => {
+      queryA.writeToStore(aPayload as any, "loaded", batch);
+    });
+    expect(store.getValue(queryA.cacheKey)?.status).toBe("loaded");
+
+    const bPayload = emp.$clone({ fullName: "Bob" });
+    store.batch({}, (batch) => {
+      queryB.writeToStore(bPayload as any, "loaded", batch);
+    });
+
+    expect(store.getValue(queryA.cacheKey)?.status).toBe("loading");
+    expect(store.getValue(queryA.cacheKey)?.value).toEqual(
+      expect.objectContaining({
+        fullName: "Alice",
+        office: "derived-from-Alice",
+      }),
+    );
+
+    store.cacheKeys.release(queryA.cacheKey);
+    store.cacheKeys.release(queryB.cacheKey);
+  });
+
+  it("does not refetch rdp variant when sibling write carries identical base fields", () => {
+    const rdpConfig = createFakeRdpConfig("office");
+
+    const queryA = store.objects.getQuery(
+      { apiName: Employee, pk: 1 },
+      rdpConfig,
+    );
+    const queryB = store.objects.getQuery({ apiName: Employee, pk: 1 });
+
+    store.cacheKeys.retain(queryA.cacheKey);
+    store.cacheKeys.retain(queryB.cacheKey);
+    store.subjects.get(queryA.cacheKey).subscribe(() => {});
+    store.subjects.get(queryB.cacheKey).subscribe(() => {});
+
     const aPayload = emp.$clone({
       fullName: "Alice",
       office: "derived-from-Alice",
@@ -628,6 +656,12 @@ describe("ObjectsHelper variant cache keys", () => {
       queryA.writeToStore(aPayload as any, "loaded", batch);
     });
 
+    const bPayload = emp.$clone({ fullName: "Alice" });
+    store.batch({}, (batch) => {
+      queryB.writeToStore(bPayload as any, "loaded", batch);
+    });
+
+    expect(store.getValue(queryA.cacheKey)?.status).toBe("loaded");
     expect(store.getValue(queryA.cacheKey)?.value).toEqual(
       expect.objectContaining({
         fullName: "Alice",
@@ -635,23 +669,44 @@ describe("ObjectsHelper variant cache keys", () => {
       }),
     );
 
-    // Server state changes: fullName goes Alice -> Bob.
-    // Variant B fetches fresh non-RDP data. Critically, B doesn't fetch any
-    // derived field, so the payload has no fresh "office" value.
-    const bPayload = emp.$clone({ fullName: "Bob" });
+    store.cacheKeys.release(queryA.cacheKey);
+    store.cacheKeys.release(queryB.cacheKey);
+  });
+
+  it("does not refetch a no-rdp target when sibling variant has rdps", () => {
+    const rdpConfig = createFakeRdpConfig("office");
+
+    const queryA = store.objects.getQuery({ apiName: Employee, pk: 1 });
+    const queryB = store.objects.getQuery(
+      { apiName: Employee, pk: 1 },
+      rdpConfig,
+    );
+
+    store.cacheKeys.retain(queryA.cacheKey);
+    store.cacheKeys.retain(queryB.cacheKey);
+    store.subjects.get(queryA.cacheKey).subscribe(() => {});
+    store.subjects.get(queryB.cacheKey).subscribe(() => {});
+
+    store.batch({}, (batch) => {
+      queryA.writeToStore(
+        emp.$clone({ fullName: "Alice" }) as any,
+        "loaded",
+        batch,
+      );
+    });
+
+    const bPayload = emp.$clone({
+      fullName: "Bob",
+      office: "derived-from-Bob",
+    });
     store.batch({}, (batch) => {
       queryB.writeToStore(bPayload as any, "loaded", batch);
     });
 
-    const valueA = store.getValue(queryA.cacheKey);
-
-    // Non-RDP fields refresh from B (this is the propagation working as intended).
-    expect(valueA?.value).toEqual(expect.objectContaining({ fullName: "Bob" }));
-
-    // The bug: derived field carries A's pre-update value, now inconsistent
-    // with fullName="Bob". A real fix would either drop it (forcing refetch)
-    // or refresh it. Today the cache silently surfaces this inconsistency.
-    expect((valueA?.value as any)?.office).toBe("derived-from-Alice");
+    expect(store.getValue(queryA.cacheKey)?.status).toBe("loaded");
+    expect(store.getValue(queryA.cacheKey)?.value).toEqual(
+      expect.objectContaining({ fullName: "Bob" }),
+    );
 
     store.cacheKeys.release(queryA.cacheKey);
     store.cacheKeys.release(queryB.cacheKey);

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -29,6 +29,7 @@ import type { QuerySubscription } from "../QuerySubscription.js";
 import type { Rdp } from "../RdpCanonicalizer.js";
 import { tombstone } from "../tombstone.js";
 import {
+  baseFieldsChanged,
   mergeObjectFields,
   mergeSelectFields,
 } from "../utils/rdpFieldOperations.js";
@@ -230,6 +231,35 @@ export class ObjectsHelper extends AbstractHelper<
         targetCurrentValue && this.isObjectHolder(targetCurrentValue)
           ? targetCurrentValue
           : undefined;
+
+      // If the target variant holds RDP fields, those values were computed
+      // against the base fields the target last fetched. Stitching fresh
+      // base values from the source onto preserved RDP values produces an
+      // internally inconsistent entry. Refetch the target instead.
+      const targetRdpFields = this.store.objectCacheKeyRegistry.getRdpFieldSet(
+        targetKey,
+      );
+      if (targetRdpFields.size > 0 && targetHolder) {
+        const sourceRdpFields = this.store.objectCacheKeyRegistry
+          .getRdpFieldSet(sourceCacheKey);
+        if (
+          baseFieldsChanged(
+            value,
+            targetHolder,
+            sourceRdpFields,
+            targetRdpFields,
+          )
+        ) {
+          const targetQuery = this.store.queries.peek(targetKey);
+          if (targetQuery instanceof ObjectQuery) {
+            targetQuery.revalidate(true).catch(() => {
+              // The query surfaces refetch errors via its own status; this
+              // catch only prevents an unhandled rejection at the call site.
+            });
+          }
+          continue;
+        }
+      }
 
       // Preserve target-only fields when a partial-select fetch propagates
       // to a sibling variant, so different-select variants converge to the

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
@@ -34,6 +34,30 @@ export function extractRdpFieldNames(
   return new Set(Object.keys(rdpConfig));
 }
 
+export function baseFieldsChanged(
+  source: ObjectHolder,
+  target: ObjectHolder,
+  sourceRdpFields: ReadonlySet<string>,
+  targetRdpFields: ReadonlySet<string>,
+): boolean {
+  const sourceUnderlying = source[UnderlyingOsdkObject] as SimpleOsdkProperties;
+  const targetUnderlying = target[UnderlyingOsdkObject] as SimpleOsdkProperties;
+  const objectDef = source[ObjectDefRef];
+
+  for (const key of Object.keys(sourceUnderlying)) {
+    if (!(key in objectDef.properties)) {
+      continue;
+    }
+    if (sourceRdpFields.has(key) || targetRdpFields.has(key)) {
+      continue;
+    }
+    if (sourceUnderlying[key] !== targetUnderlying[key]) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function stripRdpFields(
   value: ObjectHolder,
   rdpFields: ReadonlySet<string>,


### PR DESCRIPTION
when two queries hold the same object and one fetches with withProperties while the other fetches without, the no-rdp variant's fresh base fields were getting stitched onto the rdp variant's old derived value, leaving the derived field inconsistent with the inputs sitting next to it

• detect base-field change during cross-variant propagation and refetch the rdp variant instead of merging stale derived values forward
• add baseFieldsChanged helper in rdpFieldOperations that ignores rdp fields on both sides
• cross-variant only in v1; self-write merge path unchanged