### PR TITLE
filter-list: thread renderValue through linked inputs

### DIFF
--- a/.changeset/thread-rendervalue-linked-property.md
+++ b/.changeset/thread-rendervalue-linked-property.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+thread `renderValue` through `LinkedPropertyFilter` inputs

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/renderValue.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/renderValue.test.tsx
@@ -14,14 +14,23 @@
  * limitations under the License.
  */
 
+import type { ObjectSet, ObjectTypeDefinition, PropertyKeys } from "@osdk/api";
+import { useOsdkAggregation } from "@osdk/react";
 import { cleanup, render, screen } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { LinkedPropertyInput } from "../../../inputs/LinkedPropertyInput.js";
 import type { PropertyAggregationValue } from "../../../types/AggregationTypes.js";
+import type { LinkedPropertyFilterDefinition } from "../../../types/LinkedFilterTypes.js";
 import { createRenderValueFilter } from "../comboboxFilter.js";
 import { ListogramInput } from "../ListogramInput.js";
 import { MultiSelectInput } from "../MultiSelectInput.js";
 import { SingleSelectInput } from "../SingleSelectInput.js";
+
+vi.mock("@osdk/react", () => ({
+  useOsdkAggregation: vi.fn(),
+  useRegisterUserAgent: vi.fn(),
+}));
 
 afterEach(cleanup);
 
