### PR TITLE
Rename Storybook category from Beta/ to Components/

### DIFF
--- a/packages/react-components-storybook/.storybook/main.ts
+++ b/packages/react-components-storybook/.storybook/main.ts
@@ -42,7 +42,7 @@ const config: StorybookConfig = {
     reactDocgen: "react-docgen-typescript",
   },
   staticDirs: ["../public"],
-  // Auto-inject the "beta" tag for any story whose title starts with "Beta/".
+  // Auto-inject the "beta" tag for any story whose title starts with "Components/".
   // Keeps the per-file meta to just `title:` — the tag (and the resulting tag
   // badge) is derived automatically, so contributors can't forget to set it.
   experimental_indexers: async (existingIndexers) =>
@@ -51,7 +51,7 @@ const config: StorybookConfig = {
       createIndex: async (fileName, options) => {
         const entries = await indexer.createIndex(fileName, options);
         return entries.map((entry) =>
-          entry.title?.startsWith("Beta/")
+          entry.title?.startsWith("Components/")
             ? { ...entry, tags: [...new Set([...(entry.tags ?? []), "beta"])] }
             : entry
         );

--- a/packages/react-components-storybook/src/stories/ActionForm/ActionForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ActionForm/ActionForm.stories.tsx
@@ -384,7 +384,7 @@ function UnsupportedFieldsActionFormStory(): React.ReactElement {
 }
 
 const meta = {
-  title: "Beta/ActionForm/Usage",
+  title: "Components/ActionForm/Usage",
   component: UpdateEmployeeActionFormStory,
   parameters: {
     controls: {

--- a/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
@@ -198,7 +198,7 @@ function BaseFormSubmissionOutput(): React.ReactElement {
 }
 
 const meta: Meta<BaseFormStoryProps> = {
-  title: "Beta/ActionForm/BaseForm",
+  title: "Components/ActionForm/BaseForm",
   component: BaseForm,
   decorators: [
     (Story) => (

--- a/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.stories.tsx
+++ b/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.stories.tsx
@@ -32,7 +32,7 @@ import {
 } from "./mockData.js";
 
 const meta: Meta<typeof BaseCbacPicker> = {
-  title: "Beta/CbacPicker",
+  title: "Components/CbacPicker",
   component: BaseCbacPicker,
   parameters: {
     controls: {

--- a/packages/react-components-storybook/src/stories/DocumentViewer/DocumentViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/DocumentViewer/DocumentViewer.stories.tsx
@@ -183,7 +183,7 @@ const mockUnsupportedMedia = createMockMedia(
 );
 
 const meta: Meta<DocumentViewerProps> = {
-  title: "Beta/DocumentViewer",
+  title: "Components/DocumentViewer",
   component: DocumentViewer,
   args: {
     media: mockPdfMedia,

--- a/packages/react-components-storybook/src/stories/EmailViewer/EmailViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/EmailViewer/EmailViewer.stories.tsx
@@ -96,7 +96,7 @@ function createMockEmailMedia(emlContent: string): Media {
 }
 
 const meta: Meta<BaseEmailViewerProps> = {
-  title: "Beta/DocumentViewer/Renderers/EmailViewer",
+  title: "Components/DocumentViewer/Renderers/EmailViewer",
   component: BaseEmailViewer,
   args: {
     email: SAMPLE_EMAIL,

--- a/packages/react-components-storybook/src/stories/ExcelViewer/ExcelViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ExcelViewer/ExcelViewer.stories.tsx
@@ -161,7 +161,7 @@ function createMockExcelMedia(): Media {
 }
 
 const meta: Meta<BaseExcelViewerProps> = {
-  title: "Beta/DocumentViewer/Renderers/ExcelViewer",
+  title: "Components/DocumentViewer/Renderers/ExcelViewer",
   component: BaseExcelViewer,
   args: {
     spreadsheet: SAMPLE_SPREADSHEET,

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
@@ -133,7 +133,7 @@ const FILTER_ICON = (
 );
 
 const meta: Meta<EmployeeFilterListProps> = {
-  title: "Beta/FilterList",
+  title: "Components/FilterList",
   component: FilterList,
   args: {
     title: "Filters",

--- a/packages/react-components-storybook/src/stories/FilterList/Recipes/HorizontalToolbar.stories.tsx
+++ b/packages/react-components-storybook/src/stories/FilterList/Recipes/HorizontalToolbar.stories.tsx
@@ -254,7 +254,7 @@ function HorizontalFilterToolbar(
 }
 
 const meta: Meta<typeof HorizontalFilterToolbar> = {
-  title: "Beta/FilterList/Recipes",
+  title: "Components/FilterList/Recipes",
   component: HorizontalFilterToolbar,
 };
 export default meta;

--- a/packages/react-components-storybook/src/stories/ImageViewer/BaseImageViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ImageViewer/BaseImageViewer.stories.tsx
@@ -46,7 +46,7 @@ function createSampleImageDataUrl(): string {
 const sampleImageDataUrl = createSampleImageDataUrl();
 
 const baseMeta: Meta<BaseImageViewerProps> = {
-  title: "Beta/DocumentViewer/Renderers/ImageViewer/BaseImageViewer",
+  title: "Components/DocumentViewer/Renderers/ImageViewer/BaseImageViewer",
   component: BaseImageViewer,
   args: {
     src: sampleImageDataUrl,

--- a/packages/react-components-storybook/src/stories/ImageViewer/ImageViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ImageViewer/ImageViewer.stories.tsx
@@ -76,7 +76,7 @@ function createMockImageMedia(
 }
 
 const meta: Meta<ImageViewerMediaProps> = {
-  title: "Beta/DocumentViewer/Renderers/ImageViewer",
+  title: "Components/DocumentViewer/Renderers/ImageViewer",
   component: ImageViewer,
   parameters: {
     controls: { expanded: true },

--- a/packages/react-components-storybook/src/stories/MarkdownRenderer/MarkdownRenderer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/MarkdownRenderer/MarkdownRenderer.stories.tsx
@@ -98,7 +98,7 @@ You can also use explicit links like [GitHub](https://github.com).
 `;
 
 const meta: Meta<MarkdownRendererProps> = {
-  title: "Beta/DocumentViewer/Renderers/MarkdownRenderer",
+  title: "Components/DocumentViewer/Renderers/MarkdownRenderer",
   component: MarkdownRenderer,
   args: {
     content: SAMPLE_MARKDOWN,

--- a/packages/react-components-storybook/src/stories/ObjectTable/BaseTable.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/BaseTable.stories.tsx
@@ -78,7 +78,7 @@ const mockData: Person[] = [
 ];
 
 const meta: Meta<BaseTableProps<Person>> = {
-  title: "Beta/ObjectTable/Building Blocks/BaseTable",
+  title: "Components/ObjectTable/Building Blocks/BaseTable",
   component: BaseTable,
   parameters: {
     msw: {

--- a/packages/react-components-storybook/src/stories/ObjectTable/ColumnConfigDialog.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/ColumnConfigDialog.stories.tsx
@@ -41,7 +41,7 @@ const DEFAULT_VISIBILITY: Record<string, boolean> = {
 const DEFAULT_COLUMN_ORDER = ["fullName", "email", "jobTitle", "department"];
 
 const meta: Meta<ColumnConfigDialogProps> = {
-  title: "Beta/ObjectTable/Building Blocks/ColumnConfigDialog",
+  title: "Components/ObjectTable/Building Blocks/ColumnConfigDialog",
   component: ColumnConfigDialog,
   args: {
     isOpen: true,

--- a/packages/react-components-storybook/src/stories/ObjectTable/LoadingCell.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/LoadingCell.stories.tsx
@@ -18,7 +18,7 @@ import { LoadingCell } from "@osdk/react-components/experimental/object-table";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 const meta: Meta<typeof LoadingCell> = {
-  title: "Beta/ObjectTable/Building Blocks/LoadingCell",
+  title: "Components/ObjectTable/Building Blocks/LoadingCell",
   component: LoadingCell,
   args: {
     width: 200,

--- a/packages/react-components-storybook/src/stories/ObjectTable/LoadingCellContent.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/LoadingCellContent.stories.tsx
@@ -18,7 +18,7 @@ import { LoadingCellContent } from "@osdk/react-components/experimental/object-t
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 const meta: Meta<typeof LoadingCellContent> = {
-  title: "Beta/ObjectTable/Building Blocks/LoadingCellContent",
+  title: "Components/ObjectTable/Building Blocks/LoadingCellContent",
   component: LoadingCellContent,
   parameters: {
     docs: {

--- a/packages/react-components-storybook/src/stories/ObjectTable/MultiColumnSortDialog.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/MultiColumnSortDialog.stories.tsx
@@ -29,7 +29,7 @@ const SAMPLE_COLUMNS: MultiColumnSortDialogProps["columnOptions"] = [
 ];
 
 const meta: Meta<MultiColumnSortDialogProps> = {
-  title: "Beta/ObjectTable/Building Blocks/MultiColumnSortDialog",
+  title: "Components/ObjectTable/Building Blocks/MultiColumnSortDialog",
   component: MultiColumnSortDialog,
   args: {
     isOpen: true,

--- a/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.stories.tsx
@@ -45,7 +45,7 @@ import {
 type EmployeeTableProps = ObjectTableProps<typeof Employee>;
 
 const meta: Meta<EmployeeTableProps> = {
-  title: "Beta/ObjectTable/Features",
+  title: "Components/ObjectTable/Features",
   component: ObjectTable,
   parameters: {
     msw: {

--- a/packages/react-components-storybook/src/stories/ObjectTable/Recipes/WithConfigureColumnsButton.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/Recipes/WithConfigureColumnsButton.stories.tsx
@@ -30,7 +30,7 @@ import { Employee } from "../../../types/Employee.js";
 type EmployeeTableProps = ObjectTableProps<typeof Employee>;
 
 const meta: Meta<EmployeeTableProps> = {
-  title: "Beta/ObjectTable/Recipes",
+  title: "Components/ObjectTable/Recipes",
   component: ObjectTable,
   parameters: {
     msw: {

--- a/packages/react-components-storybook/src/stories/PdfViewer/Content.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/Content.stories.tsx
@@ -24,7 +24,8 @@ const SAMPLE_PDF_URL =
   "https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf";
 
 const meta: Meta<PdfViewerContentProps> = {
-  title: "Beta/DocumentViewer/Renderers/PdfViewer/Building Blocks/Content",
+  title:
+    "Components/DocumentViewer/Renderers/PdfViewer/Building Blocks/Content",
   component: PdfViewerContent,
   args: {
     src: SAMPLE_PDF_URL,

--- a/packages/react-components-storybook/src/stories/PdfViewer/Features/PdfViewerFeatures.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/Features/PdfViewerFeatures.stories.tsx
@@ -68,7 +68,7 @@ const mockBookmarkedMedia = createMockMedia(
 );
 
 const meta: Meta<PdfViewerMediaProps> = {
-  title: "Beta/DocumentViewer/Renderers/PdfViewer/Features",
+  title: "Components/DocumentViewer/Renderers/PdfViewer/Features",
   component: PdfViewer,
   args: {
     media: mockMedia,

--- a/packages/react-components-storybook/src/stories/PdfViewer/PdfViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/PdfViewer.stories.tsx
@@ -22,7 +22,7 @@ import { MEDIA_EMPLOYEE_PK } from "../../mocks/fauxFoundry.js";
 import { Employee } from "../../types/Employee.js";
 
 const meta: Meta<PdfViewerMediaProps> = {
-  title: "Beta/DocumentViewer/Renderers/PdfViewer",
+  title: "Components/DocumentViewer/Renderers/PdfViewer",
   component: PdfViewer,
   parameters: {
     controls: { expanded: true },

--- a/packages/react-components-storybook/src/stories/PdfViewer/Recipes/AnnotationCreator/AnnotationCreator.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/Recipes/AnnotationCreator/AnnotationCreator.stories.tsx
@@ -333,7 +333,7 @@ function AnnotationCreatorDemo(
 }
 
 const meta: Meta<PdfViewerProps> = {
-  title: "Beta/DocumentViewer/Renderers/PdfViewer/Recipes",
+  title: "Components/DocumentViewer/Renderers/PdfViewer/Recipes",
   component: BasePdfViewer,
 };
 

--- a/packages/react-components-storybook/src/stories/PdfViewer/Recipes/AnnotationExplorer/AnnotationExplorer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/Recipes/AnnotationExplorer/AnnotationExplorer.stories.tsx
@@ -375,7 +375,7 @@ function AnnotationExplorerDemo(
 }
 
 const meta: Meta<PdfViewerProps> = {
-  title: "Beta/DocumentViewer/Renderers/PdfViewer/Recipes",
+  title: "Components/DocumentViewer/Renderers/PdfViewer/Recipes",
   component: BasePdfViewer,
 };
 

--- a/packages/react-components-storybook/src/stories/PdfViewer/Recipes/CustomAnnotations/CustomAnnotations.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/Recipes/CustomAnnotations/CustomAnnotations.stories.tsx
@@ -107,7 +107,7 @@ const CUSTOM_ANNOTATIONS: PdfAnnotation[] = [
 ];
 
 const meta: Meta<PdfViewerProps> = {
-  title: "Beta/DocumentViewer/Renderers/PdfViewer/Recipes",
+  title: "Components/DocumentViewer/Renderers/PdfViewer/Recipes",
   component: BasePdfViewer,
   args: {
     src: SAMPLE_PDF_URL,

--- a/packages/react-components-storybook/src/stories/PdfViewer/Recipes/InteractiveForm/InteractiveForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/Recipes/InteractiveForm/InteractiveForm.stories.tsx
@@ -329,7 +329,7 @@ function InteractiveFormWithSidebar(): React.ReactElement {
 }
 
 const meta: Meta<PdfViewerProps> = {
-  title: "Beta/DocumentViewer/Renderers/PdfViewer/Recipes",
+  title: "Components/DocumentViewer/Renderers/PdfViewer/Recipes",
   component: BasePdfViewer,
 };
 

--- a/packages/react-components-storybook/src/stories/PdfViewer/SearchBar.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/SearchBar.stories.tsx
@@ -20,7 +20,8 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
 const meta: Meta<PdfViewerSearchBarProps> = {
-  title: "Beta/DocumentViewer/Renderers/PdfViewer/Building Blocks/SearchBar",
+  title:
+    "Components/DocumentViewer/Renderers/PdfViewer/Building Blocks/SearchBar",
   component: PdfViewerSearchBar,
   args: {
     query: "",

--- a/packages/react-components-storybook/src/stories/PdfViewer/Toolbar.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/Toolbar.stories.tsx
@@ -20,7 +20,8 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
 const meta: Meta<PdfViewerToolbarProps> = {
-  title: "Beta/DocumentViewer/Renderers/PdfViewer/Building Blocks/Toolbar",
+  title:
+    "Components/DocumentViewer/Renderers/PdfViewer/Building Blocks/Toolbar",
   component: PdfViewerToolbar,
   args: {
     currentPage: 1,

--- a/packages/react-components-storybook/src/stories/TiffRenderer/TiffRendererFeatures.stories.tsx
+++ b/packages/react-components-storybook/src/stories/TiffRenderer/TiffRendererFeatures.stories.tsx
@@ -102,7 +102,7 @@ function createSampleTiffBytes(): Uint8Array {
 const sampleTiffBytes = createSampleTiffBytes();
 
 const meta: Meta<TiffRendererProps> = {
-  title: "Beta/DocumentViewer/Renderers/TiffRenderer",
+  title: "Components/DocumentViewer/Renderers/TiffRenderer",
   component: TiffRenderer,
   args: {
     content: sampleTiffBytes,

--- a/packages/react-components-storybook/src/stories/VideoViewer/VideoViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/VideoViewer/VideoViewer.stories.tsx
@@ -49,7 +49,7 @@ function createMockMedia(url: string, filename: string): Media {
 const mockMedia = createMockMedia(SAMPLE_VIDEO_URL, "example.mp4");
 
 const meta: Meta<VideoViewerMediaProps> = {
-  title: "Beta/DocumentViewer/Renderers/VideoViewer",
+  title: "Components/DocumentViewer/Renderers/VideoViewer",
   component: VideoViewer,
   args: {
     media: mockMedia,

--- a/packages/react-components-storybook/src/stories/XmlViewer/XmlViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/XmlViewer/XmlViewer.stories.tsx
@@ -79,7 +79,7 @@ function createMockXmlMedia(xmlContent: string): Media {
 }
 
 const meta: Meta<BaseXmlViewerProps> = {
-  title: "Beta/DocumentViewer/Renderers/XmlViewer",
+  title: "Components/DocumentViewer/Renderers/XmlViewer",
   component: BaseXmlViewer,
   args: {
     content: SAMPLE_XML,

--- a/packages/react-components/CLAUDE.md
+++ b/packages/react-components/CLAUDE.md
@@ -96,16 +96,16 @@ For every state change with a built-in default behavior (sort, filter, select, e
 ## Storybook
 
 - Stories live in `packages/react-components-storybook/src/stories/<Name>/<Name>.stories.tsx`
-- **Tier placement is via `title:`, not folder path.** New components belong under the `Beta/` category:
+- **Tier placement is via `title:`, not folder path.** New components belong under the `Components/` category:
 
   ```ts
   const meta: Meta<typeof MyComponent> = {
-    title: "Beta/<Name>", // or "Beta/<Parent>/<Subfeature>"
+    title: "Components/<Name>", // or "Components/<Parent>/<Subfeature>"
     component: MyComponent,
   };
   ```
 
-  The `beta` tag (and resulting tag badge) is injected automatically by the indexer in `.storybook/main.ts` for any title starting with `Beta/` — do **not** add `tags: ["beta"]` manually.
+  The `beta` tag (and resulting tag badge) is injected automatically by the indexer in `.storybook/main.ts` for any title starting with `Components/` — do **not** add `tags: ["beta"]` manually.
 
   Produces URLs like `beta-myname--default`, matching `beta-baseform--default`, `beta-objecttable-building-blocks-basetable--default`
 - **OSDK-aware components must accept mocked data via props in stories.** Storybook runs without a Foundry stack, so the OSDK wrapper cannot fetch real data there. Either expose a `data` / `objects` / `value` prop the story can populate, or render the `Base<Name>` component directly. Use the MSW addon for stories that exercise hook-level fetch paths

--- a/packages/react-components/CONTRIBUTING.md
+++ b/packages/react-components/CONTRIBUTING.md
@@ -226,16 +226,16 @@ Storybook runs on `http://localhost:6006`.
 
 - Story files live in `packages/react-components-storybook/src/stories/<Name>/<Name>.stories.tsx`. Folders match the component name; sub-stories live alongside, optionally under a `Recipes/` or `Features/` subfolder
 - Follow the [Component Story Format (CSF)](https://storybook.js.org/docs/api/csf)
-- **Tier placement is via the meta `title:`, not the folder path.** New components belong under the `Beta/` category:
+- **Tier placement is via the meta `title:`, not the folder path.** New components belong under the `Components/` category:
 
   ```ts
   const meta: Meta<typeof MyComponent> = {
-    title: "Beta/<Name>", // or "Beta/<Parent>/<Subfeature>"
+    title: "Components/<Name>", // or "Components/<Parent>/<Subfeature>"
     component: MyComponent,
   };
   ```
 
-  The `beta` tag (and resulting tag badge) is injected automatically by the indexer in `.storybook/main.ts` for any title starting with `Beta/` — do **not** add `tags: ["beta"]` manually.
+  The `beta` tag (and resulting tag badge) is injected automatically by the indexer in `.storybook/main.ts` for any title starting with `Components/` — do **not** add `tags: ["beta"]` manually.
 
   This produces URLs like `beta-myname--default`, matching the existing pattern (`beta-baseform--default`, `beta-objecttable-building-blocks-basetable--default`)
 - Include stories that demonstrate the component's key states: default, loading, error, empty, and edge cases


### PR DESCRIPTION
## Summary
- Rename all story titles from `Beta/` to `Components/` prefix across 30 story files
- Update the auto-tagging indexer in `.storybook/main.ts` to tag `Components/` instead of `Beta/`
- Update `CLAUDE.md` and `CONTRIBUTING.md` references

## Test plan
- [ ] Storybook sidebar shows stories under `Components/` instead of `Beta/`
- [ ] Beta tag badge still appears on all component stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)