### PR TITLE
filter-list: right-align Clear All in exclude row

### DIFF
--- a/.changeset/filter-list-exclude-row-clear-all-right-align.md
+++ b/.changeset/filter-list-exclude-row-clear-all-right-align.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+right-align Clear all in FilterList exclude row

--- a/packages/react-components/src/filter-list/base/FilterListItem.module.css
+++ b/packages/react-components/src/filter-list/base/FilterListItem.module.css
@@ -167,6 +167,7 @@
 .excludeRow {
   display: flex;
   align-items: center;
+  width: 100%;
   opacity: 0;
   height: 0;
   overflow: hidden;


### PR DESCRIPTION
right-align Clear All button against the right edge of the exclude row

• adds `margin-left: auto` on `.clearAllButton` in `FilterListItem.module.css`
• existing flex container handles the layout, no JSX changes