### PR TITLE
make react-devtools package public again

### DIFF
--- a/.changeset/react-devtools-public-again.md
+++ b/.changeset/react-devtools-public-again.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+Make react-devtools package public again

--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -421,7 +421,6 @@ const archetypeRules = archetypes(
       react: true,
       output: OUTPUT_ESM_ONLY,
       cssExport: ["styles.css"],
-      private: true,
     },
   )
   .addArchetype(

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@osdk/react-devtools",
-  "private": true,
   "version": "0.8.0",
   "description": "Developer tools and debugging utilities for OSDK React Toolkit",
   "license": "Apache-2.0",
@@ -96,7 +95,14 @@
   "publishConfig": {
     "access": "public"
   },
-  "files": [],
+  "files": [
+    "build/esm",
+    "build/types",
+    "CHANGELOG.md",
+    "package.json",
+    "templates",
+    "*.d.ts"
+  ],
   "module": "./build/esm/index.js",
   "types": "./build/types/index.d.ts",
   "sideEffects": [


### PR DESCRIPTION
reverses the react-devtools-specific parts of #3210 so the package publishes to npm again

• drop `"private": true` from `packages/react-devtools/package.json`
• restore the real `files` allowlist (was blanked to `[]`)
• remove `private: true` from the react-devtools archetype in `.monorepolint.config.mjs`

