### PR TITLE
Render CBAC/MANDATORY marking columns in ObjectTable

### DIFF
--- a/.changeset/object-table-marking-render.md
+++ b/.changeset/object-table-marking-render.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+Render CBAC and MANDATORY marking property columns in `ObjectTable`. Columns backed by marking properties whose `typeMetadata.markingType` is `"CBAC"` now render via the `CbacBanner`, and `"MANDATORY"` marking columns render one pill per marking on the row. Columns whose marking subtype isn't surfaced by the platform fall back to the previous default rendering.

--- a/packages/react-components-storybook/src/mocks/employeeMetadata.ts
+++ b/packages/react-components-storybook/src/mocks/employeeMetadata.ts
@@ -571,6 +571,42 @@ export const employeeMetadata: TH_ObjectTypeFullMetadata<Employee> = {
           },
         ],
       },
+      "classificationMarking": {
+        "displayName": "Classification",
+        "dataType": {
+          "type": "marking",
+          "markingType": "MANDATORY",
+        },
+        "rid":
+          "ri.ontology.main.property.c1a55001-aaaa-4d5e-9abc-classification1",
+        "status": {
+          "type": "experimental",
+        },
+        "visibility": "NORMAL",
+        "typeClasses": [],
+      },
+      // The TH helper constrains `dataType.type` to equal the SDK property
+      // type ("marking"), but on the wire, multi-valued markings are
+      // represented as `{ type: "array", subType: { type: "marking" } }`.
+      // The cast lets us encode the real wire shape while keeping the rest
+      // of the metadata strictly typed.
+      "clearanceMarking": {
+        "displayName": "Clearance",
+        "dataType": {
+          "type": "array",
+          "subType": {
+            "type": "marking",
+            "markingType": "CBAC",
+          },
+        } as unknown as { type: "marking" },
+        "rid":
+          "ri.ontology.main.property.c1a55001-bbbb-4d5e-9abc-clearance00001",
+        "status": {
+          "type": "experimental",
+        },
+        "visibility": "NORMAL",
+        "typeClasses": [],
+      },
     },
     "rid": "ri.ontology.main.object-type.ade16a88-ecc4-4f96-9751-ca1799247d64",
     "titleProperty": "fullName",

