### PR TITLE
Fix interface cycles on all internal types

### DIFF
--- a/.changeset/hungry-news-relate.md
+++ b/.changeset/hungry-news-relate.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker": patch
+---
+
+fix cyclical interfaces on all internal types

--- a/packages/maker/src/api/defineOntology.ts
+++ b/packages/maker/src/api/defineOntology.ts
@@ -47,6 +47,13 @@ import type { OntologyDefinition } from "./common/OntologyDefinition.js";
 import { OntologyEntityTypeEnum } from "./common/OntologyEntityTypeEnum.js";
 import type { OntologyEntityType } from "./common/OntologyEntityTypeMapping.js";
 import type { InterfaceType } from "./interface/InterfaceType.js";
+import type {
+  IntermediaryObjectLinkReference,
+  LinkType,
+} from "./links/LinkType.js";
+import type { InterfaceImplementation } from "./object/InterfaceImplementation.js";
+import type { ObjectType } from "./object/ObjectType.js";
+import type { ObjectTypeDefinition } from "./object/ObjectTypeDefinition.js";
 
 // type -> apiName -> entity
 /** @internal */
@@ -181,7 +188,7 @@ export function writeStaticObjects(outputDir: string): void {
           const filePath = path.join(typeDirPath, `${entityFileNameBase}.ts`);
           const entityTypeName = getEntityTypeName(ontologyTypeEnumKey);
           const entityJSON = JSON.stringify(
-            explodeInterfaceType(entity),
+            sanitizeTypes(entity),
             null,
             2,
           ).replace(
@@ -256,25 +263,99 @@ export function buildDatasource(
   });
 }
 
