### PR TITLE
chore: re-enable oxlint custom-error-definition and default-param-last

### DIFF
--- a/.changeset/oxc-reenable-custom-error-default-param.md
+++ b/.changeset/oxc-reenable-custom-error-default-param.md
@@ -1,0 +1,11 @@
+---
+"@osdk/shared.net.errors": patch
+"@osdk/shared.net.fetch": patch
+"@osdk/foundry-config-json": patch
+"@osdk/widget.vite-plugin": patch
+"@osdk/functions": patch
+"@osdk/client": patch
+"@osdk/faux": patch
+---
+
+Set the `name` property on custom error classes so thrown errors report their own class name

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -51,8 +51,8 @@ export default defineConfig({
     "typescript/no-explicit-any": "warn",
     "eqeqeq": ["error", "always", { "null": "never" }],
     "no-eq-null": "off",
-    "unicorn/custom-error-definition": "off",
-    "default-param-last": "off",
+    "unicorn/custom-error-definition": "error",
+    "default-param-last": "error",
     "require-await": "off",
     "typescript/require-await": "off",
     // Adding the `u` flag to an existing regex can change its matching semantics;

--- a/packages/cli.common/src/ExitProcessError.ts
+++ b/packages/cli.common/src/ExitProcessError.ts
@@ -22,5 +22,6 @@ export class ExitProcessError extends Error {
     public readonly originalError?: Error | undefined
   ) {
     super(msg);
+    this.name = "ExitProcessError";
   }
 }

--- a/packages/cli.common/src/YargsCheckError.ts
+++ b/packages/cli.common/src/YargsCheckError.ts
@@ -17,5 +17,6 @@
 export class YargsCheckError extends Error {
   constructor(msg?: string) {
     super(msg);
+    this.name = "YargsCheckError";
   }
 }

--- a/packages/client/src/actions/ActionValidationError.ts
+++ b/packages/client/src/actions/ActionValidationError.ts
@@ -19,5 +19,6 @@ import type { ValidateActionResponseV2 as ActionValidationResponse } from "@osdk
 export class ActionValidationError extends Error {
   constructor(public validation: ActionValidationResponse) {
     super("Validation Error: " + JSON.stringify(validation, null, 2));
+    this.name = "ActionValidationError";
   }
 }

--- a/packages/client/src/logger/BaseLogger.ts
+++ b/packages/client/src/logger/BaseLogger.ts
@@ -41,7 +41,7 @@ export abstract class BaseLogger implements Logger {
 
   constructor(
     bindings: Record<string, any>,
-    options: { level?: string; msgPrefix?: string } = {},
+    options: { level?: string; msgPrefix?: string },
     factory: LoggerConstructor
   ) {
     this.bindings = bindings;

--- a/packages/client/src/object/aggregate.ts
+++ b/packages/client/src/object/aggregate.ts
@@ -44,7 +44,7 @@ export async function aggregate<
 >(
   clientCtx: MinimalClient,
   objectType: Q,
-  objectSet: ObjectSet = resolveBaseObjectSetType(objectType),
+  objectSet: ObjectSet,
   req: AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<Q, AO>
 ): Promise<AggregationsResults<Q, AO>> {
   const resolvedObjectSet = resolveBaseObjectSetType(objectType);

--- a/packages/faux/src/FauxFoundry/FauxAdmin.ts
+++ b/packages/faux/src/FauxFoundry/FauxAdmin.ts
@@ -102,6 +102,10 @@ export class FauxAdmin {
   }
 
   listUsers(
+    // Reordering these params to satisfy default-param-last would change this
+    // exported method's signature; the `pageSize` default mirrors the API's
+    // "return all" behavior and is only reached when a caller passes `undefined`.
+    // oxlint-disable-next-line default-param-last
     pageSize: number | undefined = this.#users.length,
     pageToken: string | undefined,
     status: UserStatus | undefined

--- a/packages/faux/src/handlers/util/handleOpenApiCall.ts
+++ b/packages/faux/src/handlers/util/handleOpenApiCall.ts
@@ -41,6 +41,7 @@ export class OpenApiCallError extends Error {
         json.parameters
       )}`
     );
+    this.name = "OpenApiCallError";
   }
 }
 

--- a/packages/foundry-config-json/src/autoVersion.ts
+++ b/packages/foundry-config-json/src/autoVersion.ts
@@ -28,6 +28,7 @@ export class AutoVersionError extends Error {
     public readonly tip?: string
   ) {
     super(msg);
+    this.name = "AutoVersionError";
   }
 }
 

--- a/packages/functions/src/errors/UserFacingError.ts
+++ b/packages/functions/src/errors/UserFacingError.ts
@@ -17,5 +17,6 @@
 export class UserFacingError extends Error {
   constructor(message: string) {
     super(message);
+    this.name = "UserFacingError";
   }
 }

--- a/packages/shared.net.errors/src/PalantirApiError.ts
+++ b/packages/shared.net.errors/src/PalantirApiError.ts
@@ -15,7 +15,6 @@
  */
 
 export class PalantirApiError extends Error implements PalantirApiError {
-  public message: string;
   public errorName?: string;
   public errorCode?: string;
   public errorDescription?: string;
@@ -33,7 +32,7 @@ export class PalantirApiError extends Error implements PalantirApiError {
     parameters?: any
   ) {
     super(message);
-    this.message = message;
+    this.name = "PalantirApiError";
     this.errorName = errorName;
     this.errorCode = errorCode;
     this.errorDescription = errorDescription;

--- a/packages/shared.net.errors/src/UnknownError.ts
+++ b/packages/shared.net.errors/src/UnknownError.ts
@@ -25,6 +25,7 @@ export class UnknownError extends PalantirApiError {
     statusCode?: number
   ) {
     super(message, errorName, undefined, undefined, statusCode);
+    this.name = "UnknownError";
     this.originalError = originalError;
   }
 }

--- a/packages/shared.net.fetch/src/createFetchHeaderMutator.ts
+++ b/packages/shared.net.fetch/src/createFetchHeaderMutator.ts
@@ -15,6 +15,10 @@
  */
 
 export function createFetchHeaderMutator(
+  // Reordering these params to satisfy default-param-last would break this
+  // published function's signature; `mutator` is required, so the `= fetch`
+  // default is only reachable when a caller explicitly passes `undefined`.
+  // oxlint-disable-next-line default-param-last
   fetchFn: typeof fetch | undefined = fetch,
   mutator: (headers: Headers) => Promise<Headers> | Headers
 ): typeof fetch {

--- a/packages/tool.release/src/FailedWithUserMessage.ts
+++ b/packages/tool.release/src/FailedWithUserMessage.ts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+// `FailedWithUserMessage` is a deliberate name (thrown at ~10 call sites and
+// surfaced in vitest error snapshots); appending "Error" would be churn with no
+// behavioral benefit.
+// oxlint-disable-next-line unicorn/custom-error-definition
 export class FailedWithUserMessage extends Error {
   constructor(message: string) {
     super(message);

--- a/packages/widget.vite-plugin/src/client/app.tsx
+++ b/packages/widget.vite-plugin/src/client/app.tsx
@@ -43,6 +43,7 @@ class ResponseError extends Error {
 
   constructor(message: string, response: string, hint?: string) {
     super(message);
+    this.name = "ResponseError";
     this.response = response;
     this.hint = hint;
   }

--- a/packages/widget.vite-plugin/src/dev-plugin/publishDevModeSettings.ts
+++ b/packages/widget.vite-plugin/src/dev-plugin/publishDevModeSettings.ts
@@ -34,6 +34,7 @@ class ResponseError extends Error {
 
   constructor(message: string, response: string) {
     super(message);
+    this.name = "ResponseError";
     try {
       const parsed = JSON.parse(response);
       this.#response = JSON.stringify(parsed, null, 4);


### PR DESCRIPTION
## What

Re-enables two behavior/API-risk lint rules that the oxc migration parked at `"off"` in the root `oxlint.config.ts`, and fixes the underlying findings in the already-migrated packages. This is the first ("quick wins") PR in the effort to re-enable the six parked behavior rules, one rule (or group) per PR.

Rules flipped `off -> error`:
- `unicorn/custom-error-definition` (12 findings in migrated packages)
- `default-param-last` (4 findings in migrated packages)

## `unicorn/custom-error-definition`

Set `this.name` in the constructor of each custom `Error` subclass so instances report their own class name instead of the inherited `"Error"`:

- `PalantirApiError`, `UnknownError` (`shared.net.errors`)
- `ActionValidationError` (`client`)
- `OpenApiCallError` (`faux`)
- `AutoVersionError` (`foundry-config-json`)
- `UserFacingError` (`functions`)
- `ExitProcessError`, `YargsCheckError` (`cli.common`)
- `ResponseError` x2 (`widget.vite-plugin`)

`PalantirApiError` additionally drops the redundant `this.message = message` (and its field re-declaration): `super(message)` already sets it, and keeping a bare `message` field under `useDefineForClassFields` would reset it to `undefined`.

`tool.release`'s `FailedWithUserMessage` keeps its deliberate name (thrown at ~10 sites, surfaced in vitest error snapshots) via a scoped inline disable rather than an invasive class rename.

## `default-param-last`

All four findings are a defaulted parameter followed by a required one, so the default is unreachable at every call site.

- Internal functions get a clean fix by dropping the dead default: `BaseLogger` constructor (not public API; all 3 subclasses pass `options`) and the `@internal` `aggregate` helper (all callers pass `objectSet`).
- Exported functions keep their published signatures via a scoped inline disable: `createFetchHeaderMutator` (`shared.net.fetch`) and `FauxAdmin.listUsers` (`faux`).

Verified `.name`-based logic / serialization does not depend on these errors being named `"Error"`.

## Verification

- `oxlint` (root + affected nested configs): 0 findings for both rules in migrated packages
- `pnpm turbo typecheck transpile build`: green (50 tasks)
- `pnpm turbo test` for affected packages: green (client 950, faux 147, functions, foundry-config-json, shared.net.*, cli.common, widget.vite-plugin, tool.release)
- `pnpm turbo lint` for affected packages: green
- `pnpm turbo check-api` (client, functions): no API report changes
- `monorepolint check`: 0
- `dprint check`: clean

## Changeset

One `patch` changeset covering the changed public packages.

## Notes

The one remaining `custom-error-definition` finding (`typescript-docs-example-generator`) is in a package not yet migrated to oxlint (still on eslint), so it is out of scope and does not block CI.