### PR TITLE
Scenario clients ignore an active transaction instead of throwing

### DIFF
--- a/.changeset/scenario-ignore-transaction.md
+++ b/.changeset/scenario-ignore-transaction.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+withScenario / createScenario now ignore an active transaction on the supplied client (logging a console.warn and scoping to the scenario) instead of throwing.

--- a/packages/client/src/scenarios/ScenarioClient.ts
+++ b/packages/client/src/scenarios/ScenarioClient.ts
@@ -184,8 +184,9 @@ export function isScenarioClient(
 }
 
 /**
- * Shared internal builder used by both {@link withScenario} and {@link createScenario}. Validates the parent client
- * is not already inside a scenario or transaction, then constructs a fresh {@link Client} via
+ * Shared internal builder used by both {@link withScenario} and {@link createScenario}. Throws if the parent client
+ * is already inside a scenario. If the parent client has an active transaction, the transaction is ignored (a warning
+ * is logged) and the client is scoped to the scenario instead. Constructs a fresh {@link Client} via
  * `createClientWithScenario` and decorates it with {@link EXPERIMENTAL_ScenarioClient}-only methods.
  *
  * @internal
@@ -197,8 +198,9 @@ export function buildScenarioClient(
   const ctx: MinimalClient = parent[additionalContext];
 
   if (ctx.transactionId != null) {
-    throw new Error(
-      "withScenario / createScenario: the supplied client already has an active transaction. Scenarios cannot be nested on transactions.",
+    // eslint-disable-next-line no-console
+    console.warn(
+      "withScenario / createScenario: the supplied client has an active transaction. Ignoring the transaction and scoping to the scenario instead.",
     );
   }
   if (ctx.scenarioRid != null) {

--- a/packages/client/src/scenarios/createScenario.test.ts
+++ b/packages/client/src/scenarios/createScenario.test.ts
@@ -74,7 +74,8 @@ describe("createScenario", () => {
     expect(url.searchParams.get("scenarioRid")).toBe(newScenarioRid);
   });
 
-  it("rejects a client with an active transaction at runtime", async () => {
+  it("warns and ignores an active transaction, scoping to the new scenario", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const txClient = createClientWithTransaction(
       "ri.transactions..transaction.xyz",
       async () => {},
@@ -84,7 +85,19 @@ describe("createScenario", () => {
       {},
       fetchFunction,
     );
-    await expect(createScenario(txClient)).rejects.toThrow(/transaction/);
+    const newScenarioRid = "ri.actions..scenario.new";
+    const createResponse: CreateOntologyScenarioResponse = {
+      scenarioRid: newScenarioRid,
+    };
+    mockFetchResponse(fetchFunction, createResponse);
+
+    const scenario = await createScenario(txClient);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/transaction/),
+    );
+    expect(scenario.getScenarioReference()).toBe(newScenarioRid);
+    warnSpy.mockRestore();
   });
 
   it("rejects a client already scoped to a scenario at runtime", async () => {

--- a/packages/client/src/scenarios/createScenario.ts
+++ b/packages/client/src/scenarios/createScenario.ts
@@ -26,8 +26,9 @@ import {
  * Mint a fresh ontology scenario and return a client scoped to it.
  *
  * @param client - The base {@link Client} to derive context (`baseUrl`, `ontologyRid`, `tokenProvider`, `branch`, …)
- *   from. Throws at runtime if the client is already scoped to a scenario or transaction. When the base client has a
- *   branch set, the newly minted scenario uses that branch as its base.
+ *   from. Throws at runtime if the client is already scoped to a scenario. If the client has an active transaction,
+ *   the transaction is ignored (a warning is logged) and the client is scoped to the new scenario. When the base
+ *   client has a branch set, the newly minted scenario uses that branch as its base.
  * @returns a {@link EXPERIMENTAL_ScenarioClient} bound to the freshly minted scenario RID.
  *
  * @beta This is an experimental, unstable feature subject to change.
@@ -45,11 +46,6 @@ export async function createScenario(
 ): Promise<EXPERIMENTAL_ScenarioClient> {
   const ctx: MinimalClient = client[additionalContext];
 
-  if (ctx.transactionId != null) {
-    throw new Error(
-      "createScenario: the supplied client already has an active transaction. Scenarios cannot be nested on transactions.",
-    );
-  }
   if (ctx.scenarioRid != null) {
     throw new Error(
       "createScenario: the supplied client already has an active scenario. Scenarios cannot be nested.",

--- a/packages/client/src/scenarios/withScenario.test.ts
+++ b/packages/client/src/scenarios/withScenario.test.ts
@@ -67,7 +67,8 @@ describe("withScenario", () => {
     );
   });
 
-  it("rejects a client with an active transaction at runtime", () => {
+  it("warns and ignores an active transaction, scoping to the scenario", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const txClient = createClientWithTransaction(
       "ri.transactions..transaction.xyz",
       async () => {},
@@ -77,9 +78,12 @@ describe("withScenario", () => {
       {},
       fetchFunction,
     );
-    expect(() => withScenario(txClient, "ri.actions..scenario.abc")).toThrow(
-      /transaction/,
+    const scenario = withScenario(txClient, "ri.actions..scenario.abc");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/transaction/),
     );
+    expect(scenario.getScenarioReference()).toBe("ri.actions..scenario.abc");
+    warnSpy.mockRestore();
   });
 
   it("rejects a client already scoped to a scenario at runtime", () => {

--- a/packages/client/src/scenarios/withScenario.ts
+++ b/packages/client/src/scenarios/withScenario.ts
@@ -25,7 +25,8 @@ import {
  * subsequent operations (`fetchPage`, `applyAction`, `executeFunction`, etc.) to the given `scenarioRid`.
  *
  * @param client - The base {@link Client} to derive context (`baseUrl`, `ontologyRid`, `tokenProvider`, `branch`, …)
- *   from. Throws at runtime if the client is already scoped to a scenario or transaction.
+ *   from. Throws at runtime if the client is already scoped to a scenario. If the client has an active transaction,
+ *   the transaction is ignored (a warning is logged) and the client is scoped to the scenario.
  * @param scenarioRid - The RID of the scenario to attach to.
  * @returns a {@link EXPERIMENTAL_ScenarioClient} bound to `scenarioRid`.
  *


### PR DESCRIPTION
## Summary

`withScenario` and `createScenario` previously threw when the supplied client already had an active transaction (_"Scenarios cannot be nested on transactions."_). They now:

- log a `console.warn`,
- ignore the transaction id, and
- scope the returned client to the scenario instead.

Nesting a scenario inside another scenario is unchanged and still throws.

## Changes

- `ScenarioClient.ts` (`buildScenarioClient`): replace the transaction `throw` with a `console.warn`; the fresh client minted by `createClientWithScenario` already carries only the scenario id, so the transaction is dropped.
- `createScenario.ts`: drop the early transaction `throw` so the warning is emitted exactly once by the shared builder; the network call still proceeds.
- Updated JSDoc on `withScenario` / `createScenario` / `buildScenarioClient`.
- Updated tests in `withScenario.test.ts` and `createScenario.test.ts` to assert the warning + scenario scoping instead of a throw.
- Added a changeset.

## Test plan

- `pnpm exec vitest run src/scenarios/` in `packages/client` — 27 passing
- `pnpm turbo typecheck --filter=@osdk/client` — passes
- `pnpm turbo check-api --filter=@osdk/client` — completes successfully (no report change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)