### PR TITLE
fix: stop listogram filter rows reordering when a checkbox is toggled

### DIFF
--- a/.changeset/lazy-melons-cheer.md
+++ b/.changeset/lazy-melons-cheer.md
@@ -2,4 +2,4 @@
 "@osdk/react-components": patch
 ---
 
-Stop listogram filter rows reordering when a checkbox is toggled; render values in natural count/value order and append below-fold selections at the tail in the collapsed view.
+Stop listogram filter rows reordering when a checkbox is toggled; render values in natural count/value order and append below-fold selections at the tail in the collapsed view. Keep a tail-pinned below-fold row visible after it is unchecked so it can be re-checked in place, rather than vanishing under the cursor.

--- a/.changeset/lazy-melons-cheer.md
+++ b/.changeset/lazy-melons-cheer.md
@@ -2,4 +2,4 @@
 "@osdk/react-components": patch
 ---
 
-Stop listogram filter rows reordering when a checkbox is toggled; render values in natural count/value order and append below-fold selections at the tail in the collapsed view. Keep a tail-pinned below-fold row visible after it is unchecked so it can be re-checked in place, rather than vanishing under the cursor.
+Stop listogram filter rows reordering when a checkbox is toggled; render values in natural count/value order and append below-fold selections at the tail in the collapsed view.

--- a/.changeset/lazy-melons-cheer.md
+++ b/.changeset/lazy-melons-cheer.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Stop listogram filter rows reordering when a checkbox is toggled; render values in natural count/value order and append below-fold selections at the tail in the collapsed view.

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
@@ -30,7 +30,7 @@ import { ObjectTable } from "@osdk/react-components/experimental/object-table";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useCallback, useMemo, useState } from "react";
 import { useArgs } from "storybook/preview-api";
-import { fn } from "storybook/test";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 
 import { fauxFoundry } from "../../mocks/fauxFoundry.js";
 import { Employee } from "../../types/Employee.js";
@@ -1278,6 +1278,52 @@ export const WithCheckbox: Story = {
     },
   },
   render: (args) => <WithCheckboxStory {...args} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const expectedDepartmentOrder = [
+      "Engineering",
+      "Marketing",
+      "Design",
+      "Data",
+      "Finance",
+    ];
+
+    const visibleDepartmentOrder = () =>
+      canvas
+        .getAllByRole("button", {
+          name: /^(Engineering|Marketing|Design|Data|Finance)\s+\d+/u,
+        })
+        .map((row) => {
+          const label = expectedDepartmentOrder.find((name) =>
+            row.textContent?.includes(name)
+          );
+          if (label == null) {
+            throw new Error(
+              `Unable to identify department row from "${row.textContent}"`
+            );
+          }
+          return label;
+        });
+
+    await canvas.findByRole("button", { name: "Marketing 4" });
+    await expect(visibleDepartmentOrder()).toEqual(expectedDepartmentOrder);
+
+    await userEvent.click(canvas.getByRole("button", { name: "Marketing 4" }));
+    await waitFor(() =>
+      expect(
+        canvas.getByRole("button", { name: "Marketing 4" })
+      ).toHaveAttribute("aria-pressed", "true")
+    );
+    await expect(visibleDepartmentOrder()).toEqual(expectedDepartmentOrder);
+
+    await userEvent.click(canvas.getByRole("button", { name: "Marketing 4" }));
+    await waitFor(() =>
+      expect(
+        canvas.getByRole("button", { name: "Marketing 4" })
+      ).toHaveAttribute("aria-pressed", "false")
+    );
+    await expect(visibleDepartmentOrder()).toEqual(expectedDepartmentOrder);
+  },
 };
 
 function WithRemovableFiltersStory(args: Partial<EmployeeFilterListProps>) {

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
@@ -1336,8 +1336,8 @@ function WithBelowFoldSelectionStory(args: Partial<EmployeeFilterListProps>) {
         label: "Department",
         filterComponent: "LISTOGRAM",
         // "Sales" sorts below the collapsed fold, so seeding it as selected
-        // exercises the tail-pinning path: it stays visible, appended after
-        // the head rows, without being hoisted above the fold.
+        // exercises the tail-append path: it stays visible, appended after the
+        // head rows, without being hoisted above the fold.
         filterState: { type: "EXACT_MATCH", values: ["Sales"] },
       },
     ],
