### PR TITLE
fix rdp derived field clearing in the observable cache merge

### DIFF
--- a/.changeset/rdp-derived-clear.md
+++ b/.changeset/rdp-derived-clear.md
@@ -2,4 +2,4 @@
 "@osdk/client": patch
 ---
 
-Fix runtime-derived-property (RDP) cache merges dropping or stale-serving derived values. Derived fields are now resolved by the query's rdp set rather than by object-schema membership or wire presence, so: a derived value that becomes null clears instead of retaining the stale cached value; a derived field shared by two queries with overlapping rdp sets is no longer dropped when one propagates to the other; and a query using both `$select` and a derived property keeps the derived field on a partial write.
+Fix runtime-derived-property (RDP) cache merges dropping or stale-serving derived values. A write now declares the derived fields it actually computed, so: a derived value that becomes null clears instead of retaining the stale cached value; a derived field shared by two queries with overlapping rdp sets is no longer dropped when one propagates to the other; a query using both `$select` and a derived property keeps the derived field on a partial write; and a subscription update, which carries base props only, preserves the cached derived values instead of clearing them on every tick.

--- a/.changeset/rdp-derived-clear.md
+++ b/.changeset/rdp-derived-clear.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Fix runtime-derived-property (RDP) cache merges dropping or stale-serving derived values. Derived fields are now resolved by the query's rdp set rather than by object-schema membership or wire presence, so: a derived value that becomes null clears instead of retaining the stale cached value; a derived field shared by two queries with overlapping rdp sets is no longer dropped when one propagates to the other; and a query using both `$select` and a derived property keeps the derived field on a partial write.

--- a/packages/client/src/observable/internal/base-list/BaseListQuery.ts
+++ b/packages/client/src/observable/internal/base-list/BaseListQuery.ts
@@ -38,6 +38,7 @@ import type { SortingStrategy } from "../sorting/SortingStrategy.js";
 import { NoOpSortingStrategy } from "../sorting/SortingStrategy.js";
 import type { SubjectPayload } from "../SubjectPayload.js";
 import type { ObjectUpdate } from "../types/ObjectUpdate.js";
