### PR TITLE
Export branchRid from generated SDK

### DIFF
--- a/.changeset/silent-rabbits-smash.md
+++ b/.changeset/silent-rabbits-smash.md
@@ -2,4 +2,4 @@
 "@osdk/generator": minor
 ---
 
-Export branchRid from generated SDK
+Always export `$branch` from the generated SDK root.

--- a/.changeset/silent-rabbits-smash.md
+++ b/.changeset/silent-rabbits-smash.md
@@ -1,0 +1,5 @@
+---
+"@osdk/generator": minor
+---
+
+Export branchRid from generated SDK

--- a/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
@@ -2,3 +2,8 @@ export type $ExpectedClientVersion = '2.32.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';
+/**
+ * The RID of the Foundry branch this SDK was generated against, or
+ * `undefined` if it was generated against the main branch.
+ */
+export const $branchRid: string | undefined = undefined;

--- a/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/OntologyMetadata.ts
@@ -6,4 +6,4 @@ export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-a
  * The RID of the Foundry branch this SDK was generated against, or
  * `undefined` if it was generated against the main branch.
  */
-export const $branchRid: string | undefined = undefined;
+export const $branch: string | undefined = undefined;

--- a/examples-extra/docs_example/src/generatedNoCheck/index.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/index.ts
@@ -15,4 +15,4 @@ export * as $Objects from './ontology/objects.js';
 export {} from './ontology/queries.js';
 export * as $Queries from './ontology/queries.js';
 export { $osdkMetadata } from './OntologyMetadata.js';
-export { $ontologyRid } from './OntologyMetadata.js';
+export { $branchRid, $ontologyRid } from './OntologyMetadata.js';

--- a/examples-extra/docs_example/src/generatedNoCheck/index.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/index.ts
@@ -15,4 +15,4 @@ export * as $Objects from './ontology/objects.js';
 export {} from './ontology/queries.js';
 export * as $Queries from './ontology/queries.js';
 export { $osdkMetadata } from './OntologyMetadata.js';
-export { $branchRid, $ontologyRid } from './OntologyMetadata.js';
+export { $branch, $ontologyRid } from './OntologyMetadata.js';

--- a/examples-extra/docs_example/turbo.json
+++ b/examples-extra/docs_example/turbo.json
@@ -4,7 +4,7 @@
     "codegen": {
       "inputs": ["ontology.json"],
       "outputs": ["src/generatedNoCheck/**/*"],
-      "dependsOn": ["@osdk/cli.cmd.typescript#transpileEsm", "^transpileEsm"]
+      "dependsOn": ["@osdk/cli.cmd.typescript#transpile"]
     }
   }
 }

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/OntologyMetadata.ts
@@ -2,3 +2,8 @@ export type $ExpectedClientVersion = '2.32.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.dep';
+/**
+ * The RID of the Foundry branch this SDK was generated against, or
+ * `undefined` if it was generated against the main branch.
+ */
+export const $branchRid: string | undefined = undefined;

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/OntologyMetadata.ts
@@ -6,4 +6,4 @@ export const $ontologyRid = 'ri.ontology.main.ontology.dep';
  * The RID of the Foundry branch this SDK was generated against, or
  * `undefined` if it was generated against the main branch.
  */
-export const $branchRid: string | undefined = undefined;
+export const $branch: string | undefined = undefined;

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/index.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/index.ts
@@ -7,4 +7,4 @@ export * as $Objects from './ontology/objects.js';
 export {} from './ontology/queries.js';
 export * as $Queries from './ontology/queries.js';
 export { $osdkMetadata } from './OntologyMetadata.js';
-export { $branchRid, $ontologyRid } from './OntologyMetadata.js';
+export { $branch, $ontologyRid } from './OntologyMetadata.js';

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/index.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/index.ts
@@ -7,4 +7,4 @@ export * as $Objects from './ontology/objects.js';
 export {} from './ontology/queries.js';
 export * as $Queries from './ontology/queries.js';
 export { $osdkMetadata } from './OntologyMetadata.js';
