### PR TITLE
add overview base tab to devtools

### DIFF
--- a/.changeset/dt2-tab-overview.md
+++ b/.changeset/dt2-tab-overview.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+add the Overview base tab: an at-a-glance landing view with usage summary, cold-start-aware headline metrics, and top recommendations

--- a/packages/react-devtools/src/components/overview/HeadlineMetrics.tsx
+++ b/packages/react-devtools/src/components/overview/HeadlineMetrics.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Card } from "@blueprintjs/core";
+import React from "react";
+
+import { useCanonicalMetrics } from "../../hooks/useCanonicalMetrics.js";
+import { formatMetric, type Metric } from "../../metrics/canonicalMetrics.js";
+import type { MonitorStore } from "../../store/MonitorStore.js";
+
+import styles from "./OverviewPanel.module.scss";
+
+interface HeadlineMetricsProps {
+  monitorStore: MonitorStore;
+}
+
+/**
+ * Three headline numbers with cold-start awareness: until enough samples are
+ * collected each shows a neutral "collecting data…" instead of an alarming 0%.
+ */
+export const HeadlineMetrics: React.FC<HeadlineMetricsProps> = ({
+  monitorStore,
+}) => {
+  const metrics = useCanonicalMetrics(monitorStore);
+  const stats: Array<{ label: string; metric: Metric }> = [
+    { label: "Cache hit rate", metric: metrics.cacheHitRate },
+    { label: "Requests saved", metric: metrics.requestsSaved },
+    { label: "Optimistic coverage", metric: metrics.optimisticCoverage },
+  ];
+
+  return (
+    <div className={styles.headline}>
+      {stats.map((stat) => (
+        <Card key={stat.label} className={styles.statCard}>
+          <div
+            className={
+              stat.metric.ready ? styles.statValue : styles.statPending
+            }
+          >
+            {formatMetric(stat.metric)}
+          </div>
+          <div className={styles.statLabel}>{stat.label}</div>
+        </Card>
+      ))}
+    </div>
+  );
+};

