### PR TITLE
Merge @osdk/cbac-components into @osdk/react-components

### DIFF
--- a/.changeset/merge-cbac-into-react-components.md
+++ b/.changeset/merge-cbac-into-react-components.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+Merge `@osdk/cbac-components` into `@osdk/react-components`. The CBAC picker (`CbacPicker`, `CbacPickerDialog`, `CbacBanner`, `BaseCbacPicker`, `BaseCbacBanner`, `BaseCbacPickerDialog`, `MaxClassificationField`, and selection-logic utilities) is now exported from `@osdk/react-components/experimental/cbac-picker`. The legacy `@osdk/cbac-components` package remains in the repository for reference but is no longer the source of truth.

--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -378,6 +378,7 @@ const archetypeRules = archetypes(
       attwExcludeEntrypoints: [
         "./experimental/action-form",
         "./experimental/aip-agent-chat",
+        "./experimental/cbac-picker",
         "./experimental/document-viewer",
         "./experimental/email-viewer",
         "./experimental/excel-viewer",

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -31,7 +31,7 @@ Pre-built, Ontology-aware React components with data loading, caching, and state
 - [FilterList](/react-components/FilterList) - Aggregation-based filter UI
 - [ActionForm](/react-components/ActionForm) - Generated and custom forms for applying OSDK actions
 - [PdfViewer](/react-components/PdfViewer) - PDF viewer with annotations and search
-- [CbacPicker](/cbac-components/CbacPicker) - Classification marking picker, dialog, and banner
+- [CbacPicker](/react-components/CbacPicker) - Classification marking picker, dialog, and banner
 
 ### Other Guides
 

--- a/docs/sidebarsReactComponents.ts
+++ b/docs/sidebarsReactComponents.ts
@@ -34,18 +34,7 @@ const sidebars: SidebarsConfig = {
         "ImageViewer",
         "VideoViewer",
         "XmlViewer",
-      ],
-    },
-    {
-      type: "category",
-      label: "@osdk/cbac-components",
-      collapsed: false,
-      items: [
-        {
-          type: "link",
-          label: "CbacPicker",
-          href: "/cbac-components/CbacPicker",
-        },
+        "CbacPicker",
       ],
     },
   ],

--- a/packages/cbac-components/AGENTS.md
+++ b/packages/cbac-components/AGENTS.md
@@ -1,5 +1,7 @@
 # @osdk/cbac-components
 
