### PR TITLE
chore: extend oxfmt to css/scss/html in oxc-migrated packages

### DIFF
--- a/.changeset/oxc-format-css-scss-html.md
+++ b/.changeset/oxc-format-css-scss-html.md
@@ -1,0 +1,8 @@
+---
+"@osdk/react-components": patch
+"@osdk/react-devtools": patch
+"@osdk/cbac-components": patch
+"@osdk/widget.vite-plugin": patch
+---
+
+Extend oxfmt formatting to css, scss, and html in oxc-migrated packages. These file types were previously left unformatted (dprint had no css/html plugin); they are now covered by oxfmt and reformatted accordingly. yaml stays excluded because the only yaml in migrated packages is mustache-template documentation that oxfmt would corrupt.

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -117,10 +117,22 @@ const OXC_NESTED_CONFIG_PACKAGES = {
 
 // All oxc packages (root-config + nested-config) are excluded from the ESLint +
 // dprint path below.
-const OXC_PACKAGE_EXCLUDES = [
+const ALL_OXC_PACKAGES = [
   ...OXC_PACKAGES,
   ...Object.keys(OXC_NESTED_CONFIG_PACKAGES),
-].map((p) => `**/packages/${p}/**`);
+];
+const OXC_PACKAGE_EXCLUDES = ALL_OXC_PACKAGES.map((p) => `**/packages/${p}/**`);
+
+/*
+ * css / scss / html inside oxc packages are formatted by oxfmt (the root config
+ * covers these types). They run oxfmt ONLY: oxlint is a JS/TS linter and does
+ * not process stylesheets or html, so handing it these files would match 0 files
+ * and exit non-zero. dprint never formatted these types either, so packages
+ * still on the eslint/dprint path get no handler for them.
+ */
+const OXC_STYLE_GLOB = `packages/{${
+  ALL_OXC_PACKAGES.join(",")
+}}/**/*.{css,scss,html}`;
 
 // Files that must never be linted/formatted regardless of toolchain: generated
 // SDK output and copied templates. Both the oxc and ESLint paths below exclude
@@ -189,6 +201,12 @@ export default {
       },
     ]),
   ),
+  [OXC_STYLE_GLOB]: (files) => {
+    const match = micromatch.not(files, IGNORED_FILE_GLOBS, MICROMATCH_OPTS);
+    if (match.length === 0) return [];
+    // oxfmt only — oxlint does not handle css/scss/html (see OXC_STYLE_GLOB).
+    return [`oxfmt -c oxfmt.config.ts ${match.join(" ")}`];
+  },
   "packages/**/*.{js,jsx,ts,tsx,mjs,cjs}": (
     files,
   ) => {

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -26,9 +26,13 @@ export default defineConfig({
     ),
     "**/package.json",
     "**/tsconfig.json",
-    // YAML is not formatted by dprint either (no yaml plugin); some packages keep
-    // significant-whitespace data here (e.g. mustache templates in
-    // typescript-sdk-docs/src/documentation.yml) that reformatting would corrupt.
+    // YAML stays excluded. The only .yml/.yaml inside oxc-migrated packages are
+    // the mustache-template docs (react-sdk-docs / typescript-sdk-docs
+    // src/documentation.yml) and historical changelog entries (**/changelog/,
+    // excluded below). oxfmt's YAML formatter changes the indentation of the
+    // `{{#isUnary}}` / `{{/isUnary}}` mustache sections inside the `|-` scalars,
+    // which corrupts the templates (verified). There is nothing else to gain, so
+    // leave the whole type to its authors.
     "**/*.yml",
     "**/*.yaml",
     // JSON / JSONC ARE formatted by oxfmt (parity with dprint, which formatted
@@ -44,17 +48,14 @@ export default defineConfig({
     // embedded JSX expressions (e.g. the `{/* license */}` block), breaking
     // Storybook's mdx indexer.
     "**/*.mdx",
-    // CSS / SCSS are not formatted by dprint either (no css plugin); component
-    // packages hand-maintain these stylesheets (e.g. @osdk/cbac-components and,
-    // ahead, @osdk/react-components). Leave them to their authors so the tooling
-    // migration touches only .ts/.tsx.
-    "**/*.css",
-    "**/*.scss",
-    // HTML is not formatted by dprint either (no html plugin); the vite sandbox
-    // apps hand-maintain their index.html entry points. Leave them to their
-    // authors so the tooling migration touches only .ts/.tsx (and the json/md
-    // dprint already formatted).
-    "**/*.html",
+    // CSS / SCSS / HTML ARE formatted by oxfmt (these types were never covered by
+    // dprint, which had no css/html plugin). oxfmt only runs inside oxc-migrated
+    // packages (each invokes `oxfmt -c ../../oxfmt.config.ts .`), so enabling
+    // these types here formats the migrated component packages' stylesheets
+    // (@osdk/react-components, @osdk/cbac-components, @osdk/react-devtools, …) and
+    // the vite sandbox apps' index.html entry points, while packages still on the
+    // dprint/eslint path are untouched. `.hbs`/mustache stays out via the
+    // **/templates/ exclusion below; YAML stays out above.
     // Shipped scaffolding under create-app/create-widget template packages'
     // templates/ dirs is not part of this repo's own source: it carries its own
     // (soon-to-be-oxc) tooling config, uses .hbs mustache templates oxfmt would

--- a/packages/cbac-components/src/cbac-picker/base/MarkingButton.module.css
+++ b/packages/cbac-components/src/cbac-picker/base/MarkingButton.module.css
@@ -31,7 +31,9 @@
   background-color: var(--osdk-cbac-marking-button-bg-default, transparent);
 }
 
-.markingButton:hover:not(:disabled):not([aria-disabled="true"]):not(.disallowed):not(.impliedDisallowed):not(.selected):not(.implied) {
+.markingButton:hover:not(:disabled):not([aria-disabled="true"]):not(
+    .disallowed
+  ):not(.impliedDisallowed):not(.selected):not(.implied) {
   background-color: var(--osdk-surface-background-color-default-hover);
 }
 

--- a/packages/cbac-components/src/cbac-picker/base/OverflowItem.module.css
+++ b/packages/cbac-components/src/cbac-picker/base/OverflowItem.module.css
@@ -19,8 +19,7 @@
   align-items: center;
   width: 100%;
   text-align: left;
-  padding: var(--osdk-surface-spacing)
-    calc(var(--osdk-surface-spacing) * 1.5);
+  padding: var(--osdk-surface-spacing) calc(var(--osdk-surface-spacing) * 1.5);
   font-size: var(--osdk-cbac-overflow-button-font-size);
   font-family: inherit;
   cursor: pointer;

--- a/packages/e2e.sandbox.officeassignment/index.html
+++ b/packages/e2e.sandbox.officeassignment/index.html
@@ -4,9 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Office Assignment - OSDK e2e Sandbox</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/packages/e2e.sandbox.officenetwork/index.html
+++ b/packages/e2e.sandbox.officenetwork/index.html
@@ -6,9 +6,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Office Network - OSDK Features Demo</title>
     <!-- IBM Plex Sans & Mono Typography -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/packages/e2e.sandbox.peopleapp/src/App.css
+++ b/packages/e2e.sandbox.peopleapp/src/App.css
@@ -42,5 +42,5 @@
 }
 
 .error {
-  color: #CD4246;
+  color: #cd4246;
 }

--- a/packages/e2e.sandbox.todoapp/src/App.css
+++ b/packages/e2e.sandbox.todoapp/src/App.css
@@ -42,5 +42,5 @@
 }
 
 .error {
-  color: #CD4246;
+  color: #cd4246;
 }

--- a/packages/e2e.sandbox.todoapp/src/index.css
+++ b/packages/e2e.sandbox.todoapp/src/index.css
@@ -1,1 +1,1 @@
-@import 'tailwindcss';
+@import "tailwindcss";

--- a/packages/react-components/src/action-form/BaseForm.module.css
+++ b/packages/react-components/src/action-form/BaseForm.module.css
@@ -45,7 +45,8 @@
   align-items: center;
   padding-block: var(--osdk-form-content-padding-inline);
   padding-inline: var(--osdk-form-content-padding-inline);
-  border-block-start: var(--osdk-surface-border-width) solid var(--osdk-form-footer-border-color);
+  border-block-start: var(--osdk-surface-border-width) solid
+    var(--osdk-form-footer-border-color);
   flex-shrink: 0;
 }
 

--- a/packages/react-components/src/base-components/combobox/Combobox.module.css
+++ b/packages/react-components/src/base-components/combobox/Combobox.module.css
@@ -562,7 +562,10 @@
   }
 
   &[aria-disabled="true"]:hover {
-    color: var(--osdk-combobox-clear-color, var(--osdk-iconography-color-muted));
+    color: var(
+      --osdk-combobox-clear-color,
+      var(--osdk-iconography-color-muted)
+    );
     background-color: transparent;
   }
 }

--- a/packages/react-components/src/base-components/select/Select.module.css
+++ b/packages/react-components/src/base-components/select/Select.module.css
@@ -230,10 +230,7 @@
   display: flex;
   flex-direction: column;
   min-width: var(--anchor-width);
-  max-height: min(
-    var(--osdk-select-popup-max-height),
-    var(--available-height)
-  );
+  max-height: min(var(--osdk-select-popup-max-height), var(--available-height));
   overflow-y: auto;
   padding: calc(var(--osdk-select-spacing, var(--osdk-surface-spacing)) * 1.5);
   border-radius: var(

--- a/packages/react-components/src/base-components/switch/Switch.module.css
+++ b/packages/react-components/src/base-components/switch/Switch.module.css
@@ -41,30 +41,52 @@
   border-radius: var(--osdk-switch-border-radius, 9999px);
   position: relative;
   border: none;
-  transition: background-color var(--osdk-switch-transition-duration, var(--osdk-emphasis-transition-duration))
+  transition: background-color
+    var(
+      --osdk-switch-transition-duration,
+      var(--osdk-emphasis-transition-duration)
+    )
     var(--osdk-switch-transition-ease, var(--osdk-emphasis-ease-default));
 
   &[data-unchecked] {
-    background-color: var(--osdk-switch-track-bg, var(--osdk-intent-default-rest));
+    background-color: var(
+      --osdk-switch-track-bg,
+      var(--osdk-intent-default-rest)
+    );
 
     &:hover {
-      background-color: var(--osdk-switch-track-bg-hover, var(--osdk-intent-default-hover));
+      background-color: var(
+        --osdk-switch-track-bg-hover,
+        var(--osdk-intent-default-hover)
+      );
     }
 
     &:active {
-      background-color: var(--osdk-switch-track-bg-active, var(--osdk-intent-default-active));
+      background-color: var(
+        --osdk-switch-track-bg-active,
+        var(--osdk-intent-default-active)
+      );
     }
   }
 
   &[data-checked] {
-    background-color: var(--osdk-switch-track-bg-checked, var(--osdk-intent-primary-rest));
+    background-color: var(
+      --osdk-switch-track-bg-checked,
+      var(--osdk-intent-primary-rest)
+    );
 
     &:hover {
-      background-color: var(--osdk-switch-track-bg-checked-hover, var(--osdk-intent-primary-hover));
+      background-color: var(
+        --osdk-switch-track-bg-checked-hover,
+        var(--osdk-intent-primary-hover)
+      );
     }
 
     &:active {
-      background-color: var(--osdk-switch-track-bg-checked-active, var(--osdk-intent-primary-active));
+      background-color: var(
+        --osdk-switch-track-bg-checked-active,
+        var(--osdk-intent-primary-active)
+      );
     }
   }
 
@@ -74,9 +96,12 @@
   }
 
   &:focus-visible {
-    outline: var(--osdk-switch-focus-width, var(--osdk-emphasis-focus-width)) solid
-      var(--osdk-switch-focus-color, var(--osdk-emphasis-focus-color));
-    outline-offset: var(--osdk-switch-focus-offset, var(--osdk-emphasis-focus-offset));
+    outline: var(--osdk-switch-focus-width, var(--osdk-emphasis-focus-width))
+      solid var(--osdk-switch-focus-color, var(--osdk-emphasis-focus-color));
+    outline-offset: var(
+      --osdk-switch-focus-offset,
+      var(--osdk-emphasis-focus-offset)
+    );
   }
 }
 
