### PR TITLE
Revert 3348

### DIFF
--- a/.changeset/quiet-melons-burn.md
+++ b/.changeset/quiet-melons-burn.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Revert the empty-where-clause runtime checks added in #3348. `modernToLegacyWhereClause` no longer throws on an empty clause, and `.where({})` no longer short-circuits to a no-op, restoring the pre-#3348 behavior where an empty clause lowers to an empty AND. Note: this reintroduces the original behavior where a `.where({})` (including no-filter `useOsdkObjects`/`useOsdkAggregation` queries via the observable layer) emits an empty AND on the wire, which some object-storage backends reject on the aggregate path.

--- a/packages/client/src/derivedProperties/createWithPropertiesObjectSet.ts
+++ b/packages/client/src/derivedProperties/createWithPropertiesObjectSet.ts
@@ -42,13 +42,6 @@ export function createWithPropertiesObjectSet<
       }, definitionMap);
     },
     where: (clause) => {
-      if (clause == null || Object.keys(clause).length === 0) {
-        return createWithPropertiesObjectSet(
-          objectType,
-          objectSet,
-          definitionMap,
-        );
-      }
       const rdpNames = new Set(definitionMap.keys());
       return createWithPropertiesObjectSet(objectType, {
         type: "filter",

--- a/packages/client/src/internal/conversions/modernToLegacyWhereClause.ts
+++ b/packages/client/src/internal/conversions/modernToLegacyWhereClause.ts
@@ -76,11 +76,6 @@ export function modernToLegacyWhereClause<
   const parts = Object.entries(whereClause).map(([key, value]) => ({
     [key]: value,
   })) as WhereClause<T, RDPs>[];
-  invariant(
-    parts.length > 0,
-    "Cannot convert an empty where clause to a filter. "
-      + "Skip the .where() call entirely when no conditions are provided.",
-  );
   if (parts.length === 1) {
     return modernToLegacyWhereClauseInner(
       whereClause,

--- a/packages/client/src/objectSet/ObjectSet.test.ts
+++ b/packages/client/src/objectSet/ObjectSet.test.ts
@@ -56,7 +56,6 @@ import {
   createMockCaptureClient,
   getLastObjectSetRequest,
 } from "../util/mockCaptureClient.js";
-import { getWireObjectSet } from "./createObjectSet.js";
 
 type ApiNameAsString<
   T extends ObjectOrInterfaceDefinition,
@@ -498,11 +497,6 @@ describe("ObjectSet", () => {
       employeeId: { $in: ids },
     });
     expect(objectSet).toBeDefined();
-  });
-
-  it(".where({}) is a no-op (no empty-AND filter on the wire)", () => {
-    const base = client(Employee);
-    expect(getWireObjectSet(base.where({}))).toEqual(getWireObjectSet(base));
   });
 
   it("does not allow arbitrary keys when no properties", () => {

--- a/packages/client/src/objectSet/createObjectSet.ts
+++ b/packages/client/src/objectSet/createObjectSet.ts
@@ -132,9 +132,6 @@ export function createObjectSet<Q extends ObjectOrInterfaceDefinition>(
     ) as ObjectSet<Q>["fetchPageWithErrors"],
 
     where: (clause) => {
-      if (clause == null || Object.keys(clause).length === 0) {
-        return clientCtx.objectSetFactory(objectType, clientCtx, objectSet);
-      }
       return clientCtx.objectSetFactory(objectType, clientCtx, {
         type: "filter",
         objectSet,


### PR DESCRIPTION
Revert the empty-where-clause runtime checks added in #3348. `modernToLegacyWhereClause` no longer throws on an empty clause, and `.where({})` no longer short-circuits to a no-op, restoring the pre-#3348 behavior where an empty clause lowers to an empty AND. Note: this reintroduces the original behavior where a `.where({})` (including no-filter `useOsdkObjects`/`useOsdkAggregation` queries via the observable layer) emits an empty AND on the wire, which some object-storage backends reject on the aggregate path.