### PR TITLE
Foundry SDK Generator | Allow Union Types to Be Generated from the SDK Generator for Query Functions

### DIFF
--- a/packages/foundry-sdk-generator/src/ontologyMetadata/ontologyMetadataResolver.ts
+++ b/packages/foundry-sdk-generator/src/ontologyMetadata/ontologyMetadataResolver.ts
@@ -699,18 +699,16 @@ export class OntologyMetadataResolver {
 
         return Result.coalesce(results);
       case "union":
-        if (
-          baseType.unionTypes.find(unionTypes => unionTypes.type === "null")
-        ) {
-          return Result.ok({});
-        }
-        return Result.err([
-          `Unable to load query ${queryApiName} because it takes an unsupported parameter type: ${
-            JSON.stringify(
-              baseType,
-            )
-          } in parameter ${propertyName}`,
-        ]);
+        const unionResults = baseType.unionTypes.map(unionType =>
+          this.visitSupportedQueryTypes(
+            queryApiName,
+            propertyName,
+            unionType,
+            loadedObjectApiNames,
+            loadedInterfaceApiNames,
+          )
+        );
+        return Result.coalesce(unionResults);
       case "entrySet":
         return Result.coalesce([
           this.visitSupportedQueryTypes(


### PR DESCRIPTION
### Summary

Union return types for query functions can now be authored as part of change "MRS Custom Types for Function Typescript V2". This change allows users to generate an SDK using a query function that has been authored with a union return type for use throughout the platform.

### Prior Behavior

// [TODO]

### Intended Behavior Post Change

// [TODO]