### PR TITLE
chore: re-enable oxlint require-unicode-regexp

### DIFF
--- a/.changeset/oxc-reenable-require-unicode-regexp.md
+++ b/.changeset/oxc-reenable-require-unicode-regexp.md
@@ -1,5 +1,6 @@
 ---
 "@osdk/foundry-config-json": patch
+"@osdk/widget.vite-plugin": patch
 "@osdk/vite-plugin-superrepo": patch
 "@osdk/osdk-docs-context": patch
 "@osdk/maker-experimental": patch

--- a/.changeset/oxc-reenable-require-unicode-regexp.md
+++ b/.changeset/oxc-reenable-require-unicode-regexp.md
@@ -1,0 +1,25 @@
+---
+"@osdk/foundry-config-json": patch
+"@osdk/vite-plugin-superrepo": patch
+"@osdk/osdk-docs-context": patch
+"@osdk/maker-experimental": patch
+"@osdk/typescript-sdk-docs": patch
+"@osdk/react-components": patch
+"@osdk/react-devtools": patch
+"@osdk/vite-plugin-oac": patch
+"@osdk/cbac-components": patch
+"@osdk/seed-compiler": patch
+"@osdk/unit-testing": patch
+"@osdk/maker-import": patch
+"@osdk/create-app": patch
+"@osdk/create-widget": patch
+"@osdk/aip-core": patch
+"@osdk/client": patch
+"@osdk/faux": patch
+"@osdk/maker": patch
+"@osdk/react": patch
+"@osdk/cli": patch
+"@osdk/api": patch
+---
+
+Add the `u` (unicode) flag to regular expressions to satisfy the require-unicode-regexp lint rule

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { defineConfig } from "oxlint";
 import core from "ultracite/oxlint/core";
 import react from "ultracite/oxlint/react";
@@ -55,9 +71,7 @@ export default defineConfig({
     "default-param-last": "error",
     "require-await": "off",
     "typescript/require-await": "off",
-    // Adding the `u` flag to an existing regex can change its matching semantics;
-    // leave published runtime regexes untouched in this tooling migration.
-    "require-unicode-regexp": "off",
+    "require-unicode-regexp": "error",
 
     // --- Repo-wide cosmetic / high-churn policy ---
     // These rules from Ultracite's strict preset are auto-fixable but purely

--- a/packages/aip-core/src/generateText.e2e.test.ts
+++ b/packages/aip-core/src/generateText.e2e.test.ts
@@ -122,7 +122,7 @@ describeIfConfigured("generateText (e2e)", () => {
       expect(call.toolName).toBe("getWeather");
       const input = call.input as { city?: string };
       assertDefined(input.city, "tool call city");
-      expect(input.city.toLowerCase()).toMatch(/san\s*francisco|sf/);
+      expect(input.city.toLowerCase()).toMatch(/san\s*francisco|sf/u);
     },
     E2E_TIMEOUT_MS
   );

--- a/packages/aip-core/src/generateText.test.ts
+++ b/packages/aip-core/src/generateText.test.ts
@@ -225,7 +225,7 @@ describe("generateText", () => {
         prompt: "hi",
         messages: [{ role: "user", content: "also hi" }],
       })
-    ).rejects.toThrow(/cannot specify both/);
+    ).rejects.toThrow(/cannot specify both/u);
   });
 
   it("throws on non-OK responses", async () => {
@@ -237,7 +237,7 @@ describe("generateText", () => {
     const model = foundryModel({ client, model: "gpt-4o" });
 
     await expect(generateText({ model, prompt: "hi" })).rejects.toThrow(
-      /500.*Internal Server Error/
+      /500.*Internal Server Error/u
     );
   });
 

--- a/packages/aip-core/src/internal/streamStep.ts
+++ b/packages/aip-core/src/internal/streamStep.ts
@@ -179,7 +179,7 @@ async function parseSseStream(
       if (done) {
         break;
       }
-      buffer += value.replace(/\r\n/g, "\n");
+      buffer += value.replace(/\r\n/gu, "\n");
 
       let frameEnd = buffer.indexOf("\n\n");
       while (frameEnd !== -1) {

--- a/packages/aip-core/src/streamText.test.ts
+++ b/packages/aip-core/src/streamText.test.ts
@@ -358,7 +358,7 @@ describe("streamText", () => {
     const errChunk = chunks.find((c) => c.type === "error");
     expect(errChunk).toBeDefined();
 
-    await expect(result.text).rejects.toThrow(/500/);
+    await expect(result.text).rejects.toThrow(/500/u);
     await new Promise((r) => setTimeout(r, 0));
     expect(onError).toHaveBeenCalledTimes(1);
   });
@@ -400,7 +400,7 @@ describe("streamText", () => {
         prompt: "hi",
         messages: [{ role: "user", content: "also hi" }],
       })
-    ).toThrow(/cannot specify both/);
+    ).toThrow(/cannot specify both/u);
   });
 
   it("skips malformed SSE frames and surfaces a warning", async () => {
@@ -461,6 +461,6 @@ describe("streamText", () => {
     const chunks = await collectChunks(result.fullStream);
     const errChunk = chunks.find((c) => c.type === "error");
     expect(errChunk).toBeDefined();
-    await expect(result.text).rejects.toThrow(/upstream model went away/);
+    await expect(result.text).rejects.toThrow(/upstream model went away/u);
   });
 });