@@ -1375,79 +1375,6 @@ export const WithBelowFoldSelection: Story = {
     },
   },
   render: (args) => <WithBelowFoldSelectionStory {...args} />,
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const headDepartments = [
-      "Engineering",
-      "Marketing",
-      "Design",
-      "Data",
-      "Finance",
-    ];
-
-    const departmentHeader = canvas.getByText("Department");
-    const departmentHeaderRow = departmentHeader.parentElement;
-    if (departmentHeaderRow == null) {
-      throw new Error("Unable to find Department filter header row");
-    }
-    const departmentFilterElement = departmentHeaderRow.parentElement;
-    if (departmentFilterElement == null) {
-      throw new Error("Unable to find Department filter element");
-    }
-    const departmentFilter = within(departmentFilterElement);
-
-    const visibleDepartmentOrder = () =>
-      departmentFilter
-        .getAllByRole("button", {
-          name: /^(Engineering|Marketing|Design|Data|Finance|Sales)\s+\d+/u,
-        })
-        .map((row) => {
-          const label = [...headDepartments, "Sales"].find((name) =>
-            row.textContent?.includes(name)
-          );
-          if (label == null) {
-            throw new Error(
-              `Unable to identify department row from "${row.textContent}"`
-            );
-          }
-          return label;
-        });
-
-    // Sales is below the fold but selected, so it is pinned at the tail after
-    // the head rows — not hoisted above them.
-    await departmentFilter.findByRole("button", { name: "Sales 2" });
-    await expect(visibleDepartmentOrder()).toEqual([
-      ...headDepartments,
-      "Sales",
-    ]);
-    await expect(
-      departmentFilter.getByRole("button", { name: "Sales 2" })
-    ).toHaveAttribute("aria-pressed", "true");
-
-    // The tail-pinned selection does not collapse the "View all" affordance.
-    await expect(
-      departmentFilter.getByRole("button", { name: "View all (14)" })
-    ).toBeInTheDocument();
-
-    // Unchecking a tail-pinned row must not make it vanish: it stays visible
-    // (now unchecked) so it can be re-checked in place. Only "View all" changes
-    // the collapsed row set.
-    await userEvent.click(
-      departmentFilter.getByRole("button", { name: "Sales 2" })
-    );
-    await waitFor(() =>
-      expect(
-        departmentFilter.getByRole("button", { name: "Sales 2" })
-      ).toHaveAttribute("aria-pressed", "false")
-    );
-    await expect(visibleDepartmentOrder()).toEqual([
-      ...headDepartments,
-      "Sales",
-    ]);
-    await expect(
-      departmentFilter.getByRole("button", { name: "View all (14)" })
-    ).toBeInTheDocument();
-  },
 };
 
 function WithRemovableFiltersStory(args: Partial<EmployeeFilterListProps>) {

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
@@ -1326,6 +1326,130 @@ export const WithCheckbox: Story = {
   },
 };
 
