### PR TITLE
Add $snapshot option to fetchPage

### DIFF
--- a/.changeset/fancy-seals-raise.md
+++ b/.changeset/fancy-seals-raise.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client": minor
+"@osdk/api": minor
+---
+
+add $snapshot option to fetchPage

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -653,6 +653,8 @@ export interface FetchPageArgs<
     $nextPageToken?: string;
     	// (undocumented)
     $pageSize?: number;
+    	// Warning: (tsdoc-undefined-tag) The TSDoc tag "@default" is not defined in this configuration
+    $snapshot?: boolean;
 }
 
 // Warning: (ae-forgotten-export) The symbol "ExtractOptions" needs to be exported by the entry point index.d.ts

--- a/packages/api/src/object/FetchPageArgs.ts
+++ b/packages/api/src/object/FetchPageArgs.ts
@@ -129,7 +129,7 @@ export interface FetchPageArgs<
     & MODIFIERS
     & { [P in Exclude<keyof MODIFIERS, PropertyKeys<Q>>]: never };
   /**
-   * Ensures paging consistency by freezing the view at the time of query to prevent duplicate or missing items. New results cannot be added to page when $snapshot is set to true.
+   * Ensures paging consistency by freezing the view at the time of query to prevent duplicate or missing items. Setting $snapshot to false ensures that you will always get the latest results.
    * @default false
    */
   $snapshot?: boolean;

--- a/packages/api/src/object/FetchPageArgs.ts
+++ b/packages/api/src/object/FetchPageArgs.ts
@@ -68,10 +68,6 @@ export namespace ObjectSetArgs {
     $nextPageToken?: string;
     $pageSize?: number;
   }
-
-  export interface Snapshot {
-    $snapshot?: boolean;
-  }
 }
 
 export interface SelectArg<
@@ -101,8 +97,6 @@ export type SelectArgToKeys<
   : A["$select"] extends readonly string[] ? A["$select"][number]
   : PropertyKeys<Q>;
 
-export interface SnapshotArg extends ObjectSetArgs.Snapshot {}
-
 export interface FetchPageArgs<
   Q extends ObjectOrInterfaceDefinition,
   K extends string = PropertyKeys<Q>,
@@ -126,8 +120,7 @@ export interface FetchPageArgs<
     ORDER_BY_OPTIONS,
     PROPERTY_SECURITIES,
     MODIFIERS
-  >,
-  SnapshotArg
+  >
 {
   $nextPageToken?: string;
   $pageSize?: number;
@@ -135,6 +128,11 @@ export interface FetchPageArgs<
     & ApplyModifiersArg<Q>
     & MODIFIERS
     & { [P in Exclude<keyof MODIFIERS, PropertyKeys<Q>>]: never };
+  /**
+   * Ensures paging consistency by freezing the view at the time of query to prevent duplicate or missing items. New results cannot be added to page when $snapshot is set to true.
+   * @default false
+   */
+  $snapshot?: boolean;
 }
 
 export interface AsyncIterArgs<

--- a/packages/api/src/object/FetchPageArgs.ts
+++ b/packages/api/src/object/FetchPageArgs.ts
@@ -68,6 +68,10 @@ export namespace ObjectSetArgs {
     $nextPageToken?: string;
     $pageSize?: number;
   }
+
+  export interface Snapshot {
+    $snapshot?: boolean;
+  }
 }
 
 export interface SelectArg<
@@ -97,6 +101,8 @@ export type SelectArgToKeys<
   : A["$select"] extends readonly string[] ? A["$select"][number]
   : PropertyKeys<Q>;
 
+export interface SnapshotArg extends ObjectSetArgs.Snapshot {}
+
 export interface FetchPageArgs<
   Q extends ObjectOrInterfaceDefinition,
   K extends string = PropertyKeys<Q>,
@@ -120,7 +126,8 @@ export interface FetchPageArgs<
     ORDER_BY_OPTIONS,
     PROPERTY_SECURITIES,
     MODIFIERS
