### PR TITLE
Fix writeable client reads not flushing staged edits

### DIFF
--- a/.changeset/writeable-client-flush-edits.md
+++ b/.changeset/writeable-client-flush-edits.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client": patch
+"@osdk/functions": patch
+---
+
+Fix writeable client reads not flushing staged edits: persist `flushEdits` onto the client context and wire it to the EditRequestManager so awaiting a read (fetchOne/fetchPage/aggregate/query) flushes pending creates/updates first.

--- a/packages/client/src/createMinimalClient.ts
+++ b/packages/client/src/createMinimalClient.ts
@@ -78,6 +78,7 @@ export function createMinimalClient(
     ontologyRid: metadata.ontologyRid,
     logger: options.logger,
     transactionId: options.transactionId,
+    flushEdits: options.flushEdits,
     scenarioRid: options.scenarioRid,
     clientCacheKey: {} as ClientCacheKey,
     requestContext: {},

--- a/packages/functions/src/transactions/createWriteableClient.test.ts
+++ b/packages/functions/src/transactions/createWriteableClient.test.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Employee } from "@osdk/client.test.ontology";
+import type { SetupServer } from "@osdk/shared.test";
+import {
+  LegacyFauxFoundry,
+  MockOntologiesV2,
+  startNodeApiServer,
+} from "@osdk/shared.test";
+import type { Mock } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Edits } from "../edits/types.js";
+import { createWriteableClient } from "./createWriteableClient.js";
+import { EditRequestManager } from "./EditRequestManager.js";
+import type { WriteableClient } from "./WriteableClient.js";
+
+describe("createWriteableClient", () => {
+  let client: WriteableClient<Edits.Object<Employee>>;
+  let apiServer: SetupServer;
+  let baseUrl: string;
+  let mockedRequestHandler: Mock<
+    Parameters<typeof MockOntologiesV2.OntologyTransactions.postEdits>[1]
+  >;
+
+  beforeAll(() => {
+    const testSetup = startNodeApiServer(
+      new LegacyFauxFoundry(),
+      createWriteableClient.bind(null, "transaction"),
+    );
+    ({ client, apiServer } = testSetup);
+    baseUrl = testSetup.fauxFoundry.baseUrl;
+
+    mockedRequestHandler = vi.fn<
+      Parameters<typeof MockOntologiesV2.OntologyTransactions.postEdits>[1]
+    >(async () => ({ status: 200, body: {} }));
+    apiServer.use(
+      MockOntologiesV2.OntologyTransactions.postEdits(
+        baseUrl,
+        mockedRequestHandler,
+      ),
+    );
+
+    return () => {
+      apiServer.close();
+    };
+  });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("flushes pending edits when a read is awaited", async () => {
+    const flushSpy = vi.spyOn(
+      EditRequestManager.prototype,
+      "flushPendingEdits",
+    );
+
+    void client.create(Employee, { employeeId: 1, fullName: "John Doe" });
+
+    expect(flushSpy).not.toHaveBeenCalled();
+
+    // Awaiting any read must flush the buffered edit first.
+    await client(Employee).fetchOne(50030);
+
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+    expect(mockedRequestHandler).toHaveBeenCalledTimes(1);
+    expect(await mockedRequestHandler.mock.calls[0][0].request.json())
+      .toMatchInlineSnapshot(`
+        {
+          "edits": [
+            {
+              "objectType": "Employee",
+              "properties": {
+                "employeeId": 1,
+                "fullName": "John Doe",
+              },
+              "type": "addObject",
+            },
+          ],
+        }
+      `);
+  });
+});

