### PR TITLE
add canonical metrics model and useCanonicalMetrics hook

### DIFF
--- a/.changeset/canonical-metrics.md
+++ b/.changeset/canonical-metrics.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+Add a canonical, request-based metrics source (getCanonicalMetrics + useCanonicalMetrics) that derives the nine shared devtools metrics from a MetricsSnapshot and gates each one behind a per-metric sample-count readiness flag so cold-start values no longer read as broken

--- a/packages/react-devtools/src/hooks/useCanonicalMetrics.ts
+++ b/packages/react-devtools/src/hooks/useCanonicalMetrics.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+
+import type { CanonicalMetrics } from "../metrics/canonicalMetrics.js";
+import { getCanonicalMetrics } from "../metrics/canonicalMetrics.js";
+import type { MonitorStore } from "../store/MonitorStore.js";
+
+export function useCanonicalMetrics(
+  monitorStore: MonitorStore
+): CanonicalMetrics {
+  const store = monitorStore.getMetricsStore();
+  const subscribe = useCallback(
+    (callback: () => void) => store.subscribe(callback),
+    [store]
+  );
+  const getSnapshot = useCallback(() => store.getSnapshot(), [store]);
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  return useMemo(() => getCanonicalMetrics(snapshot), [snapshot]);
+}

--- a/packages/react-devtools/src/index.ts
+++ b/packages/react-devtools/src/index.ts
@@ -34,8 +34,15 @@ export {
   useComputeRecording,
   useComputeRequests,
 } from "./hooks/useComputeSelectors.js";
+export { useCanonicalMetrics } from "./hooks/useCanonicalMetrics.js";
 export { useMetrics } from "./hooks/useMetrics.js";
 export { usePersistedState } from "./hooks/usePersistedState.js";
+
+export {
+  getCanonicalMetrics,
+  MIN_SAMPLES,
+} from "./metrics/canonicalMetrics.js";
+export type { CanonicalMetrics, Metric } from "./metrics/canonicalMetrics.js";
 
 export type { Fiber } from "./fiber/types.js";
 export { ComputeStore } from "./store/ComputeStore.js";

--- a/packages/react-devtools/src/metrics/canonicalMetrics.test.ts
+++ b/packages/react-devtools/src/metrics/canonicalMetrics.test.ts
@@ -264,14 +264,4 @@ describe("getCanonicalMetrics", () => {
       expect(metrics[key].ready).toBe(false);
     }
   });
-
-  it("guards divisions on a freshly constructed MetricsStore snapshot", () => {
-    const metrics = getCanonicalMetrics(store.getSnapshot());
-
-    for (const key of CANONICAL_KEYS) {
-      expect(Number.isFinite(metrics[key].value)).toBe(true);
-      expect(metrics[key].value).toBe(0);
-      expect(metrics[key].ready).toBe(false);
-    }
-  });
 });