+import { EMPTY_RDP_SET } from "../utils/rdpFieldOperations.js";
 import type {
   CollectionConnectableParams,
   CollectionStorageData,
@@ -772,12 +773,14 @@ export abstract class BaseListQuery<
 
     if (state === "ADDED_OR_UPDATED") {
       this.store.batch({}, (batch) => {
+        // the stream carries base props only and computes no derived fields.
         this.store.objects.storeOsdkInstances(
           [object as Osdk.Instance<ObjectTypeDefinition>],
           batch,
           this.rdpConfig, // Safe - null for queries without RDPs
           undefined,
           this.includeAllBaseObjectProperties,
+          EMPTY_RDP_SET,
         );
       });
     } else if (state === "REMOVED") {

--- a/packages/client/src/observable/internal/list/ListQuery.ts
+++ b/packages/client/src/observable/internal/list/ListQuery.ts
@@ -55,6 +55,7 @@ import type { SimpleWhereClause } from "../SimpleWhereClause.js";
 import { OrderBySortingStrategy } from "../sorting/SortingStrategy.js";
 import type { Store } from "../Store.js";
 import type { SubjectPayload } from "../SubjectPayload.js";
+import { EMPTY_RDP_SET } from "../utils/rdpFieldOperations.js";
 import {
   INCLUDE_ALL_BASE_PROPERTIES_IDX,
   INTERSECT_IDX,
@@ -603,12 +604,14 @@ export abstract class ListQuery extends BaseListQuery<
           : objOrIface) as unknown as ObjectHolder;
 
       this.store.batch({}, (batch) => {
+        // the stream carries base props only and computes no derived fields.
         this.store.objects.storeOsdkInstances(
           [object as Osdk.Instance<any>],
           batch,
           this.rdpConfig,
           undefined,
           this.includeAllBaseObjectProperties,
+          EMPTY_RDP_SET,
         );
       });
     } else if (state === "REMOVED") {

--- a/packages/client/src/observable/internal/object/ObjectQuery.ts
+++ b/packages/client/src/observable/internal/object/ObjectQuery.ts
@@ -38,6 +38,7 @@ import { Query } from "../Query.js";
 import type { Store } from "../Store.js";
 import type { SubjectPayload } from "../SubjectPayload.js";
 import { tombstone } from "../tombstone.js";
+import { extractRdpFieldNames } from "../utils/rdpFieldOperations.js";
 import { type ObjectCacheKey, RDP_CONFIG_IDX } from "./ObjectCacheKey.js";
 
 export class ObjectQuery extends Query<
@@ -183,6 +184,7 @@ export class ObjectQuery extends Query<
     status: Status,
     batch: BatchContext,
     selectFields?: ReadonlySet<string>,
+    computedRdpFields?: ReadonlySet<string>,
   ): Entry<ObjectCacheKey> {
     const entry = batch.read(this.cacheKey);
     const rdpConfig = this.cacheKey.otherKeys[RDP_CONFIG_IDX];
@@ -194,12 +196,17 @@ export class ObjectQuery extends Query<
       rdpConfig,
     );
 
+    // a caller passes the derived fields it computed. when it doesn't, default
+    // to every derived field the key tracks.
+    const computed = computedRdpFields ?? extractRdpFieldNames(rdpConfig);
+
     this.store.objects.propagateWrite(
       this.cacheKey,
       data,
       status,
       batch,
       selectFields,
+      computed,
     );
 
     return batch.read(this.cacheKey)!;

--- a/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
@@ -275,6 +275,36 @@ describe("ObjectsHelper.propagateWrite RDP merge", () => {
     expect(valueB?.fullName).toBe("Bob");
     expect(valueB?.derivedAddress).toBe("new-addr");
   });
+
+  it("preserves the cached derived value when a same-key write computed no derived fields", () => {
+    const rdpConfig = createFakeRdpConfig("derivedAddress");
+    const queryB = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+    }, rdpConfig);
+
+    const seeded = emp.$clone({ derivedAddress: "123 Main St" } as any);
+    store.batch({}, (batch) => {
+      queryB.writeToStore(seeded as any, "loaded", batch);
+    });
+
+    // A write that computed no derived fields (empty set) carries base props
+    // only, so the cached derived value must survive.
+    const updated = emp.$clone({ fullName: "Bob" });
+    store.batch({}, (batch) => {
+      queryB.writeToStore(
+        updated as any,
+        "loaded",
+        batch,
+        undefined,
+        new Set<string>(),
+      );
+    });
+
+    const valueB = store.getValue(queryB.cacheKey)?.value as any;
+    expect(valueB?.fullName).toBe("Bob");
+    expect(valueB?.derivedAddress).toBe("123 Main St");
+  });
 });
 
 describe("ObjectsHelper.isKeyActive", () => {

--- a/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
@@ -190,6 +190,91 @@ describe("ObjectsHelper.propagateWrite RDP merge", () => {
       }),
     );
   });
