### PR TITLE
add copy-prompt builder and button for devtools recommendations

### DIFF
--- a/.changeset/copy-prompt-button.md
+++ b/.changeset/copy-prompt-button.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+add copy-prompt builder and CopyPromptButton for actionable performance recommendations

--- a/packages/react-devtools/src/components/CopyPromptButton.test.tsx
+++ b/packages/react-devtools/src/components/CopyPromptButton.test.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildCopyAllPrompt,
+  buildCopyPrompt,
+} from "../recommendations/copyPrompt.js";
+import type { Recommendation } from "../utils/PerformanceRecommendationEngine.js";
+
+const { CopyPromptButton } = await import("./CopyPromptButton.js");
+
+function makeRec(overrides: Partial<Recommendation> = {}): Recommendation {
+  return {
+    id: "rec-1",
+    level: "high",
+    category: "Bandwidth",
+    title: "EmployeeCard fetches unused data",
+    description: "This component fetches 12 properties but only uses 3",
+    impact: "Save 4.2KB bandwidth per load",
+    effort: "Low",
+    suggestion: "Use $select to only fetch used properties",
+    dismissible: true,
+    ...overrides,
+  };
+}
+
+const writeText = vi.fn<(text: string) => Promise<void>>();
+
+beforeEach(() => {
+  writeText.mockReset();
+  writeText.mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+async function flushMicrotasks(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe("CopyPromptButton", () => {
+  it("copies the single-recommendation prompt and flips the icon to tick", async () => {
+    const rec = makeRec({ filePath: "src/A.tsx", lineNumber: 7 });
+
+    const { container } = render(<CopyPromptButton recommendation={rec} />);
+
+    expect(container.querySelector('[data-icon="clipboard"]')).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button"));
+    await flushMicrotasks();
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText).toHaveBeenCalledWith(buildCopyPrompt(rec));
+    expect(container.querySelector('[data-icon="tick"]')).not.toBeNull();
+    expect(container.querySelector('[data-icon="clipboard"]')).toBeNull();
+  });
+
+  it("copies the combined prompt for multiple recommendations", async () => {
+    const recs = [makeRec({ id: "rec-1" }), makeRec({ id: "rec-2" })];
+
+    render(<CopyPromptButton recommendations={recs} />);
+
+    fireEvent.click(screen.getByRole("button"));
+    await flushMicrotasks();
+
+    expect(writeText).toHaveBeenCalledWith(buildCopyAllPrompt(recs));
+  });
+
+  it("resets the icon back to clipboard after the timeout elapses", async () => {
+    vi.useFakeTimers();
+    const rec = makeRec();
+
+    const { container } = render(<CopyPromptButton recommendation={rec} />);
+
+    fireEvent.click(screen.getByRole("button"));
+    await flushMicrotasks();
+
+    expect(container.querySelector('[data-icon="tick"]')).not.toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(container.querySelector('[data-icon="tick"]')).toBeNull();
+    expect(container.querySelector('[data-icon="clipboard"]')).not.toBeNull();
+  });
+
+  it("defaults to the single label and respects an override", () => {
+    const { rerender } = render(
+      <CopyPromptButton recommendation={makeRec()} />
+    );
+
+    expect(screen.getByText("Copy prompt")).not.toBeNull();
+
+    rerender(
+      <CopyPromptButton recommendation={makeRec()} label="Fix it for me" />
+    );
+
+    expect(screen.getByText("Fix it for me")).not.toBeNull();
+  });
+
+  it("defaults to the copy-all label for multiple recommendations", () => {
+    render(<CopyPromptButton recommendations={[makeRec()]} />);
+
+    expect(screen.getByText("Copy all")).not.toBeNull();
+  });
+});

--- a/packages/react-devtools/src/components/CopyPromptButton.tsx
+++ b/packages/react-devtools/src/components/CopyPromptButton.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button } from "@blueprintjs/core";
+import React, { useCallback, useRef, useState } from "react";
+
+import {
+  buildCopyAllPrompt,
+  buildCopyPrompt,
+} from "../recommendations/copyPrompt.js";
+import type { Recommendation } from "../utils/PerformanceRecommendationEngine.js";
+
+export type CopyPromptButtonProps =
+  | { recommendation: Recommendation; label?: string }
+  | { recommendations: Recommendation[]; label?: string };
+
+export const CopyPromptButton: React.FC<CopyPromptButtonProps> = (props) => {
+  const [copied, setCopied] = useState(false);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const isSingle = "recommendation" in props;
+  const prompt = isSingle
+    ? buildCopyPrompt(props.recommendation)
+    : buildCopyAllPrompt(props.recommendations);
+  const label = props.label ?? (isSingle ? "Copy prompt" : "Copy all");
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(prompt);
+      setCopied(true);
+      clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard writes can reject (e.g. denied permission); ignore silently.
+    }
+  }, [prompt]);
+
+  return (
+    <Button
+      variant="minimal"
+      size="small"
+      icon={copied ? "tick" : "clipboard"}
+      onClick={() => void handleCopy()}
+    >
+      {label}
+    </Button>
+  );
+};

