### PR TITLE
fix loading height jumps in filter list select and text tags inputs

### DIFF
--- a/.changeset/fix-filter-list-loading-heights.md
+++ b/.changeset/fix-filter-list-loading-heights.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+prevent height jumps in SingleSelectInput, MultiSelectInput, and TextTagsInput during loading

--- a/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.module.css
@@ -18,6 +18,17 @@
   display: flex;
   flex-direction: column;
   gap: var(--osdk-filter-multiselect-gap);
+  transition: opacity var(--osdk-filter-content-fade-duration);
+}
+
+.multiSelect[data-loading="true"] {
+  opacity: 0.5;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .multiSelect {
+    transition: none;
+  }
 }
 
 .itemLabel {

--- a/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.tsx
@@ -25,6 +25,7 @@ import { MultiSelectDropdownLayout } from "./MultiSelectDropdownLayout.js";
 import { MultiSelectInlineLayout } from "./MultiSelectInlineLayout.js";
 import styles from "./MultiSelectInput.module.css";
 import { NoValueLabel } from "./NoValueLabel.js";
+import { SelectInputSkeleton } from "./SelectInputSkeleton.js";
 import sharedStyles from "./shared.module.css";
 import { useStableData } from "./useStableData.js";
 
@@ -141,6 +142,8 @@ function MultiSelectInputInner({
     [placeholder, ariaLabel, renderValue],
   );
 
+  const isNoData = !error && stableValues.length === 0;
+
   return (
     <div
       className={classnames(styles.multiSelect, className)}
@@ -153,10 +156,9 @@ function MultiSelectInputInner({
         </div>
       )}
 
-      {!error && stableValues.length === 0 && (
-        <div className={sharedStyles.emptyMessage}>
-          {isLoading ? "Loading options..." : "No options available"}
-        </div>
+      {isNoData && isLoading && <SelectInputSkeleton />}
+      {isNoData && !isLoading && (
+        <div className={sharedStyles.emptyMessage}>No options available</div>
       )}
 
       {stableValues.length > 0 && (
@@ -167,12 +169,6 @@ function MultiSelectInputInner({
           items={items}
           filter={comboboxFilter}
         >
-          {isLoading && (
-            <div className={sharedStyles.loadingMessage}>
-              Updating...
-            </div>
-          )}
-
           {layout === "inline"
             ? (
               <MultiSelectInlineLayout

--- a/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.tsx
@@ -151,20 +151,21 @@ function MultiSelectInputInner({
       style={style}
       data-loading={isReloading}
     >
+      <span className={sharedStyles.srOnly} role="status">
+        {isLoading ? "Loading options" : ""}
+      </span>
+
       {error && (
         <div className={sharedStyles.errorMessage}>
           Error loading options: {error.message}
         </div>
       )}
 
-      {isNoData && (
-        isLoading
-          ? <SelectInputSkeleton />
-          : (
-            <div className={sharedStyles.emptyMessage}>
-              No options available
-            </div>
-          )
+      {isNoData && isLoading && <SelectInputSkeleton />}
+      {isNoData && !isLoading && (
+        <div className={sharedStyles.emptyMessage}>
+          No options available
+        </div>
       )}
 
       {stableValues.length > 0 && (

--- a/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.tsx
@@ -143,12 +143,13 @@ function MultiSelectInputInner({
   );
 
   const isNoData = !error && stableValues.length === 0;
+  const isReloading = isLoading && stableValues.length > 0;
 
   return (
     <div
       className={classnames(styles.multiSelect, className)}
       style={style}
-      data-loading={isLoading && stableValues.length > 0}
+      data-loading={isReloading}
     >
       {error && (
         <div className={sharedStyles.errorMessage}>
@@ -156,9 +157,14 @@ function MultiSelectInputInner({
         </div>
       )}
 
-      {isNoData && isLoading && <SelectInputSkeleton />}
-      {isNoData && !isLoading && (
-        <div className={sharedStyles.emptyMessage}>No options available</div>
+      {isNoData && (
+        isLoading
+          ? <SelectInputSkeleton />
+          : (
+            <div className={sharedStyles.emptyMessage}>
+              No options available
+            </div>
+          )
       )}
 
       {stableValues.length > 0 && (

--- a/packages/react-components/src/filter-list/base/inputs/SelectInputSkeleton.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/SelectInputSkeleton.tsx
@@ -16,11 +16,15 @@
 
 import React, { memo } from "react";
 import { SkeletonBar } from "../../../base-components/skeleton/SkeletonBar.js";
+import sharedStyles from "./shared.module.css";
 
 export const SelectInputSkeleton = memo(
   function SelectInputSkeleton(): React.ReactElement {
     return (
       <div data-testid="select-input-skeleton">
+        <span className={sharedStyles.srOnly} role="status">
+          Loading options
+        </span>
         <SkeletonBar
           width="100%"
           height="var(--osdk-filter-skeleton-input-height)"

--- a/packages/react-components/src/filter-list/base/inputs/SelectInputSkeleton.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/SelectInputSkeleton.tsx
@@ -14,22 +14,16 @@
  * limitations under the License.
  */
 
-import React, { memo } from "react";
+import React from "react";
 import { SkeletonBar } from "../../../base-components/skeleton/SkeletonBar.js";
-import sharedStyles from "./shared.module.css";
 
-export const SelectInputSkeleton = memo(
-  function SelectInputSkeleton(): React.ReactElement {
-    return (
-      <div data-testid="select-input-skeleton">
-        <span className={sharedStyles.srOnly} role="status">
-          Loading options
-        </span>
-        <SkeletonBar
-          width="100%"
-          height="var(--osdk-filter-skeleton-input-height)"
-        />
-      </div>
-    );
-  },
-);
+export function SelectInputSkeleton(): React.ReactElement {
+  return (
+    <div data-testid="select-input-skeleton">
+      <SkeletonBar
+        width="100%"
+        height="var(--osdk-filter-skeleton-input-height)"
+      />
+    </div>
+  );
+}

--- a/packages/react-components/src/filter-list/base/inputs/SelectInputSkeleton.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/SelectInputSkeleton.tsx
@@ -14,23 +14,18 @@
  * limitations under the License.
  */
 
-.textTags {
-  display: flex;
-  flex-direction: column;
-  gap: var(--osdk-filter-texttags-gap);
-  transition: opacity var(--osdk-filter-content-fade-duration);
-}
+import React, { memo } from "react";
+import { SkeletonBar } from "../../../base-components/skeleton/SkeletonBar.js";
 
-.textTags[data-loading="true"] {
-  opacity: 0.5;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .textTags {
-    transition: none;
-  }
-}
-
-.input {
-  flex: 1;
-}
+export const SelectInputSkeleton = memo(
+  function SelectInputSkeleton(): React.ReactElement {
+    return (
+      <div data-testid="select-input-skeleton">
+        <SkeletonBar
+          width="100%"
+          height="var(--osdk-filter-skeleton-input-height)"
+        />
+      </div>
+    );
+  },
+);

--- a/packages/react-components/src/filter-list/base/inputs/SingleSelectInput.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/SingleSelectInput.module.css
@@ -17,6 +17,17 @@
 .singleSelect {
   display: flex;
   flex-direction: column;
+  transition: opacity var(--osdk-filter-content-fade-duration);
+}
+
+.singleSelect[data-loading="true"] {
+  opacity: 0.5;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .singleSelect {
+    transition: none;
+  }
 }
 
 .selectContainer {

--- a/packages/react-components/src/filter-list/base/inputs/SingleSelectInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/SingleSelectInput.tsx
@@ -22,6 +22,7 @@ import { isEmptyValue } from "../../utils/filterValues.js";
 import { useFilterListBoundary } from "../FilterListBoundaryContext.js";
 import { createRenderValueFilter } from "./comboboxFilter.js";
 import { NoValueLabel } from "./NoValueLabel.js";
+import { SelectInputSkeleton } from "./SelectInputSkeleton.js";
 import sharedStyles from "./shared.module.css";
 import styles from "./SingleSelectInput.module.css";
 import { useStableData } from "./useStableData.js";
@@ -103,6 +104,8 @@ function SingleSelectInputInner({
     [countByValue, showCounts, renderValue],
   );
 
+  const isNoData = !error && stableValues.length === 0;
+
   return (
     <div
       className={classnames(styles.singleSelect, className)}
@@ -115,10 +118,9 @@ function SingleSelectInputInner({
         </div>
       )}
 
-      {!error && stableValues.length === 0 && (
-        <div className={sharedStyles.emptyMessage}>
-          {isLoading ? "Loading options..." : "No options available"}
-        </div>
+      {isNoData && isLoading && <SelectInputSkeleton />}
+      {isNoData && !isLoading && (
+        <div className={sharedStyles.emptyMessage}>No options available</div>
       )}
 
       {stableValues.length > 0 && (

--- a/packages/react-components/src/filter-list/base/inputs/SingleSelectInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/SingleSelectInput.tsx
@@ -113,20 +113,21 @@ function SingleSelectInputInner({
       style={style}
       data-loading={isReloading}
     >
+      <span className={sharedStyles.srOnly} role="status">
+        {isLoading ? "Loading options" : ""}
+      </span>
+
       {error && (
         <div className={sharedStyles.errorMessage}>
           Error loading options: {error.message}
         </div>
       )}
 
-      {isNoData && (
-        isLoading
-          ? <SelectInputSkeleton />
-          : (
-            <div className={sharedStyles.emptyMessage}>
-              No options available
-            </div>
-          )
+      {isNoData && isLoading && <SelectInputSkeleton />}
+      {isNoData && !isLoading && (
+        <div className={sharedStyles.emptyMessage}>
+          No options available
+        </div>
       )}
 
       {stableValues.length > 0 && (

--- a/packages/react-components/src/filter-list/base/inputs/SingleSelectInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/SingleSelectInput.tsx
@@ -105,12 +105,13 @@ function SingleSelectInputInner({
   );
 
   const isNoData = !error && stableValues.length === 0;
+  const isReloading = isLoading && stableValues.length > 0;
 
   return (
     <div
       className={classnames(styles.singleSelect, className)}
       style={style}
-      data-loading={isLoading && stableValues.length > 0}
+      data-loading={isReloading}
     >
       {error && (
         <div className={sharedStyles.errorMessage}>
@@ -118,9 +119,14 @@ function SingleSelectInputInner({
         </div>
       )}
 
-      {isNoData && isLoading && <SelectInputSkeleton />}
-      {isNoData && !isLoading && (
-        <div className={sharedStyles.emptyMessage}>No options available</div>
+      {isNoData && (
+        isLoading
+          ? <SelectInputSkeleton />
+          : (
+            <div className={sharedStyles.emptyMessage}>
+              No options available
+            </div>
+          )
       )}
 
       {stableValues.length > 0 && (

--- a/packages/react-components/src/filter-list/base/inputs/TextTagsInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/TextTagsInput.tsx
@@ -22,6 +22,7 @@ import type { PropertyAggregationValue } from "../../types/AggregationTypes.js";
 import { isEmptyValue } from "../../utils/filterValues.js";
 import { useFilterListBoundary } from "../FilterListBoundaryContext.js";
 import { NoValueLabel } from "./NoValueLabel.js";
+import { SelectInputSkeleton } from "./SelectInputSkeleton.js";
 import sharedStyles from "./shared.module.css";
 import styles from "./TextTagsInput.module.css";
 
@@ -170,6 +171,10 @@ function TextTagsInputInner({
       style={style}
       data-loading={isLoading && suggestions.length > 0}
     >
+      <span className={sharedStyles.srOnly} role="status">
+        {isLoading ? "Loading options" : ""}
+      </span>
+
       {error && (
         <div className={sharedStyles.errorMessage}>
           Error loading suggestions: {error.message}
@@ -227,6 +232,10 @@ function TextTagsInputInner({
           </Combobox.Positioner>
         </Combobox.Portal>
       </Combobox.Root>
+
+      {!error && suggestions.length === 0 && isLoading && !!suggestionLimit && (
+        <SelectInputSkeleton />
+      )}
     </div>
   );
 }

--- a/packages/react-components/src/filter-list/base/inputs/TextTagsInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/TextTagsInput.tsx
@@ -168,7 +168,7 @@ function TextTagsInputInner({
     <div
       className={classnames(styles.textTags, className)}
       style={style}
-      data-loading={isLoading}
+      data-loading={isLoading && suggestions.length > 0}
     >
       {error && (
         <div className={sharedStyles.errorMessage}>

--- a/packages/react-components/src/filter-list/base/inputs/TextTagsInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/TextTagsInput.tsx
@@ -227,12 +227,6 @@ function TextTagsInputInner({
           </Combobox.Positioner>
         </Combobox.Portal>
       </Combobox.Root>
-
-      {isLoading && !!suggestionLimit && (
-        <div className={sharedStyles.loadingMessage}>
-          Loading suggestions...
-        </div>
-      )}
     </div>
   );
 }

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/stableData.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/stableData.test.tsx
@@ -57,7 +57,7 @@ describe("MultiSelectInput stableData", () => {
     expect(screen.queryByText("Loading options...")).toBeNull();
   });
 
-  it("shows loading message on first load with no data", () => {
+  it("shows skeleton on first load with no data", () => {
     const { rerender } = render(
       <MultiSelectInput
         values={[]}
@@ -68,7 +68,8 @@ describe("MultiSelectInput stableData", () => {
       />,
     );
 
-    expect(screen.getByText("Loading options...")).toBeDefined();
+    expect(screen.queryByTestId("select-input-skeleton")).not.toBeNull();
+    expect(screen.queryByText("Loading options...")).toBeNull();
 
     rerender(
       <MultiSelectInput
@@ -81,7 +82,7 @@ describe("MultiSelectInput stableData", () => {
     );
 
     expect(screen.getByText("No options available")).toBeDefined();
-    expect(screen.queryByText("Loading options...")).toBeNull();
+    expect(screen.queryByTestId("select-input-skeleton")).toBeNull();
   });
 
   it("transitions to empty-state when refetch resolves to no data", () => {
@@ -138,7 +139,7 @@ describe("SingleSelectInput stableData", () => {
     expect(screen.queryByText("Loading options...")).toBeNull();
   });
 
-  it("shows loading message on first load with no data", () => {
+  it("shows skeleton on first load with no data", () => {
     const { rerender } = render(
       <SingleSelectInput
         values={[]}
@@ -149,7 +150,8 @@ describe("SingleSelectInput stableData", () => {
       />,
     );
 
-    expect(screen.getByText("Loading options...")).toBeDefined();
+    expect(screen.queryByTestId("select-input-skeleton")).not.toBeNull();
+    expect(screen.queryByText("Loading options...")).toBeNull();
 
     rerender(
       <SingleSelectInput
@@ -162,7 +164,7 @@ describe("SingleSelectInput stableData", () => {
     );
 
     expect(screen.getByText("No options available")).toBeDefined();
-    expect(screen.queryByText("Loading options...")).toBeNull();
+    expect(screen.queryByTestId("select-input-skeleton")).toBeNull();
   });
 
   it("transitions to empty-state when refetch resolves to no data", () => {

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/stableData.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/stableData.test.tsx
@@ -20,6 +20,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PropertyAggregationValue } from "../../../types/AggregationTypes.js";
 import { MultiSelectInput } from "../MultiSelectInput.js";
 import { SingleSelectInput } from "../SingleSelectInput.js";
+import { TextTagsInput } from "../TextTagsInput.js";
 
 afterEach(cleanup);
 
@@ -190,5 +191,65 @@ describe("SingleSelectInput stableData", () => {
 
     expect(screen.getByText("No options available")).toBeDefined();
     expect(container.querySelector("input")).toBeNull();
+  });
+});
+
+describe("TextTagsInput stableData", () => {
+  it("shows skeleton on first load with no suggestions when suggestionLimit is set", () => {
+    const { rerender } = render(
+      <TextTagsInput
+        suggestions={[]}
+        isLoading={true}
+        error={null}
+        tags={[]}
+        onChange={vi.fn()}
+        suggestionLimit={10}
+      />,
+    );
+
+    expect(screen.queryByTestId("select-input-skeleton")).not.toBeNull();
+
+    rerender(
+      <TextTagsInput
+        suggestions={[{ value: "Engineering", count: 1 }]}
+        isLoading={false}
+        error={null}
+        tags={[]}
+        onChange={vi.fn()}
+        suggestionLimit={10}
+      />,
+    );
+
+    expect(screen.queryByTestId("select-input-skeleton")).toBeNull();
+  });
+
+  it("does not show skeleton when suggestionLimit is 0", () => {
+    render(
+      <TextTagsInput
+        suggestions={[]}
+        isLoading={true}
+        error={null}
+        tags={[]}
+        onChange={vi.fn()}
+        suggestionLimit={0}
+      />,
+    );
+
+    expect(screen.queryByTestId("select-input-skeleton")).toBeNull();
+  });
+
+  it("does not show skeleton when suggestions exist", () => {
+    render(
+      <TextTagsInput
+        suggestions={[{ value: "Engineering", count: 1 }]}
+        isLoading={true}
+        error={null}
+        tags={[]}
+        onChange={vi.fn()}
+        suggestionLimit={10}
+      />,
+    );
+
+    expect(screen.queryByTestId("select-input-skeleton")).toBeNull();
   });
 });

--- a/packages/react-components/src/filter-list/base/inputs/shared.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/shared.module.css
@@ -30,6 +30,18 @@
   color: var(--osdk-filter-message-color-danger);
 }
 
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
 /* Shared tag styles */
 .tagContainer {
   display: flex;

--- a/packages/react-components/src/filter-list/base/inputs/shared.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/shared.module.css
@@ -15,7 +15,6 @@
  */
 
 /* Shared message styles for filter inputs */
-.loadingMessage,
 .errorMessage,
 .emptyMessage {
   font-family: var(--osdk-filter-message-font-family);
@@ -23,7 +22,6 @@
   padding: var(--osdk-filter-message-padding);
 }
 
-.loadingMessage,
 .emptyMessage {
   color: var(--osdk-filter-message-color-muted);
 }

--- a/packages/react-components/src/tokens/component-tokens/filter-list.css
+++ b/packages/react-components/src/tokens/component-tokens/filter-list.css
@@ -446,6 +446,7 @@
   /* Skeleton Loading */
   --osdk-filter-skeleton-text-height: calc(var(--osdk-surface-spacing) * 1.5);
   --osdk-filter-skeleton-count-width: calc(var(--osdk-surface-spacing) * 2.5);
+  --osdk-filter-skeleton-input-height: var(--osdk-combobox-trigger-min-height, 30px);
 
   /* Filter Popover (composable label + popover-trigger primitive) */
   --osdk-filter-popover-gap: calc(var(--osdk-surface-spacing) * 1);


### PR DESCRIPTION
single-line text messages during loading caused the filter panel to jump as heights shifted between the loading placeholder and the full component

• replace first-load "Loading options..." text with a `SelectInputSkeleton` that matches the combobox input height, preventing the short→tall jump
• remove "Updating..." message from `MultiSelectInput` and "Loading suggestions..." from `TextTagsInput` — these added height during refetch; `data-loading` opacity fade now handles visual feedback instead
• add `transition: opacity` + `prefers-reduced-motion` guard to all three components, matching the existing `ListogramInput` pattern