### PR TITLE
[Component] Fix date picker scroll blocking in editable ObjectTable

### DIFF
--- a/.changeset/fix-date-picker-scroll-blocking.md
+++ b/.changeset/fix-date-picker-scroll-blocking.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Fix page scroll being blocked when opening a date picker in an editable ObjectTable

--- a/.changeset/petite-beers-bet.md
+++ b/.changeset/petite-beers-bet.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+Fix table scroll when date picker is open

--- a/.changeset/petite-beers-bet.md
+++ b/.changeset/petite-beers-bet.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-components": minor
----
-
-Fix table scroll when date picker is open

--- a/packages/react-components/src/object-table/components/DatePickerCellField.tsx
+++ b/packages/react-components/src/object-table/components/DatePickerCellField.tsx
@@ -85,6 +85,7 @@ function DatePickerCellFieldInner({
         value={dateValue}
         onChange={handleChange}
         portalRef={portalRef}
+        modal={false}
       />
       {hasValidationError && (
         <span className={styles.errorIconWrapper}>


### PR DESCRIPTION
## Summary

Follow-up to #3237, which fixed the same bug for dropdowns. The DatePicker's default `modal="trap-focus"` renders a full-viewport `PortalDismissLayer` that intercepts `pointerdown` events. In an editable `ObjectTable` cell, that breaks touch/trackpad scrolling and swallows clicks on the rest of the page while the calendar is open.

- Pass `modal={false}` from `DatePickerCellField` so the dismiss layer isn't rendered for inline cell editing
- `DatePicker` already supports `modal: "trap-focus" | false`; this just opts the table cell out

Before:

https://github.com/user-attachments/assets/b3ccf0ef-f807-4e11-addb-d6162683a724

After:

https://github.com/user-attachments/assets/bf927140-b6fb-4675-8282-3419a48ceda6

