### PR TITLE
Lazy-load the CBAC banner in ObjectTable marking cells

### DIFF
--- a/.changeset/objecttable-lazy-cbac-banner.md
+++ b/.changeset/objecttable-lazy-cbac-banner.md
@@ -2,4 +2,4 @@
 "@osdk/react-components": patch
 ---
 
-Lazy-load the CBAC banner in ObjectTable marking cells so consumers no longer pull the CBAC picker (and the optional `@osdk/foundry.admin` peer it reaches) into their main bundle unless a CBAC/MANDATORY marking column actually renders. Degrades gracefully to an empty cell if the banner chunk fails to load.
+Lazy-load the CBAC banner in ObjectTable marking cells so consumers no longer pull the CBAC picker (and the optional `@osdk/foundry.admin` peer it reaches) into their main bundle unless a CBAC/MANDATORY marking column actually renders. Falls back to the raw marking ids if the banner chunk fails to load.

--- a/.changeset/objecttable-lazy-cbac-banner.md
+++ b/.changeset/objecttable-lazy-cbac-banner.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Lazy-load the CBAC banner in ObjectTable marking cells so consumers no longer pull the CBAC picker (and the optional `@osdk/foundry.admin` peer it reaches) into their main bundle unless a CBAC/MANDATORY marking column actually renders. Degrades gracefully to an empty cell if the banner chunk fails to load.

