### PR TITLE
fix misleading patterns in @osdk/react and react-components docs

### DIFF
--- a/.changeset/fix-docs-snippets-imports.md
+++ b/.changeset/fix-docs-snippets-imports.md
@@ -1,0 +1,16 @@
+---
+"@osdk/react-sdk-docs": patch
+"@osdk/react-components": patch
+"@osdk/cbac-components": patch
+---
+
+Fix misleading patterns in @osdk/react and @osdk/react-components docs that were confusing downstream coding agents and humans alike.
+
+• react-sdk-docs `reactProviderSetup` and `clientSetup` snippets now pass a real ontology RID placeholder to `createClient` instead of `{{{packageName}}}` (which resolves to the npm SDK package name, not the ontology RID)
+• Stop pretending `$` is exported from the user's SDK — `$` is a local alias users sometimes create; docs now use `client(Type)` directly, matching the pattern already used in getting-started.md / cache-management.md
+• Standardize the SDK placeholder on `@my/osdk` across all docs (was a mix of `@my/osdk`, `@YourApp/sdk`, `@your-app/sdk`) and add a `:::note About @my/osdk` callout to each react-components doc that imports from it
+• Fix several broken/missing imports in code snippets: `cache-management.md` setup block was using `createClient` / `createObservableClient` / `authProvider` without importing or defining any of them; `advanced-queries.md` derived-property fragments were missing `Employee` and `useOsdkObjects` imports
+• Fix `querying-data.md` self-referential typo "_Stable - available from both `@osdk/react` and `@osdk/react`_" → second should be `@osdk/react/experimental`
+• Fix `advanced-queries.md` duplicate `const { data }` declaration that would not compile
+• Remove unused `useOsdkObject` import from one `advanced-queries.md` snippet
+• Install commands now show npm / pnpm / yarn alternatives with a tip block recommending users skip the step if their tooling already installs dependencies — fixes Pilot running `pnpm` in npm-managed projects and the install-race-with-harness issue

--- a/docs/react/advanced-queries.md
+++ b/docs/react/advanced-queries.md
@@ -24,38 +24,40 @@ Prefer `useOsdkObjects` when both hooks would work. Both support filtering, sort
 Note that `pivotTo` and `streamUpdates` cannot be combined — see the note below.
 
 ```tsx
-import { $, Todo } from "@my/osdk";
+import { Todo } from "@my/osdk";
 import { useObjectSet, useOsdkObjects } from "@osdk/react";
+import client from "./client";
 
 // Simple query - use useOsdkObjects
-const { data } = useOsdkObjects(Todo, {
+const { data: simpleData } = useOsdkObjects(Todo, {
   where: { isComplete: false },
   orderBy: { createdAt: "desc" },
 });
 
 // Set operations - use useObjectSet
-const urgentTodos = $(Todo).where({ isUrgent: true });
-const completedTodos = $(Todo).where({ isComplete: true });
+const urgentTodos = client(Todo).where({ isUrgent: true });
+const completedTodos = client(Todo).where({ isComplete: true });
 
-const { data } = useObjectSet($(Todo), {
+const { data: setData } = useObjectSet(client(Todo), {
   union: [urgentTodos],
   subtract: [completedTodos],
 });
 ```
 
-:::note The `$` function
-The `$` function from your generated SDK creates an ObjectSet from an object type. `$(Todo)` creates an ObjectSet containing all Todo objects that you can then filter, union, intersect, or subtract with other ObjectSets.
+:::note Building ObjectSets
+Call your OSDK client with an object type — `client(Todo)` — to create an `ObjectSet`. You can then filter, union, intersect, or subtract it before passing it to `useObjectSet`. The `client` here is whatever you exported from `createClient(...)` in your app (`./client` in these examples).
 :::
 
 ### Basic Usage
 
 ```tsx
-import { $, Todo } from "@my/osdk";
+import { Todo } from "@my/osdk";
 import { useObjectSet } from "@osdk/react";
+import client from "./client";
 
 function TodosWithSetOperations() {
-  const allTodos = $(Todo);
-  const completedTodos = $(Todo).where({ isComplete: true });
+  const allTodos = client(Todo);
+  const completedTodos = client(Todo).where({ isComplete: true });
 
   const { data, isLoading, fetchMore } = useObjectSet(allTodos, {
     subtract: [completedTodos],
@@ -83,12 +85,13 @@ function TodosWithSetOperations() {
 Combine multiple object sets:
 
 ```tsx
-import { $, Todo } from "@my/osdk";
+import { Todo } from "@my/osdk";
 import { useObjectSet } from "@osdk/react";
