### PR TITLE
Sort decimal/long properties numerically in observable client

### DIFF
--- a/.changeset/quick-pandas-jump.md
+++ b/.changeset/quick-pandas-jump.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Sort decimal and long properties (including derived ones, and on interface lists) numerically instead of lexicographically in the observable client

--- a/packages/client/src/object/convertWireToOsdkObjects/InterfaceHolder.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/InterfaceHolder.ts
@@ -15,8 +15,10 @@
  */
 
 import type { InterfaceMetadata, ObjectMetadata, Osdk } from "@osdk/api";
+import type { DerivedPropertyRuntimeMetadata } from "../../derivedProperties/derivedPropertyRuntimeMetadata.js";
 import type { FormatPropertyOptions } from "../formatting/applyPropertyFormatter.js";
 import type { BaseHolder } from "./BaseHolder.js";
+import type { RdpDefRef } from "./InternalSymbols.js";
 import { InterfaceDefRef } from "./InternalSymbols.js";
 
 /** @internal */
@@ -24,6 +26,7 @@ export interface InterfaceHolder<
   _Q extends Osdk.Instance<any> = never,
 > extends BaseHolder {
   [InterfaceDefRef]: InterfaceMetadata;
+  readonly [RdpDefRef]?: DerivedPropertyRuntimeMetadata;
 
   readonly "$__EXPERIMENTAL__NOT_SUPPORTED_YET__metadata": {
     readonly ObjectMetadata: ObjectMetadata;

--- a/packages/client/src/object/convertWireToOsdkObjects/InternalSymbols.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/InternalSymbols.ts
@@ -16,6 +16,7 @@
 
 import type { ObjectOrInterfaceDefinition, OsdkBase } from "@osdk/api";
 import type { PropertySecurities } from "@osdk/foundry.ontologies";
+import type { DerivedPropertyRuntimeMetadata } from "../../derivedProperties/derivedPropertyRuntimeMetadata.js";
 
 /** @internal */
 export const UnderlyingOsdkObject = Symbol(
@@ -25,6 +26,18 @@ export const UnderlyingOsdkObject = Symbol(
 /** @internal */
 export const ObjectDefRef = Symbol(
   process.env.MODE !== "production" ? "ObjectDefinition" : undefined,
+);
+
+/**
+ * Holds the runtime metadata for an object's derived (runtime-derived)
+ * properties. Unlike regular properties, derived properties aren't part of the
+ * object/interface metadata, so their types are captured here at construction
+ * time (e.g. so sorting can compare numeric-but-string types correctly).
+ *
+ * @internal
+ */
+export const RdpDefRef = Symbol(
+  process.env.MODE !== "production" ? "DerivedPropertyDefinitions" : undefined,
 );
 
 /** @internal */
@@ -46,5 +59,6 @@ export interface HolderBase<T extends ObjectOrInterfaceDefinition> {
   [UnderlyingOsdkObject]: OsdkBase<any>;
   [ObjectDefRef]?: T;
   [InterfaceDefRef]?: T;
+  [RdpDefRef]?: DerivedPropertyRuntimeMetadata;
   [PropertySecuritiesRef]?: PropertySecurities[];
 }

--- a/packages/client/src/object/convertWireToOsdkObjects/ObjectHolder.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/ObjectHolder.ts
@@ -15,11 +15,12 @@
  */
 
 import type { Osdk } from "@osdk/api";
+import type { DerivedPropertyRuntimeMetadata } from "../../derivedProperties/derivedPropertyRuntimeMetadata.js";
 import type { MinimalClient } from "../../MinimalClientContext.js";
 import type { FetchedObjectTypeDefinition } from "../../ontology/OntologyProvider.js";
 import type { BaseHolder } from "./BaseHolder.js";
 import type { get$link } from "./getDollarLink.js";
-import type { ClientRef, ObjectDefRef } from "./InternalSymbols.js";
+import type { ClientRef, ObjectDefRef, RdpDefRef } from "./InternalSymbols.js";
 
 /**
  * @internal
@@ -32,6 +33,7 @@ export interface ObjectHolder<_Q extends Osdk.Instance<any> = never>
 {
   readonly [ObjectDefRef]: FetchedObjectTypeDefinition;
   readonly [ClientRef]: MinimalClient;
+  readonly [RdpDefRef]: DerivedPropertyRuntimeMetadata;
 
   readonly "$link": ReturnType<typeof get$link>;
 }

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
@@ -20,7 +20,7 @@ import {
   InterfaceDefinitions,
 } from "../../ontology/OntologyProvider.js";
 import { createOsdkInterface } from "./createOsdkInterface.js";
-import { ObjectDefRef } from "./InternalSymbols.js";
+import { ObjectDefRef, RdpDefRef } from "./InternalSymbols.js";
 
 describe(createOsdkInterface, () => {
   it("works in the normal case", () => {
@@ -151,6 +151,125 @@ describe(createOsdkInterface, () => {
         "asdf": "hi mom"
       }"
     `);
+  });
+
+  it("carries runtime-derived properties and RDP metadata onto the interface", () => {
+    const rdpMetadata = {
+      "total": {
+        selectedOrCollectedPropertyType: { type: "decimal" },
+        definition: { type: "selection" },
+      },
+    };
+
+    const underlying = {
+      "foo": "hi mom",
+      // derived properties live alongside regular ones on the underlying object
+      "total": "10",
+
+      [RdpDefRef]: rdpMetadata,
+
+      [ObjectDefRef]: {
+        [InterfaceDefinitions]: {},
+        apiName: "Obj",
+        displayName: "",
+        interfaceMap: {
+          "IFoo": {
+            "asdf": "foo",
+          },
+        },
+        inverseInterfaceMap: {},
+        links: {},
+        pluralDisplayName: "",
+        primaryKeyApiName: "",
+        primaryKeyType: "string",
+        properties: {
+          "foo": {
+            type: "string",
+          },
+        },
+        type: "object",
+        titleProperty: "foo",
+        rid: "",
+        status: "ACTIVE",
+        icon: undefined,
+        visibility: undefined,
+        description: undefined,
+      } satisfies FetchedObjectTypeDefinition,
+    };
+
+    const iface = createOsdkInterface(underlying as any, {
+      "apiName": "IFoo",
+      displayName: "",
+      links: {},
+      properties: {
+        "asdf": {
+          type: "string",
+        },
+      },
+      rid: "",
+      type: "interface",
+      implements: [],
+      description: undefined,
+    });
+
+    // the derived value is exposed on the interface view ...
+    expect((iface as any).total).toBe("10");
+    expect(Object.keys(iface)).toContain("total");
+    // ... and the RDP metadata is carried so its type can be resolved.
+    expect((iface as any)[RdpDefRef]).toBe(rdpMetadata);
+  });
+
+  it("does not let a $-prefixed derived property clobber the $-metadata", () => {
+    // RDP names are developer-chosen aliases and never $-prefixed in practice,
+    // but a derived property literally named "$title" must not overwrite the
+    // interface's $title accessor.
+    const underlying = {
+      "foo": "hi mom",
+      "$title": "real title",
+      "$primaryKey": "pk-1",
+      "$apiName": "Obj",
+
+      [RdpDefRef]: {
+        "$title": {
+          selectedOrCollectedPropertyType: { type: "string" },
+          definition: { type: "selection" },
+        },
+      },
+
+      [ObjectDefRef]: {
+        [InterfaceDefinitions]: {},
+        apiName: "Obj",
+        displayName: "",
+        interfaceMap: { "IFoo": { "asdf": "foo" } },
+        inverseInterfaceMap: {},
+        links: {},
+        pluralDisplayName: "",
+        primaryKeyApiName: "$primaryKey",
+        primaryKeyType: "string",
+        properties: { "foo": { type: "string" } },
+        type: "object",
+        titleProperty: "foo",
+        rid: "",
+        status: "ACTIVE",
+        icon: undefined,
+        visibility: undefined,
+        description: undefined,
+      } satisfies FetchedObjectTypeDefinition,
+    };
+
+    const iface = createOsdkInterface(underlying as any, {
+      "apiName": "IFoo",
+      displayName: "",
+      links: {},
+      properties: { "asdf": { type: "string" } },
+      rid: "",
+      type: "interface",
+      implements: [],
+      description: undefined,
+    });
+
+    // $title remains the interface's title accessor, not the RDP value.
+    expect((iface as any).$title).toBe("real title");
   });
 
   it("works with mixed namespaces", () => {

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
@@ -293,8 +293,10 @@ describe(createOsdkInterface, () => {
 
   it("does not let a $-prefixed derived property clobber the $-metadata", () => {
     // RDP names are developer-chosen aliases and never $-prefixed in practice,
-    // but a derived property literally named "$title" must not overwrite the
-    // interface's $title accessor.
+    // but a derived property literally named "$apiName" must not overwrite the
+    // interface's $apiName. This discriminates clobbering because the interface
+    // metadata value ("IFoo") differs from the underlying object's value
+    // ("Obj") -- a clobbering RDP would surface "Obj".
     const underlying = {
       "foo": "hi mom",
       "$title": "real title",
@@ -302,7 +304,7 @@ describe(createOsdkInterface, () => {
       "$apiName": "Obj",
 
       [RdpDefRef]: {
-        "$title": {
+        "$apiName": {
           selectedOrCollectedPropertyType: { type: "string" },
           definition: { type: "selection" },
         },
@@ -340,8 +342,8 @@ describe(createOsdkInterface, () => {
       description: undefined,
     });
 
-    // $title remains the interface's title accessor, not the RDP value.
-    expect((iface as any).$title).toBe("real title");
+    // $apiName remains the interface's apiName, not the underlying RDP value.
+    expect((iface as any).$apiName).toBe("IFoo");
   });
 
   it("works with mixed namespaces", () => {

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
+import type { DerivedPropertyDefinition } from "@osdk/foundry.ontologies";
 import { describe, expect, it } from "vitest";
+import type { DerivedPropertyRuntimeMetadata } from "../../derivedProperties/derivedPropertyRuntimeMetadata.js";
+import type { MinimalClient } from "../../MinimalClientContext.js";
 import {
   type FetchedObjectTypeDefinition,
   InterfaceDefinitions,
 } from "../../ontology/OntologyProvider.js";
 import { createOsdkInterface } from "./createOsdkInterface.js";
+import { createOsdkObject } from "./createOsdkObject.js";
 import { ObjectDefRef, RdpDefRef } from "./InternalSymbols.js";
 
 describe(createOsdkInterface, () => {
@@ -217,6 +221,74 @@ describe(createOsdkInterface, () => {
     expect(Object.keys(iface)).toContain("total");
     // ... and the RDP metadata is carried so its type can be resolved.
     expect((iface as any)[RdpDefRef]).toBe(rdpMetadata);
+  });
+
+  it("carries RDP metadata end-to-end when the underlying is built via createOsdkObject", () => {
+    // The test above sets [RdpDefRef] on a hand-rolled underlying; this one
+    // exercises the real path -- createOsdkObject populates [RdpDefRef] -- so a
+    // regression in that wiring (not just in createOsdkInterface) is caught.
+    const objectDef = {
+      [InterfaceDefinitions]: {},
+      apiName: "Obj",
+      displayName: "",
+      interfaceMap: { "IFoo": { "asdf": "foo" } },
+      inverseInterfaceMap: {},
+      links: {},
+      pluralDisplayName: "",
+      primaryKeyApiName: "$primaryKey",
+      primaryKeyType: "string",
+      properties: { "foo": { type: "string" } },
+      type: "object",
+      titleProperty: "foo",
+      rid: "",
+      status: "ACTIVE",
+      icon: undefined,
+      visibility: undefined,
+      description: undefined,
+    } satisfies FetchedObjectTypeDefinition;
+
+    const rdpMetadata: DerivedPropertyRuntimeMetadata = {
+      "total": {
+        definition: {
+          type: "selection",
+          operation: { type: "get", selectedPropertyApiName: "foo" },
+        } as DerivedPropertyDefinition,
+        selectedOrCollectedPropertyType: { type: "decimal" },
+      },
+    };
+
+    const underlying = createOsdkObject(
+      {} as MinimalClient,
+      objectDef,
+      {
+        $apiName: "Obj",
+        $objectType: "Obj",
+        $primaryKey: "pk-1",
+        $title: "hi mom",
+        foo: "hi mom",
+        // the derived value lives alongside regular properties on the underlying
+        total: "10",
+      },
+      rdpMetadata,
+    );
+
+    const iface = createOsdkInterface(underlying, {
+      "apiName": "IFoo",
+      displayName: "",
+      links: {},
+      properties: { "asdf": { type: "string" } },
+      rid: "",
+      type: "interface",
+      implements: [],
+      description: undefined,
+    });
+
+    // the derived value is exposed on the interface view ...
+    expect((iface as any).total).toBe("10");
+    expect(Object.keys(iface)).toContain("total");
+    // ... and the captured type survives, so consumers resolve it as numeric.
+    expect(iface[RdpDefRef]?.total?.selectedOrCollectedPropertyType?.type)
+      .toBe("decimal");
   });
 
   it("does not let a $-prefixed derived property clobber the $-metadata", () => {

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.ts
@@ -45,6 +45,20 @@ export function createOsdkInterface<
       // first to minimize hidden classes
       [UnderlyingOsdkObject]: { value: underlying },
 
+      // Expose each runtime-derived (RDP) property value. These aren't part of
+      // interfaceDef.properties, so copy them from the underlying object (the
+      // RDP type metadata is carried separately via [RdpDefRef] below, so
+      // consumers like orderBy sorting can resolve their numeric types).
+      // Defined before the "$"-metadata descriptors so a derived property can
+      // never clobber them -- a later same-named "$"-descriptor wins.
+      ...Object.fromEntries(
+        Object.keys(underlying[RdpDefRef] ?? {})
+          .map(k => [k, {
+            enumerable: k in underlying,
+            value: underlying[k as keyof typeof underlying],
+          }]),
+      ),
+
       "$apiName": { value: interfaceDef.apiName, enumerable: true },
       "$as": {
         value: underlying.$as,
@@ -105,22 +119,10 @@ export function createOsdkInterface<
 
       [InterfaceDefRef]: { value: interfaceDef },
 
-      // Runtime-derived (RDP) properties aren't part of interfaceDef.properties,
-      // so copy their values from the underlying object and carry the RDP
-      // metadata, so consumers (e.g. orderBy sorting and where-clause filtering)
-      // can read the values and resolve their numeric types.
+      // Carry the RDP type metadata so consumers (e.g. orderBy sorting and
+      // where-clause filtering) can resolve a derived property's numeric type.
+      // The values themselves are spread in above.
       [RdpDefRef]: { value: underlying[RdpDefRef] },
-
-      // Skip any "$"-prefixed RDP name so a derived property can never clobber
-      // the fixed "$"-metadata descriptors defined above (RDP names are
-      // developer-chosen aliases and are never "$"-prefixed in practice).
-      ...Object.fromEntries(
-        Object.keys(underlying[RdpDefRef] ?? {}).filter(k => !k.startsWith("$"))
-          .map(k => [k, {
-            enumerable: k in underlying,
-            value: underlying[k as keyof typeof underlying],
-          }]),
-      ),
 
       ...Object.fromEntries(
         Object.keys(interfaceDef.properties).map(p => {

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.ts
@@ -22,6 +22,7 @@ import type { InterfaceHolder } from "./InterfaceHolder.js";
 import {
   InterfaceDefRef,
   ObjectDefRef,
+  RdpDefRef,
   UnderlyingOsdkObject,
 } from "./InternalSymbols.js";
 import type { ObjectHolder } from "./ObjectHolder.js";
@@ -103,6 +104,23 @@ export function createOsdkInterface<
       },
 
       [InterfaceDefRef]: { value: interfaceDef },
+
+      // Runtime-derived (RDP) properties aren't part of interfaceDef.properties,
+      // so copy their values from the underlying object and carry the RDP
+      // metadata, so consumers (e.g. orderBy sorting and where-clause filtering)
+      // can read the values and resolve their numeric types.
+      [RdpDefRef]: { value: underlying[RdpDefRef] },
+
+      // Skip any "$"-prefixed RDP name so a derived property can never clobber
+      // the fixed "$"-metadata descriptors defined above (RDP names are
+      // developer-chosen aliases and are never "$"-prefixed in practice).
+      ...Object.fromEntries(
+        Object.keys(underlying[RdpDefRef] ?? {}).filter(k => !k.startsWith("$"))
+          .map(k => [k, {
+            enumerable: k in underlying,
+            value: underlying[k as keyof typeof underlying],
+          }]),
+      ),
 
       ...Object.fromEntries(
         Object.keys(interfaceDef.properties).map(p => {

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -43,6 +43,7 @@ import {
   ClientRef,
   ObjectDefRef,
   PropertySecuritiesRef,
+  RdpDefRef,
   UnderlyingOsdkObject,
 } from "./InternalSymbols.js";
 import type { ObjectHolder } from "./ObjectHolder.js";
@@ -83,7 +84,12 @@ const basePropDefs = {
       const def = this[ObjectDefRef];
 
       if (update == null) {
-        return createOsdkObject(this[ClientRef], def, { ...rawObj });
+        return createOsdkObject(
+          this[ClientRef],
+          def,
+          { ...rawObj },
+          this[RdpDefRef],
+        );
       }
 
       if (
@@ -100,7 +106,12 @@ const basePropDefs = {
       }
 
       const newObject = { ...this[UnderlyingOsdkObject], ...update };
-      return createOsdkObject(this[ClientRef], this[ObjectDefRef], newObject);
+      return createOsdkObject(
+        this[ClientRef],
+        this[ObjectDefRef],
+        newObject,
+        this[RdpDefRef],
+      );
     },
   },
   "$objectSpecifier": {
@@ -183,6 +194,9 @@ export function createOsdkObject(
       },
       [ObjectDefRef]: { value: objectDef, enumerable: false }, // TODO: Potentially update when GA metadata field
       [ClientRef]: { value: client, enumerable: false },
+      // Derived property types aren't part of objectDef; keep them on the holder
+      // so consumers (e.g. orderBy sorting) can resolve their types.
+      [RdpDefRef]: { value: derivedPropertyTypeByName, enumerable: false },
       ...basePropDefs,
     } satisfies Record<keyof ObjectHolder, PropertyDescriptor>,
   );

--- a/packages/client/src/observable/internal/compareNumericStrings.test.ts
+++ b/packages/client/src/observable/internal/compareNumericStrings.test.ts
@@ -92,6 +92,23 @@ describe(compareNumericStrings, () => {
     expect(compareNumericStrings("abc", "xyz")).toBe(0);
   });
 
+  it("treats empty/whitespace as the smallest value, not as zero", () => {
+    // compareNumericStrings defines the ascending order, where an empty/
+    // whitespace ("no value") cell is the smallest -- so it sorts before every
+    // number (and the caller negates the result for descending, putting it
+    // last). Number("") === 0, so it must NOT be compared as the value zero.
+    expect(compareNumericStrings("", "10")).toBe(-1);
+    expect(compareNumericStrings("10", "")).toBe(1);
+    expect(compareNumericStrings("", "-5")).toBe(-1);
+    expect(compareNumericStrings("", "0")).toBe(-1);
+    expect(compareNumericStrings("   ", "0")).toBe(-1);
+    expect(compareNumericStrings("\n", "0")).toBe(-1);
+    // Empty sorts before even malformed values, and two empties are equal.
+    expect(compareNumericStrings("", "abc")).toBe(-1);
+    expect(compareNumericStrings("abc", "")).toBe(1);
+    expect(compareNumericStrings("", "")).toBe(0);
+  });
+
   it("is transitive on junk-containing input, so Array.sort is order-independent", () => {
     // With a non-transitive comparator (junk == 5 and junk == 10 while 5 < 10),
     // even the finite values would be misordered depending on the starting

--- a/packages/client/src/observable/internal/compareNumericStrings.test.ts
+++ b/packages/client/src/observable/internal/compareNumericStrings.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { compareNumericStrings } from "./compareNumericStrings.js";
+
+describe(compareNumericStrings, () => {
+  /** Sorts a copy of `values` ascending using only the comparator. */
+  function sortedAsc(values: string[]): string[] {
+    return [...values].sort(compareNumericStrings);
+  }
+
+  it("orders integers/longs by value, not lexicographically", () => {
+    // Lexicographically this would be 10, 100, 2, 9.
+    expect(sortedAsc(["10", "9", "100", "2"])).toEqual([
+      "2",
+      "9",
+      "10",
+      "100",
+    ]);
+  });
+
+  it("preserves precision for longs beyond Number.MAX_SAFE_INTEGER", () => {
+    // 2^53 and 2^53 + 1 are indistinguishable as JS numbers.
+    expect(compareNumericStrings("9007199254740993", "9007199254740992"))
+      .toBe(1);
+    expect(compareNumericStrings("9007199254740992", "9007199254740993"))
+      .toBe(-1);
+    expect(compareNumericStrings("9007199254740992", "9007199254740992"))
+      .toBe(0);
+  });
+
+  it("orders decimals by value", () => {
+    expect(sortedAsc(["10", "9", "100"])).toEqual(["9", "10", "100"]);
+    expect(sortedAsc(["1.5", "1.25", "1.125"])).toEqual([
+      "1.125",
+      "1.25",
+      "1.5",
+    ]);
+  });
+
+  it("preserves precision for large non-integer decimals beyond a double", () => {
+    // These differ only in the 17th significant digit, which a double can't
+    // represent: Number("9007199254740993.5") === Number("9007199254740993.6").
+    expect(sortedAsc([
+      "9007199254740993.6",
+      "9007199254740993.5",
+      "9007199254740993.55",
+    ])).toEqual([
+      "9007199254740993.5",
+      "9007199254740993.55",
+      "9007199254740993.6",
+    ]);
+  });
+
+  it("treats trailing-zero fractions as equal (10 == 10.00)", () => {
+    expect(compareNumericStrings("10", "10.00")).toBe(0);
+    expect(compareNumericStrings("1.5", "1.50")).toBe(0);
+  });
+
+  it("handles signs, including +, -, and -0", () => {
+    expect(compareNumericStrings("-1.5", "1.5")).toBe(-1);
+    expect(compareNumericStrings("-1.5", "-1.25")).toBe(-1);
+    expect(compareNumericStrings("+10", "9")).toBe(1);
+    expect(compareNumericStrings("-0.0", "0.0")).toBe(0);
+  });
+
+  it("falls back to a Number comparison for exotic forms (e.g. scientific)", () => {
+    expect(compareNumericStrings("1e3", "999")).toBe(1);
+    expect(compareNumericStrings("999", "1e3")).toBe(-1);
+  });
+
+  it("keeps a total order for unparseable values (NaN sorts last)", () => {
+    // A non-numeric string can't be compared by value, so it must sort after
+    // every finite value and never compare equal to one -- otherwise the
+    // comparator is non-transitive and Array.sort is corrupted (see below).
+    expect(compareNumericStrings("abc", "10")).toBe(1);
+    expect(compareNumericStrings("10", "abc")).toBe(-1);
+    expect(compareNumericStrings("abc", "xyz")).toBe(0);
+  });
+
+  it("is transitive on junk-containing input, so Array.sort is order-independent", () => {
+    // With a non-transitive comparator (junk == 5 and junk == 10 while 5 < 10),
+    // even the finite values would be misordered depending on the starting
+    // order. A total order keeps the finite values correctly sorted and the junk
+    // last regardless of input order (junk-vs-junk is equal, so its relative
+    // order tracks input -- that's fine).
+    const forward = ["10", "abc", "5", "2", "xyz", "100", "3"];
+    const reversed = [...forward].reverse();
+
+    for (const input of [forward, reversed]) {
+      const sorted = [...input].sort(compareNumericStrings);
+      expect(sorted.slice(0, 5)).toEqual(["2", "3", "5", "10", "100"]);
+      expect(sorted.slice(5).sort()).toEqual(["abc", "xyz"]);
+    }
+  });
+});

--- a/packages/client/src/observable/internal/compareNumericStrings.ts
+++ b/packages/client/src/observable/internal/compareNumericStrings.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Matches a plain base-10 number in decimal notation (optionally signed,
+ * optional fractional part) -- this covers both `long` (no fraction) and
+ * `decimal`. Excludes exotic forms like scientific notation, which fall back
+ * to Number().
+ */
+const NUMERIC_STRING = /^[+-]?\d+(\.\d+)?$/;
+
+/**
+ * Compares two numeric strings (the wire encoding for `decimal` and `long`) by
+ * value, ascending.
+ *
+ * Scales both operands to a common number of fractional digits and compares
+ * them as BigInt, so the result is exact for arbitrary precision -- including
+ * longs beyond Number.MAX_SAFE_INTEGER and decimals whose fractional parts
+ * exceed the precision of a double. Exotic forms (e.g. scientific notation)
+ * fall back to a best-effort Number() comparison.
+ *
+ * The fallback keeps a TOTAL order even for unparseable input: a value that
+ * isn't a finite number (e.g. malformed data on a numeric column) sorts after
+ * every finite value and is never reported equal to one. This matters because
+ * the function is used as an Array.sort comparator -- a NaN-vs-finite pair that
+ * returned 0 would make the comparator non-transitive and corrupt the sort.
+ */
+export function compareNumericStrings(a: string, b: string): number {
+  if (!NUMERIC_STRING.test(a) || !NUMERIC_STRING.test(b)) {
+    const aNum = Number(a);
+    const bNum = Number(b);
+    const aIsNaN = Number.isNaN(aNum);
+    const bIsNaN = Number.isNaN(bNum);
+    if (aIsNaN || bIsNaN) {
+      // NaN sorts last; two NaNs are equal.
+      return aIsNaN && bIsNaN ? 0 : aIsNaN ? 1 : -1;
+    }
+    return aNum < bNum ? -1 : aNum > bNum ? 1 : 0;
+  }
+
+  const [aInt, aFrac = ""] = a.split(".");
+  const [bInt, bFrac = ""] = b.split(".");
+  const fracDigits = Math.max(aFrac.length, bFrac.length);
+
+  // Concatenating the (sign-bearing) integer part with the zero-padded
+  // fractional part scales both values by the same power of ten, so the
+  // BigInt comparison preserves the original ordering exactly.
+  const aScaled = BigInt(aInt + aFrac.padEnd(fracDigits, "0"));
+  const bScaled = BigInt(bInt + bFrac.padEnd(fracDigits, "0"));
+  return aScaled < bScaled ? -1 : aScaled > bScaled ? 1 : 0;
+}

--- a/packages/client/src/observable/internal/compareNumericStrings.ts
+++ b/packages/client/src/observable/internal/compareNumericStrings.ts
@@ -32,20 +32,30 @@ const NUMERIC_STRING = /^[+-]?\d+(\.\d+)?$/;
  * exceed the precision of a double. Exotic forms (e.g. scientific notation)
  * fall back to a best-effort Number() comparison.
  *
- * The fallback keeps a TOTAL order even for unparseable input: a value that
- * isn't a finite number (e.g. malformed data on a numeric column) sorts after
- * every finite value and is never reported equal to one. This matters because
- * the function is used as an Array.sort comparator -- a NaN-vs-finite pair that
- * returned 0 would make the comparator non-transitive and corrupt the sort.
+ * Empty/whitespace values represent "no value" and sort as the smallest value:
+ * first when ascending, last when descending, matching Workshop's blank-cell
+ * ordering. (Note Number("") === 0, so they must NOT be compared as zero.)
+ *
+ * Any other non-numeric input (malformed data on a numeric column) sorts last
+ * and is never reported equal to a finite value, so the comparator stays a
+ * TOTAL order -- it's used as an Array.sort comparator, and a non-transitive
+ * NaN-vs-finite pair would corrupt the sort.
  */
 export function compareNumericStrings(a: string, b: string): number {
   if (!NUMERIC_STRING.test(a) || !NUMERIC_STRING.test(b)) {
+    // Empty/whitespace ("no value") is the smallest value; two such are equal.
+    const aEmpty = a.trim() === "";
+    const bEmpty = b.trim() === "";
+    if (aEmpty || bEmpty) {
+      return aEmpty && bEmpty ? 0 : aEmpty ? -1 : 1;
+    }
+
     const aNum = Number(a);
     const bNum = Number(b);
     const aIsNaN = Number.isNaN(aNum);
     const bIsNaN = Number.isNaN(bNum);
     if (aIsNaN || bIsNaN) {
-      // NaN sorts last; two NaNs are equal.
+      // Malformed values sort last; two NaNs are equal.
       return aIsNaN && bIsNaN ? 0 : aIsNaN ? 1 : -1;
     }
     return aNum < bNum ? -1 : aNum > bNum ? 1 : 0;

--- a/packages/client/src/observable/internal/list/ListQuery.test.ts
+++ b/packages/client/src/observable/internal/list/ListQuery.test.ts
@@ -17,6 +17,7 @@
 import {
   Employee,
   FooInterface,
+  objectTypeWithAllPropertyTypes,
   Office,
   Todo,
 } from "@osdk/client.test.ontology";
@@ -56,6 +57,12 @@ function setupOntology(fauxFoundry: FauxFoundry) {
   fauxFoundry.getDefaultOntology().registerObjectType(
     stubData.todoWithLinkTypes,
   );
+  fauxFoundry.getDefaultOntology().registerObjectType({
+    // Drop the self-link: its ONE cardinality has no foreign key, which
+    // FauxFoundry rejects, and the sorting tests don't traverse links.
+    ...stubData.objectTypeWithAllPropertyTypesWithLinkTypes,
+    linkTypes: [],
+  });
 }
 
 function setupTodos(
@@ -571,6 +578,81 @@ describe("ListQuery sort stability across pages", () => {
     // clientOrdered sorts by text asc, then PK tiebreaker for equal keys
     const ids = payload!.resolvedList!.map((t) => t.id);
     expect(ids).toEqual([10, 30, 31, 20]);
+  });
+
+  it("clientOrdered sorts decimal/long properties numerically, not lexicographically", async () => {
+    const dataStore = fauxFoundry.getDefaultDataStore();
+    dataStore.clear();
+
+    // decimal/long arrive as strings. Lexicographically these sort as
+    // "10" < "100" < "2" < "9", which is wrong; the fix sorts them by value.
+    // The longs straddle 2^53, where doubles lose precision.
+    const rows = [
+      { id: 1, decimal: "10", long: "9007199254740993" },
+      { id: 2, decimal: "9", long: "9007199254740992" },
+      { id: 3, decimal: "100", long: "42" },
+      { id: 4, decimal: "2", long: "100" },
+    ];
+    for (const row of rows) {
+      dataStore.registerObject(objectTypeWithAllPropertyTypes, {
+        $apiName: "objectTypeWithAllPropertyTypes",
+        ...row,
+      });
+    }
+
+    // Fetch real instances (carry the object metadata used to resolve types).
+    const fetched = await Promise.all(
+      rows.map((row) =>
+        client(objectTypeWithAllPropertyTypes).fetchOne(row.id)
+      ),
+    );
+
+    async function expectClientOrdered(
+      orderByProp: "decimal" | "long",
+      expectedIds: number[],
+    ) {
+      const listSub = mockListSubCallback();
+      defer(
+        store.lists.observe(
+          {
+            type: objectTypeWithAllPropertyTypes,
+            where: {},
+            orderBy: { [orderByProp]: "asc" },
+            pageSize: 10,
+          },
+          listSub,
+        ),
+      );
+
+      await waitForCall(listSub.next, 1);
+      expectSingleListCallAndClear(listSub, undefined, { status: "loading" });
+      await waitForCall(listSub.next, 1);
+      expectSingleListCallAndClear(listSub, expect.anything(), {
+        status: "loaded",
+      });
+
+      // Push in id order (i.e. unsorted by the ordered property).
+      updateList(
+        store,
+        {
+          type: objectTypeWithAllPropertyTypes,
+          where: {},
+          orderBy: { [orderByProp]: "asc" },
+        },
+        fetched,
+      );
+
+      await waitForCall(listSub.next, 1);
+      const payload = expectSingleListCallAndClear(listSub, expect.anything(), {
+        status: "loaded",
+      });
+      expect(payload!.resolvedList!.map((o) => o.id)).toEqual(expectedIds);
+    }
+
+    // decimal asc: 2 < 9 < 10 < 100  -> ids 4,2,1,3
+    await expectClientOrdered("decimal", [4, 2, 1, 3]);
+    // long asc: 42 < 100 < 2^53 < 2^53+1 -> ids 3,4,2,1
+    await expectClientOrdered("long", [3, 4, 2, 1]);
   });
 });
 

--- a/packages/client/src/observable/internal/list/ListQuery.test.ts
+++ b/packages/client/src/observable/internal/list/ListQuery.test.ts
@@ -609,7 +609,7 @@ describe("ListQuery sort stability across pages", () => {
 
     async function expectClientOrdered(
       orderByProp: "decimal" | "long",
-      expectedIds: number[],
+      expectedValues: string[],
     ) {
       const listSub = mockListSubCallback();
       defer(
@@ -646,13 +646,18 @@ describe("ListQuery sort stability across pages", () => {
       const payload = expectSingleListCallAndClear(listSub, expect.anything(), {
         status: "loaded",
       });
-      expect(payload!.resolvedList!.map((o) => o.id)).toEqual(expectedIds);
+      const resolved = payload!.resolvedList!;
+      // The ordered property itself is in true numeric order (not lexicographic).
+      expect(resolved.map((o) => o[orderByProp])).toEqual(expectedValues);
     }
 
-    // decimal asc: 2 < 9 < 10 < 100  -> ids 4,2,1,3
-    await expectClientOrdered("decimal", [4, 2, 1, 3]);
-    // long asc: 42 < 100 < 2^53 < 2^53+1 -> ids 3,4,2,1
-    await expectClientOrdered("long", [3, 4, 2, 1]);
+    // decimal asc: 2 < 9 < 10 < 100
+    await expectClientOrdered("decimal", ["2", "9", "10", "100"]);
+    // long asc: 42 < 100 < 2^53 < 2^53+1
+    await expectClientOrdered(
+      "long",
+      ["42", "100", "9007199254740992", "9007199254740993"],
+    );
   });
 });
 

--- a/packages/client/src/observable/internal/resolvePropertyType.test.ts
+++ b/packages/client/src/observable/internal/resolvePropertyType.test.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  InterfaceDefRef,
+  ObjectDefRef,
+  RdpDefRef,
+} from "../../object/convertWireToOsdkObjects/InternalSymbols.js";
+import {
+  isNumericStringType,
+  type PropertyTypeSource,
+  resolvePropertyType,
+} from "./resolvePropertyType.js";
+
+describe(isNumericStringType, () => {
+  it("is true for the wire-encoded-as-string numeric types", () => {
+    expect(isNumericStringType("decimal")).toBe(true);
+    expect(isNumericStringType("long")).toBe(true);
+  });
+
+  it("is false for everything else", () => {
+    // integer/double/float arrive as JS numbers, so they don't need this path.
+    expect(isNumericStringType("integer")).toBe(false);
+    expect(isNumericStringType("double")).toBe(false);
+    expect(isNumericStringType("string")).toBe(false);
+    expect(isNumericStringType("timestamp")).toBe(false);
+    expect(isNumericStringType(undefined)).toBe(false);
+  });
+});
+
+describe(resolvePropertyType, () => {
+  it("returns undefined when the holder is missing", () => {
+    expect(resolvePropertyType(undefined, "amount")).toBeUndefined();
+  });
+
+  it("resolves a regular property from the object metadata", () => {
+    const holder: PropertyTypeSource = {
+      [ObjectDefRef]: { properties: { amount: { type: "decimal" } } } as any,
+    };
+    expect(resolvePropertyType(holder, "amount")).toBe("decimal");
+  });
+
+  it("resolves a regular property from the interface metadata", () => {
+    const holder: PropertyTypeSource = {
+      [InterfaceDefRef]: { properties: { amount: { type: "long" } } } as any,
+    };
+    expect(resolvePropertyType(holder, "amount")).toBe("long");
+  });
+
+  it("resolves a namespaced interface property by its stripped key", () => {
+    // The interface view exposes the property under the namespace-stripped key
+    // ("amount"), but interfaceDef.properties is keyed by the full wire apiName
+    // ("a.amount"); resolution must re-qualify so numeric comparison engages.
+    const holder: PropertyTypeSource = {
+      [InterfaceDefRef]: {
+        apiName: "a.IFoo",
+        properties: { "a.amount": { type: "decimal" } },
+      } as any,
+    };
+    expect(resolvePropertyType(holder, "amount")).toBe("decimal");
+  });
+
+  it("resolves a mixed-namespace interface property by its full key", () => {
+    // When the property namespace differs from the interface namespace the view
+    // exposes the full key, which the direct lookup already finds.
+    const holder: PropertyTypeSource = {
+      [InterfaceDefRef]: {
+        apiName: "b.IFoo",
+        properties: { "a.amount": { type: "long" } },
+      } as any,
+    };
+    expect(resolvePropertyType(holder, "a.amount")).toBe("long");
+  });
+
+  it("resolves a derived property from the RDP metadata", () => {
+    const holder: PropertyTypeSource = {
+      [RdpDefRef]: {
+        total: {
+          selectedOrCollectedPropertyType: { type: "decimal" },
+          definition: { type: "selection" } as any,
+        },
+      },
+    };
+    expect(resolvePropertyType(holder, "total")).toBe("decimal");
+  });
+
+  it("returns undefined for a derived property without a resolvable type", () => {
+    const holder: PropertyTypeSource = {
+      [RdpDefRef]: {
+        avg: {
+          selectedOrCollectedPropertyType: undefined,
+          definition: { type: "selection" } as any,
+        },
+      },
+    };
+    expect(resolvePropertyType(holder, "avg")).toBeUndefined();
+  });
+
+  it("returns undefined for an unknown key", () => {
+    const holder: PropertyTypeSource = {
+      [ObjectDefRef]: { properties: { amount: { type: "decimal" } } } as any,
+    };
+    expect(resolvePropertyType(holder, "missing")).toBeUndefined();
+  });
+});

--- a/packages/client/src/observable/internal/resolvePropertyType.test.ts
+++ b/packages/client/src/observable/internal/resolvePropertyType.test.ts
@@ -21,24 +21,24 @@ import {
   RdpDefRef,
 } from "../../object/convertWireToOsdkObjects/InternalSymbols.js";
 import {
-  isNumericStringType,
+  isStringEncodedNumericType,
   type PropertyTypeSource,
   resolvePropertyType,
 } from "./resolvePropertyType.js";
 
-describe(isNumericStringType, () => {
+describe(isStringEncodedNumericType, () => {
   it("is true for the wire-encoded-as-string numeric types", () => {
-    expect(isNumericStringType("decimal")).toBe(true);
-    expect(isNumericStringType("long")).toBe(true);
+    expect(isStringEncodedNumericType("decimal")).toBe(true);
+    expect(isStringEncodedNumericType("long")).toBe(true);
   });
 
   it("is false for everything else", () => {
     // integer/double/float arrive as JS numbers, so they don't need this path.
-    expect(isNumericStringType("integer")).toBe(false);
-    expect(isNumericStringType("double")).toBe(false);
-    expect(isNumericStringType("string")).toBe(false);
-    expect(isNumericStringType("timestamp")).toBe(false);
-    expect(isNumericStringType(undefined)).toBe(false);
+    expect(isStringEncodedNumericType("integer")).toBe(false);
+    expect(isStringEncodedNumericType("double")).toBe(false);
+    expect(isStringEncodedNumericType("string")).toBe(false);
+    expect(isStringEncodedNumericType("timestamp")).toBe(false);
+    expect(isStringEncodedNumericType(undefined)).toBe(false);
   });
 });
 

--- a/packages/client/src/observable/internal/resolvePropertyType.ts
+++ b/packages/client/src/observable/internal/resolvePropertyType.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { InterfaceMetadata, ObjectMetadata } from "@osdk/api";
+import type { DerivedPropertyRuntimeMetadata } from "../../derivedProperties/derivedPropertyRuntimeMetadata.js";
+import { extractNamespace } from "../../internal/conversions/extractNamespace.js";
+import {
+  InterfaceDefRef,
+  ObjectDefRef,
+  RdpDefRef,
+} from "../../object/convertWireToOsdkObjects/InternalSymbols.js";
+
+/**
+ * Property types that the wire encodes as strings even though they're numbers.
+ * Comparing them with `<` / `>` sorts them lexicographically ("10" < "9"), so
+ * they need to be compared numerically instead.
+ */
+const NUMERIC_STRING_PROPERTY_TYPES: ReadonlySet<string> = new Set([
+  "decimal",
+  "long",
+]);
+
+export function isNumericStringType(type: string | undefined): boolean {
+  return type != null && NUMERIC_STRING_PROPERTY_TYPES.has(type);
+}
+
+/**
+ * Subset of a holder needed to resolve the declared type of a property. The
+ * holder symbols are optional because a holder is either an object or an
+ * interface, and only objects carry the object-level metadata.
+ */
+export interface PropertyTypeSource {
+  readonly [ObjectDefRef]?: ObjectMetadata;
+  readonly [InterfaceDefRef]?: InterfaceMetadata;
+  readonly [RdpDefRef]?: DerivedPropertyRuntimeMetadata;
+}
+
+/**
+ * Resolves the declared property type for a property key from a holder.
+ * Regular properties live in the object/interface metadata; derived
+ * (runtime-derived) properties live in the separate RDP metadata.
+ * Returns undefined when the type can't be determined (e.g. derived
+ * aggregations like avg that don't preserve a single source type).
+ */
+export function resolvePropertyType(
+  holder: PropertyTypeSource | undefined,
+  key: string,
+): string | undefined {
+  if (holder == null) {
+    return undefined;
+  }
+  const objectType = holder[ObjectDefRef]?.properties?.[key]?.type;
+  if (typeof objectType === "string") {
+    return objectType;
+  }
+  const interfaceType = resolveInterfacePropertyType(
+    holder[InterfaceDefRef],
+    key,
+  );
+  if (typeof interfaceType === "string") {
+    return interfaceType;
+  }
+  const selectedType = holder[RdpDefRef]?.[key]?.selectedOrCollectedPropertyType
+    ?.type;
+  return typeof selectedType === "string" ? selectedType : undefined;
+}
+
+/**
+ * Looks up an interface property's type by the key the interface holder exposes.
+ * The holder strips the namespace from a property whose namespace matches the
+ * interface's (createOsdkInterface), but `interfaceDef.properties` is keyed by
+ * the full wire apiName -- so a direct lookup of the stripped key misses for a
+ * namespaced interface. Re-qualify with the interface's namespace on miss so
+ * numeric comparison still engages for namespaced interface properties.
+ */
+function resolveInterfacePropertyType(
+  interfaceDef: InterfaceMetadata | undefined,
+  key: string,
+): string | undefined {
+  if (interfaceDef == null) {
+    return undefined;
+  }
+  const direct = interfaceDef.properties?.[key]?.type;
+  if (typeof direct === "string") {
+    return direct;
+  }
+  const [namespace] = extractNamespace(interfaceDef.apiName);
+  if (namespace == null) {
+    return undefined;
+  }
+  const requalified = interfaceDef.properties?.[`${namespace}.${key}`]?.type;
+  return typeof requalified === "string" ? requalified : undefined;
+}

--- a/packages/client/src/observable/internal/resolvePropertyType.ts
+++ b/packages/client/src/observable/internal/resolvePropertyType.ts
@@ -33,7 +33,7 @@ const NUMERIC_STRING_PROPERTY_TYPES: ReadonlySet<string> = new Set([
   "long",
 ]);
 
-export function isNumericStringType(type: string | undefined): boolean {
+export function isStringEncodedNumericType(type: string | undefined): boolean {
   return type != null && NUMERIC_STRING_PROPERTY_TYPES.has(type);
 }
 

--- a/packages/client/src/observable/internal/sorting/SortingStrategy.test.ts
+++ b/packages/client/src/observable/internal/sorting/SortingStrategy.test.ts
@@ -149,6 +149,26 @@ describe("createOrderBySortFns", () => {
     ]);
   });
 
+  it("sorts empty values first ascending and last descending", () => {
+    // Unlike null (always last), an empty/whitespace decimal is treated as the
+    // smallest value, so it leads ascending and trails descending -- matching
+    // what Workshop shows for a blank cell on a numeric column.
+    const holders = ["10", "", "9"].map((amount) =>
+      fakeHolder({ amount }, { propertyTypes: { amount: "decimal" } })
+    );
+
+    expect(sort({ amount: "asc" }, holders).map((h) => h.amount)).toEqual([
+      "",
+      "9",
+      "10",
+    ]);
+    expect(sort({ amount: "desc" }, holders).map((h) => h.amount)).toEqual([
+      "10",
+      "9",
+      "",
+    ]);
+  });
+
   it("sorts interface lists by a regular decimal property numerically", () => {
     const holders = ["10", "9", "100"].map((amount) =>
       fakeInterfaceHolder(amount, "decimal", "regular")

--- a/packages/client/src/observable/internal/sorting/SortingStrategy.test.ts
+++ b/packages/client/src/observable/internal/sorting/SortingStrategy.test.ts
@@ -27,136 +27,6 @@ import { InterfaceDefinitions } from "../../../ontology/OntologyProvider.js";
 import type { Canonical } from "../Canonical.js";
 import { createOrderBySortFns } from "./SortingStrategy.js";
 
-interface FakeHolderRefs {
-  /** Type of a regular property keyed by property name. */
-  propertyTypes?: Record<string, unknown>;
-  /** Type of a derived (RDP) property keyed by property name. */
-  derivedTypes?: Record<string, unknown>;
-  /** Derived properties present but without a statically-known type. */
-  derivedUntyped?: readonly string[];
-}
-
-/**
- * Builds a minimal holder that exposes only what the orderBy comparator reads:
- * the property values plus the metadata symbols used to resolve property types.
- */
-function fakeHolder(
-  values: Record<string, unknown>,
-  refs: FakeHolderRefs = {},
-): ObjectHolder {
-  const holder: { [k: string]: unknown } & {
-    [ObjectDefRef]?: unknown;
-    [RdpDefRef]?: unknown;
-  } = { ...values };
-
-  if (refs.propertyTypes != null) {
-    holder[ObjectDefRef] = {
-      properties: Object.fromEntries(
-        Object.entries(refs.propertyTypes).map((
-          [name, type],
-        ) => [name, { type }]),
-      ),
-    };
-  }
-
-  if (refs.derivedTypes != null || refs.derivedUntyped != null) {
-    const rdp: Record<string, unknown> = {};
-    for (const [name, type] of Object.entries(refs.derivedTypes ?? {})) {
-      rdp[name] = { selectedOrCollectedPropertyType: { type } };
-    }
-    for (const name of refs.derivedUntyped ?? []) {
-      rdp[name] = { selectedOrCollectedPropertyType: undefined };
-    }
-    holder[RdpDefRef] = rdp;
-  }
-
-  return holder as ObjectHolder;
-}
-
-/**
- * Builds a real interface holder (via createOsdkInterface) over an underlying
- * object with a single `amount` property, so the comparator is exercised
- * against the actual interface view -- including the namespace-stripped keys
- * and the derived-property metadata it now carries.
- *
- * For "regular" the property lives in the interface metadata; for "derived" it
- * lives only in the RDP metadata (as a runtime-derived property would).
- */
-function fakeInterfaceHolder(
-  amount: unknown,
-  type: string,
-  kind: "regular" | "derived",
-  interfaceApiName: string = "IFoo",
-): InterfaceHolder {
-  // A namespaced interface property's full apiName carries the interface's
-  // namespace; the interface view exposes it under the stripped "amount".
-  const [namespace] = extractNamespace(interfaceApiName);
-  const ifaceProp = namespace != null ? `${namespace}.amount` : "amount";
-
-  const underlying: Record<string | symbol, unknown> = {
-    amount,
-    [ObjectDefRef]: {
-      [InterfaceDefinitions]: {},
-      apiName: "Obj",
-      displayName: "",
-      interfaceMap: {
-        [interfaceApiName]: kind === "regular" ? { [ifaceProp]: "amount" } : {},
-      },
-      inverseInterfaceMap: {},
-      links: {},
-      pluralDisplayName: "",
-      primaryKeyApiName: "id",
-      primaryKeyType: "string",
-      properties: { "amount": { type } },
-      type: "object",
-      titleProperty: "amount",
-      rid: "",
-      status: "ACTIVE",
-      icon: undefined,
-      visibility: undefined,
-      description: undefined,
-    },
-  };
-
-  if (kind === "derived") {
-    underlying[RdpDefRef] = {
-      "amount": {
-        selectedOrCollectedPropertyType: { type },
-        definition: { type: "selection" },
-      },
-    };
-  }
-
-  return createOsdkInterface(underlying as any, {
-    "apiName": interfaceApiName,
-    displayName: "",
-    links: {},
-    properties: kind === "regular" ? { [ifaceProp]: { type } } : {},
-    rid: "",
-    type: "interface",
-    implements: [],
-    description: undefined,
-  });
-}
-
-function sort(
-  orderBy: Record<string, "asc" | "desc">,
-  holders: Array<ObjectHolder | InterfaceHolder>,
-): Array<ObjectHolder | InterfaceHolder> {
-  const sortFns = createOrderBySortFns(
-    orderBy as Canonical<Record<string, "asc" | "desc" | undefined>>,
-  );
-  return [...holders].sort((a, b) => {
-    for (const fn of sortFns) {
-      const ret = fn(a, b);
-      if (ret !== 0) {
-        return ret;
-      }
-    }
-    return 0;
-  });
-}
-
 describe("createOrderBySortFns", () => {
   it("sorts decimal properties numerically, not lexicographically", () => {
     const holders = ["10", "9", "100", "2"].map((amount) =>
@@ -320,3 +190,133 @@ describe("createOrderBySortFns", () => {
     ]);
   });
 });
+
+interface FakeHolderRefs {
+  /** Type of a regular property keyed by property name. */
+  propertyTypes?: Record<string, unknown>;
+  /** Type of a derived (RDP) property keyed by property name. */
+  derivedTypes?: Record<string, unknown>;
+  /** Derived properties present but without a statically-known type. */
+  derivedUntyped?: readonly string[];
+}
+
+/**
+ * Builds a minimal holder that exposes only what the orderBy comparator reads:
+ * the property values plus the metadata symbols used to resolve property types.
+ */
+function fakeHolder(
+  values: Record<string, unknown>,
+  refs: FakeHolderRefs = {},
+): ObjectHolder {
+  const holder: { [k: string]: unknown } & {
+    [ObjectDefRef]?: unknown;
+    [RdpDefRef]?: unknown;
+  } = { ...values };
+
+  if (refs.propertyTypes != null) {
+    holder[ObjectDefRef] = {
+      properties: Object.fromEntries(
+        Object.entries(refs.propertyTypes).map((
+          [name, type],
+        ) => [name, { type }]),
+      ),
+    };
+  }
+
+  if (refs.derivedTypes != null || refs.derivedUntyped != null) {
+    const rdp: Record<string, unknown> = {};
+    for (const [name, type] of Object.entries(refs.derivedTypes ?? {})) {
+      rdp[name] = { selectedOrCollectedPropertyType: { type } };
+    }
+    for (const name of refs.derivedUntyped ?? []) {
+      rdp[name] = { selectedOrCollectedPropertyType: undefined };
+    }
+    holder[RdpDefRef] = rdp;
+  }
+
+  return holder as ObjectHolder;
+}
+
+/**
+ * Builds a real interface holder (via createOsdkInterface) over an underlying
+ * object with a single `amount` property, so the comparator is exercised
+ * against the actual interface view -- including the namespace-stripped keys
+ * and the derived-property metadata it now carries.
+ *
+ * For "regular" the property lives in the interface metadata; for "derived" it
+ * lives only in the RDP metadata (as a runtime-derived property would).
+ */
+function fakeInterfaceHolder(
+  amount: unknown,
+  type: string,
+  kind: "regular" | "derived",
+  interfaceApiName: string = "IFoo",
+): InterfaceHolder {
+  // A namespaced interface property's full apiName carries the interface's
+  // namespace; the interface view exposes it under the stripped "amount".
+  const [namespace] = extractNamespace(interfaceApiName);
+  const ifaceProp = namespace != null ? `${namespace}.amount` : "amount";
+
+  const underlying: Record<string | symbol, unknown> = {
+    amount,
+    [ObjectDefRef]: {
+      [InterfaceDefinitions]: {},
+      apiName: "Obj",
+      displayName: "",
+      interfaceMap: {
+        [interfaceApiName]: kind === "regular" ? { [ifaceProp]: "amount" } : {},
+      },
+      inverseInterfaceMap: {},
+      links: {},
+      pluralDisplayName: "",
+      primaryKeyApiName: "id",
+      primaryKeyType: "string",
+      properties: { "amount": { type } },
+      type: "object",
+      titleProperty: "amount",
+      rid: "",
+      status: "ACTIVE",
+      icon: undefined,
+      visibility: undefined,
+      description: undefined,
+    },
+  };
+
+  if (kind === "derived") {
+    underlying[RdpDefRef] = {
+      "amount": {
+        selectedOrCollectedPropertyType: { type },
+        definition: { type: "selection" },
+      },
+    };
+  }
+
+  return createOsdkInterface(underlying as any, {
+    "apiName": interfaceApiName,
+    displayName: "",
+    links: {},
+    properties: kind === "regular" ? { [ifaceProp]: { type } } : {},
+    rid: "",
+    type: "interface",
+    implements: [],
+    description: undefined,
+  });
+}
+
+function sort(
+  orderBy: Record<string, "asc" | "desc">,
+  holders: Array<ObjectHolder | InterfaceHolder>,
+): Array<ObjectHolder | InterfaceHolder> {
+  const sortFns = createOrderBySortFns(
+    orderBy as Canonical<Record<string, "asc" | "desc" | undefined>>,
+  );
+  return [...holders].sort((a, b) => {
+    for (const fn of sortFns) {
+      const ret = fn(a, b);
+      if (ret !== 0) {
+        return ret;
+      }
+    }
+    return 0;
+  });
+}

--- a/packages/client/src/observable/internal/sorting/SortingStrategy.test.ts
+++ b/packages/client/src/observable/internal/sorting/SortingStrategy.test.ts
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { extractNamespace } from "../../../internal/conversions/extractNamespace.js";
+import { createOsdkInterface } from "../../../object/convertWireToOsdkObjects/createOsdkInterface.js";
+import type { InterfaceHolder } from "../../../object/convertWireToOsdkObjects/InterfaceHolder.js";
+import {
+  ObjectDefRef,
+  RdpDefRef,
+} from "../../../object/convertWireToOsdkObjects/InternalSymbols.js";
+import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
+import { InterfaceDefinitions } from "../../../ontology/OntologyProvider.js";
+import type { Canonical } from "../Canonical.js";
+import { createOrderBySortFns } from "./SortingStrategy.js";
+
+interface FakeHolderRefs {
+  /** Type of a regular property keyed by property name. */
+  propertyTypes?: Record<string, unknown>;
+  /** Type of a derived (RDP) property keyed by property name. */
+  derivedTypes?: Record<string, unknown>;
+  /** Derived properties present but without a statically-known type. */
+  derivedUntyped?: readonly string[];
+}
+
+/**
+ * Builds a minimal holder that exposes only what the orderBy comparator reads:
+ * the property values plus the metadata symbols used to resolve property types.
+ */
+function fakeHolder(
+  values: Record<string, unknown>,
+  refs: FakeHolderRefs = {},
+): ObjectHolder {
+  const holder: { [k: string]: unknown } & {
+    [ObjectDefRef]?: unknown;
+    [RdpDefRef]?: unknown;
+  } = { ...values };
+
+  if (refs.propertyTypes != null) {
+    holder[ObjectDefRef] = {
+      properties: Object.fromEntries(
+        Object.entries(refs.propertyTypes).map((
+          [name, type],
+        ) => [name, { type }]),
+      ),
+    };
+  }
+
+  if (refs.derivedTypes != null || refs.derivedUntyped != null) {
+    const rdp: Record<string, unknown> = {};
+    for (const [name, type] of Object.entries(refs.derivedTypes ?? {})) {
+      rdp[name] = { selectedOrCollectedPropertyType: { type } };
+    }
+    for (const name of refs.derivedUntyped ?? []) {
+      rdp[name] = { selectedOrCollectedPropertyType: undefined };
+    }
+    holder[RdpDefRef] = rdp;
+  }
+
+  return holder as ObjectHolder;
+}
+
+/**
+ * Builds a real interface holder (via createOsdkInterface) over an underlying
+ * object with a single `amount` property, so the comparator is exercised
+ * against the actual interface view -- including the namespace-stripped keys
+ * and the derived-property metadata it now carries.
+ *
+ * For "regular" the property lives in the interface metadata; for "derived" it
+ * lives only in the RDP metadata (as a runtime-derived property would).
+ */
+function fakeInterfaceHolder(
+  amount: unknown,
+  type: string,
+  kind: "regular" | "derived",
+  interfaceApiName: string = "IFoo",
+): InterfaceHolder {
+  // A namespaced interface property's full apiName carries the interface's
+  // namespace; the interface view exposes it under the stripped "amount".
+  const [namespace] = extractNamespace(interfaceApiName);
+  const ifaceProp = namespace != null ? `${namespace}.amount` : "amount";
+
+  const underlying: Record<string | symbol, unknown> = {
+    amount,
+    [ObjectDefRef]: {
+      [InterfaceDefinitions]: {},
+      apiName: "Obj",
+      displayName: "",
+      interfaceMap: {
+        [interfaceApiName]: kind === "regular" ? { [ifaceProp]: "amount" } : {},
+      },
+      inverseInterfaceMap: {},
+      links: {},
+      pluralDisplayName: "",
+      primaryKeyApiName: "id",
+      primaryKeyType: "string",
+      properties: { "amount": { type } },
+      type: "object",
+      titleProperty: "amount",
+      rid: "",
+      status: "ACTIVE",
+      icon: undefined,
+      visibility: undefined,
+      description: undefined,
+    },
+  };
+
+  if (kind === "derived") {
+    underlying[RdpDefRef] = {
+      "amount": {
+        selectedOrCollectedPropertyType: { type },
+        definition: { type: "selection" },
+      },
+    };
+  }
+
+  return createOsdkInterface(underlying as any, {
+    "apiName": interfaceApiName,
+    displayName: "",
+    links: {},
+    properties: kind === "regular" ? { [ifaceProp]: { type } } : {},
+    rid: "",
+    type: "interface",
+    implements: [],
+    description: undefined,
+  });
+}
+
+function sort(
+  orderBy: Record<string, "asc" | "desc">,
+  holders: Array<ObjectHolder | InterfaceHolder>,
+): Array<ObjectHolder | InterfaceHolder> {
+  const sortFns = createOrderBySortFns(
+    orderBy as Canonical<Record<string, "asc" | "desc" | undefined>>,
+  );
+  return [...holders].sort((a, b) => {
+    for (const fn of sortFns) {
+      const ret = fn(a, b);
+      if (ret !== 0) {
+        return ret;
+      }
+    }
+    return 0;
+  });
+}
+
+describe("createOrderBySortFns", () => {
+  it("sorts decimal properties numerically, not lexicographically", () => {
+    const holders = ["10", "9", "100", "2"].map((amount) =>
+      fakeHolder({ amount }, { propertyTypes: { amount: "decimal" } })
+    );
+
+    expect(sort({ amount: "asc" }, holders).map((h) => h.amount)).toEqual([
+      "2",
+      "9",
+      "10",
+      "100",
+    ]);
+    expect(sort({ amount: "desc" }, holders).map((h) => h.amount)).toEqual([
+      "100",
+      "10",
+      "9",
+      "2",
+    ]);
+  });
+
+  it("sorts long properties numerically", () => {
+    // The value-level precision/edge cases live in compareNumericStrings.test;
+    // here we just assert the `long` type routes through numeric comparison.
+    const holders = ["10", "9", "100"].map((id) =>
+      fakeHolder({ id }, { propertyTypes: { id: "long" } })
+    );
+
+    expect(sort({ id: "asc" }, holders).map((h) => h.id)).toEqual([
+      "9",
+      "10",
+      "100",
+    ]);
+    expect(sort({ id: "desc" }, holders).map((h) => h.id)).toEqual([
+      "100",
+      "10",
+      "9",
+    ]);
+  });
+
+  it("keeps real string properties lexicographic", () => {
+    const holders = ["10", "9", "100"].map((name) =>
+      fakeHolder({ name }, { propertyTypes: { name: "string" } })
+    );
+
+    expect(sort({ name: "asc" }, holders).map((h) => h.name)).toEqual([
+      "10",
+      "100",
+      "9",
+    ]);
+  });
+
+  it("sorts derived decimal properties numerically", () => {
+    const holders = ["10", "9", "100"].map((total) =>
+      fakeHolder({ total }, { derivedTypes: { total: "decimal" } })
+    );
+
+    expect(sort({ total: "asc" }, holders).map((h) => h.total)).toEqual([
+      "9",
+      "10",
+      "100",
+    ]);
+  });
+
+  it("sorts untyped derived properties lexicographically and deterministically", () => {
+    // A derived property whose type can't be resolved (no metadata) is NOT
+    // guessed-as-numeric from its values: numeric comparison engages only when
+    // the property type is known to be decimal/long. So an untyped string-valued
+    // derived property stays lexicographic ("10" sorts before "9") regardless of
+    // the other values on the page -- a single, page-independent total order.
+    const numericOnly = ["10", "9", "100"].map((agg) =>
+      fakeHolder({ agg }, { derivedUntyped: ["agg"] })
+    );
+    expect(sort({ agg: "asc" }, numericOnly).map((h) => h.agg)).toEqual([
+      "10",
+      "100",
+      "9",
+    ]);
+
+    // Adding a non-numeric sibling does not change the relative order of "10"
+    // and "9" -- the ordering is stable under the contents of the page.
+    const withNonNumeric = ["10", "9", "x"].map((agg) =>
+      fakeHolder({ agg }, { derivedUntyped: ["agg"] })
+    );
+    expect(sort({ agg: "asc" }, withNonNumeric).map((h) => h.agg)).toEqual([
+      "10",
+      "9",
+      "x",
+    ]);
+  });
+
+  it("sorts numbers numerically", () => {
+    const holders = [10, 9, 100, 2].map((value) =>
+      fakeHolder({ value }, { propertyTypes: { value: "integer" } })
+    );
+
+    expect(sort({ value: "asc" }, holders).map((h) => h.value)).toEqual([
+      2,
+      9,
+      10,
+      100,
+    ]);
+  });
+
+  it("sorts nulls last regardless of direction", () => {
+    const holders = [
+      fakeHolder({ amount: "5" }, { propertyTypes: { amount: "decimal" } }),
+      fakeHolder({ amount: null }, { propertyTypes: { amount: "decimal" } }),
+      fakeHolder({ amount: "10" }, { propertyTypes: { amount: "decimal" } }),
+    ];
+
+    expect(sort({ amount: "asc" }, holders).map((h) => h.amount)).toEqual([
+      "5",
+      "10",
+      null,
+    ]);
+    expect(sort({ amount: "desc" }, holders).map((h) => h.amount)).toEqual([
+      "10",
+      "5",
+      null,
+    ]);
+  });
+
+  it("sorts interface lists by a regular decimal property numerically", () => {
+    const holders = ["10", "9", "100"].map((amount) =>
+      fakeInterfaceHolder(amount, "decimal", "regular")
+    );
+
+    expect(sort({ amount: "asc" }, holders).map((h) => h.amount)).toEqual([
+      "9",
+      "10",
+      "100",
+    ]);
+  });
+
+  it("sorts interface lists by a derived decimal property numerically", () => {
+    // Derived properties used to be dropped entirely from the interface view;
+    // now their value and type metadata are carried, so they sort numerically.
+    const holders = ["10", "9", "100"].map((amount) =>
+      fakeInterfaceHolder(amount, "decimal", "derived")
+    );
+
+    expect(sort({ amount: "asc" }, holders).map((h) => h.amount)).toEqual([
+      "9",
+      "10",
+      "100",
+    ]);
+  });
+
+  it("sorts namespaced interface decimal properties numerically", () => {
+    // The interface view exposes "a.amount" under the stripped key "amount"
+    // while interfaceDef.properties is keyed "a.amount"; type resolution must
+    // re-qualify so numeric (not lexicographic) comparison still engages.
+    const holders = ["10", "9", "100"].map((amount) =>
+      fakeInterfaceHolder(amount, "decimal", "regular", "a.IFoo")
+    );
+
+    expect(sort({ amount: "asc" }, holders).map((h) => h.amount)).toEqual([
+      "9",
+      "10",
+      "100",
+    ]);
+  });
+});

--- a/packages/client/src/observable/internal/sorting/SortingStrategy.ts
+++ b/packages/client/src/observable/internal/sorting/SortingStrategy.ts
@@ -22,7 +22,7 @@ import { compareNumericStrings } from "../compareNumericStrings.js";
 import type { ObjectCacheKey } from "../object/ObjectCacheKey.js";
 import { PK_IDX } from "../object/ObjectCacheKey.js";
 import {
-  isNumericStringType,
+  isStringEncodedNumericType,
   resolvePropertyType,
 } from "../resolvePropertyType.js";
 
@@ -136,7 +136,7 @@ export function createOrderBySortFns(
       if (typeof aValue === "string" && typeof bValue === "string") {
         const propertyType = resolvePropertyType(a, key)
           ?? resolvePropertyType(b, key);
-        if (isNumericStringType(propertyType)) {
+        if (isStringEncodedNumericType(propertyType)) {
           return -m * compareNumericStrings(aValue, bValue);
         }
       }

--- a/packages/client/src/observable/internal/sorting/SortingStrategy.ts
+++ b/packages/client/src/observable/internal/sorting/SortingStrategy.ts
@@ -18,8 +18,13 @@ import type { InterfaceHolder } from "../../../object/convertWireToOsdkObjects/I
 import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
 import type { BatchContext } from "../BatchContext.js";
 import type { Canonical } from "../Canonical.js";
+import { compareNumericStrings } from "../compareNumericStrings.js";
 import type { ObjectCacheKey } from "../object/ObjectCacheKey.js";
 import { PK_IDX } from "../object/ObjectCacheKey.js";
+import {
+  isNumericStringType,
+  resolvePropertyType,
+} from "../resolvePropertyType.js";
 
 /**
  * Strategy interface for collection sorting
@@ -113,13 +118,29 @@ export function createOrderBySortFns(
       if (aValue == null && bValue == null) {
         return 0;
       }
+      // Nulls always sort last, regardless of direction.
       if (aValue == null) {
         return 1;
       }
       if (bValue == null) {
         return -1;
       }
+
       const m = order === "asc" ? -1 : 1;
+
+      // decimal/long are wire-encoded as strings; comparing them with `<` / `>`
+      // sorts them lexicographically ("10" < "9"), so compare them numerically
+      // when the property type says they're numbers. Types that aren't
+      // numeric-string-encoded (real strings, dates, etc.) keep the
+      // lexicographic comparison, which is correct for them.
+      if (typeof aValue === "string" && typeof bValue === "string") {
+        const propertyType = resolvePropertyType(a, key)
+          ?? resolvePropertyType(b, key);
+        if (isNumericStringType(propertyType)) {
+          return -m * compareNumericStrings(aValue, bValue);
+        }
+      }
+
       return aValue < bValue ? m : aValue > bValue ? -m : 0;
     };
   });

--- a/packages/client/src/observable/internal/sorting/SortingStrategy.ts
+++ b/packages/client/src/observable/internal/sorting/SortingStrategy.ts
@@ -108,6 +108,10 @@ export function createOrderBySortFns(
   orderBy: Canonical<Record<string, "asc" | "desc" | undefined>>,
 ): ObjectInterfaceComparer[] {
   return Object.entries(orderBy).map(([key, order]) => {
+    // The declared property type is invariant across the whole sort, so resolve
+    // it once on the first string pair and cache it rather than re-resolving on
+    // every comparison.
+    let isNumeric: boolean | undefined;
     return (
       a: ObjectHolder | InterfaceHolder | undefined,
       b: ObjectHolder | InterfaceHolder | undefined,
@@ -134,9 +138,10 @@ export function createOrderBySortFns(
       // numeric-string-encoded (real strings, dates, etc.) keep the
       // lexicographic comparison, which is correct for them.
       if (typeof aValue === "string" && typeof bValue === "string") {
-        const propertyType = resolvePropertyType(a, key)
-          ?? resolvePropertyType(b, key);
-        if (isStringEncodedNumericType(propertyType)) {
+        isNumeric ??= isStringEncodedNumericType(
+          resolvePropertyType(a, key) ?? resolvePropertyType(b, key),
+        );
+        if (isNumeric) {
           return -m * compareNumericStrings(aValue, bValue);
         }
       }

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
@@ -14,12 +14,15 @@
  * limitations under the License.
  */
 
+import type { DerivedPropertyDefinition } from "@osdk/foundry.ontologies";
 import { describe, expect, it } from "vitest";
+import type { DerivedPropertyRuntimeMetadata } from "../../../derivedProperties/derivedPropertyRuntimeMetadata.js";
 import type { MinimalClient } from "../../../MinimalClientContext.js";
 import { createOsdkObject } from "../../../object/convertWireToOsdkObjects/createOsdkObject.js";
 import {
   ClientRef,
   ObjectDefRef,
+  RdpDefRef,
   UnderlyingOsdkObject,
 } from "../../../object/convertWireToOsdkObjects/InternalSymbols.js";
 import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
@@ -75,6 +78,43 @@ function createTestObject(
     ...defaultProps,
     ...props,
   });
+}
+
+function buildRdpMeta(
+  types: Record<string, string>,
+): DerivedPropertyRuntimeMetadata {
+  const meta: DerivedPropertyRuntimeMetadata = {};
+  for (const [key, type] of Object.entries(types)) {
+    meta[key] = {
+      // resolvePropertyType only reads selectedOrCollectedPropertyType.type;
+      // the definition needs just enough shape for createOsdkObject's RDP
+      // deserialization (it inspects definition.operation.type).
+      definition: {
+        type: "selection",
+        operation: { type: "get" },
+      } as DerivedPropertyDefinition,
+      selectedOrCollectedPropertyType: { type },
+    };
+  }
+  return meta;
+}
+
+function createTestObjectWithRdp(
+  props: Partial<SimpleOsdkProperties>,
+  rdpTypes: Record<string, string>,
+): ObjectHolder {
+  const defaultProps: SimpleOsdkProperties = {
+    $apiName: "Employee",
+    $objectType: "Employee",
+    $primaryKey: 50030,
+    $title: "John Doe",
+  };
+  return createOsdkObject(
+    mockClient,
+    employeeObjectDef,
+    { ...defaultProps, ...props },
+    buildRdpMeta(rdpTypes),
+  );
 }
 
 function assertValidObjectHolder(obj: ObjectHolder): void {
@@ -319,5 +359,84 @@ describe("mergeSelectFields", () => {
     expect(underlying.office).toBe("SF");
     expect(underlying.rdpField1).toBe("existing-rdp");
     expect(underlying.employeeId).toBe(50030);
+  });
+
+  it("preserves RDP type metadata from both holders", () => {
+    const source = createTestObjectWithRdp(
+      { employeeId: 50030, rdpField1: "10" },
+      { rdpField1: "decimal" },
+    );
+    const existing = createTestObjectWithRdp(
+      { employeeId: 50030, rdpField2: "9007199254740993" },
+      { rdpField2: "long" },
+    );
+
+    const result = mergeSelectFields(source, new Set(["rdpField1"]), existing);
+
+    expect(result[RdpDefRef].rdpField1?.selectedOrCollectedPropertyType?.type)
+      .toBe("decimal");
+    expect(result[RdpDefRef].rdpField2?.selectedOrCollectedPropertyType?.type)
+      .toBe("long");
+  });
+});
+
+describe("rdpFieldOperations RDP metadata preservation", () => {
+  it("preserves metadata when stripping rdp fields", () => {
+    const source = createTestObjectWithRdp(
+      { employeeId: 50030, rdpField1: "10" },
+      { rdpField1: "decimal" },
+    );
+
+    // targetRdpFields empty -> stripRdpFields path
+    const result = mergeObjectFields(
+      source,
+      new Set(["rdpField1"]),
+      new Set(),
+      undefined,
+    );
+
+    expect(result[RdpDefRef].rdpField1?.selectedOrCollectedPropertyType?.type)
+      .toBe("decimal");
+  });
+
+  it("preserves metadata when filtering to a subset of rdp fields", () => {
+    const source = createTestObjectWithRdp(
+      { employeeId: 50030, rdpField1: "10", rdpField2: "20" },
+      { rdpField1: "decimal", rdpField2: "long" },
+    );
+
+    // source is a strict superset of target -> filterToRdpFields path
+    const result = mergeObjectFields(
+      source,
+      new Set(["rdpField1", "rdpField2"]),
+      new Set(["rdpField1"]),
+      undefined,
+    );
+
+    expect(result[RdpDefRef].rdpField1?.selectedOrCollectedPropertyType?.type)
+      .toBe("decimal");
+  });
+
+  it("preserves metadata from source and target on the full merge path", () => {
+    const source = createTestObjectWithRdp(
+      { employeeId: 50030, rdpField1: "10" },
+      { rdpField1: "decimal" },
+    );
+    const target = createTestObjectWithRdp(
+      { employeeId: 50030, rdpField2: "9007199254740993" },
+      { rdpField2: "long" },
+    );
+
+    const result = mergeObjectFields(
+      source,
+      new Set(["rdpField1"]),
+      new Set(["rdpField1", "rdpField2"]),
+      target,
+    );
+
+    expect(result[RdpDefRef].rdpField1?.selectedOrCollectedPropertyType?.type)
+      .toBe("decimal");
+    expect(result[RdpDefRef].rdpField2?.selectedOrCollectedPropertyType?.type)
+      .toBe("long");
   });
 });

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
@@ -18,6 +18,7 @@ import { createOsdkObject } from "../../../object/convertWireToOsdkObjects/creat
 import {
   ClientRef,
   ObjectDefRef,
+  RdpDefRef,
   UnderlyingOsdkObject,
 } from "../../../object/convertWireToOsdkObjects/InternalSymbols.js";
 import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
@@ -84,7 +85,15 @@ function stripRdpFields(
     }
   }
 
-  return createOsdkObject(value[ClientRef], objectDef, newProps);
+  // Forward the RDP type metadata so derived numeric (decimal/long) fields keep
+  // sorting/filtering numerically after a rebuild; entries for stripped fields
+  // are harmless since resolvePropertyType only reads keys present on the holder.
+  return createOsdkObject(
+    value[ClientRef],
+    objectDef,
+    newProps,
+    value[RdpDefRef],
+  );
 }
 
 function isSuperset(
@@ -124,7 +133,12 @@ function filterToRdpFields(
     }
   }
 
-  return createOsdkObject(value[ClientRef], objectDef, newProps);
+  return createOsdkObject(
+    value[ClientRef],
+    objectDef,
+    newProps,
+    value[RdpDefRef],
+  );
 }
 
 export function mergeSelectFields(
@@ -161,7 +175,13 @@ export function mergeSelectFields(
     }
   }
 
-  return createOsdkObject(sourceValue[ClientRef], objectDef, newProps);
+  // RDP fields can come from either holder, so merge both sets of metadata.
+  return createOsdkObject(
+    sourceValue[ClientRef],
+    objectDef,
+    newProps,
+    { ...existingValue[RdpDefRef], ...sourceValue[RdpDefRef] },
+  );
 }
 
 export function mergeObjectFields(
@@ -223,9 +243,11 @@ export function mergeObjectFields(
     }
   }
 
+  // Target supplies the preserved RDP fields, so merge its metadata too.
   return createOsdkObject(
     sourceValue[ClientRef],
     objectDef,
     newProps,
+    { ...targetCurrentValue?.[RdpDefRef], ...sourceValue[RdpDefRef] },
   );
 }

--- a/packages/client/src/util/extractRdpDefinition.test.ts
+++ b/packages/client/src/util/extractRdpDefinition.test.ts
@@ -165,38 +165,6 @@ describe("extractRdpDefinition", () => {
     });
   });
 
