### PR TITLE
add human-readable query param formatter

### DIFF
--- a/.changeset/devtools-query-params-format.md
+++ b/.changeset/devtools-query-params-format.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+add human-readable query param formatter for devtools component/performance tabs

--- a/packages/react-devtools/src/components/queryParamsFormat.test.ts
+++ b/packages/react-devtools/src/components/queryParamsFormat.test.ts
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type {
+  ComponentHookBinding,
+  QueryParams,
+} from "../utils/ComponentQueryRegistry.js";
+import { formatHookSignature, formatQueryParams } from "./queryParamsFormat.js";
+
+function makeBinding(queryParams: QueryParams): ComponentHookBinding {
+  return {
+    componentId: "c1",
+    componentName: "Demo",
+    hookType: "useOsdkObjects",
+    hookIndex: 0,
+    subscriptionId: "s1",
+    querySignature: "sig",
+    queryParams,
+    stackTrace: "",
+    mountedAt: 0,
+    renderCount: 1,
+    lastRenderDuration: 0,
+    avgRenderDuration: 0,
+  };
+}
+
+describe("formatQueryParams", () => {
+  describe("object", () => {
+    it("renders the primary key", () => {
+      expect(
+        formatQueryParams({
+          type: "object",
+          objectType: "Parcel",
+          primaryKey: "123",
+        })
+      ).toBe("pk 123");
+    });
+
+    it("returns empty string when the primary key is empty", () => {
+      expect(
+        formatQueryParams({
+          type: "object",
+          objectType: "Parcel",
+          primaryKey: "",
+        })
+      ).toBe("");
+    });
+  });
+
+  describe("list", () => {
+    it("renders where, orderBy, and pageSize", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { status: "active" },
+          orderBy: { createdAt: "desc" },
+          pageSize: 50,
+        })
+      ).toBe('where status = "active" · orderBy createdAt desc · pageSize 50');
+    });
+
+    it("renders operator where clauses", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { age: { $gte: 21 } },
+        })
+      ).toBe("where age >= 21");
+    });
+
+    it("renders $and clauses", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { $and: [{ status: "active" }, { region: "west" }] },
+        })
+      ).toBe('where status = "active" and region = "west"');
+    });
+
+    it("renders $or clauses", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { $or: [{ status: "active" }, { status: "pending" }] },
+        })
+      ).toBe('where status = "active" or status = "pending"');
+    });
+
+    it("renders $not clauses", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { $not: { status: "active" } },
+        })
+      ).toBe('where not (status = "active")');
+    });
+
+    it("renders $isNull true and false", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { closedAt: { $isNull: true } },
+        })
+      ).toBe("where closedAt is null");
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { closedAt: { $isNull: false } },
+        })
+      ).toBe("where closedAt is not null");
+    });
+
+    it("renders $in clauses", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { status: { $in: ["active", "pending"] } },
+        })
+      ).toBe('where status in ["active","pending"]');
+    });
+
+    it("returns empty string for an empty where clause and no other detail", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: {},
+        })
+      ).toBe("");
+    });
+
+    it("returns empty string when where and orderBy are undefined", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+        })
+      ).toBe("");
+    });
+  });
+
+  describe("aggregation", () => {
+    it("renders where and aggregate", () => {
+      expect(
+        formatQueryParams({
+          type: "aggregation",
+          objectType: "Employee",
+          where: { dept: "eng" },
+          aggregate: { "salary:avg": "unordered" },
+        })
+      ).toBe('where dept = "eng" · aggregate salary:avg');
+    });
+
+    it("returns empty string when nothing is set", () => {
+      expect(
+        formatQueryParams({
+          type: "aggregation",
+          objectType: "Employee",
+        })
+      ).toBe("");
+    });
+  });
+
+  describe("objectSet", () => {
+    it("renders operation labels", () => {
+      expect(
+        formatQueryParams({
+          type: "objectSet",
+          baseObjectSet: "Employees",
+          operations: [{ type: "filter" }, { type: "pivotTo" }],
+        })
+      ).toBe("filter, pivotTo");
+    });
+
+    it("returns empty string when there are no operations", () => {
+      expect(
+        formatQueryParams({
+          type: "objectSet",
+          baseObjectSet: "Employees",
+          operations: [],
+        })
+      ).toBe("");
+    });
+  });
+
+  describe("action", () => {
+    it("returns empty string", () => {
+      expect(
+        formatQueryParams({ type: "action", actionName: "createTask" })
+      ).toBe("");
+    });
+  });
+
+  describe("links", () => {
+    it("returns empty string", () => {
+      expect(
+        formatQueryParams({
+          type: "links",
+          sourceObject: "Parcel",
+          linkName: "tasks",
+        })
+      ).toBe("");
+    });
+  });
+});
+
+describe("formatHookSignature", () => {
+  it("renders the documented example exactly", () => {
+    expect(
+      formatHookSignature(
+        makeBinding({
+          type: "list",
+          objectType: "Parcel",
+          where: { status: "active" },
+          orderBy: { createdAt: "desc" },
+        })
+      )
+    ).toBe('Parcel · where status = "active" · orderBy createdAt desc');
+  });
+
+  it("renders object signatures", () => {
+    expect(
+      formatHookSignature(
+        makeBinding({ type: "object", objectType: "Parcel", primaryKey: "123" })
+      )
+    ).toBe("Parcel · pk 123");
+  });
+
+  it("renders a list with no detail as just the type name", () => {
+    expect(
+      formatHookSignature(makeBinding({ type: "list", objectType: "Parcel" }))
+    ).toBe("Parcel");
+  });
+
+  it("renders action signatures using the action name", () => {
+    expect(
+      formatHookSignature(
+        makeBinding({ type: "action", actionName: "createTask" })
+      )
+    ).toBe("createTask");
+  });
+
+  it("renders link signatures with the arrow notation", () => {
+    expect(
+      formatHookSignature(
+        makeBinding({
+          type: "links",
+          sourceObject: "Parcel",
+          linkName: "tasks",
+        })
+      )
+    ).toBe("Parcel → tasks");
+  });
+
+  it("renders aggregation signatures", () => {
+    expect(
+      formatHookSignature(
+        makeBinding({
+          type: "aggregation",
+          objectType: "Employee",
+          where: { dept: "eng" },
+          aggregate: { "salary:avg": "unordered" },
+        })
+      )
+    ).toBe('Employee · where dept = "eng" · aggregate salary:avg');
+  });
+
+  it("renders objectSet signatures", () => {
+    expect(
+      formatHookSignature(
+        makeBinding({
+          type: "objectSet",
+          baseObjectSet: "Employees",
+          operations: [{ type: "filter" }],
+        })
+      )
+    ).toBe("Employees · filter");
+  });
+});

