### PR TITLE
aip-agent-chat: restyle chat UI and add Callout component

### DIFF
--- a/.changeset/aip-agent-chat-design-restyle.md
+++ b/.changeset/aip-agent-chat-design-restyle.md
@@ -1,0 +1,6 @@
+---
+"@osdk/react-components": patch
+"@osdk/react-components-storybook": patch
+---
+
+Restyle AipAgentChat to match Threads 2.0 design with light gray user bubbles, plain-text assistant messages, rounded inlined composer, and centered max-width layout. Add reusable Callout base component with intent-tinted backgrounds and dark mode support. Add AipAgentChat storybook stories.

--- a/.changeset/aip-agent-chat-design-restyle.md
+++ b/.changeset/aip-agent-chat-design-restyle.md
@@ -3,4 +3,4 @@
 "@osdk/react-components-storybook": patch
 ---
 
-Restyle AipAgentChat to match Threads 2.0 design with light gray user bubbles, plain-text assistant messages, rounded inlined composer, and centered max-width layout. Add reusable Callout base component with intent-tinted backgrounds and dark mode support. Add AipAgentChat storybook stories.
+Restyle AipAgentChat to match Threads 2.0 design with light gray user bubbles, plain-text assistant messages, rounded inlined composer, centered max-width layout, and no composer divider. Add reusable Callout base component with intent-tinted backgrounds and dark mode support. Add AipAgentChat storybook stories.

