### PR TITLE
fix duplicate whereClause props in renderValue tests

### DIFF
--- a/packages/react-components/src/filter-list/base/inputs/__tests__/renderValue.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/renderValue.test.tsx
@@ -406,7 +406,6 @@ describe("LinkedPropertyInput renderValue", () => {
           },
         }}
         onFilterStateChanged={vi.fn()}
-        whereClause={{} as WhereClause<ObjectTypeDefinition>}
       />,
     );
 
@@ -433,7 +432,6 @@ describe("LinkedPropertyInput renderValue", () => {
           },
         }}
         onFilterStateChanged={vi.fn()}
-        whereClause={{} as WhereClause<ObjectTypeDefinition>}
       />,
     );
 
@@ -461,7 +459,6 @@ describe("LinkedPropertyInput renderValue", () => {
         }}
         onFilterStateChanged={vi.fn()}
         searchQuery="abc"
-        whereClause={{} as WhereClause<ObjectTypeDefinition>}
       />,
     );
 
@@ -492,7 +489,6 @@ describe("LinkedPropertyInput renderValue", () => {
           },
         }}
         onFilterStateChanged={vi.fn()}
-        whereClause={{} as WhereClause<ObjectTypeDefinition>}
       />,
     );
 


### PR DESCRIPTION
fixes typecheck failure on main from collision between #3348 and #3356

• #3348 added whereClause to four LinkedPropertyInput test renders
• #3356 branched earlier and added whereClause at a different position in the same four renders
• both landed on main, producing TS17001 duplicate JSX attribute errors that block the version PR

removes the four duplicates added by #3356