### PR TITLE
split histogram date filter into independent from/to pickers

### DIFF
--- a/.changeset/histogram-date-filter-independent-pickers.md
+++ b/.changeset/histogram-date-filter-independent-pickers.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Histogram date filter: From and To inputs now open independent single-month popovers with Today/Clear actions, replacing the shared two-month range calendar that was confusing users next to the histogram bars

--- a/packages/react-components/src/filter-list/base/inputs/RangeInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/RangeInput.tsx
@@ -142,10 +142,9 @@ export interface RangeInputConfig<T> {
   formatPlaceholder?: (value: T) => string;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
   /**
-   * For `inputType === "date"`: forwarded to the shared `DateRangePicker`'s
-   * `formatDate` so the date-range histogram From/To inputs render the
-   * consumer-provided display string instead of ISO. Ignored for number
-   * ranges.
+   * For `inputType === "date"`: forwarded to each `DatePicker` (From/To)
+   * so the histogram From/To inputs render the consumer-provided display
+   * string instead of ISO. Ignored for number ranges.
    */
   formatDate?: (date: Date) => string;
 }
@@ -224,6 +223,19 @@ function RangeInputInner<T>({
       }, DEBOUNCE_MS),
     [config],
   );
+
+  // Date branch handlers — only invoked when `config.inputType === "date"`,
+  // so T is Date. Reusing the refs above keeps the callbacks identity-stable
+  // across renders, so the cross-bound update of one boundary doesn't bust
+  // the React.memo on the OTHER DatePicker.
+  const handleDateMinChange = useCallback((next: Date | null): void => {
+    const dispatch = onChangeRef.current as RangeOnChange<Date>;
+    dispatch(next ?? undefined, maxValueRef.current as Date | undefined);
+  }, []);
+  const handleDateMaxChange = useCallback((next: Date | null): void => {
+    const dispatch = onChangeRef.current as RangeOnChange<Date>;
+    dispatch(minValueRef.current as Date | undefined, next ?? undefined);
+  }, []);
 
   useEffect(() => {
     setLocalMin(config.formatValue(minValue));
@@ -859,7 +871,8 @@ function RangeInputInner<T>({
           <DateRangeInputs
             minValue={minValue as Date | undefined}
             maxValue={maxValue as Date | undefined}
-            onChange={onChange as RangeOnChange<Date>}
+            onMinChange={handleDateMinChange}
+            onMaxChange={handleDateMaxChange}
             formatDate={config.formatDate}
             minLabel={config.minLabel}
             maxLabel={config.maxLabel}
@@ -918,7 +931,8 @@ type RangeOnChange<T> = (
 interface DateRangeInputsProps {
   minValue: Date | undefined;
   maxValue: Date | undefined;
-  onChange: RangeOnChange<Date>;
+  onMinChange: (next: Date | null) => void;
+  onMaxChange: (next: Date | null) => void;
   formatDate: ((date: Date) => string) | undefined;
   minLabel: string;
   maxLabel: string;
@@ -927,31 +941,17 @@ interface DateRangeInputsProps {
 function DateRangeInputs({
   minValue,
   maxValue,
-  onChange,
+  onMinChange,
+  onMaxChange,
   formatDate,
   minLabel,
   maxLabel,
 }: DateRangeInputsProps): React.ReactElement {
-  // Each input drives only its own boundary. Cross-bounding via min/max
-  // prevents the user from picking a From > current To (or vice versa)
-  // without needing dual-popover overlap logic.
-  const handleMinChange = useCallback(
-    (next: Date | null) => {
-      onChange(next ?? undefined, maxValue);
-    },
-    [onChange, maxValue],
-  );
-  const handleMaxChange = useCallback(
-    (next: Date | null) => {
-      onChange(minValue, next ?? undefined);
-    },
-    [onChange, minValue],
-  );
   return (
     <div className={styles.rangeInputs}>
       <DatePicker
         value={minValue ?? null}
-        onChange={handleMinChange}
+        onChange={onMinChange}
         max={maxValue}
         placeholder={minLabel}
         ariaLabel={minLabel}
@@ -959,7 +959,7 @@ function DateRangeInputs({
       />
       <DatePicker
         value={maxValue ?? null}
-        onChange={handleMaxChange}
+        onChange={onMaxChange}
         min={minValue}
         placeholder={maxLabel}
         ariaLabel={maxLabel}

--- a/packages/react-components/src/filter-list/base/inputs/RangeInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/RangeInput.tsx
@@ -27,7 +27,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { DateRangePicker } from "../../../shared/calendar/index.js";
+import { DatePicker } from "../../../shared/calendar/index.js";
 import {
   createHistogramBuckets,
   getMaxBucketCount,
@@ -932,24 +932,37 @@ function DateRangeInputs({
   minLabel,
   maxLabel,
 }: DateRangeInputsProps): React.ReactElement {
-  const handleChange = useCallback(
-    (next: readonly [Date | null, Date | null] | null) => {
-      const [start, end] = next ?? [null, null];
-      onChange(start ?? undefined, end ?? undefined);
+  // Each input drives only its own boundary. Cross-bounding via min/max
+  // prevents the user from picking a From > current To (or vice versa)
+  // without needing dual-popover overlap logic.
+  const handleMinChange = useCallback(
+    (next: Date | null) => {
+      onChange(next ?? undefined, maxValue);
     },
-    [onChange],
+    [onChange, maxValue],
   );
-  const value = useMemo<readonly [Date | null, Date | null]>(
-    () => [minValue ?? null, maxValue ?? null],
-    [minValue, maxValue],
+  const handleMaxChange = useCallback(
+    (next: Date | null) => {
+      onChange(minValue, next ?? undefined);
+    },
+    [onChange, minValue],
   );
   return (
     <div className={styles.rangeInputs}>
-      <DateRangePicker
-        value={value}
-        onChange={handleChange}
-        placeholderStart={minLabel}
-        placeholderEnd={maxLabel}
+      <DatePicker
+        value={minValue ?? null}
+        onChange={handleMinChange}
+        max={maxValue}
+        placeholder={minLabel}
+        ariaLabel={minLabel}
+        formatDate={formatDate}
+      />
+      <DatePicker
+        value={maxValue ?? null}
+        onChange={handleMaxChange}
+        min={minValue}
+        placeholder={maxLabel}
+        ariaLabel={maxLabel}
         formatDate={formatDate}
       />
     </div>

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/DateRangeHistogramInput.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/DateRangeHistogramInput.test.tsx
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DateRangeHistogramInput } from "../DateRangeHistogramInput.js";
+
+// Replace the lazy single-date calendar with a synchronous import so the
+// popover renders in happy-dom without resolving React.lazy.
+vi.mock("../../../../shared/calendar/LazyDateCalendar.js", async () => {
+  const { default: DateCalendar } = await vi.importActual<
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    typeof import("../../../../shared/calendar/DateCalendar.js")
+  >("../../../../shared/calendar/DateCalendar.js");
+  return { LazyDateCalendar: DateCalendar };
+});
+
+afterEach(cleanup);
+
+const buckets = [
+  { value: new Date(2024, 0, 1), count: 5 },
+  { value: new Date(2024, 5, 30), count: 7 },
+];
+
+describe("DateRangeHistogramInput", () => {
+  it("renders independent From and To inputs", () => {
+    render(
+      <DateRangeHistogramInput
+        valueCountPairs={buckets}
+        isLoading={false}
+        minValue={undefined}
+        maxValue={undefined}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByLabelText("From")).toBeDefined();
+    expect(screen.getByLabelText("To")).toBeDefined();
+  });
+
+  describe("independent popovers", () => {
+    it("opens only the From popover when From is focused", () => {
+      render(
+        <DateRangeHistogramInput
+          valueCountPairs={buckets}
+          isLoading={false}
+          minValue={undefined}
+          maxValue={undefined}
+          onChange={vi.fn()}
+        />,
+      );
+      const fromInput = screen.getByLabelText("From");
+      const toInput = screen.getByLabelText("To");
+
+      fireEvent.focus(fromInput);
+
+      expect(fromInput.getAttribute("aria-expanded")).toBe("true");
+      expect(toInput.getAttribute("aria-expanded")).toBe("false");
+    });
+
+    it("opens only the To popover when To is focused", () => {
+      render(
+        <DateRangeHistogramInput
+          valueCountPairs={buckets}
+          isLoading={false}
+          minValue={undefined}
+          maxValue={undefined}
+          onChange={vi.fn()}
+        />,
+      );
+      const fromInput = screen.getByLabelText("From");
+      const toInput = screen.getByLabelText("To");
+
+      fireEvent.focus(toInput);
+
+      expect(toInput.getAttribute("aria-expanded")).toBe("true");
+      expect(fromInput.getAttribute("aria-expanded")).toBe("false");
+    });
+  });
+
+  describe("Today and Clear actions", () => {
+    it("renders Today and Clear in the From popover", () => {
+      render(
+        <DateRangeHistogramInput
+          valueCountPairs={buckets}
+          isLoading={false}
+          minValue={undefined}
+          maxValue={undefined}
+          onChange={vi.fn()}
+        />,
+      );
+      fireEvent.focus(screen.getByLabelText("From"));
+
+      expect(screen.getByRole("button", { name: "Today" })).toBeDefined();
+      expect(screen.getByRole("button", { name: "Clear" })).toBeDefined();
+    });
+
+    it("renders Today and Clear in the To popover", () => {
+      render(
+        <DateRangeHistogramInput
+          valueCountPairs={buckets}
+          isLoading={false}
+          minValue={undefined}
+          maxValue={undefined}
+          onChange={vi.fn()}
+        />,
+      );
+      fireEvent.focus(screen.getByLabelText("To"));
+
+      expect(screen.getByRole("button", { name: "Today" })).toBeDefined();
+      expect(screen.getByRole("button", { name: "Clear" })).toBeDefined();
+    });
+
+    it("Clear in From input resets only minValue", () => {
+      const onChange = vi.fn();
+      const min = new Date(2024, 0, 15);
+      const max = new Date(2024, 5, 30);
+      render(
+        <DateRangeHistogramInput
+          valueCountPairs={buckets}
+          isLoading={false}
+          minValue={min}
+          maxValue={max}
+          onChange={onChange}
+        />,
+      );
+      fireEvent.focus(screen.getByLabelText("From"));
+      fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+
+      expect(onChange).toHaveBeenCalledWith(undefined, max);
+    });
+
+    it("Today in From input sets minValue to today's date", () => {
+      const onChange = vi.fn();
+      render(
+        <DateRangeHistogramInput
+          valueCountPairs={buckets}
+          isLoading={false}
+          minValue={undefined}
+          maxValue={undefined}
+          onChange={onChange}
+        />,
+      );
+      fireEvent.focus(screen.getByLabelText("From"));
+      fireEvent.click(screen.getByRole("button", { name: "Today" }));
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const [picked, otherBoundary] = onChange.mock.calls[0];
+      expect(picked).toBeInstanceOf(Date);
+      const today = new Date();
+      expect((picked as Date).getFullYear()).toBe(today.getFullYear());
+      expect((picked as Date).getMonth()).toBe(today.getMonth());
+      expect((picked as Date).getDate()).toBe(today.getDate());
+      expect(otherBoundary).toBeUndefined();
+    });
+  });
+
+  describe("cross-bound constraints", () => {
+    it("blocks picking a From date after the current To", () => {
+      // Seed both values so the From calendar opens at the same month as the
+      // boundary — otherwise the viewport lands on today's date and the
+      // boundary day isn't in the DOM.
+      const onChange = vi.fn();
+      render(
+        <DateRangeHistogramInput
+          valueCountPairs={buckets}
+          isLoading={false}
+          minValue={new Date(2024, 0, 5)}
+          maxValue={new Date(2024, 0, 10)}
+          onChange={onChange}
+        />,
+      );
+      fireEvent.focus(screen.getByLabelText("From"));
+
+      // 11th is past the cross-bound. Clicking must not propagate.
+      fireEvent.click(screen.getByText("11"));
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("blocks picking a To date before the current From", () => {
+      const onChange = vi.fn();
+      render(
+        <DateRangeHistogramInput
+          valueCountPairs={buckets}
+          isLoading={false}
+          minValue={new Date(2024, 0, 20)}
+          maxValue={new Date(2024, 0, 25)}
+          onChange={onChange}
+        />,
+      );
+      fireEvent.focus(screen.getByLabelText("To"));
+
+      // 19th is before the cross-bound. Clicking must not propagate.
+      fireEvent.click(screen.getByText("19"));
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/DateRangeHistogramInput.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/DateRangeHistogramInput.test.tsx
@@ -36,32 +36,36 @@ const buckets = [
   { value: new Date(2024, 5, 30), count: 7 },
 ];
 
+const slashFormat = (d: Date): string =>
+  `${String(d.getMonth() + 1).padStart(2, "0")}/${
+    String(d.getDate()).padStart(2, "0")
+  }/${d.getFullYear()}`;
+
+function renderInput(
+  props: Partial<React.ComponentProps<typeof DateRangeHistogramInput>> = {},
+) {
+  return render(
+    <DateRangeHistogramInput
+      valueCountPairs={buckets}
+      isLoading={false}
+      minValue={undefined}
+      maxValue={undefined}
+      onChange={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
 describe("DateRangeHistogramInput", () => {
   it("renders independent From and To inputs", () => {
-    render(
-      <DateRangeHistogramInput
-        valueCountPairs={buckets}
-        isLoading={false}
-        minValue={undefined}
-        maxValue={undefined}
-        onChange={vi.fn()}
-      />,
-    );
+    renderInput();
     expect(screen.getByLabelText("From")).toBeDefined();
     expect(screen.getByLabelText("To")).toBeDefined();
   });
 
   describe("independent popovers", () => {
     it("opens only the From popover when From is focused", () => {
-      render(
-        <DateRangeHistogramInput
-          valueCountPairs={buckets}
-          isLoading={false}
-          minValue={undefined}
-          maxValue={undefined}
-          onChange={vi.fn()}
-        />,
-      );
+      renderInput();
       const fromInput = screen.getByLabelText("From");
       const toInput = screen.getByLabelText("To");
 
@@ -72,15 +76,7 @@ describe("DateRangeHistogramInput", () => {
     });
 
     it("opens only the To popover when To is focused", () => {
-      render(
-        <DateRangeHistogramInput
-          valueCountPairs={buckets}
-          isLoading={false}
-          minValue={undefined}
-          maxValue={undefined}
-          onChange={vi.fn()}
-        />,
-      );
+      renderInput();
       const fromInput = screen.getByLabelText("From");
       const toInput = screen.getByLabelText("To");
 
@@ -93,15 +89,7 @@ describe("DateRangeHistogramInput", () => {
 
   describe("Today and Clear actions", () => {
     it("renders Today and Clear in the From popover", () => {
-      render(
-        <DateRangeHistogramInput
-          valueCountPairs={buckets}
-          isLoading={false}
-          minValue={undefined}
-          maxValue={undefined}
-          onChange={vi.fn()}
-        />,
-      );
+      renderInput();
       fireEvent.focus(screen.getByLabelText("From"));
 
       expect(screen.getByRole("button", { name: "Today" })).toBeDefined();
@@ -109,15 +97,7 @@ describe("DateRangeHistogramInput", () => {
     });
 
     it("renders Today and Clear in the To popover", () => {
-      render(
-        <DateRangeHistogramInput
-          valueCountPairs={buckets}
-          isLoading={false}
-          minValue={undefined}
-          maxValue={undefined}
-          onChange={vi.fn()}
-        />,
-      );
+      renderInput();
       fireEvent.focus(screen.getByLabelText("To"));
 
       expect(screen.getByRole("button", { name: "Today" })).toBeDefined();
@@ -128,15 +108,7 @@ describe("DateRangeHistogramInput", () => {
       const onChange = vi.fn();
       const min = new Date(2024, 0, 15);
       const max = new Date(2024, 5, 30);
-      render(
-        <DateRangeHistogramInput
-          valueCountPairs={buckets}
-          isLoading={false}
-          minValue={min}
-          maxValue={max}
-          onChange={onChange}
-        />,
-      );
+      renderInput({ minValue: min, maxValue: max, onChange });
       fireEvent.focus(screen.getByLabelText("From"));
       fireEvent.click(screen.getByRole("button", { name: "Clear" }));
 
@@ -145,25 +117,19 @@ describe("DateRangeHistogramInput", () => {
 
     it("Today in From input sets minValue to today's date", () => {
       const onChange = vi.fn();
-      render(
-        <DateRangeHistogramInput
-          valueCountPairs={buckets}
-          isLoading={false}
-          minValue={undefined}
-          maxValue={undefined}
-          onChange={onChange}
-        />,
-      );
+      renderInput({ onChange });
       fireEvent.focus(screen.getByLabelText("From"));
       fireEvent.click(screen.getByRole("button", { name: "Today" }));
 
       expect(onChange).toHaveBeenCalledTimes(1);
       const [picked, otherBoundary] = onChange.mock.calls[0];
-      expect(picked).toBeInstanceOf(Date);
+      if (!(picked instanceof Date)) {
+        throw new Error("expected picked to be a Date");
+      }
       const today = new Date();
-      expect((picked as Date).getFullYear()).toBe(today.getFullYear());
-      expect((picked as Date).getMonth()).toBe(today.getMonth());
-      expect((picked as Date).getDate()).toBe(today.getDate());
+      expect(picked.getFullYear()).toBe(today.getFullYear());
+      expect(picked.getMonth()).toBe(today.getMonth());
+      expect(picked.getDate()).toBe(today.getDate());
       expect(otherBoundary).toBeUndefined();
     });
   });
@@ -174,15 +140,11 @@ describe("DateRangeHistogramInput", () => {
       // boundary — otherwise the viewport lands on today's date and the
       // boundary day isn't in the DOM.
       const onChange = vi.fn();
-      render(
-        <DateRangeHistogramInput
-          valueCountPairs={buckets}
-          isLoading={false}
-          minValue={new Date(2024, 0, 5)}
-          maxValue={new Date(2024, 0, 10)}
-          onChange={onChange}
-        />,
-      );
+      renderInput({
+        minValue: new Date(2024, 0, 5),
+        maxValue: new Date(2024, 0, 10),
+        onChange,
+      });
       fireEvent.focus(screen.getByLabelText("From"));
 
       // 11th is past the cross-bound. Clicking must not propagate.
@@ -192,20 +154,52 @@ describe("DateRangeHistogramInput", () => {
 
     it("blocks picking a To date before the current From", () => {
       const onChange = vi.fn();
-      render(
-        <DateRangeHistogramInput
-          valueCountPairs={buckets}
-          isLoading={false}
-          minValue={new Date(2024, 0, 20)}
-          maxValue={new Date(2024, 0, 25)}
-          onChange={onChange}
-        />,
-      );
+      renderInput({
+        minValue: new Date(2024, 0, 20),
+        maxValue: new Date(2024, 0, 25),
+        onChange,
+      });
       fireEvent.focus(screen.getByLabelText("To"));
 
       // 19th is before the cross-bound. Clicking must not propagate.
       fireEvent.click(screen.getByText("19"));
       expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("formatDate plumbing", () => {
+    it("uses formatDate for the histogram bar tooltip when provided", () => {
+      const { container } = renderInput({ formatDate: slashFormat });
+      // The histogram bar tooltip is portaled to document.body when a bar
+      // is hovered, so we query there rather than the local container.
+      const rects = container.querySelectorAll(
+        "rect[class*=\"histogramBar\"]",
+      );
+      expect(rects.length).toBeGreaterThan(0);
+      fireEvent.pointerMove(rects[0], { pointerId: 1 });
+      const tooltip = document.body.querySelector("div[class*=\"tooltip\"]");
+      expect(tooltip).not.toBeNull();
+      expect(tooltip?.textContent ?? "").toMatch(/\d{2}\/\d{2}\/\d{4}/);
+    });
+
+    it("honors formatDate on the From input display", () => {
+      const min = new Date(2024, 0, 15);
+      renderInput({ minValue: min, formatDate: slashFormat });
+      const fromInput = screen.getByLabelText("From") as HTMLInputElement;
+      expect(fromInput.value).toBe(slashFormat(min));
+    });
+
+    it("uses the default tooltip format when formatDate is omitted", () => {
+      const { container } = renderInput();
+      const rects = container.querySelectorAll(
+        "rect[class*=\"histogramBar\"]",
+      );
+      expect(rects.length).toBeGreaterThan(0);
+      fireEvent.pointerMove(rects[0], { pointerId: 1 });
+      const tooltip = document.body.querySelector("div[class*=\"tooltip\"]");
+      expect(tooltip).not.toBeNull();
+      // ISO format when formatDate is omitted.
+      expect(tooltip?.textContent ?? "").toMatch(/^\d{4}-\d{2}-\d{2}/);
     });
   });
 });

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/dateFormatting.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/dateFormatting.test.tsx
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { DateRangeHistogramInput } from "../DateRangeHistogramInput.js";
 import { MultiDateInput } from "../MultiDateInput.js";
 import { TimelineInput } from "../TimelineInput.js";
 
@@ -142,82 +141,6 @@ describe("formatDate / parseDate plumbing", () => {
         ) as HTMLInputElement;
         expect(input.type).toBe("date");
         expect(input.value).toBe("2024-05-01");
-      },
-    );
-  });
-
-  describe("DateRangeHistogramInput", () => {
-    const buckets = [
-      { value: new Date(2024, 0, 1), count: 5 },
-      { value: new Date(2024, 5, 30), count: 7 },
-    ];
-
-    it(
-      "uses formatDate for the histogram bar tooltip when provided",
-      () => {
-        const { container } = render(
-          <DateRangeHistogramInput
-            valueCountPairs={buckets}
-            isLoading={false}
-            minValue={undefined}
-            maxValue={undefined}
-            onChange={vi.fn()}
-            formatDate={slashFormat}
-          />,
-        );
-        // The histogram bar tooltip is portaled to document.body when a bar
-        // is hovered, so we query there rather than the local container.
-        const rects = container.querySelectorAll(
-          "rect[class*=\"histogramBar\"]",
-        );
-        expect(rects.length).toBeGreaterThan(0);
-        fireEvent.pointerMove(rects[0], { pointerId: 1 });
-        const tooltip = document.body.querySelector("div[class*=\"tooltip\"]");
-        expect(tooltip).not.toBeNull();
-        expect(tooltip?.textContent ?? "").toMatch(/\d{2}\/\d{2}\/\d{4}/);
-      },
-    );
-
-    it(
-      "honors formatDate on the From input display",
-      () => {
-        const min = new Date(2024, 0, 15);
-        render(
-          <DateRangeHistogramInput
-            valueCountPairs={buckets}
-            isLoading={false}
-            minValue={min}
-            maxValue={undefined}
-            onChange={vi.fn()}
-            formatDate={slashFormat}
-          />,
-        );
-        const fromInput = screen.getByLabelText("From") as HTMLInputElement;
-        expect(fromInput.value).toBe(slashFormat(min));
-      },
-    );
-
-    it(
-      "uses the default tooltip format when formatDate is omitted",
-      () => {
-        const { container } = render(
-          <DateRangeHistogramInput
-            valueCountPairs={buckets}
-            isLoading={false}
-            minValue={undefined}
-            maxValue={undefined}
-            onChange={vi.fn()}
-          />,
-        );
-        const rects = container.querySelectorAll(
-          "rect[class*=\"histogramBar\"]",
-        );
-        expect(rects.length).toBeGreaterThan(0);
-        fireEvent.pointerMove(rects[0], { pointerId: 1 });
-        const tooltip = document.body.querySelector("div[class*=\"tooltip\"]");
-        expect(tooltip).not.toBeNull();
-        // ISO format when formatDate is omitted.
-        expect(tooltip?.textContent ?? "").toMatch(/^\d{4}-\d{2}-\d{2}/);
       },
     );
   });

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/dateFormatting.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/dateFormatting.test.tsx
@@ -179,7 +179,7 @@ describe("formatDate / parseDate plumbing", () => {
     );
 
     it(
-      "keeps the DatePicker input value as ISO regardless of formatDate",
+      "honors formatDate on the From input display",
       () => {
         const min = new Date(2024, 0, 15);
         render(
@@ -192,14 +192,8 @@ describe("formatDate / parseDate plumbing", () => {
             formatDate={slashFormat}
           />,
         );
-        const startInput = screen.getByLabelText(
-          "Start date",
-        ) as HTMLInputElement;
-        // The shared DateRangePicker shows the consumer-pinned format in the
-        // idle text, but the underlying calendar value remains ISO. Tests
-        // rely on the displayed value here, which now goes through
-        // formatDate when provided.
-        expect(startInput.value).toBe(slashFormat(min));
+        const fromInput = screen.getByLabelText("From") as HTMLInputElement;
+        expect(fromInput.value).toBe(slashFormat(min));
       },
     );
 


### PR DESCRIPTION
the histogram filter's from/to inputs shared a single two-month range popover, which users mistook for the histogram drag-to-scroll bars and which had no today/clear actions

• swap the shared DateRangePicker for two independent DatePicker instances inside DateRangeInputs
• cross-bound via min/max so picking From > current To (or To < current From) is blocked
• inherit Today/Clear from the existing single-date DateCalendar action bar; action-form's DATE_RANGE_INPUT field is untouched