### PR TITLE
Add @osdk/codemod: codemod CLI for react/experimental-to-ga migration

### DIFF
--- a/.changeset/add-codemod-package.md
+++ b/.changeset/add-codemod-package.md
@@ -1,0 +1,5 @@
+---
+"@osdk/codemod": minor
+---
+
+Add @osdk/codemod: a standalone codemod CLI that automates the rename migration from @osdk/react/experimental to the stable 2.15 API

--- a/dprint.json
+++ b/dprint.json
@@ -22,7 +22,8 @@
     "examples-extra/**/dist",
     "**/tsup.config.bundled_*",
     "**/api-docs/",
-    "**/*.report.api.md"
+    "**/*.report.api.md",
+    "**/__testfixtures__/**"
   ],
   "plugins": [
     "https://plugins.dprint.dev/typescript-0.90.4.wasm",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -252,6 +252,8 @@ export default tseslint.config(
     ignores: [
       // Uses ESLint 8 + @typescript-eslint v6, incompatible with v8 type-checked rules
       "packages/typescript-sdk-docs-examples/**",
+      // CLI tool; jscodeshift's CJS API requires `any` throughout — no value in type-checking
+      "packages/codemod/**",
     ],
     extends: [
       tseslint.configs.strictTypeCheckedOnly,
@@ -337,6 +339,7 @@ export default tseslint.config(
   },
   {
     files: ["**/*.test.ts"],
+    ignores: ["packages/codemod/**"],
     rules: {
       // Just trying to reduce the errors in tests
       "@typescript-eslint/unbound-method": "warn",
@@ -363,6 +366,7 @@ export default tseslint.config(
       "examples-extra/**/*",
       "packages/e2e.sandbox.*/**/*",
       "packages/typescript-sdk-docs-examples/**/*",
+      "packages/codemod/**/*",
     ],
     rules: {
       "no-console": "off",
@@ -440,6 +444,7 @@ export default tseslint.config(
       "**/src/generatedNoCheck/",
       "**/src/generatedNoCheck2/",
       "**/templates/",
+      "**/__testfixtures__/**",
       "examples/**/*",
       "packages/monorepo.*/**",
       "google-font-mocked-response.js",

--- a/packages/codemod/bin/osdk-codemod.mjs
+++ b/packages/codemod/bin/osdk-codemod.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+// @ts-check
+
+import { main } from "../build/esm/index.js";
+main();

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@osdk/codemod",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/palantir/osdk-ts.git"
+  },
+  "description": "Codemods for OSDK TypeScript SDK migrations",
+  "bin": {
+    "osdk-codemod": "./bin/osdk-codemod.mjs"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./build/types/index.d.ts",
+        "default": "./build/esm/index.js"
+      },
+      "default": "./build/esm/index.js"
+    }
+  },
+  "scripts": {
+    "check-spelling": "cspell --quiet .",
+    "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
+    "fix-lint": "eslint . --fix && dprint fmt",
+    "lint": "eslint . && dprint check",
+    "test": "vitest run",
+    "transpileEsm": "monorepo.tool.transpile -f esm -m normal -t node",
+    "transpileTypes": "monorepo.tool.transpile -f esm -m types -t node",
+    "typecheck": "tsc --noEmit --emitDeclarationOnly false"
+  },
+  "dependencies": {
+    "@clack/prompts": "^1.5.1",
+    "jscodeshift": "^17.3.0",
+    "semver": "^7.7.2",
+    "yargs": "^17.7.2"
+  },
+  "devDependencies": {
+    "@osdk/monorepo.tsconfig": "workspace:~",
+    "@types/jscodeshift": "^17.3.0",
+    "@types/node": "^18.19.124",
+    "@types/semver": "^7.5.8",
+    "@types/yargs": "^17.0.33",
+    "typescript": "~5.5.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "bin",
+    "build"
+  ],
+  "module": "./build/esm/index.js",
+  "types": "./build/esm/index.d.ts"
+}

--- a/packages/codemod/src/index.ts
+++ b/packages/codemod/src/index.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+import { runPicker } from "./picker.js";
+import { checkPreflight } from "./preflight.js";
+import { runTransform } from "./run.js";
+import { TRANSFORMS } from "./transforms/index.js";
+
+export async function main(): Promise<void> {
+  await yargs(hideBin(process.argv))
+    .scriptName("osdk-codemod")
+    .usage("$0 [transform] [path] [options]")
+    .command(
+      "$0 [transform] [path]",
+      "Run an OSDK codemod transform",
+      (y) =>
+        y
+          .positional("transform", {
+            type: "string",
+            describe: "Transform name (e.g. react/experimental-to-ga)",
+          })
+          .positional("path", {
+            type: "string",
+            default: ".",
+            describe: "Path to transform",
+          })
+          .option("dry", {
+            type: "boolean",
+            default: false,
+            describe: "Dry run — print file names without writing",
+          })
+          .option("print", {
+            type: "boolean",
+            default: false,
+            describe: "Print transformed output to stdout",
+          })
+          .option("force", {
+            type: "boolean",
+            default: false,
+            describe: "Skip preflight version check",
+          }),
+      async (argv) => {
+        const targetPath = (argv.path as string | undefined) ?? ".";
+
+        if (!argv.force) {
+          await checkPreflight(targetPath);
+        }
+
+        let transformName = argv.transform as string | undefined;
+
+        if (!transformName) {
+          const picked = await runPicker();
+          if (picked == null) {
+            process.exit(0);
+          }
+          transformName = picked;
+        }
+
+        const known = TRANSFORMS.find((t) => t.name === transformName);
+        if (!known) {
+          const list = TRANSFORMS.map((t) => `  ${t.name}`).join("\n");
+          console.error(
+            `Unknown transform: ${transformName}\nAvailable:\n${list}`,
+          );
+          process.exit(1);
+        }
+
+        await runTransform(transformName, targetPath, {
+          dry: argv.dry,
+          print: argv.print,
+        });
+      },
+    )
+    .help()
+    .parseAsync();
+}

--- a/packages/codemod/src/picker.ts
+++ b/packages/codemod/src/picker.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { intro, isCancel, outro, select } from "@clack/prompts";
+import { TRANSFORMS } from "./transforms/index.js";
+
+export async function runPicker(): Promise<string | null> {
+  intro("@osdk/codemod");
+
+  const result = await select({
+    message: "Which transform would you like to run?",
+    options: TRANSFORMS.map((t) => ({
+      value: t.name,
+      label: t.name,
+      hint: t.description,
+    })),
+  });
+
+  if (isCancel(result)) {
+    outro("Cancelled.");
+    return null;
+  }
+
+  return result;
+}

--- a/packages/codemod/src/preflight.ts
+++ b/packages/codemod/src/preflight.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createRequire } from "node:module";
+import { resolve } from "node:path";
+import semver from "semver";
+
+const MIN_REACT_VERSION = "2.15.0";
+
+export async function checkPreflight(targetPath: string): Promise<void> {
+  const absTarget = resolve(process.cwd(), targetPath);
+  const req = createRequire(absTarget + "/package.json");
+
+  let version: string | undefined;
+  try {
+    const pkg = req("@osdk/react/package.json") as { version: string };
+    version = pkg.version;
+  } catch {
+    // @osdk/react not found in target project — skip preflight
+    return;
+  }
+
+  if (version && semver.lt(version, MIN_REACT_VERSION)) {
+    console.warn(
+      `\nWarning: @osdk/react@${version} found in ${absTarget}.\n`
+        + `  This transform targets @osdk/react >= ${MIN_REACT_VERSION}.\n`
+        + `  Upgrade @osdk/react first, then run this codemod.\n`,
+    );
+  }
+}

--- a/packages/codemod/src/run.ts
+++ b/packages/codemod/src/run.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const _require = createRequire(import.meta.url);
+
+export interface RunOptions {
+  dry?: boolean;
+  print?: boolean;
+  force?: boolean;
+  extensions?: string;
+}
+
+interface RunStats {
+  error: number;
+  ok: number;
+  nochange: number;
+  skip: number;
+}
+
+export async function runTransform(
+  transformName: string,
+  targetPath: string,
+  options: RunOptions,
+): Promise<void> {
+  // Resolve the compiled transform path relative to this module.
+  // At runtime this file is at build/esm/run.js and the transform
+  // is at build/esm/transforms/<name>.js.
+  const transformPath = resolve(
+    __dirname,
+    "transforms",
+    transformName + ".js",
+  );
+
+  const { run } = loadRunner();
+
+  const stats: RunStats = await run(transformPath, [targetPath], {
+    dry: options.dry ?? false,
+    print: options.print ?? false,
+    extensions: options.extensions ?? "tsx,ts,jsx,js",
+    parser: "tsx",
+    verbose: 0,
+    silent: false,
+    babel: false,
+    runInBand: false,
+  });
+
+  printSummary(stats, options.dry ?? false);
+}
+
+function loadRunner(): {
+  run: (
+    transformFile: string,
+    paths: string[],
+    options: Record<string, unknown>,
+  ) => Promise<RunStats>;
+} {
+  // jscodeshift is CJS; use createRequire for reliable import from ESM.
+  const runner = _require("jscodeshift/src/Runner.js") as {
+    run: (
+      transformFile: string,
+      paths: string[],
+      options: Record<string, unknown>,
+    ) => Promise<RunStats>;
+  };
+  return runner;
+}
+
+function printSummary(stats: RunStats, dry: boolean): void {
+  const mode = dry ? " (dry run)" : "";
+  console.log(`\nResults${mode}:`);
+  console.log(`  ok:       ${stats.ok}`);
+  console.log(`  nochange: ${stats.nochange}`);
+  console.log(`  skip:     ${stats.skip}`);
+  if (stats.error > 0) {
+    console.error(`  error:    ${stats.error}`);
+  }
+}

--- a/packages/codemod/src/transforms/index.ts
+++ b/packages/codemod/src/transforms/index.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface TransformMeta {
+  name: string;
+  description: string;
+}
+
+export const TRANSFORMS: TransformMeta[] = [
+  {
+    name: "react/experimental-to-ga",
+    description:
+      "Rename @osdk/react/experimental imports to the stable 2.15 API",
+  },
+];

--- a/packages/codemod/src/transforms/react/__testfixtures__/aliased-import.input.tsx
+++ b/packages/codemod/src/transforms/react/__testfixtures__/aliased-import.input.tsx
@@ -1,0 +1,13 @@
+import {
+  OsdkProvider2 as Provider,
+  useOsdkClient2 as useClient,
+} from "@osdk/react/experimental";
+
+export function App() {
+  const client = useClient();
+  return (
+    <Provider client={client}>
+      <div />
+    </Provider>
+  );
+}

--- a/packages/codemod/src/transforms/react/__testfixtures__/aliased-import.output.tsx
+++ b/packages/codemod/src/transforms/react/__testfixtures__/aliased-import.output.tsx
@@ -1,0 +1,13 @@
+import {
+  OsdkProvider as Provider,
+  useOsdkClient as useClient,
+} from "@osdk/react";
+
+export function App() {
+  const client = useClient();
+  return (
+    <Provider client={client}>
+      <div />
+    </Provider>
+  );
+}

--- a/packages/codemod/src/transforms/react/__testfixtures__/basic-specifiers.input.tsx
+++ b/packages/codemod/src/transforms/react/__testfixtures__/basic-specifiers.input.tsx
@@ -1,0 +1,7 @@
+import { useLinks, useObjectSet } from "@osdk/react/experimental";
+import { usePlatformApi } from "@osdk/react/experimental/admin";
+
+export function MyComponent() {
+  const items = useObjectSet(MyObj.objectSet, {});
+  return null;
+}

--- a/packages/codemod/src/transforms/react/__testfixtures__/basic-specifiers.output.tsx
+++ b/packages/codemod/src/transforms/react/__testfixtures__/basic-specifiers.output.tsx
@@ -1,0 +1,7 @@
+import { useLinks, useObjectSet } from "@osdk/react";
+import { usePlatformApi } from "@osdk/react/platform-apis";
+
+export function MyComponent() {
+  const items = useObjectSet(MyObj.objectSet, {});
+  return null;
+}

--- a/packages/codemod/src/transforms/react/__testfixtures__/mock-rewrites.input.tsx
+++ b/packages/codemod/src/transforms/react/__testfixtures__/mock-rewrites.input.tsx
@@ -1,0 +1,5 @@
+vi.mock("@osdk/react/experimental", () => ({
+  OsdkProvider2: () => null,
+}));
+
+jest.mock("@osdk/react/experimental/admin", () => ({}));

--- a/packages/codemod/src/transforms/react/__testfixtures__/mock-rewrites.output.tsx
+++ b/packages/codemod/src/transforms/react/__testfixtures__/mock-rewrites.output.tsx
@@ -1,0 +1,5 @@
+vi.mock("@osdk/react", () => ({
+  OsdkProvider2: () => null,
+}));
+
+jest.mock("@osdk/react/platform-apis", () => ({}));

--- a/packages/codemod/src/transforms/react/__testfixtures__/observable-split.input.tsx
+++ b/packages/codemod/src/transforms/react/__testfixtures__/observable-split.input.tsx
@@ -1,0 +1,14 @@
+import {
+  augment,
+  createObservableClient,
+} from "@osdk/client/unstable-do-not-use";
+import type {
+  ObservableClient,
+  OsdkConfig,
+} from "@osdk/client/unstable-do-not-use";
+
+export { createObservableClient } from "@osdk/client/unstable-do-not-use";
+export {
+  augment,
+  createObservableClient,
+} from "@osdk/client/unstable-do-not-use";

--- a/packages/codemod/src/transforms/react/__testfixtures__/observable-split.output.tsx
+++ b/packages/codemod/src/transforms/react/__testfixtures__/observable-split.output.tsx
@@ -1,0 +1,9 @@
+import { augment } from "@osdk/client/unstable-do-not-use";
+import { createObservableClient } from "@osdk/client/observable";
+import type { OsdkConfig } from "@osdk/client/unstable-do-not-use";
+
+import type { ObservableClient } from "@osdk/client/observable";
+
+export { createObservableClient } from "@osdk/client/observable";
+export { augment } from "@osdk/client/unstable-do-not-use";
+export { createObservableClient } from "@osdk/client/observable";

--- a/packages/codemod/src/transforms/react/__testfixtures__/reexport.input.tsx
+++ b/packages/codemod/src/transforms/react/__testfixtures__/reexport.input.tsx
@@ -1,0 +1,3 @@
+export { OsdkProvider2 } from "@osdk/react/experimental";
+export { OsdkProvider2 as MyProvider } from "@osdk/react/experimental";
+export { useObjectSet, useOsdkClient2 } from "@osdk/react/experimental";

--- a/packages/codemod/src/transforms/react/__testfixtures__/reexport.output.tsx
+++ b/packages/codemod/src/transforms/react/__testfixtures__/reexport.output.tsx
@@ -1,0 +1,3 @@
+export { OsdkProvider as OsdkProvider2 } from "@osdk/react";
+export { OsdkProvider as MyProvider } from "@osdk/react";
+export { useObjectSet, useOsdkClient as useOsdkClient2 } from "@osdk/react";

--- a/packages/codemod/src/transforms/react/__testfixtures__/rename-provider.input.tsx
+++ b/packages/codemod/src/transforms/react/__testfixtures__/rename-provider.input.tsx
@@ -1,0 +1,15 @@
+import { OsdkProvider2, useOsdkClient2 } from "@osdk/react/experimental";
+import React from "react";
+
+interface Props {
+  client: unknown;
+}
+
+export function App({ client }: Props) {
+  const c = useOsdkClient2();
+  return (
+    <OsdkProvider2 client={client}>
+      <div>{String(c)}</div>
+    </OsdkProvider2>
+  );
+}

--- a/packages/codemod/src/transforms/react/__testfixtures__/rename-provider.output.tsx
+++ b/packages/codemod/src/transforms/react/__testfixtures__/rename-provider.output.tsx
@@ -1,0 +1,15 @@
+import { OsdkProvider, useOsdkClient } from "@osdk/react";
+import React from "react";
+
+interface Props {
+  client: unknown;
+}
+
+export function App({ client }: Props) {
+  const c = useOsdkClient();
+  return (
+    <OsdkProvider client={client}>
+      <div>{String(c)}</div>
+    </OsdkProvider>
+  );
+}

--- a/packages/codemod/src/transforms/react/__tests__/experimental-to-ga.test.ts
+++ b/packages/codemod/src/transforms/react/__tests__/experimental-to-ga.test.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import transform from "../experimental-to-ga.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = join(__dirname, "..", "__testfixtures__");
+
+const _require = createRequire(import.meta.url);
+
+function applyTransform(source: string): string {
+  // jscodeshift is CJS; load it via require from our ESM test
+  const jscodeshift = (_require("jscodeshift") as any).withParser("tsx");
+
+  const reports: string[] = [];
+  const result = transform(
+    { source, path: "test.tsx" },
+    {
+      jscodeshift,
+      j: jscodeshift,
+      stats: () => {},
+      report: (msg: string) => {
+        reports.push(msg);
+      },
+    },
+    {},
+  );
+
+  return (result ?? source).trim();
+}
+
+function applyTransformWithReports(source: string): {
+  output: string;
+  reports: string[];
+} {
+  const jscodeshift = (_require("jscodeshift") as any).withParser("tsx");
+  const reports: string[] = [];
+
+  const result = transform(
+    { source, path: "test.tsx" },
+    {
+      jscodeshift,
+      j: jscodeshift,
+      stats: () => {},
+      report: (msg: string) => {
+        reports.push(msg);
+      },
+    },
+    {},
+  );
+
+  return { output: (result ?? source).trim(), reports };
+}
+
+function readFixture(name: string): string {
+  return readFileSync(join(fixturesDir, name), "utf8");
+}
+
+describe("react/experimental-to-ga", () => {
+  it("rewrites basic @osdk/react/experimental and /admin specifiers", () => {
+    const input = readFixture("basic-specifiers.input.tsx");
+    const expected = readFixture("basic-specifiers.output.tsx").trim();
+    expect(applyTransform(input)).toBe(expected);
+  });
+
+  it("renames OsdkProvider2 and useOsdkClient2 in imports and body", () => {
+    const input = readFixture("rename-provider.input.tsx");
+    const expected = readFixture("rename-provider.output.tsx").trim();
+    expect(applyTransform(input)).toBe(expected);
+  });
+
+  it("applies cheap fix for aliased imports (body untouched)", () => {
+    const input = readFixture("aliased-import.input.tsx");
+    const expected = readFixture("aliased-import.output.tsx").trim();
+    expect(applyTransform(input)).toBe(expected);
+  });
+
+  it("rewrites re-exports alias-preserving", () => {
+    const input = readFixture("reexport.input.tsx");
+    const expected = readFixture("reexport.output.tsx").trim();
+    expect(applyTransform(input)).toBe(expected);
+  });
+
+  it("splits @osdk/client/unstable-do-not-use between old and /observable", () => {
+    const input = readFixture("observable-split.input.tsx");
+    const expected = readFixture("observable-split.output.tsx").trim();
+    expect(applyTransform(input)).toBe(expected);
+  });
+
+  it("rewrites jest.mock / vi.mock string literals", () => {
+    const input = readFixture("mock-rewrites.input.tsx");
+    const expected = readFixture("mock-rewrites.output.tsx").trim();
+    expect(applyTransform(input)).toBe(expected);
+  });
+
+  it("does not touch files with no matching imports", () => {
+    const source =
+      `import { useState } from 'react';\nexport default function Foo() { return null; }`;
+    // When transform returns file.source unchanged the output equals input
+    expect(applyTransform(source)).toBe(source.trim());
+  });
+
+  it("reports observableClient prop usage", () => {
+    const source = `
+import { OsdkProvider } from '@osdk/react';
+export function App({ client, obs }: any) {
+  return <OsdkProvider client={client} observableClient={obs} />;
+}`;
+    const { reports } = applyTransformWithReports(source);
+    expect(reports.some((r) => r.includes("observableClient"))).toBe(true);
+  });
+
+  it("reports and skips body rename on name collision", () => {
+    const source = `
+import { OsdkProvider2 } from '@osdk/react/experimental';
+const OsdkProvider = 'taken';
+export function App({ c }: any) {
+  return <OsdkProvider2 client={c} />;
+}`;
+    const { output, reports } = applyTransformWithReports(source);
+    expect(reports.some((r) => r.includes("name collision"))).toBe(true);
+    // The old name must still appear in the output (rename skipped)
+    expect(output).toContain("OsdkProvider2");
+  });
+});

--- a/packages/codemod/src/transforms/react/experimental-to-ga.ts
+++ b/packages/codemod/src/transforms/react/experimental-to-ga.ts
@@ -1,0 +1,351 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  API,
+  ASTPath,
+  ExportSpecifier,
+  FileInfo,
+  ImportSpecifier,
+  Options,
+} from "jscodeshift";
+
+// Names promoted from @osdk/client/unstable-do-not-use → @osdk/client/observable.
+// Derived from packages/client/src/public/observable.ts export surface.
+const OBSERVABLE_NAMES = new Set([
+  "ActionSignatureFromDef",
+  "CacheEntry",
+  "CacheSnapshot",
+  "CanonicalizedOptions",
+  "CanonicalizeOptionsInput",
+  "ObservableClient",
+  "ObserveAggregationArgs",
+  "ObserveFunctionCallbackArgs",
+  "ObserveFunctionOptions",
+  "ObserveObjectCallbackArgs",
+  "ObserveObjectsCallbackArgs",
+  "ObserveObjectSetArgs",
+  "ObserveLinks",
+  "Observer",
+  "QueryParameterType",
+  "QueryReturnType",
+  "Unsubscribable",
+  "createObservableClient",
+]);
+
+// @osdk/react subpath rewrites
+const REACT_MODULE_MAP: Record<string, string> = {
+  "@osdk/react/experimental": "@osdk/react",
+  "@osdk/react/experimental/admin": "@osdk/react/platform-apis",
+};
+
+// Specifier renames within @osdk/react/experimental
+const IMPORT_RENAMES: Record<string, string> = {
+  OsdkProvider2: "OsdkProvider",
+  useOsdkClient2: "useOsdkClient",
+};
+
+export const parser = "tsx";
+
+export default function transformer(
+  file: FileInfo,
+  api: API,
+  _options: Options = {},
+): string {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let dirty = false;
+
+  // localName → newName for unaliased renames that need body-level fix-up
+  const bodyRenames = new Map<string, string>();
+
+  // ── 1. Import declarations ────────────────────────────────────────────────
+
+  root.find(j.ImportDeclaration).forEach((path) => {
+    const src = path.node.source.value as string;
+
+    // @osdk/react/experimental[/admin] → @osdk/react[/platform-apis]
+    if (REACT_MODULE_MAP[src]) {
+      path.node.source.value = REACT_MODULE_MAP[src];
+      dirty = true;
+
+      if (src === "@osdk/react/experimental") {
+        (path.node.specifiers ?? []).forEach((spec) => {
+          if (spec.type !== "ImportSpecifier") return;
+          const importedName = getImportedName(spec);
+          const localName = spec.local?.name ?? importedName;
+          const newName = IMPORT_RENAMES[importedName];
+          if (!newName) return;
+
+          spec.imported = j.identifier(newName);
+
+          if (localName === importedName) {
+            // Unaliased import: update local binding and schedule body rename
+            spec.local = j.identifier(newName);
+            bodyRenames.set(importedName, newName);
+          }
+          // Aliased (import { OsdkProvider2 as P }): only the imported name
+          // changes; the local alias P stays, so no body rename needed.
+        });
+      }
+      return;
+    }
+
+    // @osdk/client/unstable-do-not-use → split between old path and /observable
+    if (src === "@osdk/client/unstable-do-not-use") {
+      const allSpecs = (path.node.specifiers ?? []).filter(
+        (s): s is ImportSpecifier => s.type === "ImportSpecifier",
+      );
+
+      const promoted = allSpecs.filter((s) =>
+        OBSERVABLE_NAMES.has(getImportedName(s))
+      );
+      const kept = allSpecs.filter(
+        (s) => !OBSERVABLE_NAMES.has(getImportedName(s)),
+      );
+
+      if (promoted.length === 0) return;
+      dirty = true;
+
+      if (kept.length === 0) {
+        path.node.source.value = "@osdk/client/observable";
+      } else {
+        path.node.specifiers = kept;
+        const newDecl = j.importDeclaration(
+          promoted,
+          j.stringLiteral("@osdk/client/observable"),
+        );
+        // Preserve import kind (e.g. `import type { ... }`)
+        (newDecl as any).importKind = (path.node as any).importKind ?? "value";
+        path.insertAfter(newDecl);
+      }
+    }
+  });
+
+  // ── 2. Named re-exports ───────────────────────────────────────────────────
+
+  root.find(j.ExportNamedDeclaration).forEach((path) => {
+    if (!path.node.source) return;
+    const src = path.node.source.value as string;
+
+    if (REACT_MODULE_MAP[src]) {
+      path.node.source.value = REACT_MODULE_MAP[src];
+      dirty = true;
+
+      if (src === "@osdk/react/experimental") {
+        const specifiers = path.node.specifiers ?? [];
+        for (let i = 0; i < specifiers.length; i++) {
+          const spec = specifiers[i];
+          if (spec.type !== "ExportSpecifier") continue;
+          const localName = getExportLocalName(spec);
+          const newLocalName = IMPORT_RENAMES[localName];
+          if (!newLocalName) continue;
+
+          // Preserve the exported (downstream) name.
+          // export { OsdkProvider2 }        → export { OsdkProvider as OsdkProvider2 }
+          // export { OsdkProvider2 as Foo } → export { OsdkProvider as Foo }
+          //
+          // Replace the whole ExportSpecifier with a fresh plain object so
+          // recast uses the generic printer (not the source-patcher), which
+          // correctly emits the "local as exported" form.
+          const exportedName = getExportedName(spec);
+          specifiers[i] = {
+            type: "ExportSpecifier",
+            local: j.identifier(newLocalName),
+            exported: j.identifier(exportedName),
+            exportKind: (spec as any).exportKind ?? "value",
+          } as unknown as ExportSpecifier;
+        }
+      }
+      return;
+    }
+
+    if (src === "@osdk/client/unstable-do-not-use") {
+      const allSpecs = (path.node.specifiers ?? []).filter(
+        (s): s is ExportSpecifier => s.type === "ExportSpecifier",
+      );
+
+      const promoted = allSpecs.filter((s) =>
+        OBSERVABLE_NAMES.has(getExportLocalName(s))
+      );
+      const kept = allSpecs.filter(
+        (s) => !OBSERVABLE_NAMES.has(getExportLocalName(s)),
+      );
+
+      if (promoted.length === 0) return;
+      dirty = true;
+
+      if (kept.length === 0) {
+        path.node.source.value = "@osdk/client/observable";
+      } else {
+        path.node.specifiers = kept;
+        const newExport = j.exportNamedDeclaration(
+          null,
+          promoted,
+          j.stringLiteral("@osdk/client/observable"),
+        );
+        path.insertAfter(newExport);
+      }
+    }
+  });
+
+  // ── 3. jest.mock / vi.mock string-literal path rewrites ───────────────────
+
+  root.find(j.CallExpression).forEach((path) => {
+    const callee = path.node.callee;
+    if (callee.type !== "MemberExpression") return;
+    if (callee.object.type !== "Identifier") return;
+    if (callee.property.type !== "Identifier") return;
+
+    const obj = callee.object.name;
+    const method = callee.property.name;
+    if ((obj !== "jest" && obj !== "vi") || method !== "mock") return;
+
+    const firstArg = path.node.arguments[0];
+    if (!firstArg) return;
+
+    const strVal = getStringLiteralValue(firstArg);
+    if (strVal == null) return;
+
+    if (REACT_MODULE_MAP[strVal]) {
+      setStringLiteralValue(firstArg, REACT_MODULE_MAP[strVal]);
+      dirty = true;
+    }
+
+    if (strVal === "@osdk/client/unstable-do-not-use") {
+      api.report(
+        `${file.path}: ${obj}.mock('@osdk/client/unstable-do-not-use') — verify split to @osdk/client/observable manually`,
+      );
+    }
+  });
+
+  // ── 4. Body renames for unaliased imports ─────────────────────────────────
+
+  if (bodyRenames.size > 0) {
+    bodyRenames.forEach((newName, oldName) => {
+      // Collision: newName is already declared locally (not from our import)
+      let collisionFound = false;
+      root.find(j.Identifier, { name: newName }).forEach((idPath) => {
+        if (isLocalDeclaration(idPath, newName)) collisionFound = true;
+      });
+
+      if (collisionFound) {
+        api.report(
+          `${file.path}: name collision — '${newName}' already defined; skipping rename of '${oldName}'`,
+        );
+        return;
+      }
+
+      root.find(j.Identifier, { name: oldName }).forEach((idPath) => {
+        // Skip the import specifier itself (already updated above)
+        const parentType = idPath.parent.node.type;
+        if (
+          parentType === "ImportSpecifier"
+          || parentType === "ImportDefaultSpecifier"
+        ) return;
+        // Skip re-export local names (already updated above)
+        if (
+          parentType === "ExportSpecifier"
+          && idPath.parent.node.local === idPath.node
+        ) return;
+
+        idPath.node.name = newName;
+      });
+    });
+    dirty = true;
+  }
+
+  // ── 5. Skip-and-report: <OsdkProvider observableClient={...}> ────────────
+
+  root
+    .find(j.JSXAttribute, { name: { name: "observableClient" } })
+    .forEach((path) => {
+      const parentEl = path.parent?.node;
+      const elName = parentEl?.name?.name ?? parentEl?.name?.object?.name;
+      if (typeof elName === "string" && elName.includes("OsdkProvider")) {
+        api.report(
+          `${file.path}: <${elName} observableClient={...}> — use TestOsdkProvider from @osdk/react/testing instead`,
+        );
+      }
+    });
+
+  // ── 6. Skip-and-report: dynamic import() with non-literal specifier ───────
+
+  root.find(j.CallExpression, { callee: { type: "Import" } }).forEach(
+    (path) => {
+      const arg = path.node.arguments[0];
+      if (arg && arg.type !== "StringLiteral" && arg.type !== "Literal") {
+        api.report(
+          `${file.path}: dynamic import() with non-literal specifier — inspect manually`,
+        );
+      }
+    },
+  );
+
+  return dirty ? root.toSource({ quote: "double" }) : file.source;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function getImportedName(spec: ImportSpecifier): string {
+  const imp = spec.imported;
+  if (imp.type === "Identifier") return imp.name;
+  return (imp as any).value as string;
+}
+
+function getExportedName(spec: ExportSpecifier): string {
+  const exp = spec.exported;
+  if (exp.type === "Identifier") return exp.name;
+  return (exp as any).name as string;
+}
+
+function getExportLocalName(spec: ExportSpecifier): string {
+  const local = spec.local;
+  if (!local) return "";
+  const n = local.name;
+  // TSTypeParameter.name can be IdentifierKind; in practice export specifiers
+  // always have plain string names, so cast via type guard.
+  if (typeof n === "string") return n;
+  return (n as { name: string }).name;
+}
+
+function getStringLiteralValue(node: any): string | null {
+  if (node.type === "StringLiteral") return node.value as string;
+  if (node.type === "Literal" && typeof node.value === "string") {
+    return node.value as string;
+  }
+  return null;
+}
+
+function setStringLiteralValue(node: any, value: string): void {
+  node.value = value;
+  if (node.extra) node.extra.rawValue = value;
+  if (node.extra) node.extra.raw = JSON.stringify(value);
+}
+
+function isLocalDeclaration(path: ASTPath<any>, name: string): boolean {
+  const parent = path.parent?.node;
+  if (!parent) return false;
+  const t = parent.type;
+  return (
+    (t === "VariableDeclarator" && parent.id === path.node)
+    || t === "FunctionDeclaration"
+    || t === "ClassDeclaration"
+    || (t === "ImportSpecifier"
+      && parent.local === path.node
+      && (parent.imported?.name ?? parent.imported?.value) !== name)
+  );
+}

--- a/packages/codemod/tsconfig.json
+++ b/packages/codemod/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@osdk/monorepo.tsconfig/base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build/esm"
+  },
+  "include": [
+    "./src/**/*"
+  ],
+  "exclude": [
+    "./src/**/__testfixtures__/**"
+  ],
+  "references": []
+}

