### PR TITLE
Mikhailprice/blob download filename parameter

### DIFF
--- a/.changeset/pdf-viewer-download-event-fix.md
+++ b/.changeset/pdf-viewer-download-event-fix.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Fix PDF viewer toolbar download saving an invalid filename.

--- a/.changeset/pdf-viewer-download-filename-prop.md
+++ b/.changeset/pdf-viewer-download-filename-prop.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+Add `downloadFileName` prop to set the PDF download name.

--- a/packages/react-components/src/pdf-viewer/PdfViewer.tsx
+++ b/packages/react-components/src/pdf-viewer/PdfViewer.tsx
@@ -17,7 +17,7 @@
 import { Error as ErrorIcon, Spin } from "@blueprintjs/icons";
 import classnames from "classnames";
 import "pdfjs-dist/web/pdf_viewer.css";
-import React, { forwardRef, useImperativeHandle } from "react";
+import React, { forwardRef, useCallback, useImperativeHandle } from "react";
 import { PdfAnnotationOverlay } from "./components/PdfAnnotationOverlay.js";
 import { PdfViewerOutlineSidebar } from "./components/PdfViewerOutlineSidebar.js";
 import { PdfViewerSearchBar } from "./components/PdfViewerSearchBar.js";
@@ -89,6 +89,10 @@ export const BasePdfViewer: React.ForwardRefExoticComponent<
 
     const annotationsByPage = usePdfAnnotationsByPage(annotations);
 
+    const handleDownload = useCallback(() => {
+      viewer.download();
+    }, [viewer]);
+
     const rootClassName = classnames(styles.pdfViewer, className);
 
     if (viewer.loading) {
@@ -135,7 +139,7 @@ export const BasePdfViewer: React.ForwardRefExoticComponent<
           onAutoSizeToggle={viewer.toggleAutoSize}
           onSearchOpen={viewer.search.openSearch}
           onSidebarToggle={viewer.toggleSidebar}
-          onDownload={viewer.download}
+          onDownload={handleDownload}
           enableDownload={enableDownload}
           onRotateLeft={viewer.rotateLeft}
           onRotateRight={viewer.rotateRight}

--- a/packages/react-components/src/pdf-viewer/PdfViewer.tsx
+++ b/packages/react-components/src/pdf-viewer/PdfViewer.tsx
@@ -50,6 +50,7 @@ export const BasePdfViewer: React.ForwardRefExoticComponent<
     initialAutoSize = false,
     initialSidebarOpen = false,
     enableDownload = false,
+    downloadFileName,
     sidebarMode: sidebarModeProp = "thumbnails",
     outlineIcons,
     className,
@@ -90,8 +91,8 @@ export const BasePdfViewer: React.ForwardRefExoticComponent<
     const annotationsByPage = usePdfAnnotationsByPage(annotations);
 
     const handleDownload = useCallback(() => {
-      viewer.download();
-    }, [viewer]);
+      viewer.download(downloadFileName);
+    }, [viewer, downloadFileName]);
 
     const rootClassName = classnames(styles.pdfViewer, className);
 

--- a/packages/react-components/src/pdf-viewer/__tests__/PdfViewer.test.tsx
+++ b/packages/react-components/src/pdf-viewer/__tests__/PdfViewer.test.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { usePdfViewerState } from "../hooks/usePdfViewerState.js";
+import { BasePdfViewer } from "../PdfViewer.js";
+
+vi.mock("../hooks/usePdfViewerState.js", () => ({
+  usePdfViewerState: vi.fn(),
+}));
+vi.mock("../hooks/usePdfHighlightMode.js", () => ({
+  usePdfHighlightMode: () => ({
+    highlightModeActive: false,
+    toggleHighlightMode: vi.fn(),
+    deleteHighlight: vi.fn(),
+  }),
+}));
+vi.mock("../hooks/usePdfFormFields.js", () => ({
+  usePdfFormFields: () => ({ hasFormFields: false, submitFormData: vi.fn() }),
+}));
+vi.mock("../hooks/usePdfAnnotationsByPage.js", () => ({
+  usePdfAnnotationsByPage: () => ({}),
+}));
+
+const mockedUsePdfViewerState = vi.mocked(usePdfViewerState);
+
+function createViewer(download: (filename?: string) => void) {
+  const ref = { current: null };
+  return {
+    loading: false,
+    error: undefined,
+    document: {},
+    numPages: 3,
+    currentPage: 1,
+    scale: 1,
+    autoSize: false,
+    sidebarOpen: false,
+    sidebarMode: "thumbnails",
+    outlineItems: [],
+    portalTargets: [],
+    containerRef: ref,
+    viewerRef: ref,
+    pdfViewerRef: ref,
+    eventBusRef: ref,
+    scrollToPage: vi.fn(),
+    setSidebarMode: vi.fn(),
+    zoomIn: vi.fn(),
+    zoomOut: vi.fn(),
+    toggleAutoSize: vi.fn(),
+    toggleSidebar: vi.fn(),
+    rotateLeft: vi.fn(),
+    rotateRight: vi.fn(),
+    search: {
+      query: "",
+      isSearchOpen: false,
+      openSearch: vi.fn(),
+      closeSearch: vi.fn(),
+      setQuery: vi.fn(),
+      nextMatch: vi.fn(),
+      prevMatch: vi.fn(),
+      totalMatches: 0,
+      currentMatchIndex: 0,
+    },
+    download,
+  } as unknown as ReturnType<typeof usePdfViewerState>;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("BasePdfViewer download wiring", () => {
+  it("forwards downloadFileName to viewer.download when the toolbar button is clicked", () => {
+    const download = vi.fn();
+    mockedUsePdfViewerState.mockReturnValue(createViewer(download));
+
+    render(
+      <BasePdfViewer
+        src="x.pdf"
+        enableDownload={true}
+        downloadFileName="custom.pdf"
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Download"));
+
+    expect(download).toHaveBeenCalledTimes(1);
+    expect(download).toHaveBeenCalledWith("custom.pdf");
+  });
+
+  it("drops the click event instead of using it as the filename", () => {
+    const download = vi.fn();
+    mockedUsePdfViewerState.mockReturnValue(createViewer(download));
+
+    render(<BasePdfViewer src="x.pdf" enableDownload={true} />);
+    fireEvent.click(screen.getByLabelText("Download"));
+
+    expect(download).toHaveBeenCalledTimes(1);
+    expect(download).toHaveBeenCalledWith(undefined);
+    const arg = download.mock.calls[0][0];
+    expect(arg === undefined || typeof arg === "string").toBe(true);
+  });
+});

--- a/packages/react-components/src/pdf-viewer/hooks/__tests__/usePdfViewerState.test.ts
+++ b/packages/react-components/src/pdf-viewer/hooks/__tests__/usePdfViewerState.test.ts
@@ -380,6 +380,54 @@ describe("usePdfViewerState", () => {
     });
   });
 
