### PR TITLE
make the dev-mode action delay configurable

### DIFF
--- a/.changeset/dev-mode-action-delay.md
+++ b/.changeset/dev-mode-action-delay.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client": minor
+"@osdk/react": minor
+---
+
+Make the dev-mode action delay smart, configurable, and discoverable. The delay now only applies to actions with an optimistic update (function-backed actions stay fast), is tunable via `OsdkProvider`'s `devMode={{ actionDelayMs }}` prop and the `createObservableClient` `devMode.actionDelayMs` option (0 disables), and logs a one-time message explaining it.

--- a/docs/react/actions.md
+++ b/docs/react/actions.md
@@ -321,6 +321,26 @@ const updatedTodo = todo.$clone({
 
 :::
 
+### Dev-Mode Action Delay
+
+In development builds, the observable client adds a short artificial delay (1000ms by default) to an action's result when an `$optimisticUpdate` is provided. This makes the optimistic state visible before the server response lands, so you can confirm your optimistic updates render correctly. The delay never runs in production builds, and it is skipped entirely for actions without an optimistic update (such as function-backed actions), so those stay fast.
+
+Tune or disable it on the provider:
+
+```tsx
+// Disable the delay
+<OsdkProvider client={client} devMode={{ actionDelayMs: 0 }}>
+  {children}
+</OsdkProvider>
+
+// Use a shorter delay
+<OsdkProvider client={client} devMode={{ actionDelayMs: 200 }}>
+  {children}
+</OsdkProvider>
+```
+
+The first time the delay is applied, a one-time message is logged to the console explaining what happened and how to turn it off. If you are configuring the observable client directly, the same option is available as `createObservableClient(client, extraUserAgents, { devMode: { actionDelayMs: 0 } })`.
+
 ---
 
 ## useDebouncedCallback

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -662,9 +662,26 @@ export type CanonicalizedOptions<
   [K in keyof T]: T[K];
 };
 
+export interface ObservableClientOptions {
+  /**
+   * Dev-only behaviors of the observable client. These options have no effect
+   * in production builds, where the relevant code is stripped at build time.
+   */
+  devMode?: {
+    /**
+     * Artificial delay, in milliseconds, applied to single action results in
+     * dev mode so optimistic updates are visible before the server response
+     * lands. Only applied when an optimistic update is provided to the action.
+     * Set to 0 to disable. Defaults to 1000.
+     */
+    actionDelayMs?: number;
+  };
+}
+
 export function createObservableClient(
   client: Client,
   extraUserAgents?: () => string[],
+  options?: ObservableClientOptions,
 ): ObservableClient {
   // First we need a modified client that adds an extra header so we know its
   // an observable client
@@ -689,7 +706,7 @@ export function createObservableClient(
 
   // Then we use that client instead. Because the `client` does not hold
   // any real state, this whole thing works.
-  return new ObservableClientImpl(new Store(tweakedClient));
+  return new ObservableClientImpl(new Store(tweakedClient, options));
 }
 
 export interface Unsubscribable {

--- a/packages/client/src/observable/internal/Store.ts
+++ b/packages/client/src/observable/internal/Store.ts
@@ -29,7 +29,11 @@ import invariant from "tiny-invariant";
 import type { ActionSignatureFromDef } from "../../actions/applyAction.js";
 import { additionalContext, type Client } from "../../Client.js";
 import { DEBUG_REFCOUNTS } from "../DebugFlags.js";
-import type { CacheEntry, CacheSnapshot } from "../ObservableClient.js";
+import type {
+  CacheEntry,
+  CacheSnapshot,
+  ObservableClientOptions,
+} from "../ObservableClient.js";
 import type { OptimisticBuilder } from "../OptimisticBuilder.js";
 import { ActionApplication } from "./actions/ActionApplication.js";
 import {
@@ -123,6 +127,14 @@ export class Store {
   /** @internal */
   readonly logger?: Logger;
 
+  /**
+   * Resolved dev-mode action delay in ms (0 disables); only read in dev builds.
+   * @internal
+   */
+  readonly devModeActionDelayMs: number;
+
+  #devModeDelayWarned = false;
+
   readonly cacheKeys: CacheKeys<KnownCacheKey>;
   readonly queries: Queries = new Queries();
 
@@ -156,11 +168,12 @@ export class Store {
   readonly media: MediaHelper;
   readonly objectSets: ObjectSetHelper;
 
-  constructor(client: Client) {
+  constructor(client: Client, options?: ObservableClientOptions) {
     this.logger = client[additionalContext].logger?.child({}, {
       msgPrefix: "Store",
     });
     this.client = client;
+    this.devModeActionDelayMs = options?.devMode?.actionDelayMs ?? 1000;
 
     this.cacheKeys = new CacheKeys<KnownCacheKey>({
       onDestroy: this.#cleanupCacheKey,
@@ -203,6 +216,26 @@ export class Store {
       this.selectCanonicalizer,
       this.objectSetArrayCanonicalizer,
     );
+  }
+
+  /**
+   * Logs the dev-mode delay explanation once per store. No-op in production.
+   * @internal
+   */
+  maybeWarnDevModeDelayApplied(): void {
+    if (process.env.NODE_ENV !== "production" && !this.#devModeDelayWarned) {
+      this.#devModeDelayWarned = true;
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[@osdk/client] Applied a ${this.devModeActionDelayMs}ms dev-mode `
+          + `delay to an action with an optimistic update so the optimistic `
+          + `state is visible before the server responds. This only happens `
+          + `in dev mode and only for actions with an optimistic update. Tune `
+          + `it via the OsdkProvider \`devMode={{ actionDelayMs }}\` prop `
+          + `(or the createObservableClient \`devMode.actionDelayMs\` option); `
+          + `set it to 0 to disable.`,
+      );
+    }
   }
 
   /**

--- a/packages/client/src/observable/internal/actions/ActionApplication.test.ts
+++ b/packages/client/src/observable/internal/actions/ActionApplication.test.ts
@@ -450,4 +450,83 @@ describe("ActionApplication invalidation", () => {
 
     subscription.unsubscribe();
   });
+
+  describe("dev-mode action delay", () => {
+    const noopOptimistic = () => {};
+
+    it("defaults the resolved delay to 1000ms", () => {
+      expect(new Store(client).devModeActionDelayMs).toBe(1000);
+    });
+
+    it("resolves a configured delay from options", () => {
+      expect(
+        new Store(client, { devMode: { actionDelayMs: 0 } })
+          .devModeActionDelayMs,
+      ).toBe(0);
+      expect(
+        new Store(client, { devMode: { actionDelayMs: 250 } })
+          .devModeActionDelayMs,
+      ).toBe(250);
+    });
+
+    it("skips the delay when no optimistic update is provided", async () => {
+      const warnSpy = vi.spyOn(store, "maybeWarnDevModeDelayApplied");
+
+      await store.applyAction(editTodo, { id: 0, text: "no-optimistic" });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("applies the delay when an optimistic update is provided", async () => {
+      const fastStore = new Store(client, { devMode: { actionDelayMs: 20 } });
+      const warnSpy = vi.spyOn(fastStore, "maybeWarnDevModeDelayApplied");
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+      await fastStore.applyAction(editTodo, { id: 0, text: "optimistic" }, {
+        optimisticUpdate: noopOptimistic,
+      });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 20);
+
+      setTimeoutSpy.mockRestore();
+    });
+
+    it("does not delay when the configured delay is 0", async () => {
+      const noDelayStore = new Store(client, {
+        devMode: { actionDelayMs: 0 },
+      });
+      const warnSpy = vi.spyOn(
+        noDelayStore,
+        "maybeWarnDevModeDelayApplied",
+      );
+
+      await noDelayStore.applyAction(editTodo, { id: 0, text: "instant" }, {
+        optimisticUpdate: noopOptimistic,
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("warns at most once per store", async () => {
+      const fastStore = new Store(client, { devMode: { actionDelayMs: 20 } });
+      const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(
+        () => {},
+      );
+
+      await fastStore.applyAction(editTodo, { id: 0, text: "first" }, {
+        optimisticUpdate: noopOptimistic,
+      });
+      await fastStore.applyAction(editTodo, { id: 0, text: "second" }, {
+        optimisticUpdate: noopOptimistic,
+      });
+
+      const devModeWarnings = consoleWarnSpy.mock.calls.filter(
+        ([first]) => typeof first === "string" && first.includes("dev-mode"),
+      );
+      expect(devModeWarnings).toHaveLength(1);
+
+      consoleWarnSpy.mockRestore();
+    });
+  });
 });

--- a/packages/client/src/observable/internal/actions/ActionApplication.ts
+++ b/packages/client/src/observable/internal/actions/ActionApplication.ts
@@ -20,8 +20,6 @@ import { API_NAME_IDX } from "../list/ListCacheKey.js";
 import type { Store } from "../Store.js";
 import { runOptimisticJob } from "./OptimisticJob.js";
 
-const ACTION_DELAY = process.env.NODE_ENV === "production" ? 0 : 1000;
-
 export class ActionApplication {
   constructor(private store: Store) {}
 
@@ -65,11 +63,12 @@ export class ActionApplication {
         );
 
         if (process.env.NODE_ENV !== "production") {
-          if (ACTION_DELAY > 0) {
+          // Skip when there's no optimistic update to surface (e.g. FBAs).
+          const delayMs = this.store.devModeActionDelayMs;
+          if (optimisticUpdate != null && delayMs > 0) {
+            this.store.maybeWarnDevModeDelayApplied();
             logger?.debug("action done, pausing", actionResults);
-            await new Promise<void>(resolve =>
-              setTimeout(resolve, ACTION_DELAY)
-            );
+            await new Promise<void>(resolve => setTimeout(resolve, delayMs));
             logger?.debug("action done, pausing done");
           }
         }

--- a/packages/client/src/public/observable.ts
+++ b/packages/client/src/public/observable.ts
@@ -22,6 +22,7 @@ export type {
   CanonicalizedOptions,
   CanonicalizeOptionsInput,
   ObservableClient,
+  ObservableClientOptions,
   ObserveAggregationArgs,
   ObserveFunctionCallbackArgs,
   ObserveFunctionOptions,

--- a/packages/react/src/new/OsdkProvider.tsx
+++ b/packages/react/src/new/OsdkProvider.tsx
@@ -15,6 +15,7 @@
  */
 
 import type { Client } from "@osdk/client";
+import type { ObservableClientOptions } from "@osdk/client/observable";
 import { createObservableClient } from "@osdk/client/observable";
 import React, { useCallback, useMemo, useRef } from "react";
 import { getRegisteredDevTools } from "../public/devtools-registry.js";
@@ -31,12 +32,19 @@ interface OsdkProviderOptions {
   children: React.ReactNode;
   client: Client;
   enableDevTools?: boolean;
+  /**
+   * Dev-only behaviors of the underlying observable client. Has no effect in
+   * production builds. Use `devMode={{ actionDelayMs: 0 }}` to disable the
+   * artificial action delay that makes optimistic updates visible in dev.
+   */
+  devMode?: ObservableClientOptions["devMode"];
 }
 
 export function OsdkProvider({
   children,
   client,
   enableDevTools,
+  devMode,
 }: OsdkProviderOptions): React.JSX.Element {
   const devtoolsEnabled = __DEV__
     && (enableDevTools ?? getRegisteredDevTools() != null);
@@ -50,13 +58,15 @@ export function OsdkProvider({
     };
   }, []);
 
+  const actionDelayMs = devMode?.actionDelayMs;
   const baseObservableClient = useMemo(
     () =>
       createObservableClient(
         client,
         () => [...userAgentsRef.current],
+        { devMode: { actionDelayMs } },
       ),
-    [client],
+    [client, actionDelayMs],
   );
 
   const { client: devToolsClient, wrapChildren } = useDevToolsClient(

--- a/packages/react/src/new/__tests__/OsdkProvider.test.tsx
+++ b/packages/react/src/new/__tests__/OsdkProvider.test.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Client } from "@osdk/client";
+import type { ObservableClient } from "@osdk/client/observable";
+import { render } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { OsdkProvider } from "../OsdkProvider.js";
+
+const { createObservableClientMock } = vi.hoisted(() => ({
+  createObservableClientMock: vi.fn(
+    () => ({}) as unknown as ObservableClient,
+  ),
+}));
+
+vi.mock("@osdk/client/observable", () => ({
+  createObservableClient: createObservableClientMock,
+}));
+
+const mockClient = {} as unknown as Client;
+
+describe("OsdkProvider", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes the devMode option through to createObservableClient", () => {
+    render(
+      <OsdkProvider client={mockClient} devMode={{ actionDelayMs: 0 }}>
+        <div />
+      </OsdkProvider>,
+    );
+
+    expect(createObservableClientMock).toHaveBeenCalledTimes(1);
+    expect(createObservableClientMock).toHaveBeenLastCalledWith(
+      mockClient,
+      expect.any(Function),
+      { devMode: { actionDelayMs: 0 } },
+    );
+  });
+
+  it("defaults actionDelayMs to undefined when devMode is omitted", () => {
+    render(
+      <OsdkProvider client={mockClient}>
+        <div />
+      </OsdkProvider>,
+    );
+
+    expect(createObservableClientMock).toHaveBeenLastCalledWith(
+      mockClient,
+      expect.any(Function),
+      { devMode: { actionDelayMs: undefined } },
+    );
+  });
+
+  it("does not recreate the observable client when actionDelayMs is unchanged", () => {
+    const { rerender } = render(
+      <OsdkProvider client={mockClient} devMode={{ actionDelayMs: 250 }}>
+        <div />
+      </OsdkProvider>,
+    );
+
+    expect(createObservableClientMock).toHaveBeenCalledTimes(1);
+
+    // New object literal, same value: must not re-create the client.
+    rerender(
+      <OsdkProvider client={mockClient} devMode={{ actionDelayMs: 250 }}>
+        <div />
+      </OsdkProvider>,
+    );
+
+    expect(createObservableClientMock).toHaveBeenCalledTimes(1);
+
+    // Changing the value re-creates the client.
+    rerender(
+      <OsdkProvider client={mockClient} devMode={{ actionDelayMs: 0 }}>
+        <div />
+      </OsdkProvider>,
+    );
+
+    expect(createObservableClientMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
the observable client forced a 1s dev-mode delay on every action to make optimistic updates visible, which hurt local devx, especially for function-backed actions where optimistic updates don't apply

• skip the dev-mode delay when an action has no optimistic update, so function-backed actions stay fast
• add `devMode.actionDelayMs` to tune or disable it via the OsdkProvider prop and the createObservableClient option (0 disables, default 1000)
• log a one-time message explaining the delay and how to turn it off
