### PR TITLE
[Component] ObjectTable: simplify RowSelectionChange + stability fixes

### DIFF
--- a/.changeset/object-table-row-selection-changed-payload-cleanup.md
+++ b/.changeset/object-table-row-selection-changed-payload-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+ObjectTable: drop the redundant `selectedRowIds` field from the `RowSelectionChange` payload delivered to `onRowSelectionChanged`. The primary keys are still available via `selectedRows.map(r => r.$primaryKey)`. `selectedRowIds` was redundant with `selectedRows` and was kept only as a transitional alias.

--- a/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.stories.tsx
@@ -200,7 +200,7 @@ const meta: Meta<EmployeeTableProps> = {
     },
     onRowSelectionChanged: {
       description:
-        "Called when the row selection changes, with a RowSelectionChange payload (selectedRowIds, selectedRows, isSelectAll, derived objectSet). Preferred over the deprecated onRowSelection callback.",
+        "Called when the row selection changes, with a RowSelectionChange payload (selectedRows, isSelectAll, derived objectSet). Preferred over the deprecated onRowSelection callback.",
       control: false,
       table: {
         category: "Events",
@@ -979,8 +979,7 @@ export const EventListeners: Story = {
     console.log("Column header clicked:", columnId);
   }}
   onRowSelectionChanged={(change) => {
-    console.log("Selection changed:", change.selectedRowIds, change.isSelectAll);
-    console.log("Selected rows:", change.selectedRows);
+    console.log("Selection changed:", change.selectedRows, change.isSelectAll);
     console.log("Derived objectSet:", change.objectSet);
   }}
   onOrderByChanged={(orderBy) => {
@@ -1025,7 +1024,9 @@ export const EventListeners: Story = {
     const handleRowSelectionChanged = useCallback(
       (change: any) => {
         args.onRowSelectionChanged?.(change);
-        setSelectedRows(change.selectedRowIds);
+        setSelectedRows(
+          change.selectedRows.map((r: any) => r.$primaryKey),
+        );
         setIsSelectAll(change.isSelectAll);
         setLastEvent("onRowSelectionChanged");
       },
@@ -1198,7 +1199,7 @@ return (
     selectedRows={selectedRows}
     isAllSelected={isSelectAll}
     onRowSelectionChanged={(change) => {
-      setSelectedRows(change.selectedRowIds);
+      setSelectedRows(change.selectedRows.map((r) => r.$primaryKey));
       setIsSelectAll(change.isSelectAll);
     }}
   />
@@ -1213,10 +1214,13 @@ return (
     const [isSelectAll, setIsSelectAll] = useState<boolean>(false);
     const handleRowSelectionChanged = useCallback(
       (
-        change: { selectedRowIds: any[]; isSelectAll: boolean },
+        change: {
+          selectedRows: Array<{ $primaryKey: any }>;
+          isSelectAll: boolean;
+        },
       ) => {
         args.onRowSelectionChanged?.(change as any);
-        setSelectedRows(change.selectedRowIds);
+        setSelectedRows(change.selectedRows.map((r) => r.$primaryKey));
         setIsSelectAll(change.isSelectAll);
       },
       [args],

--- a/packages/react-components/docs/ObjectTable.md
+++ b/packages/react-components/docs/ObjectTable.md
@@ -128,13 +128,13 @@ Each column header has a menu with items for sorting, filtering, pinning, resizi
 
 ### Row Selection
 
-| Prop                    | Type                                     | Default  | Description                                                                                                                                                                                                                 |
-| ----------------------- | ---------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `selectionMode`         | `"single" \| "multiple" \| "none"`       | `"none"` | Selection mode. "multiple" shows checkboxes                                                                                                                                                                                 |
-| `selectedRows`          | `PrimaryKeyType<Q>[]`                    | -        | Selected rows (controlled mode)                                                                                                                                                                                             |
-| `isAllSelected`         | `boolean`                                | -        | Indicates all rows are selected (controlled mode only)                                                                                                                                                                      |
-| `onRowSelectionChanged` | `(change: RowSelectionChange) => void`   | -        | **Preferred.** Fires with `{ selectedRowIds, selectedRows, isSelectAll, objectSet }`. The `objectSet` is the underlying set when "select all" is active, otherwise narrowed by `$primaryKey`. See [example](#row-selection) |
-| `onRowSelection`        | `(selectedRowIds, isSelectAll?) => void` | -        | **Deprecated** — use `onRowSelectionChanged`. Still fires for backwards compatibility. Refires with the expanded id list after "select all" + scroll                                                                        |
+| Prop                    | Type                                     | Default  | Description                                                                                                                                                                                                 |
+| ----------------------- | ---------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `selectionMode`         | `"single" \| "multiple" \| "none"`       | `"none"` | Selection mode. "multiple" shows checkboxes                                                                                                                                                                 |
+| `selectedRows`          | `PrimaryKeyType<Q>[]`                    | -        | Selected rows (controlled mode)                                                                                                                                                                             |
+| `isAllSelected`         | `boolean`                                | -        | Indicates all rows are selected (controlled mode only)                                                                                                                                                      |
+| `onRowSelectionChanged` | `(change: RowSelectionChange) => void`   | -        | **Preferred.** Fires with `{ selectedRows, isSelectAll, objectSet }`. The `objectSet` is the underlying set when "select all" is active, otherwise narrowed by `$primaryKey`. See [example](#row-selection) |
+| `onRowSelection`        | `(selectedRowIds, isSelectAll?) => void` | -        | **Deprecated** — use `onRowSelectionChanged`. Still fires for backwards compatibility. Refires with the expanded id list after "select all" + scroll                                                        |
 
 ### Interactions
 
@@ -665,14 +665,14 @@ function EmployeesTable() {
   objectType={Employee}
   selectionMode="multiple"
   onRowSelectionChanged={({
-    selectedRowIds,
     selectedRows,
     isSelectAll,
     objectSet,
   }) => {
-    // selectedRowIds: PrimaryKeyType<Employee>[] — current selection
-    // selectedRows:   loaded row instances matching selectedRowIds
-    //                 (pages not yet fetched are absent when isSelectAll)
+    // selectedRows:   loaded row instances currently selected.
+    //                 Pages not yet fetched are absent when isSelectAll.
+    //                 Use selectedRows.map(r => r.$primaryKey) if you
+    //                 need the primary keys.
     // isSelectAll:    true only when the user invoked "select all" (or
     //                 controlled isAllSelected={true}) — NOT just because
     //                 every visible row happens to be checked
@@ -692,12 +692,12 @@ function EmployeesTable() {
 
 The legacy `onRowSelection(selectedRowIds, isSelectAll?)` callback is deprecated but still fires for backwards compatibility. The equivalents in `onRowSelectionChanged` are:
 
-| Legacy parameter           | New payload field |
-| -------------------------- | ----------------- |
-| `selectedRowIds`           | `selectedRowIds`  |
-| `isSelectAll` (second arg) | `isSelectAll`     |
-| _(not previously exposed)_ | `selectedRows`    |
-| _(not previously exposed)_ | `objectSet`       |
+| Legacy parameter           | New payload field                      |
+| -------------------------- | -------------------------------------- |
+| `selectedRowIds`           | `selectedRows.map(r => r.$primaryKey)` |
+| `isSelectAll` (second arg) | `isSelectAll`                          |
+| _(not previously exposed)_ | `selectedRows`                         |
+| _(not previously exposed)_ | `objectSet`                            |
 
 ### Example 12: Custom Column Type
 

--- a/packages/react-components/src/object-table/ObjectTable.tsx
+++ b/packages/react-components/src/object-table/ObjectTable.tsx
@@ -76,6 +76,7 @@ export function ObjectTable<
   onOrderByChanged,
   onColumnsPinnedChanged,
   onColumnResize,
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- intentional pass-through to fire alongside onRowSelectionChanged for backwards compatibility
   onRowSelection,
   onRowSelectionChanged,
   onColumnHeaderClick,
@@ -146,18 +147,19 @@ export function ObjectTable<
       if (resultingObjectSet) {
         if (primaryKeyApiName) {
           derivedObjectSet =
-            change.isSelectAll && change.selectedRowIds.length > 0
+            change.isSelectAll && change.selectedRows.length > 0
               ? resultingObjectSet
               : resultingObjectSet.where({
-                [primaryKeyApiName]: { $in: change.selectedRowIds },
+                [primaryKeyApiName]: {
+                  $in: change.selectedRows.map(r => r.$primaryKey),
+                },
               } as WhereClause<Q, RDPs>);
-        } else if (change.isSelectAll && change.selectedRowIds.length > 0) {
+        } else if (change.isSelectAll && change.selectedRows.length > 0) {
           derivedObjectSet = resultingObjectSet;
         }
       }
 
       onRowSelectionChanged({
-        selectedRowIds: change.selectedRowIds,
         selectedRows: change.selectedRows,
         isSelectAll: change.isSelectAll,
         objectSet: derivedObjectSet,

--- a/packages/react-components/src/object-table/ObjectTableApi.ts
+++ b/packages/react-components/src/object-table/ObjectTableApi.ts
@@ -540,10 +540,9 @@ export interface ObjectTableProps<
    * Called when the row selection changes.
    *
    * @deprecated Use {@link onRowSelectionChanged} instead. The new callback
-   * delivers a {@link RowSelectionChange} object with `selectedRowIds`,
-   * `selectedRows`, `isSelectAll`, and a derived `objectSet`. This legacy
-   * callback continues to fire alongside the new one for backwards
-   * compatibility.
+   * delivers a {@link RowSelectionChange} object with `selectedRows`,
+   * `isSelectAll`, and a derived `objectSet`. This legacy callback
+   * continues to fire alongside the new one for backwards compatibility.
    *
    * @param selectedRowIds The primary keys of currently selected rows
    * @param isSelectAll Whether the change was triggered by a "select all" action. Defaults to false
@@ -597,21 +596,18 @@ export interface ObjectTableProps<
 
 /**
  * Payload for {@link ObjectTableProps.onRowSelectionChanged}. Consolidates
- * the primary-key list, loaded row instances, the `isSelectAll` semantic
- * intent, and an `ObjectSet` covering the selection.
+ * the loaded row instances, the `isSelectAll` semantic intent, and an
+ * `ObjectSet` covering the selection.
  */
 export interface RowSelectionChange<
   Q extends ObjectOrInterfaceDefinition,
   RDPs extends Record<string, SimplePropertyDef> = Record<string, never>,
 > {
-  /** Primary keys of currently selected rows. */
-  selectedRowIds: PrimaryKeyType<Q>[];
-
   /**
-   * Loaded row instances corresponding to `selectedRowIds`. When
-   * `isSelectAll` is true, this reflects only the rows currently in the
-   * table — pages not yet fetched are absent. Use `objectSet` for the
-   * cross-page view.
+   * Loaded row instances currently selected. When `isSelectAll` is true,
+   * this reflects only the rows currently in the table — pages not yet
+   * fetched are absent. Use `objectSet` for the cross-page view, and
+   * `selectedRows.map(r => r.$primaryKey)` if you need the primary keys.
    */
   selectedRows: Osdk.Instance<Q, "$allBaseProperties", PropertyKeys<Q>, RDPs>[];
 
@@ -619,7 +615,7 @@ export interface RowSelectionChange<
    * True when the user invoked "select all" (header checkbox) or when
    * controlled mode supplies `isAllSelected={true}`. Distinct from "every
    * loaded row happens to be selected" — that condition is reflected by
-   * `selectedRowIds.length` matching the visible row count but does not set
+   * `selectedRows.length` matching the visible row count but does not set
    * this flag.
    */
   isSelectAll: boolean;
@@ -631,7 +627,7 @@ export interface RowSelectionChange<
    *   provided, otherwise derived from `objectType` via `client(...)`).
    *   This includes rows not yet loaded into the table.
    * - Partial selection → the underlying `ObjectSet` narrowed to
-   *   `{ [primaryKeyApiName]: { $in: selectedRowIds } }`.
+   *   `{ [primaryKeyApiName]: { $in: selectedRows.map(r => r.$primaryKey) } }`.
    * - "Deselect all" → an empty `ObjectSet` (`$in: []`).
    *
    * `undefined` for interface types without a resolvable

--- a/packages/react-components/src/object-table/hooks/__tests__/useRowSelection.test.tsx
+++ b/packages/react-components/src/object-table/hooks/__tests__/useRowSelection.test.tsx
@@ -1175,7 +1175,6 @@ describe("useRowSelection", () => {
       });
 
       expect(onRowSelectionChanged).toHaveBeenCalledWith({
-        selectedRowIds: [data[0].$primaryKey],
         selectedRows: [data[0]],
         isSelectAll: false,
       });
@@ -1200,7 +1199,6 @@ describe("useRowSelection", () => {
       });
 
       expect(onRowSelectionChanged).toHaveBeenLastCalledWith({
-        selectedRowIds: [],
         selectedRows: [],
         isSelectAll: false,
       });
@@ -1225,7 +1223,6 @@ describe("useRowSelection", () => {
       });
 
       expect(onRowSelectionChanged).toHaveBeenLastCalledWith({
-        selectedRowIds: [data[0].$primaryKey, data[2].$primaryKey],
         selectedRows: [data[0], data[2]],
         isSelectAll: false,
       });
@@ -1250,11 +1247,6 @@ describe("useRowSelection", () => {
       });
 
       expect(onRowSelectionChanged).toHaveBeenLastCalledWith({
-        selectedRowIds: [
-          data[1].$primaryKey,
-          data[2].$primaryKey,
-          data[3].$primaryKey,
-        ],
         selectedRows: [data[1], data[2], data[3]],
         isSelectAll: false,
       });
@@ -1276,7 +1268,6 @@ describe("useRowSelection", () => {
       });
 
       expect(onRowSelectionChanged).toHaveBeenCalledWith({
-        selectedRowIds: data.map(item => item.$primaryKey),
         selectedRows: data,
         isSelectAll: true,
       });
@@ -1301,7 +1292,6 @@ describe("useRowSelection", () => {
       });
 
       expect(onRowSelectionChanged).toHaveBeenLastCalledWith({
-        selectedRowIds: [],
         selectedRows: [],
         isSelectAll: false,
       });
@@ -1333,7 +1323,6 @@ describe("useRowSelection", () => {
       // Both callbacks consistently report isSelectAll=false on deselect
       expect(onRowSelection).toHaveBeenLastCalledWith([], false);
       expect(onRowSelectionChanged).toHaveBeenLastCalledWith({
-        selectedRowIds: [],
         selectedRows: [],
         isSelectAll: false,
       });
@@ -1360,7 +1349,6 @@ describe("useRowSelection", () => {
       rerender({ data: moreData });
 
       expect(onRowSelectionChanged).toHaveBeenLastCalledWith({
-        selectedRowIds: moreData.map(item => item.$primaryKey),
         selectedRows: moreData,
         isSelectAll: true,
       });
@@ -1388,7 +1376,6 @@ describe("useRowSelection", () => {
         false,
       );
       expect(onRowSelectionChanged).toHaveBeenCalledWith({
-        selectedRowIds: [data[0].$primaryKey],
         selectedRows: [data[0]],
         isSelectAll: false,
       });
@@ -1410,7 +1397,6 @@ describe("useRowSelection", () => {
       });
 
       expect(onRowSelectionChanged).toHaveBeenCalledWith({
-        selectedRowIds: data.map(item => item.$primaryKey),
         selectedRows: data,
         isSelectAll: true,
       });
@@ -1433,7 +1419,6 @@ describe("useRowSelection", () => {
       });
 
       expect(onRowSelectionChanged).toHaveBeenCalledWith({
-        selectedRowIds: [data[0].$primaryKey, data[2].$primaryKey],
         selectedRows: [data[0], data[2]],
         isSelectAll: false,
       });
@@ -1456,7 +1441,6 @@ describe("useRowSelection", () => {
       });
 
       expect(onRowSelectionChanged).toHaveBeenCalledWith({
-        selectedRowIds: data.map(item => item.$primaryKey),
         selectedRows: data,
         isSelectAll: true,
       });

--- a/packages/react-components/src/object-table/hooks/useRowSelection.ts
+++ b/packages/react-components/src/object-table/hooks/useRowSelection.ts
@@ -23,6 +23,7 @@ import type {
 } from "@osdk/api";
 import type { RowSelectionState } from "@tanstack/react-table";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEventCallback } from "../../shared/hooks/useEventCallback.js";
 import { getRowId, getRowIdFromPrimaryKey } from "../utils/getRowId.js";
 
 /**
@@ -34,7 +35,6 @@ export interface UseRowSelectionChange<
   Q extends ObjectOrInterfaceDefinition,
   RDPs extends Record<string, SimplePropertyDef> = Record<string, never>,
 > {
-  selectedRowIds: PrimaryKeyType<Q>[];
   selectedRows: Osdk.Instance<
     Q,
     "$allBaseProperties",
@@ -86,6 +86,7 @@ export function useRowSelection<
   selectionMode = "none",
   selectedRows,
   isAllSelected: isAllSelectedProp,
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- intentional pass-through to fire alongside onRowSelectionChanged for backwards compatibility
   onRowSelection,
   onRowSelectionChanged,
   data,
@@ -145,7 +146,7 @@ export function useRowSelection<
   // Dedupes refires when "select all" is active and data grows.
   const lastFiredAllSelectedIdsRef = useRef<string | null>(null);
 
-  const fireSelectionCallbacks = useCallback(
+  const fireSelectionCallbacks = useEventCallback(
     (ids: PrimaryKeyType<Q>[], isSelectAll: boolean) => {
       onRowSelection?.(ids, isSelectAll);
       if (onRowSelectionChanged) {
@@ -155,13 +156,11 @@ export function useRowSelection<
           selectedKeySet.has(String(item.$primaryKey))
         );
         onRowSelectionChanged({
-          selectedRowIds: ids,
           selectedRows: instances,
           isSelectAll,
         });
       }
     },
-    [onRowSelection, onRowSelectionChanged, data],
   );
 
   const onToggleAll = useCallback(() => {
@@ -237,7 +236,7 @@ export function useRowSelection<
   );
 
   // Refire callbacks when uncontrolled "select all" is active and new rows arrive.
-  useEffect(() => {
+  useEffect(function syncSelectAllOnDataChange() {
     if (isControlled || !internalIsAllSelected || !data) {
       if (!internalIsAllSelected) {
         lastFiredAllSelectedIdsRef.current = null;


### PR DESCRIPTION
## Summary

Follow-up to #3277 addressing review comments from @nfdiop.

- **Drop redundant `selectedRowIds` from `RowSelectionChange`.** The payload delivered to `onRowSelectionChanged` no longer carries a separate primary-key list — `selectedRows.map(r => r.$primaryKey)` covers the use case. Removes duplication with `selectedRows`.
- **Stabilize `fireSelectionCallbacks` in `useRowSelection`.** Wraps it in the existing `useEventCallback` so the callback identity doesn't churn when consumers pass inline `onRowSelection` / `onRowSelectionChanged` handlers (which is the common case). Removes those callbacks from downstream `useCallback` deps.
- **Name the select-all data-sync `useEffect`.** Adds `function syncSelectAllOnDataChange` for clearer stack frames and devtools labels.

