### PR TITLE
[react-components] Allow interface object sets in ObjectTable

### DIFF
--- a/.changeset/interface-objectset-objecttable.md
+++ b/.changeset/interface-objectset-objecttable.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+ObjectTable now honors a caller-supplied `objectSet` for interface types (previously it was ignored for interfaces and the table fell back to fetching by type, leaving only a property `where` to filter). This lets an interface-backed table be driven by a composed/filtered object set, e.g. a pivot-derived set. For an interface object set, rows expose the interface's declared properties (plus any `withProperties`); concrete-only properties are not loaded.

--- a/packages/react-components/src/object-table/ObjectTableApi.ts
+++ b/packages/react-components/src/object-table/ObjectTableApi.ts
@@ -297,7 +297,12 @@ export interface ObjectTableProps<
 
   /**
    * The set of objects to show in the table.
-   * If provided and the objectType is not an interface, the table will use objectSet to fetch objects instead of fetching based on objectType.
+   * If provided, the table fetches through this object set instead of fetching based on
+   * objectType. Supported for both object and interface types.
+   *
+   * For an interface object set, rows expose the interface's declared properties (plus any
+   * `withProperties` derived from `rdp` column locators); the underlying concrete object's
+   * non-interface properties are not loaded. Use objectType-based fetching if you need those.
    */
   objectSet?: ObjectSet<Q>;
 

--- a/packages/react-components/src/object-table/hooks/__tests__/useObjectTableData.test.tsx
+++ b/packages/react-components/src/object-table/hooks/__tests__/useObjectTableData.test.tsx
@@ -373,7 +373,7 @@ describe(useObjectTableData, () => {
     );
   });
 
-  it("when objectSet is provided but type is interface, only enables useOsdkObjects ", () => {
+  it("when objectSet is provided for an interface, enables useObjectSet (not useOsdkObjects)", () => {
     renderHook(
       () =>
         useObjectTableData(
@@ -386,16 +386,16 @@ describe(useObjectTableData, () => {
       { wrapper },
     );
 
-    expect(useOsdkObjects).toHaveBeenCalledWith(
-      TestInterfaceType,
+    expect(useObjectSet).toHaveBeenCalledWith(
+      mockObjectSet,
       expect.objectContaining({
         enabled: true,
         pageSize: 50,
       }),
     );
 
-    expect(useObjectSet).toHaveBeenCalledWith(
-      undefined,
+    expect(useOsdkObjects).toHaveBeenCalledWith(
+      TestInterfaceType,
       expect.objectContaining({
         enabled: false,
         pageSize: 50,

--- a/packages/react-components/src/object-table/hooks/useObjectTableData.ts
+++ b/packages/react-components/src/object-table/hooks/useObjectTableData.ts
@@ -120,12 +120,11 @@ export function useObjectTableData<
     );
   }, [columnDefinitions]);
 
-  // When objectSet is provided and it's an object type, use useObjectSet. Otherwise, use useOsdkObjects.
-  const isObjectType = objectOrInterfaceType.type === "object";
-  const shouldUseObjectSet = !!objectSet && isObjectType;
+  // Use the caller's objectSet whenever provided (object or interface types), else fetch
+  // by type. For an interface objectSet, rows carry interface-declared props (+ withProperties)
+  // only, not the full underlying object — see the objectSet prop docs.
+  const shouldUseObjectSet = !!objectSet;
 
-  // When shouldUseObjectSet is true, we know objectSet is defined
-  // and objectOrInterfaceType is an ObjectTypeDefinition
   const objectSetResult = useObjectSet(
     shouldUseObjectSet ? objectSet as ObjectSet<Q, RDPs> : undefined as any,
     {


### PR DESCRIPTION
useObjectTableData only routed through useObjectSet when objectType was an object type (shouldUseObjectSet = !!objectSet && isObjectType), so a caller-supplied objectSet was silently ignored for interface-backed tables

Relax it to shouldUseObjectSet = !!objectSet so an interface-backed table can be driven by a composed/filtered object set (e.g. a pivot-derived set), not just a property `where`.


FLAG:

For an interface object set the returned rows expose the interface's declared properties (plus any withProperties from rdp column locators); the underlying concrete object's non-interface properties are not loaded (the useObjectSet path does not reload-as-full-objects the way the useOsdkObjects interface path does).

- useObjectTableData.ts: relax the guard, drop the now-dead isObjectType.
- ObjectTableApi.ts: update the objectSet prop docs.
- useObjectTableData.test.tsx: invert the interface-routing test to assert interface + objectSet now enables useObjectSet.