### PR TITLE
expose intercept as an opt-in devtools plugin

### DIFF
--- a/.changeset/canonical-metrics.md
+++ b/.changeset/canonical-metrics.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+Add a canonical, request-based metrics source (getCanonicalMetrics + useCanonicalMetrics) that derives the nine shared devtools metrics from a MetricsSnapshot and gates each one behind a per-metric sample-count readiness flag so cold-start values no longer read as broken

--- a/.changeset/copy-prompt-button.md
+++ b/.changeset/copy-prompt-button.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+add copy-prompt builder and CopyPromptButton for actionable performance recommendations

--- a/.changeset/devtools-plugin-registry.md
+++ b/.changeset/devtools-plugin-registry.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+Add the devtools plugin contract (DevToolsPlugin/DevToolsPanelProps), a subscribable global plugin registry, the useDevToolsTabs hook, and the ./advanced entrypoint so base tabs and advanced plugins share one shape.

--- a/.changeset/devtools-query-params-format.md
+++ b/.changeset/devtools-query-params-format.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+add human-readable query param formatter for devtools component/performance tabs

--- a/.changeset/intercept-plugin.md
+++ b/.changeset/intercept-plugin.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+expose the intercept tab as an opt-in devtools plugin via the advanced entry point

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -15,6 +15,13 @@
       },
       "default": "./build/esm/index.js"
     },
+    "./advanced": {
+      "import": {
+        "types": "./build/types/advanced.d.ts",
+        "default": "./build/esm/advanced.js"
+      },
+      "default": "./build/esm/advanced.js"
+    },
     "./vite": {
       "import": {
         "types": "./build/types/public/vite.d.ts",

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -17,10 +17,10 @@
     },
     "./advanced": {
       "import": {
-        "types": "./build/types/advanced.d.ts",
-        "default": "./build/esm/advanced.js"
+        "types": "./build/types/public/advanced.d.ts",
+        "default": "./build/esm/public/advanced.js"
       },
-      "default": "./build/esm/advanced.js"
+      "default": "./build/esm/public/advanced.js"
     },
     "./vite": {
       "import": {

--- a/packages/react-devtools/src/advanced.ts
+++ b/packages/react-devtools/src/advanced.ts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-// WS-P1/P2/P3 + WS-M1 populate this entrypoint with cacheTab/computeTab/interceptTab.
+// Entry point for the advanced plugin tabs (cache, compute, intercept). Populated when those tabs are added.
 // eslint-disable-next-line unicorn/require-module-specifiers -- placeholder empty module until advanced plugins land
 export {};

--- a/packages/react-devtools/src/advanced.ts
+++ b/packages/react-devtools/src/advanced.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// WS-P1/P2/P3 + WS-M1 populate this entrypoint with cacheTab/computeTab/interceptTab.
+// eslint-disable-next-line unicorn/require-module-specifiers -- placeholder empty module until advanced plugins land
+export {};

--- a/packages/react-devtools/src/components/CopyPromptButton.test.tsx
+++ b/packages/react-devtools/src/components/CopyPromptButton.test.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildCopyAllPrompt,
+  buildCopyPrompt,
+} from "../recommendations/copyPrompt.js";
+import type { Recommendation } from "../utils/PerformanceRecommendationEngine.js";
+
+const { CopyPromptButton } = await import("./CopyPromptButton.js");
+
+function makeRec(overrides: Partial<Recommendation> = {}): Recommendation {
+  return {
+    id: "rec-1",
+    level: "high",
+    category: "Bandwidth",
+    title: "EmployeeCard fetches unused data",
+    description: "This component fetches 12 properties but only uses 3",
+    impact: "Save 4.2KB bandwidth per load",
+    effort: "Low",
+    suggestion: "Use $select to only fetch used properties",
+    dismissible: true,
+    ...overrides,
+  };
+}
+
+const writeText = vi.fn<(text: string) => Promise<void>>();
+
+beforeEach(() => {
+  writeText.mockReset();
+  writeText.mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+async function flushMicrotasks(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe("CopyPromptButton", () => {
+  it("copies the single-recommendation prompt and flips the icon to tick", async () => {
+    const rec = makeRec({ filePath: "src/A.tsx", lineNumber: 7 });
+
+    const { container } = render(<CopyPromptButton recommendation={rec} />);
+
+    expect(container.querySelector('[data-icon="clipboard"]')).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button"));
+    await flushMicrotasks();
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText).toHaveBeenCalledWith(buildCopyPrompt(rec));
+    expect(container.querySelector('[data-icon="tick"]')).not.toBeNull();
+    expect(container.querySelector('[data-icon="clipboard"]')).toBeNull();
+  });
+
+  it("copies the combined prompt for multiple recommendations", async () => {
+    const recs = [makeRec({ id: "rec-1" }), makeRec({ id: "rec-2" })];
+
+    render(<CopyPromptButton recommendations={recs} />);
+
+    fireEvent.click(screen.getByRole("button"));
+    await flushMicrotasks();
+
+    expect(writeText).toHaveBeenCalledWith(buildCopyAllPrompt(recs));
+  });
+
+  it("resets the icon back to clipboard after the timeout elapses", async () => {
+    vi.useFakeTimers();
+    const rec = makeRec();
+
+    const { container } = render(<CopyPromptButton recommendation={rec} />);
+
+    fireEvent.click(screen.getByRole("button"));
+    await flushMicrotasks();
+
+    expect(container.querySelector('[data-icon="tick"]')).not.toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(container.querySelector('[data-icon="tick"]')).toBeNull();
+    expect(container.querySelector('[data-icon="clipboard"]')).not.toBeNull();
+  });
+
+  it("defaults to the single label and respects an override", () => {
+    const { rerender } = render(
+      <CopyPromptButton recommendation={makeRec()} />
+    );
+
+    expect(screen.getByText("Copy prompt")).not.toBeNull();
+
+    rerender(
+      <CopyPromptButton recommendation={makeRec()} label="Fix it for me" />
+    );
+
+    expect(screen.getByText("Fix it for me")).not.toBeNull();
+  });
+
+  it("defaults to the copy-all label for multiple recommendations", () => {
+    render(<CopyPromptButton recommendations={[makeRec()]} />);
+
+    expect(screen.getByText("Copy all")).not.toBeNull();
+  });
+});

--- a/packages/react-devtools/src/components/CopyPromptButton.tsx
+++ b/packages/react-devtools/src/components/CopyPromptButton.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button } from "@blueprintjs/core";
+import React, { useCallback, useRef, useState } from "react";
+
+import {
+  buildCopyAllPrompt,
+  buildCopyPrompt,
+} from "../recommendations/copyPrompt.js";
+import type { Recommendation } from "../utils/PerformanceRecommendationEngine.js";
+
+export type CopyPromptButtonProps =
+  | { recommendation: Recommendation; label?: string }
+  | { recommendations: Recommendation[]; label?: string };
+
+export const CopyPromptButton: React.FC<CopyPromptButtonProps> = (props) => {
+  const [copied, setCopied] = useState(false);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const isSingle = "recommendation" in props;
+  const prompt = isSingle
+    ? buildCopyPrompt(props.recommendation)
+    : buildCopyAllPrompt(props.recommendations);
+  const label = props.label ?? (isSingle ? "Copy prompt" : "Copy all");
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(prompt);
+      setCopied(true);
+      clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard writes can reject (e.g. denied permission); ignore silently.
+    }
+  }, [prompt]);
+
+  return (
+    <Button
+      variant="minimal"
+      size="small"
+      icon={copied ? "tick" : "clipboard"}
+      onClick={() => void handleCopy()}
+    >
+      {label}
+    </Button>
+  );
+};

--- a/packages/react-devtools/src/components/InterceptTab.tsx
+++ b/packages/react-devtools/src/components/InterceptTab.tsx
@@ -21,6 +21,13 @@ import { createPollingStore } from "../hooks/createPollingStore.js";
 import { useInspectorSelection } from "../hooks/useInspectorSelection.js";
 import type { MockResponse } from "../mocking/MockManager.js";
 import type {
+  HydrateOverrideFormParams,
+  InterceptAction,
+  MockConfiguration,
+  MockWithConfig,
+  SelectedQuery,
+} from "../plugins/intercept/types.js";
+import type {
   PrototypeOverride,
   PrototypeOverrideParams,
 } from "../prototyping/PrototypeOverrideStore.js";
@@ -79,32 +86,6 @@ function parseJsonField<T>(
   }
 }
 
