### PR TITLE
Handle delete interface rules in the full metadata converters

### DIFF
--- a/.changeset/salty-kings-think.md
+++ b/.changeset/salty-kings-think.md
@@ -1,0 +1,5 @@
+---
+"@osdk/generator-converters.ontologyir": patch
+---
+
+Handle delete interface rules

--- a/packages/generator-converters.ontologyir/src/OntologyBlockDataToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyBlockDataToFullMetadataConverter.ts
@@ -429,17 +429,28 @@ export class OntologyBlockDataToFullMetadataConverter {
           const r = irLogic.deleteObjectRule;
           const ontologyIrParameter =
             action.actionType.metadata.parameters[r.objectToDelete];
-          if (ontologyIrParameter.type.type !== "objectReference") {
-            throw new Error("invalid parameter type");
+          switch (ontologyIrParameter.type.type) {
+            case "objectReference": {
+              return {
+                type: "deleteObject",
+                objectTypeApiName: resolveBlockDataApiName(
+                  ontologyIrParameter.type.objectReference.objectTypeId,
+                  objectTypeLookup,
+                ),
+              } satisfies Ontologies.LogicRule;
+            }
+            case "interfaceReference": {
+              return {
+                type: "deleteInterfaceObject",
+                interfaceTypeApiName: resolveBlockDataApiName(
+                  ontologyIrParameter.type.interfaceReference.interfaceTypeRid,
+                  objectTypeLookup,
+                ),
+              } satisfies Ontologies.LogicRule;
+            }
+            default:
+              throw new Error("invalid objectToDelete parameter type");
           }
-
-          return {
-            type: "deleteObject",
-            objectTypeApiName: resolveBlockDataApiName(
-              ontologyIrParameter.type.objectReference.objectTypeId,
-              objectTypeLookup,
-            ),
-          } satisfies Ontologies.LogicRule;
         }
         case "modifyInterfaceRule": {
           const r = irLogic.modifyInterfaceRule;

--- a/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
@@ -975,15 +975,24 @@ export class OntologyIrToFullMetadataConverter {
           const r = irLogic.deleteObjectRule;
           const ontologyIrParameter =
             action.actionType.metadata.parameters[r.objectToDelete];
-          if (ontologyIrParameter.type.type !== "objectReference") {
-            throw new Error("invalid parameter type");
+          switch (ontologyIrParameter.type.type) {
+            case "objectReference": {
+              return {
+                type: "deleteObject",
+                objectTypeApiName:
+                  ontologyIrParameter.type.objectReference.objectTypeId,
+              } satisfies Ontologies.LogicRule;
+            }
+            case "interfaceReference": {
+              return {
+                type: "deleteInterfaceObject",
+                interfaceTypeApiName:
+                  ontologyIrParameter.type.interfaceReference.interfaceTypeRid,
+              } satisfies Ontologies.LogicRule;
+            }
+            default:
+              throw new Error("invalid objectToDelete parameter type");
           }
-
-          return {
-            type: "deleteObject",
-            objectTypeApiName:
-              ontologyIrParameter.type.objectReference.objectTypeId,
-          } satisfies Ontologies.LogicRule;
         }
         case "modifyInterfaceRule": {
           const r = irLogic.modifyInterfaceRule;


### PR DESCRIPTION
deleteObjectRules can refer to both objects and interfaces, so we need special handling for the interface case