### PR TITLE
add dev-mode observable client debug and loglevel config knobs

### DIFF
--- a/.changeset/observable-dev-debug.md
+++ b/.changeset/observable-dev-debug.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client": minor
+"@osdk/react": minor
+---
+
+Add dev-mode observable client debugging knobs. `devMode.logLevel` raises the client's log level so its `debug` tracing is visible, and `devMode.debug.refCounts` / `devMode.debug.cacheKeys` turn on cache-internals logging. They are exposed through `createObservableClient`'s `devMode` option and the `OsdkProvider` `devMode` prop, and are stripped from production builds.

--- a/docs/react/cache-management.md
+++ b/docs/react/cache-management.md
@@ -194,6 +194,24 @@ function TodoView({ todo }: { todo: Todo.OsdkInstance }) {
 }
 ```
 
+## Dev-Mode Debugging
+
+The observable client has dev-only debugging knobs on the `OsdkProvider` `devMode` prop. They have no effect in production builds, where the relevant code is stripped at build time.
+
+The client's loggers default to the `error` level, which hides the `debug` tracing the observable layer emits. Raise the level to surface it:
+
+```tsx
+<OsdkProvider client={client} devMode={{ logLevel: "debug" }}>
+```
+
+The cache internals can also log their behavior. `refCounts` logs cache-entry reference-count lifecycle (creation, live counts, time-to-live countdown, cleanup, finalization) and shortens the retention window so cleanup is observable sooner; `cacheKeys` logs cache-key canonicalization lookups:
+
+```tsx
+<OsdkProvider client={client} devMode={{ debug: { refCounts: true, cacheKeys: true } }}>
+```
+
+If you are configuring the observable client directly, the same options are available as `createObservableClient(client, extraUserAgents, { devMode: { logLevel: "debug", debug: { refCounts: true } } })`.
+
 ## Best Practices
 
 1. **Reuse query parameters.** Two components that pass identical `where` / `orderBy` / `withProperties` share one cache entry. Hoist the parameter object to a module-level constant or memoize it so React doesn't construct a new one each render.

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -675,8 +675,48 @@ export interface ObservableClientOptions {
      * Set to 0 to disable. Defaults to 1000.
      */
     actionDelayMs?: number;
+
+    /**
+     * Log level for the observable client in dev mode. The client's loggers
+     * default to `"error"`, which hides the `debug`-level tracing the observable
+     * layer emits; set this to `"debug"` (or lower) to surface that tracing.
+     * Inherited by every child logger the observable client creates.
+     */
+    logLevel?: ObservableClientLogLevel;
+
+    /**
+     * Verbose cache-internals logging in dev mode, off by default. These logs
+     * are written with `console` directly and are stripped from production
+     * builds.
+     */
+    debug?: {
+      /**
+       * Logs cache-entry reference-count lifecycle: creation, live counts,
+       * time-to-live countdown, cleanup, and finalization. Also shortens the
+       * retention window so cleanup is observable sooner.
+       */
+      refCounts?: boolean;
+
+      /**
+       * Logs cache-key canonicalization lookups, reporting whether each looked
+       * up key already existed in the trie.
+       */
+      cacheKeys?: boolean;
+    };
   };
 }
+
+/**
+ * Log levels accepted by {@link ObservableClientOptions.devMode}'s `logLevel`,
+ * ordered from most to least verbose.
+ */
+export type ObservableClientLogLevel =
+  | "trace"
+  | "debug"
+  | "info"
+  | "warn"
+  | "error"
+  | "fatal";
 
 export function createObservableClient(
   client: Client,

--- a/packages/client/src/observable/internal/CacheKeys.ts
+++ b/packages/client/src/observable/internal/CacheKeys.ts
@@ -24,6 +24,9 @@ import { RefCounts } from "./RefCounts.js";
  * - Uses Trie structure for efficient storage and lookup
  */
 export class CacheKeys<TCacheKey extends CacheKey> {
+  #debugRefCounts: boolean;
+  #debugCacheKeys: boolean;
+
   #cacheKeys = new Trie<TCacheKey>(false, (keys) => {
     const cacheKey = {
       type: keys[0],
@@ -31,7 +34,7 @@ export class CacheKeys<TCacheKey extends CacheKey> {
     } as unknown as TCacheKey;
     this.#onCreate?.(cacheKey);
 
-    if (DEBUG_REFCOUNTS) {
+    if (process.env.NODE_ENV !== "production" && this.#debugRefCounts) {
       // eslint-disable-next-line no-console
       console.log(
         `CacheKeys.onCreate(${cacheKey.type}, ${
@@ -51,10 +54,7 @@ export class CacheKeys<TCacheKey extends CacheKey> {
     return cacheKey;
   });
 
-  #refCounts = new RefCounts<TCacheKey>(
-    DEBUG_REFCOUNTS ? 15_000 : 60_000,
-    (k) => this.#cleanupCacheKey(k),
-  );
+  #refCounts: RefCounts<TCacheKey>;
 
   // we are currently only using this for debug logging and should just remove it in the future if that
   // continues to be true
