### PR TITLE
Add brand theme decorator for CSS custom property injection

### DIFF
--- a/.changeset/remove-storybook-addon-themes.md
+++ b/.changeset/remove-storybook-addon-themes.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components-storybook": patch
+---
+
+Remove @storybook/addon-themes in preparation for custom theme preset switcher

--- a/.changeset/theme-data-layer.md
+++ b/.changeset/theme-data-layer.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components-storybook": patch
+---
+
+Add theme data layer: types, token map, presets, and state management for brand theme system

--- a/.changeset/theme-decorator.md
+++ b/.changeset/theme-decorator.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components-storybook": patch
+---
+
+Add brand theme decorator that injects CSS custom property overrides into the Storybook preview

--- a/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/constants.ts
+++ b/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/constants.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const ADDON_ID = "osdk/brand-theme-extractor";
+export const PANEL_ID = `${ADDON_ID}/panel`;
+export const GLOBALS_KEY = "brandTheme";

--- a/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/decorator.tsx
+++ b/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/decorator.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Decorator } from "@storybook/react-vite";
+import React, { useEffect, useMemo } from "react";
+import { GLOBALS_KEY } from "./constants.js";
+import { parseBrandThemeState } from "./state.js";
+import { getTokenRole, TOKEN_ROLES } from "./token-map.js";
+
+const STYLE_ID = "brand-theme-overrides";
+
+/**
+ * Preview-side decorator that reads brand theme globals and injects
+ * a <style> tag with CSS custom property overrides into the preview
+ * document head. Uses :root with high specificity to override theme values.
+ */
+export const BrandThemeDecorator: Decorator = (Story, context) => {
+  const brandTheme = React.useMemo(
+    () => parseBrandThemeState(context.globals[GLOBALS_KEY]),
+    [context.globals],
+  );
+
+  const cssText = useMemo(() => {
+    if (!brandTheme?.active) return "";
+    if (!brandTheme.assignments || brandTheme.assignments.length === 0) {
+      return "";
+    }
+
+    // First, reset ALL token-map properties so stale values from a
+    // previous preset don't linger when switching themes.
+    const resets: string[] = [];
+    for (const role of TOKEN_ROLES) {
+      for (const prop of role.cssProperties) {
+        resets.push(`  ${prop}: initial;`);
+      }
+    }
+
+    // Then apply the current preset's overrides.
+    const overrides: string[] = [];
+
+    for (const assignment of brandTheme.assignments) {
+      const roleDef = getTokenRole(assignment.role);
+      if (!roleDef) continue;
+
+      let value: string | undefined;
+      if (
+        assignment.colorIndex >= 0
+        && brandTheme.palette?.[assignment.colorIndex]
+      ) {
+        value = brandTheme.palette[assignment.colorIndex].hex;
+      } else if (assignment.customValue) {
+        value = assignment.customValue;
+      }
+
+      if (!value) continue;
+
+      if (
+        (roleDef.inputType === "px" || roleDef.inputType === "ms")
+        && /^\d+(\.\d+)?$/.test(value)
+      ) {
+        value = `${value}${roleDef.inputType}`;
+      }
+
+      for (const prop of roleDef.cssProperties) {
+        overrides.push(`  ${prop}: ${value};`);
+      }
+    }
+
+    if (overrides.length === 0) return "";
+
+    // Use @layer to ensure overrides sit above theme layers.
+    // The styles.css layers are: storybook, osdk.styles, cbac.components, themes.
+    // An unlayered style block always beats layered styles in the cascade.
+    // Reset block reverts stale tokens; override block applies the new theme.
+    return `:root:root {\n${resets.join("\n")}\n${overrides.join("\n")}\n}`;
+  }, [brandTheme]);
+
+  useEffect(function syncBrandThemeOverrideStyle() {
+    let styleEl = document.getElementById(STYLE_ID) as HTMLStyleElement | null;
+
+    if (cssText) {
+      if (!styleEl) {
+        styleEl = document.createElement("style");
+        styleEl.id = STYLE_ID;
+        document.head.appendChild(styleEl);
+      }
+      styleEl.textContent = cssText;
+    } else if (styleEl) {
+      styleEl.remove();
+    }
+
+    return () => {
+      const el = document.getElementById(STYLE_ID);
+      if (el) el.remove();
+    };
+  }, [cssText]);
+
+  useEffect(function applyBlueprintColorMode() {
+    const root = document.documentElement;
+    if (brandTheme.colorMode === "dark") {
+      root.setAttribute("data-bp-color-scheme", "dark");
+    } else {
+      root.removeAttribute("data-bp-color-scheme");
+    }
+
+    return () => {
+      root.removeAttribute("data-bp-color-scheme");
+    };
+  }, [brandTheme.colorMode]);
+
+  return <Story />;
+};

