### PR TITLE
fix(react-components): switch xlsx to xlsx-republish to address CVE

### DIFF
--- a/.changeset/fix-xlsx-cdn-replacement.md
+++ b/.changeset/fix-xlsx-cdn-replacement.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Replace `xlsx` dependency with `xlsx-republish`, a community republish of the latest SheetJS CDN release (`0.20.3`) back to npm. The maintainer-published `xlsx` on npm is pinned at `0.18.5` (which has a known prototype-pollution CVE) and SheetJS now distributes fixed releases only via their own CDN, so npm consumers cannot get a patched version through the registry.

--- a/packages/react-components-storybook/package.json
+++ b/packages/react-components-storybook/package.json
@@ -49,7 +49,7 @@
     "storybook-addon-tag-badges": "^3.1.0",
     "typescript": "~5.5.4",
     "vite": "^6.0.6",
-    "xlsx": "^0.18.5"
+    "xlsx-republish": "0.20.3"
   },
   "msw": {
     "workerDirectory": [

--- a/packages/react-components-storybook/src/stories/DocumentViewer/DocumentViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/DocumentViewer/DocumentViewer.stories.tsx
@@ -21,7 +21,7 @@ import type { DocumentViewerProps } from "@osdk/react-components/experimental/do
 import { DocumentViewer } from "@osdk/react-components/experimental/document-viewer";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { http, HttpResponse, passthrough } from "msw";
-import { utils, write } from "xlsx";
+import { utils, write } from "xlsx-republish";
 
 const SAMPLE_PDF_URL =
   `${import.meta.env.BASE_URL}compressed.tracemonkey-pldi-09.pdf`;

--- a/packages/react-components-storybook/src/stories/ExcelViewer/ExcelViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ExcelViewer/ExcelViewer.stories.tsx
@@ -28,7 +28,7 @@ import {
 } from "@osdk/react-components/experimental/excel-viewer";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { http, passthrough } from "msw";
-import { utils, write } from "xlsx";
+import { utils, write } from "xlsx-republish";
 
 const SAMPLE_SPREADSHEET: ParsedSpreadsheet = {
   sheets: [

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -195,7 +195,7 @@
     "react-markdown": "^9.0.3",
     "remark-gfm": "^4.0.1",
     "utif": "^3.1.0",
-    "xlsx": "^0.18.5"
+    "xlsx-republish": "0.20.3"
   },
   "peerDependencies": {
     "@osdk/aip-core": "workspace:^",

--- a/packages/react-components/src/excel-viewer/parseSpreadsheet.ts
+++ b/packages/react-components/src/excel-viewer/parseSpreadsheet.ts
@@ -16,7 +16,7 @@
 
 /* cspell:words defval */
 
-import { read, utils } from "xlsx";
+import { read, utils } from "xlsx-republish";
 import type { ParsedSpreadsheet, SheetData } from "./ExcelViewerApi.js";
 
 export async function parseSpreadsheetFromResponse(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4688,9 +4688,9 @@ importers:
       utif:
         specifier: ^3.1.0
         version: 3.1.0
-      xlsx:
-        specifier: ^0.18.5
-        version: 0.18.5
+      xlsx-republish:
+        specifier: 0.20.3
+        version: 0.20.3
     devDependencies:
       '@osdk/aip-core':
         specifier: workspace:*
@@ -4840,9 +4840,9 @@ importers:
       vite:
         specifier: ^6.0.6
         version: 6.4.2(@types/node@20.19.13)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.3)
-      xlsx:
-        specifier: ^0.18.5
-        version: 0.18.5
+      xlsx-republish:
+        specifier: 0.20.3
+        version: 0.20.3
 
   packages/react-components-styles:
     devDependencies:
@@ -12219,10 +12219,6 @@ packages:
     resolution: {integrity: sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==}
     engines: {node: '>= 10.0.0'}
 
-  adler-32@1.3.1:
-    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
-    engines: {node: '>=0.8'}
-
   adm-zip@0.5.16:
     resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
     engines: {node: '>=12.0'}
@@ -12899,10 +12895,6 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
-  cfb@1.2.2:
-    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
-    engines: {node: '>=0.8'}
-
   chai@5.2.0:
     resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
     engines: {node: '>=12'}
@@ -13106,10 +13098,6 @@ packages:
 
   codemirror@6.0.2:
     resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
-
-  codepage@1.15.0:
-    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
-    engines: {node: '>=0.8'}
 
   collapse-white-space@1.0.6:
     resolution: {integrity: sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==}
@@ -14886,10 +14874,6 @@ packages:
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
-
-  frac@1.1.2:
-    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
-    engines: {node: '>=0.8'}
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -19717,10 +19701,6 @@ packages:
     resolution: {integrity: sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==}
     engines: {node: '>=12'}
 
-  ssf@0.11.2:
-    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
-    engines: {node: '>=0.8'}
-
   ssri@10.0.6:
     resolution: {integrity: sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -21331,20 +21311,12 @@ packages:
   wildcard@2.0.1:
     resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
 
-  wmf@1.0.2:
-    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
-    engines: {node: '>=0.8'}
-
   wonka@6.3.4:
     resolution: {integrity: sha512-CjpbqNtBGNAeyNS/9W6q3kSkKE52+FjIj7AkFlLr11s/VWGUu6a2CdYSdGxocIhIVjaW/zchesBQUKPVU69Cqg==}
 
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
-
-  word@0.3.0:
-    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
-    engines: {node: '>=0.8'}
 
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
@@ -21433,8 +21405,8 @@ packages:
     resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
     engines: {node: '>=12'}
 
-  xlsx@0.18.5:
-    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+  xlsx-republish@0.20.3:
+    resolution: {integrity: sha512-iIO8XheF1Ml+78jeZQuowobWIpRW/IxVmQEUA0JUNhtdLvgn5xxWTiIkr2dslnDjVANtqRhUvYDfr+Nw3fw3Ug==}
     engines: {node: '>=0.8'}
     hasBin: true
 
@@ -30103,8 +30075,6 @@ snapshots:
 
   address@1.2.2: {}
 
-  adler-32@1.3.1: {}
-
   adm-zip@0.5.16: {}
 
   agent-base@6.0.2:
@@ -30932,11 +30902,6 @@ snapshots:
 
   ccount@2.0.1: {}
 
-  cfb@1.2.2:
-    dependencies:
-      adler-32: 1.3.1
-      crc-32: 1.2.2
-
   chai@5.2.0:
     dependencies:
       assertion-error: 2.0.1
@@ -31168,8 +31133,6 @@ snapshots:
       '@codemirror/search': 6.6.0
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.40.0
-
-  codepage@1.15.0: {}
 
   collapse-white-space@1.0.6: {}
 
@@ -33442,8 +33405,6 @@ snapshots:
   format@0.2.2: {}
 
   forwarded@0.2.0: {}
-
-  frac@1.1.2: {}
 
   fraction.js@4.3.7: {}
 
@@ -39745,10 +39706,6 @@ snapshots:
 
   srcset@4.0.0: {}
 
-  ssf@0.11.2:
-    dependencies:
-      frac: 1.1.2
-
   ssri@10.0.6:
     dependencies:
       minipass: 7.1.3
@@ -41932,13 +41889,9 @@ snapshots:
 
   wildcard@2.0.1: {}
 
-  wmf@1.0.2: {}
-
   wonka@6.3.4: {}
 
   word-wrap@1.2.5: {}
-
-  word@0.3.0: {}
 
   wordwrap@1.0.0: {}
 
@@ -42015,15 +41968,7 @@ snapshots:
 
   xdg-basedir@5.1.0: {}
 
-  xlsx@0.18.5:
-    dependencies:
-      adler-32: 1.3.1
-      cfb: 1.2.2
-      codepage: 1.15.0
-      crc-32: 1.2.2
-      ssf: 0.11.2
-      wmf: 1.0.2
-      word: 0.3.0
+  xlsx-republish@0.20.3: {}
 
   xml-js@1.6.11:
     dependencies:


### PR DESCRIPTION
## Summary

The maintainer-published `xlsx` on npm is pinned at `0.18.5`, which has a known prototype-pollution CVE. SheetJS has stopped publishing fixed releases to the npm registry, distributing them only via their own CDN, so npm consumers cannot get a patched version through the registry.

This PR replaces the `xlsx` dependency with [`xlsx-republish`](https://www.npmjs.com/package/xlsx-republish), a well-regarded community republish of the latest SheetJS CDN release (`0.20.3`) back to npm. This gives downstream consumers (e.g. `foundry-sdk-asset-bundle`) a patched version through normal registry channels, without needing to pull tarballs from the SheetJS CDN.

## Changes

- `@osdk/react-components`: `xlsx@^0.18.5` → `xlsx-republish@^0.20.3`
- `@osdk/react-components-storybook`: same swap (storybook fixtures synthesize test `.xlsx` files via `xlsx`)
- Updated three import sites (one in `parseSpreadsheet.ts`, two in stories)
- Regenerated `pnpm-lock.yaml`

API usage is unchanged. `xlsx-republish` re-exports the same `read` / `utils` / `write` surface.