### PR TITLE
Make the Component Overview Storybook story fill the preview height.

### DIFF
--- a/.changeset/storybook-overview-full-height.md
+++ b/.changeset/storybook-overview-full-height.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components-storybook": patch
+---
+
+Make the Component Overview Storybook story fill the preview height.

--- a/packages/react-components-storybook/src/stories/Overview/Overview.stories.tsx
+++ b/packages/react-components-storybook/src/stories/Overview/Overview.stories.tsx
@@ -306,7 +306,7 @@ function DataTab(): React.ReactElement {
   const [collapsed, setCollapsed] = useState(false);
 
   return (
-    <div style={{ display: "flex", height: 500 }}>
+    <div style={{ display: "flex", height: "100%", minHeight: 0 }}>
       <div
         style={{
           ...FILTER_WRAPPER_STYLE,
@@ -324,7 +324,7 @@ function DataTab(): React.ReactElement {
           showActiveFilterCount={true}
         />
       </div>
-      <div style={{ flex: 1, minWidth: 0 }}>
+      <div style={{ flex: 1, minHeight: 0, minWidth: 0 }}>
         <ObjectTable objectType={Employee} filter={filterClause} />
       </div>
     </div>
@@ -358,7 +358,7 @@ function ViewersTab({
   const loadingMessage = isLoading ? "Loading document..." : "No media found.";
 
   return (
-    <div style={{ height: 400, position: "relative" }}>
+    <div style={{ height: "100%", minHeight: 0, position: "relative" }}>
       {hasMedia && (
         <DocumentViewer
           key={selectedViewerType}
@@ -427,11 +427,19 @@ function ComponentOverview(): React.ReactElement {
   );
 
   return (
-    <div>
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100vh",
+        minHeight: 0,
+      }}
+    >
       <div
         style={{
           display: "flex",
           alignItems: "center",
+          flexShrink: 0,
           borderBottom:
             "1px solid var(--osdk-surface-border-color-default, #d1d5db)",
         }}
@@ -499,11 +507,13 @@ function ComponentOverview(): React.ReactElement {
         )}
       </div>
 
-      {activeTab === "data" && <DataTab />}
-      {activeTab === "viewers" && (
-        <ViewersTab selectedViewerType={selectedViewerType} />
-      )}
-      {activeTab === "forms" && <FormsTab />}
+      <div style={{ flex: 1, minHeight: 0, overflow: "auto" }}>
+        {activeTab === "data" && <DataTab />}
+        {activeTab === "viewers" && (
+          <ViewersTab selectedViewerType={selectedViewerType} />
+        )}
+        {activeTab === "forms" && <FormsTab />}
+      </div>
     </div>
   );
 }

--- a/packages/react-components-storybook/src/stories/Overview/Overview.stories.tsx
+++ b/packages/react-components-storybook/src/stories/Overview/Overview.stories.tsx
@@ -432,7 +432,6 @@ function ComponentOverview(): React.ReactElement {
         display: "flex",
         flexDirection: "column",
         height: "100vh",
-        minHeight: 0,
       }}
     >
       <div


### PR DESCRIPTION
### Before

<img width="1511" height="834" alt="Screenshot 2026-07-03 at 11 07 38" src="https://github.com/user-attachments/assets/c9fa1ea6-9657-4aa4-9da8-dc858a71b03f" />

<img width="1511" height="834" alt="Screenshot 2026-07-03 at 11 07 45" src="https://github.com/user-attachments/assets/36b4db50-e935-46a6-a66e-81ce3d8fff9c" />

### After

<img width="1511" height="834" alt="Screenshot 2026-07-03 at 11 07 52" src="https://github.com/user-attachments/assets/6cf832cc-c571-4b82-892e-9c40a99a470e" />

<img width="1511" height="834" alt="Screenshot 2026-07-03 at 11 07 58" src="https://github.com/user-attachments/assets/df386d17-6336-477c-ab37-97a30f750996" />

