### PR TITLE
Add per-component MDX docs pages to Storybook

### DIFF
--- a/.changeset/mdx-docs-import.md
+++ b/.changeset/mdx-docs-import.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components-storybook": patch
+---
+
+Add per-component MDX documentation pages importing existing docs

--- a/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
+++ b/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
@@ -20,13 +20,13 @@ import actionFormDocs from "@docs/ActionForm.md?raw";
 
 <Meta title="Components/ActionForm/Docs" tags={["beta"]}/>
 
+# ActionForm
+
+<Canvas of={ActionFormStories.Default} />
+
 <Markdown>{actionFormDocs}</Markdown>
 
 ## Interactive Demos
-
-### Default
-
-<Canvas of={ActionFormStories.Default} />
 
 ### Submit Success
 

--- a/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
+++ b/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
@@ -20,11 +20,13 @@ import actionFormDocs from "@docs/ActionForm.md?raw";
 
 <Meta title="Components/ActionForm/Docs" tags={["beta"]}/>
 
-<Canvas of={ActionFormStories.Default} />
-
 <Markdown>{actionFormDocs}</Markdown>
 
 ## Interactive Demos
+
+### Default
+
+<Canvas of={ActionFormStories.Default} />
 
 ### Submit Success
 

--- a/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
+++ b/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
@@ -20,8 +20,6 @@ import actionFormDocs from "@docs/ActionForm.md?raw";
 
 <Meta title="Components/ActionForm/Docs" tags={["beta"]}/>
 
-# ActionForm
-
 <Canvas of={ActionFormStories.Default} />
 
 <Markdown>{actionFormDocs}</Markdown>

--- a/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
+++ b/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
@@ -14,40 +14,9 @@
  * limitations under the License.
  */}
 
-import { Meta, Markdown, Canvas, Controls } from "@storybook/addon-docs/blocks";
-import * as ActionFormStories from "./ActionForm.stories";
+import { Meta, Markdown } from "@storybook/addon-docs/blocks";
 import actionFormDocs from "@docs/ActionForm.md?raw";
 
 <Meta title="Components/ActionForm/Docs" tags={["beta"]}/>
 
 <Markdown>{actionFormDocs}</Markdown>
-
-## Interactive Demos
-
-### Default
-
-<Canvas of={ActionFormStories.Default} />
-
-### Submit Success
-
-<Canvas of={ActionFormStories.SubmitSuccess} />
-
-### Submit Failure
-
-<Canvas of={ActionFormStories.SubmitFailure} />
-
-### Validation Errors
-
-<Canvas of={ActionFormStories.ValidationErrors} />
-
-### Custom Submit Handler
-
-<Canvas of={ActionFormStories.CustomSubmitHandler} />
-
-### With Title
-
-<Canvas of={ActionFormStories.WithTitle} />
-
-### Props
-
-<Controls of={ActionFormStories.Default} />

--- a/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
+++ b/packages/react-components-storybook/src/stories/ActionForm/ActionForm.mdx
@@ -1,0 +1,53 @@
+{/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */}
+
+import { Meta, Markdown, Canvas, Controls } from "@storybook/addon-docs/blocks";
+import * as ActionFormStories from "./ActionForm.stories";
+import actionFormDocs from "@docs/ActionForm.md?raw";
+
+<Meta title="Components/ActionForm/Docs" tags={["beta"]}/>
+
+<Markdown>{actionFormDocs}</Markdown>
+
+## Interactive Demos
+
+### Default
+
+<Canvas of={ActionFormStories.Default} />
+
+### Submit Success
+
+<Canvas of={ActionFormStories.SubmitSuccess} />
+
+### Submit Failure
+
+<Canvas of={ActionFormStories.SubmitFailure} />
+
+### Validation Errors
+
+<Canvas of={ActionFormStories.ValidationErrors} />
+
+### Custom Submit Handler
+
+<Canvas of={ActionFormStories.CustomSubmitHandler} />
+
+### With Title
+
+<Canvas of={ActionFormStories.WithTitle} />
+
+### Props
+
+<Controls of={ActionFormStories.Default} />

--- a/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.mdx
+++ b/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.mdx
@@ -23,6 +23,8 @@ import * as CbacPickerStories from "./CbacPicker.stories";
 
 # CbacPicker
 
+<Canvas of={CbacPickerStories.Default} />
+
 Components for managing classification-based access control (CBAC) markings.
 CBAC markings control who can access data. Each piece of data can be tagged
 with markings from different categories, and the combination determines its
@@ -35,10 +37,6 @@ which combinations are valid, which markings are implied by others, and which
 are disallowed.
 
 ## Interactive Demos
