### PR TITLE
Revert "Remove AIP entrypoints (#3406)"

### DIFF
--- a/.changeset/aip-entrypoints-return.md
+++ b/.changeset/aip-entrypoints-return.md
@@ -1,0 +1,7 @@
+---
+"@osdk/aip-core": minor
+"@osdk/react": minor
+"@osdk/react-components": minor
+---
+
+Restore the AIP chat entry points (`@osdk/react/experimental/aip` and `@osdk/react-components/experimental/aip-agent-chat`) and publish `@osdk/aip-core` so the optional peer dependency resolves from the registry.

--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -118,7 +118,6 @@ const archetypeRules = archetypes(
   .addArchetype(
     "minimal packages",
     [
-      "@osdk/aip-core",
       "@osdk/e2e.generated.1.1.x",
       "@osdk/examples.*",
       "@psdk/examples.*",
@@ -134,6 +133,7 @@ const archetypeRules = archetypes(
   .addArchetype(
     "standardLibraries",
     [
+      "@osdk/aip-core",
       "@osdk/foundry-config-json",
       "@osdk/generator-converters",
       "@osdk/generator-converters.ontologyir",

--- a/packages/aip-core/package.json
+++ b/packages/aip-core/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@osdk/aip-core",
-  "private": true,
   "version": "0.5.0",
   "description": "Core building blocks for the AIP SDK: streaming chat completions, tool calling, and chat transports backed by the Foundry Language Model Service",
   "access": "public",

--- a/packages/e2e.sandbox.peopleapp/package.json
+++ b/packages/e2e.sandbox.peopleapp/package.json
@@ -38,11 +38,15 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
+    "@ai-sdk/provider": "^3.0.8",
+    "@ai-sdk/react": "^3.0.170",
+    "@osdk/aip-core": "workspace:~",
     "@osdk/api": "workspace:~",
     "@osdk/client": "workspace:~",
     "@osdk/oauth": "workspace:~",
     "@osdk/react": "workspace:~",
     "@osdk/react-components": "workspace:~",
+    "ai": "^6.0.168",
     "core-js": "^3.45.1",
     "maplibre-gl": "^5.7.1",
     "react": "^18.3.1",

--- a/packages/e2e.sandbox.peopleapp/src/App.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/App.tsx
@@ -15,6 +15,8 @@ function PeopleApp() {
     ? "action-form-filter-list-repro"
     : path === "/form"
     ? "form"
+    : path === "/aip-agent-chat"
+    ? "aip-agent-chat"
     : "offices";
 
   return (
@@ -56,6 +58,13 @@ function PeopleApp() {
           onClick={() => navigate("/form")}
         >
           Form
+        </Button>
+        <Button
+          variant="tab"
+          active={activeTab === "aip-agent-chat"}
+          onClick={() => navigate("/aip-agent-chat")}
+        >
+          AipAgentChat
         </Button>
       </div>
 

--- a/packages/e2e.sandbox.peopleapp/src/app/aip-agent-chat/page.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/aip-agent-chat/page.tsx
@@ -1,0 +1,15 @@
+import { AipAgentChat } from "@osdk/react-components/experimental/aip-agent-chat";
+import { platformClient } from "../../foundryClient.js";
+
+const AVAILABLE_MODELS = ["gpt-4o", "gpt-5.4", "non-existent-model"];
+
+export function AipAgentChatPage() {
+  return (
+    <div className="w-full max-w-2xl flex flex-col h-[70vh]">
+      <AipAgentChat
+        client={platformClient}
+        availableModels={AVAILABLE_MODELS}
+      />
+    </div>
+  );
+}

--- a/packages/e2e.sandbox.peopleapp/src/router.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/router.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import PeopleApp from "./App.js";
 import { EmployeeActionFormFilterListReproPage } from "./app/action-form-filter-list-repro/page.js";
+import { AipAgentChatPage } from "./app/aip-agent-chat/page.js";
 import { AuthCallbackPage } from "./app/auth/callback/page.js";
 import { EmployeesFilterListPage } from "./app/employees/filterListPage.js";
 import { EmployeesPage } from "./app/employees/page.js";
@@ -41,6 +42,10 @@ const router = createBrowserRouter([
       {
         path: "/form",
         element: <FormPage />,
+      },
+      {
+        path: "/aip-agent-chat",
+        element: <AipAgentChatPage />,
       },
     ],
   },

--- a/packages/react-components/AGENTS.md
+++ b/packages/react-components/AGENTS.md
@@ -44,6 +44,7 @@ Components are imported from their individual entry points under `@osdk/react-co
 - `@osdk/react-components/experimental/pdf-viewer` — PdfViewer, BasePdfViewer, and building blocks/hooks
 - `@osdk/react-components/experimental/tiff-renderer` — TiffRenderer
 - `@osdk/react-components/experimental/markdown-renderer` — MarkdownRenderer
+- `@osdk/react-components/experimental/aip-agent-chat` — AipAgentChat, BaseAipAgentChat
 - `@osdk/react-components/experimental/document-viewer` — DocumentViewer
 - `@osdk/react-components/experimental/email-viewer` — EmailViewer, BaseEmailViewer
 - `@osdk/react-components/experimental/excel-viewer` — ExcelViewer, BaseExcelViewer
@@ -64,6 +65,8 @@ Components are imported from their individual entry points under `@osdk/react-co
 | **BasePdfViewer**          | OSDK-agnostic base PDF viewer — accepts a URL or ArrayBuffer directly. Use when building custom data fetching on top of the viewer UI.      |
 | **TiffRenderer**           | TIFF image renderer — accepts a `Uint8Array` and renders onto a canvas with size validation and error handling.                             |
 | **MarkdownRenderer**       | Markdown renderer that accepts a markdown string and renders it with styled headings, code blocks, tables, and links.                       |
+| **AipAgentChat**           | Chat surface backed by Foundry LMS via `useChat`. Takes a `PlatformClient` + model API name and renders messages, composer, and streaming.  |
+| **BaseAipAgentChat**       | OSDK-agnostic base chat — accepts `messages`/`status`/`onSendMessage` directly. Use for custom chat-state plumbing.                         |
 | **DocumentViewer**         | Unified media viewer that auto-detects file type (PDF, TIFF, image, video, Excel, email, markdown, XML) and renders the appropriate viewer. |
 | **EmailViewer**            | Email viewer — parses and renders `.eml` files with headers, HTML body (sandboxed iframe), and plain text fallback.                         |
 | **ExcelViewer**            | Excel viewer — parses and renders `.xlsx` spreadsheets with sheet tabs and column/row headers.                                              |

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -125,19 +125,20 @@ Add `isolation: isolate` to your app's root element. This is required for Base U
 
 The components that this package will provide are:
 
-| Component        | Description                                                                         | Documentation                                                                                           |
-| ---------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `ObjectTable`    | Displays an Object Set as a sortable, paginated table with inline editing support   | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/ObjectTable.md)    |
-| `PdfViewer`      | Renders PDF documents with annotations, search, sidebar navigation, and zoom        | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/PdfViewer.md)      |
-| `FilterList`     | Visualize a high-level summary of objects data to allow users to filter that data.  | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/FilterList.md)     |
-| `ActionForm`     | Auto-generated form for executing Ontology Actions                                  | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/ActionForm.md)     |
-| `DocumentViewer` | Unified media viewer that auto-detects file type and renders the appropriate viewer | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/DocumentViewer.md) |
-| `EmailViewer`    | Parses and renders EML files with headers and sandboxed HTML body                   | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/EmailViewer.md)    |
-| `ExcelViewer`    | Renders Excel spreadsheets with sheet tabs and column/row headers                   | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/ExcelViewer.md)    |
-| `ImageViewer`    | Renders images (PNG, JPEG, GIF, SVG, WebP, BMP)                                     | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/ImageViewer.md)    |
-| `VideoViewer`    | Renders video with native browser controls                                          | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/VideoViewer.md)    |
-| `XmlViewer`      | Renders XML content with syntax preservation                                        | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/XmlViewer.md)      |
-| `CbacPicker`     | Picker for classification-based access control (CBAC) markings with banner display  | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/CbacPicker.md)     |
+| Component        | Description                                                                                     | Documentation                                                                                           |
+| ---------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `ObjectTable`    | Displays an Object Set as a sortable, paginated table with inline editing support               | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/ObjectTable.md)    |
+| `PdfViewer`      | Renders PDF documents with annotations, search, sidebar navigation, and zoom                    | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/PdfViewer.md)      |
+| `FilterList`     | Visualize a high-level summary of objects data to allow users to filter that data.              | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/FilterList.md)     |
+| `ActionForm`     | Auto-generated form for executing Ontology Actions                                              | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/ActionForm.md)     |
+| `AipAgentChat`   | Chat surface backed by Foundry LMS via `useChat` — takes a `PlatformClient` and model API name. | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/AipAgentChat.md)   |
+| `DocumentViewer` | Unified media viewer that auto-detects file type and renders the appropriate viewer             | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/DocumentViewer.md) |
+| `EmailViewer`    | Parses and renders EML files with headers and sandboxed HTML body                               | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/EmailViewer.md)    |
+| `ExcelViewer`    | Renders Excel spreadsheets with sheet tabs and column/row headers                               | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/ExcelViewer.md)    |
+| `ImageViewer`    | Renders images (PNG, JPEG, GIF, SVG, WebP, BMP)                                                 | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/ImageViewer.md)    |
+| `VideoViewer`    | Renders video with native browser controls                                                      | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/VideoViewer.md)    |
+| `XmlViewer`      | Renders XML content with syntax preservation                                                    | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/XmlViewer.md)      |
+| `CbacPicker`     | Picker for classification-based access control (CBAC) markings with banner display              | [Guide](https://github.com/palantir/osdk-ts/blob/main/packages/react-components/docs/CbacPicker.md)     |
 
 ## Component Architecture
 

--- a/packages/react-components/docs/AipAgentChat.md
+++ b/packages/react-components/docs/AipAgentChat.md
@@ -1,0 +1,207 @@
+# AipAgentChat
+
+A React component for rendering an AI chat surface backed by Foundry's
+LMS via `useChat` from `@osdk/react/experimental/aip`. Importing the
+component is sufficient — consumers do not need to import `useChat` or
+`foundryModel` themselves.
+
+## Import
+
+```tsx
+import {
+  AipAgentChat,
+  BaseAipAgentChat,
+} from "@osdk/react-components/experimental/aip-agent-chat";
+```
+
+- **`AipAgentChat`** — Primary component for OSDK usage. Accepts a
+  Foundry `PlatformClient` and an LMS model API name; constructs the
+  language-model handle, drives `useChat`, and renders the chat UI.
+- **`BaseAipAgentChat`** — Lower-level OSDK-agnostic component that
+  accepts `messages`, `status`, and `onSendMessage` directly. Use this
+  when you already manage chat state yourself (a custom hook, a
+  non-OSDK backend, etc.).
+
+## Usage
+
+### Minimal
+
+```tsx
+import { AipAgentChat } from "@osdk/react-components/experimental/aip-agent-chat";
+import { platformClient } from "./foundryClient.js";
+
+// `model` and `defaultModel` are both optional — falls back to "gpt-4o".
+<AipAgentChat client={platformClient} />;
+```
+
+### Pinned model
+
+```tsx
+<AipAgentChat
+  client={platformClient}
+  model="gpt-4o"
+  system="You are a concise assistant. Keep answers short."
+/>;
+```
+
+### With model picker (controlled)
+
+```tsx
+function MyChat() {
+  const [model, setModel] = useState("gpt-4o");
+  return (
+    <AipAgentChat
+      client={platformClient}
+      model={model}
+      availableModels={["gpt-4o", "AnthropicClaude_4_6_Sonnet"]}
+      onModelChange={setModel}
+    />
+  );
+}
+```
+
+### With model picker (uncontrolled)
+
+```tsx
+<AipAgentChat
+  client={platformClient}
+  defaultModel="gpt-4o"
+  availableModels={["gpt-4o", "AnthropicClaude_4_6_Sonnet"]}
+  onModelChange={(modelName) => analytics.track({ modelName })}
+/>;
+```
+
+The component manages model state internally; `onModelChange` is a
+non-controlling listener (analytics, persistence, etc.).
+
+### Custom render
+
+```tsx
+import {
+  AipAgentChat,
+  getUIMessageText,
+  type UIMessage,
+} from "@osdk/react-components/experimental/aip-agent-chat";
+
+<AipAgentChat
+  client={platformClient}
+  model="gpt-4o"
+  renderMessage={(message: UIMessage) => (
+    <div>
+      <strong>{message.role}:</strong> {getUIMessageText(message)}
+    </div>
+  )}
+  renderEmptyState={() => <p>Ready when you are.</p>}
+/>;
+```
+
+### Drop down to BaseAipAgentChat
+
+`BaseAipAgentChat` is OSDK-agnostic — the consumer drives the chat by
+passing the current `messages`, `status`, `error`, and an `onSendMessage`
+callback that resolves once the user's message has been forwarded.
+Use it for non-OSDK backends, custom transports, or unit tests.
+
+```tsx
+import {
+  BaseAipAgentChat,
+  type ChatStatus,
+  type UIMessage,
+} from "@osdk/react-components/experimental/aip-agent-chat";
+
+function MyChat() {
+  const [messages, setMessages] = useState<ReadonlyArray<UIMessage>>([]);
+  const [status, setStatus] = useState<ChatStatus>("ready");
+  const [error, setError] = useState<Error | undefined>();
+
+  return (
+    <BaseAipAgentChat
+      messages={messages}
+      status={status}
+      error={error}
+      onSendMessage={async (text) => {
+        setStatus("submitted");
+        try {
+          const reply = await callMyBackend(text, { history: messages });
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: crypto.randomUUID(),
+              role: "user",
+              parts: [{ type: "text", text }],
+            },
+            {
+              id: crypto.randomUUID(),
+              role: "assistant",
+              parts: [{ type: "text", text: reply }],
+            },
+          ]);
+          setStatus("ready");
+        } catch (err) {
+          setError(err as Error);
+          setStatus("error");
+        }
+      }}
+      onStop={() => setStatus("ready")}
+      onClearError={() => setError(undefined)}
+    />
+  );
+}
+```
+
+### Drop further: useChat directly
+
+For full control over the chat hook (regenerate, multi-step agent
+loops, custom transports), call `useChat` from `@osdk/react/experimental/aip`
+yourself and feed the result into your own UI.
+
+```tsx
+import { foundryModel } from "@osdk/aip-core";
+import { useChat } from "@osdk/react/experimental/aip";
+
+function MyChat() {
+  const lmsModel = useMemo(
+    () => foundryModel({ client: platformClient, model: "gpt-4o" }),
+    [],
+  );
+  const { messages, status, error, sendMessage, stop, clearError } = useChat({
+    model: lmsModel,
+  });
+
+  return (
+    <YourCustomChatLayout
+      messages={messages}
+      status={status}
+      error={error}
+      onSend={(text) => void sendMessage({ text })}
+      onStop={stop}
+      onClearError={clearError}
+    />
+  );
+}
+```
+
+## Props
+
+See [`AipAgentChatApi.ts`](../src/aip-agent-chat/AipAgentChatApi.ts) for
+the full prop list with JSDoc. `client` is the only required prop.
+`model` (controlled) and `defaultModel` (uncontrolled) are both
+optional; if neither is supplied the chat falls back to the first
+entry of `availableModels` (when provided), or to `"gpt-4o"`. Notable
+optional props:
+
+- `availableModels` + `onModelChange` — render a model picker in the
+  composer footer.
+- `system` — system prompt prepended to every request.
+- `initialMessages` — seed conversation snapshot.
+- `enableAutoScroll` (default `true`) — auto-pin to the bottom of the
+  message list as new tokens arrive.
+- `renderEmptyState` / `renderMessage` — render overrides.
+- `onError`, `onFinish` — listeners forwarded to `useChat`.
+
+## Theming
+
+CSS variables are documented in
+[`docs/CSSVariables.md`](./CSSVariables.md). The `--osdk-aip-agent-chat-*`
+namespace covers spacing, bubble colors, composer styling, and the
+3-dot loader.

--- a/packages/react-components/docs/CSSVariables.md
+++ b/packages/react-components/docs/CSSVariables.md
@@ -232,6 +232,38 @@ Component-specific semantic tokens that may reference Blueprint tokens or define
 | `--osdk-surface-border`               | `var(--osdk-surface-border-width) solid var(--osdk-surface-border-color-default)` | Reusable border shorthand      |
 | `--osdk-disabled-opacity`             | `0.5`                                                                             | Disabled state opacity         |
 
+### AIP Agent Chat
+
+Tokens for the `AipAgentChat` chat surface (container, message bubbles, composer, empty state, loader, error banner).
+
+| Variable                                             | Default Value                                       | Description                                 |
+| ---------------------------------------------------- | --------------------------------------------------- | ------------------------------------------- |
+| `--osdk-aip-agent-chat-background`                   | `var(--osdk-background-primary)`                    | Chat container background                   |
+| `--osdk-aip-agent-chat-border-color`                 | `var(--osdk-surface-border-color-default)`          | Container, error, composer separator color  |
+| `--osdk-aip-agent-chat-border-radius`                | `var(--osdk-surface-border-radius)`                 | Container and bubble corner radius          |
+| `--osdk-aip-agent-chat-padding`                      | `calc(var(--osdk-surface-spacing) * 5)`             | Outer padding for message list and composer |
+| `--osdk-aip-agent-chat-message-gap`                  | `calc(var(--osdk-surface-spacing) * 5)`             | Vertical gap between messages               |
+| `--osdk-aip-agent-chat-section-gap`                  | `calc(var(--osdk-surface-spacing) * 2.5)`           | Gap between composer rows / footer items    |
+| `--osdk-aip-agent-chat-bubble-padding`               | `calc(var(--osdk-surface-spacing) * 3)`             | Padding inside each message bubble          |
+| `--osdk-aip-agent-chat-bubble-border-radius`         | `var(--osdk-surface-border-radius)`                 | Bubble corner radius                        |
+| `--osdk-aip-agent-chat-bubble-max-width`             | `80%`                                               | Maximum bubble width                        |
+| `--osdk-aip-agent-chat-user-bubble-background`       | `var(--osdk-intent-primary-rest)`                   | User-message bubble background              |
+| `--osdk-aip-agent-chat-user-bubble-color`            | `var(--osdk-intent-primary-foreground)`             | User-message text color                     |
+| `--osdk-aip-agent-chat-assistant-bubble-background`  | `var(--osdk-background-secondary)`                  | Assistant-message bubble background         |
+| `--osdk-aip-agent-chat-assistant-bubble-color`       | `var(--osdk-typography-color-default-rest)`         | Assistant-message text color                |
+| `--osdk-aip-agent-chat-composer-background`          | `var(--osdk-surface-background-color-default-rest)` | Composer background                         |
+| `--osdk-aip-agent-chat-composer-border-color`        | `var(--osdk-surface-border-color-default)`          | Composer top-border color                   |
+| `--osdk-aip-agent-chat-composer-textarea-min-height` | `calc(var(--osdk-surface-spacing) * 14)`            | Textarea minimum height                     |
+| `--osdk-aip-agent-chat-composer-textarea-max-height` | `200px`                                             | Textarea maximum height                     |
+| `--osdk-aip-agent-chat-empty-color`                  | `var(--osdk-typography-color-muted)`                | Empty-state subtext color                   |
+| `--osdk-aip-agent-chat-empty-icon-color`             | `var(--osdk-intent-primary-rest)`                   | Empty-state icon color                      |
+| `--osdk-aip-agent-chat-empty-icon-size`              | `calc(var(--osdk-surface-spacing) * 12)`            | Empty-state icon size                       |
+| `--osdk-aip-agent-chat-loader-color`                 | `var(--osdk-typography-color-muted)`                | 3-dot streaming loader color                |
+| `--osdk-aip-agent-chat-loader-dot-size`              | `calc(var(--osdk-surface-spacing) * 1.5)`           | Loader dot diameter                         |
+| `--osdk-aip-agent-chat-loader-dot-gap`               | `calc(var(--osdk-surface-spacing) * 0.5)`           | Loader dot gap                              |
+| `--osdk-aip-agent-chat-error-color`                  | `var(--osdk-typography-color-danger-rest)`          | Error banner text color                     |
+| `--osdk-aip-agent-chat-error-background`             | `var(--osdk-surface-background-color-danger-rest)`  | Error banner background                     |
+
 ### Drag Handle
 
 Shared tokens for drag handle styling across components.

--- a/packages/react-components/docs/Welcome.md
+++ b/packages/react-components/docs/Welcome.md
@@ -18,6 +18,7 @@ forms, and filters.
 | `FilterList`     | Interactive filter panel with histogram filters, date ranges, and search     |
 | `ActionForm`     | Auto-generated form for executing Ontology Actions                           |
 | `DocumentViewer` | Unified media viewer that auto-detects file type (PDF, Excel, images, video) |
+| `AipAgentChat`   | Chat surface backed by Foundry LMS                                           |
 
 All components are exported under `@osdk/react-components/experimental/*`
 sub-paths (e.g. `@osdk/react-components/experimental/object-table`).

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -43,6 +43,15 @@
       "require": "./build/cjs/public/experimental/action-form.cjs",
       "default": "./build/browser/public/experimental/action-form.js"
     },
