### PR TITLE
[Component] Fix editable cell phantom outline and date picker styling

### DIFF
--- a/.changeset/fix-editable-cell-dropdown-and-datepicker-outlines.md
+++ b/.changeset/fix-editable-cell-dropdown-and-datepicker-outlines.md
@@ -1,0 +1,16 @@
+---
+"@osdk/react-components": patch
+---
+
+Fix two ObjectTable editable-cell visual issues:
+
+- Dropdown cell no longer shows a phantom "edited" outline after clearing a
+  never-set cell. `EditableCell` and `useEditableTable` now treat `null` and
+  `undefined` as the same empty state when deciding whether an edit is a
+  revert, so clearing a cell whose value was `undefined` removes the edit
+  entry instead of leaving a stale "edited" indicator. `""` remains a
+  distinct value — clearing an empty string still registers as an edit.
+- Date picker cell now shows the same focus outline as the text input cell,
+  and no longer renders the date picker's own box-shadow on top of the cell
+  border. The cell wrapper also reserves a transparent border so focusing
+  the picker doesn't shift layout.

--- a/packages/react-components/src/object-table/EditableCell.module.css
+++ b/packages/react-components/src/object-table/EditableCell.module.css
@@ -89,13 +89,17 @@
 }
 
 .osdkEditableCellDatePicker {
-  /* Override the default borders in date picker */
+  /* Override the default borders/shadow in date picker so the cell wrapper
+     is the only thing painting a border on focus. Without these overrides
+     the date picker's own input-wrapper draws a box-shadow on top of the
+     cell border, masking the cell's :focus-within outline. */
   --osdk-datetime-input-border-width: 0px;
   --osdk-datetime-input-border-color: transparent;
   --osdk-datetime-input-border-color-focus: transparent;
   --osdk-datetime-input-focus-width: 0px;
   --osdk-datetime-input-bg: transparent;
   --osdk-datetime-input-bg-hover: transparent;
+  --osdk-input-shadow: none;
 
   --osdk-datetime-input-padding: var(--osdk-surface-spacing)
     calc(var(--osdk-surface-spacing) * 3);
@@ -104,6 +108,9 @@
   align-items: center;
   justify-content: space-between;
   border-radius: var(--osdk-surface-border-radius);
+  /* Reserve space for the focus border so layout doesn't shift on focus,
+     matching .osdkEditableCell. */
+  border: var(--osdk-surface-border-width) solid transparent;
 
   tr[data-focused="true"] & {
     border: var(--osdk-table-cell-editable-border);

--- a/packages/react-components/src/object-table/EditableCell.tsx
+++ b/packages/react-components/src/object-table/EditableCell.tsx
@@ -28,6 +28,7 @@ import { DatePickerCellField } from "./components/DatePickerCellField.js";
 import { DropdownCellField } from "./components/DropdownCellField.js";
 import { TextInputCellField } from "./components/TextInputCellField.js";
 import styles from "./EditableCell.module.css";
+import { cellValuesEqual } from "./utils/editableUtils.js";
 import type { CellEditInfo, EditFieldConfig } from "./utils/types.js";
 
 const NUMBER_TYPES: readonly string[] = [
@@ -137,7 +138,7 @@ function EditableCellInner<TData extends RowData, CellValue = unknown>({
   }, []);
 
   const hasValidationError = validationError != null;
-  const isEdited = (currentValue ?? null) !== (initialValue ?? null);
+  const isEdited = !cellValuesEqual(currentValue, initialValue);
 
   useEffect(() => {
     setInputValue(valueToString(currentValue));
@@ -256,7 +257,11 @@ function EditableCellInner<TData extends RowData, CellValue = unknown>({
 
   const handleCommit = useCallback(
     (newValue: unknown) => {
-      if ((newValue ?? null) === (currentValue ?? null)) return;
+      // No-op if the value hasn't actually moved from what the cell already
+      // displays. null and undefined are treated as the same empty state so
+      // a dropdown that clears a never-set cell doesn't fire; "" stays
+      // distinct since an empty string can be meaningful data.
+      if (cellValuesEqual(newValue, currentValue)) return;
       commitEdit(newValue as CellValue);
     },
     [commitEdit, currentValue],

--- a/packages/react-components/src/object-table/hooks/__tests__/useEditableTable.test.ts
+++ b/packages/react-components/src/object-table/hooks/__tests__/useEditableTable.test.ts
@@ -106,6 +106,40 @@ describe("useEditableTable", () => {
     expect(result.current.cellEdits).toEqual({});
   });
 
+  it.each([
+    {
+      name: "null newValue clearing undefined oldValue",
+      newValue: null,
+      oldValue: undefined,
+    },
+    {
+      name: "undefined newValue clearing null oldValue",
+      newValue: undefined,
+      oldValue: null,
+    },
+    { name: "null clearing null", newValue: null, oldValue: null },
+  ])(
+    "removes cell from cellEdits when $name (null/undefined equivalence)",
+    ({ newValue, oldValue }) => {
+      const { result } = renderHook(() =>
+        useEditableTable({ editMode: "always" })
+      );
+      const cellId = getCellId({ rowId: "row-1", columnId: "col-1" });
+
+      act(() => {
+        result.current.onCellEdit(cellId, {
+          rowId: "row-1",
+          columnId: "col-1",
+          newValue,
+          oldValue,
+          originalRowData: createMockObjectInstance("row-1"),
+        });
+      });
+
+      expect(result.current.cellEdits).toEqual({});
+    },
+  );
+
   it("handles multiple cell edits", () => {
     const { result } = renderHook(() =>
       useEditableTable({ editMode: "always" })

--- a/packages/react-components/src/object-table/hooks/useEditableTable.ts
+++ b/packages/react-components/src/object-table/hooks/useEditableTable.ts
@@ -23,6 +23,7 @@ import type {
 } from "@osdk/api";
 import { useCallback, useState } from "react";
 import type { ObjectTableProps } from "../ObjectTableApi.js";
+import { cellValuesEqual } from "../utils/editableUtils.js";
 import type {
   CellEditInfo,
   EditableConfig,
@@ -109,8 +110,11 @@ export function useEditableTable<
         unknown
       >,
     ) => {
-      // If value is changed back to original, remove it from edits
-      if (info.newValue === info.oldValue) {
+      // If value is changed back to original, remove it from edits. null
+      // and undefined are treated as the same empty state so clearing a
+      // never-set cell doesn't leave a phantom "edited" indicator. "" stays
+      // a distinct value.
+      if (cellValuesEqual(info.newValue, info.oldValue)) {
         setCellEdits(prev => {
           const { [cellId]: _, ...rest } = prev;
           return rest;

--- a/packages/react-components/src/object-table/utils/editableUtils.ts
+++ b/packages/react-components/src/object-table/utils/editableUtils.ts
@@ -47,3 +47,14 @@ export function isCellEditable<TData extends RowData>(
   }
   return editable === true;
 }
+
+/**
+ * Whether two cell values are equivalent for the purpose of detecting "no
+ * actual edit". Treats `null` and `undefined` as the same "empty" state so
+ * clearing a never-set cell doesn't register as an edit. `""` is kept
+ * distinct because an empty string can be meaningful data (e.g. a data
+ * quality signal) and clearing it to null IS an edit.
+ */
+export function cellValuesEqual(a: unknown, b: unknown): boolean {
+  return (a ?? null) === (b ?? null);
+}


### PR DESCRIPTION
## Summary

- Clearing a never-set ObjectTable cell no longer leaves a phantom "edited" outline. `useEditableTable`'s revert-detection used strict `===`, so a `null` clear of an `undefined` cell stayed in `cellEdits` forever. Routed `useEditableTable` and `EditableCell` through a new `cellValuesEqual` helper that treats `null` and `undefined` as the same empty state. Empty string stays a distinct value — clearing `""` still registers as an edit.
- Date picker editable cell now shows the same focus outline as the text input cell. Killed `--osdk-input-shadow` inside `.osdkEditableCellDatePicker` (the date picker's inner `box-shadow` was sitting on top of the cell border) and reserved a transparent default border so focus doesn't shift layout.

## Demo

https://github.com/user-attachments/assets/372814f3-3ed5-44a1-a9c8-367552c3a6e6


