### PR TITLE
Faux foundry - Add support for object set references

### DIFF
--- a/.changeset/beige-fans-do.md
+++ b/.changeset/beige-fans-do.md
@@ -1,0 +1,5 @@
+---
+"@osdk/faux": minor
+---
+
+Adds support for object set references in faux

--- a/packages/faux/src/FauxFoundry/FauxDataStore.test.ts
+++ b/packages/faux/src/FauxFoundry/FauxDataStore.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type * as OntologiesV2 from "@osdk/foundry.ontologies";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { BaseServerObject } from "./BaseServerObject.js";
 import { FauxAttachmentStore } from "./FauxAttachmentStore.js";
@@ -125,6 +126,13 @@ describe(FauxDataStore, () => {
               description: "leadId",
               typeClasses: [],
             },
+            status: {
+              dataType: { type: "string" },
+              rid: "ri.status",
+              displayName: "status",
+              description: "status",
+              typeClasses: [],
+            },
           },
           status: "ACTIVE",
           titleProperty: "id",
@@ -221,6 +229,115 @@ describe(FauxDataStore, () => {
         employeeId,
         "contributedProjects",
       ),
+    });
+
+    describe("object set references", () => {
+      const activeEmployeesRid =
+        "ri.object-set.active-employees" as OntologiesV2.ObjectSetRid;
+
+      const activeEmployeesObjectSet = {
+        type: "filter",
+        objectSet: {
+          type: "base",
+          objectType: "Employee",
+        },
+        where: {
+          type: "eq",
+          field: "status",
+          value: "ACTIVE",
+        },
+      } as OntologiesV2.ObjectSet;
+
+      it("registers and returns object sets by rid", () => {
+        fauxDataStore.registerObjectSet(
+          activeEmployeesRid,
+          activeEmployeesObjectSet,
+        );
+
+        expect(fauxDataStore.getObjectSetOrThrow(activeEmployeesRid)).toBe(
+          activeEmployeesObjectSet,
+        );
+      });
+
+      it("overwrites an object set registered with the same rid", () => {
+        const inactiveEmployeesObjectSet = {
+          type: "filter",
+          objectSet: {
+            type: "base",
+            objectType: "Employee",
+          },
+          where: {
+            type: "eq",
+            field: "status",
+            value: "INACTIVE",
+          },
+        } as OntologiesV2.ObjectSet;
+
+        fauxDataStore.registerObjectSet(
+          activeEmployeesRid,
+          activeEmployeesObjectSet,
+        );
+        fauxDataStore.registerObjectSet(
+          activeEmployeesRid,
+          inactiveEmployeesObjectSet,
+        );
+
+        expect(fauxDataStore.getObjectSetOrThrow(activeEmployeesRid)).toBe(
+          inactiveEmployeesObjectSet,
+        );
+      });
+
+      it("throws ObjectSetNotFound for unknown object set rids", () => {
+        expect(() =>
+          fauxDataStore.getObjectSetOrThrow(
+            "ri.object-set.missing",
+          )
+        ).toThrow(
+          "NOT_FOUND ObjectSetNotFound {\"objectSetRid\":\"ri.object-set.missing\"}",
+        );
+      });
+
+      it("loads objects from a registered object set reference", () => {
+        const { a, b, c } = employees;
+        fauxDataStore.registerObject({ ...a, status: "ACTIVE" });
+        fauxDataStore.registerObject({ ...b, status: "INACTIVE" });
+        fauxDataStore.registerObject({ ...c, status: "ACTIVE" });
+        fauxDataStore.registerObjectSet(
+          activeEmployeesRid,
+          activeEmployeesObjectSet,
+        );
+
+        const page = fauxDataStore.getObjectsFromObjectSet({
+          objectSet: {
+            type: "reference",
+            reference: activeEmployeesRid,
+          },
+          select: [],
+          selectV2: [{
+            type: "property",
+            apiName: "id",
+          }, {
+            type: "property",
+            apiName: "status",
+          }],
+        });
+
+        expect(page.totalCount).toBe("2");
+        expect(page.data).toEqual([
+          {
+            __apiName: "Employee",
+            __primaryKey: "a",
+            id: "a",
+            status: "ACTIVE",
+          },
+          {
+            __apiName: "Employee",
+            __primaryKey: "c",
+            id: "c",
+            status: "ACTIVE",
+          },
+        ]);
+      });
     });
 
     it("should work in the happy paths", () => {

--- a/packages/faux/src/FauxFoundry/FauxDataStore.ts
+++ b/packages/faux/src/FauxFoundry/FauxDataStore.ts
@@ -26,7 +26,11 @@ import { randomUUID } from "node:crypto";
 import { inspect } from "node:util";
 import invariant from "tiny-invariant";
 import type { ReadonlyDeep } from "type-fest";
-import { InvalidRequest, ObjectNotFoundError } from "../errors.js";
+import {
+  InvalidRequest,
+  ObjectNotFoundError,
+  ObjectSetNotFoundError,
+} from "../errors.js";
 import { subSelectProperties } from "../filterObjects.js";
 import { getPaginationParamsFromRequest } from "../handlers/util/getPaginationParams.js";
 import { OpenApiCallError } from "../handlers/util/handleOpenApiCall.js";
@@ -139,6 +143,11 @@ export class FauxDataStore {
   #manyLinks = new DefaultMap(
     (_objectLocator: ObjectLocator) => new SetMultiMap<string, ObjectLocator>(),
   );
+
+  #objectSets = new Map<
+    OntologiesV2.ObjectSetRid,
+    OntologiesV2.ObjectSet
+  >();
 
   #fauxOntology: FauxOntology;
 
@@ -670,6 +679,28 @@ export class FauxDataStore {
     return mediaRef;
   }
 
+  registerObjectSet(
+    objectSetRid: OntologiesV2.ObjectSetRid,
+    objectSet: OntologiesV2.ObjectSet,
+  ): void {
+    this.#objectSets.set(objectSetRid, objectSet);
+  }
+
+  getObjectSetOrThrow(
+    objectSetRid: OntologiesV2.ObjectSetRid,
+  ): OntologiesV2.ObjectSet {
+    const objectSet = this.#objectSets.get(objectSetRid);
+
+    if (objectSet == null) {
+      throw new OpenApiCallError(
+        404,
+        ObjectSetNotFoundError(objectSetRid),
+      );
+    }
+
+    return objectSet;
+  }
+
   getMediaOrThrow(
     objectType: OntologiesV2.ObjectTypeApiName,
     primaryKey: string,
@@ -891,7 +922,11 @@ export class FauxDataStore {
     const loadPropertySecurities = parsedBody.loadPropertySecurities ?? false;
     // when we have interfaces in here, we have a little trick for
     // caching off the important properties
-    let objects = getObjectsFromSet(this, parsedBody.objectSet, undefined);
+    let objects = getObjectsFromSet(
+      this,
+      parsedBody.objectSet,
+      undefined,
+    );
 
     let propertySecuritiesLocator: ObjectLocator | undefined;
     if (loadPropertySecurities) {

--- a/packages/faux/src/FauxFoundry/getObjectsFromSet.test.ts
+++ b/packages/faux/src/FauxFoundry/getObjectsFromSet.test.ts
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type * as OntologiesV2 from "@osdk/foundry.ontologies";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { BaseServerObject } from "./BaseServerObject.js";
+import { FauxAttachmentStore } from "./FauxAttachmentStore.js";
+import { FauxDataStore } from "./FauxDataStore.js";
+import { FauxOntology } from "./FauxOntology.js";
+import { getObjectsFromSet } from "./getObjectsFromSet.js";
+
+describe(getObjectsFromSet, () => {
+  let fauxDataStore: FauxDataStore;
+
+  const activeEmployeesRid: OntologiesV2.ObjectSetRid =
+    "ri.object-set.active-employees";
+  const nestedActiveEmployeesRid: OntologiesV2.ObjectSetRid =
+    "ri.object-set.nested-active-employees";
+
+  const employeeObjects: BaseServerObject[] = [
+    {
+      __apiName: "Employee",
+      __primaryKey: "a",
+      __rid: "ri.employee.a",
+      id: "a",
+      status: "ACTIVE",
+      level: 1,
+    },
+    {
+      __apiName: "Employee",
+      __primaryKey: "b",
+      __rid: "ri.employee.b",
+      id: "b",
+      status: "INACTIVE",
+      level: 2,
+    },
+    {
+      __apiName: "Employee",
+      __primaryKey: "c",
+      __rid: "ri.employee.c",
+      id: "c",
+      status: "ACTIVE",
+      level: 3,
+    },
+  ];
+
+  const activeEmployeesObjectSet: OntologiesV2.ObjectSet = {
+    type: "filter",
+    objectSet: {
+      type: "base",
+      objectType: "Employee",
+    },
+    where: {
+      type: "eq",
+      field: "status",
+      value: "ACTIVE",
+    },
+  };
+
+  beforeEach(() => {
+    const fauxOntology = new FauxOntology({
+      apiName: "foo",
+      description: "foo",
+      displayName: "foo",
+      rid: "ri.foo",
+    });
+    fauxDataStore = new FauxDataStore(
+      fauxOntology,
+      new FauxAttachmentStore(),
+      true,
+    );
+
+    fauxOntology.registerObjectType({
+      implementsInterfaces: [],
+      implementsInterfaces2: {},
+      linkTypes: [],
+      objectType: {
+        apiName: "Employee",
+        description: "Employee",
+        displayName: "Employee",
+        rid: "ri.Employee",
+        icon: {
+          color: "#000000",
+          name: "whoCares",
+          type: "blueprint",
+        },
+        pluralDisplayName: "Employees",
+        primaryKey: "id",
+        properties: {
+          id: {
+            dataType: { type: "string" },
+            rid: "ri.id",
+            displayName: "id",
+            description: "id",
+            typeClasses: [],
+          },
+          status: {
+            dataType: { type: "string" },
+            rid: "ri.status",
+            displayName: "status",
+            description: "status",
+            typeClasses: [],
+          },
+          level: {
+            dataType: { type: "integer" },
+            rid: "ri.level",
+            displayName: "level",
+            description: "level",
+            typeClasses: [],
+          },
+        },
+        status: "ACTIVE",
+        titleProperty: "id",
+      },
+      sharedPropertyTypeMapping: {},
+    });
+
+    for (const employee of employeeObjects) {
+      fauxDataStore.registerObject(employee);
+    }
+  });
+
+  const ids = (objects: BaseServerObject[]) => objects.map(o => o.id);
+
+  it("resolves a reference object set from the data store", () => {
+    fauxDataStore.registerObjectSet(
+      activeEmployeesRid,
+      activeEmployeesObjectSet,
+    );
+
+    expect(ids(getObjectsFromSet(
+      fauxDataStore,
+      {
+        type: "reference",
+        reference: activeEmployeesRid,
+      },
+      undefined,
+    ))).toEqual(["a", "c"]);
+  });
+
+  it("resolves nested reference object sets", () => {
+    fauxDataStore.registerObjectSet(
+      activeEmployeesRid,
+      activeEmployeesObjectSet,
+    );
+    fauxDataStore.registerObjectSet(
+      nestedActiveEmployeesRid,
+      {
+        type: "reference",
+        reference: activeEmployeesRid,
+      },
+    );
+
+    expect(ids(getObjectsFromSet(
+      fauxDataStore,
+      {
+        type: "reference",
+        reference: nestedActiveEmployeesRid,
+      },
+      undefined,
+    ))).toEqual(["a", "c"]);
+  });
+
+  it("supports references inside composed object sets", () => {
+    fauxDataStore.registerObjectSet(
+      activeEmployeesRid,
+      activeEmployeesObjectSet,
+    );
+
+    expect(ids(getObjectsFromSet(
+      fauxDataStore,
+      {
+        type: "intersect",
+        objectSets: [
+          {
+            type: "reference",
+            reference: activeEmployeesRid,
+          },
+          {
+            type: "filter",
+            objectSet: {
+              type: "base",
+              objectType: "Employee",
+            },
+            where: {
+              type: "gte",
+              field: "level",
+              value: 2,
+            },
+          },
+        ],
+      },
+      undefined,
+    ))).toEqual(["c"]);
+  });
+
+  it("supports references in derived property object sets", () => {
+    fauxDataStore.registerObjectSet(
+      activeEmployeesRid,
+      activeEmployeesObjectSet,
+    );
+
+    const objects = getObjectsFromSet(
+      fauxDataStore,
+      {
+        type: "withProperties",
+        objectSet: {
+          type: "base",
+          objectType: "Employee",
+        },
+        derivedProperties: {
+          activeEmployeeCount: {
+            type: "selection",
+            objectSet: {
+              type: "reference",
+              reference: activeEmployeesRid,
+            },
+            operation: {
+              type: "count",
+            },
+          },
+        },
+      },
+      undefined,
+    );
+
+    expect(objects.map(o => ({
+      id: o.id,
+      activeEmployeeCount: o.activeEmployeeCount,
+    }))).toEqual([
+      { id: "a", activeEmployeeCount: "2" },
+      { id: "b", activeEmployeeCount: "2" },
+      { id: "c", activeEmployeeCount: "2" },
+    ]);
+  });
+
+  it("throws ObjectSetNotFound for missing reference object sets", () => {
+    expect(() =>
+      getObjectsFromSet(
+        fauxDataStore,
+        {
+          type: "reference",
+          reference: "ri.object-set.missing",
+        },
+        undefined,
+      )
+    ).toThrow(
+      "NOT_FOUND ObjectSetNotFound {\"objectSetRid\":\"ri.object-set.missing\"}",
+    );
+  });
+});

--- a/packages/faux/src/FauxFoundry/getObjectsFromSet.ts
+++ b/packages/faux/src/FauxFoundry/getObjectsFromSet.ts
@@ -84,10 +84,10 @@ export function getObjectsFromSet(
 
           if (!match) {
             set.delete(obj);
-          } else if (obj["$propsToReturn"] || match["$propsToReturn"]) {
-            obj["$propsToReturn"] = {
-              ...obj["$propsToReturn"],
-              ...match["$propsToReturn"],
+          } else if (obj.$propsToReturn || match.$propsToReturn) {
+            obj.$propsToReturn = {
+              ...obj.$propsToReturn,
+              ...match.$propsToReturn,
             };
           }
         }
@@ -191,8 +191,11 @@ export function getObjectsFromSet(
       return set.slice(0, numNeighbors);
 
     case "reference":
-      throw new Error(
-        `Unhandled objectSet type ${JSON.stringify(objectSet)} in shared.test`,
+      const objectSetRid = objectSet.reference;
+      return getObjectsFromSet(
+        ds,
+        ds.getObjectSetOrThrow(objectSetRid),
+        methodInput,
       );
   }
 

--- a/packages/faux/src/errors.ts
+++ b/packages/faux/src/errors.ts
@@ -21,6 +21,7 @@ import type {
   UserNotFound,
 } from "@osdk/foundry.admin";
 import type { InvalidPageToken } from "@osdk/foundry.core";
+import type { ObjectSetNotFound } from "@osdk/foundry.ontologies";
 import type {
   ActionNotFound,
   ApplyActionFailed,
@@ -102,6 +103,21 @@ export function ObjectNotFoundError(
     parameters: {
       objectType,
       primaryKey,
+    },
+  };
+}
+
+export function ObjectSetNotFoundError(
+  objectSetRid: string,
+): ObjectSetNotFound {
+  return {
+    errorCode: "NOT_FOUND",
+    errorName: "ObjectSetNotFound",
+    errorDescription:
+      "The requested object set is not found, or the client token does not have access to it.",
+    errorInstanceId,
+    parameters: {
+      objectSetRid,
     },
   };
 }
@@ -219,7 +235,7 @@ export const GetUserNotFoundError = (userId: string): UserNotFound => ({
   errorName: "UserNotFound",
   errorInstanceId,
   parameters: {
-    userId: userId,
+    userId,
   },
   errorDescription: "The given User could not be found.",
 });
@@ -254,7 +270,7 @@ export const GetInvalidPageTokenError = (
   errorCode: "INVALID_ARGUMENT",
   errorName: "InvalidPageToken",
   errorDescription: "The provided page token is invalid.",
-  errorInstanceId: errorInstanceId,
+  errorInstanceId,
   parameters: {
     pageToken,
   },


### PR DESCRIPTION
Add support for object set references. This is needed for Pilot for custom widget integration. The consumer can register temporary object sets that can be used when loading data.