### PR TITLE
Cap long select dropdowns

### DIFF
--- a/.changeset/fix-action-form-dropdown-height.md
+++ b/.changeset/fix-action-form-dropdown-height.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Cap long ActionForm select dropdowns so they scroll inside dialogs.

--- a/packages/react-components/src/base-components/select/Select.module.css
+++ b/packages/react-components/src/base-components/select/Select.module.css
@@ -224,7 +224,10 @@
   display: flex;
   flex-direction: column;
   min-width: var(--anchor-width);
-  max-height: var(--available-height);
+  max-height: min(
+    var(--osdk-select-popup-max-height),
+    var(--available-height)
+  );
   overflow-y: auto;
   padding: calc(var(--osdk-select-spacing, var(--osdk-surface-spacing)) * 1.5);
   border-radius: var(

--- a/packages/react-components/src/tokens.css
+++ b/packages/react-components/src/tokens.css
@@ -19,6 +19,7 @@
 @import "./tokens/component-tokens/object-set.css";
 @import "./tokens/component-tokens/pdf-viewer.css";
 @import "./tokens/component-tokens/radio.css";
+@import "./tokens/component-tokens/select.css";
 @import "./tokens/component-tokens/table.css";
 @import "./tokens/component-tokens/timepicker.css";
 @import "./tokens/component-tokens/tooltip.css";

--- a/packages/react-components/src/tokens/component-tokens/select.css
+++ b/packages/react-components/src/tokens/component-tokens/select.css
@@ -1,0 +1,7 @@
+:root {
+  /* Select popup: cap long dropdowns so they scroll inside the popup instead
+     of growing to fill the available viewport/dialog height. The component
+     still respects Base UI's `--available-height`, so short viewports can use
+     a smaller cap when there is less room around the trigger. */
+  --osdk-select-popup-max-height: 320px;
+}


### PR DESCRIPTION
## Summary
- Add a select popup max-height token
- Cap select popups with the token while still respecting available viewport height
- Add a changeset for the React components package

## Test plan
- pnpm turbo transpileBrowser --filter=@osdk/react-components
- Storybook manual verification: ActionForm dialog dropdown max-height resolves to 320px and scrolls