### PR TITLE
Add ActionForm edited tags

### DIFF
--- a/.changeset/bright-ferrets-edit.md
+++ b/.changeset/bright-ferrets-edit.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+ActionForm fields now show an `Edited` tag after users edit them.

--- a/packages/react-components/src/action-form/FormField.module.css
+++ b/packages/react-components/src/action-form/FormField.module.css
@@ -46,6 +46,21 @@
   gap: var(--osdk-form-label-row-gap);
 }
 
+.osdkFormFieldEditedTag {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  margin-inline-start: auto;
+  padding-block: calc(var(--osdk-surface-spacing) * 0.5);
+  padding-inline: calc(var(--osdk-surface-spacing) * 1.5);
+  border-radius: var(--osdk-surface-border-radius);
+  background-color: var(--osdk-custom-color-gray-2);
+  color: var(--osdk-typography-color-default-rest);
+  font-size: var(--osdk-typography-size-body-small);
+  font-weight: var(--osdk-typography-weight-bold);
+  line-height: var(--osdk-typography-line-height-default);
+}
+
 .osdkFormFieldInfoIcon {
   display: inline-flex;
   align-items: center;

--- a/packages/react-components/src/action-form/FormField.module.css
+++ b/packages/react-components/src/action-form/FormField.module.css
@@ -44,6 +44,11 @@
   display: flex;
   align-items: center;
   gap: var(--osdk-form-label-row-gap);
+  /* Reserve the edited pill's block size so showing it does not grow the label row. */
+  min-block-size: calc(
+    var(--osdk-typography-size-body-small) * var(--osdk-typography-line-height-default) +
+      var(--osdk-surface-spacing)
+  );
 }
 
 .osdkFormFieldEditedTag {

--- a/packages/react-components/src/action-form/FormField.module.css
+++ b/packages/react-components/src/action-form/FormField.module.css
@@ -45,10 +45,7 @@
   align-items: center;
   gap: var(--osdk-form-label-row-gap);
   /* Reserve the edited pill's block size so showing it does not grow the label row. */
-  min-block-size: calc(
-    var(--osdk-typography-size-body-small) * var(--osdk-typography-line-height-default) +
-      var(--osdk-surface-spacing)
-  );
+  min-block-size: var(--osdk-form-label-row-min-block-size);
 }
 
 .osdkFormFieldEditedTag {
@@ -56,14 +53,14 @@
   align-items: center;
   flex-shrink: 0;
   margin-inline-start: auto;
-  padding-block: calc(var(--osdk-surface-spacing) * 0.5);
-  padding-inline: calc(var(--osdk-surface-spacing) * 1.5);
-  border-radius: var(--osdk-surface-border-radius);
-  background-color: var(--osdk-custom-color-gray-2);
-  color: var(--osdk-typography-color-default-rest);
-  font-size: var(--osdk-typography-size-body-small);
-  font-weight: var(--osdk-typography-weight-bold);
-  line-height: var(--osdk-typography-line-height-default);
+  padding-block: var(--osdk-form-edited-tag-padding-block);
+  padding-inline: var(--osdk-form-edited-tag-padding-inline);
+  border-radius: var(--osdk-form-edited-tag-border-radius);
+  background-color: var(--osdk-form-edited-tag-bg);
+  color: var(--osdk-form-edited-tag-color);
+  font-size: var(--osdk-form-edited-tag-font-size);
+  font-weight: var(--osdk-form-edited-tag-font-weight);
+  line-height: var(--osdk-form-edited-tag-line-height);
 }
 
 .osdkFormFieldInfoIcon {

--- a/packages/react-components/src/action-form/FormField.tsx
+++ b/packages/react-components/src/action-form/FormField.tsx
@@ -25,6 +25,7 @@ interface FormFieldProps {
   isRequired?: boolean;
   helperText?: React.ReactNode;
   helperTextPlacement?: "bottom" | "tooltip";
+  isEdited?: boolean;
   error?: string;
   onBlur?: (e: React.FocusEvent<HTMLDivElement>) => void;
   children: React.ReactNode;
@@ -36,6 +37,7 @@ export const FormField: React.FC<FormFieldProps> = memo(function FormFieldFn({
   isRequired,
   helperText,
   helperTextPlacement = "tooltip",
+  isEdited,
   error,
   onBlur,
   children,
@@ -43,6 +45,7 @@ export const FormField: React.FC<FormFieldProps> = memo(function FormFieldFn({
   const hasHelperText = helperText != null && helperText !== "";
   const showTooltip = hasHelperText && helperTextPlacement === "tooltip";
   const showBottomText = hasHelperText && helperTextPlacement === "bottom";
+  const showEditedTag = isEdited === true;
 
   const labelElement = label != null
     ? (
@@ -57,17 +60,21 @@ export const FormField: React.FC<FormFieldProps> = memo(function FormFieldFn({
       </label>
     )
     : null;
+  const labelRow = labelElement != null || showTooltip || showEditedTag
+    ? (
+      <div className={styles.osdkFormFieldLabelRow}>
+        {labelElement}
+        {showTooltip && <InfoTip label={label}>{helperText}</InfoTip>}
+        {showEditedTag && (
+          <span className={styles.osdkFormFieldEditedTag}>Edited</span>
+        )}
+      </div>
+    )
+    : null;
 
   return (
     <div className={styles.osdkFormField} onBlur={onBlur}>
-      {showTooltip
-        ? (
-          <div className={styles.osdkFormFieldLabelRow}>
-            {labelElement}
-            <InfoTip label={label}>{helperText}</InfoTip>
-          </div>
-        )
-        : labelElement}
+      {labelRow}
       {showBottomText && (
         <div className={styles.osdkFormFieldHelperText}>{helperText}</div>
       )}

--- a/packages/react-components/src/action-form/__tests__/BaseForm.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/BaseForm.test.tsx
@@ -22,7 +22,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { FormContentItem } from "../ActionFormApi.js";
 import { BaseForm } from "../BaseForm.js";
@@ -73,6 +73,28 @@ describe("BaseForm", () => {
   });
 
   describe("uncontrolled mode", () => {
+    it("keeps edited state after a blank field is restored", async () => {
+      render(
+        <BaseForm formContent={[field(makeDef("name"))]} onSubmit={vi.fn()} />,
+      );
+
+      expect(screen.queryByText("Edited")).toBeNull();
+
+      const nameInput = screen.getByRole("textbox", { name: "name" });
+      fireEvent.change(nameInput, { target: { value: "Alice" } });
+
+      await waitFor(() => {
+        expect(screen.getByText("Edited")).toBeDefined();
+      });
+      expect(screen.getByRole("textbox", { name: "name" })).toBeDefined();
+
+      fireEvent.change(nameInput, { target: { value: "" } });
+
+      await waitFor(() => {
+        expect(screen.getByText("Edited")).toBeDefined();
+      });
+    });
+
     it("submits entered field values", async () => {
       const onSubmit = vi.fn();
 
@@ -320,6 +342,50 @@ describe("BaseForm", () => {
   });
 
   describe("controlled mode", () => {
+    it("keeps edited state after parent state updates and value is restored", async () => {
+      const content: ReadonlyArray<FormContentItem> = [field(makeDef("name"))];
+
+      function ControlledWrapper() {
+        const [formState, setFormState] = useState<Record<string, unknown>>({
+          name: "Initial",
+        });
+
+        const handleFieldChange = useCallback(
+          (fieldKey: string, value: unknown) => {
+            setFormState((prev) => ({ ...prev, [fieldKey]: value }));
+          },
+          [],
+        );
+
+        return (
+          <BaseForm
+            formContent={content}
+            formState={formState}
+            onFieldValueChange={handleFieldChange}
+            onSubmit={vi.fn()}
+          />
+        );
+      }
+
+      render(<ControlledWrapper />);
+
+      expect(screen.queryByText("Edited")).toBeNull();
+
+      const nameInput = screen.getByRole("textbox", { name: "name" });
+      fireEvent.change(nameInput, { target: { value: "Updated" } });
+
+      await waitFor(() => {
+        expect(screen.getByText("Edited")).toBeDefined();
+      });
+      expect(screen.getByRole("textbox", { name: "name" })).toBeDefined();
+
+      fireEvent.change(nameInput, { target: { value: "Initial" } });
+
+      await waitFor(() => {
+        expect(screen.getByText("Edited")).toBeDefined();
+      });
+    });
+
     it("calls onFieldValueChange when a field is edited", () => {
       const onFieldValueChange = vi.fn();
 
@@ -846,11 +912,12 @@ describe("BaseForm", () => {
       );
 
       expect(screen.queryByDisplayValue("sensitive value")).toBeNull();
-      expect(screen.getByRole("textbox", { name: /Unsupported/ }))
-        .toHaveProperty(
-          "value",
-          "Unsupported field type. Use a CUSTOM field instead",
-        );
+      expect(
+        screen.getByRole("textbox", { name: /Unsupported/ }),
+      ).toHaveProperty(
+        "value",
+        "Unsupported field type. Use a CUSTOM field instead",
+      );
 
       fireEvent.click(screen.getByRole("button", { name: /submit/i }));
 

--- a/packages/react-components/src/action-form/fields/FieldBridge.tsx
+++ b/packages/react-components/src/action-form/fields/FieldBridge.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo, useCallback, useMemo } from "react";
+import React, { memo, useCallback, useMemo, useState } from "react";
 import type { Control } from "react-hook-form";
 import { useController } from "react-hook-form";
 import type {
@@ -32,10 +32,7 @@ export interface FieldBridgeProps {
   portalContainer?: PortalContainer;
 }
 const SELECT_LIKE_FIELDS: ReadonlySet<FieldComponent> = new Set<FieldComponent>(
-  [
-    "RADIO_BUTTONS",
-    "SWITCH",
-  ],
+  ["RADIO_BUTTONS", "SWITCH"],
 );
 
 export const FieldBridge: React.FC<FieldBridgeProps> = memo(
@@ -45,10 +42,7 @@ export const FieldBridge: React.FC<FieldBridgeProps> = memo(
     onExternalChange,
     portalContainer,
   }: FieldBridgeProps): React.ReactElement {
-    const rules = useMemo(
-      () => extractValidationRules(fieldDef),
-      [fieldDef],
-    );
+    const rules = useMemo(() => extractValidationRules(fieldDef), [fieldDef]);
 
     const {
       field: { onChange, onBlur, value },
@@ -61,10 +55,15 @@ export const FieldBridge: React.FC<FieldBridgeProps> = memo(
 
     const isSelectLike = SELECT_LIKE_FIELDS.has(fieldDef.fieldComponent);
     const isDropdown = fieldDef.fieldComponent === "DROPDOWN";
+    // RHF's touched state is blur-based and dirty state is value-comparison
+    // based. The tag represents an actual user edit, so set it from the
+    // field change path and keep it visible even if the value is restored.
+    const [isEdited, setIsEdited] = useState(false);
 
     const handleChange = useCallback(
       (newValue: unknown) => {
         onChange(newValue);
+        setIsEdited(true);
         onExternalChange?.(fieldDef.fieldKey, newValue);
         // Select-like fields are "pick once" interactions — mark as touched
         // immediately so RHF revalidates (clears errors) on selection rather
@@ -99,6 +98,7 @@ export const FieldBridge: React.FC<FieldBridgeProps> = memo(
         // would fire prematurely when the popover opens.
         onBlur={isDropdown ? undefined : handleBlur}
         onFieldBlur={isDropdown ? onBlur : undefined}
+        isEdited={isEdited}
         error={fieldError?.message}
         portalContainer={portalContainer}
       />

--- a/packages/react-components/src/action-form/fields/FormFieldRenderer.tsx
+++ b/packages/react-components/src/action-form/fields/FormFieldRenderer.tsx
@@ -48,6 +48,7 @@ export interface FormFieldRendererProps {
   onBlur?: (e: React.FocusEvent<HTMLDivElement>) => void;
   /** Field-level blur for fields that own their touched state (e.g. dropdowns). */
   onFieldBlur?: () => void;
+  isEdited: boolean;
   error: string | undefined;
   portalContainer?: PortalContainer;
 }
@@ -59,6 +60,7 @@ export const FormFieldRenderer: React.FC<FormFieldRendererProps> = memo(
     onFieldValueChange,
     onBlur,
     onFieldBlur,
+    isEdited,
     error,
     portalContainer,
   }: FormFieldRendererProps): React.ReactElement {
@@ -72,6 +74,7 @@ export const FormFieldRenderer: React.FC<FormFieldRendererProps> = memo(
         fieldKey={fieldDefinition.fieldKey}
         helperText={helperText}
         helperTextPlacement={helperTextPlacement}
+        isEdited={isEdited}
         error={error}
         onBlur={onBlur}
       >

--- a/packages/react-components/src/tokens/component-tokens/form.css
+++ b/packages/react-components/src/tokens/component-tokens/form.css
@@ -44,6 +44,27 @@
   );
   --osdk-form-error-color: var(--osdk-typography-color-danger-rest);
 
+  /* Edited tag */
+  --osdk-form-edited-tag-bg: var(--osdk-custom-color-gray-2);
+  --osdk-form-edited-tag-color: var(--osdk-typography-color-default-rest);
+  --osdk-form-edited-tag-font-size: var(--osdk-typography-size-body-small);
+  --osdk-form-edited-tag-font-weight: var(--osdk-typography-weight-bold);
+  --osdk-form-edited-tag-line-height: var(
+    --osdk-typography-line-height-default
+  );
+  --osdk-form-edited-tag-padding-block: calc(var(--osdk-surface-spacing) * 0.5);
+  --osdk-form-edited-tag-padding-inline: calc(
+    var(--osdk-surface-spacing) * 1.5
+  );
+  --osdk-form-edited-tag-border-radius: var(--osdk-surface-border-radius);
+
+  /* Label row reserved height (accounts for edited tag) to avoid layout shift */
+  --osdk-form-label-row-min-block-size: calc(
+    var(--osdk-form-edited-tag-font-size) *
+      var(--osdk-form-edited-tag-line-height) +
+      var(--osdk-form-edited-tag-padding-block) * 2
+  );
+
   /* Form footer error indicator */
   --osdk-form-footer-error-color: var(--osdk-form-error-color);
   --osdk-form-footer-error-font-size: var(--osdk-typography-size-body-medium);


### PR DESCRIPTION
## Summary
- add an Edited tag to ActionForm fields after users edit them
- keep edited state tied to user changes rather than RHF dirty/touched semantics
- add coverage for restored values staying marked as edited

## Verification
- pnpm -C packages/react-components exec vitest run src/action-form/__tests__/BaseForm.test.tsx src/action-form/__tests__/FormField.test.tsx
- pnpm turbo typecheck --filter=@osdk/react-components
- git diff --check

<img width="633" height="583" alt="Screenshot 2026-05-18 at 13 57 29" src="https://github.com/user-attachments/assets/251f33f2-c131-449a-9973-4d911327965c" />