### PR TITLE
[Component] Add renderEmptyState

### DIFF
--- a/.changeset/basetable-render-empty-state.md
+++ b/.changeset/basetable-render-empty-state.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+`ObjectTable` now accepts an optional `renderEmptyState` prop for overriding the default "No Data" indicator with a custom `ReactNode`.

--- a/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.stories.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { NonIdealState } from "@blueprintjs/core";
 import type {
   DerivedProperty,
   ObjectSet,
@@ -1964,6 +1965,64 @@ return (
           {...args}
           getRowAttributes={getRowAttributes}
           className="customTableStyling"
+        />
+      </div>
+    );
+  },
+};
+
+export const CustomEmptyState: Story = {
+  args: {
+    objectType: Employee,
+    columnDefinitions: defaultEmployeeColumns,
+    renderEmptyState: () => (
+      <NonIdealState
+        icon="folder-close"
+        title="No saved PTL views found."
+      />
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Override the default empty state with a custom render function. Useful for matching product copy or visuals (here a Blueprint `NonIdealState`).",
+      },
+      source: {
+        code: `
+import { NonIdealState } from "@blueprintjs/core";
+
+const emptyObjectSet = client(Employee).where({
+  jobProfile: "Nonexistent Role",
+});
+
+return (
+  <ObjectTable
+    objectType={Employee}
+    objectSet={emptyObjectSet}
+    renderEmptyState={() => (
+      <NonIdealState
+        icon="folder-close"
+        title="No saved PTL views found."
+      />
+    )}
+  />
+);
+`,
+      },
+    },
+  },
+  render: (args) => {
+    const client = useOsdkClient();
+    const emptyObjectSet = client(Employee).where({
+      jobProfile: "Nonexistent Role",
+    });
+
+    return (
+      <div className="object-table-container" style={{ height: "600px" }}>
+        <ObjectTable
+          {...args}
+          objectSet={emptyObjectSet}
         />
       </div>
     );

--- a/packages/react-components/docs/ObjectTable.md
+++ b/packages/react-components/docs/ObjectTable.md
@@ -141,6 +141,7 @@ Each column header has a menu with items for sorting, filtering, pinning, resizi
 | ----------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `onRowClick`            | `(object) => void`                                 | Called when a row is clicked                                                                                                         |
 | `renderCellContextMenu` | `(row, cellValue) => ReactNode`                    | Custom context menu for right-click on cells                                                                                         |
+| `renderEmptyState`      | `() => ReactNode`                                  | Render override for the empty state. Called when the table has no rows and no error. Defaults to a "No Data" indicator               |
 | `getRowAttributes`      | `(rowData) => Record<string, string \| undefined>` | Extra HTML attributes (typically `data-*`) applied to each `<tr>`. See [Row Attributes](#row-attributes-and-conditional-row-styling) |
 
 ### Cell Editing

--- a/packages/react-components/src/object-table/ObjectTable.tsx
+++ b/packages/react-components/src/object-table/ObjectTable.tsx
@@ -271,6 +271,7 @@ export function ObjectTable<
       onColumnHeaderClick={handleColumnHeaderClick}
       rowHeight={props.rowHeight}
       renderCellContextMenu={onRenderCellContextMenu}
+      renderEmptyState={props.renderEmptyState}
       className={props.className}
       error={error}
       headerMenuFeatureFlags={headerMenuFeatureFlags}

--- a/packages/react-components/src/object-table/ObjectTableApi.ts
+++ b/packages/react-components/src/object-table/ObjectTableApi.ts
@@ -556,6 +556,13 @@ export interface ObjectTableProps<
   ) => React.ReactNode;
 
   /**
+   * Render override for the empty state. Called when the table has no
+   * rows and no error. When omitted, a default "No Data" indicator is
+   * rendered.
+   */
+  renderEmptyState?: () => React.ReactNode;
+
+  /**
    * The height of each row in pixels.
    *
    * @default 40

--- a/packages/react-components/src/object-table/Table.tsx
+++ b/packages/react-components/src/object-table/Table.tsx
@@ -95,6 +95,12 @@ export interface BaseTableProps<
    * column (`hasEditableColumns`).
    */
   showEditFooter?: boolean;
+  /**
+   * Render override for the empty state. Called when the table has no
+   * rows and no error. When omitted, a default "No Data" indicator is
+   * rendered.
+   */
+  renderEmptyState?: () => React.ReactNode;
 }
 
 export function BaseTable<
@@ -124,6 +130,7 @@ function BaseTableInner<
     editableConfig,
     getRowAttributes,
     showEditFooter = true,
+    renderEmptyState,
   }: BaseTableProps<TData>,
 ): ReactElement {
   const tableContainerRef = useRef<HTMLDivElement>(null);
@@ -252,7 +259,11 @@ function BaseTableInner<
               </>
             )}
         </table>
-        {!hasData && error == null && <NonIdealState message={"No Data"} />}
+        {!hasData && error == null && (
+          renderEmptyState != null
+            ? renderEmptyState()
+            : <NonIdealState message={"No Data"} />
+        )}
         {error != null && (
           <NonIdealState message={`Error Loading Data: ${error.message}`} />
         )}


### PR DESCRIPTION
Updated default empty and error states:

<img width="1721" height="803" alt="Screenshot 2026-05-14 at 23 20 35" src="https://github.com/user-attachments/assets/ad9c73d0-474f-47b3-8dd8-2c4d90565030" />

<img width="1721" height="803" alt="Screenshot 2026-05-14 at 23 20 39" src="https://github.com/user-attachments/assets/292da8c7-eff5-44e9-9e19-53c3b1bc1559" />


Example of custom empty state:
<img width="1418" height="905" alt="Screenshot 2026-05-14 at 22 54 19" src="https://github.com/user-attachments/assets/c700638b-44e3-440c-92f0-18815a7565b0" />


