### PR TITLE
add cache plugin to react-devtools

### DIFF
--- a/.changeset/canonical-metrics.md
+++ b/.changeset/canonical-metrics.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+Add a canonical, request-based metrics source (getCanonicalMetrics + useCanonicalMetrics) that derives the nine shared devtools metrics from a MetricsSnapshot and gates each one behind a per-metric sample-count readiness flag so cold-start values no longer read as broken

--- a/.changeset/copy-prompt-button.md
+++ b/.changeset/copy-prompt-button.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+add copy-prompt builder and CopyPromptButton for actionable performance recommendations

--- a/.changeset/devtools-cache-plugin.md
+++ b/.changeset/devtools-cache-plugin.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+Add the opt-in cache plugin (cacheTab) and expose it plus registerDevToolsPlugin through the ./advanced entry point.

--- a/.changeset/devtools-cache-plugin.md
+++ b/.changeset/devtools-cache-plugin.md
@@ -1,5 +1,5 @@
 ---
-"@osdk/react-devtools": patch
+"@osdk/react-devtools": minor
 ---
 
-Add the opt-in cache plugin (cacheTab) and expose it plus registerDevToolsPlugin through the ./advanced entry point.
+Add the opt-in cache plugin (cacheTab) and expose it plus registerDevToolsPlugin through the ./advanced entry point. The cache tab is split into the cache-entry inspector on top and a live cache hit/miss list on the bottom, separated by a draggable divider whose position is persisted.

--- a/.changeset/devtools-plugin-registry.md
+++ b/.changeset/devtools-plugin-registry.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+Add the devtools plugin contract (DevToolsPlugin/DevToolsPanelProps), a subscribable global plugin registry, the useDevToolsTabs hook, and the ./advanced entrypoint so base tabs and advanced plugins share one shape.

--- a/.changeset/devtools-query-params-format.md
+++ b/.changeset/devtools-query-params-format.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+add human-readable query param formatter for devtools component/performance tabs

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -15,6 +15,13 @@
       },
       "default": "./build/esm/index.js"
     },
+    "./advanced": {
+      "import": {
+        "types": "./build/types/advanced.d.ts",
+        "default": "./build/esm/advanced.js"
+      },
+      "default": "./build/esm/advanced.js"
+    },
     "./vite": {
       "import": {
         "types": "./build/types/public/vite.d.ts",

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -17,10 +17,10 @@
     },
     "./advanced": {
       "import": {
-        "types": "./build/types/advanced.d.ts",
-        "default": "./build/esm/advanced.js"
+        "types": "./build/types/public/advanced.d.ts",
+        "default": "./build/esm/public/advanced.js"
       },
-      "default": "./build/esm/advanced.js"
+      "default": "./build/esm/public/advanced.js"
     },
     "./vite": {
       "import": {

--- a/packages/react-devtools/src/advanced.ts
+++ b/packages/react-devtools/src/advanced.ts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-// WS-P1/P2/P3 + WS-M1 populate this entrypoint with cacheTab/computeTab/interceptTab.
+// Entry point for the advanced plugin tabs (cache, compute, intercept). Populated when those tabs are added.
 // eslint-disable-next-line unicorn/require-module-specifiers -- placeholder empty module until advanced plugins land
 export {};

--- a/packages/react-devtools/src/advanced.ts
+++ b/packages/react-devtools/src/advanced.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// WS-P1/P2/P3 + WS-M1 populate this entrypoint with cacheTab/computeTab/interceptTab.
+// eslint-disable-next-line unicorn/require-module-specifiers -- placeholder empty module until advanced plugins land
+export {};

--- a/packages/react-devtools/src/components/CopyPromptButton.test.tsx
+++ b/packages/react-devtools/src/components/CopyPromptButton.test.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildCopyAllPrompt,
+  buildCopyPrompt,
+} from "../recommendations/copyPrompt.js";
+import type { Recommendation } from "../utils/PerformanceRecommendationEngine.js";
+
+const { CopyPromptButton } = await import("./CopyPromptButton.js");
+
+function makeRec(overrides: Partial<Recommendation> = {}): Recommendation {
+  return {
+    id: "rec-1",
+    level: "high",
+    category: "Bandwidth",
+    title: "EmployeeCard fetches unused data",
+    description: "This component fetches 12 properties but only uses 3",
+    impact: "Save 4.2KB bandwidth per load",
+    effort: "Low",
+    suggestion: "Use $select to only fetch used properties",
+    dismissible: true,
+    ...overrides,
+  };
+}
+
+const writeText = vi.fn<(text: string) => Promise<void>>();
+
+beforeEach(() => {
+  writeText.mockReset();
+  writeText.mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+async function flushMicrotasks(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe("CopyPromptButton", () => {
+  it("copies the single-recommendation prompt and flips the icon to tick", async () => {
+    const rec = makeRec({ filePath: "src/A.tsx", lineNumber: 7 });
+
+    const { container } = render(<CopyPromptButton recommendation={rec} />);
+
+    expect(container.querySelector('[data-icon="clipboard"]')).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button"));
+    await flushMicrotasks();
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText).toHaveBeenCalledWith(buildCopyPrompt(rec));
+    expect(container.querySelector('[data-icon="tick"]')).not.toBeNull();
+    expect(container.querySelector('[data-icon="clipboard"]')).toBeNull();
+  });
+
+  it("copies the combined prompt for multiple recommendations", async () => {
+    const recs = [makeRec({ id: "rec-1" }), makeRec({ id: "rec-2" })];
+
+    render(<CopyPromptButton recommendations={recs} />);
+
+    fireEvent.click(screen.getByRole("button"));
+    await flushMicrotasks();
+
+    expect(writeText).toHaveBeenCalledWith(buildCopyAllPrompt(recs));
+  });
+
+  it("resets the icon back to clipboard after the timeout elapses", async () => {
+    vi.useFakeTimers();
+    const rec = makeRec();
+
+    const { container } = render(<CopyPromptButton recommendation={rec} />);
+
+    fireEvent.click(screen.getByRole("button"));
+    await flushMicrotasks();
+
+    expect(container.querySelector('[data-icon="tick"]')).not.toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(container.querySelector('[data-icon="tick"]')).toBeNull();
+    expect(container.querySelector('[data-icon="clipboard"]')).not.toBeNull();
+  });
+
+  it("defaults to the single label and respects an override", () => {
+    const { rerender } = render(
+      <CopyPromptButton recommendation={makeRec()} />
+    );
+
+    expect(screen.getByText("Copy prompt")).not.toBeNull();
+
+    rerender(
+      <CopyPromptButton recommendation={makeRec()} label="Fix it for me" />
+    );
+
+    expect(screen.getByText("Fix it for me")).not.toBeNull();
+  });
+
+  it("defaults to the copy-all label for multiple recommendations", () => {
+    render(<CopyPromptButton recommendations={[makeRec()]} />);
+
+    expect(screen.getByText("Copy all")).not.toBeNull();
+  });
+});

--- a/packages/react-devtools/src/components/CopyPromptButton.tsx
+++ b/packages/react-devtools/src/components/CopyPromptButton.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button } from "@blueprintjs/core";
+import React, { useCallback, useRef, useState } from "react";
+
+import {
+  buildCopyAllPrompt,
+  buildCopyPrompt,
+} from "../recommendations/copyPrompt.js";
+import type { Recommendation } from "../utils/PerformanceRecommendationEngine.js";
+
+export type CopyPromptButtonProps =
+  | { recommendation: Recommendation; label?: string }
+  | { recommendations: Recommendation[]; label?: string };
+
+export const CopyPromptButton: React.FC<CopyPromptButtonProps> = (props) => {
+  const [copied, setCopied] = useState(false);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const isSingle = "recommendation" in props;
+  const prompt = isSingle
+    ? buildCopyPrompt(props.recommendation)
+    : buildCopyAllPrompt(props.recommendations);
+  const label = props.label ?? (isSingle ? "Copy prompt" : "Copy all");
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(prompt);
+      setCopied(true);
+      clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard writes can reject (e.g. denied permission); ignore silently.
+    }
+  }, [prompt]);
+
+  return (
+    <Button
+      variant="minimal"
+      size="small"
+      icon={copied ? "tick" : "clipboard"}
+      onClick={() => void handleCopy()}
+    >
+      {label}
+    </Button>
+  );
+};