--- a/packages/codemod/vitest.config.mts
+++ b/packages/codemod/vitest.config.mts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { configDefaults, defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    pool: "forks",
+    exclude: [...configDefaults.exclude, "**/build/**/*"],
+  },
+});

--- a/packages/monorepo.cspell/dict.normal-dev-words.txt
+++ b/packages/monorepo.cspell/dict.normal-dev-words.txt
@@ -8,7 +8,13 @@ blockquotes
 Canonicalizer
 Canonicalizers
 codegen
+codemod
+codemods
 commitish
+jscodeshift
+nochange
+testfixtures
+unaliased
 Cpath
 Csvg
 dedups

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2090,6 +2090,40 @@ importers:
         specifier: ~5.5.4
         version: 5.5.4
 
+  packages/codemod:
+    dependencies:
+      '@clack/prompts':
+        specifier: ^1.5.1
+        version: 1.5.1
+      jscodeshift:
+        specifier: ^17.3.0
+        version: 17.3.0(@babel/preset-env@7.26.0(@babel/core@7.28.4))
+      semver:
+        specifier: ^7.7.2
+        version: 7.7.4
+      yargs:
+        specifier: ^17.7.2
+        version: 17.7.2
+    devDependencies:
+      '@osdk/monorepo.tsconfig':
+        specifier: workspace:~
+        version: link:../monorepo.tsconfig
+      '@types/jscodeshift':
+        specifier: ^17.3.0
+        version: 17.3.0
+      '@types/node':
+        specifier: ^18.19.124
+        version: 18.19.124
+      '@types/semver':
+        specifier: ^7.5.8
+        version: 7.7.1
+      '@types/yargs':
+        specifier: ^17.0.33
+        version: 17.0.33
+      typescript:
+        specifier: ~5.5.4
+        version: 5.5.4
+
   packages/create-app:
     dependencies:
       '@osdk/generator-utils':
