### PR TITLE
Fix ObjectTable overlays inside drawers and dialogs

### DIFF
--- a/.changeset/fix-object-table-overlays.md
+++ b/.changeset/fix-object-table-overlays.md
@@ -1,0 +1,6 @@
+---
+"@osdk/react-components": patch
+"@osdk/react-components-storybook": patch
+---
+
+Fix ObjectTable overlay menus and dialogs inside drawers and dialogs.

--- a/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.stories.tsx
@@ -35,6 +35,11 @@ import { fn } from "storybook/test";
 import { fauxFoundry } from "../../mocks/fauxFoundry.js";
 import { Employee } from "../../types/Employee.js";
 import { WorkerInterface } from "../../types/WorkerInterface.js";
+import {
+  ObjectTableInBaseUIDialog,
+  ObjectTableInBlueprintDialog,
+  ObjectTableInBlueprintDrawer,
+} from "./overlays/ObjectTableOverlayStories.js";
 
 // Create a concrete type for Storybook to parse more easily
 type EmployeeTableProps = ObjectTableProps<typeof Employee>;
@@ -1290,6 +1295,73 @@ export const DisableAllHeaderMenuFeatures: Story = {
       <ObjectTable {...args} />
     </div>
   ),
+};
+
+export const HeaderMenuInsideBlueprintDrawer: Story = {
+  args: {
+    objectType: Employee,
+    columnDefinitions: defaultEmployeeColumns,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Scenario for the header menu dropdown when ObjectTable is rendered inside a Blueprint Drawer. "
+          + "Open the drawer and click any column header chevron; the menu should appear above the drawer.",
+      },
+      source: {
+        code: `<Drawer isOpen={true} title="ObjectTable in Blueprint Drawer">
+  <ObjectTable objectType={Employee} columnDefinitions={defaultEmployeeColumns} />
+</Drawer>`,
+      },
+    },
+  },
+  render: (args) => <ObjectTableInBlueprintDrawer tableProps={args} />,
+};
+
+export const HeaderMenuInsideBlueprintDialog: Story = {
+  args: {
+    objectType: Employee,
+    columnDefinitions: defaultEmployeeColumns,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Scenario for the header menu dropdown when ObjectTable is rendered inside a Blueprint Dialog. "
+          + "Open the dialog and click any column header chevron; the menu should appear above the dialog.",
+      },
+      source: {
+        code: `<Dialog isOpen={true} title="ObjectTable in Blueprint Dialog">
+  <ObjectTable objectType={Employee} columnDefinitions={defaultEmployeeColumns} />
+</Dialog>`,
+      },
+    },
+  },
+  render: (args) => <ObjectTableInBlueprintDialog tableProps={args} />,
+};
+
+export const HeaderMenuInsideBaseUIDialog: Story = {
+  args: {
+    objectType: Employee,
+    columnDefinitions: defaultEmployeeColumns,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Scenario for the header menu dropdown when ObjectTable is rendered inside the OSDK Base UI Dialog primitive. "
+          + "Open the dialog and click any column header chevron; the menu should appear above the dialog.",
+      },
+      source: {
+        code:
+          `<Dialog isOpen={true} title="ObjectTable in Base UI Dialog" onOpenChange={setIsOpen}>
+  <ObjectTable objectType={Employee} columnDefinitions={defaultEmployeeColumns} />
+</Dialog>`,
+      },
+    },
+  },
+  render: (args) => <ObjectTableInBaseUIDialog tableProps={args} />,
 };
 
 export const CustomRowHeight: Story = {

--- a/packages/react-components-storybook/src/stories/ObjectTable/overlays/ObjectTableOverlayStories.module.css
+++ b/packages/react-components-storybook/src/stories/ObjectTable/overlays/ObjectTableOverlayStories.module.css
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.reopenButton {
+  margin-block-end: calc(var(--osdk-surface-spacing) * 3);
+}
+
+.drawerBody {
+  box-sizing: border-box;
+  block-size: 100%;
+  padding-block: calc(var(--osdk-surface-spacing) * 4);
+  padding-inline: calc(var(--osdk-surface-spacing) * 4);
+}
+
+.blueprintDialog {
+  inline-size: min(1120px, calc(100vw - calc(var(--osdk-surface-spacing) * 8)));
+}
+
+.blueprintDialogContent {
+  box-sizing: border-box;
+  block-size: min(720px, calc(100vh - calc(var(--osdk-surface-spacing) * 20)));
+  padding-block: calc(var(--osdk-surface-spacing) * 4);
+  padding-inline: calc(var(--osdk-surface-spacing) * 4);
+}
+
+.baseUiDialog {
+  inline-size: min(1120px, calc(100vw - calc(var(--osdk-surface-spacing) * 8)));
+  block-size: min(760px, calc(100vh - calc(var(--osdk-surface-spacing) * 8)));
+}
+
+.shell {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--osdk-surface-spacing) * 3);
+  block-size: 100%;
+  min-block-size: 0;
+}
+
+.instructions {
+  color: var(--osdk-typography-color-muted);
+  font-size: var(--osdk-typography-size-body-small);
+}
+
+.tableFrame {
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: auto;
+  min-block-size: 0;
+  border-width: var(--osdk-surface-border-width);
+  border-style: solid;
+  border-color: var(--osdk-surface-border-color-default);
+  border-radius: var(--osdk-surface-border-radius);
+  overflow: hidden;
+}