-  it("does not capture a source type for sum aggregations (returns double)", async () => {
-    const objectSetWithSum: ObjectSet = {
-      type: "withProperties",
-      objectSet: {
-        type: "searchAround",
-        objectSet: { type: "base", objectType: "BaseType" },
-        link: "testLink1",
-      },
-      derivedProperties: {
-        totalAmount: {
-          type: "selection",
-          objectSet: {
-            type: "searchAround",
-            objectSet: { type: "methodInput" },
-            link: "testLink2",
-          },
-          operation: {
-            type: "sum",
-            selectedPropertyApiName: "decimalProperty",
-          },
-        },
-      },
-    };
-
-    const result = await extractRdpDefinition(mockClientCtx, objectSetWithSum);
-
-    // The API contract types sum (like avg) as double, not as the source
-    // property's type, so we leave it untyped -- it's a JS number, compared
-    // natively rather than as a numeric string.
-    expect(result.totalAmount.selectedOrCollectedPropertyType).toBeUndefined();
-  });
-
   it("combines definitions from multiple derived properties", async () => {
     const nestedObjectSet: ObjectSet = {
       type: "withProperties",

--- a/packages/client/src/util/extractRdpDefinition.test.ts
+++ b/packages/client/src/util/extractRdpDefinition.test.ts
@@ -48,6 +48,9 @@ describe("extractRdpDefinition", () => {
               testProperty: {
                 type: "attachment",
               } satisfies ObjectMetadata.Property,
+              decimalProperty: {
+                type: "decimal",
+              } satisfies ObjectMetadata.Property,
             },
           };
         } else {
@@ -108,6 +111,90 @@ describe("extractRdpDefinition", () => {
       }
     `,
     );
+  });
+
+  it("captures the source property type for min/max aggregations", async () => {
+    const objectSetWithMinMax: ObjectSet = {
+      type: "withProperties",
+      objectSet: {
+        type: "searchAround",
+        objectSet: { type: "base", objectType: "BaseType" },
+        link: "testLink1",
+      },
+      derivedProperties: {
+        maxAmount: {
+          type: "selection",
+          objectSet: {
+            type: "searchAround",
+            objectSet: { type: "methodInput" },
+            link: "testLink2",
+          },
+          operation: {
+            type: "max",
+            selectedPropertyApiName: "decimalProperty",
+          },
+        },
+        minAmount: {
+          type: "selection",
+          objectSet: {
+            type: "searchAround",
+            objectSet: { type: "methodInput" },
+            link: "testLink2",
+          },
+          operation: {
+            type: "min",
+            selectedPropertyApiName: "decimalProperty",
+          },
+        },
+      },
+    };
+
+    const result = await extractRdpDefinition(
+      mockClientCtx,
+      objectSetWithMinMax,
+    );
+
+    // min/max preserve the aggregated property's type, so the type is captured
+    // exactly (rather than left undefined and guessed from the value at sort
+    // time).
+    expect(result.maxAmount.selectedOrCollectedPropertyType).toEqual({
+      type: "decimal",
+    });
+    expect(result.minAmount.selectedOrCollectedPropertyType).toEqual({
+      type: "decimal",
+    });
+  });
+
+  it("does not capture a source type for sum aggregations (returns double)", async () => {
+    const objectSetWithSum: ObjectSet = {
+      type: "withProperties",
+      objectSet: {
+        type: "searchAround",
+        objectSet: { type: "base", objectType: "BaseType" },
+        link: "testLink1",
+      },
+      derivedProperties: {
+        totalAmount: {
+          type: "selection",
+          objectSet: {
+            type: "searchAround",
+            objectSet: { type: "methodInput" },
+            link: "testLink2",
+          },
+          operation: {
+            type: "sum",
+            selectedPropertyApiName: "decimalProperty",
+          },
+        },
+      },
+    };
+
+    const result = await extractRdpDefinition(mockClientCtx, objectSetWithSum);
+
+    // The API contract types sum (like avg) as double, not as the source
+    // property's type, so we leave it untyped -- it's a JS number, compared
+    // natively rather than as a numeric string.
+    expect(result.totalAmount.selectedOrCollectedPropertyType).toBeUndefined();
   });
 
   it("combines definitions from multiple derived properties", async () => {

--- a/packages/client/src/util/extractRdpDefinition.ts
+++ b/packages/client/src/util/extractRdpDefinition.ts
@@ -110,6 +110,14 @@ async function extractRdpDefinitionInternal(
           case "collectList":
           case "collectSet":
           case "get":
+          // get/collect/min/max preserve the aggregated property's numeric type
+          // (e.g. min of a decimal is a decimal, which is wire-encoded as a
+          // string), so capture it -- sorting/filtering relies on it to compare
+          // numerically. sum/avg/distinct/count don't preserve the type (the API
+          // contract types them as double/integer, returned as JS numbers), so
+          // they fall through and are left untyped.
+          case "min":
+          case "max":
             // This is the object set construction for the derived property definition construction. We pass in childObjectType so that when we reach MethodInputObjectSet, we know where to start looking.
             const { childObjectType: operationLevelObjectType } =
               await extractRdpDefinitionInternal(

--- a/packages/e2e.sandbox.peopleapp/ontology.json
+++ b/packages/e2e.sandbox.peopleapp/ontology.json
@@ -365,6 +365,18 @@
               "type": "experimental"
             },
             "visibility": "NORMAL"
+          },
+          "stockOptions": {
+            "displayName": "Stock Options",
+            "dataType": {
+              "type": "long"
+            },
+            "rid": "ri.ontology.main.property.cd208b3b-1f94-45ba-b894-f24167e03718",
+            "status": {
+              "type": "experimental"
+            },
+            "visibility": "NORMAL",
+            "typeClasses": []
           }
         },
         "rid": "ri.ontology.main.object-type.ade16a88-ecc4-4f96-9751-ca1799247d64",
@@ -583,6 +595,14 @@
             "type": "string"
           },
           "required": false
+        },
+        "stockOptions": {
+          "displayName": "Stock Options",
+          "dataType": {
+            "type": "long"
+          },
+          "required": false,
+          "typeClasses": []
         }
       },
       "rid": "ri.actions.main.action-type.1e59bc2b-4f3a-47d1-82d2-7d0516c7c4ee",

--- a/packages/e2e.sandbox.peopleapp/src/app/employees/EmployeesTable.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/employees/EmployeesTable.tsx
@@ -21,6 +21,7 @@ import { DownloadEmployeesButton } from "./DownloadEmployeesButton.js";
 
 type RDPs = {
   managerName: "string";
+  leadStockOptions: "long";
 };
 
 type FunctionColumns = {
@@ -28,11 +29,7 @@ type FunctionColumns = {
 };
 
 const columnDefinitions: Array<
-  ColumnDefinition<
-    Employee,
-    RDPs,
-    FunctionColumns
-  >
+  ColumnDefinition<Employee, RDPs, FunctionColumns>
 > = [
   {
     locator: {
@@ -70,6 +67,21 @@ const columnDefinitions: Array<
   },
   {
     locator: { type: "property", id: "jobTitle" },
+  },
+  // Base long property — longs arrive as strings; sorting must be numeric.
+  {
+    locator: { type: "property", id: "stockOptions" },
+    columnName: "Stock Options",
+  },
+  // Derived long property (the reported scenario): the lead's stock options.
+  {
+    locator: {
+      type: "rdp",
+      id: "leadStockOptions",
+      creator: (baseObjectSet: DerivedProperty.Builder<Employee, false>) =>
+        baseObjectSet.pivotTo("lead").selectProperty("stockOptions"),
+    },
+    columnName: "Lead Stock Options (derived)",
   },
   {
     locator: { type: "property", id: "firstFullTimeStartDate" },
@@ -146,13 +158,10 @@ function ThemeToggle(): React.ReactElement {
 }
 
 export function EmployeesTable(): React.ReactElement {
-  const handleSubmitEdits = useCallback(
-    async () => {
-      alert(`Submitting edits...`);
-      return true;
-    },
-    [],
-  );
+  const handleSubmitEdits = useCallback(async () => {
+    alert(`Submitting edits...`);
+    return true;
+  }, []);
 
   const client = useOsdkClient();
 
@@ -184,10 +193,16 @@ export function EmployeesTable(): React.ReactElement {
             objectType={Employee}
             columnDefinitions={columnDefinitions}
             selectionMode={"multiple"}
-            defaultOrderBy={[{
-              property: "firstFullTimeStartDate",
-              direction: "desc",
-            }]}
+            defaultOrderBy={[
+              {
+                property: "leadStockOptions",
+                direction: "asc",
+              },
+              {
+                property: "firstFullTimeStartDate",
+                direction: "desc",
+              },
+            ]}
             onSubmitEdits={handleSubmitEdits}
             tableRef={tableRef}
           />

--- a/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/ontology/actions/modifyEmployee.ts
+++ b/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/ontology/actions/modifyEmployee.ts
@@ -24,12 +24,20 @@ export namespace modifyEmployee {
       nullable: true;
       type: 'string';
     };
+    stockOptions: {
+      description: undefined;
+      multiplicity: false;
+      nullable: true;
+      type: 'long';
+    };
   };
 
   export interface Params {
     readonly employee: ActionParam.ObjectType<Employee>;
 
     readonly primary_office_id?: ActionParam.PrimitiveType<'string'> | null;
+
+    readonly stockOptions?: ActionParam.PrimitiveType<'long'> | null;
   }
 
   // Represents a fqn of the action
@@ -49,6 +57,7 @@ export namespace modifyEmployee {
 /**
  * @param {ActionParam.ObjectType<Employee>} employee
  * @param {ActionParam.PrimitiveType<"string">} [primary_office_id]
+ * @param {ActionParam.PrimitiveType<"long">} [stockOptions]
  */
 export interface modifyEmployee extends ActionDefinition<modifyEmployee.Signatures> {
   __DefinitionMetadata?: {

--- a/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/ontology/objects/Employee.ts
+++ b/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/ontology/objects/Employee.ts
@@ -45,6 +45,7 @@ export namespace Employee {
     | 'preferredNameFirst'
     | 'preferredNameLast'
     | 'primaryOfficeId'
+    | 'stockOptions'
     | 'team'
     | 'workerType';
 
@@ -279,6 +280,14 @@ export namespace Employee {
      *   display name: 'Primary Office ID'
      */
     readonly primaryOfficeId: $PropType['string'] | undefined;
+    /**
+     * @experimental
+     *
+     *   property status: experimental
+     *
+     *   display name: 'Stock Options'
+     */
+    readonly stockOptions: $PropType['long'] | undefined;
     /**
      * @experimental
      *
@@ -565,6 +574,14 @@ export interface Employee extends $ObjectTypeDefinition {
        *   display name: 'Primary Office ID'
        */
       primaryOfficeId: $PropertyDef<'string', 'nullable', 'single'>;
+      /**
+       * @experimental
+       *
+       *   property status: experimental
+       *
+       *   display name: 'Stock Options'
+       */
+      stockOptions: $PropertyDef<'long', 'nullable', 'single'>;
       /**
        * @experimental
        *

--- a/packages/monorepo.cspell/cspell.config.js
+++ b/packages/monorepo.cspell/cspell.config.js
@@ -165,6 +165,11 @@ const cspell = {
         // used in a const (that is removed in a different PR)
         "asdfasdfdhjlkajhgj",
 
+        // numeric sort/filter comments
+        "misordered",
+        "requalified",
+        "unparseable",
+
         // Used in a stub
         "Clooney",
         "Itask",


### PR DESCRIPTION
## What

Sorts `decimal` and `long` properties numerically instead of lexicographically in the observable client. These property types arrive over the wire as strings, so `orderBy` previously sorted them as text (`"10" < "2"`), producing the wrong order. This also covers derived (RDP) properties and interface lists.

## How

- Adds `compareNumericStrings` — a BigInt-based comparator that orders numeric strings by value.
- Adds `resolvePropertyType`, which resolves a property's declared type at runtime via the object/interface definition or RDP metadata.
- Threads RDP type metadata (`RdpDefRef`) through object/interface construction and the strip/filter/merge rebuild paths so the type survives, and captures the property type for `min`/`max` aggregations.
- `SortingStrategy` uses these to sort numeric-typed properties by value.

## Before
<img width="926" height="600" alt="before_fix" src="https://github.com/user-attachments/assets/7593fe7f-6398-4df8-bf93-ff69cf3c0210" />

## After
<img width="926" height="600" alt="after_fix" src="https://github.com/user-attachments/assets/47485681-0ff8-44b3-b403-c039748850a3" />

## Notes
This is the first half of a split from #3476. The numeric **comparison/filtering** side follows in a stacked PR (`nfdiop/comparison-numeric-properties`); the shared RDP-metadata infrastructure lands here since it ships first.