### PR TITLE
Fix listogram bar border-radius and background token

### DIFF
--- a/.changeset/listogram-bar-styling.md
+++ b/.changeset/listogram-bar-styling.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Fix listogram bar border-radius distortion and use theme-aware background token

--- a/packages/react-components/src/filter-list/base/inputs/ListogramInput.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/ListogramInput.module.css
@@ -113,18 +113,15 @@
   height: var(--osdk-filter-listogram-bar-height);
   background: var(--osdk-filter-listogram-bar-bg);
   border-radius: var(--osdk-filter-listogram-bar-border-radius);
-  overflow: hidden;
 }
 
 .barFill {
   display: block;
   height: 100%;
-  width: 100%;
+  width: calc(var(--osdk-filter-listogram-bar-fill-scale, 0) * 100%);
   background: var(--osdk-filter-listogram-row-bar-color, var(--osdk-filter-listogram-bar-color));
   border-radius: var(--osdk-filter-listogram-bar-border-radius);
-  transform-origin: left;
-  transform: scaleX(var(--osdk-filter-listogram-bar-fill-scale, 0));
-  transition: transform var(--osdk-filter-listogram-bar-fill-transition);
+  transition: width var(--osdk-filter-listogram-bar-fill-transition);
 }
 
 .row[aria-pressed="true"] .barFill {

--- a/packages/react-components/src/tokens/component-tokens/filter-list.css
+++ b/packages/react-components/src/tokens/component-tokens/filter-list.css
@@ -223,8 +223,8 @@
 
   --osdk-filter-listogram-bar-height: calc(var(--osdk-surface-spacing) * 2);
   --osdk-filter-listogram-bar-width: calc(var(--osdk-surface-spacing) * 12.5);
-  --osdk-filter-listogram-bar-bg: var(--osdk-palette-gray-100);
-  --osdk-filter-listogram-bar-border-radius: var(--osdk-surface-border-radius);
+  --osdk-filter-listogram-bar-bg: var(--osdk-background-tertiary);
+  --osdk-filter-listogram-bar-border-radius: calc(var(--osdk-surface-border-radius) * 0.5);
   --osdk-filter-listogram-bar-color: var(--osdk-intent-primary-rest);
   --osdk-filter-listogram-bar-fill-transition: var(
       --osdk-emphasis-transition-duration


### PR DESCRIPTION
## Summary
- Switch listogram bar fill from `scaleX()` to `width` percentage so border-radius renders uniformly on both sides. The `scaleX()` approach distorts the border-radius — on short bars the left corners look squished/pointy while the right side stays round. With `width`, both sides render identically regardless of fill level.
- Derive bar border-radius from the surface token at half size (`calc(var(--osdk-surface-border-radius) * 0.5)`) for a subtler look that scales with theming
- Replace non-existent `--osdk-palette-gray-100` background token with theme-aware `--osdk-background-tertiary`, fixing the bar track across light, dark, modern, and devcon themes


Before:
<img width="434" height="291" alt="Screenshot 2026-06-04 at 12 07 37 PM" src="https://github.com/user-attachments/assets/ace7718e-e8b6-46b6-96fa-54edc9025186" />



After
<img width="616" height="433" alt="Screenshot 2026-06-04 at 12 05 59 PM" src="https://github.com/user-attachments/assets/685e3c7f-1787-481a-8971-3e40e716e8bf" />

## Test plan
- [ ] Open Storybook FilterList stories, verify listogram bars have uniform rounded corners on both ends at all fill levels
- [ ] Switch between light, dark, modern, and devcon themes — bar track background should adapt correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)