### PR TITLE
Render AipAgentChat as a Storybook folder and align its docs

### DIFF
--- a/.changeset/aip-agent-chat-beta-folder.md
+++ b/.changeset/aip-agent-chat-beta-folder.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components-storybook": patch
+---
+
+Move the AipAgentChat story under Components with a beta badge

--- a/.changeset/aip-agent-chat-beta-folder.md
+++ b/.changeset/aip-agent-chat-beta-folder.md
@@ -2,4 +2,4 @@
 "@osdk/react-components-storybook": patch
 ---
 
-Move the AipAgentChat story under Components with a beta badge
+Render the AipAgentChat story as a folder under Components (matching CbacPicker) with a Docs page and beta badge

--- a/packages/react-components-storybook/src/stories/AipAgentChat/AipAgentChat.mdx
+++ b/packages/react-components-storybook/src/stories/AipAgentChat/AipAgentChat.mdx
@@ -1,0 +1,22 @@
+{/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */}
+
+import { Meta, Markdown } from "@storybook/addon-docs/blocks";
+import aipAgentChatDocs from "@docs/AipAgentChat.md?raw";
+
+<Meta title="Components/AipAgentChat/Docs" tags={["beta"]}/>
+
+<Markdown>{aipAgentChatDocs}</Markdown>

