### PR TITLE
Lazily import optional @osdk/foundry.admin peer in @osdk/react platform-api hooks

### DIFF
--- a/.changeset/react-platform-apis-lazy-foundry-peer.md
+++ b/.changeset/react-platform-apis-lazy-foundry-peer.md
@@ -2,4 +2,4 @@
 "@osdk/react": patch
 ---
 
-Lazily import the optional `@osdk/foundry.admin` peer in platform-api admin hooks so consumer builds (e.g. Vite/Rollup) no longer fail with "X is not exported" when the optional peer is not installed.
+Lazily import the optional `@osdk/foundry.admin` peer in platform-api admin hooks so consumer builds (e.g. Vite/Rollup) no longer fail with "X is not exported" when the optional peer is not installed. If the peer is missing at runtime, the hooks now surface a clear, actionable error ("install @osdk/foundry.admin") via their `error` state instead of an opaque module-resolution failure.

--- a/.changeset/react-platform-apis-lazy-foundry-peer.md
+++ b/.changeset/react-platform-apis-lazy-foundry-peer.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react": patch
+---
+
+Lazily import the optional `@osdk/foundry.admin` peer in platform-api admin hooks so consumer builds (e.g. Vite/Rollup) no longer fail with "X is not exported" when the optional peer is not installed.

--- a/packages/react/src/new/platform-apis/admin/importFoundryAdmin.ts
+++ b/packages/react/src/new/platform-apis/admin/importFoundryAdmin.ts
@@ -17,6 +17,11 @@
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 type FoundryAdminModule = typeof import("@osdk/foundry.admin");
 
+const MISSING_PEER_MESSAGE =
+  "@osdk/react: the optional peer dependency \"@osdk/foundry.admin\" is "
+  + "required to use the admin platform-api hooks (e.g. useCbacBanner, "
+  + "useMarkings, useFoundryUser). Install it to use these hooks.";
+
 /**
  * Lazily import the optional `@osdk/foundry.admin` peer dependency used by the
  * admin platform-api hooks.
@@ -26,16 +31,21 @@ type FoundryAdminModule = typeof import("@osdk/foundry.admin");
  * fail their bundler build when it's absent. If the peer is missing, the import
  * rejects with a clear, actionable error instead of an opaque module-resolution
  * failure; that error surfaces through the hook's `error` state.
+ *
+ * Some bundlers resolve a missing optional peer to an empty stub module rather
+ * than failing, so the import succeeds but the expected exports are absent. We
+ * validate a known export (`Users`) post-import to surface the same actionable
+ * error instead of an opaque `TypeError` at the hook call site.
  */
 export async function importFoundryAdmin(): Promise<FoundryAdminModule> {
+  let mod: FoundryAdminModule;
   try {
-    return await import("@osdk/foundry.admin");
+    mod = await import("@osdk/foundry.admin");
   } catch (cause) {
-    throw new Error(
-      "@osdk/react: the optional peer dependency \"@osdk/foundry.admin\" is "
-        + "required to use the admin platform-api hooks (e.g. useCbacBanner, "
-        + "useMarkings, useFoundryUser). Install it to use these hooks.",
-      { cause },
-    );
+    throw new Error(MISSING_PEER_MESSAGE, { cause });
   }
+  if (mod?.Users == null) {
+    throw new Error(MISSING_PEER_MESSAGE);
+  }
+  return mod;
 }

--- a/packages/react/src/new/platform-apis/admin/importFoundryAdmin.ts
+++ b/packages/react/src/new/platform-apis/admin/importFoundryAdmin.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+type FoundryAdminModule = typeof import("@osdk/foundry.admin");
+
+/**
+ * Lazily import the optional `@osdk/foundry.admin` peer dependency used by the
+ * admin platform-api hooks.
+ *
+ * Kept as a dynamic import (rather than a static top-level import) so consumers
+ * who don't use the admin hooks aren't forced to install the peer and don't
+ * fail their bundler build when it's absent. If the peer is missing, the import
+ * rejects with a clear, actionable error instead of an opaque module-resolution
+ * failure; that error surfaces through the hook's `error` state.
+ */
+export async function importFoundryAdmin(): Promise<FoundryAdminModule> {
+  try {
+    return await import("@osdk/foundry.admin");
+  } catch (cause) {
+    throw new Error(
+      "@osdk/react: the optional peer dependency \"@osdk/foundry.admin\" is "
+        + "required to use the admin platform-api hooks (e.g. useCbacBanner, "
+        + "useMarkings, useFoundryUser). Install it to use these hooks.",
+      { cause },
+    );
+  }
+}