@@ -64,13 +64,22 @@ export class CacheKeys<TCacheKey extends CacheKey> {
   #onDestroy?: (cacheKey: TCacheKey) => void;
 
   constructor(
-    { onCreate, onDestroy }: {
+    { onCreate, onDestroy, debug }: {
       onCreate?: (cacheKey: TCacheKey) => void;
       onDestroy?: (cacheKey: TCacheKey) => void;
+      debug?: { refCounts?: boolean; cacheKeys?: boolean };
     },
   ) {
     this.#onCreate = onCreate;
     this.#onDestroy = onDestroy;
+    this.#debugRefCounts = debug?.refCounts ?? DEBUG_REFCOUNTS;
+    this.#debugCacheKeys = debug?.cacheKeys ?? DEBUG_CACHE_KEYS;
+
+    this.#refCounts = new RefCounts<TCacheKey>(
+      this.#debugRefCounts ? 15_000 : 60_000,
+      (k) => this.#cleanupCacheKey(k),
+      this.#debugRefCounts,
+    );
 
     setInterval(() => {
       this.#refCounts.gc();
@@ -96,7 +105,7 @@ export class CacheKeys<TCacheKey extends CacheKey> {
     ...args: K["__cacheKey"]["args"]
   ): K {
     const cacheKeyArgs = this.#normalizeArgs(type, args);
-    if (process.env.NODE_ENV !== "production" && DEBUG_CACHE_KEYS) {
+    if (process.env.NODE_ENV !== "production" && this.#debugCacheKeys) {
       // eslint-disable-next-line no-console
       console.debug(
         `CacheKeys.get([${type},

--- a/packages/client/src/observable/internal/RefCounts.test.ts
+++ b/packages/client/src/observable/internal/RefCounts.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RefCounts } from "./RefCounts.js";
+
+describe("RefCounts", () => {
+  const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+  afterEach(() => {
+    process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+    vi.restoreAllMocks();
+  });
+
+  function retainedRefCounts(debug?: boolean) {
+    const refCounts = new RefCounts<{ id: number }>(0, () => {}, debug);
+    refCounts.retain(refCounts.register({ id: 1 }));
+    return refCounts;
+  }
+
+  it("logs reference counts during gc when debug is enabled", () => {
+    const refCounts = retainedRefCounts(true);
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+
+    refCounts.gc();
+
+    const countLogs = debugSpy.mock.calls.filter(
+      ([first]) =>
+        typeof first === "string" && first.includes("RefCounts.gc() - counts"),
+    );
+    expect(countLogs.length).toBeGreaterThan(0);
+  });
+
+  it("does not log during gc when debug is disabled", () => {
+    const refCounts = retainedRefCounts();
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+
+    refCounts.gc();
+
+    expect(debugSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not log during gc in production even when debug is enabled", () => {
+    const refCounts = retainedRefCounts(true);
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+
+    process.env.NODE_ENV = "production";
+    refCounts.gc();
+
+    expect(debugSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/observable/internal/RefCounts.ts
+++ b/packages/client/src/observable/internal/RefCounts.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { DEBUG_REFCOUNTS } from "../DebugFlags.js";
-
 export class RefCounts<T extends {}> {
   private refCounts = new Map<T, number>();
 
@@ -23,7 +21,11 @@ export class RefCounts<T extends {}> {
   // needed which is good for quick clicks across tabs.
   private gcMap = new Map<T, number /* death time */>();
 
-  constructor(private keepAlive: number, private cleanup: (key: T) => void) {
+  constructor(
+    private keepAlive: number,
+    private cleanup: (key: T) => void,
+    private debug: boolean = false,
+  ) {
   }
 
   register<X extends T>(key: X): X {
@@ -65,7 +67,7 @@ export class RefCounts<T extends {}> {
   gc(): void {
     const now = Date.now();
 
-    if (DEBUG_REFCOUNTS) {
+    if (process.env.NODE_ENV !== "production" && this.debug) {
       for (const [key, count] of this.refCounts) {
         // eslint-disable-next-line no-console
         console.debug("RefCounts.gc() - counts: ", JSON.stringify(key), count);
@@ -73,7 +75,9 @@ export class RefCounts<T extends {}> {
     }
 
     for (const [key, deathTime] of this.gcMap) {
-      if (DEBUG_REFCOUNTS && deathTime >= now) {
+      if (
+        process.env.NODE_ENV !== "production" && this.debug && deathTime >= now
+      ) {
         // eslint-disable-next-line no-console
         console.debug(
           "RefCounts.gc() - ttl ",
@@ -83,7 +87,7 @@ export class RefCounts<T extends {}> {
       }
 
       if (deathTime < now) {
-        if (DEBUG_REFCOUNTS) {
+        if (process.env.NODE_ENV !== "production" && this.debug) {
           // eslint-disable-next-line no-console
           console.debug(
             "RefCounts.gc() - registering cleaning up",

--- a/packages/client/src/observable/internal/Store.test.ts
+++ b/packages/client/src/observable/internal/Store.test.ts
@@ -46,7 +46,7 @@ import {
 } from "vitest";
 import type { BaseServerObject } from "../../../../faux/build/types/FauxFoundry/BaseServerObject.js";
 import { ActionValidationError } from "../../actions/ActionValidationError.js";
-import { type Client } from "../../Client.js";
+import { additionalContext, type Client } from "../../Client.js";
 import { createClient } from "../../createClient.js";
 import { TestLogger } from "../../logger/TestLogger.js";
 import type { ObjectHolder } from "../../object/convertWireToOsdkObjects/ObjectHolder.js";
@@ -3180,6 +3180,94 @@ describe(Store, () => {
         );
       }
     });
+  });
+});
+
+describe("Store dev-mode logLevel and debug forwarding", () => {
+  it("forwards devMode.logLevel to the root logger", () => {
+    const { client } = createClientMockHelper();
+    const rootLogger = client[additionalContext].logger;
+    invariant(rootLogger);
+    const childSpy = vi.mocked(rootLogger.child);
+    childSpy.mockClear();
+
+    new Store(client, { devMode: { logLevel: "debug" } });
+
+    expect(childSpy).toHaveBeenCalledWith({}, {
+      msgPrefix: "Store",
+      level: "debug",
+    });
+  });
+
+  it("leaves the logger level unset when no logLevel is given", () => {
+    const { client } = createClientMockHelper();
+    const rootLogger = client[additionalContext].logger;
+    invariant(rootLogger);
+    const childSpy = vi.mocked(rootLogger.child);
+    childSpy.mockClear();
+
+    new Store(client);
+
+    expect(childSpy).toHaveBeenCalledWith({}, {
+      msgPrefix: "Store",
+      level: undefined,
+    });
+  });
+
+  it("logs cache-key creation when devMode.debug.refCounts is on", () => {
+    const { client } = createClientMockHelper();
+    const store = new Store(client, {
+      devMode: { debug: { refCounts: true } },
+    });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    store.cacheKeys.get("object", "Employee", 1);
+
+    const onCreateLogs = logSpy.mock.calls.filter(
+      ([first]) =>
+        typeof first === "string" && first.includes("CacheKeys.onCreate"),
+    );
+    expect(onCreateLogs).toHaveLength(1);
+
+    logSpy.mockRestore();
+  });
+
+  it("logs cache-key lookups when devMode.debug.cacheKeys is on", () => {
+    const { client } = createClientMockHelper();
+    const store = new Store(client, {
+      devMode: { debug: { cacheKeys: true } },
+    });
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+
+    store.cacheKeys.get("object", "Employee", 1);
+
+    const getLogs = debugSpy.mock.calls.filter(
+      ([first]) =>
+        typeof first === "string" && first.includes("CacheKeys.get("),
+    );
+    expect(getLogs).toHaveLength(1);
+
+    debugSpy.mockRestore();
+  });
+
+  it("does not log cache internals by default", () => {
+    const { client } = createClientMockHelper();
+    const store = new Store(client);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+
+    store.cacheKeys.get("object", "Employee", 1);
+
+    const cacheLogs = [...logSpy.mock.calls, ...debugSpy.mock.calls].filter(
+      ([first]) =>
+        typeof first === "string"
+        && (first.includes("CacheKeys.onCreate")
+          || first.includes("CacheKeys.get(")),
+    );
+    expect(cacheLogs).toHaveLength(0);
+
+    logSpy.mockRestore();
+    debugSpy.mockRestore();
   });
 });
 

--- a/packages/client/src/observable/internal/Store.ts
+++ b/packages/client/src/observable/internal/Store.ts
@@ -135,6 +135,12 @@ export class Store {
 
   #devModeDelayWarned = false;
 
+  /**
+   * Resolved dev-mode refcount debug flag; only read in dev builds.
+   * @internal
+   */
+  #debugRefCounts: boolean;
+
   readonly cacheKeys: CacheKeys<KnownCacheKey>;
   readonly queries: Queries = new Queries();
 
@@ -171,12 +177,16 @@ export class Store {
   constructor(client: Client, options?: ObservableClientOptions) {
     this.logger = client[additionalContext].logger?.child({}, {
       msgPrefix: "Store",
+      level: options?.devMode?.logLevel,
     });
     this.client = client;
     this.devModeActionDelayMs = options?.devMode?.actionDelayMs ?? 1000;
+    this.#debugRefCounts = options?.devMode?.debug?.refCounts
+      ?? DEBUG_REFCOUNTS;
 
     this.cacheKeys = new CacheKeys<KnownCacheKey>({
       onDestroy: this.#cleanupCacheKey,
+      debug: options?.devMode?.debug,
     });
 
     this.aggregations = new AggregationsHelper(
@@ -245,7 +255,7 @@ export class Store {
   #cleanupCacheKey = (key: KnownCacheKey) => {
     const subject = this.subjects.peek(key);
 
-    if (DEBUG_REFCOUNTS) {
+    if (process.env.NODE_ENV !== "production" && this.#debugRefCounts) {
       // eslint-disable-next-line no-console
       console.log(
         `CacheKey cleaning up (${

--- a/packages/client/src/public/observable.ts
+++ b/packages/client/src/public/observable.ts
@@ -22,6 +22,7 @@ export type {
   CanonicalizedOptions,
   CanonicalizeOptionsInput,
   ObservableClient,
+  ObservableClientLogLevel,
   ObservableClientOptions,
   ObserveAggregationArgs,
   ObserveFunctionCallbackArgs,

--- a/packages/react/src/new/OsdkProvider.tsx
+++ b/packages/react/src/new/OsdkProvider.tsx
@@ -35,7 +35,10 @@ interface OsdkProviderOptions {
   /**
    * Dev-only behaviors of the underlying observable client. Has no effect in
    * production builds. Use `devMode={{ actionDelayMs: 0 }}` to disable the
-   * artificial action delay that makes optimistic updates visible in dev.
+   * artificial action delay that makes optimistic updates visible in dev,
+   * `devMode={{ logLevel: "debug" }}` to surface the observable client's debug
+   * tracing, or `devMode={{ debug: { refCounts: true } }}` to log cache
+   * internals.
    */
   devMode?: ObservableClientOptions["devMode"];
 }
@@ -59,14 +62,23 @@ export function OsdkProvider({
   }, []);
 
   const actionDelayMs = devMode?.actionDelayMs;
+  const logLevel = devMode?.logLevel;
+  const debugRefCounts = devMode?.debug?.refCounts;
+  const debugCacheKeys = devMode?.debug?.cacheKeys;
   const baseObservableClient = useMemo(
     () =>
       createObservableClient(
         client,
         () => [...userAgentsRef.current],
-        { devMode: { actionDelayMs } },
+        {
+          devMode: {
+            actionDelayMs,
+            logLevel,
+            debug: { refCounts: debugRefCounts, cacheKeys: debugCacheKeys },
+          },
+        },
       ),
-    [client, actionDelayMs],
+    [client, actionDelayMs, logLevel, debugRefCounts, debugCacheKeys],
   );
 
   const { client: devToolsClient, wrapChildren } = useDevToolsClient(

--- a/packages/react/src/new/__tests__/OsdkProvider.test.tsx
+++ b/packages/react/src/new/__tests__/OsdkProvider.test.tsx
@@ -33,6 +33,26 @@ vi.mock("@osdk/client/observable", () => ({
 
 const mockClient = {} as unknown as Client;
 
+function expectedOptions(
+  overrides?: {
+    actionDelayMs?: number;
+    logLevel?: string;
+    refCounts?: boolean;
+    cacheKeys?: boolean;
+  },
+) {
+  return {
+    devMode: {
+      actionDelayMs: overrides?.actionDelayMs,
+      logLevel: overrides?.logLevel,
+      debug: {
+        refCounts: overrides?.refCounts,
+        cacheKeys: overrides?.cacheKeys,
+      },
+    },
+  };
+}
+
 describe("OsdkProvider", () => {
   afterEach(() => {
     vi.clearAllMocks();
@@ -49,11 +69,11 @@ describe("OsdkProvider", () => {
     expect(createObservableClientMock).toHaveBeenLastCalledWith(
       mockClient,
       expect.any(Function),
-      { devMode: { actionDelayMs: 0 } },
+      expectedOptions({ actionDelayMs: 0 }),
     );
   });
 
-  it("defaults actionDelayMs to undefined when devMode is omitted", () => {
+  it("defaults the devMode fields to undefined when devMode is omitted", () => {
     render(
       <OsdkProvider client={mockClient}>
         <div />
@@ -63,7 +83,24 @@ describe("OsdkProvider", () => {
     expect(createObservableClientMock).toHaveBeenLastCalledWith(
       mockClient,
       expect.any(Function),
-      { devMode: { actionDelayMs: undefined } },
+      expectedOptions(),
+    );
+  });
+
+  it("passes logLevel and debug flags through to createObservableClient", () => {
+    render(
+      <OsdkProvider
+        client={mockClient}
+        devMode={{ logLevel: "debug", debug: { refCounts: true } }}
+      >
+        <div />
+      </OsdkProvider>,
+    );
+
+    expect(createObservableClientMock).toHaveBeenLastCalledWith(
+      mockClient,
+      expect.any(Function),
+      expectedOptions({ logLevel: "debug", refCounts: true }),
     );
   });
 
@@ -88,6 +125,43 @@ describe("OsdkProvider", () => {
     // Changing the value re-creates the client.
     rerender(
       <OsdkProvider client={mockClient} devMode={{ actionDelayMs: 0 }}>
+        <div />
+      </OsdkProvider>,
+    );
+
+    expect(createObservableClientMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not recreate the observable client when logLevel and debug are unchanged", () => {
+    const { rerender } = render(
+      <OsdkProvider
+        client={mockClient}
+        devMode={{ logLevel: "debug", debug: { refCounts: true } }}
+      >
+        <div />
+      </OsdkProvider>,
+    );
+
+    expect(createObservableClientMock).toHaveBeenCalledTimes(1);
+
+    // New devMode and debug object literals, same values: must not re-create.
+    rerender(
+      <OsdkProvider
+        client={mockClient}
+        devMode={{ logLevel: "debug", debug: { refCounts: true } }}
+      >
+        <div />
+      </OsdkProvider>,
+    );
+
+    expect(createObservableClientMock).toHaveBeenCalledTimes(1);
+
+    // Changing logLevel re-creates the client.
+    rerender(
+      <OsdkProvider
+        client={mockClient}
+        devMode={{ logLevel: "trace", debug: { refCounts: true } }}
+      >
         <div />
       </OsdkProvider>,
     );


### PR DESCRIPTION
adds three dev-only configuration knobs to the observable client for debugging local behavior

• devMode.logLevel raises the client log level (default error) so its debug tracing is visible, cascading to every child logger
• devMode.debug.refCounts and devMode.debug.cacheKeys turn the hardcoded debug-flag module constants into per-client toggles for cache-internals logging
• all stay stripped from production builds and are exposed through createObservableClient and the OsdkProvider devMode prop
