### PR TITLE
Unwrap secured $primaryKey and $title

### DIFF
--- a/.changeset/unwrap-secured-primary-key-title.md
+++ b/.changeset/unwrap-secured-primary-key-title.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client": patch
+"@osdk/api": patch
+---
+
+Unwrap `$primaryKey` and `$title` when they are returned as secured property values, and include them as keys in `$propertySecurities` (both at the type level and at runtime, including interface views).

--- a/packages/api/src/OsdkObjectFrom.ts
+++ b/packages/api/src/OsdkObjectFrom.ts
@@ -380,7 +380,11 @@ type ObjectPropertySecurities<
   Q extends ObjectOrInterfaceDefinition,
   T extends PropertyKeys<Q>,
 > = {
-  [K in T]: CompileTimeMetadata<Q>["properties"][K]["multiplicity"] extends true
-    ? PropertySecurity[][]
-    : PropertySecurity[];
+  [K in T | "$primaryKey" | "$title"]: K extends "$primaryKey" | "$title"
+    ? PropertySecurity[]
+    : K extends PropertyKeys<Q>
+      ? CompileTimeMetadata<Q>["properties"][K]["multiplicity"] extends true
+        ? PropertySecurity[][]
+      : PropertySecurity[]
+    : never;
 };

--- a/packages/api/src/__quickinfo_snapshot__/__snapshots__/osdkInstance.snap
+++ b/packages/api/src/__quickinfo_snapshot__/__snapshots__/osdkInstance.snap
@@ -260,6 +260,8 @@ type osdkInstance_property_securities =
       addressStruct: Array<PropertySecurity>;
       salaryHistory: Array<Array<PropertySecurity>>;
       bonusHistory: Array<Array<PropertySecurity>>;
+      $primaryKey: Array<PropertySecurity>;
+      $title: Array<PropertySecurity>;
     };
   };
 

