### PR TITLE
fix: pin @osdk/aip-core peer range to avoid major-bump cascade

### DIFF
--- a/.changeset/aip-core-peer-range-major-cascade.md
+++ b/.changeset/aip-core-peer-range-major-cascade.md
@@ -1,0 +1,6 @@
+---
+"@osdk/react-components": patch
+"@osdk/react": patch
+---
+
+Pin the `@osdk/aip-core` peerDependency range to `>=0.5.0 <1.0.0` instead of `workspace:^` so a minor bump of `@osdk/aip-core` (e.g. 0.5.0 -> 0.6.0) no longer falls out of the caret range and triggers a major-bump cascade across the release plan.

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -216,7 +216,7 @@
     "xlsx-republish": "0.20.3"
   },
   "peerDependencies": {
-    "@osdk/aip-core": "workspace:^",
+    "@osdk/aip-core": ">=0.5.0 <1.0.0",
     "@osdk/api": "^2.8.0",
     "@osdk/client": "^2.8.0",
     "@osdk/react": "^2.8.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -99,7 +99,7 @@
     "fast-deep-equal": "^3.1.3"
   },
   "peerDependencies": {
-    "@osdk/aip-core": "workspace:^",
+    "@osdk/aip-core": ">=0.5.0 <1.0.0",
     "@osdk/api": "^2.15.0",
     "@osdk/client": "^2.15.0",
     "@osdk/foundry.admin": "*",


### PR DESCRIPTION
## Problem

`./scripts/createReleasePr.sh` fails with:

> ERROR  Package "@osdk/aip-core" received a major bump (0.5.0 -> 1.0.0). Major bumps are never allowed.

## Root cause

`@osdk/react` and `@osdk/react-components` declared `"@osdk/aip-core": "workspace:^"` in their `peerDependencies`.

1. The `aip-entrypoints-return` changeset gives `@osdk/aip-core` a **minor** bump → `0.5.0 → 0.6.0`.
2. On a `0.x` version, `^0.5.0` means `>=0.5.0 <0.6.0`, so `0.6.0` is **out of range**.
3. Changesets bumps a dependent whose **peer** range goes out of range as **major**. Since `@osdk/react` is in the fixed group with `@osdk/api`/`@osdk/client`, the major cascaded across nearly the whole monorepo — `aip-core` was just the first package `mutateReleasePlan` tripped on.

This is the same bug class fixed in #3459 for the `@osdk/language-models` peer; the revert in `afc63a794c` ("Revert Remove AIP entrypoints") reintroduced the `workspace:^` peer for these two packages.

## Fix

Pin the peer range to an explicit `>=0.5.0 <1.0.0` (matching #3459's pattern) in both packages. A plain semver range is no longer auto-bumped by changesets (`bumpVersionsWithWorkspaceProtocolOnly: true`) and stays satisfied for both the current workspace (`0.5.0`) and the upcoming `0.6.0`.

## Verification

Reproduced the actual `assembleReleasePlan` computation:

- **Before:** `aip-core 0.5.0 → 1.0.0` (major), 36 packages going major.
- **After:** `aip-core 0.5.0 → 0.6.0` (minor), **zero** major bumps.

No lockfile change was needed (the workspace package still satisfies the range).