### PR TITLE
Add injectable subscribe functions for embedded ObjectSet workflows.

### DIFF
--- a/.changeset/quiet-pugs-grow.md
+++ b/.changeset/quiet-pugs-grow.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": minor
+---
+
+Add `createClientWithSubscribe` (unstable) to allow overriding `objectSet.subscribe` behavior with a custom `subscribeFn`.

--- a/packages/client/src/MinimalClientContext.ts
+++ b/packages/client/src/MinimalClientContext.ts
@@ -19,6 +19,7 @@ import type { SharedClientContext } from "@osdk/shared.client2";
 import type { convertWireToOsdkObjects } from "./object/convertWireToOsdkObjects.js";
 import type { ObjectSetFactory } from "./objectSet/ObjectSetFactory.js";
 import type { OntologyProvider } from "./ontology/OntologyProvider.js";
+import type { SubscribeFn } from "./SubscribeFn.js";
 
 declare const tag: unique symbol;
 
@@ -37,6 +38,8 @@ export interface MinimalClient extends SharedClientContext {
   objectSetFactory: ObjectSetFactory<any, any>;
   /** @internal */
   objectFactory: typeof convertWireToOsdkObjects;
+  /** @internal */
+  subscribeFn: SubscribeFn;
 
   transactionId?: string;
   flushEdits?: () => Promise<void>;

--- a/packages/client/src/SubscribeFn.ts
+++ b/packages/client/src/SubscribeFn.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  ObjectOrInterfaceDefinition,
+  ObjectSetSubscription,
+  PropertyKeys,
+} from "@osdk/api";
+import type { ObjectSet as WireObjectSet } from "@osdk/foundry.ontologies";
+
+/**
+ * The injectable seam for `objectSet.subscribe()`. Matches the shape of
+ * `ObjectSetListenerWebsocket.subscribe`. The default delegates to the websocket
+ * implementation; embedders (e.g. embedded ontology) can provide their own to capture
+ * the original subscribe request (`objectType`, the wire `objectSet`, `properties`,
+ * `shouldLoadRids`) rather than the resulting websocket traffic.
+ */
+export type SubscribeFn = <
+  Q extends ObjectOrInterfaceDefinition,
+  P extends PropertyKeys<Q>,
+>(
+  objectType: ObjectOrInterfaceDefinition,
+  objectSet: WireObjectSet,
+  listener: ObjectSetSubscription.Listener<Q, P>,
+  properties?: Array<P>,
+  shouldLoadRids?: boolean,
+) => Promise<() => void>;

--- a/packages/client/src/createClient.ts
+++ b/packages/client/src/createClient.ts
@@ -64,6 +64,7 @@ import type { ObjectSetFactory } from "./objectSet/ObjectSetFactory.js";
 import { ObjectSetListenerWebsocket } from "./objectSet/ObjectSetListenerWebsocket.js";
 import { applyQuery } from "./queries/applyQuery.js";
 import type { QuerySignatureFromDef } from "./queries/types.js";
+import type { SubscribeFn } from "./SubscribeFn.js";
 
 // We import it this way to keep compatible with CJS. If we referenced the
 // value of `symbolClientContext` directly, then we would have to a dynamic import