--- a/packages/react-devtools/src/components/queryParamsFormat.ts
+++ b/packages/react-devtools/src/components/queryParamsFormat.ts
@@ -38,46 +38,27 @@ function isOperatorObject(value: unknown): value is Record<string, unknown> {
   return keys.length > 0 && keys.every((key) => key.startsWith("$"));
 }
 
+const OPERATOR_SYMBOLS: Record<string, string> = {
+  $eq: "=",
+  $ne: "!=",
+  $gt: ">",
+  $gte: ">=",
+  $lt: "<",
+  $lte: "<=",
+  $contains: "contains",
+  $startsWith: "startsWith",
+  $in: "in",
+};
+
 function formatSingleOperator(
   field: string,
   op: string,
   value: unknown
 ): string {
-  switch (op) {
-    case "$eq": {
-      return `${field} = ${formatValue(value)}`;
-    }
-    case "$ne": {
-      return `${field} != ${formatValue(value)}`;
-    }
-    case "$gt": {
-      return `${field} > ${formatValue(value)}`;
-    }
-    case "$gte": {
-      return `${field} >= ${formatValue(value)}`;
-    }
-    case "$lt": {
-      return `${field} < ${formatValue(value)}`;
-    }
-    case "$lte": {
-      return `${field} <= ${formatValue(value)}`;
-    }
-    case "$isNull": {
-      return value === true ? `${field} is null` : `${field} is not null`;
-    }
-    case "$contains": {
-      return `${field} contains ${formatValue(value)}`;
-    }
-    case "$startsWith": {
-      return `${field} startsWith ${formatValue(value)}`;
-    }
-    case "$in": {
-      return `${field} in ${formatValue(value)}`;
-    }
-    default: {
-      return `${field} ${op} ${formatValue(value)}`;
-    }
+  if (op === "$isNull") {
+    return value === true ? `${field} is null` : `${field} is not null`;
   }
+  return `${field} ${OPERATOR_SYMBOLS[op] ?? op} ${formatValue(value)}`;
 }
 
 function formatOperator(

--- a/packages/react-devtools/src/components/queryParamsFormat.ts
+++ b/packages/react-devtools/src/components/queryParamsFormat.ts
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  ComponentHookBinding,
+  QueryParams,
+} from "../utils/ComponentQueryRegistry.js";
+
+const SEPARATOR = " · ";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != null && !Array.isArray(value);
+}
+
+function formatValue(value: unknown): string {
+  const json = JSON.stringify(value);
+  return json === undefined ? "" : json;
+}
+
+function isOperatorObject(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const keys = Object.keys(value);
+  return keys.length > 0 && keys.every((key) => key.startsWith("$"));
+}
+
+function formatSingleOperator(
+  field: string,
+  op: string,
+  value: unknown
+): string {
+  switch (op) {
+    case "$eq": {
+      return `${field} = ${formatValue(value)}`;
+    }
+    case "$ne": {
+      return `${field} != ${formatValue(value)}`;
+    }
+    case "$gt": {
+      return `${field} > ${formatValue(value)}`;
+    }
+    case "$gte": {
+      return `${field} >= ${formatValue(value)}`;
+    }
+    case "$lt": {
+      return `${field} < ${formatValue(value)}`;
+    }
+    case "$lte": {
+      return `${field} <= ${formatValue(value)}`;
+    }
+    case "$isNull": {
+      return value === true ? `${field} is null` : `${field} is not null`;
+    }
+    case "$contains": {
+      return `${field} contains ${formatValue(value)}`;
+    }
+    case "$startsWith": {
+      return `${field} startsWith ${formatValue(value)}`;
+    }
+    case "$in": {
+      return `${field} in ${formatValue(value)}`;
+    }
+    default: {
+      return `${field} ${op} ${formatValue(value)}`;
+    }
+  }
+}
+
+function formatOperator(
+  field: string,
+  operator: Record<string, unknown>
+): string {
+  const parts: string[] = [];
+  for (const op of Object.keys(operator)) {
+    parts.push(formatSingleOperator(field, op, operator[op]));
+  }
+  return parts.join(", ");
+}
+
+function joinSubClauses(clauses: unknown[], joiner: string): string {
+  const rendered = clauses
+    .map((clause) => formatWhereClause(clause))
+    .filter(Boolean);
+  return rendered.join(joiner);
+}
+
+function formatWhereClause(where: unknown): string {
+  if (!isRecord(where)) {
+    return "";
+  }
+  if (Array.isArray(where.$and)) {
+    return joinSubClauses(where.$and, " and ");
+  }
+  if (Array.isArray(where.$or)) {
+    return joinSubClauses(where.$or, " or ");
+  }
+  if (where.$not !== undefined) {
+    const inner = formatWhereClause(where.$not);
+    return inner ? `not (${inner})` : "";
+  }
+  const parts: string[] = [];
+  for (const key of Object.keys(where)) {
+    const value = where[key];
+    if (isOperatorObject(value)) {
+      parts.push(formatOperator(key, value));
+    } else {
+      parts.push(`${key} = ${formatValue(value)}`);
+    }
+  }
+  return parts.join(", ");
+}
+
+function formatOrderBy(orderBy: unknown): string {
+  if (!isRecord(orderBy)) {
+    return "";
+  }
+  const parts: string[] = [];
+  for (const field of Object.keys(orderBy)) {
+    const direction = orderBy[field];
+    if (typeof direction === "string") {
+      parts.push(`${field} ${direction}`);
+    } else {
+      parts.push(field);
+    }
+  }
+  return parts.join(", ");
+}
+
+function formatAggregate(aggregate: unknown): string {
+  if (typeof aggregate === "string") {
+    return aggregate;
+  }
+  if (!isRecord(aggregate)) {
+    return "";
+  }
+  return Object.keys(aggregate).join(", ");
+}
+
+function formatObjectSetOperations(operations: unknown[]): string {
+  const labels = operations.map((operation) => {
+    if (isRecord(operation) && typeof operation.type === "string") {
+      return operation.type;
+    }
+    return "operation";
+  });
+  return labels.join(", ");
+}
+
+export function formatQueryParams(params: QueryParams): string {
+  switch (params.type) {
+    case "object": {
+      return params.primaryKey ? `pk ${params.primaryKey}` : "";
+    }
+    case "list": {
+      const parts: string[] = [];
+      const whereClause = formatWhereClause(params.where);
+      if (whereClause) {
+        parts.push(`where ${whereClause}`);
+      }
+      const orderByClause = formatOrderBy(params.orderBy);
+      if (orderByClause) {
+        parts.push(`orderBy ${orderByClause}`);
+      }
+      if (params.pageSize !== undefined) {
+        parts.push(`pageSize ${params.pageSize}`);
+      }
+      return parts.join(SEPARATOR);
+    }
+    case "aggregation": {
+      const parts: string[] = [];
+      const whereClause = formatWhereClause(params.where);
+      if (whereClause) {
+        parts.push(`where ${whereClause}`);
+      }
+      const aggregateClause = formatAggregate(params.aggregate);
+      if (aggregateClause) {
+        parts.push(`aggregate ${aggregateClause}`);
+      }
+      return parts.join(SEPARATOR);
+    }
+    case "objectSet": {
+      return formatObjectSetOperations(params.operations);
+    }
+    case "action": {
+      return "";
+    }
+    case "links": {
+      return "";
+    }
+    default: {
+      return "";
+    }
+  }
+}
+
+function getTypeName(params: QueryParams): string {
+  switch (params.type) {
+    case "object":
+    case "list":
+    case "aggregation": {
+      return params.objectType;
+    }
+    case "action": {
+      return params.actionName;
+    }
+    case "links": {
+      return `${params.sourceObject} → ${params.linkName}`;
+    }
+    case "objectSet": {
+      return params.baseObjectSet;
+    }
+    default: {
+      return "";
+    }
+  }
+}
+
+export function formatHookSignature(binding: ComponentHookBinding): string {
+  const typeName = getTypeName(binding.queryParams);
+  return [typeName, formatQueryParams(binding.queryParams)]
+    .filter(Boolean)
+    .join(SEPARATOR);
+}


### PR DESCRIPTION
convert cryptic hook signatures into readable query parameter summaries for display in the tabs

• formatQueryParams formats structured params into · separated strings (where, orderBy, select, args)
• formatHookSignature creates readable labels combining the object type with formatted params
• supports all hook kinds and gracefully handles empty or undefined parameters