-
-### Default
-
-<Canvas of={CbacPickerStories.Default} />
 
 ### Read-Only
 

--- a/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.mdx
+++ b/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.mdx
@@ -48,10 +48,6 @@ are disallowed.
 
 <Canvas of={CbacPickerStories.WithInitialSelection} />
 
-### In Dialog
-
-<Canvas of={CbacPickerStories.InDialog} />
-
 ### With Implied and Disallowed
 
 <Canvas of={CbacPickerStories.WithImpliedAndDisallowed} />

--- a/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.mdx
+++ b/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.mdx
@@ -21,9 +21,9 @@ import * as CbacPickerStories from "./CbacPicker.stories";
 
 <Meta title="Components/CbacPicker/Docs" tags={["beta"]}/>
 
-# CbacPicker
-
 <Canvas of={CbacPickerStories.Default} />
+
+# CbacPicker
 
 Components for managing classification-based access control (CBAC) markings.
 CBAC markings control who can access data. Each piece of data can be tagged

--- a/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.mdx
+++ b/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.mdx
@@ -21,8 +21,6 @@ import * as CbacPickerStories from "./CbacPicker.stories";
 
 <Meta title="Components/CbacPicker/Docs" tags={["beta"]}/>
 
-<Canvas of={CbacPickerStories.Default} />
-
 # CbacPicker
 
 Components for managing classification-based access control (CBAC) markings.
@@ -37,6 +35,10 @@ which combinations are valid, which markings are implied by others, and which
 are disallowed.
 
 ## Interactive Demos
+
+### Default
+
+<Canvas of={CbacPickerStories.Default} />
 
 ### Read-Only
 

--- a/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.mdx
+++ b/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.mdx
@@ -1,0 +1,65 @@
+{/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */}
+
+{/* cspell:words cbac */}
+
+import { Meta, Canvas, Controls } from "@storybook/addon-docs/blocks";
+import * as CbacPickerStories from "./CbacPicker.stories";
+
+<Meta title="Components/CbacPicker/Docs" tags={["beta"]}/>
+
+# CbacPicker
+
+Components for managing classification-based access control (CBAC) markings.
+CBAC markings control who can access data. Each piece of data can be tagged
+with markings from different categories, and the combination determines its
+access restrictions.
+
+The picker lets users select markings grouped by category. Some categories are
+**disjunctive** (pick exactly one, like a sensitivity level) and others are
+**conjunctive** (pick any combination, like access groups). The server enforces
+which combinations are valid, which markings are implied by others, and which
+are disallowed.
+
+## Interactive Demos
+
+### Default
+
+<Canvas of={CbacPickerStories.Default} />
+
+### Read-Only
+
+<Canvas of={CbacPickerStories.ReadOnly} />
+
+### With Initial Selection
+
+<Canvas of={CbacPickerStories.WithInitialSelection} />
+
+### In Dialog
+
+<Canvas of={CbacPickerStories.InDialog} />
+
+### With Implied and Disallowed
+
+<Canvas of={CbacPickerStories.WithImpliedAndDisallowed} />
+
+### Banner Only
+
+<Canvas of={CbacPickerStories.BannerOnly} />
+
+### Props
+
+<Controls of={CbacPickerStories.Default} />

--- a/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.mdx
+++ b/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.mdx
@@ -16,8 +16,7 @@
 
 {/* cspell:words cbac */}
 
-import { Meta, Canvas, Controls } from "@storybook/addon-docs/blocks";
-import * as CbacPickerStories from "./CbacPicker.stories";
+import { Meta } from "@storybook/addon-docs/blocks";
 
 <Meta title="Components/CbacPicker/Docs" tags={["beta"]}/>
 
@@ -33,29 +32,3 @@ The picker lets users select markings grouped by category. Some categories are
 **conjunctive** (pick any combination, like access groups). The server enforces
 which combinations are valid, which markings are implied by others, and which
 are disallowed.
-
-## Interactive Demos
-
-### Default
-
-<Canvas of={CbacPickerStories.Default} />
-
-### Read-Only
-
-<Canvas of={CbacPickerStories.ReadOnly} />
-
-### With Initial Selection
-
-<Canvas of={CbacPickerStories.WithInitialSelection} />
-
-### With Implied and Disallowed
-
-<Canvas of={CbacPickerStories.WithImpliedAndDisallowed} />
-
-### Banner Only
-
-<Canvas of={CbacPickerStories.BannerOnly} />
-
-### Props
-
-<Controls of={CbacPickerStories.Default} />

