### PR TITLE
Fix docs

### DIFF
--- a/.changeset/react-components-docs-install-and-tokens.md
+++ b/.changeset/react-components-docs-install-and-tokens.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Fix inaccurate docs: drop stale `@beta` install pins (now older than `latest`) so all setup pages agree on untagged installs, soften the "every `--osdk-*` token maps to a `--bp-*` token" claim (some hold raw values), and clarify that `osdk.tokens`/`osdk.components` ship inside the single `styles.css` import.

--- a/.changeset/react-components-docs-install-and-tokens.md
+++ b/.changeset/react-components-docs-install-and-tokens.md
@@ -2,4 +2,4 @@
 "@osdk/react-components": patch
 ---
 
-Fix inaccurate docs: drop stale `@beta` install pins (now older than `latest`) so all setup pages agree on untagged installs, soften the "every `--osdk-*` token maps to a `--bp-*` token" claim (some hold raw values), and clarify that `osdk.tokens`/`osdk.components` ship inside the single `styles.css` import.
+Fix inaccurate docs: drop stale `@beta` install pins (now older than `latest`) so all setup pages agree on untagged installs, soften the "every `--osdk-*` token maps to a `--bp-*` token" claim (some hold raw values), simplify the Layers section to user-facing setup, and remove `@osdk/cbac-components` install/style references now that CBAC components are merged into `@osdk/react-components`.

