### PR TITLE
Compare long/decimal numerically in observable client where-clause filters

### DIFF
--- a/.changeset/kind-rivers-dance.md
+++ b/.changeset/kind-rivers-dance.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Compare long/decimal properties numerically in observable client where-clause filters ($gt, $lt, $gte, $lte, $eq, $ne, $in)

--- a/packages/client/src/observable/internal/evaluateFilter.test.ts
+++ b/packages/client/src/observable/internal/evaluateFilter.test.ts
@@ -150,4 +150,103 @@ describe("evaluateFilter", () => {
       expect(evaluateFilter("$intersects", {}, {}, false)).toBe(true);
     });
   });
+
+  // `long`/`decimal` arrive over the wire as strings. Comparing them with raw
+  // JS operators is lexicographic ("10" < "2") and precision-sensitive
+  // ("5.30" !== "5.3"). When the declared property type is a string-encoded
+  // numeric type, the filter must compare by numeric value instead.
+  describe("string-encoded numeric properties", () => {
+    // Behavior 1: ordered comparisons compare numerically, not lexically.
+    it.each(["long", "decimal"])(
+      "ordered comparisons compare numerically for %s",
+      (propertyType) => {
+        expect(evaluateFilter("$gt", "10", "2", true, propertyType)).toBe(true);
+        expect(evaluateFilter("$lt", "10", "2", true, propertyType)).toBe(
+          false,
+        );
+        expect(evaluateFilter("$gte", "5", "5", true, propertyType)).toBe(true);
+        expect(evaluateFilter("$lte", "5", "5", true, propertyType)).toBe(true);
+        expect(evaluateFilter("$gt", "5", "5", true, propertyType)).toBe(false);
+      },
+    );
+
+    // Behavior 2: $eq/$ne are precision-insensitive and cross-type aware.
+    it("$eq / $ne compare by numeric value", () => {
+      expect(evaluateFilter("$eq", "5.30", "5.3", true, "decimal")).toBe(true);
+      expect(evaluateFilter("$eq", "5.30", "5.4", true, "decimal")).toBe(false);
+      expect(evaluateFilter("$ne", "5.30", "5.3", true, "decimal")).toBe(false);
+      expect(evaluateFilter("$ne", "5.30", "5.4", true, "decimal")).toBe(true);
+    });
+
+    it("$eq routes a cross-type (string vs number) expected through numeric comparison", () => {
+      expect(evaluateFilter("$eq", "10", 10, true, "long")).toBe(true);
+    });
+
+    // Behavior 3: $in membership is precision-insensitive.
+    it("$in compares membership by numeric value", () => {
+      expect(evaluateFilter("$in", "5.30", ["5.3", "6"], true, "decimal")).toBe(
+        true,
+      );
+      expect(evaluateFilter("$in", "7", ["1", "5", "10"], true, "long")).toBe(
+        false,
+      );
+    });
+
+    it("$in returns false for a non-array expected on a numeric column", () => {
+      expect(evaluateFilter("$in", "5", null, true, "long")).toBe(false);
+    });
+
+    // Behavior 5: empty/whitespace/null edge cases on numeric columns.
+    it.each(["long", "decimal"])(
+      "handles empty / whitespace / null without throwing for %s",
+      (propertyType) => {
+        expect(evaluateFilter("$eq", "", "", true, propertyType)).toBe(true);
+        expect(evaluateFilter("$gt", "5", "", true, propertyType)).toBe(true);
+        expect(evaluateFilter("$lt", "", "5", true, propertyType)).toBe(true);
+        expect(evaluateFilter("$gt", null, "5", true, propertyType)).toBe(
+          false,
+        );
+        expect(evaluateFilter("$isNull", null, undefined, true, propertyType))
+          .toBe(true);
+      },
+    );
+
+    // Behavior 4: non-numeric property types are unaffected. A careless
+    // implementation that always routes through compareNumericStrings would
+    // break these (e.g. it would coerce "a" to malformed and mis-handle, or
+    // mangle boolean / integer comparisons).
+    it.each([undefined, "string", "integer"] as const)(
+      "leaves non-numeric comparisons unchanged for propertyType=%s",
+      (propertyType) => {
+        expect(evaluateFilter("$gt", 10, 5, true, propertyType)).toBe(true);
+        expect(evaluateFilter("$eq", "a", "a", true, propertyType)).toBe(true);
+        expect(evaluateFilter("$ne", "a", "b", true, propertyType)).toBe(true);
+        expect(
+          evaluateFilter("$startsWith", "hello", "he", true, propertyType),
+        ).toBe(true);
+        expect(evaluateFilter("$eq", true, true, true, propertyType)).toBe(
+          true,
+        );
+        expect(evaluateFilter("$isNull", null, true, true, propertyType)).toBe(
+          true,
+        );
+        expect(evaluateFilter("$in", 5, [1, 5, 10], true, propertyType)).toBe(
+          true,
+        );
+        // strict-vs-loose deferral for unsupported ops is preserved.
+        expect(
+          evaluateFilter("$contains", "hello", "ell", true, propertyType),
+        ).toBe(false);
+        expect(
+          evaluateFilter("$contains", "hello", "ell", false, propertyType),
+        ).toBe(true);
+        expect(evaluateFilter("$intersects", {}, {}, true, propertyType)).toBe(
+          false,
+        );
+        expect(evaluateFilter("$intersects", {}, {}, false, propertyType)).toBe(
+          true,
+        );
+      },
+    );
+  });
 });

