### PR TITLE
Sort attached MDX docs entries first within component folders

### DIFF
--- a/.changeset/storybook-docs-sort.md
+++ b/.changeset/storybook-docs-sort.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components-storybook": patch
+---
+
+Sort attached MDX docs entries first within component folders

--- a/packages/react-components-storybook/.storybook/preview.tsx
+++ b/packages/react-components-storybook/.storybook/preview.tsx
@@ -50,7 +50,10 @@ const mockClient = createClient(
 const preview: Preview = {
   parameters: {
     options: {
-      storySort: (a, b) => {
+      storySort: (
+        a: { title: string; type: string; id: string },
+        b: { title: string; type: string; id: string },
+      ) => {
         // Top-level category ordering
         const categoryOrder = ["Docs", "Components"];
         const aCat = a.title.split("/")[0];

--- a/packages/react-components-storybook/.storybook/preview.tsx
+++ b/packages/react-components-storybook/.storybook/preview.tsx
@@ -49,26 +49,46 @@ const mockClient = createClient(
 
 const preview: Preview = {
   parameters: {
-    // Storybook 10 reads storySort from parameters.options (statically parsed)
     options: {
-      storySort: {
-        order: [
-          "Docs",
-          [
-            "Welcome",
-            "Installation",
-            "Changelog",
-            "Guides",
-            ["Getting Started", "Usage with OSDK"],
-            "Styling",
-            ["Overview"],
-            "Tokens",
-            ["Colors", "Typography", "Spacing"],
-          ],
-          "Components",
-          ["*"],
-          "*",
-        ],
+      storySort: (a, b) => {
+        // Top-level category ordering
+        const categoryOrder = ["Docs", "Components"];
+        const aCat = a.title.split("/")[0];
+        const bCat = b.title.split("/")[0];
+        const aIdx = categoryOrder.indexOf(aCat);
+        const bIdx = categoryOrder.indexOf(bCat);
+        const aOrder = aIdx === -1 ? categoryOrder.length : aIdx;
+        const bOrder = bIdx === -1 ? categoryOrder.length : bIdx;
+        if (aOrder !== bOrder) return aOrder - bOrder;
+
+        // Sub-ordering within the top-level "Docs" category
+        if (aCat === "Docs" && bCat === "Docs") {
+          const docsOrder = [
+            "Docs/Welcome",
+            "Docs/Installation",
+            "Docs/Changelog",
+            "Docs/Guides/Getting Started",
+            "Docs/Guides/Usage with OSDK",
+            "Docs/Styling/Overview",
+            "Docs/Tokens/Colors",
+            "Docs/Tokens/Typography",
+            "Docs/Tokens/Spacing",
+          ];
+          const aDocIdx = docsOrder.indexOf(a.title);
+          const bDocIdx = docsOrder.indexOf(b.title);
+          const aDocOrder = aDocIdx === -1 ? docsOrder.length : aDocIdx;
+          const bDocOrder = bDocIdx === -1 ? docsOrder.length : bDocIdx;
+          if (aDocOrder !== bDocOrder) return aDocOrder - bDocOrder;
+        }
+
+        // Within the same component, put docs entries first
+        if (a.title === b.title && a.type !== b.type) {
+          if (a.type === "docs") return -1;
+          if (b.type === "docs") return 1;
+        }
+
+        // Default: alphabetical by id
+        return a.id.localeCompare(b.id, undefined, { numeric: true });
       },
     },
     controls: {

--- a/packages/react-components-storybook/.storybook/preview.tsx
+++ b/packages/react-components-storybook/.storybook/preview.tsx
@@ -50,10 +50,8 @@ const mockClient = createClient(
 const preview: Preview = {
   parameters: {
     options: {
-      storySort: (
-        a: { title: string; type: string; id: string },
-        b: { title: string; type: string; id: string },
-      ) => {
+      // @ts-expect-error — Storybook eval()s storySort at build time; TS types break it
+      storySort: (a, b) => {
         // Top-level category ordering
         const categoryOrder = ["Docs", "Components"];
         const aCat = a.title.split("/")[0];


### PR DESCRIPTION
## Summary
- Add a `storySort` function to `preview.tsx` that puts docs entries before stories within the same component in the Storybook sidebar
- Preserves the existing top-level Docs category ordering (Welcome, Installation, Changelog, etc.)
- Falls back to alphabetical sorting by id for everything else

## Context
Storybook 10 renders attached MDX docs pages as the last entry inside a component folder by default. This change puts them first, matching the expected `autodocs` behavior.

## Test plan
- [ ] Verify "Docs" appears as the first entry inside DocumentViewer folder
- [ ] Verify top-level Docs category order is preserved (Welcome > Installation > Changelog > ...)
- [ ] Verify Components are still sorted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)