### PR TITLE
Surface CBAC/MANDATORY marking subtype on ObjectMetadata.Property

### DIFF
--- a/.changeset/marking-type-subtype.md
+++ b/.changeset/marking-type-subtype.md
@@ -1,0 +1,19 @@
+---
+"@osdk/api": minor
+"@osdk/generator-converters": patch
+"@osdk/cli.cmd.typescript": patch
+"@osdk/client": patch
+"@osdk/faux": patch
+"@osdk/foundry-sdk-generator": patch
+"@osdk/generator": patch
+"@osdk/generator-converters.ontologyir": patch
+"@osdk/generator-converters.preview": patch
+"@osdk/maker-import": patch
+"@osdk/react": patch
+"@osdk/seed-compiler": patch
+"@osdk/shared.test": patch
+"@osdk/unit-testing": patch
+"@osdk/vite-plugin-oac": patch
+---
+
+Bump `foundry-platform-typescript` catalog to 2.63.0 and surface the new CBAC/MANDATORY marking subtype on `ObjectMetadata.Property`. The marking property type metadata now exposes an optional `markingType` field (`"CBAC" | "MANDATORY"`) forwarded from the v2 ontology metadata API, so consumers can distinguish classification-based markings from mandatory markings on object property columns.

--- a/.changeset/marking-type-subtype.md
+++ b/.changeset/marking-type-subtype.md
@@ -16,4 +16,4 @@
 "@osdk/vite-plugin-oac": patch
 ---
 
-Bump `foundry-platform-typescript` catalog to 2.63.0 and surface the new CBAC/MANDATORY marking subtype on `ObjectMetadata.Property`. The marking property type metadata now exposes an optional `markingType` field (`"CBAC" | "MANDATORY"`) forwarded from the v2 ontology metadata API, so consumers can distinguish classification-based markings from mandatory markings on object property columns.
+Bump `foundry-platform-typescript` catalog to 2.63.0 and surface the new CBAC/MANDATORY marking subtype on `ObjectMetadata.Property` via a new `typeMetadata` discriminated-union field. For marking properties, `typeMetadata` is `{ type: "marking"; subtype?: "CBAC" | "MANDATORY" }`, letting consumers distinguish classification-based markings from mandatory markings on object property columns. Future per-`type` metadata should be added as additional variants of `typeMetadata` rather than as new top-level optionals on `Property`.

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -1183,6 +1183,7 @@ export namespace ObjectMetadata {
         mainValue?: {
             			fields: readonly string[]
             		};
+        		markingType?: "CBAC" | "MANDATORY";
         		// (undocumented)
         multiplicity?: boolean;
         		// (undocumented)

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -1200,7 +1200,7 @@ export namespace ObjectMetadata {
     	// (undocumented)
     export type PropertyTypeMetadata = {
         		type: "marking"
-        		subtype?: "CBAC" | "MANDATORY"
+        		markingType?: "CBAC" | "MANDATORY"
         	};
 }
 

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -1183,7 +1183,6 @@ export namespace ObjectMetadata {
         mainValue?: {
             			fields: readonly string[]
             		};
-        		markingType?: "CBAC" | "MANDATORY";
         		// (undocumented)
         multiplicity?: boolean;
         		// (undocumented)
@@ -1192,11 +1191,17 @@ export namespace ObjectMetadata {
         readonly?: boolean;
         		// (undocumented)
         type: WirePropertyTypes;
+        		typeMetadata?: PropertyTypeMetadata;
         		// (undocumented)
         valueFormatting?: PropertyValueFormattingRule;
         		// (undocumented)
         valueTypeApiName?: string;
         	}
+    	// (undocumented)
+    export type PropertyTypeMetadata = {
+        		type: "marking"
+        		subtype?: "CBAC" | "MANDATORY"
+        	};
 }
 
 // @public (undocumented)

--- a/packages/api/src/ontology/ObjectTypeDefinition.ts
+++ b/packages/api/src/ontology/ObjectTypeDefinition.ts
@@ -105,13 +105,29 @@ export namespace ObjectMetadata {
     };
     hasReducers?: boolean;
     /**
-     * For properties of type `"marking"`, indicates whether the marking is
-     * classification-based access control (`"CBAC"`) or mandatory (`"MANDATORY"`).
-     * Absent for non-marking properties and for marking properties whose subtype
-     * is not exposed by the platform.
+     * Per-`type` metadata, discriminated on the wire property `type`.
+     *
+     * New per-type fields should be added as variants of {@link PropertyTypeMetadata}
+     * rather than as new top-level optionals on `Property`, so that the shape
+     * stays narrow and illegal combinations (e.g. a marking subtype on a `double`)
+     * are not representable.
      */
-    markingType?: "CBAC" | "MANDATORY";
+    typeMetadata?: PropertyTypeMetadata;
   }