--- a/packages/react-devtools/src/components/queryParamsFormat.test.ts
+++ b/packages/react-devtools/src/components/queryParamsFormat.test.ts
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type {
+  ComponentHookBinding,
+  QueryParams,
+} from "../utils/ComponentQueryRegistry.js";
+import { formatHookSignature, formatQueryParams } from "./queryParamsFormat.js";
+
+function makeBinding(queryParams: QueryParams): ComponentHookBinding {
+  return {
+    componentId: "c1",
+    componentName: "Demo",
+    hookType: "useOsdkObjects",
+    hookIndex: 0,
+    subscriptionId: "s1",
+    querySignature: "sig",
+    queryParams,
+    stackTrace: "",
+    mountedAt: 0,
+    renderCount: 1,
+    lastRenderDuration: 0,
+    avgRenderDuration: 0,
+  };
+}
+
+describe("formatQueryParams", () => {
+  describe("object", () => {
+    it("renders the primary key", () => {
+      expect(
+        formatQueryParams({
+          type: "object",
+          objectType: "Parcel",
+          primaryKey: "123",
+        })
+      ).toBe("pk 123");
+    });
+
+    it("returns empty string when the primary key is empty", () => {
+      expect(
+        formatQueryParams({
+          type: "object",
+          objectType: "Parcel",
+          primaryKey: "",
+        })
+      ).toBe("");
+    });
+  });
+
+  describe("list", () => {
+    it("renders where, orderBy, and pageSize", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { status: "active" },
+          orderBy: { createdAt: "desc" },
+          pageSize: 50,
+        })
+      ).toBe('where status = "active" · orderBy createdAt desc · pageSize 50');
+    });
+
+    it("renders operator where clauses", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { age: { $gte: 21 } },
+        })
+      ).toBe("where age >= 21");
+    });
+
+    it("renders $and clauses", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { $and: [{ status: "active" }, { region: "west" }] },
+        })
+      ).toBe('where status = "active" and region = "west"');
+    });
+
+    it("renders $or clauses", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { $or: [{ status: "active" }, { status: "pending" }] },
+        })
+      ).toBe('where status = "active" or status = "pending"');
+    });
+
+    it("renders $not clauses", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { $not: { status: "active" } },
+        })
+      ).toBe('where not (status = "active")');
+    });
+
+    it("renders $isNull true and false", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { closedAt: { $isNull: true } },
+        })
+      ).toBe("where closedAt is null");
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { closedAt: { $isNull: false } },
+        })
+      ).toBe("where closedAt is not null");
+    });
+
+    it("renders $in clauses", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { status: { $in: ["active", "pending"] } },
+        })
+      ).toBe('where status in ["active","pending"]');
+    });
+
+    it("returns empty string for an empty where clause and no other detail", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: {},
+        })
+      ).toBe("");
+    });
+
+    it("returns empty string when where and orderBy are undefined", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+        })
+      ).toBe("");
+    });
+  });
+
+  describe("aggregation", () => {
+    it("renders where and aggregate", () => {
+      expect(
+        formatQueryParams({
+          type: "aggregation",
+          objectType: "Employee",
+          where: { dept: "eng" },
+          aggregate: { "salary:avg": "unordered" },
+        })
+      ).toBe('where dept = "eng" · aggregate salary:avg');
+    });
+
+    it("returns empty string when nothing is set", () => {
+      expect(
+        formatQueryParams({
+          type: "aggregation",
+          objectType: "Employee",
+        })
+      ).toBe("");
+    });
+  });
+
+  describe("objectSet", () => {
+    it("renders operation labels", () => {
+      expect(
+        formatQueryParams({
+          type: "objectSet",
+          baseObjectSet: "Employees",
+          operations: [{ type: "filter" }, { type: "pivotTo" }],
+        })
+      ).toBe("filter, pivotTo");
+    });
+
+    it("returns empty string when there are no operations", () => {
+      expect(
+        formatQueryParams({
+          type: "objectSet",
+          baseObjectSet: "Employees",
+          operations: [],
+        })
+      ).toBe("");
+    });
+  });
+
+  describe("action", () => {
+    it("returns empty string", () => {
+      expect(
+        formatQueryParams({ type: "action", actionName: "createTask" })
+      ).toBe("");
+    });
+  });
+
+  describe("links", () => {
+    it("returns empty string", () => {
+      expect(
+        formatQueryParams({
+          type: "links",
+          sourceObject: "Parcel",
+          linkName: "tasks",
+        })
+      ).toBe("");
+    });
+  });
+});
+
+describe("formatHookSignature", () => {
+  it("renders the documented example exactly", () => {
+    expect(
+      formatHookSignature(
+        makeBinding({
+          type: "list",
+          objectType: "Parcel",
+          where: { status: "active" },
+          orderBy: { createdAt: "desc" },
+        })
+      )
+    ).toBe('Parcel · where status = "active" · orderBy createdAt desc');
+  });
+
+  it("renders object signatures", () => {
+    expect(
+      formatHookSignature(
+        makeBinding({ type: "object", objectType: "Parcel", primaryKey: "123" })
+      )
+    ).toBe("Parcel · pk 123");
+  });
+
+  it("renders a list with no detail as just the type name", () => {
+    expect(
+      formatHookSignature(makeBinding({ type: "list", objectType: "Parcel" }))
+    ).toBe("Parcel");
+  });
+
+  it("renders action signatures using the action name", () => {
+    expect(
+      formatHookSignature(
+        makeBinding({ type: "action", actionName: "createTask" })
+      )
+    ).toBe("createTask");
+  });
+
+  it("renders link signatures with the arrow notation", () => {
+    expect(
+      formatHookSignature(
+        makeBinding({
+          type: "links",
+          sourceObject: "Parcel",
+          linkName: "tasks",
+        })
+      )
+    ).toBe("Parcel → tasks");
+  });
+
+  it("renders aggregation signatures", () => {
+    expect(
+      formatHookSignature(
+        makeBinding({
+          type: "aggregation",
+          objectType: "Employee",
+          where: { dept: "eng" },
+          aggregate: { "salary:avg": "unordered" },
+        })
+      )
+    ).toBe('Employee · where dept = "eng" · aggregate salary:avg');
+  });
+
+  it("renders objectSet signatures", () => {
+    expect(
+      formatHookSignature(
+        makeBinding({
+          type: "objectSet",
+          baseObjectSet: "Employees",
+          operations: [{ type: "filter" }],
+        })
+      )
+    ).toBe("Employees · filter");
+  });
+});

--- a/packages/react-devtools/src/components/queryParamsFormat.ts
+++ b/packages/react-devtools/src/components/queryParamsFormat.ts
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  ComponentHookBinding,
+  QueryParams,
+} from "../utils/ComponentQueryRegistry.js";
+
+const SEPARATOR = " · ";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != null && !Array.isArray(value);
+}
+
+function formatValue(value: unknown): string {
+  const json = JSON.stringify(value);
+  return json === undefined ? "" : json;
+}
+
+function isOperatorObject(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const keys = Object.keys(value);
+  return keys.length > 0 && keys.every((key) => key.startsWith("$"));
+}
+
+function formatSingleOperator(
+  field: string,
+  op: string,
+  value: unknown
+): string {
+  switch (op) {
+    case "$eq": {
+      return `${field} = ${formatValue(value)}`;
+    }
+    case "$ne": {
+      return `${field} != ${formatValue(value)}`;
+    }
+    case "$gt": {
+      return `${field} > ${formatValue(value)}`;
+    }
+    case "$gte": {
+      return `${field} >= ${formatValue(value)}`;
+    }
+    case "$lt": {
+      return `${field} < ${formatValue(value)}`;
+    }
+    case "$lte": {
+      return `${field} <= ${formatValue(value)}`;
+    }
+    case "$isNull": {
+      return value === true ? `${field} is null` : `${field} is not null`;
+    }
+    case "$contains": {
+      return `${field} contains ${formatValue(value)}`;
+    }
+    case "$startsWith": {
+      return `${field} startsWith ${formatValue(value)}`;
+    }
+    case "$in": {
+      return `${field} in ${formatValue(value)}`;
+    }
+    default: {
+      return `${field} ${op} ${formatValue(value)}`;
+    }
+  }
+}
+
+function formatOperator(
+  field: string,
+  operator: Record<string, unknown>
+): string {
+  const parts: string[] = [];
+  for (const op of Object.keys(operator)) {
+    parts.push(formatSingleOperator(field, op, operator[op]));
+  }
+  return parts.join(", ");
+}
+
+function joinSubClauses(clauses: unknown[], joiner: string): string {
+  const rendered = clauses
+    .map((clause) => formatWhereClause(clause))
+    .filter(Boolean);
+  return rendered.join(joiner);
+}
+
+function formatWhereClause(where: unknown): string {
+  if (!isRecord(where)) {
+    return "";
+  }
+  if (Array.isArray(where.$and)) {
+    return joinSubClauses(where.$and, " and ");
+  }
+  if (Array.isArray(where.$or)) {
+    return joinSubClauses(where.$or, " or ");
+  }
+  if (where.$not !== undefined) {
+    const inner = formatWhereClause(where.$not);
+    return inner ? `not (${inner})` : "";
+  }
+  const parts: string[] = [];
+  for (const key of Object.keys(where)) {
+    const value = where[key];
+    if (isOperatorObject(value)) {
+      parts.push(formatOperator(key, value));
+    } else {
+      parts.push(`${key} = ${formatValue(value)}`);
+    }
+  }
+  return parts.join(", ");
+}
+
+function formatOrderBy(orderBy: unknown): string {
+  if (!isRecord(orderBy)) {
+    return "";
+  }
+  const parts: string[] = [];
+  for (const field of Object.keys(orderBy)) {
+    const direction = orderBy[field];
+    if (typeof direction === "string") {
+      parts.push(`${field} ${direction}`);
+    } else {
+      parts.push(field);
+    }
+  }
+  return parts.join(", ");
+}
+
+function formatAggregate(aggregate: unknown): string {
+  if (typeof aggregate === "string") {
+    return aggregate;
+  }
+  if (!isRecord(aggregate)) {
+    return "";
+  }
+  return Object.keys(aggregate).join(", ");
+}
+
+function formatObjectSetOperations(operations: unknown[]): string {
+  const labels = operations.map((operation) => {
+    if (isRecord(operation) && typeof operation.type === "string") {
+      return operation.type;
+    }
+    return "operation";
+  });
+  return labels.join(", ");
+}
+
+export function formatQueryParams(params: QueryParams): string {
+  switch (params.type) {
+    case "object": {
+      return params.primaryKey ? `pk ${params.primaryKey}` : "";
+    }
+    case "list": {
+      const parts: string[] = [];
+      const whereClause = formatWhereClause(params.where);
+      if (whereClause) {
+        parts.push(`where ${whereClause}`);
+      }
+      const orderByClause = formatOrderBy(params.orderBy);
+      if (orderByClause) {
+        parts.push(`orderBy ${orderByClause}`);
+      }
+      if (params.pageSize !== undefined) {
+        parts.push(`pageSize ${params.pageSize}`);
+      }
+      return parts.join(SEPARATOR);
+    }
+    case "aggregation": {
+      const parts: string[] = [];
+      const whereClause = formatWhereClause(params.where);
+      if (whereClause) {
+        parts.push(`where ${whereClause}`);
+      }
+      const aggregateClause = formatAggregate(params.aggregate);
+      if (aggregateClause) {
+        parts.push(`aggregate ${aggregateClause}`);
+      }
+      return parts.join(SEPARATOR);
+    }
+    case "objectSet": {
+      return formatObjectSetOperations(params.operations);
+    }
+    case "action": {
+      return "";
+    }
+    case "links": {
+      return "";
+    }
+    default: {
+      return "";
+    }
+  }
+}
+
+function getTypeName(params: QueryParams): string {
+  switch (params.type) {
+    case "object":
+    case "list":
+    case "aggregation": {
+      return params.objectType;
+    }
+    case "action": {
+      return params.actionName;
+    }
+    case "links": {
+      return `${params.sourceObject} → ${params.linkName}`;
+    }
+    case "objectSet": {
+      return params.baseObjectSet;
+    }
+    default: {
+      return "";
+    }
+  }
+}
+
+export function formatHookSignature(binding: ComponentHookBinding): string {
+  const typeName = getTypeName(binding.queryParams);
+  return [typeName, formatQueryParams(binding.queryParams)]
+    .filter(Boolean)
+    .join(SEPARATOR);
+}

