### PR TITLE
fix tailwind preflight overriding osdk.components in officenetwork

### DIFF
--- a/packages/e2e.sandbox.officenetwork/src/index.css
+++ b/packages/e2e.sandbox.officenetwork/src/index.css
@@ -1,3 +1,8 @@
+/* Cascade layer order: tailwind layers first, osdk last so osdk.components
+   wins over tailwind's preflight (e.g. button { opacity: 1 } would otherwise
+   override .headerActionButton { opacity: 0 } from react-components). */
+@layer theme, base, components, utilities, osdk.tokens, osdk.components;
+
 @import "@osdk/react-components/styles.css";
 @import "tailwindcss";
 


### PR DESCRIPTION
## Summary

filter-list per-item action icons (search, overflow menu) and drag handles were permanently visible in the officenetwork sandbox because tailwind's `@layer base` preflight (`button { opacity: 1 }`) was overriding the hover-only `.headerActionButton { opacity: 0 }` rule from `@osdk/react-components`. cascade layer order ended up `osdk.tokens, osdk.components, theme, base, components, utilities` — tailwind's base won.

• declare cascade layer order in officenetwork `index.css` so `osdk.components` comes last in the layer order and wins over tailwind's base/components/utilities

## Test plan

- [ ] run officenetwork locally (`pnpm --filter @osdk/e2e.sandbox.officenetwork dev`) and confirm filter-list per-item icons (search, 3-dot overflow, drag handle) are hidden until you hover the row