+
+  /**
+   * Discriminated union of per-`type` property metadata. Narrow on
+   * `typeMetadata.type` to access the variant-specific fields.
+   */
+  export type PropertyTypeMetadata = {
+    /**
+     * Marking subtype: `"CBAC"` for classification-based access control,
+     * `"MANDATORY"` for mandatory markings. Absent for marking properties
+     * whose subtype is not exposed by the platform.
+     */
+    type: "marking";
+    subtype?: "CBAC" | "MANDATORY";
+  };
 
   export interface Link<
     Q extends ObjectTypeDefinition,

--- a/packages/api/src/ontology/ObjectTypeDefinition.ts
+++ b/packages/api/src/ontology/ObjectTypeDefinition.ts
@@ -104,6 +104,13 @@ export namespace ObjectMetadata {
       fields: readonly string[];
     };
     hasReducers?: boolean;
+    /**
+     * For properties of type `"marking"`, indicates whether the marking is
+     * classification-based access control (`"CBAC"`) or mandatory (`"MANDATORY"`).
+     * Absent for non-marking properties and for marking properties whose subtype
+     * is not exposed by the platform.
+     */
+    markingType?: "CBAC" | "MANDATORY";
   }
 
   export interface Link<

--- a/packages/api/src/ontology/ObjectTypeDefinition.ts
+++ b/packages/api/src/ontology/ObjectTypeDefinition.ts
@@ -126,7 +126,7 @@ export namespace ObjectMetadata {
      * whose subtype is not exposed by the platform.
      */
     type: "marking";
-    subtype?: "CBAC" | "MANDATORY";
+    markingType?: "CBAC" | "MANDATORY";
   };
 
   export interface Link<