@@ -89,7 +114,11 @@
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  transition: left var(--osdk-switch-transition-duration, var(--osdk-emphasis-transition-duration))
+  transition: left
+    var(
+      --osdk-switch-transition-duration,
+      var(--osdk-emphasis-transition-duration)
+    )
     var(--osdk-switch-transition-ease, var(--osdk-emphasis-ease-default));
 
   &[data-unchecked] {
@@ -97,6 +126,9 @@
   }
 
   &[data-checked] {
-    left: calc(var(--osdk-switch-track-width) - var(--osdk-switch-thumb-size) - var(--osdk-switch-thumb-offset));
+    left: calc(
+      var(--osdk-switch-track-width) - var(--osdk-switch-thumb-size) -
+        var(--osdk-switch-thumb-offset)
+    );
   }
 }

--- a/packages/react-components/src/cbac-picker/base/MarkingButton.module.css
+++ b/packages/react-components/src/cbac-picker/base/MarkingButton.module.css
@@ -31,7 +31,9 @@
   background-color: var(--osdk-cbac-marking-button-bg-default, transparent);
 }
 
-.markingButton:hover:not(:disabled):not([aria-disabled="true"]):not(.disallowed):not(.impliedDisallowed):not(.selected):not(.implied) {
+.markingButton:hover:not(:disabled):not([aria-disabled="true"]):not(
+    .disallowed
+  ):not(.impliedDisallowed):not(.selected):not(.implied) {
   background-color: var(--osdk-surface-background-color-default-hover);
 }
 

--- a/packages/react-components/src/cbac-picker/base/OverflowItem.module.css
+++ b/packages/react-components/src/cbac-picker/base/OverflowItem.module.css
@@ -19,8 +19,7 @@
   align-items: center;
   width: 100%;
   text-align: left;
-  padding: var(--osdk-surface-spacing)
-    calc(var(--osdk-surface-spacing) * 1.5);
+  padding: var(--osdk-surface-spacing) calc(var(--osdk-surface-spacing) * 1.5);
   font-size: var(--osdk-cbac-overflow-button-font-size);
   font-family: inherit;
   cursor: pointer;

--- a/packages/react-components/src/excel-viewer/BaseExcelViewer.module.css
+++ b/packages/react-components/src/excel-viewer/BaseExcelViewer.module.css
@@ -83,14 +83,16 @@
   background-color: var(--osdk-excel-viewer-tab-bg);
   flex-shrink: 0;
   overflow-x: auto;
-  padding: var(--osdk-excel-viewer-tab-bar-padding) var(--osdk-excel-viewer-tab-bar-padding) 0;
+  padding: var(--osdk-excel-viewer-tab-bar-padding)
+    var(--osdk-excel-viewer-tab-bar-padding) 0;
 }
 
 .tab {
   padding: var(--osdk-excel-viewer-tab-padding);
   border: var(--osdk-excel-viewer-tab-border);
   border-bottom: none;
-  border-radius: var(--osdk-excel-viewer-tab-border-radius) var(--osdk-excel-viewer-tab-border-radius) 0 0;
+  border-radius: var(--osdk-excel-viewer-tab-border-radius)
+    var(--osdk-excel-viewer-tab-border-radius) 0 0;
   background-color: var(--osdk-excel-viewer-tab-bg);
   font-family: var(--osdk-typography-family-default);
   font-size: var(--osdk-typography-size-body-x-small);

--- a/packages/react-components/src/filter-list/base/AddFilterPopover.module.css
+++ b/packages/react-components/src/filter-list/base/AddFilterPopover.module.css
@@ -39,7 +39,8 @@
   }
 
   &:focus-visible {
-    outline: var(--osdk-filter-input-focus-outline-width) solid var(--osdk-filter-input-focus-outline-color);
+    outline: var(--osdk-filter-input-focus-outline-width) solid
+      var(--osdk-filter-input-focus-outline-color);
     outline-offset: var(--osdk-filter-input-focus-outline-offset);
   }
 

--- a/packages/react-components/src/filter-list/base/FilterList.module.css
+++ b/packages/react-components/src/filter-list/base/FilterList.module.css
@@ -79,7 +79,8 @@
   }
 
   &:focus-visible {
-    outline: var(--osdk-filter-input-focus-outline-width) solid var(--osdk-filter-input-focus-outline-color);
+    outline: var(--osdk-filter-input-focus-outline-width) solid
+      var(--osdk-filter-input-focus-outline-color);
     outline-offset: var(--osdk-filter-input-focus-outline-offset);
   }
 
@@ -135,7 +136,8 @@
   }
 
   &:focus-visible {
-    outline: var(--osdk-filter-input-focus-outline-width) solid var(--osdk-filter-input-focus-outline-color);
+    outline: var(--osdk-filter-input-focus-outline-width) solid
+      var(--osdk-filter-input-focus-outline-color);
     outline-offset: var(--osdk-filter-input-focus-outline-offset);
   }
 

--- a/packages/react-components/src/filter-list/base/FilterListHeader.module.css
+++ b/packages/react-components/src/filter-list/base/FilterListHeader.module.css
@@ -84,7 +84,8 @@
   }
 
   &:focus-visible {
-    outline: var(--osdk-filter-input-focus-outline-width) solid var(--osdk-filter-input-focus-outline-color);
+    outline: var(--osdk-filter-input-focus-outline-width) solid
+      var(--osdk-filter-input-focus-outline-color);
     outline-offset: var(--osdk-filter-input-focus-outline-offset);
   }
 
@@ -118,7 +119,8 @@
   }
 
   &:focus-visible {
-    outline: var(--osdk-filter-input-focus-outline-width) solid var(--osdk-filter-input-focus-outline-color);
+    outline: var(--osdk-filter-input-focus-outline-width) solid
+      var(--osdk-filter-input-focus-outline-color);
     outline-offset: var(--osdk-filter-input-focus-outline-offset);
   }
 

--- a/packages/react-components/src/filter-list/base/FilterPopover.module.css
+++ b/packages/react-components/src/filter-list/base/FilterPopover.module.css
@@ -105,9 +105,10 @@
   top: auto;
   bottom: calc(
     (
-        var(--osdk-filter-popover-trigger-min-height)
-          - var(--osdk-filter-popover-remove-size)
-      ) / 2
+        var(--osdk-filter-popover-trigger-min-height) -
+          var(--osdk-filter-popover-remove-size)
+      ) /
+      2
   );
   transform: none;
 }

--- a/packages/react-components/src/filter-list/base/inputs/ContainsTextInput.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/ContainsTextInput.module.css
@@ -30,7 +30,8 @@
 
   &:focus-within {
     border-color: var(--osdk-filter-input-focus-border);
-    outline: var(--osdk-filter-input-focus-outline-width) solid var(--osdk-filter-input-focus-outline-color);
+    outline: var(--osdk-filter-input-focus-outline-width) solid
+      var(--osdk-filter-input-focus-outline-color);
     outline-offset: var(--osdk-filter-input-focus-outline-offset);
   }
 
@@ -81,7 +82,8 @@
   }
 
   &:focus-visible {
-    outline: var(--osdk-filter-input-focus-outline-width) solid var(--osdk-filter-input-focus-outline-color);
+    outline: var(--osdk-filter-input-focus-outline-width) solid
+      var(--osdk-filter-input-focus-outline-color);
     outline-offset: var(--osdk-filter-input-focus-outline-offset);
   }
 

--- a/packages/react-components/src/filter-list/base/inputs/ListogramInput.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/ListogramInput.module.css
@@ -119,13 +119,19 @@
   display: block;
   height: 100%;
   width: calc(var(--osdk-filter-listogram-bar-fill-scale, 0) * 100%);
-  background: var(--osdk-filter-listogram-row-bar-color, var(--osdk-filter-listogram-bar-color));
+  background: var(
+    --osdk-filter-listogram-row-bar-color,
+    var(--osdk-filter-listogram-bar-color)
+  );
   border-radius: var(--osdk-filter-listogram-bar-border-radius);
   transition: width var(--osdk-filter-listogram-bar-fill-transition);
 }
 
 .row[aria-pressed="true"] .barFill {
-  background: var(--osdk-filter-listogram-row-bar-color, var(--osdk-filter-listogram-selected-color));
+  background: var(
+    --osdk-filter-listogram-row-bar-color,
+    var(--osdk-filter-listogram-selected-color)
+  );
 }
 
 .viewAllButton {

--- a/packages/react-components/src/filter-list/base/inputs/MultiDateInput.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/MultiDateInput.module.css
@@ -50,7 +50,8 @@
 
   &:focus {
     border-color: var(--osdk-filter-input-focus-border);
-    outline: var(--osdk-filter-input-focus-outline-width) solid var(--osdk-filter-input-focus-outline-color);
+    outline: var(--osdk-filter-input-focus-outline-width) solid
+      var(--osdk-filter-input-focus-outline-color);
     outline-offset: var(--osdk-filter-input-focus-outline-offset);
   }
 }

--- a/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/MultiSelectInput.module.css
@@ -69,7 +69,8 @@
 
   &:focus {
     border-color: var(--osdk-filter-input-focus-border);
-    outline: var(--osdk-filter-input-focus-outline-width) solid var(--osdk-filter-input-focus-outline-color);
+    outline: var(--osdk-filter-input-focus-outline-width) solid
+      var(--osdk-filter-input-focus-outline-color);
     outline-offset: var(--osdk-filter-input-focus-outline-offset);
   }
 

--- a/packages/react-components/src/filter-list/base/inputs/NullValueWrapper.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/NullValueWrapper.module.css
@@ -21,10 +21,7 @@
 }
 
 .noValueLabel {
-  color: var(
-    --osdk-filter-null-label-color,
-    var(--osdk-filter-no-value-color)
-  );
+  color: var(--osdk-filter-null-label-color, var(--osdk-filter-no-value-color));
   font-family: var(--osdk-filter-null-label-font-family, inherit);
   font-size: var(--osdk-filter-null-label-font-size, inherit);
   line-height: var(--osdk-filter-null-label-line-height, inherit);

--- a/packages/react-components/src/filter-list/base/inputs/RangeInput.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/RangeInput.module.css
@@ -49,8 +49,7 @@
   color: var(--osdk-intent-primary-rest);
   background: transparent;
   border: none;
-  padding: calc(var(--osdk-surface-spacing) * 0.5)
-    var(--osdk-surface-spacing);
+  padding: calc(var(--osdk-surface-spacing) * 0.5) var(--osdk-surface-spacing);
   cursor: pointer;
   border-radius: var(--osdk-surface-border-radius);
 
@@ -70,8 +69,7 @@
   display: inline-block;
   background: var(--osdk-typography-color-default-rest);
   color: var(--osdk-background-primary);
-  padding: calc(var(--osdk-surface-spacing) * 0.5)
-    var(--osdk-surface-spacing);
+  padding: calc(var(--osdk-surface-spacing) * 0.5) var(--osdk-surface-spacing);
   border-radius: var(--osdk-surface-border-radius);
   font-family: var(--osdk-filter-range-label-font-family);
   font-size: var(--osdk-typography-size-body-small);
@@ -92,7 +90,8 @@
 .axisLines,
 .bars,
 .countLabels,
-.xTicks {}
+.xTicks {
+}
 
 .selectionBand {
   fill: var(
@@ -185,7 +184,8 @@
 
   &:focus {
     border-color: var(--osdk-filter-input-focus-border);
-    outline: var(--osdk-filter-input-focus-outline-width) solid var(--osdk-filter-input-focus-outline-color);
+    outline: var(--osdk-filter-input-focus-outline-width) solid
+      var(--osdk-filter-input-focus-outline-color);
     outline-offset: var(--osdk-filter-input-focus-outline-offset);
   }
 

--- a/packages/react-components/src/filter-list/base/inputs/SingleDateInput.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/SingleDateInput.module.css
@@ -37,7 +37,8 @@
 
   &:focus {
     border-color: var(--osdk-filter-input-focus-border);
-    outline: var(--osdk-filter-input-focus-outline-width) solid var(--osdk-filter-input-focus-outline-color);
+    outline: var(--osdk-filter-input-focus-outline-width) solid
+      var(--osdk-filter-input-focus-outline-color);
     outline-offset: var(--osdk-filter-input-focus-outline-offset);
   }
 }

--- a/packages/react-components/src/filter-list/base/inputs/TimelineInput.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/TimelineInput.module.css
@@ -69,7 +69,8 @@
 
   &:focus {
     border-color: var(--osdk-filter-input-focus-border);
-    outline: var(--osdk-filter-input-focus-outline-width) solid var(--osdk-filter-input-focus-outline-color);
+    outline: var(--osdk-filter-input-focus-outline-width) solid
+      var(--osdk-filter-input-focus-outline-color);
     outline-offset: var(--osdk-filter-input-focus-outline-offset);
   }
 }

--- a/packages/react-components/src/filter-list/base/inputs/shared.module.css
+++ b/packages/react-components/src/filter-list/base/inputs/shared.module.css
@@ -80,7 +80,8 @@
   }
 
   &:focus-visible {
-    outline: var(--osdk-filter-input-focus-outline-width) solid var(--osdk-filter-input-focus-outline-color);
+    outline: var(--osdk-filter-input-focus-outline-width) solid
+      var(--osdk-filter-input-focus-outline-color);
     outline-offset: var(--osdk-filter-input-focus-outline-offset);
   }
 

