### PR TITLE
add client-wide default dedupe interval and page size config knobs

### DIFF
--- a/.changeset/observable-runtime-defaults.md
+++ b/.changeset/observable-runtime-defaults.md
@@ -3,4 +3,4 @@
 "@osdk/react": minor
 ---
 
-Add client-wide defaults to the observable client: `defaultDedupeInterval` and `defaultPageSize`. Subscriptions that do not set their own `dedupeInterval` or `pageSize` inherit these, so teams don't have to thread the same value through every hook. Exposed through `createObservableClient`'s options and the `OsdkProvider` props.
+Add client-wide defaults to the observable client: `defaultDedupeInterval` and `defaultPageSize`. Subscriptions that do not set their own `dedupeInterval` or `pageSize` inherit these, so teams don't have to thread the same value through every hook. Exposed through `createObservableClient`'s options and the `OsdkProvider` props. A subscription's own option always overrides the default, including an explicit `dedupeInterval: 0` to opt out of a non-zero default.

--- a/.changeset/observable-runtime-defaults.md
+++ b/.changeset/observable-runtime-defaults.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client": minor
+"@osdk/react": minor
+---
+
+Add client-wide defaults to the observable client: `defaultDedupeInterval` and `defaultPageSize`. Subscriptions that do not set their own `dedupeInterval` or `pageSize` inherit these, so teams don't have to thread the same value through every hook. Exposed through `createObservableClient`'s options and the `OsdkProvider` props.

