### PR TITLE
[maker-experimental] remove jiti

### DIFF
--- a/.changeset/shaggy-bags-laugh.md
+++ b/.changeset/shaggy-bags-laugh.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker-experimental": patch
+---
+
+remove jiti

--- a/packages/maker-experimental/src/cli/main.ts
+++ b/packages/maker-experimental/src/cli/main.ts
@@ -22,9 +22,9 @@ import { OntologyIrToFullMetadataConverter } from "@osdk/generator-converters.on
 import { PreviewOntologyIrConverter } from "@osdk/generator-converters.preview";
 import { cleanAndValidateLinkTypeId } from "@osdk/maker";
 import { consola } from "consola";
-import { createJiti } from "jiti";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { pathToFileURL } from "node:url";
 import invariant from "tiny-invariant";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
@@ -417,14 +417,7 @@ async function loadOntology(
 ) {
   const result = await defineOntologyV2(
     apiNamespace,
-    async () => {
-      const jiti = createJiti(import.meta.filename, {
-        moduleCache: true,
-        debug: false,
-        importMeta: import.meta,
-      });
-      const module = await jiti.import(input);
-    },
+    async () => await import(pathToFileURL(input).href),
     functionsIrFile,
     randomnessKey,
   );


### PR DESCRIPTION
the theory is our function discovery library does `createRequire(pathToFileURL` resolution on dependencies that messes up jiti's `loadOntology` call