--- a/packages/react-devtools/src/hooks/useCanonicalMetrics.ts
+++ b/packages/react-devtools/src/hooks/useCanonicalMetrics.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+
+import type { CanonicalMetrics } from "../metrics/canonicalMetrics.js";
+import { getCanonicalMetrics } from "../metrics/canonicalMetrics.js";
+import type { MonitorStore } from "../store/MonitorStore.js";
+
+export function useCanonicalMetrics(
+  monitorStore: MonitorStore
+): CanonicalMetrics {
+  const store = monitorStore.getMetricsStore();
+  const subscribe = useCallback(
+    (callback: () => void) => store.subscribe(callback),
+    [store]
+  );
+  const getSnapshot = useCallback(() => store.getSnapshot(), [store]);
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  return useMemo(() => getCanonicalMetrics(snapshot), [snapshot]);
+}

--- a/packages/react-devtools/src/index.ts
+++ b/packages/react-devtools/src/index.ts
@@ -34,8 +34,15 @@ export {
   useComputeRecording,
   useComputeRequests,
 } from "./hooks/useComputeSelectors.js";
+export { useCanonicalMetrics } from "./hooks/useCanonicalMetrics.js";
 export { useMetrics } from "./hooks/useMetrics.js";
 export { usePersistedState } from "./hooks/usePersistedState.js";
+
+export {
+  getCanonicalMetrics,
+  MIN_SAMPLES,
+} from "./metrics/canonicalMetrics.js";
+export type { CanonicalMetrics, Metric } from "./metrics/canonicalMetrics.js";
 
 export type { Fiber } from "./fiber/types.js";
 export { ComputeStore } from "./store/ComputeStore.js";

--- a/packages/react-devtools/src/metrics/canonicalMetrics.test.ts
+++ b/packages/react-devtools/src/metrics/canonicalMetrics.test.ts
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MetricsStore } from "../store/MetricsStore.js";
+import type {
+  AggregateMetrics,
+  MetricRates,
+  MetricsSnapshot,
+} from "../types/index.js";
+import type { CanonicalMetrics } from "./canonicalMetrics.js";
+import { getCanonicalMetrics, MIN_SAMPLES } from "./canonicalMetrics.js";
+
+function flushMicrotasksAndTimers(): void {
+  vi.advanceTimersByTime(0);
+}
+
+function zeroAggregates(): AggregateMetrics {
+  return {
+    cacheHits: 0,
+    cacheMisses: 0,
+    deduplications: 0,
+    optimisticUpdates: 0,
+    totalResponseTime: 0,
+    cachedResponseTime: 0,
+    networkResponseTime: 0,
+    requestsSaved: 0,
+    bytesServedFromCache: 0,
+    totalObjectsFromCache: 0,
+    totalObjectsFromNetwork: 0,
+    actionCount: 0,
+    configuredOptimisticActionCount: 0,
+    optimisticActionCount: 0,
+    rollbackActionCount: 0,
+    totalOptimisticRenderTime: 0,
+    totalServerRoundTripTime: 0,
+    totalPerceivedSpeedup: 0,
+    totalOptimisticObjectsAffected: 0,
+    revalidations: 0,
+    validationCount: 0,
+    totalValidationTime: 0,
+  };
+}
+
+function zeroRates(): MetricRates {
+  return {
+    cacheHitRate: 0,
+    deduplicationRate: 0,
+    optimisticUpdateRate: 0,
+    averageResponseTime: 0,
+    averageCachedResponseTime: 0,
+    optimisticActionCoverage: 0,
+    configuredOptimisticActionRate: 0,
+    rollbackRate: 0,
+    averageOptimisticRenderTime: 0,
+    averageServerRoundTripTime: 0,
+    averagePerceivedSpeedup: 0,
+    averageValidationTime: 0,
+    validationTimeSaved: 0,
+  };
+}
+
+function makeSnapshot(overrides: Partial<AggregateMetrics>): MetricsSnapshot {
+  return {
+    recent: [],
+    aggregates: { ...zeroAggregates(), ...overrides },
+    rates: zeroRates(),
+    timeSeries: {
+      timestamps: [],
+      cacheHits: [],
+      cacheMisses: [],
+      revalidations: [],
+      deduplications: [],
+    },
+  };
+}
+
+const CANONICAL_KEYS: ReadonlyArray<keyof CanonicalMetrics> = [
+  "avgCachedMs",
+  "avgNetworkMs",
+  "avgPerceivedSpeedupMs",
+  "avgResponseMs",
+  "cacheHitRate",
+  "estimatedTimeSavedMs",
+  "optimisticCoverage",
+  "requestsSaved",
+  "rollbackRate",
+];
+
+describe("getCanonicalMetrics", () => {
+  let store: MetricsStore;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+
+    if (globalThis.requestIdleCallback === undefined) {
+      globalThis.requestIdleCallback = ((cb: IdleRequestCallback) => {
+        return setTimeout(
+          () =>
+            cb({
+              didTimeout: false,
+              timeRemaining: () => 50,
+            }),
+          0
+        ) as unknown as number;
+      }) as typeof globalThis.requestIdleCallback;
+      globalThis.cancelIdleCallback = ((id: number) => {
+        clearTimeout(id);
+      }) as typeof globalThis.cancelIdleCallback;
+    }
+
+    store = new MetricsStore(100, 10);
+  });
+
+  afterEach(() => {
+    store.dispose();
+    vi.useRealTimers();
+  });
+
+  it("exposes exactly the nine canonical metric keys", () => {
+    const metrics = getCanonicalMetrics(makeSnapshot({}));
+    expect(Object.keys(metrics).sort()).toEqual([...CANONICAL_KEYS]);
+  });
+
+  it("locks the MIN_SAMPLES thresholds", () => {
+    expect(MIN_SAMPLES).toEqual({
+      cacheHitRate: 20,
+      latency: 5,
+      requestsSaved: 1,
+      optimisticCoverage: 3,
+      rollbackRate: 3,
+    });
+  });
+
+  it("matches MetricsStore.getCacheHitRate() for the request-based formula", () => {
+    for (let i = 0; i < 14; i++) {
+      store.recordCacheHit(`hit-${i}`, 5);
+    }
+    for (let i = 0; i < 4; i++) {
+      store.recordCacheMiss(`miss-${i}`, 100);
+    }
+    for (let i = 0; i < 2; i++) {
+      store.recordRevalidation(`reval-${i}`, 80);
+    }
+    flushMicrotasksAndTimers();
+
+    const snapshot = store.getSnapshot();
+    const metrics = getCanonicalMetrics(snapshot);
+
+    expect(metrics.cacheHitRate.value).toBeCloseTo(store.getCacheHitRate());
+    expect(metrics.cacheHitRate.value).toBeCloseTo((14 + 2) / 20);
+    expect(metrics.cacheHitRate.sampleCount).toBe(20);
+    expect(metrics.cacheHitRate.ready).toBe(true);
+  });
+
+  it("assigns request and millisecond units", () => {
+    const metrics = getCanonicalMetrics(
+      makeSnapshot({ cacheHits: 5, revalidations: 3, deduplications: 2 })
+    );
+
+    expect(metrics.requestsSaved.unit).toBe("requests");
+    expect(metrics.estimatedTimeSavedMs.unit).toBe("ms");
+    expect(metrics.avgNetworkMs.unit).toBe("ms");
+    expect(metrics.avgResponseMs.unit).toBe("ms");
+    expect(metrics.avgCachedMs.unit).toBe("ms");
+    expect(metrics.avgPerceivedSpeedupMs.unit).toBe("ms");
+    expect(metrics.cacheHitRate.unit).toBeUndefined();
+    expect(metrics.optimisticCoverage.unit).toBeUndefined();
+    expect(metrics.rollbackRate.unit).toBeUndefined();
+  });
+
+  it("computes requestsSaved and derives estimatedTimeSavedMs from it", () => {
+    const metrics = getCanonicalMetrics(
+      makeSnapshot({
+        cacheHits: 10,
+        cacheMisses: 5,
+        networkResponseTime: 500,
+      })
+    );
+
+    expect(metrics.avgNetworkMs.value).toBeCloseTo(100);
+    expect(metrics.requestsSaved.value).toBe(10);
+    expect(metrics.estimatedTimeSavedMs.value).toBeCloseTo(1000);
+    expect(metrics.estimatedTimeSavedMs.sampleCount).toBe(10);
+  });
+
+  it("gates cacheHitRate readiness at the twenty-sample threshold", () => {
+    const below = getCanonicalMetrics(makeSnapshot({ cacheHits: 19 }));
+    expect(below.cacheHitRate.sampleCount).toBe(19);
+    expect(below.cacheHitRate.ready).toBe(false);
+
+    const atThreshold = getCanonicalMetrics(makeSnapshot({ cacheHits: 20 }));
+    expect(atThreshold.cacheHitRate.sampleCount).toBe(20);
+    expect(atThreshold.cacheHitRate.ready).toBe(true);
+  });
+
+  it("gates latency metrics at the five-sample threshold", () => {
+    const below = getCanonicalMetrics(
+      makeSnapshot({ cacheMisses: 4, networkResponseTime: 400 })
+    );
+    expect(below.avgNetworkMs.ready).toBe(false);
+
+    const atThreshold = getCanonicalMetrics(
+      makeSnapshot({ cacheMisses: 5, networkResponseTime: 500 })
+    );
+    expect(atThreshold.avgNetworkMs.ready).toBe(true);
+    expect(atThreshold.avgNetworkMs.value).toBeCloseTo(100);
+  });
+
+  it("gates requestsSaved at the single-sample threshold", () => {
+    expect(getCanonicalMetrics(makeSnapshot({})).requestsSaved.ready).toBe(
+      false
+    );
+    expect(
+      getCanonicalMetrics(makeSnapshot({ cacheHits: 1 })).requestsSaved.ready
+    ).toBe(true);
+  });
+
+  it("gates optimistic coverage and rollback rate at the three-sample threshold", () => {
+    const below = getCanonicalMetrics(
+      makeSnapshot({
+        actionCount: 2,
+        optimisticActionCount: 1,
+        rollbackActionCount: 1,
+      })
+    );
+    expect(below.optimisticCoverage.ready).toBe(false);
+    expect(below.rollbackRate.ready).toBe(false);
+
+    const atThreshold = getCanonicalMetrics(
+      makeSnapshot({
+        actionCount: 3,
+        optimisticActionCount: 3,
+        rollbackActionCount: 0,
+      })
+    );
+    expect(atThreshold.optimisticCoverage.ready).toBe(true);
+    expect(atThreshold.optimisticCoverage.value).toBeCloseTo(1);
+    expect(atThreshold.rollbackRate.ready).toBe(true);
+    expect(atThreshold.rollbackRate.value).toBeCloseTo(0);
+  });
+
+  it("guards every division to a finite zero and stays not-ready on a zeroed snapshot", () => {
+    const metrics = getCanonicalMetrics(makeSnapshot({}));
+
+    for (const key of CANONICAL_KEYS) {
+      expect(Number.isFinite(metrics[key].value)).toBe(true);
+      expect(metrics[key].value).toBe(0);
+      expect(metrics[key].sampleCount).toBe(0);
+      expect(metrics[key].ready).toBe(false);
+    }
+  });
+
+  it("guards divisions on a freshly constructed MetricsStore snapshot", () => {
+    const metrics = getCanonicalMetrics(store.getSnapshot());
+
+    for (const key of CANONICAL_KEYS) {
+      expect(Number.isFinite(metrics[key].value)).toBe(true);
+      expect(metrics[key].value).toBe(0);
+      expect(metrics[key].ready).toBe(false);
+    }
+  });
+});

