### PR TITLE
add devtools plugin contract and registry

### DIFF
--- a/.changeset/devtools-plugin-registry.md
+++ b/.changeset/devtools-plugin-registry.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+Add the devtools plugin contract (DevToolsPlugin/DevToolsPanelProps), a subscribable global plugin registry, the useDevToolsTabs hook, and the ./advanced entrypoint so base tabs and advanced plugins share one shape.

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -15,6 +15,13 @@
       },
       "default": "./build/esm/index.js"
     },
+    "./advanced": {
+      "import": {
+        "types": "./build/types/public/advanced.d.ts",
+        "default": "./build/esm/public/advanced.js"
+      },
+      "default": "./build/esm/public/advanced.js"
+    },
     "./vite": {
       "import": {
         "types": "./build/types/public/vite.d.ts",

--- a/packages/react-devtools/src/plugins/baseTabs.ts
+++ b/packages/react-devtools/src/plugins/baseTabs.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DevToolsPlugin } from "./types.js";
+
+// Populated with the base tab objects (Overview, Components, Performance, Console) when they are added.
+export const BASE_TABS: DevToolsPlugin[] = [];

--- a/packages/react-devtools/src/plugins/index.ts
+++ b/packages/react-devtools/src/plugins/index.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { BASE_TABS } from "./baseTabs.js";
+export {
+  getRegisteredPlugins,
+  registerDevToolsPlugin,
+  subscribePlugins,
+} from "./registry.js";
+export type {
+  DevToolsPanelComponent,
+  DevToolsPanelProps,
+  DevToolsPlugin,
+} from "./types.js";
+export { useDevToolsTabs } from "./useDevToolsTabs.js";

--- a/packages/react-devtools/src/plugins/registry.test.ts
+++ b/packages/react-devtools/src/plugins/registry.test.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getRegisteredPlugins,
+  registerDevToolsPlugin,
+  subscribePlugins,
+} from "./registry.js";
+import type { DevToolsPlugin } from "./types.js";
+
+const GLOBAL_STORE_KEY = "__OSDK_DEVTOOLS_MONITOR_STORE__";
+
+function makePlugin(
+  id: string,
+  overrides?: Partial<DevToolsPlugin>
+): DevToolsPlugin {
+  return {
+    id,
+    label: id,
+    icon: "cube",
+    panel: () => null,
+    ...overrides,
+  };
+}
+
+function setGlobalStoreStub(): void {
+  (globalThis as Record<string, unknown>)[GLOBAL_STORE_KEY] = {
+    getMetricsStore() {},
+    getComputeStore() {},
+  };
+}
+
+const cleanups: Array<() => void> = [];
+
+function track(unregister: () => void): () => void {
+  cleanups.push(unregister);
+  return unregister;
+}
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups.length = 0;
+  Reflect.deleteProperty(globalThis, GLOBAL_STORE_KEY);
+});
+
+describe("registry", () => {
+  it("register makes a plugin appear in getRegisteredPlugins", () => {
+    const plugin = makePlugin("appears");
+    track(registerDevToolsPlugin(plugin));
+    expect(getRegisteredPlugins()).toContain(plugin);
+  });
+
+  it("ignores a duplicate id and returns a no-op unregister", () => {
+    const first = makePlugin("dup", { label: "first" });
+    const second = makePlugin("dup", { label: "second" });
+    track(registerDevToolsPlugin(first));
+    const unregisterDuplicate = registerDevToolsPlugin(second);
+
+    const plugins = getRegisteredPlugins();
+    expect(plugins.filter((plugin) => plugin.id === "dup")).toHaveLength(1);
+    expect(plugins).toContain(first);
+    expect(plugins).not.toContain(second);
+
+    unregisterDuplicate();
+    expect(getRegisteredPlugins()).toContain(first);
+  });
+
+  it("unregister removes the plugin", () => {
+    const plugin = makePlugin("removable");
+    const unregister = registerDevToolsPlugin(plugin);
+    expect(getRegisteredPlugins()).toContain(plugin);
+
+    unregister();
+    expect(getRegisteredPlugins()).not.toContain(plugin);
+  });
+
+  it("notifies subscribers on register and on unregister", () => {
+    const callback = vi.fn();
+    const unsubscribe = subscribePlugins(callback);
+
+    const unregister = registerDevToolsPlugin(makePlugin("notify"));
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    unregister();
+    expect(callback).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+  });
+
+  it("calls init exactly once on register when the global store is present", () => {
+    setGlobalStoreStub();
+    const init = vi.fn();
+    track(registerDevToolsPlugin(makePlugin("with-store", { init })));
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call init and does not throw when the global store is absent", () => {
+    const init = vi.fn();
+    expect(() => {
+      track(registerDevToolsPlugin(makePlugin("no-store", { init })));
+    }).not.toThrow();
+    expect(init).not.toHaveBeenCalled();
+  });
+
+  it("returns a stable snapshot reference that only changes on mutation", () => {
+    const initial = getRegisteredPlugins();
+    expect(getRegisteredPlugins()).toBe(initial);
+
+    const unregister = registerDevToolsPlugin(makePlugin("snapshot"));
+    const afterRegister = getRegisteredPlugins();
+    expect(afterRegister).not.toBe(initial);
+    expect(getRegisteredPlugins()).toBe(afterRegister);
+
+    unregister();
+    const afterUnregister = getRegisteredPlugins();
+    expect(afterUnregister).not.toBe(afterRegister);
+  });
+});

--- a/packages/react-devtools/src/plugins/registry.ts
+++ b/packages/react-devtools/src/plugins/registry.ts
@@ -39,10 +39,6 @@ const listeners = new Set<() => void>();
 
 let snapshot: readonly DevToolsPlugin[] = [];
 
