### PR TITLE
rebuild devtools components tab as an ontology tree

### DIFF
--- a/.changeset/dt2-tab-components.md
+++ b/.changeset/dt2-tab-components.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+rebuild the Components base tab as a collapsible ontology tree showing the object types, actions, and properties each component touches, with search and per-component health badges

--- a/packages/react-devtools/src/components/components/ComponentCard.tsx
+++ b/packages/react-devtools/src/components/components/ComponentCard.tsx
@@ -33,6 +33,8 @@ function moreRow(depth: number, hidden: number): React.ReactNode {
   if (hidden <= 0) {
     return null;
   }
+  // TODO: make this row expandable so users can reveal the hidden items instead
+  // of only seeing a static "+ N more" count.
   return <TreeRow depth={depth} leaf label={`+ ${hidden} more`} />;
 }
 
@@ -124,6 +126,8 @@ export const ComponentCard: React.FC<ComponentCardProps> = ({
                   label={group.objectType}
                   count={group.names.length}
                 >
+                  {/* TODO: show each property's read value on hover once the
+                      access tracker captures values, not just names. */}
                   {visible.map((propertyName) => (
                     <TreeRow
                       key={propertyName}

--- a/packages/react-devtools/src/components/components/ComponentCard.tsx
+++ b/packages/react-devtools/src/components/components/ComponentCard.tsx
@@ -27,10 +27,8 @@ interface ComponentCardProps {
   ontology: ComponentOntology;
 }
 
-/** How many leaf rows to show before collapsing the rest into "+N more". */
 const VISIBLE_LEAVES = 5;
 
-/** A muted, non-interactive "+N more" leaf row. */
 function moreRow(depth: number, hidden: number): React.ReactNode {
   if (hidden <= 0) {
     return null;
@@ -38,12 +36,6 @@ function moreRow(depth: number, hidden: number): React.ReactNode {
   return <TreeRow depth={depth} leaf label={`+ ${hidden} more`} />;
 }
 
-/**
- * One live component rendered as an ontology tree: the object types and actions
- * it uses (inferred from hook usage) plus the instances and properties it read
- * and its React props. Health is summarized in the header badge; the per-object
- * detail is available on expand.
- */
 export const ComponentCard: React.FC<ComponentCardProps> = ({
   name,
   ontology,

--- a/packages/react-devtools/src/components/components/ComponentCard.tsx
+++ b/packages/react-devtools/src/components/components/ComponentCard.tsx
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from "classnames";
+import React from "react";
+
+import type { ComponentOntology } from "./deriveComponentOntology.js";
+import { TreeRow } from "./TreeRow.js";
+
+import styles from "./ComponentsPanel.module.scss";
+
+interface ComponentCardProps {
+  name: string;
+  ontology: ComponentOntology;
+}
+
+/** How many leaf rows to show before collapsing the rest into "+N more". */
+const VISIBLE_LEAVES = 5;
+
+/** A muted, non-interactive "+N more" leaf row. */
+function moreRow(depth: number, hidden: number): React.ReactNode {
+  if (hidden <= 0) {
+    return null;
+  }
+  return <TreeRow depth={depth} leaf label={`+ ${hidden} more`} />;
+}
+
+/**
+ * One live component rendered as an ontology tree: the object types and actions
+ * it uses (inferred from hook usage) plus the instances and properties it read
+ * and its React props. Health is summarized in the header badge; the per-object
+ * detail is available on expand.
+ */
+export const ComponentCard: React.FC<ComponentCardProps> = ({
+  name,
+  ontology,
+}) => {
+  const badge = (
+    <span
+      className={classNames(
+        styles.healthBadge,
+        ontology.healthy ? styles.healthy : styles.unhealthy
+      )}
+    >
+      {ontology.healthy ? "Healthy" : ontology.warning}
+    </span>
+  );
+
+  return (
+    <div className={styles.componentCard}>
+      <TreeRow depth={0} icon="widget" label={name} badge={badge}>
+        {ontology.objectTypes.length > 0 ? (
+          <TreeRow
+            depth={1}
+            label="Related objects"
+            count={ontology.objectTypes.length}
+            defaultOpen
+          >
+            {ontology.objectTypes.map((objectType) => {
+              const visible = objectType.instances.slice(0, VISIBLE_LEAVES);
+              const hidden = objectType.instances.length - visible.length;
+              return (
+                <TreeRow
+                  key={objectType.name}
+                  depth={2}
+                  icon="cube"
+                  label={objectType.name}
+                  count={
+                    objectType.instances.length > 0
+                      ? objectType.instances.length
+                      : undefined
+                  }
+                >
+                  {visible.map((primaryKey) => (
+                    <TreeRow
+                      key={primaryKey}
+                      depth={3}
+                      icon="cube"
+                      leaf
+                      label={primaryKey}
+                    />
+                  ))}
+                  {moreRow(3, hidden)}
+                </TreeRow>
+              );
+            })}
+          </TreeRow>
+        ) : null}
+
+        {ontology.actions.length > 0 ? (
+          <TreeRow
+            depth={1}
+            label="Related actions"
+            count={ontology.actions.length}
+            defaultOpen
+          >
+            {ontology.actions.slice(0, VISIBLE_LEAVES).map((action) => (
+              <TreeRow key={action} depth={2} icon="key" leaf label={action} />
+            ))}
+            {moreRow(2, ontology.actions.length - VISIBLE_LEAVES)}
+          </TreeRow>
+        ) : null}
+
+        {ontology.properties.length > 0 ? (
+          <TreeRow
+            depth={1}
+            label="Related properties"
+            count={ontology.properties.length}
+            defaultOpen
+          >
+            {ontology.properties.map((group) => {
+              const visible = group.names.slice(0, VISIBLE_LEAVES);
+              const hidden = group.names.length - visible.length;
+              return (
+                <TreeRow
+                  key={group.objectType}
+                  depth={2}
+                  icon="cube"
+                  label={group.objectType}
+                  count={group.names.length}
+                >
+                  {visible.map((propertyName) => (
+                    <TreeRow
+                      key={propertyName}
+                      depth={3}
+                      icon="property"
+                      leaf
+                      label={propertyName}
+                    />
+                  ))}
+                  {moreRow(3, hidden)}
+                </TreeRow>
+              );
+            })}
+          </TreeRow>
+        ) : null}
+
+        {ontology.reactProps.length > 0 ? (
+          <TreeRow
+            depth={1}
+            label="React props"
+            count={ontology.reactProps.length}
+          >
+            {ontology.reactProps.map(([key, value]) => (
+              <TreeRow
+                key={key}
+                depth={2}
+                leaf
+                label={
+                  <span className={styles.propRow}>
+                    <span className={styles.propKey}>{key}</span>
+                    <span className={styles.propValue}>{value}</span>
+                  </span>
+                }
+              />
+            ))}
+          </TreeRow>
+        ) : null}
+      </TreeRow>
+    </div>
+  );
+};

--- a/packages/react-devtools/src/components/components/ComponentFilters.tsx
+++ b/packages/react-devtools/src/components/components/ComponentFilters.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Icon } from "@blueprintjs/core";
+import React from "react";
+
+import styles from "./ComponentsPanel.module.scss";
+
+export interface ComponentFilter {
+  kind: "objectType" | "action";
+  name: string;
+}
+
+interface ComponentFiltersProps {
+  objectTypes: string[];
+  actions: string[];
+  active: ComponentFilter | null;
+  onChange: (filter: ComponentFilter | null) => void;
+}
+
+/** Chip row for narrowing the component list to one object type or action. */
+export const ComponentFilters: React.FC<ComponentFiltersProps> = ({
+  objectTypes,
+  actions,
+  active,
+  onChange,
+}) => {
+  if (objectTypes.length === 0 && actions.length === 0) {
+    return null;
+  }
+
+  const chipClass = (isActive: boolean) =>
+    isActive ? `${styles.chip} ${styles.chipActive}` : styles.chip;
+
+  const isActive = (kind: ComponentFilter["kind"], name: string) =>
+    active != null && active.kind === kind && active.name === name;
+
+  const toggle = (filter: ComponentFilter) => {
+    onChange(isActive(filter.kind, filter.name) ? null : filter);
+  };
+
+  return (
+    <div className={styles.filters}>
+      <button
+        type="button"
+        className={chipClass(active == null)}
+        aria-pressed={active == null}
+        onClick={() => onChange(null)}
+      >
+        All
+      </button>
+      {objectTypes.map((name) => (
+        <button
+          key={`object:${name}`}
+          type="button"
+          className={chipClass(isActive("objectType", name))}
+          aria-pressed={isActive("objectType", name)}
+          onClick={() => toggle({ kind: "objectType", name })}
+        >
+          <Icon icon="cube" size={11} />
+          {name}
+        </button>
+      ))}
+      {actions.map((name) => (
+        <button
+          key={`action:${name}`}
+          type="button"
+          className={chipClass(isActive("action", name))}
+          aria-pressed={isActive("action", name)}
+          onClick={() => toggle({ kind: "action", name })}
+        >
+          <Icon icon="key" size={11} />
+          {name}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/packages/react-devtools/src/components/components/ComponentFilters.tsx
+++ b/packages/react-devtools/src/components/components/ComponentFilters.tsx
@@ -31,7 +31,6 @@ interface ComponentFiltersProps {
   onChange: (filter: ComponentFilter | null) => void;
 }
 
-/** Chip row for narrowing the component list to one object type or action. */
 export const ComponentFilters: React.FC<ComponentFiltersProps> = ({
   objectTypes,
   actions,

--- a/packages/react-devtools/src/components/components/ComponentsHeader.tsx
+++ b/packages/react-devtools/src/components/components/ComponentsHeader.tsx
@@ -28,10 +28,6 @@ function plural(count: number, noun: string): string {
   return `${count} ${noun}${count === 1 ? "" : "s"}`;
 }
 
-/**
- * The summary line above the tree: how many components are mounted and, across
- * all of them, how many distinct object types and action types they touch.
- */
 export const ComponentsHeader: React.FC<ComponentsHeaderProps> = ({
   componentCount,
   objectTypeCount,

--- a/packages/react-devtools/src/components/components/ComponentsHeader.tsx
+++ b/packages/react-devtools/src/components/components/ComponentsHeader.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+
+import styles from "./ComponentsPanel.module.scss";
+
+interface ComponentsHeaderProps {
+  componentCount: number;
+  objectTypeCount: number;
+  actionTypeCount: number;
+}
+
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+/**
+ * The summary line above the tree: how many components are mounted and, across
+ * all of them, how many distinct object types and action types they touch.
+ */
+export const ComponentsHeader: React.FC<ComponentsHeaderProps> = ({
+  componentCount,
+  objectTypeCount,
+  actionTypeCount,
+}) => {
+  return (
+    <div className={styles.summary}>
+      <span className={styles.summaryText}>
+        <span className={styles.summaryStrong}>
+          {plural(componentCount, "component")}
+        </span>
+        <span className={styles.summaryDot}>•</span>
+        <span>{plural(objectTypeCount, "object type")}</span>
+        <span className={styles.summaryDot}>•</span>
+        <span>{plural(actionTypeCount, "action type")}</span>
+      </span>
+    </div>
+  );
+};

--- a/packages/react-devtools/src/components/components/ComponentsPanel.module.scss
+++ b/packages/react-devtools/src/components/components/ComponentsPanel.module.scss
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use '../tokens' as t;
+@use '../mixins' as m;
+
+.panel {
+  display: flex;
+  flex-direction: column;
+}
+
+.toolbar {
+  position: sticky;
+  top: 0;
+  z-index: t.$z-sticky;
+  padding: 8px 12px;
+  background: t.$bg-surface;
+  border-bottom: 1px solid t.$border-subtle;
+}
+
+// Summary line: "N components • M object types • K action types".
+.summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 7px 12px;
+  border-bottom: 1px solid t.$border-default;
+}
+
+.summaryText {
+  font-size: t.$font-size-sm;
+  color: t.$text-secondary;
+}
+
+.summaryStrong {
+  color: t.$text-primary;
+  font-weight: t.$font-weight-semi;
+}
+
+.summaryDot {
+  margin: 0 6px;
+  color: t.$text-tertiary;
+}
+
+// Filter chips: All + one per object type / action, narrowing the list below.
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 8px 12px;
+  border-bottom: 1px solid t.$border-subtle;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 10px;
+  background: t.$bg-elevated;
+  color: t.$text-secondary;
+  border: 1px solid t.$border-default;
+  border-radius: t.$radius-md;
+  font-size: t.$font-size-xs;
+  cursor: pointer;
+  transition: background-color t.$transition-fast, color t.$transition-fast;
+
+  &:hover {
+    background: t.$bg-hover;
+    color: t.$text-primary;
+  }
+}
+
+.chipActive {
+  background: t.$blue-bg;
+  color: t.$blue;
+  border-color: t.$blue;
+
+  &:hover {
+    background: t.$blue-bg;
+    color: t.$blue;
+  }
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+}
+
+.empty {
+  font-size: t.$font-size-base;
+  color: t.$text-tertiary;
+  padding: 16px 12px;
+}
+
+.componentCard {
+  border-bottom: 1px solid t.$border-subtle;
+}
+
+// --- Tree ---------------------------------------------------------------
+
+.treeNode {
+  min-width: 0;
+}
+
+.treeRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 26px;
+  padding-top: 3px;
+  padding-bottom: 3px;
+  padding-right: 10px;
+  color: t.$text-secondary;
+  font-size: t.$font-size-sm;
+  border-left: 2px solid transparent;
+  transition: background-color t.$transition-fast, border-left-color t.$transition-fast;
+}
+
+.treeRowInteractive {
+  cursor: pointer;
+
+  &:hover {
+    background: t.$bg-hover;
+    border-left-color: t.$text-tertiary;
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-left-color: t.$blue;
+    background: t.$bg-hover;
+  }
+}
+
+.treeRowLeaf {
+  .treeLabel {
+    color: t.$text-tertiary;
+    font-family: t.$font-mono;
+    font-size: t.$font-size-xs;
+  }
+}
+
+// Depth 0 is the component header: raised, bolder, primary text.
+.depth0 {
+  padding-left: 8px;
+  background: t.$bg-raised;
+
+  .treeLabel {
+    color: t.$text-primary;
+    font-size: t.$font-size-md;
+    font-weight: t.$font-weight-semi;
+  }
+}
+
+.depth1 {
+  padding-left: 26px;
+
+  .treeLabel {
+    color: t.$text-primary;
+    font-weight: t.$font-weight-medium;
+  }
+}
+
+.depth2 {
+  padding-left: 44px;
+}
+
+.depth3 {
+  padding-left: 62px;
+}
+
+.depth4 {
+  padding-left: 80px;
+}
+
+.treeChevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  flex-shrink: 0;
+  color: t.$text-tertiary;
+}
+
+.treeIcon {
+  flex-shrink: 0;
+  color: t.$blue;
+}
+
+.treeLabel {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.treeCount {
+  flex-shrink: 0;
+  padding: 1px 7px;
+  background: t.$bg-elevated;
+  color: t.$text-secondary;
+  border-radius: t.$radius-sm;
+  font-family: t.$font-mono;
+  font-size: t.$font-size-xs;
+  font-variant-numeric: tabular-nums;
+}
+
+.treeChildren {
+  min-width: 0;
+}
+
+// --- Health badge -------------------------------------------------------
+
+.healthBadge {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  padding: 1px 8px;
+  border-radius: t.$radius-sm;
+  font-size: t.$font-size-xs;
+  font-weight: t.$font-weight-semi;
+  line-height: 1.5;
+  white-space: nowrap;
+}
+
+.healthy {
+  background: t.$green-bg;
+  color: t.$green;
+}
+
+.unhealthy {
+  background: t.$orange-bg;
+  color: t.$orange;
+}
+
+// --- React prop key/value leaf ------------------------------------------
+
+.propRow {
+  display: flex;
+  gap: 8px;
+  min-width: 0;
+  width: 100%;
+}
+
+.propKey {
+  flex: none;
+  font-family: t.$font-mono;
+  color: t.$text-tertiary;
+}
+
+.propValue {
+  flex: 1;
+  min-width: 0;
+  font-family: t.$font-mono;
+  color: t.$text-secondary;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/packages/react-devtools/src/components/components/ComponentsPanel.module.scss
+++ b/packages/react-devtools/src/components/components/ComponentsPanel.module.scss
@@ -31,7 +31,6 @@
   border-bottom: 1px solid t.$border-subtle;
 }
 
-// Summary line: "N components • M object types • K action types".
 .summary {
   display: flex;
   align-items: center;
@@ -56,7 +55,6 @@
   color: t.$text-tertiary;
 }
 
-// Filter chips: All + one per object type / action, narrowing the list below.
 .filters {
   display: flex;
   flex-wrap: wrap;

--- a/packages/react-devtools/src/components/components/ComponentsPanel.test.tsx
+++ b/packages/react-devtools/src/components/components/ComponentsPanel.test.tsx
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { MonitorStore } from "../../store/MonitorStore.js";
+import type { UnusedProperty, WastedRender } from "../../types/index.js";
+import type { ComponentHookBinding } from "../../utils/ComponentQueryRegistry.js";
+import type { PropertyAccessEvent } from "../../utils/PropertyAccessTracker.js";
+import { ComponentsPanel } from "./ComponentsPanel.js";
+
+function makeBinding(
+  overrides: Partial<ComponentHookBinding> = {}
+): ComponentHookBinding {
+  return {
+    componentId: "c1",
+    componentName: "ParcelList",
+    hookType: "useOsdkObjects",
+    hookIndex: 0,
+    subscriptionId: "s1",
+    querySignature: "useOsdkObjects:Parcel",
+    queryParams: { type: "list", objectType: "Parcel" },
+    stackTrace: "",
+    mountedAt: 0,
+    renderCount: 2,
+    lastRenderDuration: 0,
+    avgRenderDuration: 0,
+    ...overrides,
+  };
+}
+
+interface StoreOptions {
+  propsById?: Record<string, Record<string, string>>;
+  accessesById?: Record<string, PropertyAccessEvent[]>;
+  wasted?: WastedRender[];
+  unused?: UnusedProperty[];
+}
+
+function makeStore(
+  active: Map<string, ComponentHookBinding[]>,
+  options: StoreOptions = {}
+): MonitorStore {
+  const {
+    propsById = {},
+    accessesById = {},
+    wasted = [],
+    unused = [],
+  } = options;
+  const stub = {
+    getComponentRegistry: () => ({
+      subscribe: () => () => {},
+      getVersion: () => 0,
+      getActiveComponents: () => active,
+      getComponentProps: (id: string) => propsById[id],
+    }),
+    getPropertyAccessTracker: () => ({
+      getWastedRenders: () => wasted,
+      getUnusedProperties: () => unused,
+      getAccessesByComponent: (id: string) => accessesById[id] ?? [],
+    }),
+  };
+  return stub as unknown as MonitorStore;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+/** Matches for `label` that are tree nodes, not filter chips (chips are buttons). */
+function treeNodes(label: string): HTMLElement[] {
+  return screen
+    .getAllByText(label)
+    .filter((el) => el.closest("button") == null);
+}
+
+describe("ComponentsPanel", () => {
+  it("renders the ontology search box and the mounted components", () => {
+    const active = new Map([["c1", [makeBinding()]]]);
+    render(<ComponentsPanel monitorStore={makeStore(active)} />);
+    expect(screen.getByPlaceholderText("Search ontology")).not.toBeNull();
+    expect(screen.getByText("ParcelList")).not.toBeNull();
+  });
+
+  it("shows an empty state when nothing is mounted", () => {
+    render(<ComponentsPanel monitorStore={makeStore(new Map())} />);
+    expect(
+      screen.getByText("No OSDK components are mounted yet.")
+    ).not.toBeNull();
+  });
+
+  it("summarizes component, object type, and action type counts", () => {
+    const active = new Map([
+      [
+        "c1",
+        [
+          makeBinding(),
+          makeBinding({
+            hookType: "useOsdkAction",
+            queryParams: { type: "action", actionName: "createParcel" },
+          }),
+        ],
+      ],
+    ]);
+    render(<ComponentsPanel monitorStore={makeStore(active)} />);
+    expect(screen.getByText("1 component")).not.toBeNull();
+    expect(screen.getByText("1 object type")).not.toBeNull();
+    expect(screen.getByText("1 action type")).not.toBeNull();
+  });
+
+  it("shows related object types and actions, not hook names", () => {
+    const active = new Map([
+      [
+        "c1",
+        [
+          makeBinding(),
+          makeBinding({
+            hookType: "useOsdkAction",
+            queryParams: { type: "action", actionName: "createParcel" },
+          }),
+        ],
+      ],
+    ]);
+    render(<ComponentsPanel monitorStore={makeStore(active)} />);
+    fireEvent.click(screen.getByText("ParcelList"));
+
+    expect(screen.getByText("Related objects")).not.toBeNull();
+    expect(treeNodes("Parcel").length).toBeGreaterThan(0);
+    expect(screen.getByText("Related actions")).not.toBeNull();
+    expect(treeNodes("createParcel").length).toBeGreaterThan(0);
+    expect(screen.queryByText("useOsdkObjects")).toBeNull();
+    expect(screen.queryByText("useOsdkAction")).toBeNull();
+  });
+
+  it("shows React props for a component", () => {
+    const active = new Map([["c1", [makeBinding()]]]);
+    const store = makeStore(active, {
+      propsById: { c1: { title: "Hello" } },
+    });
+    render(<ComponentsPanel monitorStore={store} />);
+    fireEvent.click(screen.getByText("ParcelList"));
+    fireEvent.click(screen.getByText("React props"));
+
+    expect(screen.getByText("title")).not.toBeNull();
+    expect(screen.getByText("Hello")).not.toBeNull();
+  });
+
+  it("expands an object type to reveal instances, truncating with +N more", () => {
+    const accesses: PropertyAccessEvent[] = [];
+    for (let i = 0; i < 8; i++) {
+      accesses.push({
+        componentId: "c1",
+        objectKey: `Parcel:p${i}`,
+        property: "name",
+        timestamp: 0,
+      });
+    }
+    const active = new Map([["c1", [makeBinding()]]]);
+    const store = makeStore(active, { accessesById: { c1: accesses } });
+    render(<ComponentsPanel monitorStore={store} />);
+
+    fireEvent.click(screen.getByText("ParcelList"));
+    // "Parcel" is a filter chip and two tree nodes (Related objects, Related
+    // properties); the first tree node is the Related objects group.
+    fireEvent.click(treeNodes("Parcel")[0]);
+
+    expect(screen.getByText("p0")).not.toBeNull();
+    expect(screen.getByText("+ 3 more")).not.toBeNull();
+  });
+
+  it("marks a clean component Healthy and a noisy one with a warning", () => {
+    const activeHealthy = new Map([["c1", [makeBinding()]]]);
+    const { unmount } = render(
+      <ComponentsPanel monitorStore={makeStore(activeHealthy)} />
+    );
+    expect(screen.getByText("Healthy")).not.toBeNull();
+    unmount();
+
+    const activeNoisy = new Map([["c1", [makeBinding()]]]);
+    const store = makeStore(activeNoisy, {
+      wasted: [
+        {
+          componentId: "c1",
+          componentName: "ParcelList",
+          count: 2,
+          timestamp: 0,
+        },
+      ],
+    });
+    render(<ComponentsPanel monitorStore={store} />);
+    expect(screen.getByText("2 wasted")).not.toBeNull();
+    expect(screen.queryByText("Healthy")).toBeNull();
+  });
+
+  it("filters components by the search query", () => {
+    const active = new Map([
+      ["c1", [makeBinding()]],
+      [
+        "c2",
+        [
+          makeBinding({
+            componentName: "WorkspaceView",
+            queryParams: { type: "list", objectType: "Workspace" },
+          }),
+        ],
+      ],
+    ]);
+    render(<ComponentsPanel monitorStore={makeStore(active)} />);
+    expect(screen.getByText("ParcelList")).not.toBeNull();
+    expect(screen.getByText("WorkspaceView")).not.toBeNull();
+
+    fireEvent.change(screen.getByPlaceholderText("Search ontology"), {
+      target: { value: "workspace" },
+    });
+    expect(screen.queryByText("ParcelList")).toBeNull();
+    expect(screen.getByText("WorkspaceView")).not.toBeNull();
+  });
+
+  it("filters components to a selected object type chip", () => {
+    const active = new Map([
+      ["c1", [makeBinding()]],
+      [
+        "c2",
+        [
+          makeBinding({
+            componentName: "WorkspaceView",
+            queryParams: { type: "list", objectType: "Workspace" },
+          }),
+        ],
+      ],
+    ]);
+    render(<ComponentsPanel monitorStore={makeStore(active)} />);
+
+    fireEvent.click(screen.getByText("Parcel"));
+    expect(screen.getByText("ParcelList")).not.toBeNull();
+    expect(screen.queryByText("WorkspaceView")).toBeNull();
+
+    fireEvent.click(screen.getByText("All"));
+    expect(screen.getByText("WorkspaceView")).not.toBeNull();
+  });
+
+  it("filters components to a selected action chip", () => {
+    const active = new Map([
+      [
+        "c1",
+        [
+          makeBinding({
+            hookType: "useOsdkAction",
+            queryParams: { type: "action", actionName: "createParcel" },
+          }),
+        ],
+      ],
+      ["c2", [makeBinding({ componentName: "WorkspaceView" })]],
+    ]);
+    render(<ComponentsPanel monitorStore={makeStore(active)} />);
+
+    fireEvent.click(screen.getByText("createParcel"));
+    expect(screen.getByText("ParcelList")).not.toBeNull();
+    expect(screen.queryByText("WorkspaceView")).toBeNull();
+  });
+});

--- a/packages/react-devtools/src/components/components/ComponentsPanel.tsx
+++ b/packages/react-devtools/src/components/components/ComponentsPanel.tsx
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InputGroup } from "@blueprintjs/core";
+import React, {
+  useCallback,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from "react";
+
+import type { MonitorStore } from "../../store/MonitorStore.js";
+import { resolveComponentName } from "../resolveComponentName.js";
+import { ComponentCard } from "./ComponentCard.js";
+import { type ComponentFilter, ComponentFilters } from "./ComponentFilters.js";
+import { ComponentsHeader } from "./ComponentsHeader.js";
+import {
+  type ComponentOntology,
+  deriveComponentOntology,
+} from "./deriveComponentOntology.js";
+import { useComponentInsights } from "./useComponentInsights.js";
+
+import styles from "./ComponentsPanel.module.scss";
+
+interface ComponentEntry {
+  componentId: string;
+  name: string;
+  ontology: ComponentOntology;
+  /** Lowercased searchable text: name + object types + actions + properties. */
+  haystack: string;
+}
+
+interface ComponentsPanelProps {
+  monitorStore: MonitorStore;
+}
+
+/**
+ * The component inspector: every mounted OSDK component as an ontology tree of
+ * the object types, actions, and properties it uses. Search by name, or filter
+ * down to a single object type or action.
+ */
+export const ComponentsPanel: React.FC<ComponentsPanelProps> = ({
+  monitorStore,
+}) => {
+  const registry = monitorStore.getComponentRegistry();
+  const tracker = monitorStore.getPropertyAccessTracker();
+  const subscribe = useCallback(
+    (cb: () => void) => registry.subscribe(cb),
+    [registry]
+  );
+  const getVersion = useCallback(() => registry.getVersion(), [registry]);
+  const version = useSyncExternalStore(subscribe, getVersion, getVersion);
+  const insights = useComponentInsights(monitorStore);
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState<ComponentFilter | null>(null);
+
+  const entries = useMemo<ComponentEntry[]>(() => {
+    return [...registry.getActiveComponents().entries()].map(
+      ([componentId, bindings]) => {
+        const ontology = deriveComponentOntology(
+          bindings,
+          tracker.getAccessesByComponent(componentId),
+          registry.getComponentProps(componentId),
+          {
+            wasted: insights.wastedByComponent.get(componentId),
+            unused: insights.unusedByComponent.get(componentId),
+          }
+        );
+        const name = resolveComponentName(bindings);
+        const haystack = [
+          name,
+          ...ontology.objectTypes.map((t) => t.name),
+          ...ontology.objectTypes.flatMap((t) => t.instances),
+          ...ontology.actions,
+          ...ontology.properties.flatMap((p) => [p.objectType, ...p.names]),
+        ]
+          .join(" ")
+          .toLowerCase();
+        return { componentId, name, ontology, haystack };
+      }
+    );
+    // version + insights drive the recompute as the registry and tracker change.
+  }, [registry, tracker, version, insights]);
+
+  const facets = useMemo(() => {
+    const objectTypes = new Set<string>();
+    const actions = new Set<string>();
+    for (const entry of entries) {
+      for (const objectType of entry.ontology.objectTypes) {
+        objectTypes.add(objectType.name);
+      }
+      for (const action of entry.ontology.actions) {
+        actions.add(action);
+      }
+    }
+    return {
+      objectTypes: [...objectTypes].sort((a, b) => a.localeCompare(b)),
+      actions: [...actions].sort((a, b) => a.localeCompare(b)),
+    };
+  }, [entries]);
+
+  const query = search.trim().toLowerCase();
+  const visible = entries.filter((entry) => {
+    if (query.length > 0 && !entry.haystack.includes(query)) {
+      return false;
+    }
+    if (filter != null) {
+      const inScope =
+        filter.kind === "objectType"
+          ? entry.ontology.objectTypes.some((t) => t.name === filter.name)
+          : entry.ontology.actions.includes(filter.name);
+      if (!inScope) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  return (
+    <div className={styles.panel}>
+      <div className={styles.toolbar}>
+        <InputGroup
+          leftIcon="search"
+          placeholder="Search ontology"
+          value={search}
+          onChange={(event) => setSearch(event.currentTarget.value)}
+        />
+      </div>
+      <ComponentsHeader
+        componentCount={entries.length}
+        objectTypeCount={facets.objectTypes.length}
+        actionTypeCount={facets.actions.length}
+      />
+      <ComponentFilters
+        objectTypes={facets.objectTypes}
+        actions={facets.actions}
+        active={filter}
+        onChange={setFilter}
+      />
+      {visible.length === 0 ? (
+        <div className={styles.empty}>
+          {entries.length > 0
+            ? "No components match."
+            : "No OSDK components are mounted yet."}
+        </div>
+      ) : (
+        <div className={styles.list}>
+          {visible.map((entry) => (
+            <ComponentCard
+              key={entry.componentId}
+              name={entry.name}
+              ontology={entry.ontology}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/react-devtools/src/components/components/ComponentsPanel.tsx
+++ b/packages/react-devtools/src/components/components/ComponentsPanel.tsx
@@ -47,11 +47,6 @@ interface ComponentsPanelProps {
   monitorStore: MonitorStore;
 }
 
-/**
- * The component inspector: every mounted OSDK component as an ontology tree of
- * the object types, actions, and properties it uses. Search by name, or filter
- * down to a single object type or action.
- */
 export const ComponentsPanel: React.FC<ComponentsPanelProps> = ({
   monitorStore,
 }) => {

--- a/packages/react-devtools/src/components/components/TreeRow.tsx
+++ b/packages/react-devtools/src/components/components/TreeRow.tsx
@@ -21,15 +21,10 @@ import React, { useState } from "react";
 import styles from "./ComponentsPanel.module.scss";
 
 interface TreeRowProps {
-  /** Row label; a string renders as the row text, nodes render as-is. */
   label: React.ReactNode;
-  /** Indentation level (0 = component, 1 = category, 2 = object type, 3 = leaf). */
   depth: number;
-  /** Leading Blueprint icon. */
   icon?: IconName;
-  /** Trailing count chip. */
   count?: number;
-  /** Trailing badge node (e.g. a Healthy pill), shown after the count. */
   badge?: React.ReactNode;
   /** Whether the row is expanded on first render (only relevant with children). */
   defaultOpen?: boolean;
@@ -46,8 +41,6 @@ function depthClass(depth: number): string | undefined {
   return styles[DEPTH_CLASS[clamped]];
 }
 
-// Every level of the tree is a TreeRow, so indentation and interaction stay
-// consistent; rows with children toggle on click, leaf rows do not.
 export const TreeRow: React.FC<TreeRowProps> = ({
   label,
   depth,
@@ -62,17 +55,19 @@ export const TreeRow: React.FC<TreeRowProps> = ({
   const [open, setOpen] = useState(defaultOpen);
 
   const toggle = (): void => {
-    if (collapsible) {
-      setOpen((prev) => !prev);
-    }
+    setOpen((prev) => !prev);
   };
 
   const onKeyDown = (event: React.KeyboardEvent): void => {
-    if (collapsible && (event.key === "Enter" || event.key === " ")) {
+    if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
       toggle();
     }
   };
+
+  const interactiveProps: React.HTMLAttributes<HTMLDivElement> = collapsible
+    ? { onClick: toggle, onKeyDown, tabIndex: 0, "aria-expanded": open }
+    : {};
 
   return (
     <div className={styles.treeNode}>
@@ -81,29 +76,26 @@ export const TreeRow: React.FC<TreeRowProps> = ({
           [styles.treeRowLeaf]: leaf,
           [styles.treeRowInteractive]: collapsible,
         })}
-        onClick={collapsible ? toggle : undefined}
-        onKeyDown={collapsible ? onKeyDown : undefined}
         role="treeitem"
-        tabIndex={collapsible ? 0 : undefined}
-        aria-expanded={collapsible ? open : undefined}
+        {...interactiveProps}
       >
         <span className={styles.treeChevron}>
-          {collapsible ? (
+          {collapsible && (
             <Icon icon={open ? "chevron-down" : "chevron-right"} size={12} />
-          ) : null}
+          )}
         </span>
-        {icon !== undefined ? (
+        {icon !== undefined && (
           <Icon className={styles.treeIcon} icon={icon} size={14} />
-        ) : null}
+        )}
         <span className={styles.treeLabel}>{label}</span>
-        {count !== undefined ? (
+        {count !== undefined && (
           <span className={styles.treeCount}>{count}</span>
-        ) : null}
-        {badge !== undefined ? badge : null}
+        )}
+        {badge}
       </div>
-      {collapsible && open ? (
+      {collapsible && open && (
         <div className={styles.treeChildren}>{children}</div>
-      ) : null}
+      )}
     </div>
   );
 };

--- a/packages/react-devtools/src/components/components/TreeRow.tsx
+++ b/packages/react-devtools/src/components/components/TreeRow.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Icon, type IconName } from "@blueprintjs/core";
+import classNames from "classnames";
+import React, { useState } from "react";
+
+import styles from "./ComponentsPanel.module.scss";
+
+interface TreeRowProps {
+  /** Row label; a string renders as the row text, nodes render as-is. */
+  label: React.ReactNode;
+  /** Indentation level (0 = component, 1 = category, 2 = object type, 3 = leaf). */
+  depth: number;
+  /** Leading Blueprint icon. */
+  icon?: IconName;
+  /** Trailing count chip. */
+  count?: number;
+  /** Trailing badge node (e.g. a Healthy pill), shown after the count. */
+  badge?: React.ReactNode;
+  /** Whether the row is expanded on first render (only relevant with children). */
+  defaultOpen?: boolean;
+  /** Rendered when open; their presence makes the row collapsible. */
+  children?: React.ReactNode;
+  /** Dimmer, monospace styling for leaf rows. */
+  leaf?: boolean;
+}
+
+const DEPTH_CLASS = ["depth0", "depth1", "depth2", "depth3", "depth4"] as const;
+
+function depthClass(depth: number): string | undefined {
+  const clamped = Math.min(Math.max(depth, 0), DEPTH_CLASS.length - 1);
+  return styles[DEPTH_CLASS[clamped]];
+}
+
+/**
+ * One collapsible row in the ontology tree. Rows with children show a chevron
+ * and toggle on click; leaf rows align to the same indent without one. Every
+ * level of the tree (component, category, object type, instance/property) is a
+ * `TreeRow`, so indentation and interaction stay consistent.
+ */
+export const TreeRow: React.FC<TreeRowProps> = ({
+  label,
+  depth,
+  icon,
+  count,
+  badge,
+  defaultOpen = false,
+  children,
+  leaf = false,
+}) => {
+  const collapsible = React.Children.count(children) > 0;
+  const [open, setOpen] = useState(defaultOpen);
+
+  const toggle = (): void => {
+    if (collapsible) {
+      setOpen((prev) => !prev);
+    }
+  };
+
+  const onKeyDown = (event: React.KeyboardEvent): void => {
+    if (collapsible && (event.key === "Enter" || event.key === " ")) {
+      event.preventDefault();
+      toggle();
+    }
+  };
+
+  return (
+    <div className={styles.treeNode}>
+      <div
+        className={classNames(styles.treeRow, depthClass(depth), {
+          [styles.treeRowLeaf]: leaf,
+          [styles.treeRowInteractive]: collapsible,
+        })}
+        onClick={collapsible ? toggle : undefined}
+        onKeyDown={collapsible ? onKeyDown : undefined}
+        role="treeitem"
+        tabIndex={collapsible ? 0 : undefined}
+        aria-expanded={collapsible ? open : undefined}
+      >
+        <span className={styles.treeChevron}>
+          {collapsible ? (
+            <Icon icon={open ? "chevron-down" : "chevron-right"} size={12} />
+          ) : null}
+        </span>
+        {icon !== undefined ? (
+          <Icon className={styles.treeIcon} icon={icon} size={14} />
+        ) : null}
+        <span className={styles.treeLabel}>{label}</span>
+        {count !== undefined ? (
+          <span className={styles.treeCount}>{count}</span>
+        ) : null}
+        {badge !== undefined ? badge : null}
+      </div>
+      {collapsible && open ? (
+        <div className={styles.treeChildren}>{children}</div>
+      ) : null}
+    </div>
+  );
+};

--- a/packages/react-devtools/src/components/components/TreeRow.tsx
+++ b/packages/react-devtools/src/components/components/TreeRow.tsx
@@ -41,6 +41,7 @@ function depthClass(depth: number): string | undefined {
   return styles[DEPTH_CLASS[clamped]];
 }
 
+// TODO: evaluate replacing this hand-rolled tree with Blueprint's <Tree>.
 export const TreeRow: React.FC<TreeRowProps> = ({
   label,
   depth,
@@ -51,7 +52,10 @@ export const TreeRow: React.FC<TreeRowProps> = ({
   children,
   leaf = false,
 }) => {
-  const collapsible = React.Children.count(children) > 0;
+  // toArray drops null/undefined/boolean children, so a row whose only children
+  // render to nothing (e.g. an object type with no instances) is not treated as
+  // collapsible and shows no caret.
+  const collapsible = React.Children.toArray(children).length > 0;
   const [open, setOpen] = useState(defaultOpen);
 
   const toggle = (): void => {

--- a/packages/react-devtools/src/components/components/TreeRow.tsx
+++ b/packages/react-devtools/src/components/components/TreeRow.tsx
@@ -46,12 +46,8 @@ function depthClass(depth: number): string | undefined {
   return styles[DEPTH_CLASS[clamped]];
 }
 
-/**
- * One collapsible row in the ontology tree. Rows with children show a chevron
- * and toggle on click; leaf rows align to the same indent without one. Every
- * level of the tree (component, category, object type, instance/property) is a
- * `TreeRow`, so indentation and interaction stay consistent.
- */
+// Every level of the tree is a TreeRow, so indentation and interaction stay
+// consistent; rows with children toggle on click, leaf rows do not.
 export const TreeRow: React.FC<TreeRowProps> = ({
   label,
   depth,

--- a/packages/react-devtools/src/components/components/deriveComponentOntology.test.ts
+++ b/packages/react-devtools/src/components/components/deriveComponentOntology.test.ts
@@ -77,7 +77,7 @@ describe("objectTypeOf", () => {
 });
 
 describe("deriveComponentOntology", () => {
-  it("surfaces object types and actions from hook usage, not hook names", () => {
+  it("derives object types and actions from each binding's query params", () => {
     const result = deriveComponentOntology(
       [
         binding({ type: "list", objectType: "Parcel" }),
@@ -172,6 +172,8 @@ describe("deriveComponentOntology", () => {
       }
     );
     expect(result.healthy).toBe(false);
+    // wasted.count (3 wasted renders) and the two unused properties (over-fetch 2)
+    // are each summarized into the warning string.
     expect(result.warning).toContain("3 wasted");
     expect(result.warning).toContain("over-fetch 2");
   });

--- a/packages/react-devtools/src/components/components/deriveComponentOntology.test.ts
+++ b/packages/react-devtools/src/components/components/deriveComponentOntology.test.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type {
+  ComponentHookBinding,
+  QueryParams,
+} from "../../utils/ComponentQueryRegistry.js";
+import type { PropertyAccessEvent } from "../../utils/PropertyAccessTracker.js";
+import {
+  deriveComponentOntology,
+  objectTypeOf,
+} from "./deriveComponentOntology.js";
+
+function binding(queryParams: QueryParams): ComponentHookBinding {
+  return {
+    componentId: "c1",
+    componentName: "C",
+    hookType: "useOsdkObjects",
+    hookIndex: 0,
+    subscriptionId: "s",
+    querySignature: "sig",
+    queryParams,
+    stackTrace: "",
+    mountedAt: 0,
+    renderCount: 0,
+    lastRenderDuration: 0,
+    avgRenderDuration: 0,
+  };
+}
+
+function access(objectKey: string, property: string): PropertyAccessEvent {
+  return { componentId: "c1", objectKey, property, timestamp: 0 };
+}
+
+describe("objectTypeOf", () => {
+  it("reads the object type from each query shape", () => {
+    expect(objectTypeOf({ type: "list", objectType: "Parcel" })).toBe("Parcel");
+    expect(
+      objectTypeOf({ type: "object", objectType: "Parcel", primaryKey: "1" })
+    ).toBe("Parcel");
+    expect(objectTypeOf({ type: "aggregation", objectType: "Parcel" })).toBe(
+      "Parcel"
+    );
+    expect(
+      objectTypeOf({
+        type: "links",
+        sourceObject: "Parcel:p1",
+        linkName: "owner",
+      })
+    ).toBe("Parcel");
+    expect(
+      objectTypeOf({
+        type: "objectSet",
+        baseObjectSet: "Parcel",
+        operations: [],
+      })
+    ).toBe("Parcel");
+    expect(
+      objectTypeOf({ type: "action", actionName: "createParcel" })
+    ).toBeNull();
+  });
+});
+
+describe("deriveComponentOntology", () => {
+  it("surfaces object types and actions from hook usage, not hook names", () => {
+    const result = deriveComponentOntology(
+      [
+        binding({ type: "list", objectType: "Parcel" }),
+        binding({ type: "object", objectType: "Workspace", primaryKey: "w1" }),
+        binding({ type: "action", actionName: "createParcel" }),
+      ],
+      [],
+      undefined,
+      {}
+    );
+
+    expect(result.objectTypes.map((t) => t.name)).toEqual([
+      "Parcel",
+      "Workspace",
+    ]);
+    expect(result.actions).toEqual(["createParcel"]);
+  });
+
+  it("groups read instances and properties by object type", () => {
+    const result = deriveComponentOntology(
+      [binding({ type: "list", objectType: "Parcel" })],
+      [
+        access("Parcel:p2", "status"),
+        access("Parcel:p1", "name"),
+        access("Parcel:p1", "status"),
+        // nested proxy key: instance is p1, property attributed to Parcel.
+        access("Parcel:p1.owner", "displayName"),
+      ],
+      undefined,
+      {}
+    );
+
+    const parcel = result.objectTypes.find((t) => t.name === "Parcel");
+    expect(parcel?.instances).toEqual(["p1", "p2"]);
+
+    const parcelProps = result.properties.find(
+      (p) => p.objectType === "Parcel"
+    );
+    expect(parcelProps?.names).toEqual(["displayName", "name", "status"]);
+  });
+
+  it("exposes react props as sorted entries", () => {
+    const result = deriveComponentOntology(
+      [binding({ type: "list", objectType: "Parcel" })],
+      [],
+      { title: "Hello", count: "3" },
+      {}
+    );
+    expect(result.reactProps).toContainEqual(["title", "Hello"]);
+    expect(result.reactProps).toContainEqual(["count", "3"]);
+  });
+
+  it("is healthy with no wasted renders or over-fetch", () => {
+    const result = deriveComponentOntology(
+      [binding({ type: "list", objectType: "Parcel" })],
+      [],
+      undefined,
+      {}
+    );
+    expect(result.healthy).toBe(true);
+    expect(result.warning).toBeUndefined();
+  });
+
+  it("reports a warning when wasted renders or over-fetch exist", () => {
+    const result = deriveComponentOntology(
+      [binding({ type: "list", objectType: "Parcel" })],
+      [],
+      undefined,
+      {
+        wasted: {
+          componentId: "c1",
+          componentName: "C",
+          count: 3,
+          timestamp: 0,
+        },
+        unused: [
+          {
+            componentId: "c1",
+            componentName: "C",
+            propertyName: "a",
+            totalRenders: 10,
+            accessCount: 0,
+          },
+          {
+            componentId: "c1",
+            componentName: "C",
+            propertyName: "b",
+            totalRenders: 10,
+            accessCount: 0,
+          },
+        ],
+      }
+    );
+    expect(result.healthy).toBe(false);
+    expect(result.warning).toContain("3 wasted");
+    expect(result.warning).toContain("over-fetch 2");
+  });
+
+  it("drops Unknown object types and actions", () => {
+    const result = deriveComponentOntology(
+      [
+        binding({ type: "list", objectType: "Unknown" }),
+        binding({ type: "action", actionName: "Unknown" }),
+      ],
+      [],
+      undefined,
+      {}
+    );
+    expect(result.objectTypes).toEqual([]);
+    expect(result.actions).toEqual([]);
+  });
+});

--- a/packages/react-devtools/src/components/components/deriveComponentOntology.ts
+++ b/packages/react-devtools/src/components/components/deriveComponentOntology.ts
@@ -21,7 +21,6 @@ import type {
 } from "../../utils/ComponentQueryRegistry.js";
 import type { PropertyAccessEvent } from "../../utils/PropertyAccessTracker.js";
 
-/** The object type a query reads from, or null for actions (shown by name). */
 export function objectTypeOf(params: QueryParams): string | null {
   switch (params.type) {
     case "object":
@@ -43,9 +42,7 @@ export function objectTypeOf(params: QueryParams): string | null {
 }
 
 export interface OntologyObjectType {
-  /** Object type api name, e.g. "Parcel". */
   name: string;
-  /** Distinct primary keys of instances the component actually read. */
   instances: string[];
 }
 
@@ -55,17 +52,11 @@ export interface OntologyProperties {
 }
 
 export interface ComponentOntology {
-  /** Object types the component reads, inferred from hook usage. */
   objectTypes: OntologyObjectType[];
-  /** Action names the component invokes, inferred from hook usage. */
   actions: string[];
-  /** Properties the component read, grouped by object type. */
   properties: OntologyProperties[];
-  /** React props captured from the fiber. */
   reactProps: Array<[string, string]>;
-  /** True when the component has no wasted renders and no over-fetch. */
   healthy: boolean;
-  /** Short human label describing the health warning, when not healthy. */
   warning?: string;
 }
 

--- a/packages/react-devtools/src/components/components/deriveComponentOntology.ts
+++ b/packages/react-devtools/src/components/components/deriveComponentOntology.ts
@@ -46,7 +46,8 @@ export interface OntologyObjectType {
   instances: string[];
 }
 
-export interface OntologyProperties {
+/** The property names a component read on a single object type. */
+export interface ObjectTypeProperties {
   objectType: string;
   names: string[];
 }
@@ -54,7 +55,7 @@ export interface OntologyProperties {
 export interface ComponentOntology {
   objectTypes: OntologyObjectType[];
   actions: string[];
-  properties: OntologyProperties[];
+  properties: ObjectTypeProperties[];
   reactProps: Array<[string, string]>;
   healthy: boolean;
   warning?: string;
@@ -143,7 +144,7 @@ export function deriveComponentOntology(
       ),
     }));
 
-  const properties: OntologyProperties[] = [...propertiesByType.entries()]
+  const properties: ObjectTypeProperties[] = [...propertiesByType.entries()]
     .filter(([, names]) => names.size > 0)
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([objectType, names]) => ({

--- a/packages/react-devtools/src/components/components/deriveComponentOntology.ts
+++ b/packages/react-devtools/src/components/components/deriveComponentOntology.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { UnusedProperty, WastedRender } from "../../types/index.js";
+import type {
+  ComponentHookBinding,
+  QueryParams,
+} from "../../utils/ComponentQueryRegistry.js";
+import type { PropertyAccessEvent } from "../../utils/PropertyAccessTracker.js";
+
+/** The object type a query reads from, or null for actions (shown by name). */
+export function objectTypeOf(params: QueryParams): string | null {
+  switch (params.type) {
+    case "object":
+    case "list":
+    case "aggregation": {
+      return params.objectType;
+    }
+    case "links": {
+      // sourceObject may be "Type" or "Type:primaryKey" depending on capture path.
+      return params.sourceObject.split(":")[0] || params.sourceObject;
+    }
+    case "objectSet": {
+      return params.baseObjectSet;
+    }
+    default: {
+      return null;
+    }
+  }
+}
+
+export interface OntologyObjectType {
+  /** Object type api name, e.g. "Parcel". */
+  name: string;
+  /** Distinct primary keys of instances the component actually read. */
+  instances: string[];
+}
+
+export interface OntologyProperties {
+  objectType: string;
+  names: string[];
+}
+
+export interface ComponentOntology {
+  /** Object types the component reads, inferred from hook usage. */
+  objectTypes: OntologyObjectType[];
+  /** Action names the component invokes, inferred from hook usage. */
+  actions: string[];
+  /** Properties the component read, grouped by object type. */
+  properties: OntologyProperties[];
+  /** React props captured from the fiber. */
+  reactProps: Array<[string, string]>;
+  /** True when the component has no wasted renders and no over-fetch. */
+  healthy: boolean;
+  /** Short human label describing the health warning, when not healthy. */
+  warning?: string;
+}
+
+export interface ComponentInsight {
+  wasted?: WastedRender;
+  unused?: UnusedProperty[];
+}
+
+/** Split an access `objectKey` ("Parcel:123" or nested "Parcel:123.owner"). */
+function parseObjectKey(
+  objectKey: string
+): { objectType: string; primaryKey: string } | null {
+  const colon = objectKey.indexOf(":");
+  if (colon <= 0) {
+    return null;
+  }
+  const objectType = objectKey.slice(0, colon);
+  // Nested proxy keys append ".<prop>"; the instance identity is the first segment.
+  const primaryKey = objectKey.slice(colon + 1).split(".")[0];
+  if (primaryKey.length === 0) {
+    return null;
+  }
+  return { objectType, primaryKey };
+}
+
+const isKnown = (type: string | null): type is string =>
+  type != null && type !== "Unknown";
+
+/**
+ * Reduce a component's hook bindings, property access, props, and health signals
+ * into the ontology tree the Components tab renders: the object types and actions
+ * it uses, the instances and properties it read, and its React props.
+ */
+export function deriveComponentOntology(
+  bindings: ComponentHookBinding[],
+  accesses: PropertyAccessEvent[],
+  props: Record<string, string> | undefined,
+  insight: ComponentInsight
+): ComponentOntology {
+  const objectTypeNames = new Set<string>();
+  const actionNames = new Set<string>();
+
+  for (const binding of bindings) {
+    if (binding.queryParams.type === "action") {
+      const name = binding.queryParams.actionName;
+      if (isKnown(name)) {
+        actionNames.add(name);
+      }
+      continue;
+    }
+    const type = objectTypeOf(binding.queryParams);
+    if (isKnown(type)) {
+      objectTypeNames.add(type);
+    }
+  }
+
+  const instancesByType = new Map<string, Set<string>>();
+  const propertiesByType = new Map<string, Set<string>>();
+
+  for (const access of accesses) {
+    const parsed = parseObjectKey(access.objectKey);
+    if (parsed == null) {
+      continue;
+    }
+    const { objectType, primaryKey } = parsed;
+
+    let instanceSet = instancesByType.get(objectType);
+    if (instanceSet === undefined) {
+      instanceSet = new Set<string>();
+      instancesByType.set(objectType, instanceSet);
+    }
+    instanceSet.add(primaryKey);
+
+    let propSet = propertiesByType.get(objectType);
+    if (propSet === undefined) {
+      propSet = new Set<string>();
+      propertiesByType.set(objectType, propSet);
+    }
+    propSet.add(access.property);
+  }
+
+  // Object types come from hook usage; instances layer in from what was read.
+  const objectTypes: OntologyObjectType[] = [...objectTypeNames]
+    .sort((a, b) => a.localeCompare(b))
+    .map((name) => ({
+      name,
+      instances: [...(instancesByType.get(name) ?? [])].sort((a, b) =>
+        a.localeCompare(b)
+      ),
+    }));
+
+  const properties: OntologyProperties[] = [...propertiesByType.entries()]
+    .filter(([, names]) => names.size > 0)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([objectType, names]) => ({
+      objectType,
+      names: [...names].sort((a, b) => a.localeCompare(b)),
+    }));
+
+  const wastedCount = insight.wasted?.count ?? 0;
+  const overFetchCount = insight.unused?.length ?? 0;
+  const healthy = wastedCount === 0 && overFetchCount === 0;
+
+  let warning: string | undefined;
+  if (!healthy) {
+    const parts: string[] = [];
+    if (wastedCount > 0) {
+      parts.push(`${wastedCount} wasted`);
+    }
+    if (overFetchCount > 0) {
+      parts.push(`over-fetch ${overFetchCount}`);
+    }
+    warning = parts.join(" · ");
+  }
+
+  return {
+    objectTypes,
+    actions: [...actionNames].sort((a, b) => a.localeCompare(b)),
+    properties,
+    reactProps: props ? Object.entries(props) : [],
+    healthy,
+    warning,
+  };
+}

--- a/packages/react-devtools/src/components/components/deriveComponentOntology.ts
+++ b/packages/react-devtools/src/components/components/deriveComponentOntology.ts
@@ -94,11 +94,6 @@ function parseObjectKey(
 const isKnown = (type: string | null): type is string =>
   type != null && type !== "Unknown";
 
-/**
- * Reduce a component's hook bindings, property access, props, and health signals
- * into the ontology tree the Components tab renders: the object types and actions
- * it uses, the instances and properties it read, and its React props.
- */
 export function deriveComponentOntology(
   bindings: ComponentHookBinding[],
   accesses: PropertyAccessEvent[],

--- a/packages/react-devtools/src/components/components/useComponentInsights.ts
+++ b/packages/react-devtools/src/components/components/useComponentInsights.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo } from "react";
+
+import { useSharedTick } from "../../hooks/useSharedTick.js";
+import type { MonitorStore } from "../../store/MonitorStore.js";
+import type { UnusedProperty, WastedRender } from "../../types/index.js";
+
+export interface ComponentInsights {
+  wastedByComponent: Map<string, WastedRender>;
+  unusedByComponent: Map<string, UnusedProperty[]>;
+}
+
+/**
+ * Per-component health signals (wasted renders, over-fetched properties) keyed
+ * by componentId. The underlying tracker isn't subscribable, so we recompute on
+ * the shared polling tick the rest of the inspector already uses.
+ */
+export function useComponentInsights(
+  monitorStore: MonitorStore
+): ComponentInsights {
+  const tick = useSharedTick();
+  return useMemo(() => {
+    const tracker = monitorStore.getPropertyAccessTracker();
+    const wastedByComponent = new Map<string, WastedRender>();
+    for (const wasted of tracker.getWastedRenders()) {
+      wastedByComponent.set(wasted.componentId, wasted);
+    }
+    const unusedByComponent = new Map<string, UnusedProperty[]>();
+    for (const unused of tracker.getUnusedProperties()) {
+      const list = unusedByComponent.get(unused.componentId) ?? [];
+      list.push(unused);
+      unusedByComponent.set(unused.componentId, list);
+    }
+    return { wastedByComponent, unusedByComponent };
+    // tick drives the recompute since the tracker has no change subscription.
+  }, [monitorStore, tick]);
+}

--- a/packages/react-devtools/src/components/components/useComponentInsights.ts
+++ b/packages/react-devtools/src/components/components/useComponentInsights.ts
@@ -25,11 +25,6 @@ export interface ComponentInsights {
   unusedByComponent: Map<string, UnusedProperty[]>;
 }
 
-/**
- * Per-component health signals (wasted renders, over-fetched properties) keyed
- * by componentId. The underlying tracker isn't subscribable, so we recompute on
- * the shared polling tick the rest of the inspector already uses.
- */
 export function useComponentInsights(
   monitorStore: MonitorStore
 ): ComponentInsights {

--- a/packages/react-devtools/src/components/components/useComponentInsights.ts
+++ b/packages/react-devtools/src/components/components/useComponentInsights.ts
@@ -42,6 +42,5 @@ export function useComponentInsights(
       unusedByComponent.set(unused.componentId, list);
     }
     return { wastedByComponent, unusedByComponent };
-    // tick drives the recompute since the tracker has no change subscription.
   }, [monitorStore, tick]);
 }

--- a/packages/react-devtools/src/fiber/HookStateInspector.ts
+++ b/packages/react-devtools/src/fiber/HookStateInspector.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { getComponentId, getComponentName } from "./FiberInspection.js";
+import {
+  getComponentId,
+  getComponentName,
+  getProps,
+} from "./FiberInspection.js";
 import { safeFiberOperation } from "./SafeFiberOperation.js";
 import { traverseAllFibers, walkFiberTree } from "./traverseFiber.js";
 import type {
@@ -412,6 +416,64 @@ export interface DiscoveredComponent {
   componentName: string;
   hooks: OsdkHookMetadata[];
   sourceLocation: { fileName?: string; lineNumber?: number } | null;
+  /** Short string preview of the component's React props. */
+  props?: Record<string, string>;
+}
+
+const MAX_PROP_KEYS = 12;
+const MAX_PROP_VALUE_LEN = 80;
+
+/** One-line, reference-free preview of a single prop value. */
+function summarizePropValue(value: unknown): string {
+  if (value == null) {
+    return "null";
+  }
+  switch (typeof value) {
+    case "undefined": {
+      return "undefined";
+    }
+    case "string": {
+      const text =
+        value.length > MAX_PROP_VALUE_LEN
+          ? `${value.slice(0, MAX_PROP_VALUE_LEN)}…`
+          : value;
+      return JSON.stringify(text);
+    }
+    case "number":
+    case "boolean":
+    case "bigint": {
+      return String(value);
+    }
+    case "function": {
+      return "ƒ";
+    }
+    case "object": {
+      if (Array.isArray(value)) {
+        return `Array(${value.length})`;
+      }
+      const record = value as Record<string, unknown>;
+      if (typeof record.$apiName === "string") {
+        return `<${record.$apiName}>`;
+      }
+      return "{…}";
+    }
+    default: {
+      return String(value);
+    }
+  }
+}
+
+function summarizeProps(fiber: Fiber): Record<string, string> | undefined {
+  const raw = getProps(fiber);
+  const keys = Object.keys(raw).filter((key) => key !== "children");
+  if (keys.length === 0) {
+    return undefined;
+  }
+  const summary: Record<string, string> = {};
+  for (const key of keys.slice(0, MAX_PROP_KEYS)) {
+    summary[key] = summarizePropValue(raw[key]);
+  }
+  return summary;
 }
 
 export function discoverOsdkComponentsFromRoot(
@@ -442,6 +504,7 @@ export function discoverOsdkComponentsFromRoot(
             componentName,
             hooks: metadata,
             sourceLocation,
+            props: summarizeProps(fiber),
           });
         }
       });

--- a/packages/react-devtools/src/fiber/HookStateInspector.ts
+++ b/packages/react-devtools/src/fiber/HookStateInspector.ts
@@ -421,6 +421,8 @@ export interface DiscoveredComponent {
 
 const MAX_PROP_KEYS = 12;
 // Longest a prop-value preview may be before it's truncated, in characters.
+// TODO: preserve the untruncated value alongside this preview so the inspector
+// can show the full value in a tooltip on hover.
 const MAX_PROP_VALUE_LEN = 80;
 
 function summarizePropValue(value: unknown): string {

--- a/packages/react-devtools/src/fiber/HookStateInspector.ts
+++ b/packages/react-devtools/src/fiber/HookStateInspector.ts
@@ -416,14 +416,12 @@ export interface DiscoveredComponent {
   componentName: string;
   hooks: OsdkHookMetadata[];
   sourceLocation: { fileName?: string; lineNumber?: number } | null;
-  /** Short string preview of the component's React props. */
   props?: Record<string, string>;
 }
 
 const MAX_PROP_KEYS = 12;
 const MAX_PROP_VALUE_LEN = 80;
 
-/** One-line, reference-free preview of a single prop value. */
 function summarizePropValue(value: unknown): string {
   if (value == null) {
     return "null";

--- a/packages/react-devtools/src/fiber/HookStateInspector.ts
+++ b/packages/react-devtools/src/fiber/HookStateInspector.ts
@@ -420,6 +420,7 @@ export interface DiscoveredComponent {
 }
 
 const MAX_PROP_KEYS = 12;
+// Longest a prop-value preview may be before it's truncated, in characters.
 const MAX_PROP_VALUE_LEN = 80;
 
 function summarizePropValue(value: unknown): string {

--- a/packages/react-devtools/src/utils/ComponentQueryRegistry.ts
+++ b/packages/react-devtools/src/utils/ComponentQueryRegistry.ts
@@ -478,6 +478,7 @@ export class ComponentQueryRegistry {
     this.bindings.clear();
     this.componentToBindings.clear();
     this.queryToBindings.clear();
+    this.componentProps.clear();
     this.subscriptionToBinding.clear();
   }
 

--- a/packages/react-devtools/src/utils/ComponentQueryRegistry.ts
+++ b/packages/react-devtools/src/utils/ComponentQueryRegistry.ts
@@ -93,6 +93,7 @@ export class ComponentQueryRegistry {
   private bindings = new Map<string, ComponentHookBinding>();
   private componentToBindings = new Map<string, Set<string>>();
   private queryToBindings = new Map<string, Set<string>>();
+  private componentProps = new Map<string, Record<string, string>>();
   private subscriptionToBinding = new Map<string, string>();
 
   private bindingIdCounter = 0;
@@ -314,6 +315,10 @@ export class ComponentQueryRegistry {
     for (const [componentId, component] of discovered) {
       seenComponentIds.add(componentId);
 
+      if (component.props !== undefined) {
+        this.componentProps.set(componentId, component.props);
+      }
+
       const existingBindingIds = this.componentToBindings.get(componentId);
 
       if (existingBindingIds && existingBindingIds.size > 0) {
@@ -344,6 +349,7 @@ export class ComponentQueryRegistry {
     const now = Date.now();
     for (const [componentId, bindingIds] of this.componentToBindings) {
       if (!seenComponentIds.has(componentId)) {
+        this.componentProps.delete(componentId);
         for (const bindingId of bindingIds) {
           const binding = this.bindings.get(bindingId);
           if (binding && !binding.unmountedAt) {
@@ -352,6 +358,10 @@ export class ComponentQueryRegistry {
         }
       }
     }
+  }
+
+  getComponentProps(componentId: string): Record<string, string> | undefined {
+    return this.componentProps.get(componentId);
   }
 
   private buildQuerySignature(


### PR DESCRIPTION
rebuilds the components tab to show each mounted component as an ontology tree

• object types, actions, properties and react props a component uses, filterable by name
• derives the ontology from hook usage and the property access tracker
• health badge summarizing wasted renders and over-fetch



## Screenshot

![components tab](https://github.com/palantir/osdk-ts/raw/ksethi/devtools-screenshots/screenshots/dt-tab-components.png)
