### PR TITLE
fix failed to load null count when no cross-filter is active

### DIFF
--- a/.changeset/filter-null-count-empty-where.md
+++ b/.changeset/filter-null-count-empty-where.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Fix "Failed to load null count" error on date and number range filters when no cross-filter is active. The null-count aggregation no longer wraps an empty where clause inside `$and`, which the aggregation API rejects.

--- a/packages/react-components/src/filter-list/__tests__/DateRangeFilterInput.test.tsx
+++ b/packages/react-components/src/filter-list/__tests__/DateRangeFilterInput.test.tsx
@@ -89,4 +89,27 @@ describe("DateRangeFilterInput", () => {
     expect(andClauses).toContainEqual({ createdAt: { $isNull: true } });
     expect(andClauses).toContainEqual(whereClause);
   });
+
+  it("uses the bare null-check when whereClause is empty", () => {
+    const whereClause = {} as WhereClause<typeof MockObjectType>;
+
+    render(
+      <DateRangeFilterInput
+        objectType={MockObjectType}
+        propertyKey="createdAt"
+        filterState={undefined}
+        onFilterStateChanged={vi.fn()}
+        whereClause={whereClause}
+      />,
+    );
+
+    const calls = vi.mocked(useOsdkAggregation).mock.calls;
+    const nullCountCall = calls.find(
+      (c) => (c[1].aggregate as Record<string, unknown>).$groupBy == null,
+    );
+    expect(nullCountCall).toBeDefined();
+    // An empty {} inside $and is rejected by the aggregation API, so the
+    // null count query must fall back to the bare null-check predicate.
+    expect(nullCountCall![1].where).toEqual({ createdAt: { $isNull: true } });
+  });
 });

--- a/packages/react-components/src/filter-list/__tests__/NumberRangeFilterInput.test.tsx
+++ b/packages/react-components/src/filter-list/__tests__/NumberRangeFilterInput.test.tsx
@@ -88,4 +88,27 @@ describe("NumberRangeFilterInput", () => {
     expect(andClauses).toContainEqual({ score: { $isNull: true } });
     expect(andClauses).toContainEqual(whereClause);
   });
+
+  it("uses the bare null-check when whereClause is empty", () => {
+    const whereClause = {} as WhereClause<typeof MockObjectType>;
+
+    render(
+      <NumberRangeFilterInput
+        objectType={MockObjectType}
+        propertyKey="score"
+        filterState={undefined}
+        onFilterStateChanged={vi.fn()}
+        whereClause={whereClause}
+      />,
+    );
+
+    const calls = vi.mocked(useOsdkAggregation).mock.calls;
+    const nullCountCall = calls.find(
+      (c) => (c[1].aggregate as Record<string, unknown>).$groupBy == null,
+    );
+    expect(nullCountCall).toBeDefined();
+    // An empty {} inside $and is rejected by the aggregation API, so the
+    // null count query must fall back to the bare null-check predicate.
+    expect(nullCountCall![1].where).toEqual({ score: { $isNull: true } });
+  });
 });

