### PR TITLE
@osdk/language-models: accept a Client in the helper functions

### DIFF
--- a/.changeset/language-models-accept-client.md
+++ b/.changeset/language-models-accept-client.md
@@ -1,0 +1,5 @@
+---
+"@osdk/language-models": minor
+---
+
+`getOpenAiBaseUrl`/`getAnthropicBaseUrl`/`getGoogleBaseUrl`/`getFoundryToken`/`createFetch` now accept an OSDK `Client` in addition to a `PlatformClient`, resolving the underlying client context internally.

--- a/packages/language-models/package.json
+++ b/packages/language-models/package.json
@@ -41,6 +41,10 @@
     "transpileTypes": "monorepo.tool.transpile -f esm -m types -t node",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
+  "dependencies": {
+    "@osdk/shared.client": "^1.0.1",
+    "@osdk/shared.client2": "^1.0.0"
+  },
   "peerDependencies": {
     "@osdk/client": "workspace:^"
   },

--- a/packages/language-models/src/utils.test.ts
+++ b/packages/language-models/src/utils.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { PlatformClient } from "@osdk/client";
+import { createClient, type PlatformClient } from "@osdk/client";
 import { describe, expect, it, vi } from "vitest";
 import {
   createFetch,
@@ -109,6 +109,31 @@ describe("getGoogleBaseUrl", () => {
       baseUrl: "https://example.palantirfoundry.com/",
     });
 
+    expect(getGoogleBaseUrl(client)).toBe(
+      "https://example.palantirfoundry.com/api/v2/llm/proxy/google",
+    );
+  });
+});
+
+describe("accepts an OSDK Client (context nested under symbolClientContext)", () => {
+  it("resolves token, fetch, and base URLs through the nested context", async () => {
+    const mockFetch = vi.fn();
+    const client = createClient(
+      "https://example.palantirfoundry.com/",
+      "ri.a.b.ontology",
+      async () => "nested-token",
+      {},
+      mockFetch,
+    );
+
+    expect(await getFoundryToken(client)).toBe("nested-token");
+    expect(typeof createFetch(client)).toBe("function");
+    expect(getOpenAiBaseUrl(client)).toBe(
+      "https://example.palantirfoundry.com/api/v2/llm/proxy/openai/v1",
+    );
+    expect(getAnthropicBaseUrl(client)).toBe(
+      "https://example.palantirfoundry.com/api/v2/llm/proxy/anthropic",
+    );
     expect(getGoogleBaseUrl(client)).toBe(
       "https://example.palantirfoundry.com/api/v2/llm/proxy/google",
     );

--- a/packages/language-models/src/utils.ts
+++ b/packages/language-models/src/utils.ts
@@ -14,7 +14,19 @@
  * limitations under the License.
  */
 
-import type { PlatformClient } from "@osdk/client";
+import type { Client, PlatformClient } from "@osdk/client";
+import { symbolClientContext as legacySymbolClientContext } from "@osdk/shared.client";
+import { symbolClientContext } from "@osdk/shared.client2";
+
+function resolveContext(client: Client | PlatformClient): PlatformClient {
+  if (symbolClientContext in client) {
+    return client[symbolClientContext] as PlatformClient;
+  }
+  if (legacySymbolClientContext in client) {
+    return client[legacySymbolClientContext] as PlatformClient;
+  }
+  return client as PlatformClient;
+}
 
 /**
  * Returns the PlatformClient's `fetch` function, which automatically
@@ -39,9 +51,9 @@ import type { PlatformClient } from "@osdk/client";
  * ```
  */
 export function createFetch(
-  client: PlatformClient,
+  client: Client | PlatformClient,
 ): typeof globalThis.fetch {
-  return client.fetch;
+  return resolveContext(client).fetch;
 }
 
 /**
@@ -56,9 +68,9 @@ export function createFetch(
  * ```
  */
 export async function getFoundryToken(
-  client: PlatformClient,
+  client: Client | PlatformClient,
 ): Promise<string> {
-  return client.tokenProvider();
+  return resolveContext(client).tokenProvider();
 }
 
 /**
@@ -73,8 +85,11 @@ export async function getFoundryToken(
  * // Returns: "https://example.palantirfoundry.com/api/v2/llm/proxy/anthropic"
  * ```
  */
-export function getAnthropicBaseUrl(client: PlatformClient): string {
-  return new URL("api/v2/llm/proxy/anthropic", client.baseUrl).toString();
+export function getAnthropicBaseUrl(client: Client | PlatformClient): string {
+  return new URL(
+    "api/v2/llm/proxy/anthropic",
+    resolveContext(client).baseUrl,
+  ).toString();
 }
 
 /**
@@ -89,8 +104,11 @@ export function getAnthropicBaseUrl(client: PlatformClient): string {
  * // Returns: "https://example.palantirfoundry.com/api/v2/llm/proxy/openai/v1"
  * ```
  */
-export function getOpenAiBaseUrl(client: PlatformClient): string {
-  return new URL("api/v2/llm/proxy/openai/v1", client.baseUrl).toString();
+export function getOpenAiBaseUrl(client: Client | PlatformClient): string {
+  return new URL(
+    "api/v2/llm/proxy/openai/v1",
+    resolveContext(client).baseUrl,
+  ).toString();
 }
 
 /**
@@ -113,6 +131,9 @@ export function getOpenAiBaseUrl(client: PlatformClient): string {
  * });
  * ```
  */
-export function getGoogleBaseUrl(client: PlatformClient): string {
-  return new URL("api/v2/llm/proxy/google", client.baseUrl).toString();
+export function getGoogleBaseUrl(client: Client | PlatformClient): string {
+  return new URL(
+    "api/v2/llm/proxy/google",
+    resolveContext(client).baseUrl,
+  ).toString();
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4171,6 +4171,12 @@ importers:
       '@osdk/client':
         specifier: workspace:^
         version: link:../client
+      '@osdk/shared.client':
+        specifier: ^1.0.1
+        version: 1.0.1
+      '@osdk/shared.client2':
+        specifier: ^1.0.0
+        version: 1.0.0
     devDependencies:
       '@osdk/monorepo.api-extractor':
         specifier: workspace:~


### PR DESCRIPTION
The `@osdk/language-models` helpers (`createFetch`, `getFoundryToken`, `getOpenAiBaseUrl`, `getAnthropicBaseUrl`, `getGoogleBaseUrl`) now accept an OSDK `Client` in addition to a `PlatformClient`. The underlying client context is resolved internally, so callers no longer need to extract it by hand.