### PR TITLE
Add --osdk-table-cell-bg

### DIFF
--- a/.changeset/object-table-cell-background-token.md
+++ b/.changeset/object-table-cell-background-token.md
@@ -1,0 +1,18 @@
+---
+"@osdk/react-components": minor
+---
+
+Add `--osdk-table-cell-bg` CSS variable on `ObjectTable` / `BaseTable`
+cells, and tag each `<td>` with `data-editable="true"` when the cell renders
+as editable. The variable defaults to `inherit`, preserving current visuals.
+
+Renamed `--osdk-table-cell-editable-bg` to `--osdk-table-cell-input-bg`. 
+
+Combine the two to highlight editable cells before any row is clicked into,
+without altering component logic:
+
+```css
+.my-table td[data-editable] {
+  --osdk-table-cell-bg: var(--my-editable-tint);
+}
+```

--- a/packages/react-components-styles/CSS_VARIABLES.md
+++ b/packages/react-components-styles/CSS_VARIABLES.md
@@ -234,7 +234,7 @@ Styling for dialog/modal components.
 | Variable                          | Default Value                                                                 | Description              |
 | --------------------------------- | ----------------------------------------------------------------------------- | ------------------------ |
 | `--osdk-dialog-padding`           | `calc(var(--osdk-surface-spacing) * 2) calc(var(--osdk-surface-spacing) * 4)` | Base dialog padding      |
-| `--osdk-dialog-backdrop-bg`       | `var(--osdk-background-backdrop)`                                           | Backdrop overlay color   |
+| `--osdk-dialog-backdrop-bg`       | `var(--osdk-background-backdrop)`                                             | Backdrop overlay color   |
 | `--osdk-dialog-header-padding`    | `var(--osdk-dialog-padding)`                                                  | Header section padding   |
 | `--osdk-dialog-title-font-size`   | `var(--osdk-typography-size-body-medium)`                                     | Dialog title font size   |
 | `--osdk-dialog-title-font-weight` | `var(--osdk-typography-weight-bold)`                                          | Dialog title font weight |
@@ -313,29 +313,29 @@ These variables define the purpose of each border type, making it easier to cust
 
 #### Cell Styling
 
-| Variable                     | Default Value                            | Description |
-| ---------------------------- | ---------------------------------------- | ----------- |
-| `--osdk-table-cell-padding`  | `0 calc(var(--osdk-surface-spacing) * 2)` | Cell padding |
-| `--osdk-table-cell-fontSize` | `var(--osdk-typography-size-body-medium)` | Cell text size |
+| Variable                     | Default Value                               | Description     |
+| ---------------------------- | ------------------------------------------- | --------------- |
+| `--osdk-table-cell-padding`  | `0 calc(var(--osdk-surface-spacing) * 2)`   | Cell padding    |
+| `--osdk-table-cell-fontSize` | `var(--osdk-typography-size-body-medium)`   | Cell text size  |
 | `--osdk-table-cell-color`    | `var(--osdk-typography-color-default-rest)` | Cell text color |
 
 #### Editable Cell Styling
 
-| Variable                               | Default Value                              | Description                                         |
-| -------------------------------------- | ------------------------------------------ | --------------------------------------------------- |
-| `--osdk-table-cell-editable-border`   | `var(--osdk-surface-border-width) solid var(--osdk-surface-border-color-strong)` | Border for editable cells in edit mode |
-| `--osdk-table-cell-edited-border`     | `var(--osdk-surface-border-width) solid var(--osdk-intent-primary-rest)` | Border for edited cells with pending changes |
-| `--osdk-table-cell-edited-border-error` | `var(--osdk-surface-border-width) solid var(--osdk-intent-danger-rest)` | Border for cells with validation errors |
-| `--osdk-table-cell-editable-bg`       | `var(--osdk-background-primary)`           | Background for editable cells |
+| Variable                                | Default Value                                                                    | Description                                  |
+| --------------------------------------- | -------------------------------------------------------------------------------- | -------------------------------------------- |
+| `--osdk-table-cell-editable-border`     | `var(--osdk-surface-border-width) solid var(--osdk-surface-border-color-strong)` | Border for editable cells in edit mode       |
+| `--osdk-table-cell-edited-border`       | `var(--osdk-surface-border-width) solid var(--osdk-intent-primary-rest)`         | Border for edited cells with pending changes |
+| `--osdk-table-cell-edited-border-error` | `var(--osdk-surface-border-width) solid var(--osdk-intent-danger-rest)`          | Border for cells with validation errors      |
+| `--osdk-table-cell-input-bg`            | `var(--osdk-background-primary)`                                                 | Background for editable cells                |
 
 #### Edit Container
 
-| Variable                             | Default Value                                      | Description                                |
-| ------------------------------------ | -------------------------------------------------- | ------------------------------------------ |
-| `--osdk-table-edit-container-padding` | `calc(var(--osdk-surface-spacing) * 2) calc(var(--osdk-surface-spacing) * 4)` | Padding for the edit controls container |
-| `--osdk-table-edit-container-min-height` | `calc(var(--osdk-surface-spacing) * 12)`      | Minimum height for edit controls container |
-| `--osdk-table-cell-fontSize` | `var(--osdk-typography-size-body-medium)`   | Cell text size  |
-| `--osdk-table-cell-color`    | `var(--osdk-typography-color-default-rest)` | Cell text color |
+| Variable                                 | Default Value                                                                 | Description                                |
+| ---------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------ |
+| `--osdk-table-edit-container-padding`    | `calc(var(--osdk-surface-spacing) * 2) calc(var(--osdk-surface-spacing) * 4)` | Padding for the edit controls container    |
+| `--osdk-table-edit-container-min-height` | `calc(var(--osdk-surface-spacing) * 12)`                                      | Minimum height for edit controls container |
+| `--osdk-table-cell-fontSize`             | `var(--osdk-typography-size-body-medium)`                                     | Cell text size                             |
+| `--osdk-table-cell-color`                | `var(--osdk-typography-color-default-rest)`                                   | Cell text color                            |
 
 #### Header Menu
 
