### PR TITLE
Fix full metadata generation for links

### DIFF
--- a/.changeset/smart-camels-find.md
+++ b/.changeset/smart-camels-find.md
@@ -1,0 +1,5 @@
+---
+"@osdk/generator-converters.ontologyir": patch
+---
+
+Fix full metadata link gen

--- a/packages/generator-converters.ontologyir/src/OntologyBlockDataToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyBlockDataToFullMetadataConverter.ts
@@ -246,7 +246,7 @@ export class OntologyBlockDataToFullMetadataConverter {
         linkType.status,
       );
 
-      let mappings: Record<string, Ontologies.LinkTypeSideV2>;
+      let mappings: Record<string, Ontologies.LinkTypeSideV2[]>;
       switch (linkType.definition.type) {
         case "manyToMany": {
           const linkDef = linkType.definition.manyToMany;
@@ -268,6 +268,8 @@ export class OntologyBlockDataToFullMetadataConverter {
             ...sideA,
             apiName: linkDef.objectTypeBToALinkMetadata.apiName
               ?? "",
+            displayName: linkDef.objectTypeBToALinkMetadata
+              .displayMetadata.displayName,
             objectTypeApiName: resolveBlockDataApiName(
               linkDef.objectTypeRidA,
               objectTypeLookup,
@@ -275,9 +277,11 @@ export class OntologyBlockDataToFullMetadataConverter {
           };
 
           mappings = {
-            [linkDef.objectTypeRidA]: sideA,
-            [linkDef.objectTypeRidB]: sideB,
+            [linkDef.objectTypeRidA]: [],
+            [linkDef.objectTypeRidB]: [],
           };
+          mappings[linkDef.objectTypeRidA].push(sideA);
+          mappings[linkDef.objectTypeRidB].push(sideB);
           break;
         }
         case "oneToMany": {
@@ -326,9 +330,11 @@ export class OntologyBlockDataToFullMetadataConverter {
           };
 
           mappings = {
-            [linkDef.objectTypeRidOneSide]: oneSide,
-            [linkDef.objectTypeRidManySide]: manySide,
+            [linkDef.objectTypeRidOneSide]: [],
+            [linkDef.objectTypeRidManySide]: [],
           };
+          mappings[linkDef.objectTypeRidOneSide].push(oneSide);
+          mappings[linkDef.objectTypeRidManySide].push(manySide);
           break;
         }
         default:
@@ -340,7 +346,7 @@ export class OntologyBlockDataToFullMetadataConverter {
         if (!result[objectTypeApiName]) {
           result[objectTypeApiName] = [];
         }
-        result[objectTypeApiName].push(linkSide);
+        result[objectTypeApiName].push(...linkSide);
       }
     }
 

--- a/packages/generator-converters.ontologyir/src/OntologyBlockDataToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyBlockDataToFullMetadataConverter.ts
@@ -300,9 +300,9 @@ export class OntologyBlockDataToFullMetadataConverter {
 
           const manySide: Ontologies.LinkTypeSideV2 = {
             ...common,
-            apiName: linkDef.oneToManyLinkMetadata.apiName ?? "",
+            apiName: linkDef.manyToOneLinkMetadata.apiName ?? "",
             displayName:
-              linkDef.oneToManyLinkMetadata.displayMetadata.displayName,
+              linkDef.manyToOneLinkMetadata.displayMetadata.displayName,
             objectTypeApiName: resolveBlockDataApiName(
               linkDef.objectTypeRidOneSide,
               objectTypeLookup,
@@ -320,9 +320,9 @@ export class OntologyBlockDataToFullMetadataConverter {
           const oneSide: Ontologies.LinkTypeSideV2 = {
             ...common,
             cardinality: "MANY",
-            apiName: linkDef.manyToOneLinkMetadata.apiName ?? "",
+            apiName: linkDef.oneToManyLinkMetadata.apiName ?? "",
             displayName:
-              linkDef.manyToOneLinkMetadata.displayMetadata.displayName,
+              linkDef.oneToManyLinkMetadata.displayMetadata.displayName,
             objectTypeApiName: resolveBlockDataApiName(
               linkDef.objectTypeRidManySide,
               objectTypeLookup,

--- a/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadaConvert.test.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadaConvert.test.ts
@@ -3150,9 +3150,9 @@ describe(OntologyIrToFullMetadataConverter, () => {
             "implementsInterfaces2": {},
             "linkTypes": [
               {
-                "apiName": "distributionRouteAnalysis",
+                "apiName": "distributionCenterProposal",
                 "cardinality": "MANY",
-                "displayName": "Distribution Route Analysis",
+                "displayName": "Distribution Center Proposal",
                 "linkTypeRid": "ri.Dc3DistributionCenterProposal.Dc3DistributionCenterProposalToDistributionRoute.Dc3DistributionRouteAnalysis",
                 "objectTypeApiName": "Dc3DistributionRouteAnalysis",
                 "status": "ACTIVE",
@@ -3234,18 +3234,18 @@ describe(OntologyIrToFullMetadataConverter, () => {
             "implementsInterfaces2": {},
             "linkTypes": [
               {
-                "apiName": "restaurant",
+                "apiName": "distributionRouteAnalysis",
                 "cardinality": "ONE",
-                "displayName": "Restaurant",
+                "displayName": "Distribution Route Analysis",
                 "foreignKeyPropertyApiName": "restaurant",
                 "linkTypeRid": "ri.Dc3Restaurant.Dc3RestaurantToDistributionRoute.Dc3DistributionRouteAnalysis",
                 "objectTypeApiName": "Dc3Restaurant",
                 "status": "ACTIVE",
               },
               {
-                "apiName": "distributionCenterProposal",
+                "apiName": "distributionRouteAnalysis",
                 "cardinality": "ONE",
-                "displayName": "Distribution Center Proposal",
+                "displayName": "Distribution Route Analysis",
                 "foreignKeyPropertyApiName": "distributionProposal",
                 "linkTypeRid": "ri.Dc3DistributionCenterProposal.Dc3DistributionCenterProposalToDistributionRoute.Dc3DistributionRouteAnalysis",
                 "objectTypeApiName": "Dc3DistributionCenterProposal",
@@ -3328,9 +3328,9 @@ describe(OntologyIrToFullMetadataConverter, () => {
             "implementsInterfaces2": {},
             "linkTypes": [
               {
-                "apiName": "distributionRouteAnalysis",
+                "apiName": "restaurant",
                 "cardinality": "MANY",
-                "displayName": "Distribution Route Analysis",
+                "displayName": "Restaurant",
                 "linkTypeRid": "ri.Dc3Restaurant.Dc3RestaurantToDistributionRoute.Dc3DistributionRouteAnalysis",
                 "objectTypeApiName": "Dc3DistributionRouteAnalysis",
                 "status": "ACTIVE",

--- a/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
@@ -870,9 +870,9 @@ export class OntologyIrToFullMetadataConverter {
 
           const manySide: Ontologies.LinkTypeSideV2 = {
             ...common,
-            apiName: linkDef.oneToManyLinkMetadata.apiName ?? "",
+            apiName: linkDef.manyToOneLinkMetadata.apiName ?? "",
             displayName:
-              linkDef.oneToManyLinkMetadata.displayMetadata.displayName,
+              linkDef.manyToOneLinkMetadata.displayMetadata.displayName,
             objectTypeApiName: linkDef.objectTypeRidOneSide,
             cardinality: "ONE",
             // This should only exist on the one side and it should be the property on this object
@@ -885,9 +885,9 @@ export class OntologyIrToFullMetadataConverter {
           const oneSide: Ontologies.LinkTypeSideV2 = {
             ...common,
             cardinality: "MANY",
-            apiName: linkDef.manyToOneLinkMetadata.apiName ?? "",
+            apiName: linkDef.oneToManyLinkMetadata.apiName ?? "",
             displayName:
-              linkDef.manyToOneLinkMetadata.displayMetadata.displayName,
+              linkDef.oneToManyLinkMetadata.displayMetadata.displayName,
             objectTypeApiName: linkDef.objectTypeRidManySide,
           };
 

--- a/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
@@ -823,7 +823,7 @@ export class OntologyIrToFullMetadataConverter {
       const linkType = link.linkType;
       const linkStatus = this.convertLinkTypeStatus(linkType.status);
 
-      let mappings: Record<string, Ontologies.LinkTypeSideV2>;
+      let mappings: Record<string, Ontologies.LinkTypeSideV2[]>;
       switch (linkType.definition.type) {
         case "manyToMany": {
           const linkDef = linkType.definition.manyToMany;
@@ -842,13 +842,17 @@ export class OntologyIrToFullMetadataConverter {
             ...sideA,
             apiName: linkDef.objectTypeBToALinkMetadata.apiName
               ?? "",
+            displayName: linkDef.objectTypeBToALinkMetadata
+              .displayMetadata.displayName,
             objectTypeApiName: linkDef.objectTypeRidA,
           };
 
           mappings = {
-            [linkDef.objectTypeRidA]: sideA,
-            [linkDef.objectTypeRidB]: sideB,
+            [linkDef.objectTypeRidA]: [],
+            [linkDef.objectTypeRidB]: [],
           };
+          mappings[linkDef.objectTypeRidA].push(sideA);
+          mappings[linkDef.objectTypeRidB].push(sideB);
           break;
         }
         case "oneToMany": {
@@ -888,9 +892,11 @@ export class OntologyIrToFullMetadataConverter {
           };
 
           mappings = {
-            [linkDef.objectTypeRidOneSide]: oneSide,
-            [linkDef.objectTypeRidManySide]: manySide,
+            [linkDef.objectTypeRidOneSide]: [],
+            [linkDef.objectTypeRidManySide]: [],
           };
+          mappings[linkDef.objectTypeRidOneSide].push(oneSide);
+          mappings[linkDef.objectTypeRidManySide].push(manySide);
           break;
         }
         default:
@@ -902,7 +908,7 @@ export class OntologyIrToFullMetadataConverter {
         if (!result[objectTypeApiName]) {
           result[objectTypeApiName] = [];
         }
-        result[objectTypeApiName].push(linkSide);
+        result[objectTypeApiName].push(...linkSide);
       }
     }
 


### PR DESCRIPTION
The two sides of self referential links would overwrite each other

Api names were on the wrong side for one to many links. Fixed to match foundry-as-code generator