### PR TITLE
wire shape option into useOsdkObject

### DIFF
--- a/.changeset/shapes-wire-object.md
+++ b/.changeset/shapes-wire-object.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react": patch
+---
+
+add shape option to useOsdkObject and react to inline config changes

--- a/packages/react/src/new/shapes/useStableShapeDefinition.ts
+++ b/packages/react/src/new/shapes/useStableShapeDefinition.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectOrInterfaceDefinition } from "@osdk/api";
+import type { InlineShapeConfig, ShapeDefinition } from "@osdk/api/unstable";
+import { configToShapeDefinition } from "@osdk/api/unstable";
+import React from "react";
+
+/**
+ * Resolves the shape definition for a hook's `shape` option.
+ *
+ * Pre-built shapes already carry a __shapeId and pass through unchanged.
+ * Inline configs must stay reactive: the definition is recomputed each render
+ * so structural config changes take effect, but the previous definition is
+ * reused while its content hash (__shapeId) is unchanged so downstream
+ * memoization keyed on the shape identity stays stable.
+ */
+export function useStableShapeDefinition<
+  Q extends ObjectOrInterfaceDefinition,
+>(
+  type: Q,
+  rawShape: InlineShapeConfig<Q> | ShapeDefinition<Q>,
+): ShapeDefinition<Q> {
+  const derivedShapeRef = React.useRef<
+    { id: string; def: ShapeDefinition<Q> } | undefined
+  >(undefined);
+
+  const isPreBuilt = typeof rawShape === "object" && rawShape != null
+    && "__shapeId" in rawShape;
+
+  if (isPreBuilt) {
+    return rawShape as ShapeDefinition<Q>;
+  }
+
+  const derived = configToShapeDefinition(
+    type,
+    rawShape as InlineShapeConfig<Q>,
+  );
+  if (
+    derivedShapeRef.current == null
+    || derivedShapeRef.current.id !== derived.__shapeId
+  ) {
+    derivedShapeRef.current = { id: derived.__shapeId, def: derived };
+  }
+  return derivedShapeRef.current.def;
+}

--- a/packages/react/src/new/useOsdkObject.ts
+++ b/packages/react/src/new/useOsdkObject.ts
@@ -16,14 +16,28 @@
 
 import type {
   ObjectOrInterfaceDefinition,
+  ObjectTypeDefinition,
   Osdk,
   PrimaryKeyType,
   PropertyKeys,
 } from "@osdk/api";
+import type {
+  InferShapeDefinition,
+  InlineShapeConfig,
+  LinkLoadConfig,
+  LinkStatus,
+  NullabilityViolation,
+  ShapeDefinition,
+  ShapeDerivedLinks,
+  ShapeInstance,
+} from "@osdk/api/unstable";
 import type { ObserveObjectCallbackArgs } from "@osdk/client/observable";
 import React from "react";
 import { devToolsMetadata, makeExternalStore } from "./makeExternalStore.js";
 import { OsdkContext } from "./OsdkContext.js";
+import type { UseShapeResult } from "./shapes/useShape.js";
+import { useShapeSingle } from "./shapes/useShape.js";
+import { useStableShapeDefinition } from "./shapes/useStableShapeDefinition.js";
 
 export interface UseOsdkObjectResult<
   Q extends ObjectOrInterfaceDefinition,
@@ -38,6 +52,48 @@ export interface UseOsdkObjectResult<
    */
   isOptimistic: boolean;
   forceUpdate: () => void;
+}
+
+/**
+ * Options for useOsdkObject with inline shape config.
+ */
+export interface UseOsdkObjectShapeOptions<
+  Q extends ObjectTypeDefinition,
+  C extends InlineShapeConfig<Q>,
+> {
+  shape: C;
+  enabled?: boolean;
+  links?: Partial<Record<string, LinkLoadConfig>>;
+}
+
+/**
+ * Result type for useOsdkObject with inline shape config.
+ */
+export interface UseOsdkObjectShapeResult<
+  Q extends ObjectTypeDefinition,
+  C extends InlineShapeConfig<Q>,
+> {
+  data: ShapeInstance<InferShapeDefinition<Q, C>> | undefined;
+  shape: InferShapeDefinition<Q, C>;
+  isLoading: boolean;
+  error: Error | undefined;
+  isOptimistic: boolean;
+  droppedDueToNullability: boolean;
+  nullabilityViolations: readonly NullabilityViolation[];
+  linkStatus: Partial<
+    {
+      [K in keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>]: LinkStatus;
+    }
+  >;
+  loadDeferred: (
+    linkName: keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>,
+  ) => void;
+  retry: (
+    linkName?: keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>,
+  ) => void;
+  invalidate: (
+    linkName?: keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>,
+  ) => void;
 }
 
 export interface UseOsdkObjectOptions<