--- a/packages/react-devtools/src/components/CopyPromptButton.tsx
+++ b/packages/react-devtools/src/components/CopyPromptButton.tsx
@@ -15,8 +15,9 @@
  */
 
 import { Button } from "@blueprintjs/core";
-import React, { useCallback, useRef, useState } from "react";
+import React from "react";
 
+import { useCopyToClipboard } from "../hooks/useCopyToClipboard.js";
 import {
   buildCopyAllPrompt,
   buildCopyPrompt,
@@ -28,8 +29,7 @@ export type CopyPromptButtonProps =
   | { recommendations: Recommendation[]; label?: string };
 
 export const CopyPromptButton: React.FC<CopyPromptButtonProps> = (props) => {
-  const [copied, setCopied] = useState(false);
-  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const { copied, copy } = useCopyToClipboard();
 
   const isSingle = "recommendation" in props;
   const prompt = isSingle
@@ -37,23 +37,12 @@ export const CopyPromptButton: React.FC<CopyPromptButtonProps> = (props) => {
     : buildCopyAllPrompt(props.recommendations);
   const label = props.label ?? (isSingle ? "Copy prompt" : "Copy all");
 
-  const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(prompt);
-      setCopied(true);
-      clearTimeout(copyTimeoutRef.current);
-      copyTimeoutRef.current = setTimeout(() => setCopied(false), 1500);
-    } catch {
-      // Clipboard writes can reject (e.g. denied permission); ignore silently.
-    }
-  }, [prompt]);
-
   return (
     <Button
       variant="minimal"
       size="small"
       icon={copied ? "tick" : "clipboard"}
-      onClick={() => void handleCopy()}
+      onClick={() => void copy(prompt)}
     >
       {label}
     </Button>

--- a/packages/react-devtools/src/hooks/useCopyToClipboard.ts
+++ b/packages/react-devtools/src/hooks/useCopyToClipboard.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useRef, useState } from "react";
+
+export interface UseCopyToClipboard {
+  copied: boolean;
+  copy: (text: string) => Promise<void>;
+}
+
+/**
+ * Copies text to the clipboard and briefly reports success so a caller can flip
+ * an icon or label. Clipboard writes can reject (e.g. denied permission); those
+ * are swallowed and leave `copied` false.
+ */
+export function useCopyToClipboard(resetMs = 1500): UseCopyToClipboard {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const copy = useCallback(
+    async (text: string) => {
+      try {
+        await navigator.clipboard.writeText(text);
+        setCopied(true);
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = setTimeout(() => setCopied(false), resetMs);
+      } catch {
+        // Clipboard writes can reject (e.g. denied permission); ignore silently.
+      }
+    },
+    [resetMs]
+  );
+
+  return { copied, copy };
+}

