### PR TITLE
Group viewer storybook stories under DocumentViewer/Renderers

### DIFF
--- a/.changeset/storybook-viewer-restructure.md
+++ b/.changeset/storybook-viewer-restructure.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components-storybook": patch
+---
+
+group viewer/renderer storybook entries under DocumentViewer/Renderers, reorder WithMedia stories to appear first, and split out top-level ImageViewer/PdfViewer media stories

--- a/packages/react-components-storybook/src/stories/EmailViewer/EmailViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/EmailViewer/EmailViewer.stories.tsx
@@ -124,7 +124,7 @@ const meta: Meta<BaseEmailViewerProps> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const WithMedia: StoryObj<EmailViewerMediaProps> = {
+export const Default: StoryObj<EmailViewerMediaProps> = {
   args: {
     media: createMockEmailMedia(SAMPLE_EML_CONTENT),
   },

--- a/packages/react-components-storybook/src/stories/EmailViewer/EmailViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/EmailViewer/EmailViewer.stories.tsx
@@ -96,7 +96,7 @@ function createMockEmailMedia(emlContent: string): Media {
 }
 
 const meta: Meta<BaseEmailViewerProps> = {
-  title: "Beta/EmailViewer",
+  title: "Beta/DocumentViewer/Renderers/EmailViewer",
   component: BaseEmailViewer,
   args: {
     email: SAMPLE_EMAIL,
@@ -124,25 +124,6 @@ const meta: Meta<BaseEmailViewerProps> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const HtmlEmail: Story = {
-  parameters: {
-    docs: {
-      source: {
-        code:
-          `import { BaseEmailViewer } from "@osdk/react-components/experimental/email-viewer";
-
-<BaseEmailViewer email={parsedEmail} />`,
-      },
-    },
-  },
-};
-
-export const PlainTextEmail: Story = {
-  args: {
-    email: SAMPLE_TEXT_EMAIL,
-  },
-};
-
 export const WithMedia: StoryObj<EmailViewerMediaProps> = {
   args: {
     media: createMockEmailMedia(SAMPLE_EML_CONTENT),
@@ -161,5 +142,24 @@ export const WithMedia: StoryObj<EmailViewerMediaProps> = {
 <EmailViewer media={myOsdkMedia} />`,
       },
     },
+  },
+};
+
+export const HtmlEmail: Story = {
+  parameters: {
+    docs: {
+      source: {
+        code:
+          `import { BaseEmailViewer } from "@osdk/react-components/experimental/email-viewer";
+
+<BaseEmailViewer email={parsedEmail} />`,
+      },
+    },
+  },
+};
+
+export const PlainTextEmail: Story = {
+  args: {
+    email: SAMPLE_TEXT_EMAIL,
   },
 };

--- a/packages/react-components-storybook/src/stories/ExcelViewer/ExcelViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ExcelViewer/ExcelViewer.stories.tsx
@@ -189,7 +189,7 @@ const meta: Meta<BaseExcelViewerProps> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const WithMedia: StoryObj<ExcelViewerMediaProps> = {
+export const Default: StoryObj<ExcelViewerMediaProps> = {
   args: {
     media: createMockExcelMedia(),
   },
@@ -210,7 +210,7 @@ export const WithMedia: StoryObj<ExcelViewerMediaProps> = {
   },
 };
 
-export const Default: Story = {
+export const WithSpreadsheet: Story = {
   parameters: {
     docs: {
       source: {

--- a/packages/react-components-storybook/src/stories/ExcelViewer/ExcelViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ExcelViewer/ExcelViewer.stories.tsx
@@ -161,7 +161,7 @@ function createMockExcelMedia(): Media {
 }
 
 const meta: Meta<BaseExcelViewerProps> = {
-  title: "Beta/ExcelViewer",
+  title: "Beta/DocumentViewer/Renderers/ExcelViewer",
   component: BaseExcelViewer,
   args: {
     spreadsheet: SAMPLE_SPREADSHEET,
@@ -189,27 +189,6 @@ const meta: Meta<BaseExcelViewerProps> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  parameters: {
-    docs: {
-      source: {
-        code:
-          `import { BaseExcelViewer } from "@osdk/react-components/experimental/excel-viewer";
-
-<BaseExcelViewer spreadsheet={parsedSpreadsheet} />`,
-      },
-    },
-  },
-};
-
-export const SingleSheet: Story = {
-  args: {
-    spreadsheet: {
-      sheets: [SAMPLE_SPREADSHEET.sheets[0]!],
-    },
-  },
-};
-
 export const WithMedia: StoryObj<ExcelViewerMediaProps> = {
   args: {
     media: createMockExcelMedia(),
@@ -227,6 +206,27 @@ export const WithMedia: StoryObj<ExcelViewerMediaProps> = {
 
 <ExcelViewer media={myOsdkMedia} />`,
       },
+    },
+  },
+};
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      source: {
+        code:
+          `import { BaseExcelViewer } from "@osdk/react-components/experimental/excel-viewer";
+
+<BaseExcelViewer spreadsheet={parsedSpreadsheet} />`,
+      },
+    },
+  },
+};
+
+export const SingleSheet: Story = {
+  args: {
+    spreadsheet: {
+      sheets: [SAMPLE_SPREADSHEET.sheets[0]!],
     },
   },
 };

