### PR TITLE
ci: harden against fork PR supply-chain risks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
 
   bundle-size:
     name: Bundle Size
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
     timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:
@@ -313,10 +313,91 @@ jobs:
             gh pr comment "${{ github.event.pull_request.number }}" -F /tmp/comment.md
           fi
 
+  fork-guard:
+    name: Fork sensitive-paths guard
+    # Only fork PRs need this check; for in-repo PRs and push events we trust the author
+    # and the job becomes a no-op success.
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Check out code
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Guard install-time config from fork PRs
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BYPASS_LABEL: safe-to-test
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+
+          # Maintainer override: if the PR carries the bypass label, accept.
+          if echo "$PR_LABELS" | grep -q "\"$BYPASS_LABEL\""; then
+            echo "Bypass label '$BYPASS_LABEL' is set; skipping sensitive-paths check."
+            exit 0
+          fi
+
+          git fetch origin "$BASE_SHA" --depth=1
+          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          echo "Changed files:"
+          echo "$CHANGED"
+          echo "---"
+
+          violations=()
+
+          # Direct sensitive paths
+          while IFS= read -r f; do
+            case "$f" in
+              .npmrc|pnpm-workspace.yaml)
+                violations+=("$f (install-time config)")
+                ;;
+              .github/workflows/*)
+                violations+=("$f (CI workflow)")
+                ;;
+            esac
+          done <<< "$CHANGED"
+
+          # Lockfile changed without any package.json change: classic tampering signal
+          if echo "$CHANGED" | grep -qx "pnpm-lock.yaml"; then
+            if ! echo "$CHANGED" | grep -q "package.json$"; then
+              violations+=("pnpm-lock.yaml changed without any package.json change")
+            fi
+          fi
+
+          # Root package.json pnpm field changed (overrides, onlyBuiltDependencies, etc.)
+          if echo "$CHANGED" | grep -qx "package.json"; then
+            base_pnpm=$(git show "$BASE_SHA:package.json" | jq -c '.pnpm // {}')
+            head_pnpm=$(git show "$HEAD_SHA:package.json" | jq -c '.pnpm // {}')
+            if [ "$base_pnpm" != "$head_pnpm" ]; then
+              violations+=("package.json 'pnpm' field changed (overrides/onlyBuiltDependencies)")
+            fi
+          fi
+
+          if [ "${#violations[@]}" -gt 0 ]; then
+            echo "::error::This fork PR modifies install-time or CI configuration."
+            echo "::error::Maintainer review required. Apply the '$BYPASS_LABEL' label to bypass after review."
+            echo ""
+            echo "Violations:"
+            for v in "${violations[@]}"; do
+              echo "  - $v"
+            done
+            exit 1
+          fi
+
+          echo "No sensitive-path modifications detected."
+
   ci-build:
     name: ci-build
     if: ${{ always() }}
-    needs: [build, e2e, cspell]
+    needs: [build, e2e, cspell, fork-guard]
     runs-on: ubuntu-latest
     steps:
       - name: Verify dependent jobs succeeded
@@ -331,5 +412,9 @@ jobs:
           fi
           if [[ "${{ needs.cspell.result }}" != "success" ]]; then
             echo "cspell did not succeed: ${{ needs.cspell.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.fork-guard.result }}" != "success" ]]; then
+            echo "fork-guard did not succeed: ${{ needs.fork-guard.result }}"
             exit 1
           fi


### PR DESCRIPTION
## Summary

Two CI changes to reduce exposure to npm supply-chain attacks via fork PRs.

### 1. Skip `bundle-size` on fork PRs

The `bundle-size` job posts a comment on the PR via `gh pr comment`, which needs `pull-requests: write` on `GITHUB_TOKEN`. GitHub auto-downgrades that token to read-only for fork PRs, so the job was already failing on every fork PR. Skipping it explicitly avoids the noisy red check.

The job is **not** part of the `ci-build` required-check aggregate, so this doesn't change merge requirements.

### 2. New `fork-guard` job

A new job that fails fork PRs which modify install-time or CI configuration without explicit maintainer review.

**Triggers a failure when a fork PR changes**:
- `.npmrc` or `pnpm-workspace.yaml` (install-time config)
- `.github/workflows/**` (CI workflows)
- `pnpm-lock.yaml` *without an accompanying `package.json` change* (the classic lock-tampering signal)
- The `pnpm` field in root `package.json` (overrides / `onlyBuiltDependencies`)

**Bypass**: maintainer applies the `safe-to-test` label after reviewing the diff and re-runs the job.

**Why this matters**: the repo is already well-hardened against in-tree attacks (`strict-dep-builds=true`, `minimum-release-age=4320`, `trust-policy=no-downgrade`, `block-exotic-subdeps=true`, explicit `onlyBuiltDependencies` allowlist). But all of those protections live in files a fork PR can edit. The real damage from a tampered fork PR materialises *after merge*, when its `pnpm-lock.yaml` / `.npmrc` lands on `main` and the next CI run has access to secrets. This guard makes those edits a visible, gated step rather than a quiet diff that's easy to miss in review.

Wired into the existing `ci-build` aggregate so it's part of the required check set without any branch-protection changes.

## Test plan

- [ ] Confirm `ci-build` is the required check in branch protection (it likely already is)
- [ ] Verify on this (non-fork) PR: `fork-guard` runs as a no-op success
- [ ] Manual sanity check: when a fork PR opens later, confirm the job fails on a `.npmrc` edit and that applying `safe-to-test` lets it pass on re-run