--- a/packages/react-devtools/src/recommendations/copyPrompt.test.ts
+++ b/packages/react-devtools/src/recommendations/copyPrompt.test.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { Recommendation } from "../utils/PerformanceRecommendationEngine.js";
+import { OSDK_GUIDANCE_BY_CATEGORY } from "../utils/PerformanceRecommendationEngine.js";
+import { buildCopyAllPrompt, buildCopyPrompt } from "./copyPrompt.js";
+
+function makeRec(overrides: Partial<Recommendation> = {}): Recommendation {
+  return {
+    id: "rec-1",
+    level: "high",
+    category: "Bandwidth",
+    title: "EmployeeCard fetches unused data",
+    description: "This component fetches 12 properties but only uses 3",
+    impact: "Save 4.2KB bandwidth per load",
+    effort: "Low",
+    suggestion: "Use $select to only fetch used properties",
+    dismissible: true,
+    ...overrides,
+  };
+}
+
+describe("buildCopyPrompt", () => {
+  it("always renders intro, issue, suggestion, guidance and task sections", () => {
+    const prompt = buildCopyPrompt(makeRec());
+
+    expect(prompt).toContain("OSDK React Toolkit");
+    expect(prompt).toContain(
+      "ISSUE: EmployeeCard fetches unused data (Bandwidth, severity: high)"
+    );
+    expect(prompt).toContain(
+      "WHY IT MATTERS: This component fetches 12 properties but only uses 3"
+    );
+    expect(prompt).toContain("EXPECTED IMPACT: Save 4.2KB bandwidth per load");
+    expect(prompt).toContain(
+      "SUGGESTED FIX:\nUse $select to only fetch used properties"
+    );
+    expect(prompt).toContain("OSDK GUIDANCE:");
+    expect(prompt).toContain("TASK: Apply the suggested fix");
+  });
+
+  it("omits the LOCATION line when filePath is absent", () => {
+    expect(buildCopyPrompt(makeRec())).not.toContain("LOCATION:");
+  });
+
+  it("renders LOCATION with line number when both filePath and lineNumber are present", () => {
+    const prompt = buildCopyPrompt(
+      makeRec({ filePath: "src/A.tsx", lineNumber: 17 })
+    );
+
+    expect(prompt).toContain("LOCATION: src/A.tsx:17");
+  });
+
+  it("renders LOCATION without a line suffix when only filePath is present", () => {
+    const prompt = buildCopyPrompt(makeRec({ filePath: "src/A.tsx" }));
+
+    expect(prompt).toContain("LOCATION: src/A.tsx");
+    expect(prompt).not.toContain("src/A.tsx:");
+  });
+
+  it("includes lineNumber 0 in the LOCATION line", () => {
+    const prompt = buildCopyPrompt(
+      makeRec({ filePath: "src/A.tsx", lineNumber: 0 })
+    );
+
+    expect(prompt).toContain("LOCATION: src/A.tsx:0");
+  });
+
+  it("omits the CURRENT CODE block when currentCode is absent", () => {
+    expect(buildCopyPrompt(makeRec())).not.toContain("CURRENT CODE:");
+  });
+
+  it("renders a fenced CURRENT CODE block when currentCode is present", () => {
+    const prompt = buildCopyPrompt(makeRec({ currentCode: "const x = 1;" }));
+
+    expect(prompt).toContain("CURRENT CODE:\n```tsx\nconst x = 1;\n```");
+  });
+
+  it("renders the suggestion without a code fence when code is absent", () => {
+    const prompt = buildCopyPrompt(makeRec());
+
+    expect(prompt).toContain(
+      "SUGGESTED FIX:\nUse $select to only fetch used properties"
+    );
+    expect(prompt).not.toContain("```tsx");
+  });
+
+  it("appends a fenced code block under SUGGESTED FIX when code is present", () => {
+    const prompt = buildCopyPrompt(makeRec({ code: "const y = 2;" }));
+
+    expect(prompt).toContain(
+      "SUGGESTED FIX:\nUse $select to only fetch used properties\n```tsx\nconst y = 2;\n```"
+    );
+  });
+
+  it("prefers the recommendation's own osdkGuidance when provided", () => {
+    const prompt = buildCopyPrompt(
+      makeRec({ osdkGuidance: "Custom guidance for this rec." })
+    );
+
+    expect(prompt).toContain("OSDK GUIDANCE:\nCustom guidance for this rec.");
+  });
+
+  it("falls back to the category guidance when osdkGuidance is absent", () => {
+    const prompt = buildCopyPrompt(makeRec({ category: "Cache" }));
+
+    expect(prompt).toContain(
+      `OSDK GUIDANCE:\n${OSDK_GUIDANCE_BY_CATEGORY.Cache}`
+    );
+  });
+});
+
+describe("buildCopyAllPrompt", () => {
+  it("renders the count preamble", () => {
+    const prompt = buildCopyAllPrompt([makeRec(), makeRec({ id: "rec-2" })]);
+
+    expect(prompt).toContain(
+      "Here are 2 OSDK optimizations, ordered by priority:"
+    );
+  });
+
+  it("numbers each recommendation and separates them with a horizontal rule", () => {
+    const prompt = buildCopyAllPrompt([
+      makeRec({ id: "rec-1", title: "First" }),
+      makeRec({ id: "rec-2", title: "Second" }),
+    ]);
+
+    expect(prompt).toContain("1. You are helping optimize");
+    expect(prompt).toContain("2. You are helping optimize");
+    expect(prompt).toContain("\n\n---\n\n");
+  });
+});

