### PR TITLE
[Component] Pass row's pending edits to getFieldComponentProps

### DIFF
--- a/.changeset/edit-field-props-row-edits.md
+++ b/.changeset/edit-field-props-row-edits.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+ObjectTable `EditFieldConfig.getFieldComponentProps` now receives a second `edits` argument with the row's pending cell edits (keyed by columnId), so editor configuration can react to other in-progress edits within the same row.

--- a/packages/react-components/src/object-table/DefaultCellRenderer.tsx
+++ b/packages/react-components/src/object-table/DefaultCellRenderer.tsx
@@ -23,12 +23,32 @@ import { isAsyncCellData } from "./utils/AsyncCellData.js";
 import { isCellEditable } from "./utils/editableUtils.js";
 import { getCellId } from "./utils/getCellId.js";
 import { shouldShowEditableCell } from "./utils/shouldShowEditableCell.js";
+import type { CellEditInfo } from "./utils/types.js";
 
 function toDisplayValue(value: unknown): React.ReactNode {
   if (typeof value === "boolean") {
     return String(value);
   }
   return value as React.ReactNode;
+}
+
+// Returns the subset of `cellEdits` belonging to `rowId`, re-keyed by columnId.
+// Returns `undefined` (stable reference) when the row has no pending edits, so
+// that `React.memo` on `EditableCell` can skip re-renders of unedited rows when
+// edits change elsewhere in the table.
+function filterCellEditsToRow<TData extends RowData>(
+  cellEdits: Record<string, CellEditInfo<TData, unknown>> | undefined,
+  rowId: string,
+): Record<string, CellEditInfo<TData, unknown>> | undefined {
+  if (!cellEdits) return undefined;
+  let result: Record<string, CellEditInfo<TData, unknown>> | undefined;
+  for (const edit of Object.values(cellEdits)) {
+    if (edit.rowId === rowId) {
+      result ??= {};
+      result[edit.columnId] = edit;
+    }
+  }
+  return result;
 }
 
 export function renderDefaultCell<TData extends RowData>(
@@ -84,6 +104,7 @@ export function renderDefaultCell<TData extends RowData>(
     : editedValue?.newValue;
   const validationError = meta.validationErrors?.get(cellId);
   const isRowFocused = meta.focusedRowId === rowId;
+  const rowCellEdits = filterCellEditsToRow(cellEdits, rowId);
 
   return (
     <EditableCell<TData>
@@ -92,7 +113,7 @@ export function renderDefaultCell<TData extends RowData>(
       cellId={cellId}
       dataType={columnMeta?.dataType}
       editFieldConfig={columnMeta?.editFieldConfig}
-      cellEdits={cellEdits}
+      rowCellEdits={rowCellEdits}
       onCellEdit={meta.onCellEdit}
       onCellValidationError={meta.onCellValidationError}
       clearCellValidationError={meta.clearCellValidationError}

--- a/packages/react-components/src/object-table/DefaultCellRenderer.tsx
+++ b/packages/react-components/src/object-table/DefaultCellRenderer.tsx
@@ -92,6 +92,7 @@ export function renderDefaultCell<TData extends RowData>(
       cellId={cellId}
       dataType={columnMeta?.dataType}
       editFieldConfig={columnMeta?.editFieldConfig}
+      cellEdits={cellEdits}
       onCellEdit={meta.onCellEdit}
       onCellValidationError={meta.onCellValidationError}
       clearCellValidationError={meta.clearCellValidationError}

--- a/packages/react-components/src/object-table/EditableCell.tsx
+++ b/packages/react-components/src/object-table/EditableCell.tsx
@@ -65,11 +65,12 @@ export interface EditableCellProps<TData extends RowData, CellValue = unknown> {
   validateEdit?: (value: unknown) => Promise<string | undefined>;
   editFieldConfig?: EditFieldConfig<TData>;
   /**
-   * Full table cellEdits map (keyed by `rowId-columnId`). Filtered to the
-   * current row internally and forwarded to
-   * `EditFieldConfig#getFieldComponentProps`.
+   * Pending edits for this row, keyed by `columnId`. Forwarded to
+   * `EditFieldConfig#getFieldComponentProps`. Filtering happens in
+   * `DefaultCellRenderer` so unedited rows receive a stable `undefined`
+   * reference and `React.memo` can skip them.
    */
-  cellEdits?: Record<string, CellEditInfo<TData, unknown>>;
+  rowCellEdits?: Record<string, CellEditInfo<TData, unknown>>;
   isRowFocused?: boolean;
 }
 
@@ -119,7 +120,7 @@ function EditableCellInner<TData extends RowData, CellValue = unknown>({
   validateEdit,
   validationError,
   editFieldConfig,
-  cellEdits,
+  rowCellEdits,
   isRowFocused = false,
 }: EditableCellProps<TData, CellValue>): React.ReactElement {
   const [inputValue, setInputValue] = useState<string>(
@@ -264,20 +265,6 @@ function EditableCellInner<TData extends RowData, CellValue = unknown>({
   const inputType = dataType && NUMBER_TYPES.includes(dataType)
     ? "number"
     : "text";
-
-  // Pending edits for this row, re-keyed by columnId. Recomputed only when
-  // the cellEdits map identity changes.
-  const rowCellEdits = useMemo(() => {
-    if (!cellEdits) return undefined;
-    let result: Record<string, CellEditInfo<TData, unknown>> | undefined;
-    for (const edit of Object.values(cellEdits)) {
-      if (edit.rowId === rowId) {
-        result ??= {};
-        result[edit.columnId] = edit;
-      }
-    }
-    return result;
-  }, [cellEdits, rowId]);
 
   // Compute field-component props once per (editFieldConfig, originalRowData, rowCellEdits).
   // The narrowed return type is preserved in each useMemo

--- a/packages/react-components/src/object-table/EditableCell.tsx
+++ b/packages/react-components/src/object-table/EditableCell.tsx
@@ -64,6 +64,12 @@ export interface EditableCellProps<TData extends RowData, CellValue = unknown> {
   columnId: string;
   validateEdit?: (value: unknown) => Promise<string | undefined>;
   editFieldConfig?: EditFieldConfig<TData>;
+  /**
+   * Full table cellEdits map (keyed by `rowId-columnId`). Filtered to the
+   * current row internally and forwarded to
+   * `EditFieldConfig#getFieldComponentProps`.
+   */
+  cellEdits?: Record<string, CellEditInfo<TData, unknown>>;
   isRowFocused?: boolean;
 }
 
@@ -113,6 +119,7 @@ function EditableCellInner<TData extends RowData, CellValue = unknown>({
   validateEdit,
   validationError,
   editFieldConfig,
+  cellEdits,
   isRowFocused = false,
 }: EditableCellProps<TData, CellValue>): React.ReactElement {
   const [inputValue, setInputValue] = useState<string>(
@@ -258,22 +265,36 @@ function EditableCellInner<TData extends RowData, CellValue = unknown>({
     ? "number"
     : "text";
 
-  // Compute field-component props once per (editFieldConfig, originalRowData).
+  // Pending edits for this row, re-keyed by columnId. Recomputed only when
+  // the cellEdits map identity changes.
+  const rowCellEdits = useMemo(() => {
+    if (!cellEdits) return undefined;
+    let result: Record<string, CellEditInfo<TData, unknown>> | undefined;
+    for (const edit of Object.values(cellEdits)) {
+      if (edit.rowId === rowId) {
+        result ??= {};
+        result[edit.columnId] = edit;
+      }
+    }
+    return result;
+  }, [cellEdits, rowId]);
+
+  // Compute field-component props once per (editFieldConfig, originalRowData, rowCellEdits).
   // The narrowed return type is preserved in each useMemo
   const dropdownFieldProps = useMemo(
     () =>
       editFieldConfig?.fieldComponent === "DROPDOWN"
-        ? editFieldConfig.getFieldComponentProps(originalRowData)
+        ? editFieldConfig.getFieldComponentProps(originalRowData, rowCellEdits)
         : undefined,
-    [editFieldConfig, originalRowData],
+    [editFieldConfig, originalRowData, rowCellEdits],
   );
 
   const datePickerFieldProps = useMemo(
     () =>
       editFieldConfig?.fieldComponent === "DATE_PICKER"
-        ? editFieldConfig.getFieldComponentProps(originalRowData)
+        ? editFieldConfig.getFieldComponentProps(originalRowData, rowCellEdits)
         : undefined,
-    [editFieldConfig, originalRowData],
+    [editFieldConfig, originalRowData, rowCellEdits],
   );
 
   const renderFieldInput = () => {

--- a/packages/react-components/src/object-table/ObjectTableApi.ts
+++ b/packages/react-components/src/object-table/ObjectTableApi.ts
@@ -129,9 +129,10 @@ interface EditableColumnDefinition<
    * When provided, the column uses the specified field component
    * (e.g. dropdown) instead of the default auto-detected text/number input.
    *
-   * `getFieldComponentProps` receives the row's object and returns the props
-   * to pass to the field component, so editor configuration can depend on the
-   * current row.
+   * `getFieldComponentProps` receives the row's object and a map of any
+   * pending edits for that row (keyed by column id), and returns the props to
+   * pass to the field component. Editor configuration can depend on the
+   * current row or on other in-progress edits within the row.
    */
   editFieldConfig?: EditFieldConfig<
     Osdk.Instance<Q, "$allBaseProperties", PropertyKeys<Q>, RDPs>

--- a/packages/react-components/src/object-table/__tests__/DefaultCellRenderer.test.tsx
+++ b/packages/react-components/src/object-table/__tests__/DefaultCellRenderer.test.tsx
@@ -16,17 +16,31 @@
 
 import type { CellContext } from "@tanstack/react-table";
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { renderDefaultCell } from "../DefaultCellRenderer.js";
+import type { CellEditInfo, EditFieldConfig } from "../utils/types.js";
 
 function createCellContext(
   value: unknown,
+  overrides?: {
+    rowId?: string;
+    columnId?: string;
+    rowData?: unknown;
+    tableMeta?: Record<string, unknown>;
+    columnMeta?: Record<string, unknown>;
+  },
 ): CellContext<unknown, unknown> {
   return {
     getValue: () => value,
-    table: { options: { meta: undefined } },
-    column: { columnDef: { meta: undefined } },
-    row: { original: {}, id: "row-0" },
+    table: { options: { meta: overrides?.tableMeta } },
+    column: {
+      id: overrides?.columnId ?? "col-0",
+      columnDef: { meta: overrides?.columnMeta },
+    },
+    row: {
+      original: overrides?.rowData ?? {},
+      id: overrides?.rowId ?? "row-0",
+    },
   } as unknown as CellContext<unknown, unknown>;
 }
 
@@ -69,5 +83,55 @@ describe("renderDefaultCell", () => {
     const result = renderDefaultCell(createCellContext(undefined));
     render(<div data-testid="cell">{result}</div>);
     expect(screen.getByTestId("cell").textContent).toBe("");
+  });
+
+  it("should pass only the current row's pending edits to getFieldComponentProps", () => {
+    const getFieldComponentProps = vi.fn().mockReturnValue({ items: [] });
+    const editFieldConfig: EditFieldConfig<unknown> = {
+      fieldComponent: "DROPDOWN",
+      getFieldComponentProps,
+    };
+    const rowData = { id: "row-1" };
+    const otherRowEdit: CellEditInfo<unknown, unknown> = {
+      rowId: "row-2",
+      columnId: "col-other",
+      newValue: "other-row-new",
+      oldValue: "other-row-old",
+      originalRowData: { id: "row-2" },
+    };
+    const sameRowEdit: CellEditInfo<unknown, unknown> = {
+      rowId: "row-1",
+      columnId: "col-sibling",
+      newValue: "sibling-new",
+      oldValue: "sibling-old",
+      originalRowData: rowData,
+    };
+
+    const result = renderDefaultCell(createCellContext("initial", {
+      rowId: "row-1",
+      columnId: "col-1",
+      rowData,
+      tableMeta: {
+        onCellEdit: vi.fn(),
+        isInEditMode: true,
+        focusedRowId: "row-1",
+        cellEdits: {
+          "row-2_col-other": otherRowEdit,
+          "row-1_col-sibling": sameRowEdit,
+        },
+      },
+      columnMeta: {
+        editable: true,
+        editFieldConfig,
+      },
+    }));
+
+    render(<div data-testid="cell">{result}</div>);
+
+    expect(getFieldComponentProps).toHaveBeenCalled();
+    const [forwardedRowData, forwardedEdits] =
+      getFieldComponentProps.mock.calls[0];
+    expect(forwardedRowData).toBe(rowData);
+    expect(forwardedEdits).toEqual({ "col-sibling": sameRowEdit });
   });
 });

--- a/packages/react-components/src/object-table/utils/types.ts
+++ b/packages/react-components/src/object-table/utils/types.ts
@@ -167,12 +167,17 @@ type EditFieldComponent = keyof EditFieldPropsByType;
 /**
  * Configuration for an editable cell's field component.
  *
- * `getFieldComponentProps` is called with the row's object so the configuration
- * can vary per row (e.g. dropdown items that depend on row state).
+ * `getFieldComponentProps` is called with the row's object and a map of any
+ * pending cell edits for the same row, keyed by `columnId`. This lets the
+ * configuration depend on row state or on other in-progress edits within the
+ * row (e.g. dropdown items that change once another column is edited).
  */
 export type EditFieldConfig<TData = unknown> = {
   [K in EditFieldComponent]: {
     fieldComponent: K;
-    getFieldComponentProps: (object: TData) => EditFieldPropsByType[K];
+    getFieldComponentProps: (
+      object: TData,
+      edits?: Record<string, CellEditInfo<TData, unknown>>,
+    ) => EditFieldPropsByType[K];
   };
 }[EditFieldComponent];


### PR DESCRIPTION
EditFieldConfig.getFieldComponentProps now receives a second optional argument: the row's pending cell edits keyed by columnId. Editor configuration can react to other in-progress edits within the same row (e.g. dropdown items that change once another column is edited).