### PR TITLE
fix useLinks crash when source is interface-typed

### DIFF
--- a/.changeset/uselinks-interface-typed-fix.md
+++ b/.changeset/uselinks-interface-typed-fix.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+fix crash when useLinks is called with an interface-typed source object

--- a/packages/client/src/object/convertWireToOsdkObjects/InterfaceHolder.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/InterfaceHolder.ts
@@ -17,7 +17,7 @@
 import type { InterfaceMetadata, ObjectMetadata, Osdk } from "@osdk/api";
 import type { FormatPropertyOptions } from "../formatting/applyPropertyFormatter.js";
 import type { BaseHolder } from "./BaseHolder.js";
-import type { InterfaceDefRef } from "./InternalSymbols.js";
+import { InterfaceDefRef } from "./InternalSymbols.js";
 
 /** @internal */
 export interface InterfaceHolder<
@@ -36,4 +36,9 @@ export interface InterfaceHolder<
     propertyApiName: PropertyApiName,
     options?: FormatPropertyOptions,
   ) => string | undefined;
+}
+
+/** @internal */
+export function isInterfaceHolder(v: unknown): v is InterfaceHolder {
+  return typeof v === "object" && v != null && InterfaceDefRef in v;
 }

--- a/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
@@ -15,11 +15,15 @@
  */
 
 import type { Osdk } from "@osdk/api";
-import { Employee } from "@osdk/client.test.ontology";
+import { Employee, FooInterface } from "@osdk/client.test.ontology";
 import { FauxFoundry, ontologies, startNodeApiServer } from "@osdk/shared.test";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { Client } from "../../../Client.js";
 import { createClient } from "../../../createClient.js";
+import {
+  InterfaceDefRef,
+  ObjectDefRef,
+} from "../../../object/convertWireToOsdkObjects/InternalSymbols.js";
 import type { Canonical } from "../Canonical.js";
 import type { Rdp } from "../RdpCanonicalizer.js";
 import { Store } from "../Store.js";
@@ -652,5 +656,67 @@ describe("ObjectsHelper variant cache keys", () => {
 
     store.cacheKeys.release(queryA.cacheKey);
     store.cacheKeys.release(queryB.cacheKey);
+  });
+});
+
+describe("ObjectsHelper.storeOsdkInstances interface unwrap", () => {
+  let client: Client;
+  let store: Store;
+  let emp: Osdk.Instance<Employee>;
+
+  beforeAll(async () => {
+    const testSetup = startNodeApiServer(
+      new FauxFoundry("https://stack.palantir.com/"),
+      createClient,
+    );
+    client = testSetup.client;
+
+    const fauxOntology = testSetup.fauxFoundry.getDefaultOntology();
+    ontologies.addEmployeeOntology(fauxOntology);
+
+    testSetup.fauxFoundry.getDefaultDataStore().registerObject(Employee, {
+      employeeId: 1,
+      fullName: "Alice",
+    });
+
+    emp = await client(Employee).fetchOne(1, { $includeRid: true });
+
+    return () => {
+      testSetup.apiServer.close();
+    };
+  });
+
+  beforeEach(() => {
+    store = new Store(client);
+    return () => {
+      store = undefined!;
+    };
+  });
+
+  it("unwraps an InterfaceHolder to the underlying ObjectHolder when storing", () => {
+    const ifaceInstance = emp.$as(FooInterface);
+
+    expect(ifaceInstance.$apiName).toBe("FooInterface");
+    expect(ifaceInstance.$objectType).toBe("Employee");
+    expect(InterfaceDefRef in ifaceInstance).toBe(true);
+
+    const cacheKeys = store.batch({}, (batch) => {
+      return store.objects.storeOsdkInstances(
+        [ifaceInstance],
+        batch,
+      );
+    }).retVal;
+
+    expect(cacheKeys).toHaveLength(1);
+
+    const cached = store.getValue(cacheKeys[0])?.value;
+    expect(cached).toBeDefined();
+    if (!cached) {
+      return;
+    }
+    expect(cached.$apiName).toBe("Employee");
+    expect(cached.$objectType).toBe("Employee");
+    expect(cached[ObjectDefRef]).toBeDefined();
+    expect(InterfaceDefRef in cached).toBe(false);
   });
 });

