### PR TITLE
Allow require implementation for iatc

### DIFF
--- a/.changeset/free-bees-shout.md
+++ b/.changeset/free-bees-shout.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker": patch
+---
+
+allow require implementation for interface action type constraint

--- a/packages/maker/src/api/defineInterfaceActionTypeConstraint.ts
+++ b/packages/maker/src/api/defineInterfaceActionTypeConstraint.ts
@@ -44,18 +44,6 @@ export function defineInterfaceActionTypeConstraint(
   );
 
   invariant(
-    !def.requireImplementation,
-    `requireImplementation is not yet supported for action type constraints`,
-  );
-
-  for (const param of def.parameters) {
-    invariant(
-      !param.requireImplementation,
-      `requireImplementation is not yet supported for parameter constraints`,
-    );
-  }
-
-  invariant(
     def.interfaceType.actionTypeConstraints.find(
       a => a.metadata.apiName === apiNameWithNamespace,
     ) == null,

--- a/packages/maker/src/api/defineObject.ts
+++ b/packages/maker/src/api/defineObject.ts
@@ -194,21 +194,6 @@ export function defineObject(
   );
 
   objectDef.implementsInterfaces?.forEach(interfaceImpl => {
-    const requiredActionTypeConstraints =
-      (interfaceImpl.implements.actionTypeConstraints
-        ?? [])
-        .filter((actionTypeConstraint: any) =>
-          actionTypeConstraint.requireImplementation
-        );
-    invariant(
-      requiredActionTypeConstraints.length === 0,
-      `Object "${objectDef.apiName}" implements interface "${interfaceImpl.implements.apiName}" which has required action type constraints: ${
-        requiredActionTypeConstraints.map((actionTypeConstraint: any) =>
-          actionTypeConstraint.metadata.apiName
-        ).join(", ")
-      }. Action type constraint implementation mappings are not yet supported in OAC.`,
-    );
-
     const allInterfaceProperties = getFlattenedInterfaceProperties(
       interfaceImpl.implements,
     );

--- a/packages/maker/src/api/defineObject.ts
+++ b/packages/maker/src/api/defineObject.ts
@@ -194,6 +194,16 @@ export function defineObject(
   );
 
   objectDef.implementsInterfaces?.forEach(interfaceImpl => {
+    const requiredConstraints = (interfaceImpl.implements.actionTypeConstraints
+      ?? [])
+      .filter((c: any) => c.requireImplementation);
+    invariant(
+      requiredConstraints.length === 0,
+      `Object "${objectDef.apiName}" implements interface "${interfaceImpl.implements.apiName}" which has required action type constraints: ${
+        requiredConstraints.map((c: any) => c.metadata.apiName).join(", ")
+      }. Action type constraint implementation mappings are not yet supported in OAC.`,
+    );
+
     const allInterfaceProperties = getFlattenedInterfaceProperties(
       interfaceImpl.implements,
     );

--- a/packages/maker/src/api/defineObject.ts
+++ b/packages/maker/src/api/defineObject.ts
@@ -194,13 +194,18 @@ export function defineObject(
   );
 
   objectDef.implementsInterfaces?.forEach(interfaceImpl => {
-    const requiredConstraints = (interfaceImpl.implements.actionTypeConstraints
-      ?? [])
-      .filter((c: any) => c.requireImplementation);
+    const requiredActionTypeConstraints =
+      (interfaceImpl.implements.actionTypeConstraints
+        ?? [])
+        .filter((actionTypeConstraint: any) =>
+          actionTypeConstraint.requireImplementation
+        );
     invariant(
-      requiredConstraints.length === 0,
+      requiredActionTypeConstraints.length === 0,
       `Object "${objectDef.apiName}" implements interface "${interfaceImpl.implements.apiName}" which has required action type constraints: ${
-        requiredConstraints.map((c: any) => c.metadata.apiName).join(", ")
+        requiredActionTypeConstraints.map((actionTypeConstraint: any) =>
+          actionTypeConstraint.metadata.apiName
+        ).join(", ")
       }. Action type constraint implementation mappings are not yet supported in OAC.`,
     );
 

--- a/packages/maker/src/api/test/interfaces.test.ts
+++ b/packages/maker/src/api/test/interfaces.test.ts
@@ -1444,36 +1444,38 @@ describe("Interfaces", () => {
       expect(param.requireImplementation).toBe(true);
     });
 
-    it("throws when object implements interface with required constraint", () => {
-      const iface = defineInterface({ apiName: "MyInterface" });
+    it("throws when object implements interface with required constraint", async () => {
+      await expect(
+        defineOntology("com.palantir.", () => {
+          const iface = defineInterface({ apiName: "MyInterface" });
 
-      defineInterfaceActionTypeConstraint({
-        interfaceType: iface,
-        apiName: "myConstraint",
-        displayName: "My Constraint",
-        description: "A test constraint",
-        requireImplementation: true,
-        parameters: [],
-      });
+          defineInterfaceActionTypeConstraint({
+            interfaceType: iface,
+            apiName: "myConstraint",
+            displayName: "My Constraint",
+            description: "A test constraint",
+            requireImplementation: true,
+            parameters: [],
+          });
 
-      expect(() => {
-        defineObject({
-          apiName: "myObject",
-          displayName: "My Object",
-          pluralDisplayName: "My Objects",
-          titlePropertyApiName: "name",
-          primaryKeyPropertyApiName: "id",
-          properties: {
-            "id": { type: "string", displayName: "ID" },
-            "name": { type: "string", displayName: "Name" },
-          },
-          implementsInterfaces: [{
-            implements: iface,
-            propertyMapping: [],
-          }],
-        });
-      }).toThrowErrorMatchingInlineSnapshot(
-        `[Error: Invariant failed: Object "myObject" implements interface "com.palantir.MyInterface" which has required action type constraints: com.palantir.myConstraint. Action type constraint implementation mappings are not yet supported in OAC.]`,
+          defineObject({
+            apiName: "myObject",
+            displayName: "My Object",
+            pluralDisplayName: "My Objects",
+            titlePropertyApiName: "name",
+            primaryKeyPropertyApiName: "id",
+            properties: {
+              "id": { type: "string", displayName: "ID" },
+              "name": { type: "string", displayName: "Name" },
+            },
+            implementsInterfaces: [{
+              implements: iface,
+              propertyMapping: [],
+            }],
+          });
+        }, undefined),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Object "com.palantir.myObject" implements interface "com.palantir.MyInterface" which has required action type constraints: com.palantir.myConstraint. Action type constraint implementation mappings are not yet supported in OAC.]`,
       );
     });
 

--- a/packages/maker/src/api/test/interfaces.test.ts
+++ b/packages/maker/src/api/test/interfaces.test.ts
@@ -1475,7 +1475,7 @@ describe("Interfaces", () => {
           });
         }, undefined),
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `[Error: Invariant failed: Object "com.palantir.myObject" implements interface "com.palantir.MyInterface" which has required action type constraints: com.palantir.myConstraint. Action type constraint implementation mappings are not yet supported in OAC.]`,
+        `[Error: Invariant failed: Object "com.palantir.myObject" implements interface "com.palantir.MyInterface" which has required action type constraints: com.palantir.myConstraint. Action type constraint implementation is not yet supported in OAC. Set requireImplementation to false and manually implement the constraint after installation.]`,
       );
     });
 

--- a/packages/maker/src/api/test/interfaces.test.ts
+++ b/packages/maker/src/api/test/interfaces.test.ts
@@ -17,6 +17,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { defineInterface } from "../defineInterface.js";
 import { defineInterfaceActionTypeConstraint } from "../defineInterfaceActionTypeConstraint.js";
+import { defineObject } from "../defineObject.js";
 import { defineOntology, dumpOntologyFullMetadata } from "../defineOntology.js";
 import { defineSharedPropertyType } from "../defineSpt.js";
 
@@ -1418,45 +1419,93 @@ describe("Interfaces", () => {
       );
     });
 
-    it("throws when requireImplementation is true on constraint", () => {
+    it("allows requireImplementation true on constraint definition", () => {
       const iface = defineInterface({ apiName: "MyInterface" });
 
+      defineInterfaceActionTypeConstraint({
+        interfaceType: iface,
+        apiName: "myConstraint",
+        displayName: "My Constraint",
+        description: "A test constraint",
+        requireImplementation: true,
+        parameters: [
+          {
+            apiName: "boolParam",
+            displayName: "Boolean Param",
+            type: { type: "boolean", boolean: {} },
+            requireImplementation: true,
+          },
+        ],
+      });
+
+      const constraint = iface.actionTypeConstraints[0];
+      expect(constraint.requireImplementation).toBe(true);
+      const param = Object.values(constraint.parameters)[0];
+      expect(param.requireImplementation).toBe(true);
+    });
+
+    it("throws when object implements interface with required constraint", () => {
+      const iface = defineInterface({ apiName: "MyInterface" });
+
+      defineInterfaceActionTypeConstraint({
+        interfaceType: iface,
+        apiName: "myConstraint",
+        displayName: "My Constraint",
+        description: "A test constraint",
+        requireImplementation: true,
+        parameters: [],
+      });
+
       expect(() => {
-        defineInterfaceActionTypeConstraint({
-          interfaceType: iface,
-          apiName: "myConstraint",
-          displayName: "My Constraint",
-          description: "A test constraint",
-          requireImplementation: true,
-          parameters: [],
+        defineObject({
+          apiName: "myObject",
+          displayName: "My Object",
+          pluralDisplayName: "My Objects",
+          titlePropertyApiName: "name",
+          primaryKeyPropertyApiName: "id",
+          properties: {
+            "id": { type: "string", displayName: "ID" },
+            "name": { type: "string", displayName: "Name" },
+          },
+          implementsInterfaces: [{
+            implements: iface,
+            propertyMapping: [],
+          }],
         });
       }).toThrowErrorMatchingInlineSnapshot(
-        `[Error: Invariant failed: requireImplementation is not yet supported for action type constraints]`,
+        `[Error: Invariant failed: Object "myObject" implements interface "com.palantir.MyInterface" which has required action type constraints: com.palantir.myConstraint. Action type constraint implementation mappings are not yet supported in OAC.]`,
       );
     });
 
-    it("throws when requireImplementation is true on parameter constraint", () => {
+    it("allows object to implement interface with non-required constraint", () => {
       const iface = defineInterface({ apiName: "MyInterface" });
 
-      expect(() => {
-        defineInterfaceActionTypeConstraint({
-          interfaceType: iface,
-          apiName: "myConstraint",
-          displayName: "My Constraint",
-          description: "A test constraint",
-          requireImplementation: false,
-          parameters: [
-            {
-              apiName: "boolParam",
-              displayName: "Boolean Param",
-              type: { type: "boolean", boolean: {} },
-              requireImplementation: true,
-            },
-          ],
-        });
-      }).toThrowErrorMatchingInlineSnapshot(
-        `[Error: Invariant failed: requireImplementation is not yet supported for parameter constraints]`,
-      );
+      defineInterfaceActionTypeConstraint({
+        interfaceType: iface,
+        apiName: "myConstraint",
+        displayName: "My Constraint",
+        description: "A test constraint",
+        requireImplementation: false,
+        parameters: [],
+      });
+
+      const obj = defineObject({
+        apiName: "myObject",
+        displayName: "My Object",
+        pluralDisplayName: "My Objects",
+        titlePropertyApiName: "name",
+        primaryKeyPropertyApiName: "id",
+        properties: {
+          "id": { type: "string", displayName: "ID" },
+          "name": { type: "string", displayName: "Name" },
+        },
+        implementsInterfaces: [{
+          implements: iface,
+          propertyMapping: [],
+        }],
+      });
+
+      expect(obj).toBeDefined();
     });
   });
 });

--- a/packages/maker/src/conversion/toMarketplace/convertObject.ts
+++ b/packages/maker/src/conversion/toMarketplace/convertObject.ts
@@ -83,6 +83,19 @@ export function convertObject(
 
   const implementations = objectType.implementsInterfaces ?? [];
 
+  for (const impl of implementations) {
+    const requiredConstraints = (impl.implements.actionTypeConstraints ?? [])
+      .filter(constraint => constraint.requireImplementation);
+    invariant(
+      requiredConstraints.length === 0,
+      `Object "${objectType.apiName}" implements interface "${impl.implements.apiName}" which has required action type constraints: ${
+        requiredConstraints.map(constraint => constraint.metadata.apiName).join(
+          ", ",
+        )
+      }. Action type constraint implementation mappings are not yet supported in OAC.`,
+    );
+  }
+
   return {
     objectType: {
       displayMetadata: {

--- a/packages/maker/src/conversion/toMarketplace/convertObject.ts
+++ b/packages/maker/src/conversion/toMarketplace/convertObject.ts
@@ -92,7 +92,7 @@ export function convertObject(
         requiredConstraints.map(constraint => constraint.metadata.apiName).join(
           ", ",
         )
-      }. Action type constraint implementation mappings are not yet supported in OAC.`,
+      }. Action type constraint implementation is not yet supported in OAC. Set requireImplementation to false and manually implement the constraint after installation.`,
     );
   }
 


### PR DESCRIPTION
We don't allow setting an interface action type constraint to be required. This PR enables an IATC to be required, but we will throw if an object type attempts to implement an interface type that has a required IATC because we don't have support for IATC implementation yet.