@@ -112,6 +113,7 @@ export function createClientInternal(
   transactionRid: string | undefined,
   flushEdits: (() => Promise<void>) | undefined,
   scenarioRid: string | undefined,
+  subscribeFn: SubscribeFn | undefined,
   baseUrl: string,
   ontologyRid: string | Promise<string>,
   tokenProvider: () => Promise<string>,
@@ -149,6 +151,7 @@ export function createClientInternal(
       flushEdits,
       scenarioRid,
       branch: options?.UNSTABLE_DO_NOT_USE_BRANCH,
+      subscribeFn,
     },
     fetchFn,
     objectSetFactory,
@@ -470,6 +473,7 @@ export const createClient: (
   undefined,
   undefined,
   undefined,
+  undefined,
 );
 
 export const createClientWithTransaction: (
@@ -482,6 +486,31 @@ export const createClientWithTransaction: (
     transactionRid,
     flushEdits,
     undefined,
+    undefined,
+    ...args,
+  ) as Client;
+
+/**
+ * Creates a {@link Client} whose `objectSet.subscribe()` calls are routed through a caller-supplied
+ * `subscribeFn` instead of the default WebSocket implementation. This is the subscribe analogue of
+ * the `fetchFn` parameter on {@link createClient}: it lets an embedder (e.g. an embedded backend)
+ * capture the original subscribe request — `objectType`, the wire `objectSet`, the requested
+ * `properties`, and `shouldLoadRids` — rather than the resulting WebSocket traffic.
+ *
+ * @param subscribeFn - The subscribe implementation to use for all `objectSet.subscribe()` calls.
+ * @param args - The remaining {@link createClient} arguments (`baseUrl`, `ontologyRid`,
+ *   `tokenProvider`, `options`, `fetchFn`).
+ */
+export const createClientWithSubscribe: (
+  subscribeFn: SubscribeFn,
+  ...args: Parameters<typeof createClient>
+) => Client = (subscribeFn, ...args) =>
+  createClientInternal(
+    createObjectSet,
+    undefined,
+    undefined,
+    undefined,
+    subscribeFn,
     ...args,
   ) as Client;
 
@@ -495,6 +524,7 @@ export const createClientWithScenario: (
     undefined,
     undefined,
     scenarioRid,
+    undefined,
     ...args,
   ) as Client;
 

--- a/packages/client/src/createMinimalClient.ts
+++ b/packages/client/src/createMinimalClient.ts
@@ -29,6 +29,7 @@ import {
   createStandardOntologyProviderFactory,
   type OntologyCachingOptions,
 } from "./ontology/StandardOntologyProvider.js";
+import type { SubscribeFn } from "./SubscribeFn.js";
 import { USER_AGENT } from "./util/UserAgent.js";
 
 /** @internal */
@@ -43,6 +44,7 @@ export function createMinimalClient(
     scenarioRid?: string;
     branch?: string;
     headers?: Record<string, string>;
+    subscribeFn?: SubscribeFn;
   } = {},
   fetchFn: (
     input: Request | URL | string,
@@ -86,12 +88,31 @@ export function createMinimalClient(
     narrowTypeInterfaceOrObjectMapping: {},
   } satisfies Omit<
     MinimalClient,
-    "ontologyProvider"
+    "ontologyProvider" | "subscribeFn"
   > as any;
 
   return Object.freeze(Object.assign(minimalClient, {
     ontologyProvider: createOntologyProviderFactory(
       options,
     )(minimalClient),
+    subscribeFn: options.subscribeFn ?? ((
+      objectType,
+      objectSet,
+      listener,
+      properties,
+      shouldLoadRids,
+    ) =>
+      import("./objectSet/ObjectSetListenerWebsocket.js").then((
+        { ObjectSetListenerWebsocket },
+      ) =>
+        ObjectSetListenerWebsocket.getInstance(minimalClient)
+          .subscribe(
+            objectType,
+            objectSet,
+            listener,
+            properties,
+            shouldLoadRids,
+          )
+      )) satisfies SubscribeFn,
   }));
 }

--- a/packages/client/src/objectSet/createObjectSet.ts
+++ b/packages/client/src/objectSet/createObjectSet.ts
@@ -284,17 +284,13 @@ export function createObjectSet<Q extends ObjectOrInterfaceDefinition>(
       listener,
       opts,
     ) => {
-      const pendingSubscribe = import("./ObjectSetListenerWebsocket.js")
-        .then(({ ObjectSetListenerWebsocket }) =>
-          ObjectSetListenerWebsocket.getInstance(clientCtx)
-            .subscribe(
-              objectType,
-              objectSet,
-              listener as ObjectSetSubscription.Listener<Q, any>,
-              opts?.properties,
-              opts?.includeRid,
-            )
-        );
+      const pendingSubscribe = clientCtx.subscribeFn(
+        objectType,
+        objectSet,
+        listener as ObjectSetSubscription.Listener<Q, any>,
+        opts?.properties,
+        opts?.includeRid,
+      );
 
       return { unsubscribe: async () => (await pendingSubscribe)() };
     },

--- a/packages/client/src/observable/internal/testUtils.ts
+++ b/packages/client/src/observable/internal/testUtils.ts
@@ -214,6 +214,7 @@ export function createClientMockHelper(): MockClientHelper {
     },
     tokenProvider: vitest.fn(),
     objectSetFactory: vitest.fn(),
+    subscribeFn: vitest.fn(),
     fetch: vitest.fn(),
     clientCacheKey: {} as any,
     requestContext: {},

--- a/packages/client/src/public/unstable-do-not-use.ts
+++ b/packages/client/src/public/unstable-do-not-use.ts
@@ -23,7 +23,11 @@ export {
 } from "../public-utils/osdkConfig.js";
 export type { OsdkConfig } from "../public-utils/osdkConfig.js";
 
-export { createClientWithTransaction } from "../createClient.js";
+export {
+  createClientWithSubscribe,
+  createClientWithTransaction,
+} from "../createClient.js";
+export type { SubscribeFn } from "../SubscribeFn.js";
 
 export { createScenario } from "../scenarios/createScenario.js";
 export type { EXPERIMENTAL_ScenarioClient } from "../scenarios/ScenarioClient.js";


### PR DESCRIPTION
In order for Embedded Ontology applications to use ObjectSet subscribe functions, it needs to be possible to capture subscribe requests from the default websocket behavior. This adds an option injectable subscribeFn wrapper to enable custom clients to override subscribe behavior with fully custom logic.