--- a/packages/react-components-storybook/src/stories/DocumentViewer/DocumentViewer.mdx
+++ b/packages/react-components-storybook/src/stories/DocumentViewer/DocumentViewer.mdx
@@ -20,8 +20,6 @@ import documentViewerDocs from "@docs/DocumentViewer.md?raw";
 
 <Meta title="Components/DocumentViewer/Docs" tags={["beta"]}/>
 
-# DocumentViewer
-
 <Canvas of={DocumentViewerStories.Pdf} />
 
 <Markdown>{documentViewerDocs}</Markdown>

--- a/packages/react-components-storybook/src/stories/DocumentViewer/DocumentViewer.mdx
+++ b/packages/react-components-storybook/src/stories/DocumentViewer/DocumentViewer.mdx
@@ -20,11 +20,13 @@ import documentViewerDocs from "@docs/DocumentViewer.md?raw";
 
 <Meta title="Components/DocumentViewer/Docs" tags={["beta"]}/>
 
-<Canvas of={DocumentViewerStories.Pdf} />
-
 <Markdown>{documentViewerDocs}</Markdown>
 
 ## Interactive Demos
+
+### PDF
+
+<Canvas of={DocumentViewerStories.Pdf} />
 
 ### Image
 

--- a/packages/react-components-storybook/src/stories/DocumentViewer/DocumentViewer.mdx
+++ b/packages/react-components-storybook/src/stories/DocumentViewer/DocumentViewer.mdx
@@ -1,0 +1,65 @@
+{/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */}
+
+import { Meta, Markdown, Canvas, Controls } from "@storybook/addon-docs/blocks";
+import * as DocumentViewerStories from "./DocumentViewer.stories";
+import documentViewerDocs from "@docs/DocumentViewer.md?raw";
+
+<Meta title="Components/DocumentViewer/Docs" tags={["beta"]}/>
+
+<Markdown>{documentViewerDocs}</Markdown>
+
+## Interactive Demos
+
+### PDF
+
+<Canvas of={DocumentViewerStories.Pdf} />
+
+### Image
+
+<Canvas of={DocumentViewerStories.Image} />
+
+### Markdown
+
+<Canvas of={DocumentViewerStories.Markdown} />
+
+### Video
+
+<Canvas of={DocumentViewerStories.Video} />
+
+### Excel
+
+<Canvas of={DocumentViewerStories.Excel} />
+
+### Email
+
+<Canvas of={DocumentViewerStories.Email} />
+
+### XML
+
+<Canvas of={DocumentViewerStories.Xml} />
+
+### TIFF
+
+<Canvas of={DocumentViewerStories.Tiff} />
+
+### Unsupported Type
+
+<Canvas of={DocumentViewerStories.UnsupportedType} />
+
+### Props
+
+<Controls of={DocumentViewerStories.Pdf} />

--- a/packages/react-components-storybook/src/stories/DocumentViewer/DocumentViewer.mdx
+++ b/packages/react-components-storybook/src/stories/DocumentViewer/DocumentViewer.mdx
@@ -14,52 +14,9 @@
  * limitations under the License.
  */}
 
-import { Meta, Markdown, Canvas, Controls } from "@storybook/addon-docs/blocks";
-import * as DocumentViewerStories from "./DocumentViewer.stories";
+import { Meta, Markdown } from "@storybook/addon-docs/blocks";
 import documentViewerDocs from "@docs/DocumentViewer.md?raw";
 
 <Meta title="Components/DocumentViewer/Docs" tags={["beta"]}/>
 
 <Markdown>{documentViewerDocs}</Markdown>
-
-## Interactive Demos
-
-### PDF
-
-<Canvas of={DocumentViewerStories.Pdf} />
-
-### Image
-
-<Canvas of={DocumentViewerStories.Image} />
-
-### Markdown
-
-<Canvas of={DocumentViewerStories.Markdown} />
-
-### Video
-
-<Canvas of={DocumentViewerStories.Video} />
-
-### Excel
-
-<Canvas of={DocumentViewerStories.Excel} />
-
-### Email
-
-<Canvas of={DocumentViewerStories.Email} />
-
-### XML
-
-<Canvas of={DocumentViewerStories.Xml} />
-
-### TIFF
-
-<Canvas of={DocumentViewerStories.Tiff} />
-
-### Unsupported Type
-
-<Canvas of={DocumentViewerStories.UnsupportedType} />
-
-### Props
-
-<Controls of={DocumentViewerStories.Pdf} />

