### PR TITLE
Sort and filter decimal/long properties numerically in observable client

### DIFF
--- a/.changeset/quick-pandas-jump.md
+++ b/.changeset/quick-pandas-jump.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Sort and filter decimal and long properties (including derived ones, and on interface lists) numerically instead of lexicographically in the observable client

--- a/packages/client/src/object/convertWireToOsdkObjects/InterfaceHolder.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/InterfaceHolder.ts
@@ -15,8 +15,10 @@
  */
 
 import type { InterfaceMetadata, ObjectMetadata, Osdk } from "@osdk/api";
+import type { DerivedPropertyRuntimeMetadata } from "../../derivedProperties/derivedPropertyRuntimeMetadata.js";
 import type { FormatPropertyOptions } from "../formatting/applyPropertyFormatter.js";
 import type { BaseHolder } from "./BaseHolder.js";
+import type { RdpDefRef } from "./InternalSymbols.js";
 import { InterfaceDefRef } from "./InternalSymbols.js";
 
 /** @internal */
@@ -24,6 +26,7 @@ export interface InterfaceHolder<
   _Q extends Osdk.Instance<any> = never,
 > extends BaseHolder {
   [InterfaceDefRef]: InterfaceMetadata;
+  readonly [RdpDefRef]?: DerivedPropertyRuntimeMetadata;
 
   readonly "$__EXPERIMENTAL__NOT_SUPPORTED_YET__metadata": {
     readonly ObjectMetadata: ObjectMetadata;

--- a/packages/client/src/object/convertWireToOsdkObjects/InternalSymbols.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/InternalSymbols.ts
@@ -16,6 +16,7 @@
 
 import type { ObjectOrInterfaceDefinition, OsdkBase } from "@osdk/api";
 import type { PropertySecurities } from "@osdk/foundry.ontologies";
+import type { DerivedPropertyRuntimeMetadata } from "../../derivedProperties/derivedPropertyRuntimeMetadata.js";
 
 /** @internal */
 export const UnderlyingOsdkObject = Symbol(
@@ -25,6 +26,18 @@ export const UnderlyingOsdkObject = Symbol(
 /** @internal */
 export const ObjectDefRef = Symbol(
   process.env.MODE !== "production" ? "ObjectDefinition" : undefined,
+);
+
+/**
+ * Holds the runtime metadata for an object's derived (runtime-derived)
+ * properties. Unlike regular properties, derived properties aren't part of the
+ * object/interface metadata, so their types are captured here at construction
+ * time (e.g. so sorting can compare numeric-but-string types correctly).
+ *
+ * @internal
+ */
+export const RdpDefRef = Symbol(
+  process.env.MODE !== "production" ? "DerivedPropertyDefinitions" : undefined,
 );
 
 /** @internal */
@@ -46,5 +59,6 @@ export interface HolderBase<T extends ObjectOrInterfaceDefinition> {
   [UnderlyingOsdkObject]: OsdkBase<any>;
   [ObjectDefRef]?: T;
   [InterfaceDefRef]?: T;
+  [RdpDefRef]?: DerivedPropertyRuntimeMetadata;
   [PropertySecuritiesRef]?: PropertySecurities[];
 }

--- a/packages/client/src/object/convertWireToOsdkObjects/ObjectHolder.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/ObjectHolder.ts
@@ -15,11 +15,12 @@
  */
 
 import type { Osdk } from "@osdk/api";
+import type { DerivedPropertyRuntimeMetadata } from "../../derivedProperties/derivedPropertyRuntimeMetadata.js";
 import type { MinimalClient } from "../../MinimalClientContext.js";
 import type { FetchedObjectTypeDefinition } from "../../ontology/OntologyProvider.js";
 import type { BaseHolder } from "./BaseHolder.js";
 import type { get$link } from "./getDollarLink.js";
-import type { ClientRef, ObjectDefRef } from "./InternalSymbols.js";
+import type { ClientRef, ObjectDefRef, RdpDefRef } from "./InternalSymbols.js";
 
 /**
  * @internal
@@ -32,6 +33,7 @@ export interface ObjectHolder<_Q extends Osdk.Instance<any> = never>
 {
   readonly [ObjectDefRef]: FetchedObjectTypeDefinition;
   readonly [ClientRef]: MinimalClient;
+  readonly [RdpDefRef]: DerivedPropertyRuntimeMetadata;
 
   readonly "$link": ReturnType<typeof get$link>;
 }

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
@@ -20,7 +20,7 @@ import {
   InterfaceDefinitions,
 } from "../../ontology/OntologyProvider.js";
 import { createOsdkInterface } from "./createOsdkInterface.js";
-import { ObjectDefRef } from "./InternalSymbols.js";
+import { ObjectDefRef, RdpDefRef } from "./InternalSymbols.js";
 
 describe(createOsdkInterface, () => {
   it("works in the normal case", () => {
@@ -151,6 +151,72 @@ describe(createOsdkInterface, () => {
         "asdf": "hi mom"
       }"
     `);
+  });
+
+  it("carries runtime-derived properties and RDP metadata onto the interface", () => {
+    const rdpMetadata = {
+      "total": {
+        selectedOrCollectedPropertyType: { type: "decimal" },
+        definition: { type: "selection" },
+      },
+    };
+
+    const underlying = {
+      "foo": "hi mom",
+      // derived properties live alongside regular ones on the underlying object
+      "total": "10",
+
+      [RdpDefRef]: rdpMetadata,
+
+      [ObjectDefRef]: {
+        [InterfaceDefinitions]: {},
+        apiName: "Obj",
+        displayName: "",
+        interfaceMap: {
+          "IFoo": {
+            "asdf": "foo",
+          },
+        },
+        inverseInterfaceMap: {},
+        links: {},
+        pluralDisplayName: "",
+        primaryKeyApiName: "",
+        primaryKeyType: "string",
+        properties: {
+          "foo": {
+            type: "string",
+          },
+        },
+        type: "object",
+        titleProperty: "foo",
+        rid: "",
+        status: "ACTIVE",
+        icon: undefined,
+        visibility: undefined,
+        description: undefined,
+      } satisfies FetchedObjectTypeDefinition,
+    };
+
+    const iface = createOsdkInterface(underlying as any, {
+      "apiName": "IFoo",
+      displayName: "",
+      links: {},
+      properties: {
+        "asdf": {
+          type: "string",
+        },
+      },
+      rid: "",
+      type: "interface",
+      implements: [],
+      description: undefined,
+    });
+
+    // the derived value is exposed on the interface view ...
+    expect((iface as any).total).toBe("10");
+    expect(Object.keys(iface)).toContain("total");
+    // ... and the RDP metadata is carried so its type can be resolved.
+    expect((iface as any)[RdpDefRef]).toBe(rdpMetadata);
   });
 
   it("works with mixed namespaces", () => {

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.ts
@@ -22,6 +22,7 @@ import type { InterfaceHolder } from "./InterfaceHolder.js";
 import {
   InterfaceDefRef,
   ObjectDefRef,
+  RdpDefRef,
   UnderlyingOsdkObject,
 } from "./InternalSymbols.js";
 import type { ObjectHolder } from "./ObjectHolder.js";
@@ -103,6 +104,19 @@ export function createOsdkInterface<
       },
 
       [InterfaceDefRef]: { value: interfaceDef },
+
+      // Runtime-derived (RDP) properties aren't part of interfaceDef.properties,
+      // so copy their values from the underlying object and carry the RDP
+      // metadata, so consumers (e.g. orderBy sorting and where-clause filtering)
+      // can read the values and resolve their numeric types.
+      [RdpDefRef]: { value: underlying[RdpDefRef] },
+
+      ...Object.fromEntries(
+        Object.keys(underlying[RdpDefRef] ?? {}).map(k => [k, {
+          enumerable: k in underlying,
+          value: underlying[k as keyof typeof underlying],
+        }]),
+      ),
 
       ...Object.fromEntries(
         Object.keys(interfaceDef.properties).map(p => {

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -43,6 +43,7 @@ import {
   ClientRef,
   ObjectDefRef,
   PropertySecuritiesRef,
+  RdpDefRef,
   UnderlyingOsdkObject,
 } from "./InternalSymbols.js";
 import type { ObjectHolder } from "./ObjectHolder.js";
@@ -83,7 +84,12 @@ const basePropDefs = {
       const def = this[ObjectDefRef];
 
       if (update == null) {
-        return createOsdkObject(this[ClientRef], def, { ...rawObj });
+        return createOsdkObject(
+          this[ClientRef],
+          def,
+          { ...rawObj },
+          this[RdpDefRef],
+        );
       }
 
       if (
@@ -100,7 +106,12 @@ const basePropDefs = {
       }
 
       const newObject = { ...this[UnderlyingOsdkObject], ...update };
-      return createOsdkObject(this[ClientRef], this[ObjectDefRef], newObject);
+      return createOsdkObject(
+        this[ClientRef],
+        this[ObjectDefRef],
+        newObject,
+        this[RdpDefRef],
+      );
     },
   },
   "$objectSpecifier": {
@@ -183,6 +194,9 @@ export function createOsdkObject(
       },
       [ObjectDefRef]: { value: objectDef, enumerable: false }, // TODO: Potentially update when GA metadata field
       [ClientRef]: { value: client, enumerable: false },
+      // Derived property types aren't part of objectDef; keep them on the holder
+      // so consumers (e.g. orderBy sorting) can resolve their types.
+      [RdpDefRef]: { value: derivedPropertyTypeByName, enumerable: false },
       ...basePropDefs,
     } satisfies Record<keyof ObjectHolder, PropertyDescriptor>,
   );

--- a/packages/client/src/observable/internal/compareNumericStrings.test.ts
+++ b/packages/client/src/observable/internal/compareNumericStrings.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { compareNumericStrings } from "./compareNumericStrings.js";
+
+describe(compareNumericStrings, () => {
+  /** Sorts a copy of `values` ascending using only the comparator. */
+  function sortedAsc(values: string[]): string[] {
+    return [...values].sort(compareNumericStrings);
+  }
+
+  it("orders integers/longs by value, not lexicographically", () => {
+    // Lexicographically this would be 10, 100, 2, 9.
+    expect(sortedAsc(["10", "9", "100", "2"])).toEqual([
+      "2",
+      "9",
+      "10",
+      "100",
+    ]);
+  });
+
+  it("preserves precision for longs beyond Number.MAX_SAFE_INTEGER", () => {
+    // 2^53 and 2^53 + 1 are indistinguishable as JS numbers.
+    expect(compareNumericStrings("9007199254740993", "9007199254740992"))
+      .toBe(1);
+    expect(compareNumericStrings("9007199254740992", "9007199254740993"))
+      .toBe(-1);
+    expect(compareNumericStrings("9007199254740992", "9007199254740992"))
+      .toBe(0);
+  });
+
+  it("orders decimals by value", () => {
+    expect(sortedAsc(["10", "9", "100"])).toEqual(["9", "10", "100"]);
+    expect(sortedAsc(["1.5", "1.25", "1.125"])).toEqual([
+      "1.125",
+      "1.25",
+      "1.5",
+    ]);
+  });
+
+  it("preserves precision for large non-integer decimals beyond a double", () => {
+    // These differ only in the 17th significant digit, which a double can't
+    // represent: Number("9007199254740993.5") === Number("9007199254740993.6").
+    expect(sortedAsc([
+      "9007199254740993.6",
+      "9007199254740993.5",
+      "9007199254740993.55",
+    ])).toEqual([
+      "9007199254740993.5",
+      "9007199254740993.55",
+      "9007199254740993.6",
+    ]);
+  });
+
+  it("treats trailing-zero fractions as equal (10 == 10.00)", () => {
+    expect(compareNumericStrings("10", "10.00")).toBe(0);
+    expect(compareNumericStrings("1.5", "1.50")).toBe(0);
+  });
+
+  it("handles signs, including +, -, and -0", () => {
+    expect(compareNumericStrings("-1.5", "1.5")).toBe(-1);
+    expect(compareNumericStrings("-1.5", "-1.25")).toBe(-1);
+    expect(compareNumericStrings("+10", "9")).toBe(1);
+    expect(compareNumericStrings("-0.0", "0.0")).toBe(0);
+  });
+
+  it("falls back to a Number comparison for exotic forms (e.g. scientific)", () => {
+    expect(compareNumericStrings("1e3", "999")).toBe(1);
+    expect(compareNumericStrings("999", "1e3")).toBe(-1);
+  });
+});

--- a/packages/client/src/observable/internal/compareNumericStrings.ts
+++ b/packages/client/src/observable/internal/compareNumericStrings.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Matches a plain base-10 number in decimal notation (optionally signed,
+ * optional fractional part) -- this covers both `long` (no fraction) and
+ * `decimal`. Excludes exotic forms like scientific notation, which fall back
+ * to Number().
+ */
+const NUMERIC_STRING = /^[+-]?\d+(\.\d+)?$/;
+
+/**
+ * Compares two numeric strings (the wire encoding for `decimal` and `long`) by
+ * value, ascending.
+ *
+ * Scales both operands to a common number of fractional digits and compares
+ * them as BigInt, so the result is exact for arbitrary precision -- including
+ * longs beyond Number.MAX_SAFE_INTEGER and decimals whose fractional parts
+ * exceed the precision of a double. Exotic forms (e.g. scientific notation)
+ * fall back to a best-effort Number() comparison.
+ */
+export function compareNumericStrings(a: string, b: string): number {
+  if (!NUMERIC_STRING.test(a) || !NUMERIC_STRING.test(b)) {
+    const aNum = Number(a);
+    const bNum = Number(b);
+    return aNum < bNum ? -1 : aNum > bNum ? 1 : 0;
+  }
+
+  const [aInt, aFrac = ""] = a.split(".");
+  const [bInt, bFrac = ""] = b.split(".");
+  const fracDigits = Math.max(aFrac.length, bFrac.length);
+
+  // Concatenating the (sign-bearing) integer part with the zero-padded
+  // fractional part scales both values by the same power of ten, so the
+  // BigInt comparison preserves the original ordering exactly.
+  const aScaled = BigInt(aInt + aFrac.padEnd(fracDigits, "0"));
+  const bScaled = BigInt(bInt + bFrac.padEnd(fracDigits, "0"));
+  return aScaled < bScaled ? -1 : aScaled > bScaled ? 1 : 0;
+}

--- a/packages/client/src/observable/internal/evaluateFilter.ts
+++ b/packages/client/src/observable/internal/evaluateFilter.ts
@@ -16,28 +16,44 @@
 
 import type { PossibleWhereClauseFilters } from "@osdk/api";
 import invariant from "tiny-invariant";
+import { compareNumericStrings } from "./compareNumericStrings.js";
+import { isNumericStringType } from "./resolvePropertyType.js";
 
 /**
  * Evaluates a where clause filter against a value.
  * This is a runtime evaluation function that handles different property types.
+ *
+ * @param propertyType - the declared type of the property being filtered, used
+ * to compare decimal/long (wire-encoded as strings) numerically rather than
+ * lexicographically for the ordered operators. Undefined for properties whose
+ * type can't be resolved, in which case the native comparison is used.
  */
 export function evaluateFilter(
   f: PossibleWhereClauseFilters,
   realValue: any,
   expected: any,
   strict: boolean,
+  propertyType?: string,
 ): boolean {
   switch (f) {
     case "$eq":
       return realValue === expected;
-    case "$gt":
-      return realValue > expected;
-    case "$lt":
-      return realValue < expected;
-    case "$gte":
-      return realValue >= expected;
-    case "$lte":
-      return realValue <= expected;
+    case "$gt": {
+      const c = numericCompare(realValue, expected, propertyType);
+      return c != null ? c > 0 : realValue > expected;
+    }
+    case "$lt": {
+      const c = numericCompare(realValue, expected, propertyType);
+      return c != null ? c < 0 : realValue < expected;
+    }
+    case "$gte": {
+      const c = numericCompare(realValue, expected, propertyType);
+      return c != null ? c >= 0 : realValue >= expected;
+    }
+    case "$lte": {
+      const c = numericCompare(realValue, expected, propertyType);
+      return c != null ? c <= 0 : realValue <= expected;
+    }
     case "$ne":
       return realValue !== expected;
     case "$in":
@@ -67,4 +83,25 @@ export function evaluateFilter(
       }
       return !strict;
   }
+}
+
+/**
+ * Returns the numeric ordering (-1/0/1) of two values when the property is a
+ * decimal/long wire-encoded as strings, or undefined when the native
+ * comparison operators should be used instead (real strings, dates, numbers,
+ * or values that aren't both strings).
+ */
+function numericCompare(
+  realValue: unknown,
+  expected: unknown,
+  propertyType: string | undefined,
+): number | undefined {
+  if (
+    isNumericStringType(propertyType)
+    && typeof realValue === "string"
+    && typeof expected === "string"
+  ) {
+    return compareNumericStrings(realValue, expected);
+  }
+  return undefined;
 }

--- a/packages/client/src/observable/internal/evaluateFilter.ts
+++ b/packages/client/src/observable/internal/evaluateFilter.ts
@@ -36,8 +36,10 @@ export function evaluateFilter(
   propertyType?: string,
 ): boolean {
   switch (f) {
-    case "$eq":
-      return realValue === expected;
+    case "$eq": {
+      const c = numericCompare(realValue, expected, propertyType);
+      return c != null ? c === 0 : realValue === expected;
+    }
     case "$gt": {
       const c = numericCompare(realValue, expected, propertyType);
       return c != null ? c > 0 : realValue > expected;
@@ -54,10 +56,21 @@ export function evaluateFilter(
       const c = numericCompare(realValue, expected, propertyType);
       return c != null ? c <= 0 : realValue <= expected;
     }
-    case "$ne":
-      return realValue !== expected;
+    case "$ne": {
+      const c = numericCompare(realValue, expected, propertyType);
+      return c != null ? c !== 0 : realValue !== expected;
+    }
     case "$in":
-      return Array.isArray(expected) && expected.includes(realValue);
+      if (!Array.isArray(expected)) {
+        return false;
+      }
+      if (isNumericStringType(propertyType)) {
+        return expected.some((e) => {
+          const c = numericCompare(realValue, e, propertyType);
+          return c != null ? c === 0 : realValue === e;
+        });
+      }
+      return expected.includes(realValue);
     case "$isNull":
       return realValue == null;
     case "$startsWith":
@@ -87,21 +100,42 @@ export function evaluateFilter(
 
 /**
  * Returns the numeric ordering (-1/0/1) of two values when the property is a
- * decimal/long wire-encoded as strings, or undefined when the native
- * comparison operators should be used instead (real strings, dates, numbers,
- * or values that aren't both strings).
+ * decimal/long, or undefined when the native comparison operators should be
+ * used instead (real strings, dates, or values that aren't numbers/strings).
+ *
+ * Real (wire) decimal/long values arrive as strings, but public number filters
+ * (e.g. `{ long: { $gt: 5 } }`) supply JS numbers, so both operands are
+ * normalized to their numeric-string form before the exact comparison. Note a
+ * number literal beyond 2^53 is already rounded by JS before it reaches here, so
+ * exactness is only guaranteed for the string-side value and safe-range numbers.
  */
 function numericCompare(
   realValue: unknown,
   expected: unknown,
   propertyType: string | undefined,
 ): number | undefined {
-  if (
-    isNumericStringType(propertyType)
-    && typeof realValue === "string"
-    && typeof expected === "string"
-  ) {
-    return compareNumericStrings(realValue, expected);
+  if (!isNumericStringType(propertyType)) {
+    return undefined;
+  }
+  const r = toComparableNumericString(realValue);
+  const e = toComparableNumericString(expected);
+  if (r == null || e == null) {
+    return undefined;
+  }
+  return compareNumericStrings(r, e);
+}
+
+/**
+ * Normalizes a filter/real value to the numeric-string form `compareNumericStrings`
+ * expects: strings pass through, numbers are stringified, anything else yields
+ * undefined so the caller falls back to native comparison.
+ */
+function toComparableNumericString(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number") {
+    return String(value);
   }
   return undefined;
 }

--- a/packages/client/src/observable/internal/list/ListQuery.test.ts
+++ b/packages/client/src/observable/internal/list/ListQuery.test.ts
@@ -17,6 +17,7 @@
 import {
   Employee,
   FooInterface,
+  objectTypeWithAllPropertyTypes,
   Office,
   Todo,
 } from "@osdk/client.test.ontology";
@@ -56,6 +57,12 @@ function setupOntology(fauxFoundry: FauxFoundry) {
   fauxFoundry.getDefaultOntology().registerObjectType(
     stubData.todoWithLinkTypes,
   );
+  fauxFoundry.getDefaultOntology().registerObjectType({
+    // Drop the self-link: its ONE cardinality has no foreign key, which
+    // FauxFoundry rejects, and the sorting tests don't traverse links.
+    ...stubData.objectTypeWithAllPropertyTypesWithLinkTypes,
+    linkTypes: [],
+  });
 }
 
 function setupTodos(
@@ -571,6 +578,81 @@ describe("ListQuery sort stability across pages", () => {
     // clientOrdered sorts by text asc, then PK tiebreaker for equal keys
     const ids = payload!.resolvedList!.map((t) => t.id);
     expect(ids).toEqual([10, 30, 31, 20]);
+  });
+
+  it("clientOrdered sorts decimal/long properties numerically, not lexicographically", async () => {
+    const dataStore = fauxFoundry.getDefaultDataStore();
+    dataStore.clear();
+
+    // decimal/long arrive as strings. Lexicographically these sort as
+    // "10" < "100" < "2" < "9", which is wrong; the fix sorts them by value.
+    // The longs straddle 2^53, where doubles lose precision.
+    const rows = [
+      { id: 1, decimal: "10", long: "9007199254740993" },
+      { id: 2, decimal: "9", long: "9007199254740992" },
+      { id: 3, decimal: "100", long: "42" },
+      { id: 4, decimal: "2", long: "100" },
+    ];
+    for (const row of rows) {
+      dataStore.registerObject(objectTypeWithAllPropertyTypes, {
+        $apiName: "objectTypeWithAllPropertyTypes",
+        ...row,
+      });
+    }
+
+    // Fetch real instances (carry the object metadata used to resolve types).
+    const fetched = await Promise.all(
+      rows.map((row) =>
+        client(objectTypeWithAllPropertyTypes).fetchOne(row.id)
+      ),
+    );
+
+    async function expectClientOrdered(
+      orderByProp: "decimal" | "long",
+      expectedIds: number[],
+    ) {
+      const listSub = mockListSubCallback();
+      defer(
+        store.lists.observe(
+          {
+            type: objectTypeWithAllPropertyTypes,
+            where: {},
+            orderBy: { [orderByProp]: "asc" },
+            pageSize: 10,
+          },
+          listSub,
+        ),
+      );
+
+      await waitForCall(listSub.next, 1);
+      expectSingleListCallAndClear(listSub, undefined, { status: "loading" });
+      await waitForCall(listSub.next, 1);
+      expectSingleListCallAndClear(listSub, expect.anything(), {
+        status: "loaded",
+      });
+
+      // Push in id order (i.e. unsorted by the ordered property).
+      updateList(
+        store,
+        {
+          type: objectTypeWithAllPropertyTypes,
+          where: {},
+          orderBy: { [orderByProp]: "asc" },
+        },
+        fetched,
+      );
+
+      await waitForCall(listSub.next, 1);
+      const payload = expectSingleListCallAndClear(listSub, expect.anything(), {
+        status: "loaded",
+      });
+      expect(payload!.resolvedList!.map((o) => o.id)).toEqual(expectedIds);
+    }
+
+    // decimal asc: 2 < 9 < 10 < 100  -> ids 4,2,1,3
+    await expectClientOrdered("decimal", [4, 2, 1, 3]);
+    // long asc: 42 < 100 < 2^53 < 2^53+1 -> ids 3,4,2,1
+    await expectClientOrdered("long", [3, 4, 2, 1]);
   });
 });
 

--- a/packages/client/src/observable/internal/objectMatchesWhereClause.test.ts
+++ b/packages/client/src/observable/internal/objectMatchesWhereClause.test.ts
@@ -294,3 +294,67 @@ describe("decimal/long ordered comparisons", () => {
       .toBe(false);
   });
 });
+
+describe("decimal/long filters with public number-typed values", () => {
+  // The real (wire) value is a string, but public NumberFilter values are JS
+  // numbers, so the matcher must bridge "5" and 5.
+  it("compares $gt against a number without precision loss at 2^53", () => {
+    const obj = holderWithTypes(
+      { big: "9007199254740993" },
+      { big: "long" },
+    );
+
+    // 9007199254740992 (=2^53) is exactly representable as a number.
+    expect(
+      objectSortaMatchesWhereClause(
+        obj,
+        { big: { $gt: 9007199254740992 } },
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it("matches $eq against a number", () => {
+    const obj = holderWithTypes({ long: "5" }, { long: "long" });
+
+    expect(objectSortaMatchesWhereClause(obj, { long: { $eq: 5 } }, true))
+      .toBe(true);
+    expect(objectSortaMatchesWhereClause(obj, { long: { $eq: 6 } }, true))
+      .toBe(false);
+  });
+
+  it("matches $ne against a number", () => {
+    const obj = holderWithTypes({ long: "5" }, { long: "long" });
+
+    expect(objectSortaMatchesWhereClause(obj, { long: { $ne: 6 } }, true))
+      .toBe(true);
+    expect(objectSortaMatchesWhereClause(obj, { long: { $ne: 5 } }, true))
+      .toBe(false);
+  });
+
+  it("matches $in against numbers", () => {
+    const obj = holderWithTypes({ long: "5" }, { long: "long" });
+
+    expect(objectSortaMatchesWhereClause(obj, { long: { $in: [5] } }, true))
+      .toBe(true);
+    expect(objectSortaMatchesWhereClause(obj, { long: { $in: [6, 7] } }, true))
+      .toBe(false);
+  });
+
+  it("matches the primitive-shorthand equality against a number", () => {
+    const obj = holderWithTypes({ long: "5" }, { long: "long" });
+
+    // `{ long: 5 }` shorthand, where the real value is the string "5".
+    expect(objectSortaMatchesWhereClause(obj, { long: 5 }, true)).toBe(true);
+    expect(objectSortaMatchesWhereClause(obj, { long: 6 }, true)).toBe(false);
+  });
+
+  it("matches a decimal $eq against a fractional number", () => {
+    const obj = holderWithTypes({ amount: "1.5" }, { amount: "decimal" });
+
+    expect(objectSortaMatchesWhereClause(obj, { amount: { $eq: 1.5 } }, true))
+      .toBe(true);
+    expect(objectSortaMatchesWhereClause(obj, { amount: { $eq: 1.25 } }, true))
+      .toBe(false);
+  });
+});

--- a/packages/client/src/observable/internal/objectMatchesWhereClause.test.ts
+++ b/packages/client/src/observable/internal/objectMatchesWhereClause.test.ts
@@ -17,6 +17,7 @@
 import type { Osdk, WhereClause } from "@osdk/api";
 import type { objectTypeWithAllPropertyTypes } from "@osdk/client.test.ontology";
 import { describe, expect, expectTypeOf, it } from "vitest";
+import { ObjectDefRef } from "../../object/convertWireToOsdkObjects/InternalSymbols.js";
 import type { ObjectHolder } from "../../object/convertWireToOsdkObjects/ObjectHolder.js";
 import { objectSortaMatchesWhereClause } from "./objectMatchesWhereClause.js";
 
@@ -222,4 +223,74 @@ describe(objectSortaMatchesWhereClause, () => {
         .toBe(nonStrictExpected);
     },
   );
+});
+
+/**
+ * Builds a minimal holder exposing the property values plus the object metadata
+ * the matcher reads to resolve a property's type.
+ */
+function holderWithTypes(
+  values: Record<string, unknown>,
+  types: Record<string, string>,
+): ObjectHolder {
+  const holder: { [k: string]: unknown } & { [ObjectDefRef]?: unknown } = {
+    ...values,
+    [ObjectDefRef]: {
+      properties: Object.fromEntries(
+        Object.entries(types).map(([name, type]) => [name, { type }]),
+      ),
+    },
+  };
+  return holder as ObjectHolder;
+}
+
+describe("decimal/long ordered comparisons", () => {
+  // decimal/long are wire-encoded as strings; the matcher must compare them
+  // numerically. Lexicographically "10" < "9", so these cases all flip if the
+  // native string operators are used.
+  it("compares decimal $gt/$gte/$lt/$lte numerically", () => {
+    const obj = holderWithTypes({ amount: "10" }, { amount: "decimal" });
+
+    expect(objectSortaMatchesWhereClause(obj, { amount: { $gt: "9" } }, true))
+      .toBe(true);
+    expect(objectSortaMatchesWhereClause(obj, { amount: { $lt: "9" } }, true))
+      .toBe(false);
+    expect(objectSortaMatchesWhereClause(obj, { amount: { $gte: "10" } }, true))
+      .toBe(true);
+    expect(objectSortaMatchesWhereClause(obj, { amount: { $lte: "9" } }, true))
+      .toBe(false);
+    // boundary: 10.0 == 10 numerically
+    expect(
+      objectSortaMatchesWhereClause(obj, { amount: { $gte: "10.0" } }, true),
+    )
+      .toBe(true);
+    expect(
+      objectSortaMatchesWhereClause(obj, { amount: { $lte: "10.0" } }, true),
+    )
+      .toBe(true);
+  });
+
+  it("compares long values beyond 2^53 without precision loss", () => {
+    const obj = holderWithTypes(
+      { big: "9007199254740993" },
+      { big: "long" },
+    );
+
+    // 9007199254740993 > 9007199254740992, indistinguishable as doubles.
+    expect(
+      objectSortaMatchesWhereClause(
+        obj,
+        { big: { $gt: "9007199254740992" } },
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps native comparison for real string properties", () => {
+    const obj = holderWithTypes({ name: "10" }, { name: "string" });
+
+    // lexicographic: "10" is not > "9"
+    expect(objectSortaMatchesWhereClause(obj, { name: { $gt: "9" } }, true))
+      .toBe(false);
+  });
 });

--- a/packages/client/src/observable/internal/objectMatchesWhereClause.ts
+++ b/packages/client/src/observable/internal/objectMatchesWhereClause.ts
@@ -106,10 +106,13 @@ export function objectSortaMatchesWhereClause(
       return evaluateFilter(f, realValue, expected, strict, propertyType);
     }
 
+    // Primitive shorthand (e.g. `{ long: 5 }`). Route through the shared $eq
+    // evaluator so decimal/long values (wire-encoded as strings) still match a
+    // number-typed filter value.
     if (key in o) {
-      if (o[key as keyof typeof o] === filter) {
-        return true;
-      }
+      const realValue: any = o[key as keyof typeof o];
+      const propertyType = resolvePropertyType(o, key);
+      return evaluateFilter("$eq", realValue, filter, strict, propertyType);
     }
     return false;
   });

--- a/packages/client/src/observable/internal/objectMatchesWhereClause.ts
+++ b/packages/client/src/observable/internal/objectMatchesWhereClause.ts
@@ -20,6 +20,7 @@ import invariant from "tiny-invariant";
 import type { InterfaceHolder } from "../../object/convertWireToOsdkObjects/InterfaceHolder.js";
 import type { ObjectHolder } from "../../object/convertWireToOsdkObjects/ObjectHolder.js";
 import { evaluateFilter } from "./evaluateFilter.js";
+import { resolvePropertyType } from "./resolvePropertyType.js";
 import type { SimpleWhereClause } from "./SimpleWhereClause.js";
 
 function is$and(
@@ -101,7 +102,8 @@ export function objectSortaMatchesWhereClause(
       const realValue: any = o[key as keyof typeof o];
       const [f] = Object.keys(filter) as Array<PossibleWhereClauseFilters>;
       const expected = (filter as any)[f];
-      return evaluateFilter(f, realValue, expected, strict);
+      const propertyType = resolvePropertyType(o, key);
+      return evaluateFilter(f, realValue, expected, strict, propertyType);
     }
 
     if (key in o) {

--- a/packages/client/src/observable/internal/resolvePropertyType.test.ts
+++ b/packages/client/src/observable/internal/resolvePropertyType.test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  InterfaceDefRef,
+  ObjectDefRef,
+  RdpDefRef,
+} from "../../object/convertWireToOsdkObjects/InternalSymbols.js";
+import {
+  isNumericStringType,
+  type PropertyTypeSource,
+  resolvePropertyType,
+} from "./resolvePropertyType.js";
+
+describe(isNumericStringType, () => {
+  it("is true for the wire-encoded-as-string numeric types", () => {
+    expect(isNumericStringType("decimal")).toBe(true);
+    expect(isNumericStringType("long")).toBe(true);
+  });
+
+  it("is false for everything else", () => {
+    // integer/double/float arrive as JS numbers, so they don't need this path.
+    expect(isNumericStringType("integer")).toBe(false);
+    expect(isNumericStringType("double")).toBe(false);
+    expect(isNumericStringType("string")).toBe(false);
+    expect(isNumericStringType("timestamp")).toBe(false);
+    expect(isNumericStringType(undefined)).toBe(false);
+  });
+});
+
+describe(resolvePropertyType, () => {
+  it("returns undefined when the holder is missing", () => {
+    expect(resolvePropertyType(undefined, "amount")).toBeUndefined();
+  });
+
+  it("resolves a regular property from the object metadata", () => {
+    const holder: PropertyTypeSource = {
+      [ObjectDefRef]: { properties: { amount: { type: "decimal" } } } as any,
+    };
+    expect(resolvePropertyType(holder, "amount")).toBe("decimal");
+  });
+
+  it("resolves a regular property from the interface metadata", () => {
+    const holder: PropertyTypeSource = {
+      [InterfaceDefRef]: { properties: { amount: { type: "long" } } } as any,
+    };
+    expect(resolvePropertyType(holder, "amount")).toBe("long");
+  });
+
+  it("resolves a derived property from the RDP metadata", () => {
+    const holder: PropertyTypeSource = {
+      [RdpDefRef]: {
+        total: {
+          selectedOrCollectedPropertyType: { type: "decimal" },
+          definition: { type: "selection" } as any,
+        },
+      },
+    };
+    expect(resolvePropertyType(holder, "total")).toBe("decimal");
+  });
+
+  it("returns undefined for a derived property without a resolvable type", () => {
+    const holder: PropertyTypeSource = {
+      [RdpDefRef]: {
+        avg: {
+          selectedOrCollectedPropertyType: undefined,
+          definition: { type: "selection" } as any,
+        },
+      },
+    };
+    expect(resolvePropertyType(holder, "avg")).toBeUndefined();
+  });
+
+  it("returns undefined for an unknown key", () => {
+    const holder: PropertyTypeSource = {
+      [ObjectDefRef]: { properties: { amount: { type: "decimal" } } } as any,
+    };
+    expect(resolvePropertyType(holder, "missing")).toBeUndefined();
+  });
+});

--- a/packages/client/src/observable/internal/resolvePropertyType.ts
+++ b/packages/client/src/observable/internal/resolvePropertyType.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { InterfaceMetadata, ObjectMetadata } from "@osdk/api";
+import type { DerivedPropertyRuntimeMetadata } from "../../derivedProperties/derivedPropertyRuntimeMetadata.js";
+import {
+  InterfaceDefRef,
+  ObjectDefRef,
+  RdpDefRef,
+} from "../../object/convertWireToOsdkObjects/InternalSymbols.js";
+
+/**
+ * Property types that the wire encodes as strings even though they're numbers.
+ * Comparing them with `<` / `>` sorts them lexicographically ("10" < "9"), so
+ * they need to be compared numerically instead.
+ */
+const NUMERIC_STRING_PROPERTY_TYPES: ReadonlySet<string> = new Set([
+  "decimal",
+  "long",
+]);
+
+export function isNumericStringType(type: string | undefined): boolean {
+  return type != null && NUMERIC_STRING_PROPERTY_TYPES.has(type);
+}
+
+/**
+ * Subset of a holder needed to resolve the declared type of a property. The
+ * holder symbols are optional because a holder is either an object or an
+ * interface, and only objects carry the object-level metadata.
+ */
+export interface PropertyTypeSource {
+  readonly [ObjectDefRef]?: ObjectMetadata;
+  readonly [InterfaceDefRef]?: InterfaceMetadata;
+  readonly [RdpDefRef]?: DerivedPropertyRuntimeMetadata;
+}
+
+/**
+ * Resolves the declared property type for a property key from a holder.
+ * Regular properties live in the object/interface metadata; derived
+ * (runtime-derived) properties live in the separate RDP metadata.
+ * Returns undefined when the type can't be determined (e.g. derived
+ * aggregations like avg that don't preserve a single source type).
+ */
+export function resolvePropertyType(
+  holder: PropertyTypeSource | undefined,
+  key: string,
+): string | undefined {
+  if (holder == null) {
+    return undefined;
+  }
+  const objectType = holder[ObjectDefRef]?.properties?.[key]?.type;
+  if (typeof objectType === "string") {
+    return objectType;
+  }
+  const interfaceType = holder[InterfaceDefRef]?.properties?.[key]?.type;
+  if (typeof interfaceType === "string") {
+    return interfaceType;
+  }
+  const selectedType = holder[RdpDefRef]?.[key]?.selectedOrCollectedPropertyType
+    ?.type;
+  return typeof selectedType === "string" ? selectedType : undefined;
+}

--- a/packages/client/src/observable/internal/sorting/SortingStrategy.test.ts
+++ b/packages/client/src/observable/internal/sorting/SortingStrategy.test.ts
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { createOsdkInterface } from "../../../object/convertWireToOsdkObjects/createOsdkInterface.js";
+import type { InterfaceHolder } from "../../../object/convertWireToOsdkObjects/InterfaceHolder.js";
+import {
+  ObjectDefRef,
+  RdpDefRef,
+} from "../../../object/convertWireToOsdkObjects/InternalSymbols.js";
+import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
+import { InterfaceDefinitions } from "../../../ontology/OntologyProvider.js";
+import type { Canonical } from "../Canonical.js";
+import { createOrderBySortFns } from "./SortingStrategy.js";
+
+interface FakeHolderRefs {
+  /** Type of a regular property keyed by property name. */
+  propertyTypes?: Record<string, unknown>;
+  /** Type of a derived (RDP) property keyed by property name. */
+  derivedTypes?: Record<string, unknown>;
+  /** Derived properties present but without a statically-known type. */
+  derivedUntyped?: readonly string[];
+}
+
+/**
+ * Builds a minimal holder that exposes only what the orderBy comparator reads:
+ * the property values plus the metadata symbols used to resolve property types.
+ */
+function fakeHolder(
+  values: Record<string, unknown>,
+  refs: FakeHolderRefs = {},
+): ObjectHolder {
+  const holder: { [k: string]: unknown } & {
+    [ObjectDefRef]?: unknown;
+    [RdpDefRef]?: unknown;
+  } = { ...values };
+
+  if (refs.propertyTypes != null) {
+    holder[ObjectDefRef] = {
+      properties: Object.fromEntries(
+        Object.entries(refs.propertyTypes).map((
+          [name, type],
+        ) => [name, { type }]),
+      ),
+    };
+  }
+
+  if (refs.derivedTypes != null || refs.derivedUntyped != null) {
+    const rdp: Record<string, unknown> = {};
+    for (const [name, type] of Object.entries(refs.derivedTypes ?? {})) {
+      rdp[name] = { selectedOrCollectedPropertyType: { type } };
+    }
+    for (const name of refs.derivedUntyped ?? []) {
+      rdp[name] = { selectedOrCollectedPropertyType: undefined };
+    }
+    holder[RdpDefRef] = rdp;
+  }
+
+  return holder as ObjectHolder;
+}
+
+/**
+ * Builds a real interface holder (via createOsdkInterface) over an underlying
+ * object with a single `amount` property, so the comparator is exercised
+ * against the actual interface view -- including the namespace-stripped keys
+ * and the derived-property metadata it now carries.
+ *
+ * For "regular" the property lives in the interface metadata; for "derived" it
+ * lives only in the RDP metadata (as a runtime-derived property would).
+ */
+function fakeInterfaceHolder(
+  amount: unknown,
+  type: string,
+  kind: "regular" | "derived",
+): InterfaceHolder {
+  const underlying: Record<string | symbol, unknown> = {
+    amount,
+    [ObjectDefRef]: {
+      [InterfaceDefinitions]: {},
+      apiName: "Obj",
+      displayName: "",
+      interfaceMap: {
+        "IFoo": kind === "regular" ? { "amount": "amount" } : {},
+      },
+      inverseInterfaceMap: {},
+      links: {},
+      pluralDisplayName: "",
+      primaryKeyApiName: "id",
+      primaryKeyType: "string",
+      properties: { "amount": { type } },
+      type: "object",
+      titleProperty: "amount",
+      rid: "",
+      status: "ACTIVE",
+      icon: undefined,
+      visibility: undefined,
+      description: undefined,
+    },
+  };
+
+  if (kind === "derived") {
+    underlying[RdpDefRef] = {
+      "amount": {
+        selectedOrCollectedPropertyType: { type },
+        definition: { type: "selection" },
+      },
+    };
+  }
+
+  return createOsdkInterface(underlying as any, {
+    "apiName": "IFoo",
+    displayName: "",
+    links: {},
+    properties: kind === "regular" ? { "amount": { type } } : {},
+    rid: "",
+    type: "interface",
+    implements: [],
+    description: undefined,
+  });
+}
+
+function sort(
+  orderBy: Record<string, "asc" | "desc">,
+  holders: Array<ObjectHolder | InterfaceHolder>,
+): Array<ObjectHolder | InterfaceHolder> {
+  const sortFns = createOrderBySortFns(
+    orderBy as Canonical<Record<string, "asc" | "desc" | undefined>>,
+  );
+  return [...holders].sort((a, b) => {
+    for (const fn of sortFns) {
+      const ret = fn(a, b);
+      if (ret !== 0) {
+        return ret;
+      }
+    }
+    return 0;
+  });
+}
+
+describe("createOrderBySortFns", () => {
+  it("sorts decimal properties numerically, not lexicographically", () => {
+    const holders = ["10", "9", "100", "2"].map((amount) =>
+      fakeHolder({ amount }, { propertyTypes: { amount: "decimal" } })
+    );
+
+    expect(sort({ amount: "asc" }, holders).map((h) => h.amount)).toEqual([
+      "2",
+      "9",
+      "10",
+      "100",
+    ]);
+    expect(sort({ amount: "desc" }, holders).map((h) => h.amount)).toEqual([
+      "100",
+      "10",
+      "9",
+      "2",
+    ]);
+  });
+
+  it("sorts long properties numerically", () => {
+    // The value-level precision/edge cases live in compareNumericStrings.test;
+    // here we just assert the `long` type routes through numeric comparison.
+    const holders = ["10", "9", "100"].map((id) =>
+      fakeHolder({ id }, { propertyTypes: { id: "long" } })
+    );
+
+    expect(sort({ id: "asc" }, holders).map((h) => h.id)).toEqual([
+      "9",
+      "10",
+      "100",
+    ]);
+  });
+
+  it("keeps real string properties lexicographic", () => {
+    const holders = ["10", "9", "100"].map((name) =>
+      fakeHolder({ name }, { propertyTypes: { name: "string" } })
+    );
+
+    expect(sort({ name: "asc" }, holders).map((h) => h.name)).toEqual([
+      "10",
+      "100",
+      "9",
+    ]);
+  });
+
+  it("sorts derived decimal properties numerically", () => {
+    const holders = ["10", "9", "100"].map((total) =>
+      fakeHolder({ total }, { derivedTypes: { total: "decimal" } })
+    );
+
+    expect(sort({ total: "asc" }, holders).map((h) => h.total)).toEqual([
+      "9",
+      "10",
+      "100",
+    ]);
+  });
+
+  it("sorts untyped derived properties lexicographically and deterministically", () => {
+    // A derived property whose type can't be resolved (no metadata) is NOT
+    // guessed-as-numeric from its values. The previous value-based heuristic
+    // was non-deterministic: the same two values ordered differently depending
+    // on a sibling value (numeric when every value parsed as a number,
+    // lexicographic once any didn't). Now an untyped property is always
+    // lexicographic, so "10" sorts before "9" regardless of siblings.
+    const numericOnly = ["10", "9", "100"].map((agg) =>
+      fakeHolder({ agg }, { derivedUntyped: ["agg"] })
+    );
+    expect(sort({ agg: "asc" }, numericOnly).map((h) => h.agg)).toEqual([
+      "10",
+      "100",
+      "9",
+    ]);
+
+    // Adding a non-numeric sibling does not change the relative order of "10"
+    // and "9" -- the ordering is stable under the contents of the page.
+    const withNonNumeric = ["10", "9", "x"].map((agg) =>
+      fakeHolder({ agg }, { derivedUntyped: ["agg"] })
+    );
+    expect(sort({ agg: "asc" }, withNonNumeric).map((h) => h.agg)).toEqual([
+      "10",
+      "9",
+      "x",
+    ]);
+  });
+
+  it("sorts numbers numerically", () => {
+    const holders = [10, 9, 100, 2].map((value) =>
+      fakeHolder({ value }, { propertyTypes: { value: "integer" } })
+    );
+
+    expect(sort({ value: "asc" }, holders).map((h) => h.value)).toEqual([
+      2,
+      9,
+      10,
+      100,
+    ]);
+  });
+
+  it("sorts nulls last regardless of direction", () => {
+    const holders = [
+      fakeHolder({ amount: "5" }, { propertyTypes: { amount: "decimal" } }),
+      fakeHolder({ amount: null }, { propertyTypes: { amount: "decimal" } }),
+      fakeHolder({ amount: "10" }, { propertyTypes: { amount: "decimal" } }),
+    ];
+
+    expect(sort({ amount: "asc" }, holders).map((h) => h.amount)).toEqual([
+      "5",
+      "10",
+      null,
+    ]);
+    expect(sort({ amount: "desc" }, holders).map((h) => h.amount)).toEqual([
+      "10",
+      "5",
+      null,
+    ]);
+  });
+
+  it("sorts interface lists by a regular decimal property numerically", () => {
+    const holders = ["10", "9", "100"].map((amount) =>
+      fakeInterfaceHolder(amount, "decimal", "regular")
+    );
+
+    expect(sort({ amount: "asc" }, holders).map((h) => h.amount)).toEqual([
+      "9",
+      "10",
+      "100",
+    ]);
+  });
+
+  it("sorts interface lists by a derived decimal property numerically", () => {
+    // Derived properties used to be dropped entirely from the interface view;
+    // now their value and type metadata are carried, so they sort numerically.
+    const holders = ["10", "9", "100"].map((amount) =>
+      fakeInterfaceHolder(amount, "decimal", "derived")
+    );
+
+    expect(sort({ amount: "asc" }, holders).map((h) => h.amount)).toEqual([
+      "9",
+      "10",
+      "100",
+    ]);
+  });
+});

--- a/packages/client/src/observable/internal/sorting/SortingStrategy.ts
+++ b/packages/client/src/observable/internal/sorting/SortingStrategy.ts
@@ -18,8 +18,13 @@ import type { InterfaceHolder } from "../../../object/convertWireToOsdkObjects/I
 import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
 import type { BatchContext } from "../BatchContext.js";
 import type { Canonical } from "../Canonical.js";
+import { compareNumericStrings } from "../compareNumericStrings.js";
 import type { ObjectCacheKey } from "../object/ObjectCacheKey.js";
 import { PK_IDX } from "../object/ObjectCacheKey.js";
+import {
+  isNumericStringType,
+  resolvePropertyType,
+} from "../resolvePropertyType.js";
 
 /**
  * Strategy interface for collection sorting
@@ -113,13 +118,29 @@ export function createOrderBySortFns(
       if (aValue == null && bValue == null) {
         return 0;
       }
+      // Nulls always sort last, regardless of direction.
       if (aValue == null) {
         return 1;
       }
       if (bValue == null) {
         return -1;
       }
+
       const m = order === "asc" ? -1 : 1;
+
+      // decimal/long are wire-encoded as strings; comparing them with `<` / `>`
+      // sorts them lexicographically ("10" < "9"), so compare them numerically
+      // when the property type says they're numbers. Types that aren't
+      // numeric-string-encoded (real strings, dates, etc.) keep the
+      // lexicographic comparison, which is correct for them.
+      if (typeof aValue === "string" && typeof bValue === "string") {
+        const propertyType = resolvePropertyType(a, key)
+          ?? resolvePropertyType(b, key);
+        if (isNumericStringType(propertyType)) {
+          return -m * compareNumericStrings(aValue, bValue);
+        }
+      }
+
       return aValue < bValue ? m : aValue > bValue ? -m : 0;
     };
   });

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
@@ -14,12 +14,15 @@
  * limitations under the License.
  */
 
+import type { DerivedPropertyDefinition } from "@osdk/foundry.ontologies";
 import { describe, expect, it } from "vitest";
+import type { DerivedPropertyRuntimeMetadata } from "../../../derivedProperties/derivedPropertyRuntimeMetadata.js";
 import type { MinimalClient } from "../../../MinimalClientContext.js";
 import { createOsdkObject } from "../../../object/convertWireToOsdkObjects/createOsdkObject.js";
 import {
   ClientRef,
   ObjectDefRef,
+  RdpDefRef,
   UnderlyingOsdkObject,
 } from "../../../object/convertWireToOsdkObjects/InternalSymbols.js";
 import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
@@ -75,6 +78,43 @@ function createTestObject(
     ...defaultProps,
     ...props,
   });
+}
+
+function buildRdpMeta(
+  types: Record<string, string>,
+): DerivedPropertyRuntimeMetadata {
+  const meta: DerivedPropertyRuntimeMetadata = {};
+  for (const [key, type] of Object.entries(types)) {
+    meta[key] = {
+      // resolvePropertyType only reads selectedOrCollectedPropertyType.type;
+      // the definition needs just enough shape for createOsdkObject's RDP
+      // deserialization (it inspects definition.operation.type).
+      definition: {
+        type: "selection",
+        operation: { type: "get" },
+      } as DerivedPropertyDefinition,
+      selectedOrCollectedPropertyType: { type },
+    };
+  }
+  return meta;
+}
+
+function createTestObjectWithRdp(
+  props: Partial<SimpleOsdkProperties>,
+  rdpTypes: Record<string, string>,
+): ObjectHolder {
+  const defaultProps: SimpleOsdkProperties = {
+    $apiName: "Employee",
+    $objectType: "Employee",
+    $primaryKey: 50030,
+    $title: "John Doe",
+  };
+  return createOsdkObject(
+    mockClient,
+    employeeObjectDef,
+    { ...defaultProps, ...props },
+    buildRdpMeta(rdpTypes),
+  );
 }
 
 function assertValidObjectHolder(obj: ObjectHolder): void {
@@ -319,5 +359,84 @@ describe("mergeSelectFields", () => {
     expect(underlying.office).toBe("SF");
     expect(underlying.rdpField1).toBe("existing-rdp");
     expect(underlying.employeeId).toBe(50030);
+  });
+
+  it("preserves RDP type metadata from both holders", () => {
+    const source = createTestObjectWithRdp(
+      { employeeId: 50030, rdpField1: "10" },
+      { rdpField1: "decimal" },
+    );
+    const existing = createTestObjectWithRdp(
+      { employeeId: 50030, rdpField2: "9007199254740993" },
+      { rdpField2: "long" },
+    );
+
+    const result = mergeSelectFields(source, new Set(["rdpField1"]), existing);
+
+    expect(result[RdpDefRef].rdpField1?.selectedOrCollectedPropertyType?.type)
+      .toBe("decimal");
+    expect(result[RdpDefRef].rdpField2?.selectedOrCollectedPropertyType?.type)
+      .toBe("long");
+  });
+});
+
+describe("rdpFieldOperations RDP metadata preservation", () => {
+  it("preserves metadata when stripping rdp fields", () => {
+    const source = createTestObjectWithRdp(
+      { employeeId: 50030, rdpField1: "10" },
+      { rdpField1: "decimal" },
+    );
+
+    // targetRdpFields empty -> stripRdpFields path
+    const result = mergeObjectFields(
+      source,
+      new Set(["rdpField1"]),
+      new Set(),
+      undefined,
+    );
+
+    expect(result[RdpDefRef].rdpField1?.selectedOrCollectedPropertyType?.type)
+      .toBe("decimal");
+  });
+
+  it("preserves metadata when filtering to a subset of rdp fields", () => {
+    const source = createTestObjectWithRdp(
+      { employeeId: 50030, rdpField1: "10", rdpField2: "20" },
+      { rdpField1: "decimal", rdpField2: "long" },
+    );
+
+    // source is a strict superset of target -> filterToRdpFields path
+    const result = mergeObjectFields(
+      source,
+      new Set(["rdpField1", "rdpField2"]),
+      new Set(["rdpField1"]),
+      undefined,
+    );
+
+    expect(result[RdpDefRef].rdpField1?.selectedOrCollectedPropertyType?.type)
+      .toBe("decimal");
+  });
+
+  it("preserves metadata from source and target on the full merge path", () => {
+    const source = createTestObjectWithRdp(
+      { employeeId: 50030, rdpField1: "10" },
+      { rdpField1: "decimal" },
+    );
+    const target = createTestObjectWithRdp(
+      { employeeId: 50030, rdpField2: "9007199254740993" },
+      { rdpField2: "long" },
+    );
+
+    const result = mergeObjectFields(
+      source,
+      new Set(["rdpField1"]),
+      new Set(["rdpField1", "rdpField2"]),
+      target,
+    );
+
+    expect(result[RdpDefRef].rdpField1?.selectedOrCollectedPropertyType?.type)
+      .toBe("decimal");
+    expect(result[RdpDefRef].rdpField2?.selectedOrCollectedPropertyType?.type)
+      .toBe("long");
   });
 });

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
@@ -18,6 +18,7 @@ import { createOsdkObject } from "../../../object/convertWireToOsdkObjects/creat
 import {
   ClientRef,
   ObjectDefRef,
+  RdpDefRef,
   UnderlyingOsdkObject,
 } from "../../../object/convertWireToOsdkObjects/InternalSymbols.js";
 import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
@@ -84,7 +85,15 @@ function stripRdpFields(
     }
   }
 
-  return createOsdkObject(value[ClientRef], objectDef, newProps);
+  // Forward the RDP type metadata so derived numeric (decimal/long) fields keep
+  // sorting/filtering numerically after a rebuild; entries for stripped fields
+  // are harmless since resolvePropertyType only reads keys present on the holder.
+  return createOsdkObject(
+    value[ClientRef],
+    objectDef,
+    newProps,
+    value[RdpDefRef],
+  );
 }
 
 function isSuperset(
@@ -124,7 +133,12 @@ function filterToRdpFields(
     }
   }
 
-  return createOsdkObject(value[ClientRef], objectDef, newProps);
+  return createOsdkObject(
+    value[ClientRef],
+    objectDef,
+    newProps,
+    value[RdpDefRef],
+  );
 }
 
 export function mergeSelectFields(
@@ -161,7 +175,13 @@ export function mergeSelectFields(
     }
   }
 
