### PR TITLE
Hold typechecks to TS 6 strict deprecation defaults

### DIFF
--- a/packages/e2e.generated.1.1.x/tsconfig.cjs.json
+++ b/packages/e2e.generated.1.1.x/tsconfig.cjs.json
@@ -2,6 +2,11 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "CommonJS",
+    // This fixture deliberately verifies that the generated SDK typechecks and
+    // emits declarations for a CommonJS consumer using classic (node10) module
+    // resolution; silence the TypeScript 6 deprecation so the intentional
+    // setting still type-checks.
+    "ignoreDeprecations": "6.0",
     "moduleResolution": "Node",
     "target": "ES6",
     "rootDir": "src",

--- a/packages/monorepo.tool.transpile/bin/transpile2.mjs
+++ b/packages/monorepo.tool.transpile/bin/transpile2.mjs
@@ -237,7 +237,13 @@ async function transpileWithTsup(format, target) {
     },
     clean: false, // we do this ourselves so its granular
     silent: true,
-    dts: format === "cjs",
+    // tsup's dts build always injects the `baseUrl` compiler option (defaulting
+    // it to "."), which TypeScript 6 reports as deprecated. Our tsconfigs no
+    // longer set `ignoreDeprecations`, so we scope it to the dts build here
+    // rather than relaxing the option for `tsc` typechecks.
+    dts: format === "cjs"
+      ? { compilerOptions: { ignoreDeprecations: "6.0" } }
+      : false,
 
     sourcemap: true,
     splitting: true,

--- a/packages/monorepo.tsconfig/base-4.9.json
+++ b/packages/monorepo.tsconfig/base-4.9.json
@@ -15,8 +15,6 @@
     "resolveJsonModule": true,
     "stripInternal": true,
     "jsx": "react-jsx",
-    "ignoreDeprecations": "6.0",
-    "types": ["*"],
-    "noUncheckedSideEffectImports": false
+    "types": ["*"]
   }
 }

--- a/packages/ontology-explorer-app/src/scss.d.ts
+++ b/packages/ontology-explorer-app/src/scss.d.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare module "*.scss" {
+  const content: string;
+  export default content;
+}

--- a/packages/react-components/src/css.d.ts
+++ b/packages/react-components/src/css.d.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare module "*.css" {
+  const content: string;
+  export default content;
+}

--- a/packages/widget.vite-plugin/src/css.d.ts
+++ b/packages/widget.vite-plugin/src/css.d.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare module "*.css" {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
## What

Builds on the TypeScript 6.0 upgrade (#3490) by removing the blanket deprecation suppression from the shared base tsconfig, so `tsc` typechecks are held to TypeScript 6's stricter defaults.

Removed from `packages/monorepo.tsconfig/base-4.9.json`:
- `ignoreDeprecations: "6.0"` — the repo-wide suppression
- `noUncheckedSideEffectImports: false` — removing this restores the TS 6 default (`true`)

## Fallout fixed

- **`noUncheckedSideEffectImports` (now on)** surfaced `TS2882` on CSS/SCSS side-effect imports. Added ambient module declarations (matching the existing `react-devtools/src/css.d.ts` pattern) in `react-components`, `widget.vite-plugin`, and `ontology-explorer-app`.
- **tsup's dts build** always injects the deprecated `baseUrl` option, which only errors during `transpileCjs` (not plain `tsc`). Scoped `ignoreDeprecations` to tsup's dts build via the transpile tool (`dts.compilerOptions`) so `tsc` typechecks stay strict.
- **`e2e.generated.1.1.x`** typechecks node10/CommonJS resolution directly with `tsc` (a deliberate legacy-resolution fixture), so it gets its own narrowly-scoped, commented `ignoreDeprecations`. The pre-existing `tests/verify-cjs-node10` / `verify-fallback-package-v2` fixtures keep theirs for the same reason.

## Size

6 files, +73/-4 (most of the additions are the standard license header in the three small `*.d.ts` files).

## Verification (local)

- `turbo run build` (typecheck + transpile), `lint //#check-mrl`, `check-api`, `ci:cspell`, `changeset status`, and `turbo run test` (186 tasks) all pass.
- No new changeset added: the changed published packages (`react-components`, `widget.vite-plugin`) are already covered by existing changesets on the TS 6 branch.

> Targets `ts-latest-upgrade` rather than `main` so the diff is just this change.