+  async function expectDownloadFilename(
+    src: string | ArrayBuffer,
+    expectedFilename: string,
+  ) {
+    const onDownload = vi.fn();
+    const coreResult = createMockCoreResult();
+    coreResult.document = {
+      getData: () => Promise.resolve(new Uint8Array([1, 2, 3])),
+    } as unknown as PDFDocumentProxy;
+
+    mockedUsePdfViewerCore.mockReturnValue(coreResult);
+    mockedUsePdfViewerSearch.mockReturnValue(createMockSearchResult());
+    mockedUsePdfOutline.mockReturnValue([]);
+
+    const { result } = renderHook(() => usePdfViewerState({ src, onDownload }));
+
+    await act(async () => {
+      result.current.download();
+    });
+
+    expect(onDownload).toHaveBeenCalledWith({
+      success: true,
+      filename: expectedFilename,
+    });
+  }
+
+  it("should derive the download filename from the src URL basename", async () => {
+    await expectDownloadFilename(
+      "https://example.com/files/report-2024.pdf",
+      "report-2024.pdf",
+    );
+  });
+
+  it("should strip the query string when deriving the filename from src", async () => {
+    await expectDownloadFilename(
+      "https://example.com/files/report.pdf?token=abc&page=1",
+      "report.pdf",
+    );
+  });
+
+  it("should fall back to document.pdf when src has no usable basename", async () => {
+    await expectDownloadFilename("https://example.com/files/", "document.pdf");
+  });
+
+  it("should use document.pdf when src is an ArrayBuffer", async () => {
+    await expectDownloadFilename(new ArrayBuffer(8), "document.pdf");
+  });
+
   it("should call onDownload with failure result when getData rejects", async () => {
     const onDownload = vi.fn();
     const downloadError = new Error("Corrupted data");

--- a/packages/react-components/src/pdf-viewer/types.ts
+++ b/packages/react-components/src/pdf-viewer/types.ts
@@ -222,6 +222,11 @@ export interface PdfViewerProps {
    */
   enableDownload?: boolean;
   /**
+   * Filename used when the user downloads the PDF via the toolbar button.
+   * If omitted, the name is derived from the `src` URL, falling back to "document.pdf".
+   */
+  downloadFileName?: string;
+  /**
    * Which sidebar panel to show: thumbnails or document outline.
    * @default "thumbnails"
    */


### PR DESCRIPTION

  ## Add `downloadFileName` prop to the PDF viewer

  > Stacked on #<PR1>. Review/merge that first; this branch contains its commit
  > and should be based on `mikhailprice/pdf-viewer-download-filename`.

  ### Motivation
  The toolbar download derives its filename from `src`. When `src` is a **Blob /
  ArrayBuffer** (or a `blob:` object URL), there is no name to parse, so the saved
  file falls back to a generic `document.pdf` — consumers have no way to set the
  intended name.

  ### Change
  Add an optional `downloadFileName` prop to `PdfViewerProps`; when provided, the
  toolbar download uses it. Behaviour is unchanged when omitted (still derived from
  `src`).

  ```ts
  // types.ts
  downloadFileName?: string;

  // PdfViewer.tsx
  const handleDownload = useCallback(() => {
    viewer.download(downloadFileName);
  }, [viewer, downloadFileName]);

  Testing

  - vitest run src/pdf-viewer → 159/159 pass
  - eslint + dprint clean
  - Changeset: @osdk/react-components minor
