### PR TITLE
Add non-null assertion to CipherText

### DIFF
--- a/.changeset/ninety-lies-lead.md
+++ b/.changeset/ninety-lies-lead.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client": patch
+"@osdk/api": patch
+---
+
+Add nullity check for decrypt

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -391,7 +391,7 @@ export type BaseWirePropertyTypes = "string" | "datetime" | "double" | "boolean"
 
 // @public
 export interface CipherText {
-    	decrypt(): Promise<string | undefined>;
+    	decrypt(): Promise<string>;
 }
 
 // @public (undocumented)

--- a/packages/api/src/object/CipherText.ts
+++ b/packages/api/src/object/CipherText.ts
@@ -31,5 +31,5 @@ export interface CipherText {
    * Decrypts the ciphertext and resolves to the plaintext value.
    * @returns the decrypted plaintext
    */
-  decrypt(): Promise<string | undefined>;
+  decrypt(): Promise<string>;
 }

--- a/packages/client/src/createCipherTextProperty.ts
+++ b/packages/client/src/createCipherTextProperty.ts
@@ -16,6 +16,7 @@
 
 import type { CipherText } from "@osdk/api";
 import { decrypt as cipherTextDecrypt } from "@osdk/foundry.ontologies/CipherTextProperty";
+import invariant from "tiny-invariant";
 import type { MinimalClient } from "./MinimalClientContext.js";
 
 export class CipherTextPropertyImpl implements CipherText {
@@ -33,13 +34,17 @@ export class CipherTextPropertyImpl implements CipherText {
     this.#locator = [objectApiName, primaryKey, propertyName];
   }
 
-  async decrypt(): Promise<string | undefined> {
+  async decrypt(): Promise<string> {
     const ontologyRid = await this.#client.ontologyRid;
     const result = await cipherTextDecrypt(
       this.#client,
       ontologyRid,
       ...this.#locator,
     );
-    return result.plaintext;
+    invariant(
+      Object.hasOwn(result, "plaintext"),
+      "Expected decryption result to have plaintext value",
+    );
+    return result.plaintext!;
   }
 }


### PR DESCRIPTION
Added the following line to `decrypt` on CipherText to always return `Promise<string>` instead of `Promise<string | undefined>`.

- Backend does not return null-plaintext result when the request is successful.
  - This is currently inconsistent with generated types but this PR is made to prevent a breaking change in the future.

```typescript
invariant(
      Object.hasOwn(result, "plaintext"),
      "Expected decryption result to have plaintext value",
    );
```