+import client from "./client";
 
 function CombinedTodoQuery() {
-  const highPriorityTodos = $(Todo).where({ priority: "high" });
-  const urgentTodos = $(Todo).where({ isUrgent: true });
+  const highPriorityTodos = client(Todo).where({ priority: "high" });
+  const urgentTodos = client(Todo).where({ isUrgent: true });
 
   const { data } = useObjectSet(highPriorityTodos, {
     union: [urgentTodos], // High priority OR urgent
@@ -103,12 +106,13 @@ function CombinedTodoQuery() {
 Find objects that exist in all sets:
 
 ```tsx
-import { $, Todo } from "@my/osdk";
+import { Todo } from "@my/osdk";
 import { useObjectSet } from "@osdk/react";
+import client from "./client";
 
 function StarredAndIncompleteTodos() {
-  const starred = $(Todo).where({ isStarred: true });
-  const incomplete = $(Todo).where({ isComplete: false });
+  const starred = client(Todo).where({ isStarred: true });
+  const incomplete = client(Todo).where({ isComplete: false });
 
   const { data } = useObjectSet(starred, {
     intersect: [incomplete],
@@ -128,12 +132,13 @@ function StarredAndIncompleteTodos() {
 Remove objects that exist in another set:
 
 ```tsx
-import { $, Todo } from "@my/osdk";
+import { Todo } from "@my/osdk";
 import { useObjectSet } from "@osdk/react";
+import client from "./client";
 
 function ActiveTodos() {
-  const allTodos = $(Todo);
-  const completedTodos = $(Todo).where({ isComplete: true });
+  const allTodos = client(Todo);
+  const completedTodos = client(Todo).where({ isComplete: true });
 
   const { data } = useObjectSet(allTodos, {
     subtract: [completedTodos],
@@ -146,13 +151,14 @@ function ActiveTodos() {
 #### Combined Operations
 
 ```tsx
-import { $, Todo } from "@my/osdk";
+import { Todo } from "@my/osdk";
 import { useObjectSet } from "@osdk/react";
+import client from "./client";
 
 function ComplexTodoQuery() {
-  const highPriorityTodos = $(Todo).where({ priority: "high" });
-  const urgentTodos = $(Todo).where({ isUrgent: true });
-  const completedTodos = $(Todo).where({ isComplete: true });
+  const highPriorityTodos = client(Todo).where({ priority: "high" });
+  const urgentTodos = client(Todo).where({ isUrgent: true });
+  const completedTodos = client(Todo).where({ isComplete: true });
 
   const { data } = useObjectSet(highPriorityTodos, {
     union: [urgentTodos], // High priority OR urgent
@@ -168,13 +174,14 @@ function ComplexTodoQuery() {
 Navigate to linked objects:
 
 ```tsx
-import { $, Employee } from "@my/osdk";
+import { Employee } from "@my/osdk";
 import { useObjectSet } from "@osdk/react";
+import client from "./client";
 
 function EmployeeDepartments(
   { employee }: { employee: Employee.OsdkInstance },
 ) {
-  const employeeSet = $(Employee).where({ id: employee.id });
+  const employeeSet = client(Employee).where({ id: employee.id });
 
   const { data } = useObjectSet(employeeSet, {
     pivotTo: "department",
@@ -191,10 +198,11 @@ function EmployeeDepartments(
 ### Auto-Fetching and Streaming
 
 ```tsx
-import { $, Todo } from "@my/osdk";
+import { Todo } from "@my/osdk";
 import { useObjectSet } from "@osdk/react";
+import client from "./client";
 
-const { data, isLoading } = useObjectSet($(Todo), {
+const { data, isLoading } = useObjectSet(client(Todo), {
   where: { isComplete: false },
   autoFetchMore: 200, // Fetch at least 200 items
   streamUpdates: true, // Real-time WebSocket updates
@@ -283,7 +291,9 @@ For numeric aggregates (`sum`, `avg`, `min`, `max`) over an empty result set, th
 ### Advanced Examples
 
 ```tsx
+import { Employee } from "@my/osdk";
 import type { DerivedProperty } from "@osdk/client";
+import { useOsdkObjects } from "@osdk/react";
 
 const { data } = useOsdkObjects(Employee, {
   where: { department: "Engineering" },
@@ -306,7 +316,9 @@ const { data } = useOsdkObjects(Employee, {
 You can filter on derived properties in your where clause:
 
 ```tsx
+import { Employee } from "@my/osdk";
 import type { DerivedProperty } from "@osdk/client";
+import { useOsdkObjects } from "@osdk/react";
 
 const { data } = useOsdkObjects(Employee, {
   withProperties: {
@@ -397,7 +409,7 @@ For finer-grained control, depend on specific object instances:
 
 ```tsx
 import { Employee, getEmployeeReport } from "@my/osdk";
-import { useOsdkFunction, useOsdkObject } from "@osdk/react";
+import { useOsdkFunction } from "@osdk/react";
 
 function EmployeeReport({ employee }: { employee: Employee.OsdkInstance }) {
   const { data, isLoading } = useOsdkFunction(getEmployeeReport, {

--- a/docs/react/cache-management.md
+++ b/docs/react/cache-management.md
@@ -85,38 +85,6 @@ Automatic updates don't cover:
 
 The `ObservableClient` provides methods to manually invalidate cached data.
 
-### Setup
-
-`OsdkProvider` creates its own `ObservableClient` internally — you only need to construct one yourself if you want to call invalidation methods (`invalidateObjects`, `invalidateObjectType`, `invalidateFunction`, …) from outside the React tree (for example, from a WebSocket handler in `client.ts`). In that case, create one and pass it explicitly so React and your handler share the same cache:
-
-```tsx
-// client.ts
-import { createClient } from "@osdk/client";
-import { createObservableClient } from "@osdk/client/observable";
-
-const client = createClient(
-  "https://your-stack.palantirfoundry.com",
-  "ri.ontology.main.ontology.00000000-0000-0000-0000-000000000000",
-  async () => "your-token",
-);
-
-// Create and export the observable client for invalidation
-export const observableClient = createObservableClient(client);
-export { client };
-```
-
-```tsx
-// main.tsx
-import { OsdkProvider } from "@osdk/react";
-import { client, observableClient } from "./client";
-
-ReactDOM.createRoot(document.getElementById("root")!).render(
-  <OsdkProvider client={client} observableClient={observableClient}>
-    <App />
-  </OsdkProvider>,
-);
-```
-
 ### Invalidation Methods
 
 #### Object Invalidation

--- a/docs/react/cache-management.md
+++ b/docs/react/cache-management.md
@@ -90,13 +90,14 @@ The `ObservableClient` provides methods to manually invalidate cached data.
 `OsdkProvider` creates its own `ObservableClient` internally — you only need to construct one yourself if you want to call invalidation methods (`invalidateObjects`, `invalidateObjectType`, `invalidateFunction`, …) from outside the React tree (for example, from a WebSocket handler in `client.ts`). In that case, create one and pass it explicitly so React and your handler share the same cache:
 
 ```tsx
-import { Todo } from "@my/osdk";
-import { useObservableClient } from "@osdk/react";
+// client.ts
+import { createClient } from "@osdk/client";
+import { createObservableClient } from "@osdk/client/observable";
 
 const client = createClient(
   "https://your-stack.palantirfoundry.com",
-  "your-ontology-rid",
-  authProvider,
+  "ri.ontology.main.ontology.00000000-0000-0000-0000-000000000000",
+  async () => "your-token",
 );
 
 // Create and export the observable client for invalidation

--- a/docs/react/getting-started.md
+++ b/docs/react/getting-started.md
@@ -10,8 +10,20 @@ This guide covers installation, setup, and your first OSDK React application.
 
 ### 1. Install `@osdk/react`
 
+:::tip If your tooling already installs dependencies, skip this step.
+:::
+
+Use whichever package manager your project uses:
+
 ```bash
+# npm
 npm install @osdk/api @osdk/client @osdk/react
+
+# pnpm
+pnpm add @osdk/api @osdk/client @osdk/react
+
+# yarn
+yarn add @osdk/api @osdk/client @osdk/react
 ```
 
 :::warning Version Compatibility
@@ -36,7 +48,7 @@ If you haven't generated an SDK yet:
 ```json
 {
   "dependencies": {
-    "@your-app/sdk": "^0.4.0"
+    "@my/osdk": "^0.4.0"
   }
 }
 ```

--- a/docs/react/prerequisites.md
+++ b/docs/react/prerequisites.md
@@ -8,9 +8,20 @@ Setup required before using `@osdk/react` hooks.
 
 ## Install dependencies
 
+:::tip If your tooling already installs dependencies, skip this step.
+:::
+
+Use whichever package manager your project uses:
+
 ```bash
-npm install @osdk/api @osdk/client @osdk/react
-npm install react react-dom
+# npm
+npm install @osdk/api @osdk/client @osdk/react react react-dom
+
+# pnpm
+pnpm add @osdk/api @osdk/client @osdk/react react react-dom
+
+# yarn
+yarn add @osdk/api @osdk/client @osdk/react react react-dom
 ```
 
 ## Configure the OSDK client

--- a/docs/react/prerequisites.md
+++ b/docs/react/prerequisites.md
@@ -34,7 +34,7 @@ import { OsdkProvider } from "@osdk/react";
 
 const client = createClient(
   "https://your-stack.palantirfoundry.com",
-  "ri.ontology.main.ontology.00000000-0000-0000-0000-000000000000",
+  "ri.ontology.main.ontology.{UUID}",
   async () => {
     // return your auth token
   },

--- a/docs/react/querying-data.md
+++ b/docs/react/querying-data.md
@@ -639,7 +639,7 @@ const { links } = useLinks(employee, "reports", {
 
 ## useOsdkClient
 
-_Stable - available from both `@osdk/react` and `@osdk/react`_
+_Stable - available from both `@osdk/react` and `@osdk/react/experimental`_
 
 Access the OSDK client directly for custom queries.
 

--- a/packages/cbac-components/README.md
+++ b/packages/cbac-components/README.md
@@ -8,14 +8,32 @@ These components are OSDK-aware — pass in marking IDs, and they handle data lo
 
 ## Installation
 
+> If your tooling already installs dependencies, skip this section.
+
+Use whichever package manager your project uses:
+
 ```sh
+# npm
 npm install @osdk/cbac-components@beta
+
+# pnpm
+pnpm add @osdk/cbac-components@beta
+
+# yarn
+yarn add @osdk/cbac-components@beta
 ```
 
 **Peer Dependencies:**
 
 ```sh
+# npm
 npm install react react-dom classnames @osdk/react @osdk/react-components
+
+# pnpm
+pnpm add react react-dom classnames @osdk/react @osdk/react-components
+
+# yarn
+yarn add react react-dom classnames @osdk/react @osdk/react-components
 ```
 
 - `react`, `@types/react`, `react-dom` - React 17, 18, or 19

--- a/packages/react-components/docs/ActionForm.md
+++ b/packages/react-components/docs/ActionForm.md
@@ -22,9 +22,13 @@ import type { FormFieldDefinition } from "@osdk/react-components/experimental";
 
 ## Basic Usage
 
+:::note About `@my/osdk` and `./client`
+`@my/osdk` is a placeholder for **your generated SDK package** (e.g. `@your-app/sdk`). `./client` (used in scoped object-select examples below) is the file in your app where you exported the OSDK client returned by `createClient(...)`. Replace both with the actual paths in your project.
+:::
+
 ```tsx
+import { updateEmployee } from "@my/osdk";
 import { ActionForm } from "@osdk/react-components/experimental";
-import { updateEmployee } from "@YourApp/sdk";
 
 function UpdateEmployeeForm() {
   return <ActionForm actionDefinition={updateEmployee} />;
@@ -124,12 +128,13 @@ const fields = [
 `OBJECT_SELECT` can load options from either an object type or a pre-scoped object set. Pass `objectType` for an unfiltered selector, or pass `objectSet` to limit selectable options. The two are mutually exclusive. Search text is applied within the object set, and the current value is not automatically cleared when it is outside that set.
 
 ```tsx
-import { $, Employee, updateEmployee } from "@YourApp/sdk";
+import { Employee, updateEmployee } from "@my/osdk";
 import { useMemo } from "react";
+import client from "./client";
 
 function UpdateEmployeeForm() {
   const marketingEmployees = useMemo(
-    () => $(Employee).where({ department: "Marketing" }),
+    () => client(Employee).where({ department: "Marketing" }),
     [],
   );
 

--- a/packages/react-components/docs/FilterList.md
+++ b/packages/react-components/docs/FilterList.md
@@ -28,17 +28,21 @@ import { FilterList } from "@osdk/react-components/experimental/filter-list";
 
 ## Basic Usage
 
+:::note About `@my/osdk` and `./client`
+`@my/osdk` is a placeholder for **your generated SDK package** (e.g. `@your-app/sdk`). `./client` is the file in your app where you exported the OSDK client returned by `createClient(...)`. Replace both with the actual paths in your project.
+:::
+
 The simplest way to use FilterList is with an objectSet and a few filter definitions:
 
 ```typescript
+import { Employee } from "@my/osdk";
 import { FilterList } from "@osdk/react-components/experimental/filter-list";
-import { Employee } from "@YourApp/sdk";
-import { $ } from "@YourApp/sdk";
+import client from "./client";
 
 function EmployeeFilters() {
   return (
     <FilterList
-      objectSet={$(Employee)}
+      objectSet={client(Employee)}
       filterDefinitions={[
         {
           type: "PROPERTY",
@@ -156,18 +160,18 @@ When using `type: "PROPERTY"` or `type: "LINKED_PROPERTY"`, specify a `filterCom
 Use controlled `filterClause` to connect FilterList and ObjectTable:
 
 ```typescript
+import { Employee } from "@my/osdk";
 import type { WhereClause } from "@osdk/api";
 import { FilterList } from "@osdk/react-components/experimental/filter-list";
 import { ObjectTable } from "@osdk/react-components/experimental/object-table";
-import { Employee } from "@YourApp/sdk";
-import { $ } from "@YourApp/sdk";
 import { useMemo, useState } from "react";
+import client from "./client";
 
 function EmployeeDashboard() {
   const [filterClause, setFilterClause] = useState<
     WhereClause<typeof Employee>
   >({});
-  const objectSet = useMemo(() => $(Employee), []);
+  const objectSet = useMemo(() => client(Employee), []);
 
   return (
     <div style={{ display: "flex", gap: 16, height: 600 }}>
@@ -242,7 +246,7 @@ const filterDefinitions = [
 ];
 
 <FilterList
-  objectSet={$(Employee)}
+  objectSet={client(Employee)}
   filterDefinitions={filterDefinitions}
   addFilterMode="uncontrolled"
   showResetButton={true}
@@ -263,7 +267,7 @@ const handleFilterRemoved = (filterKey) => {
 };
 
 <FilterList
-  objectSet={$(Employee)}
+  objectSet={client(Employee)}
   filterDefinitions={definitions}
   addFilterMode="controlled"
   onFilterRemoved={handleFilterRemoved}
@@ -276,14 +280,14 @@ const handleFilterRemoved = (filterKey) => {
 Pass a `.where()` objectSet to scope filter dropdown values. For example, to only show Engineering employees:
 
 ```typescript
+import { Employee } from "@my/osdk";
 import { FilterList } from "@osdk/react-components/experimental/filter-list";
-import { Employee } from "@YourApp/sdk";
-import { $ } from "@YourApp/sdk";
 import { useMemo } from "react";
+import client from "./client";
 
 function EngineeringFilters() {
   const engineeringSet = useMemo(
-    () => $(Employee).where({ department: "Engineering" }),
+    () => client(Employee).where({ department: "Engineering" }),
     [],
   );
 
@@ -316,7 +320,10 @@ const filterDefinitions = [
   { type: "PROPERTY", key: "locationCity", filterComponent: "LISTOGRAM" },
 ];
 
-<FilterList objectSet={$(Employee)} filterDefinitions={filterDefinitions} />;
+<FilterList
+  objectSet={client(Employee)}
+  filterDefinitions={filterDefinitions}
+/>;
 ```
 
 ### Custom Listogram Colors
@@ -325,7 +332,7 @@ Assign colors to specific values in a listogram:
 
 ```typescript
 <FilterList
-  objectSet={$(Employee)}
+  objectSet={client(Employee)}
   filterDefinitions={[
     {
       type: "PROPERTY",
@@ -353,7 +360,7 @@ const USER_NAMES: Record<string, string> = {
 };
 
 <FilterList
-  objectSet={$(Task)}
+  objectSet={client(Task)}
   filterDefinitions={[
     {
       type: "PROPERTY",
@@ -379,7 +386,7 @@ Control how much detail each listogram row shows:
 // "minimal": checkbox + label only
 
 <FilterList
-  objectSet={$(Employee)}
+  objectSet={client(Employee)}
   filterDefinitions={[
     {
       type: "PROPERTY",
@@ -397,7 +404,7 @@ By default, LISTOGRAM filters show at most 5 items with a "View all" link. Overr
 
 ```typescript
 <FilterList
-  objectSet={$(Employee)}
+  objectSet={client(Employee)}
   filterDefinitions={[
     {
       type: "PROPERTY",
@@ -421,7 +428,7 @@ function CollapsibleFilters() {
 
   return (
     <FilterList
-      objectSet={$(Employee)}
+      objectSet={client(Employee)}
       title="Filters"
       collapsed={collapsed}
       onCollapsedChange={setCollapsed}
@@ -440,7 +447,7 @@ Enable reordering of filters via drag and drop:
 
 ```typescript
 <FilterList
-  objectSet={$(Employee)}
+  objectSet={client(Employee)}
   filterDefinitions={filterDefinitions}
   enableSorting={true}
 />;
@@ -454,7 +461,7 @@ LISTOGRAM and TEXT_TAGS filters support an exclude/include toggle. Hover a filte
 // Exclude mode is built into LISTOGRAM filters automatically.
 // Users access it via the overflow menu (three dots) on each filter item.
 <FilterList
-  objectSet={$(Employee)}
+  objectSet={client(Employee)}
   filterDefinitions={[
     {
       type: "PROPERTY",
@@ -487,7 +494,7 @@ Use the `className` prop for scoped styling:
 
 ```typescript
 <FilterList
-  objectSet={$(Employee)}
+  objectSet={client(Employee)}
   className="my-custom-filters"
   filterDefinitions={[...]}
 />
@@ -499,6 +506,6 @@ For a full reference of CSS tokens, see the [CSS Variables documentation](./CSSV
 
 - **Memoize filterDefinitions** -- define the array outside the component or wrap in `useMemo` to avoid unnecessary re-renders
 - **Use controlled mode for persistence** -- provide `filterClause` and `onFilterClauseChanged` to persist filter state across navigation
-- **Use objectSet constraints to scope filter values** -- pass a prefiltered objectSet (e.g. `$(Employee).where(...)`) so filter dropdowns only show relevant values
+- **Use objectSet constraints to scope filter values** -- pass a prefiltered objectSet (e.g. `client(Employee).where(...)`) so filter dropdowns only show relevant values
 - **Keep filter lists focused** -- show 3-8 filters; too many filters overwhelm users
 - **Use `addFilterMode="uncontrolled"` for progressive disclosure** -- start with a few visible filters and let users add more as needed

--- a/packages/react-components/docs/ObjectTable.md
+++ b/packages/react-components/docs/ObjectTable.md
@@ -34,13 +34,17 @@ import type {
 
 ## Basic Usage
 
+:::note About `@my/osdk`
+`@my/osdk` is a placeholder for **your generated SDK package** (e.g. `@your-app/sdk`). Replace it with the actual package name in your project.
+:::
+
 ### Minimal Example
 
 The simplest way to use ObjectTable is with just an object type:
 
 ```typescript
+import { Office } from "@my/osdk";
 import { ObjectTable } from "@osdk/react-components/experimental/object-table";
-import { Office } from "@YourApp/sdk";
 
 function OfficesPage() {
   return (
@@ -310,11 +314,11 @@ Displays header and cell with the provided custom renderers.
 ### Example 1: Basic Table with Custom Column Definitions
 
 ```typescript
+import { Employee } from "@my/osdk";
 import {
   type ColumnDefinition,
   ObjectTable,
 } from "@osdk/react-components/experimental/object-table";
-import { Employee } from "@YourApp/sdk";
 
 const columnDefinitions: Array<ColumnDefinition<typeof Employee>> = [
   {
@@ -347,8 +351,8 @@ function EmployeesTable() {
 ### Example 2: Table with Multiple Selection
 
 ```typescript
+import { Employee } from "@my/osdk";
 import { ObjectTable } from "@osdk/react-components/experimental/object-table";
-import { Employee } from "@YourApp/sdk";
 
 function EmployeesTable() {
   return (
@@ -363,8 +367,8 @@ function EmployeesTable() {
 ### Example 3: Table with Default Sorting
 
 ```typescript
+import { Employee } from "@my/osdk";
 import { ObjectTable } from "@osdk/react-components/experimental/object-table";
-import { Employee } from "@YourApp/sdk";
 
 function EmployeesTable() {
   return (
@@ -382,11 +386,11 @@ function EmployeesTable() {
 ### Example 4: Custom Cell Rendering
 
 ```typescript
+import { Employee } from "@my/osdk";
 import {
   type ColumnDefinition,
   ObjectTable,
 } from "@osdk/react-components/experimental/object-table";
-import { Employee } from "@YourApp/sdk";
 
 const columnDefinitions: Array<ColumnDefinition<typeof Employee>> = [
   {
@@ -419,11 +423,11 @@ function EmployeesTable() {
 ### Example 5: Custom Header Rendering
 
 ```typescript
+import { Employee } from "@my/osdk";
 import {
   type ColumnDefinition,
   ObjectTable,
 } from "@osdk/react-components/experimental/object-table";
-import { Employee } from "@YourApp/sdk";
 
 const columnDefinitions: Array<ColumnDefinition<typeof Employee>> = [
   {
@@ -469,8 +473,8 @@ const columnDefinitions: Array<ColumnDefinition<typeof Employee>> = [
 ### Example 7: Context Menu on Cell Right-Click
 
 ```typescript
+import { Employee } from "@my/osdk";
 import { ObjectTable } from "@osdk/react-components/experimental/object-table";
-import { Employee } from "@YourApp/sdk";
 
 function EmployeesTable() {
   const renderCellContextMenu = (employee: Employee, cellValue: unknown) => (
@@ -506,8 +510,8 @@ function EmployeesTable() {
 ### Example 8: Row Click Handler
 
 ```typescript
+import { Employee } from "@my/osdk";
 import { ObjectTable } from "@osdk/react-components/experimental/object-table";
-import { Employee } from "@YourApp/sdk";
 import { useRouter } from "next/router";
 
 function EmployeesTable() {
@@ -531,12 +535,12 @@ function EmployeesTable() {
 You can filter by object properties and derived properties by including them in the `WhereClause`:
 
 ```typescript
+import { Employee } from "@my/osdk";
 import { DerivedProperty } from "@osdk/client";
 import {
   type ColumnDefinition,
   ObjectTable,
 } from "@osdk/react-components/experimental/object-table";
-import { Employee } from "@YourApp/sdk";
 
 type RDPs = {
   managerName: string | undefined;
@@ -579,8 +583,8 @@ function EmployeesWithManagerTable() {
 ### Example 10: Controlled Sorting
 
 ```typescript
+import { Employee } from "@my/osdk";
 import { ObjectTable } from "@osdk/react-components/experimental/object-table";
-import { Employee } from "@YourApp/sdk";
 import { useState } from "react";
 
 function EmployeesTable() {
@@ -606,8 +610,8 @@ function EmployeesTable() {
 ### Example 11: Controlled Row Selection
 
 ```typescript
+import { Employee } from "@my/osdk";
 import { ObjectTable } from "@osdk/react-components/experimental/object-table";
-import { Employee } from "@YourApp/sdk";
 import { useState } from "react";
 
 function EmployeesTable() {
@@ -659,11 +663,11 @@ function EmployeesTable() {
 In a custom column type, you can render anything in the column by passing in renderHeader and renderCell props.
 
 ```typescript
+import { Employee } from "@my/osdk";
 import {
   type ColumnDefinition,
   ObjectTable,
 } from "@osdk/react-components/experimental/object-table";
-import { Employee } from "@YourApp/sdk";
 
 const columnDefinitions: Array<ColumnDefinition<typeof Employee>> = [
   {
@@ -698,13 +702,13 @@ function EmployeesTable() {
 Enable inline editing with validation, dropdown selectors, and bulk submission:
 
 ```typescript
+import { Employee, updateMultipleEmployees } from "@my/osdk";
 import { useOsdkAction } from "@osdk/react";
 import {
   type CellEditInfo,
   type ColumnDefinition,
   ObjectTable,
 } from "@osdk/react-components/experimental/object-table";
-import { Employee, updateMultipleEmployees } from "@YourApp/sdk";
 
 const columnDefinitions: Array<ColumnDefinition<typeof Employee>> = [
   {
@@ -840,11 +844,11 @@ function EditableEmployeesTable() {
 Pass a function to `editable` to gate editing per row, and a `getFieldComponentProps` function to compute editor props from the row's data:
 
 ```typescript
+import { Employee } from "@my/osdk";
 import {
   type ColumnDefinition,
   ObjectTable,
 } from "@osdk/react-components/experimental/object-table";
-import { Employee } from "@YourApp/sdk";
 
 const columnDefinitions: Array<ColumnDefinition<typeof Employee>> = [
   {
@@ -871,12 +875,12 @@ const columnDefinitions: Array<ColumnDefinition<typeof Employee>> = [
 Use the `ColumnConfigDialog` component to create a custom column configuration experience:
 
 ```typescript
+import { Employee } from "@my/osdk";
 import {
   ColumnConfigDialog,
   type ColumnDefinition,
   ObjectTable,
 } from "@osdk/react-components/experimental/object-table";
-import { Employee } from "@YourApp/sdk";
 import { useCallback, useMemo, useState } from "react";
 
 const initialColumnDefinitions: Array<ColumnDefinition<typeof Employee>> = [
@@ -1000,11 +1004,11 @@ This example demonstrates:
 Display values computed by OSDK functions (queries) alongside regular property columns. Function columns automatically handle loading states, caching, and deduplication.
 
 ```typescript
+import { Employee, getEmployeeMetrics } from "@my/osdk";
 import {
   type ColumnDefinition,
   ObjectTable,
 } from "@osdk/react-components/experimental/object-table";
-import { Employee, getEmployeeMetrics } from "@YourApp/sdk";
 
 // Define a type map for your function columns
 type EmployeeFunctionColumns = {
@@ -1175,9 +1179,9 @@ Adjust row height for better readability:
 Use `getRowAttributes` to apply custom HTML attributes (typically `data-*` attributes) to each `<tr>` element. This is the recommended pattern for conditional row styling — for example, changing a row's background color based on the underlying object's state.
 
 ```tsx
+import { Employee } from "@my/osdk";
 import type { Osdk } from "@osdk/api";
 import { ObjectTable } from "@osdk/react-components/experimental/object-table";
-import { Employee } from "@YourApp/sdk";
 import { useCallback } from "react";
 
 function EmployeesTable() {
@@ -1248,11 +1252,11 @@ The ObjectTable automatically implements infinite scroll pagination, with page s
 Use TypeScript generics to ensure type safety:
 
 ```typescript
+import { Employee } from "@my/osdk";
 import {
   type ColumnDefinition,
   ObjectTable,
 } from "@osdk/react-components/experimental/object-table";
-import { Employee } from "@YourApp/sdk";
 
 type RDPs = {
   managerName: string | undefined;
@@ -1275,8 +1279,8 @@ const columnDefinitions: Array<ColumnDefinition<typeof Employee, RDPs>> = [
 Let TypeScript infer types from your OSDK object type:
 
 ```typescript
+import { Employee } from "@my/osdk";
 import type { PropertyKeys } from "@osdk/client";
-import { Employee } from "@YourApp/sdk";
 
 // PropertyKeys gives you all valid property names
 type EmployeeProps = PropertyKeys<typeof Employee>;

--- a/packages/react-components/docs/Prerequisites.md
+++ b/packages/react-components/docs/Prerequisites.md
@@ -8,11 +8,29 @@ Setup required before using `@osdk/react-components` or `@osdk/cbac-components`.
 
 ## Install dependencies
 
+:::tip If your tooling already installs dependencies, skip this step.
+:::
+
+Use whichever package manager your project uses (`# if using CBAC components` lines are optional):
+
 ```bash
+# npm
 npm install @osdk/api@beta @osdk/client@beta @osdk/react@beta
 npm install @osdk/react-components
 npm install @osdk/cbac-components # if using CBAC components
 npm install react react-dom classnames
+
+# pnpm
+pnpm add @osdk/api@beta @osdk/client@beta @osdk/react@beta
+pnpm add @osdk/react-components
+pnpm add @osdk/cbac-components # if using CBAC components
+pnpm add react react-dom classnames
+
+# yarn
+yarn add @osdk/api@beta @osdk/client@beta @osdk/react@beta
+yarn add @osdk/react-components
+yarn add @osdk/cbac-components # if using CBAC components
+yarn add react react-dom classnames
 ```
 
 ## Configure the OSDK client

--- a/packages/react-components/docs/Prerequisites.md
+++ b/packages/react-components/docs/Prerequisites.md
@@ -43,7 +43,7 @@ import { OsdkProvider } from "@osdk/react";
 
 const client = createClient(
   "https://your-stack.palantirfoundry.com",
-  "ri.ontology.main.ontology.00000000-0000-0000-0000-000000000000",
+  "ri.ontology.main.ontology.{UUID}",
   async () => {
     // return your auth token
   },

--- a/packages/react-sdk-docs/src/documentation.yml
+++ b/packages/react-sdk-docs/src/documentation.yml
@@ -9,7 +9,7 @@ versions:
 
             const client = createClient(
               "https://your-stack.palantirfoundry.com",
-              "ri.ontology.main.ontology.00000000-0000-0000-0000-000000000000",
+              "ri.ontology.main.ontology.{UUID}",
               async () => "your-token"
             );
 
@@ -655,7 +655,7 @@ versions:
 
             const client = createClient(
               "https://your-stack.palantirfoundry.com",
-              "ri.ontology.main.ontology.00000000-0000-0000-0000-000000000000",
+              "ri.ontology.main.ontology.{UUID}",
               async () => "your-token"
             );
 

--- a/packages/react-sdk-docs/src/documentation.yml
+++ b/packages/react-sdk-docs/src/documentation.yml
@@ -9,7 +9,7 @@ versions:
 
             const client = createClient(
               "https://your-stack.palantirfoundry.com",
-              "{{{packageName}}}",
+              "ri.ontology.main.ontology.00000000-0000-0000-0000-000000000000",
               async () => "your-token"
             );
 
@@ -655,7 +655,7 @@ versions:
 
             const client = createClient(
               "https://your-stack.palantirfoundry.com",
-              "{{{packageName}}}",
+              "ri.ontology.main.ontology.00000000-0000-0000-0000-000000000000",
               async () => "your-token"
             );
 

--- a/packages/react-sdk-docs/src/generatedNoCheck/docsNoComputedVariables.ts
+++ b/packages/react-sdk-docs/src/generatedNoCheck/docsNoComputedVariables.ts
@@ -12,7 +12,7 @@ export const snippets: SdkSnippets<typeof OSDK_SNIPPETS_SPEC> = {
       "snippets": {
         "reactProviderSetup": [
           {
-            "template": "import { OsdkProvider } from \"@osdk/react\";\nimport { createClient } from \"@osdk/client\";\n\nconst client = createClient(\n  \"https://your-stack.palantirfoundry.com\",\n  \"ri.ontology.main.ontology.00000000-0000-0000-0000-000000000000\",\n  async () => \"your-token\"\n);\n\nfunction App() {\n  return (\n    <OsdkProvider client={client}>\n      <YourApp />\n    </OsdkProvider>\n  );\n}"
+            "template": "import { OsdkProvider } from \"@osdk/react\";\nimport { createClient } from \"@osdk/client\";\n\nconst client = createClient(\n  \"https://your-stack.palantirfoundry.com\",\n  \"ri.ontology.main.ontology.{UUID}\",\n  async () => \"your-token\"\n);\n\nfunction App() {\n  return (\n    <OsdkProvider client={client}>\n      <YourApp />\n    </OsdkProvider>\n  );\n}"
           }
         ],
         "reactUseOsdkObjectsBasic": [
@@ -174,7 +174,7 @@ export const snippets: SdkSnippets<typeof OSDK_SNIPPETS_SPEC> = {
         ],
         "clientSetup": [
           {
-            "template": "import { OsdkProvider } from \"@osdk/react\";\nimport { createClient } from \"@osdk/client\";\n\nconst client = createClient(\n  \"https://your-stack.palantirfoundry.com\",\n  \"ri.ontology.main.ontology.00000000-0000-0000-0000-000000000000\",\n  async () => \"your-token\"\n);\n\nfunction App() {\n  return (\n    <OsdkProvider client={client}>\n      <YourApp />\n    </OsdkProvider>\n  );\n}"
+            "template": "import { OsdkProvider } from \"@osdk/react\";\nimport { createClient } from \"@osdk/client\";\n\nconst client = createClient(\n  \"https://your-stack.palantirfoundry.com\",\n  \"ri.ontology.main.ontology.{UUID}\",\n  async () => \"your-token\"\n);\n\nfunction App() {\n  return (\n    <OsdkProvider client={client}>\n      <YourApp />\n    </OsdkProvider>\n  );\n}"
           }
         ],
         "callFunction": [

--- a/packages/react-sdk-docs/src/generatedNoCheck/docsNoComputedVariables.ts
+++ b/packages/react-sdk-docs/src/generatedNoCheck/docsNoComputedVariables.ts
@@ -12,7 +12,7 @@ export const snippets: SdkSnippets<typeof OSDK_SNIPPETS_SPEC> = {
       "snippets": {
         "reactProviderSetup": [
           {
-            "template": "import { OsdkProvider } from \"@osdk/react\";\nimport { createClient } from \"@osdk/client\";\n\nconst client = createClient(\n  \"https://your-stack.palantirfoundry.com\",\n  \"{{{packageName}}}\",\n  async () => \"your-token\"\n);\n\nfunction App() {\n  return (\n    <OsdkProvider client={client}>\n      <YourApp />\n    </OsdkProvider>\n  );\n}"
+            "template": "import { OsdkProvider } from \"@osdk/react\";\nimport { createClient } from \"@osdk/client\";\n\nconst client = createClient(\n  \"https://your-stack.palantirfoundry.com\",\n  \"ri.ontology.main.ontology.00000000-0000-0000-0000-000000000000\",\n  async () => \"your-token\"\n);\n\nfunction App() {\n  return (\n    <OsdkProvider client={client}>\n      <YourApp />\n    </OsdkProvider>\n  );\n}"
           }
         ],
         "reactUseOsdkObjectsBasic": [
@@ -174,7 +174,7 @@ export const snippets: SdkSnippets<typeof OSDK_SNIPPETS_SPEC> = {
         ],
         "clientSetup": [
           {
-            "template": "import { OsdkProvider } from \"@osdk/react\";\nimport { createClient } from \"@osdk/client\";\n\nconst client = createClient(\n  \"https://your-stack.palantirfoundry.com\",\n  \"{{{packageName}}}\",\n  async () => \"your-token\"\n);\n\nfunction App() {\n  return (\n    <OsdkProvider client={client}>\n      <YourApp />\n    </OsdkProvider>\n  );\n}"
+            "template": "import { OsdkProvider } from \"@osdk/react\";\nimport { createClient } from \"@osdk/client\";\n\nconst client = createClient(\n  \"https://your-stack.palantirfoundry.com\",\n  \"ri.ontology.main.ontology.00000000-0000-0000-0000-000000000000\",\n  async () => \"your-token\"\n);\n\nfunction App() {\n  return (\n    <OsdkProvider client={client}>\n      <YourApp />\n    </OsdkProvider>\n  );\n}"
           }
         ],
         "callFunction": [


### PR DESCRIPTION
There were some inaccuracies our snippets re what package manager to use, what `createClient` actually takes, some code examples, etc. This PR attempts to correct them.

• rewrite `import { $ } from "@my/osdk"` to `client(Type)` — `$` is never exported from the generated SDK, it's a local alias users sometimes create; replaced ~30 sites with the `client(Type)` pattern already used elsewhere in the docs
• standardize SDK placeholder on `@my/osdk` across docs (was a mix of `@my/osdk`, `@YourApp/sdk`, `@your-app/sdk`) and add an `About @my/osdk` callout to each react-components doc
• fix `createClient`'s 2nd arg in react-sdk-docs snippets — was rendering the npm package name, now uses an ontology rid placeholder; fix several other broken snippets with missing imports (cache-management setup block, advanced-queries derived-property fragments) and one duplicate `const { data }` that wouldn't compile
• install commands now show npm/pnpm/yarn alternatives with a skip-if-installed tip — addresses pilot running pnpm in npm projects and the install-race-with-harness issue