@@ -93,11 +149,44 @@ export function useOsdkObject<
   primaryKey: PrimaryKeyType<Q>,
   options?: UseOsdkObjectOptions<Q>,
 ): UseOsdkObjectResult<Q>;
+/**
+ * Loads an object by type and primary key with an inline shape config.
+ * The shape defines nullability constraints, defaults, transforms, and derived links.
+ *
+ * @param type
+ * @param primaryKey
+ * @param options Options including the inline shape config
+ */
+export function useOsdkObject<
+  Q extends ObjectTypeDefinition,
+  const C extends InlineShapeConfig<Q>,
+>(
+  type: Q,
+  primaryKey: PrimaryKeyType<Q>,
+  options: UseOsdkObjectShapeOptions<Q, C>,
+): UseOsdkObjectShapeResult<Q, C>;
+/**
+ * Loads an object by type and primary key with a pre-built ShapeDefinition.
+ */
+export function useOsdkObject<
+  S extends ShapeDefinition<ObjectTypeDefinition>,
+>(
+  type: S extends ShapeDefinition<infer Q> ? Q : ObjectTypeDefinition,
+  primaryKey: PrimaryKeyType<
+    S extends ShapeDefinition<infer Q> ? Q : ObjectTypeDefinition
+  >,
+  options: {
+    shape: S;
+    enabled?: boolean;
+    links?: Partial<Record<string, LinkLoadConfig>>;
+  },
+): UseShapeResult<S>;
 /*
     Implementation of useOsdkObject
  */
 export function useOsdkObject<
   Q extends ObjectOrInterfaceDefinition,
+  C extends InlineShapeConfig<Q> = InlineShapeConfig<Q>,
 >(
   ...args:
     | [obj: Osdk.Instance<Q>, enabled?: boolean]
@@ -107,22 +196,159 @@ export function useOsdkObject<
       primaryKey: PrimaryKeyType<Q>,
       options?: UseOsdkObjectOptions<Q>,
     ]
