### PR TITLE
Re-export GeoJSON subtypes

### DIFF
--- a/.changeset/functions-geojson-subtypes.md
+++ b/.changeset/functions-geojson-subtypes.md
@@ -1,0 +1,5 @@
+---
+"@osdk/functions": minor
+---
+
+Export additional GeoJSON subtypes (GeometryCollection, LineString, MultiLineString, MultiPoint, MultiPolygon, Polygon) alongside Geometry and Point.

--- a/etc/functions.report.api.md
+++ b/etc/functions.report.api.md
@@ -8,16 +8,22 @@ import { Attachment } from '@osdk/client';
 import type { Client } from '@osdk/client';
 import type { CompileTimeMetadata } from '@osdk/client';
 import { Geometry } from 'geojson';
+import { GeometryCollection } from 'geojson';
 import type { GroupId as GroupId_2 } from '@osdk/foundry.core';
 import type { InterfaceDefinition } from '@osdk/client';
+import { LineString } from 'geojson';
 import type { Media } from '@osdk/client';
 import { MediaReference } from '@osdk/client';
 import { MediaUpload } from '@osdk/client';
+import { MultiLineString } from 'geojson';
+import { MultiPoint } from 'geojson';
+import { MultiPolygon } from 'geojson';
 import type { ObjectMetadata } from '@osdk/client';
 import type { ObjectTypeDefinition } from '@osdk/client';
 import type { Osdk } from '@osdk/client';
 import type { OsdkObjectCreatePropertyType } from '@osdk/client';
 import { Point } from 'geojson';
+import { Polygon } from 'geojson';
 import type { PropertyKeys } from '@osdk/client';
 import { Range as Range_2 } from '@osdk/client';
 import { ThreeDimensionalAggregation } from '@osdk/client';
@@ -144,6 +150,8 @@ export type Float<T extends number = number> = T & {
 
 export { Geometry }
 
+export { GeometryCollection }
+
 // @public (undocumented)
 export type GroupId = GroupId_2 & {
     	__groupIdBrand?: void
@@ -153,6 +161,8 @@ export type GroupId = GroupId_2 & {
 export type Integer<T extends number = number> = T & {
     	__integerBrand?: void
 };
+
+export { LineString }
 
 // @public (undocumented)
 export type Long<T extends string = string> = T & {
@@ -176,6 +186,12 @@ interface Model {
 
 // @public (undocumented)
 function model(alias: string): Model;
+
+export { MultiLineString }
+
+export { MultiPoint }
+
+export { MultiPolygon }
 
 // @public (undocumented)
 interface Notification_2 {
@@ -216,6 +232,8 @@ export interface PlatformNotification {
 }
 
 export { Point }
+
+export { Polygon }
 
 // @public (undocumented)
 export type Principal = {

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -53,4 +53,12 @@ export type {
 export type { ClassificationMarking, MandatoryMarking } from "./Markings.js";
 export type { GroupId, Principal, UserId } from "./UserGroup.js";
 
-export type { Geometry, Point } from "geojson";
+export type { 
+  Geometry,
+  GeometryCollection,
+  LineString,
+  MultiLineString,
+  MultiPoint,
+  MultiPolygon,
+  Point,
+  Polygon } from "geojson";

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -53,7 +53,7 @@ export type {
 export type { ClassificationMarking, MandatoryMarking } from "./Markings.js";
 export type { GroupId, Principal, UserId } from "./UserGroup.js";
 
-export type { 
+export type {
   Geometry,
   GeometryCollection,
   LineString,
@@ -61,4 +61,5 @@ export type {
   MultiPoint,
   MultiPolygon,
   Point,
-  Polygon } from "geojson";
+  Polygon,
+} from "geojson";


### PR DESCRIPTION
Re-exports Polygon, LineString, MultiPoint, MultiPolygon, MultiLineString, and GeometryCollection from geojson alongside the existing Geometry and Point re-exports.