### PR TITLE
Make empty $and/$or/$not operands a compile-time error

### DIFF
--- a/.changeset/spicy-rivers-cheer.md
+++ b/.changeset/spicy-rivers-cheer.md
@@ -1,0 +1,6 @@
+---
+"@osdk/api": minor
+"@osdk/client": minor
+---
+
+An empty `{}` operand of `$and`/`$or`/`$not` in a where clause is now a compile-time error instead of failing at runtime. Such an operand lowers to an empty AND on the wire, which some object-storage backends reject (`Core:InvalidAndFilter`), and is almost always a bug (e.g. a `cond ? {...} : {}` that fell through). Top-level `.where({})` remains a legal no-op. Adds and exports `NonEmptyWhereClause` for typing dynamically-built `$and`/`$or` arrays. Note: this tightens types, so code that previously compiled with an empty operand will now need to prune it (e.g. `.filter(v => Object.keys(v).length > 0)`).

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -268,7 +268,7 @@ export type AndWhereClause<
 	T extends ObjectOrInterfaceDefinition,
 	RDPs extends Record<string, SimplePropertyDef> = {}
 > = {
-    	$and: WhereClause<T, RDPs>[]
+    	$and: NonEmptyWhereClause<T, RDPs>[]
 };
 
 // @public (undocumented)
