### PR TITLE
Version Packages

### DIFF
--- a/.changeset/fix-xlsx-cdn-replacement.md
+++ b/.changeset/fix-xlsx-cdn-replacement.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-components": patch
----
-
-Replace `xlsx` dependency with `xlsx-republish`, a community republish of the latest SheetJS CDN release (`0.20.3`) back to npm. The maintainer-published `xlsx` on npm is pinned at `0.18.5` (which has a known prototype-pollution CVE) and SheetJS now distributes fixed releases only via their own CDN, so npm consumers cannot get a patched version through the registry.

--- a/packages/react-components-styles/CHANGELOG.md
+++ b/packages/react-components-styles/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/react-components-styles
 
+## 0.26.0
+
 ## 0.25.0
 
 ## 0.24.0

--- a/packages/react-components-styles/package.json
+++ b/packages/react-components-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/react-components-styles",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/react-components
 
+## 0.26.0
+
+### Minor Changes
+
+- 67d5449: Replace `xlsx` dependency with `xlsx-republish`, a community republish of the latest SheetJS CDN release (`0.20.3`) back to npm. The maintainer-published `xlsx` on npm is pinned at `0.18.5` (which has a known prototype-pollution CVE) and SheetJS now distributes fixed releases only via their own CDN, so npm consumers cannot get a patched version through the registry.
+
 ## 0.25.0
 
 ### Minor Changes

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/react-components",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.


# Releases
## @osdk/react-components@0.26.0

### Minor Changes

-   67d5449: Replace `xlsx` dependency with `xlsx-republish`, a community republish of the latest SheetJS CDN release (`0.20.3`) back to npm. The maintainer-published `xlsx` on npm is pinned at `0.18.5` (which has a known prototype-pollution CVE) and SheetJS now distributes fixed releases only via their own CDN, so npm consumers cannot get a patched version through the registry.

## @osdk/react-components-styles@0.26.0