--- a/packages/react-components/src/object-table/MultiColumnSortDialog.module.css
+++ b/packages/react-components/src/object-table/MultiColumnSortDialog.module.css
@@ -118,7 +118,6 @@
   text-align: left;
 }
 
-
 .truncate {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/packages/react-components/src/object-table/TableRow.module.css
+++ b/packages/react-components/src/object-table/TableRow.module.css
@@ -38,16 +38,20 @@
   &:hover {
     z-index: 3;
     background-color: var(--osdk-table-row-bg-hover);
-    border-top: var(--osdk-table-border-width) solid var(--osdk-table-row-border-color-hover);
-    border-bottom: var(--osdk-table-border-width) solid var(--osdk-table-row-border-color-hover);
+    border-top: var(--osdk-table-border-width) solid
+      var(--osdk-table-row-border-color-hover);
+    border-bottom: var(--osdk-table-border-width) solid
+      var(--osdk-table-row-border-color-hover);
   }
 
   &[data-selected="true"],
   &[data-focused="true"] {
     z-index: 2;
     background-color: var(--osdk-table-row-bg-active);
-    border-top: var(--osdk-table-border-width) solid var(--osdk-table-row-border-color-active);
-    border-bottom: var(--osdk-table-border-width) solid var(--osdk-table-row-border-color-active);
+    border-top: var(--osdk-table-border-width) solid
+      var(--osdk-table-row-border-color-active);
+    border-bottom: var(--osdk-table-border-width) solid
+      var(--osdk-table-row-border-color-active);
   }
 
   &[data-selected="true"] + &[data-selected="true"] {

--- a/packages/react-components/src/pdf-viewer/components/PdfViewerOutlineSidebar.module.css
+++ b/packages/react-components/src/pdf-viewer/components/PdfViewerOutlineSidebar.module.css
@@ -8,7 +8,6 @@
   overflow: hidden;
 }
 
-
 .scrollContainer {
   flex: 1;
   overflow-y: auto;
@@ -36,7 +35,10 @@
 }
 
 .outlineItem:hover {
-  background-color: var(--osdk-pdf-viewer-outline-item-hover-bg, rgba(0, 0, 0, 0.06));
+  background-color: var(
+    --osdk-pdf-viewer-outline-item-hover-bg,
+    rgba(0, 0, 0, 0.06)
+  );
 }
 
 .outlineItem:focus-visible {
@@ -45,8 +47,14 @@
 }
 
 .outlineItemActive {
-  background-color: var(--osdk-pdf-viewer-outline-item-active-bg, rgba(45, 114, 210, 0.1));
-  color: var(--osdk-pdf-viewer-outline-item-active-color, var(--osdk-intent-primary-rest));
+  background-color: var(
+    --osdk-pdf-viewer-outline-item-active-bg,
+    rgba(45, 114, 210, 0.1)
+  );
+  color: var(
+    --osdk-pdf-viewer-outline-item-active-color,
+    var(--osdk-intent-primary-rest)
+  );
   font-weight: var(--osdk-typography-weight-bold);
 }
 
@@ -86,4 +94,3 @@
   font-size: var(--osdk-typography-size-body-small);
   color: var(--osdk-typography-color-muted);
 }
-

--- a/packages/react-components/src/pdf-viewer/components/PdfViewerSidebar.module.css
+++ b/packages/react-components/src/pdf-viewer/components/PdfViewerSidebar.module.css
@@ -8,7 +8,6 @@
   overflow: hidden;
 }
 
-
 .scrollContainer {
   flex: 1;
   overflow-y: auto;

--- a/packages/react-components/src/pdf-viewer/components/PdfViewerSidebarHeader.module.css
+++ b/packages/react-components/src/pdf-viewer/components/PdfViewerSidebarHeader.module.css
@@ -61,10 +61,19 @@
 }
 
 .modeButton[data-pressed] {
-  background-color: var(--osdk-pdf-viewer-outline-item-active-bg, rgba(45, 114, 210, 0.1));
-  color: var(--osdk-pdf-viewer-outline-item-active-color, var(--osdk-intent-primary-rest));
+  background-color: var(
+    --osdk-pdf-viewer-outline-item-active-bg,
+    rgba(45, 114, 210, 0.1)
+  );
+  color: var(
+    --osdk-pdf-viewer-outline-item-active-color,
+    var(--osdk-intent-primary-rest)
+  );
 }
 
 .modeButton[data-pressed]:hover {
-  background-color: var(--osdk-pdf-viewer-outline-item-active-bg, rgba(45, 114, 210, 0.1));
+  background-color: var(
+    --osdk-pdf-viewer-outline-item-active-bg,
+    rgba(45, 114, 210, 0.1)
+  );
 }

--- a/packages/react-components/src/shared/ErrorBoundary.module.css
+++ b/packages/react-components/src/shared/ErrorBoundary.module.css
@@ -21,18 +21,25 @@
   gap: var(--osdk-error-boundary-gap, 8px);
   padding: var(--osdk-error-boundary-padding, 8px);
   border-radius: var(--osdk-error-boundary-border-radius, 4px);
