### PR TITLE
filter-list: configurable actions and overflow menu

### DIFF
--- a/.changeset/filter-list-actions.md
+++ b/.changeset/filter-list-actions.md
@@ -1,0 +1,9 @@
+---
+"@osdk/react-components": minor
+---
+
+add configurable filter actions, move remove into overflow menu, surface overflow on every filter
+
+• every filter row now renders the `...` overflow menu, including linked, range, and timeline filters
+• the standalone remove (X) button moves into the overflow menu by default
+• new `actions` field on `FilterDefinition` controls search/overflow/remove visibility

--- a/.nexus/plans/daaeb485-88fa-41c4-8101-eb35b2664d50.md
+++ b/.nexus/plans/daaeb485-88fa-41c4-8101-eb35b2664d50.md
@@ -1,0 +1,144 @@
+# Plan: filter-list-actions
+
+## Goal
+
+Tackle the three FilterList Fixes items assigned to the shared
+`ksethi/filter-list-actions` branch/worktree:
+
+1. **P0 — `...` overflow menu missing on most filter items (incl. linked)**
+2. **P0 — MULTI_SELECT consistency: hide monocle, keep `...`**
+3. **P1 — Configurable filter action icons and placement**
+
+Open a single PR on `ksethi/filter-list-actions` against `main` once the work
+is done and link it back to the user.
+
+## Why these three are one PR, not three
+
+The dependency notes in the goal spec are explicit: all three items touch
+the same surfaces — `FilterDefinition`, `FilterListItem.tsx` header action
+rendering, `supportsSearch`/`supportsExcluding`, `ExcludeDropdown`,
+`FilterInputExcludeRow`, and `LinkedPropertyInput` — and the configurable-
+actions item generalizes the monocle opt-out. Splitting them into
+independent worktrees would either (a) create a series of conflicting
+branches that have to rebase on each other, or (b) duplicate the public-API
+surface (e.g. a one-off `searchField` flag that gets immediately replaced by
+the generalized `actions` config). Doing them in one coherent pass on
+`ksethi/filter-list-actions` is what the spec asks for and what avoids
+churn.
+
+## Approach
+
+### 1. Refactor the header action rendering in `FilterListItem.tsx`
+
+- Drop the `hasOverflowActions = supportsExcluding(filterState)` gate.
+  Every filter row gets the `...` overflow trigger.
+- Remove the standalone `RemoveIcon` button in the header. Removal moves
+  into the `...` menu.
+- Compute `effectiveState` once for capability checks:
+  `filterState?.type === "linkedProperty" ? filterState.linkedFilterState : filterState`.
+  Pass that to `supportsExcluding` / `supportsSearch` so linked filters
+  inherit their inner filter's capabilities (e.g. a linked
+  `MULTI_SELECT` shows the Keep/Exclude option, a linked `NUMBER_RANGE`
+  does not).
+- Centralize header-action rendering: search, overflow, and (now) remove
+  share one placement decision driven by the new `actions` config (see #3).
+
+### 2. Replace `ExcludeDropdown` with a dynamic overflow menu
+
+- Build `OverflowMenu` (or rename/extend `ExcludeDropdown`) that renders
+  a menu with the following items, gated on the effective filter state:
+  - **Keeping / Excluding** toggle — only when `supportsExcluding(effectiveState)`.
+  - **Clear all selections** — only when the filter has selected values
+    (covers SELECT, EXACT_MATCH, NUMBER_RANGE, DATE_RANGE, TIMELINE,
+    LinkedProperty unwrapped, etc.).
+  - **Remove filter** — always, when `onFilterRemoved` is provided.
+- Wire `Clear all` to invoke the same handler the existing exclude row
+  uses (route through the existing `onClearAll` plumbing in
+  `FilterInputExcludeRow` / the per-input clear-all handlers; do not
+  duplicate the reset logic).
+- Update `FilterInputExcludeRow.handleToggleExclude` so that when the
+  outer state is `linkedProperty`, it toggles `isExcluding` on the inner
+  `linkedFilterState` and re-wraps before calling `onFilterStateChanged`.
+  Read `isExcluding` and `selectedCount` from the inner state too.
+
+### 3. Add a typed `actions` config to `FilterDefinition`
+
+Add an opt-in `actions?: FilterActionsConfig` field to the
+`PropertyFilterDefinitionBase`, `HasLinkFilterDefinition`, and
+`LinkedPropertyFilterDefinition` types. Shape:
+
+```ts
+interface FilterActionsConfig {
+  /**
+   * Show / hide / relocate the search (monocle) action.
+   * @default true (renders in header when the filter type supports search)
+   */
+  search?: boolean | "menu";
+  /**
+   * Show / hide the overflow `...` action.
+   * @default true (always renders)
+   */
+  overflow?: boolean;
+  /**
+   * Show / hide / relocate the remove action.
+   * @default "menu"  (after this change, remove lives inside the overflow menu by default)
+   */
+  remove?: boolean | "menu";
+  /**
+   * Placement of the action cluster relative to the title/value area.
+   * @default "header-end"
+   */
+  placement?: "header-start" | "header-end";
+}
+```
+
+- Defaults are chosen to keep the post-refactor behavior backward-
+  compatible (search visible where it used to be, overflow always on,
+  remove inside the menu, header-end placement).
+- The MULTI_SELECT-monocle-opt-out case from item #2 is then just
+  `actions: { search: false }`. No separate `searchField` flag is
+  introduced; the generalized API covers it.
+- Plumb `actions` through `FilterList` → `BaseFilterList` →
+  `FilterListItem` (the definition already flows through these layers).
+
+### 4. Tests
+
+In `packages/react-components/src/filter-list/base/__tests__/FilterListItem.test.tsx`
+(or the closest existing test file — append to existing files, do not
+create parallel split files):
+
+- Overflow `...` renders for every filter type, including `linkedProperty`,
+  `NUMBER_RANGE`, `DATE_RANGE`, `TIMELINE`, `TOGGLE`, `HAS_LINK`.
+- Standalone X (the old `RemoveIcon` button outside the menu) is gone.
+- Menu renders Keep/Exclude only when the effective filter supports it
+  (and surfaces it for `linkedProperty` wrapping a SELECT/EXACT_MATCH).
+- Menu renders Remove when `onFilterRemoved` is provided.
+- Menu renders Clear-all when there is an active selection (including
+  linked filters).
+- Toggling exclude on a `linkedProperty` filter updates the inner state's
+  `isExcluding`, not the outer wrapper's.
+- `actions: { search: false }` hides the monocle on a MULTI_SELECT while
+  the overflow `...` still renders.
+- `actions: { remove: "menu" | true }` controls where remove appears.
+
+### 5. Verification & PR
+
+- `pnpm turbo typecheck --filter=@osdk/react-components`
+- `pnpm --dir packages/react-components vitest run` (and `pkill -f vitest`
+  after).
+- `pnpm turbo check-api --filter=@osdk/react-components` since
+  `FilterDefinition` gains a public field — commit the updated API report.
+- `npx dprint fmt` on changed files only.
+- One changeset at `.changeset/filter-list-actions.md` bumping
+  `@osdk/react-components` minor (new optional public API).
+- Open a single PR on `ksethi/filter-list-actions` against `main` and link
+  it back to the user.
+
+## Out of scope (handled by other branches in the work plan)
+
+- `renderValue` ReactNode fallback → `ksethi/filter-list-linked-render-value`
+- Clear-all alignment in exclude row → `ksethi/filter-list-clear-all-alignment`
+- Reset baseline diff → `ksethi/filter-list-reset-baseline`
+- Number-range / "No value" alignment → `ksethi/filter-list-input-alignment`
+- `formatDate` plumbing for date inputs → `ksethi/filter-list-format-date-inputs`
+- Relative date shortcuts → `ksethi/filter-list-date-shortcuts`

--- a/packages/react-components/src/filter-list/FilterList.tsx
+++ b/packages/react-components/src/filter-list/FilterList.tsx
@@ -25,10 +25,20 @@ import type {
   FilterKey,
   FilterListProps,
 } from "./FilterListApi.js";
+import type { FilterActionsConfig } from "./FilterListItemApi.js";
 import { useFilterListState } from "./hooks/useFilterListState.js";
 import { useFilterVisibility } from "./hooks/useFilterVisibility.js";
 import { getFilterKey } from "./utils/getFilterKey.js";
 import { getFilterLabel } from "./utils/getFilterLabel.js";
+
+function getFilterActions<Q extends ObjectTypeDefinition>(
+  definition: FilterDefinitionUnion<Q>,
+): FilterActionsConfig | undefined {
+  if ("actions" in definition) {
+    return definition.actions;
+  }
+  return undefined;
+}
 
 export function FilterList<Q extends ObjectTypeDefinition>(
   props: FilterListProps<Q>,
@@ -215,6 +225,7 @@ export function FilterList<Q extends ObjectTypeDefinition>(
       renderInput={renderInput}
       getFilterKey={getFilterKey}
       getFilterLabel={getFilterLabel}
+      getFilterActions={getFilterActions}
       activeFilterCount={activeFilterCount}
       onReset={handleReset}
       showResetButton={showResetButton}

--- a/packages/react-components/src/filter-list/FilterListItemApi.ts
+++ b/packages/react-components/src/filter-list/FilterListItemApi.ts
@@ -331,6 +331,51 @@ interface PropertyFilterDefinitionBase<
    * @default true
    */
   isVisible?: boolean;
+
+  /**
+   * Per-filter configuration for the header action cluster (search monocle,
+   * overflow `...` menu, and remove). See {@link FilterActionsConfig}.
+   */
+  actions?: FilterActionsConfig;
+}
+
+/**
+ * Configuration for the action cluster that renders alongside the filter
+ * title (search monocle, overflow menu, remove).
+ *
+ * Every field is optional; defaults are picked to match the post-refactor
+ * behavior — overflow `...` always shows, remove lives inside the overflow
+ * menu, search renders in the header for filter types that support it, and
+ * actions sit at the end of the header.
+ */
+export interface FilterActionsConfig {
+  /**
+   * Show or hide the search (monocle) action in the header. When `false`, the
+   * monocle never renders. Useful for `MULTI_SELECT` filters whose combobox
+   * already exposes inline search, so the monocle would be redundant.
+   * @default true (renders in header when the filter type supports search)
+   */
+  search?: boolean;
+
+  /**
+   * Show or hide the overflow `...` action in the header.
+   * @default true
+   */
+  overflow?: boolean;
+
+  /**
+   * Where the remove action lives. `true` renders a standalone remove button
+   * in the header; `false` hides removal entirely; `"menu"` keeps removal but
+   * exposes it as an item inside the overflow `...` menu.
+   * @default "menu"
+   */
+  remove?: boolean | "menu";
+
+  /**
+   * Placement of the action cluster relative to the title/value area.
+   * @default "header-end"
+   */
+  placement?: "header-end";
 }
 
 /**

--- a/packages/react-components/src/filter-list/base/BaseFilterList.tsx
+++ b/packages/react-components/src/filter-list/base/BaseFilterList.tsx
@@ -38,6 +38,7 @@ export function BaseFilterList<D>(
     renderInput,
     getFilterKey,
     getFilterLabel,
+    getFilterActions,
     activeFilterCount,
     onReset,
     onFilterAdded,
@@ -116,6 +117,7 @@ export function BaseFilterList<D>(
               renderInput={renderInput}
               getFilterKey={getFilterKey}
               getFilterLabel={getFilterLabel}
+              getFilterActions={getFilterActions}
               enableSorting={enableSorting}
             />
           </div>

--- a/packages/react-components/src/filter-list/base/BaseFilterListApi.ts
+++ b/packages/react-components/src/filter-list/base/BaseFilterListApi.ts
@@ -15,7 +15,7 @@
  */
 
 import type React from "react";
-import type { FilterState } from "../FilterListItemApi.js";
+import type { FilterActionsConfig, FilterState } from "../FilterListItemApi.js";
 
 export type RenderFilterInput<D> = (props: {
   definition: D;
@@ -33,6 +33,11 @@ export interface BaseFilterListProps<D> {
   renderInput: RenderFilterInput<D>;
   getFilterKey: (definition: D) => string;
   getFilterLabel: (definition: D) => string;
+  /**
+   * Resolve per-filter action visibility/placement config from a definition.
+   * When omitted, every filter falls back to default action behavior.
+   */
+  getFilterActions?: (definition: D) => FilterActionsConfig | undefined;
   activeFilterCount: number;
   onReset?: () => void;
   onFilterAdded?: () => void;

--- a/packages/react-components/src/filter-list/base/FilterInputExcludeRow.tsx
+++ b/packages/react-components/src/filter-list/base/FilterInputExcludeRow.tsx
@@ -22,10 +22,20 @@ import { supportsExcluding } from "../utils/filterValues.js";
 import { ExcludeDropdown } from "./ExcludeDropdown.js";
 import styles from "./FilterListItem.module.css";
 
+function getEffectiveState(
+  filterState: FilterState | undefined,
+): FilterState | undefined {
+  if (filterState?.type === "linkedProperty") {
+    return filterState.linkedFilterState;
+  }
+  return filterState;
+}
+
 function getSelectedCount(filterState: FilterState | undefined): number {
-  if (!filterState) return 0;
-  if (filterState.type === "EXACT_MATCH") return filterState.values.length;
-  if (filterState.type === "SELECT") return filterState.selectedValues.length;
+  const effective = getEffectiveState(filterState);
+  if (!effective) return 0;
+  if (effective.type === "EXACT_MATCH") return effective.values.length;
+  if (effective.type === "SELECT") return effective.selectedValues.length;
   return 0;
 }
 
@@ -47,22 +57,35 @@ function FilterInputExcludeRowInner({
   children,
 }: FilterInputExcludeRowProps): React.ReactElement {
   const handleToggleExclude = useCallback(() => {
-    if (filterState) {
+    if (!filterState) {
+      return;
+    }
+    if (filterState.type === "linkedProperty") {
+      const inner = filterState.linkedFilterState;
       onFilterStateChanged({
         ...filterState,
-        isExcluding: !filterState.isExcluding,
+        linkedFilterState: {
+          ...inner,
+          isExcluding: !inner.isExcluding,
+        },
       });
+      return;
     }
+    onFilterStateChanged({
+      ...filterState,
+      isExcluding: !filterState.isExcluding,
+    });
   }, [filterState, onFilterStateChanged]);
 
-  const isExcluding = filterState?.isExcluding ?? false;
+  const effectiveState = getEffectiveState(filterState);
+  const isExcluding = effectiveState?.isExcluding ?? false;
   const isOpen = excludeRowOpen ?? false;
   const selectedCount = useMemo(
     () => getSelectedCount(filterState),
     [filterState],
   );
 
-  if (!supportsExcluding(filterState)) {
+  if (!supportsExcluding(effectiveState)) {
     return <>{children}</>;
   }
 

--- a/packages/react-components/src/filter-list/base/FilterListContent.tsx
+++ b/packages/react-components/src/filter-list/base/FilterListContent.tsx
@@ -39,7 +39,7 @@ import {
 } from "@dnd-kit/sortable";
 import classnames from "classnames";
 import React, { useCallback, useMemo, useState } from "react";
-import type { FilterState } from "../FilterListItemApi.js";
+import type { FilterActionsConfig, FilterState } from "../FilterListItemApi.js";
 import type { RenderFilterInput } from "./BaseFilterListApi.js";
 import styles from "./FilterListContent.module.css";
 import { FilterListItem } from "./FilterListItem.js";
@@ -74,6 +74,7 @@ interface FilterListContentProps<D> {
   renderInput: RenderFilterInput<D>;
   getFilterKey: (definition: D) => string;
   getFilterLabel: (definition: D) => string;
+  getFilterActions?: (definition: D) => FilterActionsConfig | undefined;
   enableSorting?: boolean;
   className?: string;
   style?: React.CSSProperties;
@@ -88,6 +89,7 @@ export function FilterListContent<D>({
   renderInput,
   getFilterKey,
   getFilterLabel,
+  getFilterActions,
   enableSorting,
   className,
   style,
@@ -227,6 +229,7 @@ export function FilterListContent<D>({
               const filterKey = getFilterKey(definition);
               const label = getFilterLabel(definition);
               const state = filterStates.get(filterKey);
+              const actions = getFilterActions?.(definition);
 
               return (
                 <SortableFilterListItem
@@ -239,6 +242,7 @@ export function FilterListContent<D>({
                   onFilterStateChanged={onFilterStateChanged}
                   onFilterRemoved={onFilterRemoved}
                   renderInput={renderInput}
+                  actions={actions}
                 />
               );
             })}
@@ -258,6 +262,7 @@ export function FilterListContent<D>({
                 onFilterRemoved={onFilterRemoved}
                 renderInput={renderInput}
                 dragHandleAttributes={DRAG_OVERLAY_HANDLE_ATTRIBUTES}
+                actions={getFilterActions?.(activeDefinition)}
               />
             )}
           </DragOverlay>
@@ -274,6 +279,7 @@ export function FilterListContent<D>({
       {filterDefinitions.map((definition) => {
         const filterKey = getFilterKey(definition);
         const state = filterStates.get(filterKey);
+        const actions = getFilterActions?.(definition);
 
         return (
           <FilterListItem
@@ -285,6 +291,7 @@ export function FilterListContent<D>({
             onFilterStateChanged={onFilterStateChanged}
             onFilterRemoved={onFilterRemoved}
             renderInput={renderInput}
+            actions={actions}
           />
         );
       })}

--- a/packages/react-components/src/filter-list/base/FilterListItem.tsx
+++ b/packages/react-components/src/filter-list/base/FilterListItem.tsx
@@ -21,45 +21,50 @@ import type {
   DraggableSyntheticListeners,
 } from "@dnd-kit/core";
 import classnames from "classnames";
-import React, { memo, useCallback, useState } from "react";
+import React, { memo, useCallback, useMemo, useState } from "react";
 import { ErrorBoundary } from "../../shared/ErrorBoundary.js";
-import type { FilterState } from "../FilterListItemApi.js";
-import { supportsExcluding, supportsSearch } from "../utils/filterValues.js";
+import type { FilterActionsConfig, FilterState } from "../FilterListItemApi.js";
+import {
+  clearFilterStateSelections,
+  filterHasActiveState,
+  supportsExcluding,
+  supportsSearch,
+} from "../utils/filterValues.js";
 import type { RenderFilterInput } from "./BaseFilterListApi.js";
 import { DragHandleIcon } from "./DragHandleIcon.js";
-import { OverflowMenuIcon, RemoveIcon, SearchIcon } from "./FilterIcons.js";
+import { RemoveIcon, SearchIcon } from "./FilterIcons.js";
 import styles from "./FilterListItem.module.css";
+import { FilterOverflowMenu } from "./FilterOverflowMenu.js";
 
-function hasActiveSelection(filterState: FilterState | undefined): boolean {
-  if (filterState == null) {
-    return false;
+function getEffectiveFilterState(
+  filterState: FilterState | undefined,
+): FilterState | undefined {
+  if (filterState?.type === "linkedProperty") {
+    return filterState.linkedFilterState;
   }
-  switch (filterState.type) {
-    case "EXACT_MATCH":
-      return filterState.values.length > 0;
-    case "SELECT":
-      return filterState.selectedValues.length > 0;
-    case "CONTAINS_TEXT":
-      return filterState.value != null && filterState.value.length > 0;
-    case "NUMBER_RANGE":
-      return filterState.minValue != null || filterState.maxValue != null;
-    case "DATE_RANGE":
-      return filterState.minValue != null || filterState.maxValue != null;
-    case "TIMELINE":
-      return filterState.startDate != null || filterState.endDate != null;
-    case "TOGGLE":
-      return filterState.enabled;
-    case "keywordSearch":
-      return filterState.searchTerm.length > 0;
-    case "hasLink":
-      return filterState.hasLink;
-    case "linkedProperty":
-      return hasActiveSelection(filterState.linkedFilterState);
-    case "custom":
-      return true;
-    default:
-      return false;
+  return filterState;
+}
+
+function withInnerExcludingToggled(
+  filterState: FilterState | undefined,
+): FilterState | undefined {
+  if (!filterState) {
+    return undefined;
   }
+  if (filterState.type === "linkedProperty") {
+    const inner = filterState.linkedFilterState;
+    return {
+      ...filterState,
+      linkedFilterState: {
+        ...inner,
+        isExcluding: !inner.isExcluding,
+      },
+    };
+  }
+  return {
+    ...filterState,
+    isExcluding: !filterState.isExcluding,
+  };
 }
 
 interface FilterListItemProps<D> {
@@ -77,6 +82,7 @@ interface FilterListItemProps<D> {
   dragHandleListeners?: DraggableSyntheticListeners;
   className?: string;
   style?: React.CSSProperties;
+  actions?: FilterActionsConfig;
 }
 
 function FilterListItemInner<D>({
@@ -91,11 +97,11 @@ function FilterListItemInner<D>({
   dragHandleListeners,
   className,
   style,
+  actions,
 }: FilterListItemProps<D>): React.ReactElement {
   const [searchState, setSearchState] = useState<
     { type: "closed" } | { type: "open"; query: string }
   >({ type: "closed" });
-  const [excludeRowOpen, setExcludeRowOpen] = useState(false);
 
   const handleFilterStateChanged = useCallback(
     (newState: FilterState) => {
@@ -125,17 +131,40 @@ function FilterListItemInner<D>({
     onFilterRemoved?.(filterKey);
   }, [filterKey, onFilterRemoved]);
 
-  const handleToggleExcludeRow = useCallback(() => {
-    setExcludeRowOpen((prev) => !prev);
-  }, []);
+  const handleToggleExclude = useCallback(() => {
+    const next = withInnerExcludingToggled(filterState);
+    if (next) {
+      onFilterStateChanged(filterKey, next);
+    }
+  }, [filterState, filterKey, onFilterStateChanged]);
+
+  const handleClearSelection = useCallback(() => {
+    if (filterState) {
+      onFilterStateChanged(filterKey, clearFilterStateSelections(filterState));
+    }
+  }, [filterState, filterKey, onFilterStateChanged]);
 
   const searchInputRef = useCallback((element: HTMLInputElement | null) => {
     element?.focus({ preventScroll: true });
   }, []);
 
-  const showExcludeDropdown = supportsExcluding(filterState);
-  const showSearch = supportsSearch(filterState);
-  const hasOverflowActions = showExcludeDropdown;
+  const effectiveState = useMemo(
+    () => getEffectiveFilterState(filterState),
+    [filterState],
+  );
+
+  const supportsExcludeAction = supportsExcluding(effectiveState);
+  const supportsSearchAction = supportsSearch(effectiveState);
+  const hasSelection = filterHasActiveState(filterState);
+
+  const searchEnabled = actions?.search ?? true;
+  const overflowEnabled = actions?.overflow ?? true;
+  const removeMode = actions?.remove ?? "menu";
+
+  const showSearchInHeader = searchEnabled && supportsSearchAction;
+  const showHeaderRemove = removeMode === true && onFilterRemoved != null;
+  const showMenuRemove = removeMode === "menu" && onFilterRemoved != null;
+  const isExcluding = effectiveState?.isExcluding ?? false;
 
   const searchOpen = searchState.type === "open";
   const searchQuery = searchState.type === "open" ? searchState.query : "";
@@ -147,7 +176,7 @@ function FilterListItemInner<D>({
     <div
       className={classnames(styles.filterItem, className)}
       style={style}
-      data-has-selection={hasActiveSelection(filterState) || undefined}
+      data-has-selection={hasSelection || undefined}
     >
       <div className={styles.itemHeader}>
         {dragHandleAttributes && (
@@ -165,7 +194,7 @@ function FilterListItemInner<D>({
         >
           {label}
         </span>
-        {showSearch && (
+        {showSearchInHeader && (
           <Button
             className={styles.headerActionButton}
             onClick={handleToggleSearch}
@@ -175,7 +204,7 @@ function FilterListItemInner<D>({
             <SearchIcon />
           </Button>
         )}
-        {onFilterRemoved && (
+        {showHeaderRemove && (
           <Button
             className={styles.headerActionButton}
             onClick={handleRemove}
@@ -184,15 +213,15 @@ function FilterListItemInner<D>({
             <RemoveIcon />
           </Button>
         )}
-        {hasOverflowActions && (
-          <Button
-            className={styles.headerActionButton}
-            onClick={handleToggleExcludeRow}
-            aria-label="More actions"
-            aria-pressed={excludeRowOpen}
-          >
-            <OverflowMenuIcon />
-          </Button>
+        {overflowEnabled && (
+          <FilterOverflowMenu
+            supportsExcluding={supportsExcludeAction}
+            isExcluding={isExcluding}
+            onToggleExclude={handleToggleExclude}
+            hasSelection={hasSelection}
+            onClearSelection={hasSelection ? handleClearSelection : undefined}
+            onRemove={showMenuRemove ? handleRemove : undefined}
+          />
         )}
       </div>
 
@@ -228,7 +257,6 @@ function FilterListItemInner<D>({
             filterState,
             onFilterStateChanged: handleFilterStateChanged,
             searchQuery: searchQueryForInput,
-            excludeRowOpen,
           })}
         </ErrorBoundary>
       </div>

--- a/packages/react-components/src/filter-list/base/FilterOverflowMenu.tsx
+++ b/packages/react-components/src/filter-list/base/FilterOverflowMenu.tsx
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Menu } from "@base-ui/react/menu";
+import React, { memo, useCallback } from "react";
+import styles from "./ExcludeDropdown.module.css";
+import { CheckIcon, ExcludeIcon, OverflowMenuIcon } from "./FilterIcons.js";
+import { useFilterListBoundary } from "./FilterListBoundaryContext.js";
+import itemStyles from "./FilterListItem.module.css";
+
+export interface FilterOverflowMenuProps {
+  /**
+   * Whether the wrapped filter supports a Keep/Exclude toggle. When `false`,
+   * the menu skips the keep/exclude items.
+   */
+  supportsExcluding: boolean;
+  /**
+   * Current exclude state (drawn from the inner filter state for
+   * `linkedProperty` filters).
+   */
+  isExcluding: boolean;
+  /**
+   * Toggle exclude/keep. Already unwraps/re-wraps `linkedProperty` state.
+   */
+  onToggleExclude: () => void;
+  /**
+   * Whether the wrapped filter currently has a clearable selection.
+   */
+  hasSelection: boolean;
+  /**
+   * Clear the active selection. When omitted (or when `hasSelection` is
+   * false), the "Clear all selections" item is omitted.
+   */
+  onClearSelection?: () => void;
+  /**
+   * Removes the filter row entirely. When provided, the menu renders a
+   * "Remove filter" item at the bottom.
+   */
+  onRemove?: () => void;
+  /**
+   * Accessible label for the trigger button. Defaults to "More actions".
+   */
+  triggerAriaLabel?: string;
+}
+
+function FilterOverflowMenuInner({
+  supportsExcluding,
+  isExcluding,
+  onToggleExclude,
+  hasSelection,
+  onClearSelection,
+  onRemove,
+  triggerAriaLabel = "More actions",
+}: FilterOverflowMenuProps): React.ReactElement | null {
+  const collisionBoundary = useFilterListBoundary();
+
+  const handleKeep = useCallback(() => {
+    if (isExcluding) {
+      onToggleExclude();
+    }
+  }, [isExcluding, onToggleExclude]);
+
+  const handleExclude = useCallback(() => {
+    if (!isExcluding) {
+      onToggleExclude();
+    }
+  }, [isExcluding, onToggleExclude]);
+
+  const handleClear = useCallback(() => {
+    onClearSelection?.();
+  }, [onClearSelection]);
+
+  const handleRemove = useCallback(() => {
+    onRemove?.();
+  }, [onRemove]);
+
+  const showClear = hasSelection && onClearSelection != null;
+  const showRemove = onRemove != null;
+  const hasAnyItems = supportsExcluding || showClear || showRemove;
+  if (!hasAnyItems) {
+    return null;
+  }
+
+  return (
+    <Menu.Root>
+      <Menu.Trigger
+        className={itemStyles.headerActionButton}
+        aria-label={triggerAriaLabel}
+      >
+        <OverflowMenuIcon />
+      </Menu.Trigger>
+      <Menu.Portal>
+        <Menu.Positioner
+          className={styles.positioner}
+          sideOffset={4}
+          collisionBoundary={collisionBoundary}
+        >
+          <Menu.Popup className={styles.popup}>
+            {supportsExcluding && (
+              <>
+                <Menu.Item
+                  className={styles.menuItem}
+                  onClick={handleKeep}
+                >
+                  <span className={styles.menuItemCheck}>
+                    {!isExcluding && <CheckIcon />}
+                  </span>
+                  Keep matching
+                </Menu.Item>
+                <Menu.Item
+                  className={styles.menuItem}
+                  onClick={handleExclude}
+                >
+                  <span className={styles.menuItemCheck}>
+                    {isExcluding && <ExcludeIcon />}
+                  </span>
+                  Exclude matching
+                </Menu.Item>
+              </>
+            )}
+            {showClear && (
+              <Menu.Item
+                className={styles.menuItem}
+                onClick={handleClear}
+              >
+                <span className={styles.menuItemCheck} />
+                Clear all selections
+              </Menu.Item>
+            )}
+            {showRemove && (
+              <Menu.Item
+                className={styles.menuItem}
+                onClick={handleRemove}
+              >
+                <span className={styles.menuItemCheck} />
+                Remove filter
+              </Menu.Item>
+            )}
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+  );
+}
+
+export const FilterOverflowMenu: React.MemoExoticComponent<
+  typeof FilterOverflowMenuInner
+> = memo(FilterOverflowMenuInner);

--- a/packages/react-components/src/filter-list/base/SortableFilterListItem.tsx
+++ b/packages/react-components/src/filter-list/base/SortableFilterListItem.tsx
@@ -18,7 +18,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import classnames from "classnames";
 import React, { memo, useMemo } from "react";
-import type { FilterState } from "../FilterListItemApi.js";
+import type { FilterActionsConfig, FilterState } from "../FilterListItemApi.js";
 import type { RenderFilterInput } from "./BaseFilterListApi.js";
 import { FilterListItem } from "./FilterListItem.js";
 import styles from "./FilterListItem.module.css";
@@ -35,6 +35,7 @@ interface SortableFilterListItemProps<D> {
   ) => void;
   onFilterRemoved?: (filterKey: string) => void;
   renderInput: RenderFilterInput<D>;
+  actions?: FilterActionsConfig;
 }
 
 function SortableFilterListItemInner<D>({
@@ -46,6 +47,7 @@ function SortableFilterListItemInner<D>({
   onFilterStateChanged,
   onFilterRemoved,
   renderInput,
+  actions,
 }: SortableFilterListItemProps<D>): React.ReactElement {
   const {
     attributes,
@@ -77,6 +79,7 @@ function SortableFilterListItemInner<D>({
         renderInput={renderInput}
         dragHandleAttributes={attributes}
         dragHandleListeners={listeners}
+        actions={actions}
       />
     </div>
   );

--- a/packages/react-components/src/filter-list/base/__tests__/FilterListItem.test.tsx
+++ b/packages/react-components/src/filter-list/base/__tests__/FilterListItem.test.tsx
@@ -1,0 +1,452 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  FilterActionsConfig,
+  FilterState,
+} from "../../FilterListItemApi.js";
+import type { RenderFilterInput } from "../BaseFilterListApi.js";
+import { FilterListItem } from "../FilterListItem.js";
+
+afterEach(cleanup);
+
+interface StubDefinition {
+  kind: string;
+  actions?: FilterActionsConfig;
+}
+
+const stubRenderInput: RenderFilterInput<StubDefinition> = ({
+  definition,
+}) => <div data-testid={`filter-input-${definition.kind}`} />;
+
+function renderItem({
+  filterState,
+  onFilterStateChanged = vi.fn(),
+  onFilterRemoved,
+  actions,
+  label = "Test Filter",
+  kind = "test",
+}: {
+  filterState?: FilterState;
+  onFilterStateChanged?: (key: string, state: FilterState) => void;
+  onFilterRemoved?: (key: string) => void;
+  actions?: FilterActionsConfig;
+  label?: string;
+  kind?: string;
+}) {
+  return render(
+    <FilterListItem<StubDefinition>
+      definition={{ kind }}
+      filterKey="test-key"
+      label={label}
+      filterState={filterState}
+      onFilterStateChanged={onFilterStateChanged}
+      onFilterRemoved={onFilterRemoved}
+      renderInput={stubRenderInput}
+      actions={actions}
+    />,
+  );
+}
+
+function openOverflowMenu(): HTMLElement {
+  const trigger = screen.getByRole("button", { name: /More actions/i });
+  fireEvent.click(trigger);
+  return trigger;
+}
+
+describe("FilterListItem", () => {
+  describe("overflow menu trigger", () => {
+    it.each<[string, FilterState | undefined]>([
+      [
+        "LISTOGRAM",
+        { type: "EXACT_MATCH", values: [] } satisfies FilterState,
+      ],
+      [
+        "MULTI_SELECT",
+        { type: "SELECT", selectedValues: [] } satisfies FilterState,
+      ],
+      [
+        "NUMBER_RANGE",
+        {
+          type: "NUMBER_RANGE",
+          minValue: undefined,
+          maxValue: undefined,
+        } satisfies FilterState,
+      ],
+      [
+        "DATE_RANGE",
+        {
+          type: "DATE_RANGE",
+          minValue: undefined,
+          maxValue: undefined,
+        } satisfies FilterState,
+      ],
+      [
+        "TIMELINE",
+        {
+          type: "TIMELINE",
+          startDate: undefined,
+          endDate: undefined,
+        } satisfies FilterState,
+      ],
+      [
+        "TOGGLE",
+        { type: "TOGGLE", enabled: false } satisfies FilterState,
+      ],
+      [
+        "HAS_LINK",
+        { type: "hasLink", hasLink: false } satisfies FilterState,
+      ],
+      [
+        "LINKED_PROPERTY (wrapping TOGGLE)",
+        {
+          type: "linkedProperty",
+          linkedFilterState: { type: "TOGGLE", enabled: false },
+        } satisfies FilterState,
+      ],
+    ])(
+      "always renders the overflow trigger for %s",
+      (_, filterState) => {
+        renderItem({ filterState, onFilterRemoved: vi.fn() });
+        expect(screen.getByRole("button", { name: /More actions/i }))
+          .toBeDefined();
+      },
+    );
+
+    it("does not render the standalone X button when remove is in the menu", () => {
+      renderItem({
+        filterState: { type: "SELECT", selectedValues: [] },
+        onFilterRemoved: vi.fn(),
+      });
+      expect(
+        screen.queryByRole("button", { name: /Remove Test Filter filter/i }),
+      ).toBeNull();
+    });
+  });
+
+  describe("overflow menu contents", () => {
+    it("offers Keep/Exclude when the filter supports excluding", async () => {
+      renderItem({
+        filterState: { type: "SELECT", selectedValues: ["a"] },
+        onFilterRemoved: vi.fn(),
+      });
+      openOverflowMenu();
+
+      await waitFor(() => {
+        expect(screen.getByRole("menuitem", { name: /Keep matching/ }))
+          .toBeDefined();
+        expect(screen.getByRole("menuitem", { name: /Exclude matching/ }))
+          .toBeDefined();
+      });
+    });
+
+    it(
+      "offers Keep/Exclude on a linkedProperty wrapping a SELECT filter",
+      async () => {
+        renderItem({
+          filterState: {
+            type: "linkedProperty",
+            linkedFilterState: { type: "SELECT", selectedValues: ["x"] },
+          },
+        });
+        openOverflowMenu();
+
+        await waitFor(() => {
+          expect(screen.getByRole("menuitem", { name: /Keep matching/ }))
+            .toBeDefined();
+          expect(screen.getByRole("menuitem", { name: /Exclude matching/ }))
+            .toBeDefined();
+        });
+      },
+    );
+
+    it(
+      "does not offer Keep/Exclude when the inner filter cannot exclude",
+      async () => {
+        renderItem({
+          filterState: {
+            type: "linkedProperty",
+            linkedFilterState: {
+              type: "NUMBER_RANGE",
+              minValue: 0,
+              maxValue: 10,
+            },
+          },
+        });
+        openOverflowMenu();
+
+        await waitFor(() => {
+          expect(screen.queryByRole("menuitem", { name: /Keep matching/ }))
+            .toBeNull();
+        });
+      },
+    );
+
+    it("offers Remove filter when onFilterRemoved is provided", async () => {
+      const onFilterRemoved = vi.fn();
+      renderItem({
+        filterState: { type: "SELECT", selectedValues: [] },
+        onFilterRemoved,
+      });
+      openOverflowMenu();
+
+      const removeItem = await screen.findByRole(
+        "menuitem",
+        { name: /Remove filter/ },
+      );
+      fireEvent.click(removeItem);
+      expect(onFilterRemoved).toHaveBeenCalledWith("test-key");
+    });
+
+    it("hides Remove filter when onFilterRemoved is omitted", async () => {
+      renderItem({
+        filterState: { type: "SELECT", selectedValues: ["x"] },
+      });
+      openOverflowMenu();
+
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("menuitem", { name: /Remove filter/ }),
+        ).toBeNull();
+      });
+    });
+
+    it("offers Clear all selections when a selection is present", async () => {
+      const onFilterStateChanged = vi.fn();
+      renderItem({
+        filterState: { type: "SELECT", selectedValues: ["a", "b"] },
+        onFilterStateChanged,
+      });
+      openOverflowMenu();
+
+      const clearItem = await screen.findByRole("menuitem", {
+        name: /Clear all selections/,
+      });
+      fireEvent.click(clearItem);
+      expect(onFilterStateChanged).toHaveBeenCalledWith("test-key", {
+        type: "SELECT",
+        selectedValues: [],
+      });
+    });
+
+    it(
+      "offers Clear all selections on a linkedProperty filter with an active inner selection",
+      async () => {
+        const onFilterStateChanged = vi.fn();
+        renderItem({
+          filterState: {
+            type: "linkedProperty",
+            linkedFilterState: {
+              type: "EXACT_MATCH",
+              values: ["alpha"],
+            },
+          },
+          onFilterStateChanged,
+        });
+        openOverflowMenu();
+
+        const clearItem = await screen.findByRole("menuitem", {
+          name: /Clear all selections/,
+        });
+        fireEvent.click(clearItem);
+        expect(onFilterStateChanged).toHaveBeenCalledWith("test-key", {
+          type: "linkedProperty",
+          linkedFilterState: {
+            type: "EXACT_MATCH",
+            values: [],
+          },
+        });
+      },
+    );
+
+    it("hides Clear all selections when no selection is present", async () => {
+      renderItem({
+        filterState: { type: "SELECT", selectedValues: [] },
+        onFilterRemoved: vi.fn(),
+      });
+      openOverflowMenu();
+
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("menuitem", { name: /Clear all selections/ }),
+        ).toBeNull();
+      });
+    });
+  });
+
+  describe("Keep/Exclude toggle", () => {
+    it("toggles isExcluding on a regular filter", async () => {
+      const onFilterStateChanged = vi.fn();
+      renderItem({
+        filterState: { type: "SELECT", selectedValues: ["a"] },
+        onFilterStateChanged,
+      });
+      openOverflowMenu();
+
+      const excludeItem = await screen.findByRole("menuitem", {
+        name: /Exclude matching/,
+      });
+      fireEvent.click(excludeItem);
+      expect(onFilterStateChanged).toHaveBeenCalledWith("test-key", {
+        type: "SELECT",
+        selectedValues: ["a"],
+        isExcluding: true,
+      });
+    });
+
+    it(
+      "toggles isExcluding on the INNER linkedFilterState, not the wrapper",
+      async () => {
+        const onFilterStateChanged = vi.fn();
+        renderItem({
+          filterState: {
+            type: "linkedProperty",
+            linkedFilterState: {
+              type: "SELECT",
+              selectedValues: ["beta"],
+              isExcluding: false,
+            },
+          },
+          onFilterStateChanged,
+        });
+        openOverflowMenu();
+
+        const excludeItem = await screen.findByRole("menuitem", {
+          name: /Exclude matching/,
+        });
+        fireEvent.click(excludeItem);
+
+        expect(onFilterStateChanged).toHaveBeenCalledWith("test-key", {
+          type: "linkedProperty",
+          linkedFilterState: {
+            type: "SELECT",
+            selectedValues: ["beta"],
+            isExcluding: true,
+          },
+        });
+      },
+    );
+  });
+
+  describe("actions config", () => {
+    it("hides the search monocle when actions.search is false", () => {
+      renderItem({
+        filterState: { type: "SELECT", selectedValues: [] },
+        actions: { search: false },
+      });
+      expect(screen.queryByRole("button", { name: /Search values/i }))
+        .toBeNull();
+    });
+
+    it(
+      "keeps the overflow trigger even when the monocle is hidden",
+      () => {
+        renderItem({
+          filterState: { type: "SELECT", selectedValues: [] },
+          actions: { search: false },
+        });
+        expect(screen.getByRole("button", { name: /More actions/i }))
+          .toBeDefined();
+      },
+    );
+
+    it("renders the monocle by default for searchable filter types", () => {
+      renderItem({
+        filterState: { type: "SELECT", selectedValues: [] },
+      });
+      expect(screen.getByRole("button", { name: /Search values/i }))
+        .toBeDefined();
+    });
+
+    it(
+      "renders the remove button in the header when actions.remove is true",
+      () => {
+        const onFilterRemoved = vi.fn();
+        renderItem({
+          filterState: { type: "SELECT", selectedValues: [] },
+          actions: { remove: true },
+          onFilterRemoved,
+        });
+        const headerRemove = screen.getByRole("button", {
+          name: /Remove Test Filter filter/i,
+        });
+        fireEvent.click(headerRemove);
+        expect(onFilterRemoved).toHaveBeenCalledWith("test-key");
+      },
+    );
+
+    it(
+      "omits remove from the overflow menu when actions.remove is true",
+      async () => {
+        renderItem({
+          filterState: { type: "SELECT", selectedValues: [] },
+          actions: { remove: true },
+          onFilterRemoved: vi.fn(),
+        });
+        openOverflowMenu();
+        await waitFor(() => {
+          expect(
+            screen.queryByRole("menuitem", { name: /Remove filter/ }),
+          ).toBeNull();
+        });
+      },
+    );
+
+    it(
+      "hides remove entirely when actions.remove is false",
+      async () => {
+        renderItem({
+          filterState: { type: "SELECT", selectedValues: ["x"] },
+          actions: { remove: false },
+          onFilterRemoved: vi.fn(),
+        });
+        // No header X
+        expect(
+          screen.queryByRole("button", { name: /Remove Test Filter filter/i }),
+        ).toBeNull();
+        // No menu item either
+        openOverflowMenu();
+        await waitFor(() => {
+          expect(
+            screen.queryByRole("menuitem", { name: /Remove filter/ }),
+          ).toBeNull();
+        });
+      },
+    );
+
+    it(
+      "hides the overflow trigger entirely when actions.overflow is false",
+      () => {
+        renderItem({
+          filterState: { type: "SELECT", selectedValues: ["x"] },
+          actions: { overflow: false },
+          onFilterRemoved: vi.fn(),
+        });
+        expect(screen.queryByRole("button", { name: /More actions/i }))
+          .toBeNull();
+      },
+    );
+  });
+});

--- a/packages/react-components/src/filter-list/types/LinkedFilterTypes.ts
+++ b/packages/react-components/src/filter-list/types/LinkedFilterTypes.ts
@@ -22,6 +22,7 @@ import type {
 } from "@osdk/api";
 import type {
   BaseFilterState,
+  FilterActionsConfig,
   FilterState,
   FilterStateByComponentType,
   PropertyTypeFromKey,
@@ -70,6 +71,12 @@ export interface HasLinkFilterDefinition<
    * @default true
    */
   isVisible?: boolean;
+
+  /**
+   * Per-filter configuration for the header action cluster (search monocle,
+   * overflow `...` menu, and remove). See {@link FilterActionsConfig}.
+   */
+  actions?: FilterActionsConfig;
 }
 
 /**
@@ -110,4 +117,10 @@ export interface LinkedPropertyFilterDefinition<
    * @default true
    */
   isVisible?: boolean;
+
+  /**
+   * Per-filter configuration for the header action cluster (search monocle,
+   * overflow `...` menu, and remove). See {@link FilterActionsConfig}.
+   */
+  actions?: FilterActionsConfig;
 }

--- a/packages/react-components/src/filter-list/utils/__tests__/filterValues.test.ts
+++ b/packages/react-components/src/filter-list/utils/__tests__/filterValues.test.ts
@@ -16,7 +16,11 @@
 
 import { describe, expect, it } from "vitest";
 import type { PropertyAggregationValue } from "../../types/AggregationTypes.js";
-import { dedupeEmptyAggregationRows, isEmptyValue } from "../filterValues.js";
+import {
+  clearFilterStateSelections,
+  dedupeEmptyAggregationRows,
+  isEmptyValue,
+} from "../filterValues.js";
 
 describe("filterValues", () => {
   describe("isEmptyValue", () => {
@@ -94,6 +98,102 @@ describe("filterValues", () => {
       expect(dedupeEmptyAggregationRows(input)).toEqual([
         { value: "alpha", count: 5 },
       ]);
+    });
+  });
+
+  describe("clearFilterStateSelections", () => {
+    it("empties SELECT selectedValues but keeps isExcluding", () => {
+      expect(
+        clearFilterStateSelections({
+          type: "SELECT",
+          selectedValues: ["a", "b"],
+          isExcluding: true,
+        }),
+      ).toEqual({
+        type: "SELECT",
+        selectedValues: [],
+        isExcluding: true,
+      });
+    });
+
+    it("empties EXACT_MATCH values", () => {
+      expect(
+        clearFilterStateSelections({
+          type: "EXACT_MATCH",
+          values: ["alpha", "beta"],
+        }),
+      ).toEqual({
+        type: "EXACT_MATCH",
+        values: [],
+      });
+    });
+
+    it("clears CONTAINS_TEXT value", () => {
+      expect(
+        clearFilterStateSelections({
+          type: "CONTAINS_TEXT",
+          value: "needle",
+        }),
+      ).toEqual({
+        type: "CONTAINS_TEXT",
+        value: undefined,
+      });
+    });
+
+    it("clears NUMBER_RANGE min/max but preserves includeNull", () => {
+      expect(
+        clearFilterStateSelections({
+          type: "NUMBER_RANGE",
+          minValue: 1,
+          maxValue: 5,
+          includeNull: true,
+        }),
+      ).toEqual({
+        type: "NUMBER_RANGE",
+        minValue: undefined,
+        maxValue: undefined,
+        includeNull: true,
+      });
+    });
+
+    it("recursively clears linkedProperty inner state", () => {
+      expect(
+        clearFilterStateSelections({
+          type: "linkedProperty",
+          linkedFilterState: {
+            type: "EXACT_MATCH",
+            values: ["x", "y"],
+          },
+        }),
+      ).toEqual({
+        type: "linkedProperty",
+        linkedFilterState: {
+          type: "EXACT_MATCH",
+          values: [],
+        },
+      });
+    });
+
+    it("resets TOGGLE to false", () => {
+      expect(
+        clearFilterStateSelections({ type: "TOGGLE", enabled: true }),
+      ).toEqual({ type: "TOGGLE", enabled: false });
+    });
+
+    it("clears TIMELINE start/end", () => {
+      const start = new Date("2024-01-01");
+      const end = new Date("2024-02-01");
+      expect(
+        clearFilterStateSelections({
+          type: "TIMELINE",
+          startDate: start,
+          endDate: end,
+        }),
+      ).toEqual({
+        type: "TIMELINE",
+        startDate: undefined,
+        endDate: undefined,
+      });
     });
   });
 });

--- a/packages/react-components/src/filter-list/utils/filterValues.ts
+++ b/packages/react-components/src/filter-list/utils/filterValues.ts
@@ -125,6 +125,51 @@ export function filterValuesBySearch<T>(
   return values.filter((v) => getValue(v).toLowerCase().includes(lowerSearch));
 }
 
+/**
+ * Returns a copy of the filter state with all selectable values cleared.
+ * Used by the overflow menu's "Clear all selections" action so the action
+ * works uniformly across every filter type (including linked filters, which
+ * recurse into their inner state).
+ *
+ * `includeNull` is preserved on range filters — clearing the value range
+ * shouldn't reset the unrelated "include nulls" choice.
+ */
+export function clearFilterStateSelections(
+  state: FilterState,
+): FilterState {
+  switch (state.type) {
+    case "EXACT_MATCH":
+      return { ...state, values: [] };
+    case "SELECT":
+      return { ...state, selectedValues: [] };
+    case "CONTAINS_TEXT":
+      return { ...state, value: undefined };
+    case "NUMBER_RANGE":
+      return { ...state, minValue: undefined, maxValue: undefined };
+    case "DATE_RANGE":
+      return { ...state, minValue: undefined, maxValue: undefined };
+    case "TIMELINE":
+      return { ...state, startDate: undefined, endDate: undefined };
+    case "TOGGLE":
+      return { ...state, enabled: false };
+    case "hasLink":
+      return { ...state, hasLink: false };
+    case "linkedProperty":
+      return {
+        ...state,
+        linkedFilterState: clearFilterStateSelections(state.linkedFilterState),
+      };
+    case "keywordSearch":
+      return { ...state, searchTerm: "" };
+    case "custom":
+      return state;
+    default: {
+      const _exhaustive: never = state;
+      return state;
+    }
+  }
+}
+
 /** Check if a filter state has an active (non-empty) value. */
 export function filterHasActiveState(state: FilterState | undefined): boolean {
   if (!state) return false;

--- a/packages/react-components/src/public/experimental/filter-list.ts
+++ b/packages/react-components/src/public/experimental/filter-list.ts
@@ -31,6 +31,7 @@ export type {
   FilterListProps,
 } from "../../filter-list/FilterListApi.js";
 export type {
+  FilterActionsConfig,
   FilterComponentType,
   FilterListItemProps,
   FilterState,


### PR DESCRIPTION
add configurable per-filter actions and surface an overflow menu on every filter

• every filter row renders an overflow menu including linked, range, and timeline filters
• the standalone remove (X) button moves into the overflow menu by default
• new `actions` field on `FilterDefinition` controls search, overflow, and remove visibility