--- a/packages/react-components-storybook/src/stories/DocumentViewer/DocumentViewer.mdx
+++ b/packages/react-components-storybook/src/stories/DocumentViewer/DocumentViewer.mdx
@@ -20,13 +20,13 @@ import documentViewerDocs from "@docs/DocumentViewer.md?raw";
 
 <Meta title="Components/DocumentViewer/Docs" tags={["beta"]}/>
 
+# DocumentViewer
+
+<Canvas of={DocumentViewerStories.Pdf} />
+
 <Markdown>{documentViewerDocs}</Markdown>
 
 ## Interactive Demos
-
-### PDF
-
-<Canvas of={DocumentViewerStories.Pdf} />
 
 ### Image
 

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.mdx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.mdx
@@ -20,8 +20,6 @@ import filterListDocs from "@docs/FilterList.md?raw";
 
 <Meta title="Components/FilterList/Docs" tags={["beta"]}/>
 
-# FilterList
-
 <Canvas of={FilterListStories.Default} />
 
 <Markdown>{filterListDocs}</Markdown>

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.mdx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.mdx
@@ -1,0 +1,53 @@
+{/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */}
+
+import { Meta, Markdown, Canvas, Controls } from "@storybook/addon-docs/blocks";
+import * as FilterListStories from "./FilterList.stories";
+import filterListDocs from "@docs/FilterList.md?raw";
+
+<Meta title="Components/FilterList/Docs" tags={["beta"]}/>
+
+<Markdown>{filterListDocs}</Markdown>
+
+## Interactive Demos
+
+### Default
+
+<Canvas of={FilterListStories.Default} />
+
+### Combined with ObjectTable
+
+<Canvas of={FilterListStories.CombinedWithObjectTable} />
+
+### Add / Remove Filters
+
+<Canvas of={FilterListStories.AddFilterMode} />
+
+### Keyword Search
+
+<Canvas of={FilterListStories.KeywordSearch} />
+
+### Linked Property Filter
+
+<Canvas of={FilterListStories.CombinedWithLinkedFilter} />
+
+### Custom Filters
+
+<Canvas of={FilterListStories.WithCustomFilters} />
+
+### Props
+
+<Controls of={FilterListStories.Default} />

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.mdx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.mdx
@@ -20,13 +20,13 @@ import filterListDocs from "@docs/FilterList.md?raw";
 
 <Meta title="Components/FilterList/Docs" tags={["beta"]}/>
 
+# FilterList
+
+<Canvas of={FilterListStories.Default} />
+
 <Markdown>{filterListDocs}</Markdown>
 
 ## Interactive Demos
-
-### Default
-
-<Canvas of={FilterListStories.Default} />
 
 ### Combined with ObjectTable
 

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.mdx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.mdx
@@ -20,11 +20,13 @@ import filterListDocs from "@docs/FilterList.md?raw";
 
 <Meta title="Components/FilterList/Docs" tags={["beta"]}/>
 
-<Canvas of={FilterListStories.Default} />
-
 <Markdown>{filterListDocs}</Markdown>
 
 ## Interactive Demos
+
+### Default
+
+<Canvas of={FilterListStories.Default} />
 
 ### Combined with ObjectTable
 

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.mdx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.mdx
@@ -14,40 +14,9 @@
  * limitations under the License.
  */}
 
-import { Meta, Markdown, Canvas, Controls } from "@storybook/addon-docs/blocks";
-import * as FilterListStories from "./FilterList.stories";
+import { Meta, Markdown } from "@storybook/addon-docs/blocks";
 import filterListDocs from "@docs/FilterList.md?raw";
 
 <Meta title="Components/FilterList/Docs" tags={["beta"]}/>
 
 <Markdown>{filterListDocs}</Markdown>
-
-## Interactive Demos
-
-### Default
-
-<Canvas of={FilterListStories.Default} />
-
-### Combined with ObjectTable
-
-<Canvas of={FilterListStories.CombinedWithObjectTable} />
-
-### Add / Remove Filters
-
-<Canvas of={FilterListStories.AddFilterMode} />
-
-### Keyword Search
-
-<Canvas of={FilterListStories.KeywordSearch} />
-
-### Linked Property Filter
-
-<Canvas of={FilterListStories.CombinedWithLinkedFilter} />
-
-### Custom Filters
-
-<Canvas of={FilterListStories.WithCustomFilters} />
-
-### Props
-
-<Controls of={FilterListStories.Default} />

