### PR TITLE
Export createAuthlessClient from @osdk/oauth

### DIFF
--- a/.changeset/new-pandas-judge.md
+++ b/.changeset/new-pandas-judge.md
@@ -1,0 +1,5 @@
+---
+"@osdk/oauth": minor
+---
+
+Add Supported Client for Public Apps

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -16,6 +16,7 @@
 
 export type { TokenStorageType } from "./common.js";
 export type { ConfidentialOauthClient } from "./ConfidentialOauthClient.js";
+export { createAuthlessClient } from "./createAuthlessClient.js";
 export { createConfidentialOauthClient } from "./createConfidentialOauthClient.js";
 export {
   createPublicOauthClient,


### PR DESCRIPTION
Exposes the existing createAuthlessClient (used by Public Apps that talk to Foundry without an OAuth login flow) as a public API of @osdk/oauth.

### What
Exposes the existing `createAuthlessClient` as a public export of `@osdk/oauth`.

### Why
Self-Service Public Apps talk to Foundry **without an OAuth login flow**. Public Apps instead use an authless client. The implementation (`createAuthlessClient.ts`) already shipped in the package source but was never exported, so downstream apps and the upcoming React (Public) template can't import it. This makes it part of the public API.

### Changes
- `packages/oauth/src/index.ts` — add `export { createAuthlessClient } from "./createAuthlessClient.js"`
- Changeset: `@osdk/oauth` **minor** (new public API surface)

### Linked PRs
First of a 3-PR stack splitting up the Public Apps work:
1. **(this PR)** export `createAuthlessClient`
2. https://github.com/palantir/osdk-ts/pull/3431
3. https://github.com/palantir/osdk-ts/pull/3432