-export interface MockConfiguration {
-  primitive: SelectedPrimitive;
-  mockType: "static" | "function" | "passthrough";
-  responseType: "success" | "error";
-  usePayload?: boolean;
-  payload?: string;
-  useResponse?: boolean;
-  staticData?: string;
-  functionCode?: string;
-  errorMessage?: string;
-  enabled: boolean;
-}
-
-export interface SelectedQuery {
-  componentId: string;
-  componentName: string;
-  objectType: string;
-  hookType: string;
-  hookIndex: number;
-  originalParams: PrototypeOverrideParams;
-  querySignature: string;
-  isAggregation?: boolean;
-}
-
-type MockWithConfig = MockResponse & { config: MockConfiguration };
-
 interface InterceptState {
   selectedPrimitive: SelectedPrimitive | null;
   mocks: Array<MockWithConfig>;
@@ -161,51 +142,6 @@ const initialState: InterceptState = {
   choosingPrimitive: null,
   error: null,
 };
-
-export type InterceptAction =
-  | { type: "SET_SELECTED_PRIMITIVE"; primitive: SelectedPrimitive | null }
-  | { type: "SET_MOCKS"; mocks: Array<MockWithConfig> }
-  | {
-      type: "UPDATE_MOCKS";
-      updater: (prev: Array<MockWithConfig>) => Array<MockWithConfig>;
-    }
-  | { type: "SET_EDITING_MOCK"; mock: MockWithConfig | null }
-  | { type: "SET_MOCK_TYPE"; mockType: MockConfiguration["mockType"] }
-  | {
-      type: "SET_RESPONSE_TYPE";
-      responseType: MockConfiguration["responseType"];
-    }
-  | { type: "SET_USE_PAYLOAD"; usePayload: boolean }
-  | { type: "SET_MOCK_PAYLOAD"; mockPayload: string }
-  | { type: "SET_USE_RESPONSE"; useResponse: boolean }
-  | { type: "SET_STATIC_DATA"; staticData: string }
-  | { type: "SET_FUNCTION_CODE"; functionCode: string }
-  | { type: "SET_ERROR_MESSAGE"; errorMessage: string }
-  | { type: "SET_SELECTED_QUERY"; query: SelectedQuery | null }
-  | { type: "SET_ACTIVE_OVERRIDES"; overrides: PrototypeOverride[] }
-  | { type: "SET_WHERE_CLAUSE_TEXT"; text: string }
-  | { type: "SET_ORDER_BY_TEXT"; text: string }
-  | { type: "SET_PAGE_SIZE"; pageSize: number | undefined }
-  | { type: "SET_GROUP_BY_TEXT"; text: string }
-  | { type: "SET_SELECT_TEXT"; text: string }
-  | { type: "SET_CHOOSING_PRIMITIVE"; primitive: SelectedPrimitive | null }
-  | { type: "SET_ERROR"; error: string | null }
-  | { type: "HYDRATE_OVERRIDE_FORM"; params: HydrateOverrideFormParams }
-  | { type: "INIT_MOCK_FORM_FROM_CONFIG"; config: MockConfiguration }
-  | { type: "INIT_MOCK_FORM_FROM_PRIMITIVE"; primitive: SelectedPrimitive }
-  | { type: "SELECT_PRIMITIVE_FOR_MOCK"; primitive: SelectedPrimitive }
-  | { type: "CANCEL_MOCK_EDITOR" }
-  | { type: "CLEAR_SELECTION" }
-  | { type: "SAVE_MOCK_DONE" };
-
-interface HydrateOverrideFormParams {
-  isAggregation: boolean;
-  where?: unknown;
-  orderBy?: unknown;
-  pageSize?: number;
-  groupBy?: unknown;
-  select?: unknown;
-}
 
 function hydrateOverrideFields(
   params: HydrateOverrideFormParams

--- a/packages/react-devtools/src/components/MockEditor.tsx
+++ b/packages/react-devtools/src/components/MockEditor.tsx
@@ -28,7 +28,10 @@ import {
 import React from "react";
 
 import type { MockResponse } from "../mocking/MockManager.js";
-import type { InterceptAction, MockConfiguration } from "./InterceptTab.js";
+import type {
+  InterceptAction,
+  MockConfiguration,
+} from "../plugins/intercept/types.js";
 import type { SelectedPrimitive } from "./PrimitiveSelectionPanel.js";
 
 import styles from "./InterceptTab.module.scss";

--- a/packages/react-devtools/src/components/OverrideEditor.tsx
+++ b/packages/react-devtools/src/components/OverrideEditor.tsx
@@ -18,8 +18,11 @@ import { Button, FormGroup, Icon, NumericInput } from "@blueprintjs/core";
 import type { ReactCodeMirrorProps } from "@uiw/react-codemirror";
 import React, { Suspense } from "react";
 
+import type {
+  InterceptAction,
+  SelectedQuery,
+} from "../plugins/intercept/types.js";
 import type { PrototypeOverride } from "../prototyping/PrototypeOverrideStore.js";
-import type { InterceptAction, SelectedQuery } from "./InterceptTab.js";
 
 import styles from "./InterceptTab.module.scss";
 

--- a/packages/react-devtools/src/components/queryParamsFormat.test.ts
+++ b/packages/react-devtools/src/components/queryParamsFormat.test.ts
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type {
+  ComponentHookBinding,
+  QueryParams,
+} from "../utils/ComponentQueryRegistry.js";
+import { formatHookSignature, formatQueryParams } from "./queryParamsFormat.js";
+
+function makeBinding(queryParams: QueryParams): ComponentHookBinding {
+  return {
+    componentId: "c1",
+    componentName: "Demo",
+    hookType: "useOsdkObjects",
+    hookIndex: 0,
+    subscriptionId: "s1",
+    querySignature: "sig",
+    queryParams,
+    stackTrace: "",
+    mountedAt: 0,
+    renderCount: 1,
+    lastRenderDuration: 0,
+    avgRenderDuration: 0,
+  };
+}
+
+describe("formatQueryParams", () => {
+  describe("object", () => {
+    it("renders the primary key", () => {
+      expect(
+        formatQueryParams({
+          type: "object",
+          objectType: "Parcel",
+          primaryKey: "123",
+        })
+      ).toBe("pk 123");
+    });
+
+    it("returns empty string when the primary key is empty", () => {
+      expect(
+        formatQueryParams({
+          type: "object",
+          objectType: "Parcel",
+          primaryKey: "",
+        })
+      ).toBe("");
+    });
+  });
+
+  describe("list", () => {
+    it("renders where, orderBy, and pageSize", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { status: "active" },
+          orderBy: { createdAt: "desc" },
+          pageSize: 50,
+        })
+      ).toBe('where status = "active" · orderBy createdAt desc · pageSize 50');
+    });
+
+    it("renders operator where clauses", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { age: { $gte: 21 } },
+        })
+      ).toBe("where age >= 21");
+    });
+
+    it("renders $and clauses", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { $and: [{ status: "active" }, { region: "west" }] },
+        })
+      ).toBe('where status = "active" and region = "west"');
+    });
+
+    it("renders $or clauses", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { $or: [{ status: "active" }, { status: "pending" }] },
+        })
+      ).toBe('where status = "active" or status = "pending"');
+    });
+
+    it("renders $not clauses", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { $not: { status: "active" } },
+        })
+      ).toBe('where not (status = "active")');
+    });
+
+    it("renders $isNull true and false", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { closedAt: { $isNull: true } },
+        })
+      ).toBe("where closedAt is null");
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { closedAt: { $isNull: false } },
+        })
+      ).toBe("where closedAt is not null");
+    });
+
+    it("renders $in clauses", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: { status: { $in: ["active", "pending"] } },
+        })
+      ).toBe('where status in ["active","pending"]');
+    });
+
+    it("returns empty string for an empty where clause and no other detail", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+          where: {},
+        })
+      ).toBe("");
+    });
+
+    it("returns empty string when where and orderBy are undefined", () => {
+      expect(
+        formatQueryParams({
+          type: "list",
+          objectType: "Parcel",
+        })
+      ).toBe("");
+    });
+  });
+
+  describe("aggregation", () => {
+    it("renders where and aggregate", () => {
+      expect(
+        formatQueryParams({
+          type: "aggregation",
+          objectType: "Employee",
+          where: { dept: "eng" },
+          aggregate: { "salary:avg": "unordered" },
+        })
+      ).toBe('where dept = "eng" · aggregate salary:avg');
+    });
+
+    it("returns empty string when nothing is set", () => {
+      expect(
+        formatQueryParams({
+          type: "aggregation",
+          objectType: "Employee",
+        })
+      ).toBe("");
+    });
+  });
+
+  describe("objectSet", () => {
+    it("renders operation labels", () => {
+      expect(
+        formatQueryParams({
+          type: "objectSet",
+          baseObjectSet: "Employees",
+          operations: [{ type: "filter" }, { type: "pivotTo" }],
+        })
+      ).toBe("filter, pivotTo");
+    });
+
+    it("returns empty string when there are no operations", () => {
+      expect(
+        formatQueryParams({
+          type: "objectSet",
+          baseObjectSet: "Employees",
+          operations: [],
+        })
+      ).toBe("");
+    });
+  });
+
+  describe("action", () => {
+    it("returns empty string", () => {
+      expect(
+        formatQueryParams({ type: "action", actionName: "createTask" })
+      ).toBe("");
+    });
+  });
+
+  describe("links", () => {
+    it("returns empty string", () => {
+      expect(
+        formatQueryParams({
+          type: "links",
+          sourceObject: "Parcel",
+          linkName: "tasks",
+        })
+      ).toBe("");
+    });
+  });
+});
+
+describe("formatHookSignature", () => {
+  it("renders the documented example exactly", () => {
+    expect(
+      formatHookSignature(
+        makeBinding({
+          type: "list",
+          objectType: "Parcel",
+          where: { status: "active" },
+          orderBy: { createdAt: "desc" },
+        })
+      )
+    ).toBe('Parcel · where status = "active" · orderBy createdAt desc');
+  });
+
+  it("renders object signatures", () => {
+    expect(
+      formatHookSignature(
+        makeBinding({ type: "object", objectType: "Parcel", primaryKey: "123" })
+      )
+    ).toBe("Parcel · pk 123");
+  });
+
+  it("renders a list with no detail as just the type name", () => {
+    expect(
+      formatHookSignature(makeBinding({ type: "list", objectType: "Parcel" }))
+    ).toBe("Parcel");
+  });
+
+  it("renders action signatures using the action name", () => {
+    expect(
+      formatHookSignature(
+        makeBinding({ type: "action", actionName: "createTask" })
+      )
+    ).toBe("createTask");
+  });
+
+  it("renders link signatures with the arrow notation", () => {
+    expect(
+      formatHookSignature(
+        makeBinding({
+          type: "links",
+          sourceObject: "Parcel",
+          linkName: "tasks",
+        })
+      )
+    ).toBe("Parcel → tasks");
+  });
+
+  it("renders aggregation signatures", () => {
+    expect(
+      formatHookSignature(
+        makeBinding({
+          type: "aggregation",
+          objectType: "Employee",
+          where: { dept: "eng" },
+          aggregate: { "salary:avg": "unordered" },
+        })
+      )
+    ).toBe('Employee · where dept = "eng" · aggregate salary:avg');
+  });
+
+  it("renders objectSet signatures", () => {
+    expect(
+      formatHookSignature(
+        makeBinding({
+          type: "objectSet",
+          baseObjectSet: "Employees",
+          operations: [{ type: "filter" }],
+        })
+      )
+    ).toBe("Employees · filter");
+  });
+});

