### PR TITLE
feat(unit-testing): export MockClient type from experimental entry

### DIFF
--- a/.changeset/expose-mockclient-experimental.md
+++ b/.changeset/expose-mockclient-experimental.md
@@ -1,0 +1,5 @@
+---
+"@osdk/unit-testing": minor
+---
+
+Export `MockClient`, `StubClient`, and `MockOsdkObjectOptions` types from the `@osdk/unit-testing/experimental` entry point so callers can annotate the value returned by `createMockClient` directly instead of `ReturnType<typeof createMockClient>`.

--- a/packages/unit-testing/src/public/experimental.ts
+++ b/packages/unit-testing/src/public/experimental.ts
@@ -18,8 +18,11 @@ export type {
   AggregateStubBuilder,
   FetchOneStubBuilder,
   FetchPageStubBuilder,
+  MockClient,
+  MockOsdkObjectOptions,
   QueryStubBuilder,
   StubBuilderFor,
+  StubClient,
 } from "../api/index.js";
 export { createMockAttachment } from "../mock/createMockAttachment.js";
 export { createMockClient } from "../mock/createMockClient.js";


### PR DESCRIPTION
## What

Export the `MockClient` type (plus `StubClient` and `MockOsdkObjectOptions`) from the `@osdk/unit-testing/experimental` entry point.

## Why

The `/experimental` entry re-exported the `createMockClient` **function** but not the `MockClient` **type** it returns. Callers importing `createMockClient` from `/experimental` had no way to name its return type and were forced to write:

```ts
function stubFaxSetQuery(
  mockClient: ReturnType<typeof createMockClient>,
  results: object[],
) { /* ... */ }
```

With this change they can annotate directly:

```ts
import { createMockClient, type MockClient } from "@osdk/unit-testing/experimental";

function stubFaxSetQuery(mockClient: MockClient, results: object[]) { /* ... */ }
```

`MockClient` was already exported from the main (`.`) entry — this brings the experimental entry to parity by also adding `StubClient` and `MockOsdkObjectOptions` (the companion types for the value creators the experimental entry already exposes).

## Notes

- No API report change: api-extractor tracks the `.` entry, which already exported these types.
- `pnpm turbo typecheck check-api --filter=@osdk/unit-testing` passes (remaining warnings are pre-existing missing-release-tag warnings in unrelated code).
- Changeset included (`@osdk/unit-testing`: minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)