### PR TITLE
fix: widen @osdk/aip-core language-models peer range to avoid major-bump cascade

### DIFF
--- a/.changeset/aip-core-language-models-peer-range.md
+++ b/.changeset/aip-core-language-models-peer-range.md
@@ -1,0 +1,5 @@
+---
+"@osdk/aip-core": patch
+---
+
+Widen the `@osdk/language-models` peer dependency range to `>=0.6.0 <1.0.0` so that minor (0.x) bumps of `@osdk/language-models` no longer force a major version bump on `@osdk/aip-core`.

--- a/packages/aip-core/package.json
+++ b/packages/aip-core/package.json
@@ -54,7 +54,7 @@
   "peerDependencies": {
     "@ai-sdk/provider": "^3.0.0",
     "@osdk/client": "workspace:^",
-    "@osdk/language-models": "workspace:^"
+    "@osdk/language-models": ">=0.6.0 <1.0.0"
   },
   "peerDependenciesMeta": {
     "@ai-sdk/provider": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1633,8 +1633,8 @@ importers:
         specifier: workspace:^
         version: link:../client
       '@osdk/language-models':
-        specifier: workspace:^
-        version: link:../language-models
+        specifier: '>=0.6.0 <1.0.0'
+        version: 0.6.0(@osdk/client@packages+client)
     devDependencies:
       '@ai-sdk/provider':
         specifier: ^3.0.8
@@ -9128,6 +9128,11 @@ packages:
 
   '@osdk/internal.foundry.ontologies@2.63.0':
     resolution: {integrity: sha512-tSDRH8gNfh3Xt76uMpbDh7C76ff99b1FnU6pz6Yxv0t5Lc0+eydm9l3wOm9Md43yowP30KtsN7K9d+bFMYNIMw==}
+
+  '@osdk/language-models@0.6.0':
+    resolution: {integrity: sha512-cPyJA4YG6BeIKu1TtjKdqRfSCA85SOLoN+o8PCkJHx35Gn7YCUbHe0gWiSqznak0XzA7HjzWcSouPjWYjmdogw==}
+    peerDependencies:
+      '@osdk/client': ^2.16.0
 
   '@osdk/legacy-client@2.5.6':
     resolution: {integrity: sha512-QPeCcuqCv+s6toIxWMRArKJx35bzvcpoKAqsQ6YYiFEiGn43vLoQQGbeMlnqcGYfdbljyzeOoDxZtgVIn6a8HA==}
@@ -26523,6 +26528,10 @@ snapshots:
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
+
+  '@osdk/language-models@0.6.0(@osdk/client@packages+client)':
+    dependencies:
+      '@osdk/client': link:packages/client
 
   '@osdk/legacy-client@2.5.6':
     dependencies:


### PR DESCRIPTION
## Why

`createReleasePr.sh` aborts during versioning with:

> `ERROR  Package "@osdk/aip-core" received a major bump (0.4.0 -> 1.0.0). Major bumps are never allowed.`

No changeset names `aip-core` — the major bump **cascades from a peer dependency**:

- `@osdk/language-models` is being minor-bumped `0.6.0 → 0.7.0` (PR #3451 changeset).
- `@osdk/aip-core` peer-depends on `"@osdk/language-models": "workspace:^"`, i.e. `^0.6.0`, which allows `>=0.6.0 <0.7.0`.
- `0.7.0` is **out of range** for `^0.6.0`. With this repo's `onlyUpdatePeerDependentsWhenOutOfRange: true`, changesets treats an out-of-range **peer** dep bump as breaking for the dependent, forcing `aip-core` to a **major** (`0.4.0 → 1.0.0`).
- The release tooling (`mutateReleasePlan.js`) hard-forbids majors → abort.

(`@osdk/client` does not cascade: it's `workspace:^` = `^2.30.x`, and its minor bump to `2.31.0` stays within the caret range — only the 0.x caret on `language-models` is narrow enough to go out of range.)

## What

Widen the `@osdk/language-models` peer range to `>=0.6.0 <1.0.0` so 0.x minor bumps stay in range and never cascade to a major. pnpm's workspace protocol has no OR/range syntax, so this drops the `workspace:` prefix for that one peer dep; the local workspace package still links correctly (verified `aip-core/node_modules/@osdk/language-models` → workspace `0.6.0`).

`@osdk/aip-core` is `"private": true` (never published), so this affects only internal resolution.

## Verification

- `pnpm install` clean; workspace symlink confirmed.
- `./scripts/createReleasePr.sh` no longer hits the major-bump abort.