### PR TITLE
remove action metadata calls when applying

### DIFF
--- a/.changeset/cold-jars-repair.md
+++ b/.changeset/cold-jars-repair.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Remove unnecessary network calls when applying actions.

--- a/packages/client/src/actions/applyAction.ts
+++ b/packages/client/src/actions/applyAction.ts
@@ -147,9 +147,6 @@ export async function applyAction<
           ? await remapBatchActionParams(
             parameters,
             client,
-            await client.ontologyProvider.getActionDefinition(
-              action.unsanitizedApiName ?? action.apiName,
-            ),
           )
           : [],
         options: {
@@ -174,9 +171,6 @@ export async function applyAction<
             CompileTimeActionMetadata<AD>["parameters"]
           >,
           client,
-          await client.ontologyProvider.getActionDefinition(
-            action.unsanitizedApiName ?? action.apiName,
-          ),
         ),
         options: {
           mode: (options as ApplyActionOptions)?.$validateOnly
@@ -216,7 +210,6 @@ async function remapActionParams<AD extends ActionDefinition<any>>(
     | OsdkActionParameters<CompileTimeActionMetadata<AD>["parameters"]>
     | undefined,
   client: MinimalClient,
-  actionMetadata: ActionMetadata,
 ): Promise<Record<string, DataValue>> {
   if (params == null) {
     return {};
@@ -224,7 +217,7 @@ async function remapActionParams<AD extends ActionDefinition<any>>(
 
   const parameterMap: { [parameterName: string]: unknown } = {};
   for (const [key, value] of Object.entries(params)) {
-    parameterMap[key] = await toDataValue(value, client, actionMetadata);
+    parameterMap[key] = await toDataValue(value, client);
   }
 
   return parameterMap;
@@ -235,12 +228,11 @@ async function remapBatchActionParams<
 >(
   params: OsdkActionParameters<CompileTimeActionMetadata<AD>["parameters"]>[],
   client: MinimalClient,
-  actionMetadata: ActionMetadata,
 ) {
   const remappedParams = await Promise.all(params.map(
     async param => {
       return {
-        parameters: await remapActionParams<AD>(param, client, actionMetadata),
+        parameters: await remapActionParams<AD>(param, client),
       };
     },
   ));

--- a/packages/client/src/util/toDataValue.test.ts
+++ b/packages/client/src/util/toDataValue.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ActionMetadata, Media, MediaUpload } from "@osdk/api";
+import type { Media, MediaUpload } from "@osdk/api";
 import { Employee, Task } from "@osdk/client.test.ontology";
 import type { MediaReference } from "@osdk/foundry.core";
 import type { SetupServer } from "@osdk/shared.test";
@@ -39,7 +39,6 @@ import { toDataValue } from "./toDataValue.js";
 describe(toDataValue, () => {
   let client: Client;
   let clientCtx: MinimalClient;
-  let mockActionMetadata: ActionMetadata;
   let apiServer: SetupServer;
 
   const mockFetch: MockedFunction<typeof globalThis.fetch> = vi.fn();
@@ -56,12 +55,6 @@ describe(toDataValue, () => {
       testSetup.auth,
       {},
     );
-
-    // toDataValue only needs the apiName right now, update this if that changes
-    const fakeActionMetadata = {
-      apiName: "createUnstructuredImageExampleObject",
-    };
-    mockActionMetadata = fakeActionMetadata as ActionMetadata;
 
     return () => {
       testSetup.apiServer.close();
@@ -81,7 +74,6 @@ describe(toDataValue, () => {
     const convertedBasic = await toDataValue(
       basic,
       clientCtx,
-      mockActionMetadata,
     );
     expect(convertedBasic).toEqual(basic);
   });
@@ -98,7 +90,6 @@ describe(toDataValue, () => {
         attachmentSet,
       },
       clientCtx,
-      mockActionMetadata,
     );
 
     expect(recursiveConversion).toEqual({
@@ -118,7 +109,6 @@ describe(toDataValue, () => {
     const recursiveConversion = await toDataValue(
       struct,
       clientCtx,
-      mockActionMetadata,
     );
 
     expect(recursiveConversion).toEqual({
@@ -136,10 +126,10 @@ describe(toDataValue, () => {
       coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]],
     };
 
-    expect(await toDataValue(point, clientCtx, mockActionMetadata)).toEqual(
+    expect(await toDataValue(point, clientCtx)).toEqual(
       point,
     );
-    expect(await toDataValue(polygon, clientCtx, mockActionMetadata)).toEqual(
+    expect(await toDataValue(polygon, clientCtx)).toEqual(
       polygon,
     );
   });
@@ -149,7 +139,6 @@ describe(toDataValue, () => {
     const ontologyConversion = await toDataValue(
       employee,
       clientCtx,
-      mockActionMetadata,
     );
     expect(ontologyConversion).toEqual(
       stubData.employee1.__primaryKey,
@@ -161,7 +150,6 @@ describe(toDataValue, () => {
     const ontologyConversion = await toDataValue(
       task,
       clientCtx,
-      mockActionMetadata,
     );
     expect(ontologyConversion).toEqual(
       task.$primaryKey,
@@ -189,7 +177,6 @@ describe(toDataValue, () => {
     const objectSetConversion = await toDataValue(
       clientObjectSet,
       clientCtx,
-      mockActionMetadata,
     );
     expect(objectSetConversion).toMatchInlineSnapshot(
       expected,
@@ -198,7 +185,6 @@ describe(toDataValue, () => {
     const definitionConversion = await toDataValue(
       definition,
       clientCtx,
-      mockActionMetadata,
     );
     expect(definitionConversion).toMatchInlineSnapshot(expected);
   });
@@ -209,7 +195,6 @@ describe(toDataValue, () => {
     const converted = await toDataValue(
       attachmentUpload,
       clientCtx,
-      mockActionMetadata,
     );
 
     expect(converted).toMatch(/ri\.attachments.main.attachment\.[a-z0-9\-]+/i);
@@ -226,7 +211,7 @@ describe(toDataValue, () => {
       { name: "file1.txt" },
     );
 
-    const converted = await toDataValue(file, clientCtx, mockActionMetadata);
+    const converted = await toDataValue(file, clientCtx);
     expect(converted).toMatch(/ri\.attachments.main.attachment\.[a-z0-9\-]+/i);
   });
 
@@ -260,7 +245,7 @@ describe(toDataValue, () => {
           },
         ),
       );
-      const converted = await toDataValue(file, clientCtx, mockActionMetadata);
+      const converted = await toDataValue(file, clientCtx);
       expect(isMediaReference(converted)).toBe(true);
     });
   });
@@ -281,7 +266,6 @@ describe(toDataValue, () => {
     const converted = await toDataValue(
       mediaReference,
       clientCtx,
-      mockActionMetadata,
     );
     expect(converted).toEqual(mediaReference);
   });
@@ -290,7 +274,6 @@ describe(toDataValue, () => {
     const converted = await toDataValue(
       null,
       clientCtx,
-      mockActionMetadata,
     );
     expect(converted).toBeNull();
   });
@@ -320,7 +303,6 @@ describe(toDataValue, () => {
     const converted = await toDataValue(
       mockMedia,
       clientCtx,
-      mockActionMetadata,
     );
 
     expect(converted).toEqual(expectedMediaReference);
@@ -333,7 +315,6 @@ describe(toDataValue, () => {
     const converted = await toDataValue(
       scenario,
       clientCtx,
-      mockActionMetadata,
     );
     expect(converted).toBe("ri.actions..scenario.abc");
   });

--- a/packages/client/src/util/toDataValue.ts
+++ b/packages/client/src/util/toDataValue.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import type { ActionMetadata } from "@osdk/api";
 import { MediaSets } from "@osdk/foundry.mediasets";
 import { type DataValue } from "@osdk/foundry.ontologies";
 import * as Attachments from "@osdk/foundry.ontologies/Attachment";
@@ -44,7 +43,6 @@ import { isWireObjectSet } from "./WireObjectSet.js";
 export async function toDataValue(
   value: unknown,
   client: MinimalClient,
-  actionMetadata: ActionMetadata,
 ): Promise<DataValue> {
   if (value == null) {
     // typeof null is 'object' so do this first
@@ -62,14 +60,13 @@ export async function toDataValue(
     ) {
       const converted = [];
       for (const value of values) {
-        converted.push(await toDataValue(value, client, actionMetadata));
+        converted.push(await toDataValue(value, client));
       }
       return converted;
     }
     const promiseArray = Array.from(
       value,
-      async (innerValue) =>
-        await toDataValue(innerValue, client, actionMetadata),
+      async (innerValue) => await toDataValue(innerValue, client),
     );
     return Promise.all(promiseArray);
   }
@@ -83,7 +80,7 @@ export async function toDataValue(
         filename: value.name,
       },
     );
-    return await toDataValue(attachment.rid, client, actionMetadata);
+    return await toDataValue(attachment.rid, client);
   }
 
   if (isAttachmentFile(value)) {
@@ -94,7 +91,7 @@ export async function toDataValue(
         filename: value.name as string,
       },
     );
-    return await toDataValue(attachment.rid, client, actionMetadata);
+    return await toDataValue(attachment.rid, client);
   }
 
   if (isMediaUpload(value)) {
@@ -106,7 +103,7 @@ export async function toDataValue(
         preview: true,
       },
     );
-    return await toDataValue(mediaRef, client, actionMetadata);
+    return await toDataValue(mediaRef, client);
   }
 
   if (isMedia(value)) {
@@ -119,11 +116,11 @@ export async function toDataValue(
 
   // objects just send the JSON'd primaryKey
   if (isOntologyObjectV2(value)) {
-    return await toDataValue(value.__primaryKey, client, actionMetadata);
+    return await toDataValue(value.__primaryKey, client);
   }
 
   if (isObjectSpecifiersObject(value)) {
-    return await toDataValue(value.$primaryKey, client, actionMetadata);
+    return await toDataValue(value.$primaryKey, client);
   }
 
   // object set (the rid as a string (passes through the last return), or the ObjectSet definition directly)
@@ -154,7 +151,7 @@ export async function toDataValue(
     return Object.entries(value).reduce(
       async (promisedAcc, [key, structValue]) => {
         const acc = await promisedAcc;
-        acc[key] = await toDataValue(structValue, client, actionMetadata);
+        acc[key] = await toDataValue(structValue, client);
         return acc;
       },
       Promise.resolve({} as { [key: string]: DataValue }),


### PR DESCRIPTION
We no longer need to pull the latest action metadata when parsing parameters, so removed it from our code paths