### PR TITLE
Enable standalone MDX documentation pages in Storybook

### DIFF
--- a/.changeset/storybook-mdx-glob.md
+++ b/.changeset/storybook-mdx-glob.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components-storybook": patch
+---
+
+Enable standalone MDX documentation pages co-located with stories

--- a/packages/react-components-storybook/.storybook/main.ts
+++ b/packages/react-components-storybook/.storybook/main.ts
@@ -21,7 +21,7 @@ const storybookBasePath = process.env.STORYBOOK_BASE_PATH;
 const config: StorybookConfig = {
   stories: [
     "../src/**/*.stories.@(js|jsx|ts|tsx|mdx)",
-    "../src/docs/**/*.mdx",
+    "../src/**/*.mdx",
   ],
   addons: [
     "@storybook/addon-a11y",
@@ -50,11 +50,14 @@ const config: StorybookConfig = {
   // in the manager config. When a component graduates to GA, remove
   // tags: ["beta"] from its story meta — the indexer only adds the tag,
   // it does not override an explicit empty tags array.
+  // MDX files are skipped because wrapping their index entries breaks
+  // attached-docs sidebar placement in Storybook 10.
   experimental_indexers: async (existingIndexers) =>
     (existingIndexers ?? []).map((indexer) => ({
       ...indexer,
       createIndex: async (fileName, options) => {
         const entries = await indexer.createIndex(fileName, options);
+        if (fileName.endsWith(".mdx")) return entries;
         return entries.map((entry) =>
           entry.title?.startsWith("Components/")
             ? { ...entry, tags: [...new Set([...(entry.tags ?? []), "beta"])] }


### PR DESCRIPTION
## Summary
- Add `../src/**/*.mdx` glob to discover standalone MDX files alongside story files
- Skip MDX files in the beta-tag indexer to prevent breaking attached-docs sidebar placement in Storybook 10

## Context
This is infrastructure for adding component documentation pages (e.g. DocumentViewer, FilterList) as MDX files co-located with their stories. Without the glob change, Storybook only discovers MDX files in `src/docs/`. Without the indexer fix, wrapping MDX index entries breaks the sidebar attachment.

## Test plan
- [ ] Existing docs pages (Welcome, Installation, Changelog) still render
- [ ] Beta badges still appear on component stories
- [ ] No new sidebar entries appear (no MDX files exist yet on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)