### PR TITLE
add batched derived links store for simple links

### DIFF
--- a/.changeset/shapes-batched-core.md
+++ b/.changeset/shapes-batched-core.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react": patch
+---
+
+add batched derived links store using observeLinks for simple pivot links

--- a/packages/react/src/new/shapes/batchedDerivedLinksStore.ts
+++ b/packages/react/src/new/shapes/batchedDerivedLinksStore.ts
@@ -1,0 +1,405 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectOrInterfaceDefinition, Osdk } from "@osdk/api";
+import type { ShapeDerivedLinkDef } from "@osdk/api/shapes-internal";
+import type {
+  LinkLoadConfig,
+  LinkStatus,
+  ShapeDefinition,
+} from "@osdk/api/unstable";
+import type { Client } from "@osdk/client";
+import { applyShapeTransformationsToArray } from "@osdk/client/unstable-do-not-use";
+import type {
+  ObservableClient,
+  Observer,
+  Unsubscribable,
+} from "@osdk/client/unstable-do-not-use";
+import {
+  createCachingNotifier,
+  createStoreSubscribe,
+  createVersionedCache,
+  wrapError,
+} from "../shared/storeUtils.js";
+import type { AnyShapeInstance } from "./types.js";
+import {
+  isBatchableLink,
+  NOOP_FETCH_MORE,
+  violationsToError,
+} from "./types.js";
+
+export interface BatchedDerivedLinksPayload<
+  S extends ShapeDefinition<ObjectOrInterfaceDefinition>,
+> {
+  linksBySourcePk: Map<string | number, Record<string, AnyShapeInstance[]>>;
+  linkStatusBySourcePk: Map<
+    string | number,
+    Partial<Record<string, LinkStatus>>
+  >;
+  aggregatedLinkStatus: Partial<Record<string, LinkStatus>>;
+  anyLoading: boolean;
+  anyError: boolean;
+}
+
+export interface BatchedDerivedLinksStore<
+  S extends ShapeDefinition<ObjectOrInterfaceDefinition>,
+> {
+  subscribe: (notify: () => void) => () => void;
+  getSnapshot: () => BatchedDerivedLinksPayload<S>;
+  updateSourceObjects: (
+    sourceObjects: Osdk.Instance<ObjectOrInterfaceDefinition>[],
+    transformedData: AnyShapeInstance[],
+  ) => void;
+  loadDeferred: (sourcePk: string | number, linkName: string) => void;
+  retry: (sourcePk?: string | number, linkName?: string) => void;
+  destroy: () => void;
+}
+
+interface TransformedSourceData {
+  data: AnyShapeInstance[];
+  error?: Error;
+}
+
+interface BatchableLinkState {
+  linkDef: ShapeDerivedLinkDef;
+  status: "init" | "loading" | "loaded" | "error" | "deferred";
+  error?: Error;
+  subscription?: Unsubscribable;
+  transformedBySourcePk: Map<string | number, TransformedSourceData>;
+  hasMore: boolean;
+  fetchMore: () => Promise<void>;
+}
+
+export function createEmptyBatchedDerivedLinksStore<
+  S extends ShapeDefinition<ObjectOrInterfaceDefinition>,
+>(): BatchedDerivedLinksStore<S> {
+  const emptyPayload: BatchedDerivedLinksPayload<S> = {
+    linksBySourcePk: new Map(),
+    linkStatusBySourcePk: new Map(),
+    aggregatedLinkStatus: {},
+    anyLoading: false,
+    anyError: false,
+  };
+
+  return {
+    subscribe: () => () => {},
+    getSnapshot: () => emptyPayload,
+    updateSourceObjects: () => {},
+    loadDeferred: () => {},
+    retry: () => {},
+    destroy: () => {},
+  };
+}
+
+// observeLinks is strongly typed but shapes work with erased types.
+// This local alias lets us call it with string link names and untyped objects.
+type ObserveLinksUntyped = (
+  objects: ReadonlyArray<Osdk.Instance<ObjectOrInterfaceDefinition>>,
+  linkName: string,
+  options: {
+    pageSize?: number;
+    dedupeInterval?: number;
+  },
+  subFn: Observer<{
+    linkedObjectsBySourcePrimaryKey: ReadonlyMap<
+      string | number,
+      ReadonlyArray<Osdk.Instance<ObjectOrInterfaceDefinition>>
+    >;
+    resolvedList: Osdk.Instance<ObjectOrInterfaceDefinition>[] | undefined;
+    isOptimistic: boolean;
+    lastUpdated: number;
+    fetchMore: () => Promise<void>;
+    hasMore: boolean;
+    status: string;
+  }>,
+) => Unsubscribable;
+
+// Adapter to bridge the strongly-typed observeLinks signature to the
+// untyped ObserveLinksUntyped used internally. The any casts are
+// contained here instead of spread through call sites.
+function adaptObserveLinks(
+  observeLinks: ObservableClient["observeLinks"],
+): ObserveLinksUntyped {
+  return (objects, linkName, options, subFn) => {
+    return observeLinks(
+      objects as ReadonlyArray<Osdk.Instance<ObjectOrInterfaceDefinition>>,
+      linkName as Parameters<ObservableClient["observeLinks"]>[1],
+      options as Parameters<ObservableClient["observeLinks"]>[2],
+      subFn as Parameters<ObservableClient["observeLinks"]>[3],
+    );
+  };
+}
+
+export function createBatchedDerivedLinksStore<
+  S extends ShapeDefinition<ObjectOrInterfaceDefinition>,
+>(
+  shape: S,
+  allLinks: readonly ShapeDerivedLinkDef[],
+  observableClient: ObservableClient,
+  client: Client,
+  linkConfig: Partial<Record<string, LinkLoadConfig>>,
+): BatchedDerivedLinksStore<S> {
+  const batchableLinks: ShapeDerivedLinkDef[] = [];
+  for (const linkDef of allLinks) {
+    if (isBatchableLink(linkDef)) {
+      batchableLinks.push(linkDef);
+    }
+  }
+
+  const subscribers = new Set<() => void>();
+  const cache = createVersionedCache<BatchedDerivedLinksPayload<S>>();
+  const rawNotify = createCachingNotifier(subscribers, cache);
+  function notifySubscribers(): void {
+    rawNotify();
+  }
+
+  const linkStates = new Map<string, BatchableLinkState>();
+
+  let currentSourceObjects: Osdk.Instance<ObjectOrInterfaceDefinition>[] = [];
+  let destroyed = false;
+
+  const observeLinksUntyped = adaptObserveLinks(observableClient.observeLinks);
+
+  for (const linkDef of batchableLinks) {
+    const config = linkConfig[linkDef.name];
+    const isDeferred = linkDef.config.defer ?? config?.defer ?? false;
+
+    linkStates.set(linkDef.name, {
+      linkDef,
+      status: isDeferred ? "deferred" : "init",
+      error: undefined,
+      subscription: undefined,
+      transformedBySourcePk: new Map(),
+      hasMore: false,
+      fetchMore: NOOP_FETCH_MORE,
+    });
+  }
+
+  function teardownSubscription(state: BatchableLinkState): void {
+    if (state.subscription) {
+      state.subscription.unsubscribe();
+      state.subscription = undefined;
+    }
+  }
+
+  function teardownBatchedSubscriptions(): void {
+    for (const state of linkStates.values()) {
+      teardownSubscription(state);
+    }
+  }
+
+  function cleanupAll(): void {
+    teardownBatchedSubscriptions();
+  }
+
+  function startObserveLinks(
+    state: BatchableLinkState,
+    sourceObjects: Osdk.Instance<ObjectOrInterfaceDefinition>[],
+  ): void {
+    teardownSubscription(state);
+    const linkApiName = state.linkDef.objectSetDef.segments[0].linkName;
+    const config = linkConfig[state.linkDef.name];
+
+    if (sourceObjects.length === 0) {
+      state.status = "loaded";
+      state.transformedBySourcePk.clear();
+      state.hasMore = false;
+      state.fetchMore = NOOP_FETCH_MORE;
+      return;
+    }
+
+    state.status = "loading";
+    state.error = undefined;
+
+    state.subscription = observeLinksUntyped(
+      sourceObjects,
+      linkApiName,
+      {
+        pageSize: config?.pageSize,
+      },
+      {
+        next: (payload) => {
+          if (destroyed) {
+            return;
+          }
+
+          state.transformedBySourcePk.clear();
+          for (
+            const [pk, objects] of payload.linkedObjectsBySourcePrimaryKey
+          ) {
+            const result = applyShapeTransformationsToArray(
+              state.linkDef.targetShape,
+              [...objects],
+            );
+            state.transformedBySourcePk.set(pk, {
+              data: result.data,
+              error: violationsToError(
+                state.linkDef.targetShape,
+                result.violations,
+              ),
+            });
+          }
+
+          state.status = payload.status === "loading" ? "loading" : "loaded";
+          state.hasMore = payload.hasMore;
+          state.fetchMore = payload.fetchMore;
+          state.error = undefined;
+          notifySubscribers();
+        },
+        error: (err) => {
+          if (destroyed) {
+            return;
+          }
+          state.status = "error";
+          state.error = wrapError(err);
+          notifySubscribers();
+        },
+        complete: () => {},
+      },
+    );
+  }
+
+  function updateSourceObjects(
+    sourceObjects: Osdk.Instance<ObjectOrInterfaceDefinition>[],
+    transformedData: AnyShapeInstance[],
+  ): void {
+    if (destroyed) {
+      return;
+    }
+    currentSourceObjects = sourceObjects;
+
+    for (const state of linkStates.values()) {
+      if (state.status !== "deferred") {
+        startObserveLinks(state, sourceObjects);
+      }
+    }
+    notifySubscribers();
+  }
+
+  function buildSnapshot(): BatchedDerivedLinksPayload<S> {
+    return cache.get(() => {
+      const linksBySourcePk = new Map<
+        string | number,
+        Record<string, AnyShapeInstance[]>
+      >();
+      const linkStatusBySourcePk = new Map<
+        string | number,
+        Partial<Record<string, LinkStatus>>
+      >();
+      let anyLoading = false;
+      let anyError = false;
+
+      for (const obj of currentSourceObjects) {
+        const sourcePk = obj.$primaryKey;
+        const links: Record<string, AnyShapeInstance[]> = {};
+        const statuses: Partial<Record<string, LinkStatus>> = {};
+
+        for (const [linkName, state] of linkStates) {
+          const precomputed = state.transformedBySourcePk.get(sourcePk);
+          links[linkName] = precomputed?.data ?? [];
+          statuses[linkName] = {
+            isLoading: state.status === "loading" || state.status === "init",
+            error: state.error ?? precomputed?.error,
+            hasMore: state.hasMore,
+            fetchMore: state.fetchMore,
+          };
+        }
+
+        linksBySourcePk.set(sourcePk, links);
+        linkStatusBySourcePk.set(sourcePk, statuses);
+      }
+
+      const aggregatedLinkStatus: Partial<Record<string, LinkStatus>> = {};
+
+      for (const [linkName, state] of linkStates) {
+        const isLoadingOrInit = state.status === "loading"
+          || state.status === "init";
+        if (isLoadingOrInit) {
+          anyLoading = true;
+        }
+        if (state.status === "error") {
+          anyError = true;
+        }
+
+        aggregatedLinkStatus[linkName] = {
+          isLoading: isLoadingOrInit,
+          error: state.error,
+          hasMore: state.hasMore,
+          fetchMore: state.fetchMore,
+        };
+      }
+
+      return {
+        linksBySourcePk,
+        linkStatusBySourcePk,
+        aggregatedLinkStatus,
+        anyLoading,
+        anyError,
+      };
+    });
+  }
+
+  const subscribe = createStoreSubscribe(subscribers, () => {}, cleanupAll);
+
+  function loadDeferred(
+    sourcePk: string | number,
+    linkName: string,
+  ): void {
+    const state = linkStates.get(linkName);
+    if (state) {
+      if (state.status !== "deferred") {
+        return;
+      }
+      startObserveLinks(state, currentSourceObjects);
+      notifySubscribers();
+    }
+  }
+
+  function retry(sourcePk?: string | number, linkName?: string): void {
+    const retryBatchedState = (state: BatchableLinkState) => {
+      if (state.status !== "error") {
+        return;
+      }
+      startObserveLinks(state, currentSourceObjects);
+      notifySubscribers();
+    };
+
+    if (linkName) {
+      const state = linkStates.get(linkName);
+      if (state) {
+        retryBatchedState(state);
+      }
+    } else {
+      for (const state of linkStates.values()) {
+        retryBatchedState(state);
+      }
+    }
+  }
+
+  function destroy(): void {
+    destroyed = true;
+    cleanupAll();
+  }
+
+  return {
+    subscribe,
+    getSnapshot: buildSnapshot,
+    updateSourceObjects,
+    loadDeferred,
+    retry,
+    destroy,
+  };
+}

