### PR TITLE
Remove @storybook/addon-themes and clean up preview config

### DIFF
--- a/.changeset/remove-storybook-addon-themes.md
+++ b/.changeset/remove-storybook-addon-themes.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components-storybook": patch
+---
+
+Remove @storybook/addon-themes in preparation for custom theme preset switcher

--- a/packages/react-components-storybook/.storybook/main.ts
+++ b/packages/react-components-storybook/.storybook/main.ts
@@ -22,7 +22,6 @@ const config: StorybookConfig = {
     "@storybook/addon-a11y",
     "@storybook/addon-docs",
     "@storybook/addon-links",
-    "@storybook/addon-themes",
     "@storybook/addon-mcp",
     "msw-storybook-addon",
     "storybook-addon-tag-badges",

--- a/packages/react-components-storybook/.storybook/preview.tsx
+++ b/packages/react-components-storybook/.storybook/preview.tsx
@@ -16,7 +16,6 @@
 
 import { createClient } from "@osdk/client";
 import { OsdkProvider } from "@osdk/react";
-import { withThemeByDataAttribute } from "@storybook/addon-themes";
 import type { Preview } from "@storybook/react-vite";
 import { initialize, mswLoader } from "msw-storybook-addon";
 import { fauxFoundry, setupFauxFoundry } from "../src/mocks/fauxFoundry.js";
@@ -25,7 +24,7 @@ import "./styles.css";
 // Initialize MSW with proper options
 // This is synchronous, it only configures MSW
 // The actual service worker registration happens in the mswLoader, which runs before each story
-const basePath = (import.meta as any).env?.BASE_URL ?? "/";
+const basePath = import.meta.env.BASE_URL ?? "/";
 const serviceWorkerUrl = `${basePath}${
   basePath.endsWith("/") ? "" : "/"
 }mockServiceWorker.js`;
@@ -76,15 +75,6 @@ const preview: Preview = {
         </OsdkProvider>
       </div>
     ),
-    withThemeByDataAttribute({
-      themes: {
-        light: "light",
-        modern: "modern",
-        devcon: "devcon",
-      },
-      defaultTheme: "light",
-      attributeName: "data-theme",
-    }),
   ],
 };
 

--- a/packages/react-components-storybook/package.json
+++ b/packages/react-components-storybook/package.json
@@ -32,7 +32,6 @@
     "@storybook/addon-docs": "^10.2.10",
     "@storybook/addon-links": "^10.2.10",
     "@storybook/addon-mcp": "^0.2.3",
-    "@storybook/addon-themes": "^10.2.10",
     "@storybook/react-vite": "^10.2.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/node": "^20.19.13",

--- a/packages/react-components-storybook/src/styles/storybook.css
+++ b/packages/react-components-storybook/src/styles/storybook.css
@@ -65,7 +65,6 @@ body {
   --osdk-form-content-padding-block: calc(var(--osdk-surface-spacing) * 4);
 
   width: min(480px, calc(100vw - calc(var(--osdk-surface-spacing) * 8)));
-  max-height: calc(100vh - calc(var(--osdk-surface-spacing) * 16));
 }
 
 .osdkCustomTextarea {


### PR DESCRIPTION
## Summary
- Remove `@storybook/addon-themes` addon and its `withThemeByDataAttribute` decorator in preparation for the custom brand theme preset system
- Fix `as any` cast on `import.meta.env` in preview config
- Remove unnecessary `max-height` constraint on dialog form styles

## Test plan
- [ ] Storybook builds without errors
- [ ] Stories render correctly in default light theme
- [ ] No broken imports or runtime errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)