### PR TITLE
OsdkThemeProvider

### DIFF
--- a/.changeset/osdk-theme-provider.md
+++ b/.changeset/osdk-theme-provider.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+Add `<OsdkThemeProvider>` and `useOsdkTheme` (from `@osdk/react-components/experimental/theme`) for opt-in theming.

--- a/.changeset/osdk-theme-provider.md
+++ b/.changeset/osdk-theme-provider.md
@@ -2,4 +2,4 @@
 "@osdk/react-components": minor
 ---
 
-Add `<OsdkThemeProvider>` and `useOsdkTheme` (from `@osdk/react-components/experimental/theme`) for opt-in theming. 
+Add `<OsdkThemeProvider>` and `useOsdkTheme` (from `@osdk/react-components/experimental/theme`) for opt-in theming.

--- a/.changeset/osdk-theme-provider.md
+++ b/.changeset/osdk-theme-provider.md
@@ -2,4 +2,4 @@
 "@osdk/react-components": minor
 ---
 
-Add `<OsdkThemeProvider>` and `useOsdkTheme` (from `@osdk/react-components/experimental/theme`) for opt-in theming. The provider seeds its state from `defaultTheme` (`"light" | "dark" | "system"`, defaults to `"system"`) and writes `data-bp-color-scheme` onto the document root — or a custom `target` — so OSDK and Blueprint tokens flip together. `"system"` follows `prefers-color-scheme` and reacts to OS changes at runtime; descendants switch modes by calling `setTheme` from `useOsdkTheme`.
+Add `<OsdkThemeProvider>` and `useOsdkTheme` (from `@osdk/react-components/experimental/theme`) for opt-in theming. 

--- a/.changeset/osdk-theme-provider.md
+++ b/.changeset/osdk-theme-provider.md
@@ -2,4 +2,4 @@
 "@osdk/react-components": minor
 ---
 
-Add `<OsdkThemeProvider>` and `useOsdkTheme` (from `@osdk/react-components/experimental/theme`) for opt-in theming.
+Add `<OsdkThemeProvider>` and `useOsdkTheme` (from `@osdk/react-components/experimental/theme`) for opt-in theming. The provider seeds its state from `defaultTheme` (`"light" | "dark" | "system"`, defaults to `"system"`) and writes `data-bp-color-scheme` onto the document root — or a custom `target` — so OSDK and Blueprint tokens flip together. `"system"` follows `prefers-color-scheme` and reacts to OS changes at runtime; descendants switch modes by calling `setTheme` from `useOsdkTheme`.

--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -386,6 +386,7 @@ const archetypeRules = archetypes(
         "./experimental/markdown-renderer",
         "./experimental/object-table",
         "./experimental/pdf-viewer",
+        "./experimental/theme",
         "./experimental/tiff-renderer",
         "./experimental/video-viewer",
         "./experimental/xml-viewer",

--- a/packages/e2e.sandbox.peopleapp/src/app/employees/EmployeesTable.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/employees/EmployeesTable.tsx
@@ -1,13 +1,19 @@
-import type { DerivedProperty, Osdk, PropertyKeys } from "@osdk/api";
+import type { DerivedProperty, Osdk } from "@osdk/api";
 import { useOsdkClient } from "@osdk/react";
 import type { ColumnDefinition } from "@osdk/react-components/experimental/object-table";
 import { ObjectTable } from "@osdk/react-components/experimental/object-table";
+import {
+  type OsdkThemeMode,
+  OsdkThemeProvider,
+  useOsdkTheme,
+} from "@osdk/react-components/experimental/theme";
 import React, { useCallback } from "react";
 import {
   Employee,
   getEmployeeDaysSinceStart,
 } from "../../generatedNoCheck2/index.js";
 import "./EmployeesTable.css";
+import { Button } from "../../components/Button.js";
 
 type RDPs = {
   managerName: "string";
@@ -103,7 +109,39 @@ const columnDefinitions: Array<
   },
 ];
 
-export function EmployeesTable() {
+const THEME_MODES: readonly OsdkThemeMode[] = ["light", "dark", "system"];
+
+function ThemeToggle(): React.ReactElement {
+  const { theme, resolvedTheme, setTheme } = useOsdkTheme();
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 8,
+        alignItems: "center",
+        marginBottom: 8,
+        fontSize: 12,
+      }}
+    >
+      <span style={{ color: "#666" }}>
+        Theme: <strong>{theme}</strong>
+        {theme === "system" ? ` (resolved: ${resolvedTheme})` : ""}
+      </span>
+      {THEME_MODES.map((mode) => (
+        <Button
+          key={mode}
+          type="button"
+          onClick={() => setTheme(mode)}
+          disabled={theme === mode}
+        >
+          {mode}
+        </Button>
+      ))}
+    </div>
+  );
+}
+
+export function EmployeesTable(): React.ReactElement {
   const handleSubmitEdits = useCallback(
     async () => {
       alert(`Submitting edits...`);
@@ -112,46 +150,39 @@ export function EmployeesTable() {
     [],
   );
 
-  const getRowAttributes = useCallback(
-    (
-      employee: Osdk.Instance<
-        Employee,
-        "$allBaseProperties",
-        PropertyKeys<Employee>,
-        RDPs
-      >,
-    ): Record<string, string | undefined> => ({
-      "data-highlight-row": employee.jobTitle === "Content Manager"
-        ? "true"
-        : undefined,
-    }),
-    [],
-  );
-
   const client = useOsdkClient();
 
   const os = client(Employee);
 
   return (
-    <div
-      style={{
-        height: "300px",
-        overflow: "hidden",
-      }}
-    >
-      <ObjectTable<Employee, RDPs, FunctionColumns>
-        objectSet={os}
-        objectType={Employee}
-        columnDefinitions={columnDefinitions}
-        selectionMode={"multiple"}
-        defaultOrderBy={[{
-          property: "firstFullTimeStartDate",
-          direction: "desc",
-        }]}
-        onSubmitEdits={handleSubmitEdits}
-        getRowAttributes={getRowAttributes}
-        className={"customEmployeesTable"}
-      />
-    </div>
+    <OsdkThemeProvider>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          width: "100%",
+        }}
+      >
+        <ThemeToggle />
+        <div
+          style={{
+            height: "300px",
+            overflow: "hidden",
+          }}
+        >
+          <ObjectTable<Employee, RDPs, FunctionColumns>
+            objectSet={os}
+            objectType={Employee}
+            columnDefinitions={columnDefinitions}
+            selectionMode={"multiple"}
+            defaultOrderBy={[{
+              property: "firstFullTimeStartDate",
+              direction: "desc",
+            }]}
+            onSubmitEdits={handleSubmitEdits}
+          />
+        </div>
+      </div>
+    </OsdkThemeProvider>
   );
 }