--- a/packages/react/src/new/shapes/batchedDerivedLinksStore.ts
+++ b/packages/react/src/new/shapes/batchedDerivedLinksStore.ts
@@ -127,9 +127,10 @@ type ObserveLinksUntyped = (
   }>,
 ) => Unsubscribable;
 
-// Adapter to bridge the strongly-typed observeLinks signature to the
-// untyped ObserveLinksUntyped used internally. The any casts are
-// contained here instead of spread through call sites.
+// Bridges observeLinks, whose generics require the concrete object and link
+// types, to the erased-type alias shapes operate on (string link names,
+// untyped instances). The casts are confined to this one adapter instead of
+// being repeated at every call site.
 function adaptObserveLinks(
   observeLinks: ObservableClient["observeLinks"],
 ): ObserveLinksUntyped {
@@ -141,6 +142,25 @@ function adaptObserveLinks(
       subFn as Parameters<ObservableClient["observeLinks"]>[3],
     );
   };
+}
+
+function sameSourcePkSet(
+  a: ReadonlyArray<Osdk.Instance<ObjectOrInterfaceDefinition>>,
+  b: ReadonlyArray<Osdk.Instance<ObjectOrInterfaceDefinition>>,
+): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  const seen = new Set<string | number>();
+  for (const obj of a) {
+    seen.add(obj.$primaryKey);
+  }
+  for (const obj of b) {
+    if (!seen.has(obj.$primaryKey)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 export function createBatchedDerivedLinksStore<
@@ -170,6 +190,7 @@ export function createBatchedDerivedLinksStore<
 
   let currentSourceObjects: Osdk.Instance<ObjectOrInterfaceDefinition>[] = [];
   let destroyed = false;
+  let observationsActive = false;
 
   const observeLinksUntyped = adaptObserveLinks(observableClient.observeLinks);
 
@@ -203,6 +224,16 @@ export function createBatchedDerivedLinksStore<
 
   function cleanupAll(): void {
     teardownBatchedSubscriptions();
+    observationsActive = false;
+  }
+
+  function startAllNonDeferred(): void {
+    for (const state of linkStates.values()) {
+      if (state.status !== "deferred") {
+        startObserveLinks(state, currentSourceObjects);
+      }
+    }
+    observationsActive = true;
   }
 
   function startObserveLinks(
@@ -279,13 +310,19 @@ export function createBatchedDerivedLinksStore<
     if (destroyed) {
       return;
     }
-    currentSourceObjects = sourceObjects;
-
-    for (const state of linkStates.values()) {
-      if (state.status !== "deferred") {
-        startObserveLinks(state, sourceObjects);
-      }
+    // observeLinks is keyed by source primary key, so a new list reference
+    // carrying the same pks (revalidation, stream update) resolves the exact
+    // same links. Restarting in that case tears down and re-subscribes every
+    // link and flashes a loading state, so skip it when the pk set is unchanged.
+    if (
+      observationsActive
+      && sameSourcePkSet(currentSourceObjects, sourceObjects)
+    ) {
+      currentSourceObjects = sourceObjects;
+      return;
     }
+    currentSourceObjects = sourceObjects;
+    startAllNonDeferred();
     notifySubscribers();
   }
 
@@ -334,9 +371,24 @@ export function createBatchedDerivedLinksStore<
           anyError = true;
         }
 
+        // Subscription errors live on the state; shape transformation
+        // violations live per source pk. Surface either one in the aggregate
+        // so a require/transform violation isn't invisible to consumers that
+        // only read aggregatedLinkStatus (matches the per-source statuses and
+        // the per-item store's link error fidelity).
+        let linkError = state.error;
+        if (linkError == null) {
+          for (const transformed of state.transformedBySourcePk.values()) {
+            if (transformed.error != null) {
+              linkError = transformed.error;
+              break;
+            }
+          }
+        }
+
         aggregatedLinkStatus[linkName] = {
           isLoading: isLoadingOrInit,
-          error: state.error,
+          error: linkError,
           hasMore: state.hasMore,
           fetchMore: state.fetchMore,
         };
@@ -352,7 +404,22 @@ export function createBatchedDerivedLinksStore<
     });
   }
 
-  const subscribe = createStoreSubscribe(subscribers, () => {}, cleanupAll);
+  // The first subscribe arrives after updateSourceObjects has already started
+  // observation. A later re-subscribe (remount / StrictMode) finds the
+  // subscriptions torn down by cleanupAll on the previous last-unsubscribe, so
+  // re-arm from the retained source objects instead of going dormant forever.
+  function onResubscribe(): void {
+    if (!observationsActive && currentSourceObjects.length > 0) {
+      startAllNonDeferred();
+      notifySubscribers();
+    }
+  }
+
+  const subscribe = createStoreSubscribe(
+    subscribers,
+    onResubscribe,
+    cleanupAll,
+  );
 
   function loadDeferred(
     sourcePk: string | number,


### PR DESCRIPTION
list mode link store that batches simple pivot links into one observeLinks call

• single hop pivots with no filters resolve for the whole list in one request
• per source primary key snapshot and aggregated link status

incorporates resolved review feedback from #2836.