--- a/packages/react-devtools/src/metrics/canonicalMetrics.test.ts
+++ b/packages/react-devtools/src/metrics/canonicalMetrics.test.ts
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MetricsStore } from "../store/MetricsStore.js";
+import type {
+  AggregateMetrics,
+  MetricRates,
+  MetricsSnapshot,
+} from "../types/index.js";
+import type { CanonicalMetrics } from "./canonicalMetrics.js";
+import { getCanonicalMetrics, MIN_SAMPLES } from "./canonicalMetrics.js";
+
+function flushMicrotasksAndTimers(): void {
+  vi.advanceTimersByTime(0);
+}
+
+function zeroAggregates(): AggregateMetrics {
+  return {
+    cacheHits: 0,
+    cacheMisses: 0,
+    deduplications: 0,
+    optimisticUpdates: 0,
+    totalResponseTime: 0,
+    cachedResponseTime: 0,
+    networkResponseTime: 0,
+    requestsSaved: 0,
+    bytesServedFromCache: 0,
+    totalObjectsFromCache: 0,
+    totalObjectsFromNetwork: 0,
+    actionCount: 0,
+    configuredOptimisticActionCount: 0,
+    optimisticActionCount: 0,
+    rollbackActionCount: 0,
+    totalOptimisticRenderTime: 0,
+    totalServerRoundTripTime: 0,
+    totalPerceivedSpeedup: 0,
+    totalOptimisticObjectsAffected: 0,
+    revalidations: 0,
+    validationCount: 0,
+    totalValidationTime: 0,
+  };
+}
+
+function zeroRates(): MetricRates {
+  return {
+    cacheHitRate: 0,
+    deduplicationRate: 0,
+    optimisticUpdateRate: 0,
+    averageResponseTime: 0,
+    averageCachedResponseTime: 0,
+    optimisticActionCoverage: 0,
+    configuredOptimisticActionRate: 0,
+    rollbackRate: 0,
+    averageOptimisticRenderTime: 0,
+    averageServerRoundTripTime: 0,
+    averagePerceivedSpeedup: 0,
+    averageValidationTime: 0,
+    validationTimeSaved: 0,
+  };
+}
+
+function makeSnapshot(overrides: Partial<AggregateMetrics>): MetricsSnapshot {
+  return {
+    recent: [],
+    aggregates: { ...zeroAggregates(), ...overrides },
+    rates: zeroRates(),
+    timeSeries: {
+      timestamps: [],
+      cacheHits: [],
+      cacheMisses: [],
+      revalidations: [],
+      deduplications: [],
+    },
+  };
+}
+
+const CANONICAL_KEYS: ReadonlyArray<keyof CanonicalMetrics> = [
+  "avgCachedMs",
+  "avgNetworkMs",
+  "avgPerceivedSpeedupMs",
+  "avgResponseMs",
+  "cacheHitRate",
+  "estimatedTimeSavedMs",
+  "optimisticCoverage",
+  "requestsSaved",
+  "rollbackRate",
+];
+
+describe("getCanonicalMetrics", () => {
+  let store: MetricsStore;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+
+    if (globalThis.requestIdleCallback === undefined) {
+      globalThis.requestIdleCallback = ((cb: IdleRequestCallback) => {
+        return setTimeout(
+          () =>
+            cb({
+              didTimeout: false,
+              timeRemaining: () => 50,
+            }),
+          0
+        ) as unknown as number;
+      }) as typeof globalThis.requestIdleCallback;
+      globalThis.cancelIdleCallback = ((id: number) => {
+        clearTimeout(id);
+      }) as typeof globalThis.cancelIdleCallback;
+    }
+
+    store = new MetricsStore(100, 10);
+  });
+
+  afterEach(() => {
+    store.dispose();
+    vi.useRealTimers();
+  });
+
+  it("exposes exactly the nine canonical metric keys", () => {
+    const metrics = getCanonicalMetrics(makeSnapshot({}));
+    expect(Object.keys(metrics).sort()).toEqual([...CANONICAL_KEYS]);
+  });
+
+  it("locks the MIN_SAMPLES thresholds", () => {
+    expect(MIN_SAMPLES).toEqual({
+      cacheHitRate: 20,
+      latency: 5,
+      requestsSaved: 1,
+      optimisticCoverage: 3,
+      rollbackRate: 3,
+    });
+  });
+
+  it("matches MetricsStore.getCacheHitRate() for the request-based formula", () => {
+    for (let i = 0; i < 14; i++) {
+      store.recordCacheHit(`hit-${i}`, 5);
+    }
+    for (let i = 0; i < 4; i++) {
+      store.recordCacheMiss(`miss-${i}`, 100);
+    }
+    for (let i = 0; i < 2; i++) {
+      store.recordRevalidation(`reval-${i}`, 80);
+    }
+    flushMicrotasksAndTimers();
+
+    const snapshot = store.getSnapshot();
+    const metrics = getCanonicalMetrics(snapshot);
+
+    expect(metrics.cacheHitRate.value).toBeCloseTo(store.getCacheHitRate());
+    expect(metrics.cacheHitRate.value).toBeCloseTo((14 + 2) / 20);
+    expect(metrics.cacheHitRate.sampleCount).toBe(20);
+    expect(metrics.cacheHitRate.ready).toBe(true);
+  });
+
+  it("assigns request and millisecond units", () => {
+    const metrics = getCanonicalMetrics(
+      makeSnapshot({ cacheHits: 5, revalidations: 3, deduplications: 2 })
+    );
+
+    expect(metrics.requestsSaved.unit).toBe("requests");
+    expect(metrics.estimatedTimeSavedMs.unit).toBe("ms");
+    expect(metrics.avgNetworkMs.unit).toBe("ms");
+    expect(metrics.avgResponseMs.unit).toBe("ms");
+    expect(metrics.avgCachedMs.unit).toBe("ms");
+    expect(metrics.avgPerceivedSpeedupMs.unit).toBe("ms");
+    expect(metrics.cacheHitRate.unit).toBeUndefined();
+    expect(metrics.optimisticCoverage.unit).toBeUndefined();
+    expect(metrics.rollbackRate.unit).toBeUndefined();
+  });
+
+  it("computes requestsSaved and derives estimatedTimeSavedMs from it", () => {
+    const metrics = getCanonicalMetrics(
+      makeSnapshot({
+        cacheHits: 10,
+        cacheMisses: 5,
+        networkResponseTime: 500,
+      })
+    );
+
+    expect(metrics.avgNetworkMs.value).toBeCloseTo(100);
+    expect(metrics.requestsSaved.value).toBe(10);
+    expect(metrics.estimatedTimeSavedMs.value).toBeCloseTo(1000);
+    expect(metrics.estimatedTimeSavedMs.sampleCount).toBe(10);
+  });
+
+  it("gates cacheHitRate readiness at the twenty-sample threshold", () => {
+    const below = getCanonicalMetrics(makeSnapshot({ cacheHits: 19 }));
+    expect(below.cacheHitRate.sampleCount).toBe(19);
+    expect(below.cacheHitRate.ready).toBe(false);
+
+    const atThreshold = getCanonicalMetrics(makeSnapshot({ cacheHits: 20 }));
+    expect(atThreshold.cacheHitRate.sampleCount).toBe(20);
+    expect(atThreshold.cacheHitRate.ready).toBe(true);
+  });
+
+  it("gates latency metrics at the five-sample threshold", () => {
+    const below = getCanonicalMetrics(
+      makeSnapshot({ cacheMisses: 4, networkResponseTime: 400 })
+    );
+    expect(below.avgNetworkMs.ready).toBe(false);
+
+    const atThreshold = getCanonicalMetrics(
+      makeSnapshot({ cacheMisses: 5, networkResponseTime: 500 })
+    );
+    expect(atThreshold.avgNetworkMs.ready).toBe(true);
+    expect(atThreshold.avgNetworkMs.value).toBeCloseTo(100);
+  });
+
+  it("gates requestsSaved at the single-sample threshold", () => {
+    expect(getCanonicalMetrics(makeSnapshot({})).requestsSaved.ready).toBe(
+      false
+    );
+    expect(
+      getCanonicalMetrics(makeSnapshot({ cacheHits: 1 })).requestsSaved.ready
+    ).toBe(true);
+  });
+
+  it("gates optimistic coverage and rollback rate at the three-sample threshold", () => {
+    const below = getCanonicalMetrics(
+      makeSnapshot({
+        actionCount: 2,
+        optimisticActionCount: 1,
+        rollbackActionCount: 1,
+      })
+    );
+    expect(below.optimisticCoverage.ready).toBe(false);
+    expect(below.rollbackRate.ready).toBe(false);
+
+    const atThreshold = getCanonicalMetrics(
+      makeSnapshot({
+        actionCount: 3,
+        optimisticActionCount: 3,
+        rollbackActionCount: 0,
+      })
+    );
+    expect(atThreshold.optimisticCoverage.ready).toBe(true);
+    expect(atThreshold.optimisticCoverage.value).toBeCloseTo(1);
+    expect(atThreshold.rollbackRate.ready).toBe(true);
+    expect(atThreshold.rollbackRate.value).toBeCloseTo(0);
+  });
+
+  it("guards every division to a finite zero and stays not-ready on a zeroed snapshot", () => {
+    const metrics = getCanonicalMetrics(makeSnapshot({}));
+
+    for (const key of CANONICAL_KEYS) {
+      expect(Number.isFinite(metrics[key].value)).toBe(true);
+      expect(metrics[key].value).toBe(0);
+      expect(metrics[key].sampleCount).toBe(0);
+      expect(metrics[key].ready).toBe(false);
+    }
+  });
+
+  it("guards divisions on a freshly constructed MetricsStore snapshot", () => {
+    const metrics = getCanonicalMetrics(store.getSnapshot());
+
+    for (const key of CANONICAL_KEYS) {
+      expect(Number.isFinite(metrics[key].value)).toBe(true);
+      expect(metrics[key].value).toBe(0);
+      expect(metrics[key].ready).toBe(false);
+    }
+  });
+});

