### PR TITLE
add shape projection hooks

### DIFF
--- a/.changeset/shapes-hooks.md
+++ b/.changeset/shapes-hooks.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react": patch
+---
+
+add useShapeSingle and useShapeList shape projection hooks

--- a/packages/react/src/new/shapes/useShape.ts
+++ b/packages/react/src/new/shapes/useShape.ts
@@ -16,10 +16,12 @@
 
 import type {
   ObjectOrInterfaceDefinition,
+  Osdk,
   PrimaryKeyType,
   PropertyKeys,
   WhereClause,
 } from "@osdk/api";
+import type { ShapeDerivedLinkDef } from "@osdk/api/shapes-internal";
 import type {
   LinkLoadConfig,
   LinkStatus,
@@ -29,6 +31,31 @@ import type {
   ShapeDerivedLinks,
   ShapeInstance,
 } from "@osdk/api/unstable";
+import { ShapeNullabilityError } from "@osdk/api/unstable";
+import type {
+  ObserveObjectCallbackArgs,
+  ObserveObjectsCallbackArgs,
+} from "@osdk/client/observable";
+import {
+  applyShapeTransformations,
+  applyShapeTransformationsToArray,
+} from "@osdk/client/unstable-do-not-use";
+import React from "react";
+import { devToolsMetadata, makeExternalStore } from "../makeExternalStore.js";
+import { OsdkContext } from "../OsdkContext.js";
+import { useStableValue } from "../shared/storeUtils.js";
+import {
+  createBatchedDerivedLinksStore,
+  createEmptyBatchedDerivedLinksStore,
+} from "./batchedDerivedLinksStore.js";
+import {
+  createDerivedLinksStore,
+  createEmptyDerivedLinksStore,
+} from "./derivedLinksStore.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 export interface UseShapeResult<
   S extends ShapeDefinition<ObjectOrInterfaceDefinition>,
@@ -88,24 +115,466 @@ export interface UseShapeListResult<
   invalidate: (linkName?: keyof ShapeDerivedLinks<S>) => void;
 }
 
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
 export function useShapeSingle<
   S extends ShapeDefinition<ObjectOrInterfaceDefinition>,
 >(
-  _shape: S,
-  _primaryKey: PrimaryKeyType<ShapeBaseType<S>>,
-  _options?: {
+  shape: S,
+  primaryKey: PrimaryKeyType<ShapeBaseType<S>>,
+  options?: {
     enabled?: boolean;
-    links?: Partial<{ [K in keyof ShapeDerivedLinks<S>]: LinkLoadConfig }>;
+    links?: Partial<Record<string, LinkLoadConfig>> | undefined;
   },
 ): UseShapeResult<S> {
-  throw new Error("useShapeSingle is not implemented yet");
+  const { enabled = true, links: linkConfig = {} } = options ?? {};
+  const { observableClient, client } = React.useContext(OsdkContext);
+  const objectType = shape.__baseTypeApiName;
+
+  const selectProps = React.useMemo(
+    () => Object.keys(shape.__props) as PropertyKeys<ShapeBaseType<S>>[],
+    [shape.__props],
+  );
+
+  const baseStore = React.useMemo(
+    () => {
+      if (!enabled) {
+        return makeExternalStore<ObserveObjectCallbackArgs<ShapeBaseType<S>>>(
+          () => ({ unsubscribe: () => {} }),
+          devToolsMetadata({
+            hookType: "useShapeSingle",
+            objectType,
+            primaryKey: String(primaryKey),
+          }),
+        );
+      }
+
+      return makeExternalStore<ObserveObjectCallbackArgs<ShapeBaseType<S>>>(
+        (observer) =>
+          observableClient.observeObject(objectType, primaryKey, {
+            mode: undefined,
+            ...(selectProps.length > 0 ? { select: selectProps } : {}),
+          }, observer),
+        devToolsMetadata({
+          hookType: "useShapeSingle",
+          objectType,
+          primaryKey: String(primaryKey),
+        }),
+      );
+    },
+    [
+      enabled,
+      observableClient,
+      objectType,
+      primaryKey,
+      shape.__shapeId,
+      selectProps,
+    ],
+  );
+
+  const basePayload = React.useSyncExternalStore(
+    baseStore.subscribe,
+    baseStore.getSnapShot,
+  );
+
+  const transformResult = React.useMemo(() => {
+    if (!basePayload?.object) {
+      return {
+        data: undefined,
+        dropped: false,
+        violations: [] as NullabilityViolation[],
+      };
+    }
+    return applyShapeTransformations(
+      shape,
+      basePayload.object as Osdk.Instance<ShapeBaseType<S>>,
+    );
+  }, [shape, basePayload?.object]);
+
+  const stableLinkConfig = useStableValue(linkConfig) as Partial<
+    Record<keyof ShapeDerivedLinks<S>, LinkLoadConfig>
+  >;
+
+  const sourceObject = basePayload?.object as
+    | Osdk.Instance<ShapeBaseType<S>>
+    | undefined;
+
+  const linksStore = React.useMemo(() => {
+    if (
+      !enabled || !sourceObject || shape.__derivedLinks.length === 0
+    ) {
+      return createEmptyDerivedLinksStore<S>();
+    }
+    return createDerivedLinksStore<S>(
+      shape,
+      sourceObject,
+      observableClient,
+      client,
+      stableLinkConfig,
+    );
+  }, [
+    enabled,
+    // Use $primaryKey instead of sourceObject to avoid store recreation on same-PK re-renders
+    sourceObject?.$primaryKey,
+    shape.__shapeId,
+    observableClient,
+    client,
+    stableLinkConfig,
+  ]);
+
+  const linksPayload = React.useSyncExternalStore(
+    linksStore.subscribe,
+    linksStore.getSnapShot,
+  );
+
+  const dataWithLinks = React.useMemo(() => {
+    if (!transformResult.data) {
+      return undefined;
+    }
+    if (Object.keys(linksPayload.links).length === 0) {
+      return transformResult.data;
+    }
+    // ShapeInstance<S> is a conditional type which TS can't spread directly
+    return ({
+      ...transformResult.data as Record<string, unknown>,
+      ...linksPayload.links,
+    }) as ShapeInstance<S>;
+  }, [transformResult.data, linksPayload.links]);
+
+  const invalidate = React.useCallback(
+    (linkName?: keyof ShapeDerivedLinks<S>): void => {
+      if (linkName) {
+        const derivedLinks = shape
+          .__derivedLinks as readonly ShapeDerivedLinkDef[];
+        const linkDef = derivedLinks.find(l => l.name === linkName);
+        if (linkDef) {
+          void observableClient.invalidateObjectType(
+            linkDef.targetShape.__baseTypeApiName,
+          );
+        }
+      } else {
+        void observableClient.invalidateObjectType(objectType);
+      }
+    },
+    [observableClient, shape, objectType],
+  );
+
+  const baseLoading = enabled
+    ? (basePayload?.status === "loading" || basePayload?.status === "init"
+      || !basePayload)
+    : false;
+
+  return React.useMemo(() => {
+    let error: Error | undefined;
+    if (basePayload && "error" in basePayload && basePayload.error) {
+      error = basePayload.error;
+    } else if (basePayload?.status === "error") {
+      error = new Error("Failed to load object");
+    } else if (
+      transformResult.violations.some((v) => v.constraint === "require")
+    ) {
+      error = new ShapeNullabilityError(shape, transformResult.violations);
+    } else if (linksPayload.anyError) {
+      for (const [, status] of Object.entries(linksPayload.linkStatus)) {
+        const ls = status as LinkStatus | undefined;
+        if (ls?.error) {
+          error = ls.error;
+          break;
+        }
+      }
+    }
+
+    return {
+      data: dataWithLinks,
+      isLoading: baseLoading || linksPayload.anyLoading,
+      isOptimistic: !!basePayload?.isOptimistic,
+      error,
+      droppedDueToNullability: transformResult.dropped,
+      nullabilityViolations: transformResult.violations,
+      linkStatus: linksPayload.linkStatus,
+      loadDeferred: linksStore.loadDeferred,
+      retry: linksStore.retry,
+      invalidate,
+    };
+  }, [
+    dataWithLinks,
+    basePayload,
+    baseLoading,
+    transformResult,
+    linksPayload,
+    linksStore,
+    invalidate,
+    shape,
+  ]);
 }
 
 export function useShapeList<
   S extends ShapeDefinition<ObjectOrInterfaceDefinition>,
 >(
-  _shape: S,
-  _options: UseShapeListOptions<S>,
+  shape: S,
+  options: UseShapeListOptions<S>,
 ): UseShapeListResult<S> {
-  throw new Error("useShapeList is not implemented yet");
+  const {
+    where,
+    pageSize,
+    orderBy,
+    autoFetchMore,
+    dedupeIntervalMs,
+    streamUpdates,
+    enabled = true,
+    links: linkConfig = {},
+  } = options;
+
+  const { observableClient, client } = React.useContext(OsdkContext);
+  const objectType = shape.__baseType;
+  const canonWhere = observableClient.canonicalizeWhereClause(where ?? {});
+  const stableCanonWhere = React.useMemo(
+    () => canonWhere,
+    [JSON.stringify(canonWhere)],
+  );
+
+  const stableOrderBy = useStableValue(orderBy);
+  const stableLinkConfig = useStableValue(linkConfig) as Partial<
+    Record<string, LinkLoadConfig>
+  >;
+
+  const { subscribe, getSnapShot } = React.useMemo(
+    () => {
+      if (!enabled) {
+        return makeExternalStore<ObserveObjectsCallbackArgs<ShapeBaseType<S>>>(
+          () => ({ unsubscribe: () => {} }),
+          devToolsMetadata({
+            hookType: "useShapeList",
+            objectType: objectType.apiName,
+          }),
+        );
+      }
+
+      return makeExternalStore<ObserveObjectsCallbackArgs<ShapeBaseType<S>>>(
+        (observer) =>
+          observableClient.observeList(
+            {
+              type: objectType,
+              where: stableCanonWhere,
+              pageSize,
+              orderBy: stableOrderBy,
+              dedupeInterval: dedupeIntervalMs ?? 2_000,
+              streamUpdates,
+              autoFetchMore,
+            },
+            observer,
+          ),
+        devToolsMetadata({
+          hookType: "useShapeList",
+          objectType: objectType.apiName,
+          where: canonWhere,
+          orderBy: stableOrderBy,
+          pageSize,
+        }),
+      );
+    },
+    [
+      enabled,
+      observableClient,
+      objectType,
+      stableCanonWhere,
+      pageSize,
+      stableOrderBy,
+      dedupeIntervalMs,
+      streamUpdates,
+      autoFetchMore,
+      shape.__shapeId,
+    ],
+  );
+
+  const payload = React.useSyncExternalStore(subscribe, getSnapShot);
+
+  const transformResult = React.useMemo(() => {
+    if (!payload?.resolvedList) {
+      return {
+        data: [] as ShapeInstance<S>[],
+        droppedCount: 0,
+        violations: [] as NullabilityViolation[],
+      };
+    }
+    return applyShapeTransformationsToArray(
+      shape,
+      payload.resolvedList as Osdk.Instance<ShapeBaseType<S>>[],
+    );
+  }, [shape, payload?.resolvedList]);
+
+  const linksStore = React.useMemo(() => {
+    if (!enabled || shape.__derivedLinks.length === 0) {
+      return createEmptyBatchedDerivedLinksStore<S>();
+    }
+    return createBatchedDerivedLinksStore<S>(
+      shape,
+      shape.__derivedLinks as readonly ShapeDerivedLinkDef[],
+      observableClient,
+      client,
+      stableLinkConfig,
+    );
+  }, [enabled, shape.__shapeId, observableClient, client, stableLinkConfig]);
+
+  const prevSourceRef = React.useRef<{
+    list: Osdk.Instance<ObjectOrInterfaceDefinition>[] | undefined;
+    store: typeof linksStore;
+  }>({ list: undefined, store: linksStore });
+  if (
+    payload?.resolvedList !== prevSourceRef.current.list
+    || linksStore !== prevSourceRef.current.store
+  ) {
+    prevSourceRef.current = {
+      list: payload?.resolvedList as
+        | Osdk.Instance<ObjectOrInterfaceDefinition>[]
+        | undefined,
+      store: linksStore,
+    };
+    if (payload?.resolvedList) {
+      linksStore.updateSourceObjects(
+        payload.resolvedList as Osdk.Instance<ObjectOrInterfaceDefinition>[],
+        transformResult.data,
+      );
+    }
+  }
+
+  const linksPayload = React.useSyncExternalStore(
+    linksStore.subscribe,
+    linksStore.getSnapshot,
+  );
+
+  const dataWithLinks = React.useMemo(() => {
+    if (!transformResult.data.length || shape.__derivedLinks.length === 0) {
+      return transformResult.data;
+    }
+    return transformResult.data.map(obj => {
+      const pkLinks = linksPayload.linksBySourcePk.get(obj.$primaryKey);
+      if (!pkLinks || Object.keys(pkLinks).length === 0) {
+        return obj;
+      }
+      return ({
+        ...obj as Record<string, unknown>,
+        ...pkLinks,
+      }) as ShapeInstance<S>;
+    });
+  }, [
+    transformResult.data,
+    linksPayload.linksBySourcePk,
+    shape.__derivedLinks.length,
+  ]);
+
+  type LinkStatusMap = Partial<
+    { [K in keyof ShapeDerivedLinks<S>]: LinkStatus }
+  >;
+
+  const itemLinkStatus = React.useMemo(() => {
+    return linksPayload.linkStatusBySourcePk as Map<
+      string | number,
+      LinkStatusMap
+    >;
+  }, [linksPayload.linkStatusBySourcePk]);
+
+  const linkStatus = React.useMemo(() => {
+    return linksPayload.aggregatedLinkStatus as LinkStatusMap;
+  }, [linksPayload.aggregatedLinkStatus]);
+
+  const invalidate = React.useCallback(
+    (linkName?: keyof ShapeDerivedLinks<S>): void => {
+      if (linkName) {
+        const derivedLinks = shape
+          .__derivedLinks as readonly ShapeDerivedLinkDef[];
+        const linkDef = derivedLinks.find(l => l.name === linkName);
+        if (linkDef) {
+          void observableClient.invalidateObjectType(
+            linkDef.targetShape.__baseTypeApiName,
+          );
+        }
+      } else {
+        void observableClient.invalidateObjectType(objectType.apiName);
+      }
+    },
+    [observableClient, shape, objectType.apiName],
+  );
+
+  const loadDeferred = React.useCallback(
+    (
+      pk: string | number,
+      linkName: keyof ShapeDerivedLinks<S>,
+    ) => {
+      linksStore.loadDeferred(pk, String(linkName));
+    },
+    [linksStore],
+  );
+
+  const retry = React.useCallback(
+    (
+      pk?: string | number,
+      linkName?: keyof ShapeDerivedLinks<S>,
+    ) => {
+      linksStore.retry(
+        pk,
+        linkName !== undefined ? String(linkName) : undefined,
+      );
+    },
+    [linksStore],
+  );
+
+  const baseLoading = enabled
+    ? (payload?.status === "loading" || payload?.status === "init" || !payload)
+    : false;
+
+  return React.useMemo(() => {
+    let error: Error | undefined;
+    if (payload && "error" in payload && payload.error) {
+      error = payload.error;
+    } else if (payload?.status === "error") {
+      error = new Error("Failed to load objects");
+    } else if (
+      transformResult.violations.some((v) => v.constraint === "require")
+    ) {
+      error = new ShapeNullabilityError(shape, transformResult.violations);
+    } else if (linksPayload.anyError) {
+      for (const [, statuses] of linksPayload.linkStatusBySourcePk) {
+        for (const [, status] of Object.entries(statuses)) {
+          const ls = status as LinkStatus | undefined;
+          if (ls?.error) {
+            error = ls.error;
+            break;
+          }
+        }
+        if (error) {
+          break;
+        }
+      }
+    }
+
+    return {
+      data: payload?.resolvedList ? dataWithLinks : undefined,
+      isLoading: baseLoading || linksPayload.anyLoading,
+      isOptimistic: payload?.isOptimistic ?? false,
+      error,
+      fetchMore: payload?.hasMore ? payload.fetchMore : undefined,
+      droppedCount: transformResult.droppedCount,
+      nullabilityViolations: transformResult.violations,
+      itemLinkStatus,
+      linkStatus,
+      loadDeferred,
+      retry,
+      invalidate,
+    };
+  }, [
+    dataWithLinks,
+    payload,
+    baseLoading,
+    transformResult,
+    linksPayload,
+    itemLinkStatus,
+    linkStatus,
+    loadDeferred,
+    retry,
+    invalidate,
+    shape,
+  ]);
 }


### PR DESCRIPTION
internal hooks powering the shape option for single objects and lists

• useShapeSingle minimizes fields and merges derived link data for one object
• useShapeList routes derived links through the batched store with per item status

incorporates resolved review feedback from #2836.
