### PR TITLE
fix tailwind preflight overriding osdk.components in officenetwork

### DIFF
--- a/packages/e2e.sandbox.officenetwork/src/index.css
+++ b/packages/e2e.sandbox.officenetwork/src/index.css
@@ -1,3 +1,8 @@
+/* Cascade layer order: tailwind layers first, osdk last so osdk.components
+   wins over tailwind's preflight (e.g. button { opacity: 1 } would otherwise
+   override .headerActionButton { opacity: 0 } from react-components). */
+@layer theme, base, components, utilities, osdk.tokens, osdk.components;
+
 @import "@osdk/react-components/styles.css";
 @import "tailwindcss";
 

--- a/packages/react-components-storybook/.storybook/main.ts
+++ b/packages/react-components-storybook/.storybook/main.ts
@@ -15,8 +15,25 @@
  */
 
 import type { StorybookConfig } from "@storybook/react-vite";
+import { createRequire } from "node:module";
+import path from "node:path";
 
 const storybookBasePath = process.env.STORYBOOK_BASE_PATH;
+
+// Pin date-fns to the v4 install (the one @osdk/faux requires for
+// `constructNow`). Two date-fns versions are hoisted into the workspace
+// (v2 via react-day-picker, v4 via faux); without this alias Vite's deps
+// optimizer picks v2 and faux modules crash at runtime.
+const dateFnsV4 = path.dirname(
+  createRequire(import.meta.url).resolve(
+    "date-fns/package.json",
+    {
+      paths: [
+        path.resolve(import.meta.dirname ?? "", "../../faux"),
+      ],
+    },
+  ),
+);
 
 const config: StorybookConfig = {
   stories: ["../src/**/*.stories.@(js|jsx|ts|tsx|mdx)"],
@@ -69,6 +86,7 @@ const config: StorybookConfig = {
     // Ensure proper resolution of workspace packages
     config.resolve = {
       ...config.resolve,
+      dedupe: [...(config.resolve?.dedupe ?? []), "date-fns"],
       alias: {
         ...config.resolve?.alias,
         // Polyfill Node.js modules for browser
@@ -79,6 +97,7 @@ const config: StorybookConfig = {
         "node:crypto": new URL("./crypto-polyfill.ts", import.meta.url)
           .pathname,
         "node:util": new URL("./util-polyfill.ts", import.meta.url).pathname,
+        "date-fns": dateFnsV4,
       },
     };
 


### PR DESCRIPTION
## Summary

filter-list per-item action icons (search, overflow menu) and drag handles were permanently visible in the officenetwork sandbox because tailwind's `@layer base` preflight (`button { opacity: 1 }`) was overriding the hover-only `.headerActionButton { opacity: 0 }` rule from `@osdk/react-components`. cascade layer order ended up `osdk.tokens, osdk.components, theme, base, components, utilities` — so tailwind's base layer won.

separate but related: storybook's vite dep optimizer was hoisting date-fns v2 (pulled in by react-day-picker) instead of v4 (pulled in by @osdk/faux for \`constructNow\`), crashing the preview on \`filterTimeSeriesData.ts\` import.

• declare cascade layer order in officenetwork \`index.css\` so \`osdk.components\` comes last in the layer order and wins over tailwind's base/components/utilities
• alias \`date-fns\` to the v4 install in \`react-components-storybook/.storybook/main.ts\` via \`createRequire\` resolved through \`@osdk/faux\`, plus \`resolve.dedupe: ["date-fns"]\`

## Test plan

- [ ] run officenetwork locally (\`pnpm --filter @osdk/e2e.sandbox.officenetwork dev\`) and confirm filter-list per-item icons are hidden until you hover the row
- [ ] run storybook locally (\`pnpm --filter @osdk/react-components-storybook dev\`) and confirm any date-fns-dependent story (e.g. filter-list with timeline / date-range) loads without \`constructNow\` errors