### PR TITLE
chore: re-enable oxlint no-useless-switch-case

### DIFF
--- a/.changeset/reenable-no-useless-switch-case.md
+++ b/.changeset/reenable-no-useless-switch-case.md
@@ -1,0 +1,9 @@
+---
+"@osdk/maker": patch
+"@osdk/maker-experimental": patch
+"@osdk/react-devtools": patch
+"@osdk/react-sdk-docs": patch
+"@osdk/typescript-sdk-docs": patch
+---
+
+Re-enable the `unicorn/no-useless-switch-case` oxlint rule and drop the redundant empty `case` labels that fell straight through to `default`. Behavior-preserving with no runtime or API changes.

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -53,13 +53,9 @@ export default defineConfig({
     "unicorn/no-lonely-if": "off",
     "jsdoc/require-param-description": "off",
     "jsdoc/require-returns-description": "off",
-    // Cyclomatic-complexity ceiling; the large discriminated-union switch helpers
-    // in the docs packages exceed it. Splitting them up is pure churn here.
+    // Cyclomatic-complexity ceiling. Not a pure autofix (requires extracting
+    // helpers, which adds bundle size), so it's handled in its own PR.
     "complexity": "off",
-    // Several switches list known discriminant values (e.g. "string", "unknown")
-    // that share the `default` body. Keeping the explicit cases documents intent;
-    // removing them would be churn with no behavioral change.
-    "unicorn/no-useless-switch-case": "off",
 
     // Rules whose autofix would change behavior or the public API of these
     // already-published packages. Kept at prior severity / disabled so the

--- a/packages/e2e.sandbox.officenetwork/src/utils/reorgAlgorithms.ts
+++ b/packages/e2e.sandbox.officenetwork/src/utils/reorgAlgorithms.ts
@@ -22,7 +22,6 @@ export function generateChanges(
       return generateSwapChanges(employees, offices, config);
     case "consolidate":
       return generateConsolidateChanges(employees, offices, config);
-    case "manual":
     default:
       return generateManualChanges(employees);
   }

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertDatasourceDefinition.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertDatasourceDefinition.ts
@@ -126,7 +126,6 @@ export function convertDatasourceDefinition(
         },
       };
 
-    case "dataset":
     default:
       // Use generateLocator for dataset datasources
       const datasetLocator = ridGenerator.generateDatasetLocator(

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertLink.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertLink.ts
@@ -321,7 +321,6 @@ export function convertLinkStatus(
       return { type: "experimental", experimental: {} };
     case "example":
       return { type: "example", example: {} };
-    case "active":
     default:
       return { type: "active", active: {} };
   }

--- a/packages/maker/src/conversion/toMarketplace/convertDatasourceDefinition.ts
+++ b/packages/maker/src/conversion/toMarketplace/convertDatasourceDefinition.ts
@@ -88,7 +88,6 @@ export function convertDatasourceDefinition(
           ),
         },
       };
-    case "dataset":
     default:
       if (
         objectType.properties?.some(

--- a/packages/maker/src/conversion/toMarketplace/convertLink.ts
+++ b/packages/maker/src/conversion/toMarketplace/convertLink.ts
@@ -293,7 +293,6 @@ export function convertLinkStatus(
       return { type: "experimental", experimental: {} };
     case "example":
       return { type: "example", example: {} };
-    case "active":
     default:
       return { type: "active", active: {} };
   }

--- a/packages/react-devtools/src/components/HookRow.tsx
+++ b/packages/react-devtools/src/components/HookRow.tsx
@@ -178,7 +178,6 @@ export const HookRow: React.FC<HookRowProps> = ({
             </Tag>
           </Tooltip>
         );
-      case "idle":
       default:
         return null;
     }

--- a/packages/react-sdk-docs/src/docs.ts
+++ b/packages/react-sdk-docs/src/docs.ts
@@ -181,7 +181,6 @@ function renderType(
     case "string": {
       return `"${type.value ?? "value"}"`;
     }
-    case "unknown":
     default: {
       return `"value"`;
     }

--- a/packages/typescript-sdk-docs/src/docs.ts
+++ b/packages/typescript-sdk-docs/src/docs.ts
@@ -452,8 +452,6 @@ function renderType(
       )}: ${renderType(type.valueType, majorVersion, context)}}`;
     }
 
-    case "string":
-    case "unknown":
     default: {
       return `"${type.value ?? "value"}"`;
     }


### PR DESCRIPTION
Re-enables the `unicorn/no-useless-switch-case` oxlint rule, which we parked repo-wide during the oxc migration, and drops the handful of redundant case labels it flags.

The rule only flags an **empty** `case` that falls straight through to `default`, e.g.:

```ts
case "manual":   // empty, falls through
default:
  return generateManualChanges(employees);   // "manual" lands here anyway
```

Removing `case "manual":` is behavior-neutral (it still hits `default`). That's all the changes here are: 8 files where an empty case fell through to a `default` that already handled it. It does not touch exhaustive `switch`es that use a `const _: never` check — those have an unreachable `default`, so nothing falls through to flag.

### Scope / what's intentionally left off

This started as a batch of formatting rules; based on review feedback the rest are staying off:

- **`prefer-destructuring`** — off. Array destructuring (`const [, x] = arr`) read worse than indexed access, and object destructuring wasn't worth the churn either, so the whole rule stays disabled.
- **`curly`** — off. Forcing braces on guard clauses like `if (x) continue;` reads worse.
- **`complexity`** — its own PR (#3687), since it can't be autofixed and its extractions add shipped code.
- **`sort-keys`** — off (alphabetizing object keys reads worse than intentional grouping).

Scope is limited to packages already on the oxc toolchain.

### Config change

Removed the `unicorn/no-useless-switch-case` off-override from the root `oxlint.config.ts`. Everything else stays off.

### Verification

Green across the repo: `lint` + `typecheck` (305/305) and the full test suite (maker 154, maker-experimental 67, react-devtools 558). Behavior-preserving.