### PR TITLE
Fix late registration of vite proxy

### DIFF
--- a/.changeset/khaki-items-talk.md
+++ b/.changeset/khaki-items-talk.md
@@ -1,0 +1,5 @@
+---
+"@osdk/vite-plugin-superrepo": minor
+---
+
+Fix race where a late-publishing service (e.g. python-functions waiting on ontology discovery) is silently absent from the proxy table. Vite's `server.restart()` dedups concurrent calls, so a change event arriving while a restart is in flight is dropped; chokidar can additionally swallow `add` for files not present at watch-time under `ignoreInitial: true`. The watcher now restarts in a loop until the discovery fingerprint is stable, and polls discovery state once per second as a fallback for missed `add` events.

--- a/packages/monorepo.cspell/dict.normal-dev-words.txt
+++ b/packages/monorepo.cspell/dict.normal-dev-words.txt
@@ -1,3 +1,4 @@
+ACMR
 aggregatable
 aimpoints
 BACKCOMPAT
@@ -10,6 +11,7 @@ codegen
 commitish
 Cpath
 Csvg
+dedups
 devx
 Discoverability
 duplicative
@@ -32,10 +34,10 @@ retryable
 rsort
 semver
 streamutils
-subdependencies
-subdeps
 struct
 structs
+subdependencies
+subdeps
 tsdoc
 typecheck
 typemapping
@@ -47,4 +49,3 @@ unioned
 unresolve
 Unsubscribable
 webapi
-ACMR

--- a/packages/vite-plugin-superrepo/src/index.ts
+++ b/packages/vite-plugin-superrepo/src/index.ts
@@ -151,20 +151,54 @@ export function smartClientPlugin(): Plugin {
       const superrepoRoot = findSuperrepoRoot(server.config.root);
       if (!superrepoRoot) return;
 
+      const ownWatcher = server.watcher;
+
       const palantirDir = path.join(superrepoRoot, ".palantir");
       const expectedFiles = PROXY_ROUTES.map((r) =>
         path.join(palantirDir, `.${r.service}-discovery.json`)
       );
       const expectedFileSet = new Set(expectedFiles);
 
+      // Fingerprint of the current set of live discovery files. We compare
+      // against this after every restart to detect changes that vite swallowed
+      // via its `_restartPromise` dedup, and on every poll tick to detect
+      // chokidar events the watcher never delivered.
+      const snapshot = (): string =>
+        PROXY_ROUTES.map((r) => {
+          const read = inspectDiscovery(superrepoRoot, r.service);
+          return read.kind === "ok"
+            ? `${r.service}:${read.entry.url}`
+            : `${r.service}:${read.kind}`;
+        }).join("|");
+
+      let lastObserved = snapshot();
+      let restartChain: Promise<void> | undefined;
       let restartTimer: ReturnType<typeof setTimeout> | undefined;
+
+      // Restart in a loop until the discovery fingerprint is stable across a
+      // full restart cycle
+      const doRestart = (): Promise<void> => {
+        if (restartChain) return restartChain;
+        restartChain = (async () => {
+          let before: string;
+          do {
+            before = snapshot();
+            await server.restart();
+          } while (snapshot() !== before);
+          lastObserved = before;
+        })().finally(() => {
+          restartChain = undefined;
+        });
+        return restartChain;
+      };
+
       const scheduleRestart = (): void => {
         if (restartTimer) clearTimeout(restartTimer);
         // Coalesce rename+write bursts that commonly emit multiple events
         // for a single discovery file update.
         restartTimer = setTimeout(() => {
           restartTimer = undefined;
-          void server.restart();
+          void doRestart();
         }, 100);
       };
 
@@ -177,7 +211,25 @@ export function smartClientPlugin(): Plugin {
       server.watcher.on("change", onPathChange);
       server.watcher.on("unlink", onPathChange);
 
+      // Polling fallback. Chokidar on Linux can drop the `add` event for a
+      // path that did not exist when `server.watcher.add()` ran (vite passes
+      // `ignoreInitial: true`
+      const pollInterval = setInterval(() => {
+        // Vite restart swaps `server.watcher` for a fresh instance; stop
+        // polling once that happens so we don't leak a timer per restart.
+        if (server.watcher !== ownWatcher) {
+          clearInterval(pollInterval);
+          return;
+        }
+        const current = snapshot();
+        if (current !== lastObserved) {
+          lastObserved = current;
+          scheduleRestart();
+        }
+      }, 1000);
+
       const cleanup = (): void => {
+        clearInterval(pollInterval);
         if (restartTimer) clearTimeout(restartTimer);
         server.watcher.off("add", onPathChange);
         server.watcher.off("change", onPathChange);


### PR DESCRIPTION
The proxy server reloaded when new discovery files appeared. If 2 appeared close to the same time, the 2nd one got skipped.

Fix this by reloading as long as there are unseen discovery files.