--- a/packages/api/src/__quickinfo_snapshot__/quickInfoTypes.test.ts
+++ b/packages/api/src/__quickinfo_snapshot__/quickInfoTypes.test.ts
@@ -44,7 +44,7 @@ const allProbes = renderQuickInfoProbes({
 
 describe("quickinfo snapshots", () => {
   for (const probesFile of probesFiles) {
-    const surface = probesFile.replace(/\.ts$/, "");
+    const surface = probesFile.replace(/\.ts$/u, "");
     it(surface, async () => {
       await expect(
         allProbes[path.join(probesDir, probesFile)]

--- a/packages/api/src/__quickinfo_snapshot__/testUtils.probe.ts
+++ b/packages/api/src/__quickinfo_snapshot__/testUtils.probe.ts
@@ -143,12 +143,12 @@ function probeDescription(
       `probe \`${name}\` is missing a JSDoc — add a /** ... */ block above its declaration`
     );
   }
-  return text.replace(/\s+/g, " ").trim();
+  return text.replace(/\s+/gu, " ").trim();
 }
 
 // Strip absolute import paths so the snapshot is identical across machines.
 function scrub(s: string): string {
-  return s.replace(/import\("[^"]+"\)\./g, "");
+  return s.replace(/import\("[^"]+"\)\./gu, "");
 }
 
 // Pretty-print one probes file's worth of probes as TS-flavored snapshot

--- a/packages/api/src/shapes/ShapeBuilder.test.ts
+++ b/packages/api/src/shapes/ShapeBuilder.test.ts
@@ -37,7 +37,7 @@ describe("createShapeBuilder", () => {
       .build();
 
     expect(shape.__baseTypeApiName).toBe("Employee");
-    expect(shape.__shapeId).toMatch(/^[0-9a-f]{8}$/);
+    expect(shape.__shapeId).toMatch(/^[0-9a-f]{8}$/u);
     const props = shape.__props as Record<string, ShapePropertyConfig>;
     expect(props.name.nullabilityOp.type).toBe("select");
     expect(props.age.nullabilityOp.type).toBe("select");

--- a/packages/api/src/shapes/computeShapeId.test.ts
+++ b/packages/api/src/shapes/computeShapeId.test.ts
@@ -39,7 +39,7 @@ function makeInput(
 describe("computeShapeId", () => {
   it("returns a deterministic 8-char hex string", () => {
     const id = computeShapeId(makeInput());
-    expect(id).toMatch(/^[0-9a-f]{8}$/);
+    expect(id).toMatch(/^[0-9a-f]{8}$/u);
     expect(computeShapeId(makeInput())).toBe(id);
   });
 

--- a/packages/cbac-components/scripts/build-css.mjs
+++ b/packages/cbac-components/scripts/build-css.mjs
@@ -71,7 +71,7 @@ async function rewriteCssImports() {
 
     // Replace CSS module imports to point to .js files
     const updatedContent = content.replaceAll(
-      /from\s+["']([^"']+\.module\.css)["']/g,
+      /from\s+["']([^"']+\.module\.css)["']/gu,
       'from "$1.js"'
     );
 

--- a/packages/cli.common/src/commands/auth/login/loginFlow.ts
+++ b/packages/cli.common/src/commands/auth/login/loginFlow.ts
@@ -133,9 +133,9 @@ async function generateCodeChallenge(codeVerifier: string) {
   const digest = await subtle.digest("SHA-256", data);
   const codeChallengeMethod = "S256";
   const codeChallenge = btoa(String.fromCharCode(...new Uint8Array(digest)))
-    .replace(/\//g, "_")
-    .replace(/\+/g, "-")
-    .replace(/=/g, "");
+    .replace(/\//gu, "_")
+    .replace(/\+/gu, "-")
+    .replace(/=/gu, "");
   return {
     codeChallenge,
     codeChallengeMethod,

--- a/packages/cli/src/util/token.ts
+++ b/packages/cli/src/util/token.ts
@@ -106,6 +106,6 @@ export function validate(token: string): void {
 
 function isJWT(token: string): boolean {
   // https://stackoverflow.com/a/65755789
-  const jwtPattern = /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]*$/;
+  const jwtPattern = /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]*$/u;
   return jwtPattern.test(token);
 }

--- a/packages/client/src/object/convertWireToOsdkObjects/OsdkCustomInspectPrototype.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/OsdkCustomInspectPrototype.ts
@@ -78,7 +78,7 @@ function customInspect(
     ret += `  ${options.stylize("$as", "special")}: ${localInspect(
       this[UnderlyingOsdkObject],
       newOptions
-    ).replace(/\n/g, `\n  `)}`;
+    ).replace(/\n/gu, `\n  `)}`;
     ret += "\n";
   }
 

--- a/packages/client/src/object/formatting/formatNumber.ts
+++ b/packages/client/src/object/formatting/formatNumber.ts
@@ -359,7 +359,7 @@ function maybeConvertNegativeToParenthesis(
   shouldConvert: boolean
 ): string {
   if (shouldConvert && value < 0) {
-    return formatted.replace(/^-/, "(") + ")";
+    return formatted.replace(/^-/u, "(") + ")";
   }
   return formatted;
 }

--- a/packages/client/src/objectSet/InterfaceObjectSet.test.ts
+++ b/packages/client/src/objectSet/InterfaceObjectSet.test.ts
@@ -176,7 +176,7 @@ describe("ObjectSet", () => {
 
         // @ts-expect-error
         expect(() => ifaceObj.$as(ComplexImplementationObject)).toThrowError(
-          /has a non-local implementation/
+          /has a non-local implementation/u
         );
       })();
     });

--- a/packages/client/src/observable/internal/getObjectTypesThatInvalidate.test.ts
+++ b/packages/client/src/observable/internal/getObjectTypesThatInvalidate.test.ts
@@ -341,7 +341,7 @@ describe(getObjectTypesThatInvalidate, () => {
           client[additionalContext],
           wireObjectSet as any
         )
-      ).rejects.toThrow(/Unsupported|Unhandled ObjectSet type/);
+      ).rejects.toThrow(/Unsupported|Unhandled ObjectSet type/u);
     }
   });
 

--- a/packages/client/src/observable/internal/media/BlobMemoryManager.test.ts
+++ b/packages/client/src/observable/internal/media/BlobMemoryManager.test.ts
@@ -54,7 +54,7 @@ describe("BlobMemoryManager", () => {
     manager.add("key", blob);
 
     const url1 = manager.createBlobUrl("key");
-    expect(url1).toMatch(/^blob:/);
+    expect(url1).toMatch(/^blob:/u);
 
     const url2 = manager.createBlobUrl("key");
     expect(url2).toBe(url1);
@@ -76,7 +76,7 @@ describe("BlobMemoryManager", () => {
     manager.releaseBlobUrl("key");
 
     const url4 = manager.createBlobUrl("key");
-    expect(url4).toMatch(/^blob:/);
+    expect(url4).toMatch(/^blob:/u);
     expect(url4).toBe(url1);
   });
 

--- a/packages/client/src/scenarios/ScenarioClient.test.ts
+++ b/packages/client/src/scenarios/ScenarioClient.test.ts
@@ -64,7 +64,7 @@ describe("ScenarioClient methods", () => {
         "https://mock.com"
       );
       expect(url.pathname).toMatch(
-        /\/scenarios\/ri\.actions\.\.scenario\.abc\/editedEntityTypes$/
+        /\/scenarios\/ri\.actions\.\.scenario\.abc\/editedEntityTypes$/u
       );
       expect(result.objectTypes).toEqual(["Employee", "Office"]);
       expect(result.linkTypes).toEqual([
@@ -96,7 +96,7 @@ describe("ScenarioClient methods", () => {
         "https://mock.com"
       );
       expect(url.pathname).toMatch(
-        /\/scenarios\/ri\.actions\.\.scenario\.abc\/objects\/Employee\/edited$/
+        /\/scenarios\/ri\.actions\.\.scenario\.abc\/objects\/Employee\/edited$/u
       );
       expect(url.searchParams.get("pageSize")).toBe("100");
       expect(url.searchParams.get("pageToken")).toBe("tok-1");
@@ -176,7 +176,7 @@ describe("ScenarioClient methods", () => {
         "https://mock.com"
       );
       expect(url.pathname).toMatch(
-        /\/scenarios\/ri\.actions\.\.scenario\.abc\/objectTypes\/Employee\/outgoingLinkTypes\/edited$/
+        /\/scenarios\/ri\.actions\.\.scenario\.abc\/objectTypes\/Employee\/outgoingLinkTypes\/edited$/u
       );
       expect(result).toEqual(["lead", "peeps"]);
     });
@@ -225,7 +225,7 @@ describe("ScenarioClient methods", () => {
         "https://mock.com"
       );
       expect(url.pathname).toMatch(
-        /\/scenarios\/ri\.actions\.\.scenario\.abc\/objects\/Employee\/links\/lead\/edited$/
+        /\/scenarios\/ri\.actions\.\.scenario\.abc\/objects\/Employee\/links\/lead\/edited$/u
       );
       expect(url.searchParams.get("pageSize")).toBe("100");
       expect(url.searchParams.get("pageToken")).toBe("tok-1");

--- a/packages/client/src/scenarios/createScenario.test.ts
+++ b/packages/client/src/scenarios/createScenario.test.ts
@@ -58,7 +58,7 @@ describe("createScenario", () => {
       fetchFunction.mock.calls[0][0] as string,
       "https://mock.com"
     );
-    expect(createUrl.pathname).toMatch(/\/scenarios\/create$/);
+    expect(createUrl.pathname).toMatch(/\/scenarios\/create$/u);
 
     expect(scenario.getScenarioReference()).toBe(newScenarioRid);
 
@@ -94,13 +94,13 @@ describe("createScenario", () => {
 
     const scenario = await createScenario(txClient);
 
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/transaction/));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/transaction/u));
     expect(scenario.getScenarioReference()).toBe(newScenarioRid);
     warnSpy.mockRestore();
   });
 
   it("rejects a client already scoped to a scenario at runtime", async () => {
     const scenario = withScenario(client, "ri.actions..scenario.abc");
-    await expect(createScenario(scenario)).rejects.toThrow(/scenario/);
+    await expect(createScenario(scenario)).rejects.toThrow(/scenario/u);
   });
 });

--- a/packages/client/src/scenarios/withScenario.test.ts
+++ b/packages/client/src/scenarios/withScenario.test.ts
@@ -80,7 +80,7 @@ describe("withScenario", () => {
       fetchFunction
     );
     const scenario = withScenario(txClient, "ri.actions..scenario.abc");
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/transaction/));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/transaction/u));
     expect(scenario.getScenarioReference()).toBe("ri.actions..scenario.abc");
     warnSpy.mockRestore();
   });
@@ -88,7 +88,7 @@ describe("withScenario", () => {
   it("rejects a client already scoped to a scenario at runtime", () => {
     const scenario = withScenario(client, "ri.actions..scenario.abc");
     expect(() => withScenario(scenario, "ri.actions..scenario.def")).toThrow(
-      /scenario/
+      /scenario/u
     );
   });
 });

--- a/packages/client/src/util/datetimeConverters.ts
+++ b/packages/client/src/util/datetimeConverters.ts
@@ -17,7 +17,7 @@
 import invariant from "tiny-invariant";
 
 const isoRegex =
-  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?$/;
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?$/u;
 
 /**
  * Extracts the date from a ISO 8601 formatted date time string. Throws if the input is not in the correct format.

--- a/packages/client/src/util/toDataValue.test.ts
+++ b/packages/client/src/util/toDataValue.test.ts
@@ -214,7 +214,7 @@ describe(toDataValue, () => {
       mockActionMetadata
     );
 
-    expect(converted).toMatch(/ri\.attachments.main.attachment\.[a-z0-9\-]+/i);
+    expect(converted).toMatch(/ri\.attachments.main.attachment\.[a-z0-9\-]+/iu);
   });
 
   it("converts file attachment uploads correctly", async () => {
@@ -227,7 +227,7 @@ describe(toDataValue, () => {
     );
 
     const converted = await toDataValue(file, clientCtx, mockActionMetadata);
-    expect(converted).toMatch(/ri\.attachments.main.attachment\.[a-z0-9\-]+/i);
+    expect(converted).toMatch(/ri\.attachments.main.attachment\.[a-z0-9\-]+/iu);
   });
 
   it("converts media uploads correctly", async () => {

--- a/packages/create-app.template-packager/src/index.ts
+++ b/packages/create-app.template-packager/src/index.ts
@@ -112,7 +112,7 @@ export async function cli(): Promise<void> {
 
 function safeRaw(q: string): string {
   return `{ type: "raw",  body: \`${q
-    .replace(/\\/g, "\\\\")
-    .replace(/`/g, "\\`")
-    .replace(/\$/g, "\\$")}\`}`;
+    .replace(/\\/gu, "\\\\")
+    .replace(/`/gu, "\\`")
+    .replace(/\$/gu, "\\$")}\`}`;
 }

--- a/packages/create-app/src/generate/generateNpmRc.ts
+++ b/packages/create-app/src/generate/generateNpmRc.ts
@@ -32,8 +32,8 @@ export function generateNpmRc({
         : osdkRegistryUrl + "/"
       : null;
   const formattedFoundryUrl = foundryUrl
-    .replace(/^https:\/\//, "")
-    .replace(/\/$/, "");
+    .replace(/^https:\/\//u, "")
+    .replace(/\/$/u, "");
   const artifactsApiUrl = formattedFoundryUrl + "/artifacts/api/";
   const packageScope = osdkPackage?.split("/")[0];
 

--- a/packages/create-app/src/prompts/promptApplicationRid.ts
+++ b/packages/create-app/src/prompts/promptApplicationRid.ts
@@ -24,7 +24,7 @@ export async function promptApplicationRid({
 }): Promise<string> {
   while (
     application == null ||
-    !/^ri\.third-party-applications\.[^.]+\.application\.[^.]+$/.test(
+    !/^ri\.third-party-applications\.[^.]+\.application\.[^.]+$/u.test(
       application
     )
   ) {

--- a/packages/create-app/src/prompts/promptApplicationUrl.ts
+++ b/packages/create-app/src/prompts/promptApplicationUrl.ts
@@ -49,7 +49,7 @@ export async function promptApplicationUrl({
     }
   }
 
-  while (applicationUrl == null || !/^https?:\/\//.test(applicationUrl)) {
+  while (applicationUrl == null || !/^https?:\/\//u.test(applicationUrl)) {
     if (applicationUrl != null) {
       consola.fail("Please enter a valid application URL");
     }
@@ -60,5 +60,5 @@ export async function promptApplicationUrl({
       { type: "text" }
     );
   }
-  return applicationUrl.replace(/\/$/, "");
+  return applicationUrl.replace(/\/$/u, "");
 }

--- a/packages/create-app/src/prompts/promptClientId.ts
+++ b/packages/create-app/src/prompts/promptClientId.ts
@@ -22,7 +22,7 @@ export async function promptClientId({
 }: {
   clientId?: string;
 }): Promise<string> {
-  while (clientId == null || !/^[0-9a-f]+$/.test(clientId)) {
+  while (clientId == null || !/^[0-9a-f]+$/u.test(clientId)) {
     if (clientId != null) {
       consola.fail("Please enter a valid OAuth client ID");
     }

--- a/packages/create-app/src/prompts/promptFoundryUrl.ts
+++ b/packages/create-app/src/prompts/promptFoundryUrl.ts
@@ -33,5 +33,5 @@ export async function promptFoundryUrl({
       { type: "text" }
     );
   }
-  return foundryUrl.replace(/\/$/, "");
+  return foundryUrl.replace(/\/$/u, "");
 }

--- a/packages/create-app/src/prompts/promptOntologyAndOsdkPackageAndOsdkRegistryUrl.ts
+++ b/packages/create-app/src/prompts/promptOntologyAndOsdkPackageAndOsdkRegistryUrl.ts
@@ -66,7 +66,7 @@ export async function promptOntologyAndOsdkPackageAndOsdkRegistryUrl({
 
   while (
     ontology == null ||
-    !/^ri\.ontology\.[^.]+\.ontology\.[^.]+$/.test(ontology)
+    !/^ri\.ontology\.[^.]+\.ontology\.[^.]+$/u.test(ontology)
   ) {
     if (ontology != null) {
       consola.fail("Please enter a valid Ontology resource identifier (rid)");
@@ -79,7 +79,7 @@ export async function promptOntologyAndOsdkPackageAndOsdkRegistryUrl({
     );
   }
 
-  while (osdkPackage == null || !/^@[a-z0-9-]+\/sdk$/.test(osdkPackage)) {
+  while (osdkPackage == null || !/^@[a-z0-9-]+\/sdk$/u.test(osdkPackage)) {
     if (osdkPackage != null) {
       consola.fail("Please enter a valid OSDK package name");
     }
@@ -93,7 +93,7 @@ export async function promptOntologyAndOsdkPackageAndOsdkRegistryUrl({
 
   while (
     osdkRegistryUrl == null ||
-    !/^https:\/\/[^/]+\/artifacts\/api\/repositories\/ri\.artifacts\.[^/]+\/contents\/release\/npm\/?$/.test(
+    !/^https:\/\/[^/]+\/artifacts\/api\/repositories\/ri\.artifacts\.[^/]+\/contents\/release\/npm\/?$/u.test(
       osdkRegistryUrl
     )
   ) {
@@ -113,6 +113,6 @@ export async function promptOntologyAndOsdkPackageAndOsdkRegistryUrl({
   return {
     ontology,
     osdkPackage,
-    osdkRegistryUrl: osdkRegistryUrl.replace(/\/$/, ""),
+    osdkRegistryUrl: osdkRegistryUrl.replace(/\/$/u, ""),
   };
 }

--- a/packages/create-app/src/prompts/promptProject.ts
+++ b/packages/create-app/src/prompts/promptProject.ts
@@ -21,7 +21,7 @@ export async function promptProject({
 }: {
   project?: string;
 }): Promise<string> {
-  while (project == null || !/^[a-zA-Z0-9-_]+$/.test(project)) {
+  while (project == null || !/^[a-zA-Z0-9-_]+$/u.test(project)) {
     if (project != null) {
       consola.fail(
         "Project name can only contain alphanumeric characters, hyphens and underscores"

--- a/packages/create-app/src/prompts/promptScopes.ts
+++ b/packages/create-app/src/prompts/promptScopes.ts
@@ -16,7 +16,7 @@
 
 import { consola } from "../consola.js";
 
-const scopeNameRegex = /^[a-zA-Z-_:]+$/;
+const scopeNameRegex = /^[a-zA-Z-_:]+$/u;
 
 export async function promptScopes({
   scopes,

--- a/packages/create-app/src/run.ts
+++ b/packages/create-app/src/run.ts
@@ -144,7 +144,7 @@ export async function run({
       if (fullPath.endsWith("/_gitignore")) {
         fs.renameSync(
           fullPath,
-          fullPath.replace(/\/_gitignore$/, "/.gitignore")
+          fullPath.replace(/\/_gitignore$/u, "/.gitignore")
         );
         return;
       }
@@ -175,7 +175,7 @@ export async function run({
       const templated = Handlebars.compile(fs.readFileSync(fullPath, "utf-8"))(
         templateContext
       );
-      fs.writeFileSync(fullPath.replace(/.hbs$/, ""), templated);
+      fs.writeFileSync(fullPath.replace(/.hbs$/u, ""), templated);
       fs.rmSync(fullPath);
     });
   };

--- a/packages/create-widget/src/generate/generateNpmRc.ts
+++ b/packages/create-widget/src/generate/generateNpmRc.ts
@@ -29,8 +29,8 @@ export function generateNpmRc({
     ? osdkRegistryUrl
     : osdkRegistryUrl + "/";
   const formattedFoundryUrl = foundryUrl
-    .replace(/^https:\/\//, "")
-    .replace(/\/$/, "");
+    .replace(/^https:\/\//u, "")
+    .replace(/\/$/u, "");
   const artifactsApiUrl = formattedFoundryUrl + "/artifacts/api/";
   const packageScope = osdkPackage.split("/")[0];
 

--- a/packages/create-widget/src/prompts/promptFoundryUrl.ts
+++ b/packages/create-widget/src/prompts/promptFoundryUrl.ts
@@ -33,5 +33,5 @@ export async function promptFoundryUrl({
       { type: "text" }
     );
   }
-  return foundryUrl.replace(/\/$/, "");
+  return foundryUrl.replace(/\/$/u, "");
 }

--- a/packages/create-widget/src/prompts/promptOsdkPackage.ts
+++ b/packages/create-widget/src/prompts/promptOsdkPackage.ts
@@ -22,7 +22,7 @@ export async function promptOsdkPackage({
 }: {
   osdkPackage?: string;
 }): Promise<string> {
-  while (osdkPackage == null || !/^@[a-z0-9-]+\/sdk$/.test(osdkPackage)) {
+  while (osdkPackage == null || !/^@[a-z0-9-]+\/sdk$/u.test(osdkPackage)) {
     if (osdkPackage != null) {
       consola.fail("Please enter a valid OSDK package name");
     }

--- a/packages/create-widget/src/prompts/promptOsdkRegistryUrl.ts
+++ b/packages/create-widget/src/prompts/promptOsdkRegistryUrl.ts
@@ -24,7 +24,7 @@ export async function promptOsdkRegistryUrl({
 }): Promise<string> {
   while (
     osdkRegistryUrl == null ||
-    !/^https:\/\/[^/]+\/artifacts\/api\/repositories\/ri\.[^/]+\/contents\/release\/npm\/?$/.test(
+    !/^https:\/\/[^/]+\/artifacts\/api\/repositories\/ri\.[^/]+\/contents\/release\/npm\/?$/u.test(
       osdkRegistryUrl
     )
   ) {
@@ -40,5 +40,5 @@ export async function promptOsdkRegistryUrl({
       { type: "text" }
     );
   }
-  return osdkRegistryUrl.replace(/\/$/, "");
+  return osdkRegistryUrl.replace(/\/$/u, "");
 }

--- a/packages/create-widget/src/prompts/promptProject.ts
+++ b/packages/create-widget/src/prompts/promptProject.ts
@@ -21,7 +21,7 @@ export async function promptProject({
 }: {
   project?: string;
 }): Promise<string> {
-  while (project == null || !/^[a-zA-Z0-9-_]+$/.test(project)) {
+  while (project == null || !/^[a-zA-Z0-9-_]+$/u.test(project)) {
     if (project != null) {
       consola.fail(
         "Project name can only contain alphanumeric characters, hyphens and underscores"

--- a/packages/create-widget/src/prompts/promptWidgetSetRid.ts
+++ b/packages/create-widget/src/prompts/promptWidgetSetRid.ts
@@ -24,7 +24,7 @@ export async function promptWidgetSetRid({
 }): Promise<string> {
   while (
     widgetSet == null ||
-    !/^ri\.widgetregistry\.\.widget-set\.[^.]+$/.test(widgetSet)
+    !/^ri\.widgetregistry\.\.widget-set\.[^.]+$/u.test(widgetSet)
   ) {
     if (widgetSet != null) {
       consola.fail("Please enter a valid widget resource identifier (rid)");

--- a/packages/create-widget/src/run.ts
+++ b/packages/create-widget/src/run.ts
@@ -106,7 +106,7 @@ export async function run({
       }
 
       if (file.endsWith("/_gitignore")) {
-        fs.renameSync(file, file.replace(/\/_gitignore$/, "/.gitignore"));
+        fs.renameSync(file, file.replace(/\/_gitignore$/u, "/.gitignore"));
         return;
       }
 
@@ -116,7 +116,7 @@ export async function run({
       const templated = Handlebars.compile(fs.readFileSync(file, "utf-8"))(
         templateContext
       );
-      fs.writeFileSync(file.replace(/.hbs$/, ""), templated);
+      fs.writeFileSync(file.replace(/.hbs$/u, ""), templated);
       fs.rmSync(file);
     });
   };

--- a/packages/e2e.sandbox.catchall/src/loggingFetch.ts
+++ b/packages/e2e.sandbox.catchall/src/loggingFetch.ts
@@ -30,7 +30,7 @@ export async function loggingFetch(
         : input.url
   );
 
-  const cleaned = url.pathname.replace(/ri.ontology..*?\//, "{rid}/");
+  const cleaned = url.pathname.replace(/ri.ontology..*?\//u, "{rid}/");
 
   logger.debug(`fetch(${chalk.blue(cleaned)})`);
   return await fetch(url, init);

--- a/packages/e2e.sandbox.officeassignment/src/utils/statusFilter.ts
+++ b/packages/e2e.sandbox.officeassignment/src/utils/statusFilter.ts
@@ -57,7 +57,7 @@ export interface LatestStatusQuery {
 // derived-property names, so identical queries can share/coalesce in the observable cache. Each
 // (type, value) is unique within one call, so the sanitized join is unique too.
 function uidFor(type: string, value: string): string {
-  return `${type}_${value}`.replace(/[^a-zA-Z0-9]/g, "_");
+  return `${type}_${value}`.replace(/[^a-zA-Z0-9]/gu, "_");
 }
 
 /**

--- a/packages/e2e.sandbox.peopleapp/src/app/employees/DownloadEmployeesButton.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/employees/DownloadEmployeesButton.tsx
@@ -88,7 +88,7 @@ function formatCellValue(cell: unknown): string {
 }
 
 function escapeCsvCell(value: string): string {
-  if (!/[",\n\r]/.test(value)) {
+  if (!/[",\n\r]/u.test(value)) {
     return value;
   }
   return `"${value.replaceAll('"', '""')}"`;

--- a/packages/faux/src/FauxFoundry/filterObjects.ts
+++ b/packages/faux/src/FauxFoundry/filterObjects.ts
@@ -164,7 +164,7 @@ export function filterObjects(
         throw new Error("propertyIdentifier not supported");
       }
       invariant(field);
-      const searchTerms = where.value.toLowerCase().split(/\s+/);
+      const searchTerms = where.value.toLowerCase().split(/\s+/u);
       return objects.filter((obj) => {
         const fieldValue = obj[field];
         if (typeof fieldValue === "string") {
@@ -182,7 +182,7 @@ export function filterObjects(
         throw new Error("propertyIdentifier not supported");
       }
       invariant(field);
-      const searchTerms = where.value.toLowerCase().split(/\s+/);
+      const searchTerms = where.value.toLowerCase().split(/\s+/u);
       return objects.filter((obj) => {
         const fieldValue = obj[field];
         if (typeof fieldValue === "string") {
@@ -200,7 +200,7 @@ export function filterObjects(
         throw new Error("propertyIdentifier not supported");
       }
       invariant(field);
-      const searchTerms = where.value.toLowerCase().split(/\s+/);
+      const searchTerms = where.value.toLowerCase().split(/\s+/u);
       return objects.filter((obj) => {
         const fieldValue = obj[field];
         if (typeof fieldValue === "string") {
@@ -227,7 +227,7 @@ export function filterObjects(
         throw new Error("propertyIdentifier not supported");
       }
       invariant(field);
-      const searchTerms = where.value.toLowerCase().split(/\s+/);
+      const searchTerms = where.value.toLowerCase().split(/\s+/u);
       return objects.filter((obj) => {
         const fieldValue = obj[field];
         if (typeof fieldValue === "string") {
@@ -261,6 +261,7 @@ export function filterObjects(
         throw new Error("propertyIdentifier not supported");
       }
       invariant(field);
+      // oxlint-disable-next-line require-unicode-regexp -- dynamic pattern; adding the u flag could change matching or throw on patterns that are valid without it
       const pattern = new RegExp(where.value);
       return objects.filter((obj) => {
         const fieldValue = obj[field];

--- a/packages/faux/src/FauxFoundry/validateAction.ts
+++ b/packages/faux/src/FauxFoundry/validateAction.ts
@@ -449,7 +449,7 @@ function isValidDateString(value: unknown): boolean {
     return false;
   }
 
-  const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+  const dateRegex = /^\d{4}-\d{2}-\d{2}$/u;
   if (!dateRegex.test(value)) {
     return false;
   }
@@ -503,6 +503,6 @@ function isValidDecimalString(value: unknown): boolean {
     return false;
   }
 
-  const decimalRegex = /^[+-]?(\d+\.?\d*|\.\d+)(E[+-]?\d+)?$/;
+  const decimalRegex = /^[+-]?(\d+\.?\d*|\.\d+)(E[+-]?\d+)?$/u;
   return decimalRegex.test(value) && !isNaN(parseFloat(value));
 }

--- a/packages/faux/src/handlers/util/camelize.ts
+++ b/packages/faux/src/handlers/util/camelize.ts
@@ -15,5 +15,5 @@
  */
 
 export function camelize(name: string): string {
-  return name.replace(/-./g, (segment) => segment[1].toUpperCase());
+  return name.replace(/-./gu, (segment) => segment[1].toUpperCase());
 }

--- a/packages/faux/src/handlers/util/handleOpenApiCall.ts
+++ b/packages/faux/src/handlers/util/handleOpenApiCall.ts
@@ -136,7 +136,7 @@ export function handleOpenApiCall<
         u.search = ""; // msw doesn't want the search string
         captured = {
           method: req.method as any,
-          endPoint: u.toString().replace(/%3A/g, ":"),
+          endPoint: u.toString().replace(/%3A/gu, ":"),
         };
 
         // fake a response object so the call doesn't fail

--- a/packages/foundry-config-json/src/autoVersion.ts
+++ b/packages/foundry-config-json/src/autoVersion.ts
@@ -56,8 +56,10 @@ export async function autoVersion(config: AutoVersionConfig): Promise<string> {
 async function gitDescribeAutoVersion(tagPrefix: string = ""): Promise<string> {
   const [matchPrefix, prefixRegex] =
     tagPrefix !== ""
-      ? [tagPrefix, new RegExp(`^${tagPrefix}`)]
-      : [undefined, new RegExp(`^v?`)];
+      ? // oxlint-disable-next-line require-unicode-regexp -- dynamic pattern; adding the u flag could change matching or throw on patterns that are valid without it
+        [tagPrefix, new RegExp(`^${tagPrefix}`)]
+      : // oxlint-disable-next-line require-unicode-regexp -- dynamic pattern; adding the u flag could change matching or throw on patterns that are valid without it
+        [undefined, new RegExp(`^v?`)];
 
   const gitVersion = await gitDescribe(matchPrefix);
   const version = gitVersion.trim().replace(prefixRegex, "");

--- a/packages/maker-experimental/src/api/overall.test.ts
+++ b/packages/maker-experimental/src/api/overall.test.ts
@@ -1200,7 +1200,7 @@ describe("Experimental Test Suite", () => {
         });
       })
     ).rejects.toThrow(
-      /Property 'ghostProperty' used in derived datasource .* is not (defined|a property)/
+      /Property 'ghostProperty' used in derived datasource .* is not (defined|a property)/u
     );
   });
 });

--- a/packages/maker-experimental/src/cli/generateBackingDataset.test.ts
+++ b/packages/maker-experimental/src/cli/generateBackingDataset.test.ts
@@ -170,10 +170,10 @@ describe("propertyTypeToSchemaType", () => {
 
   it("throws on unsupported property types", () => {
     expect(() => propertyTypeToSchemaType("unknownType")).toThrow(
-      /Unsupported property type "unknownType".*empty backing datasource/
+      /Unsupported property type "unknownType".*empty backing datasource/u
     );
     expect(() => propertyTypeToSchemaType({ type: "geopoint" })).toThrow(
-      /Unsupported property type "geopoint".*empty backing datasource/
+      /Unsupported property type "geopoint".*empty backing datasource/u
     );
   });
 });

--- a/packages/maker-experimental/src/cli/main.ts
+++ b/packages/maker-experimental/src/cli/main.ts
@@ -48,9 +48,9 @@ import {
 import type { BlockGeneratorResult } from "./marketplaceSerialization/BlockGeneratorResult.js";
 import type { InputMappingEntry } from "./marketplaceSerialization/supportingTypes.js";
 
-const apiNamespaceRegex = /^[a-z0-9-]+(\.[a-z0-9-]+)*\.$/;
+const apiNamespaceRegex = /^[a-z0-9-]+(\.[a-z0-9-]+)*\.$/u;
 const uuidRegex =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u;
 
 export default async function main(
   args: string[] = process.argv

--- a/packages/maker-experimental/src/cli/marketplaceSerialization/CodeBlockSpec.ts
+++ b/packages/maker-experimental/src/cli/marketplaceSerialization/CodeBlockSpec.ts
@@ -102,7 +102,7 @@ function generateUUIDFromStr(input: crypto.BinaryLike): UUID {
   md5Bytes[8] |= 0x80; /* set to IETF variant  */
   const hex = md5Bytes.toString("hex");
   const uuid = hex.replace(
-    /(\w{8})(\w{4})(\w{4})(\w{4})(\w{12})/,
+    /(\w{8})(\w{4})(\w{4})(\w{4})(\w{12})/u,
     "$1-$2-$3-$4-$5"
   );
   return uuid as UUID;

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertActionParameters.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertActionParameters.ts
@@ -21,7 +21,7 @@ import type { ActionType } from "@osdk/maker";
 import type { OntologyRidGenerator } from "../../util/generateRid.js";
 
 const FUNCTIONS_IR_INTERFACE_TYPE_RID_REGEX =
-  /^ri\.ontology-metadata\.temp\.interface-type\.[0-9a-f]+$/;
+  /^ri\.ontology-metadata\.temp\.interface-type\.[0-9a-f]+$/u;
 
 export function convertActionParameters(
   action: ActionType,

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertDatasourceDefinition.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertDatasourceDefinition.ts
@@ -477,7 +477,7 @@ function convertSecurityCondition(
  */
 function convertToJavaDurationFormat(iso8601: string): string {
   const match = iso8601.match(
-    /^P(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/
+    /^P(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/u
   );
   if (!match) return iso8601;
 

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertInterface.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertInterface.ts
@@ -41,7 +41,7 @@ export function convertInterface(
           ...status,
           deprecated: {
             ...status.deprecated,
-            deadline: status.deprecated.deadline?.replace(/\.000Z$/, "Z"),
+            deadline: status.deprecated.deadline?.replace(/\.000Z$/u, "Z"),
           },
         }
       : status;

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertLink.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertLink.ts
@@ -223,7 +223,7 @@ function validateLink(linkDefinition: LinkType) {
     );
 
     invariant(
-      /([a-z][a-z0-9\\-]*)/.test(linkDefinition.apiName),
+      /([a-z][a-z0-9\\-]*)/u.test(linkDefinition.apiName),
       `Top level link api names are expected to match the regex pattern ([a-z][a-z0-9\\-]*) ${linkDefinition.apiName} does not match`
     );
 

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertOntologyDefinitionToWireBlockData.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertOntologyDefinitionToWireBlockData.ts
@@ -479,7 +479,7 @@ function buildKnownIdentifiers(
   Array.from(ridGenerator.getActionTypeRids().inverse().entries()).forEach(
     ([actionTypeRid, actionReadableId]) => {
       // Extract action type API name from readable ID
-      const actionTypeApiName = actionReadableId.replace(/^action-type-/, "");
+      const actionTypeApiName = actionReadableId.replace(/^action-type-/u, "");
       const paramBiMap = ridGenerator
         .getParameterRidAndIds()
         .get(actionTypeApiName);

--- a/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ActionTypeShapeExtractor.test.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ActionTypeShapeExtractor.test.ts
@@ -146,7 +146,7 @@ function createMockRidGenerator(
     },
     getObjectTypeIds: () => new MockBiMap([]) as any,
     generateObjectTypeId: (objectTypeApiName: string) =>
-      objectTypeApiName.replace(/\./g, "-").toLowerCase(),
+      objectTypeApiName.replace(/\./gu, "-").toLowerCase(),
     generateDatasourceRid: (datasourceName: string) =>
       `ri.ontology.main.datasource.${datasourceName}`,
     generateValidationRuleRid: (actionTypeApiName: string, index: number) =>

--- a/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ObjectTypeShapeExtractor.test.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ObjectTypeShapeExtractor.test.ts
@@ -150,7 +150,7 @@ function createMockRidGenerator(
     },
     getObjectTypeIds: () => new MockBiMap([]) as any,
     generateObjectTypeId: (objectTypeApiName: string) =>
-      objectTypeApiName.replace(/\./g, "-").toLowerCase(),
+      objectTypeApiName.replace(/\./gu, "-").toLowerCase(),
     generateDatasourceRid: (datasourceName: string) =>
       `ri.ontology.main.datasource.${datasourceName}`,
     generateValidationRuleRid: (actionTypeApiName: string, index: number) =>

--- a/packages/maker-experimental/src/util/generateRid.ts
+++ b/packages/maker-experimental/src/util/generateRid.ts
@@ -1045,7 +1045,7 @@ export class OntologyRidGeneratorImpl implements OntologyRidGenerator {
     }
 
     // Match Java: apiName.replace(".", "-").toLowerCase()
-    const objectTypeId = objectTypeApiName.replace(/\./g, "-").toLowerCase();
+    const objectTypeId = objectTypeApiName.replace(/\./gu, "-").toLowerCase();
     this.objectTypeIds.put(readableId, objectTypeId);
     return objectTypeId;
   }

--- a/packages/maker-import/src/generate/utils.ts
+++ b/packages/maker-import/src/generate/utils.ts
@@ -33,7 +33,7 @@ export function withoutNamespace(apiName: string): string {
  * "Employee" -> "employee"
  */
 export function fullCamel(apiName: string): string {
-  return camel(apiName.replace(/\./g, "-"));
+  return camel(apiName.replace(/\./gu, "-"));
 }
 
 /**
@@ -45,7 +45,7 @@ export function camel(str: string): string {
   if (!str) {
     return str;
   }
-  let result = str.replace(/[-_]+(.)?/g, (_, c) => (c ? c.toUpperCase() : ""));
+  let result = str.replace(/[-_]+(.)?/gu, (_, c) => (c ? c.toUpperCase() : ""));
   result = result.charAt(0).toLowerCase() + result.slice(1);
   return result;
 }

--- a/packages/maker-import/src/generate/writeImportedOntology.ts
+++ b/packages/maker-import/src/generate/writeImportedOntology.ts
@@ -180,7 +180,7 @@ function writeEntityFile(
   const dirName = DIR_NAME_MAP[entityType];
 
   const entityJSON = JSON.stringify(entity, null, 2).replace(
-    /("__type"\s*:\s*)"([^"]*)"/g,
+    /("__type"\s*:\s*)"([^"]*)"/gu,
     (_, prefix, value) => `${prefix}OntologyEntityTypeEnum.${value}`
   );
 

--- a/packages/maker/src/api/defineAction.ts
+++ b/packages/maker/src/api/defineAction.ts
@@ -143,7 +143,7 @@ export function defineAction(actionDefInput: ActionTypeDefinition): ActionType {
     );
   }
   invariant(
-    /^[a-z0-9]+(-[a-z0-9]+)*$/.test(actionDef.apiName),
+    /^[a-z0-9]+(-[a-z0-9]+)*$/u.test(actionDef.apiName),
     `Action type apiName "${actionDef.apiName}" must be alphanumeric, lowercase, and kebab-case`
   );
 
@@ -923,9 +923,9 @@ function maybeAddList(
 
 export function kebab(s: string): string {
   return s
-    .replace(/([a-z])([A-Z])/g, "$1-$2")
-    .replace(/([A-Z])([A-Z][a-z])/g, "$1-$2")
-    .replace(/\./g, "-")
+    .replace(/([a-z])([A-Z])/gu, "$1-$2")
+    .replace(/([A-Z])([A-Z][a-z])/gu, "$1-$2")
+    .replace(/\./gu, "-")
     .toLowerCase();
 }
 

--- a/packages/maker/src/api/defineFunction.ts
+++ b/packages/maker/src/api/defineFunction.ts
@@ -110,9 +110,9 @@ export async function generateFunctionsIr(
   }
 
   // Normalize to forward slashes to match TypeScript's internal path format
-  const normalizedRootDir = rootDir.replace(/\\/g, "/");
+  const normalizedRootDir = rootDir.replace(/\\/gu, "/");
   const tsConfigPath =
-    configPath?.replace(/\\/g, "/") ?? normalizedRootDir + "/tsconfig.json";
+    configPath?.replace(/\\/gu, "/") ?? normalizedRootDir + "/tsconfig.json";
   const program = OntologyIrToFullMetadataConverter.createProgram(
     tsConfigPath,
     normalizedRootDir

--- a/packages/maker/src/api/defineObject.ts
+++ b/packages/maker/src/api/defineObject.ts
@@ -53,11 +53,11 @@ import type { PropertyTypeType } from "./properties/PropertyTypeType.js";
 import { isExotic, isStruct } from "./properties/PropertyTypeType.js";
 // From https://stackoverflow.com/a/79288714
 const ISO_8601_DURATION =
-  /^P(?!$)(?:(?:((?:\d+Y)|(?:\d+(?:\.|,)\d+Y$))?((?:\d+M)|(?:\d+(?:\.|,)\d+M$))?((?:\d+D)|(?:\d+(?:\.|,)\d+D$))?(T((?:\d+H)|(?:\d+(?:\.|,)\d+H$))?((?:\d+M)|(?:\d+(?:\.|,)\d+M$))?((?:\d+S)|(?:\d+(?:\.|,)\d+S$))?)?)|(?:\d+(?:(?:\.|,)\d+)?W))$/;
+  /^P(?!$)(?:(?:((?:\d+Y)|(?:\d+(?:\.|,)\d+Y$))?((?:\d+M)|(?:\d+(?:\.|,)\d+M$))?((?:\d+D)|(?:\d+(?:\.|,)\d+D$))?(T((?:\d+H)|(?:\d+(?:\.|,)\d+H$))?((?:\d+M)|(?:\d+(?:\.|,)\d+M$))?((?:\d+S)|(?:\d+(?:\.|,)\d+S$))?)?)|(?:\d+(?:(?:\.|,)\d+)?W))$/u;
 
 // ISO 8601 date and time format (YYYY-MM-DDThh:mm:ss.sssZ)
 const ISO_8601_DATETIME =
-  /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?)?$/;
+  /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?)?$/u;
 
 export function defineObject(
   objectDefInput: ObjectTypeDefinition

--- a/packages/maker/src/api/defineOntology.ts
+++ b/packages/maker/src/api/defineOntology.ts
@@ -192,7 +192,7 @@ export function writeStaticObjects(outputDir: string): void {
             null,
             2
           ).replace(
-            /("__type"\s*:\s*)"([^"]*)"/g,
+            /("__type"\s*:\s*)"([^"]*)"/gu,
             (_, prefix, value) => `${prefix}OntologyEntityTypeEnum.${value}`
           );
           const content = `
@@ -394,15 +394,15 @@ function filterCyclicReferences(
 
 export function cleanAndValidateLinkTypeId(apiName: string): string {
   // Insert a dash before any uppercase letter that follows a lowercase letter or digit
-  const step1 = apiName.replace(/([a-z0-9])([A-Z])/g, "$1-$2");
+  const step1 = apiName.replace(/([a-z0-9])([A-Z])/gu, "$1-$2");
   // Insert a dash after a sequence of uppercase letters when followed by a lowercase letter
   // then convert the whole string to lowercase
   // e.g., apiName, APIname, and apiNAME will all be converted to api-name
   const linkTypeId = step1
-    .replace(/([A-Z])([A-Z][a-z])/g, "$1-$2")
+    .replace(/([A-Z])([A-Z][a-z])/gu, "$1-$2")
     .toLowerCase();
 
-  const VALIDATION_PATTERN = /^([a-z][a-z0-9\-]*)$/;
+  const VALIDATION_PATTERN = /^([a-z][a-z0-9\-]*)$/u;
   if (!VALIDATION_PATTERN.test(linkTypeId)) {
     throw new Error(
       `LinkType id '${linkTypeId}' must be lower case with dashes.`
@@ -760,7 +760,7 @@ function camel(str: string): string {
   if (!str) {
     return str;
   }
-  let result = str.replace(/[-_]+(.)?/g, (_, c) => (c ? c.toUpperCase() : ""));
+  let result = str.replace(/[-_]+(.)?/gu, (_, c) => (c ? c.toUpperCase() : ""));
   result = result.charAt(0).toLowerCase() + result.slice(1);
   return result;
 }

--- a/packages/maker/src/api/defineValueType.ts
+++ b/packages/maker/src/api/defineValueType.ts
@@ -156,7 +156,7 @@ export function defineValueType(
   } = valueTypeDef;
   const apiName = namespacePrefix ? namespace + inputApiName : inputApiName;
   const semverValidation =
-    /^((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$/;
+    /^((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$/u;
   invariant(semverValidation.test(version), "Version is not a valid semver");
 
   const existingVersions =

--- a/packages/maker/src/api/test/actions.test.ts
+++ b/packages/maker/src/api/test/actions.test.ts
@@ -16923,7 +16923,7 @@ describe("Action Types", () => {
           },
         ],
       })
-    ).toThrow(/referenced but not defined/);
+    ).toThrow(/referenced but not defined/u);
   });
 
   it("Interface link action with unknown ILC throws", () => {
@@ -16993,7 +16993,7 @@ describe("Action Types", () => {
           },
         ],
       })
-    ).toThrow(/Interface link type .* does not exist on interface/);
+    ).toThrow(/Interface link type .* does not exist on interface/u);
   });
 
   it("serializes publicProject permission on action type", async () => {

--- a/packages/maker/src/api/test/defineCreateInterfaceLinkAction.test.ts
+++ b/packages/maker/src/api/test/defineCreateInterfaceLinkAction.test.ts
@@ -521,7 +521,7 @@ describe("defineCreateInterfaceLinkAction", () => {
         from: person,
         interfaceLink: "employer",
       })
-    ).toThrow(/Interface link constraint "employer" not found on interface/);
+    ).toThrow(/Interface link constraint "employer" not found on interface/u);
   });
 
   it("throws when the ILC target interface is not defined", () => {
@@ -542,7 +542,7 @@ describe("defineCreateInterfaceLinkAction", () => {
         from: person,
         interfaceLink: "employer",
       })
-    ).toThrow(/Target interface .* is not defined/);
+    ).toThrow(/Target interface .* is not defined/u);
   });
 
   it("throws when an explicit from does not match the handle's interface", () => {
@@ -569,7 +569,7 @@ describe("defineCreateInterfaceLinkAction", () => {
 
     expect(() =>
       defineCreateInterfaceLinkAction({ from: other, interfaceLink: employer })
-    ).toThrow(/does not match/);
+    ).toThrow(/does not match/u);
   });
 
   it("throws when interfaceLink is a string and from is omitted", () => {
@@ -592,7 +592,7 @@ describe("defineCreateInterfaceLinkAction", () => {
     expect(() =>
       // @ts-expect-error "from" is required when interfaceLink is a string
       defineCreateInterfaceLinkAction({ interfaceLink: "employer" })
-    ).toThrow(/"from" is required/);
+    ).toThrow(/"from" is required/u);
   });
 });
 
@@ -789,7 +789,7 @@ describe("defineDeleteInterfaceLinkAction", () => {
     expect(() =>
       // @ts-expect-error "from" is required when interfaceLink is a string
       defineDeleteInterfaceLinkAction({ interfaceLink: "employer" })
-    ).toThrow(/"from" is required/);
+    ).toThrow(/"from" is required/u);
   });
 
   it("throws when source and target parameter ids collide", () => {
@@ -816,7 +816,7 @@ describe("defineDeleteInterfaceLinkAction", () => {
         sourceParameter: { id: "shared" },
         targetParameter: { id: "shared" },
       })
-    ).toThrow(/must differ/);
+    ).toThrow(/must differ/u);
   });
 
   it("threads custom display metadata and status through", () => {

--- a/packages/maker/src/api/test/objectStatus.test.ts
+++ b/packages/maker/src/api/test/objectStatus.test.ts
@@ -43,7 +43,7 @@ describe("Object Status", () => {
               },
             })
           ).toThrowError(
-            /Object "validationTest" has "experimental" status, but the following properties have a different status: bar/
+            /Object "validationTest" has "experimental" status, but the following properties have a different status: bar/u
           );
         },
         "/tmp/"
@@ -95,7 +95,7 @@ describe("Object Status", () => {
               },
             })
           ).toThrowError(
-            /Object "exampleActiveProp" has "example" status, but the following properties have a different status: bar/
+            /Object "exampleActiveProp" has "example" status, but the following properties have a different status: bar/u
           );
         },
         "/tmp/"
@@ -126,7 +126,7 @@ describe("Object Status", () => {
               },
             })
           ).toThrowError(
-            /Object "deprecatedActiveProp" has "deprecated" status, but the following properties have a different status: bar/
+            /Object "deprecatedActiveProp" has "deprecated" status, but the following properties have a different status: bar/u
           );
         },
         "/tmp/"

--- a/packages/maker/src/api/test/objects.test.ts
+++ b/packages/maker/src/api/test/objects.test.ts
@@ -40,7 +40,7 @@ describe("Object Types", () => {
         properties: { bar: { type: "string" } },
       });
     }).toThrowErrorMatchingInlineSnapshot(
-      `[Error: Invariant failed: Invalid API name foo_with_underscores. API names must match the regex /^[a-zA-Z][a-zA-Z0-9]{0,99}$/.]`
+      `[Error: Invariant failed: Invalid API name foo_with_underscores. API names must match the regex /^[a-zA-Z][a-zA-Z0-9]{0,99}$/u.]`
     );
   });
   it("Fails if any property reference does not exist", () => {
@@ -1641,7 +1641,7 @@ describe("Object Types", () => {
       },
     });
     expect(() => dumpOntologyFullMetadata()).toThrow(
-      /Property 'ghostProperty' used in derived datasource .* is not (defined|a property)/
+      /Property 'ghostProperty' used in derived datasource .* is not (defined|a property)/u
     );
   });
   it("Derived datasources are properly defined", () => {

--- a/packages/maker/src/cli/main.ts
+++ b/packages/maker/src/cli/main.ts
@@ -25,9 +25,9 @@ import { hideBin } from "yargs/helpers";
 
 import { defineOntology } from "../api/defineOntology.js";
 
-const apiNamespaceRegex = /^[a-z0-9-]+(\.[a-z0-9-]+)*\.$/;
+const apiNamespaceRegex = /^[a-z0-9-]+(\.[a-z0-9-]+)*\.$/u;
 const uuidRegex =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u;
 
 export default async function main(
   args: string[] = process.argv

--- a/packages/maker/src/conversion/toMarketplace/convertLink.ts
+++ b/packages/maker/src/conversion/toMarketplace/convertLink.ts
@@ -202,7 +202,7 @@ function validateLink(linkDefinition: LinkType) {
     );
 
     invariant(
-      /([a-z][a-z0-9\\-]*)/.test(linkDefinition.apiName),
+      /([a-z][a-z0-9\\-]*)/u.test(linkDefinition.apiName),
       `Top level link api names are expected to match the regex pattern ([a-z][a-z0-9\\-]*) ${linkDefinition.apiName} does not match`
     );
 

--- a/packages/maker/src/util/ApiNameValidator.ts
+++ b/packages/maker/src/util/ApiNameValidator.ts
@@ -25,8 +25,8 @@ const RESERVED_KEYWORDS = new Set([
   "typeid",
   "ontologyobject",
 ]);
-export const OBJECT_API_NAME_PATTERN: RegExp = /^[a-zA-Z][a-zA-Z0-9]{0,99}$/;
-export const API_NAME_PATTERN: RegExp = /^[a-zA-Z][a-zA-Z0-9_]{0,99}$/;
+export const OBJECT_API_NAME_PATTERN: RegExp = /^[a-zA-Z][a-zA-Z0-9]{0,99}$/u;
+export const API_NAME_PATTERN: RegExp = /^[a-zA-Z][a-zA-Z0-9_]{0,99}$/u;
 
 export function isValidApiName(apiName: string): boolean {
   return (

--- a/packages/osdk-docs-context/src/OsdkExamplesContext.ts
+++ b/packages/osdk-docs-context/src/OsdkExamplesContext.ts
@@ -99,6 +99,7 @@ export class OsdkExamplesContext {
    */
   static searchExamples(pattern: string): Array<ExampleSearchResult> {
     const results: Array<ExampleSearchResult> = [];
+    // oxlint-disable-next-line require-unicode-regexp -- dynamic pattern; adding the u flag could change matching or throw on patterns that are valid without it
     const regex = new RegExp(pattern, "i");
 
     for (const [version, versionData] of Object.entries(
@@ -127,6 +128,7 @@ export class OsdkExamplesContext {
     pattern: string
   ): Array<ExampleSearchResult> {
     const results: Array<ExampleSearchResult> = [];
+    // oxlint-disable-next-line require-unicode-regexp -- dynamic pattern; adding the u flag could change matching or throw on patterns that are valid without it
     const regex = new RegExp(pattern, "i");
 
     for (const [version, versionData] of Object.entries(

--- a/packages/osdk-docs-context/src/nestedOsdkExamplesContext.test.ts
+++ b/packages/osdk-docs-context/src/nestedOsdkExamplesContext.test.ts
@@ -133,8 +133,8 @@ describe("NestedOsdkExamplesContext", () => {
         variations!["^isUnary"].code
       );
       // Check for structure rather than specific method names
-      expect(variations!["#isUnary"].code).toMatch(/selectProperty|aggregate/);
-      expect(variations!["^isUnary"].code).toMatch(/aggregate|withProperties/);
+      expect(variations!["#isUnary"].code).toMatch(/selectProperty|aggregate/u);
+      expect(variations!["^isUnary"].code).toMatch(/aggregate|withProperties/u);
     });
 
     it("returns undefined for simple examples without variations", () => {

--- a/packages/osdk-docs-context/src/nestedOsdkExamplesContext.ts
+++ b/packages/osdk-docs-context/src/nestedOsdkExamplesContext.ts
@@ -268,6 +268,7 @@ export class NestedOsdkExamplesContext {
       metadata: ExampleMetadata;
       sourceVersion: string;
     }> = [];
+    // oxlint-disable-next-line require-unicode-regexp -- dynamic pattern; adding the u flag could change matching or throw on patterns that are valid without it
     const regex = new RegExp(pattern, "i");
 
     if (targetVersion) {

--- a/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/color-utils.ts
+++ b/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/color-utils.ts
@@ -39,7 +39,7 @@ export const WCAG_AA_LARGE = 3;
 
 /** Parse hex color (3- or 6-digit) to RGB tuple */
 function hexToRgb(hex: string): [number, number, number] | null {
-  const short = /^#?([0-9a-f])([0-9a-f])([0-9a-f])$/i.exec(hex);
+  const short = /^#?([0-9a-f])([0-9a-f])([0-9a-f])$/iu.exec(hex);
   if (short) {
     return [
       parseInt(short[1] + short[1], 16),
@@ -47,7 +47,7 @@ function hexToRgb(hex: string): [number, number, number] | null {
       parseInt(short[3] + short[3], 16),
     ];
   }
-  const full = /^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+  const full = /^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/iu.exec(hex);
   if (!full) return null;
   return [parseInt(full[1], 16), parseInt(full[2], 16), parseInt(full[3], 16)];
 }

--- a/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/decorator.tsx
+++ b/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/decorator.tsx
@@ -56,7 +56,7 @@ export const BrandThemeDecorator: Decorator = (Story, context) => {
 
       if (
         (roleDef.inputType === "px" || roleDef.inputType === "ms") &&
-        /^\d+(\.\d+)?$/.test(value)
+        /^\d+(\.\d+)?$/u.test(value)
       ) {
         value = `${value}${roleDef.inputType}`;
       }

--- a/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/export.ts
+++ b/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/export.ts
@@ -41,7 +41,7 @@ function resolveTokens(assignments: TokenAssignment[]): ResolvedToken[] {
     // Append unit suffix for px/ms inputs if the value is purely numeric
     if (
       (roleDef.inputType === "px" || roleDef.inputType === "ms") &&
-      /^\d+(\.\d+)?$/.test(value)
+      /^\d+(\.\d+)?$/u.test(value)
     ) {
       value = `${value}${roleDef.inputType}`;
     }
@@ -181,7 +181,7 @@ export function generateMarkdown(
 
 function quoteIfNeeded(value: string): string {
   // Quote hex colors and values with spaces/special chars
-  if (value.startsWith("#") || /\s/.test(value) || value.includes(",")) {
+  if (value.startsWith("#") || /\s/u.test(value) || value.includes(",")) {
     return `"${value}"`;
   }
   return value;

--- a/packages/react-components-storybook/.storybook/crypto-polyfill.ts
+++ b/packages/react-components-storybook/.storybook/crypto-polyfill.ts
@@ -19,7 +19,7 @@ export const randomUUID = (): string => {
     return crypto.randomUUID();
   }
   // Fallback for older browsers
-  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replaceAll(/[xy]/g, (c) => {
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replaceAll(/[xy]/gu, (c) => {
     const r = (Math.random() * 16) | 0;
     const v = c === "x" ? r : (r & 0x3) | 0x8;
     return v.toString(16);

--- a/packages/react-components-storybook/.storybook/manager.ts
+++ b/packages/react-components-storybook/.storybook/manager.ts
@@ -79,7 +79,7 @@ addons.register(ADDON_ID, () => {
     type: types.TOOL,
     title: "Theme",
     match: ({ viewMode, tabId }) =>
-      Boolean(viewMode?.match(/^(story|docs)$/)) && !tabId,
+      Boolean(viewMode?.match(/^(story|docs)$/u)) && !tabId,
     render: ThemeToolbar,
   });
 

--- a/packages/react-components-storybook/.storybook/preview.tsx
+++ b/packages/react-components-storybook/.storybook/preview.tsx
@@ -117,8 +117,8 @@ const preview: Preview = {
     },
     controls: {
       matchers: {
-        color: /(background|color)$/i,
-        date: /Date$/i,
+        color: /(background|color)$/iu,
+        date: /Date$/iu,
       },
     },
     docs: {

--- a/packages/react-components-storybook/src/stories/ActionForm/ActionForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ActionForm/ActionForm.stories.tsx
@@ -503,10 +503,10 @@ export const SubmitSuccess: Story = {
 
     const canvas = within(canvasElement);
     const fullNameInput = await canvas.findByRole("textbox", {
-      name: /^fullName/,
+      name: /^fullName/u,
     });
     const submitButton = await canvas.findByRole("button", {
-      name: /submit/i,
+      name: /submit/iu,
     });
 
     await userEvent.type(fullNameInput, "Ada Lovelace");
@@ -516,7 +516,7 @@ export const SubmitSuccess: Story = {
     await expect(
       await canvas.findByText("Submit succeeded.")
     ).toBeInTheDocument();
-    await expect(await canvas.findByText(/Ada Lovelace/)).toBeInTheDocument();
+    await expect(await canvas.findByText(/Ada Lovelace/u)).toBeInTheDocument();
   },
 };
 
@@ -530,10 +530,10 @@ export const SubmitFailure: Story = {
 
     const canvas = within(canvasElement);
     const fullNameInput = await canvas.findByRole("textbox", {
-      name: /^fullName/,
+      name: /^fullName/u,
     });
     const submitButton = await canvas.findByRole("button", {
-      name: /submit/i,
+      name: /submit/iu,
     });
 
     await userEvent.type(fullNameInput, "Margaret Hamilton");
@@ -543,7 +543,7 @@ export const SubmitFailure: Story = {
     await waitFor(() => expect(errorSpy).toHaveBeenCalled());
     await expect(await canvas.findByText("Submit failed.")).toBeInTheDocument();
     await expect(
-      await canvas.findByText(/Demo submission failed/)
+      await canvas.findByText(/Demo submission failed/u)
     ).toBeInTheDocument();
   },
   parameters: {
@@ -569,9 +569,9 @@ export const ValidationErrors: Story = {
     successSpy.mockClear();
 
     const canvas = within(canvasElement);
-    await canvas.findByRole("textbox", { name: /^fullName/ });
+    await canvas.findByRole("textbox", { name: /^fullName/u });
     const submitButton = await canvas.findByRole("button", {
-      name: /submit/i,
+      name: /submit/iu,
     });
     await userEvent.click(submitButton);
 
@@ -595,7 +595,7 @@ export const SubmitDisabled: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(
-      await canvas.findByRole("button", { name: /submit/i })
+      await canvas.findByRole("button", { name: /submit/iu })
     ).toBeDisabled();
   },
 };
@@ -609,10 +609,10 @@ export const SlowCustomSubmit: Story = {
 
     const canvas = within(canvasElement);
     const fullNameInput = await canvas.findByRole("textbox", {
-      name: /^fullName/,
+      name: /^fullName/u,
     });
     const submitButton = await canvas.findByRole("button", {
-      name: /submit/i,
+      name: /submit/iu,
     });
 
     await userEvent.type(fullNameInput, "Katherine Johnson");
@@ -620,7 +620,7 @@ export const SlowCustomSubmit: Story = {
 
     await waitFor(() => expect(slowSubmitSpy).toHaveBeenCalled());
     await expect(
-      await canvas.findByRole("button", { name: /submitting/i })
+      await canvas.findByRole("button", { name: /submitting/iu })
     ).toBeDisabled();
   },
   parameters: {
@@ -652,10 +652,10 @@ export const CustomSubmitHandler: Story = {
 
     const canvas = within(canvasElement);
     const fullNameInput = await canvas.findByRole("textbox", {
-      name: /^fullName/,
+      name: /^fullName/u,
     });
     const submitButton = await canvas.findByRole("button", {
-      name: /submit/i,
+      name: /submit/iu,
     });
 
     await userEvent.type(fullNameInput, "Grace Hopper");

--- a/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
@@ -994,7 +994,7 @@ export const WithValidation: Story = {
   },
 };
 
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/u;
 
 const customValidateFormContent: ReadonlyArray<FormContentItem> = [
   field({

--- a/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.stories.tsx
@@ -710,9 +710,9 @@ export const MultipleSelection: Story = {
     // Re-query fresh each time: toggling the header re-renders the rows, so
     // checkbox refs captured earlier could go stale.
     const rowCheckboxes = () =>
-      canvas.findAllByRole("checkbox", { name: /select row/i });
+      canvas.findAllByRole("checkbox", { name: /select row/iu });
     const deselectAllCheckbox = () =>
-      canvas.findByRole("checkbox", { name: /deselect all rows/i });
+      canvas.findByRole("checkbox", { name: /deselect all rows/iu });
 
     // Wait for the (MSW-mocked) rows to load, then grab the per-row checkboxes.
     const [firstRow, secondRow] = await rowCheckboxes();
@@ -1971,7 +1971,7 @@ export const EditableWithValidation: Story = {
         locator: { type: "property", id: "emailPrimaryWork" },
         editable: true,
         validateEdit: async (value: unknown) => {
-          const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+          const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/u;
           return emailRegex.test(String(value ?? ""))
             ? undefined
             : "Please enter a valid email address";

--- a/packages/react-components-storybook/src/stories/ObjectTable/Recipes/WithLoadedDataDownload.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/Recipes/WithLoadedDataDownload.stories.tsx
@@ -199,7 +199,7 @@ function formatCellValue(value: unknown): string {
 }
 
 function escapeCsvCell(value: string): string {
-  if (!/[",\n\r]/.test(value)) {
+  if (!/[",\n\r]/u.test(value)) {
     return value;
   }
 

--- a/packages/react-components/scripts/build-css.mjs
+++ b/packages/react-components/scripts/build-css.mjs
@@ -73,7 +73,7 @@ async function rewriteCssImports() {
 
     // Replace CSS module imports to point to .js files
     const updatedContent = content.replaceAll(
-      /from\s+["']([^"']+\.module\.css)["']/g,
+      /from\s+["']([^"']+\.module\.css)["']/gu,
       'from "$1.js"'
     );
 

--- a/packages/react-components/src/action-form/__tests__/ActionForm.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/ActionForm.test.tsx
@@ -176,8 +176,8 @@ describe("ActionForm", () => {
     it("generates default fields from fetched metadata", () => {
       render(<ActionForm actionDefinition={TestAction} />);
 
-      expect(screen.getByRole("textbox", { name: /^name/ })).toBeDefined();
-      expect(screen.getByRole("textbox", { name: /^email/ })).toBeDefined();
+      expect(screen.getByRole("textbox", { name: /^name/u })).toBeDefined();
+      expect(screen.getByRole("textbox", { name: /^email/u })).toBeDefined();
     });
 
     it("renders default field labels from parameter keys", () => {
@@ -229,7 +229,7 @@ describe("ActionForm", () => {
       const input = screen.getByRole("textbox", { name: "Full Name" });
       expect(input).toHaveProperty("disabled", true);
 
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await vi.waitFor(() => {
         expect(mockApplyAction).toHaveBeenCalledWith(
@@ -243,7 +243,7 @@ describe("ActionForm", () => {
     it("renders submit button", () => {
       render(<ActionForm actionDefinition={TestAction} />);
 
-      expect(screen.getByRole("button", { name: /submit/i }).textContent).toBe(
+      expect(screen.getByRole("button", { name: /submit/iu }).textContent).toBe(
         "Submit"
       );
     });
@@ -256,7 +256,7 @@ describe("ActionForm", () => {
 
       render(<ActionForm actionDefinition={TestAction} />);
 
-      const button = screen.getByRole("button", { name: /submitting/i });
+      const button = screen.getByRole("button", { name: /submitting/iu });
       expect((button as HTMLButtonElement).disabled).toBe(true);
       expect(button.textContent).toBe("Submitting\u2026");
     });
@@ -273,10 +273,10 @@ describe("ActionForm", () => {
       );
 
       // Fill required field before submitting
-      fireEvent.input(screen.getByRole("textbox", { name: /^name/ }), {
+      fireEvent.input(screen.getByRole("textbox", { name: /^name/u }), {
         target: { value: "Alice" },
       });
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await vi.waitFor(() => {
         expect(onSuccess).toHaveBeenCalledWith(result);
@@ -291,10 +291,10 @@ describe("ActionForm", () => {
       render(<ActionForm actionDefinition={TestAction} onError={onError} />);
 
       // Fill required field before submitting
-      fireEvent.input(screen.getByRole("textbox", { name: /^name/ }), {
+      fireEvent.input(screen.getByRole("textbox", { name: /^name/u }), {
         target: { value: "Alice" },
       });
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await vi.waitFor(() => {
         expect(onError).toHaveBeenCalledWith({
@@ -314,7 +314,7 @@ describe("ActionForm", () => {
       );
 
       // Submit without filling the required "name" field
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await vi.waitFor(() => {
         expect(screen.getByRole("alert")).toBeDefined();
@@ -344,7 +344,7 @@ describe("ActionForm", () => {
         <ActionForm actionDefinition={TestAction} onSuccess={onSuccess} />
       );
 
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await vi.waitFor(() => {
         expect(onSuccess).toHaveBeenCalledWith(result);
@@ -369,7 +369,7 @@ describe("ActionForm", () => {
         />
       );
 
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await vi.waitFor(() => {
         expect(mockApplyAction).toHaveBeenCalledWith(
@@ -400,10 +400,10 @@ describe("ActionForm", () => {
 
       render(<ControlledWrapper />);
 
-      const textInput = screen.getByRole("textbox", { name: /^name/ });
+      const textInput = screen.getByRole("textbox", { name: /^name/u });
       fireEvent.change(textInput, { target: { value: "Updated" } });
 
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await vi.waitFor(() => {
         expect(mockApplyAction).toHaveBeenCalledWith(

--- a/packages/react-components/src/action-form/__tests__/BaseForm.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/BaseForm.test.tsx
@@ -106,10 +106,10 @@ describe("BaseForm", () => {
         />
       );
 
-      const nameInput = screen.getByRole("textbox", { name: /name/ });
+      const nameInput = screen.getByRole("textbox", { name: /name/u });
       fireEvent.change(nameInput, { target: { value: "Alice" } });
 
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await vi.waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith(
@@ -131,7 +131,7 @@ describe("BaseForm", () => {
       fireEvent.submit(form!);
       expect(onSubmit).not.toHaveBeenCalled();
 
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await vi.waitFor(() => {
         expect(onSubmit).toHaveBeenCalledTimes(1);
@@ -148,7 +148,7 @@ describe("BaseForm", () => {
         />
       );
 
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await vi.waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith(
@@ -178,10 +178,10 @@ describe("BaseForm", () => {
         />
       );
 
-      const nameInput = screen.getByRole("textbox", { name: /name/ });
+      const nameInput = screen.getByRole("textbox", { name: /name/u });
       fireEvent.change(nameInput, { target: { value: "Typed" } });
 
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await vi.waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith(
@@ -214,7 +214,7 @@ describe("BaseForm", () => {
         />
       );
 
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await vi.waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith(
@@ -399,7 +399,7 @@ describe("BaseForm", () => {
         />
       );
 
-      const nameInput = screen.getByRole("textbox", { name: /name/ });
+      const nameInput = screen.getByRole("textbox", { name: /name/u });
       fireEvent.change(nameInput, { target: { value: "Updated" } });
 
       expect(onFieldValueChange).toHaveBeenCalledWith("name", "Updated");
@@ -417,7 +417,7 @@ describe("BaseForm", () => {
         />
       );
 
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await vi.waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith(
@@ -457,10 +457,10 @@ describe("BaseForm", () => {
 
       render(<ControlledWrapper />);
 
-      const nameInput = screen.getByRole("textbox", { name: /name/ });
+      const nameInput = screen.getByRole("textbox", { name: /name/u });
       fireEvent.change(nameInput, { target: { value: "Updated" } });
 
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await vi.waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith(
@@ -484,10 +484,10 @@ describe("BaseForm", () => {
         />
       );
 
-      const nameInput = screen.getByRole("textbox", { name: /name/ });
+      const nameInput = screen.getByRole("textbox", { name: /name/u });
       fireEvent.change(nameInput, { target: { value: "User Typed This" } });
 
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await vi.waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith(
@@ -506,7 +506,7 @@ describe("BaseForm", () => {
         />
       );
 
-      const input = screen.getByRole("textbox", { name: /name/ });
+      const input = screen.getByRole("textbox", { name: /name/u });
       fireEvent.focus(input);
       fireEvent.blur(input);
 
@@ -532,7 +532,7 @@ describe("BaseForm", () => {
         />
       );
 
-      const input = screen.getByRole("textbox", { name: /name/ });
+      const input = screen.getByRole("textbox", { name: /name/u });
       fireEvent.change(input, { target: { value: "ab" } });
       fireEvent.blur(input);
 
@@ -551,7 +551,7 @@ describe("BaseForm", () => {
         />
       );
 
-      const input = screen.getByRole("textbox", { name: /name/ });
+      const input = screen.getByRole("textbox", { name: /name/u });
       fireEvent.focus(input);
       fireEvent.blur(input);
 
@@ -575,7 +575,7 @@ describe("BaseForm", () => {
         />
       );
 
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await waitFor(() => {
         expect(screen.getByRole("alert")).toBeDefined();
@@ -593,7 +593,7 @@ describe("BaseForm", () => {
       );
 
       const getSubmitButton = () =>
-        screen.getByRole("button", { name: /submit/i }) as HTMLButtonElement;
+        screen.getByRole("button", { name: /submit/iu }) as HTMLButtonElement;
 
       expect(getSubmitButton().disabled).toBe(false);
 
@@ -613,10 +613,10 @@ describe("BaseForm", () => {
       );
 
       const getSubmitButton = () =>
-        screen.getByRole("button", { name: /submit/i }) as HTMLButtonElement;
+        screen.getByRole("button", { name: /submit/iu }) as HTMLButtonElement;
 
       // Touch the field first so RHF tracks it for revalidation
-      const input = screen.getByRole("textbox", { name: /name/ });
+      const input = screen.getByRole("textbox", { name: /name/u });
       fireEvent.focus(input);
       fireEvent.blur(input);
 
@@ -647,7 +647,7 @@ describe("BaseForm", () => {
         <BaseForm formContent={[field(makeDef("name"))]} onSubmit={onSubmit} />
       );
 
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await waitFor(() => {
         expect(screen.getByText("Server error")).toBeDefined();
@@ -660,13 +660,13 @@ describe("BaseForm", () => {
         <BaseForm formContent={[field(makeDef("name"))]} onSubmit={onSubmit} />
       );
 
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await waitFor(() => {
         expect(screen.getByText("Server error")).toBeDefined();
       });
 
-      const input = screen.getByRole("textbox", { name: /name/ });
+      const input = screen.getByRole("textbox", { name: /name/u });
       fireEvent.change(input, { target: { value: "Alice" } });
 
       await waitFor(() => {
@@ -682,7 +682,7 @@ describe("BaseForm", () => {
         />
       );
 
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await waitFor(() => {
         expect(screen.getByText("1 issue")).toBeDefined();
@@ -701,18 +701,20 @@ describe("BaseForm", () => {
         <BaseForm formContent={[field(makeDef("name"))]} onSubmit={onSubmit} />
       );
 
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await waitFor(() => {
         expect(
-          screen.getByRole("button", { name: /submitting/i })
+          screen.getByRole("button", { name: /submitting/iu })
         ).toBeDefined();
       });
 
       resolveSubmit!();
 
       await waitFor(() => {
-        expect(screen.getByRole("button", { name: /^submit$/i })).toBeDefined();
+        expect(
+          screen.getByRole("button", { name: /^submit$/iu })
+        ).toBeDefined();
       });
     });
 
@@ -725,7 +727,7 @@ describe("BaseForm", () => {
         />
       );
 
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await waitFor(() => {
         expect(onSubmit).toHaveBeenCalled();
@@ -780,7 +782,7 @@ describe("BaseForm", () => {
         />
       );
 
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await waitFor(() => {
         expect(screen.getByText("2 errors")).toBeDefined();
@@ -804,7 +806,7 @@ describe("BaseForm", () => {
         <BaseForm formContent={[field(makeDef("name"))]} onSubmit={vi.fn()} />
       );
 
-      expect(screen.getByRole("button", { name: /^submit$/i })).toBeDefined();
+      expect(screen.getByRole("button", { name: /^submit$/iu })).toBeDefined();
     });
 
     it("submits values from fields inside sections", async () => {
@@ -827,10 +829,10 @@ describe("BaseForm", () => {
         />
       );
 
-      const nameInput = screen.getByRole("textbox", { name: /name/ });
+      const nameInput = screen.getByRole("textbox", { name: /name/u });
       fireEvent.change(nameInput, { target: { value: "Alice" } });
 
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await vi.waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith(
@@ -882,7 +884,7 @@ describe("BaseForm", () => {
         />
       );
 
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await waitFor(() => {
         expect(screen.getByRole("alert").textContent).toBe(
@@ -914,13 +916,13 @@ describe("BaseForm", () => {
 
       expect(screen.queryByDisplayValue("sensitive value")).toBeNull();
       expect(
-        screen.getByRole("textbox", { name: /Unsupported/ })
+        screen.getByRole("textbox", { name: /Unsupported/u })
       ).toHaveProperty(
         "value",
         "Unsupported field type. Use a CUSTOM field instead"
       );
 
-      fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+      fireEvent.click(screen.getByRole("button", { name: /submit/iu }));
 
       await waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith({

--- a/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
@@ -556,10 +556,10 @@ describe("DropdownField", () => {
       fireEvent.click(trigger);
 
       await vi.waitFor(() => {
-        const alice = screen.getByRole("option", { name: /Alice/ });
+        const alice = screen.getByRole("option", { name: /Alice/u });
         expect(alice.getAttribute("aria-selected")).toBe("true");
 
-        const bob = screen.getByRole("option", { name: /Bob/ });
+        const bob = screen.getByRole("option", { name: /Bob/u });
         expect(bob.getAttribute("aria-selected")).toBe("false");
       });
     });

--- a/packages/react-components/src/action-form/__tests__/FormSection.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/FormSection.test.tsx
@@ -60,7 +60,7 @@ describe("FormSection", () => {
       expect(screen.getByTestId("child-field")).toBeDefined();
 
       // Click the collapse trigger
-      const trigger = screen.getByRole("button", { name: /test section/i });
+      const trigger = screen.getByRole("button", { name: /test section/iu });
       fireEvent.click(trigger);
 
       // Content should be hidden (panel closed)
@@ -101,7 +101,7 @@ describe("FormSection", () => {
       ).not.toBeNull();
 
       // Click to expand
-      const trigger = screen.getByRole("button", { name: /test section/i });
+      const trigger = screen.getByRole("button", { name: /test section/iu });
       fireEvent.click(trigger);
 
       // Now visible
@@ -151,7 +151,7 @@ describe("FormSection", () => {
         </FormSection>
       );
 
-      expect(screen.queryByText(/error/)).toBeNull();
+      expect(screen.queryByText(/error/u)).toBeNull();
     });
 
     it("renders without header when showTitleBar is false", () => {

--- a/packages/react-components/src/action-form/fields/NumberInputField.tsx
+++ b/packages/react-components/src/action-form/fields/NumberInputField.tsx
@@ -35,7 +35,7 @@ import styles from "./NumberInputField.module.css";
  *
  * Rejects obviously invalid strings like "1.2.3" or "+-5".
  */
-const VALID_NUMERIC_REGEX = /^[+-.]?(\d+\.?\d*|\d*\.?\d+)?([eE][+-]?\d*)?$/;
+const VALID_NUMERIC_REGEX = /^[+-.]?(\d+\.?\d*|\d*\.?\d+)?([eE][+-]?\d*)?$/u;
 
 const DEFAULT_STEP = 1;
 const CHEVRON_SIZE = 12;

--- a/packages/react-components/src/aip-agent-chat/__tests__/BaseAipAgentChat.test.tsx
+++ b/packages/react-components/src/aip-agent-chat/__tests__/BaseAipAgentChat.test.tsx
@@ -92,7 +92,7 @@ describe("BaseAipAgentChat", () => {
       />
     );
 
-    const sendButton = screen.getByRole("button", { name: /send/i });
+    const sendButton = screen.getByRole("button", { name: /send/iu });
     expect(sendButton.matches(":disabled")).toBe(true);
   });
 
@@ -111,7 +111,7 @@ describe("BaseAipAgentChat", () => {
     const textarea = screen.getByLabelText("Message input");
     fireEvent.change(textarea, { target: { value: "hello" } });
 
-    const sendButton = screen.getByRole("button", { name: /send/i });
+    const sendButton = screen.getByRole("button", { name: /send/iu });
     expect(sendButton.matches(":disabled")).toBe(false);
   });
 
@@ -131,7 +131,7 @@ describe("BaseAipAgentChat", () => {
 
     const textarea = screen.getByLabelText("Message input");
     fireEvent.change(textarea, { target: { value: "hello world" } });
-    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+    fireEvent.click(screen.getByRole("button", { name: /send/iu }));
 
     expect(onSendMessage).toHaveBeenCalledWith("hello world");
   });
@@ -148,8 +148,8 @@ describe("BaseAipAgentChat", () => {
       />
     );
 
-    expect(screen.queryByRole("button", { name: /send/i })).toBeNull();
-    expect(screen.getByRole("button", { name: /stop/i })).toBeDefined();
+    expect(screen.queryByRole("button", { name: /send/iu })).toBeNull();
+    expect(screen.getByRole("button", { name: /stop/iu })).toBeDefined();
   });
 
   it("calls onStop when Stop button is clicked", () => {
@@ -166,7 +166,7 @@ describe("BaseAipAgentChat", () => {
       />
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /stop/i }));
+    fireEvent.click(screen.getByRole("button", { name: /stop/iu }));
 
     expect(onStop).toHaveBeenCalled();
   });
@@ -203,7 +203,7 @@ describe("BaseAipAgentChat", () => {
       />
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/iu }));
 
     expect(onClearError).toHaveBeenCalled();
   });

--- a/packages/react-components/src/filter-list/__tests__/FilterList.test.tsx
+++ b/packages/react-components/src/filter-list/__tests__/FilterList.test.tsx
@@ -54,7 +54,7 @@ describe("FilterList", () => {
       // On first render the … shows from the state buildInitialStates seeds
       // out of `definition.filterState`
       expect(
-        screen.getByRole("button", { name: /more actions/i })
+        screen.getByRole("button", { name: /more actions/iu })
       ).toBeDefined();
 
       // Removing clears the stored state and hides the filter.
@@ -62,15 +62,15 @@ describe("FilterList", () => {
         screen.getByRole("button", { name: "Remove dept filter" })
       );
       expect(
-        screen.queryByRole("button", { name: /more actions/i })
+        screen.queryByRole("button", { name: /more actions/iu })
       ).toBeNull();
 
       // Re-add it through the "+ Add filter" menu
-      fireEvent.click(screen.getByRole("button", { name: /add filter/i }));
+      fireEvent.click(screen.getByRole("button", { name: /add filter/iu }));
       fireEvent.click(screen.getByRole("menuitem", { name: "dept" }));
 
       expect(
-        screen.getByRole("button", { name: /more actions/i })
+        screen.getByRole("button", { name: /more actions/iu })
       ).toBeDefined();
     });
 
@@ -82,21 +82,21 @@ describe("FilterList", () => {
       );
 
       expect(
-        screen.getByRole("button", { name: /more actions/i })
+        screen.getByRole("button", { name: /more actions/iu })
       ).toBeDefined();
 
       fireEvent.click(
         screen.getByRole("button", { name: "Remove manager filter" })
       );
       expect(
-        screen.queryByRole("button", { name: /more actions/i })
+        screen.queryByRole("button", { name: /more actions/iu })
       ).toBeNull();
 
-      fireEvent.click(screen.getByRole("button", { name: /add filter/i }));
+      fireEvent.click(screen.getByRole("button", { name: /add filter/iu }));
       fireEvent.click(screen.getByRole("menuitem", { name: "manager" }));
 
       expect(
-        screen.getByRole("button", { name: /more actions/i })
+        screen.getByRole("button", { name: /more actions/iu })
       ).toBeDefined();
     });
 
@@ -108,23 +108,23 @@ describe("FilterList", () => {
       );
 
       expect(
-        screen.getByRole("button", { name: /more actions/i })
+        screen.getByRole("button", { name: /more actions/iu })
       ).toBeDefined();
 
       fireEvent.click(
         screen.getByRole("button", { name: "Remove manager filter" })
       );
       expect(
-        screen.queryByRole("button", { name: /more actions/i })
+        screen.queryByRole("button", { name: /more actions/iu })
       ).toBeNull();
 
-      fireEvent.click(screen.getByRole("button", { name: /add filter/i }));
+      fireEvent.click(screen.getByRole("button", { name: /add filter/iu }));
       fireEvent.click(screen.getByRole("menuitem", { name: "manager" }));
 
       // The linked filter is not seeded either; the … reappears via the
       // getEmptyDisplayState fallback (unwrapped to the inner EXACT_MATCH state).
       expect(
-        screen.getByRole("button", { name: /more actions/i })
+        screen.getByRole("button", { name: /more actions/iu })
       ).toBeDefined();
     });
 
@@ -140,7 +140,7 @@ describe("FilterList", () => {
       );
 
       expect(
-        screen.queryByRole("button", { name: /more actions/i })
+        screen.queryByRole("button", { name: /more actions/iu })
       ).toBeNull();
     });
 
@@ -154,7 +154,7 @@ describe("FilterList", () => {
         <FilterList objectType={MockObjectType} filterDefinitions={[def]} />
       );
 
-      fireEvent.click(screen.getByRole("button", { name: /more actions/i }));
+      fireEvent.click(screen.getByRole("button", { name: /more actions/iu }));
 
       // After opening, the include/exclude dropdown trigger should be visible.
       expect(screen.getByRole("button", { name: "Keeping" })).toBeDefined();

--- a/packages/react-components/src/filter-list/__tests__/FilterListDragAndDrop.test.tsx
+++ b/packages/react-components/src/filter-list/__tests__/FilterListDragAndDrop.test.tsx
@@ -81,7 +81,7 @@ describe("FilterList drag and drop", () => {
       />
     );
 
-    const dragHandles = screen.queryAllByLabelText(/Reorder/);
+    const dragHandles = screen.queryAllByLabelText(/Reorder/u);
     expect(dragHandles).toHaveLength(0);
   });
 
@@ -101,7 +101,7 @@ describe("FilterList drag and drop", () => {
       />
     );
 
-    const dragHandles = await screen.findAllByLabelText(/Reorder/);
+    const dragHandles = await screen.findAllByLabelText(/Reorder/u);
     expect(dragHandles).toHaveLength(3);
   });
 
@@ -121,7 +121,7 @@ describe("FilterList drag and drop", () => {
       />
     );
 
-    const dragHandles = await screen.findAllByLabelText(/Reorder/);
+    const dragHandles = await screen.findAllByLabelText(/Reorder/u);
     expect(dragHandles).toHaveLength(3);
   });
 
@@ -175,7 +175,7 @@ describe("FilterList drag and drop", () => {
       />
     );
 
-    await screen.findAllByLabelText(/Reorder/);
+    await screen.findAllByLabelText(/Reorder/u);
 
     expect(filterStates.get(getFilterKey(definitions[0]))).toBe(stateRef);
   });
@@ -193,7 +193,7 @@ describe("FilterList drag and drop", () => {
       />
     );
 
-    const dragHandles = screen.queryAllByLabelText(/Reorder/);
+    const dragHandles = screen.queryAllByLabelText(/Reorder/u);
     expect(dragHandles).toHaveLength(0);
   });
 
@@ -215,7 +215,7 @@ describe("FilterList drag and drop", () => {
       />
     );
 
-    await screen.findAllByLabelText(/Reorder/);
+    await screen.findAllByLabelText(/Reorder/u);
 
     expect(onOrderChange).not.toHaveBeenCalled();
   });

--- a/packages/react-components/src/filter-list/__tests__/LinkedPropertyInput.test.tsx
+++ b/packages/react-components/src/filter-list/__tests__/LinkedPropertyInput.test.tsx
@@ -386,8 +386,8 @@ describe("LinkedPropertyInput", () => {
       );
 
       // Both rows render — "Marketing" from aggregation, "Research" synthesized
-      const marketingRow = screen.getByRole("button", { name: /Marketing/ });
-      const researchRow = screen.getByRole("button", { name: /Research/ });
+      const marketingRow = screen.getByRole("button", { name: /Marketing/u });
+      const researchRow = screen.getByRole("button", { name: /Research/u });
 
       expect(marketingRow.getAttribute("aria-pressed")).toBe("true");
       expect(researchRow.getAttribute("aria-pressed")).toBe("true");
@@ -529,8 +529,8 @@ describe("LinkedPropertyInput", () => {
 
       // Both rows render — "Alice" from scoped, "Bob" synthesized from
       // emptySource as a count=0 filtered-out row.
-      expect(screen.getByRole("button", { name: /Alice/ })).toBeTruthy();
-      const bobRow = screen.getByRole("button", { name: /Bob/ });
+      expect(screen.getByRole("button", { name: /Alice/u })).toBeTruthy();
+      const bobRow = screen.getByRole("button", { name: /Bob/u });
       expect(bobRow.hasAttribute("data-filtered-out")).toBe(true);
     });
   });

--- a/packages/react-components/src/filter-list/__tests__/filterStateToWhereClause.test.ts
+++ b/packages/react-components/src/filter-list/__tests__/filterStateToWhereClause.test.ts
@@ -317,8 +317,8 @@ describe("buildWhereClause", () => {
     const andConditions = clause.$and as Array<
       Record<string, Record<string, string>>
     >;
-    expect(andConditions[0].birthDate.$gte).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-    expect(andConditions[1].birthDate.$lte).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(andConditions[0].birthDate.$gte).toMatch(/^\d{4}-\d{2}-\d{2}$/u);
+    expect(andConditions[1].birthDate.$lte).toMatch(/^\d{4}-\d{2}-\d{2}$/u);
   });
 
   it("builds $or wrapping $and for NUMBER_RANGE min+max+includeNull", () => {

--- a/packages/react-components/src/filter-list/base/__tests__/FilterListContent.test.tsx
+++ b/packages/react-components/src/filter-list/base/__tests__/FilterListContent.test.tsx
@@ -111,7 +111,7 @@ describe("FilterListContent", () => {
       );
 
       expect(
-        screen.getByRole("button", { name: /more actions/i })
+        screen.getByRole("button", { name: /more actions/iu })
       ).toBeDefined();
     });
 
@@ -134,7 +134,7 @@ describe("FilterListContent", () => {
 
       // No stored state + no fallback → no capability-driven controls.
       expect(
-        screen.queryByRole("button", { name: /more actions/i })
+        screen.queryByRole("button", { name: /more actions/iu })
       ).toBeNull();
     });
 
@@ -185,7 +185,7 @@ describe("FilterListContent", () => {
         JSON.stringify({ type: "SELECT", selectedValues: [] })
       );
       expect(
-        screen.getByRole("button", { name: /more actions/i })
+        screen.getByRole("button", { name: /more actions/iu })
       ).toBeDefined();
     });
   });

--- a/packages/react-components/src/filter-list/base/__tests__/FilterListItem.test.tsx
+++ b/packages/react-components/src/filter-list/base/__tests__/FilterListItem.test.tsx
@@ -64,7 +64,7 @@ describe("FilterListItem", () => {
         filterState: { type: "SELECT", selectedValues: [] },
       });
       expect(
-        screen.getByRole("button", { name: /search values/i })
+        screen.getByRole("button", { name: /search values/iu })
       ).toBeDefined();
     });
 
@@ -74,7 +74,7 @@ describe("FilterListItem", () => {
         searchField: false,
       });
       expect(
-        screen.queryByRole("button", { name: /search values/i })
+        screen.queryByRole("button", { name: /search values/iu })
       ).toBeNull();
     });
 
@@ -83,7 +83,7 @@ describe("FilterListItem", () => {
         filterState: { type: "NUMBER_RANGE", minValue: 1, maxValue: 5 },
       });
       expect(
-        screen.queryByRole("button", { name: /search values/i })
+        screen.queryByRole("button", { name: /search values/iu })
       ).toBeNull();
     });
 
@@ -94,7 +94,7 @@ describe("FilterListItem", () => {
         onFilterRemoved,
       });
       const removeButton = screen.getByRole("button", {
-        name: /remove department filter/i,
+        name: /remove department filter/iu,
       });
       fireEvent.click(removeButton);
       expect(onFilterRemoved).toHaveBeenCalledWith("department");
@@ -105,7 +105,7 @@ describe("FilterListItem", () => {
         filterState: { type: "SELECT", selectedValues: ["a"] },
       });
       expect(
-        screen.queryByRole("button", { name: /remove department filter/i })
+        screen.queryByRole("button", { name: /remove department filter/iu })
       ).toBeNull();
     });
 
@@ -114,7 +114,7 @@ describe("FilterListItem", () => {
         filterState: { type: "SELECT", selectedValues: ["a"] },
       });
       expect(
-        screen.getByRole("button", { name: /more actions/i })
+        screen.getByRole("button", { name: /more actions/iu })
       ).toBeDefined();
     });
 
@@ -123,7 +123,7 @@ describe("FilterListItem", () => {
         filterState: { type: "NUMBER_RANGE", minValue: 1, maxValue: 5 },
       });
       expect(
-        screen.queryByRole("button", { name: /more actions/i })
+        screen.queryByRole("button", { name: /more actions/iu })
       ).toBeNull();
     });
 
@@ -131,7 +131,7 @@ describe("FilterListItem", () => {
       renderItem({
         filterState: { type: "SELECT", selectedValues: ["a"] },
       });
-      const overflow = screen.getByRole("button", { name: /more actions/i });
+      const overflow = screen.getByRole("button", { name: /more actions/iu });
       expect(overflow.getAttribute("aria-pressed")).toBe("false");
       fireEvent.click(overflow);
       expect(overflow.getAttribute("aria-pressed")).toBe("true");
@@ -152,7 +152,7 @@ describe("FilterListItem", () => {
         },
       });
       expect(
-        screen.getByRole("button", { name: /search values/i })
+        screen.getByRole("button", { name: /search values/iu })
       ).toBeDefined();
     });
 
@@ -167,7 +167,7 @@ describe("FilterListItem", () => {
         },
       });
       expect(
-        screen.getByRole("button", { name: /more actions/i })
+        screen.getByRole("button", { name: /more actions/iu })
       ).toBeDefined();
     });
 
@@ -181,7 +181,7 @@ describe("FilterListItem", () => {
           },
         },
       });
-      const overflow = screen.getByRole("button", { name: /more actions/i });
+      const overflow = screen.getByRole("button", { name: /more actions/iu });
       expect(overflow.getAttribute("aria-pressed")).toBe("false");
       fireEvent.click(overflow);
       expect(overflow.getAttribute("aria-pressed")).toBe("true");

--- a/packages/react-components/src/filter-list/base/__tests__/FilterPopover.test.tsx
+++ b/packages/react-components/src/filter-list/base/__tests__/FilterPopover.test.tsx
@@ -68,7 +68,7 @@ describe("FilterPopover", () => {
         <div>popup body</div>
       </FilterPopover>
     );
-    const trigger = screen.getByRole("button", { name: /Any/i });
+    const trigger = screen.getByRole("button", { name: /Any/iu });
     expect(trigger.getAttribute("data-active")).toBeNull();
 
     rerender(
@@ -77,7 +77,7 @@ describe("FilterPopover", () => {
       </FilterPopover>
     );
     expect(
-      screen.getByRole("button", { name: /X/i }).getAttribute("data-active")
+      screen.getByRole("button", { name: /X/iu }).getAttribute("data-active")
     ).toBe("true");
   });
 
@@ -89,7 +89,7 @@ describe("FilterPopover", () => {
     );
     expect(screen.queryByTestId("popup-body")).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: /Any/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Any/iu }));
     expect(screen.getByTestId("popup-body")).toBeDefined();
   });
 
@@ -99,7 +99,7 @@ describe("FilterPopover", () => {
         <div data-testid="popup-body">popup body</div>
       </FilterPopover>
     );
-    const trigger = screen.getByRole("button", { name: /Any/i });
+    const trigger = screen.getByRole("button", { name: /Any/iu });
     fireEvent.click(trigger);
     expect(screen.getByTestId("popup-body")).toBeDefined();
 
@@ -117,7 +117,7 @@ describe("FilterPopover", () => {
       </FilterPopover>
     );
     expect(
-      screen.queryByRole("button", { name: /Remove Sites filter/i })
+      screen.queryByRole("button", { name: /Remove Sites filter/iu })
     ).toBeNull();
 
     rerender(
@@ -131,7 +131,7 @@ describe("FilterPopover", () => {
       </FilterPopover>
     );
     const removeButton = screen.getByRole("button", {
-      name: /Remove Sites filter/i,
+      name: /Remove Sites filter/iu,
     });
     fireEvent.click(removeButton);
     expect(onRemove).toHaveBeenCalledTimes(1);
@@ -149,7 +149,7 @@ describe("FilterPopover", () => {
       </FilterPopover>
     );
     const wrapper = container.firstElementChild;
-    expect(wrapper?.className).toMatch(/fieldGroupTop/);
+    expect(wrapper?.className).toMatch(/fieldGroupTop/u);
   });
 
   it("does not apply fieldGroupTop when labelPlacement defaults to inline", () => {
@@ -159,7 +159,7 @@ describe("FilterPopover", () => {
       </FilterPopover>
     );
     const wrapper = container.firstElementChild;
-    expect(wrapper?.className).not.toMatch(/fieldGroupTop/);
+    expect(wrapper?.className).not.toMatch(/fieldGroupTop/u);
   });
 
   it("forwards the className to the field group wrapper", () => {

--- a/packages/react-components/src/filter-list/base/inputs/TextTagsInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/TextTagsInput.tsx
@@ -27,7 +27,7 @@ import { SelectInputSkeleton } from "./SelectInputSkeleton.js";
 import sharedStyles from "./shared.module.css";
 import styles from "./TextTagsInput.module.css";
 
-const TAG_SEPARATOR_PATTERN = /[,\n]/;
+const TAG_SEPARATOR_PATTERN = /[,\n]/u;
 
 interface TagItemProps {
   tag: string;

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/DateRangeHistogramInput.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/DateRangeHistogramInput.test.tsx
@@ -179,7 +179,7 @@ describe("DateRangeHistogramInput", () => {
       fireEvent.pointerMove(rects[0], { pointerId: 1 });
       const tooltip = document.body.querySelector('div[class*="tooltip"]');
       expect(tooltip).not.toBeNull();
-      expect(tooltip?.textContent ?? "").toMatch(/\d{2}\/\d{2}\/\d{4}/);
+      expect(tooltip?.textContent ?? "").toMatch(/\d{2}\/\d{2}\/\d{4}/u);
     });
 
     it("honors formatDate on the From input display", () => {
@@ -197,7 +197,7 @@ describe("DateRangeHistogramInput", () => {
       const tooltip = document.body.querySelector('div[class*="tooltip"]');
       expect(tooltip).not.toBeNull();
       // ISO format when formatDate is omitted.
-      expect(tooltip?.textContent ?? "").toMatch(/^\d{4}-\d{2}-\d{2}/);
+      expect(tooltip?.textContent ?? "").toMatch(/^\d{4}-\d{2}-\d{2}/u);
     });
   });
 });

--- a/packages/react-components/src/filter-list/inputs/__tests__/filteredOutValues.test.tsx
+++ b/packages/react-components/src/filter-list/inputs/__tests__/filteredOutValues.test.tsx
@@ -86,8 +86,8 @@ describe("filtered-out initialFilterStates values", () => {
       );
 
       // Both rows render — "Marketing" from aggregation, "Research" synthesized
-      const marketingRow = screen.getByRole("button", { name: /Marketing/ });
-      const researchRow = screen.getByRole("button", { name: /Research/ });
+      const marketingRow = screen.getByRole("button", { name: /Marketing/u });
+      const researchRow = screen.getByRole("button", { name: /Research/u });
 
       // Both are pressed (selected) since both are in filterState.values
       expect(marketingRow.getAttribute("aria-pressed")).toBe("true");
@@ -171,12 +171,12 @@ describe("STATIC_VALUES filters", () => {
 
     expect(
       screen
-        .getByRole("button", { name: /Marketing/ })
+        .getByRole("button", { name: /Marketing/u })
         .hasAttribute("data-filtered-out")
     ).toBe(false);
     expect(
       screen
-        .getByRole("button", { name: /Operations/ })
+        .getByRole("button", { name: /Operations/u })
         .hasAttribute("data-filtered-out")
     ).toBe(false);
   });
@@ -203,10 +203,10 @@ describe("STATIC_VALUES filters", () => {
     );
 
     expect(
-      screen.getByRole("option", { name: /Alpha/ }).className
+      screen.getByRole("option", { name: /Alpha/u }).className
     ).not.toContain("filteredOutItem");
     expect(
-      screen.getByRole("option", { name: /Beta/ }).className
+      screen.getByRole("option", { name: /Beta/u }).className
     ).not.toContain("filteredOutItem");
   });
 });
@@ -260,12 +260,12 @@ describe("linked-filter filtered-out rendering (showFilteredOutValues)", () => {
     );
     expect(
       screen
-        .getByRole("button", { name: /Engineering/ })
+        .getByRole("button", { name: /Engineering/u })
         .hasAttribute("data-filtered-out")
     ).toBe(false);
     expect(
       screen
-        .getByRole("button", { name: /Marketing/ })
+        .getByRole("button", { name: /Marketing/u })
         .hasAttribute("data-filtered-out")
     ).toBe(true);
   });
@@ -374,15 +374,15 @@ describe("linked-filter filtered-out rendering (showFilteredOutValues)", () => {
 
       expect(
         screen
-          .getByRole("button", { name: /Alice/ })
+          .getByRole("button", { name: /Alice/u })
           .hasAttribute("data-filtered-out")
       ).toBe(false);
       expect(
         screen
-          .getByRole("button", { name: /Bob/ })
+          .getByRole("button", { name: /Bob/u })
           .hasAttribute("data-filtered-out")
       ).toBe(false);
-      const carolRow = screen.getByRole("button", { name: /Carol/ });
+      const carolRow = screen.getByRole("button", { name: /Carol/u });
       expect(carolRow.hasAttribute("data-filtered-out")).toBe(true);
       expect(carolRow.textContent).toContain("0");
     });
@@ -416,7 +416,7 @@ describe("linked-filter filtered-out rendering (showFilteredOutValues)", () => {
         />
       );
 
-      expect(screen.queryByRole("button", { name: /Carol/ })).toBeNull();
+      expect(screen.queryByRole("button", { name: /Carol/u })).toBeNull();
     });
   });
 });

--- a/packages/react-components/src/images/tiff-renderer/__tests__/TiffRenderer.test.tsx
+++ b/packages/react-components/src/images/tiff-renderer/__tests__/TiffRenderer.test.tsx
@@ -66,7 +66,7 @@ describe("TiffRenderer", () => {
       render(<TiffRenderer content={largeContent} />);
     });
 
-    expect(screen.getByText(/exceeds maximum size/)).toBeTruthy();
+    expect(screen.getByText(/exceeds maximum size/u)).toBeTruthy();
   });
 
   it("should call onError when decoding fails", async () => {
@@ -93,7 +93,7 @@ describe("TiffRenderer", () => {
     });
 
     expect(onError).toHaveBeenCalled();
-    expect(screen.getByText(/Could not render TIFF/)).toBeTruthy();
+    expect(screen.getByText(/Could not render TIFF/u)).toBeTruthy();
   });
 
   it("should call onError when image has missing dimensions", async () => {

--- a/packages/react-components/src/shared/calendar/TimePicker.tsx
+++ b/packages/react-components/src/shared/calendar/TimePicker.tsx
@@ -201,7 +201,7 @@ function formatSegment(value: number, segment: TimeSegment): string {
 }
 
 function parseNumber(text: string): number | undefined {
-  if (!/^\d{1,2}$/.test(text)) {
+  if (!/^\d{1,2}$/u.test(text)) {
     return undefined;
   }
   const parsed = Number(text);

--- a/packages/react-components/src/shared/dateUtils.ts
+++ b/packages/react-components/src/shared/dateUtils.ts
@@ -79,7 +79,7 @@ export function parseDatetimeFromInput(
   value: string | undefined | null
 ): Date | undefined {
   if (!value) return undefined;
-  const normalized = value.includes("T") ? value : value.replace(/\s/, "T");
+  const normalized = value.includes("T") ? value : value.replace(/\s/u, "T");
   const date = new Date(normalized);
   return isNaN(date.getTime()) ? undefined : date;
 }

--- a/packages/react-components/src/theme/__tests__/OsdkThemeProvider.test.tsx
+++ b/packages/react-components/src/theme/__tests__/OsdkThemeProvider.test.tsx
@@ -291,7 +291,7 @@ describe("useOsdkTheme", () => {
       .spyOn(console, "error")
       .mockImplementation(() => {});
     try {
-      expect(() => render(<ThemeProbe />)).toThrow(/OsdkThemeProvider/);
+      expect(() => render(<ThemeProbe />)).toThrow(/OsdkThemeProvider/u);
     } finally {
       consoleError.mockRestore();
     }

--- a/packages/react-devtools/scripts/build-css.mjs
+++ b/packages/react-devtools/scripts/build-css.mjs
@@ -121,7 +121,7 @@ async function rewriteScssImports() {
   // Matches every form esbuild/babel can emit: `from "..."`, `import("...")`,
   // and bare side-effect `import "...";`.
   const re =
-    /(from\s+["']|import\s*\(\s*["']|import\s+["'])([^"']+\.module\.scss)(["'])/g;
+    /(from\s+["']|import\s*\(\s*["']|import\s+["'])([^"']+\.module\.scss)(["'])/gu;
   for (const jsFile of jsFiles) {
     const original = await fs.readFile(jsFile, "utf-8");
     const updated = original.replace(re, "$1$2.js$3");

--- a/packages/react-devtools/src/components/DebuggingTab.test.tsx
+++ b/packages/react-devtools/src/components/DebuggingTab.test.tsx
@@ -52,11 +52,11 @@ function windowError(
 }
 
 function getErrorsCount(): number {
-  const heading = screen.getByText(/^Errors$/).closest("div");
+  const heading = screen.getByText(/^Errors$/u).closest("div");
   if (heading == null) {
     return 0;
   }
-  const countSpan = within(heading).getAllByText(/^\d+$/);
+  const countSpan = within(heading).getAllByText(/^\d+$/u);
   return Number.parseInt(countSpan[0].textContent ?? "0", 10);
 }
 

--- a/packages/react-devtools/src/inspector/utils/elementBounds.ts
+++ b/packages/react-devtools/src/inspector/utils/elementBounds.ts
@@ -25,7 +25,7 @@ function stripTranslateFromTransform(element: Element): string {
   }
 
   const matrixMatch = transform.match(
-    /matrix\(([^,]+),\s*([^,]+),\s*([^,]+),\s*([^,]+),\s*[^,]+,\s*[^)]+\)/
+    /matrix\(([^,]+),\s*([^,]+),\s*([^,]+),\s*([^,]+),\s*[^,]+,\s*[^)]+\)/u
   );
 
   if (matrixMatch) {
@@ -36,7 +36,7 @@ function stripTranslateFromTransform(element: Element): string {
     return `matrix(${a}, ${b}, ${c}, ${d}, 0, 0)`;
   }
 
-  const matrix3dMatch = transform.match(/matrix3d\(([^)]+)\)/);
+  const matrix3dMatch = transform.match(/matrix3d\(([^)]+)\)/u);
   if (matrix3dMatch) {
     const values = matrix3dMatch[1].split(",").map((v) => v.trim());
     if (values.length === 16) {

--- a/packages/react-devtools/src/mocking/MockManager.test.ts
+++ b/packages/react-devtools/src/mocking/MockManager.test.ts
@@ -180,7 +180,7 @@ describe("MockManager", () => {
   it("findMock matches by regex primaryKey", () => {
     manager.registerMock(
       createObjectMock({
-        matcher: { objectType: "Employee", primaryKey: /^pk-\d+$/ },
+        matcher: { objectType: "Employee", primaryKey: /^pk-\d+$/u },
       })
     );
 

--- a/packages/react-devtools/src/store/ConsoleLogStore.test.ts
+++ b/packages/react-devtools/src/store/ConsoleLogStore.test.ts
@@ -175,7 +175,7 @@ describe("ConsoleLogStore", () => {
       await flushMicrotasks();
 
       const entries = store.getEntries();
-      expect(entries[0].args[0]).toMatch(/\[Function:.*\]/);
+      expect(entries[0].args[0]).toMatch(/\[Function:.*\]/u);
     });
 
     it("should serialize Error with stack", async () => {

--- a/packages/react-devtools/src/store/ConsoleLogStore.ts
+++ b/packages/react-devtools/src/store/ConsoleLogStore.ts
@@ -46,7 +46,7 @@ const MAX_STRING_SIZE = 10240; // 10KB
 const MAX_TOTAL_SIZE = 10240; // 10KB
 
 const INTERNAL_FRAME_PATTERN =
-  /ConsoleLogStore|serializeArg|serializeValue|getCallerLocation|capEntrySize|osdkConsoleWrapper/;
+  /ConsoleLogStore|serializeArg|serializeValue|getCallerLocation|capEntrySize|osdkConsoleWrapper/u;
 
 // BrowserLogger formats calls with %c CSS styling and a "border: 1px solid"
 // pattern from its createStyle(). We filter these from the devtools console
@@ -61,9 +61,9 @@ function isBrowserLoggerCall(args: unknown[]): boolean {
   );
 }
 
-const CHROME_FRAME_REGEX_PAREN = /at\s+.*?\((.*?):(\d+):\d+\)/;
-const CHROME_FRAME_REGEX_BARE = /at\s+(.*?):(\d+):\d+/;
-const FIREFOX_FRAME_REGEX = /@(.*?):(\d+):\d+/;
+const CHROME_FRAME_REGEX_PAREN = /at\s+.*?\((.*?):(\d+):\d+\)/u;
+const CHROME_FRAME_REGEX_BARE = /at\s+(.*?):(\d+):\d+/u;
+const FIREFOX_FRAME_REGEX = /@(.*?):(\d+):\d+/u;
 
 function serializeValue(
   value: unknown,

--- a/packages/react-devtools/src/utils/ComponentContextCapture.ts
+++ b/packages/react-devtools/src/utils/ComponentContextCapture.ts
@@ -132,16 +132,16 @@ export class ComponentContextCapture {
     const lines = stack.split("\n");
 
     const internalPatterns = [
-      /node_modules/,
-      /@osdk\/react/,
-      /react-devtools/,
-      /ComponentContextCapture/,
-      /ObservableClientMonitor/,
-      /ComponentQueryRegistry/,
-      /packages\/react\/build/,
-      /packages\/react\/esm/,
-      /packages\/react\/src/,
-      /Proxy/,
+      /node_modules/u,
+      /@osdk\/react/u,
+      /react-devtools/u,
+      /ComponentContextCapture/u,
+      /ObservableClientMonitor/u,
+      /ComponentQueryRegistry/u,
+      /packages\/react\/build/u,
+      /packages\/react\/esm/u,
+      /packages\/react\/src/u,
+      /Proxy/u,
     ];
 
     const internalFuncNames = new Set([
@@ -175,16 +175,17 @@ export class ComponentContextCapture {
         }
       }
       return (
-        /\.(tsx?|jsx?)(\?|:|$)/.test(filePath) && !/node_modules/.test(filePath)
+        /\.(tsx?|jsx?)(\?|:|$)/u.test(filePath) &&
+        !/node_modules/u.test(filePath)
       );
     };
 
     const extractComponentNameFromPath = (filePath: string): string | null => {
-      const match = filePath.match(/\/([A-Z][a-zA-Z0-9]*)\.(tsx?|jsx?)[?:]/);
+      const match = filePath.match(/\/([A-Z][a-zA-Z0-9]*)\.(tsx?|jsx?)[?:]/u);
       if (match) {
         return match[1];
       }
-      const match2 = filePath.match(/([A-Z][a-zA-Z0-9]*)\.(tsx?|jsx?)[?:]?$/);
+      const match2 = filePath.match(/([A-Z][a-zA-Z0-9]*)\.(tsx?|jsx?)[?:]?$/u);
       if (match2) {
         return match2[1];
       }
@@ -196,7 +197,9 @@ export class ComponentContextCapture {
     for (let i = 3; i < maxLines; i++) {
       const line = lines[i];
 
-      const chromeMatch = line.match(/at\s+([A-Z]\w+)\s+\((.*?):(\d+):(\d+)\)/);
+      const chromeMatch = line.match(
+        /at\s+([A-Z]\w+)\s+\((.*?):(\d+):(\d+)\)/u
+      );
       if (chromeMatch) {
         const [, funcName, filePath, lineNum, colNum] = chromeMatch;
         if (!isInternalFrame(filePath, funcName)) {
@@ -210,7 +213,7 @@ export class ComponentContextCapture {
         continue;
       }
 
-      const firefoxMatch = line.match(/([A-Z]\w+)@(.*?):(\d+):(\d+)/);
+      const firefoxMatch = line.match(/([A-Z]\w+)@(.*?):(\d+):(\d+)/u);
       if (firefoxMatch) {
         const [, funcName, filePath, lineNum, colNum] = firefoxMatch;
         if (!isInternalFrame(filePath, funcName)) {
@@ -229,14 +232,14 @@ export class ComponentContextCapture {
       const line = lines[i];
 
       const fileMatch = line.match(
-        /\((https?:\/\/[^)]+|\/[^)]+)\)|at\s+(https?:\/\/\S+|\/\S+)/
+        /\((https?:\/\/[^)]+|\/[^)]+)\)|at\s+(https?:\/\/\S+|\/\S+)/u
       );
       if (fileMatch) {
         const filePath = fileMatch[1] || fileMatch[2];
         if (isAppFilePath(filePath)) {
           const componentName = extractComponentNameFromPath(filePath);
           if (componentName) {
-            const locationMatch = filePath.match(/:(\d+):(\d+)$/);
+            const locationMatch = filePath.match(/:(\d+):(\d+)$/u);
             return {
               componentName,
               filePath,
@@ -255,7 +258,7 @@ export class ComponentContextCapture {
     for (let i = 3; i < maxLines; i++) {
       const line = lines[i];
 
-      const anyFuncMatch = line.match(/at\s+(\w+)\s+\((.*?):(\d+):(\d+)\)/);
+      const anyFuncMatch = line.match(/at\s+(\w+)\s+\((.*?):(\d+):(\d+)\)/u);
       if (anyFuncMatch) {
         const [, funcName, filePath, lineNum, colNum] = anyFuncMatch;
         if (
@@ -276,7 +279,7 @@ export class ComponentContextCapture {
 
     for (let i = 3; i < maxLines; i++) {
       const line = lines[i];
-      const nameMatch = line.match(/at\s+([A-Z]\w+)/);
+      const nameMatch = line.match(/at\s+([A-Z]\w+)/u);
       if (nameMatch) {
         const funcName = nameMatch[1];
         if (!internalFuncNames.has(funcName)) {

--- a/packages/react-devtools/src/utils/ComponentQueryRegistry.test.ts
+++ b/packages/react-devtools/src/utils/ComponentQueryRegistry.test.ts
@@ -44,7 +44,7 @@ describe("ComponentQueryRegistry", () => {
       });
 
       expect(bindingId).toBeTruthy();
-      expect(bindingId).toMatch(/^binding-\d+$/);
+      expect(bindingId).toMatch(/^binding-\d+$/u);
     });
 
     it("should index binding by component", () => {

--- a/packages/react-devtools/src/utils/ComponentQueryRegistry.ts
+++ b/packages/react-devtools/src/utils/ComponentQueryRegistry.ts
@@ -66,19 +66,19 @@ export type QueryParams =
     };
 
 const INTERNAL_FRAME_PATTERNS = [
-  /node_modules/,
-  /@osdk\/react/,
-  /react-devtools/,
-  /ComponentContextCapture/,
-  /ObservableClientMonitor/,
-  /ComponentQueryRegistry/,
-  /packages\/react\/build/,
-  /packages\/react\/esm/,
-  /packages\/react\/src/,
+  /node_modules/u,
+  /@osdk\/react/u,
+  /react-devtools/u,
+  /ComponentContextCapture/u,
+  /ObservableClientMonitor/u,
+  /ComponentQueryRegistry/u,
+  /packages\/react\/build/u,
+  /packages\/react\/esm/u,
+  /packages\/react\/src/u,
 ];
 
-const CHROME_STACK_RE = /\((.*?):(\d+):(\d+)\)/;
-const FIREFOX_STACK_RE = /@(.*?):(\d+):(\d+)/;
+const CHROME_STACK_RE = /\((.*?):(\d+):(\d+)\)/u;
+const FIREFOX_STACK_RE = /@(.*?):(\d+):(\d+)/u;
 
 function isInternalFrame(filePath: string): boolean {
   for (const pattern of INTERNAL_FRAME_PATTERNS) {

--- a/packages/react-devtools/src/utils/ComputeMonitor.ts
+++ b/packages/react-devtools/src/utils/ComputeMonitor.ts
@@ -45,7 +45,7 @@ function isOsdkUrl(pathname: string): boolean {
 }
 
 const RID_REGEX =
-  /ri\.([a-z][a-z0-9-]*)\.([a-z0-9][a-z0-9-]*)?\.([a-z][a-z0-9-]*)\.([a-zA-Z0-9\-._]+)/;
+  /ri\.([a-z][a-z0-9-]*)\.([a-z0-9][a-z0-9-]*)?\.([a-z][a-z0-9-]*)\.([a-zA-Z0-9\-._]+)/u;
 
 export class ComputeMonitor {
   private readonly originalFetch: typeof globalThis.fetch;

--- a/packages/react-devtools/src/utils/MockDataGenerator.ts
+++ b/packages/react-devtools/src/utils/MockDataGenerator.ts
@@ -457,11 +457,11 @@ function generateId() {
 
   private static extractObjectTypeFromAction(actionName: string): string {
     const patterns = [
-      /create[_-]?(\w+)/i,
-      /add[_-]?(\w+)/i,
-      /new[_-]?(\w+)/i,
-      /(\w+)[_-]?create/i,
-      /(\w+)[_-]?add/i,
+      /create[_-]?(\w+)/iu,
+      /add[_-]?(\w+)/iu,
+      /new[_-]?(\w+)/iu,
+      /(\w+)[_-]?create/iu,
+      /(\w+)[_-]?add/iu,
     ];
 
     for (const pattern of patterns) {

--- a/packages/react-devtools/src/utils/PerformanceRecommendationEngine.ts
+++ b/packages/react-devtools/src/utils/PerformanceRecommendationEngine.ts
@@ -276,7 +276,7 @@ export class PerformanceRecommendationEngine {
 
     const totalImpact = recommendations.reduce((sum, r) => {
       if (r.impact.includes("Save")) {
-        const match = r.impact.match(/(\d+)(ms|KB|s)/);
+        const match = r.impact.match(/(\d+)(ms|KB|s)/u);
         if (match) {
           const value = Number.parseInt(match[1]);
           const unit = match[2];

--- a/packages/react-devtools/src/utils/SubscriptionTracker.test.ts
+++ b/packages/react-devtools/src/utils/SubscriptionTracker.test.ts
@@ -31,8 +31,8 @@ describe("SubscriptionTracker", () => {
     const id2 = tracker.startSubscription("sig-b");
 
     expect(id1).not.toBe(id2);
-    expect(id1).toMatch(/^sub-\d+$/);
-    expect(id2).toMatch(/^sub-\d+$/);
+    expect(id1).toMatch(/^sub-\d+$/u);
+    expect(id2).toMatch(/^sub-\d+$/u);
   });
 
   it("getActiveSubscriptions returns only non-ended subs", () => {

--- a/packages/react-devtools/src/utils/UnusedFieldAnalyzer.ts
+++ b/packages/react-devtools/src/utils/UnusedFieldAnalyzer.ts
@@ -59,7 +59,7 @@ export interface UnusedFieldReport {
   recommendation: string;
 }
 
-const QUERY_SIGNATURE_RE = /^(\w+):(.+)/;
+const QUERY_SIGNATURE_RE = /^(\w+):(.+)/u;
 
 export class UnusedFieldAnalyzer {
   constructor(

--- a/packages/react-devtools/src/utils/computePayload.test.ts
+++ b/packages/react-devtools/src/utils/computePayload.test.ts
@@ -50,7 +50,7 @@ describe("truncatePayload", () => {
     const result = truncatePayload(long);
 
     expect(result.length).toBe(10003);
-    expect(result).toMatch(/\.\.\.$/);
+    expect(result).toMatch(/\.\.\.$/u);
   });
 
   it("returns exact 10000-char strings unchanged", () => {

--- a/packages/react/src/aip/useChat.test.tsx
+++ b/packages/react/src/aip/useChat.test.tsx
@@ -547,7 +547,7 @@ describe("useChat", () => {
     it("throws when neither model nor transport is provided", () => {
       expect(() =>
         renderHook(() => useChat({ experimentalThrottle: 0 }))
-      ).toThrow(/`model` is required/);
+      ).toThrow(/`model` is required/u);
     });
   });
 });

--- a/packages/seed-compiler/src/compileSeedData.test.ts
+++ b/packages/seed-compiler/src/compileSeedData.test.ts
@@ -96,7 +96,7 @@ describe("mergeSeedOutputs", () => {
       Employee: [{ employeeId: "emp-001", firstName: "Alice" }],
     });
     expect(() => mergeSeedOutputs([output1, output2], schema)).toThrow(
-      /Duplicate primary key 'emp-001' for 'Employee'/
+      /Duplicate primary key 'emp-001' for 'Employee'/u
     );
   });
 
@@ -160,7 +160,7 @@ describe("validateSeedOutput", () => {
   it("should throw on unknown object types", () => {
     const output = makeOutput({ Ghost: [{ id: "1" }] });
     expect(() => validateSeedOutput(output, schema)).toThrow(
-      /Object type 'Ghost' in seed data is not defined in the ontology/
+      /Object type 'Ghost' in seed data is not defined in the ontology/u
     );
   });
 
@@ -169,7 +169,7 @@ describe("validateSeedOutput", () => {
       Employee: [{ employeeId: "emp-001", badProp: "x" }],
     });
     expect(() => validateSeedOutput(output, schema)).toThrow(
-      /Property 'badProp' on 'Employee' object \(index 0\) is not defined in the ontology/
+      /Property 'badProp' on 'Employee' object \(index 0\) is not defined in the ontology/u
     );
   });
 
@@ -178,7 +178,7 @@ describe("validateSeedOutput", () => {
       Employee: [{ employeeId: "emp-001", firstName: null }],
     });
     expect(() => validateSeedOutput(output, schema)).toThrow(
-      /Property 'firstName' on 'Employee' object \(index 0\) is null or undefined/
+      /Property 'firstName' on 'Employee' object \(index 0\) is null or undefined/u
     );
   });
 
@@ -198,7 +198,7 @@ describe("validateSeedOutput", () => {
       Employee: [{ employeeId: "emp-001", createdAt: 12345 }],
     });
     expect(() => validateSeedOutput(output, schema)).toThrow(
-      /Property 'createdAt' on 'Employee' object \(index 0\) expects timestamp \(a string\) but got number/
+      /Property 'createdAt' on 'Employee' object \(index 0\) expects timestamp \(a string\) but got number/u
     );
   });
 
@@ -208,7 +208,7 @@ describe("validateSeedOutput", () => {
       Employee: [{ employeeId: "emp-001", age: "30" }],
     });
     expect(() => validateSeedOutput(output, schema)).toThrow(
-      /Property 'age' on 'Employee' object \(index 0\) expects integer \(a number\) but got string/
+      /Property 'age' on 'Employee' object \(index 0\) expects integer \(a number\) but got string/u
     );
   });
 
@@ -217,7 +217,7 @@ describe("validateSeedOutput", () => {
       Employee: [{ employeeId: "emp-001", createdAt: "qdeqd" }],
     });
     expect(() => validateSeedOutput(output, schema)).toThrow(
-      /property 'createdAt' has invalid timestamp format: 'qdeqd'/
+      /property 'createdAt' has invalid timestamp format: 'qdeqd'/u
     );
   });
 
@@ -233,7 +233,7 @@ describe("validateSeedOutput", () => {
       Employee: [{ employeeId: "emp-001", score: "not-a-number" }],
     });
     expect(() => validateSeedOutput(output, schema)).toThrow(
-      /property 'score' has invalid long format/
+      /property 'score' has invalid long format/u
     );
   });
 

--- a/packages/seed-compiler/src/compileSeedData.ts
+++ b/packages/seed-compiler/src/compileSeedData.ts
@@ -81,28 +81,29 @@ const EXPECTED_JS_TYPE: Record<string, "string" | "number" | "boolean"> = {
  */
 const WIRE_TYPE_FORMAT: Record<string, { pattern: RegExp; example: string }> = {
   timestamp: {
-    pattern: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/,
+    pattern:
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/u,
     example: "2025-01-01T00:00:00Z",
   },
   date: {
-    pattern: /^\d{4}-\d{2}-\d{2}$/,
+    pattern: /^\d{4}-\d{2}-\d{2}$/u,
     example: "2025-01-01",
   },
   datetime: {
     pattern:
-      /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?)?$/,
+      /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?)?$/u,
     example: "2025-01-01T12:00:00Z",
   },
   long: {
     // Strict decimal integer — matches Rust's str::parse::<i64>().
     // No scientific notation, no decimal point, no whitespace.
-    pattern: /^-?\d+$/,
+    pattern: /^-?\d+$/u,
     example: "9007199254740993",
   },
   decimal: {
     // Numeric string with optional decimal point. Anchored.
     // Rust stores any string (no validation), but we reject obviously invalid values.
-    pattern: /^-?\d+(\.\d+)?$/,
+    pattern: /^-?\d+(\.\d+)?$/u,
     example: "123.45",
   },
 };

--- a/packages/tool.release/src/ciPublish.ts
+++ b/packages/tool.release/src/ciPublish.ts
@@ -80,7 +80,7 @@ async function getRemoteBranches(): Promise<string[]> {
     .split("\n")
     .filter((line) => !!line)
     .map((line) => {
-      const match = line.match(/release\/(.*)/);
+      const match = line.match(/release\/(.*)/u);
       if (!match) {
         consola.log(match);
         throw new Error(`Invalid branch name: ${line}`);
@@ -100,10 +100,10 @@ async function getCurrentBranch(): Promise<string> {
 export function findGreatestVersion(releaseBranches: string[]): string | null {
   if (releaseBranches.length === 0) return null;
   return releaseBranches.reduce((maxBranch, branch) => {
-    let version = branch.replace(/^.*?release\//, "");
-    let maxVersion = maxBranch.replace(/^.*?release\//, "");
-    version = version.replace(/\.x$/, ".0");
-    maxVersion = maxVersion.replace(/\.x$/, ".0");
+    let version = branch.replace(/^.*?release\//u, "");
+    let maxVersion = maxBranch.replace(/^.*?release\//u, "");
+    version = version.replace(/\.x$/u, ".0");
+    maxVersion = maxVersion.replace(/\.x$/u, ".0");
 
     if (!semver.valid(version)) {
       return maxBranch;

--- a/packages/tool.release/src/copyChangelogs.ts
+++ b/packages/tool.release/src/copyChangelogs.ts
@@ -128,7 +128,7 @@ async function updateChangelog(
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
-    const versionMatch = line.match(/^## ([\d.]+(?:-beta\.\d+)?)$/);
+    const versionMatch = line.match(/^## ([\d.]+(?:-beta\.\d+)?)$/u);
 
     if (versionMatch) {
       const entryVersion = versionMatch[1];
@@ -139,7 +139,7 @@ async function updateChangelog(
     }
   }
 
-  entry.content = entry.content.replace(/\n$/, "");
+  entry.content = entry.content.replace(/\n$/u, "");
   lines.splice(insertAt, 0, `\n## ${targetVersion}\n\n${entry.content}`);
 
   const updatedContent = lines.join("\n");

--- a/packages/tool.release/src/index.ts
+++ b/packages/tool.release/src/index.ts
@@ -216,7 +216,7 @@ async function getContext(args: {
       );
       const authLine = userNpmrcContent.split("\n").find((line) => {
         // check based on https://github.com/npm/cli/blob/8f8f71e4dd5ee66b3b17888faad5a7bf6c657eed/test/lib/adduser.js#L103-L105
-        return /^\s*\/\/registry\.npmjs\.org\/:[_-]authToken=/i.test(line);
+        return /^\s*\/\/registry\.npmjs\.org\/:[_-]authToken=/iu.test(line);
       });
       if (authLine) {
         consola.info(

--- a/packages/tool.release/src/runPublish.ts
+++ b/packages/tool.release/src/runPublish.ts
@@ -78,7 +78,7 @@ export async function runPublish({
   cwd = process.cwd(),
   context,
 }: PublishOptions): Promise<PublishResult> {
-  const [publishCommand, ...publishArgs] = script.split(/\s+/);
+  const [publishCommand, ...publishArgs] = script.split(/\s+/u);
 
   const changesetPublishOutput = await getExecOutput(
     publishCommand,
@@ -92,7 +92,7 @@ export async function runPublish({
   const releasedPackages: Package[] = [];
 
   if (tool !== "root") {
-    const newTagRegex = /New tag:\s+(@[^/]+\/[^@]+|[^/]+)@([^\s]+)/;
+    const newTagRegex = /New tag:\s+(@[^/]+\/[^@]+|[^/]+)@([^\s]+)/u;
     const packagesByName = new Map(
       packages.map((x) => [x.packageJson.name, x])
     );
@@ -131,7 +131,7 @@ export async function runPublish({
       );
     }
     const pkg = packages[0];
-    const newTagRegex = /New tag:/;
+    const newTagRegex = /New tag:/u;
 
     for (const line of changesetPublishOutput.stdout.split("\n")) {
       const match = line.match(newTagRegex);

--- a/packages/typescript-sdk-docs/src/docs.ts
+++ b/packages/typescript-sdk-docs/src/docs.ts
@@ -468,7 +468,7 @@ function getMapKeyObjectName(apiName?: string) {
 }
 
 function getDisplayName(input: string): string {
-  const tokens = input.split(/[_-]|(?<=[a-z])(?=[A-Z])/);
+  const tokens = input.split(/[_-]|(?<=[a-z])(?=[A-Z])/u);
   const result = tokens.map((token) => titleCase(token.toLowerCase())).join("");
   return result.charAt(0).toLowerCase() + result.slice(1);
 }

--- a/packages/unit-testing/src/mock/__tests__/createMockOsdkObject.test.ts
+++ b/packages/unit-testing/src/mock/__tests__/createMockOsdkObject.test.ts
@@ -191,13 +191,13 @@ describe("createMockOsdkObject", () => {
       expect(mockEmployee.$link.officeLink).toBeDefined();
 
       await expect(mockEmployee.$link.officeLink.fetchOne()).rejects.toThrow(
-        /Link "officeLink" was not configured on mock Employee/
+        /Link "officeLink" was not configured on mock Employee/u
       );
 
       const result = await mockEmployee.$link.officeLink.fetchOneWithErrors();
       expect(result.error).toBeInstanceOf(Error);
       expect(result.error!.message).toMatch(
-        /Link "officeLink" was not configured on mock Employee/
+        /Link "officeLink" was not configured on mock Employee/u
       );
       expect(result.value).toBeUndefined();
     });
@@ -215,7 +215,7 @@ describe("createMockOsdkObject", () => {
 
       expect(await mockEmployee.$link.officeLink.fetchOne()).toBe(mockOffice);
       await expect(mockEmployee.$link.lead.fetchOne()).rejects.toThrow(
-        /Link "lead" was not configured on mock Employee/
+        /Link "lead" was not configured on mock Employee/u
       );
     });
 

--- a/packages/version-updater/scripts/parseChangelog.mjs
+++ b/packages/version-updater/scripts/parseChangelog.mjs
@@ -32,11 +32,11 @@
  * @returns {VersionMapping[]} Array of version mappings
  */
 export function parseChangelog(content, peerPackageNames) {
-  const versionBlocks = content.split(/^## /m).slice(1);
+  const versionBlocks = content.split(/^## /mu).slice(1);
 
   return versionBlocks
     .map((block) => {
-      const versionMatch = block.match(/^(\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?)/);
+      const versionMatch = block.match(/^(\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?)/u);
       if (!versionMatch) {
         return undefined;
       }
@@ -44,8 +44,9 @@ export function parseChangelog(content, peerPackageNames) {
       /** @type {Record<string, string>} */
       const peerVersions = {};
       for (const peerName of peerPackageNames) {
-        const escaped = peerName.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const escaped = peerName.replaceAll(/[.*+?^${}()|[\]\\]/gu, "\\$&");
         const match = block.match(
+          // oxlint-disable-next-line require-unicode-regexp -- dynamic pattern; adding the u flag could change matching or throw on patterns that are valid without it
           new RegExp(`${escaped}@(\\d+\\.\\d+\\.\\d+(-[a-zA-Z0-9.]+)?)`)
         );
         if (match) {

--- a/packages/version-updater/scripts/postVersioning.mjs
+++ b/packages/version-updater/scripts/postVersioning.mjs
@@ -123,6 +123,7 @@ function applyLoosePeerDep(packageDir, peerName, range) {
 function updateConstVariable(filePath, variableName, value) {
   const fileContents = fs.readFileSync(filePath, "utf-8");
 
+  // oxlint-disable-next-line require-unicode-regexp -- dynamic pattern; adding the u flag could change matching or throw on patterns that are valid without it
   const regexp = new RegExp(`const ${variableName} = ".*?";`);
   if (!regexp.test(fileContents)) {
     consola.error(

--- a/packages/vite-plugin-oac/src/registerOntologyFullMetadata.ts
+++ b/packages/vite-plugin-oac/src/registerOntologyFullMetadata.ts
@@ -270,7 +270,7 @@ function paramsToDataValues(
 function camelcase(apiName: string): string {
   return apiName
     .toLowerCase()
-    .replace(/[-_]+(.)?/g, (_, chr) => (chr ? chr.toUpperCase() : ""));
+    .replace(/[-_]+(.)?/gu, (_, chr) => (chr ? chr.toUpperCase() : ""));
 }
 
 function toDataValue(value: any, param: Ontologies.ActionParameterV2): unknown {

--- a/packages/vite-plugin-superrepo/src/index.ts
+++ b/packages/vite-plugin-superrepo/src/index.ts
@@ -265,7 +265,7 @@ export function smartClientPlugin(): Plugin {
       // calls are routed to the local function runtimes. `@osdk/oauth`
       // and any other imports are untouched.
       return code.replace(
-        /from\s+(["'])@osdk\/client\1/,
+        /from\s+(["'])@osdk\/client\1/u,
         `from "@osdk/vite-plugin-superrepo/osdkClient"`
       );
     },
@@ -299,6 +299,7 @@ function buildProxyOptions(
     : basePrefix;
   if (stripPrefix) {
     options.rewrite = (p) =>
+      // oxlint-disable-next-line require-unicode-regexp -- dynamic pattern; adding the u flag could change matching or throw on patterns that are valid without it
       p.replace(new RegExp(`^${escapeRegExp(stripPrefix)}`), "");
   }
   if (isHttps) {
@@ -319,7 +320,7 @@ function buildProxyOptions(
 }
 
 function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return s.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
 
 /**

--- a/packages/vite-plugin-superrepo/src/public/smartClient.ts
+++ b/packages/vite-plugin-superrepo/src/public/smartClient.ts
@@ -21,7 +21,7 @@ import type { Client } from "@osdk/client";
 // Vite serves under `import.meta.env.BASE_URL` (trailing slash); the direct
 // fetches below hit the same-origin proxies the plugin installs, so they must
 // carry that prefix to route through Vite when it is served under a path.
-const BASE_PATH = import.meta.env.BASE_URL.replace(/\/$/, "");
+const BASE_PATH = import.meta.env.BASE_URL.replace(/\/$/u, "");
 const withBase = (path: string): string => `${BASE_PATH}${path}`;
 
 interface RuntimeConfig {
@@ -59,7 +59,7 @@ function enqueue<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 function camelToSnakeCase(str: string): string {
-  return str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+  return str.replace(/[A-Z]/gu, (letter) => `_${letter.toLowerCase()}`);
 }
 
 function hasEntries(o: unknown): boolean {

--- a/packages/widget.vite-plugin/src/build-plugin/isConfigFile.ts
+++ b/packages/widget.vite-plugin/src/build-plugin/isConfigFile.ts
@@ -17,7 +17,7 @@
 import { CONFIG_FILE_SUFFIX } from "../common/constants.js";
 
 export function isConfigFile(filePath: string): boolean {
-  const trimmedFilePath = filePath.replace(/\.[^/.]+$/, "");
+  const trimmedFilePath = filePath.replace(/\.[^/.]+$/u, "");
   return (
     filePath.endsWith(CONFIG_FILE_SUFFIX) ||
     trimmedFilePath.endsWith(CONFIG_FILE_SUFFIX)

--- a/packages/widget.vite-plugin/src/common/standardizePathAndFileExtension.ts
+++ b/packages/widget.vite-plugin/src/common/standardizePathAndFileExtension.ts
@@ -25,9 +25,9 @@ import { CONFIG_FILE_SUFFIX } from "./constants.js";
  * Additionally, replaces Windows-style backslashes with forward slashes for path consistency.
  */
 export function standardizePathAndFileExtension(file: string): string {
-  const normalizedPath = file.replace(/\\/g, "/");
+  const normalizedPath = file.replace(/\\/gu, "/");
   if (normalizedPath.endsWith(CONFIG_FILE_SUFFIX)) {
     return normalizedPath + ".js";
   }
-  return normalizedPath.replace(/\.[jt]sx?$/, ".js");
+  return normalizedPath.replace(/\.[jt]sx?$/u, ".js");
 }

--- a/packages/widget.vite-plugin/src/common/validateWidgetConfig.ts
+++ b/packages/widget.vite-plugin/src/common/validateWidgetConfig.ts
@@ -16,7 +16,7 @@
 
 import type { ParameterConfig, WidgetConfig } from "@osdk/widget.api";
 
-const ID_PATTERN = /^([a-z][a-z0-9]*)([A-Z][a-z0-9]*)*$/;
+const ID_PATTERN = /^([a-z][a-z0-9]*)([A-Z][a-z0-9]*)*$/u;
 const ID_MAX_LENGTH = 100;
 const NAME_MAX_LENGTH = 100;
 const DESCRIPTION_MAX_LENGTH = 250;

--- a/packages/widget.vite-plugin/src/dev-plugin/FoundryWidgetDevPlugin.ts
+++ b/packages/widget.vite-plugin/src/dev-plugin/FoundryWidgetDevPlugin.ts
@@ -245,7 +245,7 @@ export function FoundryWidgetDevPlugin(
       // project files like foundry.config.json / eslint.config.mjs when tailwind is used.
       if (
         standardizedSource
-          .replace(/\.[^/.]+$/, "")
+          .replace(/\.[^/.]+$/u, "")
           .endsWith(CONFIG_FILE_SUFFIX) &&
         standardizedSource.includes("/src/") &&
         codeEntrypoints[standardizedImporter] != null

--- a/packages/widget.vite-plugin/src/dev-plugin/getBaseHref.ts
+++ b/packages/widget.vite-plugin/src/dev-plugin/getBaseHref.ts
@@ -26,7 +26,7 @@ export function getBaseHref(server: ViteDevServer): string {
     ? getCodeWorkspacesBaseHref()
     : getLocalhostBaseHref(server);
   // Ensure that all URLs end with a trailing slash for consistency
-  return baseHref.replace(/\/?$/, "/");
+  return baseHref.replace(/\/?$/u, "/");
 }
 
 function getLocalhostBaseHref(server: ViteDevServer): string {


### PR DESCRIPTION
## What

Re-enables `require-unicode-regexp` (`off -> error`) in the root `oxlint.config.ts` and adds the `u` (unicode) flag to the flagged regular expressions across all migrated packages. Second PR in the effort to re-enable the six behavior/API-risk rules the oxc migration parked at `off`.

434 findings total; this PR resolves all in migrated packages (the ~39 in not-yet-migrated generator packages still lint via eslint and are out of scope).

## Why require the `u` flag?

The `u` flag opts a regex into Unicode mode, which is stricter and more correct than the default (non-unicode) mode. Enforcing it repo-wide buys:

- **Correct handling of non-BMP characters.** Without `u`, `.`, character classes, and quantifiers operate on UTF-16 code units, so a single astral character (emoji, less-common CJK, etc.) counts as *two* "characters". A pattern like `/^.$/` does not match a single emoji, and `.` / `[^x]` can split a surrogate pair mid-character. With `u`, the engine matches whole code points, which is almost always what the author intended when a regex touches user-provided text.
- **Malformed patterns fail loudly instead of silently misbehaving.** In Unicode mode, invalid or unnecessary escapes (e.g. a stray `\-` or `\ `) and reserved sequences are syntax errors; in the default mode they are silently reinterpreted. That turns a class of latent regex bugs into build-time failures.
- **Access to modern Unicode features.** `u` is the prerequisite for `\u{...}` code-point escapes and `\p{...}` / `\P{...}` Unicode property escapes, so newly written regexes can use them without a follow-up migration.
- **One consistent regex dialect.** Every regex in the codebase behaves the same way instead of some relying on the looser default behavior, which removes a footgun for future edits.

The flip is behavior-preserving *for the existing code* (see verification), while making all of the above the enforced default going forward.

## Approach

oxlint's `require-unicode-regexp` fix is gated behind `--fix-dangerously` (it can change match semantics), so this was not a blind autofix. The `u` flag was inserted into exactly the reported regex literals, then **every** change was verified:

- **Syntactic validity under `/u`:** full `typecheck` + `transpile` + `build` pass (376 tasks), so no regex contains an escape that is illegal in unicode mode.
- **Behavior preservation:** all changed regexes are ASCII-only patterns (verified: zero non-ASCII characters in the diff) matched against non-astral inputs (version strings, RIDs, file paths, API names, test assertions). The affected packages' test suites pass.
- The one behavioral surface that changed is a `maker` inline snapshot that quotes a validation regex's `.source` in an error message (now shows the `u` flag); snapshot updated.

## Dynamic `new RegExp(...)` cases

9 findings are `new RegExp(...)` built from runtime or user-provided values (faux object-search from `where.value`, osdk-docs-context example search, git tag prefixes, superrepo route prefixes, version-updater scripts). Forcing the `u` flag there could change matching or throw on patterns that are valid without it, so each keeps its current behavior via a scoped inline `// oxlint-disable-next-line require-unicode-regexp` with justification.

## Verification

- `oxlint` (root + all nested configs): 0 `require-unicode-regexp` findings in migrated packages
- `pnpm turbo typecheck transpile build`: green (376 tasks)
- `pnpm turbo test`: migrated packages green (maker snapshot updated). The only failing suite is `@osdk/example-generator` (not migrated, unchanged here; a pre-existing `.expo` on-disk-diff base failure)
- `pnpm turbo lint`: green (217 tasks), including `oxfmt --check`
- `pnpm turbo check-api` (api, client): no API report changes
- `monorepolint check`: 0; `dprint check`: clean

## Changeset

One `patch` changeset covering the 22 changed public non-ignored packages.