-  background-color: var(--osdk-error-boundary-bg, color-mix(in srgb, var(--osdk-intent-danger-rest, #c23030) 5%, transparent));
+  background-color: var(
+    --osdk-error-boundary-bg,
+    color-mix(in srgb, var(--osdk-intent-danger-rest, #c23030) 5%, transparent)
+  );
 }
 
 .errorMessage {
   margin: 0;
   font-size: var(--osdk-error-boundary-font-size, 13px);
-  color: var(--osdk-error-boundary-text-color, var(--osdk-intent-danger-rest, #c23030));
+  color: var(
+    --osdk-error-boundary-text-color,
+    var(--osdk-intent-danger-rest, #c23030)
+  );
 }
 
 .retryButton {
   padding: var(--osdk-error-boundary-button-padding, 4px 8px);
-  border: var(--osdk-surface-border-width, 1px) solid var(--osdk-error-boundary-button-border-color, currentColor);
+  border: var(--osdk-surface-border-width, 1px) solid
+    var(--osdk-error-boundary-button-border-color, currentColor);
   border-radius: var(--osdk-error-boundary-button-border-radius, 3px);
   background: transparent;
   font-size: var(--osdk-error-boundary-button-font-size, 12px);
@@ -41,11 +48,15 @@
   transition: background-color var(--osdk-filter-input-transition, 150ms ease);
 
   &:hover {
-    background-color: var(--osdk-error-boundary-button-hover-bg, color-mix(in srgb, currentColor 5%, transparent));
+    background-color: var(
+      --osdk-error-boundary-button-hover-bg,
+      color-mix(in srgb, currentColor 5%, transparent)
+    );
   }
 
   &:focus-visible {
-    outline: var(--osdk-filter-input-focus-outline-width, 2px) solid var(--osdk-filter-input-focus-outline-color, rgba(45, 114, 210, 0.6));
+    outline: var(--osdk-filter-input-focus-outline-width, 2px) solid
+      var(--osdk-filter-input-focus-outline-color, rgba(45, 114, 210, 0.6));
     outline-offset: var(--osdk-filter-input-focus-outline-offset, 2px);
   }
 

--- a/packages/react-components/src/shared/calendar/DateCalendar.module.css
+++ b/packages/react-components/src/shared/calendar/DateCalendar.module.css
@@ -239,7 +239,6 @@
   white-space: nowrap;
 }
 
-
 /* Caption dropdowns container */
 .calendarCaptionDropdowns {
   display: flex;
@@ -268,7 +267,6 @@
     outline-offset: 1px;
   }
 }
-
 
 .calendarTimeFooter {
   display: flex;

--- a/packages/react-components/src/tokens/base-tokens/base.css
+++ b/packages/react-components/src/tokens/base-tokens/base.css
@@ -220,4 +220,3 @@
 :focus-visible {
   outline: none;
 }
-

--- a/packages/react-components/src/tokens/base-tokens/blueprint-design-tokens.css
+++ b/packages/react-components/src/tokens/base-tokens/blueprint-design-tokens.css
@@ -5,269 +5,377 @@
  * Original: https://github.com/palantir/blueprint/blob/develop/packages/core/lib/css/blueprint-design-tokens.css
  */
 @charset "UTF-8";
-:root{
-  --bp-emphasis-transition-duration:100ms;
-  --bp-emphasis-ease-default:cubic-bezier(0.4, 1, 0.75, 0.9);
-  --bp-emphasis-ease-bounce:cubic-bezier(0.54, 1.12, 0.38, 1.11);
-  --bp-emphasis-focus-color:#2d72d2;
-  --bp-emphasis-focus-width:2px;
-  --bp-emphasis-focus-offset:2px;
-  --bp-emphasis-motion-reduced:0;
-  --bp-intent-default-rest:#5f6b7c;
-  --bp-intent-default-hover:#404854;
-  --bp-intent-default-active:#383e47;
-  --bp-intent-default-disabled:#8f99a8;
-  --bp-intent-default-foreground:#ffffff;
-  --bp-intent-primary-rest:#2d72d2;
-  --bp-intent-primary-hover:#215db0;
-  --bp-intent-primary-active:#184a90;
-  --bp-intent-primary-disabled:#4c90f0;
-  --bp-intent-primary-foreground:#ffffff;
-  --bp-intent-success-rest:#238551;
-  --bp-intent-success-hover:#1c6e42;
-  --bp-intent-success-active:#165a36;
-  --bp-intent-success-disabled:#32a467;
-  --bp-intent-success-foreground:#ffffff;
-  --bp-intent-warning-rest:#c87619;
-  --bp-intent-warning-hover:#935610;
-  --bp-intent-warning-active:#77450d;
-  --bp-intent-warning-disabled:#ec9a3c;
-  --bp-intent-warning-foreground:#111418;
-  --bp-intent-danger-rest:#cd4246;
-  --bp-intent-danger-hover:#ac2f33;
-  --bp-intent-danger-active:#8e292c;
-  --bp-intent-danger-disabled:#e76a6e;
-  --bp-intent-danger-foreground:#ffffff;
-  --bp-palette-black:#111418;
-  --bp-palette-white:#ffffff;
-  --bp-palette-dark-gray-1:#1c2127;
-  --bp-palette-dark-gray-2:#252a31;
-  --bp-palette-dark-gray-3:#2f343c;
-  --bp-palette-dark-gray-4:#383e47;
-  --bp-palette-dark-gray-5:#404854;
-  --bp-palette-gray-1:#5f6b7c;
-  --bp-palette-gray-2:#738091;
-  --bp-palette-gray-3:#8f99a8;
-  --bp-palette-gray-4:#abb3bf;
-  --bp-palette-gray-5:#c5cbd3;
-  --bp-palette-light-gray-1:#d3d8de;
-  --bp-palette-light-gray-2:#dce0e5;
-  --bp-palette-light-gray-3:#e5e8eb;
-  --bp-palette-light-gray-4:#edeff2;
-  --bp-palette-light-gray-5:#f6f7f9;
-  --bp-palette-blue-1:#184a90;
-  --bp-palette-blue-2:#215db0;
-  --bp-palette-blue-3:#2d72d2;
-  --bp-palette-blue-4:#4c90f0;
-  --bp-palette-blue-5:#8abbff;
-  --bp-palette-green-1:#165a36;
-  --bp-palette-green-2:#1c6e42;
-  --bp-palette-green-3:#238551;
-  --bp-palette-green-4:#32a467;
-  --bp-palette-green-5:#72ca9b;
-  --bp-palette-orange-1:#77450d;
-  --bp-palette-orange-2:#935610;
-  --bp-palette-orange-3:#c87619;
-  --bp-palette-orange-4:#ec9a3c;
-  --bp-palette-orange-5:#fbb360;
-  --bp-palette-red-1:#8e292c;
-  --bp-palette-red-2:#ac2f33;
-  --bp-palette-red-3:#cd4246;
-  --bp-palette-red-4:#e76a6e;
-  --bp-palette-red-5:#fa999c;
-  --bp-palette-vermilion-1:#96290d;
-  --bp-palette-vermilion-2:#b83211;
-  --bp-palette-vermilion-3:#d33d17;
-  --bp-palette-vermilion-4:#eb6847;
-  --bp-palette-vermilion-5:#ff9980;
-  --bp-palette-rose-1:#a82255;
-  --bp-palette-rose-2:#c22762;
-  --bp-palette-rose-3:#db2c6f;
-  --bp-palette-rose-4:#f5498b;
-  --bp-palette-rose-5:#ff66a1;
-  --bp-palette-violet-1:#5c255c;
-  --bp-palette-violet-2:#7c327c;
-  --bp-palette-violet-3:#9d3f9d;
-  --bp-palette-violet-4:#bd6bbd;
-  --bp-palette-violet-5:#d69fd6;
-  --bp-palette-indigo-1:#5642a6;
-  --bp-palette-indigo-2:#634dbf;
-  --bp-palette-indigo-3:#7961db;
-  --bp-palette-indigo-4:#9881f3;
-  --bp-palette-indigo-5:#bdadff;
-  --bp-palette-cerulean-1:#0c5174;
-  --bp-palette-cerulean-2:#0f6894;
-  --bp-palette-cerulean-3:#147eb3;
-  --bp-palette-cerulean-4:#3fa6da;
-  --bp-palette-cerulean-5:#68c1ee;
-  --bp-palette-turquoise-1:#004d46;
-  --bp-palette-turquoise-2:#007067;
-  --bp-palette-turquoise-3:#00a396;
-  --bp-palette-turquoise-4:#13c9ba;
-  --bp-palette-turquoise-5:#7ae1d8;
-  --bp-palette-forest-1:#1d7324;
-  --bp-palette-forest-2:#238c2c;
-  --bp-palette-forest-3:#29a634;
-  --bp-palette-forest-4:#43bf4d;
-  --bp-palette-forest-5:#62d96b;
-  --bp-palette-lime-1:#43501b;
-  --bp-palette-lime-2:#5a701a;
-  --bp-palette-lime-3:#8eb125;
-  --bp-palette-lime-4:#b6d94c;
-  --bp-palette-lime-5:#d4f17e;
-  --bp-palette-gold-1:#5c4405;
-  --bp-palette-gold-2:#866103;
-  --bp-palette-gold-3:#d1980b;
-  --bp-palette-gold-4:#f0b726;
-  --bp-palette-gold-5:#fbd065;
-  --bp-palette-sepia-1:#5e4123;
-  --bp-palette-sepia-2:#7a542e;
-  --bp-palette-sepia-3:#946638;
-  --bp-palette-sepia-4:#af855a;
-  --bp-palette-sepia-5:#d0b090;
-  --bp-surface-border-color-default:#5f6b7c1f;
-  --bp-surface-border-color-strong:#5f6b7c40;
-  --bp-surface-border-width:1px;
-  --bp-surface-border-radius:4px;
-  --bp-surface-shadow-0:0px 0px 0px 1px rgba(0, 0, 0, 0.15), 0px 0px 5px 0px rgba(0, 0, 0, 0.02);
-  --bp-surface-shadow-1:0px 0px 0px 1px rgba(0, 0, 0, 0.1), 0px 1px 3px 0px rgba(0, 0, 0, 0.1), 0px 1px 2px -1px rgba(0, 0, 0, 0.1);
-  --bp-surface-shadow-2:0px 0px 0px 1px rgba(0, 0, 0, 0.1), 0px 4px 6px -4px rgba(0, 0, 0, 0.1), 0px 10px 15px -3px rgba(0, 0, 0, 0.1);
-  --bp-surface-shadow-3:0px 0px 0px 1px rgba(0, 0, 0, 0.1), 0px 20px 25px -5px rgba(0, 0, 0, 0.1), 0px 10px 15px -3px rgba(0, 0, 0, 0.1);
-  --bp-surface-shadow-4:0px 0px 0px 1px rgba(0, 0, 0, 0.1), 0px 25px 50px -12px rgba(0, 0, 0, 0.3);
-  --bp-surface-spacing:4px;
-  --bp-surface-z-index-0:0;
-  --bp-surface-z-index-1:10;
-  --bp-surface-z-index-2:20;
-  --bp-surface-z-index-3:30;
-  --bp-surface-z-index-4:40;
-  --bp-surface-color-code:#ffffffb3;
-  --bp-surface-layer-opacity:0.05;
-  --bp-surface-layer-color-default:#5f6b7c0d;
-  --bp-surface-layer-color-primary:#2d72d20d;
-  --bp-surface-layer-color-success:#2385510d;
-  --bp-surface-layer-color-warning:#c876190d;
-  --bp-surface-layer-color-danger:#cd42460d;
-  --bp-surface-layer-default:linear-gradient(#5f6b7c0d 0 0);
-  --bp-surface-layer-primary:linear-gradient(#2d72d20d 0 0);
-  --bp-surface-layer-success:linear-gradient(#2385510d 0 0);
-  --bp-surface-layer-warning:linear-gradient(#c876190d 0 0);
-  --bp-surface-layer-danger:linear-gradient(#cd42460d 0 0);
-  --bp-surface-background-color-default-rest:#ffffff;
-  --bp-surface-background-color-default-hover:#f6f7f9;
-  --bp-surface-background-color-default-active:#edeff2;
-  --bp-surface-background-color-default-disabled:#ffffff;
-  --bp-surface-background-color-primary-rest:#2d72d2;
-  --bp-surface-background-color-primary-hover:#215db0;
-  --bp-surface-background-color-primary-active:#184a90;
-  --bp-surface-background-color-primary-disabled:#4c90f0;
-  --bp-surface-background-color-success-rest:#238551;
-  --bp-surface-background-color-success-hover:#1c6e42;
-  --bp-surface-background-color-success-active:#165a36;
-  --bp-surface-background-color-success-disabled:#32a467;
-  --bp-surface-background-color-warning-rest:#c87619;
-  --bp-surface-background-color-warning-hover:#935610;
-  --bp-surface-background-color-warning-active:#77450d;
-  --bp-surface-background-color-warning-disabled:#ec9a3c;
-  --bp-surface-background-color-danger-rest:#cd4246;
-  --bp-surface-background-color-danger-hover:#ac2f33;
-  --bp-surface-background-color-danger-active:#8e292c;
-  --bp-surface-background-color-danger-disabled:#e76a6e;
-  --bp-typography-family-default:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", blueprint-icons-16, sans-serif;
-  --bp-typography-family-mono:monospace;
-  --bp-typography-size-body-x-small:10px;
-  --bp-typography-size-body-small:12px;
-  --bp-typography-size-body-medium:14px;
-  --bp-typography-size-body-large:16px;
-  --bp-typography-size-heading-small:16px;
-  --bp-typography-size-heading-medium:20px;
-  --bp-typography-size-heading-large:24px;
-  --bp-typography-size-heading-x-large:28px;
-  --bp-typography-size-heading-display:46px;
-  --bp-typography-size-code-small:12px;
-  --bp-typography-size-code-medium:13px;
-  --bp-typography-size-code-large:14px;
-  --bp-typography-weight-default:400;
-  --bp-typography-weight-bold:600;
-  --bp-typography-line-height-default:1.28581;
-  --bp-typography-line-height-large:1.5;
-  --bp-typography-color-muted:#5f6b7c;
-  --bp-typography-color-default-rest:#1c2127;
-  --bp-typography-color-default-hover:#111418;
-  --bp-typography-color-default-active:#252a31;
-  --bp-typography-color-default-disabled:#8f99a8;
-  --bp-typography-color-primary-rest:#2d72d2;
-  --bp-typography-color-primary-hover:#215db0;
-  --bp-typography-color-primary-active:#184a90;
-  --bp-typography-color-primary-disabled:#4c90f0;
-  --bp-typography-color-success-rest:#238551;
-  --bp-typography-color-success-hover:#1c6e42;
-  --bp-typography-color-success-active:#165a36;
-  --bp-typography-color-success-disabled:#32a467;
-  --bp-typography-color-warning-rest:#c87619;
-  --bp-typography-color-warning-hover:#935610;
-  --bp-typography-color-warning-active:#77450d;
-  --bp-typography-color-warning-disabled:#ec9a3c;
-  --bp-typography-color-danger-rest:#cd4246;
-  --bp-typography-color-danger-hover:#ac2f33;
-  --bp-typography-color-danger-active:#8e292c;
-  --bp-typography-color-danger-disabled:#e76a6e;
+:root {
+  --bp-emphasis-transition-duration: 100ms;
+  --bp-emphasis-ease-default: cubic-bezier(0.4, 1, 0.75, 0.9);
+  --bp-emphasis-ease-bounce: cubic-bezier(0.54, 1.12, 0.38, 1.11);
+  --bp-emphasis-focus-color: #2d72d2;
+  --bp-emphasis-focus-width: 2px;
+  --bp-emphasis-focus-offset: 2px;
+  --bp-emphasis-motion-reduced: 0;
+  --bp-intent-default-rest: #5f6b7c;
+  --bp-intent-default-hover: #404854;
+  --bp-intent-default-active: #383e47;
+  --bp-intent-default-disabled: #8f99a8;
+  --bp-intent-default-foreground: #ffffff;
+  --bp-intent-primary-rest: #2d72d2;
+  --bp-intent-primary-hover: #215db0;
+  --bp-intent-primary-active: #184a90;
+  --bp-intent-primary-disabled: #4c90f0;
+  --bp-intent-primary-foreground: #ffffff;
+  --bp-intent-success-rest: #238551;
+  --bp-intent-success-hover: #1c6e42;
+  --bp-intent-success-active: #165a36;
+  --bp-intent-success-disabled: #32a467;
+  --bp-intent-success-foreground: #ffffff;
+  --bp-intent-warning-rest: #c87619;
+  --bp-intent-warning-hover: #935610;
+  --bp-intent-warning-active: #77450d;
+  --bp-intent-warning-disabled: #ec9a3c;
+  --bp-intent-warning-foreground: #111418;
+  --bp-intent-danger-rest: #cd4246;
+  --bp-intent-danger-hover: #ac2f33;
+  --bp-intent-danger-active: #8e292c;
+  --bp-intent-danger-disabled: #e76a6e;
+  --bp-intent-danger-foreground: #ffffff;
+  --bp-palette-black: #111418;
+  --bp-palette-white: #ffffff;
+  --bp-palette-dark-gray-1: #1c2127;
+  --bp-palette-dark-gray-2: #252a31;
+  --bp-palette-dark-gray-3: #2f343c;
+  --bp-palette-dark-gray-4: #383e47;
+  --bp-palette-dark-gray-5: #404854;
+  --bp-palette-gray-1: #5f6b7c;
+  --bp-palette-gray-2: #738091;
+  --bp-palette-gray-3: #8f99a8;
+  --bp-palette-gray-4: #abb3bf;
+  --bp-palette-gray-5: #c5cbd3;
+  --bp-palette-light-gray-1: #d3d8de;
+  --bp-palette-light-gray-2: #dce0e5;
+  --bp-palette-light-gray-3: #e5e8eb;
+  --bp-palette-light-gray-4: #edeff2;
+  --bp-palette-light-gray-5: #f6f7f9;
+  --bp-palette-blue-1: #184a90;
+  --bp-palette-blue-2: #215db0;
+  --bp-palette-blue-3: #2d72d2;
+  --bp-palette-blue-4: #4c90f0;
+  --bp-palette-blue-5: #8abbff;
+  --bp-palette-green-1: #165a36;
+  --bp-palette-green-2: #1c6e42;
+  --bp-palette-green-3: #238551;
+  --bp-palette-green-4: #32a467;
+  --bp-palette-green-5: #72ca9b;
+  --bp-palette-orange-1: #77450d;
+  --bp-palette-orange-2: #935610;
+  --bp-palette-orange-3: #c87619;
+  --bp-palette-orange-4: #ec9a3c;
+  --bp-palette-orange-5: #fbb360;
+  --bp-palette-red-1: #8e292c;
+  --bp-palette-red-2: #ac2f33;
+  --bp-palette-red-3: #cd4246;
+  --bp-palette-red-4: #e76a6e;
+  --bp-palette-red-5: #fa999c;
+  --bp-palette-vermilion-1: #96290d;
+  --bp-palette-vermilion-2: #b83211;
+  --bp-palette-vermilion-3: #d33d17;
+  --bp-palette-vermilion-4: #eb6847;
+  --bp-palette-vermilion-5: #ff9980;
+  --bp-palette-rose-1: #a82255;
+  --bp-palette-rose-2: #c22762;
+  --bp-palette-rose-3: #db2c6f;
+  --bp-palette-rose-4: #f5498b;
+  --bp-palette-rose-5: #ff66a1;
+  --bp-palette-violet-1: #5c255c;
+  --bp-palette-violet-2: #7c327c;
+  --bp-palette-violet-3: #9d3f9d;
+  --bp-palette-violet-4: #bd6bbd;
+  --bp-palette-violet-5: #d69fd6;
+  --bp-palette-indigo-1: #5642a6;
+  --bp-palette-indigo-2: #634dbf;
+  --bp-palette-indigo-3: #7961db;
+  --bp-palette-indigo-4: #9881f3;
+  --bp-palette-indigo-5: #bdadff;
+  --bp-palette-cerulean-1: #0c5174;
+  --bp-palette-cerulean-2: #0f6894;
+  --bp-palette-cerulean-3: #147eb3;
+  --bp-palette-cerulean-4: #3fa6da;
+  --bp-palette-cerulean-5: #68c1ee;
+  --bp-palette-turquoise-1: #004d46;
+  --bp-palette-turquoise-2: #007067;
+  --bp-palette-turquoise-3: #00a396;
+  --bp-palette-turquoise-4: #13c9ba;
+  --bp-palette-turquoise-5: #7ae1d8;
+  --bp-palette-forest-1: #1d7324;
+  --bp-palette-forest-2: #238c2c;
+  --bp-palette-forest-3: #29a634;
+  --bp-palette-forest-4: #43bf4d;
+  --bp-palette-forest-5: #62d96b;
+  --bp-palette-lime-1: #43501b;
+  --bp-palette-lime-2: #5a701a;
+  --bp-palette-lime-3: #8eb125;
+  --bp-palette-lime-4: #b6d94c;
+  --bp-palette-lime-5: #d4f17e;
+  --bp-palette-gold-1: #5c4405;
+  --bp-palette-gold-2: #866103;
+  --bp-palette-gold-3: #d1980b;
+  --bp-palette-gold-4: #f0b726;
+  --bp-palette-gold-5: #fbd065;
+  --bp-palette-sepia-1: #5e4123;
+  --bp-palette-sepia-2: #7a542e;
+  --bp-palette-sepia-3: #946638;
+  --bp-palette-sepia-4: #af855a;
+  --bp-palette-sepia-5: #d0b090;
+  --bp-surface-border-color-default: #5f6b7c1f;
+  --bp-surface-border-color-strong: #5f6b7c40;
+  --bp-surface-border-width: 1px;
+  --bp-surface-border-radius: 4px;
+  --bp-surface-shadow-0:
+    0px 0px 0px 1px rgba(0, 0, 0, 0.15), 0px 0px 5px 0px rgba(0, 0, 0, 0.02);
+  --bp-surface-shadow-1:
+    0px 0px 0px 1px rgba(0, 0, 0, 0.1), 0px 1px 3px 0px rgba(0, 0, 0, 0.1),
+    0px 1px 2px -1px rgba(0, 0, 0, 0.1);
+  --bp-surface-shadow-2:
+    0px 0px 0px 1px rgba(0, 0, 0, 0.1), 0px 4px 6px -4px rgba(0, 0, 0, 0.1),
+    0px 10px 15px -3px rgba(0, 0, 0, 0.1);
+  --bp-surface-shadow-3:
+    0px 0px 0px 1px rgba(0, 0, 0, 0.1), 0px 20px 25px -5px rgba(0, 0, 0, 0.1),
+    0px 10px 15px -3px rgba(0, 0, 0, 0.1);
+  --bp-surface-shadow-4:
+    0px 0px 0px 1px rgba(0, 0, 0, 0.1), 0px 25px 50px -12px rgba(0, 0, 0, 0.3);
+  --bp-surface-spacing: 4px;
+  --bp-surface-z-index-0: 0;
+  --bp-surface-z-index-1: 10;
+  --bp-surface-z-index-2: 20;
+  --bp-surface-z-index-3: 30;
+  --bp-surface-z-index-4: 40;
+  --bp-surface-color-code: #ffffffb3;
+  --bp-surface-layer-opacity: 0.05;
+  --bp-surface-layer-color-default: #5f6b7c0d;
+  --bp-surface-layer-color-primary: #2d72d20d;
+  --bp-surface-layer-color-success: #2385510d;
+  --bp-surface-layer-color-warning: #c876190d;
+  --bp-surface-layer-color-danger: #cd42460d;
+  --bp-surface-layer-default: linear-gradient(#5f6b7c0d 0 0);
+  --bp-surface-layer-primary: linear-gradient(#2d72d20d 0 0);
+  --bp-surface-layer-success: linear-gradient(#2385510d 0 0);
+  --bp-surface-layer-warning: linear-gradient(#c876190d 0 0);
+  --bp-surface-layer-danger: linear-gradient(#cd42460d 0 0);
+  --bp-surface-background-color-default-rest: #ffffff;
+  --bp-surface-background-color-default-hover: #f6f7f9;
+  --bp-surface-background-color-default-active: #edeff2;
+  --bp-surface-background-color-default-disabled: #ffffff;
+  --bp-surface-background-color-primary-rest: #2d72d2;
+  --bp-surface-background-color-primary-hover: #215db0;
+  --bp-surface-background-color-primary-active: #184a90;
+  --bp-surface-background-color-primary-disabled: #4c90f0;
+  --bp-surface-background-color-success-rest: #238551;
+  --bp-surface-background-color-success-hover: #1c6e42;
+  --bp-surface-background-color-success-active: #165a36;
+  --bp-surface-background-color-success-disabled: #32a467;
+  --bp-surface-background-color-warning-rest: #c87619;
+  --bp-surface-background-color-warning-hover: #935610;
+  --bp-surface-background-color-warning-active: #77450d;
+  --bp-surface-background-color-warning-disabled: #ec9a3c;
+  --bp-surface-background-color-danger-rest: #cd4246;
+  --bp-surface-background-color-danger-hover: #ac2f33;
+  --bp-surface-background-color-danger-active: #8e292c;
+  --bp-surface-background-color-danger-disabled: #e76a6e;
+  --bp-typography-family-default:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+    Cantarell, "Open Sans", "Helvetica Neue", blueprint-icons-16, sans-serif;
+  --bp-typography-family-mono: monospace;
+  --bp-typography-size-body-x-small: 10px;
+  --bp-typography-size-body-small: 12px;
+  --bp-typography-size-body-medium: 14px;
+  --bp-typography-size-body-large: 16px;
+  --bp-typography-size-heading-small: 16px;
+  --bp-typography-size-heading-medium: 20px;
+  --bp-typography-size-heading-large: 24px;
+  --bp-typography-size-heading-x-large: 28px;
+  --bp-typography-size-heading-display: 46px;
+  --bp-typography-size-code-small: 12px;
+  --bp-typography-size-code-medium: 13px;
+  --bp-typography-size-code-large: 14px;
+  --bp-typography-weight-default: 400;
+  --bp-typography-weight-bold: 600;
+  --bp-typography-line-height-default: 1.28581;
+  --bp-typography-line-height-large: 1.5;
+  --bp-typography-color-muted: #5f6b7c;
+  --bp-typography-color-default-rest: #1c2127;
+  --bp-typography-color-default-hover: #111418;
+  --bp-typography-color-default-active: #252a31;
+  --bp-typography-color-default-disabled: #8f99a8;
+  --bp-typography-color-primary-rest: #2d72d2;
+  --bp-typography-color-primary-hover: #215db0;
+  --bp-typography-color-primary-active: #184a90;
+  --bp-typography-color-primary-disabled: #4c90f0;
+  --bp-typography-color-success-rest: #238551;
+  --bp-typography-color-success-hover: #1c6e42;
+  --bp-typography-color-success-active: #165a36;
+  --bp-typography-color-success-disabled: #32a467;
+  --bp-typography-color-warning-rest: #c87619;
+  --bp-typography-color-warning-hover: #935610;
+  --bp-typography-color-warning-active: #77450d;
+  --bp-typography-color-warning-disabled: #ec9a3c;
+  --bp-typography-color-danger-rest: #cd4246;
+  --bp-typography-color-danger-hover: #ac2f33;
+  --bp-typography-color-danger-active: #8e292c;
+  --bp-typography-color-danger-disabled: #e76a6e;
 }
 
-@supports (color: oklch(from var(--any-color) l c h)){
-  :root{
-    --bp-surface-border-color-default:oklch(from var(--bp-intent-default-rest) l c h / 0.12);
-    --bp-surface-border-color-strong:oklch(from var(--bp-intent-default-rest) l c h / 0.25);
-    --bp-surface-color-code:oklch(from var(--bp-palette-white) l c h / 0.7);
-    --bp-surface-layer-color-default:oklch(from var(--bp-intent-default-rest) l c h / var(--bp-surface-layer-opacity));
-    --bp-surface-layer-color-primary:oklch(from var(--bp-intent-primary-rest) l c h / var(--bp-surface-layer-opacity));
-    --bp-surface-layer-color-success:oklch(from var(--bp-intent-success-rest) l c h / var(--bp-surface-layer-opacity));
-    --bp-surface-layer-color-warning:oklch(from var(--bp-intent-warning-rest) l c h / var(--bp-surface-layer-opacity));
-    --bp-surface-layer-color-danger:oklch(from var(--bp-intent-danger-rest) l c h / var(--bp-surface-layer-opacity));
-    --bp-surface-layer-default:linear-gradient(oklch(from var(--bp-intent-default-rest) l c h / var(--bp-surface-layer-opacity)) 0 0);
-    --bp-surface-layer-primary:linear-gradient(oklch(from var(--bp-intent-primary-rest) l c h / var(--bp-surface-layer-opacity)) 0 0);
-    --bp-surface-layer-success:linear-gradient(oklch(from var(--bp-intent-success-rest) l c h / var(--bp-surface-layer-opacity)) 0 0);
-    --bp-surface-layer-warning:linear-gradient(oklch(from var(--bp-intent-warning-rest) l c h / var(--bp-surface-layer-opacity)) 0 0);
-    --bp-surface-layer-danger:linear-gradient(oklch(from var(--bp-intent-danger-rest) l c h / var(--bp-surface-layer-opacity)) 0 0);
-    --bp-surface-background-color-default-rest:oklch(from var(--bp-intent-default-rest) calc(l * 1.909) calc(c * 0) h);
-    --bp-surface-background-color-default-hover:oklch(from var(--bp-intent-default-hover) calc(l + 0.577) calc(c + -0.02) calc(h + 6.2));
-    --bp-surface-background-color-default-active:oklch(from var(--bp-intent-default-active) calc(l + 0.59) calc(c + -0.013) calc(h + 0));
-    --bp-surface-background-color-default-disabled:oklch(from var(--bp-intent-default-disabled) calc(l * 1.471) calc(c * 0) h);
-    --bp-typography-color-default-rest:oklch(from var(--bp-intent-default-rest) calc(l + -0.279) calc(c + -0.017) calc(h + -4));
-    --bp-typography-color-default-hover:oklch(from var(--bp-intent-default-hover) calc(l + -0.209) calc(c + -0.013) calc(h + -2.7));
-    --bp-typography-color-default-active:oklch(from var(--bp-intent-default-active) calc(l + -0.079) calc(c + -0.003) calc(h + -1.6));
+@supports (color: oklch(from var(--any-color) l c h)) {
+  :root {
+    --bp-surface-border-color-default: oklch(
+      from var(--bp-intent-default-rest) l c h / 0.12
+    );
+    --bp-surface-border-color-strong: oklch(
+      from var(--bp-intent-default-rest) l c h / 0.25
+    );
+    --bp-surface-color-code: oklch(from var(--bp-palette-white) l c h / 0.7);
+    --bp-surface-layer-color-default: oklch(
+      from var(--bp-intent-default-rest) l c h / var(--bp-surface-layer-opacity)
+    );
+    --bp-surface-layer-color-primary: oklch(
+      from var(--bp-intent-primary-rest) l c h / var(--bp-surface-layer-opacity)
+    );
+    --bp-surface-layer-color-success: oklch(
+      from var(--bp-intent-success-rest) l c h / var(--bp-surface-layer-opacity)
+    );
+    --bp-surface-layer-color-warning: oklch(
+      from var(--bp-intent-warning-rest) l c h / var(--bp-surface-layer-opacity)
+    );
+    --bp-surface-layer-color-danger: oklch(
+      from var(--bp-intent-danger-rest) l c h / var(--bp-surface-layer-opacity)
+    );
+    --bp-surface-layer-default: linear-gradient(
+      oklch(
+          from var(--bp-intent-default-rest) l c h /
+            var(--bp-surface-layer-opacity)
+        )
+        0 0
+    );
+    --bp-surface-layer-primary: linear-gradient(
+      oklch(
+          from var(--bp-intent-primary-rest) l c h /
+            var(--bp-surface-layer-opacity)
+        )
+        0 0
+    );
+    --bp-surface-layer-success: linear-gradient(
+      oklch(
+          from var(--bp-intent-success-rest) l c h /
+            var(--bp-surface-layer-opacity)
+        )
+        0 0
+    );
+    --bp-surface-layer-warning: linear-gradient(
+      oklch(
+          from var(--bp-intent-warning-rest) l c h /
+            var(--bp-surface-layer-opacity)
+        )
+        0 0
+    );
+    --bp-surface-layer-danger: linear-gradient(
+      oklch(
+          from var(--bp-intent-danger-rest) l c h /
+            var(--bp-surface-layer-opacity)
+        )
+        0 0
+    );
+    --bp-surface-background-color-default-rest: oklch(
+      from var(--bp-intent-default-rest) calc(l * 1.909) calc(c * 0) h
+    );
+    --bp-surface-background-color-default-hover: oklch(
+      from var(--bp-intent-default-hover) calc(l + 0.577) calc(c + -0.02)
+        calc(h + 6.2)
+    );
+    --bp-surface-background-color-default-active: oklch(
+      from var(--bp-intent-default-active) calc(l + 0.59) calc(c + -0.013)
+        calc(h + 0)
+    );
+    --bp-surface-background-color-default-disabled: oklch(
+      from var(--bp-intent-default-disabled) calc(l * 1.471) calc(c * 0) h
+    );
+    --bp-typography-color-default-rest: oklch(
+      from var(--bp-intent-default-rest) calc(l + -0.279) calc(c + -0.017)
+        calc(h + -4)
+    );
+    --bp-typography-color-default-hover: oklch(
+      from var(--bp-intent-default-hover) calc(l + -0.209) calc(c + -0.013)
+        calc(h + -2.7)
+    );
+    --bp-typography-color-default-active: oklch(
+      from var(--bp-intent-default-active) calc(l + -0.079) calc(c + -0.003)
+        calc(h + -1.6)
+    );
   }
 }
-[data-bp-color-scheme=dark],
-.bp6-dark{
-  --bp-surface-border-color-default:#ffffff33;
-  --bp-surface-border-color-strong:#ffffff4d;
-  --bp-surface-shadow-0:inset 0px 0px 0px 1px rgba(255, 255, 255, 0.2), 0px 0px 10px 0px rgba(0, 0, 0, 0.2);
-  --bp-surface-shadow-1:inset 0px 0px 0px 1px rgba(255, 255, 255, 0.2), 0px 1px 10px 0px rgba(0, 0, 0, 0.2), 0px 1px 10px -1px rgba(0, 0, 0, 0.2);
-  --bp-surface-shadow-2:inset 0px 0px 0px 1px rgba(255, 255, 255, 0.2), 0px 4px 6px -4px rgba(0, 0, 0, 0.5), 0px 10px 30px -5px rgba(0, 0, 0, 0.5);
-  --bp-surface-shadow-3:inset 0px 0px 0px 1px rgba(255, 255, 255, 0.2), 0px 20px 25px -5px rgba(0, 0, 0, 0.3), 0px 10px 30px -5px rgba(0, 0, 0, 0.3);
-  --bp-surface-shadow-4:inset 0px 0px 0px 1px rgba(255, 255, 255, 0.2), 0px 25px 60px -12px rgba(0, 0, 0, 0.85);
-  --bp-surface-color-code:#1114184d;
-  --bp-surface-background-color-default-rest:#111418;
-  --bp-surface-background-color-default-hover:#1c2127;
-  --bp-surface-background-color-default-active:#252a31;
-  --bp-surface-background-color-default-disabled:#111418;
-  --bp-typography-color-default-rest:#a5aab3;
-  --bp-typography-color-default-hover:#646970;
-  --bp-typography-color-default-active:#54575d;
+[data-bp-color-scheme="dark"],
+.bp6-dark {
+  --bp-surface-border-color-default: #ffffff33;
+  --bp-surface-border-color-strong: #ffffff4d;
+  --bp-surface-shadow-0:
+    inset 0px 0px 0px 1px rgba(255, 255, 255, 0.2),
+    0px 0px 10px 0px rgba(0, 0, 0, 0.2);
+  --bp-surface-shadow-1:
+    inset 0px 0px 0px 1px rgba(255, 255, 255, 0.2),
+    0px 1px 10px 0px rgba(0, 0, 0, 0.2), 0px 1px 10px -1px rgba(0, 0, 0, 0.2);
+  --bp-surface-shadow-2:
+    inset 0px 0px 0px 1px rgba(255, 255, 255, 0.2),
+    0px 4px 6px -4px rgba(0, 0, 0, 0.5), 0px 10px 30px -5px rgba(0, 0, 0, 0.5);
+  --bp-surface-shadow-3:
+    inset 0px 0px 0px 1px rgba(255, 255, 255, 0.2),
+    0px 20px 25px -5px rgba(0, 0, 0, 0.3), 0px 10px 30px -5px rgba(0, 0, 0, 0.3);
+  --bp-surface-shadow-4:
+    inset 0px 0px 0px 1px rgba(255, 255, 255, 0.2),
+    0px 25px 60px -12px rgba(0, 0, 0, 0.85);
+  --bp-surface-color-code: #1114184d;
+  --bp-surface-background-color-default-rest: #111418;
+  --bp-surface-background-color-default-hover: #1c2127;
+  --bp-surface-background-color-default-active: #252a31;
+  --bp-surface-background-color-default-disabled: #111418;
+  --bp-typography-color-default-rest: #a5aab3;
+  --bp-typography-color-default-hover: #646970;
+  --bp-typography-color-default-active: #54575d;
 }
 
-@supports (color: oklch(from var(--any-color) l c h)){
-  [data-bp-color-scheme=dark],
-  .bp6-dark{
-    --bp-surface-border-color-default:oklch(from var(--bp-palette-white) l c h / 0.2);
-    --bp-surface-border-color-strong:oklch(from var(--bp-palette-white) l c h / 0.3);
-    --bp-surface-color-code:oklch(from var(--bp-palette-black) l c h / 0.3);
-    --bp-surface-background-color-default-rest:oklch(from var(--bp-intent-default-rest) calc(l * 0.362) calc(c * 0.308) calc(h + -1.44));
-    --bp-surface-background-color-default-hover:oklch(from var(--bp-intent-default-hover) calc(l * 0.615) calc(c * 0.597) calc(h + -5.29));
-    --bp-surface-background-color-default-active:oklch(from var(--bp-intent-default-active) calc(l * 0.782) calc(c * 0.84) calc(h + -1.58));
-    --bp-surface-background-color-default-disabled:oklch(from var(--bp-intent-default-disabled) calc(l * 0.279) calc(c * 0.377) calc(h + -2.74));
-    --bp-typography-color-default-rest:oklch(from var(--bp-intent-default-rest) calc(l + 0.212) calc(c + -0.016) calc(h + 6.2));
-    --bp-typography-color-default-hover:oklch(from var(--bp-intent-default-hover) calc(l + 0.12) calc(c + -0.01) calc(h + 0));
-    --bp-typography-color-default-active:oklch(from var(--bp-intent-default-active) calc(l + 0.095) calc(c + -0.008) calc(h + 0));
+@supports (color: oklch(from var(--any-color) l c h)) {
+  [data-bp-color-scheme="dark"],
+  .bp6-dark {
+    --bp-surface-border-color-default: oklch(
+      from var(--bp-palette-white) l c h / 0.2
+    );
+    --bp-surface-border-color-strong: oklch(
+      from var(--bp-palette-white) l c h / 0.3
+    );
+    --bp-surface-color-code: oklch(from var(--bp-palette-black) l c h / 0.3);
+    --bp-surface-background-color-default-rest: oklch(
+      from var(--bp-intent-default-rest) calc(l * 0.362) calc(c * 0.308)
+        calc(h + -1.44)
+    );
+    --bp-surface-background-color-default-hover: oklch(
+      from var(--bp-intent-default-hover) calc(l * 0.615) calc(c * 0.597)
+        calc(h + -5.29)
+    );
+    --bp-surface-background-color-default-active: oklch(
+      from var(--bp-intent-default-active) calc(l * 0.782) calc(c * 0.84)
+        calc(h + -1.58)
+    );
+    --bp-surface-background-color-default-disabled: oklch(
+      from var(--bp-intent-default-disabled) calc(l * 0.279) calc(c * 0.377)
+        calc(h + -2.74)
+    );
+    --bp-typography-color-default-rest: oklch(
+      from var(--bp-intent-default-rest) calc(l + 0.212) calc(c + -0.016)
+        calc(h + 6.2)
+    );
+    --bp-typography-color-default-hover: oklch(
+      from var(--bp-intent-default-hover) calc(l + 0.12) calc(c + -0.01)
+        calc(h + 0)
+    );
+    --bp-typography-color-default-active: oklch(
+      from var(--bp-intent-default-active) calc(l + 0.095) calc(c + -0.008)
+        calc(h + 0)
+    );
   }
 }

--- a/packages/react-components/src/tokens/base-tokens/dark.css
+++ b/packages/react-components/src/tokens/base-tokens/dark.css
@@ -70,7 +70,9 @@
      set --osdk-* tokens that have no --bp-* counterpart or that
      intentionally diverge from Blueprint's value. */
   --osdk-surface-shadow-2: var(--osdk-dark-surface-shadow-2);
-  --osdk-surface-border-color-default: var(--osdk-dark-bp-surface-border-color-default);
+  --osdk-surface-border-color-default: var(
+    --osdk-dark-bp-surface-border-color-default
+  );
   --osdk-background-primary: var(--osdk-dark-background-primary);
   --osdk-background-secondary: var(--osdk-dark-background-secondary);
   --osdk-background-tertiary: var(--osdk-dark-background-tertiary);

--- a/packages/react-components/src/tokens/component-tokens/aip-agent-chat.css
+++ b/packages/react-components/src/tokens/component-tokens/aip-agent-chat.css
@@ -14,13 +14,15 @@
   --osdk-aip-agent-chat-bubble-border-radius: var(--osdk-surface-border-radius);
   --osdk-aip-agent-chat-bubble-max-width: 80%;
 
-  --osdk-aip-agent-chat-user-bubble-background: var(--osdk-background-secondary);
+  --osdk-aip-agent-chat-user-bubble-background: var(
+    --osdk-background-secondary
+  );
   --osdk-aip-agent-chat-user-bubble-color: var(
     --osdk-typography-color-default-rest
   );
   --osdk-aip-agent-chat-user-bubble-border-radius: var(
-    --osdk-surface-border-radius
-  )
+      --osdk-surface-border-radius
+    )
     var(--osdk-surface-border-radius) 0 var(--osdk-surface-border-radius);
 
   --osdk-aip-agent-chat-assistant-bubble-color: var(

--- a/packages/react-components/src/tokens/component-tokens/button.css
+++ b/packages/react-components/src/tokens/component-tokens/button.css
@@ -2,10 +2,18 @@
   /* Button shared — border is none; visual border comes from box-shadow
      to match Blueprint's .bp6-button convention */
   --osdk-button-min-height: calc(var(--osdk-surface-spacing) * 7.5);
-  --osdk-button-border-color: color-mix(in oklch, var(--bp-palette-black) 20%, transparent);
+  --osdk-button-border-color: color-mix(
+    in oklch,
+    var(--bp-palette-black) 20%,
+    transparent
+  );
   --osdk-button-border: none;
   --osdk-button-border-radius: var(--osdk-surface-border-radius);
-  --osdk-button-drop-shadow-color: color-mix(in oklch, var(--bp-palette-black) 10%, transparent);
+  --osdk-button-drop-shadow-color: color-mix(
+    in oklch,
+    var(--bp-palette-black) 10%,
+    transparent
+  );
   --osdk-button-shadow:
     inset 0 0 0 1px var(--osdk-button-border-color),
     0 1px 1px var(--osdk-button-drop-shadow-color);
@@ -26,7 +34,9 @@
   --osdk-button-secondary-bg-active: var(
     --osdk-surface-background-color-default-active
   );
-  --osdk-button-secondary-border-color: var(--osdk-surface-border-color-default);
+  --osdk-button-secondary-border-color: var(
+    --osdk-surface-border-color-default
+  );
 
   /* Minimal Button */
   --osdk-button-minimal-bg: transparent;
@@ -73,8 +83,16 @@
     var(--bp-palette-black)
   );
   --osdk-button-secondary-color: var(--bp-intent-default-foreground);
-  --osdk-button-border-color: color-mix(in oklch, var(--bp-surface-border-color-default) 50%, transparent);
-  --osdk-button-drop-shadow-color: color-mix(in oklch, var(--bp-palette-black) 20%, transparent);
+  --osdk-button-border-color: color-mix(
+    in oklch,
+    var(--bp-surface-border-color-default) 50%,
+    transparent
+  );
+  --osdk-button-drop-shadow-color: color-mix(
+    in oklch,
+    var(--bp-palette-black) 20%,
+    transparent
+  );
   --osdk-button-shadow:
     inset 0 0 0 var(--bp-surface-border-width) var(--osdk-button-border-color),
     0 1px 2px var(--osdk-button-drop-shadow-color);

--- a/packages/react-components/src/tokens/component-tokens/cbac-picker.css
+++ b/packages/react-components/src/tokens/component-tokens/cbac-picker.css
@@ -25,15 +25,15 @@
 
   --osdk-cbac-banner-border-color: var(--osdk-surface-border-color-default);
   --osdk-cbac-banner-placeholder-bg: var(--osdk-intent-default-disabled);
-  --osdk-cbac-banner-placeholder-color: var(--osdk-typography-color-default-rest);
+  --osdk-cbac-banner-placeholder-color: var(
+    --osdk-typography-color-default-rest
+  );
 
   /* Marking Button */
   --osdk-cbac-marking-button-padding: calc(var(--osdk-surface-spacing) * 0.5)
     calc(var(--osdk-surface-spacing) * 1.5);
   --osdk-cbac-marking-button-border-radius: 0;
-  --osdk-cbac-marking-button-font-size: var(
-    --osdk-typography-size-body-small
-  );
+  --osdk-cbac-marking-button-font-size: var(--osdk-typography-size-body-small);
   --osdk-cbac-marking-button-gap: var(--osdk-surface-spacing);
   --osdk-cbac-marking-button-color-default: var(
     --osdk-typography-color-default-rest
@@ -91,7 +91,9 @@
   /* Validation Warning */
   --osdk-cbac-validation-warning-bg: var(--osdk-intent-warning-subtle);
   --osdk-cbac-validation-warning-color: var(--osdk-intent-warning-rest);
-  --osdk-cbac-validation-warning-padding: calc(var(--osdk-surface-spacing) * 1.5)
+  --osdk-cbac-validation-warning-padding: calc(
+      var(--osdk-surface-spacing) * 1.5
+    )
     calc(var(--osdk-surface-spacing) * 2);
   --osdk-cbac-validation-warning-font-size: var(
     --osdk-typography-size-body-small
@@ -99,7 +101,9 @@
   --osdk-cbac-validation-warning-border-radius: var(
     --osdk-surface-border-radius
   );
-  --osdk-cbac-validation-warning-chip-bg: var(--osdk-surface-background-color-default);
+  --osdk-cbac-validation-warning-chip-bg: var(
+    --osdk-surface-background-color-default
+  );
   --osdk-cbac-validation-warning-max-height: 200px;
   --osdk-cbac-validation-warning-chip-border-color: var(
     --osdk-surface-border-color-default
@@ -125,9 +129,7 @@
   --osdk-cbac-warning-callout-padding: calc(var(--osdk-surface-spacing) * 1.5)
     calc(var(--osdk-surface-spacing) * 2);
   --osdk-cbac-warning-callout-border-radius: var(--osdk-surface-border-radius);
-  --osdk-cbac-warning-callout-font-size: var(
-    --osdk-typography-size-body-small
-  );
+  --osdk-cbac-warning-callout-font-size: var(--osdk-typography-size-body-small);
 
   /* Marking Tooltip */
   --osdk-cbac-marking-tooltip-max-width: 280px;

--- a/packages/react-components/src/tokens/component-tokens/datetime-picker.css
+++ b/packages/react-components/src/tokens/component-tokens/datetime-picker.css
@@ -120,7 +120,9 @@
     --osdk-input-focus-shadow-error
   );
 
-  --osdk-datetime-input-transition-duration: var(--osdk-input-transition-duration);
+  --osdk-datetime-input-transition-duration: var(
+    --osdk-input-transition-duration
+  );
   --osdk-datetime-input-transition-ease: var(--osdk-input-transition-ease);
 
   /* Calendar fallback / loading */

--- a/packages/react-components/src/tokens/component-tokens/draggable.css
+++ b/packages/react-components/src/tokens/component-tokens/draggable.css
@@ -6,6 +6,8 @@
     calc(var(--osdk-surface-spacing) * 3);
   --osdk-draggable-item-gap: var(--osdk-surface-spacing);
   --osdk-draggable-item-drag-icon-color: var(--osdk-drag-handle-color);
-  --osdk-draggable-item-drag-icon-color-hover: var(--osdk-drag-handle-color-hover);
+  --osdk-draggable-item-drag-icon-color-hover: var(
+    --osdk-drag-handle-color-hover
+  );
   --osdk-draggable-item-icon-size: var(--osdk-iconography-size-small);
 }

--- a/packages/react-components/src/tokens/component-tokens/input.css
+++ b/packages/react-components/src/tokens/component-tokens/input.css
@@ -17,7 +17,8 @@
     inset 0 0 0 var(--osdk-input-border-width)
       color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
     0 0 0 0 transparent,
-    inset 0 1px 1px color-mix(in oklch, var(--bp-palette-black) 30%, transparent);
+    inset 0 1px 1px
+      color-mix(in oklch, var(--bp-palette-black) 30%, transparent);
 
   /* Input backgrounds */
   --osdk-input-bg: var(--osdk-surface-background-color-default-rest);
@@ -57,8 +58,14 @@
   --osdk-input-shadow:
     0 0 0 0 color-mix(in srgb, var(--bp-intent-primary-rest) 0%, transparent),
     0 0 0 0 color-mix(in srgb, var(--bp-intent-primary-rest) 0%, transparent),
-    inset 0 0 0 1px color-mix(in oklch, var(--bp-palette-white) 20%, transparent),
-    inset 0 -1px 1px 0 color-mix(in oklch, var(--bp-palette-white) 30%, transparent);
-  --osdk-input-bg: color-mix(in srgb, var(--osdk-palette-black) 30%, transparent);
+    inset 0 0 0 1px
+      color-mix(in oklch, var(--bp-palette-white) 20%, transparent),
+    inset 0 -1px 1px 0
+      color-mix(in oklch, var(--bp-palette-white) 30%, transparent);
+  --osdk-input-bg: color-mix(
+    in srgb,
+    var(--osdk-palette-black) 30%,
+    transparent
+  );
   --osdk-input-color: var(--osdk-palette-light-gray-5);
 }

--- a/packages/react-components/src/tokens/component-tokens/markdown-renderer.css
+++ b/packages/react-components/src/tokens/component-tokens/markdown-renderer.css
@@ -18,7 +18,8 @@
   --osdk-markdown-renderer-code-inline-border-radius: 3px;
 
   /* Markdown Renderer - Blockquotes */
-  --osdk-markdown-renderer-blockquote-border: 3px solid var(--osdk-intent-primary-rest);
+  --osdk-markdown-renderer-blockquote-border: 3px solid
+    var(--osdk-intent-primary-rest);
 
   /* Markdown Renderer - Links */
   --osdk-markdown-renderer-link-color: var(--osdk-intent-primary-rest);

--- a/packages/react-components/src/tokens/component-tokens/number-input.css
+++ b/packages/react-components/src/tokens/component-tokens/number-input.css
@@ -2,8 +2,8 @@
   /* Number input stepper — the +/– button group beside the text input */
   --osdk-number-input-stepper-border-width: 1px;
   --osdk-number-input-stepper-border-color: var(--osdk-button-border-color);
-  --osdk-number-input-stepper-shadow:
-    0 var(--osdk-number-input-stepper-border-width)
+  --osdk-number-input-stepper-shadow: 0
+    var(--osdk-number-input-stepper-border-width)
     var(--osdk-number-input-stepper-border-width)
     var(--osdk-button-drop-shadow-color);
 }

--- a/packages/react-components/src/tokens/component-tokens/table.css
+++ b/packages/react-components/src/tokens/component-tokens/table.css
@@ -47,9 +47,7 @@
   --osdk-table-header-menu-color-active: var(
     --osdk-typography-color-default-rest
   );
-  --osdk-table-header-menu-icon-color: var(
-    --osdk-table-header-menu-color
-  );
+  --osdk-table-header-menu-icon-color: var(--osdk-table-header-menu-color);
   --osdk-table-header-menu-bg-hover: var(
     --osdk-surface-background-color-default-hover
   );

--- a/packages/react-devtools/src/components/BubbleChart.module.scss
+++ b/packages/react-devtools/src/components/BubbleChart.module.scss
@@ -1,4 +1,4 @@
-@use 'tokens' as t;
+@use "tokens" as t;
 
 .container {
   width: 100%;

--- a/packages/react-devtools/src/components/CacheInspectorTab.module.scss
+++ b/packages/react-devtools/src/components/CacheInspectorTab.module.scss
@@ -1,5 +1,5 @@
-@use 'tokens' as t;
-@use 'mixins' as m;
+@use "tokens" as t;
+@use "mixins" as m;
 
 .cacheInspector {
   display: flex;
@@ -119,7 +119,9 @@
   gap: 10px;
   min-height: auto;
   border-left: 2px solid transparent;
-  transition: background-color t.$transition-fast, border-left-color t.$transition-fast;
+  transition:
+    background-color t.$transition-fast,
+    border-left-color t.$transition-fast;
 
   &:hover {
     background: t.$bg-hover;

--- a/packages/react-devtools/src/components/ComponentCard.module.scss
+++ b/packages/react-devtools/src/components/ComponentCard.module.scss
@@ -1,5 +1,5 @@
-@use 'tokens' as t;
-@use 'mixins' as m;
+@use "tokens" as t;
+@use "mixins" as m;
 
 .componentCard {
   @include m.dt-entrance;
@@ -23,7 +23,9 @@
   cursor: pointer;
   user-select: none;
   border-left: 2px solid transparent;
-  transition: background-color t.$transition-fast, border-left-color t.$transition-fast;
+  transition:
+    background-color t.$transition-fast,
+    border-left-color t.$transition-fast;
 
   &:hover {
     background: t.$bg-hover;

--- a/packages/react-devtools/src/components/CopyableCodeBlock.module.scss
+++ b/packages/react-devtools/src/components/CopyableCodeBlock.module.scss
@@ -1,5 +1,5 @@
-@use 'tokens' as t;
-@use 'mixins' as m;
+@use "tokens" as t;
+@use "mixins" as m;
 
 .container {
   position: relative;

--- a/packages/react-devtools/src/components/DebuggingTab.module.scss
+++ b/packages/react-devtools/src/components/DebuggingTab.module.scss
@@ -1,5 +1,5 @@
-@use 'tokens' as t;
-@use 'mixins' as m;
+@use "tokens" as t;
+@use "mixins" as m;
 
 .debuggingTab {
   display: flex;

--- a/packages/react-devtools/src/components/HookRow.module.scss
+++ b/packages/react-devtools/src/components/HookRow.module.scss
@@ -1,4 +1,4 @@
-@use 'tokens' as t;
+@use "tokens" as t;
 
 .hookRow {
   display: flex;

--- a/packages/react-devtools/src/components/ImprovementsTab.module.scss
+++ b/packages/react-devtools/src/components/ImprovementsTab.module.scss
@@ -1,5 +1,5 @@
-@use 'tokens' as t;
-@use 'mixins' as m;
+@use "tokens" as t;
+@use "mixins" as m;
 
 .emptyState {
   @include m.dt-empty-state;

--- a/packages/react-devtools/src/components/InterceptTab.module.scss
+++ b/packages/react-devtools/src/components/InterceptTab.module.scss
@@ -1,5 +1,5 @@
-@use 'tokens' as t;
-@use 'mixins' as m;
+@use "tokens" as t;
+@use "mixins" as m;
 
 .interceptTab {
   display: flex;
@@ -100,7 +100,9 @@
   cursor: pointer;
   text-align: center;
   color: t.$text-primary;
-  transition: border-color t.$transition-fast, background-color t.$transition-fast;
+  transition:
+    border-color t.$transition-fast,
+    background-color t.$transition-fast;
 
   &:hover {
     border-color: t.$blue;

--- a/packages/react-devtools/src/components/IssueCard.module.scss
+++ b/packages/react-devtools/src/components/IssueCard.module.scss
@@ -1,5 +1,5 @@
-@use 'tokens' as t;
-@use 'mixins' as m;
+@use "tokens" as t;
+@use "mixins" as m;
 
 .issueCard {
   @include m.dt-entrance;

--- a/packages/react-devtools/src/components/LogEntryCard.module.scss
+++ b/packages/react-devtools/src/components/LogEntryCard.module.scss
@@ -1,5 +1,5 @@
-@use 'tokens' as t;
-@use 'mixins' as m;
+@use "tokens" as t;
+@use "mixins" as m;
 
 .logEntry {
   @include m.dt-entrance;

--- a/packages/react-devtools/src/components/Metric.module.scss
+++ b/packages/react-devtools/src/components/Metric.module.scss
@@ -1,5 +1,5 @@
-@use 'tokens' as t;
-@use 'mixins' as m;
+@use "tokens" as t;
+@use "mixins" as m;
 
 // A single `Metric` cell — borderless; the enclosing `Metrics` grid draws the
 // dividers around it.
@@ -36,7 +36,6 @@
 
 .metricValue {
   @include m.dt-metric-value;
-
 
   // No data yet — muted, so it reads as absent rather than a real measurement.
   &.na {

--- a/packages/react-devtools/src/components/MetricLegend.module.scss
+++ b/packages/react-devtools/src/components/MetricLegend.module.scss
@@ -1,4 +1,4 @@
-@use 'tokens' as t;
+@use "tokens" as t;
 
 .metricLegend {
   display: flex;

--- a/packages/react-devtools/src/components/Metrics.module.scss
+++ b/packages/react-devtools/src/components/Metrics.module.scss
@@ -1,4 +1,4 @@
-@use 'tokens' as t;
+@use "tokens" as t;
 
 .metrics {
   display: grid;

--- a/packages/react-devtools/src/components/MonitoringPanel.module.scss
+++ b/packages/react-devtools/src/components/MonitoringPanel.module.scss
@@ -1,6 +1,6 @@
-@use 'tokens' as t;
-@use 'mixins' as m;
-@use 'theme' as theme;
+@use "tokens" as t;
+@use "mixins" as m;
+@use "theme" as theme;
 
 .panel {
   @include theme.dt-dark-theme;
@@ -189,7 +189,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background-color t.$transition-fast, color t.$transition-fast;
+  transition:
+    background-color t.$transition-fast,
+    color t.$transition-fast;
 
   &:hover {
     background: t.$bg-hover;
@@ -473,7 +475,10 @@
   cursor: pointer;
   box-shadow: t.$shadow-panel;
   z-index: t.$z-panel;
-  transition: opacity t.$transition-normal, border-color t.$transition-normal, box-shadow t.$transition-normal;
+  transition:
+    opacity t.$transition-normal,
+    border-color t.$transition-normal,
+    box-shadow t.$transition-normal;
   opacity: 0.7;
   pointer-events: auto;
 

--- a/packages/react-devtools/src/components/OverviewSection.module.scss
+++ b/packages/react-devtools/src/components/OverviewSection.module.scss
@@ -1,4 +1,4 @@
-@use 'tokens' as t;
+@use "tokens" as t;
 
 .overviewSection {
   border-radius: 0;

--- a/packages/react-devtools/src/components/PrimitiveSelectionPanel.module.scss
+++ b/packages/react-devtools/src/components/PrimitiveSelectionPanel.module.scss
@@ -1,5 +1,5 @@
-@use 'tokens' as t;
-@use 'mixins' as m;
+@use "tokens" as t;
+@use "mixins" as m;
 
 .panel {
   display: flex;
@@ -108,7 +108,9 @@
   cursor: pointer;
   text-align: left;
   margin-bottom: 0;
-  transition: background-color t.$transition-fast, border-left-color t.$transition-fast;
+  transition:
+    background-color t.$transition-fast,
+    border-left-color t.$transition-fast;
 
   &:hover {
     background: t.$bg-hover;

--- a/packages/react-devtools/src/components/_mixins.scss
+++ b/packages/react-devtools/src/components/_mixins.scss
@@ -1,4 +1,4 @@
-@use 'tokens' as t;
+@use "tokens" as t;
 
 // Uppercase muted section label
 @mixin dt-label {
@@ -95,7 +95,9 @@
   padding: 6px 12px;
   border-bottom: 1px solid t.$border-subtle;
   border-left: 2px solid transparent;
-  transition: background-color t.$transition-fast, border-left-color t.$transition-fast;
+  transition:
+    background-color t.$transition-fast,
+    border-left-color t.$transition-fast;
 
   &:hover {
     background: t.$bg-hover;
@@ -142,8 +144,12 @@
 }
 
 @keyframes dt-shimmer {
-  0% { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
 }
 
 // Staggered entrance animation for card lists
@@ -167,7 +173,13 @@
 
 @media (prefers-reduced-motion: reduce) {
   @keyframes dt-fade-up {
-    from { opacity: 1; transform: none; }
-    to { opacity: 1; transform: none; }
+    from {
+      opacity: 1;
+      transform: none;
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
   }
 }

--- a/packages/react-devtools/src/components/_tokens.scss
+++ b/packages/react-devtools/src/components/_tokens.scss
@@ -36,8 +36,15 @@ $orange-bg: var(--dt-orange-bg);
 $gray: var(--dt-gray);
 
 // Typography
-$font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-$font-mono: "JetBrains Mono", "SF Mono", "Monaco", "Menlo", "Consolas", monospace;
+$font-sans:
+  "Inter",
+  -apple-system,
+  BlinkMacSystemFont,
+  "Segoe UI",
+  Roboto,
+  sans-serif;
+$font-mono:
+  "JetBrains Mono", "SF Mono", "Monaco", "Menlo", "Consolas", monospace;
 
 // Font sizes
 $font-size-xs: 10px;

--- a/packages/react-devtools/src/components/cache/CacheTimeline.module.scss
+++ b/packages/react-devtools/src/components/cache/CacheTimeline.module.scss
@@ -1,5 +1,5 @@
-@use '../../components/tokens' as t;
-@use '../../components/mixins' as m;
+@use "../../components/tokens" as t;
+@use "../../components/mixins" as m;
 
 .operationsList {
   display: flex;

--- a/packages/react-devtools/src/components/components/ComponentsPanel.module.scss
+++ b/packages/react-devtools/src/components/components/ComponentsPanel.module.scss
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-@use '../tokens' as t;
-@use '../mixins' as m;
+@use "../tokens" as t;
+@use "../mixins" as m;
 
 .panel {
   display: flex;
@@ -85,7 +85,9 @@
   border-radius: t.$radius-md;
   font-size: t.$font-size-xs;
   cursor: pointer;
-  transition: background-color t.$transition-fast, color t.$transition-fast;
+  transition:
+    background-color t.$transition-fast,
+    color t.$transition-fast;
 
   &:hover {
     background: t.$bg-hover;
@@ -136,7 +138,9 @@
   color: t.$text-secondary;
   font-size: t.$font-size-sm;
   border-left: 2px solid transparent;
-  transition: background-color t.$transition-fast, border-left-color t.$transition-fast;
+  transition:
+    background-color t.$transition-fast,
+    border-left-color t.$transition-fast;
 }
 
 .treeRowInteractive {

--- a/packages/react-devtools/src/components/console/ConsolePanel.module.scss
+++ b/packages/react-devtools/src/components/console/ConsolePanel.module.scss
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-@use '../tokens' as t;
-@use '../mixins' as m;
+@use "../tokens" as t;
+@use "../mixins" as m;
 
 .panel {
   display: flex;

--- a/packages/react-devtools/src/inspector/components/ComponentLabel.module.scss
+++ b/packages/react-devtools/src/inspector/components/ComponentLabel.module.scss
@@ -2,15 +2,16 @@
   position: fixed;
   z-index: 2147483647;
   pointer-events: auto;
-  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
-    monospace;
+  font-family:
+    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
   font-size: 12px;
   line-height: 1.4;
   background-color: rgba(30, 30, 30, 0.95);
   color: #fff;
   border-radius: 6px;
   padding: 8px 12px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3),
+  box-shadow:
+    0 4px 12px rgba(0, 0, 0, 0.3),
     0 0 0 1px rgba(255, 255, 255, 0.1);
   max-width: 400px;
   transition: opacity 150ms ease-out;
@@ -70,7 +71,9 @@
   align-items: center;
   justify-content: center;
   border-radius: 2px;
-  transition: color 150ms ease-out, background-color 150ms ease-out;
+  transition:
+    color 150ms ease-out,
+    background-color 150ms ease-out;
 
   &:hover {
     color: #60a5fa;

--- a/packages/widget.vite-plugin/src/client/main.css
+++ b/packages/widget.vite-plugin/src/client/main.css
@@ -1,44 +1,44 @@
 .body {
-    align-items: center;
-    display: flex;
-    height: 100%;
+  align-items: center;
+  display: flex;
+  height: 100%;
 }
 
 body,
 html {
-    height: 100%;
+  height: 100%;
 }
 
 iframe {
-    display: none;
+  display: none;
 }
 
 .description {
-    display: flex;
-    align-items: center;
-    gap: 5px;
+  display: flex;
+  align-items: center;
+  gap: 5px;
 }
 
 .response-block {
-    text-align: left;
-    overflow-x: auto;
-    white-space: pre-wrap;
-    word-wrap: break-word;
+  text-align: left;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-wrap: break-word;
 }
 
 .hint-block {
-    text-align: left;
-    overflow-x: auto;
-    white-space: pre-wrap;
-    word-wrap: normal;
-    background-color: #fef3cd;
-    border: 1px solid #ffc107;
-    border-radius: 4px;
-    padding: 12px;
-    margin-bottom: 16px;
-    color: #856404;
+  text-align: left;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-wrap: normal;
+  background-color: #fef3cd;
+  border: 1px solid #ffc107;
+  border-radius: 4px;
+  padding: 12px;
+  margin-bottom: 16px;
+  color: #856404;
 }
 
 .bp6-non-ideal-state > * {
-    max-width: min(100%, 800px);
+  max-width: min(100%, 800px);
 }

--- a/turbo.json
+++ b/turbo.json
@@ -22,6 +22,11 @@
       "inputs": [
         "src/**/*.ts",
         "src/**/*.tsx",
+        "src/**/*.css",
+        "src/**/*.scss",
+        "src/**/*.html",
+        ".storybook/**/*.css",
+        "*.html",
         ".eslintrc.cjs",
         "eslint.config.mjs",
         "tsconfig.json"


### PR DESCRIPTION
## Summary

Extends the oxc formatting migration to cover **css, scss, and html** in packages already migrated to the oxc toolchain. These file types were previously left unformatted (the root `oxfmt.config.ts` explicitly ignored them, and dprint never had a css/html plugin).

`oxfmt` only runs inside oxc-migrated packages (each invokes `oxfmt -c ../../oxfmt.config.ts .`), so enabling these types formats the migrated component packages' stylesheets and the vite sandbox apps' `index.html` entry points, while packages still on the eslint/dprint path are untouched.

## File types

| Type | Status | Notes |
|------|--------|-------|
| css | ✅ enabled | 45 files reformatted |
| scss | ✅ enabled | 15 files |
| html | ✅ enabled | 2 `index.html` files |
| yaml/yml | ❌ kept excluded | The only yaml in migrated packages is the mustache-template `documentation.yml` (oxfmt reindents the `{{#isUnary}}` sections inside `|-` block scalars and corrupts them, verified) plus historical changelogs (already ignored). Nothing else to gain. |
| toml / less | n/a | Zero files in the repo |

oxlint is JS/TS only, so the new types are **formatted, not linted**.

## Changes

**Config & wiring**
- `oxfmt.config.ts`: removed the `**/*.css`, `**/*.scss`, `**/*.html` ignore entries; updated the yaml rationale.
- `.lintstagedrc.mjs`: added a css/scss/html handler scoped to the oxc packages that runs `oxfmt` only (oxlint does not process these types).
- `turbo.json`: added css/scss/html globs to the `lint` task inputs so edits bust the lint cache. (Config changes already invalidate lint via the existing `//#global-oxc-config` task.)

**Formatting** (separate commit)
- 62 files reformatted across 12 migrated packages. No behavioral changes: css selector/value wrapping, scss quote normalization and block expansion, html void-element self-closing.

## Verification
- Full `turbo lint` on `@osdk/cbac-components` passes (oxlint + oxfmt).
- `oxfmt --check` passes on all 12 affected packages (react-components: 568 files).
- Non-migrated `react-components-styles` correctly untouched.
- Single pinned tool version throughout: oxfmt 0.53.0.