### PR TITLE
docs: add DocumentViewer MDX documentation page

### DIFF
--- a/.changeset/add-documentviewer-mdx-docs.md
+++ b/.changeset/add-documentviewer-mdx-docs.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components-storybook": minor
+---
+
+Add DocumentViewer MDX documentation page to Storybook

--- a/packages/react-components-storybook/.storybook/main.ts
+++ b/packages/react-components-storybook/.storybook/main.ts
@@ -21,7 +21,7 @@ const storybookBasePath = process.env.STORYBOOK_BASE_PATH;
 const config: StorybookConfig = {
   stories: [
     "../src/**/*.stories.@(js|jsx|ts|tsx|mdx)",
-    "../src/**/*.mdx",
+    "../src/docs/**/*.mdx",
   ],
   addons: [
     "@storybook/addon-a11y",

--- a/packages/react-components-storybook/.storybook/main.ts
+++ b/packages/react-components-storybook/.storybook/main.ts
@@ -21,7 +21,7 @@ const storybookBasePath = process.env.STORYBOOK_BASE_PATH;
 const config: StorybookConfig = {
   stories: [
     "../src/**/*.stories.@(js|jsx|ts|tsx|mdx)",
-    "../src/docs/**/*.mdx",
+    "../src/**/*.mdx",
   ],
   addons: [
     "@storybook/addon-a11y",

--- a/packages/react-components-storybook/src/stories/DocumentViewer/DocumentViewer.mdx
+++ b/packages/react-components-storybook/src/stories/DocumentViewer/DocumentViewer.mdx
@@ -129,55 +129,75 @@ Unsupported MIME types display a fallback message.
 
 <Controls of={DocumentViewerStories.Pdf} />
 
-| Prop | Type | Required | Description |
-|---|---|---|---|
-| `media` | `Media` | Yes | The OSDK Media object to render |
-| `className` | `string` | No | CSS class applied to the root element |
-| `mimeTypeOverride` | `string` | No | Override the auto-detected MIME type |
-| `fileName` | `string` | No | File name hint for MIME type detection (e.g. `"scan.tif"`) |
-| `enableTiffToPdf` | `boolean` | No | When true, multi-page TIFFs are converted to PDF via MIO transform API |
-| `pdfViewerProps` | `Partial<Omit<PdfViewerProps, "src">>` | No | Props forwarded to the PDF viewer |
-| `imageViewerProps` | `Partial<Omit<BaseImageViewerProps, "src">>` | No | Props forwarded to the image viewer |
-| `videoViewerProps` | `Partial<Omit<BaseVideoViewerProps, "src">>` | No | Props forwarded to the video viewer |
-| `tiffRendererProps` | `Partial<Omit<TiffRendererProps, "content">>` | No | Props forwarded to the TIFF renderer |
-| `markdownRendererProps` | `Partial<Omit<MarkdownRendererProps, "content">>` | No | Props forwarded to the markdown renderer |
-| `excelViewerProps` | `Partial<Omit<BaseExcelViewerProps, "spreadsheet">>` | No | Props forwarded to the Excel viewer |
-| `emailViewerProps` | `Partial<Omit<BaseEmailViewerProps, "email">>` | No | Props forwarded to the email viewer |
-| `xmlViewerProps` | `Partial<Omit<BaseXmlViewerProps, "content">>` | No | Props forwarded to the XML viewer |
+<table>
+  <thead>
+    <tr><th>Prop</th><th>Type</th><th>Required</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>media</code></td><td><code>Media</code></td><td>Yes</td><td>The OSDK Media object to render</td></tr>
+    <tr><td><code>className</code></td><td><code>string</code></td><td>No</td><td>CSS class applied to the root element</td></tr>
+    <tr><td><code>mimeTypeOverride</code></td><td><code>string</code></td><td>No</td><td>Override the auto-detected MIME type</td></tr>
+    <tr><td><code>fileName</code></td><td><code>string</code></td><td>No</td><td>{"File name hint for MIME type detection (e.g. \"scan.tif\")"}</td></tr>
+    <tr><td><code>enableTiffToPdf</code></td><td><code>boolean</code></td><td>No</td><td>When true, multi-page TIFFs are converted to PDF via MIO transform API</td></tr>
+    <tr><td><code>pdfViewerProps</code></td><td><code>{"Partial<Omit<PdfViewerProps, \"src\">>"}</code></td><td>No</td><td>Props forwarded to the PDF viewer</td></tr>
+    <tr><td><code>imageViewerProps</code></td><td><code>{"Partial<Omit<BaseImageViewerProps, \"src\">>"}</code></td><td>No</td><td>Props forwarded to the image viewer</td></tr>
+    <tr><td><code>videoViewerProps</code></td><td><code>{"Partial<Omit<BaseVideoViewerProps, \"src\">>"}</code></td><td>No</td><td>Props forwarded to the video viewer</td></tr>
+    <tr><td><code>tiffRendererProps</code></td><td><code>{"Partial<Omit<TiffRendererProps, \"content\">>"}</code></td><td>No</td><td>Props forwarded to the TIFF renderer</td></tr>
+    <tr><td><code>markdownRendererProps</code></td><td><code>{"Partial<Omit<MarkdownRendererProps, \"content\">>"}</code></td><td>No</td><td>Props forwarded to the markdown renderer</td></tr>
+    <tr><td><code>excelViewerProps</code></td><td><code>{"Partial<Omit<BaseExcelViewerProps, \"spreadsheet\">>"}</code></td><td>No</td><td>Props forwarded to the Excel viewer</td></tr>
+    <tr><td><code>emailViewerProps</code></td><td><code>{"Partial<Omit<BaseEmailViewerProps, \"email\">>"}</code></td><td>No</td><td>Props forwarded to the email viewer</td></tr>
+    <tr><td><code>xmlViewerProps</code></td><td><code>{"Partial<Omit<BaseXmlViewerProps, \"content\">>"}</code></td><td>No</td><td>Props forwarded to the XML viewer</td></tr>
+  </tbody>
+</table>
 
 ### ViewerType enum
 
-| Value | Description |
-|---|---|
-| `Pdf` | PDF documents |
-| `Tiff` | TIFF images |
-| `Image` | Common image formats (PNG, JPEG, GIF, SVG, WebP, BMP) |
-| `Video` | Video files |
-| `Markdown` | Markdown text |
-| `Excel` | Excel spreadsheets (`.xlsx`) |
-| `Email` | Email messages (`.eml`) |
-| `Xml` | XML documents |
-| `Unsupported` | Unrecognized MIME types |
+<table>
+  <thead>
+    <tr><th>Value</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>Pdf</code></td><td>PDF documents</td></tr>
+    <tr><td><code>Tiff</code></td><td>TIFF images</td></tr>
+    <tr><td><code>Image</code></td><td>Common image formats (PNG, JPEG, GIF, SVG, WebP, BMP)</td></tr>
+    <tr><td><code>Video</code></td><td>Video files</td></tr>
+    <tr><td><code>Markdown</code></td><td>Markdown text</td></tr>
+    <tr><td><code>Excel</code></td><td>{"Excel spreadsheets (.xlsx)"}</td></tr>
+    <tr><td><code>Email</code></td><td>{"Email messages (.eml)"}</td></tr>
+    <tr><td><code>Xml</code></td><td>XML documents</td></tr>
+    <tr><td><code>Unsupported</code></td><td>Unrecognized MIME types</td></tr>
+  </tbody>
+</table>
 
 ### Supported MIME types
 
-| MIME type | Viewer |
-|---|---|
-| `application/pdf` | PDF viewer |
-| `image/tiff` | TIFF renderer |
-| `image/png`, `image/jpeg`, `image/gif`, `image/svg+xml`, `image/webp`, `image/bmp` | Image viewer |
-| `video/*` | Video viewer |
-| `text/markdown`, `text/x-markdown` | Markdown renderer |
-| `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` | Excel viewer |
-| `message/rfc822` | Email viewer |
-| `application/xml`, `text/xml` | XML viewer |
+<table>
+  <thead>
+    <tr><th>MIME type</th><th>Viewer</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>application/pdf</code></td><td>PDF viewer</td></tr>
+    <tr><td><code>image/tiff</code></td><td>TIFF renderer</td></tr>
+    <tr><td><code>image/png</code>, <code>image/jpeg</code>, <code>image/gif</code>, <code>image/svg+xml</code>, <code>image/webp</code>, <code>image/bmp</code></td><td>Image viewer</td></tr>
+    <tr><td><code>{"video/*"}</code></td><td>Video viewer</td></tr>
+    <tr><td><code>text/markdown</code>, <code>text/x-markdown</code></td><td>Markdown renderer</td></tr>
+    <tr><td><code>{"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"}</code></td><td>Excel viewer</td></tr>
+    <tr><td><code>message/rfc822</code></td><td>Email viewer</td></tr>
+    <tr><td><code>application/xml</code>, <code>text/xml</code></td><td>XML viewer</td></tr>
+  </tbody>
+</table>
 
 ## CSS Variables
 
-| Variable | Default | Description |
-|---|---|---|
-| `--osdk-document-viewer-bg` | `--osdk-background-primary` | Container background |
-| `--osdk-document-viewer-border` | `--osdk-surface-border` | Container border |
+<table>
+  <thead>
+    <tr><th>Variable</th><th>Default</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>--osdk-document-viewer-bg</code></td><td><code>--osdk-background-primary</code></td><td>Container background</td></tr>
+    <tr><td><code>--osdk-document-viewer-border</code></td><td><code>--osdk-surface-border</code></td><td>Container border</td></tr>
+  </tbody>
+</table>
 
 Individual sub-viewer theming is documented in each viewer's respective
 documentation.
@@ -190,9 +210,9 @@ available via CSS variables and the `className` prop.
 ## Accessibility
 
 - The PDF viewer provides keyboard navigation for pages and toolbar controls
-- Image content uses semantic `<img>` elements; pass `alt` text via
+- Image content uses semantic `img` elements; pass `alt` text via
   `imageViewerProps`
-- Video content uses the native `<video>` element with built-in browser
+- Video content uses the native `video` element with built-in browser
   controls for keyboard and screen reader support
 - The unsupported-type fallback message is rendered as visible text for
   screen readers

--- a/packages/react-components-storybook/src/stories/DocumentViewer/DocumentViewer.mdx
+++ b/packages/react-components-storybook/src/stories/DocumentViewer/DocumentViewer.mdx
@@ -1,0 +1,198 @@
+{/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */}
+
+{/* cspell:words openxmlformats officedocument spreadsheetml */}
+
+import { Meta, Canvas, Controls } from "@storybook/addon-docs/blocks";
+import * as DocumentViewerStories from "./DocumentViewer.stories";
+
+<Meta of={DocumentViewerStories} />
+
+# DocumentViewer
+
+A React component that automatically selects the correct viewer for an OSDK
+`Media` object based on its MIME type. Supports PDF, TIFF, common image
+formats, video, markdown, Excel, email, and XML.
+
+## Demo
+
+<Canvas of={DocumentViewerStories.Pdf} />
+
+## Usage
+
+```tsx
+import { DocumentViewer } from "@osdk/react-components/experimental/document-viewer";
+
+<DocumentViewer media={employee.trainingMaterial} />;
+```
+
+> `employee.trainingMaterial` is an OSDK `Media` property. `./client` exports
+> the OSDK client returned by `createClient(...)`.
+
+### Prerequisites
+
+- Install `@osdk/react-components` and its peer dependencies
+- Wrap your app with `OsdkProvider`
+- Import `@osdk/react-components/styles.css`
+
+See the [README](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/README.md#setup)
+for full setup instructions.
+
+## Examples
+
+### Image
+
+Renders common image formats (`image/png`, `image/jpeg`, `image/gif`,
+`image/svg+xml`, `image/webp`, `image/bmp`) with the built-in image viewer.
+
+<Canvas of={DocumentViewerStories.Image} />
+
+### Markdown
+
+Renders `text/markdown` and `text/x-markdown` content.
+
+<Canvas of={DocumentViewerStories.Markdown} />
+
+### Video
+
+Renders any `video/*` MIME type with native video controls.
+
+<Canvas of={DocumentViewerStories.Video} />
+
+### Excel
+
+Renders `.xlsx` spreadsheets with tabbed sheet navigation.
+
+<Canvas of={DocumentViewerStories.Excel} />
+
+### Email
+
+Renders `.eml` (RFC 822) email messages.
+
+<Canvas of={DocumentViewerStories.Email} />
+
+### XML
+
+Renders `application/xml` and `text/xml` content with syntax highlighting.
+
+<Canvas of={DocumentViewerStories.Xml} />
+
+### TIFF
+
+Renders TIFF images, including multi-page files.
+
+<Canvas of={DocumentViewerStories.Tiff} />
+
+### TIFF with PDF conversion
+
+Multi-page TIFFs can be converted to PDF via the MIO transform API for a
+better viewing experience. Falls back to the TIFF renderer if the transform
+fails or for single-page TIFFs.
+
+<Canvas of={DocumentViewerStories.TiffWithPdfConversion} />
+
+### MIME type override
+
+Override the auto-detected MIME type when the media metadata is inaccurate.
+
+<Canvas of={DocumentViewerStories.WithMimeTypeOverride} />
+
+### PDF viewer options
+
+Forward props to the underlying PDF viewer for features like an initial
+sidebar or download support.
+
+<Canvas of={DocumentViewerStories.WithPdfViewerProps} />
+
+### Unsupported type
+
+Unsupported MIME types display a fallback message.
+
+<Canvas of={DocumentViewerStories.UnsupportedType} />
+
+## API Reference
+
+### Props
+
+<Controls of={DocumentViewerStories.Pdf} />
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `media` | `Media` | Yes | The OSDK Media object to render |
+| `className` | `string` | No | CSS class applied to the root element |
+| `mimeTypeOverride` | `string` | No | Override the auto-detected MIME type |
+| `fileName` | `string` | No | File name hint for MIME type detection (e.g. `"scan.tif"`) |
+| `enableTiffToPdf` | `boolean` | No | When true, multi-page TIFFs are converted to PDF via MIO transform API |
+| `pdfViewerProps` | `Partial<Omit<PdfViewerProps, "src">>` | No | Props forwarded to the PDF viewer |
+| `imageViewerProps` | `Partial<Omit<BaseImageViewerProps, "src">>` | No | Props forwarded to the image viewer |
+| `videoViewerProps` | `Partial<Omit<BaseVideoViewerProps, "src">>` | No | Props forwarded to the video viewer |
+| `tiffRendererProps` | `Partial<Omit<TiffRendererProps, "content">>` | No | Props forwarded to the TIFF renderer |
+| `markdownRendererProps` | `Partial<Omit<MarkdownRendererProps, "content">>` | No | Props forwarded to the markdown renderer |
+| `excelViewerProps` | `Partial<Omit<BaseExcelViewerProps, "spreadsheet">>` | No | Props forwarded to the Excel viewer |
+| `emailViewerProps` | `Partial<Omit<BaseEmailViewerProps, "email">>` | No | Props forwarded to the email viewer |
+| `xmlViewerProps` | `Partial<Omit<BaseXmlViewerProps, "content">>` | No | Props forwarded to the XML viewer |
+
+### ViewerType enum
+
+| Value | Description |
+|---|---|
+| `Pdf` | PDF documents |
+| `Tiff` | TIFF images |
+| `Image` | Common image formats (PNG, JPEG, GIF, SVG, WebP, BMP) |
+| `Video` | Video files |
+| `Markdown` | Markdown text |
+| `Excel` | Excel spreadsheets (`.xlsx`) |
+| `Email` | Email messages (`.eml`) |
+| `Xml` | XML documents |
+| `Unsupported` | Unrecognized MIME types |
+
+### Supported MIME types
+
+| MIME type | Viewer |
+|---|---|
+| `application/pdf` | PDF viewer |
+| `image/tiff` | TIFF renderer |
+| `image/png`, `image/jpeg`, `image/gif`, `image/svg+xml`, `image/webp`, `image/bmp` | Image viewer |
+| `video/*` | Video viewer |
+| `text/markdown`, `text/x-markdown` | Markdown renderer |
+| `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` | Excel viewer |
+| `message/rfc822` | Email viewer |
+| `application/xml`, `text/xml` | XML viewer |
+
+## CSS Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `--osdk-document-viewer-bg` | `--osdk-background-primary` | Container background |
+| `--osdk-document-viewer-border` | `--osdk-surface-border` | Container border |
+
+Individual sub-viewer theming is documented in each viewer's respective
+documentation.
+
+## Data Attributes
+
+The DocumentViewer does not expose custom data attributes. Styling hooks are
+available via CSS variables and the `className` prop.
+
+## Accessibility
+
+- The PDF viewer provides keyboard navigation for pages and toolbar controls
+- Image content uses semantic `<img>` elements; pass `alt` text via
+  `imageViewerProps`
+- Video content uses the native `<video>` element with built-in browser
+  controls for keyboard and screen reader support
+- The unsupported-type fallback message is rendered as visible text for
+  screen readers

--- a/packages/react-components-storybook/src/stories/DocumentViewer/DocumentViewer.mdx
+++ b/packages/react-components-storybook/src/stories/DocumentViewer/DocumentViewer.mdx
@@ -19,7 +19,7 @@
 import { Meta, Canvas, Controls } from "@storybook/addon-docs/blocks";
 import * as DocumentViewerStories from "./DocumentViewer.stories";
 
-<Meta of={DocumentViewerStories} />
+<Meta title="Components/DocumentViewer/Docs" tags={["beta"]}/>
 
 # DocumentViewer
 


### PR DESCRIPTION
## Summary
- Add MDX documentation page for the DocumentViewer component in Storybook
- Covers description, usage, examples for all supported viewers (PDF, Image, Markdown, Video, Excel, Email, XML, TIFF), API reference, CSS variables, data attributes, and accessibility
- Follows the established FilterList.mdx template structure

## Test plan
- [ ] Verify Storybook builds without errors
- [ ] Confirm DocumentViewer Docs page renders at Beta/DocumentViewer/Docs
- [ ] Check all Canvas story embeds render correctly
- [ ] Verify no cspell failures in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)