@@ -356,17 +356,17 @@ Styling for the column header dropdown menu.
 
 Styling for column resize handles.
 
-| Variable                            | Default Value                            | Description                |
-| ----------------------------------- | ---------------------------------------- | -------------------------- |
+| Variable                            | Default Value                        | Description                |
+| ----------------------------------- | ------------------------------------ | -------------------------- |
 | `--osdk-table-resizer-color-hover`  | `var(--osdk-custom-color-primary-1)` | Resize handle hover color  |
-| `--osdk-table-resizer-color-active` | `var(--osdk-intent-primary-rest)`        | Resize handle active color |
+| `--osdk-table-resizer-color-active` | `var(--osdk-intent-primary-rest)`    | Resize handle active color |
 
 #### Skeleton Loading
 
-| Variable                             | Default Value                           | Description                                                |
-| ------------------------------------ | --------------------------------------- | ---------------------------------------------------------- |
-| `--osdk-table-skeleton-color-from`   | `var(--osdk-custom-color-light-gray-1)` | Skeleton animation start color (light gray at 40% opacity) |
-| `--osdk-table-skeleton-color-to`     | `var(--osdk-custom-color-gray-4)`       | Skeleton animation end color (medium gray at 40% opacity)  |
+| Variable                           | Default Value                           | Description                                                |
+| ---------------------------------- | --------------------------------------- | ---------------------------------------------------------- |
+| `--osdk-table-skeleton-color-from` | `var(--osdk-custom-color-light-gray-1)` | Skeleton animation start color (light gray at 40% opacity) |
+| `--osdk-table-skeleton-color-to`   | `var(--osdk-custom-color-gray-4)`       | Skeleton animation end color (medium gray at 40% opacity)  |
 
 #### Column Config Dialog
 
@@ -401,7 +401,7 @@ To create a custom theme, override the tokens at the appropriate level. You can 
     --osdk-table-cell-editable-border: 1px solid #3b82f6;
     --osdk-table-cell-edited-border: 2px solid #10b981;
     --osdk-table-cell-edited-border-error: 2px solid #ef4444;
-    --osdk-table-cell-editable-bg: #f0f9ff;
+    --osdk-table-cell-input-bg: #f0f9ff;
 
     /* Customize primary intent colors */
     --osdk-intent-primary-rest: #2563eb;

--- a/packages/react-components-styles/src/tokens/table.css
+++ b/packages/react-components-styles/src/tokens/table.css
@@ -48,9 +48,7 @@
   --osdk-table-header-menu-color-active: var(
     --osdk-typography-color-default-rest
   );
-  --osdk-table-header-menu-icon-color: var(
-    --osdk-table-header-menu-color
-  );
+  --osdk-table-header-menu-icon-color: var(--osdk-table-header-menu-color);
   --osdk-table-header-menu-bg-hover: var(--osdk-custom-color-gray-1);
   --osdk-table-header-menu-bg-active: var(--osdk-custom-color-gray-2);
 
@@ -76,7 +74,7 @@
     var(--osdk-intent-primary-rest);
   --osdk-table-cell-edited-border-error: var(--osdk-surface-border-width) solid
     var(--osdk-intent-danger-rest);