--- a/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
@@ -719,4 +719,49 @@ describe("ObjectsHelper.storeOsdkInstances interface unwrap", () => {
     expect(cached[ObjectDefRef]).toBeDefined();
     expect(InterfaceDefRef in cached).toBe(false);
   });
+
+  it("unwraps an InterfaceHolder when storing through the rdpConfig merge path", () => {
+    // Use an RDP field that is NOT present on the Employee object so the
+    // propagateWrite merge branch runs (actualRdpFields < expectedRdpFields).
+    // The merge path reads objectDef.properties from the incoming holder; if
+    // an InterfaceHolder slips through unwrapped, ObjectDefRef is undefined
+    // and the merge crashes. This test would FAIL on the pre-PR code.
+    const rdpConfig = createFakeRdpConfig("derivedAddress");
+
+    // Seed the cache key for (Employee, pk=1, rdpConfig) with a concrete
+    // Employee value so that the second write goes through the merge branch.
+    const queryEmp = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+    }, rdpConfig);
+    store.batch({}, (batch) => {
+      queryEmp.writeToStore(emp as any, "loaded", batch);
+    });
+
+    const ifaceInstance = emp.$as(FooInterface);
+    expect(InterfaceDefRef in ifaceInstance).toBe(true);
+
+    // Now write the same object via the InterfaceHolder through
+    // storeOsdkInstances with a NON-NULL rdpConfig. This must not throw.
+    const cacheKeys = store.batch({}, (batch) => {
+      return store.objects.storeOsdkInstances(
+        [ifaceInstance],
+        batch,
+        rdpConfig,
+      );
+    }).retVal;
+
+    expect(cacheKeys).toHaveLength(1);
+    expect(cacheKeys[0]).toBe(queryEmp.cacheKey);
+
+    const cached = store.getValue(cacheKeys[0])?.value;
+    expect(cached).toBeDefined();
+    if (!cached) {
+      return;
+    }
+    expect(cached.$apiName).toBe("Employee");
+    expect(cached.$objectType).toBe("Employee");
+    expect(cached[ObjectDefRef]).toBeDefined();
+    expect(InterfaceDefRef in cached).toBe(false);
+  });
 });

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -16,7 +16,11 @@
 
 import type { ObjectOrInterfaceDefinition, Osdk } from "@osdk/api";
 import deepEqual from "fast-deep-equal";
-import { UnderlyingOsdkObject } from "../../../object/convertWireToOsdkObjects/InternalSymbols.js";
+import type { InterfaceHolder } from "../../../object/convertWireToOsdkObjects/InterfaceHolder.js";
+import {
+  InterfaceDefRef,
+  UnderlyingOsdkObject,
+} from "../../../object/convertWireToOsdkObjects/InternalSymbols.js";
 import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
 import { getDefType } from "../../../util/interfaceUtils.js";
 import type { ObjectPayload } from "../../ObjectPayload.js";
