### PR TITLE
Support interface instance invalidation

### DIFF
--- a/.changeset/quiet-spiders-gather.md
+++ b/.changeset/quiet-spiders-gather.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Allow `invalidateObjects` to accept interface instances (`Osdk.Instance<ObjectOrInterfaceDefinition>`).

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -580,8 +580,8 @@ export interface ObservableClient extends ObserveLinks {
    */
   invalidateObjects(
     objects:
-      | Osdk.Instance<ObjectTypeDefinition>
-      | ReadonlyArray<Osdk.Instance<ObjectTypeDefinition>>,
+      | Osdk.Instance<ObjectOrInterfaceDefinition>
+      | ReadonlyArray<Osdk.Instance<ObjectOrInterfaceDefinition>>,
   ): Promise<void>;
 
   /**

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -576,6 +576,8 @@ export interface ObservableClient extends ObserveLinks {
 
   /**
    * Invalidates specific objects in the cache.
+   *
+   * Interface instances invalidate their backing concrete object.
    * @param objects - Single object or array of objects to invalidate
    */
   invalidateObjects(

--- a/packages/client/src/observable/internal/ObservableClientImpl.ts
+++ b/packages/client/src/observable/internal/ObservableClientImpl.ts
@@ -290,8 +290,8 @@ export class ObservableClientImpl implements ObservableClient {
 
   public invalidateObjects(
     objects:
-      | Osdk.Instance<ObjectTypeDefinition>
-      | ReadonlyArray<Osdk.Instance<ObjectTypeDefinition>>,
+      | Osdk.Instance<ObjectOrInterfaceDefinition>
+      | ReadonlyArray<Osdk.Instance<ObjectOrInterfaceDefinition>>,
   ): Promise<void> {
     return this.__experimentalStore.invalidateObjects(objects);
   }

--- a/packages/client/src/observable/internal/Store.invalidation.test.ts
+++ b/packages/client/src/observable/internal/Store.invalidation.test.ts
@@ -681,9 +681,11 @@ describe("Store Invalidation Type Isolation", () => {
 
       await cache.invalidateObjects(emp1AsFoo);
 
-      await new Promise(resolve => setTimeout(resolve, 500));
-
-      expect(empSubFn.next).toHaveBeenCalled();
+      await vi.waitFor(() => {
+        expect(empSubFn.next).toHaveBeenCalled();
+      });
+      // The two objects are invalidated in the same batch, so once emp1's
+      // subscription has fired the decision for emp2 has already been made.
       expect(emp2SubFn.next).not.toHaveBeenCalled();
     });
   });

--- a/packages/client/src/observable/internal/Store.invalidation.test.ts
+++ b/packages/client/src/observable/internal/Store.invalidation.test.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { Employee, Office, Todo } from "@osdk/client.test.ontology";
+import {
+  Employee,
+  FooInterface,
+  Office,
+  Todo,
+} from "@osdk/client.test.ontology";
 import {
   FauxFoundry,
   ontologies,
@@ -645,6 +650,41 @@ describe("Store Invalidation Type Isolation", () => {
       await new Promise(resolve => setTimeout(resolve, 500));
 
       expect(empSubFn.next).not.toHaveBeenCalled();
+    });
+
+    it("should invalidate the backing object when given an interface instance", async () => {
+      const { subFn: empSubFn } = await expectStandardObserveObject({
+        cache,
+        type: Employee,
+        primaryKey: EMPLOYEE_1_ID,
+      });
+      const { subFn: emp2SubFn } = await expectStandardObserveObject({
+        cache,
+        type: Employee,
+        primaryKey: EMPLOYEE_2_ID,
+      });
+
+      empSubFn.next.mockClear();
+      emp2SubFn.next.mockClear();
+
+      // An interface-origin instance is one concrete object viewed through the
+      // interface lens; it carries the backing object's $objectType/$primaryKey.
+      const { data: foos } = await client(FooInterface).fetchPage();
+      const emp1AsFoo = foos.find(foo =>
+        foo.$objectType === Employee.apiName
+        && foo.$primaryKey === EMPLOYEE_1_ID
+      );
+      invariant(emp1AsFoo);
+      expect(emp1AsFoo.$apiName).toBe(FooInterface.apiName);
+      expect(emp1AsFoo.$objectType).toBe(Employee.apiName);
+      expect(emp1AsFoo.$primaryKey).toBe(EMPLOYEE_1_ID);
+
+      await cache.invalidateObjects(emp1AsFoo);
+
+      await new Promise(resolve => setTimeout(resolve, 500));
+
+      expect(empSubFn.next).toHaveBeenCalled();
+      expect(emp2SubFn.next).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/client/src/observable/internal/Store.ts
+++ b/packages/client/src/observable/internal/Store.ts
@@ -19,6 +19,7 @@ import type {
   ActionEditResponse,
   ActionValidationResponse,
   Logger,
+  ObjectOrInterfaceDefinition,
   ObjectTypeDefinition,
   Osdk,
   PrimaryKeyType,
@@ -638,8 +639,8 @@ export class Store {
 
   public async invalidateObjects(
     objects:
-      | Osdk.Instance<ObjectTypeDefinition>
-      | ReadonlyArray<Osdk.Instance<ObjectTypeDefinition>>,
+      | Osdk.Instance<ObjectOrInterfaceDefinition>
+      | ReadonlyArray<Osdk.Instance<ObjectOrInterfaceDefinition>>,
   ): Promise<void> {
     const objectsArray = Array.isArray(objects) ? objects : [objects];
     const promises: Array<Promise<unknown>> = [];


### PR DESCRIPTION
## Summary
- allow observable cache invalidation to accept interface instances
- invalidate the backing concrete object for interface-origin instances
- add coverage for interface-origin invalidation

## Test plan
- pnpm --dir=packages/client vitest run src/observable/internal/Store.invalidation.test.ts
- pnpm turbo typecheck --filter=@osdk/client
- pnpm turbo check-api --filter=@osdk/client