### PR TITLE
fix officeassignment generated client version to unblock main ci

### DIFF
--- a/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/OntologyMetadata.ts
+++ b/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/OntologyMetadata.ts
@@ -1,4 +1,4 @@
-export type $ExpectedClientVersion = '2.30.0';
+export type $ExpectedClientVersion = '2.32.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.5a277e05-5cdb-4766-bbd1-22a4ba8d6433';


### PR DESCRIPTION
main CI broke after the version bump to 2.32.0 because the new officeassignment e2e sandbox shipped a generated metadata file still pinned to the old client version

• update `$ExpectedClientVersion` in officeassignment's generated `OntologyMetadata.ts` from 2.30.0 to 2.32.0
• matches siblings todoapp and peopleapp and the value CI regenerates, so the "verify nothing changed" step passes
• no changeset since the package is private