+    "./experimental/aip-agent-chat": {
+      "browser": "./build/browser/public/experimental/aip-agent-chat.js",
+      "import": {
+        "types": "./build/types/public/experimental/aip-agent-chat.d.ts",
+        "default": "./build/esm/public/experimental/aip-agent-chat.js"
+      },
+      "require": "./build/cjs/public/experimental/aip-agent-chat.cjs",
+      "default": "./build/browser/public/experimental/aip-agent-chat.js"
+    },
     "./experimental/cbac-picker": {
       "browser": "./build/browser/public/experimental/cbac-picker.js",
       "import": {
@@ -207,6 +216,7 @@
     "xlsx-republish": "0.20.3"
   },
   "peerDependencies": {
+    "@osdk/aip-core": "workspace:^",
     "@osdk/api": "^2.8.0",
     "@osdk/client": "^2.8.0",
     "@osdk/react": "^2.8.0",
@@ -215,7 +225,13 @@
     "react": "^17 || ^18 || ^19",
     "react-dom": "^17 || ^18 || ^19"
   },
+  "peerDependenciesMeta": {
+    "@osdk/aip-core": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@osdk/aip-core": "workspace:*",
     "@osdk/api": "workspace:*",
     "@osdk/client": "workspace:*",
     "@osdk/monorepo.api-extractor": "workspace:~",

--- a/packages/react-components/src/aip-agent-chat/AipAgentChat.module.css
+++ b/packages/react-components/src/aip-agent-chat/AipAgentChat.module.css
@@ -1,0 +1,252 @@
+.chat {
+  background: var(--osdk-aip-agent-chat-background);
+  border: 1px solid var(--osdk-aip-agent-chat-border-color);
+  border-radius: var(--osdk-aip-agent-chat-border-radius);
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  width: 100%;
+}
+
+.error {
+  align-items: flex-start;
+  background: var(--osdk-aip-agent-chat-error-background);
+  border-bottom: 1px solid var(--osdk-aip-agent-chat-border-color);
+  color: var(--osdk-aip-agent-chat-error-color);
+  display: flex;
+  flex: 0 0 auto;
+  gap: var(--osdk-aip-agent-chat-section-gap);
+  justify-content: space-between;
+  padding: var(--osdk-aip-agent-chat-section-gap)
+    var(--osdk-aip-agent-chat-padding);
+}
+
+.errorBody {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: calc(var(--osdk-surface-spacing) * 0.5);
+  min-width: 0;
+}
+
+.errorTitle {
+  font-size: var(--osdk-typography-size-body-medium);
+  font-weight: var(--osdk-typography-weight-bold);
+}
+
+.errorMessage {
+  font-size: var(--osdk-typography-size-body-small);
+  word-break: break-word;
+}
+
+.errorActions {
+  display: flex;
+  flex: 0 0 auto;
+  gap: calc(var(--osdk-surface-spacing) * 1);
+}
+
+.messageList {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: var(--osdk-aip-agent-chat-message-gap);
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--osdk-aip-agent-chat-padding);
+}
+
+.empty {
+  align-items: center;
+  color: var(--osdk-aip-agent-chat-empty-color);
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: var(--osdk-aip-agent-chat-section-gap);
+  justify-content: center;
+  padding: var(--osdk-aip-agent-chat-padding);
+  text-align: center;
+}
+
+.emptyIcon {
+  color: var(--osdk-aip-agent-chat-empty-icon-color);
+  font-size: var(--osdk-aip-agent-chat-empty-icon-size);
+}
+
+.emptyTitle {
+  color: var(--osdk-typography-color-default-rest);
+  font-size: var(--osdk-typography-size-body-large);
+  font-weight: var(--osdk-typography-weight-bold);
+}
+
+.message {
+  display: flex;
+  flex-direction: column;
+}
+
+.userMessage {
+  align-items: flex-end;
+}
+
+.assistantMessage {
+  align-items: flex-start;
+}
+
+.systemMessage {
+  align-items: center;
+}
+
+.bubble {
+  border-radius: var(--osdk-aip-agent-chat-bubble-border-radius);
+  max-width: var(--osdk-aip-agent-chat-bubble-max-width);
+  overflow-wrap: break-word;
+  padding: var(--osdk-aip-agent-chat-bubble-padding);
+  text-align: left;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.userBubble {
+  background: var(--osdk-aip-agent-chat-user-bubble-background);
+  color: var(--osdk-aip-agent-chat-user-bubble-color);
+}
+
+.assistantBubble {
+  background: var(--osdk-aip-agent-chat-assistant-bubble-background);
+  color: var(--osdk-aip-agent-chat-assistant-bubble-color);
+}
+
+.systemBubble {
+  background: var(--osdk-background-tertiary);
+  color: var(--osdk-typography-color-muted);
+  font-size: var(--osdk-typography-size-body-small);
+  font-style: italic;
+}
+
+.streamingPlaceholder {
+  color: var(--osdk-typography-color-muted);
+}
+
+.composer {
+  background: var(--osdk-aip-agent-chat-composer-background);
+  border-top: 1px solid var(--osdk-aip-agent-chat-composer-border-color);
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  gap: var(--osdk-aip-agent-chat-section-gap);
+  padding: var(--osdk-aip-agent-chat-padding);
+}
+
+.textarea {
+  background: var(--osdk-background-primary);
+  border: 1px solid var(--osdk-surface-border-color-default);
+  border-radius: var(--osdk-aip-agent-chat-border-radius);
+  color: var(--osdk-typography-color-default-rest);
+  font-family: inherit;
+  font-size: var(--osdk-typography-size-body-medium);
+  line-height: var(--osdk-typography-line-height-default);
+  max-height: var(--osdk-aip-agent-chat-composer-textarea-max-height);
+  min-height: var(--osdk-aip-agent-chat-composer-textarea-min-height);
+  outline: none;
+  padding: var(--osdk-aip-agent-chat-section-gap);
+  resize: vertical;
+  width: 100%;
+}
+
+.textarea:focus {
+  border-color: var(--osdk-emphasis-focus-color);
+}
+
+.composerActions {
+  align-items: center;
+  display: flex;
+  gap: var(--osdk-aip-agent-chat-section-gap);
+  justify-content: space-between;
+}
+
+.composerFooterLeft {
+  align-items: center;
+  display: flex;
+  flex: 1 1 auto;
+  gap: var(--osdk-aip-agent-chat-section-gap);
+  min-width: 0;
+}
+
+.modelPicker {
+  background: var(--osdk-background-primary);
+  border: 1px solid var(--osdk-surface-border-color-default);
+  border-radius: var(--osdk-aip-agent-chat-border-radius);
+  color: var(--osdk-typography-color-default-rest);
+  font-family: inherit;
+  font-size: var(--osdk-typography-size-body-small);
+  outline: none;
+  padding: calc(var(--osdk-surface-spacing) * 1)
+    calc(var(--osdk-surface-spacing) * 2);
+}
+
+.modelPicker:focus {
+  border-color: var(--osdk-emphasis-focus-color);
+}
+
+.modelPicker:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.modelPickerLabel {
+  color: var(--osdk-typography-color-muted);
+  font-size: var(--osdk-typography-size-body-small);
+}
+
+.composerFooterRight {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  gap: var(--osdk-aip-agent-chat-section-gap);
+}
+
+.loader {
+  align-items: center;
+  color: var(--osdk-aip-agent-chat-loader-color);
+  display: inline-flex;
+  gap: var(--osdk-aip-agent-chat-loader-dot-gap);
+}
+
+.loaderDot {
+  animation-duration: 1.4s;
+  animation-iteration-count: infinite;
+  animation-name: aipAgentChatLoaderBounce;
+  animation-timing-function: ease-in-out;
+  background: currentColor;
+  border-radius: 50%;
+  display: inline-block;
+  height: var(--osdk-aip-agent-chat-loader-dot-size);
+  width: var(--osdk-aip-agent-chat-loader-dot-size);
+}
+
+.loaderDot:nth-child(1) {
+  animation-delay: 0s;
+}
+
+.loaderDot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.loaderDot:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes aipAgentChatLoaderBounce {
+  0%,
+  60%,
+  100% {
+    opacity: 0.3;
+    transform: translateY(0);
+  }
+
+  30% {
+    opacity: 1;
+    transform: translateY(-25%);
+  }
+}

--- a/packages/react-components/src/aip-agent-chat/AipAgentChat.tsx
+++ b/packages/react-components/src/aip-agent-chat/AipAgentChat.tsx
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { foundryModel } from "@osdk/aip-core";
+import { useChat } from "@osdk/react/experimental/aip";
+import * as React from "react";
+import type { AipAgentChatProps } from "./AipAgentChatApi.js";
+import { BaseAipAgentChat } from "./BaseAipAgentChat.js";
+import { AipAgentChatModelPicker } from "./components/AipAgentChatModelPicker.js";
+
+export type { AipAgentChatProps } from "./AipAgentChatApi.js";
+
+const FALLBACK_MODEL_API_NAME = "gpt-4o";
+
+/**
+ * OSDK-aware chat surface backed by Foundry's Language Model Service.
+ * Constructs the LMS-backed model internally and uses `useChat` to
+ * manage conversation state, so consumers never need to import `useChat`,
+ * `streamText`, or `foundryModel` themselves.
+ */
+export function AipAgentChat({
+  client,
+  model: controlledModel,
+  defaultModel,
+  availableModels,
+  onModelChange,
+  system,
+  initialMessages,
+  className,
+  placeholder,
+  enableAutoScroll,
+  onError,
+  onFinish,
+  renderEmptyState,
+  renderMessage,
+}: AipAgentChatProps): React.ReactElement {
+  // Internal state used only in uncontrolled mode. Initialized once
+  // from the first available source: `controlledModel` → `defaultModel`
+  // → first entry of `availableModels` → `FALLBACK_MODEL_API_NAME`.
+  const [internalModel, setInternalModel] = React.useState<string>(
+    () =>
+      controlledModel
+        ?? defaultModel
+        ?? availableModels?.[0]
+        ?? FALLBACK_MODEL_API_NAME,
+  );
+
+  const isControlled = controlledModel != null;
+  const activeModel = isControlled ? controlledModel : internalModel;
+
+  const handleModelChange = React.useCallback(
+    (next: string) => {
+      if (!isControlled) {
+        setInternalModel(next);
+      }
+      onModelChange?.(next);
+    },
+    [isControlled, onModelChange],
+  );
+
+  const model = React.useMemo(
+    () => foundryModel({ client, model: activeModel }),
+    [client, activeModel],
+  );
+
+  const {
+    messages,
+    status,
+    error,
+    sendMessage,
+    stop,
+    clearError,
+  } = useChat({
+    model,
+    system,
+    messages: initialMessages,
+    onError,
+    onFinish,
+  });
+
+  // Snap the uncontrolled model to the first available option whenever the
+  // current selection isn't in `availableModels` (e.g. on first async resolve).
+  React.useEffect(() => {
+    if (
+      isControlled || availableModels == null || availableModels.length === 0
+    ) {
+      return;
+    }
+    if (!availableModels.includes(internalModel)) {
+      setInternalModel(availableModels[0]);
+    }
+  }, [isControlled, availableModels, internalModel]);
+
+  const handleSendMessage = React.useCallback(
+    (text: string) => {
+      return sendMessage({ text });
+    },
+    [sendMessage],
+  );
+
+  const isInFlight = status === "submitted" || status === "streaming";
+
+  const composerFooter = availableModels != null && availableModels.length > 0
+    ? (
+      <AipAgentChatModelPicker
+        activeModel={activeModel}
+        models={availableModels}
+        onModelChange={handleModelChange}
+        disabled={isInFlight}
+      />
+    )
+    : undefined;
+
+  return (
+    <BaseAipAgentChat
+      className={className}
+      composerFooter={composerFooter}
+      enableAutoScroll={enableAutoScroll}
+      messages={messages}
+      status={status}
+      error={error}
+      onClearError={clearError}
+      onSendMessage={handleSendMessage}
+      onStop={stop}
+      placeholder={placeholder}
+      renderEmptyState={renderEmptyState}
+      renderMessage={renderMessage}
+    />
+  );
+}

--- a/packages/react-components/src/aip-agent-chat/AipAgentChatApi.ts
+++ b/packages/react-components/src/aip-agent-chat/AipAgentChatApi.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { UIMessage } from "@osdk/aip-core";
+import type { PlatformClient } from "@osdk/client";
+import type * as React from "react";
+
+// TODO: replace `string` with a literal union of well-known LMS model API
+// names (mirrored from `quiver-language-model-service-utils`'
+// PREFERRED_MODEL_IDENTIFIERS) so consumers get IDE autocomplete on the
+// `model` / `defaultModel` / `availableModels` props. The union should
+// widen via `T | (string & {})` so registered-model API names still
+// type-check.
+
+/**
+ * Props for {@link AipAgentChat}, an OSDK-aware chat surface backed by
+ * Foundry's Language Model Service. Consumers do not need to import
+ * `streamText` or `foundryModel` themselves — passing the platform
+ * client is enough to render a working chat.
+ *
+ * If neither `model` nor `defaultModel` is supplied, the chat falls
+ * back to the first entry of `availableModels` (when provided), or to
+ * the LMS model API name `"gpt-4o"`.
+ *
+ * Default rendering is feature-complete with no overrides supplied;
+ * render slots and `on*` listeners are layered on top of the built-in
+ * behavior.
+ */
+export interface AipAgentChatProps {
+  /**
+   * Foundry platform client returned by `createPlatformClient` from
+   * `@osdk/client`. Used internally to construct the LMS-backed model
+   * for `useChat`.
+   */
+  client: PlatformClient;
+
+  /**
+   * Active LMS model API name (for example `"gpt-4o"`). Resolved
+   * internally via `foundryModel({ client, model })`.
+   *
+   * Controlled mode: when provided, the consumer holds the model state.
+   * Updates from the picker fire {@link AipAgentChatProps.onModelChange};
+   * the consumer is expected to update this prop in response.
+   *
+   * Uncontrolled mode: omit and pass {@link AipAgentChatProps.defaultModel}
+   * instead. If both are omitted, the chat falls back to the first
+   * entry of {@link AipAgentChatProps.availableModels} (when provided),
+   * or to `"gpt-4o"`.
+   */
+  model?: string;
+
+  /**
+   * Initial LMS model API name for uncontrolled mode. The component
+   * manages model state internally, switching when the user picks a
+   * different option from the picker. Ignored when
+   * {@link AipAgentChatProps.model} is also provided (controlled mode
+   * wins).
+   *
+   * @default the first entry of {@link AipAgentChatProps.availableModels}
+   * when provided, otherwise `"gpt-4o"`.
+   */
+  defaultModel?: string;
+
+  /**
+   * When provided, the chat renders a model picker in the composer
+   * footer populated with these API names.
+   *
+   * If omitted, no picker is rendered.
+   */
+  availableModels?: ReadonlyArray<string>;
+
+  /**
+   * Fires when the user selects a different model API name from the
+   * picker.
+   *
+   * - **Controlled mode** (`model` is set): the consumer is expected to
+   *   update {@link AipAgentChatProps.model} in response.
+   * - **Uncontrolled mode** (only `defaultModel` is set): a
+   *   non-controlling listener; the picker still mutates internal state
+   *   regardless. Use this for analytics or to persist the user's
+   *   choice.
+   *
+   * Has no effect unless {@link AipAgentChatProps.availableModels} is
+   * provided.
+   *
+   * @param model The model API name the user just selected.
+   */
+  onModelChange?: (model: string) => void;
+
+  /**
+   * System prompt prepended to every request.
+   */
+  system?: string;
+
+  /**
+   * Seed messages — used as the initial conversation snapshot. Forwarded
+   * to `useChat`'s `messages` option.
+   */
+  initialMessages?: ReadonlyArray<UIMessage>;
+
+  /**
+   * Additional CSS class name applied to the root chat container.
+   */
+  className?: string;
+
+  /**
+   * Placeholder text for the message composer input.
+   *
+   * @default "Type a message..."
+   */
+  placeholder?: string;
+
+  /**
+   * Whether the message list automatically scrolls to the most recent
+   * message as the conversation grows.
+   *
+   * @default true
+   */
+  enableAutoScroll?: boolean;
+
+  /**
+   * Listener fired when the underlying chat hook surfaces an error
+   * (for example a failed send or a dropped stream). Forwarded to
+   * `useChat`'s `onError`.
+   *
+   * @param error The error reported by the chat backend.
+   */
+  onError?: (error: Error) => void;
+
+  /**
+   * Listener fired once after a stream completes successfully. Forwarded
+   * to `useChat`'s `onFinish`.
+   *
+   * @param event The completed assistant message and the resulting
+   *   messages array.
+   */
+  onFinish?: (event: {
+    message: UIMessage;
+    messages: ReadonlyArray<UIMessage>;
+  }) => void;
+
+  /**
+   * Render override for the empty state shown when no messages exist
+   * yet. If omitted, a default welcome panel is rendered.
+   *
+   * @returns A React node rendered in place of the default empty state.
+   */
+  renderEmptyState?: () => React.ReactNode;
+
+  /**
+   * Render override for an individual message bubble. If omitted, the
+   * default user/assistant bubble layout is used.
+   *
+   * @param message The {@link UIMessage} to render.
+   * @returns A React node rendered in place of the default message
+   *   bubble.
+   */
+  renderMessage?: (message: UIMessage) => React.ReactNode;
+}

--- a/packages/react-components/src/aip-agent-chat/BaseAipAgentChat.tsx
+++ b/packages/react-components/src/aip-agent-chat/BaseAipAgentChat.tsx
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { UIMessage } from "@osdk/aip-core";
+import type { ChatStatus } from "@osdk/react/experimental/aip";
+import classNames from "classnames";
+import * as React from "react";
+import { ActionButton } from "../base-components/action-button/ActionButton.js";
+import styles from "./AipAgentChat.module.css";
+import { AipAgentChatComposer } from "./components/AipAgentChatComposer.js";
+import { AipAgentChatMessageList } from "./components/AipAgentChatMessageList.js";
+
+export interface BaseAipAgentChatProps {
+  /**
+   * Current messages in the conversation.
+   */
+  messages: ReadonlyArray<UIMessage>;
+
+  /**
+   * Current status of the chat lifecycle.
+   */
+  status: ChatStatus;
+
+  /**
+   * Current error, if any.
+   */
+  error: Error | undefined;
+
+  /**
+   * Called when the user sends a message. Should return a promise that
+   * resolves when the message has been sent.
+   *
+   * @param text The text the user just submitted (already trimmed).
+   */
+  onSendMessage: (text: string) => Promise<void>;
+
+  /**
+   * Called to stop an in-flight request.
+   */
+  onStop: () => void;
+
+  /**
+   * Called to clear the current error.
+   */
+  onClearError: () => void;
+
+  /**
+   * Optional content rendered in the composer footer, to the left of
+   * the send button. The OSDK wrapper uses this slot for the model
+   * picker.
+   */
+  composerFooter?: React.ReactNode;
+
+  className?: string;
+
+  /**
+   * @default "Type a message..."
+   */
+  placeholder?: string;
+
+  /**
+   * @default true
+   */
+  enableAutoScroll?: boolean;
+
+  renderEmptyState?: () => React.ReactNode;
+  renderMessage?: (message: UIMessage) => React.ReactNode;
+}
+
+/**
+ * OSDK-agnostic chat surface. Manages conversation state, streaming UI,
+ * and error display internally; the consumer provides the current state
+ * and callbacks for sending messages and managing state.
+ */
+export const BaseAipAgentChat: React.NamedExoticComponent<
+  BaseAipAgentChatProps
+> = React.memo(function BaseAipAgentChat({
+  messages,
+  status,
+  error,
+  onSendMessage,
+  onStop,
+  onClearError,
+  composerFooter,
+  className,
+  placeholder = "Type a message...",
+  enableAutoScroll = true,
+  renderEmptyState,
+  renderMessage,
+}) {
+  const isInFlight = status === "submitted" || status === "streaming";
+
+  return (
+    <div className={classNames(styles.chat, className)}>
+      {error != null && (
+        <div aria-live="polite" className={styles.error} role="alert">
+          <div className={styles.errorBody}>
+            <div className={styles.errorTitle}>Something went wrong</div>
+            <div className={styles.errorMessage}>
+              {error.message.length > 0
+                ? error.message
+                : "An unknown error occurred. Try again, or dismiss to keep the conversation."}
+            </div>
+          </div>
+          <div className={styles.errorActions}>
+            <ActionButton onClick={onClearError} type="button">
+              Dismiss
+            </ActionButton>
+          </div>
+        </div>
+      )}
+      <AipAgentChatMessageList
+        enableAutoScroll={enableAutoScroll}
+        isStreaming={isInFlight}
+        messages={messages}
+        renderEmptyState={renderEmptyState}
+        renderMessage={renderMessage}
+      />
+      <AipAgentChatComposer
+        footerLeft={composerFooter}
+        isInFlight={isInFlight}
+        onSendMessage={onSendMessage}
+        onStop={onStop}
+        placeholder={placeholder}
+      />
+    </div>
+  );
+});

--- a/packages/react-components/src/aip-agent-chat/__tests__/AipAgentChat.test.tsx
+++ b/packages/react-components/src/aip-agent-chat/__tests__/AipAgentChat.test.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it } from "vitest";
+
+/**
+ * The OSDK wrapper {@link AipAgentChat} delegates its rendering to
+ * {@link BaseAipAgentChat} (covered by `BaseAipAgentChat.test.tsx`) and wires
+ * it to `useChat` from `@osdk/react/experimental/aip`. The behaviors below
+ * are scaffolded as `it.todo` until a full mock harness for `useChat` lands.
+ */
+describe("AipAgentChat (OSDK wrapper)", () => {
+  it.todo("calls useChat with the configured model");
+  it.todo("wires sendMessage from useChat into BaseAipAgentChat");
+  it.todo(
+    "wraps activeModel and availableModels into a model picker rendered in composer footer",
+  );
+});

--- a/packages/react-components/src/aip-agent-chat/__tests__/BaseAipAgentChat.test.tsx
+++ b/packages/react-components/src/aip-agent-chat/__tests__/BaseAipAgentChat.test.tsx
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getUIMessageText, type UIMessage } from "@osdk/aip-core";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BaseAipAgentChat } from "../BaseAipAgentChat.js";
+
+function makeMessage(
+  role: "user" | "assistant" | "system",
+  text: string,
+): UIMessage {
+  return {
+    id: `${role}-${Math.random()}`,
+    role,
+    parts: [{ type: "text", text }],
+  };
+}
+
+describe("BaseAipAgentChat", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders the default empty state when there are no messages", () => {
+    render(
+      <BaseAipAgentChat
+        messages={[]}
+        status="ready"
+        error={undefined}
+        onSendMessage={vi.fn()}
+        onStop={vi.fn()}
+        onClearError={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Start a conversation")).toBeDefined();
+    expect(
+      screen.getByText("Type a message below to chat with the assistant."),
+    ).toBeDefined();
+  });
+
+  it("renders messages passed as props", () => {
+    const userMsg = makeMessage("user", "Hello there");
+    const assistantMsg = makeMessage("assistant", "Hi back!");
+
+    render(
+      <BaseAipAgentChat
+        messages={[userMsg, assistantMsg]}
+        status="ready"
+        error={undefined}
+        onSendMessage={vi.fn()}
+        onStop={vi.fn()}
+        onClearError={vi.fn()}
+      />,
+    );
+
+    const userGroup = screen.getByLabelText("User message");
+    const assistantGroup = screen.getByLabelText("Assistant message");
+
+    expect(userGroup.textContent).toContain(getUIMessageText(userMsg));
+    expect(assistantGroup.textContent).toContain(
+      getUIMessageText(assistantMsg),
+    );
+  });
+
+  it("disables the Send button when the textarea is empty", () => {
+    render(
+      <BaseAipAgentChat
+        messages={[]}
+        status="ready"
+        error={undefined}
+        onSendMessage={vi.fn()}
+        onStop={vi.fn()}
+        onClearError={vi.fn()}
+      />,
+    );
+
+    const sendButton = screen.getByRole("button", { name: /send/i });
+    expect(sendButton.matches(":disabled")).toBe(true);
+  });
+
+  it("enables Send button when textarea has text", () => {
+    render(
+      <BaseAipAgentChat
+        messages={[]}
+        status="ready"
+        error={undefined}
+        onSendMessage={vi.fn()}
+        onStop={vi.fn()}
+        onClearError={vi.fn()}
+      />,
+    );
+
+    const textarea = screen.getByLabelText("Message input");
+    fireEvent.change(textarea, { target: { value: "hello" } });
+
+    const sendButton = screen.getByRole("button", { name: /send/i });
+    expect(sendButton.matches(":disabled")).toBe(false);
+  });
+
+  it("calls onSendMessage when Send button is clicked", async () => {
+    const onSendMessage = vi.fn(() => Promise.resolve());
+
+    render(
+      <BaseAipAgentChat
+        messages={[]}
+        status="ready"
+        error={undefined}
+        onSendMessage={onSendMessage}
+        onStop={vi.fn()}
+        onClearError={vi.fn()}
+      />,
+    );
+
+    const textarea = screen.getByLabelText("Message input");
+    fireEvent.change(textarea, { target: { value: "hello world" } });
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+
+    expect(onSendMessage).toHaveBeenCalledWith("hello world");
+  });
+
+  it("shows Stop button when status is submitted", () => {
+    render(
+      <BaseAipAgentChat
+        messages={[]}
+        status="submitted"
+        error={undefined}
+        onSendMessage={vi.fn()}
+        onStop={vi.fn()}
+        onClearError={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: /send/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /stop/i })).toBeDefined();
+  });
+
+  it("calls onStop when Stop button is clicked", () => {
+    const onStop = vi.fn();
+
+    render(
+      <BaseAipAgentChat
+        messages={[]}
+        status="streaming"
+        error={undefined}
+        onSendMessage={vi.fn()}
+        onStop={onStop}
+        onClearError={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /stop/i }));
+
+    expect(onStop).toHaveBeenCalled();
+  });
+
+  it("renders error banner when error is present", () => {
+    const error = new Error("Something went wrong");
+
+    render(
+      <BaseAipAgentChat
+        messages={[]}
+        status="error"
+        error={error}
+        onSendMessage={vi.fn()}
+        onStop={vi.fn()}
+        onClearError={vi.fn()}
+      />,
+    );
+
+    const banner = screen.getByRole("alert");
+    expect(banner.textContent).toContain("Something went wrong");
+  });
+
+  it("calls onClearError when Dismiss is clicked", () => {
+    const onClearError = vi.fn();
+
+    render(
+      <BaseAipAgentChat
+        messages={[]}
+        status="error"
+        error={new Error("Something went wrong")}
+        onSendMessage={vi.fn()}
+        onStop={vi.fn()}
+        onClearError={onClearError}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+
+    expect(onClearError).toHaveBeenCalled();
+  });
+
+  it("renders composerFooter content inside the composer footer", () => {
+    render(
+      <BaseAipAgentChat
+        composerFooter={
+          <span data-testid="footer-slot">model-picker-stub</span>
+        }
+        messages={[]}
+        status="ready"
+        error={undefined}
+        onSendMessage={vi.fn()}
+        onStop={vi.fn()}
+        onClearError={vi.fn()}
+      />,
+    );
+
+    const slot = screen.getByTestId("footer-slot");
+    expect(slot.textContent).toBe("model-picker-stub");
+  });
+
+  it("calls renderEmptyState when there are no messages", () => {
+    const renderEmptyState = vi.fn(() => (
+      <div data-testid="custom-empty">no messages yet</div>
+    ));
+
+    render(
+      <BaseAipAgentChat
+        renderEmptyState={renderEmptyState}
+        messages={[]}
+        status="ready"
+        error={undefined}
+        onSendMessage={vi.fn()}
+        onStop={vi.fn()}
+        onClearError={vi.fn()}
+      />,
+    );
+
+    expect(renderEmptyState).toHaveBeenCalled();
+    expect(screen.getByTestId("custom-empty")).toBeDefined();
+    expect(screen.queryByText("Start a conversation")).toBeNull();
+  });
+
+  it("calls renderMessage once per message and renders its return value", () => {
+    const renderMessage = vi.fn((message: UIMessage) => (
+      <div data-testid={`custom-${message.id}`}>
+        {`[${message.role}] ${getUIMessageText(message)}`}
+      </div>
+    ));
+
+    const userMsg = makeMessage("user", "first");
+    const assistantMsg = makeMessage("assistant", "second");
+
+    render(
+      <BaseAipAgentChat
+        renderMessage={renderMessage}
+        messages={[userMsg, assistantMsg]}
+        status="ready"
+        error={undefined}
+        onSendMessage={vi.fn()}
+        onStop={vi.fn()}
+        onClearError={vi.fn()}
+      />,
+    );
+
+    expect(renderMessage).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId(`custom-${userMsg.id}`).textContent).toBe(
+      "[user] first",
+    );
+    expect(screen.getByTestId(`custom-${assistantMsg.id}`).textContent).toBe(
+      "[assistant] second",
+    );
+    // The default bubble (with aria-label="User message") must NOT render.
+    expect(screen.queryByLabelText("User message")).toBeNull();
+    expect(screen.queryByLabelText("Assistant message")).toBeNull();
+  });
+});