@@ -1335,12 +1335,21 @@ export interface Model3dMediaItemMetadata {
 // @public (undocumented)
 export type Model3dType = "POINT_CLOUD" | "MESH";
 
+// Warning: (ae-forgotten-export) The symbol "IsNever" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "NonEmptyPropertyWhereClause" needs to be exported by the entry point index.d.ts
+//
+// @public
+export type NonEmptyWhereClause<
+	T extends ObjectOrInterfaceDefinition,
+	RDPs extends Record<string, SimplePropertyDef> = {}
+> = OrWhereClause<T, RDPs> | AndWhereClause<T, RDPs> | NotWhereClause<T, RDPs> | (IsNever<keyof CompileTimeMetadata<T>["properties"]> extends true ? never : NonEmptyPropertyWhereClause<T, RDPs>);
+
 // @public (undocumented)
 export type NotWhereClause<
 	T extends ObjectOrInterfaceDefinition,
 	RDPs extends Record<string, SimplePropertyDef> = {}
 > = {
-    	$not: WhereClause<T, RDPs>
+    	$not: NonEmptyWhereClause<T, RDPs>
 };
 
 // @public (undocumented)
@@ -1715,10 +1724,9 @@ export type OrWhereClause<
 	T extends ObjectOrInterfaceDefinition,
 	RDPs extends Record<string, SimplePropertyDef> = {}
 > = {
-    	$or: WhereClause<T, RDPs>[]
+    	$or: NonEmptyWhereClause<T, RDPs>[]
 };
 
-// Warning: (ae-forgotten-export) The symbol "IsNever" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "IsAny" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "ExtractPropsKeysFromOldPropsStyle" needs to be exported by the entry point index.d.ts
 //

--- a/etc/client.report.api.md
+++ b/etc/client.report.api.md
@@ -32,6 +32,7 @@ import { MediaMetadata as MediaMetadata_2 } from '@osdk/api';
 import { MediaReference } from '@osdk/api';
 import { MediaUpload } from '@osdk/api';
 import type { MinimalObjectSet } from '@osdk/api/unstable';
+import { NonEmptyWhereClause } from '@osdk/api';
 import { ObjectMetadata } from '@osdk/api';
 import type { ObjectOrInterfaceDefinition } from '@osdk/api';
 import type { ObjectQueryDataType } from '@osdk/api';
@@ -170,6 +171,8 @@ export { MediaMetadata_2 as MediaMetadata }
 export { MediaReference }
 
 export { MediaUpload }
+
+export { NonEmptyWhereClause }
 
 export { ObjectMetadata }
 

--- a/packages/api/src/aggregate/WhereClause.ts
+++ b/packages/api/src/aggregate/WhereClause.ts
@@ -198,21 +198,21 @@ export type AndWhereClause<
   T extends ObjectOrInterfaceDefinition,
   RDPs extends Record<string, SimplePropertyDef> = {},
 > = {
-  $and: WhereClause<T, RDPs>[];
+  $and: NonEmptyWhereClause<T, RDPs>[];
 };
 
 export type OrWhereClause<
   T extends ObjectOrInterfaceDefinition,
   RDPs extends Record<string, SimplePropertyDef> = {},
 > = {
-  $or: WhereClause<T, RDPs>[];
+  $or: NonEmptyWhereClause<T, RDPs>[];
 };
 
 export type NotWhereClause<
   T extends ObjectOrInterfaceDefinition,
   RDPs extends Record<string, SimplePropertyDef> = {},
 > = {
-  $not: WhereClause<T, RDPs>;
+  $not: NonEmptyWhereClause<T, RDPs>;
 };
 
 export type PropertyWhereClause<T extends ObjectOrInterfaceDefinition> = {
@@ -229,6 +229,48 @@ type MergedPropertyWhereClause<
     DerivedObjectOrInterfaceDefinition.WithDerivedProperties<T, RDPs>
   >
   | SpecialPropertyWhereClause<T>;
+
+/**
+ * Given an object type with all-optional keys, produce the union of variants that
+ * each require at least one key to be present. Used to forbid an empty `{}` operand:
+ * because `{}` is structurally assignable to an all-optional object, the only way to
+ * reject it is to require a key.
+ */
+type RequireAtLeastOne<T> = {
+  [K in keyof T]-?:
+    & Required<Pick<T, K>>
+    & Partial<Pick<T, Exclude<keyof T, K>>>;
+}[keyof T];
+
+/**
+ * The non-empty form of {@link MergedPropertyWhereClause}. `RequireAtLeastOne` must be
+ * distributed across each member of the union: `keyof (A | B)` is `keyof A & keyof B`,
+ * which would collapse to `never` for the property/special-property union and reject
+ * every clause.
+ */
+type NonEmptyPropertyWhereClause<
+  T extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef> = {},
+> = MergedPropertyWhereClause<T, RDPs> extends infer M
+  ? (M extends unknown ? RequireAtLeastOne<M> : never)
+  : never;
+
+/**
+ * A {@link WhereClause} that may not be the empty object `{}`. This is the operand type
+ * for the `$and`/`$or`/`$not` boolean operators: an empty operand is meaningless (it lowers to
+ * an empty AND on the wire, which some object-storage backends reject) and is almost
+ * always a bug, so it is rejected at compile time. Top-level `.where({})` remains a legal
+ * no-op because the `where` argument is typed as {@link WhereClause}, not this type.
+ */
+export type NonEmptyWhereClause<
+  T extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, SimplePropertyDef> = {},
+> =
+  | OrWhereClause<T, RDPs>
+  | AndWhereClause<T, RDPs>
+  | NotWhereClause<T, RDPs>
+  | (IsNever<keyof CompileTimeMetadata<T>["properties"]> extends true ? never
+    : NonEmptyPropertyWhereClause<T, RDPs>);
 
 export type WhereClause<
   T extends ObjectOrInterfaceDefinition,

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -36,6 +36,7 @@ export type {
   AndWhereClause,
   GeoFilter_Intersects,
   GeoFilter_Within,
+  NonEmptyWhereClause,
   NotWhereClause,
   OrWhereClause,
   PossibleWhereClauseFilters,

--- a/packages/api/src/objectSet/ObjectSet.test.ts
+++ b/packages/api/src/objectSet/ObjectSet.test.ts
@@ -1454,6 +1454,70 @@ describe("ObjectSet", () => {
     });
   });
 
+  describe("where clause empty operands", () => {
+    it("allows a top-level empty clause as a no-op", () => {
+      fauxObjectSet.where({});
+    });
+
+    it("allows non-empty operands of $and/$or/$not", () => {
+      fauxObjectSet.where({
+        $and: [{ employeeId: { $eq: 1 } }, { class: "x" }],
+      });
+      fauxObjectSet.where({ $or: [{ employeeId: { $eq: 1 } }] });
+      fauxObjectSet.where({ $not: { class: "x" } });
+      // multi-key, struct, array, and special-property operands
+      fauxObjectSet.where({ $and: [{ class: "x", fullName: "y" }] });
+      fauxObjectSet.where({
+        $and: [{ addressStruct: { city: { $eq: "x" } } }],
+      });
+      fauxObjectSet.where({ $and: [{ salaryHistory: { $contains: 5 } }] });
+      fauxObjectSet.where({
+        $and: [{ $title: { $eq: "x" } }, { $primaryKey: { $eq: 1 } }],
+      });
+      // nested boolean operators
+      fauxObjectSet.where({ $or: [{ $and: [{ class: "x" }] }] });
+    });
+
+    it("allows empty $and/$or arrays at the type level (runtime no-op/guard)", () => {
+      fauxObjectSet.where({ $and: [] });
+      fauxObjectSet.where({ $or: [] });
+    });
+
+    it("rejects an empty {} operand of $and", () => {
+      fauxObjectSet.where({
+        $and: [
+          { employeeId: { $eq: 1 } },
+          // @ts-expect-error an empty {} operand is meaningless and not allowed
+          {},
+        ],
+      });
+    });
+
+    it("rejects an empty {} operand of $or", () => {
+      fauxObjectSet.where({
+        // @ts-expect-error an empty {} operand is meaningless and not allowed
+        $or: [{}],
+      });
+    });
+
+    it("rejects an empty {} operand of $not", () => {
+      fauxObjectSet.where({
+        // @ts-expect-error an empty {} operand is meaningless and not allowed
+        $not: {},
+      });
+    });
+
+    it("rejects a conditional that can fall through to {}", () => {
+      const cond = true as boolean;
+      fauxObjectSet.where({
+        $and: [
+          // @ts-expect-error the {} branch of the ternary is not a valid operand
+          cond ? { class: "x" } : {},
+        ],
+      });
+    });
+  });
+
   describe("asyncIterLinks", async () => {
     it("typechecks self-referential one link", async () => {
       for await (

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -38,6 +38,7 @@ export type {
   MediaMetadata,
   MediaReference,
   MediaUpload,
+  NonEmptyWhereClause,
   ObjectMetadata,
   ObjectSet,
   ObjectSpecifier,

--- a/packages/client/src/internal/conversions/modernToLegacyWhereClause.test.ts
+++ b/packages/client/src/internal/conversions/modernToLegacyWhereClause.test.ts
@@ -1666,4 +1666,52 @@ describe(modernToLegacyWhereClause, () => {
       `);
     });
   });
+
+  describe("empty clauses", () => {
+    // These shapes are now compile-time errors (see the ObjectSet type tests); the casts
+    // exercise the runtime backstop that protects JS / `as any` callers from shipping an
+    // empty AND, which some object-storage backends reject (Core:InvalidAndFilter).
+    it("throws on an empty `{}` operand nested in a non-empty $and", () => {
+      expect(() =>
+        modernToLegacyWhereClause<ObjAllProps>(
+          { $and: [{ string: { $eq: "a" } }, {} as any] },
+          objectTypeWithAllPropertyTypes,
+        )
+      ).toThrowError(/empty where clause/);
+    });
+
+    it("throws on an empty $and array instead of emitting an empty AND", () => {
+      expect(() =>
+        modernToLegacyWhereClause<ObjAllProps>(
+          { $and: [] } as any,
+          objectTypeWithAllPropertyTypes,
+        )
+      ).toThrowError(/empty combinator/);
+    });
+
+    it("throws on an empty $or array", () => {
+      expect(() =>
+        modernToLegacyWhereClause<ObjAllProps>(
+          { $or: [] } as any,
+          objectTypeWithAllPropertyTypes,
+        )
+      ).toThrowError(/empty combinator/);
+    });
+
+    it("throws on the bug-report shape rather than silently emitting an empty AND", () => {
+      // Models `where({ $and: [a, b, cond ? c : {}] })` when the ternary falls to `{}`.
+      expect(() =>
+        modernToLegacyWhereClause<ObjAllProps>(
+          {
+            $and: [
+              { string: { $eq: "a" } },
+              { integer: { $eq: 1 } },
+              {} as any,
+            ],
+          },
+          objectTypeWithAllPropertyTypes,
+        )
+      ).toThrowError(/empty where clause/);
+    });
+  });
 });

--- a/packages/client/src/internal/conversions/modernToLegacyWhereClause.ts
+++ b/packages/client/src/internal/conversions/modernToLegacyWhereClause.ts
@@ -78,8 +78,10 @@ export function modernToLegacyWhereClause<
   })) as WhereClause<T, RDPs>[];
   invariant(
     parts.length > 0,
-    "Cannot convert an empty where clause to a filter. "
-      + "Skip the .where() call entirely when no conditions are provided.",
+    "Cannot convert an empty where clause `{}` to a filter. "
+      + "If this came from an `$and`/`$or` operand, remove the empty `{}` element "
+      + "(this is now a compile-time error). For a top-level no-op, omit the .where() "
+      + "call entirely when no conditions are provided.",
   );
   if (parts.length === 1) {
     return modernToLegacyWhereClauseInner(
@@ -110,17 +112,31 @@ export function modernToLegacyWhereClauseInner<
   invariant(parts.length === 1, "Invalid where clause provided.");
 
   if (isAndClause(whereClause)) {
+    const operands = whereClause.$and as WhereClause<T, RDPs>[];
+    invariant(
+      operands.length > 0,
+      "Cannot convert an empty `$and` array to a filter. An empty combinator has no "
+        + "meaning and is rejected by some object-storage backends; remove it or prune "
+        + "empty arrays from dynamic builders before querying.",
+    );
     return {
       type: "and",
-      value: (whereClause.$and as WhereClause<T, RDPs>[]).map(
+      value: operands.map(
         (clause) =>
           modernToLegacyWhereClause(clause, objectOrInterface, rdpNames),
       ),
     };
   } else if (isOrClause(whereClause)) {
+    const operands = whereClause.$or as WhereClause<T, RDPs>[];
+    invariant(
+      operands.length > 0,
+      "Cannot convert an empty `$or` array to a filter. An empty combinator has no "
+        + "meaning and is rejected by some object-storage backends; remove it or prune "
+        + "empty arrays from dynamic builders before querying.",
+    );
     return {
       type: "or",
-      value: (whereClause.$or as WhereClause<T, RDPs>[]).map(
+      value: operands.map(
         (clause) =>
           modernToLegacyWhereClause(clause, objectOrInterface, rdpNames),
       ),

--- a/packages/e2e.sandbox.officeassignment/src/constants/baseFilter.ts
+++ b/packages/e2e.sandbox.officeassignment/src/constants/baseFilter.ts
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-import type { WhereClause } from "@osdk/api";
+import type { NonEmptyWhereClause } from "@osdk/api";
 import type { Assignment } from "../generatedNoCheck2/index.js";
 
 /**
  * The app only ever looks at active, permanent assignments. Both tabs scope their object sets to
- * this base filter before any user filtering is applied.
+ * this base filter before any user filtering is applied. Typed as {@link NonEmptyWhereClause} so it
+ * can be used directly as an `$and` operand.
  */
-export const ASSIGNMENT_BASE_WHERE: WhereClause<Assignment> = {
+export const ASSIGNMENT_BASE_WHERE: NonEmptyWhereClause<Assignment> = {
   assignmentType: { $eq: "Permanent" },
   assignmentStatus: { $eq: "Active" },
 };

--- a/packages/e2e.sandbox.officeassignment/src/utils/combineWhere.ts
+++ b/packages/e2e.sandbox.officeassignment/src/utils/combineWhere.ts
@@ -14,16 +14,21 @@
  * limitations under the License.
  */
 
-import type { ObjectTypeDefinition, WhereClause } from "@osdk/api";
+import type {
+  NonEmptyWhereClause,
+  ObjectTypeDefinition,
+  WhereClause,
+} from "@osdk/api";
 
 /**
  * True when the clause is present and has at least one condition. The OSDK rejects an empty
  * `.where({})`, and components such as FilterList emit `{}` when no filter is active, so callers
- * use this to coerce empty clauses to `undefined`.
+ * use this to coerce empty clauses to `undefined`. Narrows to {@link NonEmptyWhereClause} so the
+ * result can be used as a `$and`/`$or` operand.
  */
 export function isNonEmptyWhere<Q extends ObjectTypeDefinition>(
   clause: WhereClause<Q> | undefined,
-): clause is WhereClause<Q> {
+): clause is NonEmptyWhereClause<Q> {
   return clause != null && Object.keys(clause).length > 0;
 }
 
@@ -34,7 +39,9 @@ export function isNonEmptyWhere<Q extends ObjectTypeDefinition>(
 export function combineWhere<Q extends ObjectTypeDefinition>(
   clauses: Array<WhereClause<Q> | undefined>,
 ): WhereClause<Q> | undefined {
-  const nonEmpty: Array<WhereClause<Q>> = clauses.filter(isNonEmptyWhere);
+  const nonEmpty: Array<NonEmptyWhereClause<Q>> = clauses.filter(
+    isNonEmptyWhere,
+  );
   if (nonEmpty.length === 0) {
     return undefined;
   }

--- a/packages/e2e.sandbox.officeassignment/src/utils/statusFilter.ts
+++ b/packages/e2e.sandbox.officeassignment/src/utils/statusFilter.ts
@@ -16,6 +16,7 @@
 
 import type {
   DerivedProperty,
+  NonEmptyWhereClause,
   SimplePropertyDef,
   WhereClause,
 } from "@osdk/api";
@@ -41,6 +42,14 @@ export type StatusRdpWhereClause = WhereClause<
   Assignment,
   Record<string, SimplePropertyDef>
 >;
+/**
+ * The non-empty form of {@link StatusRdpWhereClause}, used for the elements of `$and`/`$or`
+ * arrays we build dynamically (an empty `{}` operand is a compile-time error).
+ */
+export type NonEmptyStatusRdpWhereClause = NonEmptyWhereClause<
+  Assignment,
+  Record<string, SimplePropertyDef>
+>;
 
 /**
  * The derived properties plus the where clause that, together, select the assignments whose latest
@@ -49,7 +58,7 @@ export type StatusRdpWhereClause = WhereClause<
  */
 export interface LatestStatusQuery {
   readonly withProperties: StatusRdpCreators;
-  readonly where: StatusRdpWhereClause;
+  readonly where: NonEmptyStatusRdpWhereClause;
 }
 
 // Deterministic, collision-free suffix per (type, value): same selections always produce the same
@@ -124,7 +133,7 @@ function buildCountOfTypeRdp(
 function latestValueCondition(
   targetMaxKey: string,
   diffKey: string,
-): StatusRdpWhereClause {
+): NonEmptyStatusRdpWhereClause {
   return {
     $or: [
       { [diffKey]: { $gte: 0 } },
@@ -168,11 +177,11 @@ export function buildLatestStatusQuery(
   }
 
   let withProperties: StatusRdpCreators = {};
-  const perTypeConditions: StatusRdpWhereClause[] = [];
+  const perTypeConditions: NonEmptyStatusRdpWhereClause[] = [];
 
   for (const [type, values] of byType) {
     const noRecordValue = getNoRecordValue(type);
-    const withinTypeConditions: StatusRdpWhereClause[] = [];
+    const withinTypeConditions: NonEmptyStatusRdpWhereClause[] = [];
 
     for (const value of values) {
       const uid = uidFor(type, value);
@@ -197,7 +206,7 @@ export function buildLatestStatusQuery(
     );
   }
 
-  let where: StatusRdpWhereClause;
+  let where: NonEmptyStatusRdpWhereClause;
   if (perTypeConditions.length === 1) {
     where = perTypeConditions[0];
   } else if (composeAcrossTypes === "$and") {


### PR DESCRIPTION
https://github.com/palantir/osdk-ts/pull/3348 added a runtime check that throws on an empty `.where({})` but it caught more than intended: an empty `{}` tucked inside an `$and`/`$or`/`$not` array (think `cond ? {...} : {}`) now blows up at runtime, even though it compiled fine and used to work. Turns out an empty operand lowers to an empty AND on the wire, which some storage backends reject outright, so it was never really valid anyway, just silently tolerated on some paths.

This change makes that a compile-time error instead. Empty operands of `$and`/`$or`/`$not` are now rejected by the type system (via a new `NonEmptyWhereClause`), so the bug shows up while you're writing it rather than a surprise at runtime. Top-level `.where({})` still works as a no-op, and the runtime check stays as a backstop with a clearer message for JS callers.