--- a/docs/react/getting-started.md
+++ b/docs/react/getting-started.md
@@ -68,6 +68,18 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
 );
 ```
 
+### Client-Wide Defaults
+
+`OsdkProvider` accepts defaults that apply to every hook, so you don't have to thread the same value through each call:
+
+```tsx
+<OsdkProvider client={client} defaultPageSize={50} defaultDedupeInterval={5000}>
+  <App />
+</OsdkProvider>;
+```
+
+`defaultPageSize` (default 100) sets the list page size for subscriptions that don't pass their own `pageSize`. `defaultDedupeInterval` (default 0) sets how long, in milliseconds, a query skips repeat fetches after one completes when a subscription doesn't pass its own `dedupeInterval`. A hook's own option always overrides the default.
+
 Available exports from `@osdk/react`:
 
 - `OsdkProvider` - Provider, required at the app root

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -704,6 +704,20 @@ export interface ObservableClientOptions {
       cacheKeys?: boolean;
     };
   };
+
+  /**
+   * Default dedupe interval, in milliseconds, applied to subscriptions that do
+   * not specify their own. While a query has fetched within this window, repeat
+   * revalidations are skipped. A subscription's own `dedupeInterval` overrides
+   * it. Defaults to 0 (no deduping).
+   */
+  defaultDedupeInterval?: number;
+
+  /**
+   * Default page size for list subscriptions that do not specify their own
+   * `pageSize`. A subscription's own `pageSize` overrides it. Defaults to 100.
+   */
+  defaultPageSize?: number;
 }
 
 /**

--- a/packages/client/src/observable/internal/AbstractHelper.ts
+++ b/packages/client/src/observable/internal/AbstractHelper.ts
@@ -131,7 +131,7 @@ export abstract class AbstractHelper<
     const sub = useView
       ? new ListQueryView<PAYLOAD & BaseListPayloadShape>(
         query,
-        listOptions.pageSize ?? 100,
+        listOptions.pageSize ?? this.store.defaultPageSize,
         listOptions.autoFetchMore,
       ).subscribe(subFn as Observer<PAYLOAD & BaseListPayloadShape>)
       : query.subscribe(subFn);

--- a/packages/client/src/observable/internal/Query.ts
+++ b/packages/client/src/observable/internal/Query.ts
@@ -120,7 +120,7 @@ export abstract class Query<
     subscriptionId: string,
     dedupeInterval: number | undefined,
   ): void {
-    if (dedupeInterval != null && dedupeInterval > 0) {
+    if (dedupeInterval != null) {
       this.#subscriptionDedupeIntervals.set(subscriptionId, dedupeInterval);
     }
   }

--- a/packages/client/src/observable/internal/Query.ts
+++ b/packages/client/src/observable/internal/Query.ts
@@ -137,7 +137,7 @@ export abstract class Query<
    */
   private getMinimumDedupeInterval(): number {
     if (this.#subscriptionDedupeIntervals.size === 0) {
-      return this.options.dedupeInterval ?? 0;
+      return this.options.dedupeInterval ?? this.store.defaultDedupeInterval;
     }
 
     return Math.min(...this.#subscriptionDedupeIntervals.values());

--- a/packages/client/src/observable/internal/Store.test.ts
+++ b/packages/client/src/observable/internal/Store.test.ts
@@ -3271,6 +3271,27 @@ describe("Store dev-mode logLevel and debug forwarding", () => {
   });
 });
 
+describe("Store runtime defaults", () => {
+  it("defaults defaultDedupeInterval to 0 and defaultPageSize to 100", () => {
+    const { client } = createClientMockHelper();
+    const store = new Store(client);
+
+    expect(store.defaultDedupeInterval).toBe(0);
+    expect(store.defaultPageSize).toBe(100);
+  });
+
+  it("resolves configured defaults from options", () => {
+    const { client } = createClientMockHelper();
+    const store = new Store(client, {
+      defaultDedupeInterval: 2000,
+      defaultPageSize: 25,
+    });
+
+    expect(store.defaultDedupeInterval).toBe(2000);
+    expect(store.defaultPageSize).toBe(25);
+  });
+});
+
 export function asBsoStub(
   x: ObjectHolder<any> | Osdk.Instance<any>,
 ): BaseServerObject {

--- a/packages/client/src/observable/internal/Store.test.ts
+++ b/packages/client/src/observable/internal/Store.test.ts
@@ -82,6 +82,7 @@ import {
   updateList,
   updateObject,
   waitForCall,
+  waitForPayload,
 } from "./testUtils.js";
 import { invalidateList } from "./testUtils/invalidateList.js";
 import { expectStandardObserveLink } from "./testUtils/observeLink/expectStandardObserveLink.js";
@@ -495,6 +496,62 @@ describe(Store, () => {
       expectSingleLinkCallAndClear(linkSubFn, [], {
         status: "loaded",
       });
+    });
+
+    it("subscription dedupeInterval 0 overrides a non-zero defaultDedupeInterval", async () => {
+      const localStore = new Store(client, { defaultDedupeInterval: 60_000 });
+
+      const { payload: emp1Payload } = await expectStandardObserveObject({
+        cache: localStore,
+        type: Employee,
+        primaryKey: 2,
+      });
+      const emp2 = emp1Payload?.object;
+      invariant(emp2);
+
+      const linkSubFn1 = mockLinkSubCallback();
+      const sub1 = localStore.links.observe({
+        linkName: "peeps",
+        srcType: { type: "object", apiName: emp2.$apiName },
+        sourceUnderlyingObjectType: emp2.$objectType,
+        pk: emp2.$primaryKey,
+        dedupeInterval: 0,
+      }, linkSubFn1);
+
+      await waitForCall(linkSubFn1);
+      expectSingleLinkCallAndClear(linkSubFn1, undefined, {
+        status: "loading",
+      });
+
+      await waitForCall(linkSubFn1);
+      expectSingleLinkCallAndClear(linkSubFn1, [], {
+        status: "loaded",
+      });
+
+      sub1.unsubscribe();
+
+      // The store's defaultDedupeInterval is 60s, but the subscription's own
+      // dedupeInterval of 0 opts out, so re-subscribing refetches instead of
+      // serving the deduped value. A deduped re-subscribe would emit a single
+      // "loaded" with no "loading" state.
+      const linkSubFn2 = mockLinkSubCallback();
+      defer(localStore.links.observe({
+        linkName: "peeps",
+        srcType: { type: "object", apiName: emp2.$apiName },
+        sourceUnderlyingObjectType: emp2.$objectType,
+        pk: emp2.$primaryKey,
+        dedupeInterval: 0,
+      }, linkSubFn2));
+
+      await waitForPayload(
+        linkSubFn2,
+        (payload) => payload.status === "loaded",
+      );
+
+      const statuses = linkSubFn2.next.mock.calls.map(([payload]) =>
+        payload.status
+      );
+      expect(statuses).toContain("loading");
     });
 
     describe("multi-object observeLinks", () => {

--- a/packages/client/src/observable/internal/Store.ts
+++ b/packages/client/src/observable/internal/Store.ts
@@ -141,6 +141,18 @@ export class Store {
    */
   #debugRefCounts: boolean;
 
+  /**
+   * Default dedupe interval (ms) for subscriptions that do not set their own.
+   * @internal
+   */
+  readonly defaultDedupeInterval: number;
+
+  /**
+   * Default list page size for subscriptions that do not set their own.
+   * @internal
+   */
+  readonly defaultPageSize: number;
+
   readonly cacheKeys: CacheKeys<KnownCacheKey>;
   readonly queries: Queries = new Queries();
 
@@ -183,6 +195,8 @@ export class Store {
     this.devModeActionDelayMs = options?.devMode?.actionDelayMs ?? 1000;
     this.#debugRefCounts = options?.devMode?.debug?.refCounts
       ?? DEBUG_REFCOUNTS;
+    this.defaultDedupeInterval = options?.defaultDedupeInterval ?? 0;
+    this.defaultPageSize = options?.defaultPageSize ?? 100;
 
     this.cacheKeys = new CacheKeys<KnownCacheKey>({
       onDestroy: this.#cleanupCacheKey,

--- a/packages/client/src/observable/internal/base-list/BaseListQuery.ts
+++ b/packages/client/src/observable/internal/base-list/BaseListQuery.ts
@@ -391,7 +391,8 @@ export abstract class BaseListQuery<
 
   /**
    * Get the effective fetch pageSize (max across all subscribers).
-   * Falls back to options.pageSize or 100 if no subscribers have registered.
+   * Falls back to options.pageSize, then the store's defaultPageSize, if no
+   * subscribers have registered.
    */
   getEffectiveFetchPageSize(): number {
     if (this.#subscriberPageSizes.size > 0) {

--- a/packages/client/src/observable/internal/base-list/BaseListQuery.ts
+++ b/packages/client/src/observable/internal/base-list/BaseListQuery.ts
@@ -397,7 +397,7 @@ export abstract class BaseListQuery<
     if (this.#subscriberPageSizes.size > 0) {
       return Math.max(...this.#subscriberPageSizes.values());
     }
-    return this.options.pageSize ?? 100;
+    return this.options.pageSize ?? this.store.defaultPageSize;
   }
 
   /**

--- a/packages/client/src/observable/internal/list/ListQuery.test.ts
+++ b/packages/client/src/observable/internal/list/ListQuery.test.ts
@@ -235,6 +235,37 @@ describe("ListQuery autoFetchMore tests", () => {
     expectNoMoreCalls(listSub);
   });
 
+  it("uses the client defaultPageSize when no pageSize is provided", async () => {
+    setupTodos(fauxFoundry, 100);
+    const localStore = new Store(client, { defaultPageSize: 5 });
+
+    testStage("Observe a list with no pageSize");
+    const listSub = mockListSubCallback();
+    defer(
+      localStore.lists.observe(
+        {
+          type: Todo,
+          where: {},
+          orderBy: {},
+        },
+        listSub,
+      ),
+    );
+
+    testStage("Initial loading state");
+    await waitForCall(listSub.next, 1);
+    expectSingleListCallAndClear(listSub, undefined, { status: "loading" });
+
+    testStage("First page loads at the default page size");
+    await waitForCall(listSub.next, 1);
+    const payload = expectSingleListCallAndClear(listSub, expect.anything(), {
+      status: "loaded",
+    });
+
+    expect(payload?.resolvedList?.length).toBe(5);
+    expect(payload?.hasMore).toBe(true);
+  });
+
   it("autoFetchMore stops at last page when fewer items than threshold", async () => {
     setupTodos(fauxFoundry, 100);
 

--- a/packages/react/src/new/OsdkProvider.tsx
+++ b/packages/react/src/new/OsdkProvider.tsx
@@ -41,6 +41,16 @@ interface OsdkProviderOptions {
    * internals.
    */
   devMode?: ObservableClientOptions["devMode"];
+  /**
+   * Default dedupe interval, in milliseconds, for subscriptions that do not set
+   * their own. Defaults to 0 (no deduping).
+   */
+  defaultDedupeInterval?: ObservableClientOptions["defaultDedupeInterval"];
+  /**
+   * Default page size for list subscriptions that do not set their own.
+   * Defaults to 100.
+   */
+  defaultPageSize?: ObservableClientOptions["defaultPageSize"];
 }
 
 export function OsdkProvider({
@@ -48,6 +58,8 @@ export function OsdkProvider({
   client,
   enableDevTools,
   devMode,
+  defaultDedupeInterval,
+  defaultPageSize,
 }: OsdkProviderOptions): React.JSX.Element {
   const devtoolsEnabled = __DEV__
     && (enableDevTools ?? getRegisteredDevTools() != null);
@@ -76,9 +88,19 @@ export function OsdkProvider({
             logLevel,
             debug: { refCounts: debugRefCounts, cacheKeys: debugCacheKeys },
           },
+          defaultDedupeInterval,
+          defaultPageSize,
         },
       ),
-    [client, actionDelayMs, logLevel, debugRefCounts, debugCacheKeys],
+    [
+      client,
+      actionDelayMs,
+      logLevel,
+      debugRefCounts,
+      debugCacheKeys,
+      defaultDedupeInterval,
+      defaultPageSize,
+    ],
   );
 
   const { client: devToolsClient, wrapChildren } = useDevToolsClient(

--- a/packages/react/src/new/__tests__/OsdkProvider.test.tsx
+++ b/packages/react/src/new/__tests__/OsdkProvider.test.tsx
@@ -39,6 +39,8 @@ function expectedOptions(
     logLevel?: string;
     refCounts?: boolean;
     cacheKeys?: boolean;
+    defaultDedupeInterval?: number;
+    defaultPageSize?: number;
   },
 ) {
   return {
@@ -50,6 +52,8 @@ function expectedOptions(
         cacheKeys: overrides?.cacheKeys,
       },
     },
+    defaultDedupeInterval: overrides?.defaultDedupeInterval,
+    defaultPageSize: overrides?.defaultPageSize,
   };
 }
 
@@ -102,6 +106,51 @@ describe("OsdkProvider", () => {
       expect.any(Function),
       expectedOptions({ logLevel: "debug", refCounts: true }),
     );
+  });
+
+  it("passes defaultDedupeInterval and defaultPageSize through to createObservableClient", () => {
+    render(
+      <OsdkProvider
+        client={mockClient}
+        defaultDedupeInterval={2000}
+        defaultPageSize={50}
+      >
+        <div />
+      </OsdkProvider>,
+    );
+
+    expect(createObservableClientMock).toHaveBeenLastCalledWith(
+      mockClient,
+      expect.any(Function),
+      expectedOptions({ defaultDedupeInterval: 2000, defaultPageSize: 50 }),
+    );
+  });
+
+  it("does not recreate the observable client when defaults are unchanged", () => {
+    const { rerender } = render(
+      <OsdkProvider client={mockClient} defaultPageSize={50}>
+        <div />
+      </OsdkProvider>,
+    );
+
+    expect(createObservableClientMock).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <OsdkProvider client={mockClient} defaultPageSize={50}>
+        <div />
+      </OsdkProvider>,
+    );
+
+    expect(createObservableClientMock).toHaveBeenCalledTimes(1);
+
+    // Changing the default re-creates the client.
+    rerender(
+      <OsdkProvider client={mockClient} defaultPageSize={25}>
+        <div />
+      </OsdkProvider>,
+    );
+
+    expect(createObservableClientMock).toHaveBeenCalledTimes(2);
   });
 
   it("does not recreate the observable client when actionDelayMs is unchanged", () => {


### PR DESCRIPTION
adds client-wide default options so teams don't have to thread the same value through every hook

• defaultDedupeInterval sets the revalidation dedupe window for subscriptions that don't specify their own
• defaultPageSize sets the list page size for subscriptions that don't specify their own
• exposed through createObservableClient options and OsdkProvider props, with per-call options still taking precedence
