### PR TITLE
[1/4]: add Overview tab primitives

### DIFF
--- a/.changeset/gentle-otters-wander.md
+++ b/.changeset/gentle-otters-wander.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+Add Overview tab primitives (Metric, Metrics, OverviewSection) and a dummy-data OverviewTab to the monitoring panel.

--- a/packages/e2e.sandbox.officenetwork/package.json
+++ b/packages/e2e.sandbox.officenetwork/package.json
@@ -27,7 +27,7 @@
     "build": "vite build",
     "check-spelling": "cspell --quiet .",
     "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
-    "dev": "trap 'kill 0' EXIT; pnpm turbo watch transpileBrowser transpileEsm --filter='@osdk/e2e.sandbox.officenetwork^...' & vite",
+    "dev": "vite",
     "fix-lint": "oxlint -c ./oxlint.config.ts --fix . && oxfmt -c ../../oxfmt.config.ts .",
     "lint": "oxlint -c ./oxlint.config.ts . && oxfmt -c ../../oxfmt.config.ts --check .",
     "preview": "vite preview",

--- a/packages/e2e.sandbox.officenetwork/package.json
+++ b/packages/e2e.sandbox.officenetwork/package.json
@@ -27,7 +27,7 @@
     "build": "vite build",
     "check-spelling": "cspell --quiet .",
     "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
-    "dev": "vite",
+    "dev": "trap 'kill 0' EXIT; pnpm turbo watch transpileBrowser transpileEsm --filter='@osdk/e2e.sandbox.officenetwork^...' & vite",
     "fix-lint": "oxlint -c ./oxlint.config.ts --fix . && oxfmt -c ../../oxfmt.config.ts .",
     "lint": "oxlint -c ./oxlint.config.ts . && oxfmt -c ../../oxfmt.config.ts --check .",
     "preview": "vite preview",

--- a/packages/monorepo.cspell/cspell.config.js
+++ b/packages/monorepo.cspell/cspell.config.js
@@ -131,7 +131,7 @@ const cspell = {
     "oauth",
     "css",
   ],
-  words: ["todoapp"],
+  words: ["todoapp", "borderless", "overfetching"],
   suggestWords: [],
   ignoreWords: [],
   import: [],

--- a/packages/react-devtools/src/components/Metric.module.scss
+++ b/packages/react-devtools/src/components/Metric.module.scss
@@ -1,0 +1,63 @@
+@use 'tokens' as t;
+@use 'mixins' as m;
+
+// A single `Metric` cell — borderless; the enclosing `Metrics` grid draws the
+// dividers around it.
+.metricItem {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px;
+  background: t.$bg-surface;
+}
+
+.metricItemHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.metricHelp {
+  flex-shrink: 0;
+  color: t.$text-tertiary;
+  cursor: help;
+}
+
+// `Metric` help-tooltip body: the definition text plus, for colored metrics, a
+// color key supplied by the caller.
+.metricHelpContent {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 220px;
+  line-height: 1.4;
+}
+
+.metricValue {
+  @include m.dt-metric-value;
+
+  &.success {
+    color: t.$green;
+  }
+
+  &.warning {
+    color: t.$orange;
+  }
+
+  &.danger {
+    color: t.$red;
+  }
+
+  // No data yet — muted, so it reads as absent rather than a real measurement.
+  &.na {
+    color: t.$text-tertiary;
+  }
+}
+
+// Push the footer to the bottom of the (equal-height) cell so the "View in …"
+// links line up across a row even when metric labels wrap to different heights.
+.metricFooter {
+  margin-top: auto;
+  padding-top: 6px;
+}

