### PR TITLE
Add unsupported ActionForm fields

### DIFF
--- a/.changeset/unsupported-action-form-fields.md
+++ b/.changeset/unsupported-action-form-fields.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Show unsupported ActionForm field types and recommend CUSTOM fields.

--- a/packages/react-components-storybook/src/mocks/fauxFoundry.ts
+++ b/packages/react-components-storybook/src/mocks/fauxFoundry.ts
@@ -59,6 +59,56 @@ export const toggleRemoteStoryAction = TypeHelpers
   .addParameter("isRemote", "boolean", false)
   .build();
 
+type ActionParameterMap = Parameters<
+  typeof TypeHelpers.createActionType
+>[0]["parameters"];
+
+const unsupportedFieldsActionParameters = {
+  structPayload: {
+    displayName: "Struct payload",
+    dataType: {
+      type: "struct",
+      fields: [
+        {
+          name: "externalId",
+          fieldType: { type: "string" },
+          required: true,
+        },
+      ],
+    },
+    required: true,
+    typeClasses: [],
+  },
+  geoshape: {
+    displayName: "Geoshape",
+    dataType: { type: "geoshape" },
+    required: false,
+    typeClasses: [],
+  },
+  classification: {
+    displayName: "Classification",
+    dataType: { type: "marking" },
+    required: false,
+    typeClasses: [],
+  },
+  objectKind: {
+    displayName: "Object type",
+    dataType: { type: "objectType" },
+    required: false,
+    typeClasses: [],
+  },
+} satisfies ActionParameterMap;
+
+export const unsupportedFieldsStoryAction = TypeHelpers
+  .actionTypeBuilder(
+    TypeHelpers.createActionType({
+      apiName: "unsupportedFieldsStoryAction",
+      displayName: "Review unsupported fields",
+      parameters: unsupportedFieldsActionParameters,
+    }),
+  )
+  .build();
+
 let isInitialized = false;
 
 export async function setupFauxFoundry(): Promise<void> {
@@ -82,6 +132,10 @@ export async function setupFauxFoundry(): Promise<void> {
   );
   fauxFoundry.getDefaultOntology().registerActionType(
     toggleRemoteStoryAction.actionTypeV2,
+    () => undefined,
+  );
+  fauxFoundry.getDefaultOntology().registerActionType(
+    unsupportedFieldsStoryAction.actionTypeV2,
     () => undefined,
   );
 

--- a/packages/react-components-storybook/src/stories/ActionForm/ActionForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ActionForm/ActionForm.stories.tsx
@@ -316,7 +316,7 @@ export const WithUnsupportedFields: Story = {
     docs: {
       source: {
         code: `<ActionForm
-  actionDefinition={unsupportedFieldsStoryAction}
+  actionDefinition={unsupportedFieldsStoryAction.actionDefinition}
   showFormTitle={true}
 />`,
       },

--- a/packages/react-components-storybook/src/stories/ActionForm/ActionForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ActionForm/ActionForm.stories.tsx
@@ -23,9 +23,14 @@ import { ActionForm } from "@osdk/react-components/experimental";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import React, { useState } from "react";
 import { fn } from "storybook/test";
-import { updateEmployeeStoryAction } from "../../mocks/fauxFoundry.js";
+import {
+  unsupportedFieldsStoryAction,
+  updateEmployeeStoryAction,
+} from "../../mocks/fauxFoundry.js";
 
 const actionDefinition = updateEmployeeStoryAction.actionDefinition;
+const unsupportedFieldsActionDefinition =
+  unsupportedFieldsStoryAction.actionDefinition;
 
 const actionFormDefaultValueFields: ReadonlyArray<
   FormFieldDefinition<typeof actionDefinition>
@@ -292,6 +297,27 @@ export const WithFieldOverrides: Story = {
 <ActionForm
   actionDefinition={updateEmployeeStoryAction}
   formFieldDefinitions={fields}
+/>`,
+      },
+    },
+  },
+};
+
+export const WithUnsupportedFields: Story = {
+  render: () => (
+    <ActionForm
+      actionDefinition={unsupportedFieldsActionDefinition}
+      showFormTitle={true}
+      onSuccess={handleSuccess}
+      onError={errorSpy}
+    />
+  ),
+  parameters: {
+    docs: {
+      source: {
+        code: `<ActionForm
+  actionDefinition={unsupportedFieldsStoryAction}
+  showFormTitle={true}
 />`,
       },
     },

--- a/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
@@ -533,6 +533,59 @@ export const WithSwitch: Story = {
   },
 };
 
+const unsupportedFormContent: ReadonlyArray<FormContentItem> = [
+  field({
+    fieldKey: "structPayload",
+    fieldComponent: "UNSUPPORTED",
+    label: "Struct payload",
+    isRequired: true,
+    fieldComponentProps: {},
+  }),
+  field({
+    fieldKey: "geoshape",
+    fieldComponent: "UNSUPPORTED",
+    label: "Geoshape",
+    fieldComponentProps: {},
+  }),
+];
+
+export const WithUnsupportedFields: Story = {
+  args: {
+    formTitle: "Unsupported field types",
+    formContent: unsupportedFormContent,
+    onSubmit: handleSubmit,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `const formContent = [
+  {
+    fieldKey: "structPayload",
+    fieldComponent: "UNSUPPORTED",
+    label: "Struct payload",
+    isRequired: true,
+    fieldComponentProps: {},
+  },
+  {
+    fieldKey: "geoshape",
+    fieldComponent: "UNSUPPORTED",
+    label: "Geoshape",
+    fieldComponentProps: {},
+  },
+];
+
+// Unsupported fields render a disabled message.
+// Use fieldComponent: "CUSTOM" when you need to collect a value for these types.
+<BaseForm
+  formTitle="Unsupported field types"
+  formContent={formContent}
+  onSubmit={(formState) => console.log("Submitted:", formState)}
+/>`,
+      },
+    },
+  },
+};
+
 const validationFormContent: ReadonlyArray<FormContentItem> = [
   field({
     fieldKey: "name",

--- a/packages/react-components/src/action-form/FormFieldApi.ts
+++ b/packages/react-components/src/action-form/FormFieldApi.ts
@@ -155,6 +155,7 @@ export interface FormFieldPropsByType {
   TEXT_AREA: TextAreaFieldProps;
   TEXT_INPUT: TextInputFieldProps;
   CUSTOM: CustomFieldProps<unknown>;
+  UNSUPPORTED: UnsupportedFieldProps;
 }
 
 /**
@@ -332,6 +333,11 @@ export interface TextInputFieldProps extends
   >
 {
   placeholder?: string;
+
+  /**
+   * Whether this text input is disabled.
+   */
+  disabled?: boolean;
 }
 
 /**
@@ -463,6 +469,10 @@ export interface CustomFieldProps<V> extends BaseFormFieldProps<V> {
   customRenderer: (props: BaseFormFieldProps<V>) => React.ReactNode;
 }
 
+export interface UnsupportedFieldProps
+  extends Pick<BaseFormFieldProps<string>, "id" | "error">
+{}
+
 export interface BaseFormFieldProps<V> {
   /**
    * The HTML `id` attribute for the field input element.
@@ -513,8 +523,6 @@ export type ActionParameters<Q extends ActionDefinition<unknown>> =
 
 /**
  * Extracts the value type for a specific parameter
- *
- * TODO: Re-use `BaseType`
  */
 export type FieldValueType<
   Q extends ActionDefinition<unknown>,
@@ -524,6 +532,9 @@ export type FieldValueType<
   : ActionParameters<Q>[K]["type"] extends ActionMetadata.DataType.ObjectSet<
     infer T
   > ? ActionParam.ObjectSetType<T>
+  : ActionParameters<Q>[K]["type"] extends ActionMetadata.DataType.Interface<
+    infer T
+  > ? ActionParam.InterfaceType<T>
   : ActionParameters<Q>[K]["type"] extends ActionMetadata.DataType.Struct<
     infer T
   > ? ActionParam.StructType<T>
@@ -554,7 +565,8 @@ export type FieldComponent =
   | "SWITCH"
   | "TEXT_AREA"
   | "TEXT_INPUT"
-  | "CUSTOM";
+  | "CUSTOM"
+  | "UNSUPPORTED";
 
 /**
  * Describes the data type of a form field, independent of OSDK.
@@ -629,10 +641,14 @@ export type ValidFormFieldForPropertyType<P extends FieldDescriptorType> =
   | "CUSTOM"
   | (P extends { type: "objectSet" } ? "OBJECT_SET"
     : P extends { type: "object" } ? "OBJECT_SELECT"
+    : P extends { type: "interface" } ? "UNSUPPORTED"
+    : P extends { type: "struct" } ? "UNSUPPORTED"
     : P extends "mediaReference" | "attachment" ? "FILE_PICKER"
     : P extends "boolean" ? "RADIO_BUTTONS" | "DROPDOWN" | "SWITCH"
     : P extends "string" ? "TEXT_INPUT" | "TEXT_AREA"
     : P extends "datetime" | "timestamp" ? "DATETIME_PICKER"
+    : P extends "marking" | "geohash" | "geoshape" | "objectType"
+      ? "UNSUPPORTED"
     : P extends
       | "double"
       | "integer"

--- a/packages/react-components/src/action-form/__tests__/BaseForm.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/BaseForm.test.tsx
@@ -772,4 +772,93 @@ describe("BaseForm", () => {
       });
     });
   });
+
+  describe("unsupported fields", () => {
+    it("renders a disabled text input with the unsupported field message", () => {
+      render(
+        <BaseForm
+          formContent={[
+            field({
+              fieldKey: "unsupported",
+              label: "Unsupported",
+              fieldComponent: "UNSUPPORTED",
+              fieldComponentProps: {},
+            }),
+          ]}
+          onSubmit={vi.fn()}
+        />,
+      );
+
+      const input = screen.getByRole("textbox", { name: "Unsupported" });
+      expect(input).toHaveProperty(
+        "value",
+        "Unsupported field type. Use a CUSTOM field instead",
+      );
+      expect(input).toHaveProperty("disabled", true);
+    });
+
+    it("uses the required validation message for required unsupported fields", async () => {
+      const onSubmit = vi.fn();
+
+      render(
+        <BaseForm
+          formContent={[
+            field({
+              fieldKey: "unsupported",
+              label: "Unsupported",
+              fieldComponent: "UNSUPPORTED",
+              isRequired: true,
+              fieldComponentProps: {},
+            }),
+          ]}
+          onSubmit={onSubmit}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert").textContent).toBe(
+          "This field is required",
+        );
+      });
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("submits controlled form state without displaying it in unsupported fields", async () => {
+      const onSubmit = vi.fn();
+
+      render(
+        <BaseForm
+          formContent={[
+            field({
+              fieldKey: "unsupported",
+              label: "Unsupported",
+              fieldComponent: "UNSUPPORTED",
+              isRequired: true,
+              fieldComponentProps: {},
+            }),
+          ]}
+          formState={{ unsupported: "sensitive value" }}
+          onFieldValueChange={vi.fn()}
+          onSubmit={onSubmit}
+        />,
+      );
+
+      expect(screen.queryByDisplayValue("sensitive value")).toBeNull();
+      expect(screen.getByRole("textbox", { name: /Unsupported/ }))
+        .toHaveProperty(
+          "value",
+          "Unsupported field type. Use a CUSTOM field instead",
+        );
+
+      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith({
+          unsupported: "sensitive value",
+        });
+      });
+    });
+  });
 });

--- a/packages/react-components/src/action-form/__tests__/BaseForm.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/BaseForm.test.tsx
@@ -819,7 +819,7 @@ describe("BaseForm", () => {
 
       await waitFor(() => {
         expect(screen.getByRole("alert").textContent).toBe(
-          "This field is required",
+          "This field is required. Render a CUSTOM field to submit a value.",
         );
       });
       expect(onSubmit).not.toHaveBeenCalled();
@@ -846,11 +846,12 @@ describe("BaseForm", () => {
       );
 
       expect(screen.queryByDisplayValue("sensitive value")).toBeNull();
-      expect(screen.getByRole("textbox", { name: /Unsupported/ }))
-        .toHaveProperty(
-          "value",
-          "Unsupported field type. Use a CUSTOM field instead",
-        );
+      expect(
+        screen.getByRole("textbox", { name: /Unsupported/ }),
+      ).toHaveProperty(
+        "value",
+        "Unsupported field type. Use a CUSTOM field instead",
+      );
 
       fireEvent.click(screen.getByRole("button", { name: /submit/i }));
 

--- a/packages/react-components/src/action-form/__tests__/BaseForm.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/BaseForm.test.tsx
@@ -819,7 +819,7 @@ describe("BaseForm", () => {
 
       await waitFor(() => {
         expect(screen.getByRole("alert").textContent).toBe(
-          "This field is required. Render a CUSTOM field to submit a value.",
+          "This field is required",
         );
       });
       expect(onSubmit).not.toHaveBeenCalled();
@@ -846,12 +846,11 @@ describe("BaseForm", () => {
       );
 
       expect(screen.queryByDisplayValue("sensitive value")).toBeNull();
-      expect(
-        screen.getByRole("textbox", { name: /Unsupported/ }),
-      ).toHaveProperty(
-        "value",
-        "Unsupported field type. Use a CUSTOM field instead",
-      );
+      expect(screen.getByRole("textbox", { name: /Unsupported/ }))
+        .toHaveProperty(
+          "value",
+          "Unsupported field type. Use a CUSTOM field instead",
+        );
 
       fireEvent.click(screen.getByRole("button", { name: /submit/i }));
 

--- a/packages/react-components/src/action-form/__tests__/TextInputField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/TextInputField.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TextInputField } from "../fields/TextInputField.js";
+
+describe("TextInputField", () => {
+  afterEach(cleanup);
+
+  it("does not allow changes when disabled", () => {
+    const onChange = vi.fn();
+
+    render(
+      <TextInputField
+        value="locked"
+        onChange={onChange}
+        disabled={true}
+      />,
+    );
+
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveProperty("disabled", true);
+
+    fireEvent.change(input, { target: { value: "updated" } });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-components/src/action-form/fields/FormFieldRenderer.tsx
+++ b/packages/react-components/src/action-form/fields/FormFieldRenderer.tsx
@@ -38,6 +38,9 @@ import { SwitchField } from "./SwitchField.js";
 import { TextAreaField } from "./TextAreaField.js";
 import { TextInputField } from "./TextInputField.js";
 
+const UNSUPPORTED_FIELD_MESSAGE =
+  "Unsupported field type. Use a CUSTOM field instead";
+
 export interface FormFieldRendererProps {
   fieldDefinition: RendererFieldDefinition;
   value: unknown;
@@ -117,6 +120,16 @@ function renderFieldComponent(
           placeholder={fieldDefinition.placeholder}
           error={error}
           {...fieldDefinition.fieldComponentProps}
+        />
+      );
+    case "UNSUPPORTED":
+      return (
+        <TextInputField
+          {...fieldDefinition.fieldComponentProps}
+          id={fieldDefinition.fieldKey}
+          value={UNSUPPORTED_FIELD_MESSAGE}
+          error={error}
+          disabled={true}
         />
       );
     case "TEXT_AREA":

--- a/packages/react-components/src/action-form/fields/TextInputField.tsx
+++ b/packages/react-components/src/action-form/fields/TextInputField.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Input } from "@base-ui/react/input";
-import React from "react";
+import React, { useCallback } from "react";
 import type { TextInputFieldProps } from "../FormFieldApi.js";
 import styles from "./BaseInput.module.css";
 
@@ -27,17 +27,29 @@ export function TextInputField({
   placeholder,
   minLength,
   maxLength,
+  disabled,
 }: TextInputFieldProps & { id?: string }): React.ReactElement {
+  const handleValueChange = useCallback(
+    (nextValue: string) => {
+      if (disabled === true) {
+        return;
+      }
+      onChange?.(nextValue);
+    },
+    [disabled, onChange],
+  );
+
   return (
     <Input
       id={id}
       className={styles.osdkBaseInput}
       type="text"
       value={value ?? ""}
-      onValueChange={onChange}
+      onValueChange={handleValueChange}
       placeholder={placeholder}
       minLength={minLength}
       maxLength={maxLength}
+      disabled={disabled}
       aria-invalid={error != null || undefined}
     />
   );

--- a/packages/react-components/src/action-form/utils/__tests__/extractValidationRules.test.ts
+++ b/packages/react-components/src/action-form/utils/__tests__/extractValidationRules.test.ts
@@ -211,6 +211,16 @@ describe("extractValidationRules", () => {
       expect(rules.required).toBe("This field is required");
       expect(rules.validate).toBeUndefined();
     });
+
+    it("returns only required for UNSUPPORTED when isRequired", () => {
+      const rules = extractValidationRules(makeFieldDef({
+        fieldComponent: "UNSUPPORTED",
+        isRequired: true,
+        fieldComponentProps: {},
+      }));
+      expect(rules.required).toBe("This field is required");
+      expect(rules.validate).toBeUndefined();
+    });
   });
 
   describe("custom validate", () => {

--- a/packages/react-components/src/action-form/utils/__tests__/extractValidationRules.test.ts
+++ b/packages/react-components/src/action-form/utils/__tests__/extractValidationRules.test.ts
@@ -218,7 +218,9 @@ describe("extractValidationRules", () => {
         isRequired: true,
         fieldComponentProps: {},
       }));
-      expect(rules.required).toBe("This field is required");
+      expect(rules.required).toBe(
+        "This field is required. Render a CUSTOM field to submit a value.",
+      );
       expect(rules.validate).toBeUndefined();
     });
   });

--- a/packages/react-components/src/action-form/utils/__tests__/extractValidationRules.test.ts
+++ b/packages/react-components/src/action-form/utils/__tests__/extractValidationRules.test.ts
@@ -218,9 +218,7 @@ describe("extractValidationRules", () => {
         isRequired: true,
         fieldComponentProps: {},
       }));
-      expect(rules.required).toBe(
-        "This field is required. Render a CUSTOM field to submit a value.",
-      );
+      expect(rules.required).toBe("This field is required");
       expect(rules.validate).toBeUndefined();
     });
   });

--- a/packages/react-components/src/action-form/utils/__tests__/getDefaultFieldDefinitions.test.ts
+++ b/packages/react-components/src/action-form/utils/__tests__/getDefaultFieldDefinitions.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ActionMetadata } from "@osdk/api";
+import { describe, expect, it } from "vitest";
+import { getDefaultFieldDefinitions } from "../getDefaultFieldDefinitions.js";
+
+function makeMetadata(
+  parameter: ActionMetadata.Parameter,
+): ActionMetadata {
+  return {
+    type: "action",
+    apiName: "TestAction",
+    displayName: "Test action",
+    parameters: { tags: parameter },
+    status: "ACTIVE",
+    rid: "ri.action.test",
+  };
+}
+
+describe("getDefaultFieldDefinitions", () => {
+  it.each(
+    [
+      "marking",
+      "geohash",
+      "geoshape",
+      "objectType",
+    ] satisfies ReadonlyArray<ActionMetadata.DataType.BaseActionParameterTypes>,
+  )(
+    "renders unsupported primitive parameter type %s as unsupported",
+    (parameterType) => {
+      const [fieldDefinition] = getDefaultFieldDefinitions(makeMetadata({
+        type: parameterType,
+        nullable: false,
+      }));
+
+      expect(fieldDefinition).toMatchObject({
+        fieldKey: "tags",
+        fieldComponent: "UNSUPPORTED",
+        fieldComponentProps: {},
+      });
+    },
+  );
+
+  it("renders interface parameters as unsupported", () => {
+    const [fieldDefinition] = getDefaultFieldDefinitions(makeMetadata({
+      type: { type: "interface", interface: "Employee" },
+      nullable: false,
+    }));
+
+    expect(fieldDefinition).toMatchObject({
+      fieldKey: "tags",
+      fieldComponent: "UNSUPPORTED",
+      fieldComponentProps: {},
+    });
+  });
+
+  it("renders struct parameters as unsupported", () => {
+    const [fieldDefinition] = getDefaultFieldDefinitions(makeMetadata({
+      type: { type: "struct", struct: { name: "string" } },
+      nullable: false,
+    }));
+
+    expect(fieldDefinition).toMatchObject({
+      fieldKey: "tags",
+      fieldComponent: "UNSUPPORTED",
+      fieldComponentProps: {},
+    });
+  });
+});

--- a/packages/react-components/src/action-form/utils/extractValidationRules.ts
+++ b/packages/react-components/src/action-form/utils/extractValidationRules.ts
@@ -113,7 +113,7 @@ export function extractValidationRules(
       }
       break;
     }
-    // DROPDOWN, RADIO_BUTTONS, CUSTOM, OBJECT_SET: only `required` applies
+    // DROPDOWN, RADIO_BUTTONS, CUSTOM, OBJECT_SET, UNSUPPORTED: only `required` applies
     default:
       break;
   }

--- a/packages/react-components/src/action-form/utils/extractValidationRules.ts
+++ b/packages/react-components/src/action-form/utils/extractValidationRules.ts
@@ -22,9 +22,6 @@ import type {
 
 type RhfRules = RegisterOptions<Record<string, unknown>, string>;
 
-const UNSUPPORTED_REQUIRED_FIELD_MESSAGE =
-  "This field is required. Render a CUSTOM field to submit a value.";
-
 /**
  * Derives react-hook-form validation rules from a field definition's
  * constraint props (min, max, minLength, etc.) and the optional
@@ -39,7 +36,7 @@ export function extractValidationRules(
   const rules: RhfRules = {};
 
   if (fieldDef.isRequired) {
-    rules.required = getRequiredMessage(fieldDef);
+    rules.required = getMessage(fieldDef, { type: "required" });
   }
 
   const validateFns: Record<
@@ -144,17 +141,6 @@ function getMessage(
   error: ValidationError,
 ): string {
   return fieldDef.onValidationError?.(error) ?? getDefaultMessage(error);
-}
-
-function getRequiredMessage(fieldDef: RendererFieldDefinition): string {
-  const customMessage = fieldDef.onValidationError?.({ type: "required" });
-  if (customMessage != null) {
-    return customMessage;
-  }
-  if (fieldDef.fieldComponent === "UNSUPPORTED") {
-    return UNSUPPORTED_REQUIRED_FIELD_MESSAGE;
-  }
-  return getDefaultMessage({ type: "required" });
 }
 
 function getDefaultMessage(error: ValidationError): string {

--- a/packages/react-components/src/action-form/utils/extractValidationRules.ts
+++ b/packages/react-components/src/action-form/utils/extractValidationRules.ts
@@ -22,6 +22,9 @@ import type {
 
 type RhfRules = RegisterOptions<Record<string, unknown>, string>;
 
+const UNSUPPORTED_REQUIRED_FIELD_MESSAGE =
+  "This field is required. Render a CUSTOM field to submit a value.";
+
 /**
  * Derives react-hook-form validation rules from a field definition's
  * constraint props (min, max, minLength, etc.) and the optional
@@ -36,7 +39,7 @@ export function extractValidationRules(
   const rules: RhfRules = {};
 
   if (fieldDef.isRequired) {
-    rules.required = getMessage(fieldDef, { type: "required" });
+    rules.required = getRequiredMessage(fieldDef);
   }
 
   const validateFns: Record<
@@ -141,6 +144,17 @@ function getMessage(
   error: ValidationError,
 ): string {
   return fieldDef.onValidationError?.(error) ?? getDefaultMessage(error);
+}
+
+function getRequiredMessage(fieldDef: RendererFieldDefinition): string {
+  const customMessage = fieldDef.onValidationError?.({ type: "required" });
+  if (customMessage != null) {
+    return customMessage;
+  }
+  if (fieldDef.fieldComponent === "UNSUPPORTED") {
+    return UNSUPPORTED_REQUIRED_FIELD_MESSAGE;
+  }
+  return getDefaultMessage({ type: "required" });
 }
 
 function getDefaultMessage(error: ValidationError): string {

--- a/packages/react-components/src/action-form/utils/getDefaultFieldDefinitions.ts
+++ b/packages/react-components/src/action-form/utils/getDefaultFieldDefinitions.ts
@@ -15,6 +15,7 @@
  */
 
 import type { ActionMetadata } from "@osdk/api";
+import { assertUnreachable } from "../../shared/assertUnreachable.js";
 import type { RendererFieldDefinition } from "../FormFieldApi.js";
 
 /**
@@ -132,10 +133,6 @@ function buildFieldDefinition(
         fieldComponentProps: {},
       };
     default:
-      return {
-        ...base,
-        fieldComponent: "UNSUPPORTED",
-        fieldComponentProps: {},
-      };
+      return assertUnreachable(paramType);
   }
 }

--- a/packages/react-components/src/action-form/utils/getDefaultFieldDefinitions.ts
+++ b/packages/react-components/src/action-form/utils/getDefaultFieldDefinitions.ts
@@ -15,7 +15,6 @@
  */
 
 import type { ActionMetadata } from "@osdk/api";
-import { assertUnreachable } from "../../shared/assertUnreachable.js";
 import type { RendererFieldDefinition } from "../FormFieldApi.js";
 
 /**
@@ -74,15 +73,10 @@ function buildFieldDefinition(
           },
         };
       case "interface":
-        return {
-          ...base,
-          fieldComponent: "TEXT_INPUT",
-          fieldComponentProps: {},
-        };
       case "struct":
         return {
           ...base,
-          fieldComponent: "TEXT_INPUT",
+          fieldComponent: "UNSUPPORTED",
           fieldComponentProps: {},
         };
     }
@@ -90,13 +84,18 @@ function buildFieldDefinition(
 
   switch (paramType) {
     case "string":
+      return {
+        ...base,
+        fieldComponent: "TEXT_INPUT",
+        fieldComponentProps: {},
+      };
     case "marking":
     case "geohash":
     case "geoshape":
     case "objectType":
       return {
         ...base,
-        fieldComponent: "TEXT_INPUT",
+        fieldComponent: "UNSUPPORTED",
         fieldComponentProps: {},
       };
     case "boolean":
@@ -133,6 +132,10 @@ function buildFieldDefinition(
         fieldComponentProps: {},
       };
     default:
-      return assertUnreachable(paramType);
+      return {
+        ...base,
+        fieldComponent: "UNSUPPORTED",
+        fieldComponentProps: {},
+      };
   }
 }

--- a/packages/react-components/src/public/experimental/action-form.ts
+++ b/packages/react-components/src/public/experimental/action-form.ts
@@ -48,5 +48,6 @@ export type {
   RendererFieldDefinition,
   TextAreaFieldProps,
   TextInputFieldProps,
+  UnsupportedFieldProps,
   ValidationError,
 } from "../../action-form/FormFieldApi.js";


### PR DESCRIPTION
## Summary
- Add UNSUPPORTED ActionForm field component for unsupported field descriptor types
- Allow CUSTOM fields for every field descriptor type
- Add ActionForm/BaseForm stories and tests for unsupported fields

## Verification
- pnpm turbo typecheck --filter=@osdk/react-components --filter=@osdk/react-components-storybook
- pnpm --dir=packages/react-components exec vitest run src/action-form/__tests__/TextInputField.test.tsx src/action-form/__tests__/BaseForm.test.tsx src/action-form/utils/__tests__/getDefaultFieldDefinitions.test.ts src/action-form/utils/__tests__/extractValidationRules.test.ts
- pnpm turbo check-api --filter=@osdk/react-components
- pnpm exec dprint check <changed files>
- git diff --check

<img width="523" height="472" alt="Screenshot 2026-05-13 at 15 49 09" src="https://github.com/user-attachments/assets/608f8bcf-34b9-4bbe-a11c-f1304f403e37" />