### PR TITLE
add resolveToObjectType option to object set queries

### DIFF
--- a/.changeset/object-set-resolve-to-object-type.md
+++ b/.changeset/object-set-resolve-to-object-type.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client": minor
+"@osdk/react": minor
+---
+
+Add a `resolveToObjectType` option to `observeObjectSet`/`useObjectSet` (interface bases only) to opt out of interface-view projection and receive raw object-type instances, matching the existing option on `observeList`/`observeLinks`.

--- a/packages/client/src/observable/internal/Store.test.ts
+++ b/packages/client/src/observable/internal/Store.test.ts
@@ -2676,6 +2676,37 @@ describe(Store, () => {
         expect(sub.error).not.toHaveBeenCalled();
       });
 
+      it("returns raw object instances when resolveToObjectType is set", async () => {
+        registerSanta();
+
+        const sub = mockObserver<ObjectSetPayload | undefined>();
+        defer(
+          store.objectSets.observe({
+            baseObjectSet: client(FooInterface) as ObjectSet<FooInterface>,
+            resolveToObjectType: true,
+          }, sub),
+        );
+
+        await vi.waitFor(() => {
+          expect(sub.next).toHaveBeenLastCalledWith(
+            expect.objectContaining({ status: "loaded" }),
+          );
+        }, { timeout: 5000 });
+
+        expect(sub.next).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            status: "loaded",
+            resolvedList: [
+              expect.objectContaining({
+                $apiName: "Employee",
+                $objectType: "Employee",
+                fullName: "Santa Claus",
+              }),
+            ],
+          }),
+        );
+      });
+
       it("projects the interface view with a where clause", async () => {
         registerSanta();
 
@@ -2856,6 +2887,22 @@ describe(Store, () => {
             }),
           );
         }, { timeout: 5000 });