-  >
+  >,
+  SnapshotArg
 {
   $nextPageToken?: string;
   $pageSize?: number;

--- a/packages/client/src/object/fetchPage.test.ts
+++ b/packages/client/src/object/fetchPage.test.ts
@@ -55,7 +55,7 @@ function makeCapturingClient() {
     json: () => Promise.resolve({ data: [] }),
     status: 200,
     ok: true,
-  } as any);
+  } as Response);
   const client = createMinimalClient(
     metadata,
     "https://foo",

--- a/packages/client/src/object/fetchPage.test.ts
+++ b/packages/client/src/object/fetchPage.test.ts
@@ -25,7 +25,8 @@ import type {
 } from "@osdk/api";
 import { Employee, FooInterface, Todo } from "@osdk/client.test.ontology";
 import type { SearchJsonQueryV2 } from "@osdk/foundry.ontologies";
-import { describe, expect, expectTypeOf, it } from "vitest";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+import type { MockedFunction } from "vitest";
 import { createMinimalClient } from "../createMinimalClient.js";
 import {
   buildSelectV2,
@@ -38,6 +39,58 @@ import {
   createObjectSet,
   getWireObjectSet,
 } from "../objectSet/createObjectSet.js";
+
+/**
+ * Builds a minimal client whose `fetch` is a vitest mock, so tests can inspect
+ * the request bodies the client sends. The mock resolves every request with an
+ * empty (`{ data: [] }`), 200 OK response, so callers only care about what was
+ * sent, not what comes back.
+ *
+ * @returns the `client` to drive under test and the `fetchFn` mock to assert against
+ *   (typically via {@link lastObjectSetRequest}).
+ */
+function makeCapturingClient() {
+  const fetchFn = vi.fn() as MockedFunction<typeof globalThis.fetch>;
+  fetchFn.mockResolvedValue({
+    json: () => Promise.resolve({ data: [] }),
+    status: 200,
+    ok: true,
+  } as any);
+  const client = createMinimalClient(
+    metadata,
+    "https://foo",
+    async () => "",
+    {},
+    fetchFn,
+  );
+  return { client, fetchFn };
+}
+
+/**
+ * Finds the most recent request the mock `fetchFn` received whose JSON body
+ * mentions an `objectSet` (i.e. the object-set load call fetchPage issues),
+ * and returns it parsed. Walks the recorded calls newest-first so the latest
+ * matching request wins.
+ *
+ * @param fetchFn the mock returned by {@link makeCapturingClient}
+ * @returns the parsed request body, or `undefined` if no object-set request was sent
+ */
+function lastObjectSetRequest(
+  fetchFn: MockedFunction<typeof globalThis.fetch>,
+) {
+  const requestBody = fetchFn.mock.calls.reduceRight<string | undefined>(
+    (acc, cur) => {
+      if (acc) return acc;
+      const body = cur?.[1]?.body;
+      if (typeof body === "string" && body.includes("objectSet")) {
+        return body;
+      }
+    },
+    undefined,
+  );
+  if (!requestBody) return undefined;
+  return JSON.parse(requestBody);
+}
 
 const metadata = {
   ontologyRid: "asdf",
@@ -616,6 +669,27 @@ describe(fetchPage, () => {
         propertyIdentifier: { type: "property", apiName: "myStruct" },
         loadLevel: { type: "extractMainValue" },
       });
+    });
+  });
+
+  describe("snapshot", () => {
+    it("exposes $snapshot to client (type)", () => {
+      expectTypeOf<FetchPageArgs<Employee>>().toHaveProperty("$snapshot");
+    });
+    it("sets snapshot = false by default", async () => {
+      const { client, fetchFn } = makeCapturingClient();
+      await fetchPage(client, Employee, {});
+      expect(lastObjectSetRequest(fetchFn).snapshot).toBe(false);
+    });
+    it("properly generates fetch request when $snapshot is true", async () => {
+      const { client, fetchFn } = makeCapturingClient();
+      await fetchPage(client, Employee, { $snapshot: true });
+      expect(lastObjectSetRequest(fetchFn).snapshot).toBe(true);
+    });
+    it("strips $snapshot from the wire request body", async () => {
+      const { client, fetchFn } = makeCapturingClient();
+      await fetchPage(client, Employee, { $snapshot: true });
+      expect(lastObjectSetRequest(fetchFn)).not.toHaveProperty("$snapshot");
     });
   });
 });

