### PR TITLE
fix osdk-docs-context codegen missing esm dependency

### DIFF
--- a/.changeset/osdk-docs-context-codegen-esm-dep.md
+++ b/.changeset/osdk-docs-context-codegen-esm-dep.md
@@ -1,4 +1,0 @@
----
----
-
-Add `@osdk/typescript-sdk-docs-examples#transpileEsm` to the `osdk-docs-context` codegen task graph so the esm output it imports at runtime is always built first.

--- a/.changeset/osdk-docs-context-codegen-esm-dep.md
+++ b/.changeset/osdk-docs-context-codegen-esm-dep.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add `@osdk/typescript-sdk-docs-examples#transpileEsm` to the `osdk-docs-context` codegen task graph so the esm output it imports at runtime is always built first.

--- a/packages/osdk-docs-context/turbo.json
+++ b/packages/osdk-docs-context/turbo.json
@@ -5,7 +5,8 @@
       "outputs": ["src/generated/**/*"],
       "dependsOn": [
         "@osdk/osdk-docs-context-generator#transpile",
-        "@osdk/typescript-sdk-docs-examples#codegen"
+        "@osdk/typescript-sdk-docs-examples#codegen",
+        "@osdk/typescript-sdk-docs-examples#transpileEsm"
       ]
     }
   }


### PR DESCRIPTION
codegen for osdk-docs-context imports the esm output of typescript-sdk-docs-examples at runtime but never forced it to be built, causing ERR_MODULE_NOT_FOUND during release codegen

• add `@osdk/typescript-sdk-docs-examples#transpileEsm` to the codegen task graph in `packages/osdk-docs-context/turbo.json`
• generate-osdk-context imports build/esm/index.js, which only the transpileEsm task produces