### PR TITLE
Add override options to createClientFromWriteableClient and guard batch actions on transactional clients

### DIFF
--- a/.changeset/writeable-client-overrides-and-batch-invariant.md
+++ b/.changeset/writeable-client-overrides-and-batch-invariant.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": minor
+---
+
+`createClientFromWriteableClient` now accepts an optional `options` argument to override `transactionId`, `baseUrl`, `ontologyRid`, or `tokenProvider` from the source client. `applyAction` also now throws when batch actions are invoked on a client with an active transaction id, since batch actions are not supported for staged edit functions.

--- a/packages/client/src/actions/applyAction.ts
+++ b/packages/client/src/actions/applyAction.ts
@@ -31,6 +31,7 @@ import type {
   SyncApplyActionResponseV2,
 } from "@osdk/foundry.ontologies";
 import * as Actions from "@osdk/foundry.ontologies/Action";
+import invariant from "tiny-invariant";
 import type { MinimalClient } from "../MinimalClientContext.js";
 import { addUserAgentAndRequestContextHeaders } from "../util/addUserAgentAndRequestContextHeaders.js";
 import { augmentRequestContext } from "../util/augmentRequestContext.js";
@@ -129,6 +130,10 @@ export async function applyAction<
     action,
   );
   if (Array.isArray(parameters)) {
+    invariant(
+      client.transactionId == null,
+      "Batch actions are not supported for staged edit functions or when supplying a transaction ID",
+    );
     const response = await Actions.applyBatch(
       clientWithHeaders,
       await client.ontologyRid,

--- a/packages/client/src/createClientFromWriteableClient.ts
+++ b/packages/client/src/createClientFromWriteableClient.ts
@@ -17,8 +17,23 @@
 import { additionalContext, type Client } from "./Client.js";
 import { createClientWithTransaction } from "./createClient.js";
 
+/**
+ * Experimental helper method to create a new client instantiated with a transaction id
+ * Will extract the transactionId, URL, Ontology RID, and token from the original client
+ * unless overridden.
+ *
+ * @param writeableClient A client initiated with a transaction id, such as a WriteableClient
+ * @param options A set of options to override from the provided client.
+ * @returns Client instantiated on a transaction
+ */
 export function createClientFromWriteableClient(
   writeableClient: Client,
+  options?: {
+    transactionId?: string;
+    baseUrl?: string;
+    ontologyRid?: string | Promise<string>;
+    tokenProvider?: () => Promise<string>;
+  },
 ): Client {
   const ctx = writeableClient[additionalContext];
 
@@ -29,10 +44,10 @@ export function createClientFromWriteableClient(
   }
 
   return createClientWithTransaction(
-    ctx.transactionId,
+    options?.transactionId ?? ctx.transactionId,
     ctx.flushEdits,
-    ctx.baseUrl,
-    ctx.ontologyRid,
-    ctx.tokenProvider,
+    options?.baseUrl ?? ctx.baseUrl,
+    options?.ontologyRid ?? ctx.ontologyRid,
+    options?.tokenProvider ?? ctx.tokenProvider,
   );
 }


### PR DESCRIPTION
## Summary
- `createClientFromWriteableClient` now accepts an optional `options` argument to override `transactionId`, `baseUrl`, `ontologyRid`, or `tokenProvider` from the source client, so callers can derive a related client without inheriting every field.
- `applyAction` throws an invariant when batch actions are invoked on a client with an active `transactionId`, since batch actions are not supported for staged edit functions.

## Test plan
- [ ] CI passes (typecheck, lint, tests, changeset check)
- [ ] Manual: confirm batch action call on a transactional client now throws with the expected message
- [ ] Manual: confirm `createClientFromWriteableClient(writeable, { baseUrl })` honors the override

🤖 Generated with [Claude Code](https://claude.com/claude-code)