### PR TITLE
Improve ActionForm Storybook stories

### DIFF
--- a/.changeset/busy-dodos-drum.md
+++ b/.changeset/busy-dodos-drum.md
@@ -1,0 +1,4 @@
+---
+---
+
+Improve ActionForm Storybook examples and documentation.

--- a/packages/react-components-storybook/src/mocks/fauxFoundry.ts
+++ b/packages/react-components-storybook/src/mocks/fauxFoundry.ts
@@ -63,6 +63,69 @@ type ActionParameterMap = Parameters<
   typeof TypeHelpers.createActionType
 >[0]["parameters"];
 
+const generatedFieldsActionParameters = {
+  fullName: {
+    displayName: "Full name",
+    dataType: { type: "string" },
+    required: true,
+    typeClasses: [],
+  },
+  yearsExperience: {
+    displayName: "Years of experience",
+    dataType: { type: "integer" },
+    required: false,
+    typeClasses: [],
+  },
+  isRemote: {
+    displayName: "Remote employee",
+    dataType: { type: "boolean" },
+    required: false,
+    typeClasses: [],
+  },
+  startDate: {
+    displayName: "Start date",
+    dataType: { type: "timestamp" },
+    required: false,
+    typeClasses: [],
+  },
+  document: {
+    displayName: "Document",
+    dataType: { type: "attachment" },
+    required: false,
+    typeClasses: [],
+  },
+  manager: {
+    displayName: "Manager",
+    dataType: {
+      type: "object",
+      objectApiName: "Employee",
+      objectTypeApiName: "Employee",
+    },
+    required: false,
+    typeClasses: [],
+  },
+  reviewPool: {
+    displayName: "Review pool",
+    dataType: {
+      type: "objectSet",
+      objectApiName: "Employee",
+      objectTypeApiName: "Employee",
+    },
+    required: false,
+    typeClasses: [],
+  },
+} satisfies ActionParameterMap;
+
+export const generatedFieldsStoryAction = TypeHelpers
+  .actionTypeBuilder(
+    TypeHelpers.createActionType({
+      apiName: "generatedFieldsStoryAction",
+      displayName: "Create employee profile",
+      parameters: generatedFieldsActionParameters,
+    }),
+  )
+  .build();
+
 const unsupportedFieldsActionParameters = {
   structPayload: {
     displayName: "Struct payload",
@@ -132,6 +195,10 @@ export async function setupFauxFoundry(): Promise<void> {
   );
   fauxFoundry.getDefaultOntology().registerActionType(
     toggleRemoteStoryAction.actionTypeV2,
+    () => undefined,
+  );
+  fauxFoundry.getDefaultOntology().registerActionType(
+    generatedFieldsStoryAction.actionTypeV2,
     () => undefined,
   );
   fauxFoundry.getDefaultOntology().registerActionType(

--- a/packages/react-components-storybook/src/stories/ActionForm/ActionForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ActionForm/ActionForm.stories.tsx
@@ -14,23 +14,81 @@
  * limitations under the License.
  */
 
-import type { ActionEditResponse } from "@osdk/api";
+import type { ActionDefinition, ActionEditResponse } from "@osdk/api";
 import type {
+  ActionFormProps,
   FormFieldDefinition,
   FormState,
 } from "@osdk/react-components/experimental";
 import { ActionForm } from "@osdk/react-components/experimental";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import React, { useState } from "react";
-import { fn } from "storybook/test";
+import React, { useCallback, useState } from "react";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import {
+  generatedFieldsStoryAction,
   unsupportedFieldsStoryAction,
   updateEmployeeStoryAction,
 } from "../../mocks/fauxFoundry.js";
+import {
+  FormStoryLayout,
+  type StorySubmissionSnapshot,
+  SubmissionOutputPanel,
+} from "./SubmissionOutputPanel.js";
 
 const actionDefinition = updateEmployeeStoryAction.actionDefinition;
+const generatedFieldsActionDefinition =
+  generatedFieldsStoryAction.actionDefinition;
 const unsupportedFieldsActionDefinition =
   unsupportedFieldsStoryAction.actionDefinition;
+const SUBMIT_DELAY_MS = 1500;
+interface UpdateEmployeeActionFormStoryProps {
+  formFieldDefinitions?: ReadonlyArray<
+    FormFieldDefinition<typeof actionDefinition>
+  >;
+  formTitle?: string;
+  isSubmitDisabled?: boolean;
+  onSubmit?: ActionFormProps<typeof actionDefinition>["onSubmit"];
+  showFormTitle?: boolean;
+}
+
+type UpdateEmployeeApplyAction = Parameters<
+  NonNullable<ActionFormProps<typeof actionDefinition>["onSubmit"]>
+>[1];
+type GeneratedFieldsApplyAction = Parameters<
+  NonNullable<
+    ActionFormProps<typeof generatedFieldsActionDefinition>["onSubmit"]
+  >
+>[1];
+type UnsupportedFieldsApplyAction = Parameters<
+  NonNullable<
+    ActionFormProps<typeof unsupportedFieldsActionDefinition>["onSubmit"]
+  >
+>[1];
+type StoryOnSubmit<Q extends ActionDefinition<unknown>> = NonNullable<
+  ActionFormProps<Q>["onSubmit"]
+>;
+type StoryOnError<Q extends ActionDefinition<unknown>> = NonNullable<
+  ActionFormProps<Q>["onError"]
+>;
+type StoryApplyAction<Q extends ActionDefinition<unknown>> = Parameters<
+  StoryOnSubmit<Q>
+>[1];
+
+interface UseActionFormSubmissionOptions<
+  Q extends ActionDefinition<unknown>,
+> {
+  applyStoryAction: (
+    formState: FormState<Q>,
+    applyAction: StoryApplyAction<Q>,
+  ) => Promise<ActionEditResponse | undefined>;
+  onSubmit?: StoryOnSubmit<Q>;
+}
+
+interface ActionFormSubmissionHandlers<Q extends ActionDefinition<unknown>> {
+  handleStoryError: StoryOnError<Q>;
+  handleStorySubmit: StoryOnSubmit<Q>;
+  submission: StorySubmissionSnapshot;
+}
 
 const actionFormDefaultValueFields: ReadonlyArray<
   FormFieldDefinition<typeof actionDefinition>
@@ -71,6 +129,7 @@ const actionFormDefaultValueFields: ReadonlyArray<
     fieldComponentProps: {
       items: [true, false],
       itemToStringLabel: (value) => value === true ? "Full-time" : "Contractor",
+      placeholder: "Select employment type",
     },
   },
 ];
@@ -113,56 +172,525 @@ const actionFormOverrideFields: ReadonlyArray<
     fieldComponentProps: {
       items: [true, false],
       itemToStringLabel: (value) => value === true ? "Full-time" : "Contractor",
+      placeholder: "Select employment type",
     },
   },
 ];
 
 const successSpy = fn().mockName("onSuccess");
 const errorSpy = fn().mockName("onError");