-  return createOsdkObject(sourceValue[ClientRef], objectDef, newProps);
+  // RDP fields can come from either holder, so merge both sets of metadata.
+  return createOsdkObject(
+    sourceValue[ClientRef],
+    objectDef,
+    newProps,
+    { ...existingValue[RdpDefRef], ...sourceValue[RdpDefRef] },
+  );
 }
 
 export function mergeObjectFields(
@@ -223,9 +243,11 @@ export function mergeObjectFields(
     }
   }
 
+  // Target supplies the preserved RDP fields, so merge its metadata too.
   return createOsdkObject(
     sourceValue[ClientRef],
     objectDef,
     newProps,
+    { ...targetCurrentValue?.[RdpDefRef], ...sourceValue[RdpDefRef] },
   );
 }

--- a/packages/client/src/util/extractRdpDefinition.test.ts
+++ b/packages/client/src/util/extractRdpDefinition.test.ts
@@ -48,6 +48,9 @@ describe("extractRdpDefinition", () => {
               testProperty: {
                 type: "attachment",
               } satisfies ObjectMetadata.Property,
+              decimalProperty: {
+                type: "decimal",
+              } satisfies ObjectMetadata.Property,
             },
           };
         } else {
@@ -108,6 +111,92 @@ describe("extractRdpDefinition", () => {
       }
     `,
     );
+  });
+
+  it("captures the source property type for min/max aggregations", async () => {
+    const objectSetWithMinMax: ObjectSet = {
+      type: "withProperties",
+      objectSet: {
+        type: "searchAround",
+        objectSet: { type: "base", objectType: "BaseType" },
+        link: "testLink1",
+      },
+      derivedProperties: {
+        maxAmount: {
+          type: "selection",
+          objectSet: {
+            type: "searchAround",
+            objectSet: { type: "methodInput" },
+            link: "testLink2",
+          },
+          operation: {
+            type: "max",
+            selectedPropertyApiName: "decimalProperty",
+          },
+        },
+        minAmount: {
+          type: "selection",
+          objectSet: {
+            type: "searchAround",
+            objectSet: { type: "methodInput" },
+            link: "testLink2",
+          },
+          operation: {
+            type: "min",
+            selectedPropertyApiName: "decimalProperty",
+          },
+        },
+      },
+    };
+
+    const result = await extractRdpDefinition(
+      mockClientCtx,
+      objectSetWithMinMax,
+    );
+
+    // min/max preserve the aggregated property's type, so the type is captured
+    // exactly (rather than left undefined and guessed from the value at sort
+    // time).
+    expect(result.maxAmount.selectedOrCollectedPropertyType).toEqual({
+      type: "decimal",
+    });
+    expect(result.minAmount.selectedOrCollectedPropertyType).toEqual({
+      type: "decimal",
+    });
+  });
+
+  it("captures the source property type for sum aggregations", async () => {
+    const objectSetWithSum: ObjectSet = {
+      type: "withProperties",
+      objectSet: {
+        type: "searchAround",
+        objectSet: { type: "base", objectType: "BaseType" },
+        link: "testLink1",
+      },
+      derivedProperties: {
+        totalAmount: {
+          type: "selection",
+          objectSet: {
+            type: "searchAround",
+            objectSet: { type: "methodInput" },
+            link: "testLink2",
+          },
+          operation: {
+            type: "sum",
+            selectedPropertyApiName: "decimalProperty",
+          },
+        },
+      },
+    };
+
+    const result = await extractRdpDefinition(mockClientCtx, objectSetWithSum);
+
+    // sum of a decimal is a decimal (wire-encoded as a string), so the type is
+    // captured -- letting sorting/filtering compare it numerically rather than
+    // guessing from the value.
+    expect(result.totalAmount.selectedOrCollectedPropertyType).toEqual({
+      type: "decimal",
+    });
   });
 
   it("combines definitions from multiple derived properties", async () => {

--- a/packages/client/src/util/extractRdpDefinition.test.ts
+++ b/packages/client/src/util/extractRdpDefinition.test.ts
@@ -165,7 +165,7 @@ describe("extractRdpDefinition", () => {
     });
   });
 
-  it("captures the source property type for sum aggregations", async () => {
+  it("does not capture a source type for sum aggregations (returns double)", async () => {
     const objectSetWithSum: ObjectSet = {
       type: "withProperties",
       objectSet: {
@@ -191,12 +191,10 @@ describe("extractRdpDefinition", () => {
 
     const result = await extractRdpDefinition(mockClientCtx, objectSetWithSum);
 
-    // sum of a decimal is a decimal (wire-encoded as a string), so the type is
-    // captured -- letting sorting/filtering compare it numerically rather than
-    // guessing from the value.
-    expect(result.totalAmount.selectedOrCollectedPropertyType).toEqual({
-      type: "decimal",
-    });
+    // The API contract types sum (like avg) as double, not as the source
+    // property's type, so we leave it untyped -- it's a JS number, compared
+    // natively rather than as a numeric string.
+    expect(result.totalAmount.selectedOrCollectedPropertyType).toBeUndefined();
   });
 
   it("combines definitions from multiple derived properties", async () => {

--- a/packages/client/src/util/extractRdpDefinition.ts
+++ b/packages/client/src/util/extractRdpDefinition.ts
@@ -110,6 +110,15 @@ async function extractRdpDefinitionInternal(
           case "collectList":
           case "collectSet":
           case "get":
+          // min/max/sum preserve the aggregated property's numeric type (e.g.
+          // min or sum of a decimal is a decimal, which is wire-encoded as a
+          // string), so capture it the same way -- sorting/filtering relies on
+          // it to compare numerically. avg/count/distinct don't preserve the
+          // type (they return double/integer as JS numbers), so they fall
+          // through and are left untyped.
+          case "min":
+          case "max":
+          case "sum":
             // This is the object set construction for the derived property definition construction. We pass in childObjectType so that when we reach MethodInputObjectSet, we know where to start looking.
             const { childObjectType: operationLevelObjectType } =
               await extractRdpDefinitionInternal(

--- a/packages/client/src/util/extractRdpDefinition.ts
+++ b/packages/client/src/util/extractRdpDefinition.ts
@@ -110,15 +110,14 @@ async function extractRdpDefinitionInternal(
           case "collectList":
           case "collectSet":
           case "get":
-          // min/max/sum preserve the aggregated property's numeric type (e.g.
-          // min or sum of a decimal is a decimal, which is wire-encoded as a
-          // string), so capture it the same way -- sorting/filtering relies on
-          // it to compare numerically. avg/count/distinct don't preserve the
-          // type (they return double/integer as JS numbers), so they fall
-          // through and are left untyped.
+          // get/collect/min/max preserve the aggregated property's numeric type
+          // (e.g. min of a decimal is a decimal, which is wire-encoded as a
+          // string), so capture it -- sorting/filtering relies on it to compare
+          // numerically. sum/avg/distinct/count don't preserve the type (the API
+          // contract types them as double/integer, returned as JS numbers), so
+          // they fall through and are left untyped.
           case "min":
           case "max":
-          case "sum":
             // This is the object set construction for the derived property definition construction. We pass in childObjectType so that when we reach MethodInputObjectSet, we know where to start looking.
             const { childObjectType: operationLevelObjectType } =
               await extractRdpDefinitionInternal(


### PR DESCRIPTION
## Summary

Numeric properties (`decimal` and `long`) are transmitted over the wire as strings. The observable client was comparing them lexicographically, so sorting and range filtering produced wrong results (e.g. `"10"` sorted before `"9"`, and `$gt`/`$lt` comparisons were string-based).

This change makes the observable client sort and filter `decimal`/`long` properties numerically. It covers:

- Direct object properties
- Derived (runtime-derived) properties
- Properties on interface lists

## Approach

- Add `compareNumericStrings` to compare numeric string values without precision loss
- Add `resolvePropertyType` to determine a property's wire type, including derived properties and interface-backed properties
- Wire the numeric comparison into `SortingStrategy` and `evaluateFilter` / `objectMatchesWhereClause`
- Expose the property-type metadata needed from the object/interface holders

## Testing

Unit tests added for `compareNumericStrings`, `resolvePropertyType`, sorting, filtering, and the holder/RDP plumbing.
