### PR TITLE
address officeassignment sandbox review comments

### DIFF
--- a/packages/e2e.sandbox.officeassignment/src/App.tsx
+++ b/packages/e2e.sandbox.officeassignment/src/App.tsx
@@ -28,7 +28,7 @@ const TABS: readonly TabSpec[] = [
   { id: TAB_STATUS_UPDATES, label: "Status Updates" },
 ];
 
-export default function App(): React.JSX.Element {
+export function App(): React.JSX.Element {
   const [activeTab, setActiveTab] = React.useState<string>(TAB_ASSIGNMENTS);
 
   return (

--- a/packages/e2e.sandbox.officeassignment/src/components/AssignmentDrawer/AssignmentDrawer.tsx
+++ b/packages/e2e.sandbox.officeassignment/src/components/AssignmentDrawer/AssignmentDrawer.tsx
@@ -88,7 +88,11 @@ export function AssignmentDrawer(
 
             <section className={styles.section}>
               <h3 className={styles.sectionTitle}>Edit assignment</h3>
-              <UpdateAssignmentForm assignment={object} />
+              {/* Remount on assignment change so the form re-seeds from the new object. */}
+              <UpdateAssignmentForm
+                key={object.$primaryKey}
+                assignment={object}
+              />
             </section>
 
             <section className={styles.section}>

--- a/packages/e2e.sandbox.officeassignment/src/components/actions/ToggleExclusionButton.tsx
+++ b/packages/e2e.sandbox.officeassignment/src/components/actions/ToggleExclusionButton.tsx
@@ -19,6 +19,7 @@ import { useOsdkAction } from "@osdk/react";
 import React from "react";
 import type { StatusUpdate } from "../../generatedNoCheck2/index.js";
 import { toggleStatusExclusion } from "../../generatedNoCheck2/index.js";
+import { ErrorBanner } from "../common/index.js";
 import styles from "./actions.module.css";
 
 export interface ToggleExclusionButtonProps {
@@ -30,7 +31,9 @@ export function ToggleExclusionButton(
   props: ToggleExclusionButtonProps,
 ): React.JSX.Element {
   const { statusUpdate } = props;
-  const { applyAction, isPending } = useOsdkAction(toggleStatusExclusion);
+  const { applyAction, isPending, error } = useOsdkAction(
+    toggleStatusExclusion,
+  );
   const currentlyExcluded = statusUpdate.isExcluded === true;
 
   const onClick = React.useCallback(() => {
@@ -40,14 +43,20 @@ export function ToggleExclusionButton(
     });
   }, [applyAction, statusUpdate, currentlyExcluded]);
 
+  const errorMessage = error?.actionValidation?.message
+    ?? (error != null ? "Failed to toggle exclusion." : undefined);
+
   return (
-    <button
-      type="button"
-      className={styles.linkButton}
-      onClick={onClick}
-      disabled={isPending}
-    >
-      {currentlyExcluded ? "Include" : "Exclude"}
-    </button>
+    <>
+      <button
+        type="button"
+        className={styles.linkButton}
+        onClick={onClick}
+        disabled={isPending}
+      >
+        {currentlyExcluded ? "Include" : "Exclude"}
+      </button>
+      <ErrorBanner message={errorMessage} context="Toggle exclusion" />
+    </>
   );
 }

--- a/packages/e2e.sandbox.officeassignment/src/components/actions/UpdateAssignmentForm.tsx
+++ b/packages/e2e.sandbox.officeassignment/src/components/actions/UpdateAssignmentForm.tsx
@@ -15,103 +15,94 @@
  */
 
 import { useOsdkAction } from "@osdk/react";
+import {
+  ActionForm,
+  type FormFieldDefinition,
+  type FormState,
+} from "@osdk/react-components/experimental/action-form";
 import React from "react";
 import type { Assignment } from "../../generatedNoCheck2/index.js";
 import { updateAssignment } from "../../generatedNoCheck2/index.js";
 import { ErrorBanner } from "../common/index.js";
-import styles from "./actions.module.css";
 
 export interface UpdateAssignmentFormProps {
   assignment: Assignment.OsdkInstance;
 }
 
-interface FormFields {
-  title: string;
-  function: string;
-  officeId: string;
-  floorId: string;
-  managerId: string;
+type EditableFieldKey =
+  | "title"
+  | "function"
+  | "officeId"
+  | "floorId"
+  | "managerId";
+
+const TEXT_FIELDS: ReadonlyArray<
+  { fieldKey: EditableFieldKey; label: string }
+> = [
+  { fieldKey: "title", label: "Title" },
+  { fieldKey: "function", label: "Function" },
+  { fieldKey: "officeId", label: "Office ID" },
+  { fieldKey: "floorId", label: "Floor ID" },
+  { fieldKey: "managerId", label: "Manager ID" },
+];
+
+function emptyToUndefined(value: string | undefined): string | undefined {
+  return value == null || value === "" ? undefined : value;
 }
 
-function fieldsFromAssignment(assignment: Assignment.OsdkInstance): FormFields {
-  return {
-    title: assignment.title ?? "",
-    function: assignment.function ?? "",
-    officeId: assignment.officeId ?? "",
-    floorId: assignment.floorId ?? "",
-    managerId: assignment.managerId ?? "",
-  };
-}
-
-function emptyToUndefined(value: string): string | undefined {
-  return value === "" ? undefined : value;
-}
-
-/** Edits an assignment's role details and location/ownership FKs. */
+/**
+ * Edits an assignment's role details and location/ownership FKs.
+ *
+ * Built on the `ActionForm` component: the editable parameters are declared as text fields seeded
+ * from the current assignment, while the fixed `assignment` object parameter is injected in
+ * `onSubmit`. Seed values are read once on mount, so the parent remounts this form (keyed on the
+ * assignment's primary key) when a different assignment loads.
+ */
 export function UpdateAssignmentForm(
   props: UpdateAssignmentFormProps,
 ): React.JSX.Element {
   const { assignment } = props;
-  const { applyAction, isPending, error } = useOsdkAction(updateAssignment);
-  const [fields, setFields] = React.useState<FormFields>(() =>
-    fieldsFromAssignment(assignment)
+  const { applyAction, error } = useOsdkAction(updateAssignment);
+
+  const fieldDefinitions = React.useMemo<
+    ReadonlyArray<FormFieldDefinition<typeof updateAssignment>>
+  >(
+    () =>
+      TEXT_FIELDS.map(({ fieldKey, label }) => ({
+        fieldKey,
+        label,
+        fieldComponent: "TEXT_INPUT",
+        defaultValue: assignment[fieldKey] ?? "",
+        fieldComponentProps: {},
+      })),
+    [assignment],
   );
 
-  const setField = React.useCallback(
-    (key: keyof FormFields, value: string) => {
-      setFields((prev) => ({ ...prev, [key]: value }));
-    },
-    [],
-  );
-
-  const onSubmit = React.useCallback(
-    (event: React.FormEvent) => {
-      event.preventDefault();
-      void applyAction({
+  const handleSubmit = React.useCallback(
+    async (formState: FormState<typeof updateAssignment>) => {
+      await applyAction({
         assignment,
-        title: emptyToUndefined(fields.title),
-        function: emptyToUndefined(fields.function),
-        officeId: emptyToUndefined(fields.officeId),
-        floorId: emptyToUndefined(fields.floorId),
-        managerId: emptyToUndefined(fields.managerId),
+        title: emptyToUndefined(formState.title),
+        function: emptyToUndefined(formState.function),
+        officeId: emptyToUndefined(formState.officeId),
+        floorId: emptyToUndefined(formState.floorId),
+        managerId: emptyToUndefined(formState.managerId),
       });
     },
-    [applyAction, assignment, fields],
+    [applyAction, assignment],
   );
 
-  const textFields: Array<{ key: keyof FormFields; label: string }> = [
-    { key: "title", label: "Title" },
-    { key: "function", label: "Function" },
-    { key: "officeId", label: "Office ID" },
-    { key: "floorId", label: "Floor ID" },
-    { key: "managerId", label: "Manager ID" },
-  ];
-
   return (
-    <form className={styles.form} onSubmit={onSubmit}>
-      {textFields.map(({ key, label }) => (
-        <label key={key} className={styles.field}>
-          <span className={styles.fieldLabel}>{label}</span>
-          <input
-            className={styles.input}
-            type="text"
-            value={fields[key]}
-            onChange={(e) =>
-              setField(key, e.target.value)}
-          />
-        </label>
-      ))}
-      <button
-        type="submit"
-        className={styles.primaryButton}
-        disabled={isPending}
-      >
-        Save changes
-      </button>
+    <>
+      <ActionForm
+        actionDefinition={updateAssignment}
+        formFieldDefinitions={fieldDefinitions}
+        onSubmit={handleSubmit}
+      />
       <ErrorBanner
         message={error?.actionValidation?.message}
         context="Update assignment"
       />
-    </form>
+    </>
   );
 }

--- a/packages/e2e.sandbox.officeassignment/src/components/common/Drawer.tsx
+++ b/packages/e2e.sandbox.officeassignment/src/components/common/Drawer.tsx
@@ -27,6 +27,8 @@ export interface DrawerProps {
 /** A minimal right-side overlay drawer. No external UI library dependency. */
 export function Drawer(props: DrawerProps): React.JSX.Element | null {
   const { isOpen, onClose, title, children } = props;
+  // Stable per-instance id so the dialog can name itself via the title; drawers can stack.
+  const titleId = React.useId();
   if (!isOpen) {
     return null;
   }
@@ -38,9 +40,14 @@ export function Drawer(props: DrawerProps): React.JSX.Element | null {
         className={styles.backdrop}
         onClick={onClose}
       />
-      <aside className={styles.panel} role="dialog" aria-modal="true">
+      <aside
+        className={styles.panel}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+      >
         <header className={styles.header}>
-          <div className={styles.title}>{title}</div>
+          <div id={titleId} className={styles.title}>{title}</div>
           <button
             type="button"
             className={styles.closeButton}

--- a/packages/e2e.sandbox.officeassignment/src/hooks/useAssignmentFilters.ts
+++ b/packages/e2e.sandbox.officeassignment/src/hooks/useAssignmentFilters.ts
@@ -42,7 +42,7 @@ export interface UseAssignmentFiltersResult {
   readonly filterClause: WhereClause<Assignment> | undefined;
   readonly setFilterClause: (c: WhereClause<Assignment>) => void;
   /** Per-filter UI state + visibility/order, for FilterList rehydration. */
-  readonly initialFilterStates: Map<string, FilterState>;
+  readonly filterStates: Map<string, FilterState>;
   readonly orderedFilterDefs: Array<IdentifiedFilterDef<Assignment>>;
   readonly handleFilterStateChanged: (
     def: FilterDefinitionUnion<Assignment>,
@@ -144,8 +144,10 @@ export function useAssignmentFilters(): UseAssignmentFiltersResult {
 
   const handleReset = React.useCallback(() => {
     setLatestSelections([]);
+    setComposeAcrossTypes("$and");
     setFilterClauseRaw(undefined);
     setFilterStates(new Map());
+    setFilterVisibility(undefined);
     setResetKey((prev) => prev + 1);
   }, []);
 
@@ -169,7 +171,7 @@ export function useAssignmentFilters(): UseAssignmentFiltersResult {
     setComposeAcrossTypes,
     filterClause,
     setFilterClause,
-    initialFilterStates: filterStates,
+    filterStates,
     orderedFilterDefs,
     handleFilterStateChanged,
     handleFilterVisibilityChange,

--- a/packages/e2e.sandbox.officeassignment/src/hooks/useStatusUpdateFilters.ts
+++ b/packages/e2e.sandbox.officeassignment/src/hooks/useStatusUpdateFilters.ts
@@ -31,7 +31,7 @@ export interface UseStatusUpdateFiltersResult {
   readonly objectSet: ObjectSet<StatusUpdate>;
   readonly filterClause: WhereClause<StatusUpdate> | undefined;
   readonly setFilterClause: (c: WhereClause<StatusUpdate>) => void;
-  readonly initialFilterStates: Map<string, FilterState>;
+  readonly filterStates: Map<string, FilterState>;
   readonly orderedFilterDefs: Array<IdentifiedFilterDef<StatusUpdate>>;
   readonly handleFilterStateChanged: (
     def: FilterDefinitionUnion<StatusUpdate>,
@@ -105,6 +105,7 @@ export function useStatusUpdateFilters(): UseStatusUpdateFiltersResult {
   const handleReset = React.useCallback(() => {
     setFilterClauseRaw(undefined);
     setFilterStates(new Map());
+    setFilterVisibility(undefined);
     setResetKey((prev) => prev + 1);
   }, []);
 
@@ -112,7 +113,7 @@ export function useStatusUpdateFilters(): UseStatusUpdateFiltersResult {
     objectSet,
     filterClause,
     setFilterClause,
-    initialFilterStates: filterStates,
+    filterStates,
     orderedFilterDefs,
     handleFilterStateChanged,
     handleFilterVisibilityChange,

--- a/packages/e2e.sandbox.officeassignment/src/index.ts
+++ b/packages/e2e.sandbox.officeassignment/src/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { default as App } from "./App.js";
+export { App } from "./App.js";

--- a/packages/e2e.sandbox.officeassignment/src/main.tsx
+++ b/packages/e2e.sandbox.officeassignment/src/main.tsx
@@ -18,7 +18,7 @@ import { OsdkProvider } from "@osdk/react";
 import { OsdkDevTools } from "@osdk/react-devtools";
 import React from "react";
 import ReactDOM from "react-dom/client";
-import App from "./App.js";
+import { App } from "./App.js";
 import { $ } from "./foundryClient.js";
 import "./index.css";
 

--- a/packages/e2e.sandbox.officeassignment/src/tables/AssignmentsTable/AssignmentsTable.tsx
+++ b/packages/e2e.sandbox.officeassignment/src/tables/AssignmentsTable/AssignmentsTable.tsx
@@ -35,6 +35,9 @@ const DEFAULT_ORDER_BY: Array<OrderByEntry<Assignment, AssignmentColumnRdps>> =
     { property: "assignmentId", direction: "asc" },
   ];
 
+// Static column definitions — no runtime inputs, so hoisted out of the component.
+const BASE_COLUMN_DEFS = createAssignmentColumnDefinitions();
+
 interface AssignmentsTableProps {
   objectSet: ObjectSet<Assignment>;
   filter?: WhereClause<Assignment>;
@@ -56,11 +59,6 @@ export const AssignmentsTable = React.memo<AssignmentsTableProps>(
     selectedRows,
     onRowSelectionChanged,
   }) {
-    const baseColumnDefs = React.useMemo(
-      () => createAssignmentColumnDefinitions(),
-      [],
-    );
-
     const {
       orderBy,
       effectiveColumnDefs,
@@ -69,7 +67,7 @@ export const AssignmentsTable = React.memo<AssignmentsTableProps>(
       handleColumnResize,
       handleColumnsPinnedChanged,
     } = useObjectTableState<Assignment, AssignmentColumnRdps>(
-      baseColumnDefs,
+      BASE_COLUMN_DEFS,
       DEFAULT_ORDER_BY,
     );
 

--- a/packages/e2e.sandbox.officeassignment/src/tables/StatusUpdatesTable/StatusUpdatesTable.tsx
+++ b/packages/e2e.sandbox.officeassignment/src/tables/StatusUpdatesTable/StatusUpdatesTable.tsx
@@ -34,6 +34,9 @@ const DEFAULT_ORDER_BY: Array<
   { property: "timestampEpochMs", direction: "desc" },
 ];
 
+// Static column definitions — no runtime inputs, so hoisted out of the component.
+const BASE_COLUMN_DEFS = createStatusUpdateColumnDefinitions();
+
 interface StatusUpdatesTableProps {
   objectSet: ObjectSet<StatusUpdate>;
   filter?: WhereClause<StatusUpdate>;
@@ -41,11 +44,6 @@ interface StatusUpdatesTableProps {
 
 export const StatusUpdatesTable = React.memo<StatusUpdatesTableProps>(
   function StatusUpdatesTableFn({ objectSet, filter }) {
-    const baseColumnDefs = React.useMemo(
-      () => createStatusUpdateColumnDefinitions(),
-      [],
-    );
-
     const {
       orderBy,
       effectiveColumnDefs,
@@ -54,7 +52,7 @@ export const StatusUpdatesTable = React.memo<StatusUpdatesTableProps>(
       handleColumnResize,
       handleColumnsPinnedChanged,
     } = useObjectTableState<StatusUpdate, StatusUpdateColumnRdps>(
-      baseColumnDefs,
+      BASE_COLUMN_DEFS,
       DEFAULT_ORDER_BY,
     );
 

--- a/packages/e2e.sandbox.officeassignment/src/tabs/AssignmentsTab/AssignmentsTab.tsx
+++ b/packages/e2e.sandbox.officeassignment/src/tabs/AssignmentsTab/AssignmentsTab.tsx
@@ -35,7 +35,7 @@ export function AssignmentsTab(): React.JSX.Element {
     setComposeAcrossTypes,
     filterClause,
     setFilterClause,
-    initialFilterStates,
+    filterStates,
     orderedFilterDefs,
     handleFilterStateChanged,
     handleFilterVisibilityChange,
@@ -78,7 +78,7 @@ export function AssignmentsTab(): React.JSX.Element {
           onFilterStateChanged={handleFilterStateChanged}
           onFilterVisibilityChange={handleFilterVisibilityChange}
           onReset={handleReset}
-          initialFilterStates={initialFilterStates}
+          initialFilterStates={filterStates}
         />
       </aside>
       <div className={styles.main}>

--- a/packages/e2e.sandbox.officeassignment/src/tabs/StatusUpdatesTab/StatusUpdatesTab.module.css
+++ b/packages/e2e.sandbox.officeassignment/src/tabs/StatusUpdatesTab/StatusUpdatesTab.module.css
@@ -23,7 +23,3 @@
   flex: 1;
   min-height: 0;
 }
-
-.excludedValue {
-  color: var(--oa-text-muted);
-}

--- a/packages/e2e.sandbox.officeassignment/src/tabs/StatusUpdatesTab/StatusUpdatesTab.tsx
+++ b/packages/e2e.sandbox.officeassignment/src/tabs/StatusUpdatesTab/StatusUpdatesTab.tsx
@@ -29,7 +29,7 @@ export function StatusUpdatesTab(): React.JSX.Element {
     objectSet,
     filterClause,
     setFilterClause,
-    initialFilterStates,
+    filterStates,
     orderedFilterDefs,
     handleFilterStateChanged,
     handleFilterVisibilityChange,
@@ -49,7 +49,7 @@ export function StatusUpdatesTab(): React.JSX.Element {
           onFilterStateChanged={handleFilterStateChanged}
           onFilterVisibilityChange={handleFilterVisibilityChange}
           onReset={handleReset}
-          initialFilterStates={initialFilterStates}
+          initialFilterStates={filterStates}
         />
       </aside>
       <div className={styles.main}>

--- a/packages/e2e.sandbox.officeassignment/src/utils/applyVisibilityState.ts
+++ b/packages/e2e.sandbox.officeassignment/src/utils/applyVisibilityState.ts
@@ -31,9 +31,12 @@ export function applyVisibilityState<T extends { isVisible?: boolean }>(
   getId: (def: T) => string,
   applyOverrides?: (def: T) => T,
 ): Array<T & { isVisible: boolean }> {
+  const apply = (def: T): T =>
+    applyOverrides != null ? applyOverrides(def) : def;
+
   if (savedState == null) {
     return baseDefs.map((def) => {
-      const base = applyOverrides != null ? applyOverrides(def) : def;
+      const base = apply(def);
       return { ...base, isVisible: base.isVisible ?? true };
     });
   }
@@ -46,14 +49,14 @@ export function applyVisibilityState<T extends { isVisible?: boolean }>(
     const def = defMap.get(id);
     if (def != null) {
       seen.add(id);
-      const base = applyOverrides != null ? applyOverrides(def) : def;
+      const base = apply(def);
       result.push({ ...base, isVisible });
     }
   }
 
   for (const def of baseDefs) {
     if (!seen.has(getId(def))) {
-      const base = applyOverrides != null ? applyOverrides(def) : def;
+      const base = apply(def);
       result.push({ ...base, isVisible: base.isVisible ?? true });
     }
   }

--- a/packages/e2e.sandbox.officeassignment/src/utils/statusFilter.ts
+++ b/packages/e2e.sandbox.officeassignment/src/utils/statusFilter.ts
@@ -78,20 +78,21 @@ function buildLatestValueRdps(
     $and: [{ type: { $eq: sel.type } }, { value: { $ne: sel.value } }],
   };
 
+  // Latest timestamp over the rows matching `where`. Kept as a local (not the creator type) so its
+  // narrow numeric return type is preserved — `diff` reuses it via `.subtract`, which the widened
+  // creator return type would drop.
+  const latestTimestamp = (
+    base: Parameters<StatusRdpCreators[string]>[0],
+    where: typeof targetWhere | typeof negatedWhere,
+  ) => base.pivotTo(STATUS_LINK).where(where).aggregate("timestampEpochMs:max");
+
   const targetMax: StatusRdpCreators[string] = (base) =>
-    base.pivotTo(STATUS_LINK).where(targetWhere).aggregate(
-      "timestampEpochMs:max",
-    );
+    latestTimestamp(base, targetWhere);
 
   const diff: StatusRdpCreators[string] = (base) =>
-    base.pivotTo(STATUS_LINK).where(targetWhere).aggregate(
-      "timestampEpochMs:max",
-    )
-      .subtract(
-        base.pivotTo(STATUS_LINK).where(negatedWhere).aggregate(
-          "timestampEpochMs:max",
-        ),
-      );
+    latestTimestamp(base, targetWhere).subtract(
+      latestTimestamp(base, negatedWhere),
+    );
 
   return {
     creators: { [targetMaxKey]: targetMax, [diffKey]: diff },


### PR DESCRIPTION
follow-up to #3412 addressing review comments on the officeassignment e2e sandbox

• refactor the edit form onto ActionForm and surface action errors on the exclusion toggle
• rename the filter-state hook return, broaden filter reset, and give the drawer dialog an accessible name
• small cleanups: hoist static column defs, dedupe the latest-timestamp rdp, drop dead css, named app export