--- a/packages/react-components/src/filter-list/inputs/DateRangeFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/DateRangeFilterInput.tsx
@@ -23,7 +23,7 @@ import type { FilterState } from "../FilterListItemApi.js";
 import {
   createGroupByAggregateOptions,
   createNullCountAggregateOptions,
-  createNullWhereClause,
+  createNullCountWhereClause,
 } from "../utils/aggregationHelpers.js";
 
 interface DateRangeFilterInputProps<Q extends ObjectTypeDefinition> {
@@ -121,10 +121,7 @@ function DateRangeFilterInputInner<Q extends ObjectTypeDefinition>({
   // Combine null-check with cross-filter where clause so the null count
   // reflects the filtered dataset, not the full dataset
   const nullCountWhereClause = useMemo(
-    () =>
-      ({
-        $and: [createNullWhereClause<Q>(propertyKey), whereClause],
-      }) as WhereClause<Q>,
+    () => createNullCountWhereClause<Q>(propertyKey, whereClause),
     [propertyKey, whereClause],
   );
 

--- a/packages/react-components/src/filter-list/inputs/DateRangeFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/DateRangeFilterInput.tsx
@@ -118,8 +118,6 @@ function DateRangeFilterInputInner<Q extends ObjectTypeDefinition>({
     [],
   );
 
-  // Combine null-check with cross-filter where clause so the null count
-  // reflects the filtered dataset, not the full dataset
   const nullCountWhereClause = useMemo(
     () => createNullCountWhereClause<Q>(propertyKey, whereClause),
     [propertyKey, whereClause],

--- a/packages/react-components/src/filter-list/inputs/NumberRangeFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/NumberRangeFilterInput.tsx
@@ -131,8 +131,6 @@ function NumberRangeFilterInputInner<Q extends ObjectTypeDefinition>({
     [],
   );
 
-  // Combine null-check with cross-filter where clause so the null count
-  // reflects the filtered dataset, not the full dataset
   const nullCountWhereClause = useMemo(
     () => createNullCountWhereClause<Q>(propertyKey, whereClause),
     [propertyKey, whereClause],

--- a/packages/react-components/src/filter-list/inputs/NumberRangeFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/NumberRangeFilterInput.tsx
@@ -23,7 +23,7 @@ import type { FilterState } from "../FilterListItemApi.js";
 import {
   createGroupByAggregateOptions,
   createNullCountAggregateOptions,
-  createNullWhereClause,
+  createNullCountWhereClause,
 } from "../utils/aggregationHelpers.js";
 
 interface NumberRangeFilterInputProps<Q extends ObjectTypeDefinition> {
@@ -134,10 +134,7 @@ function NumberRangeFilterInputInner<Q extends ObjectTypeDefinition>({
   // Combine null-check with cross-filter where clause so the null count
   // reflects the filtered dataset, not the full dataset
   const nullCountWhereClause = useMemo(
-    () =>
-      ({
-        $and: [createNullWhereClause<Q>(propertyKey), whereClause],
-      }) as WhereClause<Q>,
+    () => createNullCountWhereClause<Q>(propertyKey, whereClause),
     [propertyKey, whereClause],
   );
 

--- a/packages/react-components/src/filter-list/utils/aggregationHelpers.ts
+++ b/packages/react-components/src/filter-list/utils/aggregationHelpers.ts
@@ -48,3 +48,22 @@ export function createNullWhereClause<
 >(propertyKey: string): WhereClause<Q> {
   return { [propertyKey]: { $isNull: true } } as WhereClause<Q>;
 }
+
+/**
+ * Builds the where clause for a null-count aggregation, combining the
+ * property null-check with the cross-filter where clause.
+ *
+ * The cross-filter clause is only included when it is non-empty. An empty
+ * `{}` clause inside an `$and` is rejected by the aggregation API ("Cannot
+ * convert an empty where clause to a filter"), so when no cross-filter is
+ * active we return the bare null-check predicate.
+ */
+export function createNullCountWhereClause<
+  Q extends ObjectTypeDefinition,
+>(propertyKey: string, crossFilterWhereClause: WhereClause<Q>): WhereClause<Q> {
+  const nullClause = createNullWhereClause<Q>(propertyKey);
+  if (Object.keys(crossFilterWhereClause).length === 0) {
+    return nullClause;
+  }
+  return { $and: [nullClause, crossFilterWhereClause] } as WhereClause<Q>;
+}

--- a/packages/react-components/src/filter-list/utils/aggregationHelpers.ts
+++ b/packages/react-components/src/filter-list/utils/aggregationHelpers.ts
@@ -54,9 +54,8 @@ export function createNullWhereClause<
  * property null-check with the cross-filter where clause.
  *
  * The cross-filter clause is only included when it is non-empty. An empty
- * `{}` clause inside an `$and` is rejected by the aggregation API ("Cannot
- * convert an empty where clause to a filter"), so when no cross-filter is
- * active we return the bare null-check predicate.
+ * `{}` clause inside an `$and` is rejected by the aggregation API, so when no
+ * cross-filter is active we return the bare null-check predicate.
  */
 export function createNullCountWhereClause<
   Q extends ObjectTypeDefinition,


### PR DESCRIPTION
date and number range filters showed "Failed to load null count" whenever no cross-filter was active

• when there are no other active filters the cross-filter where clause is an empty `{}`, and wrapping it in `$and` produced `{ $and: [nullCheck, {}] }` which the aggregation API rejects with "Cannot convert an empty where clause to a filter"
• added `createNullCountWhereClause` helper to return a null-check predicate when the cross-filter is empty and only builds the `$and` when a real cross-filter exists so we don't end up in this situation

