### PR TITLE
fix pdfviewer annotationlayer stories crashing on missing transform prop

### DIFF
--- a/packages/react-components-storybook/src/stories/PdfViewer/AnnotationLayer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/PdfViewer/AnnotationLayer.stories.tsx
@@ -73,7 +73,18 @@ const meta: Meta<PdfViewerAnnotationLayerProps> = {
         background: "#fff",
       }}
     >
-      <PdfViewerAnnotationLayer {...args} />
+      <PdfViewerAnnotationLayer
+        {...args}
+        // pdf.js viewport.transform for a non-rotated page: scales and flips y.
+        transform={[
+          args.scale,
+          0,
+          0,
+          -args.scale,
+          0,
+          args.pageHeight * args.scale,
+        ]}
+      />
     </div>
   ),
   argTypes: {


### PR DESCRIPTION
the three PdfViewerAnnotationLayer storybook stories crashed at render with `Cannot read properties of undefined (reading '0')`, surfaced by chromatic

• the component requires a `transform` matrix (pdf.js `viewport.transform`) which it reads as `m[0]`, `m[1]`, etc, but the stories never passed it, so `m` was undefined
• the stories now supply the same non-rotated viewport transform the component test and real `PdfAnnotationOverlay` usage use: scale and flip y
• verified all three stories (Default, Highlights Only, Zoomed In) now render their annotations with no errors
