### PR TITLE
Mikhailprice/pdf viewer download filename

### DIFF
--- a/.changeset/pdf-viewer-download-event-fix.md
+++ b/.changeset/pdf-viewer-download-event-fix.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Fix PDF viewer toolbar download saving an invalid filename.

--- a/packages/react-components/src/pdf-viewer/PdfViewer.tsx
+++ b/packages/react-components/src/pdf-viewer/PdfViewer.tsx
@@ -17,7 +17,7 @@
 import { Error as ErrorIcon, Spin } from "@blueprintjs/icons";
 import classnames from "classnames";
 import "pdfjs-dist/web/pdf_viewer.css";
-import React, { forwardRef, useImperativeHandle } from "react";
+import React, { forwardRef, useCallback, useImperativeHandle } from "react";
 import { PdfAnnotationOverlay } from "./components/PdfAnnotationOverlay.js";
 import { PdfViewerOutlineSidebar } from "./components/PdfViewerOutlineSidebar.js";
 import { PdfViewerSearchBar } from "./components/PdfViewerSearchBar.js";
@@ -89,6 +89,10 @@ export const BasePdfViewer: React.ForwardRefExoticComponent<
 
     const annotationsByPage = usePdfAnnotationsByPage(annotations);
 
+    const handleDownload = useCallback(() => {
+      viewer.download();
+    }, [viewer]);
+
     const rootClassName = classnames(styles.pdfViewer, className);
 
     if (viewer.loading) {
@@ -135,7 +139,7 @@ export const BasePdfViewer: React.ForwardRefExoticComponent<
           onAutoSizeToggle={viewer.toggleAutoSize}
           onSearchOpen={viewer.search.openSearch}
           onSidebarToggle={viewer.toggleSidebar}
-          onDownload={viewer.download}
+          onDownload={handleDownload}
           enableDownload={enableDownload}
           onRotateLeft={viewer.rotateLeft}
           onRotateRight={viewer.rotateRight}


### PR DESCRIPTION
 ---
  PR 1 — mikhailprice/pdf-viewer-download-filename → main

  ## Fix PDF viewer toolbar download saving files as "[object Object]"

  ### Problem
  The PDF viewer's toolbar **Download** button wired its `onClick` directly to the
  viewer's `download(filename?)` handler:

  ```tsx
  <Button onClick={onDownload} … />   // onDownload === viewer.download

  React therefore passed the click event as the filename argument. The
  filename resolver returns its argument verbatim when non-null:

  function resolveDownloadFilename(src, filename) {
    if (filename != null) return filename;          // ← the event object
    if (typeof src === "string") return src.split("/").pop()?.split("?")[0] || "document.pdf";
    return "document.pdf";
  }
```
  So a.download was set to the event object and every download saved as
  [object Object] — for any consumer of the built-in toolbar.

  Fix

  Wrap the toolbar handler so the event is not forwarded; the filename is resolved
  from src as intended.
```
  const handleDownload = useCallback(() => {
    viewer.download();
  }, [viewer]);
  // onDownload={handleDownload}
```
  Testing

  - vitest run src/pdf-viewer → 159/159 pass
  - eslint + dprint clean
  - Changeset: @osdk/react-components patch

  ---