### PR TITLE
add chromatic visual regression testing for storybook

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,6 +19,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: chromatic-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   chromatic:
     name: Run Chromatic
@@ -30,8 +34,9 @@ jobs:
       contents: read
     steps:
       - name: Check out code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           # Chromatic needs full git history to track baselines across commits.
           fetch-depth: 0
           persist-credentials: false
@@ -39,7 +44,7 @@ jobs:
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
           cache: "pnpm"

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,8 +6,16 @@ env:
 on:
   push:
     branches: [main]
+    paths:
+      - 'packages/react-components/**'
+      - 'packages/react-components-storybook/**'
+      - '.github/workflows/chromatic.yml'
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - 'packages/react-components/**'
+      - 'packages/react-components-storybook/**'
+      - '.github/workflows/chromatic.yml'
 
 permissions: {}
 

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,60 @@
+name: Chromatic
+
+env:
+  DO_NOT_TRACK: 1
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  chromatic:
+    name: Run Chromatic
+    # Fork PRs cannot read the CHROMATIC_PROJECT_TOKEN secret, so skip them.
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Chromatic needs full git history to track baselines across commits.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build dependencies for Storybook
+        run: pnpm --filter "@osdk/*" transpileBrowser
+
+      - name: Build Storybook
+        env:
+          # Chromatic serves the build at the domain root, so override the
+          # GitHub Pages base path (/osdk-ts/storybook/) to avoid 404ing assets.
+          STORYBOOK_BASE_PATH: /
+        run: pnpm --filter @osdk/react-components-storybook build
+
+      - name: Publish to Chromatic
+        uses: chromaui/action@0b8c883861c1663076150cf1f4592b19d1ff6a54 # v17.0.1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: packages/react-components-storybook
+          storybookBuildDir: storybook-static
+          # Report visual changes without failing CI; review and accept them in
+          # the Chromatic app.
+          exitZeroOnChanges: true

--- a/packages/react-components-storybook/.gitignore
+++ b/packages/react-components-storybook/.gitignore
@@ -5,6 +5,9 @@ node_modules/
 storybook-static/
 build/
 
+# Chromatic
+chromatic-diagnostics.json
+
 # IDE
 .vscode/
 .idea/

--- a/packages/react-components-storybook/package.json
+++ b/packages/react-components-storybook/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "storybook build",
+    "chromatic": "STORYBOOK_BASE_PATH=/ chromatic --build-script-name build",
     "dev": "trap 'kill 0' EXIT; pnpm turbo watch transpileBrowser --filter='@osdk/react-components-storybook^...' & storybook dev -p 6006",
     "fix-lint": "eslint . --fix && dprint fmt",
     "lint": "eslint . && dprint check",
@@ -39,6 +40,7 @@
     "@types/react": "^18.3.24",
     "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "^4.3.4",
+    "chromatic": "~17.0.1",
     "classnames": "^2.5.1",
     "eslint-plugin-storybook": "^10.2.10",
     "pdf-lib": "^1.17.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4792,6 +4792,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.7.0(vite@6.4.2(@types/node@20.19.13)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.3))
+      chromatic:
+        specifier: ~17.0.1
+        version: 17.0.1
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -12950,6 +12953,22 @@ packages:
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
+
+  chromatic@17.0.1:
+    resolution: {integrity: sha512-6qcoYWLT917ov8kpeN7YCVIUTdnI8ecEduT2dbyh39clUsIvR7YLDKyPPTKYE2vZgZsMGgeErv0aedJuaxhrqA==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@chromatic-com/cypress': ^0.*.* || ^1.0.0
+      '@chromatic-com/playwright': ^0.*.* || ^1.0.0
+      '@chromatic-com/vitest': ^0.*.* || ^1.0.0
+    peerDependenciesMeta:
+      '@chromatic-com/cypress':
+        optional: true
+      '@chromatic-com/playwright':
+        optional: true
+      '@chromatic-com/vitest':
+        optional: true
 
   chrome-launcher@0.15.2:
     resolution: {integrity: sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==}
@@ -21750,7 +21769,7 @@ snapshots:
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
       fflate: 0.8.2
-      semver: 7.7.2
+      semver: 7.7.4
       ts-expose-internals-conditionally: 1.0.0-empty.0
       typescript: 5.3.3
       validate-npm-package-name: 5.0.1
@@ -29308,7 +29327,7 @@ snapshots:
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.9
-      semver: 7.7.2
+      semver: 7.7.4
       ts-api-utils: 2.1.0(typescript@5.5.4)
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -30966,6 +30985,10 @@ snapshots:
   chownr@2.0.0: {}
 
   chownr@3.0.0: {}
+
+  chromatic@17.0.1:
+    dependencies:
+      semver: 7.7.4
 
   chrome-launcher@0.15.2:
     dependencies:


### PR DESCRIPTION
adds chromatic to catch visual regressions against the react-components storybook

it's not super smart in running only on PRs where it makes sense (uses the same paths filtering the storybook preview jobs do) but if this turns out to be useful we should look into integrating https://www.chromatic.com/docs/turbosnap/ for more performant / smarter running

• new `.github/workflows/chromatic.yml` runs on prs and pushes to main, skips fork prs, and is non-blocking (`exitZeroOnChanges`); not wired into the required ci-build gate.
• adds the chromatic dep and a local `pnpm chromatic` script that builds storybook with a root base path so stories render correctly in chromatic instead of under the github pages path
• token is read from the `CHROMATIC_PROJECT_TOKEN` repo secret which has not been configured and i think we'll need devtools to help us configure? unsure but will figure out the process here  

~~note: the chromatic check will be red until the pre-existing PdfViewerAnnotationLayer story crashes are fixed in https://github.com/palantir/osdk-ts/pull/3421~~
