### PR TITLE
add enabled option to useOsdkAggregation

### DIFF
--- a/.changeset/aggregation-enabled-flag.md
+++ b/.changeset/aggregation-enabled-flag.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react": minor
+---
+
+add an `enabled` option to `useOsdkAggregation` to conditionally defer the aggregation

--- a/packages/react/src/new/__tests__/useOsdkAggregation.test.tsx
+++ b/packages/react/src/new/__tests__/useOsdkAggregation.test.tsx
@@ -29,18 +29,20 @@ const AGGREGATE = { $select: { $count: "unordered" } } as const;
 function createMockObservableClient(): {
   client: ObservableClient;
   observeAggregation: ReturnType<typeof vi.fn>;
+  invalidateObjectType: ReturnType<typeof vi.fn>;
 } {
   const observeAggregation = vi.fn(
     (_args: unknown, _observer: Observer<unknown>) => ({
       unsubscribe: vi.fn(),
     }),
   );
+  const invalidateObjectType = vi.fn().mockResolvedValue(undefined);
   const client = {
     observeAggregation,
     canonicalizeOptions: vi.fn((opts: unknown) => opts),
-    invalidateObjectType: vi.fn().mockResolvedValue(undefined),
+    invalidateObjectType,
   } as unknown as ObservableClient;
-  return { client, observeAggregation };
+  return { client, observeAggregation, invalidateObjectType };
 }
 
 function createWrapper(observableClient: ObservableClient) {
@@ -62,9 +64,10 @@ function createWrapper(observableClient: ObservableClient) {
 describe("useOsdkAggregation", () => {
   let observableClient: ObservableClient;
   let observeAggregation: ReturnType<typeof vi.fn>;
+  let invalidateObjectType: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    ({ client: observableClient, observeAggregation } =
+    ({ client: observableClient, observeAggregation, invalidateObjectType } =
       createMockObservableClient());
   });
 
@@ -169,6 +172,39 @@ describe("useOsdkAggregation", () => {
       );
 
       expect(observeAggregation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("refetch", () => {
+    it("invalidates the object type when enabled is true", async () => {
+      const { result } = renderHook(
+        () =>
+          useOsdkAggregation(Employee, { aggregate: AGGREGATE, enabled: true }),
+        { wrapper: createWrapper(observableClient) },
+      );
+
+      await act(async () => {
+        await result.current.refetch();
+      });
+
+      expect(invalidateObjectType).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not invalidate the object type when enabled is false", async () => {
+      const { result } = renderHook(
+        () =>
+          useOsdkAggregation(Employee, {
+            aggregate: AGGREGATE,
+            enabled: false,
+          }),
+        { wrapper: createWrapper(observableClient) },
+      );
+
+      await act(async () => {
+        await result.current.refetch();
+      });
+
+      expect(invalidateObjectType).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/react/src/new/__tests__/useOsdkAggregation.test.tsx
+++ b/packages/react/src/new/__tests__/useOsdkAggregation.test.tsx
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectSet } from "@osdk/api";
+import type { Client } from "@osdk/client";
+import { Employee } from "@osdk/client.test.ontology";
+import type { ObservableClient } from "@osdk/client/observable";
+import { renderHook } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { OsdkContext } from "../OsdkContext.js";
+import { useOsdkAggregation } from "../useOsdkAggregation.js";
+
+const AGGREGATE = { $select: { $count: "unordered" } } as const;
+
+function createMockObservableClient(): {
+  client: ObservableClient;
+  observeAggregation: ReturnType<typeof vi.fn>;
+} {
+  const observeAggregation = vi.fn(() => ({ unsubscribe: vi.fn() }));
+  const client = {
+    observeAggregation,
+    canonicalizeOptions: vi.fn((opts: unknown) => opts),
+    invalidateObjectType: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ObservableClient;
+  return { client, observeAggregation };
+}
+
+function createWrapper(observableClient: ObservableClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <OsdkContext.Provider
+        value={{
+          client: {} as Client,
+          observableClient,
+          devtoolsEnabled: false,
+        }}
+      >
+        {children}
+      </OsdkContext.Provider>
+    );
+  };
+}
+
+describe("useOsdkAggregation", () => {
+  let observableClient: ObservableClient;
+  let observeAggregation: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    ({ client: observableClient, observeAggregation } =
+      createMockObservableClient());
+  });
+
+  describe("enabled option", () => {
+    it("does not call observeAggregation when enabled is false", () => {
+      const { result } = renderHook(
+        () =>
+          useOsdkAggregation(Employee, {
+            aggregate: AGGREGATE,
+            enabled: false,
+          }),
+        { wrapper: createWrapper(observableClient) },
+      );
+
+      expect(observeAggregation).not.toHaveBeenCalled();
+      expect(result.current.data).toBeUndefined();
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeUndefined();
+    });
+
+    it("calls observeAggregation once when enabled is true", () => {
+      renderHook(
+        () =>
+          useOsdkAggregation(Employee, { aggregate: AGGREGATE, enabled: true }),
+        { wrapper: createWrapper(observableClient) },
+      );
+
+      expect(observeAggregation).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls observeAggregation by default when enabled is omitted", () => {
+      renderHook(
+        () => useOsdkAggregation(Employee, { aggregate: AGGREGATE }),
+        { wrapper: createWrapper(observableClient) },
+      );
+
+      expect(observeAggregation).toHaveBeenCalledTimes(1);
+    });
+
+    it("starts observing when enabled flips from false to true", () => {
+      const { rerender } = renderHook(
+        ({ enabled }) =>
+          useOsdkAggregation(Employee, { aggregate: AGGREGATE, enabled }),
+        {
+          wrapper: createWrapper(observableClient),
+          initialProps: { enabled: false },
+        },
+      );
+
+      expect(observeAggregation).not.toHaveBeenCalled();
+
+      rerender({ enabled: true });
+
+      expect(observeAggregation).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call observeAggregation when enabled is false even with an objectSet", () => {
+      const objectSet = {} as unknown as ObjectSet<typeof Employee>;
+
+      renderHook(
+        () =>
+          useOsdkAggregation(Employee, {
+            objectSet,
+            aggregate: AGGREGATE,
+            enabled: false,
+          }),
+        { wrapper: createWrapper(observableClient) },
+      );
+
+      expect(observeAggregation).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/react/src/new/__tests__/useOsdkAggregation.test.tsx
+++ b/packages/react/src/new/__tests__/useOsdkAggregation.test.tsx
@@ -17,8 +17,8 @@
 import type { ObjectSet } from "@osdk/api";
 import type { Client } from "@osdk/client";
 import { Employee } from "@osdk/client.test.ontology";
-import type { ObservableClient } from "@osdk/client/observable";
-import { renderHook } from "@testing-library/react";
+import type { ObservableClient, Observer } from "@osdk/client/observable";
+import { act, renderHook } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { OsdkContext } from "../OsdkContext.js";
@@ -30,7 +30,11 @@ function createMockObservableClient(): {
   client: ObservableClient;
   observeAggregation: ReturnType<typeof vi.fn>;
 } {
-  const observeAggregation = vi.fn(() => ({ unsubscribe: vi.fn() }));
+  const observeAggregation = vi.fn(
+    (_args: unknown, _observer: Observer<unknown>) => ({
+      unsubscribe: vi.fn(),
+    }),
+  );
   const client = {
     observeAggregation,
     canonicalizeOptions: vi.fn((opts: unknown) => opts),
@@ -115,6 +119,40 @@ describe("useOsdkAggregation", () => {
       rerender({ enabled: true });
 
       expect(observeAggregation).toHaveBeenCalledTimes(1);
+    });
+
+    it("clears data when enabled flips from true to false", () => {
+      const unsubscribe = vi.fn();
+      let observer: Observer<unknown> | undefined;
+      observeAggregation.mockImplementation((_args, obs: Observer<unknown>) => {
+        observer = obs;
+        return { unsubscribe };
+      });
+
+      const { result, rerender } = renderHook(
+        ({ enabled }) =>
+          useOsdkAggregation(Employee, { aggregate: AGGREGATE, enabled }),
+        {
+          wrapper: createWrapper(observableClient),
+          initialProps: { enabled: true },
+        },
+      );
+
+      act(() => {
+        observer?.next({ status: "loaded", result: { $count: 5 } });
+      });
+
+      expect(observeAggregation).toHaveBeenCalledTimes(1);
+      expect(result.current.data).toEqual({ $count: 5 });
+      expect(result.current.isLoading).toBe(false);
+
+      rerender({ enabled: false });
+
+      expect(unsubscribe).toHaveBeenCalledTimes(1);
+      expect(observeAggregation).toHaveBeenCalledTimes(1);
+      expect(result.current.data).toBeUndefined();
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeUndefined();
     });
 
     it("does not call observeAggregation when enabled is false even with an objectSet", () => {

--- a/packages/react/src/new/useOsdkAggregation.ts
+++ b/packages/react/src/new/useOsdkAggregation.ts
@@ -71,6 +71,16 @@ interface UseOsdkAggregationBaseOptions<
    * network request if the second is within `dedupeIntervalMs`.
    */
   dedupeIntervalMs?: number;
+
+  /**
+   * Enable or disable the query.
+   *
+   * When `false`, the query will not automatically execute. It will still
+   * return any cached data, but will not fetch from the server.
+   *
+   * @default true
+   */
+  enabled?: boolean;
 }
 
 export interface UseOsdkAggregationOptions<
@@ -164,6 +174,7 @@ export function useOsdkAggregation<
     intersectWith,
     aggregate,
     dedupeIntervalMs,
+    enabled = true,
   } = options;
   const objectSet = "objectSet" in options ? options.objectSet : undefined;
 
@@ -185,6 +196,16 @@ export function useOsdkAggregation<
 
   const { subscribe, getSnapShot } = React.useMemo(
     () => {
+      if (!enabled) {
+        return makeExternalStore<ObserveAggregationArgs<Q, A>>(
+          () => ({ unsubscribe: () => {} }),
+          devToolsMetadata({
+            hookType: "useOsdkAggregation",
+            objectType: type.apiName,
+          }),
+        );
+      }
+
       const currentObjectSet = objectSetRef.current;
       if (currentObjectSet) {
         return makeExternalStoreAsync<ObserveAggregationArgs<Q, A>>(
@@ -232,6 +253,7 @@ export function useOsdkAggregation<
       );
     },
     [
+      enabled,
       observableClient,
       type.apiName,
       type.type,
@@ -252,8 +274,8 @@ export function useOsdkAggregation<
 
   return React.useMemo(() => ({
     data: payload?.result as AggregationsResults<Q, A> | undefined,
-    isLoading: isPayloadLoading(payload, true),
+    isLoading: isPayloadLoading(payload, enabled),
     error: extractPayloadError(payload, "Failed to execute aggregation"),
     refetch,
-  }), [payload, refetch]);
+  }), [payload, enabled, refetch]);
 }

--- a/packages/react/src/new/useOsdkAggregation.ts
+++ b/packages/react/src/new/useOsdkAggregation.ts
@@ -77,7 +77,9 @@ interface UseOsdkAggregationBaseOptions<
    *
    * When `false`, the hook does not subscribe or fetch from the server and
    * reports `data: undefined`, `isLoading: false`, and `error: undefined`.
-   * Setting it back to `true` re-subscribes and fetches.
+   * `refetch()` is also a no-op while disabled, so it will not invalidate the
+   * object type or trigger network requests. Setting it back to `true`
+   * re-subscribes and fetches.
    *
    * @default true
    */
@@ -270,8 +272,11 @@ export function useOsdkAggregation<
   const payload = React.useSyncExternalStore(subscribe, getSnapShot);
 
   const refetch = React.useCallback(async () => {
+    if (!enabled) {
+      return;
+    }
     await observableClient.invalidateObjectType(type.apiName);
-  }, [observableClient, type.apiName]);
+  }, [observableClient, type.apiName, enabled]);
 
   return React.useMemo(() => ({
     data: payload?.result as AggregationsResults<Q, A> | undefined,

--- a/packages/react/src/new/useOsdkAggregation.ts
+++ b/packages/react/src/new/useOsdkAggregation.ts
@@ -73,10 +73,11 @@ interface UseOsdkAggregationBaseOptions<
   dedupeIntervalMs?: number;
 
   /**
-   * Enable or disable the query.
+   * Enable or disable the aggregation.
    *
-   * When `false`, the query will not automatically execute. It will still
-   * return any cached data, but will not fetch from the server.
+   * When `false`, the hook does not subscribe or fetch from the server and
+   * reports `data: undefined`, `isLoading: false`, and `error: undefined`.
+   * Setting it back to `true` re-subscribes and fetches.
    *
    * @default true
    */


### PR DESCRIPTION
brings useOsdkAggregation in line with the other data hooks by letting callers conditionally defer the aggregation

• new `enabled` option (defaults to `true`); when `false` the hook skips the subscription and does not fetch from the server
• disabled hooks report `data: undefined`, `isLoading: false`, `error: undefined`, matching useOsdkObjects and the other hooks
• flipping `enabled` from `false` to `true` re-subscribes and fetches