+    | [
+      type: Q,
+      primaryKey: PrimaryKeyType<Q>,
+      options: UseOsdkObjectShapeOptions<
+        Q & ObjectTypeDefinition,
+        C & InlineShapeConfig<Q & ObjectTypeDefinition>
+      >,
+    ]
+    | [
+      type: Q,
+      primaryKey: PrimaryKeyType<Q>,
+      options: {
+        shape: ShapeDefinition<Q>;
+        enabled?: boolean;
+        links?: Partial<Record<string, LinkLoadConfig>>;
+      },
+    ]
+):
+  | UseOsdkObjectResult<Q>
+  | UseOsdkObjectShapeResult<
+    Q & ObjectTypeDefinition,
+    C & InlineShapeConfig<Q & ObjectTypeDefinition>
+  >
+  | UseShapeResult<ShapeDefinition<Q>>
+{
+  const isInstanceSignature = "$objectType" in args[0];
+
+  const hasShapeOptions = !isInstanceSignature
+    && args.length >= 3
+    && typeof args[2] === "object"
+    && args[2] != null
+    && "shape" in args[2];
+
+  const modeRef = React.useRef(hasShapeOptions);
+  if (modeRef.current !== hasShapeOptions) {
+    throw new Error(
+      "useOsdkObject: cannot switch between shape/non-shape mode",
+    );
+  }
+
+  if (hasShapeOptions) {
+    return useOsdkObjectWithShape(
+      args[0] as Q,
+      args[1] as PrimaryKeyType<Q>,
+      args[2] as {
+        shape: C | ShapeDefinition<Q>;
+        enabled?: boolean;
+        links?: Partial<Record<string, LinkLoadConfig>>;
+      },
+    );
+  }
+
+  // Original overloads (instance or type+pk)
+
+  return useOsdkObjectBase(
+    args as
+      | [obj: Osdk.Instance<Q>, enabled?: boolean]
+      | [type: Q, primaryKey: PrimaryKeyType<Q>, enabled?: boolean]
+      | [
+        type: Q,
+        primaryKey: PrimaryKeyType<Q>,
+        options?: UseOsdkObjectOptions<Q>,
+      ],
+  );
+}
+
+function useOsdkObjectWithShape<
+  Q extends ObjectOrInterfaceDefinition,
+  C extends InlineShapeConfig<Q> = InlineShapeConfig<Q>,
+>(
+  type: Q,
+  primaryKey: PrimaryKeyType<Q>,
+  options: {
+    shape: C | ShapeDefinition<Q>;
+    enabled?: boolean;
+    links?: Partial<Record<string, LinkLoadConfig>>;
+  },
+):
+  | UseOsdkObjectShapeResult<
+    Q & ObjectTypeDefinition,
+    C & InlineShapeConfig<Q & ObjectTypeDefinition>
+  >
+  | UseShapeResult<ShapeDefinition<Q>>
+{
+  const rawShape = options.shape;
+
+  const isPreBuilt = typeof rawShape === "object" && rawShape != null
+    && "__shapeId" in rawShape;
+
+  const shapeDef = useStableShapeDefinition(type, rawShape);
+
+  const result = useShapeSingle(
+    shapeDef,
+    primaryKey,
+    { enabled: options.enabled, links: options.links },
+  );
+
+  if (isPreBuilt) {
+    return result;
+  }
+
+  type ResolvedC = C & InlineShapeConfig<Q & ObjectTypeDefinition>;
+  type ResolvedQ = Q & ObjectTypeDefinition;
+
+  return {
+    data: result.data as
+      | ShapeInstance<InferShapeDefinition<ResolvedQ, ResolvedC>>
+      | undefined,
+    shape: shapeDef as InferShapeDefinition<ResolvedQ, ResolvedC>,
+    isLoading: result.isLoading,
+    error: result.error,
+    isOptimistic: result.isOptimistic,
+    droppedDueToNullability: result.droppedDueToNullability,
+    nullabilityViolations: result.nullabilityViolations,
+    linkStatus: result.linkStatus as UseOsdkObjectShapeResult<
+      ResolvedQ,
+      ResolvedC
+    >["linkStatus"],
+    loadDeferred: result.loadDeferred as UseOsdkObjectShapeResult<
+      ResolvedQ,
+      ResolvedC
+    >["loadDeferred"],
+    retry: result.retry as UseOsdkObjectShapeResult<
+      ResolvedQ,
+      ResolvedC
+    >["retry"],
+    invalidate: result.invalidate as UseOsdkObjectShapeResult<
+      ResolvedQ,
+      ResolvedC
+    >["invalidate"],
+  };
+}
+
+function useOsdkObjectBase<Q extends ObjectOrInterfaceDefinition>(
+  args:
+    | [obj: Osdk.Instance<Q>, enabled?: boolean]
+    | [type: Q, primaryKey: PrimaryKeyType<Q>, enabled?: boolean]
+    | [
+      type: Q,
+      primaryKey: PrimaryKeyType<Q>,
+      options?: UseOsdkObjectOptions<Q>,
+    ],
 ): UseOsdkObjectResult<Q> {
   const { observableClient } = React.useContext(OsdkContext);
 
-  // Check if first arg is an instance to discriminate signatures
-  // TypeScript cannot narrow rest parameter unions with optional parameters,
-  // so we must use type assertions after runtime discrimination
   const isInstanceSignature = "$objectType" in args[0];
 
-  // Extract options object if provided (3rd arg is an object with $select or enabled)
   const optionsArg = !isInstanceSignature
       && args[2] != null
       && typeof args[2] === "object"
     ? args[2]
     : undefined;
 
-  // Extract enabled flag - 2nd param for instance signature, 3rd for type signature
   const enabled = isInstanceSignature
     ? (typeof args[1] === "boolean" ? args[1] : true)
     : optionsArg

--- a/packages/react/src/public/experimental.ts
+++ b/packages/react/src/public/experimental.ts
@@ -68,6 +68,11 @@ export { useOsdkObject } from "../new/useOsdkObject.js";
 
 /** @deprecated Import from `@osdk/react` instead. */
 export type {
+  UseOsdkObjectResult,
+  UseOsdkObjectShapeOptions,
+  UseOsdkObjectShapeResult,
+} from "../new/useOsdkObject.js";
+export type {
   UseOsdkListResult,
   UseOsdkObjectsOptions,
 } from "../new/useOsdkObjects.js";

--- a/packages/react/test/useOsdkObject.shape.test.tsx
+++ b/packages/react/test/useOsdkObject.shape.test.tsx
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectTypeDefinition } from "@osdk/api";
+import type { ShapePropertyConfig } from "@osdk/api/shapes-internal";
+import type { InlineShapeConfig, ShapeDefinition } from "@osdk/api/unstable";
+import { Employee } from "@osdk/client.test.ontology";
+import { renderHook } from "@testing-library/react";
+import * as React from "react";
+import { beforeEach, describe, expect, it, vitest } from "vitest";
+import { OsdkContext } from "../src/new/OsdkContext.js";
+import { useOsdkObject } from "../src/new/useOsdkObject.js";
+
+const MockObjectType = {
+  apiName: "MockObject",
+  primaryKeyType: "string",
+} as unknown as ObjectTypeDefinition;
+
+function makeMockShapeDefinition(
+  props: Record<string, ShapePropertyConfig>,
+): ShapeDefinition<typeof MockObjectType> {
+  return {
+    __shapeId: "test-shape-id",
+    __debugName: "TestShape",
+    __baseType: MockObjectType,
+    __baseTypeApiName: "MockObject",
+    __props: Object.freeze(props),
+    __derivedLinks: Object.freeze([]),
+    __selectedPropsType: {},
+    __derivedLinksType: {},
+  } as ShapeDefinition<typeof MockObjectType>;
+}
+
+describe("useOsdkObject with pre-built ShapeDefinition", () => {
+  const mockObserveObject = vitest.fn();
+
+  const createWrapper = () => {
+    const observableClient = {
+      observeObject: mockObserveObject,
+      canonicalizeWhereClause: vitest.fn((w: unknown) => w),
+      invalidateObjectType: vitest.fn(),
+    };
+
+    return ({ children }: React.PropsWithChildren) => (
+      <OsdkContext.Provider
+        value={{ observableClient, client: {} } as never}
+      >
+        {children}
+      </OsdkContext.Provider>
+    );
+  };
+
+  beforeEach(() => {
+    mockObserveObject.mockClear();
+    mockObserveObject.mockReturnValue({ unsubscribe: vitest.fn() });
+  });
+
+  it("should call observeObject with select for shape properties", () => {
+    const shape = makeMockShapeDefinition({
+      name: { nullabilityOp: { type: "require" } },
+      age: { nullabilityOp: { type: "select" } },
+    });
+    const wrapper = createWrapper();
+
+    renderHook(
+      () => useOsdkObject(MockObjectType, "pk-1", { shape }),
+      { wrapper },
+    );
+
+    expect(mockObserveObject).toHaveBeenCalledWith(
+      "MockObject",
+      "pk-1",
+      { mode: undefined, select: expect.arrayContaining(["name", "age"]) },
+      expect.any(Object),
+    );
+  });
+
+  it("should return loading state initially", () => {
+    const shape = makeMockShapeDefinition({
+      name: { nullabilityOp: { type: "select" } },
+    });
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () => useOsdkObject(MockObjectType, "pk-1", { shape }),
+      { wrapper },
+    );
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("should NOT call observeObject when enabled is false", () => {
+    const shape = makeMockShapeDefinition({
+      name: { nullabilityOp: { type: "select" } },
+    });
+    const wrapper = createWrapper();
+
+    renderHook(
+      () =>
+        useOsdkObject(MockObjectType, "pk-1", {
+          shape,
+          enabled: false,
+        }),
+      { wrapper },
+    );
+
+    expect(mockObserveObject).not.toHaveBeenCalled();
+  });
+
+  it("should return shape result fields (not plain object result)", () => {
+    const shape = makeMockShapeDefinition({
+      name: { nullabilityOp: { type: "select" } },
+    });
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () => useOsdkObject(MockObjectType, "pk-1", { shape }),
+      { wrapper },
+    );
+
+    expect(result.current).toHaveProperty("data");
+    expect(result.current).toHaveProperty("isLoading");
+    expect(result.current).toHaveProperty("droppedDueToNullability");
+    expect(result.current).toHaveProperty("nullabilityViolations");
+    expect(result.current).toHaveProperty("linkStatus");
+    expect(result.current).toHaveProperty("loadDeferred");
+    expect(result.current).toHaveProperty("retry");
+    expect(result.current).toHaveProperty("invalidate");
+    // Pre-built shapes should NOT have a `shape` field (that's for inline configs)
+    expect(result.current).not.toHaveProperty("shape");
+  });
+});
+
+describe("useOsdkObject with inline shape config", () => {
+  const mockObserveObject = vitest.fn();
+
+  const createWrapper = () => {
+    const observableClient = {
+      observeObject: mockObserveObject,
+      canonicalizeWhereClause: vitest.fn((w: unknown) => w),
+      invalidateObjectType: vitest.fn(),
+    };
+
+    return ({ children }: React.PropsWithChildren) => (
+      <OsdkContext.Provider
+        value={{ observableClient, client: {} } as never}
+      >
+        {children}
+      </OsdkContext.Provider>
+    );
+  };
+
+  beforeEach(() => {
+    mockObserveObject.mockClear();
+    mockObserveObject.mockReturnValue({ unsubscribe: vitest.fn() });
+  });
+
+  function lastSelect(): readonly string[] | undefined {
+    const calls = mockObserveObject.mock.calls;
+    const lastCall = calls[calls.length - 1];
+    return lastCall?.[2]?.select;
+  }
+
+  it("re-derives the shape when the inline config changes across renders", () => {
+    const wrapper = createWrapper();
+
+    const { rerender } = renderHook(
+      ({ config }: { config: InlineShapeConfig<typeof Employee> }) =>
+        useOsdkObject(Employee, 1, { shape: config }),
+      {
+        wrapper,
+        initialProps: {
+          config: { select: ["fullName"] } satisfies InlineShapeConfig<
+            typeof Employee
+          >,
+        },
+      },
+    );
+
+    expect(lastSelect()).toContain("fullName");
+    expect(lastSelect()).not.toContain("office");
+
+    rerender({
+      config: { select: ["office"] } satisfies InlineShapeConfig<
+        typeof Employee
+      >,
+    });
+
+    // With the freeze bug the projection stays pinned to the first config and
+    // never selects "office"; the reactive fix must pick up the new config.
+    expect(lastSelect()).toContain("office");
+  });
+
+  it("keeps the same shape definition when the config is structurally equal", () => {
+    const wrapper = createWrapper();
+
+    const { rerender } = renderHook(
+      ({ config }: { config: InlineShapeConfig<typeof Employee> }) =>
+        useOsdkObject(Employee, 1, { shape: config }),
+      {
+        wrapper,
+        initialProps: {
+          config: { select: ["fullName"] } satisfies InlineShapeConfig<
+            typeof Employee
+          >,
+        },
+      },
+    );
+
+    const callsAfterFirst = mockObserveObject.mock.calls.length;
+
+    // New object identity, same structural content: must not re-subscribe.
+    rerender({
+      config: { select: ["fullName"] } satisfies InlineShapeConfig<
+        typeof Employee
+      >,
+    });
+
+    expect(mockObserveObject.mock.calls.length).toBe(callsAfterFirst);
+  });
+});

