### PR TITLE
Add createTheme API

### DIFF
--- a/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/BrandThemeDecorator.tsx
+++ b/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/BrandThemeDecorator.tsx
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
+import { OsdkThemeProvider } from "@osdk/react-components/experimental/theme";
 import type { Decorator } from "@storybook/react-vite";
-import React, { useLayoutEffect, useMemo } from "react";
-import { resolveThemeCssVariables } from "./brandThemeCssVariables.js";
+import React, { useMemo } from "react";
+import { resolveBrandTheme } from "./brandThemeCssVariables.js";
 import {
   BRAND_THEME_PRESET_GLOBAL_KEY,
   parseBrandThemePresetGlobal,
+  resolveBrandThemePreset,
 } from "./brandThemeState.js";
 
 interface BrandThemeDecoratorProps {
@@ -27,54 +29,28 @@ interface BrandThemeDecoratorProps {
   globals: Record<string, unknown>;
 }
 
-interface PreviousCssVariableValue {
-  value: string;
-  priority: string;
-}
-
 export const BrandThemeDecorator = React.memo(function BrandThemeDecoratorFn(
   { Story, globals }: BrandThemeDecoratorProps,
 ) {
   const selectedPresetGlobal = globals[BRAND_THEME_PRESET_GLOBAL_KEY];
-  const cssVariables = useMemo(
-    () =>
-      resolveThemeCssVariables(
-        parseBrandThemePresetGlobal(selectedPresetGlobal),
-      ),
+  const selectedPreset = useMemo(
+    () => parseBrandThemePresetGlobal(selectedPresetGlobal),
     [selectedPresetGlobal],
   );
+  const themePreset = useMemo(
+    () => resolveBrandThemePreset(selectedPreset),
+    [selectedPreset],
+  );
+  const theme = useMemo(
+    () => resolveBrandTheme(selectedPreset),
+    [selectedPreset],
+  );
 
-  useLayoutEffect(function applyBrandThemeCssVariables() {
-    const rootStyle = document.documentElement.style;
-    const previousValues = new Map<string, PreviousCssVariableValue>();
-
-    for (const [cssPropertyName, cssPropertyValue] of cssVariables) {
-      previousValues.set(
-        cssPropertyName,
-        {
-          priority: rootStyle.getPropertyPriority(cssPropertyName),
-          value: rootStyle.getPropertyValue(cssPropertyName),
-        },
-      );
-      rootStyle.setProperty(cssPropertyName, cssPropertyValue);
-    }
-
-    return () => {
-      for (const [cssPropertyName, previous] of previousValues) {
-        if (previous.value === "") {
-          rootStyle.removeProperty(cssPropertyName);
-        } else {
-          rootStyle.setProperty(
-            cssPropertyName,
-            previous.value,
-            previous.priority,
-          );
-        }
-      }
-    };
-  }, [cssVariables]);
-
-  return <Story />;
+  return (
+    <OsdkThemeProvider colorScheme={themePreset.colorMode} theme={theme}>
+      <Story />
+    </OsdkThemeProvider>
+  );
 });
 
 export const withBrandThemeDecorator: Decorator = (Story, context) => (

--- a/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/__tests__/BrandThemeDecorator.spec.tsx
+++ b/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/__tests__/BrandThemeDecorator.spec.tsx
@@ -58,6 +58,7 @@ function renderDecorator(element: React.ReactElement) {
 describe("BrandThemeDecorator", () => {
   afterEach(() => {
     document.documentElement.removeAttribute("style");
+    document.documentElement.removeAttribute("data-bp-color-scheme");
     document.body.replaceChildren();
   });
 
@@ -74,6 +75,9 @@ describe("BrandThemeDecorator", () => {
         "--osdk-intent-primary-rest",
       ),
     ).toBe("#16a34a");
+    expect(
+      document.documentElement.getAttribute("data-bp-color-scheme"),
+    ).toBe("dark");
   });
 
   it("removes stale preset variables when the selected preset changes", () => {

--- a/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/brandThemeCssVariables.ts
+++ b/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/brandThemeCssVariables.ts
@@ -15,6 +15,10 @@
  */
 
 import {
+  createTheme,
+  type OsdkTheme,
+} from "@osdk/react-components/experimental/theme";
+import {
   type BrandThemePresetSelection,
   resolveBrandThemePreset,
 } from "./brandThemeState.js";
@@ -22,9 +26,9 @@ import { SEMANTIC_TOKEN_MAP } from "./semanticTokenMap.js";
 
 export function resolveThemeCssVariables(
   selection: BrandThemePresetSelection,
-): Map<string, string> {
+): Map<`--${string}`, string> {
   const preset = resolveBrandThemePreset(selection);
-  const variables = new Map<string, string>();
+  const variables = new Map<`--${string}`, string>();
 
   for (const assignment of preset.assignments) {
     const cssPropertyNames = SEMANTIC_TOKEN_MAP[assignment.role];
@@ -50,6 +54,16 @@ export function resolveThemeCssVariables(
   }
 
   return variables;
+}
+
+export function resolveBrandTheme(
+  selection: BrandThemePresetSelection,
+): OsdkTheme {
+  return createTheme({
+    cssVariables: Object.fromEntries(
+      resolveThemeCssVariables(selection),
+    ) as Partial<Record<`--${string}`, string>>,
+  });
 }
 
 function formatTokenValue(

--- a/packages/react-components-storybook/.storybook/preview.tsx
+++ b/packages/react-components-storybook/.storybook/preview.tsx
@@ -16,7 +16,6 @@
 
 import { createClient } from "@osdk/client";
 import { OsdkProvider } from "@osdk/react";
-import { OsdkThemeProvider } from "@osdk/react-components/experimental/theme";
 import type { Preview } from "@storybook/react-vite";
 import { initialize, mswLoader } from "msw-storybook-addon";
 import { fauxFoundry, setupFauxFoundry } from "../src/mocks/fauxFoundry.js";
@@ -25,11 +24,6 @@ import {
   brandThemeGlobalTypes,
   initialBrandThemeGlobals,
 } from "./addons/brand-theme-extractor/brandThemeGlobalTypes.js";
-import {
-  BRAND_THEME_PRESET_GLOBAL_KEY,
-  parseBrandThemePresetGlobal,
-  resolveBrandThemePreset,
-} from "./addons/brand-theme-extractor/brandThemeState.js";
 import "./styles.css";
 
 // Initialize MSW with proper options
@@ -81,18 +75,11 @@ const preview: Preview = {
     await fauxFoundryReady;
   }, mswLoader],
   decorators: [
-    (Story, context) => {
-      const themePreset = resolveBrandThemePreset(
-        parseBrandThemePresetGlobal(
-          context.globals[BRAND_THEME_PRESET_GLOBAL_KEY],
-        ),
-      );
+    (Story) => {
       return (
         <div className="root">
           <OsdkProvider client={mockClient}>
-            <OsdkThemeProvider theme={themePreset.colorMode}>
-              <Story />
-            </OsdkThemeProvider>
+            <Story />
           </OsdkProvider>
         </div>
       );

--- a/packages/react-components/docs/CSSVariables.md
+++ b/packages/react-components/docs/CSSVariables.md
@@ -1508,7 +1508,7 @@ For more comprehensive theming, override the Blueprint tokens that the OSDK toke
 
 ## Dark Mode
 
-`@osdk/react-components` ships built-in dark-theme overrides that activate when `[data-bp-color-scheme="dark"]` is set on an ancestor element (typically `<html>`) — matching Blueprint's own convention so the OSDK + Blueprint tokens flip together. The supported way to set the attribute is `<OsdkThemeProvider>` from `@osdk/react-components/experimental/theme`; see [OsdkThemeProvider](./OsdkThemeProvider.md) for the full reference, including `defaultTheme="system"` (the default, follows `prefers-color-scheme`), runtime toggles via `useOsdkTheme`, and controlled mode for integrating with an external theme store.
+`@osdk/react-components` ships built-in dark-theme overrides that activate when `[data-bp-color-scheme="dark"]` is set on an ancestor element (typically `<html>`) — matching Blueprint's own convention so the OSDK + Blueprint tokens flip together. The supported way to set the attribute is `<OsdkThemeProvider>` from `@osdk/react-components/experimental/theme`; see [OsdkThemeProvider](./OsdkThemeProvider.md) for the full reference, including `defaultColorScheme="system"` (the default, follows `prefers-color-scheme`), runtime toggles via `useOsdkTheme`, and controlled mode for integrating with an external color-scheme store.
 
 Under `[data-bp-color-scheme="dark"]` Blueprint flips its own `--bp-*` tokens, so `dark.css` only re-maps the subset of `--osdk-*` tokens that have no `--bp-*` counterpart or that intentionally diverge from Blueprint's value.
 

--- a/packages/react-components/docs/OsdkThemeProvider.md
+++ b/packages/react-components/docs/OsdkThemeProvider.md
@@ -1,32 +1,15 @@
 # OsdkThemeProvider
 
-Provides OSDK theme state to descendants and writes a `data-bp-color-scheme` attribute onto the document so the OSDK + Blueprint design tokens activate the right theme. Components inside the provider re-render automatically when the resolved theme changes.
-
-## Prerequisites
-
-Before using `OsdkThemeProvider`, complete the library setup described in [Prerequisites](./Prerequisites.md), in particular the CSS layer imports - the provider only flips an attribute; the OSDK token CSS does the rest.
-
-## Table of Contents
-
-- [Import](#import)
-- [Quick start](#quick-start)
-- [Props reference](#props-reference)
-- [`useOsdkTheme` hook](#useosdktheme-hook)
-- [Examples](#examples)
-  - [Default: follow the OS preference](#default-follow-the-os-preference)
-  - [Force light or dark with `defaultTheme`](#force-light-or-dark-with-defaulttheme)
-  - [Build a `ThemeToggle`](#build-a-themetoggle)
-  - [Drive the theme from an external store (controlled mode)](#drive-the-theme-from-an-external-store-controlled-mode)
-  - [Scope theming to a subtree](#scope-theming-to-a-subtree)
-- [Branching on the resolved theme in JS](#branching-on-the-resolved-theme-in-js)
+Provides OSDK color-scheme state to descendants, writes `data-bp-color-scheme` onto the DOM, and optionally applies custom design-token CSS variables created with `createTheme`.
 
 ## Import
 
 ```tsx
 import {
-  type OsdkThemeMode,
+  createTheme,
+  type OsdkColorScheme,
   OsdkThemeProvider,
-  type ResolvedOsdkTheme,
+  type ResolvedOsdkColorScheme,
   useOsdkTheme,
 } from "@osdk/react-components/experimental/theme";
 ```
@@ -47,21 +30,20 @@ function App() {
 }
 ```
 
-With no props the provider follows `prefers-color-scheme` and re-renders when the OS preference changes. To override the OS at runtime, descendants call `setTheme` from [`useOsdkTheme`](#useosdktheme-hook).
-
-> **Always render the provider somewhere above OSDK components.** OSDK components stay in light mode without it — the CSS only flips when `data-bp-color-scheme="dark"` is on an ancestor, and the provider is the supported way to manage that attribute. If an external store already owns your theme value, use [controlled mode](#drive-the-theme-from-an-external-store-controlled-mode) instead of skipping the provider — that way descendants can still call `useOsdkTheme`.
+With no props, the provider follows `prefers-color-scheme` and re-renders when the OS preference changes. To override the OS at runtime, descendants call `setColorScheme` from `useOsdkTheme`.
 
 ## Props reference
 
-| Prop             | Type                                          | Default                    | Description                                                                                                                                                                                                                                                                                             |
-| ---------------- | --------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `theme`          | `"light" \| "dark" \| "system"` _(optional)_  | —                          | Controlled theme. When provided, the provider does not maintain its own state — the parent must respond to `onThemeChanged` (or update its own external store) and re-render with the new value. See [Drive the theme from an external store](#drive-the-theme-from-an-external-store-controlled-mode). |
-| `defaultTheme`   | `"light" \| "dark" \| "system"`               | `"system"`                 | Initial theme when uncontrolled. Ignored when `theme` is provided. The provider owns the state from then on; descendants change it at runtime via `useOsdkTheme().setTheme`.                                                                                                                            |
-| `onThemeChanged` | `(theme: OsdkThemeMode) => void` _(optional)_ | —                          | Fires whenever a descendant calls `setTheme`. Use this to layer side effects (persistence, analytics) on top of the default state update, or to drive an external store in controlled mode.                                                                                                             |
-| `target`         | `HTMLElement \| null` _(optional)_            | `document.documentElement` | Element to write `data-bp-color-scheme` onto. Defaults to `<html>` so Blueprint portals (popovers, dialogs, tooltips) — which render outside the React tree — also receive the theme. See [Scope theming to a subtree](#scope-theming-to-a-subtree).                                                    |
-| `children`       | `React.ReactNode`                             | —                          | Subtree that should resolve the theme via `useOsdkTheme`.                                                                                                                                                                                                                                               |
+| Prop                   | Type                                                  | Default                    | Description                                                                                                             |
+| ---------------------- | ----------------------------------------------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `colorScheme`          | `"light" \| "dark" \| "system"` _(optional)_          | —                          | Controlled color scheme. When provided, the parent must update it in response to `onColorSchemeChanged`.                |
+| `defaultColorScheme`   | `"light" \| "dark" \| "system"`                       | `"system"`                 | Initial color scheme when uncontrolled. Ignored when `colorScheme` is provided.                                         |
+| `onColorSchemeChanged` | `(colorScheme: OsdkColorScheme) => void` _(optional)_ | —                          | Fires whenever a descendant calls `setColorScheme`.                                                                     |
+| `theme`                | `OsdkTheme` _(optional)_                              | —                          | Custom design-token theme created with `createTheme`.                                                                   |
+| `target`               | `HTMLElement \| null` _(optional)_                    | `document.documentElement` | Element to write the color-scheme attribute and theme CSS variables onto. Defaults to `<html>` so portals inherit them. |
+| `children`             | `React.ReactNode`                                     | —                          | Subtree that should resolve the color scheme via `useOsdkTheme`.                                                        |
 
-### `defaultTheme` modes
+## Color scheme modes
 
 | Mode       | Behavior                                                                                |
 | ---------- | --------------------------------------------------------------------------------------- |
@@ -69,170 +51,166 @@ With no props the provider follows `prefers-color-scheme` and re-renders when th
 | `"light"`  | Starts in light mode regardless of the OS preference.                                   |
 | `"dark"`   | Starts in dark mode regardless of the OS preference.                                    |
 
-`"system"` is the only mode where the resolved theme can change without anyone calling `setTheme` — it reacts to the OS preference flipping while your app is open.
+`"system"` is the only mode where the resolved color scheme can change without anyone calling `setColorScheme`.
+
+## Custom themes
+
+Use `createTheme` for brand tokens. Color scheme remains a separate prop so runtime light/dark toggles do not require recreating the design-token object.
+
+```tsx
+import {
+  createTheme,
+  OsdkThemeProvider,
+} from "@osdk/react-components/experimental/theme";
+
+const acmeTheme = createTheme({
+  colors: {
+    background: "#ffffff",
+    surface: "#f6f7f9",
+    text: "#1c2127",
+    textMuted: "#5f6b7c",
+    primary: "#7c3aed",
+    primaryForeground: "#ffffff",
+    border: "#d9dce3",
+  },
+  typography: {
+    fontFamily: "Inter, system-ui, sans-serif",
+    bodySmall: 12,
+    bodyMedium: 14,
+    bodyLarge: 16,
+  },
+  radius: 6,
+  spacing: 4,
+});
+
+export function Root() {
+  return (
+    <OsdkThemeProvider theme={acmeTheme}>
+      <App />
+    </OsdkThemeProvider>
+  );
+}
+```
+
+`createTheme` maps semantic OSDK tokens to the underlying OSDK and Blueprint CSS variables. Use the `cssVariables` escape hatch for variables that do not have a semantic field yet:
+
+```tsx
+const theme = createTheme({
+  colors: { primary: "#16a34a" },
+  cssVariables: {
+    "--osdk-table-header-bg": "#14532d",
+  },
+});
+```
 
 ## `useOsdkTheme` hook
 
 ```tsx
-const { theme, resolvedTheme, setTheme } = useOsdkTheme();
+const { colorScheme, resolvedColorScheme, setColorScheme, theme } =
+  useOsdkTheme();
 ```
 
-| Field           | Type                            | Description                                                                                               |
-| --------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `theme`         | `"light" \| "dark" \| "system"` | The requested mode, including `"system"`.                                                                 |
-| `resolvedTheme` | `"light" \| "dark"`             | The concrete theme actually applied to the DOM. When `theme === "system"`, tracks `prefers-color-scheme`. |
-| `setTheme`      | `(next: OsdkThemeMode) => void` | Switch the requested mode at runtime.                                                                     |
+| Field                 | Type                              | Description                                                                                                     |
+| --------------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `colorScheme`         | `"light" \| "dark" \| "system"`   | The requested mode, including `"system"`.                                                                       |
+| `resolvedColorScheme` | `"light" \| "dark"`               | The concrete color scheme currently applied to the DOM. When `colorScheme === "system"`, tracks the OS setting. |
+| `setColorScheme`      | `(next: OsdkColorScheme) => void` | Switch the requested mode at runtime.                                                                           |
+| `theme`               | `OsdkTheme \| undefined`          | The custom design-token theme currently applied by the provider, if any.                                        |
 
 Must be called from a descendant of `<OsdkThemeProvider>`; throws otherwise.
 
 ## Examples
 
-### Default: follow the OS preference
-
-The simplest setup — no props needed. The provider starts in `"system"` mode, listens to `prefers-color-scheme`, and flips automatically when the user toggles their OS appearance.
+### Force light or dark with `defaultColorScheme`
 
 ```tsx
-import { OsdkThemeProvider } from "@osdk/react-components/experimental/theme";
-
-export function Root() {
-  return (
-    <OsdkProvider client={client}>
-      <OsdkThemeProvider>
-        <App />
-      </OsdkThemeProvider>
-    </OsdkProvider>
-  );
-}
-```
-
-To verify this in development, open Chrome DevTools → `⌘⇧P` → "Show Rendering" → set "Emulate CSS media feature prefers-color-scheme" to `light` or `dark`.
-
-### Force light or dark with `defaultTheme`
-
-Pin the initial mode if your app intentionally ships in light or dark regardless of the OS:
-
-```tsx
-<OsdkThemeProvider defaultTheme="dark">
+<OsdkThemeProvider defaultColorScheme="dark">
   <App />
 </OsdkThemeProvider>;
 ```
 
-Users can still switch at runtime via `useOsdkTheme().setTheme`; `defaultTheme` only seeds the initial value.
+Users can still switch at runtime via `useOsdkTheme().setColorScheme`; `defaultColorScheme` only seeds the initial value.
 
-### Build a `ThemeToggle`
-
-A typical settings-bar control that lets the user pick light/dark/system:
+### Build a color-scheme toggle
 
 ```tsx
 import {
-  type OsdkThemeMode,
+  type OsdkColorScheme,
   useOsdkTheme,
 } from "@osdk/react-components/experimental/theme";
 
-const MODES: readonly OsdkThemeMode[] = ["light", "dark", "system"];
+const COLOR_SCHEMES: readonly OsdkColorScheme[] = ["light", "dark", "system"];
 
 export function ThemeToggle() {
-  const { theme, resolvedTheme, setTheme } = useOsdkTheme();
+  const { colorScheme, resolvedColorScheme, setColorScheme } = useOsdkTheme();
   return (
     <div role="group" aria-label="Theme">
-      {MODES.map((mode) => (
+      {COLOR_SCHEMES.map((nextColorScheme) => (
         <button
-          key={mode}
+          key={nextColorScheme}
           type="button"
-          onClick={() => setTheme(mode)}
-          aria-pressed={theme === mode}
+          onClick={() => setColorScheme(nextColorScheme)}
+          aria-pressed={colorScheme === nextColorScheme}
         >
-          {mode}
+          {nextColorScheme}
         </button>
       ))}
-      {theme === "system" && (
-        <span aria-live="polite">(resolved: {resolvedTheme})</span>
+      {colorScheme === "system" && (
+        <span aria-live="polite">(resolved: {resolvedColorScheme})</span>
       )}
     </div>
   );
 }
 ```
 
-Render it anywhere inside the provider:
-
-```tsx
-<OsdkThemeProvider>
-  <Header>
-    <ThemeToggle />
-  </Header>
-  <main>{/* ... */}</main>
-</OsdkThemeProvider>;
-```
-
-### Drive the theme from an external store (controlled mode)
-
-If the theme value already lives outside the OSDK tree (e.g. in a parent design-system provider), pass it in via the `theme` prop. The provider stops owning state; you re-render it with the new value when the store changes, and the provider rewrites `data-bp-color-scheme` accordingly.
-
-```tsx
-import {
-  type OsdkThemeMode,
-  OsdkThemeProvider,
-} from "@osdk/react-components/experimental/theme";
-import { useAppTheme } from "../store/theme.js"; // your own store hook
-
-export function AppRoot() {
-  // `theme` is owned by the app's store, not by the provider.
-  const theme = useAppTheme();
-  return (
-    <OsdkProvider client={client}>
-      <OsdkThemeProvider theme={theme}>
-        <App />
-      </OsdkThemeProvider>
-    </OsdkProvider>
-  );
-}
-```
-
-If descendants call `setTheme` from `useOsdkTheme()`, controlled mode does **not** update the provider's state — it fires `onThemeChanged` so you can route the change back into your store.
+### Drive the color scheme from an external store
 
 ```tsx
 <OsdkThemeProvider
-  theme={theme}
-  onThemeChanged={(next) => dispatch(setTheme(next))}
+  colorScheme={colorScheme}
+  onColorSchemeChanged={(next) => dispatch(setColorScheme(next))}
 >
   <App />
 </OsdkThemeProvider>;
 ```
 
-Use controlled mode whenever an external source of truth exists. Use uncontrolled (just `defaultTheme`) when the provider can own the state itself.
+Use controlled mode whenever an external source of truth exists. Use uncontrolled mode when the provider can own the state itself.
 
 ### Scope theming to a subtree
 
-By default the provider writes `data-bp-color-scheme` onto `<html>` so portaled overlays (popovers, dialogs, tooltips) inherit the theme. To theme only a slice of the page — for example, embedding an OSDK dashboard inside a host app that already manages its own theme — pass a `target`:
+By default the provider writes to `<html>` so portaled overlays inherit the color scheme and theme variables. To theme only a slice of the page, pass a `target`:
 
 ```tsx
-import { useRef } from "react";
+import { useState } from "react";
 
 export function DashboardEmbed() {
-  const scopeRef = useRef<HTMLDivElement>(null);
+  const [themeTarget, setThemeTarget] = useState<HTMLDivElement | null>(null);
+
   return (
-    <div ref={scopeRef}>
-      <OsdkThemeProvider target={scopeRef.current} defaultTheme="dark">
-        <Dashboard />
-      </OsdkThemeProvider>
+    <div ref={setThemeTarget}>
+      {themeTarget != null && (
+        <OsdkThemeProvider target={themeTarget} defaultColorScheme="dark">
+          <Dashboard />
+        </OsdkThemeProvider>
+      )}
     </div>
   );
 }
 ```
 
-Trade-off: portals from `@base-ui/react` / Blueprint render in a portal container that is **not** a descendant of `scopeRef`, so dropdowns and tooltips opened from inside the scoped subtree will follow the document-level theme, not the scoped one. Use the default (`<html>`) target unless you specifically need per-region theming.
+### Branch on the resolved color scheme in JS
 
-## Branching on the resolved theme in JS
-
-If you need to swap an asset or change a non-CSS value based on theme, read `resolvedTheme` — not `theme` — so the `"system"` mode resolves to a concrete `"light"` or `"dark"` for you:
+If you need to swap an asset or change a non-CSS value based on the resolved color scheme, read `resolvedColorScheme`:
 
 ```tsx
-function LogoMark() {
-  const { resolvedTheme } = useOsdkTheme();
+function Logo() {
+  const { resolvedColorScheme } = useOsdkTheme();
   return (
     <img
-      src={resolvedTheme === "dark" ? "/logo-dark.svg" : "/logo-light.svg"}
-      alt="Logo"
+      src={resolvedColorScheme === "dark"
+        ? "/logo-dark.svg"
+        : "/logo-light.svg"}
+      alt="Acme"
     />
   );
 }

--- a/packages/react-components/docs/Prerequisites.md
+++ b/packages/react-components/docs/Prerequisites.md
@@ -145,7 +145,7 @@ function App() {
 
 By default the provider follows `prefers-color-scheme` and writes the resolved value to `data-bp-color-scheme` on `<html>` — matching [Blueprint's convention](https://blueprintjs.com/docs/#core/colors) so the theme also applies to portaled overlays (popovers, dialogs, tooltips).
 
-See [OsdkThemeProvider](./OsdkThemeProvider.md) for the full reference, including the `defaultTheme` modes, the `useOsdkTheme` hook, persisting the user's choice, and integrating with an external theme store via controlled mode.
+See [OsdkThemeProvider](./OsdkThemeProvider.md) for the full reference, including the `defaultColorScheme` modes, the `useOsdkTheme` hook, persisting the user's choice, and integrating with an external color-scheme store via controlled mode.
 
 ### Accessibility
 

--- a/packages/react-components/src/public/experimental/theme.ts
+++ b/packages/react-components/src/public/experimental/theme.ts
@@ -14,13 +14,19 @@
  * limitations under the License.
  */
 
+export { createTheme } from "../../theme/createTheme.js";
 export {
   OsdkThemeProvider,
   type OsdkThemeProviderProps,
 } from "../../theme/OsdkThemeProvider.js";
 export type {
+  OsdkColorScheme,
+  OsdkTheme,
+  OsdkThemeColors,
   OsdkThemeContextValue,
-  OsdkThemeMode,
-  ResolvedOsdkTheme,
+  OsdkThemeOverride,
+  OsdkThemeTokenValue,
+  OsdkThemeTypography,
+  ResolvedOsdkColorScheme,
 } from "../../theme/types.js";
 export { useOsdkTheme } from "../../theme/useOsdkTheme.js";

--- a/packages/react-components/src/theme/OsdkThemeProvider.tsx
+++ b/packages/react-components/src/theme/OsdkThemeProvider.tsx
@@ -17,33 +17,45 @@
 import React from "react";
 import { OsdkThemeContext } from "./OsdkThemeContext.js";
 import type {
+  OsdkColorScheme,
+  OsdkTheme,
   OsdkThemeContextValue,
-  OsdkThemeMode,
-  ResolvedOsdkTheme,
+  ResolvedOsdkColorScheme,
 } from "./types.js";
 import { useSystemTheme } from "./useSystemTheme.js";
 
 export const DATA_THEME_ATTR = "data-bp-color-scheme";
 
+interface PreviousCssVariableValue {
+  priority: string;
+  value: string;
+}
+
 export interface OsdkThemeProviderProps {
   /**
-   * Controlled theme. When provided, the provider does not maintain its
-   * own state — the parent must respond to `onThemeChanged` (or update its
-   * own external store) and re-render with the new value. Use this when an
-   * external store already owns the theme value (e.g. Redux/Zustand, a
-   * parent design-system provider, or a Storybook toolbar).
+   * Controlled color scheme. When provided, the provider does not maintain
+   * its own state — the parent must respond to `onColorSchemeChanged` (or
+   * update its own external store) and re-render with the new value.
    */
-  theme?: OsdkThemeMode;
+  colorScheme?: OsdkColorScheme;
 
   /**
-   * Initial theme when uncontrolled. Ignored when `theme` is provided.
+   * Initial color scheme when uncontrolled. Ignored when `colorScheme` is
+   * provided.
    *
    * @default "system"
    */
-  defaultTheme?: OsdkThemeMode;
+  defaultColorScheme?: OsdkColorScheme;
 
-  /** Fires whenever `setTheme` is called from a descendant. */
-  onThemeChanged?: (theme: OsdkThemeMode) => void;
+  /** Fires whenever `setColorScheme` is called from a descendant. */
+  onColorSchemeChanged?: (colorScheme: OsdkColorScheme) => void;
+
+  /**
+   * Custom design-token theme created with {@link createTheme}. Color scheme
+   * state remains separate so runtime light/dark toggles do not need to
+   * recreate brand-token objects.
+   */
+  theme?: OsdkTheme;
 
   /**
    * Element to write `data-bp-color-scheme` onto.
@@ -62,39 +74,43 @@ export interface OsdkThemeProviderProps {
  * `data-bp-color-scheme` attribute onto the document so the CSS in
  * `tokens/base-tokens/dark.css` activates the right theme.
  *
- * `defaultTheme="system"` (default) follows the OS `prefers-color-scheme`
- * setting and re-renders when it changes. `defaultTheme="light"` /
- * `defaultTheme="dark"` start in the given theme regardless of the OS
- * preference. Call {@link useOsdkTheme}().setTheme from a descendant to
- * switch modes at runtime.
+ * `defaultColorScheme="system"` (default) follows the OS
+ * `prefers-color-scheme` setting and re-renders when it changes.
+ * `defaultColorScheme="light"` / `defaultColorScheme="dark"` start in the
+ * given color scheme regardless of the OS preference. Call
+ * {@link useOsdkTheme}().setColorScheme from a descendant to switch modes at
+ * runtime.
  *
- * To integrate with an external theme store, pass `theme` (controlled
- * mode)
+ * To integrate with an external color-scheme store, pass `colorScheme`
+ * (controlled mode). Pass `theme` for custom design tokens created with
+ * {@link createTheme}.
  */
 export function OsdkThemeProvider({
-  theme: controlledTheme,
-  defaultTheme = "system",
-  onThemeChanged,
+  colorScheme: controlledColorScheme,
+  defaultColorScheme = "system",
+  onColorSchemeChanged,
+  theme,
   target,
   children,
 }: OsdkThemeProviderProps): React.ReactElement {
-  const [internalTheme, setInternalTheme] = React.useState<OsdkThemeMode>(
-    defaultTheme,
+  const [internalColorScheme, setInternalColorScheme] = React.useState<
+    OsdkColorScheme
+  >(
+    defaultColorScheme,
   );
-  const theme = controlledTheme ?? internalTheme;
+  const colorScheme = controlledColorScheme ?? internalColorScheme;
 
   const systemTheme = useSystemTheme();
-  const resolvedTheme: ResolvedOsdkTheme = theme === "system"
+  const resolvedColorScheme: ResolvedOsdkColorScheme = colorScheme === "system"
     ? systemTheme
-    : theme;
+    : colorScheme;
 
-  React.useLayoutEffect(() => {
-    const element = target
-      ?? (typeof document !== "undefined" ? document.documentElement : null);
+  React.useLayoutEffect(function applyColorSchemeAttribute() {
+    const element = getThemeTarget(target);
     if (element == null) return;
 
     const previous = element.getAttribute(DATA_THEME_ATTR);
-    element.setAttribute(DATA_THEME_ATTR, resolvedTheme);
+    element.setAttribute(DATA_THEME_ATTR, resolvedColorScheme);
     return () => {
       if (previous == null) {
         element.removeAttribute(DATA_THEME_ATTR);
@@ -102,21 +118,57 @@ export function OsdkThemeProvider({
         element.setAttribute(DATA_THEME_ATTR, previous);
       }
     };
-  }, [resolvedTheme, target]);
+  }, [resolvedColorScheme, target]);
 
-  const setTheme = React.useCallback(
-    (next: OsdkThemeMode) => {
-      if (controlledTheme === undefined) {
-        setInternalTheme(next);
+  React.useLayoutEffect(function applyThemeCssVariables() {
+    const element = getThemeTarget(target);
+    if (element == null || theme == null || theme.cssVariables.size === 0) {
+      return;
+    }
+
+    const previousValues = new Map<string, PreviousCssVariableValue>();
+
+    for (const [cssVariableName, cssVariableValue] of theme.cssVariables) {
+      previousValues.set(cssVariableName, {
+        priority: element.style.getPropertyPriority(cssVariableName),
+        value: element.style.getPropertyValue(cssVariableName),
+      });
+      element.style.setProperty(cssVariableName, cssVariableValue);
+    }
+
+    return () => {
+      for (const [cssVariableName, previousValue] of previousValues) {
+        if (previousValue.value === "") {
+          element.style.removeProperty(cssVariableName);
+        } else {
+          element.style.setProperty(
+            cssVariableName,
+            previousValue.value,
+            previousValue.priority,
+          );
+        }
       }
-      onThemeChanged?.(next);
+    };
+  }, [target, theme]);
+
+  const setColorScheme = React.useCallback(
+    (next: OsdkColorScheme) => {
+      if (controlledColorScheme === undefined) {
+        setInternalColorScheme(next);
+      }
+      onColorSchemeChanged?.(next);
     },
-    [controlledTheme, onThemeChanged],
+    [controlledColorScheme, onColorSchemeChanged],
   );
 
   const value = React.useMemo<OsdkThemeContextValue>(
-    () => ({ theme, resolvedTheme, setTheme }),
-    [theme, resolvedTheme, setTheme],
+    () => ({
+      colorScheme,
+      resolvedColorScheme,
+      setColorScheme,
+      theme,
+    }),
+    [colorScheme, resolvedColorScheme, setColorScheme, theme],
   );
 
   return (
@@ -124,4 +176,9 @@ export function OsdkThemeProvider({
       {children}
     </OsdkThemeContext.Provider>
   );
+}
+
+function getThemeTarget(target: HTMLElement | null | undefined) {
+  return target
+    ?? (typeof document !== "undefined" ? document.documentElement : null);
 }

--- a/packages/react-components/src/theme/__tests__/OsdkThemeProvider.test.tsx
+++ b/packages/react-components/src/theme/__tests__/OsdkThemeProvider.test.tsx
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 
+// @vitest-environment happy-dom
+
 import { act, cleanup, render, screen } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTheme } from "../createTheme.js";
 import { DATA_THEME_ATTR, OsdkThemeProvider } from "../OsdkThemeProvider.js";
-import type { OsdkThemeMode } from "../types.js";
+import type { OsdkColorScheme } from "../types.js";
 import { useOsdkTheme } from "../useOsdkTheme.js";
 
 type MediaQueryListener = (event: { matches: boolean }) => void;
@@ -65,33 +68,33 @@ function installMatchMediaMock(initialMatches: boolean): {
 }
 
 function ThemeProbe(): React.ReactElement {
-  const { theme, resolvedTheme } = useOsdkTheme();
+  const { colorScheme, resolvedColorScheme } = useOsdkTheme();
   return (
     <div>
-      <span data-testid="theme">{theme}</span>
-      <span data-testid="resolved">{resolvedTheme}</span>
+      <span data-testid="color-scheme">{colorScheme}</span>
+      <span data-testid="resolved">{resolvedColorScheme}</span>
     </div>
   );
 }
 
 function ThemeToggle(): React.ReactElement {
-  const { setTheme } = useOsdkTheme();
+  const { setColorScheme } = useOsdkTheme();
   return (
     <>
       <button
         type="button"
         data-testid="set-light"
-        onClick={() => setTheme("light")}
+        onClick={() => setColorScheme("light")}
       />
       <button
         type="button"
         data-testid="set-dark"
-        onClick={() => setTheme("dark")}
+        onClick={() => setColorScheme("dark")}
       />
       <button
         type="button"
         data-testid="set-system"
-        onClick={() => setTheme("system")}
+        onClick={() => setColorScheme("system")}
       />
     </>
   );
@@ -107,6 +110,7 @@ describe("OsdkThemeProvider", () => {
   afterEach(() => {
     cleanup();
     document.documentElement.removeAttribute(DATA_THEME_ATTR);
+    document.documentElement.removeAttribute("style");
     media.cleanup();
   });
 
@@ -118,7 +122,7 @@ describe("OsdkThemeProvider", () => {
       </OsdkThemeProvider>,
     );
 
-    expect(screen.getByTestId("theme").textContent).toBe("system");
+    expect(screen.getByTestId("color-scheme").textContent).toBe("system");
     expect(screen.getByTestId("resolved").textContent).toBe("dark");
     expect(document.documentElement.getAttribute(DATA_THEME_ATTR)).toBe("dark");
   });
@@ -127,7 +131,7 @@ describe("OsdkThemeProvider", () => {
     // Set (prefers-color-scheme: dark) to true
     media.setMatches(true);
     render(
-      <OsdkThemeProvider defaultTheme="light">
+      <OsdkThemeProvider defaultColorScheme="light">
         <ThemeProbe />
       </OsdkThemeProvider>,
     );
@@ -158,7 +162,7 @@ describe("OsdkThemeProvider", () => {
     expect(document.documentElement.getAttribute(DATA_THEME_ATTR)).toBe("dark");
   });
 
-  it("setTheme updates the active theme in uncontrolled mode", () => {
+  it("setColorScheme updates the active color scheme in uncontrolled mode", () => {
     media.setMatches(true);
     render(
       <OsdkThemeProvider>
@@ -170,21 +174,24 @@ describe("OsdkThemeProvider", () => {
     expect(screen.getByTestId("resolved").textContent).toBe("dark");
 
     act(() => {
-      // Calls setTheme
+      // Calls setColorScheme
       screen.getByTestId("set-light").click();
     });
 
-    expect(screen.getByTestId("theme").textContent).toBe("light");
+    expect(screen.getByTestId("color-scheme").textContent).toBe("light");
     expect(screen.getByTestId("resolved").textContent).toBe("light");
     expect(document.documentElement.getAttribute(DATA_THEME_ATTR)).toBe(
       "light",
     );
   });
 
-  it("controlled mode ignores setTheme and fires onThemeChanged", () => {
-    const onThemeChanged = vi.fn();
+  it("controlled mode ignores setColorScheme and fires onColorSchemeChanged", () => {
+    const onColorSchemeChanged = vi.fn();
     render(
-      <OsdkThemeProvider theme="light" onThemeChanged={onThemeChanged}>
+      <OsdkThemeProvider
+        colorScheme="light"
+        onColorSchemeChanged={onColorSchemeChanged}
+      >
         <ThemeProbe />
         <ThemeToggle />
       </OsdkThemeProvider>,
@@ -193,13 +200,13 @@ describe("OsdkThemeProvider", () => {
     expect(screen.getByTestId("resolved").textContent).toBe("light");
 
     act(() => {
-      // Calls setTheme
+      // Calls setColorScheme
       screen.getByTestId("set-dark").click();
     });
 
-    expect(onThemeChanged).toHaveBeenCalledWith("dark");
+    expect(onColorSchemeChanged).toHaveBeenCalledWith("dark");
     // controlled mode: still light because parent didn't re-render
-    expect(screen.getByTestId("theme").textContent).toBe("light");
+    expect(screen.getByTestId("color-scheme").textContent).toBe("light");
     expect(document.documentElement.getAttribute(DATA_THEME_ATTR)).toBe(
       "light",
     );
@@ -207,9 +214,14 @@ describe("OsdkThemeProvider", () => {
 
   it("controlled theme re-renders propagate to the DOM", () => {
     function Harness(): React.ReactElement {
-      const [theme, setTheme] = React.useState<OsdkThemeMode>("light");
+      const [colorScheme, setColorScheme] = React.useState<OsdkColorScheme>(
+        "light",
+      );
       return (
-        <OsdkThemeProvider theme={theme} onThemeChanged={setTheme}>
+        <OsdkThemeProvider
+          colorScheme={colorScheme}
+          onColorSchemeChanged={setColorScheme}
+        >
           <ThemeProbe />
           <ThemeToggle />
         </OsdkThemeProvider>
@@ -222,18 +234,18 @@ describe("OsdkThemeProvider", () => {
     );
 
     act(() => {
-      // Calls setTheme
+      // Calls setColorScheme
       screen.getByTestId("set-dark").click();
     });
 
-    expect(screen.getByTestId("theme").textContent).toBe("dark");
+    expect(screen.getByTestId("color-scheme").textContent).toBe("dark");
     expect(document.documentElement.getAttribute(DATA_THEME_ATTR)).toBe("dark");
   });
 
   it("restores the previous data theme attribute on unmount", () => {
     document.documentElement.setAttribute(DATA_THEME_ATTR, "light");
     const { unmount } = render(
-      <OsdkThemeProvider defaultTheme="dark">
+      <OsdkThemeProvider defaultColorScheme="dark">
         <ThemeProbe />
       </OsdkThemeProvider>,
     );
@@ -250,7 +262,7 @@ describe("OsdkThemeProvider", () => {
   it("removes the data theme attribute on unmount when there was none", () => {
     expect(document.documentElement.getAttribute(DATA_THEME_ATTR)).toBeNull();
     const { unmount } = render(
-      <OsdkThemeProvider defaultTheme="dark">
+      <OsdkThemeProvider defaultColorScheme="dark">
         <ThemeProbe />
       </OsdkThemeProvider>,
     );
@@ -267,13 +279,134 @@ describe("OsdkThemeProvider", () => {
     document.body.appendChild(custom);
     try {
       render(
-        <OsdkThemeProvider defaultTheme="dark" target={custom}>
+        <OsdkThemeProvider defaultColorScheme="dark" target={custom}>
           <ThemeProbe />
         </OsdkThemeProvider>,
       );
 
       expect(custom.getAttribute(DATA_THEME_ATTR)).toBe("dark");
       expect(document.documentElement.getAttribute(DATA_THEME_ATTR)).toBeNull();
+    } finally {
+      document.body.removeChild(custom);
+    }
+  });
+
+  it("applies custom theme CSS variables to the default target", () => {
+    const theme = createTheme({
+      colors: {
+        primary: "#7c3aed",
+      },
+    });
+
+    render(
+      <OsdkThemeProvider theme={theme}>
+        <ThemeProbe />
+      </OsdkThemeProvider>,
+    );
+
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--osdk-intent-primary-rest",
+      ),
+    ).toBe("#7c3aed");
+  });
+
+  it("removes stale theme CSS variables when the theme changes", () => {
+    const firstTheme = createTheme({
+      colors: {
+        primary: "#7c3aed",
+      },
+      cssVariables: {
+        "--osdk-custom-token": "first",
+      },
+    });
+    const secondTheme = createTheme({
+      colors: {
+        primary: "#16a34a",
+      },
+    });
+
+    const { rerender } = render(
+      <OsdkThemeProvider theme={firstTheme}>
+        <ThemeProbe />
+      </OsdkThemeProvider>,
+    );
+
+    expect(
+      document.documentElement.style.getPropertyValue("--osdk-custom-token"),
+    ).toBe("first");
+
+    rerender(
+      <OsdkThemeProvider theme={secondTheme}>
+        <ThemeProbe />
+      </OsdkThemeProvider>,
+    );
+
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--osdk-intent-primary-rest",
+      ),
+    ).toBe("#16a34a");
+    expect(
+      document.documentElement.style.getPropertyValue("--osdk-custom-token"),
+    ).toBe("");
+  });
+
+  it("restores previous inline theme CSS variable values and priorities", () => {
+    document.documentElement.style.setProperty(
+      "--osdk-intent-primary-rest",
+      "rebeccapurple",
+      "important",
+    );
+    const theme = createTheme({
+      colors: {
+        primary: "#7c3aed",
+      },
+    });
+
+    const { unmount } = render(
+      <OsdkThemeProvider theme={theme}>
+        <ThemeProbe />
+      </OsdkThemeProvider>,
+    );
+
+    unmount();
+
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--osdk-intent-primary-rest",
+      ),
+    ).toBe("rebeccapurple");
+    expect(
+      document.documentElement.style.getPropertyPriority(
+        "--osdk-intent-primary-rest",
+      ),
+    ).toBe("important");
+  });
+  it("writes custom theme CSS variables to a custom target element", () => {
+    const custom = document.createElement("div");
+    document.body.appendChild(custom);
+    const theme = createTheme({
+      colors: {
+        primary: "#7c3aed",
+      },
+    });
+
+    try {
+      render(
+        <OsdkThemeProvider theme={theme} target={custom}>
+          <ThemeProbe />
+        </OsdkThemeProvider>,
+      );
+
+      expect(
+        custom.style.getPropertyValue("--osdk-intent-primary-rest"),
+      ).toBe("#7c3aed");
+      expect(
+        document.documentElement.style.getPropertyValue(
+          "--osdk-intent-primary-rest",
+        ),
+      ).toBe("");
     } finally {
       document.body.removeChild(custom);
     }

--- a/packages/react-components/src/theme/__tests__/createTheme.test.ts
+++ b/packages/react-components/src/theme/__tests__/createTheme.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { createTheme } from "../createTheme.js";
+
+describe("createTheme", () => {
+  it("maps semantic theme overrides to OSDK and Blueprint CSS variables", () => {
+    const theme = createTheme({
+      colors: {
+        background: "#ffffff",
+        primary: "#7c3aed",
+        textMuted: "#5f6b7c",
+      },
+      typography: {
+        bodySmall: 12,
+        fontFamily: "Inter, system-ui, sans-serif",
+        fontWeightBold: 600,
+      },
+      radius: 6,
+      transitionDuration: 150,
+    });
+
+    expect(theme.cssVariables.get("--osdk-background-primary")).toBe(
+      "#ffffff",
+    );
+    expect(theme.cssVariables.get("--osdk-intent-primary-rest")).toBe(
+      "#7c3aed",
+    );
+    expect(theme.cssVariables.get("--bp-intent-primary-rest")).toBe(
+      "#7c3aed",
+    );
+    expect(theme.cssVariables.get("--osdk-typography-color-muted")).toBe(
+      "#5f6b7c",
+    );
+    expect(theme.cssVariables.get("--osdk-typography-size-body-small")).toBe(
+      "12px",
+    );
+    expect(theme.cssVariables.get("--osdk-typography-family-default")).toBe(
+      "Inter, system-ui, sans-serif",
+    );
+    expect(theme.cssVariables.get("--osdk-typography-weight-bold")).toBe(
+      "600",
+    );
+    expect(theme.cssVariables.get("--osdk-surface-border-radius")).toBe("6px");
+    expect(theme.cssVariables.get("--osdk-emphasis-transition-duration")).toBe(
+      "150ms",
+    );
+  });
+
+  it("ignores empty resets and lets raw CSS variables override semantic values", () => {
+    const theme = createTheme({
+      colors: {
+        primary: "initial",
+        border: "",
+      },
+      spacing: 4,
+      cssVariables: {
+        "--osdk-surface-spacing": "0.5rem",
+        "--osdk-custom-token": "oklch(0.5 0.1 250)",
+        "--osdk-empty-token": "",
+      },
+    });
+
+    expect(theme.cssVariables.get("--osdk-intent-primary-rest")).toBe(
+      undefined,
+    );
+    expect(theme.cssVariables.get("--osdk-surface-border-color-default")).toBe(
+      undefined,
+    );
+    expect(theme.cssVariables.get("--osdk-surface-spacing")).toBe("0.5rem");
+    expect(theme.cssVariables.get("--osdk-custom-token")).toBe(
+      "oklch(0.5 0.1 250)",
+    );
+    expect(theme.cssVariables.has("--osdk-empty-token")).toBe(false);
+  });
+});

--- a/packages/react-components/src/theme/createTheme.ts
+++ b/packages/react-components/src/theme/createTheme.ts
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  SEMANTIC_TOKEN_MAP,
+  type SemanticTokenRole,
+} from "./semanticTokenMap.js";
+import type {
+  OsdkTheme,
+  OsdkThemeOverride,
+  OsdkThemeTokenValue,
+} from "./types.js";
+
+const COLOR_TOKEN_ROLES = {
+  background: "background",
+  border: "border",
+  danger: "danger",
+  icon: "icon-color",
+  primary: "primary",
+  primaryForeground: "primary-foreground",
+  secondary: "secondary",
+  secondaryForeground: "secondary-foreground",
+  success: "success",
+  surface: "surface",
+  text: "text",
+  textMuted: "text-muted",
+  warning: "warning",
+} as const satisfies Record<
+  keyof NonNullable<OsdkThemeOverride["colors"]>,
+  SemanticTokenRole
+>;
+
+const TYPOGRAPHY_TOKEN_ROLES = {
+  bodyLarge: "font-size-large",
+  bodyMedium: "font-size-medium",
+  bodySmall: "font-size-small",
+  fontFamily: "font-family",
+  fontWeightBold: "font-weight-bold",
+  fontWeightDefault: "font-weight-default",
+  lineHeight: "line-height",
+} as const satisfies Record<
+  keyof NonNullable<OsdkThemeOverride["typography"]>,
+  SemanticTokenRole
+>;
+
+const ROOT_TOKEN_ROLES = {
+  borderWidth: "border-width",
+  focusOffset: "focus-offset",
+  focusWidth: "focus-width",
+  radius: "border-radius",
+  shadow: "shadow",
+  spacing: "spacing",
+  transitionDuration: "transition-duration",
+} as const satisfies Record<
+  keyof Omit<OsdkThemeOverride, "colors" | "cssVariables" | "typography">,
+  SemanticTokenRole
+>;
+
+/**
+ * Converts semantic OSDK theme overrides into the concrete CSS variables used
+ * by OSDK and Blueprint components.
+ */
+export function createTheme(themeOverride: OsdkThemeOverride): OsdkTheme {
+  const cssVariables = new Map<`--${string}`, string>();
+
+  applyThemeSection(cssVariables, themeOverride.colors, COLOR_TOKEN_ROLES);
+  applyThemeSection(
+    cssVariables,
+    themeOverride.typography,
+    TYPOGRAPHY_TOKEN_ROLES,
+  );
+  applyThemeSection(cssVariables, {
+    borderWidth: themeOverride.borderWidth,
+    focusOffset: themeOverride.focusOffset,
+    focusWidth: themeOverride.focusWidth,
+    radius: themeOverride.radius,
+    shadow: themeOverride.shadow,
+    spacing: themeOverride.spacing,
+    transitionDuration: themeOverride.transitionDuration,
+  }, ROOT_TOKEN_ROLES);
+
+  for (
+    const [cssVariableName, cssVariableValue] of Object.entries(
+      themeOverride.cssVariables ?? {},
+    )
+  ) {
+    if (!isCssVariableName(cssVariableName)) {
+      continue;
+    }
+
+    const formattedValue = formatTokenValue({
+      role: "css-variable",
+      value: cssVariableValue,
+    });
+    if (formattedValue == null) {
+      continue;
+    }
+
+    cssVariables.set(cssVariableName, formattedValue);
+  }
+
+  return { cssVariables };
+}
+
+function applyThemeSection<TThemeSection extends object>(
+  cssVariables: Map<`--${string}`, string>,
+  themeSection: TThemeSection | undefined,
+  tokenRoles: Record<keyof TThemeSection, SemanticTokenRole>,
+): void {
+  if (themeSection == null) {
+    return;
+  }
+
+  for (
+    const [themeKey, tokenValue] of Object.entries(themeSection) as Array<
+      [keyof TThemeSection, OsdkThemeTokenValue | undefined]
+    >
+  ) {
+    const tokenRole = tokenRoles[themeKey];
+    if (tokenRole == null) {
+      continue;
+    }
+
+    const formattedValue = formatTokenValue({
+      role: tokenRole,
+      value: tokenValue,
+    });
+    if (formattedValue == null) {
+      continue;
+    }
+
+    for (const cssVariableName of SEMANTIC_TOKEN_MAP[tokenRole]) {
+      cssVariables.set(cssVariableName, formattedValue);
+    }
+  }
+}
+
+export function formatTokenValue(
+  { role, value }: {
+    role: SemanticTokenRole | "css-variable";
+    value: OsdkThemeTokenValue | undefined;
+  },
+): string | undefined {
+  if (value == null) {
+    return undefined;
+  }
+
+  const stringValue = String(value);
+  if (stringValue.trim() === "" || stringValue === "initial") {
+    return undefined;
+  }
+
+  if (
+    (role === "font-size-small"
+      || role === "font-size-medium"
+      || role === "font-size-large"
+      || role === "border-radius"
+      || role === "spacing"
+      || role === "border-width"
+      || role === "focus-width"
+      || role === "focus-offset")
+    && /^\d+(\.\d+)?$/.test(stringValue)
+  ) {
+    return `${stringValue}px`;
+  }
+
+  if (
+    role === "transition-duration" && /^\d+(\.\d+)?$/.test(stringValue)
+  ) {
+    return `${stringValue}ms`;
+  }
+
+  return stringValue;
+}
+
+function isCssVariableName(name: string): name is `--${string}` {
+  return name.startsWith("--");
+}

--- a/packages/react-components/src/theme/semanticTokenMap.ts
+++ b/packages/react-components/src/theme/semanticTokenMap.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const SEMANTIC_TOKEN_MAP = {
+  background: [
+    "--osdk-background-primary",
+    "--osdk-table-row-bg-default",
+    "--osdk-table-row-bg-alternate",
+    "--osdk-surface-background-color-default-rest",
+    "--bp-surface-background-color-default-rest",
+    "--bp-surface-background-color-default-disabled",
+  ],
+  surface: [
+    "--osdk-background-secondary",
+    "--osdk-background-tertiary",
+    "--osdk-surface-background-color-default-hover",
+    "--bp-surface-background-color-default-hover",
+    "--osdk-surface-background-color-default-active",
+    "--bp-surface-background-color-default-active",
+    "--osdk-table-header-bg",
+    "--osdk-checkbox-bg-hover",
+  ],
+  text: [
+    "--osdk-typography-color-default-rest",
+    "--bp-typography-color-default-rest",
+    "--osdk-tooltip-color",
+    "--osdk-table-header-color",
+    "--osdk-table-cell-color",
+  ],
+  "text-muted": [
+    "--osdk-typography-color-muted",
+    "--bp-typography-color-muted",
+    "--osdk-intent-default-rest",
+    "--bp-intent-default-rest",
+    "--osdk-table-header-menu-color",
+  ],
+  primary: [
+    "--osdk-intent-primary-rest",
+    "--bp-intent-primary-rest",
+    "--osdk-emphasis-focus-color",
+    "--bp-emphasis-focus-color",
+    "--osdk-checkbox-bg-checked",
+  ],
+  "primary-foreground": [
+    "--osdk-intent-primary-foreground",
+    "--bp-intent-primary-foreground",
+    "--osdk-checkbox-checked-foreground",
+  ],
+  secondary: ["--osdk-button-secondary-bg"],
+  "secondary-foreground": [
+    "--osdk-button-secondary-color",
+    "--osdk-intent-default-foreground",
+    "--bp-intent-default-foreground",
+  ],
+  "icon-color": ["--osdk-iconography-color-muted", "--osdk-drag-handle-color"],
+  border: [
+    "--osdk-surface-border-color-default",
+    "--bp-surface-border-color-default",
+    "--osdk-surface-border-color-strong",
+    "--bp-surface-border-color-strong",
+    "--osdk-table-border-color",
+    "--osdk-checkbox-border-color",
+  ],
+  danger: [
+    "--osdk-intent-danger-rest",
+    "--bp-intent-danger-rest",
+    "--osdk-intent-danger-foreground",
+    "--bp-intent-danger-foreground",
+  ],
+  success: [
+    "--osdk-intent-success-rest",
+    "--bp-intent-success-rest",
+    "--osdk-intent-success-foreground",
+    "--bp-intent-success-foreground",
+  ],
+  warning: [
+    "--osdk-intent-warning-rest",
+    "--bp-intent-warning-rest",
+    "--osdk-intent-warning-foreground",
+    "--bp-intent-warning-foreground",
+  ],
+  "font-family": [
+    "--osdk-typography-family-default",
+    "--bp-typography-family-default",
+  ],
+  "font-size-small": [
+    "--osdk-typography-size-body-small",
+    "--bp-typography-size-body-small",
+  ],
+  "font-size-medium": [
+    "--osdk-typography-size-body-medium",
+    "--bp-typography-size-body-medium",
+  ],
+  "font-size-large": [
+    "--osdk-typography-size-body-large",
+    "--bp-typography-size-body-large",
+  ],
+  "font-weight-default": [
+    "--osdk-typography-weight-default",
+    "--bp-typography-weight-default",
+  ],
+  "font-weight-bold": [
+    "--osdk-typography-weight-bold",
+    "--bp-typography-weight-bold",
+  ],
+  "line-height": [
+    "--osdk-typography-line-height-default",
+    "--bp-typography-line-height-default",
+  ],
+  "border-radius": [
+    "--osdk-surface-border-radius",
+    "--bp-surface-border-radius",
+  ],
+  spacing: ["--osdk-surface-spacing", "--bp-surface-spacing"],
+  "border-width": ["--osdk-surface-border-width", "--bp-surface-border-width"],
+  shadow: [
+    "--osdk-surface-shadow-2",
+    "--bp-surface-shadow-2",
+    "--osdk-input-shadow",
+  ],
+  "focus-width": ["--osdk-emphasis-focus-width", "--bp-emphasis-focus-width"],
+  "focus-offset": [
+    "--osdk-emphasis-focus-offset",
+    "--bp-emphasis-focus-offset",
+  ],
+  "transition-duration": [
+    "--osdk-emphasis-transition-duration",
+    "--bp-emphasis-transition-duration",
+  ],
+} as const;
+
+export type SemanticTokenRole = keyof typeof SEMANTIC_TOKEN_MAP;

--- a/packages/react-components/src/theme/types.ts
+++ b/packages/react-components/src/theme/types.ts
@@ -20,24 +20,71 @@
  * - `"light"` / `"dark"` — force the given theme regardless of OS preference.
  * - `"system"` — follow `prefers-color-scheme` and react to changes at runtime.
  */
-export type OsdkThemeMode = "light" | "dark" | "system";
+export type OsdkColorScheme = "light" | "dark" | "system";
 
 /**
- * The concrete theme actually applied to the DOM. `OsdkThemeMode` of
+ * The concrete color scheme actually applied to the DOM. `OsdkColorScheme` of
  * `"system"` resolves to either `"light"` or `"dark"` depending on the
  * current value of `prefers-color-scheme`.
  */
-export type ResolvedOsdkTheme = "light" | "dark";
+export type ResolvedOsdkColorScheme = "light" | "dark";
+
+export type OsdkThemeTokenValue = string | number;
+
+export interface OsdkThemeColors {
+  background: string;
+  surface: string;
+  text: string;
+  textMuted: string;
+  primary: string;
+  primaryForeground: string;
+  secondary: string;
+  secondaryForeground: string;
+  icon: string;
+  border: string;
+  danger: string;
+  success: string;
+  warning: string;
+}
+
+export interface OsdkThemeTypography {
+  fontFamily: string;
+  bodySmall: OsdkThemeTokenValue;
+  bodyMedium: OsdkThemeTokenValue;
+  bodyLarge: OsdkThemeTokenValue;
+  fontWeightDefault: OsdkThemeTokenValue;
+  fontWeightBold: OsdkThemeTokenValue;
+  lineHeight: OsdkThemeTokenValue;
+}
+
+export interface OsdkThemeOverride {
+  colors?: Partial<OsdkThemeColors>;
+  typography?: Partial<OsdkThemeTypography>;
+  radius?: OsdkThemeTokenValue;
+  spacing?: OsdkThemeTokenValue;
+  borderWidth?: OsdkThemeTokenValue;
+  shadow?: string;
+  focusWidth?: OsdkThemeTokenValue;
+  focusOffset?: OsdkThemeTokenValue;
+  transitionDuration?: OsdkThemeTokenValue;
+  cssVariables?: Partial<Record<`--${string}`, string>>;
+}
+
+export interface OsdkTheme {
+  cssVariables: ReadonlyMap<`--${string}`, string>;
+}
 
 export interface OsdkThemeContextValue {
-  /** The requested mode, including `"system"`. */
-  theme: OsdkThemeMode;
-  /** The concrete theme currently applied to the DOM. */
-  resolvedTheme: ResolvedOsdkTheme;
+  /** The requested color scheme, including `"system"`. */
+  colorScheme: OsdkColorScheme;
+  /** The concrete color scheme currently applied to the DOM. */
+  resolvedColorScheme: ResolvedOsdkColorScheme;
+  /** The custom design-token theme currently applied to the DOM. */
+  theme: OsdkTheme | undefined;
   /**
-   * Update the requested mode. In controlled mode (`theme` prop on the
-   * provider) this only invokes `onThemeChanged`; the consumer is expected
-   * to re-render the provider with the new value.
+   * Update the requested color scheme. In controlled mode (`colorScheme` prop
+   * on the provider) this only invokes `onColorSchemeChanged`; the consumer is
+   * expected to re-render the provider with the new value.
    */
-  setTheme: (theme: OsdkThemeMode) => void;
+  setColorScheme: (colorScheme: OsdkColorScheme) => void;
 }

--- a/packages/react-components/src/theme/useOsdkTheme.ts
+++ b/packages/react-components/src/theme/useOsdkTheme.ts
@@ -19,18 +19,20 @@ import { OsdkThemeContext } from "./OsdkThemeContext.js";
 import type { OsdkThemeContextValue } from "./types.js";
 
 /**
- * Read the active OSDK theme and update it imperatively.
+ * Read the active OSDK color scheme/theme and update the color scheme
+ * imperatively.
  *
  * Must be called from a descendant of `<OsdkThemeProvider>`; throws otherwise.
  *
  * @returns
- * - `theme` — the requested mode (`"light" | "dark" | "system"`).
- * - `resolvedTheme` — the concrete theme on the DOM (`"light" | "dark"`).
- *   When `theme === "system"`, this tracks `prefers-color-scheme` and
- *   updates as the OS preference changes.
- * - `setTheme(next)` — update the mode. In controlled mode this only
- *   invokes the provider's `onThemeChanged`; the consumer must re-render
- *   the provider with the new value.
+ * - `colorScheme` — the requested mode (`"light" | "dark" | "system"`).
+ * - `resolvedColorScheme` — the concrete scheme on the DOM (`"light" |
+ *   "dark"`). When `colorScheme === "system"`, this tracks
+ *   `prefers-color-scheme` and updates as the OS preference changes.
+ * - `theme` — the design-token theme applied to the provider target.
+ * - `setColorScheme(next)` — update the mode. In controlled mode this only
+ *   invokes the provider's `onColorSchemeChanged`; the consumer must
+ *   re-render the provider with the new value.
  */
 export function useOsdkTheme(): OsdkThemeContextValue {
   const ctx = useContext(OsdkThemeContext);

--- a/packages/react-components/src/theme/useSystemTheme.ts
+++ b/packages/react-components/src/theme/useSystemTheme.ts
@@ -15,7 +15,7 @@
  */
 
 import { useSyncExternalStore } from "react";
-import type { ResolvedOsdkTheme } from "./types.js";
+import type { ResolvedOsdkColorScheme } from "./types.js";
 
 const DARK_QUERY = "(prefers-color-scheme: dark)";
 
@@ -30,7 +30,7 @@ function subscribe(callback: () => void): () => void {
   return () => mql.removeEventListener("change", callback);
 }
 
-function getSnapshot(): ResolvedOsdkTheme {
+function getSnapshot(): ResolvedOsdkColorScheme {
   if (
     typeof window === "undefined" || typeof window.matchMedia !== "function"
   ) {
@@ -39,7 +39,7 @@ function getSnapshot(): ResolvedOsdkTheme {
   return window.matchMedia(DARK_QUERY).matches ? "dark" : "light";
 }
 
-function getServerSnapshot(): ResolvedOsdkTheme {
+function getServerSnapshot(): ResolvedOsdkColorScheme {
   return "light";
 }
 
@@ -48,6 +48,6 @@ function getServerSnapshot(): ResolvedOsdkTheme {
  * the current resolved value. Re-renders the consumer when the OS preference
  * changes. SSR-safe: returns `"light"` on the server.
  */
-export function useSystemTheme(): ResolvedOsdkTheme {
+export function useSystemTheme(): ResolvedOsdkColorScheme {
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }


### PR DESCRIPTION
## Summary
- Adds experimental `createTheme(...)` API for semantic OSDK theme overrides plus raw CSS variable escape hatch
- Breaks experimental `OsdkThemeProvider` color mode props to `colorScheme` / `defaultColorScheme` / `onColorSchemeChanged`, reserving `theme` for design-token themes
- Moves CSS variable application/restoration into `OsdkThemeProvider` and refactors the Storybook brand preset decorator to use the public provider API
- Updates docs and tests for the new API shape

## Verification
- `pnpm exec vitest run packages/react-components/src/theme/__tests__/*.test.ts*`
- `pnpm exec vitest run .storybook/addons/brand-theme-extractor/__tests__/*.spec.ts*` from `packages/react-components-storybook`
- `pnpm --filter @osdk/react-components typecheck`
- `pnpm --filter @osdk/react-components-storybook typecheck`
- `pnpm --filter @osdk/react-components-storybook build`
- ESLint/dprint/cspell on changed files
- Cleanroom review completed; doc blockers fixed