-  --osdk-table-cell-editable-bg: var(--osdk-background-primary);
+  --osdk-table-cell-input-bg: var(--osdk-background-primary);
   --osdk-table-edit-container-padding: calc(var(--osdk-surface-spacing) * 2)
     calc(var(--osdk-surface-spacing) * 4);
   --osdk-table-edit-container-min-height: calc(

--- a/packages/react-components/docs/CSSVariables.md
+++ b/packages/react-components/docs/CSSVariables.md
@@ -1227,11 +1227,12 @@ Styling for table components including headers, rows, and cells.
 
 #### Cell Styling
 
-| Variable                     | Default Value                               | Description     |
-| ---------------------------- | ------------------------------------------- | --------------- |
-| `--osdk-table-cell-padding`  | `0 calc(var(--osdk-surface-spacing) * 2)`   | Cell padding    |
-| `--osdk-table-cell-fontSize` | `var(--osdk-typography-size-body-medium)`   | Cell text size  |
-| `--osdk-table-cell-color`    | `var(--osdk-typography-color-default-rest)` | Cell text color |
+| Variable                     | Default Value                               | Description                                                                                                                                                                                                                                                                                        |
+| ---------------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--osdk-table-cell-padding`  | `0 calc(var(--osdk-surface-spacing) * 2)`   | Cell padding                                                                                                                                                                                                                                                                                       |
+| `--osdk-table-cell-fontSize` | `var(--osdk-typography-size-body-medium)`   | Cell text size                                                                                                                                                                                                                                                                                     |
+| `--osdk-table-cell-color`    | `var(--osdk-typography-color-default-rest)` | Cell text color                                                                                                                                                                                                                                                                                    |
+| `--osdk-table-cell-bg`       | `inherit`                                   | Cell background color. Each `<td>` also receives a `data-editable="true"` attribute when the cell is editable (column is marked editable, table is in edit mode, and the row passes any predicate), so consumers can scope the variable with `td[data-editable]` to highlight only editable cells. |
 
 #### Editable Cell Styling
 
@@ -1240,7 +1241,7 @@ Styling for table components including headers, rows, and cells.
 | `--osdk-table-cell-editable-border`     | `var(--osdk-surface-border-width) solid var(--osdk-surface-border-color-strong)` | Border for editable cells in edit mode       |
 | `--osdk-table-cell-edited-border`       | `var(--osdk-surface-border-width) solid var(--osdk-intent-primary-rest)`         | Border for edited cells with pending changes |
 | `--osdk-table-cell-edited-border-error` | `var(--osdk-surface-border-width) solid var(--osdk-intent-danger-rest)`          | Border for cells with validation errors      |
-| `--osdk-table-cell-editable-bg`         | `var(--osdk-background-primary)`                                                 | Background for editable cells                |
+| `--osdk-table-cell-input-bg`            | `var(--osdk-background-primary)`                                                 | Background for editable cells                |
 
 #### Edit Container
 
@@ -1432,7 +1433,7 @@ To create a custom theme, override the tokens at the appropriate level. You can 
     --osdk-table-cell-editable-border: 1px solid #3b82f6;
     --osdk-table-cell-edited-border: 2px solid #10b981;
     --osdk-table-cell-edited-border-error: 2px solid #ef4444;
-    --osdk-table-cell-editable-bg: #f0f9ff;
+    --osdk-table-cell-input-bg: #f0f9ff;
 
     /* Customize primary intent colors */
     --osdk-intent-primary-rest: #2563eb;

--- a/packages/react-components/docs/CSSVariables.md
+++ b/packages/react-components/docs/CSSVariables.md
@@ -1227,21 +1227,21 @@ Styling for table components including headers, rows, and cells.
 
 #### Cell Styling
 
-| Variable                     | Default Value                               | Description                                                                                                                                                                                                                                                                                        |
-| ---------------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--osdk-table-cell-padding`  | `0 calc(var(--osdk-surface-spacing) * 2)`   | Cell padding                                                                                                                                                                                                                                                                                       |
-| `--osdk-table-cell-fontSize` | `var(--osdk-typography-size-body-medium)`   | Cell text size                                                                                                                                                                                                                                                                                     |
-| `--osdk-table-cell-color`    | `var(--osdk-typography-color-default-rest)` | Cell text color                                                                                                                                                                                                                                                                                    |
-| `--osdk-table-cell-bg`       | `inherit`                                   | Cell background color. Each `<td>` also receives a `data-editable="true"` attribute when the cell is editable (column is marked editable, table is in edit mode, and the row passes any predicate), so consumers can scope the variable with `td[data-editable]` to highlight only editable cells. |
+| Variable                     | Default Value                               | Description                                                                                                                                                  |
+| ---------------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--osdk-table-cell-padding`  | `0 calc(var(--osdk-surface-spacing) * 2)`   | Cell padding                                                                                                                                                 |
+| `--osdk-table-cell-fontSize` | `var(--osdk-typography-size-body-medium)`   | Cell text size                                                                                                                                               |
+| `--osdk-table-cell-color`    | `var(--osdk-typography-color-default-rest)` | Cell text color                                                                                                                                              |
+| `--osdk-table-cell-bg`       | `inherit`                                   | Background color of the entire `<td>` cell, including the cell padding. Pair with `--osdk-table-cell-input-bg` to also color the inner editable input field. |
 
 #### Editable Cell Styling
 
-| Variable                                | Default Value                                                                    | Description                                  |
-| --------------------------------------- | -------------------------------------------------------------------------------- | -------------------------------------------- |
-| `--osdk-table-cell-editable-border`     | `var(--osdk-surface-border-width) solid var(--osdk-surface-border-color-strong)` | Border for editable cells in edit mode       |
-| `--osdk-table-cell-edited-border`       | `var(--osdk-surface-border-width) solid var(--osdk-intent-primary-rest)`         | Border for edited cells with pending changes |
-| `--osdk-table-cell-edited-border-error` | `var(--osdk-surface-border-width) solid var(--osdk-intent-danger-rest)`          | Border for cells with validation errors      |
-| `--osdk-table-cell-input-bg`            | `var(--osdk-background-primary)`                                                 | Background for editable cells                |
+| Variable                                | Default Value                                                                    | Description                                                                                                                                                                   |
+| --------------------------------------- | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--osdk-table-cell-editable-border`     | `var(--osdk-surface-border-width) solid var(--osdk-surface-border-color-strong)` | Border for editable cells in edit mode                                                                                                                                        |
+| `--osdk-table-cell-edited-border`       | `var(--osdk-surface-border-width) solid var(--osdk-intent-primary-rest)`         | Border for edited cells with pending changes                                                                                                                                  |
+| `--osdk-table-cell-edited-border-error` | `var(--osdk-surface-border-width) solid var(--osdk-intent-danger-rest)`          | Border for cells with validation errors                                                                                                                                       |
+| `--osdk-table-cell-input-bg`            | `var(--osdk-background-primary)`                                                 | Background of the input field inside an editable cell. Sits inside the cell padding, so `--osdk-table-cell-bg` (or any cell-level background) stays visible around the input. |
 
 #### Edit Container
 

--- a/packages/react-components/docs/ObjectTable.md
+++ b/packages/react-components/docs/ObjectTable.md
@@ -4,11 +4,11 @@ A comprehensive guide for using the ObjectTable component from `@osdk/react-comp
 
 ## Prerequisites
 
-Before using ObjectTable, make sure you have completed the library setup described in the [README](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/README.md#setup), including:
+Before using ObjectTable, make sure you have completed the library setup described in [Prerequisites](./Prerequisites.md), including:
 
 - Installing the required dependencies
 - Wrapping your app with `OsdkProvider`
-- Adding the CSS imports
+- Adding the CSS imports and configuring `@layer` order
 
 ## Table of Contents
 
@@ -1270,7 +1270,6 @@ Notes:
 
 - Combine multiple attribute selectors to express priority (the most specific selector wins, per normal CSS rules).
 - The table sets its own attributes (`data-selected`, `data-focused`, `data-row-parity`, `data-pinned`) on rows and cells. Avoid using these names in `getRowAttributes` since they would override the built-in behavior.
-- `getRowAttributes` runs for every visible row, so memoize it with `useCallback` to keep referential equality across renders.
 
 ### Loading and Empty States
 
@@ -1358,153 +1357,240 @@ type EmployeeProps = PropertyKeys<typeof Employee>;
 
 ## Theming
 
-The ObjectTable (and all OSDK components) can be themed using CSS custom properties included in `@osdk/react-components/styles.css`.
+The ObjectTable emits a stable set of `data-*` attributes on its rendered DOM, and exposes every visual property through `--osdk-table-*` CSS variables. Together they let you override appearance via the table's `className` (or any parent wrapper) without forking the component or relying on internal class names. See [Prerequisites › Token scopes](./Prerequisites.md#token-scopes) for the underlying `--osdk-*` / `--bp-*` token model.
 
-### Understanding Token Scopes
+The sub-sections below list the attributes and variables available on each rendered element, followed by [override examples](#override-examples). CSS variables cascade, so you can override them on a parent element to affect every nested cell or row.
 
-**OSDK Tokens (`--osdk-*`)**
+### `<thead>` — Table header row container
 
-- All tokens used in OSDK components are prefixed with `--osdk-`
-- Any Blueprint token used in OSDK components is mapped to an `--osdk-*` token
-- Override these to theme **OSDK components only**
-- Safe to customize without affecting other Blueprint components in your app
+**Data attributes**
 
-**Blueprint Tokens (`--bp-*`)**
+| Attribute       | Values            | Meaning                                           |
+| --------------- | ----------------- | ------------------------------------------------- |
+| `data-resizing` | `true` \| `false` | Set while the user is actively resizing a column. |
 
-- Core design tokens from Blueprint design system
-- Override these to theme **both Blueprint and OSDK components**
-- Use this for consistent theming across your entire application
+**CSS variables**
 
-### Customization Strategies
+| Variable                            | Default                                  | Description                            |
+| ----------------------------------- | ---------------------------------------- | -------------------------------------- |
+| `--osdk-table-header-height`        | `50px`                                   | Header row height.                     |
+| `--osdk-table-header-bg`            | `var(--osdk-background-secondary)`       | Header background color.               |
+| `--osdk-table-header-fontWeight`    | `var(--osdk-typography-weight-bold)`     | Header text weight.                    |
+| `--osdk-table-header-fontSize`      | `var(--osdk-typography-size-body-small)` | Header text size.                      |
+| `--osdk-table-header-color`         | `var(--osdk-typography-color-muted)`     | Header text color.                     |
+| `--osdk-table-header-divider`       | `var(--osdk-table-border)`               | Vertical divider between header cells. |
+| `--osdk-table-resizer-color-hover`  | `var(--osdk-custom-color-primary-1)`     | Resize handle hover color.             |
+| `--osdk-table-resizer-color-active` | `var(--osdk-intent-primary-rest)`        | Resize handle active color.            |
 
-#### 1. Override OSDK Tokens Only
+### `<th>` — Header cell
 
-Change OSDK component styling without affecting other Blueprint components in your app:
+**Data attributes**
 
-```css
-@layer osdk.styles, user.theme;
+| Attribute     | Values                       | Meaning               |
+| ------------- | ---------------------------- | --------------------- |
+| `data-pinned` | `left` \| `right` \| `false` | Column pinning state. |
 
-@import "@osdk/react-components/styles.css" layer(osdk.styles);
+**CSS variables**
 
-@layer user.theme {
-  :root {
-    /* Only affects OSDK table headers */
-    --osdk-table-header-bg: #f0f0f0;
-    --osdk-table-border-color: #e0e0e0;
-    --osdk-table-row-hover-bg: #f9fafb;
+| Variable                                | Default                                                                  | Description                    |
+| --------------------------------------- | ------------------------------------------------------------------------ | ------------------------------ |
+| `--osdk-table-pinned-column-border`     | `var(--osdk-table-border)`                                               | Border for pinned columns.     |
+| `--osdk-table-header-menu-padding`      | `calc(var(--osdk-surface-spacing) * 0.25)`                               | Menu button padding.           |
+| `--osdk-table-header-menu-bg`           | `var(--osdk-custom-color-light-gray-2)`                                  | Menu button background.        |
+| `--osdk-table-header-menu-border`       | `var(--osdk-surface-border-width) solid var(--osdk-custom-color-gray-4)` | Menu button border.            |
+| `--osdk-table-header-menu-color`        | `var(--osdk-typography-color-muted)`                                     | Menu icon color.               |
+| `--osdk-table-header-menu-color-active` | `var(--osdk-typography-color-default-rest)`                              | Menu icon color when active.   |
+| `--osdk-table-header-menu-icon-color`   | `var(--osdk-table-header-menu-color)`                                    | Menu chevron color.            |
+| `--osdk-table-header-menu-bg-hover`     | `var(--osdk-custom-color-gray-1)`                                        | Menu button hover background.  |
+| `--osdk-table-header-menu-bg-active`    | `var(--osdk-custom-color-gray-2)`                                        | Menu button active background. |
 
-    /* Only affects OSDK components using primary intent */
-    --osdk-intent-primary-rest: #2563eb;
-    --osdk-intent-primary-hover: #1d4ed8;
-  }
-}
-```
+### `<tr>` — Body row
 
-#### 2. Override Blueprint Tokens
+**Data attributes**
 
-Change both Blueprint and OSDK components for consistent theming:
+| Attribute         | Values            | Meaning                                                 |
+| ----------------- | ----------------- | ------------------------------------------------------- |
+| `data-selected`   | `true` \| `false` | Whether the row is selected.                            |
+| `data-focused`    | `true` \| `false` | Whether the row currently has focus (last-clicked row). |
+| `data-row-parity` | `even` \| `odd`   | Row index parity, for striping.                         |
 
-```css
-@layer osdk.styles, user.theme;
+You can also attach custom `data-*` attributes per row with the `getRowAttributes` prop — see [Row Attributes and Conditional Row Styling](#row-attributes-and-conditional-row-styling).
 
-@import "@osdk/react-components/styles.css" layer(osdk.styles);
+**CSS variables**
 
-@layer user.theme {
-  :root {
-    /* Affects ALL components (Blueprint + OSDK) using primary intent */
-    --bp-intent-primary-rest: #2563eb;
-    --bp-intent-primary-hover: #1d4ed8;
-    --bp-intent-primary-active: #1e40af;
+| Variable                               | Default                                                                                    | Description                      |
+| -------------------------------------- | ------------------------------------------------------------------------------------------ | -------------------------------- |
+| `--osdk-table-row-bg-default`          | `var(--osdk-background-primary)`                                                           | Default row background.          |
+| `--osdk-table-row-bg-alternate`        | `var(--osdk-background-tertiary)`                                                          | Alternate (odd) row background.  |
+| `--osdk-table-row-bg-hover`            | `color-mix(in srgb, var(--osdk-intent-primary-hover) 10%, var(--osdk-background-primary))` | Row hover background.            |
+| `--osdk-table-row-bg-active`           | `color-mix(in srgb, var(--osdk-intent-primary-hover) 10%, var(--osdk-background-primary))` | Active/selected row background.  |
+| `--osdk-table-row-border-color-hover`  | `var(--osdk-intent-primary-rest)`                                                          | Border color for hovered rows.   |
+| `--osdk-table-row-border-color-active` | `var(--osdk-intent-primary-rest)`                                                          | Border color for selected rows.  |
+| `--osdk-table-row-divider`             | `var(--osdk-table-border)`                                                                 | Horizontal divider between rows. |
 
-    /* Affects all spacing and borders across the design system */
-    --bp-surface-spacing: 8px;
-    --bp-surface-border-radius: 8px;
-  }
-}
-```
+### `<td>` — Body cell
 
-#### 3. Scoped Overrides for Specific Tables
+**Data attributes**
 
-Apply custom styles to specific ObjectTable instances using the `className` prop:
+| Attribute       | Values                       | Meaning                                                |
+| --------------- | ---------------------------- | ------------------------------------------------------ |
+| `data-pinned`   | `left` \| `right` \| `false` | Mirrors the column's pinning state.                    |
+| `data-editable` | `true` \| (absent)           | Present when the cell is editable in the current mode. |
 
-```typescript
-// Component
+**CSS variables**
+
+| Variable                                | Default                                                                          | Description                                   |
+| --------------------------------------- | -------------------------------------------------------------------------------- | --------------------------------------------- |
+| `--osdk-table-cell-padding`             | `0 calc(var(--osdk-surface-spacing) * 2)`                                        | Cell padding.                                 |
+| `--osdk-table-cell-fontSize`            | `var(--osdk-typography-size-body-medium)`                                        | Cell text size.                               |
+| `--osdk-table-cell-color`               | `var(--osdk-typography-color-default-rest)`                                      | Cell text color.                              |
+| `--osdk-table-cell-bg`                  | `inherit`                                                                        | Cell background color.                        |
+| `--osdk-table-cell-divider`             | `var(--osdk-table-border-width) solid transparent`                               | Vertical divider between row cells.           |
+| `--osdk-table-cell-editable-border`     | `var(--osdk-surface-border-width) solid var(--osdk-surface-border-color-strong)` | Border for editable cells in edit mode.       |
+| `--osdk-table-cell-edited-border`       | `var(--osdk-surface-border-width) solid var(--osdk-intent-primary-rest)`         | Border for edited cells with pending changes. |
+| `--osdk-table-cell-edited-border-error` | `var(--osdk-surface-border-width) solid var(--osdk-intent-danger-rest)`          | Border for cells with validation errors.      |
+| `--osdk-table-cell-input-bg`            | `var(--osdk-background-primary)`                                                 | Background for editable inputs.               |
+
+Scope `--osdk-table-cell-*` overrides with `td[data-editable]` to target only editable cells.
+
+### Edit footer container
+
+Rendered when `editMode` is `manual` or when `onSubmitEdits` is provided.
+
+| Variable                                 | Default                                                                       | Description                                     |
+| ---------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------- |
+| `--osdk-table-edit-container-padding`    | `calc(var(--osdk-surface-spacing) * 2) calc(var(--osdk-surface-spacing) * 4)` | Padding for the edit controls container.        |
+| `--osdk-table-edit-container-min-height` | `calc(var(--osdk-surface-spacing) * 12)`                                      | Minimum height for the edit controls container. |
+
+### Column config dialog
+
+Rendered when `enableColumnConfig` is `true` and the user opens the dialog.
+
+| Variable                                        | Default                            | Description                                  |
+| ----------------------------------------------- | ---------------------------------- | -------------------------------------------- |
+| `--osdk-table-column-config-dialog-min-width`   | `800px`                            | Minimum width for the column config dialog.  |
+| `--osdk-table-column-config-dialog-min-height`  | `400px`                            | Minimum height for the column config dialog. |
+| `--osdk-table-column-config-visible-columns-bg` | `var(--osdk-background-secondary)` | Background for the visible columns section.  |
+
+### Skeleton loading rows
+
+Shown while data is loading.
+
+| Variable                           | Default                                | Description                     |
+| ---------------------------------- | -------------------------------------- | ------------------------------- |
+| `--osdk-table-skeleton-color-from` | `var(--osdk-background-skeleton-from)` | Skeleton animation start color. |
+| `--osdk-table-skeleton-color-to`   | `var(--osdk-background-skeleton-to)`   | Skeleton animation end color.   |
+
+### Shared border tokens
+
+These feed into the per-element border variables above.
+
+| Variable                    | Default                                                               | Description                          |
+| --------------------------- | --------------------------------------------------------------------- | ------------------------------------ |
+| `--osdk-table-border-color` | `var(--osdk-surface-border-color-default)`                            | Base color for all table borders.    |
+| `--osdk-table-border-width` | `var(--osdk-surface-border-width)`                                    | Base width for all table borders.    |
+| `--osdk-table-border`       | `var(--osdk-table-border-width) solid var(--osdk-table-border-color)` | Base table border (outermost edges). |
+
+See [CSSVariables.md](./CSSVariables.md) for the canonical reference of every `--osdk-table-*` token.
+
+### Override examples
+
+Each example below scopes overrides under a `className` passed to `<ObjectTable className="my-table" />` so other tables on the page are unaffected. Drop the class selector to apply globally via `:root` in the `user.theme` layer.
+
+#### Editable cell background
+
+Use the `data-editable` attribute that the table sets on every editable `<td>` to highlight only the cells the user can actually change. Pair it with `--osdk-table-cell-editable-border` to outline the cell in edit mode and `--osdk-table-cell-edited-border` to mark cells with pending changes.
+
+```tsx
 <ObjectTable
   objectType={Employee}
-  className="custom-employee-table"
+  columnDefinitions={editableColumns}
+  editMode="manual"
+  className="my-table"
 />;
 ```
 
 ```css
-/* Styles */
-.custom-employee-table {
-  --osdk-table-header-bg: #1e40af;
-  --osdk-table-header-text-color: white;
-  --osdk-table-row-hover-bg: #dbeafe;
+/* Editable cells get a soft yellow background to signal they're interactive. */
+.my-table td[data-editable="true"] {
+  --osdk-table-cell-bg: #fffbeb;
 }
 ```
 
-### Common Theming Examples
+#### Row attributes for conditional row styling
 
-#### Dark Mode
+Attach custom `data-*` attributes per row with the `getRowAttributes` prop and drive row styling in CSS using attribute selectors. Row background comes from `--osdk-table-row-bg-default` and `--osdk-table-row-bg-alternate` — overriding both ensures the override wins regardless of zebra parity.
+
+```tsx
+import { useCallback } from "react";
+
+const getRowAttributes = useCallback(
+  (employee: Osdk.Instance<typeof Employee>) => ({
+    "data-status": employee.status,
+    "data-overdue": employee.daysOverdue > 0 ? "true" : undefined,
+  }),
+  [],
+);
+
+<ObjectTable
+  objectType={Employee}
+  className="my-table"
+  getRowAttributes={getRowAttributes}
+/>;
+```
 
 ```css
-@layer user.theme {
-  [data-theme="dark"] {
-    --osdk-table-header-bg: #1f2937;
-    --osdk-table-border-color: #374151;
-    --osdk-table-row-hover-bg: #374151;
-    --osdk-surface-bg: #111827;
-    --osdk-text-primary: #f9fafb;
-  }
+.my-table tr[data-status="Inactive"] {
+  --osdk-table-row-bg-default: #f3f4f6;
+  --osdk-table-row-bg-alternate: #f3f4f6;
+  color: #6b7280;
+}
+
+.my-table tr[data-overdue="true"] {
+  --osdk-table-row-bg-default: #fef2f2;
+  --osdk-table-row-bg-alternate: #fef2f2;
+}
+
+/* Combine selectors to express priority — most specific wins. */
+.my-table tr[data-status="Active"][data-overdue="true"] {
+  --osdk-table-row-bg-default: #fffbeb;
+  --osdk-table-row-bg-alternate: #fffbeb;
 }
 ```
 
-#### Compact Table
+Notes:
+
+- Entries whose value is `undefined` are skipped, so attributes can be conditional without emitting empty values.
+- The table reserves `data-selected`, `data-focused`, `data-row-parity`, and `data-pinned` on rows and cells — don't return those names from `getRowAttributes`.
+
+See [Row Attributes and Conditional Row Styling](#row-attributes-and-conditional-row-styling) for the full pattern walkthrough.
+
+#### Scoped overrides for a specific table
+
+```tsx
+<ObjectTable objectType={Employee} className="custom-employee-table" />;
+```
+
+```css
+.custom-employee-table {
+  --osdk-table-header-bg: #1e40af;
+  --osdk-table-header-color: #ffffff;
+  --osdk-table-row-bg-hover: #dbeafe;
+}
+```
+
+#### Compact density
+
+```tsx
+<ObjectTable objectType={Employee} className="compact-table" rowHeight={32} />;
+```
 
 ```css
 .compact-table {
-  --osdk-surface-spacing: 4px;
-  --osdk-table-cell-padding: 8px;
+  --osdk-table-header-height: 36px;
+  --osdk-table-cell-padding: 0 8px;
 }
 ```
-
-```typescript
-<ObjectTable
-  objectType={Employee}
-  className="compact-table"
-  rowHeight={32}
-/>;
-```
-
-#### Custom Brand Colors
-
-```css
-@layer user.theme {
-  :root {
-    /* Use your brand's primary color */
-    --bp-intent-primary-rest: #7c3aed;
-    --bp-intent-primary-hover: #6d28d9;
-    --bp-intent-primary-active: #5b21b6;
-  }
-}
-```
-
-### Available CSS Variables
-
-For a complete reference of all available CSS tokens for theming, see:
-
-- [CSS Variables Documentation](./CSSVariables.md)
-
-### Accessibility Note
-
-When overriding theme tokens, ensure your custom colors meet accessibility standards:
-
-- **Color contrast ratios** (WCAG AA): 4.5:1 for normal text, 3:1 for large text
-- **Readable text** on all background colors
-- **Clear visual distinction** between interactive states (rest, hover, active, disabled)
-
-The default tokens are designed to meet WCAG AA standards.
 
 ## Additional Resources
 

--- a/packages/react-components/docs/Prerequisites.md
+++ b/packages/react-components/docs/Prerequisites.md
@@ -40,9 +40,21 @@ All component packages require an `OsdkProvider` wrapping your app. Without it, 
 
 ## CSS setup
 
-Components use CSS [`@layer`](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer) for predictable theming. Add these imports to your application's entry CSS file (e.g., `index.css`).
+### IMPORTANT: Portal isolation (required)
+
+Components use [Base UI](https://base-ui.com) portals, which require stacking context isolation:
+
+```css
+.root {
+  isolation: isolate;
+}
+```
+
+Apply this to your root element. See the [Base UI docs](https://base-ui.com/react/overview/quick-start#portals) for details.
 
 ### Layers
+
+Components use CSS [`@layer`](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer) for predictable theming. Add these imports to your application's entry CSS file (e.g., `index.css`).
 
 | Layer             | Purpose                                                    |
 | ----------------- | ---------------------------------------------------------- |
@@ -51,7 +63,7 @@ Components use CSS [`@layer`](https://developer.mozilla.org/en-US/docs/Web/CSS/@
 
 Later layers always win when styles conflict, regardless of selector specificity.
 
-### Without Tailwind
+#### Without Tailwind
 
 ```css
 /* index.css */
@@ -61,7 +73,7 @@ Later layers always win when styles conflict, regardless of selector specificity
 @import "@osdk/cbac-components/styles.css" layer(cbac.components); /* only needed if using CBAC components */
 ```
 
-### With Tailwind CSS v4
+#### With Tailwind CSS v4
 
 ```css
 /* index.css */
@@ -73,7 +85,7 @@ Later layers always win when styles conflict, regardless of selector specificity
 @import "@osdk/cbac-components/styles.css" layer(cbac.components); /* only needed if using CBAC components */
 ```
 
-### Custom theme overrides
+#### Custom theme overrides
 
 Add a custom layer after the OSDK layers to override any token:
 
@@ -85,14 +97,18 @@ Add a custom layer after the OSDK layers to override any token:
 @import "./user-brand.css" layer(user.brand);
 ```
 
-### Portal isolation (required)
+### Token scopes
 
-Components use [Base UI](https://base-ui.com) portals, which require stacking context isolation:
+All components resolve their visual properties through CSS custom properties. There are two scopes of tokens you can target when theming:
 
-```css
-.root {
-  isolation: isolate;
-}
-```
+- **OSDK tokens (`--osdk-*`)** — every visual property used inside OSDK components resolves through a token prefixed with `--osdk-` (e.g. `--osdk-table-header-bg`, `--osdk-form-section-padding`). Override these to theme **OSDK components only**, leaving other Blueprint components in your app untouched.
+- **Blueprint tokens (`--bp-*`)** — the underlying Blueprint design tokens that `--osdk-*` tokens map to. Override these for consistent theming across **both Blueprint and OSDK components**.
 
-Apply this to your root element. See the [Base UI docs](https://base-ui.com/react/overview/quick-start#portals) for details.
+Per-component references list the `--osdk-*` variables each component exposes — see, for example, [ObjectTable › Theming](./ObjectTable.md#theming). The full catalog of variables lives in [CSSVariables.md](./CSSVariables.md).
+
+### Accessibility
+
+When overriding theme tokens, keep the result accessible:
+
+- **Color contrast (WCAG AA):** 4.5:1 for normal text, 3:1 for large text.
+- **Distinct interactive states:** rest, hover, active, selected, and focused should each be visually distinguishable — the default `--osdk-table-row-bg-*` and `--osdk-table-row-border-color-*` tokens are designed to meet WCAG AA; preserve that intent in custom themes.

--- a/packages/react-components/src/object-table/EditableCell.module.css
+++ b/packages/react-components/src/object-table/EditableCell.module.css
@@ -12,7 +12,7 @@
 
   tr[data-focused="true"] & {
     border: var(--osdk-table-cell-editable-border);
-    background: var(--osdk-table-cell-editable-bg);
+    background: var(--osdk-table-cell-input-bg);
 
     &.osdkEditedInput {
       border: var(--osdk-table-cell-edited-border);
@@ -35,7 +35,7 @@
   }
 
   &.error {
-    background: var(--osdk-table-cell-editable-bg);
+    background: var(--osdk-table-cell-input-bg);
     border: var(--osdk-table-cell-edited-border-error);
   }
 }
@@ -60,7 +60,7 @@
 
   tr[data-focused="true"] & {
     border: var(--osdk-table-cell-editable-border);
-    background: var(--osdk-table-cell-editable-bg);
+    background: var(--osdk-table-cell-input-bg);
 
     &.osdkEditedInput {
       border: var(--osdk-table-cell-edited-border);
@@ -83,7 +83,7 @@
   }
 
   &.error {
-    background: var(--osdk-table-cell-editable-bg);
+    background: var(--osdk-table-cell-input-bg);
     border: var(--osdk-table-cell-edited-border-error);
   }
 }
@@ -114,7 +114,7 @@
 
   tr[data-focused="true"] & {
     border: var(--osdk-table-cell-editable-border);
-    background: var(--osdk-table-cell-editable-bg);
+    background: var(--osdk-table-cell-input-bg);
 
     &.osdkEditedInput {
       border: var(--osdk-table-cell-edited-border);
@@ -137,7 +137,7 @@
   }
 
   &.error {
-    background: var(--osdk-table-cell-editable-bg);
+    background: var(--osdk-table-cell-input-bg);
     border: var(--osdk-table-cell-edited-border-error);
   }
 }
@@ -168,7 +168,7 @@
 .osdkEditedInput {
   border-radius: var(--osdk-surface-border-radius);
   border: var(--osdk-table-cell-edited-border);
-  background: var(--osdk-table-cell-editable-bg);
+  background: var(--osdk-table-cell-input-bg);
 }
 
 .validationError {

--- a/packages/react-components/src/object-table/TableCell.module.css
+++ b/packages/react-components/src/object-table/TableCell.module.css
@@ -23,7 +23,7 @@
   padding: var(--osdk-table-cell-padding);
   font-size: var(--osdk-table-cell-fontSize);
   color: var(--osdk-table-cell-color);
-  background-color: inherit;
+  background-color: var(--osdk-table-cell-bg);
   border-right: var(--osdk-table-cell-divider);
 
   &:first-child {
@@ -39,7 +39,7 @@
 .osdkTableCell[data-pinned="right"] {
   position: sticky;
   z-index: var(--osdk-surface-z-index-1);
-  background-color: inherit;
+  background-color: var(--osdk-table-cell-bg);
 }
 
 /* Last left-pinned column - no left-pinned siblings after it */

--- a/packages/react-components/src/object-table/TableCell.tsx
+++ b/packages/react-components/src/object-table/TableCell.tsx
@@ -22,7 +22,9 @@ import { CellContextMenu } from "./CellContextMenu.js";
 import { useCellContextMenu } from "./hooks/useCellContextMenu.js";
 import styles from "./TableCell.module.css";
 import { SELECTION_COLUMN_ID } from "./utils/constants.js";
+import { isCellEditable } from "./utils/editableUtils.js";
 import { getColumnPinningStyles } from "./utils/getColumnPinningStyles.js";
+import { shouldShowEditableCell } from "./utils/shouldShowEditableCell.js";
 
 interface TableCellProps<TData extends RowData> {
   cell: Cell<TData, unknown>;
@@ -53,11 +55,20 @@ export function TableCell<TData extends RowData>(
 
   const { columnStyles } = getColumnPinningStyles(cell.column);
 
+  const tableMeta = cell.getContext().table.options.meta;
+  const columnMeta = cell.column.columnDef.meta;
+  const isEditable = shouldShowEditableCell(
+    isCellEditable(columnMeta?.editable, cell.row.original),
+    tableMeta?.onCellEdit,
+    tableMeta?.isInEditMode,
+  );
+
   return (
     <>
       <td
         ref={tdRef}
         data-pinned={cell.column.getIsPinned()}
+        data-editable={isEditable ? "true" : undefined}
         className={styles.osdkTableCell}
         style={columnStyles}
         onContextMenu={handleOpenContextMenu}

--- a/packages/react-components/src/tokens/component-tokens/table.css
+++ b/packages/react-components/src/tokens/component-tokens/table.css
@@ -37,6 +37,7 @@
   --osdk-table-cell-padding: 0 calc(var(--osdk-surface-spacing) * 2);
   --osdk-table-cell-fontSize: var(--osdk-typography-size-body-medium);
   --osdk-table-cell-color: var(--osdk-typography-color-default-rest);
+  --osdk-table-cell-bg: inherit;
 
   /* Table Header Menu */
   --osdk-table-header-menu-padding: calc(var(--osdk-surface-spacing) * 0.25);
@@ -74,7 +75,7 @@
     var(--osdk-intent-primary-rest);
   --osdk-table-cell-edited-border-error: var(--osdk-surface-border-width) solid
     var(--osdk-intent-danger-rest);
-  --osdk-table-cell-editable-bg: var(--osdk-background-primary);
+  --osdk-table-cell-input-bg: var(--osdk-background-primary);
   --osdk-table-edit-container-padding: calc(var(--osdk-surface-spacing) * 2)
     calc(var(--osdk-surface-spacing) * 4);
   --osdk-table-edit-container-min-height: calc(


### PR DESCRIPTION
Add `--osdk-table-cell-bg` CSS variable on `ObjectTable` / `BaseTable`
cells, and tag each `<td>` with `data-editable="true"` when the cell renders
as editable. The variable defaults to `inherit`, preserving current visuals.

Renamed `--osdk-table-cell-editable-bg` to `--osdk-table-cell-input-bg`. 


https://github.com/user-attachments/assets/9b6ab4b9-9d49-4970-9b46-26c807684d51

