### PR TITLE
Move vitest to devDependencies in @osdk/unit-testing

### DIFF
--- a/.changeset/unit-testing-vitest-devdep.md
+++ b/.changeset/unit-testing-vitest-devdep.md
@@ -1,0 +1,5 @@
+---
+"@osdk/unit-testing": patch
+---
+
+Move vitest from dependencies to devDependencies since it is only used in tests, not in the shipped output

--- a/packages/unit-testing/package.json
+++ b/packages/unit-testing/package.json
@@ -52,8 +52,7 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "tiny-invariant": "^1.3.3",
-    "vitest": "^3.2.4"
+    "tiny-invariant": "^1.3.3"
   },
   "peerDependencies": {
     "@osdk/api": "workspace:^",
@@ -71,7 +70,8 @@
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
     "msw": "^2.11.1",
-    "typescript": "~5.5.4"
+    "typescript": "~5.5.4",
+    "vitest": "^3.2.4"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5435,9 +5435,6 @@ importers:
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3
-      vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(happy-dom@20.8.9)(jiti@2.5.1)(jsdom@20.0.3(canvas@2.11.2))(less@4.5.1)(lightningcss@1.32.0)(msw@2.11.1(@types/node@24.12.0)(typescript@5.5.4))(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.3)
     devDependencies:
       '@microsoft/api-documenter':
         specifier: ^7.26.32
@@ -5472,6 +5469,9 @@ importers:
       typescript:
         specifier: ~5.5.4
         version: 5.5.4
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(happy-dom@20.8.9)(jiti@2.5.1)(jsdom@20.0.3(canvas@2.11.2))(less@4.5.1)(lightningcss@1.32.0)(msw@2.11.1(@types/node@24.12.0)(typescript@5.5.4))(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.3)
 
   packages/version-updater:
     devDependencies:


### PR DESCRIPTION
## Summary

`vitest` was listed as a runtime `dependency` of `@osdk/unit-testing`, but it is only used in `.test.ts` files. None of the shipped entrypoints (`index.ts`, `public/experimental.ts`, `api/*.ts`, `mock/createMock*.ts`) import it, and the public `.d.ts` surface does not expose any vitest types — so consumers do not need it at install time. This moves it to `devDependencies`.

`tiny-invariant` remains the only runtime dependency.

## Verification

- `pnpm turbo typecheck --filter=@osdk/unit-testing` — passed
- `pnpm turbo test --filter=@osdk/unit-testing` — 99 tests passed (vitest still resolvable as a dev dep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)