### PR TITLE
chore: re-enable oxlint require-await

### DIFF
--- a/.changeset/oxc-reenable-require-await.md
+++ b/.changeset/oxc-reenable-require-await.md
@@ -1,0 +1,22 @@
+---
+"@osdk/foundry-config-json": patch
+"@osdk/maker-experimental": patch
+"@osdk/client.unstable.tpsa": patch
+"@osdk/widget.vite-plugin": patch
+"@osdk/cbac-components": patch
+"@osdk/client.unstable": patch
+"@osdk/language-models": patch
+"@osdk/unit-testing": patch
+"@osdk/create-app": patch
+"@osdk/react-components": patch
+"@osdk/aip-core": patch
+"@osdk/functions": patch
+"@osdk/shared.net": patch
+"@osdk/client": patch
+"@osdk/oauth": patch
+"@osdk/react": patch
+"@osdk/cli": patch
+"@osdk/api": patch
+---
+
+Enable the require-await lint rule: drop the redundant `async` keyword from test callbacks that never await, and keep intentionally-async (Promise-returning) functions as-is

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -71,8 +71,8 @@ export default defineConfig({
     "no-eq-null": "off",
     "unicorn/custom-error-definition": "error",
     "default-param-last": "error",
-    "require-await": "off",
-    "typescript/require-await": "off",
+    "require-await": "error",
+    "typescript/require-await": "error",
     "require-unicode-regexp": "error",
 
     // --- Repo-wide cosmetic / high-churn policy ---

--- a/packages/aip-core/src/ai-sdk/__tests__/foundry-chat-language-model.test.ts
+++ b/packages/aip-core/src/ai-sdk/__tests__/foundry-chat-language-model.test.ts
@@ -31,6 +31,7 @@ function createModel(opts: {
   model: FoundryChatLanguageModel;
   fetchMock: ReturnType<typeof vi.fn>;
 } {
+  // oxlint-disable-next-line require-await -- intentionally async: assigned to a Promise-returning callback/mock type; no await needed
   const fetchMock = vi.fn<typeof globalThis.fetch>(async () => {
     if (opts.stream) {
       const body = opts.responseBody as string;

--- a/packages/aip-core/src/generateText.e2e.test.ts
+++ b/packages/aip-core/src/generateText.e2e.test.ts
@@ -46,7 +46,7 @@ const describeIfConfigured = baseUrl && token ? describe : describe.skip;
 const E2E_TIMEOUT_MS = 30_000;
 
 function makeClient(baseUrlIn: string, tokenIn: string): PlatformClient {
-  const fetchFn: typeof globalThis.fetch = async (input, init) => {
+  const fetchFn: typeof globalThis.fetch = (input, init) => {
     const headers = new Headers(init?.headers);
     headers.set("Authorization", `Bearer ${tokenIn}`);
     return fetch(input, { ...init, headers });

--- a/packages/aip-core/src/generateText.test.ts
+++ b/packages/aip-core/src/generateText.test.ts
@@ -35,6 +35,7 @@ function createMockClient(options: MockClientOptions = {}): {
   client: PlatformClient;
   fetch: ReturnType<typeof vi.fn>;
 } {
+  // oxlint-disable-next-line require-await -- intentionally async: assigned to a Promise-returning callback/mock type; no await needed
   const fetchMock = vi.fn<typeof globalThis.fetch>(async (_input, _init) => {
     const body = options.responseBody ?? defaultResponse();
     return new Response(JSON.stringify(body), {

--- a/packages/aip-core/src/lmsChatTransport.ts
+++ b/packages/aip-core/src/lmsChatTransport.ts
@@ -63,6 +63,7 @@ export class LmsChatTransport implements ChatTransport<UIMessage> {
     this.opts = opts;
   }
 
+  // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
   // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   sendMessages = async (
     args: SendMessagesArgs
@@ -186,6 +187,7 @@ export class LmsChatTransport implements ChatTransport<UIMessage> {
     );
   };
 
+  // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
   // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   reconnectToStream = async (
     _args: ChatTransportReconnectArgs

--- a/packages/aip-core/src/lmsChatTransport.ts
+++ b/packages/aip-core/src/lmsChatTransport.ts
@@ -63,6 +63,7 @@ export class LmsChatTransport implements ChatTransport<UIMessage> {
     this.opts = opts;
   }
 
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   sendMessages = async (
     args: SendMessagesArgs
   ): Promise<ReadableStream<UIMessageChunk>> => {
@@ -185,6 +186,7 @@ export class LmsChatTransport implements ChatTransport<UIMessage> {
     );
   };
 
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   reconnectToStream = async (
     _args: ChatTransportReconnectArgs
   ): Promise<ReadableStream<UIMessageChunk> | null> => {

--- a/packages/aip-core/src/streamText.test.ts
+++ b/packages/aip-core/src/streamText.test.ts
@@ -63,10 +63,12 @@ function createMockClient(args: MockClientArgs = {}): {
   fetch: ReturnType<typeof vi.fn>;
 } {
   const fetchMock = vi.fn<typeof globalThis.fetch>(
+    // oxlint-disable-next-line require-await -- intentionally async: assigned to a Promise-returning callback/mock type; no await needed
     async () => args.response ?? sseResponse(args)
   );
   const client: PlatformClient = {
     baseUrl: args.baseUrl ?? "https://example.palantirfoundry.com",
+    // oxlint-disable-next-line require-await -- intentionally async: assigned to a Promise-returning callback/mock type; no await needed
     tokenProvider: async () => "test-token",
     fetch: fetchMock,
   };

--- a/packages/api/src/OsdkObjectFrom.test.ts
+++ b/packages/api/src/OsdkObjectFrom.test.ts
@@ -484,7 +484,7 @@ describe("ExtractOptions", () => {
   });
 
   describe("Interface casting works as intended", () => {
-    it("mapping as with fqn property names works", async () => {
+    it("mapping as with fqn property names works", () => {
       expectTypeOf<
         MapPropNamesToInterface<
           quickerAndDirtier,

--- a/packages/api/src/junk.test.ts
+++ b/packages/api/src/junk.test.ts
@@ -17,7 +17,7 @@
 import { describe, expect, it } from "vitest";
 
 describe("anything", () => {
-  it("does", async () => {
+  it("does", () => {
     expect(1).toBe(1);
   });
 });

--- a/packages/api/src/objectSet/ObjectSet.test.ts
+++ b/packages/api/src/objectSet/ObjectSet.test.ts
@@ -1453,7 +1453,7 @@ describe("ObjectSet", () => {
     });
   });
 
-  describe("asyncIterLinks", async () => {
+  describe("asyncIterLinks", () => {
     it("typechecks self-referential one link", async () => {
       for await (const {
         source,

--- a/packages/cbac-components/scripts/build-css.mjs
+++ b/packages/cbac-components/scripts/build-css.mjs
@@ -30,6 +30,7 @@ const buildDir = path.join(__dirname, "..", "build", "browser");
 async function findCssModules(dir) {
   const entries = await fs.readdir(dir, { withFileTypes: true });
   const files = await Promise.all(
+    // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     entries.map(async (entry) => {
       const fullPath = path.join(dir, entry.name);
       if (entry.isDirectory()) {
@@ -46,6 +47,7 @@ async function findCssModules(dir) {
 async function findJsFiles(dir) {
   const entries = await fs.readdir(dir, { withFileTypes: true });
   const files = await Promise.all(
+    // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     entries.map(async (entry) => {
       const fullPath = path.join(dir, entry.name);
       if (entry.isDirectory()) {

--- a/packages/cbac-components/scripts/build-css.mjs
+++ b/packages/cbac-components/scripts/build-css.mjs
@@ -30,6 +30,7 @@ const buildDir = path.join(__dirname, "..", "build", "browser");
 async function findCssModules(dir) {
   const entries = await fs.readdir(dir, { withFileTypes: true });
   const files = await Promise.all(
+    // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
     // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     entries.map(async (entry) => {
       const fullPath = path.join(dir, entry.name);
@@ -47,6 +48,7 @@ async function findCssModules(dir) {
 async function findJsFiles(dir) {
   const entries = await fs.readdir(dir, { withFileTypes: true });
   const files = await Promise.all(
+    // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
     // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     entries.map(async (entry) => {
       const fullPath = path.join(dir, entry.name);

--- a/packages/cli.cmd.typescript/src/generate/handleGenerate.mts
+++ b/packages/cli.cmd.typescript/src/generate/handleGenerate.mts
@@ -85,6 +85,7 @@ async function generateFromStack(args: TypescriptGenerateArgs) {
   });
   const ctx = createSharedClientContext(
     args.foundryUrl!,
+    // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     async () => token.access_token,
     USER_AGENT
   );
@@ -382,6 +383,7 @@ function createNormalFs(): MinimalFs {
     mkdir: async (path: string, options?: { recursive: boolean }) => {
       await fs.promises.mkdir(path, options);
     },
+    // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     readdir: async (path: string) => fs.promises.readdir(path),
   };
 }

--- a/packages/cli.cmd.typescript/src/generate/handleGenerate.mts
+++ b/packages/cli.cmd.typescript/src/generate/handleGenerate.mts
@@ -383,6 +383,7 @@ function createNormalFs(): MinimalFs {
     mkdir: async (path: string, options?: { recursive: boolean }) => {
       await fs.promises.mkdir(path, options);
     },
+    // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
     // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     readdir: async (path: string) => fs.promises.readdir(path),
   };

--- a/packages/cli.common/src/getYargsBase.ts
+++ b/packages/cli.common/src/getYargsBase.ts
@@ -26,36 +26,39 @@ import { logLevelMiddleware } from "./yargs/logLevelMiddleware.js";
 import { YargsCheckError } from "./YargsCheckError.js";
 
 export function getYargsBase(args: string[]): Argv<CliCommonArgs> {
-  return yargs(hideBin(args))
-    .wrap(Math.min(150, yargs().terminalWidth()))
-    .env("OSDK")
-    .version(false)
-    .option("verbose", {
-      alias: "v",
-      type: "boolean",
-      description: "Enable verbose logging",
-      count: true,
-    })
-    .demandCommand()
-    .middleware(logLevelMiddleware, true)
-    .strict()
-    .fail(async (msg, err, argv) => {
-      if (err instanceof ExitProcessError) {
-        consola.error(err.message);
-        if (err.tip != null) {
-          consola.log(colorize("bold", `💡 Tip: ${err.tip}`));
-          consola.log("");
-        }
-        consola.debug(err.stack);
-      } else {
-        if (err && !(err instanceof YargsCheckError)) {
-          throw err;
+  return (
+    yargs(hideBin(args))
+      .wrap(Math.min(150, yargs().terminalWidth()))
+      .env("OSDK")
+      .version(false)
+      .option("verbose", {
+        alias: "v",
+        type: "boolean",
+        description: "Enable verbose logging",
+        count: true,
+      })
+      .demandCommand()
+      .middleware(logLevelMiddleware, true)
+      .strict()
+      // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
+      .fail(async (msg, err, argv) => {
+        if (err instanceof ExitProcessError) {
+          consola.error(err.message);
+          if (err.tip != null) {
+            consola.log(colorize("bold", `💡 Tip: ${err.tip}`));
+            consola.log("");
+          }
+          consola.debug(err.stack);
         } else {
-          argv.showHelp();
-          consola.log("");
-          consola.error(msg);
+          if (err && !(err instanceof YargsCheckError)) {
+            throw err;
+          } else {
+            argv.showHelp();
+            consola.log("");
+            consola.error(msg);
+          }
         }
-      }
-      process.exit(1);
-    });
+        process.exit(1);
+      })
+  );
 }

--- a/packages/cli.common/src/yargs/logLevelMiddleware.ts
+++ b/packages/cli.common/src/yargs/logLevelMiddleware.ts
@@ -19,6 +19,7 @@ import { consola } from "consola";
 import type { CliCommonArgs } from "../CliCommonArgs.js";
 
 let firstTime = true;
+// oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 export async function logLevelMiddleware(args: CliCommonArgs): Promise<void> {
   if (firstTime) {
     firstTime = false;

--- a/packages/cli/src/commands/site/deploy/logSiteDeployCommandConfigFileOverride.ts
+++ b/packages/cli/src/commands/site/deploy/logSiteDeployCommandConfigFileOverride.ts
@@ -20,6 +20,7 @@ import type { Arguments } from "yargs";
 
 import type { SiteDeployArgs } from "./SiteDeployArgs.js";
 
+// oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 export async function logSiteDeployCommandConfigFileOverride(
   args: Arguments<SiteDeployArgs>,
   config: SiteConfig | undefined

--- a/packages/cli/src/commands/site/logSiteCommandConfigFileOverride.ts
+++ b/packages/cli/src/commands/site/logSiteCommandConfigFileOverride.ts
@@ -20,6 +20,7 @@ import type { Arguments } from "yargs";
 
 import type { CommonSiteArgs } from "./CommonSiteArgs.js";
 
+// oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 export async function logSiteCommandConfigFileOverride(
   args: Arguments<CommonSiteArgs>,
   config: FoundryConfig<"site"> | undefined

--- a/packages/client.test.ontology/generateMockOntology.js
+++ b/packages/client.test.ontology/generateMockOntology.js
@@ -85,6 +85,7 @@ await generateClientSdkVersionTwoPointZero(
     mkdir: async (path, options) => {
       await mkdir(path, options);
     },
+    // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     readdir: async (path) => readdir(path),
   },
   outDir,

--- a/packages/client.unstable.tpsa/oxlint.config.ts
+++ b/packages/client.unstable.tpsa/oxlint.config.ts
@@ -56,5 +56,12 @@ export default defineConfig({
     // oxfmt owns import spacing in this migration; the generated files do not
     // carry a blank line after their import block. Not enforced by prior ESLint.
     "import/newline-after-import": "off",
+    // The conjure generator emits every service method as `async`, and many have
+    // no `await` (they just build and return a request). This is generated code
+    // (regenerated on codegen, not hand-editable), and the `async` is load-bearing
+    // for the methods' `Promise`-returning signatures, so require-await is disabled
+    // here rather than rewriting the generated tree. Not enforced by prior ESLint.
+    "require-await": "off",
+    "typescript/require-await": "off",
   },
 });

--- a/packages/client.unstable/oxlint.config.ts
+++ b/packages/client.unstable/oxlint.config.ts
@@ -49,5 +49,12 @@ export default defineConfig({
     // oxfmt owns import spacing in this migration; the generated files do not
     // carry a blank line after their import block. Not enforced by prior ESLint.
     "import/newline-after-import": "off",
+    // The conjure generator emits every service method as `async`, and many have
+    // no `await` (they just build and return a request). This is generated code
+    // (regenerated on codegen, not hand-editable), and the `async` is load-bearing
+    // for the methods' `Promise`-returning signatures, so require-await is disabled
+    // here rather than rewriting the generated tree. Not enforced by prior ESLint.
+    "require-await": "off",
+    "typescript/require-await": "off",
   },
 });

--- a/packages/client/src/__unstable/ConjureSupport.ts
+++ b/packages/client/src/__unstable/ConjureSupport.ts
@@ -103,6 +103,7 @@ export class MetadataClient {
     getLinkMapping: () => Promise<ObjectLinkMapping>;
     getRid: () => string;
     getApiName: () => Promise<string | null | undefined>;
+    // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   }> = strongMemoAsync(async (rid: string) => {
     return Promise.resolve({
       getPropertyMapping: this.#objectPropertyMapping.bind(this, rid),

--- a/packages/client/src/__unstable/ConjureSupport.ts
+++ b/packages/client/src/__unstable/ConjureSupport.ts
@@ -103,6 +103,7 @@ export class MetadataClient {
     getLinkMapping: () => Promise<ObjectLinkMapping>;
     getRid: () => string;
     getApiName: () => Promise<string | null | undefined>;
+    // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
     // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   }> = strongMemoAsync(async (rid: string) => {
     return Promise.resolve({

--- a/packages/client/src/actions/actions.test.ts
+++ b/packages/client/src/actions/actions.test.ts
@@ -407,7 +407,7 @@ describe.each([
     expectTypeOf<typeof result>().toEqualTypeOf<undefined>();
     expect(result).toBeUndefined();
   });
-  it("Accepts interfaces if implementing object types unknown", async () => {
+  it("Accepts interfaces if implementing object types unknown", () => {
     const clientBoundTakesInterface = client(deleteBarInterface).applyAction;
 
     type InferredParamType = Parameters<typeof clientBoundTakesInterface>[0];
@@ -697,7 +697,7 @@ describe("ActionResponse remapping", () => {
       }
     `);
   });
-  it("actions are enumerable", async () => {
+  it("actions are enumerable", () => {
     const actions = Object.keys($Actions);
     expect(actions).toStrictEqual([
       "actionTakesAttachment",
@@ -723,5 +723,5 @@ function wrapper<R>(fn: () => R): typeof fn {
 }
 
 async function example() {
-  await wrapper(async () => Promise.resolve("hi"))();
+  await wrapper(() => Promise.resolve("hi"))();
 }

--- a/packages/client/src/createClient.test.ts
+++ b/packages/client/src/createClient.test.ts
@@ -53,7 +53,7 @@ describe(createClient, () => {
     client = createClient(
       "https://mock.com",
       ontologyRid,
-      async () => "Token",
+      () => "Token",
       undefined,
       fetchFunction
     );
@@ -88,7 +88,7 @@ describe(createClient, () => {
       const clientWithHeaders = createClient(
         "https://mock.com",
         ontologyRid,
-        async () => "Token",
+        () => "Token",
         { headers: { "Fetch-User-Agent": "my-app/1.0" } },
         customFetch
       );
@@ -109,12 +109,12 @@ describe(createClient, () => {
   });
 
   describe("check url formatting", () => {
-    it("urls are correctly formatted", async () => {
+    it("urls are correctly formatted", () => {
       const spy = vi.spyOn(SharedClientContext, "createSharedClientContext");
       const client = createClient(
         "https://mock.com",
         ontologyRid,
-        async () => "Token",
+        () => "Token",
         undefined,
         fetchFunction
       );
@@ -123,7 +123,7 @@ describe(createClient, () => {
       createClient(
         "https://mock1.com/",
         ontologyRid,
-        async () => "Token",
+        () => "Token",
         undefined,
         fetchFunction
       );
@@ -132,7 +132,7 @@ describe(createClient, () => {
       createClient(
         "https://mock2.com/stuff/first/foo",
         ontologyRid,
-        async () => "Token",
+        () => "Token",
         undefined,
         fetchFunction
       );
@@ -143,7 +143,7 @@ describe(createClient, () => {
       createClient(
         "https://mock3.com/stuff/first/foo/",
         ontologyRid,
-        async () => "Token",
+        () => "Token",
         undefined,
         fetchFunction
       );
@@ -158,7 +158,7 @@ describe(createClient, () => {
 
       void metadataCacheClient({
         baseUrl: "https://mock4.com/",
-        ontologyProvider: { getObjectDefinition: async () => ({}) },
+        ontologyProvider: { getObjectDefinition: () => ({}) },
       } as any);
 
       expect(
@@ -176,7 +176,7 @@ describe(createClient, () => {
         async () => {},
         "https://mock.com",
         ontologyRid,
-        async () => "Token",
+        () => "Token",
         {},
         fetchFunction
       );

--- a/packages/client/src/createMediaFromReference.ts
+++ b/packages/client/src/createMediaFromReference.ts
@@ -46,6 +46,7 @@ export function createMediaFromReferenceInternal(
     mediaReference.reference.mediaSetViewItem;
   const token = mediaReference.reference.mediaSetViewItem.token;
   return {
+    // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
     // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     async fetchContents(): Promise<Response> {
       return MediaSets.read(

--- a/packages/client/src/createMediaFromReference.ts
+++ b/packages/client/src/createMediaFromReference.ts
@@ -46,6 +46,7 @@ export function createMediaFromReferenceInternal(
     mediaReference.reference.mediaSetViewItem;
   const token = mediaReference.reference.mediaSetViewItem.token;
   return {
+    // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     async fetchContents(): Promise<Response> {
       return MediaSets.read(
         client,

--- a/packages/client/src/intellisense.test.ts
+++ b/packages/client/src/intellisense.test.ts
@@ -96,7 +96,7 @@ describe("intellisense", () => {
     await tsServer.sendOpenRequest({ file: intellisenseFilePath });
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     tsServer.stop();
     tsServer = undefined as any;
   });

--- a/packages/client/src/internal/conversions/modernToLegacyWhereClause.test.ts
+++ b/packages/client/src/internal/conversions/modernToLegacyWhereClause.test.ts
@@ -278,7 +278,7 @@ describe(modernToLegacyWhereClause, () => {
 
   describe("single checks", () => {
     describe("$within", () => {
-      it("properly generates bbox shortcut", async () => {
+      it("properly generates bbox shortcut", () => {
         expect(
           modernToLegacyWhereClause<ObjAllProps>(
             {
@@ -312,7 +312,7 @@ describe(modernToLegacyWhereClause, () => {
         `);
       });
 
-      it("properly generates bbox long form", async () => {
+      it("properly generates bbox long form", () => {
         expect(
           modernToLegacyWhereClause<ObjAllProps>(
             {
@@ -348,7 +348,7 @@ describe(modernToLegacyWhereClause, () => {
         `);
       });
 
-      it("properly generates within radius", async () => {
+      it("properly generates within radius", () => {
         expect(
           modernToLegacyWhereClause<ObjAllProps>(
             {
@@ -379,7 +379,7 @@ describe(modernToLegacyWhereClause, () => {
       `);
       });
 
-      it("properly generates within radius of geopoint", async () => {
+      it("properly generates within radius of geopoint", () => {
         // suppose you loaded an object with a geopoint field
         // and you want to find all objects within 5 km of that point
         const pointAsGeoJsonPoint: Point = {
@@ -416,7 +416,7 @@ describe(modernToLegacyWhereClause, () => {
       `);
       });
 
-      it("properly generates within polygon", async () => {
+      it("properly generates within polygon", () => {
         expect(
           modernToLegacyWhereClause<ObjAllProps>(
             {
@@ -461,7 +461,7 @@ describe(modernToLegacyWhereClause, () => {
         `);
       });
 
-      it("properly generates within polygon geojson", async () => {
+      it("properly generates within polygon geojson", () => {
         expect(
           modernToLegacyWhereClause<ObjAllProps>(
             {
@@ -506,7 +506,7 @@ describe(modernToLegacyWhereClause, () => {
           }
         `);
       });
-      it("check types", async () => {
+      it("check types", () => {
         expectType<WhereClause<ObjAllProps>>({
           geoPoint: {
             $within: [-5, 5, -10, 10],
@@ -582,7 +582,7 @@ describe(modernToLegacyWhereClause, () => {
         });
       });
       describe("$intersects", () => {
-        it("properly generates bbox shortcut", async () => {
+        it("properly generates bbox shortcut", () => {
           expect(
             modernToLegacyWhereClause<ObjAllProps>(
               {
@@ -615,7 +615,7 @@ describe(modernToLegacyWhereClause, () => {
         }
       `);
         });
-        it("properly generates bbox long form", async () => {
+        it("properly generates bbox long form", () => {
           expect(
             modernToLegacyWhereClause<ObjAllProps>(
               {
@@ -651,7 +651,7 @@ describe(modernToLegacyWhereClause, () => {
         `);
         });
 
-        it("properly generates intersects polygon", async () => {
+        it("properly generates intersects polygon", () => {
           expect(
             modernToLegacyWhereClause<ObjAllProps>(
               {
@@ -696,7 +696,7 @@ describe(modernToLegacyWhereClause, () => {
           `);
         });
 
-        it("properly generates within polygon geojson", async () => {
+        it("properly generates within polygon geojson", () => {
           expect(
             modernToLegacyWhereClause<ObjAllProps>(
               {

--- a/packages/client/src/object/Cache.ts
+++ b/packages/client/src/object/Cache.ts
@@ -125,6 +125,7 @@ export function createAsyncClientCache<K, V extends {}>(
       return cache.get(client, key);
     },
 
+    // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     get: async function get(client: MinimalClient, key: K) {
       return (
         cache.get(client, key) ??

--- a/packages/client/src/object/Cache.ts
+++ b/packages/client/src/object/Cache.ts
@@ -125,6 +125,7 @@ export function createAsyncClientCache<K, V extends {}>(
       return cache.get(client, key);
     },
 
+    // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
     // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     get: async function get(client: MinimalClient, key: K) {
       return (

--- a/packages/client/src/object/SimpleCache.ts
+++ b/packages/client/src/object/SimpleCache.ts
@@ -106,6 +106,7 @@ export function createSimpleAsyncCache<K, V>(
       return cache.get(key);
     },
 
+    // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
     // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     get: async function get(key: K) {
       return cache.get(key) ?? inProgress.get(key) ?? ret.set(key, fn(key));

--- a/packages/client/src/object/SimpleCache.ts
+++ b/packages/client/src/object/SimpleCache.ts
@@ -106,6 +106,7 @@ export function createSimpleAsyncCache<K, V>(
       return cache.get(key);
     },
 
+    // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     get: async function get(key: K) {
       return cache.get(key) ?? inProgress.get(key) ?? ret.set(key, fn(key));
     },

--- a/packages/client/src/object/aggregate.test.ts
+++ b/packages/client/src/object/aggregate.test.ts
@@ -67,7 +67,7 @@ beforeAll(() => {
   clientCtx = createMinimalClient(
     metadata,
     "https://host.com",
-    async () => "myAccessToken",
+    () => "myAccessToken",
     {},
     mockFetch
   );
@@ -75,7 +75,7 @@ beforeAll(() => {
   client = createClient(
     "https://host.com",
     metadata.ontologyRid,
-    async () => "",
+    () => "",
     undefined,
     mockFetch
   );
@@ -592,7 +592,7 @@ describe("aggregate", () => {
       });
     });
 
-    it("disallows null values with default value", async () => {
+    it("disallows null values with default value", () => {
       void client(Todo).aggregate({
         $select: {
           "text:exactDistinct": "unordered",
@@ -713,7 +713,7 @@ describe("aggregate", () => {
     ).rejects.toThrow("Aggregation request failed");
   });
 
-  it("works with where: todo", async () => {
+  it("works with where: todo", () => {
     const f: AggregateOpts<Employee> = {
       $select: {
         "office:approximateDistinct": "unordered",

--- a/packages/client/src/object/attachment.test.ts
+++ b/packages/client/src/object/attachment.test.ts
@@ -31,7 +31,7 @@ describe("attachments", () => {
   let apiServer: SetupServer;
   let client: Client;
 
-  beforeAll(async () => {
+  beforeAll(() => {
     ({ client, apiServer, fauxFoundry } = startNodeApiServer(
       new LegacyFauxFoundry(),
       createClient

--- a/packages/client/src/object/convertWireToOsdkObjects.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.test.ts
@@ -215,11 +215,11 @@ describe("convertWireToOsdkObjects", () => {
     const clientCtx = createMinimalClient(
       { ontologyRid: $ontologyRid },
       "https://stack.palantir.com",
-      async () => "myAccessToken"
+      () => "myAccessToken"
     );
     createSharedClientContext(
       "https://stack.palantir.com",
-      async () => "myAccessToken",
+      () => "myAccessToken",
       "userAgent"
     );
 
@@ -247,7 +247,7 @@ describe("convertWireToOsdkObjects", () => {
     const clientCtx = createMinimalClient(
       { ontologyRid: $ontologyRid },
       "https://stack.palantir.com",
-      async () => "myAccessToken"
+      () => "myAccessToken"
     );
 
     const objectFromWire = {
@@ -304,7 +304,7 @@ describe("convertWireToOsdkObjects", () => {
     const clientCtx = createMinimalClient(
       { ontologyRid: $ontologyRid },
       "https://stack.palantir.com",
-      async () => "myAccessToken"
+      () => "myAccessToken"
     );
 
     const objectFromWire = {
@@ -362,7 +362,7 @@ describe("convertWireToOsdkObjects", () => {
     const clientCtx = createMinimalClient(
       { ontologyRid: $ontologyRid },
       "https://stack.palantir.com",
-      async () => "myAccessToken"
+      () => "myAccessToken"
     );
 
     const objectFromWire = {
@@ -426,7 +426,7 @@ describe("convertWireToOsdkObjects", () => {
     const clientCtx = createMinimalClient(
       { ontologyRid: $ontologyRid },
       "https://stack.palantir.com",
-      async () => "myAccessToken"
+      () => "myAccessToken"
     );
 
     const objectFromWire = {

--- a/packages/client/src/object/fetchPage.test.ts
+++ b/packages/client/src/object/fetchPage.test.ts
@@ -129,7 +129,7 @@ describe(fetchPage, () => {
   });
 
   it("converts interface objectsets to search properly part 2", () => {
-    const client = createMinimalClient(metadata, "https://foo", async () => "");
+    const client = createMinimalClient(metadata, "https://foo", () => "");
     const objectSet = createObjectSet(Todo, client)
       .where({
         text: "hello",
@@ -158,7 +158,7 @@ describe(fetchPage, () => {
   });
 
   it("converts interface object set for new API correctly", () => {
-    const client = createMinimalClient(metadata, "https://foo", async () => "");
+    const client = createMinimalClient(metadata, "https://foo", () => "");
     const objectSet = createObjectSet(FooInterface, client).where({
       fooSpt: "hello",
     });
@@ -216,7 +216,7 @@ describe(fetchPage, () => {
   });
 
   it("where clause keys correctly typed", () => {
-    const client = createMinimalClient(metadata, "https://foo", async () => "");
+    const client = createMinimalClient(metadata, "https://foo", () => "");
     const objectSet = createObjectSet(Todo, client);
     const objectSetWithSpecialPropertyTypes = createObjectSet(Employee, client);
 
@@ -258,7 +258,7 @@ describe(fetchPage, () => {
   });
 
   it("supports string comparison filters (gt, gte, lt, lte) on string properties", () => {
-    const client = createMinimalClient(metadata, "https://foo", async () => "");
+    const client = createMinimalClient(metadata, "https://foo", () => "");
     const objectSet = createObjectSet(Todo, client);
 
     // String properties should support all comparison operators
@@ -288,7 +288,7 @@ describe(fetchPage, () => {
   });
 
   it("does not expose string comparison filters on non-string properties", () => {
-    const client = createMinimalClient(metadata, "https://foo", async () => "");
+    const client = createMinimalClient(metadata, "https://foo", () => "");
     const objectSetWithSpecialPropertyTypes = createObjectSet(Employee, client);
 
     // geotimeSeriesReference should NOT support string comparison operators

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -481,6 +481,7 @@ export async function fetchPageWithErrorsInternal<
  * @returns
  * @internal
  */
+// oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 export async function fetchPage<
   Q extends ObjectOrInterfaceDefinition,
   L extends PropertyKeys<Q>,
@@ -498,6 +499,7 @@ export async function fetchPage<
 }
 
 /** @internal */
+// oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 export async function fetchPageWithErrors<
   Q extends ObjectOrInterfaceDefinition,
   L extends PropertyKeys<Q>,
@@ -613,6 +615,7 @@ export function remapPropertyNames(
   return propertyNames;
 }
 
+// oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 async function applyFetchArgs<
   Q extends ObjectOrInterfaceDefinition,
   L extends PropertyKeys<Q>,

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -481,6 +481,7 @@ export async function fetchPageWithErrorsInternal<
  * @returns
  * @internal
  */
+// TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
 // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 export async function fetchPage<
   Q extends ObjectOrInterfaceDefinition,
@@ -499,6 +500,7 @@ export async function fetchPage<
 }
 
 /** @internal */
+// TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
 // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 export async function fetchPageWithErrors<
   Q extends ObjectOrInterfaceDefinition,

--- a/packages/client/src/object/geotimeseriesreference.test.ts
+++ b/packages/client/src/object/geotimeseriesreference.test.ts
@@ -51,7 +51,7 @@ describe("Timeseries", () => {
     ],
   };
 
-  beforeAll(async () => {
+  beforeAll(() => {
     const testSetup = startNodeApiServer(new LegacyFauxFoundry(), createClient);
     ({ client } = testSetup);
 

--- a/packages/client/src/object/object.test.ts
+++ b/packages/client/src/object/object.test.ts
@@ -57,7 +57,7 @@ describe.each([
   let client: Client;
   let apiServer: SetupServer;
 
-  beforeAll(async () => {
+  beforeAll(() => {
     ({ client, apiServer } = startNodeApiServer(
       new LegacyFauxFoundry(baseUrl),
       createClient
@@ -205,7 +205,7 @@ describe.each([
         "ri.phonograph2-objects.main.object.88a6fccb-f333-46d6-a07e-7725c5f18b61"
       );
     });
-    it("objects are enumerable in an sdk", async () => {
+    it("objects are enumerable in an sdk", () => {
       const objects = Object.keys($Objects);
       expect(objects.sort()).toStrictEqual(
         [
@@ -251,7 +251,7 @@ describe.each([
       });
     });
 
-    it("clones and updates an object with another osdk object", async () => {
+    it("clones and updates an object with another osdk object", () => {
       const updatedEmployee = createOsdkObject(
         client[additionalContext],
         {
@@ -304,7 +304,7 @@ describe.each([
       });
     });
 
-    it("correctly scopes up with another OSDK object", async () => {
+    it("correctly scopes up with another OSDK object", () => {
       const firstEmployee = { $clone: () => {} } as unknown as Osdk.Instance<
         Employee,
         never,
@@ -315,7 +315,7 @@ describe.each([
       >();
     });
 
-    it("Correctly preserves keys from original and new with distinct property key sets", async () => {
+    it("Correctly preserves keys from original and new with distinct property key sets", () => {
       const firstEmployee = { $clone: () => {} } as unknown as Osdk.Instance<
         Employee,
         never,
@@ -326,7 +326,7 @@ describe.each([
       ).toMatchTypeOf<Osdk.Instance<Employee, never, "class" | "office">>();
     });
 
-    it("clones and updates an object with a record", async () => {
+    it("clones and updates an object with a record", () => {
       const mergedEmployee = employee.$clone({
         class: "Green",
         employeeId: 50031,
@@ -354,7 +354,7 @@ describe.each([
       });
     });
 
-    it("correctly scopes up with a record", async () => {
+    it("correctly scopes up with a record", () => {
       const firstEmployee = { $clone: () => {} } as unknown as Osdk.Instance<
         Employee,
         never,
@@ -377,7 +377,7 @@ describe.each([
       >();
     });
 
-    it("correctly sets title", async () => {
+    it("correctly sets title", () => {
       const mergedEmployee = employee.$clone({
         fullName: "Brad Pitt",
       });
@@ -401,7 +401,7 @@ describe.each([
       });
     });
 
-    it("is able to clone with nothing passed in", async () => {
+    it("is able to clone with nothing passed in", () => {
       expect(employee.$clone()).toMatchObject({
         $apiName: "Employee",
         $objectType: "Employee",
@@ -415,7 +415,7 @@ describe.each([
       });
     });
 
-    it("throws when merging objects with different primary keys", async () => {
+    it("throws when merging objects with different primary keys", () => {
       expect(() =>
         employee.$clone({
           class: "Green",
@@ -886,23 +886,21 @@ describe.each([
   });
 });
 
-export async function shouldError(client: Client): Promise<Osdk<Employee>> {
+export function shouldError(client: Client): Promise<Osdk<Employee>> {
   // @ts-expect-error
   return client(Employee).fetchOne(1, {
     $select: ["employeeId"],
   });
 }
 
-export async function shouldError2(
-  client: Client
-): Promise<Employee.OsdkObject> {
+export function shouldError2(client: Client): Promise<Employee.OsdkObject> {
   // @ts-expect-error
   return client(Employee).fetchOne(1, {
     $select: ["employeeId"],
   });
 }
 
-export async function shouldCompile_client_fetchOne_old_select(
+export function shouldCompile_client_fetchOne_old_select(
   client: Client
 ): Promise<Osdk<Employee, "employeeId">> {
   return client(Employee).fetchOne(1, {
@@ -910,7 +908,7 @@ export async function shouldCompile_client_fetchOne_old_select(
   });
 }
 
-export async function shouldCompile_unstableClient_fetchOne_old_select(
+export function shouldCompile_unstableClient_fetchOne_old_select(
   client: Client
 ): Promise<Osdk<Employee, "employeeId">> {
   return client(Employee).fetchOne(1, {
@@ -918,7 +916,7 @@ export async function shouldCompile_unstableClient_fetchOne_old_select(
   });
 }
 
-export async function shouldCompile_client_fetchOne_new_select(
+export function shouldCompile_client_fetchOne_new_select(
   client: Client
 ): Promise<Employee.OsdkObject<never, "employeeId">> {
   return client(Employee).fetchOne(1, {
@@ -926,7 +924,7 @@ export async function shouldCompile_client_fetchOne_new_select(
   });
 }
 
-export async function shouldCompile_unstableClient_fetchOne_new_select(
+export function shouldCompile_unstableClient_fetchOne_new_select(
   client: Client
 ): Promise<Osdk<Employee, "employeeId">> {
   return client(Employee).fetchOne(1, {
@@ -934,13 +932,13 @@ export async function shouldCompile_unstableClient_fetchOne_new_select(
   });
 }
 
-export async function shouldCompile_client_fetchOne_old_noArgs(
+export function shouldCompile_client_fetchOne_old_noArgs(
   client: Client
 ): Promise<Osdk<Employee>> {
   return client(Employee).fetchOne(1);
 }
 
-export async function shouldCompile_unstableClient_fetchOne_noArgs(
+export function shouldCompile_unstableClient_fetchOne_noArgs(
   client: Client
 ): Promise<Osdk<Employee>> {
   return client(Employee).fetchOne(1);

--- a/packages/client/src/objectSet/InterfaceObjectSet.test.ts
+++ b/packages/client/src/objectSet/InterfaceObjectSet.test.ts
@@ -102,7 +102,7 @@ describe("ObjectSet", () => {
     expect(asEmployee2.fullName).toEqual("Santa Claus");
   });
 
-  it("interface links", async () => {
+  it("interface links", () => {
     const objectSet = client(BarInterface).pivotTo("toFoo");
     expectTypeOf<typeof objectSet>().toEqualTypeOf<
       ObjectSet<FooInterface, never>

--- a/packages/client/src/objectSet/ObjectSetListenerWebsocket.test.ts
+++ b/packages/client/src/objectSet/ObjectSetListenerWebsocket.test.ts
@@ -103,7 +103,7 @@ vi.mock("isomorphic-ws", async (importOriginal) => {
 
 let currentSubscriptionId = 0;
 
-describe("ObjectSetListenerWebsocket", async () => {
+describe("ObjectSetListenerWebsocket", () => {
   let apiServer: SetupServer;
   beforeAll(() => {
     const testSetup = startNodeApiServer(
@@ -142,7 +142,7 @@ describe("ObjectSetListenerWebsocket", async () => {
       minimalClient = createMinimalClient(
         { ontologyRid: $ontologyRid },
         STACK,
-        async () => "myAccessToken",
+        () => "myAccessToken",
         { logger: rootLogger }
       );
       client = new ObjectSetListenerWebsocket(
@@ -220,7 +220,7 @@ describe("ObjectSetListenerWebsocket", async () => {
         expectEqualRemoveAndAddListeners(ws);
       });
 
-      it("only sends a single request", async () => {
+      it("only sends a single request", () => {
         respondSuccessToSubscribe(ws, subReq1);
         // actually this is broken FIXME
         unsubscribe();
@@ -254,7 +254,7 @@ describe("ObjectSetListenerWebsocket", async () => {
           expectEqualRemoveAndAddListeners(ws);
         });
 
-        describe("reconnect", async () => {
+        describe("reconnect", () => {
           beforeEach(async () => {
             [ws] = await Promise.all([
               expectWebSocketConstructed(),
@@ -289,7 +289,7 @@ describe("ObjectSetListenerWebsocket", async () => {
           listener.onSuccessfulSubscription.mockReset();
         });
 
-        it("should call onError", async () => {
+        it("should call onError", () => {
           expect(listener.onError).toHaveBeenCalled();
           expect(listener.onError.mock.calls[0][0].subscriptionClosed).toBe(
             false
@@ -362,7 +362,7 @@ describe("ObjectSetListenerWebsocket", async () => {
           `);
         });
 
-        describe("additional subscription", async () => {
+        describe("additional subscription", () => {
           let unsubscribe2: () => void;
           let subReq2: ObjectSetStreamSubscribeRequests;
           beforeEach(async () => {
@@ -404,7 +404,7 @@ describe("ObjectSetListenerWebsocket", async () => {
             expectEqualRemoveAndAddListeners(ws);
           });
 
-          describe("reconnect, resubscribe successfully", async () => {
+          describe("reconnect, resubscribe successfully", () => {
             beforeEach(async () => {
               [ws] = await Promise.all([
                 expectWebSocketConstructed(),
@@ -452,7 +452,7 @@ describe("ObjectSetListenerWebsocket", async () => {
         minimalClient = createMinimalClient(
           { ontologyRid: $ontologyRid },
           STACK,
-          async () => "myAccessToken",
+          () => "myAccessToken",
           { logger: rootLogger }
         );
         client = new ObjectSetListenerWebsocket(
@@ -520,7 +520,7 @@ describe("ObjectSetListenerWebsocket", async () => {
   });
 
   describe("types", () => {
-    it("does not return rid on object type if requested and object has a GTSR", async () => {
+    it("does not return rid on object type if requested and object has a GTSR", () => {
       const client: Client = ((a: any) => ({
         subscribe: (a: any, b: any) => {},
       })) as Client;
@@ -538,7 +538,7 @@ describe("ObjectSetListenerWebsocket", async () => {
       );
     });
 
-    it("does not return rid on object type if not requested", async () => {
+    it("does not return rid on object type if not requested", () => {
       const client: Client = ((a: any) => ({
         subscribe: (a: any, b: any) => {},
       })) as Client;
@@ -551,7 +551,7 @@ describe("ObjectSetListenerWebsocket", async () => {
       });
     });
 
-    it("does return rid on object type if requested and object does not have a GTSR", async () => {
+    it("does return rid on object type if requested and object does not have a GTSR", () => {
       const client: Client = ((a: any) => ({
         subscribe: (a: any, b: any) => {},
       })) as Client;

--- a/packages/client/src/observable/internal/BulkObjectLoader.test.ts
+++ b/packages/client/src/observable/internal/BulkObjectLoader.test.ts
@@ -32,7 +32,7 @@ describe(BulkObjectLoader, () => {
   let client: Mock<Client> & Client;
   let mockClient: MockClientHelper;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     mockClient = createClientMockHelper();
     client = mockClient.client;
 

--- a/packages/client/src/observable/internal/ObservableClientImpl.ts
+++ b/packages/client/src/observable/internal/ObservableClientImpl.ts
@@ -404,6 +404,7 @@ export class ObservableClientImpl implements ObservableClient {
     );
   }
 
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   public async getCacheSnapshot(): Promise<CacheSnapshot> {
     return this.__experimentalStore.getCacheSnapshot();
   }

--- a/packages/client/src/observable/internal/Store.invalidation.test.ts
+++ b/packages/client/src/observable/internal/Store.invalidation.test.ts
@@ -122,7 +122,7 @@ describe("Store Invalidation Type Isolation", () => {
     // Note: There are no direct Todo-Employee links in the test ontology
   }
 
-  beforeAll(async () => {
+  beforeAll(() => {
     // Set up the mock environment and client
     const testSetup = startNodeApiServer(
       new FauxFoundry("https://stack.palantir.com/"),

--- a/packages/client/src/observable/internal/Store.test.ts
+++ b/packages/client/src/observable/internal/Store.test.ts
@@ -211,7 +211,7 @@ describe(Store, () => {
     let cache: Store;
     let fauxFoundry: FauxFoundry;
 
-    beforeAll(async () => {
+    beforeAll(() => {
       // Set up the mock environment and client
       const testSetup = startNodeApiServer(
         new FauxFoundry("https://stack.palantir.com/"),
@@ -877,7 +877,7 @@ describe(Store, () => {
       };
     });
 
-    it("basic single object works", async () => {
+    it("basic single object works", () => {
       const emp = employeesAsServerReturns[0];
 
       const cacheKey = cacheKeys.get<ObjectCacheKey>(
@@ -906,7 +906,7 @@ describe(Store, () => {
     });
 
     describe("optimistic updates", () => {
-      it("rolls back objects", async () => {
+      it("rolls back objects", () => {
         const emp = employeesAsServerReturns[0];
         updateObject(cache, emp); // pre-seed the cache with the "real" value
 
@@ -1040,7 +1040,7 @@ describe(Store, () => {
         });
       });
 
-      it("rolls back to an updated real value via list", async () => {
+      it("rolls back to an updated real value via list", () => {
         const emp = employeesAsServerReturns[0];
         updateObject(cache, emp); // pre-seed the cache with the "real" value
 
@@ -1450,7 +1450,7 @@ describe(Store, () => {
       const subFn1 = mockSingleSubCallback();
       const subFn2 = mockSingleSubCallback();
 
-      beforeEach(async () => {
+      beforeEach(() => {
         subFn1.complete.mockClear();
         subFn1.next.mockClear();
         subFn1.error.mockClear();
@@ -1636,7 +1636,7 @@ describe(Store, () => {
         expectSingleObjectCallAndClear(subFn, undefined!, "init");
       });
 
-      it("does basic observation and unsubscribe", async () => {
+      it("does basic observation and unsubscribe", () => {
         const emp = employeesAsServerReturns.find(
           (x) => x.$primaryKey === JOHN_DOE_ID
         )!;
@@ -1659,7 +1659,7 @@ describe(Store, () => {
         expect(subFn.next).not.toHaveBeenCalled();
       });
 
-      it("observes with list update", async () => {
+      it("observes with list update", () => {
         const emp = employeesAsServerReturns.find(
           (x) => x.$primaryKey === JOHN_DOE_ID
         )!;
@@ -2120,7 +2120,7 @@ describe(Store, () => {
     let fauxFoundry: FauxFoundry;
     let store: Store;
 
-    beforeAll(async () => {
+    beforeAll(() => {
       const testSetup = startNodeApiServer(
         new FauxFoundry("https://stack.palantir.com/", undefined, { logger }),
         createClient,
@@ -2139,7 +2139,7 @@ describe(Store, () => {
       apiServer.resetHandlers();
     });
 
-    beforeEach(async () => {
+    beforeEach(() => {
       store = new Store(client);
     });
 
@@ -2356,7 +2356,7 @@ describe(Store, () => {
       });
     });
 
-    describe("orderBy", async () => {
+    describe("orderBy", () => {
       let nextPk = 0;
 
       let fauxObjectA: Osdk.Instance<Todo>;

--- a/packages/client/src/observable/internal/Store.ts
+++ b/packages/client/src/observable/internal/Store.ts
@@ -672,6 +672,7 @@ export class Store {
     return Promise.allSettled(promises).then(() => void 0);
   }
 
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   public async invalidateAll(): Promise<void> {
     const promises: Array<Promise<unknown>> = [];
     for (const cacheKey of this.queries.keys()) {
@@ -684,6 +685,7 @@ export class Store {
     return Promise.allSettled(promises).then(() => void 0);
   }
 
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   public async invalidateObjects(
     objects:
       | Osdk.Instance<ObjectOrInterfaceDefinition>
@@ -700,6 +702,7 @@ export class Store {
     return Promise.allSettled(promises).then(() => void 0);
   }
 
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   public async invalidateFunction(
     apiName: string | QueryDefinition<unknown>,
     params?: Record<string, unknown>
@@ -707,6 +710,7 @@ export class Store {
     return this.functions.invalidateFunction(apiName, params);
   }
 
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   public async invalidateFunctionsByObject(
     apiName: string,
     primaryKey: string | number

--- a/packages/client/src/observable/internal/Store.ts
+++ b/packages/client/src/observable/internal/Store.ts
@@ -672,6 +672,7 @@ export class Store {
     return Promise.allSettled(promises).then(() => void 0);
   }
 
+  // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
   // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   public async invalidateAll(): Promise<void> {
     const promises: Array<Promise<unknown>> = [];
@@ -685,6 +686,7 @@ export class Store {
     return Promise.allSettled(promises).then(() => void 0);
   }
 
+  // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
   // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   public async invalidateObjects(
     objects:
@@ -702,6 +704,7 @@ export class Store {
     return Promise.allSettled(promises).then(() => void 0);
   }
 
+  // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
   // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   public async invalidateFunction(
     apiName: string | QueryDefinition<unknown>,
@@ -710,6 +713,7 @@ export class Store {
     return this.functions.invalidateFunction(apiName, params);
   }
 
+  // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
   // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   public async invalidateFunctionsByObject(
     apiName: string,

--- a/packages/client/src/observable/internal/links/SpecificLinkQuery.ts
+++ b/packages/client/src/observable/internal/links/SpecificLinkQuery.ts
@@ -330,6 +330,7 @@ export class SpecificLinkQuery extends BaseListQuery<
   /**
    * Implements Query.maybeUpdateAndRevalidate to handle cache invalidation
    */
+  // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
   // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   maybeUpdateAndRevalidate = async (
     changes: Changes,

--- a/packages/client/src/observable/internal/links/SpecificLinkQuery.ts
+++ b/packages/client/src/observable/internal/links/SpecificLinkQuery.ts
@@ -330,6 +330,7 @@ export class SpecificLinkQuery extends BaseListQuery<
   /**
    * Implements Query.maybeUpdateAndRevalidate to handle cache invalidation
    */
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   maybeUpdateAndRevalidate = async (
     changes: Changes,
     _optimisticId: OptimisticId | undefined

--- a/packages/client/src/observable/internal/list/InterfaceListQuery.ts
+++ b/packages/client/src/observable/internal/list/InterfaceListQuery.ts
@@ -111,6 +111,7 @@ export class InterfaceListQuery extends ListQuery {
     }
   }
 
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   protected async postProcessFetchedData(
     data: Osdk.Instance<any>[]
   ): Promise<Osdk.Instance<any>[]> {

--- a/packages/client/src/observable/internal/list/InterfaceListQuery.ts
+++ b/packages/client/src/observable/internal/list/InterfaceListQuery.ts
@@ -111,6 +111,7 @@ export class InterfaceListQuery extends ListQuery {
     }
   }
 
+  // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
   // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   protected async postProcessFetchedData(
     data: Osdk.Instance<any>[]

--- a/packages/client/src/observable/internal/list/ListQuery.ts
+++ b/packages/client/src/observable/internal/list/ListQuery.ts
@@ -389,6 +389,7 @@ export abstract class ListQuery extends BaseListQuery<
    * Subclasses override to add type-specific logic (e.g. interface
    * implementation checks).
    */
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   async revalidateObjectType(objectType: string): Promise<boolean> {
     return (
       this.apiName === objectType ||

--- a/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
@@ -496,6 +496,7 @@ export class ObjectSetQuery extends BaseListQuery<
     );
   }
 
+  // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
   // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   invalidateObjectType = async (
     objectType: string,

--- a/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
@@ -496,6 +496,7 @@ export class ObjectSetQuery extends BaseListQuery<
     );
   }
 
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   invalidateObjectType = async (
     objectType: string,
     changes: Changes | undefined

--- a/packages/client/src/ontology/StandardOntologyProvider.ts
+++ b/packages/client/src/ontology/StandardOntologyProvider.ts
@@ -71,6 +71,7 @@ export const createStandardOntologyProviderFactory: (
       return deepFreeze(await loadInterfaceMetadata(client, key));
     }
 
+    // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     async function loadQuery(client: MinimalClient, key: string) {
       return loadQueryMetadata(client, key);
     }

--- a/packages/client/src/ontology/StandardOntologyProvider.ts
+++ b/packages/client/src/ontology/StandardOntologyProvider.ts
@@ -71,6 +71,7 @@ export const createStandardOntologyProviderFactory: (
       return deepFreeze(await loadInterfaceMetadata(client, key));
     }
 
+    // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
     // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     async function loadQuery(client: MinimalClient, key: string) {
       return loadQueryMetadata(client, key);

--- a/packages/client/src/public-utils/hydrateAttachmentFromRid.ts
+++ b/packages/client/src/public-utils/hydrateAttachmentFromRid.ts
@@ -40,6 +40,7 @@ export function hydrateAttachmentFromRidInternal(
 ): Attachment {
   return {
     rid,
+    // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     async fetchContents() {
       return Attachments.read(client, rid);
     },

--- a/packages/client/src/public-utils/hydrateAttachmentFromRid.ts
+++ b/packages/client/src/public-utils/hydrateAttachmentFromRid.ts
@@ -40,6 +40,7 @@ export function hydrateAttachmentFromRidInternal(
 ): Attachment {
   return {
     rid,
+    // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
     // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     async fetchContents() {
       return Attachments.read(client, rid);

--- a/packages/client/src/queries/queries.test.ts
+++ b/packages/client/src/queries/queries.test.ts
@@ -465,7 +465,7 @@ describe("queries", () => {
 
     expectTypeOf<ObjectSet<Employee>>().toMatchTypeOf<typeof result>();
   });
-  it("queries are enumerable", async () => {
+  it("queries are enumerable", () => {
     const queries = Object.keys($Queries);
     expect(queries).toStrictEqual([
       "acceptsThreeDimensionalAggregationFunction",
@@ -581,8 +581,8 @@ describe("queries", () => {
       };
 
       const mockMedia: Media = {
-        fetchContents: async () => new Response(),
-        fetchMetadata: async () => ({
+        fetchContents: () => new Response(),
+        fetchMetadata: () => ({
           path: "/test.png",
           sizeBytes: 1000,
           mediaType: "image/png",

--- a/packages/client/src/scenarios/ScenarioClient.test.ts
+++ b/packages/client/src/scenarios/ScenarioClient.test.ts
@@ -39,7 +39,7 @@ describe("ScenarioClient methods", () => {
     client = createClient(
       "https://mock.com",
       ontologyRid,
-      async () => "Token",
+      () => "Token",
       undefined,
       fetchFunction
     );

--- a/packages/client/src/scenarios/createScenario.test.ts
+++ b/packages/client/src/scenarios/createScenario.test.ts
@@ -38,7 +38,7 @@ describe("createScenario", () => {
     client = createClient(
       "https://mock.com",
       ontologyRid,
-      async () => "Token",
+      () => "Token",
       undefined,
       fetchFunction
     );
@@ -82,7 +82,7 @@ describe("createScenario", () => {
       async () => {},
       "https://mock.com",
       ontologyRid,
-      async () => "Token",
+      () => "Token",
       {},
       fetchFunction
     );

--- a/packages/client/src/scenarios/withScenario.test.ts
+++ b/packages/client/src/scenarios/withScenario.test.ts
@@ -34,7 +34,7 @@ describe("withScenario", () => {
     client = createClient(
       "https://mock.com",
       ontologyRid,
-      async () => "Token",
+      () => "Token",
       undefined,
       fetchFunction
     );
@@ -75,7 +75,7 @@ describe("withScenario", () => {
       async () => {},
       "https://mock.com",
       ontologyRid,
-      async () => "Token",
+      () => "Token",
       {},
       fetchFunction
     );

--- a/packages/client/src/util/mockCaptureClient.ts
+++ b/packages/client/src/util/mockCaptureClient.ts
@@ -41,6 +41,7 @@ export function createMockCaptureClient(
   const client = createMinimalClient(
     metadata,
     "https://foo",
+    // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     async () => "",
     {},
     fetchFn

--- a/packages/client/src/util/toDataValue.test.ts
+++ b/packages/client/src/util/toDataValue.test.ts
@@ -230,7 +230,7 @@ describe(toDataValue, () => {
     expect(converted).toMatch(/ri\.attachments.main.attachment\.[a-z0-9\-]+/iu);
   });
 
-  it("converts media uploads correctly", async () => {
+  it("converts media uploads correctly", () => {
     const file: MediaUpload = {
       data: new Blob([JSON.stringify({ name: "Hello World" }, null, 2)], {
         type: "application/json",
@@ -303,11 +303,11 @@ describe(toDataValue, () => {
     };
 
     const mockMedia: Media = {
-      fetchMetadata: async () => ({
+      fetchMetadata: () => ({
         sizeBytes: 1024,
         mediaType: "image/png",
       }),
-      fetchContents: async () => new Response(),
+      fetchContents: () => new Response(),
       getMediaReference: () => expectedMediaReference,
     };
 

--- a/packages/create-app/src/prompts/promptCorsProxy.ts
+++ b/packages/create-app/src/prompts/promptCorsProxy.ts
@@ -17,6 +17,7 @@
 import { consola } from "../consola.js";
 import { italic } from "../highlight.js";
 
+// oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 export async function promptCorsProxy({
   corsProxy,
 }: {

--- a/packages/create-app/src/prompts/promptCorsProxy.ts
+++ b/packages/create-app/src/prompts/promptCorsProxy.ts
@@ -17,6 +17,7 @@
 import { consola } from "../consola.js";
 import { italic } from "../highlight.js";
 
+// TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
 // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 export async function promptCorsProxy({
   corsProxy,

--- a/packages/e2e.generated.1.1.x/tsup.mjs
+++ b/packages/e2e.generated.1.1.x/tsup.mjs
@@ -53,7 +53,7 @@ export default async function makeTsupOptions(options, ourOptions) {
     splitting: true,
     shims: true, // so we can use __dirname in both esm and cjs
     minify: false, // !options.watch,
-    onSuccess: async () => {
+    onSuccess: () => {
       // eslint-disable-next-line no-console
       console.log("👍");
     },

--- a/packages/e2e.sandbox.catchall/src/client.ts
+++ b/packages/e2e.sandbox.catchall/src/client.ts
@@ -29,6 +29,7 @@ invariant(process.env.SECONDARY_FOUNDRY_USER_TOKEN !== undefined);
 export const client: Client = createClient(
   process.env.FOUNDRY_STACK,
   "ri.ontology.main.ontology.00000000-0000-0000-0000-000000000000",
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   async () => process.env.FOUNDRY_USER_TOKEN!,
   { logger },
   loggingFetch
@@ -37,6 +38,7 @@ export const client: Client = createClient(
 export const dsClient: Client = createClient(
   process.env.SECONDARY_FOUNDRY_STACK,
   "ri.ontology.main.ontology.6ae2b235-997d-4b5e-9611-85fa88742697",
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   async () => process.env.SECONDARY_FOUNDRY_USER_TOKEN!,
   { logger },
   loggingFetch
@@ -45,6 +47,7 @@ export const dsClient: Client = createClient(
 export const dsmtClient: Client = createClient(
   process.env.SECONDARY_FOUNDRY_STACK,
   "ri.ontology.main.ontology.7ab4d20d-b742-4f58-b795-55695e862bc7",
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   async () => process.env.SECONDARY_FOUNDRY_USER_TOKEN!,
   { logger },
   loggingFetch
@@ -53,6 +56,7 @@ export const dsmtClient: Client = createClient(
 export const z2vClient: Client = createClient(
   process.env.FOUNDRY_STACK,
   "ri.ontology.main.ontology.8fca0141-468f-4910-9949-8d9b6d9939b2",
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   async () => process.env.FOUNDRY_USER_TOKEN!,
   { logger },
   loggingFetch
@@ -61,6 +65,7 @@ export const z2vClient: Client = createClient(
 export const ontologyClient: Client = createClient(
   process.env.FOUNDRY_STACK,
   "ri.ontology.main.ontology.273dd4a1-84fa-4401-88df-d08bb2f3f397",
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   async () => process.env.FOUNDRY_USER_TOKEN!,
   { logger },
   loggingFetch
@@ -69,6 +74,7 @@ export const ontologyClient: Client = createClient(
 export const mjClient: Client = createClient(
   process.env.TERTIARY_FOUNDRY_STACK ?? "",
   "ri.ontology.main.ontology.2050a743-3d09-4fdc-b0ba-6377bebe3709",
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   async () => process.env.TERTIARY_FOUNDRY_USER_TOKEN ?? "",
   { logger },
   loggingFetch
@@ -77,6 +83,7 @@ export const mjClient: Client = createClient(
 export const cipherTextOntologyClient: Client = createClient(
   process.env.FOUNDRY_STACK,
   "ri.ontology.main.ontology.a35bb7f9-2c57-4199-a1cd-af461d88bd6e",
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   async () => process.env.FOUNDRY_USER_TOKEN!,
   { logger },
   loggingFetch
@@ -88,5 +95,6 @@ export const cipherTextOntologyClient: Client = createClient(
  */
 export const platformClient: PlatformClient = createPlatformClient(
   process.env.FOUNDRY_STACK,
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   async () => process.env.FOUNDRY_USER_TOKEN!
 );

--- a/packages/e2e.sandbox.catchall/src/run2DArrayParamQueryTest.ts
+++ b/packages/e2e.sandbox.catchall/src/run2DArrayParamQueryTest.ts
@@ -26,6 +26,7 @@ const client = createClient(
   process.env.FOUNDRY_STACK!,
   // Dev Opi Test Ontology
   "ri.ontology.main.ontology.698267cc-6b48-4d98-beff-29beb24e9361",
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   async () => process.env.FOUNDRY_USER_TOKEN!,
   { logger },
   loggingFetch

--- a/packages/e2e.sandbox.peopleapp/src/app/employees/EmployeesTable.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/employees/EmployeesTable.tsx
@@ -43,6 +43,7 @@ const columnDefinitions: Array<
       id: "fullName",
     },
     columnName: "My Name",
+    // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     validateEdit: async (value: unknown) => {
       if (typeof value !== "string" || !value.trim()) {
         return "Name cannot be empty";
@@ -177,6 +178,7 @@ function ThemeToggle(): React.ReactElement {
 }
 
 export function EmployeesTable(): React.ReactElement {
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   const handleSubmitEdits = useCallback(async () => {
     alert(`Submitting edits...`);
     return true;

--- a/packages/e2e.sandbox.peopleapp/src/app/form/page.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/form/page.tsx
@@ -210,6 +210,7 @@ export function FormPage() {
   >(undefined);
 
   const handleSubmit = useCallback(
+    // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     async (formState: Record<string, unknown>) => {
       setSubmittedState(formState);
     },

--- a/packages/foundry-config-json/src/autoVersion.ts
+++ b/packages/foundry-config-json/src/autoVersion.ts
@@ -39,6 +39,7 @@ export class AutoVersionError extends Error {
  * @returns A promise that resolves to the version string.
  * @throws An error if the version string is not SemVer compliant or if the version cannot be determined.
  */
+// TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
 // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 export async function autoVersion(config: AutoVersionConfig): Promise<string> {
   switch (config.type) {

--- a/packages/foundry-config-json/src/autoVersion.ts
+++ b/packages/foundry-config-json/src/autoVersion.ts
@@ -39,6 +39,7 @@ export class AutoVersionError extends Error {
  * @returns A promise that resolves to the version string.
  * @throws An error if the version string is not SemVer compliant or if the version cannot be determined.
  */
+// oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 export async function autoVersion(config: AutoVersionConfig): Promise<string> {
   switch (config.type) {
     case "git-describe":

--- a/packages/functions/src/transactions/createWriteableClient.test.ts
+++ b/packages/functions/src/transactions/createWriteableClient.test.ts
@@ -47,7 +47,7 @@ describe("createWriteableClient", () => {
 
     mockedRequestHandler = vi.fn<
       Parameters<typeof MockOntologiesV2.OntologyTransactions.postEdits>[1]
-    >(async () => ({ status: 200, body: {} }));
+    >(() => ({ status: 200, body: {} }));
     apiServer.use(
       MockOntologiesV2.OntologyTransactions.postEdits(
         baseUrl,

--- a/packages/functions/src/transactions/createWriteableClient.ts
+++ b/packages/functions/src/transactions/createWriteableClient.ts
@@ -124,6 +124,7 @@ export function createWriteableClient<X extends AnyEdit = never>(
       },
     },
     create: {
+      // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
       // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
       async value<OTD extends CreatableObjectOrInterfaceTypes<X>>(
         obj: OTD,

--- a/packages/functions/src/transactions/createWriteableClient.ts
+++ b/packages/functions/src/transactions/createWriteableClient.ts
@@ -124,6 +124,7 @@ export function createWriteableClient<X extends AnyEdit = never>(
       },
     },
     create: {
+      // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
       async value<OTD extends CreatableObjectOrInterfaceTypes<X>>(
         obj: OTD,
         properties: CreatableObjectOrInterfaceTypeProperties<X, OTD>

--- a/packages/language-models/src/utils.test.ts
+++ b/packages/language-models/src/utils.test.ts
@@ -30,6 +30,7 @@ function createMockClient(overrides?: Partial<PlatformClient>): PlatformClient {
   return {
     baseUrl: "https://example.palantirfoundry.com",
     fetch: vi.fn(),
+    // oxlint-disable-next-line require-await -- intentionally async: assigned to a Promise-returning callback/mock type; no await needed
     tokenProvider: async () => "test-token-abc",
     ...overrides,
   } as PlatformClient;
@@ -47,6 +48,7 @@ describe("createFetch", () => {
 describe("getFoundryToken", () => {
   it("returns the token from the client's token provider", async () => {
     const client = createMockClient({
+      // oxlint-disable-next-line require-await -- intentionally async: assigned to a Promise-returning callback/mock type; no await needed
       tokenProvider: async () => "my-foundry-token",
     });
 
@@ -121,6 +123,7 @@ describe("accepts an OSDK Client (context nested under symbolClientContext)", ()
     const client = createClient(
       "https://example.palantirfoundry.com/",
       "ri.a.b.ontology",
+      // oxlint-disable-next-line require-await -- intentionally async: assigned to a Promise-returning callback/mock type; no await needed
       async () => "nested-token",
       {},
       mockFetch

--- a/packages/language-models/src/utils.ts
+++ b/packages/language-models/src/utils.ts
@@ -67,6 +67,7 @@ export function createFetch(
  * const token = await getFoundryToken(platformClient);
  * ```
  */
+// TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
 // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 export async function getFoundryToken(
   client: Client | PlatformClient

--- a/packages/language-models/src/utils.ts
+++ b/packages/language-models/src/utils.ts
@@ -67,6 +67,7 @@ export function createFetch(
  * const token = await getFoundryToken(platformClient);
  * ```
  */
+// oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 export async function getFoundryToken(
   client: Client | PlatformClient
 ): Promise<string> {

--- a/packages/maker-experimental/src/cli/generateBackingDataset.ts
+++ b/packages/maker-experimental/src/cli/generateBackingDataset.ts
@@ -369,6 +369,7 @@ async function generateBackingDatasetBlock(
 /**
  * Generate a backing datasource BlockGeneratorResult for an object type.
  */
+// oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 export async function generateBackingDatasetBlockResult(
   objectTypeBlockData: ObjectTypeBlockDataV2,
   buildDir: string,
@@ -395,6 +396,7 @@ export async function generateBackingDatasetBlockResult(
 /**
  * Generate a backing datasource BlockGeneratorResult for a many-to-many link type.
  */
+// oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 export async function generateBackingDatasetBlockResultForLink(
   linkTypeBlockData: LinkTypeBlockDataV2,
   linkApiName: string,

--- a/packages/maker-experimental/src/cli/generateBackingDataset.ts
+++ b/packages/maker-experimental/src/cli/generateBackingDataset.ts
@@ -369,6 +369,7 @@ async function generateBackingDatasetBlock(
 /**
  * Generate a backing datasource BlockGeneratorResult for an object type.
  */
+// TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
 // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 export async function generateBackingDatasetBlockResult(
   objectTypeBlockData: ObjectTypeBlockDataV2,
@@ -396,6 +397,7 @@ export async function generateBackingDatasetBlockResult(
 /**
  * Generate a backing datasource BlockGeneratorResult for a many-to-many link type.
  */
+// TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
 // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 export async function generateBackingDatasetBlockResultForLink(
   linkTypeBlockData: LinkTypeBlockDataV2,

--- a/packages/oauth/src/__tests__/createPublicOauthClient.test.ts
+++ b/packages/oauth/src/__tests__/createPublicOauthClient.test.ts
@@ -43,7 +43,7 @@ type ProcessedPublicOauthClientOptionsReturn = ReturnType<
 >;
 
 describe("createPublicOauthClient", () => {
-  it("should return the same processed options for both client creation methods", async () => {
+  it("should return the same processed options for both client creation methods", () => {
     const mockProcessOptionsAndAssignDefaults =
       vi.fn<
         (

--- a/packages/oauth/src/createAuthlessClient.ts
+++ b/packages/oauth/src/createAuthlessClient.ts
@@ -20,6 +20,7 @@
  * @returns A token provider function that returns a Promise resolving to a public token
  */
 export function createAuthlessClient(): () => Promise<string> {
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   return async () => {
     return "PUBLIC";
   };

--- a/packages/react-components-storybook/.storybook/main.ts
+++ b/packages/react-components-storybook/.storybook/main.ts
@@ -49,6 +49,7 @@ const config: StorybookConfig = {
   // it does not override an explicit empty tags array.
   // MDX files are skipped because wrapping their index entries breaks
   // attached-docs sidebar placement in Storybook 10.
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   experimental_indexers: async (existingIndexers) =>
     (existingIndexers ?? []).map((indexer) => ({
       ...indexer,
@@ -62,6 +63,7 @@ const config: StorybookConfig = {
         );
       },
     })),
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   async viteFinal(config) {
     // Set base path for GitHub Pages deployment. PR previews are published
     // under /storybook/pr-<number>/, so CI can override the default path.

--- a/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
@@ -1002,6 +1002,7 @@ const customValidateFormContent: ReadonlyArray<FormContentItem> = [
     fieldComponent: "TEXT_INPUT",
     label: "Email",
     isRequired: true,
+    // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     validate: async (value: unknown) => {
       if (typeof value !== "string" || value.length === 0) {
         return undefined;

--- a/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.stories.tsx
@@ -1960,6 +1960,7 @@ export const EditableWithValidation: Story = {
       {
         locator: { type: "property", id: "fullName" },
         editable: true,
+        // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
         validateEdit: async (value: unknown) => {
           const str = String(value ?? "");
           return str.trim().length >= 2
@@ -1970,6 +1971,7 @@ export const EditableWithValidation: Story = {
       {
         locator: { type: "property", id: "emailPrimaryWork" },
         editable: true,
+        // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
         validateEdit: async (value: unknown) => {
           const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/u;
           return emailRegex.test(String(value ?? ""))
@@ -1980,6 +1982,7 @@ export const EditableWithValidation: Story = {
       {
         locator: { type: "property", id: "employeeNumber" },
         editable: true,
+        // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
         validateEdit: async (value: unknown) => {
           return Number(value) > 0
             ? undefined
@@ -2004,6 +2007,7 @@ export const EditableWithValidation: Story = {
             placeholder: "Search job titles…",
           }),
         },
+        // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
         validateEdit: async (value: unknown) => {
           return value ? undefined : "Job title is required";
         },
@@ -2036,6 +2040,7 @@ export const EditableWithValidation: Story = {
             placeholder: "Select date...",
           }),
         },
+        // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
         validateEdit: async (value: unknown) => {
           if (!value || isNaN(Date.parse(value as string))) {
             return "Please enter a valid date";
@@ -2052,6 +2057,7 @@ export const EditableWithValidation: Story = {
     ],
     editMode: "always",
     onSubmitEdits: fn(
+      // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
       async (edits: CellEditInfo<Osdk.Instance<Employee>>[]) => {
         return true;
       }

--- a/packages/react-components/scripts/build-css.mjs
+++ b/packages/react-components/scripts/build-css.mjs
@@ -32,6 +32,7 @@ const srcDir = path.join(__dirname, "..", "src");
 async function findCssModules(dir) {
   const entries = await fs.readdir(dir, { withFileTypes: true });
   const files = await Promise.all(
+    // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     entries.map(async (entry) => {
       const fullPath = path.join(dir, entry.name);
       if (entry.isDirectory()) {
@@ -48,6 +49,7 @@ async function findCssModules(dir) {
 async function findJsFiles(dir) {
   const entries = await fs.readdir(dir, { withFileTypes: true });
   const files = await Promise.all(
+    // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     entries.map(async (entry) => {
       const fullPath = path.join(dir, entry.name);
       if (entry.isDirectory()) {

--- a/packages/react-components/scripts/build-css.mjs
+++ b/packages/react-components/scripts/build-css.mjs
@@ -32,6 +32,7 @@ const srcDir = path.join(__dirname, "..", "src");
 async function findCssModules(dir) {
   const entries = await fs.readdir(dir, { withFileTypes: true });
   const files = await Promise.all(
+    // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
     // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     entries.map(async (entry) => {
       const fullPath = path.join(dir, entry.name);
@@ -49,6 +50,7 @@ async function findCssModules(dir) {
 async function findJsFiles(dir) {
   const entries = await fs.readdir(dir, { withFileTypes: true });
   const files = await Promise.all(
+    // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
     // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     entries.map(async (entry) => {
       const fullPath = path.join(dir, entry.name);

--- a/packages/react-components/src/aip-agent-chat/__tests__/BaseAipAgentChat.test.tsx
+++ b/packages/react-components/src/aip-agent-chat/__tests__/BaseAipAgentChat.test.tsx
@@ -115,7 +115,7 @@ describe("BaseAipAgentChat", () => {
     expect(sendButton.matches(":disabled")).toBe(false);
   });
 
-  it("calls onSendMessage when Send button is clicked", async () => {
+  it("calls onSendMessage when Send button is clicked", () => {
     const onSendMessage = vi.fn(() => Promise.resolve());
 
     render(

--- a/packages/react-components/src/base-components/select/__tests__/Select.test.tsx
+++ b/packages/react-components/src/base-components/select/__tests__/Select.test.tsx
@@ -35,7 +35,7 @@ describe("Select", () => {
   afterEach(cleanup);
 
   describe("object values with isItemEqualToValue", () => {
-    it("selects an item using structural equality via isItemEqualToValue", async () => {
+    it("selects an item using structural equality via isItemEqualToValue", () => {
       const onValueChange = vi.fn();
       // Value is structurally equal but referentially different from USERS[0]
       const selectedValue: User = { id: 1, name: "Alice" };

--- a/packages/react-components/src/images/tiff-renderer/__tests__/TiffRenderer.test.tsx
+++ b/packages/react-components/src/images/tiff-renderer/__tests__/TiffRenderer.test.tsx
@@ -49,7 +49,7 @@ describe("TiffRenderer", () => {
 
     const content = new Uint8Array(100);
     let container: HTMLElement;
-    await act(async () => {
+    await act(() => {
       ({ container } = render(<TiffRenderer content={content} />));
     });
 
@@ -62,7 +62,7 @@ describe("TiffRenderer", () => {
   it("should show error when TIFF exceeds max size", async () => {
     const largeContent = new Uint8Array(26_000_000);
 
-    await act(async () => {
+    await act(() => {
       render(<TiffRenderer content={largeContent} />);
     });
 
@@ -76,7 +76,7 @@ describe("TiffRenderer", () => {
 
     const onError = vi.fn();
     const content = new Uint8Array(100);
-    await act(async () => {
+    await act(() => {
       render(<TiffRenderer content={content} onError={onError} />);
     });
 
@@ -88,7 +88,7 @@ describe("TiffRenderer", () => {
 
     const onError = vi.fn();
     const content = new Uint8Array(100);
-    await act(async () => {
+    await act(() => {
       render(<TiffRenderer content={content} onError={onError} />);
     });
 
@@ -107,7 +107,7 @@ describe("TiffRenderer", () => {
 
     const onError = vi.fn();
     const content = new Uint8Array(100);
-    await act(async () => {
+    await act(() => {
       render(<TiffRenderer content={content} onError={onError} />);
     });
 
@@ -118,7 +118,7 @@ describe("TiffRenderer", () => {
     const largeContent = new Uint8Array(26_000_000);
     const onError = vi.fn();
 
-    await act(async () => {
+    await act(() => {
       render(<TiffRenderer content={largeContent} onError={onError} />);
     });
 

--- a/packages/react-components/src/markdown-renderer/MarkdownViewerMedia.tsx
+++ b/packages/react-components/src/markdown-renderer/MarkdownViewerMedia.tsx
@@ -33,6 +33,7 @@ export interface MarkdownViewerMediaProps extends Omit<
   media: Media;
 }
 
+// oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 const transformToText = async (response: Response): Promise<string> => {
   return response.text();
 };

--- a/packages/react-components/src/markdown-renderer/MarkdownViewerMedia.tsx
+++ b/packages/react-components/src/markdown-renderer/MarkdownViewerMedia.tsx
@@ -33,6 +33,7 @@ export interface MarkdownViewerMediaProps extends Omit<
   media: Media;
 }
 
+// TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
 // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 const transformToText = async (response: Response): Promise<string> => {
   return response.text();

--- a/packages/react-components/src/object-table/hooks/__tests__/useEditableTable.test.ts
+++ b/packages/react-components/src/object-table/hooks/__tests__/useEditableTable.test.ts
@@ -269,7 +269,7 @@ describe("useEditableTable", () => {
     expect(onSubmitEdits).toHaveBeenCalledWith([edit1, edit2]);
   });
 
-  it("when submit edits is undefined, onSubmitEdits is undefined", async () => {
+  it("when submit edits is undefined, onSubmitEdits is undefined", () => {
     const { result } = renderHook(() =>
       useEditableTable({
         editMode: "always",

--- a/packages/react-components/src/object-table/hooks/__tests__/useFunctionColumnsData.test.ts
+++ b/packages/react-components/src/object-table/hooks/__tests__/useFunctionColumnsData.test.ts
@@ -215,7 +215,7 @@ describe("useFunctionColumnsData", () => {
     });
   });
 
-  it("should fetch data for function columns", async () => {
+  it("should fetch data for function columns", () => {
     const mockResult = {
       "TestObject:obj1": { value: "result1" },
       "TestObject:obj2": { value: "result2" },
@@ -310,7 +310,7 @@ describe("useFunctionColumnsData", () => {
     );
   });
 
-  it("should extract value using getValue function when specified", async () => {
+  it("should extract value using getValue function when specified", () => {
     const mockResult = {
       "TestObject:obj1": {
         status: "active",
@@ -372,7 +372,7 @@ describe("useFunctionColumnsData", () => {
     });
   });
 
-  it("should handle multiple queries", async () => {
+  it("should handle multiple queries", () => {
     const mockObjects = [
       {
         $objectType: "TestObject",
@@ -504,7 +504,7 @@ describe("useFunctionColumnsData", () => {
     );
   });
 
-  it("should handle missing object in the result", async () => {
+  it("should handle missing object in the result", () => {
     // 2 objects
     const mockObjects = [
       {
@@ -612,7 +612,7 @@ describe("useFunctionColumnsData", () => {
     expect(result.current.testColumn.obj1.data).toBeUndefined();
   });
 
-  it("should handle errors gracefully", async () => {
+  it("should handle errors gracefully", () => {
     const mockError = new Error("Query failed");
 
     vi.mocked(useOsdkFunctions).mockReturnValue([

--- a/packages/react-components/src/object-table/hooks/__tests__/useObjectTableSnapshot.test.ts
+++ b/packages/react-components/src/object-table/hooks/__tests__/useObjectTableSnapshot.test.ts
@@ -424,7 +424,7 @@ describe(useObjectTableSnapshot, () => {
      * `executeFunction` when called with a query definition.
      */
     function makeFunctionClient(executeResult: Record<string, unknown>) {
-      const executeFunction = vi.fn(async () => executeResult);
+      const executeFunction = vi.fn(() => executeResult);
       const pageObjectSet = {};
       const baseObjectSet = { where: vi.fn(() => pageObjectSet) };
       const client = vi.fn((arg: { type?: string }) =>

--- a/packages/react-components/src/object-table/hooks/useEditableTable.ts
+++ b/packages/react-components/src/object-table/hooks/useEditableTable.ts
@@ -121,6 +121,7 @@ export function useEditableTable<
     setValidationErrors(new Map());
   }, []);
 
+  // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
   // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   const handleSubmitEdits = useCallback(async () => {
     const edits = Object.values(cellEdits);

--- a/packages/react-components/src/object-table/hooks/useEditableTable.ts
+++ b/packages/react-components/src/object-table/hooks/useEditableTable.ts
@@ -121,6 +121,7 @@ export function useEditableTable<
     setValidationErrors(new Map());
   }, []);
 
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   const handleSubmitEdits = useCallback(async () => {
     const edits = Object.values(cellEdits);
     return onSubmitEdits ? onSubmitEdits(edits) : false;

--- a/packages/react-components/src/object-table/utils/__tests__/objectTableSnapshot.test.ts
+++ b/packages/react-components/src/object-table/utils/__tests__/objectTableSnapshot.test.ts
@@ -68,6 +68,7 @@ function makePage(primaryKeys: number[]): AnyPagedObjects {
 describe("fetchFunctionColumnPage", () => {
   it("maps each object key to its raw cell value when no getValue is set", async () => {
     const locator = makeFunctionLocator("computed");
+    // oxlint-disable-next-line require-await -- intentionally async: assigned to a Promise-returning callback/mock type; no await needed
     const executeFunction = vi.fn(async () => ({ "1": "alpha", "2": "beta" }));
 
     const result = await fetchFunctionColumnPage(
@@ -86,6 +87,7 @@ describe("fetchFunctionColumnPage", () => {
     const locator = makeFunctionLocator("computed", {
       getValue: (raw) => (raw as { v: number }).v * 2,
     });
+    // oxlint-disable-next-line require-await -- intentionally async: assigned to a Promise-returning callback/mock type; no await needed
     const executeFunction = vi.fn(async () => ({
       "1": { v: 10 },
       "2": { v: 21 },
@@ -104,6 +106,7 @@ describe("fetchFunctionColumnPage", () => {
   it("fills every object's cell with the Error when the query rejects", async () => {
     const failure = new Error("boom");
     const locator = makeFunctionLocator("computed");
+    // oxlint-disable-next-line require-await -- intentionally async: assigned to a Promise-returning callback/mock type; no await needed
     const executeFunction = vi.fn(async () => {
       throw failure;
     });
@@ -123,6 +126,7 @@ describe("fetchFunctionColumnValues", () => {
   it("merges per-page maps into one map per column", async () => {
     const locator = makeFunctionLocator("computed");
     const executeFunction = vi.fn(
+      // oxlint-disable-next-line require-await -- intentionally async: assigned to a Promise-returning callback/mock type; no await needed
       async (_q: QueryDefinition<{}>, _params: unknown) => {
         const callIndex = executeFunction.mock.calls.length;
         return callIndex === 1 ? { "1": "page1-a" } : { "2": "page2-a" };
@@ -144,6 +148,7 @@ describe("fetchFunctionColumnValues", () => {
     const locator = makeFunctionLocator("computed");
     const failure = new Error("page1 failed");
     const executeFunction = vi.fn(
+      // oxlint-disable-next-line require-await -- intentionally async: assigned to a Promise-returning callback/mock type; no await needed
       async (_q: QueryDefinition<{}>, _params: unknown) => {
         const callIndex = executeFunction.mock.calls.length;
         if (callIndex === 1) throw failure;

--- a/packages/react-components/src/pdf-viewer/hooks/__tests__/usePdfViewerState.test.ts
+++ b/packages/react-components/src/pdf-viewer/hooks/__tests__/usePdfViewerState.test.ts
@@ -373,7 +373,7 @@ describe("usePdfViewerState", () => {
       usePdfViewerState({ src: "test.pdf", onDownload })
     );
 
-    await act(async () => {
+    await act(() => {
       result.current.download("report.pdf");
     });
 
@@ -399,7 +399,7 @@ describe("usePdfViewerState", () => {
 
     const { result } = renderHook(() => usePdfViewerState({ src, onDownload }));
 
-    await act(async () => {
+    await act(() => {
       result.current.download();
     });
 
@@ -447,7 +447,7 @@ describe("usePdfViewerState", () => {
       usePdfViewerState({ src: "test.pdf", onDownload })
     );
 
-    await act(async () => {
+    await act(() => {
       result.current.download();
     });
 
@@ -472,7 +472,7 @@ describe("usePdfViewerState", () => {
       usePdfViewerState({ src: "test.pdf", onDownload })
     );
 
-    await act(async () => {
+    await act(() => {
       result.current.download();
     });
 
@@ -503,7 +503,7 @@ describe("usePdfViewerState", () => {
       })
     );
 
-    await act(async () => {
+    await act(() => {
       result.current.download();
     });
 

--- a/packages/react-components/src/xml-viewer/XmlViewer.tsx
+++ b/packages/react-components/src/xml-viewer/XmlViewer.tsx
@@ -24,6 +24,7 @@ import type { XmlViewerMediaProps } from "./XmlViewerApi.js";
 
 import styles from "./BaseXmlViewer.module.css";
 
+// oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 const transformToText = async (response: Response): Promise<string> => {
   return response.text();
 };

--- a/packages/react-components/src/xml-viewer/XmlViewer.tsx
+++ b/packages/react-components/src/xml-viewer/XmlViewer.tsx
@@ -24,6 +24,7 @@ import type { XmlViewerMediaProps } from "./XmlViewerApi.js";
 
 import styles from "./BaseXmlViewer.module.css";
 
+// TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
 // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 const transformToText = async (response: Response): Promise<string> => {
   return response.text();

--- a/packages/react/src/aip/useChat.test.tsx
+++ b/packages/react/src/aip/useChat.test.tsx
@@ -49,6 +49,7 @@ function createMockTransport(): MockTransport {
   }> = [];
 
   const sendMessages = vi.fn(
+    // oxlint-disable-next-line require-await -- intentionally async: assigned to a Promise-returning callback/mock type; no await needed
     async (args: {
       trigger: "submit-message" | "regenerate-message";
       chatId: string;
@@ -70,6 +71,7 @@ function createMockTransport(): MockTransport {
       });
     }
   );
+  // oxlint-disable-next-line require-await -- intentionally async: assigned to a Promise-returning callback/mock type; no await needed
   const reconnect = vi.fn(async () => null);
 
   const transport: ChatTransport<UIMessage> = {

--- a/packages/react/src/new/__tests__/useStableObjectSet.test.ts
+++ b/packages/react/src/new/__tests__/useStableObjectSet.test.ts
@@ -25,6 +25,7 @@ import { useStableObjectSet } from "../core/useStableObjectSet.js";
 const client = createClient(
   "https://stack.palantir.com/",
   "ri.ontology.main.ontology.dummy",
+  // oxlint-disable-next-line require-await -- intentionally async: assigned to a Promise-returning callback/mock type; no await needed
   async () => "token"
 );
 

--- a/packages/react/test/useOsdkMetadata.test.tsx
+++ b/packages/react/test/useOsdkMetadata.test.tsx
@@ -30,7 +30,7 @@ describe(useOsdkMetadata, () => {
   it("works", async () => {
     const deferred = pDefer();
     const fakeClient = {
-      fetchMetadata: vitest.fn(async (o) => {
+      fetchMetadata: vitest.fn((o) => {
         return deferred.promise;
       }),
     } as any as Client;

--- a/packages/shared.net/src/createClientContext.ts
+++ b/packages/shared.net/src/createClientContext.ts
@@ -32,6 +32,7 @@ export function createClientContext(
 ): SharedClientContext {
   return createSharedClientContext(
     baseUrl,
+    // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     async () => tokenProvider(),
     [userAgent].filter((x) => x && x?.length > 0).join(" "),
     fetchFn

--- a/packages/shared.net/src/createClientContext.ts
+++ b/packages/shared.net/src/createClientContext.ts
@@ -32,6 +32,7 @@ export function createClientContext(
 ): SharedClientContext {
   return createSharedClientContext(
     baseUrl,
+    // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
     // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     async () => tokenProvider(),
     [userAgent].filter((x) => x && x?.length > 0).join(" "),

--- a/packages/shared.test.intellisense/src/tsserver.ts
+++ b/packages/shared.test.intellisense/src/tsserver.ts
@@ -55,6 +55,7 @@ class TsServerImpl extends EventEmitter<{
     return this.#subprocess;
   }
 
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   async start(): Promise<this> {
     this.#subprocess = execaNode({
       ipc: true,

--- a/packages/tool.release/src/publishPackages.ts
+++ b/packages/tool.release/src/publishPackages.ts
@@ -132,6 +132,7 @@ export async function packageVersionsOrEmptySet(
   }
 }
 
+// TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
 // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 async function getUnpublishedPackages(packages: Array<Package>) {
   return pFilter(packages, async (pkg) => {

--- a/packages/tool.release/src/publishPackages.ts
+++ b/packages/tool.release/src/publishPackages.ts
@@ -132,6 +132,7 @@ export async function packageVersionsOrEmptySet(
   }
 }
 
+// oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 async function getUnpublishedPackages(packages: Array<Package>) {
   return pFilter(packages, async (pkg) => {
     const { name, version } = pkg.packageJson;

--- a/packages/tool.release/src/util/getVersionPrBody.ts
+++ b/packages/tool.release/src/util/getVersionPrBody.ts
@@ -61,6 +61,7 @@ type GetMessageOptions = {
   preState?: PreState;
 };
 
+// oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 export async function getVersionPrBody({
   hasPublishScript,
   preState,

--- a/packages/unit-testing/src/example-function-tests/objectWithLinks/objectWithLinks.ts
+++ b/packages/unit-testing/src/example-function-tests/objectWithLinks/objectWithLinks.ts
@@ -41,6 +41,7 @@ export async function countEmployeePeeps(
   return count;
 }
 
+// TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
 // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 export async function getSpecificPeep(
   employee: Osdk.Instance<Employee>,

--- a/packages/unit-testing/src/example-function-tests/objectWithLinks/objectWithLinks.ts
+++ b/packages/unit-testing/src/example-function-tests/objectWithLinks/objectWithLinks.ts
@@ -41,6 +41,7 @@ export async function countEmployeePeeps(
   return count;
 }
 
+// oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 export async function getSpecificPeep(
   employee: Osdk.Instance<Employee>,
   peepId: number

--- a/packages/unit-testing/src/mock/__tests__/createMockOsdkObject.test.ts
+++ b/packages/unit-testing/src/mock/__tests__/createMockOsdkObject.test.ts
@@ -361,7 +361,7 @@ describe("createMockOsdkObject", () => {
         expect(results[1]).toBe(mockPeep2);
       });
 
-      it("throws when aggregate is called on many link stub", async () => {
+      it("throws when aggregate is called on many link stub", () => {
         const mockEmployee = createMockOsdkObject(
           Employee,
           { employeeId: 1 },

--- a/packages/unit-testing/src/mock/createMockClient.ts
+++ b/packages/unit-testing/src/mock/createMockClient.ts
@@ -193,6 +193,7 @@ export function createMockClient(): MockClient {
     queryStubs.length = 0;
   };
 
+  // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   mockClient.fetchMetadata = async () => {
     invariant(false, "fetchMetadata is not supported in mocks");
   };
@@ -204,6 +205,7 @@ export function createMockClient(): MockClient {
   Object.defineProperty(mockClient, SYMBOL_CLIENT_CONTEXT, {
     value: createPlatformClient(
       "https://mock.invalid/",
+      // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
       async () => "mock-token"
     ),
     enumerable: false,

--- a/packages/unit-testing/src/mock/createMockObjectSetWithResolver.ts
+++ b/packages/unit-testing/src/mock/createMockObjectSetWithResolver.ts
@@ -60,6 +60,7 @@ export function createMockObjectSetWithResolver<
     withProperties: () =>
       // TODO: Add with properties support
       void invariant(false, "withProperties is not supported in mocks") as any,
+    // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     fetchPage: async (args?: unknown) =>
       terminal<PageResult<Osdk.Instance<Q>>>("fetchPage", args) as any,
     fetchPageWithErrors: async (args?: unknown) => {
@@ -72,6 +73,7 @@ export function createMockObjectSetWithResolver<
         return { type: "error" as const, error };
       }
     },
+    // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     fetchOne: (async (pk: unknown) =>
       terminal<Osdk.Instance<Q>>("fetchOne", pk)) as any,
     fetchOneWithErrors: (async (pk: unknown) => {
@@ -84,6 +86,7 @@ export function createMockObjectSetWithResolver<
         return { type: "error" as const, error } as any;
       }
     }) as any,
+    // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
     aggregate: async (req: AggregateOpts<Q>) =>
       terminal<AggregationsResults<Q, AggregateOpts<Q>>>(
         "aggregate",

--- a/packages/unit-testing/src/mock/createMockOsdkObject.ts
+++ b/packages/unit-testing/src/mock/createMockOsdkObject.ts
@@ -110,6 +110,7 @@ function createManyLinkStub<T extends ObjectTypeDefinition>(
         [Symbol.asyncIterator]() {
           return this;
         },
+        // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
         async next() {
           if (index < linkedObjects.length) {
             return { value: linkedObjects[index++], done: false as const };

--- a/packages/version-updater/src/junk.test.ts
+++ b/packages/version-updater/src/junk.test.ts
@@ -17,7 +17,7 @@
 import { describe, expect, it } from "vitest";
 
 describe("anything", () => {
-  it("does", async () => {
+  it("does", () => {
     expect(1).toBe(1);
   });
 });

--- a/packages/widget.vite-plugin/src/build-plugin/FoundryWidgetBuildPlugin.ts
+++ b/packages/widget.vite-plugin/src/build-plugin/FoundryWidgetBuildPlugin.ts
@@ -120,6 +120,7 @@ async function createModuleEvaluationServer(
   });
 }
 
+// TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
 // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 async function computeWidgetSetVersion(
   foundryConfig: LoadedFoundryConfig<"widgetSet">

--- a/packages/widget.vite-plugin/src/build-plugin/FoundryWidgetBuildPlugin.ts
+++ b/packages/widget.vite-plugin/src/build-plugin/FoundryWidgetBuildPlugin.ts
@@ -120,6 +120,7 @@ async function createModuleEvaluationServer(
   });
 }
 
+// oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 async function computeWidgetSetVersion(
   foundryConfig: LoadedFoundryConfig<"widgetSet">
 ): Promise<string> {

--- a/packages/widget.vite-plugin/src/common/visitNpmPackages.ts
+++ b/packages/widget.vite-plugin/src/common/visitNpmPackages.ts
@@ -21,6 +21,7 @@ import resolvePackagePath from "resolve-package-path";
 
 import type { PackageJson } from "./PackageJson.js";
 
+// TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
 // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 export async function visitNpmPackages(
   rootPackageJsonPath: string,

--- a/packages/widget.vite-plugin/src/common/visitNpmPackages.ts
+++ b/packages/widget.vite-plugin/src/common/visitNpmPackages.ts
@@ -21,6 +21,7 @@ import resolvePackagePath from "resolve-package-path";
 
 import type { PackageJson } from "./PackageJson.js";
 
+// oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
 export async function visitNpmPackages(
   rootPackageJsonPath: string,
   onVisit: (packageJsonPath: string, packageJson: PackageJson) => void


### PR DESCRIPTION
## What

Re-enables `require-await` and `typescript/require-await` (`off -> error`) in the root `oxlint.config.ts`, and resolves all findings. Fourth PR in the effort to re-enable the six behavior/API-risk rules the oxc migration parked at `off`.

## How the findings were resolved

`require-await` flags `async` functions with no `await`. The findings fell into three groups, each handled by its safest fix:

**1. Test callbacks (~127) — drop the redundant `async`.**
`it(...)` / `describe(...)` / `beforeEach(...)` and mock functions that never `await`. Removing `async` is behavior-identical and has no API surface. (15 of the originally-flagged test callbacks turned out to be typed mocks that *require* `async` to match a `() => Promise<T>` slot — those were kept async + disabled instead; caught by typecheck.)

**2. Shipped-source functions (76) — keep `async`, add a scoped disable.**
These are async to satisfy a `Promise`-returning contract: cache getters (`AsyncClientCache`/`WeakAsyncCache`), token providers, `ObservableClient` methods, `async next()` iterators, mock `ObjectSet` methods, `validateEdit` callbacks. Removing `async` would break their types (verified by typecheck) or change throw-timing / the published `Promise` signature, so per the migration's behavior-preserving rule each gets a justified `// oxlint-disable-next-line require-await`.

**3. Generated conjure trees (571) — disable in the nested configs.**
`client.unstable` (527) and `client.unstable.tpsa` (44) lint their checked-in `src/generated/**` trees, where the conjure generator emits every service method as `async` (many with no `await`). This is regenerated code, not hand-editable, so `require-await` is turned off in those packages' nested configs — matching their existing generated-tree rule opt-outs (`no-barrel-file`, `import/newline-after-import`).

Also dropped a redundant `async` from `e2e.generated.1.1.x`'s tsup `onSuccess` hook.

> Note: these generated-tree findings are only surfaced by the packages' *own* nested configs (which re-include `**/generated`), not by a root-level lint pass — so `pnpm turbo lint` (what CI runs) is the ground truth here.

## Verification

- `pnpm turbo lint` (root + all nested configs): **217 tasks green** — 0 `require-await` findings
- `pnpm turbo typecheck transpile build`: green (376 tasks) — confirms no `async` was removed where its `Promise<T>` type is load-bearing
- Affected test suites: green (api, client, react, react-components, aip-core, oauth, language-models, unit-testing, functions, version-updater)
- `pnpm turbo check-api` (api, client, functions): no API report changes
- `monorepolint check`: 0; `dprint check`: clean

## Changeset

One `patch` changeset covering the 18 changed public non-ignored packages.