### PR TITLE
[Components] Polish AipAgentChat storybook layout and docs

### DIFF
--- a/packages/react-components-storybook/src/stories/AipAgentChat/AipAgentChat.mdx
+++ b/packages/react-components-storybook/src/stories/AipAgentChat/AipAgentChat.mdx
@@ -1,0 +1,22 @@
+{/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */}
+
+import { Meta, Markdown } from "@storybook/addon-docs/blocks";
+import aipAgentChatDocs from "@docs/AipAgentChat.md?raw";
+
+<Meta title="Components/AipAgentChat/Docs" tags={["beta"]}/>
+
+<Markdown>{aipAgentChatDocs}</Markdown>

--- a/packages/react-components-storybook/src/stories/AipAgentChat/AipAgentChat.stories.tsx
+++ b/packages/react-components-storybook/src/stories/AipAgentChat/AipAgentChat.stories.tsx
@@ -140,10 +140,11 @@ function InteractiveChat(
 }
 
 const meta: Meta<typeof InteractiveChat> = {
-  title: "Beta/AipAgentChat",
+  title: "Components/AipAgentChat",
   component: InteractiveChat,
+  tags: ["beta"],
   render: (args) => (
-    <div style={{ height: "600px", maxWidth: "700px" }}>
+    <div style={{ height: "100vh" }}>
       <InteractiveChat {...args} />
     </div>
   ),
@@ -153,15 +154,51 @@ const meta: Meta<typeof InteractiveChat> = {
 };
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 /** Empty chat with the default welcome state. Type a message to start a simulated conversation. */
-export const Default: Story = {};
+export const Default: Story = {
+  parameters: {
+    docs: {
+      source: {
+        code: `import { AipAgentChat } from "@osdk/react-components/experimental/aip-agent-chat";
+import { createPlatformClient } from "@osdk/client";
+
+const client = createPlatformClient({ /* ... */ });
+
+<AipAgentChat
+  client={client}
+  availableModels={["gpt-4o", "gpt-4o-mini"]}
+/>`,
+      },
+    },
+  },
+};
 
 /** Chat pre-populated with an existing conversation. */
 export const WithConversation: Story = {
   args: {
     initialMessages: SAMPLE_CONVERSATION,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `import { AipAgentChat } from "@osdk/react-components/experimental/aip-agent-chat";
+import type { UIMessage } from "@osdk/react-components/experimental/aip-agent-chat";
+
+const initialMessages: UIMessage[] = [
+  { id: "1", role: "user", parts: [{ type: "text", text: "..." }] },
+  { id: "2", role: "assistant", parts: [{ type: "text", text: "..." }] },
+];
+
+<AipAgentChat
+  client={client}
+  availableModels={["gpt-4o", "gpt-4o-mini"]}
+  initialMessages={initialMessages}
+/>`,
+      },
+    },
   },
 };
 
@@ -171,11 +208,39 @@ export const WithError: Story = {
     simulateError: true,
     initialMessages: SAMPLE_CONVERSATION.slice(0, 2),
   },
+  parameters: {
+    docs: {
+      source: {
+        code: `import { AipAgentChat } from "@osdk/react-components/experimental/aip-agent-chat";
+
+// Errors from the underlying LMS stream surface via onError and render
+// as a dismissible banner above the composer.
+<AipAgentChat
+  client={client}
+  availableModels={["gpt-4o", "gpt-4o-mini"]}
+  onError={(error) => console.error(error)}
+/>`,
+      },
+    },
+  },
 };
 
 /** Custom placeholder text in the composer. */
 export const CustomPlaceholder: Story = {
   args: {
     placeholder: "Ask me anything about your data...",
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `import { AipAgentChat } from "@osdk/react-components/experimental/aip-agent-chat";
+
+<AipAgentChat
+  client={client}
+  availableModels={["gpt-4o", "gpt-4o-mini"]}
+  placeholder="Ask me anything about your data..."
+/>`,
+      },
+    },
   },
 };


### PR DESCRIPTION
Splits out only the storybook changes from #3601 (the component/API changes stay in that PR).

- Move `AipAgentChat` from `Beta/` to `Components/` and mark it with the `beta` tag
- Use a full-height story layout
- Add an `AipAgentChat.mdx` docs page that renders the component's markdown docs
- Add per-story Code panel usage examples for the `Default`, `WithConversation`, `WithError`, and `CustomPlaceholder` stories

Scoped to the two storybook files so it stands alone on `main` — the context-picker / model-picker demos are omitted because they depend on component API changes not yet merged.

No changeset: `@osdk/react-components-storybook` is a private, unpublished package.