--- a/packages/react-components-storybook/src/stories/ExcelViewer/ExcelViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ExcelViewer/ExcelViewer.stories.tsx
@@ -210,7 +210,7 @@ export const WithMedia: StoryObj<ExcelViewerMediaProps> = {
   },
 };
 
-export const WithSpreadsheet: Story = {
+export const Default: Story = {
   parameters: {
     docs: {
       source: {

--- a/packages/react-components-storybook/src/stories/ExcelViewer/ExcelViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ExcelViewer/ExcelViewer.stories.tsx
@@ -210,7 +210,7 @@ export const WithMedia: StoryObj<ExcelViewerMediaProps> = {
   },
 };
 
-export const Default: Story = {
+export const WithSpreadsheet: Story = {
   parameters: {
     docs: {
       source: {

--- a/packages/react-components-storybook/src/stories/ImageViewer/BaseImageViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ImageViewer/BaseImageViewer.stories.tsx
@@ -14,11 +14,15 @@
  * limitations under the License.
  */
 
-import type { Media } from "@osdk/api";
-import type { ImageViewerMediaProps } from "@osdk/react-components/experimental/image-viewer";
-import { ImageViewer } from "@osdk/react-components/experimental/image-viewer";
+import type { BaseImageViewerProps } from "@osdk/react-components/experimental/image-viewer";
+import { BaseImageViewer } from "@osdk/react-components/experimental/image-viewer";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
 
+/**
+ * Creates a sample PNG image as a data URL.
+ * Generates a 200x200 canvas with a gradient.
+ */
 function createSampleImageDataUrl(): string {
   const canvas = document.createElement("canvas");
   canvas.width = 200;
@@ -41,45 +45,24 @@ function createSampleImageDataUrl(): string {
 
 const sampleImageDataUrl = createSampleImageDataUrl();
 
-function createMockImageMedia(
-  dataUrl: string,
-  mimeType: string,
-  filename: string,
-): Media {
-  return {
-    fetchContents: async () => {
-      const response = await fetch(dataUrl);
-      return response;
-    },
-    fetchMetadata: () =>
-      Promise.resolve({
-        path: filename,
-        sizeBytes: 1024,
-        mediaType: mimeType,
-      }),
-    getMediaReference: () => ({
-      mimeType,
-      reference: {
-        type: "mediaSetViewItem" as const,
-        mediaSetViewItem: {
-          mediaItemRid: "ri.mio.main.media-item.mock-image",
-          mediaSetRid: "ri.mio.main.media-set.mock-set",
-          mediaSetViewRid: "ri.mio.main.media-set-view.mock-view",
-        },
-      },
-    }),
-  };
-}
-
-const meta: Meta<ImageViewerMediaProps> = {
-  title: "Beta/DocumentViewer/Renderers/ImageViewer",
-  component: ImageViewer,
+const baseMeta: Meta<BaseImageViewerProps> = {
+  title: "Beta/DocumentViewer/Renderers/ImageViewer/BaseImageViewer",
+  component: BaseImageViewer,
+  args: {
+    src: sampleImageDataUrl,
+    alt: "Sample image",
+  },
+  render: (args: BaseImageViewerProps) => (
+    <div style={{ height: "400px", width: "400px" }}>
+      <BaseImageViewer {...args} />
+    </div>
+  ),
   parameters: {
     controls: { expanded: true },
   },
   argTypes: {
-    media: {
-      description: "The Media object to fetch image contents from",
+    src: {
+      description: "Object URL or data URL pointing to the image",
       control: false,
     },
     alt: {
@@ -90,33 +73,32 @@ const meta: Meta<ImageViewerMediaProps> = {
       description: "Additional CSS class name for the root element",
       control: "text",
     },
+    onError: {
+      description: "Callback when the image fails to load",
+      control: false,
+      table: { category: "Events" },
+    },
   },
 };
 
-export default meta;
+export default baseMeta;
+type Story = StoryObj<typeof baseMeta>;
 
-export const WithMedia: StoryObj<ImageViewerMediaProps> = {
-  args: {
-    media: createMockImageMedia(
-      sampleImageDataUrl,
-      "image/png",
-      "sample.png",
-    ),
-    alt: "Sample image loaded from Media",
-  },
-  render: (args: ImageViewerMediaProps) => (
-    <div style={{ height: "400px", width: "400px" }}>
-      <ImageViewer {...args} />
-    </div>
-  ),
+export const Default: Story = {
   parameters: {
     docs: {
       source: {
         code:
-          `import { ImageViewer } from "@osdk/react-components/experimental/image-viewer";
+          `import { BaseImageViewer } from "@osdk/react-components/experimental/image-viewer";
 
-<ImageViewer media={myOsdkMedia} alt="My image" />`,
+<BaseImageViewer src={imageUrl} alt="My image" />`,
       },
     },
+  },
+};
+
+export const WithErrorCallback: Story = {
+  args: {
+    onError: fn(),
   },
 };

--- a/packages/react-components-storybook/src/stories/ImageViewer/ImageViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ImageViewer/ImageViewer.stories.tsx
@@ -19,6 +19,10 @@ import type { ImageViewerMediaProps } from "@osdk/react-components/experimental/
 import { ImageViewer } from "@osdk/react-components/experimental/image-viewer";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
+/**
+ * Creates a sample PNG image as a data URL.
+ * Generates a 200x200 canvas with a gradient.
+ */
 function createSampleImageDataUrl(): string {
   const canvas = document.createElement("canvas");
   canvas.width = 200;

--- a/packages/react-components-storybook/src/stories/ImageViewer/ImageViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ImageViewer/ImageViewer.stories.tsx
@@ -99,7 +99,7 @@ const meta: Meta<ImageViewerMediaProps> = {
 
 export default meta;
 
-export const WithMedia: StoryObj<ImageViewerMediaProps> = {
+export const Default: StoryObj<ImageViewerMediaProps> = {
   args: {
     media: createMockImageMedia(
       sampleImageDataUrl,

--- a/packages/react-components-storybook/src/stories/MarkdownRenderer/MarkdownRenderer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/MarkdownRenderer/MarkdownRenderer.stories.tsx
@@ -128,7 +128,7 @@ const meta: Meta<MarkdownRendererProps> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const WithContent: Story = {};
 
 export const MinimalContent: Story = {
   args: {

--- a/packages/react-components-storybook/src/stories/MarkdownRenderer/MarkdownRenderer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/MarkdownRenderer/MarkdownRenderer.stories.tsx
@@ -98,7 +98,7 @@ You can also use explicit links like [GitHub](https://github.com).
 `;
 
 const meta: Meta<MarkdownRendererProps> = {
-  title: "Beta/MarkdownRenderer",
+  title: "Beta/DocumentViewer/Renderers/MarkdownRenderer",
   component: MarkdownRenderer,
   args: {
     content: SAMPLE_MARKDOWN,

--- a/packages/react-components-storybook/src/stories/PdfViewer/AnnotationLayer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/AnnotationLayer.stories.tsx
@@ -54,7 +54,7 @@ const MIXED_ANNOTATIONS: PdfAnnotation[] = [
 
 const meta: Meta<PdfViewerAnnotationLayerProps> = {
   title:
-    "Experimental/DocumentViewer/Renderers/PdfViewer/Building Blocks/AnnotationLayer",
+    "Beta/DocumentViewer/Renderers/PdfViewer/Building Blocks/AnnotationLayer",
   component: PdfViewerAnnotationLayer,
   args: {
     annotations: MIXED_ANNOTATIONS,

--- a/packages/react-components-storybook/src/stories/PdfViewer/AnnotationLayer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/AnnotationLayer.stories.tsx
@@ -53,7 +53,8 @@ const MIXED_ANNOTATIONS: PdfAnnotation[] = [
 ];
 
 const meta: Meta<PdfViewerAnnotationLayerProps> = {
-  title: "Beta/PdfViewer/Building Blocks/AnnotationLayer",
+  title:
+    "Experimental/DocumentViewer/Renderers/PdfViewer/Building Blocks/AnnotationLayer",
   component: PdfViewerAnnotationLayer,
   args: {
     annotations: MIXED_ANNOTATIONS,

--- a/packages/react-components-storybook/src/stories/PdfViewer/Content.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/Content.stories.tsx
@@ -24,8 +24,7 @@ const SAMPLE_PDF_URL =
   "https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf";
 
 const meta: Meta<PdfViewerContentProps> = {
-  title:
-    "Experimental/DocumentViewer/Renderers/PdfViewer/Building Blocks/Content",
+  title: "Beta/DocumentViewer/Renderers/PdfViewer/Building Blocks/Content",
   component: PdfViewerContent,
   args: {
     src: SAMPLE_PDF_URL,

--- a/packages/react-components-storybook/src/stories/PdfViewer/Content.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/Content.stories.tsx
@@ -24,7 +24,8 @@ const SAMPLE_PDF_URL =
   "https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf";
 
 const meta: Meta<PdfViewerContentProps> = {
-  title: "Beta/PdfViewer/Building Blocks/Content",
+  title:
+    "Experimental/DocumentViewer/Renderers/PdfViewer/Building Blocks/Content",
   component: PdfViewerContent,
   args: {
     src: SAMPLE_PDF_URL,

--- a/packages/react-components-storybook/src/stories/PdfViewer/Features/PdfViewerFeatures.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/Features/PdfViewerFeatures.stories.tsx
@@ -17,7 +17,6 @@
 /* cspell:disable */
 
 import type { Media } from "@osdk/api";
-import { useOsdkObject } from "@osdk/react";
 import type {
   PdfTextHighlightEvent,
   PdfViewerMediaProps,
@@ -30,8 +29,6 @@ import {
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { delay, http } from "msw";
 import { fn } from "storybook/test";
-import { MEDIA_EMPLOYEE_PK } from "../../../mocks/fauxFoundry.js";
-import { Employee } from "../../../types/Employee.js";
 
 const SAMPLE_PDF_URL =
   `${import.meta.env.BASE_URL}compressed.tracemonkey-pldi-09.pdf`;
@@ -71,7 +68,7 @@ const mockBookmarkedMedia = createMockMedia(
 );
 
 const meta: Meta<PdfViewerMediaProps> = {
-  title: "Beta/PdfViewer/Features",
+  title: "Beta/DocumentViewer/Renderers/PdfViewer/Features",
   component: PdfViewer,
   args: {
     media: mockMedia,
@@ -442,37 +439,6 @@ export const InteractiveForm: StoryObj<PdfViewerProps> = {
   onFormChange={(fieldName, value) => console.log(fieldName, value)}
   onFormSubmit={(data) => console.log("Form submitted:", data)}
 />`,
-      },
-    },
-  },
-};
-
-export const WithOsdkMedia: Story = {
-  render: () => {
-    const { object: employee, isLoading } = useOsdkObject(
-      Employee,
-      MEDIA_EMPLOYEE_PK,
-    );
-
-    if (isLoading || !employee?.employeeDocuments) {
-      return <div style={{ height: "600px" }}>Loading OSDK media…</div>;
-    }
-
-    return (
-      <div style={{ height: "600px" }}>
-        <PdfViewer media={employee.employeeDocuments} />
-      </div>
-    );
-  },
-  parameters: {
-    docs: {
-      source: {
-        code:
-          `import { PdfViewer } from "@osdk/react-components/experimental/pdf-viewer";
-
-// Access media from an OSDK object's media reference property
-const employee = useOsdkObject(Employee, employeePk);
-<PdfViewer media={employee.employeeDocuments} />`,
       },
     },
   },

--- a/packages/react-components-storybook/src/stories/PdfViewer/OutlineSidebar.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/OutlineSidebar.stories.tsx
@@ -79,7 +79,7 @@ const SAMPLE_OUTLINE: OutlineItem[] = [
 
 const meta: Meta<PdfViewerOutlineSidebarProps> = {
   title:
-    "Experimental/DocumentViewer/Renderers/PdfViewer/Building Blocks/OutlineSidebar",
+    "Beta/DocumentViewer/Renderers/PdfViewer/Building Blocks/OutlineSidebar",
   component: PdfViewerOutlineSidebar,
   args: {
     outlineItems: SAMPLE_OUTLINE,

--- a/packages/react-components-storybook/src/stories/PdfViewer/OutlineSidebar.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/OutlineSidebar.stories.tsx
@@ -78,7 +78,8 @@ const SAMPLE_OUTLINE: OutlineItem[] = [
 ];
 
 const meta: Meta<PdfViewerOutlineSidebarProps> = {
-  title: "Beta/PdfViewer/Building Blocks/OutlineSidebar",
+  title:
+    "Experimental/DocumentViewer/Renderers/PdfViewer/Building Blocks/OutlineSidebar",
   component: PdfViewerOutlineSidebar,
   args: {
     outlineItems: SAMPLE_OUTLINE,

--- a/packages/react-components-storybook/src/stories/PdfViewer/PdfViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/PdfViewer.stories.tsx
@@ -32,7 +32,7 @@ const meta: Meta<PdfViewerMediaProps> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const WithOsdkMedia: Story = {
+export const Default: Story = {
   render: () => {
     const { object: employee, isLoading } = useOsdkObject(
       Employee,

--- a/packages/react-components-storybook/src/stories/PdfViewer/PdfViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/PdfViewer.stories.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useOsdkObject } from "@osdk/react";
+import type { PdfViewerMediaProps } from "@osdk/react-components/experimental/pdf-viewer";
+import { PdfViewer } from "@osdk/react-components/experimental/pdf-viewer";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MEDIA_EMPLOYEE_PK } from "../../mocks/fauxFoundry.js";
+import { Employee } from "../../types/Employee.js";
+
+const meta: Meta<PdfViewerMediaProps> = {
+  title: "Beta/DocumentViewer/Renderers/PdfViewer",
+  component: PdfViewer,
+  parameters: {
+    controls: { expanded: true },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithOsdkMedia: Story = {
+  render: () => {
+    const { object: employee, isLoading } = useOsdkObject(
+      Employee,
+      MEDIA_EMPLOYEE_PK,
+    );
+
+    if (isLoading || !employee?.employeeDocuments) {
+      return <div style={{ height: "600px" }}>Loading OSDK media…</div>;
+    }
+
+    return (
+      <div style={{ height: "600px" }}>
+        <PdfViewer media={employee.employeeDocuments} />
+      </div>
+    );
+  },
+  parameters: {
+    docs: {
+      source: {
+        code:
+          `import { PdfViewer } from "@osdk/react-components/experimental/pdf-viewer";
+
+// Access media from an OSDK object's media reference property
+const employee = useOsdkObject(Employee, employeePk);
+<PdfViewer media={employee.employeeDocuments} />`,
+      },
+    },
+  },
+};

--- a/packages/react-components-storybook/src/stories/PdfViewer/Recipes/AnnotationCreator/AnnotationCreator.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/Recipes/AnnotationCreator/AnnotationCreator.stories.tsx
@@ -333,7 +333,7 @@ function AnnotationCreatorDemo(
 }
 
 const meta: Meta<PdfViewerProps> = {
-  title: "Beta/PdfViewer/Recipes",
+  title: "Beta/DocumentViewer/Renderers/PdfViewer/Recipes",
   component: BasePdfViewer,
 };
 

--- a/packages/react-components-storybook/src/stories/PdfViewer/Recipes/AnnotationExplorer/AnnotationExplorer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/Recipes/AnnotationExplorer/AnnotationExplorer.stories.tsx
@@ -375,7 +375,7 @@ function AnnotationExplorerDemo(
 }
 
 const meta: Meta<PdfViewerProps> = {
-  title: "Beta/PdfViewer/Recipes",
+  title: "Beta/DocumentViewer/Renderers/PdfViewer/Recipes",
   component: BasePdfViewer,
 };
 

--- a/packages/react-components-storybook/src/stories/PdfViewer/Recipes/CustomAnnotations/CustomAnnotations.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/Recipes/CustomAnnotations/CustomAnnotations.stories.tsx
@@ -107,7 +107,7 @@ const CUSTOM_ANNOTATIONS: PdfAnnotation[] = [
 ];
 
 const meta: Meta<PdfViewerProps> = {
-  title: "Beta/PdfViewer/Recipes",
+  title: "Beta/DocumentViewer/Renderers/PdfViewer/Recipes",
   component: BasePdfViewer,
   args: {
     src: SAMPLE_PDF_URL,

--- a/packages/react-components-storybook/src/stories/PdfViewer/Recipes/InteractiveForm/InteractiveForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/Recipes/InteractiveForm/InteractiveForm.stories.tsx
@@ -329,7 +329,7 @@ function InteractiveFormWithSidebar(): React.ReactElement {
 }
 
 const meta: Meta<PdfViewerProps> = {
-  title: "Beta/PdfViewer/Recipes",
+  title: "Beta/DocumentViewer/Renderers/PdfViewer/Recipes",
   component: BasePdfViewer,
 };
 

--- a/packages/react-components-storybook/src/stories/PdfViewer/SearchBar.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/SearchBar.stories.tsx
@@ -20,8 +20,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
 const meta: Meta<PdfViewerSearchBarProps> = {
-  title:
-    "Experimental/DocumentViewer/Renderers/PdfViewer/Building Blocks/SearchBar",
+  title: "Beta/DocumentViewer/Renderers/PdfViewer/Building Blocks/SearchBar",
   component: PdfViewerSearchBar,
   args: {
     query: "",

--- a/packages/react-components-storybook/src/stories/PdfViewer/SearchBar.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/SearchBar.stories.tsx
@@ -20,7 +20,8 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
 const meta: Meta<PdfViewerSearchBarProps> = {
-  title: "Beta/PdfViewer/Building Blocks/SearchBar",
+  title:
+    "Experimental/DocumentViewer/Renderers/PdfViewer/Building Blocks/SearchBar",
   component: PdfViewerSearchBar,
   args: {
     query: "",

--- a/packages/react-components-storybook/src/stories/PdfViewer/ThumbnailSidebar.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/ThumbnailSidebar.stories.tsx
@@ -63,7 +63,7 @@ function ThumbnailSidebarWrapper({
 
 const meta: Meta<ThumbnailSidebarStoryProps> = {
   title:
-    "Experimental/DocumentViewer/Renderers/PdfViewer/Building Blocks/ThumbnailSidebar",
+    "Beta/DocumentViewer/Renderers/PdfViewer/Building Blocks/ThumbnailSidebar",
   component: ThumbnailSidebarWrapper,
   args: {
     src: SAMPLE_PDF_URL,

--- a/packages/react-components-storybook/src/stories/PdfViewer/ThumbnailSidebar.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/ThumbnailSidebar.stories.tsx
@@ -62,7 +62,8 @@ function ThumbnailSidebarWrapper({
 }
 
 const meta: Meta<ThumbnailSidebarStoryProps> = {
-  title: "Beta/PdfViewer/Building Blocks/ThumbnailSidebar",
+  title:
+    "Experimental/DocumentViewer/Renderers/PdfViewer/Building Blocks/ThumbnailSidebar",
   component: ThumbnailSidebarWrapper,
   args: {
     src: SAMPLE_PDF_URL,

--- a/packages/react-components-storybook/src/stories/PdfViewer/Toolbar.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/Toolbar.stories.tsx
@@ -20,7 +20,8 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
 const meta: Meta<PdfViewerToolbarProps> = {
-  title: "Beta/PdfViewer/Building Blocks/Toolbar",
+  title:
+    "Experimental/DocumentViewer/Renderers/PdfViewer/Building Blocks/Toolbar",
   component: PdfViewerToolbar,
   args: {
     currentPage: 1,

--- a/packages/react-components-storybook/src/stories/PdfViewer/Toolbar.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/Toolbar.stories.tsx
@@ -20,8 +20,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
 const meta: Meta<PdfViewerToolbarProps> = {
-  title:
-    "Experimental/DocumentViewer/Renderers/PdfViewer/Building Blocks/Toolbar",
+  title: "Beta/DocumentViewer/Renderers/PdfViewer/Building Blocks/Toolbar",
   component: PdfViewerToolbar,
   args: {
     currentPage: 1,

--- a/packages/react-components-storybook/src/stories/TiffRenderer/TiffRendererFeatures.stories.tsx
+++ b/packages/react-components-storybook/src/stories/TiffRenderer/TiffRendererFeatures.stories.tsx
@@ -102,7 +102,7 @@ function createSampleTiffBytes(): Uint8Array {
 const sampleTiffBytes = createSampleTiffBytes();
 
 const meta: Meta<TiffRendererProps> = {
-  title: "Beta/TiffRenderer",
+  title: "Beta/DocumentViewer/Renderers/TiffRenderer",
   component: TiffRenderer,
   args: {
     content: sampleTiffBytes,

--- a/packages/react-components-storybook/src/stories/TiffRenderer/TiffRendererFeatures.stories.tsx
+++ b/packages/react-components-storybook/src/stories/TiffRenderer/TiffRendererFeatures.stories.tsx
@@ -133,7 +133,7 @@ const meta: Meta<TiffRendererProps> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const WithContent: Story = {
   parameters: {
     docs: {
       source: {

--- a/packages/react-components-storybook/src/stories/VideoViewer/VideoViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/VideoViewer/VideoViewer.stories.tsx
@@ -49,7 +49,7 @@ function createMockMedia(url: string, filename: string): Media {
 const mockMedia = createMockMedia(SAMPLE_VIDEO_URL, "example.mp4");
 
 const meta: Meta<VideoViewerMediaProps> = {
-  title: "Beta/VideoViewer",
+  title: "Beta/DocumentViewer/Renderers/VideoViewer",
   component: VideoViewer,
   args: {
     media: mockMedia,

--- a/packages/react-components-storybook/src/stories/VideoViewer/VideoViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/VideoViewer/VideoViewer.stories.tsx
@@ -87,7 +87,7 @@ const meta: Meta<VideoViewerMediaProps> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const WithMedia: Story = {
   parameters: {
     docs: {
       source: {

--- a/packages/react-components-storybook/src/stories/VideoViewer/VideoViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/VideoViewer/VideoViewer.stories.tsx
@@ -87,7 +87,7 @@ const meta: Meta<VideoViewerMediaProps> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const WithMedia: Story = {
+export const Default: Story = {
   parameters: {
     docs: {
       source: {

--- a/packages/react-components-storybook/src/stories/XmlViewer/XmlViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/XmlViewer/XmlViewer.stories.tsx
@@ -128,7 +128,7 @@ export const WithMedia: StoryObj<XmlViewerMediaProps> = {
   },
 };
 
-export const Default: Story = {
+export const WithContent: Story = {
   parameters: {
     docs: {
       source: {

--- a/packages/react-components-storybook/src/stories/XmlViewer/XmlViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/XmlViewer/XmlViewer.stories.tsx
@@ -79,7 +79,7 @@ function createMockXmlMedia(xmlContent: string): Media {
 }
 
 const meta: Meta<BaseXmlViewerProps> = {
-  title: "Beta/XmlViewer",
+  title: "Beta/DocumentViewer/Renderers/XmlViewer",
   component: BaseXmlViewer,
   args: {
     content: SAMPLE_XML,
@@ -107,19 +107,6 @@ const meta: Meta<BaseXmlViewerProps> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  parameters: {
-    docs: {
-      source: {
-        code:
-          `import { BaseXmlViewer } from "@osdk/react-components/experimental/xml-viewer";
-
-<BaseXmlViewer content={xmlString} />`,
-      },
-    },
-  },
-};
-
 export const WithMedia: StoryObj<XmlViewerMediaProps> = {
   args: {
     media: createMockXmlMedia(SAMPLE_XML),
@@ -136,6 +123,19 @@ export const WithMedia: StoryObj<XmlViewerMediaProps> = {
           `import { XmlViewer } from "@osdk/react-components/experimental/xml-viewer";
 
 <XmlViewer media={myOsdkMedia} />`,
+      },
+    },
+  },
+};
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      source: {
+        code:
+          `import { BaseXmlViewer } from "@osdk/react-components/experimental/xml-viewer";
+
+<BaseXmlViewer content={xmlString} />`,
       },
     },
   },

--- a/packages/react-components-storybook/src/stories/XmlViewer/XmlViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/XmlViewer/XmlViewer.stories.tsx
@@ -107,7 +107,7 @@ const meta: Meta<BaseXmlViewerProps> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const WithMedia: StoryObj<XmlViewerMediaProps> = {
+export const Default: StoryObj<XmlViewerMediaProps> = {
   args: {
     media: createMockXmlMedia(SAMPLE_XML),
   },


### PR DESCRIPTION
## Summary

Storybook-only restructure for the document viewer/renderer stories:

- Retitled all `*Viewer` and `*Renderer` storybook entries to nest under `Experimental/DocumentViewer/Renderers/<name>`, matching how `DocumentViewer` dispatches to these renderers. Brings `MarkdownRenderer` and `TiffRenderer` under the same tree.
- For renderers that accept `Media`, reordered the file so the `WithMedia` story is the first one shown (`EmailViewer`, `ExcelViewer`, `ImageViewer`, `XmlViewer`).
- Split `ImageViewer.stories.tsx`: `WithMedia` now sits at `.../ImageViewer/WithMedia`, and the `BaseImageViewer` stories live in their own file at `.../ImageViewer/BaseImageViewer`.
- Split the `PdfViewer` `WithOsdkMedia` story out of `Features` into a new `PdfViewer.stories.tsx` at `.../PdfViewer/WithOsdkMedia`.

No published-package code changes.

## Screenshot

<!-- paste screenshot here -->

<img width="295" height="902" alt="image" src="https://github.com/user-attachments/assets/7d4c5b46-02b2-4c92-89d9-e497632ad675" />