--- a/packages/react-components/src/aip-agent-chat/components/AipAgentChatComposer.tsx
+++ b/packages/react-components/src/aip-agent-chat/components/AipAgentChatComposer.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Input } from "@base-ui/react/input";
+import classNames from "classnames";
+import * as React from "react";
+import { ActionButton } from "../../base-components/action-button/ActionButton.js";
+import styles from "../AipAgentChat.module.css";
+
+export interface AipAgentChatComposerProps {
+  isInFlight: boolean;
+  onSendMessage: (text: string) => void;
+  onStop?: () => void;
+  placeholder?: string;
+  className?: string;
+  /**
+   * Optional content rendered to the left of the send button (e.g. the
+   * model picker passed in by the OSDK wrapper).
+   */
+  footerLeft?: React.ReactNode;
+}
+
+/**
+ * Textarea + send/stop button. Enter sends; Shift+Enter inserts a newline.
+ * The button toggles to "Stop" while a stream is in flight (when an
+ * `onStop` callback is provided).
+ */
+export function AipAgentChatComposer({
+  isInFlight,
+  onSendMessage,
+  onStop,
+  placeholder,
+  className,
+  footerLeft,
+}: AipAgentChatComposerProps): React.ReactElement {
+  const [draft, setDraft] = React.useState("");
+
+  const canSend = !isInFlight && draft.trim().length > 0;
+
+  const handleSend = React.useCallback(() => {
+    const trimmed = draft.trim();
+    if (trimmed.length === 0) {
+      return;
+    }
+    // Absorb sync throws and unhandled rejections; chat-level errors are
+    // surfaced via `onError` on the upstream useChat hook.
+    try {
+      const result = onSendMessage(trimmed) as void | Promise<void>;
+      if (result instanceof Promise) {
+        result.catch(noop);
+      }
+    } catch {
+      // swallow sync throws
+    }
+    setDraft("");
+  }, [draft, onSendMessage]);
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === "Enter" && !event.shiftKey) {
+        event.preventDefault();
+        if (!isInFlight) {
+          handleSend();
+        }
+      }
+    },
+    [handleSend, isInFlight],
+  );
+
+  // Attach the keydown handler in the `render` prop so it can be typed against
+  // the actual rendered <textarea> element rather than base-ui's HTMLInputElement.
+  const renderTextarea = React.useCallback(
+    (props: React.ComponentPropsWithRef<"textarea">) => (
+      <textarea {...props} onKeyDown={handleKeyDown} rows={3} />
+    ),
+    [handleKeyDown],
+  );
+
+  return (
+    <div className={classNames(styles.composer, className)}>
+      <Input
+        aria-label="Message input"
+        className={styles.textarea}
+        onValueChange={setDraft}
+        placeholder={placeholder}
+        value={draft}
+        render={renderTextarea}
+      />
+      <div className={styles.composerActions}>
+        <div className={styles.composerFooterLeft}>{footerLeft}</div>
+        <div className={styles.composerFooterRight}>
+          {isInFlight && onStop != null
+            ? (
+              <ActionButton onClick={onStop} type="button">
+                Stop
+              </ActionButton>
+            )
+            : (
+              <ActionButton
+                disabled={!canSend}
+                onClick={handleSend}
+                type="button"
+                variant="primary"
+              >
+                Send
+              </ActionButton>
+            )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function noop(): void {}

--- a/packages/react-components/src/aip-agent-chat/components/AipAgentChatLoader.tsx
+++ b/packages/react-components/src/aip-agent-chat/components/AipAgentChatLoader.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from "classnames";
+import * as React from "react";
+import styles from "../AipAgentChat.module.css";
+
+export interface AipAgentChatLoaderProps {
+  className?: string;
+  label?: string;
+}
+
+/**
+ * Three-dot bouncing animation rendered while the agent is responding.
+ */
+export function AipAgentChatLoader(
+  { className, label = "Assistant is responding" }: AipAgentChatLoaderProps,
+): React.ReactElement {
+  return (
+    <div
+      aria-label={label}
+      aria-live="polite"
+      className={classNames(styles.loader, className)}
+      role="status"
+    >
+      <span aria-hidden="true" className={styles.loaderDot} />
+      <span aria-hidden="true" className={styles.loaderDot} />
+      <span aria-hidden="true" className={styles.loaderDot} />
+    </div>
+  );
+}

--- a/packages/react-components/src/aip-agent-chat/components/AipAgentChatMessage.tsx
+++ b/packages/react-components/src/aip-agent-chat/components/AipAgentChatMessage.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getUIMessageText, type UIMessage } from "@osdk/aip-core";
+import classNames from "classnames";
+import * as React from "react";
+import styles from "../AipAgentChat.module.css";
+
+export interface AipAgentChatMessageProps {
+  message: UIMessage;
+}
+
+/**
+ * Default rendering for a single chat message bubble. User messages are
+ * right-aligned with a primary background; assistant messages are
+ * left-aligned with a secondary background; system messages render
+ * centered in muted style.
+ */
+export function AipAgentChatMessage(
+  { message }: AipAgentChatMessageProps,
+): React.ReactElement {
+  const text = getUIMessageText(message);
+  const role = message.role;
+  const styling = ROLE_STYLING[role];
+
+  return (
+    <div
+      aria-label={styling.label}
+      className={classNames(styles.message, styling.container)}
+      role="group"
+    >
+      <div className={classNames(styles.bubble, styling.bubble)}>
+        {text.length > 0
+          ? text
+          : <span className={styles.streamingPlaceholder}>…</span>}
+      </div>
+    </div>
+  );
+}
+
+interface RoleStyling {
+  container: string;
+  bubble: string;
+  label: string;
+}
+
+const ROLE_STYLING: Record<UIMessage["role"], RoleStyling> = {
+  user: {
+    container: styles.userMessage,
+    bubble: styles.userBubble,
+    label: "User message",
+  },
+  assistant: {
+    container: styles.assistantMessage,
+    bubble: styles.assistantBubble,
+    label: "Assistant message",
+  },
+  system: {
+    container: styles.systemMessage,
+    bubble: styles.systemBubble,
+    label: "System message",
+  },
+};

--- a/packages/react-components/src/aip-agent-chat/components/AipAgentChatMessageList.tsx
+++ b/packages/react-components/src/aip-agent-chat/components/AipAgentChatMessageList.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Chat } from "@blueprintjs/icons";
+import { getUIMessageText, type UIMessage } from "@osdk/aip-core";
+import classNames from "classnames";
+import * as React from "react";
+import styles from "../AipAgentChat.module.css";
+import { useChatAutoScroll } from "../hooks/useChatAutoScroll.js";
+import { AipAgentChatLoader } from "./AipAgentChatLoader.js";
+import { AipAgentChatMessage } from "./AipAgentChatMessage.js";
+
+export interface AipAgentChatMessageListProps {
+  messages: ReadonlyArray<UIMessage>;
+  isStreaming: boolean;
+  enableAutoScroll: boolean;
+  className?: string;
+  renderEmptyState?: () => React.ReactNode;
+  renderMessage?: (message: UIMessage) => React.ReactNode;
+}
+
+const DEFAULT_EMPTY_STATE: React.ReactNode = (
+  <>
+    <Chat className={styles.emptyIcon} size={64} />
+    <div className={styles.emptyTitle}>Start a conversation</div>
+    <div>Type a message below to chat with the assistant.</div>
+  </>
+);
+
+export function AipAgentChatMessageList({
+  messages,
+  isStreaming,
+  enableAutoScroll,
+  className,
+  renderEmptyState,
+  renderMessage,
+}: AipAgentChatMessageListProps): React.ReactElement {
+  const lastMessage = messages.at(-1);
+  const lastMessageTextLength = lastMessage != null
+    ? getUIMessageText(lastMessage).length
+    : 0;
+  const scrollSignal = `${messages.length}:${lastMessageTextLength}`;
+
+  const setContainerRef = useChatAutoScroll<HTMLDivElement>(
+    scrollSignal,
+    enableAutoScroll,
+  );
+
+  const isEmpty = messages.length === 0 && !isStreaming;
+  const showLoader = isStreaming && lastMessage?.role !== "assistant";
+
+  return (
+    <div
+      aria-live={isEmpty ? undefined : "polite"}
+      className={classNames(
+        styles.messageList,
+        isEmpty && styles.empty,
+        className,
+      )}
+      ref={setContainerRef}
+      role={isEmpty ? undefined : "log"}
+    >
+      {isEmpty
+        ? (renderEmptyState != null ? renderEmptyState() : DEFAULT_EMPTY_STATE)
+        : (
+          <>
+            {messages.map(message => (
+              <React.Fragment key={message.id}>
+                {renderMessage != null
+                  ? renderMessage(message)
+                  : <AipAgentChatMessage message={message} />}
+              </React.Fragment>
+            ))}
+            {showLoader && (
+              <div
+                className={classNames(styles.message, styles.assistantMessage)}
+              >
+                <div
+                  className={classNames(styles.bubble, styles.assistantBubble)}
+                >
+                  <AipAgentChatLoader />
+                </div>
+              </div>
+            )}
+          </>
+        )}
+    </div>
+  );
+}

