### PR TITLE
Fix convertWireToOsdkObjects test arg order broken by #3275

### DIFF
--- a/.changeset/fix-convert-wire-test-arg-order.md
+++ b/.changeset/fix-convert-wire-test-arg-order.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix test-only regression from #3275: re-order `convertWireToOsdkObjects` args at the `$as` + `$loadPropertySecurityMetadata` test call site so it matches the new parameter order.

--- a/packages/client/src/object/convertWireToOsdkObjects.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.test.ts
@@ -1097,9 +1097,9 @@ describe("convertWireToOsdkObjects", () => {
       client[additionalContext],
       [wireEmployee],
       undefined,
-      false,
       {},
       wireSecurities,
+      false,
     ) as unknown as Osdk.Instance<Employee, "$propertySecurities">[];
 
     const asFoo = holder.$as(FooInterface);


### PR DESCRIPTION
## Summary
- The `$as on an object loaded with $loadPropertySecurityMetadata produces the full interface view…` test was still passing args to `convertWireToOsdkObjects` in the **old** order, despite #3275 reordering the function's parameters.
- With the wrong order, `{}` ended up in the `propertySecurities` slot. Because `{}.length` is `undefined`, the `wirePropertySecurities.length === 0` early-return guard in `parseWhenSecuritiesLoaded` never fired and `securityIndex < undefined` then tripped the `Expected property security index to be within bounds` invariant.
- This is currently the only red test on `main`'s CI (see the failing `Build and Test (18/20/22/24)` jobs).

<img width="1325" height="505" alt="Screenshot 2026-05-15 at 19 51 00" src="https://github.com/user-attachments/assets/04da8040-e92f-43c0-a105-4c2939f9e5e6" />

## Test plan
- [x] `pnpm exec vitest run convertWireToOsdkObjects` → 38/38 passing
- [x] `pnpm turbo typecheck --filter=@osdk/client`
