### PR TITLE
Fix ObjectTable select-all aria label

### DIFF
--- a/.changeset/quiet-wolves-howl.md
+++ b/.changeset/quiet-wolves-howl.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Update ObjectTable header select-all checkbox aria label to reflect actual action (deselect when rows are selected)

--- a/packages/react-components/src/object-table/SelectionCells.tsx
+++ b/packages/react-components/src/object-table/SelectionCells.tsx
@@ -29,12 +29,14 @@ export function SelectionHeaderCell({
   hasSelection,
   onToggleAll,
 }: SelectionHeaderCellProps): React.ReactElement {
+  const checkboxLabel = hasSelection ? "Deselect all rows" : "Select all rows";
+
   return (
     <Checkbox
       indeterminate={hasSelection && !isAllSelected}
       checked={isAllSelected}
       onCheckedChange={onToggleAll}
-      aria-label={"Select all rows"}
+      aria-label={checkboxLabel}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Follow-up to #3381, which changed ObjectTable header select-all behavior to deselect when any rows are selected
- Update the header select-all checkbox aria label to match the action it now performs
- Announce "Deselect all rows" when any rows are selected

## Testing
- pnpm vitest run src/object-table/hooks/__tests__/useSelectionColumn.test.tsx src/object-table/hooks/__tests__/useRowSelection.test.tsx
- pnpm turbo typecheck --filter=@osdk/react-components
- pnpm exec dprint check packages/react-components/src/object-table/SelectionCells.tsx --incremental=false
- git diff --check