### PR TITLE
@osdk/functions Byte and Short types support

### DIFF
--- a/.changeset/fuzzy-nights-jog.md
+++ b/.changeset/fuzzy-nights-jog.md
@@ -1,0 +1,5 @@
+---
+"@osdk/functions": minor
+---
+
+Added support for Byte and Short types in @osdk/functions

--- a/etc/functions.report.api.md
+++ b/etc/functions.report.api.md
@@ -44,6 +44,11 @@ declare namespace Aliases {
 export { Attachment }
 
 // @public (undocumented)
+export type Byte<T extends number = number> = T & {
+    	__byteBrand?: void
+};
+
+// @public (undocumented)
 export type ClassificationMarking<T extends string = string> = T & {
     	__markingBrand?: "classification"
 };
@@ -253,6 +258,11 @@ export interface RidLinkTarget {
     	// (undocumented)
     type: "rid";
 }
+
+// @public (undocumented)
+export type Short<T extends number = number> = T & {
+    	_shortBrand?: void
+};
 
 // @public (undocumented)
 interface Source {

--- a/packages/functions/src/PrimitiveTypes.ts
+++ b/packages/functions/src/PrimitiveTypes.ts
@@ -18,6 +18,8 @@ export type Integer<T extends number = number> = T & { __integerBrand?: void };
 export type Float<T extends number = number> = T & { __floatBrand?: void };
 export type Double<T extends number = number> = T & { __doubleBrand?: void };
 export type Long<T extends string = string> = T & { __longBrand?: void };
+export type Byte<T extends number = number> = T & { __byteBrand?: void };
+export type Short<T extends number = number> = T & { _shortBrand?: void };
 
 export type DateISOString<T extends string = string> = T & {
   __dateBrand?: void;

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -15,11 +15,13 @@
  */
 
 export type {
+  Byte,
   DateISOString,
   Double,
   Float,
   Integer,
   Long,
+  Short,
   TimestampISOString,
 } from "./PrimitiveTypes.js";
 


### PR DESCRIPTION
### Overview
Added support for Byte and Short types

```tsx
import { Byte, Short } from "@osdk/functions"

function myFunction(byteParam: Byte, shortParam: Short): void {
   // implementation
}

export default myFunction;
```