+const customSubmitSpy = fn().mockName("onSubmit");
+const slowSubmitSpy = fn().mockName("onSubmit:slow");
+const failingSubmitSpy = fn().mockName("onSubmit:failure");
 
 function handleSuccess(result: ActionEditResponse | undefined): void {
   successSpy(result);
 }
 
+function applyUpdateEmployeeStoryAction(
+  formState: FormState<typeof actionDefinition>,
+  applyAction: UpdateEmployeeApplyAction,
+): ReturnType<UpdateEmployeeApplyAction> {
+  // ActionForm passes coerced form values to custom submit handlers at runtime.
+  // The callback type currently exposes metadata-shaped ActionParameters, so the
+  // story uses the callback's parameter type to keep the example wired to the
+  // real apply path while preserving type safety.
+  return applyAction(
+    formState as unknown as Parameters<UpdateEmployeeApplyAction>[0],
+  );
+}
+
+function applyGeneratedFieldsStoryAction(
+  formState: FormState<typeof generatedFieldsActionDefinition>,
+  applyAction: GeneratedFieldsApplyAction,
+): ReturnType<GeneratedFieldsApplyAction> {
+  // See applyUpdateEmployeeStoryAction: this keeps the generated-fields story
+  // using the same applyAction path even though the callback type is metadata-shaped.
+  return applyAction(
+    formState as unknown as Parameters<GeneratedFieldsApplyAction>[0],
+  );
+}
+
+function applyUnsupportedFieldsStoryAction(
+  formState: FormState<typeof unsupportedFieldsActionDefinition>,
+  applyAction: UnsupportedFieldsApplyAction,
+): ReturnType<UnsupportedFieldsApplyAction> {
+  // See applyUpdateEmployeeStoryAction: unsupported-field stories still submit
+  // through the real applyAction path so the response panel shows true results.
+  return applyAction(
+    formState as unknown as Parameters<UnsupportedFieldsApplyAction>[0],
+  );
+}
+
+const handleCustomSubmit: NonNullable<
+  ActionFormProps<typeof actionDefinition>["onSubmit"]
+> = (formState, applyAction) => {
+  customSubmitSpy(formState);
+  return applyUpdateEmployeeStoryAction(formState, applyAction);
+};
+
+const handleSlowSubmit: NonNullable<
+  ActionFormProps<typeof actionDefinition>["onSubmit"]
+> = async (formState, applyAction) => {
+  slowSubmitSpy(formState);
+  await waitForStoryDelay(SUBMIT_DELAY_MS);
+  return applyUpdateEmployeeStoryAction(formState, applyAction);
+};
+
+const handleFailingSubmit: NonNullable<
+  ActionFormProps<typeof actionDefinition>["onSubmit"]
+> = async (formState) => {
+  failingSubmitSpy(formState);
+  await waitForStoryDelay(300);
+  throw new Error("Demo submission failed");
+};
+
+function waitForStoryDelay(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+function useActionFormSubmission<Q extends ActionDefinition<unknown>>({
+  applyStoryAction,
+  onSubmit,
+}: UseActionFormSubmissionOptions<Q>): ActionFormSubmissionHandlers<Q> {
+  const [submission, setSubmission] = useState<
+    StorySubmissionSnapshot
+  >({ status: "idle" });
+
+  const handleStorySubmit: StoryOnSubmit<Q> = useCallback(
+    async (formState, applyAction) => {
+      setSubmission({ status: "submitting", submittedValues: formState });
+      try {
+        let response: unknown;
+        if (onSubmit == null) {
+          const actionResponse = await applyStoryAction(
+            formState,
+            applyAction,
+          );
+          handleSuccess(actionResponse);
+          response = actionResponse;
+        } else {
+          response = await onSubmit(formState, applyAction);
+        }
+        setSubmission({
+          status: "success",
+          submittedValues: formState,
+          response,
+        });
+        return response;
+      } catch (error) {
+        setSubmission({ status: "error", submittedValues: formState, error });
+        throw error;
+      }
+    },
+    [applyStoryAction, onSubmit],
+  );
+
+  const handleStoryError: StoryOnError<Q> = useCallback((error) => {
+    setSubmission((currentSubmission) => ({
+      ...currentSubmission,
+      status: "error",
+      error,
+    }));
+    errorSpy(error);
+  }, []);
+
+  return { handleStoryError, handleStorySubmit, submission };
+}
+
+function UpdateEmployeeActionFormStory({
+  formFieldDefinitions,
+  formTitle,
+  isSubmitDisabled,
+  onSubmit,
+  showFormTitle,
+}: UpdateEmployeeActionFormStoryProps): React.ReactElement {
+  const { handleStoryError, handleStorySubmit, submission } =
+    useActionFormSubmission({
+      applyStoryAction: applyUpdateEmployeeStoryAction,
+      onSubmit,
+    });
+
+  return (
+    <FormStoryLayout
+      output={
+        <SubmissionOutputPanel
+          idleMessage="Submit the form to see the action response."
+          snapshot={submission}
+        />
+      }
+    >
+      <ActionForm
+        actionDefinition={actionDefinition}
+        formFieldDefinitions={formFieldDefinitions}
+        formTitle={formTitle}
+        isSubmitDisabled={isSubmitDisabled}
+        onError={handleStoryError}
+        onSubmit={handleStorySubmit}
+        showFormTitle={showFormTitle}
+      />
+    </FormStoryLayout>
+  );
+}
+
+function DefaultActionFormStory(): React.ReactElement {
+  const { handleStoryError, handleStorySubmit, submission } =
+    useActionFormSubmission({
+      applyStoryAction: applyGeneratedFieldsStoryAction,
+    });
+
+  return (
+    <FormStoryLayout
+      output={
+        <SubmissionOutputPanel
+          idleMessage="Submit the form to see the action response."
+          snapshot={submission}
+        />
+      }
+    >
+      <ActionForm
+        actionDefinition={generatedFieldsActionDefinition}
+        onError={handleStoryError}
+        onSubmit={handleStorySubmit}
+        showFormTitle={true}
+      />
+    </FormStoryLayout>
+  );
+}
+
+function UnsupportedFieldsActionFormStory(): React.ReactElement {
+  const { handleStoryError, handleStorySubmit, submission } =
+    useActionFormSubmission({
+      applyStoryAction: applyUnsupportedFieldsStoryAction,
+    });
+
+  return (
+    <FormStoryLayout
+      output={
+        <SubmissionOutputPanel
+          idleMessage="Submit the form to see the action response."
+          snapshot={submission}
+        />
+      }
+    >
+      <ActionForm
+        actionDefinition={unsupportedFieldsActionDefinition}
+        onError={handleStoryError}
+        onSubmit={handleStorySubmit}
+        showFormTitle={true}
+      />
+    </FormStoryLayout>
+  );
+}
+
 const meta = {
-  title: "Experimental/ActionForm",
-  component: ActionForm,
-  decorators: [
-    (Story) => (
-      <div className="osdkFormCard">
-        <Story />
-      </div>
-    ),
-  ],
+  title: "Experimental/ActionForm/Usage",
+  component: UpdateEmployeeActionFormStory,
   parameters: {
+    controls: {
+      expanded: true,
+    },
     docs: {
       description: {
         component:
-          "ActionForm fetches action metadata through @osdk/react and renders a submit-ready BaseForm. These stories exercise the same metadata and action hooks used by applications.",
+          "ActionForm fetches action metadata through @osdk/react, renders fields for each action parameter, validates user input, and submits through useOsdkAction.",
       },
     },
   },
-} satisfies Meta;
+  argTypes: {
+    formFieldDefinitions: {
+      control: false,
+      description:
+        "Complete replacement for generated fields. Include every action parameter that should appear in the form.",
+    },
+    formTitle: {
+      control: "text",
+      description: "Optional title used when showFormTitle is true.",
+    },
+    isSubmitDisabled: {
+      control: "boolean",
+      description: "Disables the submit button before validation runs.",
+    },
+    onSubmit: {
+      control: false,
+      table: { category: "Events" },
+    },
+    showFormTitle: {
+      control: "boolean",
+      description: "Shows the form title above the generated fields.",
+    },
+  },
+  args: {
+    isSubmitDisabled: false,
+    showFormTitle: false,
+  },
+} satisfies Meta<typeof UpdateEmployeeActionFormStory>;
 
 export default meta;