--- a/packages/react-devtools/src/components/Metric.module.scss
+++ b/packages/react-devtools/src/components/Metric.module.scss
@@ -37,17 +37,6 @@
 .metricValue {
   @include m.dt-metric-value;
 
-  &.success {
-    color: t.$green;
-  }
-
-  &.warning {
-    color: t.$orange;
-  }
-
-  &.danger {
-    color: t.$red;
-  }
 
   // No data yet — muted, so it reads as absent rather than a real measurement.
   &.na {

--- a/packages/react-devtools/src/components/Metric.tsx
+++ b/packages/react-devtools/src/components/Metric.tsx
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import { Classes, Icon } from "@blueprintjs/core";
-import type { Intent } from "@blueprintjs/core";
+import { AnchorButton, Classes } from "@blueprintjs/core";
 import classNames from "classnames";
 import React from "react";
 
 import { BpTooltip } from "./common/BpTooltip.js";
+import { METRIC_INTENT_COLOR } from "./metricIntent.js";
+import type { MetricIntent } from "./metricIntent.js";
 
 import styles from "./Metric.module.scss";
 
@@ -33,10 +34,10 @@ export interface MetricProps {
    */
   value: string | number | null | undefined;
   /**
-   * Colors the value via Blueprint's `Intent`; defaults to `"none"` (no color).
-   * Only `success`/`warning`/`danger` are colored. Ignored when `value` is empty.
+   * Colors the value using its `MetricIntent` color; defaults to `"none"`
+   * (inherits the surrounding text color). Ignored when `value` is empty.
    */
-  intent?: Intent;
+  intent?: MetricIntent;
   /**
    * When set, renders a top-right "?" icon whose tooltip shows this content — the
    * metric's definition and, where the value is colored, its color key.
@@ -67,7 +68,9 @@ export function Metric({
           <BpTooltip
             content={<div className={styles.metricHelpContent}>{help}</div>}
           >
-            <Icon
+            <AnchorButton
+              variant="minimal"
+              size="small"
               icon="help"
               className={styles.metricHelp}
               aria-label={`About ${title}`}
@@ -76,10 +79,8 @@ export function Metric({
         )}
       </div>
       <span
-        className={classNames(
-          styles.metricValue,
-          isEmpty ? styles.na : styles[intent]
-        )}
+        className={classNames(styles.metricValue, isEmpty && styles.na)}
+        style={isEmpty ? undefined : { color: METRIC_INTENT_COLOR[intent] }}
       >
         {isEmpty ? "N/A" : value}
       </span>

--- a/packages/react-devtools/src/components/Metric.tsx
+++ b/packages/react-devtools/src/components/Metric.tsx
@@ -61,7 +61,7 @@ export function Metric({
   const isEmpty = value == null || value === "";
   const panelContainer = React.useContext(PanelContainerContext);
   return (
-    <section className={styles.metricItem} aria-label={title}>
+    <div className={styles.metricItem}>
       <div className={styles.metricItemHeader}>
         <span className={Classes.TEXT_MUTED}>{title}</span>
         {help != null && (
@@ -86,6 +86,6 @@ export function Metric({
         {isEmpty ? "N/A" : value}
       </span>
       {footer != null && <div className={styles.metricFooter}>{footer}</div>}
-    </section>
+    </div>
   );
 }

--- a/packages/react-devtools/src/components/Metric.tsx
+++ b/packages/react-devtools/src/components/Metric.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Classes, Icon, Tooltip } from "@blueprintjs/core";
+import type { Intent } from "@blueprintjs/core";
+import classNames from "classnames";
+import React from "react";
+
+import { PanelContainerContext } from "./PanelContainerContext.js";
+
+import styles from "./Metric.module.scss";
+
+export interface MetricProps {
+  /** The metric label, e.g. "Cache hit rate". */
+  title: string;
+  /**
+   * The formatted value to display, e.g. "74%", "340ms", or a count. Pass
+   * `null`/`undefined` when there is no data yet — the cell renders a muted
+   * "N/A" and ignores `intent`.
+   */
+  value: string | number | null | undefined;
+  /**
+   * Colors the value via Blueprint's `Intent`; defaults to `"none"` (no color).
+   * Only `success`/`warning`/`danger` are colored. Ignored when `value` is empty.
+   */
+  intent?: Intent;
+  /**
+   * When set, renders a top-right "?" icon whose tooltip shows this content — the
+   * metric's definition and, where the value is colored, its color key.
+   */
+  help?: React.ReactNode;
+  /** Optional content rendered below the value, e.g. a "View in …" link. */
+  footer?: React.ReactNode;
+}
+
+/**
+ * A single metric cell — label, value, and optional help tooltip / footer. Meant
+ * to sit inside a `Metrics` grid, which draws the surrounding border and the
+ * hairline dividers between cells (the cell itself is borderless).
+ */
+export function Metric({
+  title,
+  value,
+  help,
+  footer,
+  intent = "none",
+}: MetricProps): React.JSX.Element {
+  const isEmpty = value == null || value === "";
+  const panelContainer = React.useContext(PanelContainerContext);
+  return (
+    <section className={styles.metricItem} aria-label={title}>
+      <div className={styles.metricItemHeader}>
+        <span className={Classes.TEXT_MUTED}>{title}</span>
+        {help != null && (
+          <Tooltip
+            content={<div className={styles.metricHelpContent}>{help}</div>}
+            portalContainer={panelContainer ?? undefined}
+          >
+            <Icon
+              icon="help"
+              className={styles.metricHelp}
+              aria-label={`About ${title}`}
+            />
+          </Tooltip>
+        )}
+      </div>
+      <span
+        className={classNames(
+          styles.metricValue,
+          isEmpty ? styles.na : styles[intent]
+        )}
+      >
+        {isEmpty ? "N/A" : value}
+      </span>
+      {footer != null && <div className={styles.metricFooter}>{footer}</div>}
+    </section>
+  );
+}

--- a/packages/react-devtools/src/components/Metric.tsx
+++ b/packages/react-devtools/src/components/Metric.tsx
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { Classes, Icon, Tooltip } from "@blueprintjs/core";
+import { Classes, Icon } from "@blueprintjs/core";
 import type { Intent } from "@blueprintjs/core";
 import classNames from "classnames";
 import React from "react";
 
-import { PanelContainerContext } from "./PanelContainerContext.js";
+import { BpTooltip } from "./common/BpTooltip.js";
 
 import styles from "./Metric.module.scss";
 
@@ -59,22 +59,20 @@ export function Metric({
   intent = "none",
 }: MetricProps): React.JSX.Element {
   const isEmpty = value == null || value === "";
-  const panelContainer = React.useContext(PanelContainerContext);
   return (
     <div className={styles.metricItem}>
       <div className={styles.metricItemHeader}>
         <span className={Classes.TEXT_MUTED}>{title}</span>
         {help != null && (
-          <Tooltip
+          <BpTooltip
             content={<div className={styles.metricHelpContent}>{help}</div>}
-            portalContainer={panelContainer ?? undefined}
           >
             <Icon
               icon="help"
               className={styles.metricHelp}
               aria-label={`About ${title}`}
             />
-          </Tooltip>
+          </BpTooltip>
         )}
       </div>
       <span

--- a/packages/react-devtools/src/components/MetricLegend.module.scss
+++ b/packages/react-devtools/src/components/MetricLegend.module.scss
@@ -1,0 +1,41 @@
+@use 'tokens' as t;
+
+.metricLegend {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.legendRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: t.$font-size-sm;
+  font-family: t.$font-mono;
+}
+
+.legendSwatch {
+  width: 10px;
+  height: 10px;
+  border-radius: t.$radius-sm;
+  flex-shrink: 0;
+
+  &.success {
+    background: t.$green;
+  }
+
+  &.warning {
+    background: t.$orange;
+  }
+
+  &.danger {
+    background: t.$red;
+  }
+
+  &.na {
+    background: t.$text-tertiary;
+  }
+}

--- a/packages/react-devtools/src/components/MetricLegend.module.scss
+++ b/packages/react-devtools/src/components/MetricLegend.module.scss
@@ -22,20 +22,4 @@
   height: 10px;
   border-radius: t.$radius-sm;
   flex-shrink: 0;
-
-  &.success {
-    background: t.$green;
-  }
-
-  &.warning {
-    background: t.$orange;
-  }
-
-  &.danger {
-    background: t.$red;
-  }
-
-  &.na {
-    background: t.$text-tertiary;
-  }
 }

--- a/packages/react-devtools/src/components/MetricLegend.tsx
+++ b/packages/react-devtools/src/components/MetricLegend.tsx
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-import classNames from "classnames";
 import React from "react";
+
+import { METRIC_INTENT_COLOR } from "./metricIntent.js";
+import type { MetricIntent } from "./metricIntent.js";
 
 import styles from "./MetricLegend.module.scss";
 
-/** The swatch colors a legend row can use — mirror the `Metric` value colors. */
-export type MetricLegendSwatch = "success" | "warning" | "danger" | "na";
-
 export interface MetricLegendEntry {
   /** Which swatch color to show. */
-  swatch: MetricLegendSwatch;
+  swatch: MetricIntent;
   /** The range/description this color denotes, e.g. "≥ 70%" or "> 0". */
   label: React.ReactNode;
 }
@@ -46,7 +45,10 @@ export function MetricLegend({
       {entries.map((entry) => (
         <li key={entry.swatch} className={styles.legendRow}>
           <span
-            className={classNames(styles.legendSwatch, styles[entry.swatch])}
+            className={styles.legendSwatch}
+            style={{
+              backgroundColor: METRIC_INTENT_COLOR[entry.swatch],
+            }}
             aria-hidden={true}
           />
           {entry.label}

--- a/packages/react-devtools/src/components/MetricLegend.tsx
+++ b/packages/react-devtools/src/components/MetricLegend.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from "classnames";
+import React from "react";
+
+import styles from "./MetricLegend.module.scss";
+
+/** The swatch colors a legend row can use — mirror the `Metric` value colors. */
+export type MetricLegendSwatch = "success" | "warning" | "danger" | "na";
+
+export interface MetricLegendEntry {
+  /** Which swatch color to show. */
+  swatch: MetricLegendSwatch;
+  /** The range/description this color denotes, e.g. "≥ 70%" or "> 0". */
+  label: React.ReactNode;
+}
+
+export interface MetricLegendProps {
+  /** The color-key rows, top to bottom. */
+  entries: readonly MetricLegendEntry[];
+}
+
+/**
+ * A small color key for a `Metric`'s help tooltip, mapping each swatch color to
+ * the value range it denotes.
+ */
+export function MetricLegend({
+  entries,
+}: MetricLegendProps): React.JSX.Element {
+  return (
+    <ul className={styles.metricLegend}>
+      {entries.map((entry) => (
+        <li key={entry.swatch} className={styles.legendRow}>
+          <span
+            className={classNames(styles.legendSwatch, styles[entry.swatch])}
+            aria-hidden={true}
+          />
+          {entry.label}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/react-devtools/src/components/Metrics.module.scss
+++ b/packages/react-devtools/src/components/Metrics.module.scss
@@ -1,0 +1,11 @@
+@use 'tokens' as t;
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1px;
+  background: t.$border-default;
+  border: 1px solid t.$border-default;
+  border-radius: t.$radius-md;
+  overflow: hidden;
+}

--- a/packages/react-devtools/src/components/Metrics.tsx
+++ b/packages/react-devtools/src/components/Metrics.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+
+import styles from "./Metrics.module.scss";
+
+export interface MetricsProps {
+  /**
+   * Fixed number of columns. Omit for a responsive auto-fit layout. The cells
+   * are separated by hairline dividers within a single rounded border.
+   */
+  columns?: number;
+  /** A list of `Metric` cells. */
+  children: React.ReactNode;
+}
+
+/**
+ * A grid of `Metric` cells rendered as one rounded-bordered card
+ */
+export function Metrics({
+  columns,
+  children,
+}: MetricsProps): React.JSX.Element {
+  return (
+    <div
+      className={styles.metrics}
+      style={
+        columns != null
+          ? { gridTemplateColumns: `repeat(${columns}, 1fr)` }
+          : undefined
+      }
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/react-devtools/src/components/Metrics.tsx
+++ b/packages/react-devtools/src/components/Metrics.tsx
@@ -20,8 +20,8 @@ import styles from "./Metrics.module.scss";
 
 export interface MetricsProps {
   /**
-   * Fixed number of columns. Omit for a responsive auto-fit layout. The cells
-   * are separated by hairline dividers within a single rounded border.
+   * Fixed number of columns. Omit for a responsive auto-fit layout. The cells are separated by hairline dividers
+   * within a single rounded border.
    */
   columns?: number;
   /** A list of `Metric` cells. */
@@ -40,7 +40,7 @@ export function Metrics({
       className={styles.metrics}
       style={
         columns != null
-          ? { gridTemplateColumns: `repeat(${columns}, 1fr)` }
+          ? { gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }
           : undefined
       }
     >

--- a/packages/react-devtools/src/components/MonitoringPanel.tsx
+++ b/packages/react-devtools/src/components/MonitoringPanel.tsx
@@ -31,6 +31,7 @@ import { ComputeTab } from "./ComputeTab.js";
 import { DebuggingTab } from "./DebuggingTab.js";
 import { InterceptTab } from "./InterceptTab.js";
 import { MonitorErrorBoundary } from "./MonitorErrorBoundary.js";
+import { PanelContainerContext } from "./PanelContainerContext.js";
 import { PerformanceTab } from "./PerformanceTab.js";
 
 import styles from "./MonitoringPanel.module.scss";
@@ -134,7 +135,10 @@ export const MonitoringPanel: React.FC<MonitoringPanelProps> = ({
     [themePreference, systemPrefersDark]
   );
 
-  const panelRef = useRef<HTMLDivElement>(null);
+  // A callback-ref-driven state (not a plain ref) so the context Provider
+  // re-renders with the panel element once it mounts — descendants portal
+  // overlays into it. See PanelContainerContext.
+  const [panelEl, setPanelEl] = useState<HTMLDivElement | null>(null);
   const isDragging = useRef(false);
   const isResizing = useRef<string | null>(null);
   const dragStart = useRef({ x: 0, y: 0, elemX: 0, elemY: 0 });
@@ -421,179 +425,185 @@ export const MonitoringPanel: React.FC<MonitoringPanelProps> = ({
     }
   );
   return createPortal(
-    <div
-      ref={panelRef}
-      className={panelClassName}
-      data-dt-theme={resolvedTheme}
-      style={{
-        left:
-          effectivePosition.dockMode === "docked-bottom"
-            ? 0
-            : effectivePosition.x,
-        top:
-          effectivePosition.dockMode === "docked-right"
-            ? 0
-            : effectivePosition.y,
-        width: effectivePosition.width,
-        height: effectivePosition.height,
-        right: effectivePosition.dockMode === "docked-right" ? 0 : undefined,
-        bottom: effectivePosition.dockMode === "docked-bottom" ? 0 : undefined,
-      }}
-    >
-      {(position.dockMode === "floating"
-        ? [
-            { cls: [styles.horizontal, styles.top], handle: "top" },
-            { cls: [styles.horizontal, styles.bottom], handle: "bottom" },
-            { cls: [styles.vertical, styles.left], handle: "left" },
-            { cls: [styles.vertical, styles.right], handle: "right" },
-            { cls: [styles.corner, styles.topLeft], handle: "topLeft" },
-            { cls: [styles.corner, styles.topRight], handle: "topRight" },
-            { cls: [styles.corner, styles.bottomLeft], handle: "bottomLeft" },
-            { cls: [styles.corner, styles.bottomRight], handle: "bottomRight" },
-          ]
-        : position.dockMode === "docked-bottom"
-          ? [{ cls: [styles.horizontal, styles.top], handle: "top" }]
-          : position.dockMode === "docked-right"
-            ? [{ cls: [styles.vertical, styles.left], handle: "left" }]
-            : []
-      ).map(({ cls, handle }) => (
-        <div
-          key={handle}
-          className={classNames(styles.resizeHandle, ...cls)}
-          onMouseDown={(e) => handleResizeMouseDown(e, handle)}
-        />
-      ))}
+    <PanelContainerContext.Provider value={panelEl}>
+      <div
+        ref={setPanelEl}
+        className={panelClassName}
+        data-dt-theme={resolvedTheme}
+        style={{
+          left:
+            effectivePosition.dockMode === "docked-bottom"
+              ? 0
+              : effectivePosition.x,
+          top:
+            effectivePosition.dockMode === "docked-right"
+              ? 0
+              : effectivePosition.y,
+          width: effectivePosition.width,
+          height: effectivePosition.height,
+          right: effectivePosition.dockMode === "docked-right" ? 0 : undefined,
+          bottom:
+            effectivePosition.dockMode === "docked-bottom" ? 0 : undefined,
+        }}
+      >
+        {(position.dockMode === "floating"
+          ? [
+              { cls: [styles.horizontal, styles.top], handle: "top" },
+              { cls: [styles.horizontal, styles.bottom], handle: "bottom" },
+              { cls: [styles.vertical, styles.left], handle: "left" },
+              { cls: [styles.vertical, styles.right], handle: "right" },
+              { cls: [styles.corner, styles.topLeft], handle: "topLeft" },
+              { cls: [styles.corner, styles.topRight], handle: "topRight" },
+              { cls: [styles.corner, styles.bottomLeft], handle: "bottomLeft" },
+              {
+                cls: [styles.corner, styles.bottomRight],
+                handle: "bottomRight",
+              },
+            ]
+          : position.dockMode === "docked-bottom"
+            ? [{ cls: [styles.horizontal, styles.top], handle: "top" }]
+            : position.dockMode === "docked-right"
+              ? [{ cls: [styles.vertical, styles.left], handle: "left" }]
+              : []
+        ).map(({ cls, handle }) => (
+          <div
+            key={handle}
+            className={classNames(styles.resizeHandle, ...cls)}
+            onMouseDown={(e) => handleResizeMouseDown(e, handle)}
+          />
+        ))}
 
-      <div className={styles.header} onMouseDown={handleMouseDown}>
-        <h3 className={styles.title}>
-          OSDK Devtools
-          <span className={styles.badge}>Beta</span>
-        </h3>
-        <div className={styles.controls}>
-          <Button
-            variant="minimal"
-            size="small"
-            icon={
-              themePreference === "dark"
-                ? "moon"
-                : themePreference === "light"
-                  ? "flash"
-                  : "automatic-updates"
-            }
-            onClick={() =>
-              setThemePreference(
+        <div className={styles.header} onMouseDown={handleMouseDown}>
+          <h3 className={styles.title}>
+            OSDK Devtools
+            <span className={styles.badge}>Beta</span>
+          </h3>
+          <div className={styles.controls}>
+            <Button
+              variant="minimal"
+              size="small"
+              icon={
                 themePreference === "dark"
-                  ? "light"
+                  ? "moon"
                   : themePreference === "light"
-                    ? "auto"
-                    : "dark"
-              )
+                    ? "flash"
+                    : "automatic-updates"
+              }
+              onClick={() =>
+                setThemePreference(
+                  themePreference === "dark"
+                    ? "light"
+                    : themePreference === "light"
+                      ? "auto"
+                      : "dark"
+                )
+              }
+              title={`Theme: ${themePreference} (click to cycle)`}
+              aria-label={`Theme: ${themePreference}. Click to cycle.`}
+            />
+            <Button
+              variant="minimal"
+              size="small"
+              icon={
+                position.dockMode === "floating"
+                  ? "widget"
+                  : position.dockMode === "docked-bottom"
+                    ? "layout-sorted-clusters"
+                    : "layout-hierarchy"
+              }
+              onClick={handleDockToggle}
+              title={`Dock mode: ${position.dockMode} (click to cycle)`}
+              aria-label={`Dock mode: ${position.dockMode}. Click to cycle.`}
+            />
+            <Button
+              variant="minimal"
+              size="small"
+              icon="reset"
+              onClick={() => metricsStore.reset()}
+              title="Reset metrics"
+              aria-label="Reset metrics"
+            />
+            <Button
+              variant="minimal"
+              size="small"
+              icon="minimize"
+              onClick={() =>
+                setPosition((prev) => ({ ...prev, collapsed: true }))
+              }
+              title="Minimize"
+              aria-label="Minimize devtools panel"
+            />
+          </div>
+        </div>
+
+        <div className={styles.tabs} role="tablist" aria-label="Devtools tabs">
+          {(["performance", "compute", "intercept", "debugging"] as const).map(
+            (tab) => (
+              <button
+                key={tab}
+                type="button"
+                role="tab"
+                aria-selected={activeTab === tab}
+                className={classNames(
+                  styles.tabButton,
+                  activeTab === tab && styles.tabButtonActive
+                )}
+                onClick={() => setActiveTab(tab)}
+              >
+                {tab.charAt(0).toUpperCase() + tab.slice(1)}
+              </button>
+            )
+          )}
+        </div>
+
+        <div className={styles.content}>
+          {(!fiberCapabilities.hookInstalled ||
+            !fiberCapabilities.fiberAccessWorking) && (
+            <DegradationNotice onRetry={() => validateFiberAccess()} />
+          )}
+
+          <div
+            className={
+              activeTab === "performance"
+                ? styles.tabContentVisible
+                : styles.tabContentHidden
             }
-            title={`Theme: ${themePreference} (click to cycle)`}
-            aria-label={`Theme: ${themePreference}. Click to cycle.`}
-          />
-          <Button
-            variant="minimal"
-            size="small"
-            icon={
-              position.dockMode === "floating"
-                ? "widget"
-                : position.dockMode === "docked-bottom"
-                  ? "layout-sorted-clusters"
-                  : "layout-hierarchy"
+          >
+            <PerformanceTab
+              metricsStore={metricsStore}
+              monitorStore={monitorStore}
+            />
+          </div>
+          <div
+            className={
+              activeTab === "compute"
+                ? styles.tabContentVisible
+                : styles.tabContentHidden
             }
-            onClick={handleDockToggle}
-            title={`Dock mode: ${position.dockMode} (click to cycle)`}
-            aria-label={`Dock mode: ${position.dockMode}. Click to cycle.`}
-          />
-          <Button
-            variant="minimal"
-            size="small"
-            icon="reset"
-            onClick={() => metricsStore.reset()}
-            title="Reset metrics"
-            aria-label="Reset metrics"
-          />
-          <Button
-            variant="minimal"
-            size="small"
-            icon="minimize"
-            onClick={() =>
-              setPosition((prev) => ({ ...prev, collapsed: true }))
+          >
+            <ComputeTab computeStore={computeStore} />
+          </div>
+          <div
+            className={
+              activeTab === "intercept"
+                ? styles.tabContentVisible
+                : styles.tabContentHidden
             }
-            title="Minimize"
-            aria-label="Minimize devtools panel"
-          />
+          >
+            <InterceptTab monitorStore={monitorStore} theme={resolvedTheme} />
+          </div>
+          <div
+            className={
+              activeTab === "debugging"
+                ? styles.tabContentVisible
+                : styles.tabContentHidden
+            }
+          >
+            <DebuggingTab monitorStore={monitorStore} />
+          </div>
         </div>
       </div>
-
-      <div className={styles.tabs} role="tablist" aria-label="Devtools tabs">
-        {(["performance", "compute", "intercept", "debugging"] as const).map(
-          (tab) => (
-            <button
-              key={tab}
-              type="button"
-              role="tab"
-              aria-selected={activeTab === tab}
-              className={classNames(
-                styles.tabButton,
-                activeTab === tab && styles.tabButtonActive
-              )}
-              onClick={() => setActiveTab(tab)}
-            >
-              {tab.charAt(0).toUpperCase() + tab.slice(1)}
-            </button>
-          )
-        )}
-      </div>
-
-      <div className={styles.content}>
-        {(!fiberCapabilities.hookInstalled ||
-          !fiberCapabilities.fiberAccessWorking) && (
-          <DegradationNotice onRetry={() => validateFiberAccess()} />
-        )}
-
-        <div
-          className={
-            activeTab === "performance"
-              ? styles.tabContentVisible
-              : styles.tabContentHidden
-          }
-        >
-          <PerformanceTab
-            metricsStore={metricsStore}
-            monitorStore={monitorStore}
-          />
-        </div>
-        <div
-          className={
-            activeTab === "compute"
-              ? styles.tabContentVisible
-              : styles.tabContentHidden
-          }
-        >
-          <ComputeTab computeStore={computeStore} />
-        </div>
-        <div
-          className={
-            activeTab === "intercept"
-              ? styles.tabContentVisible
-              : styles.tabContentHidden
-          }
-        >
-          <InterceptTab monitorStore={monitorStore} theme={resolvedTheme} />
-        </div>
-        <div
-          className={
-            activeTab === "debugging"
-              ? styles.tabContentVisible
-              : styles.tabContentHidden
-          }
-        >
-          <DebuggingTab monitorStore={monitorStore} />
-        </div>
-      </div>
-    </div>,
+    </PanelContainerContext.Provider>,
     document.body
   );
 };

--- a/packages/react-devtools/src/components/OverviewSection.module.scss
+++ b/packages/react-devtools/src/components/OverviewSection.module.scss
@@ -2,11 +2,10 @@
 
 .overviewSection {
   border-radius: 0;
-  // A real top border as the section divider (matches the 1px divider used
-  // elsewhere).
+  // A real top border as the section divider (matches the 1px divider used elsewhere).
   border-top: 1px solid t.$border-default;
 
-  // Clear Blueprint's `.bp6-elevation-0` box-shadow outline so that we don't a border like inline
+  // Clear Blueprint's `.bp6-elevation-0` box-shadow outline so that we don't have borders on the left and right
   &:global(.bp6-elevation-0) {
     box-shadow: none;
   }

--- a/packages/react-devtools/src/components/OverviewSection.module.scss
+++ b/packages/react-devtools/src/components/OverviewSection.module.scss
@@ -1,0 +1,18 @@
+@use 'tokens' as t;
+
+.overviewSection {
+  border-radius: 0;
+  // A real top border as the section divider (matches the 1px divider used
+  // elsewhere).
+  border-top: 1px solid t.$border-default;
+
+  // Clear Blueprint's `.bp6-elevation-0` box-shadow outline so that we don't a border like inline
+  &:global(.bp6-elevation-0) {
+    box-shadow: none;
+  }
+
+  .overviewSectionCard {
+    padding: 12px;
+    background: t.$bg-surface;
+  }
+}

--- a/packages/react-devtools/src/components/OverviewSection.tsx
+++ b/packages/react-devtools/src/components/OverviewSection.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Section, SectionCard } from "@blueprintjs/core";
+import React from "react";
+
+import styles from "./OverviewSection.module.scss";
+
+export interface OverviewSectionProps {
+  /** The section header title, e.g. "Ontology". */
+  title: string;
+  /** The section body — typically a grid of tiles. */
+  children: React.ReactNode;
+}
+
+export function OverviewSection({
+  title,
+  children,
+}: OverviewSectionProps): React.JSX.Element {
+  return (
+    <Section
+      collapsible={true}
+      compact={true}
+      title={title}
+      className={styles.overviewSection}
+    >
+      <SectionCard className={styles.overviewSectionCard}>
+        {children}
+      </SectionCard>
+    </Section>
+  );
+}

--- a/packages/react-devtools/src/components/OverviewTab.module.scss
+++ b/packages/react-devtools/src/components/OverviewTab.module.scss
@@ -1,48 +1,5 @@
-@use 'tokens' as t;
-
 .overviewTab {
   display: flex;
   flex-direction: column;
-  gap: 0px;
   padding: 0;
-}
-
-.metricLegend {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.legendRow {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: t.$font-size-sm;
-  font-family: t.$font-mono;
-}
-
-.legendSwatch {
-  width: 10px;
-  height: 10px;
-  border-radius: t.$radius-sm;
-  flex-shrink: 0;
-
-  &.success {
-    background: t.$green;
-  }
-
-  &.warning {
-    background: t.$orange;
-  }
-
-  &.danger {
-    background: t.$red;
-  }
-
-  &.na {
-    background: t.$text-tertiary;
-  }
 }

--- a/packages/react-devtools/src/components/OverviewTab.module.scss
+++ b/packages/react-devtools/src/components/OverviewTab.module.scss
@@ -1,0 +1,48 @@
+@use 'tokens' as t;
+
+.overviewTab {
+  display: flex;
+  flex-direction: column;
+  gap: 0px;
+  padding: 0;
+}
+
+.metricLegend {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.legendRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: t.$font-size-sm;
+  font-family: t.$font-mono;
+}
+
+.legendSwatch {
+  width: 10px;
+  height: 10px;
+  border-radius: t.$radius-sm;
+  flex-shrink: 0;
+
+  &.success {
+    background: t.$green;
+  }
+
+  &.warning {
+    background: t.$orange;
+  }
+
+  &.danger {
+    background: t.$red;
+  }
+
+  &.na {
+    background: t.$text-tertiary;
+  }
+}

--- a/packages/react-devtools/src/components/OverviewTab.tsx
+++ b/packages/react-devtools/src/components/OverviewTab.tsx
@@ -15,11 +15,12 @@
  */
 
 import { AnchorButton, NonIdealState } from "@blueprintjs/core";
-import classNames from "classnames";
 import React from "react";
 
 import { formatNumber, formatTime } from "../utils/format.js";
 import { Metric } from "./Metric.js";
+import { MetricLegend } from "./MetricLegend.js";
+import type { MetricLegendEntry } from "./MetricLegend.js";
 import { Metrics } from "./Metrics.js";
 import { OverviewSection } from "./OverviewSection.js";
 
@@ -55,6 +56,15 @@ const debugging = {
   overfetchingCount: 2,
   errorWarningCount: 1,
 };
+
+/**
+ * Color key shared by the count metrics where any occurrence is a problem — a
+ * positive value is flagged `danger`; zero / no data reads as muted.
+ */
+const POSITIVE_IS_PROBLEM_LEGEND: readonly MetricLegendEntry[] = [
+  { swatch: "danger", label: "> 0" },
+  { swatch: "na", label: "0 / no data" },
+];
 
 /**
  * The Overview tab — an at-a-glance summary of the monitored client's ontology
@@ -103,35 +113,13 @@ export function OverviewTab(): React.JSX.Element {
               <>
                 Share of object reads served from the normalized cache instead
                 of the network.
-                <ul className={styles.metricLegend}>
-                  <li className={styles.legendRow}>
-                    <span
-                      className={classNames(
-                        styles.legendSwatch,
-                        styles.success
-                      )}
-                      aria-hidden={true}
-                    />
-                    ≥ 70%
-                  </li>
-                  <li className={styles.legendRow}>
-                    <span
-                      className={classNames(
-                        styles.legendSwatch,
-                        styles.warning
-                      )}
-                      aria-hidden={true}
-                    />
-                    40–70%
-                  </li>
-                  <li className={styles.legendRow}>
-                    <span
-                      className={classNames(styles.legendSwatch, styles.danger)}
-                      aria-hidden={true}
-                    />
-                    {"< 40%"}
-                  </li>
-                </ul>
+                <MetricLegend
+                  entries={[
+                    { swatch: "success", label: "≥ 70%" },
+                    { swatch: "warning", label: "40–70%" },
+                    { swatch: "danger", label: "< 40%" },
+                  ]}
+                />
               </>
             }
             value={
@@ -173,22 +161,7 @@ export function OverviewTab(): React.JSX.Element {
               <>
                 Requests for data an in-flight request already covered,
                 collapsed onto a single fetch by deduplication.
-                <ul className={styles.metricLegend}>
-                  <li className={styles.legendRow}>
-                    <span
-                      className={classNames(styles.legendSwatch, styles.danger)}
-                      aria-hidden={true}
-                    />
-                    {"> 0"}
-                  </li>
-                  <li className={styles.legendRow}>
-                    <span
-                      className={classNames(styles.legendSwatch, styles.na)}
-                      aria-hidden={true}
-                    />
-                    0 / no data
-                  </li>
-                </ul>
+                <MetricLegend entries={POSITIVE_IS_PROBLEM_LEGEND} />
               </>
             }
             value={
@@ -209,22 +182,7 @@ export function OverviewTab(): React.JSX.Element {
               <>
                 Components whose hooks fetch fields that no descendant ever
                 reads.
-                <ul className={styles.metricLegend}>
-                  <li className={styles.legendRow}>
-                    <span
-                      className={classNames(styles.legendSwatch, styles.danger)}
-                      aria-hidden={true}
-                    />
-                    {"> 0"}
-                  </li>
-                  <li className={styles.legendRow}>
-                    <span
-                      className={classNames(styles.legendSwatch, styles.na)}
-                      aria-hidden={true}
-                    />
-                    0 / no data
-                  </li>
-                </ul>
+                <MetricLegend entries={POSITIVE_IS_PROBLEM_LEGEND} />
               </>
             }
             value={
@@ -245,26 +203,25 @@ export function OverviewTab(): React.JSX.Element {
               <>
                 Uncaught errors and console warnings captured from @osdk/react
                 hooks and your render tree this session.
-                <ul className={styles.metricLegend}>
-                  <li className={styles.legendRow}>
-                    <span
-                      className={classNames(styles.legendSwatch, styles.danger)}
-                      aria-hidden={true}
-                    />
-                    {"> 0"}
-                  </li>
-                  <li className={styles.legendRow}>
-                    <span
-                      className={classNames(styles.legendSwatch, styles.na)}
-                      aria-hidden={true}
-                    />
-                    0
-                  </li>
-                </ul>
+                <MetricLegend
+                  entries={[
+                    { swatch: "danger", label: "> 0" },
+                    { swatch: "na", label: "0" },
+                  ]}
+                />
               </>
             }
-            value={formatNumber(debugging.errorWarningCount)}
-            intent={debugging.errorWarningCount > 0 ? "danger" : "none"}
+            value={
+              debugging.errorWarningCount != null
+                ? formatNumber(debugging.errorWarningCount)
+                : null
+            }
+            intent={
+              debugging.errorWarningCount != null &&
+              debugging.errorWarningCount > 0
+                ? "danger"
+                : "none"
+            }
           />
         </Metrics>
       </OverviewSection>

--- a/packages/react-devtools/src/components/OverviewTab.tsx
+++ b/packages/react-devtools/src/components/OverviewTab.tsx
@@ -31,13 +31,6 @@ import styles from "./OverviewTab.module.scss";
  */
 const OSDK_DOCS_URL = "https://palantir.github.io/osdk-ts/";
 
-/**
- * Gates the Overview tab. Off by default while the tab is still being built out
- * on dummy data — flip to `true` (or wire to config) to surface it. Exported so
- * tests and callers can branch on whether the tab is available.
- */
-export const IS_OVERVIEW_TAB_ENABLED = false;
-
 // TODO: Fetch the real data later
 const usage = {
   objectTypeCount: 8,
@@ -53,7 +46,7 @@ const performance = {
 };
 
 const debugging = {
-  overfetchingCount: 2,
+  overfetchingCount: undefined,
   errorWarningCount: 1,
 };
 
@@ -63,7 +56,7 @@ const debugging = {
  */
 const POSITIVE_IS_PROBLEM_LEGEND: readonly MetricLegendEntry[] = [
   { swatch: "danger", label: "> 0" },
-  { swatch: "na", label: "0 / no data" },
+  { swatch: "none", label: "0 / no data" },
 ];
 
 /**
@@ -203,12 +196,7 @@ export function OverviewTab(): React.JSX.Element {
               <>
                 Uncaught errors and console warnings captured from @osdk/react
                 hooks and your render tree this session.
-                <MetricLegend
-                  entries={[
-                    { swatch: "danger", label: "> 0" },
-                    { swatch: "na", label: "0" },
-                  ]}
-                />
+                <MetricLegend entries={POSITIVE_IS_PROBLEM_LEGEND} />
               </>
             }
             value={

--- a/packages/react-devtools/src/components/OverviewTab.tsx
+++ b/packages/react-devtools/src/components/OverviewTab.tsx
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AnchorButton, NonIdealState } from "@blueprintjs/core";
+import classNames from "classnames";
+import React from "react";
+
+import { formatNumber, formatTime } from "../utils/format.js";
+import { Metric } from "./Metric.js";
+import { Metrics } from "./Metrics.js";
+import { OverviewSection } from "./OverviewSection.js";
+
+import styles from "./OverviewTab.module.scss";
+
+/**
+ * Link to the osdk/react pages instead of the public docs since they contain more examples
+ */
+const OSDK_DOCS_URL = "https://palantir.github.io/osdk-ts/";
+
+/**
+ * Gates the Overview tab. Off by default while the tab is still being built out
+ * on dummy data — flip to `true` (or wire to config) to surface it. Exported so
+ * tests and callers can branch on whether the tab is available.
+ */
+export const IS_OVERVIEW_TAB_ENABLED = true;
+
+// TODO: Fetch the real data later
+const usage = {
+  objectTypeCount: 8,
+  actionTypeCount: 3,
+  linkCount: 5,
+};
+
+const performance = {
+  cacheHitRate: 0.82,
+  networkRequests: 1240,
+  averageResponseTime: 45,
+  duplicateRequests: 0,
+};
+
+const debugging = {
+  overfetchingCount: 2,
+  errorWarningCount: 1,
+};
+
+/**
+ * The Overview tab — an at-a-glance summary of the monitored client's ontology
+ * usage and health metrics. Shows the "no ontology" empty state when the
+ * registry is empty; otherwise renders the ontology counts and the performance
+ * metrics grid.
+ */
+export function OverviewTab(): React.JSX.Element {
+  const isOntologyEmpty =
+    usage.objectTypeCount + usage.actionTypeCount + usage.linkCount === 0;
+
+  return (
+    <div className={styles.overviewTab}>
+      <OverviewSection title="Ontology">
+        {isOntologyEmpty ? (
+          <NonIdealState
+            icon="cube"
+            title="No ontology usage detected"
+            description="We didn't detect any ontology used inside the components of this app."
+            action={
+              <AnchorButton
+                href={OSDK_DOCS_URL}
+                target="_blank"
+                rel="noreferrer"
+                intent="primary"
+                endIcon="share"
+                variant="outlined"
+              >
+                View documentation
+              </AnchorButton>
+            }
+          />
+        ) : (
+          <Metrics columns={3}>
+            <Metric title="Object types" value={usage.objectTypeCount} />
+            <Metric title="Action types" value={usage.actionTypeCount} />
+            <Metric title="Links" value={usage.linkCount} />
+          </Metrics>
+        )}
+      </OverviewSection>
+      <OverviewSection title="Metrics">
+        <Metrics columns={2}>
+          <Metric
+            title="Cache hit rate"
+            help={
+              <>
+                Share of object reads served from the normalized cache instead
+                of the network.
+                <ul className={styles.metricLegend}>
+                  <li className={styles.legendRow}>
+                    <span
+                      className={classNames(
+                        styles.legendSwatch,
+                        styles.success
+                      )}
+                      aria-hidden={true}
+                    />
+                    ≥ 70%
+                  </li>
+                  <li className={styles.legendRow}>
+                    <span
+                      className={classNames(
+                        styles.legendSwatch,
+                        styles.warning
+                      )}
+                      aria-hidden={true}
+                    />
+                    40–70%
+                  </li>
+                  <li className={styles.legendRow}>
+                    <span
+                      className={classNames(styles.legendSwatch, styles.danger)}
+                      aria-hidden={true}
+                    />
+                    {"< 40%"}
+                  </li>
+                </ul>
+              </>
+            }
+            value={
+              performance.cacheHitRate == null
+                ? null
+                : `${Math.round(performance.cacheHitRate * 100)}%`
+            }
+            intent={
+              performance.cacheHitRate == null
+                ? "none"
+                : performance.cacheHitRate > 0.7
+                  ? "success"
+                  : performance.cacheHitRate > 0.4
+                    ? "warning"
+                    : "danger"
+            }
+          />
+          <Metric
+            title="Network requests"
+            help="Requests that went to the network — cache misses plus revalidations."
+            value={
+              performance.networkRequests == null
+                ? null
+                : formatNumber(performance.networkRequests)
+            }
+          />
+          <Metric
+            title="Avg response time"
+            help="Average response time across requests. Cache reads are typically under 1ms; network reads dominate."
+            value={
+              performance.averageResponseTime == null
+                ? null
+                : formatTime(performance.averageResponseTime)
+            }
+          />
+          <Metric
+            title="Duplicate requests"
+            help={
+              <>
+                Requests for data an in-flight request already covered,
+                collapsed onto a single fetch by deduplication.
+                <ul className={styles.metricLegend}>
+                  <li className={styles.legendRow}>
+                    <span
+                      className={classNames(styles.legendSwatch, styles.danger)}
+                      aria-hidden={true}
+                    />
+                    {"> 0"}
+                  </li>
+                  <li className={styles.legendRow}>
+                    <span
+                      className={classNames(styles.legendSwatch, styles.na)}
+                      aria-hidden={true}
+                    />
+                    0 / no data
+                  </li>
+                </ul>
+              </>
+            }
+            value={
+              performance.duplicateRequests == null
+                ? null
+                : formatNumber(performance.duplicateRequests)
+            }
+            intent={
+              performance.duplicateRequests != null &&
+              performance.duplicateRequests > 0
+                ? "danger"
+                : "none"
+            }
+          />
+          <Metric
+            title="Overfetching"
+            help={
+              <>
+                Components whose hooks fetch fields that no descendant ever
+                reads.
+                <ul className={styles.metricLegend}>
+                  <li className={styles.legendRow}>
+                    <span
+                      className={classNames(styles.legendSwatch, styles.danger)}
+                      aria-hidden={true}
+                    />
+                    {"> 0"}
+                  </li>
+                  <li className={styles.legendRow}>
+                    <span
+                      className={classNames(styles.legendSwatch, styles.na)}
+                      aria-hidden={true}
+                    />
+                    0 / no data
+                  </li>
+                </ul>
+              </>
+            }
+            value={
+              debugging.overfetchingCount == null
+                ? null
+                : formatNumber(debugging.overfetchingCount)
+            }
+            intent={
+              debugging.overfetchingCount != null &&
+              debugging.overfetchingCount > 0
+                ? "danger"
+                : "none"
+            }
+          />
+          <Metric
+            title="Errors & warnings"
+            help={
+              <>
+                Uncaught errors and console warnings captured from @osdk/react
+                hooks and your render tree this session.
+                <ul className={styles.metricLegend}>
+                  <li className={styles.legendRow}>
+                    <span
+                      className={classNames(styles.legendSwatch, styles.danger)}
+                      aria-hidden={true}
+                    />
+                    {"> 0"}
+                  </li>
+                  <li className={styles.legendRow}>
+                    <span
+                      className={classNames(styles.legendSwatch, styles.na)}
+                      aria-hidden={true}
+                    />
+                    0
+                  </li>
+                </ul>
+              </>
+            }
+            value={formatNumber(debugging.errorWarningCount)}
+            intent={debugging.errorWarningCount > 0 ? "danger" : "none"}
+          />
+        </Metrics>
+      </OverviewSection>
+    </div>
+  );
+}

--- a/packages/react-devtools/src/components/OverviewTab.tsx
+++ b/packages/react-devtools/src/components/OverviewTab.tsx
@@ -36,7 +36,7 @@ const OSDK_DOCS_URL = "https://palantir.github.io/osdk-ts/";
  * on dummy data — flip to `true` (or wire to config) to surface it. Exported so
  * tests and callers can branch on whether the tab is available.
  */
-export const IS_OVERVIEW_TAB_ENABLED = true;
+export const IS_OVERVIEW_TAB_ENABLED = false;
 
 // TODO: Fetch the real data later
 const usage = {

--- a/packages/react-devtools/src/components/PanelContainerContext.ts
+++ b/packages/react-devtools/src/components/PanelContainerContext.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Context } from "react";
+import { createContext } from "react";
+
+/**
+ * The panel's root element, published so descendants can portal overlays
+ * (tooltips, popovers) into the panel instead of `document.body`.
+ */
+export const PanelContainerContext: Context<HTMLElement | null> =
+  createContext<HTMLElement | null>(null);

--- a/packages/react-devtools/src/components/common/BpTooltip.tsx
+++ b/packages/react-devtools/src/components/common/BpTooltip.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Tooltip } from "@blueprintjs/core";
+import type { TooltipProps } from "@blueprintjs/core";
+import React from "react";
+
+import { PanelContainerContext } from "../PanelContainerContext.js";
+
+/**
+ * Blueprint `Tooltip` pre-wired to portal into the devtools panel (via
+ * `PanelContainerContext`) instead of `document.body`, so the tooltip inherits
+ * the panel's theme and stacking context. Takes all the usual `TooltipProps`;
+ * an explicitly passed `portalContainer` still wins.
+ */
+export function BpTooltip({
+  portalContainer,
+  ...props
+}: TooltipProps): React.JSX.Element {
+  const panelContainer = React.useContext(PanelContainerContext);
+  return (
+    <Tooltip
+      portalContainer={portalContainer ?? panelContainer ?? undefined}
+      {...props}
+    />
+  );
+}

--- a/packages/react-devtools/src/components/metricIntent.ts
+++ b/packages/react-devtools/src/components/metricIntent.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The intents a `Metric` value — and its `MetricLegend` swatch — can take.
+ * Shared by both so they can't diverge on which color means what. `none` is the
+ * neutral/no-status case.
+ */
+export type MetricIntent = "none" | "success" | "warning" | "danger";
+
+/**
+ * `MetricIntent` → the Blueprint intent color token it renders with, so colors
+ * track the panel theme. `none` maps to `undefined`: a value inherits the
+ * surrounding text color; a swatch falls back to its own muted fill.
+ */
+export const METRIC_INTENT_COLOR: Record<MetricIntent, string | undefined> = {
+  none: undefined,
+  success: "var(--bp-intent-success-rest)",
+  warning: "var(--bp-intent-warning-rest)",
+  danger: "var(--bp-intent-danger-rest)",
+};


### PR DESCRIPTION
## What

Adds an Overview tab to the react-devtools monitoring panel, plus the primitives it's built from:

- `OverviewTab` — an at-a-glance summary of the monitored client's ontology usage and health: object/action/link counts, cache hit rate, network requests, response time, duplicate requests, overfetching, and errors & warnings. Shows a "no ontology" empty state when nothing is registered.
- `Metric` / `Metrics` — a single metric cell and the bordered grid that lays them out, with hairline dividers.
- `MetricLegend` + `metricIntent` — a color key for a metric's help tooltip, and the shared `MetricIntent → Blueprint color` mapping so a value and its legend swatch can't disagree on what a color means.
- `OverviewSection` — a collapsible Blueprint `Section` wrapper for grouping metrics.
- `PanelContainerContext` + `BpTooltip` — portal tooltips/overlays into the panel instead of `document.body`, so they inherit the panel's theme and stacking context. `MonitoringPanel` now provides the context.

## Notes

- The tab runs on hardcoded dummy data (see the `TODO: Fetch the real data later`); the real data hooks are intentionally left out of this change.

## Next
This PR is the first one to split and clean this [PR](https://github.com/palantir/osdk-ts/pull/3634). Next is to wire real data into this PR

<img width="493" height="646" alt="Screenshot 2026-07-06 at 15 15 05" src="https://github.com/user-attachments/assets/adb1e002-7085-442c-b540-88811bd193f6" />