--- a/packages/client/src/object/fetchPage.test.ts
+++ b/packages/client/src/object/fetchPage.test.ts
@@ -25,8 +25,7 @@ import type {
 } from "@osdk/api";
 import { Employee, FooInterface, Todo } from "@osdk/client.test.ontology";
 import type { SearchJsonQueryV2 } from "@osdk/foundry.ontologies";
-import { describe, expect, expectTypeOf, it, vi } from "vitest";
-import type { MockedFunction } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import { createMinimalClient } from "../createMinimalClient.js";
 import {
   buildSelectV2,
@@ -39,58 +38,6 @@ import {
   createObjectSet,
   getWireObjectSet,
 } from "../objectSet/createObjectSet.js";
-
-/**
- * Builds a minimal client whose `fetch` is a vitest mock, so tests can inspect
- * the request bodies the client sends. The mock resolves every request with an
- * empty (`{ data: [] }`), 200 OK response, so callers only care about what was
- * sent, not what comes back.
- *
- * @returns the `client` to drive under test and the `fetchFn` mock to assert against
- *   (typically via {@link lastObjectSetRequest}).
- */
-function makeCapturingClient() {
-  const fetchFn = vi.fn() as MockedFunction<typeof globalThis.fetch>;
-  fetchFn.mockResolvedValue({
-    json: () => Promise.resolve({ data: [] }),
-    status: 200,
-    ok: true,
-  } as Response);
-  const client = createMinimalClient(
-    metadata,
-    "https://foo",
-    async () => "",
-    {},
-    fetchFn,
-  );
-  return { client, fetchFn };
-}
-
-/**
- * Finds the most recent request the mock `fetchFn` received whose JSON body
- * mentions an `objectSet` (i.e. the object-set load call fetchPage issues),
- * and returns it parsed. Walks the recorded calls newest-first so the latest
- * matching request wins.
- *
- * @param fetchFn the mock returned by {@link makeCapturingClient}
- * @returns the parsed request body, or `undefined` if no object-set request was sent
- */
-function lastObjectSetRequest(
-  fetchFn: MockedFunction<typeof globalThis.fetch>,
-) {
-  const requestBody = fetchFn.mock.calls.reduceRight<string | undefined>(
-    (acc, cur) => {
-      if (acc) return acc;
-      const body = cur?.[1]?.body;
-      if (typeof body === "string" && body.includes("objectSet")) {
-        return body;
-      }
-    },
-    undefined,
-  );
-  if (!requestBody) return undefined;
-  return JSON.parse(requestBody);
-}
 
 const metadata = {
   ontologyRid: "asdf",
@@ -669,27 +616,6 @@ describe(fetchPage, () => {
         propertyIdentifier: { type: "property", apiName: "myStruct" },
         loadLevel: { type: "extractMainValue" },
       });
-    });
-  });
-
-  describe("snapshot", () => {
-    it("exposes $snapshot to client (type)", () => {
-      expectTypeOf<FetchPageArgs<Employee>>().toHaveProperty("$snapshot");
-    });
-    it("sets snapshot = false by default", async () => {
-      const { client, fetchFn } = makeCapturingClient();
-      await fetchPage(client, Employee, {});
-      expect(lastObjectSetRequest(fetchFn).snapshot).toBe(false);
-    });
-    it("properly generates fetch request when $snapshot is true", async () => {
-      const { client, fetchFn } = makeCapturingClient();
-      await fetchPage(client, Employee, { $snapshot: true });
-      expect(lastObjectSetRequest(fetchFn).snapshot).toBe(true);
-    });
-    it("strips $snapshot from the wire request body", async () => {
-      const { client, fetchFn } = makeCapturingClient();
-      await fetchPage(client, Employee, { $snapshot: true });
-      expect(lastObjectSetRequest(fetchFn)).not.toHaveProperty("$snapshot");
     });
   });
 });

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -219,7 +219,6 @@ export async function fetchStaticRidPage<
     {},
     PROPERTY_SECURITIES
   >,
