### PR TITLE
reject numeric literals on derived-property numeric expressions

### DIFF
--- a/.changeset/reject-derived-property-literals.md
+++ b/.changeset/reject-derived-property-literals.md
@@ -1,0 +1,7 @@
+---
+"@osdk/api": patch
+---
+
+reject numeric literals on derived-property numeric expressions at compile time
+
+The runtime never supported numeric literals as arguments to `add`/`subtract`/`multiply`/`divide`/`max`/`min` on derived properties — passing one would throw `Invariant failed: Literals for derived properties are not yet supported`. The type signature is now tightened to match the runtime, so the error surfaces at compile time instead. Pass another numeric derived property (e.g. `selectedInteger`) as the argument, or clamp/transform the value at the consumer.

--- a/packages/api/src/derivedProperties/DerivedProperty.ts
+++ b/packages/api/src/derivedProperties/DerivedProperty.ts
@@ -154,43 +154,6 @@ type Pivotable<
     : DerivedProperty.SelectPropertyBuilder<LinkedType<Q, L>, false>;
 };
 
-type Constant<Q extends ObjectOrInterfaceDefinition> = {
-  readonly constant: {
-    readonly double: (
-      value: number,
-    ) => DerivedProperty.NumericPropertyDefinition<
-      SimplePropertyDef.Make<"double", "non-nullable", "single">,
-      Q
-    >;
-
-    readonly integer: (
-      value: number,
-    ) => DerivedProperty.NumericPropertyDefinition<
-      SimplePropertyDef.Make<"integer", "non-nullable", "single">,
-      Q
-    >;
-    readonly long: (
-      value: string,
-    ) => DerivedProperty.NumericPropertyDefinition<
-      SimplePropertyDef.Make<"long", "non-nullable", "single">,
-      Q
-    >;
-
-    readonly datetime: (
-      value: string,
-    ) => DerivedProperty.DatetimePropertyDefinition<
-      SimplePropertyDef.Make<"datetime", "non-nullable", "single">,
-      Q
-    >;
-    readonly timestamp: (
-      value: string,
-    ) => DerivedProperty.DatetimePropertyDefinition<
-      SimplePropertyDef.Make<"timestamp", "non-nullable", "single">,
-      Q
-    >;
-  };
-};
-
 type Aggregatable<
   Q extends ObjectOrInterfaceDefinition,
 > = {

--- a/packages/api/src/derivedProperties/Expressions.ts
+++ b/packages/api/src/derivedProperties/Expressions.ts
@@ -46,8 +46,7 @@ export type DefinitionForType<
   : DerivedProperty.Definition<T, Q>;
 
 type NumericExpressionArg<Q extends ObjectOrInterfaceDefinition> =
-  | number
-  | DerivedProperty.NumericPropertyDefinition<any, Q>;
+  DerivedProperty.NumericPropertyDefinition<any, Q>;
 
 type ReturnTypeForNumericMethod<
   Q extends ObjectOrInterfaceDefinition,
@@ -87,18 +86,16 @@ type ReturnTypeForDatetimeMethod<
 type ExtractWirePropertyTypeFromNumericArg<
   Q extends ObjectOrInterfaceDefinition,
   ARG extends NumericExpressionArg<Q>,
-> = ARG extends number ? "double"
-  : ARG extends DerivedProperty.NumericPropertyDefinition<infer T, Q>
-    ? T extends SimplePropertyDef ? SimplePropertyDef.ExtractWirePropertyType<T>
-    : never
-  : ARG extends PropertyKeys.Filtered<Q, WithPropertiesNumerics>
-    ? NonNullable<CompileTimeMetadata<Q>["properties"][ARG]["type"]>
+> = ARG extends DerivedProperty.NumericPropertyDefinition<infer T, Q>
+  ? T extends SimplePropertyDef ? SimplePropertyDef.ExtractWirePropertyType<T>
+  : never
   : never;
 
 /**
  * Numeric expression methods chainable off a numeric derived property.
- * Each binary method accepts either a numeric literal or another numeric derived
- * property as its right-hand side; unary methods (`abs`, `negate`) take no argument.
+ * Each binary method accepts another numeric derived property as its right-hand
+ * side; unary methods (`abs`, `negate`) take no argument. Numeric literals are
+ * not supported.
  * @example
  * ```ts
  * await client(Employee).withProperties({
@@ -113,7 +110,7 @@ export type NumericExpressions<
   Q extends ObjectOrInterfaceDefinition,
   LEFT_PROPERTY_TYPE extends SimplePropertyDef,
 > = {
-  /** Adds a numeric value or another numeric derived property. */
+  /** Adds another numeric derived property. */
   readonly add: <A extends NumericExpressionArg<Q>>(
     value: A,
   ) => ReturnTypeForNumericMethod<
@@ -122,7 +119,7 @@ export type NumericExpressions<
     ExtractWirePropertyTypeFromNumericArg<Q, A>
   >;
 
-  /** Subtracts a numeric value or another numeric derived property. */
+  /** Subtracts another numeric derived property. */
   readonly subtract: <A extends NumericExpressionArg<Q>>(
     value: A,
   ) => ReturnTypeForNumericMethod<
@@ -131,7 +128,7 @@ export type NumericExpressions<
     ExtractWirePropertyTypeFromNumericArg<Q, A>
   >;
 
-  /** Multiplies by a numeric value or another numeric derived property. */
+  /** Multiplies by another numeric derived property. */
   readonly multiply: <A extends NumericExpressionArg<Q>>(
     value: A,
   ) => ReturnTypeForNumericMethod<
@@ -140,7 +137,7 @@ export type NumericExpressions<
     ExtractWirePropertyTypeFromNumericArg<Q, A>
   >;
 
-  /** Divides by a numeric value or another numeric derived property. */
+  /** Divides by another numeric derived property. */
   readonly divide: <A extends NumericExpressionArg<Q>>(
     value: A,
   ) => ReturnTypeForNumericMethod<
@@ -161,7 +158,7 @@ export type NumericExpressions<
     Q
   >;
 
-  /** Takes the larger of this value and another numeric value or derived property. */
+  /** Takes the larger of this value and another numeric derived property. */
   readonly max: <A extends NumericExpressionArg<Q>>(
     value: A,
   ) => ReturnTypeForNumericMethod<
@@ -170,7 +167,7 @@ export type NumericExpressions<
     ExtractWirePropertyTypeFromNumericArg<Q, A>
   >;
 
-  /** Takes the smaller of this value and another numeric value or derived property. */
+  /** Takes the smaller of this value and another numeric derived property. */
   readonly min: <A extends NumericExpressionArg<Q>>(
     value: A,
   ) => ReturnTypeForNumericMethod<

--- a/packages/api/src/objectSet/ObjectSet.test.ts
+++ b/packages/api/src/objectSet/ObjectSet.test.ts
@@ -807,14 +807,19 @@ describe("ObjectSet", () => {
               >
             >;
 
-            selectedInteger.add(1);
-            selectedInteger.subtract(1);
-            selectedInteger.multiply(1);
-            selectedInteger.divide(1);
+            selectedInteger.add(selectedInteger);
+            selectedInteger.subtract(selectedInteger);
+            selectedInteger.multiply(selectedInteger);
+            selectedInteger.divide(selectedInteger);
             selectedInteger.abs();
             selectedInteger.negate();
+            selectedInteger.max(selectedInteger);
+            selectedInteger.min(selectedInteger);
+
+            // @ts-expect-error -- numeric literals are not supported at runtime
+            selectedInteger.add(1);
+            // @ts-expect-error -- numeric literals are not supported at runtime
             selectedInteger.max(1);
-            selectedInteger.min(1);
 
             // @ts-expect-error
             selectedInteger.extractPart("1");
@@ -879,14 +884,14 @@ describe("ObjectSet", () => {
               >
             >;
 
-            selectedInteger.add(1);
-            selectedInteger.subtract(1);
-            selectedInteger.multiply(1);
-            selectedInteger.divide(1);
+            selectedInteger.add(selectedInteger);
+            selectedInteger.subtract(selectedInteger);
+            selectedInteger.multiply(selectedInteger);
+            selectedInteger.divide(selectedInteger);
             selectedInteger.abs();
             selectedInteger.negate();
-            selectedInteger.max(1);
-            selectedInteger.min(1);
+            selectedInteger.max(selectedInteger);
+            selectedInteger.min(selectedInteger);
 
             // @ts-expect-error
             selectedInteger.extractPart("1");
@@ -951,14 +956,14 @@ describe("ObjectSet", () => {
               >
             >;
 
-            maxAggregation.add(1);
-            maxAggregation.subtract(1);
-            maxAggregation.multiply(1);
-            maxAggregation.divide(1);
+            maxAggregation.add(maxAggregation);
+            maxAggregation.subtract(maxAggregation);
+            maxAggregation.multiply(maxAggregation);
+            maxAggregation.divide(maxAggregation);
             maxAggregation.abs();
             maxAggregation.negate();
-            maxAggregation.max(1);
-            maxAggregation.min(1);
+            maxAggregation.max(maxAggregation);
+            maxAggregation.min(maxAggregation);
 
             expectTypeOf(
               base.pivotTo("peeps").aggregate("employeeId:sum"),
@@ -1112,19 +1117,23 @@ describe("ObjectSet", () => {
         });
       });
 
-      it("allows adding number literals as a double", () => {
-        const objectSet = fauxObjectSet.withProperties({
+      it("rejects number literals on numeric expressions", () => {
+        fauxObjectSet.withProperties({
           "myProp1": (base) => {
-            const plus = base.pivotTo("lead").selectProperty("employeeId")
-              .add(1);
-            expectTypeOf(plus).toEqualTypeOf<
-              DerivedProperty.NumericPropertyDefinition<
-                "double",
-                EmployeeApiTest
-              >
-            >();
-
-            return plus;
+            const selected = base.pivotTo("lead").selectProperty("employeeId");
+            // @ts-expect-error -- numeric literals are not supported at runtime
+            selected.add(1);
+            // @ts-expect-error -- numeric literals are not supported at runtime
+            selected.subtract(1);
+            // @ts-expect-error -- numeric literals are not supported at runtime
+            selected.multiply(1);
+            // @ts-expect-error -- numeric literals are not supported at runtime
+            selected.divide(1);
+            // @ts-expect-error -- numeric literals are not supported at runtime
+            selected.max(1);
+            // @ts-expect-error -- numeric literals are not supported at runtime
+            selected.min(1);
+            return selected;
           },
         });
       });


### PR DESCRIPTION
## Summary
literal numbers like `.max(1)` typed as valid but threw "literals for derived properties are not yet supported" at runtime; tighten the @osdk/api types so the same call now fails at compile time

• narrow `NumericExpressionArg` so add/subtract/multiply/divide/max/min only accept another numeric derived property
• delete the unused, never-implemented `Constant<Q>` type from the builder surface
• prune the dead `extends number ? "double"` branch from `ExtractWirePropertyTypeFromNumericArg`