### PR TITLE
docs: add ActionForm MDX documentation page

### DIFF
--- a/.changeset/actionform-mdx-docs.md
+++ b/.changeset/actionform-mdx-docs.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components-storybook": patch
+---
+
+Add ActionForm MDX documentation page with usage examples, API reference, CSS variables, and data attributes

--- a/packages/react-components-storybook/.storybook/main.ts
+++ b/packages/react-components-storybook/.storybook/main.ts
@@ -21,7 +21,7 @@ const storybookBasePath = process.env.STORYBOOK_BASE_PATH;
 const config: StorybookConfig = {
   stories: [
     "../src/**/*.stories.@(js|jsx|ts|tsx|mdx)",
-    "../src/**/*.mdx",
+    "../src/docs/**/*.mdx",
   ],
   addons: [
     "@storybook/addon-a11y",

--- a/packages/react-components-storybook/.storybook/main.ts
+++ b/packages/react-components-storybook/.storybook/main.ts
@@ -21,7 +21,7 @@ const storybookBasePath = process.env.STORYBOOK_BASE_PATH;
 const config: StorybookConfig = {
   stories: [
     "../src/**/*.stories.@(js|jsx|ts|tsx|mdx)",
-    "../src/docs/**/*.mdx",
+    "../src/**/*.mdx",
   ],
   addons: [
     "@storybook/addon-a11y",

--- a/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
+++ b/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
@@ -145,137 +145,197 @@ full control over field values.
 
 ### ActionFormProps
 
-| Prop | Type | Description |
-|---|---|---|
-| `actionDefinition` | `ActionDefinition` | The OSDK action definition to render a form for (required) |
-| `showFormTitle` | `boolean` | Whether to show the form title. Default `false` |
-| `formTitle` | `string` | Optional title used when `showFormTitle` is `true`. Falls back to the action display name |
-| `formFieldDefinitions` | `FormFieldDefinition[]` | Complete replacement for generated fields. Include every action parameter that should appear |
-| `isSubmitDisabled` | `boolean` | Disables the submit button before validation runs |
-| `formState` | `FormState` | Controlled form state. When provided, `onFormStateChange` is required |
-| `onFormStateChange` | `(updater) => void` | Called when any field value changes. Required in controlled mode |
-| `onSubmit` | `(formState, applyAction) => Promise` | Custom submit handler. Receives the form state and the `applyAction` callback |
-| `onValidationResponse` | `(results) => void` | Called when a validation-only submission returns results |
-| `onSuccess` | `(results) => void` | Called when the action is successfully applied |
-| `onError` | `(error: FormError) => void` | Called when a submission or validation error occurs |
+<table>
+  <thead>
+    <tr><th>Prop</th><th>Type</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>actionDefinition</code></td><td><code>ActionDefinition</code></td><td>The OSDK action definition to render a form for (required)</td></tr>
+    <tr><td><code>showFormTitle</code></td><td><code>boolean</code></td><td>{"Whether to show the form title. Default false"}</td></tr>
+    <tr><td><code>formTitle</code></td><td><code>string</code></td><td>{"Optional title used when showFormTitle is true. Falls back to the action display name"}</td></tr>
+    <tr><td><code>formFieldDefinitions</code></td><td><code>{"FormFieldDefinition[]"}</code></td><td>Complete replacement for generated fields. Include every action parameter that should appear</td></tr>
+    <tr><td><code>isSubmitDisabled</code></td><td><code>boolean</code></td><td>Disables the submit button before validation runs</td></tr>
+    <tr><td><code>formState</code></td><td><code>FormState</code></td><td>{"Controlled form state. When provided, onFormStateChange is required"}</td></tr>
+    <tr><td><code>onFormStateChange</code></td><td><code>{"(updater) => void"}</code></td><td>Called when any field value changes. Required in controlled mode</td></tr>
+    <tr><td><code>onSubmit</code></td><td><code>{"(formState, applyAction) => Promise"}</code></td><td>{"Receives the form state and the applyAction callback"}</td></tr>
+    <tr><td><code>onValidationResponse</code></td><td><code>{"(results) => void"}</code></td><td>Called when a validation-only submission returns results</td></tr>
+    <tr><td><code>onSuccess</code></td><td><code>{"(results) => void"}</code></td><td>Called when the action is successfully applied</td></tr>
+    <tr><td><code>onError</code></td><td><code>{"(error: FormError) => void"}</code></td><td>Called when a submission or validation error occurs</td></tr>
+  </tbody>
+</table>
 
 ### FormFieldDefinition
 
-| Field | Type | Description |
-|---|---|---|
-| `fieldKey` | `FieldKey` | The action parameter key this field maps to |
-| `label` | `string` | Display label for the field |
-| `fieldComponent` | `FieldComponent` | UI component to render (see field component types below) |
-| `fieldComponentProps` | `object` | Props passed to the field component (type narrows based on `fieldComponent`) |
-| `defaultValue` | `FieldValueType` | Default value for the field |
-| `isRequired` | `boolean` | Whether the field is required |
-| `placeholder` | `string` | Placeholder text |
-| `helperText` | `ReactNode` | Additional information displayed via tooltip or below the label |
-| `helperTextPlacement` | `"bottom" \| "tooltip"` | Where to display helper text. Default `"tooltip"` |
-| `disabled` | `boolean` | Whether the field is disabled |
-| `validate` | `(value) => Promise<string \| undefined>` | Custom validation function. Return an error message or `undefined` |
-| `onValidationError` | `(error) => string \| undefined` | Customize built-in validation error messages |
+<table>
+  <thead>
+    <tr><th>Field</th><th>Type</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>fieldKey</code></td><td><code>FieldKey</code></td><td>The action parameter key this field maps to</td></tr>
+    <tr><td><code>label</code></td><td><code>string</code></td><td>Display label for the field</td></tr>
+    <tr><td><code>fieldComponent</code></td><td><code>FieldComponent</code></td><td>UI component to render (see field component types below)</td></tr>
+    <tr><td><code>fieldComponentProps</code></td><td><code>object</code></td><td>{"Props passed to the field component (type narrows based on fieldComponent)"}</td></tr>
+    <tr><td><code>defaultValue</code></td><td><code>FieldValueType</code></td><td>Default value for the field</td></tr>
+    <tr><td><code>isRequired</code></td><td><code>boolean</code></td><td>Whether the field is required</td></tr>
+    <tr><td><code>placeholder</code></td><td><code>string</code></td><td>Placeholder text</td></tr>
+    <tr><td><code>helperText</code></td><td><code>ReactNode</code></td><td>Additional information displayed via tooltip or below the label</td></tr>
+    <tr><td><code>helperTextPlacement</code></td><td><code>{"\"bottom\" | \"tooltip\""}</code></td><td>{"Where to display helper text. Default \"tooltip\""}</td></tr>
+    <tr><td><code>disabled</code></td><td><code>boolean</code></td><td>Whether the field is disabled</td></tr>
+    <tr><td><code>validate</code></td><td><code>{"(value) => Promise<string | undefined>"}</code></td><td>Custom validation function. Return an error message or undefined</td></tr>
+    <tr><td><code>onValidationError</code></td><td><code>{"(error) => string | undefined"}</code></td><td>Customize built-in validation error messages</td></tr>
+  </tbody>
+</table>
 
 ### Field Component Types
 
-| Component | Data Types | Description |
-|---|---|---|
-| `TEXT_INPUT` | `string` | Single-line text input |
-| `TEXT_AREA` | `string` | Multi-line text area |
-| `NUMBER_INPUT` | `integer`, `long`, `double` | Numeric input with stepper |
-| `DROPDOWN` | `boolean`, any | Dropdown select with optional search |
-| `RADIO_BUTTONS` | `boolean` | Radio button group |
-| `SWITCH` | `boolean` | Toggle switch |
-| `DATETIME_PICKER` | `datetime`, `timestamp` | Date and time picker |
-| `FILE_PICKER` | `attachment` | File upload picker |
-| `OBJECT_SELECT` | `object` | Object instance picker from the ontology |
-| `OBJECT_SET` | `objectSet` | Object set summary display |
-| `CUSTOM` | any | Custom renderer via `customRenderer` callback |
-| `UNSUPPORTED` | marking, geoshape, etc. | Placeholder for unsupported parameter types |
+<table>
+  <thead>
+    <tr><th>Component</th><th>Data Types</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>TEXT_INPUT</code></td><td><code>string</code></td><td>Single-line text input</td></tr>
+    <tr><td><code>TEXT_AREA</code></td><td><code>string</code></td><td>Multi-line text area</td></tr>
+    <tr><td><code>NUMBER_INPUT</code></td><td><code>integer</code>, <code>long</code>, <code>double</code></td><td>Numeric input with stepper</td></tr>
+    <tr><td><code>DROPDOWN</code></td><td><code>boolean</code>, any</td><td>Dropdown select with optional search</td></tr>
+    <tr><td><code>RADIO_BUTTONS</code></td><td><code>boolean</code></td><td>Radio button group</td></tr>
+    <tr><td><code>SWITCH</code></td><td><code>boolean</code></td><td>Toggle switch</td></tr>
+    <tr><td><code>DATETIME_PICKER</code></td><td><code>datetime</code>, <code>timestamp</code></td><td>Date and time picker</td></tr>
+    <tr><td><code>FILE_PICKER</code></td><td><code>attachment</code></td><td>File upload picker</td></tr>
+    <tr><td><code>OBJECT_SELECT</code></td><td><code>object</code></td><td>Object instance picker from the ontology</td></tr>
+    <tr><td><code>OBJECT_SET</code></td><td><code>objectSet</code></td><td>Object set summary display</td></tr>
+    <tr><td><code>CUSTOM</code></td><td>any</td><td>{"Custom renderer via customRenderer callback"}</td></tr>
+    <tr><td><code>UNSUPPORTED</code></td><td>marking, geoshape, etc.</td><td>Placeholder for unsupported parameter types</td></tr>
+  </tbody>
+</table>
 
 ### FormError
 
-| Variant | Description |
-|---|---|
-| `{ type: "validation", error }` | Action validation failed |
-| `{ type: "submission", error }` | Action submission threw an error |
-| `{ type: "unknown", error }` | An unexpected error occurred |
+<table>
+  <thead>
+    <tr><th>Variant</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>{"{ type: \"validation\", error }"}</code></td><td>Action validation failed</td></tr>
+    <tr><td><code>{"{ type: \"submission\", error }"}</code></td><td>Action submission threw an error</td></tr>
+    <tr><td><code>{"{ type: \"unknown\", error }"}</code></td><td>An unexpected error occurred</td></tr>
+  </tbody>
+</table>
 
 ### CSS Variables
 
 #### Form Layout
 
-| Variable | Default | Description |
-|---|---|---|
-| `--osdk-form-fields-gap` | `1.5 * spacing` | Gap between form fields |
-| `--osdk-form-content-padding-inline` | `0` | Inline padding of the form content area |
-| `--osdk-form-content-padding-block` | `0` | Block padding of the form content area |
+<table>
+  <thead>
+    <tr><th>Variable</th><th>Default</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>--osdk-form-fields-gap</code></td><td><code>1.5 * spacing</code></td><td>Gap between form fields</td></tr>
+    <tr><td><code>--osdk-form-content-padding-inline</code></td><td><code>0</code></td><td>Inline padding of the form content area</td></tr>
+    <tr><td><code>--osdk-form-content-padding-block</code></td><td><code>0</code></td><td>Block padding of the form content area</td></tr>
+  </tbody>
+</table>
 
 #### Form Header
 
-| Variable | Default | Description |
-|---|---|---|
-| `--osdk-form-header-border-color` | `--osdk-surface-border-color-default` | Header bottom border color |
-| `--osdk-form-header-font-size` | `--osdk-typography-size-body-large` | Header title font size |
-| `--osdk-form-header-font-weight` | `--osdk-typography-weight-bold` | Header title font weight |
-| `--osdk-form-header-color` | `--osdk-typography-color-default-rest` | Header title text color |
-| `--osdk-form-header-block-padding` | `2 * spacing` | Header block padding |
+<table>
+  <thead>
+    <tr><th>Variable</th><th>Default</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>--osdk-form-header-border-color</code></td><td><code>--osdk-surface-border-color-default</code></td><td>Header bottom border color</td></tr>
+    <tr><td><code>--osdk-form-header-font-size</code></td><td><code>--osdk-typography-size-body-large</code></td><td>Header title font size</td></tr>
+    <tr><td><code>--osdk-form-header-font-weight</code></td><td><code>--osdk-typography-weight-bold</code></td><td>Header title font weight</td></tr>
+    <tr><td><code>--osdk-form-header-color</code></td><td><code>--osdk-typography-color-default-rest</code></td><td>Header title text color</td></tr>
+    <tr><td><code>--osdk-form-header-block-padding</code></td><td><code>2 * spacing</code></td><td>Header block padding</td></tr>
+  </tbody>
+</table>
 
 #### Form Footer
 
-| Variable | Default | Description |
-|---|---|---|
-| `--osdk-form-footer-border-color` | `--osdk-surface-border-color-default` | Footer top border color |
-| `--osdk-form-footer-error-color` | `--osdk-form-error-color` | Footer error indicator color |
-| `--osdk-form-footer-error-font-size` | `--osdk-typography-size-body-medium` | Footer error text font size |
+<table>
+  <thead>
+    <tr><th>Variable</th><th>Default</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>--osdk-form-footer-border-color</code></td><td><code>--osdk-surface-border-color-default</code></td><td>Footer top border color</td></tr>
+    <tr><td><code>--osdk-form-footer-error-color</code></td><td><code>--osdk-form-error-color</code></td><td>Footer error indicator color</td></tr>
+    <tr><td><code>--osdk-form-footer-error-font-size</code></td><td><code>--osdk-typography-size-body-medium</code></td><td>Footer error text font size</td></tr>
+  </tbody>
+</table>
 
 #### Form Labels
 
-| Variable | Default | Description |
-|---|---|---|
-| `--osdk-form-label-font-size` | `--osdk-typography-size-body-medium` | Label font size |
-| `--osdk-form-label-font-weight` | `--osdk-typography-weight-bold` | Label font weight |
-| `--osdk-form-label-color` | `--osdk-typography-color-default-rest` | Label text color |
-| `--osdk-form-field-gap` | `--osdk-surface-spacing` | Gap within a form field |
-| `--osdk-form-label-row-gap` | `1 * spacing` | Gap between label and info icon |
-| `--osdk-form-info-icon-color` | `--osdk-typography-color-muted` | Info icon color |
-| `--osdk-form-required-color` | `--osdk-intent-danger-rest` | Required indicator color |
+<table>
+  <thead>
+    <tr><th>Variable</th><th>Default</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>--osdk-form-label-font-size</code></td><td><code>--osdk-typography-size-body-medium</code></td><td>Label font size</td></tr>
+    <tr><td><code>--osdk-form-label-font-weight</code></td><td><code>--osdk-typography-weight-bold</code></td><td>Label font weight</td></tr>
+    <tr><td><code>--osdk-form-label-color</code></td><td><code>--osdk-typography-color-default-rest</code></td><td>Label text color</td></tr>
+    <tr><td><code>--osdk-form-field-gap</code></td><td><code>--osdk-surface-spacing</code></td><td>Gap within a form field</td></tr>
+    <tr><td><code>--osdk-form-label-row-gap</code></td><td><code>1 * spacing</code></td><td>Gap between label and info icon</td></tr>
+    <tr><td><code>--osdk-form-info-icon-color</code></td><td><code>--osdk-typography-color-muted</code></td><td>Info icon color</td></tr>
+    <tr><td><code>--osdk-form-required-color</code></td><td><code>--osdk-intent-danger-rest</code></td><td>Required indicator color</td></tr>
+  </tbody>
+</table>
 
 #### Validation Errors
 
-| Variable | Default | Description |
-|---|---|---|
-| `--osdk-form-error-font-size` | `--osdk-typography-size-body-small` | Error message font size |
-| `--osdk-form-error-color` | `--osdk-typography-color-danger-rest` | Error message text color |
+<table>
+  <thead>
+    <tr><th>Variable</th><th>Default</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>--osdk-form-error-font-size</code></td><td><code>--osdk-typography-size-body-small</code></td><td>Error message font size</td></tr>
+    <tr><td><code>--osdk-form-error-color</code></td><td><code>--osdk-typography-color-danger-rest</code></td><td>Error message text color</td></tr>
+  </tbody>
+</table>
 
 #### Edited Tag
 
-| Variable | Default | Description |
-|---|---|---|
-| `--osdk-form-edited-tag-bg` | `--osdk-custom-color-gray-2` | Edited tag background |
-| `--osdk-form-edited-tag-color` | `--osdk-typography-color-default-rest` | Edited tag text color |
-| `--osdk-form-edited-tag-font-size` | `--osdk-typography-size-body-small` | Edited tag font size |
-| `--osdk-form-edited-tag-border-radius` | `--osdk-surface-border-radius` | Edited tag border radius |
+<table>
+  <thead>
+    <tr><th>Variable</th><th>Default</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>--osdk-form-edited-tag-bg</code></td><td><code>--osdk-custom-color-gray-2</code></td><td>Edited tag background</td></tr>
+    <tr><td><code>--osdk-form-edited-tag-color</code></td><td><code>--osdk-typography-color-default-rest</code></td><td>Edited tag text color</td></tr>
+    <tr><td><code>--osdk-form-edited-tag-font-size</code></td><td><code>--osdk-typography-size-body-small</code></td><td>Edited tag font size</td></tr>
+    <tr><td><code>--osdk-form-edited-tag-border-radius</code></td><td><code>--osdk-surface-border-radius</code></td><td>Edited tag border radius</td></tr>
+  </tbody>
+</table>
 
 #### Form Section
 
-| Variable | Default | Description |
-|---|---|---|
-| `--osdk-form-section-border-color` | `--osdk-surface-border-color-default` | Section border color |
-| `--osdk-form-section-border-radius` | `--osdk-surface-border-radius` | Section border radius |
-| `--osdk-form-section-background` | `--osdk-surface-background-color-default-rest` | Section background |
-| `--osdk-form-section-title-font-size` | `--osdk-typography-size-body-medium` | Section title font size |
-| `--osdk-form-section-title-font-weight` | `--osdk-typography-weight-bold` | Section title font weight |
-| `--osdk-form-section-title-color` | `--osdk-typography-color-default-rest` | Section title text color |
-| `--osdk-form-section-description-font-size` | `--osdk-typography-size-body-small` | Section description font size |
-| `--osdk-form-section-description-color` | `--osdk-typography-color-muted` | Section description text color |
+<table>
+  <thead>
+    <tr><th>Variable</th><th>Default</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>--osdk-form-section-border-color</code></td><td><code>--osdk-surface-border-color-default</code></td><td>Section border color</td></tr>
+    <tr><td><code>--osdk-form-section-border-radius</code></td><td><code>--osdk-surface-border-radius</code></td><td>Section border radius</td></tr>
+    <tr><td><code>--osdk-form-section-background</code></td><td><code>--osdk-surface-background-color-default-rest</code></td><td>Section background</td></tr>
+    <tr><td><code>--osdk-form-section-title-font-size</code></td><td><code>--osdk-typography-size-body-medium</code></td><td>Section title font size</td></tr>
+    <tr><td><code>--osdk-form-section-title-font-weight</code></td><td><code>--osdk-typography-weight-bold</code></td><td>Section title font weight</td></tr>
+    <tr><td><code>--osdk-form-section-title-color</code></td><td><code>--osdk-typography-color-default-rest</code></td><td>Section title text color</td></tr>
+    <tr><td><code>--osdk-form-section-description-font-size</code></td><td><code>--osdk-typography-size-body-small</code></td><td>Section description font size</td></tr>
+    <tr><td><code>--osdk-form-section-description-color</code></td><td><code>--osdk-typography-color-muted</code></td><td>Section description text color</td></tr>
+  </tbody>
+</table>
 
 ### Data Attributes
 
-| Attribute | Applied to | Description |
-|---|---|---|
-| `data-osdk-form-field-error-slot` | Error container | Marks the error message container for a form field |
-| `data-orientation` | Radio button group | Layout direction: `"horizontal"` or `"vertical"` |
+<table>
+  <thead>
+    <tr><th>Attribute</th><th>Applied to</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>data-osdk-form-field-error-slot</code></td><td>Error container</td><td>Marks the error message container for a form field</td></tr>
+    <tr><td><code>data-orientation</code></td><td>Radio button group</td><td>{"Layout direction: \"horizontal\" or \"vertical\""}</td></tr>
+  </tbody>
+</table>
 
 ## Accessibility
 

--- a/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
+++ b/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
@@ -17,7 +17,7 @@
 import { Meta, Canvas, Controls } from "@storybook/addon-docs/blocks";
 import * as ActionFormStories from "./ActionForm.stories";
 
-<Meta title="Components/ActionForm/Docs" />
+<Meta of={ActionFormStories} />
 
 # ActionForm
 

--- a/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
+++ b/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
@@ -17,7 +17,7 @@
 import { Meta, Canvas, Controls } from "@storybook/addon-docs/blocks";
 import * as ActionFormStories from "./ActionForm.stories";
 
-<Meta title="Beta/ActionForm/Docs" />
+<Meta title="Components/ActionForm/Docs" />
 
 # ActionForm
 

--- a/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
+++ b/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */}
 
-import { Meta, Canvas, Controls } from "@storybook/blocks";
+import { Meta, Canvas, Controls } from "@storybook/addon-docs/blocks";
 import * as ActionFormStories from "./ActionForm.stories";
 
 <Meta title="Beta/ActionForm/Docs" />

--- a/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
+++ b/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
@@ -1,0 +1,291 @@
+{/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */}
+
+import { Meta, Canvas, Controls } from "@storybook/blocks";
+import * as ActionFormStories from "./ActionForm.stories";
+
+<Meta title="Beta/ActionForm/Docs" />
+
+# ActionForm
+
+An OSDK-aware form component that reads action metadata through `@osdk/react`,
+renders fields for each action parameter, validates user input, and submits
+through `useOsdkAction`. Field components are generated automatically from the
+action definition, or can be overridden with custom field definitions.
+
+## Demo
+
+<Canvas of={ActionFormStories.Default} />
+
+## Usage
+
+```tsx
+import { updateEmployee } from "@my/osdk";
+import { ActionForm } from "@osdk/react-components/experimental";
+
+function EmployeeForm() {
+  return (
+    <ActionForm
+      actionDefinition={updateEmployee}
+      showFormTitle={true}
+      onSuccess={(result) => console.log("Saved", result)}
+      onError={(error) => console.error("Failed", error)}
+    />
+  );
+}
+```
+
+> `@my/osdk` is a placeholder for your generated SDK package.
+
+### Prerequisites
+
+- Install `@osdk/react-components` and its peer dependencies
+- Wrap your app with `OsdkProvider`
+- Import `@osdk/react-components/styles.css`
+
+See the [README](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/README.md#setup)
+for full setup instructions.
+
+## Examples
+
+### Validation errors
+
+Submits the form without filling required fields to show the built-in
+validation summary. The action is not applied until all required fields pass.
+
+<Canvas of={ActionFormStories.ValidationErrors} />
+
+### Submit disabled
+
+Disables the submit button before validation runs, useful when external
+conditions must be met before submission is allowed.
+
+<Canvas of={ActionFormStories.SubmitDisabled} />
+
+### Custom submit wrapper
+
+Wraps the default `applyAction` call with custom logic. Use this pattern to
+inspect, log, confirm, or transform submitted values before applying the
+action.
+
+<Canvas of={ActionFormStories.CustomSubmitHandler} />
+
+### Slow custom submit
+
+Uses a delayed custom submit handler so users can see the pending button
+state without needing a real backend slowdown.
+
+<Canvas of={ActionFormStories.SlowCustomSubmit} />
+
+### Submit failure
+
+Uses a failing custom submit handler so the story shows the error state and
+serialized error response.
+
+<Canvas of={ActionFormStories.SubmitFailure} />
+
+### With title
+
+Shows the form title derived from the action display name.
+
+<Canvas of={ActionFormStories.WithTitle} />
+
+### With custom title
+
+Provides a custom title string instead of the action display name.
+
+<Canvas of={ActionFormStories.WithCustomTitle} />
+
+### With default values
+
+Pre-populates fields with default values via `formFieldDefinitions`.
+
+<Canvas of={ActionFormStories.WithDefaultValues} />
+
+### With field overrides
+
+Overrides the generated fields with custom labels, helper text, and
+component types.
+
+<Canvas of={ActionFormStories.WithFieldOverrides} />
+
+### With unsupported fields
+
+Shows how ActionForm handles action parameters with types that do not have
+built-in field components (structs, geoshapes, markings, object types).
+
+<Canvas of={ActionFormStories.WithUnsupportedFields} />
+
+### Controlled form state
+
+Manages form state externally via `formState` and `onFormStateChange` for
+full control over field values.
+
+<Canvas of={ActionFormStories.ControlledFormState} />
+
+## API Reference
+
+### Props
+
+<Controls of={ActionFormStories.Default} />
+
+### ActionFormProps
+
+| Prop | Type | Description |
+|---|---|---|
+| `actionDefinition` | `ActionDefinition` | The OSDK action definition to render a form for (required) |
+| `showFormTitle` | `boolean` | Whether to show the form title. Default `false` |
+| `formTitle` | `string` | Optional title used when `showFormTitle` is `true`. Falls back to the action display name |
+| `formFieldDefinitions` | `FormFieldDefinition[]` | Complete replacement for generated fields. Include every action parameter that should appear |
+| `isSubmitDisabled` | `boolean` | Disables the submit button before validation runs |
+| `formState` | `FormState` | Controlled form state. When provided, `onFormStateChange` is required |
+| `onFormStateChange` | `(updater) => void` | Called when any field value changes. Required in controlled mode |
+| `onSubmit` | `(formState, applyAction) => Promise` | Custom submit handler. Receives the form state and the `applyAction` callback |
+| `onValidationResponse` | `(results) => void` | Called when a validation-only submission returns results |
+| `onSuccess` | `(results) => void` | Called when the action is successfully applied |
+| `onError` | `(error: FormError) => void` | Called when a submission or validation error occurs |
+
+### FormFieldDefinition
+
+| Field | Type | Description |
+|---|---|---|
+| `fieldKey` | `FieldKey` | The action parameter key this field maps to |
+| `label` | `string` | Display label for the field |
+| `fieldComponent` | `FieldComponent` | UI component to render (see field component types below) |
+| `fieldComponentProps` | `object` | Props passed to the field component (type narrows based on `fieldComponent`) |
+| `defaultValue` | `FieldValueType` | Default value for the field |
+| `isRequired` | `boolean` | Whether the field is required |
+| `placeholder` | `string` | Placeholder text |
+| `helperText` | `ReactNode` | Additional information displayed via tooltip or below the label |
+| `helperTextPlacement` | `"bottom" \| "tooltip"` | Where to display helper text. Default `"tooltip"` |
+| `disabled` | `boolean` | Whether the field is disabled |
+| `validate` | `(value) => Promise<string \| undefined>` | Custom validation function. Return an error message or `undefined` |
+| `onValidationError` | `(error) => string \| undefined` | Customize built-in validation error messages |
+
+### Field Component Types
+
+| Component | Data Types | Description |
+|---|---|---|
+| `TEXT_INPUT` | `string` | Single-line text input |
+| `TEXT_AREA` | `string` | Multi-line text area |
+| `NUMBER_INPUT` | `integer`, `long`, `double` | Numeric input with stepper |
+| `DROPDOWN` | `boolean`, any | Dropdown select with optional search |
+| `RADIO_BUTTONS` | `boolean` | Radio button group |
+| `SWITCH` | `boolean` | Toggle switch |
+| `DATETIME_PICKER` | `datetime`, `timestamp` | Date and time picker |
+| `FILE_PICKER` | `attachment` | File upload picker |
+| `OBJECT_SELECT` | `object` | Object instance picker from the ontology |
+| `OBJECT_SET` | `objectSet` | Object set summary display |
+| `CUSTOM` | any | Custom renderer via `customRenderer` callback |
+| `UNSUPPORTED` | marking, geoshape, etc. | Placeholder for unsupported parameter types |
+
+### FormError
+
+| Variant | Description |
+|---|---|
+| `{ type: "validation", error }` | Action validation failed |
+| `{ type: "submission", error }` | Action submission threw an error |
+| `{ type: "unknown", error }` | An unexpected error occurred |
+
+### CSS Variables
+
+#### Form Layout
+
+| Variable | Default | Description |
+|---|---|---|
+| `--osdk-form-fields-gap` | `1.5 * spacing` | Gap between form fields |
+| `--osdk-form-content-padding-inline` | `0` | Inline padding of the form content area |
+| `--osdk-form-content-padding-block` | `0` | Block padding of the form content area |
+
+#### Form Header
+
+| Variable | Default | Description |
+|---|---|---|
+| `--osdk-form-header-border-color` | `--osdk-surface-border-color-default` | Header bottom border color |
+| `--osdk-form-header-font-size` | `--osdk-typography-size-body-large` | Header title font size |
+| `--osdk-form-header-font-weight` | `--osdk-typography-weight-bold` | Header title font weight |
+| `--osdk-form-header-color` | `--osdk-typography-color-default-rest` | Header title text color |
+| `--osdk-form-header-block-padding` | `2 * spacing` | Header block padding |
+
+#### Form Footer
+
+| Variable | Default | Description |
+|---|---|---|
+| `--osdk-form-footer-border-color` | `--osdk-surface-border-color-default` | Footer top border color |
+| `--osdk-form-footer-error-color` | `--osdk-form-error-color` | Footer error indicator color |
+| `--osdk-form-footer-error-font-size` | `--osdk-typography-size-body-medium` | Footer error text font size |
+
+#### Form Labels
+
+| Variable | Default | Description |
+|---|---|---|
+| `--osdk-form-label-font-size` | `--osdk-typography-size-body-medium` | Label font size |
+| `--osdk-form-label-font-weight` | `--osdk-typography-weight-bold` | Label font weight |
+| `--osdk-form-label-color` | `--osdk-typography-color-default-rest` | Label text color |
+| `--osdk-form-field-gap` | `--osdk-surface-spacing` | Gap within a form field |
+| `--osdk-form-label-row-gap` | `1 * spacing` | Gap between label and info icon |
+| `--osdk-form-info-icon-color` | `--osdk-typography-color-muted` | Info icon color |
+| `--osdk-form-required-color` | `--osdk-intent-danger-rest` | Required indicator color |
+
+#### Validation Errors
+
+| Variable | Default | Description |
+|---|---|---|
+| `--osdk-form-error-font-size` | `--osdk-typography-size-body-small` | Error message font size |
+| `--osdk-form-error-color` | `--osdk-typography-color-danger-rest` | Error message text color |
+
+#### Edited Tag
+
+| Variable | Default | Description |
+|---|---|---|
+| `--osdk-form-edited-tag-bg` | `--osdk-custom-color-gray-2` | Edited tag background |
+| `--osdk-form-edited-tag-color` | `--osdk-typography-color-default-rest` | Edited tag text color |
+| `--osdk-form-edited-tag-font-size` | `--osdk-typography-size-body-small` | Edited tag font size |
+| `--osdk-form-edited-tag-border-radius` | `--osdk-surface-border-radius` | Edited tag border radius |
+
+#### Form Section
+
+| Variable | Default | Description |
+|---|---|---|
+| `--osdk-form-section-border-color` | `--osdk-surface-border-color-default` | Section border color |
+| `--osdk-form-section-border-radius` | `--osdk-surface-border-radius` | Section border radius |
+| `--osdk-form-section-background` | `--osdk-surface-background-color-default-rest` | Section background |
+| `--osdk-form-section-title-font-size` | `--osdk-typography-size-body-medium` | Section title font size |
+| `--osdk-form-section-title-font-weight` | `--osdk-typography-weight-bold` | Section title font weight |
+| `--osdk-form-section-title-color` | `--osdk-typography-color-default-rest` | Section title text color |
+| `--osdk-form-section-description-font-size` | `--osdk-typography-size-body-small` | Section description font size |
+| `--osdk-form-section-description-color` | `--osdk-typography-color-muted` | Section description text color |
+
+### Data Attributes
+
+| Attribute | Applied to | Description |
+|---|---|---|
+| `data-osdk-form-field-error-slot` | Error container | Marks the error message container for a form field |
+| `data-orientation` | Radio button group | Layout direction: `"horizontal"` or `"vertical"` |
+
+## Accessibility
+
+- All form fields are associated with labels via `htmlFor` and `id` attributes
+- Required fields display a visual indicator and include validation messages
+  when left empty
+- Validation error messages are rendered in an `alert` role container so
+  screen readers announce them immediately
+- The submit button reflects the current form state: enabled, disabled, or
+  pending with appropriate label changes
+- Field helper text is available via a tooltip triggered by a focusable info
+  icon next to the label
+- Keyboard navigation supports `Tab` to move between fields, `Enter` or
+  `Space` to interact with controls, and `Escape` to dismiss dropdowns

--- a/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
+++ b/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
@@ -17,7 +17,7 @@
 import { Meta, Canvas, Controls } from "@storybook/addon-docs/blocks";
 import * as ActionFormStories from "./ActionForm.stories";
 
-<Meta of={ActionFormStories} />
+<Meta title="Components/ActionForm/Docs" tags={["beta"]}/>
 
 # ActionForm
 

--- a/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
+++ b/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
@@ -125,6 +125,7 @@ component types.
 ### With unsupported fields
 
 Shows how ActionForm handles action parameters with types that do not have
+{/* cspell:ignore geoshapes */}
 built-in field components (structs, geoshapes, markings, object types).
 
 <Canvas of={ActionFormStories.WithUnsupportedFields} />


### PR DESCRIPTION
## Summary
- Add ActionForm MDX documentation page to Storybook with full API reference, CSS variables, data attributes, and examples
- Add MDX glob to Storybook config

## Test plan
- [ ] Storybook renders ActionForm docs page at `Beta/ActionForm/Docs`
- [ ] All Canvas story embeds render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)