--- a/packages/react-devtools/src/metrics/canonicalMetrics.ts
+++ b/packages/react-devtools/src/metrics/canonicalMetrics.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { MetricsSnapshot } from "../types/index.js";
+
+export interface Metric {
+  value: number;
+  sampleCount: number;
+  ready: boolean;
+  unit?: string;
+}
+
+export interface CanonicalMetrics {
+  cacheHitRate: Metric;
+  requestsSaved: Metric;
+  estimatedTimeSavedMs: Metric;
+  avgResponseMs: Metric;
+  avgCachedMs: Metric;
+  avgNetworkMs: Metric;
+  optimisticCoverage: Metric;
+  avgPerceivedSpeedupMs: Metric;
+  rollbackRate: Metric;
+}
+
+export const MIN_SAMPLES = {
+  cacheHitRate: 20,
+  latency: 5,
+  requestsSaved: 1,
+  optimisticCoverage: 3,
+  rollbackRate: 3,
+} as const;
+
+type MinSamplesGroup = keyof typeof MIN_SAMPLES;
+
+function metric(
+  value: number,
+  sampleCount: number,
+  group: MinSamplesGroup,
+  unit?: string
+): Metric {
+  const safeValue = Number.isFinite(value) ? value : 0;
+  return {
+    value: safeValue,
+    sampleCount,
+    ready: sampleCount >= MIN_SAMPLES[group],
+    unit,
+  };
+}
+
+export function getCanonicalMetrics(
+  snapshot: MetricsSnapshot
+): CanonicalMetrics {
+  const a = snapshot.aggregates;
+  const H = a.cacheHits;
+  const M = a.cacheMisses;
+  const R = a.revalidations;
+  const D = a.deduplications;
+  const A = a.actionCount;
+  const OA = a.optimisticActionCount;
+  const RB = a.rollbackActionCount;
+
+  const requestTotal = H + M + R;
+
+  const cacheHitRate = metric(
+    requestTotal > 0 ? (H + R) / requestTotal : 0,
+    requestTotal,
+    "cacheHitRate"
+  );
+
+  const requestsSavedCount = H + R + D;
+  const requestsSaved = metric(
+    requestsSavedCount,
+    requestsSavedCount,
+    "requestsSaved",
+    "requests"
+  );
+
+  const avgNetworkMs = metric(
+    a.networkResponseTime / Math.max(M, 1),
+    M,
+    "latency",
+    "ms"
+  );
+
+  const estimatedTimeSavedMs = metric(
+    requestsSaved.value * avgNetworkMs.value,
+    requestsSavedCount,
+    "requestsSaved",
+    "ms"
+  );
+
+  const avgResponseMs = metric(
+    requestTotal > 0 ? a.totalResponseTime / requestTotal : 0,
+    requestTotal,
+    "latency",
+    "ms"
+  );
+
+  const avgCachedMs = metric(
+    a.cachedResponseTime / Math.max(H, 1),
+    H,
+    "latency",
+    "ms"
+  );
+
+  const optimisticCoverage = metric(
+    A > 0 ? OA / A : 0,
+    A,
+    "optimisticCoverage"
+  );
+
+  const avgPerceivedSpeedupMs = metric(
+    a.totalPerceivedSpeedup / Math.max(OA, 1),
+    OA,
+    "latency",
+    "ms"
+  );
+
+  const rollbackRate = metric(A > 0 ? RB / A : 0, A, "rollbackRate");
+
+  return {
+    cacheHitRate,
+    requestsSaved,
+    estimatedTimeSavedMs,
+    avgResponseMs,
+    avgCachedMs,
+    avgNetworkMs,
+    optimisticCoverage,
+    avgPerceivedSpeedupMs,
+    rollbackRate,
+  };
+}

--- a/packages/react-devtools/src/plugins/baseTabs.ts
+++ b/packages/react-devtools/src/plugins/baseTabs.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DevToolsPlugin } from "./types.js";
+
+// WS-M1 (integration) fills this with the Overview/Components/Performance/Console
+// base tab objects. Kept empty here so the contract and registry land first.
+export const BASE_TABS: DevToolsPlugin[] = [];

--- a/packages/react-devtools/src/plugins/baseTabs.ts
+++ b/packages/react-devtools/src/plugins/baseTabs.ts
@@ -16,6 +16,5 @@
 
 import type { DevToolsPlugin } from "./types.js";
 
-// WS-M1 (integration) fills this with the Overview/Components/Performance/Console
-// base tab objects. Kept empty here so the contract and registry land first.
+// Populated with the base tab objects (Overview, Components, Performance, Console) when they are added.
 export const BASE_TABS: DevToolsPlugin[] = [];

--- a/packages/react-devtools/src/plugins/cache/CacheInspectorTab.test.tsx
+++ b/packages/react-devtools/src/plugins/cache/CacheInspectorTab.test.tsx
@@ -18,9 +18,12 @@ import { cleanup, render, screen } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { createMockMonitorStore } from "./testHelpers.js";
+import { createMockMonitorStore } from "../../components/testHelpers.js";
 
-const { CacheInspectorTab } = await import("./CacheInspectorTab.js");
+const { CacheInspectorTab } =
+  await import("../../components/CacheInspectorTab.js");
+const { CachePanel } = await import("./CachePanel.js");
+const { cacheTab } = await import("./cacheTab.js");
 
 describe("CacheInspectorTab", () => {
   afterEach(() => {
@@ -49,5 +52,41 @@ describe("CacheInspectorTab", () => {
     render(<CacheInspectorTab monitorStore={store} />);
 
     expect(store.loadCacheEntries).toHaveBeenCalled();
+  });
+});
+
+describe("CachePanel", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the cache inspector and drives loadCacheEntries", () => {
+    const store = createMockMonitorStore();
+
+    const { container } = render(
+      <CachePanel monitorStore={store} theme="light" />
+    );
+
+    expect(container.firstChild).not.toBeNull();
+    expect(store.loadCacheEntries).toHaveBeenCalled();
+  });
+
+  it("renders in dark theme", () => {
+    const store = createMockMonitorStore();
+
+    const { container } = render(
+      <CachePanel monitorStore={store} theme="dark" />
+    );
+
+    expect(container.firstChild).not.toBeNull();
+  });
+});
+
+describe("cacheTab", () => {
+  it("exposes the cache plugin contract", () => {
+    expect(cacheTab.id).toBe("cache");
+    expect(cacheTab.label).toBe("Cache");
+    expect(cacheTab.icon).toBe("database");
+    expect(cacheTab.panel).toBe(CachePanel);
   });
 });

