### PR TITLE
Respect subpaths when proxying API requests

### DIFF
--- a/.changeset/whole-zoos-jump.md
+++ b/.changeset/whole-zoos-jump.md
@@ -1,0 +1,5 @@
+---
+"@osdk/vite-plugin-superrepo": minor
+---
+
+Respect subpaths when proxying API requests

--- a/packages/vite-plugin-superrepo/src/index.test.ts
+++ b/packages/vite-plugin-superrepo/src/index.test.ts
@@ -60,3 +60,50 @@ it("installs ontology proxy prefixes from a live discovery file", () => {
     expect(proxy[prefix].secure).toBe(false);
   }
 });
+
+it("prefixes proxy contexts with `base` and strips it on rewrite", () => {
+  fs.writeFileSync(
+    path.join(workDir, "foundry.yml"),
+    "minCliVersion: \"0.0.0\"\n",
+  );
+  const dir = path.join(workDir, DISCOVERY_DIR);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, ".ontology-discovery.json"),
+    JSON.stringify({ pid: process.pid, url: "https://127.0.0.1:51000" }),
+  );
+  fs.writeFileSync(
+    path.join(dir, ".typescript-functions-discovery.json"),
+    JSON.stringify({ pid: process.pid, url: "https://127.0.0.1:51001" }),
+  );
+
+  const base =
+    "/foundry-container-service/proxy/ri.fcs.container.abc/port8082/";
+  const userConfig: UserConfig = { root: workDir, base };
+  const plugin = smartClientPlugin();
+  const hook = plugin.config;
+  const fn = typeof hook === "function" ? hook : hook?.handler;
+  if (!fn) throw new Error("smartClientPlugin must declare a `config` hook");
+  (fn as unknown as (
+    cfg: UserConfig,
+    env: { command: "serve" | "build"; mode: string },
+  ) => unknown)(userConfig, { command: "serve", mode: "development" });
+
+  const prefix = base.slice(0, -1); // base without the trailing slash
+  const proxy = userConfig.server?.proxy as Record<string, ProxyOptions>;
+
+  // The un-prefixed contexts must not be installed.
+  expect(proxy["/ontology-metadata"]).toBeUndefined();
+
+  // Non-rewrite route: context carries the base; rewrite strips only the base,
+  // leaving the route prefix for the backend.
+  const ontology = proxy[`${prefix}/ontology-metadata`];
+  expect(ontology.target).toBe("https://127.0.0.1:51000");
+  expect(ontology.rewrite?.(`${prefix}/ontology-metadata/foo`))
+    .toBe("/ontology-metadata/foo");
+
+  // Rewrite route: strips both the base and the route prefix.
+  const fns = proxy[`${prefix}/local-functions`];
+  expect(fns.target).toBe("https://127.0.0.1:51001");
+  expect(fns.rewrite?.(`${prefix}/local-functions/bar`)).toBe("/bar");
+});

--- a/packages/vite-plugin-superrepo/src/index.ts
+++ b/packages/vite-plugin-superrepo/src/index.ts
@@ -78,19 +78,26 @@ export function smartClientPlugin(): Plugin {
         return undefined;
       }
 
