### PR TITLE
docs: add CbacPicker MDX documentation page

### DIFF
--- a/.changeset/add-cbac-picker-mdx-docs.md
+++ b/.changeset/add-cbac-picker-mdx-docs.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components-storybook": patch
+---
+
+Add CbacPicker MDX documentation page to Storybook

--- a/packages/react-components-storybook/.storybook/main.ts
+++ b/packages/react-components-storybook/.storybook/main.ts
@@ -21,7 +21,7 @@ const storybookBasePath = process.env.STORYBOOK_BASE_PATH;
 const config: StorybookConfig = {
   stories: [
     "../src/**/*.stories.@(js|jsx|ts|tsx|mdx)",
-    "../src/**/*.mdx",
+    "../src/docs/**/*.mdx",
   ],
   addons: [
     "@storybook/addon-a11y",

--- a/packages/react-components-storybook/.storybook/main.ts
+++ b/packages/react-components-storybook/.storybook/main.ts
@@ -21,7 +21,7 @@ const storybookBasePath = process.env.STORYBOOK_BASE_PATH;
 const config: StorybookConfig = {
   stories: [
     "../src/**/*.stories.@(js|jsx|ts|tsx|mdx)",
-    "../src/docs/**/*.mdx",
+    "../src/**/*.mdx",
   ],
   addons: [
     "@storybook/addon-a11y",

--- a/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.mdx
+++ b/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.mdx
@@ -101,23 +101,33 @@ Display a standalone classification banner without the picker.
 
 ### CbacPicker Props
 
-| Prop | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `initialMarkingIds` | `string[]` | No | `[]` | Initial set of selected marking IDs |
-| `onChange` | `(markingIds: string[]) => void` | Yes | - | Called when the selection changes |
-| `maxClassificationConstraint` | `MaxClassificationConstraint` | No | - | Upper bound on the classification level |
-| `readOnly` | `boolean` | No | `false` | Disables marking toggle interactions |
-| `className` | `string` | No | - | CSS class for the picker container |
+<table>
+  <thead>
+    <tr><th>Prop</th><th>Type</th><th>Required</th><th>Default</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>initialMarkingIds</code></td><td><code>string[]</code></td><td>No</td><td><code>[]</code></td><td>Initial set of selected marking IDs</td></tr>
+    <tr><td><code>onChange</code></td><td><code>{"(markingIds: string[]) => void"}</code></td><td>Yes</td><td>-</td><td>Called when the selection changes</td></tr>
+    <tr><td><code>maxClassificationConstraint</code></td><td><code>MaxClassificationConstraint</code></td><td>No</td><td>-</td><td>Upper bound on the classification level</td></tr>
+    <tr><td><code>readOnly</code></td><td><code>boolean</code></td><td>No</td><td><code>false</code></td><td>Disables marking toggle interactions</td></tr>
+    <tr><td><code>className</code></td><td><code>string</code></td><td>No</td><td>-</td><td>CSS class for the picker container</td></tr>
+  </tbody>
+</table>
 
 ### CbacPickerDialog Props
 
-| Prop | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `isOpen` | `boolean` | Yes | - | Controls dialog visibility |
-| `onOpenChange` | `(open: boolean) => void` | Yes | - | Called when dialog open state changes |
-| `onConfirm` | `(markingIds: string[]) => void` | Yes | - | Called with the selected marking IDs on confirm |
-| `initialMarkingIds` | `string[]` | No | `[]` | Initial set of selected marking IDs |
-| `maxClassificationConstraint` | `MaxClassificationConstraint` | No | - | Upper bound on the classification level |
+<table>
+  <thead>
+    <tr><th>Prop</th><th>Type</th><th>Required</th><th>Default</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>isOpen</code></td><td><code>boolean</code></td><td>Yes</td><td>-</td><td>Controls dialog visibility</td></tr>
+    <tr><td><code>onOpenChange</code></td><td><code>{"(open: boolean) => void"}</code></td><td>Yes</td><td>-</td><td>Called when dialog open state changes</td></tr>
+    <tr><td><code>onConfirm</code></td><td><code>{"(markingIds: string[]) => void"}</code></td><td>Yes</td><td>-</td><td>Called with the selected marking IDs on confirm</td></tr>
+    <tr><td><code>initialMarkingIds</code></td><td><code>string[]</code></td><td>No</td><td><code>[]</code></td><td>Initial set of selected marking IDs</td></tr>
+    <tr><td><code>maxClassificationConstraint</code></td><td><code>MaxClassificationConstraint</code></td><td>No</td><td>-</td><td>Upper bound on the classification level</td></tr>
+  </tbody>
+</table>
 
 The dialog title automatically adjusts: "Add classification" when no initial
 markings are provided, "Edit classification" when editing existing markings.
@@ -128,43 +138,58 @@ The confirm button is disabled with a tooltip when the selection is invalid.
 For advanced use cases where you supply your own marking data instead of
 fetching from the OSDK.
 
-| Prop | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `categories` | `CategoryMarkingGroup[]` | Yes | - | Marking categories with their markings |
-| `markingStates` | `Map<string, MarkingSelectionState>` | Yes | - | State for each marking (SELECTED, IMPLIED, etc.) |
-| `banner` | `CbacBannerData` | No | - | Banner data (classification string, colors) |
-| `onMarkingToggle` | `(markingId: string) => void` | Yes | - | Called when a marking button is clicked |
-| `onDismissBanner` | `() => void` | No | - | Called when the banner dismiss button is clicked |
-| `showInfoBanner` | `boolean` | No | - | Show the "implied markings" info banner |
-| `requiredMarkingGroups` | `ReadonlyArray<RequiredMarkingGroup>` | No | - | Groups of markings that must be selected together |
-| `isValid` | `boolean` | No | - | Whether the current selection is valid |
-| `readOnly` | `boolean` | No | - | Disable marking interactions |
-| `isLoading` | `boolean` | No | - | Show loading state |
-| `error` | `Error` | No | - | Show error message |
-| `className` | `string` | No | - | CSS class for the container |
+<table>
+  <thead>
+    <tr><th>Prop</th><th>Type</th><th>Required</th><th>Default</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>categories</code></td><td><code>CategoryMarkingGroup[]</code></td><td>Yes</td><td>-</td><td>Marking categories with their markings</td></tr>
+    <tr><td><code>markingStates</code></td><td><code>{"Map<string, MarkingSelectionState>"}</code></td><td>Yes</td><td>-</td><td>State for each marking (SELECTED, IMPLIED, etc.)</td></tr>
+    <tr><td><code>banner</code></td><td><code>CbacBannerData</code></td><td>No</td><td>-</td><td>Banner data (classification string, colors)</td></tr>
+    <tr><td><code>onMarkingToggle</code></td><td><code>{"(markingId: string) => void"}</code></td><td>Yes</td><td>-</td><td>Called when a marking button is clicked</td></tr>
+    <tr><td><code>onDismissBanner</code></td><td><code>{"() => void"}</code></td><td>No</td><td>-</td><td>Called when the banner dismiss button is clicked</td></tr>
+    <tr><td><code>showInfoBanner</code></td><td><code>boolean</code></td><td>No</td><td>-</td><td>{"Show the \"implied markings\" info banner"}</td></tr>
+    <tr><td><code>requiredMarkingGroups</code></td><td><code>{"ReadonlyArray<RequiredMarkingGroup>"}</code></td><td>No</td><td>-</td><td>Groups of markings that must be selected together</td></tr>
+    <tr><td><code>isValid</code></td><td><code>boolean</code></td><td>No</td><td>-</td><td>Whether the current selection is valid</td></tr>
+    <tr><td><code>readOnly</code></td><td><code>boolean</code></td><td>No</td><td>-</td><td>Disable marking interactions</td></tr>
+    <tr><td><code>isLoading</code></td><td><code>boolean</code></td><td>No</td><td>-</td><td>Show loading state</td></tr>
+    <tr><td><code>error</code></td><td><code>Error</code></td><td>No</td><td>-</td><td>Show error message</td></tr>
+    <tr><td><code>className</code></td><td><code>string</code></td><td>No</td><td>-</td><td>CSS class for the container</td></tr>
+  </tbody>
+</table>
 
 ### BaseCbacBanner Props
 
-| Prop | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `classificationString` | `string` | Yes | - | Text displayed in the banner |
-| `textColor` | `string` | Yes | - | Banner text color |
-| `backgroundColors` | `string[]` | Yes | - | Background colors (rendered as gradient if multiple) |
-| `onClick` | `() => void` | No | - | Makes banner clickable |
-| `onDismiss` | `() => void` | No | - | Shows a dismiss button |
-| `className` | `string` | No | - | CSS class for the banner |
+<table>
+  <thead>
+    <tr><th>Prop</th><th>Type</th><th>Required</th><th>Default</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>classificationString</code></td><td><code>string</code></td><td>Yes</td><td>-</td><td>Text displayed in the banner</td></tr>
+    <tr><td><code>textColor</code></td><td><code>string</code></td><td>Yes</td><td>-</td><td>Banner text color</td></tr>
+    <tr><td><code>backgroundColors</code></td><td><code>string[]</code></td><td>Yes</td><td>-</td><td>Background colors (rendered as gradient if multiple)</td></tr>
+    <tr><td><code>onClick</code></td><td><code>{"() => void"}</code></td><td>No</td><td>-</td><td>Makes banner clickable</td></tr>
+    <tr><td><code>onDismiss</code></td><td><code>{"() => void"}</code></td><td>No</td><td>-</td><td>Shows a dismiss button</td></tr>
+    <tr><td><code>className</code></td><td><code>string</code></td><td>No</td><td>-</td><td>CSS class for the banner</td></tr>
+  </tbody>
+</table>
 
 ### Types
 
 #### MarkingSelectionState
 
-| State | Description |
-|---|---|
-| `"NONE"` | Default state, marking is available but not selected |
-| `"SELECTED"` | Marking is explicitly selected by the user |
-| `"IMPLIED"` | Marking is automatically included due to other selected markings |
-| `"DISALLOWED"` | Marking cannot be selected due to restrictions |
-| `"IMPLIED_DISALLOWED"` | Marking is both implied and disallowed by the current selection |
+<table>
+  <thead>
+    <tr><th>State</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>"NONE"</code></td><td>Default state, marking is available but not selected</td></tr>
+    <tr><td><code>"SELECTED"</code></td><td>Marking is explicitly selected by the user</td></tr>
+    <tr><td><code>"IMPLIED"</code></td><td>Marking is automatically included due to other selected markings</td></tr>
+    <tr><td><code>"DISALLOWED"</code></td><td>Marking cannot be selected due to restrictions</td></tr>
+    <tr><td><code>"IMPLIED_DISALLOWED"</code></td><td>Marking is both implied and disallowed by the current selection</td></tr>
+  </tbody>
+</table>
 
 #### CategoryMarkingGroup
 
@@ -177,11 +202,16 @@ radio-style) and a `markingType` (`"MANDATORY"` or `"CBAC"`).
 The `@osdk/cbac-components/experimental` barrel exports these selection logic
 utilities alongside the components:
 
-| Export | Description |
-|---|---|
-| `computeMarkingStates` | Compute display state for each marking given selected, implied, and disallowed IDs |
-| `toggleMarking` | Toggle a marking in the selection, respecting conjunctive/disjunctive category rules |
-| `groupMarkingsByCategory` | Group a flat list of markings into `CategoryMarkingGroup` arrays |
+<table>
+  <thead>
+    <tr><th>Export</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>computeMarkingStates</code></td><td>Compute display state for each marking given selected, implied, and disallowed IDs</td></tr>
+    <tr><td><code>toggleMarking</code></td><td>Toggle a marking in the selection, respecting conjunctive/disjunctive category rules</td></tr>
+    <tr><td><code>groupMarkingsByCategory</code></td><td>{"Group a flat list of markings into CategoryMarkingGroup arrays"}</td></tr>
+  </tbody>
+</table>
 
 ## Architecture
 

--- a/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.mdx
+++ b/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.mdx
@@ -1,0 +1,205 @@
+{/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */}
+
+import { Meta, Canvas, Controls } from "@storybook/blocks";
+import * as CbacPickerStories from "./CbacPicker.stories";
+
+<Meta title="Beta/CbacPicker/Docs" />
+
+# CbacPicker
+
+Components for managing classification-based access control (CBAC) markings.
+CBAC markings control who can access data. Each piece of data can be tagged
+with markings from different categories, and the combination determines its
+access restrictions.
+
+The picker lets users select markings grouped by category. Some categories are
+**disjunctive** (pick exactly one, like a sensitivity level) and others are
+**conjunctive** (pick any combination, like access groups). The server enforces
+which combinations are valid, which markings are implied by others, and which
+are disallowed.
+
+## Demo
+
+<Canvas of={CbacPickerStories.Default} />
+
+## Usage
+
+```tsx
+import { CbacPicker } from "@osdk/cbac-components/experimental";
+import { useState } from "react";
+
+function ClassificationForm() {
+  const [markingIds, setMarkingIds] = useState<string[]>([]);
+
+  return (
+    <CbacPicker
+      initialMarkingIds={markingIds}
+      onChange={setMarkingIds}
+    />
+  );
+}
+```
+
+### Prerequisites
+
+- Install `@osdk/cbac-components` and its peer dependencies
+- Wrap your app with `OsdkProvider`
+- Import `@osdk/cbac-components/styles.css`
+
+See the [README](https://github.com/palantir/osdk-ts/blob/main/packages/cbac-components/README.md#setup)
+for full setup instructions.
+
+## Examples
+
+### Read-only display
+
+Disable all marking interactions by setting `readOnly` to `true`.
+
+<Canvas of={CbacPickerStories.ReadOnly} />
+
+### With initial selection
+
+Pre-populate the picker with an existing set of marking IDs.
+
+<Canvas of={CbacPickerStories.WithInitialSelection} />
+
+### Picker in a dialog
+
+For modal workflows, use `CbacPickerDialog` to present the picker in a dialog
+with confirm and cancel actions.
+
+<Canvas of={CbacPickerStories.InDialog} />
+
+### With implied and disallowed markings
+
+Use `BaseCbacPicker` with `computeMarkingStates` to display markings that are
+automatically implied or restricted by the current selection.
+
+<Canvas of={CbacPickerStories.WithImpliedAndDisallowed} />
+
+### Banner only
+
+Display a standalone classification banner without the picker.
+
+<Canvas of={CbacPickerStories.BannerOnly} />
+
+## API Reference
+
+### CbacPicker Props
+
+| Prop | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `initialMarkingIds` | `string[]` | No | `[]` | Initial set of selected marking IDs |
+| `onChange` | `(markingIds: string[]) => void` | Yes | - | Called when the selection changes |
+| `maxClassificationConstraint` | `MaxClassificationConstraint` | No | - | Upper bound on the classification level |
+| `readOnly` | `boolean` | No | `false` | Disables marking toggle interactions |
+| `className` | `string` | No | - | CSS class for the picker container |
+
+### CbacPickerDialog Props
+
+| Prop | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `isOpen` | `boolean` | Yes | - | Controls dialog visibility |
+| `onOpenChange` | `(open: boolean) => void` | Yes | - | Called when dialog open state changes |
+| `onConfirm` | `(markingIds: string[]) => void` | Yes | - | Called with the selected marking IDs on confirm |
+| `initialMarkingIds` | `string[]` | No | `[]` | Initial set of selected marking IDs |
+| `maxClassificationConstraint` | `MaxClassificationConstraint` | No | - | Upper bound on the classification level |
+
+The dialog title automatically adjusts: "Add classification" when no initial
+markings are provided, "Edit classification" when editing existing markings.
+The confirm button is disabled with a tooltip when the selection is invalid.
+
+### BaseCbacPicker Props
+
+For advanced use cases where you supply your own marking data instead of
+fetching from the OSDK.
+
+| Prop | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `categories` | `CategoryMarkingGroup[]` | Yes | - | Marking categories with their markings |
+| `markingStates` | `Map<string, MarkingSelectionState>` | Yes | - | State for each marking (SELECTED, IMPLIED, etc.) |
+| `banner` | `CbacBannerData` | No | - | Banner data (classification string, colors) |
+| `onMarkingToggle` | `(markingId: string) => void` | Yes | - | Called when a marking button is clicked |
+| `onDismissBanner` | `() => void` | No | - | Called when the banner dismiss button is clicked |
+| `showInfoBanner` | `boolean` | No | - | Show the "implied markings" info banner |
+| `requiredMarkingGroups` | `ReadonlyArray<RequiredMarkingGroup>` | No | - | Groups of markings that must be selected together |
+| `isValid` | `boolean` | No | - | Whether the current selection is valid |
+| `readOnly` | `boolean` | No | - | Disable marking interactions |
+| `isLoading` | `boolean` | No | - | Show loading state |
+| `error` | `Error` | No | - | Show error message |
+| `className` | `string` | No | - | CSS class for the container |
+
+### BaseCbacBanner Props
+
+| Prop | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `classificationString` | `string` | Yes | - | Text displayed in the banner |
+| `textColor` | `string` | Yes | - | Banner text color |
+| `backgroundColors` | `string[]` | Yes | - | Background colors (rendered as gradient if multiple) |
+| `onClick` | `() => void` | No | - | Makes banner clickable |
+| `onDismiss` | `() => void` | No | - | Shows a dismiss button |
+| `className` | `string` | No | - | CSS class for the banner |
+
+### Types
+
+#### MarkingSelectionState
+
+| State | Description |
+|---|---|
+| `"NONE"` | Default state, marking is available but not selected |
+| `"SELECTED"` | Marking is explicitly selected by the user |
+| `"IMPLIED"` | Marking is automatically included due to other selected markings |
+| `"DISALLOWED"` | Marking cannot be selected due to restrictions |
+| `"IMPLIED_DISALLOWED"` | Marking is both implied and disallowed by the current selection |
+
+#### CategoryMarkingGroup
+
+A category paired with all markings that belong to it. Each category has a
+`categoryType` (`"CONJUNCTIVE"` for checkbox-style or `"DISJUNCTIVE"` for
+radio-style) and a `markingType` (`"MANDATORY"` or `"CBAC"`).
+
+### Utilities
+
+The `@osdk/cbac-components/experimental` barrel exports these selection logic
+utilities alongside the components:
+
+| Export | Description |
+|---|---|
+| `computeMarkingStates` | Compute display state for each marking given selected, implied, and disallowed IDs |
+| `toggleMarking` | Toggle a marking in the selection, respecting conjunctive/disjunctive category rules |
+| `groupMarkingsByCategory` | Group a flat list of markings into `CategoryMarkingGroup` arrays |
+
+## Architecture
+
+`@osdk/cbac-components` follows a two-layer architecture:
+
+- **OSDK layer** (`CbacPicker`, `CbacPickerDialog`) fetches data using
+  `@osdk/react` hooks, converts it to primitive props, and passes it to the
+  base layer.
+- **Base layer** (`BaseCbacPicker`, `BaseCbacBanner`, `BaseCbacPickerDialog`)
+  provides pure UI with no OSDK dependency, accepting primitive data directly.
+
+Most users should use the OSDK-layer components. The base components are for
+advanced use cases where you already have marking data from a different source.
+
+## Accessibility
+
+- Marking buttons are keyboard navigable via `Tab`
+- Each marking button supports `Enter`/`Space` to toggle selection
+- The classification banner dismiss button has an `aria-label`
+- Loading and error states use appropriate `role` attributes (`status`, `alert`)
+- Disallowed markings have `aria-disabled` to communicate state to screen readers

--- a/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.mdx
+++ b/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.mdx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */}
 
-import { Meta, Canvas, Controls } from "@storybook/blocks";
+import { Meta, Canvas, Controls } from "@storybook/addon-docs/blocks";
 import * as CbacPickerStories from "./CbacPicker.stories";
 
 <Meta title="Components/CbacPicker/Docs" tags={["beta"]}/>

--- a/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.mdx
+++ b/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.mdx
@@ -17,7 +17,7 @@
 import { Meta, Canvas, Controls } from "@storybook/blocks";
 import * as CbacPickerStories from "./CbacPicker.stories";
 
-<Meta title="Beta/CbacPicker/Docs" />
+<Meta title="Components/CbacPicker/Docs" tags={["beta"]}/>
 
 # CbacPicker
 


### PR DESCRIPTION
## Summary
- Add MDX documentation page for the CbacPicker component in Storybook at `Beta/CbacPicker/Docs`
- Update Storybook config to include standalone MDX files alongside story files
- Document all component variants (CbacPicker, CbacPickerDialog, BaseCbacPicker, BaseCbacBanner), props, types, utilities, architecture, and accessibility

## Test plan
- [ ] Verify `CbacPicker/Docs` page appears in Storybook sidebar under `Beta/CbacPicker`
- [ ] Verify all Canvas embeds render correctly (Default, ReadOnly, WithInitialSelection, InDialog, WithImpliedAndDisallowed, BannerOnly)
- [ ] Verify existing stories continue to work after the Storybook config change


🤖 Generated with [Claude Code](https://claude.com/claude-code)