### PR TITLE
Add ActionForm docs links

### DIFF
--- a/.changeset/add-action-form-docs-links.md
+++ b/.changeset/add-action-form-docs-links.md
@@ -2,4 +2,4 @@
 "@osdk/react-components": patch
 ---
 
-Add ActionForm guide links to the React components docs and package README.
+Add ActionForm guide links and document unsupported ActionForm features.

--- a/.changeset/add-action-form-docs-links.md
+++ b/.changeset/add-action-form-docs-links.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Add ActionForm guide links to the React components docs and package README.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -29,6 +29,7 @@ Pre-built, Ontology-aware React components with data loading, caching, and state
 - [Prerequisites](/react-components/Prerequisites) - Installation, CSS layers, and theming setup
 - [ObjectTable](/react-components/ObjectTable) - Sortable, filterable table with inline editing
 - [FilterList](/react-components/FilterList) - Aggregation-based filter UI
+- [ActionForm](/react-components/ActionForm) - Generated and custom forms for applying OSDK actions
 - [PdfViewer](/react-components/PdfViewer) - PDF viewer with annotations and search
 - [CbacPicker](/cbac-components/CbacPicker) - Classification marking picker, dialog, and banner
 

--- a/docs/sidebarsReactComponents.ts
+++ b/docs/sidebarsReactComponents.ts
@@ -26,6 +26,7 @@ const sidebars: SidebarsConfig = {
       items: [
         "ObjectTable",
         "FilterList",
+        "ActionForm",
         "PdfViewer",
         "DocumentViewer",
         "EmailViewer",

--- a/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
@@ -33,6 +33,10 @@ import {
   type StorySubmissionSnapshot,
   SubmissionOutputPanel,
 } from "./SubmissionOutputPanel.js";
+import {
+  THEMED_SLIDER_DEFAULT_VALUE,
+  ThemedSliderField,
+} from "./ThemedSliderField.js";
 
 /**
  * Flattened (non-union) props type for Storybook Meta.
@@ -146,18 +150,12 @@ const formContent: ReadonlyArray<FormContentItem> = [
     },
   }),
   field({
-    fieldKey: "notes",
+    fieldKey: "completion",
     fieldComponent: "CUSTOM",
-    label: "Notes",
+    label: "Completion",
     fieldComponentProps: {
-      customRenderer: (props) => (
-        <textarea
-          value={props.value != null ? String(props.value) : ""}
-          onChange={(e) => props.onChange?.(e.target.value)}
-          className="osdkCustomTextarea"
-          placeholder="Custom rendered notes field"
-        />
-      ),
+      defaultValue: THEMED_SLIDER_DEFAULT_VALUE,
+      customRenderer: (props) => <ThemedSliderField {...props} />,
     },
   }),
 ];
@@ -301,6 +299,10 @@ export const Default: Story = {
     docs: {
       source: {
         code: `import { BaseForm } from "@osdk/react-components/experimental";
+import {
+  THEMED_SLIDER_DEFAULT_VALUE,
+  ThemedSliderField,
+} from "./ThemedSliderField";
 
 const formContent = [
   {
@@ -356,17 +358,12 @@ const formContent = [
     fieldComponentProps: { accept: ".pdf,.doc,.docx" },
   },
   {
-    fieldKey: "notes",
+    fieldKey: "completion",
     fieldComponent: "CUSTOM",
-    label: "Notes",
+    label: "Completion",
     fieldComponentProps: {
-      customRenderer: (props) => (
-        <textarea
-          value={props.value ?? ""}
-          onChange={(e) => props.onChange?.(e.target.value)}
-          placeholder="Custom rendered notes field"
-        />
-      ),
+      defaultValue: THEMED_SLIDER_DEFAULT_VALUE,
+      customRenderer: (props) => <ThemedSliderField {...props} />,
     },
   },
 ];
@@ -384,7 +381,9 @@ export const Controlled: Story = {
   parameters: {
     docs: {
       source: {
-        code: `const [formState, setFormState] = useState({});
+        code: `const [formState, setFormState] = useState({
+  completion: THEMED_SLIDER_DEFAULT_VALUE,
+});
 
 const handleFieldValueChange = (fieldKey, value) => {
   setFormState((prev) => ({ ...prev, [fieldKey]: value }));
@@ -411,7 +410,9 @@ return (
 };
 
 function ControlledFormStory(): React.ReactElement {
-  const [formState, setFormState] = useState<Record<string, unknown>>({});
+  const [formState, setFormState] = useState<Record<string, unknown>>({
+    completion: THEMED_SLIDER_DEFAULT_VALUE,
+  });
 
   const handleFieldValueChange = useCallback(
     (fieldKey: string, value: unknown) => {

--- a/packages/react-components-storybook/src/stories/ActionForm/ThemedSliderField.module.css
+++ b/packages/react-components-storybook/src/stories/ActionForm/ThemedSliderField.module.css
@@ -1,0 +1,22 @@
+.sliderField {
+  display: grid;
+  gap: var(--osdk-surface-spacing);
+  color: var(--osdk-typography-color-default-rest);
+}
+
+.sliderInput {
+  width: 100%;
+  margin: 0;
+  accent-color: var(--osdk-intent-primary-rest);
+  cursor: pointer;
+}
+
+.sliderInput:disabled {
+  cursor: not-allowed;
+  opacity: var(--osdk-disabled-opacity);
+}
+
+.sliderValue {
+  color: var(--osdk-typography-color-muted);
+  font-size: var(--osdk-typography-size-body-small);
+}

--- a/packages/react-components-storybook/src/stories/ActionForm/ThemedSliderField.tsx
+++ b/packages/react-components-storybook/src/stories/ActionForm/ThemedSliderField.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { BaseFormFieldProps } from "@osdk/react-components/experimental";
+import React, { memo, useCallback } from "react";
+import styles from "./ThemedSliderField.module.css";
+
+export const THEMED_SLIDER_DEFAULT_VALUE = 50;
+const MIN_SLIDER_VALUE = 0;
+const MAX_SLIDER_VALUE = 100;
+
+export const ThemedSliderField = memo(function ThemedSliderFieldFn({
+  disabled,
+  id,
+  onChange,
+  value,
+}: BaseFormFieldProps<unknown>): React.ReactElement {
+  const numericValue = getNumericSliderValue(value);
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      onChange?.(event.currentTarget.valueAsNumber);
+    },
+    [onChange],
+  );
+
+  return (
+    <div className={styles.sliderField}>
+      <input
+        aria-valuetext={`${numericValue}% complete`}
+        className={styles.sliderInput}
+        disabled={disabled}
+        id={id}
+        max={MAX_SLIDER_VALUE}
+        min={MIN_SLIDER_VALUE}
+        onChange={handleChange}
+        type="range"
+        value={numericValue}
+      />
+      <output className={styles.sliderValue} htmlFor={id}>
+        {numericValue}% complete
+      </output>
+    </div>
+  );
+});
+
+function getNumericSliderValue(value: unknown): number {
+  return typeof value === "number" ? value : THEMED_SLIDER_DEFAULT_VALUE;
+}

--- a/packages/react-components-storybook/src/styles/storybook.css
+++ b/packages/react-components-storybook/src/styles/storybook.css
@@ -54,6 +54,7 @@ body {
   border: var(--osdk-surface-border-width) solid
     var(--osdk-surface-border-color-default);
   border-radius: var(--osdk-surface-border-radius);
+  color: var(--osdk-typography-color-default-rest);
 }
 
 .osdkFormStorySpacing {
@@ -66,16 +67,6 @@ body {
 
   width: min(480px, calc(100vw - calc(var(--osdk-surface-spacing) * 8)));
   max-height: calc(100vh - calc(var(--osdk-surface-spacing) * 16));
-}
-
-.osdkCustomTextarea {
-  width: 100%;
-  min-height: calc(var(--osdk-surface-spacing) * 15);
-  padding: calc(var(--osdk-surface-spacing) * 2);
-  border: var(--osdk-surface-border-width) solid
-    var(--osdk-surface-border-color-default);
-  border-radius: var(--osdk-surface-border-radius);
-  font-family: inherit;
 }
 
 .osdkCustomChoiceGroup {
@@ -118,6 +109,7 @@ body {
   padding: calc(var(--osdk-surface-spacing) * 3);
   border-radius: var(--osdk-surface-border-radius);
   background: var(--osdk-background-secondary);
+  color: var(--osdk-typography-color-default-rest);
   overflow: auto;
   font-size: var(--osdk-typography-size-body-small);
   max-height: 300px;

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -130,7 +130,7 @@ The components that this package will provide are:
 | `ObjectTable`    | Displays an Object Set as a sortable, paginated table with inline editing support               | [Guide](./docs/ObjectTable.md)    |
 | `PdfViewer`      | Renders PDF documents with annotations, search, sidebar navigation, and zoom                    | [Guide](./docs/PdfViewer.md)      |
 | `FilterList`     | Visualize a high-level summary of objects data to allow users to filter that data.              | [Guide](./docs/FilterList.md)     |
-| `ActionForm`     | Auto-generated form for executing Ontology Actions                                              | -                                 |
+| `ActionForm`     | Auto-generated form for executing Ontology Actions                                              | [Guide](./docs/ActionForm.md)     |
 | `AipAgentChat`   | Chat surface backed by Foundry LMS via `useChat` — takes a `PlatformClient` and model API name. | [Guide](./docs/AipAgentChat.md)   |
 | `DocumentViewer` | Unified media viewer that auto-detects file type and renders the appropriate viewer             | [Guide](./docs/DocumentViewer.md) |
 | `EmailViewer`    | Parses and renders EML files with headers and sandboxed HTML body                               | [Guide](./docs/EmailViewer.md)    |

--- a/packages/react-components/docs/ActionForm.md
+++ b/packages/react-components/docs/ActionForm.md
@@ -8,6 +8,7 @@
 - [Basic Usage](#basic-usage)
 - [Choosing ActionForm vs BaseForm](#choosing-actionform-vs-baseform)
 - [Default Field Rendering](#default-field-rendering)
+- [Unsupported Features](#unsupported-features)
 - [Custom Field Definitions](#custom-field-definitions)
 - [Behavior Notes](#behavior-notes)
 - [Examples](#examples)
@@ -35,7 +36,7 @@ function UpdateEmployeeForm() {
 }
 ```
 
-`ActionForm` fetches action metadata, renders fields for the action parameters, validates the form, and calls the OSDK action when the user submits. The form title is hidden by default. Pass `showFormTitle={true}` to show it; the title uses `formTitle` when provided, otherwise the action display name, otherwise the action API name.
+`ActionForm` fetches action metadata, renders fields for the action parameters, runs client-side validation, and calls the OSDK action when the user submits. The form title is hidden by default. Pass `showFormTitle={true}` to show it; the title uses `formTitle` when provided, otherwise the action display name, otherwise the action API name.
 
 ## Choosing ActionForm vs BaseForm
 
@@ -53,16 +54,28 @@ When `formFieldDefinitions` is omitted, `ActionForm` derives one field per actio
 | Action parameter type                          | Default field component | Default behavior                               |
 | ---------------------------------------------- | ----------------------- | ---------------------------------------------- |
 | `string`                                       | `TEXT_INPUT`            | Single-line text input                         |
-| `marking`, `geohash`, `geoshape`, `objectType` | `TEXT_INPUT`            | Text input fallback for string-like values     |
 | `boolean`                                      | `RADIO_BUTTONS`         | True/False radio options                       |
 | `integer`, `double`, `long`                    | `NUMBER_INPUT`          | Numeric input                                  |
 | `datetime`, `timestamp`                        | `DATETIME_PICKER`       | Date picker                                    |
 | `attachment`, `mediaReference`                 | `FILE_PICKER`           | File picker                                    |
 | `{ type: "object" }`                           | `OBJECT_SELECT`         | Object selector for the referenced object type |
 | `{ type: "objectSet" }`                        | `OBJECT_SET`            | Read-only object set summary                   |
-| `{ type: "interface" }`, `{ type: "struct" }`  | `TEXT_INPUT`            | Text input fallback                            |
+| `marking`, `geohash`, `geoshape`, `objectType` | `UNSUPPORTED`           | Disabled field recommending a custom field     |
+| `{ type: "interface" }`, `{ type: "struct" }`  | `UNSUPPORTED`           | Disabled field recommending a custom field     |
 
-Required validation is inferred from the action parameter's nullability. Additional validation comes from field-specific props such as `min`, `max`, `minLength`, `maxLength`, and `maxSize`.
+Required validation is inferred from the action parameter's nullability. Additional client-side validation comes from field-specific props such as `min`, `max`, `minLength`, `maxLength`, and `maxSize`.
+
+## Unsupported Features
+
+`ActionForm` is a lightweight OSDK component and does not yet match the full ActionForm in Foundry. The table below lists the main gaps to account for when adopting it.
+
+| Feature                                     | Current behavior                                                                                                                                                                                              | Workaround                                                                                                                                              |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Backend action validation                   | The form does not call backend validation before submit and does not process validation-derived displays, allowed values, defaults, or section results.                                                       | Use `formFieldDefinitions` validation props, field-level `validate`, `onSubmit`, and `onError` for app-owned checks and submission error handling.      |
+| Unsupported generated parameter types       | `marking`, `geohash`, `geoshape`, `objectType`, `interface`, and `struct` render as disabled unsupported fields by default.                                                                                   | Override those parameters with `fieldComponent: "CUSTOM"` or another compatible component in `formFieldDefinitions`.                                    |
+| Action-authored layout metadata             | Action-defined sections, form content ordering, section validation, and layout toggles are not read from metadata. Fields render in metadata parameter order unless fully replaced by `formFieldDefinitions`. | Use `BaseForm` with explicit `FormContentItem` sections when you need custom grouping, or control field order with `formFieldDefinitions`.              |
+| Conditional logic and dynamic display state | Backend-driven hidden, disabled, required, and allowed-value rules are not evaluated as the user edits the form.                                                                                              | Encode static display state in field definitions, or manage dynamic state in your app and pass updated `formFieldDefinitions` / controlled `formState`. |
+| Defaults and prefills                       | Backend prefills, type-class defaults, current timestamp defaults, and validation-derived default values are not applied automatically.                                                                       | Provide `defaultValue` in field definitions, seed controlled `formState`, or compute defaults in app code before rendering.                             |
 
 ## Custom Field Definitions
 


### PR DESCRIPTION
## Summary
- Add ActionForm to the React components docs landing page
- Add ActionForm to the React components docs sidebar
- Link the ActionForm guide from the react-components README
- Add a changeset for @osdk/react-components

## Verification
- pnpm exec dprint check docs/intro.md docs/sidebarsReactComponents.ts packages/react-components/README.md
- pnpm --filter @osdk/docs build