--- a/packages/react-devtools/src/components/queryParamsFormat.ts
+++ b/packages/react-devtools/src/components/queryParamsFormat.ts
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  ComponentHookBinding,
+  QueryParams,
+} from "../utils/ComponentQueryRegistry.js";
+
+const SEPARATOR = " · ";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != null && !Array.isArray(value);
+}
+
+function formatValue(value: unknown): string {
+  const json = JSON.stringify(value);
+  return json === undefined ? "" : json;
+}
+
+function isOperatorObject(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const keys = Object.keys(value);
+  return keys.length > 0 && keys.every((key) => key.startsWith("$"));
+}
+
+function formatSingleOperator(
+  field: string,
+  op: string,
+  value: unknown
+): string {
+  switch (op) {
+    case "$eq": {
+      return `${field} = ${formatValue(value)}`;
+    }
+    case "$ne": {
+      return `${field} != ${formatValue(value)}`;
+    }
+    case "$gt": {
+      return `${field} > ${formatValue(value)}`;
+    }
+    case "$gte": {
+      return `${field} >= ${formatValue(value)}`;
+    }
+    case "$lt": {
+      return `${field} < ${formatValue(value)}`;
+    }
+    case "$lte": {
+      return `${field} <= ${formatValue(value)}`;
+    }
+    case "$isNull": {
+      return value === true ? `${field} is null` : `${field} is not null`;
+    }
+    case "$contains": {
+      return `${field} contains ${formatValue(value)}`;
+    }
+    case "$startsWith": {
+      return `${field} startsWith ${formatValue(value)}`;
+    }
+    case "$in": {
+      return `${field} in ${formatValue(value)}`;
+    }
+    default: {
+      return `${field} ${op} ${formatValue(value)}`;
+    }
+  }
+}
+
+function formatOperator(
+  field: string,
+  operator: Record<string, unknown>
+): string {
+  const parts: string[] = [];
+  for (const op of Object.keys(operator)) {
+    parts.push(formatSingleOperator(field, op, operator[op]));
+  }
+  return parts.join(", ");
+}
+
+function joinSubClauses(clauses: unknown[], joiner: string): string {
+  const rendered = clauses
+    .map((clause) => formatWhereClause(clause))
+    .filter(Boolean);
+  return rendered.join(joiner);
+}
+
+function formatWhereClause(where: unknown): string {
+  if (!isRecord(where)) {
+    return "";
+  }
+  if (Array.isArray(where.$and)) {
+    return joinSubClauses(where.$and, " and ");
+  }
+  if (Array.isArray(where.$or)) {
+    return joinSubClauses(where.$or, " or ");
+  }
+  if (where.$not !== undefined) {
+    const inner = formatWhereClause(where.$not);
+    return inner ? `not (${inner})` : "";
+  }
+  const parts: string[] = [];
+  for (const key of Object.keys(where)) {
+    const value = where[key];
+    if (isOperatorObject(value)) {
+      parts.push(formatOperator(key, value));
+    } else {
+      parts.push(`${key} = ${formatValue(value)}`);
+    }
+  }
+  return parts.join(", ");
+}
+
+function formatOrderBy(orderBy: unknown): string {
+  if (!isRecord(orderBy)) {
+    return "";
+  }
+  const parts: string[] = [];
+  for (const field of Object.keys(orderBy)) {
+    const direction = orderBy[field];
+    if (typeof direction === "string") {
+      parts.push(`${field} ${direction}`);
+    } else {
+      parts.push(field);
+    }
+  }
+  return parts.join(", ");
+}
+
+function formatAggregate(aggregate: unknown): string {
+  if (typeof aggregate === "string") {
+    return aggregate;
+  }
+  if (!isRecord(aggregate)) {
+    return "";
+  }
+  return Object.keys(aggregate).join(", ");
+}
+
+function formatObjectSetOperations(operations: unknown[]): string {
+  const labels = operations.map((operation) => {
+    if (isRecord(operation) && typeof operation.type === "string") {
+      return operation.type;
+    }
+    return "operation";
+  });
+  return labels.join(", ");
+}
+
+export function formatQueryParams(params: QueryParams): string {
+  switch (params.type) {
+    case "object": {
+      return params.primaryKey ? `pk ${params.primaryKey}` : "";
+    }
+    case "list": {
+      const parts: string[] = [];
+      const whereClause = formatWhereClause(params.where);
+      if (whereClause) {
+        parts.push(`where ${whereClause}`);
+      }
+      const orderByClause = formatOrderBy(params.orderBy);
+      if (orderByClause) {
+        parts.push(`orderBy ${orderByClause}`);
+      }
+      if (params.pageSize !== undefined) {
+        parts.push(`pageSize ${params.pageSize}`);
+      }
+      return parts.join(SEPARATOR);
+    }
+    case "aggregation": {
+      const parts: string[] = [];
+      const whereClause = formatWhereClause(params.where);
+      if (whereClause) {
+        parts.push(`where ${whereClause}`);
+      }
+      const aggregateClause = formatAggregate(params.aggregate);
+      if (aggregateClause) {
+        parts.push(`aggregate ${aggregateClause}`);
+      }
+      return parts.join(SEPARATOR);
+    }
+    case "objectSet": {
+      return formatObjectSetOperations(params.operations);
+    }
+    case "action": {
+      return "";
+    }
+    case "links": {
+      return "";
+    }
+    default: {
+      return "";
+    }
+  }
+}
+
+function getTypeName(params: QueryParams): string {
+  switch (params.type) {
+    case "object":
+    case "list":
+    case "aggregation": {
+      return params.objectType;
+    }
+    case "action": {
+      return params.actionName;
+    }
+    case "links": {
+      return `${params.sourceObject} → ${params.linkName}`;
+    }
+    case "objectSet": {
+      return params.baseObjectSet;
+    }
+    default: {
+      return "";
+    }
+  }
+}
+
+export function formatHookSignature(binding: ComponentHookBinding): string {
+  const typeName = getTypeName(binding.queryParams);
+  return [typeName, formatQueryParams(binding.queryParams)]
+    .filter(Boolean)
+    .join(SEPARATOR);
+}

--- a/packages/react-devtools/src/hooks/useCanonicalMetrics.ts
+++ b/packages/react-devtools/src/hooks/useCanonicalMetrics.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+
+import type { CanonicalMetrics } from "../metrics/canonicalMetrics.js";
+import { getCanonicalMetrics } from "../metrics/canonicalMetrics.js";
+import type { MonitorStore } from "../store/MonitorStore.js";
+
+export function useCanonicalMetrics(
+  monitorStore: MonitorStore
+): CanonicalMetrics {
+  const store = monitorStore.getMetricsStore();
+  const subscribe = useCallback(
+    (callback: () => void) => store.subscribe(callback),
+    [store]
+  );
+  const getSnapshot = useCallback(() => store.getSnapshot(), [store]);
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  return useMemo(() => getCanonicalMetrics(snapshot), [snapshot]);
+}

--- a/packages/react-devtools/src/index.ts
+++ b/packages/react-devtools/src/index.ts
@@ -34,8 +34,15 @@ export {
   useComputeRecording,
   useComputeRequests,
 } from "./hooks/useComputeSelectors.js";
+export { useCanonicalMetrics } from "./hooks/useCanonicalMetrics.js";
 export { useMetrics } from "./hooks/useMetrics.js";
 export { usePersistedState } from "./hooks/usePersistedState.js";
+
+export {
+  getCanonicalMetrics,
+  MIN_SAMPLES,
+} from "./metrics/canonicalMetrics.js";
+export type { CanonicalMetrics, Metric } from "./metrics/canonicalMetrics.js";
 
 export type { Fiber } from "./fiber/types.js";
 export { ComputeStore } from "./store/ComputeStore.js";

