### PR TITLE
[maker-experimental] fix interface bugs

### DIFF
--- a/.changeset/dry-poems-slide.md
+++ b/.changeset/dry-poems-slide.md
@@ -1,0 +1,6 @@
+---
+"@osdk/generator-converters.ontologyir": patch
+"@osdk/maker-experimental": patch
+---
+
+fix interface bugs

--- a/packages/generator-converters.ontologyir/src/OntologyBlockDataToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyBlockDataToFullMetadataConverter.ts
@@ -41,6 +41,7 @@ export class OntologyBlockDataToFullMetadataConverter {
     const interfaceTypeLookup = buildBlockDataInterfaceTypeLookup(blockData);
     const interfaceTypes = this.getOsdkInterfaceTypesFromBlockData(
       blockData.interfaceTypes,
+      interfaceTypeLookup,
     );
     const sharedPropertyTypes = this.getOsdkSharedPropertyTypesFromBlockData(
       blockData.sharedPropertyTypes,
@@ -678,6 +679,7 @@ export class OntologyBlockDataToFullMetadataConverter {
 
   static getOsdkInterfaceTypesFromBlockData(
     interfaceBlockData: Record<string, InterfaceTypeBlockDataV2>,
+    interfaceTypeLookup: BlockDataApiNameLookup | undefined,
   ): Record<ApiName, Ontologies.InterfaceType> {
     const result: Record<ApiName, Ontologies.InterfaceType> = {};
 
@@ -696,7 +698,7 @@ export class OntologyBlockDataToFullMetadataConverter {
         const dataType = this.getOsdkPropertyTypeFromBlockData(spt.type);
         if (dataType) {
           properties[propKey] = {
-            rid,
+            rid: spt.rid,
             apiName: spt.apiName,
             displayName: spt.displayMetadata.displayName,
             description: spt.displayMetadata.description ?? undefined,
@@ -719,9 +721,13 @@ export class OntologyBlockDataToFullMetadataConverter {
         implementedByObjectTypes: [], // Empty for now
         displayName: interfaceType.displayMetadata.displayName,
         description: interfaceType.displayMetadata.description ?? undefined,
-        links: this.getOsdkInterfaceLinkTypesFromBlockData(interfaceType.links),
+        links: this.getOsdkInterfaceLinkTypesFromBlockData(
+          interfaceType.links,
+          interfaceTypeLookup,
+        ),
         allLinks: this.getOsdkInterfaceLinkTypesFromBlockData(
           interfaceType.links,
+          interfaceTypeLookup,
         ), // Same as links for now
       };
 
@@ -733,6 +739,7 @@ export class OntologyBlockDataToFullMetadataConverter {
 
   static getOsdkInterfaceLinkTypesFromBlockData(
     ilts: MarketplaceInterfaceLinkType[],
+    interfaceTypeLookup: BlockDataApiNameLookup | undefined,
   ): Record<ApiName, Ontologies.InterfaceLinkType> {
     const result: Record<ApiName, Ontologies.InterfaceLinkType> = {};
 
@@ -746,7 +753,10 @@ export class OntologyBlockDataToFullMetadataConverter {
           const interfaceType = ilt.linkedEntityTypeId.interfaceType;
           linkedEntityApiName = {
             type: "interfaceTypeApiName" as const,
-            apiName: interfaceType,
+            apiName: resolveBlockDataApiName(
+              interfaceType,
+              interfaceTypeLookup,
+            ),
           };
           break;
         }

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertInterfacePropertyType.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertInterfacePropertyType.ts
@@ -29,20 +29,23 @@ export function convertInterfaceProperty(
   ridGenerator: OntologyRidGenerator,
 ): [string, MarketplaceInterfacePropertyType] {
   if (isInterfaceSharedPropertyType(prop)) {
-    return [prop.sharedPropertyType.apiName, {
-      type: "sharedPropertyBasedPropertyType",
-      sharedPropertyBasedPropertyType: {
-        requireImplementation: prop.required,
-        sharedPropertyType: convertSpt(prop.sharedPropertyType, ridGenerator),
+    return [
+      ridGenerator.generateInterfacePropertyTypeRid(apiName, interfaceApiName),
+      {
+        type: "sharedPropertyBasedPropertyType",
+        sharedPropertyBasedPropertyType: {
+          requireImplementation: prop.required,
+          sharedPropertyType: convertSpt(prop.sharedPropertyType, ridGenerator),
+        },
       },
-    }];
+    ];
   } else {
     return [
       ridGenerator.generateInterfacePropertyTypeRid(apiName, interfaceApiName),
       {
         type: "interfaceDefinedPropertyType",
         interfaceDefinedPropertyType: {
-          apiName: apiName,
+          apiName,
           displayMetadata: {
             displayName: prop.displayName ?? apiName,
             visibility: prop.visibility ?? "NORMAL",

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertSpt.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertSpt.ts
@@ -62,14 +62,14 @@ export function convertSpt(
             apiName,
             true,
           ),
-          reducers: [{ direction: "DESCENDING_NULLS_LAST", field: null }],
+          reducers: [],
         },
       }
       : propertyTypeTypeToOntologyIrType(type, ridGenerator, apiName, true),
     aliases: aliases ?? [],
     baseFormatter,
     dataConstraints: dataConstraint,
-    gothamMapping: gothamMapping,
+    gothamMapping,
     indexedForSearch: true,
     typeClasses: typeClasses ?? [],
     valueType: valueType === undefined


### PR DESCRIPTION
- osdk generator converter didn't convert interface rids to api names and used wrong rid for interface spts
- Interface spt props didn't used apiName instead of rid as block data key
- Array spts had hardcoded reducers