-export { $ontologyRid } from './OntologyMetadata.js';
+export { $branchRid, $ontologyRid } from './OntologyMetadata.js';

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/OntologyMetadata.ts
@@ -2,3 +2,8 @@ export type $ExpectedClientVersion = '2.32.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.dep';
+/**
+ * The RID of the Foundry branch this SDK was generated against, or
+ * `undefined` if it was generated against the main branch.
+ */
+export const $branchRid: string | undefined = undefined;

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/OntologyMetadata.ts
@@ -6,4 +6,4 @@ export const $ontologyRid = 'ri.ontology.main.ontology.dep';
  * The RID of the Foundry branch this SDK was generated against, or
  * `undefined` if it was generated against the main branch.
  */
-export const $branchRid: string | undefined = undefined;
+export const $branch: string | undefined = undefined;

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/index.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/index.ts
@@ -7,4 +7,4 @@ export * as $Objects from './ontology/objects.js';
 export { getTask } from './ontology/queries.js';
 export * as $Queries from './ontology/queries.js';
 export { $osdkMetadata } from './OntologyMetadata.js';
-export { $ontologyRid } from './OntologyMetadata.js';
+export { $branchRid, $ontologyRid } from './OntologyMetadata.js';

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/index.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/index.ts
@@ -7,4 +7,4 @@ export * as $Objects from './ontology/objects.js';
 export { getTask } from './ontology/queries.js';
 export * as $Queries from './ontology/queries.js';
 export { $osdkMetadata } from './OntologyMetadata.js';
-export { $branchRid, $ontologyRid } from './OntologyMetadata.js';
+export { $branch, $ontologyRid } from './OntologyMetadata.js';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/OntologyMetadata.ts
@@ -2,3 +2,8 @@ export type $ExpectedClientVersion = '2.32.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';
+/**
+ * The RID of the Foundry branch this SDK was generated against, or
+ * `undefined` if it was generated against the main branch.
+ */
+export const $branchRid: string | undefined = undefined;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/OntologyMetadata.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/OntologyMetadata.ts
@@ -6,4 +6,4 @@ export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-a
  * The RID of the Foundry branch this SDK was generated against, or
  * `undefined` if it was generated against the main branch.
  */
-export const $branchRid: string | undefined = undefined;
+export const $branch: string | undefined = undefined;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/index.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/index.ts
@@ -92,4 +92,4 @@ export {
 } from './ontology/queries.js';
 export * as $Queries from './ontology/queries.js';
 export { $osdkMetadata } from './OntologyMetadata.js';
-export { $branchRid, $ontologyRid } from './OntologyMetadata.js';
+export { $branch, $ontologyRid } from './OntologyMetadata.js';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/index.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/index.ts
@@ -92,4 +92,4 @@ export {
 } from './ontology/queries.js';
 export * as $Queries from './ontology/queries.js';
 export { $osdkMetadata } from './OntologyMetadata.js';
-export { $ontologyRid } from './OntologyMetadata.js';
+export { $branchRid, $ontologyRid } from './OntologyMetadata.js';

--- a/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/OntologyMetadata.ts
+++ b/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/OntologyMetadata.ts
@@ -6,4 +6,4 @@ export const $ontologyRid = 'ri.ontology.main.ontology.5a277e05-5cdb-4766-bbd1-2
  * The RID of the Foundry branch this SDK was generated against, or
  * `undefined` if it was generated against the main branch.
  */
-export const $branchRid: string | undefined = undefined;
+export const $branch: string | undefined = undefined;

