### PR TITLE
add link traversal to whereclause and remove filterlist applylinkedfilters workaround

### DIFF
--- a/.changeset/where-clause-link-traversal.md
+++ b/.changeset/where-clause-link-traversal.md
@@ -1,0 +1,14 @@
+---
+"@osdk/api": minor
+"@osdk/client": minor
+"@osdk/react-components": minor
+---
+
+add link traversal support to WhereClause
+
+WhereClause now accepts link-keyed entries that the OSDK expands to ObjectSet pivot+intersect compositions when applying `where()`. FilterList emits these as part of `filterClause` so direct property facet counts reflect linked-filter selection automatically — no external pivot-and-intersect helper is required.
+
+• new `LinkWhereClause<T>` public type on `@osdk/api`
+• `.where()` runtime detects link entries via the `$reverseLink` sentinel and composes searchAround → filter → searchAround → intersect against the base; `$and`/`$or`/`$not` compose via intersect/union/subtract
+• filter-list `LINKED_PROPERTY` case emits `{ [linkName]: { $reverseLink, ...inner } }`
+• new `reverseLinkName` field on `LinkedPropertyFilterDefinition` feeds the emitted `$reverseLink`

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -1963,13 +1963,14 @@ export interface VersionBound<V extends VersionString<any, any, any>> {
     __expectedClientVersion?: V;
 }
 
+// Warning: (ae-forgotten-export) The symbol "DerivedObjectOrInterfaceDefinition" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "MergedPropertyWhereClause" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
 export type WhereClause<
 	T extends ObjectOrInterfaceDefinition,
 	RDPs extends Record<string, SimplePropertyDef> = {}
-> = OrWhereClause<T, RDPs> | AndWhereClause<T, RDPs> | NotWhereClause<T, RDPs> | LinkWhereClause<T> | (IsNever<keyof CompileTimeMetadata<T>["properties"]> extends true ? Record<string, never> : MergedPropertyWhereClause<T, RDPs>);
+> = OrWhereClause<T, RDPs> | AndWhereClause<T, RDPs> | NotWhereClause<T, RDPs> | LinkWhereClause<DerivedObjectOrInterfaceDefinition.WithDerivedProperties<T, RDPs>> | (IsNever<keyof CompileTimeMetadata<T>["properties"]> extends true ? Record<string, never> : MergedPropertyWhereClause<T, RDPs>);
 
 // @public (undocumented)
 export type WirePropertyTypes = BaseWirePropertyTypes | Record<string, BaseWirePropertyTypes>;

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -874,6 +874,9 @@ export type LinkNames<Q extends ObjectOrInterfaceDefinition> = Q extends Interfa
 export type LinkTypeApiNamesFor<Q extends ObjectOrInterfaceDefinition> = Extract<keyof CompileTimeMetadata<Q>["links"], string>;
 
 // @public (undocumented)