--- a/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.mdx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.mdx
@@ -1,0 +1,57 @@
+{/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */}
+
+import { Meta, Markdown, Canvas, Controls } from "@storybook/addon-docs/blocks";
+import * as ObjectTableStories from "./ObjectTable.stories";
+import objectTableDocs from "@docs/ObjectTable.md?raw";
+
+<Meta title="Components/ObjectTable/Docs" tags={["beta"]}/>
+
+<Markdown>{objectTableDocs}</Markdown>
+
+## Interactive Demos
+
+### Default
+
+<Canvas of={ObjectTableStories.Default} />
+
+### Single Selection
+
+<Canvas of={ObjectTableStories.SingleSelection} />
+
+### Multiple Selection
+
+<Canvas of={ObjectTableStories.MultipleSelection} />
+
+### With Context Menu
+
+<Canvas of={ObjectTableStories.WithContextMenu} />
+
+### Custom Column Widths
+
+<Canvas of={ObjectTableStories.CustomColumnWidths} />
+
+### With Default Sorting
+
+<Canvas of={ObjectTableStories.WithDefaultSorting} />
+
+### With Custom Column
+
+<Canvas of={ObjectTableStories.WithCustomColumn} />
+
+### Props
+
+<Controls of={ObjectTableStories.Default} />

--- a/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.mdx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.mdx
@@ -20,13 +20,13 @@ import objectTableDocs from "@docs/ObjectTable.md?raw";
 
 <Meta title="Components/ObjectTable/Docs" tags={["beta"]}/>
 
+# ObjectTable
+
+<Canvas of={ObjectTableStories.Default} />
+
 <Markdown>{objectTableDocs}</Markdown>
 
 ## Interactive Demos
-
-### Default
-
-<Canvas of={ObjectTableStories.Default} />
 
 ### Single Selection
 

--- a/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.mdx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.mdx
@@ -20,8 +20,6 @@ import objectTableDocs from "@docs/ObjectTable.md?raw";
 
 <Meta title="Components/ObjectTable/Docs" tags={["beta"]}/>
 
-# ObjectTable
-
 <Canvas of={ObjectTableStories.Default} />
 
 <Markdown>{objectTableDocs}</Markdown>

--- a/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.mdx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.mdx
@@ -20,11 +20,13 @@ import objectTableDocs from "@docs/ObjectTable.md?raw";
 
 <Meta title="Components/ObjectTable/Docs" tags={["beta"]}/>
 
-<Canvas of={ObjectTableStories.Default} />
-
 <Markdown>{objectTableDocs}</Markdown>
 
 ## Interactive Demos
+
+### Default
+
+<Canvas of={ObjectTableStories.Default} />
 
 ### Single Selection
 

--- a/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.mdx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.mdx
@@ -14,44 +14,9 @@
  * limitations under the License.
  */}
 
-import { Meta, Markdown, Canvas, Controls } from "@storybook/addon-docs/blocks";
-import * as ObjectTableStories from "./ObjectTable.stories";
+import { Meta, Markdown } from "@storybook/addon-docs/blocks";
 import objectTableDocs from "@docs/ObjectTable.md?raw";
 
 <Meta title="Components/ObjectTable/Docs" tags={["beta"]}/>
 
 <Markdown>{objectTableDocs}</Markdown>
-
-## Interactive Demos
-
-### Default
-
-<Canvas of={ObjectTableStories.Default} />
-
-### Single Selection
-
-<Canvas of={ObjectTableStories.SingleSelection} />
-
-### Multiple Selection
-
-<Canvas of={ObjectTableStories.MultipleSelection} />
-
-### With Context Menu
-
-<Canvas of={ObjectTableStories.WithContextMenu} />
-
-### Custom Column Widths
-
-<Canvas of={ObjectTableStories.CustomColumnWidths} />
-
-### With Default Sorting
-
-<Canvas of={ObjectTableStories.WithDefaultSorting} />
-
-### With Custom Column
-
-<Canvas of={ObjectTableStories.WithCustomColumn} />
-
-### Props
-
-<Controls of={ObjectTableStories.Default} />


### PR DESCRIPTION
## Summary
- Add MDX documentation pages for FilterList, DocumentViewer, ActionForm, and CbacPicker
- Import existing `docs/*.md` files via `@docs` alias and render with `<Markdown>`, keeping docs in sync with the source instead of duplicating content
- Add interactive story demos (`<Canvas>`) and props tables (`<Controls>`) below the imported docs
- CbacPicker has inline content since no `docs/*.md` exists for it yet

## Test plan
- [ ] Verify each docs page renders in the Storybook sidebar under Components/{Name}/Docs
- [ ] Verify the beta badge appears on each component folder
- [ ] Verify interactive Canvas demos load and are interactive
- [ ] Verify Props tables render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)