--- a/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/presets.ts
+++ b/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/presets.ts
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ThemeColorMode, TokenAssignment } from "./types.js";
+
+export interface ThemePreset {
+  id: string;
+  label: string;
+  description: string;
+  /** The color mode this preset targets. Defaults to "light". */
+  colorMode?: ThemeColorMode;
+  modes?: Record<ThemeColorMode, ThemePresetMode>;
+  /** Preview swatch colors for single-mode presets. */
+  swatches?: [string, string, string];
+  /** Token assignments for single-mode presets. */
+  assignments?: TokenAssignment[];
+}
+
+export interface ThemePresetMode {
+  /** Preview swatch colors: [background, primary, text] */
+  swatches: [string, string, string];
+  assignments: TokenAssignment[];
+}
+
+function colorAssignment(role: string, hex: string): TokenAssignment {
+  return { role, colorIndex: -1, customValue: hex };
+}
+
+function valueAssignment(role: string, value: string): TokenAssignment {
+  return { role, colorIndex: -1, customValue: value };
+}
+
+export function getThemePresetMode(
+  preset: ThemePreset,
+  colorMode: ThemeColorMode,
+): ThemePresetMode {
+  if (preset.modes) {
+    return preset.modes[colorMode];
+  }
+
+  return {
+    swatches: preset.swatches ?? ["#ffffff", "#2d72d2", "#1c2127"],
+    assignments: preset.assignments ?? [],
+  };
+}
+
+/** Shared non-color defaults used across most presets */
+function baseDefaults(overrides?: {
+  radius?: string;
+  spacing?: string;
+  shadow?: string;
+}): TokenAssignment[] {
+  return [
+    valueAssignment(
+      "font-family",
+      "Inter, system-ui, -apple-system, sans-serif",
+    ),
+    valueAssignment("font-size-small", "12"),
+    valueAssignment("font-size-medium", "14"),
+    valueAssignment("font-size-large", "16"),
+    valueAssignment("font-weight-default", "400"),
+    valueAssignment("font-weight-bold", "600"),
+    valueAssignment("line-height", "1.5"),
+    valueAssignment("border-radius", overrides?.radius ?? "4"),
+    valueAssignment("spacing", overrides?.spacing ?? "4"),
+    valueAssignment("border-width", "1"),
+    valueAssignment(
+      "shadow",
+      overrides?.shadow
+        ?? "0 1px 3px oklch(0 0 0 / 0.12), 0 1px 2px oklch(0 0 0 / 0.08)",
+    ),
+    valueAssignment("focus-width", "2"),
+    valueAssignment("focus-offset", "2"),
+    valueAssignment("transition-duration", "150"),
+  ];
+}
+
+export const THEME_PRESETS: ThemePreset[] = [
+  {
+    id: "workshop-light",
+    label: "Workshop Light",
+    description: "Default Blueprint light theme used by Workshop-style apps",
+    swatches: ["#ffffff", "#2d72d2", "#1c2127"],
+    assignments: [
+      colorAssignment("background", "#ffffff"),
+      colorAssignment("surface", "#f6f7f9"),
+      colorAssignment("text", "#1c2127"),
+      colorAssignment("text-muted", "#5f6b7c"),
+      colorAssignment("primary", "#2d72d2"),
+      colorAssignment("primary-foreground", "#ffffff"),
+      colorAssignment("secondary", "#f6f7f9"),
+      colorAssignment("secondary-foreground", "#1c2127"),
+      colorAssignment("icon-color", "#5f6b7c"),
+      colorAssignment("border", "#dce0e5"),
+      colorAssignment("danger", "#cd4246"),
+      colorAssignment("success", "#238551"),
+      ...baseDefaults({
+        shadow: "inset 0 1px 1px oklch(0 0 0 / 0.15)",
+      }),
+    ],
+  },
+  {
+    id: "workshop-dark",
+    label: "Workshop Dark",
+    description: "Default Blueprint dark theme used by Workshop-style apps",
+    colorMode: "dark",
+    swatches: ["#111418", "#2d72d2", "#a5aab3"],
+    assignments: [
+      colorAssignment("background", "#111418"),
+      colorAssignment("surface", "#1c2127"),
+      colorAssignment("text", "#a5aab3"),
+      colorAssignment("text-muted", "#8f99a8"),
+      colorAssignment("primary", "#2d72d2"),
+      colorAssignment("primary-foreground", "#ffffff"),
+      colorAssignment("secondary", "#252a31"),
+      colorAssignment("secondary-foreground", "#f6f7f9"),
+      colorAssignment("icon-color", "#8f99a8"),
+      colorAssignment("border", "#ffffff33"),
+      colorAssignment("danger", "#cd4246"),
+      colorAssignment("success", "#238551"),
+      ...baseDefaults({
+        shadow:
+          "inset 0 0 0 1px oklch(1 0 0 / 0.2), 0 4px 6px -4px oklch(0 0 0 / 0.5), 0 10px 30px -5px oklch(0 0 0 / 0.5)",
+      }),
+    ],
+  },
+  {
+    id: "devcon",
+    label: "DevCon",
+    description: "Dark theme with green accents for DevCon demos",
+    colorMode: "dark",
+    swatches: ["#0a0a0a", "#16a34a", "#86efac"],
+    assignments: [
+      colorAssignment("background", "#0a0a0a"),
+      colorAssignment("surface", "#111111"),
+      colorAssignment("text", "#86efac"),
+      colorAssignment("text-muted", "#16a34a"),
+      colorAssignment("primary", "#16a34a"),
+      colorAssignment("primary-foreground", "#0a0a0a"),
+      colorAssignment("secondary", "#1a1a1a"),
+      colorAssignment("secondary-foreground", "#86efac"),
+      colorAssignment("icon-color", "#22c55e"),
+      colorAssignment("border", "#15803d"),
+      colorAssignment("danger", "#ef4444"),
+      colorAssignment("success", "#4ade80"),
+      ...baseDefaults({
+        shadow: "0 1px 3px oklch(0 0 0 / 0.4), 0 1px 2px oklch(0 0 0 / 0.3)",
+      }),
+    ],
+  },
+  {
+    id: "midnight-blue",
+    label: "Midnight Blue",
+    description: "Dark theme with blue accents",
+    colorMode: "dark",
+    swatches: ["#0f172a", "#2563eb", "#e2e8f0"],
+    assignments: [
+      colorAssignment("background", "#0f172a"),
+      colorAssignment("surface", "#1e293b"),
+      colorAssignment("text", "#e2e8f0"),
+      colorAssignment("text-muted", "#94a3b8"),
+      colorAssignment("primary", "#2563eb"),
+      colorAssignment("primary-foreground", "#ffffff"),
+      colorAssignment("secondary", "#334155"),
+      colorAssignment("secondary-foreground", "#e2e8f0"),
+      colorAssignment("icon-color", "#8b9bb5"),
+      colorAssignment("border", "#334155"),
+      colorAssignment("danger", "#ef4444"),
+      colorAssignment("success", "#22c55e"),
+      ...baseDefaults({
+        radius: "6",
+        shadow: "0 1px 3px oklch(0 0 0 / 0.4), 0 1px 2px oklch(0 0 0 / 0.3)",
+      }),
+    ],
+  },
+  {
+    id: "warm-sand",
+    label: "Warm Sand",
+    description: "Warm neutral light theme",
+    swatches: ["#faf8f5", "#c2410c", "#44403c"],
+    assignments: [
+      colorAssignment("background", "#faf8f5"),
+      colorAssignment("surface", "#f5f0eb"),
+      colorAssignment("text", "#1c1917"),
+      colorAssignment("text-muted", "#78716c"),
+      colorAssignment("primary", "#c2410c"),
+      colorAssignment("primary-foreground", "#ffffff"),
+      colorAssignment("secondary", "#e7e5e4"),
+      colorAssignment("secondary-foreground", "#44403c"),
+      colorAssignment("icon-color", "#78716c"),
+      colorAssignment("border", "#d6d3d1"),
+      colorAssignment("danger", "#dc2626"),
+      colorAssignment("success", "#15803d"),
+      ...baseDefaults({ radius: "8" }),
+    ],
+  },
+  {
+    id: "royal-purple",
+    label: "Royal Purple",
+    description: "Dark theme with purple accents",
+    colorMode: "dark",
+    swatches: ["#1a1025", "#a855f7", "#e9d5ff"],
+    assignments: [
+      colorAssignment("background", "#1a1025"),
+      colorAssignment("surface", "#2d1b4e"),
+      colorAssignment("text", "#e9d5ff"),
+      colorAssignment("text-muted", "#a78bfa"),
+      colorAssignment("primary", "#9333ea"),
+      colorAssignment("primary-foreground", "#ffffff"),
+      colorAssignment("secondary", "#3b2563"),
+      colorAssignment("secondary-foreground", "#e9d5ff"),
+      colorAssignment("icon-color", "#c084fc"),
+      colorAssignment("border", "#4c1d95"),
+      colorAssignment("danger", "#f43f5e"),
+      colorAssignment("success", "#34d399"),
+      ...baseDefaults({
+        radius: "6",
+        shadow: "0 1px 3px oklch(0 0 0 / 0.4), 0 1px 2px oklch(0 0 0 / 0.3)",
+      }),
+    ],
+  },
+];