--- a/packages/client/src/observable/internal/evaluateFilter.ts
+++ b/packages/client/src/observable/internal/evaluateFilter.ts
@@ -16,6 +16,8 @@
 
 import type { PossibleWhereClauseFilters } from "@osdk/api";
 import invariant from "tiny-invariant";
+import { compareNumericStrings } from "./compareNumericStrings.js";
+import { isStringEncodedNumericType } from "./resolvePropertyType.js";
 
 /**
  * Evaluates a where clause filter against a value.
@@ -26,22 +28,47 @@ export function evaluateFilter(
   realValue: any,
   expected: any,
   strict: boolean,
+  // Declared property type (e.g. "long"/"decimal"). When it's a string-encoded
+  // numeric type, value comparisons route through compareNumericStrings so they
+  // compare by value rather than lexicographically/precision-sensitively.
+  propertyType?: string,
 ): boolean {
+  // `long`/`decimal` arrive over the wire as strings, so the value-comparison
+  // filters must compare them by value rather than lexicographically ("10" <
+  // "2") and precision-sensitively ("5.30" !== "5.3"). `numeric` selects that
+  // path per operator below; keeping a single switch means a new filter only
+  // has to be handled in one place.
+  const numeric = isStringEncodedNumericType(propertyType);
   switch (f) {
     case "$eq":
-      return realValue === expected;
+      return numeric
+        ? numericCompare(realValue, expected) === 0
+        : realValue === expected;
     case "$gt":
-      return realValue > expected;
+      return numeric
+        ? numericCompare(realValue, expected) > 0
+        : realValue > expected;
     case "$lt":
-      return realValue < expected;
+      return numeric
+        ? numericCompare(realValue, expected) < 0
+        : realValue < expected;
     case "$gte":
-      return realValue >= expected;
+      return numeric
+        ? numericCompare(realValue, expected) >= 0
+        : realValue >= expected;
     case "$lte":
-      return realValue <= expected;
+      return numeric
+        ? numericCompare(realValue, expected) <= 0
+        : realValue <= expected;
     case "$ne":
-      return realValue !== expected;
+      return numeric
+        ? numericCompare(realValue, expected) !== 0
+        : realValue !== expected;
     case "$in":
-      return Array.isArray(expected) && expected.includes(realValue);
+      return Array.isArray(expected)
+        && (numeric
+          ? expected.some(e => numericCompare(realValue, e) === 0)
+          : expected.includes(realValue));
     case "$isNull":
       return realValue == null;
     case "$startsWith":
@@ -67,4 +94,21 @@ export function evaluateFilter(
       }
       return !strict;
   }
+}
+
+/**
+ * Compares two values from a string-encoded numeric column by value, returning
+ * the usual comparator sign (negative / 0 / positive). Coerces via String() so
+ * a cross-type expected (e.g. `$eq("10", 10)`) still compares numerically.
+ *
+ * Returns NaN when either side has no value (null/undefined). NaN is
+ * incomparable, so every ordered comparison against it is false and `=== 0` is
+ * false, while `!== 0` is true -- i.e. a missing value matches nothing and is
+ * "not equal" to a present one, with no special-casing needed at the call site.
+ */
+function numericCompare(a: unknown, b: unknown): number {
+  if (a == null || b == null) {
+    return NaN;
+  }
+  return compareNumericStrings(String(a), String(b));
 }