--- a/packages/react-components-storybook/src/stories/AipAgentChat/AipAgentChat.stories.tsx
+++ b/packages/react-components-storybook/src/stories/AipAgentChat/AipAgentChat.stories.tsx
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  BaseAipAgentChatProps,
+  UIMessage,
+} from "@osdk/react-components/experimental/aip-agent-chat";
+import { BaseAipAgentChat } from "@osdk/react-components/experimental/aip-agent-chat";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import * as React from "react";
+
+let nextId = 1;
+function makeId(): string {
+  return `msg-${nextId++}`;
+}
+
+function makeMessage(
+  role: UIMessage["role"],
+  text: string,
+): UIMessage {
+  return {
+    id: makeId(),
+    role,
+    parts: [{ type: "text", text }],
+  };
+}
+
+const SAMPLE_CONVERSATION: UIMessage[] = [
+  makeMessage("user", "What can you help me with?"),
+  makeMessage(
+    "assistant",
+    "I can assist you with a wide range of tasks! For example, I can help answer questions, analyze data, write content, brainstorm ideas, and more. What would you like to work on today?",
+  ),
+  makeMessage("user", "Can you summarize the latest sales report?"),
+  makeMessage(
+    "assistant",
+    "Based on the Q1 sales report:\n\n- Total revenue: $2.4M (up 12% QoQ)\n- New customers: 148 (up 23%)\n- Average deal size: $16.2K\n- Top performing region: Northeast\n\nThe main growth driver was enterprise expansion deals. Would you like me to dig into any specific area?",
+  ),
+];
+
+/**
+ * Interactive wrapper that manages message state and simulates streaming
+ * responses so the story behaves like a real chat.
+ */
+function InteractiveChat(
+  props:
+    & Omit<
+      BaseAipAgentChatProps,
+      | "messages"
+      | "status"
+      | "error"
+      | "onSendMessage"
+      | "onStop"
+      | "onClearError"
+    >
+    & {
+      initialMessages?: UIMessage[];
+      simulateError?: boolean;
+    },
+) {
+  const { initialMessages = [], simulateError = false, ...rest } = props;
+  const [messages, setMessages] = React.useState<UIMessage[]>(initialMessages);
+  const [status, setStatus] = React.useState<
+    "ready" | "submitted" | "streaming"
+  >("ready");
+  const [error, setError] = React.useState<Error | undefined>(
+    simulateError
+      ? new Error("Connection timed out. Please try again.")
+      : undefined,
+  );
+  const abortRef = React.useRef(false);
+
+  const onSendMessage = React.useCallback(async (text: string) => {
+    const userMsg = makeMessage("user", text);
+    setMessages(prev => [...prev, userMsg]);
+    setStatus("submitted");
+    abortRef.current = false;
+
+    // Simulate network delay
+    await new Promise(resolve => setTimeout(resolve, 600));
+    if (abortRef.current) {
+      setStatus("ready");
+      return;
+    }
+
+    setStatus("streaming");
+    const assistantMsg = makeMessage("assistant", "");
+    setMessages(prev => [...prev, assistantMsg]);
+
+    const response =
+      "Thanks for your message! This is a simulated response that streams in token by token to demonstrate the chat experience.";
+    const words = response.split(" ");
+
+    for (let i = 0; i < words.length; i++) {
+      if (abortRef.current) break;
+      await new Promise(resolve => setTimeout(resolve, 50));
+      const partialText = words.slice(0, i + 1).join(" ");
+      setMessages(prev => {
+        const updated = [...prev];
+        const last = updated[updated.length - 1];
+        updated[updated.length - 1] = {
+          ...last,
+          parts: [{ type: "text", text: partialText }],
+        };
+        return updated;
+      });
+    }
+
+    setStatus("ready");
+  }, []);
+
+  const onStop = React.useCallback(() => {
+    abortRef.current = true;
+    setStatus("ready");
+  }, []);
+
+  const onClearError = React.useCallback(() => {
+    setError(undefined);
+  }, []);
+
+  return (
+    <BaseAipAgentChat
+      {...rest}
+      error={error}
+      messages={messages}
+      onClearError={onClearError}
+      onSendMessage={onSendMessage}
+      onStop={onStop}
+      status={status}
+    />
+  );
+}
+
+const meta: Meta<typeof InteractiveChat> = {
+  title: "Beta/AipAgentChat",
+  component: InteractiveChat,
+  render: (args) => (
+    <div style={{ height: "600px", maxWidth: "700px" }}>
+      <InteractiveChat {...args} />
+    </div>
+  ),
+  parameters: {
+    controls: { expanded: true },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Empty chat with the default welcome state. Type a message to start a simulated conversation. */
+export const Default: Story = {};
+
+/** Chat pre-populated with an existing conversation. */
+export const WithConversation: Story = {
+  args: {
+    initialMessages: SAMPLE_CONVERSATION,
+  },
+};
+
+/** Chat displaying an error banner with a dismiss button. */
+export const WithError: Story = {
+  args: {
+    simulateError: true,
+    initialMessages: SAMPLE_CONVERSATION.slice(0, 2),
+  },
+};
+
+/** Custom placeholder text in the composer. */
+export const CustomPlaceholder: Story = {
+  args: {
+    placeholder: "Ask me anything about your data...",
+  },
+};

--- a/packages/react-components/docs/CSSVariables.md
+++ b/packages/react-components/docs/CSSVariables.md
@@ -236,33 +236,53 @@ Component-specific semantic tokens that may reference Blueprint tokens or define
 
 Tokens for the `AipAgentChat` chat surface (container, message bubbles, composer, empty state, loader, error banner).
 
-| Variable                                             | Default Value                                       | Description                                 |
-| ---------------------------------------------------- | --------------------------------------------------- | ------------------------------------------- |
-| `--osdk-aip-agent-chat-background`                   | `var(--osdk-background-primary)`                    | Chat container background                   |
-| `--osdk-aip-agent-chat-border-color`                 | `var(--osdk-surface-border-color-default)`          | Container, error, composer separator color  |
-| `--osdk-aip-agent-chat-border-radius`                | `var(--osdk-surface-border-radius)`                 | Container and bubble corner radius          |
-| `--osdk-aip-agent-chat-padding`                      | `calc(var(--osdk-surface-spacing) * 5)`             | Outer padding for message list and composer |
-| `--osdk-aip-agent-chat-message-gap`                  | `calc(var(--osdk-surface-spacing) * 5)`             | Vertical gap between messages               |
-| `--osdk-aip-agent-chat-section-gap`                  | `calc(var(--osdk-surface-spacing) * 2.5)`           | Gap between composer rows / footer items    |
-| `--osdk-aip-agent-chat-bubble-padding`               | `calc(var(--osdk-surface-spacing) * 3)`             | Padding inside each message bubble          |
-| `--osdk-aip-agent-chat-bubble-border-radius`         | `var(--osdk-surface-border-radius)`                 | Bubble corner radius                        |
-| `--osdk-aip-agent-chat-bubble-max-width`             | `80%`                                               | Maximum bubble width                        |
-| `--osdk-aip-agent-chat-user-bubble-background`       | `var(--osdk-intent-primary-rest)`                   | User-message bubble background              |
-| `--osdk-aip-agent-chat-user-bubble-color`            | `var(--osdk-intent-primary-foreground)`             | User-message text color                     |
-| `--osdk-aip-agent-chat-assistant-bubble-background`  | `var(--osdk-background-secondary)`                  | Assistant-message bubble background         |
-| `--osdk-aip-agent-chat-assistant-bubble-color`       | `var(--osdk-typography-color-default-rest)`         | Assistant-message text color                |
-| `--osdk-aip-agent-chat-composer-background`          | `var(--osdk-surface-background-color-default-rest)` | Composer background                         |
-| `--osdk-aip-agent-chat-composer-border-color`        | `var(--osdk-surface-border-color-default)`          | Composer top-border color                   |
-| `--osdk-aip-agent-chat-composer-textarea-min-height` | `calc(var(--osdk-surface-spacing) * 14)`            | Textarea minimum height                     |
-| `--osdk-aip-agent-chat-composer-textarea-max-height` | `200px`                                             | Textarea maximum height                     |
-| `--osdk-aip-agent-chat-empty-color`                  | `var(--osdk-typography-color-muted)`                | Empty-state subtext color                   |
-| `--osdk-aip-agent-chat-empty-icon-color`             | `var(--osdk-intent-primary-rest)`                   | Empty-state icon color                      |
-| `--osdk-aip-agent-chat-empty-icon-size`              | `calc(var(--osdk-surface-spacing) * 12)`            | Empty-state icon size                       |
-| `--osdk-aip-agent-chat-loader-color`                 | `var(--osdk-typography-color-muted)`                | 3-dot streaming loader color                |
-| `--osdk-aip-agent-chat-loader-dot-size`              | `calc(var(--osdk-surface-spacing) * 1.5)`           | Loader dot diameter                         |
-| `--osdk-aip-agent-chat-loader-dot-gap`               | `calc(var(--osdk-surface-spacing) * 0.5)`           | Loader dot gap                              |
-| `--osdk-aip-agent-chat-error-color`                  | `var(--osdk-typography-color-danger-rest)`          | Error banner text color                     |
-| `--osdk-aip-agent-chat-error-background`             | `var(--osdk-surface-background-color-danger-rest)`  | Error banner background                     |
+| Variable                                             | Default Value                                                                                             | Description                                         |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `--osdk-aip-agent-chat-background`                   | `var(--osdk-background-primary)`                                                                          | Chat container background                           |
+| `--osdk-aip-agent-chat-border-color`                 | `var(--osdk-surface-border-color-default)`                                                                | Container and composer separator color              |
+| `--osdk-aip-agent-chat-border-radius`                | `var(--osdk-surface-border-radius)`                                                                       | Container corner radius                             |
+| `--osdk-aip-agent-chat-padding`                      | `calc(var(--osdk-surface-spacing) * 5)`                                                                   | Outer padding for message list and composer         |
+| `--osdk-aip-agent-chat-message-gap`                  | `calc(var(--osdk-surface-spacing) * 5)`                                                                   | Vertical gap between messages                       |
+| `--osdk-aip-agent-chat-section-gap`                  | `calc(var(--osdk-surface-spacing) * 2.5)`                                                                 | Gap between composer rows / footer items            |
+| `--osdk-aip-agent-chat-content-max-width`            | `780px`                                                                                                   | Maximum width of the chat content area              |
+| `--osdk-aip-agent-chat-bubble-padding`               | `calc(var(--osdk-surface-spacing) * 3)`                                                                   | Padding inside each message bubble                  |
+| `--osdk-aip-agent-chat-bubble-border-radius`         | `var(--osdk-surface-border-radius)`                                                                       | Bubble corner radius                                |
+| `--osdk-aip-agent-chat-bubble-max-width`             | `80%`                                                                                                     | Maximum bubble width                                |
+| `--osdk-aip-agent-chat-user-bubble-background`       | `var(--osdk-background-secondary)`                                                                        | User-message bubble background                      |
+| `--osdk-aip-agent-chat-user-bubble-color`            | `var(--osdk-typography-color-default-rest)`                                                               | User-message text color                             |
+| `--osdk-aip-agent-chat-user-bubble-border-radius`    | `var(--osdk-surface-border-radius) var(--osdk-surface-border-radius) 0 var(--osdk-surface-border-radius)` | User-message bubble corner radius (chat-tail shape) |
+| `--osdk-aip-agent-chat-assistant-bubble-color`       | `var(--osdk-typography-color-default-rest)`                                                               | Assistant-message text color                        |
+| `--osdk-aip-agent-chat-composer-border-radius`       | `calc(var(--osdk-surface-spacing) * 2.5)`                                                                 | Composer input border radius                        |
+| `--osdk-aip-agent-chat-composer-background`          | `var(--osdk-surface-background-color-default-rest)`                                                       | Composer background                                 |
+| `--osdk-aip-agent-chat-composer-textarea-min-height` | `calc(var(--osdk-surface-spacing) * 14)`                                                                  | Textarea minimum height                             |
+| `--osdk-aip-agent-chat-composer-textarea-max-height` | `200px`                                                                                                   | Textarea maximum height                             |
+| `--osdk-aip-agent-chat-empty-color`                  | `var(--osdk-typography-color-muted)`                                                                      | Empty-state subtext color                           |
+| `--osdk-aip-agent-chat-empty-icon-color`             | `var(--osdk-intent-primary-rest)`                                                                         | Empty-state icon color                              |
+| `--osdk-aip-agent-chat-empty-icon-size`              | `calc(var(--osdk-surface-spacing) * 12)`                                                                  | Empty-state icon size                               |
+| `--osdk-aip-agent-chat-loader-color`                 | `var(--osdk-typography-color-muted)`                                                                      | 3-dot streaming loader color                        |
+| `--osdk-aip-agent-chat-loader-dot-size`              | `calc(var(--osdk-surface-spacing) * 1.5)`                                                                 | Loader dot diameter                                 |
+| `--osdk-aip-agent-chat-loader-dot-gap`               | `calc(var(--osdk-surface-spacing) * 0.5)`                                                                 | Loader dot gap                                      |
+
+### Callout
+
+Tokens for the `Callout` component used for error, warning, success, and info banners. In dark mode, the intent text colors switch to brighter `--rest` shades for readability.
+
+| Variable                            | Default Value                                                                | Description               |
+| ----------------------------------- | ---------------------------------------------------------------------------- | ------------------------- |
+| `--osdk-callout-padding`            | `calc(var(--osdk-surface-spacing) * 4)`                                      | Inner padding             |
+| `--osdk-callout-gap`                | `calc(var(--osdk-surface-spacing) * 2)`                                      | Gap between icon and text |
+| `--osdk-callout-border-radius`      | `var(--osdk-surface-border-radius)`                                          | Corner radius             |
+| `--osdk-callout-title-font-size`    | `var(--osdk-typography-size-body-medium)`                                    | Title font size           |
+| `--osdk-callout-title-font-weight`  | `var(--osdk-typography-weight-bold)`                                         | Title font weight         |
+| `--osdk-callout-message-font-size`  | `var(--osdk-typography-size-body-small)`                                     | Message body font size    |
+| `--osdk-callout-error-background`   | `color-mix(in srgb, var(--osdk-intent-danger-rest) 10%, transparent)`        | Error intent background   |
+| `--osdk-callout-error-color`        | `var(--osdk-intent-danger-hover)` (dark: `var(--osdk-intent-danger-rest)`)   | Error intent text color   |
+| `--osdk-callout-warning-background` | `color-mix(in srgb, var(--osdk-intent-warning-rest) 10%, transparent)`       | Warning intent background |
+| `--osdk-callout-warning-color`      | `var(--osdk-intent-warning-hover)` (dark: `var(--osdk-intent-warning-rest)`) | Warning intent text color |
+| `--osdk-callout-success-background` | `color-mix(in srgb, var(--osdk-intent-success-rest) 10%, transparent)`       | Success intent background |
+| `--osdk-callout-success-color`      | `var(--osdk-intent-success-hover)` (dark: `var(--osdk-intent-success-rest)`) | Success intent text color |
+| `--osdk-callout-info-background`    | `color-mix(in srgb, var(--osdk-intent-primary-rest) 10%, transparent)`       | Info intent background    |
+| `--osdk-callout-info-color`         | `var(--osdk-intent-primary-hover)` (dark: `var(--osdk-intent-primary-rest)`) | Info intent text color    |
 
 ### Drag Handle
 

--- a/packages/react-components/src/aip-agent-chat/AipAgentChat.module.css
+++ b/packages/react-components/src/aip-agent-chat/AipAgentChat.module.css
@@ -10,44 +10,8 @@
   width: 100%;
 }
 
-.error {
-  align-items: flex-start;
-  background: var(--osdk-aip-agent-chat-error-background);
-  border-bottom: 1px solid var(--osdk-aip-agent-chat-border-color);
-  color: var(--osdk-aip-agent-chat-error-color);
-  display: flex;
-  flex: 0 0 auto;
-  gap: var(--osdk-aip-agent-chat-section-gap);
-  justify-content: space-between;
-  padding: var(--osdk-aip-agent-chat-section-gap)
-    var(--osdk-aip-agent-chat-padding);
-}
-
-.errorBody {
-  display: flex;
-  flex: 1 1 auto;
-  flex-direction: column;
-  gap: calc(var(--osdk-surface-spacing) * 0.5);
-  min-width: 0;
-}
-
-.errorTitle {
-  font-size: var(--osdk-typography-size-body-medium);
-  font-weight: var(--osdk-typography-weight-bold);
-}
-
-.errorMessage {
-  font-size: var(--osdk-typography-size-body-small);
-  word-break: break-word;
-}
-
-.errorActions {
-  display: flex;
-  flex: 0 0 auto;
-  gap: calc(var(--osdk-surface-spacing) * 1);
-}
-
 .messageList {
+  align-items: center;
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
@@ -57,13 +21,18 @@
   padding: var(--osdk-aip-agent-chat-padding);
 }
 
+.messageList:not(.empty) > * {
+  max-width: var(--osdk-aip-agent-chat-content-max-width);
+  width: 100%;
+}
+
 .empty {
   align-items: center;
   color: var(--osdk-aip-agent-chat-empty-color);
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
-  gap: var(--osdk-aip-agent-chat-section-gap);
+  gap: var(--osdk-aip-agent-chat-message-gap);
   justify-content: center;
   padding: var(--osdk-aip-agent-chat-padding);
   text-align: center;
@@ -109,12 +78,14 @@
 
 .userBubble {
   background: var(--osdk-aip-agent-chat-user-bubble-background);
+  border-radius: var(--osdk-aip-agent-chat-user-bubble-border-radius);
   color: var(--osdk-aip-agent-chat-user-bubble-color);
 }
 
 .assistantBubble {
-  background: var(--osdk-aip-agent-chat-assistant-bubble-background);
+  background: transparent;
   color: var(--osdk-aip-agent-chat-assistant-bubble-color);
+  padding: 0;
 }
 
 .systemBubble {
@@ -129,6 +100,7 @@
 }
 
 .composer {
+  align-items: center;
   background: var(--osdk-aip-agent-chat-composer-background);
   border-top: 1px solid var(--osdk-aip-agent-chat-composer-border-color);
   display: flex;
@@ -138,10 +110,27 @@
   padding: var(--osdk-aip-agent-chat-padding);
 }
 
-.textarea {
+.composer > * {
+  max-width: var(--osdk-aip-agent-chat-content-max-width);
+  width: 100%;
+}
+
+.inputWrapper {
   background: var(--osdk-background-primary);
   border: 1px solid var(--osdk-surface-border-color-default);
-  border-radius: var(--osdk-aip-agent-chat-border-radius);
+  border-radius: var(--osdk-aip-agent-chat-composer-border-radius);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.inputWrapper:focus-within {
+  border-color: var(--osdk-emphasis-focus-color);
+}
+
+.textarea {
+  background: transparent;
+  border: none;
   color: var(--osdk-typography-color-default-rest);
   font-family: inherit;
   font-size: var(--osdk-typography-size-body-medium);
@@ -150,19 +139,16 @@
   min-height: var(--osdk-aip-agent-chat-composer-textarea-min-height);
   outline: none;
   padding: var(--osdk-aip-agent-chat-section-gap);
-  resize: vertical;
+  resize: none;
   width: 100%;
 }
 
-.textarea:focus {
-  border-color: var(--osdk-emphasis-focus-color);
-}
-
-.composerActions {
+.inputActions {
   align-items: center;
   display: flex;
-  gap: var(--osdk-aip-agent-chat-section-gap);
-  justify-content: space-between;
+  justify-content: flex-end;
+  padding: 0 var(--osdk-aip-agent-chat-section-gap)
+    var(--osdk-aip-agent-chat-section-gap);
 }
 
 .composerFooterLeft {
@@ -197,13 +183,6 @@
 .modelPickerLabel {
   color: var(--osdk-typography-color-muted);
   font-size: var(--osdk-typography-size-body-small);
-}
-
-.composerFooterRight {
-  align-items: center;
-  display: flex;
-  flex: 0 0 auto;
-  gap: var(--osdk-aip-agent-chat-section-gap);
 }
 
 .loader {

--- a/packages/react-components/src/aip-agent-chat/AipAgentChat.module.css
+++ b/packages/react-components/src/aip-agent-chat/AipAgentChat.module.css
@@ -102,7 +102,7 @@
 .composer {
   align-items: center;
   background: var(--osdk-aip-agent-chat-composer-background);
-  border-top: 1px solid var(--osdk-aip-agent-chat-composer-border-color);
+
   display: flex;
   flex: 0 0 auto;
   flex-direction: column;

--- a/packages/react-components/src/aip-agent-chat/BaseAipAgentChat.tsx
+++ b/packages/react-components/src/aip-agent-chat/BaseAipAgentChat.tsx
@@ -19,6 +19,7 @@ import type { ChatStatus } from "@osdk/react/experimental/aip";
 import classNames from "classnames";
 import * as React from "react";
 import { ActionButton } from "../base-components/action-button/ActionButton.js";
+import { Callout } from "../base-components/callout/Callout.js";
 import styles from "./AipAgentChat.module.css";
 import { AipAgentChatComposer } from "./components/AipAgentChatComposer.js";
 import { AipAgentChatMessageList } from "./components/AipAgentChatMessageList.js";
@@ -106,21 +107,19 @@ export const BaseAipAgentChat: React.NamedExoticComponent<
   return (
     <div className={classNames(styles.chat, className)}>
       {error != null && (
-        <div aria-live="polite" className={styles.error} role="alert">
-          <div className={styles.errorBody}>
-            <div className={styles.errorTitle}>Something went wrong</div>
-            <div className={styles.errorMessage}>
-              {error.message.length > 0
-                ? error.message
-                : "An unknown error occurred. Try again, or dismiss to keep the conversation."}
-            </div>
-          </div>
-          <div className={styles.errorActions}>
+        <Callout
+          actions={
             <ActionButton onClick={onClearError} type="button">
               Dismiss
             </ActionButton>
-          </div>
-        </div>
+          }
+          intent="error"
+          title="Something went wrong"
+        >
+          {error.message.length > 0
+            ? error.message
+            : "An unknown error occurred. Try again, or dismiss to keep the conversation."}
+        </Callout>
       )}
       <AipAgentChatMessageList
         enableAutoScroll={enableAutoScroll}

--- a/packages/react-components/src/aip-agent-chat/components/AipAgentChatComposer.tsx
+++ b/packages/react-components/src/aip-agent-chat/components/AipAgentChatComposer.tsx
@@ -91,17 +91,16 @@ export function AipAgentChatComposer({
 
   return (
     <div className={classNames(styles.composer, className)}>
-      <Input
-        aria-label="Message input"
-        className={styles.textarea}
-        onValueChange={setDraft}
-        placeholder={placeholder}
-        value={draft}
-        render={renderTextarea}
-      />
-      <div className={styles.composerActions}>
-        <div className={styles.composerFooterLeft}>{footerLeft}</div>
-        <div className={styles.composerFooterRight}>
+      <div className={styles.inputWrapper}>
+        <Input
+          aria-label="Message input"
+          className={styles.textarea}
+          onValueChange={setDraft}
+          placeholder={placeholder}
+          value={draft}
+          render={renderTextarea}
+        />
+        <div className={styles.inputActions}>
           {isInFlight && onStop != null
             ? (
               <ActionButton onClick={onStop} type="button">
@@ -120,6 +119,9 @@ export function AipAgentChatComposer({
             )}
         </div>
       </div>
+      {footerLeft != null && (
+        <div className={styles.composerFooterLeft}>{footerLeft}</div>
+      )}
     </div>
   );
 }

--- a/packages/react-components/src/base-components/callout/Callout.module.css
+++ b/packages/react-components/src/base-components/callout/Callout.module.css
@@ -1,0 +1,59 @@
+.callout {
+  align-items: flex-start;
+  border-radius: var(--osdk-callout-border-radius);
+  display: flex;
+  gap: var(--osdk-callout-gap);
+  padding: var(--osdk-callout-padding);
+}
+
+.error {
+  background: var(--osdk-callout-error-background);
+  color: var(--osdk-callout-error-color);
+}
+
+.warning {
+  background: var(--osdk-callout-warning-background);
+  color: var(--osdk-callout-warning-color);
+}
+
+.success {
+  background: var(--osdk-callout-success-background);
+  color: var(--osdk-callout-success-color);
+}
+
+.info {
+  background: var(--osdk-callout-info-background);
+  color: var(--osdk-callout-info-color);
+}
+
+.icon {
+  flex: 0 0 auto;
+  line-height: 0;
+  padding-top: 1px;
+}
+
+.body {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: calc(var(--osdk-surface-spacing) * 1);
+  min-width: 0;
+}
+
+.title {
+  font-size: var(--osdk-callout-title-font-size);
+  font-weight: var(--osdk-callout-title-font-weight);
+}
+
+.message {
+  font-size: var(--osdk-callout-message-font-size);
+  word-break: break-word;
+}
+
+.actions {
+  align-items: center;
+  align-self: stretch;
+  display: flex;
+  flex: 0 0 auto;
+  justify-content: center;
+}

--- a/packages/react-components/src/base-components/callout/Callout.tsx
+++ b/packages/react-components/src/base-components/callout/Callout.tsx
@@ -49,9 +49,9 @@ export interface CalloutProps {
   actions?: React.ReactNode;
 
   /**
-   * Override the default intent icon. Pass `false` to hide the icon.
+   * Override the default intent icon.
    */
-  icon?: React.ComponentType<{ size?: number }> | false;
+  icon?: React.ComponentType<{ size?: number }>;
 
   className?: string;
 }
@@ -86,9 +86,7 @@ export const Callout: React.NamedExoticComponent<CalloutProps> = React.memo(
     icon,
     className,
   }) {
-    const IconComponent = icon !== false
-      ? (icon ?? DEFAULT_ICONS[intent])
-      : undefined;
+    const IconComponent = icon ?? DEFAULT_ICONS[intent];
 
     return (
       <div

--- a/packages/react-components/src/base-components/callout/Callout.tsx
+++ b/packages/react-components/src/base-components/callout/Callout.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Error as ErrorIcon,
+  InfoSign,
+  Tick,
+  WarningSign,
+} from "@blueprintjs/icons";
+import classNames from "classnames";
+import * as React from "react";
+import styles from "./Callout.module.css";
+
+export type CalloutIntent = "error" | "warning" | "success" | "info";
+
+export interface CalloutProps {
+  /**
+   * Visual intent that determines background, border, and text color.
+   */
+  intent: CalloutIntent;
+
+  /**
+   * Optional bold heading displayed above the message content.
+   */
+  title?: string;
+
+  /**
+   * Message content rendered inside the callout body.
+   */
+  children?: React.ReactNode;
+
+  /**
+   * Optional slot for action buttons (e.g. dismiss, retry) rendered
+   * on the trailing edge.
+   */
+  actions?: React.ReactNode;
+
+  /**
+   * Override the default intent icon. Pass `false` to hide the icon.
+   */
+  icon?: React.ComponentType<{ size?: number }> | false;
+
+  className?: string;
+}
+
+const DEFAULT_ICONS: Record<
+  CalloutIntent,
+  React.ComponentType<{ size?: number }>
+> = {
+  error: ErrorIcon,
+  warning: WarningSign,
+  success: Tick,
+  info: InfoSign,
+};
+
+const INTENT_STYLES: Record<CalloutIntent, string> = {
+  error: styles.error,
+  warning: styles.warning,
+  success: styles.success,
+  info: styles.info,
+};
+
+/**
+ * A styled alert banner supporting four intent levels with an icon,
+ * title, message body, and action slot.
+ */
+export const Callout: React.NamedExoticComponent<CalloutProps> = React.memo(
+  function Callout({
+    intent,
+    title,
+    children,
+    actions,
+    icon,
+    className,
+  }) {
+    const IconComponent = icon !== false
+      ? (icon ?? DEFAULT_ICONS[intent])
+      : undefined;
+
+    return (
+      <div
+        aria-live="polite"
+        className={classNames(
+          styles.callout,
+          INTENT_STYLES[intent],
+          className,
+        )}
+        role="alert"
+      >
+        {IconComponent != null && (
+          <span className={styles.icon}>
+            <IconComponent size={16} />
+          </span>
+        )}
+        <div className={styles.body}>
+          {title != null && <div className={styles.title}>{title}</div>}
+          {children != null && <div className={styles.message}>{children}</div>}
+        </div>
+        {actions != null && <div className={styles.actions}>{actions}</div>}
+      </div>
+    );
+  },
+);

--- a/packages/react-components/src/tokens.css
+++ b/packages/react-components/src/tokens.css
@@ -4,6 +4,7 @@
 
 /* Component tokens: component-specific tokens that reference base tokens */
 @import "./tokens/component-tokens/aip-agent-chat.css";
+@import "./tokens/component-tokens/callout.css";
 @import "./tokens/component-tokens/async-dropdown.css";
 @import "./tokens/component-tokens/button.css";
 @import "./tokens/component-tokens/cbac-picker.css";

--- a/packages/react-components/src/tokens/base-tokens/dark.css
+++ b/packages/react-components/src/tokens/base-tokens/dark.css
@@ -55,6 +55,12 @@
     var(--osdk-intent-primary-rest) 25%,
     var(--osdk-background-primary)
   );
+
+  /* Callout: use brighter rest shade for readability on dark backgrounds */
+  --osdk-dark-callout-error-color: var(--osdk-intent-danger-rest);
+  --osdk-dark-callout-warning-color: var(--osdk-intent-warning-rest);
+  --osdk-dark-callout-success-color: var(--osdk-intent-success-rest);
+  --osdk-dark-callout-info-color: var(--osdk-intent-primary-rest);
 }
 
 [data-bp-color-scheme="dark"],
@@ -81,4 +87,8 @@
     var(--osdk-table-border-color);
   --osdk-table-row-bg-hover: var(--osdk-dark-table-row-bg-hover);
   --osdk-table-row-bg-active: var(--osdk-dark-table-row-bg-hover);
+  --osdk-callout-error-color: var(--osdk-dark-callout-error-color);
+  --osdk-callout-warning-color: var(--osdk-dark-callout-warning-color);
+  --osdk-callout-success-color: var(--osdk-dark-callout-success-color);
+  --osdk-callout-info-color: var(--osdk-dark-callout-info-color);
 }

--- a/packages/react-components/src/tokens/component-tokens/aip-agent-chat.css
+++ b/packages/react-components/src/tokens/component-tokens/aip-agent-chat.css
@@ -14,17 +14,24 @@
   --osdk-aip-agent-chat-bubble-border-radius: var(--osdk-surface-border-radius);
   --osdk-aip-agent-chat-bubble-max-width: 80%;
 
-  --osdk-aip-agent-chat-user-bubble-background: var(--osdk-intent-primary-rest);
+  --osdk-aip-agent-chat-user-bubble-background: var(--osdk-background-secondary);
   --osdk-aip-agent-chat-user-bubble-color: var(
-    --osdk-intent-primary-foreground
+    --osdk-typography-color-default-rest
   );
+  --osdk-aip-agent-chat-user-bubble-border-radius: var(
+    --osdk-surface-border-radius
+  )
+    var(--osdk-surface-border-radius) 0 var(--osdk-surface-border-radius);
 
-  --osdk-aip-agent-chat-assistant-bubble-background: var(
-    --osdk-background-secondary
-  );
   --osdk-aip-agent-chat-assistant-bubble-color: var(
     --osdk-typography-color-default-rest
   );
+
+  --osdk-aip-agent-chat-composer-border-radius: calc(
+    var(--osdk-surface-spacing) * 2.5
+  );
+
+  --osdk-aip-agent-chat-content-max-width: 780px;
 
   /* Composer */
   --osdk-aip-agent-chat-composer-background: var(
@@ -49,8 +56,4 @@
     var(--osdk-surface-spacing) * 1.5
   );
   --osdk-aip-agent-chat-loader-dot-gap: calc(var(--osdk-surface-spacing) * 0.5);
-
-  /* Error banner */
-  --osdk-aip-agent-chat-error-color: var(--osdk-intent-danger-foreground);
-  --osdk-aip-agent-chat-error-background: var(--osdk-intent-danger-rest);
 }

--- a/packages/react-components/src/tokens/component-tokens/aip-agent-chat.css
+++ b/packages/react-components/src/tokens/component-tokens/aip-agent-chat.css
@@ -37,9 +37,6 @@
   --osdk-aip-agent-chat-composer-background: var(
     --osdk-surface-background-color-default-rest
   );
-  --osdk-aip-agent-chat-composer-border-color: var(
-    --osdk-surface-border-color-default
-  );
   --osdk-aip-agent-chat-composer-textarea-min-height: calc(
     var(--osdk-surface-spacing) * 14
   );

--- a/packages/react-components/src/tokens/component-tokens/callout.css
+++ b/packages/react-components/src/tokens/component-tokens/callout.css
@@ -1,0 +1,40 @@
+:root {
+  /* Layout */
+  --osdk-callout-padding: calc(var(--osdk-surface-spacing) * 4);
+  --osdk-callout-gap: calc(var(--osdk-surface-spacing) * 2);
+  --osdk-callout-border-radius: var(--osdk-surface-border-radius);
+
+  /* Typography */
+  --osdk-callout-title-font-size: var(--osdk-typography-size-body-medium);
+  --osdk-callout-title-font-weight: var(--osdk-typography-weight-bold);
+  --osdk-callout-message-font-size: var(--osdk-typography-size-body-small);
+
+  /* Intent backgrounds: 10% tint of the intent rest color.
+     rgba() with semi-transparency naturally adapts to light/dark backgrounds. */
+  --osdk-callout-error-background: color-mix(
+    in srgb,
+    var(--osdk-intent-danger-rest) 10%,
+    transparent
+  );
+  --osdk-callout-warning-background: color-mix(
+    in srgb,
+    var(--osdk-intent-warning-rest) 10%,
+    transparent
+  );
+  --osdk-callout-success-background: color-mix(
+    in srgb,
+    var(--osdk-intent-success-rest) 10%,
+    transparent
+  );
+  --osdk-callout-info-background: color-mix(
+    in srgb,
+    var(--osdk-intent-primary-rest) 10%,
+    transparent
+  );
+
+  /* Intent text: darker hover shade for light mode */
+  --osdk-callout-error-color: var(--osdk-intent-danger-hover);
+  --osdk-callout-warning-color: var(--osdk-intent-warning-hover);
+  --osdk-callout-success-color: var(--osdk-intent-success-hover);
+  --osdk-callout-info-color: var(--osdk-intent-primary-hover);
+}


### PR DESCRIPTION
## Summary
- Restyle `AipAgentChat` to match Threads 2.0 design: light gray user bubbles with asymmetric rounding, plain-text (transparent background) assistant messages, rounded inlined composer with textarea + actions inside a single bordered wrapper, and a centered 780px max-width content column
- Remove composer divider border (`border-top`) for a cleaner look
- Add reusable `Callout` base component (`error` / `warning` / `success` / `info` intents) with light tinted backgrounds via `color-mix` from intent tokens, plus dark mode overrides in `dark.css`
- Replace raw error `<div>` markup in `BaseAipAgentChat` with the new `Callout` component
- Add `AipAgentChat` storybook stories (Default, WithConversation, WithError, CustomPlaceholder)

## Changes

### Chat restyle
- User bubbles: light gray background, asymmetric border-radius via `--osdk-aip-agent-chat-user-bubble-border-radius`
- Assistant bubbles: transparent background, no padding (plain text flow)
- Message list and composer content constrained to `--osdk-aip-agent-chat-content-max-width` (780px) and centered
- Composer: textarea and action buttons wrapped in a single `inputWrapper` with rounded corners (`--osdk-aip-agent-chat-composer-border-radius`), no top border divider, focus ring on the wrapper instead of the textarea
- Textarea: `resize: none` (no manual resize handle)

### Callout component
- New `base-components/callout/` — `Callout.tsx` + `Callout.module.css`
- Intents: `error`, `warning`, `success`, `info` with configurable title, children, and actions slot
- Backgrounds derived via `color-mix()` from existing intent color tokens
- Dark mode overrides in `dark.css`
- Component tokens in `tokens/component-tokens/callout.css`

### Storybook
- New `AipAgentChat.stories.tsx` with 4 stories exercising default, conversation, error, and custom placeholder states

## Test plan
- [ ] Run storybook (`pnpm dev` in `react-components-storybook`) and verify all 4 AipAgentChat stories render correctly
- [ ] Toggle dark mode in storybook and verify Callout error banner has readable text on dark backgrounds
- [ ] Verify `pnpm turbo typecheck --filter=@osdk/react-components` passes
- [ ] Verify `pnpm turbo test --filter=@osdk/react-components` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)