--- a/packages/react-devtools/src/plugins/cache/CacheInspectorTab.test.tsx
+++ b/packages/react-devtools/src/plugins/cache/CacheInspectorTab.test.tsx
@@ -23,6 +23,7 @@ import { createMockMonitorStore } from "../../components/testHelpers.js";
 const { CacheInspectorTab } =
   await import("../../components/CacheInspectorTab.js");
 const { CachePanel } = await import("./CachePanel.js");
+const { CacheSplitView } = await import("./CacheSplitView.js");
 const { cacheTab } = await import("./cacheTab.js");
 
 describe("CacheInspectorTab", () => {
@@ -79,6 +80,22 @@ describe("CachePanel", () => {
     );
 
     expect(container.firstChild).not.toBeNull();
+  });
+});
+
+describe("CacheSplitView", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the cache inspector and the hit/miss list", () => {
+    const store = createMockMonitorStore();
+
+    render(<CacheSplitView monitorStore={store} />);
+
+    expect(store.getMetricsStore).toHaveBeenCalled();
+    expect(store.loadCacheEntries).toHaveBeenCalled();
+    expect(screen.getByText("No cache hits or misses yet")).not.toBeNull();
   });
 });
 

--- a/packages/react-devtools/src/plugins/cache/CachePanel.tsx
+++ b/packages/react-devtools/src/plugins/cache/CachePanel.tsx
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
-// Entry point for the advanced plugin tabs (cache, compute, intercept).
-export { cacheTab } from "./plugins/cache/cacheTab.js";
-export { registerDevToolsPlugin } from "./plugins/registry.js";
+import type { FC } from "react";
+
+import { CacheInspectorTab } from "../../components/CacheInspectorTab.js";
+import type { DevToolsPanelProps } from "../types.js";
+
+export const CachePanel: FC<DevToolsPanelProps> = ({ monitorStore }) => {
+  return <CacheInspectorTab monitorStore={monitorStore} />;
+};

--- a/packages/react-devtools/src/plugins/cache/CachePanel.tsx
+++ b/packages/react-devtools/src/plugins/cache/CachePanel.tsx
@@ -16,9 +16,9 @@
 
 import type { FC } from "react";
 
-import { CacheInspectorTab } from "../../components/CacheInspectorTab.js";
 import type { DevToolsPanelProps } from "../types.js";
+import { CacheSplitView } from "./CacheSplitView.js";
 
 export const CachePanel: FC<DevToolsPanelProps> = ({ monitorStore }) => {
-  return <CacheInspectorTab monitorStore={monitorStore} />;
+  return <CacheSplitView monitorStore={monitorStore} />;
 };

--- a/packages/react-devtools/src/plugins/cache/CacheSplitView.module.scss
+++ b/packages/react-devtools/src/plugins/cache/CacheSplitView.module.scss
@@ -1,0 +1,33 @@
+@use '../../components/tokens' as t;
+
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.topPane {
+  flex: 0 0 auto;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.divider {
+  flex: 0 0 6px;
+  cursor: ns-resize;
+  background: t.$border-default;
+  transition: background t.$transition-fast;
+
+  &:hover {
+    background: var(--dt-blue-resize-hover);
+  }
+}
+
+.bottomPane {
+  flex: 1 1 0;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}

--- a/packages/react-devtools/src/plugins/cache/CacheSplitView.tsx
+++ b/packages/react-devtools/src/plugins/cache/CacheSplitView.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useCallback, useRef } from "react";
+
+import { CacheInspectorTab } from "../../components/CacheInspectorTab.js";
+import { usePersistedState } from "../../hooks/usePersistedState.js";
+import type { MonitorStore } from "../../store/MonitorStore.js";
+import { CacheTimeline } from "./CacheTimeline.js";
+
+import styles from "./CacheSplitView.module.scss";
+
+const MIN_FRACTION = 0.2;
+const MAX_FRACTION = 0.8;
+
+export interface CacheSplitViewProps {
+  monitorStore: MonitorStore;
+}
+
+/**
+ * The Cache tab layout: the cache-entry inspector on top and a live cache
+ * hit/miss list on the bottom, separated by a draggable divider whose position
+ * is persisted.
+ */
+export const CacheSplitView: React.FC<CacheSplitViewProps> = ({
+  monitorStore,
+}) => {
+  const metricsStore = monitorStore.getMetricsStore();
+  const [splitFraction, setSplitFraction] = usePersistedState<number>(
+    "osdk-cache-split",
+    0.5
+  );
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isDragging = useRef(false);
+  const dragAbortRef = useRef<AbortController | null>(null);
+  const setSplitFractionRef = useRef(setSplitFraction);
+  setSplitFractionRef.current = setSplitFraction;
+
+  const attachDragListeners = useCallback(() => {
+    dragAbortRef.current?.abort();
+    const controller = new AbortController();
+    dragAbortRef.current = controller;
+    const { signal } = controller;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!isDragging.current) {
+        return;
+      }
+      const container = containerRef.current;
+      if (!container) {
+        return;
+      }
+      const rect = container.getBoundingClientRect();
+      if (rect.height === 0) {
+        return;
+      }
+      const fraction = (e.clientY - rect.top) / rect.height;
+      const clamped = Math.max(MIN_FRACTION, Math.min(MAX_FRACTION, fraction));
+      setSplitFractionRef.current(clamped);
+    };
+
+    const handleMouseUp = () => {
+      isDragging.current = false;
+      controller.abort();
+      dragAbortRef.current = null;
+    };
+
+    document.addEventListener("mousemove", handleMouseMove, { signal });
+    document.addEventListener("mouseup", handleMouseUp, { signal });
+  }, []);
+
+  const handleDividerMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      isDragging.current = true;
+      e.preventDefault();
+      attachDragListeners();
+    },
+    [attachDragListeners]
+  );
+
+  return (
+    <div ref={containerRef} className={styles.container}>
+      <div
+        className={styles.topPane}
+        style={{ flexBasis: `${splitFraction * 100}%` }}
+      >
+        <CacheInspectorTab monitorStore={monitorStore} />
+      </div>
+      <div className={styles.divider} onMouseDown={handleDividerMouseDown} />
+      <div className={styles.bottomPane}>
+        <CacheTimeline
+          metricsStore={metricsStore}
+          monitorStore={monitorStore}
+        />
+      </div>
+    </div>
+  );
+};

