### PR TITLE
Add rich dropdown labels

### DIFF
--- a/.changeset/rich-dropdown-labels.md
+++ b/.changeset/rich-dropdown-labels.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Add rich item label rendering to ActionForm dropdown fields.

--- a/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
@@ -62,6 +62,14 @@ const DEPARTMENT_ITEMS = [
 
 const TAG_ITEMS = ["Urgent", "Review", "Follow-up", "Archived", "Pinned"];
 
+const USER_ID_ITEMS = ["usr_ada", "usr_grace", "usr_katherine"];
+
+const USER_DIRECTORY: Record<string, { name: string; team: string }> = {
+  usr_ada: { name: "Ada Lovelace", team: "Computation" },
+  usr_grace: { name: "Grace Hopper", team: "Compilers" },
+  usr_katherine: { name: "Katherine Johnson", team: "Flight dynamics" },
+};
+
 const formContent: ReadonlyArray<FormContentItem> = [
   field({
     fieldKey: "name",
@@ -961,6 +969,78 @@ export const WithMultiSelectDropdown: Story = {
 ];
 
 // Side-by-side comparison: plain multi-Select vs searchable multi-Combobox.
+<BaseForm
+  formContent={formContent}
+  onSubmit={(formState) => console.log("Submitted:", formState)}
+/>`,
+      },
+    },
+  },
+};
+
+const richDropdownLabelFormContent: ReadonlyArray<FormContentItem> = [
+  field({
+    fieldKey: "assigneeUserId",
+    fieldComponent: "DROPDOWN",
+    label: "Assignee",
+    fieldComponentProps: {
+      items: USER_ID_ITEMS,
+      itemToStringLabel: getUserIdLabel,
+      renderItemLabel: renderUserIdLabel,
+      isSearchable: true,
+      placeholder: "Search users...",
+    },
+  }),
+  field({
+    fieldKey: "reviewerUserIds",
+    fieldComponent: "DROPDOWN",
+    label: "Reviewers",
+    fieldComponentProps: {
+      items: USER_ID_ITEMS,
+      itemToStringLabel: getUserIdLabel,
+      renderItemLabel: renderUserIdLabel,
+      isMultiple: true,
+      isSearchable: true,
+      placeholder: "Search reviewers...",
+    },
+  }),
+];
+
+export const WithRichDropdownLabels: Story = {
+  args: {
+    formContent: richDropdownLabelFormContent,
+    onSubmit: handleSubmit,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `const userIds = ["usr_ada", "usr_grace", "usr_katherine"];
+
+const usersById = {
+  usr_ada: { name: "Ada Lovelace", team: "Computation" },
+  usr_grace: { name: "Grace Hopper", team: "Compilers" },
+  usr_katherine: { name: "Katherine Johnson", team: "Flight dynamics" },
+};
+
+const formContent = [
+  {
+    fieldKey: "assigneeUserId",
+    fieldComponent: "DROPDOWN",
+    label: "Assignee",
+    fieldComponentProps: {
+      items: userIds,
+      itemToStringLabel: (userId) => usersById[userId]?.name ?? userId,
+      renderItemLabel: (userId) => (
+        <span>
+          <strong>{usersById[userId]?.name ?? userId}</strong>
+          <span>{usersById[userId]?.team}</span>
+        </span>
+      ),
+      isSearchable: true,
+    },
+  },
+];
+
 <BaseForm
   formContent={formContent}
   onSubmit={(formState) => console.log("Submitted:", formState)}
@@ -1878,3 +1958,24 @@ export const WithGridSection: Story = {
     onSubmit: handleSubmit,
   },
 };
+function getUserIdLabel(item: unknown): string {
+  if (typeof item !== "string") {
+    return String(item);
+  }
+
+  return USER_DIRECTORY[item]?.name ?? item;
+}
+
+function renderUserIdLabel(item: unknown): React.ReactNode {
+  const userId = String(item);
+  const user = USER_DIRECTORY[userId];
+
+  return (
+    <span className="osdkRichDropdownLabel">
+      <strong>{user?.name ?? userId}</strong>
+      {user?.team != null
+        ? <span className="osdkRichDropdownDescription">{user.team}</span>
+        : null}
+    </span>
+  );
+}

--- a/packages/react-components-storybook/src/styles/storybook.css
+++ b/packages/react-components-storybook/src/styles/storybook.css
@@ -123,3 +123,15 @@ body {
   font-size: var(--osdk-typography-size-body-small);
   max-height: 300px;
 }
+
+.osdkRichDropdownLabel {
+  display: inline-flex;
+  flex-direction: column;
+  gap: calc(var(--osdk-surface-spacing) * 0.5);
+  min-width: 0;
+}
+
+.osdkRichDropdownDescription {
+  color: var(--osdk-typography-color-muted);
+  font-size: var(--osdk-typography-size-body-small);
+}

--- a/packages/react-components/docs/ActionForm.md
+++ b/packages/react-components/docs/ActionForm.md
@@ -95,6 +95,30 @@ const fields = [
 <ActionForm actionDefinition={updateEmployee} formFieldDefinitions={fields} />;
 ```
 
+### Rich dropdown labels
+
+Use `itemToStringLabel` for the dropdown's text behavior: search matching, accessibility labels, fallback item keys, and default visual text. Add `renderItemLabel` when the visible label needs richer React content while preserving the same string behavior.
+
+```tsx
+const fields = [
+  {
+    fieldKey: "assigneeUserId",
+    label: "Assignee",
+    fieldComponent: "DROPDOWN",
+    fieldComponentProps: {
+      items: userIds,
+      itemToStringLabel: (userId) => userNames[userId] ?? userId,
+      renderItemLabel: (userId) => (
+        <span>
+          <strong>{userNames[userId] ?? userId}</strong>
+          <span>{userTeams[userId]}</span>
+        </span>
+      ),
+    },
+  },
+] satisfies Array<FormFieldDefinition<typeof updateEmployee>>;
+```
+
 ### Scoped object select fields
 
 `OBJECT_SELECT` can load options from either an object type or a pre-scoped object set. Pass `objectType` for an unfiltered selector, or pass `objectSet` to limit selectable options. The two are mutually exclusive. Search text is applied within the object set, and the current value is not automatically cleared when it is outside that set.

--- a/packages/react-components/src/action-form/FormFieldApi.ts
+++ b/packages/react-components/src/action-form/FormFieldApi.ts
@@ -169,9 +169,16 @@ export interface DropdownFieldProps<V, Multiple extends boolean = false>
   items: V[];
 
   /**
-   * Converts an item to a display string. Defaults to `String()`.
+   * Converts an item to searchable text and the default visual label. Defaults to `String()`.
+   * Use `renderItemLabel` when the visible label needs rich React content.
    */
   itemToStringLabel?: (item: V) => string;
+
+  /**
+   * Renders an item label with custom React content.
+   * `itemToStringLabel` is still used for search, accessibility, and fallback keys.
+   */
+  renderItemLabel?: (item: V) => React.ReactNode;
 
   /**
    * Returns a unique string key for a list item. Used as the React `key`.

--- a/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
@@ -14,11 +14,15 @@
  * limitations under the License.
  */
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DropdownField } from "../fields/DropdownField.js";
-
-const STRING_ITEMS = ["Alice", "Bob", "Charlie"];
 
 describe("DropdownField", () => {
   afterEach(cleanup);
@@ -60,25 +64,70 @@ describe("DropdownField", () => {
     });
 
     it("uses itemToStringLabel for display", () => {
-      interface User {
-        id: number;
-        name: string;
-      }
-      const users: User[] = [
-        { id: 1, name: "Alice" },
-        { id: 2, name: "Bob" },
-      ];
-
       render(
-        <DropdownField<User>
-          value={users[0]}
-          items={users}
-          itemToStringLabel={(u) => u.name}
-          isItemEqual={(a, b) => a.id === b.id}
+        <DropdownField<TestUser>
+          value={USER_ITEMS[0]}
+          items={USER_ITEMS}
+          itemToStringLabel={testUserNameLabel}
+          isItemEqual={isSameTestUser}
         />,
       );
 
       expect(screen.getByRole("combobox").textContent).toContain("Alice");
+    });
+
+    it("renders ReactNode labels in the trigger and options", async () => {
+      render(
+        <DropdownField<TestUser>
+          value={USER_ITEMS[0]}
+          items={USER_ITEMS}
+          itemToStringLabel={testUserToStringLabel}
+          renderItemLabel={renderTestUserLabel}
+          itemToKey={testUserToKey}
+          isItemEqual={isSameTestUser}
+        />,
+      );
+
+      const trigger = screen.getByRole("combobox");
+      expect(within(trigger).getByText("Alice")).toBeDefined();
+      expect(within(trigger).getByTestId("role-1").textContent).toBe("Admin");
+
+      fireEvent.click(trigger);
+
+      await vi.waitFor(() => {
+        const option = screen.getByRole("option", { name: "Bob User" });
+        expect(within(option).getByText("Bob")).toBeDefined();
+        expect(within(option).getByTestId("role-2").textContent).toBe("User");
+      });
+    });
+
+    it("renders ReactNode labels for array-valued items", async () => {
+      render(
+        <DropdownField<ArrayItem>
+          value={ARRAY_ITEMS[0]}
+          items={ARRAY_ITEMS}
+          itemToStringLabel={arrayItemToStringLabel}
+          renderItemLabel={renderArrayItemLabel}
+          itemToKey={arrayItemToKey}
+          isItemEqual={isSameArrayItem}
+        />,
+      );
+
+      const trigger = screen.getByRole("combobox");
+      expect(within(trigger).getByText("Alice")).toBeDefined();
+      expect(within(trigger).getByTestId("array-role-Alice").textContent).toBe(
+        "Admin",
+      );
+
+      fireEvent.click(trigger);
+
+      await vi.waitFor(() => {
+        const option = screen.getByRole("option", { name: "Bob User" });
+        expect(within(option).getByText("Bob")).toBeDefined();
+        expect(within(option).getByTestId("array-role-Bob").textContent).toBe(
+          "User",
+        );
+      });
     });
 
     it("renders the popup portal inside the provided container", async () => {
@@ -184,6 +233,90 @@ describe("DropdownField", () => {
 
       const trigger = screen.getByRole("combobox");
       expect(trigger.textContent).toContain("Alice");
+    });
+
+    it("renders ReactNode labels and filters searchable items by their text", async () => {
+      render(
+        <DropdownField<TestUser>
+          value={USER_ITEMS[0]}
+          items={USER_ITEMS}
+          itemToStringLabel={testUserToStringLabel}
+          renderItemLabel={renderTestUserLabel}
+          itemToKey={testUserToKey}
+          isItemEqual={isSameTestUser}
+          isSearchable={true}
+        />,
+      );
+
+      const trigger = screen.getByRole("combobox");
+      expect(within(trigger).getByText("Alice")).toBeDefined();
+      expect(within(trigger).getByTestId("role-1").textContent).toBe(
+        "Admin",
+      );
+
+      fireEvent.click(trigger);
+
+      await vi.waitFor(() => {
+        expect(screen.getByPlaceholderText("Search…")).toBeDefined();
+      });
+
+      fireEvent.change(screen.getByPlaceholderText("Search…"), {
+        target: { value: "Bob" },
+      });
+
+      await vi.waitFor(() => {
+        const option = screen.getByRole("option", { name: "Bob User" });
+        expect(within(option).getByText("Bob")).toBeDefined();
+        expect(
+          within(option).getByTestId("role-2").textContent,
+        ).toBe("User");
+        expect(screen.queryByRole("option", { name: "Alice Admin" }))
+          .toBeNull();
+      });
+    });
+
+    it("renders ReactNode labels for searchable array-valued items", () => {
+      render(
+        <DropdownField<ArrayItem>
+          value={ARRAY_ITEMS[0]}
+          items={ARRAY_ITEMS}
+          itemToStringLabel={arrayItemToStringLabel}
+          renderItemLabel={renderArrayItemLabel}
+          itemToKey={arrayItemToKey}
+          isItemEqual={isSameArrayItem}
+          isSearchable={true}
+        />,
+      );
+
+      const trigger = screen.getByRole("combobox");
+      expect(within(trigger).getByText("Alice")).toBeDefined();
+      expect(within(trigger).getByTestId("array-role-Alice").textContent).toBe(
+        "Admin",
+      );
+    });
+
+    it("renders ReactNode labels in multi-select chips and uses text labels for remove buttons", () => {
+      render(
+        <DropdownField<TestUser, true>
+          value={[USER_ITEMS[0]]}
+          items={USER_ITEMS}
+          itemToStringLabel={testUserToStringLabel}
+          renderItemLabel={renderTestUserLabel}
+          itemToKey={testUserToKey}
+          isItemEqual={isSameTestUser}
+          isSearchable={true}
+          isMultiple={true}
+        />,
+      );
+
+      const trigger = screen.getByRole("combobox");
+      expect(within(trigger).getByText("Alice")).toBeDefined();
+      expect(within(trigger).getByTestId("role-1").textContent).toBe(
+        "Admin",
+      );
+      expect(
+        screen.getByRole("button", { name: "Remove Alice Admin" }),
+      ).toBeDefined();
     });
 
     it("shows placeholder when no value is selected", () => {
@@ -595,3 +728,69 @@ describe("DropdownField", () => {
     });
   });
 });
+
+const STRING_ITEMS = ["Alice", "Bob", "Charlie"];
+
+interface TestUser {
+  id: number;
+  name: string;
+  role: string;
+}
+
+const USER_ITEMS: TestUser[] = [
+  { id: 1, name: "Alice", role: "Admin" },
+  { id: 2, name: "Bob", role: "User" },
+];
+
+function testUserNameLabel(user: TestUser): string {
+  return user.name;
+}
+
+function testUserToStringLabel(user: TestUser): string {
+  return `${user.name} ${user.role}`;
+}
+
+function renderTestUserLabel(user: TestUser) {
+  return (
+    <span>
+      <strong>{user.name}</strong>
+      <span data-testid={`role-${user.id}`}>{user.role}</span>
+    </span>
+  );
+}
+
+function testUserToKey(user: TestUser): string {
+  return String(user.id);
+}
+
+function isSameTestUser(a: TestUser, b: TestUser): boolean {
+  return a.id === b.id;
+}
+
+type ArrayItem = readonly [name: string, role: string];
+
+const ARRAY_ITEMS: ArrayItem[] = [
+  ["Alice", "Admin"],
+  ["Bob", "User"],
+];
+
+function arrayItemToStringLabel(item: ArrayItem): string {
+  return `${item[0]} ${item[1]}`;
+}
+
+function renderArrayItemLabel(item: ArrayItem) {
+  return (
+    <span>
+      <strong>{item[0]}</strong>
+      <span data-testid={`array-role-${item[0]}`}>{item[1]}</span>
+    </span>
+  );
+}
+
+function arrayItemToKey(item: ArrayItem): string {
+  return item[0];
+}
+
+function isSameArrayItem(a: ArrayItem, b: ArrayItem): boolean {
+  return a[0] === b[0] && a[1] === b[1];
+}

--- a/packages/react-components/src/action-form/fields/DropdownField.tsx
+++ b/packages/react-components/src/action-form/fields/DropdownField.tsx
@@ -37,6 +37,7 @@ interface InnerSelectProps<V, Multiple extends boolean>
   extends Omit<DropdownFieldProps<V, Multiple>, "isSearchable">
 {
   itemToStringLabel: (item: V) => string;
+  renderItemLabel: (item: V) => React.ReactNode;
   getKey: (item: V) => string;
   portalRef?: React.Ref<HTMLDivElement>;
   query?: string;
@@ -63,6 +64,7 @@ export const DropdownField: <V, Multiple extends boolean = false>(
   isSearchable = false,
   isMultiple,
   itemToStringLabel,
+  renderItemLabel,
   itemToKey,
   value,
   query,
@@ -84,6 +86,8 @@ export const DropdownField: <V, Multiple extends boolean = false>(
   const resolvedItemToStringLabel = itemToStringLabel
     ?? defaultItemToStringLabel;
 
+  const resolvedRenderItemLabel = renderItemLabel ?? resolvedItemToStringLabel;
+
   const getKey = useCallback(
     (item: V) => itemToKey?.(item) ?? resolvedItemToStringLabel(item),
     [itemToKey, resolvedItemToStringLabel],
@@ -97,6 +101,7 @@ export const DropdownField: <V, Multiple extends boolean = false>(
         isMultiple={isMultiple}
         value={normalizedValue}
         itemToStringLabel={resolvedItemToStringLabel}
+        renderItemLabel={resolvedRenderItemLabel}
         getKey={getKey}
         isSearchable={isSearchable}
         query={query}
@@ -115,6 +120,7 @@ export const DropdownField: <V, Multiple extends boolean = false>(
       {...rest}
       value={normalizedValue}
       itemToStringLabel={resolvedItemToStringLabel}
+      renderItemLabel={resolvedRenderItemLabel}
       getKey={getKey}
       modal={modal}
     />
@@ -130,6 +136,7 @@ const SelectDropdown = typedReactMemo(function SelectDropdownFn<
   onChange,
   items,
   itemToStringLabel,
+  renderItemLabel,
   getKey,
   isItemEqual,
   placeholder,
@@ -141,6 +148,12 @@ const SelectDropdown = typedReactMemo(function SelectDropdownFn<
   const [open, setOpen] = useState(false);
 
   const hasValue = value != null;
+
+  const renderSingleSelectedItemLabel = useCallback(
+    (selectedValue: V | null) =>
+      selectedValue == null ? null : renderItemLabel(selectedValue),
+    [renderItemLabel],
+  );
 
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {
@@ -177,7 +190,7 @@ const SelectDropdown = typedReactMemo(function SelectDropdownFn<
       >
         <Select.Trigger id={id} placeholder={placeholder}>
           <div className={selectStyles.osdkSelectValueContainer}>
-            <Select.Value />
+            <Select.Value>{renderSingleSelectedItemLabel}</Select.Value>
             {placeholder != null && (
               <span className={selectStyles.osdkSelectPlaceholder}>
                 {placeholder}
@@ -208,11 +221,19 @@ const SelectDropdown = typedReactMemo(function SelectDropdownFn<
           )}
           <Select.Positioner>
             <Select.Popup>
-              {items.map((item) => (
-                <Select.Item key={getKey(item)} value={item}>
-                  {itemToStringLabel(item)}
-                </Select.Item>
-              ))}
+              {items.map((item) => {
+                const itemLabel = itemToStringLabel(item);
+                return (
+                  <Select.Item
+                    key={getKey(item)}
+                    value={item}
+                    label={itemLabel}
+                    aria-label={itemLabel}
+                  >
+                    {renderItemLabel(item)}
+                  </Select.Item>
+                );
+              })}
             </Select.Popup>
           </Select.Positioner>
         </Select.Portal>
@@ -230,6 +251,7 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
   onChange,
   items,
   itemToStringLabel,
+  renderItemLabel,
   getKey,
   isItemEqual,
   isMultiple,
@@ -250,6 +272,12 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
   const hasValue = isMultiple
     ? Array.isArray(value) && value.length > 0
     : value != null;
+
+  const renderSingleSelectedItemLabel = useCallback(
+    (selectedValue: V | null) =>
+      selectedValue == null ? null : renderItemLabel(selectedValue),
+    [renderItemLabel],
+  );
 
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {
@@ -308,17 +336,20 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
   }, [handleOpenChange]);
 
   const renderItem = useCallback(
-    (item: V) => (
-      <Combobox.Item key={getKey(item)} value={item}>
-        {isMultiple && (
-          <Combobox.ItemIndicator>
-            <Tick />
-          </Combobox.ItemIndicator>
-        )}
-        {itemToStringLabel(item)}
-      </Combobox.Item>
-    ),
-    [getKey, isMultiple, itemToStringLabel],
+    (item: V) => {
+      const itemLabel = itemToStringLabel(item);
+      return (
+        <Combobox.Item key={getKey(item)} value={item} aria-label={itemLabel}>
+          {isMultiple && (
+            <Combobox.ItemIndicator>
+              <Tick />
+            </Combobox.ItemIndicator>
+          )}
+          {renderItemLabel(item)}
+        </Combobox.Item>
+      );
+    },
+    [getKey, isMultiple, itemToStringLabel, renderItemLabel],
   );
 
   return (
@@ -351,7 +382,7 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
                       key={getKey(item)}
                       className={comboboxStyles.osdkComboboxTriggerChip}
                     >
-                      {itemToStringLabel(item)}
+                      {renderItemLabel(item)}
                       <span
                         role="button"
                         aria-label={`Remove ${itemToStringLabel(item)}`}
@@ -367,7 +398,9 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
               )
               : (
                 <>
-                  <Combobox.Value />
+                  <Combobox.Value>
+                    {renderSingleSelectedItemLabel}
+                  </Combobox.Value>
                   {!hasValue && placeholder != null && (
                     <span className={comboboxStyles.osdkComboboxPlaceholder}>
                       {placeholder}


### PR DESCRIPTION
## Summary
- add renderItemLabel to ActionForm dropdown props for rich visual labels
- keep itemToStringLabel string-only for search, accessibility, fallback keys, and default text
- add docs, Storybook example, tests, and changeset

## Verification
- pnpm --dir packages/react-components exec vitest run src/action-form/__tests__/DropdownField.test.tsx
- pnpm turbo typecheck --filter=@osdk/react-components --filter=@osdk/react-components-storybook
- pnpm exec dprint check packages/react-components/src/action-form/FormFieldApi.ts packages/react-components/src/action-form/fields/DropdownField.tsx packages/react-components/src/action-form/__tests__/DropdownField.test.tsx packages/react-components/docs/ActionForm.md packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx packages/react-components-storybook/src/styles/storybook.css .changeset/rich-dropdown-labels.md

<img width="928" height="600" alt="demo_labels" src="https://github.com/user-attachments/assets/abaf44e2-63ae-417f-aef5-c1a4af015c93" />
