### PR TITLE
Remove @storybook/addon-themes (cleanup)

### DIFF
--- a/.changeset/remove-storybook-addon-themes.md
+++ b/.changeset/remove-storybook-addon-themes.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components-storybook": patch
+---
+
+Remove @storybook/addon-themes now that custom brand theme preset system is in place

--- a/packages/react-components-storybook/.storybook/main.ts
+++ b/packages/react-components-storybook/.storybook/main.ts
@@ -22,7 +22,6 @@ const config: StorybookConfig = {
     "@storybook/addon-a11y",
     "@storybook/addon-docs",
     "@storybook/addon-links",
-    "@storybook/addon-themes",
     "@storybook/addon-mcp",
     "msw-storybook-addon",
     "storybook-addon-tag-badges",

--- a/packages/react-components-storybook/.storybook/preview.tsx
+++ b/packages/react-components-storybook/.storybook/preview.tsx
@@ -16,7 +16,6 @@
 
 import { createClient } from "@osdk/client";
 import { OsdkProvider } from "@osdk/react";
-import { withThemeByDataAttribute } from "@storybook/addon-themes";
 import type { Preview } from "@storybook/react-vite";
 import { initialize, mswLoader } from "msw-storybook-addon";
 import { fauxFoundry, setupFauxFoundry } from "../src/mocks/fauxFoundry.js";
@@ -31,7 +30,7 @@ import "./styles.css";
 // Initialize MSW with proper options
 // This is synchronous, it only configures MSW
 // The actual service worker registration happens in the mswLoader, which runs before each story
-const basePath = (import.meta as any).env?.BASE_URL ?? "/";
+const basePath = import.meta.env.BASE_URL ?? "/";
 const serviceWorkerUrl = `${basePath}${
   basePath.endsWith("/") ? "" : "/"
 }mockServiceWorker.js`;
@@ -85,15 +84,6 @@ const preview: Preview = {
         </OsdkProvider>
       </div>
     ),
-    withThemeByDataAttribute({
-      themes: {
-        light: "light",
-        modern: "modern",
-        devcon: "devcon",
-      },
-      defaultTheme: "light",
-      attributeName: "data-theme",
-    }),
     BrandThemeDecorator,
   ],
 };

--- a/packages/react-components-storybook/package.json
+++ b/packages/react-components-storybook/package.json
@@ -33,7 +33,6 @@
     "@storybook/addon-links": "^10.2.10",
     "@storybook/addon-mcp": "^0.2.3",
     "@storybook/icons": "^2.0.1",
-    "@storybook/addon-themes": "^10.2.10",
     "@storybook/react-vite": "^10.2.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/node": "^20.19.13",

--- a/packages/react-components-storybook/src/styles/storybook.css
+++ b/packages/react-components-storybook/src/styles/storybook.css
@@ -65,7 +65,6 @@ body {
   --osdk-form-content-padding-block: calc(var(--osdk-surface-spacing) * 4);
 
   width: min(480px, calc(100vw - calc(var(--osdk-surface-spacing) * 8)));
-  max-height: calc(100vh - calc(var(--osdk-surface-spacing) * 16));
 }
 
 .osdkCustomTextarea {


### PR DESCRIPTION
## Summary
- Remove `@storybook/addon-themes` addon and its `withThemeByDataAttribute` decorator — no longer needed now that the custom brand theme system is fully in place
- Fix `as any` cast on `import.meta.env` in preview config
- Remove unnecessary `max-height` constraint on dialog form styles

**PR chain:** #3306 → decorator → toolbar → **this PR** (last — merge when ready to drop the old theme system)

## Test plan
- [ ] Storybook builds without errors
- [ ] Stories render correctly using the new brand theme system
- [ ] No broken imports or runtime errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)