--- a/packages/client/src/observable/internal/objectMatchesWhereClause.test.ts
+++ b/packages/client/src/observable/internal/objectMatchesWhereClause.test.ts
@@ -14,9 +14,21 @@
  * limitations under the License.
  */
 
-import type { Osdk, WhereClause } from "@osdk/api";
+import type {
+  InterfaceMetadata,
+  ObjectMetadata,
+  Osdk,
+  WhereClause,
+} from "@osdk/api";
 import type { objectTypeWithAllPropertyTypes } from "@osdk/client.test.ontology";
+import type { DerivedPropertyDefinition } from "@osdk/foundry.ontologies";
 import { describe, expect, expectTypeOf, it } from "vitest";
+import type { DerivedPropertyRuntimeMetadata } from "../../derivedProperties/derivedPropertyRuntimeMetadata.js";
+import type { InterfaceHolder } from "../../object/convertWireToOsdkObjects/InterfaceHolder.js";
+import {
+  InterfaceDefRef,
+  ObjectDefRef,
+} from "../../object/convertWireToOsdkObjects/InternalSymbols.js";
 import type { ObjectHolder } from "../../object/convertWireToOsdkObjects/ObjectHolder.js";
 import { objectSortaMatchesWhereClause } from "./objectMatchesWhereClause.js";
 
@@ -222,4 +234,159 @@ describe(objectSortaMatchesWhereClause, () => {
         .toBe(nonStrictExpected);
     },
   );
