### PR TITLE
[Components] clear function/derived cell when new value is null

### DIFF
--- a/.changeset/object-table-clear-null-derived-cell.md
+++ b/.changeset/object-table-clear-null-derived-cell.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+ObjectTable: clear a function/derived-property cell when its value disappears from a resolved query result instead of retaining the stale previous value.

--- a/packages/react-components/src/object-table/hooks/__tests__/useFunctionColumnsData.test.ts
+++ b/packages/react-components/src/object-table/hooks/__tests__/useFunctionColumnsData.test.ts
@@ -550,6 +550,59 @@ describe("useFunctionColumnsData", () => {
     });
   });
 
+  it("clears a cell whose value disappears from a resolved result, but keeps previous data while reloading", () => {
+    // First render: obj1 has a value.
+    vi.mocked(useOsdkFunctions).mockReturnValue([
+      {
+        data: { "TestObject:obj1": { value: "result1" } },
+        error: undefined,
+        isLoading: false,
+        lastUpdated: Date.now(),
+      },
+    ] as unknown as UseOsdkFunctionsResult);
+
+    const { result, rerender } = renderHook(
+      () =>
+        useFunctionColumnsData({
+          objectOrInterfaceType: TestObjectType,
+          objects: mockObjects,
+          columnDefinitions,
+        }),
+    );
+
+    expect(result.current.testColumn.obj1.data).toEqual({ value: "result1" });
+
+    // Refetch in flight: obj1's key not yet present but loading — keep the
+    // previous value so the cell doesn't flash empty.
+    vi.mocked(useOsdkFunctions).mockReturnValue([
+      {
+        data: {},
+        error: undefined,
+        isLoading: true,
+        lastUpdated: 0,
+      },
+    ] as unknown as UseOsdkFunctionsResult);
+    rerender();
+
+    expect(result.current.testColumn.obj1.isLoading).toBe(true);
+    expect(result.current.testColumn.obj1.data).toEqual({ value: "result1" });
+
+    // Refetch resolved with obj1 absent (its value became null) — the cell
+    // must clear instead of retaining the stale previous value.
+    vi.mocked(useOsdkFunctions).mockReturnValue([
+      {
+        data: {},
+        error: undefined,
+        isLoading: false,
+        lastUpdated: Date.now(),
+      },
+    ] as unknown as UseOsdkFunctionsResult);
+    rerender();
+
+    expect(result.current.testColumn.obj1.isLoading).toBe(false);
+    expect(result.current.testColumn.obj1.data).toBeUndefined();
+  });
+
   it("should handle errors gracefully", async () => {
     const mockError = new Error("Query failed");
 

--- a/packages/react-components/src/object-table/hooks/useFunctionColumnsData.ts
+++ b/packages/react-components/src/object-table/hooks/useFunctionColumnsData.ts
@@ -384,9 +384,15 @@ function resolveCell(
     const rawData = result.functionsMap[objectKey];
     return { isLoading: false, data: getValue ? getValue(rawData) : rawData };
   }
-  // Key not in results — still loading, or query returned no data for this object
-  // Return with previous data
-  return { isLoading: result.isLoading, data: prevData };
+  // Key not in results. While the query is still loading, keep showing the
+  // previous data so the cell doesn't flash empty during a refetch. Once the
+  // query has resolved without an entry for this object, its value is gone —
+  // clear the cell instead of retaining the stale previous value (otherwise a
+  // cell whose derived value became null keeps displaying the old value).
+  return {
+    isLoading: result.isLoading,
+    data: result.isLoading ? prevData : undefined,
+  };
 }
 
 const useStableObjects = <


### PR DESCRIPTION
resolveCell fell back to the previous value whenever an object's key was absent from the query result — including after the query had resolved. A derived-property cell whose value became null kept showing the old value. Only retain previous data while the query is loading (to avoid flashing empty during a refetch); clear the cell once it resolves without an entry.