### PR TITLE
Scenarios: getEditedEntities + editedEntitiesAsyncIter (beta)

### DIFF
--- a/.changeset/scenarios-edited-entities.md
+++ b/.changeset/scenarios-edited-entities.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": minor
+---
+
+Add `getEditedEntityTypes`, `getEditedEntities` (paginated), and `editedEntitiesAsyncIter` (auto-paginating, deduped) methods to `ScenarioClient`. Lets consumers discover which object types and primary keys have been edited within a scenario for diff and merge workflows. Beta — surface may change.

--- a/packages/client/src/scenarios/ScenarioClient.test.ts
+++ b/packages/client/src/scenarios/ScenarioClient.test.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Employee } from "@osdk/client.test.ontology";
+import type { MockedFunction } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Client } from "../Client.js";
+import { createClient } from "../createClient.js";
+import { mockFetchResponse } from "../createClient.test.js";
+import { withScenario } from "./withScenario.js";
+
+describe("ScenarioClient methods", () => {
+  const ontologyRid = "ri.not.important";
+  let fetchFunction: MockedFunction<typeof globalThis.fetch>;
+  let client: Client;
+
+  beforeEach(() => {
+    fetchFunction = vi.fn();
+    client = createClient(
+      "https://mock.com",
+      ontologyRid,
+      async () => "Token",
+      undefined,
+      fetchFunction,
+    );
+  });
+
+  describe("getEditedEntityTypes", () => {
+    it("calls the editedEntityTypes endpoint and returns the response shape", async () => {
+      const scenario = withScenario(client, "ri.actions..scenario.abc");
+      mockFetchResponse(fetchFunction, {
+        objectTypes: ["Employee", "Office"],
+        linkTypes: [{ objectType: "Employee", linkType: "manages" }],
+      });
+
+      const result = await scenario.getEditedEntityTypes();
+
+      expect(fetchFunction).toHaveBeenCalledTimes(1);
+      const url = new URL(
+        fetchFunction.mock.calls[0][0] as string,
+        "https://mock.com",
+      );
+      expect(url.pathname).toMatch(
+        /\/scenarios\/ri\.actions\.\.scenario\.abc\/editedEntityTypes$/,
+      );
+      expect(result.objectTypes).toEqual(["Employee", "Office"]);
+      expect(result.linkTypes).toEqual([
+        { objectType: "Employee", linkType: "manages" },
+      ]);
+    });
+  });
+
+  describe("getEditedEntities (page form)", () => {
+    it("calls the listScenarioEditedObjects endpoint with pageSize/pageToken", async () => {
+      const scenario = withScenario(client, "ri.actions..scenario.abc");
+      mockFetchResponse(fetchFunction, {
+        data: [],
+        nextPageToken: "tok-2",
+      });
+
+      const result = await scenario.getEditedEntities(Employee, {
+        pageSize: 100,
+        pageToken: "tok-1",
+      });
+
+      expect(fetchFunction).toHaveBeenCalledTimes(1);
+      const url = new URL(
+        fetchFunction.mock.calls[0][0] as string,
+        "https://mock.com",
+      );
+      expect(url.pathname).toMatch(
+        /\/scenarios\/ri\.actions\.\.scenario\.abc\/objects\/Employee\/edited$/,
+      );
+      expect(url.searchParams.get("pageSize")).toBe("100");
+      expect(url.searchParams.get("pageToken")).toBe("tok-1");
+      expect(result.nextPageToken).toBe("tok-2");
+      expect(result.data).toEqual([]);
+    });
+  });
+
+  describe("editedEntitiesAsyncIter", () => {
+    it("walks pages until nextPageToken is absent", async () => {
+      const scenario = withScenario(client, "ri.actions..scenario.abc");
+
+      // Page 1: token present
+      mockFetchResponse(fetchFunction, {
+        data: [],
+        nextPageToken: "tok-2",
+      });
+      // Page 2: token absent → iter terminates
+      mockFetchResponse(fetchFunction, {
+        data: [],
+      });
+
+      const keys: unknown[] = [];
+      for await (const obj of scenario.editedEntitiesAsyncIter(Employee)) {
+        keys.push(obj.$primaryKey);
+      }
+
+      expect(keys).toEqual([]);
+      expect(fetchFunction).toHaveBeenCalledTimes(2);
+      // Second call carries the pageToken from the first response
+      const secondUrl = new URL(
+        fetchFunction.mock.calls[1][0] as string,
+        "https://mock.com",
+      );
+      expect(secondUrl.searchParams.get("pageToken")).toBe("tok-2");
+    });
+
+    it("terminates when nextPageToken is absent on the first response", async () => {
+      const scenario = withScenario(client, "ri.actions..scenario.abc");
+      mockFetchResponse(fetchFunction, {
+        data: [],
+      });
+
+      const keys: unknown[] = [];
+      for await (const obj of scenario.editedEntitiesAsyncIter(Employee)) {
+        keys.push(obj.$primaryKey);
+      }
+
+      expect(keys).toEqual([]);
+      expect(fetchFunction).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/client/src/scenarios/ScenarioClient.test.ts
+++ b/packages/client/src/scenarios/ScenarioClient.test.ts
@@ -113,13 +113,13 @@ describe("ScenarioClient methods", () => {
         data: [
           { __apiName: "Employee", __primaryKey: 1 },
           { __apiName: "Employee", __primaryKey: 2 },
-          { __apiName: "Employee", __primaryKey: 2 }, // intra-page dupe
+          { __apiName: "Employee", __primaryKey: 2 },
         ],
         nextPageToken: "tok-2",
       };
       const page2: ListScenarioEditedObjectsResponse = {
         data: [
-          { __apiName: "Employee", __primaryKey: 2 }, // cross-page dupe
+          { __apiName: "Employee", __primaryKey: 2 },
           { __apiName: "Employee", __primaryKey: 3 },
         ],
       };

--- a/packages/client/src/scenarios/ScenarioClient.test.ts
+++ b/packages/client/src/scenarios/ScenarioClient.test.ts
@@ -69,7 +69,10 @@ describe("ScenarioClient methods", () => {
     it("calls the listScenarioEditedObjects endpoint with pageSize/pageToken", async () => {
       const scenario = withScenario(client, "ri.actions..scenario.abc");
       mockFetchResponse(fetchFunction, {
-        data: [],
+        data: [
+          { __apiName: "Employee", __primaryKey: 50030 },
+          { __apiName: "Employee", __primaryKey: 50031 },
+        ],
         nextPageToken: "tok-2",
       });
 
@@ -89,22 +92,30 @@ describe("ScenarioClient methods", () => {
       expect(url.searchParams.get("pageSize")).toBe("100");
       expect(url.searchParams.get("pageToken")).toBe("tok-1");
       expect(result.nextPageToken).toBe("tok-2");
-      expect(result.data).toEqual([]);
+      expect(result.data).toEqual([
+        { $apiName: "Employee", $primaryKey: 50030 },
+        { $apiName: "Employee", $primaryKey: 50031 },
+      ]);
     });
   });
 
   describe("editedEntitiesAsyncIter", () => {
-    it("walks pages until nextPageToken is absent", async () => {
+    it("paginates and dedupes by $primaryKey across pages", async () => {
       const scenario = withScenario(client, "ri.actions..scenario.abc");
 
-      // Page 1: token present
       mockFetchResponse(fetchFunction, {
-        data: [],
+        data: [
+          { __apiName: "Employee", __primaryKey: 1 },
+          { __apiName: "Employee", __primaryKey: 2 },
+          { __apiName: "Employee", __primaryKey: 2 }, // intra-page dupe
+        ],
         nextPageToken: "tok-2",
       });
-      // Page 2: token absent → iter terminates
       mockFetchResponse(fetchFunction, {
-        data: [],
+        data: [
+          { __apiName: "Employee", __primaryKey: 2 }, // cross-page dupe
+          { __apiName: "Employee", __primaryKey: 3 },
+        ],
       });
 
       const keys: unknown[] = [];
@@ -112,9 +123,8 @@ describe("ScenarioClient methods", () => {
         keys.push(obj.$primaryKey);
       }
 
-      expect(keys).toEqual([]);
+      expect(keys).toEqual([1, 2, 3]);
       expect(fetchFunction).toHaveBeenCalledTimes(2);
-      // Second call carries the pageToken from the first response
       const secondUrl = new URL(
         fetchFunction.mock.calls[1][0] as string,
         "https://mock.com",
@@ -125,7 +135,7 @@ describe("ScenarioClient methods", () => {
     it("terminates when nextPageToken is absent on the first response", async () => {
       const scenario = withScenario(client, "ri.actions..scenario.abc");
       mockFetchResponse(fetchFunction, {
-        data: [],
+        data: [{ __apiName: "Employee", __primaryKey: 42 }],
       });
 
       const keys: unknown[] = [];
@@ -133,7 +143,7 @@ describe("ScenarioClient methods", () => {
         keys.push(obj.$primaryKey);
       }
 
-      expect(keys).toEqual([]);
+      expect(keys).toEqual([42]);
       expect(fetchFunction).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/client/src/scenarios/ScenarioClient.test.ts
+++ b/packages/client/src/scenarios/ScenarioClient.test.ts
@@ -15,6 +15,10 @@
  */
 
 import { Employee } from "@osdk/client.test.ontology";
+import type {
+  ListScenarioEditedEntityTypesResponse,
+  ListScenarioEditedObjectsResponse,
+} from "@osdk/foundry.ontologies";
 import type { MockedFunction } from "vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Client } from "../Client.js";
@@ -41,12 +45,13 @@ describe("ScenarioClient methods", () => {
   describe("getEditedEntityTypes", () => {
     it("calls the editedEntityTypes endpoint and returns the response shape", async () => {
       const scenario = withScenario(client, "ri.actions..scenario.abc");
-      mockFetchResponse(fetchFunction, {
+      const mock: ListScenarioEditedEntityTypesResponse = {
         objectTypes: ["Employee", "Office"],
         linkTypes: [
           { objectTypeApiName: "Employee", linkTypes: ["manages", "lead"] },
         ],
-      });
+      };
+      mockFetchResponse(fetchFunction, mock);
 
       const result = await scenario.getEditedEntityTypes();
 
@@ -68,13 +73,14 @@ describe("ScenarioClient methods", () => {
   describe("getEditedEntities (page form)", () => {
     it("calls the listScenarioEditedObjects endpoint with pageSize/pageToken", async () => {
       const scenario = withScenario(client, "ri.actions..scenario.abc");
-      mockFetchResponse(fetchFunction, {
+      const mock: ListScenarioEditedObjectsResponse = {
         data: [
           { __apiName: "Employee", __primaryKey: 50030 },
           { __apiName: "Employee", __primaryKey: 50031 },
         ],
         nextPageToken: "tok-2",
-      });
+      };
+      mockFetchResponse(fetchFunction, mock);
 
       const result = await scenario.getEditedEntities(Employee, {
         pageSize: 100,
@@ -103,20 +109,22 @@ describe("ScenarioClient methods", () => {
     it("paginates and dedupes by $primaryKey across pages", async () => {
       const scenario = withScenario(client, "ri.actions..scenario.abc");
 
-      mockFetchResponse(fetchFunction, {
+      const page1: ListScenarioEditedObjectsResponse = {
         data: [
           { __apiName: "Employee", __primaryKey: 1 },
           { __apiName: "Employee", __primaryKey: 2 },
           { __apiName: "Employee", __primaryKey: 2 }, // intra-page dupe
         ],
         nextPageToken: "tok-2",
-      });
-      mockFetchResponse(fetchFunction, {
+      };
+      const page2: ListScenarioEditedObjectsResponse = {
         data: [
           { __apiName: "Employee", __primaryKey: 2 }, // cross-page dupe
           { __apiName: "Employee", __primaryKey: 3 },
         ],
-      });
+      };
+      mockFetchResponse(fetchFunction, page1);
+      mockFetchResponse(fetchFunction, page2);
 
       const keys: unknown[] = [];
       for await (const obj of scenario.editedEntitiesAsyncIter(Employee)) {
@@ -134,9 +142,10 @@ describe("ScenarioClient methods", () => {
 
     it("terminates when nextPageToken is absent on the first response", async () => {
       const scenario = withScenario(client, "ri.actions..scenario.abc");
-      mockFetchResponse(fetchFunction, {
+      const mock: ListScenarioEditedObjectsResponse = {
         data: [{ __apiName: "Employee", __primaryKey: 42 }],
-      });
+      };
+      mockFetchResponse(fetchFunction, mock);
 
       const keys: unknown[] = [];
       for await (const obj of scenario.editedEntitiesAsyncIter(Employee)) {

--- a/packages/client/src/scenarios/ScenarioClient.test.ts
+++ b/packages/client/src/scenarios/ScenarioClient.test.ts
@@ -43,7 +43,9 @@ describe("ScenarioClient methods", () => {
       const scenario = withScenario(client, "ri.actions..scenario.abc");
       mockFetchResponse(fetchFunction, {
         objectTypes: ["Employee", "Office"],
-        linkTypes: [{ objectType: "Employee", linkType: "manages" }],
+        linkTypes: [
+          { objectTypeApiName: "Employee", linkTypes: ["manages", "lead"] },
+        ],
       });
 
       const result = await scenario.getEditedEntityTypes();
@@ -58,7 +60,7 @@ describe("ScenarioClient methods", () => {
       );
       expect(result.objectTypes).toEqual(["Employee", "Office"]);
       expect(result.linkTypes).toEqual([
-        { objectType: "Employee", linkType: "manages" },
+        { objectTypeApiName: "Employee", linkTypes: ["manages", "lead"] },
       ]);
     });
   });

--- a/packages/client/src/scenarios/ScenarioClient.ts
+++ b/packages/client/src/scenarios/ScenarioClient.ts
@@ -14,9 +14,37 @@
  * limitations under the License.
  */
 
+import type { ObjectTypeDefinition, Osdk } from "@osdk/api";
+import type {
+  ObjectTypeApiName,
+  ObjectTypeLinkTypeApiNameMapping,
+  OntologyObjectV2,
+} from "@osdk/foundry.ontologies";
+import { OntologyScenarios } from "@osdk/foundry.ontologies";
 import { additionalContext, type Client } from "../Client.js";
 import { createClientWithScenario } from "../createClient.js";
 import type { MinimalClient } from "../MinimalClientContext.js";
+
+/**
+ * The object types and link types that have been modified within a scenario. Returned by
+ * {@link EXPERIMENTAL_ScenarioClient.getEditedEntityTypes}. Only many-to-many link type edits are surfaced via
+ * `linkTypes`; one-to-many edits surface as object edits on the object type that owns the foreign key property.
+ */
+export interface ScenarioEditedEntityTypes {
+  objectTypes: ObjectTypeApiName[];
+  linkTypes: ObjectTypeLinkTypeApiNameMapping[];
+}
+
+/**
+ * A page of objects edited within a scenario for a given object type. Returned by
+ * {@link EXPERIMENTAL_ScenarioClient.getEditedEntities}. The instances are sparse: only `$primaryKey` and `$apiName`
+ * are populated. Use {@link Client.call} (e.g. `scenario(MyObject).where({ $primaryKey: { $in: keys } }).fetchPage()`)
+ * to load full objects under the scenario context.
+ */
+export interface EditedEntitiesPage<Q extends ObjectTypeDefinition> {
+  data: Osdk.Instance<Q>[];
+  nextPageToken?: string;
+}
 
 /**
  * A {@link Client} attached to an ontology scenario. All read and write operations performed via this client are
@@ -29,6 +57,64 @@ export interface EXPERIMENTAL_ScenarioClient extends Client {
    * The scenario RID this client is scoped to.
    */
   getScenarioReference(): string;
+
+  /**
+   * List the object types and many-to-many link types that have been modified within this scenario. Useful as a
+   * pre-step before paginating individual edited objects per type.
+   */
+  getEditedEntityTypes(): Promise<ScenarioEditedEntityTypes>;
+
+  /**
+   * Get a page of objects that have been edited within this scenario for a given object type. Each instance only
+   * carries `$primaryKey` and `$apiName`; load full objects via the scenario client itself.
+   *
+   * @example
+   * ```ts
+   * let pageToken: string | undefined;
+   * const keys: string[] = [];
+   * do {
+   *   const page = await scenario.getEditedEntities(Doctor, { pageSize: 500, pageToken });
+   *   keys.push(...page.data.map(o => o.$primaryKey as string));
+   *   pageToken = page.nextPageToken;
+   * } while (pageToken);
+   * ```
+   */
+  getEditedEntities<Q extends ObjectTypeDefinition>(
+    objectType: Q,
+    options?: { pageSize?: number; pageToken?: string },
+  ): Promise<EditedEntitiesPage<Q>>;
+
+  /**
+   * Stream the objects edited within this scenario for a given object type. Pages are fetched lazily and
+   * deduplicated by `$primaryKey` across pages (Funnel may return duplicates).
+   *
+   * @example
+   * ```ts
+   * for await (const obj of scenario.editedEntitiesAsyncIter(Doctor, { pageSize: 500 })) {
+   *   // obj.$primaryKey is the unique key for this edited object
+   * }
+   * ```
+   */
+  editedEntitiesAsyncIter<Q extends ObjectTypeDefinition>(
+    objectType: Q,
+    options?: { pageSize?: number },
+  ): AsyncIterableIterator<Osdk.Instance<Q>>;
+}
+
+async function convertSparseEditedObjects<Q extends ObjectTypeDefinition>(
+  innerCtx: MinimalClient,
+  data: OntologyObjectV2[],
+): Promise<Osdk.Instance<Q>[]> {
+  if (data.length === 0) return [];
+  const converted = await innerCtx.objectFactory(
+    innerCtx,
+    data,
+    undefined,
+    {},
+    undefined,
+    true,
+  );
+  return converted as unknown as Osdk.Instance<Q>[];
 }
 
 /**
@@ -67,9 +153,72 @@ export function buildScenarioClient(
     ctx.fetch,
   );
 
+  const innerCtx: MinimalClient = inner[additionalContext];
+
+  async function getEditedEntityTypes(): Promise<ScenarioEditedEntityTypes> {
+    const ontologyRid = await innerCtx.ontologyRid;
+    const response = await OntologyScenarios.listScenarioEditedEntityTypes(
+      innerCtx,
+      ontologyRid,
+      scenarioRid,
+    );
+    return {
+      objectTypes: response.objectTypes as ObjectTypeApiName[],
+      linkTypes: response.linkTypes as ObjectTypeLinkTypeApiNameMapping[],
+    };
+  }
+
+  async function getEditedEntities<Q extends ObjectTypeDefinition>(
+    objectType: Q,
+    options?: { pageSize?: number; pageToken?: string },
+  ): Promise<EditedEntitiesPage<Q>> {
+    const ontologyRid = await innerCtx.ontologyRid;
+    const response = await OntologyScenarios.listScenarioEditedObjects(
+      innerCtx,
+      ontologyRid,
+      scenarioRid,
+      objectType.apiName,
+      { pageSize: options?.pageSize, pageToken: options?.pageToken },
+    );
+    return {
+      data: await convertSparseEditedObjects<Q>(innerCtx, response.data),
+      nextPageToken: response.nextPageToken,
+    };
+  }
+
+  async function* editedEntitiesAsyncIter<Q extends ObjectTypeDefinition>(
+    objectType: Q,
+    options?: { pageSize?: number },
+  ): AsyncIterableIterator<Osdk.Instance<Q>> {
+    const seen = new Set<unknown>();
+    let pageToken: string | undefined;
+    do {
+      const page = await getEditedEntities(objectType, {
+        pageSize: options?.pageSize,
+        pageToken,
+      });
+      for (const obj of page.data) {
+        const key = obj.$primaryKey;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        yield obj;
+      }
+      pageToken = page.nextPageToken;
+    } while (pageToken != null);
+  }
+
   return Object.defineProperties(inner, {
     getScenarioReference: {
       value: () => scenarioRid,
+    },
+    getEditedEntityTypes: {
+      value: getEditedEntityTypes,
+    },
+    getEditedEntities: {
+      value: getEditedEntities,
+    },
+    editedEntitiesAsyncIter: {
+      value: editedEntitiesAsyncIter,
     },
   }) as EXPERIMENTAL_ScenarioClient;
 }

--- a/packages/client/src/scenarios/ScenarioClient.ts
+++ b/packages/client/src/scenarios/ScenarioClient.ts
@@ -15,15 +15,19 @@
  */
 
 import type { ObjectTypeDefinition, Osdk } from "@osdk/api";
-import type {
-  ObjectTypeApiName,
-  ObjectTypeLinkTypeApiNameMapping,
-  OntologyObjectV2,
-} from "@osdk/foundry.ontologies";
 import { OntologyScenarios } from "@osdk/foundry.ontologies";
 import { additionalContext, type Client } from "../Client.js";
 import { createClientWithScenario } from "../createClient.js";
 import type { MinimalClient } from "../MinimalClientContext.js";
+
+/**
+ * The set of many-to-many link types modified within a scenario for one source object type. Returned as part of
+ * {@link ScenarioEditedEntityTypes.linkTypes}.
+ */
+export interface EditedLinkTypeMapping {
+  objectTypeApiName: string;
+  linkTypes: string[];
+}
 
 /**
  * The object types and link types that have been modified within a scenario. Returned by
@@ -31,8 +35,8 @@ import type { MinimalClient } from "../MinimalClientContext.js";
  * `linkTypes`; one-to-many edits surface as object edits on the object type that owns the foreign key property.
  */
 export interface ScenarioEditedEntityTypes {
-  objectTypes: ObjectTypeApiName[];
-  linkTypes: ObjectTypeLinkTypeApiNameMapping[];
+  objectTypes: string[];
+  linkTypes: EditedLinkTypeMapping[];
 }
 
 /**
@@ -101,22 +105,6 @@ export interface EXPERIMENTAL_ScenarioClient extends Client {
   ): AsyncIterableIterator<Osdk.Instance<Q>>;
 }
 
-async function convertSparseEditedObjects<Q extends ObjectTypeDefinition>(
-  innerCtx: MinimalClient,
-  data: OntologyObjectV2[],
-): Promise<Osdk.Instance<Q>[]> {
-  if (data.length === 0) return [];
-  const converted = await innerCtx.objectFactory(
-    innerCtx,
-    data,
-    undefined,
-    {},
-    undefined,
-    true,
-  );
-  return converted as unknown as Osdk.Instance<Q>[];
-}
-
 /**
  * Shared internal builder used by both {@link withScenario} and {@link createScenario}. Validates the parent client
  * is not already inside a scenario or transaction, then constructs a fresh {@link Client} via
@@ -163,8 +151,8 @@ export function buildScenarioClient(
       scenarioRid,
     );
     return {
-      objectTypes: response.objectTypes as ObjectTypeApiName[],
-      linkTypes: response.linkTypes as ObjectTypeLinkTypeApiNameMapping[],
+      objectTypes: response.objectTypes,
+      linkTypes: response.linkTypes,
     };
   }
 
@@ -180,8 +168,18 @@ export function buildScenarioClient(
       objectType.apiName,
       { pageSize: options?.pageSize, pageToken: options?.pageToken },
     );
+    const data = response.data.length === 0
+      ? []
+      : (await innerCtx.objectFactory(
+        innerCtx,
+        response.data,
+        undefined,
+        {},
+        undefined,
+        true,
+      )) as unknown as Osdk.Instance<Q>[];
     return {
-      data: await convertSparseEditedObjects<Q>(innerCtx, response.data),
+      data,
       nextPageToken: response.nextPageToken,
     };
   }

--- a/packages/client/src/scenarios/ScenarioClient.ts
+++ b/packages/client/src/scenarios/ScenarioClient.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import type { ObjectTypeDefinition, Osdk } from "@osdk/api";
+import type {
+  ObjectIdentifiers,
+  ObjectTypeDefinition,
+  PrimaryKeyType,
+} from "@osdk/api";
 import { OntologyScenarios } from "@osdk/foundry.ontologies";
 import { additionalContext, type Client } from "../Client.js";
 import { createClientWithScenario } from "../createClient.js";
@@ -40,13 +44,13 @@ export interface ScenarioEditedEntityTypes {
 }
 
 /**
- * A page of objects edited within a scenario for a given object type. Returned by
- * {@link EXPERIMENTAL_ScenarioClient.getEditedEntities}. The instances are sparse: only `$primaryKey` and `$apiName`
- * are populated. Use {@link Client.call} (e.g. `scenario(MyObject).where({ $primaryKey: { $in: keys } }).fetchPage()`)
- * to load full objects under the scenario context.
+ * A page of edited object identifiers ({@link ObjectIdentifiers} — `$primaryKey` + `$apiName`) within a scenario
+ * for a given object type. Returned by {@link EXPERIMENTAL_ScenarioClient.getEditedEntities}. To load full property
+ * values, pass the primary keys back through the scenario client, e.g.
+ * `scenario(MyObject).where({ $primaryKey: { $in: keys } }).fetchPage()`.
  */
 export interface EditedEntitiesPage<Q extends ObjectTypeDefinition> {
-  data: Osdk.Instance<Q>[];
+  data: ObjectIdentifiers<Q>[];
   nextPageToken?: string;
 }
 
@@ -69,16 +73,17 @@ export interface EXPERIMENTAL_ScenarioClient extends Client {
   getEditedEntityTypes(): Promise<ScenarioEditedEntityTypes>;
 
   /**
-   * Get a page of objects that have been edited within this scenario for a given object type. Each instance only
-   * carries `$primaryKey` and `$apiName`; load full objects via the scenario client itself.
+   * Get a page of object identifiers ({@link ObjectIdentifiers} — `$primaryKey` + `$apiName` only) that have been
+   * edited within this scenario for the given object type. Use the scenario client to fetch full property values
+   * if needed.
    *
    * @example
    * ```ts
    * let pageToken: string | undefined;
-   * const keys: string[] = [];
+   * const keys: unknown[] = [];
    * do {
    *   const page = await scenario.getEditedEntities(Doctor, { pageSize: 500, pageToken });
-   *   keys.push(...page.data.map(o => o.$primaryKey as string));
+   *   keys.push(...page.data.map(o => o.$primaryKey));
    *   pageToken = page.nextPageToken;
    * } while (pageToken);
    * ```
@@ -89,8 +94,9 @@ export interface EXPERIMENTAL_ScenarioClient extends Client {
   ): Promise<EditedEntitiesPage<Q>>;
 
   /**
-   * Stream the objects edited within this scenario for a given object type. Pages are fetched lazily and
-   * deduplicated by `$primaryKey` across pages (Funnel may return duplicates).
+   * Stream object identifiers ({@link ObjectIdentifiers}) for the objects edited within this scenario for the
+   * given object type. Pages are fetched lazily and deduplicated by `$primaryKey` across pages (Funnel may return
+   * duplicates).
    *
    * @example
    * ```ts
@@ -102,7 +108,7 @@ export interface EXPERIMENTAL_ScenarioClient extends Client {
   editedEntitiesAsyncIter<Q extends ObjectTypeDefinition>(
     objectType: Q,
     options?: { pageSize?: number },
-  ): AsyncIterableIterator<Osdk.Instance<Q>>;
+  ): AsyncIterableIterator<ObjectIdentifiers<Q>>;
 }
 
 /**
@@ -168,16 +174,13 @@ export function buildScenarioClient(
       objectType.apiName,
       { pageSize: options?.pageSize, pageToken: options?.pageToken },
     );
-    const data = response.data.length === 0
-      ? []
-      : (await innerCtx.objectFactory(
-        innerCtx,
-        response.data,
-        undefined,
-        {},
-        undefined,
-        true,
-      )) as unknown as Osdk.Instance<Q>[];
+    const data: ObjectIdentifiers<Q>[] = response.data.map((entry) => {
+      const wire = entry as { __apiName?: unknown; __primaryKey?: unknown };
+      return {
+        $apiName: wire.__apiName as Q["apiName"],
+        $primaryKey: wire.__primaryKey as PrimaryKeyType<Q>,
+      };
+    });
     return {
       data,
       nextPageToken: response.nextPageToken,
@@ -187,7 +190,7 @@ export function buildScenarioClient(
   async function* editedEntitiesAsyncIter<Q extends ObjectTypeDefinition>(
     objectType: Q,
     options?: { pageSize?: number },
-  ): AsyncIterableIterator<Osdk.Instance<Q>> {
+  ): AsyncIterableIterator<ObjectIdentifiers<Q>> {
     const seen = new Set<unknown>();
     let pageToken: string | undefined;
     do {

--- a/packages/client/src/scenarios/ScenarioClient.ts
+++ b/packages/client/src/scenarios/ScenarioClient.ts
@@ -28,25 +28,25 @@ import type { MinimalClient } from "../MinimalClientContext.js";
  * The set of many-to-many link types modified within a scenario for one source object type. Returned as part of
  * {@link ScenarioEditedEntityTypes.linkTypes}.
  */
-export interface EditedLinkTypeMapping {
+export interface EditedLinksForObjectType {
   objectTypeApiName: string;
   linkTypes: string[];
 }
 
 /**
- * The object types and link types that have been modified within a scenario. Returned by
- * {@link EXPERIMENTAL_ScenarioClient.getEditedEntityTypes}. Only many-to-many link type edits are surfaced via
- * `linkTypes`; one-to-many edits surface as object edits on the object type that owns the foreign key property.
+ * The object types and link types that have been modified within a scenario. Only many-to-many link type edits are
+ * surfaced via `linkTypes`; one-to-many edits surface as object edits on the object type that owns the foreign key
+ * property.
  */
 export interface ScenarioEditedEntityTypes {
   objectTypes: string[];
-  linkTypes: EditedLinkTypeMapping[];
+  linkTypes: EditedLinksForObjectType[];
 }
 
 /**
- * A page of edited object identifiers ({@link ObjectIdentifiers} — `$primaryKey` + `$apiName`) within a scenario
- * for a given object type. Returned by {@link EXPERIMENTAL_ScenarioClient.getEditedEntities}. To load full property
- * values, pass the primary keys back through the scenario client, e.g.
+ * A page of edited object identifiers within a scenario for a given object type. Returned by
+ * {@link EXPERIMENTAL_ScenarioClient.getEditedEntities}. To load full property values, pass the primary keys back
+ * through the scenario client, e.g.
  * `scenario(MyObject).where({ $primaryKey: { $in: keys } }).fetchPage()`.
  */
 export interface EditedEntitiesPage<Q extends ObjectTypeDefinition> {
@@ -73,14 +73,14 @@ export interface EXPERIMENTAL_ScenarioClient extends Client {
   getEditedEntityTypes(): Promise<ScenarioEditedEntityTypes>;
 
   /**
-   * Get a page of object identifiers ({@link ObjectIdentifiers} — `$primaryKey` + `$apiName` only) that have been
+   * Get a page of object identifiers that have been
    * edited within this scenario for the given object type. Use the scenario client to fetch full property values
    * if needed.
    *
    * @example
    * ```ts
    * let pageToken: string | undefined;
-   * const keys: unknown[] = [];
+   * const keys: string[] = [];
    * do {
    *   const page = await scenario.getEditedEntities(Doctor, { pageSize: 500, pageToken });
    *   keys.push(...page.data.map(o => o.$primaryKey));
@@ -94,7 +94,7 @@ export interface EXPERIMENTAL_ScenarioClient extends Client {
   ): Promise<EditedEntitiesPage<Q>>;
 
   /**
-   * Stream object identifiers ({@link ObjectIdentifiers}) for the objects edited within this scenario for the
+   * Stream object identifiers for the objects edited within this scenario for the
    * given object type. Pages are fetched lazily and deduplicated by `$primaryKey` across pages (Funnel may return
    * duplicates).
    *

--- a/packages/client/src/scenarios/createScenario.test.ts
+++ b/packages/client/src/scenarios/createScenario.test.ts
@@ -15,6 +15,10 @@
  */
 
 import { BarInterface } from "@osdk/client.test.ontology";
+import type {
+  CreateOntologyScenarioResponse,
+  LoadObjectSetV2MultipleObjectTypesResponse,
+} from "@osdk/foundry.ontologies";
 import type { MockedFunction } from "vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Client } from "../Client.js";
@@ -41,7 +45,10 @@ describe("createScenario", () => {
 
   it("calls the create endpoint and threads the returned rid", async () => {
     const newScenarioRid = "ri.actions..scenario.new";
-    mockFetchResponse(fetchFunction, { scenarioRid: newScenarioRid });
+    const createResponse: CreateOntologyScenarioResponse = {
+      scenarioRid: newScenarioRid,
+    };
+    mockFetchResponse(fetchFunction, createResponse);
 
     const scenario = await createScenario(client);
 
@@ -55,7 +62,10 @@ describe("createScenario", () => {
     expect(scenario.getScenarioReference()).toBe(newScenarioRid);
 
     // Subsequent requests carry the new rid
-    mockFetchResponse(fetchFunction, { data: [] });
+    const loadResponse: LoadObjectSetV2MultipleObjectTypesResponse = {
+      data: [],
+    };
+    mockFetchResponse(fetchFunction, loadResponse);
     await scenario(BarInterface).fetchPage();
     const url = new URL(
       fetchFunction.mock.calls[1][0] as string,

--- a/packages/client/src/scenarios/withScenario.test.ts
+++ b/packages/client/src/scenarios/withScenario.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { BarInterface } from "@osdk/client.test.ontology";
+import type { LoadObjectSetV2MultipleObjectTypesResponse } from "@osdk/foundry.ontologies";
 import type { MockedFunction } from "vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Client } from "../Client.js";
@@ -51,7 +52,8 @@ describe("withScenario", () => {
 
   it("forwards scenarioRid as a query param on fetchPage", async () => {
     const scenario = withScenario(client, "ri.actions..scenario.abc");
-    mockFetchResponse(fetchFunction, { data: [] });
+    const mock: LoadObjectSetV2MultipleObjectTypesResponse = { data: [] };
+    mockFetchResponse(fetchFunction, mock);
 
     await scenario(BarInterface).fetchPage();
 


### PR DESCRIPTION
## Summary

Extends \`ScenarioClient\` with three methods backed by \`OntologyScenarios.listScenarioEditedEntityTypes\` and \`listScenarioEditedObjects\`. \`getEditedEntityTypes\` returns the union of edited object and link types on the scenario. \`getEditedEntities\` paginates edited objects by type (sparse instances — only \`\$primaryKey\` and \`\$apiName\` populated). \`editedEntitiesAsyncIter\` auto-paginates and dedupes by \`\$primaryKey\` across pages. Together they're the building blocks for N-way scenario diff workflows.

## Usage

```ts
import { withScenario } from "@osdk/client/unstable-do-not-use";
import { Doctor } from "@my/sdk";

const scenario = withScenario(client, "ri.actions..scenario.abc");

// 1. Discover what changed
const { objectTypes, linkTypes } = await scenario.getEditedEntityTypes();

// 2. Paginate edited objects (page form, explicit pageToken loop)
let pageToken: string | undefined;
const keys: unknown[] = [];
do {
  const page = await scenario.getEditedEntities(Doctor, { pageSize: 500, pageToken });
  keys.push(...page.data.map(o => o.\$primaryKey));
  pageToken = page.nextPageToken;
} while (pageToken);

// 3. Or stream and dedupe via the async iterator
for await (const obj of scenario.editedEntitiesAsyncIter(Doctor, { pageSize: 500 })) {
  console.log(obj.\$apiName, obj.\$primaryKey);
}

// 4. Re-fetch under the scenario context for full property values
const full = await scenario(Doctor)
  .where({ \$primaryKey: { \$in: keys } })
  .fetchPage();
```

## Test plan

- [x] \`pnpm turbo typecheck --filter=@osdk/client\`
- [x] \`pnpm turbo test --filter=@osdk/client\` — 799/799 tests pass, 4 new tests in \`scenarioClient.test.ts\`
- [ ] Manual: run the N-way diff workflow against a stack with 2+ scenarios sharing edits

> Stacked on https://github.com/palantir/osdk-ts/pull/3331

🤖 Generated with [Claude Code](https://claude.com/claude-code)