-// convert linked interface api name references to full type before codegen
-export function explodeInterfaceType(
+export function sanitizeTypes(
   entity: OntologyEntityType,
 ): OntologyEntityType {
-  if (entity.__type === OntologyEntityTypeEnum.INTERFACE_TYPE) {
-    return filterCyclicReferences({
-      ...entity,
-      linkedInterfaces: (entity.linkedInterfaces ?? []).map(
-        interfaceTypeOrApiName =>
-          typeof interfaceTypeOrApiName === "string"
-            ? ontologyDefinition[OntologyEntityTypeEnum.INTERFACE_TYPE][
-              interfaceTypeOrApiName
-            ]
-            : interfaceTypeOrApiName,
-      ),
-    });
-  } else {
-    return entity;
+  switch (entity.__type) {
+    case OntologyEntityTypeEnum.INTERFACE_TYPE:
+      return filterCyclicReferences({
+        ...entity,
+        linkedInterfaces: (entity.linkedInterfaces ?? []).map(
+          interfaceTypeOrApiName =>
+            typeof interfaceTypeOrApiName === "string"
+              ? ontologyDefinition[OntologyEntityTypeEnum.INTERFACE_TYPE][
+                interfaceTypeOrApiName
+              ]
+              : interfaceTypeOrApiName,
+        ),
+      });
+    case OntologyEntityTypeEnum.OBJECT_TYPE:
+      return entity.implementsInterfaces === undefined
+        ? entity
+        : {
+          ...entity,
+          implementsInterfaces: sanitizeImplements(entity.implementsInterfaces),
+        };
+    case OntologyEntityTypeEnum.LINK_TYPE:
+      return sanitizeLinkInterfaces(entity);
+    default:
+      return entity;
   }
+}
+
+function sanitizeImplements(
+  implementsInterfaces: ReadonlyArray<InterfaceImplementation>,
+): Array<InterfaceImplementation> {
+  return implementsInterfaces.map(impl => ({
+    ...impl,
+    implements: filterCyclicReferences(impl.implements),
+  }));
+}
+
+function sanitizeImplementer(
+  object: ObjectTypeDefinition | ObjectType,
+): ObjectTypeDefinition | ObjectType {
+  return object.implementsInterfaces === undefined
+    ? object
+    : {
+      ...object,
+      implementsInterfaces: sanitizeImplements(object.implementsInterfaces),
+    };
+}
+
+function sanitizeLinkSideObject(
+  object: ObjectTypeDefinition | ObjectType | string,
+): ObjectTypeDefinition | ObjectType | string {
+  return typeof object === "string" ? object : sanitizeImplementer(object);
+}
+
+function sanitizeLinkInterfaces(link: LinkType): LinkType {
+  if ("one" in link) {
+    return {
+      ...link,
+      one: { ...link.one, object: sanitizeLinkSideObject(link.one.object) },
+      toMany: {
+        ...link.toMany,
+        object: sanitizeLinkSideObject(link.toMany.object),
+      },
+    };
+  }
+  if ("intermediaryObjectType" in link) {
+    return {
+      ...link,
+      intermediaryObjectType: sanitizeImplementer(link.intermediaryObjectType),
+      many: sanitizeIntermediarySide(link.many),
+      toMany: sanitizeIntermediarySide(link.toMany),
+    };
+  }
+  return {
+    ...link,
+    many: { ...link.many, object: sanitizeLinkSideObject(link.many.object) },
+    toMany: {
+      ...link.toMany,
+      object: sanitizeLinkSideObject(link.toMany.object),
+    },
+  };
+}
+
+function sanitizeIntermediarySide(
+  side: IntermediaryObjectLinkReference,
+): IntermediaryObjectLinkReference {
+  return {
+    ...side,
+    object: sanitizeLinkSideObject(side.object),
+    linkToIntermediary: sanitizeLinkInterfaces(side.linkToIntermediary),
+  };
 }
 
 function filterCyclicReferences(

--- a/packages/maker/src/api/defineOntology.ts
+++ b/packages/maker/src/api/defineOntology.ts
@@ -294,7 +294,7 @@ export function sanitizeTypes(
 }
 
 function sanitizeImplements(
-  implementsInterfaces: ReadonlyArray<InterfaceImplementation>,
+  implementsInterfaces: Array<InterfaceImplementation>,
 ): Array<InterfaceImplementation> {
   return implementsInterfaces.map(impl => ({
     ...impl,

--- a/packages/maker/src/api/test/links.test.ts
+++ b/packages/maker/src/api/test/links.test.ts
@@ -24,6 +24,7 @@ import {
   defineOntology,
   dumpOntologyFullMetadata,
   getOntologyDefinition,
+  sanitizeTypes,
 } from "../defineOntology.js";
 import { type InterfaceType } from "../interface/InterfaceType.js";
 
@@ -2311,5 +2312,67 @@ describe("Link Types", () => {
         ontologyPackageRid: null,
       });
     }, "/tmp/");
+  });
+
+  describe("Self-referential interface link constraints", () => {
+    it("serializes objects and links that reach a self-referential interface", () => {
+      const node = defineInterface({
+        apiName: "treeNode",
+        properties: {
+          parentId: {
+            displayName: "Parent Id",
+            type: "string",
+            required: true,
+          },
+        },
+      });
+
+      defineInterfaceLinkConstraint({
+        apiName: "parent",
+        from: node,
+        toOne: node,
+      });
+
+      const object = defineObject({
+        apiName: "treeObject",
+        displayName: "Tree Object",
+        pluralDisplayName: "Tree Objects",
+        titlePropertyApiName: "id",
+        primaryKeyPropertyApiName: "id",
+        properties: {
+          id: { type: "string" },
+          parentId: { type: "string" },
+        },
+        implementsInterfaces: [
+          {
+            implements: node,
+            propertyMapping: [
+              { interfaceProperty: "parentId", mapsTo: "parentId" },
+            ],
+          },
+        ],
+      });
+
+      defineLink({
+        apiName: "objectToObject",
+        one: { object, metadata: { apiName: "parents" } },
+        toMany: { object, metadata: { apiName: "children" } },
+        manyForeignKeyProperty: "parentId",
+      });
+
+      const definition = getOntologyDefinition();
+      const objectEntity = definition[OntologyEntityTypeEnum.OBJECT_TYPE][
+        "com.palantir.treeObject"
+      ];
+      // Link types are stored under their raw apiName (defineLink does not
+      // prepend the namespace, unlike objects/interfaces).
+      const linkEntity =
+        definition[OntologyEntityTypeEnum.LINK_TYPE].objectToObject;
+
+      expect(() => JSON.stringify(sanitizeTypes(objectEntity)))
+        .not.toThrow();
+      expect(() => JSON.stringify(sanitizeTypes(linkEntity)))
+        .not.toThrow();
+    });
   });
 });


### PR DESCRIPTION
objects and links can directly contain the new interface types without filtering for cycles. This would break during json serialization when we write the codegen