-  useSnapshot: boolean = false,
 ): Promise<
   FetchPageResult<
     ObjectOrInterfaceDefinition,
@@ -242,7 +241,7 @@ export async function fetchStaticRidPage<
       },
       select: ((args?.$select as string[] | undefined) ?? []),
       excludeRid: !args?.$includeRid,
-      snapshot: useSnapshot,
+      snapshot: args.$snapshot ?? false,
       loadPropertySecurities: shouldLoadPropertySecurities,
     } as LoadObjectSetV2MultipleObjectTypesRequest,
     client,
@@ -303,7 +302,6 @@ async function fetchInterfacePage<
   interfaceType: Q,
   args: FetchPageArgs<Q, L, R, any, S, T>,
   objectSet: ObjectSet,
-  useSnapshot: boolean = false,
 ): Promise<FetchPageResult<Q, L, R, S, T>> {
   const extractedInterfaceTypeApiName = (await extractObjectOrInterfaceType(
     client,
@@ -345,7 +343,7 @@ async function fetchInterfacePage<
       selectV2,
       loadPropertySecurities: shouldLoadPropertySecurities,
       excludeRid: !args?.$includeRid,
-      snapshot: useSnapshot,
+      snapshot: args.$snapshot ?? false,
     },
     client,
     interfaceType,
@@ -410,7 +408,6 @@ export async function fetchPageInternal<
     ORDER_BY_OPTIONS,
     PROPERTY_SECURITIES
   > = {},
-  useSnapshot: boolean,
 ): Promise<
   FetchPageResult<Q, L, R, S, T, ORDER_BY_OPTIONS, PROPERTY_SECURITIES>
 > {
@@ -429,7 +426,6 @@ export async function fetchPageInternal<
         ORDER_BY_OPTIONS
       >,
       objectSet,
-      useSnapshot,
     ) as any; // fixme
   } else {
     return await fetchObjectPage(
@@ -446,7 +442,6 @@ export async function fetchPageInternal<
         ORDER_BY_OPTIONS
       >,
       objectSet,
-      useSnapshot,
     ) as any; // fixme
   }
 }
@@ -466,13 +461,11 @@ export async function fetchPageWithErrorsInternal<
   args: FetchPageArgs<Q, L, R, A, S, T> = {},
 ): Promise<Result<FetchPageResult<Q, L, R, S, T>>> {
   try {
-    const { $snapshot, ...restArgs } = args;
     const result = await fetchPageInternal(
       client,
       objectType,
       objectSet,
-      restArgs,
-      $snapshot ?? false,
+      args,
     );
     return { value: result };
   } catch (e) {
@@ -504,13 +497,11 @@ export async function fetchPage<
   args: FetchPageArgs<Q, L, R, any, S, T, never, {}, PROPERTY_SECURITIES>,
   objectSet: ObjectSet = resolveBaseObjectSetType(objectType),
 ): Promise<FetchPageResult<Q, L, R, S, T, {}, PROPERTY_SECURITIES>> {
-  const { $snapshot, ...restArgs } = args;
   return fetchPageInternal(
     client,
     objectType,
     objectSet,
-    restArgs,
-    $snapshot ?? false,
+    args,
   );
 }
 
@@ -713,7 +704,6 @@ export async function fetchObjectPage<
   objectType: Q,
   args: FetchPageArgs<Q, L, R, Augments, S, T, never, ORDER_BY_OPTIONS>,
   objectSet: ObjectSet,
-  useSnapshot: boolean = false,
 ): Promise<FetchPageResult<Q, L, R, S, T, ORDER_BY_OPTIONS>> {
   // For simple object fetches, since we know the object type up front
   // we can parallelize network requests for loading metadata and loading the actual objects
@@ -755,7 +745,7 @@ export async function fetchObjectPage<
       selectV2,
       loadPropertySecurities: shouldLoadPropertySecurities,
       excludeRid: !args?.$includeRid,
-      snapshot: useSnapshot,
+      snapshot: args.$snapshot ?? false,
     },
     client,
     objectType,

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -410,7 +410,7 @@ export async function fetchPageInternal<
     ORDER_BY_OPTIONS,
     PROPERTY_SECURITIES
   > = {},