+
+  it("clears a derived value when a same-key refetch omits it", () => {
+    const rdpConfig = createFakeRdpConfig("derivedAddress");
+    const queryB = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+    }, rdpConfig);
+
+    const seeded = emp.$clone({ derivedAddress: "123 Main St" } as any);
+    store.batch({}, (batch) => {
+      queryB.writeToStore(seeded as any, "loaded", batch);
+    });
+    expect(
+      (store.getValue(queryB.cacheKey)?.value as any)?.derivedAddress,
+    ).toBe("123 Main St");
+
+    store.batch({}, (batch) => {
+      queryB.writeToStore(emp as any, "loaded", batch);
+    });
+
+    const valueB = store.getValue(queryB.cacheKey)?.value as any;
+    expect(valueB?.fullName).toBe("Alice");
+    expect(valueB?.derivedAddress).toBeUndefined();
+  });
+
+  it("preserves the cached derived value when a no-RDP sibling writes", () => {
+    // The sibling did not compute the derived field, so it must survive.
+    const rdpConfig = createFakeRdpConfig("derivedAddress");
+    const queryWithRdp = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+    }, rdpConfig);
+    const queryNoRdp = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+    }, undefined);
+
+    store.cacheKeys.retain(queryWithRdp.cacheKey);
+    store.subjects.get(queryWithRdp.cacheKey).subscribe(() => {});
+
+    const seeded = emp.$clone({ derivedAddress: "123 Main St" } as any);
+    store.batch({}, (batch) => {
+      queryWithRdp.writeToStore(seeded as any, "loaded", batch);
+    });
+
+    const updated = emp.$clone({ fullName: "Bob" });
+    store.batch({}, (batch) => {
+      queryNoRdp.writeToStore(updated as any, "loaded", batch);
+    });
+
+    const rdpValue = store.getValue(queryWithRdp.cacheKey)?.value as any;
+    expect(rdpValue?.fullName).toBe("Bob");
+    expect(rdpValue?.derivedAddress).toBe("123 Main St");
+
+    store.cacheKeys.release(queryWithRdp.cacheKey);
+  });
+
+  it("keeps the recomputed derived value on a $select refetch", () => {
+    const rdpConfig = createFakeRdpConfig("derivedAddress");
+    const queryB = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+    }, rdpConfig);
+
+    const seeded = emp.$clone({ derivedAddress: "old-addr" } as any);
+    store.batch({}, (batch) => {
+      queryB.writeToStore(seeded as any, "loaded", batch);
+    });
+
+    const reloaded = emp.$clone(
+      { fullName: "Bob", derivedAddress: "new-addr" } as any,
+    );
+    store.batch({}, (batch) => {
+      queryB.writeToStore(
+        reloaded as any,
+        "loaded",
+        batch,
+        new Set(["fullName"]),
+      );
+    });
+
+    const valueB = store.getValue(queryB.cacheKey)?.value as any;
+    expect(valueB?.fullName).toBe("Bob");
+    expect(valueB?.derivedAddress).toBe("new-addr");
+  });
 });
 
 describe("ObjectsHelper.isKeyActive", () => {

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -152,52 +152,28 @@ export class ObjectsHelper extends AbstractHelper<
 
     let valueToWrite = !dataChanged && existing ? existing.value : value;
 
-    // When a $select-filtered fetch returns partial objects, merge with
-    // existing cached data to preserve fields not in the select set.
+    const sourceRdpFields = this.store.objectCacheKeyRegistry.getRdpFieldSet(
+      sourceCacheKey,
+    );
+
+    // A $select fetch carries only the base props it selected, so merge it with
+    // the cached value. A full write owns every field and is stored as-is, so an
+    // omitted derived value clears instead of being refilled from stale cache.
     const existingHolder = existing?.value;
-    const canMergeSelectFields = dataChanged
+    if (
+      dataChanged
+      && valueToWrite !== tombstone
       && selectFields
       && selectFields.size > 0
       && existingHolder
-      && this.isObjectHolder(existingHolder);
-
-    if (canMergeSelectFields && valueToWrite !== tombstone) {
+      && this.isObjectHolder(existingHolder)
+    ) {
       valueToWrite = mergeSelectFields(
         valueToWrite,
         selectFields,
         existingHolder,
+        sourceRdpFields,
       );
-    }
-
-    // When an object (e.g. from a subscription update) is written to a cache
-    // key that has RDP configuration, the incoming value may lack derived
-    // property values. Merge with the existing cached value so that RDP fields
-    // not present in the incoming object are preserved.
-    if (
-      valueToWrite !== tombstone
-      && existing?.value
-      && this.isObjectHolder(existing.value)
-    ) {
-      const expectedRdpFields = this.store.objectCacheKeyRegistry
-        .getRdpFieldSet(sourceCacheKey);
-      if (expectedRdpFields.size > 0) {
-        const underlying = valueToWrite[UnderlyingOsdkObject];
-        const actualRdpFields = new Set<string>();
-        for (const field of expectedRdpFields) {
-          if (underlying && field in underlying) {
-            actualRdpFields.add(field);
-          }
-        }
-
-        if (actualRdpFields.size !== expectedRdpFields.size) {
-          valueToWrite = mergeObjectFields(
-            valueToWrite,
-            actualRdpFields,
-            expectedRdpFields,
-            existing.value,
-          );
-        }
-      }
     }
 
     batch.write(sourceCacheKey, valueToWrite, status);
@@ -241,7 +217,12 @@ export class ObjectsHelper extends AbstractHelper<
       // union rather than clobbering each other.
       let merged = value;
       if (selectFields?.size && targetHolder) {
-        merged = mergeSelectFields(merged, selectFields, targetHolder);
+        merged = mergeSelectFields(
+          merged,
+          selectFields,
+          targetHolder,
+          sourceRdpFields,
+        );
       }
       merged = this.mergeForTarget(
         merged,

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -37,6 +37,18 @@ import {
 import { type ObjectCacheKey } from "./ObjectCacheKey.js";
 import { ObjectQuery } from "./ObjectQuery.js";
 
+function isSuperset(
+  a: ReadonlySet<string>,
+  b: ReadonlySet<string>,
+): boolean {
+  for (const field of b) {
+    if (!a.has(field)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export class ObjectsHelper extends AbstractHelper<
   ObjectQuery,
   ObserveObjectOptions<any>
@@ -113,6 +125,7 @@ export class ObjectsHelper extends AbstractHelper<
     rdpConfig?: Canonical<Rdp> | null,
     selectFields?: ReadonlySet<string>,
     includeAllBaseObjectProperties?: boolean,
+    computedRdpFields?: ReadonlySet<string>,
   ): ObjectCacheKey[] {
     const holders: ReadonlyArray<ObjectHolder | InterfaceHolder> =
       values as ReadonlyArray<ObjectHolder | InterfaceHolder>;
@@ -123,7 +136,13 @@ export class ObjectsHelper extends AbstractHelper<
         apiName: v.$objectType ?? v.$apiName,
         pk: v.$primaryKey,
         $includeAllBaseObjectProperties: includeAllBaseObjectProperties,
-      }, rdpConfig).writeToStore(concreteHolder, "loaded", batch, selectFields)
+      }, rdpConfig).writeToStore(
+        concreteHolder,
+        "loaded",
+        batch,
+        selectFields,
+        computedRdpFields,
+      )
         .cacheKey;
     });
   }
@@ -138,6 +157,7 @@ export class ObjectsHelper extends AbstractHelper<
     status: Status,
     batch: BatchContext,
     selectFields?: ReadonlySet<string>,
+    computedRdpFields?: ReadonlySet<string>,
   ): void {
     const existing = batch.read(sourceCacheKey);
     const dataChanged = !existing
@@ -152,28 +172,38 @@ export class ObjectsHelper extends AbstractHelper<
 
     let valueToWrite = !dataChanged && existing ? existing.value : value;
 
-    const sourceRdpFields = this.store.objectCacheKeyRegistry.getRdpFieldSet(
+    // derived fields the key tracks vs derived fields this write computed.
+    const trackedRdpFields = this.store.objectCacheKeyRegistry.getRdpFieldSet(
       sourceCacheKey,
     );
+    const sourceRdpFields = computedRdpFields ?? trackedRdpFields;
 
-    // A $select fetch carries only the base props it selected, so merge it with
-    // the cached value. A full write owns every field and is stored as-is, so an
-    // omitted derived value clears instead of being refilled from stale cache.
+    // a $select carries only some base props, and a write that computed only
+    // some derived fields leaves the rest out; either way merge to keep the
+    // cached values. a write that computed every tracked field is stored as-is,
+    // so an omitted field clears.
     const existingHolder = existing?.value;
     if (
       dataChanged
       && valueToWrite !== tombstone
-      && selectFields
-      && selectFields.size > 0
       && existingHolder
       && this.isObjectHolder(existingHolder)
     ) {
-      valueToWrite = mergeSelectFields(
-        valueToWrite,
-        selectFields,
-        existingHolder,
-        sourceRdpFields,
-      );
+      if (selectFields && selectFields.size > 0) {
+        valueToWrite = mergeSelectFields(
+          valueToWrite,
+          selectFields,
+          existingHolder,
+          sourceRdpFields,
+        );
+      } else if (!isSuperset(sourceRdpFields, trackedRdpFields)) {
+        valueToWrite = mergeObjectFields(
+          valueToWrite,
+          sourceRdpFields,
+          trackedRdpFields,
+          existingHolder,
+        );
+      }
     }
 
     batch.write(sourceCacheKey, valueToWrite, status);
@@ -227,7 +257,7 @@ export class ObjectsHelper extends AbstractHelper<
       merged = this.mergeForTarget(
         merged,
         targetHolder,
-        sourceCacheKey,
+        sourceRdpFields,
         targetKey,
       );
 
@@ -268,12 +298,9 @@ export class ObjectsHelper extends AbstractHelper<
   private mergeForTarget(
     sourceValue: ObjectHolder,
     targetCurrentValue: ObjectHolder | undefined,
-    sourceCacheKey: ObjectCacheKey,
+    sourceRdpFields: ReadonlySet<string>,
     targetCacheKey: ObjectCacheKey,
   ): ObjectHolder {
-    const sourceRdpFields = this.store.objectCacheKeyRegistry.getRdpFieldSet(
-      sourceCacheKey,
-    );
     const targetRdpFields = this.store.objectCacheKeyRegistry.getRdpFieldSet(
       targetCacheKey,
     );

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
@@ -195,7 +195,7 @@ describe("rdpFieldOperations", () => {
     expect(underlying.rdpField2).toBe(999);
   });
 
-  it("mergeObjectFields preserves target RDP value when source has undefined for shared field", () => {
+  it("mergeObjectFields clears a shared field the source owns but left undefined", () => {
     const source = createTestObject({
       employeeId: 50030,
       fullName: "John Doe",
@@ -218,8 +218,7 @@ describe("rdpFieldOperations", () => {
     const underlying = getUnderlyingProps(result);
     expect(underlying.employeeId).toBe(50030);
     expect(underlying.fullName).toBe("John Doe");
-    // Target's non-null value should be preserved when source has undefined
-    expect(underlying.rdpField1).toBe("existing-value");
+    expect(underlying.rdpField1).toBeUndefined();
     expect(underlying.rdpField2).toBe(999);
   });
 
@@ -311,7 +310,7 @@ describe("mergeSelectFields", () => {
     });
 
     const selectFields = new Set(["fullName", "office"]);
-    const result = mergeSelectFields(source, selectFields, existing);
+    const result = mergeSelectFields(source, selectFields, existing, new Set());
 
     assertValidObjectHolder(result);
     const underlying = getUnderlyingProps(result);
@@ -319,5 +318,32 @@ describe("mergeSelectFields", () => {
     expect(underlying.office).toBe("SF");
     expect(underlying.rdpField1).toBe("existing-rdp");
     expect(underlying.employeeId).toBe(50030);
+  });
+
+  it("keeps the source's derived field on a partial write", () => {
+    const source = createTestObject({
+      employeeId: 50030,
+      fullName: "Updated Name",
+      computedScore: 42,
+    });
+    const existing = createTestObject({
+      employeeId: 50030,
+      fullName: "Old Name",
+      office: "NYC",
+      computedScore: 7,
+    });
+
+    const result = mergeSelectFields(
+      source,
+      new Set(["fullName"]),
+      existing,
+      new Set(["computedScore"]),
+    );
+
+    assertValidObjectHolder(result);
+    const underlying = getUnderlyingProps(result);
+    expect(underlying.fullName).toBe("Updated Name");
+    expect(underlying.office).toBe("NYC");
+    expect(underlying.computedScore).toBe(42);
   });
 });

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
@@ -56,9 +56,6 @@ const employeeObjectDef = {
     employeeId: { type: "integer" },
     fullName: { type: "string" },
     office: { type: "string" },
-    rdpField1: { type: "string" },
-    rdpField2: { type: "double" },
-    rdpField3: { type: "string" },
   },
 } satisfies FetchedObjectTypeDefinition;
 
@@ -300,23 +297,20 @@ describe("mergeSelectFields", () => {
     const source = createTestObject({
       employeeId: 50030,
       fullName: "Updated Name",
-      office: "SF",
     });
     const existing = createTestObject({
       employeeId: 50030,
       fullName: "Old Name",
       office: "NYC",
-      rdpField1: "existing-rdp",
     });
 
-    const selectFields = new Set(["fullName", "office"]);
+    const selectFields = new Set(["fullName"]);
     const result = mergeSelectFields(source, selectFields, existing, new Set());
 
     assertValidObjectHolder(result);
     const underlying = getUnderlyingProps(result);
     expect(underlying.fullName).toBe("Updated Name");
-    expect(underlying.office).toBe("SF");
-    expect(underlying.rdpField1).toBe("existing-rdp");
+    expect(underlying.office).toBe("NYC");
     expect(underlying.employeeId).toBe(50030);
   });
 

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
@@ -116,11 +116,13 @@ function filterToRdpFields(
   };
 
   for (const key of Object.keys(underlying)) {
-    if (key in objectDef.properties) {
-      const isRdpField = sourceRdpFields.has(key);
-      if (!isRdpField || rdpFieldsToKeep.has(key)) {
+    // Derived names are not in objectDef.properties, so gate them on the rdp set.
+    if (sourceRdpFields.has(key)) {
+      if (rdpFieldsToKeep.has(key)) {
         newProps[key] = underlying[key];
       }
+    } else if (key in objectDef.properties) {
+      newProps[key] = underlying[key];
     }
   }
 
@@ -131,6 +133,7 @@ export function mergeSelectFields(
   sourceValue: ObjectHolder,
   selectFields: ReadonlySet<string>,
   existingValue: ObjectHolder,
+  sourceRdpFields: ReadonlySet<string>,
 ): ObjectHolder {
   const sourceUnderlying =
     sourceValue[UnderlyingOsdkObject] as SimpleOsdkProperties;
@@ -156,7 +159,10 @@ export function mergeSelectFields(
   }
 
   for (const key of Object.keys(sourceUnderlying)) {
-    if (key in objectDef.properties && selectFields.has(key)) {
+    // Take the source's derived fields, plus the base props it selected.
+    if (sourceRdpFields.has(key)) {
+      newProps[key] = sourceUnderlying[key];
+    } else if (key in objectDef.properties && selectFields.has(key)) {
       newProps[key] = sourceUnderlying[key];
     }
   }
@@ -205,20 +211,22 @@ export function mergeObjectFields(
     }
   }
 
+  // Carry the source's derived fields the target wants (the base loop skips them
+  // since their names are not schema props). An omitted owned field stays unset,
+  // so a value that became null clears rather than refilling from stale cache.
+  for (const field of sourceRdpFields) {
+    if (targetRdpFields.has(field) && field in sourceUnderlying) {
+      newProps[field] = sourceUnderlying[field];
+    }
+  }
+
   if (targetCurrentValue) {
     const targetUnderlying =
       targetCurrentValue[UnderlyingOsdkObject] as SimpleOsdkProperties;
+    // Keep the target's value for derived fields the source did not compute.
     for (const field of targetRdpFields) {
-      if (field in targetUnderlying) {
-        // Preserve target's value when:
-        // 1. Source doesn't have this RDP field at all, OR
-        // 2. Source hasn't provided the value (undefined)
-        if (
-          !sourceRdpFields.has(field)
-          || newProps[field] === undefined
-        ) {
-          newProps[field] = targetUnderlying[field];
-        }
+      if (!sourceRdpFields.has(field) && field in targetUnderlying) {
+        newProps[field] = targetUnderlying[field];
       }
     }
   }

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
@@ -116,7 +116,7 @@ function filterToRdpFields(
   };
 
   for (const key of Object.keys(underlying)) {
-    // Derived names are not in objectDef.properties, so gate them on the rdp set.
+    // keep the target's derived fields and every base prop.
     if (sourceRdpFields.has(key)) {
       if (rdpFieldsToKeep.has(key)) {
         newProps[key] = underlying[key];
@@ -203,17 +203,13 @@ export function mergeObjectFields(
   };
 
   for (const key of Object.keys(sourceUnderlying)) {
-    if (
-      key in objectDef.properties
-      && (!sourceRdpFields.has(key) || targetRdpFields.has(key))
-    ) {
+    if (key in objectDef.properties) {
       newProps[key] = sourceUnderlying[key];
     }
   }
 
-  // Carry the source's derived fields the target wants (the base loop skips them
-  // since their names are not schema props). An omitted owned field stays unset,
-  // so a value that became null clears rather than refilling from stale cache.
+  // take the source's derived fields the target wants. if the source left one
+  // out then it just clears.
   for (const field of sourceRdpFields) {
     if (targetRdpFields.has(field) && field in sourceUnderlying) {
       newProps[field] = sourceUnderlying[field];

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
@@ -26,6 +26,9 @@ import type { FetchedObjectTypeDefinition } from "../../../ontology/OntologyProv
 import type { Canonical } from "../Canonical.js";
 import type { Rdp } from "../RdpCanonicalizer.js";
 
+/** shared empty set for writes that compute no derived fields. */
+export const EMPTY_RDP_SET: ReadonlySet<string> = new Set();
+
 export function extractRdpFieldNames(
   rdpConfig: Canonical<Rdp> | undefined,
 ): ReadonlySet<string> {


### PR DESCRIPTION
runtime-derived-property columns kept showing a stale value after the derived value became null, because the cache merge resolved derived fields by object-schema membership and wire presence instead of the query's rdp set

• resolve derived fields by the query rdp set so the source owns what it computed and an omitted field clears
• drop the same-key wire-presence heuristic so a full refetch that omits a now-null derived value clears it
• stop dropping shared derived fields and select+derived values when propagating to sibling cache keys

this is the focused root-cause fix split out below the broader merge rearchitecture in #3523