--- a/packages/react-devtools/src/plugins/cache/CacheTimeline.module.scss
+++ b/packages/react-devtools/src/plugins/cache/CacheTimeline.module.scss
@@ -1,0 +1,78 @@
+@use '../../components/tokens' as t;
+@use '../../components/mixins' as m;
+
+.operationsList {
+  flex: 1;
+  overflow: auto;
+  @include m.dt-scrollbar;
+}
+
+.operationItem {
+  @include m.dt-list-item;
+  padding: 6px 12px;
+}
+
+.operationType {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: t.$radius-sm;
+  font-size: t.$font-size-xs;
+  font-weight: t.$font-weight-bold;
+  color: t.$bg-base;
+  flex-shrink: 0;
+
+  &.cacheHit {
+    background: t.$green;
+  }
+
+  &.cacheMiss {
+    background: t.$red;
+  }
+}
+
+.operationDetails {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.operationSignature {
+  font-size: t.$font-size-base;
+  font-family: t.$font-mono;
+  color: t.$text-primary;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.operationTime {
+  font-size: t.$font-size-xs;
+  color: t.$text-tertiary;
+  font-family: t.$font-mono;
+}
+
+.operationMetric {
+  font-size: t.$font-size-sm;
+  font-weight: t.$font-weight-semi;
+  font-family: t.$font-mono;
+  color: t.$text-secondary;
+  padding: 1px 4px;
+  background: t.$bg-hover;
+  border-radius: t.$radius-sm;
+}
+
+.operationMetrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.emptyState {
+  @include m.dt-empty-state;
+  font-size: t.$font-size-base;
+}

--- a/packages/react-devtools/src/plugins/cache/CacheTimeline.tsx
+++ b/packages/react-devtools/src/plugins/cache/CacheTimeline.tsx
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from "classnames";
+import React, { useMemo } from "react";
+
+import { createPollingStore } from "../../hooks/createPollingStore.js";
+import { useMetrics } from "../../hooks/useMetrics.js";
+import type { MetricsStore } from "../../store/MetricsStore.js";
+import type { MonitorStore } from "../../store/MonitorStore.js";
+import type { Operation } from "../../types/index.js";
+import { formatTime } from "../../utils/format.js";
+
+import styles from "./CacheTimeline.module.scss";
+
+const MAX_RECENT_OPERATIONS = 50;
+
+export interface CacheTimelineProps {
+  metricsStore: MetricsStore;
+  monitorStore: MonitorStore;
+}
+
+/**
+ * A live list of cache-hit and cache-miss operations. Deliberately limited to
+ * those two operation types — no revalidation, deduplication, optimistic, or
+ * action rows.
+ */
+export const CacheTimeline: React.FC<CacheTimelineProps> = ({
+  metricsStore,
+  monitorStore,
+}) => {
+  const metrics = useMetrics(metricsStore);
+
+  const enrichmentStore = React.useMemo(
+    () =>
+      createPollingStore(async () => {
+        const cacheEntries = await monitorStore.loadCacheEntries();
+        return { cacheEntries };
+      }, 2000),
+    [monitorStore]
+  );
+  const enrichmentData = React.useSyncExternalStore(
+    enrichmentStore.subscribe,
+    enrichmentStore.getSnapshot
+  );
+  const cacheEntries = enrichmentData?.cacheEntries ?? [];
+
+  const displayNameMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const entry of cacheEntries) {
+      if (entry.data && typeof entry.data === "object") {
+        const data = entry.data as Record<string, unknown>;
+        const primaryKey = data.$primaryKey;
+        const objectType = data.$objectType ?? entry.objectType;
+        const displayName =
+          data.title ??
+          data.name ??
+          data.label ??
+          data.displayName ??
+          data.description;
+        if (
+          typeof displayName === "string" &&
+          displayName.length > 0 &&
+          (typeof primaryKey === "string" || typeof primaryKey === "number") &&
+          typeof objectType === "string"
+        ) {
+          map.set(`${objectType}:${String(primaryKey)}`, displayName);
+        }
+      }
+    }
+    return map;
+  }, [cacheEntries]);
+
+  const getDisplayNameKey = (signature: string): string | null => {
+    const parts = signature.split(":");
+    if (parts.length >= 3 && parts[0] === "object") {
+      return `${parts[1]}:${parts.slice(2).join(":")}`;
+    }
+    return null;
+  };
+
+  const operations = useMemo(
+    () =>
+      metrics.recent
+        .filter((op) => op.type === "cache-hit" || op.type === "cache-miss")
+        .slice(-MAX_RECENT_OPERATIONS)
+        .reverse(),
+    [metrics.recent]
+  );
+
+  return (
+    <div className={styles.operationsList}>
+      {operations.length > 0 ? (
+        operations.map((op) => {
+          const displayKey = getDisplayNameKey(op.signature);
+          return (
+            <OperationItem
+              key={op.id}
+              operation={op}
+              formatTime={formatTime}
+              displayName={
+                displayKey ? displayNameMap.get(displayKey) : undefined
+              }
+            />
+          );
+        })
+      ) : (
+        <div className={styles.emptyState}>No cache hits or misses yet</div>
+      )}
+    </div>
+  );
+};
+
+const OPERATION_DISPLAY: Record<
+  "cache-hit" | "cache-miss",
+  { icon: string; class: string; tooltip: string }
+> = {
+  "cache-hit": {
+    icon: "✓",
+    class: styles.cacheHit,
+    tooltip: "Cache hit — served from cache",
+  },
+  "cache-miss": {
+    icon: "×",
+    class: styles.cacheMiss,
+    tooltip: "Cache miss — fetched from network",
+  },
+};
+
+interface OperationItemProps {
+  operation: Operation;
+  formatTime: (ms: number) => string;
+  displayName?: string;
+}
+
+const OperationItem: React.FC<OperationItemProps> = ({
+  operation,
+  formatTime,
+  displayName,
+}) => {
+  const getEnrichedSignature = (): string => {
+    if (displayName) {
+      const parts = operation.signature.split(":");
+      if (parts.length >= 2) {
+        const objectType = parts[1];
+        const truncatedName =
+          displayName.length > 20
+            ? `${displayName.slice(0, 20)}…`
+            : displayName;
+        return `${objectType}: ${truncatedName}`;
+      }
+    }
+    return operation.signature;
+  };
+
+  const isHit = operation.type === "cache-hit";
+  const display = isHit
+    ? OPERATION_DISPLAY["cache-hit"]
+    : OPERATION_DISPLAY["cache-miss"];
+
+  return (
+    <div className={styles.operationItem}>
+      <span
+        className={classNames(styles.operationType, display.class)}
+        title={display.tooltip}
+      >
+        {display.icon}
+      </span>
+      <div className={styles.operationDetails}>
+        <div className={styles.operationSignature}>
+          {getEnrichedSignature()}
+        </div>
+        <div className={styles.operationTime}>
+          {new Date(operation.timestamp).toLocaleTimeString()}
+        </div>
+        {operation.responseTime != null && (
+          <div className={styles.operationMetrics}>
+            <span className={styles.operationMetric}>
+              {formatTime(operation.responseTime)}
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/packages/react-devtools/src/plugins/cache/cacheTab.ts
+++ b/packages/react-devtools/src/plugins/cache/cacheTab.ts
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
-// Entry point for the advanced plugin tabs (cache, compute, intercept).
-export { cacheTab } from "./plugins/cache/cacheTab.js";
-export { registerDevToolsPlugin } from "./plugins/registry.js";
+import type { DevToolsPlugin } from "../types.js";
+import { CachePanel } from "./CachePanel.js";
+
+export const cacheTab: DevToolsPlugin = {
+  id: "cache",
+  label: "Cache",
+  icon: "database",
+  panel: CachePanel,
+};

--- a/packages/react-devtools/src/plugins/index.ts
+++ b/packages/react-devtools/src/plugins/index.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { BASE_TABS } from "./baseTabs.js";
+export {
+  getRegisteredPlugins,
+  registerDevToolsPlugin,
+  subscribePlugins,
+} from "./registry.js";
+export type {
+  DevToolsPanelComponent,
+  DevToolsPanelProps,
+  DevToolsPlugin,
+} from "./types.js";
+export { useDevToolsTabs } from "./useDevToolsTabs.js";

--- a/packages/react-devtools/src/plugins/registry.test.ts
+++ b/packages/react-devtools/src/plugins/registry.test.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getRegisteredPlugins,
+  registerDevToolsPlugin,
+  subscribePlugins,
+} from "./registry.js";
+import type { DevToolsPlugin } from "./types.js";
+
+const GLOBAL_STORE_KEY = "__OSDK_DEVTOOLS_MONITOR_STORE__";
+
+function makePlugin(
+  id: string,
+  overrides?: Partial<DevToolsPlugin>
+): DevToolsPlugin {
+  return {
+    id,
+    label: id,
+    icon: "cube",
+    panel: () => null,
+    ...overrides,
+  };
+}
+
+function setGlobalStoreStub(): void {
+  (globalThis as Record<string, unknown>)[GLOBAL_STORE_KEY] = {
+    getMetricsStore() {},
+    getComputeStore() {},
+  };
+}
+
+const cleanups: Array<() => void> = [];
+
+function track(unregister: () => void): () => void {
+  cleanups.push(unregister);
+  return unregister;
+}
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups.length = 0;
+  Reflect.deleteProperty(globalThis, GLOBAL_STORE_KEY);
+});
+
+describe("registry", () => {
+  it("register makes a plugin appear in getRegisteredPlugins", () => {
+    const plugin = makePlugin("appears");
+    track(registerDevToolsPlugin(plugin));
+    expect(getRegisteredPlugins()).toContain(plugin);
+  });
+
+  it("ignores a duplicate id and returns a no-op unregister", () => {
+    const first = makePlugin("dup", { label: "first" });
+    const second = makePlugin("dup", { label: "second" });
+    track(registerDevToolsPlugin(first));
+    const unregisterDuplicate = registerDevToolsPlugin(second);
+
+    const plugins = getRegisteredPlugins();
+    expect(plugins.filter((plugin) => plugin.id === "dup")).toHaveLength(1);
+    expect(plugins).toContain(first);
+    expect(plugins).not.toContain(second);
+
+    unregisterDuplicate();
+    expect(getRegisteredPlugins()).toContain(first);
+  });
+
+  it("unregister removes the plugin", () => {
+    const plugin = makePlugin("removable");
+    const unregister = registerDevToolsPlugin(plugin);
+    expect(getRegisteredPlugins()).toContain(plugin);
+
+    unregister();
+    expect(getRegisteredPlugins()).not.toContain(plugin);
+  });
+
+  it("notifies subscribers on register and on unregister", () => {
+    const callback = vi.fn();
+    const unsubscribe = subscribePlugins(callback);
+
+    const unregister = registerDevToolsPlugin(makePlugin("notify"));
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    unregister();
+    expect(callback).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+  });
+
+  it("calls init exactly once on register when the global store is present", () => {
+    setGlobalStoreStub();
+    const init = vi.fn();
+    track(registerDevToolsPlugin(makePlugin("with-store", { init })));
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call init and does not throw when the global store is absent", () => {
+    const init = vi.fn();
+    expect(() => {
+      track(registerDevToolsPlugin(makePlugin("no-store", { init })));
+    }).not.toThrow();
+    expect(init).not.toHaveBeenCalled();
+  });
+
+  it("returns a stable snapshot reference that only changes on mutation", () => {
+    const initial = getRegisteredPlugins();
+    expect(getRegisteredPlugins()).toBe(initial);
+
+    const unregister = registerDevToolsPlugin(makePlugin("snapshot"));
+    const afterRegister = getRegisteredPlugins();
+    expect(afterRegister).not.toBe(initial);
+    expect(getRegisteredPlugins()).toBe(afterRegister);
+
+    unregister();
+    const afterUnregister = getRegisteredPlugins();
+    expect(afterUnregister).not.toBe(afterRegister);
+  });
+});

--- a/packages/react-devtools/src/plugins/registry.ts
+++ b/packages/react-devtools/src/plugins/registry.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { MonitorStore } from "../store/MonitorStore.js";
+import type { DevToolsPlugin } from "./types.js";
+
+const GLOBAL_STORE_KEY = "__OSDK_DEVTOOLS_MONITOR_STORE__";
+
+function getGlobalMonitorStore(): MonitorStore | undefined {
+  if (typeof globalThis !== "undefined" && GLOBAL_STORE_KEY in globalThis) {
+    const candidate = (globalThis as Record<string, unknown>)[GLOBAL_STORE_KEY];
+    if (
+      typeof candidate === "object" &&
+      candidate != null &&
+      "getMetricsStore" in candidate &&
+      "getComputeStore" in candidate
+    ) {
+      return candidate as MonitorStore;
+    }
+  }
+  return undefined;
+}
+
+const registered: DevToolsPlugin[] = [];
+const listeners = new Set<() => void>();
+
+let snapshot: readonly DevToolsPlugin[] = [];
+
+function rebuildSnapshot(): void {
+  snapshot = [...registered];
+}
+
+function notifyListeners(): void {
+  for (const listener of listeners) {
+    try {
+      listener();
+    } catch {
+      // don't let a bad listener break the others
+    }
+  }
+}
+
+export function registerDevToolsPlugin(plugin: DevToolsPlugin): () => void {
+  if (registered.some((existing) => existing.id === plugin.id)) {
+    return () => {};
+  }
+
+  registered.push(plugin);
+  rebuildSnapshot();
+
+  const store = getGlobalMonitorStore();
+  if (store) {
+    plugin.init?.(store);
+  }
+
+  notifyListeners();
+
+  return () => {
+    const index = registered.indexOf(plugin);
+    if (index === -1) {
+      return;
+    }
+    registered.splice(index, 1);
+    rebuildSnapshot();
+
+    const disposeStore = getGlobalMonitorStore();
+    if (disposeStore) {
+      plugin.dispose?.(disposeStore);
+    }
+
+    notifyListeners();
+  };
+}
+
+export function getRegisteredPlugins(): readonly DevToolsPlugin[] {
+  return snapshot;
+}
+
+export function subscribePlugins(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}

--- a/packages/react-devtools/src/plugins/types.ts
+++ b/packages/react-devtools/src/plugins/types.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ComponentType } from "react";
+
+import type { MonitorStore } from "../store/MonitorStore.js";
+
+export interface DevToolsPanelProps {
+  monitorStore: MonitorStore;
+  theme: "light" | "dark";
+}
+export type DevToolsPanelComponent = ComponentType<DevToolsPanelProps>;
+
+export interface DevToolsPlugin {
+  id: string; // stable; persistence + active-tab key, e.g. "cache"
+  label: string; // tab-bar label
+  icon: string; // Blueprint icon name
+  panel: DevToolsPanelComponent; // mounted only while its tab is active
+  init?: (monitorStore: MonitorStore) => void; // idempotent wiring; no-op in v1
+  dispose?: (monitorStore: MonitorStore) => void;
+  activateOnView?: boolean; // default true
+}