--- a/packages/react-components/src/aip-agent-chat/components/AipAgentChatModelPicker.tsx
+++ b/packages/react-components/src/aip-agent-chat/components/AipAgentChatModelPicker.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from "classnames";
+import * as React from "react";
+import styles from "../AipAgentChat.module.css";
+
+export interface AipAgentChatModelPickerProps {
+  models: ReadonlyArray<string>;
+  activeModel: string;
+  onModelChange: (model: string) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * Native-select model picker rendered in the composer footer when the
+ * OSDK wrapper is given an `availableModels` list. Operates on Foundry
+ * LMS model API names. Renders a read-only label when exactly one model
+ * is available so the active model stays visible without offering a
+ * dropdown the user can't act on; renders nothing when the list is empty.
+ */
+export function AipAgentChatModelPicker({
+  models,
+  activeModel,
+  onModelChange,
+  disabled,
+  className,
+}: AipAgentChatModelPickerProps): React.ReactElement | null {
+  const handleChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      onModelChange(event.target.value);
+    },
+    [onModelChange],
+  );
+
+  if (models.length === 0) {
+    return null;
+  }
+
+  if (models.length === 1) {
+    return (
+      <span className={classNames(styles.modelPickerLabel, className)}>
+        Model: {activeModel}
+      </span>
+    );
+  }
+
+  return (
+    <select
+      aria-label="Active model"
+      className={classNames(styles.modelPicker, className)}
+      disabled={disabled}
+      onChange={handleChange}
+      value={activeModel}
+    >
+      {models.map(modelName => (
+        <option key={modelName} value={modelName}>
+          {modelName}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/packages/react-components/src/aip-agent-chat/hooks/useChatAutoScroll.ts
+++ b/packages/react-components/src/aip-agent-chat/hooks/useChatAutoScroll.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+
+/**
+ * Keeps a scrollable container pinned to its bottom whenever `signal` changes
+ * (typically a string encoding the messages array length and streaming token
+ * count).
+ *
+ * Disengages temporarily once the user scrolls up — pinning resumes when the
+ * user scrolls back near the bottom. Returns a callback ref to attach to the
+ * scrollable element; the listener follows the element across re-mounts.
+ */
+export function useChatAutoScroll<T extends HTMLElement>(
+  signal: string,
+  enabled: boolean,
+): React.RefCallback<T> {
+  const elRef = React.useRef<T | null>(null);
+  const cleanupRef = React.useRef<(() => void) | null>(null);
+  const isPinnedRef = React.useRef<boolean>(true);
+
+  const setRef = React.useCallback<React.RefCallback<T>>((el) => {
+    cleanupRef.current?.();
+    cleanupRef.current = null;
+    elRef.current = el;
+    if (el == null) {
+      return;
+    }
+    const onScroll = () => {
+      const distanceFromBottom = el.scrollHeight - el.scrollTop
+        - el.clientHeight;
+      isPinnedRef.current = distanceFromBottom <= NEAR_BOTTOM_THRESHOLD_PX;
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+    cleanupRef.current = () => el.removeEventListener("scroll", onScroll);
+  }, []);
+
+  React.useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    const el = elRef.current;
+    if (el == null || !isPinnedRef.current) {
+      return;
+    }
+    el.scrollTop = el.scrollHeight;
+  }, [signal, enabled]);
+
+  return setRef;
+}
+
+const NEAR_BOTTOM_THRESHOLD_PX = 32;

--- a/packages/react-components/src/public/experimental/aip-agent-chat.ts
+++ b/packages/react-components/src/public/experimental/aip-agent-chat.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TODO: Add osdk metrics
+// This component uses platformClient, maybe we want to add userAgent header to the platformClient instead
+export { AipAgentChat } from "../../aip-agent-chat/AipAgentChat.js";
+
+export type { AipAgentChatProps } from "../../aip-agent-chat/AipAgentChatApi.js";
+
+export { BaseAipAgentChat } from "../../aip-agent-chat/BaseAipAgentChat.js";
+export type { BaseAipAgentChatProps } from "../../aip-agent-chat/BaseAipAgentChat.js";
+
+export type { UIMessage, UIMessageRole } from "@osdk/aip-core";
+export { getUIMessageText } from "@osdk/aip-core";
+
+export type { ChatStatus } from "@osdk/react/experimental/aip";

--- a/packages/react-components/src/tokens.css
+++ b/packages/react-components/src/tokens.css
@@ -3,6 +3,7 @@
 @import "./tokens/base-tokens/dark.css";
 
 /* Component tokens: component-specific tokens that reference base tokens */
+@import "./tokens/component-tokens/aip-agent-chat.css";
 @import "./tokens/component-tokens/async-dropdown.css";
 @import "./tokens/component-tokens/button.css";
 @import "./tokens/component-tokens/cbac-picker.css";

--- a/packages/react-components/src/tokens/component-tokens/aip-agent-chat.css
+++ b/packages/react-components/src/tokens/component-tokens/aip-agent-chat.css
@@ -1,0 +1,56 @@
+:root {
+  /* Container */
+  --osdk-aip-agent-chat-background: var(--osdk-background-primary);
+  --osdk-aip-agent-chat-border-color: var(--osdk-surface-border-color-default);
+  --osdk-aip-agent-chat-border-radius: var(--osdk-surface-border-radius);
+
+  /* Spacing */
+  --osdk-aip-agent-chat-padding: calc(var(--osdk-surface-spacing) * 5);
+  --osdk-aip-agent-chat-message-gap: calc(var(--osdk-surface-spacing) * 5);
+  --osdk-aip-agent-chat-section-gap: calc(var(--osdk-surface-spacing) * 2.5);
+
+  /* Message bubble */
+  --osdk-aip-agent-chat-bubble-padding: calc(var(--osdk-surface-spacing) * 3);
+  --osdk-aip-agent-chat-bubble-border-radius: var(--osdk-surface-border-radius);
+  --osdk-aip-agent-chat-bubble-max-width: 80%;
+
+  --osdk-aip-agent-chat-user-bubble-background: var(--osdk-intent-primary-rest);
+  --osdk-aip-agent-chat-user-bubble-color: var(
+    --osdk-intent-primary-foreground
+  );
+
+  --osdk-aip-agent-chat-assistant-bubble-background: var(
+    --osdk-background-secondary
+  );
+  --osdk-aip-agent-chat-assistant-bubble-color: var(
+    --osdk-typography-color-default-rest
+  );
+
+  /* Composer */
+  --osdk-aip-agent-chat-composer-background: var(
+    --osdk-surface-background-color-default-rest
+  );
+  --osdk-aip-agent-chat-composer-border-color: var(
+    --osdk-surface-border-color-default
+  );
+  --osdk-aip-agent-chat-composer-textarea-min-height: calc(
+    var(--osdk-surface-spacing) * 14
+  );
+  --osdk-aip-agent-chat-composer-textarea-max-height: 200px;
+
+  /* Empty state */
+  --osdk-aip-agent-chat-empty-color: var(--osdk-typography-color-muted);
+  --osdk-aip-agent-chat-empty-icon-color: var(--osdk-intent-primary-rest);
+  --osdk-aip-agent-chat-empty-icon-size: calc(var(--osdk-surface-spacing) * 12);
+
+  /* Loader (3-dot bouncing) */
+  --osdk-aip-agent-chat-loader-color: var(--osdk-typography-color-muted);
+  --osdk-aip-agent-chat-loader-dot-size: calc(
+    var(--osdk-surface-spacing) * 1.5
+  );
+  --osdk-aip-agent-chat-loader-dot-gap: calc(var(--osdk-surface-spacing) * 0.5);
+
+  /* Error banner */
+  --osdk-aip-agent-chat-error-color: var(--osdk-intent-danger-foreground);
+  --osdk-aip-agent-chat-error-background: var(--osdk-intent-danger-rest);
+}

--- a/packages/react/experimental/aip.d.ts
+++ b/packages/react/experimental/aip.d.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from "../build/cjs/public/experimental/aip.cjs";

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -61,6 +61,15 @@
       "require": "./build/cjs/public/experimental/admin.cjs",
       "default": "./build/browser/public/experimental/admin.js"
     },
+    "./experimental/aip": {
+      "browser": "./build/browser/public/experimental/aip.js",
+      "import": {
+        "types": "./build/types/public/experimental/aip.d.ts",
+        "default": "./build/esm/public/experimental/aip.js"
+      },
+      "require": "./build/cjs/public/experimental/aip.cjs",
+      "default": "./build/browser/public/experimental/aip.js"
+    },
     "./*": {
       "browser": "./build/browser/public/*.js",
       "import": {
@@ -90,6 +99,7 @@
     "fast-deep-equal": "^3.1.3"
   },
   "peerDependencies": {
+    "@osdk/aip-core": "workspace:^",
     "@osdk/api": "^2.15.0",
     "@osdk/client": "^2.15.0",
     "@osdk/foundry.admin": "*",
@@ -99,6 +109,9 @@
     "react-dom": "^17 || ^18 || ^19"
   },
   "peerDependenciesMeta": {
+    "@osdk/aip-core": {
+      "optional": true
+    },
     "@osdk/foundry.admin": {
       "optional": true
     },
@@ -107,6 +120,7 @@
     }
   },
   "devDependencies": {
+    "@osdk/aip-core": "workspace:*",
     "@osdk/api": "workspace:*",
     "@osdk/client": "workspace:*",
     "@osdk/client.test.ontology": "workspace:*",

--- a/packages/react/src/aip/chatStore.ts
+++ b/packages/react/src/aip/chatStore.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { UIMessage } from "@osdk/aip-core";
+
+export type ChatStatus = "ready" | "submitted" | "streaming" | "error";
+
+export interface ChatState {
+  messages: ReadonlyArray<UIMessage>;
+  status: ChatStatus;
+  error: Error | undefined;
+}
+
+export interface ChatStore {
+  getSnapshot: () => ChatState;
+  /** Subscribe to state changes. Returns the unsubscribe function. */
+  subscribe: (notify: () => void) => () => void;
+  /** Replace state and notify subscribers synchronously. */
+  setState: (
+    next: ChatState | ((prev: ChatState) => ChatState),
+  ) => void;
+  /**
+   * Replace state and coalesce subscriber notifications across rapid calls.
+   * Notifications fire `throttleMs` after the first change in a quiet window.
+   * Use for high-frequency updates (e.g. token streaming) where one render per
+   * change is wasteful.
+   */
+  setStateThrottled: (
+    next: ChatState | ((prev: ChatState) => ChatState),
+  ) => void;
+}
+
+export interface CreateChatStoreOptions {
+  initialMessages?: ReadonlyArray<UIMessage>;
+  /** Min ms between subscriber notifications. 0 = synchronous. Defaults to 0. */
+  throttleMs?: number;
+}
+
+/**
+ * Tiny pub-sub store backing `useChat`. Throttles subscriber notifications so
+ * fast token-delta streams don't trigger one render per token.
+ */
+export function createChatStore(options: CreateChatStoreOptions): ChatStore {
+  let state: ChatState = {
+    messages: options.initialMessages ?? [],
+    status: "ready",
+    error: undefined,
+  };
+
+  const subscribers = new Set<() => void>();
+  const throttleMs = options.throttleMs ?? 0;
+  let pendingNotify: ReturnType<typeof setTimeout> | undefined;
+
+  const notifyNow = (): void => {
+    if (pendingNotify != null) {
+      clearTimeout(pendingNotify);
+      pendingNotify = undefined;
+    }
+    for (const s of subscribers) {
+      s();
+    }
+  };
+
+  const notifyThrottled = (): void => {
+    if (throttleMs <= 0) {
+      notifyNow();
+      return;
+    }
+    if (pendingNotify != null) {
+      return;
+    }
+    pendingNotify = setTimeout(notifyNow, throttleMs);
+  };
+
+  return {
+    getSnapshot: () => state,
+    subscribe: (notify) => {
+      subscribers.add(notify);
+      return () => {
+        subscribers.delete(notify);
+      };
+    },
+    setState: (next) => {
+      state = typeof next === "function" ? next(state) : next;
+      notifyNow();
+    },
+    setStateThrottled: (next) => {
+      state = typeof next === "function" ? next(state) : next;
+      notifyThrottled();
+    },
+  };
+}

--- a/packages/react/src/aip/chatStream.ts
+++ b/packages/react/src/aip/chatStream.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  type ChatTransport,
+  generateMessageId,
+  type UIMessage,
+  type UIMessageChunk,
+} from "@osdk/aip-core";
+import type React from "react";
+import type { ChatStore } from "./chatStore.js";
+
+/**
+ * Mutable orchestration handle threaded through the streaming functions.
+ * Holds everything they need to read snapshots, mutate state, and check
+ * whether their stream is still the active one.
+ */
+export interface StreamContext {
+  store: ChatStore;
+  abortRef: React.MutableRefObject<AbortController | undefined>;
+  stoppedRef: React.MutableRefObject<boolean>;
+  onFinish:
+    | ((event: {
+      message: UIMessage;
+      messages: ReadonlyArray<UIMessage>;
+    }) => void)
+    | undefined;
+  onError: ((error: Error) => void) | undefined;
+}
+
+export async function runChatStream(
+  ctx: StreamContext,
+  transport: ChatTransport<UIMessage>,
+  chatId: string,
+  seed: ReadonlyArray<UIMessage>,
+  trigger: "submit-message" | "regenerate-message",
+): Promise<void> {
+  ctx.abortRef.current?.abort();
+  const ctrl = new AbortController();
+  ctx.abortRef.current = ctrl;
+  ctx.stoppedRef.current = false;
+
+  const assistantId = generateMessageId();
+  try {
+    const stream = await transport.sendMessages({
+      trigger,
+      chatId,
+      messageId: assistantId,
+      messages: seed.slice(),
+      abortSignal: ctrl.signal,
+    });
+    await drainStream(ctx, stream, assistantId, ctrl);
+  } catch (err) {
+    handleStreamError(ctx, err, ctrl);
+  }
+}
+
+export async function drainStream(
+  ctx: StreamContext,
+  stream: ReadableStream<UIMessageChunk>,
+  assistantMessageId: string,
+  capturedCtrl: AbortController,
+): Promise<void> {
+  const { store } = ctx;
+  const reader = stream.getReader();
+  let textBuf = "";
+
+  const isStale = (): boolean =>
+    ctx.abortRef.current != null && ctx.abortRef.current !== capturedCtrl;
+
+  // Caller dropped our assistant message via `setMessages` mid-stream.
+  // Treat as "the consumer no longer wants this stream" — quietly stop.
+  const isOrphaned = (): boolean => {
+    const messages = store.getSnapshot().messages;
+    return textBuf.length > 0
+      && !messages.some((m) => m.id === assistantMessageId);
+  };
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (isStale()) {
+        await reader.cancel();
+        return;
+      }
+      if (isOrphaned()) {
+        await reader.cancel();
+        store.setState((prev) => ({ ...prev, status: "ready" }));
+        return;
+      }
+      if (value.type === "text-delta") {
+        textBuf += value.delta;
+        upsertAssistantText(store, assistantMessageId, textBuf);
+      } else if (value.type === "error") {
+        if (ctx.stoppedRef.current || capturedCtrl.signal.aborted) {
+          return;
+        }
+        await reader.cancel();
+        throw new Error(value.errorText);
+      }
+    }
+    if (isStale()) {
+      return;
+    }
+    store.setState((prev) => ({ ...prev, status: "ready" }));
+    const finalSnap = store.getSnapshot();
+    const finalMessage = finalSnap.messages.find(
+      (m) => m.id === assistantMessageId,
+    );
+    if (finalMessage != null && ctx.onFinish != null) {
+      ctx.onFinish({ message: finalMessage, messages: finalSnap.messages });
+    }
+  } catch (err) {
+    handleStreamError(ctx, err, capturedCtrl);
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function upsertAssistantText(
+  store: ChatStore,
+  assistantMessageId: string,
+  text: string,
+): void {
+  store.setStateThrottled((prev) => {
+    const exists = prev.messages.some((m) => m.id === assistantMessageId);
+    const messages = exists
+      ? prev.messages.map((m) =>
+        m.id === assistantMessageId
+          ? { ...m, parts: [{ type: "text" as const, text }] }
+          : m
+      )
+      : [
+        ...prev.messages,
+        {
+          id: assistantMessageId,
+          role: "assistant" as const,
+          parts: [{ type: "text" as const, text }],
+        },
+      ];
+    return { ...prev, status: "streaming", messages };
+  });
+}
+
+function handleStreamError(
+  ctx: StreamContext,
+  err: unknown,
+  capturedCtrl: AbortController,
+): void {
+  if (ctx.abortRef.current != null && ctx.abortRef.current !== capturedCtrl) {
+    return;
+  }
+  const error = err instanceof Error ? err : new Error(String(err));
+  if (
+    ctx.stoppedRef.current
+    || error.name === "AbortError"
+    || capturedCtrl.signal.aborted
+  ) {
+    ctx.store.setState((prev) => ({
+      ...prev,
+      status: "ready",
+      error: undefined,
+    }));
+    return;
+  }
+  ctx.store.setState((prev) => ({ ...prev, status: "error", error }));
+  ctx.onError?.(error);
+}

--- a/packages/react/src/aip/useChat.test.tsx
+++ b/packages/react/src/aip/useChat.test.tsx
@@ -1,0 +1,553 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ChatTransport, UIMessage, UIMessageChunk } from "@osdk/aip-core";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useChat } from "./useChat.js";
+
+interface MockTransport {
+  transport: ChatTransport<UIMessage>;
+  /** Push the next chunk into the stream returned from sendMessages. */
+  push: (chunk: UIMessageChunk) => void;
+  /** Close the current stream cleanly. */
+  finish: () => void;
+  /** Error the current stream. */
+  fail: (err: Error) => void;
+  sendCalls: () => Array<{
+    trigger: "submit-message" | "regenerate-message";
+    chatId: string;
+    messageId: string;
+    messages: Array<UIMessage>;
+    abortSignal: AbortSignal | undefined;
+  }>;
+  reconnect: ReturnType<typeof vi.fn>;
+}
+
+function createMockTransport(): MockTransport {
+  let controller: ReadableStreamDefaultController<UIMessageChunk> | undefined;
+  const calls: Array<{
+    trigger: "submit-message" | "regenerate-message";
+    chatId: string;
+    messageId: string;
+    messages: Array<UIMessage>;
+    abortSignal: AbortSignal | undefined;
+  }> = [];
+
+  const sendMessages = vi.fn(async (args: {
+    trigger: "submit-message" | "regenerate-message";
+    chatId: string;
+    messageId: string;
+    messages: Array<UIMessage>;
+    abortSignal: AbortSignal | undefined;
+  }) => {
+    calls.push({
+      trigger: args.trigger,
+      chatId: args.chatId,
+      messageId: args.messageId,
+      messages: args.messages,
+      abortSignal: args.abortSignal,
+    });
+    return new ReadableStream<UIMessageChunk>({
+      start(c) {
+        controller = c;
+      },
+    });
+  });
+  const reconnect = vi.fn(async () => null);
+
+  const transport: ChatTransport<UIMessage> = {
+    sendMessages: sendMessages as ChatTransport<UIMessage>["sendMessages"],
+    reconnectToStream: reconnect as ChatTransport<
+      UIMessage
+    >["reconnectToStream"],
+  };
+
+  return {
+    transport,
+    push: (chunk) => controller?.enqueue(chunk),
+    finish: () => controller?.close(),
+    fail: (err) => controller?.error(err),
+    sendCalls: () => calls,
+    reconnect,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function assertDefined<T>(
+  value: T,
+  label: string,
+): asserts value is NonNullable<T> {
+  if (value == null) {
+    throw new Error(`${label} was unexpectedly null/undefined`);
+  }
+}
+
+describe("useChat", () => {
+  describe("initial state", () => {
+    it("starts ready with no messages by default", () => {
+      const m = createMockTransport();
+      const { result } = renderHook(() =>
+        useChat({ transport: m.transport, experimentalThrottle: 0 })
+      );
+      expect(result.current.messages).toEqual([]);
+      expect(result.current.status).toBe("ready");
+      expect(result.current.error).toBeUndefined();
+      expect(typeof result.current.id).toBe("string");
+      expect(result.current.id.length).toBeGreaterThan(0);
+    });
+
+    it("seeds with initial messages", () => {
+      const m = createMockTransport();
+      const seed: Array<UIMessage> = [
+        { id: "u-1", role: "user", parts: [{ type: "text", text: "hi" }] },
+      ];
+      const { result } = renderHook(() =>
+        useChat({
+          transport: m.transport,
+          messages: seed,
+          experimentalThrottle: 0,
+        })
+      );
+      expect(result.current.messages).toEqual(seed);
+    });
+
+    it("respects a user-provided id", () => {
+      const m = createMockTransport();
+      const { result } = renderHook(() =>
+        useChat({
+          transport: m.transport,
+          id: "fixed-id",
+          experimentalThrottle: 0,
+        })
+      );
+      expect(result.current.id).toBe("fixed-id");
+    });
+  });
+
+  describe("sendMessage", () => {
+    it("appends the user message and transitions through submitted -> streaming -> ready", async () => {
+      const m = createMockTransport();
+      const onFinish = vi.fn();
+      const { result } = renderHook(() =>
+        useChat({
+          transport: m.transport,
+          experimentalThrottle: 0,
+          onFinish,
+        })
+      );
+
+      await act(async () => {
+        void result.current.sendMessage({ text: "hello" });
+        await Promise.resolve();
+      });
+
+      // After awaiting the queued microtask, status should be at least submitted
+      // and the user message present.
+      expect(result.current.status).toBe("submitted");
+      expect(result.current.messages).toHaveLength(1);
+      expect(result.current.messages[0]?.role).toBe("user");
+
+      const sendArgs = m.sendCalls()[0];
+      assertDefined(sendArgs, "sendCalls()[0]");
+      expect(sendArgs.trigger).toBe("submit-message");
+      const { messageId: assistantId } = sendArgs;
+      assertDefined(assistantId, "sendArgs.messageId");
+
+      await act(async () => {
+        m.push({ type: "start", messageId: assistantId });
+        m.push({ type: "start-step" });
+        m.push({ type: "text-start", id: `${assistantId}-text-0` });
+        m.push({
+          type: "text-delta",
+          id: `${assistantId}-text-0`,
+          delta: "Hi ",
+        });
+        m.push({
+          type: "text-delta",
+          id: `${assistantId}-text-0`,
+          delta: "there",
+        });
+        await Promise.resolve();
+      });
+
+      expect(result.current.status).toBe("streaming");
+      expect(result.current.messages).toHaveLength(2);
+      const assistant = result.current.messages[1];
+      assertDefined(assistant, "messages[1]");
+      expect(assistant.role).toBe("assistant");
+      expect(assistant.id).toBe(assistantId);
+      expect(extractText(assistant)).toBe("Hi there");
+
+      await act(async () => {
+        m.push({ type: "text-end", id: `${assistantId}-text-0` });
+        m.push({ type: "finish-step" });
+        m.push({ type: "finish" });
+        m.finish();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(result.current.status).toBe("ready");
+      expect(onFinish).toHaveBeenCalledTimes(1);
+      const finishCall = onFinish.mock.calls[0];
+      assertDefined(finishCall, "onFinish.mock.calls[0]");
+      const finishArg = finishCall[0];
+      expect(extractText(finishArg.message)).toBe("Hi there");
+      expect(finishArg.messages).toHaveLength(2);
+    });
+
+    it("supports text-delta concatenation with no preceding text-start", async () => {
+      const m = createMockTransport();
+      const { result } = renderHook(() =>
+        useChat({ transport: m.transport, experimentalThrottle: 0 })
+      );
+
+      await act(async () => {
+        void result.current.sendMessage({ text: "hi" });
+        await Promise.resolve();
+      });
+
+      const sendArgs = m.sendCalls()[0];
+      assertDefined(sendArgs, "sendCalls()[0]");
+      const { messageId: assistantId } = sendArgs;
+      assertDefined(assistantId, "sendArgs.messageId");
+      await act(async () => {
+        m.push({ type: "text-delta", id: "x", delta: "a" });
+        m.push({ type: "text-delta", id: "x", delta: "bc" });
+        m.finish();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const assistant = result.current.messages[1];
+      assertDefined(assistant, "messages[1]");
+      expect(extractText(assistant)).toBe("abc");
+      expect(result.current.status).toBe("ready");
+      expect(assistantId).toBeDefined();
+    });
+
+    it("populates error when the transport fails", async () => {
+      const m = createMockTransport();
+      const onError = vi.fn();
+      const { result } = renderHook(() =>
+        useChat({
+          transport: m.transport,
+          experimentalThrottle: 0,
+          onError,
+        })
+      );
+
+      await act(async () => {
+        void result.current.sendMessage({ text: "hi" });
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        m.fail(new Error("upstream blew up"));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(result.current.status).toBe("error");
+      expect(result.current.error?.message).toBe("upstream blew up");
+      expect(onError).toHaveBeenCalledTimes(1);
+    });
+
+    it("handles error chunks emitted on the stream", async () => {
+      const m = createMockTransport();
+      const onError = vi.fn();
+      const { result } = renderHook(() =>
+        useChat({
+          transport: m.transport,
+          experimentalThrottle: 0,
+          onError,
+        })
+      );
+
+      await act(async () => {
+        void result.current.sendMessage({ text: "hi" });
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        m.push({ type: "error", errorText: "model exploded" });
+        m.finish();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(result.current.status).toBe("error");
+      expect(result.current.error?.message).toBe("model exploded");
+      expect(onError).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("stop", () => {
+    it("aborts an in-flight stream and resets to ready", async () => {
+      const m = createMockTransport();
+      const { result } = renderHook(() =>
+        useChat({ transport: m.transport, experimentalThrottle: 0 })
+      );
+
+      await act(async () => {
+        void result.current.sendMessage({ text: "hi" });
+        await Promise.resolve();
+      });
+
+      const sendArgs = m.sendCalls()[0];
+      assertDefined(sendArgs, "sendCalls()[0]");
+      const { messageId: assistantId } = sendArgs;
+      assertDefined(assistantId, "sendArgs.messageId");
+      await act(async () => {
+        m.push({
+          type: "text-delta",
+          id: `${assistantId}-text-0`,
+          delta: "partial",
+        });
+        await Promise.resolve();
+      });
+
+      expect(result.current.status).toBe("streaming");
+
+      const abortError = new Error("aborted");
+      abortError.name = "AbortError";
+
+      await act(async () => {
+        result.current.stop();
+        m.fail(abortError);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(result.current.status).toBe("ready");
+      expect(result.current.error).toBeUndefined();
+      // Partial assistant text remains in messages — that's fine; user can call setMessages to clean up.
+    });
+  });
+
+  describe("regenerate", () => {
+    it("drops the trailing assistant message and re-streams", async () => {
+      const m = createMockTransport();
+      const seed: Array<UIMessage> = [
+        { id: "u-1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        {
+          id: "a-1",
+          role: "assistant",
+          parts: [{ type: "text", text: "first reply" }],
+        },
+      ];
+      const { result } = renderHook(() =>
+        useChat({
+          transport: m.transport,
+          messages: seed,
+          experimentalThrottle: 0,
+        })
+      );
+
+      await act(async () => {
+        void result.current.regenerate();
+        await Promise.resolve();
+      });
+
+      expect(m.sendCalls()).toHaveLength(1);
+      const sendArgs = m.sendCalls()[0];
+      assertDefined(sendArgs, "sendCalls()[0]");
+      expect(sendArgs.trigger).toBe("regenerate-message");
+      expect(sendArgs.messages).toEqual([seed[0]]);
+      expect(result.current.messages).toEqual([seed[0]]);
+      expect(result.current.status).toBe("submitted");
+
+      const { messageId: assistantId } = sendArgs;
+      assertDefined(assistantId, "sendArgs.messageId");
+      await act(async () => {
+        m.push({
+          type: "text-delta",
+          id: `${assistantId}-text-0`,
+          delta: "second",
+        });
+        m.finish();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(result.current.messages).toHaveLength(2);
+      const second = result.current.messages[1];
+      assertDefined(second, "messages[1]");
+      expect(extractText(second)).toBe("second");
+    });
+
+    it("is a no-op when there's no assistant message to drop", async () => {
+      const m = createMockTransport();
+      const { result } = renderHook(() =>
+        useChat({ transport: m.transport, experimentalThrottle: 0 })
+      );
+
+      await act(async () => {
+        await result.current.regenerate();
+      });
+
+      expect(m.sendCalls()).toHaveLength(0);
+      expect(result.current.status).toBe("ready");
+    });
+  });
+
+  describe("clearError", () => {
+    it("resets to ready and clears the error", async () => {
+      const m = createMockTransport();
+      const { result } = renderHook(() =>
+        useChat({ transport: m.transport, experimentalThrottle: 0 })
+      );
+
+      await act(async () => {
+        void result.current.sendMessage({ text: "hi" });
+        await Promise.resolve();
+      });
+      await act(async () => {
+        m.fail(new Error("nope"));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(result.current.status).toBe("error");
+
+      act(() => {
+        result.current.clearError();
+      });
+      expect(result.current.status).toBe("ready");
+      expect(result.current.error).toBeUndefined();
+    });
+  });
+
+  describe("setMessages", () => {
+    it("replaces messages with an array", () => {
+      const m = createMockTransport();
+      const { result } = renderHook(() =>
+        useChat({ transport: m.transport, experimentalThrottle: 0 })
+      );
+      const next: Array<UIMessage> = [{
+        id: "x",
+        role: "user",
+        parts: [{ type: "text", text: "set" }],
+      }];
+
+      act(() => result.current.setMessages(next));
+      expect(result.current.messages).toEqual(next);
+    });
+
+    it("supports updater function form", () => {
+      const m = createMockTransport();
+      const { result } = renderHook(() =>
+        useChat({
+          transport: m.transport,
+          messages: [{
+            id: "u-1",
+            role: "user",
+            parts: [{ type: "text", text: "a" }],
+          }],
+          experimentalThrottle: 0,
+        })
+      );
+      act(() =>
+        result.current.setMessages((prev) => [
+          ...prev,
+          {
+            id: "u-2",
+            role: "user",
+            parts: [{ type: "text", text: "b" }],
+          },
+        ])
+      );
+      expect(result.current.messages).toHaveLength(2);
+    });
+
+    it("is a no-op while a stream is in flight", async () => {
+      const m = createMockTransport();
+      const { result } = renderHook(() =>
+        useChat({ transport: m.transport, experimentalThrottle: 0 })
+      );
+
+      await act(async () => {
+        void result.current.sendMessage({ text: "hi" });
+        await Promise.resolve();
+      });
+      const submittedMessages = result.current.messages;
+      expect(result.current.status).toBe("submitted");
+
+      act(() => result.current.setMessages([]));
+      expect(result.current.messages).toEqual(submittedMessages);
+
+      const sendArgs = m.sendCalls()[0];
+      assertDefined(sendArgs, "sendCalls()[0]");
+      const { messageId: assistantId } = sendArgs;
+      assertDefined(assistantId, "sendArgs.messageId");
+      await act(async () => {
+        m.push({
+          type: "text-delta",
+          id: `${assistantId}-text-0`,
+          delta: "hi",
+        });
+        await Promise.resolve();
+      });
+      expect(result.current.status).toBe("streaming");
+
+      act(() => result.current.setMessages([]));
+      expect(result.current.messages.length).toBeGreaterThan(0);
+
+      await act(async () => {
+        m.finish();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(result.current.status).toBe("ready");
+
+      act(() => result.current.setMessages([]));
+      expect(result.current.messages).toEqual([]);
+    });
+  });
+
+  describe("resumeStream", () => {
+    it("is a no-op when reconnectToStream returns null", async () => {
+      const m = createMockTransport();
+      const { result } = renderHook(() =>
+        useChat({ transport: m.transport, experimentalThrottle: 0 })
+      );
+
+      await act(async () => {
+        await result.current.resumeStream();
+      });
+
+      expect(m.reconnect).toHaveBeenCalledTimes(1);
+      expect(result.current.status).toBe("ready");
+    });
+  });
+
+  describe("validation", () => {
+    it("throws when neither model nor transport is provided", () => {
+      expect(() => renderHook(() => useChat({ experimentalThrottle: 0 })))
+        .toThrow(/`model` is required/);
+    });
+  });
+});
+
+function extractText(m: UIMessage): string {
+  return (m.parts ?? [])
+    .filter((p): p is { type: "text"; text: string } => p.type === "text")
+    .map((p) => p.text)
+    .join("");
+}

--- a/packages/react/src/aip/useChat.ts
+++ b/packages/react/src/aip/useChat.ts
@@ -1,0 +1,390 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  type ChatTransport,
+  generateMessageId,
+  type LanguageModel,
+  LmsChatTransport,
+  type LmsChatTransportOptions,
+  type UIMessage,
+} from "@osdk/aip-core";
+import React from "react";
+import {
+  type ChatStatus,
+  type ChatStore,
+  createChatStore,
+} from "./chatStore.js";
+import {
+  drainStream,
+  runChatStream,
+  type StreamContext,
+} from "./chatStream.js";
+
+export type { ChatStatus } from "./chatStore.js";
+
+/**
+ * Options for {@link useChat}.
+ *
+ * v0 covers text-only chat. Tools, multi-step agent loops, and stream
+ * resume are not supported.
+ */
+export interface UseChatOptions {
+  /** Required when no `transport` is provided: the LMS-backed model. */
+  model?: LanguageModel;
+
+  /** System prompt prepended to every request. Forwarded to the default transport. */
+  system?: string;
+
+  /** Sampling controls. Forwarded to the default transport. */
+  temperature?: number;
+  maxOutputTokens?: number;
+  topP?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  stopSequences?: Array<string>;
+  seed?: number;
+  headers?: Record<string, string | undefined>;
+
+  /** Stable chat id. A stable id is generated if not provided. */
+  id?: string;
+
+  /** Initial messages — used as the seed snapshot. */
+  messages?: ReadonlyArray<UIMessage>;
+
+  /** Override the transport. Defaults to a new `LmsChatTransport(options)`. */
+  transport?: ChatTransport<UIMessage>;
+
+  /**
+   * Throttle subscriber notifications during streaming (ms). Default 50ms,
+   * which keeps token-by-token rendering smooth without rerendering per token.
+   */
+  experimentalThrottle?: number;
+
+  /** Fires when an in-flight stream errors out. */
+  onError?: (error: Error) => void;
+
+  /** Fires once after a stream completes successfully. */
+  onFinish?: (event: {
+    message: UIMessage;
+    messages: ReadonlyArray<UIMessage>;
+  }) => void;
+}
+
+/** Return value of {@link useChat}. */
+export interface UseChatReturn {
+  id: string;
+  messages: ReadonlyArray<UIMessage>;
+  /** No-op while a stream is in flight (`status === "streaming" | "submitted"`). Call `stop()` first to mutate during a stream. */
+  setMessages: (
+    messages:
+      | ReadonlyArray<UIMessage>
+      | ((prev: ReadonlyArray<UIMessage>) => ReadonlyArray<UIMessage>),
+  ) => void;
+
+  status: ChatStatus;
+  error: Error | undefined;
+
+  sendMessage: (message: SendMessageInput) => Promise<void>;
+  regenerate: (options?: { messageId?: string }) => Promise<void>;
+  stop: () => void;
+  /** Calls `transport.reconnectToStream`. v0: LMS returns null, so this is a no-op. */
+  resumeStream: () => Promise<void>;
+  clearError: () => void;
+}
+
+/** Input shape accepted by `sendMessage`. */
+export type SendMessageInput =
+  | { text: string }
+  | { role: "user"; parts: UIMessage["parts"] };
+
+/**
+ * React hook for streaming chat completions through `@osdk/aip-core`'s
+ * `streamText`.
+ *
+ * @example
+ * ```tsx
+ * const { messages, status, sendMessage, stop, error } = useChat({
+ *   model: foundryModel({ client, model: "gpt-4o" }),
+ *   system: "You are a concise assistant.",
+ * });
+ * ```
+ */
+export function useChat(options: UseChatOptions): UseChatReturn {
+  const { onFinish, onError } = options;
+
+  const id = React.useMemo(
+    () => options.id ?? generateMessageId(),
+    [options.id],
+  );
+
+  // JSON-stringify keys keep the memo stable when callers pass inline objects.
+  const headersKey = JSON.stringify(options.headers ?? null);
+  const stopSequencesKey = JSON.stringify(options.stopSequences ?? null);
+  const transport = React.useMemo<ChatTransport<UIMessage>>(
+    () => {
+      if (options.transport != null) {
+        return options.transport;
+      }
+      if (options.model == null) {
+        throw new Error(
+          "useChat: `model` is required when no `transport` is provided.",
+        );
+      }
+      const built: LmsChatTransportOptions = {
+        model: options.model,
+        system: options.system,
+        temperature: options.temperature,
+        maxOutputTokens: options.maxOutputTokens,
+        topP: options.topP,
+        presencePenalty: options.presencePenalty,
+        frequencyPenalty: options.frequencyPenalty,
+        stopSequences: options.stopSequences,
+        seed: options.seed,
+        headers: options.headers,
+      };
+      return new LmsChatTransport(built);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      options.transport,
+      options.model,
+      options.system,
+      options.temperature,
+      options.maxOutputTokens,
+      options.topP,
+      options.presencePenalty,
+      options.frequencyPenalty,
+      options.seed,
+      headersKey,
+      stopSequencesKey,
+    ],
+  );
+
+  const store = React.useMemo<ChatStore>(
+    () =>
+      createChatStore({
+        initialMessages: options.messages,
+        throttleMs: options.experimentalThrottle ?? 50,
+      }),
+    // Recreating the store mid-session would drop chat state, so it's keyed
+    // only by `id`. Use `setMessages` to mutate messages at runtime.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [id],
+  );
+
+  const state = React.useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getSnapshot,
+  );
+
+  const abortRef = React.useRef<AbortController | undefined>(undefined);
+  const stoppedRef = React.useRef<boolean>(false);
+
+  const ctxRef = React.useRef<StreamContext>({
+    store,
+    abortRef,
+    stoppedRef,
+    onFinish,
+    onError,
+  });
+  ctxRef.current = { store, abortRef, stoppedRef, onFinish, onError };
+
+  const runStream = React.useCallback(
+    (
+      seed: ReadonlyArray<UIMessage>,
+      trigger: "submit-message" | "regenerate-message",
+    ): Promise<void> =>
+      runChatStream(ctxRef.current, transport, id, seed, trigger),
+    [transport, id],
+  );
+
+  const sendMessage = React.useCallback(
+    async (input: SendMessageInput): Promise<void> => {
+      const userMsg = normalizeUserMessage(input);
+      const seeded = [...store.getSnapshot().messages, userMsg];
+      store.setState({
+        messages: seeded,
+        status: "submitted",
+        error: undefined,
+      });
+      await runStream(seeded, "submit-message");
+    },
+    [store, runStream],
+  );
+
+  const regenerate = React.useCallback(
+    async (regenerateOpts?: { messageId?: string }): Promise<void> => {
+      const messages = store.getSnapshot().messages;
+      const cutoff = resolveRegenerateCutoff(
+        messages,
+        regenerateOpts?.messageId,
+      );
+      if (cutoff.kind === "noop") {
+        return;
+      }
+      if (cutoff.kind === "error") {
+        store.setState((prev) => ({
+          ...prev,
+          status: "error",
+          error: cutoff.error,
+        }));
+        return;
+      }
+      const truncated = messages.slice(0, cutoff.index);
+      store.setState({
+        messages: truncated,
+        status: "submitted",
+        error: undefined,
+      });
+      await runStream(truncated, "regenerate-message");
+    },
+    [store, runStream],
+  );
+
+  const stop = React.useCallback((): void => {
+    stoppedRef.current = true;
+    abortRef.current?.abort();
+    abortRef.current = undefined;
+  }, []);
+
+  const resumeStream = React.useCallback(async (): Promise<void> => {
+    const stream = await transport.reconnectToStream({ chatId: id });
+    if (stream == null) {
+      return;
+    }
+    abortRef.current?.abort();
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+    const assistantId = generateMessageId();
+    await drainStream(ctxRef.current, stream, assistantId, ctrl);
+  }, [transport, id]);
+
+  const clearError = React.useCallback((): void => {
+    // Resetting from streaming/submitted would race the in-flight stream, so
+    // only reset when status === "error".
+    store.setState(
+      (prev) =>
+        prev.status === "error"
+          ? { ...prev, status: "ready", error: undefined }
+          : prev,
+    );
+  }, [store]);
+
+  const setMessages = React.useCallback(
+    (
+      next:
+        | ReadonlyArray<UIMessage>
+        | ((prev: ReadonlyArray<UIMessage>) => ReadonlyArray<UIMessage>),
+    ): void => {
+      store.setState((prev) => {
+        if (prev.status === "streaming" || prev.status === "submitted") {
+          return prev;
+        }
+        return {
+          ...prev,
+          messages: typeof next === "function" ? next(prev.messages) : next,
+        };
+      });
+    },
+    [store],
+  );
+
+  return React.useMemo(
+    () => ({
+      id,
+      messages: state.messages,
+      setMessages,
+      status: state.status,
+      error: state.error,
+      sendMessage,
+      regenerate,
+      stop,
+      resumeStream,
+      clearError,
+    }),
+    [
+      id,
+      state.messages,
+      state.status,
+      state.error,
+      setMessages,
+      sendMessage,
+      regenerate,
+      stop,
+      resumeStream,
+      clearError,
+    ],
+  );
+}
+
+type RegenerateCutoff =
+  | { kind: "noop" }
+  | { kind: "error"; error: Error }
+  | { kind: "ok"; index: number };
+
+function resolveRegenerateCutoff(
+  messages: ReadonlyArray<UIMessage>,
+  messageId: string | undefined,
+): RegenerateCutoff {
+  if (messageId != null) {
+    const index = messages.findIndex((m) => m.id === messageId);
+    if (index < 0) {
+      return { kind: "noop" };
+    }
+    const target = messages[index];
+    if (target == null || target.role !== "assistant") {
+      return {
+        kind: "error",
+        error: new Error(
+          `useChat.regenerate: messageId "${messageId}" is `
+            + `not an assistant message; only assistant messages can be regenerated.`,
+        ),
+      };
+    }
+    return { kind: "ok", index };
+  }
+  const lastAssistant = findLastAssistantIndex(messages);
+  if (lastAssistant < 0) {
+    return { kind: "noop" };
+  }
+  return { kind: "ok", index: lastAssistant };
+}
+
+function normalizeUserMessage(input: SendMessageInput): UIMessage {
+  if ("text" in input) {
+    return {
+      id: generateMessageId(),
+      role: "user",
+      parts: [{ type: "text", text: input.text }],
+    };
+  }
+  return {
+    id: generateMessageId(),
+    role: input.role,
+    parts: input.parts,
+  };
+}
+
+function findLastAssistantIndex(arr: ReadonlyArray<UIMessage>): number {
+  for (let i = arr.length - 1; i >= 0; i--) {
+    if (arr[i]?.role === "assistant") {
+      return i;
+    }
+  }
+  return -1;
+}

--- a/packages/react/src/public/experimental/aip.ts
+++ b/packages/react/src/public/experimental/aip.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type { ChatStatus } from "../../aip/chatStore.js";
+export { useChat } from "../../aip/useChat.js";
+export type {
+  SendMessageInput,
+  UseChatOptions,
+  UseChatReturn,
+} from "../../aip/useChat.js";
+
+export type { UIMessage, UIMessageChunk } from "@osdk/aip-core";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3555,6 +3555,15 @@ importers:
 
   packages/e2e.sandbox.peopleapp:
     dependencies:
+      '@ai-sdk/provider':
+        specifier: ^3.0.8
+        version: 3.0.8
+      '@ai-sdk/react':
+        specifier: ^3.0.170
+        version: 3.0.170(react@18.3.1)(zod@3.25.76)
+      '@osdk/aip-core':
+        specifier: workspace:~
+        version: link:../aip-core
       '@osdk/api':
         specifier: workspace:~
         version: link:../api
@@ -3570,6 +3579,9 @@ importers:
       '@osdk/react-components':
         specifier: workspace:~
         version: link:../react-components
+      ai:
+        specifier: ^6.0.168
+        version: 6.0.168(zod@3.25.76)
       core-js:
         specifier: ^3.45.1
         version: 3.45.1
@@ -4680,6 +4692,9 @@ importers:
         specifier: ^17 || ^18 || ^19
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@osdk/aip-core':
+        specifier: workspace:*
+        version: link:../aip-core
       '@osdk/api':
         specifier: workspace:*
         version: link:../api
@@ -4804,6 +4819,9 @@ importers:
         specifier: 0.20.3
         version: 0.20.3
     devDependencies:
+      '@osdk/aip-core':
+        specifier: workspace:*
+        version: link:../aip-core
       '@osdk/api':
         specifier: workspace:*
         version: link:../api
@@ -6035,9 +6053,27 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
+  '@ai-sdk/gateway@3.0.104':
+    resolution: {integrity: sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.23':
+    resolution: {integrity: sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
+
+  '@ai-sdk/react@3.0.170':
+    resolution: {integrity: sha512-YUDn+mK0c8iUz14rCBf1A0zg6SV5b5aSVUz+azF1bdBd1SFXVI19dKYR+PQSpZY+0+z+zs252AAsacUqiO98Kw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
 
   '@algolia/abtesting@1.12.0':
     resolution: {integrity: sha512-EfW0bfxjPs+C7ANkJDw2TATntfBKsFiy7APh+KO0pQ8A6HYa5I0NjFuCGCXWfzzzLXNZta3QUl3n5Kmm6aJo9Q==}
@@ -9044,6 +9080,10 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
 
   '@osdk/api@1.9.3':
     resolution: {integrity: sha512-ZGPh9iRBF+XNhOJr0dbYeLSFYQUydr1OVY5h7BNYz4DByT9l56u1C1sQTMVSPGH75KSQ77nUz7WbuJIWSDPVcA==}
@@ -12432,6 +12472,10 @@ packages:
     peerDependencies:
       valibot: ^1.2.0
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vis.gl/react-mapbox@8.0.4':
     resolution: {integrity: sha512-NFk0vsWcNzSs0YCsVdt2100Zli9QWR+pje8DacpLkkGEAXFaJsFtI1oKD0Hatiate4/iAIW39SQHhgfhbeEPfQ==}
     peerDependencies:
@@ -12878,6 +12922,12 @@ packages:
   aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
+
+  ai@6.0.168:
+    resolution: {integrity: sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
@@ -15046,6 +15096,10 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
 
   exec-async@2.2.0:
     resolution: {integrity: sha512-87OpwcEiMia/DeiKFzaQNBNFeN3XkkpYIh9FyOqq5mS2oKv3CBE67PXoEKcr6nodWdXNogTiQ0jE2NGuoffXPw==}
@@ -20903,6 +20957,10 @@ packages:
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
 
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
+
   through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
 
@@ -22377,9 +22435,33 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
+  '@ai-sdk/gateway@3.0.104(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
+      '@vercel/oidc': 3.2.0
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@4.0.23(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 3.25.76
+
   '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
+
+  '@ai-sdk/react@3.0.170(react@18.3.1)(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
+      ai: 6.0.168(zod@3.25.76)
+      react: 18.3.1
+      swr: 2.3.6(react@18.3.1)
+      throttleit: 2.1.0
+    transitivePeerDependencies:
+      - zod
 
   '@algolia/abtesting@1.12.0':
     dependencies:
@@ -26794,6 +26876,8 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
+  '@opentelemetry/api@1.9.0': {}
+
   '@osdk/api@1.9.3':
     dependencies:
       '@osdk/gateway': 2.4.2
@@ -30566,6 +30650,8 @@ snapshots:
     dependencies:
       valibot: 1.2.0(typescript@5.5.4)
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vis.gl/react-mapbox@8.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -31378,6 +31464,14 @@ snapshots:
     dependencies:
       clean-stack: 2.2.0
       indent-string: 4.0.0
+
+  ai@6.0.168(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.104(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      zod: 3.25.76
 
   ajv-draft-04@1.0.0(ajv@8.13.0):
     optionalDependencies:
@@ -34033,6 +34127,8 @@ snapshots:
   eventemitter3@5.0.1: {}
 
   events@3.3.0: {}
+
+  eventsource-parser@3.0.8: {}
 
   exec-async@2.2.0: {}
 
@@ -41647,6 +41743,8 @@ snapshots:
       real-require: 0.2.0
 
   throat@5.0.0: {}
+
+  throttleit@2.1.0: {}
 
   through2@2.0.5:
     dependencies:


### PR DESCRIPTION
This reverts commit c3752ce6d3000eb085fde2389f228f0b0f4cb90a, restoring the AIP chat entry points (@osdk/react/experimental/aip and @osdk/react-components/experimental/aip-agent-chat).

To avoid the optional-peer-dependency problem that motivated #3406, also make @osdk/aip-core publishable so the optional peer resolves from the registry:
  - remove "private": true from packages/aip-core/package.json
  - move @osdk/aip-core from the "minimal packages" archetype to "standardLibraries" in .monorepolint.config.mjs (reverses #3162)