@@ -286,5 +295,166 @@ describe("SingleSelectInput renderValue", () => {
     );
 
     expect(screen.queryByText("Alice Smith")).toBeNull();
+  });
+});
+
+const MockLinkedObjectType = {
+  apiName: "Office",
+  type: "object",
+  __DefinitionMetadata: {
+    primaryKeyApiName: "officeId",
+    primaryKeyType: "string",
+    properties: {
+      officeId: { type: "string", multiplicity: false },
+      name: { type: "string", multiplicity: false },
+    },
+  },
+} as unknown as ObjectTypeDefinition;
+
+function createMockLinkedObjectSet(): ObjectSet<ObjectTypeDefinition> {
+  const linkedObjectSet = {
+    $objectSetInternals: {
+      def: MockLinkedObjectType,
+    },
+  };
+
+  return {
+    $objectSetInternals: {
+      def: {
+        apiName: "Employee",
+        type: "object",
+      } as ObjectTypeDefinition,
+    },
+    pivotTo: vi.fn().mockReturnValue(linkedObjectSet),
+  } as unknown as ObjectSet<ObjectTypeDefinition>;
+}
+
+function createLinkedDefinition(
+  linkedFilterComponent: "MULTI_SELECT" | "LISTOGRAM" | "SINGLE_SELECT",
+  renderValue?: (value: string) => React.ReactNode,
+): LinkedPropertyFilterDefinition<
+  ObjectTypeDefinition,
+  string,
+  ObjectTypeDefinition,
+  PropertyKeys<ObjectTypeDefinition>
+> {
+  const innerStateType = linkedFilterComponent === "LISTOGRAM"
+    ? { type: "EXACT_MATCH" as const, values: [] }
+    : { type: "SELECT" as const, selectedValues: [] };
+
+  return {
+    type: "LINKED_PROPERTY",
+    linkName: "primaryOffice",
+    linkedPropertyKey: "name" as PropertyKeys<ObjectTypeDefinition>,
+    linkedFilterComponent,
+    linkedFilterState: innerStateType,
+    filterState: {
+      type: "linkedProperty",
+      linkedFilterState: innerStateType,
+    },
+    renderValue,
+  } as LinkedPropertyFilterDefinition<
+    ObjectTypeDefinition,
+    string,
+    ObjectTypeDefinition,
+    PropertyKeys<ObjectTypeDefinition>
+  >;
+}
+
+function mockLinkedAggregationData(
+  groups: Array<{ name: string; count: number }>,
+): void {
+  vi.mocked(useOsdkAggregation).mockReturnValue({
+    data: groups.map((g) => ({
+      $group: { name: g.name },
+      $count: g.count,
+    })),
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  } as unknown as ReturnType<typeof useOsdkAggregation>);
+}
+
+describe("LinkedPropertyInput renderValue", () => {
+  const renderValueAsNode = (value: string): React.ReactNode => (
+    <a href={`/user/${value}`} data-testid={`linked-anchor-${value}`}>
+      {LABELS[value] ?? value}
+    </a>
+  );
+
+  it("renders JSX returned from renderValue inside a MULTI_SELECT chip", () => {
+    mockLinkedAggregationData([
+      { name: "abc-123", count: 4 },
+      { name: "def-456", count: 2 },
+    ]);
+
+    render(
+      <LinkedPropertyInput
+        objectSet={createMockLinkedObjectSet()}
+        definition={createLinkedDefinition("MULTI_SELECT", renderValueAsNode)}
+        filterState={{
+          type: "linkedProperty",
+          linkedFilterState: {
+            type: "SELECT",
+            selectedValues: ["abc-123"],
+          },
+        }}
+        onFilterStateChanged={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("linked-anchor-abc-123")).toBeDefined();
+    expect(screen.getByText("Alice Smith")).toBeDefined();
+  });
+
+  it("renders JSX returned from renderValue inside a LISTOGRAM row", () => {
+    mockLinkedAggregationData([
+      { name: "abc-123", count: 4 },
+      { name: "def-456", count: 2 },
+    ]);
+
+    render(
+      <LinkedPropertyInput
+        objectSet={createMockLinkedObjectSet()}
+        definition={createLinkedDefinition("LISTOGRAM", renderValueAsNode)}
+        filterState={{
+          type: "linkedProperty",
+          linkedFilterState: {
+            type: "EXACT_MATCH",
+            values: [],
+          },
+        }}
+        onFilterStateChanged={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("linked-anchor-abc-123")).toBeDefined();
+    expect(screen.getByTestId("linked-anchor-def-456")).toBeDefined();
+  });
+
+  it("falls back to raw value for LISTOGRAM search when renderValue returns JSX", () => {
+    mockLinkedAggregationData([
+      { name: "abc-123", count: 4 },
+      { name: "def-456", count: 2 },
+    ]);
+
+    render(
+      <LinkedPropertyInput
+        objectSet={createMockLinkedObjectSet()}
+        definition={createLinkedDefinition("LISTOGRAM", renderValueAsNode)}
+        filterState={{
+          type: "linkedProperty",
+          linkedFilterState: {
+            type: "EXACT_MATCH",
+            values: [],
+          },
+        }}
+        onFilterStateChanged={vi.fn()}
+        searchQuery="abc"
+      />,
+    );
+
+    expect(screen.getByTestId("linked-anchor-abc-123")).toBeDefined();
+    expect(screen.queryByTestId("linked-anchor-def-456")).toBeNull();
   });
 });

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/renderValue.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/renderValue.test.tsx
@@ -29,7 +29,6 @@ import { SingleSelectInput } from "../SingleSelectInput.js";
 
 vi.mock("@osdk/react", () => ({
   useOsdkAggregation: vi.fn(),
-  useRegisterUserAgent: vi.fn(),
 }));
 
 afterEach(cleanup);
@@ -456,5 +455,33 @@ describe("LinkedPropertyInput renderValue", () => {
 
     expect(screen.getByTestId("linked-anchor-abc-123")).toBeDefined();
     expect(screen.queryByTestId("linked-anchor-def-456")).toBeNull();
+  });
+
+  it("mounts SINGLE_SELECT with renderValue without error", () => {
+    // LinkedSingleSelectInput renders dropdown items inside a Combobox portal
+    // that jsdom can't mount — see the SingleSelectInput renderValue block
+    // above. Smoke-check that LinkedPropertyInput accepts renderValue on the
+    // SINGLE_SELECT path without throwing.
+    mockLinkedAggregationData([
+      { name: "abc-123", count: 4 },
+      { name: "def-456", count: 2 },
+    ]);
+
+    const { container } = render(
+      <LinkedPropertyInput
+        objectSet={createMockLinkedObjectSet()}
+        definition={createLinkedDefinition("SINGLE_SELECT", renderValueAsNode)}
+        filterState={{
+          type: "linkedProperty",
+          linkedFilterState: {
+            type: "SELECT",
+            selectedValues: [],
+          },
+        }}
+        onFilterStateChanged={vi.fn()}
+      />,
+    );
+
+    expect(container.querySelector("input")).toBeDefined();
   });
 });

--- a/packages/react-components/src/filter-list/inputs/LinkedPropertyInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/LinkedPropertyInput.tsx
@@ -250,6 +250,7 @@ function LinkedPropertyInputInner<
             selectedValues={values}
             onChange={onSelectChange}
             showCount={definition.showCount}
+            renderValue={definition.renderValue}
             layout={layout}
           />
         );
@@ -267,6 +268,7 @@ function LinkedPropertyInputInner<
             selectedValue={value}
             onChange={onSingleSelectChange}
             showCount={definition.showCount}