--- a/packages/react/test/useOsdkObject.shape.test.tsx
+++ b/packages/react/test/useOsdkObject.shape.test.tsx
@@ -88,21 +88,6 @@ describe("useOsdkObject with pre-built ShapeDefinition", () => {
     );
   });
 
-  it("should return loading state initially", () => {
-    const shape = makeMockShapeDefinition({
-      name: { nullabilityOp: { type: "select" } },
-    });
-    const wrapper = createWrapper();
-
-    const { result } = renderHook(
-      () => useOsdkObject(MockObjectType, "pk-1", { shape }),
-      { wrapper },
-    );
-
-    expect(result.current.isLoading).toBe(true);
-    expect(result.current.data).toBeUndefined();
-  });
-
   it("should NOT call observeObject when enabled is false", () => {
     const shape = makeMockShapeDefinition({
       name: { nullabilityOp: { type: "select" } },
@@ -132,14 +117,6 @@ describe("useOsdkObject with pre-built ShapeDefinition", () => {
       { wrapper },
     );
 
-    expect(result.current).toHaveProperty("data");
-    expect(result.current).toHaveProperty("isLoading");
-    expect(result.current).toHaveProperty("droppedDueToNullability");
-    expect(result.current).toHaveProperty("nullabilityViolations");
-    expect(result.current).toHaveProperty("linkStatus");
-    expect(result.current).toHaveProperty("loadDeferred");
-    expect(result.current).toHaveProperty("retry");
-    expect(result.current).toHaveProperty("invalidate");
     // Pre-built shapes should NOT have a `shape` field (that's for inline configs)
     expect(result.current).not.toHaveProperty("shape");
   });


### PR DESCRIPTION
adds the shape option to the single object hook and makes inline configs reactive

• dispatches to a dedicated useOsdkObjectWithShape function guarded by a mode lock
• inline configs now re-derive on structural changes instead of freezing at mount

inline configs are re-derived through a shared useStableShapeDefinition helper keyed on the content hash __shapeId. that hash is built from a JSON stringify that drops function values, so a config differing only in a transforms or links.via callback hashes identically and will not re-derive. structural changes (require/select/defaults/link structure) are covered; callback-identity-only changes are not.

incorporates resolved review feedback from #2837.