--- a/packages/functions/src/transactions/createWriteableClient.ts
+++ b/packages/functions/src/transactions/createWriteableClient.ts
@@ -48,13 +48,19 @@ export function createWriteableClient<
 ): WriteableClient<X> {
   const ontologyRid = args[1];
 
+  // Read operations (fetchPage, aggregate, applyQuery, ...) call
+  // `client.flushEdits()` before hitting the wire so staged edits are visible
+  // to the read. The arrow defers resolving `editRequestManager` until call
+  // time; flushEdits is only invoked during a read, which always happens after
+  // construction, so the reference is assigned by then.
+  let editRequestManager: EditRequestManager;
   const client = createClientWithTransaction(
     transactionId,
-    async () => {},
+    () => editRequestManager.flushPendingEdits(),
     ...args,
   ) as Client;
 
-  const editRequestManager = new EditRequestManager(
+  editRequestManager = new EditRequestManager(
     client as WriteableClient<any>, // This cast is safe because we create the writeable client properties below.
   );
 
@@ -63,7 +69,7 @@ export function createWriteableClient<
     client,
     {
       link: {
-        value: function<
+        value<
           SOL extends AddLinkSources<X>,
           A extends AddLinkApiNames<X, SOL>,
         >(
@@ -97,7 +103,7 @@ export function createWriteableClient<
         },
       },
       unlink: {
-        value: function<
+        value<
           SOL extends RemoveLinkSources<X>,
           A extends RemoveLinkApiNames<X, SOL>,
         >(
@@ -128,7 +134,7 @@ export function createWriteableClient<
         },
       },
       create: {
-        value: async function<OTD extends CreatableObjectOrInterfaceTypes<X>>(
+        async value<OTD extends CreatableObjectOrInterfaceTypes<X>>(
           obj: OTD,
           properties: CreatableObjectOrInterfaceTypeProperties<X, OTD>,
         ): Promise<void> {
@@ -145,7 +151,7 @@ export function createWriteableClient<
         },
       },
       update: {
-        value: function<
+        value<
           SOL extends UpdatableObjectOrInterfaceLocators<X>,
           OTD extends UpdatableObjectOrInterfaceLocatorProperties<X, SOL>,
         >(
@@ -166,7 +172,7 @@ export function createWriteableClient<
         },
       },
       delete: {
-        value: function<OL extends DeletableObjectOrInterfaceLocators<X>>(
+        value<OL extends DeletableObjectOrInterfaceLocators<X>>(
           obj: OL,
         ): Promise<void> {
           return editRequestManager.postEdit({

--- a/packages/functions/src/transactions/createWriteableClient.ts
+++ b/packages/functions/src/transactions/createWriteableClient.ts
@@ -48,11 +48,6 @@ export function createWriteableClient<
 ): WriteableClient<X> {
   const ontologyRid = args[1];
 
-  // Read operations (fetchPage, aggregate, applyQuery, ...) call
-  // `client.flushEdits()` before hitting the wire so staged edits are visible
-  // to the read. The arrow defers resolving `editRequestManager` until call
-  // time; flushEdits is only invoked during a read, which always happens after
-  // construction, so the reference is assigned by then.
   let editRequestManager: EditRequestManager;
   const client = createClientWithTransaction(
     transactionId,


### PR DESCRIPTION
## Problem

On a writeable client, staging an edit and then awaiting a read doesn't see the edit:

```ts
client.create(TransactionTestObject, { name: str });
const rid = await client(TransactionTestObject).fetchOne(str, { $includeRid: true }); // misses the create
```

Read operations (`fetchPage`/`aggregate`/`applyQuery`/...) already guard an auto-flush on `client.flushEdits()` so that edits staged via the writeable client are dispatched to the transaction before the read. Two links in that chain were broken, so the mechanism was effectively dead:

1. **`createMinimalClient`** declared `flushEdits` on its options and on `MinimalClientContext`, but never copied `options.flushEdits` onto the context object. `client.flushEdits` was therefore always `undefined` and the `if (client.flushEdits != null)` guard never fired.
2. **`createWriteableClient`** passed `async () => {}` (a no-op) as the `flushEdits` callback to `createClientWithTransaction` instead of wiring it to the `EditRequestManager`.

## Fix

- `createMinimalClient.ts`: persist `flushEdits: options.flushEdits` onto the client context.
- `createWriteableClient.ts`: wire the callback to `() => editRequestManager.flushPendingEdits()`, using a deferred `let` to resolve the construction-order cycle (the manager needs the client, the client context needs the callback).

## Test

Added `createWriteableClient.test.ts`: stage a `create` without an explicit flush, then await `fetchOne`, asserting `flushPendingEdits` runs and the staged `addObject` edit is dispatched. Verified it fails if either fix is reverted.

## Verification

- Typecheck passes for `@osdk/client` and `@osdk/functions`.
- Full suites pass: functions 43/43, client 278/278.
- dprint + pre-commit hooks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)