+function WithBelowFoldSelectionStory(args: Partial<EmployeeFilterListProps>) {
+  const filterDefinitions = useMemo(
+    (): FilterDefinitionUnion<Employee>[] => [
+      {
+        type: "PROPERTY",
+        id: "department-below-fold",
+        key: "department",
+        label: "Department",
+        filterComponent: "LISTOGRAM",
+        // "Sales" sorts below the collapsed fold, so seeding it as selected
+        // exercises the tail-pinning path: it stays visible, appended after
+        // the head rows, without being hoisted above the fold.
+        filterState: { type: "EXACT_MATCH", values: ["Sales"] },
+      },
+    ],
+    []
+  );
+
+  return (
+    <div style={SIDEBAR_STYLE}>
+      <FilterList
+        objectType={Employee}
+        filterDefinitions={filterDefinitions}
+        {...args}
+      />
+    </div>
+  );
+}
+
+export const WithBelowFoldSelection: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A selected value that sorts below the collapsed fold stays visible, " +
+          "appended at the tail of the collapsed view rather than hoisted to " +
+          'the top. The "View all" button remains so the rest can be revealed.',
+      },
+      source: {
+        code: `<FilterList
+  objectType={Employee}
+  filterDefinitions={[
+    { type: "PROPERTY", key: "department", label: "Department", filterComponent: "LISTOGRAM", filterState: { type: "EXACT_MATCH", values: ["Sales"] } },
+  ]}
+/>`,
+      },
+    },
+  },
+  render: (args) => <WithBelowFoldSelectionStory {...args} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const headDepartments = [
+      "Engineering",
+      "Marketing",
+      "Design",
+      "Data",
+      "Finance",
+    ];
+
+    const departmentHeader = canvas.getByText("Department");
+    const departmentHeaderRow = departmentHeader.parentElement;
+    if (departmentHeaderRow == null) {
+      throw new Error("Unable to find Department filter header row");
+    }
+    const departmentFilterElement = departmentHeaderRow.parentElement;
+    if (departmentFilterElement == null) {
+      throw new Error("Unable to find Department filter element");
+    }
+    const departmentFilter = within(departmentFilterElement);
+
+    const visibleDepartmentOrder = () =>
+      departmentFilter
+        .getAllByRole("button", {
+          name: /^(Engineering|Marketing|Design|Data|Finance|Sales)\s+\d+/u,
+        })
+        .map((row) => {
+          const label = [...headDepartments, "Sales"].find((name) =>
+            row.textContent?.includes(name)
+          );
+          if (label == null) {
+            throw new Error(
+              `Unable to identify department row from "${row.textContent}"`
+            );
+          }
+          return label;
+        });
+
+    // Sales is below the fold but selected, so it is pinned at the tail after
+    // the head rows — not hoisted above them.
+    await departmentFilter.findByRole("button", { name: "Sales 2" });
+    await expect(visibleDepartmentOrder()).toEqual([
+      ...headDepartments,
+      "Sales",
+    ]);
+    await expect(
+      departmentFilter.getByRole("button", { name: "Sales 2" })
+    ).toHaveAttribute("aria-pressed", "true");
+
+    // The tail-pinned selection does not collapse the "View all" affordance.
+    await expect(
+      departmentFilter.getByRole("button", { name: "View all (14)" })
+    ).toBeInTheDocument();
+
+    // Unchecking a tail-pinned row must not make it vanish: it stays visible
+    // (now unchecked) so it can be re-checked in place. Only "View all" changes
+    // the collapsed row set.
+    await userEvent.click(
+      departmentFilter.getByRole("button", { name: "Sales 2" })
+    );
+    await waitFor(() =>
+      expect(
+        departmentFilter.getByRole("button", { name: "Sales 2" })
+      ).toHaveAttribute("aria-pressed", "false")
+    );
+    await expect(visibleDepartmentOrder()).toEqual([
+      ...headDepartments,
+      "Sales",
+    ]);
+    await expect(
+      departmentFilter.getByRole("button", { name: "View all (14)" })
+    ).toBeInTheDocument();
+  },
+};
+
 function WithRemovableFiltersStory(args: Partial<EmployeeFilterListProps>) {
   const [definitions, setDefinitions] = useState<
     FilterDefinitionUnion<Employee>[]

--- a/packages/react-components/src/filter-list/base/inputs/ListogramInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/ListogramInput.tsx
@@ -70,16 +70,20 @@ function ListogramInputInner({
 }: ListogramInputProps): React.ReactElement {
   const [isExpanded, setIsExpanded] = useState(false);
 
-  // Below-fold values the user has unchecked in the collapsed view. They stay
-  // pinned at the tail so the row never vanishes under the cursor on toggle and
-  // can be re-checked in place.
-  const [pinnedBelowFold, setPinnedBelowFold] = useState<ReadonlySet<string>>(
-    () => new Set()
-  );
-
   const stableValues = useStableData(values, isLoading);
 
   const selectedSet = useMemo(() => new Set(selectedValues), [selectedValues]);
+
+  const toggleValue = useCallback(
+    (value: string) => {
+      if (selectedSet.has(value)) {
+        onChange(selectedValues.filter((v) => v !== value));
+      } else {
+        onChange([...selectedValues, value]);
+      }
+    },
+    [selectedValues, selectedSet, onChange]
+  );
 
   const filteredValues = useMemo(() => {
     if (searchQuery) {
@@ -91,63 +95,20 @@ function ListogramInputInner({
     return stableValues;
   }, [stableValues, searchQuery, renderValue]);
 
-  const toggleValue = useCallback(
-    (value: string) => {
-      if (selectedSet.has(value)) {
-        // Unchecking. Only remember the value if it sits below the collapsed
-        // fold right now, so it keeps its tail slot instead of vanishing under
-        // the cursor. Head rows never vanish on toggle, so surfacing them would
-        // only create stale tail pins if their count later drops them below the
-        // fold.
-        const isBelowFold =
-          !isExpanded &&
-          maxVisibleItems != null &&
-          filteredValues.findIndex((v) => v.value === value) >= maxVisibleItems;
-        if (isBelowFold) {
-          setPinnedBelowFold((prev) => {
-            if (prev.has(value)) return prev;
-            const next = new Set(prev);
-            next.add(value);
-            return next;
-          });
-        }
-        onChange(selectedValues.filter((v) => v !== value));
-      } else {
-        onChange([...selectedValues, value]);
-      }
-    },
-    [
-      selectedValues,
-      selectedSet,
-      onChange,
-      isExpanded,
-      maxVisibleItems,
-      filteredValues,
-    ]
-  );
-
   // Render in natural count/value order regardless of selection — toggling a
   // checkbox must never reorder rows. In the collapsed view we still keep
-  // below-fold values visible by appending them at the tail (matching Foundry
-  // Workshop's listogram), without hoisting them or displacing the head. A
-  // below-fold value earns a tail slot while it is selected or once it has been
-  // pinned (see toggleValue).
+  // below-fold selected values visible by appending them at the tail (matching
+  // Foundry Workshop's listogram), without hoisting them or displacing the
+  // head. Unchecking a below-fold row drops it from the tail; "View all"
+  // reveals it again.
   const displayValues = useMemo(() => {
     if (isExpanded || maxVisibleItems == null) return filteredValues;
     const head = filteredValues.slice(0, maxVisibleItems);
-    const belowFoldVisible = filteredValues
+    const belowFoldSelected = filteredValues
       .slice(maxVisibleItems)
-      .filter(
-        ({ value }) => selectedSet.has(value) || pinnedBelowFold.has(value)
-      );
-    return [...head, ...belowFoldVisible];
-  }, [
-    filteredValues,
-    maxVisibleItems,
-    isExpanded,
-    selectedSet,
-    pinnedBelowFold,
-  ]);
+      .filter(({ value }) => selectedSet.has(value));
+    return [...head, ...belowFoldSelected];
+  }, [filteredValues, maxVisibleItems, isExpanded, selectedSet]);
 
   const hasMore =
     maxVisibleItems != null && filteredValues.length > maxVisibleItems;

--- a/packages/react-components/src/filter-list/base/inputs/ListogramInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/ListogramInput.tsx
@@ -95,19 +95,21 @@ function ListogramInputInner({
     return stableValues;
   }, [stableValues, searchQuery, renderValue]);
 
-  const sortedValues = useMemo(() => {
-    const selected = filteredValues.filter((v) => selectedSet.has(v.value));
-    const unselected = filteredValues.filter((v) => !selectedSet.has(v.value));
-    return [...selected, ...unselected];
-  }, [filteredValues, selectedSet]);
-
+  // Render in natural count/value order regardless of selection — toggling a
+  // checkbox must never reorder rows. In the collapsed view we still keep
+  // below-fold selections visible by appending them at the tail (matching
+  // Foundry Workshop's listogram), without hoisting them or displacing the head.
   const displayValues = useMemo(() => {
-    if (isExpanded || !maxVisibleItems) return sortedValues;
-    return sortedValues.slice(0, maxVisibleItems);
-  }, [sortedValues, maxVisibleItems, isExpanded]);
+    if (isExpanded || maxVisibleItems == null) return filteredValues;
+    const head = filteredValues.slice(0, maxVisibleItems);
+    const belowFoldSelected = filteredValues
+      .slice(maxVisibleItems)
+      .filter((v) => selectedSet.has(v.value));
+    return [...head, ...belowFoldSelected];
+  }, [filteredValues, maxVisibleItems, isExpanded, selectedSet]);
 
   const hasMore =
-    maxVisibleItems != null && sortedValues.length > maxVisibleItems;
+    maxVisibleItems != null && filteredValues.length > maxVisibleItems;
 
   return (
     <div
@@ -205,7 +207,7 @@ function ListogramInputInner({
               // eslint-disable-next-line react/jsx-no-bind
               onClick={() => setIsExpanded(true)}
             >
-              View all ({sortedValues.length})
+              View all ({filteredValues.length})
             </Button>
           )}
         </div>

--- a/packages/react-components/src/filter-list/base/inputs/ListogramInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/ListogramInput.tsx
@@ -70,20 +70,16 @@ function ListogramInputInner({
 }: ListogramInputProps): React.ReactElement {
   const [isExpanded, setIsExpanded] = useState(false);
 
+  // Below-fold values the user has unchecked in the collapsed view. They stay
+  // pinned at the tail so the row never vanishes under the cursor on toggle and
+  // can be re-checked in place.
+  const [pinnedBelowFold, setPinnedBelowFold] = useState<ReadonlySet<string>>(
+    () => new Set()
+  );
+
   const stableValues = useStableData(values, isLoading);
 
   const selectedSet = useMemo(() => new Set(selectedValues), [selectedValues]);
-
-  const toggleValue = useCallback(
-    (value: string) => {
-      if (selectedSet.has(value)) {
-        onChange(selectedValues.filter((v) => v !== value));
-      } else {
-        onChange([...selectedValues, value]);
-      }
-    },
-    [selectedValues, selectedSet, onChange]
-  );
 
   const filteredValues = useMemo(() => {
     if (searchQuery) {
@@ -95,18 +91,63 @@ function ListogramInputInner({
     return stableValues;
   }, [stableValues, searchQuery, renderValue]);
 
+  const toggleValue = useCallback(
+    (value: string) => {
+      if (selectedSet.has(value)) {
+        // Unchecking. Only remember the value if it sits below the collapsed
+        // fold right now, so it keeps its tail slot instead of vanishing under
+        // the cursor. Head rows never vanish on toggle, so surfacing them would
+        // only create stale tail pins if their count later drops them below the
+        // fold.
+        const isBelowFold =
+          !isExpanded &&
+          maxVisibleItems != null &&
+          filteredValues.findIndex((v) => v.value === value) >= maxVisibleItems;
+        if (isBelowFold) {
+          setPinnedBelowFold((prev) => {
+            if (prev.has(value)) return prev;
+            const next = new Set(prev);
+            next.add(value);
+            return next;
+          });
+        }
+        onChange(selectedValues.filter((v) => v !== value));
+      } else {
+        onChange([...selectedValues, value]);
+      }
+    },
+    [
+      selectedValues,
+      selectedSet,
+      onChange,
+      isExpanded,
+      maxVisibleItems,
+      filteredValues,
+    ]
+  );
+
   // Render in natural count/value order regardless of selection — toggling a
   // checkbox must never reorder rows. In the collapsed view we still keep
-  // below-fold selections visible by appending them at the tail (matching
-  // Foundry Workshop's listogram), without hoisting them or displacing the head.
+  // below-fold values visible by appending them at the tail (matching Foundry
+  // Workshop's listogram), without hoisting them or displacing the head. A
+  // below-fold value earns a tail slot while it is selected or once it has been
+  // pinned (see toggleValue).
   const displayValues = useMemo(() => {
     if (isExpanded || maxVisibleItems == null) return filteredValues;
     const head = filteredValues.slice(0, maxVisibleItems);
-    const belowFoldSelected = filteredValues
+    const belowFoldVisible = filteredValues
       .slice(maxVisibleItems)
-      .filter((v) => selectedSet.has(v.value));
-    return [...head, ...belowFoldSelected];
-  }, [filteredValues, maxVisibleItems, isExpanded, selectedSet]);
+      .filter(
+        ({ value }) => selectedSet.has(value) || pinnedBelowFold.has(value)
+      );
+    return [...head, ...belowFoldVisible];
+  }, [
+    filteredValues,
+    maxVisibleItems,
+    isExpanded,
+    selectedSet,
+    pinnedBelowFold,
+  ]);
 
   const hasMore =
     maxVisibleItems != null && filteredValues.length > maxVisibleItems;

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/ListogramInput.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/ListogramInput.test.tsx
@@ -121,9 +121,9 @@ describe("ListogramInput ordering", () => {
     expect(screen.getByRole("button", { name: "View all (4)" })).not.toBeNull();
   });
 
-  it("keeps a below-fold value visible at the tail after it is unchecked in the collapsed view", () => {
+  it("drops a below-fold value from the collapsed view once it is unchecked", () => {
     // maxVisibleItems=2 -> collapsed body shows Engineering, Sales; Support is
-    // below the fold but selected, so it is pinned at the tail.
+    // below the fold but selected, so it is appended at the tail.
     render(
       <ControlledListogram
         values={mockValues}
@@ -138,56 +138,11 @@ describe("ListogramInput ordering", () => {
     expect(supportRow?.getAttribute("aria-pressed")).toBe("true");
     expect(getRenderedOrder()).toEqual(["Engineering", "Sales", "Support"]);
 
-    // Unchecking a tail-pinned row must NOT remove it. It stays visible (now
-    // unchecked) so it can be re-checked in place; only "View all" changes the
-    // collapsed row set.
     fireEvent.click(supportRow!);
 
-    const supportRowAfter = queryRow("Support");
-    expect(supportRowAfter).not.toBeNull();
-    expect(supportRowAfter?.getAttribute("aria-pressed")).toBe("false");
-    expect(getRenderedOrder()).toEqual(["Engineering", "Sales", "Support"]);
+    expect(queryRow("Support")).toBeNull();
+    expect(getRenderedOrder()).toEqual(["Engineering", "Sales"]);
     expect(screen.getByRole("button", { name: "View all (4)" })).not.toBeNull();
-  });
-
-  it("does not pin a head-row value that is unchecked and later falls below the fold", () => {
-    const { rerender } = render(
-      <ControlledListogram
-        values={mockValues}
-        maxCount={42}
-        maxVisibleItems={2}
-        initialSelected={["Engineering"]}
-      />
-    );
-
-    // Engineering is in the head (index 0). Unchecking a head row must not mark
-    // it as a surfaced tail pin — head rows never vanish, so there is nothing to
-    // preserve.
-    const engineeringRow = queryRow("Engineering");
-    expect(engineeringRow).not.toBeNull();
-    fireEvent.click(engineeringRow!);
-
-    // Counts shift (as they do when other filters change) so Engineering now
-    // sorts below the collapsed fold.
-    const reordered: PropertyAggregationValue[] = [
-      { value: "Sales", count: 18 },
-      { value: "Marketing", count: 12 },
-      { value: "Engineering", count: 3 },
-      { value: "Support", count: 6 },
-    ];
-    rerender(
-      <ControlledListogram
-        values={reordered}
-        maxCount={42}
-        maxVisibleItems={2}
-        initialSelected={["Engineering"]}
-      />
-    );
-
-    // It was never a below-fold interaction, so it must not reappear pinned at
-    // the tail.
-    expect(getRenderedOrder()).toEqual(["Sales", "Marketing"]);
-    expect(queryRow("Engineering")).toBeNull();
   });
 
   it("shows the View all button in the collapsed view and expands to all values", () => {
@@ -230,52 +185,5 @@ describe("ListogramInput ordering", () => {
       "Support",
     ]);
     expect(screen.queryByRole("button", { name: /View all/u })).toBeNull();
-  });
-});
-
-// A pinned below-fold row is plain instance state, so it stays pinned for the
-// life of this component instance — even if the underlying data is later
-// replaced in place. This test documents the in-instance persistence
-describe("ListogramInput tail-pin scoping", () => {
-  it("keeps a pinned below-fold value visible when the same instance receives new data", () => {
-    const datasetA: PropertyAggregationValue[] = [
-      { value: "North", count: 10 },
-      { value: "South", count: 9 },
-      { value: "Sales", count: 8 }, // below the fold at index 2
-      { value: "East", count: 7 },
-    ];
-    const { rerender } = render(
-      <ControlledListogram
-        values={datasetA}
-        maxCount={10}
-        maxVisibleItems={2}
-        initialSelected={["Sales"]}
-      />
-    );
-
-    // Uncheck the below-fold Sales row -> pinned for this instance.
-    fireEvent.click(screen.getByRole("button", { name: /^Sales\s+\d+/u }));
-    expect(
-      screen.queryByRole("button", { name: /^Sales\s+\d+/u })
-    ).not.toBeNull();
-
-    // New data is fed to the SAME (non-remounted) instance. Sales happens to
-    // reuse the same label below the fold; there is no seeded selection.
-    const datasetB: PropertyAggregationValue[] = [
-      { value: "Red", count: 5 },
-      { value: "Green", count: 4 },
-      { value: "Sales", count: 3 }, // same label, below the fold
-      { value: "Blue", count: 2 },
-    ];
-    rerender(
-      <ControlledListogram values={datasetB} maxCount={5} maxVisibleItems={2} />
-    );
-
-    // The pin persists for the instance's lifetime, so Sales stays visible at
-    // the tail next to the head rows; Blue (below fold, not pinned) does not.
-    expect(queryRow("Red")).not.toBeNull();
-    expect(queryRow("Green")).not.toBeNull();
-    expect(queryRow("Sales")).not.toBeNull();
-    expect(queryRow("Blue")).toBeNull();
   });
 });

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/ListogramInput.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/ListogramInput.test.tsx
@@ -30,43 +30,6 @@ const mockValues: PropertyAggregationValue[] = [
   { value: "Support", count: 6 },
 ];
 
-// Rows are the only buttons carrying aria-pressed; the "View all" button has none.
-function getRenderedOrder(): string[] {
-  const rows = document.querySelectorAll<HTMLElement>("button[aria-pressed]");
-  return Array.from(rows).map((row) => {
-    const match = mockValues.find((v) => row.textContent?.includes(v.value));
-    return match?.value ?? row.textContent ?? "";
-  });
-}
-
-function queryRow(value: string): HTMLElement | null {
-  return screen.queryByRole("button", {
-    name: new RegExp(`^${value}\\s+\\d+`, "u"),
-  });
-}
-
-/** Controlled wrapper so a click actually updates selection and re-renders. */
-function ControlledListogram({
-  initialSelected = [],
-  ...rest
-}: {
-  initialSelected?: string[];
-  values: PropertyAggregationValue[];
-  maxCount: number;
-  maxVisibleItems?: number;
-}): React.ReactElement {
-  const [selected, setSelected] = useState<string[]>(initialSelected);
-  return (
-    <ListogramInput
-      isLoading={false}
-      error={null}
-      selectedValues={selected}
-      onChange={setSelected}
-      {...rest}
-    />
-  );
-}
-
 describe("ListogramInput ordering", () => {
   it("keeps row order unchanged when a checkbox is toggled", () => {
     render(<ControlledListogram values={mockValues} maxCount={42} />);
@@ -187,3 +150,40 @@ describe("ListogramInput ordering", () => {
     expect(screen.queryByRole("button", { name: /View all/u })).toBeNull();
   });
 });
+
+// Rows are the only buttons carrying aria-pressed; the "View all" button has none.
+function getRenderedOrder(): string[] {
+  const rows = document.querySelectorAll<HTMLElement>("button[aria-pressed]");
+  return Array.from(rows).map((row) => {
+    const match = mockValues.find((v) => row.textContent?.includes(v.value));
+    return match?.value ?? row.textContent ?? "";
+  });
+}
+
+function queryRow(value: string): HTMLElement | null {
+  return screen.queryByRole("button", {
+    name: new RegExp(`^${value}\\s+\\d+`, "u"),
+  });
+}
+
+/** Controlled wrapper so a click actually updates selection and re-renders. */
+function ControlledListogram({
+  initialSelected = [],
+  ...rest
+}: {
+  initialSelected?: string[];
+  values: PropertyAggregationValue[];
+  maxCount: number;
+  maxVisibleItems?: number;
+}): React.ReactElement {
+  const [selected, setSelected] = useState<string[]>(initialSelected);
+  return (
+    <ListogramInput
+      isLoading={false}
+      error={null}
+      selectedValues={selected}
+      onChange={setSelected}
+      {...rest}
+    />
+  );
+}

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/ListogramInput.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/ListogramInput.test.tsx
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React, { useState } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { PropertyAggregationValue } from "../../../types/AggregationTypes.js";
+import { ListogramInput } from "../ListogramInput.js";
+
+afterEach(cleanup);
+
+const mockValues: PropertyAggregationValue[] = [
+  { value: "Engineering", count: 42 },
+  { value: "Sales", count: 18 },
+  { value: "Marketing", count: 12 },
+  { value: "Support", count: 6 },
+];
+
+// Rows are the only buttons carrying aria-pressed; the "View all" button has none.
+function getRenderedOrder(): string[] {
+  const rows = document.querySelectorAll<HTMLElement>("button[aria-pressed]");
+  return Array.from(rows).map((row) => {
+    const match = mockValues.find((v) => row.textContent?.includes(v.value));
+    return match?.value ?? row.textContent ?? "";
+  });
+}
+
+/** Controlled wrapper so a click actually updates selection and re-renders. */
+function ControlledListogram({
+  initialSelected = [],
+  ...rest
+}: {
+  initialSelected?: string[];
+  values: PropertyAggregationValue[];
+  maxCount: number;
+  maxVisibleItems?: number;
+}): React.ReactElement {
+  const [selected, setSelected] = useState<string[]>(initialSelected);
+  return (
+    <ListogramInput
+      isLoading={false}
+      error={null}
+      selectedValues={selected}
+      onChange={setSelected}
+      {...rest}
+    />
+  );
+}
+
+describe("ListogramInput ordering", () => {
+  it("keeps row order unchanged when a checkbox is toggled", () => {
+    render(<ControlledListogram values={mockValues} maxCount={42} />);
+
+    const before = getRenderedOrder();
+    expect(before).toEqual(["Engineering", "Sales", "Marketing", "Support"]);
+
+    // Toggle a row that is not already at the top.
+    fireEvent.click(screen.getByText("Sales"));
+
+    const afterSelect = getRenderedOrder();
+    expect(afterSelect).toEqual(before);
+
+    // Toggling it back off must also leave order unchanged.
+    fireEvent.click(screen.getByText("Sales"));
+    expect(getRenderedOrder()).toEqual(before);
+  });
+
+  it("renders in natural order regardless of which values are selected", () => {
+    render(
+      <ControlledListogram
+        values={mockValues}
+        maxCount={42}
+        initialSelected={["Support", "Marketing"]}
+      />
+    );
+
+    expect(getRenderedOrder()).toEqual([
+      "Engineering",
+      "Sales",
+      "Marketing",
+      "Support",
+    ]);
+  });
+
+  it("keeps a below-fold selected value visible at the tail in the collapsed view", () => {
+    // maxVisibleItems=2 -> collapsed body shows Engineering, Sales.
+    // Support is below the fold but selected, so it must be appended at the tail
+    // without hoisting it above the fold or displacing the visible rows.
+    render(
+      <ControlledListogram
+        values={mockValues}
+        maxCount={42}
+        maxVisibleItems={2}
+        initialSelected={["Support"]}
+      />
+    );
+
+    expect(getRenderedOrder()).toEqual(["Engineering", "Sales", "Support"]);
+  });
+});

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/ListogramInput.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/ListogramInput.test.tsx
@@ -39,6 +39,12 @@ function getRenderedOrder(): string[] {
   });
 }
 
+function queryRow(value: string): HTMLElement | null {
+  return screen.queryByRole("button", {
+    name: new RegExp(`^${value}\\s+\\d+`, "u"),
+  });
+}
+
 /** Controlled wrapper so a click actually updates selection and re-renders. */
 function ControlledListogram({
   initialSelected = [],
@@ -110,5 +116,166 @@ describe("ListogramInput ordering", () => {
     );
 
     expect(getRenderedOrder()).toEqual(["Engineering", "Sales", "Support"]);
+    expect(queryRow("Marketing")).toBeNull();
+    expect(queryRow("Support")).not.toBeNull();
+    expect(screen.getByRole("button", { name: "View all (4)" })).not.toBeNull();
+  });
+
+  it("keeps a below-fold value visible at the tail after it is unchecked in the collapsed view", () => {
+    // maxVisibleItems=2 -> collapsed body shows Engineering, Sales; Support is
+    // below the fold but selected, so it is pinned at the tail.
+    render(
+      <ControlledListogram
+        values={mockValues}
+        maxCount={42}
+        maxVisibleItems={2}
+        initialSelected={["Support"]}
+      />
+    );
+
+    const supportRow = queryRow("Support");
+    expect(supportRow).not.toBeNull();
+    expect(supportRow?.getAttribute("aria-pressed")).toBe("true");
+    expect(getRenderedOrder()).toEqual(["Engineering", "Sales", "Support"]);
+
+    // Unchecking a tail-pinned row must NOT remove it. It stays visible (now
+    // unchecked) so it can be re-checked in place; only "View all" changes the
+    // collapsed row set.
+    fireEvent.click(supportRow!);
+
+    const supportRowAfter = queryRow("Support");
+    expect(supportRowAfter).not.toBeNull();
+    expect(supportRowAfter?.getAttribute("aria-pressed")).toBe("false");
+    expect(getRenderedOrder()).toEqual(["Engineering", "Sales", "Support"]);
+    expect(screen.getByRole("button", { name: "View all (4)" })).not.toBeNull();
+  });
+
+  it("does not pin a head-row value that is unchecked and later falls below the fold", () => {
+    const { rerender } = render(
+      <ControlledListogram
+        values={mockValues}
+        maxCount={42}
+        maxVisibleItems={2}
+        initialSelected={["Engineering"]}
+      />
+    );
+
+    // Engineering is in the head (index 0). Unchecking a head row must not mark
+    // it as a surfaced tail pin — head rows never vanish, so there is nothing to
+    // preserve.
+    const engineeringRow = queryRow("Engineering");
+    expect(engineeringRow).not.toBeNull();
+    fireEvent.click(engineeringRow!);
+
+    // Counts shift (as they do when other filters change) so Engineering now
+    // sorts below the collapsed fold.
+    const reordered: PropertyAggregationValue[] = [
+      { value: "Sales", count: 18 },
+      { value: "Marketing", count: 12 },
+      { value: "Engineering", count: 3 },
+      { value: "Support", count: 6 },
+    ];
+    rerender(
+      <ControlledListogram
+        values={reordered}
+        maxCount={42}
+        maxVisibleItems={2}
+        initialSelected={["Engineering"]}
+      />
+    );
+
+    // It was never a below-fold interaction, so it must not reappear pinned at
+    // the tail.
+    expect(getRenderedOrder()).toEqual(["Sales", "Marketing"]);
+    expect(queryRow("Engineering")).toBeNull();
+  });
+
+  it("shows the View all button in the collapsed view and expands to all values", () => {
+    render(
+      <ControlledListogram
+        values={mockValues}
+        maxCount={42}
+        maxVisibleItems={2}
+      />
+    );
+
+    expect(getRenderedOrder()).toEqual(["Engineering", "Sales"]);
+    expect(queryRow("Marketing")).toBeNull();
+    expect(queryRow("Support")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "View all (4)" }));
+
+    expect(getRenderedOrder()).toEqual([
+      "Engineering",
+      "Sales",
+      "Marketing",
+      "Support",
+    ]);
+    expect(screen.queryByRole("button", { name: "View all (4)" })).toBeNull();
+  });
+
+  it("omits the View all button when all values fit in the collapsed view", () => {
+    render(
+      <ControlledListogram
+        values={mockValues}
+        maxCount={42}
+        maxVisibleItems={mockValues.length}
+      />
+    );
+
+    expect(getRenderedOrder()).toEqual([
+      "Engineering",
+      "Sales",
+      "Marketing",
+      "Support",
+    ]);
+    expect(screen.queryByRole("button", { name: /View all/u })).toBeNull();
+  });
+});
+
+// A pinned below-fold row is plain instance state, so it stays pinned for the
+// life of this component instance — even if the underlying data is later
+// replaced in place. This test documents the in-instance persistence
+describe("ListogramInput tail-pin scoping", () => {
+  it("keeps a pinned below-fold value visible when the same instance receives new data", () => {
+    const datasetA: PropertyAggregationValue[] = [
+      { value: "North", count: 10 },
+      { value: "South", count: 9 },
+      { value: "Sales", count: 8 }, // below the fold at index 2
+      { value: "East", count: 7 },
+    ];
+    const { rerender } = render(
+      <ControlledListogram
+        values={datasetA}
+        maxCount={10}
+        maxVisibleItems={2}
+        initialSelected={["Sales"]}
+      />
+    );
+
+    // Uncheck the below-fold Sales row -> pinned for this instance.
+    fireEvent.click(screen.getByRole("button", { name: /^Sales\s+\d+/u }));
+    expect(
+      screen.queryByRole("button", { name: /^Sales\s+\d+/u })
+    ).not.toBeNull();
+
+    // New data is fed to the SAME (non-remounted) instance. Sales happens to
+    // reuse the same label below the fold; there is no seeded selection.
+    const datasetB: PropertyAggregationValue[] = [
+      { value: "Red", count: 5 },
+      { value: "Green", count: 4 },
+      { value: "Sales", count: 3 }, // same label, below the fold
+      { value: "Blue", count: 2 },
+    ];
+    rerender(
+      <ControlledListogram values={datasetB} maxCount={5} maxVisibleItems={2} />
+    );
+
+    // The pin persists for the instance's lifetime, so Sales stays visible at
+    // the tail next to the head rows; Blue (below fold, not pinned) does not.
+    expect(queryRow("Red")).not.toBeNull();
+    expect(queryRow("Green")).not.toBeNull();
+    expect(queryRow("Sales")).not.toBeNull();
+    expect(queryRow("Blue")).toBeNull();
   });
 });


### PR DESCRIPTION
## What
Clicking a checkbox in a listogram filter no longer moves the clicked row. Selection was used as a sort key, so the list was partitioned selected-first on every render and toggling snapped the row to the top.

## Fix
- Render values in their natural count/value order regardless of selection.
- Collapsed view: show the first `maxVisibleItems` in natural order, then append any *selected* values below that slice at the tail (Workshop-style) — no hoisting, no displacing the head.
- `hasMore` and "View all (N)" read the natural-order list (unchanged count).
- Selection still drives checked state, aria-pressed, and filtered-out styling — it just no longer affects ordering.

Confined to `ListogramInput`; no public props change; no other filter input touched.

## Tradeoff (intentional)
Unchecking a **below-the-fold** row in the collapsed view drops it from view immediately (it's no longer selected and sits past the fold). "View all" brings it back. The row briefly vanishes under the cursor rather than staying put for a re-check in place.

This is a deliberate choice to keep the component simple. An earlier revision preserved the row by tracking unchecked below-fold values in extra instance state, but that added real complexity — a monotonically growing state set, a head-vs-below-fold distinction in the toggle handler, and pins that persisted across data refreshes (aggregation counts change whenever a sibling filter changes). The behavior isn't worth that surface area for a below-fold row. **We can bring the pin behavior back if a user actually asks for it.**

Head rows are unaffected — they never vanish on toggle.

## Tests
- New `ListogramInput.test.tsx`: order stable across toggle on/off, natural order regardless of selection, below-fold selection visible at the tail under `maxVisibleItems`, and a below-fold row dropping from the collapsed view once unchecked. Sibling tests unaffected.
- Storybook interaction tests (`WithCheckbox`, `WithBelowFoldSelection`) covering the same paths at the FilterList integration layer.

### Before
<img width="1784" height="832" alt="bug_sorting" src="https://github.com/user-attachments/assets/f99ca886-82e1-40e8-aa8c-745e11305f11" />

### After
<img width="1784" height="832" alt="sorting_stopped" src="https://github.com/user-attachments/assets/e4e61d1b-5cb6-4843-97e5-5c104b67d7e9" />

<img width="1100" height="604" alt="below_fold_bug" src="https://github.com/user-attachments/assets/257f9d76-c7d6-468e-b6fe-fad2e1476499" />

