### PR TITLE
Add null parameter type for struct action params

### DIFF
--- a/.changeset/light-olives-attend.md
+++ b/.changeset/light-olives-attend.md
@@ -1,0 +1,8 @@
+---
+"@osdk/shared.test": patch
+"@osdk/client": patch
+"@osdk/faux": patch
+"@osdk/api": patch
+---
+
+Add ability to pass null for struct action parameters.

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -155,7 +155,7 @@ export namespace ActionParam {
             	} ? R extends true ? K : never : never]? : T[K] extends {
             		type: infer U
             		nullable: infer R
-            	} ? U extends keyof DataValueClientToWire ? R extends true ? DataValueClientToWire[U] | undefined : never : never : never };
+            	} ? U extends keyof DataValueClientToWire ? R extends true ? DataValueClientToWire[U] | null : never : never : never };
 }
 
 // @public (undocumented)

--- a/packages/api/src/actions/Actions.ts
+++ b/packages/api/src/actions/Actions.ts
@@ -105,7 +105,7 @@ export namespace ActionParam {
       : never]?: T[K] extends { type: infer U; nullable: infer R }
       ? U extends keyof DataValueClientToWire
         ? R extends true
-          ? DataValueClientToWire[U] | undefined
+          ? DataValueClientToWire[U] | null
           : never
         : never
       : never;

--- a/packages/client/src/actions/actions.test.ts
+++ b/packages/client/src/actions/actions.test.ts
@@ -211,7 +211,7 @@ describe.each([
     type InferredParamType = Parameters<typeof clientBoundActionTakesStruct>[0];
     expectTypeOf<{
       name: string;
-      address: { city: string; state: string; zipcode?: number | undefined };
+      address: { city: string; state: string; zipcode?: number | null };
     }>().toMatchTypeOf<InferredParamType>();
 
     const result = void (await client(createStructPerson).applyAction({
@@ -220,6 +220,19 @@ describe.each([
     }));
     expectTypeOf<typeof result>().toEqualTypeOf<undefined>();
     expect(result).toBeUndefined();
+
+    // Nullable struct fields accept null (to clear the value), undefined, or omission.
+    const nullFieldResult = await client(createStructPerson).applyAction({
+      name: "testMan",
+      address: { city: "NYC", state: "NY", zipcode: null },
+    });
+    expect(nullFieldResult).toBeUndefined();
+
+    const omittedFieldResult = await client(createStructPerson).applyAction({
+      name: "testMan",
+      address: { city: "NYC", state: "NY" },
+    });
+    expect(omittedFieldResult).toBeUndefined();
   });
 
   it("Accepts attachments", async () => {

--- a/packages/faux/src/FauxFoundry/validateAction.ts
+++ b/packages/faux/src/FauxFoundry/validateAction.ts
@@ -251,10 +251,19 @@ function validateActionParameterType(
 
       for (const { name, fieldType, required } of dataType.fields) {
         const fieldValue = (value as Record<string, unknown>)[name];
-        if (
-          (required && fieldValue == null) ||
-          !matchesOntologyDataType(fieldType, fieldValue)
-        ) {
+        // A non-required field may be omitted or explicitly null; only run the
+        // type check when a value is actually present.
+        if (fieldValue == null) {
+          if (required) {
+            ret.result = "INVALID";
+            ret.parameters[paramKey] = {
+              ...baseParam,
+            };
+            return;
+          }
+          continue;
+        }
+        if (!matchesOntologyDataType(fieldType, fieldValue)) {
           ret.result = "INVALID";
           ret.parameters[paramKey] = {
             ...baseParam,

--- a/packages/shared.test/src/stubs/actions.ts
+++ b/packages/shared.test/src/stubs/actions.ts
@@ -294,7 +294,7 @@ export function registerLazyActions(fauxOntology: FauxOntology): void {
       [actionRequestWithStruct, actionResponse],
       [actionRequestWithStructAcceptNull, actionResponse],
       [actionRequestWithStructAcceptUndefined, actionResponse],
-    ]),
+    ])
   );
 
   fauxOntology.registerActionType(

--- a/packages/shared.test/src/stubs/actions.ts
+++ b/packages/shared.test/src/stubs/actions.ts
@@ -129,6 +129,22 @@ export const actionRequestWithStruct: ApplyActionRequestV2 = {
   },
 };
 
+export const actionRequestWithStructAcceptNull: ApplyActionRequestV2 = {
+  options: { mode: "VALIDATE_AND_EXECUTE", returnEdits: "NONE" },
+  parameters: {
+    name: "testMan",
+    address: { city: "NYC", state: "NY", zipcode: null },
+  },
+};
+
+export const actionRequestWithStructAcceptUndefined: ApplyActionRequestV2 = {
+  options: { mode: "VALIDATE_AND_EXECUTE", returnEdits: "NONE" },
+  parameters: {
+    name: "testMan",
+    address: { city: "NYC", state: "NY" },
+  },
+};
+
 export const actionRequestWithGeoshape: ApplyActionRequestV2 = {
   options: { mode: "VALIDATE_AND_EXECUTE", returnEdits: "NONE" },
   parameters: {
@@ -274,7 +290,11 @@ export function registerLazyActions(fauxOntology: FauxOntology): void {
 
   fauxOntology.registerActionType(
     ActionTakesStruct,
-    createLazyDoNothingActionImpl([[actionRequestWithStruct, actionResponse]])
+    createLazyDoNothingActionImpl([
+      [actionRequestWithStruct, actionResponse],
+      [actionRequestWithStructAcceptNull, actionResponse],
+      [actionRequestWithStructAcceptUndefined, actionResponse],
+    ]),
   );
 
   fauxOntology.registerActionType(


### PR DESCRIPTION
Previously, you could not pass in null for struct action params. This disallows people from clearing values in struct fields, we have now enabled that in the types.