--- a/packages/react-components/docs/Prerequisites.md
+++ b/packages/react-components/docs/Prerequisites.md
@@ -71,20 +71,9 @@ Apply this to your root element. See the [Base UI docs](https://base-ui.com/reac
 
 ### Layers
 
-Components use CSS [`@layer`](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer) for predictable theming. Add these imports to your application's entry CSS file (e.g., `index.css`).
+Import the component styles into a CSS [`@layer`](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer) in your application's entry CSS file (e.g., `index.css`). Using a layer keeps the cascade predictable: later layers always win when styles conflict, regardless of selector specificity, so your own styles and theme overrides take precedence over the defaults.
 
-| Layer             | Purpose                                                    |
-| ----------------- | ---------------------------------------------------------- |
-| `osdk.tokens`     | Design tokens (colors, spacing, typography) — the defaults |
-| `osdk.components` | Component structural styles (layout, borders, sizing)      |
-
-Both layers are bundled inside the single `@osdk/react-components/styles.css`
-import shown below — you do **not** import them separately. The stylesheet
-declares `@layer osdk.tokens, osdk.components` internally (so tokens always sit
-below component styles); importing it into your own `osdk.components` layer, as
-the examples do, nests both under that layer.
-
-Later layers always win when styles conflict, regardless of selector specificity.
+The examples below import the styles into a layer named `osdk.components`; declare any of your own layers after it to override.
 
 #### Without Tailwind
 

--- a/packages/react-components/docs/Prerequisites.md
+++ b/packages/react-components/docs/Prerequisites.md
@@ -14,19 +14,19 @@ Use whichever package manager your project uses (`# if using CBAC components` li
 
 ```bash
 # npm
-npm install @osdk/api@beta @osdk/client@beta @osdk/react@beta
+npm install @osdk/api @osdk/client @osdk/react
 npm install @osdk/react-components
 npm install @osdk/cbac-components # if using CBAC components
 npm install react react-dom classnames
 
 # pnpm
-pnpm add @osdk/api@beta @osdk/client@beta @osdk/react@beta
+pnpm add @osdk/api @osdk/client @osdk/react
 pnpm add @osdk/react-components
 pnpm add @osdk/cbac-components # if using CBAC components
 pnpm add react react-dom classnames
 
 # yarn
-yarn add @osdk/api@beta @osdk/client@beta @osdk/react@beta
+yarn add @osdk/api @osdk/client @osdk/react
 yarn add @osdk/react-components
 yarn add @osdk/cbac-components # if using CBAC components
 yarn add react react-dom classnames
@@ -78,6 +78,12 @@ Components use CSS [`@layer`](https://developer.mozilla.org/en-US/docs/Web/CSS/@
 | `osdk.tokens`     | Design tokens (colors, spacing, typography) — the defaults |
 | `osdk.components` | Component structural styles (layout, borders, sizing)      |
 
+Both layers are bundled inside the single `@osdk/react-components/styles.css`
+import shown below — you do **not** import them separately. The stylesheet
+declares `@layer osdk.tokens, osdk.components` internally (so tokens always sit
+below component styles); importing it into your own `osdk.components` layer, as
+the examples do, nests both under that layer.
+
 Later layers always win when styles conflict, regardless of selector specificity.
 
 #### Without Tailwind
@@ -119,7 +125,7 @@ Add a custom layer after the OSDK layers to override any token:
 All components resolve their visual properties through CSS custom properties. There are two scopes of tokens you can target when theming:
 
 - **OSDK tokens (`--osdk-*`)** — every visual property used inside OSDK components resolves through a token prefixed with `--osdk-` (e.g. `--osdk-table-header-bg`, `--osdk-form-section-padding`). Override these to theme **OSDK components only**, leaving other Blueprint components in your app untouched.
-- **Blueprint tokens (`--bp-*`)** — the underlying Blueprint design tokens that `--osdk-*` tokens map to. Override these for consistent theming across **both Blueprint and OSDK components**.
+- **Blueprint tokens (`--bp-*`)** — the underlying Blueprint design tokens that most `--osdk-*` tokens map to. Override these for consistent theming across **both Blueprint and OSDK components**. (A few `--osdk-*` tokens hold raw values rather than mapping to a `--bp-*` token — override those `--osdk-*` tokens directly.)
 
 Per-component references list the `--osdk-*` variables each component exposes — see, for example, [ObjectTable › Theming](./ObjectTable.md#theming). The full catalog of variables lives in [CSSVariables.md](./CSSVariables.md).
 

--- a/packages/react-components/docs/Prerequisites.md
+++ b/packages/react-components/docs/Prerequisites.md
@@ -4,31 +4,28 @@ sidebar_position: 1
 
 # Prerequisites
 
-Setup required before using `@osdk/react-components` or `@osdk/cbac-components`.
+Setup required before using `@osdk/react-components`.
 
 ## Install dependencies
 
 > **Tip:** If your tooling already installs dependencies, skip this step.
 
-Use whichever package manager your project uses (`# if using CBAC components` lines are optional):
+Use whichever package manager your project uses:
 
 ```bash
 # npm
 npm install @osdk/api @osdk/client @osdk/react
 npm install @osdk/react-components
-npm install @osdk/cbac-components # if using CBAC components
 npm install react react-dom classnames
 
 # pnpm
 pnpm add @osdk/api @osdk/client @osdk/react
 pnpm add @osdk/react-components
-pnpm add @osdk/cbac-components # if using CBAC components
 pnpm add react react-dom classnames
 
 # yarn
 yarn add @osdk/api @osdk/client @osdk/react
 yarn add @osdk/react-components
-yarn add @osdk/cbac-components # if using CBAC components
 yarn add react react-dom classnames
 ```
 
@@ -79,22 +76,20 @@ The examples below import the styles into a layer named `osdk.components`; decla
 
 ```css
 /* index.css */
-@layer osdk.components, cbac.components;
+@layer osdk.components;
 
 @import "@osdk/react-components/styles.css" layer(osdk.components);
-@import "@osdk/cbac-components/styles.css" layer(cbac.components); /* only needed if using CBAC components */
 ```
 
 #### With Tailwind CSS v4
 
 ```css
 /* index.css */
-@layer tailwind, osdk.components, cbac.components;
+@layer tailwind, osdk.components;
 
 @import "tailwindcss" layer(tailwind);
 
 @import "@osdk/react-components/styles.css" layer(osdk.components);
-@import "@osdk/cbac-components/styles.css" layer(cbac.components); /* only needed if using CBAC components */
 ```
 
 #### Custom theme overrides
@@ -105,7 +100,6 @@ Add a custom layer after the OSDK layers to override any token:
 @layer osdk.components, user.brand;
 
 @import "@osdk/react-components/styles.css" layer(osdk.components);
-@import "@osdk/cbac-components/styles.css" layer(cbac.components); /* only needed if using CBAC components */
 @import "./user-brand.css" layer(user.brand);
 ```
 

--- a/packages/react-components/docs/StylingOverview.md
+++ b/packages/react-components/docs/StylingOverview.md
@@ -28,9 +28,9 @@ inherited from `@blueprintjs/core`.
 
 ### Layer 2: OSDK Tokens
 
-OSDK tokens (`--osdk-*`) map to Blueprint tokens by default. Override these
-to theme OSDK components **without** affecting other Blueprint components in
-your app.
+Most OSDK tokens (`--osdk-*`) map to Blueprint tokens by default; a few hold
+raw values instead (e.g. opacities and cursors). Override these to theme OSDK
+components **without** affecting other Blueprint components in your app.
 
 ```css
 :root {
@@ -121,10 +121,13 @@ design-system provider), pass `theme` instead of `defaultTheme`:
 | `--osdk-*`             | Theme only OSDK components, leave Blueprint unchanged |
 | `--osdk-<component>-*` | Customize a single component                          |
 
-Every `--osdk-*` token maps to a `--bp-*` token by default. If your app
-uses Blueprint components alongside OSDK components and you want a
-consistent look, override the `--bp-*` tokens. If you only want to restyle
-OSDK components without affecting Blueprint, override the `--osdk-*` tokens.
+Most `--osdk-*` tokens map to a `--bp-*` token by default (a handful — e.g.
+`--osdk-disabled-opacity`, `--osdk-drag-handle-cursor` — hold raw values
+instead). If your app uses Blueprint components alongside OSDK components and
+you want a consistent look, override the `--bp-*` tokens; for `--osdk-*` tokens
+with no `--bp-*` backing, override the `--osdk-*` token directly. If you only
+want to restyle OSDK components without affecting Blueprint, override the
+`--osdk-*` tokens.
 
 ## Custom Themes
 


### PR DESCRIPTION
- Removed @beta from the install instructions
- Removed separate instructions for cbac-components as it's been moved into react-components
- Simplified css setup, user doesn't need to know about the layers under the hood
- 