### PR TITLE
[maker-experimental] imported interface fixes

### DIFF
--- a/.changeset/tall-gifts-flow.md
+++ b/.changeset/tall-gifts-flow.md
@@ -1,0 +1,6 @@
+---
+"@osdk/generator-converters.ontologyir": patch
+"@osdk/maker-experimental": patch
+---
+
+fix imported interface shapes

--- a/packages/generator-converters.ontologyir/src/OntologyBlockDataToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyBlockDataToFullMetadataConverter.ts
@@ -747,12 +747,56 @@ export class OntologyBlockDataToFullMetadataConverter {
         }
       }
 
+      // Convert propertiesV3 to propertiesV2 (Ontologies.InterfacePropertyType)
+      const propertiesV2: Record<string, Ontologies.InterfacePropertyType> = {};
+      for (
+        const [_propRid, propValue] of Object.entries(
+          interfaceType.propertiesV3 ?? {},
+        )
+      ) {
+        if (propValue.type === "sharedPropertyBasedPropertyType") {
+          const spt = propValue.sharedPropertyBasedPropertyType
+            .sharedPropertyType;
+          const dataType = this.getOsdkPropertyTypeFromBlockData(spt.type);
+          if (dataType) {
+            propertiesV2[spt.apiName] = {
+              type: "interfaceSharedPropertyType",
+              rid: spt.rid,
+              apiName: spt.apiName,
+              displayName: spt.displayMetadata.displayName,
+              description: spt.displayMetadata.description ?? undefined,
+              dataType,
+              required: propValue.sharedPropertyBasedPropertyType
+                .requireImplementation,
+              typeClasses: [],
+            };
+          }
+        } else if (propValue.type === "interfaceDefinedPropertyType") {
+          const idp = propValue.interfaceDefinedPropertyType;
+          const dataType = this.getOsdkPropertyTypeFromBlockData(
+            idp.type as unknown as Type,
+          );
+          if (dataType) {
+            propertiesV2[idp.apiName] = {
+              type: "interfaceDefinedPropertyType",
+              rid: idp.rid,
+              apiName: idp.apiName,
+              displayName: idp.displayMetadata.displayName,
+              description: idp.displayMetadata.description ?? undefined,
+              dataType,
+              requireImplementation: idp.constraints.requireImplementation,
+              typeClasses: idp.constraints.typeClasses ?? [],
+            };
+          }
+        }
+      }
+
       const result_interfaceType: Ontologies.InterfaceType = {
         apiName: interfaceType.apiName,
         rid,
         properties,
         allProperties: properties, // Same as properties for now
-        propertiesV2: {},
+        propertiesV2,
         allPropertiesV2: {},
         extendsInterfaces: interfaceType.extendsInterfaces.map(val =>
           resolveBlockDataApiName(val, interfaceTypeLookup)

--- a/packages/generator-converters.ontologyir/src/OntologyBlockDataToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyBlockDataToFullMetadataConverter.ts
@@ -747,56 +747,12 @@ export class OntologyBlockDataToFullMetadataConverter {
         }
       }
 
-      // Convert propertiesV3 to propertiesV2 (Ontologies.InterfacePropertyType)
-      const propertiesV2: Record<string, Ontologies.InterfacePropertyType> = {};
-      for (
-        const [_propRid, propValue] of Object.entries(
-          interfaceType.propertiesV3 ?? {},
-        )
-      ) {
-        if (propValue.type === "sharedPropertyBasedPropertyType") {
-          const spt = propValue.sharedPropertyBasedPropertyType
-            .sharedPropertyType;
-          const dataType = this.getOsdkPropertyTypeFromBlockData(spt.type);
-          if (dataType) {
-            propertiesV2[spt.apiName] = {
-              type: "interfaceSharedPropertyType",
-              rid: spt.rid,
-              apiName: spt.apiName,
-              displayName: spt.displayMetadata.displayName,
-              description: spt.displayMetadata.description ?? undefined,
-              dataType,
-              required: propValue.sharedPropertyBasedPropertyType
-                .requireImplementation,
-              typeClasses: [],
-            };
-          }
-        } else if (propValue.type === "interfaceDefinedPropertyType") {
-          const idp = propValue.interfaceDefinedPropertyType;
-          const dataType = this.getOsdkPropertyTypeFromBlockData(
-            idp.type as unknown as Type,
-          );
-          if (dataType) {
-            propertiesV2[idp.apiName] = {
-              type: "interfaceDefinedPropertyType",
-              rid: idp.rid,
-              apiName: idp.apiName,
-              displayName: idp.displayMetadata.displayName,
-              description: idp.displayMetadata.description ?? undefined,
-              dataType,
-              requireImplementation: idp.constraints.requireImplementation,
-              typeClasses: idp.constraints.typeClasses ?? [],
-            };
-          }
-        }
-      }
-
       const result_interfaceType: Ontologies.InterfaceType = {
         apiName: interfaceType.apiName,
         rid,
         properties,
         allProperties: properties, // Same as properties for now
-        propertiesV2,
+        propertiesV2: {},
         allPropertiesV2: {},
         extendsInterfaces: interfaceType.extendsInterfaces.map(val =>
           resolveBlockDataApiName(val, interfaceTypeLookup)

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertActionHelpers.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertActionHelpers.ts
@@ -640,7 +640,9 @@ export function extractAllowedValues(
         objectTypeReference: {
           type: "objectTypeReference",
           objectTypeReference: {
-            interfaceTypeRids: allowedValues.interfaceTypes,
+            interfaceTypeRids: allowedValues.interfaceTypes.map(
+              apiName => ridGenerator.generateRidForInterface(apiName),
+            ),
           },
         },
       };

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertActionParameters.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertActionParameters.ts
@@ -88,6 +88,13 @@ export function convertActionParameters(
           };
           break;
 
+        case "objectTypeReference":
+          convertedType = {
+            type: "objectTypeReference",
+            objectTypeReference: {},
+          };
+          break;
+
         default:
           // Pass through other types unchanged
           convertedType = parameter.type;

--- a/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ImportedShapeExtractor.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ImportedShapeExtractor.ts
@@ -319,25 +319,16 @@ function extractImportedInterfaceTypes(
       interfaceType.apiName,
     );
 
-    // Build properties list (SPT references)
-    const properties: string[] = (interfaceType.properties ?? []).map(
-      (spt: any) => {
-        const sptId = knownIdentifiers.sharedPropertyTypes?.[spt.rid];
-        return sptId ?? spt.rid;
-      },
+    // Build properties list from propertiesV2 (SPT references as BlockInternalIds)
+    const properties: string[] = Object.values(
+      interfaceType.propertiesV2 ?? {},
+    ).map(propEntry =>
+      ridGenerator.toBlockInternalId(
+        ReadableIdGenerator.getForSpt(
+          propEntry.sharedPropertyType.apiName,
+        ),
+      )
     );
-
-    // Build propertiesV2 list (interface property references)
-    const propertiesV2: string[] = [];
-    for (
-      const [propertyRid] of Object.entries(interfaceType.propertiesV3 ?? {})
-    ) {
-      const propReadableId = ridGenerator.getInterfacePropertyTypeRids()
-        .inverse().get(propertyRid);
-      if (propReadableId) {
-        propertiesV2.push(ridGenerator.toBlockInternalId(propReadableId));
-      }
-    }
 
     // Build links list
     const links: string[] = (interfaceType.links ?? []).map(
@@ -353,7 +344,7 @@ function extractImportedInterfaceTypes(
         interfaceType.displayMetadata.description ?? "",
       ),
       properties,
-      propertiesV2,
+      propertiesV2: [],
       links,
     };
 
@@ -362,42 +353,19 @@ function extractImportedInterfaceTypes(
       interfaceType: inputShape,
     });
 
-    // Generate interface property type input shapes
+    // Generate SPT input shapes
     for (
-      const [propertyRid, property] of Object.entries(
-        interfaceType.propertiesV3 ?? {},
+      const [_sptRid, propEntry] of Object.entries(
+        interfaceType.propertiesV2 ?? {},
       )
     ) {
-      const propReadableId = ridGenerator.getInterfacePropertyTypeRids()
-        .inverse().get(propertyRid);
-      if (!propReadableId) continue;
+      const spt = propEntry.sharedPropertyType;
+      const sptReadableId = ReadableIdGenerator.getForSpt(spt.apiName);
+      if (blockShapes.inputShapes.has(sptReadableId)) continue;
 
-      if (property.type === "interfaceDefinedPropertyType") {
-        const propInputShape: InterfacePropertyTypeInputShape = {
-          about: createLocalizedAbout(
-            property.interfaceDefinedPropertyType.displayMetadata.displayName,
-            property.interfaceDefinedPropertyType.displayMetadata.description
-              ?? "",
-          ),
-          type: {
-            type: "objectPropertyType",
-            objectPropertyType: typeToMarketplaceObjectPropertyType(
-              property.interfaceDefinedPropertyType.type,
-            ),
-          },
-          interfaceType: ridGenerator.toBlockInternalId(interfaceReadableId),
-          requireImplementation:
-            property.interfaceDefinedPropertyType.constraints
-              .requireImplementation,
-        };
-        blockShapes.inputShapes.set(propReadableId, {
-          type: "interfacePropertyType",
-          interfacePropertyType: propInputShape,
-        });
-      } else if (property.type === "sharedPropertyBasedPropertyType") {
-        const spt = property.sharedPropertyBasedPropertyType.sharedPropertyType;
-        const sptReadableId = ReadableIdGenerator.getForSpt(spt.apiName);
-        const sharedPropInputShape: SharedPropertyTypeInputShape = {
+      blockShapes.inputShapes.set(sptReadableId, {
+        type: "sharedPropertyType",
+        sharedPropertyType: {
           about: createLocalizedAbout(
             spt.displayMetadata.displayName,
             spt.displayMetadata.description ?? "",
@@ -406,12 +374,48 @@ function extractImportedInterfaceTypes(
             type: "objectPropertyType",
             objectPropertyType: typeToMarketplaceObjectPropertyType(spt.type),
           },
-        };
-        blockShapes.inputShapes.set(sptReadableId, {
-          type: "sharedPropertyType",
-          sharedPropertyType: sharedPropInputShape,
-        });
-      }
+        },
+      });
+      blockShapes.inputShapeMetadata.set(sptReadableId, {
+        isOptional: false,
+        isAccessedInReconcile: true,
+        reconcileAccessRequirements: "RESOURCE_EXISTENCE_REQUIRED",
+        preallocateAccessRequirements: "RESOURCE_PREALLOCATION_REQUIRED",
+      });
+    }
+
+    // Generate interface-defined property type input shapes
+    for (
+      const [propertyRid, property] of Object.entries(
+        interfaceType.propertiesV3 ?? {},
+      )
+    ) {
+      if (property.type !== "interfaceDefinedPropertyType") continue;
+
+      const propReadableId = ridGenerator.getInterfacePropertyTypeRids()
+        .inverse().get(propertyRid);
+      if (!propReadableId) continue;
+
+      const propInputShape: InterfacePropertyTypeInputShape = {
+        about: createLocalizedAbout(
+          property.interfaceDefinedPropertyType.displayMetadata.displayName,
+          property.interfaceDefinedPropertyType.displayMetadata.description
+            ?? "",
+        ),
+        type: {
+          type: "objectPropertyType",
+          objectPropertyType: typeToMarketplaceObjectPropertyType(
+            property.interfaceDefinedPropertyType.type,
+          ),
+        },
+        interfaceType: ridGenerator.toBlockInternalId(interfaceReadableId),
+        requireImplementation: property.interfaceDefinedPropertyType.constraints
+          .requireImplementation,
+      };
+      blockShapes.inputShapes.set(propReadableId, {
+        type: "interfacePropertyType",
+        interfacePropertyType: propInputShape,
+      });
     }
 
     // Generate interface link type input shapes
@@ -421,24 +425,19 @@ function extractImportedInterfaceTypes(
         interfaceLinkType.metadata.apiName,
       );
 
-      const linkedEntityTypeRef = interfaceLinkType.linkedEntityTypeId.type
-          === "interfaceType"
+      const linkedInterfaceRid =
+        interfaceLinkType.linkedEntityTypeId.type === "interfaceType"
+          ? interfaceLinkType.linkedEntityTypeId.interfaceType
+          : undefined;
+
+      const linkedReadableId = linkedInterfaceRid
+        ? ridGenerator.getInterfaceRids().inverse().get(linkedInterfaceRid)
+        : undefined;
+
+      const linkedEntityTypeRef = linkedReadableId
         ? {
           type: "interfaceType" as const,
-          interfaceType: ridGenerator.toBlockInternalId(
-            ReadableIdGenerator.getForInterface(
-              // resolve interface RID to apiName
-              ridGenerator.getInterfaceRids().inverse().get(
-                  interfaceLinkType.linkedEntityTypeId.interfaceType,
-                )
-                ? ridGenerator.toBlockInternalId(
-                  ridGenerator.getInterfaceRids().inverse().get(
-                    interfaceLinkType.linkedEntityTypeId.interfaceType,
-                  )!,
-                )
-                : interfaceLinkType.linkedEntityTypeId.interfaceType,
-            ),
-          ),
+          interfaceType: ridGenerator.toBlockInternalId(linkedReadableId),
         }
         : undefined;
 

--- a/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ImportedShapeExtractor.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ImportedShapeExtractor.ts
@@ -394,7 +394,11 @@ function extractImportedInterfaceTypes(
 
       const propReadableId = ridGenerator.getInterfacePropertyTypeRids()
         .inverse().get(propertyRid);
-      if (!propReadableId) continue;
+      if (!propReadableId) {
+        throw new Error(
+          `Missing readable ID for interface-defined property RID ${propertyRid} on interface ${interfaceType.apiName}`,
+        );
+      }
 
       const propInputShape: InterfacePropertyTypeInputShape = {
         about: createLocalizedAbout(

--- a/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/IrShapeExtractor.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/IrShapeExtractor.ts
@@ -248,7 +248,14 @@ function extractInterfaceType(
     ),
   };
 
-  // Add shared property type input shapes for properties not in output
+  // Add shared property type input shapes for properties not in output,
+  // and extract value type input shapes for interface-defined properties
+  const blockShapesRef: BlockShapes = {
+    inputShapes: inputShapeMap,
+    outputShapes: outputShapeMap,
+    inputShapeMetadata: inputShapeMetadataMap,
+    inputMappings: [],
+  };
   for (
     const [_propertyRid, property] of Object.entries(
       interfaceType.propertiesV3,
@@ -278,6 +285,16 @@ function extractInterfaceType(
         },
       );
       inputShapeMetadataMap.set(sptReadableId, SPT_INPUT_SHAPE_METADATA);
+    } else if (property.type === "interfaceDefinedPropertyType") {
+      // TODO: once we have published output shapes for a while, add IPT input shapes
+      const idp = property.interfaceDefinedPropertyType;
+      extractValueTypeInputShapeIfPresent(
+        idp.constraints.valueType ?? undefined,
+        idp.displayMetadata.displayName,
+        idp.type as unknown as Type,
+        blockShapesRef,
+        ridGenerator,
+      );
     }
   }
 


### PR DESCRIPTION
misc interface fixes that came up during defense ontology testing

- Match imported interface input shapes to match java - only populate `properties` and use correct internal ids
- Fix imported interface link shapes
- Fix spt shape generation for imported interfaces
- Extract value type shapes from spts on all interfaces
- More objectTypeReference fixes on actions