-  useSnapshot: boolean = false,
+  useSnapshot: boolean,
 ): Promise<
   FetchPageResult<Q, L, R, S, T, ORDER_BY_OPTIONS, PROPERTY_SECURITIES>
 > {
@@ -466,7 +466,14 @@ export async function fetchPageWithErrorsInternal<
   args: FetchPageArgs<Q, L, R, A, S, T> = {},
 ): Promise<Result<FetchPageResult<Q, L, R, S, T>>> {
   try {
-    const result = await fetchPageInternal(client, objectType, objectSet, args);
+    const { $snapshot, ...restArgs } = args;
+    const result = await fetchPageInternal(
+      client,
+      objectType,
+      objectSet,
+      restArgs,
+      $snapshot ?? false,
+    );
     return { value: result };
   } catch (e) {
     if (e instanceof Error) {
@@ -497,7 +504,14 @@ export async function fetchPage<
   args: FetchPageArgs<Q, L, R, any, S, T, never, {}, PROPERTY_SECURITIES>,
   objectSet: ObjectSet = resolveBaseObjectSetType(objectType),
 ): Promise<FetchPageResult<Q, L, R, S, T, {}, PROPERTY_SECURITIES>> {
-  return fetchPageInternal(client, objectType, objectSet, args);
+  const { $snapshot, ...restArgs } = args;
+  return fetchPageInternal(
+    client,
+    objectType,
+    objectSet,
+    restArgs,
+    $snapshot ?? false,
+  );
 }
 
 /** @internal */

--- a/packages/client/src/objectSet/ObjectSet.test.ts
+++ b/packages/client/src/objectSet/ObjectSet.test.ts
@@ -18,6 +18,7 @@ import type {
   Attachment,
   CompileTimeMetadata,
   ConvertProps,
+  FetchPageArgs,
   FetchPageResult,
   InterfaceDefinition,
   ObjectOrInterfaceDefinition,
@@ -49,6 +50,11 @@ import {
 import { beforeAll, describe, expect, expectTypeOf, it } from "vitest";
 import type { Client } from "../Client.js";
 import { createClient } from "../createClient.js";
+import { fetchPage } from "../object/fetchPage.js";
+import {
+  createMockCaptureClient,
+  getLastObjectSetRequest,
+} from "../util/mockCaptureClient.js";
 import { getWireObjectSet } from "./createObjectSet.js";
 
 type ApiNameAsString<
@@ -1302,6 +1308,32 @@ describe("ObjectSet", () => {
 
         cheesedFooNotStrict.fooSpt;
       });
+    });
+  });
+
+  describe("snapshot", () => {
+    it("exposes $snapshot to client (type)", () => {
+      expectTypeOf<FetchPageArgs<Employee>>().toHaveProperty("$snapshot");
+    });
+    it("sets snapshot = false by default", async () => {
+      const { client, fetchFn } = createMockCaptureClient();
+      await fetchPage(client, Employee, {});
+      expect(
+        (getLastObjectSetRequest(fetchFn) as { snapshot: boolean }).snapshot,
+      ).toBe(false);
+    });
+    it("properly generates fetch request when $snapshot is true", async () => {
+      const { client, fetchFn } = createMockCaptureClient();
+      await fetchPage(client, Employee, { $snapshot: true });
+      expect(
+        (getLastObjectSetRequest(fetchFn) as { snapshot: boolean }).snapshot,
+      ).toBe(true);
+    });
+    it("strips $snapshot from the wire request body", async () => {
+      const { client, fetchFn } = createMockCaptureClient();
+      await fetchPage(client, Employee, { $snapshot: true });
+      expect(getLastObjectSetRequest(fetchFn) as { snapshot: boolean }).not
+        .toHaveProperty("$snapshot");
     });
   });
 });