--- a/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/OntologyMetadata.ts
+++ b/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/OntologyMetadata.ts
@@ -2,3 +2,8 @@ export type $ExpectedClientVersion = '2.32.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.5a277e05-5cdb-4766-bbd1-22a4ba8d6433';
+/**
+ * The RID of the Foundry branch this SDK was generated against, or
+ * `undefined` if it was generated against the main branch.
+ */
+export const $branchRid: string | undefined = undefined;

--- a/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/index.ts
+++ b/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/index.ts
@@ -7,4 +7,4 @@ export * as $Objects from './ontology/objects.js';
 export {} from './ontology/queries.js';
 export * as $Queries from './ontology/queries.js';
 export { $osdkMetadata } from './OntologyMetadata.js';
-export { $branchRid, $ontologyRid } from './OntologyMetadata.js';
+export { $branch, $ontologyRid } from './OntologyMetadata.js';

--- a/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/index.ts
+++ b/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/index.ts
@@ -7,4 +7,4 @@ export * as $Objects from './ontology/objects.js';
 export {} from './ontology/queries.js';
 export * as $Queries from './ontology/queries.js';
 export { $osdkMetadata } from './OntologyMetadata.js';
-export { $ontologyRid } from './OntologyMetadata.js';
+export { $branchRid, $ontologyRid } from './OntologyMetadata.js';

--- a/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/OntologyMetadata.ts
+++ b/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/OntologyMetadata.ts
@@ -2,3 +2,8 @@ export type $ExpectedClientVersion = '2.32.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';
+/**
+ * The RID of the Foundry branch this SDK was generated against, or
+ * `undefined` if it was generated against the main branch.
+ */
+export const $branchRid: string | undefined = undefined;

--- a/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/OntologyMetadata.ts
+++ b/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/OntologyMetadata.ts
@@ -6,4 +6,4 @@ export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-a
  * The RID of the Foundry branch this SDK was generated against, or
  * `undefined` if it was generated against the main branch.
  */
-export const $branchRid: string | undefined = undefined;
+export const $branch: string | undefined = undefined;

--- a/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/index.ts
+++ b/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/index.ts
@@ -7,4 +7,4 @@ export * as $Objects from './ontology/objects.js';
 export { getEmployeeDaysSinceStart } from './ontology/queries.js';
 export * as $Queries from './ontology/queries.js';
 export { $osdkMetadata } from './OntologyMetadata.js';
-export { $ontologyRid } from './OntologyMetadata.js';
+export { $branchRid, $ontologyRid } from './OntologyMetadata.js';

--- a/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/index.ts
+++ b/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/index.ts
@@ -7,4 +7,4 @@ export * as $Objects from './ontology/objects.js';
 export { getEmployeeDaysSinceStart } from './ontology/queries.js';
 export * as $Queries from './ontology/queries.js';
 export { $osdkMetadata } from './OntologyMetadata.js';
-export { $branchRid, $ontologyRid } from './OntologyMetadata.js';
+export { $branch, $ontologyRid } from './OntologyMetadata.js';

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/OntologyMetadata.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/OntologyMetadata.ts
@@ -2,3 +2,8 @@ export type $ExpectedClientVersion = '2.32.0';
 export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/dev osdk-cli/dev' };
 
 export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e';
+/**
+ * The RID of the Foundry branch this SDK was generated against, or
+ * `undefined` if it was generated against the main branch.
+ */
+export const $branchRid: string | undefined = undefined;

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/OntologyMetadata.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/OntologyMetadata.ts
@@ -6,4 +6,4 @@ export const $ontologyRid = 'ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-a
  * The RID of the Foundry branch this SDK was generated against, or
  * `undefined` if it was generated against the main branch.
  */
-export const $branchRid: string | undefined = undefined;
+export const $branch: string | undefined = undefined;

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/index.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/index.ts
@@ -7,4 +7,4 @@ export * as $Objects from './ontology/objects.js';
 export {} from './ontology/queries.js';
 export * as $Queries from './ontology/queries.js';
 export { $osdkMetadata } from './OntologyMetadata.js';