--- a/packages/react-devtools/src/metrics/canonicalMetrics.test.ts
+++ b/packages/react-devtools/src/metrics/canonicalMetrics.test.ts
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MetricsStore } from "../store/MetricsStore.js";
+import type {
+  AggregateMetrics,
+  MetricRates,
+  MetricsSnapshot,
+} from "../types/index.js";
+import type { CanonicalMetrics } from "./canonicalMetrics.js";
+import { getCanonicalMetrics, MIN_SAMPLES } from "./canonicalMetrics.js";
+
+function flushMicrotasksAndTimers(): void {
+  vi.advanceTimersByTime(0);
+}
+
+function zeroAggregates(): AggregateMetrics {
+  return {
+    cacheHits: 0,
+    cacheMisses: 0,
+    deduplications: 0,
+    optimisticUpdates: 0,
+    totalResponseTime: 0,
+    cachedResponseTime: 0,
+    networkResponseTime: 0,
+    requestsSaved: 0,
+    bytesServedFromCache: 0,
+    totalObjectsFromCache: 0,
+    totalObjectsFromNetwork: 0,
+    actionCount: 0,
+    configuredOptimisticActionCount: 0,
+    optimisticActionCount: 0,
+    rollbackActionCount: 0,
+    totalOptimisticRenderTime: 0,
+    totalServerRoundTripTime: 0,
+    totalPerceivedSpeedup: 0,
+    totalOptimisticObjectsAffected: 0,
+    revalidations: 0,
+    validationCount: 0,
+    totalValidationTime: 0,
+  };
+}
+
+function zeroRates(): MetricRates {
+  return {
+    cacheHitRate: 0,
+    deduplicationRate: 0,
+    optimisticUpdateRate: 0,
+    averageResponseTime: 0,
+    averageCachedResponseTime: 0,
+    optimisticActionCoverage: 0,
+    configuredOptimisticActionRate: 0,
+    rollbackRate: 0,
+    averageOptimisticRenderTime: 0,
+    averageServerRoundTripTime: 0,
+    averagePerceivedSpeedup: 0,
+    averageValidationTime: 0,
+    validationTimeSaved: 0,
+  };
+}
+
+function makeSnapshot(overrides: Partial<AggregateMetrics>): MetricsSnapshot {
+  return {
+    recent: [],
+    aggregates: { ...zeroAggregates(), ...overrides },
+    rates: zeroRates(),
+    timeSeries: {
+      timestamps: [],
+      cacheHits: [],
+      cacheMisses: [],
+      revalidations: [],
+      deduplications: [],
+    },
+  };
+}
+
+const CANONICAL_KEYS: ReadonlyArray<keyof CanonicalMetrics> = [
+  "avgCachedMs",
+  "avgNetworkMs",
+  "avgPerceivedSpeedupMs",
+  "avgResponseMs",
+  "cacheHitRate",
+  "estimatedTimeSavedMs",
+  "optimisticCoverage",
+  "requestsSaved",
+  "rollbackRate",
+];
+
+describe("getCanonicalMetrics", () => {
+  let store: MetricsStore;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+
+    if (globalThis.requestIdleCallback === undefined) {
+      globalThis.requestIdleCallback = ((cb: IdleRequestCallback) => {
+        return setTimeout(
+          () =>
+            cb({
+              didTimeout: false,
+              timeRemaining: () => 50,
+            }),
+          0
+        ) as unknown as number;
+      }) as typeof globalThis.requestIdleCallback;
+      globalThis.cancelIdleCallback = ((id: number) => {
+        clearTimeout(id);
+      }) as typeof globalThis.cancelIdleCallback;
+    }
+
+    store = new MetricsStore(100, 10);
+  });
+
+  afterEach(() => {
+    store.dispose();
+    vi.useRealTimers();
+  });
+
+  it("exposes exactly the nine canonical metric keys", () => {
+    const metrics = getCanonicalMetrics(makeSnapshot({}));
+    expect(Object.keys(metrics).sort()).toEqual([...CANONICAL_KEYS]);
+  });
+
+  it("locks the MIN_SAMPLES thresholds", () => {
+    expect(MIN_SAMPLES).toEqual({
+      cacheHitRate: 20,
+      latency: 5,
+      requestsSaved: 1,
+      optimisticCoverage: 3,
+      rollbackRate: 3,
+    });
+  });
+
+  it("matches MetricsStore.getCacheHitRate() for the request-based formula", () => {
+    for (let i = 0; i < 14; i++) {
+      store.recordCacheHit(`hit-${i}`, 5);
+    }
+    for (let i = 0; i < 4; i++) {
+      store.recordCacheMiss(`miss-${i}`, 100);
+    }
+    for (let i = 0; i < 2; i++) {
+      store.recordRevalidation(`reval-${i}`, 80);
+    }
+    flushMicrotasksAndTimers();
+
+    const snapshot = store.getSnapshot();
+    const metrics = getCanonicalMetrics(snapshot);
+
+    expect(metrics.cacheHitRate.value).toBeCloseTo(store.getCacheHitRate());
+    expect(metrics.cacheHitRate.value).toBeCloseTo((14 + 2) / 20);
+    expect(metrics.cacheHitRate.sampleCount).toBe(20);
+    expect(metrics.cacheHitRate.ready).toBe(true);
+  });
+
+  it("assigns request and millisecond units", () => {
+    const metrics = getCanonicalMetrics(
+      makeSnapshot({ cacheHits: 5, revalidations: 3, deduplications: 2 })
+    );
+
+    expect(metrics.requestsSaved.unit).toBe("requests");
+    expect(metrics.estimatedTimeSavedMs.unit).toBe("ms");
+    expect(metrics.avgNetworkMs.unit).toBe("ms");
+    expect(metrics.avgResponseMs.unit).toBe("ms");
+    expect(metrics.avgCachedMs.unit).toBe("ms");
+    expect(metrics.avgPerceivedSpeedupMs.unit).toBe("ms");
+    expect(metrics.cacheHitRate.unit).toBeUndefined();
+    expect(metrics.optimisticCoverage.unit).toBeUndefined();
+    expect(metrics.rollbackRate.unit).toBeUndefined();
+  });
+
+  it("computes requestsSaved and derives estimatedTimeSavedMs from it", () => {
+    const metrics = getCanonicalMetrics(
+      makeSnapshot({
+        cacheHits: 10,
+        cacheMisses: 5,
+        networkResponseTime: 500,
+      })
+    );
+
+    expect(metrics.avgNetworkMs.value).toBeCloseTo(100);
+    expect(metrics.requestsSaved.value).toBe(10);
+    expect(metrics.estimatedTimeSavedMs.value).toBeCloseTo(1000);
+    expect(metrics.estimatedTimeSavedMs.sampleCount).toBe(10);
+  });
+
+  it("gates cacheHitRate readiness at the twenty-sample threshold", () => {
+    const below = getCanonicalMetrics(makeSnapshot({ cacheHits: 19 }));
+    expect(below.cacheHitRate.sampleCount).toBe(19);
+    expect(below.cacheHitRate.ready).toBe(false);
+
+    const atThreshold = getCanonicalMetrics(makeSnapshot({ cacheHits: 20 }));
+    expect(atThreshold.cacheHitRate.sampleCount).toBe(20);
+    expect(atThreshold.cacheHitRate.ready).toBe(true);
+  });
+
+  it("gates latency metrics at the five-sample threshold", () => {
+    const below = getCanonicalMetrics(
+      makeSnapshot({ cacheMisses: 4, networkResponseTime: 400 })
+    );
+    expect(below.avgNetworkMs.ready).toBe(false);
+
+    const atThreshold = getCanonicalMetrics(
+      makeSnapshot({ cacheMisses: 5, networkResponseTime: 500 })
+    );
+    expect(atThreshold.avgNetworkMs.ready).toBe(true);
+    expect(atThreshold.avgNetworkMs.value).toBeCloseTo(100);
+  });
+
+  it("gates requestsSaved at the single-sample threshold", () => {
+    expect(getCanonicalMetrics(makeSnapshot({})).requestsSaved.ready).toBe(
+      false
+    );
+    expect(
+      getCanonicalMetrics(makeSnapshot({ cacheHits: 1 })).requestsSaved.ready
+    ).toBe(true);
+  });
+
+  it("gates optimistic coverage and rollback rate at the three-sample threshold", () => {
+    const below = getCanonicalMetrics(
+      makeSnapshot({
+        actionCount: 2,
+        optimisticActionCount: 1,
+        rollbackActionCount: 1,
+      })
+    );
+    expect(below.optimisticCoverage.ready).toBe(false);
+    expect(below.rollbackRate.ready).toBe(false);
+
+    const atThreshold = getCanonicalMetrics(
+      makeSnapshot({
+        actionCount: 3,
+        optimisticActionCount: 3,
+        rollbackActionCount: 0,
+      })
+    );
+    expect(atThreshold.optimisticCoverage.ready).toBe(true);
+    expect(atThreshold.optimisticCoverage.value).toBeCloseTo(1);
+    expect(atThreshold.rollbackRate.ready).toBe(true);
+    expect(atThreshold.rollbackRate.value).toBeCloseTo(0);
+  });
+
+  it("guards every division to a finite zero and stays not-ready on a zeroed snapshot", () => {
+    const metrics = getCanonicalMetrics(makeSnapshot({}));
+
+    for (const key of CANONICAL_KEYS) {
+      expect(Number.isFinite(metrics[key].value)).toBe(true);
+      expect(metrics[key].value).toBe(0);
+      expect(metrics[key].sampleCount).toBe(0);
+      expect(metrics[key].ready).toBe(false);
+    }
+  });
+
+  it("guards divisions on a freshly constructed MetricsStore snapshot", () => {
+    const metrics = getCanonicalMetrics(store.getSnapshot());
+
+    for (const key of CANONICAL_KEYS) {
+      expect(Number.isFinite(metrics[key].value)).toBe(true);
+      expect(metrics[key].value).toBe(0);
+      expect(metrics[key].ready).toBe(false);
+    }
+  });
+});