--- a/packages/client/src/objectSet/createObjectSet.ts
+++ b/packages/client/src/objectSet/createObjectSet.ts
@@ -225,8 +225,7 @@ export function createObjectSet<Q extends ObjectOrInterfaceDefinition>(
           ),
           objectType,
           objectSet,
-          { ...args, $pageSize: 10000, $nextPageToken },
-          true,
+          { ...args, $pageSize: 10000, $nextPageToken, $snapshot: true },
         );
         $nextPageToken = result.nextPageToken;
 

--- a/packages/client/src/util/mockCaptureClient.ts
+++ b/packages/client/src/util/mockCaptureClient.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { LoadObjectSetRequestV2 } from "@osdk/foundry.ontologies";
+import { type MockedFunction, vi } from "vitest";
+import { createMinimalClient } from "../createMinimalClient.js";
+import type { MinimalClientParams } from "../MinimalClientContext.js";
+
+/**
+ * @internal
+ * Builds a minimal client whose `fetch` is a vitest mock, so tests can inspect
+ * the request bodies the client sends. The mock resolves every request with an
+ * empty (`{ data: [] }`), 200 OK response, so callers only care about what was
+ * sent, not what comes back.
+ * @returns the `client` to drive under test and the `fetchFn` mock to assert against
+ *   (typically via {@link getLastObjectSetRequest}).
+ */
+export function createMockCaptureClient(
+  metadata: MinimalClientParams["metadata"] = { ontologyRid: "unset" },
+) {
+  const fetchFn = vi.fn() as MockedFunction<typeof globalThis.fetch>;
+  fetchFn.mockResolvedValue({
+    json: () => Promise.resolve({ data: [] }),
+    status: 200,
+    ok: true,
+  } as Response);
+  const client = createMinimalClient(
+    metadata,
+    "https://foo",
+    async () => "",
+    {},
+    fetchFn,
+  );
+  return { client, fetchFn };
+}
+
+/**
+ * @internal
+ * Finds the most recent request the mock `fetchFn` received whose JSON body
+ * mentions an `objectSet` (i.e. the object-set load call fetchPage issues),
+ * and returns it parsed. Walks the recorded calls newest-first so the latest
+ * matching request wins.
+ *
+ * @param fetchFn the mock returned by {@link createMockCapturingClient}
+ * @returns the parsed request body, or `undefined` if no object-set request was sent
+ */
+export function getLastObjectSetRequest(
+  fetchFn: MockedFunction<typeof globalThis.fetch>,
+): LoadObjectSetRequestV2 | undefined {
+  const requestBody = fetchFn.mock.calls.reduceRight<string | undefined>(
+    (acc, cur) => {
+      if (acc) return acc;
+      const body = cur?.[1]?.body;
+      if (typeof body === "string" && body.includes("objectSet")) {
+        return body;
+      }
+    },
+    undefined,
+  );
+  if (!requestBody) return undefined;
+  return JSON.parse(requestBody);
+}


### PR DESCRIPTION
This PR addresses #3345.

> API Gateway supports snapshot consistency [when loading an object set](https://www.palantir.com/docs/foundry/api/v2/ontologies-v2-resources/ontology-object-sets/load-object-set/), however this option is not exposed for fetchPage in the OSDK.

`FetchPageArgs` now expects an optional `$snapshot` argument which corresponds to the [`snapshot` request parameter](https://www.palantir.com/docs/foundry/api/v2/ontologies-v2-resources/ontology-object-sets/load-object-set#request-body:~:text=yet%20generally%20available.-,snapshot,booleanoptional,-A%20flag%20to)