--- a/packages/react/src/new/platform-apis/admin/useCbacBanner.ts
+++ b/packages/react/src/new/platform-apis/admin/useCbacBanner.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { CbacBanners } from "@osdk/foundry.admin";
 import React from "react";
 import { usePlatformQuery } from "../../../utils/usePlatformQuery.js";
 import { OsdkContext } from "../../OsdkContext.js";
@@ -68,7 +67,8 @@ export function useCbacBanner(
 
   const enabled = stableMarkingIds.length > 0 && externalEnabled;
 
-  const handleQuery = React.useCallback(() => {
+  const handleQuery = React.useCallback(async () => {
+    const { CbacBanners } = await import("@osdk/foundry.admin");
     return CbacBanners.get(client, {
       markingIds: stableMarkingIds,
       preview: true,

--- a/packages/react/src/new/platform-apis/admin/useCbacBanner.ts
+++ b/packages/react/src/new/platform-apis/admin/useCbacBanner.ts
@@ -17,6 +17,7 @@
 import React from "react";
 import { usePlatformQuery } from "../../../utils/usePlatformQuery.js";
 import { OsdkContext } from "../../OsdkContext.js";
+import { importFoundryAdmin } from "./importFoundryAdmin.js";
 
 export interface CbacBannerData {
   classificationString: string;
@@ -68,7 +69,7 @@ export function useCbacBanner(
   const enabled = stableMarkingIds.length > 0 && externalEnabled;
 
   const handleQuery = React.useCallback(async () => {
-    const { CbacBanners } = await import("@osdk/foundry.admin");
+    const { CbacBanners } = await importFoundryAdmin();
     return CbacBanners.get(client, {
       markingIds: stableMarkingIds,
       preview: true,

--- a/packages/react/src/new/platform-apis/admin/useCbacMarkingRestrictions.ts
+++ b/packages/react/src/new/platform-apis/admin/useCbacMarkingRestrictions.ts
@@ -17,6 +17,7 @@
 import React from "react";
 import { usePlatformQuery } from "../../../utils/usePlatformQuery.js";
 import { OsdkContext } from "../../OsdkContext.js";
+import { importFoundryAdmin } from "./importFoundryAdmin.js";
 
 export interface CbacMarkingRestrictionsData {
   disallowedMarkings: string[];
@@ -70,9 +71,7 @@ export function useCbacMarkingRestrictions(
   const enabled = stableMarkingIds.length > 0 && externalEnabled;
 
   const handleQuery = React.useCallback(async () => {
-    const { CbacMarkingRestrictionsObjects } = await import(
-      "@osdk/foundry.admin"
-    );
+    const { CbacMarkingRestrictionsObjects } = await importFoundryAdmin();
     return CbacMarkingRestrictionsObjects.get(client, {
       markingIds: stableMarkingIds,
       preview: true,

--- a/packages/react/src/new/platform-apis/admin/useCbacMarkingRestrictions.ts
+++ b/packages/react/src/new/platform-apis/admin/useCbacMarkingRestrictions.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { CbacMarkingRestrictionsObjects } from "@osdk/foundry.admin";
 import React from "react";
 import { usePlatformQuery } from "../../../utils/usePlatformQuery.js";
 import { OsdkContext } from "../../OsdkContext.js";
@@ -70,7 +69,10 @@ export function useCbacMarkingRestrictions(
 
   const enabled = stableMarkingIds.length > 0 && externalEnabled;
 
-  const handleQuery = React.useCallback(() => {
+  const handleQuery = React.useCallback(async () => {
+    const { CbacMarkingRestrictionsObjects } = await import(
+      "@osdk/foundry.admin"
+    );
     return CbacMarkingRestrictionsObjects.get(client, {
       markingIds: stableMarkingIds,
       preview: true,

--- a/packages/react/src/new/platform-apis/admin/useCurrentFoundryUser.ts
+++ b/packages/react/src/new/platform-apis/admin/useCurrentFoundryUser.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { type User, Users } from "@osdk/foundry.admin";
+import type { User } from "@osdk/foundry.admin";
 import React from "react";
 import { usePlatformQuery } from "../../../utils/usePlatformQuery.js";
 import { OsdkContext } from "../../OsdkContext.js";
@@ -55,7 +55,10 @@ export function useCurrentFoundryUser(
   const { client } = React.useContext(OsdkContext);
 
   const handleQuery = React.useCallback(
-    () => Users.getCurrent(client),
+    async () => {
+      const { Users } = await import("@osdk/foundry.admin");
+      return Users.getCurrent(client);
+    },
     [client],
   );
 

--- a/packages/react/src/new/platform-apis/admin/useCurrentFoundryUser.ts
+++ b/packages/react/src/new/platform-apis/admin/useCurrentFoundryUser.ts
@@ -18,6 +18,7 @@ import type { User } from "@osdk/foundry.admin";
 import React from "react";
 import { usePlatformQuery } from "../../../utils/usePlatformQuery.js";
 import { OsdkContext } from "../../OsdkContext.js";
+import { importFoundryAdmin } from "./importFoundryAdmin.js";
 
 export interface UseCurrentFoundryUserOptions {
   /**
@@ -56,7 +57,7 @@ export function useCurrentFoundryUser(
 
   const handleQuery = React.useCallback(
     async () => {
-      const { Users } = await import("@osdk/foundry.admin");
+      const { Users } = await importFoundryAdmin();
       return Users.getCurrent(client);
     },
     [client],

--- a/packages/react/src/new/platform-apis/admin/useFoundryUser.ts
+++ b/packages/react/src/new/platform-apis/admin/useFoundryUser.ts
@@ -19,6 +19,7 @@ import type { UserStatus } from "@osdk/foundry.core";
 import React from "react";
 import { usePlatformQuery } from "../../../utils/usePlatformQuery.js";
 import { OsdkContext } from "../../OsdkContext.js";
+import { importFoundryAdmin } from "./importFoundryAdmin.js";
 
 export interface UseFoundryUserOptions {
   /**
@@ -65,7 +66,7 @@ export function useFoundryUser(
   const { client } = React.useContext(OsdkContext);
 
   const handleQuery = React.useCallback(async () => {
-    const { Users } = await import("@osdk/foundry.admin");
+    const { Users } = await importFoundryAdmin();
     return Users.get(client, userId, { status });
   }, [client, userId, status]);
 

--- a/packages/react/src/new/platform-apis/admin/useFoundryUser.ts
+++ b/packages/react/src/new/platform-apis/admin/useFoundryUser.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { type User, Users } from "@osdk/foundry.admin";
+import type { User } from "@osdk/foundry.admin";
 import type { UserStatus } from "@osdk/foundry.core";
 import React from "react";
 import { usePlatformQuery } from "../../../utils/usePlatformQuery.js";
@@ -64,7 +64,8 @@ export function useFoundryUser(
 ): UseFoundryUserResult {
   const { client } = React.useContext(OsdkContext);
 
-  const handleQuery = React.useCallback(() => {
+  const handleQuery = React.useCallback(async () => {
+    const { Users } = await import("@osdk/foundry.admin");
     return Users.get(client, userId, { status });
   }, [client, userId, status]);
 

--- a/packages/react/src/new/platform-apis/admin/useFoundryUsersList.ts
+++ b/packages/react/src/new/platform-apis/admin/useFoundryUsersList.ts
@@ -19,6 +19,7 @@ import type { UserStatus } from "@osdk/foundry.core";
 import React from "react";
 import { usePlatformQuery } from "../../../utils/usePlatformQuery.js";
 import { OsdkContext } from "../../OsdkContext.js";
+import { importFoundryAdmin } from "./importFoundryAdmin.js";
 
 export interface UseFoundryUsersListOptions {
   /**
@@ -83,7 +84,7 @@ export function useFoundryUsersList(
   const { client } = React.useContext(OsdkContext);
 
   const handleQuery = React.useCallback(async () => {
-    const { Users } = await import("@osdk/foundry.admin");
+    const { Users } = await importFoundryAdmin();
     return Users.list(client, { include, pageSize, pageToken });
   }, [client, include, pageSize, pageToken]);
 

--- a/packages/react/src/new/platform-apis/admin/useFoundryUsersList.ts
+++ b/packages/react/src/new/platform-apis/admin/useFoundryUsersList.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { type ListUsersResponse, Users } from "@osdk/foundry.admin";
+import type { ListUsersResponse } from "@osdk/foundry.admin";
 import type { UserStatus } from "@osdk/foundry.core";
 import React from "react";
 import { usePlatformQuery } from "../../../utils/usePlatformQuery.js";
@@ -82,7 +82,8 @@ export function useFoundryUsersList(
 ): UseFoundryUsersListResult {
   const { client } = React.useContext(OsdkContext);
 
-  const handleQuery = React.useCallback(() => {
+  const handleQuery = React.useCallback(async () => {
+    const { Users } = await import("@osdk/foundry.admin");
     return Users.list(client, { include, pageSize, pageToken });
   }, [client, include, pageSize, pageToken]);
 

--- a/packages/react/src/new/platform-apis/admin/useMarkingCategories.ts
+++ b/packages/react/src/new/platform-apis/admin/useMarkingCategories.ts
@@ -18,6 +18,7 @@ import type { MarkingCategory } from "@osdk/foundry.admin";
 import React from "react";
 import { usePlatformQuery } from "../../../utils/usePlatformQuery.js";
 import { OsdkContext } from "../../OsdkContext.js";
+import { importFoundryAdmin } from "./importFoundryAdmin.js";
 
 export interface UseMarkingCategoriesOptions {
   /**
@@ -54,7 +55,7 @@ export function useMarkingCategories(
   const { client } = React.useContext(OsdkContext);
 
   const handleQuery = React.useCallback(async () => {
-    const { MarkingCategories } = await import("@osdk/foundry.admin");
+    const { MarkingCategories } = await importFoundryAdmin();
     return MarkingCategories.list(client);
   }, [client]);
 

--- a/packages/react/src/new/platform-apis/admin/useMarkingCategories.ts
+++ b/packages/react/src/new/platform-apis/admin/useMarkingCategories.ts
@@ -15,7 +15,6 @@
  */
 
 import type { MarkingCategory } from "@osdk/foundry.admin";
-import { MarkingCategories } from "@osdk/foundry.admin";
 import React from "react";
 import { usePlatformQuery } from "../../../utils/usePlatformQuery.js";
 import { OsdkContext } from "../../OsdkContext.js";
@@ -54,7 +53,8 @@ export function useMarkingCategories(
 ): UseMarkingCategoriesResult {
   const { client } = React.useContext(OsdkContext);
 
-  const handleQuery = React.useCallback(() => {
+  const handleQuery = React.useCallback(async () => {
+    const { MarkingCategories } = await import("@osdk/foundry.admin");
     return MarkingCategories.list(client);
   }, [client]);
 

--- a/packages/react/src/new/platform-apis/admin/useMarkings.ts
+++ b/packages/react/src/new/platform-apis/admin/useMarkings.ts
@@ -18,6 +18,7 @@ import type { Marking } from "@osdk/foundry.admin";
 import React from "react";
 import { usePlatformQuery } from "../../../utils/usePlatformQuery.js";
 import { OsdkContext } from "../../OsdkContext.js";
+import { importFoundryAdmin } from "./importFoundryAdmin.js";
 
 export interface UseMarkingsOptions {
   /**
@@ -54,7 +55,7 @@ export function useMarkings(
   const { client } = React.useContext(OsdkContext);
 
   const handleQuery = React.useCallback(async () => {
-    const { Markings } = await import("@osdk/foundry.admin");
+    const { Markings } = await importFoundryAdmin();
     return Markings.list(client);
   }, [client]);
 

--- a/packages/react/src/new/platform-apis/admin/useMarkings.ts
+++ b/packages/react/src/new/platform-apis/admin/useMarkings.ts
@@ -15,7 +15,6 @@
  */
 
 import type { Marking } from "@osdk/foundry.admin";
-import { Markings } from "@osdk/foundry.admin";
 import React from "react";
 import { usePlatformQuery } from "../../../utils/usePlatformQuery.js";
 import { OsdkContext } from "../../OsdkContext.js";
@@ -54,7 +53,8 @@ export function useMarkings(
 ): UseMarkingsResult {
   const { client } = React.useContext(OsdkContext);
 
-  const handleQuery = React.useCallback(() => {
+  const handleQuery = React.useCallback(async () => {
+    const { Markings } = await import("@osdk/foundry.admin");
     return Markings.list(client);
   }, [client]);
 

--- a/packages/react/src/new/platform-apis/admin/useUserMarkings.ts
+++ b/packages/react/src/new/platform-apis/admin/useUserMarkings.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { Users } from "@osdk/foundry.admin";
 import React from "react";
 import { usePlatformQuery } from "../../../utils/usePlatformQuery.js";
 import { OsdkContext } from "../../OsdkContext.js";
@@ -61,6 +60,7 @@ export function useUserViewMarkings(
   const { client } = React.useContext(OsdkContext);
 
   const handleQuery = React.useCallback(async () => {
+    const { Users } = await import("@osdk/foundry.admin");
     const resolvedUserId = userId
       ?? (await Users.getCurrent(client)).id;
     return Users.getMarkings(client, resolvedUserId);

--- a/packages/react/src/new/platform-apis/admin/useUserMarkings.ts
+++ b/packages/react/src/new/platform-apis/admin/useUserMarkings.ts
@@ -17,6 +17,7 @@
 import React from "react";
 import { usePlatformQuery } from "../../../utils/usePlatformQuery.js";
 import { OsdkContext } from "../../OsdkContext.js";
+import { importFoundryAdmin } from "./importFoundryAdmin.js";
 
 export interface UseUserViewMarkingsOptions {
   /**
@@ -60,7 +61,7 @@ export function useUserViewMarkings(
   const { client } = React.useContext(OsdkContext);
 
   const handleQuery = React.useCallback(async () => {
-    const { Users } = await import("@osdk/foundry.admin");
+    const { Users } = await importFoundryAdmin();
     const resolvedUserId = userId
       ?? (await Users.getCurrent(client)).id;
     return Users.getMarkings(client, resolvedUserId);


### PR DESCRIPTION
## Problem

Consumers running `vite build` against `@osdk/react` fail when they do **not** install the optional `@osdk/foundry.admin` peer dependency:

```
✗ Build failed in 3.19s
error during build:
node_modules/@osdk/react/build/browser/new/platform-apis/admin/useCbacBanner.js (17:9): "CbacBanners" is not exported by "__vite-optional-peer-dep:@osdk/foundry.admin:@osdk/react:false", imported by "node_modules/@osdk/react/build/browser/new/platform-apis/admin/useCbacBanner.js".
file: /app/.../repo/node_modules/@osdk/react/build/browser/new/platform-apis/admin/useCbacBanner.js:17:9

15:  */
16:
17: import { CbacBanners } from "@osdk/foundry.admin";
             ^
18: import React from "react";
19: import { usePlatformQuery } from "../../../utils/usePlatformQuery.js";
```

## Root cause

`@osdk/foundry.admin` is declared as an **optional** peer dependency (`peerDependenciesMeta.optional: true`) because only the admin platform-api hooks need it — the core object/ObjectSet hooks do not. When a consumer omits the peer, Vite replaces the module with an empty optional-peer-dep stub (`__vite-optional-peer-dep:@osdk/foundry.admin:@osdk/react:false`). The admin hooks used a **static** top-level `import { CbacBanners } from "@osdk/foundry.admin"`, so Rollup tries to resolve the named export `CbacBanners` against the empty stub and fails the build — even for consumers who never call the hook.

`useCbacBanner` is just the first one Rollup chokes on; **all 8 admin hooks** shared the same static value import (`CbacBanners`, `CbacMarkingRestrictionsObjects`, `Markings`, `Users`, `MarkingCategories`).

## Fix

Move the value imports into lazy `await import("@osdk/foundry.admin")` calls inside each hook's query callback. This is compatible with `usePlatformQuery`'s `() => Promise<T>` signature and mirrors the existing pattern in `foundry-sdk-generator` (`await import("@osdk/foundry.ontologies")`). Type-only imports (`type User`, `Marking`, `MarkingCategory`, `ListUsersResponse`, `UserStatus`) stay at the top since they're erased at build time.

This keeps the peer **truly optional**:
- Consumers who don't use admin hooks no longer pull `@osdk/foundry.admin` into their module graph → build passes, zero bundle cost (separate chunk, never loaded).
- Consumers who do use admin hooks install the peer and it resolves at runtime as before.

Keeping it as a *required* peer would have "fixed" the build only by forcing every `@osdk/react` consumer to install the full admin SDK — strictly worse and contrary to the optional design.
