### PR TITLE
Import CbacPicker docs from source in Storybook MDX

### DIFF
--- a/.changeset/cbac-storybook-docs-import.md
+++ b/.changeset/cbac-storybook-docs-import.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components-storybook": patch
+---
+
+Import CbacPicker docs from source package instead of inlining a summary in Storybook MDX

--- a/packages/react-components-storybook/.storybook/main.ts
+++ b/packages/react-components-storybook/.storybook/main.ts
@@ -83,6 +83,8 @@ const config: StorybookConfig = {
         // wrappers can import .md files without fragile relative paths.
         "@docs": new URL("../../react-components/docs", import.meta.url)
           .pathname,
+        "@cbac-docs": new URL("../../cbac-components/docs", import.meta.url)
+          .pathname,
         "@rc-root": new URL("../../react-components", import.meta.url)
           .pathname,
         // Polyfill Node.js modules for browser

--- a/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.mdx
+++ b/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.mdx
@@ -16,19 +16,9 @@
 
 {/* cspell:words cbac */}
 
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta, Markdown } from "@storybook/addon-docs/blocks";
+import cbacPickerDocs from "@cbac-docs/CbacPicker.md?raw";
 
 <Meta title="Components/CbacPicker/Docs" tags={["beta"]}/>
 
-# CbacPicker
-
-Components for managing classification-based access control (CBAC) markings.
-CBAC markings control who can access data. Each piece of data can be tagged
-with markings from different categories, and the combination determines its
-access restrictions.
-
-The picker lets users select markings grouped by category. Some categories are
-**disjunctive** (pick exactly one, like a sensitivity level) and others are
-**conjunctive** (pick any combination, like access groups). The server enforces
-which combinations are valid, which markings are implied by others, and which
-are disallowed.
+<Markdown>{cbacPickerDocs}</Markdown>


### PR DESCRIPTION
## Summary
- Replace hand-written CbacPicker docs summary in Storybook MDX with a raw import from `@cbac-docs/CbacPicker.md`, matching the pattern used by ObjectTable, FilterList, ActionForm, and DocumentViewer
- Add `@cbac-docs` webpack alias pointing to `packages/cbac-components/docs` in Storybook config

## Test plan
- [ ] Verify Storybook builds without errors
- [ ] Confirm CbacPicker docs page renders the full content from the source markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)