+});
+
+// `long`/`decimal` arrive over the wire as strings, so a holder with long "10"
+// and clause `{long:{$gt:"2"}}` is lexicographically false but numerically
+// true. The matcher must compare numerically when the declared type (resolved
+// off the holder metadata or the derived metadata arg) says it's numeric.
+//
+// These fixtures genuinely carry ObjectDefRef / InterfaceDefRef so
+// resolvePropertyType returns a real type (the base fauxObject above is cast
+// without metadata, so it resolves to undefined and stays lexicographic).
+type AnyHolder = ObjectHolder | InterfaceHolder;
+
+function objectHolder(
+  values: Record<string, unknown>,
+  properties: Record<string, ObjectMetadata.Property>,
+): AnyHolder {
+  return {
+    ...values,
+    [ObjectDefRef]: { properties } as ObjectMetadata,
+  } as unknown as AnyHolder;
+}
+
+function interfaceHolder(
+  values: Record<string, unknown>,
+  apiName: string,
+  properties: Record<string, InterfaceMetadata.Property>,
+): AnyHolder {
+  return {
+    ...values,
+    [InterfaceDefRef]: { apiName, properties } as InterfaceMetadata,
+  } as unknown as AnyHolder;
+}
+
+describe("objectSortaMatchesWhereClause numeric-string comparison", () => {
+  // Behavior 6: OBJECT holder path.
+  describe("object holder", () => {
+    const holder = objectHolder(
+      { long: "10", decimal: "5.3", boolean: true },
+      { long: { type: "long" }, decimal: { type: "decimal" } },
+    );
+
+    it.each([true, false])(
+      "{long:{$gt:\"2\"}} matches long \"10\" numerically (strict=%s)",
+      (strict) => {
+        expect(
+          objectSortaMatchesWhereClause(holder, { long: { $gt: "2" } }, strict),
+        ).toBe(true);
+      },
+    );
+
+    it("{decimal:{$eq:\"5.30\"}} matches decimal \"5.3\" (precision-insensitive)", () => {
+      expect(
+        objectSortaMatchesWhereClause(
+          holder,
+          { decimal: { $eq: "5.30" } },
+          true,
+        ),
+      ).toBe(true);
+    });
+
+    it("falls back to lexicographic when the holder carries no metadata", () => {
+      // No ObjectDefRef => resolvePropertyType is undefined => raw operators =>
+      // "10" > "2" is lexicographically false. Documents the dependency.
+      const noMeta = { long: "10" } as unknown as AnyHolder;
+      expect(
+        objectSortaMatchesWhereClause(noMeta, { long: { $gt: "2" } }, true),
+      ).toBe(false);
+    });
+  });
+
+  // Behavior 7: INTERFACE holder path, including a namespaced apiName re-qualify.
+  describe("interface holder", () => {
+    it("compares an interface long property numerically", () => {
+      const holder = interfaceHolder(
+        { amount: "10" },
+        "IFoo",
+        { amount: { type: "long" } },
+      );
+      // Lexicographically "10" >= "9" is FALSE ("1" < "9"); numerically TRUE.
+      expect(
+        objectSortaMatchesWhereClause(holder, { amount: { $gte: "9" } }, true),
+      ).toBe(true);
+    });
+
+    it("compares a namespaced interface decimal property numerically", () => {
+      // The view exposes the namespace-stripped key ("amount") but the metadata
+      // is keyed by the full wire apiName ("a.amount"); resolution re-qualifies.
+      const holder = interfaceHolder(
+        { amount: "10" },
+        "a.IFoo",
+        { "a.amount": { type: "long" } },
+      );
+      // Lexicographically "10" >= "9" is FALSE ("1" < "9"); numerically TRUE.
+      expect(
+        objectSortaMatchesWhereClause(holder, { amount: { $gte: "9" } }, true),
+      ).toBe(true);
+    });
+  });
+
+  // Behavior 8: regression + nested composites thread the metadata through.
+  describe("nested composites", () => {
+    const holder = objectHolder(
+      { long: "10", decimal: "5.3", boolean: true },
+      { long: { type: "long" }, decimal: { type: "decimal" } },
+    );
+
+    it("$and with a numeric-string leaf and a boolean leaf resolves true", () => {
+      expect(
+        objectSortaMatchesWhereClause(
+          holder,
+          { $and: [{ long: { $gt: "2" } }, { boolean: true }] },
+          true,
+        ),
+      ).toBe(true);
+    });
+
+    it("$not over a numeric-string leaf resolves correctly", () => {
+      // long "10" is NOT < "2" numerically, so $not(...) is true.
+      expect(
+        objectSortaMatchesWhereClause(
+          holder,
+          { $not: { long: { $lt: "2" } } },
+          true,
+        ),
+      ).toBe(true);
+    });
+  });
+
+  // Behavior 9: derived-metadata matcher slice -- the 4th arg drives numeric
+  // comparison for a derived property with NO query-class wiring involved.
+  describe("derived property metadata (matcher slice)", () => {
+    it("uses the derivedPropertyMetadata arg to compare a derived long numerically", () => {
+      // myDerived is not in the object metadata; its type comes from the arg.
+      const holder = objectHolder(
+        { myDerived: "10" },
+        {},
+      );
+      const derivedMetadata: DerivedPropertyRuntimeMetadata = {
+        myDerived: {
+          selectedOrCollectedPropertyType: { type: "long" },
+          definition: { type: "selection" } as DerivedPropertyDefinition,
+        },
+      };
+      expect(
+        objectSortaMatchesWhereClause(
+          holder,
+          { myDerived: { $gt: "2" } } as unknown as WhereClause<
+            objectTypeWithAllPropertyTypes
+          >,
+          true,
+          derivedMetadata,
+        ),
+      ).toBe(true);
+    });
+  });
 });

--- a/packages/client/src/observable/internal/objectMatchesWhereClause.ts
+++ b/packages/client/src/observable/internal/objectMatchesWhereClause.ts
@@ -17,9 +17,11 @@
 import type { PossibleWhereClauseFilters } from "@osdk/api";
 import deepEqual from "fast-deep-equal";
 import invariant from "tiny-invariant";
+import type { DerivedPropertyRuntimeMetadata } from "../../derivedProperties/derivedPropertyRuntimeMetadata.js";
 import type { InterfaceHolder } from "../../object/convertWireToOsdkObjects/InterfaceHolder.js";
 import type { ObjectHolder } from "../../object/convertWireToOsdkObjects/ObjectHolder.js";
 import { evaluateFilter } from "./evaluateFilter.js";
