### PR TITLE
Fix RDP cell value retains old value when cleared

### DIFF
--- a/.changeset/clear-null-rdp-merge.md
+++ b/.changeset/clear-null-rdp-merge.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Clear a runtime-derived-property (RDP) value when it becomes null. When merging an updated object into the cache, the RDP merge previously retained the stale previous value if the source omitted the field (which is how a now-null derived value arrives over the wire). The source query is now authoritative for the RDP fields it computed, so a cleared derived value propagates instead of showing the old value.

--- a/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
@@ -190,6 +190,82 @@ describe("ObjectsHelper.propagateWrite RDP merge", () => {
       }),
     );
   });
+
+  it("clears an RDP value when the canonical query refetches and the new value omits it", () => {
+    // The canonical owner of an RDP cache key is authoritative for the RDPs
+    // the key expects to compute. When a refetch returns the object with the
+    // derived value omitted (which is how a now-null derived value arrives
+    // over the wire) the cell must clear instead of retaining the stale
+    // previously cached value.
+    const rdpConfig = createFakeRdpConfig("fieldA");
+    const queryWithRdp = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+    }, rdpConfig);
+
+    // Seed: object has fieldA = "alice-rdp"
+    const empWithFieldA = emp.$clone({ fieldA: "alice-rdp" } as any);
+    store.batch({}, (batch) => {
+      queryWithRdp.writeToStore(empWithFieldA as any, "loaded", batch);
+    });
+    expect(
+      (store.getValue(queryWithRdp.cacheKey)?.value as any)?.fieldA,
+    ).toBe("alice-rdp");
+
+    // Refetch: the same canonical query writes an object without fieldA
+    // (server returned null → wire omitted the key).
+    const empWithoutFieldA = emp.$clone({ fullName: "Bob" });
+    store.batch({}, (batch) => {
+      queryWithRdp.writeToStore(empWithoutFieldA as any, "loaded", batch);
+    });
+
+    const valueAfter = store.getValue(queryWithRdp.cacheKey)?.value as any;
+    expect(valueAfter?.fullName).toBe("Bob");
+    // The derived value became null — the cache must reflect that, not the
+    // stale "alice-rdp" value.
+    expect(valueAfter?.fieldA).toBeUndefined();
+  });
+
+  it("preserves the cached RDP value when a no-RDP sibling query writes", () => {
+    // ActionForm scenario: a separate query that does not need the RDP field
+    // (e.g. loadObjects with no withProperties) writes the same object to its
+    // own cache key. The write propagates to the sibling RDP cache key — and
+    // because the source query did not compute the RDP, the sibling's cached
+    // derived value must be preserved, not clobbered.
+    const rdpConfig = createFakeRdpConfig("fieldA");
+    const queryWithRdp = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+    }, rdpConfig);
+    const queryNoRdp = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+    }, undefined);
+
+    // Make the RDP cache key active so sibling propagation reaches it.
+    store.cacheKeys.retain(queryWithRdp.cacheKey);
+    store.subjects.get(queryWithRdp.cacheKey).subscribe(() => {});
+
+    // Seed the RDP cache key with fieldA = "alice-rdp"
+    const empWithFieldA = emp.$clone({ fieldA: "alice-rdp" } as any);
+    store.batch({}, (batch) => {
+      queryWithRdp.writeToStore(empWithFieldA as any, "loaded", batch);
+    });
+
+    // The no-RDP query writes an updated object (no fieldA in the payload).
+    const empBob = emp.$clone({ fullName: "Bob" });
+    store.batch({}, (batch) => {
+      queryNoRdp.writeToStore(empBob as any, "loaded", batch);
+    });
+
+    const rdpValueAfter = store.getValue(queryWithRdp.cacheKey)?.value as any;
+    // Base field updated by sibling propagation
+    expect(rdpValueAfter?.fullName).toBe("Bob");
+    // Derived value preserved — the no-RDP source query did not compute it.
+    expect(rdpValueAfter?.fieldA).toBe("alice-rdp");
+
+    store.cacheKeys.release(queryWithRdp.cacheKey);
+  });
 });
 
 describe("ObjectsHelper.isKeyActive", () => {

--- a/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
@@ -192,11 +192,6 @@ describe("ObjectsHelper.propagateWrite RDP merge", () => {
   });
 
   it("clears an RDP value when the canonical query refetches and the new value omits it", () => {
-    // The canonical owner of an RDP cache key is authoritative for the RDPs
-    // the key expects to compute. When a refetch returns the object with the
-    // derived value omitted (which is how a now-null derived value arrives
-    // over the wire) the cell must clear instead of retaining the stale
-    // previously cached value.
     const rdpConfig = createFakeRdpConfig("fieldA");
     const queryWithRdp = store.objects.getQuery({
       apiName: Employee,
@@ -227,11 +222,6 @@ describe("ObjectsHelper.propagateWrite RDP merge", () => {
   });
 
   it("preserves the cached RDP value when a no-RDP sibling query writes", () => {
-    // ActionForm scenario: a separate query that does not need the RDP field
-    // (e.g. loadObjects with no withProperties) writes the same object to its
-    // own cache key. The write propagates to the sibling RDP cache key — and
-    // because the source query did not compute the RDP, the sibling's cached
-    // derived value must be preserved, not clobbered.
     const rdpConfig = createFakeRdpConfig("fieldA");
     const queryWithRdp = store.objects.getQuery({
       apiName: Employee,

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -169,10 +169,6 @@ export class ObjectsHelper extends AbstractHelper<
       );
     }
 
-    // When an object (e.g. from a subscription update) is written to a cache
-    // key that has RDP configuration, the incoming value may lack derived
-    // property values. Merge with the existing cached value so that RDP fields
-    // not present in the incoming object are preserved.
     if (
       valueToWrite !== tombstone
       && existing?.value
@@ -180,23 +176,17 @@ export class ObjectsHelper extends AbstractHelper<
     ) {
       const expectedRdpFields = this.store.objectCacheKeyRegistry
         .getRdpFieldSet(sourceCacheKey);
-      if (expectedRdpFields.size > 0) {
-        const underlying = valueToWrite[UnderlyingOsdkObject];
-        const actualRdpFields = new Set<string>();
-        for (const field of expectedRdpFields) {
-          if (underlying && field in underlying) {
-            actualRdpFields.add(field);
-          }
-        }
 
-        if (actualRdpFields.size !== expectedRdpFields.size) {
-          valueToWrite = mergeObjectFields(
-            valueToWrite,
-            actualRdpFields,
-            expectedRdpFields,
-            existing.value,
-          );
-        }
+      // When the sourceCacheKey contains RDP fields, it intentionally requires the set of RDPs
+      if (expectedRdpFields.size > 0) {
+        // Passing expectedRdpFields as both sourceRdpFields and targetRdpFields so the rdp keys match exactly
+        // In mergeObjectFields it hits the isSuperset short-circuit (sizes equal, identical sets) and return sourceValue as-is
+        valueToWrite = mergeObjectFields(
+          valueToWrite,
+          expectedRdpFields,
+          expectedRdpFields,
+          existing.value,
+        );
       }
     }
 
@@ -212,6 +202,7 @@ export class ObjectsHelper extends AbstractHelper<
       sourceCacheKey,
     );
 
+    // Propagate write to sibling cache keys that observe the same (apiName, pk)
     const relatedKeys = metadata
       ? this.store.objectCacheKeyRegistry.getVariants(
         metadata.apiName,

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
@@ -195,7 +195,7 @@ describe("rdpFieldOperations", () => {
     expect(underlying.rdpField2).toBe(999);
   });
 
-  it("mergeObjectFields preserves target RDP value when source has undefined for shared field", () => {
+  it("mergeObjectFields clears a shared RDP field that the source computed but left undefined", () => {
     const source = createTestObject({
       employeeId: 50030,
       fullName: "John Doe",
@@ -218,8 +218,71 @@ describe("rdpFieldOperations", () => {
     const underlying = getUnderlyingProps(result);
     expect(underlying.employeeId).toBe(50030);
     expect(underlying.fullName).toBe("John Doe");
-    // Target's non-null value should be preserved when source has undefined
-    expect(underlying.rdpField1).toBe("existing-value");
+    // The source query computed rdpField1, so it is authoritative: an undefined
+    // value means the derived value became null and the stale target value must
+    // be cleared rather than retained.
+    expect(underlying.rdpField1).toBeUndefined();
+    // rdpField2 was not computed by the source query, so the target's value is
+    // preserved.
+    expect(underlying.rdpField2).toBe(999);
+  });
+
+  it("mergeObjectFields clears a shared RDP field that the source query computed but the wire omitted (became null)", () => {
+    // Real-world shape: the wire returns all non-null RDPs and omits the ones
+    // that became null. The canonical writer of the cache key passes its
+    // query's RDP *intent* (`expectedRdpFields`) as `sourceRdpFields`, so an
+    // omitted-but-expected RDP is interpreted as "became null" and the stale
+    // cached value must clear.
+    const source = createTestObject({
+      employeeId: 50030,
+      fullName: "John Doe",
+      // rdpField1 omitted — became null
+      rdpField2: 42, // rdpField2 still has a value
+    });
+    const target = createTestObject({
+      employeeId: 50030,
+      rdpField1: "existing-value", // stale; must NOT be retained
+      rdpField2: 999, // about to be replaced by source's new 42
+    });
+
+    const result = mergeObjectFields(
+      source,
+      // Source query computed both — this is the canonical writer's intent.
+      new Set(["rdpField1", "rdpField2"]),
+      new Set(["rdpField1", "rdpField2"]),
+      target,
+    );
+
+    assertValidObjectHolder(result);
+    const underlying = getUnderlyingProps(result);
+    expect(underlying.rdpField1).toBeUndefined();
+    expect(underlying.rdpField2).toBe(42);
+  });
+
+  it("mergeObjectFields preserves target RDP value when source did not compute that field", () => {
+    const source = createTestObject({
+      employeeId: 50030,
+      fullName: "John Doe",
+      rdpField1: "source-value",
+    });
+    const target = createTestObject({
+      employeeId: 50030,
+      rdpField1: "old-value",
+      rdpField2: 999,
+    });
+
+    const result = mergeObjectFields(
+      source,
+      // Source only computed rdpField1; rdpField2 is left untouched.
+      new Set(["rdpField1"]),
+      new Set(["rdpField1", "rdpField2"]),
+      target,
+    );
+
+    assertValidObjectHolder(result);
+    const underlying = getUnderlyingProps(result);
+    expect(underlying.rdpField1).toBe("source-value");
+    // rdpField2 was not in the source query, so the target's value survives.
     expect(underlying.rdpField2).toBe(999);
   });
 

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
@@ -227,38 +227,6 @@ describe("rdpFieldOperations", () => {
     expect(underlying.rdpField2).toBe(999);
   });
 
-  it("mergeObjectFields clears a shared RDP field that the source query computed but the wire omitted (became null)", () => {
-    // Real-world shape: the wire returns all non-null RDPs and omits the ones
-    // that became null. The canonical writer of the cache key passes its
-    // query's RDP *intent* (`expectedRdpFields`) as `sourceRdpFields`, so an
-    // omitted-but-expected RDP is interpreted as "became null" and the stale
-    // cached value must clear.
-    const source = createTestObject({
-      employeeId: 50030,
-      fullName: "John Doe",
-      // rdpField1 omitted — became null
-      rdpField2: 42, // rdpField2 still has a value
-    });
-    const target = createTestObject({
-      employeeId: 50030,
-      rdpField1: "existing-value", // stale; must NOT be retained
-      rdpField2: 999, // about to be replaced by source's new 42
-    });
-
-    const result = mergeObjectFields(
-      source,
-      // Source query computed both — this is the canonical writer's intent.
-      new Set(["rdpField1", "rdpField2"]),
-      new Set(["rdpField1", "rdpField2"]),
-      target,
-    );
-
-    assertValidObjectHolder(result);
-    const underlying = getUnderlyingProps(result);
-    expect(underlying.rdpField1).toBeUndefined();
-    expect(underlying.rdpField2).toBe(42);
-  });
-
   it("mergeObjectFields preserves target RDP value when source did not compute that field", () => {
     const source = createTestObject({
       employeeId: 50030,

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
@@ -196,6 +196,11 @@ describe("rdpFieldOperations", () => {
   });
 
   it("mergeObjectFields clears a shared RDP field that the source computed but left undefined", () => {
+    // Regression guard: a previous version of the merge-back loop had a
+    // `|| newProps[field] === undefined` clause that re-filled an undefined
+    // source RDP from the target. That overrides the source's authority over
+    // its own declared RDP fields and resurrects stale data when the derived
+    // value becomes null (wire omits the key).
     const source = createTestObject({
       employeeId: 50030,
       fullName: "John Doe",

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
@@ -170,12 +170,12 @@ export function mergeObjectFields(
   targetRdpFields: ReadonlySet<string>,
   targetCurrentValue: ObjectHolder | undefined,
 ): ObjectHolder {
-  // Case: The destination (target) query does not need RDP
+  // When the destination (target) query does not need RDP
   if (targetRdpFields.size === 0) {
     return stripRdpFields(sourceValue, sourceRdpFields);
   }
 
-  // Case: Source contains more than the required RDP fields
+  // When source contains more than the required RDP fields
   if (isSuperset(sourceRdpFields, targetRdpFields)) {
     if (sourceRdpFields.size === targetRdpFields.size) {
       return sourceValue;

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
@@ -101,8 +101,8 @@ function isSuperset(
 
 function filterToRdpFields(
   value: ObjectHolder,
-  rdpFieldsToKeep: ReadonlySet<string>,
-  sourceRdpFields: ReadonlySet<string>,
+  rdpFieldsToKeep: ReadonlySet<string>, // old
+  sourceRdpFields: ReadonlySet<string>, // new
 ): ObjectHolder {
   const underlying = value[UnderlyingOsdkObject] as SimpleOsdkProperties;
   const objectDef = requireObjectDef(value[ObjectDefRef], underlying);
@@ -170,17 +170,23 @@ export function mergeObjectFields(
   targetRdpFields: ReadonlySet<string>,
   targetCurrentValue: ObjectHolder | undefined,
 ): ObjectHolder {
+  // Case: The destination (target) query does not need RDP
   if (targetRdpFields.size === 0) {
     return stripRdpFields(sourceValue, sourceRdpFields);
   }
 
+  // Case: Source contains more than the required RDP fields
   if (isSuperset(sourceRdpFields, targetRdpFields)) {
     if (sourceRdpFields.size === targetRdpFields.size) {
       return sourceValue;
     }
+    // Filter to return only the RDP fields that are needed by target
     return filterToRdpFields(sourceValue, targetRdpFields, sourceRdpFields);
   }
 
+  /**
+   * Mixed case: each side has RDP fields the other doesn't
+   */
   const sourceUnderlying =
     sourceValue[UnderlyingOsdkObject] as SimpleOsdkProperties;
   const objectDef = requireObjectDef(
@@ -188,6 +194,7 @@ export function mergeObjectFields(
     sourceUnderlying,
   );
 
+  // Create a new property bag
   const newProps: SimpleOsdkProperties = {
     $apiName: sourceUnderlying.$apiName,
     $objectType: sourceUnderlying.$objectType,
@@ -196,7 +203,12 @@ export function mergeObjectFields(
     $rid: sourceUnderlying.$rid,
   };
 
+  // For every key on the source data
   for (const key of Object.keys(sourceUnderlying)) {
+    // Only add to newProps if it is an object property AND
+    //  Either it is not an RDP in the source
+    //  Or it is an RDP that the target needs
+    // --> This skips source's RDP fields that the target doesn't care about.
     if (
       key in objectDef.properties
       && (!sourceRdpFields.has(key) || targetRdpFields.has(key))
@@ -205,18 +217,14 @@ export function mergeObjectFields(
     }
   }
 
+  // For each RDP needed in target, assign the existing value only when the source does not have the field.
+  // When the source has it, the value should always come from the source, and that should have b
   if (targetCurrentValue) {
     const targetUnderlying =
       targetCurrentValue[UnderlyingOsdkObject] as SimpleOsdkProperties;
     for (const field of targetRdpFields) {
       if (field in targetUnderlying) {
-        // Preserve target's value when:
-        // 1. Source doesn't have this RDP field at all, OR
-        // 2. Source hasn't provided the value (undefined)
-        if (
-          !sourceRdpFields.has(field)
-          || newProps[field] === undefined
-        ) {
+        if (!sourceRdpFields.has(field)) {
           newProps[field] = targetUnderlying[field];
         }
       }

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
@@ -217,8 +217,7 @@ export function mergeObjectFields(
     }
   }
 
-  // For each RDP needed in target, assign the existing value only when the source does not have the field.
-  // When the source has it, the value should always come from the source, and that should have b
+  // For each RDP needed in target, assign the existing value when the source query did not declare this RDP in its intent
   if (targetCurrentValue) {
     const targetUnderlying =
       targetCurrentValue[UnderlyingOsdkObject] as SimpleOsdkProperties;

--- a/packages/react-components/src/object-table/hooks/__tests__/useObjectTableData.test.tsx
+++ b/packages/react-components/src/object-table/hooks/__tests__/useObjectTableData.test.tsx
@@ -618,6 +618,86 @@ describe(useObjectTableData, () => {
     ]);
   });
 
+  describe("runtime derived property (RDP) columns", () => {
+    const rdpColumnDefinitions: Array<
+      ColumnDefinition<TestObject, { derived: SimplePropertyDef }>
+    > = [
+      {
+        locator: { type: "property", id: "name" as TestObjectKeys },
+      },
+      {
+        locator: {
+          type: "rdp",
+          id: "derived",
+          creator: (() => ({})) as unknown as DerivedProperty.Creator<
+            TestObject,
+            SimplePropertyDef
+          >,
+        },
+      },
+    ];
+
+    it("reflects an RDP field becoming null when a later snapshot omits the key", () => {
+      vi.mocked(useFunctionColumnsData).mockReturnValue({});
+
+      // First snapshot: the object has a value for the derived property.
+      vi.mocked(useOsdkObjects).mockReturnValue({
+        data: [
+          {
+            $primaryKey: "1",
+            $apiName: "TestObject",
+            name: "Object 1",
+            derived: "rdp-value",
+          },
+        ],
+        isLoading: false,
+        error: undefined,
+        fetchMore: vi.fn(),
+        isOptimistic: false,
+      } as any);
+
+      const { result, rerender } = renderHook(
+        () => useObjectTableData(TestObjectType, rdpColumnDefinitions),
+        { wrapper },
+      );
+
+      expect(result.current.data).toEqual([
+        {
+          $primaryKey: "1",
+          $apiName: "TestObject",
+          name: "Object 1",
+          derived: "rdp-value",
+        },
+      ]);
+
+      // Second snapshot: the derived value became null, so the wire omits the
+      // key entirely. The resolved object must not carry the stale value.
+      vi.mocked(useOsdkObjects).mockReturnValue({
+        data: [
+          {
+            $primaryKey: "1",
+            $apiName: "TestObject",
+            name: "Object 1",
+          },
+        ],
+        isLoading: false,
+        error: undefined,
+        fetchMore: vi.fn(),
+        isOptimistic: false,
+      } as any);
+      rerender();
+
+      expect(result.current.data).toEqual([
+        {
+          $primaryKey: "1",
+          $apiName: "TestObject",
+          name: "Object 1",
+        },
+      ]);
+      expect(result.current.data?.[0]).not.toHaveProperty("derived");
+    });
+  });
+
   describe("streamUpdates", () => {
     it("forwards streamUpdates to useOsdkObjects when no objectSet is provided", () => {
       renderHook(


### PR DESCRIPTION
## Summary

Fixes the same class of bug as #3433 (function/derived ObjectTable cells not clearing when their value becomes null), but for **RDP (runtime-derived-property) columns**. The root cause is in the `@osdk/client` observable store.

## The problem
In mergeObjectFields, the old value is assigned to the RDP field when the field is missing (cleared) in the new data. 

The original code does not differentiate these when RDP field is missing from the new data:
1. When the RDP is missing because it was set to null.
2. When the RDP is missing from the data because the query does not include any RDP fields.

Repro-ed in https://github.com/palantir/osdk-ts/pull/3520

## Is there a workaround?
No, I tried doing observableClient.invalidateAll() and the old value still stay. Invalidation is already done on action completion - when setting an RDP field from null to some value, the cell reloads and shows new data.

## The fix
Get the query intent from sourceCacheKey to identify whether the query asked for the RDPs to decide if we should clear the RDP or keep the existing value. If the query contains the RDP field key, but the new data does not have the RDP field, then it means the RDP field is cleared.

**Implementation**
Pass the set of RDP field keys from sourceCacheKey (contains the intent) to mergeObjectFields as the sourceRdpFields and targetRdpFields. This means that the source data should contain the same set of RDP fields as the target cache we are writing to.

FLUP: To refactor to make this code more readable. Added comments for now to help understanding through the logic
