### PR TITLE
fix(build): order @osdk/generator before @osdk/cli's esbuild bundle

### DIFF
--- a/packages/cli.cmd.typescript/turbo.json
+++ b/packages/cli.cmd.typescript/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "transpileEsm": {
+      "dependsOn": ["^transpileEsm"]
+    }
+  }
+}


### PR DESCRIPTION
## Problem

CI intermittently fails the **Bundle Size** check (and matrix shards of **Build and Test**) at `@osdk/cli#transpileEsm` with:

```
✘ [ERROR] Could not resolve "../GenerateContext/ForeignType.js"
✘ [ERROR] Could not resolve "../GenerateContext/EnhancedInterfaceType.js"
✘ [ERROR] Could not resolve "../GenerateContext/enhanceOntology.js"
... Build failed with 10-11 errors → @osdk/cli#transpileEsm exited (1)
```

It's flaky (single matrix shard / base build fails, others pass), which is the signature of a build-ordering race rather than a code bug — the `GenerateContext/*` files exist in source and are unchanged.

## Root cause

`@osdk/cli`'s `transpileEsm` runs esbuild in **bundle mode** and force-inlines `@osdk/cli.cmd.typescript` (it's a `devDependency` in the tsup `noExternal` list). That transitively inlines `@osdk/generator`, so the bundle reaches into `generator/build/esm/**` and follows its relative imports into `GenerateContext/*.js`. This only works if `@osdk/generator`'s `build/esm` is fully emitted first.

turbo's `^transpileEsm` is **immediate-only** — transitivity requires every intermediate package to also propagate it. `@osdk/cli.cmd.typescript` had no `turbo.json`, so it used the root `transpileEsm` definition, which has **no `^transpileEsm`**. The chain `cli → cli.cmd.typescript → generator` was broken, so `generator#transpileEsm` was never ordered before `cli`'s bundle.

`turbo run transpileEsm --filter=@osdk/cli --dry-run` before the fix:
```
cli#transpileEsm deps: [cli.cmd.typescript, cli.common, foundry-config-json, ...]  # immediate only
generator#transpileEsm in run?: false                                              # never scheduled
```

## Fix

Add a `turbo.json` to `@osdk/cli.cmd.typescript` propagating `^transpileEsm` (matching `@osdk/cli`'s own config). `generator` already propagates `^transpileEsm`, so the full chain now completes.

After the fix:
- dry-run shows `generator#transpileEsm in run?: true` and `cli.cmd.typescript#transpileEsm` depends on `@osdk/generator#transpileEsm`
- `turbo run transpileEsm --filter=@osdk/cli --force` → 11 tasks, clean, no resolve errors

## Changeset

None — the only change is build tooling (`turbo.json`) in the **private** `@osdk/cli.cmd.typescript`; no published package code changes (`changeset status` confirms nothing to bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)