### PR TITLE
add annotate, contrast, encrypt, and decrypt image operations to experimental media transformation

### DIFF
--- a/.changeset/media-transformation-image-operations.md
+++ b/.changeset/media-transformation-image-operations.md
@@ -1,0 +1,6 @@
+---
+"@osdk/api": patch
+"@osdk/client": patch
+---
+
+Add annotate, contrast, encrypt, and decrypt image operations to the experimental media transformation surface, closing parity with the platform image-operation set.

--- a/packages/api/src/experimental/MediaTransformation.ts
+++ b/packages/api/src/experimental/MediaTransformation.ts
@@ -341,6 +341,86 @@ export interface ImageSpec {
   $mimeType: "BMP" | "TIFF" | "NITF" | "JP2K" | "JPG" | "PNG" | "WEBP";
 }
 
+/**
+ * @experimental
+ */
+export interface Annotation {
+  $geometry: AnnotateGeometry;
+  $label?: string;
+  $color?: Color;
+  $thickness?: number;
+  $fontSize?: number;
+}
+
+/**
+ * @experimental
+ */
+export interface AnnotateGeometryOptions {
+  $boundingBox: BoundingBox;
+}
+
+export namespace AnnotateGeometry {
+  export interface $boundingBox extends Just<
+    "$boundingBox",
+    AnnotateGeometryOptions
+  > {}
+}
+
+export type AnnotateGeometry = AnnotateGeometry.$boundingBox;
+
+/**
+ * @experimental
+ */
+export interface BoundingBox {
+  $left: number;
+  $top: number;
+  $width: number;
+  $height: number;
+}
+
+/**
+ * @experimental
+ */
+export interface Color {
+  $r: number;
+  $g: number;
+  $b: number;
+  $a?: number;
+}
+
+/**
+ * @experimental
+ */
+export interface ContrastTypeOptions {
+  $equalize: {};
+  $rayleigh: { $sigma: number };
+  $binarize: { $threshold?: number };
+}
+
+export namespace ContrastType {
+  export interface $equalize extends Just<"$equalize", ContrastTypeOptions> {}
+  export interface $rayleigh extends Just<"$rayleigh", ContrastTypeOptions> {}
+  export interface $binarize extends Just<"$binarize", ContrastTypeOptions> {}
+}
+
+export type ContrastType =
+  | ContrastType.$equalize
+  | ContrastType.$rayleigh
+  | ContrastType.$binarize;
+
+/**
+ * @experimental
+ */
+export interface ImagePixelCoordinate {
+  $x: number;
+  $y: number;
+}
+
+/**
+ * @experimental
+ */
+export type ImageRegionPolygon = Array<ImagePixelCoordinate>;
+
 // ─── Image operations ─────────────────────────────────────────────────────────
 
 /**
@@ -358,6 +438,16 @@ export interface ImageOperationOptions {
   };
   $grayscale: {};
   $tile: { $zoom: number; $x: number; $y: number };
+  $annotate: { $annotations: Array<Annotation> };
+  $contrast: { $contrastType: ContrastType };
+  $encrypt: {
+    $polygons: Array<ImageRegionPolygon>;
+    $cipherLicenseRid: string;
+  };
+  $decrypt: {
+    $polygons: Array<ImageRegionPolygon>;
+    $cipherLicenseRid: string;
+  };
 }
 
 /**
@@ -376,6 +466,10 @@ export namespace ImageOperation {
     ImageOperationOptions
   > {}
   export interface $tile extends Just<"$tile", ImageOperationOptions> {}
+  export interface $annotate extends Just<"$annotate", ImageOperationOptions> {}
+  export interface $contrast extends Just<"$contrast", ImageOperationOptions> {}
+  export interface $encrypt extends Just<"$encrypt", ImageOperationOptions> {}
+  export interface $decrypt extends Just<"$decrypt", ImageOperationOptions> {}
 }
 
 /**
@@ -387,7 +481,11 @@ export type ImageOperation =
   | ImageOperation.$rotate
   | ImageOperation.$crop
   | ImageOperation.$grayscale
-  | ImageOperation.$tile;
+  | ImageOperation.$tile
+  | ImageOperation.$annotate
+  | ImageOperation.$contrast
+  | ImageOperation.$encrypt
+  | ImageOperation.$decrypt;
 
 // ─── Video operations ─────────────────────────────────────────────────────────
 

--- a/packages/api/src/public/unstable.ts
+++ b/packages/api/src/public/unstable.ts
@@ -25,9 +25,14 @@ export {
 } from "../experimental/fetchPageByRid.js";
 export { __EXPERIMENTAL__NOT_SUPPORTED_YET__getBulkLinks } from "../experimental/getBulkLinks.js";
 export type {
+  AnnotateGeometry,
+  Annotation,
   AudioEncoding,
   AudioOperation,
   AudioToTextOperation,
+  BoundingBox,
+  Color,
+  ContrastType,
   DicomToImageOperation,
   DocumentTextExtractionConfig,
   DocumentToDocumentOperation,
@@ -36,6 +41,8 @@ export type {
   EmailToAttachmentOperation,
   EmailToTextOperation,
   ImageOperation,
+  ImagePixelCoordinate,
+  ImageRegionPolygon,
   ImageSpec,
   ImageToDocumentOperation,
   ImageToEmbeddingOperation,

--- a/packages/client/src/internal/conversions/makeMediaTransformation.test.ts
+++ b/packages/client/src/internal/conversions/makeMediaTransformation.test.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ImageOperation, MediaTransformation } from "@osdk/api/unstable";
+import { describe, expect, it } from "vitest";
+
+import { makeMediaTransformation } from "./makeMediaTransformation.js";
+
+/**
+ * Runs a single image operation through the serializer and returns the
+ * converted wire operation, so each test can assert on its exact shape.
+ */
+function convertImageOp(op: ImageOperation): unknown {
+  const transformation: MediaTransformation = {
+    $image: { $encoding: "png", $operations: [op] },
+  };
+  const result = makeMediaTransformation(transformation) as {
+    type: string;
+    operations: Array<unknown>;
+  };
+  expect(result.type).toBe("image");
+  return result.operations[0];
+}
+
+describe("makeMediaTransformation image operations", () => {
+  it("converts $tile (regression: previously the implicit catch-all)", () => {
+    expect(convertImageOp({ $tile: { $zoom: 2, $x: 1, $y: 3 } })).toEqual({
+      type: "tile",
+      zoom: 2,
+      x: 1,
+      y: 3,
+    });
+  });
+
+  it("converts $annotate with a bounding box, label, and color", () => {
+    expect(
+      convertImageOp({
+        $annotate: {
+          $annotations: [
+            {
+              $geometry: {
+                $boundingBox: { $left: 1, $top: 2, $width: 3, $height: 4 },
+              },
+              $label: "cat",
+              $color: { $r: 255, $g: 0, $b: 0, $a: 0.5 },
+              $thickness: 2,
+              $fontSize: 12,
+            },
+          ],
+        },
+      })
+    ).toEqual({
+      type: "annotate",
+      annotations: [
+        {
+          geometry: {
+            type: "boundingBox",
+            boundingBox: { left: 1, top: 2, width: 3, height: 4 },
+          },
+          label: "cat",
+          color: { r: 255, g: 0, b: 0, a: 0.5 },
+          thickness: 2,
+          fontSize: 12,
+        },
+      ],
+    });
+  });
+
+  it("converts $annotate with only the required geometry", () => {
+    expect(
+      convertImageOp({
+        $annotate: {
+          $annotations: [
+            {
+              $geometry: {
+                $boundingBox: { $left: 0, $top: 0, $width: 10, $height: 10 },
+              },
+            },
+          ],
+        },
+      })
+    ).toEqual({
+      type: "annotate",
+      annotations: [
+        {
+          geometry: {
+            type: "boundingBox",
+            boundingBox: { left: 0, top: 0, width: 10, height: 10 },
+          },
+        },
+      ],
+    });
+  });
+
+  it("converts $contrast equalize", () => {
+    expect(
+      convertImageOp({ $contrast: { $contrastType: { $equalize: {} } } })
+    ).toEqual({ type: "contrast", contrastType: { type: "equalize" } });
+  });
+
+  it("converts $contrast rayleigh", () => {
+    expect(
+      convertImageOp({
+        $contrast: { $contrastType: { $rayleigh: { $sigma: 0.7 } } },
+      })
+    ).toEqual({
+      type: "contrast",
+      contrastType: { type: "rayleigh", sigma: 0.7 },
+    });
+  });
+
+  it("converts $contrast binarize with a threshold", () => {
+    expect(
+      convertImageOp({
+        $contrast: { $contrastType: { $binarize: { $threshold: 128 } } },
+      })
+    ).toEqual({
+      type: "contrast",
+      contrastType: { type: "binarize", threshold: 128 },
+    });
+  });
+
+  it("converts $contrast binarize without a threshold", () => {
+    expect(
+      convertImageOp({ $contrast: { $contrastType: { $binarize: {} } } })
+    ).toEqual({ type: "contrast", contrastType: { type: "binarize" } });
+  });
+
+  it("converts $encrypt with polygon regions and a cipher license", () => {
+    expect(
+      convertImageOp({
+        $encrypt: {
+          $polygons: [
+            [
+              { $x: 0, $y: 0 },
+              { $x: 10, $y: 0 },
+              {
+                $x: 10,
+                $y: 10,
+              },
+            ],
+          ],
+          $cipherLicenseRid: "ri.cipher.main.license.1",
+        },
+      })
+    ).toEqual({
+      type: "encrypt",
+      polygons: [
+        [
+          { x: 0, y: 0 },
+          { x: 10, y: 0 },
+          { x: 10, y: 10 },
+        ],
+      ],
+      cipherLicenseRid: "ri.cipher.main.license.1",
+    });
+  });
+
+  it("converts $decrypt with polygon regions and a cipher license", () => {
+    expect(
+      convertImageOp({
+        $decrypt: {
+          $polygons: [
+            [
+              { $x: 1, $y: 1 },
+              { $x: 5, $y: 1 },
+              { $x: 5, $y: 5 },
+            ],
+          ],
+          $cipherLicenseRid: "ri.cipher.main.license.2",
+        },
+      })
+    ).toEqual({
+      type: "decrypt",
+      polygons: [
+        [
+          { x: 1, y: 1 },
+          { x: 5, y: 1 },
+          { x: 5, y: 5 },
+        ],
+      ],
+      cipherLicenseRid: "ri.cipher.main.license.2",
+    });
+  });
+});