--- a/packages/react-components-storybook/src/stories/ObjectTable/overlays/ObjectTableOverlayStories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/overlays/ObjectTableOverlayStories.tsx
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Dialog as BlueprintDialog, Drawer } from "@blueprintjs/core";
+import { ObjectTable } from "@osdk/react-components/experimental/object-table";
+import type {
+  ObjectTableProps,
+} from "@osdk/react-components/experimental/object-table";
+import { Dialog as BaseUIDialog } from "@osdk/react-components/primitives";
+import React, { memo, useCallback, useState } from "react";
+import type { Employee } from "../../../types/Employee.js";
+import styles from "./ObjectTableOverlayStories.module.css";
+
+type EmployeeTableProps = ObjectTableProps<typeof Employee>;
+
+interface ObjectTableOverlayStoryProps {
+  tableProps: EmployeeTableProps;
+}
+
+const HeaderMenuOverlayContent = memo(function HeaderMenuOverlayContentFn({
+  tableProps,
+}: ObjectTableOverlayStoryProps): React.ReactElement {
+  return (
+    <div className={styles.shell}>
+      <div className={styles.instructions}>
+        Click a column header chevron. The header menu should open above the
+        overlay and stay interactive.
+      </div>
+      <div className={styles.tableFrame}>
+        <ObjectTable {...tableProps} />
+      </div>
+    </div>
+  );
+});
+
+export const ObjectTableInBlueprintDrawer = memo(
+  function ObjectTableInBlueprintDrawerFn({
+    tableProps,
+  }: ObjectTableOverlayStoryProps): React.ReactElement {
+    const [isOpen, setIsOpen] = useState(true);
+
+    const handleOpen = useCallback(() => {
+      setIsOpen(true);
+    }, []);
+
+    const handleClose = useCallback(() => {
+      setIsOpen(false);
+    }, []);
+
+    return (
+      <>
+        <Button
+          className={styles.reopenButton}
+          onClick={handleOpen}
+          text="Open drawer"
+        />
+        <Drawer
+          isOpen={isOpen}
+          onClose={handleClose}
+          size="90%"
+          title="ObjectTable in Blueprint Drawer"
+        >
+          <div className={styles.drawerBody}>
+            <HeaderMenuOverlayContent tableProps={tableProps} />
+          </div>
+        </Drawer>
+      </>
+    );
+  },
+);
+
+export const ObjectTableInBlueprintDialog = memo(
+  function ObjectTableInBlueprintDialogFn({
+    tableProps,
+  }: ObjectTableOverlayStoryProps): React.ReactElement {
+    const [isOpen, setIsOpen] = useState(true);
+
+    const handleOpen = useCallback(() => {
+      setIsOpen(true);
+    }, []);
+
+    const handleClose = useCallback(() => {
+      setIsOpen(false);
+    }, []);
+
+    return (
+      <>
+        <Button
+          className={styles.reopenButton}
+          onClick={handleOpen}
+          text="Open Blueprint dialog"
+        />
+        <BlueprintDialog
+          className={styles.blueprintDialog}
+          isOpen={isOpen}
+          onClose={handleClose}
+          title="ObjectTable in Blueprint Dialog"
+        >
+          <div className={styles.blueprintDialogContent}>
+            <HeaderMenuOverlayContent tableProps={tableProps} />
+          </div>
+        </BlueprintDialog>
+      </>
+    );
+  },
+);
+
+export const ObjectTableInBaseUIDialog = memo(
+  function ObjectTableInBaseUIDialogFn({
+    tableProps,
+  }: ObjectTableOverlayStoryProps): React.ReactElement {
+    const [isOpen, setIsOpen] = useState(true);
+
+    const handleOpen = useCallback(() => {
+      setIsOpen(true);
+    }, []);
+
+    const handleOpenChange = useCallback((open: boolean) => {
+      setIsOpen(open);
+    }, []);
+
+    return (
+      <>
+        <Button
+          className={styles.reopenButton}
+          onClick={handleOpen}
+          text="Open Base UI dialog"
+        />
+        <BaseUIDialog
+          className={styles.baseUiDialog}
+          isOpen={isOpen}
+          onOpenChange={handleOpenChange}
+          title="ObjectTable in Base UI Dialog"
+        >
+          <HeaderMenuOverlayContent tableProps={tableProps} />
+        </BaseUIDialog>
+      </>
+    );
+  },
+);