+export type LinkWhereClause<T extends ObjectOrInterfaceDefinition> = { [L in LinkNames<T>]? : WhereClause<LinkedType<T, L>> };
+
+// @public (undocumented)
 export interface Logger {
     	child(bindings: Record<string, any>, options?: {
         		level?: string
@@ -1966,7 +1969,7 @@ export interface VersionBound<V extends VersionString<any, any, any>> {
 export type WhereClause<
 	T extends ObjectOrInterfaceDefinition,
 	RDPs extends Record<string, SimplePropertyDef> = {}
-> = OrWhereClause<T, RDPs> | AndWhereClause<T, RDPs> | NotWhereClause<T, RDPs> | (IsNever<keyof CompileTimeMetadata<T>["properties"]> extends true ? Record<string, never> : MergedPropertyWhereClause<T, RDPs>);
+> = OrWhereClause<T, RDPs> | AndWhereClause<T, RDPs> | NotWhereClause<T, RDPs> | LinkWhereClause<T> | (IsNever<keyof CompileTimeMetadata<T>["properties"]> extends true ? Record<string, never> : MergedPropertyWhereClause<T, RDPs>);
 
 // @public (undocumented)
 export type WirePropertyTypes = BaseWirePropertyTypes | Record<string, BaseWirePropertyTypes>;

--- a/packages/api/src/__quickinfo_snapshot__/__snapshots__/objectSet.snap
+++ b/packages/api/src/__quickinfo_snapshot__/__snapshots__/objectSet.snap
@@ -316,6 +316,12 @@ type objectSet_where_clause_param =
   | OrWhereClause<EmployeeApiTest, {}>
   | AndWhereClause<EmployeeApiTest, {}>
   | NotWhereClause<EmployeeApiTest, {}>
+  | LinkWhereClause<
+    DerivedObjectOrInterfaceDefinition.WithDerivedProperties<
+      EmployeeApiTest,
+      {}
+    >
+  >
   | {
     class?: StringFilter | undefined;
     fullName?: StringFilter | undefined;
@@ -402,6 +408,15 @@ type objectSet_with_rdp_where_clause_param =
       { mom: "integer" }
     >,
     {}
+  >
+  | LinkWhereClause<
+    DerivedObjectOrInterfaceDefinition.WithDerivedProperties<
+      DerivedObjectOrInterfaceDefinition.WithDerivedProperties<
+        EmployeeApiTest,
+        { mom: "integer" }
+      >,
+      {}
+    >
   >
   | {
     mom?: NumberFilter | undefined;

--- a/packages/api/src/aggregate/WhereClause.ts
+++ b/packages/api/src/aggregate/WhereClause.ts
@@ -26,6 +26,7 @@ import type {
 import type { SimplePropertyDef } from "../ontology/SimplePropertyDef.js";
 import type { BaseWirePropertyTypes } from "../ontology/WirePropertyTypes.js";
 import type { IsNever } from "../OsdkObjectFrom.js";
+import type { LinkedType, LinkNames } from "../util/LinkUtils.js";
 import type { ArrayFilter } from "./ArrayFilter.js";
 import type { BaseFilter } from "./BaseFilter.js";
 import type { BooleanFilter } from "./BooleanFilter.js";
@@ -205,6 +206,10 @@ export type PropertyWhereClause<T extends ObjectOrInterfaceDefinition> = {
   >;
 };
 
+export type LinkWhereClause<T extends ObjectOrInterfaceDefinition> = {
+  [L in LinkNames<T>]?: WhereClause<LinkedType<T, L>>;
+};
+
 type MergedPropertyWhereClause<
   T extends ObjectOrInterfaceDefinition,
   RDPs extends Record<string, SimplePropertyDef> = {},
@@ -219,6 +224,7 @@ export type WhereClause<
   | OrWhereClause<T, RDPs>
   | AndWhereClause<T, RDPs>
   | NotWhereClause<T, RDPs>
+  | LinkWhereClause<T>
   | (IsNever<keyof CompileTimeMetadata<T>["properties"]> extends true
     ? Record<string, never>
     : MergedPropertyWhereClause<T, RDPs>);

--- a/packages/api/src/aggregate/WhereClause.ts
+++ b/packages/api/src/aggregate/WhereClause.ts
@@ -224,7 +224,9 @@ export type WhereClause<
   | OrWhereClause<T, RDPs>
   | AndWhereClause<T, RDPs>
   | NotWhereClause<T, RDPs>
-  | LinkWhereClause<T>
+  | LinkWhereClause<
+    DerivedObjectOrInterfaceDefinition.WithDerivedProperties<T, RDPs>
+  >
   | (IsNever<keyof CompileTimeMetadata<T>["properties"]> extends true
     ? Record<string, never>
     : MergedPropertyWhereClause<T, RDPs>);

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -36,6 +36,7 @@ export type {
   AndWhereClause,
   GeoFilter_Intersects,
   GeoFilter_Within,
+  LinkWhereClause,
   NotWhereClause,
   OrWhereClause,
   PossibleWhereClauseFilters,

--- a/packages/client/src/internal/conversions/applyWhereClauseToObjectSet.test.ts
+++ b/packages/client/src/internal/conversions/applyWhereClauseToObjectSet.test.ts
@@ -1,0 +1,330 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Employee } from "@osdk/client.test.ontology";
+import type { ObjectSet as WireObjectSet } from "@osdk/foundry.ontologies";
+import { describe, expect, it } from "vitest";
+import { applyWhereClauseToObjectSet } from "./applyWhereClauseToObjectSet.js";
+
+const employeeBase: WireObjectSet = { type: "base", objectType: "Employee" };
+
+describe(applyWhereClauseToObjectSet, () => {
+  it("pure-property clause emits a filter wrap (existing behavior)", () => {
+    const result = applyWhereClauseToObjectSet(
+      employeeBase,
+      { fullName: { $eq: "Alice" } },
+      Employee,
+    );
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "objectSet": {
+          "objectType": "Employee",
+          "type": "base",
+        },
+        "type": "filter",
+        "where": {
+          "field": "fullName",
+          "type": "eq",
+          "value": "Alice",
+        },
+      }
+    `);
+  });
+
+  it("empty clause returns the base objectSet unchanged", () => {
+    const result = applyWhereClauseToObjectSet(employeeBase, {}, Employee);
+    expect(result).toBe(employeeBase);
+  });
+
+  it("link traversal with $reverseLink expands to pivot+filter+reversePivot", () => {
+    // "Employees whose lead has fullName=Alice"
+    const result = applyWhereClauseToObjectSet(
+      employeeBase,
+      {
+        lead: {
+          $reverseLink: "peeps",
+          fullName: { $eq: "Alice" },
+        },
+      } as Parameters<typeof applyWhereClauseToObjectSet>[1],
+      Employee,
+    );
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "link": "peeps",
+        "objectSet": {
+          "objectSet": {
+            "link": "lead",
+            "objectSet": {
+              "objectType": "Employee",
+              "type": "base",
+            },
+            "type": "searchAround",
+          },
+          "type": "filter",
+          "where": {
+            "field": "fullName",
+            "type": "eq",
+            "value": "Alice",
+          },
+        },
+        "type": "searchAround",
+      }
+    `);
+  });
+
+  it("mixed property + link entries intersect", () => {
+    const result = applyWhereClauseToObjectSet(
+      employeeBase,
+      {
+        fullName: { $eq: "Bob" },
+        lead: {
+          $reverseLink: "peeps",
+          fullName: { $eq: "Alice" },
+        },
+      } as Parameters<typeof applyWhereClauseToObjectSet>[1],
+      Employee,
+    );
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "objectSets": [
+          {
+            "objectSet": {
+              "objectType": "Employee",
+              "type": "base",
+            },
+            "type": "filter",
+            "where": {
+              "field": "fullName",
+              "type": "eq",
+              "value": "Bob",
+            },
+          },
+          {
+            "link": "peeps",
+            "objectSet": {
+              "objectSet": {
+                "link": "lead",
+                "objectSet": {
+                  "objectType": "Employee",
+                  "type": "base",
+                },
+                "type": "searchAround",
+              },
+              "type": "filter",
+              "where": {
+                "field": "fullName",
+                "type": "eq",
+                "value": "Alice",
+              },
+            },
+            "type": "searchAround",
+          },
+        ],
+        "type": "intersect",
+      }
+    `);
+  });
+
+  it("multi-hop link traversal works via recursion", () => {
+    const result = applyWhereClauseToObjectSet(
+      employeeBase,
+      {
+        lead: {
+          $reverseLink: "peeps",
+          lead: {
+            $reverseLink: "peeps",
+            fullName: { $eq: "CEO" },
+          },
+        },
+      } as Parameters<typeof applyWhereClauseToObjectSet>[1],
+      Employee,
+    );
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "link": "peeps",
+        "objectSet": {
+          "link": "peeps",
+          "objectSet": {
+            "objectSet": {
+              "link": "lead",
+              "objectSet": {
+                "link": "lead",
+                "objectSet": {
+                  "objectType": "Employee",
+                  "type": "base",
+                },
+                "type": "searchAround",
+              },
+              "type": "searchAround",
+            },
+            "type": "filter",
+            "where": {
+              "field": "fullName",
+              "type": "eq",
+              "value": "CEO",
+            },
+          },
+          "type": "searchAround",
+        },
+        "type": "searchAround",
+      }
+    `);
+  });
+
+  it("$and composes via intersect", () => {
+    const result = applyWhereClauseToObjectSet(
+      employeeBase,
+      {
+        $and: [
+          { fullName: { $eq: "Bob" } },
+          { employeeId: { $gt: 5 } },
+        ],
+      },
+      Employee,
+    );
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "objectSets": [
+          {
+            "objectSet": {
+              "objectType": "Employee",
+              "type": "base",
+            },
+            "type": "filter",
+            "where": {
+              "field": "fullName",
+              "type": "eq",
+              "value": "Bob",
+            },
+          },
+          {
+            "objectSet": {
+              "objectType": "Employee",
+              "type": "base",
+            },
+            "type": "filter",
+            "where": {
+              "field": "employeeId",
+              "type": "gt",
+              "value": 5,
+            },
+          },
+        ],
+        "type": "intersect",
+      }
+    `);
+  });
+
+  it("$or composes via union", () => {
+    const result = applyWhereClauseToObjectSet(
+      employeeBase,
+      {
+        $or: [
+          { fullName: { $eq: "Bob" } },
+          { fullName: { $eq: "Alice" } },
+        ],
+      },
+      Employee,
+    );
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "objectSets": [
+          {
+            "objectSet": {
+              "objectType": "Employee",
+              "type": "base",
+            },
+            "type": "filter",
+            "where": {
+              "field": "fullName",
+              "type": "eq",
+              "value": "Bob",
+            },
+          },
+          {
+            "objectSet": {
+              "objectType": "Employee",
+              "type": "base",
+            },
+            "type": "filter",
+            "where": {
+              "field": "fullName",
+              "type": "eq",
+              "value": "Alice",
+            },
+          },
+        ],
+        "type": "union",
+      }
+    `);
+  });
+
+  it("$not composes via subtract", () => {
+    const result = applyWhereClauseToObjectSet(
+      employeeBase,
+      { $not: { fullName: { $eq: "Bob" } } },
+      Employee,
+    );
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "objectSets": [
+          {
+            "objectType": "Employee",
+            "type": "base",
+          },
+          {
+            "objectSet": {
+              "objectType": "Employee",
+              "type": "base",
+            },
+            "type": "filter",
+            "where": {
+              "field": "fullName",
+              "type": "eq",
+              "value": "Bob",
+            },
+          },
+        ],
+        "type": "subtract",
+      }
+    `);
+  });
+
+  it("link entry without $reverseLink falls through to legacy where (preserves backward compat for $isNotNull on link names)", () => {
+    // Existing pattern from filter-list HAS_LINK case
+    const result = applyWhereClauseToObjectSet(
+      employeeBase,
+      { lead: { $isNull: false } } as Parameters<
+        typeof applyWhereClauseToObjectSet
+      >[1],
+      Employee,
+    );
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "objectSet": {
+          "objectType": "Employee",
+          "type": "base",
+        },
+        "type": "filter",
+        "where": {
+          "field": "lead",
+          "type": "isNull",
+          "value": false,
+        },
+      }
+    `);
+  });
+});