--- a/packages/react-devtools/src/plugins/useDevToolsTabs.ts
+++ b/packages/react-devtools/src/plugins/useDevToolsTabs.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo, useSyncExternalStore } from "react";
+
+import { BASE_TABS } from "./baseTabs.js";
+import { getRegisteredPlugins, subscribePlugins } from "./registry.js";
+import type { DevToolsPlugin } from "./types.js";
+
+export function useDevToolsTabs(): readonly DevToolsPlugin[] {
+  const plugins = useSyncExternalStore(subscribePlugins, getRegisteredPlugins);
+
+  return useMemo(() => {
+    const seen = new Set<string>();
+    const deduped: DevToolsPlugin[] = [];
+    for (const plugin of [...BASE_TABS, ...plugins]) {
+      if (seen.has(plugin.id)) {
+        continue;
+      }
+      seen.add(plugin.id);
+      deduped.push(plugin);
+    }
+    return deduped;
+  }, [plugins]);
+}

--- a/packages/react-devtools/src/public/advanced.ts
+++ b/packages/react-devtools/src/public/advanced.ts
@@ -15,5 +15,5 @@
  */
 
 // Entry point for the advanced plugin tabs (cache, compute, intercept).
-export { cacheTab } from "./plugins/cache/cacheTab.js";
-export { registerDevToolsPlugin } from "./plugins/registry.js";
+export { cacheTab } from "../plugins/cache/cacheTab.js";
+export { registerDevToolsPlugin } from "../plugins/registry.js";

--- a/packages/react-devtools/src/recommendations/__snapshots__/copyPrompt.test.ts.snap
+++ b/packages/react-devtools/src/recommendations/__snapshots__/copyPrompt.test.ts.snap
@@ -1,0 +1,65 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`buildCopyAllPrompt > matches the full combined template 1`] = `
+"Here are 2 OSDK optimizations, ordered by priority:
+
+1. You are helping optimize an app built with the OSDK React Toolkit (@osdk/react).
+
+ISSUE: First (Performance, severity: high)
+WHY IT MATTERS: This component fetches 12 properties but only uses 3
+EXPECTED IMPACT: Save 4.2KB bandwidth per load
+
+SUGGESTED FIX:
+Use $select to only fetch used properties
+
+OSDK GUIDANCE:
+Avoid sequential data dependencies. Prefer a single query (using $select, links, or an object set) over chained hooks that wait on one another, so the toolkit can resolve data in parallel.
+
+TASK: Apply the suggested fix at the location above. Keep behavior identical except for the optimization. If the file/line is approximate, search for the matching hook call.
+
+---
+
+2. You are helping optimize an app built with the OSDK React Toolkit (@osdk/react).
+
+ISSUE: Second (Cache, severity: high)
+WHY IT MATTERS: This component fetches 12 properties but only uses 3
+EXPECTED IMPACT: Save 4.2KB bandwidth per load
+
+LOCATION: src/B.tsx:9
+
+SUGGESTED FIX:
+Use $select to only fetch used properties
+
+OSDK GUIDANCE:
+Reuse shared object sets and query keys so the toolkit can serve cached results instead of refetching. Avoid recreating query inputs on every render.
+
+TASK: Apply the suggested fix at the location above. Keep behavior identical except for the optimization. If the file/line is approximate, search for the matching hook call."
+`;
+
+exports[`buildCopyPrompt > renders the full template for a fully-populated recommendation 1`] = `
+"You are helping optimize an app built with the OSDK React Toolkit (@osdk/react).
+
+ISSUE: EmployeeCard fetches unused data (Bandwidth, severity: high)
+WHY IT MATTERS: This component fetches 12 properties but only uses 3
+EXPECTED IMPACT: Save 4.2KB bandwidth per load
+
+LOCATION: src/components/EmployeeCard.tsx:42
+
+CURRENT CODE:
+\`\`\`tsx
+const { object } = useOsdkObject(Employee, id);
+\`\`\`
+
+SUGGESTED FIX:
+Use $select to only fetch used properties
+\`\`\`tsx
+const { object } = useOsdkObject(Employee, id, {
+  $select: ["name"]
+});
+\`\`\`
+
+OSDK GUIDANCE:
+Use $select to fetch only the properties a component reads.
+
+TASK: Apply the suggested fix at the location above. Keep behavior identical except for the optimization. If the file/line is approximate, search for the matching hook call."
+`;