--- a/packages/react-devtools/src/metrics/canonicalMetrics.ts
+++ b/packages/react-devtools/src/metrics/canonicalMetrics.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { MetricsSnapshot } from "../types/index.js";
+
+export interface Metric {
+  value: number;
+  sampleCount: number;
+  ready: boolean;
+  unit?: string;
+}
+
+export interface CanonicalMetrics {
+  cacheHitRate: Metric;
+  requestsSaved: Metric;
+  estimatedTimeSavedMs: Metric;
+  avgResponseMs: Metric;
+  avgCachedMs: Metric;
+  avgNetworkMs: Metric;
+  optimisticCoverage: Metric;
+  avgPerceivedSpeedupMs: Metric;
+  rollbackRate: Metric;
+}
+
+export const MIN_SAMPLES = {
+  cacheHitRate: 20,
+  latency: 5,
+  requestsSaved: 1,
+  optimisticCoverage: 3,
+  rollbackRate: 3,
+} as const;
+
+type MinSamplesGroup = keyof typeof MIN_SAMPLES;
+
+function metric(
+  value: number,
+  sampleCount: number,
+  group: MinSamplesGroup,
+  unit?: string
+): Metric {
+  const safeValue = Number.isFinite(value) ? value : 0;
+  return {
+    value: safeValue,
+    sampleCount,
+    ready: sampleCount >= MIN_SAMPLES[group],
+    unit,
+  };
+}
+
+export function getCanonicalMetrics(
+  snapshot: MetricsSnapshot
+): CanonicalMetrics {
+  const a = snapshot.aggregates;
+  const H = a.cacheHits;
+  const M = a.cacheMisses;
+  const R = a.revalidations;
+  const D = a.deduplications;
+  const A = a.actionCount;
+  const OA = a.optimisticActionCount;
+  const RB = a.rollbackActionCount;
+
+  const requestTotal = H + M + R;
+
+  const cacheHitRate = metric(
+    requestTotal > 0 ? (H + R) / requestTotal : 0,
+    requestTotal,
+    "cacheHitRate"
+  );
+
+  const requestsSavedCount = H + R + D;
+  const requestsSaved = metric(
+    requestsSavedCount,
+    requestsSavedCount,
+    "requestsSaved",
+    "requests"
+  );
+
+  const avgNetworkMs = metric(
+    a.networkResponseTime / Math.max(M, 1),
+    M,
+    "latency",
+    "ms"
+  );
+
+  const estimatedTimeSavedMs = metric(
+    requestsSaved.value * avgNetworkMs.value,
+    requestsSavedCount,
+    "requestsSaved",
+    "ms"
+  );
+
+  const avgResponseMs = metric(
+    requestTotal > 0 ? a.totalResponseTime / requestTotal : 0,
+    requestTotal,
+    "latency",
+    "ms"
+  );
+
+  const avgCachedMs = metric(
+    a.cachedResponseTime / Math.max(H, 1),
+    H,
+    "latency",
+    "ms"
+  );
+
+  const optimisticCoverage = metric(
+    A > 0 ? OA / A : 0,
+    A,
+    "optimisticCoverage"
+  );
+
+  const avgPerceivedSpeedupMs = metric(
+    a.totalPerceivedSpeedup / Math.max(OA, 1),
+    OA,
+    "latency",
+    "ms"
+  );
+
+  const rollbackRate = metric(A > 0 ? RB / A : 0, A, "rollbackRate");
+
+  return {
+    cacheHitRate,
+    requestsSaved,
+    estimatedTimeSavedMs,
+    avgResponseMs,
+    avgCachedMs,
+    avgNetworkMs,
+    optimisticCoverage,
+    avgPerceivedSpeedupMs,
+    rollbackRate,
+  };
+}