-type Story = StoryObj;
+type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  render: () => (
-    <ActionForm
-      actionDefinition={actionDefinition}
-      onSuccess={handleSuccess}
-      onError={errorSpy}
-    />
-  ),
+  render: () => <DefaultActionFormStory />,
   parameters: {
     docs: {
+      description: {
+        story:
+          "Shows ActionForm's default behavior: it maps action metadata to generated field components when no formFieldDefinitions are provided.",
+      },
       source: {
         code: `import { ActionForm } from "@osdk/react-components/experimental";
 
+// ActionForm reads the action definition metadata and chooses default
+// field components for supported parameter types.
+//
+// This story uses an action with this shape:
+//
+// {
+//   apiName: "generatedFieldsStoryAction",
+//   displayName: "Create employee profile",
+//   parameters: {
+//     fullName: {
+//       displayName: "Full name",
+//       dataType: { type: "string" },
+//       required: true,
+//     },
+//     yearsExperience: {
+//       displayName: "Years of experience",
+//       dataType: { type: "integer" },
+//     },
+//     isRemote: {
+//       displayName: "Remote employee",
+//       dataType: { type: "boolean" },
+//     },
+//     startDate: {
+//       displayName: "Start date",
+//       dataType: { type: "timestamp" },
+//     },
+//     document: {
+//       displayName: "Document",
+//       dataType: { type: "attachment" },
+//     },
+//     manager: {
+//       displayName: "Manager",
+//       dataType: {
+//         type: "object",
+//         objectTypeApiName: "Employee",
+//       },
+//     },
+//     reviewPool: {
+//       displayName: "Review pool",
+//       dataType: {
+//         type: "objectSet",
+//         objectTypeApiName: "Employee",
+//       },
+//     },
+//   },
+// }
+//
+// No formFieldDefinitions are passed here; the fields are generated from the
+// action metadata above.
 <ActionForm
+  actionDefinition={generatedFieldsStoryAction.actionDefinition}
+  showFormTitle={true}
+/>`,
+      },
+    },
+  },
+};
+
+export const SubmitSuccess: Story = {
+  play: async ({ canvasElement }) => {
+    successSpy.mockClear();
+
+    const canvas = within(canvasElement);
+    const fullNameInput = await canvas.findByRole("textbox", {
+      name: /^fullName/,
+    });
+    const submitButton = await canvas.findByRole("button", {
+      name: /submit/i,
+    });
+
+    await userEvent.type(
+      fullNameInput,
+      "Ada Lovelace",
+    );
+    await userEvent.click(submitButton);
+
+    await waitFor(() => expect(successSpy).toHaveBeenCalled());
+    await expect(await canvas.findByText("Submit succeeded."))
+      .toBeInTheDocument();
+    await expect(await canvas.findByText(/Ada Lovelace/)).toBeInTheDocument();
+  },
+};
+
+export const SubmitFailure: Story = {
+  args: {
+    onSubmit: handleFailingSubmit,
+  },
+  play: async ({ canvasElement }) => {
+    errorSpy.mockClear();
+    failingSubmitSpy.mockClear();
+
+    const canvas = within(canvasElement);
+    const fullNameInput = await canvas.findByRole("textbox", {
+      name: /^fullName/,
+    });
+    const submitButton = await canvas.findByRole("button", {
+      name: /submit/i,
+    });
+
+    await userEvent.type(
+      fullNameInput,
+      "Margaret Hamilton",
+    );
+    await userEvent.click(submitButton);
+
+    await waitFor(() => expect(failingSubmitSpy).toHaveBeenCalled());
+    await waitFor(() => expect(errorSpy).toHaveBeenCalled());
+    await expect(await canvas.findByText("Submit failed."))
+      .toBeInTheDocument();
+    await expect(await canvas.findByText(/Demo submission failed/))
+      .toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Uses a failing custom submit handler so the story shows the error state and serialized error response.",
+      },
+      source: {
+        code: `<ActionForm
   actionDefinition={updateEmployeeStoryAction}
-  onSuccess={(result) => console.log("Applied:", result)}
+  onSubmit={async () => {
+    throw new Error("Demo submission failed");
+  }}
+/>`,
+      },
+    },
+  },
+};
+
+export const ValidationErrors: Story = {
+  play: async ({ canvasElement }) => {
+    successSpy.mockClear();
+
+    const canvas = within(canvasElement);
+    await canvas.findByRole("textbox", { name: /^fullName/ });
+    const submitButton = await canvas.findByRole("button", {
+      name: /submit/i,
+    });
+    await userEvent.click(submitButton);
+
+    await expect(await canvas.findByRole("alert")).toBeInTheDocument();
+    await expect(successSpy).not.toHaveBeenCalled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Submits the untouched form to show the required-field validation summary. The action is not applied until required fields are valid.",
+      },
+    },
+  },
+};
+
+export const SubmitDisabled: Story = {
+  args: {
+    isSubmitDisabled: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByRole("button", { name: /submit/i }))
+      .toBeDisabled();
+  },
+};
+
+export const SlowCustomSubmit: Story = {
+  args: {
+    onSubmit: handleSlowSubmit,
+  },
+  play: async ({ canvasElement }) => {
+    slowSubmitSpy.mockClear();
+
+    const canvas = within(canvasElement);
+    const fullNameInput = await canvas.findByRole("textbox", {
+      name: /^fullName/,
+    });
+    const submitButton = await canvas.findByRole("button", {
+      name: /submit/i,
+    });
+
+    await userEvent.type(
+      fullNameInput,
+      "Katherine Johnson",
+    );
+    await userEvent.click(submitButton);
+
+    await waitFor(() => expect(slowSubmitSpy).toHaveBeenCalled());
+    await expect(
+      await canvas.findByRole("button", { name: /submitting/i }),
+    ).toBeDisabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Uses a delayed custom submit handler so users can see the pending button state without needing a real backend slowdown.",
+      },
+      source: {
+        code: `<ActionForm
+  actionDefinition={updateEmployeeStoryAction}
+  onSubmit={async (formState, applyAction) => {
+    await showReviewStep(formState);
+    await applyAction(formState);
+  }}
+/>`,
+      },
+    },
+  },
+};
+
+export const CustomSubmitHandler: Story = {
+  name: "Custom Submit Wrapper",
+  args: {
+    onSubmit: handleCustomSubmit,
+  },
+  play: async ({ canvasElement }) => {
+    customSubmitSpy.mockClear();
+
+    const canvas = within(canvasElement);
+    const fullNameInput = await canvas.findByRole("textbox", {
+      name: /^fullName/,
+    });
+    const submitButton = await canvas.findByRole("button", {
+      name: /submit/i,
+    });
+
+    await userEvent.type(
+      fullNameInput,
+      "Grace Hopper",
+    );
+    await userEvent.click(submitButton);
+
+    await waitFor(() =>
+      expect(customSubmitSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ fullName: "Grace Hopper" }),
+      )
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Wraps the default applyAction call with custom logic. Use this pattern to inspect, log, confirm, or transform submitted values before applying the action.",
+      },
+      source: {
+        code: `<ActionForm
+  actionDefinition={updateEmployeeStoryAction}
+  onSubmit={async (formState, applyAction) => {
+    console.log("Reviewing before submit", formState);
+    return applyAction(formState);
+  }}
 />`,
       },
     },