--- a/packages/react-devtools/src/recommendations/copyPrompt.test.ts
+++ b/packages/react-devtools/src/recommendations/copyPrompt.test.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { Recommendation } from "../utils/PerformanceRecommendationEngine.js";
+import { OSDK_GUIDANCE_BY_CATEGORY } from "../utils/PerformanceRecommendationEngine.js";
+import { buildCopyAllPrompt, buildCopyPrompt } from "./copyPrompt.js";
+
+function makeRec(overrides: Partial<Recommendation> = {}): Recommendation {
+  return {
+    id: "rec-1",
+    level: "high",
+    category: "Bandwidth",
+    title: "EmployeeCard fetches unused data",
+    description: "This component fetches 12 properties but only uses 3",
+    impact: "Save 4.2KB bandwidth per load",
+    effort: "Low",
+    suggestion: "Use $select to only fetch used properties",
+    dismissible: true,
+    ...overrides,
+  };
+}
+
+describe("buildCopyPrompt", () => {
+  it("renders the full template for a fully-populated recommendation", () => {
+    const rec = makeRec({
+      filePath: "src/components/EmployeeCard.tsx",
+      lineNumber: 42,
+      currentCode: "const { object } = useOsdkObject(Employee, id);",
+      code: 'const { object } = useOsdkObject(Employee, id, {\n  $select: ["name"]\n});',
+      osdkGuidance:
+        "Use $select to fetch only the properties a component reads.",
+    });
+
+    expect(buildCopyPrompt(rec)).toMatchSnapshot();
+  });
+
+  it("always renders intro, issue, suggestion, guidance and task sections", () => {
+    const prompt = buildCopyPrompt(makeRec());
+
+    expect(prompt).toContain("OSDK React Toolkit");
+    expect(prompt).toContain(
+      "ISSUE: EmployeeCard fetches unused data (Bandwidth, severity: high)"
+    );
+    expect(prompt).toContain(
+      "WHY IT MATTERS: This component fetches 12 properties but only uses 3"
+    );
+    expect(prompt).toContain("EXPECTED IMPACT: Save 4.2KB bandwidth per load");
+    expect(prompt).toContain(
+      "SUGGESTED FIX:\nUse $select to only fetch used properties"
+    );
+    expect(prompt).toContain("OSDK GUIDANCE:");
+    expect(prompt).toContain("TASK: Apply the suggested fix");
+  });
+
+  it("omits the LOCATION line when filePath is absent", () => {
+    expect(buildCopyPrompt(makeRec())).not.toContain("LOCATION:");
+  });
+
+  it("renders LOCATION with line number when both filePath and lineNumber are present", () => {
+    const prompt = buildCopyPrompt(
+      makeRec({ filePath: "src/A.tsx", lineNumber: 17 })
+    );
+
+    expect(prompt).toContain("LOCATION: src/A.tsx:17");
+  });
+
+  it("renders LOCATION without a line suffix when only filePath is present", () => {
+    const prompt = buildCopyPrompt(makeRec({ filePath: "src/A.tsx" }));
+
+    expect(prompt).toContain("LOCATION: src/A.tsx");
+    expect(prompt).not.toContain("src/A.tsx:");
+  });
+
+  it("includes lineNumber 0 in the LOCATION line", () => {
+    const prompt = buildCopyPrompt(
+      makeRec({ filePath: "src/A.tsx", lineNumber: 0 })
+    );
+
+    expect(prompt).toContain("LOCATION: src/A.tsx:0");
+  });
+
+  it("omits the CURRENT CODE block when currentCode is absent", () => {
+    expect(buildCopyPrompt(makeRec())).not.toContain("CURRENT CODE:");
+  });
+
+  it("renders a fenced CURRENT CODE block when currentCode is present", () => {
+    const prompt = buildCopyPrompt(makeRec({ currentCode: "const x = 1;" }));
+
+    expect(prompt).toContain("CURRENT CODE:\n```tsx\nconst x = 1;\n```");
+  });
+
+  it("renders the suggestion without a code fence when code is absent", () => {
+    const prompt = buildCopyPrompt(makeRec());
+
+    expect(prompt).toContain(
+      "SUGGESTED FIX:\nUse $select to only fetch used properties"
+    );
+    expect(prompt).not.toContain("```tsx");
+  });
+
+  it("appends a fenced code block under SUGGESTED FIX when code is present", () => {
+    const prompt = buildCopyPrompt(makeRec({ code: "const y = 2;" }));
+
+    expect(prompt).toContain(
+      "SUGGESTED FIX:\nUse $select to only fetch used properties\n```tsx\nconst y = 2;\n```"
+    );
+  });
+
+  it("prefers the recommendation's own osdkGuidance when provided", () => {
+    const prompt = buildCopyPrompt(
+      makeRec({ osdkGuidance: "Custom guidance for this rec." })
+    );
+
+    expect(prompt).toContain("OSDK GUIDANCE:\nCustom guidance for this rec.");
+  });
+
+  it("falls back to the category guidance when osdkGuidance is absent", () => {
+    const prompt = buildCopyPrompt(makeRec({ category: "Cache" }));
+
+    expect(prompt).toContain(
+      `OSDK GUIDANCE:\n${OSDK_GUIDANCE_BY_CATEGORY.Cache}`
+    );
+  });
+});
+
+describe("buildCopyAllPrompt", () => {
+  it("renders the count preamble", () => {
+    const prompt = buildCopyAllPrompt([makeRec(), makeRec({ id: "rec-2" })]);
+
+    expect(prompt).toContain(
+      "Here are 2 OSDK optimizations, ordered by priority:"
+    );
+  });
+
+  it("numbers each recommendation and separates them with a horizontal rule", () => {
+    const prompt = buildCopyAllPrompt([
+      makeRec({ id: "rec-1", title: "First" }),
+      makeRec({ id: "rec-2", title: "Second" }),
+    ]);
+
+    expect(prompt).toContain("1. You are helping optimize");
+    expect(prompt).toContain("2. You are helping optimize");
+    expect(prompt).toContain("\n\n---\n\n");
+  });
+
+  it("matches the full combined template", () => {
+    const recs = [
+      makeRec({ id: "rec-1", title: "First", category: "Performance" }),
+      makeRec({
+        id: "rec-2",
+        title: "Second",
+        category: "Cache",
+        filePath: "src/B.tsx",
+        lineNumber: 9,
+      }),
+    ];
+
+    expect(buildCopyAllPrompt(recs)).toMatchSnapshot();
+  });
+});

--- a/packages/react-devtools/src/recommendations/copyPrompt.ts
+++ b/packages/react-devtools/src/recommendations/copyPrompt.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Recommendation } from "../utils/PerformanceRecommendationEngine.js";
+import { OSDK_GUIDANCE_BY_CATEGORY } from "../utils/PerformanceRecommendationEngine.js";
+
+const INTRO =
+  "You are helping optimize an app built with the OSDK React Toolkit (@osdk/react).";
+
+const TASK =
+  "TASK: Apply the suggested fix at the location above. Keep behavior identical except for the optimization. If the file/line is approximate, search for the matching hook call.";
+
+/**
+ * Builds an AI-ready prompt for a single performance recommendation. Sections
+ * with no data are omitted cleanly so the output stays reproducible.
+ */
+export function buildCopyPrompt(rec: Recommendation): string {
+  const sections: string[] = [
+    INTRO,
+    [
+      `ISSUE: ${rec.title} (${rec.category}, severity: ${rec.level})`,
+      `WHY IT MATTERS: ${rec.description}`,
+      `EXPECTED IMPACT: ${rec.impact}`,
+    ].join("\n"),
+  ];
+
+  if (rec.filePath) {
+    const location =
+      rec.lineNumber != null
+        ? `${rec.filePath}:${rec.lineNumber}`
+        : rec.filePath;
+    sections.push(`LOCATION: ${location}`);
+  }
+
+  if (rec.currentCode) {
+    sections.push(`CURRENT CODE:\n\`\`\`tsx\n${rec.currentCode}\n\`\`\``);
+  }
+
+  sections.push(
+    rec.code
+      ? `SUGGESTED FIX:\n${rec.suggestion}\n\`\`\`tsx\n${rec.code}\n\`\`\``
+      : `SUGGESTED FIX:\n${rec.suggestion}`
+  );
+
+  const guidance = rec.osdkGuidance ?? OSDK_GUIDANCE_BY_CATEGORY[rec.category];
+  sections.push(`OSDK GUIDANCE:\n${guidance}`);
+
+  sections.push(TASK);
+
+  return sections.join("\n\n");
+}
+
+/**
+ * Builds a single combined prompt covering several recommendations, ordered as
+ * given. Each recommendation is numbered and the entries are separated by a
+ * horizontal rule.
+ */
+export function buildCopyAllPrompt(recs: Recommendation[]): string {
+  const preamble = `Here are ${recs.length} OSDK optimizations, ordered by priority:`;
+  const items = recs.map((rec, i) => `${i + 1}. ${buildCopyPrompt(rec)}`);
+  return `${preamble}\n\n${items.join("\n\n---\n\n")}`;
+}

--- a/packages/react-devtools/src/utils/PerformanceRecommendationEngine.ts
+++ b/packages/react-devtools/src/utils/PerformanceRecommendationEngine.ts
@@ -47,7 +47,25 @@ export interface Recommendation {
   suggestion: string;
   code?: string;
   dismissible: boolean;
+  filePath?: string;
+  lineNumber?: number;
+  currentCode?: string;
+  osdkGuidance?: string;
 }
+
+export const OSDK_GUIDANCE_BY_CATEGORY: Record<RecommendationCategory, string> =
+  {
+    Performance:
+      "Avoid sequential data dependencies. Prefer a single query (using $select, links, or an object set) over chained hooks that wait on one another, so the toolkit can resolve data in parallel.",
+    Bandwidth:
+      "Use $select to fetch only the properties a component reads. The toolkit caches and revalidates per-property, so narrower selections reduce payload size and unnecessary refetches.",
+    "Code Quality":
+      "Keep query definitions colocated with the component that consumes them and request only the data you render. Lean queries are easier for the toolkit to cache and dedupe.",
+    Cache:
+      "Reuse shared object sets and query keys so the toolkit can serve cached results instead of refetching. Avoid recreating query inputs on every render.",
+    Queries:
+      "Consolidate overlapping queries. The toolkit deduplicates identical query signatures, so aligning inputs lets multiple components share one subscription.",
+  };
 
 export interface PerformanceScore {
   overall: number; // 0-100
@@ -108,6 +126,7 @@ export class PerformanceRecommendationEngine {
         suggestion: wf.suggestion,
         code: wf.code,
         dismissible: true,
+        osdkGuidance: OSDK_GUIDANCE_BY_CATEGORY.Performance,
       });
     }
 
@@ -118,6 +137,11 @@ export class PerformanceRecommendationEngine {
       ) {
         continue;
       }
+
+      const subscribers = this.registry.getQuerySubscribers(
+        offender.querySignature
+      );
+      const locatedBinding = subscribers.find((b) => b.filePath);
 
       recommendations.push({
         id: `field-${offender.querySignature}`,
@@ -132,6 +156,9 @@ export class PerformanceRecommendationEngine {
         suggestion: "Use $select to only fetch used properties",
         code: offender.suggestion,
         dismissible: true,
+        filePath: locatedBinding?.filePath,
+        lineNumber: locatedBinding?.lineNumber,
+        osdkGuidance: OSDK_GUIDANCE_BY_CATEGORY.Bandwidth,
       });
     }
 
@@ -152,6 +179,7 @@ export class PerformanceRecommendationEngine {
           effort: "Medium",
           suggestion: rec.suggestion,
           dismissible: true,
+          osdkGuidance: OSDK_GUIDANCE_BY_CATEGORY.Cache,
         });
       }
     }


### PR DESCRIPTION
wraps the existing cache inspector as an opt-in advanced plugin

• new cache plugin in src/plugins/cache/ that wraps CacheInspectorTab and conforms to DevToolsPanelProps
• plugin is exported from the /advanced subpath for consumers to opt-in via registerDevToolsPlugin
• polling scoped to panel mount/unmount lifecycle and hit rates sourced from canonical metrics