--- a/packages/client/src/object/convertWireToOsdkObjects.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.test.ts
@@ -1082,8 +1082,8 @@ describe("convertWireToOsdkObjects", () => {
   it("$as on an object loaded with $loadPropertySecurityMetadata produces the full interface view, threading $propertySecurities and the standard $* props", async () => {
     const wireEmployee = {
       __apiName: "Employee",
-      __primaryKey: 50031,
-      __title: "Jane Doe",
+      __primaryKey: { value: 50031, propertySecurityIndex: 0 },
+      __title: { value: "Jane Doe", propertySecurityIndex: 0 },
       employeeId: 50031,
       fullName: { value: "Jane Doe", propertySecurityIndex: 0 },
       office: { value: "SEA", propertySecurityIndex: 0 },
@@ -1113,7 +1113,9 @@ describe("convertWireToOsdkObjects", () => {
       >
     >();
 
-    expectTypeOf(asFoo.$propertySecurities).toEqualTypeOf<{
+    expectTypeOf(asFoo.$propertySecurities).branded.toEqualTypeOf<{
+      $primaryKey: PropertySecurity[];
+      $title: PropertySecurity[];
       fooIdp: PropertySecurity[];
       fooSpt: PropertySecurity[];
     }>();
@@ -1125,6 +1127,16 @@ describe("convertWireToOsdkObjects", () => {
         "$objectType": "Employee",
         "$primaryKey": 50031,
         "$propertySecurities": {
+          "$primaryKey": [
+            {
+              "type": "unsupportedPolicy",
+            },
+          ],
+          "$title": [
+            {
+              "type": "unsupportedPolicy",
+            },
+          ],
           "fooIdp": [
             {
               "type": "unsupportedPolicy",

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.ts
@@ -168,6 +168,10 @@ function remapPropertySecuritiesForInterface(
   const remapped: PropertySecuritiesMap = {};
 
   for (const objPropName of Object.keys(underlyingSecurities)) {
+    if (objPropName === "$primaryKey" || objPropName === "$title") {
+      remapped[objPropName] = underlyingSecurities[objPropName];
+      continue;
+    }
     const interfacePropName = inverseMap[objPropName];
     if (interfacePropName == null) continue;
 

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -58,6 +58,8 @@ const specialPropertyTypes = new Set(
   ],
 );
 
+const securableSpecialKeys = new Set(["$primaryKey", "$title"]);
+
 // kept separate so we are not redefining these functions
 // every time an object is created.
 const basePropDefs = {
@@ -358,7 +360,9 @@ function parseWhenSecuritiesLoaded(
 
   for (const propKey of Object.keys(rawObject)) {
     if (
-      propKey in objectDef.properties || propKey in derivedPropertyTypeByName
+      propKey in objectDef.properties
+      || propKey in derivedPropertyTypeByName
+      || securableSpecialKeys.has(propKey)
     ) {
       const value = rawObject[propKey];
 

--- a/packages/client/src/object/object.test.ts
+++ b/packages/client/src/object/object.test.ts
@@ -582,6 +582,8 @@ describe.each([
 
       expectTypeOf(object.$propertySecurities).toMatchObjectType<
         {
+          $primaryKey: PropertySecurity[];
+          $title: PropertySecurity[];
           class: PropertySecurity[];
           employeeId: PropertySecurity[];
           fullName: PropertySecurity[];
@@ -608,6 +610,44 @@ describe.each([
           "$objectType": "Employee",
           "$primaryKey": 20003,
           "$propertySecurities": {
+            "$primaryKey": [
+              {
+                "conjunctive": [
+                  "CONFIDENTIAL",
+                  "INTERNAL",
+                ],
+                "containerConjunctive": undefined,
+                "containerDisjunctive": undefined,
+                "disjunctive": [
+                  [
+                    "SECRET",
+                  ],
+                  [
+                    "TOP_SECRET",
+                  ],
+                ],
+                "type": "propertyMarkings",
+              },
+            ],
+            "$title": [
+              {
+                "conjunctive": [
+                  "CONFIDENTIAL",
+                  "INTERNAL",
+                ],
+                "containerConjunctive": undefined,
+                "containerDisjunctive": undefined,
+                "disjunctive": [
+                  [
+                    "SECRET",
+                  ],
+                  [
+                    "TOP_SECRET",
+                  ],
+                ],
+                "type": "propertyMarkings",
+              },
+            ],
             "class": [
               {
                 "type": "errorComputingSecurity",

--- a/packages/client/src/objectSet/ObjectSet.test.ts
+++ b/packages/client/src/objectSet/ObjectSet.test.ts
@@ -308,6 +308,8 @@ describe("ObjectSet", () => {
 
     expectTypeOf(employees.data[0].$propertySecurities).toMatchObjectType<
       {
+        $primaryKey: PropertySecurity[];
+        $title: PropertySecurity[];
         class: PropertySecurity[];
         employeeId: PropertySecurity[];
         fullName: PropertySecurity[];

--- a/packages/e2e.sandbox.catchall/src/runPropertySecuritiesTest.ts
+++ b/packages/e2e.sandbox.catchall/src/runPropertySecuritiesTest.ts
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-import { MasonHeavyEquipment, MasonMovie } from "@osdk/e2e.generated.catchall";
-import { dsClient, dsmtClient } from "./client.js";
+import { MasonHeavyEquipment } from "@osdk/e2e.generated.catchall";
+import { dsmtClient } from "./client.js";
 
 export async function runPropertySecuritiesTest(): Promise<void> {
-  const objects = await dsClient(MasonMovie).fetchPage({
-    $loadPropertySecurityMetadata: true,
-  });
-  const movieObject1 = objects.data[0];
-  console.log("Unsupported View Securities for MasonMovie object:");
-  console.log(
-    JSON.stringify(
-      movieObject1.$propertySecurities,
-      null,
-      2,
-    ),
-  );
+  // const objects = await dsClient(MasonMovie).fetchPage({
+  //   $loadPropertySecurityMetadata: true,
+  // });
+  // const movieObject1 = objects.data[0];
+  // console.log("Unsupported View Securities for MasonMovie object:");
+  // console.log(
+  //   JSON.stringify(
+  //     movieObject1.$propertySecurities,
+  //     null,
+  //     2,
+  //   ),
+  // );
 
   const heavyEquipmentObject1 = await dsmtClient(MasonHeavyEquipment).fetchOne(
     "equipment_34968",
@@ -41,7 +41,7 @@ export async function runPropertySecuritiesTest(): Promise<void> {
   console.log("Securities for MasonHeavyEquipment object:");
   console.log(
     JSON.stringify(
-      heavyEquipmentObject1.$propertySecurities,
+      heavyEquipmentObject1.$propertySecurities.$primaryKey,
       null,
       2,
     ),

--- a/packages/e2e.sandbox.catchall/src/runPropertySecuritiesTest.ts
+++ b/packages/e2e.sandbox.catchall/src/runPropertySecuritiesTest.ts
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-import { MasonHeavyEquipment } from "@osdk/e2e.generated.catchall";
-import { dsmtClient } from "./client.js";
+import { MasonHeavyEquipment, MasonMovie } from "@osdk/e2e.generated.catchall";
+import { dsClient, dsmtClient } from "./client.js";
 
 export async function runPropertySecuritiesTest(): Promise<void> {
-  // const objects = await dsClient(MasonMovie).fetchPage({
-  //   $loadPropertySecurityMetadata: true,
-  // });
-  // const movieObject1 = objects.data[0];
-  // console.log("Unsupported View Securities for MasonMovie object:");
-  // console.log(
-  //   JSON.stringify(
-  //     movieObject1.$propertySecurities,
-  //     null,
-  //     2,
-  //   ),
-  // );
+  const objects = await dsClient(MasonMovie).fetchPage({
+    $loadPropertySecurityMetadata: true,
+  });
+  const movieObject1 = objects.data[0];
+  console.log("Unsupported View Securities for MasonMovie object:");
+  console.log(
+    JSON.stringify(
+      movieObject1.$propertySecurities,
+      null,
+      2,
+    ),
+  );
 
   const heavyEquipmentObject1 = await dsmtClient(MasonHeavyEquipment).fetchOne(
     "equipment_34968",
@@ -41,7 +41,7 @@ export async function runPropertySecuritiesTest(): Promise<void> {
   console.log("Securities for MasonHeavyEquipment object:");
   console.log(
     JSON.stringify(
-      heavyEquipmentObject1.$propertySecurities.$primaryKey,
+      heavyEquipmentObject1.$propertySecurities,
       null,
       2,
     ),

--- a/packages/faux/src/FauxFoundry/FauxDataStore.ts
+++ b/packages/faux/src/FauxFoundry/FauxDataStore.ts
@@ -308,14 +308,14 @@ export class FauxDataStore {
 
   registerObjectWithPropertySecurities(
     regularObject: BaseServerObject,
-    securedObject: BaseServerObject,
+    securedObject: OntologiesV2.OntologyObjectV2,
     propertySecurities: OntologiesV2.PropertySecurities[],
   ): BaseServerObject {
     const registeredObj = this.registerObject(regularObject);
 
     this.#objectsWithSecurities.get(registeredObj.__apiName).set(
       String(registeredObj.__primaryKey),
-      Object.freeze({ ...securedObject }),
+      Object.freeze({ ...securedObject }) as BaseServerObject,
     );
     this.#propertySecurities.set(
       objectLocator(registeredObj),
@@ -893,12 +893,14 @@ export class FauxDataStore {
     // caching off the important properties
     let objects = getObjectsFromSet(this, parsedBody.objectSet, undefined);
 
+    let propertySecuritiesLocator: ObjectLocator | undefined;
     if (loadPropertySecurities) {
       invariant(
         objects.length === 1,
         "Loading property securities is only supported when loading a single object",
       );
 
+      propertySecuritiesLocator = objectLocator(objects[0]);
       objects = [
         this.getObjectWithSecurities(
           objects[0].__apiName,
@@ -926,10 +928,8 @@ export class FauxDataStore {
       objects,
       getPaginationParamsFromRequest(parsedBody),
       true,
-      loadPropertySecurities
-        ? this.#propertySecurities.get(
-          objectLocator(objects[0]),
-        )
+      propertySecuritiesLocator != null
+        ? this.#propertySecurities.get(propertySecuritiesLocator)
         : undefined,
     );
 

--- a/packages/shared.test/src/stubs/objects.ts
+++ b/packages/shared.test/src/stubs/objects.ts
@@ -408,9 +408,15 @@ export const unsecuredEmployee = {
 
 export const securedEmployee = {
   __rid: "ri.phonograph2-objects.main.object.88a6fccb-f333-46d6-a07e-as3der",
-  __primaryKey: 20003,
+  __primaryKey: {
+    value: 20003,
+    propertySecurityIndex: 0,
+  },
   __apiName: "Employee",
-  __title: "Bruce Banner",
+  __title: {
+    value: "Bruce Banner",
+    propertySecurityIndex: 0,
+  },
   employeeId: {
     value: 20003,
     propertySecurityIndex: 0,


### PR DESCRIPTION
When loaded with `$loadPropertySecurityMetadata`, the backend wraps `__primaryKey` and `__title` as secured property values. Unwrap them and surface their security in `$propertySecurities`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)