@@ -170,14 +698,9 @@ export const Default: Story = {
 };
 
 export const WithTitle: Story = {
-  render: () => (
-    <ActionForm
-      actionDefinition={actionDefinition}
-      showFormTitle={true}
-      onSuccess={handleSuccess}
-      onError={errorSpy}
-    />
-  ),
+  args: {
+    showFormTitle: true,
+  },
   parameters: {
     docs: {
       source: {
@@ -190,15 +713,17 @@ export const WithTitle: Story = {
   },
 };
 
+export const WithCustomTitle: Story = {
+  args: {
+    formTitle: "Update employee profile",
+    showFormTitle: true,
+  },
+};
+
 export const WithDefaultValues: Story = {
-  render: () => (
-    <ActionForm
-      actionDefinition={actionDefinition}
-      formFieldDefinitions={actionFormDefaultValueFields}
-      onSuccess={handleSuccess}
-      onError={errorSpy}
-    />
-  ),
+  args: {
+    formFieldDefinitions: actionFormDefaultValueFields,
+  },
   parameters: {
     docs: {
       source: {
@@ -238,6 +763,7 @@ export const WithDefaultValues: Story = {
       items: [true, false],
       itemToStringLabel: (value) =>
         value === true ? "Full-time" : "Contractor",
+      placeholder: "Select employment type",
     },
   },
 ] satisfies Array<FormFieldDefinition<typeof updateEmployeeStoryAction>>;
@@ -252,14 +778,9 @@ export const WithDefaultValues: Story = {
 };
 
 export const WithFieldOverrides: Story = {
-  render: () => (
-    <ActionForm
-      actionDefinition={actionDefinition}
-      formFieldDefinitions={actionFormOverrideFields}
-      onSuccess={handleSuccess}
-      onError={errorSpy}
-    />
-  ),
+  args: {
+    formFieldDefinitions: actionFormOverrideFields,
+  },
   parameters: {
     docs: {
       source: {
@@ -272,6 +793,16 @@ export const WithFieldOverrides: Story = {
     fieldComponentProps: {
       placeholder: "Ada Lovelace",
       minLength: 2,
+    },
+  },
+  {
+    fieldKey: "yearsExperience",
+    label: "Relevant experience",
+    fieldComponent: "NUMBER_INPUT",
+    helperText: "Whole years only.",
+    fieldComponentProps: {
+      min: 0,
+      max: 80,
     },
   },
   {
@@ -290,6 +821,7 @@ export const WithFieldOverrides: Story = {
       items: [true, false],
       itemToStringLabel: (value) =>
         value === true ? "Full-time" : "Contractor",
+      placeholder: "Select employment type",
     },
   },
 ] satisfies Array<FormFieldDefinition<typeof updateEmployeeStoryAction>>;
@@ -304,18 +836,47 @@ export const WithFieldOverrides: Story = {
 };
 
 export const WithUnsupportedFields: Story = {
-  render: () => (
-    <ActionForm
-      actionDefinition={unsupportedFieldsActionDefinition}
-      showFormTitle={true}
-      onSuccess={handleSuccess}
-      onError={errorSpy}
-    />
-  ),
+  render: () => <UnsupportedFieldsActionFormStory />,
   parameters: {
     docs: {
       source: {
-        code: `<ActionForm
+        code:
+          `// This story uses an action with parameter types that ActionForm does
+// not currently generate default field components for.
+//
+// {
+//   apiName: "unsupportedFieldsStoryAction",
+//   displayName: "Review unsupported fields",
+//   parameters: {
+//     structPayload: {
+//       displayName: "Struct payload",
+//       dataType: {
+//         type: "struct",
+//         fields: [
+//           {
+//             name: "externalId",
+//             fieldType: { type: "string" },
+//             required: true,
+//           },
+//         ],
+//       },
+//       required: true,
+//     },
+//     geoshape: {
+//       displayName: "Geoshape",
+//       dataType: { type: "geoshape" },
+//     },
+//     classification: {
+//       displayName: "Classification",
+//       dataType: { type: "marking" },
+//     },
+//     objectKind: {
+//       displayName: "Object type",
+//       dataType: { type: "objectType" },
+//     },
+//   },
+// }
+<ActionForm
   actionDefinition={unsupportedFieldsStoryAction.actionDefinition}
   showFormTitle={true}
 />`,
@@ -355,22 +916,35 @@ function ControlledActionFormStory(): React.ReactElement {
     isRemote: true,
     isFullTime: true,
   });
+  const { handleStoryError, handleStorySubmit, submission } =
+    useActionFormSubmission({
+      applyStoryAction: applyUpdateEmployeeStoryAction,
+    });
 
   return (
-    <>
-      <div className="osdkFormStorySpacing">
-        <strong>Current Form State:</strong>
-        <pre className="osdkCodeOutput">
-          {JSON.stringify(formState, null, 2)}
-        </pre>
-      </div>
-      <ActionForm
-        actionDefinition={actionDefinition}
-        formState={formState}
-        onFormStateChange={setFormState}
-        onSuccess={handleSuccess}
-        onError={errorSpy}
-      />
-    </>
+    <FormStoryLayout
+      output={
+        <SubmissionOutputPanel
+          idleMessage="Submit the form to see the action response."
+          snapshot={submission}
+        />
+      }
+    >
+      <>
+        <div className="osdkFormStorySpacing">
+          <strong>Current form state (JSON):</strong>
+          <pre className="osdkCodeOutput">
+              {JSON.stringify(formState, null, 2)}
+          </pre>
+        </div>
+        <ActionForm
+          actionDefinition={actionDefinition}
+          formState={formState}
+          onError={handleStoryError}
+          onFormStateChange={setFormState}
+          onSubmit={handleStorySubmit}
+        />
+      </>
+    </FormStoryLayout>
   );
 }

--- a/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
@@ -27,6 +27,11 @@ import React, { useCallback, useMemo, useState } from "react";
 import { fn } from "storybook/test";
 import { fauxFoundry } from "../../mocks/fauxFoundry.js";
 import { Employee } from "../../types/Employee.js";
+import {
+  FormStoryLayout,
+  type StorySubmissionSnapshot,
+  SubmissionOutputPanel,
+} from "./SubmissionOutputPanel.js";
 
 /**
  * Flattened (non-union) props type for Storybook Meta.
@@ -38,11 +43,13 @@ import { Employee } from "../../types/Employee.js";
 interface BaseFormStoryProps {
   formTitle?: string;
   formContent: ReadonlyArray<FormContentItem>;
-  onSubmit: (formState: Record<string, unknown>) => void;
+  onSubmit: (formState: Record<string, unknown>) => Promise<void> | void;
   isSubmitDisabled?: boolean;
   isPending?: boolean;
   isLoading?: boolean;
   className?: string;
+  submitButtonText?: string;
+  submitButtonVariant?: "primary" | "secondary";
 }
 
 function field(definition: RendererFieldDefinition): FormContentItem {
@@ -156,48 +163,49 @@ const formContent: ReadonlyArray<FormContentItem> = [
 
 const EMPTY_FORM_CONTENT: ReadonlyArray<FormContentItem> = [];
 
-const TOAST_DURATION_MS = 3000;
-
-// Module-level ref so handleSubmit can trigger the toast rendered by SubmitToast.
-const toastRef: { current: ((msg: string) => void) | undefined } = {
+// Most BaseForm stories share handleSubmit through CSF args, while the output
+// panel is mounted by a decorator. This bridge lets the shared submit handler
+// update the panel without rewriting every story with a custom render function.
+const submitOutputRef: {
+  current: ((snapshot: StorySubmissionSnapshot) => void) | undefined;
+} = {
   current: undefined,
 };
 
 // Spy that logs submissions to the Storybook Actions panel
-// and shows a brief success toast in the story canvas.
+// while the canvas shows the submitted values in the JSON panel.
 const submitSpy = fn().mockName("onSubmit");
 function handleSubmit(formState: Record<string, unknown>): void {
   submitSpy(formState);
-  toastRef.current?.("Submitted successfully");
+  submitOutputRef.current?.({
+    status: "success",
+    submittedValues: formState,
+    response: { message: "onSubmit completed" },
+  });
 }
 
-function SubmitToast(): React.ReactElement | null {
-  const [message, setMessage] = useState<string>();
+function BaseFormSubmissionOutput(): React.ReactElement {
+  const [snapshot, setSnapshot] = useState<StorySubmissionSnapshot>({
+    status: "idle",
+  });
+  submitOutputRef.current = setSnapshot;
 
-  const showToast = useCallback((msg: string) => {
-    setMessage(msg);
-    setTimeout(() => setMessage(undefined), TOAST_DURATION_MS);
-  }, []);
-
-  toastRef.current = showToast;
-
-  if (message == null) {
-    return null;
-  }
-  return <div className="osdkSubmitToast">{message}</div>;
+  return (
+    <SubmissionOutputPanel
+      idleMessage="Submit the form to see submitted values."
+      snapshot={snapshot}
+    />
+  );
 }
 
 const meta: Meta<BaseFormStoryProps> = {
-  title: "Experimental/ActionForm/Building Blocks/BaseForm",
+  title: "Experimental/ActionForm/BaseForm",
   component: BaseForm,
   decorators: [
     (Story) => (
-      <>
-        <SubmitToast />
-        <div className="osdkFormCard">
-          <Story />
-        </div>
-      </>
+      <FormStoryLayout output={<BaseFormSubmissionOutput />}>
+        <Story />
+      </FormStoryLayout>
     ),
   ],
   parameters: {
@@ -261,6 +269,21 @@ const meta: Meta<BaseFormStoryProps> = {
     className: {
       description: "Additional CSS class name for the form.",
       control: "text",
+    },
+    submitButtonText: {
+      description: "Text displayed in the submit button.",
+      control: "text",
+      table: {
+        defaultValue: { summary: "Submit" },
+      },
+    },
+    submitButtonVariant: {
+      description: "Visual variant of the submit button.",
+      control: "select",
+      options: ["primary", "secondary"],
+      table: {
+        defaultValue: { summary: "primary" },
+      },
     },
   },
 };
@@ -489,6 +512,27 @@ export const Pending: Story = {
   formContent={formContent}
   isPending={true}
   onSubmit={(formState) => console.log("Submitted:", formState)}
+/>`,
+      },
+    },
+  },
+};
+
+export const WithCustomSubmitButton: Story = {
+  args: {
+    formContent,
+    onSubmit: handleSubmit,
+    submitButtonText: "Save employee",
+    submitButtonVariant: "secondary",
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<BaseForm
+  formContent={formContent}
+  onSubmit={(formState) => console.log("Submitted:", formState)}
+  submitButtonText="Save employee"
+  submitButtonVariant="secondary"
 />`,
       },
     },
@@ -1090,6 +1134,7 @@ const formContent = [
         </span>
       ),
       isSearchable: true,
+      placeholder: "Search users...",
     },
   },
 ];
@@ -1574,7 +1619,7 @@ export const WithHelperText: Story = {
   parameters: {
     docs: {
       source: {
-        code: `const fieldDefinitions = [
+        code: `const formContent = [
   {
     fieldKey: "email",
     fieldComponent: "TEXT_INPUT",
@@ -1619,7 +1664,7 @@ export const WithHelperText: Story = {
 // "tooltip" (default) shows an info icon next to the label.
 // "bottom" renders the text below the label, above the input.
 <BaseForm
-  fieldDefinitions={fieldDefinitions}
+  formContent={formContent}
   onSubmit={(formState) => console.log("Submitted:", formState)}
 />`,
       },
@@ -1805,7 +1850,7 @@ export const WithObjectSelect: Story = {
   parameters: {
     docs: {
       source: {
-        code: `const fieldDefinitions = [
+        code: `const formContent = [
   {
     fieldKey: "name",
     fieldComponent: "TEXT_INPUT",
@@ -1827,7 +1872,7 @@ export const WithObjectSelect: Story = {
 // OBJECT_SELECT renders a searchable dropdown that queries
 // the Foundry ontology for objects matching the search term.
 <BaseForm
-  fieldDefinitions={fieldDefinitions}
+  formContent={formContent}
   onSubmit={(formState) => console.log("Submitted:", formState)}
 />`,
       },

--- a/packages/react-components-storybook/src/stories/ActionForm/SubmissionOutputPanel.tsx
+++ b/packages/react-components-storybook/src/stories/ActionForm/SubmissionOutputPanel.tsx
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+
+const FORM_STORY_LAYOUT_STYLE = {
+  display: "flex",
+  gap: 16,
+  alignItems: "flex-start",
+} as const;
+
+const SUBMISSION_OUTPUT_STYLE = {
+  flex: 1,
+  minWidth: 360,
+} as const;
+
+const SUBMISSION_STATUS_STYLE = {
+  marginTop: 8,
+  marginBottom: 8,
+  fontSize: 12,
+  fontWeight: 600,
+} as const;
+
+const SUBMISSION_PRE_STYLE = {
+  marginTop: 8,
+  padding: 12,
+  background: "#f5f5f5",
+  borderRadius: 4,
+  fontSize: 12,
+  overflow: "auto",
+  maxHeight: 560,
+} as const;
+
+export type StorySubmissionStatus =
+  | "idle"
+  | "submitting"
+  | "success"
+  | "error";
+
+export interface StorySubmissionSnapshot {
+  status: StorySubmissionStatus;
+  submittedValues?: unknown;
+  response?: unknown;
+  error?: unknown;
+}
+
+interface FormStoryLayoutProps {
+  children: React.ReactNode;
+  output: React.ReactNode;
+}
+
+export function FormStoryLayout({
+  children,
+  output,
+}: FormStoryLayoutProps): React.ReactElement {
+  return (
+    <div style={FORM_STORY_LAYOUT_STYLE}>
+      <div className="osdkFormCard">{children}</div>
+      {output}
+    </div>
+  );
+}
+
+interface SubmissionOutputPanelProps {
+  idleMessage: string;
+  snapshot: StorySubmissionSnapshot;
+}
+
+export function SubmissionOutputPanel({
+  idleMessage,
+  snapshot,
+}: SubmissionOutputPanelProps): React.ReactElement {
+  const responseJson = snapshot.status === "idle"
+    ? "(no submission yet)"
+    : stringifyStoryValue(buildSubmissionJson(snapshot));
+  const isError = snapshot.status === "error";
+
+  return (
+    <div style={SUBMISSION_OUTPUT_STYLE}>
+      <strong>Submission response (JSON):</strong>
+      <div
+        role={isError ? "alert" : "status"}
+        style={{
+          ...SUBMISSION_STATUS_STYLE,
+          color: isError ? "#c23030" : "#276749",
+        }}
+      >
+        {getSubmissionStatusText(snapshot.status, idleMessage)}
+      </div>
+      <pre style={SUBMISSION_PRE_STYLE}>{responseJson}</pre>
+    </div>
+  );
+}
+
+function getSubmissionStatusText(
+  status: StorySubmissionStatus,
+  idleMessage: string,
+): string {
+  switch (status) {
+    case "idle":
+      return idleMessage;
+    case "submitting":
+      return "Submitting…";
+    case "success":
+      return "Submit succeeded.";
+    case "error":
+      return "Submit failed.";
+  }
+}
+
+function buildSubmissionJson(snapshot: StorySubmissionSnapshot): unknown {
+  return {
+    status: snapshot.status,
+    submittedValues: snapshot.submittedValues ?? null,
+    response: snapshot.response ?? null,
+    error: snapshot.error ?? null,
+  };
+}
+
+function stringifyStoryValue(value: unknown): string {
+  return JSON.stringify(value, storyJsonReplacer, 2) ?? String(value);
+}
+
+function storyJsonReplacer(_key: string, value: unknown): unknown {
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+    };
+  }
+  // Storybook can render docs in non-browser contexts where File is not
+  // defined, so guard the constructor before serializing uploaded files.
+  if (typeof File !== "undefined" && value instanceof File) {
+    return {
+      name: value.name,
+      size: value.size,
+      type: value.type,
+    };
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  return value;
+}

--- a/packages/react-components-storybook/src/styles/storybook.css
+++ b/packages/react-components-storybook/src/styles/storybook.css
@@ -43,33 +43,6 @@ body {
   color: #2563eb;
 }
 
-/* Submit toast — auto-dismissing success banner */
-.osdkSubmitToast {
-  max-width: 480px;
-  width: 100%;
-  margin-bottom: calc(var(--osdk-surface-spacing) * 2);
-  padding: calc(var(--osdk-surface-spacing) * 2)
-    calc(var(--osdk-surface-spacing) * 3);
-  background: var(--osdk-intent-success-rest);
-  color: var(--osdk-intent-success-foreground);
-  border-radius: var(--osdk-surface-border-radius);
-  font-size: var(--osdk-typography-size-body-small);
-  font-weight: 500;
-  animation: osdkToastFadeIn 0.2s ease-out;
-}
-
-@keyframes osdkToastFadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(-8px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
 .osdkFormCard {
   --osdk-form-label-font-size: var(--osdk-typography-size-body-small);
   --osdk-form-content-padding-inline: calc(var(--osdk-surface-spacing) * 4);


### PR DESCRIPTION
## Summary
- reorganize ActionForm/BaseForm stories under Experimental/ActionForm
- make ActionForm default story demonstrate generated fields from action metadata
- add shared JSON submission output panel for ActionForm and BaseForm stories
- document action shapes for default and unsupported-field examples

## Verification
- Storybook works as expected


#### Before
<img width="1508" height="831" alt="Screenshot 2026-05-19 at 10 03 32" src="https://github.com/user-attachments/assets/214a0776-c1ce-4153-91a9-82bb48a2c4ba" />

#### After
<img width="1508" height="831" alt="Screenshot 2026-05-19 at 10 03 10" src="https://github.com/user-attachments/assets/00ca3134-782e-4fe4-9aed-024bbe2430ec" />


