### PR TITLE
make devtools shell registry-driven and fix layout bugs

### DIFF
--- a/.changeset/devtools-registry-driven-panel.md
+++ b/.changeset/devtools-registry-driven-panel.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+Drive the devtools panel tabs from the plugin registry, mount only the active tab, use a single scroll container, and default the panel to bottom-right opened on first run.

--- a/packages/react-devtools/src/components/MonitoringPanel.module.scss
+++ b/packages/react-devtools/src/components/MonitoringPanel.module.scss
@@ -195,7 +195,9 @@
 
 .content {
   flex: 1;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   pointer-events: auto;
@@ -214,14 +216,6 @@
 
 .tabButtonActive {
   @include m.dt-tab-active;
-}
-
-.tabContentVisible {
-  display: contents;
-}
-
-.tabContentHidden {
-  display: none;
 }
 
 .metricsGrid {
@@ -309,8 +303,6 @@
 
 .operationsList {
   flex: 1;
-  overflow: auto;
-  @include m.dt-scrollbar;
 }
 
 .operationItem {

--- a/packages/react-devtools/src/components/MonitoringPanel.module.scss
+++ b/packages/react-devtools/src/components/MonitoringPanel.module.scss
@@ -2,6 +2,13 @@
 @use 'mixins' as m;
 @use 'theme' as theme;
 
+// Blueprint tooltip/popover portals mount at document.body with a low default
+// z-index, which leaves them behind the floating panel and makes the info
+// tooltips unreadable. Lift devtools overlays above the panel.
+:global(.osdk-devtools-portal) {
+  z-index: t.$z-modal;
+}
+
 .panel {
   @include theme.dt-dark-theme;
 

--- a/packages/react-devtools/src/components/MonitoringPanel.test.tsx
+++ b/packages/react-devtools/src/components/MonitoringPanel.test.tsx
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { registerDevToolsPlugin } from "../plugins/registry.js";
+import type { DevToolsPlugin } from "../plugins/types.js";
 import { createMockMonitorStore } from "./testHelpers.js";
 
 vi.mock("../fiber/DegradationNotice.js", () => ({
@@ -36,33 +38,85 @@ vi.mock("../fiber/validation.js", () => ({
 
 const { MonitoringPanel } = await import("./MonitoringPanel.js");
 
+const ACTIVE_TAB_KEY = "osdk-devtools-active-tab";
+
+function makePlugin(id: string, label: string): DevToolsPlugin {
+  return {
+    id,
+    label,
+    icon: "cube",
+    panel: () => <div data-testid={`panel-${id}`}>{`${label} panel`}</div>,
+  };
+}
+
 describe("MonitoringPanel", () => {
+  let unregisterFns: Array<() => void> = [];
+
+  function register(plugin: DevToolsPlugin): void {
+    unregisterFns.push(registerDevToolsPlugin(plugin));
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   afterEach(() => {
     cleanup();
+    for (const unregister of unregisterFns) {
+      unregister();
+    }
+    unregisterFns = [];
+    localStorage.clear();
   });
 
-  it("renders the panel with title and tabs", () => {
+  it("renders one tab button per registered plugin", () => {
+    register(makePlugin("overview", "Overview"));
+    register(makePlugin("cache", "Cache"));
+    register(makePlugin("actions", "Actions"));
+
     const store = createMockMonitorStore();
     render(<MonitoringPanel monitorStore={store} />);
 
-    expect(screen.queryByText("OSDK Devtools")).not.toBeNull();
-    expect(screen.queryByText("Performance")).not.toBeNull();
-    expect(screen.queryByText("Compute")).not.toBeNull();
-    expect(screen.queryByText("Intercept")).not.toBeNull();
-    expect(screen.queryByText("Debugging")).not.toBeNull();
+    expect(screen.getAllByRole("tab")).toHaveLength(3);
+    expect(screen.getByRole("tab", { name: "Overview" })).not.toBeNull();
+    expect(screen.getByRole("tab", { name: "Cache" })).not.toBeNull();
+    expect(screen.getByRole("tab", { name: "Actions" })).not.toBeNull();
   });
 
-  it("renders the beta badge", () => {
+  it("mounts only the active tab's panel", () => {
+    register(makePlugin("overview", "Overview"));
+    register(makePlugin("cache", "Cache"));
+
     const store = createMockMonitorStore();
     render(<MonitoringPanel monitorStore={store} />);
 
-    expect(screen.queryAllByText("Beta").length).toBeGreaterThan(0);
+    expect(screen.queryByTestId("panel-overview")).not.toBeNull();
+    expect(screen.queryByTestId("panel-cache")).toBeNull();
   });
 
-  it("defaults to the performance tab", () => {
+  it("swaps the mounted panel when another tab is clicked", () => {
+    register(makePlugin("overview", "Overview"));
+    register(makePlugin("cache", "Cache"));
+
     const store = createMockMonitorStore();
     render(<MonitoringPanel monitorStore={store} />);
 
-    expect(screen.queryAllByText("Cache Hit Rate").length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByRole("tab", { name: "Cache" }));
+
+    expect(screen.queryByTestId("panel-cache")).not.toBeNull();
+    expect(screen.queryByTestId("panel-overview")).toBeNull();
+  });
+
+  it("falls back to the first tab when the persisted active id is absent", () => {
+    localStorage.setItem(ACTIVE_TAB_KEY, JSON.stringify("removed-tab"));
+
+    register(makePlugin("overview", "Overview"));
+    register(makePlugin("cache", "Cache"));
+
+    const store = createMockMonitorStore();
+    render(<MonitoringPanel monitorStore={store} />);
+
+    expect(screen.queryByTestId("panel-overview")).not.toBeNull();
+    expect(screen.queryByTestId("panel-cache")).toBeNull();
   });
 });

--- a/packages/react-devtools/src/components/MonitoringPanel.tsx
+++ b/packages/react-devtools/src/components/MonitoringPanel.tsx
@@ -16,7 +16,7 @@
 
 import { Button, Classes, Tooltip } from "@blueprintjs/core";
 import classNames from "classnames";
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import React, { useCallback, useMemo, useRef } from "react";
 import { createPortal } from "react-dom";
 
 import {
@@ -25,13 +25,10 @@ import {
 } from "../fiber/DegradationNotice.js";
 import { validateFiberAccess } from "../fiber/validation.js";
 import { usePersistedState } from "../hooks/usePersistedState.js";
+import { useDevToolsTabs } from "../plugins/useDevToolsTabs.js";
 import type { MonitorStore } from "../store/MonitorStore.js";
 import type { PanelPosition } from "../types/index.js";
-import { ComputeTab } from "./ComputeTab.js";
-import { DebuggingTab } from "./DebuggingTab.js";
-import { InterceptTab } from "./InterceptTab.js";
 import { MonitorErrorBoundary } from "./MonitorErrorBoundary.js";
-import { PerformanceTab } from "./PerformanceTab.js";
 
 import styles from "./MonitoringPanel.module.scss";
 
@@ -78,6 +75,7 @@ const UI_CONSTANTS = {
   DEFAULT_PANEL_HEIGHT: 600,
   DEFAULT_PANEL_RIGHT_OFFSET: 420,
   DEFAULT_PANEL_TOP_OFFSET: 20,
+  DEFAULT_PANEL_MARGIN: 16,
   MIN_PANEL_WIDTH: 320,
   MIN_PANEL_HEIGHT: 200,
   TOOLTIP_HOVER_DELAY: 500,
@@ -98,19 +96,30 @@ export const MonitoringPanel: React.FC<MonitoringPanelProps> = ({
   monitorStore,
 }) => {
   const metricsStore = monitorStore.getMetricsStore();
-  const computeStore = monitorStore.getComputeStore();
   const fiberCapabilities = useFiberCapabilities();
-  const [activeTab, setActiveTab] = useState<
-    "performance" | "compute" | "intercept" | "debugging"
-  >("performance");
+  const tabs = useDevToolsTabs();
+  const [activeTabId, setActiveTabId] = usePersistedState<string>(
+    "osdk-devtools-active-tab",
+    "overview"
+  );
+  const [openedBefore, setOpenedBefore] = usePersistedState(
+    "osdk-devtools-opened-before",
+    false
+  );
   const [position, setPosition] = usePersistedState<PanelPosition>(
-    "osdk-monitor-position",
+    "osdk-monitor-position-v2",
     {
-      x: window.innerWidth - UI_CONSTANTS.DEFAULT_PANEL_RIGHT_OFFSET,
-      y: UI_CONSTANTS.DEFAULT_PANEL_TOP_OFFSET,
+      x:
+        window.innerWidth -
+        UI_CONSTANTS.DEFAULT_PANEL_WIDTH -
+        UI_CONSTANTS.DEFAULT_PANEL_MARGIN,
+      y:
+        window.innerHeight -
+        UI_CONSTANTS.DEFAULT_PANEL_HEIGHT -
+        UI_CONSTANTS.DEFAULT_PANEL_MARGIN,
       width: UI_CONSTANTS.DEFAULT_PANEL_WIDTH,
       height: UI_CONSTANTS.DEFAULT_PANEL_HEIGHT,
-      collapsed: false,
+      collapsed: true,
       dockMode: "floating",
     }
   );
@@ -392,7 +401,14 @@ export const MonitoringPanel: React.FC<MonitoringPanelProps> = ({
     return position;
   }, [position, windowSize]);
 
-  if (position.collapsed) {
+  const activePlugin = useMemo(
+    () => tabs.find((tab) => tab.id === activeTabId) ?? tabs[0],
+    [tabs, activeTabId]
+  );
+
+  const collapsed = openedBefore ? position.collapsed : false;
+
+  if (collapsed) {
     return createPortal(
       <Tooltip
         content="View OSDK Devtools"
@@ -402,7 +418,10 @@ export const MonitoringPanel: React.FC<MonitoringPanelProps> = ({
         <div
           className={styles.minimized}
           data-dt-theme={resolvedTheme}
-          onClick={() => setPosition((prev) => ({ ...prev, collapsed: false }))}
+          onClick={() => {
+            setOpenedBefore(true);
+            setPosition((prev) => ({ ...prev, collapsed: false }));
+          }}
         >
           <span className={styles.minimizedIcon}>&lt;/&gt;</span>
         </div>
@@ -518,9 +537,10 @@ export const MonitoringPanel: React.FC<MonitoringPanelProps> = ({
             variant="minimal"
             size="small"
             icon="minimize"
-            onClick={() =>
-              setPosition((prev) => ({ ...prev, collapsed: true }))
-            }
+            onClick={() => {
+              setOpenedBefore(true);
+              setPosition((prev) => ({ ...prev, collapsed: true }));
+            }}
             title="Minimize"
             aria-label="Minimize devtools panel"
           />
@@ -528,23 +548,21 @@ export const MonitoringPanel: React.FC<MonitoringPanelProps> = ({
       </div>
 
       <div className={styles.tabs} role="tablist" aria-label="Devtools tabs">
-        {(["performance", "compute", "intercept", "debugging"] as const).map(
-          (tab) => (
-            <button
-              key={tab}
-              type="button"
-              role="tab"
-              aria-selected={activeTab === tab}
-              className={classNames(
-                styles.tabButton,
-                activeTab === tab && styles.tabButtonActive
-              )}
-              onClick={() => setActiveTab(tab)}
-            >
-              {tab.charAt(0).toUpperCase() + tab.slice(1)}
-            </button>
-          )
-        )}
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-selected={activePlugin?.id === tab.id}
+            className={classNames(
+              styles.tabButton,
+              activePlugin?.id === tab.id && styles.tabButtonActive
+            )}
+            onClick={() => setActiveTabId(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
       </div>
 
       <div className={styles.content}>
@@ -553,45 +571,14 @@ export const MonitoringPanel: React.FC<MonitoringPanelProps> = ({
           <DegradationNotice onRetry={() => validateFiberAccess()} />
         )}
 
-        <div
-          className={
-            activeTab === "performance"
-              ? styles.tabContentVisible
-              : styles.tabContentHidden
-          }
-        >
-          <PerformanceTab
-            metricsStore={metricsStore}
+        {activePlugin ? (
+          <activePlugin.panel
             monitorStore={monitorStore}
+            theme={resolvedTheme}
           />
-        </div>
-        <div
-          className={
-            activeTab === "compute"
-              ? styles.tabContentVisible
-              : styles.tabContentHidden
-          }
-        >
-          <ComputeTab computeStore={computeStore} />
-        </div>
-        <div
-          className={
-            activeTab === "intercept"
-              ? styles.tabContentVisible
-              : styles.tabContentHidden
-          }
-        >
-          <InterceptTab monitorStore={monitorStore} theme={resolvedTheme} />
-        </div>
-        <div
-          className={
-            activeTab === "debugging"
-              ? styles.tabContentVisible
-              : styles.tabContentHidden
-          }
-        >
-          <DebuggingTab monitorStore={monitorStore} />
-        </div>
+        ) : (
+          <div className={styles.emptyState}>No devtools tabs registered.</div>
+        )}
       </div>
     </div>,
     document.body

--- a/packages/react-devtools/src/components/_mixins.scss
+++ b/packages/react-devtools/src/components/_mixins.scss
@@ -71,6 +71,13 @@
   color: t.$text-tertiary;
 }
 
+// Panel body: vertical flex column that defers scrolling to its scroll parent
+@mixin dt-panel-body {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
 // Code block
 @mixin dt-code-block {
   background: t.$bg-base;


### PR DESCRIPTION
replace hardcoded tabs with registry-driven tabs from the plugin system

• tabs now read from useDevToolsTabs() registry instead of hardcoded union
• mount only active tab, fixing bug where tab clicks required a resize
• single scroll container instead of double-scroll; bottom-right default on first run with persistence