-function rebuildSnapshot(): void {
-  snapshot = [...registered];
-}
-
 function notifyListeners(): void {
   for (const listener of listeners) {
     try {
@@ -59,7 +55,7 @@ export function registerDevToolsPlugin(plugin: DevToolsPlugin): () => void {
   }
 
   registered.push(plugin);
-  rebuildSnapshot();
+  snapshot = [...registered];
 
   const store = getGlobalMonitorStore();
   if (store) {
@@ -74,7 +70,7 @@ export function registerDevToolsPlugin(plugin: DevToolsPlugin): () => void {
       return;
     }
     registered.splice(index, 1);
-    rebuildSnapshot();
+    snapshot = [...registered];
 
     const disposeStore = getGlobalMonitorStore();
     if (disposeStore) {

--- a/packages/react-devtools/src/plugins/registry.ts
+++ b/packages/react-devtools/src/plugins/registry.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { MonitorStore } from "../store/MonitorStore.js";
+import type { DevToolsPlugin } from "./types.js";
+
+const GLOBAL_STORE_KEY = "__OSDK_DEVTOOLS_MONITOR_STORE__";
+
+function getGlobalMonitorStore(): MonitorStore | undefined {
+  if (typeof globalThis !== "undefined" && GLOBAL_STORE_KEY in globalThis) {
+    const candidate = (globalThis as Record<string, unknown>)[GLOBAL_STORE_KEY];
+    if (
+      typeof candidate === "object" &&
+      candidate != null &&
+      "getMetricsStore" in candidate &&
+      "getComputeStore" in candidate
+    ) {
+      return candidate as MonitorStore;
+    }
+  }
+  return undefined;
+}
+
+const registered: DevToolsPlugin[] = [];
+const listeners = new Set<() => void>();
+
+let snapshot: readonly DevToolsPlugin[] = [];
+
+function rebuildSnapshot(): void {
+  snapshot = [...registered];
+}
+
+function notifyListeners(): void {
+  for (const listener of listeners) {
+    try {
+      listener();
+    } catch {
+      // don't let a bad listener break the others
+    }
+  }
+}
+
+export function registerDevToolsPlugin(plugin: DevToolsPlugin): () => void {
+  if (registered.some((existing) => existing.id === plugin.id)) {
+    return () => {};
+  }
+
+  registered.push(plugin);
+  rebuildSnapshot();
+
+  const store = getGlobalMonitorStore();
+  if (store) {
+    plugin.init?.(store);
+  }
+
+  notifyListeners();
+
+  return () => {
+    const index = registered.indexOf(plugin);
+    if (index === -1) {
+      return;
+    }
+    registered.splice(index, 1);
+    rebuildSnapshot();
+
+    const disposeStore = getGlobalMonitorStore();
+    if (disposeStore) {
+      plugin.dispose?.(disposeStore);
+    }
+
+    notifyListeners();
+  };
+}
+
+export function getRegisteredPlugins(): readonly DevToolsPlugin[] {
+  return snapshot;
+}
+
+export function subscribePlugins(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}

--- a/packages/react-devtools/src/plugins/types.ts
+++ b/packages/react-devtools/src/plugins/types.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ComponentType } from "react";
+
+import type { MonitorStore } from "../store/MonitorStore.js";
+
+export interface DevToolsPanelProps {
+  monitorStore: MonitorStore;
+  theme: "light" | "dark";
+}
+export type DevToolsPanelComponent = ComponentType<DevToolsPanelProps>;
+
+export interface DevToolsPlugin {
+  id: string; // stable; persistence + active-tab key, e.g. "cache"
+  label: string; // tab-bar label
+  icon: string; // Blueprint icon name
+  panel: DevToolsPanelComponent; // mounted only while its tab is active
+  init?: (monitorStore: MonitorStore) => void; // idempotent wiring; no-op in v1
+  dispose?: (monitorStore: MonitorStore) => void;
+  activateOnView?: boolean; // default true
+}

--- a/packages/react-devtools/src/plugins/useDevToolsTabs.ts
+++ b/packages/react-devtools/src/plugins/useDevToolsTabs.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo, useSyncExternalStore } from "react";
+
+import { BASE_TABS } from "./baseTabs.js";
+import { getRegisteredPlugins, subscribePlugins } from "./registry.js";
+import type { DevToolsPlugin } from "./types.js";
+
+export function useDevToolsTabs(): readonly DevToolsPlugin[] {
+  const plugins = useSyncExternalStore(subscribePlugins, getRegisteredPlugins);
+
+  return useMemo(() => {
+    const seen = new Set<string>();
+    const deduped: DevToolsPlugin[] = [];
+    for (const plugin of [...BASE_TABS, ...plugins]) {
+      if (seen.has(plugin.id)) {
+        continue;
+      }
+      seen.add(plugin.id);
+      deduped.push(plugin);
+    }
+    return deduped;
+  }, [plugins]);
+}

--- a/packages/react-devtools/src/public/advanced.ts
+++ b/packages/react-devtools/src/public/advanced.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Entry point for the advanced plugin tabs (cache, compute, intercept). Populated when those tabs are added.
+// eslint-disable-next-line unicorn/require-module-specifiers -- placeholder empty module until advanced plugins land
+export {};


### PR DESCRIPTION
define a shared plugin contract and subscribable registry so base tabs and advanced plugins use one shape

• define the DevToolsPlugin interface (id, label, icon, panel component, optional init/dispose) and DevToolsPanelProps
• implement a subscribable registry with idempotent registerDevToolsPlugin plus a useDevToolsTabs hook
• wire the ./advanced subpath for advanced plugin exports