### PR TITLE
CipherText codegen / decrypt

### DIFF
--- a/.changeset/soft-symbols-rescue.md
+++ b/.changeset/soft-symbols-rescue.md
@@ -1,0 +1,10 @@
+---
+"@osdk/foundry-sdk-generator": minor
+"@osdk/generator-converters": minor
+"@osdk/shared.test": minor
+"@osdk/client": minor
+"@osdk/faux": minor
+"@osdk/api": minor
+---
+
+Add CipherText support for codegen and implement decryption interface

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -391,7 +391,7 @@ export type BaseWirePropertyTypes = "string" | "datetime" | "double" | "boolean"
 
 // @public
 export interface CipherText {
-    	decrypt(): Promise<string>;
+    	decrypt(): Promise<string | undefined>;
 }
 
 // @public (undocumented)

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -390,8 +390,8 @@ export interface BaseObjectSet<Q extends ObjectOrInterfaceDefinition> {
 export type BaseWirePropertyTypes = "string" | "datetime" | "double" | "boolean" | "integer" | "timestamp" | "short" | "long" | "float" | "decimal" | "byte" | "marking" | "cipherText" | "mediaReference" | "numericTimeseries" | "stringTimeseries" | "sensorTimeseries" | "attachment" | "geopoint" | "geoshape" | "geotimeSeriesReference" | "vector";
 
 // @public
-export interface CipherText<T extends string = string> {
-    	decrypt(): Promise<T>;
+export interface CipherText {
+    	decrypt(): Promise<string>;
 }
 
 // @public (undocumented)

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -387,7 +387,12 @@ export interface BaseObjectSet<Q extends ObjectOrInterfaceDefinition> {
 }
 
 // @public (undocumented)
-export type BaseWirePropertyTypes = "string" | "datetime" | "double" | "boolean" | "integer" | "timestamp" | "short" | "long" | "float" | "decimal" | "byte" | "marking" | "mediaReference" | "numericTimeseries" | "stringTimeseries" | "sensorTimeseries" | "attachment" | "geopoint" | "geoshape" | "geotimeSeriesReference" | "vector";
+export type BaseWirePropertyTypes = "string" | "datetime" | "double" | "boolean" | "integer" | "timestamp" | "short" | "long" | "float" | "decimal" | "byte" | "marking" | "cipherText" | "mediaReference" | "numericTimeseries" | "stringTimeseries" | "sensorTimeseries" | "attachment" | "geopoint" | "geoshape" | "geotimeSeriesReference" | "vector";
+
+// @public
+export interface CipherText<T extends string = string> {
+    	decrypt(): Promise<T>;
+}
 
 // @public (undocumented)
 export type ColorInterpretation = "UNDEFINED" | "GRAY" | "PALETTE_INDEX" | "RED" | "GREEN" | "BLUE" | "ALPHA" | "HUE" | "SATURATION" | "LIGHTNESS" | "CYAN" | "MAGENTA" | "YELLOW" | "BLACK" | "Y_CB_CR_SPACE_Y" | "Y_CB_CR_SPACE_CB" | "Y_CB_CR_SPACE_CR";
@@ -1952,6 +1957,8 @@ export interface PropertyValueWireToClient {
     boolean: boolean;
     	// (undocumented)
     byte: number;
+    	// (undocumented)
+    cipherText: CipherText;
     	// (undocumented)
     datetime: string;
     	// (undocumented)

--- a/etc/client.report.api.md
+++ b/etc/client.report.api.md
@@ -14,6 +14,7 @@ import { ApplyActionOptions } from '@osdk/api';
 import { ApplyBatchActionOptions } from '@osdk/api';
 import { Attachment } from '@osdk/api';
 import type { AttachmentUpload } from '@osdk/api';
+import { CipherText } from '@osdk/api';
 import { CompileTimeMetadata } from '@osdk/api';
 import type { DataValueClientToWire } from '@osdk/api';
 import type { DataValueWireToClient } from '@osdk/api';
@@ -92,6 +93,8 @@ export { ApplyActionOptions }
 export { ApplyBatchActionOptions }
 
 export { Attachment }
+
+export { CipherText }
 
 // Warning: (ae-forgotten-export) The symbol "OldSharedClient" needs to be exported by the entry point index.d.ts
 //

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -71,6 +71,7 @@ export type {
   AttachmentMetadata,
   AttachmentUpload,
 } from "./object/Attachment.js";
+export type { CipherText } from "./object/CipherText.js";
 export type {
   AsyncIterArgs,
   Augment,

--- a/packages/api/src/mapping/PropertyValueMapping.ts
+++ b/packages/api/src/mapping/PropertyValueMapping.ts
@@ -15,6 +15,7 @@
  */
 
 import type { Attachment, AttachmentUpload } from "../object/Attachment.js";
+import type { CipherText } from "../object/CipherText.js";
 import type { Media, MediaReference } from "../object/Media.js";
 import type {
   GeotimeSeriesProperty,
@@ -28,6 +29,7 @@ export interface PropertyValueWireToClient {
   attachment: Attachment;
   boolean: boolean;
   byte: number;
+  cipherText: CipherText;
   datetime: string;
   decimal: string;
   double: number;
@@ -64,6 +66,7 @@ export interface PropertyValueClientToWire {
   attachment: string | AttachmentUpload | Blob & { readonly name: string };
   boolean: boolean;
   byte: number;
+  cipherText: CipherText;
   datetime: string;
   decimal: string | number;
   double: number;
@@ -96,6 +99,7 @@ export interface PropertyValueWireToCreate {
   attachment: Attachment | string;
   boolean: boolean;
   byte: number;
+  cipherText: CipherText;
   datetime: string;
   decimal: string;
   double: number;

--- a/packages/api/src/object/CipherText.ts
+++ b/packages/api/src/object/CipherText.ts
@@ -15,7 +15,7 @@
  */
 
 /**
- * The client-side representation of a `cipherText` property. The encrypted
+ * Representation of a `cipherText` property. The encrypted
  * value is not stored; call {@link CipherText.decrypt} to retrieve the
  * decrypted plaintext on backend.
  *

--- a/packages/api/src/object/CipherText.ts
+++ b/packages/api/src/object/CipherText.ts
@@ -31,5 +31,5 @@ export interface CipherText {
    * Decrypts the ciphertext and resolves to the plaintext value.
    * @returns the decrypted plaintext
    */
-  decrypt(): Promise<string>;
+  decrypt(): Promise<string | undefined>;
 }

--- a/packages/api/src/object/CipherText.ts
+++ b/packages/api/src/object/CipherText.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The client-side representation of a `cipherText` property. The encrypted
+ * value is held opaquely; call {@link CipherText.decrypt} to retrieve the
+ * decrypted plaintext.
+ *
+ * @example
+ * ```ts
+ * const employee = await client(Employee).fetchOne(12345);
+ * const ssn = await employee.encryptedSsn?.decrypt();
+ * ```
+ * @public
+ */
+export interface CipherText {
+  /**
+   * Decrypts the ciphertext and resolves to the plaintext value.
+   * @returns the decrypted plaintext
+   */
+  decrypt(): Promise<string>;
+}

--- a/packages/api/src/object/CipherText.ts
+++ b/packages/api/src/object/CipherText.ts
@@ -16,8 +16,8 @@
 
 /**
  * The client-side representation of a `cipherText` property. The encrypted
- * value is held opaquely; call {@link CipherText.decrypt} to retrieve the
- * decrypted plaintext.
+ * value is not stored; call {@link CipherText.decrypt} to retrieve the
+ * decrypted plaintext on backend.
  *
  * @example
  * ```ts

--- a/packages/client/src/createCipherTextProperty.ts
+++ b/packages/client/src/createCipherTextProperty.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { CipherText } from "@osdk/api";
+import { decrypt as cipherTextDecrypt } from "@osdk/foundry.ontologies/CipherTextProperty";
+import invariant from "tiny-invariant";
+import type { MinimalClient } from "./MinimalClientContext.js";
+
+export class CipherTextPropertyImpl implements CipherText {
+  #client: MinimalClient;
+  #triplet: [string, unknown, string];
+
+  constructor(args: {
+    client: MinimalClient;
+    objectApiName: string;
+    primaryKey: unknown;
+    propertyName: string;
+  }) {
+    const { client, objectApiName, primaryKey, propertyName } = args;
+    this.#client = client;
+    this.#triplet = [objectApiName, primaryKey, propertyName];
+  }
+
+  async decrypt(): Promise<string> {
+    const [objectApiName, primaryKey, propertyName] = this.#triplet;
+    const ontologyRid = await this.#client.ontologyRid;
+    const result = await cipherTextDecrypt(
+      this.#client,
+      ontologyRid,
+      objectApiName,
+      primaryKey as string,
+      propertyName,
+    );
+    invariant(
+      typeof result.plaintext !== "undefined",
+      "Expected decryption to return non-empty value",
+    );
+    return result.plaintext;
+  }
+}

--- a/packages/client/src/createCipherTextProperty.ts
+++ b/packages/client/src/createCipherTextProperty.ts
@@ -16,7 +16,6 @@
 
 import type { CipherText } from "@osdk/api";
 import { decrypt as cipherTextDecrypt } from "@osdk/foundry.ontologies/CipherTextProperty";
-import invariant from "tiny-invariant";
 import type { MinimalClient } from "./MinimalClientContext.js";
 
 export class CipherTextPropertyImpl implements CipherText {
@@ -34,17 +33,13 @@ export class CipherTextPropertyImpl implements CipherText {
     this.#triplet = [objectApiName, primaryKey, propertyName];
   }
 
-  async decrypt(): Promise<string> {
+  async decrypt(): Promise<string | undefined> {
     const ontologyRid = await this.#client.ontologyRid;
     const result = await cipherTextDecrypt(
       this.#client,
       ontologyRid,
       ...this.#triplet,
     );
-    invariant(
-      typeof result.plaintext !== "undefined",
-      "Expected decryption to return non-empty value",
-    );
-    return result.plaintext;
+    return result.plaintext!;
   }
 }

--- a/packages/client/src/createCipherTextProperty.ts
+++ b/packages/client/src/createCipherTextProperty.ts
@@ -40,6 +40,6 @@ export class CipherTextPropertyImpl implements CipherText {
       ontologyRid,
       ...this.#triplet,
     );
-    return result.plaintext!;
+    return result.plaintext;
   }
 }

--- a/packages/client/src/createCipherTextProperty.ts
+++ b/packages/client/src/createCipherTextProperty.ts
@@ -20,7 +20,7 @@ import type { MinimalClient } from "./MinimalClientContext.js";
 
 export class CipherTextPropertyImpl implements CipherText {
   #client: MinimalClient;
-  #triplet: [string, any, string];
+  #locator: [string, any, string];
 
   constructor(args: {
     client: MinimalClient;
@@ -30,7 +30,7 @@ export class CipherTextPropertyImpl implements CipherText {
   }) {
     const { client, objectApiName, primaryKey, propertyName } = args;
     this.#client = client;
-    this.#triplet = [objectApiName, primaryKey, propertyName];
+    this.#locator = [objectApiName, primaryKey, propertyName];
   }
 
   async decrypt(): Promise<string | undefined> {
@@ -38,7 +38,7 @@ export class CipherTextPropertyImpl implements CipherText {
     const result = await cipherTextDecrypt(
       this.#client,
       ontologyRid,
-      ...this.#triplet,
+      ...this.#locator,
     );
     return result.plaintext;
   }

--- a/packages/client/src/createCipherTextProperty.ts
+++ b/packages/client/src/createCipherTextProperty.ts
@@ -21,12 +21,12 @@ import type { MinimalClient } from "./MinimalClientContext.js";
 
 export class CipherTextPropertyImpl implements CipherText {
   #client: MinimalClient;
-  #triplet: [string, unknown, string];
+  #triplet: [string, any, string];
 
   constructor(args: {
     client: MinimalClient;
     objectApiName: string;
-    primaryKey: unknown;
+    primaryKey: any;
     propertyName: string;
   }) {
     const { client, objectApiName, primaryKey, propertyName } = args;
@@ -35,14 +35,11 @@ export class CipherTextPropertyImpl implements CipherText {
   }
 
   async decrypt(): Promise<string> {
-    const [objectApiName, primaryKey, propertyName] = this.#triplet;
     const ontologyRid = await this.#client.ontologyRid;
     const result = await cipherTextDecrypt(
       this.#client,
       ontologyRid,
-      objectApiName,
-      primaryKey as string,
-      propertyName,
+      ...this.#triplet,
     );
     invariant(
       typeof result.plaintext !== "undefined",

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -27,6 +27,7 @@ export type {
   ApplyActionOptions,
   ApplyBatchActionOptions,
   Attachment,
+  CipherText,
   CompileTimeMetadata,
   DerivedProperty,
   InterfaceDefinition,

--- a/packages/client/src/object/ciphertext.test.ts
+++ b/packages/client/src/object/ciphertext.test.ts
@@ -41,16 +41,8 @@ describe("cipherText", () => {
       .where({ id: stubData.objectWithAllPropertyTypes1.id }).fetchPage();
 
     expectTypeOf(object1.cipherText).toEqualTypeOf<CipherText | undefined>();
-    expect(object1.cipherText).toBeDefined();
     expect(typeof object1.cipherText?.decrypt).toBe("function");
-  });
-
-  it("decrypts the property value through the ontology endpoint", async () => {
-    const { data: [object1] } = await client(objectTypeWithAllPropertyTypes)
-      .where({ id: stubData.objectWithAllPropertyTypes1.id }).fetchPage();
-
     const plaintext = await object1.cipherText?.decrypt();
-
     // See packages/faux/src/handlers/createCipherTextHandlers.ts
     expect(plaintext).toBe(
       "decrypted:objectTypeWithAllPropertyTypes:1:cipherText",

--- a/packages/client/src/object/ciphertext.test.ts
+++ b/packages/client/src/object/ciphertext.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { CipherText } from "@osdk/api";
+import { objectTypeWithAllPropertyTypes } from "@osdk/client.test.ontology";
+import {
+  LegacyFauxFoundry,
+  startNodeApiServer,
+  stubData,
+} from "@osdk/shared.test";
+import { beforeAll, describe, expect, expectTypeOf, it } from "vitest";
+import type { Client } from "../Client.js";
+import { createClient } from "../createClient.js";
+
+describe("cipherText", () => {
+  let client: Client;
+
+  beforeAll(() => {
+    const testSetup = startNodeApiServer(new LegacyFauxFoundry(), createClient);
+    ({ client } = testSetup);
+    return () => {
+      testSetup.apiServer.close();
+    };
+  });
+
+  it("generates a CipherText-typed property", async () => {
+    const { data: [object1] } = await client(objectTypeWithAllPropertyTypes)
+      .where({ id: stubData.objectWithAllPropertyTypes1.id }).fetchPage();
+
+    expectTypeOf(object1.cipherText).toEqualTypeOf<CipherText | undefined>();
+    expect(object1.cipherText).toBeDefined();
+    expect(typeof object1.cipherText?.decrypt).toBe("function");
+  });
+
+  it("decrypts the property value through the ontology endpoint", async () => {
+    const { data: [object1] } = await client(objectTypeWithAllPropertyTypes)
+      .where({ id: stubData.objectWithAllPropertyTypes1.id }).fetchPage();
+
+    const plaintext = await object1.cipherText?.decrypt();
+
+    // See packages/faux/src/handlers/createCipherTextHandlers.ts
+    expect(plaintext).toBe(
+      "decrypted:objectTypeWithAllPropertyTypes:1:cipherText",
+    );
+  });
+});

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { PropertySecurity } from "@osdk/api";
+import type { BaseWirePropertyTypes, PropertySecurity } from "@osdk/api";
 import type { MediaReference } from "@osdk/foundry.core";
 import type {
   Attachment,
@@ -24,6 +24,7 @@ import type {
   SecuredPropertyValue,
 } from "@osdk/foundry.ontologies";
 import invariant from "tiny-invariant";
+import { CipherTextPropertyImpl } from "../../createCipherTextProperty.js";
 import { GeotimeSeriesPropertyImpl } from "../../createGeotimeSeriesProperty.js";
 import { MediaReferencePropertyImpl } from "../../createMediaReferenceProperty.js";
 import { TimeSeriesPropertyImpl } from "../../createTimeseriesProperty.js";
@@ -47,9 +48,10 @@ import {
 } from "./InternalSymbols.js";
 import type { ObjectHolder } from "./ObjectHolder.js";
 
-const specialPropertyTypes = new Set(
+const specialPropertyTypes = new Set<BaseWirePropertyTypes>(
   [
     "attachment",
+    "cipherText",
     "geotimeSeriesReference",
     "mediaReference",
     "numericTimeseries",
@@ -292,7 +294,18 @@ function createSpecialProperty(
       (rawValue as Attachment).rid,
     );
   }
-
+  if (propDef.type === "cipherText") {
+    return new CipherTextPropertyImpl(
+      {
+        client,
+        objectApiName: objectDef.apiName,
+        primaryKey: rawObject[
+          objectDef.primaryKeyApiName as string
+        ],
+        propertyName: p as string,
+      },
+    );
+  }
   if (
     propDef.type === "numericTimeseries"
     || propDef.type === "stringTimeseries"

--- a/packages/e2e.generated.catchall/ontology.json
+++ b/packages/e2e.generated.catchall/ontology.json
@@ -5797,6 +5797,97 @@
         }
       },
       "sharedPropertyTypeMapping": {}
+    },
+    "CipherTextTest": {
+      "objectType": {
+        "apiName": "CipherTextTest",
+        "displayName": "CipherTextTest",
+        "status": "EXPERIMENTAL",
+        "description": "",
+        "pluralDisplayName": "CipherTextTests",
+        "icon": {
+          "type": "blueprint",
+          "color": "#4C90F0",
+          "name": "cube"
+        },
+        "primaryKey": "pk",
+        "properties": {
+          "encrypted": {
+            "displayName": "encrypted",
+            "dataType": {
+              "type": "cipherText"
+            },
+            "rid": "ri.ontology.main.property.65b638f4-00b2-4a21-ae85-4b6a730daae4",
+            "status": {
+              "type": "experimental"
+            },
+            "visibility": "NORMAL",
+            "typeClasses": []
+          },
+          "hashed": {
+            "displayName": "hashed",
+            "dataType": {
+              "type": "cipherText"
+            },
+            "rid": "ri.ontology.main.property.8792e5f4-3547-4faf-8c02-779163dabf7c",
+            "status": {
+              "type": "experimental"
+            },
+            "visibility": "NORMAL",
+            "typeClasses": []
+          },
+          "plaintext": {
+            "displayName": "plaintext",
+            "dataType": {
+              "type": "string"
+            },
+            "rid": "ri.ontology.main.property.62a94791-6be7-4457-827f-9dc41d8ad954",
+            "status": {
+              "type": "experimental"
+            },
+            "visibility": "NORMAL",
+            "typeClasses": [
+              {
+                "kind": "render_hint",
+                "name": "SELECTABLE"
+              },
+              {
+                "kind": "render_hint",
+                "name": "SORTABLE"
+              }
+            ]
+          },
+          "pk": {
+            "displayName": "pk",
+            "dataType": {
+              "type": "string"
+            },
+            "rid": "ri.ontology.main.property.48147c7b-beb8-4d22-98e2-4c9c1b61ca70",
+            "status": {
+              "type": "experimental"
+            },
+            "visibility": "NORMAL",
+            "typeClasses": [
+              {
+                "kind": "render_hint",
+                "name": "SELECTABLE"
+              },
+              {
+                "kind": "render_hint",
+                "name": "SORTABLE"
+              }
+            ]
+          }
+        },
+        "rid": "ri.ontology.main.object-type.583bebf4-2a64-4af4-8c86-8068ef5a5371",
+        "titleProperty": "pk",
+        "visibility": "NORMAL",
+        "aliases": []
+      },
+      "linkTypes": [],
+      "implementsInterfaces": [],
+      "implementsInterfaces2": {},
+      "sharedPropertyTypeMapping": {}
     }
   },
   "queryTypes": {

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/index.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/index.ts
@@ -40,6 +40,7 @@ export {
   BgaoNflPlayer,
   BoundariesUsState,
   BuilderDeploymentState,
+  CipherTextTest,
   Country_1,
   DherlihyComplexObject,
   Employee,

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects.ts
@@ -1,6 +1,7 @@
 export { BgaoNflPlayer } from './objects/BgaoNflPlayer.js';
 export { BoundariesUsState } from './objects/BoundariesUsState.js';
 export { BuilderDeploymentState } from './objects/BuilderDeploymentState.js';
+export { CipherTextTest } from './objects/CipherTextTest.js';
 export { Country_1 } from './objects/Country_1.js';
 export { DherlihyComplexObject } from './objects/DherlihyComplexObject.js';
 export { Employee } from './objects/Employee.js';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/CipherTextTest.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/CipherTextTest.ts
@@ -1,0 +1,133 @@
+import type { PropertyDef as $PropertyDef } from '@osdk/client';
+import { $osdkMetadata } from '../../OntologyMetadata.js';
+import type { $ExpectedClientVersion } from '../../OntologyMetadata.js';
+import type {
+  PropertyKeys as $PropertyKeys,
+  ObjectTypeDefinition as $ObjectTypeDefinition,
+  ObjectMetadata as $ObjectMetadata,
+} from '@osdk/client';
+import type {
+  ObjectSet as $ObjectSet,
+  Osdk as $Osdk,
+  OsdkObject as $OsdkObject,
+  PropertyValueWireToClient as $PropType,
+  SingleLinkAccessor as $SingleLinkAccessor,
+} from '@osdk/client';
+
+export namespace CipherTextTest {
+  export type PropertyKeys = 'encrypted' | 'hashed' | 'pk' | 'plaintext';
+
+  export type Links = {};
+
+  export interface Props {
+    /**
+     * @experimental
+     *
+     *   property status: experimental
+     */
+    readonly encrypted: $PropType['cipherText'] | undefined;
+    /**
+     * @experimental
+     *
+     *   property status: experimental
+     */
+    readonly hashed: $PropType['cipherText'] | undefined;
+    /**
+     * @experimental
+     *
+     *   property status: experimental
+     */
+    readonly pk: $PropType['string'];
+    /**
+     * @experimental
+     *
+     *   property status: experimental
+     */
+    readonly plaintext: $PropType['string'] | undefined;
+  }
+  export type StrictProps = Props;
+
+  export interface ObjectSet extends $ObjectSet<CipherTextTest, CipherTextTest.ObjectSet> {}
+
+  export type OsdkInstance<
+    OPTIONS extends never | '$rid' = never,
+    K extends keyof CipherTextTest.Props = keyof CipherTextTest.Props,
+  > = $Osdk.Instance<CipherTextTest, OPTIONS, K>;
+
+  /** @deprecated use OsdkInstance */
+  export type OsdkObject<
+    OPTIONS extends never | '$rid' = never,
+    K extends keyof CipherTextTest.Props = keyof CipherTextTest.Props,
+  > = OsdkInstance<OPTIONS, K>;
+}
+
+export interface CipherTextTest extends $ObjectTypeDefinition {
+  osdkMetadata: typeof $osdkMetadata;
+  type: 'object';
+  apiName: 'CipherTextTest';
+  primaryKeyApiName: 'pk';
+  primaryKeyType: 'string';
+  __DefinitionMetadata?: {
+    objectSet: CipherTextTest.ObjectSet;
+    props: CipherTextTest.Props;
+    linksType: CipherTextTest.Links;
+    strictProps: CipherTextTest.StrictProps;
+    apiName: 'CipherTextTest';
+    description: '';
+    displayName: 'CipherTextTest';
+    icon: {
+      type: 'blueprint';
+      color: '#4C90F0';
+      name: 'cube';
+    };
+    implements: [];
+    interfaceMap: {};
+    inverseInterfaceMap: {};
+    links: {};
+    pluralDisplayName: 'CipherTextTests';
+    primaryKeyApiName: 'pk';
+    primaryKeyType: 'string';
+    properties: {
+      /**
+       * @experimental
+       *
+       *   property status: experimental
+       */
+      encrypted: $PropertyDef<'cipherText', 'nullable', 'single'>;
+      /**
+       * @experimental
+       *
+       *   property status: experimental
+       */
+      hashed: $PropertyDef<'cipherText', 'nullable', 'single'>;
+      /**
+       * @experimental
+       *
+       *   property status: experimental
+       */
+      pk: $PropertyDef<'string', 'non-nullable', 'single'>;
+      /**
+       * @experimental
+       *
+       *   property status: experimental
+       */
+      plaintext: $PropertyDef<'string', 'nullable', 'single'>;
+    };
+    rid: 'ri.ontology.main.object-type.583bebf4-2a64-4af4-8c86-8068ef5a5371';
+    status: 'EXPERIMENTAL';
+    titleProperty: 'pk';
+    type: 'object';
+    visibility: 'NORMAL';
+  };
+}
+
+export const CipherTextTest = {
+  type: 'object',
+  apiName: 'CipherTextTest',
+  osdkMetadata: $osdkMetadata,
+  primaryKeyApiName: 'pk',
+  primaryKeyType: 'string',
+  internalDoNotUseMetadata: {
+    rid: 'ri.ontology.main.object-type.583bebf4-2a64-4af4-8c86-8068ef5a5371',
+  },
+} satisfies CipherTextTest & { internalDoNotUseMetadata: { rid: string } } as CipherTextTest;

--- a/packages/e2e.sandbox.catchall/src/client.ts
+++ b/packages/e2e.sandbox.catchall/src/client.ts
@@ -73,7 +73,7 @@ export const mjClient: Client = createClient(
   loggingFetch,
 );
 
-export const eaOntologyClient: Client = createClient(
+export const cipherTextOntologyClient: Client = createClient(
   process.env.FOUNDRY_STACK,
   "ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e",
   async () => process.env.FOUNDRY_USER_TOKEN!,

--- a/packages/e2e.sandbox.catchall/src/client.ts
+++ b/packages/e2e.sandbox.catchall/src/client.ts
@@ -73,6 +73,14 @@ export const mjClient: Client = createClient(
   loggingFetch,
 );
 
+export const eaOntologyClient: Client = createClient(
+  process.env.FOUNDRY_STACK,
+  "ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e",
+  async () => process.env.FOUNDRY_USER_TOKEN!,
+  { logger },
+  loggingFetch,
+);
+
 /**
  * Generally consumers wont need this and will use their createClient() but
  * I want to use this to be sure everything works.

--- a/packages/e2e.sandbox.catchall/src/runCipherTextTest.ts
+++ b/packages/e2e.sandbox.catchall/src/runCipherTextTest.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CipherTextTest } from "@osdk/e2e.generated.catchall";
+import invariant from "tiny-invariant";
+import { eaOntologyClient } from "./client.js";
+
+export async function runCipherTextTest(): Promise<void> {
+  const nonNullPk = "784691a7-2203-4088-8c0c-43b5cb25e563";
+  const result = await eaOntologyClient(CipherTextTest).fetchOne(
+    nonNullPk,
+  );
+  const plaintextTruth = result.plaintext;
+  const plaintext = await result.encrypted?.decrypt();
+  invariant(
+    plaintext === plaintextTruth,
+    "Expected plaintext == plaintextTruth",
+  );
+
+  const { data: nullFilterTestData } = await eaOntologyClient(
+    CipherTextTest,
+  ).where({
+    encrypted: {
+      $isNull: true,
+    },
+  }).fetchPage();
+
+  invariant(
+    typeof nullFilterTestData?.[0]?.plaintext === "undefined",
+    "Expected null object to have empty plaintext",
+  );
+
+  const { data: nonNullFilterTestData } = await eaOntologyClient(CipherTextTest)
+    .where({
+      encrypted: {
+        $eq:
+          "CIPHER::ri.bellaso.main.cipher-channel.fac3283c-c2c1-4570-b7ca-f9ec5fd9df80::oZ7g+aCWqU+CZjzhl5F3FspKSa0ijiiNuFcZ6c6IV8LOHH9VQ2Y3NcVPB7QOZNCgjHOShA==::CIPHER",
+      },
+    }).fetchPage();
+
+  invariant(
+    nonNullFilterTestData?.[0]?.pk === nonNullPk,
+    "Expected non-null object to have same pk",
+  );
+
+  console.log("All tests passed!");
+}
+
+void runCipherTextTest();

--- a/packages/e2e.sandbox.catchall/src/runCipherTextTest.ts
+++ b/packages/e2e.sandbox.catchall/src/runCipherTextTest.ts
@@ -16,11 +16,11 @@
 
 import { CipherTextTest } from "@osdk/e2e.generated.catchall";
 import invariant from "tiny-invariant";
-import { eaOntologyClient } from "./client.js";
+import { cipherTextOntologyClient } from "./client.js";
 
 export async function runCipherTextTest(): Promise<void> {
   const nonNullPk = "784691a7-2203-4088-8c0c-43b5cb25e563";
-  const result = await eaOntologyClient(CipherTextTest).fetchOne(
+  const result = await cipherTextOntologyClient(CipherTextTest).fetchOne(
     nonNullPk,
   );
   const plaintextTruth = result.plaintext;
@@ -30,7 +30,7 @@ export async function runCipherTextTest(): Promise<void> {
     "Expected plaintext == plaintextTruth",
   );
 
-  const { data: nullFilterTestData } = await eaOntologyClient(
+  const { data: nullFilterTestData } = await cipherTextOntologyClient(
     CipherTextTest,
   ).where({
     encrypted: {
@@ -43,7 +43,9 @@ export async function runCipherTextTest(): Promise<void> {
     "Expected null object to have empty plaintext",
   );
 
-  const { data: nonNullFilterTestData } = await eaOntologyClient(CipherTextTest)
+  const { data: nonNullFilterTestData } = await cipherTextOntologyClient(
+    CipherTextTest,
+  )
     .where({
       encrypted: {
         $eq:

--- a/packages/faux/src/handlers/createCipherTextHandlers.ts
+++ b/packages/faux/src/handlers/createCipherTextHandlers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/faux/src/handlers/createCipherTextHandlers.ts
+++ b/packages/faux/src/handlers/createCipherTextHandlers.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable @typescript-eslint/require-await */
+
+import { OntologiesV2 } from "../mock/index.js";
+import type { FauxFoundryHandlersFactory } from "./createFauxFoundryHandlers.js";
+
+export const createCipherTextHandlers: FauxFoundryHandlersFactory = (
+  baseUrl,
+  fauxFoundry,
+) => [
+  /**
+   * Decrypt a ciphertext property value.
+   */
+  OntologiesV2.CipherTextProperties.decrypt(
+    baseUrl,
+    async (
+      { params: { ontologyApiName, objectType, primaryKey, propertyName } },
+    ) => {
+      fauxFoundry.getDataStore(ontologyApiName).getObjectOrThrow(
+        objectType,
+        primaryKey,
+      );
+      return {
+        // Just return a deterministic string that acts as plaintext
+        plaintext: `decrypted:${objectType}:${primaryKey}:${propertyName}`,
+      };
+    },
+  ),
+];

--- a/packages/faux/src/handlers/createFauxFoundryHandlers.ts
+++ b/packages/faux/src/handlers/createFauxFoundryHandlers.ts
@@ -19,6 +19,7 @@ import type { FauxFoundry } from "../FauxFoundry/FauxFoundry.js";
 import { createActionHandlers } from "./createActionHandlers.js";
 import { createAdminHandlers } from "./createAdminHandlers.js";
 import { createAttachmentHandlers } from "./createAttachmentHandlers.js";
+import { createCipherTextHandlers } from "./createCipherTextHandlers.js";
 import { createLoadObjectsHandlers } from "./createLoadObjectsHandlers.js";
 import { createMediaRefHandlers } from "./createMediaRefHandlers.js";
 import { createMultipassServerHandlers } from "./createMultipassServerHandlers.js";
@@ -46,6 +47,7 @@ export function createFauxFoundryHandlers(
     createTimeseriesAndGeotimeHandlers,
     createAttachmentHandlers,
     createMediaRefHandlers,
+    createCipherTextHandlers,
     createAdminHandlers,
   ].flatMap(x => x(baseUrl, fauxFoundry));
 }

--- a/packages/faux/src/mock/OntologiesV2/CipherTextProperties.ts
+++ b/packages/faux/src/mock/OntologiesV2/CipherTextProperties.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/faux/src/mock/OntologiesV2/CipherTextProperties.ts
+++ b/packages/faux/src/mock/OntologiesV2/CipherTextProperties.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,30 +14,14 @@
  * limitations under the License.
  */
 
-export type WirePropertyTypes =
-  | BaseWirePropertyTypes
-  | Record<string, BaseWirePropertyTypes>;
+import { CipherTextProperties } from "@osdk/foundry.ontologies";
+import type { CallFactory } from "../../handlers/util/handleOpenApiCall.js";
+import { handleOpenApiCall } from "../../handlers/util/handleOpenApiCall.js";
 
-export type BaseWirePropertyTypes =
-  | "string"
-  | "datetime"
-  | "double"
-  | "boolean"
-  | "integer"
-  | "timestamp"
-  | "short"
-  | "long"
-  | "float"
-  | "decimal"
-  | "byte"
-  | "marking"
-  | "cipherText"
-  | "mediaReference"
-  | "numericTimeseries"
-  | "stringTimeseries"
-  | "sensorTimeseries"
-  | "attachment"
-  | "geopoint"
-  | "geoshape"
-  | "geotimeSeriesReference"
-  | "vector";
+export const decrypt: CallFactory<
+  "ontologyApiName" | "objectType" | "primaryKey" | "propertyName",
+  typeof CipherTextProperties.decrypt
+> = handleOpenApiCall(
+  CipherTextProperties.decrypt,
+  ["ontologyApiName", "objectType", "primaryKey", "propertyName"],
+);

--- a/packages/faux/src/mock/OntologiesV2/index.ts
+++ b/packages/faux/src/mock/OntologiesV2/index.ts
@@ -18,6 +18,7 @@ export * as Actions from "./Actions.js";
 export * as ActionTypesV2 from "./ActionTypesV2.js";
 export * as AttachmentPropertiesV2 from "./AttachmentPropertiesV2.js";
 export * as Attachments from "./Attachments.js";
+export * as CipherTextProperties from "./CipherTextProperties.js";
 export * as LinkedObjectsV2 from "./LinkedObjectsV2.js";
 export * as MediaReferenceProperties from "./MediaReferenceProperties.js";
 export * as ObjectTypesV2 from "./ObjectTypesV2.js";

--- a/packages/foundry-sdk-generator/src/ontologyMetadata/ontologyMetadataResolver.ts
+++ b/packages/foundry-sdk-generator/src/ontologyMetadata/ontologyMetadataResolver.ts
@@ -744,8 +744,6 @@ export class OntologyMetadataResolver {
       case "null":
       case "void":
         return Result.ok({});
-      case "mediaReference":
-      case "typeReference":
       case "unsupported":
         return Result.err([
           `Unable to load query ${queryApiName} because it takes an unsupported parameter type: ${

--- a/packages/generator-converters/src/wirePropertyV2ToSdkPropertyDefinition.ts
+++ b/packages/generator-converters/src/wirePropertyV2ToSdkPropertyDefinition.ts
@@ -117,6 +117,7 @@ export function wirePropertyV2ToSdkPropertyDefinition(
     case "timeseries":
     case "geotimeSeriesReference":
     case "vector":
+    case "cipherText":
       return {
         displayName: input.displayName,
         multiplicity: false,
@@ -171,14 +172,6 @@ export function wirePropertyV2ToSdkPropertyDefinition(
         ...extractTypeMetadata(input.dataType),
       };
     }
-    case "cipherText": {
-      log?.info(
-        `${JSON.stringify(input.dataType.type)} is not a supported dataType`,
-      );
-
-      return undefined;
-    }
-
     default:
       const _: never = input.dataType;
       log?.info(
@@ -211,6 +204,7 @@ function objectPropertyTypeToSdkPropertyDefinition(
     case "geotimeSeriesReference":
     case "mediaReference":
     case "vector":
+    case "cipherText":
       return propertyType.type;
     case "date":
       return "datetime";
@@ -233,13 +227,6 @@ function objectPropertyTypeToSdkPropertyDefinition(
         },
         {},
       );
-    }
-    case "cipherText": {
-      log?.info(
-        `${JSON.stringify(propertyType.type)} is not a supported propertyType`,
-      );
-
-      return undefined;
     }
     default: {
       const _: never = propertyType;

--- a/packages/shared.test/src/stubs/objectTypeV2.ts
+++ b/packages/shared.test/src/stubs/objectTypeV2.ts
@@ -569,6 +569,13 @@ export const objectTypeWithAllPropertyTypes: ObjectTypeV2 = {
       rid: "rid",
       typeClasses: [],
     },
+    cipherText: {
+      dataType: {
+        type: "cipherText",
+      },
+      rid: "rid",
+      typeClasses: [],
+    },
   },
   rid: "ri.ontology.main.object-type.401ac022-89eb-4591-8b7e-0a912b9efb44",
   status: "ACTIVE",

--- a/packages/shared.test/src/stubs/objects.ts
+++ b/packages/shared.test/src/stubs/objects.ts
@@ -281,6 +281,7 @@ export const objectWithAllPropertyTypes1 = {
       },
     },
   },
+  cipherText: "ciphertext-encrypted-value",
 } as const;
 
 export const objectWithAllPropertyTypesEmptyEntries = {
@@ -366,6 +367,7 @@ export const objectWithAllPropertyTypes2 = {
     },
   ],
   mediaReference: "ri.MediaReferencePlaceholder2",
+  cipherText: "ciphertext-encrypted-value",
 } as const;
 
 export const basicPropertySecurities: PropertySecurities[] = [


### PR DESCRIPTION
## Summary

Adds end-to-end support for `cipherText` ontology properties: they now flow through codegen and are exposed on OSDK objects as a `CipherText` value whose plaintext can be retrieved on demand via `.decrypt()`.

Previously the generator-converters explicitly dropped `cipherText` properties (logging `"... is not a supported dataType"` and returning `undefined`), so they never appeared on generated objects.

## Changes

**API surface (`@osdk/api`)**
- New `CipherText` interface (`packages/api/src/object/CipherText.ts`): an opaque handle exposing `decrypt(): Promise<string>`.
- Registered `cipherText` in `BaseWirePropertyTypes` and mapped it to `CipherText` across `PropertyValueWireToClient` / `ClientToWire` / `WireToCreate`.

**Codegen (`@osdk/generator-converters`)**
- `wirePropertyV2ToSdkPropertyDefinition` now emits a real property definition for `cipherText` instead of skipping it (in both the dataType and objectPropertyType switches).

**Client (`@osdk/client`)**
- `CipherTextPropertyImpl` (`createCipherTextProperty.ts`) holds the `(objectApiName, primaryKey, propertyName)` triplet and calls the `CipherTextProperty.decrypt` ontologies endpoint, resolving to the plaintext.
- `createOsdkObject` treats `cipherText` as a special property type and instantiates the impl lazily.

**Faux / test infra (`@osdk/faux`, `@osdk/shared.test`)**
- New `CipherTextProperties.decrypt` mock handler returning a deterministic `decrypted:<objectType>:<pk>:<propertyName>` string.
- Added a `cipherText` property to the all-property-types stub object/objectTypeV2.

## Testing

- New `packages/client/src/object/ciphertext.test.ts` verifies the generated property is typed `CipherText | undefined` and that `.decrypt()` round-trips through the ontology endpoint.
- e2e sandbox runner (`runCipherTextTest.ts`) and generated `CipherTextTest` object added to the catchall fixtures.

## Usage

```typescript
const result = await client(CipherTextObject).fetchOne("pk-001");
const plaintext = await result.encryptedField?.decrypt();
```

Note that if the cipher text property key does not contain a value it will be omitted from the raw object itself; check for `Object.prototype.hasOwnProperty.call(result, "encryptedField")` for empty value checks