### PR TITLE
right-align clear all in filter-list exclude row via flex leading wrapper

### DIFF
--- a/.changeset/filter-list-clear-all-flex-leading.md
+++ b/.changeset/filter-list-clear-all-flex-leading.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Make the filter-list exclude row Clear all button reliably right-align against consumer CSS resets.

--- a/packages/react-components/src/filter-list/base/FilterInputExcludeRow.tsx
+++ b/packages/react-components/src/filter-list/base/FilterInputExcludeRow.tsx
@@ -71,19 +71,21 @@ function FilterInputExcludeRowInner({
           [styles.excludeRowVisible]: isOpen,
         })}
       >
-        <ExcludeDropdown
-          isExcluding={isExcluding}
-          onToggleExclude={handleToggleExclude}
-        />
-        {totalValueCount != null && totalValueCount > 0 && (
-          <span
-            className={styles.excludeCountLabel}
-            title="Approximate count of unique values"
-          >
-            {selectedCount.toLocaleString()} of{" "}
-            {totalValueCount.toLocaleString()} values
-          </span>
-        )}
+        <div className={styles.excludeRowLeading}>
+          <ExcludeDropdown
+            isExcluding={isExcluding}
+            onToggleExclude={handleToggleExclude}
+          />
+          {totalValueCount != null && totalValueCount > 0 && (
+            <span
+              className={styles.excludeCountLabel}
+              title="Approximate count of unique values"
+            >
+              {selectedCount.toLocaleString()} of{" "}
+              {totalValueCount.toLocaleString()} values
+            </span>
+          )}
+        </div>
         {onClearAll && selectedCount > 0 && (
           <Button
             className={styles.clearAllButton}

--- a/packages/react-components/src/filter-list/base/FilterListItem.module.css
+++ b/packages/react-components/src/filter-list/base/FilterListItem.module.css
@@ -168,6 +168,7 @@
   display: flex;
   align-items: center;
   width: 100%;
+  gap: var(--osdk-surface-spacing);
   opacity: 0;
   height: 0;
   overflow: hidden;
@@ -185,15 +186,22 @@
   overflow: visible;
 }
 
+.excludeRowLeading {
+  display: flex;
+  align-items: center;
+  flex: 1 1 auto;
+  min-width: 0;
+  gap: calc(var(--osdk-surface-spacing) * 0.5);
+}
+
 .excludeCountLabel {
   font-family: var(--osdk-filter-item-exclude-dropdown-font-family);
   font-size: var(--osdk-filter-item-exclude-dropdown-font-size);
   color: var(--osdk-filter-item-exclude-dropdown-color);
-  margin-left: calc(var(--osdk-surface-spacing) * 0.5);
 }
 
 .clearAllButton {
-  margin-left: auto;
+  flex: 0 0 auto;
   background: none;
   border: none;
   cursor: pointer;


### PR DESCRIPTION
the previous right-align fix (#3337) used `margin-left: auto` on the clear all button, which collapses when a consumer app's css reset zeroes out button margins

• wrap the keeping dropdown and count label in a leading div with `flex: 1 1 auto; min-width: 0` so it consumes remaining row space
• drop `margin-left: auto` on the clear all button; use `flex: 0 0 auto` and move the inter-item spacing onto the row gap and leading-group gap
• no api change, no consumer-visible behavior change in well-behaved css contexts