### PR TITLE
Wire up the platform API proxy & log proxied requests

### DIFF
--- a/.changeset/fair-books-wish.md
+++ b/.changeset/fair-books-wish.md
@@ -1,0 +1,5 @@
+---
+"@osdk/vite-plugin-superrepo": minor
+---
+
+Wire up the platform API proxy & log proxied requests

--- a/packages/vite-plugin-superrepo/src/index.test.ts
+++ b/packages/vite-plugin-superrepo/src/index.test.ts
@@ -31,7 +31,7 @@ afterEach(() => {
   fs.rmSync(workDir, { recursive: true, force: true });
 });
 
-it("installs all three ontology proxy prefixes from a live discovery file", () => {
+it("installs ontology proxy prefixes from a live discovery file", () => {
   fs.writeFileSync(
     path.join(workDir, "foundry.yml"),
     "minCliVersion: \"0.0.0\"\n",
@@ -54,9 +54,7 @@ it("installs all three ontology proxy prefixes from a live discovery file", () =
   ) => unknown)(userConfig, { command: "serve", mode: "development" });
 
   const proxy = userConfig.server?.proxy as Record<string, ProxyOptions>;
-  for (
-    const prefix of ["/api/v2", "/ontology-metadata", "/object-set-service"]
-  ) {
+  for (const prefix of ["/ontology-metadata", "/object-set-service"]) {
     expect(proxy[prefix].target).toBe("https://127.0.0.1:51000");
     expect(proxy[prefix].changeOrigin).toBe(true);
     expect(proxy[prefix].secure).toBe(false);

--- a/packages/vite-plugin-superrepo/src/index.ts
+++ b/packages/vite-plugin-superrepo/src/index.ts
@@ -17,7 +17,7 @@
 import fs from "node:fs";
 import https from "node:https";
 import path from "node:path";
-import type { Plugin, ProxyOptions, UserConfig } from "vite";
+import type { Logger, Plugin, ProxyOptions, UserConfig } from "vite";
 import {
   type DiscoveryEntry,
   type DiscoveryService,
@@ -36,7 +36,6 @@ export const PROXY_ROUTES: ReadonlyArray<{
   /** Strip the prefix before forwarding. */
   rewrite: boolean;
 }> = [
-  { prefix: "/api/v2", service: "ontology", rewrite: false },
   { prefix: "/ontology-metadata", service: "ontology", rewrite: false },
   { prefix: "/object-set-service", service: "ontology", rewrite: false },
   {
@@ -49,9 +48,6 @@ export const PROXY_ROUTES: ReadonlyArray<{
     service: "python-functions",
     rewrite: true,
   },
-  // Catch-all platform-API prefix. Must come after the more-specific
-  // `/api/v2` ontology route above, because Vite iterates the proxy map
-  // in insertion order and picks the first `url.startsWith(prefix)` hit.
   { prefix: "/api", service: "platform-api-proxy", rewrite: false },
 ];
 
@@ -63,6 +59,9 @@ export const PROXY_ROUTES: ReadonlyArray<{
  */
 export function smartClientPlugin(): Plugin {
   const pendingWarnings: string[] = [];
+  const setupProxies: Array<{ prefix: string; target: string }> = [];
+  let logger: Logger | undefined;
+  const getLogger = (): Logger | undefined => logger;
 
   return {
     name: "vite-plugin-smart-client",
@@ -89,7 +88,9 @@ export function smartClientPlugin(): Plugin {
             read.entry,
             route,
             pendingWarnings,
+            getLogger,
           );
+          setupProxies.push({ prefix: route.prefix, target: read.entry.url });
           continue;
         }
         switch (read.kind) {
@@ -129,10 +130,21 @@ export function smartClientPlugin(): Plugin {
     },
 
     configResolved(resolvedConfig) {
+      logger = resolvedConfig.logger;
       for (const message of pendingWarnings) {
         resolvedConfig.logger.warn(`[vite-plugin-superrepo] ${message}`);
       }
       pendingWarnings.length = 0;
+
+      if (setupProxies.length > 0) {
+        const width = Math.max(...setupProxies.map((p) => p.prefix.length));
+        resolvedConfig.logger.info("[vite-plugin-superrepo] proxies:");
+        for (const { prefix, target } of setupProxies) {
+          resolvedConfig.logger.info(
+            `  ${prefix.padEnd(width)} → ${target}`,
+          );
+        }
+      }
     },
 
     configureServer(server) {
@@ -205,11 +217,20 @@ function buildProxyOptions(
   entry: DiscoveryEntry,
   route: { prefix: string; rewrite: boolean },
   pendingWarnings: string[],
+  getLogger: () => Logger | undefined,
 ): ProxyOptions {
   const isHttps = entry.url.startsWith("https://");
   const options: ProxyOptions = {
     target: entry.url,
     changeOrigin: true,
+    configure: (proxy) => {
+      proxy.on("proxyReq", (_proxyReq, req) => {
+        getLogger()?.info(
+          `[vite-plugin-superrepo] ${route.prefix} ${req.method} ${req.url}`
+            + ` → ${entry.url}`,
+        );
+      });
+    },
   };
   if (route.rewrite) {
     options.rewrite = (p) =>


### PR DESCRIPTION
- The platform api proxy was shadowed by the ontology proxy making it inaccessible. This is fixed in this PR.
- Add additional logging to make the proxying behaviour understandable.