--- a/packages/react-devtools/src/metrics/canonicalMetrics.ts
+++ b/packages/react-devtools/src/metrics/canonicalMetrics.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { MetricsSnapshot } from "../types/index.js";
+
+export interface Metric {
+  value: number;
+  sampleCount: number;
+  ready: boolean;
+  unit?: string;
+}
+
+export interface CanonicalMetrics {
+  cacheHitRate: Metric;
+  requestsSaved: Metric;
+  estimatedTimeSavedMs: Metric;
+  avgResponseMs: Metric;
+  avgCachedMs: Metric;
+  avgNetworkMs: Metric;
+  optimisticCoverage: Metric;
+  avgPerceivedSpeedupMs: Metric;
+  rollbackRate: Metric;
+}
+
+export const MIN_SAMPLES = {
+  cacheHitRate: 20,
+  latency: 5,
+  requestsSaved: 1,
+  optimisticCoverage: 3,
+  rollbackRate: 3,
+} as const;
+
+type MinSamplesGroup = keyof typeof MIN_SAMPLES;
+
+function metric(
+  value: number,
+  sampleCount: number,
+  group: MinSamplesGroup,
+  unit?: string
+): Metric {
+  const safeValue = Number.isFinite(value) ? value : 0;
+  return {
+    value: safeValue,
+    sampleCount,
+    ready: sampleCount >= MIN_SAMPLES[group],
+    unit,
+  };
+}
+
+export function getCanonicalMetrics(
+  snapshot: MetricsSnapshot
+): CanonicalMetrics {
+  const a = snapshot.aggregates;
+  const H = a.cacheHits;
+  const M = a.cacheMisses;
+  const R = a.revalidations;
+  const D = a.deduplications;
+  const A = a.actionCount;
+  const OA = a.optimisticActionCount;
+  const RB = a.rollbackActionCount;
+
+  const requestTotal = H + M + R;
+
+  const cacheHitRate = metric(
+    requestTotal > 0 ? (H + R) / requestTotal : 0,
+    requestTotal,
+    "cacheHitRate"
+  );
+
+  const requestsSavedCount = H + R + D;
+  const requestsSaved = metric(
+    requestsSavedCount,
+    requestsSavedCount,
+    "requestsSaved",
+    "requests"
+  );
+
+  const avgNetworkMs = metric(
+    a.networkResponseTime / Math.max(M, 1),
+    M,
+    "latency",
+    "ms"
+  );
+
+  const estimatedTimeSavedMs = metric(
+    requestsSaved.value * avgNetworkMs.value,
+    requestsSavedCount,
+    "requestsSaved",
+    "ms"
+  );
+
+  const avgResponseMs = metric(
+    requestTotal > 0 ? a.totalResponseTime / requestTotal : 0,
+    requestTotal,
+    "latency",
+    "ms"
+  );
+
+  const avgCachedMs = metric(
+    a.cachedResponseTime / Math.max(H, 1),
+    H,
+    "latency",
+    "ms"
+  );
+
+  const optimisticCoverage = metric(
+    A > 0 ? OA / A : 0,
+    A,
+    "optimisticCoverage"
+  );
+
+  const avgPerceivedSpeedupMs = metric(
+    a.totalPerceivedSpeedup / Math.max(OA, 1),
+    OA,
+    "latency",
+    "ms"
+  );
+
+  const rollbackRate = metric(A > 0 ? RB / A : 0, A, "rollbackRate");
+
+  return {
+    cacheHitRate,
+    requestsSaved,
+    estimatedTimeSavedMs,
+    avgResponseMs,
+    avgCachedMs,
+    avgNetworkMs,
+    optimisticCoverage,
+    avgPerceivedSpeedupMs,
+    rollbackRate,
+  };
+}

--- a/packages/react-devtools/src/plugins/baseTabs.ts
+++ b/packages/react-devtools/src/plugins/baseTabs.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DevToolsPlugin } from "./types.js";
+
+// WS-M1 (integration) fills this with the Overview/Components/Performance/Console
+// base tab objects. Kept empty here so the contract and registry land first.
+export const BASE_TABS: DevToolsPlugin[] = [];

--- a/packages/react-devtools/src/plugins/baseTabs.ts
+++ b/packages/react-devtools/src/plugins/baseTabs.ts
@@ -16,6 +16,5 @@
 
 import type { DevToolsPlugin } from "./types.js";
 
-// WS-M1 (integration) fills this with the Overview/Components/Performance/Console
-// base tab objects. Kept empty here so the contract and registry land first.
+// Populated with the base tab objects (Overview, Components, Performance, Console) when they are added.
 export const BASE_TABS: DevToolsPlugin[] = [];

--- a/packages/react-devtools/src/plugins/index.ts
+++ b/packages/react-devtools/src/plugins/index.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { BASE_TABS } from "./baseTabs.js";
+export {
+  getRegisteredPlugins,
+  registerDevToolsPlugin,
+  subscribePlugins,
+} from "./registry.js";
+export type {
+  DevToolsPanelComponent,
+  DevToolsPanelProps,
+  DevToolsPlugin,
+} from "./types.js";
+export { useDevToolsTabs } from "./useDevToolsTabs.js";

--- a/packages/react-devtools/src/plugins/intercept/InterceptPanel.test.tsx
+++ b/packages/react-devtools/src/plugins/intercept/InterceptPanel.test.tsx
@@ -18,11 +18,11 @@ import { cleanup, render, screen } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { createMockMonitorStore } from "./testHelpers.js";
+import { createMockMonitorStore } from "../../components/testHelpers.js";
 
-const { InterceptTab } = await import("./InterceptTab.js");
+const { InterceptPanel } = await import("./InterceptPanel.js");
 