--- a/packages/react-components-storybook/src/mocks/fauxFoundry.ts
+++ b/packages/react-components-storybook/src/mocks/fauxFoundry.ts
@@ -393,6 +393,14 @@ export async function setupFauxFoundry(): Promise<void> {
   };
 
   admin.setBannerResolver((markingIds, markings) => {
+    if (markingIds.length === 0) {
+      return {
+        classificationString: "UNMARKED",
+        textColor: "#FFFFFF",
+        backgroundColors: ["#8F99A8"],
+      };
+    }
+
     const markingMap = new Map(markings.map((m) => [m.id, m]));
     const classificationId = markingIds.find(
       (id) => markingMap.get(id)?.categoryId === "cat-classification",
@@ -402,13 +410,6 @@ export async function setupFauxFoundry(): Promise<void> {
       // No classification marking — label with the joined marking names so
       // CBAC compartment / releasability columns render meaningfully on
       // their own. Color tracks the first marking's category.
-      if (markingIds.length === 0) {
-        return {
-          classificationString: "UNMARKED",
-          textColor: "#FFFFFF",
-          backgroundColors: ["#8F99A8"],
-        };
-      }
       const resolved = markingIds.map((id) => markingMap.get(id)?.name ?? id);
       const firstCategoryId = markingIds
         .map((id) => markingMap.get(id)?.categoryId)

--- a/packages/react-components-storybook/src/mocks/fauxFoundry.ts
+++ b/packages/react-components-storybook/src/mocks/fauxFoundry.ts
@@ -206,10 +206,38 @@ export async function setupFauxFoundry(): Promise<void> {
     () => undefined,
   );
 
-  // Add mock data from JSON file
+  // Add mock data from JSON file. We synthesize marking values so the
+  // ObjectTable marking column story has data to render — each employee is
+  // assigned a classification (cycling unclassified → top-secret) and a
+  // CBAC clearance set (compartments + releasability) varying by index.
   const dataStore = fauxFoundry.getDefaultDataStore();
-  employeeData.forEach((employee) => {
-    dataStore.registerObject(employee);
+  const classificationCycle = [
+    "m-unclassified",
+    "m-confidential",
+    "m-secret",
+    "m-top-secret",
+  ];
+  const compartmentPool = ["m-alpha", "m-bravo", "m-charlie"];
+  const releasabilityPool = [
+    "m-rel-usa",
+    "m-rel-allied",
+    "m-no-foreign",
+  ];
+  employeeData.forEach((employee, index) => {
+    const classificationMarking = classificationCycle[
+      index % classificationCycle.length
+    ];
+    const compartmentCount = (index % compartmentPool.length) + 1;
+    const releasabilityCount = (index % releasabilityPool.length) + 1;
+    const clearanceMarking = [
+      ...compartmentPool.slice(0, compartmentCount),
+      ...releasabilityPool.slice(0, releasabilityCount),
+    ];
+    dataStore.registerObject({
+      ...employee,
+      classificationMarking,
+      clearanceMarking,
+    });
   });
 
   // Register sample PDF media for an employee's employeeDocuments property
@@ -359,6 +387,11 @@ export async function setupFauxFoundry(): Promise<void> {
     admin.registerMarking(marking);
   }
 
+  const categoryColors: Record<string, { textColor: string; bg: string }> = {
+    "cat-compartment": { textColor: "#FFFFFF", bg: "#5B3F8A" },
+    "cat-releasability": { textColor: "#FFFFFF", bg: "#1F6FB5" },
+  };
+
   admin.setBannerResolver((markingIds, markings) => {
     const markingMap = new Map(markings.map((m) => [m.id, m]));
     const classificationId = markingIds.find(
@@ -366,10 +399,27 @@ export async function setupFauxFoundry(): Promise<void> {
     );
 
     if (classificationId == null) {
+      // No classification marking — label with the joined marking names so
+      // CBAC compartment / releasability columns render meaningfully on
+      // their own. Color tracks the first marking's category.
+      if (markingIds.length === 0) {
+        return {
+          classificationString: "UNMARKED",
+          textColor: "#FFFFFF",
+          backgroundColors: ["#8F99A8"],
+        };
+      }
+      const resolved = markingIds.map((id) => markingMap.get(id)?.name ?? id);
+      const firstCategoryId = markingIds
+        .map((id) => markingMap.get(id)?.categoryId)
+        .find((cid): cid is string => cid != null);
+      const swatch = firstCategoryId != null
+        ? categoryColors[firstCategoryId]
+        : undefined;
       return {
-        classificationString: "UNMARKED",
-        textColor: "#FFFFFF",
-        backgroundColors: ["#8F99A8"],
+        classificationString: resolved.join(", "),
+        textColor: swatch?.textColor ?? "#FFFFFF",
+        backgroundColors: [swatch?.bg ?? "#8F99A8"],
       };
     }
 

--- a/packages/react-components-storybook/src/stories/ObjectTable/MarkingColumns.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/MarkingColumns.stories.tsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BaseTable } from "@osdk/react-components/experimental/object-table";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ColumnDef } from "@tanstack/react-table";
+import { getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import { fauxFoundry } from "../../mocks/fauxFoundry.js";
+
+type MarkingRow = {
+  id: number;
+  name: string;
+  classification: string[];
+  compartments: string[];
+  releasability: string[];
+  unspecifiedMarking: string[];
+};
+
+const rows: MarkingRow[] = [
+  {
+    id: 1,
+    name: "Dossier A",
+    classification: ["m-secret"],
+    compartments: ["m-alpha", "m-bravo"],
+    releasability: ["m-rel-usa"],
+    unspecifiedMarking: ["m-confidential"],
+  },
+  {
+    id: 2,
+    name: "Dossier B",
+    classification: ["m-top-secret"],
+    compartments: ["m-alpha", "m-bravo", "m-charlie"],
+    releasability: ["m-rel-allied", "m-no-foreign"],
+    unspecifiedMarking: ["m-unclassified"],
+  },
+  {
+    id: 3,
+    name: "Dossier C",
+    classification: ["m-confidential"],
+    compartments: [],
+    releasability: ["m-rel-usa", "m-rel-allied"],
+    unspecifiedMarking: [],
+  },
+];
+
+const columns: ColumnDef<MarkingRow>[] = [
+  {
+    id: "name",
+    accessorKey: "name",
+    header: "Name",
+    size: 140,
+  },
+  {
+    id: "classification",
+    accessorKey: "classification",
+    header: "Classification (MANDATORY)",
+    size: 220,
+    meta: { markingType: "MANDATORY" },
+  },
+  {
+    id: "compartments",
+    accessorKey: "compartments",
+    header: "Compartments (CBAC)",
+    size: 260,
+    meta: { markingType: "CBAC" },
+  },
+  {
+    id: "releasability",
+    accessorKey: "releasability",
+    header: "Releasability (CBAC)",
+    size: 260,
+    meta: { markingType: "CBAC" },
+  },
+  {
+    id: "unspecifiedMarking",
+    accessorKey: "unspecifiedMarking",
+    header: "Unspecified marking subtype",
+    size: 240,
+  },
+];
+
+const meta: Meta<typeof BaseTable<MarkingRow>> = {
+  title: "Components/ObjectTable/Marking Columns",
+  component: BaseTable,
+  tags: ["beta"],
+  parameters: {
+    msw: {
+      handlers: [...fauxFoundry.handlers],
+    },
+    docs: {
+      description: {
+        component:
+          "Demonstrates how ObjectTable renders marking property columns. The marking subtype on the column meta (`markingType: \"CBAC\" | \"MANDATORY\"`) is populated automatically by `useColumnDefs` from `ObjectMetadata.Property.typeMetadata`. CBAC columns render via `CbacBanner`; MANDATORY columns render one pill per marking id; marking columns whose subtype is not surfaced fall back to the default cell renderer.",
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => {
+    const table = useReactTable({
+      data: rows,
+      columns,
+      getCoreRowModel: getCoreRowModel(),
+    });
+
+    return (
+      <div style={{ height: 360 }}>
+        <BaseTable table={table} />
+      </div>
+    );
+  },
+};
+
+export const EmptyMarkings: Story = {
+  name: "Empty marking values",
+  render: () => {
+    const emptyRows: MarkingRow[] = [{
+      id: 1,
+      name: "Dossier with no markings",
+      classification: [],
+      compartments: [],
+      releasability: [],
+      unspecifiedMarking: [],
+    }];
+
+    const table = useReactTable({
+      data: emptyRows,
+      columns,
+      getCoreRowModel: getCoreRowModel(),
+    });
+
+    return (
+      <div style={{ height: 200 }}>
+        <BaseTable table={table} />
+      </div>
+    );
+  },
+};

--- a/packages/react-components-storybook/src/stories/ObjectTable/MarkingColumns.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/MarkingColumns.stories.tsx
@@ -14,87 +14,17 @@
  * limitations under the License.
  */
 
-import { BaseTable } from "@osdk/react-components/experimental/object-table";
+import { ObjectTable } from "@osdk/react-components/experimental/object-table";
+import type { ObjectTableProps } from "@osdk/react-components/experimental/object-table";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import type { ColumnDef } from "@tanstack/react-table";
-import { getCoreRowModel, useReactTable } from "@tanstack/react-table";
 import { fauxFoundry } from "../../mocks/fauxFoundry.js";
+import { Employee } from "../../types/Employee.js";
 
-type MarkingRow = {
-  id: number;
-  name: string;
-  classification: string[];
-  compartments: string[];
-  releasability: string[];
-  unspecifiedMarking: string[];
-};
+type EmployeeTableProps = ObjectTableProps<typeof Employee>;
 
-const rows: MarkingRow[] = [
-  {
-    id: 1,
-    name: "Dossier A",
-    classification: ["m-secret"],
-    compartments: ["m-alpha", "m-bravo"],
-    releasability: ["m-rel-usa"],
-    unspecifiedMarking: ["m-confidential"],
-  },
-  {
-    id: 2,
-    name: "Dossier B",
-    classification: ["m-top-secret"],
-    compartments: ["m-alpha", "m-bravo", "m-charlie"],
-    releasability: ["m-rel-allied", "m-no-foreign"],
-    unspecifiedMarking: ["m-unclassified"],
-  },
-  {
-    id: 3,
-    name: "Dossier C",
-    classification: ["m-confidential"],
-    compartments: [],
-    releasability: ["m-rel-usa", "m-rel-allied"],
-    unspecifiedMarking: [],
-  },
-];
-
-const columns: ColumnDef<MarkingRow>[] = [
-  {
-    id: "name",
-    accessorKey: "name",
-    header: "Name",
-    size: 140,
-  },
-  {
-    id: "classification",
-    accessorKey: "classification",
-    header: "Classification (MANDATORY)",
-    size: 220,
-    meta: { markingType: "MANDATORY" },
-  },
-  {
-    id: "compartments",
-    accessorKey: "compartments",
-    header: "Compartments (CBAC)",
-    size: 260,
-    meta: { markingType: "CBAC" },
-  },
-  {
-    id: "releasability",
-    accessorKey: "releasability",
-    header: "Releasability (CBAC)",
-    size: 260,
-    meta: { markingType: "CBAC" },
-  },
-  {
-    id: "unspecifiedMarking",
-    accessorKey: "unspecifiedMarking",
-    header: "Unspecified marking subtype",
-    size: 240,
-  },
-];
-
-const meta: Meta<typeof BaseTable<MarkingRow>> = {
-  title: "Components/ObjectTable/Marking Columns",
-  component: BaseTable,
+const meta: Meta<EmployeeTableProps> = {
+  title: "Components/ObjectTable/Features",
+  component: ObjectTable,
   tags: ["beta"],
   parameters: {
     msw: {
@@ -103,7 +33,7 @@ const meta: Meta<typeof BaseTable<MarkingRow>> = {
     docs: {
       description: {
         component:
-          "Demonstrates how ObjectTable renders marking property columns. The marking subtype on the column meta (`markingType: \"CBAC\" | \"MANDATORY\"`) is populated automatically by `useColumnDefs` from `ObjectMetadata.Property.typeMetadata`. CBAC columns render via `CbacBanner`; MANDATORY columns render one pill per marking id; marking columns whose subtype is not surfaced fall back to the default cell renderer.",
+          "Exercises the full OSDK metadata → `useColumnDefs` → `renderDefaultCell` chain. The `Employee` mock includes a MANDATORY `classificationMarking` and a CBAC `clearanceMarking` array; `ObjectTable` reads `typeMetadata.markingType` from the wire metadata and routes each cell through the matching renderer (`CbacBanner` for CBAC, one banner per marking for MANDATORY).",
       },
     },
   },
@@ -111,46 +41,19 @@ const meta: Meta<typeof BaseTable<MarkingRow>> = {
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
-
-export const Default: Story = {
-  render: () => {
-    const table = useReactTable({
-      data: rows,
-      columns,
-      getCoreRowModel: getCoreRowModel(),
-    });
-
-    return (
-      <div style={{ height: 360 }}>
-        <BaseTable table={table} />
-      </div>
-    );
+export const MarkingColumns: StoryObj<EmployeeTableProps> = {
+  args: {
+    objectType: Employee,
+    columnDefinitions: [
+      { locator: { type: "property", id: "fullName" } },
+      { locator: { type: "property", id: "department" } },
+      { locator: { type: "property", id: "classificationMarking" } },
+      { locator: { type: "property", id: "clearanceMarking" } },
+    ],
   },
-};
-
-export const EmptyMarkings: Story = {
-  name: "Empty marking values",
-  render: () => {
-    const emptyRows: MarkingRow[] = [{
-      id: 1,
-      name: "Dossier with no markings",
-      classification: [],
-      compartments: [],
-      releasability: [],
-      unspecifiedMarking: [],
-    }];
-
-    const table = useReactTable({
-      data: emptyRows,
-      columns,
-      getCoreRowModel: getCoreRowModel(),
-    });
-
-    return (
-      <div style={{ height: 200 }}>
-        <BaseTable table={table} />
-      </div>
-    );
-  },
+  render: (args) => (
+    <div style={{ height: 480 }}>
+      <ObjectTable {...args} />
+    </div>
+  ),
 };

--- a/packages/react-components-storybook/src/types/Employee.ts
+++ b/packages/react-components-storybook/src/types/Employee.ts
@@ -55,7 +55,9 @@ export namespace Employee {
     | "locationRegion"
     | "team"
     | "favPlace"
-    | "locationType";
+    | "locationType"
+    | "classificationMarking"
+    | "clearanceMarking";
 
   export interface Links {
     readonly lead: $SingleLinkAccessor<Employee>;
@@ -94,6 +96,10 @@ export namespace Employee {
     readonly favPlace: $PropType["geopoint"] | undefined;
     readonly locationType: $PropType["string"] | undefined;
     readonly isRemote: $PropType["boolean"] | undefined;
+    readonly classificationMarking: $PropType["marking"] | undefined;
+    readonly clearanceMarking:
+      | ReadonlyArray<$PropType["marking"]>
+      | undefined;
   }
 
   export interface StrictProps {
@@ -128,6 +134,10 @@ export namespace Employee {
     readonly favPlace: $PropType["geopoint"] | undefined;
     readonly locationType: $PropType["string"] | undefined;
     readonly isRemote: $PropType["boolean"] | undefined;
+    readonly classificationMarking: $PropType["marking"] | undefined;
+    readonly clearanceMarking:
+      | ReadonlyArray<$PropType["marking"]>
+      | undefined;
   }
 
   export interface ObjectSet extends $ObjectSet<Employee, Employee.ObjectSet> {}
@@ -183,6 +193,8 @@ export interface Employee extends $ObjectTypeDefinition {
       favPlace: $PropertyDef<"geopoint", "nullable", "single">;
       locationType: $PropertyDef<"string", "nullable", "single">;
       isRemote: $PropertyDef<"boolean", "nullable", "single">;
+      classificationMarking: $PropertyDef<"marking", "nullable", "single">;
+      clearanceMarking: $PropertyDef<"marking", "nullable", "array">;
     };
     links: {
       lead: $ObjectMetadata.Link<Employee, false>;

--- a/packages/react-components/src/object-table/DefaultCellRenderer.tsx
+++ b/packages/react-components/src/object-table/DefaultCellRenderer.tsx
@@ -17,6 +17,8 @@
 import type { CellContext, RowData } from "@tanstack/react-table";
 import React from "react";
 import { AsyncValueCell } from "./components/AsyncValueCell.js";
+import { CbacMarkingCell } from "./components/CbacMarkingCell.js";
+import { MandatoryMarkingCell } from "./components/MandatoryMarkingCell.js";
 import { EditableCell } from "./EditableCell.js";
 import styles from "./EditableCell.module.css";
 import { isAsyncCellData } from "./utils/AsyncCellData.js";
@@ -67,6 +69,14 @@ export function renderDefaultCell<TData extends RowData>(
   // and cannot be edited in the table. Return the async cell directly.
   if (columnMeta?.isAsyncColumn && asyncCellData) {
     return <AsyncValueCell {...asyncCellData} />;
+  }
+
+  if (columnMeta?.markingType === "CBAC") {
+    return <CbacMarkingCell value={cellValue} />;
+  }
+
+  if (columnMeta?.markingType === "MANDATORY") {
+    return <MandatoryMarkingCell value={cellValue} />;
   }
 
   const rowData = cellContext.row.original;

--- a/packages/react-components/src/object-table/Table.tsx
+++ b/packages/react-components/src/object-table/Table.tsx
@@ -50,6 +50,14 @@ declare module "@tanstack/react-table" {
     isVisible?: boolean;
     editable?: boolean | ((object: TData) => boolean);
     dataType?: string;
+    /**
+     * For columns backed by a `"marking"` property, the marking subtype as
+     * surfaced by the platform: `"CBAC"` for classification-based access
+     * control or `"MANDATORY"` for mandatory markings. Absent for
+     * non-marking columns and for marking columns whose subtype isn't
+     * exposed.
+     */
+    markingType?: "CBAC" | "MANDATORY";
     editFieldConfig?: EditFieldConfig<TData>;
     validateEdit?: (value: unknown) => Promise<string | undefined>;
   }

--- a/packages/react-components/src/object-table/__tests__/DefaultCellRenderer.test.tsx
+++ b/packages/react-components/src/object-table/__tests__/DefaultCellRenderer.test.tsx
@@ -16,9 +16,16 @@
 
 import type { CellContext } from "@tanstack/react-table";
 import { cleanup, render, screen } from "@testing-library/react";
+import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { renderDefaultCell } from "../DefaultCellRenderer.js";
 import type { CellEditInfo, EditFieldConfig } from "../utils/types.js";
+
+vi.mock("../../cbac-picker/CbacBanner.js", () => ({
+  CbacBanner: ({ markingIds }: { markingIds: string[] }) => (
+    <div data-testid="cbac-banner">{markingIds.join(",")}</div>
+  ),
+}));
 
 function createCellContext(
   value: unknown,
@@ -83,6 +90,58 @@ describe("renderDefaultCell", () => {
     const result = renderDefaultCell(createCellContext(undefined));
     render(<div data-testid="cell">{result}</div>);
     expect(screen.getByTestId("cell").textContent).toBe("");
+  });
+
+  describe("marking columns", () => {
+    it("renders a CbacBanner for a CBAC marking column with a single id", () => {
+      const result = renderDefaultCell(createCellContext("marking-1", {
+        columnMeta: { markingType: "CBAC" },
+      }));
+      render(<div data-testid="cell">{result}</div>);
+      expect(screen.getByTestId("cbac-banner").textContent).toBe("marking-1");
+    });
+
+    it("renders a CbacBanner for a CBAC marking column with multiple ids", () => {
+      const result = renderDefaultCell(createCellContext(["m-1", "m-2"], {
+        columnMeta: { markingType: "CBAC" },
+      }));
+      render(<div data-testid="cell">{result}</div>);
+      expect(screen.getByTestId("cbac-banner").textContent).toBe("m-1,m-2");
+    });
+
+    it("renders nothing for an empty CBAC marking value", () => {
+      const result = renderDefaultCell(createCellContext(null, {
+        columnMeta: { markingType: "CBAC" },
+      }));
+      render(<div data-testid="cell">{result}</div>);
+      expect(screen.queryByTestId("cbac-banner")).toBeNull();
+    });
+
+    it("renders one pill per id for a MANDATORY marking column", () => {
+      const result = renderDefaultCell(createCellContext(["m-1", "m-2"], {
+        columnMeta: { markingType: "MANDATORY" },
+      }));
+      render(<div data-testid="cell">{result}</div>);
+      expect(screen.getByText("m-1")).toBeDefined();
+      expect(screen.getByText("m-2")).toBeDefined();
+    });
+
+    it("renders a single pill for a single-valued MANDATORY marking", () => {
+      const result = renderDefaultCell(createCellContext("m-1", {
+        columnMeta: { markingType: "MANDATORY" },
+      }));
+      render(<div data-testid="cell">{result}</div>);
+      expect(screen.getByText("m-1")).toBeDefined();
+    });
+
+    it("falls back to the default renderer when markingType is absent", () => {
+      const result = renderDefaultCell(createCellContext("plain-value", {
+        columnMeta: { dataType: "marking" },
+      }));
+      render(<div data-testid="cell">{result}</div>);
+      expect(screen.getByTestId("cell").textContent).toBe("plain-value");
+      expect(screen.queryByTestId("cbac-banner")).toBeNull();
+    });
   });
 
   it("should pass only the current row's pending edits to getFieldComponentProps", () => {

--- a/packages/react-components/src/object-table/__tests__/DefaultCellRenderer.test.tsx
+++ b/packages/react-components/src/object-table/__tests__/DefaultCellRenderer.test.tsx
@@ -23,7 +23,9 @@ import type { CellEditInfo, EditFieldConfig } from "../utils/types.js";
 
 vi.mock("../../cbac-picker/CbacBanner.js", () => ({
   CbacBanner: ({ markingIds }: { markingIds: string[] }) => (
-    <div data-testid="cbac-banner">{markingIds.join(",")}</div>
+    <div data-testid="cbac-banner" data-marking-ids={markingIds.join(",")}>
+      {markingIds.join(",")}
+    </div>
   ),
 }));
 
@@ -117,21 +119,27 @@ describe("renderDefaultCell", () => {
       expect(screen.queryByTestId("cbac-banner")).toBeNull();
     });
 
-    it("renders one pill per id for a MANDATORY marking column", () => {
+    it("renders one CbacBanner per id for a MANDATORY marking column", () => {
       const result = renderDefaultCell(createCellContext(["m-1", "m-2"], {
         columnMeta: { markingType: "MANDATORY" },
       }));
       render(<div data-testid="cell">{result}</div>);
-      expect(screen.getByText("m-1")).toBeDefined();
-      expect(screen.getByText("m-2")).toBeDefined();
+      const banners = screen.getAllByTestId("cbac-banner");
+      expect(banners).toHaveLength(2);
+      expect(banners.map((el) => el.getAttribute("data-marking-ids"))).toEqual([
+        "m-1",
+        "m-2",
+      ]);
     });
 
-    it("renders a single pill for a single-valued MANDATORY marking", () => {
+    it("renders a single CbacBanner for a single-valued MANDATORY marking", () => {
       const result = renderDefaultCell(createCellContext("m-1", {
         columnMeta: { markingType: "MANDATORY" },
       }));
       render(<div data-testid="cell">{result}</div>);
-      expect(screen.getByText("m-1")).toBeDefined();
+      const banners = screen.getAllByTestId("cbac-banner");
+      expect(banners).toHaveLength(1);
+      expect(banners[0].getAttribute("data-marking-ids")).toBe("m-1");
     });
 
     it("falls back to the default renderer when markingType is absent", () => {

--- a/packages/react-components/src/object-table/__tests__/DefaultCellRenderer.test.tsx
+++ b/packages/react-components/src/object-table/__tests__/DefaultCellRenderer.test.tsx
@@ -132,6 +132,21 @@ describe("renderDefaultCell", () => {
       ]);
     });
 
+    it("deduplicates marking ids so duplicate values don't break React keys", () => {
+      const result = renderDefaultCell(
+        createCellContext(["m-1", "m-1", "m-2"], {
+          columnMeta: { markingType: "MANDATORY" },
+        }),
+      );
+      render(<div data-testid="cell">{result}</div>);
+      const banners = screen.getAllByTestId("cbac-banner");
+      expect(banners).toHaveLength(2);
+      expect(banners.map((el) => el.getAttribute("data-marking-ids"))).toEqual([
+        "m-1",
+        "m-2",
+      ]);
+    });
+
     it("renders a single CbacBanner for a single-valued MANDATORY marking", () => {
       const result = renderDefaultCell(createCellContext("m-1", {
         columnMeta: { markingType: "MANDATORY" },

--- a/packages/react-components/src/object-table/components/CbacMarkingCell.tsx
+++ b/packages/react-components/src/object-table/components/CbacMarkingCell.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { CbacBanner } from "../../cbac-picker/CbacBanner.js";
+import { toMarkingIdArray } from "../utils/markingValue.js";
+
+export interface CbacMarkingCellProps {
+  value: unknown;
+}
+
+export function CbacMarkingCell({
+  value,
+}: CbacMarkingCellProps): React.ReactNode {
+  const markingIds = toMarkingIdArray(value);
+  if (markingIds.length === 0) {
+    return null;
+  }
+  return <CbacBanner markingIds={markingIds} />;
+}

--- a/packages/react-components/src/object-table/components/MandatoryMarkingCell.module.css
+++ b/packages/react-components/src/object-table/components/MandatoryMarkingCell.module.css
@@ -1,0 +1,36 @@
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--osdk-mandatory-marking-cell-gap, 4px);
+  align-items: center;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--osdk-mandatory-marking-pill-padding-y, 1px)
+    var(--osdk-mandatory-marking-pill-padding-x, 6px);
+  border-radius: var(
+    --osdk-mandatory-marking-pill-border-radius,
+    var(--osdk-surface-border-radius)
+  );
+  background: var(
+    --osdk-mandatory-marking-pill-background,
+    var(--osdk-surface-background-color-default-hover)
+  );
+  color: var(
+    --osdk-mandatory-marking-pill-color,
+    var(--osdk-typography-color-default-rest)
+  );
+  border: var(--osdk-surface-border-width) solid
+    var(
+      --osdk-mandatory-marking-pill-border-color,
+      var(--osdk-surface-border-color-default)
+    );
+  font-size: var(--osdk-typography-size-body-small, 11px);
+  line-height: 1.2;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/packages/react-components/src/object-table/components/MandatoryMarkingCell.module.css
+++ b/packages/react-components/src/object-table/components/MandatoryMarkingCell.module.css
@@ -6,31 +6,5 @@
 }
 
 .pill {
-  display: inline-flex;
-  align-items: center;
-  padding: var(--osdk-mandatory-marking-pill-padding-y, 1px)
-    var(--osdk-mandatory-marking-pill-padding-x, 6px);
-  border-radius: var(
-    --osdk-mandatory-marking-pill-border-radius,
-    var(--osdk-surface-border-radius)
-  );
-  background: var(
-    --osdk-mandatory-marking-pill-background,
-    var(--osdk-surface-background-color-default-hover)
-  );
-  color: var(
-    --osdk-mandatory-marking-pill-color,
-    var(--osdk-typography-color-default-rest)
-  );
-  border: var(--osdk-surface-border-width) solid
-    var(
-      --osdk-mandatory-marking-pill-border-color,
-      var(--osdk-surface-border-color-default)
-    );
-  font-size: var(--osdk-typography-size-body-small, 11px);
-  line-height: 1.2;
   max-width: 100%;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }

--- a/packages/react-components/src/object-table/components/MandatoryMarkingCell.module.css
+++ b/packages/react-components/src/object-table/components/MandatoryMarkingCell.module.css
@@ -1,7 +1,7 @@
 .container {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--osdk-mandatory-marking-cell-gap, 4px);
+  gap: var(--osdk-surface-spacing);
   align-items: center;
 }
 

--- a/packages/react-components/src/object-table/components/MandatoryMarkingCell.tsx
+++ b/packages/react-components/src/object-table/components/MandatoryMarkingCell.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from "react";
+import { CbacBanner } from "../../cbac-picker/CbacBanner.js";
 import { toMarkingIdArray } from "../utils/markingValue.js";
 import styles from "./MandatoryMarkingCell.module.css";
 
@@ -22,6 +23,11 @@ export interface MandatoryMarkingCellProps {
   value: unknown;
 }
 
+/**
+ * Renders one CBAC-resolved banner per marking on the row. MANDATORY marking
+ * columns render per-marking (rather than via a single combined banner) so
+ * each individual marking on the object is visible at a glance.
+ */
 export function MandatoryMarkingCell({
   value,
 }: MandatoryMarkingCellProps): React.ReactNode {
@@ -32,9 +38,7 @@ export function MandatoryMarkingCell({
   return (
     <span className={styles.container}>
       {markingIds.map((id) => (
-        <span key={id} className={styles.pill} title={id}>
-          {id}
-        </span>
+        <CbacBanner key={id} markingIds={[id]} className={styles.pill} />
       ))}
     </span>
   );

--- a/packages/react-components/src/object-table/components/MandatoryMarkingCell.tsx
+++ b/packages/react-components/src/object-table/components/MandatoryMarkingCell.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { toMarkingIdArray } from "../utils/markingValue.js";
+import styles from "./MandatoryMarkingCell.module.css";
+
+export interface MandatoryMarkingCellProps {
+  value: unknown;
+}
+
+export function MandatoryMarkingCell({
+  value,
+}: MandatoryMarkingCellProps): React.ReactNode {
+  const markingIds = toMarkingIdArray(value);
+  if (markingIds.length === 0) {
+    return null;
+  }
+  return (
+    <span className={styles.container}>
+      {markingIds.map((id) => (
+        <span key={id} className={styles.pill} title={id}>
+          {id}
+        </span>
+      ))}
+    </span>
+  );
+}

--- a/packages/react-components/src/object-table/hooks/__tests__/useColumnDefs.test.tsx
+++ b/packages/react-components/src/object-table/hooks/__tests__/useColumnDefs.test.tsx
@@ -745,6 +745,75 @@ describe(useColumnDefs, () => {
     expect(result.current.columns).toEqual([]);
   });
 
+  describe("marking column meta", () => {
+    const markingMetadata = {
+      ...mockMetadata,
+      properties: {
+        cbacMarking: {
+          type: "marking" as const,
+          displayName: "CBAC Marking",
+          typeMetadata: {
+            type: "marking" as const,
+            markingType: "CBAC" as const,
+          },
+        },
+        mandatoryMarking: {
+          type: "marking" as const,
+          displayName: "Mandatory Marking",
+          typeMetadata: {
+            type: "marking" as const,
+            markingType: "MANDATORY" as const,
+          },
+        },
+        plainMarking: {
+          type: "marking" as const,
+          displayName: "Plain Marking",
+        },
+        notAMarking: {
+          type: "string" as const,
+          displayName: "Plain String",
+        },
+      },
+    };
+
+    it("propagates markingType from property metadata onto column meta", async () => {
+      const deferred = pDefer();
+      const fakeClient = {
+        fetchMetadata: vitest.fn(() => deferred.promise),
+      } as unknown as Client;
+
+      const wrapper = createWrapper(fakeClient);
+
+      const columnDefinitions: Array<ColumnDefinition<TestObject, {}, {}>> = [
+        { locator: { type: "property", id: "cbacMarking" as TestObjectKeys } },
+        {
+          locator: {
+            type: "property",
+            id: "mandatoryMarking" as TestObjectKeys,
+          },
+        },
+        { locator: { type: "property", id: "plainMarking" as TestObjectKeys } },
+        { locator: { type: "property", id: "notAMarking" as TestObjectKeys } },
+      ];
+
+      const { result } = renderHook(
+        () => useColumnDefs(TestObjectType, columnDefinitions),
+        { wrapper },
+      );
+
+      deferred.resolve(markingMetadata);
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.columns[0]?.meta?.markingType).toBe("CBAC");
+      expect(result.current.columns[1]?.meta?.markingType).toBe("MANDATORY");
+      expect(result.current.columns[2]?.meta?.markingType).toBeUndefined();
+      expect(result.current.columns[3]?.meta?.markingType).toBeUndefined();
+    });
+  });
+
   it("memoizes columns based on metadata properties", async () => {
     const deferred = pDefer();
     const fakeClient = {

--- a/packages/react-components/src/object-table/hooks/useColumnDefs.ts
+++ b/packages/react-components/src/object-table/hooks/useColumnDefs.ts
@@ -127,6 +127,10 @@ function getColumnsFromColumnDefinitions<
         ? propertyMetadata.type
         : undefined;
 
+    const markingType = propertyMetadata?.typeMetadata?.type === "marking"
+      ? propertyMetadata.typeMetadata.markingType
+      : undefined;
+
     const colDef: AccessorColumnDef<
       Osdk.Instance<Q, "$allBaseProperties", PropertyKeys<Q>, RDPs>
     > = {
@@ -140,6 +144,7 @@ function getColumnsFromColumnDefinitions<
         editable,
         editFieldConfig,
         dataType,
+        markingType,
         validateEdit,
       },
       size: width,

--- a/packages/react-components/src/object-table/utils/markingValue.ts
+++ b/packages/react-components/src/object-table/utils/markingValue.ts
@@ -18,12 +18,20 @@
  * Normalize a marking property's cell value into a string[] of marking ids.
  * Marking properties may arrive as a single string (single-valued) or
  * string[] (multi-valued); null/undefined become an empty array.
+ *
+ * Duplicates are removed so callers (e.g. per-marking pill renderers) can
+ * safely use the marking id as a React key.
  */
 export function toMarkingIdArray(value: unknown): string[] {
-  if (value == null) return [];
-  if (typeof value === "string") return [value];
+  if (value == null) {
+    return [];
+  }
+  if (typeof value === "string") {
+    return [value];
+  }
   if (Array.isArray(value)) {
-    return value.filter((v): v is string => typeof v === "string");
+    const ids = value.filter((v): v is string => typeof v === "string");
+    return Array.from(new Set(ids));
   }
   return [];
 }

--- a/packages/react-components/src/object-table/utils/markingValue.ts
+++ b/packages/react-components/src/object-table/utils/markingValue.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Normalize a marking property's cell value into a string[] of marking ids.
+ * Marking properties may arrive as a single string (single-valued) or
+ * string[] (multi-valued); null/undefined become an empty array.
+ */
+export function toMarkingIdArray(value: unknown): string[] {
+  if (value == null) return [];
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) {
+    return value.filter((v): v is string => typeof v === "string");
+  }
+  return [];
+}


### PR DESCRIPTION
## Summary

- Threads the `markingType` field from `ObjectMetadata.Property.typeMetadata` (landed via #3444's marking subtype work on the platform metadata) through `ObjectTable`'s column meta.
- `CBAC` marking columns now render via `CbacBanner` (in-tree at `@osdk/react-components/experimental/cbac-picker`).
- `MANDATORY` marking columns render one pill per marking on the row.
- Marking columns without a surfaced subtype, and non-marking columns, are unchanged.

## Demo

<img width="974" height="513" alt="Screenshot 2026-06-05 at 08 40 10" src="https://github.com/user-attachments/assets/0332b4fe-1dc4-4ac9-bfcc-95eed909c566" />


## Test plan
- [x] `pnpm turbo typecheck --filter=@osdk/react-components`
- [x] `pnpm turbo test --filter=@osdk/react-components` (1178 passing — new coverage in `DefaultCellRenderer.test.tsx` and `useColumnDefs.test.tsx` for CBAC single/multi/empty, MANDATORY single/multi, unspecified marking fallback, and column-meta plumbing)
- [x] Render visually in Storybook against a real ontology to confirm pill / banner styling matches Workshop