--- a/packages/react-devtools/src/components/overview/OverviewPanel.module.scss
+++ b/packages/react-devtools/src/components/overview/OverviewPanel.module.scss
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.overview {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 12px;
+}
+
+.headline {
+  display: flex;
+  gap: 8px;
+}
+
+.statCard {
+  flex: 1;
+  padding: 12px;
+  text-align: center;
+}
+
+.statValue {
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.statPending {
+  font-size: 13px;
+  opacity: 0.6;
+}
+
+.statLabel {
+  font-size: 11px;
+  opacity: 0.7;
+  margin-top: 4px;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sectionTitle {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.7;
+}
+
+.usageGroups {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.usageGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.usageKind {
+  font-size: 11px;
+  font-weight: 600;
+  opacity: 0.6;
+  margin-bottom: 2px;
+}
+
+.usageRow {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  padding: 2px 4px;
+}
+
+.usageName {
+  font-family: monospace;
+}
+
+.usageCount {
+  opacity: 0.7;
+}
+
+.recHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.recItem {
+  margin-bottom: 8px;
+}
+
+.recBody {
+  font-size: 12px;
+  margin-bottom: 6px;
+}
+
+.recActions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.empty {
+  font-size: 12px;
+  opacity: 0.6;
+  padding: 8px 4px;
+}

--- a/packages/react-devtools/src/components/overview/OverviewPanel.test.tsx
+++ b/packages/react-devtools/src/components/overview/OverviewPanel.test.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { MonitorStore } from "../../store/MonitorStore.js";
+import type { MetricsSnapshot } from "../../types/index.js";
+import type { ComponentHookBinding } from "../../utils/ComponentQueryRegistry.js";
+import { OverviewPanel } from "./OverviewPanel.js";
+
+function emptyAggregates(): MetricsSnapshot["aggregates"] {
+  return {
+    cacheHits: 0,
+    cacheMisses: 0,
+    revalidations: 0,
+    deduplications: 0,
+    actionCount: 0,
+    optimisticActionCount: 0,
+    rollbackActionCount: 0,
+    networkResponseTime: 0,
+    cachedResponseTime: 0,
+    totalResponseTime: 0,
+    totalPerceivedSpeedup: 0,
+  } as MetricsSnapshot["aggregates"];
+}
+
+function makeStore(bindings: ComponentHookBinding[]): MonitorStore {
+  const snapshot = { aggregates: emptyAggregates() } as MetricsSnapshot;
+  const active = new Map<string, ComponentHookBinding[]>();
+  if (bindings.length > 0) {
+    active.set("component-1", bindings);
+  }
+  const stub = {
+    getMetricsStore: () => ({
+      subscribe: () => () => {},
+      getSnapshot: () => snapshot,
+    }),
+    getComponentRegistry: () => ({
+      subscribe: () => () => {},
+      getVersion: () => 0,
+      getActiveComponents: () => active,
+    }),
+    getCacheSnapshot: () =>
+      Promise.resolve({
+        entries: [],
+        stats: { totalEntries: 0, totalSize: 0, totalHits: 0 },
+      }),
+    getRecommendationEngine: () => ({
+      generateRecommendations: () => [],
+    }),
+  };
+  return stub as unknown as MonitorStore;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("OverviewPanel", () => {
+  it("renders headline metrics, usage and recommendations sections", () => {
+    render(<OverviewPanel monitorStore={makeStore([])} theme="light" />);
+    expect(screen.getByText("Cache hit rate")).toBeTruthy();
+    expect(screen.getByText("Top recommendations")).toBeTruthy();
+  });
+
+  it("shows a cold-start state before enough samples are collected", () => {
+    render(<OverviewPanel monitorStore={makeStore([])} theme="light" />);
+    expect(screen.getAllByText("collecting data…").length).toBeGreaterThan(0);
+  });
+
+  it("lists object types that are in use", () => {
+    const binding = {
+      componentId: "component-1",
+      componentName: "ParcelList",
+      hookType: "useOsdkObjects",
+      hookIndex: 0,
+      subscriptionId: "sub-1",
+      querySignature: "useOsdkObjects:Parcel",
+      queryParams: { type: "list", objectType: "Parcel" },
+      stackTrace: "",
+      mountedAt: 0,
+      renderCount: 1,
+      lastRenderDuration: 0,
+      avgRenderDuration: 0,
+    } as ComponentHookBinding;
+    render(<OverviewPanel monitorStore={makeStore([binding])} theme="light" />);
+    expect(screen.getByText("Parcel")).toBeTruthy();
+  });
+});

--- a/packages/react-devtools/src/components/overview/OverviewPanel.tsx
+++ b/packages/react-devtools/src/components/overview/OverviewPanel.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+
+import type { DevToolsPanelProps } from "../../plugins/types.js";
+import { HeadlineMetrics } from "./HeadlineMetrics.js";
+import { TopRecommendations } from "./TopRecommendations.js";
+import { UsageSummary } from "./UsageSummary.js";
+
+import styles from "./OverviewPanel.module.scss";
+
+/**
+ * The at-a-glance landing tab: headline metrics, what the app is using, and the
+ * top performance recommendations. Reads everything from the monitor store; no
+ * configuration required.
+ */
+export const OverviewPanel: React.FC<DevToolsPanelProps> = ({
+  monitorStore,
+}) => {
+  return (
+    <div className={styles.overview}>
+      <HeadlineMetrics monitorStore={monitorStore} />
+      <UsageSummary monitorStore={monitorStore} />
+      <TopRecommendations monitorStore={monitorStore} />
+    </div>
+  );
+};

--- a/packages/react-devtools/src/components/overview/TopRecommendations.tsx
+++ b/packages/react-devtools/src/components/overview/TopRecommendations.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Callout } from "@blueprintjs/core";
+import React from "react";
+
+import { useRecommendations } from "../../hooks/useRecommendations.js";
+import { levelToIntent } from "../../recommendations/levelToIntent.js";
+import type { MonitorStore } from "../../store/MonitorStore.js";
+import { CopyPromptButton } from "../CopyPromptButton.js";
+
+import styles from "./OverviewPanel.module.scss";
+
+interface TopRecommendationsProps {
+  monitorStore: MonitorStore;
+}
+
+/**
+ * The top few performance recommendations, each with a one-click "Copy prompt"
+ * button that puts an AI-ready fix prompt on the clipboard. Shares the
+ * recommendation store with the Performance tab so both stay in sync.
+ */
+export const TopRecommendations: React.FC<TopRecommendationsProps> = ({
+  monitorStore,
+}) => {
+  const { recommendations } = useRecommendations(monitorStore);
+  const top = recommendations.slice(0, 3);
+
+  return (
+    <div className={styles.section}>
+      <div className={styles.recHeader}>
+        <span className={styles.sectionTitle}>Top recommendations</span>
+        {recommendations.length > 0 ? (
+          <CopyPromptButton
+            recommendations={recommendations}
+            label="Copy all"
+          />
+        ) : null}
+      </div>
+      {top.length === 0 ? (
+        <div className={styles.empty}>No recommendations right now.</div>
+      ) : (
+        top.map((rec) => (
+          <Callout
+            key={rec.id}
+            className={styles.recItem}
+            intent={levelToIntent(rec.level)}
+            title={rec.title}
+          >
+            <div className={styles.recBody}>{rec.description}</div>
+            <div className={styles.recActions}>
+              <CopyPromptButton recommendation={rec} />
+            </div>
+          </Callout>
+        ))
+      )}
+    </div>
+  );
+};

--- a/packages/react-devtools/src/components/overview/UsageSummary.tsx
+++ b/packages/react-devtools/src/components/overview/UsageSummary.tsx
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useCallback, useMemo, useSyncExternalStore } from "react";
+
+import type { MonitorStore } from "../../store/MonitorStore.js";
+import type { QueryParams } from "../../utils/ComponentQueryRegistry.js";
+
+import styles from "./OverviewPanel.module.scss";
+
+type UsageKind = "Object types" | "Actions" | "Links";
+
+const KIND_ORDER: UsageKind[] = ["Object types", "Actions", "Links"];
+
+function usageKind(params: QueryParams): UsageKind {
+  if (params.type === "action") {
+    return "Actions";
+  }
+  if (params.type === "links") {
+    return "Links";
+  }
+  return "Object types";
+}
+
+function usageName(params: QueryParams): string {
+  switch (params.type) {
+    case "object":
+    case "list":
+    case "aggregation": {
+      return params.objectType;
+    }
+    case "action": {
+      return params.actionName;
+    }
+    case "links": {
+      return `${params.sourceObject} → ${params.linkName}`;
+    }
+    case "objectSet": {
+      return params.baseObjectSet;
+    }
+    default: {
+      return "Unknown";
+    }
+  }
+}
+
+interface UsageEntry {
+  name: string;
+  count: number;
+}
+
+interface UsageSummaryProps {
+  monitorStore: MonitorStore;
+}
+
+/**
+ * What the running app is actually using: object types, actions and links in
+ * play, with how many live components reference each. Derived from the
+ * component registry, no extra instrumentation.
+ */
+export const UsageSummary: React.FC<UsageSummaryProps> = ({ monitorStore }) => {
+  const registry = monitorStore.getComponentRegistry();
+  const subscribe = useCallback(
+    (cb: () => void) => registry.subscribe(cb),
+    [registry]
+  );
+  const getVersion = useCallback(() => registry.getVersion(), [registry]);
+  const version = useSyncExternalStore(subscribe, getVersion, getVersion);
+
+  const groups = useMemo(() => {
+    const byKind = new Map<UsageKind, Map<string, number>>();
+    for (const bindings of registry.getActiveComponents().values()) {
+      for (const binding of bindings) {
+        const kind = usageKind(binding.queryParams);
+        const name = usageName(binding.queryParams);
+        let names = byKind.get(kind);
+        if (names === undefined) {
+          names = new Map<string, number>();
+          byKind.set(kind, names);
+        }
+        names.set(name, (names.get(name) ?? 0) + 1);
+      }
+    }
+    return KIND_ORDER.map((kind) => {
+      const names = byKind.get(kind);
+      const entries: UsageEntry[] = names
+        ? [...names.entries()]
+            .map(([name, count]) => ({ name, count }))
+            .sort((a, b) => b.count - a.count)
+        : [];
+      return { kind, entries };
+    }).filter((group) => group.entries.length > 0);
+    // version participates so the memo recomputes when the registry changes.
+  }, [registry, version]);
+
+  if (groups.length === 0) {
+    return (
+      <div className={styles.section}>
+        <div className={styles.sectionTitle}>In use</div>
+        <div className={styles.empty}>No OSDK hooks have rendered yet.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.section}>
+      <div className={styles.sectionTitle}>In use</div>
+      <div className={styles.usageGroups}>
+        {groups.map((group) => (
+          <div key={group.kind} className={styles.usageGroup}>
+            <div className={styles.usageKind}>{group.kind}</div>
+            {group.entries.map((entry) => (
+              <div key={entry.name} className={styles.usageRow}>
+                <span className={styles.usageName}>{entry.name}</span>
+                <span className={styles.usageCount}>{entry.count}</span>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/packages/react-devtools/src/components/overview/overviewTab.ts
+++ b/packages/react-devtools/src/components/overview/overviewTab.ts
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-import { overviewTab } from "../components/overview/overviewTab.js";
-import type { DevToolsPlugin } from "./types.js";
+import type { DevToolsPlugin } from "../../plugins/types.js";
+import { OverviewPanel } from "./OverviewPanel.js";
 
-// The base tabs shown in the devtools shell, in display order. Each tab PR
-// appends its plugin here (Overview, Components, Performance, Console, Cache).
-export const BASE_TABS: DevToolsPlugin[] = [overviewTab];
+export const overviewTab: DevToolsPlugin = {
+  id: "overview",
+  label: "Overview",
+  icon: "home",
+  panel: OverviewPanel,
+};

--- a/packages/react-devtools/src/recommendations/levelToIntent.ts
+++ b/packages/react-devtools/src/recommendations/levelToIntent.ts
@@ -14,9 +14,24 @@
  * limitations under the License.
  */
 
-import { overviewTab } from "../components/overview/overviewTab.js";
-import type { DevToolsPlugin } from "./types.js";
+import type { Intent } from "@blueprintjs/core";
 
-// The base tabs shown in the devtools shell, in display order. Each tab PR
-// appends its plugin here (Overview, Components, Performance, Console, Cache).
-export const BASE_TABS: DevToolsPlugin[] = [overviewTab];
+import type { RecommendationLevel } from "../utils/PerformanceRecommendationEngine.js";
+
+/** Map a recommendation severity level to a Blueprint intent for display. */
+export function levelToIntent(level: RecommendationLevel): Intent {
+  switch (level) {
+    case "critical": {
+      return "danger";
+    }
+    case "high": {
+      return "warning";
+    }
+    case "medium": {
+      return "primary";
+    }
+    default: {
+      return "none";
+    }
+  }
+}


### PR DESCRIPTION
adds the overview tab: headline metrics, a usage summary, and top recommendations

• headline metrics and usage summary built on the canonical metrics
• top recommendations with copy-prompt, sharing the recommendation store with performance
• uses the shared metric and intent formatting helpers