--- a/packages/client/src/internal/conversions/makeMediaTransformation.ts
+++ b/packages/client/src/internal/conversions/makeMediaTransformation.ts
@@ -15,9 +15,13 @@
  */
 
 import type {
+  AnnotateGeometry,
+  Annotation,
   AudioEncoding,
   AudioOperation,
   AudioToTextOperation,
+  Color,
+  ContrastType,
   DicomToImageOperation,
   DocumentTextExtractionConfig,
   DocumentToDocumentOperation,
@@ -26,6 +30,7 @@ import type {
   EmailToAttachmentOperation,
   EmailToTextOperation,
   ImageOperation,
+  ImageRegionPolygon,
   ImageSpec,
   ImageToDocumentOperation,
   ImageToEmbeddingOperation,
@@ -392,15 +397,86 @@ function convertImageOperation(op: ImageOperation) {
     };
   } else if ("$grayscale" in op) {
     return { type: "grayscale" as const };
-  } else {
-    const tile = (op as ImageOperation & { $tile: {} }).$tile;
+  } else if ("$tile" in op && op.$tile != null) {
     return {
       type: "tile" as const,
-      zoom: tile.$zoom,
-      x: tile.$x,
-      y: tile.$y,
+      zoom: op.$tile.$zoom,
+      x: op.$tile.$x,
+      y: op.$tile.$y,
+    };
+  } else if ("$annotate" in op && op.$annotate != null) {
+    return {
+      type: "annotate" as const,
+      annotations: op.$annotate.$annotations.map(convertAnnotation),
+    };
+  } else if ("$contrast" in op && op.$contrast != null) {
+    return {
+      type: "contrast" as const,
+      contrastType: convertContrastType(op.$contrast.$contrastType),
+    };
+  } else if ("$encrypt" in op && op.$encrypt != null) {
+    return {
+      type: "encrypt" as const,
+      polygons: op.$encrypt.$polygons.map(convertImageRegionPolygon),
+      cipherLicenseRid: op.$encrypt.$cipherLicenseRid,
+    };
+  } else {
+    const decrypt = (op as ImageOperation & { $decrypt: {} }).$decrypt;
+    return {
+      type: "decrypt" as const,
+      polygons: decrypt.$polygons.map(convertImageRegionPolygon),
+      cipherLicenseRid: decrypt.$cipherLicenseRid,
     };
   }
+}
+
+function convertAnnotation(annotation: Annotation) {
+  return {
+    geometry: convertAnnotateGeometry(annotation.$geometry),
+    label: annotation.$label,
+    color:
+      annotation.$color != null ? convertColor(annotation.$color) : undefined,
+    thickness: annotation.$thickness,
+    fontSize: annotation.$fontSize,
+  };
+}
+
+function convertAnnotateGeometry(geometry: AnnotateGeometry) {
+  return {
+    type: "boundingBox" as const,
+    boundingBox: {
+      left: geometry.$boundingBox.$left,
+      top: geometry.$boundingBox.$top,
+      width: geometry.$boundingBox.$width,
+      height: geometry.$boundingBox.$height,
+    },
+  };
+}
+
+function convertColor(color: Color) {
+  return { r: color.$r, g: color.$g, b: color.$b, a: color.$a };
+}
+
+function convertContrastType(contrastType: ContrastType) {
+  if ("$equalize" in contrastType) {
+    return { type: "equalize" as const };
+  } else if ("$rayleigh" in contrastType && contrastType.$rayleigh != null) {
+    return {
+      type: "rayleigh" as const,
+      sigma: contrastType.$rayleigh.$sigma,
+    };
+  } else {
+    const binarize = (contrastType as ContrastType & { $binarize: {} })
+      .$binarize;
+    return { type: "binarize" as const, threshold: binarize.$threshold };
+  }
+}
+
+function convertImageRegionPolygon(polygon: ImageRegionPolygon) {
+  return polygon.map((coordinate) => ({
+    x: coordinate.$x,
+    y: coordinate.$y,
+  }));
 }
 
 function convertVideoOperation(op: VideoOperation) {

--- a/packages/monorepo.cspell/dict.foundry-words.txt
+++ b/packages/monorepo.cspell/dict.foundry-words.txt
@@ -1,6 +1,7 @@
 ASMT
 BDUS
 bellaso
+binarize
 blockset
 CBAC
 CMYK


### PR DESCRIPTION
## BLUF
Add the missing 4 image operations (`annotate`, `contrast`, `encrypt`, `decrypt`), to be in parity with what's available + exposed in python-osdk.

## Changes in this PR
Add `$annotate`, `$contrast`, `$encrypt`, and `$decrypt` to the `ImageOperation` union
