### PR TITLE
Fix ObjectTable select all behavior

### DIFF
--- a/.changeset/objtable-select-all-toggle-deselect.md
+++ b/.changeset/objtable-select-all-toggle-deselect.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+ObjectTable: clicking the header select-all checkbox now deselects all rows whenever any rows are selected (including the indeterminate state). Previously a partial selection promoted to "select all" on click, requiring a second click to clear. 

--- a/packages/react-components/src/object-table/hooks/__tests__/useRowSelection.test.tsx
+++ b/packages/react-components/src/object-table/hooks/__tests__/useRowSelection.test.tsx
@@ -528,7 +528,11 @@ describe("useRowSelection", () => {
           result.current.onToggleRow("item-1", 1);
         });
 
-        // Select all then deselect all
+        // Partial selection → deselect; empty → select all; all → deselect.
+        // After this cycle, selection is empty but lastSelectedRowIndex is still 1.
+        act(() => {
+          result.current.onToggleAll();
+        });
         act(() => {
           result.current.onToggleAll();
         });
@@ -546,6 +550,63 @@ describe("useRowSelection", () => {
           [data[1].$primaryKey, data[2].$primaryKey, data[3].$primaryKey],
           false,
         );
+      });
+    });
+
+    describe("onToggleAll from indeterminate state", () => {
+      it("deselects all when some rows are selected (uncontrolled)", () => {
+        const data = createMockData(5);
+        const onRowSelection = vi.fn();
+        const { result } = renderHook(() =>
+          useRowSelection({
+            selectionMode: "multiple",
+            onRowSelection,
+            data,
+          })
+        );
+
+        // Select two of five rows → indeterminate
+        act(() => {
+          result.current.onToggleRow("item-0", 0);
+        });
+        act(() => {
+          result.current.onToggleRow("item-2", 2);
+        });
+
+        expect(result.current.isAllSelected).toBe(false);
+        expect(result.current.hasSelection).toBe(true);
+
+        // Click header checkbox: clears the selection rather than promoting to "select all"
+        act(() => {
+          result.current.onToggleAll();
+        });
+
+        expect(result.current.rowSelection).toEqual({});
+        expect(result.current.isAllSelected).toBe(false);
+        expect(result.current.hasSelection).toBe(false);
+        expect(onRowSelection).toHaveBeenLastCalledWith([], false);
+      });
+
+      it("deselects all when controlled selectedRows is non-empty but not all", () => {
+        const data = createMockData(5);
+        const onRowSelection = vi.fn();
+        const { result } = renderHook(() =>
+          useRowSelection({
+            selectionMode: "multiple",
+            selectedRows: [data[0].$primaryKey, data[2].$primaryKey],
+            onRowSelection,
+            data,
+          })
+        );
+
+        expect(result.current.isAllSelected).toBe(false);
+        expect(result.current.hasSelection).toBe(true);
+
+        act(() => {
+          result.current.onToggleAll();
+        });
+
+        expect(onRowSelection).toHaveBeenCalledWith([], false);
       });
     });
 

--- a/packages/react-components/src/object-table/hooks/useRowSelection.ts
+++ b/packages/react-components/src/object-table/hooks/useRowSelection.ts
@@ -166,7 +166,9 @@ export function useRowSelection<
   const onToggleAll = useCallback(() => {
     if (!enableRowSelection || !data) return;
 
-    const newIsAllSelected = !isAllSelected;
+    // Any existing selection (full or partial/indeterminate) clears on click;
+    // only an empty selection promotes to "select all".
+    const newIsAllSelected = !hasSelection;
     const newSelectedRows: PrimaryKeyType<Q>[] = newIsAllSelected
       ? data.map(item => item.$primaryKey)
       : [];
@@ -182,7 +184,7 @@ export function useRowSelection<
   }, [
     enableRowSelection,
     data,
-    isAllSelected,
+    hasSelection,
     isControlled,
     fireSelectionCallbacks,
   ]);


### PR DESCRIPTION
Fix the select all toggle behaviour to be consistent with workshop table - deselect all when some rows are selected

Before:

https://github.com/user-attachments/assets/90aca995-cc8c-4ef4-9848-9fe75b18af92

After:

https://github.com/user-attachments/assets/2fd0b948-71c9-4238-a11f-16e73e307f94


