### PR TITLE
wire shape option into useOsdkObjects

### DIFF
--- a/.changeset/shapes-wire-objects.md
+++ b/.changeset/shapes-wire-objects.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react": patch
+---
+
+add shape option to useOsdkObjects and react to inline config changes

--- a/packages/react/src/new/useOsdkObjects.ts
+++ b/packages/react/src/new/useOsdkObjects.ts
@@ -25,11 +25,23 @@ import type {
   SimplePropertyDef,
   WhereClause,
 } from "@osdk/api";
+import type {
+  InferShapeDefinition,
+  InlineShapeConfig,
+  LinkStatus,
+  NullabilityViolation,
+  ShapeDefinition,
+  ShapeDerivedLinks,
+  ShapeInstance,
+} from "@osdk/api/unstable";
 import type { ObserveObjectsCallbackArgs } from "@osdk/client/observable";
 import React from "react";
 import { extractPayloadError, isPayloadLoading } from "./hookUtils.js";
 import { devToolsMetadata, makeExternalStore } from "./makeExternalStore.js";
 import { OsdkContext } from "./OsdkContext.js";
+import type { PerItemLinkStatus } from "./shapes/useShape.js";
+import { useShapeList } from "./shapes/useShape.js";
+import { useStableShapeDefinition } from "./shapes/useStableShapeDefinition.js";
 
 /**
  * Restricts `resolveToObjectType` to interface queries only.
@@ -232,6 +244,39 @@ export interface UseOsdkListResult<
   refetch: () => Promise<void>;
 }
 
+export interface UseOsdkObjectsShapeResult<
+  Q extends ObjectOrInterfaceDefinition,
+  C extends InlineShapeConfig<Q>,
+> {
+  data: ShapeInstance<InferShapeDefinition<Q, C>>[] | undefined;
+  shape: InferShapeDefinition<Q, C>;
+  isLoading: boolean;
+  error: Error | undefined;
+  isOptimistic: boolean;
+  fetchMore: (() => Promise<void>) | undefined;
+  droppedCount: number;
+  nullabilityViolations: readonly NullabilityViolation[];
+  itemLinkStatus: PerItemLinkStatus<InferShapeDefinition<Q, C>>;
+  linkStatus: Partial<
+    {
+      [K in keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>]: LinkStatus;
+    }
+  >;
+  loadDeferred: (
+    primaryKey: string | number,
+    linkName: keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>,
+  ) => void;
+  retry: (
+    primaryKey?: string | number,
+    linkName?: keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>,
+  ) => void;
+  invalidate: (
+    linkName?: keyof ShapeDerivedLinks<InferShapeDefinition<Q, C>>,
+  ) => void;
+}
+
+const EMPTY_WHERE = {};
+
 // pivotTo overloads: streamUpdates is forbidden (the server does not support
 // websocket subscriptions for link-traversal queries).
 export function useOsdkObjects<
@@ -254,6 +299,7 @@ export function useOsdkObjects<
   options: UseOsdkObjectsOptions<Q, {}> & {
     pivotTo: L;
     streamUpdates?: never;
+    shape?: never;
   },
 ): UseOsdkListResult<LinkedType<Q, L>, {}>;
 
@@ -272,6 +318,19 @@ export function useOsdkObjects<
 
 export function useOsdkObjects<
   Q extends ObjectOrInterfaceDefinition,
+  const C extends InlineShapeConfig<Q>,
+>(
+  type: Q,
+  options:
+    & Omit<
+      UseOsdkObjectsOptions<Q>,
+      "pivotTo" | "withProperties" | "rids" | "intersectWith"
+    >
+    & { shape: C; pivotTo?: never },
+): UseOsdkObjectsShapeResult<Q, C>;
+
+export function useOsdkObjects<
+  Q extends ObjectOrInterfaceDefinition,
   RDPs extends Record<string, SimplePropertyDef> = {},
 >(
   type: Q,
@@ -281,6 +340,40 @@ export function useOsdkObjects<
 ): UseOsdkListResult<Q, RDPs>;
 
 export function useOsdkObjects<
+  Q extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef> = {},
+  C extends InlineShapeConfig<Q> = InlineShapeConfig<Q>,
+>(
+  type: Q,
+  options?: UseOsdkObjectsOptions<Q, RDPs> & { shape?: C },
+):
+  | UseOsdkListResult<Q, RDPs>
+  | UseOsdkListResult<Q, RDPs, "$rid">
+  | UseOsdkListResult<LinkedType<Q, LinkNames<Q>>>
+  | UseOsdkListResult<LinkedType<Q, LinkNames<Q>>, {}, "$rid">
+  | UseOsdkObjectsShapeResult<Q, C>
+{
+  const hasShape = options !== undefined && "shape" in options
+    && options.shape !== undefined;
+
+  const modeRef = React.useRef(hasShape);
+  if (modeRef.current !== hasShape) {
+    throw new Error(
+      "useOsdkObjects: cannot switch between shape/non-shape mode",
+    );
+  }
+
+  if (hasShape) {
+    return useOsdkObjectsWithShape(
+      type,
+      options as UseOsdkObjectsOptions<Q> & { shape: C },
+    );
+  }
+
+  return useOsdkObjectsBase(type, options);
+}
+
+function useOsdkObjectsBase<
   Q extends ObjectOrInterfaceDefinition,
   RDPs extends Record<string, SimplePropertyDef> = {},
 >(
@@ -295,11 +388,11 @@ export function useOsdkObjects<
   const { observableClient } = React.useContext(OsdkContext);
 
   const {
+    rids,
     pageSize,
     dedupeIntervalMs,
     withProperties,
     enabled = true,
-    rids,
     where,
     orderBy,
     streamUpdates,
@@ -411,4 +504,55 @@ export function useOsdkObjects<
     }),
     [listPayload, enabled, refetch],
   );
+}
+
+function useOsdkObjectsWithShape<
+  Q extends ObjectOrInterfaceDefinition,
+  C extends InlineShapeConfig<Q>,
+>(
+  type: Q,
+  options: UseOsdkObjectsOptions<Q> & { shape: C },
+): UseOsdkObjectsShapeResult<Q, C> {
+  type S = InferShapeDefinition<Q, C>;
+
+  const shapeDef = useStableShapeDefinition(type, options.shape) as S;
+
+  const result = useShapeList(
+    shapeDef as ShapeDefinition<Q>,
+    {
+      where: options.where,
+      pageSize: options.pageSize,
+      orderBy: options.orderBy,
+      autoFetchMore: options.autoFetchMore,
+      dedupeIntervalMs: options.dedupeIntervalMs,
+      streamUpdates: options.streamUpdates,
+      enabled: options.enabled,
+      links: undefined,
+    },
+  );
+
+  return {
+    data: result.data as ShapeInstance<S>[] | undefined,
+    shape: shapeDef,
+    isLoading: result.isLoading,
+    error: result.error,
+    isOptimistic: result.isOptimistic,
+    fetchMore: result.fetchMore,
+    droppedCount: result.droppedCount,
+    nullabilityViolations: result.nullabilityViolations,
+    itemLinkStatus: result.itemLinkStatus as PerItemLinkStatus<S>,
+    linkStatus: result.linkStatus as UseOsdkObjectsShapeResult<
+      Q,
+      C
+    >["linkStatus"],
+    loadDeferred: result.loadDeferred as UseOsdkObjectsShapeResult<
+      Q,
+      C
+    >["loadDeferred"],
+    retry: result.retry as UseOsdkObjectsShapeResult<Q, C>["retry"],
+    invalidate: result.invalidate as UseOsdkObjectsShapeResult<
+      Q,
+      C
+    >["invalidate"],
+  };
 }

--- a/packages/react/src/public/experimental.ts
+++ b/packages/react/src/public/experimental.ts
@@ -75,6 +75,7 @@ export type {
 export type {
   UseOsdkListResult,
   UseOsdkObjectsOptions,
+  UseOsdkObjectsShapeResult,
 } from "../new/useOsdkObjects.js";
 
 /** @deprecated Import from `@osdk/react` instead. */


### PR DESCRIPTION
adds the shape option to the list hook and makes inline configs reactive

• dispatches to a dedicated useOsdkObjectsWithShape function guarded by a mode lock
• inline configs now re-derive on structural changes instead of freezing at mount

same __shapeId caveat as the single object hook: a config differing only in a transforms or links.via callback hashes identically and will not re-derive. structural changes are covered, callback-identity-only changes are not.

incorporates resolved review feedback from #2837.
