### PR TITLE
Add osdk-react-migrate migration skill to @osdk/react

### DIFF
--- a/.changeset/add-react-migrate-skill.md
+++ b/.changeset/add-react-migrate-skill.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react": minor
+---
+
+Add osdk-react-migrate migration skill for converting OSDK-backed data fetching to @osdk/react hooks

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -142,7 +142,8 @@
     "CHANGELOG.md",
     "package.json",
     "templates",
-    "*.d.ts"
+    "*.d.ts",
+    "skills"
   ],
   "main": "./build/cjs/index.cjs",
   "module": "./build/esm/index.js",

--- a/packages/react/skills/osdk-react-migrate/SKILL.md
+++ b/packages/react/skills/osdk-react-migrate/SKILL.md
@@ -1,0 +1,138 @@
+# osdk-react-migrate
+
+Perform the adoption migration: convert OSDK-backed data fetching (raw client calls in `useEffect`, TanStack Query, SWR) to `@osdk/react` hooks. Only OSDK-backed call sites are converted — non-OSDK fetches stay in their existing library. Coexistence is an endorsed end state.
+
+## Load context before starting
+
+Read all three reference files before touching any code:
+
+- `references/hooks.md` — complete `@osdk/react` hook API
+- `references/patterns.md` — correct usage patterns and anti-patterns to enforce
+- `references/migration-guide.md` — before/after examples for each migration type
+
+## Step 0 — Guardrail (codemod bridge)
+
+Before doing any judgment work, check for deprecated API usage:
+
+```sh
+grep -rn "from ['\"]@osdk/react/experimental" src/
+```
+
+**If any matches are found:** stop immediately and tell the user:
+
+> Your codebase imports from `@osdk/react/experimental`, which is the deprecated 0.x API. Run the rename migration first:
+>
+> ```sh
+> npx @osdk/codemod react/experimental-to-ga <path>
+> ```
+>
+> Re-run this skill once the rename migration is complete.
+
+**If no matches:** proceed to Step 1.
+
+## Step 1 — Discover OSDK-backed call sites
+
+Search for patterns that indicate OSDK data fetching:
+
+```sh
+# useEffect patterns with client
+grep -rn "client\.objects\|\.fetchPage\|\.fetchOne\|\.fetchPageWithErrors" src/
+
+# TanStack Query hooks
+grep -rn "useQuery\|useMutation\|useInfiniteQuery" src/ | grep -v node_modules
+
+# SWR hooks
+grep -rn "useSWR\|useSWRImmutable" src/ | grep -v node_modules
+```
+
+For each result, open the file and determine whether the fetch is OSDK-backed (calls into a generated SDK object type or action) or not. Only OSDK-backed sites are migrated. Non-OSDK fetches — external REST APIs, GraphQL, custom backends — stay in their current library.
+
+## Step 2 — Convert each call site
+
+Use `references/migration-guide.md` for concrete before/after examples. The mapping:
+
+| Current pattern                              | Target hook                         |
+| -------------------------------------------- | ----------------------------------- |
+| `useEffect` + `client(Type).fetchPage()`     | `useOsdkObjects`                    |
+| `useEffect` + `client(Type).fetchOne(id)`    | `useOsdkObject`                     |
+| `useEffect` + link traversal                 | `useLinks`                          |
+| `useQuery` wrapping an OSDK object fetch     | `useOsdkObjects` or `useOsdkObject` |
+| `useMutation` wrapping an OSDK action        | `useOsdkAction`                     |
+| `useSWR` wrapping an OSDK object fetch       | `useOsdkObjects` or `useOsdkObject` |
+| `useQuery` wrapping an OSDK aggregation      | `useOsdkAggregation`                |
+| `useQuery` wrapping an OSDK function call    | `useOsdkFunction`                   |
+| Complex `ObjectSet` union/intersect/subtract | `useObjectSet`                      |
+
+After converting a site:
+
+- Remove the `useState`/`useEffect` block (or `useQuery`/`useSWR` call) that was replaced
+- Remove stale imports that are no longer referenced (`useEffect`, `useState`, `useQuery`, `useMutation`, `useSWR`, etc.)
+- Add any missing `@osdk/react` imports for the new hooks
+
+## Step 3 — Flag advanced cache sites (don't force)
+
+Some call sites use cache features that don't have a direct safe equivalent in `@osdk/react`. For these, add a comment and leave the code unchanged:
+
+```tsx
+// osdk-react-migrate: manual cache tuning — conversion skipped.
+// This site configures staleTime/refetchInterval. @osdk/react manages
+// invalidation automatically after actions; if you no longer need manual
+// control, remove this comment and convert to useOsdkObjects.
+const { data } = useQuery({ ... });
+```
+
+Flag (don't force) any site that uses:
+
+- `staleTime`, `cacheTime`, or `gcTime` set to a custom value
+- `refetchInterval` or `refetchIntervalInBackground`
+- `refetchOnWindowFocus: false` or `refetchOnMount: false`
+- TanStack `onMutate` + manual optimistic-update rollback (`onError` with `context`)
+- `queryClient.invalidateQueries()` called immediately after the action (the action should drive invalidation; if manual invalidation is present, the developer may have a reason)
+
+## Step 4 — Ensure OsdkProvider is at the app root
+
+```sh
+grep -rn "OsdkProvider" src/
+```
+
+If not found: locate the app entry point (`main.tsx`, `index.tsx`, or `App.tsx`) and add the provider:
+
+```tsx
+import { OsdkProvider } from "@osdk/react";
+import client from "./client";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <OsdkProvider client={client}>
+    <App />
+  </OsdkProvider>,
+);
+```
+
+If already present: skip this step.
+
+## Step 5 — Update imports
+
+Add any missing `@osdk/react` imports for hooks used after conversion. Remove imports that are no longer needed.
+
+```tsx
+// Add only what was used in this file
+import { useOsdkAction, useOsdkObjects } from "@osdk/react";
+```
+
+## Rules to enforce during conversion
+
+See `references/patterns.md` for the full list. The critical invariants:
+
+1. **Never conditionally call hooks.** Use the `enabled` option instead of an `if` guard.
+2. **Keep rendering during loading.** Do not use early returns like `if (isLoading) return <Spinner />`. Render loading indicators alongside existing data. Exception: `if (!data && isLoading)` is acceptable for initial load.
+3. **`useOsdkObject` `enabled` is positional**, not in an options object. Third argument for type+key form: `useOsdkObject(Type, id, false)`.
+4. **Prefer `useOsdkObjects`.** Only use `useObjectSet` when the query needs `union`, `intersect`, or `subtract` set operations.
+
+## Summary to report when done
+
+Tell the user:
+
+- How many call sites were converted (by hook type)
+- How many were flagged instead of converted (with the reason for each)
+- Whether `OsdkProvider` was added or was already present
+- Any files where you left a `// osdk-react-migrate: review needed` comment because the conversion intent was unclear

--- a/packages/react/skills/osdk-react-migrate/references/hooks.md
+++ b/packages/react/skills/osdk-react-migrate/references/hooks.md
@@ -1,0 +1,215 @@
+# @osdk/react Hook API Reference
+
+Distilled from `AGENTS.md` and `docs/react/`. Use this for grounding conversion decisions.
+
+## Installation
+
+`pnpm add @osdk/react @osdk/client @osdk/api`. All three packages must use compatible versions — the observable runtime is version-locked across them. See `AGENTS.md` for the CHANGELOG version-matching recipe.
+
+Optional peers (install only if you import from the corresponding surface):
+
+- `@osdk/foundry.admin` + `@osdk/foundry.core`: required for any hook from `@osdk/react/platform-apis`
+
+## Provider
+
+### OsdkProvider
+
+Required at the app root. Every hook reads from it.
+
+```tsx
+import { OsdkProvider } from "@osdk/react";
+import client from "./client";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <OsdkProvider client={client}>
+    <App />
+  </OsdkProvider>,
+);
+```
+
+Rule: `OsdkProvider` must wrap the entire app, not just the components that use hooks. Components outside the provider cannot use any `@osdk/react` hook.
+
+## Data hooks
+
+### useOsdkObjects
+
+Retrieve and observe a list of objects. The default hook for list queries.
+
+```tsx
+const { data, isLoading, error, fetchMore, hasMore } = useOsdkObjects(Type, options?);
+```
+
+Key options: `where`, `orderBy`, `pageSize`, `enabled`, `autoFetchMore`, `streamUpdates`, `intersectWith`, `pivotTo`, `withProperties`, `dedupeIntervalMs`, `rids`, `$select`.
+
+Return values:
+
+- `data` — array (undefined while initially loading)
+- `isLoading` — true while fetching (also true during revalidation with existing data)
+- `isOptimistic` — true when list order is affected by optimistic updates
+- `fetchMore` — load next page (undefined when no more pages)
+- `hasMore` — true if more pages exist
+- `totalCount` — string; parse with `Number(totalCount)` for arithmetic
+- `objectSet` — the transformed ObjectSet; pass to `useObjectSet` or `useOsdkAggregation`
+- `refetch` — manually invalidate and refetch
+- `error`
+
+### useOsdkObject
+
+Retrieve and observe a single object.
+
+```tsx
+// By type + primary key
+const { object, isLoading, error } = useOsdkObject(Type, primaryKey, optionsOrEnabled?);
+
+// Track an existing instance
+const { object, isLoading, isOptimistic } = useOsdkObject(instance);
+```
+
+**`enabled` is positional (third argument), not in an options object:**
+
+```tsx
+useOsdkObject(Employee, id, false); // disabled
+useOsdkObject(Employee, id, { $select: ["fullName"] }); // options object
+```
+
+Return values: `object`, `isLoading`, `isOptimistic`, `error`.
+
+### useLinks
+
+Observe relationships between objects.
+
+```tsx
+const { links, isLoading, fetchMore, hasMore } = useLinks(objectOrArray, linkName, options?);
+```
+
+Key options: `where`, `pageSize`, `orderBy`, `enabled`, `mode` (`"force"` | `"offline"`), `dedupeIntervalMs`.
+
+Return values: `links`, `isLoading`, `isOptimistic`, `fetchMore`, `hasMore`, `error`.
+
+Accepts a single object instance or an array (loads links from all sources at once).
+
+### useObjectSet
+
+Advanced queries with set operations. Use `useOsdkObjects` by default; reach for this only when you need `union`, `intersect`, or `subtract`.
+
+```tsx
+const { data, isLoading, error } = useObjectSet(objectSet, options?);
+```
+
+Where `objectSet` is an `ObjectSet` instance: `client(Type)`, or with operations chained.
+
+Key options: `union`, `intersect`, `subtract`, `where`, `withProperties`, `pivotTo`, `orderBy`, `pageSize`, `streamUpdates`, `autoFetchMore`, `enabled`.
+
+**`streamUpdates` and `pivotTo` cannot be combined.**
+
+### useOsdkAggregation
+
+Server-side grouping and aggregation.
+
+```tsx
+const { data, isLoading, error } = useOsdkAggregation(Type, {
+  aggregate: {
+    $select: { $count: "unordered", "salary:avg": "unordered" },
+    $groupBy: { department: "exact" },   // optional
+  },
+  where: { ... },
+});
+```
+
+`$select` key format: `$count`, `"prop:sum"`, `"prop:avg"`, `"prop:min"`, `"prop:max"`, `"prop:exactDistinct"`, `"prop:approximateDistinct"`.
+
+Return: `data` (single object for non-grouped; array for grouped), `isLoading`, `error`, `refetch`.
+
+### useOsdkFunction / useOsdkFunctions
+
+Execute and observe ontology functions.
+
+```tsx
+const { data, isLoading, error, refetch } = useOsdkFunction(fn, {
+  params: { n: 5 },
+  dependsOn: [Employee], // refetch when any Employee changes
+  dependsOnObjects: [employee], // refetch when this specific instance changes
+  enabled: true,
+  dedupeIntervalMs: 2000,
+});
+```
+
+Return: `data`, `isLoading`, `error`, `lastUpdated`, `refetch`.
+
+## Action hook
+
+### useOsdkAction
+
+Execute and validate actions.
+
+```tsx
+const {
+  applyAction,
+  validateAction,
+  isPending,
+  isValidating,
+  error,
+  validationResult,
+  data,
+} = useOsdkAction(actionDef);
+```
+
+`applyAction` accepts a single args object or an array for batch:
+
+```tsx
+applyAction({ employee, primary_office_id });
+applyAction([{ employee: emp1, ... }, { employee: emp2, ... }]);
+```
+
+Optimistic updates via `$optimisticUpdate` param:
+
+```tsx
+applyAction({
+  todo,
+  isComplete: true,
+  $optimisticUpdate: (ou) => {
+    ou.updateObject(todo.$clone({ isComplete: true }));
+  },
+});
+```
+
+`error` shape: `{ actionValidation?: ActionValidationError; unknown?: unknown }`.
+
+## Utility hooks
+
+### useOsdkClient
+
+Access the OSDK client directly for use in event handlers or effects.
+
+```tsx
+const client = useOsdkClient();
+```
+
+### useObservableClient
+
+Access the `ObservableClient` for manual cache invalidation.
+
+```tsx
+const observableClient = useObservableClient();
+await observableClient.invalidateObjectType(Todo);
+await observableClient.invalidateObjects([todo1, todo2]);
+await observableClient.invalidateAll();
+```
+
+### useDebouncedCallback
+
+Debounce a callback function.
+
+```tsx
+const debouncedSave = useDebouncedCallback((value: string) => { ... }, 500);
+debouncedSave.cancel();
+debouncedSave.flush();
+```
+
+## Exports summary
+
+**`@osdk/react`** (main): `OsdkProvider`, `useOsdkObjects`, `useOsdkObject`, `useOsdkAction`, `useLinks`, `useObjectSet`, `useOsdkAggregation`, `useOsdkFunction`, `useOsdkFunctions`, `useStableObjectSet`, `useOsdkClient`, `useObservableClient`, `useOsdkMetadata`, `useRegisterUserAgent`, `useDebouncedCallback`, `registerDevTools`, `getRegisteredDevTools`.
+
+**`@osdk/react/platform-apis`**: `useCurrentFoundryUser`, `useFoundryUser`, `useFoundryUsersList`, `useMarkings`, `useMarkingCategories`, `useUserViewMarkings`, `useCbacBanner`, `useCbacMarkingRestrictions`. Requires `@osdk/foundry.admin` + `@osdk/foundry.core`.
+
+**`@osdk/react/devtools-registry`**: `registerDevTools`, `getRegisteredDevTools`, `DevToolsRegistry`.

--- a/packages/react/skills/osdk-react-migrate/references/migration-guide.md
+++ b/packages/react/skills/osdk-react-migrate/references/migration-guide.md
@@ -1,0 +1,459 @@
+# Adoption Migration Guide
+
+Step-by-step before/after examples for converting OSDK-backed data fetching to `@osdk/react` hooks.
+
+## useEffect + client → useOsdkObjects
+
+The most common pattern. A `useState`+`useEffect` pair that calls `client(Type).fetchPage()`.
+
+**Before:**
+
+```tsx
+import { Employee } from "@my/osdk";
+import { useEffect, useState } from "react";
+
+function EmployeeList() {
+  const [employees, setEmployees] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    setIsLoading(true);
+    client(Employee).fetchPage().then(r => {
+      setEmployees(r.data);
+      setIsLoading(false);
+    });
+  }, []);
+
+  if (isLoading) return <div>Loading...</div>;
+  return (
+    <div>{employees.map(e => <div key={e.$primaryKey}>{e.fullName}</div>)}</div>
+  );
+}
+```
+
+**After:**
+
+```tsx
+import { Employee } from "@my/osdk";
+import { useOsdkObjects } from "@osdk/react";
+
+function EmployeeList() {
+  const { data: employees, isLoading } = useOsdkObjects(Employee);
+
+  return (
+    <div>
+      {isLoading && <div>Loading...</div>}
+      {employees?.map(e => <div key={e.$primaryKey}>{e.fullName}</div>)}
+    </div>
+  );
+}
+```
+
+**What changed:**
+
+- Removed `useState` (x2) and `useEffect`
+- Replaced with `useOsdkObjects` (one line)
+- Loading indicator rendered alongside data (not as early return)
+- Removed `useEffect` and `useState` imports if unused
+
+---
+
+## useEffect + client → useOsdkObject (single object by key)
+
+**Before:**
+
+```tsx
+function EmployeeDetail({ id }: { id: string }) {
+  const [employee, setEmployee] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    setIsLoading(true);
+    client(Employee).fetchOne(id).then(e => {
+      setEmployee(e);
+      setIsLoading(false);
+    });
+  }, [id]);
+
+  if (isLoading && !employee) return <div>Loading...</div>;
+  if (!employee) return <div>Not found</div>;
+  return <div>{employee.fullName}</div>;
+}
+```
+
+**After:**
+
+```tsx
+import { useOsdkObject } from "@osdk/react";
+
+function EmployeeDetail({ id }: { id: string }) {
+  const { object: employee, isLoading } = useOsdkObject(Employee, id);
+
+  if (!employee && isLoading) return <div>Loading...</div>;
+  if (!employee) return <div>Not found</div>;
+  return <div>{employee.fullName}</div>;
+}
+```
+
+---
+
+## TanStack Query useQuery → useOsdkObjects
+
+**Before:**
+
+```tsx
+import { useQuery } from "@tanstack/react-query";
+
+function TodoList() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["todos"],
+    queryFn: () => client(Todo).fetchPage().then(r => r.data),
+  });
+
+  if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error</div>;
+  return <div>{data?.map(t => <div key={t.$primaryKey}>{t.title}</div>)}</div>;
+}
+```
+
+**After:**
+
+```tsx
+import { useOsdkObjects } from "@osdk/react";
+
+function TodoList() {
+  const { data, isLoading, error } = useOsdkObjects(Todo);
+
+  if (error) return <div>Error: {error.message}</div>;
+  return (
+    <div>
+      {isLoading && <div>Loading...</div>}
+      {data?.map(t => <div key={t.$primaryKey}>{t.title}</div>)}
+    </div>
+  );
+}
+```
+
+---
+
+## TanStack Query useQuery → useOsdkObject (single by key)
+
+**Before:**
+
+```tsx
+const { data } = useQuery({
+  queryKey: ["employee", id],
+  queryFn: () => client(Employee).fetchOne(id),
+});
+```
+
+**After:**
+
+```tsx
+const { object: data, isLoading } = useOsdkObject(Employee, id);
+```
+
+---
+
+## TanStack Query useMutation → useOsdkAction
+
+**Before:**
+
+```tsx
+import { useMutation } from "@tanstack/react-query";
+
+function UpdateButton({ employee }) {
+  const mutation = useMutation({
+    mutationFn: () =>
+      client(modifyEmployee).applyAction({ employee, primary_office_id: "hq" }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["employees"] }),
+  });
+
+  return (
+    <button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+      Update Office
+    </button>
+  );
+}
+```
+
+**After:**
+
+```tsx
+import { useOsdkAction } from "@osdk/react";
+import { useCallback } from "react";
+
+function UpdateButton({ employee }) {
+  const { applyAction, isPending } = useOsdkAction(modifyEmployee);
+
+  const handleClick = useCallback(() => {
+    applyAction({ employee, primary_office_id: "hq" });
+  }, [applyAction, employee]);
+
+  return (
+    <button onClick={handleClick} disabled={isPending}>
+      Update Office
+    </button>
+  );
+}
+```
+
+**Note:** Remove the `queryClient.invalidateQueries()` call — `useOsdkAction` triggers cache invalidation automatically via the action response.
+
+---
+
+## SWR useSWR → useOsdkObjects
+
+**Before:**
+
+```tsx
+import useSWR from "swr";
+
+function TodoList() {
+  const { data, isLoading } = useSWR(
+    "todos",
+    () => client(Todo).fetchPage().then(r => r.data),
+  );
+
+  return <div>{data?.map(t => <div key={t.$primaryKey}>{t.title}</div>)}</div>;
+}
+```
+
+**After:**
+
+```tsx
+import { useOsdkObjects } from "@osdk/react";
+
+function TodoList() {
+  const { data, isLoading } = useOsdkObjects(Todo);
+  return (
+    <div>
+      {isLoading && <div>Loading...</div>}
+      {data?.map(t => <div key={t.$primaryKey}>{t.title}</div>)}
+    </div>
+  );
+}
+```
+
+---
+
+## useEffect + link traversal → useLinks
+
+**Before:**
+
+```tsx
+function Reports({ employee }) {
+  const [reports, setReports] = useState([]);
+
+  useEffect(() => {
+    client(employee).links.reports.fetchPage().then(r => setReports(r.data));
+  }, [employee.$primaryKey]);
+
+  return (
+    <div>{reports.map(r => <div key={r.$primaryKey}>{r.fullName}</div>)}</div>
+  );
+}
+```
+
+**After:**
+
+```tsx
+import { useLinks } from "@osdk/react";
+
+function Reports({ employee }) {
+  const { links: reports, isLoading } = useLinks(employee, "reports");
+
+  return (
+    <div>
+      {isLoading && <div>Loading...</div>}
+      {reports?.map(r => <div key={r.$primaryKey}>{r.fullName}</div>)}
+    </div>
+  );
+}
+```
+
+---
+
+## useQuery with aggregation → useOsdkAggregation
+
+**Before:**
+
+```tsx
+const { data } = useQuery({
+  queryKey: ["todo-stats"],
+  queryFn: () => client(Todo).aggregate({ $count: {} }),
+});
+```
+
+**After:**
+
+```tsx
+import { useOsdkAggregation } from "@osdk/react";
+
+const { data } = useOsdkAggregation(Todo, {
+  aggregate: { $select: { $count: "unordered" } },
+});
+// Access via data?.$count
+```
+
+---
+
+## useQuery with function call → useOsdkFunction
+
+**Before:**
+
+```tsx
+const { data } = useQuery({
+  queryKey: ["metrics", deptId],
+  queryFn: () => client(getMetrics).executeFunction({ deptId }),
+});
+```
+
+**After:**
+
+```tsx
+import { useOsdkFunction } from "@osdk/react";
+
+const { data } = useOsdkFunction(getMetrics, {
+  params: { deptId },
+  dependsOn: [Employee], // optional: auto-refetch when Employee objects change
+});
+```
+
+---
+
+## Complex ObjectSet → useObjectSet
+
+Only reach for `useObjectSet` when you need set operations (`union`, `intersect`, `subtract`).
+
+**Before:**
+
+```tsx
+const { data } = useQuery({
+  queryKey: ["active-high-priority"],
+  queryFn: async () => {
+    const high = client(Todo).where({ priority: "high" });
+    const completed = client(Todo).where({ isComplete: true });
+    const set = high.subtract(completed);
+    return set.fetchPage().then(r => r.data);
+  },
+});
+```
+
+**After:**
+
+```tsx
+import { useObjectSet } from "@osdk/react";
+
+const highPriority = client(Todo).where({ priority: "high" });
+const completed = client(Todo).where({ isComplete: true });
+
+const { data } = useObjectSet(highPriority, {
+  subtract: [completed],
+});
+```
+
+---
+
+## Adding OsdkProvider to the app root
+
+If `OsdkProvider` is missing, add it at the outermost render call.
+
+**Before:**
+
+```tsx
+// main.tsx
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);
+```
+
+**After:**
+
+```tsx
+// main.tsx
+import { OsdkProvider } from "@osdk/react";
+import client from "./client";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <OsdkProvider client={client}>
+      <App />
+    </OsdkProvider>
+  </React.StrictMode>,
+);
+```
+
+---
+
+## Adding optimistic updates to an action
+
+When converting a TanStack mutation that had an `onMutate` optimistic update, preserve the intent using `$optimisticUpdate`:
+
+**Before:**
+
+```tsx
+const mutation = useMutation({
+  mutationFn: () =>
+    client(completeTodo).applyAction({ todo, isComplete: true }),
+  onMutate: async () => {
+    await queryClient.cancelQueries({ queryKey: ["todos"] });
+    const previous = queryClient.getQueryData(["todos"]);
+    queryClient.setQueryData(
+      ["todos"],
+      old => old.map(t => t.id === todo.id ? { ...t, isComplete: true } : t),
+    );
+    return { previous };
+  },
+  onError: (_, __, context) => {
+    queryClient.setQueryData(["todos"], context.previous);
+  },
+});
+```
+
+**After:**
+
+```tsx
+const { applyAction, isPending } = useOsdkAction(completeTodo);
+
+const handleClick = useCallback(() => {
+  applyAction({
+    todo,
+    isComplete: true,
+    $optimisticUpdate: (ou) => {
+      ou.updateObject(todo.$clone({ isComplete: true }));
+    },
+  });
+}, [applyAction, todo]);
+```
+
+The `$optimisticUpdate` callback receives an update builder. Call `ou.updateObject(instance.$clone({ ... }))` to apply optimistic changes. On failure they roll back automatically.
+
+---
+
+## Sites to flag (don't convert)
+
+Leave these in place with a comment:
+
+```tsx
+// osdk-react-migrate: manual cache tuning — conversion skipped.
+// staleTime and refetchInterval configure custom cache behavior.
+// @osdk/react invalidates automatically after actions. If manual
+// control is no longer needed, convert to useOsdkObjects.
+const { data } = useQuery({
+  queryKey: ["employee", id],
+  queryFn: () => client(Employee).fetchOne(id),
+  staleTime: 5 * 60 * 1000,
+  refetchInterval: 30_000,
+});
+```
+
+Flag conditions (any one is sufficient):
+
+- `staleTime`, `cacheTime`, or `gcTime` set to a non-default value
+- `refetchInterval` or `refetchIntervalInBackground`
+- `refetchOnWindowFocus: false` or `refetchOnMount: false`
+- TanStack `onMutate` + manual rollback (`onError` with `context`) not representable as `$optimisticUpdate`
+- Manual `queryClient.invalidateQueries()` called immediately after an OSDK action call

--- a/packages/react/skills/osdk-react-migrate/references/patterns.md
+++ b/packages/react/skills/osdk-react-migrate/references/patterns.md
@@ -1,0 +1,251 @@
+# Correct Usage Patterns
+
+Reference for enforcing correct `@osdk/react` patterns during the adoption migration.
+
+## Rules (must enforce on every converted file)
+
+### Rule 1 — Never conditionally call hooks
+
+React's rules of hooks apply. The `enabled` option is the correct escape hatch.
+
+```tsx
+// WRONG — conditional hook call
+if (shouldLoad) {
+  const { data } = useOsdkObjects(Todo);
+}
+
+// CORRECT — use enabled
+const { data } = useOsdkObjects(Todo, { enabled: shouldLoad });
+```
+
+```tsx
+// WRONG — hook inside event handler
+const handleClick = () => {
+  const client = useOsdkClient(); // runtime error
+};
+
+// CORRECT — hook at component top level
+function MyComponent() {
+  const client = useOsdkClient();
+  const handleClick = () => {/* use client here */};
+}
+```
+
+### Rule 2 — Keep rendering during loading; no early returns
+
+`@osdk/react` hooks may have stale data while reloading (`isLoading: true` with `data` already set). Early returns on `isLoading` discard existing data and cause UI flashing.
+
+```tsx
+// WRONG — discards existing data on revalidation
+if (isLoading) return <Spinner />;
+return <List data={data} />;
+
+// CORRECT — render both together
+return (
+  <div>
+    {isLoading && <Spinner />}
+    <List data={data} />
+  </div>
+);
+```
+
+Exception: `if (!data && isLoading)` is acceptable for the initial load state before any data has arrived.
+
+```tsx
+// ACCEPTABLE for initial load
+if (!data && isLoading) return <div>Loading...</div>;
+```
+
+### Rule 3 — useOsdkObject `enabled` is positional
+
+For the type+key overload, `enabled` is the third argument, not inside an options object.
+
+```tsx
+// WRONG
+useOsdkObject(Employee, id, { enabled: false });
+
+// CORRECT
+useOsdkObject(Employee, id, false);
+useOsdkObject(Employee, id, true);
+
+// Options object is the third arg for property selection, not enabled
+useOsdkObject(Employee, id, { $select: ["fullName"] });
+```
+
+### Rule 4 — Prefer useOsdkObjects over useObjectSet
+
+`useOsdkObjects` is more optimized. Only reach for `useObjectSet` when the query requires `union`, `intersect`, or `subtract` set operations on two or more `ObjectSet` instances.
+
+```tsx
+// WRONG — unnecessary useObjectSet
+const { data } = useObjectSet(client(Todo), { where: { isComplete: false } });
+
+// CORRECT — useOsdkObjects handles simple queries
+const { data } = useOsdkObjects(Todo, { where: { isComplete: false } });
+
+// CORRECT — useObjectSet for set operations
+const highPriority = client(Todo).where({ priority: "high" });
+const completed = client(Todo).where({ isComplete: true });
+const { data } = useObjectSet(highPriority, { subtract: [completed] });
+```
+
+### Rule 5 — streamUpdates and pivotTo cannot be combined
+
+```tsx
+// WRONG
+useOsdkObjects(Todo, { streamUpdates: true, pivotTo: "assignee" });
+
+// CORRECT — choose one or the other
+useOsdkObjects(Todo, { streamUpdates: true });
+useOsdkObjects(Todo, { pivotTo: "assignee" });
+```
+
+### Rule 6 — Don't copy OSDK data into a second store
+
+Avoid copying OSDK hook results into Redux, TanStack Query cache, or component state — this loses normalization and fights optimistic updates.
+
+```tsx
+// WRONG — second source of truth
+const { data } = useOsdkObjects(Todo);
+const [todos, setTodos] = useState([]);
+useEffect(() => {
+  setTodos(data ?? []);
+}, [data]); // redundant
+
+// CORRECT — consume data directly from the hook
+const { data: todos } = useOsdkObjects(Todo);
+```
+
+## Patterns to generate
+
+### Object list
+
+```tsx
+import { Todo } from "@my/osdk";
+import { useOsdkObjects } from "@osdk/react";
+
+function TodoList() {
+  const { data, isLoading, error } = useOsdkObjects(Todo, {
+    where: { isComplete: false },
+    orderBy: { createdAt: "desc" },
+  });
+
+  if (error) return <div>Error: {error.message}</div>;
+
+  return (
+    <div>
+      {isLoading && <div>Loading...</div>}
+      {data?.map(todo => <div key={todo.$primaryKey}>{todo.title}</div>)}
+    </div>
+  );
+}
+```
+
+### Single object by primary key
+
+```tsx
+import { Employee } from "@my/osdk";
+import { useOsdkObject } from "@osdk/react";
+
+function EmployeeDetail({ id }: { id: string }) {
+  const { object, isLoading, error } = useOsdkObject(Employee, id);
+
+  if (!object && isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+  if (!object) return <div>Not found</div>;
+
+  return <div>{object.fullName}</div>;
+}
+```
+
+### Action
+
+```tsx
+import { modifyEmployee } from "@my/osdk";
+import { useOsdkAction } from "@osdk/react";
+import { useCallback } from "react";
+
+function EditButton({ employee }) {
+  const { applyAction, isPending, error } = useOsdkAction(modifyEmployee);
+
+  const handleClick = useCallback(() => {
+    applyAction({ employee, primary_office_id: "new-office" });
+  }, [applyAction, employee]);
+
+  return (
+    <div>
+      <button onClick={handleClick} disabled={isPending}>
+        {isPending ? "Saving..." : "Update Office"}
+      </button>
+      {error?.actionValidation && <div>{error.actionValidation.message}</div>}
+    </div>
+  );
+}
+```
+
+### Links
+
+```tsx
+import { Employee } from "@my/osdk";
+import { useLinks } from "@osdk/react";
+
+function DirectReports({ employee }: { employee: Employee.OsdkInstance }) {
+  const { links, isLoading, fetchMore, hasMore } = useLinks(
+    employee,
+    "reports",
+    {
+      orderBy: { fullName: "asc" },
+    },
+  );
+
+  return (
+    <div>
+      {isLoading && <div>Loading...</div>}
+      {links?.map(r => <div key={r.$primaryKey}>{r.fullName}</div>)}
+      {hasMore && <button onClick={() => fetchMore?.()}>Load more</button>}
+    </div>
+  );
+}
+```
+
+### Conditional query with enabled
+
+```tsx
+const { data } = useOsdkObjects(Todo, {
+  enabled: userId !== undefined,
+  where: { assignee: userId },
+});
+```
+
+### Function with dependency tracking
+
+```tsx
+import { Employee, getMetrics } from "@my/osdk";
+import { useOsdkFunction } from "@osdk/react";
+
+function Metrics({ deptId }: { deptId: string }) {
+  const { data, isLoading } = useOsdkFunction(getMetrics, {
+    params: { deptId },
+    dependsOn: [Employee], // auto-refetch when any Employee changes
+  });
+
+  return (
+    <div>
+      {isLoading && <span>Updating...</span>}
+      {data && <span>Headcount: {data.headcount}</span>}
+    </div>
+  );
+}
+```
+
+## Anti-patterns to flag
+
+| Anti-pattern                                              | Correct pattern                                            |
+| --------------------------------------------------------- | ---------------------------------------------------------- |
+| `if (x) { useOsdkObjects(...) }`                          | `useOsdkObjects(..., { enabled: x })`                      |
+| `if (isLoading) return <Spinner />`                       | Render `{isLoading && <Spinner />}` alongside data         |
+| `useOsdkObject(T, id, { enabled: false })`                | `useOsdkObject(T, id, false)`                              |
+| `useObjectSet(client(T), { where: ... })` with no set ops | `useOsdkObjects(T, { where: ... })`                        |
+| Copying hook result into `useState`                       | Consume directly from the hook                             |
+| `streamUpdates: true` + `pivotTo` together                | Use one or the other                                       |
+| Calling `invalidateObjectType` after an OSDK action       | Remove manual invalidation; actions drive it automatically |


### PR DESCRIPTION
Ships the adoption migration skill at packages/react/skills/osdk-react-migrate/. The skill converts OSDK-backed data fetching (useEffect + client, TanStack Query, SWR) to @osdk/react hooks. Includes a Step 0 guardrail that blocks conversion until the rename migration (npx @osdk/codemod react/experimental-to-ga) is run. Reference files in references/ ground the model against the live hook API.