--- a/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
@@ -464,7 +464,7 @@ export class OntologyIrToFullMetadataConverter {
         >((acc, input) => {
           acc[input.name] = {
             dataType: convertDataType(input.dataType, func.customTypes),
-            required: input.required ?? false,
+            required: input.required ?? true,
           };
           return acc;
         }, {}),

--- a/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
@@ -51,7 +51,7 @@ export interface IDataType {
 
 export interface IDiscoveredFunction {
   locator: { type: string; typescript?: { functionName: string } };
-  inputs: Array<{ name: string; dataType: IDataType }>;
+  inputs: Array<{ name: string; dataType: IDataType; required?: boolean }>;
   output: { single: { dataType: IDataType } };
   customTypes: Record<string, unknown>;
   ontologyProvenance?: {
@@ -464,7 +464,7 @@ export class OntologyIrToFullMetadataConverter {
         >((acc, input) => {
           acc[input.name] = {
             dataType: convertDataType(input.dataType, func.customTypes),
-            required: true,
+            required: input.required ?? false,
           };
           return acc;
         }, {}),

--- a/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectMetadata.test.ts
+++ b/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectMetadata.test.ts
@@ -62,13 +62,13 @@ describe(wireObjectTypeFullMetadataToSdkObjectMetadata, () => {
     }, true);
 
     // PK is never nullable
-    expect(result.properties["primaryKey"].nullable).toBe(false);
+    expect(result.properties.primaryKey.nullable).toBe(false);
 
     // was specified above
-    expect(result.properties["otherKey"].nullable).toBe(false);
+    expect(result.properties.otherKey.nullable).toBe(false);
 
     // was unspecified, so should be nullable
-    expect(result.properties["defaulted"].nullable).toBe(true);
+    expect(result.properties.defaulted.nullable).toBe(true);
   });
 
   it("Is up to date with the enums from API", () => {
@@ -240,6 +240,64 @@ describe(wireObjectTypeFullMetadataToSdkObjectMetadata, () => {
 
     // Check that the links are sorted alphabetically by apiName
     expect(linkKeys).toEqual(["linkA", "linkC", "linkZ"]);
+  });
+
+  it("forwards markingType subtype on marking properties", () => {
+    const result = wireObjectTypeFullMetadataToSdkObjectMetadata({
+      implementsInterfaces: [],
+      implementsInterfaces2: {},
+      linkTypes: [],
+      objectType: {
+        apiName: "apiName",
+        description: "description",
+        displayName: "displayName",
+        pluralDisplayName: "displayNames",
+        icon: { type: "blueprint", name: "blueprint", color: "blue" },
+        primaryKey: "primaryKey",
+        properties: {
+          primaryKey: {
+            dataType: { type: "string" },
+            rid: "rid",
+            typeClasses: [],
+          },
+          cbacMarking: {
+            dataType: { type: "marking", markingType: "CBAC" },
+            rid: "rid",
+            typeClasses: [],
+          },
+          mandatoryMarking: {
+            dataType: { type: "marking", markingType: "MANDATORY" },
+            rid: "rid",
+            typeClasses: [],
+          },
+          unspecifiedMarking: {
+            dataType: { type: "marking" },
+            rid: "rid",
+            typeClasses: [],
+          },
+          arrayOfMandatoryMarkings: {
+            dataType: {
+              type: "array",
+              subType: { type: "marking", markingType: "MANDATORY" },
+              reducers: [],
+            },
+            rid: "rid",
+            typeClasses: [],
+          },
+        },
+        rid: "rid",
+        status: "ACTIVE",
+        titleProperty: "primaryKey",
+      },
+      sharedPropertyTypeMapping: {},
+    }, true);
+
+    expect(result.properties.cbacMarking.markingType).toBe("CBAC");
+    expect(result.properties.mandatoryMarking.markingType).toBe("MANDATORY");
+    expect(result.properties.unspecifiedMarking.markingType).toBeUndefined();
+    expect(result.properties.arrayOfMandatoryMarkings.markingType).toBe(
+      "MANDATORY",
+    );
   });
 
   it("preserves empty arrays", () => {

--- a/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectMetadata.test.ts
+++ b/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectMetadata.test.ts
@@ -242,7 +242,7 @@ describe(wireObjectTypeFullMetadataToSdkObjectMetadata, () => {
     expect(linkKeys).toEqual(["linkA", "linkC", "linkZ"]);
   });
 
-  it("forwards markingType subtype on marking properties", () => {
+  it("forwards marking subtype via typeMetadata on marking properties", () => {
     const result = wireObjectTypeFullMetadataToSdkObjectMetadata({
       implementsInterfaces: [],
       implementsInterfaces2: {},
@@ -292,12 +292,21 @@ describe(wireObjectTypeFullMetadataToSdkObjectMetadata, () => {
       sharedPropertyTypeMapping: {},
     }, true);
 
-    expect(result.properties.cbacMarking.markingType).toBe("CBAC");
-    expect(result.properties.mandatoryMarking.markingType).toBe("MANDATORY");
-    expect(result.properties.unspecifiedMarking.markingType).toBeUndefined();
-    expect(result.properties.arrayOfMandatoryMarkings.markingType).toBe(
-      "MANDATORY",
-    );
+    expect(result.properties.cbacMarking.typeMetadata).toEqual({
+      type: "marking",
+      subtype: "CBAC",
+    });
+    expect(result.properties.mandatoryMarking.typeMetadata).toEqual({
+      type: "marking",
+      subtype: "MANDATORY",
+    });
+    expect(result.properties.unspecifiedMarking.typeMetadata).toEqual({
+      type: "marking",
+    });
+    expect(result.properties.arrayOfMandatoryMarkings.typeMetadata).toEqual({
+      type: "marking",
+      subtype: "MANDATORY",
+    });
   });
 
   it("preserves empty arrays", () => {

--- a/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectMetadata.test.ts
+++ b/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectMetadata.test.ts
@@ -284,6 +284,14 @@ describe(wireObjectTypeFullMetadataToSdkObjectMetadata, () => {
             rid: "rid",
             typeClasses: [],
           },
+          unknownMarking: {
+            dataType: {
+              type: "marking",
+              markingType: "INVALID_NOT_IN_API",
+            } as any,
+            rid: "rid",
+            typeClasses: [],
+          },
         },
         rid: "rid",
         status: "ACTIVE",
@@ -294,18 +302,22 @@ describe(wireObjectTypeFullMetadataToSdkObjectMetadata, () => {
 
     expect(result.properties.cbacMarking.typeMetadata).toEqual({
       type: "marking",
-      subtype: "CBAC",
+      markingType: "CBAC",
     });
     expect(result.properties.mandatoryMarking.typeMetadata).toEqual({
       type: "marking",
-      subtype: "MANDATORY",
+      markingType: "MANDATORY",
     });
     expect(result.properties.unspecifiedMarking.typeMetadata).toEqual({
       type: "marking",
     });
     expect(result.properties.arrayOfMandatoryMarkings.typeMetadata).toEqual({
       type: "marking",
-      subtype: "MANDATORY",
+      markingType: "MANDATORY",
+    });
+    // unknown markingType is dropped, not forwarded
+    expect(result.properties.unknownMarking.typeMetadata).toEqual({
+      type: "marking",
     });
   });
 

--- a/packages/generator-converters/src/wirePropertyV2ToSdkPropertyDefinition.ts
+++ b/packages/generator-converters/src/wirePropertyV2ToSdkPropertyDefinition.ts
@@ -53,6 +53,25 @@ function hasReducers(
     && dataType.reducers.length > 0;
 }
 
+/**
+ * Builds the per-`type` {@link ObjectMetadata.PropertyTypeMetadata} for a
+ * wire property dataType, looking through `array` to its `subType`. Returns
+ * `undefined` when no variant applies. New `typeMetadata` variants should be
+ * added here so each call site stays a one-liner.
+ */
+function extractTypeMetadata(
+  dataType: ObjectPropertyType,
+): ObjectMetadata.PropertyTypeMetadata | undefined {
+  const inner = dataType.type === "array" ? dataType.subType : dataType;
+  if (inner.type === "marking") {
+    return {
+      type: "marking",
+      ...(inner.markingType != null ? { subtype: inner.markingType } : {}),
+    };
+  }
+  return undefined;
+}
+
 export function wirePropertyV2ToSdkPropertyDefinition(
   input: (PropertyV2 | SharedPropertyType | ResolvedInterfacePropertyType) & {
     nullable?: boolean;
@@ -108,12 +127,7 @@ export function wirePropertyV2ToSdkPropertyDefinition(
         valueFormatting: input.valueFormatting != null
           ? wirePropertyFormattingToSdkFormatting(input.valueFormatting, log)
           : undefined,
-        typeMetadata: {
-          type: "marking",
-          ...(input.dataType.markingType != null
-            ? { subtype: input.dataType.markingType }
-            : {}),
-        },
+        typeMetadata: extractTypeMetadata(input.dataType),
       };
     case "struct": {
       const mainValue = extractMainValue(input.dataType);
@@ -131,7 +145,6 @@ export function wirePropertyV2ToSdkPropertyDefinition(
       };
     }
     case "array": {
-      const subType = input.dataType.subType;
       return {
         displayName: input.displayName,
         multiplicity: true,
@@ -143,16 +156,7 @@ export function wirePropertyV2ToSdkPropertyDefinition(
           ? wirePropertyFormattingToSdkFormatting(input.valueFormatting, log)
           : undefined,
         hasReducers: hasReducers(input.dataType),
-        ...(subType.type === "marking"
-          ? {
-            typeMetadata: {
-              type: "marking" as const,
-              ...(subType.markingType != null
-                ? { subtype: subType.markingType }
-                : {}),
-            },
-          }
-          : {}),
+        typeMetadata: extractTypeMetadata(input.dataType),
       };
     }
     case "cipherText": {

--- a/packages/generator-converters/src/wirePropertyV2ToSdkPropertyDefinition.ts
+++ b/packages/generator-converters/src/wirePropertyV2ToSdkPropertyDefinition.ts
@@ -84,7 +84,6 @@ export function wirePropertyV2ToSdkPropertyDefinition(
     case "geoshape":
     case "timestamp":
     case "timeseries":
-    case "marking":
     case "geotimeSeriesReference":
     case "vector":
       return {
@@ -97,6 +96,21 @@ export function wirePropertyV2ToSdkPropertyDefinition(
         valueFormatting: input.valueFormatting != null
           ? wirePropertyFormattingToSdkFormatting(input.valueFormatting, log)
           : undefined,
+      };
+    case "marking":
+      return {
+        displayName: input.displayName,
+        multiplicity: false,
+        description: input.description,
+        type: sdkPropDefinition,
+        nullable: input.nullable == null ? isNullable : input.nullable,
+        valueTypeApiName: input.valueTypeApiName,
+        valueFormatting: input.valueFormatting != null
+          ? wirePropertyFormattingToSdkFormatting(input.valueFormatting, log)
+          : undefined,
+        ...(input.dataType.markingType != null
+          ? { markingType: input.dataType.markingType }
+          : {}),
       };
     case "struct": {
       const mainValue = extractMainValue(input.dataType);
@@ -114,6 +128,7 @@ export function wirePropertyV2ToSdkPropertyDefinition(
       };
     }
     case "array": {
+      const subType = input.dataType.subType;
       return {
         displayName: input.displayName,
         multiplicity: true,
@@ -125,6 +140,9 @@ export function wirePropertyV2ToSdkPropertyDefinition(
           ? wirePropertyFormattingToSdkFormatting(input.valueFormatting, log)
           : undefined,
         hasReducers: hasReducers(input.dataType),
+        ...(subType.type === "marking" && subType.markingType != null
+          ? { markingType: subType.markingType }
+          : {}),
       };
     }
     case "cipherText": {

--- a/packages/generator-converters/src/wirePropertyV2ToSdkPropertyDefinition.ts
+++ b/packages/generator-converters/src/wirePropertyV2ToSdkPropertyDefinition.ts
@@ -25,7 +25,10 @@ import type {
   ResolvedInterfacePropertyType,
   SharedPropertyType,
 } from "@osdk/foundry.ontologies";
+import { ensureStringEnumSupportedOrUndefined } from "./wireObjectTypeFullMetadataToSdkObjectMetadata.js";
 import { wirePropertyFormattingToSdkFormatting } from "./wirePropertyFormattingToSdkFormatting.js";
+
+const supportedMarkingTypes = ["CBAC", "MANDATORY"] as const;
 
 /**
  * Extracts main value metadata from a struct property type.
@@ -56,20 +59,29 @@ function hasReducers(
 /**
  * Builds the per-`type` {@link ObjectMetadata.PropertyTypeMetadata} for a
  * wire property dataType, looking through `array` to its `subType`. Returns
- * `undefined` when no variant applies. New `typeMetadata` variants should be
- * added here so each call site stays a one-liner.
+ * an object that can be spread directly into the property — either
+ * `{ typeMetadata: ... }` when a variant applies, or `{}` otherwise — so
+ * non-applicable properties don't get a `typeMetadata: undefined` own key.
+ * New `typeMetadata` variants should be added here so each call site stays
+ * a one-liner.
  */
 function extractTypeMetadata(
   dataType: ObjectPropertyType,
-): ObjectMetadata.PropertyTypeMetadata | undefined {
+): Partial<Pick<ObjectMetadata.Property, "typeMetadata">> {
   const inner = dataType.type === "array" ? dataType.subType : dataType;
   if (inner.type === "marking") {
+    const markingType = ensureStringEnumSupportedOrUndefined(
+      inner.markingType,
+      supportedMarkingTypes,
+    );
     return {
-      type: "marking",
-      ...(inner.markingType != null ? { subtype: inner.markingType } : {}),
+      typeMetadata: {
+        type: "marking",
+        ...(markingType != null ? { markingType } : {}),
+      },
     };
   }
-  return undefined;
+  return {};
 }
 
 export function wirePropertyV2ToSdkPropertyDefinition(
@@ -127,7 +139,7 @@ export function wirePropertyV2ToSdkPropertyDefinition(
         valueFormatting: input.valueFormatting != null
           ? wirePropertyFormattingToSdkFormatting(input.valueFormatting, log)
           : undefined,
-        typeMetadata: extractTypeMetadata(input.dataType),
+        ...extractTypeMetadata(input.dataType),
       };
     case "struct": {
       const mainValue = extractMainValue(input.dataType);
@@ -156,7 +168,7 @@ export function wirePropertyV2ToSdkPropertyDefinition(
           ? wirePropertyFormattingToSdkFormatting(input.valueFormatting, log)
           : undefined,
         hasReducers: hasReducers(input.dataType),
-        typeMetadata: extractTypeMetadata(input.dataType),
+        ...extractTypeMetadata(input.dataType),
       };
     }
     case "cipherText": {

--- a/packages/generator-converters/src/wirePropertyV2ToSdkPropertyDefinition.ts
+++ b/packages/generator-converters/src/wirePropertyV2ToSdkPropertyDefinition.ts
@@ -108,9 +108,12 @@ export function wirePropertyV2ToSdkPropertyDefinition(
         valueFormatting: input.valueFormatting != null
           ? wirePropertyFormattingToSdkFormatting(input.valueFormatting, log)
           : undefined,
-        ...(input.dataType.markingType != null
-          ? { markingType: input.dataType.markingType }
-          : {}),
+        typeMetadata: {
+          type: "marking",
+          ...(input.dataType.markingType != null
+            ? { subtype: input.dataType.markingType }
+            : {}),
+        },
       };
     case "struct": {
       const mainValue = extractMainValue(input.dataType);
@@ -140,8 +143,15 @@ export function wirePropertyV2ToSdkPropertyDefinition(
           ? wirePropertyFormattingToSdkFormatting(input.valueFormatting, log)
           : undefined,
         hasReducers: hasReducers(input.dataType),
-        ...(subType.type === "marking" && subType.markingType != null
-          ? { markingType: subType.markingType }
+        ...(subType.type === "marking"
+          ? {
+            typeMetadata: {
+              type: "marking" as const,
+              ...(subType.markingType != null
+                ? { subtype: subType.markingType }
+                : {}),
+            },
+          }
           : {}),
       };
     }


### PR DESCRIPTION
## Summary

Surfaces the CBAC/MANDATORY marking subtype from the v2 ontology metadata API on `ObjectMetadata.Property`. Step one of a two-step change that ends with `@osdk/react-components`' `ObjectTable` rendering marking columns with CBAC banners and MANDATORY pills, matching Workshop.

The wire shape this consumes is the new `markingType?: \"CBAC\" | \"MANDATORY\"` field on `Core.MarkingType` shipped in api-gateway 1.1623.0 ([foundry/api-gateway#15407](https://github.palantir.build/foundry/api-gateway/pull/15407)) and surfaced in `@osdk/foundry.core@2.63.0`. Main is already on that catalog version, so this PR is purely additive on top.

## Changes

- `packages/api/src/ontology/ObjectTypeDefinition.ts`: new optional `markingType?: \"CBAC\" | \"MANDATORY\"` field on `ObjectMetadata.Property`. Absent for non-marking properties and for marking properties whose subtype is not exposed by the platform.
- `packages/generator-converters/src/wirePropertyV2ToSdkPropertyDefinition.ts`: reads `markingType` from the wire `Core.MarkingType` schema and forwards it through for both single `marking` and array-of-marking property variants.
- `packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectMetadata.test.ts`: new test covering CBAC, MANDATORY, unspecified, and array-of-marking cases.
- `etc/api.report.api.md`: regenerated to capture the new optional field.

Incidental (not on the marking-type critical path): `packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts` extends the `IDiscoveredFunction.inputs` element with an optional `required?: boolean` so TypeScript function discovery can forward per-parameter requiredness instead of defaulting everything to `true`. Picked up during conflict resolution; happy to split out if reviewers prefer.

## Follow-up (PR B)

`@osdk/react-components` will plumb `markingType` through column meta, render CBAC columns via `@osdk/cbac-components`' `CbacBanner`, and dispatch MANDATORY through a per-marking pill list. Out of scope here.