+> **DEPRECATED / RELOCATED**: The CBAC components have been merged into [`@osdk/react-components`](../react-components) and are now exported from `@osdk/react-components/experimental/cbac-picker`. This package is kept for legacy reference only and is no longer the source of truth. **New consumers should import from `@osdk/react-components`.** See [`../react-components/docs/CbacPicker.md`](../react-components/docs/CbacPicker.md) and [`../react-components/AGENTS.md`](../react-components/AGENTS.md) for usage guidance.
+
 React components for [classification-based access control (CBAC)](https://www.palantir.com/docs/foundry/security/classification-based-access-controls/). CBAC markings control who can access data — users select markings from categories (disjunctive = pick one, conjunctive = pick many) and the server computes restrictions (implied, disallowed, required markings) and resolves a classification banner. Pass in marking IDs and these components handle all of that automatically. Requires `@osdk/react` (see the `@osdk/react` package's `AGENTS.md` for hooks and provider setup).
 
 ## Components

--- a/packages/cbac-components/CLAUDE.md
+++ b/packages/cbac-components/CLAUDE.md
@@ -1,3 +1,5 @@
+> **DEPRECATED / RELOCATED**: The CBAC components have been merged into [`@osdk/react-components`](../react-components). The canonical source now lives at `packages/react-components/src/cbac-picker/` and is exported from `@osdk/react-components/experimental/cbac-picker`. This package is kept for legacy reference only — **do not develop new features here**. New work belongs in `@osdk/react-components` (see its `CLAUDE.md` and `CONTRIBUTING.md`).
+
 This documentation provides guidance for developing in `@osdk/cbac-components`.
 
 ## TypeScript Best Practices

--- a/packages/cbac-components/README.md
+++ b/packages/cbac-components/README.md
@@ -1,6 +1,6 @@
 # @osdk/cbac-components
 
-> **DEPRECATED / RELOCATED**: The CBAC components have been merged into [`@osdk/react-components`](../react-components) and are now exported from `@osdk/react-components/experimental/cbac-picker`. This package is kept in the repository for legacy reference only and is no longer the source of truth. **New consumers should import from `@osdk/react-components`.** See [`packages/react-components/docs/CbacPicker.md`](../react-components/docs/CbacPicker.md) for usage.
+> **DEPRECATED / RELOCATED**: The CBAC components have been merged into [`@osdk/react-components`](https://github.com/palantir/osdk-ts/tree/main/packages/react-components) and are now exported from `@osdk/react-components/experimental/cbac-picker`. This package is kept in the repository for legacy reference only and is no longer the source of truth. **New consumers should import from `@osdk/react-components`.** See [`packages/react-components/docs/CbacPicker.md`](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/CbacPicker.md) for usage.
 
 > **Beta Release**: This package is currently in beta. Please use the latest beta version for the most up-to-date features and fixes.
 

--- a/packages/cbac-components/README.md
+++ b/packages/cbac-components/README.md
@@ -1,5 +1,7 @@
 # @osdk/cbac-components
 
+> **DEPRECATED / RELOCATED**: The CBAC components have been merged into [`@osdk/react-components`](../react-components) and are now exported from `@osdk/react-components/experimental/cbac-picker`. This package is kept in the repository for legacy reference only and is no longer the source of truth. **New consumers should import from `@osdk/react-components`.** See [`packages/react-components/docs/CbacPicker.md`](../react-components/docs/CbacPicker.md) for usage.
+
 > **Beta Release**: This package is currently in beta. Please use the latest beta version for the most up-to-date features and fixes.
 
 React components for managing [classification-based access control (CBAC)](https://www.palantir.com/docs/foundry/security/classification-based-access-controls/) markings. CBAC markings control who can access data — each piece of data can be tagged with markings from different categories, and the combination determines its access restrictions.

--- a/packages/cbac-components/docs/CbacPicker.md
+++ b/packages/cbac-components/docs/CbacPicker.md
@@ -1,6 +1,6 @@
 # CbacPicker
 
-> **DEPRECATED / RELOCATED**: These components have moved into `@osdk/react-components` and are exported from `@osdk/react-components/experimental/cbac-picker`. The up-to-date guide lives at [/react-components/CbacPicker](/react-components/CbacPicker). This file is kept for legacy reference only.
+> **DEPRECATED / RELOCATED**: These components have moved into `@osdk/react-components` and are exported from `@osdk/react-components/experimental/cbac-picker`. The up-to-date guide lives at [../react-components/CbacPicker](../react-components/CbacPicker). This file is kept for legacy reference only.
 
 Components for managing [classification-based access control (CBAC)](https://www.palantir.com/docs/foundry/security/classification-based-access-controls/) markings. CBAC markings control who can access data — each piece of data can be tagged with markings from different categories, and the combination determines its access restrictions.
 

--- a/packages/react-components-storybook/.storybook/main.ts
+++ b/packages/react-components-storybook/.storybook/main.ts
@@ -83,8 +83,6 @@ const config: StorybookConfig = {
         // wrappers can import .md files without fragile relative paths.
         "@docs": new URL("../../react-components/docs", import.meta.url)
           .pathname,
-        "@cbac-docs": new URL("../../cbac-components/docs", import.meta.url)
-          .pathname,
         "@rc-root": new URL("../../react-components", import.meta.url)
           .pathname,
         // Polyfill Node.js modules for browser

--- a/packages/react-components-storybook/.storybook/styles.css
+++ b/packages/react-components-storybook/.storybook/styles.css
@@ -1,7 +1,6 @@
-@layer storybook, osdk.styles, cbac.components, themes;
+@layer storybook, osdk.styles, themes;
 
 @import "@blueprintjs/core/lib/css/blueprint.css" layer(storybook);
 @import "../src/styles/storybook.css" layer(storybook);
 @import "@osdk/react-components/styles.css" layer(osdk.styles);
-@import "@osdk/cbac-components/styles.css" layer(cbac.components);
 @import "./themes.css" layer(themes);

--- a/packages/react-components-storybook/package.json
+++ b/packages/react-components-storybook/package.json
@@ -23,7 +23,6 @@
   "devDependencies": {
     "@blueprintjs/core": "^6.10.0",
     "@osdk/api": "workspace:*",
-    "@osdk/cbac-components": "workspace:*",
     "@osdk/client": "workspace:*",
     "@osdk/monorepo.tsconfig": "workspace:~",
     "@osdk/react": "workspace:*",

--- a/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.stories.tsx
+++ b/packages/react-components-storybook/src/stories/CbacPicker/CbacPicker.stories.tsx
@@ -20,7 +20,7 @@ import {
   CbacPicker,
   CbacPickerDialog,
   computeMarkingStates,
-} from "@osdk/cbac-components/experimental";
+} from "@osdk/react-components/experimental/cbac-picker";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useCallback, useMemo, useState } from "react";
 import {

--- a/packages/react-components-storybook/src/stories/CbacPicker/mockData.ts
+++ b/packages/react-components-storybook/src/stories/CbacPicker/mockData.ts
@@ -19,7 +19,7 @@ import type {
   CbacBannerData,
   PickerMarking,
   PickerMarkingCategory,
-} from "@osdk/cbac-components/experimental";
+} from "@osdk/react-components/experimental/cbac-picker";
 
 export const classificationLevelCategory: PickerMarkingCategory = {
   id: "cat-classification",

--- a/packages/react-components/AGENTS.md
+++ b/packages/react-components/AGENTS.md
@@ -89,4 +89,4 @@ Before using any component, read the relevant doc from this package:
 - **TiffRenderer**: Read [docs/TiffViewer.md](./docs/TiffViewer.md) for props and usage
 - **MarkdownRenderer**: Read [docs/MarkdownRenderer.md](./docs/MarkdownRenderer.md) for props, examples, and theming
 - **FilterList**: Read [docs/FilterList.md](./docs/FilterList.md) for props, examples, and usage
-- **CbacPicker**: Read [docs/CbacPicker.md](./docs/CbacPicker.md) for props, examples, base components, and troubleshooting. Import from `@osdk/react-components/experimental/cbac-picker`.
+- **CbacPicker**: Read [docs/CbacPicker.md](./docs/CbacPicker.md) for props, examples, base components, and troubleshooting

--- a/packages/react-components/AGENTS.md
+++ b/packages/react-components/AGENTS.md
@@ -51,25 +51,32 @@ Components are imported from their individual entry points under `@osdk/react-co
 - `@osdk/react-components/experimental/video-viewer` — VideoViewer, BaseVideoViewer
 - `@osdk/react-components/experimental/xml-viewer` — XmlViewer, BaseXmlViewer
 
-| Component              | Description                                                                                                                                 |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| **ObjectTable**        | Table for displaying OSDK object sets with sorting, filtering, inline editing, column pinning/resizing, row selection, and infinite scroll. |
-| **BaseTable**          | OSDK-agnostic base table — use when building custom data fetching on top of the table UI.                                                   |
-| **FilterList**         | Aggregation-based filter UI for object sets with draggable reordering.                                                                      |
-| **BaseFilterList**     | OSDK-agnostic base filter list — use for custom filter implementations.                                                                     |
-| **ActionForm**         | Form for applying OSDK actions with generated or custom field definitions.                                                                  |
-| **BaseForm**           | OSDK-agnostic base action form — use when supplying explicit field content and submit handling.                                             |
-| **ColumnConfigDialog** | Dialog for managing column visibility and drag-and-drop reordering.                                                                         |
-| **PdfViewer**          | PDF viewer for OSDK Media objects with toolbar, search, annotations, sidebar (thumbnails/outline), highlight mode, and form fields.         |
-| **BasePdfViewer**      | OSDK-agnostic base PDF viewer — accepts a URL or ArrayBuffer directly. Use when building custom data fetching on top of the viewer UI.      |
-| **TiffRenderer**       | TIFF image renderer — accepts a `Uint8Array` and renders onto a canvas with size validation and error handling.                             |
-| **MarkdownRenderer**   | Markdown renderer that accepts a markdown string and renders it with styled headings, code blocks, tables, and links.                       |
-| **DocumentViewer**     | Unified media viewer that auto-detects file type (PDF, TIFF, image, video, Excel, email, markdown, XML) and renders the appropriate viewer. |
-| **EmailViewer**        | Email viewer — parses and renders `.eml` files with headers, HTML body (sandboxed iframe), and plain text fallback.                         |
-| **ExcelViewer**        | Excel viewer — parses and renders `.xlsx` spreadsheets with sheet tabs and column/row headers.                                              |
-| **ImageViewer**        | Image viewer — renders images (PNG, JPEG, GIF, SVG, WebP, BMP) with object-fit contain.                                                     |
-| **VideoViewer**        | Video viewer — renders video with native browser controls.                                                                                  |
-| **XmlViewer**          | XML viewer — renders XML content with syntax preservation.                                                                                  |
+| Component                  | Description                                                                                                                                 |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ObjectTable**            | Table for displaying OSDK object sets with sorting, filtering, inline editing, column pinning/resizing, row selection, and infinite scroll. |
+| **BaseTable**              | OSDK-agnostic base table — use when building custom data fetching on top of the table UI.                                                   |
+| **FilterList**             | Aggregation-based filter UI for object sets with draggable reordering.                                                                      |
+| **BaseFilterList**         | OSDK-agnostic base filter list — use for custom filter implementations.                                                                     |
+| **ActionForm**             | Form for applying OSDK actions with generated or custom field definitions.                                                                  |
+| **BaseForm**               | OSDK-agnostic base action form — use when supplying explicit field content and submit handling.                                             |
+| **ColumnConfigDialog**     | Dialog for managing column visibility and drag-and-drop reordering.                                                                         |
+| **PdfViewer**              | PDF viewer for OSDK Media objects with toolbar, search, annotations, sidebar (thumbnails/outline), highlight mode, and form fields.         |
+| **BasePdfViewer**          | OSDK-agnostic base PDF viewer — accepts a URL or ArrayBuffer directly. Use when building custom data fetching on top of the viewer UI.      |
+| **TiffRenderer**           | TIFF image renderer — accepts a `Uint8Array` and renders onto a canvas with size validation and error handling.                             |
+| **MarkdownRenderer**       | Markdown renderer that accepts a markdown string and renders it with styled headings, code blocks, tables, and links.                       |
+| **DocumentViewer**         | Unified media viewer that auto-detects file type (PDF, TIFF, image, video, Excel, email, markdown, XML) and renders the appropriate viewer. |
+| **EmailViewer**            | Email viewer — parses and renders `.eml` files with headers, HTML body (sandboxed iframe), and plain text fallback.                         |
+| **ExcelViewer**            | Excel viewer — parses and renders `.xlsx` spreadsheets with sheet tabs and column/row headers.                                              |
+| **ImageViewer**            | Image viewer — renders images (PNG, JPEG, GIF, SVG, WebP, BMP) with object-fit contain.                                                     |
+| **VideoViewer**            | Video viewer — renders video with native browser controls.                                                                                  |
+| **XmlViewer**              | XML viewer — renders XML content with syntax preservation.                                                                                  |
+| **CbacPicker**             | Picker for classification-based access control (CBAC) markings — disjunctive/conjunctive categories, restriction enforcement, banner.       |
+| **CbacPickerDialog**       | Dialog wrapper for `CbacPicker` with confirm/cancel actions and validation.                                                                 |
+| **CbacBanner**             | OSDK-aware classification banner that resolves a marking-set into a colored banner.                                                         |
+| **BaseCbacPicker**         | OSDK-agnostic base CBAC picker — use when building custom data fetching on top of the picker UI.                                            |
+| **BaseCbacBanner**         | OSDK-agnostic classification banner display with customizable colors and text.                                                              |
+| **BaseCbacPickerDialog**   | OSDK-agnostic dialog wrapper for `BaseCbacPicker`.                                                                                          |
+| **MaxClassificationField** | Field that lets users constrain the maximum classification allowed for a marking selection.                                                 |
 
 ## Documentation
 
@@ -82,3 +89,4 @@ Before using any component, read the relevant doc from this package:
 - **TiffRenderer**: Read [docs/TiffViewer.md](./docs/TiffViewer.md) for props and usage
 - **MarkdownRenderer**: Read [docs/MarkdownRenderer.md](./docs/MarkdownRenderer.md) for props, examples, and theming
 - **FilterList**: Read [docs/FilterList.md](./docs/FilterList.md) for props, examples, and usage
+- **CbacPicker**: Read [docs/CbacPicker.md](./docs/CbacPicker.md) for props, examples, base components, and troubleshooting. Import from `@osdk/react-components/experimental/cbac-picker`.

--- a/packages/react-components/CLAUDE.md
+++ b/packages/react-components/CLAUDE.md
@@ -141,6 +141,10 @@ For every state change with a built-in default behavior (sort, filter, select, e
 
 - Do not fix diagnostic warnings in old code
 
+## CBAC components
+
+The CBAC (classification-based access control) picker lives at `src/cbac-picker/` and is exported through `src/public/experimental/cbac-picker.ts` under the `@osdk/react-components/experimental/cbac-picker` subpath. It was merged in from the legacy `@osdk/cbac-components` package — see `docs/CbacPicker.md` for usage. The legacy package still exists on disk for reference but is no longer the source of truth.
+
 ## Common pitfalls
 
 - **NEVER `pnpm --dir <path> turbo` or `cd <path> && pnpm turbo`** — the `--dir` flag breaks Turbo (pnpm interprets the path as the command). Always `pnpm turbo <task> --filter=@osdk/react-components`. For non-turbo commands (vitest, lint), `pnpm --dir packages/react-components <cmd>` is fine

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -137,6 +137,7 @@ The components that this package will provide are:
 | `ImageViewer`    | Renders images (PNG, JPEG, GIF, SVG, WebP, BMP)                                     | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/ImageViewer.md)    |
 | `VideoViewer`    | Renders video with native browser controls                                          | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/VideoViewer.md)    |
 | `XmlViewer`      | Renders XML content with syntax preservation                                        | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/XmlViewer.md)      |
+| `CbacPicker`     | Picker for classification-based access control (CBAC) markings with banner display  | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/CbacPicker.md)     |
 
 ## Component Architecture
 

--- a/packages/react-components/docs/CbacPicker.md
+++ b/packages/react-components/docs/CbacPicker.md
@@ -1,14 +1,12 @@
 # CbacPicker
 
-> **DEPRECATED / RELOCATED**: These components have moved into `@osdk/react-components` and are exported from `@osdk/react-components/experimental/cbac-picker`. The up-to-date guide lives at [/react-components/CbacPicker](/react-components/CbacPicker). This file is kept for legacy reference only.
-
 Components for managing [classification-based access control (CBAC)](https://www.palantir.com/docs/foundry/security/classification-based-access-controls/) markings. CBAC markings control who can access data — each piece of data can be tagged with markings from different categories, and the combination determines its access restrictions.
 
 The picker lets users select markings grouped by category. Some categories are **disjunctive** (pick exactly one, like a sensitivity level) and others are **conjunctive** (pick any combination, like access groups). The server enforces which combinations are valid, which markings are implied by others, and which are disallowed.
 
 ## Prerequisites
 
-Before using CBAC components, make sure you have completed the library setup described in the [README](https://github.com/palantir/osdk-ts/blob/main/packages/cbac-components/README.md#setup), including:
+Before using CBAC components, make sure you have completed the library setup described in the [README](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/README.md#setup), including:
 
 - Installing the required dependencies
 - Wrapping your app with `OsdkProvider`
@@ -34,7 +32,7 @@ import {
   BaseCbacPickerDialog,
   CbacPicker,
   CbacPickerDialog,
-} from "@osdk/cbac-components/experimental";
+} from "@osdk/react-components/experimental/cbac-picker";
 ```
 
 ## Basic Usage
@@ -44,7 +42,7 @@ import {
 The simplest way to use the CBAC picker is inline with `CbacPicker`:
 
 ```typescript
-import { CbacPicker } from "@osdk/cbac-components/experimental";
+import { CbacPicker } from "@osdk/react-components/experimental/cbac-picker";
 import { useState } from "react";
 
 function ClassificationForm() {
@@ -66,7 +64,7 @@ This renders a marking picker that fetches categories and markings via the OSDK,
 For modal workflows, use `CbacPickerDialog`:
 
 ```typescript
-import { CbacPickerDialog } from "@osdk/cbac-components/experimental";
+import { CbacPickerDialog } from "@osdk/react-components/experimental/cbac-picker";
 import { useState } from "react";
 
 function ClassificationDialog() {
@@ -293,7 +291,7 @@ Groups a flat list of markings into `CategoryMarkingGroup` arrays, ordered by ca
 ### Example 1: Basic Inline Picker
 
 ```typescript
-import { CbacPicker } from "@osdk/cbac-components/experimental";
+import { CbacPicker } from "@osdk/react-components/experimental/cbac-picker";
 import { useState } from "react";
 
 function ClassificationForm() {
@@ -315,7 +313,7 @@ function ClassificationForm() {
 ### Example 2: Picker in a Dialog with Confirmation
 
 ```typescript
-import { CbacPickerDialog } from "@osdk/cbac-components/experimental";
+import { CbacPickerDialog } from "@osdk/react-components/experimental/cbac-picker";
 import { useState } from "react";
 
 function DocumentClassification() {
@@ -347,7 +345,7 @@ function DocumentClassification() {
 ### Example 3: Read-Only Classification Display
 
 ```typescript
-import { CbacPicker } from "@osdk/cbac-components/experimental";
+import { CbacPicker } from "@osdk/react-components/experimental/cbac-picker";
 
 interface ClassificationViewerProps {
   markingIds: string[];
@@ -376,7 +374,7 @@ import {
   type CategoryMarkingGroup,
   computeMarkingStates,
   toggleMarking,
-} from "@osdk/cbac-components/experimental";
+} from "@osdk/react-components/experimental/cbac-picker";
 import { useCallback, useMemo, useState } from "react";
 
 const CATEGORIES: CategoryMarkingGroup[] = [
@@ -450,7 +448,7 @@ The frontend handles **only UI concerns**: toggling selections (respecting conju
 
 ### Two-layer architecture
 
-`@osdk/cbac-components` follows the same pattern as `@osdk/react-components`:
+`@osdk/react-components` follows the same pattern as `@osdk/react-components`:
 
 - **OSDK layer** (`CbacPicker`, `CbacPickerDialog`) — fetches data using `@osdk/react` hooks, converts it to primitive props, passes to the base layer
 - **Base layer** (`BaseCbacPicker`, `BaseCbacBanner`, `BaseCbacPickerDialog`) — pure UI with no OSDK dependency, accepts primitive data directly
@@ -480,18 +478,18 @@ The frontend handles **only UI concerns**: toggling selections (respecting conju
 
 ### CSS not applied
 
-- Ensure you've imported `@osdk/cbac-components/styles.css` in your CSS entry file
+- Ensure you've imported `@osdk/react-components/styles.css` in your CSS entry file
 - If using CSS layers, verify the layer order includes the cbac styles
 
 ### Type errors with imports
 
-- All components and types should be imported from `@osdk/cbac-components/experimental`
+- All components and types should be imported from `@osdk/react-components/experimental/cbac-picker`
 - Ensure your `@osdk/react` and `@osdk/react-components` peer dependencies are installed
 
 ## Additional Resources
 
-- [CbacPicker Implementation](https://github.com/palantir/osdk-ts/blob/main/packages/cbac-components/src/cbac-picker/CbacPicker.tsx)
-- [CbacPickerDialog Implementation](https://github.com/palantir/osdk-ts/blob/main/packages/cbac-components/src/cbac-picker/CbacPickerDialog.tsx)
-- [Selection Logic](https://github.com/palantir/osdk-ts/blob/main/packages/cbac-components/src/cbac-picker/utils/selectionLogic.ts)
-- [Type Definitions](https://github.com/palantir/osdk-ts/blob/main/packages/cbac-components/src/cbac-picker/types.ts)
+- [CbacPicker Implementation](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/src/cbac-picker/CbacPicker.tsx)
+- [CbacPickerDialog Implementation](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/src/cbac-picker/CbacPickerDialog.tsx)
+- [Selection Logic](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/src/cbac-picker/utils/selectionLogic.ts)
+- [Type Definitions](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/src/cbac-picker/types.ts)
 - [@osdk/react Documentation](https://github.com/palantir/osdk-ts/blob/main/docs/react/getting-started.md)

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -43,6 +43,15 @@
       "require": "./build/cjs/public/experimental/action-form.cjs",
       "default": "./build/browser/public/experimental/action-form.js"
     },
+    "./experimental/cbac-picker": {
+      "browser": "./build/browser/public/experimental/cbac-picker.js",
+      "import": {
+        "types": "./build/types/public/experimental/cbac-picker.d.ts",
+        "default": "./build/esm/public/experimental/cbac-picker.js"
+      },
+      "require": "./build/cjs/public/experimental/cbac-picker.cjs",
+      "default": "./build/browser/public/experimental/cbac-picker.js"
+    },
     "./experimental/document-viewer": {
       "browser": "./build/browser/public/experimental/document-viewer.js",
       "import": {
@@ -163,7 +172,7 @@
     }
   },
   "scripts": {
-    "check-attw": "attw --pack . --exclude-entrypoints ./styles.css ./experimental/action-form ./experimental/aip-agent-chat ./experimental/document-viewer ./experimental/email-viewer ./experimental/excel-viewer ./experimental/filter-list ./experimental/image-viewer ./experimental/markdown-renderer ./experimental/object-table ./experimental/pdf-viewer ./experimental/theme ./experimental/tiff-renderer ./experimental/video-viewer ./experimental/xml-viewer",
+    "check-attw": "attw --pack . --exclude-entrypoints ./styles.css ./experimental/action-form ./experimental/aip-agent-chat ./experimental/cbac-picker ./experimental/document-viewer ./experimental/email-viewer ./experimental/excel-viewer ./experimental/filter-list ./experimental/image-viewer ./experimental/markdown-renderer ./experimental/object-table ./experimental/pdf-viewer ./experimental/theme ./experimental/tiff-renderer ./experimental/video-viewer ./experimental/xml-viewer",
     "check-spelling": "cspell --quiet .",
     "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
     "fix-lint": "eslint . --fix && dprint fmt",

--- a/packages/react-components/src/cbac-picker/CbacBanner.tsx
+++ b/packages/react-components/src/cbac-picker/CbacBanner.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCbacBanner } from "@osdk/react/platform-apis";
+import React from "react";
+import { BaseCbacBanner } from "./base/BaseCbacBanner.js";
+import { resolveBannerDisplay } from "./utils/cbacPickerUtils.js";
+
+export interface CbacBannerProps {
+  markingIds: string[];
+  onClick?: () => void;
+  onDismiss?: () => void;
+  className?: string;
+}
+
+export function CbacBanner({
+  markingIds,
+  onClick,
+  onDismiss,
+  className,
+}: CbacBannerProps): React.ReactElement {
+  const { banner } = useCbacBanner({ markingIds });
+  const resolved = resolveBannerDisplay(banner);
+
+  return (
+    <BaseCbacBanner
+      classificationString={resolved.classificationString}
+      textColor={resolved.textColor}
+      backgroundColors={resolved.backgroundColors}
+      onClick={onClick}
+      onDismiss={onDismiss}
+      className={className}
+    />
+  );
+}

--- a/packages/react-components/src/cbac-picker/CbacBannerPopover.tsx
+++ b/packages/react-components/src/cbac-picker/CbacBannerPopover.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  useCbacBanner,
+  useMarkingCategories,
+  useMarkings,
+} from "@osdk/react/platform-apis";
+import React from "react";
+import { BaseCbacBannerPopover } from "./base/BaseCbacBannerPopover.js";
+import { CbacPickerDialog } from "./CbacPickerDialog.js";
+import type { MaxClassificationConstraint } from "./types.js";
+import {
+  groupMarkingsByCategory,
+  resolveBannerDisplay,
+} from "./utils/cbacPickerUtils.js";
+
+export interface CbacBannerPopoverProps {
+  markingIds: string[];
+  onChange: (markingIds: string[]) => void;
+  maxClassificationConstraint?: MaxClassificationConstraint;
+  className?: string;
+}
+
+export function CbacBannerPopover({
+  markingIds,
+  onChange,
+  maxClassificationConstraint,
+  className,
+}: CbacBannerPopoverProps): React.ReactElement {
+  const {
+    banner,
+    isLoading: bannerLoading,
+    error: bannerError,
+    refetch: refetchBanner,
+  } = useCbacBanner({ markingIds });
+  const {
+    categories,
+    isLoading: categoriesLoading,
+    error: categoriesError,
+    refetch: refetchCategories,
+  } = useMarkingCategories();
+  const {
+    markings,
+    isLoading: markingsLoading,
+    error: markingsError,
+    refetch: refetchMarkings,
+  } = useMarkings();
+
+  const [isDialogOpen, setIsDialogOpen] = React.useState(false);
+
+  const isLoading = bannerLoading || categoriesLoading || markingsLoading;
+
+  const error = bannerError ?? categoriesError ?? markingsError;
+
+  const handleRetry = React.useCallback(() => {
+    refetchBanner();
+    refetchCategories();
+    refetchMarkings();
+  }, [refetchBanner, refetchCategories, refetchMarkings]);
+
+  const appliedMarkings = React.useMemo(
+    () => groupMarkingsByCategory(markingIds, categories, markings),
+    [markingIds, categories, markings],
+  );
+
+  const resolved = resolveBannerDisplay(banner);
+
+  const description = markingIds.length === 0
+    ? "This data has no classification restrictions."
+    : `This data is classified as: ${resolved.classificationString}`;
+
+  const handleEditClick = React.useCallback(() => {
+    setIsDialogOpen(true);
+  }, []);
+
+  const handleConfirm = React.useCallback((newMarkingIds: string[]) => {
+    onChange(newMarkingIds);
+    setIsDialogOpen(false);
+  }, [onChange]);
+
+  return (
+    <>
+      <BaseCbacBannerPopover
+        classificationString={resolved.classificationString}
+        textColor={resolved.textColor}
+        backgroundColors={resolved.backgroundColors}
+        appliedMarkings={appliedMarkings}
+        onEditClick={handleEditClick}
+        description={description}
+        isLoading={isLoading}
+        error={error}
+        onRetry={handleRetry}
+        className={className}
+      />
+      {isDialogOpen && (
+        <CbacPickerDialog
+          isOpen={isDialogOpen}
+          onOpenChange={setIsDialogOpen}
+          onConfirm={handleConfirm}
+          initialMarkingIds={markingIds}
+          maxClassificationConstraint={maxClassificationConstraint}
+        />
+      )}
+    </>
+  );
+}

--- a/packages/react-components/src/cbac-picker/CbacPicker.tsx
+++ b/packages/react-components/src/cbac-picker/CbacPicker.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { BaseCbacPicker } from "./base/BaseCbacPicker.js";
+import type { MaxClassificationConstraint } from "./types.js";
+import { useCbacSelection } from "./useCbacSelection.js";
+import { useConstraintCallout } from "./useConstraintCallout.js";
+import { EMPTY_ARRAY } from "./utils/cbacPickerUtils.js";
+import { toggleMarking } from "./utils/selectionLogic.js";
+
+export interface CbacPickerProps {
+  initialMarkingIds?: string[];
+  onChange: (markingIds: string[]) => void;
+  maxClassificationConstraint?: MaxClassificationConstraint;
+  readOnly?: boolean;
+  className?: string;
+}
+
+export function CbacPicker({
+  initialMarkingIds,
+  onChange,
+  maxClassificationConstraint,
+  readOnly,
+  className,
+}: CbacPickerProps): React.ReactElement {
+  const {
+    selectedIdsRef,
+    setSelectedIds,
+    categoryGroups,
+    markingStates,
+    banner,
+    requiredMarkingGroups,
+    isValid,
+    isLoading,
+    error,
+  } = useCbacSelection(initialMarkingIds);
+
+  const handleMarkingToggle = React.useCallback(
+    (markingId: string) => {
+      if (readOnly) {
+        return;
+      }
+      const newSelection = toggleMarking(
+        markingId,
+        selectedIdsRef.current,
+        categoryGroups,
+      );
+      setSelectedIds(newSelection);
+      onChange(newSelection);
+    },
+    [readOnly, categoryGroups, onChange],
+  );
+
+  const handleDismiss = React.useCallback(() => {
+    setSelectedIds(EMPTY_ARRAY);
+    onChange(EMPTY_ARRAY);
+  }, [onChange]);
+
+  const constraintCallout = useConstraintCallout(maxClassificationConstraint);
+
+  return (
+    <BaseCbacPicker
+      categories={categoryGroups}
+      markingStates={markingStates}
+      banner={banner}
+      onMarkingToggle={handleMarkingToggle}
+      onDismissBanner={handleDismiss}
+      requiredMarkingGroups={requiredMarkingGroups}
+      isValid={isValid}
+      readOnly={readOnly}
+      isLoading={isLoading}
+      error={error}
+      validationCallouts={constraintCallout}
+      className={className}
+    />
+  );
+}

--- a/packages/react-components/src/cbac-picker/CbacPickerDialog.tsx
+++ b/packages/react-components/src/cbac-picker/CbacPickerDialog.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { BaseCbacPickerDialog } from "./base/BaseCbacPickerDialog.js";
+import type { MaxClassificationConstraint } from "./types.js";
+import { useCbacSelection } from "./useCbacSelection.js";
+import { useConstraintCallout } from "./useConstraintCallout.js";
+import { getSubmitDisabledReason } from "./utils/validationMessages.js";
+
+export interface CbacPickerDialogProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (markingIds: string[]) => void;
+  initialMarkingIds?: string[];
+  maxClassificationConstraint?: MaxClassificationConstraint;
+}
+
+export function CbacPickerDialog({
+  isOpen,
+  onOpenChange,
+  onConfirm,
+  initialMarkingIds,
+  maxClassificationConstraint,
+}: CbacPickerDialogProps): React.ReactElement {
+  const {
+    selectedIds,
+    categoryGroups,
+    markingStates,
+    banner,
+    requiredMarkingGroups,
+    isValid,
+    userSatisfiesMarkings,
+    disallowedMarkingIds,
+    isLoading,
+    error,
+    toggle,
+    dismiss,
+    reset,
+  } = useCbacSelection(initialMarkingIds);
+
+  // Parent controls dialog close on confirm (e.g. to show a loading state)
+  const handleConfirm = React.useCallback(() => {
+    onConfirm(selectedIds);
+  }, [onConfirm, selectedIds]);
+
+  const handleCancel = React.useCallback(() => {
+    reset();
+    onOpenChange(false);
+  }, [reset, onOpenChange]);
+
+  const hasInitialMarkings = initialMarkingIds !== undefined
+    && initialMarkingIds.length > 0;
+
+  const submitDisabledReason = React.useMemo(
+    () =>
+      getSubmitDisabledReason({
+        isValid,
+        requiredMarkingGroups,
+        selectedIds,
+        disallowedMarkingIds,
+        userSatisfiesMarkings,
+      }),
+    [
+      isValid,
+      requiredMarkingGroups,
+      selectedIds,
+      disallowedMarkingIds,
+      userSatisfiesMarkings,
+    ],
+  );
+
+  const constraintCallout = useConstraintCallout(maxClassificationConstraint);
+
+  return (
+    <BaseCbacPickerDialog
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      onConfirm={handleConfirm}
+      onCancel={handleCancel}
+      title={hasInitialMarkings ? "Edit classification" : "Add classification"}
+      categories={categoryGroups}
+      markingStates={markingStates}
+      banner={banner}
+      onMarkingToggle={toggle}
+      onDismissBanner={dismiss}
+      requiredMarkingGroups={requiredMarkingGroups}
+      isValid={isValid}
+      submitDisabledReason={submitDisabledReason}
+      validationCallouts={constraintCallout}
+      isLoading={isLoading}
+      error={error}
+    />
+  );
+}

--- a/packages/react-components/src/cbac-picker/base/BaseCbacBanner.module.css
+++ b/packages/react-components/src/cbac-picker/base/BaseCbacBanner.module.css
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.bannerRow {
+  display: flex;
+  align-items: center;
+  border-radius: var(--osdk-cbac-banner-border-radius);
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--osdk-cbac-banner-bg);
+  color: var(--osdk-cbac-banner-color);
+}
+
+.banner {
+  flex: 1;
+  padding: var(--osdk-cbac-banner-padding);
+  font-size: var(--osdk-cbac-banner-font-size);
+  font-weight: var(--osdk-cbac-banner-font-weight);
+  text-align: var(--osdk-cbac-banner-text-align);
+  font-family: inherit;
+  border: none;
+  background: transparent;
+  color: inherit;
+}
+
+.clickable {
+  cursor: pointer;
+}
+
+.clickable:focus-visible {
+  outline: var(--osdk-focus-outline);
+  outline-offset: var(--osdk-focus-visible-outline-offset);
+}
+
+.clickable:hover {
+  filter: brightness(0.9);
+  text-decoration: underline;
+}
+
+.dismissButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: calc(var(--osdk-surface-spacing) * 1);
+  margin-right: calc(var(--osdk-surface-spacing) * 1);
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  border-radius: var(--osdk-surface-border-radius);
+  flex-shrink: 0;
+}
+
+.dismissButton:hover {
+  filter: brightness(0.8);
+}
+
+.dismissButton:focus-visible {
+  outline: var(--osdk-focus-outline);
+  outline-offset: var(--osdk-focus-visible-outline-offset);
+}

--- a/packages/react-components/src/cbac-picker/base/BaseCbacBanner.tsx
+++ b/packages/react-components/src/cbac-picker/base/BaseCbacBanner.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button } from "@base-ui/react/button";
+import { Cross } from "@blueprintjs/icons";
+import classnames from "classnames";
+import React from "react";
+import { backgroundFromColors } from "../utils/cbacPickerUtils.js";
+import styles from "./BaseCbacBanner.module.css";
+
+export interface BaseCbacBannerProps {
+  classificationString: string;
+  textColor: string;
+  backgroundColors: string[];
+  onClick?: () => void;
+  onDismiss?: () => void;
+  className?: string;
+}
+
+export function BaseCbacBanner({
+  classificationString,
+  textColor,
+  backgroundColors,
+  onClick,
+  onDismiss,
+  className,
+}: BaseCbacBannerProps): React.ReactElement {
+  const bannerStyle = React.useMemo((): React.CSSProperties => ({
+    "--osdk-cbac-banner-bg": backgroundFromColors(backgroundColors),
+    "--osdk-cbac-banner-color": textColor,
+  } as React.CSSProperties), [textColor, backgroundColors]);
+
+  const handleDismiss = React.useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onDismiss?.();
+    },
+    [onDismiss],
+  );
+
+  const dismissButton = onDismiss != null
+    ? (
+      <Button
+        className={styles.dismissButton}
+        onClick={handleDismiss}
+        aria-label="Clear classification"
+      >
+        <Cross size={12} color="currentColor" />
+      </Button>
+    )
+    : null;
+
+  if (onClick != null) {
+    return (
+      <div
+        className={classnames(styles.bannerRow, className)}
+        style={bannerStyle}
+      >
+        <Button
+          className={classnames(styles.banner, styles.clickable)}
+          onClick={onClick}
+          aria-label="Edit classification"
+        >
+          {classificationString}
+        </Button>
+        {dismissButton}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={classnames(styles.bannerRow, className)}
+      style={bannerStyle}
+    >
+      <span className={styles.banner}>
+        {classificationString}
+      </span>
+      {dismissButton}
+    </div>
+  );
+}

--- a/packages/react-components/src/cbac-picker/base/BaseCbacBannerPopover.module.css
+++ b/packages/react-components/src/cbac-picker/base/BaseCbacBannerPopover.module.css
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.popover {
+  max-width: var(--osdk-cbac-popover-max-width);
+  padding: var(--osdk-cbac-popover-padding);
+  background: var(--osdk-surface-background-color-default);
+  border: 1px solid var(--osdk-surface-border-color-default);
+  border-radius: var(--osdk-surface-border-radius);
+  box-shadow: var(--osdk-surface-elevation-2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--osdk-cbac-popover-section-gap);
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--osdk-cbac-popover-pill-padding);
+  border-radius: var(--osdk-cbac-popover-pill-border-radius);
+  font-size: var(--osdk-typography-size-body-small);
+  font-weight: var(--osdk-typography-weight-bold);
+  width: fit-content;
+}
+
+.sectionLabel {
+  font-size: var(--osdk-typography-size-body-small);
+  font-weight: var(--osdk-typography-weight-bold);
+  color: var(--osdk-typography-color-default-muted);
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.markingGroup {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--osdk-surface-spacing) * 0.5);
+}
+
+.markingCategoryName {
+  font-size: var(--osdk-typography-size-body-small);
+  font-weight: var(--osdk-typography-weight-bold);
+  color: var(--osdk-typography-color-default-rest);
+  margin: 0;
+}
+
+.markingName {
+  font-size: var(--osdk-typography-size-body-small);
+  color: var(--osdk-typography-color-default-rest);
+  margin: 0;
+  padding-left: calc(var(--osdk-surface-spacing) * 2);
+}
+
+.noMarkings {
+  font-size: var(--osdk-typography-size-body-small);
+  color: var(--osdk-typography-color-default-muted);
+  margin: 0;
+}
+
+.divider {
+  border: none;
+  border-top: 1px solid var(--osdk-surface-border-color-default);
+  margin: 0;
+}
+
+.editButton {
+  width: 100%;
+}
+
+.description {
+  font-size: var(--osdk-typography-size-body-small);
+  color: var(--osdk-typography-color-default-muted);
+  margin: 0;
+}
+
+/* Skeleton loading */
+.skeletonContainer {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--osdk-surface-spacing) * 1.5);
+}
+
+.skeletonPill {
+  width: var(--osdk-cbac-skeleton-pill-width);
+  height: var(--osdk-cbac-skeleton-pill-height);
+}
+
+.skeletonLine {
+  width: 100%;
+  height: var(--osdk-cbac-skeleton-line-height);
+}
+
+.skeletonLineNarrow {
+  width: var(--osdk-cbac-skeleton-line-narrow-width);
+  height: var(--osdk-cbac-skeleton-line-height);
+}
+
+/* Error state */
+.errorContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--osdk-surface-spacing);
+  padding: calc(var(--osdk-surface-spacing) * 2) 0;
+}
+
+.errorMessage {
+  font-size: var(--osdk-typography-size-body-small);
+  color: var(--osdk-typography-color-default-rest);
+  font-weight: var(--osdk-typography-weight-bold);
+  margin: 0;
+  text-align: center;
+}
+
+.errorRemediation {
+  font-size: var(--osdk-typography-size-body-small);
+  color: var(--osdk-typography-color-default-muted);
+  margin: 0;
+  text-align: center;
+}
+
+/* Warnings section */
+.warningsSection {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--osdk-surface-spacing) * 1.5);
+}
+
+.warningsHeader {
+  font-size: var(--osdk-typography-size-body-small);
+  font-weight: var(--osdk-typography-weight-bold);
+  color: var(--osdk-typography-color-default-muted);
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.warningCallout {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--osdk-surface-spacing);
+  padding: var(--osdk-cbac-warning-callout-padding);
+  background: var(--osdk-cbac-warning-callout-bg);
+  color: var(--osdk-cbac-warning-callout-color);
+  border-radius: var(--osdk-cbac-warning-callout-border-radius);
+  font-size: var(--osdk-cbac-warning-callout-font-size);
+}
+
+.warningIcon {
+  flex-shrink: 0;
+  margin-top: calc(var(--osdk-surface-spacing) * 0.125);
+}
+
+.warningText {
+  margin: 0;
+}
+
+/* Banner trigger wrapper with caret */
+.bannerTriggerWrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.caretIcon {
+  position: absolute;
+  right: calc(var(--osdk-surface-spacing) * 1.5);
+  display: flex;
+  align-items: center;
+  color: inherit;
+  opacity: 0;
+  transition: opacity var(--osdk-emphasis-transition-duration)
+    var(--osdk-emphasis-ease-default);
+  pointer-events: none;
+}
+
+.bannerTriggerWrapper:hover .caretIcon,
+.caretIconVisible {
+  opacity: 1;
+}

--- a/packages/react-components/src/cbac-picker/base/BaseCbacBannerPopover.tsx
+++ b/packages/react-components/src/cbac-picker/base/BaseCbacBannerPopover.tsx
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Popover } from "@base-ui/react/popover";
+import { CaretDown, CaretUp, WarningSign } from "@blueprintjs/icons";
+import classnames from "classnames";
+import React from "react";
+import { ActionButton } from "../../base-components/action-button/ActionButton.js";
+import { SkeletonBar } from "../../base-components/skeleton/SkeletonBar.js";
+import {
+  type AppliedMarkingGroup,
+  backgroundFromColors,
+} from "../utils/cbacPickerUtils.js";
+export type { AppliedMarkingGroup } from "../utils/cbacPickerUtils.js";
+import { formatCbacError } from "../utils/errorMessages.js";
+import { BaseCbacBanner } from "./BaseCbacBanner.js";
+import styles from "./BaseCbacBannerPopover.module.css";
+
+export interface BaseCbacBannerPopoverProps {
+  classificationString: string;
+  textColor: string;
+  backgroundColors: string[];
+  appliedMarkings: AppliedMarkingGroup[];
+  onEditClick: () => void;
+  description?: string;
+  isLoading?: boolean;
+  error?: Error;
+  onRetry?: () => void;
+  onDismiss?: () => void;
+  warnings?: string[];
+  className?: string;
+}
+
+export function BaseCbacBannerPopover({
+  classificationString,
+  textColor,
+  backgroundColors,
+  appliedMarkings,
+  onEditClick,
+  description,
+  isLoading,
+  error,
+  onRetry,
+  onDismiss,
+  warnings,
+  className,
+}: BaseCbacBannerPopoverProps): React.ReactElement {
+  const [open, setOpen] = React.useState(false);
+
+  const handleEditClick = React.useCallback(() => {
+    setOpen(false);
+    onEditClick();
+  }, [onEditClick]);
+
+  const pillStyle = React.useMemo((): React.CSSProperties => ({
+    color: textColor,
+    background: backgroundFromColors(backgroundColors),
+  }), [textColor, backgroundColors]);
+
+  const showSkeleton = isLoading === true && appliedMarkings.length === 0;
+
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Trigger
+        nativeButton={false}
+        render={
+          <div className={styles.bannerTriggerWrapper}>
+            <BaseCbacBanner
+              classificationString={classificationString}
+              textColor={textColor}
+              backgroundColors={backgroundColors}
+              onDismiss={onDismiss}
+              className={className}
+            />
+            <span
+              className={classnames(
+                styles.caretIcon,
+                open && styles.caretIconVisible,
+              )}
+            >
+              {open ? <CaretUp size={12} /> : <CaretDown size={12} />}
+            </span>
+          </div>
+        }
+      />
+      <Popover.Portal>
+        <Popover.Positioner side="bottom" align="center">
+          <Popover.Popup className={styles.popover}>
+            <PopoverContent
+              showSkeleton={showSkeleton}
+              error={error}
+              onRetry={onRetry}
+              pillStyle={pillStyle}
+              classificationString={classificationString}
+              description={description}
+              appliedMarkings={appliedMarkings}
+              warnings={warnings}
+              handleEditClick={handleEditClick}
+            />
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+
+interface PopoverContentProps {
+  showSkeleton: boolean;
+  error: Error | undefined;
+  onRetry: (() => void) | undefined;
+  pillStyle: React.CSSProperties;
+  classificationString: string;
+  description: string | undefined;
+  appliedMarkings: AppliedMarkingGroup[];
+  warnings: string[] | undefined;
+  handleEditClick: () => void;
+}
+
+const PopoverContent = React.memo(function PopoverContent({
+  showSkeleton,
+  error,
+  onRetry,
+  pillStyle,
+  classificationString,
+  description,
+  appliedMarkings,
+  warnings,
+  handleEditClick,
+}: PopoverContentProps): React.ReactElement {
+  const hasMarkings = appliedMarkings.length > 0;
+  const hasWarnings = warnings !== undefined && warnings.length > 0;
+  if (showSkeleton) {
+    return <PopoverSkeleton />;
+  }
+
+  if (error !== undefined) {
+    const errorMessage = formatCbacError(error);
+    return (
+      <div className={styles.errorContainer}>
+        <p className={styles.errorMessage}>
+          {errorMessage.title}
+        </p>
+        {errorMessage.remediation && (
+          <p className={styles.errorRemediation}>
+            {errorMessage.remediation}
+          </p>
+        )}
+        {onRetry !== undefined && (
+          <ActionButton variant="secondary" onClick={onRetry}>
+            Retry
+          </ActionButton>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div
+        className={styles.pill}
+        style={pillStyle}
+        title={classificationString}
+      >
+        {classificationString}
+      </div>
+
+      {description !== undefined && (
+        <p className={styles.description}>{description}</p>
+      )}
+
+      <p className={styles.sectionLabel}>Applied markings</p>
+
+      {hasMarkings
+        ? (
+          appliedMarkings.map((group) => (
+            <div key={group.categoryName} className={styles.markingGroup}>
+              <p className={styles.markingCategoryName}>
+                {group.categoryName}
+              </p>
+              {group.markingNames.map((name, i) => (
+                <p key={`${name}-${i}`} className={styles.markingName}>
+                  {name}
+                </p>
+              ))}
+            </div>
+          ))
+        )
+        : <p className={styles.noMarkings}>No markings applied</p>}
+
+      {hasWarnings && warnings !== undefined && (
+        <>
+          <hr className={styles.divider} />
+          <div className={styles.warningsSection}>
+            <p className={styles.warningsHeader}>Warnings and Notices</p>
+            {warnings.map((warning, i) => (
+              <div key={`warning-${i}`} className={styles.warningCallout}>
+                <WarningSign className={styles.warningIcon} size={14} />
+                <p className={styles.warningText}>{warning}</p>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      <hr className={styles.divider} />
+
+      <ActionButton
+        variant="primary"
+        className={styles.editButton}
+        onClick={handleEditClick}
+      >
+        {hasMarkings ? "Edit classification" : "Set classification"}
+      </ActionButton>
+    </>
+  );
+});
+
+function PopoverSkeleton(): React.ReactElement {
+  return (
+    <div className={styles.skeletonContainer}>
+      <SkeletonBar className={styles.skeletonPill} />
+      <SkeletonBar className={styles.skeletonLine} />
+      <SkeletonBar className={styles.skeletonLineNarrow} />
+    </div>
+  );
+}

--- a/packages/react-components/src/cbac-picker/base/BaseCbacPicker.module.css
+++ b/packages/react-components/src/cbac-picker/base/BaseCbacPicker.module.css
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.picker {
+  display: flex;
+  flex-direction: column;
+  gap: var(--osdk-cbac-picker-category-gap);
+  padding: var(--osdk-cbac-picker-padding);
+  width: 100%;
+}
+
+.categoriesContainer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--osdk-cbac-picker-category-gap);
+  overflow-y: auto;
+}
+
+.innerBanner {
+  border: 1px solid var(--osdk-cbac-banner-border-color);
+}
+
+.statusMessage {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--osdk-surface-spacing) * 0.5);
+  padding: calc(var(--osdk-surface-spacing) * 3) 0;
+  color: var(--osdk-typography-color-muted);
+  font-style: italic;
+}
+
+.statusMessage p {
+  margin: 0;
+}

--- a/packages/react-components/src/cbac-picker/base/BaseCbacPicker.tsx
+++ b/packages/react-components/src/cbac-picker/base/BaseCbacPicker.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classnames from "classnames";
+import React from "react";
+import type {
+  CategoryMarkingGroup as CategoryMarkingGroupType,
+  CbacBannerData,
+  MarkingSelectionState,
+  RequiredMarkingGroup,
+} from "../types.js";
+import { formatCbacError } from "../utils/errorMessages.js";
+import { BaseCbacBanner } from "./BaseCbacBanner.js";
+import styles from "./BaseCbacPicker.module.css";
+import { CategoryMarkingGroup } from "./CategoryMarkingGroup.js";
+import { InfoBanner } from "./InfoBanner.js";
+import { ValidationWarning } from "./ValidationWarning.js";
+
+export interface BaseCbacPickerProps {
+  categories: CategoryMarkingGroupType[];
+  markingStates: Map<string, MarkingSelectionState>;
+  banner?: CbacBannerData;
+  onMarkingToggle: (markingId: string) => void;
+  onDismissBanner?: () => void;
+  showInfoBanner?: boolean;
+  requiredMarkingGroups?: ReadonlyArray<RequiredMarkingGroup>;
+  isValid?: boolean;
+  readOnly?: boolean;
+  isLoading?: boolean;
+  error?: Error;
+  validationCallouts?: React.ReactNode;
+  className?: string;
+}
+
+export function BaseCbacPicker({
+  categories,
+  markingStates,
+  banner,
+  onMarkingToggle,
+  onDismissBanner,
+  showInfoBanner,
+  requiredMarkingGroups,
+  isValid,
+  readOnly,
+  isLoading,
+  error,
+  validationCallouts,
+  className,
+}: BaseCbacPickerProps): React.ReactElement {
+  const errorMessage = error != null ? formatCbacError(error) : undefined;
+  const showInitialLoading = isLoading === true && categories.length === 0;
+  const showValidationWarning = isValid === false
+    && requiredMarkingGroups != null
+    && requiredMarkingGroups.length > 0;
+
+  return (
+    <div className={classnames(styles.picker, className)}>
+      {showInfoBanner === true && (
+        <InfoBanner message="Implied markings are (in parentheses)." />
+      )}
+      {banner != null && (
+        <BaseCbacBanner
+          classificationString={banner.classificationString}
+          textColor={banner.textColor}
+          backgroundColors={banner.backgroundColors}
+          onDismiss={onDismissBanner}
+          className={styles.innerBanner}
+        />
+      )}
+      {errorMessage !== undefined
+        ? (
+          <div
+            className={styles.statusMessage}
+            role="alert"
+          >
+            <p>{errorMessage.title}</p>
+            {errorMessage.remediation && <p>{errorMessage.remediation}</p>}
+          </div>
+        )
+        : showInitialLoading
+        ? (
+          <div
+            className={styles.statusMessage}
+            role="status"
+            aria-live="polite"
+          >
+            Loading...
+          </div>
+        )
+        : (
+          <div className={styles.categoriesContainer}>
+            {categories.map((group) => (
+              <CategoryMarkingGroup
+                key={group.category.id}
+                categoryName={group.category.name}
+                categoryDescription={group.category.description}
+                markings={group.markings}
+                markingStates={markingStates}
+                readOnly={readOnly}
+                onMarkingToggle={onMarkingToggle}
+              />
+            ))}
+          </div>
+        )}
+      {validationCallouts}
+      {showValidationWarning && (
+        <ValidationWarning requiredMarkingGroups={requiredMarkingGroups} />
+      )}
+    </div>
+  );
+}

--- a/packages/react-components/src/cbac-picker/base/BaseCbacPickerDialog.tsx
+++ b/packages/react-components/src/cbac-picker/base/BaseCbacPickerDialog.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { Dialog } from "../../base-components/dialog/Dialog.js";
+import { BaseCbacPicker } from "./BaseCbacPicker.js";
+import type { BaseCbacPickerProps } from "./BaseCbacPicker.js";
+import { CbacPickerDialogFooter } from "./CbacPickerDialogFooter.js";
+
+export interface BaseCbacPickerDialogProps extends BaseCbacPickerProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+  title?: string;
+  submitDisabledReason?: string;
+}
+
+export function BaseCbacPickerDialog({
+  isOpen,
+  onOpenChange,
+  onConfirm,
+  onCancel,
+  title = "Select classification",
+  submitDisabledReason,
+  ...pickerProps
+}: BaseCbacPickerDialogProps): React.ReactElement {
+  const handleOpenChange = React.useCallback(
+    (open: boolean) => {
+      if (!open) {
+        onCancel();
+      }
+      onOpenChange(open);
+    },
+    [onCancel, onOpenChange],
+  );
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onOpenChange={handleOpenChange}
+      title={title}
+      footer={
+        <CbacPickerDialogFooter
+          onCancel={onCancel}
+          onConfirm={onConfirm}
+          submitDisabledReason={submitDisabledReason}
+        />
+      }
+      disablePointerDismissal={true}
+    >
+      <BaseCbacPicker
+        {...pickerProps}
+        showInfoBanner={pickerProps.showInfoBanner ?? true}
+      />
+    </Dialog>
+  );
+}

--- a/packages/react-components/src/cbac-picker/base/CategoryMarkingGroup.module.css
+++ b/packages/react-components/src/cbac-picker/base/CategoryMarkingGroup.module.css
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.categoryGroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--osdk-cbac-marking-button-gap);
+}
+
+.categoryHeader {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--osdk-surface-spacing) * 0.75);
+}
+
+.categoryName {
+  font-size: var(--osdk-cbac-picker-category-title-font-size);
+  font-weight: var(--osdk-cbac-picker-category-title-font-weight);
+  color: var(--osdk-cbac-picker-category-title-color);
+  letter-spacing: var(--osdk-cbac-picker-category-title-letter-spacing);
+  margin: 0;
+}
+
+.infoIcon {
+  display: inline-flex;
+  color: var(--osdk-typography-color-muted);
+  cursor: help;
+}
+
+.infoTooltip {
+  z-index: var(--osdk-cbac-marking-tooltip-z-index);
+  max-width: var(--osdk-cbac-marking-tooltip-max-width);
+  padding: var(--osdk-cbac-marking-tooltip-padding);
+  background-color: var(--osdk-tooltip-bg);
+  border: 1px solid var(--osdk-tooltip-border-color);
+  border-radius: var(--osdk-surface-border-radius);
+  box-shadow: var(--osdk-tooltip-shadow);
+  font-size: var(--osdk-cbac-marking-tooltip-font-size);
+  line-height: 1.4;
+  color: var(--osdk-typography-color-muted);
+}
+
+.markingGrid {
+  display: grid;
+  grid-template-columns: repeat(
+    var(--osdk-cbac-picker-marking-grid-columns),
+    1fr
+  );
+  border-top: 1px solid var(--osdk-cbac-picker-marking-grid-border-color);
+  border-left: 1px solid var(--osdk-cbac-picker-marking-grid-border-color);
+}
+
+.emptyCell {
+  border-right: 1px solid var(--osdk-cbac-marking-button-border-color-default);
+  border-bottom: 1px solid var(--osdk-cbac-marking-button-border-color-default);
+}

--- a/packages/react-components/src/cbac-picker/base/CategoryMarkingGroup.tsx
+++ b/packages/react-components/src/cbac-picker/base/CategoryMarkingGroup.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Tooltip } from "@base-ui/react/tooltip";
+import { InfoSign } from "@blueprintjs/icons";
+import React from "react";
+import type { MarkingSelectionState } from "../types.js";
+import styles from "./CategoryMarkingGroup.module.css";
+import { MarkingButton } from "./MarkingButton.js";
+import { OverflowButton } from "./OverflowButton.js";
+import { isImplied } from "./selectionStateHelpers.js";
+
+const GRID_COLUMNS = 4;
+const VISIBLE_ROWS = 3;
+const DEFAULT_MARKING_STATE: MarkingSelectionState = "NONE";
+
+export interface CategoryMarkingGroupProps {
+  categoryName: string;
+  categoryDescription?: string;
+  markings: ReadonlyArray<{ id: string; name: string; description?: string }>;
+  markingStates: Map<string, MarkingSelectionState>;
+  readOnly?: boolean;
+  onMarkingToggle: (markingId: string) => void;
+}
+
+export const CategoryMarkingGroup: React.MemoExoticComponent<
+  (props: CategoryMarkingGroupProps) => React.ReactElement
+> = React.memo(function CategoryMarkingGroup({
+  categoryName,
+  categoryDescription,
+  markings,
+  markingStates,
+  readOnly,
+  onMarkingToggle,
+}: CategoryMarkingGroupProps): React.ReactElement {
+  const headingId = React.useId();
+
+  const resolvedMarkings = React.useMemo(
+    () =>
+      markings.map((marking) => ({
+        id: marking.id,
+        label: marking.name,
+        description: marking.description,
+        selectionState: markingStates.get(marking.id) ?? DEFAULT_MARKING_STATE,
+        disabled: readOnly,
+      })),
+    [markings, markingStates, readOnly],
+  );
+
+  const maxVisible = GRID_COLUMNS * VISIBLE_ROWS;
+  const hasOverflow = resolvedMarkings.length > maxVisible;
+  const visibleMarkings = hasOverflow
+    ? resolvedMarkings.slice(0, maxVisible - 1)
+    : resolvedMarkings;
+  const overflowMarkings = hasOverflow
+    ? resolvedMarkings.slice(maxVisible - 1)
+    : [];
+
+  const gridItemCount = hasOverflow
+    ? visibleMarkings.length + 1
+    : visibleMarkings.length;
+  const emptyCellCount = (GRID_COLUMNS - (gridItemCount % GRID_COLUMNS))
+    % GRID_COLUMNS;
+
+  const hasActiveOverflow = overflowMarkings.some(
+    (m) => m.selectionState === "SELECTED" || isImplied(m.selectionState),
+  );
+
+  return (
+    <div
+      className={styles.categoryGroup}
+      role="group"
+      aria-labelledby={headingId}
+    >
+      <div className={styles.categoryHeader}>
+        <h3 id={headingId} className={styles.categoryName}>{categoryName}</h3>
+        {categoryDescription != null && categoryDescription.length > 0 && (
+          <Tooltip.Root>
+            <Tooltip.Trigger
+              render={
+                <span
+                  className={styles.infoIcon}
+                  aria-label="Category description"
+                >
+                  <InfoSign size={12} />
+                </span>
+              }
+            />
+            <Tooltip.Portal>
+              <Tooltip.Positioner side="top" sideOffset={4}>
+                <Tooltip.Popup className={styles.infoTooltip}>
+                  {categoryDescription}
+                </Tooltip.Popup>
+              </Tooltip.Positioner>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+        )}
+      </div>
+      <div className={styles.markingGrid}>
+        {visibleMarkings.map((marking) => (
+          <MarkingButton
+            key={marking.id}
+            id={marking.id}
+            label={marking.label}
+            description={marking.description}
+            selectionState={marking.selectionState}
+            disabled={marking.disabled}
+            onToggle={onMarkingToggle}
+          />
+        ))}
+        {hasOverflow && (
+          <OverflowButton
+            overflowMarkings={overflowMarkings}
+            hasActiveOverflow={hasActiveOverflow}
+            onMarkingToggle={onMarkingToggle}
+          />
+        )}
+        {Array.from({ length: emptyCellCount }, (_, i) => (
+          <div
+            key={`empty-${i}`}
+            className={styles.emptyCell}
+          />
+        ))}
+      </div>
+    </div>
+  );
+});

--- a/packages/react-components/src/cbac-picker/base/CbacPickerDialogFooter.module.css
+++ b/packages/react-components/src/cbac-picker/base/CbacPickerDialogFooter.module.css
@@ -1,4 +1,4 @@
-{/*
+/*
  * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,13 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */}
+ */
 
-{/* cspell:words cbac */}
-
-import { Meta, Markdown } from "@storybook/addon-docs/blocks";
-import cbacPickerDocs from "@docs/CbacPicker.md?raw";
-
-<Meta title="Components/CbacPicker/Docs" tags={["beta"]}/>
-
-<Markdown>{cbacPickerDocs}</Markdown>
+.tooltipTriggerWrapper {
+  display: contents;
+}

--- a/packages/react-components/src/cbac-picker/base/CbacPickerDialogFooter.tsx
+++ b/packages/react-components/src/cbac-picker/base/CbacPickerDialogFooter.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { ActionButton } from "../../base-components/action-button/ActionButton.js";
+import { Tooltip } from "../../base-components/tooltip/index.js";
+import styles from "./CbacPickerDialogFooter.module.css";
+
+interface CbacPickerDialogFooterProps {
+  onCancel: () => void;
+  onConfirm: () => void;
+  submitDisabledReason?: string;
+}
+
+export function CbacPickerDialogFooter({
+  onCancel,
+  onConfirm,
+  submitDisabledReason,
+}: CbacPickerDialogFooterProps): React.ReactElement {
+  const isSubmitDisabled = submitDisabledReason != null;
+
+  const submitButton = (
+    <ActionButton
+      variant="primary"
+      onClick={onConfirm}
+      disabled={isSubmitDisabled}
+    >
+      Set classification
+    </ActionButton>
+  );
+
+  return (
+    <>
+      <ActionButton variant="secondary" onClick={onCancel}>
+        Cancel
+      </ActionButton>
+      {isSubmitDisabled
+        ? (
+          <Tooltip.Root>
+            <Tooltip.Trigger
+              render={<span className={styles.tooltipTriggerWrapper} />}
+            >
+              {submitButton}
+            </Tooltip.Trigger>
+            <Tooltip.Portal>
+              <Tooltip.Positioner side="top">
+                <Tooltip.Popup>
+                  {submitDisabledReason}
+                  <Tooltip.Arrow />
+                </Tooltip.Popup>
+              </Tooltip.Positioner>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+        )
+        : submitButton}
+    </>
+  );
+}

--- a/packages/react-components/src/cbac-picker/base/InfoBanner.module.css
+++ b/packages/react-components/src/cbac-picker/base/InfoBanner.module.css
@@ -1,4 +1,4 @@
-{/*
+/*
  * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,13 +12,19 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */}
+ */
 
-{/* cspell:words cbac */}
+.infoBanner {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--osdk-surface-spacing) * 1.5);
+  padding: var(--osdk-cbac-info-banner-padding);
+  background: var(--osdk-cbac-info-banner-bg);
+  color: var(--osdk-cbac-info-banner-color);
+  font-size: var(--osdk-cbac-info-banner-font-size);
+  border-radius: var(--osdk-cbac-info-banner-border-radius);
+}
 
-import { Meta, Markdown } from "@storybook/addon-docs/blocks";
-import cbacPickerDocs from "@docs/CbacPicker.md?raw";
-
-<Meta title="Components/CbacPicker/Docs" tags={["beta"]}/>
-
-<Markdown>{cbacPickerDocs}</Markdown>
+.icon {
+  flex-shrink: 0;
+}

--- a/packages/react-components/src/cbac-picker/base/InfoBanner.tsx
+++ b/packages/react-components/src/cbac-picker/base/InfoBanner.tsx
@@ -1,4 +1,4 @@
-{/*
+/*
  * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,13 +12,26 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */}
+ */
 
-{/* cspell:words cbac */}
+import { InfoSign } from "@blueprintjs/icons";
+import classnames from "classnames";
+import React from "react";
+import styles from "./InfoBanner.module.css";
 
-import { Meta, Markdown } from "@storybook/addon-docs/blocks";
-import cbacPickerDocs from "@docs/CbacPicker.md?raw";
+export interface InfoBannerProps {
+  message: string;
+  className?: string;
+}
 
-<Meta title="Components/CbacPicker/Docs" tags={["beta"]}/>
-
-<Markdown>{cbacPickerDocs}</Markdown>
+export function InfoBanner({
+  message,
+  className,
+}: InfoBannerProps): React.ReactElement {
+  return (
+    <div className={classnames(styles.infoBanner, className)}>
+      <InfoSign className={styles.icon} size={14} />
+      <span>{message}</span>
+    </div>
+  );
+}

--- a/packages/react-components/src/cbac-picker/base/MarkingButton.module.css
+++ b/packages/react-components/src/cbac-picker/base/MarkingButton.module.css
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.markingButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: var(--osdk-cbac-marking-button-padding);
+  border-radius: var(--osdk-cbac-marking-button-border-radius);
+  font-size: var(--osdk-cbac-marking-button-font-size);
+  font-family: inherit;
+  cursor: pointer;
+  border: none;
+  border-right: 1px solid var(--osdk-cbac-marking-button-border-color-default);
+  border-bottom: 1px solid var(--osdk-cbac-marking-button-border-color-default);
+  color: var(--osdk-cbac-marking-button-color-default);
+  background-color: var(--osdk-cbac-marking-button-bg-default, transparent);
+}
+
+.markingButton:hover:not(:disabled):not([aria-disabled="true"]):not(.disallowed):not(.impliedDisallowed):not(.selected):not(.implied) {
+  background-color: var(--osdk-surface-background-color-default-hover);
+}
+
+.selected {
+  color: var(--osdk-cbac-marking-button-color-selected);
+  background-color: var(--osdk-cbac-marking-button-bg-selected);
+  border-color: var(--osdk-cbac-marking-button-border-color-selected);
+}
+
+.selected:hover:not(:disabled):not([aria-disabled="true"]) {
+  background-color: var(
+    --osdk-cbac-marking-button-bg-selected-hover,
+    var(--osdk-cbac-marking-button-bg-selected)
+  );
+  filter: brightness(0.85);
+}
+
+.implied {
+  color: var(--osdk-cbac-marking-button-color-implied);
+  background-color: var(--osdk-cbac-marking-button-bg-implied);
+  border-color: var(--osdk-cbac-marking-button-border-color-implied);
+}
+
+.disallowed,
+.impliedDisallowed {
+  color: var(--osdk-cbac-marking-button-color-disallowed);
+  background-color: var(--osdk-cbac-marking-button-bg-disallowed);
+  border-color: var(--osdk-cbac-marking-button-border-color-disallowed);
+  cursor: not-allowed;
+  opacity: var(--osdk-cbac-disabled-opacity);
+  text-decoration: line-through;
+}
+
+.markingButton:focus-visible {
+  outline: var(--osdk-focus-outline);
+  outline-offset: var(--osdk-focus-visible-outline-offset);
+}
+
+.markingButton:disabled {
+  cursor: not-allowed;
+}
+
+.tooltip {
+  z-index: var(--osdk-cbac-marking-tooltip-z-index);
+  max-width: var(--osdk-cbac-marking-tooltip-max-width);
+  padding: var(--osdk-cbac-marking-tooltip-padding);
+  background-color: var(--osdk-tooltip-bg);
+  border: 1px solid var(--osdk-tooltip-border-color);
+  border-radius: var(--osdk-surface-border-radius);
+  box-shadow: var(--osdk-tooltip-shadow);
+  font-size: var(--osdk-cbac-marking-tooltip-font-size);
+  line-height: 1.4;
+}
+
+.tooltipTitle {
+  margin: 0;
+  font-weight: var(--osdk-typography-weight-bold);
+  color: var(--osdk-typography-color-default-rest);
+}
+
+.tooltipDescription {
+  margin: calc(var(--osdk-surface-spacing) * 0.5) 0 0;
+  color: var(--osdk-typography-color-muted);
+}
+
+.tooltipHint {
+  margin: calc(var(--osdk-surface-spacing) * 0.5) 0 0;
+  font-style: italic;
+  color: var(--osdk-typography-color-muted);
+}

--- a/packages/react-components/src/cbac-picker/base/MarkingButton.tsx
+++ b/packages/react-components/src/cbac-picker/base/MarkingButton.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button } from "@base-ui/react/button";
+import { Tooltip } from "@base-ui/react/tooltip";
+import classnames from "classnames";
+import React from "react";
+import type { MarkingSelectionState } from "../types.js";
+import styles from "./MarkingButton.module.css";
+import { getDisplayLabel, isDisallowed } from "./selectionStateHelpers.js";
+
+export interface MarkingButtonProps {
+  id: string;
+  label: string;
+  description?: string;
+  selectionState: MarkingSelectionState;
+  onToggle: (markingId: string) => void;
+  disabled?: boolean;
+}
+
+const selectionStateClassMap: Record<
+  MarkingSelectionState,
+  string | undefined
+> = {
+  SELECTED: styles.selected,
+  IMPLIED: styles.implied,
+  DISALLOWED: styles.disallowed,
+  IMPLIED_DISALLOWED: styles.impliedDisallowed,
+  NONE: undefined,
+};
+
+function getSelectionHint(state: MarkingSelectionState): string | undefined {
+  switch (state) {
+    case "SELECTED":
+      return "Click to deselect";
+    case "IMPLIED":
+      return "Implied by another marking";
+    case "DISALLOWED":
+    case "IMPLIED_DISALLOWED":
+      return "Not available with current selection. Deselect your current choice first.";
+    case "NONE":
+      return undefined;
+  }
+}
+
+export const MarkingButton: React.MemoExoticComponent<
+  (props: MarkingButtonProps) => React.ReactElement
+> = React.memo(function MarkingButton({
+  id,
+  label,
+  description,
+  selectionState,
+  onToggle,
+  disabled,
+}: MarkingButtonProps): React.ReactElement {
+  const handleToggle = React.useCallback(() => {
+    onToggle(id);
+  }, [onToggle, id]);
+
+  const hasDescription = description !== undefined
+    && description.length > 0;
+  const isButtonDisabled = disabled ?? isDisallowed(selectionState);
+  const showTooltip = hasDescription || isDisallowed(selectionState);
+  const hint = getSelectionHint(selectionState);
+
+  const button = (
+    <Button
+      className={classnames(
+        styles.markingButton,
+        selectionStateClassMap[selectionState],
+      )}
+      onClick={isButtonDisabled ? undefined : handleToggle}
+      disabled={showTooltip ? undefined : isButtonDisabled}
+      aria-disabled={showTooltip ? isButtonDisabled : undefined}
+      aria-pressed={selectionState === "SELECTED"
+        || selectionState === "IMPLIED"}
+      title={showTooltip ? undefined : label}
+    >
+      {getDisplayLabel(label, selectionState)}
+    </Button>
+  );
+
+  if (!showTooltip) {
+    return button;
+  }
+
+  return (
+    <Tooltip.Root>
+      <Tooltip.Trigger render={button} />
+      <Tooltip.Portal>
+        <Tooltip.Positioner sideOffset={8}>
+          <Tooltip.Popup className={styles.tooltip}>
+            <p className={styles.tooltipTitle}>{label}</p>
+            {hasDescription && (
+              <p className={styles.tooltipDescription}>{description}</p>
+            )}
+            {hint != null && (
+              <p className={styles.tooltipHint}>
+                {hint}
+              </p>
+            )}
+          </Tooltip.Popup>
+        </Tooltip.Positioner>
+      </Tooltip.Portal>
+    </Tooltip.Root>
+  );
+});

--- a/packages/react-components/src/cbac-picker/base/MaxClassificationField.module.css
+++ b/packages/react-components/src/cbac-picker/base/MaxClassificationField.module.css
@@ -1,4 +1,4 @@
-{/*
+/*
  * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,13 +12,28 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */}
+ */
 
-{/* cspell:words cbac */}
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--osdk-cbac-marking-button-gap);
+}
 
-import { Meta, Markdown } from "@storybook/addon-docs/blocks";
-import cbacPickerDocs from "@docs/CbacPicker.md?raw";
+.label {
+  font-size: var(--osdk-cbac-picker-category-title-font-size);
+  font-weight: var(--osdk-cbac-picker-category-title-font-weight);
+  color: var(--osdk-cbac-picker-category-title-color);
+  letter-spacing: var(--osdk-cbac-picker-category-title-letter-spacing);
+  margin: 0;
+}
 
-<Meta title="Components/CbacPicker/Docs" tags={["beta"]}/>
+.bannerWrapper {
+  pointer-events: none;
+}
 
-<Markdown>{cbacPickerDocs}</Markdown>
+.helperText {
+  font-size: var(--osdk-typography-size-body-small);
+  color: var(--osdk-typography-color-muted);
+  margin: 0;
+}

--- a/packages/react-components/src/cbac-picker/base/MaxClassificationField.tsx
+++ b/packages/react-components/src/cbac-picker/base/MaxClassificationField.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classnames from "classnames";
+import React from "react";
+import { BaseCbacBanner } from "./BaseCbacBanner.js";
+import styles from "./MaxClassificationField.module.css";
+
+export interface MaxClassificationFieldProps {
+  classificationString: string;
+  textColor: string;
+  backgroundColors: string[];
+  helperText?: string;
+  className?: string;
+}
+
+export function MaxClassificationField({
+  classificationString,
+  textColor,
+  backgroundColors,
+  helperText,
+  className,
+}: MaxClassificationFieldProps): React.ReactElement {
+  return (
+    <div className={classnames(styles.container, className)}>
+      <p className={styles.label}>Maximum allowed classification</p>
+      <div className={styles.bannerWrapper}>
+        <BaseCbacBanner
+          classificationString={classificationString}
+          textColor={textColor}
+          backgroundColors={backgroundColors}
+        />
+      </div>
+      {helperText != null && <p className={styles.helperText}>{helperText}</p>}
+    </div>
+  );
+}

--- a/packages/react-components/src/cbac-picker/base/OverflowButton.module.css
+++ b/packages/react-components/src/cbac-picker/base/OverflowButton.module.css
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.moreButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: var(--osdk-cbac-overflow-button-padding);
+  font-size: var(--osdk-cbac-overflow-button-font-size);
+  font-family: inherit;
+  cursor: pointer;
+  border: none;
+  border-right: 1px solid var(--osdk-cbac-marking-button-border-color-default);
+  border-bottom: 1px solid var(--osdk-cbac-marking-button-border-color-default);
+  color: var(--osdk-cbac-marking-button-color-default);
+  background: var(--osdk-cbac-marking-button-bg-default);
+  font-weight: var(--osdk-typography-weight-bold);
+}
+
+.moreButton:hover {
+  background: var(--osdk-surface-background-color-default-hover);
+}
+
+.moreButton:focus-visible {
+  outline: var(--osdk-focus-outline);
+  outline-offset: var(--osdk-focus-visible-outline-offset);
+}
+
+.moreButtonActive {
+  color: var(--osdk-intent-primary-rest);
+}
+
+.overflowList {
+  display: flex;
+  flex-direction: column;
+  max-height: var(--osdk-cbac-overflow-list-max-height);
+  overflow-y: auto;
+  padding: calc(var(--osdk-surface-spacing) * 0.5);
+  background: var(--osdk-surface-background-color-default);
+  border: 1px solid var(--osdk-surface-border-color-default);
+  border-radius: var(--osdk-surface-border-radius);
+  box-shadow: var(--osdk-surface-elevation-2);
+}

--- a/packages/react-components/src/cbac-picker/base/OverflowButton.tsx
+++ b/packages/react-components/src/cbac-picker/base/OverflowButton.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button } from "@base-ui/react/button";
+import { Popover } from "@base-ui/react/popover";
+import classnames from "classnames";
+import React from "react";
+import type { MarkingSelectionState } from "../types.js";
+import styles from "./OverflowButton.module.css";
+import { OverflowItem } from "./OverflowItem.js";
+
+export interface OverflowButtonProps {
+  overflowMarkings: ReadonlyArray<{
+    id: string;
+    label: string;
+    description?: string;
+    selectionState: MarkingSelectionState;
+    disabled?: boolean;
+  }>;
+  hasActiveOverflow: boolean;
+  onMarkingToggle: (markingId: string) => void;
+}
+
+export function OverflowButton({
+  overflowMarkings,
+  hasActiveOverflow,
+  onMarkingToggle,
+}: OverflowButtonProps): React.ReactElement {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Trigger
+        render={
+          <Button
+            className={classnames(
+              styles.moreButton,
+              hasActiveOverflow && styles.moreButtonActive,
+            )}
+          >
+            +{overflowMarkings.length} more
+          </Button>
+        }
+      />
+      <Popover.Portal>
+        <Popover.Positioner side="bottom" align="start">
+          <Popover.Popup className={styles.overflowList}>
+            {overflowMarkings.map((marking) => (
+              <OverflowItem
+                key={marking.id}
+                id={marking.id}
+                label={marking.label}
+                description={marking.description}
+                selectionState={marking.selectionState}
+                disabled={marking.disabled}
+                onToggle={onMarkingToggle}
+              />
+            ))}
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}

--- a/packages/react-components/src/cbac-picker/base/OverflowItem.module.css
+++ b/packages/react-components/src/cbac-picker/base/OverflowItem.module.css
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.overflowItem {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  text-align: left;
+  padding: var(--osdk-surface-spacing)
+    calc(var(--osdk-surface-spacing) * 1.5);
+  font-size: var(--osdk-cbac-overflow-button-font-size);
+  font-family: inherit;
+  cursor: pointer;
+  border: none;
+  border-radius: var(--osdk-surface-border-radius);
+  color: var(--osdk-cbac-marking-button-color-default);
+  background: transparent;
+}
+
+.overflowItem:hover:not(:disabled):not([aria-disabled="true"]) {
+  background: var(--osdk-surface-background-color-default-hover);
+}
+
+.overflowItem:focus-visible {
+  outline: var(--osdk-focus-outline);
+  outline-offset: var(--osdk-focus-visible-outline-offset);
+}
+
+.overflowItemSelected {
+  color: var(--osdk-intent-primary-rest);
+  font-weight: var(--osdk-typography-weight-bold);
+}
+
+.overflowItemDisabled {
+  color: var(--osdk-cbac-marking-button-color-disallowed);
+  cursor: not-allowed;
+  opacity: var(--osdk-cbac-disabled-opacity);
+  text-decoration: line-through;
+}
+
+.tooltip {
+  z-index: var(--osdk-cbac-marking-tooltip-z-index);
+  max-width: var(--osdk-cbac-marking-tooltip-max-width);
+  padding: var(--osdk-cbac-marking-tooltip-padding);
+  background-color: var(--osdk-tooltip-bg);
+  border: 1px solid var(--osdk-tooltip-border-color);
+  border-radius: var(--osdk-surface-border-radius);
+  box-shadow: var(--osdk-tooltip-shadow);
+  font-size: var(--osdk-cbac-marking-tooltip-font-size);
+  line-height: 1.4;
+}
+
+.tooltipDescription {
+  margin: 0;
+  color: var(--osdk-typography-color-muted);
+}
+
+.tooltipHint {
+  margin: calc(var(--osdk-surface-spacing) * 0.25) 0 0;
+  font-style: italic;
+  color: var(--osdk-typography-color-muted);
+}

--- a/packages/react-components/src/cbac-picker/base/OverflowItem.tsx
+++ b/packages/react-components/src/cbac-picker/base/OverflowItem.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button } from "@base-ui/react/button";
+import { Tooltip } from "@base-ui/react/tooltip";
+import classnames from "classnames";
+import React from "react";
+import type { MarkingSelectionState } from "../types.js";
+import styles from "./OverflowItem.module.css";
+import {
+  getDisplayLabel,
+  getTooltipText,
+  isDisallowed,
+  isImplied,
+} from "./selectionStateHelpers.js";
+
+export interface OverflowItemProps {
+  id: string;
+  label: string;
+  description?: string;
+  selectionState: MarkingSelectionState;
+  disabled?: boolean;
+  onToggle: (markingId: string) => void;
+}
+
+export const OverflowItem: React.MemoExoticComponent<
+  (props: OverflowItemProps) => React.ReactElement
+> = React.memo(function OverflowItem({
+  id,
+  label,
+  description,
+  selectionState,
+  disabled,
+  onToggle,
+}: OverflowItemProps): React.ReactElement {
+  const handleClick = React.useCallback(() => {
+    onToggle(id);
+  }, [onToggle, id]);
+
+  const disallowed = isDisallowed(selectionState);
+  const isSelected = selectionState === "SELECTED";
+  const implied = isImplied(selectionState);
+
+  const tooltipText = getTooltipText(selectionState);
+  const hasDescription = description !== undefined && description.length > 0;
+  const showTooltip = hasDescription || tooltipText != null;
+  const isItemDisabled = disabled ?? disallowed;
+
+  const button = (
+    <Button
+      className={classnames(
+        styles.overflowItem,
+        (isSelected || implied) && styles.overflowItemSelected,
+        disallowed && styles.overflowItemDisabled,
+      )}
+      onClick={isItemDisabled ? undefined : handleClick}
+      disabled={showTooltip ? undefined : isItemDisabled}
+      aria-disabled={showTooltip ? isItemDisabled : undefined}
+      aria-pressed={isSelected || implied}
+    >
+      {getDisplayLabel(label, selectionState)}
+    </Button>
+  );
+
+  if (!showTooltip) {
+    return button;
+  }
+
+  return (
+    <Tooltip.Root>
+      <Tooltip.Trigger render={button} />
+      <Tooltip.Portal>
+        <Tooltip.Positioner side="right" sideOffset={4}>
+          <Tooltip.Popup className={styles.tooltip}>
+            {hasDescription && (
+              <p className={styles.tooltipDescription}>{description}</p>
+            )}
+            {tooltipText != null && (
+              <p className={styles.tooltipHint}>{tooltipText}</p>
+            )}
+          </Tooltip.Popup>
+        </Tooltip.Positioner>
+      </Tooltip.Portal>
+    </Tooltip.Root>
+  );
+});

--- a/packages/react-components/src/cbac-picker/base/ValidationWarning.module.css
+++ b/packages/react-components/src/cbac-picker/base/ValidationWarning.module.css
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.validationWarning {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--osdk-surface-spacing) * 1.5);
+  padding: var(--osdk-cbac-validation-warning-padding);
+  background: var(--osdk-cbac-validation-warning-bg);
+  color: var(--osdk-cbac-validation-warning-color);
+  font-size: var(--osdk-cbac-validation-warning-font-size);
+  border-radius: var(--osdk-cbac-validation-warning-border-radius);
+  max-height: var(--osdk-cbac-validation-warning-max-height);
+  overflow-y: auto;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--osdk-surface-spacing) * 1.5);
+}
+
+.icon {
+  flex-shrink: 0;
+}
+
+.groupList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  padding-left: calc(var(--osdk-surface-spacing) * 3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--osdk-surface-spacing);
+}
+
+.groupItem {
+  display: flex;
+  align-items: center;
+  gap: var(--osdk-surface-spacing);
+  flex-wrap: wrap;
+}
+
+.groupNumber {
+  font-weight: var(--osdk-typography-weight-bold);
+  flex-shrink: 0;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 var(--osdk-surface-spacing);
+  border: 1px solid var(--osdk-cbac-validation-warning-chip-border-color);
+  border-radius: var(--osdk-surface-border-radius);
+  background: var(--osdk-cbac-validation-warning-chip-bg);
+  font-size: var(--osdk-cbac-validation-warning-font-size);
+  color: var(--osdk-typography-color-default-rest);
+}

--- a/packages/react-components/src/cbac-picker/base/ValidationWarning.tsx
+++ b/packages/react-components/src/cbac-picker/base/ValidationWarning.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { WarningSign } from "@blueprintjs/icons";
+import classnames from "classnames";
+import React from "react";
+import type { RequiredMarkingGroup } from "../types.js";
+import styles from "./ValidationWarning.module.css";
+
+export interface ValidationWarningProps {
+  requiredMarkingGroups: ReadonlyArray<RequiredMarkingGroup>;
+  className?: string;
+}
+
+export function ValidationWarning({
+  requiredMarkingGroups,
+  className,
+}: ValidationWarningProps): React.ReactElement {
+  return (
+    <div className={classnames(styles.validationWarning, className)}>
+      <div className={styles.header}>
+        <WarningSign className={styles.icon} size={14} />
+        <span>
+          To complete a valid classification, at least one marking from each of
+          the following sets needs to be selected:
+        </span>
+      </div>
+      <ol className={styles.groupList}>
+        {requiredMarkingGroups.map((group, index) => (
+          <li key={group.markingNames.join(",")} className={styles.groupItem}>
+            <span className={styles.groupNumber}>{index + 1}.</span>
+            {group.markingNames.map((name) => (
+              <span key={name} className={styles.chip}>{name}</span>
+            ))}
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/packages/react-components/src/cbac-picker/base/selectionStateHelpers.ts
+++ b/packages/react-components/src/cbac-picker/base/selectionStateHelpers.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { MarkingSelectionState } from "../types.js";
+
+export function isDisallowed(state: MarkingSelectionState): boolean {
+  return state === "DISALLOWED" || state === "IMPLIED_DISALLOWED";
+}
+
+export function isImplied(state: MarkingSelectionState): boolean {
+  return state === "IMPLIED" || state === "IMPLIED_DISALLOWED";
+}
+
+export function getDisplayLabel(
+  label: string,
+  state: MarkingSelectionState,
+): string {
+  return isImplied(state) ? `(${label})` : label;
+}
+
+export function getTooltipText(
+  state: MarkingSelectionState,
+): string | undefined {
+  if (state === "DISALLOWED") {
+    return "This marking is not allowed with the current selection";
+  }
+  if (state === "IMPLIED_DISALLOWED") {
+    return "This marking is implied but not allowed";
+  }
+  return undefined;
+}

--- a/packages/react-components/src/cbac-picker/types.ts
+++ b/packages/react-components/src/cbac-picker/types.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type MarkingSelectionState =
+  | "NONE"
+  | "SELECTED"
+  | "IMPLIED"
+  | "DISALLOWED"
+  | "IMPLIED_DISALLOWED";
+
+export interface CbacBannerData {
+  classificationString: string;
+  textColor: string;
+  backgroundColors: string[];
+  markingIds: string[];
+}
+
+export interface PickerMarkingCategory {
+  id: string;
+  name: string;
+  description: string;
+  categoryType: "CONJUNCTIVE" | "DISJUNCTIVE";
+  markingType: "MANDATORY" | "CBAC";
+}
+
+export interface PickerMarking {
+  id: string;
+  categoryId: string;
+  name: string;
+  description?: string;
+}
+
+export interface CategoryMarkingGroup {
+  category: PickerMarkingCategory;
+  markings: PickerMarking[];
+}
+
+export interface RequiredMarkingGroup {
+  markingNames: string[];
+}
+
+export interface MaxClassificationConstraint {
+  bannerClassificationString: string;
+  helperText?: string;
+  markingIds: string[];
+}

--- a/packages/react-components/src/cbac-picker/useCbacPickerState.ts
+++ b/packages/react-components/src/cbac-picker/useCbacPickerState.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  useCbacBanner,
+  useCbacMarkingRestrictions,
+  useMarkingCategories,
+  useMarkings,
+} from "@osdk/react/platform-apis";
+import React from "react";
+import type {
+  CategoryMarkingGroup,
+  CbacBannerData,
+  MarkingSelectionState,
+  RequiredMarkingGroup,
+} from "./types.js";
+import { EMPTY_ARRAY, resolveRequiredGroups } from "./utils/cbacPickerUtils.js";
+import {
+  computeMarkingStates,
+  groupMarkingsByCategory,
+} from "./utils/selectionLogic.js";
+
+const EMPTY_GROUPS: string[][] = [];
+
+export interface UseCbacPickerStateResult {
+  categoryGroups: CategoryMarkingGroup[];
+  markingStates: Map<string, MarkingSelectionState>;
+  banner: CbacBannerData | undefined;
+  requiredMarkingGroups: RequiredMarkingGroup[];
+  isValid: boolean;
+  userSatisfiesMarkings: boolean;
+  disallowedMarkingIds: readonly string[];
+  isLoading: boolean;
+  error: Error | undefined;
+  retry: () => void;
+}
+
+function useStableArray(arr: string[]): string[] {
+  const ref = React.useRef(arr);
+  if (
+    arr.length !== ref.current.length
+    || arr.some((id, i) => id !== ref.current[i])
+  ) {
+    ref.current = arr;
+  }
+  return ref.current;
+}
+
+export function useCbacPickerState(
+  selectedIds: string[],
+): UseCbacPickerStateResult {
+  const stableSelectedIds = useStableArray(selectedIds);
+  const {
+    categories: rawCategories,
+    isLoading: categoriesLoading,
+    error: categoriesError,
+    refetch: refetchCategories,
+  } = useMarkingCategories();
+  const {
+    markings: rawMarkings,
+    isLoading: markingsLoading,
+    error: markingsError,
+    refetch: refetchMarkings,
+  } = useMarkings();
+  const {
+    banner: latestBanner,
+    isLoading: bannerLoading,
+    error: bannerError,
+    refetch: refetchBanner,
+  } = useCbacBanner({ markingIds: stableSelectedIds });
+
+  const bannerRef = React.useRef(latestBanner);
+  if (latestBanner != null) {
+    bannerRef.current = latestBanner;
+  }
+  const banner = latestBanner ?? bannerRef.current;
+  const {
+    restrictions,
+    isLoading: restrictionsLoading,
+    error: restrictionsError,
+    refetch: refetchRestrictions,
+  } = useCbacMarkingRestrictions({ markingIds: stableSelectedIds });
+
+  const impliedMarkingIds = restrictions?.impliedMarkings ?? EMPTY_ARRAY;
+  const disallowedMarkingIds = restrictions?.disallowedMarkings ?? EMPTY_ARRAY;
+  const requiredMarkingGroups = restrictions?.requiredMarkings ?? EMPTY_GROUPS;
+  const isValid = restrictions?.isValid ?? true;
+  const userSatisfiesMarkings = restrictions?.userSatisfiesMarkings ?? true;
+
+  const isLoading = categoriesLoading || markingsLoading
+    || restrictionsLoading || bannerLoading;
+
+  const error = React.useMemo(() => {
+    const errors = [
+      categoriesError,
+      markingsError,
+      restrictionsError,
+      bannerError,
+    ].filter((e): e is Error => e != null);
+    if (errors.length > 1) {
+      return new AggregateError(
+        errors,
+        errors.map(e => e.message).join("; "),
+      );
+    }
+    return errors[0];
+  }, [categoriesError, markingsError, restrictionsError, bannerError]);
+
+  const retry = React.useCallback(() => {
+    refetchCategories();
+    refetchMarkings();
+    refetchBanner();
+    refetchRestrictions();
+  }, [refetchCategories, refetchMarkings, refetchBanner, refetchRestrictions]);
+
+  const categoryGroups = React.useMemo(
+    (): CategoryMarkingGroup[] => {
+      if (rawCategories === undefined || rawMarkings === undefined) {
+        return [];
+      }
+      return groupMarkingsByCategory(rawMarkings, rawCategories);
+    },
+    [rawMarkings, rawCategories],
+  );
+
+  const markingStates = React.useMemo(
+    () =>
+      computeMarkingStates(
+        stableSelectedIds,
+        impliedMarkingIds,
+        disallowedMarkingIds,
+      ),
+    [stableSelectedIds, impliedMarkingIds, disallowedMarkingIds],
+  );
+
+  const resolvedRequiredGroups = React.useMemo(
+    () => resolveRequiredGroups(categoryGroups, requiredMarkingGroups),
+    [categoryGroups, requiredMarkingGroups],
+  );
+
+  return React.useMemo(
+    () => ({
+      categoryGroups,
+      markingStates,
+      banner,
+      requiredMarkingGroups: resolvedRequiredGroups,
+      isValid,
+      userSatisfiesMarkings,
+      disallowedMarkingIds,
+      isLoading,
+      error,
+      retry,
+    }),
+    [
+      categoryGroups,
+      markingStates,
+      banner,
+      resolvedRequiredGroups,
+      isValid,
+      userSatisfiesMarkings,
+      disallowedMarkingIds,
+      isLoading,
+      error,
+      retry,
+    ],
+  );
+}

--- a/packages/react-components/src/cbac-picker/useCbacSelection.ts
+++ b/packages/react-components/src/cbac-picker/useCbacSelection.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import type { CategoryMarkingGroup } from "./types.js";
+import type { UseCbacPickerStateResult } from "./useCbacPickerState.js";
+import { useCbacPickerState } from "./useCbacPickerState.js";
+import { EMPTY_ARRAY } from "./utils/cbacPickerUtils.js";
+import { toggleMarking } from "./utils/selectionLogic.js";
+
+export interface UseCbacSelectionResult extends UseCbacPickerStateResult {
+  selectedIds: string[];
+  selectedIdsRef: React.MutableRefObject<string[]>;
+  setSelectedIds: React.Dispatch<React.SetStateAction<string[]>>;
+  toggle: (markingId: string) => void;
+  dismiss: () => void;
+  reset: () => void;
+}
+
+export function useCbacSelection(
+  initialMarkingIds: string[] | undefined,
+): UseCbacSelectionResult {
+  const [selectedIds, setSelectedIds] = React.useState<string[]>(
+    initialMarkingIds ?? EMPTY_ARRAY,
+  );
+
+  const [prevInitialIds, setPrevInitialIds] = React.useState(initialMarkingIds);
+  if (initialMarkingIds !== prevInitialIds) {
+    setPrevInitialIds(initialMarkingIds);
+    setSelectedIds(initialMarkingIds ?? EMPTY_ARRAY);
+  }
+
+  const pickerState = useCbacPickerState(selectedIds);
+
+  const selectedIdsRef = React.useRef(selectedIds);
+  selectedIdsRef.current = selectedIds;
+
+  const categoryGroupsRef = React.useRef<CategoryMarkingGroup[]>(
+    pickerState.categoryGroups,
+  );
+  categoryGroupsRef.current = pickerState.categoryGroups;
+
+  const toggle = React.useCallback(
+    (markingId: string) => {
+      setSelectedIds((prev) =>
+        toggleMarking(markingId, prev, categoryGroupsRef.current)
+      );
+    },
+    [],
+  );
+
+  const dismiss = React.useCallback(() => {
+    setSelectedIds(EMPTY_ARRAY);
+  }, []);
+
+  const reset = React.useCallback(() => {
+    setSelectedIds(initialMarkingIds ?? EMPTY_ARRAY);
+  }, [initialMarkingIds]);
+
+  return {
+    selectedIds,
+    selectedIdsRef,
+    setSelectedIds,
+    ...pickerState,
+    toggle,
+    dismiss,
+    reset,
+  };
+}

--- a/packages/react-components/src/cbac-picker/useConstraintCallout.tsx
+++ b/packages/react-components/src/cbac-picker/useConstraintCallout.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCbacBanner } from "@osdk/react/platform-apis";
+import React from "react";
+import { MaxClassificationField } from "./base/MaxClassificationField.js";
+import type { MaxClassificationConstraint } from "./types.js";
+import { EMPTY_ARRAY, resolveBannerDisplay } from "./utils/cbacPickerUtils.js";
+
+export function useConstraintCallout(
+  maxClassificationConstraint: MaxClassificationConstraint | undefined,
+): React.ReactNode {
+  const constraintMarkingIds = maxClassificationConstraint?.markingIds
+    ?? EMPTY_ARRAY;
+  const { banner: constraintBanner } = useCbacBanner({
+    markingIds: constraintMarkingIds,
+    enabled: maxClassificationConstraint != null,
+  });
+
+  return React.useMemo(() => {
+    if (maxClassificationConstraint == null) {
+      return undefined;
+    }
+    const resolved = resolveBannerDisplay(constraintBanner);
+    return (
+      <MaxClassificationField
+        classificationString={maxClassificationConstraint
+          .bannerClassificationString}
+        textColor={resolved.textColor}
+        backgroundColors={resolved.backgroundColors}
+        helperText={maxClassificationConstraint.helperText}
+      />
+    );
+  }, [maxClassificationConstraint, constraintBanner]);
+}

--- a/packages/react-components/src/cbac-picker/utils/cbacPickerUtils.ts
+++ b/packages/react-components/src/cbac-picker/utils/cbacPickerUtils.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  CategoryMarkingGroup,
+  CbacBannerData,
+  RequiredMarkingGroup,
+} from "../types.js";
+const UNMARKED_BACKGROUND_COLORS: string[] = ["#8F99A8"];
+const UNMARKED_TEXT_COLOR = "#FFFFFF";
+const UNMARKED_CLASSIFICATION_STRING = "UNMARKED";
+
+export const EMPTY_ARRAY: string[] = [];
+
+export function backgroundFromColors(backgroundColors: string[]): string {
+  return backgroundColors.length > 1
+    ? `linear-gradient(to right, ${backgroundColors.join(", ")})`
+    : backgroundColors[0] ?? "transparent";
+}
+
+export interface ResolvedBannerDisplay {
+  classificationString: string;
+  textColor: string;
+  backgroundColors: string[];
+}
+
+export function resolveBannerDisplay(
+  banner: CbacBannerData | undefined,
+): ResolvedBannerDisplay {
+  return {
+    classificationString: banner?.classificationString
+      ?? UNMARKED_CLASSIFICATION_STRING,
+    textColor: banner?.textColor ?? UNMARKED_TEXT_COLOR,
+    backgroundColors: banner?.backgroundColors ?? UNMARKED_BACKGROUND_COLORS,
+  };
+}
+
+export interface AppliedMarkingGroup {
+  categoryName: string;
+  markingNames: string[];
+}
+
+export function groupMarkingsByCategory(
+  markingIds: string[],
+  categories: ReadonlyArray<{ id: string; name: string }> | undefined,
+  markings:
+    | ReadonlyArray<{ id: string; name: string; categoryId: string }>
+    | undefined,
+): AppliedMarkingGroup[] {
+  if (
+    markingIds.length === 0 || categories === undefined
+    || markings === undefined
+  ) {
+    return [];
+  }
+
+  const selected = new Set(markingIds);
+  const categoryNames = new Map(categories.map((c) => [c.id, c.name]));
+  const grouped = new Map<string, string[]>();
+
+  for (const marking of markings) {
+    if (selected.has(marking.id)) {
+      const name = categoryNames.get(marking.categoryId)
+        ?? marking.categoryId;
+      const list = grouped.get(name);
+      if (list !== undefined) {
+        list.push(marking.name);
+      } else {
+        grouped.set(name, [marking.name]);
+      }
+    }
+  }
+
+  return Array.from(grouped, ([categoryName, markingNames]) => ({
+    categoryName,
+    markingNames,
+  }));
+}
+
+export function resolveRequiredGroups(
+  categoryGroups: CategoryMarkingGroup[],
+  requiredMarkingGroups: string[][],
+): RequiredMarkingGroup[] {
+  const markingIdToName = new Map(
+    categoryGroups.flatMap((g) => g.markings).map((m) =>
+      [m.id, m.name] as const
+    ),
+  );
+  return requiredMarkingGroups.map((ids) => ({
+    markingNames: ids.map((id) => markingIdToName.get(id) ?? id),
+  }));
+}

--- a/packages/react-components/src/cbac-picker/utils/errorMessages.ts
+++ b/packages/react-components/src/cbac-picker/utils/errorMessages.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface CbacErrorMessage {
+  title: string;
+  remediation: string;
+}
+
+interface ApiErrorLike {
+  statusCode?: number;
+  errorDescription?: string;
+}
+
+function isApiErrorLike(error: Error): error is Error & ApiErrorLike {
+  return "statusCode" in error
+    && typeof (error as ApiErrorLike).statusCode === "number";
+}
+
+function formatByStatusCode(error: Error & ApiErrorLike): CbacErrorMessage {
+  const statusCode = error.statusCode;
+  if (statusCode === 401) {
+    return {
+      title: "Session expired",
+      remediation: "Sign in again to continue.",
+    };
+  }
+  if (statusCode === 403) {
+    return {
+      title: "Permission denied",
+      remediation: "Contact your administrator for permission.",
+    };
+  }
+  if (statusCode === 404) {
+    return {
+      title: "Not found",
+      remediation: "The requested classification data could not be found.",
+    };
+  }
+  if (statusCode !== undefined && statusCode >= 500) {
+    return {
+      title: "Server error",
+      remediation: "Something went wrong. Try again later.",
+    };
+  }
+  if (
+    typeof error.errorDescription === "string"
+    && error.errorDescription.length > 0
+  ) {
+    return {
+      title: error.errorDescription,
+      remediation: "",
+    };
+  }
+  return {
+    title: error.message || "Something went wrong",
+    remediation: "",
+  };
+}
+
+export function formatCbacError(error: Error): CbacErrorMessage {
+  if (error instanceof AggregateError && error.errors.length > 0) {
+    const first = error.errors[0];
+    if (first instanceof Error) {
+      return formatCbacError(first);
+    }
+  }
+
+  if (isApiErrorLike(error)) {
+    return formatByStatusCode(error);
+  }
+
+  if (
+    error.message.toLowerCase().includes("network")
+    || error.message.toLowerCase().includes("fetch")
+  ) {
+    return {
+      title: "Network error",
+      remediation: "Check your connection and try again.",
+    };
+  }
+
+  return {
+    title: error.message || "Something went wrong",
+    remediation: "",
+  };
+}

--- a/packages/react-components/src/cbac-picker/utils/selectionLogic.test.ts
+++ b/packages/react-components/src/cbac-picker/utils/selectionLogic.test.ts
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type {
+  CategoryMarkingGroup,
+  PickerMarking,
+  PickerMarkingCategory,
+} from "../types.js";
+import {
+  computeMarkingStates,
+  groupMarkingsByCategory,
+  toggleMarking,
+} from "./selectionLogic.js";
+
+const conjunctiveCategory: PickerMarkingCategory = {
+  id: "cat-conj",
+  name: "Conjunctive Category",
+  description: "A conjunctive category",
+  categoryType: "CONJUNCTIVE",
+  markingType: "CBAC",
+};
+
+const disjunctiveCategory: PickerMarkingCategory = {
+  id: "cat-disjunctive",
+  name: "Disjunctive Category",
+  description: "A disjunctive category",
+  categoryType: "DISJUNCTIVE",
+  markingType: "CBAC",
+};
+
+const conjunctiveGroup: CategoryMarkingGroup = {
+  category: conjunctiveCategory,
+  markings: [
+    { id: "m1", categoryId: "cat-conj", name: "Marking 1" },
+    { id: "m2", categoryId: "cat-conj", name: "Marking 2" },
+    { id: "m3", categoryId: "cat-conj", name: "Marking 3" },
+  ],
+};
+
+const disjunctiveGroup: CategoryMarkingGroup = {
+  category: disjunctiveCategory,
+  markings: [
+    { id: "d1", categoryId: "cat-disjunctive", name: "Disjunctive 1" },
+    { id: "d2", categoryId: "cat-disjunctive", name: "Disjunctive 2" },
+  ],
+};
+
+const allGroups: CategoryMarkingGroup[] = [conjunctiveGroup, disjunctiveGroup];
+
+describe("toggleMarking", () => {
+  it("selecting a marking in a CONJUNCTIVE category adds it", () => {
+    const result = toggleMarking("m1", [], [conjunctiveGroup]);
+    expect(result).toEqual(["m1"]);
+  });
+
+  it("deselecting a marking in a CONJUNCTIVE category removes it", () => {
+    const result = toggleMarking("m1", ["m1", "m2"], [conjunctiveGroup]);
+    expect(result).toEqual(["m2"]);
+  });
+
+  it("selecting a marking in a DISJUNCTIVE category replaces previous selection in that category", () => {
+    const result = toggleMarking("d2", ["d1"], [disjunctiveGroup]);
+    expect(result).toEqual(["d2"]);
+  });
+
+  it("deselecting the only selected marking in a DISJUNCTIVE category removes it", () => {
+    const result = toggleMarking("d1", ["d1"], [disjunctiveGroup]);
+    expect(result).toEqual([]);
+  });
+
+  it("cross-category: selecting in one category doesn't affect another", () => {
+    const result = toggleMarking("d1", ["m1", "m2"], allGroups);
+    expect(result).toEqual(["m1", "m2", "d1"]);
+  });
+
+  it("returns current selection when marking id is not found in any category", () => {
+    const result = toggleMarking("unknown", ["m1"], allGroups);
+    expect(result).toEqual(["m1"]);
+  });
+
+  it("returns unchanged selection when categories array is empty", () => {
+    const result = toggleMarking("m1", ["m2"], []);
+    expect(result).toEqual(["m2"]);
+  });
+});
+
+describe("computeMarkingStates", () => {
+  it("selected marking returns SELECTED", () => {
+    const states = computeMarkingStates(["m1"], [], []);
+    expect(states.get("m1")).toBe("SELECTED");
+  });
+
+  it("implied marking returns IMPLIED", () => {
+    const states = computeMarkingStates([], ["m1"], []);
+    expect(states.get("m1")).toBe("IMPLIED");
+  });
+
+  it("disallowed marking returns DISALLOWED", () => {
+    const states = computeMarkingStates([], [], ["m1"]);
+    expect(states.get("m1")).toBe("DISALLOWED");
+  });
+
+  it("both implied and disallowed returns IMPLIED_DISALLOWED", () => {
+    const states = computeMarkingStates([], ["m1"], ["m1"]);
+    expect(states.get("m1")).toBe("IMPLIED_DISALLOWED");
+  });
+
+  it("unknown marking returns undefined from map lookup", () => {
+    const states = computeMarkingStates([], [], []);
+    expect(states.get("unknown")).toBeUndefined();
+  });
+
+  it("empty inputs returns empty map", () => {
+    const states = computeMarkingStates([], [], []);
+    expect(states.size).toBe(0);
+  });
+
+  it("marking that is both SELECTED and DISALLOWED returns SELECTED", () => {
+    const states = computeMarkingStates(["m1"], [], ["m1"]);
+    expect(states.get("m1")).toBe("SELECTED");
+  });
+
+  it("marking that is both SELECTED and IMPLIED returns SELECTED", () => {
+    const states = computeMarkingStates(["m1"], ["m1"], []);
+    expect(states.get("m1")).toBe("SELECTED");
+  });
+
+  it("marking that is SELECTED, IMPLIED, and DISALLOWED returns SELECTED", () => {
+    const states = computeMarkingStates(["m1"], ["m1"], ["m1"]);
+    expect(states.get("m1")).toBe("SELECTED");
+  });
+});
+
+describe("groupMarkingsByCategory", () => {
+  const categoryA: PickerMarkingCategory = {
+    id: "a",
+    name: "Category A",
+    description: "First",
+    categoryType: "CONJUNCTIVE",
+    markingType: "CBAC",
+  };
+
+  const categoryB: PickerMarkingCategory = {
+    id: "b",
+    name: "Category B",
+    description: "Second",
+    categoryType: "DISJUNCTIVE",
+    markingType: "MANDATORY",
+  };
+
+  const categoryEmpty: PickerMarkingCategory = {
+    id: "empty",
+    name: "Empty Category",
+    description: "No markings",
+    categoryType: "CONJUNCTIVE",
+    markingType: "CBAC",
+  };
+
+  const markings: PickerMarking[] = [
+    { id: "a1", categoryId: "a", name: "A1" },
+    { id: "a2", categoryId: "a", name: "A2" },
+    { id: "b1", categoryId: "b", name: "B1" },
+  ];
+
+  it("groups markings correctly by category", () => {
+    const groups = groupMarkingsByCategory(markings, [categoryA, categoryB]);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].category).toEqual(categoryA);
+    expect(groups[0].markings).toEqual([
+      { id: "a1", categoryId: "a", name: "A1" },
+      { id: "a2", categoryId: "a", name: "A2" },
+    ]);
+    expect(groups[1].category).toEqual(categoryB);
+    expect(groups[1].markings).toEqual([
+      { id: "b1", categoryId: "b", name: "B1" },
+    ]);
+  });
+
+  it("maintains category order", () => {
+    const groups = groupMarkingsByCategory(markings, [categoryB, categoryA]);
+    expect(groups[0].category.id).toBe("b");
+    expect(groups[1].category.id).toBe("a");
+  });
+
+  it("excludes categories with no markings", () => {
+    const groups = groupMarkingsByCategory(markings, [
+      categoryA,
+      categoryEmpty,
+      categoryB,
+    ]);
+    expect(groups).toHaveLength(2);
+    expect(groups.map((g) => g.category.id)).toEqual(["a", "b"]);
+  });
+
+  it("handles empty inputs", () => {
+    expect(groupMarkingsByCategory([], [])).toEqual([]);
+    expect(groupMarkingsByCategory([], [categoryA])).toEqual([]);
+    expect(groupMarkingsByCategory(markings, [])).toEqual([]);
+  });
+
+  it("silently drops orphan markings whose categoryId is not in categories", () => {
+    const orphanMarking: PickerMarking = {
+      id: "orphan",
+      categoryId: "nonexistent",
+      name: "Orphan",
+    };
+    const groups = groupMarkingsByCategory(
+      [...markings, orphanMarking],
+      [categoryA, categoryB],
+    );
+    expect(groups).toHaveLength(2);
+    const allMarkingIds = groups.flatMap((g) => g.markings.map((m) => m.id));
+    expect(allMarkingIds).not.toContain("orphan");
+  });
+});

--- a/packages/react-components/src/cbac-picker/utils/selectionLogic.ts
+++ b/packages/react-components/src/cbac-picker/utils/selectionLogic.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  CategoryMarkingGroup,
+  MarkingSelectionState,
+  PickerMarking,
+  PickerMarkingCategory,
+} from "../types.js";
+
+export function toggleMarking(
+  markingId: string,
+  currentSelection: string[],
+  categories: CategoryMarkingGroup[],
+): string[] {
+  const isSelected = currentSelection.includes(markingId);
+
+  let ownerGroup: CategoryMarkingGroup | undefined;
+  for (const group of categories) {
+    for (const marking of group.markings) {
+      if (marking.id === markingId) {
+        ownerGroup = group;
+        break;
+      }
+    }
+    if (ownerGroup !== undefined) {
+      break;
+    }
+  }
+
+  if (ownerGroup === undefined) {
+    return currentSelection;
+  }
+
+  if (isSelected) {
+    return currentSelection.filter((id) => id !== markingId);
+  }
+
+  // Disjunctive categories allow only one marking selected at a time (radio-style).
+  // Conjunctive categories allow multiple markings (checkbox-style).
+  if (ownerGroup.category.categoryType === "DISJUNCTIVE") {
+    const sameCategoryMarkingIds = new Set(
+      ownerGroup.markings.map((m) => m.id),
+    );
+    const withoutSameCategory = currentSelection.filter(
+      (id) => !sameCategoryMarkingIds.has(id),
+    );
+    return [...withoutSameCategory, markingId];
+  }
+
+  return [...currentSelection, markingId];
+}
+
+export function computeMarkingStates(
+  selectedIds: string[],
+  impliedIds: string[],
+  disallowedIds: string[],
+): Map<string, MarkingSelectionState> {
+  const states = new Map<string, MarkingSelectionState>();
+
+  const selectedSet = new Set(selectedIds);
+  const impliedSet = new Set(impliedIds);
+  const disallowedSet = new Set(disallowedIds);
+
+  const allIds = new Set([...selectedIds, ...impliedIds, ...disallowedIds]);
+
+  for (const id of allIds) {
+    const isImplied = impliedSet.has(id);
+    const isDisallowed = disallowedSet.has(id);
+    const isSelected = selectedSet.has(id);
+
+    if (isSelected) {
+      states.set(id, "SELECTED");
+    } else if (isImplied && isDisallowed) {
+      states.set(id, "IMPLIED_DISALLOWED");
+    } else if (isImplied) {
+      states.set(id, "IMPLIED");
+    } else if (isDisallowed) {
+      states.set(id, "DISALLOWED");
+    }
+  }
+
+  return states;
+}
+
+export function groupMarkingsByCategory(
+  markings: PickerMarking[],
+  categories: PickerMarkingCategory[],
+): CategoryMarkingGroup[] {
+  const markingsByCategoryId = new Map<string, PickerMarking[]>();
+
+  for (const marking of markings) {
+    const existing = markingsByCategoryId.get(marking.categoryId);
+    if (existing !== undefined) {
+      existing.push(marking);
+    } else {
+      markingsByCategoryId.set(marking.categoryId, [marking]);
+    }
+  }
+
+  const groups: CategoryMarkingGroup[] = [];
+
+  for (const category of categories) {
+    const categoryMarkings = markingsByCategoryId.get(category.id);
+    if (categoryMarkings !== undefined && categoryMarkings.length > 0) {
+      groups.push({ category, markings: categoryMarkings });
+    }
+  }
+
+  return groups;
+}

--- a/packages/react-components/src/cbac-picker/utils/validationMessages.test.ts
+++ b/packages/react-components/src/cbac-picker/utils/validationMessages.test.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { ValidationContext } from "./validationMessages.js";
+import { getSubmitDisabledReason } from "./validationMessages.js";
+
+const validBase: ValidationContext = {
+  isValid: true,
+  requiredMarkingGroups: [],
+  selectedIds: ["m1"],
+  disallowedMarkingIds: [],
+  userSatisfiesMarkings: true,
+};
+
+describe("getSubmitDisabledReason", () => {
+  it("returns undefined when isValid is true", () => {
+    expect(getSubmitDisabledReason(validBase)).toBeUndefined();
+  });
+
+  it("returns required markings message when required groups exist", () => {
+    expect(getSubmitDisabledReason({
+      ...validBase,
+      isValid: false,
+      requiredMarkingGroups: [{ markingNames: ["A", "B"] }],
+      disallowedMarkingIds: ["m1"],
+      userSatisfiesMarkings: false,
+    })).toBe("Selected markings do not include all required markings.");
+  });
+
+  it("returns disallowed message when selected markings are disallowed", () => {
+    expect(getSubmitDisabledReason({
+      ...validBase,
+      isValid: false,
+      selectedIds: ["m1", "m2"],
+      disallowedMarkingIds: ["m2"],
+      userSatisfiesMarkings: false,
+    })).toBe("Selections include disallowed markings.");
+  });
+
+  it("returns user satisfaction message when userSatisfiesMarkings is false", () => {
+    expect(getSubmitDisabledReason({
+      ...validBase,
+      isValid: false,
+      userSatisfiesMarkings: false,
+    })).toBe(
+      "Invalid configuration of markings. Please ensure that you have permission to use all selected markings.",
+    );
+  });
+
+  it("returns generic fallback when invalid with no specific reason", () => {
+    expect(getSubmitDisabledReason({
+      ...validBase,
+      isValid: false,
+    })).toBe("Invalid marking selection.");
+  });
+
+  it("prioritizes required markings over disallowed", () => {
+    expect(getSubmitDisabledReason({
+      ...validBase,
+      isValid: false,
+      requiredMarkingGroups: [{ markingNames: ["A"] }],
+      selectedIds: ["m1"],
+      disallowedMarkingIds: ["m1"],
+    })).toBe("Selected markings do not include all required markings.");
+  });
+
+  it("prioritizes disallowed over userSatisfiesMarkings", () => {
+    expect(getSubmitDisabledReason({
+      ...validBase,
+      isValid: false,
+      selectedIds: ["m1"],
+      disallowedMarkingIds: ["m1"],
+      userSatisfiesMarkings: false,
+    })).toBe("Selections include disallowed markings.");
+  });
+
+  it("does not flag disallowed markings that are not selected", () => {
+    expect(getSubmitDisabledReason({
+      ...validBase,
+      isValid: false,
+      selectedIds: ["m1"],
+      disallowedMarkingIds: ["m2"],
+      userSatisfiesMarkings: false,
+    })).toBe(
+      "Invalid configuration of markings. Please ensure that you have permission to use all selected markings.",
+    );
+  });
+
+  it("returns undefined when isValid is true even if userSatisfiesMarkings is false", () => {
+    expect(getSubmitDisabledReason({
+      ...validBase,
+      isValid: true,
+      userSatisfiesMarkings: false,
+    })).toBeUndefined();
+  });
+
+  it("returns generic fallback with empty selectedIds and disallowed markings", () => {
+    expect(getSubmitDisabledReason({
+      ...validBase,
+      isValid: false,
+      selectedIds: [],
+      disallowedMarkingIds: ["m1"],
+    })).toBe("Invalid marking selection.");
+  });
+});

--- a/packages/react-components/src/cbac-picker/utils/validationMessages.ts
+++ b/packages/react-components/src/cbac-picker/utils/validationMessages.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { RequiredMarkingGroup } from "../types.js";
+
+export interface ValidationContext {
+  isValid: boolean;
+  requiredMarkingGroups: ReadonlyArray<RequiredMarkingGroup>;
+  selectedIds: string[];
+  disallowedMarkingIds: readonly string[];
+  userSatisfiesMarkings: boolean;
+}
+
+export function getSubmitDisabledReason(
+  ctx: ValidationContext,
+): string | undefined {
+  if (ctx.isValid) {
+    return undefined;
+  }
+  if (ctx.requiredMarkingGroups.length > 0) {
+    return "Selected markings do not include all required markings.";
+  }
+  const selectedSet = new Set(ctx.selectedIds);
+  const hasDisallowedSelected = ctx.disallowedMarkingIds.some(
+    (id) => selectedSet.has(id),
+  );
+  if (hasDisallowedSelected) {
+    return "Selections include disallowed markings.";
+  }
+  if (!ctx.userSatisfiesMarkings) {
+    return "Invalid configuration of markings. Please ensure that you have permission to use all selected markings.";
+  }
+  return "Invalid marking selection.";
+}

--- a/packages/react-components/src/public/experimental.ts
+++ b/packages/react-components/src/public/experimental.ts
@@ -15,6 +15,7 @@
  */
 
 export * from "./experimental/action-form.js";
+export * from "./experimental/cbac-picker.js";
 export * from "./experimental/document-viewer.js";
 export * from "./experimental/email-viewer.js";
 export * from "./experimental/excel-viewer.js";

--- a/packages/react-components/src/public/experimental/cbac-picker.ts
+++ b/packages/react-components/src/public/experimental/cbac-picker.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// CBAC Picker - OSDK-aware components
+export { CbacBanner } from "../../cbac-picker/CbacBanner.js";
+export { CbacBannerPopover } from "../../cbac-picker/CbacBannerPopover.js";
+import { CbacPicker as _CbacPicker } from "../../cbac-picker/CbacPicker.js";
+import { withOsdkMetrics } from "../../util/withOsdkMetrics.js";
+export const CbacPicker: typeof _CbacPicker = withOsdkMetrics(
+  _CbacPicker,
+  "CbacPicker",
+);
+export { CbacPickerDialog } from "../../cbac-picker/CbacPickerDialog.js";
+
+// CBAC Picker - Base components
+export { BaseCbacBanner } from "../../cbac-picker/base/BaseCbacBanner.js";
+export { BaseCbacPicker } from "../../cbac-picker/base/BaseCbacPicker.js";
+export { BaseCbacPickerDialog } from "../../cbac-picker/base/BaseCbacPickerDialog.js";
+
+// CBAC Picker - Selection logic utilities
+export {
+  computeMarkingStates,
+  groupMarkingsByCategory,
+  toggleMarking,
+} from "../../cbac-picker/utils/selectionLogic.js";
+// CBAC Picker - Types
+export type {
+  CategoryMarkingGroup,
+  CbacBannerData,
+  MarkingSelectionState,
+  MaxClassificationConstraint,
+  PickerMarking,
+  PickerMarkingCategory,
+  RequiredMarkingGroup,
+} from "../../cbac-picker/types.js";
+
+// CBAC Picker - MaxClassificationField
+export { MaxClassificationField } from "../../cbac-picker/base/MaxClassificationField.js";
+export type { MaxClassificationFieldProps } from "../../cbac-picker/base/MaxClassificationField.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4744,9 +4744,6 @@ importers:
       '@osdk/api':
         specifier: workspace:*
         version: link:../api
-      '@osdk/cbac-components':
-        specifier: workspace:*
-        version: link:../cbac-components
       '@osdk/client':
         specifier: workspace:*
         version: link:../client


### PR DESCRIPTION
## Summary

Merges `@osdk/cbac-components` into `@osdk/react-components` as a feature subdirectory. The picker, its base components, and selection-logic utilities are now exported from `@osdk/react-components/experimental/cbac-picker`. The legacy `@osdk/cbac-components` package is kept on disk for reference and carries deprecation banners pointing consumers at the new home.

## What moved

- **Source**: `packages/react-components/src/cbac-picker/` mirrors the original layout (`base/`, `utils/`, hooks, types, tests). Internal `@osdk/react-components/primitives` imports were rewritten to direct `src/base-components/...` paths to match the package's own convention.
- **Public entry point**: new `src/public/experimental/cbac-picker.ts` barrel; re-exported via `src/public/experimental.ts`; added `./experimental/cbac-picker` to the package `exports` map and `check-attw`.
- **Docs**: `docs/CbacPicker.md` copied into `react-components/docs/`; README, AGENTS, CLAUDE updated to list the picker; docusaurus sidebar (`sidebarsReactComponents.ts`) gained `CbacPicker` under `@osdk/react-components`; `intro.md` link repointed.
- **Storybook**: story + mock data imports updated to the new subpath; MDX docs source switched from `@cbac-docs/` → `@docs/`; cbac CSS import removed from `.storybook/styles.css` (now bundled into `@osdk/react-components/styles.css`); `@cbac-docs` alias and `@osdk/cbac-components` devDep removed.

## What stays

- The whole `packages/cbac-components` directory remains on disk untouched in terms of code. Only its docs (`README.md`, `AGENTS.md`, `CLAUDE.md`, `docs/CbacPicker.md`) gained \"DEPRECATED / RELOCATED\" banners.
- The legacy `/cbac-components/CbacPicker` docusaurus route is intentionally preserved so external links keep working; that page now renders the deprecation banner first.

## Out of scope

No external consumers' imports were rewritten — keeping that migration as a separate follow-up so this PR is focused on making the components available in their new home.

## Changeset

`.changeset/merge-cbac-into-react-components.md` — minor bump for `@osdk/react-components` only. No published code changed in `@osdk/cbac-components`, so no changeset entry was added there.

## Verification

- [x] `pnpm turbo typecheck --filter=@osdk/react-components --filter=@osdk/react-components-storybook`
- [x] `pnpm turbo build --filter=@osdk/docs`
- [x] `pnpm vitest run cbac` in `packages/react-components` (31/31 pass)