-export { $branchRid, $ontologyRid } from './OntologyMetadata.js';
+export { $branch, $ontologyRid } from './OntologyMetadata.js';

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/index.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/index.ts
@@ -7,4 +7,4 @@ export * as $Objects from './ontology/objects.js';
 export {} from './ontology/queries.js';
 export * as $Queries from './ontology/queries.js';
 export { $osdkMetadata } from './OntologyMetadata.js';
-export { $ontologyRid } from './OntologyMetadata.js';
+export { $branchRid, $ontologyRid } from './OntologyMetadata.js';

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -563,6 +563,11 @@ describe("generator", () => {
         export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/0.0.0 osdk-cli/0.0.0' };
 
         export const $ontologyRid = 'ridHere';
+        /**
+         * The RID of the Foundry branch this SDK was generated against, or
+         * \`undefined\` if it was generated against the main branch.
+         */
+        export const $branchRid: string | undefined = undefined;
         ",
           "/foo/index.ts": "export { deleteTodos, markTodoCompleted } from './ontology/actions.js';
         export * as $Actions from './ontology/actions.js';
@@ -573,7 +578,7 @@ describe("generator", () => {
         export { getCount, returnsTodo } from './ontology/queries.js';
         export * as $Queries from './ontology/queries.js';
         export { $osdkMetadata } from './OntologyMetadata.js';
-        export { $ontologyRid } from './OntologyMetadata.js';
+        export { $branchRid, $ontologyRid } from './OntologyMetadata.js';
         ",
           "/foo/ontology/actions.ts": "export { deleteTodos } from './actions/deleteTodos.js';
         export { markTodoCompleted } from './actions/markTodoCompleted.js';
@@ -1254,6 +1259,11 @@ describe("generator", () => {
         export const $osdkMetadata = { extraUserAgent: '' };
 
         export const $ontologyRid = 'ridHere';
+        /**
+         * The RID of the Foundry branch this SDK was generated against, or
+         * \`undefined\` if it was generated against the main branch.
+         */
+        export const $branchRid: string | undefined = undefined;
         ",
           "/foo/index.ts": "export { deleteTodos, markTodoCompleted } from './ontology/actions.js';
         export * as $Actions from './ontology/actions.js';
@@ -1264,7 +1274,7 @@ describe("generator", () => {
         export { getCount, returnsTodo } from './ontology/queries.js';
         export * as $Queries from './ontology/queries.js';
         export { $osdkMetadata } from './OntologyMetadata.js';
-        export { $ontologyRid } from './OntologyMetadata.js';
+        export { $branchRid, $ontologyRid } from './OntologyMetadata.js';
         ",
           "/foo/ontology/actions.ts": "export { deleteTodos } from './actions/deleteTodos.js';
         export { markTodoCompleted } from './actions/markTodoCompleted.js';
@@ -2315,6 +2325,11 @@ describe("generator", () => {
         export const $osdkMetadata = { extraUserAgent: 'typescript-sdk/0.0.0 osdk-cli/0.0.0' };
 
         export const $ontologyRid = 'ridHere';
+        /**
+         * The RID of the Foundry branch this SDK was generated against, or
+         * \`undefined\` if it was generated against the main branch.
+         */
+        export const $branchRid: string | undefined = undefined;
         ",
           "/foo/index.ts": "export {} from './ontology/actions.js';
         export * as $Actions from './ontology/actions.js';
@@ -2325,7 +2340,7 @@ describe("generator", () => {
         export { getCount, returnsTodo } from './ontology/queries.js';
         export * as $Queries from './ontology/queries.js';
         export { $osdkMetadata } from './OntologyMetadata.js';
-        export { $ontologyRid } from './OntologyMetadata.js';
+        export { $branchRid, $ontologyRid } from './OntologyMetadata.js';
         ",
           "/foo/ontology/actions.ts": "export {};
         ",
@@ -2715,8 +2730,11 @@ describe("generator", () => {
         export const $osdkMetadata = { extraUserAgent: '' };
 
         export const $ontologyRid = 'ri.ontology.main.ontology.dep';
-
-        export const $branch = 'someRidHere';
+        /**
+         * The RID of the Foundry branch this SDK was generated against, or
+         * \`undefined\` if it was generated against the main branch.
+         */
+        export const $branchRid: string | undefined = 'someRidHere';
         ",
           "/foo/index.ts": "export {} from './ontology/actions.js';
         export * as $Actions from './ontology/actions.js';
@@ -2727,7 +2745,7 @@ describe("generator", () => {
         export {} from './ontology/queries.js';
         export * as $Queries from './ontology/queries.js';
         export { $osdkMetadata } from './OntologyMetadata.js';
-        export { $ontologyRid } from './OntologyMetadata.js';
+        export { $branchRid, $ontologyRid } from './OntologyMetadata.js';
         ",
           "/foo/ontology/actions.ts": "export {};
         ",

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -567,7 +567,7 @@ describe("generator", () => {
          * The RID of the Foundry branch this SDK was generated against, or
          * \`undefined\` if it was generated against the main branch.
          */
-        export const $branchRid: string | undefined = undefined;
+        export const $branch: string | undefined = undefined;
         ",
           "/foo/index.ts": "export { deleteTodos, markTodoCompleted } from './ontology/actions.js';
         export * as $Actions from './ontology/actions.js';
@@ -578,7 +578,7 @@ describe("generator", () => {
         export { getCount, returnsTodo } from './ontology/queries.js';
         export * as $Queries from './ontology/queries.js';
         export { $osdkMetadata } from './OntologyMetadata.js';
-        export { $branchRid, $ontologyRid } from './OntologyMetadata.js';
+        export { $branch, $ontologyRid } from './OntologyMetadata.js';
         ",
           "/foo/ontology/actions.ts": "export { deleteTodos } from './actions/deleteTodos.js';
         export { markTodoCompleted } from './actions/markTodoCompleted.js';
@@ -1263,7 +1263,7 @@ describe("generator", () => {
          * The RID of the Foundry branch this SDK was generated against, or
          * \`undefined\` if it was generated against the main branch.
          */
-        export const $branchRid: string | undefined = undefined;
+        export const $branch: string | undefined = undefined;
         ",
           "/foo/index.ts": "export { deleteTodos, markTodoCompleted } from './ontology/actions.js';
         export * as $Actions from './ontology/actions.js';
@@ -1274,7 +1274,7 @@ describe("generator", () => {
         export { getCount, returnsTodo } from './ontology/queries.js';
         export * as $Queries from './ontology/queries.js';
         export { $osdkMetadata } from './OntologyMetadata.js';
-        export { $branchRid, $ontologyRid } from './OntologyMetadata.js';
+        export { $branch, $ontologyRid } from './OntologyMetadata.js';
         ",
           "/foo/ontology/actions.ts": "export { deleteTodos } from './actions/deleteTodos.js';
         export { markTodoCompleted } from './actions/markTodoCompleted.js';
@@ -2329,7 +2329,7 @@ describe("generator", () => {
          * The RID of the Foundry branch this SDK was generated against, or
          * \`undefined\` if it was generated against the main branch.
          */
-        export const $branchRid: string | undefined = undefined;
+        export const $branch: string | undefined = undefined;
         ",
           "/foo/index.ts": "export {} from './ontology/actions.js';
         export * as $Actions from './ontology/actions.js';
@@ -2340,7 +2340,7 @@ describe("generator", () => {
         export { getCount, returnsTodo } from './ontology/queries.js';
         export * as $Queries from './ontology/queries.js';
         export { $osdkMetadata } from './OntologyMetadata.js';
-        export { $branchRid, $ontologyRid } from './OntologyMetadata.js';
+        export { $branch, $ontologyRid } from './OntologyMetadata.js';
         ",
           "/foo/ontology/actions.ts": "export {};
         ",
@@ -2734,7 +2734,7 @@ describe("generator", () => {
          * The RID of the Foundry branch this SDK was generated against, or
          * \`undefined\` if it was generated against the main branch.
          */
-        export const $branchRid: string | undefined = 'someRidHere';
+        export const $branch: string | undefined = 'someRidHere';
         ",
           "/foo/index.ts": "export {} from './ontology/actions.js';
         export * as $Actions from './ontology/actions.js';
@@ -2745,7 +2745,7 @@ describe("generator", () => {
         export {} from './ontology/queries.js';
         export * as $Queries from './ontology/queries.js';
         export { $osdkMetadata } from './OntologyMetadata.js';
-        export { $branchRid, $ontologyRid } from './OntologyMetadata.js';
+        export { $branch, $ontologyRid } from './OntologyMetadata.js';
         ",
           "/foo/ontology/actions.ts": "export {};
         ",

--- a/packages/generator/src/v2.0/generateMetadata.ts
+++ b/packages/generator/src/v2.0/generateMetadata.ts
@@ -40,7 +40,7 @@ export async function generateOntologyMetadataFile(
          * The RID of the Foundry branch this SDK was generated against, or
          * \`undefined\` if it was generated against the main branch.
          */
-        export const $branchRid: string | undefined = ${
+        export const $branch: string | undefined = ${
             ontology.raw.branch != null
               ? `"${ontology.raw.branch.rid}"`
               : "undefined"

--- a/packages/generator/src/v2.0/generateMetadata.ts
+++ b/packages/generator/src/v2.0/generateMetadata.ts
@@ -36,13 +36,15 @@ export async function generateOntologyMetadataFile(
         ontologyApiNamespace == null
           ? `
         export const $ontologyRid = "${ontology.ontology.rid}";
-        `
-          : ""
-      }
-       ${
-        ontology.raw.branch != null
-          ? `
-        export const $branch = "${ontology.raw.branch.rid}";
+        /**
+         * The RID of the Foundry branch this SDK was generated against, or
+         * \`undefined\` if it was generated against the main branch.
+         */
+        export const $branchRid: string | undefined = ${
+            ontology.raw.branch != null
+              ? `"${ontology.raw.branch.rid}"`
+              : "undefined"
+          };
         `
           : ""
       }

--- a/packages/generator/src/v2.0/generateRootIndexTsFile.ts
+++ b/packages/generator/src/v2.0/generateRootIndexTsFile.ts
@@ -44,7 +44,7 @@ export async function generateRootIndexTsFile(
         export { $osdkMetadata } from "./OntologyMetadata${importExt}";
         ${
         ontologyApiNamespace == null
-          ? `export { $ontologyRid } from "./OntologyMetadata${importExt}";`
+          ? `export { $branchRid, $ontologyRid } from "./OntologyMetadata${importExt}";`
           : ``
       }
     `,

--- a/packages/generator/src/v2.0/generateRootIndexTsFile.ts
+++ b/packages/generator/src/v2.0/generateRootIndexTsFile.ts
@@ -44,7 +44,7 @@ export async function generateRootIndexTsFile(
         export { $osdkMetadata } from "./OntologyMetadata${importExt}";
         ${
         ontologyApiNamespace == null
-          ? `export { $branchRid, $ontologyRid } from "./OntologyMetadata${importExt}";`
+          ? `export { $branch, $ontologyRid } from "./OntologyMetadata${importExt}";`
           : ``
       }
     `,


### PR DESCRIPTION
Previously SDKs generated on a branch had the $branch present in the ontologyMetadata file but wasn't exported. This PR does export it to be consumed similar to $ontologyRid, renames to $branchRid to be consistent with $ontologyRid, and exports it unconditionally where the default value is set to undefined if the SDK was generated against a branch.