### PR TITLE
fix: make lint-staged oxc excludes work under hidden checkout dirs

### DIFF
--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -134,6 +134,14 @@ const IGNORED_FILE_GLOBS = [
   "**/examples/**/*",
 ];
 
+// lint-staged passes absolute paths to these matchers, so a repo checked out
+// under a hidden directory (e.g. `/…/.codex/osdk-ts/…`) has a dot-segment in
+// the path. micromatch's `**` does not cross dot-directories unless `dot: true`
+// is set, so without it the excludes above silently fail to match: a file gets
+// routed to a formatter/linter that then matches 0 files and exits non-zero
+// ("No files found to format"/"No files found to lint"), failing the commit.
+const MICROMATCH_OPTS = { dot: true };
+
 /*
  * Overview:
  *  - Fixes lint rules and formatting for code
@@ -150,7 +158,7 @@ export default {
   ],
   "*.md": [CSPELL_CMD],
   [OXC_PACKAGE_GLOB]: (files) => {
-    const match = micromatch.not(files, IGNORED_FILE_GLOBS);
+    const match = micromatch.not(files, IGNORED_FILE_GLOBS, MICROMATCH_OPTS);
     if (match.length === 0) return [];
     // oxlint --fix first (its fixes can affect whitespace), then oxfmt last so
     // the final result is always formatted. Mirrors the package fix-lint script.
@@ -167,7 +175,11 @@ export default {
     Object.entries(OXC_NESTED_CONFIG_PACKAGES).map(([pkg, config]) => [
       `packages/${pkg}/**/*.{js,jsx,ts,tsx,mjs,cjs}`,
       (files) => {
-        const match = micromatch.not(files, IGNORED_FILE_GLOBS);
+        const match = micromatch.not(
+          files,
+          IGNORED_FILE_GLOBS,
+          MICROMATCH_OPTS,
+        );
         if (match.length === 0) return [];
         return [
           `oxlint -c ${config} --fix ${match.join(" ")}`,
@@ -186,6 +198,7 @@ export default {
         ...IGNORED_FILE_GLOBS,
         ...OXC_PACKAGE_EXCLUDES,
       ],
+      MICROMATCH_OPTS,
     );
     if (match.length === 0) return [];
     return [
@@ -204,7 +217,7 @@ export default {
       // "**/package.json",
       "tsconfig.json",
       "**/tsconfig.json",
-    ], {});
+    ], MICROMATCH_OPTS);
 
     const mrlCommands = mrlFiles.length > 0
       ? [


### PR DESCRIPTION
## Problem

A pre-commit hook failure surfaces when the repo is checked out under a hidden (dot) directory, e.g. `/…/.codex/osdk-ts/…`. It first showed up while editing `packages/react-components-storybook/src/stories/Overview/Overview.stories.tsx` (from #3615):

```
* dprint fmt .../react-components-storybook/src/stories/Overview/Overview.stories.tsx:
No files found to format with the specified plugins ...
husky - pre-commit script failed (code 1)
```

## Root cause

Not specific to that file, and not a dprint config problem. It is a latent bug in `.lintstagedrc.mjs`.

lint-staged passes **absolute** paths to its function configs. micromatch's `**` does not cross **dot-directories** unless `{ dot: true }` is set. So for a checkout under a hidden directory, the exclude globs silently fail to match (the `.codex` segment stops `**`), and a file gets routed to a tool that then matches 0 files and exits non-zero:

- an oxc-migrated file (e.g. `react-components-storybook`) routed to `dprint fmt`, which `dprint.json` excludes -> "No files found to format";
- and, after #3617, a generated/template file inside an oxc package routed to `oxlint`, which ignores it -> "No files found to lint".

Verified: `micromatch.isMatch("/…/.codex/…/packages/react-components-storybook/…", "**/packages/react-components-storybook/**")` returns `false`, and `true` once `{ dot: true }` is passed.

## Fix

Add a shared `MICROMATCH_OPTS = { dot: true }` and pass it to all four `micromatch` calls: the two oxc handlers (root + nested config), the dprint+eslint handler, and the monorepolint matcher.

Confirmed by loading the actual config with paths under a `.codex` prefix:
- storybook file -> dprint handler returns `[]` (no dprint), nested oxc handler still runs `oxlint`+`oxfmt`;
- `generatedNoCheck` file in an oxc package -> oxc handler returns `[]`.

`--allow-no-files` would have masked the routing bug rather than fixing it, so `{ dot: true }` is the correct fix.

## Notes

- Rebased onto `main` after #3617 merged; this fix also closes the same dot-directory gap in the handlers #3617 added.
- No changeset: repo tooling only, not published package code.