+      // Vite's proxy middleware runs before `base` is stripped from the URL,
+      // so each context must carry the base prefix and each rewrite must strip
+      // it back off before forwarding to the foundry-cli service.
+      const basePrefix = normalizeBasePrefix(userConfig.base);
+
       const proxy: Record<string, ProxyOptions> = {};
       const palantirDir = path.join(superrepoRoot, ".palantir");
 
       for (const route of PROXY_ROUTES) {
         const read = inspectDiscovery(superrepoRoot, route.service);
         if (read.kind === "ok") {
-          proxy[route.prefix] = buildProxyOptions(
+          const context = `${basePrefix}${route.prefix}`;
+          proxy[context] = buildProxyOptions(
             read.entry,
             route,
+            basePrefix,
             pendingWarnings,
             getLogger,
           );
-          setupProxies.push({ prefix: route.prefix, target: read.entry.url });
+          setupProxies.push({ prefix: context, target: read.entry.url });
           continue;
         }
         switch (read.kind) {
@@ -252,8 +259,8 @@ export function smartClientPlugin(): Plugin {
 
       // Redirect the `@osdk/client` import to our shim. The shim
       // re-exports the real module but replaces `createClient` with one
-      // that (a) forces `window.location.origin` as the base URL so
-      // every OSDK request flows through Vite's proxy, and (b) wraps
+      // that (a) forces the dev server's origin and base path as the base
+      // URL so every OSDK request flows through Vite's proxy, and (b) wraps
       // the resulting client with `smartClient` so `executeFunction`
       // calls are routed to the local function runtimes. `@osdk/oauth`
       // and any other imports are untouched.
@@ -268,6 +275,7 @@ export function smartClientPlugin(): Plugin {
 function buildProxyOptions(
   entry: DiscoveryEntry,
   route: { prefix: string; rewrite: boolean },
+  basePrefix: string,
   pendingWarnings: string[],
   getLogger: () => Logger | undefined,
 ): ProxyOptions {
@@ -284,9 +292,14 @@ function buildProxyOptions(
       });
     },
   };
-  if (route.rewrite) {
+  // Always strip the base prefix; additionally strip the route prefix for
+  // routes whose backend is not mounted under it.
+  const stripPrefix = route.rewrite
+    ? `${basePrefix}${route.prefix}`
+    : basePrefix;
+  if (stripPrefix) {
     options.rewrite = (p) =>
-      p.replace(new RegExp(`^${escapeRegExp(route.prefix)}`), "");
+      p.replace(new RegExp(`^${escapeRegExp(stripPrefix)}`), "");
   }
   if (isHttps) {
     if (entry.caCertPath !== undefined && fs.existsSync(entry.caCertPath)) {
@@ -307,4 +320,15 @@ function buildProxyOptions(
 
 function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Reduce a Vite `base` to a bare path prefix with no trailing slash, so
+ * `${basePrefix}${route.prefix}` reads as a clean path (`/base/api`). The root
+ * base (`/`, the default) yields an empty prefix, leaving proxy contexts
+ * identical to a non-prefixed dev server.
+ */
+function normalizeBasePrefix(base: string | undefined): string {
+  if (base == null || base === "/" || base === "") return "";
+  return base.endsWith("/") ? base.slice(0, -1) : base;
 }

--- a/packages/vite-plugin-superrepo/src/public/osdkClient.ts
+++ b/packages/vite-plugin-superrepo/src/public/osdkClient.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/// <reference types="vite/client" />
+
 import { createClient as __real } from "@osdk/client";
 import { smartClient } from "./smartClient.js";
 
@@ -25,9 +27,11 @@ export * from "@osdk/client";
  * Drop-in replacement for `createClient` from `@osdk/client` that does
  * two things on top of the real one, both dev-only:
  *
- *  1. Forces the base URL to `window.location.origin` so every OSDK
- *     request flows through the proxies that `vite-plugin-superrepo`
- *     installs on the Vite dev server.
+ *  1. Forces the base URL to the dev server's origin and base path
+ *     (`import.meta.env.BASE_URL`) so every OSDK request flows through the
+ *     proxies that `vite-plugin-superrepo` installs on the Vite dev server,
+ *     even when Vite is served under a path prefix (e.g. behind the Foundry
+ *     Container Service proxy).
  *  2. Wraps the returned client with `smartClient`, which intercepts
  *     `executeFunction` calls and routes them to the local foundry-cli
  *     typescript/python function runtimes.
@@ -44,7 +48,7 @@ export const createClient: typeof __real = (
   fetchFn,
 ) =>
   smartClient(__real(
-    window.location.origin,
+    new URL(import.meta.env.BASE_URL, window.location.origin).href,
     ontologyRid,
     tokenProvider,
     options,

--- a/packages/vite-plugin-superrepo/src/public/smartClient.ts
+++ b/packages/vite-plugin-superrepo/src/public/smartClient.ts
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 
+/// <reference types="vite/client" />
+
 import type { Client } from "@osdk/client";
+
+// Vite serves under `import.meta.env.BASE_URL` (trailing slash); the direct
+// fetches below hit the same-origin proxies the plugin installs, so they must
+// carry that prefix to route through Vite when it is served under a path.
+const BASE_PATH = import.meta.env.BASE_URL.replace(/\/$/, "");
+const withBase = (path: string): string => `${BASE_PATH}${path}`;
 
 interface RuntimeConfig {
   name: "TypeScript" | "Python";
@@ -73,9 +81,10 @@ function isOsdkObject(
 }
 
 async function fetchPkPropertyNames(): Promise<Map<string, string>> {
-  const response = await fetch("/api/v2/ontologies/ontology/objectTypes", {
-    headers: { "Authorization": LOCAL_RUNTIME_TOKEN },
-  });
+  const response = await fetch(
+    withBase("/api/v2/ontologies/ontology/objectTypes"),
+    { headers: { "Authorization": LOCAL_RUNTIME_TOKEN } },
+  );
   if (!response.ok) {
     throw new Error(
       `Failed to fetch object types: ${response.status}`,
@@ -295,7 +304,7 @@ async function fetchSpecs(
   runtime: RuntimeConfig,
 ): Promise<RuntimeSpecs | null> {
   try {
-    const response = await fetch(runtime.specsEndpoint, {
+    const response = await fetch(withBase(runtime.specsEndpoint), {
       method: "GET",
       headers: { "Authorization": LOCAL_RUNTIME_TOKEN },
       signal: AbortSignal.timeout(SPECS_TIMEOUT_MS),
@@ -362,7 +371,7 @@ async function postJsonToLocalRuntime(
   url: string,
   body: unknown,
 ): Promise<Response> {
-  const response = await fetch(url, {
+  const response = await fetch(withBase(url), {
     method: "POST",
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
In Code Workspaces, vite is configured to server the dev server under a subpath. Our API proxying didn't respect it, resulting in sending requests to the wrong url from the osdk client where vite wasn't listening.