### PR TITLE
link graph loading experiment

### DIFF
--- a/.changeset/interface-aware-graph-loading.md
+++ b/.changeset/interface-aware-graph-loading.md
@@ -1,0 +1,9 @@
+---
+"@osdk/api": minor
+"@osdk/client": minor
+"@osdk/react": minor
+"@osdk/generator": minor
+"@osdk/generator-converters": minor
+---
+
+add link-centric graph loading: generated Type.links tokens, cardinality-aware and multi-source useLinks, incremental recursion, multi-hop paths, shape follow, interface-link translation and in-SDK metadata discovery, ObjectRef keying

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -337,6 +337,15 @@ export type ConvertProps<
 	OPTIONS extends never | "$rid" | "$allBaseProperties" | "$propertySecurities" = never
 > = TO extends FROM ? P : TO extends ObjectTypeDefinition ? (UnionIfTrue<MapPropNamesToObjectType<FROM, TO, P, OPTIONS>, P extends "$rid" ? true : false, "$rid">) : TO extends InterfaceDefinition ? FROM extends ObjectTypeDefinition ? (UnionIfTrue<MapPropNamesToInterface<FROM, TO, P>, P extends "$rid" ? true : false, "$rid">) : never : never;
 
+// Warning: (ae-forgotten-export) The symbol "Node_2" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export function createLinkDef<
+	Source extends Node_2 = Node_2,
+	Target extends Node_2 = Node_2,
+	M extends boolean = boolean
+>(sourceTypeApiName: string, linkApiName: string, targetTypeApiName: string, multiplicity: M, sourceIsInterface: boolean): LinkDef<Source, Target, M extends true ? "many" : "one">;
+
 // @public
 export interface DataValueClientToWire {
     	// (undocumented)
@@ -750,6 +759,9 @@ export type GroupByClause<Q extends ObjectOrInterfaceDefinition> = { [P in Aggre
 // @public (undocumented)
 export type GroupByRange<T> = [T, T];
 
+// @public
+export function hashTraversal(descriptor: LinkTraversalDescriptor): string;
+
 // @public (undocumented)
 export interface HumanReadableFormat {
     	// (undocumented)
@@ -868,14 +880,91 @@ export function isOk<X>(a: Result<X>): a is OkResult<X>;
 // @public
 export type KnownType = "USER_OR_GROUP_ID" | "RESOURCE_RID" | "ARTIFACT_GID";
 
+// Warning: (ae-forgotten-export) The symbol "Node_3" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export interface LinkDef<
+	Source extends Node_3,
+	Target extends Node_3,
+	Card extends "one" | "many"
+> extends LinkTraversal<Source, Target, Card> {
+    	// (undocumented)
+    readonly apiName: string;
+    	// (undocumented)
+    readonly cardinality: Card;
+    	recursive(opts?: Partial<RecursiveOptions>): RecursiveTraversal<Source, Target>;
+    	// (undocumented)
+    readonly sourceType: Source;
+    	// (undocumented)
+    readonly targetType: Target;
+}
+
 // @public (undocumented)
 export type LinkedType<
 	Q extends ObjectOrInterfaceDefinition,
 	L extends LinkNames<Q>
 > = NonNullable<CompileTimeMetadata<Q>["links"][L]["__OsdkLinkTargetType"]>;
 
+// @public
+export interface LinkHopDescriptor {
+    	// (undocumented)
+    readonly limit?: number;
+    	// (undocumented)
+    readonly linkApiName: string;
+    	readonly multiplicity: boolean;
+    	// (undocumented)
+    readonly orderBy?: ReadonlyArray<{
+        		property: string
+        		direction: "asc" | "desc"
+        	}>;
+    	readonly projectShapeId?: string;
+    	readonly sourceIsInterface: boolean;
+    	// (undocumented)
+    readonly sourceTypeApiName: string;
+    	// (undocumented)
+    readonly targetTypeApiName: string;
+    	// (undocumented)
+    readonly where?: WhereClause<never>;
+}
+
 // @public (undocumented)
 export type LinkNames<Q extends ObjectOrInterfaceDefinition> = Q extends InterfaceDefinition ? keyof CompileTimeMetadata<Q>["links"] : keyof CompileTimeMetadata<Q>["links"] & string;
+
+// @public (undocumented)
+export interface LinkTraversal<
+	Source extends Node_3,
+	Target extends Node_3,
+	Card extends "one" | "many"
+> {
+    	// (undocumented)
+    readonly __descriptor: LinkTraversalDescriptor;
+    	// Warning: (ae-forgotten-export) The symbol "ShapeDefinition" needs to be exported by the entry point index.d.ts
+    readonly __projectedShape?: ShapeDefinition<Target>;
+    	// (undocumented)
+    limit(n: number): LinkTraversal<Source, Target, Card>;
+    	// (undocumented)
+    orderBy(spec: { [K in PropertyKeys<Target>]? : "asc" | "desc" }): LinkTraversal<Source, Target, Card>;
+    	// (undocumented)
+    project<S extends ShapeDefinition<Target>>(shape: S): LinkTraversal<Source, Target, Card>;
+    	then<
+    		NextTarget extends Node_3,
+    		NextCard extends "one" | "many"
+    	>(next: LinkDef<Target, NextTarget, NextCard>): Path<Source, NextTarget, Card extends "many" ? "many" : NextCard>;
+    	// (undocumented)
+    where(clause: WhereClause<Target>): LinkTraversal<Source, Target, Card>;
+}
+
+// @public (undocumented)
+export interface LinkTraversalDescriptor {
+    	// Warning: (tsdoc-escape-greater-than) The ">" character should be escaped using a backslash to avoid confusion with an HTML tag
+    readonly hops: ReadonlyArray<LinkHopDescriptor>;
+    	// (undocumented)
+    readonly kind: LinkTraversalKind;
+    	readonly recursive?: RecursiveOptions;
+}
+
+// @public (undocumented)
+export type LinkTraversalKind = "single" | "path" | "recursive";
 
 // @public (undocumented)
 export type LinkTypeApiNamesFor<Q extends ObjectOrInterfaceDefinition> = Extract<keyof CompileTimeMetadata<Q>["links"], string>;
@@ -1135,6 +1224,7 @@ export interface ObjectMetadata extends ObjectInterfaceBaseMetadata {
     //
     // (undocumented)
     icon: Icon | undefined;
+    	interfaceLinkMap?: Record<string, Record<string, string>>;
     	// (undocumented)
     interfaceMap: Record<string, Record<string, string>>;
     	// (undocumented)
@@ -1216,6 +1306,46 @@ export interface ObjectQueryDataType<T_Target extends ObjectOrInterfaceDefinitio
     	// (undocumented)
     object: string;
 }
+
+// @public
+export interface ObjectRef {
+    	// (undocumented)
+    readonly $objectType: string;
+    	// (undocumented)
+    readonly $primaryKey: string | number;
+}
+
+// @public (undocumented)
+export function objectRefEquals(a: ObjectRef, b: ObjectRef): boolean;
+
+// @public
+export function objectRefKey(ref: ObjectRef): string;
+
+// @public
+export class ObjectRefMap<V> {
+    	// (undocumented)
+    delete(ref: ObjectRef): boolean;
+    	// (undocumented)
+    entries(): Array<[ObjectRef, V]>;
+    	// (undocumented)
+    forEach(fn: (value: V, ref: ObjectRef) => void): void;
+    	// (undocumented)
+    get(ref: ObjectRef): V | undefined;
+    	// (undocumented)
+    has(ref: ObjectRef): boolean;
+    	// (undocumented)
+    keys(): ObjectRef[];
+    	// (undocumented)
+    set(ref: ObjectRef, value: V): this;
+    	// (undocumented)
+    get size(): number;
+}
+
+// @public (undocumented)
+export function objectRefOf(instance: {
+    	$objectType: string
+    	$primaryKey: string | number
+}): ObjectRef;
 
 // Warning: (ae-forgotten-export) The symbol "ObjectSetCleanedTypes" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "ExtractRdp" needs to be exported by the entry point index.d.ts
@@ -1449,6 +1579,18 @@ export interface PageResult<T> {
     nextPageToken: string | undefined;
     	// (undocumented)
     totalCount: string;
+}
+
+// @public (undocumented)
+export interface Path<
+	Source extends Node_3,
+	EndTarget extends Node_3,
+	Card extends "one" | "many"
+> extends LinkTraversal<Source, EndTarget, Card> {
+    	// (undocumented)
+    readonly __descriptor: LinkTraversalDescriptor & {
+        		kind: "path"
+        	};
 }
 
 // @public (undocumented)
@@ -1766,6 +1908,24 @@ type Range_2<T extends AllowedBucketTypes_2> = {
     	endValue?: T
 };
 export { Range_2 as Range }
+
+// @public (undocumented)
+export interface RecursiveOptions {
+    	maxDepth: number | "unbounded";
+    	maxNodes: number;
+}
+
+// @public (undocumented)
+export interface RecursiveTraversal<
+	Source extends Node_3,
+	Target extends Node_3
+> extends LinkTraversal<Source, Target, "many"> {
+    	// (undocumented)
+    readonly __descriptor: LinkTraversalDescriptor & {
+        		kind: "recursive"
+        		recursive: RecursiveOptions
+        	};
+}
 
 // Warning: (ae-forgotten-export) The symbol "ErrorResult" needs to be exported by the entry point index.d.ts
 //

--- a/etc/client.report.api.md
+++ b/etc/client.report.api.md
@@ -15,6 +15,7 @@ import { ApplyBatchActionOptions } from '@osdk/api';
 import { Attachment } from '@osdk/api';
 import type { AttachmentUpload } from '@osdk/api';
 import { CompileTimeMetadata } from '@osdk/api';
+import { createLinkDef } from '@osdk/api';
 import type { DataValueClientToWire } from '@osdk/api';
 import type { DataValueWireToClient } from '@osdk/api';
 import { DerivedProperty } from '@osdk/api';
@@ -24,6 +25,11 @@ import { InterfaceDefinition } from '@osdk/api';
 import { InterfaceMetadata } from '@osdk/api';
 import type { InterfaceQueryDataType } from '@osdk/api';
 import { isOk } from '@osdk/api';
+import { LinkDef } from '@osdk/api';
+import { LinkHopDescriptor } from '@osdk/api';
+import { LinkTraversal } from '@osdk/api';
+import { LinkTraversalDescriptor } from '@osdk/api';
+import { LinkTraversalKind } from '@osdk/api';
 import { Logger } from '@osdk/api';
 import { Media } from '@osdk/api';
 import { MediaMetadata as MediaMetadata_2 } from '@osdk/api';
@@ -43,6 +49,7 @@ import { OsdkObjectCreatePropertyType } from '@osdk/api';
 import { OsdkObjectPropertyType } from '@osdk/api';
 import { PageResult } from '@osdk/api';
 import { PalantirApiError } from '@osdk/shared.net.errors';
+import { Path } from '@osdk/api';
 import type { PrimaryKeyType } from '@osdk/api';
 import { PropertyDef } from '@osdk/api';
 import { PropertyKeys } from '@osdk/api';
@@ -53,6 +60,8 @@ import type { QueryMetadata } from '@osdk/api';
 import { QueryParam } from '@osdk/api';
 import { QueryResult } from '@osdk/api';
 import { Range as Range_2 } from '@osdk/api';
+import { RecursiveOptions } from '@osdk/api';
+import { RecursiveTraversal } from '@osdk/api';
 import { Result } from '@osdk/api';
 import type { SharedClient } from '@osdk/shared.client2';
 import { SharedClient as SharedClient_2 } from '@osdk/shared.client';
@@ -108,6 +117,7 @@ export interface Client extends SharedClient, OldSharedClient {
     	// (undocumented)
     <Q extends Experiment<"2.0.8"> | Experiment<"2.1.0"> | Experiment<"2.2.0"> | Experiment<"2.8.0"> | Experiment<"2.19.0">>(experiment: Q): ExperimentFns<Q>;
     	fetchMetadata<Q extends (ObjectTypeDefinition | InterfaceDefinition | ActionDefinition<any> | QueryDefinition<any>)>(o: Q): Promise<Q extends ObjectTypeDefinition ? ObjectMetadata : Q extends InterfaceDefinition ? InterfaceMetadata : Q extends ActionDefinition<any> ? ActionMetadata : Q extends QueryDefinition<any> ? QueryMetadata : never>;
+    	ontologyMetadata: OntologyMetadataClient;
 }
 
 export { CompileTimeMetadata }
@@ -121,6 +131,8 @@ export const createClient: (baseUrl: string, ontologyRid: string | Promise<strin
     	UNSTABLE_DO_NOT_USE_BRANCH?: string
     	headers?: Record<string, string>
 } | undefined, fetchFn?: typeof fetch | undefined) => Client;
+
+export { createLinkDef }
 
 // @public
 export function createObjectSpecifierFromPrimaryKey<Q extends ObjectTypeDefinition>(objectDef: Q, primaryKey: PrimaryKeyType<Q>): ObjectSpecifier<Q>;
@@ -147,12 +159,33 @@ export function getWireObjectSet(objectSet: ObjectSet<any> | MinimalObjectSet<an
 
 export { InterfaceDefinition }
 
+// @public (undocumented)
+export class InterfaceLinkNotResolvableError extends Error {
+    	constructor(concreteType: string, interfaceLinkApiName: string, message?: string);
+    	// (undocumented)
+    readonly concreteType: string;
+    	// (undocumented)
+    readonly interfaceLinkApiName: string;
+    	// (undocumented)
+    readonly name = "InterfaceLinkNotResolvableError";
+}
+
 export { InterfaceMetadata }
 
 // @public (undocumented)
 export function isObjectSet(o: object): o is ObjectSet<ObjectOrInterfaceDefinition>;
 
 export { isOk }
+
+export { LinkDef }
+
+export { LinkHopDescriptor }
+
+export { LinkTraversal }
+
+export { LinkTraversalDescriptor }
+
+export { LinkTraversalKind }
 
 export { Logger }
 
@@ -172,6 +205,22 @@ export { ObjectSpecifier }
 
 export { ObjectTypeDefinition }
 
+// @public (undocumented)
+export interface OntologyMetadataClient {
+    	implementationsOf(iface: InterfaceDefinition | string): Promise<string[]>;
+    	implements(objectTypeApiName: string, iface: InterfaceDefinition | string): Promise<boolean>;
+    	resolveLink(concreteType: ObjectTypeDefinition | string, interfaceLinkApiName: string): Promise<ResolvedLink>;
+}
+
+// @public (undocumented)
+export class OntologyMetadataNotFoundError extends Error {
+    	constructor(apiName: string, message?: string);
+    	// (undocumented)
+    readonly apiName: string;
+    	// (undocumented)
+    readonly name = "OntologyMetadataNotFoundError";
+}
+
 export { Osdk }
 
 export { OsdkObject }
@@ -183,6 +232,8 @@ export { OsdkObjectPropertyType }
 export { PageResult }
 
 export { PalantirApiError }
+
+export { Path }
 
 // @public (undocumented)
 export interface PlatformClient extends SharedClientContext {}
@@ -200,6 +251,18 @@ export { QueryParam }
 export { QueryResult }
 
 export { Range_2 as Range }
+
+export { RecursiveOptions }
+
+export { RecursiveTraversal }
+
+// @public (undocumented)
+export interface ResolvedLink {
+    	// (undocumented)
+    readonly concreteLinkApiName: string;
+    	readonly multiplicity: boolean;
+    	readonly targetType: string;
+}
 
 export { Result }
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -56,6 +56,20 @@ export type {
   GroupByClause,
   GroupByRange,
 } from "./groupby/GroupByClause.js";
+export { createLinkDef } from "./links/createLinkDef.js";
+export { hashTraversal } from "./links/hashTraversal.js";
+export type {
+  LinkDef,
+  LinkTraversal,
+  Path,
+  RecursiveTraversal,
+} from "./links/LinkDef.js";
+export type {
+  LinkHopDescriptor,
+  LinkTraversalDescriptor,
+  LinkTraversalKind,
+  RecursiveOptions,
+} from "./links/LinkTraversalDescriptor.js";
 export type { Logger } from "./Logger.js";
 export type {
   AllowedBucketKeyTypes,
@@ -118,6 +132,13 @@ export type {
   ObjectOrInterfaceDefinition,
   PropertyKeys,
 } from "./ontology/ObjectOrInterface.js";
+export {
+  objectRefEquals,
+  objectRefKey,
+  objectRefOf,
+} from "./ontology/ObjectRef.js";
+export type { ObjectRef } from "./ontology/ObjectRef.js";
+export { ObjectRefMap } from "./ontology/ObjectRefMap.js";
 export type { ObjectSpecifier } from "./ontology/ObjectSpecifier.js";
 export type {
   CompileTimeMetadata,

--- a/packages/api/src/links/LinkDef.test-d.ts
+++ b/packages/api/src/links/LinkDef.test-d.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expectTypeOf, it } from "vitest";
+import type { EmployeeApiTest } from "../test/EmployeeApiTest.js";
+import type { FooInterfaceApiTest } from "../test/FooInterfaceApiTest.js";
+import { createLinkDef } from "./createLinkDef.js";
+import type { Path } from "./LinkDef.js";
+
+describe("LinkDef tokens", () => {
+  it("then() chains adjacent hops and widens cardinality to 'many'", () => {
+    const employeeToFoo = createLinkDef<
+      EmployeeApiTest,
+      FooInterfaceApiTest,
+      false
+    >(
+      "Employee",
+      "owningGroup",
+      "FooInterface",
+      false,
+      false,
+    );
+    const fooToEmployee = createLinkDef<
+      FooInterfaceApiTest,
+      EmployeeApiTest,
+      true
+    >(
+      "FooInterface",
+      "members",
+      "Employee",
+      true,
+      true,
+    );
+    expectTypeOf(employeeToFoo.then(fooToEmployee))
+      .toEqualTypeOf<Path<EmployeeApiTest, EmployeeApiTest, "many">>();
+  });
+
+  it("then() rejects a hop whose source does not match the prior target", () => {
+    const employeeToFoo = createLinkDef<
+      EmployeeApiTest,
+      FooInterfaceApiTest,
+      false
+    >(
+      "Employee",
+      "owningGroup",
+      "FooInterface",
+      false,
+      false,
+    );
+    const employeeToEmployee = createLinkDef<
+      EmployeeApiTest,
+      EmployeeApiTest,
+      true
+    >(
+      "Employee",
+      "childCategories",
+      "Employee",
+      true,
+      false,
+    );
+    // @ts-expect-error source (Employee) is not adjacent to prior target (FooInterface)
+    employeeToFoo.then(employeeToEmployee);
+  });
+});

--- a/packages/api/src/links/LinkDef.ts
+++ b/packages/api/src/links/LinkDef.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { WhereClause } from "../aggregate/WhereClause.js";
+import type { InterfaceDefinition } from "../ontology/InterfaceDefinition.js";
+import type { PropertyKeys } from "../ontology/ObjectOrInterface.js";
+import type { ObjectTypeDefinition } from "../ontology/ObjectTypeDefinition.js";
+import type { ShapeDefinition } from "../shapes/ShapeDefinition.js";
+import type {
+  LinkTraversalDescriptor,
+  RecursiveOptions,
+} from "./LinkTraversalDescriptor.js";
+
+type Node = ObjectTypeDefinition | InterfaceDefinition;
+
+export interface LinkTraversal<
+  Source extends Node,
+  Target extends Node,
+  Card extends "one" | "many",
+> {
+  readonly __descriptor: LinkTraversalDescriptor;
+  /**
+   * The target shape bound by `.project()`, if any. The descriptor only carries
+   * the shape id (so it stays plain-data and structurally hashable); this field
+   * exposes the actual shape object so compilation can attach it as the derived
+   * link's target shape.
+   */
+  readonly __projectedShape?: ShapeDefinition<Target>;
+  where(clause: WhereClause<Target>): LinkTraversal<Source, Target, Card>;
+  orderBy(
+    spec: { [K in PropertyKeys<Target>]?: "asc" | "desc" },
+  ): LinkTraversal<Source, Target, Card>;
+  limit(n: number): LinkTraversal<Source, Target, Card>;
+  project<S extends ShapeDefinition<Target>>(
+    shape: S,
+  ): LinkTraversal<Source, Target, Card>;
+  /** chain a hop; adjacency (this.target === next.source) checked at the type level. */
+  then<NextTarget extends Node, NextCard extends "one" | "many">(
+    next: LinkDef<Target, NextTarget, NextCard>,
+  ): Path<Source, NextTarget, Card extends "many" ? "many" : NextCard>;
+}
+
+export interface LinkDef<
+  Source extends Node,
+  Target extends Node,
+  Card extends "one" | "many",
+> extends LinkTraversal<Source, Target, Card> {
+  readonly apiName: string;
+  readonly sourceType: Source;
+  readonly targetType: Target;
+  readonly cardinality: Card;
+  /** valid only when Source implements Target (self-referential); enforced at runtime + (best-effort) type level. */
+  recursive(
+    opts?: Partial<RecursiveOptions>,
+  ): RecursiveTraversal<Source, Target>;
+}
+
+export interface Path<
+  Source extends Node,
+  EndTarget extends Node,
+  Card extends "one" | "many",
+> extends LinkTraversal<Source, EndTarget, Card> {
+  readonly __descriptor: LinkTraversalDescriptor & { kind: "path" };
+}
+
+export interface RecursiveTraversal<Source extends Node, Target extends Node>
+  extends LinkTraversal<Source, Target, "many">
+{
+  readonly __descriptor:
+    & LinkTraversalDescriptor
+    & { kind: "recursive"; recursive: RecursiveOptions };
+}

--- a/packages/api/src/links/LinkTraversalDescriptor.ts
+++ b/packages/api/src/links/LinkTraversalDescriptor.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { WhereClause } from "../aggregate/WhereClause.js";
+
+export interface RecursiveOptions {
+  /** default 10; "unbounded" allowed only because of streaming + maxNodes. */
+  maxDepth: number | "unbounded";
+  /** hard work budget; depth alone does not bound a client-driven BFS. default 1000. */
+  maxNodes: number;
+}
+
+/** A single decorated hop. Plain data, structurally hashable. */
+export interface LinkHopDescriptor {
+  readonly sourceTypeApiName: string;
+  readonly linkApiName: string;
+  readonly targetTypeApiName: string;
+  /** false = "one", true = "many". */
+  readonly multiplicity: boolean;
+  /** true when the source type is an interface (needs WS1 resolution per concrete type). */
+  readonly sourceIsInterface: boolean;
+  readonly where?: WhereClause<never>;
+  readonly orderBy?: ReadonlyArray<
+    { property: string; direction: "asc" | "desc" }
+  >;
+  readonly limit?: number;
+  /** projection shape id, if .project() was called. */
+  readonly projectShapeId?: string;
+}
+
+export type LinkTraversalKind = "single" | "path" | "recursive";
+
+export interface LinkTraversalDescriptor {
+  readonly kind: LinkTraversalKind;
+  /** length 1 for single/recursive; >1 for path. Pairwise adjacency is pre-validated by the builder. */
+  readonly hops: ReadonlyArray<LinkHopDescriptor>;
+  /** present iff kind === "recursive". */
+  readonly recursive?: RecursiveOptions;
+}

--- a/packages/api/src/links/createLinkDef.test.ts
+++ b/packages/api/src/links/createLinkDef.test.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { ObjectTypeDefinition } from "../ontology/ObjectTypeDefinition.js";
+import { createShapeBuilder } from "../shapes/ShapeBuilder.js";
+import { createLinkDef } from "./createLinkDef.js";
+
+const MockGroup = {
+  type: "object",
+  apiName: "Group",
+} as ObjectTypeDefinition;
+
+describe("createLinkDef", () => {
+  it("builds a single-hop descriptor", () => {
+    const d = createLinkDef(
+      "Category",
+      "childCategories",
+      "Category",
+      true,
+      false,
+    );
+    expect(d.__descriptor).toEqual({
+      kind: "single",
+      hops: [{
+        sourceTypeApiName: "Category",
+        linkApiName: "childCategories",
+        targetTypeApiName: "Category",
+        multiplicity: true,
+        sourceIsInterface: false,
+      }],
+    });
+    expect(d.cardinality).toBe("many");
+  });
+
+  it("where/orderBy/limit are immutable and additive", () => {
+    const base = createLinkDef("Category", "c", "Category", true, false);
+    const filtered = base.where({ phase: "active" } as never).orderBy(
+      { startDate: "desc" } as never,
+    ).limit(5);
+    expect(base.__descriptor.hops[0].where).toBeUndefined(); // original untouched
+    expect(filtered.__descriptor.hops[0].where).toEqual({ phase: "active" });
+    expect(filtered.__descriptor.hops[0].orderBy).toEqual([{
+      property: "startDate",
+      direction: "desc",
+    }]);
+    expect(filtered.__descriptor.hops[0].limit).toBe(5);
+  });
+
+  it("then() concatenates hops, validates adjacency, and widens cardinality to many", () => {
+    const a = createLinkDef("Category", "owningGroup", "Group", false, false);
+    const b = createLinkDef(
+      "Group",
+      "members",
+      "Person",
+      true,
+      false,
+    );
+    const path = a.then(b);
+    expect(path.__descriptor.kind).toBe("path");
+    expect(path.__descriptor.hops.map((h) => h.linkApiName)).toEqual([
+      "owningGroup",
+      "members",
+    ]);
+  });
+
+  it("then() throws on adjacency mismatch", () => {
+    const a = createLinkDef("Category", "owningGroup", "Group", false, false);
+    const bad = createLinkDef("Person", "manager", "Person", false, false);
+    expect(() => a.then(bad)).toThrow(/adjacency/i);
+  });
+
+  it("recursive() requires self-referential link and sets defaults", () => {
+    const r = createLinkDef(
+      "Category",
+      "childCategories",
+      "Category",
+      true,
+      false,
+    ).recursive();
+    expect(r.__descriptor.kind).toBe("recursive");
+    expect(r.__descriptor.recursive).toEqual({ maxDepth: 10, maxNodes: 1000 });
+  });
+
+  it("recursive() rejects non-self-referential links", () => {
+    expect(() =>
+      createLinkDef("Category", "owningGroup", "Group", false, false)
+        .recursive()
+    )
+      .toThrow(/self-referential/i);
+  });
+
+  it("recursive() accepts unbounded depth with explicit budget", () => {
+    const r = createLinkDef("Category", "c", "Category", true, false)
+      .recursive({ maxDepth: "unbounded", maxNodes: 5000 });
+    expect(r.__descriptor.recursive).toEqual({
+      maxDepth: "unbounded",
+      maxNodes: 5000,
+    });
+  });
+
+  it("project() sets projectShapeId on the last hop and binds the target shape", () => {
+    const SlimGroup = createShapeBuilder(MockGroup, "SlimGroup")
+      .select("name" as never)
+      .build();
+
+    const projected = createLinkDef(
+      "Category",
+      "owningGroup",
+      "Group",
+      false,
+      false,
+    ).project(SlimGroup);
+
+    const lastHop =
+      projected.__descriptor.hops[projected.__descriptor.hops.length - 1];
+    expect(lastHop.projectShapeId).toBe(SlimGroup.__shapeId);
+    expect(projected.__projectedShape).toBe(SlimGroup);
+  });
+
+  it("project() binds the target shape on the last hop of a path", () => {
+    const SlimGroup = createShapeBuilder(MockGroup, "SlimGroup")
+      .select("name" as never)
+      .build();
+
+    const a = createLinkDef("Category", "owningGroup", "Group", false, false);
+    const b = createLinkDef("Group", "parentGroup", "Group", false, false);
+    const projected = a.then(b).project(SlimGroup);
+
+    const lastHop =
+      projected.__descriptor.hops[projected.__descriptor.hops.length - 1];
+    expect(lastHop.projectShapeId).toBe(SlimGroup.__shapeId);
+    expect(projected.__projectedShape).toBe(SlimGroup);
+  });
+});

--- a/packages/api/src/links/createLinkDef.ts
+++ b/packages/api/src/links/createLinkDef.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { WhereClause } from "../aggregate/WhereClause.js";
+import type { InterfaceDefinition } from "../ontology/InterfaceDefinition.js";
+import type { PropertyKeys } from "../ontology/ObjectOrInterface.js";
+import type { ObjectTypeDefinition } from "../ontology/ObjectTypeDefinition.js";
+import type { ShapeDefinition } from "../shapes/ShapeDefinition.js";
+import type {
+  LinkDef,
+  LinkTraversal,
+  Path,
+  RecursiveTraversal,
+} from "./LinkDef.js";
+import type {
+  LinkHopDescriptor,
+  LinkTraversalDescriptor,
+  RecursiveOptions,
+} from "./LinkTraversalDescriptor.js";
+
+type Node = ObjectTypeDefinition | InterfaceDefinition;
+
+const DEFAULT_RECURSIVE_OPTIONS: RecursiveOptions = {
+  maxDepth: 10,
+  maxNodes: 1000,
+};
+
+function withLastHop(
+  descriptor: LinkTraversalDescriptor,
+  patch: Partial<LinkHopDescriptor>,
+): LinkTraversalDescriptor {
+  const hops = descriptor.hops.slice();
+  const last = hops[hops.length - 1];
+  hops[hops.length - 1] = { ...last, ...patch };
+  return { ...descriptor, hops };
+}
+
+function cardinalityOf(
+  descriptor: LinkTraversalDescriptor,
+): "one" | "many" {
+  return descriptor.hops.some((hop) => hop.multiplicity) ? "many" : "one";
+}
+
+function assertLinkInvariant(ok: boolean, message: string): void {
+  if (!ok) {
+    throw new Error(message);
+  }
+}
+
+function buildTraversal<
+  Source extends Node,
+  Target extends Node,
+  Card extends "one" | "many",
+>(
+  descriptor: LinkTraversalDescriptor,
+  projectedShape?: ShapeDefinition<Target>,
+): LinkDef<Source, Target, Card> {
+  const hops = descriptor.hops;
+  const lastHop = hops[hops.length - 1];
+  const firstHop = hops[0];
+
+  const patchLastHop = (
+    patch: Partial<LinkHopDescriptor>,
+    projected?: ShapeDefinition<Target>,
+  ): LinkTraversal<Source, Target, Card> =>
+    buildTraversal<Source, Target, Card>(
+      withLastHop(descriptor, patch),
+      projected,
+    );
+
+  return {
+    __descriptor: descriptor,
+    __projectedShape: projectedShape,
+    apiName: lastHop.linkApiName,
+    sourceType: {} as Source,
+    targetType: {} as Target,
+    cardinality: cardinalityOf(descriptor) as Card,
+
+    where(clause: WhereClause<Target>): LinkTraversal<Source, Target, Card> {
+      return patchLastHop({ where: clause as WhereClause<never> });
+    },
+
+    orderBy(
+      spec: { [K in PropertyKeys<Target>]?: "asc" | "desc" },
+    ): LinkTraversal<Source, Target, Card> {
+      const orderBy = Object.entries(spec).map(([property, direction]) => ({
+        property,
+        direction: direction as "asc" | "desc",
+      }));
+      return patchLastHop({ orderBy });
+    },
+
+    limit(n: number): LinkTraversal<Source, Target, Card> {
+      return patchLastHop({ limit: n });
+    },
+
+    project<S extends ShapeDefinition<Target>>(
+      shape: S,
+    ): LinkTraversal<Source, Target, Card> {
+      return patchLastHop({ projectShapeId: shape.__shapeId }, shape);
+    },
+
+    then<NextTarget extends Node, NextCard extends "one" | "many">(
+      next: LinkDef<Target, NextTarget, NextCard>,
+    ): Path<Source, NextTarget, Card extends "many" ? "many" : NextCard> {
+      const nextFirstHop = next.__descriptor.hops[0];
+      assertLinkInvariant(
+        lastHop.targetTypeApiName === nextFirstHop.sourceTypeApiName,
+        `Invalid link adjacency: cannot chain "${lastHop.linkApiName}" `
+          + `(target "${lastHop.targetTypeApiName}") to "${nextFirstHop.linkApiName}" `
+          + `(source "${nextFirstHop.sourceTypeApiName}")`,
+      );
+      const pathDescriptor: LinkTraversalDescriptor = {
+        kind: "path",
+        hops: [...descriptor.hops, ...next.__descriptor.hops],
+      };
+      const built = buildTraversal<
+        Source,
+        NextTarget,
+        Card extends "many" ? "many" : NextCard
+      >(pathDescriptor);
+      return built as Path<
+        Source,
+        NextTarget,
+        Card extends "many" ? "many" : NextCard
+      >;
+    },
+
+    recursive(
+      opts?: Partial<RecursiveOptions>,
+    ): RecursiveTraversal<Source, Target> {
+      assertLinkInvariant(
+        firstHop.sourceTypeApiName === lastHop.targetTypeApiName,
+        `recursive() requires a self-referential link: source `
+          + `"${firstHop.sourceTypeApiName}" must equal target `
+          + `"${lastHop.targetTypeApiName}"`,
+      );
+      const recursive: RecursiveOptions = {
+        ...DEFAULT_RECURSIVE_OPTIONS,
+        ...opts,
+      };
+      const recursiveDescriptor: LinkTraversalDescriptor = {
+        kind: "recursive",
+        hops: descriptor.hops,
+        recursive,
+      };
+      const built = buildTraversal<Source, Target, "many">(recursiveDescriptor);
+      return built as RecursiveTraversal<Source, Target>;
+    },
+  };
+}
+
+export function createLinkDef<
+  Source extends Node = Node,
+  Target extends Node = Node,
+  M extends boolean = boolean,
+>(
+  sourceTypeApiName: string,
+  linkApiName: string,
+  targetTypeApiName: string,
+  multiplicity: M,
+  sourceIsInterface: boolean,
+): LinkDef<Source, Target, M extends true ? "many" : "one"> {
+  const descriptor: LinkTraversalDescriptor = {
+    kind: "single",
+    hops: [{
+      sourceTypeApiName,
+      linkApiName,
+      targetTypeApiName,
+      multiplicity,
+      sourceIsInterface,
+    }],
+  };
+  return buildTraversal<
+    Source,
+    Target,
+    M extends true ? "many" : "one"
+  >(descriptor);
+}

--- a/packages/api/src/links/hashTraversal.test.ts
+++ b/packages/api/src/links/hashTraversal.test.ts
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { hashTraversal } from "./hashTraversal.js";
+import type {
+  LinkHopDescriptor,
+  LinkTraversalDescriptor,
+} from "./LinkTraversalDescriptor.js";
+
+function singleHop(
+  overrides: Partial<LinkHopDescriptor> = {},
+): LinkTraversalDescriptor {
+  return {
+    kind: "single",
+    hops: [{
+      sourceTypeApiName: "Employee",
+      linkApiName: "reports",
+      targetTypeApiName: "Employee",
+      multiplicity: true,
+      sourceIsInterface: false,
+      ...overrides,
+    }],
+  };
+}
+
+describe("hashTraversal", () => {
+  it("is stable across key insertion order", () => {
+    const a: LinkTraversalDescriptor = {
+      kind: "single",
+      hops: [{
+        sourceTypeApiName: "Employee",
+        linkApiName: "reports",
+        targetTypeApiName: "Employee",
+        multiplicity: true,
+        sourceIsInterface: false,
+        where: { name: { $eq: "a" }, age: { $gt: 1 } },
+      }],
+    };
+    const b: LinkTraversalDescriptor = {
+      hops: [{
+        where: { age: { $gt: 1 }, name: { $eq: "a" } },
+        sourceIsInterface: false,
+        multiplicity: true,
+        targetTypeApiName: "Employee",
+        linkApiName: "reports",
+        sourceTypeApiName: "Employee",
+      }],
+      kind: "single",
+    };
+    expect(hashTraversal(a)).toBe(hashTraversal(b));
+  });
+
+  it("hashes equal descriptors equally", () => {
+    expect(hashTraversal(singleHop())).toBe(hashTraversal(singleHop()));
+  });
+
+  it("differs on different where clause", () => {
+    expect(hashTraversal(singleHop({ where: { name: { $eq: "a" } } }))).not
+      .toBe(
+        hashTraversal(singleHop({ where: { name: { $eq: "b" } } })),
+      );
+  });
+
+  it("differs on different limit", () => {
+    expect(hashTraversal(singleHop({ limit: 10 }))).not.toBe(
+      hashTraversal(singleHop({ limit: 20 })),
+    );
+  });
+
+  it("differs on different recursive depth", () => {
+    const base: LinkTraversalDescriptor = {
+      ...singleHop(),
+      kind: "recursive",
+    };
+    const d10: LinkTraversalDescriptor = {
+      ...base,
+      recursive: { maxDepth: 10, maxNodes: 1000 },
+    };
+    const d5: LinkTraversalDescriptor = {
+      ...base,
+      recursive: { maxDepth: 5, maxNodes: 1000 },
+    };
+    expect(hashTraversal(d10)).not.toBe(hashTraversal(d5));
+  });
+
+  it("differs on different maxNodes budget", () => {
+    const base: LinkTraversalDescriptor = {
+      ...singleHop(),
+      kind: "recursive",
+    };
+    const n1000: LinkTraversalDescriptor = {
+      ...base,
+      recursive: { maxDepth: 10, maxNodes: 1000 },
+    };
+    const n500: LinkTraversalDescriptor = {
+      ...base,
+      recursive: { maxDepth: 10, maxNodes: 500 },
+    };
+    expect(hashTraversal(n1000)).not.toBe(hashTraversal(n500));
+  });
+
+  it("differs on different kind", () => {
+    expect(hashTraversal(singleHop())).not.toBe(
+      hashTraversal({ ...singleHop(), kind: "recursive" }),
+    );
+  });
+
+  it("preserves orderBy ordering (array order is significant)", () => {
+    const ab = singleHop({
+      orderBy: [
+        { property: "a", direction: "asc" },
+        { property: "b", direction: "asc" },
+      ],
+    });
+    const ba = singleHop({
+      orderBy: [
+        { property: "b", direction: "asc" },
+        { property: "a", direction: "asc" },
+      ],
+    });
+    expect(hashTraversal(ab)).not.toBe(hashTraversal(ba));
+  });
+
+  it("ignores function-valued fields", () => {
+    const clean = singleHop();
+    const pollutedHop = { ...singleHop().hops[0], notSerialized: () => 1 };
+    const polluted: LinkTraversalDescriptor = {
+      kind: "single",
+      hops: [pollutedHop],
+    };
+    expect(hashTraversal(polluted)).toBe(hashTraversal(clean));
+  });
+
+  it("differs across path hop chains", () => {
+    const path1: LinkTraversalDescriptor = {
+      kind: "path",
+      hops: [singleHop().hops[0], {
+        sourceTypeApiName: "Employee",
+        linkApiName: "manager",
+        targetTypeApiName: "Employee",
+        multiplicity: false,
+        sourceIsInterface: false,
+      }],
+    };
+    const path2: LinkTraversalDescriptor = {
+      kind: "path",
+      hops: [singleHop().hops[0]],
+    };
+    expect(hashTraversal(path1)).not.toBe(hashTraversal(path2));
+  });
+});

--- a/packages/api/src/links/hashTraversal.ts
+++ b/packages/api/src/links/hashTraversal.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { stableStringify } from "../util/stableStringify.js";
+import type { LinkTraversalDescriptor } from "./LinkTraversalDescriptor.js";
+
+/**
+ * Produces a stable structural hash of a {@link LinkTraversalDescriptor}.
+ *
+ * Two descriptors with identical content but different object-key insertion
+ * order hash equal; descriptors differing in any structural field (kind, hop
+ * api names, multiplicity, where clause, orderBy, limit, projection shape id,
+ * recursive depth/budget) hash differently. Function-valued fields are ignored
+ * so transient closures attached during construction do not affect the hash.
+ *
+ * Used as the subscription/cache key for token-driven traversals so re-renders
+ * that rebuild a structurally-identical descriptor reuse the same subscription.
+ */
+export function hashTraversal(descriptor: LinkTraversalDescriptor): string {
+  return stableStringify(descriptor);
+}

--- a/packages/api/src/ontology/ObjectRef.test.ts
+++ b/packages/api/src/ontology/ObjectRef.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { objectRefEquals, objectRefKey, objectRefOf } from "./ObjectRef.js";
+
+describe("ObjectRef", () => {
+  it("keys are collision-free across separator-ambiguous inputs", () => {
+    const a = objectRefKey({ $objectType: "A", $primaryKey: "1:2" });
+    const b = objectRefKey({ $objectType: "A:1", $primaryKey: "2" });
+    expect(a).not.toEqual(b);
+  });
+  it("objectRefOf extracts only identity fields", () => {
+    expect(
+      objectRefOf(
+        { $objectType: "Op", $primaryKey: 7, extra: 1 } as unknown as {
+          $objectType: string;
+          $primaryKey: string | number;
+        },
+      ),
+    ).toEqual({ $objectType: "Op", $primaryKey: 7 });
+  });
+  it("objectRefEquals compares structurally", () => {
+    expect(
+      objectRefEquals({ $objectType: "Op", $primaryKey: 1 }, {
+        $objectType: "Op",
+        $primaryKey: 1,
+      }),
+    ).toBe(true);
+    expect(
+      objectRefEquals({ $objectType: "Op", $primaryKey: 1 }, {
+        $objectType: "Op",
+        $primaryKey: 2,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/api/src/ontology/ObjectRef.ts
+++ b/packages/api/src/ontology/ObjectRef.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Canonical, heterogeneous-safe identity for a stored object instance. */
+export interface ObjectRef {
+  readonly $objectType: string;
+  readonly $primaryKey: string | number;
+}
+
+/**
+ * U+0000 separator avoids collisions between e.g. ("A", "1:2") and ("A:1", "2")
+ * since neither apiName nor primary key contains a null character.
+ */
+const SEPARATOR = String.fromCharCode(0);
+
+/** Stable string key for an ObjectRef. Used internally for Map keys / dedupe. */
+export function objectRefKey(ref: ObjectRef): string {
+  return `${ref.$objectType}${SEPARATOR}${ref.$primaryKey}`;
+}
+
+export function objectRefOf(
+  instance: { $objectType: string; $primaryKey: string | number },
+): ObjectRef {
+  return {
+    $objectType: instance.$objectType,
+    $primaryKey: instance.$primaryKey,
+  };
+}
+
+export function objectRefEquals(a: ObjectRef, b: ObjectRef): boolean {
+  return a.$objectType === b.$objectType && a.$primaryKey === b.$primaryKey;
+}

--- a/packages/api/src/ontology/ObjectRefMap.test.ts
+++ b/packages/api/src/ontology/ObjectRefMap.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ObjectRefMap } from "./ObjectRefMap.js";
+
+describe("ObjectRefMap", () => {
+  it("dedupes structurally-equal refs", () => {
+    const m = new ObjectRefMap<number>();
+    m.set({ $objectType: "Op", $primaryKey: 1 }, 10);
+    m.set({ $objectType: "Op", $primaryKey: 1 }, 20);
+    expect(m.size).toBe(1);
+    expect(m.get({ $objectType: "Op", $primaryKey: 1 })).toBe(20);
+  });
+  it("keys() returns the stored ObjectRef objects", () => {
+    const m = new ObjectRefMap<number>();
+    m.set({ $objectType: "Op", $primaryKey: 1 }, 10);
+    expect(m.keys()).toEqual([{ $objectType: "Op", $primaryKey: 1 }]);
+  });
+});

--- a/packages/api/src/ontology/ObjectRefMap.ts
+++ b/packages/api/src/ontology/ObjectRefMap.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectRef } from "./ObjectRef.js";
+import { objectRefKey } from "./ObjectRef.js";
+
+/**
+ * Map keyed structurally by {@link ObjectRef}. A plain `Map<ObjectRef, V>`
+ * keyed by object identity will not dedupe structurally-equal refs, so this
+ * wrapper keys by {@link objectRefKey} while preserving the original ref.
+ */
+export class ObjectRefMap<V> {
+  readonly #m = new Map<string, { ref: ObjectRef; value: V }>();
+
+  get size(): number {
+    return this.#m.size;
+  }
+
+  get(ref: ObjectRef): V | undefined {
+    return this.#m.get(objectRefKey(ref))?.value;
+  }
+
+  has(ref: ObjectRef): boolean {
+    return this.#m.has(objectRefKey(ref));
+  }
+
+  set(ref: ObjectRef, value: V): this {
+    this.#m.set(objectRefKey(ref), { ref, value });
+    return this;
+  }
+
+  delete(ref: ObjectRef): boolean {
+    return this.#m.delete(objectRefKey(ref));
+  }
+
+  keys(): ObjectRef[] {
+    return [...this.#m.values()].map((e) => e.ref);
+  }
+
+  entries(): Array<[ObjectRef, V]> {
+    return [...this.#m.values()].map((e) => [e.ref, e.value]);
+  }
+
+  forEach(fn: (value: V, ref: ObjectRef) => void): void {
+    for (const e of this.#m.values()) {
+      fn(e.value, e.ref);
+    }
+  }
+}

--- a/packages/api/src/ontology/ObjectTypeDefinition.ts
+++ b/packages/api/src/ontology/ObjectTypeDefinition.ts
@@ -88,6 +88,16 @@ export interface ObjectMetadata extends ObjectInterfaceBaseMetadata {
       /* InterfaceType property api name */ string
     >
   >;
+  /**
+   * For each implemented interface api name, maps an interface link api name to
+   * the concrete link api name on this object type. Empty when the object
+   * implements no interface links. Enables interface-link to concrete-link
+   * resolution without an extra metadata round trip.
+   *
+   * Optional because legacy generated metadata and the many existing
+   * ObjectMetadata literals predate this field; treat a missing value as `{}`.
+   */
+  interfaceLinkMap?: Record<string, Record<string, string>>;
 }
 
 export namespace ObjectMetadata {

--- a/packages/api/src/shapes/InlineShapeConfig.ts
+++ b/packages/api/src/shapes/InlineShapeConfig.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { LinkTraversal } from "../links/LinkDef.js";
 import type {
   ObjectOrInterfaceDefinition,
   PropertyKeys,
@@ -25,6 +26,13 @@ import type {
   ShapeLinkBuilder,
 } from "./ShapeDefinition.js";
 
+/** A projected link traversal token usable as a `follow` entry, regardless of source/target node or cardinality. */
+export type AnyProjectedTraversal = LinkTraversal<
+  ObjectOrInterfaceDefinition,
+  ObjectOrInterfaceDefinition,
+  "one" | "many"
+>;
+
 export interface InlineShapeConfig<
   BASE extends ObjectOrInterfaceDefinition,
 > {
@@ -34,12 +42,26 @@ export interface InlineShapeConfig<
   readonly defaults?: {
     readonly [K in PropertyKeys<BASE>]?: NonNullable<PropertyType<BASE, K>>;
   };
+  /**
+   * Substitute a value when the source property is null. Behaves like
+   * {@link InlineShapeConfig.defaults} but keeps the substitution visible via
+   * `$missingFields` on the resulting instance.
+   */
+  readonly fallbacks?: {
+    readonly [K in PropertyKeys<BASE>]?: NonNullable<PropertyType<BASE, K>>;
+  };
   readonly transforms?: {
     readonly [K in PropertyKeys<BASE>]?: (
       value: PropertyType<BASE, K>,
     ) => unknown;
   };
   readonly links?: Record<string, InlineLinkConfig<BASE>>;
+  /**
+   * Token-driven derived links. Each value is a projected `LinkTraversal`
+   * (`Type.links.X.project(Slim)`, `.then(...).project(...)`, or
+   * `.recursive(...).project(...)`) compiled into a `ShapeDerivedLinkDef`.
+   */
+  readonly follow?: Record<string, AnyProjectedTraversal>;
 }
 
 export interface InlineLinkConfig<
@@ -82,6 +104,11 @@ export type InferInlineProps<
     >;
   }
   & {
+    [K in keyof C["fallbacks"] & PropertyKeys<BASE>]: NonNullable<
+      PropertyType<BASE, K>
+    >;
+  }
+  & {
     [K in keyof C["transforms"] & PropertyKeys<BASE>]: C["transforms"] extends
       Record<K, (v: PropertyType<BASE, K>) => infer R> ? R : never;
   };
@@ -96,11 +123,23 @@ export type InferInlineLinks<
   }
   : {};
 
+export type InferInlineFollow<
+  BASE extends ObjectOrInterfaceDefinition,
+  C extends InlineShapeConfig<BASE>,
+> = C["follow"] extends Record<string, AnyProjectedTraversal> ? {
+    [K in keyof C["follow"] & string]: NonNullable<
+      C["follow"][K]["__projectedShape"]
+    > extends ShapeDefinition<ObjectOrInterfaceDefinition>
+      ? NonNullable<C["follow"][K]["__projectedShape"]>
+      : ShapeDefinition<ObjectOrInterfaceDefinition>;
+  }
+  : {};
+
 export type InferShapeDefinition<
   BASE extends ObjectOrInterfaceDefinition,
   C extends InlineShapeConfig<BASE>,
 > = ShapeDefinition<
   BASE,
   InferInlineProps<BASE, C>,
-  InferInlineLinks<BASE, C>
+  InferInlineLinks<BASE, C> & InferInlineFollow<BASE, C>
 >;

--- a/packages/api/src/shapes/ShapeBuilder.test.ts
+++ b/packages/api/src/shapes/ShapeBuilder.test.ts
@@ -128,4 +128,32 @@ describe("createShapeLinkBuilder", () => {
     const def = result.toObjectSetDef();
     expect(def.where).toEqual({ name: "second" });
   });
+
+  it("project produces the same ShapeLinkResult as the deprecated as alias", () => {
+    const targetShape = createShapeBuilder(MockOffice).select("name" as never)
+      .build();
+
+    const fromProject = (createShapeLinkBuilder("Employee") as any)
+      .pivotTo("office")
+      .project(targetShape);
+
+    const fromAs = (createShapeLinkBuilder("Employee") as any)
+      .pivotTo("office")
+      .as(targetShape);
+
+    expect(fromProject.targetShape).toBe(targetShape);
+    expect(fromProject.objectSetDef).toEqual(fromAs.objectSetDef);
+    expect(fromProject.config).toEqual(fromAs.config);
+  });
+
+  it("project forwards config", () => {
+    const targetShape = createShapeBuilder(MockOffice).select("name" as never)
+      .build();
+
+    const result = (createShapeLinkBuilder("Employee") as any)
+      .pivotTo("office")
+      .project(targetShape, { defer: true });
+
+    expect(result.config).toEqual({ defer: true });
+  });
 });

--- a/packages/api/src/shapes/ShapeBuilder.ts
+++ b/packages/api/src/shapes/ShapeBuilder.ts
@@ -307,7 +307,7 @@ class ShapeLinkBuilderImpl<
     });
   }
 
-  as<TARGET_SHAPE extends ShapeDefinition<CURRENT>>(
+  project<TARGET_SHAPE extends ShapeDefinition<CURRENT>>(
     shape: TARGET_SHAPE,
     config: DerivedLinkConfig = {},
   ): ShapeLinkResult<TARGET_SHAPE> {
@@ -317,6 +317,14 @@ class ShapeLinkBuilderImpl<
       objectSetDef: this.toObjectSetDef(),
       config,
     } as ShapeLinkResult<TARGET_SHAPE>;
+  }
+
+  /** @deprecated Use {@link project} instead. */
+  as<TARGET_SHAPE extends ShapeDefinition<CURRENT>>(
+    shape: TARGET_SHAPE,
+    config: DerivedLinkConfig = {},
+  ): ShapeLinkResult<TARGET_SHAPE> {
+    return this.project(shape, config);
   }
 
   toObjectSetDef(): ShapeLinkObjectSetDef {

--- a/packages/api/src/shapes/ShapeDefinition.ts
+++ b/packages/api/src/shapes/ShapeDefinition.ts
@@ -15,6 +15,7 @@
  */
 
 import type { WhereClause } from "../aggregate/WhereClause.js";
+import type { RecursiveOptions } from "../links/LinkTraversalDescriptor.js";
 import type {
   ObjectOrInterfaceDefinition,
   PropertyKeys,
@@ -45,7 +46,7 @@ export interface DerivedLinkConfig {
   defer?: boolean;
 }
 
-/** The result of calling `ShapeLinkBuilder.as()`, binding a link traversal to a target shape. */
+/** The result of calling `ShapeLinkBuilder.project()`, binding a link traversal to a target shape. */
 export interface ShapeLinkResult<
   TARGET_SHAPE extends ShapeDefinition<ObjectOrInterfaceDefinition>,
 > {
@@ -83,6 +84,12 @@ export interface ShapeLinkObjectSetDef {
   readonly limit?: number;
   readonly distinct?: boolean;
   readonly setOperations?: readonly ShapeLinkSetOperation[];
+  /**
+   * Present when the traversal is recursive (built via `.recursive()`). The
+   * segments describe one expansion step; `recursive` carries the depth/node
+   * budget the runtime uses to drive the incremental closure.
+   */
+  readonly recursive?: RecursiveOptions;
 }
 
 /** How a shape handles null values for a selected property. */
@@ -152,6 +159,13 @@ export type ShapeInstance<
 > = S extends ShapeDefinition<infer BASE, infer PROPS, infer LINKS> ?
     & OsdkBase<BASE>
     & { readonly $rid: string }
+    & {
+      /**
+       * Properties whose source value was null and were substituted by a
+       * `fallbacks`/`withDefault` value. Empty when nothing was substituted.
+       */
+      readonly $missingFields: ReadonlySet<string>;
+    }
     & PROPS
     & {
       [K in keyof LINKS]: LINKS[K] extends
@@ -198,6 +212,12 @@ export interface ShapeLinkBuilder<
 
   distinct(): ShapeLinkBuilder<SOURCE, CURRENT>;
 
+  project<TARGET_SHAPE extends ShapeDefinition<CURRENT>>(
+    shape: TARGET_SHAPE,
+    config?: DerivedLinkConfig,
+  ): ShapeLinkResult<TARGET_SHAPE>;
+
+  /** @deprecated Use {@link ShapeLinkBuilder.project} instead. */
   as<TARGET_SHAPE extends ShapeDefinition<CURRENT>>(
     shape: TARGET_SHAPE,
     config?: DerivedLinkConfig,

--- a/packages/api/src/shapes/computeShapeId.ts
+++ b/packages/api/src/shapes/computeShapeId.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { stableStringify } from "../util/stableStringify.js";
 import type {
   ShapeDerivedLinkDef,
   ShapeLinkObjectSetDef,
@@ -26,18 +27,6 @@ interface ShapeIdInput {
   derivedLinks: readonly ShapeDerivedLinkDef[];
 }
 
-function sortedStringify(obj: unknown): string {
-  return JSON.stringify(
-    obj,
-    (_, v) =>
-      v && typeof v === "object" && !Array.isArray(v)
-        ? Object.fromEntries(
-          Object.entries(v).sort(([a], [b]) => a.localeCompare(b)),
-        )
-        : v,
-  );
-}
-
 /**
  * Computes a stable, deterministic identifier for a shape definition.
  * The ID uniquely represents the combination of base type, property
@@ -46,7 +35,7 @@ function sortedStringify(obj: unknown): string {
  */
 export function computeShapeId(input: ShapeIdInput): string {
   const canonical = canonicalizeShapeInput(input);
-  return simpleHash(sortedStringify(canonical));
+  return simpleHash(stableStringify(canonical));
 }
 
 function canonicalizeShapeInput(
@@ -89,7 +78,7 @@ function canonicalizeObjectSetDef(
   };
 
   if (def.where) {
-    result.where = JSON.parse(sortedStringify(def.where));
+    result.where = JSON.parse(stableStringify(def.where));
   }
 
   if (def.orderBy && def.orderBy.length > 0) {
@@ -112,6 +101,13 @@ function canonicalizeObjectSetDef(
       type: op.type,
       other: canonicalizeObjectSetDef(op.other),
     }));
+  }
+
+  if (def.recursive) {
+    result.recursive = {
+      maxDepth: def.recursive.maxDepth,
+      maxNodes: def.recursive.maxNodes,
+    };
   }
 
   return result;

--- a/packages/api/src/shapes/configToShapeDefinition.test.ts
+++ b/packages/api/src/shapes/configToShapeDefinition.test.ts
@@ -15,16 +15,33 @@
  */
 
 import { describe, expect, it } from "vitest";
+import { createLinkDef } from "../links/createLinkDef.js";
 import type { ObjectTypeDefinition } from "../ontology/ObjectTypeDefinition.js";
 import { configToShapeDefinition } from "./configToShapeDefinition.js";
 import type {
   ShapeDefinition,
+  ShapeDerivedLinkDef,
   ShapePropertyConfig,
 } from "./ShapeDefinition.js";
 
 const MockEmployee = {
   type: "object",
   apiName: "Employee",
+} as ObjectTypeDefinition;
+
+const MockOffice = {
+  type: "object",
+  apiName: "Office",
+} as ObjectTypeDefinition;
+
+const MockPerson = {
+  type: "object",
+  apiName: "Person",
+} as ObjectTypeDefinition;
+
+const MockOperation = {
+  type: "object",
+  apiName: "Operation",
 } as ObjectTypeDefinition;
 
 describe("configToShapeDefinition", () => {
@@ -51,6 +68,27 @@ describe("configToShapeDefinition", () => {
       type: "withDefault",
       defaultValue: "Unknown",
     });
+  });
+
+  it("maps fallbacks to withDefault ops", () => {
+    const shape = configToShapeDefinition(MockEmployee, {
+      fallbacks: { role: "TBD" } as any,
+    });
+
+    const props = shape.__props as Record<string, ShapePropertyConfig>;
+    expect(props.role.nullabilityOp).toEqual({
+      type: "withDefault",
+      defaultValue: "TBD",
+    });
+  });
+
+  it("throws when a property appears in both defaults and fallbacks", () => {
+    expect(() =>
+      configToShapeDefinition(MockEmployee, {
+        defaults: { role: "Unknown" } as any,
+        fallbacks: { role: "TBD" } as any,
+      })
+    ).toThrow("Property \"role\" appears in multiple config arrays");
   });
 
   it("maps transforms to withTransform ops", () => {
@@ -99,6 +137,154 @@ describe("configToShapeDefinition", () => {
     expect(link.name).toBe("offices");
     expect(link.objectSetDef.segments[0].linkName).toBe("office");
     expect(link.targetShape.__shapeId).toBe(targetShape.__shapeId);
+  });
+
+  it("compiles a single-hop follow entry into a derived link", () => {
+    const SlimOffice = configToShapeDefinition(MockOffice, {
+      select: ["name"] as any,
+    });
+
+    const shape = configToShapeDefinition(MockEmployee, {
+      follow: {
+        office: createLinkDef("Employee", "office", "Office", false, false)
+          .project(SlimOffice as ShapeDefinition<any>),
+      },
+    });
+
+    expect(shape.__derivedLinks).toHaveLength(1);
+    const link = shape.__derivedLinks[0] as ShapeDerivedLinkDef;
+    expect(link.name).toBe("office");
+    expect(link.objectSetDef.segments).toHaveLength(1);
+    expect(link.objectSetDef.segments[0].type).toBe("pivotTo");
+    expect(link.objectSetDef.segments[0].linkName).toBe("office");
+    expect(link.targetShape.__shapeId).toBe(SlimOffice.__shapeId);
+  });
+
+  it("compiles a multi-hop follow path into pivotTo segments", () => {
+    const SlimPerson = configToShapeDefinition(MockPerson, {
+      select: ["name"] as any,
+    });
+
+    const shape = configToShapeDefinition(MockEmployee, {
+      follow: {
+        managerOfOffice: createLinkDef(
+          "Employee",
+          "office",
+          "Office",
+          false,
+          false,
+        )
+          .then(createLinkDef("Office", "manager", "Person", false, false))
+          .project(SlimPerson as ShapeDefinition<any>),
+      },
+    });
+
+    expect(shape.__derivedLinks).toHaveLength(1);
+    const link = shape.__derivedLinks[0] as ShapeDerivedLinkDef;
+    expect(link.name).toBe("managerOfOffice");
+    expect(link.objectSetDef.segments).toHaveLength(2);
+    expect(link.objectSetDef.segments[0].type).toBe("pivotTo");
+    expect(link.objectSetDef.segments[0].linkName).toBe("office");
+    expect(link.objectSetDef.segments[1].type).toBe("pivotTo");
+    expect(link.objectSetDef.segments[1].linkName).toBe("manager");
+    expect(link.targetShape.__shapeId).toBe(SlimPerson.__shapeId);
+  });
+
+  it("compiles a recursive follow entry into a recursive object set def", () => {
+    const SlimOp = configToShapeDefinition(MockOperation, {
+      select: ["name"] as any,
+    });
+
+    const shape = configToShapeDefinition(MockOperation, {
+      follow: {
+        descendants: createLinkDef(
+          "Operation",
+          "subOperations",
+          "Operation",
+          true,
+          false,
+        )
+          .recursive({ maxDepth: 3 })
+          .project(SlimOp as ShapeDefinition<any>),
+      },
+    });
+
+    expect(shape.__derivedLinks).toHaveLength(1);
+    const link = shape.__derivedLinks[0] as ShapeDerivedLinkDef;
+    expect(link.name).toBe("descendants");
+    expect(link.objectSetDef.segments).toHaveLength(1);
+    expect(link.objectSetDef.segments[0].linkName).toBe("subOperations");
+    expect(link.objectSetDef.recursive).toEqual({
+      maxDepth: 3,
+      maxNodes: 1000,
+    });
+    expect(link.targetShape.__shapeId).toBe(SlimOp.__shapeId);
+  });
+
+  it("defaults a non-projected recursive follow to a minimal shape", () => {
+    const parent = configToShapeDefinition(MockOperation, {
+      require: ["name"] as any,
+    });
+
+    const shape = configToShapeDefinition(MockOperation, {
+      require: ["name"] as any,
+      follow: {
+        descendants: createLinkDef(
+          "Operation",
+          "subOperations",
+          "Operation",
+          true,
+          false,
+        ).recursive({ maxDepth: 3 }),
+      },
+    });
+
+    expect(shape.__derivedLinks).toHaveLength(1);
+    const link = shape.__derivedLinks[0] as ShapeDerivedLinkDef;
+    expect(link.name).toBe("descendants");
+    expect(link.objectSetDef.recursive).toEqual({
+      maxDepth: 3,
+      maxNodes: 1000,
+    });
+
+    const target = link.targetShape;
+    expect(target.__baseTypeApiName).toBe("Operation");
+    expect(Object.keys(target.__props)).toHaveLength(0);
+    expect(target.__derivedLinks).toHaveLength(0);
+    expect(target.__shapeId).not.toBe(parent.__shapeId);
+  });
+
+  it("throws when a non-recursive follow entry is not projected", () => {
+    expect(() =>
+      configToShapeDefinition(MockEmployee, {
+        follow: {
+          office: createLinkDef("Employee", "office", "Office", false, false),
+        },
+      })
+    ).toThrow("follow[\"office\"] must be projected with .project(shape)");
+  });
+
+  it("distinguishes shapeIds by recursive options", () => {
+    const SlimOp = configToShapeDefinition(MockOperation, {
+      select: ["name"] as any,
+    });
+    const make = (maxDepth: number) =>
+      configToShapeDefinition(MockOperation, {
+        follow: {
+          descendants: createLinkDef(
+            "Operation",
+            "subOperations",
+            "Operation",
+            true,
+            false,
+          )
+            .recursive({ maxDepth })
+            .project(SlimOp as ShapeDefinition<any>),
+        },
+      });
+
+    expect(make(3).__shapeId).not.toBe(make(5).__shapeId);
+    expect(make(3).__shapeId).toBe(make(3).__shapeId);
   });
 
   it("produces a deterministic shapeId", () => {

--- a/packages/api/src/shapes/configToShapeDefinition.ts
+++ b/packages/api/src/shapes/configToShapeDefinition.ts
@@ -14,21 +14,79 @@
  * limitations under the License.
  */
 
+import type { WhereClause } from "../aggregate/WhereClause.js";
+import type {
+  LinkHopDescriptor,
+  LinkTraversalDescriptor,
+} from "../links/LinkTraversalDescriptor.js";
 import type { ObjectOrInterfaceDefinition } from "../ontology/ObjectOrInterface.js";
 import { computeShapeId } from "./computeShapeId.js";
 import type {
   InferShapeDefinition,
   InlineShapeConfig,
 } from "./InlineShapeConfig.js";
-import { createShapeLinkBuilder } from "./ShapeBuilder.js";
+import { createShapeBuilder, createShapeLinkBuilder } from "./ShapeBuilder.js";
 import type {
   NullabilityOp,
   ShapeDefinition,
   ShapeDerivedLinkDef,
   ShapeLinkBuilderInternal,
   ShapeLinkObjectSetDef,
+  ShapeLinkOrderBy,
+  ShapeLinkSegment,
   ShapePropertyConfig,
 } from "./ShapeDefinition.js";
+
+function hopToSegment(hop: LinkHopDescriptor): ShapeLinkSegment {
+  return {
+    type: "pivotTo",
+    linkName: hop.linkApiName,
+    sourceType: hop.sourceTypeApiName,
+    targetType: hop.targetTypeApiName,
+  };
+}
+
+/**
+ * Translates a token `LinkTraversalDescriptor` into a `ShapeLinkObjectSetDef`.
+ * Each hop becomes one `pivotTo` segment. `where`/`orderBy`/`limit` come from
+ * the endpoint (last) hop, matching the top-level filter semantics of
+ * `ShapeLinkObjectSetDef`.
+ */
+function descriptorToObjectSetDef(
+  descriptor: LinkTraversalDescriptor,
+): ShapeLinkObjectSetDef {
+  const segments = descriptor.hops.map(hopToSegment);
+  const lastHop = descriptor.hops[descriptor.hops.length - 1];
+  const where = lastHop.where as
+    | WhereClause<ObjectOrInterfaceDefinition>
+    | undefined;
+  const orderBy = lastHop.orderBy as readonly ShapeLinkOrderBy[] | undefined;
+  return {
+    segments: Object.freeze(segments),
+    where,
+    orderBy: orderBy && orderBy.length > 0
+      ? Object.freeze([...orderBy])
+      : undefined,
+    limit: lastHop.limit,
+    recursive: descriptor.recursive,
+  };
+}
+
+/**
+ * Synthesizes the default target shape for a recursive `follow` entry that was
+ * not given an explicit `.project(shape)`. The projection is intentionally
+ * minimal: each node carries only its `$primaryKey`/`$title` (always present via
+ * `OsdkBase`, so no selected props are needed) and no nested derived links. The
+ * recursion itself is driven by the parent derived link's
+ * `objectSetDef.recursive`, and the flat-plus-adjacency batched store
+ * reconstructs nesting, so a self-referential link here is neither required nor
+ * desirable.
+ */
+function minimalRecursiveShape(
+  baseType: ObjectOrInterfaceDefinition,
+): ShapeDefinition<ObjectOrInterfaceDefinition> {
+  return createShapeBuilder(baseType).build();
+}
 
 export function configToShapeDefinition<
   BASE extends ObjectOrInterfaceDefinition,
@@ -78,6 +136,17 @@ export function configToShapeDefinition<
     }
   }
 
+  if (config.fallbacks) {
+    for (const [prop, defaultValue] of Object.entries(config.fallbacks)) {
+      addProp(prop, {
+        nullabilityOp: {
+          type: "withDefault",
+          defaultValue,
+        } as NullabilityOp,
+      });
+    }
+  }
+
   if (config.transforms) {
     for (const [prop, transform] of Object.entries(config.transforms)) {
       if (typeof transform !== "function") {
@@ -111,6 +180,33 @@ export function configToShapeDefinition<
         objectSetDef,
         targetShape,
         config: { defer: linkConfig.defer },
+      });
+    }
+  }
+
+  if (config.follow) {
+    const linkNames = new Set(derivedLinks.map((l) => l.name));
+    for (const [name, traversal] of Object.entries(config.follow)) {
+      if (linkNames.has(name)) {
+        throw new Error(`Derived link "${name}" is defined more than once`);
+      }
+      linkNames.add(name);
+
+      const objectSetDef = descriptorToObjectSetDef(traversal.__descriptor);
+      const isRecursive = traversal.__descriptor.kind === "recursive";
+      const targetShape = traversal.__projectedShape
+        ?? (isRecursive ? minimalRecursiveShape(baseType) : undefined);
+      if (targetShape == null) {
+        throw new Error(
+          `follow["${name}"] must be projected with .project(shape)`,
+        );
+      }
+
+      derivedLinks.push({
+        name,
+        objectSetDef,
+        targetShape,
+        config: {},
       });
     }
   }

--- a/packages/api/src/util/stableStringify.ts
+++ b/packages/api/src/util/stableStringify.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Produces a stable, order-independent JSON-like string for a value.
+ *
+ * Object keys are emitted in sorted order so two values with identical content
+ * but different key insertion order stringify equally. Arrays keep their order
+ * (array order is significant). Function-valued fields and `undefined` are
+ * dropped so transient closures attached during construction do not affect the
+ * output.
+ *
+ * Used for structural hashing/cache-keying of descriptors and shape inputs.
+ */
+export function stableStringify(value: unknown): string {
+  if (value == null) {
+    return "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringify(entry)).join(",")}]`;
+  }
+  if (typeof value === "object") {
+    const record: Record<string, unknown> = value as Record<string, unknown>;
+    const parts: Array<string> = [];
+    for (const key of Object.keys(record).sort()) {
+      const entry = record[key];
+      if (typeof entry === "function" || entry === undefined) {
+        continue;
+      }
+      parts.push(`${JSON.stringify(key)}:${stableStringify(entry)}`);
+    }
+    return `{${parts.join(",")}}`;
+  }
+  if (typeof value === "function") {
+    return "null";
+  }
+  return JSON.stringify(value);
+}

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -35,6 +35,7 @@ import type {
 import type { SharedClient } from "@osdk/shared.client2";
 import type { ActionSignatureFromDef } from "./actions/applyAction.js";
 import type { MinimalClient } from "./MinimalClientContext.js";
+import type { OntologyMetadataClient } from "./ontology/OntologyMetadataClient.js";
 import type { QuerySignatureFromDef } from "./queries/types.js";
 import type { SatisfiesSemver } from "./SatisfiesSemver.js";
 
@@ -159,6 +160,13 @@ export interface Client extends SharedClient, OldSharedClient {
       : Q extends QueryDefinition<any> ? QueryMetadata
       : never
   >;
+
+  /**
+   * Ontology metadata discovery surface for interface-aware graph loading.
+   * Resolves which concrete object types implement an interface and translates
+   * interface links to their concrete link on a given object type.
+   */
+  ontologyMetadata: OntologyMetadataClient;
 
   /** @internal */
   [additionalContext]: MinimalClient;

--- a/packages/client/src/createClient.test.ts
+++ b/packages/client/src/createClient.test.ts
@@ -202,4 +202,121 @@ describe(createClient, () => {
       expect(someParam).toBe(transactionId);
     });
   });
+
+  describe("ontologyMetadata", () => {
+    const objectFullMetadataWire = {
+      implementsInterfaces: ["CategoryInterface"],
+      implementsInterfaces2: {
+        CategoryInterface: {
+          properties: {},
+          propertiesV2: {},
+          links: { childCategories: ["concreteChildren"] },
+        },
+      },
+      linkTypes: [
+        {
+          apiName: "concreteChildren",
+          cardinality: "MANY",
+          objectTypeApiName: "SubCategory",
+          displayName: "Children",
+          status: "ACTIVE",
+          linkTypeRid: "ri.link",
+        },
+      ],
+      objectType: {
+        apiName: "SubCategory",
+        description: "description",
+        displayName: "Sub Category",
+        pluralDisplayName: "Sub Categories",
+        icon: { type: "blueprint", name: "blueprint", color: "blue" },
+        primaryKey: "primaryKey",
+        properties: {
+          primaryKey: {
+            dataType: { type: "string" },
+            rid: "ri.property",
+            typeClasses: [],
+          },
+        },
+        rid: "ri.object",
+        status: "ACTIVE",
+        titleProperty: "primaryKey",
+      },
+      sharedPropertyTypeMapping: {},
+    };
+
+    const interfaceWire = {
+      rid: "ri.interface",
+      apiName: "CategoryInterface",
+      displayName: "Category Interface",
+      description: "",
+      properties: {},
+      allProperties: {},
+      links: {},
+      allLinks: {},
+      implementedByObjectTypes: ["SubCategory"],
+    };
+
+    it("resolveLink round-trips an interface link to its concrete link through the provider", async () => {
+      const fetch = vi.fn() as MockedFunction<typeof globalThis.fetch>;
+      fetch.mockImplementation((input) => {
+        const url = String(input);
+        const body = url.includes("/fullMetadata")
+          ? objectFullMetadataWire
+          : interfaceWire;
+        return Promise.resolve(
+          {
+            json: () => Promise.resolve(body),
+            status: 200,
+            ok: true,
+          } as Response,
+        );
+      });
+
+      const localClient = createClient(
+        "https://mock.com",
+        ontologyRid,
+        async () => "Token",
+        undefined,
+        fetch,
+      );
+
+      const resolved = await localClient.ontologyMetadata.resolveLink(
+        "SubCategory",
+        "childCategories",
+      );
+
+      expect(resolved).toEqual({
+        concreteLinkApiName: "concreteChildren",
+        targetType: "SubCategory",
+        multiplicity: true,
+      });
+    });
+
+    it("implementationsOf round-trips implementedBy through the provider", async () => {
+      const fetch = vi.fn() as MockedFunction<typeof globalThis.fetch>;
+      fetch.mockImplementation(() =>
+        Promise.resolve(
+          {
+            json: () => Promise.resolve(interfaceWire),
+            status: 200,
+            ok: true,
+          } as Response,
+        )
+      );
+
+      const localClient = createClient(
+        "https://mock.com",
+        ontologyRid,
+        async () => "Token",
+        undefined,
+        fetch,
+      );
+
+      expect(
+        await localClient.ontologyMetadata.implementationsOf(
+          "CategoryInterface",
+        ),
+      ).toEqual(["SubCategory"]);
+    });
+  });
 });

--- a/packages/client/src/createClient.ts
+++ b/packages/client/src/createClient.ts
@@ -62,6 +62,8 @@ import { fetchSingle } from "./object/fetchSingle.js";
 import { createObjectSet } from "./objectSet/createObjectSet.js";
 import type { ObjectSetFactory } from "./objectSet/ObjectSetFactory.js";
 import { ObjectSetListenerWebsocket } from "./objectSet/ObjectSetListenerWebsocket.js";
+import { createOntologyMetadataClient } from "./ontology/OntologyMetadataClient.js";
+import { ontologyVersionKey } from "./ontology/versionKeyedMetadataCache.js";
 import { applyQuery } from "./queries/applyQuery.js";
 import type { QuerySignatureFromDef } from "./queries/types.js";
 
@@ -396,6 +398,11 @@ export function createClientFromContext(clientCtx: MinimalClient) {
     clientCtx,
   );
 
+  const ontologyMetadata = createOntologyMetadataClient(
+    clientCtx.ontologyProvider,
+    () => ontologyVersionKey(clientCtx),
+  );
+
   const symbolClientContext: newSymbolClientContext = "__osdkClientContext";
 
   const client: Client = Object.defineProperties<Client>(
@@ -412,6 +419,9 @@ export function createClientFromContext(clientCtx: MinimalClient) {
       },
       fetchMetadata: {
         value: fetchMetadata,
+      },
+      ontologyMetadata: {
+        value: ontologyMetadata,
       },
     } satisfies Record<keyof Client, PropertyDescriptor>,
   );

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -16,7 +16,7 @@
 
 /* eslint-disable @typescript-eslint/no-deprecated */
 
-export { isOk } from "@osdk/api";
+export { createLinkDef, isOk } from "@osdk/api";
 export type {
   ActionDefinition,
   ActionEditResponse,
@@ -31,6 +31,11 @@ export type {
   DerivedProperty,
   InterfaceDefinition,
   InterfaceMetadata,
+  LinkDef,
+  LinkHopDescriptor,
+  LinkTraversal,
+  LinkTraversalDescriptor,
+  LinkTraversalKind,
   Logger,
   Media,
   MediaMetadata,
@@ -45,6 +50,7 @@ export type {
   OsdkObjectCreatePropertyType,
   OsdkObjectPropertyType,
   PageResult,
+  Path,
   PropertyDef,
   PropertyKeys,
   PropertyValueWireToClient,
@@ -52,6 +58,8 @@ export type {
   QueryParam,
   QueryResult,
   Range,
+  RecursiveOptions,
+  RecursiveTraversal,
   Result,
   SingleLinkAccessor,
   ThreeDimensionalAggregation,
@@ -67,6 +75,14 @@ export { createClient } from "./createClient.js";
 export { createPlatformClient } from "./createPlatformClient.js";
 export type { PlatformClient } from "./createPlatformClient.js";
 export { createAttachmentUpload } from "./object/AttachmentUpload.js";
+export {
+  InterfaceLinkNotResolvableError,
+  OntologyMetadataNotFoundError,
+} from "./ontology/errors/InterfaceLinkErrors.js";
+export type {
+  OntologyMetadataClient,
+  ResolvedLink,
+} from "./ontology/OntologyMetadataClient.js";
 export type { ResultOrError } from "./ResultOrError.js";
 
 export type { ObjectSet as WireObjectSet } from "@osdk/foundry.ontologies";

--- a/packages/client/src/observable/LinkPayload.ts
+++ b/packages/client/src/observable/LinkPayload.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { ObjectRefMap } from "@osdk/api";
 import type { InterfaceHolder } from "../object/convertWireToOsdkObjects/InterfaceHolder.js";
 import type { ObjectHolder } from "../object/convertWireToOsdkObjects/ObjectHolder.js";
 import type { ObserveLinkCallbackArgs } from "./ObservableClient.js";
@@ -24,10 +25,15 @@ import type { ObserveLinkCallbackArgs } from "./ObservableClient.js";
 export interface SpecificLinkPayload extends
   Omit<
     ObserveLinkCallbackArgs<any>,
-    "resolvedList" | "linkedObjectsBySourcePrimaryKey"
+    | "resolvedList"
+    | "linkedObjectsBySource"
+    | "linkedObjectsBySourcePrimaryKey"
   >
 {
   resolvedList: Array<ObjectHolder | InterfaceHolder> | undefined;
+  linkedObjectsBySource: ObjectRefMap<
+    ReadonlyArray<ObjectHolder | InterfaceHolder>
+  >;
   linkedObjectsBySourcePrimaryKey: ReadonlyMap<
     string | number,
     ReadonlyArray<ObjectHolder | InterfaceHolder>

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -56,6 +56,8 @@ import type {
 } from "./ObservableClient/MediaObservableTypes.js";
 import type { MediaPropertyLocation } from "./ObservableClient/MediaTypes.js";
 import type { ObserveLinks } from "./ObservableClient/ObserveLink.js";
+import type { ObserveLinkClosure } from "./ObservableClient/ObserveLinkClosure.js";
+import type { ObservePath } from "./ObservableClient/ObservePath.js";
 import type { OptimisticBuilder } from "./OptimisticBuilder.js";
 
 export namespace ObservableClient {
@@ -389,7 +391,9 @@ export interface ObserveLinkCallbackArgs<
  * - Pagination support for large collections
  * - Link traversal for relationship navigation
  */
-export interface ObservableClient extends ObserveLinks {
+export interface ObservableClient
+  extends ObserveLinks, ObserveLinkClosure, ObservePath
+{
   /**
    * Observe a single object or interface instance with automatic updates when it changes.
    *

--- a/packages/client/src/observable/ObservableClient/ObserveLink.ts
+++ b/packages/client/src/observable/ObservableClient/ObserveLink.ts
@@ -17,6 +17,7 @@
 import type {
   CompileTimeMetadata,
   InterfaceDefinition,
+  ObjectRefMap,
   ObjectTypeDefinition,
   Osdk,
   PrimaryKeyType,
@@ -69,6 +70,22 @@ export namespace ObserveLinks {
     T extends ObjectTypeDefinition | InterfaceDefinition,
   > {
     resolvedList: Osdk.Instance<T, "$allBaseProperties">[] | undefined;
+
+    /**
+     * Maps each source object's {@link ObjectRef} to its linked object
+     * instances. Heterogeneous-safe: two concrete types that share a primary
+     * key key into distinct entries. A source never appears in its own group.
+     */
+    linkedObjectsBySource: ObjectRefMap<
+      ReadonlyArray<Osdk.Instance<T, "$allBaseProperties">>
+    >;
+
+    /**
+     * @deprecated Use {@link linkedObjectsBySource} instead, which keys by
+     * {@link ObjectRef} and is heterogeneous-safe. This bare primary-key map
+     * collapses sources that share a primary key across concrete types and is
+     * kept as a derived alias for one release.
+     */
     linkedObjectsBySourcePrimaryKey: ReadonlyMap<
       string | number,
       ReadonlyArray<Osdk.Instance<T, "$allBaseProperties">>

--- a/packages/client/src/observable/ObservableClient/ObserveLinkClosure.ts
+++ b/packages/client/src/observable/ObservableClient/ObserveLinkClosure.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  InterfaceDefinition,
+  LinkHopDescriptor,
+  ObjectRef,
+  ObjectRefMap,
+  ObjectTypeDefinition,
+  Osdk,
+} from "@osdk/api";
+import type { Unsubscribable } from "../Unsubscribable.js";
+import type { Observer, Status } from "./common.js";
+
+export namespace ObserveLinkClosure {
+  /**
+   * Options for observing the recursive closure of a self-referential link.
+   *
+   * The closure is driven as an incremental, client-side BFS: a snapshot is
+   * emitted to the observer after each expanded level.
+   */
+  export interface Options {
+    /** The node the BFS starts from. Excluded from the flat `data` result. */
+    root: ObjectRef;
+    /** The single decorated hop that is followed recursively. */
+    hop: LinkHopDescriptor;
+    /**
+     * Maximum BFS depth. `"unbounded"` is allowed only because streaming plus
+     * `maxNodes` keeps the traversal bounded.
+     */
+    maxDepth: number | "unbounded";
+    /** Hard work budget; depth alone does not bound a client-driven BFS. */
+    maxNodes: number;
+  }
+
+  /**
+   * User facing callback args for `observeLinkClosure`. Canonical storage stays
+   * flat (`data` + `adjacency` + `byDepth`); a tree view is derived elsewhere.
+   */
+  export interface CallbackArgs<
+    T extends ObjectTypeDefinition | InterfaceDefinition,
+  > {
+    /** flat, deduped, root-excluded discovery order, resolved to instances. */
+    data: Osdk.Instance<T, "$allBaseProperties">[];
+    /** parent -> children, including back-edges to already-visited nodes. */
+    adjacency: ObjectRefMap<ObjectRef[]>;
+    /** depth (root = 0) of every discovered node. */
+    byDepth: ObjectRefMap<number>;
+    /** nodes with potentially-unexpanded children. */
+    frontier: ObjectRef[];
+    /** deepest level reached so far. */
+    depthReached: number;
+    /** true while a level is still being expanded. */
+    isExpanding: boolean;
+    truncated: { byDepth: boolean; byNodeBudget: boolean };
+    /** extend the closure from one already-discovered node. */
+    expand: (ref: ObjectRef) => void;
+    isOptimistic: boolean;
+    status: Status;
+    error: Error | undefined;
+    lastUpdated: number;
+  }
+}
+
+export interface ObserveLinkClosure {
+  /**
+   * Observe the recursive closure of a self-referential link from a root node.
+   *
+   * Streams: the observer receives a snapshot after each expanded BFS level so
+   * data can render as it arrives.
+   */
+  observeLinkClosure<
+    T extends ObjectTypeDefinition | InterfaceDefinition,
+  >(
+    options: ObserveLinkClosure.Options,
+    subFn: Observer<ObserveLinkClosure.CallbackArgs<T>>,
+  ): Unsubscribable;
+}

--- a/packages/client/src/observable/ObservableClient/ObservePath.ts
+++ b/packages/client/src/observable/ObservableClient/ObservePath.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  InterfaceDefinition,
+  LinkHopDescriptor,
+  ObjectRef,
+  ObjectTypeDefinition,
+  Osdk,
+} from "@osdk/api";
+import type { Unsubscribable } from "../Unsubscribable.js";
+import type { Observer, Status } from "./common.js";
+
+export namespace ObservePath {
+  /**
+   * Options for observing a multi-hop `.then()` path traversal.
+   *
+   * The path is driven as a sequence of single-hop, multi-source expansions: the
+   * deduped endpoints of one hop become the source set of the next. Only the
+   * final hop's endpoints are surfaced; intermediate nodes are dropped.
+   */
+  export interface Options {
+    /** The node the traversal starts from. Excluded from the `data` result. */
+    root: ObjectRef;
+    /** The chained hops, left to right; length > 1 for a real path. */
+    hops: ReadonlyArray<LinkHopDescriptor>;
+  }
+
+  /** User facing callback args for `observePath`: deduped endpoints only. */
+  export interface CallbackArgs<
+    T extends ObjectTypeDefinition | InterfaceDefinition,
+  > {
+    /** deduped endpoint instances reachable across the full path. */
+    data: Osdk.Instance<T, "$allBaseProperties">[];
+    isOptimistic: boolean;
+    status: Status;
+    error: Error | undefined;
+    lastUpdated: number;
+  }
+}
+
+export interface ObservePath {
+  /**
+   * Observe a multi-hop `.then()` path traversal from a root node.
+   *
+   * A single snapshot is emitted once the last hop settles (no per-hop
+   * streaming). Any `"many"` hop makes the whole path `"many"`.
+   */
+  observePath<
+    T extends ObjectTypeDefinition | InterfaceDefinition,
+  >(
+    options: ObservePath.Options,
+    subFn: Observer<ObservePath.CallbackArgs<T>>,
+  ): Unsubscribable;
+}

--- a/packages/client/src/observable/internal/ObservableClientImpl.test.ts
+++ b/packages/client/src/observable/internal/ObservableClientImpl.test.ts
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { LinkHopDescriptor, ObjectRef } from "@osdk/api";
+import { Employee } from "@osdk/client.test.ontology";
+import { FauxFoundry, ontologies, startNodeApiServer } from "@osdk/shared.test";
+import invariant from "tiny-invariant";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import type { Client } from "../../Client.js";
+import { createClient } from "../../createClient.js";
+import type { Unsubscribable } from "../ObservableClient.js";
+import type { ObserveLinkClosure } from "../ObservableClient/ObserveLinkClosure.js";
+import { ObservableClientImpl } from "./ObservableClientImpl.js";
+import { Store } from "./Store.js";
+
+beforeAll(() => {
+  vi.setConfig({
+    fakeTimers: {
+      toFake: [
+        "setTimeout",
+        "clearTimeout",
+        "Date",
+        "setInterval",
+        "clearInterval",
+      ],
+    },
+  });
+});
+afterAll(() => {
+  vi.resetConfig();
+});
+
+const EMP_A = 100;
+const EMP_B = 101;
+const EMP_C = 102;
+
+function setupOntology(fauxFoundry: FauxFoundry) {
+  ontologies.addEmployeeOntology(fauxFoundry.getDefaultOntology());
+}
+
+// A linear peeps chain: empA -> empB -> empC. `peeps` is FK-backed (each child
+// has a single `lead`), so a node has exactly one parent.
+function setupPeepsChain(fauxFoundry: FauxFoundry) {
+  const dataStore = fauxFoundry.getDefaultDataStore();
+  const empA = dataStore.registerObject(Employee, { employeeId: EMP_A });
+  const empB = dataStore.registerObject(Employee, { employeeId: EMP_B });
+  const empC = dataStore.registerObject(Employee, { employeeId: EMP_C });
+  dataStore.registerLink(empA, "peeps", empB, "lead");
+  dataStore.registerLink(empB, "peeps", empC, "lead");
+}
+
+const peepsHop: LinkHopDescriptor = {
+  sourceTypeApiName: "Employee",
+  linkApiName: "peeps",
+  targetTypeApiName: "Employee",
+  multiplicity: true,
+  sourceIsInterface: false,
+};
+
+function rootRef(employeeId: number): ObjectRef {
+  return { $objectType: "Employee", $primaryKey: employeeId };
+}
+
+function closureObserver() {
+  return {
+    next: vi.fn<(args: ObserveLinkClosure.CallbackArgs<Employee>) => void>(),
+    error: vi.fn(),
+    complete: vi.fn(),
+  };
+}
+
+async function observeClosureUntilLoaded(
+  client: ObservableClientImpl,
+  root: number,
+): Promise<
+  { sub: Unsubscribable; observer: ReturnType<typeof closureObserver> }
+> {
+  const observer = closureObserver();
+  const sub = client.observeLinkClosure<Employee>(
+    {
+      root: rootRef(root),
+      hop: peepsHop,
+      maxDepth: "unbounded",
+      maxNodes: 100,
+    },
+    observer,
+  );
+  await vi.waitFor(
+    () => {
+      expect(observer.next).toHaveBeenLastCalledWith(
+        expect.objectContaining({ status: "loaded", isExpanding: false }),
+      );
+    },
+    { timeout: 5000, interval: 0 },
+  );
+  return { sub, observer };
+}
+
+function discoveredPks(observer: ReturnType<typeof closureObserver>): number[] {
+  const last = observer.next.mock.lastCall?.[0];
+  invariant(last);
+  return last.data.map((d) => d.$primaryKey).sort((a, b) => a - b);
+}
+
+describe("ObservableClientImpl", () => {
+  describe("observeLinkClosure closure gc", () => {
+    let client: Client;
+    let store: Store;
+    let observable: ObservableClientImpl;
+
+    beforeAll(async () => {
+      const testSetup = startNodeApiServer(
+        new FauxFoundry("https://stack.palantir.com/"),
+        createClient,
+      );
+      ({ client } = testSetup);
+      setupOntology(testSetup.fauxFoundry);
+      setupPeepsChain(testSetup.fauxFoundry);
+      return () => {
+        testSetup.apiServer.close();
+      };
+    });
+
+    beforeEach(() => {
+      // Fake timers must be active before the Store is constructed so the
+      // CacheKeys gc interval is faked and can be advanced below.
+      vi.useFakeTimers();
+      store = new Store(client);
+      observable = new ObservableClientImpl(store);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      store = undefined as unknown as Store;
+      observable = undefined as unknown as ObservableClientImpl;
+    });
+
+    it("retains discovered intermediates while observed, releases after last unsubscribe", async () => {
+      const { sub, observer } = await observeClosureUntilLoaded(
+        observable,
+        EMP_A,
+      );
+
+      expect(discoveredPks(observer)).toEqual([EMP_B, EMP_C]);
+
+      const keyB = store.cacheKeys.peek("object", "Employee", EMP_B);
+      const keyC = store.cacheKeys.peek("object", "Employee", EMP_C);
+      invariant(keyB);
+      invariant(keyC);
+      expect(store.getValue(keyB)?.value).toBeDefined();
+      expect(store.getValue(keyC)?.value).toBeDefined();
+
+      sub.unsubscribe();
+      vi.advanceTimersByTime(61_000);
+
+      expect(store.cacheKeys.peek("object", "Employee", EMP_B)).toBeUndefined();
+      expect(store.cacheKeys.peek("object", "Employee", EMP_C)).toBeUndefined();
+    });
+
+    it("keeps a shared node alive while a second closure still observes it", async () => {
+      const a = await observeClosureUntilLoaded(observable, EMP_A);
+      expect(discoveredPks(a.observer)).toEqual([EMP_B, EMP_C]);
+
+      const b = await observeClosureUntilLoaded(observable, EMP_B);
+      expect(discoveredPks(b.observer)).toEqual([EMP_C]);
+
+      // Closure A holds empB + empC; closure B holds empC. Dropping A must not
+      // evict empC because B still observes it.
+      a.sub.unsubscribe();
+      vi.advanceTimersByTime(61_000);
+
+      expect(store.cacheKeys.peek("object", "Employee", EMP_B)).toBeUndefined();
+      const sharedKey = store.cacheKeys.peek("object", "Employee", EMP_C);
+      invariant(sharedKey);
+      expect(store.getValue(sharedKey)?.value).toBeDefined();
+
+      // Once the last observer goes away the shared node is released too.
+      b.sub.unsubscribe();
+      vi.advanceTimersByTime(61_000);
+      expect(store.cacheKeys.peek("object", "Employee", EMP_C)).toBeUndefined();
+    });
+  });
+});

--- a/packages/client/src/observable/internal/ObservableClientImpl.ts
+++ b/packages/client/src/observable/internal/ObservableClientImpl.ts
@@ -20,7 +20,11 @@ import type {
   ActionValidationResponse,
   AggregateOpts,
   CompileTimeMetadata,
+  InterfaceDefinition,
+  LinkHopDescriptor,
+  LinkTraversalDescriptor,
   ObjectOrInterfaceDefinition,
+  ObjectRef,
   ObjectSet,
   ObjectTypeDefinition,
   Osdk,
@@ -30,9 +34,12 @@ import type {
   WhereClause,
   WirePropertyTypes,
 } from "@osdk/api";
+import { hashTraversal, objectRefKey, ObjectRefMap } from "@osdk/api";
 import { Subscription } from "rxjs";
 import type { ActionSignatureFromDef } from "../../actions/applyAction.js";
 import { additionalContext } from "../../Client.js";
+import type { InterfaceHolder } from "../../object/convertWireToOsdkObjects/InterfaceHolder.js";
+import type { ObjectHolder } from "../../object/convertWireToOsdkObjects/ObjectHolder.js";
 import {
   getWireObjectSet,
   isObjectSet,
@@ -67,8 +74,17 @@ import type {
 } from "../ObservableClient/MediaObservableTypes.js";
 import type { MediaPropertyLocation } from "../ObservableClient/MediaTypes.js";
 import type { ObserveLinks } from "../ObservableClient/ObserveLink.js";
+import type { ObserveLinkClosure } from "../ObservableClient/ObserveLinkClosure.js";
+import type { ObservePath } from "../ObservableClient/ObservePath.js";
 import type { AggregationPayloadBase } from "./aggregation/AggregationQuery.js";
 import type { Canonical } from "./Canonical.js";
+import type { ExpandedChild } from "./links/ClosureExpansion.js";
+import type { ClosurePayload } from "./links/ClosureQuery.js";
+import { ClosureQuery } from "./links/ClosureQuery.js";
+import type { PathPayload } from "./links/PathQuery.js";
+import { PathQuery } from "./links/PathQuery.js";
+import { createSharedTraversalRegistry } from "./links/sharedTraversalRegistry.js";
+import type { ObjectCacheKey } from "./object/ObjectCacheKey.js";
 import type { ObserveObjectSetOptions } from "./objectset/ObjectSetQueryOptions.js";
 import type { Rdp } from "./RdpCanonicalizer.js";
 import type { Store } from "./Store.js";
@@ -88,6 +104,16 @@ export class ObservableClientImpl implements ObservableClient {
   #unionCache = new WeakMap<Canonical<string[]>, ReadonlyArray<any>>();
   #intersectCache = new WeakMap<Canonical<string[]>, ReadonlyArray<any>>();
   #subtractCache = new WeakMap<Canonical<string[]>, ReadonlyArray<any>>();
+
+  // In-flight de-dup: identical descriptor + root share one underlying BFS.
+  #linkClosureRegistry = createSharedTraversalRegistry<
+    ObserveLinkClosure.CallbackArgs<
+      ObjectTypeDefinition | InterfaceDefinition
+    >
+  >();
+  #pathRegistry = createSharedTraversalRegistry<
+    ObservePath.CallbackArgs<ObjectTypeDefinition | InterfaceDefinition>
+  >();
 
   constructor(store: Store) {
     this.__experimentalStore = store;
@@ -255,6 +281,178 @@ export class ObservableClientImpl implements ObservableClient {
       );
   };
 
+  public observeLinkClosure<
+    T extends ObjectTypeDefinition | InterfaceDefinition,
+  >(
+    options: ObserveLinkClosure.Options,
+    subFn: Observer<ObserveLinkClosure.CallbackArgs<T>>,
+  ): Unsubscribable {
+    const store = this.__experimentalStore;
+    // cross typed to untyped barrier
+    const observer = subFn as unknown as Observer<
+      ObserveLinkClosure.CallbackArgs<
+        ObjectTypeDefinition | InterfaceDefinition
+      >
+    >;
+
+    const descriptor: LinkTraversalDescriptor = {
+      kind: "recursive",
+      hops: [options.hop],
+      recursive: { maxDepth: options.maxDepth, maxNodes: options.maxNodes },
+    };
+    const key = `${hashTraversal(descriptor)}|${objectRefKey(options.root)}`;
+
+    const subscription = new Subscription();
+    const unsubscribe = this.#linkClosureRegistry.subscribe(
+      key,
+      observer,
+      (emit) => {
+        // Retain every discovered intermediate object in the store's refcount
+        // machinery while this closure is observed, so the shared object cache
+        // keeps them alive. They are released on teardown (last unsubscribe),
+        // letting the store gc evict any nodes no other observer holds.
+        const retained = new Set<ObjectCacheKey>();
+        // Nodes this closure has registered for source-side invalidation, keyed
+        // by objectRefKey so we register each once and can unregister on
+        // teardown. An edge change sourced at any of these routes to the
+        // closure's `expand(ref)` via the store's closureInvalidationRegistry.
+        const registeredNodes = new Map<string, ObjectRef>();
+        let tornDown = false;
+        const query = new ClosureQuery<ObjectHolder | InterfaceHolder>({
+          root: options.root,
+          hop: options.hop,
+          options: { maxDepth: options.maxDepth, maxNodes: options.maxNodes },
+          resolveLink: (concreteType, interfaceLinkApiName) => {
+            // Plain object links already name their concrete link on the hop,
+            // and ontologyMetadata.resolveLink only handles interface links (it
+            // throws for object links), so short-circuit here.
+            if (!options.hop.sourceIsInterface) {
+              return Promise.resolve({
+                concreteLinkApiName: options.hop.linkApiName,
+                targetType: options.hop.targetTypeApiName,
+                multiplicity: options.hop.multiplicity,
+              });
+            }
+            return store.client.ontologyMetadata.resolveLink(
+              concreteType,
+              interfaceLinkApiName,
+            );
+          },
+          fetchLinks: (concreteType, concreteLinkApiName, sources) =>
+            fetchLinksForSources(
+              store,
+              concreteType,
+              concreteLinkApiName,
+              sources,
+            ),
+          isOptimistic: (ref) => refIsOptimistic(store, ref),
+          emit: (payload) => {
+            const args = toClosureCallbackArgs(payload);
+            if (!tornDown) {
+              const keys = store.batch(
+                {},
+                (batch) => store.objects.storeOsdkInstances(args.data, batch),
+              ).retVal;
+              for (const k of keys) {
+                if (!retained.has(k)) {
+                  retained.add(k);
+                  store.cacheKeys.retain(k);
+                }
+              }
+              for (const ref of payload.data) {
+                const nodeKey = objectRefKey(ref);
+                if (!registeredNodes.has(nodeKey)) {
+                  registeredNodes.set(nodeKey, ref);
+                  store.closureInvalidationRegistry.register(ref, query);
+                }
+              }
+            }
+            emit(args);
+          },
+        });
+        void query.run();
+        return () => {
+          tornDown = true;
+          for (const k of retained) {
+            store.cacheKeys.release(k);
+          }
+          retained.clear();
+          for (const ref of registeredNodes.values()) {
+            store.closureInvalidationRegistry.unregister(ref, query);
+          }
+          registeredNodes.clear();
+        };
+      },
+    );
+    subscription.add(unsubscribe);
+
+    return new UnsubscribableWrapper(subscription);
+  }
+
+  public observePath<
+    T extends ObjectTypeDefinition | InterfaceDefinition,
+  >(
+    options: ObservePath.Options,
+    subFn: Observer<ObservePath.CallbackArgs<T>>,
+  ): Unsubscribable {
+    const store = this.__experimentalStore;
+    // cross typed to untyped barrier
+    const observer = subFn as unknown as Observer<
+      ObservePath.CallbackArgs<ObjectTypeDefinition | InterfaceDefinition>
+    >;
+
+    const descriptor: LinkTraversalDescriptor = {
+      kind: "path",
+      hops: options.hops,
+    };
+    const key = `${hashTraversal(descriptor)}|${objectRefKey(options.root)}`;
+
+    const subscription = new Subscription();
+    const unsubscribe = this.#pathRegistry.subscribe(
+      key,
+      observer,
+      (emit) => {
+        const query = new PathQuery<ObjectHolder | InterfaceHolder>({
+          root: options.root,
+          hops: options.hops,
+          resolveLink: (concreteType, interfaceLinkApiName, hop) => {
+            // Plain object links already name their concrete link on the hop,
+            // and ontologyMetadata.resolveLink only handles interface links (it
+            // throws for object links), so short-circuit here.
+            if (!hop.sourceIsInterface) {
+              return Promise.resolve({
+                concreteLinkApiName: hop.linkApiName,
+                targetType: hop.targetTypeApiName,
+                multiplicity: hop.multiplicity,
+              });
+            }
+            return store.client.ontologyMetadata.resolveLink(
+              concreteType,
+              interfaceLinkApiName,
+            );
+          },
+          fetchLinks: (concreteType, concreteLinkApiName, sources, hop) =>
+            fetchLinksForSources(
+              store,
+              concreteType,
+              concreteLinkApiName,
+              sources,
+              hop,
+            ),
+          isOptimistic: (ref) => refIsOptimistic(store, ref),
+          emit: (payload) => {
+            emit(toPathCallbackArgs(payload));
+          },
+        });
+        void query.run();
+        return () => {};
+      },
+    );
+    subscription.add(unsubscribe);
+
+    return new UnsubscribableWrapper(subscription);
+  }
+
   public applyAction: <Q extends ActionDefinition<any>>(
     action: Q,
     args: Parameters<ActionSignatureFromDef<Q>["applyAction"]>[0],
@@ -408,6 +606,8 @@ export class ObservableClientImpl implements ObservableClient {
   }
 }
 
+type LinkedHolder = NonNullable<SpecificLinkPayload["resolvedList"]>[number];
+
 function observeSingleLink(
   store: Store,
   objectsArray: ReadonlyArray<Osdk.Instance<ObjectOrInterfaceDefinition>>,
@@ -418,6 +618,7 @@ function observeSingleLink(
   if (objectsArray.length === 0) {
     observer.next({
       resolvedList: [],
+      linkedObjectsBySource: new ObjectRefMap<ReadonlyArray<LinkedHolder>>(),
       linkedObjectsBySourcePrimaryKey: new Map(),
       isOptimistic: false,
       lastUpdated: 0,
@@ -468,8 +669,19 @@ function observeMultiLinks(
   const totalExpected = objectsArray.length;
   const perObjectData = new Map<
     string,
-    { payload: SpecificLinkPayload; pk: string | number }
+    { payload: SpecificLinkPayload; sourceRef: ObjectRef }
   >();
+  // Every source's ref is excluded from results (self-referential exclusion),
+  // computed up front so exclusion holds even before a source has reported.
+  const sourceRefKeys = new Set<string>();
+  for (const obj of objectsArray) {
+    sourceRefKeys.add(
+      objectRefKey({
+        $objectType: obj.$objectType ?? obj.$apiName,
+        $primaryKey: obj.$primaryKey,
+      }),
+    );
+  }
   let errored = false;
 
   function mergeAndEmit() {
@@ -477,25 +689,33 @@ function observeMultiLinks(
       return;
     }
 
-    const seen = new Map<
-      string,
-      NonNullable<SpecificLinkPayload["resolvedList"]>[number]
-    >();
-    const linkedObjectsBySourcePrimaryKey = new Map<
-      string | number,
-      ReadonlyArray<NonNullable<SpecificLinkPayload["resolvedList"]>[number]>
+    const seen = new Map<string, LinkedHolder>();
+    const linkedObjectsBySource = new ObjectRefMap<
+      ReadonlyArray<LinkedHolder>
     >();
     const fetchMores: Array<() => Promise<void>> = [];
     let latestUpdated = 0;
     let hasMore = false;
     let isOptimistic = false;
 
-    for (const { payload, pk } of perObjectData.values()) {
-      linkedObjectsBySourcePrimaryKey.set(pk, payload.resolvedList ?? []);
+    for (const { payload, sourceRef } of perObjectData.values()) {
+      const group: LinkedHolder[] = [];
 
       for (const obj of payload.resolvedList ?? []) {
-        seen.set(`${obj.$objectType}:${obj.$primaryKey}`, obj);
+        const refKey = objectRefKey({
+          $objectType: obj.$objectType,
+          $primaryKey: obj.$primaryKey,
+        });
+        // dedupe-by-ref with source refs excluded
+        if (sourceRefKeys.has(refKey)) {
+          continue;
+        }
+        group.push(obj);
+        seen.set(refKey, obj);
       }
+
+      linkedObjectsBySource.set(sourceRef, group);
+
       if (payload.lastUpdated > latestUpdated) {
         latestUpdated = payload.lastUpdated;
       }
@@ -508,12 +728,22 @@ function observeMultiLinks(
       }
     }
 
+    // Derived from linkedObjectsBySource; collapses sources that share a pk.
+    const linkedObjectsBySourcePrimaryKey = new Map<
+      string | number,
+      ReadonlyArray<LinkedHolder>
+    >();
+    linkedObjectsBySource.forEach((group, ref) => {
+      linkedObjectsBySourcePrimaryKey.set(ref.$primaryKey, group);
+    });
+
     const payloads = [...perObjectData.values()].map(d => d.payload);
     const loading = perObjectData.size < totalExpected
       || payloads.some(p => p.status === "init" || p.status === "loading");
 
     observer.next({
       resolvedList: Array.from(seen.values()),
+      linkedObjectsBySource,
       linkedObjectsBySourcePrimaryKey,
       isOptimistic,
       lastUpdated: latestUpdated,
@@ -531,8 +761,12 @@ function observeMultiLinks(
   }
 
   for (const obj of objectsArray) {
-    const objKey = `${obj.$objectType ?? obj.$apiName}:${obj.$primaryKey}`;
     const pk = obj.$primaryKey;
+    const sourceRef: ObjectRef = {
+      $objectType: obj.$objectType ?? obj.$apiName,
+      $primaryKey: pk,
+    };
+    const objKey = objectRefKey(sourceRef);
 
     const sourceType: "object" | "interface" = obj.$apiName === obj.$objectType
       ? "object"
@@ -555,7 +789,7 @@ function observeMultiLinks(
             if (errored) {
               return;
             }
-            perObjectData.set(objKey, { payload, pk });
+            perObjectData.set(objKey, { payload, sourceRef });
             mergeAndEmit();
           },
           error: (err: unknown) => {
@@ -574,4 +808,170 @@ function observeMultiLinks(
   }
 
   return new UnsubscribableWrapper(parentSub);
+}
+
+/**
+ * Fetches one BFS level for a set of same-typed sources by issuing a pivot
+ * query per source. Pivoting from a multi-source set loses the source->children
+ * grouping, so we fetch per source and key the result by each source's ref.
+ */
+async function fetchLinksForSources(
+  store: Store,
+  concreteType: string,
+  concreteLinkApiName: string,
+  sources: ReadonlyArray<ObjectRef>,
+  hop?: LinkHopDescriptor,
+): Promise<
+  ObjectRefMap<ReadonlyArray<ExpandedChild<ObjectHolder | InterfaceHolder>>>
+> {
+  const client = store.client;
+  const ontologyProvider = client[additionalContext].ontologyProvider;
+  const objectMetadata = await ontologyProvider.getObjectDefinition(
+    concreteType,
+  );
+  const pkApiName = objectMetadata.primaryKeyApiName;
+
+  const result = new ObjectRefMap<
+    ReadonlyArray<ExpandedChild<ObjectHolder | InterfaceHolder>>
+  >();
+
+  // Per-hop where/orderBy/limit are applied as fetchPage params so the
+  // traversal honors the filters chained onto each hop via `.where(...)` etc.
+  const fetchPageArgs: {
+    $includeRid: true;
+    $pageSize?: number;
+    $orderBy?: Record<string, "asc" | "desc">;
+    $where?: Record<string, unknown>;
+  } = { $includeRid: true };
+  if (hop?.limit != null) {
+    fetchPageArgs.$pageSize = hop.limit;
+  }
+  if (hop?.orderBy != null && hop.orderBy.length > 0) {
+    const orderBy: Record<string, "asc" | "desc"> = {};
+    for (const entry of hop.orderBy) {
+      orderBy[entry.property] = entry.direction;
+    }
+    fetchPageArgs.$orderBy = orderBy;
+  }
+  if (hop?.where != null) {
+    fetchPageArgs.$where = hop.where as Record<string, unknown>;
+  }
+
+  await Promise.all(
+    sources.map(async (source) => {
+      const sourceQuery = client({
+        type: "object",
+        apiName: concreteType,
+      } as ObjectTypeDefinition).where({
+        [pkApiName]: source.$primaryKey,
+      } as WhereClause<any>);
+
+      const response = await sourceQuery
+        .pivotTo(concreteLinkApiName)
+        .fetchPage(fetchPageArgs);
+
+      const children: Array<ExpandedChild<ObjectHolder | InterfaceHolder>> =
+        response.data.map((obj) => ({
+          ref: {
+            $objectType: obj.$objectType,
+            $primaryKey: obj.$primaryKey,
+          },
+          // cross typed to untyped barrier: holders back every Osdk.Instance
+          instance: obj as unknown as ObjectHolder | InterfaceHolder,
+        }));
+
+      result.set(source, children);
+    }),
+  );
+
+  return result;
+}
+
+/**
+ * Reads the store's per-object optimism flag for a traversal node. Mirrors the
+ * `("object", apiName, pk)` key the closure/path emit path already builds via
+ * {@link Store.objects}.storeOsdkInstances; reads it without creating or
+ * retaining the key. Returns false when no subject exists yet (fresh data).
+ */
+function refIsOptimistic(store: Store, ref: ObjectRef): boolean {
+  const key = store.cacheKeys.peek<ObjectCacheKey>(
+    "object",
+    ref.$objectType,
+    ref.$primaryKey,
+  );
+  if (key == null) {
+    return false;
+  }
+  return store.subjects.peek(key)?.getValue().isOptimistic ?? false;
+}
+
+/** Projects a {@link PathPayload} to the public path callback args. */
+function toPathCallbackArgs(
+  payload: PathPayload<ObjectHolder | InterfaceHolder>,
+): ObservePath.CallbackArgs<ObjectTypeDefinition | InterfaceDefinition> {
+  const data: Array<
+    Osdk.Instance<
+      ObjectTypeDefinition | InterfaceDefinition,
+      "$allBaseProperties"
+    >
+  > = [];
+  for (const ref of payload.data) {
+    const instance = payload.instances.get(ref);
+    if (instance != null) {
+      // cross typed to untyped barrier: holders back every Osdk.Instance
+      data.push(
+        instance as unknown as Osdk.Instance<
+          ObjectTypeDefinition | InterfaceDefinition,
+          "$allBaseProperties"
+        >,
+      );
+    }
+  }
+
+  return {
+    data,
+    isOptimistic: payload.isOptimistic,
+    status: payload.status,
+    error: payload.error,
+    lastUpdated: payload.lastUpdated,
+  };
+}
+
+/** Projects a {@link ClosurePayload} to the public closure callback args. */
+function toClosureCallbackArgs(
+  payload: ClosurePayload<ObjectHolder | InterfaceHolder>,
+): ObserveLinkClosure.CallbackArgs<ObjectTypeDefinition | InterfaceDefinition> {
+  const data: Array<
+    Osdk.Instance<
+      ObjectTypeDefinition | InterfaceDefinition,
+      "$allBaseProperties"
+    >
+  > = [];
+  for (const ref of payload.data) {
+    const instance = payload.instances.get(ref);
+    if (instance != null) {
+      // cross typed to untyped barrier: holders back every Osdk.Instance
+      data.push(
+        instance as unknown as Osdk.Instance<
+          ObjectTypeDefinition | InterfaceDefinition,
+          "$allBaseProperties"
+        >,
+      );
+    }
+  }
+
+  return {
+    data,
+    adjacency: payload.adjacency,
+    byDepth: payload.byDepth,
+    frontier: payload.frontier,
+    depthReached: payload.depthReached,
+    isExpanding: payload.isExpanding,
+    truncated: payload.truncated,
+    expand: payload.expand,
+    isOptimistic: payload.isOptimistic,
+    status: payload.status,
+    error: payload.error,
+    lastUpdated: payload.lastUpdated,
+  };
 }

--- a/packages/client/src/observable/internal/Store.test.ts
+++ b/packages/client/src/observable/internal/Store.test.ts
@@ -15,6 +15,7 @@
  */
 
 import type { ObjectSet, Osdk } from "@osdk/api";
+import { ObjectRefMap } from "@osdk/api";
 import {
   editTodo,
   Employee,
@@ -497,6 +498,302 @@ describe(Store, () => {
       });
     });
 
+    it(
+      "invalidateObject only refetches link records sourced from that exact object",
+      async () => {
+        // Two dedicated employees, each pointing at its own office through the
+        // `officeLink` (Employee->Office) relationship. The target type differs
+        // from the source type, so invalidating one source employee can only
+        // touch the sibling via the per-PK source path — never the target-type
+        // walk — which is exactly the source-side precision under test.
+        const dataStore = fauxFoundry.getDefaultDataStore();
+        const empA = 9401;
+        const officeA = "9402";
+        const empB = 9403;
+        const officeB = "9404";
+        for (
+          const [emp, office] of [[empA, officeA], [empB, officeB]] as const
+        ) {
+          dataStore.registerObject(Employee, {
+            $apiName: "Employee",
+            employeeId: emp,
+          });
+          dataStore.registerObject(Office, {
+            $apiName: "Office",
+            officeId: office,
+            name: `Office ${office}`,
+          });
+          dataStore.registerLink(
+            { __apiName: "Employee", __primaryKey: emp },
+            "officeLink",
+            { __apiName: "Office", __primaryKey: office },
+            "occupants",
+          );
+        }
+
+        try {
+          const empAOfficeFn = mockLinkSubCallback();
+          defer(cache.links.observe({
+            linkName: "officeLink",
+            srcType: { type: "object", apiName: "Employee" },
+            sourceUnderlyingObjectType: "Employee",
+            pk: empA,
+            dedupeInterval: 60_000,
+          }, empAOfficeFn));
+
+          await waitForCall(empAOfficeFn);
+          expectSingleLinkCallAndClear(empAOfficeFn, undefined, {
+            status: "loading",
+          });
+          await waitForCall(empAOfficeFn);
+          expectSingleLinkCallAndClear(
+            empAOfficeFn,
+            [expect.objectContaining({ $primaryKey: officeA })],
+            { status: "loaded" },
+          );
+
+          const empBOfficeFn = mockLinkSubCallback();
+          defer(cache.links.observe({
+            linkName: "officeLink",
+            srcType: { type: "object", apiName: "Employee" },
+            sourceUnderlyingObjectType: "Employee",
+            pk: empB,
+            dedupeInterval: 60_000,
+          }, empBOfficeFn));
+
+          await waitForCall(empBOfficeFn);
+          expectSingleLinkCallAndClear(empBOfficeFn, undefined, {
+            status: "loading",
+          });
+          await waitForCall(empBOfficeFn);
+          expectSingleLinkCallAndClear(
+            empBOfficeFn,
+            [expect.objectContaining({ $primaryKey: officeB })],
+            { status: "loaded" },
+          );
+
+          testStage("Invalidating only Employee A via the per-object path");
+
+          const invalidatePromise = cache.invalidateObject(Employee, empA);
+
+          // empA's link record refetches: loading then loaded.
+          await waitForCall(empAOfficeFn);
+          expectSingleLinkCallAndClear(
+            empAOfficeFn,
+            [expect.objectContaining({ $primaryKey: officeA })],
+            { status: "loading" },
+          );
+          await waitForCall(empAOfficeFn);
+          expectSingleLinkCallAndClear(
+            empAOfficeFn,
+            [expect.objectContaining({ $primaryKey: officeA })],
+            { status: "loaded" },
+          );
+
+          await invalidatePromise;
+
+          // empB's link record was sourced from a different object and points
+          // at a different type, so neither the source nor the target path
+          // touches it.
+          expect(empBOfficeFn.next).not.toHaveBeenCalled();
+        } finally {
+          for (
+            const [emp, office] of [[empA, officeA], [empB, officeB]] as const
+          ) {
+            dataStore.unregisterLink(
+              { __apiName: "Employee", __primaryKey: emp },
+              "officeLink",
+              { __apiName: "Office", __primaryKey: office },
+              "occupants",
+            );
+          }
+        }
+      },
+    );
+
+    it(
+      "many-cardinality link is marked optimistic while a member is optimistically edited",
+      async () => {
+        const dataStore = fauxFoundry.getDefaultDataStore();
+        // Dedicated objects keep this order-independent from the shared
+        // emp1/johnDoe peeps link that other tests mutate in place.
+        const manySrc = 9101;
+        const manyPeep = 9102;
+        for (const employeeId of [manySrc, manyPeep]) {
+          dataStore.registerObject(Employee, {
+            $apiName: "Employee",
+            employeeId,
+          });
+        }
+        dataStore.registerLink(
+          { __apiName: "Employee", __primaryKey: manySrc },
+          "peeps",
+          { __apiName: "Employee", __primaryKey: manyPeep },
+          "lead",
+        );
+
+        try {
+          const { payload: peepPayload } = await expectStandardObserveObject({
+            cache,
+            type: Employee,
+            primaryKey: manyPeep,
+          });
+          const peep = peepPayload?.object;
+          invariant(peep);
+
+          const peepsFn = mockLinkSubCallback();
+          defer(cache.links.observe({
+            linkName: "peeps",
+            srcType: { type: "object", apiName: "Employee" },
+            sourceUnderlyingObjectType: "Employee",
+            pk: manySrc,
+            dedupeInterval: 60_000,
+          }, peepsFn));
+
+          await waitForCall(peepsFn);
+          expectSingleLinkCallAndClear(peepsFn, undefined, {
+            status: "loading",
+          });
+          await waitForCall(peepsFn);
+          const loaded = expectSingleLinkCallAndClear(
+            peepsFn,
+            [expect.objectContaining({ $primaryKey: manyPeep })],
+            { status: "loaded" },
+          );
+          expect(loaded?.isOptimistic).toBe(false);
+
+          testStage("Optimistically editing a member of the many-link");
+          const optimisticId = createOptimisticId();
+          updateObject(cache, peep.$clone({ fullName: "Optimistic Name" }), {
+            optimisticId,
+          });
+
+          await waitForCall(peepsFn);
+          const optimistic = expectSingleLinkCallAndClear(
+            peepsFn,
+            [expect.objectContaining({
+              $primaryKey: manyPeep,
+              fullName: "Optimistic Name",
+            })],
+          );
+          expect(optimistic?.isOptimistic).toBe(true);
+
+          testStage("Rolling back the optimistic member edit");
+          cache.layers.remove(optimisticId);
+
+          await waitForCall(peepsFn);
+          const rolledBack = expectSingleLinkCallAndClear(
+            peepsFn,
+            [expect.objectContaining({ $primaryKey: manyPeep })],
+          );
+          expect(rolledBack?.isOptimistic).toBe(false);
+        } finally {
+          dataStore.unregisterLink(
+            { __apiName: "Employee", __primaryKey: manySrc },
+            "peeps",
+            { __apiName: "Employee", __primaryKey: manyPeep },
+            "lead",
+          );
+        }
+      },
+    );
+
+    it(
+      "one-cardinality link swaps its single value when the target is optimistically edited",
+      async () => {
+        const dataStore = fauxFoundry.getDefaultDataStore();
+        const oneSrc = 9201;
+        const oneOffice = "9202";
+        dataStore.registerObject(Employee, {
+          $apiName: "Employee",
+          employeeId: oneSrc,
+        });
+        dataStore.registerObject(Office, {
+          $apiName: "Office",
+          officeId: oneOffice,
+          name: "Original Office",
+        });
+        dataStore.registerLink(
+          { __apiName: "Employee", __primaryKey: oneSrc },
+          "officeLink",
+          { __apiName: "Office", __primaryKey: oneOffice },
+          "occupants",
+        );
+
+        try {
+          const { payload: officePayload } = await expectStandardObserveObject({
+            cache,
+            type: Office,
+            primaryKey: oneOffice,
+          });
+          const office = officePayload?.object;
+          invariant(office);
+
+          const officeLinkFn = mockLinkSubCallback();
+          defer(cache.links.observe({
+            linkName: "officeLink",
+            srcType: { type: "object", apiName: "Employee" },
+            sourceUnderlyingObjectType: "Employee",
+            pk: oneSrc,
+            dedupeInterval: 60_000,
+          }, officeLinkFn));
+
+          await waitForCall(officeLinkFn);
+          expectSingleLinkCallAndClear(officeLinkFn, undefined, {
+            status: "loading",
+          });
+          await waitForCall(officeLinkFn);
+          const loaded = expectSingleLinkCallAndClear(
+            officeLinkFn,
+            [expect.objectContaining({
+              $primaryKey: oneOffice,
+              name: "Original Office",
+            })],
+            { status: "loaded" },
+          );
+          expect(loaded?.resolvedList).toHaveLength(1);
+          expect(loaded?.isOptimistic).toBe(false);
+
+          testStage("Optimistically editing the single linked office");
+          const optimisticId = createOptimisticId();
+          updateObject(cache, office.$clone({ name: "Optimistic Office" }), {
+            optimisticId,
+          });
+
+          await waitForCall(officeLinkFn);
+          const optimistic = expectSingleLinkCallAndClear(
+            officeLinkFn,
+            [expect.objectContaining({
+              $primaryKey: oneOffice,
+              name: "Optimistic Office",
+            })],
+          );
+          expect(optimistic?.resolvedList).toHaveLength(1);
+          expect(optimistic?.isOptimistic).toBe(true);
+
+          testStage("Rolling back the optimistic office edit");
+          cache.layers.remove(optimisticId);
+
+          await waitForCall(officeLinkFn);
+          const rolledBack = expectSingleLinkCallAndClear(
+            officeLinkFn,
+            [expect.objectContaining({
+              $primaryKey: oneOffice,
+              name: "Original Office",
+            })],
+          );
+          expect(rolledBack?.isOptimistic).toBe(false);
+        } finally {
+          dataStore.unregisterLink(
+            { __apiName: "Employee", __primaryKey: oneSrc },
+            "officeLink",
+            { __apiName: "Office", __primaryKey: oneOffice },
+            "occupants",
+          );
+        }
+      },
+    );
+
     describe("multi-object observeLinks", () => {
       function getLastPayload(
         subFn: ReturnType<typeof mockLinkSubCallback>,
@@ -629,6 +926,26 @@ describe(Store, () => {
               expect.objectContaining({ $primaryKey: "101" }),
             ]),
           );
+          expect(
+            lastPayload.linkedObjectsBySource.get({
+              $objectType: "Employee",
+              $primaryKey: 1,
+            }),
+          ).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({ $primaryKey: "101" }),
+            ]),
+          );
+          expect(
+            lastPayload.linkedObjectsBySource.get({
+              $objectType: "Employee",
+              $primaryKey: 3,
+            }),
+          ).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({ $primaryKey: "101" }),
+            ]),
+          );
         } finally {
           dataStore.unregisterLink(
             { __apiName: "Employee", __primaryKey: 3 },
@@ -636,6 +953,207 @@ describe(Store, () => {
             { __apiName: "Office", __primaryKey: "101" },
             "occupants",
           );
+        }
+      });
+
+      it("exposes linkedObjectsBySource as an ObjectRefMap keyed by source ObjectRef", async () => {
+        const observableClient: ObservableClient = new ObservableClientImpl(
+          cache,
+        );
+
+        const { payload: emp1Payload } = await expectStandardObserveObject({
+          cache,
+          type: Employee,
+          primaryKey: 1,
+        });
+        const emp1 = emp1Payload?.object;
+        invariant(emp1);
+
+        const { payload: emp2Payload } = await expectStandardObserveObject({
+          cache,
+          type: Employee,
+          primaryKey: 2,
+        });
+        const emp2 = emp2Payload?.object;
+        invariant(emp2);
+
+        const linkSubFn = mockLinkSubCallback();
+
+        defer(
+          observableClient.observeLinks(
+            [emp1, emp2],
+            "officeLink",
+            { linkName: "officeLink" },
+            // @ts-expect-error crossing typed/untyped barrier for test
+            linkSubFn as unknown as Observer<SpecificLinkPayload>,
+          ),
+        );
+
+        await waitForLoaded(linkSubFn);
+        const lastPayload = getLastPayload(linkSubFn);
+
+        expect(lastPayload.linkedObjectsBySource).toBeInstanceOf(ObjectRefMap);
+        expect(
+          lastPayload.linkedObjectsBySource.get({
+            $objectType: "Employee",
+            $primaryKey: 1,
+          }),
+        ).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ $primaryKey: "101" }),
+          ]),
+        );
+        expect(
+          lastPayload.linkedObjectsBySource.get({
+            $objectType: "Employee",
+            $primaryKey: 2,
+          }),
+        ).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ $primaryKey: "102" }),
+          ]),
+        );
+      });
+
+      it("excludes source refs from every group in multi-source merge", async () => {
+        const dataStore = fauxFoundry.getDefaultDataStore();
+
+        // Use dedicated employees so the mutual peeps cycle cannot pollute the
+        // shared emp1/emp2/emp3 that the rest of the suite depends on.
+        // peeps/lead is a one-to-many (lead is the ONE side): a target belongs
+        // to at most one source's peeps group, keyed by its leadId.
+        const srcA = 9001;
+        const srcB = 9002;
+        const targetForB = 9003;
+        const targetForA = 9004;
+        for (const employeeId of [srcA, srcB, targetForA, targetForB]) {
+          dataStore.registerObject(Employee, {
+            $apiName: "Employee",
+            employeeId,
+          });
+        }
+
+        // srcA <-> srcB link to each other; each also has a non-source peep.
+        dataStore.registerLink(
+          { __apiName: "Employee", __primaryKey: srcA },
+          "peeps",
+          { __apiName: "Employee", __primaryKey: srcB },
+          "lead",
+        );
+        dataStore.registerLink(
+          { __apiName: "Employee", __primaryKey: srcB },
+          "peeps",
+          { __apiName: "Employee", __primaryKey: srcA },
+          "lead",
+        );
+        dataStore.registerLink(
+          { __apiName: "Employee", __primaryKey: srcA },
+          "peeps",
+          { __apiName: "Employee", __primaryKey: targetForA },
+          "lead",
+        );
+        dataStore.registerLink(
+          { __apiName: "Employee", __primaryKey: srcB },
+          "peeps",
+          { __apiName: "Employee", __primaryKey: targetForB },
+          "lead",
+        );
+
+        try {
+          const observableClient: ObservableClient = new ObservableClientImpl(
+            cache,
+          );
+
+          const { payload: srcAPayload } = await expectStandardObserveObject({
+            cache,
+            type: Employee,
+            primaryKey: srcA,
+          });
+          const empA = srcAPayload?.object;
+          invariant(empA);
+
+          const { payload: srcBPayload } = await expectStandardObserveObject({
+            cache,
+            type: Employee,
+            primaryKey: srcB,
+          });
+          const empB = srcBPayload?.object;
+          invariant(empB);
+
+          const linkSubFn = mockLinkSubCallback();
+
+          defer(
+            observableClient.observeLinks(
+              [empA, empB],
+              "peeps",
+              { linkName: "peeps" },
+              // @ts-expect-error crossing typed/untyped barrier for test
+              linkSubFn as unknown as Observer<SpecificLinkPayload>,
+            ),
+          );
+
+          await waitForLoaded(linkSubFn);
+          const lastPayload = getLastPayload(linkSubFn);
+
+          const gA = lastPayload.linkedObjectsBySource.get({
+            $objectType: "Employee",
+            $primaryKey: srcA,
+          }) ?? [];
+          const gB = lastPayload.linkedObjectsBySource.get({
+            $objectType: "Employee",
+            $primaryKey: srcB,
+          }) ?? [];
+
+          const gAPks = gA.map((o) => o.$primaryKey);
+          const gBPks = gB.map((o) => o.$primaryKey);
+
+          // srcA links to srcB and srcB links to srcA, but neither source may
+          // appear in any group since both are sources (self-exclusion).
+          expect(gAPks).not.toContain(srcA);
+          expect(gAPks).not.toContain(srcB);
+          expect(gBPks).not.toContain(srcA);
+          expect(gBPks).not.toContain(srcB);
+
+          // each source still surfaces its own non-source peep.
+          expect(gAPks).toContain(targetForA);
+          expect(gBPks).toContain(targetForB);
+
+          // flat list excludes source refs entirely.
+          const flatPks = (lastPayload.resolvedList ?? []).map((o) =>
+            o.$primaryKey
+          );
+          expect(flatPks).not.toContain(srcA);
+          expect(flatPks).not.toContain(srcB);
+          expect(flatPks).toContain(targetForA);
+          expect(flatPks).toContain(targetForB);
+        } finally {
+          dataStore.unregisterLink(
+            { __apiName: "Employee", __primaryKey: srcA },
+            "peeps",
+            { __apiName: "Employee", __primaryKey: srcB },
+            "lead",
+          );
+          dataStore.unregisterLink(
+            { __apiName: "Employee", __primaryKey: srcB },
+            "peeps",
+            { __apiName: "Employee", __primaryKey: srcA },
+            "lead",
+          );
+          dataStore.unregisterLink(
+            { __apiName: "Employee", __primaryKey: srcA },
+            "peeps",
+            { __apiName: "Employee", __primaryKey: targetForA },
+            "lead",
+          );
+          dataStore.unregisterLink(
+            { __apiName: "Employee", __primaryKey: srcB },
+            "peeps",
+            { __apiName: "Employee", __primaryKey: targetForB },
+            "lead",
+          );
+          for (const employeeId of [srcA, srcB, targetForA, targetForB]) {
+            dataStore.unregisterObjectOrThrow("Employee", employeeId);
+          }
         }
       });
 

--- a/packages/client/src/observable/internal/Store.ts
+++ b/packages/client/src/observable/internal/Store.ts
@@ -52,10 +52,13 @@ import { IntersectCanonicalizer } from "./IntersectCanonicalizer.js";
 import type { KnownCacheKey } from "./KnownCacheKey.js";
 import type { Entry } from "./Layer.js";
 import { Layers } from "./Layers.js";
+import { ClosureInvalidationRegistry } from "./links/ClosureInvalidationRegistry.js";
 import { LinksHelper } from "./links/LinksHelper.js";
 import {
   SOURCE_API_NAME_IDX as LINK_API_NAME_IDX,
 } from "./links/SpecificLinkCacheKey.js";
+import { SpecificLinkCacheKeyRegistry } from "./links/SpecificLinkCacheKeyRegistry.js";
+import { SpecificLinkQuery } from "./links/SpecificLinkQuery.js";
 import {
   API_NAME_IDX as LIST_API_NAME_IDX,
   RDP_IDX as LIST_RDP_IDX,
@@ -140,6 +143,12 @@ export class Store {
 
   readonly objectCacheKeyRegistry: ObjectCacheKeyRegistry =
     new ObjectCacheKeyRegistry();
+
+  readonly specificLinkCacheKeyRegistry: SpecificLinkCacheKeyRegistry =
+    new SpecificLinkCacheKeyRegistry();
+
+  readonly closureInvalidationRegistry: ClosureInvalidationRegistry =
+    new ClosureInvalidationRegistry();
 
   readonly layers: Layers = new Layers({
     logger: this.logger,
@@ -234,6 +243,8 @@ export class Store {
 
     if (key.type === "object") {
       this.objectCacheKeyRegistry.unregister(key);
+    } else if (key.type === "specificLink") {
+      this.specificLinkCacheKeyRegistry.unregister(key);
     }
   };
 
@@ -311,8 +322,27 @@ export class Store {
     }
 
     // Per-PK invalidation doesn't propagate to specificLink queries (they're
-    // keyed on srcType+srcPk+linkName, not the linked object's pk).
-    promises.push(this.invalidateLinkQueriesForType(apiName));
+    // keyed on srcType+srcPk+linkName, not the linked object's pk). Use the
+    // reverse index to refetch only the link records sourced from this exact
+    // object, instead of every link query for the type.
+    promises.push(this.invalidateLinkRecordsForSource(apiName, pk));
+
+    // The reverse index only covers links *sourced* from the edited object.
+    // Link queries that *target* this type aren't keyed on it, so editing a
+    // linked object would otherwise leave the relationships pointing at it
+    // stale. Refetch those (type-level — there is no target-side reverse index
+    // in v1) so a target-object edit still refreshes its inbound links.
+    promises.push(this.invalidateLinkRecordsForTargetType(apiName));
+
+    // A live link closure holds an adjacency entry for every node it expanded.
+    // An edge change sourced at one of those nodes must re-read just that node's
+    // children via `expand(ref)` rather than rebuild the closure from its root.
+    promises.push(
+      this.closureInvalidationRegistry.invalidateSource({
+        $objectType: apiName,
+        $primaryKey: pk,
+      }),
+    );
 
     // Function queries with explicit `dependsOnObjects` need to be told the
     // edited PK directly — they aren't object-cache variants and so aren't
@@ -323,19 +353,47 @@ export class Store {
   }
 
   /**
-   * Force every cached `specificLink` query to re-evaluate against the given
-   * apiName. Link queries are keyed on `(srcType, srcPk, linkName, ...)` rather
-   * than the linked object's pk, so per-object propagation never marks them
-   * as modified.
-   *
-   * TODO: make SpecificLinkQuery self-invalidate from per-type changes so
-   * callers don't need this manual kick.
+   * Invalidate and refetch only the `specificLink` records whose source is the
+   * given object. Uses {@link SpecificLinkCacheKeyRegistry} so we touch exactly
+   * the link queries reading outgoing links from `(apiName, pk)` rather than
+   * every link query for the type.
    */
-  public invalidateLinkQueriesForType(apiName: string): Promise<void> {
+  public invalidateLinkRecordsForSource(
+    apiName: string,
+    pk: string | number,
+  ): Promise<void> {
+    const links = this.specificLinkCacheKeyRegistry.getLinksForSource({
+      $objectType: apiName,
+      $primaryKey: pk,
+    });
+
+    const promises: Array<Promise<void>> = [];
+    for (const cacheKey of links) {
+      const query = this.queries.peek(cacheKey);
+      if (!query) {
+        continue;
+      }
+      promises.push(query.revalidate(/* force */ true));
+    }
+    return Promise.allSettled(promises).then(() => void 0);
+  }
+
+  /**
+   * Refetch the live `specificLink` queries whose *target* type is `apiName`.
+   * Link queries are keyed on `(srcType, srcPk, linkName, ...)` rather than the
+   * linked object's type, so per-object propagation never marks a query that
+   * points *at* the edited type as modified. Walk the live link queries and let
+   * each decide (via {@link SpecificLinkQuery.invalidateTargetType}) whether its
+   * target matches, directly or through an interface.
+   *
+   * TODO: a target-side reverse index would make this per-PK precise like
+   * {@link invalidateLinkRecordsForSource}; v1 stays type-level.
+   */
+  public invalidateLinkRecordsForTargetType(apiName: string): Promise<void> {
     if (process.env.NODE_ENV !== "production") {
-      this.logger?.child({ methodName: "invalidateLinkQueriesForType" }).debug(
-        apiName,
-      );
+      this.logger?.child({
+        methodName: "invalidateLinkRecordsForTargetType",
+      }).debug(apiName);
     }
 
     const promises: Array<Promise<void>> = [];
@@ -344,10 +402,9 @@ export class Store {
         continue;
       }
       const query = this.queries.peek(cacheKey);
-      if (!query) {
-        continue;
+      if (query instanceof SpecificLinkQuery) {
+        promises.push(query.invalidateTargetType(apiName, undefined));
       }
-      promises.push(query.invalidateObjectType(apiName, undefined));
     }
     return Promise.allSettled(promises).then(() => void 0);
   }

--- a/packages/client/src/observable/internal/actions/ActionApplication.ts
+++ b/packages/client/src/observable/internal/actions/ActionApplication.ts
@@ -172,6 +172,14 @@ export class ActionApplication {
       if (isEditsBranch && cacheKey.type === "object") {
         continue;
       }
+      // On the edits branch we know the precise edited PKs, so the per-PK path
+      // (Store.invalidateObject) already refreshes both the link records
+      // sourced from those objects (via the reverse index) and the link records
+      // that target their type. Walking every specificLink query here would
+      // re-introduce the blunt per-type over-invalidation on the source side.
+      if (isEditsBranch && cacheKey.type === "specificLink") {
+        continue;
+      }
       const query = this.store.queries.peek(cacheKey);
       if (!query) {
         continue;

--- a/packages/client/src/observable/internal/base-list/createCollectionConnectable.ts
+++ b/packages/client/src/observable/internal/base-list/createCollectionConnectable.ts
@@ -33,6 +33,12 @@ import type { SubjectPayload } from "../SubjectPayload.js";
 import type { Subjects } from "../Subjects.js";
 import type { CollectionConnectableParams } from "./BaseCollectionQuery.js";
 
+/** A resolved collection member: its current value and its optimism. */
+interface ResolvedMember {
+  value: unknown;
+  isOptimistic: boolean;
+}
+
 /**
  * Creates a connectable observable for a collection of objects
  *
@@ -52,40 +58,53 @@ export function createCollectionConnectable<
   return connectable<P>(
     subject.pipe(
       switchMap(listEntry => {
-        const resolvedData = listEntry?.value?.data == null
-          ? of(undefined)
-          : listEntry.value.data.length === 0
-          ? of([])
-          : combineLatest(
-            listEntry.value.data.map((cacheKey: ObjectCacheKey) =>
-              subjects.get(cacheKey).pipe(
-                map(objectEntry => objectEntry?.value!),
-                distinctUntilChanged(),
-              )
-            ),
-          );
+        // Resolve each member to both its current value and whether that value
+        // is itself optimistic. A collection has no write primitive in v1, so a
+        // link/list becomes optimistic when one of its members is optimistically
+        // edited (e.g. an action's optimistic object edit) even though the
+        // membership entry stays on the truth layer.
+        const members: Observable<ResolvedMember[] | undefined> =
+          listEntry?.value?.data == null
+            ? of(undefined)
+            : listEntry.value.data.length === 0
+            ? of([] as ResolvedMember[])
+            : combineLatest<ResolvedMember[]>(
+              listEntry.value.data.map((cacheKey: ObjectCacheKey) =>
+                subjects.get(cacheKey).pipe(
+                  map((objectEntry): ResolvedMember => ({
+                    value: objectEntry?.value,
+                    isOptimistic: objectEntry?.isOptimistic ?? false,
+                  })),
+                  distinctUntilChanged(
+                    (a, b) =>
+                      a.value === b.value && a.isOptimistic === b.isOptimistic,
+                  ),
+                )
+              ),
+            );
 
         return scheduled(
           combineLatest({
-            resolvedData,
-            isOptimistic: of(listEntry.isOptimistic),
+            members,
+            listOptimistic: of(listEntry.isOptimistic),
             status: of(listEntry.status),
             lastUpdated: of(listEntry.lastUpdated),
             totalCount: of(listEntry?.value?.totalCount),
           }).pipe(
-            map(params =>
-              createPayload({
-                resolvedData: params.resolvedData === undefined
+            map(params => {
+              const resolvedMembers = params.members;
+              return createPayload({
+                resolvedData: resolvedMembers === undefined
                   ? undefined
-                  : Array.isArray(params.resolvedData)
-                  ? params.resolvedData
-                  : [],
-                isOptimistic: params.isOptimistic,
+                  : resolvedMembers.map(member => member.value),
+                isOptimistic: params.listOptimistic
+                  || (resolvedMembers?.some(member => member.isOptimistic)
+                    ?? false),
                 status: params.status,
                 lastUpdated: params.lastUpdated,
                 totalCount: params.totalCount,
-              })
-            ),
+              });
+            }),
           ),
           asapScheduler,
         );

--- a/packages/client/src/observable/internal/links/ClosureExpansion.test.ts
+++ b/packages/client/src/observable/internal/links/ClosureExpansion.test.ts
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { LinkHopDescriptor, ObjectRef } from "@osdk/api";
+import { objectRefKey, ObjectRefMap } from "@osdk/api";
+import { describe, expect, it, vi } from "vitest";
+import type { ExpandedChild, ExpansionContext } from "./ClosureExpansion.js";
+import { ClientDrivenBfsExpansion } from "./ClosureExpansion.js";
+
+interface TestInstance {
+  $objectType: string;
+  $primaryKey: string | number;
+  name: string;
+}
+
+function ref(type: string, pk: string | number): ObjectRef {
+  return { $objectType: type, $primaryKey: pk };
+}
+
+function child(type: string, pk: string | number): ExpandedChild<TestInstance> {
+  return {
+    ref: ref(type, pk),
+    instance: { $objectType: type, $primaryKey: pk, name: `${type}-${pk}` },
+  };
+}
+
+const hop: LinkHopDescriptor = {
+  sourceTypeApiName: "Node",
+  linkApiName: "children",
+  targetTypeApiName: "Node",
+  multiplicity: true,
+  sourceIsInterface: false,
+};
+
+describe("ClientDrivenBfsExpansion", () => {
+  it("expands one level, grouping children by parent", async () => {
+    const a = ref("Node", "a");
+    const b = ref("Node", "b");
+
+    const resolveLink = vi.fn().mockResolvedValue({
+      concreteLinkApiName: "children",
+      targetType: "Node",
+      multiplicity: true,
+    });
+
+    const childrenOf = new Map<string, Array<ExpandedChild<TestInstance>>>([
+      [objectRefKey(a), [child("Node", "a1"), child("Node", "a2")]],
+      [objectRefKey(b), [child("Node", "b1")]],
+    ]);
+
+    const fetchLinks = vi.fn().mockImplementation(
+      (
+        _concreteType: string,
+        _concreteLinkApiName: string,
+        sources: ReadonlyArray<ObjectRef>,
+      ) => {
+        const result = new ObjectRefMap<
+          ReadonlyArray<ExpandedChild<TestInstance>>
+        >();
+        for (const source of sources) {
+          result.set(source, childrenOf.get(objectRefKey(source)) ?? []);
+        }
+        return Promise.resolve(result);
+      },
+    );
+
+    const recordError = vi.fn();
+    const ctx: ExpansionContext<TestInstance> = {
+      resolveLink,
+      fetchLinks,
+      recordError,
+    };
+
+    const expansion = new ClientDrivenBfsExpansion<TestInstance>();
+    const result = await expansion.expandLevel([a, b], hop, ctx);
+
+    expect(result.get(a)?.map((c) => c.ref.$primaryKey)).toEqual(["a1", "a2"]);
+    expect(result.get(b)?.map((c) => c.ref.$primaryKey)).toEqual(["b1"]);
+    expect(recordError).not.toHaveBeenCalled();
+    // single concrete type => one batched fetch
+    expect(fetchLinks).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips and records concrete types that cannot resolve the link", async () => {
+    const dog = ref("Dog", "d1");
+    const rock = ref("Rock", "r1");
+
+    const resolveLink = vi.fn().mockImplementation(
+      (concreteType: string) => {
+        if (concreteType === "Rock") {
+          return Promise.reject(
+            new Error("Rock does not implement interface link children"),
+          );
+        }
+        return Promise.resolve({
+          concreteLinkApiName: "children",
+          targetType: "Dog",
+          multiplicity: true,
+        });
+      },
+    );
+
+    const fetchLinks = vi.fn().mockImplementation(
+      (
+        _concreteType: string,
+        _concreteLinkApiName: string,
+        sources: ReadonlyArray<ObjectRef>,
+      ) => {
+        const out = new ObjectRefMap<
+          ReadonlyArray<ExpandedChild<TestInstance>>
+        >();
+        for (const source of sources) {
+          out.set(source, [child("Dog", "pup")]);
+        }
+        return Promise.resolve(out);
+      },
+    );
+
+    const recordError = vi.fn();
+    const ctx: ExpansionContext<TestInstance> = {
+      resolveLink,
+      fetchLinks,
+      recordError,
+    };
+
+    const expansion = new ClientDrivenBfsExpansion<TestInstance>();
+    const result = await expansion.expandLevel([dog, rock], hop, ctx);
+
+    expect(result.get(dog)?.map((c) => c.ref.$primaryKey)).toEqual(["pup"]);
+    expect(result.has(rock)).toBe(false);
+    expect(recordError).toHaveBeenCalledTimes(1);
+    // only the resolvable concrete type triggers a fetch
+    expect(fetchLinks).toHaveBeenCalledTimes(1);
+  });
+
+  it("fetches by the resolved concrete link name, never the interface link name", async () => {
+    const team = ref("Team", "t1");
+
+    // An interface-typed hop: the link is declared on an interface, and the
+    // concrete type resolves it to a different concrete link apiName.
+    const interfaceHop: LinkHopDescriptor = {
+      sourceTypeApiName: "HasMembers",
+      linkApiName: "members",
+      targetTypeApiName: "Person",
+      multiplicity: true,
+      sourceIsInterface: true,
+    };
+
+    const resolveLink = vi.fn().mockResolvedValue({
+      concreteLinkApiName: "teamMembers",
+      targetType: "Person",
+      multiplicity: true,
+    });
+
+    const fetchLinks = vi.fn().mockImplementation(
+      (
+        _concreteType: string,
+        _concreteLinkApiName: string,
+        sources: ReadonlyArray<ObjectRef>,
+      ) => {
+        const out = new ObjectRefMap<
+          ReadonlyArray<ExpandedChild<TestInstance>>
+        >();
+        for (const source of sources) {
+          out.set(source, [child("Person", "p1")]);
+        }
+        return Promise.resolve(out);
+      },
+    );
+
+    const recordError = vi.fn();
+    const ctx: ExpansionContext<TestInstance> = {
+      resolveLink,
+      fetchLinks,
+      recordError,
+    };
+
+    const expansion = new ClientDrivenBfsExpansion<TestInstance>();
+    const result = await expansion.expandLevel([team], interfaceHop, ctx);
+
+    // resolveLink is asked about the concrete type using the interface link name
+    expect(resolveLink).toHaveBeenCalledWith("Team", "members");
+
+    // the fetch must use the resolved concrete link name
+    expect(fetchLinks).toHaveBeenCalledTimes(1);
+    expect(fetchLinks).toHaveBeenCalledWith(
+      "Team",
+      "teamMembers",
+      [team],
+    );
+
+    // the interface link name must NEVER reach the concrete fetch
+    for (const call of fetchLinks.mock.calls) {
+      expect(call[1]).not.toBe("members");
+    }
+
+    expect(result.get(team)?.map((c) => c.ref.$primaryKey)).toEqual(["p1"]);
+    expect(recordError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/observable/internal/links/ClosureExpansion.ts
+++ b/packages/client/src/observable/internal/links/ClosureExpansion.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { LinkHopDescriptor, ObjectRef } from "@osdk/api";
+import { ObjectRefMap } from "@osdk/api";
+import type { InterfaceHolder } from "../../../object/convertWireToOsdkObjects/InterfaceHolder.js";
+import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
+import type { ResolvedLink } from "../../../ontology/OntologyMetadataClient.js";
+
+/** One resolved child: its canonical ref plus the resolved instance. */
+export interface ExpandedChild<I = ObjectHolder | InterfaceHolder> {
+  readonly ref: ObjectRef;
+  readonly instance: I;
+}
+
+/**
+ * The capabilities a {@link ClosureExpansion} needs from the surrounding
+ * client. Keeping these behind callbacks (rather than reaching into the store
+ * directly) makes the expansion strategy unit-testable and lets a future
+ * server-side transitive-closure implementation swap in without touching the
+ * BFS driver.
+ */
+export interface ExpansionContext<I = ObjectHolder | InterfaceHolder> {
+  /**
+   * Resolve an interface link on a concrete type to its concrete link. May
+   * reject with {@link InterfaceLinkNotResolvableError} for concrete types that
+   * do not implement the link.
+   */
+  resolveLink(
+    concreteType: string,
+    interfaceLinkApiName: string,
+  ): Promise<ResolvedLink>;
+  /**
+   * Issue ONE batched link fetch for a set of sources of the same concrete
+   * type, returning children grouped by their source ref.
+   */
+  fetchLinks(
+    concreteType: string,
+    concreteLinkApiName: string,
+    sources: ReadonlyArray<ObjectRef>,
+    signal?: AbortSignal,
+  ): Promise<ObjectRefMap<ReadonlyArray<ExpandedChild<I>>>>;
+  /** Record a non-fatal expansion error (e.g. a concrete type that cannot resolve the link). */
+  recordError(error: Error): void;
+}
+
+/**
+ * Strategy seam for expanding one BFS frontier level into the next. v1 is a
+ * client-driven batched BFS ({@link ClientDrivenBfsExpansion}); a server-side
+ * transitive-closure expansion can implement the same interface later.
+ */
+export interface ClosureExpansion<I = ObjectHolder | InterfaceHolder> {
+  expandLevel(
+    frontier: ReadonlyArray<ObjectRef>,
+    hop: LinkHopDescriptor,
+    ctx: ExpansionContext<I>,
+  ): Promise<ObjectRefMap<ReadonlyArray<ExpandedChild<I>>>>;
+}
+
+/**
+ * v1 client-driven BFS expansion: partition the frontier by concrete
+ * `$objectType`, resolve the (possibly interface) link per concrete type, and
+ * issue one batched fetch per concrete type. Concrete types that cannot resolve
+ * the link are skipped and recorded via {@link ExpansionContext.recordError}.
+ */
+export class ClientDrivenBfsExpansion<I = ObjectHolder | InterfaceHolder>
+  implements ClosureExpansion<I>
+{
+  async expandLevel(
+    frontier: ReadonlyArray<ObjectRef>,
+    hop: LinkHopDescriptor,
+    ctx: ExpansionContext<I>,
+  ): Promise<ObjectRefMap<ReadonlyArray<ExpandedChild<I>>>> {
+    const byType = new Map<string, ObjectRef[]>();
+    for (const ref of frontier) {
+      const group = byType.get(ref.$objectType);
+      if (group == null) {
+        byType.set(ref.$objectType, [ref]);
+      } else {
+        group.push(ref);
+      }
+    }
+
+    const result = new ObjectRefMap<ReadonlyArray<ExpandedChild<I>>>();
+
+    await Promise.all(
+      [...byType.entries()].map(async ([concreteType, sources]) => {
+        let resolved: ResolvedLink;
+        try {
+          resolved = await ctx.resolveLink(concreteType, hop.linkApiName);
+        } catch (e) {
+          ctx.recordError(e instanceof Error ? e : new Error(String(e)));
+          return;
+        }
+
+        const childrenBySource = await ctx.fetchLinks(
+          concreteType,
+          resolved.concreteLinkApiName,
+          sources,
+        );
+
+        for (const source of sources) {
+          result.set(source, childrenBySource.get(source) ?? []);
+        }
+      }),
+    );
+
+    return result;
+  }
+}

--- a/packages/client/src/observable/internal/links/ClosureInvalidationRegistry.test.ts
+++ b/packages/client/src/observable/internal/links/ClosureInvalidationRegistry.test.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { LinkHopDescriptor, ObjectRef } from "@osdk/api";
+import { ObjectRefMap } from "@osdk/api";
+import { describe, expect, it, vi } from "vitest";
+import type { ExpandedChild } from "./ClosureExpansion.js";
+import { ClosureInvalidationRegistry } from "./ClosureInvalidationRegistry.js";
+import { ClosureQuery } from "./ClosureQuery.js";
+
+interface TestInstance {
+  $objectType: string;
+  $primaryKey: string | number;
+  name: string;
+}
+
+function ref(pk: string): ObjectRef {
+  return { $objectType: "Node", $primaryKey: pk };
+}
+
+function child(pk: string): ExpandedChild<TestInstance> {
+  return {
+    ref: ref(pk),
+    instance: { $objectType: "Node", $primaryKey: pk, name: pk },
+  };
+}
+
+const hop: LinkHopDescriptor = {
+  sourceTypeApiName: "Node",
+  linkApiName: "children",
+  targetTypeApiName: "Node",
+  multiplicity: true,
+  sourceIsInterface: false,
+};
+
+function makeFetch(tree: Record<string, string[]>) {
+  const resolveLink = vi.fn().mockResolvedValue({
+    concreteLinkApiName: "children",
+    targetType: "Node",
+    multiplicity: true,
+  });
+
+  const fetchLinks = vi.fn().mockImplementation(
+    (
+      _concreteType: string,
+      _concreteLinkApiName: string,
+      sources: ReadonlyArray<ObjectRef>,
+    ) => {
+      const out = new ObjectRefMap<
+        ReadonlyArray<ExpandedChild<TestInstance>>
+      >();
+      for (const source of sources) {
+        const pks = tree[String(source.$primaryKey)] ?? [];
+        out.set(source, pks.map(child));
+      }
+      return Promise.resolve(out);
+    },
+  );
+
+  return { resolveLink, fetchLinks };
+}
+
+function pks(refs: ReadonlyArray<ObjectRef>): string[] {
+  return refs.map((r) => String(r.$primaryKey));
+}
+
+describe("ClosureInvalidationRegistry", () => {
+  it("re-expands only the affected parent on a deep edge change", async () => {
+    // root -> a -> b -> c : a depth-3 chain.
+    const fetch = makeFetch({ root: ["a"], a: ["b"], b: ["c"], c: [] });
+    const query = new ClosureQuery<TestInstance>({
+      root: ref("root"),
+      hop,
+      options: { maxDepth: 3, maxNodes: 1000 },
+      ...fetch,
+      isOptimistic: () => false,
+      emit: () => {},
+    });
+
+    await query.run();
+
+    const registry = new ClosureInvalidationRegistry();
+    for (const node of ["root", "a", "b", "c"]) {
+      registry.register(ref(node), query);
+    }
+
+    const expandSpy = vi.spyOn(query, "expand");
+    fetch.fetchLinks.mockClear();
+
+    // A deep edge sourced at "b" changed.
+    await registry.invalidateSource(ref("b"));
+
+    // Only "b" re-expanded; the closure was not rebuilt from the root.
+    expect(expandSpy).toHaveBeenCalledTimes(1);
+    expect(expandSpy).toHaveBeenCalledWith(ref("b"));
+    expect(fetch.fetchLinks).toHaveBeenCalledTimes(1);
+    const sources = fetch.fetchLinks.mock.calls[0][2] as ReadonlyArray<
+      ObjectRef
+    >;
+    expect(pks(sources)).toEqual(["b"]);
+  });
+
+  it("re-expands every live closure containing the edited source", async () => {
+    const fetchA = makeFetch({ root: ["x"], x: [] });
+    const fetchB = makeFetch({ other: ["x"], x: [] });
+    const queryA = new ClosureQuery<TestInstance>({
+      root: ref("root"),
+      hop,
+      options: { maxDepth: 2, maxNodes: 1000 },
+      ...fetchA,
+      isOptimistic: () => false,
+      emit: () => {},
+    });
+    const queryB = new ClosureQuery<TestInstance>({
+      root: ref("other"),
+      hop,
+      options: { maxDepth: 2, maxNodes: 1000 },
+      ...fetchB,
+      isOptimistic: () => false,
+      emit: () => {},
+    });
+    await queryA.run();
+    await queryB.run();
+
+    const registry = new ClosureInvalidationRegistry();
+    registry.register(ref("x"), queryA);
+    registry.register(ref("x"), queryB);
+
+    const spyA = vi.spyOn(queryA, "expand");
+    const spyB = vi.spyOn(queryB, "expand");
+
+    await registry.invalidateSource(ref("x"));
+
+    expect(spyA).toHaveBeenCalledExactlyOnceWith(ref("x"));
+    expect(spyB).toHaveBeenCalledExactlyOnceWith(ref("x"));
+  });
+
+  it("does nothing for a source no live closure contains", async () => {
+    const registry = new ClosureInvalidationRegistry();
+    await expect(registry.invalidateSource(ref("nope"))).resolves
+      .toBeUndefined();
+  });
+
+  it("stops routing to a participant after it unregisters", async () => {
+    const fetch = makeFetch({ root: ["a"], a: [] });
+    const query = new ClosureQuery<TestInstance>({
+      root: ref("root"),
+      hop,
+      options: { maxDepth: 2, maxNodes: 1000 },
+      ...fetch,
+      isOptimistic: () => false,
+      emit: () => {},
+    });
+    await query.run();
+
+    const registry = new ClosureInvalidationRegistry();
+    registry.register(ref("a"), query);
+    registry.unregister(ref("a"), query);
+
+    const expandSpy = vi.spyOn(query, "expand");
+    await registry.invalidateSource(ref("a"));
+
+    expect(expandSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/observable/internal/links/ClosureInvalidationRegistry.ts
+++ b/packages/client/src/observable/internal/links/ClosureInvalidationRegistry.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectRef } from "@osdk/api";
+import { ObjectRefMap } from "@osdk/api";
+
+/**
+ * A live closure that can re-expand a single node in response to an edge change
+ * sourced at that node. Satisfied structurally by {@link ClosureQuery}.
+ */
+export interface ClosureParticipant {
+  expand(ref: ObjectRef): void | Promise<void>;
+}
+
+/**
+ * Reverse index from a source object to the live link closures that contain it
+ * as an expanded node.
+ *
+ * A closure built by client-driven BFS holds an adjacency entry for every node
+ * it has expanded. When an edge sourced at one of those nodes changes, the
+ * closure must re-read just that node's children rather than rebuild from the
+ * root. This index lets {@link Store} route a per-object invalidation to the
+ * `expand(parentRef)` of every closure that participates in it.
+ *
+ * Mirrors {@link SpecificLinkCacheKeyRegistry}: a closure registers each node it
+ * discovers and unregisters them when the traversal is torn down.
+ */
+export class ClosureInvalidationRegistry {
+  /** Source object -> the set of live closures that expanded it. */
+  readonly #sourceToClosures = new ObjectRefMap<Set<ClosureParticipant>>();
+
+  /**
+   * Register a closure as a participant for a source object it has expanded.
+   */
+  register(sourceRef: ObjectRef, participant: ClosureParticipant): void {
+    let closures = this.#sourceToClosures.get(sourceRef);
+    if (!closures) {
+      closures = new Set();
+      this.#sourceToClosures.set(sourceRef, closures);
+    }
+    closures.add(participant);
+  }
+
+  /**
+   * Stop routing invalidations for a source object to a closure that no longer
+   * participates in it (e.g. the traversal was torn down).
+   */
+  unregister(sourceRef: ObjectRef, participant: ClosureParticipant): void {
+    const closures = this.#sourceToClosures.get(sourceRef);
+    if (!closures) {
+      return;
+    }
+    closures.delete(participant);
+    if (closures.size === 0) {
+      this.#sourceToClosures.delete(sourceRef);
+    }
+  }
+
+  /**
+   * Re-expand just the affected node in every live closure that contains the
+   * edited source. No-op when no live closure participates in it.
+   */
+  async invalidateSource(sourceRef: ObjectRef): Promise<void> {
+    const closures = this.#sourceToClosures.get(sourceRef);
+    if (!closures || closures.size === 0) {
+      return;
+    }
+    const promises: Array<void | Promise<void>> = [];
+    for (const participant of closures) {
+      promises.push(participant.expand(sourceRef));
+    }
+    await Promise.all(promises);
+  }
+}

--- a/packages/client/src/observable/internal/links/ClosureQuery.test.ts
+++ b/packages/client/src/observable/internal/links/ClosureQuery.test.ts
@@ -1,0 +1,358 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { LinkHopDescriptor, ObjectRef } from "@osdk/api";
+import { ObjectRefMap } from "@osdk/api";
+import { describe, expect, it, vi } from "vitest";
+import type { ExpandedChild } from "./ClosureExpansion.js";
+import type { ClosurePayload } from "./ClosureQuery.js";
+import { ClosureQuery } from "./ClosureQuery.js";
+
+interface TestInstance {
+  $objectType: string;
+  $primaryKey: string | number;
+  name: string;
+}
+
+function ref(pk: string): ObjectRef {
+  return { $objectType: "Node", $primaryKey: pk };
+}
+
+function child(pk: string): ExpandedChild<TestInstance> {
+  return {
+    ref: ref(pk),
+    instance: { $objectType: "Node", $primaryKey: pk, name: pk },
+  };
+}
+
+const hop: LinkHopDescriptor = {
+  sourceTypeApiName: "Node",
+  linkApiName: "children",
+  targetTypeApiName: "Node",
+  multiplicity: true,
+  sourceIsInterface: false,
+};
+
+/** Build resolveLink + fetchLinks stubs over a fixed parent->children tree. */
+function makeFetch(tree: Record<string, string[]>) {
+  const resolveLink = vi.fn().mockResolvedValue({
+    concreteLinkApiName: "children",
+    targetType: "Node",
+    multiplicity: true,
+  });
+
+  const fetchLinks = vi.fn().mockImplementation(
+    (
+      _concreteType: string,
+      _concreteLinkApiName: string,
+      sources: ReadonlyArray<ObjectRef>,
+    ) => {
+      const out = new ObjectRefMap<
+        ReadonlyArray<ExpandedChild<TestInstance>>
+      >();
+      for (const source of sources) {
+        const pks = tree[String(source.$primaryKey)] ?? [];
+        out.set(source, pks.map(child));
+      }
+      return Promise.resolve(out);
+    },
+  );
+
+  return { resolveLink, fetchLinks };
+}
+
+function pks(refs: ReadonlyArray<ObjectRef>): string[] {
+  return refs.map((r) => String(r.$primaryKey));
+}
+
+describe("ClosureQuery", () => {
+  it("runs a BFS to a fixed depth, deduping and excluding the root", async () => {
+    const tree: Record<string, string[]> = {
+      root: ["a", "b"],
+      a: ["a1", "a2"],
+      b: ["b1"],
+      a1: ["a1x"],
+    };
+    const fetch = makeFetch(tree);
+    let last: ClosurePayload<TestInstance> | undefined;
+
+    const query = new ClosureQuery<TestInstance>({
+      root: ref("root"),
+      hop,
+      options: { maxDepth: 2, maxNodes: 1000 },
+      ...fetch,
+      isOptimistic: () => false,
+      emit: (payload) => {
+        last = payload;
+      },
+    });
+
+    await query.run();
+
+    expect(last).toBeDefined();
+    const payload = last as ClosurePayload<TestInstance>;
+    expect(pks(payload.data).sort()).toEqual(["a", "a1", "a2", "b", "b1"]);
+    // root excluded from data
+    expect(payload.data.some((r) => r.$primaryKey === "root")).toBe(false);
+
+    expect(payload.byDepth.get(ref("root"))).toBe(0);
+    expect(payload.byDepth.get(ref("a"))).toBe(1);
+    expect(payload.byDepth.get(ref("b"))).toBe(1);
+    expect(payload.byDepth.get(ref("a1"))).toBe(2);
+    expect(payload.byDepth.get(ref("b1"))).toBe(2);
+
+    expect(pks(payload.adjacency.get(ref("root")) ?? [])).toEqual(["a", "b"]);
+    expect(pks(payload.adjacency.get(ref("a")) ?? [])).toEqual(["a1", "a2"]);
+    expect(pks(payload.adjacency.get(ref("b")) ?? [])).toEqual(["b1"]);
+    // depth-2 nodes were not expanded
+    expect(payload.adjacency.has(ref("a1"))).toBe(false);
+
+    expect(payload.depthReached).toBe(2);
+    expect(payload.truncated.byDepth).toBe(true);
+    expect(payload.truncated.byNodeBudget).toBe(false);
+    expect(payload.isExpanding).toBe(false);
+    expect(fetch.fetchLinks).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops at the node budget and records byNodeBudget", async () => {
+    const wide = Array.from({ length: 10 }, (_, i) => `c${i}`);
+    const fetch = makeFetch({ root: wide });
+    let last: ClosurePayload<TestInstance> | undefined;
+
+    const query = new ClosureQuery<TestInstance>({
+      root: ref("root"),
+      hop,
+      options: { maxDepth: 5, maxNodes: 5 },
+      ...fetch,
+      isOptimistic: () => false,
+      emit: (payload) => {
+        last = payload;
+      },
+    });
+
+    await query.run();
+
+    const payload = last as ClosurePayload<TestInstance>;
+    expect(payload.data.length).toBeLessThanOrEqual(5);
+    expect(payload.data.length).toBe(5);
+    expect(payload.truncated.byNodeBudget).toBe(true);
+  });
+
+  it("is cycle-safe: a revisited node is recorded but not re-expanded", async () => {
+    // root -> A -> B -> A (back-edge)
+    const fetch = makeFetch({ root: ["a"], a: ["b"], b: ["a"] });
+    let last: ClosurePayload<TestInstance> | undefined;
+
+    const query = new ClosureQuery<TestInstance>({
+      root: ref("root"),
+      hop,
+      options: { maxDepth: 10, maxNodes: 1000 },
+      ...fetch,
+      isOptimistic: () => false,
+      emit: (payload) => {
+        last = payload;
+      },
+    });
+
+    await query.run();
+
+    const payload = last as ClosurePayload<TestInstance>;
+    // A appears exactly once in the flat, deduped data
+    expect(payload.data.filter((r) => r.$primaryKey === "a")).toHaveLength(1);
+    expect(pks(payload.data).sort()).toEqual(["a", "b"]);
+    // the back-edge B -> A is recorded in adjacency
+    expect(pks(payload.adjacency.get(ref("b")) ?? [])).toEqual(["a"]);
+    // A was only expanded once (root, a, b expansions = 3 fetches)
+    expect(fetch.fetchLinks).toHaveBeenCalledTimes(3);
+  });
+
+  it("streams a snapshot after each level with isExpanding flagging progress", async () => {
+    // depth-3 nodes exist so the depth budget stops descent (no trailing
+    // empty-fetch level); two levels are expanded for maxDepth: 2.
+    const fetch = makeFetch({
+      root: ["a", "b"],
+      a: ["a1"],
+      b: ["b1"],
+      a1: ["a1x"],
+      b1: ["b1x"],
+    });
+    const snapshots: Array<ClosurePayload<TestInstance>> = [];
+
+    const query = new ClosureQuery<TestInstance>({
+      root: ref("root"),
+      hop,
+      options: { maxDepth: 2, maxNodes: 1000 },
+      ...fetch,
+      isOptimistic: () => false,
+      emit: (payload) => {
+        snapshots.push(payload);
+      },
+    });
+
+    await query.run();
+
+    // one snapshot per expanded level
+    expect(snapshots).toHaveLength(2);
+
+    expect(snapshots[0].depthReached).toBe(1);
+    expect(snapshots[0].data.length).toBe(2);
+    expect(snapshots[0].isExpanding).toBe(true);
+
+    expect(snapshots[1].depthReached).toBe(2);
+    expect(snapshots[1].data.length).toBe(4);
+    expect(snapshots[1].isExpanding).toBe(false);
+
+    // data grows monotonically across snapshots
+    expect(snapshots[1].data.length).toBeGreaterThan(snapshots[0].data.length);
+    // earlier snapshot is not mutated by later levels (tear-free)
+    expect(snapshots[0].data.length).toBe(2);
+  });
+
+  it("expand(ref) extends the closure from one node, reusing visited", async () => {
+    const fetch = makeFetch({
+      root: ["a", "b"],
+      a: ["a1", "a2"],
+      b: ["b1"],
+    });
+    const snapshots: Array<ClosurePayload<TestInstance>> = [];
+
+    const query = new ClosureQuery<TestInstance>({
+      root: ref("root"),
+      hop,
+      options: { maxDepth: 1, maxNodes: 1000 },
+      ...fetch,
+      isOptimistic: () => false,
+      emit: (payload) => {
+        snapshots.push(payload);
+      },
+    });
+
+    await query.run();
+    const afterRun = snapshots.length;
+    // depth-1 closure: a, b discovered but not expanded
+    expect(pks(snapshots[afterRun - 1].data).sort()).toEqual(["a", "b"]);
+    expect(snapshots[afterRun - 1].adjacency.has(ref("a"))).toBe(false);
+
+    await query.expand(ref("a"));
+
+    // a new snapshot was emitted
+    expect(snapshots.length).toBe(afterRun + 1);
+    const payload = snapshots[snapshots.length - 1];
+    expect(pks(payload.data).sort()).toEqual(["a", "a1", "a2", "b"]);
+    expect(pks(payload.adjacency.get(ref("a")) ?? [])).toEqual(["a1", "a2"]);
+    expect(payload.byDepth.get(ref("a1"))).toBe(2);
+
+    // expand fetched only the requested leaf
+    const lastCall = fetch.fetchLinks.mock.calls.at(-1);
+    const sources = lastCall?.[2] as ReadonlyArray<ObjectRef>;
+    expect(pks(sources)).toEqual(["a"]);
+
+    // re-expanding a node whose children are already visited adds nothing new
+    const beforeRepeat = payload.data.length;
+    await query.expand(ref("a"));
+    const repeated = snapshots[snapshots.length - 1];
+    expect(repeated.data.length).toBe(beforeRepeat);
+  });
+
+  it("surfaces an optimistic discovered node through the snapshot", async () => {
+    const fetch = makeFetch({ root: ["a", "b"] });
+    let last: ClosurePayload<TestInstance> | undefined;
+
+    const query = new ClosureQuery<TestInstance>({
+      root: ref("root"),
+      hop,
+      options: { maxDepth: 1, maxNodes: 1000 },
+      ...fetch,
+      isOptimistic: (r) => r.$primaryKey === "b",
+      emit: (payload) => {
+        last = payload;
+      },
+    });
+
+    await query.run();
+
+    const payload = last as ClosurePayload<TestInstance>;
+    expect(pks(payload.data).sort()).toEqual(["a", "b"]);
+    expect(payload.isOptimistic).toBe(true);
+  });
+
+  it("counts an optimistic edit to the root, even though root is excluded from data", async () => {
+    const fetch = makeFetch({ root: ["a"] });
+    let last: ClosurePayload<TestInstance> | undefined;
+
+    const query = new ClosureQuery<TestInstance>({
+      root: ref("root"),
+      hop,
+      options: { maxDepth: 1, maxNodes: 1000 },
+      ...fetch,
+      isOptimistic: (r) => r.$primaryKey === "root",
+      emit: (payload) => {
+        last = payload;
+      },
+    });
+
+    await query.run();
+
+    const payload = last as ClosurePayload<TestInstance>;
+    expect(payload.data.some((r) => r.$primaryKey === "root")).toBe(false);
+    expect(payload.isOptimistic).toBe(true);
+  });
+
+  it("turns optimistic when a node is edited, then clears on rollback", async () => {
+    // root -> a -> a1: run discovers "a"; expand(a) re-emits with "a1".
+    const fetch = makeFetch({ root: ["a"], a: ["a1"] });
+    const snapshots: Array<ClosurePayload<TestInstance>> = [];
+    let optimistic = true;
+
+    const query = new ClosureQuery<TestInstance>({
+      root: ref("root"),
+      hop,
+      options: { maxDepth: 1, maxNodes: 1000 },
+      ...fetch,
+      isOptimistic: (r) => optimistic && r.$primaryKey === "a",
+      emit: (payload) => {
+        snapshots.push(payload);
+      },
+    });
+
+    await query.run();
+    expect(snapshots[snapshots.length - 1].isOptimistic).toBe(true);
+
+    optimistic = false;
+    await query.expand(ref("a"));
+    expect(snapshots[snapshots.length - 1].isOptimistic).toBe(false);
+  });
+
+  it("stays non-optimistic when no discovered node is on an optimistic layer", async () => {
+    const fetch = makeFetch({ root: ["a", "b"] });
+    let last: ClosurePayload<TestInstance> | undefined;
+
+    const query = new ClosureQuery<TestInstance>({
+      root: ref("root"),
+      hop,
+      options: { maxDepth: 1, maxNodes: 1000 },
+      ...fetch,
+      isOptimistic: () => false,
+      emit: (payload) => {
+        last = payload;
+      },
+    });
+
+    await query.run();
+
+    expect((last as ClosurePayload<TestInstance>).isOptimistic).toBe(false);
+  });
+});

--- a/packages/client/src/observable/internal/links/ClosureQuery.ts
+++ b/packages/client/src/observable/internal/links/ClosureQuery.ts
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { LinkHopDescriptor, ObjectRef } from "@osdk/api";
+import { objectRefKey, ObjectRefMap } from "@osdk/api";
+import type { InterfaceHolder } from "../../../object/convertWireToOsdkObjects/InterfaceHolder.js";
+import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
+import type { ResolvedLink } from "../../../ontology/OntologyMetadataClient.js";
+import type { Status } from "../../ObservableClient/common.js";
+import type {
+  ClosureExpansion,
+  ExpandedChild,
+  ExpansionContext,
+} from "./ClosureExpansion.js";
+import { ClientDrivenBfsExpansion } from "./ClosureExpansion.js";
+import { cloneRefMap } from "./refMapUtils.js";
+
+/** Flat, deduped BFS state, all keyed by {@link ObjectRef}. */
+export interface ClosureState {
+  /** objectRefKey of every node already discovered (root included). */
+  visited: Set<string>;
+  /** parent -> children, including back-edges to already-visited nodes. */
+  adjacency: ObjectRefMap<ObjectRef[]>;
+  byDepth: ObjectRefMap<number>;
+  /** nodes with potentially-unexpanded children. */
+  frontier: ObjectRef[];
+  /** flat, deduped, root-excluded discovery order. */
+  data: ObjectRef[];
+  depthReached: number;
+  isExpanding: boolean;
+  truncated: { byDepth: boolean; byNodeBudget: boolean };
+}
+
+export interface ClosurePayload<I = ObjectHolder | InterfaceHolder>
+  extends ClosureState
+{
+  /** resolved instances for every ref in {@link ClosureState.data}. */
+  instances: ObjectRefMap<I>;
+  /** extend the closure from one already-discovered node. */
+  expand: (ref: ObjectRef) => void;
+  status: Status;
+  isOptimistic: boolean;
+  error: Error | undefined;
+  lastUpdated: number;
+}
+
+export interface ClosureQueryConfig<I = ObjectHolder | InterfaceHolder> {
+  root: ObjectRef;
+  hop: LinkHopDescriptor;
+  options: { maxDepth: number | "unbounded"; maxNodes: number };
+  resolveLink(
+    concreteType: string,
+    interfaceLinkApiName: string,
+  ): Promise<ResolvedLink>;
+  fetchLinks(
+    concreteType: string,
+    concreteLinkApiName: string,
+    sources: ReadonlyArray<ObjectRef>,
+    signal?: AbortSignal,
+  ): Promise<ObjectRefMap<ReadonlyArray<ExpandedChild<I>>>>;
+  emit: (payload: ClosurePayload<I>) => void;
+  /**
+   * Whether the node at `ref` currently sits on an optimistic layer. The
+   * closure has no write primitive, so it becomes optimistic when any
+   * discovered node is optimistically edited.
+   */
+  isOptimistic(ref: ObjectRef): boolean;
+  /** defaults to {@link ClientDrivenBfsExpansion}. */
+  expansion?: ClosureExpansion<I>;
+}
+
+/**
+ * Drives an incremental, client-side BFS over a recursive link traversal.
+ *
+ * Canonical storage stays flat (`data` + `adjacency` + `byDepth`); a tree view
+ * is derived elsewhere (WS7). The query streams: a snapshot is emitted after
+ * each expanded level so callers see data as it arrives.
+ */
+export class ClosureQuery<I = ObjectHolder | InterfaceHolder> {
+  readonly #root: ObjectRef;
+  readonly #hop: LinkHopDescriptor;
+  readonly #maxDepth: number;
+  readonly #maxNodes: number;
+  readonly #expansion: ClosureExpansion<I>;
+  readonly #ctx: ExpansionContext<I>;
+  readonly #emit: (payload: ClosurePayload<I>) => void;
+  readonly #isOptimistic: (ref: ObjectRef) => boolean;
+
+  readonly #visited = new Set<string>();
+  readonly #adjacency = new ObjectRefMap<ObjectRef[]>();
+  readonly #byDepth = new ObjectRefMap<number>();
+  readonly #instances = new ObjectRefMap<I>();
+  #frontier: ObjectRef[] = [];
+  #data: ObjectRef[] = [];
+  #depthReached = 0;
+  #isExpanding = false;
+  readonly #truncated = { byDepth: false, byNodeBudget: false };
+  #error: Error | undefined;
+  #lastUpdated = 0;
+
+  constructor(config: ClosureQueryConfig<I>) {
+    this.#root = config.root;
+    this.#hop = config.hop;
+    this.#maxDepth = config.options.maxDepth === "unbounded"
+      ? Number.POSITIVE_INFINITY
+      : config.options.maxDepth;
+    this.#maxNodes = config.options.maxNodes;
+    this.#expansion = config.expansion ?? new ClientDrivenBfsExpansion<I>();
+    this.#emit = config.emit;
+    this.#isOptimistic = config.isOptimistic;
+    this.#ctx = {
+      resolveLink: config.resolveLink,
+      fetchLinks: config.fetchLinks,
+      recordError: (error) => {
+        this.#error = error;
+      },
+    };
+
+    this.#visited.add(objectRefKey(this.#root));
+    this.#byDepth.set(this.#root, 0);
+    this.#frontier = [this.#root];
+  }
+
+  /** Runs the BFS from the root frontier to completion. */
+  async run(): Promise<void> {
+    let toExpand = this.#frontier;
+    let depth = 0;
+
+    while (
+      toExpand.length > 0
+      && depth < this.#maxDepth
+      && !this.#truncated.byNodeBudget
+    ) {
+      this.#isExpanding = true;
+      const childrenByParent = await this.#expansion.expandLevel(
+        toExpand,
+        this.#hop,
+        this.#ctx,
+      );
+
+      const next: ObjectRef[] = [];
+      for (const parent of toExpand) {
+        const children = childrenByParent.get(parent) ?? [];
+        const adjacency: ObjectRef[] = [];
+        for (const childNode of children) {
+          adjacency.push(childNode.ref);
+          if (!this.#addNode(childNode, depth + 1)) {
+            continue;
+          }
+          next.push(childNode.ref);
+        }
+        this.#adjacency.set(parent, adjacency);
+      }
+
+      depth += 1;
+      this.#depthReached = depth;
+      this.#frontier = next;
+      this.#lastUpdated = Date.now();
+
+      if (depth >= this.#maxDepth && next.length > 0) {
+        this.#truncated.byDepth = true;
+      }
+
+      const willContinue = next.length > 0
+        && depth < this.#maxDepth
+        && !this.#truncated.byNodeBudget;
+      this.#isExpanding = willContinue;
+      this.#emit(this.snapshot());
+
+      toExpand = next;
+    }
+
+    if (this.#isExpanding) {
+      this.#isExpanding = false;
+      this.#emit(this.snapshot());
+    }
+  }
+
+  /** Extends the closure from one already-discovered node, reusing `visited`. */
+  async expand(ref: ObjectRef): Promise<void> {
+    this.#isExpanding = true;
+    const parentDepth = this.#byDepth.get(ref) ?? 0;
+    const childrenByParent = await this.#expansion.expandLevel(
+      [ref],
+      this.#hop,
+      this.#ctx,
+    );
+    const children = childrenByParent.get(ref) ?? [];
+
+    const adjacency: ObjectRef[] = [];
+    const newlyExpandable: ObjectRef[] = [];
+    for (const childNode of children) {
+      adjacency.push(childNode.ref);
+      if (!this.#addNode(childNode, parentDepth + 1)) {
+        continue;
+      }
+      newlyExpandable.push(childNode.ref);
+    }
+    this.#adjacency.set(ref, adjacency);
+
+    this.#frontier = [
+      ...this.#frontier.filter((f) => objectRefKey(f) !== objectRefKey(ref)),
+      ...newlyExpandable,
+    ];
+    if (parentDepth + 1 > this.#depthReached) {
+      this.#depthReached = parentDepth + 1;
+    }
+    this.#lastUpdated = Date.now();
+    this.#isExpanding = false;
+    this.#emit(this.snapshot());
+  }
+
+  /**
+   * Adds a discovered child to the closure unless it was already visited (cycle
+   * / shared parent) or the node budget is exhausted. Returns whether the node
+   * was newly added (and thus should join the next frontier).
+   */
+  #addNode(childNode: ExpandedChild<I>, depth: number): boolean {
+    const key = objectRefKey(childNode.ref);
+    if (this.#visited.has(key)) {
+      return false;
+    }
+    if (this.#data.length >= this.#maxNodes) {
+      this.#truncated.byNodeBudget = true;
+      return false;
+    }
+    this.#visited.add(key);
+    this.#data.push(childNode.ref);
+    this.#instances.set(childNode.ref, childNode.instance);
+    this.#byDepth.set(childNode.ref, depth);
+    return true;
+  }
+
+  /** Builds a tear-free snapshot (fresh collections) of the current state. */
+  snapshot(): ClosurePayload<I> {
+    const adjacency = new ObjectRefMap<ObjectRef[]>();
+    for (const [ref, children] of this.#adjacency.entries()) {
+      adjacency.set(ref, [...children]);
+    }
+    return {
+      visited: new Set(this.#visited),
+      adjacency,
+      byDepth: cloneRefMap(this.#byDepth),
+      frontier: [...this.#frontier],
+      data: [...this.#data],
+      depthReached: this.#depthReached,
+      isExpanding: this.#isExpanding,
+      truncated: { ...this.#truncated },
+      instances: cloneRefMap(this.#instances),
+      expand: (ref) => {
+        void this.expand(ref);
+      },
+      status: this.#error != null
+        ? "error"
+        : this.#isExpanding
+        ? "loading"
+        : "loaded",
+      // OR over every discovered node (root included): an optimistic edit to
+      // any node in the closure makes the whole closure optimistic.
+      isOptimistic: this.#isOptimistic(this.#root)
+        || this.#data.some((ref) => this.#isOptimistic(ref)),
+      error: this.#error,
+      lastUpdated: this.#lastUpdated,
+    };
+  }
+}

--- a/packages/client/src/observable/internal/links/LinksHelper.ts
+++ b/packages/client/src/observable/internal/links/LinksHelper.ts
@@ -100,6 +100,10 @@ export class LinksHelper extends AbstractHelper<
     );
 
     return this.store.queries.get(linkCacheKey, () => {
+      this.store.specificLinkCacheKeyRegistry.register(linkCacheKey, {
+        $objectType: options.sourceUnderlyingObjectType,
+        $primaryKey: options.pk,
+      });
       return new SpecificLinkQuery(
         this.store,
         this.store.subjects.get(linkCacheKey),

--- a/packages/client/src/observable/internal/links/PathQuery.test.ts
+++ b/packages/client/src/observable/internal/links/PathQuery.test.ts
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { LinkHopDescriptor, ObjectRef } from "@osdk/api";
+import { objectRefKey, ObjectRefMap } from "@osdk/api";
+import { describe, expect, it, vi } from "vitest";
+import type { ExpandedChild } from "./ClosureExpansion.js";
+import type { PathPayload } from "./PathQuery.js";
+import { PathQuery } from "./PathQuery.js";
+
+interface TestInstance {
+  $objectType: string;
+  $primaryKey: string | number;
+  name: string;
+}
+
+function ref(type: string, pk: string): ObjectRef {
+  return { $objectType: type, $primaryKey: pk };
+}
+
+function child(type: string, pk: string): ExpandedChild<TestInstance> {
+  return {
+    ref: ref(type, pk),
+    instance: { $objectType: type, $primaryKey: pk, name: `${type}:${pk}` },
+  };
+}
+
+const hopChild: LinkHopDescriptor = {
+  sourceTypeApiName: "SubCategory",
+  linkApiName: "child",
+  targetTypeApiName: "Segment",
+  multiplicity: false,
+  sourceIsInterface: false,
+};
+
+const hopPriorities: LinkHopDescriptor = {
+  sourceTypeApiName: "Segment",
+  linkApiName: "segmentItems",
+  targetTypeApiName: "Priority",
+  multiplicity: true,
+  sourceIsInterface: false,
+};
+
+const hopChildren: LinkHopDescriptor = {
+  sourceTypeApiName: "SubCategory",
+  linkApiName: "children",
+  targetTypeApiName: "Segment",
+  multiplicity: true,
+  sourceIsInterface: false,
+};
+
+/**
+ * Build resolveLink + fetchLinks stubs over a fixed `${refKey}|${link}` edge
+ * map. The fetch routes per hop by the concrete link name, so each hop returns
+ * only its own children.
+ */
+function makeFetch(edges: Record<string, ExpandedChild<TestInstance>[]>) {
+  const resolveLink = vi.fn().mockImplementation(
+    (_concreteType: string, interfaceLinkApiName: string) =>
+      Promise.resolve({
+        concreteLinkApiName: interfaceLinkApiName,
+        targetType: "Node",
+        multiplicity: true,
+      }),
+  );
+
+  const fetchLinks = vi.fn().mockImplementation(
+    (
+      _concreteType: string,
+      concreteLinkApiName: string,
+      sources: ReadonlyArray<ObjectRef>,
+    ) => {
+      const out = new ObjectRefMap<
+        ReadonlyArray<ExpandedChild<TestInstance>>
+      >();
+      for (const source of sources) {
+        const key = `${objectRefKey(source)}|${concreteLinkApiName}`;
+        out.set(source, edges[key] ?? []);
+      }
+      return Promise.resolve(out);
+    },
+  );
+
+  return { resolveLink, fetchLinks };
+}
+
+function endpoints(refs: ReadonlyArray<ObjectRef>): string[] {
+  return refs.map((r) => `${r.$objectType}:${r.$primaryKey}`);
+}
+
+describe("PathQuery", () => {
+  it("traverses a two-hop path and returns the deduped endpoint set", async () => {
+    const edges: Record<string, ExpandedChild<TestInstance>[]> = {
+      [`${objectRefKey(ref("SubCategory", "cat1"))}|child`]: [
+        child("Segment", "seg1"),
+      ],
+      [`${objectRefKey(ref("Segment", "seg1"))}|segmentItems`]: [
+        child("Priority", "p1"),
+        child("Priority", "p2"),
+      ],
+    };
+    const fetch = makeFetch(edges);
+    let last: PathPayload<TestInstance> | undefined;
+
+    const query = new PathQuery<TestInstance>({
+      root: ref("SubCategory", "cat1"),
+      hops: [hopChild, hopPriorities],
+      ...fetch,
+      isOptimistic: () => false,
+      emit: (payload) => {
+        last = payload;
+      },
+    });
+
+    await query.run();
+
+    expect(last).toBeDefined();
+    const payload = last as PathPayload<TestInstance>;
+
+    // endpoints only: the leaf items, never the intermediate Segment
+    expect(endpoints(payload.data).sort()).toEqual([
+      "Priority:p1",
+      "Priority:p2",
+    ]);
+    expect(payload.data.some((r) => r.$objectType === "Segment")).toBe(false);
+
+    // instances resolved for every endpoint
+    for (const r of payload.data) {
+      expect(payload.instances.get(r)).toBeDefined();
+    }
+
+    expect(payload.status).toBe("loaded");
+    expect(payload.error).toBeUndefined();
+  });
+
+  it("dedupes an endpoint reachable through multiple branches", async () => {
+    // cat1 fans out to two segments; both link to the same shared item,
+    // plus one item each. The shared item must appear exactly once.
+    const edges: Record<string, ExpandedChild<TestInstance>[]> = {
+      [`${objectRefKey(ref("SubCategory", "cat1"))}|children`]: [
+        child("Segment", "a"),
+        child("Segment", "b"),
+      ],
+      [`${objectRefKey(ref("Segment", "a"))}|segmentItems`]: [
+        child("Priority", "shared"),
+        child("Priority", "pa"),
+      ],
+      [`${objectRefKey(ref("Segment", "b"))}|segmentItems`]: [
+        child("Priority", "shared"),
+        child("Priority", "pb"),
+      ],
+    };
+    const fetch = makeFetch(edges);
+    let last: PathPayload<TestInstance> | undefined;
+
+    const query = new PathQuery<TestInstance>({
+      root: ref("SubCategory", "cat1"),
+      hops: [hopChildren, hopPriorities],
+      ...fetch,
+      isOptimistic: () => false,
+      emit: (payload) => {
+        last = payload;
+      },
+    });
+
+    await query.run();
+
+    expect(last).toBeDefined();
+    const payload = last as PathPayload<TestInstance>;
+
+    expect(endpoints(payload.data).sort()).toEqual([
+      "Priority:pa",
+      "Priority:pb",
+      "Priority:shared",
+    ]);
+    const sharedCount = payload.data.filter(
+      (r) => r.$primaryKey === "shared",
+    ).length;
+    expect(sharedCount).toBe(1);
+  });
+
+  it("surfaces an optimistic endpoint through the path snapshot", async () => {
+    const edges: Record<string, ExpandedChild<TestInstance>[]> = {
+      [`${objectRefKey(ref("SubCategory", "cat1"))}|child`]: [
+        child("Segment", "seg1"),
+      ],
+      [`${objectRefKey(ref("Segment", "seg1"))}|segmentItems`]: [
+        child("Priority", "p1"),
+      ],
+    };
+    const fetch = makeFetch(edges);
+    let last: PathPayload<TestInstance> | undefined;
+
+    const query = new PathQuery<TestInstance>({
+      root: ref("SubCategory", "cat1"),
+      hops: [hopChild, hopPriorities],
+      ...fetch,
+      isOptimistic: (r) => r.$primaryKey === "p1",
+      emit: (payload) => {
+        last = payload;
+      },
+    });
+
+    await query.run();
+
+    const payload = last as PathPayload<TestInstance>;
+    expect(endpoints(payload.data)).toEqual(["Priority:p1"]);
+    expect(payload.isOptimistic).toBe(true);
+  });
+
+  it("ignores optimism on intermediate (non-endpoint) nodes", async () => {
+    const edges: Record<string, ExpandedChild<TestInstance>[]> = {
+      [`${objectRefKey(ref("SubCategory", "cat1"))}|child`]: [
+        child("Segment", "seg1"),
+      ],
+      [`${objectRefKey(ref("Segment", "seg1"))}|segmentItems`]: [
+        child("Priority", "p1"),
+      ],
+    };
+    const fetch = makeFetch(edges);
+    let last: PathPayload<TestInstance> | undefined;
+
+    const query = new PathQuery<TestInstance>({
+      root: ref("SubCategory", "cat1"),
+      hops: [hopChild, hopPriorities],
+      ...fetch,
+      // only the intermediate Segment is "optimistic"; it is not an endpoint
+      isOptimistic: (r) => r.$objectType === "Segment",
+      emit: (payload) => {
+        last = payload;
+      },
+    });
+
+    await query.run();
+
+    expect((last as PathPayload<TestInstance>).isOptimistic).toBe(false);
+  });
+
+  it("turns optimistic when an endpoint is edited, then clears on rollback", async () => {
+    const edges: Record<string, ExpandedChild<TestInstance>[]> = {
+      [`${objectRefKey(ref("SubCategory", "cat1"))}|child`]: [
+        child("Segment", "seg1"),
+      ],
+      [`${objectRefKey(ref("Segment", "seg1"))}|segmentItems`]: [
+        child("Priority", "p1"),
+      ],
+    };
+    const fetch = makeFetch(edges);
+    const snapshots: Array<PathPayload<TestInstance>> = [];
+    let optimistic = true;
+
+    const query = new PathQuery<TestInstance>({
+      root: ref("SubCategory", "cat1"),
+      hops: [hopChild, hopPriorities],
+      ...fetch,
+      isOptimistic: (r) => optimistic && r.$primaryKey === "p1",
+      emit: (payload) => {
+        snapshots.push(payload);
+      },
+    });
+
+    await query.run();
+    expect(snapshots[snapshots.length - 1].isOptimistic).toBe(true);
+
+    // rollback: the endpoint is no longer on an optimistic layer; re-run re-emits
+    optimistic = false;
+    await query.run();
+    expect(snapshots[snapshots.length - 1].isOptimistic).toBe(false);
+  });
+});

--- a/packages/client/src/observable/internal/links/PathQuery.ts
+++ b/packages/client/src/observable/internal/links/PathQuery.ts
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { LinkHopDescriptor, ObjectRef } from "@osdk/api";
+import { objectRefKey, ObjectRefMap } from "@osdk/api";
+import type { InterfaceHolder } from "../../../object/convertWireToOsdkObjects/InterfaceHolder.js";
+import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
+import type { ResolvedLink } from "../../../ontology/OntologyMetadataClient.js";
+import type { Status } from "../../ObservableClient/common.js";
+import type {
+  ClosureExpansion,
+  ExpandedChild,
+  ExpansionContext,
+} from "./ClosureExpansion.js";
+import { ClientDrivenBfsExpansion } from "./ClosureExpansion.js";
+import { cloneRefMap } from "./refMapUtils.js";
+
+/** Settled result of a multi-hop path traversal: deduped endpoints only. */
+export interface PathPayload<I = ObjectHolder | InterfaceHolder> {
+  /** deduped endpoint refs reachable across the full path. */
+  data: ObjectRef[];
+  /** resolved instances for every ref in {@link PathPayload.data}. */
+  instances: ObjectRefMap<I>;
+  status: Status;
+  isOptimistic: boolean;
+  error: Error | undefined;
+  lastUpdated: number;
+}
+
+export interface PathQueryConfig<I = ObjectHolder | InterfaceHolder> {
+  root: ObjectRef;
+  /** the chained hops, left to right; length > 1 for a real path. */
+  hops: ReadonlyArray<LinkHopDescriptor>;
+  resolveLink(
+    concreteType: string,
+    interfaceLinkApiName: string,
+    hop: LinkHopDescriptor,
+  ): Promise<ResolvedLink>;
+  fetchLinks(
+    concreteType: string,
+    concreteLinkApiName: string,
+    sources: ReadonlyArray<ObjectRef>,
+    hop: LinkHopDescriptor,
+    signal?: AbortSignal,
+  ): Promise<ObjectRefMap<ReadonlyArray<ExpandedChild<I>>>>;
+  emit: (payload: PathPayload<I>) => void;
+  /**
+   * Whether the endpoint at `ref` currently sits on an optimistic layer. The
+   * path becomes optimistic when any endpoint is optimistically edited.
+   */
+  isOptimistic(ref: ObjectRef): boolean;
+  /** defaults to {@link ClientDrivenBfsExpansion}. */
+  expansion?: ClosureExpansion<I>;
+}
+
+/**
+ * Drives a multi-hop `.then()` path traversal as a sequence of single-hop,
+ * multi-source expansions.
+ *
+ * Each hop is exactly one {@link ClientDrivenBfsExpansion.expandLevel} over the
+ * previous hop's endpoint set, applying that hop's own `where`/`orderBy`/`limit`
+ * via the per-hop {@link ExpansionContext}. The deduped children of one hop are
+ * carried forward as the source set of the next. Only the final hop's endpoints
+ * are returned (intermediate nodes are dropped); any `"many"` hop makes the
+ * whole path `"many"`. A single snapshot is emitted once the last hop settles
+ * (no per-hop streaming).
+ */
+export class PathQuery<I = ObjectHolder | InterfaceHolder> {
+  readonly #root: ObjectRef;
+  readonly #hops: ReadonlyArray<LinkHopDescriptor>;
+  readonly #expansion: ClosureExpansion<I>;
+  readonly #config: PathQueryConfig<I>;
+
+  #data: ObjectRef[] = [];
+  readonly #instances = new ObjectRefMap<I>();
+  #error: Error | undefined;
+  #lastUpdated = 0;
+
+  constructor(config: PathQueryConfig<I>) {
+    this.#root = config.root;
+    this.#hops = config.hops;
+    this.#expansion = config.expansion ?? new ClientDrivenBfsExpansion<I>();
+    this.#config = config;
+  }
+
+  /** Runs every hop left to right and emits the settled endpoint set. */
+  async run(): Promise<void> {
+    let frontier: ObjectRef[] = [this.#root];
+
+    for (let i = 0; i < this.#hops.length; i++) {
+      const hop = this.#hops[i];
+      const isLastHop = i === this.#hops.length - 1;
+      const childrenByParent = await this.#expansion.expandLevel(
+        frontier,
+        hop,
+        this.#ctxFor(hop),
+      );
+
+      // Dedupe children across every source in the frontier so a node reachable
+      // through multiple branches is carried forward (and returned) once.
+      const seen = new Set<string>();
+      const next: ObjectRef[] = [];
+      for (const parent of frontier) {
+        const children = childrenByParent.get(parent) ?? [];
+        for (const childNode of children) {
+          const key = objectRefKey(childNode.ref);
+          if (seen.has(key)) {
+            continue;
+          }
+          seen.add(key);
+          next.push(childNode.ref);
+          if (isLastHop) {
+            this.#instances.set(childNode.ref, childNode.instance);
+          }
+        }
+      }
+
+      frontier = next;
+      if (frontier.length === 0) {
+        break;
+      }
+    }
+
+    this.#data = frontier;
+    this.#lastUpdated = Date.now();
+    this.#config.emit(this.snapshot());
+  }
+
+  /** Per-hop expansion context that binds the hop's resolve + fetch. */
+  #ctxFor(hop: LinkHopDescriptor): ExpansionContext<I> {
+    return {
+      resolveLink: (concreteType, interfaceLinkApiName) =>
+        this.#config.resolveLink(concreteType, interfaceLinkApiName, hop),
+      fetchLinks: (concreteType, concreteLinkApiName, sources, signal) =>
+        this.#config.fetchLinks(
+          concreteType,
+          concreteLinkApiName,
+          sources,
+          hop,
+          signal,
+        ),
+      recordError: (error) => {
+        this.#error = error;
+      },
+    };
+  }
+
+  /** Builds a tear-free snapshot (fresh collections) of the settled state. */
+  snapshot(): PathPayload<I> {
+    return {
+      data: [...this.#data],
+      instances: cloneRefMap(this.#instances),
+      status: this.#error != null ? "error" : "loaded",
+      // OR over the settled endpoints: any endpoint on an optimistic layer
+      // makes the whole path optimistic.
+      isOptimistic: this.#data.some((ref) => this.#config.isOptimistic(ref)),
+      error: this.#error,
+      lastUpdated: this.#lastUpdated,
+    };
+  }
+}

--- a/packages/client/src/observable/internal/links/SpecificLinkCacheKeyRegistry.test.ts
+++ b/packages/client/src/observable/internal/links/SpecificLinkCacheKeyRegistry.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectRef } from "@osdk/api";
+import { describe, expect, it } from "vitest";
+import type { SpecificLinkCacheKey } from "./SpecificLinkCacheKey.js";
+import { SpecificLinkCacheKeyRegistry } from "./SpecificLinkCacheKeyRegistry.js";
+
+/**
+ * Builds a minimal stand-in for a {@link SpecificLinkCacheKey}. The registry
+ * only uses the key as an identity (Set / WeakMap member), so the contents do
+ * not need to be realistic.
+ */
+function createMockLinkCacheKey(
+  sourceApiName: string,
+  sourceUnderlyingObjectType: string,
+  sourcePk: string,
+  linkName: string,
+): SpecificLinkCacheKey {
+  return {
+    type: "specificLink" as const,
+    otherKeys: [
+      sourceApiName,
+      "object",
+      sourceUnderlyingObjectType,
+      sourcePk,
+      linkName,
+      {},
+      {},
+    ],
+    __cacheKey: {} as SpecificLinkCacheKey["__cacheKey"],
+  } as SpecificLinkCacheKey;
+}
+
+const sourceRef = (objectType: string, primaryKey: string): ObjectRef => ({
+  $objectType: objectType,
+  $primaryKey: primaryKey,
+});
+
+describe("SpecificLinkCacheKeyRegistry", () => {
+  it("registers link records scoped per source and de-dupes repeats", () => {
+    const registry = new SpecificLinkCacheKeyRegistry();
+
+    const source = sourceRef("Employee", "emp1");
+    const peeps = createMockLinkCacheKey(
+      "Employee",
+      "Employee",
+      "emp1",
+      "peeps",
+    );
+    const lead = createMockLinkCacheKey("Employee", "Employee", "emp1", "lead");
+    const unrelated = createMockLinkCacheKey(
+      "Employee",
+      "Employee",
+      "emp2",
+      "peeps",
+    );
+
+    registry.register(peeps, source);
+    // Repeated registration of the same record is de-duped.
+    registry.register(peeps, source);
+    registry.register(lead, source);
+    registry.register(unrelated, sourceRef("Employee", "emp2"));
+
+    const links = registry.getLinksForSource(source);
+    expect(links.size).toBe(2);
+    expect(links.has(peeps)).toBe(true);
+    expect(links.has(lead)).toBe(true);
+    expect(links.has(unrelated)).toBe(false);
+
+    const otherLinks = registry.getLinksForSource(
+      sourceRef("Employee", "emp2"),
+    );
+    expect(otherLinks.size).toBe(1);
+    expect(otherLinks.has(unrelated)).toBe(true);
+  });
+
+  it("unregister removes a record and cleans up the empty source", () => {
+    const registry = new SpecificLinkCacheKeyRegistry();
+
+    const source = sourceRef("Employee", "emp1");
+    const peeps = createMockLinkCacheKey(
+      "Employee",
+      "Employee",
+      "emp1",
+      "peeps",
+    );
+    const lead = createMockLinkCacheKey("Employee", "Employee", "emp1", "lead");
+
+    registry.register(peeps, source);
+    registry.register(lead, source);
+
+    registry.unregister(peeps);
+    const links = registry.getLinksForSource(source);
+    expect(links.size).toBe(1);
+    expect(links.has(lead)).toBe(true);
+    expect(links.has(peeps)).toBe(false);
+
+    registry.unregister(lead);
+    expect(registry.getLinksForSource(source).size).toBe(0);
+  });
+});

--- a/packages/client/src/observable/internal/links/SpecificLinkCacheKeyRegistry.ts
+++ b/packages/client/src/observable/internal/links/SpecificLinkCacheKeyRegistry.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectRef } from "@osdk/api";
+import { ObjectRefMap } from "@osdk/api";
+import type { SpecificLinkCacheKey } from "./SpecificLinkCacheKey.js";
+
+/**
+ * Reverse index from a source object to the `specificLink` cache keys that read
+ * outgoing links from it.
+ *
+ * `specificLink` queries are keyed on `(srcType, srcPk, linkName, ...)` rather
+ * than on the linked (target) object's primary key, so per-object change
+ * propagation never reaches them. When an action edits a known object we use
+ * this index to find exactly the link records whose source was touched and
+ * revalidate only those, instead of walking every cached link query.
+ *
+ * Mirrors {@link ObjectCacheKeyRegistry}: a link query registers when created
+ * and unregisters when its cache key is cleaned up.
+ */
+export class SpecificLinkCacheKeyRegistry {
+  /** Source object -> the set of link records that read from it. */
+  readonly #sourceToLinks = new ObjectRefMap<Set<SpecificLinkCacheKey>>();
+
+  /** Link record -> the source it was registered under (for unregister). */
+  readonly #linkToSource = new WeakMap<SpecificLinkCacheKey, ObjectRef>();
+
+  /**
+   * Register a link record under its source object.
+   */
+  register(cacheKey: SpecificLinkCacheKey, sourceRef: ObjectRef): void {
+    this.#linkToSource.set(cacheKey, sourceRef);
+
+    let links = this.#sourceToLinks.get(sourceRef);
+    if (!links) {
+      links = new Set();
+      this.#sourceToLinks.set(sourceRef, links);
+    }
+    links.add(cacheKey);
+  }
+
+  /**
+   * Get every link record currently registered for a source object.
+   */
+  getLinksForSource(sourceRef: ObjectRef): Set<SpecificLinkCacheKey> {
+    return new Set(this.#sourceToLinks.get(sourceRef) ?? []);
+  }
+
+  /**
+   * Unregister a link record when its cache key is being cleaned up.
+   */
+  unregister(cacheKey: SpecificLinkCacheKey): void {
+    const sourceRef = this.#linkToSource.get(cacheKey);
+    if (!sourceRef) {
+      return;
+    }
+
+    const links = this.#sourceToLinks.get(sourceRef);
+    if (links) {
+      links.delete(cacheKey);
+      if (links.size === 0) {
+        this.#sourceToLinks.delete(sourceRef);
+      }
+    }
+
+    this.#linkToSource.delete(cacheKey);
+  }
+}

--- a/packages/client/src/observable/internal/links/SpecificLinkQuery.ts
+++ b/packages/client/src/observable/internal/links/SpecificLinkQuery.ts
@@ -17,6 +17,7 @@
 import type {
   InterfaceDefinition,
   ObjectOrInterfaceDefinition,
+  ObjectRef,
   ObjectSet,
   ObjectTypeDefinition,
   Osdk,
@@ -24,9 +25,12 @@ import type {
   PrimaryKeyType,
   WhereClause,
 } from "@osdk/api";
+import { ObjectRefMap } from "@osdk/api";
 import deepEqual from "fast-deep-equal";
 import { type Subject } from "rxjs";
 import { additionalContext } from "../../../Client.js";
+import type { InterfaceHolder } from "../../../object/convertWireToOsdkObjects/InterfaceHolder.js";
+import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
 import type { SpecificLinkPayload } from "../../LinkPayload.js";
 import type { Status } from "../../ObservableClient/common.js";
 import type { ObserveLinks } from "../../ObservableClient/ObserveLink.js";
@@ -77,11 +81,21 @@ export class SpecificLinkQuery extends BaseListQuery<
   protected override createPayload(
     params: CollectionConnectableParams,
   ): SpecificLinkPayload {
+    const sourceRef: ObjectRef = {
+      $objectType: this.#sourceUnderlyingObjectType,
+      $primaryKey: this.#sourcePk,
+    };
+    const linkGroup = params.resolvedData ?? [];
+    const linkedObjectsBySource = new ObjectRefMap<
+      ReadonlyArray<ObjectHolder | InterfaceHolder>
+    >();
+    linkedObjectsBySource.set(sourceRef, linkGroup);
     return {
       ...super.createPayload(params),
+      linkedObjectsBySource,
       linkedObjectsBySourcePrimaryKey: new Map([[
         this.#sourcePk,
-        params.resolvedData ?? [],
+        linkGroup,
       ]]),
     };
   }
@@ -353,6 +367,7 @@ export class SpecificLinkQuery extends BaseListQuery<
     // 3. When the target type matches the invalidated type
     // 4. When the target is an interface and the invalidated type implements it
 
+    // 1. Source object type matches directly.
     if (
       this.#sourceTypeKind === "object" && this.#sourceApiName === objectType
     ) {
@@ -361,11 +376,11 @@ export class SpecificLinkQuery extends BaseListQuery<
     }
 
     return (async () => {
-      try {
-        const ontologyProvider = this.store.client[additionalContext]
-          .ontologyProvider;
-
-        if (this.#sourceTypeKind === "interface") {
+      // 2. Source is an interface that the invalidated type implements.
+      if (this.#sourceTypeKind === "interface") {
+        try {
+          const ontologyProvider = this.store.client[additionalContext]
+            .ontologyProvider;
           const objectMetadata = await ontologyProvider.getObjectDefinition(
             objectType,
           );
@@ -373,7 +388,43 @@ export class SpecificLinkQuery extends BaseListQuery<
             changes?.modified.add(this.cacheKey);
             return void await this.revalidate(true);
           }
+        } catch (e) {
+          if (process.env.NODE_ENV !== "production") {
+            this.logger?.error(
+              "Failed to resolve metadata during invalidation",
+              e,
+            );
+          }
+          changes?.modified.add(this.cacheKey);
+          return void await this.revalidate(true);
         }
+      }
+
+      // 3 & 4. Target type matches the invalidated type (directly or via an
+      // interface the invalidated type implements).
+      await this.invalidateTargetType(objectType, changes);
+    })();
+  };
+
+  /**
+   * Revalidate this link query when the invalidated object type is its *target*
+   * type — a direct target match, or an interface target that the invalidated
+   * object type implements (cases 3 & 4 of {@link invalidateObjectType}).
+   *
+   * Link queries are keyed on `(srcType, srcPk, linkName, ...)`, never on the
+   * linked object's type, so per-PK source invalidation never reaches a query
+   * that merely points *at* the edited object. {@link Store.invalidateObject}
+   * walks live link queries through this method so editing a linked object
+   * still refreshes the relationships that resolve to it.
+   */
+  invalidateTargetType = (
+    objectType: string,
+    changes: Changes | undefined,
+  ): Promise<void> => {
+    return (async () => {
+      try {
+        const ontologyProvider = this.store.client[additionalContext]
+          .ontologyProvider;
 
         let targetTypeApiName: string | undefined;
 
@@ -391,7 +442,9 @@ export class SpecificLinkQuery extends BaseListQuery<
             ?.targetType;
         }
 
-        if (!targetTypeApiName) return;
+        if (!targetTypeApiName) {
+          return;
+        }
 
         if (targetTypeApiName === objectType) {
           changes?.modified.add(this.cacheKey);

--- a/packages/client/src/observable/internal/links/refMapUtils.ts
+++ b/packages/client/src/observable/internal/links/refMapUtils.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ObjectRefMap } from "@osdk/api";
+
+/** Returns a fresh {@link ObjectRefMap} with the same entries (shallow values). */
+export function cloneRefMap<V>(m: ObjectRefMap<V>): ObjectRefMap<V> {
+  const out = new ObjectRefMap<V>();
+  for (const [ref, value] of m.entries()) {
+    out.set(ref, value);
+  }
+  return out;
+}

--- a/packages/client/src/observable/internal/links/sharedTraversalRegistry.test.ts
+++ b/packages/client/src/observable/internal/links/sharedTraversalRegistry.test.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { Observer } from "../../ObservableClient/common.js";
+import { createSharedTraversalRegistry } from "./sharedTraversalRegistry.js";
+
+function observer(): Observer<number> & { values: number[] } {
+  const values: number[] = [];
+  return {
+    values,
+    next: (value: number) => {
+      values.push(value);
+    },
+    error: () => {},
+    complete: () => {},
+  };
+}
+
+describe("createSharedTraversalRegistry", () => {
+  it("runs the expansion once for two subscriptions sharing a key", () => {
+    const registry = createSharedTraversalRegistry<number>();
+    const start = vi.fn().mockImplementation(
+      (_emit: (value: number) => void) => () => {},
+    );
+
+    const a = observer();
+    const b = observer();
+    registry.subscribe("k", a, start);
+    registry.subscribe("k", b, start);
+
+    // one underlying expansion despite two subscribers
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(registry.size).toBe(1);
+  });
+
+  it("broadcasts emitted values to every live observer", () => {
+    const registry = createSharedTraversalRegistry<number>();
+    let emit: (value: number) => void = () => {};
+    const start = vi.fn().mockImplementation(
+      (e: (value: number) => void) => {
+        emit = e;
+        return () => {};
+      },
+    );
+
+    const a = observer();
+    const b = observer();
+    registry.subscribe("k", a, start);
+    registry.subscribe("k", b, start);
+
+    emit(1);
+    emit(2);
+
+    expect(a.values).toEqual([1, 2]);
+    expect(b.values).toEqual([1, 2]);
+  });
+
+  it("replays the last value to a late subscriber", () => {
+    const registry = createSharedTraversalRegistry<number>();
+    let emit: (value: number) => void = () => {};
+    const start = (e: (value: number) => void) => {
+      emit = e;
+      return () => {};
+    };
+
+    const a = observer();
+    registry.subscribe("k", a, start);
+    emit(7);
+
+    const late = observer();
+    registry.subscribe("k", late, start);
+
+    // late subscriber immediately sees the last broadcast, only once
+    expect(late.values).toEqual([7]);
+  });
+
+  it("tears down the expansion exactly once on last unsubscribe", () => {
+    const registry = createSharedTraversalRegistry<number>();
+    const teardown = vi.fn();
+    const start = vi.fn().mockImplementation(
+      (_emit: (value: number) => void) => teardown,
+    );
+
+    const a = observer();
+    const b = observer();
+    const unsubA = registry.subscribe("k", a, start);
+    const unsubB = registry.subscribe("k", b, start);
+
+    unsubA();
+    expect(teardown).not.toHaveBeenCalled();
+    expect(registry.size).toBe(1);
+
+    unsubB();
+    expect(teardown).toHaveBeenCalledTimes(1);
+    expect(registry.size).toBe(0);
+
+    // double unsubscribe is a no-op
+    unsubB();
+    expect(teardown).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts a fresh expansion after a key is fully released", () => {
+    const registry = createSharedTraversalRegistry<number>();
+    const start = vi.fn().mockImplementation(
+      (_emit: (value: number) => void) => () => {},
+    );
+
+    const a = observer();
+    const unsubA = registry.subscribe("k", a, start);
+    unsubA();
+
+    const b = observer();
+    registry.subscribe("k", b, start);
+
+    expect(start).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps expansions for distinct keys independent", () => {
+    const registry = createSharedTraversalRegistry<number>();
+    const start = vi.fn().mockImplementation(
+      (_emit: (value: number) => void) => () => {},
+    );
+
+    registry.subscribe("k1", observer(), start);
+    registry.subscribe("k2", observer(), start);
+
+    expect(start).toHaveBeenCalledTimes(2);
+    expect(registry.size).toBe(2);
+  });
+});

--- a/packages/client/src/observable/internal/links/sharedTraversalRegistry.ts
+++ b/packages/client/src/observable/internal/links/sharedTraversalRegistry.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Observer } from "../../ObservableClient/common.js";
+
+/**
+ * Starts an underlying traversal. Receives the broadcast `emit` to feed
+ * snapshots to every subscriber sharing the key, and returns a teardown that
+ * is invoked once the last subscriber unsubscribes.
+ */
+export type StartTraversal<TArgs> = (
+  emit: (args: TArgs) => void,
+) => () => void;
+
+/**
+ * De-duplicates identical traversals so two subscriptions sharing a key drive
+ * a single underlying expansion (one query, one BFS).
+ *
+ * The first subscription for a key starts the expansion; later subscriptions
+ * for the same key attach to it and immediately replay the latest snapshot.
+ * The expansion is reference counted and torn down when the last subscription
+ * unsubscribes.
+ */
+export interface SharedTraversalRegistry<TArgs> {
+  subscribe(
+    key: string,
+    observer: Observer<TArgs>,
+    start: StartTraversal<TArgs>,
+  ): () => void;
+  /** number of live (started, not yet torn down) expansions. */
+  readonly size: number;
+}
+
+interface SharedEntry<TArgs> {
+  observers: Set<Observer<TArgs>>;
+  last: TArgs | undefined;
+  hasLast: boolean;
+  refCount: number;
+  teardown: () => void;
+}
+
+export function createSharedTraversalRegistry<
+  TArgs,
+>(): SharedTraversalRegistry<TArgs> {
+  const entries = new Map<string, SharedEntry<TArgs>>();
+
+  function subscribe(
+    key: string,
+    observer: Observer<TArgs>,
+    start: StartTraversal<TArgs>,
+  ): () => void {
+    let entry = entries.get(key);
+    if (entry === undefined) {
+      const observers = new Set<Observer<TArgs>>();
+      const created: SharedEntry<TArgs> = {
+        observers,
+        last: undefined,
+        hasLast: false,
+        refCount: 0,
+        teardown: () => {},
+      };
+      created.teardown = start((args) => {
+        created.last = args;
+        created.hasLast = true;
+        for (const o of observers) {
+          o.next(args);
+        }
+      });
+      entries.set(key, created);
+      entry = created;
+    }
+
+    entry.observers.add(observer);
+    entry.refCount += 1;
+
+    // a late subscriber sees the latest snapshot immediately
+    if (entry.hasLast) {
+      observer.next(entry.last as TArgs);
+    }
+
+    let unsubscribed = false;
+    return () => {
+      if (unsubscribed) {
+        return;
+      }
+      unsubscribed = true;
+      const current = entries.get(key);
+      if (current === undefined) {
+        return;
+      }
+      current.observers.delete(observer);
+      current.refCount -= 1;
+      if (current.refCount <= 0) {
+        entries.delete(key);
+        current.teardown();
+      }
+    };
+  }
+
+  return {
+    subscribe,
+    get size() {
+      return entries.size;
+    },
+  };
+}

--- a/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
@@ -765,3 +765,94 @@ describe("ObjectsHelper.storeOsdkInstances interface unwrap", () => {
     expect(InterfaceDefRef in cached).toBe(false);
   });
 });
+
+// Regression guard for the original useLinks crash: an interface-typed source
+// traversed over an RDP field used to be stored under its interface `$apiName`, so
+// the later concrete RDP merge ran with an undefined ObjectDefRef and threw a
+// TypeError in the cache. storeOsdkInstances now keys by the concrete
+// `$objectType`, so the merge sees a concrete holder and resolves without throwing.
+// This pins the behavior so a future regression to `v.$apiName` keying is caught.
+describe("ObjectsHelper interface-link RDP no-crash regression (original problem)", () => {
+  let client: Client;
+  let store: Store;
+  let emp: Osdk.Instance<Employee>;
+
+  beforeAll(async () => {
+    const testSetup = startNodeApiServer(
+      new FauxFoundry("https://stack.palantir.com/"),
+      createClient,
+    );
+    client = testSetup.client;
+
+    const fauxOntology = testSetup.fauxFoundry.getDefaultOntology();
+    ontologies.addEmployeeOntology(fauxOntology);
+
+    testSetup.fauxFoundry.getDefaultDataStore().registerObject(Employee, {
+      employeeId: 1,
+      fullName: "Alice",
+    });
+
+    emp = await client(Employee).fetchOne(1, { $includeRid: true });
+
+    return () => {
+      testSetup.apiServer.close();
+    };
+  });
+
+  beforeEach(() => {
+    store = new Store(client);
+    return () => {
+      store = undefined!;
+    };
+  });
+
+  it("stores an interface source over an RDP field without throwing and returns concrete data (already fixed on branch)", () => {
+    const rdpConfig = createFakeRdpConfig("derivedAddress");
+    const ifaceInstance = emp.$as(FooInterface);
+
+    expect(ifaceInstance.$apiName).toBe("FooInterface");
+    expect(ifaceInstance.$objectType).toBe("Employee");
+
+    // The concrete-typed query (keyed by $objectType) the store should converge
+    // on, and the interface-named query the original crash mistakenly used.
+    const concreteQuery = store.objects.getQuery(
+      { apiName: Employee, pk: 1 },
+      rdpConfig,
+    );
+    const interfaceQuery = store.objects.getQuery(
+      { apiName: FooInterface, pk: 1 },
+      rdpConfig,
+    );
+    expect(concreteQuery.cacheKey).not.toBe(interfaceQuery.cacheKey);
+
+    // Seed the concrete RDP key so the second write hits the propagateWrite
+    // merge branch (derivedAddress is absent on the object, so the merge runs).
+    store.batch({}, (batch) => {
+      concreteQuery.writeToStore(emp as any, "loaded", batch);
+    });
+
+    // Store the interface holder over the RDP field via the token-overload path.
+    // This must not throw — the original problem threw on the concrete merge.
+    const cacheKeys = store.batch({}, (batch) => {
+      return store.objects.storeOsdkInstances(
+        [ifaceInstance],
+        batch,
+        rdpConfig,
+      );
+    }).retVal;
+
+    // Keyed by the concrete type, so it lands on the concrete query's key, not
+    // the interface-named key.
+    expect(cacheKeys).toEqual([concreteQuery.cacheKey]);
+
+    const cached = store.getValue(cacheKeys[0])?.value;
+    expect(cached).toEqual(
+      expect.objectContaining({ $objectType: "Employee", $primaryKey: 1 }),
+    );
+    if (!cached) {
+      return;
+    }
+    expect(cached[ObjectDefRef]).toBeDefined();
+    expect(InterfaceDefRef in cached).toBe(false);
+  });
+});

--- a/packages/client/src/observable/internal/testUtils.ts
+++ b/packages/client/src/observable/internal/testUtils.ts
@@ -621,6 +621,8 @@ export function linkPayloadContaining(
       : {}),
     linkedObjectsBySourcePrimaryKey: x.linkedObjectsBySourcePrimaryKey
       ?? expect.anything(),
+    linkedObjectsBySource: x.linkedObjectsBySource
+      ?? expect.anything(),
   };
 }
 

--- a/packages/client/src/ontology/OntologyMetadataClient.test.ts
+++ b/packages/client/src/ontology/OntologyMetadataClient.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  InterfaceLinkNotResolvableError,
+  OntologyMetadataNotFoundError,
+} from "./errors/InterfaceLinkErrors.js";
+import type { OntologyMetadataSource } from "./OntologyMetadataClient.js";
+import { createOntologyMetadataClient } from "./OntologyMetadataClient.js";
+
+const source: OntologyMetadataSource = {
+  getInterfaceDefinition: (n) => {
+    if (n === "CategoryInterface") {
+      return Promise.resolve({
+        apiName: n,
+        implementedBy: ["Category", "SubCategory"],
+      });
+    }
+    return Promise.reject(new Error("nope"));
+  },
+  getObjectDefinition: (n) => {
+    if (n === "SubCategory") {
+      return Promise.resolve({
+        apiName: n,
+        links: {
+          concreteChildren: {
+            targetType: "SubCategory",
+            multiplicity: true,
+          },
+        },
+        interfaceLinkMap: {
+          CategoryInterface: { childCategories: "concreteChildren" },
+        },
+      });
+    }
+    return Promise.resolve({ apiName: n, links: {}, interfaceLinkMap: {} });
+  },
+};
+
+describe("OntologyMetadataClient", () => {
+  const md = createOntologyMetadataClient(source, () => Promise.resolve("v1"));
+
+  it("implementationsOf returns concrete types", async () => {
+    expect(await md.implementationsOf("CategoryInterface")).toEqual([
+      "Category",
+      "SubCategory",
+    ]);
+  });
+
+  it("implements is membership", async () => {
+    expect(await md.implements("Category", "CategoryInterface")).toBe(true);
+    expect(await md.implements("Group", "CategoryInterface")).toBe(false);
+  });
+
+  it("resolveLink maps interface link to concrete link", async () => {
+    expect(
+      await md.resolveLink("SubCategory", "childCategories"),
+    ).toEqual({
+      concreteLinkApiName: "concreteChildren",
+      targetType: "SubCategory",
+      multiplicity: true,
+    });
+  });
+
+  it("resolveLink throws when not implemented", async () => {
+    await expect(md.resolveLink("Group", "childCategories")).rejects
+      .toBeInstanceOf(InterfaceLinkNotResolvableError);
+  });
+
+  it("implementationsOf throws typed error when interface metadata is missing", async () => {
+    await expect(md.implementationsOf("Missing")).rejects.toBeInstanceOf(
+      OntologyMetadataNotFoundError,
+    );
+  });
+});

--- a/packages/client/src/ontology/OntologyMetadataClient.ts
+++ b/packages/client/src/ontology/OntologyMetadataClient.ts
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { InterfaceDefinition, ObjectTypeDefinition } from "@osdk/api";
+import {
+  InterfaceLinkNotResolvableError,
+  OntologyMetadataNotFoundError,
+} from "./errors/InterfaceLinkErrors.js";
+
+export interface ResolvedLink {
+  readonly concreteLinkApiName: string;
+  /** Concrete or interface target apiName. */
+  readonly targetType: string;
+  /** false = "one", true = "many". */
+  readonly multiplicity: boolean;
+}
+
+/**
+ * Narrow read surface the metadata client depends on. The full
+ * {@link OntologyProvider} structurally satisfies this, so the real provider
+ * can be passed directly while tests can supply a minimal stub.
+ */
+export interface OntologyMetadataSource {
+  getInterfaceDefinition(
+    apiName: string,
+  ): Promise<{ apiName: string; implementedBy?: ReadonlyArray<string> }>;
+  getObjectDefinition(
+    apiName: string,
+  ): Promise<{
+    apiName: string;
+    links: Record<string, { targetType: string; multiplicity: boolean }>;
+    interfaceLinkMap?: Record<string, Record<string, string>>;
+  }>;
+}
+
+export interface OntologyMetadataClient {
+  /** Concrete object type apiNames implementing the interface. */
+  implementationsOf(iface: InterfaceDefinition | string): Promise<string[]>;
+  /** Whether a concrete object type implements the interface. */
+  implements(
+    objectTypeApiName: string,
+    iface: InterfaceDefinition | string,
+  ): Promise<boolean>;
+  /**
+   * Resolve an interface link on a concrete type to its concrete link.
+   * Throws {@link InterfaceLinkNotResolvableError} if the concrete type does not
+   * implement that interface link (interface evolution / per-type gaps).
+   */
+  resolveLink(
+    concreteType: ObjectTypeDefinition | string,
+    interfaceLinkApiName: string,
+  ): Promise<ResolvedLink>;
+}
+
+function apiNameOf(value: { apiName: string } | string): string {
+  return typeof value === "string" ? value : value.apiName;
+}
+
+/**
+ * Creates the `client.ontologyMetadata` discovery surface.
+ *
+ * `versionKey` resolves a cache-busting token for the active ontology. v1 keys
+ * by ontology rid + branch (see `ontologyVersionKey`); when the token changes,
+ * memoized results are dropped so a mid-session ontology edit cannot surface
+ * stale interface-link resolution. A live per-request ontology version token is
+ * a v2 refinement left as the `versionKey` seam.
+ */
+export function createOntologyMetadataClient(
+  source: OntologyMetadataSource,
+  versionKey: () => Promise<string>,
+): OntologyMetadataClient {
+  let cachedVersion: string | undefined;
+  const implementationsCache = new Map<string, Promise<string[]>>();
+
+  async function resetIfVersionChanged(): Promise<void> {
+    const version = await versionKey();
+    if (version !== cachedVersion) {
+      cachedVersion = version;
+      implementationsCache.clear();
+    }
+  }
+
+  async function implementationsOf(
+    iface: InterfaceDefinition | string,
+  ): Promise<string[]> {
+    await resetIfVersionChanged();
+    const name = apiNameOf(iface);
+    const cached = implementationsCache.get(name);
+    if (cached != null) {
+      return cached;
+    }
+    const result = (async () => {
+      let def: { implementedBy?: ReadonlyArray<string> };
+      try {
+        def = await source.getInterfaceDefinition(name);
+      } catch (e) {
+        throw new OntologyMetadataNotFoundError(
+          name,
+          e instanceof Error ? e.message : undefined,
+        );
+      }
+      return [...(def.implementedBy ?? [])];
+    })();
+    implementationsCache.set(name, result);
+    return result;
+  }
+
+  async function impl(
+    objectTypeApiName: string,
+    iface: InterfaceDefinition | string,
+  ): Promise<boolean> {
+    const implementations = await implementationsOf(iface);
+    return implementations.includes(objectTypeApiName);
+  }
+
+  async function resolveLink(
+    concreteType: ObjectTypeDefinition | string,
+    interfaceLinkApiName: string,
+  ): Promise<ResolvedLink> {
+    await resetIfVersionChanged();
+    const concreteApiName = apiNameOf(concreteType);
+    let objMd: {
+      links: Record<string, { targetType: string; multiplicity: boolean }>;
+      interfaceLinkMap?: Record<string, Record<string, string>>;
+    };
+    try {
+      objMd = await source.getObjectDefinition(concreteApiName);
+    } catch (e) {
+      throw new OntologyMetadataNotFoundError(
+        concreteApiName,
+        e instanceof Error ? e.message : undefined,
+      );
+    }
+
+    const interfaceLinkMap = objMd.interfaceLinkMap ?? {};
+    let concreteLinkApiName: string | undefined;
+    for (const linkMap of Object.values(interfaceLinkMap)) {
+      if (interfaceLinkApiName in linkMap) {
+        concreteLinkApiName = linkMap[interfaceLinkApiName];
+        break;
+      }
+    }
+
+    if (concreteLinkApiName == null) {
+      throw new InterfaceLinkNotResolvableError(
+        concreteApiName,
+        interfaceLinkApiName,
+      );
+    }
+
+    const link = objMd.links[concreteLinkApiName];
+    if (link == null) {
+      throw new InterfaceLinkNotResolvableError(
+        concreteApiName,
+        interfaceLinkApiName,
+        `Interface link "${interfaceLinkApiName}" resolved to concrete link "${concreteLinkApiName}" on "${concreteApiName}", but that link is not present in the object metadata.`,
+      );
+    }
+
+    return {
+      concreteLinkApiName,
+      targetType: link.targetType,
+      multiplicity: link.multiplicity,
+    };
+  }
+
+  return {
+    implementationsOf,
+    implements: impl,
+    resolveLink,
+  };
+}

--- a/packages/client/src/ontology/errors/InterfaceLinkErrors.test.ts
+++ b/packages/client/src/ontology/errors/InterfaceLinkErrors.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  InterfaceLinkNotResolvableError,
+  OntologyMetadataNotFoundError,
+} from "./InterfaceLinkErrors.js";
+
+describe("interface link errors", () => {
+  it("OntologyMetadataNotFoundError carries apiName and a stable name", () => {
+    const e = new OntologyMetadataNotFoundError("Category");
+    expect(e.name).toBe("OntologyMetadataNotFoundError");
+    expect(e.apiName).toBe("Category");
+    expect(e).toBeInstanceOf(Error);
+  });
+  it("InterfaceLinkNotResolvableError carries concrete + link", () => {
+    const e = new InterfaceLinkNotResolvableError(
+      "SubCategory",
+      "childCategories",
+    );
+    expect(e.name).toBe("InterfaceLinkNotResolvableError");
+    expect(e.concreteType).toBe("SubCategory");
+    expect(e.interfaceLinkApiName).toBe("childCategories");
+  });
+});

--- a/packages/client/src/ontology/errors/InterfaceLinkErrors.ts
+++ b/packages/client/src/ontology/errors/InterfaceLinkErrors.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class OntologyMetadataNotFoundError extends Error {
+  override readonly name = "OntologyMetadataNotFoundError";
+  constructor(public readonly apiName: string, message?: string) {
+    super(message ?? `Ontology metadata not found for "${apiName}".`);
+  }
+}
+
+export class InterfaceLinkNotResolvableError extends Error {
+  override readonly name = "InterfaceLinkNotResolvableError";
+  constructor(
+    public readonly concreteType: string,
+    public readonly interfaceLinkApiName: string,
+    message?: string,
+  ) {
+    super(
+      message
+        ?? `Interface link "${interfaceLinkApiName}" is not resolvable on concrete type "${concreteType}".`,
+    );
+  }
+}

--- a/packages/client/src/ontology/versionKeyedMetadataCache.ts
+++ b/packages/client/src/ontology/versionKeyedMetadataCache.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { MinimalClient } from "../MinimalClientContext.js";
+
+/**
+ * Resolve a cache-busting version token for the active ontology.
+ *
+ * Decision (v1): the token is the ontology rid plus any branch. On a known
+ * version bump, callers invalidate by observing a changed token. A live
+ * per-request ontology version token is a v2 refinement and is intentionally
+ * left as a seam here so a future implementer does not mistake this for an
+ * oversight.
+ */
+export async function ontologyVersionKey(
+  client: MinimalClient,
+): Promise<string> {
+  const rid = await client.ontologyRid;
+  return `${rid} ${client.branch ?? ""}`;
+}

--- a/packages/client/src/public/observable.ts
+++ b/packages/client/src/public/observable.ts
@@ -32,4 +32,6 @@ export type {
 } from "../observable/ObservableClient.js";
 export type { Observer } from "../observable/ObservableClient/common.js";
 export type { ObserveLinks } from "../observable/ObservableClient/ObserveLink.js";
+export type { ObserveLinkClosure } from "../observable/ObservableClient/ObserveLinkClosure.js";
+export type { ObservePath } from "../observable/ObservableClient/ObservePath.js";
 export type { QueryParameterType, QueryReturnType } from "../queries/types.js";

--- a/packages/client/src/public/unstable-do-not-use.ts
+++ b/packages/client/src/public/unstable-do-not-use.ts
@@ -60,4 +60,8 @@ export type { Observer } from "../observable/ObservableClient/common.js";
 /** @deprecated Import from `@osdk/client/observable` instead. */
 export type { ObserveLinks } from "../observable/ObservableClient/ObserveLink.js";
 /** @deprecated Import from `@osdk/client/observable` instead. */
+export type { ObserveLinkClosure } from "../observable/ObservableClient/ObserveLinkClosure.js";
+/** @deprecated Import from `@osdk/client/observable` instead. */
+export type { ObservePath } from "../observable/ObservableClient/ObservePath.js";
+/** @deprecated Import from `@osdk/client/observable` instead. */
 export type { QueryParameterType, QueryReturnType } from "../queries/types.js";

--- a/packages/client/src/shapes/applyShapeTransformations.test.ts
+++ b/packages/client/src/shapes/applyShapeTransformations.test.ts
@@ -144,6 +144,51 @@ describe("applyShapeTransformations", () => {
     expect(result.violations).toEqual([]);
   });
 
+  it("records a missing field when withDefault substitutes a null source value", () => {
+    const shape = createMockShape({
+      codename: {
+        nullabilityOp: { type: "withDefault", defaultValue: "TBD" },
+      },
+    });
+    const obj = createMockObject({ codename: null });
+    const result = applyShapeTransformations(shape, obj);
+    expect(result.data).toBeDefined();
+    const data = result.data as Record<string, unknown> & {
+      $missingFields: ReadonlySet<string>;
+    };
+    expect(data.codename).toBe("TBD");
+    expect(data.$missingFields.has("codename")).toBe(true);
+  });
+
+  it("does not record a missing field when the source value is present", () => {
+    const shape = createMockShape({
+      codename: {
+        nullabilityOp: { type: "withDefault", defaultValue: "TBD" },
+      },
+    });
+    const obj = createMockObject({ codename: "TBD" });
+    const result = applyShapeTransformations(shape, obj);
+    expect(result.data).toBeDefined();
+    const data = result.data as Record<string, unknown> & {
+      $missingFields: ReadonlySet<string>;
+    };
+    expect(data.codename).toBe("TBD");
+    expect(data.$missingFields.has("codename")).toBe(false);
+  });
+
+  it("exposes an empty missing-field set when no fallback substitutes", () => {
+    const shape = createMockShape({
+      name: { nullabilityOp: { type: "select" } },
+    });
+    const obj = createMockObject({ name: "Alice" });
+    const result = applyShapeTransformations(shape, obj);
+    expect(result.data).toBeDefined();
+    const data = result.data as Record<string, unknown> & {
+      $missingFields: ReadonlySet<string>;
+    };
+    expect(data.$missingFields.size).toBe(0);
+  });
+
   it("withTransform error returns transformError violation", () => {
     const shape = createMockShape({
       name: {

--- a/packages/client/src/shapes/applyShapeTransformations.ts
+++ b/packages/client/src/shapes/applyShapeTransformations.ts
@@ -52,6 +52,7 @@ export function applyShapeTransformations<
   const primaryKey = rawObject.$primaryKey;
   const transformedProps: Record<string, unknown> = {};
   const requireProps: string[] = [];
+  const missingFields: string[] = [];
 
   // Phase 1-3: filter (dropIfNull), apply defaults and transforms
   // Collect require props to check after cloning
@@ -82,6 +83,9 @@ export function applyShapeTransformations<
         break;
       }
       case "withDefault": {
+        if (originalValue == null) {
+          missingFields.push(prop);
+        }
         transformedProps[prop] = originalValue ?? op.defaultValue;
         break;
       }
@@ -149,8 +153,21 @@ export function applyShapeTransformations<
     };
   }
 
+  // Attach the missing-field set to a fresh object so the shared cache instance
+  // is never mutated. When no transform produced a clone, clone now with no
+  // overrides to obtain an object we own.
+  const resultObject = clonedObject === rawObject
+    ? rawObject.$clone()
+    : clonedObject;
+  Object.defineProperty(resultObject, "$missingFields", {
+    value: new Set(missingFields),
+    enumerable: false,
+    configurable: true,
+    writable: false,
+  });
+
   return {
-    data: clonedObject as Osdk.Instance<ShapeBaseType<S>> & ShapeInstance<S>,
+    data: resultObject as Osdk.Instance<ShapeBaseType<S>> & ShapeInstance<S>,
     dropped: false,
     violations: [],
   };

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/ontology/interfaces/SomeInterface.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/ontology/interfaces/SomeInterface.ts
@@ -15,6 +15,8 @@ export type OsdkObjectLinks$SomeInterface = {};
 export namespace SomeInterface {
   export type PropertyKeys = 'spt';
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      *   display name: 'Some Property'
@@ -41,6 +43,7 @@ export interface SomeInterface extends $InterfaceDefinition {
   osdkMetadata: typeof $osdkMetadata;
   type: 'interface';
   apiName: 'com.example.dep.SomeInterface';
+  links: SomeInterface.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: SomeInterface.ObjectSet;
     props: SomeInterface.Props;
@@ -67,6 +70,7 @@ export const SomeInterface = {
   type: 'interface',
   apiName: 'com.example.dep.SomeInterface',
   osdkMetadata: $osdkMetadata,
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'idk2',
   },

--- a/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/ontology/objects/Task.ts
+++ b/packages/e2e.generated.api-namespace.dep/src/generatedNoCheck/ontology/objects/Task.ts
@@ -19,6 +19,8 @@ export namespace Task {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * (no ontology metadata)
@@ -51,6 +53,7 @@ export interface Task extends $ObjectTypeDefinition {
   apiName: 'com.example.dep.Task';
   primaryKeyApiName: 'taskId';
   primaryKeyType: 'string';
+  links: Task.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: Task.ObjectSet;
     props: Task.Props;
@@ -65,6 +68,7 @@ export interface Task extends $ObjectTypeDefinition {
       color: '#000000';
     };
     implements: [];
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -95,6 +99,7 @@ export const Task = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'taskId',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ridForTask',
   },

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/interfaces/SomeInterface.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/interfaces/SomeInterface.ts
@@ -15,6 +15,8 @@ export type OsdkObjectLinks$SomeInterface = {};
 export namespace SomeInterface {
   export type PropertyKeys = 'com.example.dep.spt';
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      *   display name: 'Some Property'
@@ -41,6 +43,7 @@ export interface SomeInterface extends $InterfaceDefinition {
   osdkMetadata: typeof $osdkMetadata;
   type: 'interface';
   apiName: 'com.example.local.SomeInterface';
+  links: SomeInterface.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: SomeInterface.ObjectSet;
     props: SomeInterface.Props;
@@ -67,6 +70,7 @@ export const SomeInterface = {
   type: 'interface',
   apiName: 'com.example.local.SomeInterface',
   osdkMetadata: $osdkMetadata,
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'idk2',
   },

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/objects/Thing.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/objects/Thing.ts
@@ -19,6 +19,8 @@ export namespace Thing {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * (no ontology metadata)
@@ -51,6 +53,7 @@ export interface Thing extends $ObjectTypeDefinition {
   apiName: 'Thing';
   primaryKeyApiName: 'id';
   primaryKeyType: 'integer';
+  links: Thing.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: Thing.ObjectSet;
     props: Thing.Props;
@@ -65,6 +68,9 @@ export interface Thing extends $ObjectTypeDefinition {
       color: 'green';
     };
     implements: ['com.example.dep.SomeInterface'];
+    interfaceLinkMap: {
+      'com.example.dep.SomeInterface': {};
+    };
     interfaceMap: {
       'com.example.dep.SomeInterface': {
         'com.example.dep.spt': 'body';
@@ -103,6 +109,7 @@ export const Thing = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'id',
   primaryKeyType: 'integer',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ridForThing',
   },

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/objects/UsesForeignSpt.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/objects/UsesForeignSpt.ts
@@ -19,6 +19,8 @@ export namespace UsesForeignSpt {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * (no ontology metadata)
@@ -51,6 +53,7 @@ export interface UsesForeignSpt extends $ObjectTypeDefinition {
   apiName: 'UsesForeignSpt';
   primaryKeyApiName: 'id';
   primaryKeyType: 'integer';
+  links: UsesForeignSpt.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: UsesForeignSpt.ObjectSet;
     props: UsesForeignSpt.Props;
@@ -65,6 +68,7 @@ export interface UsesForeignSpt extends $ObjectTypeDefinition {
       color: 'red';
     };
     implements: [];
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -95,6 +99,7 @@ export const UsesForeignSpt = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'id',
   primaryKeyType: 'integer',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'theRid',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/Athlete.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/Athlete.ts
@@ -15,6 +15,8 @@ export type OsdkObjectLinks$Athlete = {};
 export namespace Athlete {
   export type PropertyKeys = 'athleteId' | 'jerseyNumber' | 'name22';
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      *   display name: 'Athlete ID',
@@ -55,6 +57,7 @@ export interface Athlete extends $InterfaceDefinition {
   osdkMetadata: typeof $osdkMetadata;
   type: 'interface';
   apiName: 'Athlete';
+  links: Athlete.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: Athlete.ObjectSet;
     props: Athlete.Props;
@@ -95,6 +98,7 @@ export const Athlete = {
   type: 'interface',
   apiName: 'Athlete',
   osdkMetadata: $osdkMetadata,
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.interface-type.1b1b1b1b-1b1b-1b1b-1b1b-1b1b1b1b1b1b',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/CollateralConcernCandidate.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/CollateralConcernCandidate.ts
@@ -8,7 +8,9 @@ import type {
   Osdk as $Osdk,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export interface OsdkObjectLinks$CollateralConcernCandidate {
   'com.palantir.pcl.civpro.collateral-concern-core.collateralConcernEntityToList': CollateralConcernList.ObjectSet;
@@ -16,6 +18,14 @@ export interface OsdkObjectLinks$CollateralConcernCandidate {
 
 export namespace CollateralConcernCandidate {
   export type PropertyKeys = 'collateralConcernDescription' | 'collateralConcernName';
+
+  export interface LinkTokens {
+    readonly 'com.palantir.pcl.civpro.collateral-concern-core.collateralConcernEntityToList': $LinkDef<
+      CollateralConcernCandidate,
+      CollateralConcernList,
+      'many'
+    >;
+  }
 
   export interface Props {
     /**
@@ -51,6 +61,7 @@ export interface CollateralConcernCandidate extends $InterfaceDefinition {
   osdkMetadata: typeof $osdkMetadata;
   type: 'interface';
   apiName: 'com.palantir.pcl.civpro.collateral-concern-core.CollateralConcernCandidate';
+  links: CollateralConcernCandidate.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: CollateralConcernCandidate.ObjectSet;
     props: CollateralConcernCandidate.Props;
@@ -90,6 +101,15 @@ export const CollateralConcernCandidate = {
   type: 'interface',
   apiName: 'com.palantir.pcl.civpro.collateral-concern-core.CollateralConcernCandidate',
   osdkMetadata: $osdkMetadata,
+  links: {
+    'com.palantir.pcl.civpro.collateral-concern-core.collateralConcernEntityToList': $createLinkDef(
+      'com.palantir.pcl.civpro.collateral-concern-core.CollateralConcernCandidate',
+      'com.palantir.pcl.civpro.collateral-concern-core.collateralConcernEntityToList',
+      'com.palantir.pcl.civpro.collateral-concern-core.CollateralConcernList',
+      true,
+      true,
+    ),
+  },
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.interface.81202dc9-3dcb-4031-b102-bfdb01a0e17c',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/CollateralConcernList.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/CollateralConcernList.ts
@@ -8,7 +8,9 @@ import type {
   Osdk as $Osdk,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export interface OsdkObjectLinks$CollateralConcernList {
   'com.palantir.pcl.civpro.collateral-concern-core.collateralConcernListToEntity': CollateralConcernCandidate.ObjectSet;
@@ -16,6 +18,14 @@ export interface OsdkObjectLinks$CollateralConcernList {
 
 export namespace CollateralConcernList {
   export type PropertyKeys = 'collateralConcernListDescription' | 'collateralConcernListName';
+
+  export interface LinkTokens {
+    readonly 'com.palantir.pcl.civpro.collateral-concern-core.collateralConcernListToEntity': $LinkDef<
+      CollateralConcernList,
+      CollateralConcernCandidate,
+      'many'
+    >;
+  }
 
   export interface Props {
     /**
@@ -51,6 +61,7 @@ export interface CollateralConcernList extends $InterfaceDefinition {
   osdkMetadata: typeof $osdkMetadata;
   type: 'interface';
   apiName: 'com.palantir.pcl.civpro.collateral-concern-core.CollateralConcernList';
+  links: CollateralConcernList.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: CollateralConcernList.ObjectSet;
     props: CollateralConcernList.Props;
@@ -90,6 +101,15 @@ export const CollateralConcernList = {
   type: 'interface',
   apiName: 'com.palantir.pcl.civpro.collateral-concern-core.CollateralConcernList',
   osdkMetadata: $osdkMetadata,
+  links: {
+    'com.palantir.pcl.civpro.collateral-concern-core.collateralConcernListToEntity': $createLinkDef(
+      'com.palantir.pcl.civpro.collateral-concern-core.CollateralConcernList',
+      'com.palantir.pcl.civpro.collateral-concern-core.collateralConcernListToEntity',
+      'com.palantir.pcl.civpro.collateral-concern-core.CollateralConcernCandidate',
+      true,
+      true,
+    ),
+  },
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.interface.7d459ce8-bb84-4ea5-9039-71560d82b53f',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/EsongInterfaceA.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/EsongInterfaceA.ts
@@ -8,7 +8,9 @@ import type {
   Osdk as $Osdk,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export interface OsdkObjectLinks$EsongInterfaceA {
   esongPds: $SingleLinkAccessor<EsongPds>;
@@ -16,6 +18,10 @@ export interface OsdkObjectLinks$EsongInterfaceA {
 
 export namespace EsongInterfaceA {
   export type PropertyKeys = 'esongSptA';
+
+  export interface LinkTokens {
+    readonly esongPds: $LinkDef<EsongInterfaceA, EsongPds, 'one'>;
+  }
 
   export interface Props {
     /**
@@ -43,6 +49,7 @@ export interface EsongInterfaceA extends $InterfaceDefinition {
   osdkMetadata: typeof $osdkMetadata;
   type: 'interface';
   apiName: 'EsongInterfaceA';
+  links: EsongInterfaceA.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: EsongInterfaceA.ObjectSet;
     props: EsongInterfaceA.Props;
@@ -71,6 +78,9 @@ export const EsongInterfaceA = {
   type: 'interface',
   apiName: 'EsongInterfaceA',
   osdkMetadata: $osdkMetadata,
+  links: {
+    esongPds: $createLinkDef('EsongInterfaceA', 'esongPds', 'EsongPds', false, true),
+  },
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.interface.3f52b54b-dab9-41f1-b02c-4eba39846673',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/FooInterface.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/FooInterface.ts
@@ -21,6 +21,8 @@ export namespace FooInterface {
     | 'inheritedDescription'
     | 'name';
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      *   @deprecated
@@ -97,6 +99,7 @@ export interface FooInterface extends $InterfaceDefinition {
   osdkMetadata: typeof $osdkMetadata;
   type: 'interface';
   apiName: 'FooInterface';
+  links: FooInterface.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: FooInterface.ObjectSet;
     props: FooInterface.Props;
@@ -173,6 +176,7 @@ export const FooInterface = {
   type: 'interface',
   apiName: 'FooInterface',
   osdkMetadata: $osdkMetadata,
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.interface-type.1b1b1b1b-1b1b-1b1b-1b1b-1b1b1b1b1b1b',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/InterfaceNoProps.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/InterfaceNoProps.ts
@@ -15,6 +15,8 @@ export type OsdkObjectLinks$InterfaceNoProps = {};
 export namespace InterfaceNoProps {
   export type PropertyKeys = never;
 
+  export type LinkTokens = {};
+
   export interface Props {}
   export type StrictProps = Props;
 
@@ -36,6 +38,7 @@ export interface InterfaceNoProps extends $InterfaceDefinition {
   osdkMetadata: typeof $osdkMetadata;
   type: 'interface';
   apiName: 'InterfaceNoProps';
+  links: InterfaceNoProps.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: InterfaceNoProps.ObjectSet;
     props: InterfaceNoProps.Props;
@@ -57,6 +60,7 @@ export const InterfaceNoProps = {
   type: 'interface',
   apiName: 'InterfaceNoProps',
   osdkMetadata: $osdkMetadata,
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.interface-type.1b1b1b1b-1b1b-1b1b-1b1b-1b1b1b1b1b1b',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/MwaltherPersonV2.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/MwaltherPersonV2.ts
@@ -15,6 +15,8 @@ export type OsdkObjectLinks$MwaltherPersonV2 = {};
 export namespace MwaltherPersonV2 {
   export type PropertyKeys = 'mwaltherNam';
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      *   display name: 'prop1'
@@ -41,6 +43,7 @@ export interface MwaltherPersonV2 extends $InterfaceDefinition {
   osdkMetadata: typeof $osdkMetadata;
   type: 'interface';
   apiName: 'MwaltherPersonV2';
+  links: MwaltherPersonV2.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: MwaltherPersonV2.ObjectSet;
     props: MwaltherPersonV2.Props;
@@ -67,6 +70,7 @@ export const MwaltherPersonV2 = {
   type: 'interface',
   apiName: 'MwaltherPersonV2',
   osdkMetadata: $osdkMetadata,
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.interface.2fc1336c-6d4d-428f-9a4f-4f3ebfaf860e',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/MwaltherTestIdp.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/MwaltherTestIdp.ts
@@ -15,6 +15,8 @@ export type OsdkObjectLinks$MwaltherTestIdp = {};
 export namespace MwaltherTestIdp {
   export type PropertyKeys = 'mwaltherName' | 'idpAge' | 'mwaltherNam' | 'newProperty1';
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      *   display name: 'Details - Details',
@@ -55,6 +57,7 @@ export interface MwaltherTestIdp extends $InterfaceDefinition {
   osdkMetadata: typeof $osdkMetadata;
   type: 'interface';
   apiName: 'com.palantirfoundry.swirl.esong.MwaltherTestIdp';
+  links: MwaltherTestIdp.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: MwaltherTestIdp.ObjectSet;
     props: MwaltherTestIdp.Props;
@@ -95,6 +98,7 @@ export const MwaltherTestIdp = {
   type: 'interface',
   apiName: 'com.palantirfoundry.swirl.esong.MwaltherTestIdp',
   osdkMetadata: $osdkMetadata,
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.interface.19fcaed0-457d-4e4c-82b1-7e3933a61df3',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/NihalbCastingInterfaceB.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/NihalbCastingInterfaceB.ts
@@ -8,7 +8,9 @@ import type {
   Osdk as $Osdk,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export interface OsdkObjectLinks$NihalbCastingInterfaceB {
   nihalbCastingLinkedObjectTypeA: NihalbCastingLinkedObjectTypeA.ObjectSet;
@@ -16,6 +18,10 @@ export interface OsdkObjectLinks$NihalbCastingInterfaceB {
 
 export namespace NihalbCastingInterfaceB {
   export type PropertyKeys = 'interfaceProperty';
+
+  export interface LinkTokens {
+    readonly nihalbCastingLinkedObjectTypeA: $LinkDef<NihalbCastingInterfaceB, NihalbCastingLinkedObjectTypeA, 'many'>;
+  }
 
   export interface Props {
     /**
@@ -43,6 +49,7 @@ export interface NihalbCastingInterfaceB extends $InterfaceDefinition {
   osdkMetadata: typeof $osdkMetadata;
   type: 'interface';
   apiName: 'NihalbCastingInterfaceB';
+  links: NihalbCastingInterfaceB.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: NihalbCastingInterfaceB.ObjectSet;
     props: NihalbCastingInterfaceB.Props;
@@ -71,6 +78,15 @@ export const NihalbCastingInterfaceB = {
   type: 'interface',
   apiName: 'NihalbCastingInterfaceB',
   osdkMetadata: $osdkMetadata,
+  links: {
+    nihalbCastingLinkedObjectTypeA: $createLinkDef(
+      'NihalbCastingInterfaceB',
+      'nihalbCastingLinkedObjectTypeA',
+      'NihalbCastingLinkedObjectTypeA',
+      true,
+      true,
+    ),
+  },
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.interface.001b6854-774a-4ba4-9ea7-dedc05901e4f',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/NihalbCastingInterfaceTypeA.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/NihalbCastingInterfaceTypeA.ts
@@ -8,7 +8,9 @@ import type {
   Osdk as $Osdk,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export interface OsdkObjectLinks$NihalbCastingInterfaceTypeA {
   nihalbCastingLinkedObjectTypeA: NihalbCastingLinkedObjectTypeA.ObjectSet;
@@ -16,6 +18,14 @@ export interface OsdkObjectLinks$NihalbCastingInterfaceTypeA {
 
 export namespace NihalbCastingInterfaceTypeA {
   export type PropertyKeys = 'interfaceProperty';
+
+  export interface LinkTokens {
+    readonly nihalbCastingLinkedObjectTypeA: $LinkDef<
+      NihalbCastingInterfaceTypeA,
+      NihalbCastingLinkedObjectTypeA,
+      'many'
+    >;
+  }
 
   export interface Props {
     /**
@@ -43,6 +53,7 @@ export interface NihalbCastingInterfaceTypeA extends $InterfaceDefinition {
   osdkMetadata: typeof $osdkMetadata;
   type: 'interface';
   apiName: 'NihalbCastingInterfaceTypeA';
+  links: NihalbCastingInterfaceTypeA.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: NihalbCastingInterfaceTypeA.ObjectSet;
     props: NihalbCastingInterfaceTypeA.Props;
@@ -71,6 +82,15 @@ export const NihalbCastingInterfaceTypeA = {
   type: 'interface',
   apiName: 'NihalbCastingInterfaceTypeA',
   osdkMetadata: $osdkMetadata,
+  links: {
+    nihalbCastingLinkedObjectTypeA: $createLinkDef(
+      'NihalbCastingInterfaceTypeA',
+      'nihalbCastingLinkedObjectTypeA',
+      'NihalbCastingLinkedObjectTypeA',
+      true,
+      true,
+    ),
+  },
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.interface.daed91f9-ee83-4e6c-bfc7-a17c8ff9433c',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/NihalbCastingLinkedInterfaceTypeA.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/NihalbCastingLinkedInterfaceTypeA.ts
@@ -8,7 +8,9 @@ import type {
   Osdk as $Osdk,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export interface OsdkObjectLinks$NihalbCastingLinkedInterfaceTypeA {
   nihalbCastingInterfaceB: $SingleLinkAccessor<NihalbCastingInterfaceB>;
@@ -16,6 +18,10 @@ export interface OsdkObjectLinks$NihalbCastingLinkedInterfaceTypeA {
 
 export namespace NihalbCastingLinkedInterfaceTypeA {
   export type PropertyKeys = 'primaryKeyProp';
+
+  export interface LinkTokens {
+    readonly nihalbCastingInterfaceB: $LinkDef<NihalbCastingLinkedInterfaceTypeA, NihalbCastingInterfaceB, 'one'>;
+  }
 
   export interface Props {
     /**
@@ -44,6 +50,7 @@ export interface NihalbCastingLinkedInterfaceTypeA extends $InterfaceDefinition 
   osdkMetadata: typeof $osdkMetadata;
   type: 'interface';
   apiName: 'NihalbCastingLinkedInterfaceTypeA';
+  links: NihalbCastingLinkedInterfaceTypeA.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: NihalbCastingLinkedInterfaceTypeA.ObjectSet;
     props: NihalbCastingLinkedInterfaceTypeA.Props;
@@ -72,6 +79,15 @@ export const NihalbCastingLinkedInterfaceTypeA = {
   type: 'interface',
   apiName: 'NihalbCastingLinkedInterfaceTypeA',
   osdkMetadata: $osdkMetadata,
+  links: {
+    nihalbCastingInterfaceB: $createLinkDef(
+      'NihalbCastingLinkedInterfaceTypeA',
+      'nihalbCastingInterfaceB',
+      'NihalbCastingInterfaceB',
+      false,
+      true,
+    ),
+  },
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.interface.d3f8faae-48ea-44c6-8d43-687183d586c9',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/OsdkTestInterface.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/OsdkTestInterface.ts
@@ -15,6 +15,8 @@ export type OsdkObjectLinks$OsdkTestInterface = {};
 export namespace OsdkTestInterface {
   export type PropertyKeys = 'objectDescription';
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * (no ontology metadata)
@@ -41,6 +43,7 @@ export interface OsdkTestInterface extends $InterfaceDefinition {
   osdkMetadata: typeof $osdkMetadata;
   type: 'interface';
   apiName: 'OsdkTestInterface';
+  links: OsdkTestInterface.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: OsdkTestInterface.ObjectSet;
     props: OsdkTestInterface.Props;
@@ -67,6 +70,7 @@ export const OsdkTestInterface = {
   type: 'interface',
   apiName: 'OsdkTestInterface',
   osdkMetadata: $osdkMetadata,
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.interface.06c534fd-4f68-44d9-b268-72729a47eaab',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/TestAsTypeIltInterface.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/TestAsTypeIltInterface.ts
@@ -15,6 +15,8 @@ export type OsdkObjectLinks$TestAsTypeIltInterface = {};
 export namespace TestAsTypeIltInterface {
   export type PropertyKeys = 'com.palantir.defense.ontology.collateralConcernName';
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      *   display name: 'Name',
@@ -43,6 +45,7 @@ export interface TestAsTypeIltInterface extends $InterfaceDefinition {
   osdkMetadata: typeof $osdkMetadata;
   type: 'interface';
   apiName: 'TestAsTypeIltInterface';
+  links: TestAsTypeIltInterface.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: TestAsTypeIltInterface.ObjectSet;
     props: TestAsTypeIltInterface.Props;
@@ -71,6 +74,7 @@ export const TestAsTypeIltInterface = {
   type: 'interface',
   apiName: 'TestAsTypeIltInterface',
   osdkMetadata: $osdkMetadata,
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.interface.93463b40-940d-430d-9283-9eca82fa9aa4',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/bus_1.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/bus_1.ts
@@ -15,6 +15,8 @@ export type OsdkObjectLinks$bus_1 = {};
 export namespace bus_1 {
   export type PropertyKeys = 'vehicleId_1';
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      *   display name: 'Vehicle Id'
@@ -41,6 +43,7 @@ export interface bus_1 extends $InterfaceDefinition {
   osdkMetadata: typeof $osdkMetadata;
   type: 'interface';
   apiName: 'bus_1';
+  links: bus_1.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: bus_1.ObjectSet;
     props: bus_1.Props;
@@ -67,6 +70,7 @@ export const bus_1 = {
   type: 'interface',
   apiName: 'bus_1',
   osdkMetadata: $osdkMetadata,
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.interface.13ac66ef-d94e-4020-ac20-3285557149dd',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/mwaltherPerson.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/mwaltherPerson.ts
@@ -15,6 +15,8 @@ export type OsdkObjectLinks$mwaltherPerson = {};
 export namespace mwaltherPerson {
   export type PropertyKeys = 'age' | 'mwaltherName';
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      *   display name: 'Age (IDP)'
@@ -45,6 +47,7 @@ export interface mwaltherPerson extends $InterfaceDefinition {
   osdkMetadata: typeof $osdkMetadata;
   type: 'interface';
   apiName: 'mwaltherPerson';
+  links: mwaltherPerson.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: mwaltherPerson.ObjectSet;
     props: mwaltherPerson.Props;
@@ -75,6 +78,7 @@ export const mwaltherPerson = {
   type: 'interface',
   apiName: 'mwaltherPerson',
   osdkMetadata: $osdkMetadata,
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.interface.2bf99935-b656-4c38-87ff-5970ccb3f2a7',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/BgaoNflPlayer.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/BgaoNflPlayer.ts
@@ -19,6 +19,8 @@ export namespace BgaoNflPlayer {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * (no ontology metadata)
@@ -75,6 +77,7 @@ export interface BgaoNflPlayer extends $ObjectTypeDefinition {
   apiName: 'BgaoNflPlayer';
   primaryKeyApiName: 'id';
   primaryKeyType: 'string';
+  links: BgaoNflPlayer.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: BgaoNflPlayer.ObjectSet;
     props: BgaoNflPlayer.Props;
@@ -89,6 +92,7 @@ export interface BgaoNflPlayer extends $ObjectTypeDefinition {
       color: 'color';
     };
     implements: undefined;
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -139,6 +143,7 @@ export const BgaoNflPlayer = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'id',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.a.b.c.d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/BoundariesUsState.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/BoundariesUsState.ts
@@ -19,6 +19,8 @@ export namespace BoundariesUsState {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      *   display name: 'Geometry10M',
@@ -69,6 +71,7 @@ export interface BoundariesUsState extends $ObjectTypeDefinition {
   apiName: 'BoundariesUsState';
   primaryKeyApiName: 'usState';
   primaryKeyType: 'string';
+  links: BoundariesUsState.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: BoundariesUsState.ObjectSet;
     props: BoundariesUsState.Props;
@@ -83,6 +86,7 @@ export interface BoundariesUsState extends $ObjectTypeDefinition {
       color: 'color';
     };
     implements: undefined;
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -131,6 +135,7 @@ export const BoundariesUsState = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'usState',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.a.b.c.d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/BuilderDeploymentState.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/BuilderDeploymentState.ts
@@ -19,6 +19,8 @@ export namespace BuilderDeploymentState {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * (no ontology metadata)
@@ -55,6 +57,7 @@ export interface BuilderDeploymentState extends $ObjectTypeDefinition {
   apiName: 'BuilderDeploymentState';
   primaryKeyApiName: 'skuId';
   primaryKeyType: 'string';
+  links: BuilderDeploymentState.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: BuilderDeploymentState.ObjectSet;
     props: BuilderDeploymentState.Props;
@@ -69,6 +72,7 @@ export interface BuilderDeploymentState extends $ObjectTypeDefinition {
       color: 'color';
     };
     implements: undefined;
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -103,6 +107,7 @@ export const BuilderDeploymentState = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'skuId',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'rid.a.b.c.d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Country_1.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Country_1.ts
@@ -13,13 +13,19 @@ import type {
   OsdkObject as $OsdkObject,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export namespace Country_1 {
   export type PropertyKeys = 'airportCountryIsoCode' | 'airportCountryName';
 
   export interface Links {
     readonly stateTerritory: StateTerritory.ObjectSet;
+  }
+
+  export interface LinkTokens {
+    readonly stateTerritory: $LinkDef<Country_1, StateTerritory, 'many'>;
   }
 
   export interface Props {
@@ -63,6 +69,7 @@ export interface Country_1 extends $ObjectTypeDefinition {
   apiName: 'Country_1';
   primaryKeyApiName: 'airportCountryName';
   primaryKeyType: 'string';
+  links: Country_1.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: Country_1.ObjectSet;
     props: Country_1.Props;
@@ -77,6 +84,7 @@ export interface Country_1 extends $ObjectTypeDefinition {
       name: 'cube';
     };
     implements: [];
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {
@@ -118,6 +126,9 @@ export const Country_1 = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'airportCountryName',
   primaryKeyType: 'string',
+  links: {
+    stateTerritory: $createLinkDef('Country_1', 'stateTerritory', 'StateTerritory', true, false),
+  },
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.0a276176-8d93-489e-93b4-77673de56b9e',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/DherlihyComplexObject.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/DherlihyComplexObject.ts
@@ -19,6 +19,8 @@ export namespace DherlihyComplexObject {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * (no ontology metadata)
@@ -55,6 +57,7 @@ export interface DherlihyComplexObject extends $ObjectTypeDefinition {
   apiName: 'DherlihyComplexObject';
   primaryKeyApiName: 'id';
   primaryKeyType: 'string';
+  links: DherlihyComplexObject.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: DherlihyComplexObject.ObjectSet;
     props: DherlihyComplexObject.Props;
@@ -69,6 +72,7 @@ export interface DherlihyComplexObject extends $ObjectTypeDefinition {
       color: 'color';
     };
     implements: undefined;
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -103,6 +107,7 @@ export const DherlihyComplexObject = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'id',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'rid.a.b.c.d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Employee.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Employee.ts
@@ -13,7 +13,9 @@ import type {
   OsdkObject as $OsdkObject,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export namespace Employee {
   export type PropertyKeys =
@@ -34,6 +36,12 @@ export namespace Employee {
     readonly lead: $SingleLinkAccessor<Employee>;
     readonly peeps: Employee.ObjectSet;
     readonly ventures: Venture.ObjectSet;
+  }
+
+  export interface LinkTokens {
+    readonly lead: $LinkDef<Employee, Employee, 'one'>;
+    readonly peeps: $LinkDef<Employee, Employee, 'many'>;
+    readonly ventures: $LinkDef<Employee, Venture, 'many'>;
   }
 
   export interface Props {
@@ -108,6 +116,7 @@ export interface Employee extends $ObjectTypeDefinition {
   apiName: 'Employee';
   primaryKeyApiName: 'id';
   primaryKeyType: 'string';
+  links: Employee.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: Employee.ObjectSet;
     props: Employee.Props;
@@ -122,6 +131,9 @@ export interface Employee extends $ObjectTypeDefinition {
       color: 'color';
     };
     implements: ['FooInterface'];
+    interfaceLinkMap: {
+      FooInterface: {};
+    };
     interfaceMap: {
       FooInterface: {
         name: 'firstName';
@@ -206,6 +218,11 @@ export const Employee = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'id',
   primaryKeyType: 'string',
+  links: {
+    lead: $createLinkDef('Employee', 'lead', 'Employee', false, false),
+    peeps: $createLinkDef('Employee', 'peeps', 'Employee', true, false),
+    ventures: $createLinkDef('Employee', 'ventures', 'Venture', true, false),
+  },
   internalDoNotUseMetadata: {
     rid: 'rid.a.b.c.d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/EsongIssues.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/EsongIssues.ts
@@ -13,7 +13,9 @@ import type {
   OsdkObject as $OsdkObject,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export namespace EsongIssues {
   export type PropertyKeys =
@@ -29,6 +31,11 @@ export namespace EsongIssues {
   export interface Links {
     readonly esongPds: $SingleLinkAccessor<EsongPds>;
     readonly esongPdsM2m: EsongPds.ObjectSet;
+  }
+
+  export interface LinkTokens {
+    readonly esongPds: $LinkDef<EsongIssues, EsongPds, 'one'>;
+    readonly esongPdsM2m: $LinkDef<EsongIssues, EsongPds, 'many'>;
   }
 
   export interface Props {
@@ -119,6 +126,7 @@ export interface EsongIssues extends $ObjectTypeDefinition {
   apiName: 'EsongIssues';
   primaryKeyApiName: 'id';
   primaryKeyType: 'integer';
+  links: EsongIssues.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: EsongIssues.ObjectSet;
     props: EsongIssues.Props;
@@ -133,6 +141,11 @@ export interface EsongIssues extends $ObjectTypeDefinition {
       name: 'cube';
     };
     implements: ['EsongInterfaceA', 'EsongInterfaceC', 'EsongInterfaceWithIlts'];
+    interfaceLinkMap: {
+      EsongInterfaceA: {};
+      EsongInterfaceC: {};
+      EsongInterfaceWithIlts: {};
+    };
     interfaceMap: {
       EsongInterfaceA: {
         esongSptA: 'label';
@@ -242,6 +255,10 @@ export const EsongIssues = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'id',
   primaryKeyType: 'integer',
+  links: {
+    esongPds: $createLinkDef('EsongIssues', 'esongPds', 'EsongPds', false, false),
+    esongPdsM2m: $createLinkDef('EsongIssues', 'esongPdsM2m', 'EsongPds', true, false),
+  },
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.9e50a0d3-5b89-41f5-a894-b0e9bb388950',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/EsongPds.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/EsongPds.ts
@@ -13,7 +13,9 @@ import type {
   OsdkObject as $OsdkObject,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export namespace EsongPds {
   export type PropertyKeys = 'assignee' | 'createdAt' | 'id' | 'priority' | 'status' | 'title';
@@ -21,6 +23,11 @@ export namespace EsongPds {
   export interface Links {
     readonly esongIssues: $SingleLinkAccessor<EsongIssues>;
     readonly esongIssuesM2m: EsongIssues.ObjectSet;
+  }
+
+  export interface LinkTokens {
+    readonly esongIssues: $LinkDef<EsongPds, EsongIssues, 'one'>;
+    readonly esongIssuesM2m: $LinkDef<EsongPds, EsongIssues, 'many'>;
   }
 
   export interface Props {
@@ -95,6 +102,7 @@ export interface EsongPds extends $ObjectTypeDefinition {
   apiName: 'EsongPds';
   primaryKeyApiName: 'id';
   primaryKeyType: 'integer';
+  links: EsongPds.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: EsongPds.ObjectSet;
     props: EsongPds.Props;
@@ -109,6 +117,7 @@ export interface EsongPds extends $ObjectTypeDefinition {
       name: 'cube';
     };
     implements: [];
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {
@@ -182,6 +191,10 @@ export const EsongPds = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'id',
   primaryKeyType: 'integer',
+  links: {
+    esongIssues: $createLinkDef('EsongPds', 'esongIssues', 'EsongIssues', false, false),
+    esongIssuesM2m: $createLinkDef('EsongPds', 'esongIssuesM2m', 'EsongIssues', true, false),
+  },
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.afa55844-81e8-4a1f-9b8e-bf51a9938a4d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/FintrafficAis.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/FintrafficAis.ts
@@ -19,6 +19,8 @@ export namespace FintrafficAis {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * (no ontology metadata)
@@ -71,6 +73,7 @@ export interface FintrafficAis extends $ObjectTypeDefinition {
   apiName: 'FintrafficAis';
   primaryKeyApiName: 'mmsi';
   primaryKeyType: 'string';
+  links: FintrafficAis.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: FintrafficAis.ObjectSet;
     props: FintrafficAis.Props;
@@ -85,6 +88,7 @@ export interface FintrafficAis extends $ObjectTypeDefinition {
       color: 'color';
     };
     implements: undefined;
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -135,6 +139,7 @@ export const FintrafficAis = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'mmsi',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.a.b.c.d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/GraphqlFormatting.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/GraphqlFormatting.ts
@@ -98,6 +98,8 @@ export namespace GraphqlFormatting {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * @experimental
@@ -764,6 +766,7 @@ export interface GraphqlFormatting extends $ObjectTypeDefinition {
   apiName: 'GraphqlFormatting';
   primaryKeyApiName: 'stringPlain';
   primaryKeyType: 'string';
+  links: GraphqlFormatting.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: GraphqlFormatting.ObjectSet;
     props: GraphqlFormatting.Props;
@@ -778,6 +781,7 @@ export interface GraphqlFormatting extends $ObjectTypeDefinition {
       name: 'cube';
     };
     implements: [];
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -1444,6 +1448,7 @@ export const GraphqlFormatting = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'stringPlain',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.353eb83c-df7e-4c97-a362-1e94689869bc',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/GtfsTripTrackObject.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/GtfsTripTrackObject.ts
@@ -19,6 +19,8 @@ export namespace GtfsTripTrackObject {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * (no ontology metadata)
@@ -55,6 +57,7 @@ export interface GtfsTripTrackObject extends $ObjectTypeDefinition {
   apiName: 'GtfsTripTrackObject';
   primaryKeyApiName: 'entityId';
   primaryKeyType: 'string';
+  links: GtfsTripTrackObject.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: GtfsTripTrackObject.ObjectSet;
     props: GtfsTripTrackObject.Props;
@@ -69,6 +72,7 @@ export interface GtfsTripTrackObject extends $ObjectTypeDefinition {
       color: 'color';
     };
     implements: undefined;
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -103,6 +107,7 @@ export const GtfsTripTrackObject = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'entityId',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.a.b.c.d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/MasonHeavyEquipment.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/MasonHeavyEquipment.ts
@@ -12,7 +12,9 @@ import type {
   OsdkObject as $OsdkObject,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export namespace MasonHeavyEquipment {
   export type PropertyKeys =
@@ -45,6 +47,10 @@ export namespace MasonHeavyEquipment {
 
   export interface Links {
     readonly masonHeavyEquipment: $SingleLinkAccessor<MasonHeavyEquipment>;
+  }
+
+  export interface LinkTokens {
+    readonly masonHeavyEquipment: $LinkDef<MasonHeavyEquipment, MasonHeavyEquipment, 'one'>;
   }
 
   export interface Props {
@@ -477,6 +483,7 @@ export interface MasonHeavyEquipment extends $ObjectTypeDefinition {
   apiName: 'MasonHeavyEquipment';
   primaryKeyApiName: 'id';
   primaryKeyType: 'string';
+  links: MasonHeavyEquipment.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: MasonHeavyEquipment.ObjectSet;
     props: MasonHeavyEquipment.Props;
@@ -491,6 +498,7 @@ export interface MasonHeavyEquipment extends $ObjectTypeDefinition {
       name: 'cube';
     };
     implements: [];
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {
@@ -947,6 +955,15 @@ export const MasonHeavyEquipment = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'id',
   primaryKeyType: 'string',
+  links: {
+    masonHeavyEquipment: $createLinkDef(
+      'MasonHeavyEquipment',
+      'masonHeavyEquipment',
+      'MasonHeavyEquipment',
+      false,
+      false,
+    ),
+  },
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.73756c21-5a63-47ae-af39-2f22bedd8ec2',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/MasonMovie.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/MasonMovie.ts
@@ -19,6 +19,8 @@ export namespace MasonMovie {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * @experimental
@@ -91,6 +93,7 @@ export interface MasonMovie extends $ObjectTypeDefinition {
   apiName: 'MasonMovie';
   primaryKeyApiName: 'movie';
   primaryKeyType: 'string';
+  links: MasonMovie.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: MasonMovie.ObjectSet;
     props: MasonMovie.Props;
@@ -105,6 +108,7 @@ export interface MasonMovie extends $ObjectTypeDefinition {
       name: 'cube';
     };
     implements: [];
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -175,6 +179,7 @@ export const MasonMovie = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'movie',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.65a5444c-452e-450e-ac28-04f0028a243d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/MatthewvsDevOrderEmbedding.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/MatthewvsDevOrderEmbedding.ts
@@ -19,6 +19,8 @@ export namespace MatthewvsDevOrderEmbedding {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * @experimental
@@ -59,6 +61,7 @@ export interface MatthewvsDevOrderEmbedding extends $ObjectTypeDefinition {
   apiName: 'MatthewvsDevOrderEmbedding';
   primaryKeyApiName: 'orderId';
   primaryKeyType: 'string';
+  links: MatthewvsDevOrderEmbedding.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: MatthewvsDevOrderEmbedding.ObjectSet;
     props: MatthewvsDevOrderEmbedding.Props;
@@ -73,6 +76,7 @@ export interface MatthewvsDevOrderEmbedding extends $ObjectTypeDefinition {
       color: 'color';
     };
     implements: undefined;
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -111,6 +115,7 @@ export const MatthewvsDevOrderEmbedding = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'orderId',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'rid.a.b.c.d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/McAirportStruct.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/McAirportStruct.ts
@@ -19,6 +19,8 @@ export namespace McAirportStruct {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      *   display name: 'Airport Name'
@@ -69,6 +71,7 @@ export interface McAirportStruct extends $ObjectTypeDefinition {
   apiName: 'McAirportStruct';
   primaryKeyApiName: 'airportName';
   primaryKeyType: 'string';
+  links: McAirportStruct.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: McAirportStruct.ObjectSet;
     props: McAirportStruct.Props;
@@ -83,6 +86,7 @@ export interface McAirportStruct extends $ObjectTypeDefinition {
       color: 'color';
     };
     implements: undefined;
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -125,6 +129,7 @@ export const McAirportStruct = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'airportName',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'rid.a.b.c.d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/MnayanOsdkMediaObject.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/MnayanOsdkMediaObject.ts
@@ -19,6 +19,8 @@ export namespace MnayanOsdkMediaObject {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * (no ontology metadata)
@@ -55,6 +57,7 @@ export interface MnayanOsdkMediaObject extends $ObjectTypeDefinition {
   apiName: 'MnayanOsdkMediaObject';
   primaryKeyApiName: 'id';
   primaryKeyType: 'string';
+  links: MnayanOsdkMediaObject.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: MnayanOsdkMediaObject.ObjectSet;
     props: MnayanOsdkMediaObject.Props;
@@ -69,6 +72,7 @@ export interface MnayanOsdkMediaObject extends $ObjectTypeDefinition {
       color: 'color';
     };
     implements: undefined;
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -103,6 +107,7 @@ export const MnayanOsdkMediaObject = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'id',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'rid.a.b.c.d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/MtaBus.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/MtaBus.ts
@@ -19,6 +19,8 @@ export namespace MtaBus {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * (no ontology metadata)
@@ -59,6 +61,7 @@ export interface MtaBus extends $ObjectTypeDefinition {
   apiName: 'MtaBus';
   primaryKeyApiName: 'vehicleId';
   primaryKeyType: 'string';
+  links: MtaBus.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: MtaBus.ObjectSet;
     props: MtaBus.Props;
@@ -73,6 +76,7 @@ export interface MtaBus extends $ObjectTypeDefinition {
       color: 'color';
     };
     implements: undefined;
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -111,6 +115,7 @@ export const MtaBus = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'vehicleId',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.a.b.c.d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/MwaltherPersonOt.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/MwaltherPersonOt.ts
@@ -19,6 +19,8 @@ export namespace MwaltherPersonOt {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * @experimental
@@ -67,6 +69,7 @@ export interface MwaltherPersonOt extends $ObjectTypeDefinition {
   apiName: 'MwaltherPersonOt';
   primaryKeyApiName: 'id';
   primaryKeyType: 'string';
+  links: MwaltherPersonOt.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: MwaltherPersonOt.ObjectSet;
     props: MwaltherPersonOt.Props;
@@ -86,6 +89,12 @@ export interface MwaltherPersonOt extends $ObjectTypeDefinition {
       'MwaltherPersonV2',
       'MwaltherTestUpgrade',
     ];
+    interfaceLinkMap: {
+      'com.palantirfoundry.swirl.esong.MwaltherTest': {};
+      'com.palantirfoundry.swirl.esong.MwaltherTestIdp': {};
+      MwaltherPersonV2: {};
+      MwaltherTestUpgrade: {};
+    };
     interfaceMap: {
       'com.palantirfoundry.swirl.esong.MwaltherTest': {
         mwaltherVtInputTest: 'name';
@@ -164,6 +173,7 @@ export const MwaltherPersonOt = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'id',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.4ee4fa8d-e080-4317-be09-5e900223f4d5',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/NbaPlayer.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/NbaPlayer.ts
@@ -19,6 +19,8 @@ export namespace NbaPlayer {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * (no ontology metadata)
@@ -63,6 +65,7 @@ export interface NbaPlayer extends $ObjectTypeDefinition {
   apiName: 'NbaPlayer';
   primaryKeyApiName: 'id';
   primaryKeyType: 'string';
+  links: NbaPlayer.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: NbaPlayer.ObjectSet;
     props: NbaPlayer.Props;
@@ -77,6 +80,9 @@ export interface NbaPlayer extends $ObjectTypeDefinition {
       color: 'color';
     };
     implements: ['Athlete'];
+    interfaceLinkMap: {
+      Athlete: {};
+    };
     interfaceMap: {
       Athlete: {
         jerseyNumber: 'jerseyNumber';
@@ -131,6 +137,7 @@ export const NbaPlayer = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'id',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.a.b.c.d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/NihalbCastingLinkedObjectTypeA.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/NihalbCastingLinkedObjectTypeA.ts
@@ -15,7 +15,9 @@ import type {
   OsdkObject as $OsdkObject,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export namespace NihalbCastingLinkedObjectTypeA {
   export type PropertyKeys = 'foreignKeyProperty' | 'primaryKey_';
@@ -24,6 +26,12 @@ export namespace NihalbCastingLinkedObjectTypeA {
     readonly nihalbCastingObjectTypeA: $SingleLinkAccessor<NihalbCastingObjectTypeA>;
     readonly nihalbCastingObjectTypeB: $SingleLinkAccessor<NihalbCastingObjectTypeB>;
     readonly nihalbCastingObjectTypeC: $SingleLinkAccessor<NihalbCastingObjectTypeC>;
+  }
+
+  export interface LinkTokens {
+    readonly nihalbCastingObjectTypeA: $LinkDef<NihalbCastingLinkedObjectTypeA, NihalbCastingObjectTypeA, 'one'>;
+    readonly nihalbCastingObjectTypeB: $LinkDef<NihalbCastingLinkedObjectTypeA, NihalbCastingObjectTypeB, 'one'>;
+    readonly nihalbCastingObjectTypeC: $LinkDef<NihalbCastingLinkedObjectTypeA, NihalbCastingObjectTypeC, 'one'>;
   }
 
   export interface Props {
@@ -67,6 +75,7 @@ export interface NihalbCastingLinkedObjectTypeA extends $ObjectTypeDefinition {
   apiName: 'NihalbCastingLinkedObjectTypeA';
   primaryKeyApiName: 'primaryKey_';
   primaryKeyType: 'string';
+  links: NihalbCastingLinkedObjectTypeA.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: NihalbCastingLinkedObjectTypeA.ObjectSet;
     props: NihalbCastingLinkedObjectTypeA.Props;
@@ -81,6 +90,11 @@ export interface NihalbCastingLinkedObjectTypeA extends $ObjectTypeDefinition {
       name: 'cube';
     };
     implements: ['NihalbCastingLinkedInterfaceTypeA'];
+    interfaceLinkMap: {
+      NihalbCastingLinkedInterfaceTypeA: {
+        nihalbCastingInterfaceB: 'nihalbCastingObjectTypeC';
+      };
+    };
     interfaceMap: {
       NihalbCastingLinkedInterfaceTypeA: {
         primaryKeyProp: 'primaryKey_';
@@ -131,6 +145,29 @@ export const NihalbCastingLinkedObjectTypeA = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'primaryKey_',
   primaryKeyType: 'string',
+  links: {
+    nihalbCastingObjectTypeA: $createLinkDef(
+      'NihalbCastingLinkedObjectTypeA',
+      'nihalbCastingObjectTypeA',
+      'NihalbCastingObjectTypeA',
+      false,
+      false,
+    ),
+    nihalbCastingObjectTypeB: $createLinkDef(
+      'NihalbCastingLinkedObjectTypeA',
+      'nihalbCastingObjectTypeB',
+      'NihalbCastingObjectTypeB',
+      false,
+      false,
+    ),
+    nihalbCastingObjectTypeC: $createLinkDef(
+      'NihalbCastingLinkedObjectTypeA',
+      'nihalbCastingObjectTypeC',
+      'NihalbCastingObjectTypeC',
+      false,
+      false,
+    ),
+  },
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.e257ea9e-8127-471f-9253-d641f5585d26',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/NihalbCastingObjectTypeA.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/NihalbCastingObjectTypeA.ts
@@ -13,13 +13,23 @@ import type {
   OsdkObject as $OsdkObject,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export namespace NihalbCastingObjectTypeA {
   export type PropertyKeys = 'additionalProperty' | 'primaryKey_';
 
   export interface Links {
     readonly nihalbCastingLinkedObjectTypeAs: NihalbCastingLinkedObjectTypeA.ObjectSet;
+  }
+
+  export interface LinkTokens {
+    readonly nihalbCastingLinkedObjectTypeAs: $LinkDef<
+      NihalbCastingObjectTypeA,
+      NihalbCastingLinkedObjectTypeA,
+      'many'
+    >;
   }
 
   export interface Props {
@@ -62,6 +72,7 @@ export interface NihalbCastingObjectTypeA extends $ObjectTypeDefinition {
   apiName: 'NihalbCastingObjectTypeA';
   primaryKeyApiName: 'primaryKey_';
   primaryKeyType: 'string';
+  links: NihalbCastingObjectTypeA.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: NihalbCastingObjectTypeA.ObjectSet;
     props: NihalbCastingObjectTypeA.Props;
@@ -76,6 +87,11 @@ export interface NihalbCastingObjectTypeA extends $ObjectTypeDefinition {
       name: 'cube';
     };
     implements: ['NihalbCastingInterfaceTypeA'];
+    interfaceLinkMap: {
+      NihalbCastingInterfaceTypeA: {
+        nihalbCastingLinkedObjectTypeA: 'nihalbCastingLinkedObjectTypeAs';
+      };
+    };
     interfaceMap: {
       NihalbCastingInterfaceTypeA: {
         interfaceProperty: 'primaryKey_';
@@ -124,6 +140,15 @@ export const NihalbCastingObjectTypeA = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'primaryKey_',
   primaryKeyType: 'string',
+  links: {
+    nihalbCastingLinkedObjectTypeAs: $createLinkDef(
+      'NihalbCastingObjectTypeA',
+      'nihalbCastingLinkedObjectTypeAs',
+      'NihalbCastingLinkedObjectTypeA',
+      true,
+      false,
+    ),
+  },
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.47776705-2ee2-4f59-af48-da192cd42456',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/NihalbCastingObjectTypeB.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/NihalbCastingObjectTypeB.ts
@@ -13,13 +13,23 @@ import type {
   OsdkObject as $OsdkObject,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export namespace NihalbCastingObjectTypeB {
   export type PropertyKeys = 'additionalProperty' | 'primaryKey_';
 
   export interface Links {
     readonly nihalbCastingLinkedObjectTypeAs: NihalbCastingLinkedObjectTypeA.ObjectSet;
+  }
+
+  export interface LinkTokens {
+    readonly nihalbCastingLinkedObjectTypeAs: $LinkDef<
+      NihalbCastingObjectTypeB,
+      NihalbCastingLinkedObjectTypeA,
+      'many'
+    >;
   }
 
   export interface Props {
@@ -62,6 +72,7 @@ export interface NihalbCastingObjectTypeB extends $ObjectTypeDefinition {
   apiName: 'NihalbCastingObjectTypeB';
   primaryKeyApiName: 'primaryKey_';
   primaryKeyType: 'string';
+  links: NihalbCastingObjectTypeB.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: NihalbCastingObjectTypeB.ObjectSet;
     props: NihalbCastingObjectTypeB.Props;
@@ -76,6 +87,14 @@ export interface NihalbCastingObjectTypeB extends $ObjectTypeDefinition {
       name: 'cube';
     };
     implements: ['NihalbCastingInterfaceB', 'NihalbCastingInterfaceTypeA'];
+    interfaceLinkMap: {
+      NihalbCastingInterfaceB: {
+        nihalbCastingLinkedObjectTypeA: 'nihalbCastingLinkedObjectTypeAs';
+      };
+      NihalbCastingInterfaceTypeA: {
+        nihalbCastingLinkedObjectTypeA: 'nihalbCastingLinkedObjectTypeAs';
+      };
+    };
     interfaceMap: {
       NihalbCastingInterfaceB: {
         interfaceProperty: 'primaryKey_';
@@ -130,6 +149,15 @@ export const NihalbCastingObjectTypeB = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'primaryKey_',
   primaryKeyType: 'string',
+  links: {
+    nihalbCastingLinkedObjectTypeAs: $createLinkDef(
+      'NihalbCastingObjectTypeB',
+      'nihalbCastingLinkedObjectTypeAs',
+      'NihalbCastingLinkedObjectTypeA',
+      true,
+      false,
+    ),
+  },
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.66898c81-9a3f-4f8b-937a-6934f6d9f660',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/NihalbCastingObjectTypeC.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/NihalbCastingObjectTypeC.ts
@@ -13,13 +13,23 @@ import type {
   OsdkObject as $OsdkObject,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export namespace NihalbCastingObjectTypeC {
   export type PropertyKeys = 'additionalProperty' | 'primaryKey_';
 
   export interface Links {
     readonly nihalbCastingLinkedObjectTypeAs: NihalbCastingLinkedObjectTypeA.ObjectSet;
+  }
+
+  export interface LinkTokens {
+    readonly nihalbCastingLinkedObjectTypeAs: $LinkDef<
+      NihalbCastingObjectTypeC,
+      NihalbCastingLinkedObjectTypeA,
+      'many'
+    >;
   }
 
   export interface Props {
@@ -62,6 +72,7 @@ export interface NihalbCastingObjectTypeC extends $ObjectTypeDefinition {
   apiName: 'NihalbCastingObjectTypeC';
   primaryKeyApiName: 'primaryKey_';
   primaryKeyType: 'string';
+  links: NihalbCastingObjectTypeC.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: NihalbCastingObjectTypeC.ObjectSet;
     props: NihalbCastingObjectTypeC.Props;
@@ -76,6 +87,11 @@ export interface NihalbCastingObjectTypeC extends $ObjectTypeDefinition {
       name: 'cube';
     };
     implements: ['NihalbCastingInterfaceB'];
+    interfaceLinkMap: {
+      NihalbCastingInterfaceB: {
+        nihalbCastingLinkedObjectTypeA: 'nihalbCastingLinkedObjectTypeAs';
+      };
+    };
     interfaceMap: {
       NihalbCastingInterfaceB: {
         interfaceProperty: 'primaryKey_';
@@ -124,6 +140,15 @@ export const NihalbCastingObjectTypeC = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'primaryKey_',
   primaryKeyType: 'string',
+  links: {
+    nihalbCastingLinkedObjectTypeAs: $createLinkDef(
+      'NihalbCastingObjectTypeC',
+      'nihalbCastingLinkedObjectTypeAs',
+      'NihalbCastingLinkedObjectTypeA',
+      true,
+      false,
+    ),
+  },
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.cf0cc2e5-f032-4659-9f5a-aec285317898',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/ObjectTypeWithAllPropertyTypes.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/ObjectTypeWithAllPropertyTypes.ts
@@ -50,6 +50,8 @@ export namespace ObjectTypeWithAllPropertyTypes {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * (no ontology metadata)
@@ -199,6 +201,7 @@ export interface ObjectTypeWithAllPropertyTypes extends $ObjectTypeDefinition {
   apiName: 'ObjectTypeWithAllPropertyTypes';
   primaryKeyApiName: 'id';
   primaryKeyType: 'integer';
+  links: ObjectTypeWithAllPropertyTypes.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: ObjectTypeWithAllPropertyTypes.ObjectSet;
     props: ObjectTypeWithAllPropertyTypes.Props;
@@ -213,6 +216,7 @@ export interface ObjectTypeWithAllPropertyTypes extends $ObjectTypeDefinition {
       color: 'color';
     };
     implements: undefined;
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -359,6 +363,7 @@ export const ObjectTypeWithAllPropertyTypes = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'id',
   primaryKeyType: 'integer',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'rid.a.b.c.d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/OsdkTestObject.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/OsdkTestObject.ts
@@ -19,6 +19,8 @@ export namespace OsdkTestObject {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      *   display name: 'Description'
@@ -73,6 +75,7 @@ export interface OsdkTestObject extends $ObjectTypeDefinition {
   apiName: 'OsdkTestObject';
   primaryKeyApiName: 'primaryKey_';
   primaryKeyType: 'string';
+  links: OsdkTestObject.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: OsdkTestObject.ObjectSet;
     props: OsdkTestObject.Props;
@@ -87,6 +90,10 @@ export interface OsdkTestObject extends $ObjectTypeDefinition {
       name: 'cube';
     };
     implements: ['FooInterface', 'OsdkTestInterface'];
+    interfaceLinkMap: {
+      FooInterface: {};
+      OsdkTestInterface: {};
+    };
     interfaceMap: {
       FooInterface: {
         name: 'osdkObjectName';
@@ -149,6 +156,7 @@ export const OsdkTestObject = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'primaryKey_',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.ba4a949c-547a-45de-9c78-b772bb55acfb',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Person.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Person.ts
@@ -13,7 +13,9 @@ import type {
   OsdkObject as $OsdkObject,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export namespace Person {
   export type PropertyKeys = 'email';
@@ -21,6 +23,11 @@ export namespace Person {
   export interface Links {
     readonly Friends: Person.ObjectSet;
     readonly Todos: Todo.ObjectSet;
+  }
+
+  export interface LinkTokens {
+    readonly Friends: $LinkDef<Person, Person, 'many'>;
+    readonly Todos: $LinkDef<Person, Todo, 'many'>;
   }
 
   export interface Props {
@@ -51,6 +58,7 @@ export interface Person extends $ObjectTypeDefinition {
   apiName: 'Person';
   primaryKeyApiName: 'email';
   primaryKeyType: 'string';
+  links: Person.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: Person.ObjectSet;
     props: Person.Props;
@@ -65,6 +73,7 @@ export interface Person extends $ObjectTypeDefinition {
       color: 'color';
     };
     implements: undefined;
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {
@@ -94,6 +103,10 @@ export const Person = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'email',
   primaryKeyType: 'string',
+  links: {
+    Friends: $createLinkDef('Person', 'Friends', 'Person', true, false),
+    Todos: $createLinkDef('Person', 'Todos', 'Todo', true, false),
+  },
   internalDoNotUseMetadata: {
     rid: 'rid.a.b.c.d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/ReducerTest.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/ReducerTest.ts
@@ -25,6 +25,8 @@ export namespace ReducerTest {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * @experimental
@@ -101,6 +103,7 @@ export interface ReducerTest extends $ObjectTypeDefinition {
   apiName: 'ReducerTest';
   primaryKeyApiName: 'primaryKey_';
   primaryKeyType: 'string';
+  links: ReducerTest.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: ReducerTest.ObjectSet;
     props: ReducerTest.Props;
@@ -115,6 +118,9 @@ export interface ReducerTest extends $ObjectTypeDefinition {
       name: 'cube';
     };
     implements: ['ReducerTestInterface'];
+    interfaceLinkMap: {
+      ReducerTestInterface: {};
+    };
     interfaceMap: {
       ReducerTestInterface: {
         stringFromArrayFromAlreadyReduced: 'stringArray';
@@ -195,6 +201,7 @@ export const ReducerTest = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'primaryKey_',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.4069c2c9-9497-45ec-8fa2-02caf0c261e9',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/RhemmingsObjectWithGtsrProperty2.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/RhemmingsObjectWithGtsrProperty2.ts
@@ -19,6 +19,8 @@ export namespace RhemmingsObjectWithGtsrProperty2 {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * (no ontology metadata)
@@ -64,6 +66,7 @@ export interface RhemmingsObjectWithGtsrProperty2 extends $ObjectTypeDefinition 
   apiName: 'RhemmingsObjectWithGtsrProperty2';
   primaryKeyApiName: 'id';
   primaryKeyType: 'string';
+  links: RhemmingsObjectWithGtsrProperty2.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: RhemmingsObjectWithGtsrProperty2.ObjectSet;
     props: RhemmingsObjectWithGtsrProperty2.Props;
@@ -78,6 +81,7 @@ export interface RhemmingsObjectWithGtsrProperty2 extends $ObjectTypeDefinition 
       color: 'color';
     };
     implements: undefined;
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -120,6 +124,7 @@ export const RhemmingsObjectWithGtsrProperty2 = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'id',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.a.b.c.d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/ScenarioTestOsdk.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/ScenarioTestOsdk.ts
@@ -19,6 +19,8 @@ export namespace ScenarioTestOsdk {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * @experimental
@@ -67,6 +69,7 @@ export interface ScenarioTestOsdk extends $ObjectTypeDefinition {
   apiName: 'ScenarioTestOsdk';
   primaryKeyApiName: 'primaryKey_';
   primaryKeyType: 'string';
+  links: ScenarioTestOsdk.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: ScenarioTestOsdk.ObjectSet;
     props: ScenarioTestOsdk.Props;
@@ -81,6 +84,7 @@ export interface ScenarioTestOsdk extends $ObjectTypeDefinition {
       name: 'cube';
     };
     implements: [];
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -127,6 +131,7 @@ export const ScenarioTestOsdk = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'primaryKey_',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.ec8dc938-1a0b-45cd-96fd-68752f1ab199',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/SotSensor.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/SotSensor.ts
@@ -19,6 +19,8 @@ export namespace SotSensor {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      *   display name: 'Is Enum'
@@ -63,6 +65,7 @@ export interface SotSensor extends $ObjectTypeDefinition {
   apiName: 'SotSensor';
   primaryKeyApiName: 'seriesId';
   primaryKeyType: 'string';
+  links: SotSensor.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: SotSensor.ObjectSet;
     props: SotSensor.Props;
@@ -77,6 +80,7 @@ export interface SotSensor extends $ObjectTypeDefinition {
       color: 'color';
     };
     implements: undefined;
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -119,6 +123,7 @@ export const SotSensor = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'seriesId',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'rid.a.b.c.d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/StateTerritory.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/StateTerritory.ts
@@ -13,13 +13,19 @@ import type {
   OsdkObject as $OsdkObject,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export namespace StateTerritory {
   export type PropertyKeys = 'airportStateCode' | 'airportStateName' | 'country';
 
   export interface Links {
     readonly country1: $SingleLinkAccessor<Country_1>;
+  }
+
+  export interface LinkTokens {
+    readonly country1: $LinkDef<StateTerritory, Country_1, 'one'>;
   }
 
   export interface Props {
@@ -58,6 +64,7 @@ export interface StateTerritory extends $ObjectTypeDefinition {
   apiName: 'StateTerritory';
   primaryKeyApiName: 'airportStateName';
   primaryKeyType: 'string';
+  links: StateTerritory.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: StateTerritory.ObjectSet;
     props: StateTerritory.Props;
@@ -72,6 +79,7 @@ export interface StateTerritory extends $ObjectTypeDefinition {
       name: 'cube';
     };
     implements: [];
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {
@@ -108,6 +116,9 @@ export const StateTerritory = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'airportStateName',
   primaryKeyType: 'string',
+  links: {
+    country1: $createLinkDef('StateTerritory', 'country1', 'Country_1', false, false),
+  },
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.98f324e1-b8f4-42ef-aee7-5c4a1494ce5e',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/StructPerson.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/StructPerson.ts
@@ -19,6 +19,8 @@ export namespace StructPerson {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * (no ontology metadata)
@@ -51,6 +53,7 @@ export interface StructPerson extends $ObjectTypeDefinition {
   apiName: 'StructPerson';
   primaryKeyApiName: 'name';
   primaryKeyType: 'string';
+  links: StructPerson.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: StructPerson.ObjectSet;
     props: StructPerson.Props;
@@ -65,6 +68,7 @@ export interface StructPerson extends $ObjectTypeDefinition {
       color: 'color';
     };
     implements: undefined;
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -95,6 +99,7 @@ export const StructPerson = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'name',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.a.b.c.d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/StructPersonOpisTeam.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/StructPersonOpisTeam.ts
@@ -19,6 +19,8 @@ export namespace StructPersonOpisTeam {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * (no ontology metadata)
@@ -61,6 +63,7 @@ export interface StructPersonOpisTeam extends $ObjectTypeDefinition {
   apiName: 'StructPersonOpisTeam';
   primaryKeyApiName: 'id';
   primaryKeyType: 'string';
+  links: StructPersonOpisTeam.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: StructPersonOpisTeam.ObjectSet;
     props: StructPersonOpisTeam.Props;
@@ -75,6 +78,7 @@ export interface StructPersonOpisTeam extends $ObjectTypeDefinition {
       color: 'color';
     };
     implements: undefined;
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -109,6 +113,7 @@ export const StructPersonOpisTeam = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'id',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.a.b.c.d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/TestGeoAction.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/TestGeoAction.ts
@@ -19,6 +19,8 @@ export namespace TestGeoAction {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * (no ontology metadata)
@@ -59,6 +61,7 @@ export interface TestGeoAction extends $ObjectTypeDefinition {
   apiName: 'TestGeoAction';
   primaryKeyApiName: 'geoPk';
   primaryKeyType: 'string';
+  links: TestGeoAction.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: TestGeoAction.ObjectSet;
     props: TestGeoAction.Props;
@@ -73,6 +76,7 @@ export interface TestGeoAction extends $ObjectTypeDefinition {
       color: 'color';
     };
     implements: undefined;
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -111,6 +115,7 @@ export const TestGeoAction = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'geoPk',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.a.b.c.d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Todo.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Todo.ts
@@ -13,13 +13,19 @@ import type {
   OsdkObject as $OsdkObject,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export namespace Todo {
   export type PropertyKeys = 'body' | 'complete' | 'id' | 'priority' | 'text';
 
   export interface Links {
     readonly Assignee: $SingleLinkAccessor<Person>;
+  }
+
+  export interface LinkTokens {
+    readonly Assignee: $LinkDef<Todo, Person, 'one'>;
   }
 
   export interface Props {
@@ -68,6 +74,7 @@ export interface Todo extends $ObjectTypeDefinition {
   apiName: 'Todo';
   primaryKeyApiName: 'id';
   primaryKeyType: 'integer';
+  links: Todo.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: Todo.ObjectSet;
     props: Todo.Props;
@@ -82,6 +89,7 @@ export interface Todo extends $ObjectTypeDefinition {
       color: 'color';
     };
     implements: undefined;
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {
@@ -128,6 +136,9 @@ export const Todo = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'id',
   primaryKeyType: 'integer',
+  links: {
+    Assignee: $createLinkDef('Todo', 'Assignee', 'Person', false, false),
+  },
   internalDoNotUseMetadata: {
     rid: 'rid.a.b.c.d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/UnstructuredImageExample.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/UnstructuredImageExample.ts
@@ -19,6 +19,8 @@ export namespace UnstructuredImageExample {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * (no ontology metadata)
@@ -55,6 +57,7 @@ export interface UnstructuredImageExample extends $ObjectTypeDefinition {
   apiName: 'UnstructuredImageExample';
   primaryKeyApiName: 'mediaItemRid';
   primaryKeyType: 'string';
+  links: UnstructuredImageExample.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: UnstructuredImageExample.ObjectSet;
     props: UnstructuredImageExample.Props;
@@ -69,6 +72,7 @@ export interface UnstructuredImageExample extends $ObjectTypeDefinition {
       color: 'color';
     };
     implements: undefined;
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -103,6 +107,7 @@ export const UnstructuredImageExample = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'mediaItemRid',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'rid.a.b.c.d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Venture.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/Venture.ts
@@ -13,13 +13,19 @@ import type {
   OsdkObject as $OsdkObject,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export namespace Venture {
   export type PropertyKeys = 'ventureId' | 'ventureName' | 'ventureStart';
 
   export interface Links {
     readonly employees: Employee.ObjectSet;
+  }
+
+  export interface LinkTokens {
+    readonly employees: $LinkDef<Venture, Employee, 'many'>;
   }
 
   export interface Props {
@@ -58,6 +64,7 @@ export interface Venture extends $ObjectTypeDefinition {
   apiName: 'Venture';
   primaryKeyApiName: 'ventureId';
   primaryKeyType: 'string';
+  links: Venture.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: Venture.ObjectSet;
     props: Venture.Props;
@@ -72,6 +79,7 @@ export interface Venture extends $ObjectTypeDefinition {
       color: 'color';
     };
     implements: undefined;
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {
@@ -108,6 +116,9 @@ export const Venture = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'ventureId',
   primaryKeyType: 'string',
+  links: {
+    employees: $createLinkDef('Venture', 'employees', 'Employee', true, false),
+  },
   internalDoNotUseMetadata: {
     rid: 'rid.a.b.c.d',
   },

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/WeatherStation.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/WeatherStation.ts
@@ -19,6 +19,8 @@ export namespace WeatherStation {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      *   display name: 'Geohash',
@@ -53,6 +55,7 @@ export interface WeatherStation extends $ObjectTypeDefinition {
   apiName: 'WeatherStation';
   primaryKeyApiName: 'stationId';
   primaryKeyType: 'string';
+  links: WeatherStation.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: WeatherStation.ObjectSet;
     props: WeatherStation.Props;
@@ -67,6 +70,7 @@ export interface WeatherStation extends $ObjectTypeDefinition {
       color: 'color';
     };
     implements: undefined;
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -99,6 +103,7 @@ export const WeatherStation = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'stationId',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.a.b.c.d',
   },

--- a/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/ontology/objects/Assignment.ts
+++ b/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/ontology/objects/Assignment.ts
@@ -17,7 +17,9 @@ import type {
   OsdkObject as $OsdkObject,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export namespace Assignment {
   export type PropertyKeys =
@@ -40,6 +42,14 @@ export namespace Assignment {
     readonly manager: $SingleLinkAccessor<Manager>;
     readonly office: $SingleLinkAccessor<Office>;
     readonly statusUpdate: StatusUpdate.ObjectSet;
+  }
+
+  export interface LinkTokens {
+    readonly employee: $LinkDef<Assignment, Employee, 'one'>;
+    readonly floor: $LinkDef<Assignment, Floor, 'one'>;
+    readonly manager: $LinkDef<Assignment, Manager, 'one'>;
+    readonly office: $LinkDef<Assignment, Office, 'one'>;
+    readonly statusUpdate: $LinkDef<Assignment, StatusUpdate, 'many'>;
   }
 
   export interface Props {
@@ -162,6 +172,7 @@ export interface Assignment extends $ObjectTypeDefinition {
   apiName: 'Assignment';
   primaryKeyApiName: 'assignmentId';
   primaryKeyType: 'string';
+  links: Assignment.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: Assignment.ObjectSet;
     props: Assignment.Props;
@@ -176,6 +187,7 @@ export interface Assignment extends $ObjectTypeDefinition {
       name: 'briefcase';
     };
     implements: [];
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {
@@ -300,6 +312,13 @@ export const Assignment = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'assignmentId',
   primaryKeyType: 'string',
+  links: {
+    employee: $createLinkDef('Assignment', 'employee', 'Employee', false, false),
+    floor: $createLinkDef('Assignment', 'floor', 'Floor', false, false),
+    manager: $createLinkDef('Assignment', 'manager', 'Manager', false, false),
+    office: $createLinkDef('Assignment', 'office', 'Office', false, false),
+    statusUpdate: $createLinkDef('Assignment', 'statusUpdate', 'StatusUpdate', true, false),
+  },
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.6720b526-a510-456d-b328-73bfeb8471d7',
   },

--- a/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/ontology/objects/Employee.ts
+++ b/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/ontology/objects/Employee.ts
@@ -13,13 +13,19 @@ import type {
   OsdkObject as $OsdkObject,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export namespace Employee {
   export type PropertyKeys = 'email' | 'employeeId' | 'fullName' | 'homeRegion' | 'joinedDate';
 
   export interface Links {
     readonly assignments: Assignment.ObjectSet;
+  }
+
+  export interface LinkTokens {
+    readonly assignments: $LinkDef<Employee, Assignment, 'many'>;
   }
 
   export interface Props {
@@ -86,6 +92,7 @@ export interface Employee extends $ObjectTypeDefinition {
   apiName: 'Employee';
   primaryKeyApiName: 'employeeId';
   primaryKeyType: 'string';
+  links: Employee.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: Employee.ObjectSet;
     props: Employee.Props;
@@ -100,6 +107,7 @@ export interface Employee extends $ObjectTypeDefinition {
       name: 'person';
     };
     implements: [];
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {
@@ -164,6 +172,9 @@ export const Employee = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'employeeId',
   primaryKeyType: 'string',
+  links: {
+    assignments: $createLinkDef('Employee', 'assignments', 'Assignment', true, false),
+  },
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.679d471d-610f-4d7c-915f-c67060c5d4c0',
   },

--- a/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/ontology/objects/Floor.ts
+++ b/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/ontology/objects/Floor.ts
@@ -14,7 +14,9 @@ import type {
   OsdkObject as $OsdkObject,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export namespace Floor {
   export type PropertyKeys = 'deskCapacity' | 'floorId' | 'isExcluded' | 'name' | 'officeId';
@@ -22,6 +24,11 @@ export namespace Floor {
   export interface Links {
     readonly assignments: Assignment.ObjectSet;
     readonly office: $SingleLinkAccessor<Office>;
+  }
+
+  export interface LinkTokens {
+    readonly assignments: $LinkDef<Floor, Assignment, 'many'>;
+    readonly office: $LinkDef<Floor, Office, 'one'>;
   }
 
   export interface Props {
@@ -88,6 +95,7 @@ export interface Floor extends $ObjectTypeDefinition {
   apiName: 'Floor';
   primaryKeyApiName: 'floorId';
   primaryKeyType: 'string';
+  links: Floor.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: Floor.ObjectSet;
     props: Floor.Props;
@@ -102,6 +110,7 @@ export interface Floor extends $ObjectTypeDefinition {
       name: 'layer';
     };
     implements: [];
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {
@@ -167,6 +176,10 @@ export const Floor = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'floorId',
   primaryKeyType: 'string',
+  links: {
+    assignments: $createLinkDef('Floor', 'assignments', 'Assignment', true, false),
+    office: $createLinkDef('Floor', 'office', 'Office', false, false),
+  },
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.eafe2bc2-26d3-4d05-a01a-a563c4b538a5',
   },

--- a/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/ontology/objects/Manager.ts
+++ b/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/ontology/objects/Manager.ts
@@ -13,13 +13,19 @@ import type {
   OsdkObject as $OsdkObject,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export namespace Manager {
   export type PropertyKeys = 'email' | 'fullName' | 'managerId' | 'title';
 
   export interface Links {
     readonly assignments: Assignment.ObjectSet;
+  }
+
+  export interface LinkTokens {
+    readonly assignments: $LinkDef<Manager, Assignment, 'many'>;
   }
 
   export interface Props {
@@ -78,6 +84,7 @@ export interface Manager extends $ObjectTypeDefinition {
   apiName: 'Manager';
   primaryKeyApiName: 'managerId';
   primaryKeyType: 'string';
+  links: Manager.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: Manager.ObjectSet;
     props: Manager.Props;
@@ -92,6 +99,7 @@ export interface Manager extends $ObjectTypeDefinition {
       name: 'hat';
     };
     implements: [];
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {
@@ -148,6 +156,9 @@ export const Manager = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'managerId',
   primaryKeyType: 'string',
+  links: {
+    assignments: $createLinkDef('Manager', 'assignments', 'Assignment', true, false),
+  },
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.a63ba05c-d155-4a05-9e06-aed231a64571',
   },

--- a/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/ontology/objects/Office.ts
+++ b/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/ontology/objects/Office.ts
@@ -14,7 +14,9 @@ import type {
   OsdkObject as $OsdkObject,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export namespace Office {
   export type PropertyKeys = 'city' | 'name' | 'officeId' | 'region';
@@ -22,6 +24,11 @@ export namespace Office {
   export interface Links {
     readonly assignments: Assignment.ObjectSet;
     readonly floors: Floor.ObjectSet;
+  }
+
+  export interface LinkTokens {
+    readonly assignments: $LinkDef<Office, Assignment, 'many'>;
+    readonly floors: $LinkDef<Office, Floor, 'many'>;
   }
 
   export interface Props {
@@ -80,6 +87,7 @@ export interface Office extends $ObjectTypeDefinition {
   apiName: 'Office';
   primaryKeyApiName: 'officeId';
   primaryKeyType: 'string';
+  links: Office.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: Office.ObjectSet;
     props: Office.Props;
@@ -94,6 +102,7 @@ export interface Office extends $ObjectTypeDefinition {
       name: 'office';
     };
     implements: [];
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {
@@ -151,6 +160,10 @@ export const Office = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'officeId',
   primaryKeyType: 'string',
+  links: {
+    assignments: $createLinkDef('Office', 'assignments', 'Assignment', true, false),
+    floors: $createLinkDef('Office', 'floors', 'Floor', true, false),
+  },
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.a8feaba1-2c21-4aaa-9533-f76eac796c55',
   },

--- a/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/ontology/objects/StatusUpdate.ts
+++ b/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/ontology/objects/StatusUpdate.ts
@@ -13,7 +13,9 @@ import type {
   OsdkObject as $OsdkObject,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export namespace StatusUpdate {
   export type PropertyKeys =
@@ -30,6 +32,10 @@ export namespace StatusUpdate {
 
   export interface Links {
     readonly assignment: $SingleLinkAccessor<Assignment>;
+  }
+
+  export interface LinkTokens {
+    readonly assignment: $LinkDef<StatusUpdate, Assignment, 'one'>;
   }
 
   export interface Props {
@@ -136,6 +142,7 @@ export interface StatusUpdate extends $ObjectTypeDefinition {
   apiName: 'StatusUpdate';
   primaryKeyApiName: 'statusUpdateId';
   primaryKeyType: 'string';
+  links: StatusUpdate.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: StatusUpdate.ObjectSet;
     props: StatusUpdate.Props;
@@ -150,6 +157,7 @@ export interface StatusUpdate extends $ObjectTypeDefinition {
       name: 'timeline-events';
     };
     implements: [];
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {
@@ -254,6 +262,9 @@ export const StatusUpdate = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'statusUpdateId',
   primaryKeyType: 'string',
+  links: {
+    assignment: $createLinkDef('StatusUpdate', 'assignment', 'Assignment', false, false),
+  },
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.586dc2cc-44d2-4a82-8831-bd529c6f2042',
   },

--- a/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/ontology/objects/Employee.ts
+++ b/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/ontology/objects/Employee.ts
@@ -13,7 +13,9 @@ import type {
   OsdkObject as $OsdkObject,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export namespace Employee {
   export type PropertyKeys =
@@ -52,6 +54,12 @@ export namespace Employee {
     readonly lead: $SingleLinkAccessor<Employee>;
     readonly peeps: Employee.ObjectSet;
     readonly primaryOffice: $SingleLinkAccessor<Office>;
+  }
+
+  export interface LinkTokens {
+    readonly lead: $LinkDef<Employee, Employee, 'one'>;
+    readonly peeps: $LinkDef<Employee, Employee, 'many'>;
+    readonly primaryOffice: $LinkDef<Employee, Office, 'one'>;
   }
 
   export interface Props {
@@ -318,6 +326,7 @@ export interface Employee extends $ObjectTypeDefinition {
   apiName: 'Employee';
   primaryKeyApiName: 'employeeNumber';
   primaryKeyType: 'integer';
+  links: Employee.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: Employee.ObjectSet;
     props: Employee.Props;
@@ -332,6 +341,7 @@ export interface Employee extends $ObjectTypeDefinition {
       name: 'person';
     };
     implements: [];
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {
@@ -596,6 +606,11 @@ export const Employee = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'employeeNumber',
   primaryKeyType: 'integer',
+  links: {
+    lead: $createLinkDef('Employee', 'lead', 'Employee', false, false),
+    peeps: $createLinkDef('Employee', 'peeps', 'Employee', true, false),
+    primaryOffice: $createLinkDef('Employee', 'primaryOffice', 'Office', false, false),
+  },
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.ade16a88-ecc4-4f96-9751-ca1799247d64',
   },

--- a/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/ontology/objects/Office.ts
+++ b/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/ontology/objects/Office.ts
@@ -13,13 +13,19 @@ import type {
   OsdkObject as $OsdkObject,
   PropertyValueWireToClient as $PropType,
   SingleLinkAccessor as $SingleLinkAccessor,
+  LinkDef as $LinkDef,
 } from '@osdk/client';
+import { createLinkDef as $createLinkDef } from '@osdk/client';
 
 export namespace Office {
   export type PropertyKeys = 'location' | 'name' | 'primaryKey_';
 
   export interface Links {
     readonly occupants: Employee.ObjectSet;
+  }
+
+  export interface LinkTokens {
+    readonly occupants: $LinkDef<Office, Employee, 'many'>;
   }
 
   export interface Props {
@@ -70,6 +76,7 @@ export interface Office extends $ObjectTypeDefinition {
   apiName: 'Office';
   primaryKeyApiName: 'primaryKey_';
   primaryKeyType: 'string';
+  links: Office.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: Office.ObjectSet;
     props: Office.Props;
@@ -84,6 +91,7 @@ export interface Office extends $ObjectTypeDefinition {
       name: 'cube';
     };
     implements: [];
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {
@@ -132,6 +140,9 @@ export const Office = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'primaryKey_',
   primaryKeyType: 'string',
+  links: {
+    occupants: $createLinkDef('Office', 'occupants', 'Employee', true, false),
+  },
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.bbca9c02-5c6a-4d3a-8bf1-e4db0177ab5f',
   },

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/ontology/interfaces/TodoLike.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/ontology/interfaces/TodoLike.ts
@@ -15,6 +15,8 @@ export type OsdkObjectLinks$TodoLike = {};
 export namespace TodoLike {
   export type PropertyKeys = 'isComplete' | 'name';
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * (no ontology metadata)
@@ -45,6 +47,7 @@ export interface TodoLike extends $InterfaceDefinition {
   osdkMetadata: typeof $osdkMetadata;
   type: 'interface';
   apiName: 'TodoLike';
+  links: TodoLike.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: TodoLike.ObjectSet;
     props: TodoLike.Props;
@@ -75,6 +78,7 @@ export const TodoLike = {
   type: 'interface',
   apiName: 'TodoLike',
   osdkMetadata: $osdkMetadata,
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.interface.fe6b2917-915d-4952-b89d-1231dad224e0',
   },

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/ontology/objects/Todo.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/ontology/objects/Todo.ts
@@ -19,6 +19,8 @@ export namespace Todo {
 
   export type Links = {};
 
+  export type LinkTokens = {};
+
   export interface Props {
     /**
      * @experimental
@@ -73,6 +75,7 @@ export interface Todo extends $ObjectTypeDefinition {
   apiName: 'Todo';
   primaryKeyApiName: 'id';
   primaryKeyType: 'string';
+  links: Todo.LinkTokens;
   __DefinitionMetadata?: {
     objectSet: Todo.ObjectSet;
     props: Todo.Props;
@@ -87,6 +90,7 @@ export interface Todo extends $ObjectTypeDefinition {
       name: 'confirm';
     };
     implements: [];
+    interfaceLinkMap: {};
     interfaceMap: {};
     inverseInterfaceMap: {};
     links: {};
@@ -139,6 +143,7 @@ export const Todo = {
   osdkMetadata: $osdkMetadata,
   primaryKeyApiName: 'id',
   primaryKeyType: 'string',
+  links: {},
   internalDoNotUseMetadata: {
     rid: 'ri.ontology.main.object-type.a3fcfef9-ec11-4f2d-8a4c-dc010de837bf',
   },

--- a/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectMetadata.test.ts
+++ b/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectMetadata.test.ts
@@ -321,6 +321,83 @@ describe(wireObjectTypeFullMetadataToSdkObjectMetadata, () => {
     });
   });
 
+  it("extracts interface link map from implementsInterfaces2", () => {
+    const result = wireObjectTypeFullMetadataToSdkObjectMetadata({
+      implementsInterfaces: ["CategoryInterface"],
+      implementsInterfaces2: {
+        CategoryInterface: {
+          properties: {},
+          propertiesV2: {},
+          links: { childCategories: ["concreteChildren"] },
+        },
+      },
+      linkTypes: [
+        {
+          apiName: "concreteChildren",
+          cardinality: "MANY",
+          objectTypeApiName: "SubCategory",
+          displayName: "Children",
+          status: "ACTIVE",
+          linkTypeRid: "rid",
+        },
+      ],
+      objectType: {
+        apiName: "SubCategory",
+        description: "description",
+        displayName: "displayName",
+        pluralDisplayName: "displayNames",
+        icon: { type: "blueprint", name: "blueprint", color: "blue" },
+        primaryKey: "primaryKey",
+        properties: {
+          primaryKey: {
+            dataType: { type: "string" },
+            "rid": "rid",
+            typeClasses: [],
+          },
+        },
+        rid: "rid",
+        status: "ACTIVE",
+        titleProperty: "primaryKey",
+      },
+      sharedPropertyTypeMapping: {},
+    }, true);
+
+    expect(result.interfaceLinkMap).toEqual({
+      CategoryInterface: { childCategories: "concreteChildren" },
+    });
+  });
+
+  it("emits empty interface link map when no interface links are present", () => {
+    const result = wireObjectTypeFullMetadataToSdkObjectMetadata({
+      implementsInterfaces: ["CategoryInterface"],
+      implementsInterfaces2: {
+        CategoryInterface: { properties: {}, propertiesV2: {}, links: {} },
+      },
+      linkTypes: [],
+      objectType: {
+        apiName: "apiName",
+        description: "description",
+        displayName: "displayName",
+        pluralDisplayName: "displayNames",
+        icon: { type: "blueprint", name: "blueprint", color: "blue" },
+        primaryKey: "primaryKey",
+        properties: {
+          primaryKey: {
+            dataType: { type: "string" },
+            "rid": "rid",
+            typeClasses: [],
+          },
+        },
+        rid: "rid",
+        status: "ACTIVE",
+        titleProperty: "primaryKey",
+      },
+      sharedPropertyTypeMapping: {},
+    }, true);
+
+    expect(result.interfaceLinkMap).toEqual({ CategoryInterface: {} });
+  });
+
   it("preserves empty arrays", () => {
     const result = wireObjectTypeFullMetadataToSdkObjectMetadata({
       implementsInterfaces: [],

--- a/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectMetadata.ts
+++ b/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectMetadata.ts
@@ -83,6 +83,29 @@ export function wireObjectTypeFullMetadataToSdkObjectMetadata(
     )
     : {};
 
+  const interfaceLinkMap = objectTypeWithLink.implementsInterfaces2
+    ? Object.fromEntries(
+      Object.entries(objectTypeWithLink.implementsInterfaces2).sort(
+        ([a], [b]) => a.localeCompare(b),
+      ).map(
+        ([interfaceApiName, impl]) => {
+          const linkMap: Record<string, string> = {};
+          for (
+            const [interfaceLinkApiName, concreteLinks] of Object.entries(
+              impl.links ?? {},
+            )
+          ) {
+            const concreteLinkApiName = concreteLinks?.[0];
+            if (concreteLinkApiName != null) {
+              linkMap[interfaceLinkApiName] = concreteLinkApiName;
+            }
+          }
+          return [interfaceApiName, linkMap];
+        },
+      ),
+    )
+    : {};
+
   return {
     type: "object",
     apiName: objectTypeWithLink.objectType.apiName,
@@ -126,6 +149,7 @@ export function wireObjectTypeFullMetadataToSdkObjectMetadata(
         [interfaceApiName, props],
       ) => [interfaceApiName, invertProps(props)]),
     ),
+    interfaceLinkMap,
     icon: supportedIconTypes.includes(objectTypeWithLink.objectType.icon.type)
       ? objectTypeWithLink.objectType.icon
       : undefined,

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -770,6 +770,8 @@ describe("generator", () => {
         export namespace SomeInterface {
           export type PropertyKeys = 'SomeProperty';
 
+          export type LinkTokens = {};
+
           export interface Props {
             /**
              *   display name: 'Sum Property',
@@ -798,6 +800,7 @@ describe("generator", () => {
           osdkMetadata: typeof $osdkMetadata;
           type: 'interface';
           apiName: 'SomeInterface';
+          links: SomeInterface.LinkTokens;
           __DefinitionMetadata?: {
             objectSet: SomeInterface.ObjectSet;
             props: SomeInterface.Props;
@@ -826,6 +829,7 @@ describe("generator", () => {
           type: 'interface',
           apiName: 'SomeInterface',
           osdkMetadata: $osdkMetadata,
+          links: {},
           internalDoNotUseMetadata: {
             rid: 'idk',
           },
@@ -849,13 +853,19 @@ describe("generator", () => {
           OsdkObject as $OsdkObject,
           PropertyValueWireToClient as $PropType,
           SingleLinkAccessor as $SingleLinkAccessor,
+          LinkDef as $LinkDef,
         } from '@osdk/client';
+        import { createLinkDef as $createLinkDef } from '@osdk/client';
 
         export namespace Person {
           export type PropertyKeys = 'email';
 
           export interface Links {
             readonly Todos: Todo.ObjectSet;
+          }
+
+          export interface LinkTokens {
+            readonly Todos: $LinkDef<Person, Todo, 'many'>;
           }
 
           export interface Props {
@@ -886,6 +896,7 @@ describe("generator", () => {
           apiName: 'Person';
           primaryKeyApiName: 'email';
           primaryKeyType: 'string';
+          links: Person.LinkTokens;
           __DefinitionMetadata?: {
             objectSet: Person.ObjectSet;
             props: Person.Props;
@@ -900,6 +911,7 @@ describe("generator", () => {
               color: 'blue';
             };
             implements: [];
+            interfaceLinkMap: {};
             interfaceMap: {};
             inverseInterfaceMap: {};
             links: {
@@ -928,6 +940,9 @@ describe("generator", () => {
           osdkMetadata: $osdkMetadata,
           primaryKeyApiName: 'email',
           primaryKeyType: 'string',
+          links: {
+            Todos: $createLinkDef('Person', 'Todos', 'Todo', true, false),
+          },
           internalDoNotUseMetadata: {
             rid: 'ridForPerson',
           },
@@ -948,13 +963,19 @@ describe("generator", () => {
           OsdkObject as $OsdkObject,
           PropertyValueWireToClient as $PropType,
           SingleLinkAccessor as $SingleLinkAccessor,
+          LinkDef as $LinkDef,
         } from '@osdk/client';
+        import { createLinkDef as $createLinkDef } from '@osdk/client';
 
         export namespace Todo {
           export type PropertyKeys = 'array' | 'body' | 'complete' | 'id';
 
           export interface Links {
             readonly Assignee: $SingleLinkAccessor<Person>;
+          }
+
+          export interface LinkTokens {
+            readonly Assignee: $LinkDef<Todo, Person, 'one'>;
           }
 
           export interface Props {
@@ -999,6 +1020,7 @@ describe("generator", () => {
           apiName: 'Todo';
           primaryKeyApiName: 'id';
           primaryKeyType: 'integer';
+          links: Todo.LinkTokens;
           __DefinitionMetadata?: {
             objectSet: Todo.ObjectSet;
             props: Todo.Props;
@@ -1013,6 +1035,9 @@ describe("generator", () => {
               color: 'blue';
             };
             implements: ['SomeInterface'];
+            interfaceLinkMap: {
+              SomeInterface: {};
+            };
             interfaceMap: {
               SomeInterface: {
                 SomeProperty: 'body';
@@ -1063,6 +1088,9 @@ describe("generator", () => {
           osdkMetadata: $osdkMetadata,
           primaryKeyApiName: 'id',
           primaryKeyType: 'integer',
+          links: {
+            Assignee: $createLinkDef('Todo', 'Assignee', 'Person', false, false),
+          },
           internalDoNotUseMetadata: {
             rid: 'ridForTodo',
           },
@@ -1189,6 +1217,43 @@ describe("generator", () => {
         ",
         }
       `);
+    },
+  );
+
+  test(
+    "emits Type.links LinkDef token namespace",
+    { timeout: 60_000 },
+    async () => {
+      await generateClientSdkVersionTwoPointZero(
+        TodoWireOntology,
+        "typescript-sdk/0.0.0 osdk-cli/0.0.0",
+        helper.minimalFiles,
+        BASE_PATH,
+      );
+
+      const files = helper.getFiles();
+      const personFile = files[`${BASE_PATH}/ontology/objects/Person.ts`];
+      const todoFile = files[`${BASE_PATH}/ontology/objects/Todo.ts`];
+
+      // value import + runtime token block on the const
+      expect(personFile).toContain(
+        "import { createLinkDef as $createLinkDef } from '@osdk/client';",
+      );
+      expect(personFile).toContain(
+        "Todos: $createLinkDef('Person', 'Todos', 'Todo', true, false),",
+      );
+      // type-level token interface, many-cardinality
+      expect(personFile).toContain(
+        "readonly Todos: $LinkDef<Person, Todo, 'many'>;",
+      );
+
+      // single-cardinality link on Todo
+      expect(todoFile).toContain(
+        "Assignee: $createLinkDef('Todo', 'Assignee', 'Person', false, false),",
+      );
+      expect(todoFile).toContain(
+        "readonly Assignee: $LinkDef<Todo, Person, 'one'>;",
+      );
     },
   );
 
@@ -1461,6 +1526,8 @@ describe("generator", () => {
         export namespace SomeInterface {
           export type PropertyKeys = 'SomeProperty';
 
+          export type LinkTokens = {};
+
           export interface Props {
             /**
              *   display name: 'Sum Property',
@@ -1489,6 +1556,7 @@ describe("generator", () => {
           osdkMetadata: typeof $osdkMetadata;
           type: 'interface';
           apiName: 'foo.bar.SomeInterface';
+          links: SomeInterface.LinkTokens;
           __DefinitionMetadata?: {
             objectSet: SomeInterface.ObjectSet;
             props: SomeInterface.Props;
@@ -1517,6 +1585,7 @@ describe("generator", () => {
           type: 'interface',
           apiName: 'foo.bar.SomeInterface',
           osdkMetadata: $osdkMetadata,
+          links: {},
           internalDoNotUseMetadata: {
             rid: 'idk',
           },
@@ -1540,13 +1609,19 @@ describe("generator", () => {
           OsdkObject as $OsdkObject,
           PropertyValueWireToClient as $PropType,
           SingleLinkAccessor as $SingleLinkAccessor,
+          LinkDef as $LinkDef,
         } from '@osdk/api';
+        import { createLinkDef as $createLinkDef } from '@osdk/api';
 
         export namespace Person {
           export type PropertyKeys = 'email';
 
           export interface Links {
             readonly Todos: Todo.ObjectSet;
+          }
+
+          export interface LinkTokens {
+            readonly Todos: $LinkDef<Person, Todo, 'many'>;
           }
 
           export interface Props {
@@ -1577,6 +1652,7 @@ describe("generator", () => {
           apiName: 'foo.bar.Person';
           primaryKeyApiName: 'email';
           primaryKeyType: 'string';
+          links: Person.LinkTokens;
           __DefinitionMetadata?: {
             objectSet: Person.ObjectSet;
             props: Person.Props;
@@ -1591,6 +1667,7 @@ describe("generator", () => {
               color: 'blue';
             };
             implements: [];
+            interfaceLinkMap: {};
             interfaceMap: {};
             inverseInterfaceMap: {};
             links: {
@@ -1619,6 +1696,9 @@ describe("generator", () => {
           osdkMetadata: $osdkMetadata,
           primaryKeyApiName: 'email',
           primaryKeyType: 'string',
+          links: {
+            Todos: $createLinkDef('foo.bar.Person', 'Todos', 'foo.bar.Todo', true, false),
+          },
           internalDoNotUseMetadata: {
             rid: 'ridForPerson',
           },
@@ -1639,13 +1719,19 @@ describe("generator", () => {
           OsdkObject as $OsdkObject,
           PropertyValueWireToClient as $PropType,
           SingleLinkAccessor as $SingleLinkAccessor,
+          LinkDef as $LinkDef,
         } from '@osdk/api';
+        import { createLinkDef as $createLinkDef } from '@osdk/api';
 
         export namespace Todo {
           export type PropertyKeys = 'array' | 'body' | 'complete' | 'id';
 
           export interface Links {
             readonly Assignee: $SingleLinkAccessor<Person>;
+          }
+
+          export interface LinkTokens {
+            readonly Assignee: $LinkDef<Todo, Person, 'one'>;
           }
 
           export interface Props {
@@ -1690,6 +1776,7 @@ describe("generator", () => {
           apiName: 'foo.bar.Todo';
           primaryKeyApiName: 'id';
           primaryKeyType: 'integer';
+          links: Todo.LinkTokens;
           __DefinitionMetadata?: {
             objectSet: Todo.ObjectSet;
             props: Todo.Props;
@@ -1704,6 +1791,9 @@ describe("generator", () => {
               color: 'blue';
             };
             implements: ['foo.bar.SomeInterface'];
+            interfaceLinkMap: {
+              'foo.bar.SomeInterface': {};
+            };
             interfaceMap: {
               'foo.bar.SomeInterface': {
                 SomeProperty: 'body';
@@ -1754,6 +1844,9 @@ describe("generator", () => {
           osdkMetadata: $osdkMetadata,
           primaryKeyApiName: 'id',
           primaryKeyType: 'integer',
+          links: {
+            Assignee: $createLinkDef('foo.bar.Todo', 'Assignee', 'foo.bar.Person', false, false),
+          },
           internalDoNotUseMetadata: {
             rid: 'ridForTodo',
           },
@@ -2087,6 +2180,8 @@ describe("generator", () => {
 
             export type Links = {};
 
+            export type LinkTokens = {};
+
             export interface Props {
               /**
                * (no ontology metadata)
@@ -2119,6 +2214,7 @@ describe("generator", () => {
             apiName: 'UsesForeignSpt';
             primaryKeyApiName: 'id';
             primaryKeyType: 'integer';
+            links: UsesForeignSpt.LinkTokens;
             __DefinitionMetadata?: {
               objectSet: UsesForeignSpt.ObjectSet;
               props: UsesForeignSpt.Props;
@@ -2133,6 +2229,7 @@ describe("generator", () => {
                 name: 'document';
               };
               implements: [];
+              interfaceLinkMap: {};
               interfaceMap: {};
               inverseInterfaceMap: {};
               links: {};
@@ -2163,6 +2260,7 @@ describe("generator", () => {
             osdkMetadata: $osdkMetadata,
             primaryKeyApiName: 'id',
             primaryKeyType: 'integer',
+            links: {},
             internalDoNotUseMetadata: {
               rid: 'theRid',
             },
@@ -2349,13 +2447,19 @@ describe("generator", () => {
           OsdkObject as $OsdkObject,
           PropertyValueWireToClient as $PropType,
           SingleLinkAccessor as $SingleLinkAccessor,
+          LinkDef as $LinkDef,
         } from '@osdk/client';
+        import { createLinkDef as $createLinkDef } from '@osdk/client';
 
         export namespace Person {
           export type PropertyKeys = 'email';
 
           export interface Links {
             readonly Todos: Todo.ObjectSet;
+          }
+
+          export interface LinkTokens {
+            readonly Todos: $LinkDef<Person, Todo, 'many'>;
           }
 
           export interface Props {
@@ -2386,6 +2490,7 @@ describe("generator", () => {
           apiName: 'Person';
           primaryKeyApiName: 'email';
           primaryKeyType: 'string';
+          links: Person.LinkTokens;
           __DefinitionMetadata?: {
             objectSet: Person.ObjectSet;
             props: Person.Props;
@@ -2400,6 +2505,7 @@ describe("generator", () => {
               color: 'blue';
             };
             implements: [];
+            interfaceLinkMap: {};
             interfaceMap: {};
             inverseInterfaceMap: {};
             links: {
@@ -2428,6 +2534,9 @@ describe("generator", () => {
           osdkMetadata: $osdkMetadata,
           primaryKeyApiName: 'email',
           primaryKeyType: 'string',
+          links: {
+            Todos: $createLinkDef('Person', 'Todos', 'Todo', true, false),
+          },
           internalDoNotUseMetadata: {
             rid: 'ridForPerson',
           },
@@ -2448,13 +2557,19 @@ describe("generator", () => {
           OsdkObject as $OsdkObject,
           PropertyValueWireToClient as $PropType,
           SingleLinkAccessor as $SingleLinkAccessor,
+          LinkDef as $LinkDef,
         } from '@osdk/client';
+        import { createLinkDef as $createLinkDef } from '@osdk/client';
 
         export namespace Todo {
           export type PropertyKeys = 'array' | 'body' | 'complete' | 'id';
 
           export interface Links {
             readonly Assignee: $SingleLinkAccessor<Person>;
+          }
+
+          export interface LinkTokens {
+            readonly Assignee: $LinkDef<Todo, Person, 'one'>;
           }
 
           export interface Props {
@@ -2499,6 +2614,7 @@ describe("generator", () => {
           apiName: 'Todo';
           primaryKeyApiName: 'id';
           primaryKeyType: 'integer';
+          links: Todo.LinkTokens;
           __DefinitionMetadata?: {
             objectSet: Todo.ObjectSet;
             props: Todo.Props;
@@ -2513,6 +2629,9 @@ describe("generator", () => {
               color: 'blue';
             };
             implements: ['SomeInterface'];
+            interfaceLinkMap: {
+              SomeInterface: {};
+            };
             interfaceMap: {
               SomeInterface: {
                 SomeProperty: 'body';
@@ -2563,6 +2682,9 @@ describe("generator", () => {
           osdkMetadata: $osdkMetadata,
           primaryKeyApiName: 'id',
           primaryKeyType: 'integer',
+          links: {
+            Assignee: $createLinkDef('Todo', 'Assignee', 'Person', false, false),
+          },
           internalDoNotUseMetadata: {
             rid: 'ridForTodo',
           },
@@ -2750,6 +2872,8 @@ describe("generator", () => {
         export namespace SomeInterface {
           export type PropertyKeys = 'spt' | 'spt2';
 
+          export type LinkTokens = {};
+
           export interface Props {
             /**
              *   display name: 'Some Property'
@@ -2780,6 +2904,7 @@ describe("generator", () => {
           osdkMetadata: typeof $osdkMetadata;
           type: 'interface';
           apiName: 'com.example.dep.SomeInterface';
+          links: SomeInterface.LinkTokens;
           __DefinitionMetadata?: {
             objectSet: SomeInterface.ObjectSet;
             props: SomeInterface.Props;
@@ -2810,6 +2935,7 @@ describe("generator", () => {
           type: 'interface',
           apiName: 'com.example.dep.SomeInterface',
           osdkMetadata: $osdkMetadata,
+          links: {},
           internalDoNotUseMetadata: {
             rid: 'idk2',
           },
@@ -2837,6 +2963,8 @@ describe("generator", () => {
           export type PropertyKeys = 'body' | 'taskId';
 
           export type Links = {};
+
+          export type LinkTokens = {};
 
           export interface Props {
             /**
@@ -2870,6 +2998,7 @@ describe("generator", () => {
           apiName: 'com.example.dep.Task';
           primaryKeyApiName: 'taskId';
           primaryKeyType: 'string';
+          links: Task.LinkTokens;
           __DefinitionMetadata?: {
             objectSet: Task.ObjectSet;
             props: Task.Props;
@@ -2884,6 +3013,7 @@ describe("generator", () => {
               name: 'document';
             };
             implements: [];
+            interfaceLinkMap: {};
             interfaceMap: {};
             inverseInterfaceMap: {};
             links: {};
@@ -2914,6 +3044,7 @@ describe("generator", () => {
           osdkMetadata: $osdkMetadata,
           primaryKeyApiName: 'taskId',
           primaryKeyType: 'string',
+          links: {},
           internalDoNotUseMetadata: {
             rid: 'ridForTask',
           },

--- a/packages/generator/src/v2.0/wireInterfaceTypeV2ToSdkObjectConst.ts
+++ b/packages/generator/src/v2.0/wireInterfaceTypeV2ToSdkObjectConst.ts
@@ -31,6 +31,8 @@ import { stringify } from "../util/stringify.js";
 import type { Identifiers } from "./wireObjectTypeV2ToSdkObjectConstV2.js";
 import {
   createDefinition,
+  createLinkTokens,
+  createLinkTokensRuntime,
   createObjectSet,
   createOsdkObject,
   createPropertyKeys,
@@ -145,16 +147,27 @@ export function wireInterfaceTypeV2ToSdkObjectConst(
     );
   }
 
+  const hasLinks = definition.links != null
+    && Object.keys(definition.links).length > 0;
+
   function getV2Types(forInternalUse: boolean = false) {
+    const apiPackage = forInternalUse ? "@osdk/api" : "@osdk/client";
     return `import type {
       InterfaceDefinition as $InterfaceDefinition,
       InterfaceMetadata as $InterfaceMetadata,
       ObjectSet as $ObjectSet,
       Osdk as $Osdk,
       PropertyValueWireToClient as $PropType,
-      SingleLinkAccessor as $SingleLinkAccessor,
-    } from "${forInternalUse ? "@osdk/api" : "@osdk/client"}";
-    
+      SingleLinkAccessor as $SingleLinkAccessor,${
+      hasLinks ? `\n      LinkDef as $LinkDef,` : ""
+    }
+    } from "${apiPackage}";
+    ${
+      hasLinks
+        ? `import { createLinkDef as $createLinkDef } from "${apiPackage}";`
+        : ""
+    }
+
         ${
       definition.links
         ? Object.keys(definition.links).length > 0
@@ -192,6 +205,7 @@ ${
 
       ${createPropertyKeys(interfaceDef)}
 
+      ${createLinkTokens(ontology, interfaceDef, "LinkTokens")}
 
       ${createProps(interfaceDef, "Props", false, ontology.raw.valueTypes)}
       ${createProps(interfaceDef, "StrictProps", true, ontology.raw.valueTypes)}
@@ -222,6 +236,7 @@ ${
       type: "interface",
       apiName: "${interfaceDef.fullApiName}",
       osdkMetadata: $osdkMetadata,
+      ${createLinkTokensRuntime(interfaceDef)}
       internalDoNotUseMetadata: {
         rid: "${definition.rid}",
       },

--- a/packages/generator/src/v2.0/wireObjectTypeV2ToSdkObjectConstV2.ts
+++ b/packages/generator/src/v2.0/wireObjectTypeV2ToSdkObjectConstV2.ts
@@ -88,22 +88,33 @@ export function wireObjectTypeV2ToSdkObjectConstV2(
     propertyKeysIdentifier,
   };
 
+  const hasLinks =
+    Object.keys(object.getCleanedUpDefinition(true).links).length > 0;
+
   function getV2Types(
     object: EnhancedObjectType,
     forInternalUse: boolean = false,
   ) {
+    const apiPackage = forInternalUse ? "@osdk/api" : "@osdk/client";
     return `import type {
-      PropertyKeys as $PropertyKeys,  
+      PropertyKeys as $PropertyKeys,
       ObjectTypeDefinition as $ObjectTypeDefinition,
       ObjectMetadata as $ObjectMetadata,
-    } from "${forInternalUse ? "@osdk/api" : "@osdk/client"}";
+    } from "${apiPackage}";
      import type {
-      ObjectSet as $ObjectSet, 
+      ObjectSet as $ObjectSet,
       Osdk as $Osdk,
       OsdkObject as $OsdkObject,
       PropertyValueWireToClient as $PropType,
-      SingleLinkAccessor  as $SingleLinkAccessor,
-    } from "${forInternalUse ? "@osdk/api" : "@osdk/client"}";
+      SingleLinkAccessor  as $SingleLinkAccessor,${
+      hasLinks ? `\n      LinkDef as $LinkDef,` : ""
+    }
+    } from "${apiPackage}";
+    ${
+      hasLinks
+        ? `import { createLinkDef as $createLinkDef } from "${apiPackage}";`
+        : ""
+    }
 
 
     export namespace ${object.shortApiName} {
@@ -113,13 +124,15 @@ export function wireObjectTypeV2ToSdkObjectConstV2(
 
       ${createLinks(ontology, object, "Links")}
 
+      ${createLinkTokens(ontology, object, "LinkTokens")}
+
       ${createProps(object, "Props", false, ontology.raw.valueTypes)}
       ${createProps(object, "StrictProps", true, ontology.raw.valueTypes)}
 
       ${createObjectSet(object, identifiers)}
-      
+
       ${createOsdkObject(object, "OsdkInstance", identifiers)}
-    }    
+    }
 
 
 
@@ -143,6 +156,7 @@ export function wireObjectTypeV2ToSdkObjectConstV2(
       osdkMetadata: $osdkMetadata,
       primaryKeyApiName: "${definition.primaryKeyApiName}",
       primaryKeyType: "${definition.primaryKeyType}",
+      ${createLinkTokensRuntime(object)}
       internalDoNotUseMetadata: {
         rid: "${definition.rid}",
       },
@@ -310,6 +324,7 @@ export function createDefinition(
       primaryKeyType: "${definition.primaryKeyType}";`
       : ""
   }
+      links: ${identifier}.LinkTokens;
       __DefinitionMetadata?: {
       objectSet: ${objectSetIdentifier};
       props: ${osdkObjectPropsIdentifier};
@@ -424,6 +439,79 @@ ${
     }
     `
   }`;
+}
+
+export function createLinkTokens(
+  ontology: EnhancedOntologyDefinition,
+  object: EnhancedObjectType | EnhancedInterfaceType,
+  identifier: string,
+): string {
+  const definition = object.getCleanedUpDefinition(true);
+
+  if (Object.keys(definition.links).length === 0) {
+    return `export type ${identifier} = {};`;
+  }
+
+  const sourceIdentifier = object.shortApiName;
+  const linkTokens = definition.type === "interface"
+    ? stringify(definition.links, {
+      "*": (linkDefinition, _, key) => {
+        const linkTarget = linkDefinition.targetType === "interface"
+          ? ontology.requireInterfaceType(linkDefinition.targetTypeApiName)
+            .getImportedDefinitionIdentifier(true)
+          : ontology.requireObjectType(linkDefinition.targetTypeApiName)
+            .getImportedDefinitionIdentifier(true);
+        return [
+          `readonly ${JSON.stringify(key)}`,
+          `$LinkDef<${sourceIdentifier}, ${linkTarget}, '${
+            linkDefinition.multiplicity ? "many" : "one"
+          }'>`,
+        ];
+      },
+    })
+    : stringify(definition.links, {
+      "*": (linkDefinition, _, key) => {
+        const linkTarget = ontology.requireObjectType(linkDefinition.targetType)
+          .getImportedDefinitionIdentifier(true);
+        return [
+          `readonly ${JSON.stringify(key)}`,
+          `$LinkDef<${sourceIdentifier}, ${linkTarget}, '${
+            linkDefinition.multiplicity ? "many" : "one"
+          }'>`,
+        ];
+      },
+    });
+
+  return `
+        export interface ${identifier}  {
+${linkTokens}
+    }
+    `;
+}
+
+export function createLinkTokensRuntime(
+  object: EnhancedObjectType | EnhancedInterfaceType,
+): string {
+  const definition = object.getCleanedUpDefinition(true);
+
+  if (Object.keys(definition.links).length === 0) {
+    return `links: {},`;
+  }
+
+  const source = object.fullApiName;
+  const linkTokens = definition.type === "interface"
+    ? stringify(definition.links, {
+      "*": (linkDefinition, _, key) =>
+        `$createLinkDef("${source}", "${key}", "${linkDefinition.targetTypeApiName}", ${linkDefinition.multiplicity}, true)`,
+    })
+    : stringify(definition.links, {
+      "*": (linkDefinition, _, key) =>
+        `$createLinkDef("${source}", "${key}", "${linkDefinition.targetType}", ${linkDefinition.multiplicity}, false)`,
+    });
+
+  return `links: {
+${linkTokens}
+    },`;
 }
 
 export function createPropertyKeys(

--- a/packages/react/src/new/__tests__/useLinks.test-d.ts
+++ b/packages/react/src/new/__tests__/useLinks.test-d.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectRefMap } from "@osdk/api";
+import type { Osdk } from "@osdk/client";
+import type { Office } from "@osdk/client.test.ontology";
+import { Employee } from "@osdk/client.test.ontology";
+import { describe, expectTypeOf, it } from "vitest";
+import { useLinks } from "../useLinks.js";
+
+declare const employee: Osdk.Instance<typeof Employee>;
+declare const employees: ReadonlyArray<Osdk.Instance<typeof Employee>>;
+
+// `use`-prefixed so the rules-of-hooks lint is satisfied. These probes are
+// never invoked at runtime; only their `ReturnType` is inspected by the type
+// assertions below, which is what `tsc --noEmit` exercises during typecheck.
+function useOneProbe() {
+  return useLinks(employee, Employee.links.officeLink);
+}
+
+function useManyProbe() {
+  return useLinks(employee, Employee.links.peeps);
+}
+
+function useMultiManyProbe() {
+  return useLinks(employees, Employee.links.peeps);
+}
+
+describe("useLinks token overload types", () => {
+  it("projects a 'one' token to Osdk.Instance | null | undefined", () => {
+    expectTypeOf<ReturnType<typeof useOneProbe>["data"]>()
+      .toEqualTypeOf<
+        Osdk.Instance<typeof Office, "$allBaseProperties"> | null | undefined
+      >();
+  });
+
+  it("projects a 'many' token to Osdk.Instance[] | undefined", () => {
+    expectTypeOf<ReturnType<typeof useManyProbe>["data"]>()
+      .toEqualTypeOf<
+        Osdk.Instance<typeof Employee, "$allBaseProperties">[] | undefined
+      >();
+  });
+
+  it("projects a multi-source 'many' token with a non-optional bySource", () => {
+    expectTypeOf<ReturnType<typeof useMultiManyProbe>["data"]>()
+      .toEqualTypeOf<
+        Osdk.Instance<typeof Employee, "$allBaseProperties">[] | undefined
+      >();
+    expectTypeOf<ReturnType<typeof useMultiManyProbe>["bySource"]>()
+      .toEqualTypeOf<
+        ObjectRefMap<
+          ReadonlyArray<Osdk.Instance<typeof Employee, "$allBaseProperties">>
+        >
+      >();
+  });
+});

--- a/packages/react/src/new/__tests__/useLinks.test.tsx
+++ b/packages/react/src/new/__tests__/useLinks.test.tsx
@@ -1,0 +1,453 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  LinkHopDescriptor,
+  ObjectRef,
+  ObjectTypeDefinition,
+  Osdk,
+  Path,
+  RecursiveTraversal,
+} from "@osdk/api";
+import { ObjectRefMap } from "@osdk/api";
+import type { Client } from "@osdk/client";
+import { InterfaceLinkNotResolvableError } from "@osdk/client";
+import type { ObservableClient } from "@osdk/client/observable";
+import { act, renderHook } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OsdkContext } from "../OsdkContext.js";
+import { useLinks } from "../useLinks.js";
+
+type Observer = {
+  next: (payload: unknown) => void;
+  error: (err: unknown) => void;
+  complete: () => void;
+};
+
+type ObserveLinkClosureCall = {
+  options: {
+    root: ObjectRef;
+    hop: LinkHopDescriptor;
+    maxDepth: number | "unbounded";
+    maxNodes: number;
+  };
+  observer: Observer;
+};
+
+function createMockObservableClient(): {
+  client: ObservableClient;
+  calls: ObserveLinkClosureCall[];
+} {
+  const calls: ObserveLinkClosureCall[] = [];
+  const client = {
+    observeLinkClosure: vi
+      .fn()
+      .mockImplementation(
+        (options: ObserveLinkClosureCall["options"], observer: Observer) => {
+          calls.push({ options, observer });
+          return { unsubscribe: vi.fn() };
+        },
+      ),
+  } as unknown as ObservableClient;
+  return { client, calls };
+}
+
+function createWrapper(observableClient: ObservableClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <OsdkContext.Provider
+        value={{
+          client: {} as Client,
+          observableClient,
+          devtoolsEnabled: false,
+        }}
+      >
+        {children}
+      </OsdkContext.Provider>
+    );
+  };
+}
+
+const hop: LinkHopDescriptor = {
+  sourceTypeApiName: "Node",
+  linkApiName: "children",
+  targetTypeApiName: "Node",
+  multiplicity: true,
+  sourceIsInterface: false,
+};
+
+function recursiveToken(
+  maxDepth: number | "unbounded",
+  maxNodes: number,
+): RecursiveTraversal<ObjectTypeDefinition, ObjectTypeDefinition> {
+  return {
+    __descriptor: {
+      kind: "recursive",
+      hops: [hop],
+      recursive: { maxDepth, maxNodes },
+    },
+  } as unknown as RecursiveTraversal<
+    ObjectTypeDefinition,
+    ObjectTypeDefinition
+  >;
+}
+
+function ref(pk: string): ObjectRef {
+  return { $objectType: "Node", $primaryKey: pk };
+}
+
+function instance(pk: string): Osdk.Instance<ObjectTypeDefinition> {
+  return {
+    $apiName: "Node",
+    $objectType: "Node",
+    $primaryKey: pk,
+  } as unknown as Osdk.Instance<ObjectTypeDefinition>;
+}
+
+describe("useLinks recursive overload", () => {
+  let observableClient: ObservableClient;
+  let calls: ObserveLinkClosureCall[];
+
+  beforeEach(() => {
+    ({ client: observableClient, calls } = createMockObservableClient());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const source = instance("root");
+
+  it("forwards the root, hop and recursive options to observeLinkClosure", () => {
+    renderHook(() => useLinks(source, recursiveToken(3, 250)), {
+      wrapper: createWrapper(observableClient),
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].options.root).toEqual(ref("root"));
+    expect(calls[0].options.hop).toEqual(hop);
+    expect(calls[0].options.maxDepth).toBe(3);
+    expect(calls[0].options.maxNodes).toBe(250);
+  });
+
+  it("surfaces the closure payload fields from the engine", () => {
+    const { result } = renderHook(
+      () => useLinks(source, recursiveToken(10, 1000)),
+      { wrapper: createWrapper(observableClient) },
+    );
+
+    const adjacency = new ObjectRefMap<ObjectRef[]>();
+    adjacency.set(ref("root"), [ref("a"), ref("b")]);
+    const byDepth = new ObjectRefMap<number>();
+    byDepth.set(ref("a"), 1);
+    byDepth.set(ref("b"), 1);
+
+    act(() => {
+      calls[0].observer.next({
+        data: [instance("a"), instance("b")],
+        adjacency,
+        byDepth,
+        frontier: [ref("a"), ref("b")],
+        depthReached: 1,
+        isExpanding: false,
+        truncated: { byDepth: false, byNodeBudget: false },
+        expand: vi.fn(),
+        isOptimistic: false,
+        status: "loaded",
+        error: undefined,
+        lastUpdated: 1,
+      });
+    });
+
+    expect(result.current.data.map((o) => o.$primaryKey)).toEqual(["a", "b"]);
+    expect(result.current.frontier).toEqual([ref("a"), ref("b")]);
+    expect(result.current.adjacency.get(ref("root"))).toEqual([
+      ref("a"),
+      ref("b"),
+    ]);
+    expect(result.current.byDepth.get(ref("a"))).toBe(1);
+    expect(result.current.depthReached).toBe(1);
+    expect(result.current.isExpanding).toBe(false);
+    expect(result.current.truncated).toEqual({
+      byDepth: false,
+      byNodeBudget: false,
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it("delegates expand(ref) to the engine's expand", () => {
+    const { result } = renderHook(
+      () => useLinks(source, recursiveToken(10, 1000)),
+      { wrapper: createWrapper(observableClient) },
+    );
+
+    const expand = vi.fn();
+    act(() => {
+      calls[0].observer.next({
+        data: [],
+        adjacency: new ObjectRefMap<ObjectRef[]>(),
+        byDepth: new ObjectRefMap<number>(),
+        frontier: [],
+        depthReached: 0,
+        isExpanding: true,
+        truncated: { byDepth: false, byNodeBudget: false },
+        expand,
+        isOptimistic: false,
+        status: "loading",
+        error: undefined,
+        lastUpdated: 1,
+      });
+    });
+
+    result.current.expand(ref("a"));
+    expect(expand).toHaveBeenCalledWith(ref("a"));
+  });
+
+  it("surfaces a typed interface-link error instance from the payload", () => {
+    const { result } = renderHook(
+      () => useLinks(source, recursiveToken(10, 1000)),
+      { wrapper: createWrapper(observableClient) },
+    );
+
+    const typedError = new InterfaceLinkNotResolvableError(
+      "Node",
+      "children",
+    );
+
+    act(() => {
+      calls[0].observer.next({
+        data: [],
+        adjacency: new ObjectRefMap<ObjectRef[]>(),
+        byDepth: new ObjectRefMap<number>(),
+        frontier: [],
+        depthReached: 0,
+        isExpanding: false,
+        truncated: { byDepth: false, byNodeBudget: false },
+        expand: vi.fn(),
+        isOptimistic: false,
+        status: "error",
+        error: typedError,
+        lastUpdated: 1,
+      });
+    });
+
+    // The concrete typed error instance must reach the hook unchanged, not be
+    // flattened into a plain Error or a string message.
+    expect(result.current.error).toBe(typedError);
+    expect(result.current.error).toBeInstanceOf(
+      InterfaceLinkNotResolvableError,
+    );
+    const err = result.current.error;
+    if (err instanceof InterfaceLinkNotResolvableError) {
+      expect(err.concreteType).toBe("Node");
+      expect(err.interfaceLinkApiName).toBe("children");
+    }
+  });
+});
+
+type ObservePathCall = {
+  options: { root: ObjectRef; hops: ReadonlyArray<LinkHopDescriptor> };
+  observer: Observer;
+};
+
+function createMockPathClient(): {
+  client: ObservableClient;
+  calls: ObservePathCall[];
+} {
+  const calls: ObservePathCall[] = [];
+  const client = {
+    observePath: vi
+      .fn()
+      .mockImplementation(
+        (options: ObservePathCall["options"], observer: Observer) => {
+          calls.push({ options, observer });
+          return { unsubscribe: vi.fn() };
+        },
+      ),
+  } as unknown as ObservableClient;
+  return { client, calls };
+}
+
+const hopOne: LinkHopDescriptor = {
+  sourceTypeApiName: "SubCategory",
+  linkApiName: "child",
+  targetTypeApiName: "Segment",
+  multiplicity: false,
+  sourceIsInterface: false,
+};
+
+const hopMany: LinkHopDescriptor = {
+  sourceTypeApiName: "Segment",
+  linkApiName: "segmentItems",
+  targetTypeApiName: "Priority",
+  multiplicity: true,
+  sourceIsInterface: false,
+};
+
+const hopOne2: LinkHopDescriptor = {
+  sourceTypeApiName: "Segment",
+  linkApiName: "owner",
+  targetTypeApiName: "Person",
+  multiplicity: false,
+  sourceIsInterface: false,
+};
+
+function pathToken(
+  hops: ReadonlyArray<LinkHopDescriptor>,
+): Path<ObjectTypeDefinition, ObjectTypeDefinition, "many"> {
+  return {
+    __descriptor: { kind: "path", hops },
+  } as unknown as Path<ObjectTypeDefinition, ObjectTypeDefinition, "many">;
+}
+
+describe("useLinks path overload", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const source = instance("cat1");
+
+  it("routes a multi-hop path token to observePath with root and hops", () => {
+    const { client, calls } = createMockPathClient();
+    renderHook(() => useLinks(source, pathToken([hopOne, hopMany])), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].options.root).toEqual(ref("cat1"));
+    expect(calls[0].options.hops).toEqual([hopOne, hopMany]);
+  });
+
+  it("surfaces deduped endpoints as the many-shape result", () => {
+    const { client, calls } = createMockPathClient();
+    const { result } = renderHook(
+      () => useLinks(source, pathToken([hopOne, hopMany])),
+      { wrapper: createWrapper(client) },
+    );
+
+    act(() => {
+      calls[0].observer.next({
+        data: [instance("p1"), instance("p2")],
+        isOptimistic: false,
+        status: "loaded",
+        error: undefined,
+        lastUpdated: 1,
+      });
+    });
+
+    const endpoints = result.current.data as
+      | Osdk.Instance<ObjectTypeDefinition>[]
+      | null
+      | undefined;
+    expect(endpoints?.map((o) => o.$primaryKey)).toEqual([
+      "p1",
+      "p2",
+    ]);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it("returns the one-shape when every hop is cardinality one", () => {
+    const { client, calls } = createMockPathClient();
+    const { result } = renderHook(
+      () => useLinks(source, pathToken([hopOne, hopOne2])),
+      { wrapper: createWrapper(client) },
+    );
+
+    act(() => {
+      calls[0].observer.next({
+        data: [instance("person1")],
+        isOptimistic: false,
+        status: "loaded",
+        error: undefined,
+        lastUpdated: 1,
+      });
+    });
+
+    const data = result.current.data as
+      | Osdk.Instance<ObjectTypeDefinition>
+      | null
+      | undefined;
+    expect(data?.$primaryKey).toBe("person1");
+  });
+
+  it("resolves the one-shape to null when the path is empty", () => {
+    const { client, calls } = createMockPathClient();
+    const { result } = renderHook(
+      () => useLinks(source, pathToken([hopOne, hopOne2])),
+      { wrapper: createWrapper(client) },
+    );
+
+    act(() => {
+      calls[0].observer.next({
+        data: [],
+        isOptimistic: false,
+        status: "loaded",
+        error: undefined,
+        lastUpdated: 1,
+      });
+    });
+
+    expect(result.current.data).toBeNull();
+  });
+});
+
+describe("useLinks structural-hash subscriptions", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const source = instance("root");
+
+  // Each call builds brand-new descriptor/hop objects, mirroring an inline
+  // `Type.links.X.recursive({...})` token rebuilt on every render.
+  function freshRecursiveToken(): RecursiveTraversal<
+    ObjectTypeDefinition,
+    ObjectTypeDefinition
+  > {
+    return {
+      __descriptor: {
+        kind: "recursive",
+        hops: [{
+          sourceTypeApiName: "Node",
+          linkApiName: "children",
+          targetTypeApiName: "Node",
+          multiplicity: true,
+          sourceIsInterface: false,
+        }],
+        recursive: { maxDepth: 3, maxNodes: 250 },
+      },
+    } as unknown as RecursiveTraversal<
+      ObjectTypeDefinition,
+      ObjectTypeDefinition
+    >;
+  }
+
+  it("reuses the subscription across structurally identical tokens", () => {
+    const { client, calls } = createMockObservableClient();
+    const { rerender } = renderHook(
+      () => useLinks(source, freshRecursiveToken()),
+      { wrapper: createWrapper(client) },
+    );
+
+    expect(calls).toHaveLength(1);
+    rerender();
+    rerender();
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/packages/react/src/new/shapes/__tests__/derivedLinksStore.test.ts
+++ b/packages/react/src/new/shapes/__tests__/derivedLinksStore.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import type { ObjectRef } from "@osdk/api";
+import { ObjectRefMap } from "@osdk/api";
 import type { Client } from "@osdk/client";
 import type * as UnstableClient from "@osdk/client/unstable-do-not-use";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -96,6 +98,50 @@ function linkDef(name: string, targetShape: unknown) {
     },
     config: {},
   };
+}
+
+function recursiveLinkDef(
+  name: string,
+  linkApiName: string,
+  sourceType: string,
+  targetShape: unknown,
+) {
+  return {
+    name,
+    targetShape,
+    objectSetDef: {
+      segments: [{
+        type: "pivotTo",
+        linkName: linkApiName,
+        sourceType,
+        targetType: sourceType,
+      }],
+      recursive: { maxDepth: 3, maxNodes: 1000 },
+    },
+    config: {},
+  };
+}
+
+function recursiveTargetShape(apiName: string) {
+  const baseType = {
+    apiName,
+    primaryKeyType: "string",
+    type: "object",
+  };
+  return {
+    __shapeId: `${apiName}-recursive-shape`,
+    __debugName: `${apiName}RecursiveShape`,
+    __baseType: baseType,
+    __baseTypeApiName: apiName,
+    __props: Object.freeze({}),
+    __derivedLinks: Object.freeze([]),
+    __selectedPropsType: {},
+    __derivedLinksType: {},
+  };
+}
+
+function ref(apiName: string, pk: string): ObjectRef {
+  return { $objectType: apiName, $primaryKey: pk };
 }
 
 function rawInstance(apiName: string, pk: string): Record<string, unknown> {
@@ -228,5 +274,100 @@ describe("createDerivedLinksStore", () => {
     for (const unsub of unsubscribes) {
       expect(unsub).toHaveBeenCalled();
     }
+  });
+
+  it("drives a recursive follow via observeLinkClosure and exposes a flat list with a lazy tree view", async () => {
+    let closureObserver: Observer<unknown> | undefined;
+    const closureUnsub = vi.fn();
+
+    const observableClient = {
+      observeLinkClosure: vi.fn(
+        (_options: unknown, obs: Observer<unknown>) => {
+          closureObserver = obs;
+          return { unsubscribe: closureUnsub };
+        },
+      ),
+      observeObjectSet: vi.fn(() => ({ unsubscribe: vi.fn() })),
+    } as unknown as ObservableClient;
+
+    const targetShape = recursiveTargetShape("Operation");
+    const shape = makeShape([
+      recursiveLinkDef(
+        "descendants",
+        "subOperations",
+        "Operation",
+        targetShape,
+      ),
+    ]);
+    const sourceObject = rawInstance("Operation", "op1");
+
+    const store = createDerivedLinksStore(
+      shape,
+      sourceObject as never,
+      observableClient,
+      {} as Client,
+      {},
+    );
+
+    const notify = vi.fn();
+    store.subscribe(notify);
+
+    await vi.waitFor(() => {
+      expect(closureObserver).toBeDefined();
+    });
+
+    // op1 -> [op2, op4]; op2 -> [op3]
+    const op2 = rawInstance("Operation", "op2");
+    const op3 = rawInstance("Operation", "op3");
+    const op4 = rawInstance("Operation", "op4");
+
+    const adjacency = new ObjectRefMap<ObjectRef[]>();
+    adjacency.set(ref("Operation", "op1"), [
+      ref("Operation", "op2"),
+      ref("Operation", "op4"),
+    ]);
+    adjacency.set(ref("Operation", "op2"), [ref("Operation", "op3")]);
+    adjacency.set(ref("Operation", "op3"), []);
+    adjacency.set(ref("Operation", "op4"), []);
+
+    closureObserver?.next({
+      // BFS discovery order, root excluded
+      data: [op2, op4, op3],
+      adjacency,
+      byDepth: new ObjectRefMap(),
+      frontier: [],
+      depthReached: 2,
+      isExpanding: false,
+      truncated: { byDepth: false, byNodeBudget: false },
+      expand: () => {},
+      isOptimistic: false,
+      status: "loaded",
+      error: undefined,
+      lastUpdated: Date.now(),
+    });
+
+    const snapshot = store.getSnapShot();
+    const flat = snapshot.links.descendants as Array<Record<string, unknown>>;
+    expect(flat.map(o => o.$primaryKey).sort()).toEqual(["op2", "op3", "op4"]);
+
+    const descendantsStatus =
+      (snapshot.linkStatus as Record<string, { isLoading: boolean }>)
+        .descendants;
+    expect(descendantsStatus?.isLoading).toBe(false);
+
+    // The lazy tree view reconstructs nesting from adjacency.
+    const tree = (flat as unknown as {
+      tree: Array<Record<string, unknown>>;
+    }).tree;
+    expect(tree.map(o => o.$primaryKey).sort()).toEqual(["op2", "op4"]);
+
+    const op2Node = tree.find(o => o.$primaryKey === "op2");
+    const op2Children = op2Node?.descendants as
+      | Array<Record<string, unknown>>
+      | undefined;
+    expect(op2Children?.map(o => o.$primaryKey)).toEqual(["op3"]);
+
+    const op4Node = tree.find(o => o.$primaryKey === "op4");
+    expect(op4Node?.descendants).toBeUndefined();
   });
 });

--- a/packages/react/src/new/shapes/derivedLinksStore.ts
+++ b/packages/react/src/new/shapes/derivedLinksStore.ts
@@ -23,7 +23,9 @@
  */
 
 import type {
+  LinkHopDescriptor,
   ObjectOrInterfaceDefinition,
+  ObjectRef,
   ObjectSet,
   ObjectTypeDefinition,
   Osdk,
@@ -37,7 +39,11 @@ import type {
   ShapeDerivedLinks,
 } from "@osdk/api/unstable";
 import type { Client } from "@osdk/client";
-import type { ObservableClient, Observer } from "@osdk/client/observable";
+import type {
+  ObservableClient,
+  ObserveLinkClosure,
+  Observer,
+} from "@osdk/client/observable";
 import {
   applyShapeTransformationsToArray,
   buildObjectSetFromLinkDefByType,
@@ -57,9 +63,11 @@ import type {
   ListObserverPayload,
 } from "./types.js";
 import {
+  attachRecursiveTreeView,
   buildDataWithNestedLinks,
   cleanupNestedMap,
   createLinkEntry,
+  NOOP_FETCH_MORE,
   violationsToError,
 } from "./types.js";
 
@@ -320,10 +328,108 @@ export function createDerivedLinksStore<
     };
   }
 
+  /**
+   * Observer used for `observeLinkClosure` on a recursive link entry. The
+   * closure emits a flat, root-excluded discovery list plus an `adjacency`
+   * map. We keep the flat list as the entry's canonical `data` (so it behaves
+   * like every other link list) and attach a lazy `tree` view derived from
+   * `adjacency` so consumers can opt into the reconstructed nesting.
+   */
+  function createClosureObserver(
+    entry: LinkEntry,
+    rootRef: ObjectRef,
+  ): Observer<ObserveLinkClosure.CallbackArgs<ObjectOrInterfaceDefinition>> {
+    return {
+      next: (payload) => {
+        if (isDestroyed) {
+          return;
+        }
+        const transformResult = applyShapeTransformationsToArray(
+          entry.linkDef.targetShape,
+          payload.data,
+        );
+
+        const stillLoading = payload.isExpanding
+          || payload.status === "loading";
+        entry.status = stillLoading ? "loading" : "loaded";
+        entry.hasMore = false;
+        entry.fetchMore = NOOP_FETCH_MORE;
+        entry.error = payload.error ?? violationsToError(
+          entry.linkDef.targetShape,
+          transformResult.violations,
+        );
+
+        entry.data = attachRecursiveTreeView(
+          transformResult.data,
+          payload.adjacency,
+          rootRef,
+          entry.linkDef.name,
+        );
+
+        notifySubscribers();
+      },
+      error: (err) => {
+        if (isDestroyed) {
+          return;
+        }
+        entry.status = "error";
+        entry.error = wrapError(err);
+        notifySubscribers();
+      },
+      complete: () => {},
+    };
+  }
+
+  /**
+   * Drives a recursive follow entry via `observeLinkClosure`. The link's single
+   * segment describes one expansion hop; `objectSetDef.recursive` carries the
+   * depth/node budget. The closure is rooted at the entry's source object.
+   */
+  function startClosureObservation(entry: LinkEntry): void {
+    const recursive = entry.linkDef.objectSetDef.recursive;
+    if (recursive == null) {
+      return;
+    }
+    const segment = entry.linkDef.objectSetDef.segments[0];
+    const source = entry.sourceObject;
+    const root: ObjectRef = {
+      $objectType: source.$objectType,
+      $primaryKey: source.$primaryKey,
+    };
+    const hop: LinkHopDescriptor = {
+      sourceTypeApiName: segment.sourceType ?? source.$objectType,
+      linkApiName: segment.linkName,
+      targetTypeApiName: segment.targetType ?? source.$objectType,
+      multiplicity: true,
+      sourceIsInterface: false,
+    };
+
+    const subscription = observableClient.observeLinkClosure(
+      {
+        root,
+        hop,
+        maxDepth: recursive.maxDepth,
+        maxNodes: recursive.maxNodes,
+      },
+      createClosureObserver(entry, root),
+    );
+
+    if (isDestroyed) {
+      subscription.unsubscribe();
+      return;
+    }
+    entry.subscription = subscription;
+  }
+
   async function startLinkObservationInternal(
     entry: LinkEntry,
     sourceType: ObjectOrInterfaceDefinition,
   ): Promise<void> {
+    if (entry.linkDef.objectSetDef.recursive) {
+      startClosureObservation(entry);
+      return;
+    }
+
     const objectSet = await buildObjectSetFromLinkDefByType(
       client,
       sourceType,

--- a/packages/react/src/new/shapes/types.ts
+++ b/packages/react/src/new/shapes/types.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import type { ObjectOrInterfaceDefinition, Osdk } from "@osdk/api";
+import type { ObjectOrInterfaceDefinition, ObjectRef, Osdk } from "@osdk/api";
+import { objectRefKey, objectRefOf } from "@osdk/api";
 import type { ShapeDerivedLinkDef } from "@osdk/api/shapes-internal";
 import type {
   LinkStatus,
@@ -169,7 +170,8 @@ export function buildDataWithNestedLinks(
  * A link is batchable when it can use observeLinks (one API call for all source
  * objects) instead of per-object observeObjectSet calls. This requires a simple
  * single-hop pivotTo with no filters, ordering, limits, or set operations,
- * since observeLinks doesn't support those query features.
+ * since observeLinks doesn't support those query features. Recursive follows are
+ * never batchable: they are driven per-root by observeLinkClosure.
  */
 export function isBatchableLink(linkDef: ShapeDerivedLinkDef): boolean {
   const def = linkDef.objectSetDef;
@@ -181,5 +183,71 @@ export function isBatchableLink(linkDef: ShapeDerivedLinkDef): boolean {
     && !def.orderBy
     && def.limit == null
     && !def.distinct
+    && !def.recursive
   );
+}
+
+/**
+ * Attaches a lazy, non-enumerable `tree` view to a flat recursive-closure
+ * result. Canonical storage stays flat (the array itself) so spreads and
+ * iteration behave like any other link list; `tree` reconstructs the nesting on
+ * demand from the closure's `adjacency` map, starting at `rootRef` and nesting
+ * each node's children under `childLinkName` (the recursive link's own name).
+ * Nodes with no resolved children omit the `childLinkName` key entirely.
+ */
+export function attachRecursiveTreeView(
+  flatData: AnyShapeInstance[],
+  adjacency: ReadonlyObjectRefMap,
+  rootRef: ObjectRef,
+  childLinkName: string,
+): AnyShapeInstance[] {
+  const byRef = new Map<string, AnyShapeInstance>();
+  for (const obj of flatData) {
+    byRef.set(objectRefKey(objectRefOf(obj)), obj);
+  }
+
+  function buildChildren(
+    parentRef: ObjectRef,
+    visited: ReadonlySet<string>,
+  ): AnyShapeInstance[] {
+    const childRefs = adjacency.get(parentRef) ?? [];
+    const result: AnyShapeInstance[] = [];
+    for (const childRef of childRefs) {
+      const key = objectRefKey(childRef);
+      if (visited.has(key)) {
+        continue;
+      }
+      const child = byRef.get(key);
+      if (child === undefined) {
+        continue;
+      }
+      const nextVisited = new Set(visited).add(key);
+      const grandchildren = buildChildren(childRef, nextVisited);
+      result.push(
+        grandchildren.length > 0
+          ? { ...child, [childLinkName]: grandchildren } as AnyShapeInstance
+          : child,
+      );
+    }
+    return result;
+  }
+
+  Object.defineProperty(flatData, "tree", {
+    get() {
+      return buildChildren(rootRef, new Set([objectRefKey(rootRef)]));
+    },
+    enumerable: false,
+    configurable: true,
+  });
+
+  return flatData;
+}
+
+/**
+ * Minimal structural view of the closure `adjacency` map used by
+ * {@link attachRecursiveTreeView}. Avoids a hard dependency on the concrete
+ * `ObjectRefMap` class while still keying lookups structurally.
+ */
+export interface ReadonlyObjectRefMap {
+  get(ref: ObjectRef): ObjectRef[] | undefined;
 }

--- a/packages/react/src/new/useLinks.ts
+++ b/packages/react/src/new/useLinks.ts
@@ -15,12 +15,24 @@
  */
 
 import type {
+  LinkDef,
   LinkedType,
+  LinkHopDescriptor,
   LinkNames,
+  LinkTraversal,
   ObjectOrInterfaceDefinition,
+  ObjectRef,
+  Path,
+  RecursiveTraversal,
 } from "@osdk/api";
+import { hashTraversal, ObjectRefMap } from "@osdk/api";
 import type { Osdk, PropertyKeys, WhereClause } from "@osdk/client";
-import type { ObserveLinks } from "@osdk/client/observable";
+import type {
+  ObservableClient,
+  ObserveLinkClosure,
+  ObserveLinks,
+  ObservePath,
+} from "@osdk/client/observable";
 import React from "react";
 import { extractPayloadError, isPayloadLoading } from "./hookUtils.js";
 import { devToolsMetadata, makeExternalStore } from "./makeExternalStore.js";
@@ -137,9 +149,276 @@ export interface UseLinksResult<Q extends ObjectOrInterfaceDefinition> {
   hasMore: boolean;
 }
 
+/**
+ * Options accepted by the token overloads of {@link useLinks}. Filtering and
+ * ordering live on the token itself (via `.where(...)` / `.orderBy(...)`), so
+ * only runtime knobs are configured here.
+ */
+export interface UseLinkTokenOptions {
+  /** The preferred page size for the linked objects list. */
+  pageSize?: number;
+
+  /**
+   * The mode to use for fetching data.
+   * - undefined: Fetch data if not already in cache
+   * - "force": Always fetch fresh data
+   * - "offline": Only use cached data, don't make network requests
+   */
+  mode?: "force" | "offline";
+
+  /**
+   * The number of milliseconds to wait after the last observed link change.
+   */
+  dedupeIntervalMs?: number;
+
+  /**
+   * Enable or disable the query. When `false`, the query will not automatically
+   * execute, returning cached data without fetching from the server.
+   *
+   * @default true
+   */
+  enabled?: boolean;
+
+  /**
+   * When true, includes all properties of the underlying concrete object type
+   * for interface link targets. Has no effect when the link target is a plain
+   * object type.
+   */
+  $includeAllBaseObjectProperties?: boolean;
+
+  /**
+   * When traversing an interface link target, return the full concrete object
+   * type instances instead of interface views. Has no effect when the link
+   * target is already an object type.
+   */
+  resolveToObjectType?: boolean;
+}
+
+/**
+ * Result of a cardinality `"one"` token traversal.
+ *
+ * `data` distinguishes three states: `undefined` while loading, `null` when the
+ * link is definitively absent, and the object instance when present.
+ */
+export interface UseLinkOneResult<T extends ObjectOrInterfaceDefinition> {
+  data: Osdk.Instance<T, "$allBaseProperties"> | null | undefined;
+  isLoading: boolean;
+  error: Error | undefined;
+  isOptimistic: boolean;
+}
+
+/**
+ * Result of a cardinality `"many"` token traversal.
+ *
+ * `data` is the list of linked instances, or `undefined` while loading.
+ */
+export interface UseLinkManyResult<T extends ObjectOrInterfaceDefinition> {
+  data: Osdk.Instance<T, "$allBaseProperties">[] | undefined;
+  isLoading: boolean;
+  error: Error | undefined;
+  isOptimistic: boolean;
+  fetchMore: (() => Promise<unknown>) | undefined;
+  hasMore: boolean;
+
+  /**
+   * Maps each source object's {@link ObjectRef} to its linked object instances.
+   * Present when observing a `"many"` link; useful when observing links from
+   * multiple source objects to determine which source links to which targets.
+   */
+  bySource?: ObjectRefMap<
+    ReadonlyArray<Osdk.Instance<T, "$allBaseProperties">>
+  >;
+}
+
+/**
+ * Result of a recursive token traversal (`Type.links.X.recursive({...})`).
+ *
+ * The closure is streamed: `data` is the flat, deduped, root-excluded discovery
+ * order, growing one BFS level at a time. `adjacency` and `byDepth` describe the
+ * shape (a tree view is derived in a later work-stream), `frontier` lists nodes
+ * with potentially-unexpanded children, and `expand(ref)` extends the closure
+ * from one already-discovered node.
+ */
+export interface UseLinkClosureResult<T extends ObjectOrInterfaceDefinition> {
+  data: Osdk.Instance<T, "$allBaseProperties">[];
+  /** parent -> children, including back-edges to already-visited nodes. */
+  adjacency: ObjectRefMap<ObjectRef[]>;
+  /** depth (root = 0) of every discovered node. */
+  byDepth: ObjectRefMap<number>;
+  /** nodes with potentially-unexpanded children. */
+  frontier: ObjectRef[];
+  /** deepest level reached so far. */
+  depthReached: number;
+  /** true while a level is still being expanded. */
+  isExpanding: boolean;
+  truncated: { byDepth: boolean; byNodeBudget: boolean };
+  /** extend the closure from one already-discovered node. */
+  expand: (ref: ObjectRef) => void;
+  isLoading: boolean;
+  error: Error | undefined;
+  isOptimistic: boolean;
+}
+
+/**
+ * Payload surfaced by the external store backing {@link useLinks}. The string
+ * and `"one"`/`"many"` token paths emit {@link ObserveLinks.CallbackArgs}; the
+ * recursive token path emits {@link ObserveLinkClosure.CallbackArgs}.
+ */
+type LinksStorePayload =
+  | ObserveLinks.CallbackArgs<ObjectOrInterfaceDefinition>
+  | ObserveLinkClosure.CallbackArgs<ObjectOrInterfaceDefinition>
+  | ObservePath.CallbackArgs<ObjectOrInterfaceDefinition>;
+
 const emptyArray = Object.freeze([]);
 const emptyMap: ReadonlyMap<string | number, ReadonlyArray<never>> = new Map();
+const emptyAdjacency: ObjectRefMap<ObjectRef[]> = new ObjectRefMap();
+const emptyByDepth: ObjectRefMap<number> = new ObjectRefMap();
+const defaultTruncated = Object.freeze({
+  byDepth: false,
+  byNodeBudget: false,
+});
+const noopExpand = (_ref: ObjectRef): void => {};
+const emptyBySource: ObjectRefMap<
+  ReadonlyArray<
+    Osdk.Instance<ObjectOrInterfaceDefinition, "$allBaseProperties">
+  >
+> = new ObjectRefMap();
 
+interface ObserveLinksOptionInputs {
+  linkName: string;
+  where: object | undefined;
+  orderBy: Record<string, "asc" | "desc" | undefined> | undefined;
+  $select: readonly string[] | undefined;
+  pageSize: number | undefined;
+  mode: "force" | "offline" | undefined;
+  dedupeIntervalMs: number | undefined;
+  $includeAllBaseObjectProperties: boolean | undefined;
+  resolveToObjectType: boolean | undefined;
+}
+
+/**
+ * Canonicalizes the where/orderBy/$select inputs via the observable client and
+ * assembles the options object passed to `observeLinks`. Shared by both the
+ * legacy string path and the token path so they canonicalize identically.
+ */
+function buildObserveLinksOptions(
+  observableClient: ObservableClient,
+  inputs: ObserveLinksOptionInputs,
+): {
+  linkName: string;
+  where: object | undefined;
+  pageSize: number | undefined;
+  orderBy: Record<string, "asc" | "desc" | undefined> | undefined;
+  mode: "force" | "offline" | undefined;
+  dedupeInterval: number;
+  $includeAllBaseObjectProperties: boolean | undefined;
+  resolveToObjectType: boolean | undefined;
+  select?: readonly string[];
+} {
+  const canon = observableClient.canonicalizeOptions({
+    where: inputs.where,
+    orderBy: inputs.orderBy,
+    $select: inputs.$select,
+  });
+  return {
+    linkName: inputs.linkName,
+    where: canon.where,
+    pageSize: inputs.pageSize,
+    orderBy: canon.orderBy,
+    mode: inputs.mode,
+    dedupeInterval: inputs.dedupeIntervalMs ?? 2_000,
+    $includeAllBaseObjectProperties: inputs.$includeAllBaseObjectProperties,
+    resolveToObjectType: inputs.resolveToObjectType,
+    ...(canon.$select ? { select: canon.$select } : {}),
+  };
+}
+
+function orderByFromDescriptor(
+  hop: LinkHopDescriptor | undefined,
+): Record<string, "asc" | "desc" | undefined> | undefined {
+  if (hop?.orderBy == null) {
+    return undefined;
+  }
+  const result: Record<string, "asc" | "desc"> = {};
+  for (const entry of hop.orderBy) {
+    result[entry.property] = entry.direction;
+  }
+  return result;
+}
+
+/**
+ * Hook to observe the recursive closure of a self-referential link from a
+ * source object using a `Type.links.<name>.recursive({...})` token. The closure
+ * streams: `data` grows one BFS level at a time. Must be declared before the
+ * `"many"` overload because a {@link RecursiveTraversal} structurally satisfies
+ * `LinkTraversal<S, T, "many">`.
+ */
+export function useLinks<
+  S extends ObjectOrInterfaceDefinition,
+  T extends ObjectOrInterfaceDefinition,
+>(
+  source: Osdk.Instance<S> | undefined,
+  link: RecursiveTraversal<S, T>,
+  options?: UseLinkTokenOptions,
+): UseLinkClosureResult<T>;
+/**
+ * Hook to observe a multi-hop `.then()` path traversal whose every hop is
+ * cardinality `"one"`. The deduped endpoint resolves to the one-shape: `data`
+ * is `undefined` while loading, `null` when the path is definitively empty, and
+ * the endpoint instance when present.
+ */
+export function useLinks<
+  S extends ObjectOrInterfaceDefinition,
+  T extends ObjectOrInterfaceDefinition,
+>(
+  source: Osdk.Instance<S> | undefined,
+  link: Path<S, T, "one">,
+  options?: UseLinkTokenOptions,
+): UseLinkOneResult<T>;
+/**
+ * Hook to observe a cardinality `"one"` link from a source object using a
+ * generated `Type.links.<name>` token. `data` is `undefined` while loading,
+ * `null` when the link is definitively absent, and the linked instance when
+ * present.
+ */
+export function useLinks<
+  S extends ObjectOrInterfaceDefinition,
+  T extends ObjectOrInterfaceDefinition,
+>(
+  source: Osdk.Instance<S> | undefined,
+  link: LinkDef<S, T, "one">,
+  options?: UseLinkTokenOptions,
+): UseLinkOneResult<T>;
+/**
+ * Hook to observe a cardinality `"many"` link or traversal from a source
+ * object using a generated `Type.links.<name>` token. `data` is the list of
+ * linked instances, or `undefined` while loading.
+ */
+export function useLinks<
+  S extends ObjectOrInterfaceDefinition,
+  T extends ObjectOrInterfaceDefinition,
+>(
+  source: Osdk.Instance<S> | undefined,
+  link: LinkDef<S, T, "many"> | LinkTraversal<S, T, "many">,
+  options?: UseLinkTokenOptions,
+): UseLinkManyResult<T>;
+/**
+ * Hook to observe a cardinality `"many"` link or traversal from multiple source
+ * objects using a generated `Type.links.<name>` token. In addition to the
+ * deduped, flattened `data` list, the result exposes `bySource`, an
+ * {@link ObjectRefMap} keyed by each source object's `ObjectRef`, mapping it to
+ * the linked instances reachable from that source.
+ */
+export function useLinks<
+  S extends ObjectOrInterfaceDefinition,
+  T extends ObjectOrInterfaceDefinition,
+>(
+  sources: ReadonlyArray<Osdk.Instance<S>> | undefined,
+  link: LinkDef<S, T, "many"> | LinkTraversal<S, T, "many">,
+  options?: UseLinkTokenOptions,
+): UseLinkManyResult<T> & {
+  bySource: ObjectRefMap<ReadonlyArray<Osdk.Instance<T, "$allBaseProperties">>>;
+};
 /**
  * Hook to observe links from an object or array of objects.
  *
@@ -154,9 +433,57 @@ export function useLinks<
 >(
   objects: Osdk.Instance<T> | Array<Osdk.Instance<T>> | undefined,
   linkName: L,
-  options: UseLinksOptions<LinkedType<T, L>> = {},
-): UseLinksResult<LinkedType<T, L>> {
+  options?: UseLinksOptions<LinkedType<T, L>>,
+): UseLinksResult<LinkedType<T, L>>;
+export function useLinks(
+  objects:
+    | Osdk.Instance<ObjectOrInterfaceDefinition>
+    | ReadonlyArray<Osdk.Instance<ObjectOrInterfaceDefinition>>
+    | undefined,
+  link:
+    | string
+    | LinkTraversal<
+      ObjectOrInterfaceDefinition,
+      ObjectOrInterfaceDefinition,
+      "one" | "many"
+    >,
+  options:
+    & UseLinksBaseOptions<ObjectOrInterfaceDefinition>
+    & { resolveToObjectType?: boolean } = {},
+):
+  | UseLinksResult<ObjectOrInterfaceDefinition>
+  | UseLinkOneResult<ObjectOrInterfaceDefinition>
+  | UseLinkManyResult<ObjectOrInterfaceDefinition>
+  | UseLinkClosureResult<ObjectOrInterfaceDefinition>
+{
   const { observableClient } = React.useContext(OsdkContext);
+
+  const isToken = typeof link !== "string";
+  const descriptor = typeof link === "string" ? undefined : link.__descriptor;
+  // Token descriptors rebuild their hops/recursive objects every render, so key
+  // the subscription off a structural hash rather than object identity.
+  const descriptorHash = descriptor === undefined
+    ? undefined
+    : hashTraversal(descriptor);
+  const hop = descriptor?.hops[0];
+  const recursive = descriptor?.kind === "recursive"
+    ? descriptor.recursive
+    : undefined;
+  const pathHops = descriptor?.kind === "path" ? descriptor.hops : undefined;
+  const allHopsOne = pathHops?.every((h) => !h.multiplicity) ?? false;
+  // The token recreates its `hops` array each render, so key the subscription
+  // off the hops' stable content rather than the array's identity.
+  const pathHopsKey = pathHops === undefined
+    ? ""
+    : JSON.stringify(pathHops);
+  const cardinality: "one" | "many" | undefined = hop === undefined
+    ? undefined
+    : hop.multiplicity
+    ? "many"
+    : "one";
+  const linkName = typeof link === "string"
+    ? link
+    : link.__descriptor.hops[0].linkApiName;
 
   const {
     enabled = true,
@@ -165,11 +492,35 @@ export function useLinks<
     ...otherOptions
   } = options;
 
-  const canonOptions = observableClient.canonicalizeOptions({
-    where: otherOptions.where,
-    orderBy: otherOptions.orderBy,
-    $select: otherOptions.$select,
-  });
+  const observeOptionInputs: ObserveLinksOptionInputs = {
+    linkName,
+    mode: otherOptions.mode,
+    dedupeIntervalMs: otherOptions.dedupeIntervalMs,
+    $includeAllBaseObjectProperties,
+    resolveToObjectType,
+    // Token traversals carry where/orderBy/limit on the descriptor; the string
+    // path reads them off the options object instead.
+    ...(isToken
+      ? {
+        where: hop?.where,
+        orderBy: orderByFromDescriptor(hop),
+        $select: undefined,
+        pageSize: otherOptions.pageSize ?? hop?.limit,
+      }
+      : {
+        where: otherOptions.where,
+        orderBy: otherOptions.orderBy,
+        $select: otherOptions.$select,
+        pageSize: otherOptions.pageSize,
+      }),
+  };
+
+  // The recursive path drives a client-side BFS via observeLinkClosure and does
+  // not go through link-list canonicalization, so skip it (and its
+  // canonicalizeOptions call) entirely when a recursive token is supplied.
+  const observeOptions = (recursive !== undefined || pathHops !== undefined)
+    ? undefined
+    : buildObserveLinksOptions(observableClient, observeOptionInputs);
 
   const objectsKey = React.useMemo(() => {
     if (objects === undefined) return "";
@@ -178,7 +529,9 @@ export function useLinks<
   }, [objects]);
 
   // Convert single object to array for consistent handling
-  const objectsArray: ReadonlyArray<Osdk.Instance<T>> = React.useMemo(() => {
+  const objectsArray: ReadonlyArray<
+    Osdk.Instance<ObjectOrInterfaceDefinition>
+  > = React.useMemo(() => {
     return objects === undefined
       ? emptyArray
       : Array.isArray(objects)
@@ -188,43 +541,72 @@ export function useLinks<
 
   const { subscribe, getSnapShot } = React.useMemo(
     () => {
-      if (!enabled) {
-        return makeExternalStore<
-          ObserveLinks.CallbackArgs<LinkedType<T, L>>
-        >(
-          () => ({ unsubscribe: () => {} }),
-          devToolsMetadata({
-            hookType: "useLinks",
-            sourceObjectType: objectsArray[0]?.$apiName,
-            linkName,
-          }),
+      const source = objectsArray[0];
+      const metadata = devToolsMetadata({
+        hookType: "useLinks",
+        sourceObjectType: source?.$apiName,
+        linkName,
+      });
+
+      if (recursive !== undefined && hop !== undefined) {
+        if (!enabled || source === undefined) {
+          return makeExternalStore<LinksStorePayload>(
+            () => ({ unsubscribe: () => {} }),
+            metadata,
+          );
+        }
+        const root: ObjectRef = {
+          $objectType: source.$objectType,
+          $primaryKey: source.$primaryKey,
+        };
+        return makeExternalStore<LinksStorePayload>(
+          (observer) =>
+            observableClient.observeLinkClosure(
+              {
+                root,
+                hop,
+                maxDepth: recursive.maxDepth,
+                maxNodes: recursive.maxNodes,
+              },
+              observer,
+            ),
+          metadata,
         );
       }
-      return makeExternalStore<
-        ObserveLinks.CallbackArgs<LinkedType<T, L>>
-      >(
+
+      if (pathHops !== undefined) {
+        if (!enabled || source === undefined) {
+          return makeExternalStore<LinksStorePayload>(
+            () => ({ unsubscribe: () => {} }),
+            metadata,
+          );
+        }
+        const root: ObjectRef = {
+          $objectType: source.$objectType,
+          $primaryKey: source.$primaryKey,
+        };
+        return makeExternalStore<LinksStorePayload>(
+          (observer) =>
+            observableClient.observePath({ root, hops: pathHops }, observer),
+          metadata,
+        );
+      }
+
+      if (!enabled || observeOptions === undefined) {
+        return makeExternalStore<LinksStorePayload>(
+          () => ({ unsubscribe: () => {} }),
+          metadata,
+        );
+      }
+      return makeExternalStore<LinksStorePayload>(
         (observer) =>
-          observableClient.observeLinks<T, L>(
+          observableClient.observeLinks(
             objectsArray,
             linkName,
-            {
-              linkName,
-              where: canonOptions.where,
-              pageSize: otherOptions.pageSize,
-              orderBy: canonOptions.orderBy,
-              mode: otherOptions.mode,
-              dedupeInterval: otherOptions.dedupeIntervalMs ?? 2_000,
-              $includeAllBaseObjectProperties,
-              resolveToObjectType,
-              ...(canonOptions.$select ? { select: canonOptions.$select } : {}),
-            },
+            observeOptions,
             observer,
           ),
-        devToolsMetadata({
-          hookType: "useLinks",
-          sourceObjectType: objectsArray[0]?.$apiName,
-          linkName,
-        }),
+        metadata,
       );
     },
     [
@@ -233,12 +615,17 @@ export function useLinks<
       objectsArray,
       objectsKey,
       linkName,
-      canonOptions.where,
-      otherOptions.pageSize,
-      canonOptions.orderBy,
-      otherOptions.mode,
-      otherOptions.dedupeIntervalMs,
-      canonOptions.$select,
+      // Token path: structural hash covers hops/where/orderBy/recursive/path.
+      descriptorHash,
+      // String path keeps keying off the canonicalized option identities; for
+      // the token path these derive from the descriptor and are folded into the
+      // hash above, so they must not force a resubscribe on every render.
+      isToken ? undefined : observeOptions?.where,
+      observeOptions?.pageSize,
+      isToken ? undefined : observeOptions?.orderBy,
+      observeOptions?.mode,
+      observeOptions?.dedupeInterval,
+      observeOptions?.select,
       $includeAllBaseObjectProperties,
       !!resolveToObjectType,
     ],
@@ -249,14 +636,91 @@ export function useLinks<
     getSnapShot,
   );
 
-  return React.useMemo(() => ({
-    links: payload?.resolvedList,
-    linkedObjectsBySourcePrimaryKey: payload?.linkedObjectsBySourcePrimaryKey
-      ?? emptyMap,
-    isLoading: isPayloadLoading(payload, enabled),
-    isOptimistic: payload?.isOptimistic ?? false,
-    error: extractPayloadError(payload, "Failed to load links"),
-    fetchMore: payload?.hasMore ? payload?.fetchMore : undefined,
-    hasMore: payload?.hasMore ?? false,
-  }), [payload, enabled]);
+  return React.useMemo(() => {
+    const isLoading = isPayloadLoading(payload, enabled);
+    const error = extractPayloadError(payload, "Failed to load links");
+    const isOptimistic = payload?.isOptimistic ?? false;
+
+    if (recursive !== undefined) {
+      const closure = payload as
+        | ObserveLinkClosure.CallbackArgs<ObjectOrInterfaceDefinition>
+        | undefined;
+      return {
+        data: closure?.data ?? [],
+        adjacency: closure?.adjacency ?? emptyAdjacency,
+        byDepth: closure?.byDepth ?? emptyByDepth,
+        frontier: closure?.frontier ?? [],
+        depthReached: closure?.depthReached ?? 0,
+        isExpanding: closure?.isExpanding ?? false,
+        truncated: closure?.truncated ?? defaultTruncated,
+        expand: closure?.expand ?? noopExpand,
+        isLoading,
+        error,
+        isOptimistic,
+      };
+    }
+
+    if (pathHops !== undefined) {
+      const pathPayload = payload as
+        | ObservePath.CallbackArgs<ObjectOrInterfaceDefinition>
+        | undefined;
+      if (allHopsOne) {
+        return {
+          data: pathPayload?.data === undefined
+            ? undefined
+            : (pathPayload.data[0] ?? null),
+          isLoading,
+          error,
+          isOptimistic,
+        };
+      }
+      return {
+        data: pathPayload?.data,
+        isLoading,
+        error,
+        isOptimistic,
+        fetchMore: undefined,
+        hasMore: false,
+      };
+    }
+
+    const linksPayload = payload as
+      | ObserveLinks.CallbackArgs<ObjectOrInterfaceDefinition>
+      | undefined;
+
+    if (cardinality === "one") {
+      return {
+        data: linksPayload?.resolvedList === undefined
+          ? undefined
+          : (linksPayload.resolvedList[0] ?? null),
+        isLoading,
+        error,
+        isOptimistic,
+      };
+    }
+
+    if (cardinality === "many") {
+      return {
+        data: linksPayload?.resolvedList,
+        isLoading,
+        error,
+        isOptimistic,
+        fetchMore: linksPayload?.hasMore ? linksPayload?.fetchMore : undefined,
+        hasMore: linksPayload?.hasMore ?? false,
+        bySource: linksPayload?.linkedObjectsBySource ?? emptyBySource,
+      };
+    }
+
+    return {
+      links: linksPayload?.resolvedList,
+      linkedObjectsBySourcePrimaryKey:
+        // eslint-disable-next-line @typescript-eslint/no-deprecated -- legacy result surface intentionally mirrors the deprecated payload alias
+        linksPayload?.linkedObjectsBySourcePrimaryKey ?? emptyMap,
+      isLoading,
+      isOptimistic,
+      error,
+      fetchMore: linksPayload?.hasMore ? linksPayload?.fetchMore : undefined,
+      hasMore: linksPayload?.hasMore ?? false,
+    };
+  }, [payload, enabled, cardinality, recursive, pathHopsKey, allHopsOne]);
 }

--- a/packages/react/src/testing/createMockObservableClient.ts
+++ b/packages/react/src/testing/createMockObservableClient.ts
@@ -20,6 +20,7 @@ import type {
   PrimaryKeyType,
   WhereClause,
 } from "@osdk/api";
+import { ObjectRefMap } from "@osdk/api";
 import type {
   ObservableClient,
   Observer,
@@ -273,6 +274,39 @@ export function createMockObservableClient(
       }, delay);
       return { unsubscribe: () => {} };
     }) as ObservableClient["observeLinks"],
+
+    observeLinkClosure: ((_options, subFn): Unsubscribable => {
+      setTimeout(() => {
+        (subFn as Observer<unknown>).next({
+          data: [],
+          adjacency: new ObjectRefMap(),
+          byDepth: new ObjectRefMap(),
+          frontier: [],
+          depthReached: 0,
+          isExpanding: false,
+          truncated: { byDepth: false, byNodeBudget: false },
+          expand: () => {},
+          isOptimistic: false,
+          status: "loaded",
+          error: undefined,
+          lastUpdated: Date.now(),
+        });
+      }, delay);
+      return { unsubscribe: () => {} };
+    }) as ObservableClient["observeLinkClosure"],
+
+    observePath: ((_options, subFn): Unsubscribable => {
+      setTimeout(() => {
+        (subFn as Observer<unknown>).next({
+          data: [],
+          isOptimistic: false,
+          status: "loaded",
+          error: undefined,
+          lastUpdated: Date.now(),
+        });
+      }, delay);
+      return { unsubscribe: () => {} };
+    }) as ObservableClient["observePath"],
 
     applyAction: (async () => ({}) as never) as ObservableClient["applyAction"],
     validateAction:

--- a/packages/react/test/useLinks.enabled.test.tsx
+++ b/packages/react/test/useLinks.enabled.test.tsx
@@ -15,6 +15,7 @@
  */
 
 import type { ObjectTypeDefinition, Osdk } from "@osdk/api";
+import { ObjectRefMap } from "@osdk/api";
 import { act, renderHook } from "@testing-library/react";
 import * as React from "react";
 import { beforeEach, describe, expect, it, vitest } from "vitest";
@@ -218,5 +219,210 @@ describe("useLinks enabled option", () => {
       const options = mockObserveLinks.mock.calls[0][2];
       expect(options.resolveToObjectType).toBeUndefined();
     });
+  });
+});
+
+const manyToken = {
+  __descriptor: {
+    kind: "single",
+    hops: [{
+      sourceTypeApiName: "Category",
+      linkApiName: "childCategories",
+      targetTypeApiName: "Category",
+      multiplicity: true,
+      sourceIsInterface: false,
+    }],
+  },
+  cardinality: "many",
+} as unknown as Parameters<typeof useLinks>[1];
+
+const oneToken = {
+  __descriptor: {
+    kind: "single",
+    hops: [{
+      sourceTypeApiName: "Category",
+      linkApiName: "owningGroup",
+      targetTypeApiName: "Group",
+      multiplicity: false,
+      sourceIsInterface: false,
+    }],
+  },
+  cardinality: "one",
+} as unknown as Parameters<typeof useLinks>[1];
+
+describe("useLinks token overload", () => {
+  const mockObserveLinks = vitest.fn();
+
+  const createWrapper = () => {
+    const observableClient = {
+      observeLinks: mockObserveLinks,
+      canonicalizeOptions: vitest.fn((opts) => opts),
+    } as any;
+
+    return ({ children }: React.PropsWithChildren) => (
+      <OsdkContext.Provider
+        value={{ observableClient, devtoolsEnabled: false }}
+      >
+        {children}
+      </OsdkContext.Provider>
+    );
+  };
+
+  beforeEach(() => {
+    mockObserveLinks.mockClear();
+    mockObserveLinks.mockReturnValue({ unsubscribe: vitest.fn() });
+  });
+
+  it("should observe a 'many' token using its linkApiName", () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () => useLinks(mockObject, manyToken),
+      { wrapper },
+    );
+
+    expect(mockObserveLinks).toHaveBeenCalledTimes(1);
+    expect(mockObserveLinks.mock.calls[0][1]).toBe("childCategories");
+
+    const observer = mockObserveLinks.mock.calls[0][3];
+    const linkedA = {
+      $objectType: "Category",
+      $primaryKey: "cat-1",
+      $apiName: "Category",
+    };
+    const linkedB = {
+      $objectType: "Category",
+      $primaryKey: "cat-2",
+      $apiName: "Category",
+    };
+
+    act(() => {
+      observer.next({
+        resolvedList: [linkedA, linkedB],
+        linkedObjectsBySourcePrimaryKey: new Map(),
+        status: "loaded",
+        isOptimistic: false,
+        hasMore: false,
+      });
+    });
+
+    expect(result.current.data).toEqual([linkedA, linkedB]);
+  });
+
+  it("should project a 'one' token through loading, absent, and present", () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () => useLinks(mockObject, oneToken),
+      { wrapper },
+    );
+
+    expect(mockObserveLinks).toHaveBeenCalledTimes(1);
+    expect(mockObserveLinks.mock.calls[0][1]).toBe("owningGroup");
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(true);
+
+    const observer = mockObserveLinks.mock.calls[0][3];
+
+    act(() => {
+      observer.next({
+        resolvedList: [],
+        linkedObjectsBySourcePrimaryKey: new Map(),
+        status: "loaded",
+        isOptimistic: false,
+        hasMore: false,
+      });
+    });
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+
+    const linkedGroup = {
+      $objectType: "Group",
+      $primaryKey: "group-1",
+      $apiName: "Group",
+    };
+
+    act(() => {
+      observer.next({
+        resolvedList: [linkedGroup],
+        linkedObjectsBySourcePrimaryKey: new Map(),
+        status: "loaded",
+        isOptimistic: false,
+        hasMore: false,
+      });
+    });
+
+    expect(result.current.data).toEqual(linkedGroup);
+  });
+
+  it("should project bySource as an ObjectRefMap for a multi-source 'many' token", () => {
+    const wrapper = createWrapper();
+
+    const sourceA: Osdk.Instance<typeof MockObjectType> = {
+      $objectType: "Category",
+      $primaryKey: "src-a",
+      $apiName: "Category",
+    } as any;
+    const sourceB: Osdk.Instance<typeof MockObjectType> = {
+      $objectType: "Category",
+      $primaryKey: "src-b",
+      $apiName: "Category",
+    } as any;
+    const sources = [sourceA, sourceB];
+
+    const { result } = renderHook(
+      () => useLinks(sources, manyToken),
+      { wrapper },
+    );
+
+    expect(result.current.bySource).toBeInstanceOf(ObjectRefMap);
+    expect(result.current.bySource.size).toBe(0);
+
+    const observer = mockObserveLinks.mock.calls[0][3];
+    const linkedA = {
+      $objectType: "Category",
+      $primaryKey: "cat-1",
+      $apiName: "Category",
+    };
+    const linkedB = {
+      $objectType: "Category",
+      $primaryKey: "cat-2",
+      $apiName: "Category",
+    };
+
+    const bySource = new ObjectRefMap<ReadonlyArray<typeof linkedA>>();
+    bySource.set({ $objectType: "Category", $primaryKey: "src-a" }, [linkedA]);
+    bySource.set({ $objectType: "Category", $primaryKey: "src-b" }, [linkedB]);
+
+    act(() => {
+      observer.next({
+        resolvedList: [linkedA, linkedB],
+        linkedObjectsBySourcePrimaryKey: new Map([
+          ["src-a", [linkedA]],
+          ["src-b", [linkedB]],
+        ]),
+        linkedObjectsBySource: bySource,
+        status: "loaded",
+        isOptimistic: false,
+        hasMore: false,
+      });
+    });
+
+    expect(result.current.data).toEqual([linkedA, linkedB]);
+    expect(result.current.bySource).toBeInstanceOf(ObjectRefMap);
+    expect(result.current.bySource.size).toBe(2);
+    expect(
+      result.current.bySource.get({
+        $objectType: "Category",
+        $primaryKey: "src-a",
+      }),
+    ).toEqual([linkedA]);
+    expect(
+      result.current.bySource.get({
+        $objectType: "Category",
+        $primaryKey: "src-b",
+      }),
+    ).toEqual([linkedB]);
   });
 });


### PR DESCRIPTION
link types are the edges of the ontology graph; this makes the link the primitive you address, decorate, and traverse.

• generated `Type.links` tokens with cardinality-aware `useLinks` (one returns `Osdk | null | undefined`, many returns `Osdk[]`), multi-source partition and union keyed by `ObjectRef`, and interface-link resolution
• incremental budgeted recursion (frontier, maxDepth, maxNodes, streaming, `expand`) and multi-hop `.then()` paths, both usable inside shape `follow`
• version-keyed ontology metadata discovery, structural-hash subscriptions, refcount gc, and invalidate-and-refetch on write

stacked on #3091.

## architecture

### how the layers fit together

```mermaid
flowchart TB
  subgraph R["@osdk/react"]
    UL["useLinks(source, link)"]
    UO["useOsdkObject(s) with shape"]
  end
  subgraph C["@osdk/client observable"]
    DESC["LinkTraversalDescriptor (kind: single, path, recursive)"]
    RES["interface link resolver (resolveLink: interface to concrete)"]
    OL["observeLinks, observeMultiLinks"]
    OC["observeLinkClosure (closure engine)"]
    OP["observePath (PathQuery)"]
  end
  subgraph S["normalized store"]
    REF["keyed by ObjectRef"]
    REC["per-node link records"]
    GC["refcount gc, tear-free snapshots"]
  end
  MD["ontologyMetadata cache (version-keyed)"]
  FDY["Foundry (concrete link names only)"]

  UL --> DESC
  UO --> DESC
  DESC --> RES
  RES --> OL
  RES --> OC
  RES --> OP
  RES -. reads .-> MD
  OL --> REF
  OC --> REF
  OP --> REF
  REF --> FDY
```

### a token becomes a descriptor, the descriptor drives the return

The token is sugar; everything downstream consumes the plain-data `LinkTraversalDescriptor`, and the subscription is keyed by its structural hash (so inline tokens rebuilt each render do not resubscribe).

```mermaid
flowchart LR
  A["Type.links.X"] --> B["builder: where, orderBy, limit, project, then, recursive"]
  B --> C["LinkTraversalDescriptor (immutable plain data)"]
  C --> HK["hashTraversal(descriptor) = subscription key"]
  C --> K{"descriptor.kind + cardinality"}
  K -->|"single, one"| R1["data: Osdk or null or undefined"]
  K -->|"single, many"| R2["data: Osdk[] (+ bySource for arrays)"]
  K -->|"recursive"| R3["data, adjacency, byDepth, frontier, expand"]
  K -->|"path"| R4["data: deduped endpoint set"]
```

### the recursion engine (incremental, budgeted, streaming)

A client-driven batched BFS behind a strategy seam, so a future server-side closure can swap in without an API change. Each resolved level emits a snapshot.

```mermaid
flowchart TB
  RT["root ref (excluded from data)"] --> SEED["frontier = [root]"]
  SEED --> CHK{"frontier nonempty and budget left?"}
  CHK -->|no| DONE["emit final snapshot, isExpanding = false"]
  CHK -->|yes| EXP["expandLevel(frontier): partition by concrete type, resolveLink per type, one batched fetch each"]
  EXP --> MRG["for each child not in visited: add to visited, data, adjacency, byDepth"]
  MRG --> BUD{"maxNodes or maxDepth reached?"}
  BUD -->|yes| TR["set truncated, stop descending"]
  BUD -->|no| EM["emit snapshot (streaming), frontier = new children"]
  EM --> CHK
  TR --> DONE
```

### shapes compose the same grammar into a subgraph

`shape(node, { follow })` is additive sugar: each `follow` entry compiles its descriptor into the existing derived-link representation, with one unified loading and error state.

```mermaid
flowchart LR
  SH["shape(node, require, fallbacks, follow)"] --> F1["follow single: one pivotTo segment"]
  SH --> F2["follow path: N pivotTo segments"]
  SH --> F3["follow recursive: closure engine + lazy .tree view"]
  F1 --> DEF["ShapeDerivedLinkDef"]
  F2 --> DEF
  F3 --> DEF
  DEF --> ST["batched derived-links store"]
```