+import { resolvePropertyType } from "./resolvePropertyType.js";
 import type { SimpleWhereClause } from "./SimpleWhereClause.js";
 
 function is$and(
@@ -77,6 +79,12 @@ export function objectSortaMatchesWhereClause(
   o: ObjectHolder | InterfaceHolder,
   whereClause: SimpleWhereClause,
   strict: boolean,
+  // Derived-property runtime metadata used to resolve string-encoded numeric
+  // types for derived properties. This is the matcher-side seam: callers can
+  // pass derived metadata directly so a derived long/decimal compares
+  // numerically. NOTE: the query classes (ListQuery/ObjectSetQuery) do not yet
+  // thread derived filters end-to-end -- that plumbing is a follow-up.
+  derivedPropertyMetadata: DerivedPropertyRuntimeMetadata = {},
 ): boolean {
   if (deepEqual({}, whereClause)) {
     return true;
@@ -84,16 +92,21 @@ export function objectSortaMatchesWhereClause(
 
   if (is$and(whereClause)) {
     return whereClause.$and.every(w =>
-      objectSortaMatchesWhereClause(o, w, strict)
+      objectSortaMatchesWhereClause(o, w, strict, derivedPropertyMetadata)
     );
   }
   if (is$or(whereClause)) {
     return whereClause.$or.some(w =>
-      objectSortaMatchesWhereClause(o, w, strict)
+      objectSortaMatchesWhereClause(o, w, strict, derivedPropertyMetadata)
     );
   }
   if (is$not(whereClause)) {
-    return !objectSortaMatchesWhereClause(o, whereClause.$not, strict);
+    return !objectSortaMatchesWhereClause(
+      o,
+      whereClause.$not,
+      strict,
+      derivedPropertyMetadata,
+    );
   }
 
   return Object.entries(whereClause).every(([key, filter]) => {
@@ -101,7 +114,8 @@ export function objectSortaMatchesWhereClause(
       const realValue: any = o[key as keyof typeof o];
       const [f] = Object.keys(filter) as Array<PossibleWhereClauseFilters>;
       const expected = (filter as any)[f];
-      return evaluateFilter(f, realValue, expected, strict);
+      const propertyType = resolvePropertyType(o, key, derivedPropertyMetadata);
+      return evaluateFilter(f, realValue, expected, strict, propertyType);
     }
 
     if (key in o) {


### PR DESCRIPTION
## Summary

Follow-up to #3493. That PR made the observable client's `orderBy` sort `long`/`decimal` properties numerically; this fixes the **filter** side. Client-side where-clause comparison filters (`$gt`, `$lt`, `$gte`, `$lte`, `$eq`, `$ne`, `$in`) compared these values lexicographically/precision-sensitively, so `"10"` was not `> "2"` and `"5.30"` did not `$eq "5.3"`.

## Context

`long` and `decimal` arrive over the wire as strings. `evaluateFilter` used raw JS operators (`>`, `<`, `===`, `.includes`), which compare strings lexicographically and are precision/type sensitive. The fix resolves a property's declared type at match time and, when it's a string-encoded numeric type, routes the comparison through the existing `compareNumericStrings` (big.js) helper introduced in #3493.

## Decision

- `evaluateFilter` gains an optional `propertyType` argument. The op set stays a **single switch** — each filter selects the numeric or the existing path inline, so a new filter is still handled in one place and the exhaustiveness check guards the whole set.
- A missing value compares as `NaN`, which is incomparable: every ordered comparison against it is false and it is never reported equal, so no special-casing is needed at the call sites.
- `objectSortaMatchesWhereClause` resolves each leaf's type via the existing `resolvePropertyType` (object + interface metadata already on the holder, including namespaced interface re-qualification) and threads a `derivedPropertyMetadata` parameter through the `$and`/`$or`/`$not` recursion.

## Out of scope

Per the low-risk philosophy of #3493, the derived-property (RDP) path is wired only at the matcher level: `objectSortaMatchesWhereClause` accepts `derivedPropertyMetadata` directly, but the query classes (`ListQuery`/`ObjectSetQuery`) do not yet thread RDP definitions into the match path — that plumbing is left for a follow-up. The seam is documented at the parameter.