### PR TITLE
Fix static FilterList value colors

### DIFF
--- a/.changeset/static-filter-values-color.md
+++ b/.changeset/static-filter-values-color.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Fix static FilterList values rendering as filtered out.

--- a/.changeset/static-filter-values-color.md
+++ b/.changeset/static-filter-values-color.md
@@ -2,4 +2,4 @@
 "@osdk/react-components": patch
 ---
 
-Fix static FilterList values rendering as filtered out.
+Fix static FilterList values rendering as filtered out and keep filtered-out values accessible.

--- a/packages/react-components/docs/CSSVariables.md
+++ b/packages/react-components/docs/CSSVariables.md
@@ -960,10 +960,9 @@ Canonical "No value" styling used by the shared `NoValueLabel` component across 
 
 Styling for count=0 muted rows surfaced by `showFilteredOutValues`. Applied to listogram rows via `[data-filtered-out]` and to multi-select items via the `filteredOutItem` class.
 
-| Variable                                  | Default Value                        | Description                         |
-| ----------------------------------------- | ------------------------------------ | ----------------------------------- |
-| `--osdk-filter-filtered-out-item-opacity` | `0.5`                                | Opacity for filtered-out facet rows |
-| `--osdk-filter-filtered-out-item-color`   | `var(--osdk-typography-color-muted)` | Text color for filtered-out rows    |
+| Variable                                | Default Value                        | Description                      |
+| --------------------------------------- | ------------------------------------ | -------------------------------- |
+| `--osdk-filter-filtered-out-item-color` | `var(--osdk-typography-color-muted)` | Text color for filtered-out rows |
 
 #### Filter Popover Tokens
 

--- a/packages/react-components/src/filter-list/base/inputs/ListogramInput.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/ListogramInput.module.css
@@ -81,9 +81,7 @@
   gap: var(--osdk-filter-null-label-gap);
 }
 
-/* Muted styling for filtered-out (count=0) rows. */
 .row[data-filtered-out] {
-  opacity: var(--osdk-filter-filtered-out-item-opacity);
   color: var(--osdk-filter-filtered-out-item-color);
 }
 

--- a/packages/react-components/src/filter-list/base/inputs/ListogramInput.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/ListogramInput.module.css
@@ -48,6 +48,10 @@
 }
 
 .row {
+  --osdk-filter-listogram-row-count-color: var(
+    --osdk-filter-listogram-count-color
+  );
+
   display: flex;
   align-items: center;
   gap: var(--osdk-filter-listogram-row-gap);
@@ -56,6 +60,7 @@
   background: transparent;
   cursor: pointer;
   border-radius: var(--osdk-filter-listogram-row-border-radius);
+  color: var(--osdk-filter-listogram-label-color);
   text-align: left;
   width: 100%;
   transition: background-color var(--osdk-filter-listogram-row-transition);
@@ -82,6 +87,10 @@
 }
 
 .row[data-filtered-out] {
+  --osdk-filter-listogram-row-count-color: var(
+    --osdk-filter-filtered-out-item-color
+  );
+
   color: var(--osdk-filter-filtered-out-item-color);
 }
 
@@ -89,7 +98,7 @@
   flex: 1;
   font-family: var(--osdk-filter-listogram-label-font-family);
   font-size: var(--osdk-filter-listogram-label-font-size);
-  color: var(--osdk-filter-listogram-label-color);
+  color: currentColor;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -153,7 +162,7 @@
   font-family: var(--osdk-filter-listogram-count-font-family);
   font-size: var(--osdk-filter-listogram-count-font-size);
   font-variant-numeric: tabular-nums;
-  color: var(--osdk-filter-listogram-count-color);
+  color: var(--osdk-filter-listogram-row-count-color);
   min-width: 3ch;
   text-align: right;
 }