--- a/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/state.ts
+++ b/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/state.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  getThemePresetMode,
+  THEME_PRESETS,
+  type ThemePreset,
+} from "./presets.js";
+import type {
+  BrandThemeGlobals,
+  ExtractedColor,
+  ThemeColorMode,
+  TokenAssignment,
+} from "./types.js";
+
+export const WORKSHOP_PRESET_ID = "workshop-light";
+export const DEFAULT_COLOR_MODE: ThemeColorMode = "light";
+
+interface CreateThemeStateParams {
+  presetId: string;
+  colorMode: ThemeColorMode;
+}
+
+export function getDefaultBrandThemeState(): BrandThemeGlobals {
+  return createThemeStateForMode({
+    presetId: WORKSHOP_PRESET_ID,
+    colorMode: DEFAULT_COLOR_MODE,
+  });
+}
+
+export function createThemeStateForMode(
+  { presetId, colorMode }: CreateThemeStateParams,
+): BrandThemeGlobals {
+  const preset = findThemePreset(presetId) ?? THEME_PRESETS[0];
+  if (!preset) {
+    return {
+      active: false,
+      colorMode,
+      selectedPresetId: "",
+      palette: [],
+      assignments: [],
+    };
+  }
+
+  const effectiveColorMode = preset.colorMode ?? colorMode;
+  const presetMode = getThemePresetMode(preset, effectiveColorMode);
+
+  return {
+    active: true,
+    colorMode: effectiveColorMode,
+    selectedPresetId: preset.id,
+    palette: [],
+    assignments: presetMode.assignments,
+  };
+}
+
+export function parseBrandThemeState(raw: unknown): BrandThemeGlobals {
+  if (raw == null || raw === "") {
+    return getDefaultBrandThemeState();
+  }
+
+  const parsed = parseRawState(raw);
+  if (!parsed) {
+    return getDefaultBrandThemeState();
+  }
+
+  return {
+    active: getBoolean(parsed.active, getDefaultBrandThemeState().active),
+    colorMode: getThemeColorMode(parsed.colorMode),
+    selectedPresetId: getString(
+      parsed.selectedPresetId,
+      getDefaultBrandThemeState().selectedPresetId,
+    ),
+    palette: getExtractedColors(parsed.palette),
+    assignments: getTokenAssignments(parsed.assignments),
+  };
+}
+
+export function stringifyBrandThemeState(state: BrandThemeGlobals): string {
+  return JSON.stringify(state);
+}
+
+export function findThemePreset(presetId: string): ThemePreset | undefined {
+  return THEME_PRESETS.find((preset) => preset.id === presetId);
+}
+
+function parseRawState(raw: unknown): Record<string, unknown> | undefined {
+  if (typeof raw === "string") {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      return isRecord(parsed) ? parsed : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  return isRecord(raw) ? raw : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != null && !Array.isArray(value);
+}
+
+function getBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function getString(value: unknown, fallback: string): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function getThemeColorMode(value: unknown): ThemeColorMode {
+  return value === "dark" ? "dark" : DEFAULT_COLOR_MODE;
+}
+
+function getExtractedColors(value: unknown): ExtractedColor[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter(isExtractedColor);
+}
+
+function isExtractedColor(value: unknown): value is ExtractedColor {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return Array.isArray(value.rgb)
+    && value.rgb.length === 3
+    && value.rgb.every((channel) => typeof channel === "number")
+    && typeof value.hex === "string"
+    && typeof value.luminance === "number"
+    && typeof value.chroma === "number"
+    && typeof value.count === "number";
+}
+
+function getTokenAssignments(value: unknown): TokenAssignment[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter(isTokenAssignment);
+}
+
+function isTokenAssignment(value: unknown): value is TokenAssignment {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return typeof value.role === "string"
+    && typeof value.colorIndex === "number"
+    && (
+      value.customValue === undefined
+      || typeof value.customValue === "string"
+    );
+}

--- a/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/token-map.ts
+++ b/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/token-map.ts
@@ -1,0 +1,375 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { TokenRoleDefinition } from "./types.js";
+
+/**
+ * Complete token role definitions mapping friendly role names
+ * to actual OSDK/Blueprint CSS custom properties.
+ *
+ * Each role cascades into ALL component-level tokens that derive
+ * from it, ensuring a complete theme when colors are set.
+ *
+ * NOTE: Only override semantic tokens here — avoid palette primitives
+ * (e.g. --bp-palette-black) as they feed into oklch derivation chains.
+ * Only override rest-state intent tokens — hover/active are derived
+ * from rest via CSS defaults or oklch formulas.
+ */
+export const TOKEN_ROLES: TokenRoleDefinition[] = [
+  // ── Colors ──────────────────────────────────────────────
+  {
+    role: "background",
+    label: "Background",
+    category: "color",
+    inputType: "color",
+    cssProperties: [
+      // Semantic background
+      "--osdk-background-primary",
+      // Table row backgrounds (both default and alternate use the same color)
+      "--osdk-table-row-bg-default",
+      "--osdk-table-row-bg-alternate",
+      // Surface default rest
+      "--osdk-surface-background-color-default-rest",
+      "--bp-surface-background-color-default-rest",
+    ],
+  },
+  {
+    role: "surface",
+    label: "Surface",
+    category: "color",
+    inputType: "color",
+    cssProperties: [
+      // Semantic backgrounds
+      "--osdk-background-secondary",
+      "--osdk-background-tertiary",
+      // Surface hover/active (needed for filter list, select, combobox states)
+      "--osdk-surface-background-color-default-hover",
+      "--bp-surface-background-color-default-hover",
+      "--osdk-surface-background-color-default-active",
+      "--bp-surface-background-color-default-active",
+      // Table header
+      "--osdk-table-header-bg",
+      // Checkbox hover background
+      "--osdk-checkbox-bg-hover",
+    ],
+  },
+  {
+    role: "text",
+    label: "Text",
+    category: "color",
+    inputType: "color",
+    cssProperties: [
+      // Typography (semantic only — palette primitives excluded
+      // to preserve oklch derivation chains)
+      "--osdk-typography-color-default-rest",
+      "--bp-typography-color-default-rest",
+      // Table text
+      "--osdk-table-header-color",
+      "--osdk-table-cell-color",
+    ],
+  },
+  {
+    role: "text-muted",
+    label: "Text Muted",
+    category: "color",
+    inputType: "color",
+    cssProperties: [
+      "--osdk-typography-color-muted",
+      "--bp-typography-color-muted",
+      // Intent default (used for muted/secondary UI)
+      "--osdk-intent-default-rest",
+      "--bp-intent-default-rest",
+      // Table header menu color
+      "--osdk-table-header-menu-color",
+    ],
+  },
+  {
+    role: "primary",
+    label: "Primary",
+    category: "color",
+    inputType: "color",
+    cssProperties: [
+      // Intent primary (rest only — hover/active derive from CSS defaults)
+      "--osdk-intent-primary-rest",
+      "--bp-intent-primary-rest",
+      // Focus ring
+      "--osdk-emphasis-focus-color",
+      "--bp-emphasis-focus-color",
+      // Checkbox checked
+      "--osdk-checkbox-bg-checked",
+    ],
+  },
+  {
+    role: "primary-foreground",
+    label: "Primary Foreground",
+    category: "color",
+    inputType: "color",
+    cssProperties: [
+      "--osdk-intent-primary-foreground",
+      "--bp-intent-primary-foreground",
+      // Checkbox tick color
+      "--osdk-checkbox-checked-foreground",
+    ],
+  },
+  {
+    role: "secondary",
+    label: "Secondary",
+    category: "color",
+    inputType: "color",
+    cssProperties: [
+      // Secondary button background only — intent-default-hover
+      // intentionally excluded to preserve oklch derivation chain
+      "--osdk-button-secondary-bg",
+    ],
+  },
+  {
+    role: "secondary-foreground",
+    label: "Secondary Foreground",
+    category: "color",
+    inputType: "color",
+    cssProperties: [
+      "--osdk-button-secondary-color",
+      "--osdk-intent-default-foreground",
+      "--bp-intent-default-foreground",
+    ],
+  },
+  {
+    role: "icon-color",
+    label: "Icon Color",
+    category: "color",
+    inputType: "color",
+    cssProperties: [
+      "--osdk-iconography-color-muted",
+      "--osdk-drag-handle-color",
+    ],
+  },
+  {
+    role: "border",
+    label: "Border",
+    category: "color",
+    inputType: "color",
+    cssProperties: [
+      // Surface border (default only — strong derives from default
+      // via oklch with higher opacity)
+      "--osdk-surface-border-color-default",
+      "--bp-surface-border-color-default",
+      // Table border
+      "--osdk-table-border-color",
+      // Checkbox border color
+      "--osdk-checkbox-border-color",
+    ],
+  },
+  {
+    role: "danger",
+    label: "Danger",
+    category: "color",
+    inputType: "color",
+    cssProperties: [
+      // Rest only — hover/active derive from CSS defaults
+      "--osdk-intent-danger-rest",
+      "--bp-intent-danger-rest",
+      "--osdk-intent-danger-foreground",
+      "--bp-intent-danger-foreground",
+    ],
+  },
+  {
+    role: "success",
+    label: "Success",
+    category: "color",
+    inputType: "color",
+    cssProperties: [
+      // Rest only — hover/active derive from CSS defaults
+      "--osdk-intent-success-rest",
+      "--bp-intent-success-rest",
+      "--osdk-intent-success-foreground",
+      "--bp-intent-success-foreground",
+    ],
+  },
+  {
+    role: "warning",
+    label: "Warning",
+    category: "color",
+    inputType: "color",
+    cssProperties: [
+      "--osdk-intent-warning-rest",
+      "--bp-intent-warning-rest",
+      "--osdk-intent-warning-foreground",
+      "--bp-intent-warning-foreground",
+    ],
+  },
+
+  // ── Typography ──────────────────────────────────────────
+  {
+    role: "font-family",
+    label: "Font Family",
+    category: "typography",
+    inputType: "font",
+    cssProperties: [
+      "--osdk-typography-family-default",
+      "--bp-typography-family-default",
+    ],
+  },
+  {
+    role: "font-size-small",
+    label: "Size Small",
+    category: "typography",
+    inputType: "px",
+    cssProperties: [
+      "--osdk-typography-size-body-small",
+      "--bp-typography-size-body-small",
+    ],
+  },
+  {
+    role: "font-size-medium",
+    label: "Size Medium",
+    category: "typography",
+    inputType: "px",
+    cssProperties: [
+      "--osdk-typography-size-body-medium",
+      "--bp-typography-size-body-medium",
+    ],
+  },
+  {
+    role: "font-size-large",
+    label: "Size Large",
+    category: "typography",
+    inputType: "px",
+    cssProperties: [
+      "--osdk-typography-size-body-large",
+      "--bp-typography-size-body-large",
+    ],
+  },
+  {
+    role: "font-weight-default",
+    label: "Weight Default",
+    category: "typography",
+    inputType: "number",
+    cssProperties: [
+      "--osdk-typography-weight-default",
+      "--bp-typography-weight-default",
+    ],
+  },
+  {
+    role: "font-weight-bold",
+    label: "Weight Bold",
+    category: "typography",
+    inputType: "number",
+    cssProperties: [
+      "--osdk-typography-weight-bold",
+      "--bp-typography-weight-bold",
+    ],
+  },
+  {
+    role: "line-height",
+    label: "Line Height",
+    category: "typography",
+    inputType: "number",
+    cssProperties: [
+      "--osdk-typography-line-height-default",
+      "--bp-typography-line-height-default",
+    ],
+  },
+
+  // ── Surface ─────────────────────────────────────────────
+  {
+    role: "border-radius",
+    label: "Border Radius",
+    category: "surface",
+    inputType: "px",
+    cssProperties: [
+      "--osdk-surface-border-radius",
+      "--bp-surface-border-radius",
+    ],
+  },
+  {
+    role: "spacing",
+    label: "Spacing",
+    category: "surface",
+    inputType: "px",
+    cssProperties: [
+      "--osdk-surface-spacing",
+      "--bp-surface-spacing",
+    ],
+  },
+  {
+    role: "border-width",
+    label: "Border Width",
+    category: "surface",
+    inputType: "px",
+    cssProperties: [
+      "--osdk-surface-border-width",
+      "--bp-surface-border-width",
+    ],
+  },
+  {
+    role: "shadow",
+    label: "Shadow",
+    category: "surface",
+    inputType: "shadow",
+    cssProperties: [
+      "--osdk-surface-shadow-2",
+      "--bp-surface-shadow-2",
+      // Input shadow
+      "--osdk-input-shadow",
+    ],
+  },
+
+  // ── Emphasis ────────────────────────────────────────────
+  {
+    role: "focus-width",
+    label: "Focus Width",
+    category: "emphasis",
+    inputType: "px",
+    cssProperties: [
+      "--osdk-emphasis-focus-width",
+      "--bp-emphasis-focus-width",
+    ],
+  },
+  {
+    role: "focus-offset",
+    label: "Focus Offset",
+    category: "emphasis",
+    inputType: "px",
+    cssProperties: [
+      "--osdk-emphasis-focus-offset",
+      "--bp-emphasis-focus-offset",
+    ],
+  },
+  {
+    role: "transition-duration",
+    label: "Transition",
+    category: "emphasis",
+    inputType: "ms",
+    cssProperties: [
+      "--osdk-emphasis-transition-duration",
+      "--bp-emphasis-transition-duration",
+    ],
+  },
+];
+
+/** Get token roles filtered by category */
+export function getTokensByCategory(
+  category: string,
+): TokenRoleDefinition[] {
+  return TOKEN_ROLES.filter((t) => t.category === category);
+}
+
+/** Lookup a token role definition by role name */
+export function getTokenRole(
+  role: string,
+): TokenRoleDefinition | undefined {
+  return TOKEN_ROLES.find((t) => t.role === role);
+}

--- a/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/types.ts
+++ b/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/types.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface ExtractedColor {
+  rgb: [number, number, number];
+  hex: string;
+  luminance: number;
+  chroma: number;
+  count: number;
+}
+
+export interface TokenAssignment {
+  role: string;
+  /** Index into the palette array, or -1 for a custom value */
+  colorIndex: number;
+  /** Custom value (hex for colors, string for other tokens) */
+  customValue?: string;
+}
+
+export type ThemeColorMode = "light" | "dark";
+
+export interface BrandThemeGlobals {
+  active: boolean;
+  colorMode: ThemeColorMode;
+  selectedPresetId: string;
+  palette: ExtractedColor[];
+  assignments: TokenAssignment[];
+}
+
+export type ColorTokenRole =
+  | "background"
+  | "surface"
+  | "text"
+  | "text-muted"
+  | "primary"
+  | "primary-foreground"
+  | "secondary"
+  | "secondary-foreground"
+  | "icon-color"
+  | "border"
+  | "danger"
+  | "success";
+
+export type TypographyTokenRole =
+  | "font-family"
+  | "font-size-small"
+  | "font-size-medium"
+  | "font-size-large"
+  | "font-weight-default"
+  | "font-weight-bold"
+  | "line-height";
+
+export type SurfaceTokenRole =
+  | "border-radius"
+  | "spacing"
+  | "border-width"
+  | "shadow";
+
+export type EmphasisTokenRole =
+  | "focus-width"
+  | "focus-offset"
+  | "transition-duration";
+
+export type TokenRole =
+  | ColorTokenRole
+  | TypographyTokenRole
+  | SurfaceTokenRole
+  | EmphasisTokenRole;
+
+export type TokenCategory = "color" | "typography" | "surface" | "emphasis";
+
+export interface TokenRoleDefinition {
+  role: TokenRole;
+  label: string;
+  category: TokenCategory;
+  cssProperties: string[];
+  inputType: "color" | "text" | "px" | "number" | "ms" | "shadow" | "font";
+  defaultValue?: string;
+}

--- a/packages/react-components-storybook/.storybook/main.ts
+++ b/packages/react-components-storybook/.storybook/main.ts
@@ -22,7 +22,6 @@ const config: StorybookConfig = {
     "@storybook/addon-a11y",
     "@storybook/addon-docs",
     "@storybook/addon-links",
-    "@storybook/addon-themes",
     "@storybook/addon-mcp",
     "msw-storybook-addon",
     "storybook-addon-tag-badges",

--- a/packages/react-components-storybook/.storybook/preview.tsx
+++ b/packages/react-components-storybook/.storybook/preview.tsx
@@ -16,7 +16,6 @@
 
 import { createClient } from "@osdk/client";
 import { OsdkProvider } from "@osdk/react";
-import { withThemeByDataAttribute } from "@storybook/addon-themes";
 import type { Preview } from "@storybook/react-vite";
 import { initialize, mswLoader } from "msw-storybook-addon";
 import { fauxFoundry, setupFauxFoundry } from "../src/mocks/fauxFoundry.js";
@@ -25,7 +24,7 @@ import "./styles.css";
 // Initialize MSW with proper options
 // This is synchronous, it only configures MSW
 // The actual service worker registration happens in the mswLoader, which runs before each story
-const basePath = (import.meta as any).env?.BASE_URL ?? "/";
+const basePath = import.meta.env.BASE_URL ?? "/";
 const serviceWorkerUrl = `${basePath}${
   basePath.endsWith("/") ? "" : "/"
 }mockServiceWorker.js`;
@@ -76,15 +75,6 @@ const preview: Preview = {
         </OsdkProvider>
       </div>
     ),
-    withThemeByDataAttribute({
-      themes: {
-        light: "light",
-        modern: "modern",
-        devcon: "devcon",
-      },
-      defaultTheme: "light",
-      attributeName: "data-theme",
-    }),
   ],
 };
 