@@ -109,14 +113,11 @@ export class ObjectsHelper extends AbstractHelper<
     selectFields?: ReadonlySet<string>,
     includeAllBaseObjectProperties?: boolean,
   ): ObjectCacheKey[] {
-    return values.map(v => {
-      // Interface-typed instances ($apiName ≠ $objectType) are InterfaceHolders.
-      // The cache requires concrete ObjectHolders, so unwrap to the underlying one.
-      const concreteHolder: ObjectHolder = v.$apiName === v.$objectType
-        ? v as ObjectHolder
-        : (v as unknown as { [UnderlyingOsdkObject]: ObjectHolder })[
-          UnderlyingOsdkObject
-        ];
+    const holders = values as Array<ObjectHolder | InterfaceHolder>;
+    return holders.map(v => {
+      const concreteHolder: ObjectHolder = InterfaceDefRef in v
+        ? v[UnderlyingOsdkObject]
+        : v;
 
       return this.getQuery({
         apiName: v.$objectType ?? v.$apiName,

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -17,10 +17,8 @@
 import type { ObjectOrInterfaceDefinition, Osdk } from "@osdk/api";
 import deepEqual from "fast-deep-equal";
 import type { InterfaceHolder } from "../../../object/convertWireToOsdkObjects/InterfaceHolder.js";
-import {
-  InterfaceDefRef,
-  UnderlyingOsdkObject,
-} from "../../../object/convertWireToOsdkObjects/InternalSymbols.js";
+import { isInterfaceHolder } from "../../../object/convertWireToOsdkObjects/InterfaceHolder.js";
+import { UnderlyingOsdkObject } from "../../../object/convertWireToOsdkObjects/InternalSymbols.js";
 import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
 import { getDefType } from "../../../util/interfaceUtils.js";
 import type { ObjectPayload } from "../../ObjectPayload.js";
@@ -116,10 +114,10 @@ export class ObjectsHelper extends AbstractHelper<
     selectFields?: ReadonlySet<string>,
     includeAllBaseObjectProperties?: boolean,
   ): ObjectCacheKey[] {
-    return values.map(v => {
-      const concreteHolder: ObjectHolder = InterfaceDefRef in v
-        ? v[UnderlyingOsdkObject]
-        : (v as ObjectHolder);
+    const holders: ReadonlyArray<ObjectHolder | InterfaceHolder> =
+      values as ReadonlyArray<ObjectHolder | InterfaceHolder>;
+    return holders.map(v => {
+      const concreteHolder = isInterfaceHolder(v) ? v[UnderlyingOsdkObject] : v;
 
       return this.getQuery({
         apiName: v.$objectType ?? v.$apiName,

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -109,18 +109,22 @@ export class ObjectsHelper extends AbstractHelper<
     selectFields?: ReadonlySet<string>,
     includeAllBaseObjectProperties?: boolean,
   ): ObjectCacheKey[] {
-    return values.map(v =>
-      this.getQuery({
+    return values.map(v => {
+      // Interface-typed instances ($apiName ≠ $objectType) are InterfaceHolders.
+      // The cache requires concrete ObjectHolders, so unwrap to the underlying one.
+      const concreteHolder: ObjectHolder = v.$apiName === v.$objectType
+        ? v as ObjectHolder
+        : (v as unknown as { [UnderlyingOsdkObject]: ObjectHolder })[
+          UnderlyingOsdkObject
+        ];
+
+      return this.getQuery({
         apiName: v.$objectType ?? v.$apiName,
         pk: v.$primaryKey,
         $includeAllBaseObjectProperties: includeAllBaseObjectProperties,
-      }, rdpConfig).writeToStore(
-        v as ObjectHolder,
-        "loaded",
-        batch,
-        selectFields,
-      ).cacheKey
-    );
+      }, rdpConfig).writeToStore(concreteHolder, "loaded", batch, selectFields)
+        .cacheKey;
+    });
   }
 
   /**

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -107,17 +107,19 @@ export class ObjectsHelper extends AbstractHelper<
    * @internal
    */
   public storeOsdkInstances(
-    values: Array<ObjectHolder> | Array<Osdk.Instance<any, any, any>>,
+    values:
+      | Array<ObjectHolder>
+      | Array<InterfaceHolder>
+      | Array<Osdk.Instance<any, any, any>>,
     batch: BatchContext,
     rdpConfig?: Canonical<Rdp> | null,
     selectFields?: ReadonlySet<string>,
     includeAllBaseObjectProperties?: boolean,
   ): ObjectCacheKey[] {
-    const holders = values as Array<ObjectHolder | InterfaceHolder>;
-    return holders.map(v => {
+    return values.map(v => {
       const concreteHolder: ObjectHolder = InterfaceDefRef in v
         ? v[UnderlyingOsdkObject]
-        : v;
+        : (v as ObjectHolder);
 
       return this.getQuery({
         apiName: v.$objectType ?? v.$apiName,

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 
+import type { InterfaceMetadata } from "@osdk/api";
 import { describe, expect, it } from "vitest";
 import type { MinimalClient } from "../../../MinimalClientContext.js";
 import { createOsdkObject } from "../../../object/convertWireToOsdkObjects/createOsdkObject.js";
+import type { InterfaceHolder } from "../../../object/convertWireToOsdkObjects/InterfaceHolder.js";
 import {
   ClientRef,
+  InterfaceDefRef,
   ObjectDefRef,
   UnderlyingOsdkObject,
 } from "../../../object/convertWireToOsdkObjects/InternalSymbols.js";
@@ -297,32 +300,32 @@ describe("rdpFieldOperations", () => {
 });
 
 describe("interface-typed object guard", () => {
-  function makeInterfaceHolder(): ObjectHolder {
-    const holder = {
+  function makeInterfaceHolder(): InterfaceHolder {
+    return {
       $apiName: "IEmployee",
       $objectType: "Employee",
       $primaryKey: 1,
       $title: undefined,
       [UnderlyingOsdkObject]: {} as ObjectHolder,
-    } as unknown as ObjectHolder;
-    return holder;
+      [InterfaceDefRef]: {} as InterfaceMetadata,
+    } as InterfaceHolder;
   }
 
   it("mergeObjectFields throws a descriptive error for interface-typed source", () => {
-    const holder = makeInterfaceHolder();
+    const holder = makeInterfaceHolder() as unknown as ObjectHolder;
     expect(() =>
       mergeObjectFields(holder, new Set(["rdpField1"]), new Set(), undefined)
     ).toThrow(
-      `object 'IEmployee' is interface-typed; useLinks requires a concrete-typed source object`,
+      `rdp field operations require a concrete-typed ObjectHolder; received interface-typed 'IEmployee'`,
     );
   });
 
   it("mergeSelectFields throws a descriptive error for interface-typed source", () => {
-    const holder = makeInterfaceHolder();
+    const holder = makeInterfaceHolder() as unknown as ObjectHolder;
     const existing = createTestObject({ employeeId: 1 });
     expect(() => mergeSelectFields(holder, new Set(["fullName"]), existing))
       .toThrow(
-        `object 'IEmployee' is interface-typed; useLinks requires a concrete-typed source object`,
+        `rdp field operations require a concrete-typed ObjectHolder; received interface-typed 'IEmployee'`,
       );
   });
 });

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
@@ -296,6 +296,37 @@ describe("rdpFieldOperations", () => {
   });
 });
 
+describe("interface-typed object guard", () => {
+  function makeInterfaceHolder(): ObjectHolder {
+    const holder = {
+      $apiName: "IEmployee",
+      $objectType: "Employee",
+      $primaryKey: 1,
+      $title: undefined,
+      [UnderlyingOsdkObject]: {} as ObjectHolder,
+    } as unknown as ObjectHolder;
+    return holder;
+  }
+
+  it("mergeObjectFields throws a descriptive error for interface-typed source", () => {
+    const holder = makeInterfaceHolder();
+    expect(() =>
+      mergeObjectFields(holder, new Set(["rdpField1"]), new Set(), undefined)
+    ).toThrow(
+      `object 'IEmployee' is interface-typed; useLinks requires a concrete-typed source object`,
+    );
+  });
+
+  it("mergeSelectFields throws a descriptive error for interface-typed source", () => {
+    const holder = makeInterfaceHolder();
+    const existing = createTestObject({ employeeId: 1 });
+    expect(() => mergeSelectFields(holder, new Set(["fullName"]), existing))
+      .toThrow(
+        `object 'IEmployee' is interface-typed; useLinks requires a concrete-typed source object`,
+      );
+  });
+});
+
 describe("mergeSelectFields", () => {
   it("merges selected fields from source, preserves existing for unselected", () => {
     const source = createTestObject({

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-import type { InterfaceMetadata } from "@osdk/api";
 import { describe, expect, it } from "vitest";
 import type { MinimalClient } from "../../../MinimalClientContext.js";
 import { createOsdkObject } from "../../../object/convertWireToOsdkObjects/createOsdkObject.js";
-import type { InterfaceHolder } from "../../../object/convertWireToOsdkObjects/InterfaceHolder.js";
 import {
   ClientRef,
-  InterfaceDefRef,
   ObjectDefRef,
   UnderlyingOsdkObject,
 } from "../../../object/convertWireToOsdkObjects/InternalSymbols.js";
@@ -296,37 +293,6 @@ describe("rdpFieldOperations", () => {
     expect(underlying.employeeId).toBe(50030);
     expect(underlying.rdpField1).toBe("source-rdp1");
     expect(underlying.rdpField2).toBeUndefined();
-  });
-});
-
-describe("interface-typed object guard", () => {
-  function makeInterfaceHolder(): InterfaceHolder {
-    return {
-      $apiName: "IEmployee",
-      $objectType: "Employee",
-      $primaryKey: 1,
-      $title: undefined,
-      [UnderlyingOsdkObject]: {} as ObjectHolder,
-      [InterfaceDefRef]: {} as InterfaceMetadata,
-    } as InterfaceHolder;
-  }
-
-  it("mergeObjectFields throws a descriptive error for interface-typed source", () => {
-    const holder = makeInterfaceHolder() as unknown as ObjectHolder;
-    expect(() =>
-      mergeObjectFields(holder, new Set(["rdpField1"]), new Set(), undefined)
-    ).toThrow(
-      `rdp field operations require a concrete-typed ObjectHolder; received interface-typed 'IEmployee'`,
-    );
-  });
-
-  it("mergeSelectFields throws a descriptive error for interface-typed source", () => {
-    const holder = makeInterfaceHolder() as unknown as ObjectHolder;
-    const existing = createTestObject({ employeeId: 1 });
-    expect(() => mergeSelectFields(holder, new Set(["fullName"]), existing))
-      .toThrow(
-        `rdp field operations require a concrete-typed ObjectHolder; received interface-typed 'IEmployee'`,
-      );
   });
 });
 

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
@@ -22,6 +22,7 @@ import {
 } from "../../../object/convertWireToOsdkObjects/InternalSymbols.js";
 import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
 import type { SimpleOsdkProperties } from "../../../object/SimpleOsdkProperties.js";
+import type { FetchedObjectTypeDefinition } from "../../../ontology/OntologyProvider.js";
 import type { Canonical } from "../Canonical.js";
 import type { Rdp } from "../RdpCanonicalizer.js";
 
@@ -34,6 +35,30 @@ export function extractRdpFieldNames(
   return new Set(Object.keys(rdpConfig));
 }
 
+/**
+ * Throws a clear, actionable error if `objectDef` is undefined. The RDP merge
+ * path operates on concrete `ObjectHolder`s only; if an `InterfaceHolder` ever
+ * leaks through without being unwrapped via `storeOsdkInstances`, the missing
+ * ObjectDefRef would surface as a confusing "cannot read property 'properties'
+ * of undefined" crash. Use this helper to gate access to `objectDef.properties`
+ * so the failure mode names the actual invariant violation.
+ */
+export function requireObjectDef(
+  objectDef: FetchedObjectTypeDefinition | undefined,
+  instance: { $apiName?: string; $objectType?: string },
+): FetchedObjectTypeDefinition {
+  if (objectDef === undefined) {
+    throw new Error(
+      `Internal invariant violated: missing ObjectDefRef for $apiName=${
+        instance.$apiName ?? "?"
+      } $objectType=${instance.$objectType ?? "?"}. `
+        + `This likely means an InterfaceHolder leaked into the RDP merge path `
+        + `without being unwrapped via storeOsdkInstances.`,
+    );
+  }
+  return objectDef;
+}
+
 function stripRdpFields(
   value: ObjectHolder,
   rdpFields: ReadonlySet<string>,
@@ -43,7 +68,7 @@ function stripRdpFields(
   }
 
   const underlying = value[UnderlyingOsdkObject] as SimpleOsdkProperties;
-  const objectDef = value[ObjectDefRef];
+  const objectDef = requireObjectDef(value[ObjectDefRef], underlying);
 
   const newProps: SimpleOsdkProperties = {
     $apiName: underlying.$apiName,
@@ -80,7 +105,7 @@ function filterToRdpFields(
   sourceRdpFields: ReadonlySet<string>,
 ): ObjectHolder {
   const underlying = value[UnderlyingOsdkObject] as SimpleOsdkProperties;
-  const objectDef = value[ObjectDefRef];
+  const objectDef = requireObjectDef(value[ObjectDefRef], underlying);
 
   const newProps: SimpleOsdkProperties = {
     $apiName: underlying.$apiName,
@@ -111,7 +136,10 @@ export function mergeSelectFields(
     sourceValue[UnderlyingOsdkObject] as SimpleOsdkProperties;
   const existingUnderlying =
     existingValue[UnderlyingOsdkObject] as SimpleOsdkProperties;
-  const objectDef = sourceValue[ObjectDefRef];
+  const objectDef = requireObjectDef(
+    sourceValue[ObjectDefRef],
+    sourceUnderlying,
+  );
 
   const newProps: SimpleOsdkProperties = {
     $apiName: sourceUnderlying.$apiName,
@@ -155,7 +183,10 @@ export function mergeObjectFields(
 
   const sourceUnderlying =
     sourceValue[UnderlyingOsdkObject] as SimpleOsdkProperties;
-  const objectDef = sourceValue[ObjectDefRef];
+  const objectDef = requireObjectDef(
+    sourceValue[ObjectDefRef],
+    sourceUnderlying,
+  );
 
   const newProps: SimpleOsdkProperties = {
     $apiName: sourceUnderlying.$apiName,

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
@@ -39,7 +39,7 @@ function requireObjectDef(value: ObjectHolder): FetchedObjectTypeDefinition {
   const def = value[ObjectDefRef];
   if (!def) {
     throw new Error(
-      `object '${value.$apiName}' is interface-typed; useLinks requires a concrete-typed source object`,
+      `rdp field operations require a concrete-typed ObjectHolder; received interface-typed '${value.$apiName}'`,
     );
   }
   return def;

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
@@ -22,6 +22,7 @@ import {
 } from "../../../object/convertWireToOsdkObjects/InternalSymbols.js";
 import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
 import type { SimpleOsdkProperties } from "../../../object/SimpleOsdkProperties.js";
+import type { FetchedObjectTypeDefinition } from "../../../ontology/OntologyProvider.js";
 import type { Canonical } from "../Canonical.js";
 import type { Rdp } from "../RdpCanonicalizer.js";
 
@@ -34,6 +35,16 @@ export function extractRdpFieldNames(
   return new Set(Object.keys(rdpConfig));
 }
 
+function requireObjectDef(value: ObjectHolder): FetchedObjectTypeDefinition {
+  const def = value[ObjectDefRef];
+  if (!def) {
+    throw new Error(
+      `object '${value.$apiName}' is interface-typed; useLinks requires a concrete-typed source object`,
+    );
+  }
+  return def;
+}
+
 function stripRdpFields(
   value: ObjectHolder,
   rdpFields: ReadonlySet<string>,
@@ -43,7 +54,7 @@ function stripRdpFields(
   }
 
   const underlying = value[UnderlyingOsdkObject] as SimpleOsdkProperties;
-  const objectDef = value[ObjectDefRef];
+  const objectDef = requireObjectDef(value);
 
   const newProps: SimpleOsdkProperties = {
     $apiName: underlying.$apiName,
@@ -80,7 +91,7 @@ function filterToRdpFields(
   sourceRdpFields: ReadonlySet<string>,
 ): ObjectHolder {
   const underlying = value[UnderlyingOsdkObject] as SimpleOsdkProperties;
-  const objectDef = value[ObjectDefRef];
+  const objectDef = requireObjectDef(value);
 
   const newProps: SimpleOsdkProperties = {
     $apiName: underlying.$apiName,
@@ -111,7 +122,7 @@ export function mergeSelectFields(
     sourceValue[UnderlyingOsdkObject] as SimpleOsdkProperties;
   const existingUnderlying =
     existingValue[UnderlyingOsdkObject] as SimpleOsdkProperties;
-  const objectDef = sourceValue[ObjectDefRef];
+  const objectDef = requireObjectDef(sourceValue);
 
   const newProps: SimpleOsdkProperties = {
     $apiName: sourceUnderlying.$apiName,
@@ -155,7 +166,7 @@ export function mergeObjectFields(
 
   const sourceUnderlying =
     sourceValue[UnderlyingOsdkObject] as SimpleOsdkProperties;
-  const objectDef = sourceValue[ObjectDefRef];
+  const objectDef = requireObjectDef(sourceValue);
 
   const newProps: SimpleOsdkProperties = {
     $apiName: sourceUnderlying.$apiName,

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
@@ -22,7 +22,6 @@ import {
 } from "../../../object/convertWireToOsdkObjects/InternalSymbols.js";
 import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
 import type { SimpleOsdkProperties } from "../../../object/SimpleOsdkProperties.js";
-import type { FetchedObjectTypeDefinition } from "../../../ontology/OntologyProvider.js";
 import type { Canonical } from "../Canonical.js";
 import type { Rdp } from "../RdpCanonicalizer.js";
 
@@ -35,16 +34,6 @@ export function extractRdpFieldNames(
   return new Set(Object.keys(rdpConfig));
 }
 
-function requireObjectDef(value: ObjectHolder): FetchedObjectTypeDefinition {
-  const def = value[ObjectDefRef];
-  if (!def) {
-    throw new Error(
-      `rdp field operations require a concrete-typed ObjectHolder; received interface-typed '${value.$apiName}'`,
-    );
-  }
-  return def;
-}
-
 function stripRdpFields(
   value: ObjectHolder,
   rdpFields: ReadonlySet<string>,
@@ -54,7 +43,7 @@ function stripRdpFields(
   }
 
   const underlying = value[UnderlyingOsdkObject] as SimpleOsdkProperties;
-  const objectDef = requireObjectDef(value);
+  const objectDef = value[ObjectDefRef];
 
   const newProps: SimpleOsdkProperties = {
     $apiName: underlying.$apiName,
@@ -91,7 +80,7 @@ function filterToRdpFields(
   sourceRdpFields: ReadonlySet<string>,
 ): ObjectHolder {
   const underlying = value[UnderlyingOsdkObject] as SimpleOsdkProperties;
-  const objectDef = requireObjectDef(value);
+  const objectDef = value[ObjectDefRef];
 
   const newProps: SimpleOsdkProperties = {
     $apiName: underlying.$apiName,
@@ -122,7 +111,7 @@ export function mergeSelectFields(
     sourceValue[UnderlyingOsdkObject] as SimpleOsdkProperties;
   const existingUnderlying =
     existingValue[UnderlyingOsdkObject] as SimpleOsdkProperties;
-  const objectDef = requireObjectDef(sourceValue);
+  const objectDef = sourceValue[ObjectDefRef];
 
   const newProps: SimpleOsdkProperties = {
     $apiName: sourceUnderlying.$apiName,
@@ -166,7 +155,7 @@ export function mergeObjectFields(
 
   const sourceUnderlying =
     sourceValue[UnderlyingOsdkObject] as SimpleOsdkProperties;
-  const objectDef = requireObjectDef(sourceValue);
+  const objectDef = sourceValue[ObjectDefRef];
 
   const newProps: SimpleOsdkProperties = {
     $apiName: sourceUnderlying.$apiName,


### PR DESCRIPTION
InterfaceHolder instances were silently cast to ObjectHolder in storeOsdkInstances, leaving [ObjectDefRef] unset. When RDP field merging then accessed objectDef.properties it crashed with a cryptic TypeError instead of a useful error.

• unwrap InterfaceHolder to its underlying concrete ObjectHolder in storeOsdkInstances — fixes the root cause at the point of cache entry
• add requireObjectDef helper in rdpFieldOperations so any future interface-typed object that reaches these functions throws a clear, actionable error