### PR TITLE
rearchitect rdp cache merge

### DIFF
--- a/.changeset/rdp-merge-reconcile.md
+++ b/.changeset/rdp-merge-reconcile.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Consolidate the observable cache object merge into one field-resolution rule. Base properties and derived (RDP) fields now reconcile in a single pass: the source query owns the base properties it loaded and the derived fields it computed, an owned field it omits clears, and otherwise the target keeps its cached value.

--- a/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
@@ -76,49 +76,15 @@ describe("ObjectsHelper.propagateWrite RDP merge", () => {
     };
   });
 
-  it("skips merge when incoming object already has all expected RDP fields", () => {
-    // Use "fullName" as RDP field — it exists on the Employee object,
-    // so actualRdpFields.size === expectedRdpFields.size and merge is skipped.
-    const rdpConfig = createFakeRdpConfig("fullName");
-
-    // Create key B (with RDP for "fullName") and seed it
-    const queryB = store.objects.getQuery({
-      apiName: Employee,
-      pk: 1,
-    }, rdpConfig);
-    store.batch({}, (batch) => {
-      queryB.writeToStore(emp as any, "loaded", batch);
-    });
-
-    // Write an updated object directly to key B — since the Employee
-    // object already has "fullName", all expected RDP fields are present
-    // and the merge short-circuit should fire.
-    const updated = emp.$clone({ fullName: "Bob" });
-    store.batch({}, (batch) => {
-      queryB.writeToStore(updated as any, "loaded", batch);
-    });
-
-    // Key B should have the updated value (merge was skipped)
-    const valueB = store.getValue(queryB.cacheKey);
-    expect(valueB?.value).toEqual(
-      expect.objectContaining({
-        $primaryKey: 1,
-        fullName: "Bob",
-      }),
-    );
-  });
-
-  it("does not merge on first write to an RDP key (no existing value)", () => {
+  it("writes the value as-is on first write to an RDP key", () => {
     const rdpConfig = createFakeRdpConfig("derivedAddress");
 
-    // Create key B (with RDP for "derivedAddress") — no prior write
     const queryB = store.objects.getQuery({
       apiName: Employee,
       pk: 1,
     }, rdpConfig);
 
-    // First write — there is no existing value so the merge guard
-    // (existing?.value) is false and the value is written as-is.
+    // With no existing value, the first write is stored as-is.
     store.batch({}, (batch) => {
       queryB.writeToStore(emp as any, "loaded", batch);
     });
@@ -132,9 +98,8 @@ describe("ObjectsHelper.propagateWrite RDP merge", () => {
     );
   });
 
-  it("does not merge for a non-RDP cache key", () => {
-    // Create a plain (no RDP) key and write twice — the merge block
-    // should be skipped because expectedRdpFields is empty.
+  it("writes the latest value for a non-RDP cache key", () => {
+    // A plain (no RDP) key written twice keeps the latest value.
     const query = store.objects.getQuery({
       apiName: Employee,
       pk: 1,
@@ -158,66 +123,38 @@ describe("ObjectsHelper.propagateWrite RDP merge", () => {
     );
   });
 
-  it("merges when incoming object is missing expected RDP fields", () => {
-    // Use "derivedAddress" as RDP field — it does NOT exist on the Employee
-    // object, so actualRdpFields.size < expectedRdpFields.size and merge runs
-    // to preserve the cached RDP value.
-    const rdpConfig = createFakeRdpConfig("derivedAddress");
-
-    // Create key B (with RDP for "derivedAddress") and seed it
-    const queryB = store.objects.getQuery({
-      apiName: Employee,
-      pk: 1,
-    }, rdpConfig);
-    store.batch({}, (batch) => {
-      queryB.writeToStore(emp as any, "loaded", batch);
-    });
-
-    // Write an updated object directly to key B — since "derivedAddress"
-    // is NOT on the Employee object, actualRdpFields < expectedRdpFields
-    // and merge runs to preserve cached RDP values.
-    const updated = emp.$clone({ fullName: "Charlie" });
-    store.batch({}, (batch) => {
-      queryB.writeToStore(updated as any, "loaded", batch);
-    });
-
-    // Key B should have the updated base fields via merge
-    const valueB = store.getValue(queryB.cacheKey);
-    expect(valueB?.value).toEqual(
-      expect.objectContaining({
-        $primaryKey: 1,
-        fullName: "Charlie",
-      }),
-    );
-  });
-
-  it("clears a derived value when a same-key refetch omits it", () => {
-    const rdpConfig = createFakeRdpConfig("derivedAddress");
-    const queryB = store.objects.getQuery({
+  it("clears an RDP value when the canonical query refetches and the new value omits it", () => {
+    const rdpConfig = createFakeRdpConfig("fieldA");
+    const queryWithRdp = store.objects.getQuery({
       apiName: Employee,
       pk: 1,
     }, rdpConfig);
 
-    const seeded = emp.$clone({ derivedAddress: "123 Main St" } as any);
+    // Seed: object has fieldA = "alice-rdp"
+    const empWithFieldA = emp.$clone({ fieldA: "alice-rdp" } as any);
     store.batch({}, (batch) => {
-      queryB.writeToStore(seeded as any, "loaded", batch);
+      queryWithRdp.writeToStore(empWithFieldA as any, "loaded", batch);
     });
     expect(
-      (store.getValue(queryB.cacheKey)?.value as any)?.derivedAddress,
-    ).toBe("123 Main St");
+      (store.getValue(queryWithRdp.cacheKey)?.value as any)?.fieldA,
+    ).toBe("alice-rdp");
 
+    // Refetch: the same canonical query writes an object without fieldA
+    // (server returned null so the wire omitted the key).
+    const empWithoutFieldA = emp.$clone({ fullName: "Bob" });
     store.batch({}, (batch) => {
-      queryB.writeToStore(emp as any, "loaded", batch);
+      queryWithRdp.writeToStore(empWithoutFieldA as any, "loaded", batch);
     });
 
-    const valueB = store.getValue(queryB.cacheKey)?.value as any;
-    expect(valueB?.fullName).toBe("Alice");
-    expect(valueB?.derivedAddress).toBeUndefined();
+    const valueAfter = store.getValue(queryWithRdp.cacheKey)?.value as any;
+    expect(valueAfter?.fullName).toBe("Bob");
+    // The derived value became null, so the cache must reflect that, not the
+    // stale "alice-rdp" value.
+    expect(valueAfter?.fieldA).toBeUndefined();
   });
 
-  it("preserves the cached derived value when a no-RDP sibling writes", () => {
-    // The sibling did not compute the derived field, so it must survive.
-    const rdpConfig = createFakeRdpConfig("derivedAddress");
+  it("preserves the cached RDP value when a no-RDP sibling query writes", () => {
+    const rdpConfig = createFakeRdpConfig("fieldA");
     const queryWithRdp = store.objects.getQuery({
       apiName: Employee,
       pk: 1,
@@ -227,83 +164,29 @@ describe("ObjectsHelper.propagateWrite RDP merge", () => {
       pk: 1,
     }, undefined);
 
+    // Make the RDP cache key active so sibling propagation reaches it.
     store.cacheKeys.retain(queryWithRdp.cacheKey);
     store.subjects.get(queryWithRdp.cacheKey).subscribe(() => {});
 
-    const seeded = emp.$clone({ derivedAddress: "123 Main St" } as any);
+    // Seed the RDP cache key with fieldA = "alice-rdp"
+    const empWithFieldA = emp.$clone({ fieldA: "alice-rdp" } as any);
     store.batch({}, (batch) => {
-      queryWithRdp.writeToStore(seeded as any, "loaded", batch);
+      queryWithRdp.writeToStore(empWithFieldA as any, "loaded", batch);
     });
 
-    const updated = emp.$clone({ fullName: "Bob" });
+    // The no-RDP query writes an updated object (no fieldA in the payload).
+    const empBob = emp.$clone({ fullName: "Bob" });
     store.batch({}, (batch) => {
-      queryNoRdp.writeToStore(updated as any, "loaded", batch);
+      queryNoRdp.writeToStore(empBob as any, "loaded", batch);
     });
 
-    const rdpValue = store.getValue(queryWithRdp.cacheKey)?.value as any;
-    expect(rdpValue?.fullName).toBe("Bob");
-    expect(rdpValue?.derivedAddress).toBe("123 Main St");
+    const rdpValueAfter = store.getValue(queryWithRdp.cacheKey)?.value as any;
+    // Base field updated by sibling propagation
+    expect(rdpValueAfter?.fullName).toBe("Bob");
+    // Derived value preserved: the no-RDP source query did not compute it.
+    expect(rdpValueAfter?.fieldA).toBe("alice-rdp");
 
     store.cacheKeys.release(queryWithRdp.cacheKey);
-  });
-
-  it("keeps the recomputed derived value on a $select refetch", () => {
-    const rdpConfig = createFakeRdpConfig("derivedAddress");
-    const queryB = store.objects.getQuery({
-      apiName: Employee,
-      pk: 1,
-    }, rdpConfig);
-
-    const seeded = emp.$clone({ derivedAddress: "old-addr" } as any);
-    store.batch({}, (batch) => {
-      queryB.writeToStore(seeded as any, "loaded", batch);
-    });
-
-    const reloaded = emp.$clone(
-      { fullName: "Bob", derivedAddress: "new-addr" } as any,
-    );
-    store.batch({}, (batch) => {
-      queryB.writeToStore(
-        reloaded as any,
-        "loaded",
-        batch,
-        new Set(["fullName"]),
-      );
-    });
-
-    const valueB = store.getValue(queryB.cacheKey)?.value as any;
-    expect(valueB?.fullName).toBe("Bob");
-    expect(valueB?.derivedAddress).toBe("new-addr");
-  });
-
-  it("preserves the cached derived value when a same-key write computed no derived fields", () => {
-    const rdpConfig = createFakeRdpConfig("derivedAddress");
-    const queryB = store.objects.getQuery({
-      apiName: Employee,
-      pk: 1,
-    }, rdpConfig);
-
-    const seeded = emp.$clone({ derivedAddress: "123 Main St" } as any);
-    store.batch({}, (batch) => {
-      queryB.writeToStore(seeded as any, "loaded", batch);
-    });
-
-    // A write that computed no derived fields (empty set) carries base props
-    // only, so the cached derived value must survive.
-    const updated = emp.$clone({ fullName: "Bob" });
-    store.batch({}, (batch) => {
-      queryB.writeToStore(
-        updated as any,
-        "loaded",
-        batch,
-        undefined,
-        new Set<string>(),
-      );
-    });
-
-    const valueB = store.getValue(queryB.cacheKey)?.value as any;
-    expect(valueB?.fullName).toBe("Bob");
-    expect(valueB?.derivedAddress).toBe("123 Main St");
   });
 });
 
@@ -368,7 +251,7 @@ describe("ObjectsHelper.isKeyActive", () => {
     // Simulate pending cleanup (React unmount-remount cycle)
     store.pendingCleanup.set(queryB.cacheKey, 1);
 
-    // Write through key A — should propagate to B due to pending cleanup
+    // Write through key A, which should propagate to B due to pending cleanup
     const updated = emp.$clone({ fullName: "Bob" });
     updateObject(store, updated);
 
@@ -477,7 +360,7 @@ describe("ObjectsHelper.isKeyActive", () => {
     // Write new data while pending cleanup is active
     updateObject(store, emp.$clone({ fullName: "Updated" }));
 
-    // Re-subscribe (remount) — should see updated data
+    // Re-subscribe (remount), which should see updated data
     const subFn = mockSingleSubCallback();
     store.cacheKeys.retain(queryB.cacheKey);
     const sub2 = subjectB.subscribe(
@@ -621,7 +504,7 @@ describe("Two variants with different RDP configs - GC of one should not affect 
       1,
     )).toBe(1);
 
-    // Update via base variant — should still propagate to A
+    // Update via base variant, which should still propagate to A
     updateObject(store, emp.$clone({ fullName: "Bob" }));
 
     const valueA = store.getValue(queryA.cacheKey);
@@ -835,16 +718,14 @@ describe("ObjectsHelper.storeOsdkInstances interface unwrap", () => {
     expect(InterfaceDefRef in cached).toBe(false);
   });
 
-  it("unwraps an InterfaceHolder when storing through the rdpConfig merge path", () => {
-    // Use an RDP field that is NOT present on the Employee object so the
-    // propagateWrite merge branch runs (actualRdpFields < expectedRdpFields).
-    // The merge path reads objectDef.properties from the incoming holder; if
-    // an InterfaceHolder slips through unwrapped, ObjectDefRef is undefined
-    // and the merge crashes. This test would FAIL on the pre-PR code.
+  it("unwraps an InterfaceHolder when storing to an RDP cache key", () => {
+    // storeOsdkInstances must unwrap an InterfaceHolder to its concrete object
+    // before caching. If one slipped through, ObjectDefRef would be undefined
+    // and downstream RDP handling (requireObjectDef) would throw.
     const rdpConfig = createFakeRdpConfig("derivedAddress");
 
     // Seed the cache key for (Employee, pk=1, rdpConfig) with a concrete
-    // Employee value so that the second write goes through the merge branch.
+    // Employee value, then write the same object via an InterfaceHolder.
     const queryEmp = store.objects.getQuery({
       apiName: Employee,
       pk: 1,

--- a/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
@@ -188,6 +188,66 @@ describe("ObjectsHelper.propagateWrite RDP merge", () => {
 
     store.cacheKeys.release(queryWithRdp.cacheKey);
   });
+
+  it("preserves the cached RDP value when a write to the same key computed no derived fields", () => {
+    const rdpConfig = createFakeRdpConfig("fieldA");
+    const queryWithRdp = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+    }, rdpConfig);
+
+    // Seed: a full fetch computed fieldA = "alice-rdp".
+    const empWithFieldA = emp.$clone({ fieldA: "alice-rdp" } as any);
+    store.batch({}, (batch) => {
+      queryWithRdp.writeToStore(empWithFieldA as any, "loaded", batch);
+    });
+
+    // A write that computed no derived fields (empty set) carries base props
+    // only, so the cached derived value must survive.
+    const empBaseOnly = emp.$clone({ fullName: "Bob" });
+    store.batch({}, (batch) => {
+      queryWithRdp.writeToStore(
+        empBaseOnly as any,
+        "loaded",
+        batch,
+        undefined,
+        new Set<string>(),
+      );
+    });
+
+    const valueAfter = store.getValue(queryWithRdp.cacheKey)?.value as any;
+    expect(valueAfter?.fullName).toBe("Bob");
+    expect(valueAfter?.fieldA).toBe("alice-rdp");
+  });
+
+  it("clears the RDP value when a write claims it computed the field but omits it", () => {
+    const rdpConfig = createFakeRdpConfig("fieldA");
+    const queryWithRdp = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+    }, rdpConfig);
+
+    const empWithFieldA = emp.$clone({ fieldA: "alice-rdp" } as any);
+    store.batch({}, (batch) => {
+      queryWithRdp.writeToStore(empWithFieldA as any, "loaded", batch);
+    });
+
+    // The write computed fieldA but the value came back null, so it must clear.
+    const empWithoutFieldA = emp.$clone({ fullName: "Bob" });
+    store.batch({}, (batch) => {
+      queryWithRdp.writeToStore(
+        empWithoutFieldA as any,
+        "loaded",
+        batch,
+        undefined,
+        new Set<string>(["fieldA"]),
+      );
+    });
+
+    const valueAfter = store.getValue(queryWithRdp.cacheKey)?.value as any;
+    expect(valueAfter?.fullName).toBe("Bob");
+    expect(valueAfter?.fieldA).toBeUndefined();
+  });
 });
 
 describe("ObjectsHelper.isKeyActive", () => {

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -153,8 +153,9 @@ export class ObjectsHelper extends AbstractHelper<
       sourceCacheKey,
     );
 
-    // A partial load carries only the base props it fetched, so reconcile to keep
-    // the rest; a full load is written as-is, so an omitted field clears.
+    // a partial load only carries the base props it fetched so we reconcile to
+    // keep the rest. a full load is written straight through, so a field it left
+    // out clears.
     const existingHolder = existing?.value;
     if (
       dataChanged
@@ -164,7 +165,7 @@ export class ObjectsHelper extends AbstractHelper<
       && existingHolder
       && this.isObjectHolder(existingHolder)
     ) {
-      // Same cache key, so the target carries the same derived fields as the source.
+      // same cache key so the target tracks the same derived fields as the source.
       valueToWrite = this.mergeInto(
         valueToWrite,
         existingHolder,
@@ -249,7 +250,7 @@ export class ObjectsHelper extends AbstractHelper<
       && "$primaryKey" in value;
   }
 
-  /** Merge a freshly written object into the value cached at a key. */
+  /** merges a freshly written object into whatever is cached at a key. */
   private mergeInto(
     value: ObjectHolder,
     cached: ObjectHolder | undefined,

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -164,13 +164,13 @@ export class ObjectsHelper extends AbstractHelper<
       && existingHolder
       && this.isObjectHolder(existingHolder)
     ) {
-      valueToWrite = reconcileObject(
-        {
-          value: valueToWrite,
-          rdpFields: sourceRdpFields,
-          loadedBaseFields: selectFields,
-        },
-        { value: existingHolder, rdpFields: sourceRdpFields },
+      // Same cache key, so the target carries the same derived fields as the source.
+      valueToWrite = this.mergeInto(
+        valueToWrite,
+        existingHolder,
+        sourceRdpFields,
+        sourceRdpFields,
+        selectFields,
       );
     }
 
@@ -211,11 +211,14 @@ export class ObjectsHelper extends AbstractHelper<
           ? targetCurrentValue
           : undefined;
 
-      const merged = this.mergeForTarget(
+      const targetRdpFields = this.store.objectCacheKeyRegistry.getRdpFieldSet(
+        targetKey,
+      );
+      const merged = this.mergeInto(
         value,
         targetHolder,
         sourceRdpFields,
-        targetKey,
+        targetRdpFields,
         selectFields,
       );
 
@@ -246,29 +249,17 @@ export class ObjectsHelper extends AbstractHelper<
       && "$primaryKey" in value;
   }
 
-  /**
-   * Reconcile a freshly written object into the value cached at a sibling cache
-   * key, resolving base props by schema authority and derived fields by the two
-   * keys' rdp sets.
-   */
-  private mergeForTarget(
-    sourceValue: ObjectHolder,
-    targetCurrentValue: ObjectHolder | undefined,
+  /** Merge a freshly written object into the value cached at a key. */
+  private mergeInto(
+    value: ObjectHolder,
+    cached: ObjectHolder | undefined,
     sourceRdpFields: ReadonlySet<string>,
-    targetCacheKey: ObjectCacheKey,
-    selectFields: ReadonlySet<string> | undefined,
+    targetRdpFields: ReadonlySet<string>,
+    loadedBaseFields: ReadonlySet<string> | undefined,
   ): ObjectHolder {
-    const targetRdpFields = this.store.objectCacheKeyRegistry.getRdpFieldSet(
-      targetCacheKey,
-    );
-
     return reconcileObject(
-      {
-        value: sourceValue,
-        rdpFields: sourceRdpFields,
-        loadedBaseFields: selectFields,
-      },
-      { value: targetCurrentValue, rdpFields: targetRdpFields },
+      { value, rdpFields: sourceRdpFields, loadedBaseFields },
+      { value: cached, rdpFields: targetRdpFields },
     );
   }
 }

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -30,24 +30,9 @@ import type { Canonical } from "../Canonical.js";
 import type { QuerySubscription } from "../QuerySubscription.js";
 import type { Rdp } from "../RdpCanonicalizer.js";
 import { tombstone } from "../tombstone.js";
-import {
-  mergeObjectFields,
-  mergeSelectFields,
-} from "../utils/rdpFieldOperations.js";
+import { reconcileObject } from "../utils/rdpFieldOperations.js";
 import { type ObjectCacheKey } from "./ObjectCacheKey.js";
 import { ObjectQuery } from "./ObjectQuery.js";
-
-function isSuperset(
-  a: ReadonlySet<string>,
-  b: ReadonlySet<string>,
-): boolean {
-  for (const field of b) {
-    if (!a.has(field)) {
-      return false;
-    }
-  }
-  return true;
-}
 
 export class ObjectsHelper extends AbstractHelper<
   ObjectQuery,
@@ -125,7 +110,6 @@ export class ObjectsHelper extends AbstractHelper<
     rdpConfig?: Canonical<Rdp> | null,
     selectFields?: ReadonlySet<string>,
     includeAllBaseObjectProperties?: boolean,
-    computedRdpFields?: ReadonlySet<string>,
   ): ObjectCacheKey[] {
     const holders: ReadonlyArray<ObjectHolder | InterfaceHolder> =
       values as ReadonlyArray<ObjectHolder | InterfaceHolder>;
@@ -136,13 +120,7 @@ export class ObjectsHelper extends AbstractHelper<
         apiName: v.$objectType ?? v.$apiName,
         pk: v.$primaryKey,
         $includeAllBaseObjectProperties: includeAllBaseObjectProperties,
-      }, rdpConfig).writeToStore(
-        concreteHolder,
-        "loaded",
-        batch,
-        selectFields,
-        computedRdpFields,
-      )
+      }, rdpConfig).writeToStore(concreteHolder, "loaded", batch, selectFields)
         .cacheKey;
     });
   }
@@ -157,7 +135,6 @@ export class ObjectsHelper extends AbstractHelper<
     status: Status,
     batch: BatchContext,
     selectFields?: ReadonlySet<string>,
-    computedRdpFields?: ReadonlySet<string>,
   ): void {
     const existing = batch.read(sourceCacheKey);
     const dataChanged = !existing
@@ -172,38 +149,29 @@ export class ObjectsHelper extends AbstractHelper<
 
     let valueToWrite = !dataChanged && existing ? existing.value : value;
 
-    // derived fields the key tracks vs derived fields this write computed.
-    const trackedRdpFields = this.store.objectCacheKeyRegistry.getRdpFieldSet(
+    const sourceRdpFields = this.store.objectCacheKeyRegistry.getRdpFieldSet(
       sourceCacheKey,
     );
-    const sourceRdpFields = computedRdpFields ?? trackedRdpFields;
 
-    // a $select carries only some base props, and a write that computed only
-    // some derived fields leaves the rest out; either way merge to keep the
-    // cached values. a write that computed every tracked field is stored as-is,
-    // so an omitted field clears.
+    // A partial load carries only the base props it fetched, so reconcile to keep
+    // the rest; a full load is written as-is, so an omitted field clears.
     const existingHolder = existing?.value;
     if (
       dataChanged
       && valueToWrite !== tombstone
+      && selectFields
+      && selectFields.size > 0
       && existingHolder
       && this.isObjectHolder(existingHolder)
     ) {
-      if (selectFields && selectFields.size > 0) {
-        valueToWrite = mergeSelectFields(
-          valueToWrite,
-          selectFields,
-          existingHolder,
-          sourceRdpFields,
-        );
-      } else if (!isSuperset(sourceRdpFields, trackedRdpFields)) {
-        valueToWrite = mergeObjectFields(
-          valueToWrite,
-          sourceRdpFields,
-          trackedRdpFields,
-          existingHolder,
-        );
-      }
+      valueToWrite = reconcileObject(
+        {
+          value: valueToWrite,
+          rdpFields: sourceRdpFields,
+          loadedBaseFields: selectFields,
+        },
+        { value: existingHolder, rdpFields: sourceRdpFields },
+      );
     }
 
     batch.write(sourceCacheKey, valueToWrite, status);
@@ -218,6 +186,7 @@ export class ObjectsHelper extends AbstractHelper<
       sourceCacheKey,
     );
 
+    // Propagate write to sibling cache keys that observe the same (apiName, pk)
     const relatedKeys = metadata
       ? this.store.objectCacheKeyRegistry.getVariants(
         metadata.apiName,
@@ -242,23 +211,12 @@ export class ObjectsHelper extends AbstractHelper<
           ? targetCurrentValue
           : undefined;
 
-      // Preserve target-only fields when a partial-select fetch propagates
-      // to a sibling variant, so different-select variants converge to the
-      // union rather than clobbering each other.
-      let merged = value;
-      if (selectFields?.size && targetHolder) {
-        merged = mergeSelectFields(
-          merged,
-          selectFields,
-          targetHolder,
-          sourceRdpFields,
-        );
-      }
-      merged = this.mergeForTarget(
-        merged,
+      const merged = this.mergeForTarget(
+        value,
         targetHolder,
         sourceRdpFields,
         targetKey,
+        selectFields,
       );
 
       batch.write(targetKey, merged, status);
@@ -266,11 +224,10 @@ export class ObjectsHelper extends AbstractHelper<
   }
 
   /**
-   * Check if a cache key is actively observed or pending cleanup.
-   * During React unmount-remount cycles, a key may be momentarily
-   * unobserved while its cleanup is deferred to a microtask.
-   * We still propagate to such keys to prevent stale data when
-   * the subscription is re-established.
+   * A cache key counts as active if it is observed or pending cleanup. During
+   * React unmount-remount cycles a key can be momentarily unobserved while its
+   * cleanup is deferred to a microtask; propagating to it keeps data fresh for
+   * when the subscription is re-established.
    */
   private isKeyActive(key: ObjectCacheKey): boolean {
     const subject = this.store.subjects.peek(key);
@@ -280,9 +237,6 @@ export class ObjectsHelper extends AbstractHelper<
     return (this.store.pendingCleanup.get(key) ?? 0) > 0;
   }
 
-  /**
-   * Type guard to check if a value is an ObjectHolder
-   */
   private isObjectHolder(
     value: ObjectHolder | undefined,
   ): value is ObjectHolder {
@@ -293,23 +247,28 @@ export class ObjectsHelper extends AbstractHelper<
   }
 
   /**
-   * Merge object data for a specific target cache key, preserving RDP fields
+   * Reconcile a freshly written object into the value cached at a sibling cache
+   * key, resolving base props by schema authority and derived fields by the two
+   * keys' rdp sets.
    */
   private mergeForTarget(
     sourceValue: ObjectHolder,
     targetCurrentValue: ObjectHolder | undefined,
     sourceRdpFields: ReadonlySet<string>,
     targetCacheKey: ObjectCacheKey,
+    selectFields: ReadonlySet<string> | undefined,
   ): ObjectHolder {
     const targetRdpFields = this.store.objectCacheKeyRegistry.getRdpFieldSet(
       targetCacheKey,
     );
 
-    return mergeObjectFields(
-      sourceValue,
-      sourceRdpFields,
-      targetRdpFields,
-      targetCurrentValue,
+    return reconcileObject(
+      {
+        value: sourceValue,
+        rdpFields: sourceRdpFields,
+        loadedBaseFields: selectFields,
+      },
+      { value: targetCurrentValue, rdpFields: targetRdpFields },
     );
   }
 }

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -34,6 +34,18 @@ import { reconcileObject } from "../utils/rdpFieldOperations.js";
 import { type ObjectCacheKey } from "./ObjectCacheKey.js";
 import { ObjectQuery } from "./ObjectQuery.js";
 
+function isSuperset(
+  a: ReadonlySet<string>,
+  b: ReadonlySet<string>,
+): boolean {
+  for (const field of b) {
+    if (!a.has(field)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export class ObjectsHelper extends AbstractHelper<
   ObjectQuery,
   ObserveObjectOptions<any>
@@ -110,6 +122,7 @@ export class ObjectsHelper extends AbstractHelper<
     rdpConfig?: Canonical<Rdp> | null,
     selectFields?: ReadonlySet<string>,
     includeAllBaseObjectProperties?: boolean,
+    computedRdpFields?: ReadonlySet<string>,
   ): ObjectCacheKey[] {
     const holders: ReadonlyArray<ObjectHolder | InterfaceHolder> =
       values as ReadonlyArray<ObjectHolder | InterfaceHolder>;
@@ -120,7 +133,13 @@ export class ObjectsHelper extends AbstractHelper<
         apiName: v.$objectType ?? v.$apiName,
         pk: v.$primaryKey,
         $includeAllBaseObjectProperties: includeAllBaseObjectProperties,
-      }, rdpConfig).writeToStore(concreteHolder, "loaded", batch, selectFields)
+      }, rdpConfig).writeToStore(
+        concreteHolder,
+        "loaded",
+        batch,
+        selectFields,
+        computedRdpFields,
+      )
         .cacheKey;
     });
   }
@@ -135,6 +154,7 @@ export class ObjectsHelper extends AbstractHelper<
     status: Status,
     batch: BatchContext,
     selectFields?: ReadonlySet<string>,
+    computedRdpFields?: ReadonlySet<string>,
   ): void {
     const existing = batch.read(sourceCacheKey);
     const dataChanged = !existing
@@ -149,28 +169,32 @@ export class ObjectsHelper extends AbstractHelper<
 
     let valueToWrite = !dataChanged && existing ? existing.value : value;
 
-    const sourceRdpFields = this.store.objectCacheKeyRegistry.getRdpFieldSet(
+    // derived fields the key tracks vs derived fields this write computed.
+    const trackedRdpFields = this.store.objectCacheKeyRegistry.getRdpFieldSet(
       sourceCacheKey,
     );
+    const sourceRdpFields = computedRdpFields ?? trackedRdpFields;
 
-    // a partial load only carries the base props it fetched so we reconcile to
-    // keep the rest. a full load is written straight through, so a field it left
-    // out clears.
+    // merge to keep cached fields the write didn't load: a $select carries only
+    // some base props, and a write that computed only some derived fields leaves
+    // the rest out. a write that computed every tracked field is written as-is,
+    // so an omitted field clears.
     const existingHolder = existing?.value;
     if (
       dataChanged
       && valueToWrite !== tombstone
-      && selectFields
-      && selectFields.size > 0
       && existingHolder
       && this.isObjectHolder(existingHolder)
+      && (
+        (selectFields && selectFields.size > 0)
+        || !isSuperset(sourceRdpFields, trackedRdpFields)
+      )
     ) {
-      // same cache key so the target tracks the same derived fields as the source.
       valueToWrite = this.mergeInto(
         valueToWrite,
         existingHolder,
         sourceRdpFields,
-        sourceRdpFields,
+        trackedRdpFields,
         selectFields,
       );
     }

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
@@ -26,11 +26,7 @@ import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/Obje
 import type { SimpleOsdkProperties } from "../../../object/SimpleOsdkProperties.js";
 import type { FetchedObjectTypeDefinition } from "../../../ontology/OntologyProvider.js";
 import { InterfaceDefinitions } from "../../../ontology/OntologyProvider.js";
-import {
-  extractRdpFieldNames,
-  mergeObjectFields,
-  mergeSelectFields,
-} from "./rdpFieldOperations.js";
+import { extractRdpFieldNames, reconcileObject } from "./rdpFieldOperations.js";
 
 const mockClient = {} as MinimalClient;
 
@@ -56,6 +52,9 @@ const employeeObjectDef = {
     employeeId: { type: "integer" },
     fullName: { type: "string" },
     office: { type: "string" },
+    rdpField1: { type: "string" },
+    rdpField2: { type: "double" },
+    rdpField3: { type: "string" },
   },
 } satisfies FetchedObjectTypeDefinition;
 
@@ -87,23 +86,44 @@ function getUnderlyingProps(obj: ObjectHolder): SimpleOsdkProperties {
   return obj[UnderlyingOsdkObject] as SimpleOsdkProperties;
 }
 
-describe("rdpFieldOperations", () => {
-  it("extractRdpFieldNames returns empty set for undefined", () => {
+describe("extractRdpFieldNames", () => {
+  it("returns empty set for undefined", () => {
     expect(extractRdpFieldNames(undefined)).toEqual(new Set());
   });
+});
 
-  it("mergeObjectFields returns same object when source has no rdp fields", () => {
+describe("reconcileObject", () => {
+  it("returns the source identity when neither side has rdp fields", () => {
     const source = createTestObject({
       employeeId: 50030,
       fullName: "John Doe",
     });
 
-    const result = mergeObjectFields(source, new Set(), new Set(), undefined);
+    const result = reconcileObject(
+      { value: source, rdpFields: new Set() },
+      { value: undefined, rdpFields: new Set() },
+    );
 
     expect(result).toBe(source);
   });
 
-  it("mergeObjectFields strips rdp fields from source", () => {
+  it("returns the source identity when the rdp sets are equal", () => {
+    const source = createTestObject({
+      employeeId: 50030,
+      rdpField1: "value",
+      rdpField2: 42,
+    });
+    const rdpFields = new Set(["rdpField1", "rdpField2"]);
+
+    const result = reconcileObject(
+      { value: source, rdpFields },
+      { value: undefined, rdpFields },
+    );
+
+    expect(result).toBe(source);
+  });
+
+  it("drops source rdp fields the target does not want", () => {
     const source = createTestObject({
       employeeId: 50030,
       fullName: "John Doe",
@@ -111,11 +131,9 @@ describe("rdpFieldOperations", () => {
       rdpField2: 42,
     });
 
-    const result = mergeObjectFields(
-      source,
-      new Set(["rdpField1", "rdpField2"]),
-      new Set(),
-      undefined,
+    const result = reconcileObject(
+      { value: source, rdpFields: new Set(["rdpField1", "rdpField2"]) },
+      { value: undefined, rdpFields: new Set() },
     );
 
     assertValidObjectHolder(result);
@@ -126,20 +144,7 @@ describe("rdpFieldOperations", () => {
     expect(underlying.rdpField2).toBeUndefined();
   });
 
-  it("mergeObjectFields returns source unchanged when rdp field sets are equal", () => {
-    const source = createTestObject({
-      employeeId: 50030,
-      rdpField1: "value",
-      rdpField2: 42,
-    });
-    const rdpFields = new Set(["rdpField1", "rdpField2"]);
-
-    const result = mergeObjectFields(source, rdpFields, rdpFields, undefined);
-
-    expect(result).toBe(source);
-  });
-
-  it("mergeObjectFields filters to target rdp fields when source is strict superset", () => {
+  it("filters to the target rdp fields when the source is a strict superset", () => {
     const source = createTestObject({
       employeeId: 50030,
       fullName: "John Doe",
@@ -148,11 +153,12 @@ describe("rdpFieldOperations", () => {
       rdpField3: "value3",
     });
 
-    const result = mergeObjectFields(
-      source,
-      new Set(["rdpField1", "rdpField2", "rdpField3"]),
-      new Set(["rdpField1"]),
-      undefined,
+    const result = reconcileObject(
+      {
+        value: source,
+        rdpFields: new Set(["rdpField1", "rdpField2", "rdpField3"]),
+      },
+      { value: undefined, rdpFields: new Set(["rdpField1"]) },
     );
 
     assertValidObjectHolder(result);
@@ -164,7 +170,7 @@ describe("rdpFieldOperations", () => {
     expect(underlying.rdpField3).toBeUndefined();
   });
 
-  it("mergeObjectFields merges source and target rdp fields", () => {
+  it("merges the source and target rdp fields", () => {
     const source = createTestObject({
       employeeId: 50030,
       fullName: "John Doe",
@@ -176,11 +182,9 @@ describe("rdpFieldOperations", () => {
       rdpField2: 999,
     });
 
-    const result = mergeObjectFields(
-      source,
-      new Set(["rdpField1"]),
-      new Set(["rdpField1", "rdpField2"]),
-      target,
+    const result = reconcileObject(
+      { value: source, rdpFields: new Set(["rdpField1"]) },
+      { value: target, rdpFields: new Set(["rdpField1", "rdpField2"]) },
     );
 
     assertValidObjectHolder(result);
@@ -192,7 +196,7 @@ describe("rdpFieldOperations", () => {
     expect(underlying.rdpField2).toBe(999);
   });
 
-  it("mergeObjectFields clears a shared field the source owns but left undefined", () => {
+  it("clears a shared rdp field that the source computed but left undefined", () => {
     const source = createTestObject({
       employeeId: 50030,
       fullName: "John Doe",
@@ -204,22 +208,49 @@ describe("rdpFieldOperations", () => {
       rdpField2: 999,
     });
 
-    const result = mergeObjectFields(
-      source,
-      new Set(["rdpField1"]),
-      new Set(["rdpField1", "rdpField2"]),
-      target,
+    const result = reconcileObject(
+      { value: source, rdpFields: new Set(["rdpField1"]) },
+      { value: target, rdpFields: new Set(["rdpField1", "rdpField2"]) },
     );
 
     assertValidObjectHolder(result);
     const underlying = getUnderlyingProps(result);
     expect(underlying.employeeId).toBe(50030);
     expect(underlying.fullName).toBe("John Doe");
+    // The source query computed rdpField1, so it is authoritative: an undefined
+    // value means the derived value became null and the stale target value must
+    // be cleared rather than retained.
     expect(underlying.rdpField1).toBeUndefined();
+    // rdpField2 was not computed by the source query, so the target's value is
+    // preserved.
     expect(underlying.rdpField2).toBe(999);
   });
 
-  it("mergeObjectFields uses source RDP value when both source and target have non-null", () => {
+  it("preserves a target rdp value the source did not compute", () => {
+    const source = createTestObject({
+      employeeId: 50030,
+      fullName: "John Doe",
+      rdpField1: "source-value",
+    });
+    const target = createTestObject({
+      employeeId: 50030,
+      rdpField1: "old-value",
+      rdpField2: 999,
+    });
+
+    const result = reconcileObject(
+      { value: source, rdpFields: new Set(["rdpField1"]) },
+      { value: target, rdpFields: new Set(["rdpField1", "rdpField2"]) },
+    );
+
+    assertValidObjectHolder(result);
+    const underlying = getUnderlyingProps(result);
+    expect(underlying.rdpField1).toBe("source-value");
+    // rdpField2 was not in the source query, so the target's value survives.
+    expect(underlying.rdpField2).toBe(999);
+  });
+
+  it("uses the source rdp value when both sides have a non-null value", () => {
     const source = createTestObject({
       employeeId: 50030,
       fullName: "John Doe",
@@ -231,21 +262,18 @@ describe("rdpFieldOperations", () => {
       rdpField2: 999,
     });
 
-    const result = mergeObjectFields(
-      source,
-      new Set(["rdpField1"]),
-      new Set(["rdpField1", "rdpField2"]),
-      target,
+    const result = reconcileObject(
+      { value: source, rdpFields: new Set(["rdpField1"]) },
+      { value: target, rdpFields: new Set(["rdpField1", "rdpField2"]) },
     );
 
     assertValidObjectHolder(result);
     const underlying = getUnderlyingProps(result);
-    // Source's non-null value takes precedence when both are non-null
     expect(underlying.rdpField1).toBe("source-value");
     expect(underlying.rdpField2).toBe(999);
   });
 
-  it("mergeObjectFields propagates null RDP values from source", () => {
+  it("propagates an explicit null rdp value from the source", () => {
     const source = createTestObject({
       employeeId: 50030,
       fullName: "John Doe",
@@ -257,11 +285,9 @@ describe("rdpFieldOperations", () => {
       rdpField2: 999,
     });
 
-    const result = mergeObjectFields(
-      source,
-      new Set(["rdpField1"]),
-      new Set(["rdpField1", "rdpField2"]),
-      target,
+    const result = reconcileObject(
+      { value: source, rdpFields: new Set(["rdpField1"]) },
+      { value: target, rdpFields: new Set(["rdpField1", "rdpField2"]) },
     );
 
     assertValidObjectHolder(result);
@@ -270,18 +296,16 @@ describe("rdpFieldOperations", () => {
     expect(underlying.rdpField2).toBe(999);
   });
 
-  it("mergeObjectFields handles undefined target", () => {
+  it("handles an undefined target", () => {
     const source = createTestObject({
       employeeId: 50030,
       fullName: "John Doe",
       rdpField1: "source-rdp1",
     });
 
-    const result = mergeObjectFields(
-      source,
-      new Set(["rdpField1"]),
-      new Set(["rdpField1", "rdpField2"]),
-      undefined,
+    const result = reconcileObject(
+      { value: source, rdpFields: new Set(["rdpField1"]) },
+      { value: undefined, rdpFields: new Set(["rdpField1", "rdpField2"]) },
     );
 
     assertValidObjectHolder(result);
@@ -290,54 +314,172 @@ describe("rdpFieldOperations", () => {
     expect(underlying.rdpField1).toBe("source-rdp1");
     expect(underlying.rdpField2).toBeUndefined();
   });
-});
 
-describe("mergeSelectFields", () => {
-  it("merges selected fields from source, preserves existing for unselected", () => {
+  it("handles the full mixed case in one merge", () => {
     const source = createTestObject({
       employeeId: 50030,
-      fullName: "Updated Name",
+      fullName: "John Doe",
+      rdpField1: "source-shared",
+      rdpField3: "source-only",
     });
-    const existing = createTestObject({
+    const target = createTestObject({
       employeeId: 50030,
-      fullName: "Old Name",
-      office: "NYC",
+      rdpField1: "target-shared-stale",
+      rdpField2: 999,
     });
 
-    const selectFields = new Set(["fullName"]);
-    const result = mergeSelectFields(source, selectFields, existing, new Set());
-
-    assertValidObjectHolder(result);
-    const underlying = getUnderlyingProps(result);
-    expect(underlying.fullName).toBe("Updated Name");
-    expect(underlying.office).toBe("NYC");
-    expect(underlying.employeeId).toBe(50030);
-  });
-
-  it("keeps the source's derived field on a partial write", () => {
-    const source = createTestObject({
-      employeeId: 50030,
-      fullName: "Updated Name",
-      computedScore: 42,
-    });
-    const existing = createTestObject({
-      employeeId: 50030,
-      fullName: "Old Name",
-      office: "NYC",
-      computedScore: 7,
-    });
-
-    const result = mergeSelectFields(
-      source,
-      new Set(["fullName"]),
-      existing,
-      new Set(["computedScore"]),
+    const result = reconcileObject(
+      { value: source, rdpFields: new Set(["rdpField1", "rdpField3"]) },
+      { value: target, rdpFields: new Set(["rdpField1", "rdpField2"]) },
     );
 
     assertValidObjectHolder(result);
     const underlying = getUnderlyingProps(result);
-    expect(underlying.fullName).toBe("Updated Name");
-    expect(underlying.office).toBe("NYC");
+    expect(underlying.fullName).toBe("John Doe");
+    // Shared rdp: the source query is authoritative.
+    expect(underlying.rdpField1).toBe("source-shared");
+    // Source-only rdp the target did not ask for: dropped.
+    expect(underlying.rdpField3).toBeUndefined();
+    // Target-only rdp the source did not compute: preserved.
+    expect(underlying.rdpField2).toBe(999);
+  });
+
+  it("keeps a shared rdp whose name is not a base property (production shape)", () => {
+    // computedScore is deliberately not a schema property, mirroring production
+    // where rdp names never appear in objectDef.properties.
+    const source = createTestObject({
+      employeeId: 50030,
+      fullName: "John Doe",
+      computedScore: 42,
+    });
+    const target = createTestObject({
+      employeeId: 50030,
+      computedScore: 7,
+    });
+
+    const result = reconcileObject(
+      { value: source, rdpFields: new Set(["computedScore", "extraDerived"]) },
+      { value: target, rdpFields: new Set(["computedScore"]) },
+    );
+
+    assertValidObjectHolder(result);
+    const underlying = getUnderlyingProps(result);
+    expect(underlying.fullName).toBe("John Doe");
+    // The source computed computedScore, so it must survive the merge even
+    // though the name is not in objectDef.properties.
     expect(underlying.computedScore).toBe(42);
+  });
+
+  it("clears a base prop the target cached but a full load omitted", () => {
+    // No loadedBaseFields means a full load owns every base prop, so an omitted
+    // one clears rather than resurrecting the cached value.
+    const source = createTestObject({
+      employeeId: 50030,
+      fullName: "John Doe",
+    });
+    const target = createTestObject({
+      employeeId: 50030,
+      fullName: "John Doe",
+      office: "NYC",
+    });
+
+    const result = reconcileObject(
+      { value: source, rdpFields: new Set() },
+      { value: target, rdpFields: new Set() },
+    );
+
+    assertValidObjectHolder(result);
+    const underlying = getUnderlyingProps(result);
+    expect(underlying.fullName).toBe("John Doe");
+    expect(underlying.office).toBeUndefined();
+  });
+
+  describe("with a partial load", () => {
+    it("overlays the loaded base props and keeps the rest", () => {
+      const source = createTestObject({
+        employeeId: 50030,
+        fullName: "Updated Name",
+        office: "SF",
+      });
+      const existing = createTestObject({
+        employeeId: 50030,
+        fullName: "Old Name",
+        office: "NYC",
+      });
+
+      const result = reconcileObject(
+        {
+          value: source,
+          rdpFields: new Set(),
+          loadedBaseFields: new Set(["fullName"]),
+        },
+        { value: existing, rdpFields: new Set() },
+      );
+
+      assertValidObjectHolder(result);
+      const underlying = getUnderlyingProps(result);
+      expect(underlying.fullName).toBe("Updated Name");
+      // office was not loaded, so the existing value is kept.
+      expect(underlying.office).toBe("NYC");
+      expect(underlying.employeeId).toBe(50030);
+    });
+
+    it("carries derived fields through the merge instead of dropping them", () => {
+      // A partial write with a derived property used to drop the derived field,
+      // since the base merge only kept schema props (rdp names are not there).
+      const source = createTestObject({
+        employeeId: 50030,
+        fullName: "Updated Name",
+        computedScore: 42,
+      });
+      const existing = createTestObject({
+        employeeId: 50030,
+        fullName: "Old Name",
+        office: "NYC",
+        computedScore: 7,
+      });
+
+      const result = reconcileObject(
+        {
+          value: source,
+          rdpFields: new Set(["computedScore"]),
+          loadedBaseFields: new Set(["fullName"]),
+        },
+        { value: existing, rdpFields: new Set(["computedScore"]) },
+      );
+
+      assertValidObjectHolder(result);
+      const underlying = getUnderlyingProps(result);
+      expect(underlying.fullName).toBe("Updated Name");
+      expect(underlying.office).toBe("NYC");
+      // The source recomputed the derived field; it must survive.
+      expect(underlying.computedScore).toBe(42);
+    });
+
+    it("clears a loaded base prop the source omitted", () => {
+      // fullName was loaded but omitted (cleared); an unloaded prop is kept.
+      const source = createTestObject({
+        employeeId: 50030,
+      });
+      const existing = createTestObject({
+        employeeId: 50030,
+        fullName: "Old Name",
+        office: "NYC",
+      });
+
+      const result = reconcileObject(
+        {
+          value: source,
+          rdpFields: new Set(),
+          loadedBaseFields: new Set(["fullName"]),
+        },
+        { value: existing, rdpFields: new Set() },
+      );
+
+      assertValidObjectHolder(result);
+      const underlying = getUnderlyingProps(result);
+      expect(underlying.fullName).toBeUndefined();
+      expect(underlying.office).toBe("NYC");
+    });
   });
 });

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.test.ts
@@ -48,13 +48,13 @@ const employeeObjectDef = {
   links: {},
   implements: [],
   [InterfaceDefinitions]: {},
+  // Derived-property names (rdpField1/2/3, computedScore, ...) are deliberately
+  // absent here: in production an RDP name is never a schema property, and the
+  // merge relies on that to tell base properties from derived ones.
   properties: {
     employeeId: { type: "integer" },
     fullName: { type: "string" },
     office: { type: "string" },
-    rdpField1: { type: "string" },
-    rdpField2: { type: "double" },
-    rdpField3: { type: "string" },
   },
 } satisfies FetchedObjectTypeDefinition;
 

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
@@ -39,12 +39,29 @@ export function extractRdpFieldNames(
 }
 
 /**
- * Throws a clear, actionable error if `objectDef` is undefined. The RDP merge
- * path operates on concrete `ObjectHolder`s only; if an `InterfaceHolder` ever
- * leaks through without being unwrapped via `storeOsdkInstances`, the missing
- * ObjectDefRef would surface as a confusing "cannot read property 'properties'
- * of undefined" crash. Use this helper to gate access to `objectDef.properties`
- * so the failure mode names the actual invariant violation.
+ * The fresh value being written. `rdpFields` is the derived-field set the source
+ * computed; `loadedBaseFields` is the base props it loaded, or `undefined` for a
+ * full load that owns every base prop (so an omitted base prop clears).
+ */
+export interface ReconcileSource {
+  value: ObjectHolder;
+  rdpFields: ReadonlySet<string>;
+  loadedBaseFields?: ReadonlySet<string>;
+}
+
+/**
+ * The cache entry being written into: its current `value` (undefined on first
+ * write) and the derived-field set its key carries.
+ */
+export interface ReconcileTarget {
+  value: ObjectHolder | undefined;
+  rdpFields: ReadonlySet<string>;
+}
+
+/**
+ * Gates access to `objectDef.properties`: the merge path takes concrete
+ * `ObjectHolder`s only, and a leaked unwrapped `InterfaceHolder` has no
+ * ObjectDefRef.
  */
 export function requireObjectDef(
   objectDef: FetchedObjectTypeDefinition | undefined,
@@ -62,177 +79,118 @@ export function requireObjectDef(
   return objectDef;
 }
 
-function stripRdpFields(
-  value: ObjectHolder,
-  rdpFields: ReadonlySet<string>,
-): ObjectHolder {
-  if (rdpFields.size === 0) {
-    return value;
-  }
-
-  const underlying = value[UnderlyingOsdkObject] as SimpleOsdkProperties;
-  const objectDef = requireObjectDef(value[ObjectDefRef], underlying);
-
-  const newProps: SimpleOsdkProperties = {
-    $apiName: underlying.$apiName,
-    $objectType: underlying.$objectType,
-    $primaryKey: underlying.$primaryKey,
-    $title: underlying.$title,
-    $rid: underlying.$rid,
-  };
-
-  for (const key of Object.keys(underlying)) {
-    if (key in objectDef.properties && !rdpFields.has(key)) {
-      newProps[key] = underlying[key];
-    }
-  }
-
-  return createOsdkObject(value[ClientRef], objectDef, newProps);
-}
-
-function isSuperset(
-  superset: ReadonlySet<string>,
-  subset: ReadonlySet<string>,
+function sameMembers(
+  a: ReadonlySet<string>,
+  b: ReadonlySet<string>,
 ): boolean {
-  for (const field of subset) {
-    if (!superset.has(field)) {
+  if (a.size !== b.size) {
+    return false;
+  }
+  for (const field of a) {
+    if (!b.has(field)) {
       return false;
     }
   }
   return true;
 }
 
-function filterToRdpFields(
-  value: ObjectHolder,
-  rdpFieldsToKeep: ReadonlySet<string>,
-  sourceRdpFields: ReadonlySet<string>,
-): ObjectHolder {
-  const underlying = value[UnderlyingOsdkObject] as SimpleOsdkProperties;
-  const objectDef = requireObjectDef(value[ObjectDefRef], underlying);
+/**
+ * A schema property that is not a derived field of this key. The rdp set wins:
+ * a name that is both a schema prop and an rdp field counts as derived.
+ */
+function isBaseProperty(
+  key: string,
+  objectDef: FetchedObjectTypeDefinition,
+  rdpFields: ReadonlySet<string>,
+): boolean {
+  return key in objectDef.properties && !rdpFields.has(key);
+}
 
-  const newProps: SimpleOsdkProperties = {
-    $apiName: underlying.$apiName,
-    $objectType: underlying.$objectType,
-    $primaryKey: underlying.$primaryKey,
-    $title: underlying.$title,
-    $rid: underlying.$rid,
-  };
-
-  for (const key of Object.keys(underlying)) {
-    // keep the target's derived fields and every base prop.
-    if (sourceRdpFields.has(key)) {
-      if (rdpFieldsToKeep.has(key)) {
-        newProps[key] = underlying[key];
+/**
+ * Resolve `fields` into `into`: a field the source owns (all of them when
+ * `ownedBySource` is undefined) comes from the source, where an omitted field
+ * clears; otherwise the target's cached value is kept.
+ */
+function resolveFields(
+  into: SimpleOsdkProperties,
+  fields: Iterable<string>,
+  ownedBySource: ReadonlySet<string> | undefined,
+  sourceProps: SimpleOsdkProperties,
+  targetProps: SimpleOsdkProperties | undefined,
+): void {
+  for (const field of fields) {
+    if (ownedBySource === undefined || ownedBySource.has(field)) {
+      if (field in sourceProps) {
+        into[field] = sourceProps[field];
       }
-    } else if (key in objectDef.properties) {
-      newProps[key] = underlying[key];
+    } else if (targetProps && field in targetProps) {
+      into[field] = targetProps[field];
     }
   }
-
-  return createOsdkObject(value[ClientRef], objectDef, newProps);
 }
 
-export function mergeSelectFields(
-  sourceValue: ObjectHolder,
-  selectFields: ReadonlySet<string>,
-  existingValue: ObjectHolder,
-  sourceRdpFields: ReadonlySet<string>,
+/**
+ * Reconcile a freshly written `source` into the `target` cached at a key. One
+ * rule: the source wins for a field it owns (an omitted owned field clears),
+ * else the target keeps its value. Returns the source as-is when it is a no-op.
+ */
+export function reconcileObject(
+  source: ReconcileSource,
+  target: ReconcileTarget,
 ): ObjectHolder {
-  const sourceUnderlying =
-    sourceValue[UnderlyingOsdkObject] as SimpleOsdkProperties;
-  const existingUnderlying =
-    existingValue[UnderlyingOsdkObject] as SimpleOsdkProperties;
-  const objectDef = requireObjectDef(
-    sourceValue[ObjectDefRef],
-    sourceUnderlying,
-  );
+  if (
+    target.value === undefined
+    && source.loadedBaseFields === undefined
+    && sameMembers(source.rdpFields, target.rdpFields)
+  ) {
+    return source.value;
+  }
 
-  const newProps: SimpleOsdkProperties = {
-    $apiName: sourceUnderlying.$apiName,
-    $objectType: sourceUnderlying.$objectType,
-    $primaryKey: sourceUnderlying.$primaryKey,
-    $title: sourceUnderlying.$title,
-    $rid: sourceUnderlying.$rid ?? existingUnderlying.$rid,
+  const sourceProps = source
+    .value[UnderlyingOsdkObject] as SimpleOsdkProperties;
+  const targetProps = target.value?.[UnderlyingOsdkObject] as
+    | SimpleOsdkProperties
+    | undefined;
+  const objectDef = requireObjectDef(source.value[ObjectDefRef], sourceProps);
+
+  const result: SimpleOsdkProperties = {
+    $apiName: sourceProps.$apiName,
+    $objectType: sourceProps.$objectType,
+    $primaryKey: sourceProps.$primaryKey,
+    $title: sourceProps.$title,
+    $rid: sourceProps.$rid ?? targetProps?.$rid,
   };
 
-  for (const key of Object.keys(existingUnderlying)) {
-    if (key in objectDef.properties) {
-      newProps[key] = existingUnderlying[key];
+  // Base props from either side; the source's loaded set owns them.
+  const baseFields = new Set<string>();
+  for (const key of Object.keys(sourceProps)) {
+    if (isBaseProperty(key, objectDef, source.rdpFields)) {
+      baseFields.add(key);
     }
   }
-
-  for (const key of Object.keys(sourceUnderlying)) {
-    // Take the source's derived fields, plus the base props it selected.
-    if (sourceRdpFields.has(key)) {
-      newProps[key] = sourceUnderlying[key];
-    } else if (key in objectDef.properties && selectFields.has(key)) {
-      newProps[key] = sourceUnderlying[key];
-    }
-  }
-
-  return createOsdkObject(sourceValue[ClientRef], objectDef, newProps);
-}
-
-export function mergeObjectFields(
-  sourceValue: ObjectHolder,
-  sourceRdpFields: ReadonlySet<string>,
-  targetRdpFields: ReadonlySet<string>,
-  targetCurrentValue: ObjectHolder | undefined,
-): ObjectHolder {
-  if (targetRdpFields.size === 0) {
-    return stripRdpFields(sourceValue, sourceRdpFields);
-  }
-
-  if (isSuperset(sourceRdpFields, targetRdpFields)) {
-    if (sourceRdpFields.size === targetRdpFields.size) {
-      return sourceValue;
-    }
-    return filterToRdpFields(sourceValue, targetRdpFields, sourceRdpFields);
-  }
-
-  const sourceUnderlying =
-    sourceValue[UnderlyingOsdkObject] as SimpleOsdkProperties;
-  const objectDef = requireObjectDef(
-    sourceValue[ObjectDefRef],
-    sourceUnderlying,
-  );
-
-  const newProps: SimpleOsdkProperties = {
-    $apiName: sourceUnderlying.$apiName,
-    $objectType: sourceUnderlying.$objectType,
-    $primaryKey: sourceUnderlying.$primaryKey,
-    $title: sourceUnderlying.$title,
-    $rid: sourceUnderlying.$rid,
-  };
-
-  for (const key of Object.keys(sourceUnderlying)) {
-    if (key in objectDef.properties) {
-      newProps[key] = sourceUnderlying[key];
-    }
-  }
-
-  // take the source's derived fields the target wants. if the source left one
-  // out then it just clears.
-  for (const field of sourceRdpFields) {
-    if (targetRdpFields.has(field) && field in sourceUnderlying) {
-      newProps[field] = sourceUnderlying[field];
-    }
-  }
-
-  if (targetCurrentValue) {
-    const targetUnderlying =
-      targetCurrentValue[UnderlyingOsdkObject] as SimpleOsdkProperties;
-    // Keep the target's value for derived fields the source did not compute.
-    for (const field of targetRdpFields) {
-      if (!sourceRdpFields.has(field) && field in targetUnderlying) {
-        newProps[field] = targetUnderlying[field];
+  if (targetProps) {
+    for (const key of Object.keys(targetProps)) {
+      if (isBaseProperty(key, objectDef, target.rdpFields)) {
+        baseFields.add(key);
       }
     }
   }
-
-  return createOsdkObject(
-    sourceValue[ClientRef],
-    objectDef,
-    newProps,
+  resolveFields(
+    result,
+    baseFields,
+    source.loadedBaseFields,
+    sourceProps,
+    targetProps,
   );
+
+  // Derived fields the target key carries; the source owns the ones it computed.
+  resolveFields(
+    result,
+    target.rdpFields,
+    source.rdpFields,
+    sourceProps,
+    targetProps,
+  );
+
+  return createOsdkObject(source.value[ClientRef], objectDef, result);
 }

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
@@ -38,21 +38,21 @@ export function extractRdpFieldNames(
   return new Set(Object.keys(rdpConfig));
 }
 
-/** A newly written value, with its derived fields and the base props it loaded. */
+/** a newly written value, with the derived fields and base props it loaded. */
 export interface ReconcileSource {
   value: ObjectHolder;
   rdpFields: ReadonlySet<string>;
-  /** Undefined means a full load that owns every base prop, so a missing prop clears. */
+  /** undefined means a full load that owns every base prop, so a missing one clears. */
   loadedBaseFields?: ReadonlySet<string>;
 }
 
-/** The cache entry being written into, with the derived fields its key carries. */
+/** the cache entry we're writing into, with the derived fields its key carries. */
 export interface ReconcileTarget {
   value: ObjectHolder | undefined;
   rdpFields: ReadonlySet<string>;
 }
 
-/** The merge path only takes ObjectHolders; a leaked InterfaceHolder has no ObjectDefRef. */
+/** the merge path only takes object holders. a leaked interface holder has no object def. */
 export function requireObjectDef(
   objectDef: FetchedObjectTypeDefinition | undefined,
   instance: { $apiName?: string; $objectType?: string },
@@ -84,7 +84,7 @@ function sameMembers(
   return true;
 }
 
-/** Copy one property from the side that owns it. Absent means left out, which clears it. */
+/** copy a prop from whichever side owns it. if that side left it out we drop it and it clears. */
 function copyProperty(
   name: string,
   from: SimpleOsdkProperties | undefined,
@@ -95,11 +95,7 @@ function copyProperty(
   }
 }
 
-/**
- * The schema properties present on either side. A derived-property name is
- * never a schema property, so schema membership alone separates base from
- * derived fields.
- */
+/** the schema props found on either side. */
 function baseProperties(
   objectDef: FetchedObjectTypeDefinition,
   sourceProps: SimpleOsdkProperties,
@@ -121,7 +117,6 @@ function baseProperties(
   return names;
 }
 
-/** Did this load fetch this base property? A full load (no `$select`) fetched all of them. */
 function sourceLoadedBaseProperty(
   source: ReconcileSource,
   name: string,
@@ -131,25 +126,21 @@ function sourceLoadedBaseProperty(
 }
 
 /**
- * Merge a freshly written object (`source`) into the value cached for a query
- * (`target`). Each field is taken from whichever side owns it:
+ * merges a freshly written object into the value cached for a query. every field
+ * comes from whichever side owns it. the source owns the base props it loaded and
+ * the derived props it computed, and if it owns a field but sent nothing back that
+ * field is now empty so we clear it. the target keeps everything the source does
+ * not own.
  *
- *   - the source owns the base properties it loaded and the derived properties
- *     it computed; a field it owns but did not return is now empty, so it is
- *     cleared;
- *   - the target keeps every field the source does not own.
- *
- * The result is stored for the target query, so it carries only that query's
- * derived properties; a derived property the source computed for a different
- * query is dropped.
+ * the merged value gets stored for the target query so it only carries that query's
+ * derived props. a derived prop the source computed for some other query gets dropped.
  */
 export function reconcileObject(
   source: ReconcileSource,
   target: ReconcileTarget,
 ): ObjectHolder {
-  // Nothing to merge: the first write to this key, already matching it (a full
-  // load with the same derived properties). Return it as-is to keep the same
-  // reference for subscribers.
+  // nothing to merge here. the first write to a key already matches when it's a
+  // full load with the same derived props, so we hand back the same object.
   if (
     target.value === undefined
     && source.loadedBaseFields === undefined
@@ -173,7 +164,7 @@ export function reconcileObject(
     $rid: sourceProps.$rid ?? targetProps?.$rid,
   };
 
-  // Base properties: the source owns the ones it loaded; the target keeps the rest.
+  // base props come from the source when it loaded them, otherwise we keep what's cached.
   for (const name of baseProperties(objectDef, sourceProps, targetProps)) {
     const owner = sourceLoadedBaseProperty(source, name)
       ? sourceProps
@@ -181,7 +172,8 @@ export function reconcileObject(
     copyProperty(name, owner, result);
   }
 
-  // Derived properties the target query carries: the source owns the ones it recomputed.
+  // derived props the target tracks come from the source when it recomputed them,
+  // otherwise we keep the cache.
   for (const name of target.rdpFields) {
     const owner = source.rdpFields.has(name) ? sourceProps : targetProps;
     copyProperty(name, owner, result);

--- a/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
+++ b/packages/client/src/observable/internal/utils/rdpFieldOperations.ts
@@ -38,31 +38,21 @@ export function extractRdpFieldNames(
   return new Set(Object.keys(rdpConfig));
 }
 
-/**
- * The fresh value being written. `rdpFields` is the derived-field set the source
- * computed; `loadedBaseFields` is the base props it loaded, or `undefined` for a
- * full load that owns every base prop (so an omitted base prop clears).
- */
+/** A newly written value, with its derived fields and the base props it loaded. */
 export interface ReconcileSource {
   value: ObjectHolder;
   rdpFields: ReadonlySet<string>;
+  /** Undefined means a full load that owns every base prop, so a missing prop clears. */
   loadedBaseFields?: ReadonlySet<string>;
 }
 
-/**
- * The cache entry being written into: its current `value` (undefined on first
- * write) and the derived-field set its key carries.
- */
+/** The cache entry being written into, with the derived fields its key carries. */
 export interface ReconcileTarget {
   value: ObjectHolder | undefined;
   rdpFields: ReadonlySet<string>;
 }
 
-/**
- * Gates access to `objectDef.properties`: the merge path takes concrete
- * `ObjectHolder`s only, and a leaked unwrapped `InterfaceHolder` has no
- * ObjectDefRef.
- */
+/** The merge path only takes ObjectHolders; a leaked InterfaceHolder has no ObjectDefRef. */
 export function requireObjectDef(
   objectDef: FetchedObjectTypeDefinition | undefined,
   instance: { $apiName?: string; $objectType?: string },
@@ -94,50 +84,72 @@ function sameMembers(
   return true;
 }
 
-/**
- * A schema property that is not a derived field of this key. The rdp set wins:
- * a name that is both a schema prop and an rdp field counts as derived.
- */
-function isBaseProperty(
-  key: string,
-  objectDef: FetchedObjectTypeDefinition,
-  rdpFields: ReadonlySet<string>,
-): boolean {
-  return key in objectDef.properties && !rdpFields.has(key);
-}
-
-/**
- * Resolve `fields` into `into`: a field the source owns (all of them when
- * `ownedBySource` is undefined) comes from the source, where an omitted field
- * clears; otherwise the target's cached value is kept.
- */
-function resolveFields(
+/** Copy one property from the side that owns it. Absent means left out, which clears it. */
+function copyProperty(
+  name: string,
+  from: SimpleOsdkProperties | undefined,
   into: SimpleOsdkProperties,
-  fields: Iterable<string>,
-  ownedBySource: ReadonlySet<string> | undefined,
-  sourceProps: SimpleOsdkProperties,
-  targetProps: SimpleOsdkProperties | undefined,
 ): void {
-  for (const field of fields) {
-    if (ownedBySource === undefined || ownedBySource.has(field)) {
-      if (field in sourceProps) {
-        into[field] = sourceProps[field];
-      }
-    } else if (targetProps && field in targetProps) {
-      into[field] = targetProps[field];
-    }
+  if (from && name in from) {
+    into[name] = from[name];
   }
 }
 
 /**
- * Reconcile a freshly written `source` into the `target` cached at a key. One
- * rule: the source wins for a field it owns (an omitted owned field clears),
- * else the target keeps its value. Returns the source as-is when it is a no-op.
+ * The schema properties present on either side. A derived-property name is
+ * never a schema property, so schema membership alone separates base from
+ * derived fields.
+ */
+function baseProperties(
+  objectDef: FetchedObjectTypeDefinition,
+  sourceProps: SimpleOsdkProperties,
+  targetProps: SimpleOsdkProperties | undefined,
+): Set<string> {
+  const names = new Set<string>();
+  for (const name of Object.keys(sourceProps)) {
+    if (name in objectDef.properties) {
+      names.add(name);
+    }
+  }
+  if (targetProps) {
+    for (const name of Object.keys(targetProps)) {
+      if (name in objectDef.properties) {
+        names.add(name);
+      }
+    }
+  }
+  return names;
+}
+
+/** Did this load fetch this base property? A full load (no `$select`) fetched all of them. */
+function sourceLoadedBaseProperty(
+  source: ReconcileSource,
+  name: string,
+): boolean {
+  return source.loadedBaseFields === undefined
+    || source.loadedBaseFields.has(name);
+}
+
+/**
+ * Merge a freshly written object (`source`) into the value cached for a query
+ * (`target`). Each field is taken from whichever side owns it:
+ *
+ *   - the source owns the base properties it loaded and the derived properties
+ *     it computed; a field it owns but did not return is now empty, so it is
+ *     cleared;
+ *   - the target keeps every field the source does not own.
+ *
+ * The result is stored for the target query, so it carries only that query's
+ * derived properties; a derived property the source computed for a different
+ * query is dropped.
  */
 export function reconcileObject(
   source: ReconcileSource,
   target: ReconcileTarget,
 ): ObjectHolder {
+  // Nothing to merge: the first write to this key, already matching it (a full
+  // load with the same derived properties). Return it as-is to keep the same
+  // reference for subscribers.
   if (
     target.value === undefined
     && source.loadedBaseFields === undefined
@@ -161,36 +173,19 @@ export function reconcileObject(
     $rid: sourceProps.$rid ?? targetProps?.$rid,
   };
 
-  // Base props from either side; the source's loaded set owns them.
-  const baseFields = new Set<string>();
-  for (const key of Object.keys(sourceProps)) {
-    if (isBaseProperty(key, objectDef, source.rdpFields)) {
-      baseFields.add(key);
-    }
+  // Base properties: the source owns the ones it loaded; the target keeps the rest.
+  for (const name of baseProperties(objectDef, sourceProps, targetProps)) {
+    const owner = sourceLoadedBaseProperty(source, name)
+      ? sourceProps
+      : targetProps;
+    copyProperty(name, owner, result);
   }
-  if (targetProps) {
-    for (const key of Object.keys(targetProps)) {
-      if (isBaseProperty(key, objectDef, target.rdpFields)) {
-        baseFields.add(key);
-      }
-    }
-  }
-  resolveFields(
-    result,
-    baseFields,
-    source.loadedBaseFields,
-    sourceProps,
-    targetProps,
-  );
 
-  // Derived fields the target key carries; the source owns the ones it computed.
-  resolveFields(
-    result,
-    target.rdpFields,
-    source.rdpFields,
-    sourceProps,
-    targetProps,
-  );
+  // Derived properties the target query carries: the source owns the ones it recomputed.
+  for (const name of target.rdpFields) {
+    const owner = source.rdpFields.has(name) ? sourceProps : targetProps;
+    copyProperty(name, owner, result);
+  }
 
   return createOsdkObject(source.value[ClientRef], objectDef, result);
 }


### PR DESCRIPTION
builds on #3541. folds base-property and derived-field reconciliation into one rule in reconcileObject, so the cache merge has a single code path instead of separate select and rdp merges

• replace mergeRdpFields with reconcileObject: the source owns the base props it loaded and the derived fields it computed, an omitted owned field clears, otherwise the target's cached value is kept
• track loadedBaseFields so a full load clears the base props it omits while a partial load keeps the props it did not load
• resolve base props by schema and derived fields by the rdp sets in one pass