### PR TITLE
Bump @osdk/foundry.* catalog 2.57.0 -> 2.61.0

### DIFF
--- a/.changeset/bump-foundry-platform-sdks.md
+++ b/.changeset/bump-foundry-platform-sdks.md
@@ -1,0 +1,18 @@
+---
+"@osdk/client": patch
+"@osdk/faux": patch
+"@osdk/foundry-sdk-generator": patch
+"@osdk/generator": patch
+"@osdk/generator-converters": patch
+"@osdk/generator-converters.ontologyir": patch
+"@osdk/generator-converters.preview": patch
+"@osdk/maker-import": patch
+"@osdk/react": patch
+"@osdk/react-sdk-docs": patch
+"@osdk/seed-compiler": patch
+"@osdk/typescript-sdk-docs": patch
+"@osdk/unit-testing": patch
+"@osdk/vite-plugin-oac": patch
+---
+
+Bump `@osdk/foundry.*` and `@osdk/internal.foundry.*` catalog entries from `2.57.0` to `2.61.0`. Includes type-fixups for the new `applyScenario` / `scenarioReference` discriminated-union variants and the now-required `QueryParameterV2.required` field.

--- a/packages/faux/src/FauxFoundry/typeHelpers/TH_ApplyActionRequestV2.ts
+++ b/packages/faux/src/FauxFoundry/typeHelpers/TH_ApplyActionRequestV2.ts
@@ -26,6 +26,7 @@ import type {
 
 type TH_ActionParameterType_Primitive<X extends ActionParameterType> = X extends
   { type: "attachment" } ? AttachmentRid
+  : X extends { type: "scenarioReference" } ? { scenarioRid: string }
   : ActionParam.PrimitiveType<
     Exclude<
       X["type"],
@@ -35,6 +36,7 @@ type TH_ActionParameterType_Primitive<X extends ActionParameterType> = X extends
       | "interfaceObject"
       | "attachment"
       | "vector"
+      | "scenarioReference"
     >
   >;
 
@@ -45,6 +47,7 @@ type TH_ActionParameterType<X extends ActionParameterType> = X extends
   : X extends { type: "objectSet" } ? string
   : X extends { type: "interfaceObject" }
     ? { objectTypeApiName: string; primaryKeyValue: string }
+  : X extends { type: "scenarioReference" } ? { scenarioRid: string }
   : TH_ActionParameterType_Primitive<X>;
 
 type TH_Parameters<X extends Record<ParameterId, ActionParameterV2>> =

--- a/packages/faux/src/FauxFoundry/validateAction.ts
+++ b/packages/faux/src/FauxFoundry/validateAction.ts
@@ -273,6 +273,20 @@ function validateActionParameterType(
       return;
     }
 
+    case "scenarioReference": {
+      if (
+        !value
+        || typeof value !== "object"
+        || typeof (value as { scenarioRid?: unknown }).scenarioRid !== "string"
+      ) {
+        ret.result = "INVALID";
+        ret.parameters[paramKey] = {
+          ...baseParam,
+        };
+      }
+      return;
+    }
+
     default: {
       const _assertNever: never = dataType;
       throw new Error(

--- a/packages/foundry-sdk-generator/src/ontologyMetadata/metadataResolver.test.ts
+++ b/packages/foundry-sdk-generator/src/ontologyMetadata/metadataResolver.test.ts
@@ -379,6 +379,7 @@ describe("Load Ontologies Metadata", () => {
                 "dataType": {
                   "type": "integer",
                 },
+                "required": true,
               },
             },
             "rid": "ri.function-registry.main.function.abd64ff3-276e-48c5-afee-5a6ef0b2ea47",
@@ -423,6 +424,7 @@ describe("Load Ontologies Metadata", () => {
                 "dataType": {
                   "type": "integer",
                 },
+                "required": true,
               },
             },
             "rid": "ri.function-registry.main.function.abd64ff3-276e-48c5-afee-5a6ef0b2ea47",

--- a/packages/foundry-sdk-generator/src/ontologyMetadata/ontologyMetadataResolver.ts
+++ b/packages/foundry-sdk-generator/src/ontologyMetadata/ontologyMetadataResolver.ts
@@ -837,6 +837,7 @@ export class OntologyMetadataResolver {
         return Result.ok({});
 
       case "vector":
+      case "scenarioReference":
         return Result.err([
           `Unable to load action ${actionApiName} because it takes an unsupported parameter: ${
             JSON.stringify(

--- a/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
@@ -464,6 +464,7 @@ export class OntologyIrToFullMetadataConverter {
         >((acc, input) => {
           acc[input.name] = {
             dataType: convertDataType(input.dataType, func.customTypes),
+            required: true,
           };
           return acc;
         }, {}),
@@ -606,6 +607,7 @@ export class OntologyIrToFullMetadataConverter {
               customTypes,
               input.required,
             ),
+            required: input.required ?? true,
           };
           return acc;
         }, {}),

--- a/packages/generator-converters/src/getEditedEntities.ts
+++ b/packages/generator-converters/src/getEditedEntities.ts
@@ -40,6 +40,7 @@ export function getModifiedEntityTypes(
       case "createInterfaceObject":
       case "modifyInterfaceObject":
       case "deleteInterfaceObject":
+      case "applyScenario":
         break;
       default:
         const _: never = operation;

--- a/packages/generator/src/util/test/TodoWireOntology.ts
+++ b/packages/generator/src/util/test/TodoWireOntology.ts
@@ -191,7 +191,7 @@ export const TodoWireOntology: WireOntologyDefinition = {
         type: "integer",
       },
       parameters: {
-        completed: { dataType: { type: "boolean" } },
+        completed: { dataType: { type: "boolean" }, required: true },
       },
       rid: "rid.query.1",
       version: "1.1.0",
@@ -212,6 +212,7 @@ export const TodoWireOntology: WireOntologyDefinition = {
             objectApiName: "Todo",
             objectTypeApiName: "Todo",
           },
+          required: true,
         },
       },
       rid: "rid.query.2",

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -483,6 +483,7 @@ const referencingOntology: WireOntologyDefinition = {
             objectApiName: "com.example.dep.Task",
             objectTypeApiName: "com.example.dep.Task",
           },
+          required: true,
         },
       },
       rid: "ri.a.b.c",

--- a/packages/generator/src/v2.0/generatePerQueryDataFiles.test.ts
+++ b/packages/generator/src/v2.0/generatePerQueryDataFiles.test.ts
@@ -252,9 +252,11 @@ describe("generatePerQueryDataFiles", () => {
                 parameters: {
                   foo: {
                     dataType: { type: "string" },
+                    required: true,
                   },
                   listField: {
                     dataType: { type: "array", "subType": { "type": "float" } },
+                    required: true,
                   },
                   nestedListField: {
                     dataType: {
@@ -264,6 +266,7 @@ describe("generatePerQueryDataFiles", () => {
                         "subType": { "type": "float" },
                       },
                     },
+                    required: true,
                   },
                   paramStruct: {
                     dataType: {
@@ -291,6 +294,7 @@ describe("generatePerQueryDataFiles", () => {
                         },
                       ],
                     },
+                    required: true,
                   },
                 },
                 output: {
@@ -560,6 +564,7 @@ describe("generatePerQueryDataFiles", () => {
                       type: "typeReference",
                       typeId: "tree-node-type-id",
                     },
+                    required: true,
                   },
                 },
                 output: {
@@ -715,6 +720,7 @@ describe("generatePerQueryDataFiles", () => {
                       type: "typeReference",
                       typeId: "binary-tree-id",
                     },
+                    required: true,
                   },
                   linkedList: {
                     description: "A linked list parameter",
@@ -722,6 +728,7 @@ describe("generatePerQueryDataFiles", () => {
                       type: "typeReference",
                       typeId: "linked-list-id",
                     },
+                    required: true,
                   },
                 },
                 output: {

--- a/packages/generator/src/v2.0/generatePerQueryDataFiles.ts
+++ b/packages/generator/src/v2.0/generatePerQueryDataFiles.ts
@@ -180,7 +180,10 @@ async function generateV2QueryFile(
 
             ${
       (() => {
-        const outputDef = paramToDef({ dataType: query.output });
+        const outputDef = paramToDef({
+          dataType: query.output,
+          required: true,
+        });
         const outputType = getQueryParamType(
           ontology,
           outputDef,

--- a/packages/react-components-storybook/src/mocks/fauxFoundry.ts
+++ b/packages/react-components-storybook/src/mocks/fauxFoundry.ts
@@ -423,6 +423,7 @@ export async function setupFauxFoundry(): Promise<void> {
             objectApiName: "Employee",
             objectTypeApiName: "Employee",
           },
+          required: true,
         },
       },
       output: {

--- a/packages/shared.test/src/stubs/queryTypes.ts
+++ b/packages/shared.test/src/stubs/queryTypes.ts
@@ -24,6 +24,7 @@ export const addOneQueryType: QueryTypeV2 = {
       dataType: {
         type: "integer",
       },
+      required: true,
     },
   },
   output: {
@@ -43,6 +44,7 @@ export const addOneQueryTypeOlderVersion: QueryTypeV2 = {
       dataType: {
         type: "integer",
       },
+      required: true,
     },
   },
   output: {
@@ -90,6 +92,7 @@ export const queryTypeReturnsStruct: QueryTypeV2 = {
           },
         ],
       },
+      required: true,
     },
   },
   output: {
@@ -173,6 +176,7 @@ export const queryTypeReturnsComplexStruct: QueryTypeV2 = {
           },
         ],
       },
+      required: true,
     },
   },
   output: {
@@ -321,6 +325,7 @@ export const queryTypeAcceptsTwoDimensionalAggregation: QueryTypeV2 = {
           type: "double",
         },
       },
+      required: true,
     },
   },
   output: {
@@ -360,6 +365,7 @@ export const queryTypeAcceptsThreeDimensionalAggregation: QueryTypeV2 = {
           },
         },
       },
+      required: true,
     },
   },
   output: {
@@ -396,6 +402,7 @@ export const queryTypeAcceptsObjects: QueryTypeV2 = {
         objectApiName: "Employee",
         objectTypeApiName: "Employee",
       },
+      required: true,
     },
   },
   output: {
@@ -419,6 +426,7 @@ export const queryTypeAcceptsInterfaces: QueryTypeV2 = {
         type: "interfaceObject",
         interfaceTypeApiName: "FooInterface",
       },
+      required: true,
     },
   },
   output: {
@@ -440,6 +448,7 @@ export const queryTypeAcceptsInterfaceObjectSet: QueryTypeV2 = {
         type: "interfaceObjectSet",
         interfaceTypeApiName: "FooInterface",
       },
+      required: true,
     },
   },
   output: {
@@ -459,6 +468,7 @@ export const queryTypeOutputsInterfaceObjectSet: QueryTypeV2 = {
       dataType: {
         type: "string",
       },
+      required: true,
     },
   },
   output: {
@@ -482,6 +492,7 @@ export const queryTypeAcceptsObjectSets: QueryTypeV2 = {
         objectApiName: "Employee",
         objectTypeApiName: "Employee",
       },
+      required: true,
     },
   },
   output: {
@@ -507,6 +518,7 @@ export const queryTypeReturnsArray: QueryTypeV2 = {
         "type": "array",
         "subType": { "type": "string" },
       },
+      "required": true,
     },
   },
   "rid":
@@ -531,6 +543,7 @@ export const queryTypeReturnsArrayOfObjects: QueryTypeV2 = {
         "type": "array",
         "subType": { "type": "string" },
       },
+      "required": true,
     },
   },
   "rid":
@@ -565,6 +578,7 @@ export const queryTypeReturnsMap: QueryTypeV2 = {
           type: "string",
         },
       },
+      "required": true,
     },
   },
   "rid":
@@ -594,6 +608,7 @@ export const queryTypeAcceptsMediaReference: QueryTypeV2 = {
       dataType: {
         type: "mediaReference",
       },
+      required: true,
     },
   },
   output: {
@@ -614,6 +629,7 @@ export const queryTypeReturnsRecursiveStruct: QueryTypeV2 = {
         type: "typeReference",
         typeId: "recursive-tree-node",
       },
+      required: true,
     },
   },
   output: {
@@ -663,12 +679,14 @@ export const queryTypeWithMultipleTypeRefs: QueryTypeV2 = {
         type: "typeReference",
         typeId: "binary-tree-node",
       },
+      required: true,
     },
     linkedList: {
       dataType: {
         type: "typeReference",
         typeId: "linked-list-node",
       },
+      required: true,
     },
   },
   output: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,35 +13,35 @@ catalogs:
       specifier: 0.17.0
       version: 0.17.0
     '@osdk/foundry':
-      specifier: 2.57.0
-      version: 2.57.0
+      specifier: 2.61.0
+      version: 2.61.0
     '@osdk/foundry.admin':
-      specifier: 2.57.0
-      version: 2.57.0
+      specifier: 2.61.0
+      version: 2.61.0
     '@osdk/foundry.core':
-      specifier: 2.57.0
-      version: 2.57.0
+      specifier: 2.61.0
+      version: 2.61.0
     '@osdk/foundry.datasets':
       specifier: ~2.5.0
       version: 2.5.0
     '@osdk/foundry.functions':
-      specifier: 2.57.0
-      version: 2.57.0
+      specifier: 2.61.0
+      version: 2.61.0
     '@osdk/foundry.geo':
-      specifier: 2.57.0
-      version: 2.57.0
+      specifier: 2.61.0
+      version: 2.61.0
     '@osdk/foundry.mediasets':
-      specifier: 2.57.0
-      version: 2.57.0
+      specifier: 2.61.0
+      version: 2.61.0
     '@osdk/foundry.ontologies':
-      specifier: 2.57.0
-      version: 2.57.0
+      specifier: 2.61.0
+      version: 2.61.0
     '@osdk/foundry.thirdpartyapplications':
-      specifier: 2.57.0
-      version: 2.57.0
+      specifier: 2.61.0
+      version: 2.61.0
     '@osdk/internal.foundry.ontologies':
-      specifier: 2.57.0
-      version: 2.57.0
+      specifier: 2.61.0
+      version: 2.61.0
 
 overrides:
   trim@0.0.1: 0.0.3
@@ -1821,7 +1821,7 @@ importers:
         version: link:../cli.common
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/generator':
         specifier: workspace:~
         version: link:../generator
@@ -1904,16 +1904,16 @@ importers:
         version: link:../client.unstable
       '@osdk/foundry.core':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/foundry.functions':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/foundry.mediasets':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/generator-converters':
         specifier: workspace:*
         version: link:../generator-converters
@@ -3264,7 +3264,7 @@ importers:
         version: link:../e2e.generated.catchall
       '@osdk/foundry':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/functions':
         specifier: workspace:~
         version: link:../functions
@@ -3771,25 +3771,25 @@ importers:
         version: link:../api
       '@osdk/foundry.admin':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/foundry.core':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/foundry.geo':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/foundry.mediasets':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/generator-converters':
         specifier: workspace:~
         version: link:../generator-converters
       '@osdk/internal.foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -3884,10 +3884,10 @@ importers:
         version: link:../client.unstable.tpsa
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/foundry.thirdpartyapplications':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/generator':
         specifier: workspace:*
         version: link:../generator
@@ -4006,7 +4006,7 @@ importers:
         version: link:../api
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/generator-converters':
         specifier: workspace:~
         version: link:../generator-converters
@@ -4055,7 +4055,7 @@ importers:
         version: link:../api
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
     devDependencies:
       '@osdk/monorepo.api-extractor':
         specifier: workspace:~
@@ -4080,7 +4080,7 @@ importers:
         version: link:../client.unstable
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       consola:
         specifier: ^3.4.2
         version: 3.4.2
@@ -4114,7 +4114,7 @@ importers:
         version: link:../client.unstable
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/generator':
         specifier: workspace:~
         version: link:../generator
@@ -4311,7 +4311,7 @@ importers:
         version: link:../client.unstable
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/maker':
         specifier: workspace:~
         version: link:../maker
@@ -4582,10 +4582,10 @@ importers:
         version: link:../client.test.ontology
       '@osdk/foundry.admin':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/foundry.core':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/monorepo.api-extractor':
         specifier: workspace:~
         version: link:../monorepo.api-extractor
@@ -4970,7 +4970,7 @@ importers:
     dependencies:
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/seed-helpers':
         specifier: workspace:~
         version: link:../seed-helpers
@@ -5116,19 +5116,19 @@ importers:
         version: link:../api
       '@osdk/foundry.core':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/foundry.geo':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/generator-converters':
         specifier: workspace:~
         version: link:../generator-converters
       '@osdk/internal.foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -5456,7 +5456,7 @@ importers:
         version: link:../client.test.ontology
       '@osdk/foundry.admin':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/functions':
         specifier: workspace:~
         version: link:../functions
@@ -5510,7 +5510,7 @@ importers:
         version: link:../faux
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.57.0
+        version: 2.61.0
       '@osdk/generator-converters.ontologyir':
         specifier: workspace:*
         version: link:../generator-converters.ontologyir
@@ -8931,35 +8931,35 @@ packages:
   '@osdk/docs-spec-sdk@0.17.0':
     resolution: {integrity: sha512-uiC2wfUf3i2tQ9wQlcgwLOxHObdjxfwwvy4X04N0tZnpnXEIn7zIIa7WJqpcNUMH3g07tJLEu/wZNdUgxCnS2Q==}
 
-  '@osdk/foundry.admin@2.57.0':
-    resolution: {integrity: sha512-LyR85rpQ52EacoTHGsd4GSfiA6SfWp97rlSIdr8XN9NiBEmmaTyhXezAH6Sc/F0SIL4YLmxfmjqa9IT+mMI/hw==}
-
   '@osdk/foundry.admin@2.60.0':
     resolution: {integrity: sha512-ZmuFQwTldmSg9SAep9HPjANZhhg6Yc45Yn1VarIbY7/QsB0vQpeQamZInnXHMi0Ea4EqcrDgTX9Z7HRy6lobAw==}
 
-  '@osdk/foundry.aipagents@2.57.0':
-    resolution: {integrity: sha512-oTkP+E1XylusVPtBDQYfZDj5eUjsnq+EzEaPrm9hE7eQnhfRRrzEzE1jKSh3+f/7mVPdT58PbC3J7Kc2VPZ+ag==}
+  '@osdk/foundry.admin@2.61.0':
+    resolution: {integrity: sha512-r9DmH4HklcYSy5GU36L9Kk/gxV5oCXzVc0MuVifYqZkJVzKyAmNZiWOPCeXAhEXD75P14QbcNaWPGLJz511MlA==}
 
   '@osdk/foundry.aipagents@2.60.0':
     resolution: {integrity: sha512-xQ/bDoYT8PxIm4Q+ed4jErhrOPckB30bC9e6bteGjh9jSrSEGo3CdDUyvjFH3UeshV2Iw46fjhYtRHnKKmrF7w==}
 
-  '@osdk/foundry.audit@2.57.0':
-    resolution: {integrity: sha512-jA3HlLI0sRQaXZ+4G6N74s5kho+SUNN2sfVNYWo4TE1lTPKZleLmIdZ/1eS+3jLYwjHmK1cjd4SsCNg7CiQe6g==}
+  '@osdk/foundry.aipagents@2.61.0':
+    resolution: {integrity: sha512-LTnx6OkLqPPGIHoicnCErcDcguIpjdDPirmjLdw2WVK3Z7hClZrmTT8jcPdC5gd1GI69uH89jgF/z0GJ/Uhlug==}
 
   '@osdk/foundry.audit@2.60.0':
     resolution: {integrity: sha512-LE2yQwBNCbDy2nCSVCZdIuXJKIHfyIPgK+HfIl8tPVYBp9XQFd0Uh10CRYbLvN8hGhDxVWHttWNRWzoU0YhMkQ==}
 
-  '@osdk/foundry.checkpoints@2.57.0':
-    resolution: {integrity: sha512-hg8172mUUS8fbXCVph6Z6NXd3TwfDSCw6p9y9iLgcTJ1BeLHhx/mJb51FeUfTee1j+/McCGpRpGyKApPPeM4aQ==}
+  '@osdk/foundry.audit@2.61.0':
+    resolution: {integrity: sha512-vTAbUxavVCqaJPdC7vrr6LSUoXI3vBn4aBgqrKxovg6GLPQJ4kfXbDRif4SeDE1xlDJl6JxGLVlWo6yEWkok7w==}
 
   '@osdk/foundry.checkpoints@2.60.0':
     resolution: {integrity: sha512-T/qQYT0MfCfTzxozJw7J1GtSTLD0/9DQmDMfei5yy4w7HRfsO0YOcs+lv3suFCzRq3d7auMyIdUmAEGqBUJlUA==}
 
-  '@osdk/foundry.connectivity@2.57.0':
-    resolution: {integrity: sha512-n1DxUk9JJLqo2MLDs5oWDAKmuhEdJNjVBjlntLJM9EPPsDgP/SS5UQFjETHWNuPW9kk3b0GR59qs6/Si2wmsQA==}
+  '@osdk/foundry.checkpoints@2.61.0':
+    resolution: {integrity: sha512-mTDHzGnyZMogYJJqtgs+tYqVGyhdj2LLs2O+zyUqr5Jm8BhR+iqpwLn68XCOIlEdQI90iG2VR6arSBY6Q27uRQ==}
 
   '@osdk/foundry.connectivity@2.60.0':
     resolution: {integrity: sha512-nSorz8iYfQT7yWZLy1ZCqUXRcCSeNA2GW7SyFQ9N7wsosP5aMTADaBx1iQh7lLLbjOqRuknf0M+in87+himWeQ==}
+
+  '@osdk/foundry.connectivity@2.61.0':
+    resolution: {integrity: sha512-mMGmQ5OygKCDlaDd6KTJBRRiN1qOndQdXkD+WZ0O3G1czxsG36fhOiVxP0KxAcAyGk4lS7YLZSUzcCjdvSO8Zg==}
 
   '@osdk/foundry.core@2.44.0':
     resolution: {integrity: sha512-fdDAm2pdf67DWo32sXBcfwujAxb7YOKI4iUQ99C1JW92SQRqNBbQZQlM10RJYQ7LMq6S9P1Gz6Gx7KRV7I5Zpw==}
@@ -8967,41 +8967,41 @@ packages:
   '@osdk/foundry.core@2.5.0':
     resolution: {integrity: sha512-LV+m6/3Y+Q0lN16PAwQvoWtutY0xXdntuwOQjMR2ZqdLRlZOK2KSvfwNZnX4q8EKuvF1mJC8iaTtWh3lChpU1Q==}
 
-  '@osdk/foundry.core@2.57.0':
-    resolution: {integrity: sha512-5oNC5ey1hcLt6OlpmgR3En9RpMJbQXnD4tj3T/Qkp7Q3SWJLSrIei9Jc4Qg0wGOH4anhU07U1uB2hyEAs3i4Ew==}
-
   '@osdk/foundry.core@2.60.0':
     resolution: {integrity: sha512-jYEZpXI7HMxlRyYZYbvSpFDXlQ8+eUn0vNE1DqtAVe4n0zQ+qFuAEit53KfO1kktWSG8NQZtepUt7jcOOYoLOQ==}
 
-  '@osdk/foundry.datahealth@2.57.0':
-    resolution: {integrity: sha512-jWIrdph//86mG3jwSQSDQuZO/2FP4tWdWDyNzPbr4JDi3gRVD5psSv3aHg+nqYoLjIHxkq81yuzSY+4ef+HxpA==}
+  '@osdk/foundry.core@2.61.0':
+    resolution: {integrity: sha512-Q/4JEUubWBvc3GeEXpiOa6c1NCUeHdmzL8sZPnFQ7P6zWHictjt3bm6+Zjnuk27WDMy4Zx4ywxqMzuOA1VBSIw==}
 
   '@osdk/foundry.datahealth@2.60.0':
     resolution: {integrity: sha512-ZPtdwLMTXRInAo079YcJ9oKfdWPXDQy3XDsGLt/IwloM0Hb7xasgQzVw8a7pMxAGnjzs04HdVhjDJd4s+fD79w==}
 
+  '@osdk/foundry.datahealth@2.61.0':
+    resolution: {integrity: sha512-CErzW0JhT5fBs1nDLF87qyJ7TqPfIDhHT1uahij5/taiDejHLDxDuymSrKxgpljTk4ST1hSYyS5fO1ZhQi3eJg==}
+
   '@osdk/foundry.datasets@2.5.0':
     resolution: {integrity: sha512-W82xleLQgQFUTVnAQS54n26xUFEALayotl1f3LGeRLN6r+2G1dNp+UgRU7/IHc/xzOqgulEOGwwr6ENFcsNP2A==}
-
-  '@osdk/foundry.datasets@2.57.0':
-    resolution: {integrity: sha512-ECizSkpjQFsIHVjASCHWB9cpbgsKOIdcYwZCIcQaZ+cIpmA7StGWcRASvEm0osRzd2dThuo9ZdeXowYXJWGvTA==}
 
   '@osdk/foundry.datasets@2.60.0':
     resolution: {integrity: sha512-2r1pIjO7xCNa6+fsCRFCOEqgequST0VBC7wXL+UZN8RGZska3WTI3NLE/eJSnYJuMbyblxnkRHlpWCHyROEm7A==}
 
+  '@osdk/foundry.datasets@2.61.0':
+    resolution: {integrity: sha512-Y5NqCDgkC/ubXzxoHloZ2in33oil9h6f6uNLtGliBNLfgFtL4EYzOvPfOido9mxWJmPjYMjx1xOfC4w1CqwrzQ==}
+
   '@osdk/foundry.filesystem@2.5.0':
     resolution: {integrity: sha512-SJKZSfBc7CroyoIVW3D2SpVyaCCnhv8onzIwHcJWOnufFgSbQ3kqyWoqNiStGlymmnoSbniK3rfUFFYeUbxhDQ==}
-
-  '@osdk/foundry.filesystem@2.57.0':
-    resolution: {integrity: sha512-bEt1HZP05farbpyhrQKamjeXeZhB4TtwYaF+GRodY3If7LldMgoJgeTx/09NFX9HQPeZ2JxoBJ1GYEjABbgdOg==}
 
   '@osdk/foundry.filesystem@2.60.0':
     resolution: {integrity: sha512-K/yDJNDZ2qNRK7XcKidtbNrdpCeKkr7z6DqUzIGJEcnVKZWaKtQGn+/YyjHWwxE6Fy0xm6cZlMAKXomrXtFpLw==}
 
-  '@osdk/foundry.functions@2.57.0':
-    resolution: {integrity: sha512-abssxEIVODRh2goWm7LZQckjjP3lpxgSIYyhjqPV//gUBFCA7XBNTHPba/+/ka+qmSRZbJ+1ONOUIAO0/X1brA==}
+  '@osdk/foundry.filesystem@2.61.0':
+    resolution: {integrity: sha512-VspLl32FowTu2s/Ltjv0HDsJS/xP+ho7Mw/SrldeoAZMRbNrfyn6b+z55Tpu66ePjM9/iSi915TH1wueC20mQw==}
 
   '@osdk/foundry.functions@2.60.0':
     resolution: {integrity: sha512-SNSKbx4XuDMvvfYNCcj9yek5y+jZyEjmL2M7yDGxJhzjdEk0zkrjnEIpx3YTSJf79/29faJ79fyeBpzfhuNGxQ==}
+
+  '@osdk/foundry.functions@2.61.0':
+    resolution: {integrity: sha512-GAmZYPF3vr+x66ylvn2GfU69Qhtzmfp0moXRV2trBzfTBLsqjiwr0O0A9zpKf7SKJ1lf/RGrHpxrkznt04lrrA==}
 
   '@osdk/foundry.geo@2.44.0':
     resolution: {integrity: sha512-eXiBR2YAesPJe5amQy6G/pz0i4kmgJXiCAocMSYsgVKm/8kuMaqDUn5UJIFYo7EdjLVJueiMAFyCdN0wpK3SZA==}
@@ -9009,107 +9009,107 @@ packages:
   '@osdk/foundry.geo@2.5.0':
     resolution: {integrity: sha512-kL615eqHvn1MkP0le2r6vx/ub+lit5bKdmoWNRELMqi9s2BlLuoKAQW5H9YDQPqhHuJDjrBJAWiviOin9mUKqw==}
 
-  '@osdk/foundry.geo@2.57.0':
-    resolution: {integrity: sha512-zXw8vOdOa0duHopZJV9N9WGx5ApRhj2QSGWjY+dYOS+Xw5xyOXJ7m5gEtlFzJCXTJsi8rqwMRFvq5SI2oYpOsw==}
-
   '@osdk/foundry.geo@2.60.0':
     resolution: {integrity: sha512-/Hy00Lo5RNjY8zlQX7VDb7qfvDHztqtXoVytK5Gc78WwgMN4lfA1D5WgFlUEBs0+2JGeKtgdeO+orVhfV3epoA==}
 
-  '@osdk/foundry.geojson@2.57.0':
-    resolution: {integrity: sha512-7uzWBKJXCkJRGadQrKyj01Vu6nUrUQgdO8nVbUHbRKd+jwZRSN+tjwo62Xen7o20cL3AJv1gZE633/ow+zi4lQ==}
+  '@osdk/foundry.geo@2.61.0':
+    resolution: {integrity: sha512-1TsMIHzyBMCGMLiEk0uDhFVdFZ0e2rBIVPzG4tz7pD6bFKs/IqyresEQSK9t7AqlYRiF6+BPmj8CqA9V++SiAg==}
 
   '@osdk/foundry.geojson@2.60.0':
     resolution: {integrity: sha512-2K8KP6jPFjADoikcO9l88uwUKz96HjukKM6AqfdrKq3Jsdn2ljzXZsgYY9/11TS/Sfbvj/I8pcDb9OuLG/UYiw==}
 
-  '@osdk/foundry.languagemodels@2.57.0':
-    resolution: {integrity: sha512-Ag11jyPDeooq/pfoVAI2IeAH4E2/JTnCmpmEj3PMeNYEd7ps0eh/O60WpEdZ9SDye3FSSLZluQ+PrYEDmfTwqg==}
+  '@osdk/foundry.geojson@2.61.0':
+    resolution: {integrity: sha512-PojLYA0bG7e4MrR2/B/PkHMOFNm1YliAMs5ZWTwHf+jbzKkDtu0DDsNxyR3r3vSkJAxgG7LMPreMtuLU7mYbgw==}
 
   '@osdk/foundry.languagemodels@2.60.0':
     resolution: {integrity: sha512-ImmNdqRWa6atvwkG2mRfy4HZ6vy1AhpwUECHAQxoHKrijy6ceGRgjm9h4lMj8EVTw3FY44kTEDmxy88+OkcWEA==}
 
+  '@osdk/foundry.languagemodels@2.61.0':
+    resolution: {integrity: sha512-yGqW3jCPUfmDOdiRDTb93f2oTqhG8lgjvDFCpQievfUykZfn1MXkwIMdrNL6VT80BJ1JtHlF+1xG8a+oRiSnWQ==}
+
   '@osdk/foundry.mediasets@2.44.0':
     resolution: {integrity: sha512-l378lxKUdIMmb1txFs/hOKyPO3bc10OWU4BvaP/LMZjXLbUZPNI/DYAmKrzKTeSMGBnZ2luhqEyfPfZYMGmrhw==}
-
-  '@osdk/foundry.mediasets@2.57.0':
-    resolution: {integrity: sha512-VU5G5sRN2/454KX80Nr+rtq2mO697hTD8Az4w7pwgklaBi9Wky+asHJBH9PZ7wvDwYOQVKpRc+3BnNd49MzhyQ==}
 
   '@osdk/foundry.mediasets@2.60.0':
     resolution: {integrity: sha512-7hPoHOXvHK0KGo+PhSVIUuD+HE/3AOWylNIHtQT/VMomG+IT60Kl9tMVW+9x7b9u/+vnDs19nW30/xGBLIDMdQ==}
 
-  '@osdk/foundry.models@2.57.0':
-    resolution: {integrity: sha512-CwL1urLk76TAtxGydA1Ssv5BomYeTUPqq1QtxIlPsX2dLP2SZ2hQHdFBk/5JbJBkQk75kX0V7WzF2KeyOdR2iA==}
+  '@osdk/foundry.mediasets@2.61.0':
+    resolution: {integrity: sha512-BkVxU6u7SpM62gYXyLcIQWrovgagh5UnIeeFqdeGqAru2EtiyS5O6gj6noEyMOFFyKvMoO6litGTSbg0NdRUIQ==}
 
   '@osdk/foundry.models@2.60.0':
     resolution: {integrity: sha512-+MYa9mJij6AijIbwAPtWxwUkD2WFxS9AmOxEAz/1vCGRMJYyiH7iYPWm7ZjQLb2OFRZjwD/PG0SbSheeXqGenA==}
 
-  '@osdk/foundry.notepad@2.57.0':
-    resolution: {integrity: sha512-BAA7LXsJmFTZss2jBhoPYe3gsUaxqupBfAhJLtkAYZirJXKzlJm53DFzD64ck61TBxLGT1OxbNZPr4Wltgl+cw==}
+  '@osdk/foundry.models@2.61.0':
+    resolution: {integrity: sha512-ZrMig1yAhripuCAFnlONwhuK0O11knsNCNaEDFbqvkmYRG+r3Km+0wsSIjWj1Cr3Em8Ky9jhm1oUmEUakmKlYA==}
 
   '@osdk/foundry.notepad@2.60.0':
     resolution: {integrity: sha512-/kFXlcumh93KKnhGysH3Z4PEQ3skVzosi7/n5YZW05JELV+WbbUZwf7YjNFrYFhBINUMf2My62sbxrUT/DVFdA==}
 
+  '@osdk/foundry.notepad@2.61.0':
+    resolution: {integrity: sha512-eNK33lY0y9FxNDctFmFh4rRCl+0n+Xv+NrUDrBrWd9xNnW/kRu9sIP2P8lJBHtxAv4kUYM9QK9xa8pW6Wj5u2g==}
+
   '@osdk/foundry.ontologies@2.44.0':
     resolution: {integrity: sha512-A74NrG3tDiLNC5VW+plchrrMDf5gLekavrdyVnmVqQAkcBc6Z8/Jl+92rJbQ/v6TJnXWpCwuCkc+QQXaYlhHKQ==}
-
-  '@osdk/foundry.ontologies@2.57.0':
-    resolution: {integrity: sha512-yAQqEY1EhtVg7tEAW7tqVikNr2EMjDEdDX3ApSTXTU0vCB3FqYL0q4++p/nbnZ+9BbSus1WkrqBclGEhe6G+/w==}
 
   '@osdk/foundry.ontologies@2.60.0':
     resolution: {integrity: sha512-5oyJjXdu3zeJgHtAXWotWrBWbMwo61SZZQ0+1dePJcKXdsFAY9bjZCciQRjTI8acuujey67LEkDbmLZrHMKY8w==}
 
-  '@osdk/foundry.operations@2.57.0':
-    resolution: {integrity: sha512-MPheImqC/sU3XvHakyTN36A+Dg6aIr9aN9CHne7/BLoQuUczp0+z2mlBDz9nJ2E3v7UVJQQquckIU6SpeLN8CA==}
+  '@osdk/foundry.ontologies@2.61.0':
+    resolution: {integrity: sha512-uWhjFEuqNP7yKDg4qYPTa0B5m7ezkkLmiI+At8KEK8X/Jm9e3B1CS4Gf7ySMJjOqTZkt3pTWteNsLN9czsJPpg==}
 
   '@osdk/foundry.operations@2.60.0':
     resolution: {integrity: sha512-VemA7JxBBIyQ1ZbP3QGCSnduNN3ApBkJ3D7mWjK39yhXI/J31/hAi7nH0mY+iqjJ1KluWOP8k5JCEN/MIPWuPg==}
 
-  '@osdk/foundry.orchestration@2.57.0':
-    resolution: {integrity: sha512-+pLuT+CxrEJqziAcieQzOOAD8+2Q+GJsB29W812wpXhnByo1epRWkD/irlSUgtQCzgnFwbusV3tFk0RrUb4TKQ==}
+  '@osdk/foundry.operations@2.61.0':
+    resolution: {integrity: sha512-63OI7ZZjHJJ+YUzfDKQyklEz9cgACSOj7qtrOAm68xMjh/gWvwTdaVQ3P2Rpa9znfVgCn7T74Cu3QpsXFznieQ==}
 
   '@osdk/foundry.orchestration@2.60.0':
     resolution: {integrity: sha512-vbyH2qHTUo3g1JISHsSXl8q5leK6xLOJoVwL0pFWfnsqPOlyQBIG4AzStykuTx1B2s940efId+tXsibDuJA4Mw==}
 
-  '@osdk/foundry.pack@2.57.0':
-    resolution: {integrity: sha512-jeSpPpgxzkrlmk4sIicpRazALG44CghdAuB1v9k+L9fWmauuVGmbmgloid5j1HpicQnXPf6UKw7+zoAyyydvIg==}
+  '@osdk/foundry.orchestration@2.61.0':
+    resolution: {integrity: sha512-EK3ypV+sKtXwFaK1RP/wtRgygADvQpIk2dclWWSb3s6QACVaBwuAEBPZa/RgkNGmGjskuvHnokMXz9TSeuy6UA==}
 
   '@osdk/foundry.pack@2.60.0':
     resolution: {integrity: sha512-xnekyyVMHYKi/EpN7A1ArVMCiW2YzEos7sCdxkS2bgQjtqIwmuKgsKllGV9j6ZGOnJAO++M5Wdr8QfLpDbgiPg==}
 
-  '@osdk/foundry.publicapis@2.57.0':
-    resolution: {integrity: sha512-80vRswyI0pOmgvdxCwkigtdE9SWj96UT5X8u7Xe0UDcNxUtG7xGBNUWfCCdoWnIUTn+poZcZG/q99xV4L15Hpg==}
+  '@osdk/foundry.pack@2.61.0':
+    resolution: {integrity: sha512-I7A6x7HKW+BX2duQeQXiVgS5+d4qQHo7KUF4QPiV7ttT+AijzC68EJzF9Lot+qIU5k2PxjqTzl+BtfhwAMNupA==}
 
   '@osdk/foundry.publicapis@2.60.0':
     resolution: {integrity: sha512-MAZKd6VCE4gZ9pd88hI4MaBksFmQ3NrCzkY63pYqd6B+javPmE0NpSl7c5AUemdpRjK3DjH7NwK9OZD+09N6/g==}
 
-  '@osdk/foundry.sqlqueries@2.57.0':
-    resolution: {integrity: sha512-44iSHaaFBLUPcrFsXqagn4XK5CajGMzXsFj7YQH/cQAhgNhoXnoNT0t64RxKL2XFwjrBMxL/qYiTF8t9AxQP9Q==}
+  '@osdk/foundry.publicapis@2.61.0':
+    resolution: {integrity: sha512-odufei5olkyaWLI2bBEio3c5xJU1J9acKRQYnYPd7IvJJp0ME7Sd8tJOFVDKXn6+HBAyLKaG3b6xSzF+nR3RAg==}
 
   '@osdk/foundry.sqlqueries@2.60.0':
     resolution: {integrity: sha512-CV+QsywkrHDRqkwYWVz36FT1tB414KhMxvp8JwJ4w7XNPw2inYx+QbAh4q3COMQlJUWvHV0jEj2CxS/rNGsrPQ==}
 
-  '@osdk/foundry.streams@2.57.0':
-    resolution: {integrity: sha512-yjuDeuSRjtDRqrTEbBmA6vicl+L7OY4+p6FSo5r5KjFQB92QVN6o97bxXITdkzLFdPoK6ErKepwqa3skUEGARw==}
+  '@osdk/foundry.sqlqueries@2.61.0':
+    resolution: {integrity: sha512-am3uhgEWDZatFmX2LPg3N570u5QY6P7IYJKcN5CBffxcYUvWAjDTpAEckwbOL4l9GoXB1DwAUTdiG+yYR3pVpQ==}
 
   '@osdk/foundry.streams@2.60.0':
     resolution: {integrity: sha512-BwzS5PodbNbHIB6WjTfNO7vIjWM3KyMBT8dA/JZkMHKCto0KW6kImR3WfpkKhSJy+NkHBTg7H3byuM4glbulMQ==}
 
-  '@osdk/foundry.thirdpartyapplications@2.57.0':
-    resolution: {integrity: sha512-zzkG1iLJL+OQ+9c3RcwyP7FD+mgq41v8eWPmHFGCVgfpHmIUMDMN1/sChYHe5R12wTpbY0jgYyHfdGaSjpoo0w==}
+  '@osdk/foundry.streams@2.61.0':
+    resolution: {integrity: sha512-ICr2lgRj+1o5IwWNZfu/fcbXyjYyCbjDS+R/JBJbpJuyLtr9HD0xYQy8/hK20axeCdEeJhJHDB6OYWqFdSWo3w==}
 
   '@osdk/foundry.thirdpartyapplications@2.60.0':
     resolution: {integrity: sha512-6UOU2dGwpJYhUlqRY5YXOG64xhLCWgt/CTp16/eRz2VI2iMF2LB5kIF519v0xcn06DOiA2K6gxkfXXrmmisriQ==}
 
-  '@osdk/foundry.widgets@2.57.0':
-    resolution: {integrity: sha512-YaTROCzrp5TpCcslN2hJOholsc68VEtN1YawiAOQo9TuksKBDHdcw74/mDdr7ZjAuGtlwhcrNVaQ1plmIf2qWQ==}
+  '@osdk/foundry.thirdpartyapplications@2.61.0':
+    resolution: {integrity: sha512-auJwrE3AyQGrS9YpShrP7kGCOSEWwvvtZq6ojLXXyE+h1sqZuRxqCX7XXFUSFg+q9a9nfFA1J3PeFOWmwlkI2Q==}
 
   '@osdk/foundry.widgets@2.60.0':
     resolution: {integrity: sha512-D4cn5lngZcqR5Ih92JmbclsOpnrbyavHgs/1a0U1M6Dn+GVX9ZsJJLAOyt5TVz6wdVDIZcA5C9glaKTD7jF4Ag==}
 
-  '@osdk/foundry@2.57.0':
-    resolution: {integrity: sha512-vnp1iOm3CQDD0BQHPRQ1N8C6iT915K/8/EFXz6OdTJCnFlEaK0znm41MRRbhMQP6afj9rWXdAfJuhle4Q9cW7w==}
+  '@osdk/foundry.widgets@2.61.0':
+    resolution: {integrity: sha512-cPsDM3QHHh6CcPVqPVSD1Mr6JHKyozGCd6wrJuZzweALeLNXCQluDaUSTPWIeQYjDlHD57Xzpo/+Wvb3TjhP8w==}
 
   '@osdk/foundry@2.60.0':
     resolution: {integrity: sha512-h81o9KtDrDr9xeAsXr5mvUNhxPZ6ZosHGC+j39hCprxeU0MZXBgpwFX+FcXBNsBY/p8ucEGwGRIz5Hk0nzlNfQ==}
+
+  '@osdk/foundry@2.61.0':
+    resolution: {integrity: sha512-8ABTvt4/P+CMNgE1SqvWZXktuC1B7niv5dUUCwLR4jYe8lQRHXRrFZq8AiphDy42mh8/glD+9TVrRKvB29cEhA==}
 
   '@osdk/gateway@2.4.2':
     resolution: {integrity: sha512-A2WmRHxzCiZKyviYKAQEq9KZwL5DEkhXADLt36lMn2tGixO5qOTU7rLsE+OAA4va+evmd44TfzipJs8ieffP6g==}
@@ -9117,14 +9117,14 @@ packages:
   '@osdk/generator-converters@2.7.5':
     resolution: {integrity: sha512-dtvqVN3ufdwgsz2BlQwoTpCHuftnAQMbjAqDA/cT1wnW5wCWeo8ctxhl0ArCfM4jbGhiz9OcspHajuDC07IStw==}
 
-  '@osdk/internal.foundry.core@2.57.0':
-    resolution: {integrity: sha512-j5AhSWBoy9BeBbwQmdg/8ZudCYoW8lLlG6DLDScEBWDVRBaJpXBnSYF2tC56lst9m2ip+/zWfAeZceJV2KdIdw==}
+  '@osdk/internal.foundry.core@2.61.0':
+    resolution: {integrity: sha512-+MZSwnXEvu+6OG7csN4rfZrVvqEbQ8dTq9gdZDkv2S2K6Hl2nTwr4TTC7/ljphcDigOMocpKh/HIEdw/+0YZgA==}
 
-  '@osdk/internal.foundry.geo@2.57.0':
-    resolution: {integrity: sha512-x+BG9//QSXKi6hTR0LweTVfBKprvG/W/5yaofEvwkC5XkI5Zac8jf9ADEHD9/FrenoX9gUuuoF2y3FbuTTrCNw==}
+  '@osdk/internal.foundry.geo@2.61.0':
+    resolution: {integrity: sha512-KmgmAvRKeiZP3OhIBE3JDWkQ+Z0rkboe23I0PRH4AGUkSKIMG/mRsejqmZhPdiaz6/fofU7LX4bqMbLvNYocKQ==}
 
-  '@osdk/internal.foundry.ontologies@2.57.0':
-    resolution: {integrity: sha512-ZCk5x1iwT5pVi4jhuqdxs9G9IB9i+bqv/fzMufP8H+u6v+S5X6DrDzGI3HayPZwUVsX+fwsJP07OLGYoMpld8A==}
+  '@osdk/internal.foundry.ontologies@2.61.0':
+    resolution: {integrity: sha512-dkGh7EHjH5CRbnSITzBnlw14nWoRG3MTlA9CDIMGmSvUtbwShGwpIJBDG3Xx9d8cSxr1/vSpC7mYptM6fub/vA==}
 
   '@osdk/legacy-client@2.5.6':
     resolution: {integrity: sha512-QPeCcuqCv+s6toIxWMRArKJx35bzvcpoKAqsQ6YYiFEiGn43vLoQQGbeMlnqcGYfdbljyzeOoDxZtgVIn6a8HA==}
@@ -26063,13 +26063,6 @@ snapshots:
     dependencies:
       '@osdk/docs-spec-core': 0.6.0
 
-  '@osdk/foundry.admin@2.57.0':
-    dependencies:
-      '@osdk/foundry.core': 2.57.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.6.0
-
   '@osdk/foundry.admin@2.60.0':
     dependencies:
       '@osdk/foundry.core': 2.60.0
@@ -26077,11 +26070,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.aipagents@2.57.0':
+  '@osdk/foundry.admin@2.61.0':
     dependencies:
-      '@osdk/foundry.core': 2.57.0
-      '@osdk/foundry.functions': 2.57.0
-      '@osdk/foundry.ontologies': 2.57.0
+      '@osdk/foundry.core': 2.61.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26095,9 +26086,11 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.audit@2.57.0':
+  '@osdk/foundry.aipagents@2.61.0':
     dependencies:
-      '@osdk/foundry.core': 2.57.0
+      '@osdk/foundry.core': 2.61.0
+      '@osdk/foundry.functions': 2.61.0
+      '@osdk/foundry.ontologies': 2.61.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26109,9 +26102,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.checkpoints@2.57.0':
+  '@osdk/foundry.audit@2.61.0':
     dependencies:
-      '@osdk/foundry.core': 2.57.0
+      '@osdk/foundry.core': 2.61.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26123,10 +26116,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.connectivity@2.57.0':
+  '@osdk/foundry.checkpoints@2.61.0':
     dependencies:
-      '@osdk/foundry.core': 2.57.0
-      '@osdk/foundry.filesystem': 2.57.0
+      '@osdk/foundry.core': 2.61.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26135,6 +26127,14 @@ snapshots:
     dependencies:
       '@osdk/foundry.core': 2.60.0
       '@osdk/foundry.filesystem': 2.60.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
+  '@osdk/foundry.connectivity@2.61.0':
+    dependencies:
+      '@osdk/foundry.core': 2.61.0
+      '@osdk/foundry.filesystem': 2.61.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26153,13 +26153,6 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.1.0
 
-  '@osdk/foundry.core@2.57.0':
-    dependencies:
-      '@osdk/foundry.geo': 2.57.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.6.0
-
   '@osdk/foundry.core@2.60.0':
     dependencies:
       '@osdk/foundry.geo': 2.60.0
@@ -26167,9 +26160,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.datahealth@2.57.0':
+  '@osdk/foundry.core@2.61.0':
     dependencies:
-      '@osdk/foundry.core': 2.57.0
+      '@osdk/foundry.geo': 2.61.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26177,6 +26170,13 @@ snapshots:
   '@osdk/foundry.datahealth@2.60.0':
     dependencies:
       '@osdk/foundry.core': 2.60.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
+  '@osdk/foundry.datahealth@2.61.0':
+    dependencies:
+      '@osdk/foundry.core': 2.61.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26189,20 +26189,20 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.1.0
 
-  '@osdk/foundry.datasets@2.57.0':
-    dependencies:
-      '@osdk/foundry.core': 2.57.0
-      '@osdk/foundry.datahealth': 2.57.0
-      '@osdk/foundry.filesystem': 2.57.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.6.0
-
   '@osdk/foundry.datasets@2.60.0':
     dependencies:
       '@osdk/foundry.core': 2.60.0
       '@osdk/foundry.datahealth': 2.60.0
       '@osdk/foundry.filesystem': 2.60.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
+  '@osdk/foundry.datasets@2.61.0':
+    dependencies:
+      '@osdk/foundry.core': 2.61.0
+      '@osdk/foundry.datahealth': 2.61.0
+      '@osdk/foundry.filesystem': 2.61.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26214,13 +26214,6 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.1.0
 
-  '@osdk/foundry.filesystem@2.57.0':
-    dependencies:
-      '@osdk/foundry.core': 2.57.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.6.0
-
   '@osdk/foundry.filesystem@2.60.0':
     dependencies:
       '@osdk/foundry.core': 2.60.0
@@ -26228,10 +26221,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.functions@2.57.0':
+  '@osdk/foundry.filesystem@2.61.0':
     dependencies:
-      '@osdk/foundry.core': 2.57.0
-      '@osdk/foundry.ontologies': 2.57.0
+      '@osdk/foundry.core': 2.61.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26240,6 +26232,14 @@ snapshots:
     dependencies:
       '@osdk/foundry.core': 2.60.0
       '@osdk/foundry.ontologies': 2.60.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
+  '@osdk/foundry.functions@2.61.0':
+    dependencies:
+      '@osdk/foundry.core': 2.61.0
+      '@osdk/foundry.ontologies': 2.61.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26256,19 +26256,13 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.1.0
 
-  '@osdk/foundry.geo@2.57.0':
-    dependencies:
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.6.0
-
   '@osdk/foundry.geo@2.60.0':
     dependencies:
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.geojson@2.57.0':
+  '@osdk/foundry.geo@2.61.0':
     dependencies:
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
@@ -26280,9 +26274,8 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.languagemodels@2.57.0':
+  '@osdk/foundry.geojson@2.61.0':
     dependencies:
-      '@osdk/foundry.core': 2.57.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26294,19 +26287,19 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
+  '@osdk/foundry.languagemodels@2.61.0':
+    dependencies:
+      '@osdk/foundry.core': 2.61.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
   '@osdk/foundry.mediasets@2.44.0':
     dependencies:
       '@osdk/foundry.core': 2.44.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.5.0
-
-  '@osdk/foundry.mediasets@2.57.0':
-    dependencies:
-      '@osdk/foundry.core': 2.57.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.6.0
 
   '@osdk/foundry.mediasets@2.60.0':
     dependencies:
@@ -26315,11 +26308,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.models@2.57.0':
+  '@osdk/foundry.mediasets@2.61.0':
     dependencies:
-      '@osdk/foundry.core': 2.57.0
-      '@osdk/foundry.filesystem': 2.57.0
-      '@osdk/foundry.orchestration': 2.57.0
+      '@osdk/foundry.core': 2.61.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26334,11 +26325,12 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.notepad@2.57.0':
+  '@osdk/foundry.models@2.61.0':
     dependencies:
-      '@osdk/foundry.core': 2.57.0
-      '@osdk/foundry.filesystem': 2.57.0
-      '@osdk/foundry.ontologies': 2.57.0
+      '@osdk/foundry.core': 2.61.0
+      '@osdk/foundry.filesystem': 2.61.0
+      '@osdk/foundry.ontologies': 2.61.0
+      '@osdk/foundry.orchestration': 2.61.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26352,6 +26344,15 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
+  '@osdk/foundry.notepad@2.61.0':
+    dependencies:
+      '@osdk/foundry.core': 2.61.0
+      '@osdk/foundry.filesystem': 2.61.0
+      '@osdk/foundry.ontologies': 2.61.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
   '@osdk/foundry.ontologies@2.44.0':
     dependencies:
       '@osdk/foundry.core': 2.44.0
@@ -26359,14 +26360,6 @@ snapshots:
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.5.0
-
-  '@osdk/foundry.ontologies@2.57.0':
-    dependencies:
-      '@osdk/foundry.core': 2.57.0
-      '@osdk/foundry.geo': 2.57.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.6.0
 
   '@osdk/foundry.ontologies@2.60.0':
     dependencies:
@@ -26376,9 +26369,10 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.operations@2.57.0':
+  '@osdk/foundry.ontologies@2.61.0':
     dependencies:
-      '@osdk/foundry.ontologies': 2.57.0
+      '@osdk/foundry.core': 2.61.0
+      '@osdk/foundry.geo': 2.61.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26390,11 +26384,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.orchestration@2.57.0':
+  '@osdk/foundry.operations@2.61.0':
     dependencies:
-      '@osdk/foundry.core': 2.57.0
-      '@osdk/foundry.datasets': 2.57.0
-      '@osdk/foundry.filesystem': 2.57.0
+      '@osdk/foundry.ontologies': 2.61.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26408,10 +26400,11 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.pack@2.57.0':
+  '@osdk/foundry.orchestration@2.61.0':
     dependencies:
-      '@osdk/foundry.core': 2.57.0
-      '@osdk/foundry.filesystem': 2.57.0
+      '@osdk/foundry.core': 2.61.0
+      '@osdk/foundry.datasets': 2.61.0
+      '@osdk/foundry.filesystem': 2.61.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26424,9 +26417,10 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.publicapis@2.57.0':
+  '@osdk/foundry.pack@2.61.0':
     dependencies:
-      '@osdk/foundry.core': 2.57.0
+      '@osdk/foundry.core': 2.61.0
+      '@osdk/foundry.filesystem': 2.61.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26438,10 +26432,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.sqlqueries@2.57.0':
+  '@osdk/foundry.publicapis@2.61.0':
     dependencies:
-      '@osdk/foundry.core': 2.57.0
-      '@osdk/foundry.datasets': 2.57.0
+      '@osdk/foundry.core': 2.61.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26454,11 +26447,10 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.streams@2.57.0':
+  '@osdk/foundry.sqlqueries@2.61.0':
     dependencies:
-      '@osdk/foundry.core': 2.57.0
-      '@osdk/foundry.datasets': 2.57.0
-      '@osdk/foundry.filesystem': 2.57.0
+      '@osdk/foundry.core': 2.61.0
+      '@osdk/foundry.datasets': 2.61.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26472,9 +26464,11 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.thirdpartyapplications@2.57.0':
+  '@osdk/foundry.streams@2.61.0':
     dependencies:
-      '@osdk/foundry.core': 2.57.0
+      '@osdk/foundry.core': 2.61.0
+      '@osdk/foundry.datasets': 2.61.0
+      '@osdk/foundry.filesystem': 2.61.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26486,9 +26480,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.widgets@2.57.0':
+  '@osdk/foundry.thirdpartyapplications@2.61.0':
     dependencies:
-      '@osdk/foundry.core': 2.57.0
+      '@osdk/foundry.core': 2.61.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26500,33 +26494,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry@2.57.0':
+  '@osdk/foundry.widgets@2.61.0':
     dependencies:
-      '@osdk/foundry.admin': 2.57.0
-      '@osdk/foundry.aipagents': 2.57.0
-      '@osdk/foundry.audit': 2.57.0
-      '@osdk/foundry.checkpoints': 2.57.0
-      '@osdk/foundry.connectivity': 2.57.0
-      '@osdk/foundry.core': 2.57.0
-      '@osdk/foundry.datahealth': 2.57.0
-      '@osdk/foundry.datasets': 2.57.0
-      '@osdk/foundry.filesystem': 2.57.0
-      '@osdk/foundry.functions': 2.57.0
-      '@osdk/foundry.geo': 2.57.0
-      '@osdk/foundry.geojson': 2.57.0
-      '@osdk/foundry.languagemodels': 2.57.0
-      '@osdk/foundry.mediasets': 2.57.0
-      '@osdk/foundry.models': 2.57.0
-      '@osdk/foundry.notepad': 2.57.0
-      '@osdk/foundry.ontologies': 2.57.0
-      '@osdk/foundry.operations': 2.57.0
-      '@osdk/foundry.orchestration': 2.57.0
-      '@osdk/foundry.pack': 2.57.0
-      '@osdk/foundry.publicapis': 2.57.0
-      '@osdk/foundry.sqlqueries': 2.57.0
-      '@osdk/foundry.streams': 2.57.0
-      '@osdk/foundry.thirdpartyapplications': 2.57.0
-      '@osdk/foundry.widgets': 2.57.0
+      '@osdk/foundry.core': 2.61.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -26562,6 +26532,37 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
+  '@osdk/foundry@2.61.0':
+    dependencies:
+      '@osdk/foundry.admin': 2.61.0
+      '@osdk/foundry.aipagents': 2.61.0
+      '@osdk/foundry.audit': 2.61.0
+      '@osdk/foundry.checkpoints': 2.61.0
+      '@osdk/foundry.connectivity': 2.61.0
+      '@osdk/foundry.core': 2.61.0
+      '@osdk/foundry.datahealth': 2.61.0
+      '@osdk/foundry.datasets': 2.61.0
+      '@osdk/foundry.filesystem': 2.61.0
+      '@osdk/foundry.functions': 2.61.0
+      '@osdk/foundry.geo': 2.61.0
+      '@osdk/foundry.geojson': 2.61.0
+      '@osdk/foundry.languagemodels': 2.61.0
+      '@osdk/foundry.mediasets': 2.61.0
+      '@osdk/foundry.models': 2.61.0
+      '@osdk/foundry.notepad': 2.61.0
+      '@osdk/foundry.ontologies': 2.61.0
+      '@osdk/foundry.operations': 2.61.0
+      '@osdk/foundry.orchestration': 2.61.0
+      '@osdk/foundry.pack': 2.61.0
+      '@osdk/foundry.publicapis': 2.61.0
+      '@osdk/foundry.sqlqueries': 2.61.0
+      '@osdk/foundry.streams': 2.61.0
+      '@osdk/foundry.thirdpartyapplications': 2.61.0
+      '@osdk/foundry.widgets': 2.61.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.6.0
+
   '@osdk/gateway@2.4.2':
     dependencies:
       fetch-retry: 6.0.0
@@ -26572,23 +26573,23 @@ snapshots:
       '@osdk/api': 2.7.5
       '@osdk/foundry.ontologies': 2.44.0
 
-  '@osdk/internal.foundry.core@2.57.0':
+  '@osdk/internal.foundry.core@2.61.0':
     dependencies:
-      '@osdk/internal.foundry.geo': 2.57.0
+      '@osdk/internal.foundry.geo': 2.61.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/internal.foundry.geo@2.57.0':
+  '@osdk/internal.foundry.geo@2.61.0':
     dependencies:
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/internal.foundry.ontologies@2.57.0':
+  '@osdk/internal.foundry.ontologies@2.61.0':
     dependencies:
-      '@osdk/internal.foundry.core': 2.57.0
-      '@osdk/internal.foundry.geo': 2.57.0
+      '@osdk/internal.foundry.core': 2.61.0
+      '@osdk/internal.foundry.geo': 2.61.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,13 +22,13 @@ catalogs:
   foundry-platform-typescript:
     "@osdk/docs-spec-core": 0.6.0
     "@osdk/docs-spec-sdk": 0.17.0
-    "@osdk/foundry": 2.57.0
-    "@osdk/foundry.core": 2.57.0
+    "@osdk/foundry": 2.61.0
+    "@osdk/foundry.core": 2.61.0
     "@osdk/foundry.datasets": ~2.5.0
-    "@osdk/foundry.functions": 2.57.0
-    "@osdk/foundry.geo": 2.57.0
-    "@osdk/foundry.admin": 2.57.0
-    "@osdk/foundry.mediasets": 2.57.0
-    "@osdk/foundry.ontologies": 2.57.0
-    "@osdk/foundry.thirdpartyapplications": 2.57.0
-    "@osdk/internal.foundry.ontologies": 2.57.0
+    "@osdk/foundry.functions": 2.61.0
+    "@osdk/foundry.geo": 2.61.0
+    "@osdk/foundry.admin": 2.61.0
+    "@osdk/foundry.mediasets": 2.61.0
+    "@osdk/foundry.ontologies": 2.61.0
+    "@osdk/foundry.thirdpartyapplications": 2.61.0
+    "@osdk/internal.foundry.ontologies": 2.61.0


### PR DESCRIPTION
## Summary

Bumps the `foundry-platform-typescript` catalog from 2.57.0 to 2.61.0 so `@osdk/foundry.ontologies` exposes the new `OntologyScenarios` namespace (`createScenario`, `listScenarioEditedEntityTypes`, `listScenarioEditedObjects`, `listScenarioEditedLinkTypes`, `listScenarioEditedLinks`) and the `scenarioRid` query parameter on `Actions.apply` / `OntologyObjectSets.*` / `Queries.execute`. Fixes the breakages this introduces across the monorepo: new `applyScenario` variant in `LogicRule`, new `scenarioReference` variant in `ActionParameterType`, and `QueryParameterV2.required` becoming a required field on test stubs.

## Usage

No new user-facing API in this PR — it's a catalog bump and prep for the scenarios series. Consumers of the bumped SDK can now import:

\`\`\`ts
import { OntologyScenarios } from "@osdk/foundry.ontologies";

await OntologyScenarios.createScenario(ctx, ontologyRid, {});

await OntologyScenarios.listScenarioEditedEntityTypes(ctx, ontologyRid, scenarioRid);
\`\`\`

## Test plan

- [x] \`pnpm turbo typecheck\` — all 202 tasks pass
- [x] \`pnpm turbo test --filter=@osdk/client\` — 795/795 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)