@@ -6997,6 +7031,14 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
+  '@clack/core@1.4.1':
+    resolution: {integrity: sha512-FILJa1gGKEFTGZAJE9RpVhrjKz3c3h4ar60dSv6cGuDqufQ84YEIS3GAGvZiN+H6yaLbbvTFNejjCC4tXpZEuw==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.5.1':
+    resolution: {integrity: sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw==}
+    engines: {node: '>= 20.12.0'}
+
   '@codemirror/autocomplete@6.20.1':
     resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
 
@@ -11499,6 +11541,9 @@ packages:
   '@types/jest@29.5.14':
     resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
 
+  '@types/jscodeshift@17.3.0':
+    resolution: {integrity: sha512-ogvGG8VQQqAQQ096uRh+d6tBHrYuZjsumHirKtvBa5qEyTMN3IQJ7apo+sw9lxaB/iKWIhbbLlF3zmAWk9XQIg==}
+
   '@types/jsdom@20.0.1':
     resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
 
@@ -14804,8 +14849,17 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -16273,6 +16327,16 @@ packages:
     hasBin: true
     peerDependencies:
       '@babel/preset-env': ^7.1.6
+
+  jscodeshift@17.3.0:
+    resolution: {integrity: sha512-LjFrGOIORqXBU+jwfC9nbkjmQfFldtMIoS6d9z2LG/lkmyNXsJAySPT+2SWXJEoE68/bCWcxKpXH37npftgmow==}
+    engines: {node: '>=16'}
+    hasBin: true
+    peerDependencies:
+      '@babel/preset-env': ^7.1.6
+    peerDependenciesMeta:
+      '@babel/preset-env':
+        optional: true
 
   jsdom@20.0.3:
     resolution: {integrity: sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==}
@@ -21964,7 +22028,7 @@ snapshots:
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
       fflate: 0.8.2
-      semver: 7.7.2
+      semver: 7.7.4
       ts-expose-internals-conditionally: 1.0.0-empty.0
       typescript: 5.3.3
       validate-npm-package-name: 5.0.1
@@ -23026,7 +23090,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.7.2
+      semver: 7.7.4
 
   '@changesets/assemble-release-plan@6.0.9':
     dependencies:
@@ -23035,7 +23099,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.7.2
+      semver: 7.7.4
 
   '@changesets/changelog-git@0.2.1':
     dependencies:
@@ -23068,7 +23132,7 @@ snapshots:
       package-manager-detector: 0.2.11
       picocolors: 1.1.1
       resolve-from: 5.0.0
-      semver: 7.7.2
+      semver: 7.7.4
       spawndamnit: 3.0.1
       term-size: 2.2.1
     transitivePeerDependencies:
@@ -23150,7 +23214,7 @@ snapshots:
       mdast-util-to-string: 1.1.0
       remark-parse: 7.0.2
       remark-stringify: 7.0.4
-      semver: 7.7.2
+      semver: 7.7.4
       spawndamnit: 3.0.1
       unified: 8.4.2
 
@@ -23169,6 +23233,18 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.1
       prettier: 2.8.8
+
+  '@clack/core@1.4.1':
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.5.1':
+    dependencies:
+      '@clack/core': 1.4.1
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
 
   '@codemirror/autocomplete@6.20.1':
     dependencies:
@@ -25903,7 +25979,7 @@ snapshots:
       jest-diff: 29.7.0
       resolve-package-path: 4.0.3
       runtypes: 6.7.0
-      semver: 7.7.2
+      semver: 7.7.4
       tslib: 2.8.1
 
   '@monorepolint/utils@0.6.0-alpha.4':
@@ -29197,6 +29273,11 @@ snapshots:
       expect: 29.7.0
       pretty-format: 29.7.0
 
+  '@types/jscodeshift@17.3.0':
+    dependencies:
+      ast-types: 0.16.1
+      recast: 0.23.11
+
   '@types/jsdom@20.0.1':
     dependencies:
       '@types/node': 18.19.124
@@ -29394,7 +29475,7 @@ snapshots:
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      semver: 7.7.2
+      semver: 7.7.4
       ts-api-utils: 1.4.3(typescript@5.5.4)
     optionalDependencies:
       typescript: 5.5.4
@@ -29539,7 +29620,7 @@ snapshots:
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.9
-      semver: 7.7.2
+      semver: 7.7.4
       ts-api-utils: 2.1.0(typescript@5.5.4)
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -31889,7 +31970,7 @@ snapshots:
       cspell-lib: 8.19.4
       fast-json-stable-stringify: 2.1.0
       file-entry-cache: 9.1.0
-      semver: 7.7.2
+      semver: 7.7.4
       tinyglobby: 0.2.15
 
   css-blank-pseudo@8.0.1(postcss@8.5.6):
@@ -33533,7 +33614,17 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.0: {}
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fastest-levenshtein@1.0.16: {}
 
@@ -35368,6 +35459,31 @@ snapshots:
       recast: 0.21.5
       temp: 0.8.4
       write-file-atomic: 2.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  jscodeshift@17.3.0(@babel/preset-env@7.26.0(@babel/core@7.28.4)):
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/parser': 7.28.4
+      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-optional-chaining': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.28.4)
+      '@babel/preset-flow': 7.25.9(@babel/core@7.28.4)
+      '@babel/preset-typescript': 7.27.1(@babel/core@7.28.4)
+      '@babel/register': 7.25.9(@babel/core@7.28.4)
+      flow-parser: 0.255.0
+      graceful-fs: 4.2.11
+      micromatch: 4.0.8
+      neo-async: 2.6.2
+      picocolors: 1.1.1
+      recast: 0.23.11
+      tmp: 0.2.5
+      write-file-atomic: 5.0.1
+    optionalDependencies:
+      '@babel/preset-env': 7.26.0(@babel/core@7.28.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -37259,7 +37375,7 @@ snapshots:
       ky: 1.2.3
       registry-auth-token: 5.0.2
       registry-url: 6.0.1
-      semver: 7.7.2
+      semver: 7.7.4
 
   package-json@8.1.1:
     dependencies:


### PR DESCRIPTION
Introduces packages/codemod (@osdk/codemod) — a standalone jscodeshift-based CLI that automates renaming @osdk/react/experimental imports to the stable 2.15 GA API. Ships with one transform (react/experimental-to-ga), interactive @clack/prompts picker, semver preflight, and 9 fixture-based vitest tests.

Also excludes __testfixtures__ dirs from dprint and eslint, adds no-console override for the codemod CLI package, opts codemod out of strictTypeCheckedOnly rules (jscodeshift's CJS API requires any throughout), and adds codemod-related words to the cspell dictionary.

The next PR adds some skills => https://github.com/palantir/osdk-ts/pull/3514