--- a/packages/react-components/src/base-components/dialog/Dialog.tsx
+++ b/packages/react-components/src/base-components/dialog/Dialog.tsx
@@ -18,6 +18,7 @@ import { Dialog as BaseUIDialog } from "@base-ui/react/dialog";
 import { Cross } from "@blueprintjs/icons";
 import classnames from "classnames";
 import React from "react";
+import { usePortalContainer } from "../../shared/PortalContainerContext.js";
 import styles from "./Dialog.module.css";
 
 export interface DialogProps {
@@ -39,13 +40,15 @@ export function Dialog({
   className,
   disablePointerDismissal,
 }: DialogProps): React.ReactElement {
+  const portalContainer = usePortalContainer();
+
   return (
     <BaseUIDialog.Root
       open={isOpen}
       onOpenChange={onOpenChange}
       disablePointerDismissal={disablePointerDismissal}
     >
-      <BaseUIDialog.Portal>
+      <BaseUIDialog.Portal container={portalContainer}>
         <BaseUIDialog.Backdrop className={styles.backdrop} />
         <BaseUIDialog.Popup
           className={classnames(

--- a/packages/react-components/src/base-components/dialog/__tests__/Dialog.test.tsx
+++ b/packages/react-components/src/base-components/dialog/__tests__/Dialog.test.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from "@testing-library/react";
+import React, { createRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { PortalContainerProvider } from "../../../shared/PortalContainerContext.js";
+import { Dialog } from "../Dialog.js";
+
+describe(Dialog, () => {
+  it("renders inside a contextual portal container when provided", () => {
+    const portalContainerRef = createRef<HTMLDivElement>();
+
+    render(
+      <PortalContainerProvider container={portalContainerRef}>
+        <Dialog
+          isOpen={true}
+          onOpenChange={vi.fn()}
+          title="Configure table columns"
+        >
+          Dialog content
+        </Dialog>
+        <div data-testid="dialog-portal-container" ref={portalContainerRef} />
+      </PortalContainerProvider>,
+    );
+
+    const portalContainer = screen.getByTestId("dialog-portal-container");
+    expect(
+      portalContainer.contains(screen.getByRole("dialog")),
+    ).toBe(true);
+  });
+});

--- a/packages/react-components/src/base-components/searchable-menu/SearchableMenu.tsx
+++ b/packages/react-components/src/base-components/searchable-menu/SearchableMenu.tsx
@@ -17,6 +17,7 @@
 import { Menu } from "@base-ui/react/menu";
 import classnames from "classnames";
 import React, { memo, useCallback, useMemo, useState } from "react";
+import { usePortalContainer } from "../../shared/PortalContainerContext.js";
 import { SearchBar } from "../search-bar/SearchBar.js";
 import styles from "./SearchableMenu.module.css";
 
@@ -49,6 +50,7 @@ function SearchableMenuInner({
   collisionBoundary,
 }: SearchableMenuProps): React.ReactElement {
   const [searchQuery, setSearchQuery] = useState("");
+  const portalContainer = usePortalContainer();
 
   const filteredItems = useMemo(() => {
     const query = searchQuery.toLowerCase().trim();
@@ -84,7 +86,7 @@ function SearchableMenuInner({
       >
         {trigger}
       </Menu.Trigger>
-      <Menu.Portal>
+      <Menu.Portal container={portalContainer}>
         <Menu.Positioner
           className={classnames(styles.positioner, className)}
           sideOffset={4}

--- a/packages/react-components/src/object-table/Table.module.css
+++ b/packages/react-components/src/object-table/Table.module.css
@@ -26,6 +26,11 @@
   min-height: 0;
   overflow: auto;
   position: relative;
+  /* Sticky headers, pinned columns, and resize handles use z-index only within
+     the scroll container. Isolating that stacking context lets the sibling
+     header-menu portal paint above them by DOM order instead of competing with
+     table internals on z-index values. */
+  isolation: isolate;
   background-color: var(--osdk-background-primary);
 }
 

--- a/packages/react-components/src/object-table/Table.tsx
+++ b/packages/react-components/src/object-table/Table.tsx
@@ -23,6 +23,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { PortalContainerProvider } from "../shared/PortalContainerContext.js";
 import { LoadingStateTable } from "./LoadingStateTable.js";
 import { NonIdealState } from "./NonIdealState.js";
 import styles from "./Table.module.css";
@@ -134,6 +135,7 @@ function BaseTableInner<
   }: BaseTableProps<TData>,
 ): ReactElement {
   const tableContainerRef = useRef<HTMLDivElement>(null);
+  const objectTablePortalRef = useRef<HTMLDivElement>(null);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [focusedRowId, setFocusedRowId] = useState<string | null>(null);
   const portalTracker = usePortalTracker();
@@ -220,60 +222,65 @@ function BaseTableInner<
   }, [portalTracker]);
 
   return (
-    <div className={classNames(styles.osdkTableWrapper, className)}>
+    <PortalContainerProvider container={objectTablePortalRef}>
       <div
-        ref={tableContainerRef}
-        className={styles.osdkTableContainer}
-        onScroll={handleScroll}
+        ref={objectTablePortalRef}
+        className={classNames(styles.osdkTableWrapper, className)}
       >
-        <table>
-          {isLoading && !hasData
-            ? (
-              <LoadingStateTable
-                table={table}
-                headerGroups={headerGroups}
-                rowHeight={rowHeight}
-                tableContainerRef={tableContainerRef}
-              />
-            )
-            : (
-              <>
-                <TableHeader
+        <div
+          ref={tableContainerRef}
+          className={styles.osdkTableContainer}
+          onScroll={handleScroll}
+        >
+          <table>
+            {isLoading && !hasData
+              ? (
+                <LoadingStateTable
                   table={table}
-                  headerMenuFeatureFlags={headerMenuFeatureFlags}
-                  onColumnHeaderClick={onColumnHeaderClick}
-                />
-                <TableBody
-                  rows={rows}
-                  tableContainerRef={tableContainerRef}
-                  onRowClick={onRowClick}
-                  rowHeight={rowHeight}
-                  renderCellContextMenu={renderCellContextMenu}
-                  isLoadingMore={isLoadingMore}
                   headerGroups={headerGroups}
-                  focusedRowId={focusedRowId}
-                  setFocusedRowId={setFocusedRowId}
-                  isInEditMode={editableConfig?.editModeState.isActive}
-                  getRowAttributes={getRowAttributes}
+                  rowHeight={rowHeight}
+                  tableContainerRef={tableContainerRef}
                 />
-              </>
-            )}
-        </table>
-        {!hasData && error == null && (
-          renderEmptyState != null
-            ? renderEmptyState()
-            : <NonIdealState message={"No Data"} />
-        )}
-        {error != null && (
-          <NonIdealState message={`Error Loading Data: ${error.message}`} />
+              )
+              : (
+                <>
+                  <TableHeader
+                    table={table}
+                    headerMenuFeatureFlags={headerMenuFeatureFlags}
+                    onColumnHeaderClick={onColumnHeaderClick}
+                  />
+                  <TableBody
+                    rows={rows}
+                    tableContainerRef={tableContainerRef}
+                    onRowClick={onRowClick}
+                    rowHeight={rowHeight}
+                    renderCellContextMenu={renderCellContextMenu}
+                    isLoadingMore={isLoadingMore}
+                    headerGroups={headerGroups}
+                    focusedRowId={focusedRowId}
+                    setFocusedRowId={setFocusedRowId}
+                    isInEditMode={editableConfig?.editModeState.isActive}
+                    getRowAttributes={getRowAttributes}
+                  />
+                </>
+              )}
+          </table>
+          {!hasData && error == null && (
+            renderEmptyState != null
+              ? renderEmptyState()
+              : <NonIdealState message={"No Data"} />
+          )}
+          {error != null && (
+            <NonIdealState message={`Error Loading Data: ${error.message}`} />
+          )}
+        </div>
+        {showEditFooter && hasEditableColumns && editableConfig && (
+          <TableEditContainer
+            editableConfig={editableConfig}
+            focusedRowId={focusedRowId}
+          />
         )}
       </div>
-      {showEditFooter && hasEditableColumns && editableConfig && (
-        <TableEditContainer
-          editableConfig={editableConfig}
-          focusedRowId={focusedRowId}
-        />
-      )}
-    </div>
+    </PortalContainerProvider>
   );
 }

--- a/packages/react-components/src/object-table/TableHeaderWithPopover.tsx
+++ b/packages/react-components/src/object-table/TableHeaderWithPopover.tsx
@@ -29,6 +29,7 @@ import {
 import type { Header, RowData, Table } from "@tanstack/react-table";
 import classNames from "classnames";
 import React, { useCallback, useState } from "react";
+import { usePortalContainer } from "../shared/PortalContainerContext.js";
 import { TableHeaderContent } from "./TableHeaderContent.js";
 import styles from "./TableHeaderWithPopover.module.css";
 import type { ColumnOption } from "./utils/types.js";
@@ -113,6 +114,7 @@ export function TableHeaderWithPopover<
   onOpenMultiSort,
   onColumnHeaderClick,
 }: TableHeaderWithPopoverProps<TData>): React.ReactElement {
+  const portalContainer = usePortalContainer();
   const {
     showSortingItems = false,
     showPinningItems = false,
@@ -203,7 +205,8 @@ export function TableHeaderWithPopover<
 
   return (
     <>
-      <Menu.Root open={isOpen} onOpenChange={setIsOpen}>
+      {/* Header menus should not lock drawer/table scrolling; they dismiss like lightweight contextual menus. */}
+      <Menu.Root open={isOpen} onOpenChange={setIsOpen} modal={false}>
         <div
           className={classNames(
             styles.osdkCenterContainer,
@@ -266,7 +269,7 @@ export function TableHeaderWithPopover<
               </Menu.Trigger>
             )}
           </div>
-          <Menu.Portal container={document.body}>
+          <Menu.Portal container={portalContainer}>
             <Menu.Positioner sideOffset={4}>
               <Menu.Popup
                 className={styles.osdkHeaderPopup}

--- a/packages/react-components/src/object-table/__tests__/TableHeaderWithPopover.test.tsx
+++ b/packages/react-components/src/object-table/__tests__/TableHeaderWithPopover.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Header, Table } from "@tanstack/react-table";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React, { createRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { PortalContainerProvider } from "../../shared/PortalContainerContext.js";
+import { TableHeaderWithPopover } from "../TableHeaderWithPopover.js";
+
+interface TestRow {
+  name: string;
+}
+
+describe(TableHeaderWithPopover, () => {
+  it("renders the header menu inside the provided portal container", async () => {
+    const portalContainerRef = createRef<HTMLDivElement>();
+
+    render(
+      <PortalContainerProvider container={portalContainerRef}>
+        <TableHeaderWithPopover
+          table={createTable()}
+          header={createHeader()}
+          isColumnPinned={false}
+          featureFlags={{
+            showPinningItems: true,
+          }}
+        />
+        <div data-testid="header-menu-portal" ref={portalContainerRef} />
+      </PortalContainerProvider>,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Open header menu for column with id=name",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("menuitem", { name: "Pin column" })).toBeTruthy();
+    });
+
+    const portalContainer = screen.getByTestId("header-menu-portal");
+    expect(
+      portalContainer.contains(
+        screen.getByRole("menuitem", { name: "Pin column" }),
+      ),
+    ).toBe(true);
+  });
+});
+
+function createTable(): Table<TestRow> {
+  return {
+    setColumnPinning: vi.fn(),
+    setSorting: vi.fn(),
+    getState: () => ({
+      sorting: [],
+    }),
+  } as unknown as Table<TestRow>;
+}
+
+function createHeader(): Header<TestRow, unknown> {
+  return {
+    column: {
+      id: "name",
+      columnDef: {
+        header: "Name",
+      },
+      getIsSorted: () => false,
+      getCanSort: () => false,
+      toggleSorting: vi.fn(),
+      clearSorting: vi.fn(),
+    },
+    getContext: () => ({}),
+  } as unknown as Header<TestRow, unknown>;
+}

--- a/packages/react-components/src/shared/PortalContainerContext.tsx
+++ b/packages/react-components/src/shared/PortalContainerContext.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { createContext, useContext } from "react";
+import type { PortalContainer } from "./PortalDismissLayer.js";
+
+const PortalContainerContext = createContext<PortalContainer | undefined>(
+  undefined,
+);
+
+interface PortalContainerProviderProps {
+  container: PortalContainer;
+  children: React.ReactNode;
+}
+
+export function PortalContainerProvider({
+  container,
+  children,
+}: PortalContainerProviderProps): React.ReactElement {
+  return (
+    <PortalContainerContext.Provider value={container}>
+      {children}
+    </PortalContainerContext.Provider>
+  );
+}
+
+export function usePortalContainer(): PortalContainer | undefined {
+  return useContext(PortalContainerContext);
+}


### PR DESCRIPTION
## Summary

- Adds an ObjectTable-local portal container for overlays.
- Renders ObjectTable header menus, column config dialogs, and searchable menus inside that local portal boundary.
- Keeps overlays inside Drawer/Dialog focus boundaries while avoiding clipping by the table scroll container.
- Adds Storybook overlay scenarios for ObjectTable and BaseForm.
- Adds tests covering contextual portal rendering for dialogs and header menus.

## Why

ObjectTable header menus could fail or render incorrectly when ObjectTable was inside a Blueprint Drawer/Dialog or Base UI Dialog. The column config dialog also had focus issues inside Blueprint Drawer because it portaled to `document.body`, outside the drawer’s focus trap.

## Verification

- `pnpm --dir=packages/react-components typecheck`
- `pnpm --dir=packages/react-components vitest run src/object-table/__tests__/TableHeaderWithPopover.test.tsx src/base-components/dialog/__tests__/Dialog.test.tsx`
- `pnpm --dir=packages/react-components-storybook typecheck`
- Storybook manual check:
  - ObjectTable header menu opens inside Blueprint Drawer/Base UI Dialog
  - Configure Columns search input remains focusable and responsive inside Blueprint Drawer