### PR TITLE
Added datasets and mediaSets to ScopeResources in @osdk/functions

### DIFF
--- a/.changeset/olive-brooms-dream.md
+++ b/.changeset/olive-brooms-dream.md
@@ -1,0 +1,5 @@
+---
+"@osdk/functions": minor
+---
+
+Added datasets and mediaSets to ScopeResources

--- a/packages/functions/src/scope/types.ts
+++ b/packages/functions/src/scope/types.ts
@@ -36,7 +36,7 @@ export interface ScopeResources {
   links?: string[];
   models?: string[];
   datasets?: string[];
-  mediaSets?: string[];
+  mediasets?: string[];
   streams?: string[];
 }
 

--- a/packages/functions/src/scope/types.ts
+++ b/packages/functions/src/scope/types.ts
@@ -37,6 +37,7 @@ export interface ScopeResources {
   models?: string[];
   datasets?: string[];
   mediaSets?: string[];
+  streams?: string[];
 }
 
 /**

--- a/packages/functions/src/scope/types.ts
+++ b/packages/functions/src/scope/types.ts
@@ -27,7 +27,7 @@ import type {
  * - A string alias from resources.json (e.g. `"myObject"`)
  * - An OSDK type reference imported from your generated ontology SDK (e.g. `Employee`)
  *
- * For `links`, and `models`, only string aliases are supported.
+ * For `links`, `datasets`, `mediaSets` and `models`, only string aliases are supported.
  */
 export interface ScopeResources {
   queries?: Array<string | QueryDefinition>;
@@ -35,6 +35,8 @@ export interface ScopeResources {
   interfaces?: Array<string | InterfaceDefinition>;
   links?: string[];
   models?: string[];
+  datasets?: string[];
+  mediaSets?: string[];
 }
 
 /**

--- a/packages/functions/src/scope/types.ts
+++ b/packages/functions/src/scope/types.ts
@@ -27,7 +27,7 @@ import type {
  * - A string alias from resources.json (e.g. `"myObject"`)
  * - An OSDK type reference imported from your generated ontology SDK (e.g. `Employee`)
  *
- * For `links`, `datasets`, `mediaSets` and `models`, only string aliases are supported.
+ * For `links`, `datasets`, `streams`, `mediasets` and `models`, only string aliases are supported.
  */
 export interface ScopeResources {
   queries?: Array<string | QueryDefinition>;


### PR DESCRIPTION
datasets and mediasets are new fields that would allow functions to declare these types resources as part of the scope

```tsx
  import { FunctionConfig } from "@osdk/functions";

  export const config: FunctionConfig = {
    scope: {
      resources: { datasets: ["myDataset"], mediasets: ["myMediaSet"], streams: ["myStreamingDataset"]},
      authorization: { read: ["marking1"], write: ["marking2"] },
    },
  };
  export function myFunction(): void {}

```