### PR TITLE
Support runtime-injected types for typescript functions

### DIFF
--- a/.changeset/open-plants-kneel.md
+++ b/.changeset/open-plants-kneel.md
@@ -1,0 +1,5 @@
+---
+"@osdk/generator-converters.ontologyir": minor
+---
+
+Make client and durableContext types run-time injected types

--- a/.changeset/open-plants-kneel.md
+++ b/.changeset/open-plants-kneel.md
@@ -1,5 +1,5 @@
 ---
-"@osdk/generator-converters.ontologyir": minor
+"@osdk/generator-converters.ontologyir": patch
 ---
 
 Make client and durableContext types run-time injected types

--- a/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadaConvert.test.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadaConvert.test.ts
@@ -14,8 +14,23 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from "vitest";
-import { OntologyIrToFullMetadataConverter } from "./OntologyIrToFullMetadataConverter.js";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+import { isInjectedRuntimeInput } from "./convertDataType.js";
+import {
+  type IDiscoveredFunction,
+  OntologyIrToFullMetadataConverter,
+} from "./OntologyIrToFullMetadataConverter.js";
+
+const discoveredFunctions = vi.hoisted<IDiscoveredFunction[]>(() => []);
+
+vi.mock("@foundry/functions-typescript-osdk-discovery", () => ({
+  FunctionDiscoverer: class {
+    discover() {
+      return { discoveredFunctions };
+    }
+  },
+}));
 
 describe(OntologyIrToFullMetadataConverter, () => {
   it("should convert ontology IR to full metadata", async () => {
@@ -3419,5 +3434,127 @@ describe(OntologyIrToFullMetadataConverter, () => {
         "valueTypes": {},
       }
     `);
+  });
+
+  describe(isInjectedRuntimeInput, () => {
+    it("identifies injected runtime function inputs", () => {
+      expect(isInjectedRuntimeInput({
+        type: "client",
+        client: {
+          type: "ontologySdkClient",
+          ontologySdkClient: {},
+        },
+      })).toBe(true);
+      expect(isInjectedRuntimeInput({
+        type: "durableContext",
+        durableContext: {},
+      })).toBe(true);
+      expect(isInjectedRuntimeInput({
+        type: "anonymousCustomType",
+        anonymousCustomType: {
+          fields: {
+            client: {
+              type: "client",
+              client: {
+                type: "ontologySdkClient",
+                ontologySdkClient: {},
+              },
+            },
+            context: {
+              type: "durableContext",
+              durableContext: {},
+            },
+          },
+        },
+      })).toBe(true);
+    });
+
+    it("does not treat every anonymous custom type as injected", () => {
+      expect(isInjectedRuntimeInput({
+        type: "anonymousCustomType",
+        anonymousCustomType: {
+          fields: {
+            value: {
+              type: "string",
+            },
+          },
+        },
+      })).toBe(false);
+      expect(isInjectedRuntimeInput({
+        type: "anonymousCustomType",
+        anonymousCustomType: {
+          fields: {},
+        },
+      })).toBe(false);
+    });
+  });
+
+  it("only omits injected runtime inputs in the first position", async () => {
+    const createProgramSpy = vi.spyOn(
+      OntologyIrToFullMetadataConverter,
+      "createProgram",
+    ).mockReturnValue({} as never);
+    const clientInput = {
+      name: "client",
+      dataType: {
+        type: "client",
+        client: {
+          type: "ontologySdkClient",
+          ontologySdkClient: {},
+        },
+      },
+      required: true,
+    };
+    const valueInput = {
+      name: "value",
+      dataType: { type: "string" },
+      required: true,
+    };
+
+    discoveredFunctions.splice(0, discoveredFunctions.length, {
+      locator: {
+        type: "typescript",
+        typescript: { functionName: "contextFirst" },
+      },
+      inputs: [clientInput, valueInput],
+      output: { single: { dataType: { type: "string" } } },
+      customTypes: {},
+    }, {
+      locator: {
+        type: "typescript",
+        typescript: { functionName: "contextSecond" },
+      },
+      inputs: [valueInput, clientInput],
+      output: { single: { dataType: { type: "string" } } },
+      customTypes: {},
+    });
+
+    try {
+      const queryTypes = await OntologyIrToFullMetadataConverter
+        .discoverTypeScriptFunctions(
+          fileURLToPath(new URL(".", import.meta.url)),
+        );
+
+      expect(queryTypes.map(queryType => queryType.parameters)).toEqual([
+        {
+          value: {
+            dataType: { type: "string" },
+            required: true,
+          },
+        },
+        {
+          value: {
+            dataType: { type: "string" },
+            required: true,
+          },
+          client: {
+            dataType: { type: "string" },
+            required: true,
+          },
+        },
+      ]);
+    } finally {
+      createProgramSpy.mockRestore();
+    }
   });
 });

--- a/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
@@ -40,7 +40,7 @@ import { pathToFileURL } from "node:url";
 import invariant from "tiny-invariant";
 import * as ts from "typescript";
 import type { ApiName } from "./ApiName.js";
-import { convertDataType } from "./convertDataType.js";
+import { convertDataType, isInjectedRuntimeInput } from "./convertDataType.js";
 
 // Type definitions for optional function discovery dependencies
 // These are declared inline to avoid compile-time dependency on optional packages
@@ -469,7 +469,13 @@ export class OntologyIrToFullMetadataConverter {
         version: "0.0.0",
         parameters: func.inputs.reduce<
           Record<ApiName, Ontologies.QueryParameterV2>
-        >((acc, input) => {
+        >((acc, input, index) => {
+          // Discovery emits diagnostics requiring injected context to be the
+          // first function argument, so only strip it from that position.
+          if (index === 0 && isInjectedRuntimeInput(input.dataType)) {
+            return acc;
+          }
+
           acc[input.name] = {
             dataType: convertDataType(
               input.dataType,

--- a/packages/generator-converters.ontologyir/src/convertDataType.ts
+++ b/packages/generator-converters.ontologyir/src/convertDataType.ts
@@ -57,6 +57,35 @@ export interface IInterfaceDataType extends IDataType {
   interface: { interfaceTypeRid: string };
 }
 
+export interface IAnonymousCustomDataType extends IDataType {
+  type: "anonymousCustomType";
+  anonymousCustomType: {
+    fields: Record<string, IDataType>;
+  };
+}
+
+function isInjectedRuntimeDataType(dataType: IDataType): boolean {
+  return dataType.type === "client" || dataType.type === "durableContext";
+}
+
+function isInjectedRuntimeContext(dataType: IDataType): boolean {
+  if (dataType.type !== "anonymousCustomType") {
+    return false;
+  }
+
+  const fields = (dataType as IAnonymousCustomDataType).anonymousCustomType
+    ?.fields;
+  const fieldTypes = fields != null ? Object.values(fields) : [];
+
+  return fieldTypes.length > 0
+    && fieldTypes.every(isInjectedRuntimeDataType);
+}
+
+export function isInjectedRuntimeInput(dataType: IDataType): boolean {
+  return isInjectedRuntimeDataType(dataType)
+    || isInjectedRuntimeContext(dataType);
+}
+
 export function convertDataType(
   dataType: IDataType,
   customTypes: Record<string, unknown>,

--- a/packages/generator-converters.ontologyir/src/index.ts
+++ b/packages/generator-converters.ontologyir/src/index.ts
@@ -16,6 +16,7 @@
 
 export type { OntologyIrOntologyBlockDataV2 } from "@osdk/client.unstable";
 export type {
+  IAnonymousCustomDataType,
   IFunctionCustomDataType,
   IInterfaceDataType,
   IInterfaceObjectSetDataType,
@@ -25,6 +26,7 @@ export type {
   IOptionalDataType,
   ISetDataType,
 } from "./convertDataType.js";
+export { isInjectedRuntimeInput } from "./convertDataType.js";
 export {
   type BlockDataApiNameLookup,
   buildBlockDataInterfaceTypeLookup,


### PR DESCRIPTION
 ## Summary
Adds support in the ontology IR converter for omitting internally injected TypeScript function context inputs from generated query parameters.

This keeps generated metadata focused on user-provided function parameters while preserving normal parameter conversion behavior for non-injected inputs.

  ## Changes
  - Detects injected TypeScript function context inputs during data type conversion.
  - Omits those inputs only when they appear in the expected leading argument position.
  - Adds test coverage for injected input detection and parameter generation behavior.
  - Adds a changeset for `@osdk/generator-converters.ontologyir`.

  ## Testing
  - Added unit tests covering injected input detection and query parameter conversion.