--- a/packages/react-components-storybook/.storybook/preview.tsx
+++ b/packages/react-components-storybook/.storybook/preview.tsx
@@ -71,7 +71,7 @@ const preview: Preview = {
   }, mswLoader],
   decorators: [
     (Story, context) => {
-      // The OSDK light/dark color scheme is now driven by `<OsdkThemeProvider>`
+      // The OSDK light/dark color scheme is driven by `<OsdkThemeProvider>`
       const themeName = context.globals.theme as string | undefined;
       const colorScheme = themeName === "dark" ? "dark" : "light";
       return (

--- a/packages/react-components-storybook/.storybook/preview.tsx
+++ b/packages/react-components-storybook/.storybook/preview.tsx
@@ -16,6 +16,7 @@
 
 import { createClient } from "@osdk/client";
 import { OsdkProvider } from "@osdk/react";
+import { OsdkThemeProvider } from "@osdk/react-components/experimental/theme";
 import { withThemeByDataAttribute } from "@storybook/addon-themes";
 import type { Preview } from "@storybook/react-vite";
 import { initialize, mswLoader } from "msw-storybook-addon";
@@ -69,13 +70,24 @@ const preview: Preview = {
     await fauxFoundryReady;
   }, mswLoader],
   decorators: [
-    (Story) => (
-      <div className="root">
-        <OsdkProvider client={mockClient}>
-          <Story />
-        </OsdkProvider>
-      </div>
-    ),
+    (Story, context) => {
+      // The OSDK light/dark color scheme is now driven by
+      // `<OsdkThemeProvider>` instead of a `[data-theme="dark"]` CSS block,
+      // matching what consumers do in their own apps. `key` remounts the
+      // provider when the toolbar switches between `light` and `dark` so
+      // the seeded `defaultTheme` reflects the new selection.
+      const themeName = context.globals.theme as string | undefined;
+      const colorScheme = themeName === "dark" ? "dark" : "light";
+      return (
+        <div className="root">
+          <OsdkProvider client={mockClient}>
+            <OsdkThemeProvider key={colorScheme} defaultTheme={colorScheme}>
+              <Story />
+            </OsdkThemeProvider>
+          </OsdkProvider>
+        </div>
+      );
+    },
     withThemeByDataAttribute({
       themes: {
         light: "light",

--- a/packages/react-components-storybook/.storybook/preview.tsx
+++ b/packages/react-components-storybook/.storybook/preview.tsx
@@ -71,17 +71,13 @@ const preview: Preview = {
   }, mswLoader],
   decorators: [
     (Story, context) => {
-      // The OSDK light/dark color scheme is now driven by
-      // `<OsdkThemeProvider>` instead of a `[data-theme="dark"]` CSS block,
-      // matching what consumers do in their own apps. `key` remounts the
-      // provider when the toolbar switches between `light` and `dark` so
-      // the seeded `defaultTheme` reflects the new selection.
+      // The OSDK light/dark color scheme is now driven by `<OsdkThemeProvider>`
       const themeName = context.globals.theme as string | undefined;
       const colorScheme = themeName === "dark" ? "dark" : "light";
       return (
         <div className="root">
           <OsdkProvider client={mockClient}>
-            <OsdkThemeProvider key={colorScheme} defaultTheme={colorScheme}>
+            <OsdkThemeProvider theme={colorScheme}>
               <Story />
             </OsdkThemeProvider>
           </OsdkProvider>

--- a/packages/react-components-storybook/.storybook/themes.css
+++ b/packages/react-components-storybook/.storybook/themes.css
@@ -1,25 +1,4 @@
-/* Light theme (default) - No overrides needed, uses default Blueprint/OSDK tokens */
-[data-theme="light"] {
-  --bp-intent-primary-rest: #2d72d2;
-  --bp-intent-danger-rest: #cd4246;
-
-  --bp-palette-black: oklch(0.2827 0.019 238.86);
-  --bp-palette-white: oklch(1 0 89.88);
-
-  --bp-palette-gray-1: oklch(0.6792 0.0229 243.66);
-  --bp-palette-gray-2: oklch(0.6792 0.0229 243.66);
-  --bp-palette-gray-3: oklch(0.8562 0.0148 244.74);
-  --bp-palette-gray-4: oklch(0.8562 0.0148 244.74);
-  --bp-palette-gray-5: oklch(0.9178 0.0101 227.89);
-  --bp-palette-gray-100: oklch(0.93 0.008 240);
-  --bp-palette-gray-200: oklch(0.88 0.012 240);
-
-  --bp-palette-light-gray-1: oklch(0.9178 0.0101 227.89);
-  --bp-palette-light-gray-2: oklch(0.9587 0.0051 228.82);
-  --bp-palette-light-gray-3: oklch(0.9587 0.0051 228.82);
-  --bp-palette-light-gray-4: oklch(0.9809 0.0025 228.78);
-  --bp-palette-light-gray-5: oklch(0.9809 0.0025 228.78);
-}
+/* light and dark themes are handled in the components by default `*/
 
 /* Modern theme - based on e2e.sandbox.peopleapp theme-overrides.css */
 [data-theme="modern"] {

--- a/packages/react-components-storybook/src/styles/storybook.css
+++ b/packages/react-components-storybook/src/styles/storybook.css
@@ -113,6 +113,17 @@ body {
   }
 }
 
+/* Dark-mode highlight values for the same rows. Activated by the
+   `data-bp-color-scheme="dark"` attribute that `<OsdkThemeProvider>`
+   writes onto the document root. */
+[data-bp-color-scheme="dark"] .customTableStyling {
+  tr[data-highlight-row="true"] {
+    --osdk-table-row-bg-default: #1c2a3a;
+    --osdk-table-row-bg-alternate: #182230;
+    --osdk-table-row-bg-hover: #213548;
+  }
+}
+
 .osdkCodeOutput {
   margin: 0;
   padding: calc(var(--osdk-surface-spacing) * 3);

--- a/packages/react-components-styles/CSS_VARIABLES.md
+++ b/packages/react-components-styles/CSS_VARIABLES.md
@@ -21,6 +21,7 @@ Complete reference of all CSS custom properties (variables) used in `@osdk/react
   - [Drag Handle](#drag-handle)
   - [Button](#button)
   - [Checkbox](#checkbox)
+  - [Combobox](#combobox)
   - [CBAC Picker](#cbac-picker)
   - [DateTime Picker](#datetime-picker)
   - [Dialog](#dialog)
@@ -33,6 +34,7 @@ Complete reference of all CSS custom properties (variables) used in `@osdk/react
   - [Object Set](#object-set)
   - [PDF Viewer](#pdf-viewer)
   - [Radio](#radio)
+  - [Select](#select)
   - [Switch](#switch)
   - [Table](#table)
   - [Time Picker](#time-picker)
@@ -227,6 +229,7 @@ Component-specific semantic tokens that may reference Blueprint tokens or define
 | `--osdk-focus-outline`                | `var(--osdk-emphasis-focus-width) solid var(--osdk-emphasis-focus-color)`         | Focus ring style               |
 | `--osdk-focus-visible-outline-offset` | `var(--osdk-emphasis-focus-offset)`                                               | Focus ring offset from element |
 | `--osdk-surface-border`               | `var(--osdk-surface-border-width) solid var(--osdk-surface-border-color-default)` | Reusable border shorthand      |
+| `--osdk-disabled-opacity`             | `0.5`                                                                             | Disabled state opacity         |
 
 ### AIP Agent Chat
 
@@ -321,6 +324,14 @@ Styling for checkbox components.
 | `--osdk-checkbox-bg-checked-hover`   | `var(--osdk-intent-primary-hover)`                    | Checked hover background    |
 | `--osdk-checkbox-bg-checked-active`  | `var(--osdk-intent-primary-active)`                   | Checked active background   |
 | `--osdk-checkbox-checked-foreground` | `var(--osdk-intent-primary-foreground)`               | Checkmark color             |
+
+### Combobox
+
+Styling for combobox components.
+
+| Variable                           | Default Value | Description          |
+| ---------------------------------- | ------------- | -------------------- |
+| `--osdk-combobox-popup-max-height` | `320px`       | Popup maximum height |
 
 ### CBAC Picker
 
@@ -1040,7 +1051,7 @@ Shared styling for input components.
 | `--osdk-input-focus-width`         | `var(--osdk-emphasis-focus-width)`                                                | Focus ring width        |
 | `--osdk-input-focus-color`         | `var(--osdk-emphasis-focus-color)`                                                | Focus ring color        |
 | `--osdk-input-focus-offset`        | `var(--osdk-emphasis-focus-offset)`                                               | Focus ring offset       |
-| `--osdk-input-disabled-opacity`    | `0.5`                                                                             | Disabled opacity        |
+| `--osdk-input-disabled-opacity`    | `var(--osdk-disabled-opacity)`                                                    | Input disabled opacity  |
 
 ### Markdown Renderer
 
@@ -1151,6 +1162,14 @@ Styling for radio button components.
 | `--osdk-radio-bg-checked-hover`  | `var(--osdk-intent-primary-hover)`                   | Checked hover background    |
 | `--osdk-radio-bg-checked-active` | `var(--osdk-intent-primary-active)`                  | Checked active background   |
 | `--osdk-radio-indicator-color`   | `var(--osdk-intent-primary-foreground)`              | Indicator dot color         |
+
+### Select
+
+Styling for select components.
+
+| Variable                         | Default Value | Description          |
+| -------------------------------- | ------------- | -------------------- |
+| `--osdk-select-popup-max-height` | `320px`       | Popup maximum height |
 
 ### Switch
 
@@ -1489,17 +1508,13 @@ For more comprehensive theming, override the Blueprint tokens that the OSDK toke
 
 ## Dark Mode
 
-`@osdk/react-components` ships built-in dark-theme overrides. They activate automatically in any of three ways:
+`@osdk/react-components` ships built-in dark-theme overrides that activate when `[data-bp-color-scheme="dark"]` is set on an ancestor element (typically `<html>`) — matching Blueprint's own convention so the OSDK + Blueprint tokens flip together. The recommended way to set the attribute is `<OsdkThemeProvider>` from `@osdk/react-components/experimental/theme`; see [OsdkThemeProvider](./OsdkThemeProvider.md) for the full reference, including `defaultTheme="system"` (the default, follows `prefers-color-scheme`), runtime toggles via `useOsdkTheme`, and the attribute-only path for hosts that already manage theme themselves.
 
-1. **`prefers-color-scheme: dark`** — matches the [Foundry custom widgets dark theme guidance](https://www.palantir.com/docs/foundry/custom-widgets/dark-theme). When a parent application (Foundry, the OS) declares dark color scheme, the widget switches without any host configuration.
-2. **`[data-bp-color-scheme="dark"]` or `.bp6-dark`** — matches the Blueprint convention. Set this attribute / class on any ancestor (often `<html>`) to force dark explicitly. Useful when the OS preference doesn't reflect what the host wants, or when previewing dark mode in isolation.
-3. **`[data-theme="dark"]`** — matches the Tailwind/Primer/Storybook toolbar convention. Lets Storybook (and other hosts that already use this attribute) opt into dark without duplicating overrides.
-
-The attribute paths win over the media query when both apply, giving hosts an explicit override. Under `[data-bp-color-scheme="dark"]` / `.bp6-dark`, Blueprint flips `--bp-*` itself, so `dark.css` only re-maps `--osdk-*` tokens. The other two selectors also flip the relevant `--bp-*` tokens because Blueprint doesn't fire there.
+Under `[data-bp-color-scheme="dark"]` Blueprint flips its own `--bp-*` tokens, so `dark.css` only re-maps the subset of `--osdk-*` tokens that have no `--bp-*` counterpart or that intentionally diverge from Blueprint's value.
 
 ### Adding your own dark overrides
 
-To customize dark-mode tokens beyond the defaults, declare your overrides in a higher layer using the same selectors:
+To customize dark-mode tokens beyond the defaults, declare your overrides in a higher layer using the same selector:
 
 ```css
 @layer osdk.styles, user.theme;
@@ -1507,15 +1522,7 @@ To customize dark-mode tokens beyond the defaults, declare your overrides in a h
 @import "@osdk/react-components/styles.css" layer(osdk.styles);
 
 @layer user.theme {
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --osdk-background-primary: #0a0a0a;
-      --osdk-table-row-bg-alternate: #161616;
-    }
-  }
-
-  [data-bp-color-scheme="dark"],
-  .bp6-dark {
+  [data-bp-color-scheme="dark"] {
     --osdk-background-primary: #0a0a0a;
     --osdk-table-row-bg-alternate: #161616;
   }

--- a/packages/react-components/docs/CSSVariables.md
+++ b/packages/react-components/docs/CSSVariables.md
@@ -1508,7 +1508,7 @@ For more comprehensive theming, override the Blueprint tokens that the OSDK toke
 
 ## Dark Mode
 
-`@osdk/react-components` ships built-in dark-theme overrides that activate when `[data-bp-color-scheme="dark"]` is set on an ancestor element (typically `<html>`) — matching Blueprint's own convention so the OSDK + Blueprint tokens flip together. The recommended way to set the attribute is `<OsdkThemeProvider>` from `@osdk/react-components/experimental/theme`; see [OsdkThemeProvider](./OsdkThemeProvider.md) for the full reference, including `defaultTheme="system"` (the default, follows `prefers-color-scheme`), runtime toggles via `useOsdkTheme`, and the attribute-only path for hosts that already manage theme themselves.
+`@osdk/react-components` ships built-in dark-theme overrides that activate when `[data-bp-color-scheme="dark"]` is set on an ancestor element (typically `<html>`) — matching Blueprint's own convention so the OSDK + Blueprint tokens flip together. The supported way to set the attribute is `<OsdkThemeProvider>` from `@osdk/react-components/experimental/theme`; see [OsdkThemeProvider](./OsdkThemeProvider.md) for the full reference, including `defaultTheme="system"` (the default, follows `prefers-color-scheme`), runtime toggles via `useOsdkTheme`, and controlled mode for integrating with an external theme store.
 
 Under `[data-bp-color-scheme="dark"]` Blueprint flips its own `--bp-*` tokens, so `dark.css` only re-maps the subset of `--osdk-*` tokens that have no `--bp-*` counterpart or that intentionally diverge from Blueprint's value.
 

--- a/packages/react-components/docs/CSSVariables.md
+++ b/packages/react-components/docs/CSSVariables.md
@@ -1508,17 +1508,13 @@ For more comprehensive theming, override the Blueprint tokens that the OSDK toke
 
 ## Dark Mode
 
-`@osdk/react-components` ships built-in dark-theme overrides. They activate automatically in any of three ways:
+`@osdk/react-components` ships built-in dark-theme overrides that activate when `[data-bp-color-scheme="dark"]` is set on an ancestor element (typically `<html>`) — matching Blueprint's own convention so the OSDK + Blueprint tokens flip together. The recommended way to set the attribute is `<OsdkThemeProvider>` from `@osdk/react-components/experimental/theme`; see [OsdkThemeProvider](./OsdkThemeProvider.md) for the full reference, including `defaultTheme="system"` (the default, follows `prefers-color-scheme`), runtime toggles via `useOsdkTheme`, and the attribute-only path for hosts that already manage theme themselves.
 
-1. **`prefers-color-scheme: dark`** — matches the [Foundry custom widgets dark theme guidance](https://www.palantir.com/docs/foundry/custom-widgets/dark-theme). When a parent application (Foundry, the OS) declares dark color scheme, the widget switches without any host configuration.
-2. **`[data-bp-color-scheme="dark"]` or `.bp6-dark`** — matches the Blueprint convention. Set this attribute / class on any ancestor (often `<html>`) to force dark explicitly. Useful when the OS preference doesn't reflect what the host wants, or when previewing dark mode in isolation.
-3. **`[data-theme="dark"]`** — matches the Tailwind/Primer/Storybook toolbar convention. Lets Storybook (and other hosts that already use this attribute) opt into dark without duplicating overrides.
-
-The attribute paths win over the media query when both apply, giving hosts an explicit override. Under `[data-bp-color-scheme="dark"]` / `.bp6-dark`, Blueprint flips `--bp-*` itself, so `dark.css` only re-maps `--osdk-*` tokens. The other two selectors also flip the relevant `--bp-*` tokens because Blueprint doesn't fire there.
+Under `[data-bp-color-scheme="dark"]` Blueprint flips its own `--bp-*` tokens, so `dark.css` only re-maps the subset of `--osdk-*` tokens that have no `--bp-*` counterpart or that intentionally diverge from Blueprint's value.
 
 ### Adding your own dark overrides
 
-To customize dark-mode tokens beyond the defaults, declare your overrides in a higher layer using the same selectors:
+To customize dark-mode tokens beyond the defaults, declare your overrides in a higher layer using the same selector:
 
 ```css
 @layer osdk.styles, user.theme;
@@ -1526,15 +1522,7 @@ To customize dark-mode tokens beyond the defaults, declare your overrides in a h
 @import "@osdk/react-components/styles.css" layer(osdk.styles);
 
 @layer user.theme {
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --osdk-background-primary: #0a0a0a;
-      --osdk-table-row-bg-alternate: #161616;
-    }
-  }
-
-  [data-bp-color-scheme="dark"],
-  .bp6-dark {
+  [data-bp-color-scheme="dark"] {
     --osdk-background-primary: #0a0a0a;
     --osdk-table-row-bg-alternate: #161616;
   }

--- a/packages/react-components/docs/OsdkThemeProvider.md
+++ b/packages/react-components/docs/OsdkThemeProvider.md
@@ -16,7 +16,6 @@ Before using `OsdkThemeProvider`, complete the library setup described in [Prere
   - [Default: follow the OS preference](#default-follow-the-os-preference)
   - [Force light or dark with `defaultTheme`](#force-light-or-dark-with-defaulttheme)
   - [Build a `ThemeToggle`](#build-a-themetoggle)
-  - [Persist the user's choice to `localStorage`](#persist-the-users-choice-to-localstorage)
   - [Drive the theme from an external store (controlled mode)](#drive-the-theme-from-an-external-store-controlled-mode)
   - [Scope theming to a subtree](#scope-theming-to-a-subtree)
 - [Branching on the resolved theme in JS](#branching-on-the-resolved-theme-in-js)
@@ -167,7 +166,7 @@ Render it anywhere inside the provider:
 
 ### Drive the theme from an external store (controlled mode)
 
-If the theme value already lives outside the OSDK tree (e.g. in a parent design-system provider), pass it in via the `theme` prop. The provider stops owning state; you re-render it with the new value when the store changes, and the provider rewrites `data-bp-color-scheme` accordingly. 
+If the theme value already lives outside the OSDK tree (e.g. in a parent design-system provider), pass it in via the `theme` prop. The provider stops owning state; you re-render it with the new value when the store changes, and the provider rewrites `data-bp-color-scheme` accordingly.
 
 ```tsx
 import {

--- a/packages/react-components/docs/OsdkThemeProvider.md
+++ b/packages/react-components/docs/OsdkThemeProvider.md
@@ -1,0 +1,207 @@
+# OsdkThemeProvider
+
+Provides OSDK theme state to descendants and writes a `data-bp-color-scheme` attribute onto the document so the OSDK + Blueprint design tokens activate the right theme. Components inside the provider re-render automatically when the resolved theme changes.
+
+## Prerequisites
+
+Before using `OsdkThemeProvider`, complete the library setup described in [Prerequisites](./Prerequisites.md), in particular the CSS layer imports - the provider only flips an attribute; the OSDK token CSS does the rest.
+
+## Table of Contents
+
+- [Import](#import)
+- [Quick start](#quick-start)
+- [Props reference](#props-reference)
+- [`useOsdkTheme` hook](#useosdktheme-hook)
+- [Examples](#examples)
+  - [Default: follow the OS preference](#default-follow-the-os-preference)
+  - [Force light or dark with `defaultTheme`](#force-light-or-dark-with-defaulttheme)
+  - [Build a `ThemeToggle`](#build-a-themetoggle)
+  - [Persist the user's choice to `localStorage`](#persist-the-users-choice-to-localstorage)
+  - [Scope theming to a subtree](#scope-theming-to-a-subtree)
+- [Branching on the resolved theme in JS](#branching-on-the-resolved-theme-in-js)
+- [Skipping the provider](#skipping-the-provider)
+
+## Import
+
+```tsx
+import {
+  type OsdkThemeMode,
+  OsdkThemeProvider,
+  type ResolvedOsdkTheme,
+  useOsdkTheme,
+} from "@osdk/react-components/experimental/theme";
+```
+
+## Quick start
+
+```tsx
+import { OsdkThemeProvider } from "@osdk/react-components/experimental/theme";
+
+function App() {
+  return (
+    <OsdkProvider client={client}>
+      <OsdkThemeProvider>
+        {/* your app */}
+      </OsdkThemeProvider>
+    </OsdkProvider>
+  );
+}
+```
+
+With no props the provider follows `prefers-color-scheme` and re-renders when the OS preference changes. To override the OS at runtime, descendants call `setTheme` from [`useOsdkTheme`](#useosdktheme-hook).
+
+> **If you don't render this provider**, OSDK components stay in light mode regardless of the OS preference. The CSS only flips on an explicit `data-bp-color-scheme` selector — the provider is the supported way to add one. If you'd rather not pull React state into your theming, see [Skipping the provider](#skipping-the-provider) for the attribute-only path.
+
+## Props reference
+
+| Prop           | Type                               | Default                    | Description                                                                                                                                                                                                                                          |
+| -------------- | ---------------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `defaultTheme` | `"light" \| "dark" \| "system"`    | `"system"`                 | Initial theme. The provider owns the state from then on; descendants change it at runtime via `useOsdkTheme().setTheme`.                                                                                                                             |
+| `target`       | `HTMLElement \| null` _(optional)_ | `document.documentElement` | Element to write `data-bp-color-scheme` onto. Defaults to `<html>` so Blueprint portals (popovers, dialogs, tooltips) — which render outside the React tree — also receive the theme. See [Scope theming to a subtree](#scope-theming-to-a-subtree). |
+| `children`     | `React.ReactNode`                  | —                          | Subtree that should resolve the theme via `useOsdkTheme`.                                                                                                                                                                                            |
+
+### `defaultTheme` modes
+
+| Mode       | Behavior                                                                                |
+| ---------- | --------------------------------------------------------------------------------------- |
+| `"system"` | Follows the OS `prefers-color-scheme` setting and re-renders when it changes (default). |
+| `"light"`  | Starts in light mode regardless of the OS preference.                                   |
+| `"dark"`   | Starts in dark mode regardless of the OS preference.                                    |
+
+`"system"` is the only mode where the resolved theme can change without anyone calling `setTheme` — it reacts to the OS preference flipping while your app is open.
+
+## `useOsdkTheme` hook
+
+```tsx
+const { theme, resolvedTheme, setTheme } = useOsdkTheme();
+```
+
+| Field           | Type                            | Description                                                                                               |
+| --------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `theme`         | `"light" \| "dark" \| "system"` | The requested mode, including `"system"`.                                                                 |
+| `resolvedTheme` | `"light" \| "dark"`             | The concrete theme actually applied to the DOM. When `theme === "system"`, tracks `prefers-color-scheme`. |
+| `setTheme`      | `(next: OsdkThemeMode) => void` | Switch the requested mode at runtime.                                                                     |
+
+Must be called from a descendant of `<OsdkThemeProvider>`; throws otherwise.
+
+## Examples
+
+### Default: follow the OS preference
+
+The simplest setup — no props needed. The provider starts in `"system"` mode, listens to `prefers-color-scheme`, and flips automatically when the user toggles their OS appearance.
+
+```tsx
+import { OsdkThemeProvider } from "@osdk/react-components/experimental/theme";
+
+export function Root() {
+  return (
+    <OsdkProvider client={client}>
+      <OsdkThemeProvider>
+        <App />
+      </OsdkThemeProvider>
+    </OsdkProvider>
+  );
+}
+```
+
+To verify this in development, open Chrome DevTools → `⌘⇧P` → "Show Rendering" → set "Emulate CSS media feature prefers-color-scheme" to `light` or `dark`.
+
+### Force light or dark with `defaultTheme`
+
+Pin the initial mode if your app intentionally ships in light or dark regardless of the OS:
+
+```tsx
+<OsdkThemeProvider defaultTheme="dark">
+  <App />
+</OsdkThemeProvider>;
+```
+
+Users can still switch at runtime via `useOsdkTheme().setTheme`; `defaultTheme` only seeds the initial value.
+
+### Build a `ThemeToggle`
+
+A typical settings-bar control that lets the user pick light/dark/system:
+
+```tsx
+import {
+  type OsdkThemeMode,
+  useOsdkTheme,
+} from "@osdk/react-components/experimental/theme";
+
+const MODES: readonly OsdkThemeMode[] = ["light", "dark", "system"];
+
+export function ThemeToggle() {
+  const { theme, resolvedTheme, setTheme } = useOsdkTheme();
+  return (
+    <div role="group" aria-label="Theme">
+      {MODES.map((mode) => (
+        <button
+          key={mode}
+          type="button"
+          onClick={() => setTheme(mode)}
+          aria-pressed={theme === mode}
+        >
+          {mode}
+        </button>
+      ))}
+      {theme === "system" && (
+        <span aria-live="polite">(resolved: {resolvedTheme})</span>
+      )}
+    </div>
+  );
+}
+```
+
+Render it anywhere inside the provider:
+
+```tsx
+<OsdkThemeProvider>
+  <Header>
+    <ThemeToggle />
+  </Header>
+  <main>{/* ... */}</main>
+</OsdkThemeProvider>;
+```
+
+### Scope theming to a subtree
+
+By default the provider writes `data-bp-color-scheme` onto `<html>` so portaled overlays (popovers, dialogs, tooltips) inherit the theme. To theme only a slice of the page — for example, embedding an OSDK dashboard inside a host app that already manages its own theme — pass a `target`:
+
+```tsx
+import { useRef } from "react";
+
+export function DashboardEmbed() {
+  const scopeRef = useRef<HTMLDivElement>(null);
+  return (
+    <div ref={scopeRef}>
+      <OsdkThemeProvider target={scopeRef.current} defaultTheme="dark">
+        <Dashboard />
+      </OsdkThemeProvider>
+    </div>
+  );
+}
+```
+
+Trade-off: portals from `@base-ui/react` / Blueprint render in a portal container that is **not** a descendant of `scopeRef`, so dropdowns and tooltips opened from inside the scoped subtree will follow the document-level theme, not the scoped one. Use the default (`<html>`) target unless you specifically need per-region theming.
+
+## Branching on the resolved theme in JS
+
+If you need to swap an asset or change a non-CSS value based on theme, read `resolvedTheme` — not `theme` — so the `"system"` mode resolves to a concrete `"light"` or `"dark"` for you:
+
+```tsx
+function LogoMark() {
+  const { resolvedTheme } = useOsdkTheme();
+  return (
+    <img
+      src={resolvedTheme === "dark" ? "/logo-dark.svg" : "/logo-light.svg"}
+      alt="Logo"
+    />
+  );
+}
+```
+
+## Skipping the provider
+
+If your host app already owns theme state in its own store (Redux, Zustand, a parent design-system provider), you don't need this provider at all. The OSDK tokens activate from `data-bp-color-scheme="dark"` on any ancestor element.
+
+For example, write `data-bp-color-scheme` onto `<html>` from your existing theme reducer — and OSDK tokens flip via CSS only, with no React provider needed.

--- a/packages/react-components/docs/OsdkThemeProvider.md
+++ b/packages/react-components/docs/OsdkThemeProvider.md
@@ -17,9 +17,9 @@ Before using `OsdkThemeProvider`, complete the library setup described in [Prere
   - [Force light or dark with `defaultTheme`](#force-light-or-dark-with-defaulttheme)
   - [Build a `ThemeToggle`](#build-a-themetoggle)
   - [Persist the user's choice to `localStorage`](#persist-the-users-choice-to-localstorage)
+  - [Drive the theme from an external store (controlled mode)](#drive-the-theme-from-an-external-store-controlled-mode)
   - [Scope theming to a subtree](#scope-theming-to-a-subtree)
 - [Branching on the resolved theme in JS](#branching-on-the-resolved-theme-in-js)
-- [Skipping the provider](#skipping-the-provider)
 
 ## Import
 
@@ -50,15 +50,17 @@ function App() {
 
 With no props the provider follows `prefers-color-scheme` and re-renders when the OS preference changes. To override the OS at runtime, descendants call `setTheme` from [`useOsdkTheme`](#useosdktheme-hook).
 
-> **If you don't render this provider**, OSDK components stay in light mode regardless of the OS preference. The CSS only flips on an explicit `data-bp-color-scheme` selector — the provider is the supported way to add one. If you'd rather not pull React state into your theming, see [Skipping the provider](#skipping-the-provider) for the attribute-only path.
+> **Always render the provider somewhere above OSDK components.** OSDK components stay in light mode without it — the CSS only flips when `data-bp-color-scheme="dark"` is on an ancestor, and the provider is the supported way to manage that attribute. If an external store already owns your theme value, use [controlled mode](#drive-the-theme-from-an-external-store-controlled-mode) instead of skipping the provider — that way descendants can still call `useOsdkTheme`.
 
 ## Props reference
 
-| Prop           | Type                               | Default                    | Description                                                                                                                                                                                                                                          |
-| -------------- | ---------------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `defaultTheme` | `"light" \| "dark" \| "system"`    | `"system"`                 | Initial theme. The provider owns the state from then on; descendants change it at runtime via `useOsdkTheme().setTheme`.                                                                                                                             |
-| `target`       | `HTMLElement \| null` _(optional)_ | `document.documentElement` | Element to write `data-bp-color-scheme` onto. Defaults to `<html>` so Blueprint portals (popovers, dialogs, tooltips) — which render outside the React tree — also receive the theme. See [Scope theming to a subtree](#scope-theming-to-a-subtree). |
-| `children`     | `React.ReactNode`                  | —                          | Subtree that should resolve the theme via `useOsdkTheme`.                                                                                                                                                                                            |
+| Prop             | Type                                          | Default                    | Description                                                                                                                                                                                                                                                                                             |
+| ---------------- | --------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `theme`          | `"light" \| "dark" \| "system"` _(optional)_  | —                          | Controlled theme. When provided, the provider does not maintain its own state — the parent must respond to `onThemeChanged` (or update its own external store) and re-render with the new value. See [Drive the theme from an external store](#drive-the-theme-from-an-external-store-controlled-mode). |
+| `defaultTheme`   | `"light" \| "dark" \| "system"`               | `"system"`                 | Initial theme when uncontrolled. Ignored when `theme` is provided. The provider owns the state from then on; descendants change it at runtime via `useOsdkTheme().setTheme`.                                                                                                                            |
+| `onThemeChanged` | `(theme: OsdkThemeMode) => void` _(optional)_ | —                          | Fires whenever a descendant calls `setTheme`. Use this to layer side effects (persistence, analytics) on top of the default state update, or to drive an external store in controlled mode.                                                                                                             |
+| `target`         | `HTMLElement \| null` _(optional)_            | `document.documentElement` | Element to write `data-bp-color-scheme` onto. Defaults to `<html>` so Blueprint portals (popovers, dialogs, tooltips) — which render outside the React tree — also receive the theme. See [Scope theming to a subtree](#scope-theming-to-a-subtree).                                                    |
+| `children`       | `React.ReactNode`                             | —                          | Subtree that should resolve the theme via `useOsdkTheme`.                                                                                                                                                                                                                                               |
 
 ### `defaultTheme` modes
 
@@ -163,6 +165,43 @@ Render it anywhere inside the provider:
 </OsdkThemeProvider>;
 ```
 
+### Drive the theme from an external store (controlled mode)
+
+If the theme value already lives outside the OSDK tree (e.g. in a parent design-system provider), pass it in via the `theme` prop. The provider stops owning state; you re-render it with the new value when the store changes, and the provider rewrites `data-bp-color-scheme` accordingly. 
+
+```tsx
+import {
+  type OsdkThemeMode,
+  OsdkThemeProvider,
+} from "@osdk/react-components/experimental/theme";
+import { useAppTheme } from "../store/theme.js"; // your own store hook
+
+export function AppRoot() {
+  // `theme` is owned by the app's store, not by the provider.
+  const theme = useAppTheme();
+  return (
+    <OsdkProvider client={client}>
+      <OsdkThemeProvider theme={theme}>
+        <App />
+      </OsdkThemeProvider>
+    </OsdkProvider>
+  );
+}
+```
+
+If descendants call `setTheme` from `useOsdkTheme()`, controlled mode does **not** update the provider's state — it fires `onThemeChanged` so you can route the change back into your store.
+
+```tsx
+<OsdkThemeProvider
+  theme={theme}
+  onThemeChanged={(next) => dispatch(setTheme(next))}
+>
+  <App />
+</OsdkThemeProvider>;
+```
+
+Use controlled mode whenever an external source of truth exists. Use uncontrolled (just `defaultTheme`) when the provider can own the state itself.
+
 ### Scope theming to a subtree
 
 By default the provider writes `data-bp-color-scheme` onto `<html>` so portaled overlays (popovers, dialogs, tooltips) inherit the theme. To theme only a slice of the page — for example, embedding an OSDK dashboard inside a host app that already manages its own theme — pass a `target`:
@@ -199,9 +238,3 @@ function LogoMark() {
   );
 }
 ```
-
-## Skipping the provider
-
-If your host app already owns theme state in its own store (Redux, Zustand, a parent design-system provider), you don't need this provider at all. The OSDK tokens activate from `data-bp-color-scheme="dark"` on any ancestor element.
-
-For example, write `data-bp-color-scheme` onto `<html>` from your existing theme reducer — and OSDK tokens flip via CSS only, with no React provider needed.

--- a/packages/react-components/docs/Prerequisites.md
+++ b/packages/react-components/docs/Prerequisites.md
@@ -124,6 +124,29 @@ All components resolve their visual properties through CSS custom properties. Th
 
 Per-component references list the `--osdk-*` variables each component exposes — see, for example, [ObjectTable › Theming](./ObjectTable.md#theming). The full catalog of variables lives in [CSSVariables.md](./CSSVariables.md).
 
+### Light and dark mode
+
+OSDK components ship a built-in dark theme. Wrap your app in `<OsdkThemeProvider>` to activate it and to let users override the OS preference at runtime:
+
+```tsx
+import { OsdkThemeProvider } from "@osdk/react-components/experimental/theme";
+
+function App() {
+  return (
+    <OsdkProvider client={client}>
+      <OsdkThemeProvider>
+        {/* defaults to "system" */}
+        {/* your app */}
+      </OsdkThemeProvider>
+    </OsdkProvider>
+  );
+}
+```
+
+By default the provider follows `prefers-color-scheme` and writes the resolved value to `data-bp-color-scheme` on `<html>` — matching [Blueprint's convention](https://blueprintjs.com/docs/#core/colors) so the theme also applies to portaled overlays (popovers, dialogs, tooltips).
+
+See [OsdkThemeProvider](./OsdkThemeProvider.md) for the full reference, including the `defaultTheme` modes, the `useOsdkTheme` hook, persisting the user's choice, and skipping the provider entirely if your host app already manages theme.
+
 ### Accessibility
 
 When overriding theme tokens, keep the result accessible:

--- a/packages/react-components/docs/Prerequisites.md
+++ b/packages/react-components/docs/Prerequisites.md
@@ -145,7 +145,7 @@ function App() {
 
 By default the provider follows `prefers-color-scheme` and writes the resolved value to `data-bp-color-scheme` on `<html>` — matching [Blueprint's convention](https://blueprintjs.com/docs/#core/colors) so the theme also applies to portaled overlays (popovers, dialogs, tooltips).
 
-See [OsdkThemeProvider](./OsdkThemeProvider.md) for the full reference, including the `defaultTheme` modes, the `useOsdkTheme` hook, persisting the user's choice, and skipping the provider entirely if your host app already manages theme.
+See [OsdkThemeProvider](./OsdkThemeProvider.md) for the full reference, including the `defaultTheme` modes, the `useOsdkTheme` hook, persisting the user's choice, and integrating with an external theme store via controlled mode.
 
 ### Accessibility
 

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -124,6 +124,15 @@
       "require": "./build/cjs/public/experimental/pdf-viewer.cjs",
       "default": "./build/browser/public/experimental/pdf-viewer.js"
     },
+    "./experimental/theme": {
+      "browser": "./build/browser/public/experimental/theme.js",
+      "import": {
+        "types": "./build/types/public/experimental/theme.d.ts",
+        "default": "./build/esm/public/experimental/theme.js"
+      },
+      "require": "./build/cjs/public/experimental/theme.cjs",
+      "default": "./build/browser/public/experimental/theme.js"
+    },
     "./experimental/tiff-renderer": {
       "browser": "./build/browser/public/experimental/tiff-renderer.js",
       "import": {
@@ -163,7 +172,7 @@
     }
   },
   "scripts": {
-    "check-attw": "attw --pack . --exclude-entrypoints ./styles.css ./experimental/action-form ./experimental/aip-agent-chat ./experimental/document-viewer ./experimental/email-viewer ./experimental/excel-viewer ./experimental/filter-list ./experimental/image-viewer ./experimental/markdown-renderer ./experimental/object-table ./experimental/pdf-viewer ./experimental/tiff-renderer ./experimental/video-viewer ./experimental/xml-viewer",
+    "check-attw": "attw --pack . --exclude-entrypoints ./styles.css ./experimental/action-form ./experimental/aip-agent-chat ./experimental/document-viewer ./experimental/email-viewer ./experimental/excel-viewer ./experimental/filter-list ./experimental/image-viewer ./experimental/markdown-renderer ./experimental/object-table ./experimental/pdf-viewer ./experimental/theme ./experimental/tiff-renderer ./experimental/video-viewer ./experimental/xml-viewer",
     "check-spelling": "cspell --quiet .",
     "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
     "fix-lint": "eslint . --fix && dprint fmt",

--- a/packages/react-components/src/object-table/EditableCell.module.css
+++ b/packages/react-components/src/object-table/EditableCell.module.css
@@ -52,8 +52,8 @@
 
   /* Match the text-input editable cell background so the row reads as a
      single field strip instead of mixed surface colors. */
-  --osdk-select-trigger-bg: var(--osdk-table-cell-editable-bg);
-  --osdk-combobox-trigger-bg: var(--osdk-table-cell-editable-bg);
+  --osdk-select-trigger-bg: var(--osdk-table-cell-input-bg);
+  --osdk-combobox-trigger-bg: var(--osdk-table-cell-input-bg);
 
   --osdk-combobox-input-padding: var(--osdk-surface-spacing)
     calc(var(--osdk-surface-spacing) * 3);

--- a/packages/react-components/src/public/experimental.ts
+++ b/packages/react-components/src/public/experimental.ts
@@ -23,6 +23,7 @@ export * from "./experimental/image-viewer.js";
 export * from "./experimental/markdown-renderer.js";
 export * from "./experimental/object-table.js";
 export * from "./experimental/pdf-viewer.js";
+export * from "./experimental/theme.js";
 export * from "./experimental/tiff-renderer.js";
 export * from "./experimental/video-viewer.js";
 export * from "./experimental/xml-viewer.js";

--- a/packages/react-components/src/public/experimental/theme.ts
+++ b/packages/react-components/src/public/experimental/theme.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export {
+  OsdkThemeProvider,
+  type OsdkThemeProviderProps,
+} from "../../theme/OsdkThemeProvider.js";
+export type {
+  OsdkThemeContextValue,
+  OsdkThemeMode,
+  ResolvedOsdkTheme,
+} from "../../theme/types.js";
+export { useOsdkTheme } from "../../theme/useOsdkTheme.js";

--- a/packages/react-components/src/theme/OsdkThemeContext.ts
+++ b/packages/react-components/src/theme/OsdkThemeContext.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { type Context, createContext } from "react";
+import type { OsdkThemeContextValue } from "./types.js";
+
+export const OsdkThemeContext: Context<OsdkThemeContextValue | null> =
+  createContext<OsdkThemeContextValue | null>(null);

--- a/packages/react-components/src/theme/OsdkThemeProvider.tsx
+++ b/packages/react-components/src/theme/OsdkThemeProvider.tsx
@@ -88,7 +88,7 @@ export function OsdkThemeProvider({
     ? systemTheme
     : theme;
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     const element = target
       ?? (typeof document !== "undefined" ? document.documentElement : null);
     if (element == null) return;

--- a/packages/react-components/src/theme/OsdkThemeProvider.tsx
+++ b/packages/react-components/src/theme/OsdkThemeProvider.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { OsdkThemeContext } from "./OsdkThemeContext.js";
+import type {
+  OsdkThemeContextValue,
+  OsdkThemeMode,
+  ResolvedOsdkTheme,
+} from "./types.js";
+import { useSystemTheme } from "./useSystemTheme.js";
+
+export const DATA_THEME_ATTR = "data-bp-color-scheme";
+
+export interface OsdkThemeProviderProps {
+  /**
+   * Initial theme. The provider owns the state from then on; call
+   * `setTheme` from {@link useOsdkTheme} to change it at runtime.
+   *
+   * @default "system"
+   */
+  defaultTheme?: OsdkThemeMode;
+
+  /**
+   * Element to write `data-bp-color-scheme` onto.
+   *
+   * @default `document.documentElement` - (the `<html>` element), which is
+   * the safest target because Blueprint portals (popovers, dialogs,
+   * tooltips) render outside the React tree.
+   */
+  target?: HTMLElement | null;
+
+  children: React.ReactNode;
+}
+
+/**
+ * Provides OSDK theme state to descendants and writes a
+ * `data-bp-color-scheme` attribute onto the document so the CSS in
+ * `tokens/base-tokens/dark.css` activates the right theme.
+ *
+ * `defaultTheme="system"` (default) follows the OS `prefers-color-scheme`
+ * setting and re-renders when it changes. `defaultTheme="light"` /
+ * `defaultTheme="dark"` start in the given theme regardless of the OS
+ * preference. Call {@link useOsdkTheme}().setTheme from a descendant to
+ * switch modes at runtime.
+ *
+ * For consumers whose host app already owns theme state in its own store,
+ * skip this provider and write `data-bp-color-scheme` onto the document
+ * yourself — the CSS picks it up the same way.
+ */
+export function OsdkThemeProvider({
+  defaultTheme = "system",
+  target,
+  children,
+}: OsdkThemeProviderProps): React.ReactElement {
+  const [theme, setTheme] = React.useState<OsdkThemeMode>(defaultTheme);
+
+  const systemTheme = useSystemTheme();
+  const resolvedTheme: ResolvedOsdkTheme = theme === "system"
+    ? systemTheme
+    : theme;
+
+  React.useEffect(() => {
+    const element = target
+      ?? (typeof document !== "undefined" ? document.documentElement : null);
+    if (element == null) return;
+
+    const previous = element.getAttribute(DATA_THEME_ATTR);
+    element.setAttribute(DATA_THEME_ATTR, resolvedTheme);
+    return () => {
+      if (previous == null) {
+        element.removeAttribute(DATA_THEME_ATTR);
+      } else {
+        element.setAttribute(DATA_THEME_ATTR, previous);
+      }
+    };
+  }, [resolvedTheme, target]);
+
+  const value = React.useMemo<OsdkThemeContextValue>(
+    () => ({ theme, resolvedTheme, setTheme }),
+    [theme, resolvedTheme, setTheme],
+  );
+
+  return (
+    <OsdkThemeContext.Provider value={value}>
+      {children}
+    </OsdkThemeContext.Provider>
+  );
+}

--- a/packages/react-components/src/theme/OsdkThemeProvider.tsx
+++ b/packages/react-components/src/theme/OsdkThemeProvider.tsx
@@ -27,12 +27,23 @@ export const DATA_THEME_ATTR = "data-bp-color-scheme";
 
 export interface OsdkThemeProviderProps {
   /**
-   * Initial theme. The provider owns the state from then on; call
-   * `setTheme` from {@link useOsdkTheme} to change it at runtime.
+   * Controlled theme. When provided, the provider does not maintain its
+   * own state — the parent must respond to `onThemeChanged` (or update its
+   * own external store) and re-render with the new value. Use this when an
+   * external store already owns the theme value (e.g. Redux/Zustand, a
+   * parent design-system provider, or a Storybook toolbar).
+   */
+  theme?: OsdkThemeMode;
+
+  /**
+   * Initial theme when uncontrolled. Ignored when `theme` is provided.
    *
    * @default "system"
    */
   defaultTheme?: OsdkThemeMode;
+
+  /** Fires whenever `setTheme` is called from a descendant. */
+  onThemeChanged?: (theme: OsdkThemeMode) => void;
 
   /**
    * Element to write `data-bp-color-scheme` onto.
@@ -57,16 +68,20 @@ export interface OsdkThemeProviderProps {
  * preference. Call {@link useOsdkTheme}().setTheme from a descendant to
  * switch modes at runtime.
  *
- * For consumers whose host app already owns theme state in its own store,
- * skip this provider and write `data-bp-color-scheme` onto the document
- * yourself — the CSS picks it up the same way.
+ * To integrate with an external theme store, pass `theme` (controlled
+ * mode)
  */
 export function OsdkThemeProvider({
+  theme: controlledTheme,
   defaultTheme = "system",
+  onThemeChanged,
   target,
   children,
 }: OsdkThemeProviderProps): React.ReactElement {
-  const [theme, setTheme] = React.useState<OsdkThemeMode>(defaultTheme);
+  const [internalTheme, setInternalTheme] = React.useState<OsdkThemeMode>(
+    defaultTheme,
+  );
+  const theme = controlledTheme ?? internalTheme;
 
   const systemTheme = useSystemTheme();
   const resolvedTheme: ResolvedOsdkTheme = theme === "system"
@@ -88,6 +103,16 @@ export function OsdkThemeProvider({
       }
     };
   }, [resolvedTheme, target]);
+
+  const setTheme = React.useCallback(
+    (next: OsdkThemeMode) => {
+      if (controlledTheme === undefined) {
+        setInternalTheme(next);
+      }
+      onThemeChanged?.(next);
+    },
+    [controlledTheme, onThemeChanged],
+  );
 
   const value = React.useMemo<OsdkThemeContextValue>(
     () => ({ theme, resolvedTheme, setTheme }),

--- a/packages/react-components/src/theme/__tests__/OsdkThemeProvider.test.tsx
+++ b/packages/react-components/src/theme/__tests__/OsdkThemeProvider.test.tsx
@@ -18,6 +18,7 @@ import { act, cleanup, render, screen } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DATA_THEME_ATTR, OsdkThemeProvider } from "../OsdkThemeProvider.js";
+import type { OsdkThemeMode } from "../types.js";
 import { useOsdkTheme } from "../useOsdkTheme.js";
 
 type MediaQueryListener = (event: { matches: boolean }) => void;
@@ -177,6 +178,53 @@ describe("OsdkThemeProvider", () => {
     expect(document.documentElement.getAttribute(DATA_THEME_ATTR)).toBe(
       "light",
     );
+  });
+
+  it("controlled mode ignores setTheme and fires onThemeChanged", () => {
+    const onThemeChanged = vi.fn();
+    render(
+      <OsdkThemeProvider theme="light" onThemeChanged={onThemeChanged}>
+        <ThemeProbe />
+        <ThemeToggle />
+      </OsdkThemeProvider>,
+    );
+
+    expect(screen.getByTestId("resolved").textContent).toBe("light");
+
+    act(() => {
+      screen.getByTestId("set-dark").click();
+    });
+
+    expect(onThemeChanged).toHaveBeenCalledWith("dark");
+    // controlled mode: still light because parent didn't re-render
+    expect(screen.getByTestId("theme").textContent).toBe("light");
+    expect(document.documentElement.getAttribute(DATA_THEME_ATTR)).toBe(
+      "light",
+    );
+  });
+
+  it("controlled theme re-renders propagate to the DOM", () => {
+    function Harness(): React.ReactElement {
+      const [theme, setTheme] = React.useState<OsdkThemeMode>("light");
+      return (
+        <OsdkThemeProvider theme={theme} onThemeChanged={setTheme}>
+          <ThemeProbe />
+          <ThemeToggle />
+        </OsdkThemeProvider>
+      );
+    }
+    render(<Harness />);
+
+    expect(document.documentElement.getAttribute(DATA_THEME_ATTR)).toBe(
+      "light",
+    );
+
+    act(() => {
+      screen.getByTestId("set-dark").click();
+    });
+
+    expect(screen.getByTestId("theme").textContent).toBe("dark");
+    expect(document.documentElement.getAttribute(DATA_THEME_ATTR)).toBe("dark");
   });
 
   it("restores the previous data theme attribute on unmount", () => {

--- a/packages/react-components/src/theme/__tests__/OsdkThemeProvider.test.tsx
+++ b/packages/react-components/src/theme/__tests__/OsdkThemeProvider.test.tsx
@@ -170,6 +170,7 @@ describe("OsdkThemeProvider", () => {
     expect(screen.getByTestId("resolved").textContent).toBe("dark");
 
     act(() => {
+      // Calls setTheme
       screen.getByTestId("set-light").click();
     });
 
@@ -192,6 +193,7 @@ describe("OsdkThemeProvider", () => {
     expect(screen.getByTestId("resolved").textContent).toBe("light");
 
     act(() => {
+      // Calls setTheme
       screen.getByTestId("set-dark").click();
     });
 
@@ -220,6 +222,7 @@ describe("OsdkThemeProvider", () => {
     );
 
     act(() => {
+      // Calls setTheme
       screen.getByTestId("set-dark").click();
     });
 

--- a/packages/react-components/src/theme/__tests__/OsdkThemeProvider.test.tsx
+++ b/packages/react-components/src/theme/__tests__/OsdkThemeProvider.test.tsx
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DATA_THEME_ATTR, OsdkThemeProvider } from "../OsdkThemeProvider.js";
+import { useOsdkTheme } from "../useOsdkTheme.js";
+
+type MediaQueryListener = (event: { matches: boolean }) => void;
+
+interface FakeMediaQueryList {
+  matches: boolean;
+  addEventListener: (type: "change", listener: MediaQueryListener) => void;
+  removeEventListener: (type: "change", listener: MediaQueryListener) => void;
+}
+
+function installMatchMediaMock(initialMatches: boolean): {
+  setMatches: (matches: boolean) => void;
+  cleanup: () => void;
+} {
+  const listeners = new Set<MediaQueryListener>();
+  let matches = initialMatches;
+
+  const mql: FakeMediaQueryList = {
+    get matches() {
+      return matches;
+    },
+    addEventListener: (_type, listener) => {
+      listeners.add(listener);
+    },
+    removeEventListener: (_type, listener) => {
+      listeners.delete(listener);
+    },
+  };
+
+  const original = window.matchMedia;
+  window.matchMedia = vi.fn(() => mql) as unknown as typeof window.matchMedia;
+
+  return {
+    setMatches: (next: boolean) => {
+      matches = next;
+      for (const listener of listeners) {
+        listener({ matches: next });
+      }
+    },
+    cleanup: () => {
+      window.matchMedia = original;
+    },
+  };
+}
+
+function ThemeProbe(): React.ReactElement {
+  const { theme, resolvedTheme } = useOsdkTheme();
+  return (
+    <div>
+      <span data-testid="theme">{theme}</span>
+      <span data-testid="resolved">{resolvedTheme}</span>
+    </div>
+  );
+}
+
+function ThemeToggle(): React.ReactElement {
+  const { setTheme } = useOsdkTheme();
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="set-light"
+        onClick={() => setTheme("light")}
+      />
+      <button
+        type="button"
+        data-testid="set-dark"
+        onClick={() => setTheme("dark")}
+      />
+      <button
+        type="button"
+        data-testid="set-system"
+        onClick={() => setTheme("system")}
+      />
+    </>
+  );
+}
+
+describe("OsdkThemeProvider", () => {
+  let media: ReturnType<typeof installMatchMediaMock>;
+
+  beforeEach(() => {
+    media = installMatchMediaMock(false);
+  });
+
+  afterEach(() => {
+    cleanup();
+    document.documentElement.removeAttribute(DATA_THEME_ATTR);
+    media.cleanup();
+  });
+
+  it("defaults to system mode and resolves against prefers-color-scheme", () => {
+    media.setMatches(true);
+    render(
+      <OsdkThemeProvider>
+        <ThemeProbe />
+      </OsdkThemeProvider>,
+    );
+
+    expect(screen.getByTestId("theme").textContent).toBe("system");
+    expect(screen.getByTestId("resolved").textContent).toBe("dark");
+    expect(document.documentElement.getAttribute(DATA_THEME_ATTR)).toBe("dark");
+  });
+
+  it("light/dark override the OS preference", () => {
+    // Set (prefers-color-scheme: dark) to true
+    media.setMatches(true);
+    render(
+      <OsdkThemeProvider defaultTheme="light">
+        <ThemeProbe />
+      </OsdkThemeProvider>,
+    );
+
+    expect(screen.getByTestId("resolved").textContent).toBe("light");
+    expect(document.documentElement.getAttribute(DATA_THEME_ATTR)).toBe(
+      "light",
+    );
+  });
+
+  it("reacts when the OS preference changes while in system mode", () => {
+    media.setMatches(false);
+    render(
+      <OsdkThemeProvider>
+        <ThemeProbe />
+      </OsdkThemeProvider>,
+    );
+
+    expect(document.documentElement.getAttribute(DATA_THEME_ATTR)).toBe(
+      "light",
+    );
+
+    act(() => {
+      media.setMatches(true);
+    });
+
+    expect(screen.getByTestId("resolved").textContent).toBe("dark");
+    expect(document.documentElement.getAttribute(DATA_THEME_ATTR)).toBe("dark");
+  });
+
+  it("setTheme updates the active theme in uncontrolled mode", () => {
+    media.setMatches(true);
+    render(
+      <OsdkThemeProvider>
+        <ThemeProbe />
+        <ThemeToggle />
+      </OsdkThemeProvider>,
+    );
+
+    expect(screen.getByTestId("resolved").textContent).toBe("dark");
+
+    act(() => {
+      screen.getByTestId("set-light").click();
+    });
+
+    expect(screen.getByTestId("theme").textContent).toBe("light");
+    expect(screen.getByTestId("resolved").textContent).toBe("light");
+    expect(document.documentElement.getAttribute(DATA_THEME_ATTR)).toBe(
+      "light",
+    );
+  });
+
+  it("restores the previous data theme attribute on unmount", () => {
+    document.documentElement.setAttribute(DATA_THEME_ATTR, "light");
+    const { unmount } = render(
+      <OsdkThemeProvider defaultTheme="dark">
+        <ThemeProbe />
+      </OsdkThemeProvider>,
+    );
+
+    expect(document.documentElement.getAttribute(DATA_THEME_ATTR)).toBe("dark");
+
+    unmount();
+
+    expect(document.documentElement.getAttribute(DATA_THEME_ATTR)).toBe(
+      "light",
+    );
+  });
+
+  it("removes the data theme attribute on unmount when there was none", () => {
+    expect(document.documentElement.getAttribute(DATA_THEME_ATTR)).toBeNull();
+    const { unmount } = render(
+      <OsdkThemeProvider defaultTheme="dark">
+        <ThemeProbe />
+      </OsdkThemeProvider>,
+    );
+
+    expect(document.documentElement.getAttribute(DATA_THEME_ATTR)).toBe("dark");
+
+    unmount();
+
+    expect(document.documentElement.getAttribute(DATA_THEME_ATTR)).toBeNull();
+  });
+
+  it("writes to a custom target element when provided", () => {
+    const custom = document.createElement("div");
+    document.body.appendChild(custom);
+    try {
+      render(
+        <OsdkThemeProvider defaultTheme="dark" target={custom}>
+          <ThemeProbe />
+        </OsdkThemeProvider>,
+      );
+
+      expect(custom.getAttribute(DATA_THEME_ATTR)).toBe("dark");
+      expect(document.documentElement.getAttribute(DATA_THEME_ATTR)).toBeNull();
+    } finally {
+      document.body.removeChild(custom);
+    }
+  });
+});
+
+describe("useOsdkTheme", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("throws when used outside of an OsdkThemeProvider", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(
+      () => {},
+    );
+    try {
+      expect(() => render(<ThemeProbe />)).toThrow(/OsdkThemeProvider/);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});

--- a/packages/react-components/src/theme/types.ts
+++ b/packages/react-components/src/theme/types.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Requested theme mode.
+ *
+ * - `"light"` / `"dark"` — force the given theme regardless of OS preference.
+ * - `"system"` — follow `prefers-color-scheme` and react to changes at runtime.
+ */
+export type OsdkThemeMode = "light" | "dark" | "system";
+
+/**
+ * The concrete theme actually applied to the DOM. `OsdkThemeMode` of
+ * `"system"` resolves to either `"light"` or `"dark"` depending on the
+ * current value of `prefers-color-scheme`.
+ */
+export type ResolvedOsdkTheme = "light" | "dark";
+
+export interface OsdkThemeContextValue {
+  /** The requested mode, including `"system"`. */
+  theme: OsdkThemeMode;
+  /** The concrete theme currently applied to the DOM. */
+  resolvedTheme: ResolvedOsdkTheme;
+  /**
+   * Update the requested mode. In controlled mode (`theme` prop on the
+   * provider) this only invokes `onThemeChanged`; the consumer is expected
+   * to re-render the provider with the new value.
+   */
+  setTheme: (theme: OsdkThemeMode) => void;
+}

--- a/packages/react-components/src/theme/useOsdkTheme.ts
+++ b/packages/react-components/src/theme/useOsdkTheme.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useContext } from "react";
+import { OsdkThemeContext } from "./OsdkThemeContext.js";
+import type { OsdkThemeContextValue } from "./types.js";
+
+/**
+ * Read the active OSDK theme and update it imperatively.
+ *
+ * Must be called from a descendant of `<OsdkThemeProvider>`; throws otherwise.
+ *
+ * @returns
+ * - `theme` — the requested mode (`"light" | "dark" | "system"`).
+ * - `resolvedTheme` — the concrete theme on the DOM (`"light" | "dark"`).
+ *   When `theme === "system"`, this tracks `prefers-color-scheme` and
+ *   updates as the OS preference changes.
+ * - `setTheme(next)` — update the mode. In controlled mode this only
+ *   invokes the provider's `onThemeChanged`; the consumer must re-render
+ *   the provider with the new value.
+ */
+export function useOsdkTheme(): OsdkThemeContextValue {
+  const ctx = useContext(OsdkThemeContext);
+  if (ctx == null) {
+    throw new Error(
+      "useOsdkTheme must be used within an <OsdkThemeProvider>.",
+    );
+  }
+  return ctx;
+}

--- a/packages/react-components/src/theme/useSystemTheme.ts
+++ b/packages/react-components/src/theme/useSystemTheme.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useSyncExternalStore } from "react";
+import type { ResolvedOsdkTheme } from "./types.js";
+
+const DARK_QUERY = "(prefers-color-scheme: dark)";
+
+function subscribe(callback: () => void): () => void {
+  if (
+    typeof window === "undefined" || typeof window.matchMedia !== "function"
+  ) {
+    return () => {};
+  }
+  const mql = window.matchMedia(DARK_QUERY);
+  mql.addEventListener("change", callback);
+  return () => mql.removeEventListener("change", callback);
+}
+
+function getSnapshot(): ResolvedOsdkTheme {
+  if (
+    typeof window === "undefined" || typeof window.matchMedia !== "function"
+  ) {
+    return "light";
+  }
+  return window.matchMedia(DARK_QUERY).matches ? "dark" : "light";
+}
+
+function getServerSnapshot(): ResolvedOsdkTheme {
+  return "light";
+}
+
+/**
+ * Subscribes to the OS-level `prefers-color-scheme` media query and returns
+ * the current resolved value. Re-renders the consumer when the OS preference
+ * changes. SSR-safe: returns `"light"` on the server.
+ */
+export function useSystemTheme(): ResolvedOsdkTheme {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/packages/react-components/src/tokens/base-tokens/dark.css
+++ b/packages/react-components/src/tokens/base-tokens/dark.css
@@ -1,15 +1,11 @@
 /*
- * Dark theme overrides for OSDK semantic tokens. Activated by either of:
- *   - `[data-bp-color-scheme="dark"]` — written by `<OsdkThemeProvider>`
- *     onto the document root, matching Blueprint's own convention so the
- *     theme also applies to portaled overlays
- *   - `.bp6-dark` — Blueprint's class-based variant of the same convention
+ * Dark theme overrides for OSDK semantic tokens. Activated by `[data-bp-color-scheme="dark"]` 
+ * written by `<OsdkThemeProvider>` onto the document root, matching Blueprint's own convention so the
+ * theme also applies to portaled overlays. Keeping `.bp6-dark` as well to match Blueprint's class-based 
+ * variant of the same convention.
  *
  * Source-of-truth dark values live in `--osdk-dark-*` helpers at `:root`
- * (private — do not consume directly). The activation block below maps
- * those helpers onto the public `--osdk-*` tokens; Blueprint flips its
- * own `--bp-*` tokens under the same selectors so the OSDK tokens that
- * derive from `--bp-*` (see `base.css`) cascade correctly.
+ * (private — do not consume directly).
  */
 
 :root {
@@ -87,4 +83,3 @@
   --osdk-table-row-bg-hover: var(--osdk-dark-table-row-bg-hover);
   --osdk-table-row-bg-active: var(--osdk-dark-table-row-bg-hover);
 }
-

--- a/packages/react-components/src/tokens/base-tokens/dark.css
+++ b/packages/react-components/src/tokens/base-tokens/dark.css
@@ -1,10 +1,15 @@
 /*
- * Dark theme overrides for OSDK semantic tokens. Activated by `[data-bp-color-scheme="dark"]` 
- * set using OsdkThemeProvider.
- * 
+ * Dark theme overrides for OSDK semantic tokens. Activated by either of:
+ *   - `[data-bp-color-scheme="dark"]` — written by `<OsdkThemeProvider>`
+ *     onto the document root, matching Blueprint's own convention so the
+ *     theme also applies to portaled overlays
+ *   - `.bp6-dark` — Blueprint's class-based variant of the same convention
+ *
  * Source-of-truth dark values live in `--osdk-dark-*` helpers at `:root`
- * (private — do not consume directly). The three activation blocks below
- * map those helpers onto the public `--bp-*` / `--osdk-*` tokens.
+ * (private — do not consume directly). The activation block below maps
+ * those helpers onto the public `--osdk-*` tokens; Blueprint flips its
+ * own `--bp-*` tokens under the same selectors so the OSDK tokens that
+ * derive from `--bp-*` (see `base.css`) cascade correctly.
  */
 
 :root {
@@ -83,62 +88,3 @@
   --osdk-table-row-bg-active: var(--osdk-dark-table-row-bg-hover);
 }
 
-/* Note: data-theme attribute is added to work with storybook themes
- * It also flips `--bp-*` because Blueprint doesn't fire there.
- */
-[data-theme="dark"] {
-  /* --bp-* flips (Blueprint doesn't respond to data-theme). */
-  --bp-surface-border-color-default: var(
-    --osdk-dark-bp-surface-border-color-default
-  );
-  --bp-surface-border-color-strong: var(
-    --osdk-dark-bp-surface-border-color-strong
-  );
-  --bp-surface-shadow-0: var(--osdk-dark-bp-surface-shadow-0);
-  --bp-surface-shadow-1: var(--osdk-dark-bp-surface-shadow-1);
-  --bp-surface-shadow-2: var(--osdk-dark-bp-surface-shadow-2);
-  --bp-surface-shadow-3: var(--osdk-dark-bp-surface-shadow-3);
-  --bp-surface-shadow-4: var(--osdk-dark-bp-surface-shadow-4);
-  --bp-surface-color-code: var(--osdk-dark-bp-surface-color-code);
-  --bp-surface-background-color-default-rest: var(
-    --osdk-dark-bp-surface-background-color-default-rest
-  );
-  --bp-surface-background-color-default-hover: var(
-    --osdk-dark-bp-surface-background-color-default-hover
-  );
-  --bp-surface-background-color-default-active: var(
-    --osdk-dark-bp-surface-background-color-default-active
-  );
-  --bp-surface-background-color-default-disabled: var(
-    --osdk-dark-bp-surface-background-color-default-disabled
-  );
-  --bp-typography-color-default-rest: var(
-    --osdk-dark-bp-typography-color-default-rest
-  );
-  --bp-typography-color-default-hover: var(
-    --osdk-dark-bp-typography-color-default-hover
-  );
-  --bp-typography-color-default-active: var(
-    --osdk-dark-bp-typography-color-default-active
-  );
-
-  /* --osdk-* overrides */
-  --osdk-background-primary: var(--osdk-dark-background-primary);
-  --osdk-background-secondary: var(--osdk-dark-background-secondary);
-  --osdk-background-tertiary: var(--osdk-dark-background-tertiary);
-  --osdk-typography-color-muted: var(--osdk-dark-typography-color-muted);
-  --osdk-intent-default-rest: var(--osdk-dark-intent-default-rest);
-  --osdk-intent-default-foreground: var(--osdk-dark-intent-default-foreground);
-  --osdk-button-secondary-bg: var(--osdk-dark-button-secondary-bg);
-  --osdk-button-secondary-color: var(--osdk-dark-button-secondary-color);
-  --osdk-table-row-bg-default: var(--osdk-dark-table-row-bg-default);
-  --osdk-table-header-bg: var(--osdk-dark-table-header-bg);
-  --osdk-table-header-color: var(--osdk-dark-table-header-color);
-  --osdk-table-cell-color: var(--osdk-dark-table-cell-color);
-  --osdk-table-header-menu-color: var(--osdk-dark-table-header-menu-color);
-  --osdk-table-border-color: var(--osdk-dark-table-border-color);
-  --osdk-table-cell-divider: var(--osdk-table-border-width) solid
-    var(--osdk-table-border-color);
-  --osdk-table-row-bg-hover: var(--osdk-dark-table-row-bg-hover);
-  --osdk-table-row-bg-active: var(--osdk-dark-table-row-bg-hover);
-}

--- a/packages/react-components/src/tokens/base-tokens/dark.css
+++ b/packages/react-components/src/tokens/base-tokens/dark.css
@@ -1,18 +1,10 @@
 /*
- * Dark theme overrides for OSDK semantic tokens. Activated by any of:
- *   - `prefers-color-scheme: dark` (OS-level, matches Foundry custom-widgets)
- *   - `[data-bp-color-scheme="dark"]` / `.bp6-dark` (Blueprint convention)
- *   - `[data-theme="dark"]` (Tailwind/Primer/Storybook toolbar convention;
- *     lets Storybook import this file directly instead of duplicating)
- *
+ * Dark theme overrides for OSDK semantic tokens. Activated by `[data-bp-color-scheme="dark"]` 
+ * set using OsdkThemeProvider.
+ * 
  * Source-of-truth dark values live in `--osdk-dark-*` helpers at `:root`
  * (private — do not consume directly). The three activation blocks below
  * map those helpers onto the public `--bp-*` / `--osdk-*` tokens.
- *
- * `[data-bp-color-scheme="dark"], .bp6-dark` only re-maps `--osdk-*` —
- * Blueprint flips `--bp-*` itself under those selectors. The other two
- * blocks also flip `--bp-*` because Blueprint doesn't fire there.
- *
  */
 
 :root {
@@ -24,16 +16,13 @@
     0px 0px 10px 0px rgba(0, 0, 0, 0.2);
   --osdk-dark-bp-surface-shadow-1:
     inset 0px 0px 0px 1px rgba(255, 255, 255, 0.2),
-    0px 1px 10px 0px rgba(0, 0, 0, 0.2),
-    0px 1px 10px -1px rgba(0, 0, 0, 0.2);
+    0px 1px 10px 0px rgba(0, 0, 0, 0.2), 0px 1px 10px -1px rgba(0, 0, 0, 0.2);
   --osdk-dark-bp-surface-shadow-2:
     inset 0px 0px 0px 1px rgba(255, 255, 255, 0.2),
-    0px 4px 6px -4px rgba(0, 0, 0, 0.5),
-    0px 10px 30px -5px rgba(0, 0, 0, 0.5);
+    0px 4px 6px -4px rgba(0, 0, 0, 0.5), 0px 10px 30px -5px rgba(0, 0, 0, 0.5);
   --osdk-dark-bp-surface-shadow-3:
     inset 0px 0px 0px 1px rgba(255, 255, 255, 0.2),
-    0px 20px 25px -5px rgba(0, 0, 0, 0.3),
-    0px 10px 30px -5px rgba(0, 0, 0, 0.3);
+    0px 20px 25px -5px rgba(0, 0, 0, 0.3), 0px 10px 30px -5px rgba(0, 0, 0, 0.3);
   --osdk-dark-bp-surface-shadow-4:
     inset 0px 0px 0px 1px rgba(255, 255, 255, 0.2),
     0px 25px 60px -12px rgba(0, 0, 0, 0.85);
@@ -68,67 +57,12 @@
   );
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    /* --bp-* flips (Blueprint doesn't respond to prefers-color-scheme) */
-    --bp-surface-border-color-default: var(--osdk-dark-bp-surface-border-color-default);
-    --bp-surface-border-color-strong: var(--osdk-dark-bp-surface-border-color-strong);
-    --bp-surface-shadow-0: var(--osdk-dark-bp-surface-shadow-0);
-    --bp-surface-shadow-1: var(--osdk-dark-bp-surface-shadow-1);
-    --bp-surface-shadow-2: var(--osdk-dark-bp-surface-shadow-2);
-    --bp-surface-shadow-3: var(--osdk-dark-bp-surface-shadow-3);
-    --bp-surface-shadow-4: var(--osdk-dark-bp-surface-shadow-4);
-    --bp-surface-color-code: var(--osdk-dark-bp-surface-color-code);
-    --bp-surface-background-color-default-rest: var(--osdk-dark-bp-surface-background-color-default-rest);
-    --bp-surface-background-color-default-hover: var(--osdk-dark-bp-surface-background-color-default-hover);
-    --bp-surface-background-color-default-active: var(--osdk-dark-bp-surface-background-color-default-active);
-    --bp-surface-background-color-default-disabled: var(--osdk-dark-bp-surface-background-color-default-disabled);
-    --bp-typography-color-default-rest: var(--osdk-dark-bp-typography-color-default-rest);
-    --bp-typography-color-default-hover: var(--osdk-dark-bp-typography-color-default-hover);
-    --bp-typography-color-default-active: var(--osdk-dark-bp-typography-color-default-active);
-
-    /* --osdk-* overrides */
-    --osdk-background-primary: var(--osdk-dark-background-primary);
-    --osdk-background-secondary: var(--osdk-dark-background-secondary);
-    --osdk-background-tertiary: var(--osdk-dark-background-tertiary);
-    --osdk-typography-color-muted: var(--osdk-dark-typography-color-muted);
-    --osdk-intent-default-rest: var(--osdk-dark-intent-default-rest);
-    --osdk-intent-default-foreground: var(--osdk-dark-intent-default-foreground);
-    --osdk-button-secondary-bg: var(--osdk-dark-button-secondary-bg);
-    --osdk-button-secondary-color: var(--osdk-dark-button-secondary-color);
-    --osdk-table-row-bg-default: var(--osdk-dark-table-row-bg-default);
-    --osdk-table-header-bg: var(--osdk-dark-table-header-bg);
-    --osdk-table-header-color: var(--osdk-dark-table-header-color);
-    --osdk-table-cell-color: var(--osdk-dark-table-cell-color);
-    --osdk-table-header-menu-color: var(--osdk-dark-table-header-menu-color);
-    --osdk-table-border-color: var(--osdk-dark-table-border-color);
-    --osdk-table-cell-divider: var(--osdk-table-border-width) solid
-      var(--osdk-table-border-color);
-    --osdk-table-row-bg-hover: var(--osdk-dark-table-row-bg-hover);
-    --osdk-table-row-bg-active: var(--osdk-dark-table-row-bg-hover);
-  }
-}
-
-[data-theme="dark"] {
-  /* --bp-* flips (Blueprint doesn't respond to data-theme).
-     Mirrors the @media (prefers-color-scheme: dark) block above. */
-  --bp-surface-border-color-default: var(--osdk-dark-bp-surface-border-color-default);
-  --bp-surface-border-color-strong: var(--osdk-dark-bp-surface-border-color-strong);
-  --bp-surface-shadow-0: var(--osdk-dark-bp-surface-shadow-0);
-  --bp-surface-shadow-1: var(--osdk-dark-bp-surface-shadow-1);
-  --bp-surface-shadow-2: var(--osdk-dark-bp-surface-shadow-2);
-  --bp-surface-shadow-3: var(--osdk-dark-bp-surface-shadow-3);
-  --bp-surface-shadow-4: var(--osdk-dark-bp-surface-shadow-4);
-  --bp-surface-color-code: var(--osdk-dark-bp-surface-color-code);
-  --bp-surface-background-color-default-rest: var(--osdk-dark-bp-surface-background-color-default-rest);
-  --bp-surface-background-color-default-hover: var(--osdk-dark-bp-surface-background-color-default-hover);
-  --bp-surface-background-color-default-active: var(--osdk-dark-bp-surface-background-color-default-active);
-  --bp-surface-background-color-default-disabled: var(--osdk-dark-bp-surface-background-color-default-disabled);
-  --bp-typography-color-default-rest: var(--osdk-dark-bp-typography-color-default-rest);
-  --bp-typography-color-default-hover: var(--osdk-dark-bp-typography-color-default-hover);
-  --bp-typography-color-default-active: var(--osdk-dark-bp-typography-color-default-active);
-
-  /* --osdk-* overrides */
+[data-bp-color-scheme="dark"],
+.bp6-dark {
+  /* Blueprint already flips --bp-* under these selectors, so any --osdk-*
+     token derived from --bp-* (see base.css) cascades correctly. We only
+     set --osdk-* tokens that have no --bp-* counterpart or that
+     intentionally diverge from Blueprint's value. */
   --osdk-background-primary: var(--osdk-dark-background-primary);
   --osdk-background-secondary: var(--osdk-dark-background-secondary);
   --osdk-background-tertiary: var(--osdk-dark-background-tertiary);
@@ -149,12 +83,46 @@
   --osdk-table-row-bg-active: var(--osdk-dark-table-row-bg-hover);
 }
 
-[data-bp-color-scheme="dark"],
-.bp6-dark {
-  /* Blueprint already flips --bp-* under these selectors, so any --osdk-*
-     token derived from --bp-* (see base.css) cascades correctly. We only
-     set --osdk-* tokens that have no --bp-* counterpart or that
-     intentionally diverge from Blueprint's value. */
+/* Note: data-theme attribute is added to work with storybook themes
+ * It also flips `--bp-*` because Blueprint doesn't fire there.
+ */
+[data-theme="dark"] {
+  /* --bp-* flips (Blueprint doesn't respond to data-theme). */
+  --bp-surface-border-color-default: var(
+    --osdk-dark-bp-surface-border-color-default
+  );
+  --bp-surface-border-color-strong: var(
+    --osdk-dark-bp-surface-border-color-strong
+  );
+  --bp-surface-shadow-0: var(--osdk-dark-bp-surface-shadow-0);
+  --bp-surface-shadow-1: var(--osdk-dark-bp-surface-shadow-1);
+  --bp-surface-shadow-2: var(--osdk-dark-bp-surface-shadow-2);
+  --bp-surface-shadow-3: var(--osdk-dark-bp-surface-shadow-3);
+  --bp-surface-shadow-4: var(--osdk-dark-bp-surface-shadow-4);
+  --bp-surface-color-code: var(--osdk-dark-bp-surface-color-code);
+  --bp-surface-background-color-default-rest: var(
+    --osdk-dark-bp-surface-background-color-default-rest
+  );
+  --bp-surface-background-color-default-hover: var(
+    --osdk-dark-bp-surface-background-color-default-hover
+  );
+  --bp-surface-background-color-default-active: var(
+    --osdk-dark-bp-surface-background-color-default-active
+  );
+  --bp-surface-background-color-default-disabled: var(
+    --osdk-dark-bp-surface-background-color-default-disabled
+  );
+  --bp-typography-color-default-rest: var(
+    --osdk-dark-bp-typography-color-default-rest
+  );
+  --bp-typography-color-default-hover: var(
+    --osdk-dark-bp-typography-color-default-hover
+  );
+  --bp-typography-color-default-active: var(
+    --osdk-dark-bp-typography-color-default-active
+  );
+
+  /* --osdk-* overrides */
   --osdk-background-primary: var(--osdk-dark-background-primary);
   --osdk-background-secondary: var(--osdk-dark-background-secondary);
   --osdk-background-tertiary: var(--osdk-dark-background-tertiary);


### PR DESCRIPTION
Add `<OsdkThemeProvider>` and `useOsdkTheme` (from `@osdk/react-components/experimental/theme`) for opt-in theming. The provider seeds its state from `defaultTheme` (`"light" | "dark" | "system"`, defaults to `"system"`) and writes `data-bp-color-scheme` onto the document root — or a custom `target` — so OSDK and Blueprint tokens flip together. `"system"` follows `prefers-color-scheme` and reacts to OS changes at runtime; descendants switch modes by calling `setTheme` from `useOsdkTheme`.