### PR TITLE
Version Packages

### DIFF
--- a/.changeset/add-storybook-doc-pages.md
+++ b/.changeset/add-storybook-doc-pages.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-components": patch
----
-
-Add documentation MDX pages to Storybook sidebar (Welcome, Guides, Styling, Tokens, Hooks)

--- a/.changeset/object-table-stream-updates.md
+++ b/.changeset/object-table-stream-updates.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-components": minor
----
-
-ObjectTable: expose `streamUpdates` prop that opts the table into websocket-driven live updates when matching objects are added, updated, or removed in Foundry. Forwarded to both `useObjectSet` and `useOsdkObjects`.

--- a/.changeset/pdf-viewer-annotation-removechild-fix.md
+++ b/.changeset/pdf-viewer-annotation-removechild-fix.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-components": patch
----
-
-Fix `NotFoundError: removeChild` crashes when zooming or switching documents in `PdfViewer`. Annotation overlays are now rendered as siblings of pdfjs content (using measured page coordinates) instead of portaled into pdfjs-owned DOM. `AnnotationPortalTarget` now exposes `left`/`top`/`width`/`height`/`transform` in place of `container`. Annotation remeasures triggered by zoom, rotation, and container resize are now coalesced to one `requestAnimationFrame` tick, eliminating O(annotated pages) `getBoundingClientRect` reads on every pinch-zoom event.

--- a/.changeset/wide-kids-jog.md
+++ b/.changeset/wide-kids-jog.md
@@ -1,6 +1,0 @@
----
-"@osdk/react-components-storybook": patch
-"@osdk/react-components": patch
----
-
-Hide the DatePicker popover when its anchor scrolls out of view. Fixes an issue where the date picker in `ObjectTable` cells continued to render outside the table bounds after the cell scrolled out of the visible area.

--- a/packages/react-components-storybook/CHANGELOG.md
+++ b/packages/react-components-storybook/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/react-components-storybook
 
+## 0.19.0
+
+### Minor Changes
+
+- 4c53e48: Hide the DatePicker popover when its anchor scrolls out of view. Fixes an issue where the date picker in `ObjectTable` cells continued to render outside the table bounds after the cell scrolled out of the visible area.
+
 ## 0.18.0
 
 ### Patch Changes

--- a/packages/react-components-storybook/package.json
+++ b/packages/react-components-storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/react-components-storybook",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/react-components-styles/CHANGELOG.md
+++ b/packages/react-components-styles/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/react-components-styles
 
+## 0.21.0
+
 ## 0.20.0
 
 ## 0.19.0

--- a/packages/react-components-styles/package.json
+++ b/packages/react-components-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/react-components-styles",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @osdk/react-components
 
+## 0.21.0
+
+### Minor Changes
+
+- 44c5f57: Add documentation MDX pages to Storybook sidebar (Welcome, Guides, Styling, Tokens, Hooks)
+- 837ea03: ObjectTable: expose `streamUpdates` prop that opts the table into websocket-driven live updates when matching objects are added, updated, or removed in Foundry. Forwarded to both `useObjectSet` and `useOsdkObjects`.
+- 0907d00: Fix `NotFoundError: removeChild` crashes when zooming or switching documents in `PdfViewer`. Annotation overlays are now rendered as siblings of pdfjs content (using measured page coordinates) instead of portaled into pdfjs-owned DOM. `AnnotationPortalTarget` now exposes `left`/`top`/`width`/`height`/`transform` in place of `container`. Annotation remeasures triggered by zoom, rotation, and container resize are now coalesced to one `requestAnimationFrame` tick, eliminating O(annotated pages) `getBoundingClientRect` reads on every pinch-zoom event.
+- 4c53e48: Hide the DatePicker popover when its anchor scrolls out of view. Fixes an issue where the date picker in `ObjectTable` cells continued to render outside the table bounds after the cell scrolled out of the visible area.
+
 ## 0.20.0
 
 ### Minor Changes

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/react-components",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.


# Releases
## @osdk/react-components@0.21.0

### Minor Changes

-   44c5f57: Add documentation MDX pages to Storybook sidebar (Welcome, Guides, Styling, Tokens, Hooks)
-   837ea03: ObjectTable: expose `streamUpdates` prop that opts the table into websocket-driven live updates when matching objects are added, updated, or removed in Foundry. Forwarded to both `useObjectSet` and `useOsdkObjects`.
-   0907d00: Fix `NotFoundError: removeChild` crashes when zooming or switching documents in `PdfViewer`. Annotation overlays are now rendered as siblings of pdfjs content (using measured page coordinates) instead of portaled into pdfjs-owned DOM. `AnnotationPortalTarget` now exposes `left`/`top`/`width`/`height`/`transform` in place of `container`. Annotation remeasures triggered by zoom, rotation, and container resize are now coalesced to one `requestAnimationFrame` tick, eliminating O(annotated pages) `getBoundingClientRect` reads on every pinch-zoom event.
-   4c53e48: Hide the DatePicker popover when its anchor scrolls out of view. Fixes an issue where the date picker in `ObjectTable` cells continued to render outside the table bounds after the cell scrolled out of the visible area.

## @osdk/react-components-styles@0.21.0



## @osdk/react-components-storybook@0.19.0

### Minor Changes

-   4c53e48: Hide the DatePicker popover when its anchor scrolls out of view. Fixes an issue where the date picker in `ObjectTable` cells continued to render outside the table bounds after the cell scrolled out of the visible area.