--- a/packages/react-components/src/object-table/__tests__/DefaultCellRenderer.test.tsx
+++ b/packages/react-components/src/object-table/__tests__/DefaultCellRenderer.test.tsx
@@ -95,20 +95,38 @@ describe("renderDefaultCell", () => {
   });
 
   describe("marking columns", () => {
-    it("renders a CbacBanner for a CBAC marking column with a single id", () => {
+    // Placed first in this block so the lazily-imported CbacBanner module is
+    // still unresolved when it runs. A lazy boundary renders its Suspense
+    // fallback (no banner) on the first synchronous pass, then resolves the
+    // banner asynchronously. An eager static import renders the banner
+    // synchronously — that eager import is the build coupling this change removes.
+    it("lazy-loads the CbacBanner instead of importing it eagerly", async () => {
       const result = renderDefaultCell(createCellContext("marking-1", {
         columnMeta: { markingType: "CBAC" },
       }));
       render(<div data-testid="cell">{result}</div>);
-      expect(screen.getByTestId("cbac-banner").textContent).toBe("marking-1");
+      expect(screen.queryByTestId("cbac-banner")).toBeNull();
+      expect(await screen.findByTestId("cbac-banner")).toBeTruthy();
     });
 
-    it("renders a CbacBanner for a CBAC marking column with multiple ids", () => {
+    it("renders a CbacBanner for a CBAC marking column with a single id", async () => {
+      const result = renderDefaultCell(createCellContext("marking-1", {
+        columnMeta: { markingType: "CBAC" },
+      }));
+      render(<div data-testid="cell">{result}</div>);
+      expect((await screen.findByTestId("cbac-banner")).textContent).toBe(
+        "marking-1",
+      );
+    });
+
+    it("renders a CbacBanner for a CBAC marking column with multiple ids", async () => {
       const result = renderDefaultCell(createCellContext(["m-1", "m-2"], {
         columnMeta: { markingType: "CBAC" },
       }));
       render(<div data-testid="cell">{result}</div>);
-      expect(screen.getByTestId("cbac-banner").textContent).toBe("m-1,m-2");
+      expect((await screen.findByTestId("cbac-banner")).textContent).toBe(
+        "m-1,m-2",
+      );
     });
 
     it("renders nothing for an empty CBAC marking value", () => {
@@ -119,12 +137,12 @@ describe("renderDefaultCell", () => {
       expect(screen.queryByTestId("cbac-banner")).toBeNull();
     });
 
-    it("renders one CbacBanner per id for a MANDATORY marking column", () => {
+    it("renders one CbacBanner per id for a MANDATORY marking column", async () => {
       const result = renderDefaultCell(createCellContext(["m-1", "m-2"], {
         columnMeta: { markingType: "MANDATORY" },
       }));
       render(<div data-testid="cell">{result}</div>);
-      const banners = screen.getAllByTestId("cbac-banner");
+      const banners = await screen.findAllByTestId("cbac-banner");
       expect(banners).toHaveLength(2);
       expect(banners.map((el) => el.getAttribute("data-marking-ids"))).toEqual([
         "m-1",
@@ -132,14 +150,14 @@ describe("renderDefaultCell", () => {
       ]);
     });
 
-    it("deduplicates marking ids so duplicate values don't break React keys", () => {
+    it("deduplicates marking ids so duplicate values don't break React keys", async () => {
       const result = renderDefaultCell(
         createCellContext(["m-1", "m-1", "m-2"], {
           columnMeta: { markingType: "MANDATORY" },
         }),
       );
       render(<div data-testid="cell">{result}</div>);
-      const banners = screen.getAllByTestId("cbac-banner");
+      const banners = await screen.findAllByTestId("cbac-banner");
       expect(banners).toHaveLength(2);
       expect(banners.map((el) => el.getAttribute("data-marking-ids"))).toEqual([
         "m-1",
@@ -147,12 +165,12 @@ describe("renderDefaultCell", () => {
       ]);
     });
 
-    it("renders a single CbacBanner for a single-valued MANDATORY marking", () => {
+    it("renders a single CbacBanner for a single-valued MANDATORY marking", async () => {
       const result = renderDefaultCell(createCellContext("m-1", {
         columnMeta: { markingType: "MANDATORY" },
       }));
       render(<div data-testid="cell">{result}</div>);
-      const banners = screen.getAllByTestId("cbac-banner");
+      const banners = await screen.findAllByTestId("cbac-banner");
       expect(banners).toHaveLength(1);
       expect(banners[0].getAttribute("data-marking-ids")).toBe("m-1");
     });

--- a/packages/react-components/src/object-table/components/CbacMarkingCell.tsx
+++ b/packages/react-components/src/object-table/components/CbacMarkingCell.tsx
@@ -15,8 +15,8 @@
  */
 
 import React from "react";
-import { CbacBanner } from "../../cbac-picker/CbacBanner.js";
 import { toMarkingIdArray } from "../utils/markingValue.js";
+import { LazyCbacBanner } from "./LazyCbacBanner.js";
 
 export interface CbacMarkingCellProps {
   value: unknown;
@@ -29,5 +29,5 @@ export function CbacMarkingCell({
   if (markingIds.length === 0) {
     return null;
   }
-  return <CbacBanner markingIds={markingIds} />;
+  return <LazyCbacBanner markingIds={markingIds} />;
 }

--- a/packages/react-components/src/object-table/components/LazyCbacBanner.module.css
+++ b/packages/react-components/src/object-table/components/LazyCbacBanner.module.css
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Reserves the banner's intrinsic height (one line of body-small text plus the
+ * banner's vertical padding) while the CbacBanner chunk loads, so the first
+ * paint of a marking column doesn't flash empty and shift when the banner pops
+ * in. Sized purely from the shared --osdk-cbac-banner-* tokens, with a
+ * zero-content nbsp line so the box matches the real banner without hardcoding
+ * a height.
+ */
+.fallback {
+  display: block;
+  padding: var(--osdk-cbac-banner-padding);
+  font-size: var(--osdk-cbac-banner-font-size);
+}
+
+.fallback::before {
+  content: "\00a0";
+}

--- a/packages/react-components/src/object-table/components/LazyCbacBanner.tsx
+++ b/packages/react-components/src/object-table/components/LazyCbacBanner.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { Suspense } from "react";
+import type { CbacBannerProps } from "../../cbac-picker/CbacBanner.js";
+
+// Rendered when the CbacBanner chunk can't be loaded. CbacBanner pulls in
+// `@osdk/react/platform-apis`, whose admin hooks depend on the optional
+// `@osdk/foundry.admin` peer; if that chunk fails to load (peer not installed,
+// or a transient network error), degrade to an empty cell rather than letting
+// the failure propagate up and take down the whole table.
+function CbacBannerUnavailable(_props: CbacBannerProps): null {
+  return null;
+}
+
+// Lazily import CbacBanner so ObjectTable consumers don't pull the CBAC picker
+// (and the optional `@osdk/foundry.admin` peer it reaches) into their main
+// bundle unless a CBAC/MANDATORY marking column actually renders. The `.catch`
+// keeps a chunk-load failure from crashing the table.
+const CbacBannerLazy = React.lazy<React.ComponentType<CbacBannerProps>>(() =>
+  import("../../cbac-picker/CbacBanner.js")
+    .then((m) => ({ default: m.CbacBanner }))
+    .catch((error: unknown) => {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[@osdk/react-components] Failed to load the CBAC banner. Install the "
+          + "optional `@osdk/foundry.admin` peer dependency to render CBAC "
+          + "marking columns.",
+        error,
+      );
+      return { default: CbacBannerUnavailable };
+    })
+);
+
+/**
+ * Suspense-wrapped, lazily-loaded {@link CbacBanner}. Same props as
+ * `CbacBanner`; renders nothing while the chunk loads or if it fails to load.
+ */
+export function LazyCbacBanner(props: CbacBannerProps): React.ReactElement {
+  return (
+    <Suspense fallback={null}>
+      <CbacBannerLazy {...props} />
+    </Suspense>
+  );
+}

--- a/packages/react-components/src/object-table/components/LazyCbacBanner.tsx
+++ b/packages/react-components/src/object-table/components/LazyCbacBanner.tsx
@@ -16,6 +16,7 @@
 
 import React, { Suspense } from "react";
 import type { CbacBannerProps } from "../../cbac-picker/CbacBanner.js";
+import styles from "./LazyCbacBanner.module.css";
 
 // Rendered when the CbacBanner chunk can't be loaded. CbacBanner pulls in
 // `@osdk/react/platform-apis`, whose admin hooks depend on the optional
@@ -49,12 +50,13 @@ const CbacBannerLazy = React.lazy<React.ComponentType<CbacBannerProps>>(() =>
 
 /**
  * Suspense-wrapped, lazily-loaded {@link CbacBanner}. Same props as
- * `CbacBanner`; renders nothing while the chunk loads, and falls back to the
- * raw marking ids if the chunk fails to load.
+ * `CbacBanner`; renders a height-reserving placeholder while the chunk loads
+ * (so the first paint doesn't flash and shift), and falls back to the raw
+ * marking ids if the chunk fails to load.
  */
 export function LazyCbacBanner(props: CbacBannerProps): React.ReactElement {
   return (
-    <Suspense fallback={null}>
+    <Suspense fallback={<span className={styles.fallback} aria-hidden={true} />}>
       <CbacBannerLazy {...props} />
     </Suspense>
   );

--- a/packages/react-components/src/object-table/components/LazyCbacBanner.tsx
+++ b/packages/react-components/src/object-table/components/LazyCbacBanner.tsx
@@ -20,10 +20,12 @@ import type { CbacBannerProps } from "../../cbac-picker/CbacBanner.js";
 // Rendered when the CbacBanner chunk can't be loaded. CbacBanner pulls in
 // `@osdk/react/platform-apis`, whose admin hooks depend on the optional
 // `@osdk/foundry.admin` peer; if that chunk fails to load (peer not installed,
-// or a transient network error), degrade to an empty cell rather than letting
-// the failure propagate up and take down the whole table.
-function CbacBannerUnavailable(_props: CbacBannerProps): null {
-  return null;
+// or a transient network error), fall back to the raw marking ids rather than
+// hiding the markings entirely or letting the failure take down the table.
+function CbacBannerUnavailable(
+  { markingIds, className }: CbacBannerProps,
+): React.ReactElement {
+  return <span className={className}>{markingIds.join(", ")}</span>;
 }
 
 // Lazily import CbacBanner so ObjectTable consumers don't pull the CBAC picker
@@ -47,7 +49,8 @@ const CbacBannerLazy = React.lazy<React.ComponentType<CbacBannerProps>>(() =>
 
 /**
  * Suspense-wrapped, lazily-loaded {@link CbacBanner}. Same props as
- * `CbacBanner`; renders nothing while the chunk loads or if it fails to load.
+ * `CbacBanner`; renders nothing while the chunk loads, and falls back to the
+ * raw marking ids if the chunk fails to load.
  */
 export function LazyCbacBanner(props: CbacBannerProps): React.ReactElement {
   return (

--- a/packages/react-components/src/object-table/components/MandatoryMarkingCell.tsx
+++ b/packages/react-components/src/object-table/components/MandatoryMarkingCell.tsx
@@ -15,8 +15,8 @@
  */
 
 import React from "react";
-import { CbacBanner } from "../../cbac-picker/CbacBanner.js";
 import { toMarkingIdArray } from "../utils/markingValue.js";
+import { LazyCbacBanner } from "./LazyCbacBanner.js";
 import styles from "./MandatoryMarkingCell.module.css";
 
 export interface MandatoryMarkingCellProps {
@@ -38,7 +38,7 @@ export function MandatoryMarkingCell({
   return (
     <span className={styles.container}>
       {markingIds.map((id) => (
-        <CbacBanner key={id} markingIds={[id]} className={styles.pill} />
+        <LazyCbacBanner key={id} markingIds={[id]} className={styles.pill} />
       ))}
     </span>
   );

--- a/packages/react-components/src/object-table/components/__tests__/LazyCbacBanner.test.tsx
+++ b/packages/react-components/src/object-table/components/__tests__/LazyCbacBanner.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -44,7 +44,7 @@ describe("LazyCbacBanner", () => {
     );
   });
 
-  it("degrades to an empty cell (no crash) when the chunk fails to load", async () => {
+  it("falls back to the raw marking ids (no crash) when the chunk fails to load", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.doMock("../../../cbac-picker/CbacBanner.js", () => ({
       // Accessing the named export throws, so the dynamic import inside
@@ -57,14 +57,14 @@ describe("LazyCbacBanner", () => {
 
     render(
       <div data-testid="host">
-        <LazyCbacBanner markingIds={["m-1"]} />
+        <LazyCbacBanner markingIds={["m-1", "m-2"]} />
       </div>,
     );
 
-    // The fallback resolves to an empty render; the host stays mounted and the
-    // failure is logged exactly once rather than thrown.
-    await waitFor(() => expect(warnSpy).toHaveBeenCalledTimes(1));
-    expect(screen.getByTestId("host")).toBeTruthy();
+    // The fallback renders the raw marking ids rather than crashing or hiding
+    // them, and the failure is logged exactly once rather than thrown.
+    expect(await screen.findByText("m-1, m-2")).toBeTruthy();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(screen.queryByTestId("cbac-banner")).toBeNull();
   });
 });

--- a/packages/react-components/src/object-table/components/__tests__/LazyCbacBanner.test.tsx
+++ b/packages/react-components/src/object-table/components/__tests__/LazyCbacBanner.test.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Each test re-imports LazyCbacBanner after registering its own mock of the
+// underlying CbacBanner module, so the success and load-failure paths can
+// diverge within a single file.
+afterEach(() => {
+  cleanup();
+  vi.resetModules();
+  vi.restoreAllMocks();
+  vi.doUnmock("../../../cbac-picker/CbacBanner.js");
+});
+
+describe("LazyCbacBanner", () => {
+  it("renders the CbacBanner once its chunk resolves", async () => {
+    vi.doMock("../../../cbac-picker/CbacBanner.js", () => ({
+      CbacBanner: ({ markingIds }: { markingIds: string[] }) => (
+        <div data-testid="cbac-banner">{markingIds.join(",")}</div>
+      ),
+    }));
+    const { LazyCbacBanner } = await import("../LazyCbacBanner.js");
+
+    render(<LazyCbacBanner markingIds={["m-1", "m-2"]} />);
+
+    expect((await screen.findByTestId("cbac-banner")).textContent).toBe(
+      "m-1,m-2",
+    );
+  });
+
+  it("degrades to an empty cell (no crash) when the chunk fails to load", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.doMock("../../../cbac-picker/CbacBanner.js", () => ({
+      // Accessing the named export throws, so the dynamic import inside
+      // LazyCbacBanner rejects and the `.catch` fallback takes over.
+      get CbacBanner(): never {
+        throw new Error("simulated chunk load failure");
+      },
+    }));
+    const { LazyCbacBanner } = await import("../LazyCbacBanner.js");
+
+    render(
+      <div data-testid="host">
+        <LazyCbacBanner markingIds={["m-1"]} />
+      </div>,
+    );
+
+    // The fallback resolves to an empty render; the host stays mounted and the
+    // failure is logged exactly once rather than thrown.
+    await waitFor(() => expect(warnSpy).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId("host")).toBeTruthy();
+    expect(screen.queryByTestId("cbac-banner")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

Importing `ObjectTable` from `@osdk/react-components` dragged the CBAC picker — and the optional `@osdk/foundry.admin` peer it transitively reaches — into every consumer's **eager** module graph, even tables with no marking columns:

```
ObjectTable → useColumnDefs → DefaultCellRenderer
  → CbacMarkingCell / MandatoryMarkingCell
    → CbacBanner (cbac-picker)
      → @osdk/react/platform-apis → useCbacBanner → @osdk/foundry.admin
```

## Fix

New `LazyCbacBanner` wrapper (`React.lazy` + `Suspense`, following the existing `LazyDateCalendar` precedent), rendered by both `CbacMarkingCell` and `MandatoryMarkingCell`. The `CbacBanner` chunk now loads only when a `CBAC`/`MANDATORY` marking column actually renders. A `.catch` in the lazy factory degrades to an empty cell (logging once) if the chunk fails to load, so a load failure can't crash the table.

Both marking cells import `CbacBanner`, so the lazy boundary is placed at `CbacBanner` (one wrapper covers both cells) rather than at a single cell.

Fallback display when CbacBanner is not imported

<img width="351" height="516" alt="Screenshot 2026-06-15 at 20 45 48" src="https://github.com/user-attachments/assets/0a04c061-aa7b-45d8-b1c8-90795be52740" />

## Relationship to #3480

This is **code-splitting + graceful degradation**, not the build fix. The actual `vite build` failure (`"CbacBanners" is not exported by …foundry.admin…`) is fixed in #3480, which removes the static `@osdk/foundry.admin` named import inside the `@osdk/react` hooks. Lazy-loading alone can't fix the build because Rollup still validates named imports of statically-imported modules inside a dynamically-imported chunk. The two land together.

## Verification

- object-table + new `LazyCbacBanner` tests green, including a lazy-boundary test (banner is not rendered synchronously) and a guard test (degrades + warns once on chunk-load failure)
- transpiled browser output: **no static `cbac-picker` import** remains in the eager object-table graph; `LazyCbacBanner.js` carries the dynamic `import("../../cbac-picker/CbacBanner.js")`
- typecheck + lint clean for changed files