--- a/packages/react-components/src/filter-list/base/inputs/ListogramInput.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/ListogramInput.module.css
@@ -48,10 +48,6 @@
 }
 
 .row {
-  --osdk-filter-listogram-row-count-color: var(
-    --osdk-filter-listogram-count-color
-  );
-
   display: flex;
   align-items: center;
   gap: var(--osdk-filter-listogram-row-gap);
@@ -60,7 +56,6 @@
   background: transparent;
   cursor: pointer;
   border-radius: var(--osdk-filter-listogram-row-border-radius);
-  color: var(--osdk-filter-listogram-label-color);
   text-align: left;
   width: 100%;
   transition: background-color var(--osdk-filter-listogram-row-transition);
@@ -86,8 +81,12 @@
   gap: var(--osdk-filter-null-label-gap);
 }
 
+/* Muted styling for filtered-out (count=0) rows. */
 .row[data-filtered-out] {
-  --osdk-filter-listogram-row-count-color: var(
+  --osdk-filter-listogram-count-color: var(
+    --osdk-filter-filtered-out-item-color
+  );
+  --osdk-filter-listogram-label-color: var(
     --osdk-filter-filtered-out-item-color
   );
 
@@ -98,7 +97,7 @@
   flex: 1;
   font-family: var(--osdk-filter-listogram-label-font-family);
   font-size: var(--osdk-filter-listogram-label-font-size);
-  color: currentColor;
+  color: var(--osdk-filter-listogram-label-color);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -162,7 +161,7 @@
   font-family: var(--osdk-filter-listogram-count-font-family);
   font-size: var(--osdk-filter-listogram-count-font-size);
   font-variant-numeric: tabular-nums;
-  color: var(--osdk-filter-listogram-row-count-color);
+  color: var(--osdk-filter-listogram-count-color);
   min-width: 3ch;
   text-align: right;
 }

--- a/packages/react-components/src/filter-list/base/inputs/ListogramInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/ListogramInput.tsx
@@ -43,6 +43,7 @@ interface ListogramInputProps {
   displayMode?: ListogramDisplayMode;
   showCount?: boolean;
   isExcluding?: boolean;
+  showFilteredOutValues?: boolean;
   className?: string;
   style?: React.CSSProperties;
   maxVisibleItems?: number;
@@ -61,6 +62,7 @@ function ListogramInputInner({
   displayMode = "full",
   showCount = true,
   isExcluding,
+  showFilteredOutValues = true,
   className,
   style,
   maxVisibleItems,
@@ -138,7 +140,9 @@ function ListogramInputInner({
             const perRowColor = colorMap?.[value];
             const isEmpty = isEmptyValue(value);
 
-            const isFilteredOut = count === 0 && !selectedSet.has(value);
+            const isFilteredOut = showFilteredOutValues
+              && count === 0
+              && !selectedSet.has(value);
             return (
               <Button
                 key={value}

--- a/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.module.css
@@ -43,15 +43,13 @@
   font-family: var(--osdk-filter-multiselect-count-font-family);
   font-size: var(--osdk-filter-multiselect-count-font-size);
   font-variant-numeric: tabular-nums;
-  color: var(
-    --osdk-filter-multiselect-item-count-color,
-    var(--osdk-filter-multiselect-count-color)
-  );
+  color: var(--osdk-filter-multiselect-count-color);
   flex-shrink: 0;
 }
 
+/* Muted styling for filtered-out (count=0) entries. */
 .filteredOutItem {
-  --osdk-filter-multiselect-item-count-color: var(
+  --osdk-filter-multiselect-count-color: var(
     --osdk-filter-filtered-out-item-color
   );
 

--- a/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.module.css
@@ -47,9 +47,7 @@
   flex-shrink: 0;
 }
 
-/* Muted styling for filtered-out (count=0) entries. */
 .filteredOutItem {
-  opacity: var(--osdk-filter-filtered-out-item-opacity);
   color: var(--osdk-filter-filtered-out-item-color);
 }
 

--- a/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.module.css
@@ -43,11 +43,18 @@
   font-family: var(--osdk-filter-multiselect-count-font-family);
   font-size: var(--osdk-filter-multiselect-count-font-size);
   font-variant-numeric: tabular-nums;
-  color: var(--osdk-filter-multiselect-count-color);
+  color: var(
+    --osdk-filter-multiselect-item-count-color,
+    var(--osdk-filter-multiselect-count-color)
+  );
   flex-shrink: 0;
 }
 
 .filteredOutItem {
+  --osdk-filter-multiselect-item-count-color: var(
+    --osdk-filter-filtered-out-item-color
+  );
+
   color: var(--osdk-filter-filtered-out-item-color);
 }
 

--- a/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.tsx
@@ -49,6 +49,7 @@ interface MultiSelectInputProps {
   style?: React.CSSProperties;
   placeholder?: string;
   showCounts?: boolean;
+  showFilteredOutValues?: boolean;
   ariaLabel?: string;
   renderValue?: (value: string) => React.ReactNode;
   layout?: MultiSelectInputLayout;
@@ -64,6 +65,7 @@ function MultiSelectInputInner({
   style,
   placeholder = "Select values...",
   showCounts = true,
+  showFilteredOutValues = true,
   ariaLabel = "Search values",
   renderValue,
   layout = "dropdown",
@@ -103,7 +105,9 @@ function MultiSelectInputInner({
     (value: string) => {
       const isEmpty = isEmptyValue(value);
       const count = countByValue.get(value) ?? 0;
-      const isFilteredOut = count === 0 && !selectedSet.has(value);
+      const isFilteredOut = showFilteredOutValues
+        && count === 0
+        && !selectedSet.has(value);
       return (
         <Combobox.Item
           key={value}
@@ -124,7 +128,7 @@ function MultiSelectInputInner({
         </Combobox.Item>
       );
     },
-    [countByValue, selectedSet, showCounts, renderValue],
+    [countByValue, selectedSet, showCounts, showFilteredOutValues, renderValue],
   );
 
   const renderChips = useCallback(

--- a/packages/react-components/src/filter-list/inputs/StaticValuesFilterInput.tsx
+++ b/packages/react-components/src/filter-list/inputs/StaticValuesFilterInput.tsx
@@ -33,6 +33,10 @@ import {
   coerceToStringArray,
 } from "../utils/coerceFilterValue.js";
 
+// Static values are caller-provided options, not aggregation results, so their
+// zero counts should not be interpreted as values filtered out by another facet.
+const SHOW_FILTERED_OUT_VALUES = false;
+
 interface StaticValuesFilterInputProps<Q extends ObjectTypeDefinition> {
   /** The static values filter definition containing values and component config */
   definition: StaticValuesFilterDefinition<Q>;
@@ -196,6 +200,7 @@ function StaticValuesFilterInputInner<Q extends ObjectTypeDefinition>({
             displayMode={definition.listogramConfig?.displayMode}
             showCount={definition.showCount}
             isExcluding={isExcluding}
+            showFilteredOutValues={SHOW_FILTERED_OUT_VALUES}
             maxVisibleItems={definition.listogramConfig?.maxVisibleItems ?? 5}
             searchQuery={searchQuery}
             renderValue={definition.renderValue}
@@ -241,6 +246,7 @@ function StaticValuesFilterInputInner<Q extends ObjectTypeDefinition>({
             selectedValues={select.selectedValues}
             onChange={select.handleMultiChange}
             showCounts={definition.showCount}
+            showFilteredOutValues={SHOW_FILTERED_OUT_VALUES}
             ariaLabel={`Search ${definition.key} values`}
             renderValue={definition.renderValue}
             layout={layout}

--- a/packages/react-components/src/filter-list/inputs/__tests__/filteredOutValues.test.tsx
+++ b/packages/react-components/src/filter-list/inputs/__tests__/filteredOutValues.test.tsx
@@ -30,10 +30,12 @@ import type {
   LinkedFilter,
   LinkedPropertyFilterDefinition,
 } from "../../types/LinkedFilterTypes.js";
+import type { StaticValuesFilterDefinition } from "../../types/StaticValuesTypes.js";
 import { LinkedPropertyInput } from "../LinkedPropertyInput.js";
 import { ListogramFilterInput } from "../ListogramFilterInput.js";
 import { MultiSelectFilterInput } from "../MultiSelectFilterInput.js";
 import { SingleSelectFilterInput } from "../SingleSelectFilterInput.js";
+import { StaticValuesFilterInput } from "../StaticValuesFilterInput.js";
 
 vi.mock("@osdk/react", () => ({
   useOsdkAggregation: vi.fn(),
@@ -142,6 +144,67 @@ describe("filtered-out initialFilterStates values", () => {
       expect(screen.queryByText("No options available")).toBeNull();
       expect(screen.getByLabelText("Select name")).toBeDefined();
     });
+  });
+});
+
+describe("STATIC_VALUES filters", () => {
+  it("does not mark unselected static listogram values as filtered out", () => {
+    const definition = {
+      type: "STATIC_VALUES",
+      key: "department",
+      filterComponent: "LISTOGRAM",
+      values: ["Marketing", "Operations"],
+      filterState: { type: "EXACT_MATCH", values: [] },
+    } satisfies StaticValuesFilterDefinition<
+      typeof MockObjectType,
+      "LISTOGRAM"
+    >;
+
+    render(
+      <StaticValuesFilterInput
+        definition={definition}
+        filterState={definition.filterState}
+        onFilterStateChanged={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /Marketing/ }).hasAttribute(
+        "data-filtered-out",
+      ),
+    ).toBe(false);
+    expect(
+      screen.getByRole("button", { name: /Operations/ }).hasAttribute(
+        "data-filtered-out",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not style unselected static multi-select values as filtered out", () => {
+    const definition = {
+      type: "STATIC_VALUES",
+      key: "team",
+      filterComponent: "MULTI_SELECT",
+      values: ["Alpha", "Beta"],
+      filterState: { type: "SELECT", selectedValues: [] },
+    } satisfies StaticValuesFilterDefinition<
+      typeof MockObjectType,
+      "MULTI_SELECT"
+    >;
+
+    render(
+      <StaticValuesFilterInput
+        definition={definition}
+        filterState={definition.filterState}
+        onFilterStateChanged={vi.fn()}
+        layout="inline"
+      />,
+    );
+
+    expect(screen.getByRole("option", { name: /Alpha/ }).className).not
+      .toContain("filteredOutItem");
+    expect(screen.getByRole("option", { name: /Beta/ }).className).not
+      .toContain("filteredOutItem");
   });
 });
 

--- a/packages/react-components/src/tokens/component-tokens/filter-list.css
+++ b/packages/react-components/src/tokens/component-tokens/filter-list.css
@@ -24,7 +24,6 @@
 
   /* Filtered-out entries: values present in the wider scope but absent from
      the narrowed scope. Rendered as count=0 muted rows. */
-  --osdk-filter-filtered-out-item-opacity: 0.5;
   --osdk-filter-filtered-out-item-color: var(--osdk-typography-color-muted);
 
   /* Filter List Header */


### PR DESCRIPTION
## Summary
- prevent static FilterList values from being treated as filtered-out count=0 aggregation rows
- keep filtered-out rows/options readable by removing row-level opacity while preserving muted text color
- update filtered-out token docs and regression coverage

## Storybook stories to test
- `Components/FilterList / With static values`
  - Static listogram values should render at normal contrast (not greyed out).
  - Open the Team multi-select dropdown; options should render normally.
- `Components/FilterList / Combined linked + direct filters (zero-count filtered-out rows)`
  - Select a Manager Name such as Margaret Jackson.
  - Department / Location City count=0 filtered-out values should remain readable and pass color-contrast checks.

## Before
<img width="357" height="641" alt="Screenshot 2026-06-01 at 11 48 54" src="https://github.com/user-attachments/assets/0bd45302-88ab-4839-a745-99de0326be02" />

## After
<img width="357" height="641" alt="Screenshot 2026-06-01 at 11 48 16" src="https://github.com/user-attachments/assets/3c993308-dc29-45fd-a498-c7dedbcd947b" />

## Verification
- `pnpm --dir=packages/react-components exec vitest run src/filter-list/inputs/__tests__/filteredOutValues.test.tsx`
- `pnpm turbo typecheck --filter=@osdk/react-components`
- Storybook visual check for the stories above
- axe color-contrast check in Storybook after selecting a Manager Name
