### PR TITLE
chore: hide source code in Overview story Docs tab

### DIFF
--- a/.changeset/overview-hide-docs-source.md
+++ b/.changeset/overview-hide-docs-source.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components-storybook": patch
+---
+
+Hide source code panel in Overview story Docs tab

--- a/packages/react-components-storybook/src/stories/Overview/Overview.stories.tsx
+++ b/packages/react-components-storybook/src/stories/Overview/Overview.stories.tsx
@@ -515,6 +515,7 @@ const meta: Meta = {
   parameters: {
     layout: "fullscreen",
     controls: { disable: true },
+    docs: { source: { code: null } },
     msw: {
       handlers: [
         ...fauxFoundry.handlers,


### PR DESCRIPTION
## Summary

- Hide the source code block in the Docs tab for the Overview story
- The Overview is a showcase page with a large composite component — the raw source is not useful for consumers browsing the docs

## Changes

- **Overview.stories.tsx**: Add `docs: { source: { code: null } }` to story parameters

## Test plan

- [ ] Start Storybook (`pnpm --dir packages/react-components-storybook dev`)
- [ ] Navigate to Components > Overview > Docs tab
- [ ] Verify no source code block is shown
- [ ] Verify the Canvas tab still renders the story correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)