--- a/packages/react-components-storybook/src/stories/AipAgentChat/AipAgentChat.stories.tsx
+++ b/packages/react-components-storybook/src/stories/AipAgentChat/AipAgentChat.stories.tsx
@@ -140,7 +140,7 @@ function InteractiveChat(
 }
 
 const meta: Meta<typeof InteractiveChat> = {
-  title: "Components/BaseChat/AipAgentChat",
+  title: "Components/AipAgentChat/BaseChat",
   component: InteractiveChat,
   render: (args) => (
     <div style={{ height: "600px", maxWidth: "700px" }}>

--- a/packages/react-components-storybook/src/stories/AipAgentChat/AipAgentChat.stories.tsx
+++ b/packages/react-components-storybook/src/stories/AipAgentChat/AipAgentChat.stories.tsx
@@ -140,7 +140,7 @@ function InteractiveChat(
 }
 
 const meta: Meta<typeof InteractiveChat> = {
-  title: "Components/AipAgentChat",
+  title: "Components/BaseChat/AipAgentChat",
   component: InteractiveChat,
   render: (args) => (
     <div style={{ height: "600px", maxWidth: "700px" }}>

--- a/packages/react-components-storybook/src/stories/AipAgentChat/AipAgentChat.stories.tsx
+++ b/packages/react-components-storybook/src/stories/AipAgentChat/AipAgentChat.stories.tsx
@@ -140,7 +140,7 @@ function InteractiveChat(
 }
 
 const meta: Meta<typeof InteractiveChat> = {
-  title: "Beta/AipAgentChat",
+  title: "Components/AipAgentChat",
   component: InteractiveChat,
   render: (args) => (
     <div style={{ height: "600px", maxWidth: "700px" }}>

--- a/packages/react-components-storybook/src/stories/AipAgentChat/AipAgentChat.stories.tsx
+++ b/packages/react-components-storybook/src/stories/AipAgentChat/AipAgentChat.stories.tsx
@@ -140,7 +140,7 @@ function InteractiveChat(
 }
 
 const meta: Meta<typeof InteractiveChat> = {
-  title: "Components/AipAgentChat/BaseChat",
+  title: "Components/AipAgentChat",
   component: InteractiveChat,
   render: (args) => (
     <div style={{ height: "600px", maxWidth: "700px" }}>

--- a/packages/react-components/docs/AipAgentChat.md
+++ b/packages/react-components/docs/AipAgentChat.md
@@ -9,7 +9,7 @@ component is sufficient — consumers do not need to import `useChat` or
 
 - [Import](#import)
 - [Basic Usage](#basic-usage)
-- [Props](#props)
+- [Props Reference](#props-reference)
 - [Theming](#theming)
 
 ## Import
@@ -190,7 +190,7 @@ function MyChat() {
 }
 ```
 
-## Props
+## Props Reference
 
 See [`AipAgentChatApi.ts`](../src/aip-agent-chat/AipAgentChatApi.ts) for
 the full prop list with JSDoc. `client` is the only required prop.

--- a/packages/react-components/docs/AipAgentChat.md
+++ b/packages/react-components/docs/AipAgentChat.md
@@ -5,6 +5,13 @@ LMS via `useChat` from `@osdk/react/experimental/aip`. Importing the
 component is sufficient — consumers do not need to import `useChat` or
 `foundryModel` themselves.
 
+## Table of Contents
+
+- [Import](#import)
+- [Usage](#usage)
+- [Props](#props)
+- [Theming](#theming)
+
 ## Import
 
 ```tsx
@@ -202,6 +209,11 @@ optional props:
 ## Theming
 
 CSS variables are documented in
-[`docs/CSSVariables.md`](./CSSVariables.md). The `--osdk-aip-agent-chat-*`
-namespace covers spacing, bubble colors, composer styling, and the
-3-dot loader.
+[`docs/CSSVariables.md`](./CSSVariables.md#aip-agent-chat) under **AIP
+Agent Chat**. The `--osdk-aip-agent-chat-*` namespace covers the
+container, spacing, message bubbles, composer, empty state, and the
+3-dot streaming loader. Defaults live in
+[`src/tokens/component-tokens/aip-agent-chat.css`](../src/tokens/component-tokens/aip-agent-chat.css);
+color, spacing, and radius tokens derive from `--osdk-*` semantic
+tokens, so brand overrides applied at the `--osdk-*` layer flow through
+automatically.

--- a/packages/react-components/docs/AipAgentChat.md
+++ b/packages/react-components/docs/AipAgentChat.md
@@ -8,7 +8,7 @@ component is sufficient — consumers do not need to import `useChat` or
 ## Table of Contents
 
 - [Import](#import)
-- [Usage](#usage)
+- [Basic Usage](#basic-usage)
 - [Props](#props)
 - [Theming](#theming)
 
@@ -29,15 +29,17 @@ import {
   when you already manage chat state yourself (a custom hook, a
   non-OSDK backend, etc.).
 
-## Usage
+## Basic Usage
 
-### Minimal
+### Minimal Example
+
+The simplest way to use `AipAgentChat` is with just a platform client;
+`model` and `defaultModel` are both optional and fall back to `"gpt-4o"`:
 
 ```tsx
 import { AipAgentChat } from "@osdk/react-components/experimental/aip-agent-chat";
 import { platformClient } from "./foundryClient.js";
 
-// `model` and `defaultModel` are both optional — falls back to "gpt-4o".
 <AipAgentChat client={platformClient} />;
 ```
 

--- a/packages/react-components/docs/CSSVariables.md
+++ b/packages/react-components/docs/CSSVariables.md
@@ -18,6 +18,7 @@ Complete reference of all CSS custom properties (variables) used in `@osdk/react
   - [Custom Colors](#custom-colors)
 - [OSDK Component Tokens](#osdk-component-tokens)
   - [Shared Styling](#shared-styling)
+  - [AIP Agent Chat](#aip-agent-chat)
   - [Drag Handle](#drag-handle)
   - [Button](#button)
   - [Checkbox](#checkbox)


### PR DESCRIPTION
## Summary

Renders the **AipAgentChat** Storybook story as a proper sidebar folder (matching CbacPicker/ActionForm) and brings its docs in line with the other component docs.

### Storybook

- Story title is `Components/AipAgentChat`; a new `AipAgentChat.mdx` (`Components/AipAgentChat/Docs`) sits alongside it. Having a `Docs` sub-node under the same prefix promotes AipAgentChat to a **folder** in the sidebar — a bare `Components/AipAgentChat` stays a component even with multiple stories. This mirrors the `CbacPicker` pattern exactly.
- The `beta` tag badge is still auto-injected by the indexer in `.storybook/main.ts` for any title under `Components/`.
- Drops the earlier redundant `BaseChat` leaf.

### Docs (`packages/react-components/docs/AipAgentChat.md`)

- Added a **Table of Contents**.
- Aligned section language with sibling docs: `Usage` → `Basic Usage`, `Minimal` → `Minimal Example` (with a lead-in sentence), `Props` → `Props Reference`.
- Verified the doc is up to date against source — props (`AipAgentChatApi.ts`), exports, and the `useChat`/`foundryModel` import paths all match.

### Design tokens

- Cross-checked all 24 `--osdk-aip-agent-chat-*` tokens: names and default values in `CSSVariables.md` match `src/tokens/component-tokens/aip-agent-chat.css` exactly.
- Fixed a stale ToC in `CSSVariables.md` that was missing the **AIP Agent Chat** entry, and pointed the doc's Theming section at the exact token source/anchor.

No changeset for `@osdk/react-components` (docs only); the existing changeset covers `@osdk/react-components-storybook`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
