### PR TITLE
Ontology as Code | Allow "Exotic Strings" To Be Primary Keys on Object Creation

### DIFF
--- a/.changeset/shaky-lamps-retire.md
+++ b/.changeset/shaky-lamps-retire.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker": minor
+---
+
+Allow creation of object types with exotic strings to allow for analyzers and render hints to be set at time of creation from OAC

--- a/packages/maker/src/api/defineObject.ts
+++ b/packages/maker/src/api/defineObject.ts
@@ -49,7 +49,11 @@ import type {
 import type { ObjectTypeDefinition } from "./object/ObjectTypeDefinition.js";
 import type { ObjectTypeStatus } from "./object/ObjectTypeStatus.js";
 import type { PropertyTypeType } from "./properties/PropertyTypeType.js";
-import { isExotic, isStruct } from "./properties/PropertyTypeType.js";
+import {
+  isExotic,
+  isExoticString,
+  isStruct,
+} from "./properties/PropertyTypeType.js";
 // From https://stackoverflow.com/a/79288714
 const ISO_8601_DURATION =
   /^P(?!$)(?:(?:((?:\d+Y)|(?:\d+(?:\.|,)\d+Y$))?((?:\d+M)|(?:\d+(?:\.|,)\d+M$))?((?:\d+D)|(?:\d+(?:\.|,)\d+D$))?(T((?:\d+H)|(?:\d+(?:\.|,)\d+H$))?((?:\d+M)|(?:\d+(?:\.|,)\d+M$))?((?:\d+S)|(?:\d+(?:\.|,)\d+S$))?)?)|(?:\d+(?:(?:\.|,)\d+)?W))$/;
@@ -186,10 +190,14 @@ export function defineObject(
         && !isExotic(titleProp.mainValue.type)),
     `Title property ${objectDef.titlePropertyApiName} must be a primitive type`,
   );
+
+  // Only allow creation if primary key is a primitive type or an "exotic string" type.
+  // This is because the "exotic string" contains other options such as analyzers/render hints that are also valid.
+  const apiNameProp = objectDef.properties
+    ?.[objectDef.primaryKeyPropertyApiName]
+    ?.type;
   invariant(
-    !isExotic(
-      objectDef.properties?.[objectDef.primaryKeyPropertyApiName]?.type,
-    ),
+    !isExotic(apiNameProp) || isExoticString(apiNameProp),
     `Primary key property ${objectDef.primaryKeyPropertyApiName} can only be primitive types`,
   );
 

--- a/packages/maker/src/api/properties/PropertyTypeType.ts
+++ b/packages/maker/src/api/properties/PropertyTypeType.ts
@@ -117,6 +117,11 @@ export function isStruct(
 ): type is PropertyTypeTypeStruct {
   return typeof type === "object" && type.type === "struct";
 }
+export function isExoticString(
+  type: PropertyTypeType,
+): type is PropertyTypeTypeString {
+  return typeof type === "object" && type.type === "string";
+}
 
 type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
 


### PR DESCRIPTION
### Summary

Simply allows the creation process to go through when a specific non-primitive type is set as a primary key, what I refer to here as the "exotic string", denoted by the `PropertyTypeTypeString` type in `PropertyTypeType.ts`. This behavior _is_ presently supported in OMA, so the idea here is to just get to parity with it. 

### Potential Improvements

We could make a generalized method to check if a given `PropertyTypeType` is a given `PropertyTypeType`'s type (E.g., combine the methods `isExoticString()` and `isStruct()` into a single method and make it more generalized), but `isStruct()` is used in a ton of spots and didn't want to change a bunch of logic for this FR - LMK if I am off base here and would be happy to implement the method! 😊

### Prior Behavior

1. User creates a new object in OAC with an exotic string as the primary key and pre-configured analyzers + render hints set on the exotic string
2. User attempts to build
3. User receives error `Primary key property <property-name-here> can only be primitive types` 
4. Sadness ensues 😭

### Intended Behavior after Change

1. User creates a new object in OAC with an exotic string as the primary key and pre-configured analyzers + render hints set on the exotic string
2. User attempts to build
3. User is able to create a new object with pre-configured analyzers and render hints
4. User is happy 😊