+      });
+
+      it("keeps resolveToObjectType out of the canonicalized operations", () => {
+        // resolveToObjectType is a view-level concern, not a query identity, so
+        // it must not appear in the operations half of the cache key (the wire +
+        // operations). Two queries differing only in the flag therefore carry
+        // identical operations.
+        const baseObjectSet = client(FooInterface) as ObjectSet<FooInterface>;
+        const queryWithoutFlag = store.objectSets.getQuery({ baseObjectSet });
+        const queryWithFlag = store.objectSets.getQuery({
+          baseObjectSet,
+          resolveToObjectType: true,
+        });
+        expect(queryWithFlag.cacheKey.otherKeys).toEqual(
+          queryWithoutFlag.cacheKey.otherKeys,
+        );
       });
 
       it("loads a static base object set without erroring (no projection)", async () => {

--- a/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
@@ -657,10 +657,12 @@ export class ObjectSetQuery extends BaseListQuery<
   ): ObjectSetPayload {
     // The store caches the concrete object, so re-project interface results to
     // the interface view here (mirrors InterfaceListQuery.wrapObject).
+    // resolveToObjectType opts out.
     const interfaceApiName = this.#projectToInterfaceApiName;
-    const resolvedList = interfaceApiName != null
-      ? params.resolvedData?.map((o: ObjectHolder) => o.$as(interfaceApiName))
-      : params.resolvedData;
+    const resolvedList =
+      interfaceApiName != null && !this.options.resolveToObjectType
+        ? params.resolvedData?.map((o: ObjectHolder) => o.$as(interfaceApiName))
+        : params.resolvedData;
     return {
       resolvedList,
       isOptimistic: params.isOptimistic,

--- a/packages/client/src/observable/internal/objectset/ObjectSetQueryOptions.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQueryOptions.ts
@@ -86,6 +86,21 @@ export interface ObserveObjectSetOptions<
    * populated with conjunctive/disjunctive marking requirements per property.
    */
   $loadPropertySecurityMetadata?: boolean;
+
+  /**
+   * When the object set's result type is an interface, return the full concrete
+   * object type instances instead of interface views.
+   *
+   * By default, interface object sets return objects narrowed to the interface's
+   * shared property types. With `resolveToObjectType: true`, returned objects
+   * include all properties of the implementing object type under their underlying
+   * property names.
+   *
+   * Only has an effect when the result type is an interface.
+   *
+   * @default false
+   */
+  resolveToObjectType?: boolean;
 }
 
 export interface ObjectSetQueryOptions

--- a/packages/react/src/new/__tests__/useObjectSet.test.tsx
+++ b/packages/react/src/new/__tests__/useObjectSet.test.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Client } from "@osdk/client";
+import { createClient } from "@osdk/client";
+import { Employee, FooInterface } from "@osdk/client.test.ontology";
+import type { ObservableClient, Observer } from "@osdk/client/observable";
+import { renderHook } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { OsdkContext } from "../OsdkContext.js";
+import { useObjectSet } from "../useObjectSet.js";
+
+const client = createClient(
+  "https://stack.palantir.com/",
+  "ri.ontology.main.ontology.dummy",
+  async () => "token",
+);
+
+function createMockObservableClient(): {
+  client: ObservableClient;
+  observeObjectSet: ReturnType<typeof vi.fn>;
+} {
+  const observeObjectSet = vi.fn(
+    (
+      _baseObjectSet: unknown,
+      _options: unknown,
+      _observer: Observer<unknown>,
+    ) => ({
+      unsubscribe: vi.fn(),
+    }),
+  );
+  const observableClient = {
+    observeObjectSet,
+    canonicalizeOptions: vi.fn((opts: unknown) => opts),
+    invalidateObjectType: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ObservableClient;
+  return { client: observableClient, observeObjectSet };
+}
+
+function createWrapper(observableClient: ObservableClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <OsdkContext.Provider
+        value={{
+          client: {} as Client,
+          observableClient,
+          devtoolsEnabled: false,
+        }}
+      >
+        {children}
+      </OsdkContext.Provider>
+    );
+  };
+}
+
+describe("useObjectSet", () => {
+  let observableClient: ObservableClient;
+  let observeObjectSet: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    ({ client: observableClient, observeObjectSet } =
+      createMockObservableClient());
+  });
+
+  describe("resolveToObjectType", () => {
+    it("threads resolveToObjectType into observeObjectSet when set on an interface base", () => {
+      renderHook(
+        () => useObjectSet(client(FooInterface), { resolveToObjectType: true }),
+        { wrapper: createWrapper(observableClient) },
+      );
+
+      expect(observeObjectSet).toHaveBeenCalledTimes(1);
+      expect(observeObjectSet.mock.calls[0][1]).toMatchObject({
+        resolveToObjectType: true,
+      });
+    });
+
+    it("leaves resolveToObjectType undefined when omitted", () => {
+      renderHook(
+        () => useObjectSet(client(FooInterface)),
+        { wrapper: createWrapper(observableClient) },
+      );
+
+      expect(observeObjectSet).toHaveBeenCalledTimes(1);
+      expect(observeObjectSet.mock.calls[0][1].resolveToObjectType)
+        .toBeUndefined();
+    });
+
+    it("rejects resolveToObjectType on an object-type base at the type level", () => {
+      renderHook(
+        () =>
+          useObjectSet(client(Employee), {
+            // @ts-expect-error resolveToObjectType is only valid for interface bases
+            resolveToObjectType: true,
+          }),
+        { wrapper: createWrapper(observableClient) },
+      );
+
+      // The runtime still forwards it; the guarantee under test is the compile
+      // error above. Object-type results are never projected in the store.
+      expect(observeObjectSet).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/react/src/new/useObjectSet.tsx
+++ b/packages/react/src/new/useObjectSet.tsx
@@ -35,6 +35,7 @@ import {
   type Snapshot,
 } from "./makeExternalStore.js";
 import { OsdkContext } from "./OsdkContext.js";
+import type { ResolveToObjectTypeOption } from "./useOsdkObjects.js";
 
 export interface UseObjectSetOptions<
   Q extends ObjectOrInterfaceDefinition,
@@ -205,10 +206,13 @@ export function useObjectSet<
   RDPs extends Record<string, SimplePropertyDef> = {},
 >(
   baseObjectSet: ObjectSet<Q, BaseRDPs> | undefined,
-  options: UseObjectSetOptions<Q, RDPs> & {
-    pivotTo: LinkNames<Q>;
-    streamUpdates?: never;
-  },
+  options:
+    & UseObjectSetOptions<Q, RDPs>
+    & ResolveToObjectTypeOption<Q>
+    & {
+      pivotTo: LinkNames<Q>;
+      streamUpdates?: never;
+    },
 ): UseObjectSetResult<Q, RDPs>;
 
 // Non-pivotTo overload: pivotTo is forbidden to prevent fallthrough.
@@ -218,7 +222,10 @@ export function useObjectSet<
   RDPs extends Record<string, SimplePropertyDef> = {},
 >(
   baseObjectSet: ObjectSet<Q, BaseRDPs> | undefined,
-  options?: UseObjectSetOptions<Q, RDPs> & { pivotTo?: never },
+  options?:
+    & UseObjectSetOptions<Q, RDPs>
+    & ResolveToObjectTypeOption<Q>
+    & { pivotTo?: never },
 ): UseObjectSetResult<Q, RDPs>;
 
 export function useObjectSet<
@@ -227,12 +234,17 @@ export function useObjectSet<
   RDPs extends Record<string, SimplePropertyDef> = {},
 >(
   baseObjectSet: ObjectSet<Q, BaseRDPs> | undefined,
-  options: UseObjectSetOptions<Q, RDPs> = {},
+  options: UseObjectSetOptions<Q, RDPs> & { resolveToObjectType?: boolean } =
+    {},
 ): UseObjectSetResult<Q, RDPs> {
   const { observableClient } = React.useContext(OsdkContext);
 
-  const { enabled: enabledOption = true, streamUpdates, ...otherOptions } =
-    options;
+  const {
+    enabled: enabledOption = true,
+    streamUpdates,
+    resolveToObjectType,
+    ...otherOptions
+  } = options;
   const enabled = enabledOption && baseObjectSet != null;
 
   // Track object type to detect when we switch to a different object type
@@ -308,6 +320,7 @@ export function useObjectSet<
               dedupeInterval: otherOptions.dedupeIntervalMs ?? 2_000,
               autoFetchMore: otherOptions.autoFetchMore,
               streamUpdates,
+              resolveToObjectType,
               select: canonOptions.$select,
             },
             observer,
@@ -337,6 +350,7 @@ export function useObjectSet<
       otherOptions.autoFetchMore,
       otherOptions.dedupeIntervalMs,
       streamUpdates,
+      resolveToObjectType,
       objectTypeKey,
     ],
   );


### PR DESCRIPTION
extends the existing resolveToObjectType opt-out to observeObjectSet and useObjectSet, the only observe surfaces that were missing it

• interface object sets project to the interface view by default; resolveToObjectType: true returns the raw object-type instances
• type-gated to interface bases only, matching useOsdkObjects and useLinks

stacked on #3575