--- a/packages/react-components-storybook/.storybook/preview.tsx
+++ b/packages/react-components-storybook/.storybook/preview.tsx
@@ -19,6 +19,12 @@ import { OsdkProvider } from "@osdk/react";
 import type { Preview } from "@storybook/react-vite";
 import { initialize, mswLoader } from "msw-storybook-addon";
 import { fauxFoundry, setupFauxFoundry } from "../src/mocks/fauxFoundry.js";
+import { GLOBALS_KEY } from "./addons/brand-theme-extractor/constants.js";
+import { BrandThemeDecorator } from "./addons/brand-theme-extractor/decorator.js";
+import {
+  getDefaultBrandThemeState,
+  stringifyBrandThemeState,
+} from "./addons/brand-theme-extractor/state.js";
 import "./styles.css";
 
 // Initialize MSW with proper options
@@ -46,6 +52,9 @@ const mockClient = createClient(
 );
 
 const preview: Preview = {
+  initialGlobals: {
+    [GLOBALS_KEY]: stringifyBrandThemeState(getDefaultBrandThemeState()),
+  },
   parameters: {
     controls: {
       matchers: {
@@ -75,6 +84,7 @@ const preview: Preview = {
         </OsdkProvider>
       </div>
     ),
+    BrandThemeDecorator,
   ],
 };
 

--- a/packages/react-components-storybook/package.json
+++ b/packages/react-components-storybook/package.json
@@ -32,7 +32,6 @@
     "@storybook/addon-docs": "^10.2.10",
     "@storybook/addon-links": "^10.2.10",
     "@storybook/addon-mcp": "^0.2.3",
-    "@storybook/addon-themes": "^10.2.10",
     "@storybook/react-vite": "^10.2.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/node": "^20.19.13",

--- a/packages/react-components-storybook/src/styles/storybook.css
+++ b/packages/react-components-storybook/src/styles/storybook.css
@@ -65,7 +65,6 @@ body {
   --osdk-form-content-padding-block: calc(var(--osdk-surface-spacing) * 4);
 
   width: min(480px, calc(100vw - calc(var(--osdk-surface-spacing) * 8)));
-  max-height: calc(100vh - calc(var(--osdk-surface-spacing) * 16));
 }
 
 .osdkCustomTextarea {


### PR DESCRIPTION
## Summary
- Add `BrandThemeDecorator` that reads theme globals and injects a `<style>` tag with CSS custom property overrides into the preview document
- Wire decorator into `preview.tsx` with `initialGlobals` so Workshop Light theme applies by default on load

## Test plan
- [ ] Storybook loads with Workshop Light theme applied by default
- [ ] CSS custom properties are injected into `:root:root`
- [ ] Dark mode preset sets `data-bp-color-scheme="dark"` on root

🤖 Generated with [Claude Code](https://claude.com/claude-code)