--- a/packages/react-devtools/src/recommendations/copyPrompt.test.ts
+++ b/packages/react-devtools/src/recommendations/copyPrompt.test.ts
@@ -36,7 +36,7 @@ function makeRec(overrides: Partial<Recommendation> = {}): Recommendation {
 }
 
 describe("buildCopyPrompt", () => {
-  it("always renders intro, issue, suggestion, guidance and task sections", () => {
+  it("renders intro, issue, suggestion, guidance and task sections", () => {
     const prompt = buildCopyPrompt(makeRec());
 
     expect(prompt).toContain("OSDK React Toolkit");
@@ -54,13 +54,10 @@ describe("buildCopyPrompt", () => {
     expect(prompt).toContain("TASK: Apply the suggested fix");
   });
 
-  it("omits the LOCATION line when filePath is absent", () => {
-    expect(buildCopyPrompt(makeRec())).not.toContain("LOCATION:");
-  });
-
-  it("does not claim a location in the task when filePath is absent", () => {
+  it("omits LOCATION and points the task at the issue when filePath is absent", () => {
     const prompt = buildCopyPrompt(makeRec());
 
+    expect(prompt).not.toContain("LOCATION:");
     expect(prompt).not.toContain("the location above");
     expect(prompt).toContain(
       "Use the issue and suggested fix above to find the component or query"

--- a/packages/react-devtools/src/recommendations/copyPrompt.test.ts
+++ b/packages/react-devtools/src/recommendations/copyPrompt.test.ts
@@ -58,6 +58,23 @@ describe("buildCopyPrompt", () => {
     expect(buildCopyPrompt(makeRec())).not.toContain("LOCATION:");
   });
 
+  it("does not claim a location in the task when filePath is absent", () => {
+    const prompt = buildCopyPrompt(makeRec());
+
+    expect(prompt).not.toContain("the location above");
+    expect(prompt).toContain(
+      "Use the issue and suggested fix above to find the component or query"
+    );
+  });
+
+  it("points the task at the location when filePath is present", () => {
+    const prompt = buildCopyPrompt(makeRec({ filePath: "src/A.tsx" }));
+
+    expect(prompt).toContain(
+      "TASK: Apply the suggested fix at the location above"
+    );
+  });
+
   it("renders LOCATION with line number when both filePath and lineNumber are present", () => {
     const prompt = buildCopyPrompt(
       makeRec({ filePath: "src/A.tsx", lineNumber: 17 })

--- a/packages/react-devtools/src/recommendations/copyPrompt.ts
+++ b/packages/react-devtools/src/recommendations/copyPrompt.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Recommendation } from "../utils/PerformanceRecommendationEngine.js";
+import { OSDK_GUIDANCE_BY_CATEGORY } from "../utils/PerformanceRecommendationEngine.js";
+
+const INTRO =
+  "You are helping optimize an app built with the OSDK React Toolkit (@osdk/react).";
+
+const TASK =
+  "TASK: Apply the suggested fix at the location above. Keep behavior identical except for the optimization. If the file/line is approximate, search for the matching hook call.";
+
+/**
+ * Builds an AI-ready prompt for a single performance recommendation. Sections
+ * with no data are omitted cleanly so the output stays reproducible.
+ */
+export function buildCopyPrompt(rec: Recommendation): string {
+  const sections: string[] = [
+    INTRO,
+    [
+      `ISSUE: ${rec.title} (${rec.category}, severity: ${rec.level})`,
+      `WHY IT MATTERS: ${rec.description}`,
+      `EXPECTED IMPACT: ${rec.impact}`,
+    ].join("\n"),
+  ];
+
+  if (rec.filePath) {
+    const location =
+      rec.lineNumber != null
+        ? `${rec.filePath}:${rec.lineNumber}`
+        : rec.filePath;
+    sections.push(`LOCATION: ${location}`);
+  }
+
+  if (rec.currentCode) {
+    sections.push(`CURRENT CODE:\n\`\`\`tsx\n${rec.currentCode}\n\`\`\``);
+  }
+
+  sections.push(
+    rec.code
+      ? `SUGGESTED FIX:\n${rec.suggestion}\n\`\`\`tsx\n${rec.code}\n\`\`\``
+      : `SUGGESTED FIX:\n${rec.suggestion}`
+  );
+
+  const guidance = rec.osdkGuidance ?? OSDK_GUIDANCE_BY_CATEGORY[rec.category];
+  sections.push(`OSDK GUIDANCE:\n${guidance}`);
+
+  sections.push(TASK);
+
+  return sections.join("\n\n");
+}
+
+/**
+ * Builds a single combined prompt covering several recommendations, ordered as
+ * given. Each recommendation is numbered and the entries are separated by a
+ * horizontal rule.
+ */
+export function buildCopyAllPrompt(recs: Recommendation[]): string {
+  const preamble = `Here are ${recs.length} OSDK optimizations, ordered by priority:`;
+  const items = recs.map((rec, i) => `${i + 1}. ${buildCopyPrompt(rec)}`);
+  return `${preamble}\n\n${items.join("\n\n---\n\n")}`;
+}

--- a/packages/react-devtools/src/recommendations/copyPrompt.ts
+++ b/packages/react-devtools/src/recommendations/copyPrompt.ts
@@ -73,6 +73,8 @@ export function buildCopyPrompt(rec: Recommendation): string {
  * horizontal rule.
  */
 export function buildCopyAllPrompt(recs: Recommendation[]): string {
+  // Recs arrive already sorted by priority from PerformanceRecommendationEngine,
+  // so this keeps the caller's order rather than re-sorting here.
   const preamble = `Here are ${recs.length} OSDK optimizations, ordered by priority:`;
   const items = recs.map((rec, i) => `${i + 1}. ${buildCopyPrompt(rec)}`);
   return `${preamble}\n\n${items.join("\n\n---\n\n")}`;

--- a/packages/react-devtools/src/recommendations/copyPrompt.ts
+++ b/packages/react-devtools/src/recommendations/copyPrompt.ts
@@ -20,9 +20,6 @@ import { OSDK_GUIDANCE_BY_CATEGORY } from "../utils/PerformanceRecommendationEng
 const INTRO =
   "You are helping optimize an app built with the OSDK React Toolkit (@osdk/react).";
 
-const TASK =
-  "TASK: Apply the suggested fix at the location above. Keep behavior identical except for the optimization. If the file/line is approximate, search for the matching hook call.";
-
 /**
  * Builds an AI-ready prompt for a single performance recommendation. Sections
  * with no data are omitted cleanly so the output stays reproducible.
@@ -58,7 +55,14 @@ export function buildCopyPrompt(rec: Recommendation): string {
   const guidance = rec.osdkGuidance ?? OSDK_GUIDANCE_BY_CATEGORY[rec.category];
   sections.push(`OSDK GUIDANCE:\n${guidance}`);
 
-  sections.push(TASK);
+  // The location is only known when a binding could be resolved. Without it,
+  // point back at the issue and fix, which name the component or query to look
+  // for, rather than a location that was never included.
+  const task =
+    rec.filePath != null
+      ? "TASK: Apply the suggested fix at the location above, keeping behavior identical except for the optimization."
+      : "TASK: Apply the suggested fix. Use the issue and suggested fix above to find the component or query it refers to, keeping behavior identical except for the optimization.";
+  sections.push(task);
 
   return sections.join("\n\n");
 }

--- a/packages/react-devtools/src/recommendations/levelToIntent.ts
+++ b/packages/react-devtools/src/recommendations/levelToIntent.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Intent } from "@blueprintjs/core";
+
+import type { RecommendationLevel } from "../utils/PerformanceRecommendationEngine.js";
+
+/** Map a recommendation severity level to a Blueprint intent for display. */
+export function levelToIntent(level: RecommendationLevel): Intent {
+  switch (level) {
+    case "critical": {
+      return "danger";
+    }
+    case "high": {
+      return "warning";
+    }
+    case "medium": {
+      return "primary";
+    }
+    default: {
+      return "none";
+    }
+  }
+}

--- a/packages/react-devtools/src/utils/PerformanceRecommendationEngine.ts
+++ b/packages/react-devtools/src/utils/PerformanceRecommendationEngine.ts
@@ -47,7 +47,25 @@ export interface Recommendation {
   suggestion: string;
   code?: string;
   dismissible: boolean;
+  filePath?: string;
+  lineNumber?: number;
+  currentCode?: string;
+  osdkGuidance?: string;
 }
+
+export const OSDK_GUIDANCE_BY_CATEGORY: Record<RecommendationCategory, string> =
+  {
+    Performance:
+      "Avoid sequential data dependencies. Prefer a single query (using $select, links, or an object set) over chained hooks that wait on one another, so the toolkit can resolve data in parallel.",
+    Bandwidth:
+      "Use $select to fetch only the properties a component reads. The toolkit caches and revalidates per-property, so narrower selections reduce payload size and unnecessary refetches.",
+    "Code Quality":
+      "Keep query definitions colocated with the component that consumes them and request only the data you render. Lean queries are easier for the toolkit to cache and dedupe.",
+    Cache:
+      "Reuse shared object sets and query keys so the toolkit can serve cached results instead of refetching. Avoid recreating query inputs on every render.",
+    Queries:
+      "Consolidate overlapping queries. The toolkit deduplicates identical query signatures, so aligning inputs lets multiple components share one subscription.",
+  };
 
 export interface PerformanceScore {
   overall: number; // 0-100
@@ -108,6 +126,7 @@ export class PerformanceRecommendationEngine {
         suggestion: wf.suggestion,
         code: wf.code,
         dismissible: true,
+        osdkGuidance: OSDK_GUIDANCE_BY_CATEGORY.Performance,
       });
     }
 
@@ -118,6 +137,11 @@ export class PerformanceRecommendationEngine {
       ) {
         continue;
       }
+
+      const subscribers = this.registry.getQuerySubscribers(
+        offender.querySignature
+      );
+      const locatedBinding = subscribers.find((b) => b.filePath);
 
       recommendations.push({
         id: `field-${offender.querySignature}`,
@@ -132,6 +156,9 @@ export class PerformanceRecommendationEngine {
         suggestion: "Use $select to only fetch used properties",
         code: offender.suggestion,
         dismissible: true,
+        filePath: locatedBinding?.filePath,
+        lineNumber: locatedBinding?.lineNumber,
+        osdkGuidance: OSDK_GUIDANCE_BY_CATEGORY.Bandwidth,
       });
     }
 
@@ -152,6 +179,7 @@ export class PerformanceRecommendationEngine {
           effort: "Medium",
           suggestion: rec.suggestion,
           dismissible: true,
+          osdkGuidance: OSDK_GUIDANCE_BY_CATEGORY.Cache,
         });
       }
     }


### PR DESCRIPTION
adds a one-click copy-prompt action that turns a performance recommendation into an ai-ready fix prompt

• new copyPrompt builder that formats a recommendation (and a copy-all variant) into a prompt
• CopyPromptButton with clipboard write and a copied confirmation
• extends the performance recommendation engine types the button consumes