-describe("InterceptTab", () => {
+describe("InterceptPanel", () => {
   afterEach(() => {
     cleanup();
   });
@@ -30,7 +30,9 @@ describe("InterceptTab", () => {
   it("renders without crashing", () => {
     const store = createMockMonitorStore();
 
-    const { container } = render(<InterceptTab monitorStore={store} />);
+    const { container } = render(
+      <InterceptPanel monitorStore={store} theme="light" />
+    );
 
     expect(container.firstChild).not.toBeNull();
   });
@@ -38,7 +40,7 @@ describe("InterceptTab", () => {
   it("renders the unified active intercepts section", () => {
     const store = createMockMonitorStore();
 
-    render(<InterceptTab monitorStore={store} />);
+    render(<InterceptPanel monitorStore={store} theme="light" />);
 
     expect(screen.queryByText("Active Intercepts")).not.toBeNull();
     expect(screen.queryByText("No active intercepts")).not.toBeNull();
@@ -47,7 +49,7 @@ describe("InterceptTab", () => {
   it("renders the select component button", () => {
     const store = createMockMonitorStore();
 
-    render(<InterceptTab monitorStore={store} />);
+    render(<InterceptPanel monitorStore={store} theme="light" />);
 
     const buttons = screen.queryAllByText("Select Component");
     expect(buttons.length).toBeGreaterThan(0);
@@ -56,7 +58,7 @@ describe("InterceptTab", () => {
   it("accesses the mock manager from store", () => {
     const store = createMockMonitorStore();
 
-    render(<InterceptTab monitorStore={store} />);
+    render(<InterceptPanel monitorStore={store} theme="light" />);
 
     expect(store.getMockManager).toHaveBeenCalled();
   });
@@ -64,7 +66,7 @@ describe("InterceptTab", () => {
   it("accesses the prototype override store", () => {
     const store = createMockMonitorStore();
 
-    render(<InterceptTab monitorStore={store} />);
+    render(<InterceptPanel monitorStore={store} theme="light" />);
 
     expect(store.getPrototypeOverrideStore).toHaveBeenCalled();
   });

--- a/packages/react-devtools/src/plugins/intercept/InterceptPanel.tsx
+++ b/packages/react-devtools/src/plugins/intercept/InterceptPanel.tsx
@@ -14,4 +14,14 @@
  * limitations under the License.
  */
 
-export { interceptTab } from "./plugins/intercept/interceptTab.js";
+import React from "react";
+
+import { InterceptTab } from "../../components/InterceptTab.js";
+import type { DevToolsPanelProps } from "../types.js";
+
+export const InterceptPanel: React.FC<DevToolsPanelProps> = ({
+  monitorStore,
+  theme,
+}) => {
+  return <InterceptTab monitorStore={monitorStore} theme={theme} />;
+};

--- a/packages/react-devtools/src/plugins/intercept/interceptTab.ts
+++ b/packages/react-devtools/src/plugins/intercept/interceptTab.ts
@@ -14,4 +14,12 @@
  * limitations under the License.
  */
 
-export { interceptTab } from "./plugins/intercept/interceptTab.js";
+import type { DevToolsPlugin } from "../types.js";
+import { InterceptPanel } from "./InterceptPanel.js";
+
+export const interceptTab: DevToolsPlugin = {
+  id: "intercept",
+  label: "Intercept",
+  icon: "exchange",
+  panel: InterceptPanel,
+};

--- a/packages/react-devtools/src/plugins/intercept/types.ts
+++ b/packages/react-devtools/src/plugins/intercept/types.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { SelectedPrimitive } from "../../components/PrimitiveSelectionPanel.js";
+import type { MockResponse } from "../../mocking/MockManager.js";
+import type {
+  PrototypeOverride,
+  PrototypeOverrideParams,
+} from "../../prototyping/PrototypeOverrideStore.js";
+
+export interface MockConfiguration {
+  primitive: SelectedPrimitive;
+  mockType: "static" | "function" | "passthrough";
+  responseType: "success" | "error";
+  usePayload?: boolean;
+  payload?: string;
+  useResponse?: boolean;
+  staticData?: string;
+  functionCode?: string;
+  errorMessage?: string;
+  enabled: boolean;
+}
+
+export interface SelectedQuery {
+  componentId: string;
+  componentName: string;
+  objectType: string;
+  hookType: string;
+  hookIndex: number;
+  originalParams: PrototypeOverrideParams;
+  querySignature: string;
+  isAggregation?: boolean;
+}
+
+export type MockWithConfig = MockResponse & { config: MockConfiguration };
+
+export interface HydrateOverrideFormParams {
+  isAggregation: boolean;
+  where?: unknown;
+  orderBy?: unknown;
+  pageSize?: number;
+  groupBy?: unknown;
+  select?: unknown;
+}
+
+export type InterceptAction =
+  | { type: "SET_SELECTED_PRIMITIVE"; primitive: SelectedPrimitive | null }
+  | { type: "SET_MOCKS"; mocks: Array<MockWithConfig> }
+  | {
+      type: "UPDATE_MOCKS";
+      updater: (prev: Array<MockWithConfig>) => Array<MockWithConfig>;
+    }
+  | { type: "SET_EDITING_MOCK"; mock: MockWithConfig | null }
+  | { type: "SET_MOCK_TYPE"; mockType: MockConfiguration["mockType"] }
+  | {
+      type: "SET_RESPONSE_TYPE";
+      responseType: MockConfiguration["responseType"];
+    }
+  | { type: "SET_USE_PAYLOAD"; usePayload: boolean }
+  | { type: "SET_MOCK_PAYLOAD"; mockPayload: string }
+  | { type: "SET_USE_RESPONSE"; useResponse: boolean }
+  | { type: "SET_STATIC_DATA"; staticData: string }
+  | { type: "SET_FUNCTION_CODE"; functionCode: string }
+  | { type: "SET_ERROR_MESSAGE"; errorMessage: string }
+  | { type: "SET_SELECTED_QUERY"; query: SelectedQuery | null }
+  | { type: "SET_ACTIVE_OVERRIDES"; overrides: PrototypeOverride[] }
+  | { type: "SET_WHERE_CLAUSE_TEXT"; text: string }
+  | { type: "SET_ORDER_BY_TEXT"; text: string }
+  | { type: "SET_PAGE_SIZE"; pageSize: number | undefined }
+  | { type: "SET_GROUP_BY_TEXT"; text: string }
+  | { type: "SET_SELECT_TEXT"; text: string }
+  | { type: "SET_CHOOSING_PRIMITIVE"; primitive: SelectedPrimitive | null }
+  | { type: "SET_ERROR"; error: string | null }
+  | { type: "HYDRATE_OVERRIDE_FORM"; params: HydrateOverrideFormParams }
+  | { type: "INIT_MOCK_FORM_FROM_CONFIG"; config: MockConfiguration }
+  | { type: "INIT_MOCK_FORM_FROM_PRIMITIVE"; primitive: SelectedPrimitive }
+  | { type: "SELECT_PRIMITIVE_FOR_MOCK"; primitive: SelectedPrimitive }
+  | { type: "CANCEL_MOCK_EDITOR" }
+  | { type: "CLEAR_SELECTION" }
+  | { type: "SAVE_MOCK_DONE" };

--- a/packages/react-devtools/src/plugins/registry.test.ts
+++ b/packages/react-devtools/src/plugins/registry.test.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getRegisteredPlugins,
+  registerDevToolsPlugin,
+  subscribePlugins,
+} from "./registry.js";
+import type { DevToolsPlugin } from "./types.js";
+
+const GLOBAL_STORE_KEY = "__OSDK_DEVTOOLS_MONITOR_STORE__";
+
+function makePlugin(
+  id: string,
+  overrides?: Partial<DevToolsPlugin>
+): DevToolsPlugin {
+  return {
+    id,
+    label: id,
+    icon: "cube",
+    panel: () => null,
+    ...overrides,
+  };
+}
+
+function setGlobalStoreStub(): void {
+  (globalThis as Record<string, unknown>)[GLOBAL_STORE_KEY] = {
+    getMetricsStore() {},
+    getComputeStore() {},
+  };
+}
+
+const cleanups: Array<() => void> = [];
+
+function track(unregister: () => void): () => void {
+  cleanups.push(unregister);
+  return unregister;
+}
+
+afterEach(() => {
+  for (const cleanup of cleanups) {
+    cleanup();
+  }
+  cleanups.length = 0;
+  Reflect.deleteProperty(globalThis, GLOBAL_STORE_KEY);
+});
+
+describe("registry", () => {
+  it("register makes a plugin appear in getRegisteredPlugins", () => {
+    const plugin = makePlugin("appears");
+    track(registerDevToolsPlugin(plugin));
+    expect(getRegisteredPlugins()).toContain(plugin);
+  });
+
+  it("ignores a duplicate id and returns a no-op unregister", () => {
+    const first = makePlugin("dup", { label: "first" });
+    const second = makePlugin("dup", { label: "second" });
+    track(registerDevToolsPlugin(first));
+    const unregisterDuplicate = registerDevToolsPlugin(second);
+
+    const plugins = getRegisteredPlugins();
+    expect(plugins.filter((plugin) => plugin.id === "dup")).toHaveLength(1);
+    expect(plugins).toContain(first);
+    expect(plugins).not.toContain(second);
+
+    unregisterDuplicate();
+    expect(getRegisteredPlugins()).toContain(first);
+  });
+
+  it("unregister removes the plugin", () => {
+    const plugin = makePlugin("removable");
+    const unregister = registerDevToolsPlugin(plugin);
+    expect(getRegisteredPlugins()).toContain(plugin);
+
+    unregister();
+    expect(getRegisteredPlugins()).not.toContain(plugin);
+  });
+
+  it("notifies subscribers on register and on unregister", () => {
+    const callback = vi.fn();
+    const unsubscribe = subscribePlugins(callback);
+
+    const unregister = registerDevToolsPlugin(makePlugin("notify"));
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    unregister();
+    expect(callback).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+  });
+
+  it("calls init exactly once on register when the global store is present", () => {
+    setGlobalStoreStub();
+    const init = vi.fn();
+    track(registerDevToolsPlugin(makePlugin("with-store", { init })));
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call init and does not throw when the global store is absent", () => {
+    const init = vi.fn();
+    expect(() => {
+      track(registerDevToolsPlugin(makePlugin("no-store", { init })));
+    }).not.toThrow();
+    expect(init).not.toHaveBeenCalled();
+  });
+
+  it("returns a stable snapshot reference that only changes on mutation", () => {
+    const initial = getRegisteredPlugins();
+    expect(getRegisteredPlugins()).toBe(initial);
+
+    const unregister = registerDevToolsPlugin(makePlugin("snapshot"));
+    const afterRegister = getRegisteredPlugins();
+    expect(afterRegister).not.toBe(initial);
+    expect(getRegisteredPlugins()).toBe(afterRegister);
+
+    unregister();
+    const afterUnregister = getRegisteredPlugins();
+    expect(afterUnregister).not.toBe(afterRegister);
+  });
+});

--- a/packages/react-devtools/src/plugins/registry.ts
+++ b/packages/react-devtools/src/plugins/registry.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { MonitorStore } from "../store/MonitorStore.js";
+import type { DevToolsPlugin } from "./types.js";
+
+const GLOBAL_STORE_KEY = "__OSDK_DEVTOOLS_MONITOR_STORE__";
+
+function getGlobalMonitorStore(): MonitorStore | undefined {
+  if (typeof globalThis !== "undefined" && GLOBAL_STORE_KEY in globalThis) {
+    const candidate = (globalThis as Record<string, unknown>)[GLOBAL_STORE_KEY];
+    if (
+      typeof candidate === "object" &&
+      candidate != null &&
+      "getMetricsStore" in candidate &&
+      "getComputeStore" in candidate
+    ) {
+      return candidate as MonitorStore;
+    }
+  }
+  return undefined;
+}
+
+const registered: DevToolsPlugin[] = [];
+const listeners = new Set<() => void>();
+
+let snapshot: readonly DevToolsPlugin[] = [];
+
+function rebuildSnapshot(): void {
+  snapshot = [...registered];
+}
+
+function notifyListeners(): void {
+  for (const listener of listeners) {
+    try {
+      listener();
+    } catch {
+      // don't let a bad listener break the others
+    }
+  }
+}
+
+export function registerDevToolsPlugin(plugin: DevToolsPlugin): () => void {
+  if (registered.some((existing) => existing.id === plugin.id)) {
+    return () => {};
+  }
+
+  registered.push(plugin);
+  rebuildSnapshot();
+
+  const store = getGlobalMonitorStore();
+  if (store) {
+    plugin.init?.(store);
+  }
+
+  notifyListeners();
+
+  return () => {
+    const index = registered.indexOf(plugin);
+    if (index === -1) {
+      return;
+    }
+    registered.splice(index, 1);
+    rebuildSnapshot();
+
+    const disposeStore = getGlobalMonitorStore();
+    if (disposeStore) {
+      plugin.dispose?.(disposeStore);
+    }
+
+    notifyListeners();
+  };
+}
+
+export function getRegisteredPlugins(): readonly DevToolsPlugin[] {
+  return snapshot;
+}
+
+export function subscribePlugins(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}

--- a/packages/react-devtools/src/plugins/types.ts
+++ b/packages/react-devtools/src/plugins/types.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ComponentType } from "react";
+
+import type { MonitorStore } from "../store/MonitorStore.js";
+
+export interface DevToolsPanelProps {
+  monitorStore: MonitorStore;
+  theme: "light" | "dark";
+}
+export type DevToolsPanelComponent = ComponentType<DevToolsPanelProps>;
+
+export interface DevToolsPlugin {
+  id: string; // stable; persistence + active-tab key, e.g. "cache"
+  label: string; // tab-bar label
+  icon: string; // Blueprint icon name
+  panel: DevToolsPanelComponent; // mounted only while its tab is active
+  init?: (monitorStore: MonitorStore) => void; // idempotent wiring; no-op in v1
+  dispose?: (monitorStore: MonitorStore) => void;
+  activateOnView?: boolean; // default true
+}

--- a/packages/react-devtools/src/plugins/useDevToolsTabs.ts
+++ b/packages/react-devtools/src/plugins/useDevToolsTabs.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo, useSyncExternalStore } from "react";
+
+import { BASE_TABS } from "./baseTabs.js";
+import { getRegisteredPlugins, subscribePlugins } from "./registry.js";
+import type { DevToolsPlugin } from "./types.js";
+
+export function useDevToolsTabs(): readonly DevToolsPlugin[] {
+  const plugins = useSyncExternalStore(subscribePlugins, getRegisteredPlugins);
+
+  return useMemo(() => {
+    const seen = new Set<string>();
+    const deduped: DevToolsPlugin[] = [];
+    for (const plugin of [...BASE_TABS, ...plugins]) {
+      if (seen.has(plugin.id)) {
+        continue;
+      }
+      seen.add(plugin.id);
+      deduped.push(plugin);
+    }
+    return deduped;
+  }, [plugins]);
+}

--- a/packages/react-devtools/src/public/advanced.ts
+++ b/packages/react-devtools/src/public/advanced.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { interceptTab } from "./plugins/intercept/interceptTab.js";
+export { interceptTab } from "../plugins/intercept/interceptTab.js";

--- a/packages/react-devtools/src/recommendations/__snapshots__/copyPrompt.test.ts.snap
+++ b/packages/react-devtools/src/recommendations/__snapshots__/copyPrompt.test.ts.snap
@@ -1,0 +1,65 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`buildCopyAllPrompt > matches the full combined template 1`] = `
+"Here are 2 OSDK optimizations, ordered by priority:
+
+1. You are helping optimize an app built with the OSDK React Toolkit (@osdk/react).
+
+ISSUE: First (Performance, severity: high)
+WHY IT MATTERS: This component fetches 12 properties but only uses 3
+EXPECTED IMPACT: Save 4.2KB bandwidth per load
+
+SUGGESTED FIX:
+Use $select to only fetch used properties
+
+OSDK GUIDANCE:
+Avoid sequential data dependencies. Prefer a single query (using $select, links, or an object set) over chained hooks that wait on one another, so the toolkit can resolve data in parallel.
+
+TASK: Apply the suggested fix at the location above. Keep behavior identical except for the optimization. If the file/line is approximate, search for the matching hook call.
+
+---
+
+2. You are helping optimize an app built with the OSDK React Toolkit (@osdk/react).
+
+ISSUE: Second (Cache, severity: high)
+WHY IT MATTERS: This component fetches 12 properties but only uses 3
+EXPECTED IMPACT: Save 4.2KB bandwidth per load
+
+LOCATION: src/B.tsx:9
+
+SUGGESTED FIX:
+Use $select to only fetch used properties
+
+OSDK GUIDANCE:
+Reuse shared object sets and query keys so the toolkit can serve cached results instead of refetching. Avoid recreating query inputs on every render.
+
+TASK: Apply the suggested fix at the location above. Keep behavior identical except for the optimization. If the file/line is approximate, search for the matching hook call."
+`;
+
+exports[`buildCopyPrompt > renders the full template for a fully-populated recommendation 1`] = `
+"You are helping optimize an app built with the OSDK React Toolkit (@osdk/react).
+
+ISSUE: EmployeeCard fetches unused data (Bandwidth, severity: high)
+WHY IT MATTERS: This component fetches 12 properties but only uses 3
+EXPECTED IMPACT: Save 4.2KB bandwidth per load
+
+LOCATION: src/components/EmployeeCard.tsx:42
+
+CURRENT CODE:
+\`\`\`tsx
+const { object } = useOsdkObject(Employee, id);
+\`\`\`
+
+SUGGESTED FIX:
+Use $select to only fetch used properties
+\`\`\`tsx
+const { object } = useOsdkObject(Employee, id, {
+  $select: ["name"]
+});
+\`\`\`
+
+OSDK GUIDANCE:
+Use $select to fetch only the properties a component reads.
+
+TASK: Apply the suggested fix at the location above. Keep behavior identical except for the optimization. If the file/line is approximate, search for the matching hook call."
+`;

--- a/packages/react-devtools/src/recommendations/copyPrompt.test.ts
+++ b/packages/react-devtools/src/recommendations/copyPrompt.test.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { Recommendation } from "../utils/PerformanceRecommendationEngine.js";
+import { OSDK_GUIDANCE_BY_CATEGORY } from "../utils/PerformanceRecommendationEngine.js";
+import { buildCopyAllPrompt, buildCopyPrompt } from "./copyPrompt.js";
+
+function makeRec(overrides: Partial<Recommendation> = {}): Recommendation {
+  return {
+    id: "rec-1",
+    level: "high",
+    category: "Bandwidth",
+    title: "EmployeeCard fetches unused data",
+    description: "This component fetches 12 properties but only uses 3",
+    impact: "Save 4.2KB bandwidth per load",
+    effort: "Low",
+    suggestion: "Use $select to only fetch used properties",
+    dismissible: true,
+    ...overrides,
+  };
+}
+
+describe("buildCopyPrompt", () => {
+  it("renders the full template for a fully-populated recommendation", () => {
+    const rec = makeRec({
+      filePath: "src/components/EmployeeCard.tsx",
+      lineNumber: 42,
+      currentCode: "const { object } = useOsdkObject(Employee, id);",
+      code: 'const { object } = useOsdkObject(Employee, id, {\n  $select: ["name"]\n});',
+      osdkGuidance:
+        "Use $select to fetch only the properties a component reads.",
+    });
+
+    expect(buildCopyPrompt(rec)).toMatchSnapshot();
+  });
+
+  it("always renders intro, issue, suggestion, guidance and task sections", () => {
+    const prompt = buildCopyPrompt(makeRec());
+
+    expect(prompt).toContain("OSDK React Toolkit");
+    expect(prompt).toContain(
+      "ISSUE: EmployeeCard fetches unused data (Bandwidth, severity: high)"
+    );
+    expect(prompt).toContain(
+      "WHY IT MATTERS: This component fetches 12 properties but only uses 3"
+    );
+    expect(prompt).toContain("EXPECTED IMPACT: Save 4.2KB bandwidth per load");
+    expect(prompt).toContain(
+      "SUGGESTED FIX:\nUse $select to only fetch used properties"
+    );
+    expect(prompt).toContain("OSDK GUIDANCE:");
+    expect(prompt).toContain("TASK: Apply the suggested fix");
+  });
+
+  it("omits the LOCATION line when filePath is absent", () => {
+    expect(buildCopyPrompt(makeRec())).not.toContain("LOCATION:");
+  });
+
+  it("renders LOCATION with line number when both filePath and lineNumber are present", () => {
+    const prompt = buildCopyPrompt(
+      makeRec({ filePath: "src/A.tsx", lineNumber: 17 })
+    );
+
+    expect(prompt).toContain("LOCATION: src/A.tsx:17");
+  });
+
+  it("renders LOCATION without a line suffix when only filePath is present", () => {
+    const prompt = buildCopyPrompt(makeRec({ filePath: "src/A.tsx" }));
+
+    expect(prompt).toContain("LOCATION: src/A.tsx");
+    expect(prompt).not.toContain("src/A.tsx:");
+  });
+
+  it("includes lineNumber 0 in the LOCATION line", () => {
+    const prompt = buildCopyPrompt(
+      makeRec({ filePath: "src/A.tsx", lineNumber: 0 })
+    );
+
+    expect(prompt).toContain("LOCATION: src/A.tsx:0");
+  });
+
+  it("omits the CURRENT CODE block when currentCode is absent", () => {
+    expect(buildCopyPrompt(makeRec())).not.toContain("CURRENT CODE:");
+  });
+
+  it("renders a fenced CURRENT CODE block when currentCode is present", () => {
+    const prompt = buildCopyPrompt(makeRec({ currentCode: "const x = 1;" }));
+
+    expect(prompt).toContain("CURRENT CODE:\n```tsx\nconst x = 1;\n```");
+  });
+
+  it("renders the suggestion without a code fence when code is absent", () => {
+    const prompt = buildCopyPrompt(makeRec());
+
+    expect(prompt).toContain(
+      "SUGGESTED FIX:\nUse $select to only fetch used properties"
+    );
+    expect(prompt).not.toContain("```tsx");
+  });
+
+  it("appends a fenced code block under SUGGESTED FIX when code is present", () => {
+    const prompt = buildCopyPrompt(makeRec({ code: "const y = 2;" }));
+
+    expect(prompt).toContain(
+      "SUGGESTED FIX:\nUse $select to only fetch used properties\n```tsx\nconst y = 2;\n```"
+    );
+  });
+
+  it("prefers the recommendation's own osdkGuidance when provided", () => {
+    const prompt = buildCopyPrompt(
+      makeRec({ osdkGuidance: "Custom guidance for this rec." })
+    );
+
+    expect(prompt).toContain("OSDK GUIDANCE:\nCustom guidance for this rec.");
+  });
+
+  it("falls back to the category guidance when osdkGuidance is absent", () => {
+    const prompt = buildCopyPrompt(makeRec({ category: "Cache" }));
+
+    expect(prompt).toContain(
+      `OSDK GUIDANCE:\n${OSDK_GUIDANCE_BY_CATEGORY.Cache}`
+    );
+  });
+});
+
+describe("buildCopyAllPrompt", () => {
+  it("renders the count preamble", () => {
+    const prompt = buildCopyAllPrompt([makeRec(), makeRec({ id: "rec-2" })]);
+
+    expect(prompt).toContain(
+      "Here are 2 OSDK optimizations, ordered by priority:"
+    );
+  });
+
+  it("numbers each recommendation and separates them with a horizontal rule", () => {
+    const prompt = buildCopyAllPrompt([
+      makeRec({ id: "rec-1", title: "First" }),
+      makeRec({ id: "rec-2", title: "Second" }),
+    ]);
+
+    expect(prompt).toContain("1. You are helping optimize");
+    expect(prompt).toContain("2. You are helping optimize");
+    expect(prompt).toContain("\n\n---\n\n");
+  });
+
+  it("matches the full combined template", () => {
+    const recs = [
+      makeRec({ id: "rec-1", title: "First", category: "Performance" }),
+      makeRec({
+        id: "rec-2",
+        title: "Second",
+        category: "Cache",
+        filePath: "src/B.tsx",
+        lineNumber: 9,
+      }),
+    ];
+
+    expect(buildCopyAllPrompt(recs)).toMatchSnapshot();
+  });
+});

--- a/packages/react-devtools/src/recommendations/copyPrompt.ts
+++ b/packages/react-devtools/src/recommendations/copyPrompt.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Recommendation } from "../utils/PerformanceRecommendationEngine.js";
+import { OSDK_GUIDANCE_BY_CATEGORY } from "../utils/PerformanceRecommendationEngine.js";
+
+const INTRO =
+  "You are helping optimize an app built with the OSDK React Toolkit (@osdk/react).";
+
+const TASK =
+  "TASK: Apply the suggested fix at the location above. Keep behavior identical except for the optimization. If the file/line is approximate, search for the matching hook call.";
+
+/**
+ * Builds an AI-ready prompt for a single performance recommendation. Sections
+ * with no data are omitted cleanly so the output stays reproducible.
+ */
+export function buildCopyPrompt(rec: Recommendation): string {
+  const sections: string[] = [
+    INTRO,
+    [
+      `ISSUE: ${rec.title} (${rec.category}, severity: ${rec.level})`,
+      `WHY IT MATTERS: ${rec.description}`,
+      `EXPECTED IMPACT: ${rec.impact}`,
+    ].join("\n"),
+  ];
+
+  if (rec.filePath) {
+    const location =
+      rec.lineNumber != null
+        ? `${rec.filePath}:${rec.lineNumber}`
+        : rec.filePath;
+    sections.push(`LOCATION: ${location}`);
+  }
+
+  if (rec.currentCode) {
+    sections.push(`CURRENT CODE:\n\`\`\`tsx\n${rec.currentCode}\n\`\`\``);
+  }
+
+  sections.push(
+    rec.code
+      ? `SUGGESTED FIX:\n${rec.suggestion}\n\`\`\`tsx\n${rec.code}\n\`\`\``
+      : `SUGGESTED FIX:\n${rec.suggestion}`
+  );
+
+  const guidance = rec.osdkGuidance ?? OSDK_GUIDANCE_BY_CATEGORY[rec.category];
+  sections.push(`OSDK GUIDANCE:\n${guidance}`);
+
+  sections.push(TASK);
+
+  return sections.join("\n\n");
+}
+
+/**
+ * Builds a single combined prompt covering several recommendations, ordered as
+ * given. Each recommendation is numbered and the entries are separated by a
+ * horizontal rule.
+ */
+export function buildCopyAllPrompt(recs: Recommendation[]): string {
+  const preamble = `Here are ${recs.length} OSDK optimizations, ordered by priority:`;
+  const items = recs.map((rec, i) => `${i + 1}. ${buildCopyPrompt(rec)}`);
+  return `${preamble}\n\n${items.join("\n\n---\n\n")}`;
+}

--- a/packages/react-devtools/src/utils/PerformanceRecommendationEngine.ts
+++ b/packages/react-devtools/src/utils/PerformanceRecommendationEngine.ts
@@ -47,7 +47,25 @@ export interface Recommendation {
   suggestion: string;
   code?: string;
   dismissible: boolean;
+  filePath?: string;
+  lineNumber?: number;
+  currentCode?: string;
+  osdkGuidance?: string;
 }
+
+export const OSDK_GUIDANCE_BY_CATEGORY: Record<RecommendationCategory, string> =
+  {
+    Performance:
+      "Avoid sequential data dependencies. Prefer a single query (using $select, links, or an object set) over chained hooks that wait on one another, so the toolkit can resolve data in parallel.",
+    Bandwidth:
+      "Use $select to fetch only the properties a component reads. The toolkit caches and revalidates per-property, so narrower selections reduce payload size and unnecessary refetches.",
+    "Code Quality":
+      "Keep query definitions colocated with the component that consumes them and request only the data you render. Lean queries are easier for the toolkit to cache and dedupe.",
+    Cache:
+      "Reuse shared object sets and query keys so the toolkit can serve cached results instead of refetching. Avoid recreating query inputs on every render.",
+    Queries:
+      "Consolidate overlapping queries. The toolkit deduplicates identical query signatures, so aligning inputs lets multiple components share one subscription.",
+  };
 
 export interface PerformanceScore {
   overall: number; // 0-100
@@ -108,6 +126,7 @@ export class PerformanceRecommendationEngine {
         suggestion: wf.suggestion,
         code: wf.code,
         dismissible: true,
+        osdkGuidance: OSDK_GUIDANCE_BY_CATEGORY.Performance,
       });
     }
 
@@ -118,6 +137,11 @@ export class PerformanceRecommendationEngine {
       ) {
         continue;
       }
+
+      const subscribers = this.registry.getQuerySubscribers(
+        offender.querySignature
+      );
+      const locatedBinding = subscribers.find((b) => b.filePath);
 
       recommendations.push({
         id: `field-${offender.querySignature}`,
@@ -132,6 +156,9 @@ export class PerformanceRecommendationEngine {
         suggestion: "Use $select to only fetch used properties",
         code: offender.suggestion,
         dismissible: true,
+        filePath: locatedBinding?.filePath,
+        lineNumber: locatedBinding?.lineNumber,
+        osdkGuidance: OSDK_GUIDANCE_BY_CATEGORY.Bandwidth,
       });
     }
 
@@ -152,6 +179,7 @@ export class PerformanceRecommendationEngine {
           effort: "Medium",
           suggestion: rec.suggestion,
           dismissible: true,
+          osdkGuidance: OSDK_GUIDANCE_BY_CATEGORY.Cache,
         });
       }
     }


### PR DESCRIPTION
extract intercept into a plugin for opt-in advanced registration

• moved InterceptAction, SelectedQuery, MockConfiguration types to plugins/intercept/types.ts
• created InterceptPanel wrapper conforming to DevToolsPanelProps
• exported interceptTab plugin via advanced subpath for opt-in registration