--- a/packages/client/src/internal/conversions/applyWhereClauseToObjectSet.test.ts
+++ b/packages/client/src/internal/conversions/applyWhereClauseToObjectSet.test.ts
@@ -272,6 +272,36 @@ describe(applyWhereClauseToObjectSet, () => {
     `);
   });
 
+  it("$or with empty children emits an always-false filter (empty set)", () => {
+    const result = applyWhereClauseToObjectSet(
+      employeeBase,
+      { $or: [] },
+      Employee,
+    );
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "objectSet": {
+          "objectType": "Employee",
+          "type": "base",
+        },
+        "type": "filter",
+        "where": {
+          "type": "or",
+          "value": [],
+        },
+      }
+    `);
+  });
+
+  it("$and with empty children returns the base set (always true)", () => {
+    const result = applyWhereClauseToObjectSet(
+      employeeBase,
+      { $and: [] },
+      Employee,
+    );
+    expect(result).toBe(employeeBase);
+  });
+
   it("$not composes via subtract", () => {
     const result = applyWhereClauseToObjectSet(
       employeeBase,

--- a/packages/client/src/internal/conversions/applyWhereClauseToObjectSet.ts
+++ b/packages/client/src/internal/conversions/applyWhereClauseToObjectSet.ts
@@ -23,43 +23,46 @@ import type { ObjectSet as WireObjectSet } from "@osdk/foundry.ontologies";
 import { modernToLegacyWhereClause } from "./modernToLegacyWhereClause.js";
 
 const REVERSE_LINK_KEY = "$reverseLink";
-const SYNTHETIC_OBJECT_TYPE: ObjectOrInterfaceDefinition = {
+
+// fullyQualifyPropName (the only consumer of objectType inside
+// modernToLegacyWhereClause) is a no-op for type === "object", so an empty
+// apiName is safe for the linked-inner-clause recursion.
+const SYNTHETIC_OBJECT_TYPE = {
   type: "object",
   apiName: "",
 } as ObjectOrInterfaceDefinition;
 
-function isAndClause(value: unknown): value is { $and: unknown[] } {
-  return typeof value === "object" && value != null && "$and" in value
-    && Array.isArray((value as { $and: unknown }).$and);
+function hasKey<K extends string>(
+  v: unknown,
+  k: K,
+): v is Record<K, unknown> {
+  return typeof v === "object" && v != null && k in v;
 }
 
-function isOrClause(value: unknown): value is { $or: unknown[] } {
-  return typeof value === "object" && value != null && "$or" in value
-    && Array.isArray((value as { $or: unknown }).$or);
+function isAndClause(v: unknown): v is { $and: unknown[] } {
+  return hasKey(v, "$and") && Array.isArray(v.$and);
 }
 
-function isNotClause(value: unknown): value is { $not: unknown } {
-  return typeof value === "object" && value != null && "$not" in value;
+function isOrClause(v: unknown): v is { $or: unknown[] } {
+  return hasKey(v, "$or") && Array.isArray(v.$or);
 }
 
-function isLinkTraversal(value: unknown): value is { $reverseLink: string } {
-  return typeof value === "object" && value != null
-    && REVERSE_LINK_KEY in value
-    && typeof (value as { $reverseLink: unknown }).$reverseLink === "string";
+function isNotClause(v: unknown): v is { $not: Record<string, unknown> } {
+  return hasKey(v, "$not") && v.$not !== undefined;
+}
+
+function isLinkTraversal(v: unknown): v is Record<string, unknown> & {
+  $reverseLink: string;
+} {
+  return hasKey(v, REVERSE_LINK_KEY)
+    && typeof v[REVERSE_LINK_KEY] === "string";
 }
 
 /**
- * Converts a user-facing WhereClause into a wire ObjectSet composition,
- * applying the clause to `baseObjectSet`. Pure-property clauses produce
- * a `filter` wrap (identical to the previous direct path). Link-traversed
- * entries (recognized by the `$reverseLink` sentinel on the inner value)
- * expand to `pivotTo(linkName) → where(inner) → pivotTo(reverseLink) → intersect`
- * compositions. `$and`/`$or`/`$not` compose via `intersect`/`union`/`subtract`.
- *
- * Link traversal requires the caller to supply `$reverseLink` on the inner
- * value; the OSDK does not auto-resolve it because object metadata is async-
- * only. Filter-list integrations populate `$reverseLink` from
- * `LinkedPropertyFilterDefinition.reverseLinkName`.
+ * Expands a user-facing WhereClause into a wire ObjectSet composition:
+ * pure-property clauses use a `filter` wrap; `$reverseLink`-tagged link
+ * entries become `pivotTo → where → pivotTo → intersect` compositions;
+ * `$and`/`$or`/`$not` compose via `intersect`/`union`/`subtract`.
  *
  * @internal
  */
@@ -74,7 +77,7 @@ export function applyWhereClauseToObjectSet<
 ): WireObjectSet {
   return applyInner(
     baseObjectSet,
-    whereClause as unknown as Record<string, unknown>,
+    whereClause as Record<string, unknown>,
     objectType,
     rdpNames,
   );
@@ -87,70 +90,52 @@ function applyInner(
   rdpNames: Set<string> | undefined,
 ): WireObjectSet {
   if (isAndClause(whereClause)) {
-    if (whereClause.$and.length === 0) {
-      return baseObjectSet;
-    }
-    if (whereClause.$and.length === 1) {
-      return applyInner(
-        baseObjectSet,
-        whereClause.$and[0] as Record<string, unknown>,
-        objectType,
-        rdpNames,
-      );
-    }
-    return {
-      type: "intersect",
-      objectSets: whereClause.$and.map((child) =>
-        applyInner(
-          baseObjectSet,
-          child as Record<string, unknown>,
-          objectType,
-          rdpNames,
-        )
-      ),
-    };
+    // Empty AND is TRUE — unfiltered base.
+    return composeChildren(
+      baseObjectSet,
+      whereClause.$and,
+      "intersect",
+      objectType,
+      rdpNames,
+    );
   }
 
   if (isOrClause(whereClause)) {
     if (whereClause.$or.length === 0) {
-      return baseObjectSet;
+      // Empty OR is FALSE — emit an always-false filter so the wire shape
+      // represents an empty set rather than the unfiltered base.
+      return {
+        type: "filter",
+        objectSet: baseObjectSet,
+        where: { type: "or", value: [] },
+      };
     }
-    if (whereClause.$or.length === 1) {
-      return applyInner(
-        baseObjectSet,
-        whereClause.$or[0] as Record<string, unknown>,
-        objectType,
-        rdpNames,
-      );
-    }
-    return {
-      type: "union",
-      objectSets: whereClause.$or.map((child) =>
-        applyInner(
-          baseObjectSet,
-          child as Record<string, unknown>,
-          objectType,
-          rdpNames,
-        )
-      ),
-    };
-  }
-
-  if (isNotClause(whereClause)) {
-    const excluded = applyInner(
+    return composeChildren(
       baseObjectSet,
-      whereClause.$not as Record<string, unknown>,
+      whereClause.$or,
+      "union",
       objectType,
       rdpNames,
     );
+  }
+
+  if (isNotClause(whereClause)) {
     return {
       type: "subtract",
-      objectSets: [baseObjectSet, excluded],
+      objectSets: [
+        baseObjectSet,
+        applyInner(baseObjectSet, whereClause.$not, objectType, rdpNames),
+      ],
     };
   }
 
   const propertyEntries: Array<[string, unknown]> = [];
-  const linkEntries: Array<[string, { $reverseLink: string }]> = [];
+  const linkEntries: Array<[
+    string,
+    Record<string, unknown> & {
+      $reverseLink: string;
+    },
+  ]> = [];
 
   for (const [key, value] of Object.entries(whereClause)) {
     if (isLinkTraversal(value)) {
@@ -184,7 +169,7 @@ function applyInner(
     };
     const filteredLinked = applyInner(
       linkedBase,
-      innerWhere as Record<string, unknown>,
+      innerWhere,
       SYNTHETIC_OBJECT_TYPE,
       undefined,
     );
@@ -204,5 +189,36 @@ function applyInner(
   return {
     type: "intersect",
     objectSets: components,
+  };
+}
+
+function composeChildren(
+  baseObjectSet: WireObjectSet,
+  children: unknown[],
+  composeType: "intersect" | "union",
+  objectType: ObjectOrInterfaceDefinition,
+  rdpNames: Set<string> | undefined,
+): WireObjectSet {
+  if (children.length === 0) {
+    return baseObjectSet;
+  }
+  if (children.length === 1) {
+    return applyInner(
+      baseObjectSet,
+      children[0] as Record<string, unknown>,
+      objectType,
+      rdpNames,
+    );
+  }
+  return {
+    type: composeType,
+    objectSets: children.map((child) =>
+      applyInner(
+        baseObjectSet,
+        child as Record<string, unknown>,
+        objectType,
+        rdpNames,
+      )
+    ),
   };
 }

--- a/packages/client/src/internal/conversions/applyWhereClauseToObjectSet.ts
+++ b/packages/client/src/internal/conversions/applyWhereClauseToObjectSet.ts
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  ObjectOrInterfaceDefinition,
+  SimplePropertyDef,
+  WhereClause,
+} from "@osdk/api";
+import type { ObjectSet as WireObjectSet } from "@osdk/foundry.ontologies";
+import { modernToLegacyWhereClause } from "./modernToLegacyWhereClause.js";
+
+const REVERSE_LINK_KEY = "$reverseLink";
+const SYNTHETIC_OBJECT_TYPE: ObjectOrInterfaceDefinition = {
+  type: "object",
+  apiName: "",
+} as ObjectOrInterfaceDefinition;
+
+function isAndClause(value: unknown): value is { $and: unknown[] } {
+  return typeof value === "object" && value != null && "$and" in value
+    && Array.isArray((value as { $and: unknown }).$and);
+}
+
+function isOrClause(value: unknown): value is { $or: unknown[] } {
+  return typeof value === "object" && value != null && "$or" in value
+    && Array.isArray((value as { $or: unknown }).$or);
+}
+
+function isNotClause(value: unknown): value is { $not: unknown } {
+  return typeof value === "object" && value != null && "$not" in value;
+}
+
+function isLinkTraversal(value: unknown): value is { $reverseLink: string } {
+  return typeof value === "object" && value != null
+    && REVERSE_LINK_KEY in value
+    && typeof (value as { $reverseLink: unknown }).$reverseLink === "string";
+}
+
+/**
+ * Converts a user-facing WhereClause into a wire ObjectSet composition,
+ * applying the clause to `baseObjectSet`. Pure-property clauses produce
+ * a `filter` wrap (identical to the previous direct path). Link-traversed
+ * entries (recognized by the `$reverseLink` sentinel on the inner value)
+ * expand to `pivotTo(linkName) → where(inner) → pivotTo(reverseLink) → intersect`
+ * compositions. `$and`/`$or`/`$not` compose via `intersect`/`union`/`subtract`.
+ *
+ * Link traversal requires the caller to supply `$reverseLink` on the inner
+ * value; the OSDK does not auto-resolve it because object metadata is async-
+ * only. Filter-list integrations populate `$reverseLink` from
+ * `LinkedPropertyFilterDefinition.reverseLinkName`.
+ *
+ * @internal
+ */
+export function applyWhereClauseToObjectSet<
+  T extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef> = {},
+>(
+  baseObjectSet: WireObjectSet,
+  whereClause: WhereClause<T, RDPs>,
+  objectType: T,
+  rdpNames?: Set<string>,
+): WireObjectSet {
+  return applyInner(
+    baseObjectSet,
+    whereClause as unknown as Record<string, unknown>,
+    objectType,
+    rdpNames,
+  );
+}
+
+function applyInner(
+  baseObjectSet: WireObjectSet,
+  whereClause: Record<string, unknown>,
+  objectType: ObjectOrInterfaceDefinition,
+  rdpNames: Set<string> | undefined,
+): WireObjectSet {
+  if (isAndClause(whereClause)) {
+    if (whereClause.$and.length === 0) {
+      return baseObjectSet;
+    }
+    if (whereClause.$and.length === 1) {
+      return applyInner(
+        baseObjectSet,
+        whereClause.$and[0] as Record<string, unknown>,
+        objectType,
+        rdpNames,
+      );
+    }
+    return {
+      type: "intersect",
+      objectSets: whereClause.$and.map((child) =>
+        applyInner(
+          baseObjectSet,
+          child as Record<string, unknown>,
+          objectType,
+          rdpNames,
+        )
+      ),
+    };
+  }
+
+  if (isOrClause(whereClause)) {
+    if (whereClause.$or.length === 0) {
+      return baseObjectSet;
+    }
+    if (whereClause.$or.length === 1) {
+      return applyInner(
+        baseObjectSet,
+        whereClause.$or[0] as Record<string, unknown>,
+        objectType,
+        rdpNames,
+      );
+    }
+    return {
+      type: "union",
+      objectSets: whereClause.$or.map((child) =>
+        applyInner(
+          baseObjectSet,
+          child as Record<string, unknown>,
+          objectType,
+          rdpNames,
+        )
+      ),
+    };
+  }
+
+  if (isNotClause(whereClause)) {
+    const excluded = applyInner(
+      baseObjectSet,
+      whereClause.$not as Record<string, unknown>,
+      objectType,
+      rdpNames,
+    );
+    return {
+      type: "subtract",
+      objectSets: [baseObjectSet, excluded],
+    };
+  }
+
+  const propertyEntries: Array<[string, unknown]> = [];
+  const linkEntries: Array<[string, { $reverseLink: string }]> = [];
+
+  for (const [key, value] of Object.entries(whereClause)) {
+    if (isLinkTraversal(value)) {
+      linkEntries.push([key, value]);
+    } else {
+      propertyEntries.push([key, value]);
+    }
+  }
+
+  const components: WireObjectSet[] = [];
+
+  if (propertyEntries.length > 0) {
+    const propertyClause = Object.fromEntries(propertyEntries);
+    components.push({
+      type: "filter",
+      objectSet: baseObjectSet,
+      where: modernToLegacyWhereClause(
+        propertyClause as WhereClause<ObjectOrInterfaceDefinition>,
+        objectType,
+        rdpNames,
+      ),
+    });
+  }
+
+  for (const [linkName, value] of linkEntries) {
+    const { $reverseLink: reverseLink, ...innerWhere } = value;
+    const linkedBase: WireObjectSet = {
+      type: "searchAround",
+      objectSet: baseObjectSet,
+      link: linkName,
+    };
+    const filteredLinked = applyInner(
+      linkedBase,
+      innerWhere as Record<string, unknown>,
+      SYNTHETIC_OBJECT_TYPE,
+      undefined,
+    );
+    components.push({
+      type: "searchAround",
+      objectSet: filteredLinked,
+      link: reverseLink,
+    });
+  }
+
+  if (components.length === 0) {
+    return baseObjectSet;
+  }
+  if (components.length === 1) {
+    return components[0];
+  }
+  return {
+    type: "intersect",
+    objectSets: components,
+  };
+}

--- a/packages/client/src/objectSet/createObjectSet.ts
+++ b/packages/client/src/objectSet/createObjectSet.ts
@@ -57,23 +57,6 @@ import { resolveBaseObjectSetType } from "../util/objectSetUtils.js";
 import { isWireObjectSet } from "../util/WireObjectSet.js";
 import { fetchLinksPage } from "./fetchLinksPage.js";
 
-const a: WireObjectSet = {
-  "type": "interfaceLinkSearchAround",
-  "interfaceLink": "lead",
-  "objectSet": {
-    "type": "asType",
-    "entityType": "Person",
-    "objectSet": {
-      "type": "filter",
-      "objectSet": { "type": "base", "objectType": "Employee" },
-      "where": {
-        "type": "eq",
-        "field": "employeeNumber",
-        "value": "657495107",
-      },
-    },
-  },
-};
 function isObjectTypeDefinition(
   def: ObjectOrInterfaceDefinition,
 ): def is ObjectTypeDefinition {

--- a/packages/client/src/objectSet/createObjectSet.ts
+++ b/packages/client/src/objectSet/createObjectSet.ts
@@ -44,7 +44,7 @@ import type {
 } from "@osdk/foundry.ontologies";
 import invariant from "tiny-invariant";
 import { createWithPropertiesObjectSet } from "../derivedProperties/createWithPropertiesObjectSet.js";
-import { modernToLegacyWhereClause } from "../internal/conversions/modernToLegacyWhereClause.js";
+import { applyWhereClauseToObjectSet } from "../internal/conversions/applyWhereClauseToObjectSet.js";
 import type { MinimalClient } from "../MinimalClientContext.js";
 import { aggregate } from "../object/aggregate.js";
 import {
@@ -131,11 +131,11 @@ export function createObjectSet<Q extends ObjectOrInterfaceDefinition>(
     ) as ObjectSet<Q>["fetchPageWithErrors"],
 
     where: (clause) => {
-      return clientCtx.objectSetFactory(objectType, clientCtx, {
-        type: "filter",
-        objectSet,
-        where: modernToLegacyWhereClause(clause, objectType),
-      });
+      return clientCtx.objectSetFactory(
+        objectType,
+        clientCtx,
+        applyWhereClauseToObjectSet(objectSet, clause, objectType),
+      );
     },
 
     pivotTo<L extends LinkNames<Q>>(

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
@@ -1855,6 +1855,125 @@ const filterDefinitions = [
   render: (args) => <WithLinkedPropertyFiltersStory {...args} />,
 };
 
+// ---------------------------------------------------------------------------
+// Combined linked + direct filters via WhereClause link traversal
+// ---------------------------------------------------------------------------
+
+const combinedDepartmentFilter: FilterDefinitionUnion<Employee> = {
+  type: "PROPERTY",
+  id: "combined-department",
+  key: "department",
+  label: "Department",
+  filterComponent: "LISTOGRAM",
+  filterState: { type: "EXACT_MATCH", values: [] },
+};
+
+const combinedLocationCityFilter: FilterDefinitionUnion<Employee> = {
+  type: "PROPERTY",
+  id: "combined-locationCity",
+  key: "locationCity",
+  label: "Location City",
+  filterComponent: "MULTI_SELECT",
+  filterState: { type: "SELECT", selectedValues: [] },
+};
+
+const combinedLeadNameFilter: FilterDefinitionUnion<Employee> = {
+  type: "LINKED_PROPERTY",
+  id: "combined-lead-name",
+  linkName: "lead",
+  reverseLinkName: "peeps",
+  linkedPropertyKey: "fullName",
+  linkedFilterComponent: "MULTI_SELECT",
+  linkedFilterState: { type: "SELECT", selectedValues: [] },
+  filterState: {
+    type: "linkedProperty",
+    linkedFilterState: { type: "SELECT", selectedValues: [] },
+  },
+  label: "Manager Name",
+} as FilterDefinitionUnion<Employee>;
+
+const COMBINED_LINKED_FILTER_DEFINITIONS: FilterDefinitionUnion<Employee>[] = [
+  combinedLeadNameFilter,
+  combinedDepartmentFilter,
+  combinedLocationCityFilter,
+];
+
+function CombinedWithLinkedFilterStory(
+  args: Partial<EmployeeFilterListProps>,
+) {
+  const client = useOsdkClient();
+  const baseObjectSet = useMemo(() => client(Employee), [client]);
+
+  const [filterClause, setFilterClause] = useState<
+    WhereClause<Employee> | undefined
+  >(undefined);
+
+  const argsOnFilterClauseChanged = args.onFilterClauseChanged;
+  const handleFilterClauseChanged = useCallback(
+    (clause: WhereClause<Employee>) => {
+      setFilterClause(clause);
+      argsOnFilterClauseChanged?.(clause);
+    },
+    [argsOnFilterClauseChanged],
+  );
+
+  return (
+    <div style={COMBINED_LAYOUT_STYLE}>
+      <div style={SIDEBAR_FIXED_STYLE}>
+        <FilterList
+          {...args}
+          objectType={Employee}
+          objectSet={baseObjectSet}
+          filterDefinitions={COMBINED_LINKED_FILTER_DEFINITIONS}
+          filterClause={filterClause}
+          onFilterClauseChanged={handleFilterClauseChanged}
+        />
+      </div>
+      <div style={FLEX_FILL_STYLE}>
+        <ObjectTable
+          objectType={Employee}
+          objectSet={baseObjectSet}
+          filter={filterClause}
+        />
+      </div>
+    </div>
+  );
+}
+
+export const CombinedWithLinkedFilter: Story = {
+  name: "Combined linked + direct filters",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A linked filter (Manager Name) and direct property filters coexist in "
+          + "one FilterList. The FilterList emits a `filterClause` that includes "
+          + "linked-filter conditions via `$reverseLink`-tagged entries; the OSDK "
+          + "expands them to pivot+intersect when applying `where(filterClause)` "
+          + "on the ObjectTable's objectSet. Direct property facet counts reflect "
+          + "linked filter selections automatically.",
+      },
+      source: {
+        code: `const baseObjectSet = useMemo(() => client(Employee), [client]);
+
+<FilterList
+  objectType={Employee}
+  objectSet={baseObjectSet}
+  filterDefinitions={filterDefinitions}
+  filterClause={filterClause}
+  onFilterClauseChanged={setFilterClause}
+/>
+<ObjectTable
+  objectType={Employee}
+  objectSet={baseObjectSet}
+  filter={filterClause}
+/>`,
+      },
+    },
+  },
+  render: (args) => <CombinedWithLinkedFilterStory {...args} />,
+};
+
 function CustomNameContainsFilter({
   filterState,
   onFilterStateChanged,

--- a/packages/react-components/src/filter-list/__tests__/filterStateToWhereClause.test.ts
+++ b/packages/react-components/src/filter-list/__tests__/filterStateToWhereClause.test.ts
@@ -26,6 +26,7 @@ import {
   createDateRangeState,
   createHasLinkFilterDef,
   createKeywordSearchFilterDef,
+  createLinkedPropertyFilterDef,
   createNumberRangeState,
   createPropertyFilterDef,
   createSelectState,
@@ -232,6 +233,81 @@ describe("buildWhereClause", () => {
     );
     const result = buildWhereClause([def], filterStates);
     expect(result).toEqual({});
+  });
+
+  describe("LINKED_PROPERTY", () => {
+    it("emits $reverseLink-tagged link entry when reverseLinkName and selection are present", () => {
+      const def = createLinkedPropertyFilterDef("lead", "fullName", "peeps");
+      const filterStates = stateMap(
+        [def, {
+          type: "linkedProperty",
+          linkedFilterState: {
+            type: "EXACT_MATCH",
+            values: ["Alice", "Bob"],
+          },
+        }],
+      );
+      const result = buildWhereClause([def], filterStates);
+      expect(result).toEqual({
+        lead: {
+          $reverseLink: "peeps",
+          fullName: { $in: ["Alice", "Bob"] },
+        },
+      });
+    });
+
+    it("emits no clause when reverseLinkName is missing", () => {
+      const def = createLinkedPropertyFilterDef("lead", "fullName");
+      const filterStates = stateMap(
+        [def, {
+          type: "linkedProperty",
+          linkedFilterState: {
+            type: "EXACT_MATCH",
+            values: ["Alice"],
+          },
+        }],
+      );
+      const result = buildWhereClause([def], filterStates);
+      expect(result).toEqual({});
+    });
+
+    it("emits no clause when linked filter selection is empty", () => {
+      const def = createLinkedPropertyFilterDef("lead", "fullName", "peeps");
+      const filterStates = stateMap(
+        [def, {
+          type: "linkedProperty",
+          linkedFilterState: { type: "EXACT_MATCH", values: [] },
+        }],
+      );
+      const result = buildWhereClause([def], filterStates);
+      expect(result).toEqual({});
+    });
+
+    it("combines linked-filter clause with direct-property clause via $and", () => {
+      const linkedDef = createLinkedPropertyFilterDef(
+        "lead",
+        "fullName",
+        "peeps",
+      );
+      const directDef = createPropertyFilterDef("name", "MULTI_SELECT");
+      const filterStates = stateMap(
+        [linkedDef, {
+          type: "linkedProperty",
+          linkedFilterState: {
+            type: "EXACT_MATCH",
+            values: ["Alice"],
+          },
+        }],
+        [directDef, { type: "SELECT", selectedValues: ["Bob"] }],
+      );
+      const result = buildWhereClause([linkedDef, directDef], filterStates);
+      expect(result).toEqual({
+        $and: [
+          { lead: { $reverseLink: "peeps", fullName: "Alice" } },
+          { name: "Bob" },
+        ],
+      });
+    });
   });
 
   it("builds $containsAllTerms for keywordSearch filter with AND operator", () => {

--- a/packages/react-components/src/filter-list/__tests__/filterStateToWhereClause.test.ts
+++ b/packages/react-components/src/filter-list/__tests__/filterStateToWhereClause.test.ts
@@ -289,7 +289,11 @@ describe("buildWhereClause", () => {
         "fullName",
         "peeps",
       );
-      const directDef = createPropertyFilterDef("name", "MULTI_SELECT");
+      const directDef = createPropertyFilterDef(
+        "name",
+        "MULTI_SELECT",
+        { type: "SELECT", selectedValues: [] },
+      );
       const filterStates = stateMap(
         [linkedDef, {
           type: "linkedProperty",

--- a/packages/react-components/src/filter-list/__tests__/testUtils.ts
+++ b/packages/react-components/src/filter-list/__tests__/testUtils.ts
@@ -85,11 +85,13 @@ export function createHasLinkFilterDef(
 export function createLinkedPropertyFilterDef(
   linkName: string,
   linkedPropertyKey: string,
+  reverseLinkName?: string,
 ): FilterDefinitionUnion<typeof MockObjectType> {
   return {
     type: "LINKED_PROPERTY",
     linkName,
     linkedPropertyKey,
+    reverseLinkName,
     linkedFilterComponent: "LISTOGRAM",
     linkedFilterState: { type: "EXACT_MATCH", values: [] },
     filterState: {

--- a/packages/react-components/src/filter-list/types/LinkedFilterTypes.ts
+++ b/packages/react-components/src/filter-list/types/LinkedFilterTypes.ts
@@ -90,6 +90,14 @@ export interface LinkedPropertyFilterDefinition<
    */
   id?: string;
   linkName: L;
+  /**
+   * Name of the link on the linked object type that points back to `Q`.
+   * Emitted as `$reverseLink` on the link-keyed entry the FilterList adds
+   * to `filterClause` so the OSDK can pivot back to the source set when
+   * applying the where clause. Filters without `reverseLinkName` are
+   * skipped — they contribute no narrowing.
+   */
+  reverseLinkName?: LinkNames<LinkedQ>;
   linkedPropertyKey: LinkedK;
   linkedFilterComponent: LinkedC;
   linkedFilterState: FilterStateByComponentType[LinkedC];

--- a/packages/react-components/src/filter-list/utils/filterStateToWhereClause.ts
+++ b/packages/react-components/src/filter-list/utils/filterStateToWhereClause.ts
@@ -321,9 +321,12 @@ export function buildWhereClause<Q extends ObjectTypeDefinition>(
           break;
         }
         if (definition.reverseLinkName == null) {
-          // Without reverseLinkName the OSDK cannot pivot back to the source
-          // object type. The filter contributes no narrowing; documented on
-          // LinkedPropertyFilterDefinition.reverseLinkName.
+          if (process.env.NODE_ENV !== "production") {
+            // eslint-disable-next-line no-console
+            console.warn(
+              `[FilterList] LINKED_PROPERTY filter "${definition.linkName}" is missing reverseLinkName; filter will be skipped`,
+            );
+          }
           break;
         }
         const innerWhere = buildPropertyKeyClause(

--- a/packages/react-components/src/filter-list/utils/filterStateToWhereClause.ts
+++ b/packages/react-components/src/filter-list/utils/filterStateToWhereClause.ts
@@ -204,22 +204,12 @@ function filterStateToPropertyFilter(
 }
 
 /**
- * Builds a WhereClause from filter definitions and their current states.
- *
- * The filterStates map uses string keys derived from filter definitions via
- * getFilterKey(). This ensures stable state lookups even when filters are
- * reordered or definition object references change.
- *
- * Note: The `as WhereClause<Q>` casts are necessary because we're building
- * clauses dynamically from property keys determined at runtime. TypeScript
- * cannot verify that the constructed clause structure matches the generic Q's
- * expected shape, but the structure is guaranteed to be valid by construction.
- */
-/**
  * Builds a WHERE clause fragment for a single property key from filter state.
- * Shared by PROPERTY and STATIC_VALUES filter types.
+ * Shared by PROPERTY and STATIC_VALUES filter types, and reused by
+ * `applyLinkedFilters` to construct the inner where clause on a linked
+ * object's property.
  */
-function buildPropertyKeyClause(
+export function buildPropertyKeyClause(
   key: string,
   state: FilterState,
   propertyType?: string,
@@ -253,6 +243,18 @@ export interface PropertyTypeInfo {
   multiplicity: boolean;
 }
 
+/**
+ * Builds a WhereClause from filter definitions and their current states.
+ *
+ * The filterStates map uses string keys derived from filter definitions via
+ * getFilterKey(). This ensures stable state lookups even when filters are
+ * reordered or definition object references change.
+ *
+ * Note: The `as WhereClause<Q>` casts are necessary because we're building
+ * clauses dynamically from property keys determined at runtime. TypeScript
+ * cannot verify that the constructed clause structure matches the generic Q's
+ * expected shape, but the structure is guaranteed to be valid by construction.
+ */
 export function buildWhereClause<Q extends ObjectTypeDefinition>(
   definitions: Array<FilterDefinitionUnion<Q>> | undefined,
   filterStates: Map<string, FilterState>,
@@ -309,11 +311,34 @@ export function buildWhereClause<Q extends ObjectTypeDefinition>(
       }
 
       case "LINKED_PROPERTY": {
-        // OSDK WhereClause does not support filtering through links.
-        // Link-based filtering requires ObjectSet operations (pivotTo/intersect).
-        // LinkedProperty filters render UI for selection but cannot be included
-        // in the where clause. Consumers needing linked property filtering must
-        // implement it using ObjectSet.pivotTo() and intersect().
+        if (state.type !== "linkedProperty") {
+          if (process.env.NODE_ENV !== "production") {
+            // eslint-disable-next-line no-console
+            console.warn(
+              `[FilterList] State type mismatch for linkedProperty filter "${definition.linkName}": expected linkedProperty, got ${state.type}`,
+            );
+          }
+          break;
+        }
+        if (definition.reverseLinkName == null) {
+          // Without reverseLinkName the OSDK cannot pivot back to the source
+          // object type. The filter contributes no narrowing; documented on
+          // LinkedPropertyFilterDefinition.reverseLinkName.
+          break;
+        }
+        const innerWhere = buildPropertyKeyClause(
+          definition.linkedPropertyKey as string,
+          state.linkedFilterState,
+        );
+        if (innerWhere === undefined) {
+          break;
+        }
+        clauses.push({
+          [definition.linkName]: {
+            $reverseLink: definition.reverseLinkName,
+            ...innerWhere,
+          },
+        });
         break;
       }
 

--- a/packages/react-components/src/object-table/ObjectTable.tsx
+++ b/packages/react-components/src/object-table/ObjectTable.tsx
@@ -21,7 +21,6 @@ import type {
   PropertyKeys,
   QueryDefinition,
   SimplePropertyDef,
-  WhereClause,
 } from "@osdk/api";
 import type { Cell } from "@tanstack/react-table";
 import { getCoreRowModel, useReactTable } from "@tanstack/react-table";
@@ -149,11 +148,15 @@ export function ObjectTable<
           derivedObjectSet =
             change.isSelectAll && change.selectedRows.length > 0
               ? resultingObjectSet
-              : resultingObjectSet.where({
-                [primaryKeyApiName]: {
-                  $in: change.selectedRows.map(r => r.$primaryKey),
-                },
-              } as WhereClause<Q, RDPs>);
+              : resultingObjectSet.where(
+                {
+                  [primaryKeyApiName]: {
+                    $in: change.selectedRows.map(r => r.$primaryKey),
+                  },
+                } as unknown as Parameters<
+                  typeof resultingObjectSet["where"]
+                >[0],
+              );
         } else if (change.isSelectAll && change.selectedRows.length > 0) {
           derivedObjectSet = resultingObjectSet;
         }

--- a/packages/react-components/src/object-table/hooks/useFunctionColumnsData.ts
+++ b/packages/react-components/src/object-table/hooks/useFunctionColumnsData.ts
@@ -22,7 +22,6 @@ import type {
   PropertyKeys,
   QueryDefinition,
   SimplePropertyDef,
-  WhereClause,
 } from "@osdk/api";
 import {
   type FunctionQueryParams,
@@ -236,7 +235,7 @@ function buildPagedObjectSets<
       [primaryKeyApiName]: {
         $in: page.map(obj => obj.$primaryKey),
       },
-    } as WhereClause<Q, RDPs>;
+    } as unknown as Parameters<typeof objectSet["where"]>[0];
 
     return { objectSet: objectSet.where(whereClause), objects: page };
   });


### PR DESCRIPTION
extends whereclause so the filter list can express linked-property filters directly as where conditions; OSDK expands link-keyed entries into pivot+intersect ObjectSet compositions at where() time

• new `LinkWhereClause<T>` arm on `WhereClause<T, RDPs>` in `@osdk/api`; `.where()` runtime detects link entries via the `$reverseLink` sentinel and composes `searchAround → filter → searchAround → intersect`; `$and`/`$or`/`$not` compose via intersect/union/subtract
• filter-list `LINKED_PROPERTY` case emits `{ [linkName]: { $reverseLink, ...inner } }` from a new `reverseLinkName` field on `LinkedPropertyFilterDefinition`
• `perFilterWhereClauses` now naturally carry linked-filter conditions so direct property facet counts narrow correctly when a linked filter is active

supersedes #3287, which was building the ghost-row/applyLinkedFilters workaround for the same problem