### PR TITLE
fix interface object set projection in observeObjectSet and useObjectSet

### DIFF
--- a/.changeset/interface-object-set-projection.md
+++ b/.changeset/interface-object-set-projection.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client": minor
+"@osdk/react": minor
+---
+
+Fix `observeObjectSet`/`useObjectSet` returning underlying object-type property names (e.g. `documentId`) instead of interface shared-property-type names (e.g. `mediaId`) for interface base object sets. Interface results are now re-projected to the interface view, optimistic updates are matched and projected correctly, and invalidating an implementing object type revalidates the set.

--- a/packages/client/src/observable/internal/Store.test.ts
+++ b/packages/client/src/observable/internal/Store.test.ts
@@ -50,6 +50,7 @@ import { additionalContext, type Client } from "../../Client.js";
 import { createClient } from "../../createClient.js";
 import { TestLogger } from "../../logger/TestLogger.js";
 import type { ObjectHolder } from "../../object/convertWireToOsdkObjects/ObjectHolder.js";
+import { createObjectSet } from "../../objectSet/createObjectSet.js";
 import type { SpecificLinkPayload } from "../LinkPayload.js";
 import type { ObjectSetPayload } from "../ObjectSetPayload.js";
 import type {
@@ -2625,6 +2626,322 @@ describe(Store, () => {
       );
 
       expect(sub.error).not.toHaveBeenCalled();
+    });
+
+    describe("interface base object set", () => {
+      beforeEach(() => {
+        fauxFoundry.getDefaultDataStore().clear();
+      });
+
+      function registerSanta() {
+        return fauxFoundry.getDefaultDataStore().registerObject(Employee, {
+          $apiName: "Employee",
+          employeeId: 50050,
+          fullName: "Santa Claus",
+          office: "NYC",
+        });
+      }
+
+      it("projects to the interface view (fooSpt), not the underlying property (fullName)", async () => {
+        registerSanta();
+
+        const sub = mockObserver<ObjectSetPayload | undefined>();
+        defer(
+          store.objectSets.observe({
+            baseObjectSet: client(FooInterface) as ObjectSet<FooInterface>,
+          }, sub),
+        );
+
+        await vi.waitFor(() => {
+          expect(sub.next).toHaveBeenLastCalledWith(
+            expect.objectContaining({ status: "loaded" }),
+          );
+        }, { timeout: 5000 });
+
+        expect(sub.next).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            status: "loaded",
+            resolvedList: [
+              expect.objectContaining({
+                $apiName: "FooInterface",
+                $objectType: "Employee",
+                fooSpt: "Santa Claus",
+              }),
+            ],
+          }),
+        );
+
+        const obj = sub.next.mock.calls.at(-1)?.[0]?.resolvedList?.[0];
+        expect(obj).not.toHaveProperty("fullName");
+        expect(sub.error).not.toHaveBeenCalled();
+      });
+
+      it("projects the interface view with a where clause", async () => {
+        registerSanta();
+
+        const sub = mockObserver<ObjectSetPayload | undefined>();
+        defer(
+          store.objectSets.observe({
+            baseObjectSet: client(FooInterface).where({
+              fooSpt: "Santa Claus",
+            }),
+          }, sub),
+        );
+
+        await vi.waitFor(() => {
+          expect(sub.next).toHaveBeenLastCalledWith(
+            expect.objectContaining({ status: "loaded" }),
+          );
+        }, { timeout: 5000 });
+
+        expect(sub.next).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            status: "loaded",
+            resolvedList: [
+              expect.objectContaining({
+                $apiName: "FooInterface",
+                fooSpt: "Santa Claus",
+              }),
+            ],
+          }),
+        );
+      });
+
+      it("projects the interface view with orderBy", async () => {
+        registerSanta();
+        fauxFoundry.getDefaultDataStore().registerObject(Employee, {
+          $apiName: "Employee",
+          employeeId: 50051,
+          fullName: "Aaron Aardvark",
+          office: "LA",
+        });
+
+        const sub = mockObserver<ObjectSetPayload | undefined>();
+        defer(
+          store.objectSets.observe({
+            baseObjectSet: client(FooInterface) as ObjectSet<FooInterface>,
+            orderBy: { fooSpt: "asc" },
+          }, sub),
+        );
+
+        await vi.waitFor(() => {
+          expect(sub.next).toHaveBeenLastCalledWith(
+            expect.objectContaining({ status: "loaded" }),
+          );
+        }, { timeout: 5000 });
+
+        const payload = sub.next.mock.calls.at(-1)?.[0];
+        expect(payload?.resolvedList?.[0]).toMatchObject({
+          $apiName: "FooInterface",
+          fooSpt: "Aaron Aardvark",
+        });
+      });
+
+      it("does not project object-type base object sets", async () => {
+        registerSanta();
+
+        const sub = mockObserver<ObjectSetPayload | undefined>();
+        defer(
+          store.objectSets.observe({
+            baseObjectSet: client(Employee) as ObjectSet<Employee>,
+          }, sub),
+        );
+
+        await vi.waitFor(() => {
+          expect(sub.next).toHaveBeenLastCalledWith(
+            expect.objectContaining({ status: "loaded" }),
+          );
+        }, { timeout: 5000 });
+
+        expect(sub.next).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            resolvedList: [
+              expect.objectContaining({
+                $apiName: "Employee",
+                fullName: "Santa Claus",
+              }),
+            ],
+          }),
+        );
+      });
+
+      it("reflects optimistic additions, projected and where-matched", async () => {
+        fauxFoundry.getDefaultDataStore().registerObject(Employee, {
+          $apiName: "Employee",
+          employeeId: 60000,
+          fullName: "Keep Me",
+          office: "NYC",
+        });
+
+        const sub = mockObserver<ObjectSetPayload | undefined>();
+        defer(
+          store.objectSets.observe({
+            baseObjectSet: client(FooInterface) as ObjectSet<FooInterface>,
+            where: { fooSpt: "Keep Me" },
+          }, sub),
+        );
+
+        await vi.waitFor(() => {
+          expect(sub.next).toHaveBeenLastCalledWith(
+            expect.objectContaining({ status: "loaded" }),
+          );
+        }, { timeout: 5000 });
+
+        sub.next.mockClear();
+
+        const rollback = runOptimisticJob(store, (b) => {
+          b.createObject(Employee, 60001, {
+            employeeId: 60001,
+            fullName: "Keep Me",
+            office: "LA",
+          });
+          b.createObject(Employee, 60002, {
+            employeeId: 60002,
+            fullName: "Drop Me",
+            office: "LA",
+          });
+        });
+
+        await vi.waitFor(() => {
+          expect(sub.next).toHaveBeenCalled();
+        }, { timeout: 5000 });
+
+        const payload = sub.next.mock.calls.at(-1)?.[0];
+        expect(payload?.isOptimistic).toBe(true);
+        const ids = payload?.resolvedList?.map((o) => o.$primaryKey) ?? [];
+        expect(ids).toContain(60000);
+        expect(ids).toContain(60001);
+        expect(ids).not.toContain(60002);
+        for (const o of payload?.resolvedList ?? []) {
+          expect(o.$apiName).toBe("FooInterface");
+        }
+
+        await rollback();
+      });
+
+      it("revalidates when an implementing concrete type is invalidated", async () => {
+        registerSanta();
+
+        const sub = mockObserver<ObjectSetPayload | undefined>();
+        defer(
+          store.objectSets.observe({
+            baseObjectSet: client(FooInterface) as ObjectSet<FooInterface>,
+          }, sub),
+        );
+
+        await vi.waitFor(() => {
+          expect(sub.next).toHaveBeenLastCalledWith(
+            expect.objectContaining({ status: "loaded" }),
+          );
+        }, { timeout: 5000 });
+
+        fauxFoundry.getDefaultDataStore().registerObject(Employee, {
+          $apiName: "Employee",
+          employeeId: 50052,
+          fullName: "New Saint",
+          office: "SF",
+        });
+
+        sub.next.mockClear();
+        await store.invalidateObjectType(Employee, undefined);
+
+        await vi.waitFor(() => {
+          expect(sub.next).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              status: "loaded",
+              resolvedList: expect.arrayContaining([
+                expect.objectContaining({ fooSpt: "Santa Claus" }),
+                expect.objectContaining({ fooSpt: "New Saint" }),
+              ]),
+            }),
+          );
+        }, { timeout: 5000 });
+      });
+
+      it("loads a static base object set without erroring (no projection)", async () => {
+        // A pure static (or reference) base set has no statically determinable
+        // result type, so projection resolution throws; it must be caught and
+        // the set served without projection rather than driven into an error state.
+        const rid = "ri.phonograph2-objects.main.object.static-employee-50060";
+        fauxFoundry.getDefaultDataStore().registerObject(Employee, {
+          $apiName: "Employee",
+          $rid: rid,
+          employeeId: 50060,
+          fullName: "Static Employee",
+          office: "NYC",
+        });
+
+        const staticSet = createObjectSet(
+          Employee,
+          client[additionalContext],
+          { type: "static", objects: [rid] },
+        );
+
+        const sub = mockObserver<ObjectSetPayload | undefined>();
+        defer(store.objectSets.observe({ baseObjectSet: staticSet }, sub));
+
+        await vi.waitFor(() => {
+          expect(sub.next).toHaveBeenLastCalledWith(
+            expect.objectContaining({ status: "loaded" }),
+          );
+        }, { timeout: 5000 });
+
+        expect(sub.error).not.toHaveBeenCalled();
+        expect(sub.next).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            resolvedList: [
+              expect.objectContaining({
+                $apiName: "Employee",
+                fullName: "Static Employee",
+              }),
+            ],
+          }),
+        );
+      });
+
+      it("projects optimistic additions on a filtered interface base set", async () => {
+        fauxFoundry.getDefaultDataStore().registerObject(Employee, {
+          $apiName: "Employee",
+          employeeId: 60100,
+          fullName: "Prefiltered",
+          office: "NYC",
+        });
+
+        const sub = mockObserver<ObjectSetPayload | undefined>();
+        defer(
+          store.objectSets.observe({
+            baseObjectSet: client(FooInterface).where({
+              fooSpt: "Prefiltered",
+            }),
+          }, sub),
+        );
+
+        // Apply the optimistic add before the first fetch resolves. The
+        // projection target for a filtered interface base must be resolved
+        // synchronously in the constructor for the add to be projected rather
+        // than dropped against the (empty) concrete result type name.
+        const rollback = runOptimisticJob(store, (b) => {
+          b.createObject(Employee, 60101, {
+            employeeId: 60101,
+            fullName: "Prefiltered",
+            office: "LA",
+          });
+        });
+
+        await vi.waitFor(() => {
+          const ids = sub.next.mock.calls.at(-1)?.[0]?.resolvedList?.map((o) =>
+            o.$primaryKey
+          ) ?? [];
+          expect(ids).toContain(60101);
+        }, { timeout: 5000 });
+
+        const payload = sub.next.mock.calls.at(-1)?.[0];
+        for (const o of payload?.resolvedList ?? []) {
+          expect(o.$apiName).toBe("FooInterface");
+        }
+
+        await rollback();
+      });
     });
 
     describe("ObjectSetQuery maybeUpdateAndRevalidate", () => {

--- a/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-import type { ObjectSet, Osdk, PageResult } from "@osdk/api";
+import type { InterfaceMetadata, ObjectSet, Osdk, PageResult } from "@osdk/api";
 import type { ObjectSet as WireObjectSet } from "@osdk/foundry.ontologies";
 import type { Observable, Subscription } from "rxjs";
 import { additionalContext } from "../../../Client.js";
 import type { InterfaceHolder } from "../../../object/convertWireToOsdkObjects/InterfaceHolder.js";
+import { ObjectDefRef } from "../../../object/convertWireToOsdkObjects/InternalSymbols.js";
 import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
 import { getWireObjectSet } from "../../../objectSet/createObjectSet.js";
+import type { FetchedObjectTypeDefinition } from "../../../ontology/OntologyProvider.js";
 import { extractRdpDefinition } from "../../../util/extractRdpDefinition.js";
 import type { ObjectSetPayload } from "../../ObjectSetPayload.js";
 import type { Status } from "../../ObservableClient/common.js";
@@ -59,6 +61,12 @@ export class ObjectSetQuery extends BaseListQuery<
   #objectTypes: Set<string>;
   #requiresServerEvaluation: boolean;
   #resultTypeApiName: string;
+
+  // Interface api name to re-project resolved objects to via `$as`, or undefined
+  // for a concrete object-type result. interfaceBase leaves resolve this
+  // synchronously in the constructor; composed/pivoted sets resolve on first fetch.
+  #projectToInterfaceApiName: string | undefined;
+  #projectionResolved = false;
 
   // Object types this query's RDPs traverse; an edit to any of these triggers
   // revalidation. Lazily populated on first fetch when `withProperties` is set.
@@ -104,6 +112,19 @@ export class ObjectSetQuery extends BaseListQuery<
 
     this.#resultTypeApiName =
       ObjectSetQuery.#extractTypeFromWireObjectSet(baseWire) ?? "";
+
+    // Resolve an interfaceBase leaf synchronously so optimistic updates project
+    // before the first fetch. A concrete base needs no projection; anything else
+    // resolves during the first fetch.
+    if (!operations.pivotTo) {
+      const leafInterface = ObjectSetQuery.#findInterfaceLeaf(baseWire);
+      if (leafInterface != null) {
+        this.#projectToInterfaceApiName = leafInterface;
+        this.#projectionResolved = true;
+      } else if (baseWire.type === "base") {
+        this.#projectionResolved = true;
+      }
+    }
 
     if (opts.autoFetchMore === true) {
       this.minResultsToLoad = Number.MAX_SAFE_INTEGER;
@@ -201,11 +222,36 @@ export class ObjectSetQuery extends BaseListQuery<
     return undefined;
   }
 
+  // Walks filter/nearestNeighbors wrappers (which preserve the result type) to an
+  // interfaceBase leaf and returns its interface api name, else undefined.
+  static #findInterfaceLeaf(wire: WireObjectSet): string | undefined {
+    switch (wire.type) {
+      case "interfaceBase":
+        return wire.interfaceType;
+      case "filter":
+      case "nearestNeighbors":
+        return ObjectSetQuery.#findInterfaceLeaf(wire.objectSet);
+      default:
+        return undefined;
+    }
+  }
+
   /**
    * Register changes to the cache specific to ObjectSetQuery
    */
   protected registerCacheChanges(batch: BatchContext): void {
     batch.changes.registerObjectSet(this.cacheKey);
+  }
+
+  // Records the interface to project to once the result type is known; a
+  // non-interface or unresolved result type means no projection.
+  #resolveProjection(
+    resultType: FetchedObjectTypeDefinition | InterfaceMetadata | undefined,
+  ): void {
+    this.#projectToInterfaceApiName = resultType?.type === "interface"
+      ? resultType.apiName
+      : undefined;
+    this.#projectionResolved = true;
   }
 
   /**
@@ -235,6 +281,10 @@ export class ObjectSetQuery extends BaseListQuery<
         ),
       );
       this.#rdpInvalidationSet = invalidationSet;
+
+      if (!this.#projectionResolved) {
+        this.#resolveProjection(resultType);
+      }
     }
 
     if (
@@ -245,6 +295,25 @@ export class ObjectSetQuery extends BaseListQuery<
       this.#rdpInvalidationSet = await this.#computeInvalidationTypes(
         wireObjectSet,
       );
+    }
+
+    // Resolve projection for composed/pivoted sets not resolved above, before the
+    // first store write. getObjectTypesThatInvalidate throws when the result type
+    // is not statically determinable (static/reference) -> no projection.
+    if (!this.#projectionResolved) {
+      try {
+        const { resultType } = await getObjectTypesThatInvalidate(
+          this.store.client[additionalContext],
+          getWireObjectSet(this.#composedObjectSet),
+        );
+        this.#resolveProjection(resultType);
+      } catch (error) {
+        this.store.logger?.error(
+          "Failed to resolve interface projection for object set query, applying no projection",
+          error,
+        );
+        this.#resolveProjection(undefined);
+      }
     }
 
     // Fetch the data with pagination
@@ -356,18 +425,37 @@ export class ObjectSetQuery extends BaseListQuery<
     | { addedObjects: ObjectHolder[]; modifiedObjects: ObjectHolder[] }
     | undefined
   {
-    const resultApiName = this.#resultTypeApiName;
-    const addedObjects = changes.addedObjects.get(resultApiName) ?? [];
-    const modifiedObjects = changes.modifiedObjects.get(resultApiName) ?? [];
+    const interfaceApiName = this.#projectToInterfaceApiName;
 
+    let addedObjects: ObjectHolder[];
+    let modifiedObjects: ObjectHolder[];
     let hasRelevantDeletions = false;
-    for (const key of changes.deleted) {
-      if (
-        key.type === "object"
-        && key.otherKeys[OBJECT_API_NAME_IDX] === resultApiName
-      ) {
-        hasRelevantDeletions = true;
-        break;
+
+    if (interfaceApiName != null) {
+      // Objects are cached by concrete type, so collect every changed holder
+      // whose type implements this interface. Any deletion is potentially
+      // relevant; reconcileListChanges handles the precise removal.
+      addedObjects = ObjectSetQuery.#filterImplementing(
+        changes.addedObjects,
+        interfaceApiName,
+      );
+      modifiedObjects = ObjectSetQuery.#filterImplementing(
+        changes.modifiedObjects,
+        interfaceApiName,
+      );
+      hasRelevantDeletions = changes.deleted.size > 0;
+    } else {
+      const resultApiName = this.#resultTypeApiName;
+      addedObjects = changes.addedObjects.get(resultApiName) ?? [];
+      modifiedObjects = changes.modifiedObjects.get(resultApiName) ?? [];
+      for (const key of changes.deleted) {
+        if (
+          key.type === "object"
+          && key.otherKeys[OBJECT_API_NAME_IDX] === resultApiName
+        ) {
+          hasRelevantDeletions = true;
+          break;
+        }
       }
     }
 
@@ -379,6 +467,19 @@ export class ObjectSetQuery extends BaseListQuery<
     }
 
     return { addedObjects, modifiedObjects };
+  }
+
+  static #filterImplementing(
+    objects: Iterable<readonly [string, ObjectHolder]>,
+    interfaceApiName: string,
+  ): ObjectHolder[] {
+    const result: ObjectHolder[] = [];
+    for (const [, holder] of objects) {
+      if (interfaceApiName in holder[ObjectDefRef].interfaceMap) {
+        result.push(holder);
+      }
+    }
+    return result;
   }
 
   #handleLocalUpdate(
@@ -454,12 +555,18 @@ export class ObjectSetQuery extends BaseListQuery<
     definite: ReadonlySet<ObjectHolder | InterfaceHolder>;
     uncertain: ReadonlySet<ObjectHolder | InterfaceHolder>;
   } {
+    const interfaceApiName = this.#projectToInterfaceApiName;
     const definite = new Set<ObjectHolder | InterfaceHolder>();
     const uncertain = new Set<ObjectHolder | InterfaceHolder>();
     for (const obj of objects) {
-      if (objectMatchesWhereClause(obj, whereClause, true)) {
+      // Match against the interface view (the where-clause uses interface
+      // property names) but keep the concrete holder for cache-key derivation.
+      const toMatch = interfaceApiName != null
+        ? obj.$as(interfaceApiName)
+        : obj;
+      if (objectMatchesWhereClause(toMatch, whereClause, true)) {
         definite.add(obj);
-      } else if (objectMatchesWhereClause(obj, whereClause, false)) {
+      } else if (objectMatchesWhereClause(toMatch, whereClause, false)) {
         uncertain.add(obj);
       }
     }
@@ -470,16 +577,24 @@ export class ObjectSetQuery extends BaseListQuery<
     wireObjectSet: WireObjectSet,
   ): Promise<Set<string>> {
     try {
-      const { invalidationSet } = await getObjectTypesThatInvalidate(
-        this.store.client[additionalContext],
-        wireObjectSet,
-      );
+      const { invalidationSet, resultType } =
+        await getObjectTypesThatInvalidate(
+          this.store.client[additionalContext],
+          wireObjectSet,
+        );
+      // Resolve projection from the same call to avoid a second traversal.
+      if (!this.#projectionResolved) {
+        this.#resolveProjection(resultType);
+      }
       return invalidationSet;
     } catch (error) {
       this.store.logger?.error(
         "Failed to compute invalidation types for object set query, falling back to empty set",
         error,
       );
+      if (!this.#projectionResolved) {
+        this.#resolveProjection(undefined);
+      }
       return new Set();
     }
   }
@@ -507,6 +622,27 @@ export class ObjectSetQuery extends BaseListQuery<
       changes?.modified.add(this.cacheKey);
       return this.revalidate(true);
     }
+
+    // An edit to any concrete type implementing this interface must revalidate.
+    // Implementing types aren't known statically, so check the type's metadata.
+    const interfaceApiName = this.#projectToInterfaceApiName;
+    if (interfaceApiName != null && interfaceApiName !== objectType) {
+      let implementsInterface: boolean;
+      try {
+        const metadata = await this.store.client.fetchMetadata({
+          type: "object",
+          apiName: objectType,
+        });
+        implementsInterface = interfaceApiName in metadata.interfaceMap;
+      } catch {
+        // If metadata can't be loaded, revalidate to be safe.
+        implementsInterface = true;
+      }
+      if (implementsInterface) {
+        changes?.modified.add(this.cacheKey);
+        return this.revalidate(true);
+      }
+    }
     return Promise.resolve();
   };
 
@@ -519,8 +655,14 @@ export class ObjectSetQuery extends BaseListQuery<
       totalCount?: string;
     },
   ): ObjectSetPayload {
+    // The store caches the concrete object, so re-project interface results to
+    // the interface view here (mirrors InterfaceListQuery.wrapObject).
+    const interfaceApiName = this.#projectToInterfaceApiName;
+    const resolvedList = interfaceApiName != null
+      ? params.resolvedData?.map((o: ObjectHolder) => o.$as(interfaceApiName))
+      : params.resolvedData;
     return {
-      resolvedList: params.resolvedData,
+      resolvedList,
       isOptimistic: params.isOptimistic,
       fetchMore: this.fetchMore,
       hasMore: this.nextPageToken != null,


### PR DESCRIPTION
interface base object sets observed via observeObjectSet/useObjectSet returned underlying object-type property names (e.g. documentId) instead of interface shared-property names (e.g. mediaId), while core fetchPage was already correct

• re-project interface results to the interface view on read
• match and project optimistic updates and revalidate the set when an implementing concrete type changes
• resolve filtered interface bases synchronously and guard projection resolution so non-determinable sets (static, reference) still load

the resolveToObjectType opt-out for raw object instances is split into #3577
