### PR TITLE
filter-list: no-value baseline and range hyphen alignment

### DIFF
--- a/.changeset/filter-list-no-value-baseline-and-range-hyphen.md
+++ b/.changeset/filter-list-no-value-baseline-and-range-hyphen.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+fix filter-list "no value" baseline and range hyphen vertical alignment

--- a/packages/react-components/src/filter-list/base/inputs/NullValueWrapper.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/NullValueWrapper.module.css
@@ -32,7 +32,7 @@
 
 .nullValueRow {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   justify-content: space-between;
   padding: var(--osdk-filter-null-row-padding);
   border-top: var(--osdk-filter-null-row-border-top);

--- a/packages/react-components/src/filter-list/base/inputs/RangeInput.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/RangeInput.module.css
@@ -197,9 +197,11 @@
 .separator {
   display: flex;
   align-items: center;
-  height: calc(
-    var(--osdk-filter-input-font-size) + var(--osdk-filter-input-padding) * 2
-  );
+  font-family: var(--osdk-filter-input-font-family);
+  font-size: var(--osdk-filter-input-font-size);
+  padding: var(--osdk-filter-input-padding);
+  border: var(--osdk-filter-input-border);
+  border-color: transparent;
   color: var(--osdk-filter-range-separator-color);
 }
 


### PR DESCRIPTION
fix no-value baseline and range hyphen vertical alignment in filter list

• adjust the no-value placeholder so its baseline matches adjacent inputs
• realign the hyphen separator between range inputs vertically