### PR TITLE
Fix list parameter required validation for function backed actions

### DIFF
--- a/.changeset/wicked-gifts-pull.md
+++ b/.changeset/wicked-gifts-pull.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker-experimental": patch
+---
+
+Fix parameter required validation for function backed actions

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertActionHelpers.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertActionHelpers.ts
@@ -307,13 +307,24 @@ function convertFunctionBackedAction(
     };
 
     const paramType = dataTypeToActionParameterType(input.dataType);
+    const listTypes = [
+      ...Object.values(PRIMITIVE_LIST_TYPES),
+      "objectReferenceList",
+      "interfaceReferenceList",
+      "structList",
+    ];
 
     syntheticParameters.push({
       id: paramId,
       displayName: uppercaseFirstLetter(paramId),
       type: paramType,
       validation: {
-        required: true,
+        required:
+          (typeof paramType === "object") && listTypes.includes(paramType.type)
+            ? {
+              listLength: {},
+            }
+            : input.required,
         defaultVisibility: "editable",
         allowedValues: extractAllowedValuesFromActionParameterType(paramType),
       },
@@ -454,6 +465,7 @@ const PRIMITIVE_LIST_TYPES: Record<string, ActionParameter["type"]> = {
   "date": "dateList",
   "timestamp": "timestampList",
   "attachment": "attachmentList",
+  "decimal": "decimalList",
 };
 
 function dataTypeToActionParameterListType(

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertActionHelpers.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertActionHelpers.ts
@@ -466,6 +466,9 @@ const PRIMITIVE_LIST_TYPES: Record<string, ActionParameter["type"]> = {
   "timestamp": "timestampList",
   "attachment": "attachmentList",
   "decimal": "decimalList",
+  "geoshape": "geoshapeList",
+  "mediaReference": "mediaReferenceList",
+  "marking": "markingList",
 };
 
 function dataTypeToActionParameterListType(


### PR DESCRIPTION
We had an invalid `required` validation for function backed action list parameters