+            renderValue={definition.renderValue}
           />
         );
       }
@@ -344,6 +346,7 @@ function LinkedPropertyInputInner<
             onChange={onExactMatchChange}
             searchQuery={searchQuery}
             showCount={definition.showCount}
+            renderValue={definition.renderValue}
           />
         );
       }
@@ -433,6 +436,7 @@ interface LinkedMultiSelectInputProps<Q extends ObjectTypeDefinition>
   selectedValues: string[];
   onChange: (values: string[]) => void;
   showCount?: boolean;
+  renderValue?: (value: string) => React.ReactNode;
   layout?: MultiSelectInputLayout;
 }
 
@@ -443,6 +447,7 @@ function LinkedMultiSelectInput<Q extends ObjectTypeDefinition>({
   selectedValues,
   onChange,
   showCount,
+  renderValue,
   layout,
 }: LinkedMultiSelectInputProps<Q>): React.ReactElement {
   const aggregationOptions = useMemo(
@@ -464,6 +469,7 @@ function LinkedMultiSelectInput<Q extends ObjectTypeDefinition>({
       selectedValues={selectedValues}
       onChange={onChange}
       showCounts={showCount}
+      renderValue={renderValue}
       layout={layout}
     />
   );
@@ -475,6 +481,7 @@ interface LinkedSingleSelectInputProps<Q extends ObjectTypeDefinition>
   selectedValue: string | undefined;
   onChange: (value: string | undefined) => void;
   showCount?: boolean;
+  renderValue?: (value: string) => React.ReactNode;
 }
 
 function LinkedSingleSelectInput<Q extends ObjectTypeDefinition>({
@@ -484,6 +491,7 @@ function LinkedSingleSelectInput<Q extends ObjectTypeDefinition>({
   selectedValue,
   onChange,
   showCount,
+  renderValue,
 }: LinkedSingleSelectInputProps<Q>): React.ReactElement {
   const aggregationOptions = useMemo(
     () => ({
@@ -506,6 +514,7 @@ function LinkedSingleSelectInput<Q extends ObjectTypeDefinition>({
       selectedValue={selectedValue}
       onChange={onChange}
       showCounts={showCount}
+      renderValue={renderValue}
       ariaLabel={`Select ${propertyKey as string}`}
     />
   );
@@ -518,6 +527,7 @@ interface LinkedListogramInputProps<Q extends ObjectTypeDefinition>
   onChange: (values: string[]) => void;
   searchQuery?: string;
   showCount?: boolean;
+  renderValue?: (value: string) => React.ReactNode;
 }
 
 function LinkedListogramInput<Q extends ObjectTypeDefinition>({
@@ -528,6 +538,7 @@ function LinkedListogramInput<Q extends ObjectTypeDefinition>({
   onChange,
   searchQuery,
   showCount,
+  renderValue,
 }: LinkedListogramInputProps<Q>): React.ReactElement {
   const aggregationOptions = useMemo(
     () => ({ activeValues: selectedValues }),
@@ -550,6 +561,7 @@ function LinkedListogramInput<Q extends ObjectTypeDefinition>({
       onChange={onChange}
       searchQuery={searchQuery}
       showCount={showCount}
+      renderValue={renderValue}
     />
   );
 }

--- a/packages/react-components/src/filter-list/types/LinkedFilterTypes.ts
+++ b/packages/react-components/src/filter-list/types/LinkedFilterTypes.ts
@@ -20,6 +20,7 @@ import type {
   ObjectTypeDefinition,
   PropertyKeys,
 } from "@osdk/api";
+import type { ReactNode } from "react";
 import type {
   BaseFilterState,
   FilterState,
@@ -103,6 +104,15 @@ export interface LinkedPropertyFilterDefinition<
    * @default true for LISTOGRAM and MULTI_SELECT, false for SINGLE_SELECT
    */
   showCount?: boolean;
+
+  /**
+   * Custom display function for filter values.
+   * Replaces the default string display in dropdown items, chips, and listogram rows.
+   * When the function returns a string, that string is also used for search matching
+   * within filter dropdowns. When it returns a non-string `ReactNode`, search falls
+   * back to the raw value.
+   */
+  renderValue?: (value: string) => ReactNode;
 
   /**
    * Controls whether this filter is rendered.


### PR DESCRIPTION
thread renderValue through LinkedPropertyFilter inputs

• linked property inputs now accept and forward the `renderValue` prop
• matches the existing behavior of non-linked filter inputs