--- a/packages/react-devtools/src/metrics/canonicalMetrics.ts
+++ b/packages/react-devtools/src/metrics/canonicalMetrics.ts
@@ -64,23 +64,23 @@ export function getCanonicalMetrics(
   snapshot: MetricsSnapshot
 ): CanonicalMetrics {
   const a = snapshot.aggregates;
-  const H = a.cacheHits;
-  const M = a.cacheMisses;
-  const R = a.revalidations;
-  const D = a.deduplications;
-  const A = a.actionCount;
-  const OA = a.optimisticActionCount;
-  const RB = a.rollbackActionCount;
+  const hits = a.cacheHits;
+  const misses = a.cacheMisses;
+  const revals = a.revalidations;
+  const dedups = a.deduplications;
+  const actions = a.actionCount;
+  const optimisticActions = a.optimisticActionCount;
+  const rollbacks = a.rollbackActionCount;
 
-  const requestTotal = H + M + R;
+  const requestTotal = hits + misses + revals;
 
   const cacheHitRate = metric(
-    requestTotal > 0 ? (H + R) / requestTotal : 0,
+    requestTotal > 0 ? (hits + revals) / requestTotal : 0,
     requestTotal,
     "cacheHitRate"
   );
 
-  const requestsSavedCount = H + R + D;
+  const requestsSavedCount = hits + revals + dedups;
   const requestsSaved = metric(
     requestsSavedCount,
     requestsSavedCount,
@@ -89,8 +89,8 @@ export function getCanonicalMetrics(
   );
 
   const avgNetworkMs = metric(
-    a.networkResponseTime / Math.max(M, 1),
-    M,
+    a.networkResponseTime / Math.max(misses, 1),
+    misses,
     "latency",
     "ms"
   );
@@ -110,26 +110,30 @@ export function getCanonicalMetrics(
   );
 
   const avgCachedMs = metric(
-    a.cachedResponseTime / Math.max(H, 1),
-    H,
+    a.cachedResponseTime / Math.max(hits, 1),
+    hits,
     "latency",
     "ms"
   );
 
   const optimisticCoverage = metric(
-    A > 0 ? OA / A : 0,
-    A,
+    actions > 0 ? optimisticActions / actions : 0,
+    actions,
     "optimisticCoverage"
   );
 
   const avgPerceivedSpeedupMs = metric(
-    a.totalPerceivedSpeedup / Math.max(OA, 1),
-    OA,
+    a.totalPerceivedSpeedup / Math.max(optimisticActions, 1),
+    optimisticActions,
     "latency",
     "ms"
   );
 
-  const rollbackRate = metric(A > 0 ? RB / A : 0, A, "rollbackRate");
+  const rollbackRate = metric(
+    actions > 0 ? rollbacks / actions : 0,
+    actions,
+    "rollbackRate"
+  );
 
   return {
     cacheHitRate,


### PR DESCRIPTION
multiple modules compute metrics differently; create one canonical source with request-based rates and cold-start ready states

• add getCanonicalMetrics to compute cache hit rate, request savings, latency averages, optimistic coverage, and rollback rate from MetricsSnapshot
• add useCanonicalMetrics hook to subscribe to canonical metrics via MonitorStore; provides a single source for all tabs
• include ready flags based on sample thresholds for each metric so the UI can handle cold-start appropriately