### PR TITLE
Fix ObjectTable pinned column transparent background regression

### DIFF
--- a/.changeset/object-table-pinned-column-bg.md
+++ b/.changeset/object-table-pinned-column-bg.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Fix `ObjectTable` pinned columns rendering with a transparent background, causing scrolled cells from non-pinned columns to bleed through and overlap pinned text. Regression introduced in v0.18.0 by the `--osdk-table-cell-bg` token — declaring `--osdk-table-cell-bg: inherit` at `:root` silently resolved to the guaranteed-invalid value (no parent to inherit from), so `var(--osdk-table-cell-bg)` fell back to `transparent`. The default is now expressed as a `var()` fallback (`var(--osdk-table-cell-bg, inherit)`) so unset cells inherit the row background while consumer overrides still apply.

--- a/packages/react-components/src/object-table/TableCell.module.css
+++ b/packages/react-components/src/object-table/TableCell.module.css
@@ -23,7 +23,7 @@
   padding: var(--osdk-table-cell-padding);
   font-size: var(--osdk-table-cell-fontSize);
   color: var(--osdk-table-cell-color);
-  background-color: var(--osdk-table-cell-bg);
+  background-color: var(--osdk-table-cell-bg, inherit);
   border-right: var(--osdk-table-cell-divider);
 
   &:first-child {
@@ -39,7 +39,7 @@
 .osdkTableCell[data-pinned="right"] {
   position: sticky;
   z-index: var(--osdk-surface-z-index-1);
-  background-color: var(--osdk-table-cell-bg);
+  background-color: var(--osdk-table-cell-bg, inherit);
 }
 
 /* Last left-pinned column - no left-pinned siblings after it */

--- a/packages/react-components/src/tokens/component-tokens/table.css
+++ b/packages/react-components/src/tokens/component-tokens/table.css
@@ -37,7 +37,6 @@
   --osdk-table-cell-padding: 0 calc(var(--osdk-surface-spacing) * 2);
   --osdk-table-cell-fontSize: var(--osdk-typography-size-body-medium);
   --osdk-table-cell-color: var(--osdk-typography-color-default-rest);
-  --osdk-table-cell-bg: inherit;
 
   /* Table Header Menu */
   --osdk-table-header-menu-padding: calc(var(--osdk-surface-spacing) * 0.25);


### PR DESCRIPTION
## Summary
- Restore opaque pinned-column cells in `ObjectTable`. Regression from v0.18.0 (#3300) where pinned columns rendered transparent and let scrolled non-pinned cells visually overlap pinned text.
- Root cause: `--osdk-table-cell-bg: inherit;` declared at `:root` resolves to the [guaranteed-invalid value](https://www.w3.org/TR/css-variables-1/#guaranteed-invalid-value) (no parent to inherit from), so `var(--osdk-table-cell-bg)` falls back to `background-color`'s initial value, `transparent`.
- Fix: stop declaring the token at `:root`; express the default as a `var()` fallback (`var(--osdk-table-cell-bg, inherit)`) so cells inherit the row background by default. The public token contract is unchanged — consumers can still set `--osdk-table-cell-bg` to override, and the documented default (`inherit`) still describes the real behavior.

