### PR TITLE
Extract cache tab

### DIFF
--- a/.changeset/quick-lions-cheer.md
+++ b/.changeset/quick-lions-cheer.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+Move the cache inspector into its own top-level Devtools tab

--- a/packages/react-devtools/src/components/DebuggingTab.tsx
+++ b/packages/react-devtools/src/components/DebuggingTab.tsx
@@ -24,7 +24,6 @@ import { useConsoleLogs } from "../hooks/useConsoleLogs.js";
 import type { MonitorStore } from "../store/MonitorStore.js";
 import type { ComponentHookBinding } from "../utils/ComponentQueryRegistry.js";
 import { formatTime } from "../utils/format.js";
-import { CacheInspectorTab } from "./CacheInspectorTab.js";
 import { ComponentCard } from "./ComponentCard.js";
 import { ImprovementsTab } from "./ImprovementsTab.js";
 import { IssueCard } from "./IssueCard.js";
@@ -186,7 +185,6 @@ function collectIssues(monitorStore: MonitorStore, now: number): Issue[] {
 
 export const DebuggingTab: React.FC<DebuggingTabProps> = ({ monitorStore }) => {
   const [searchQuery, setSearchQuery] = useState("");
-  const [cacheExpanded, setCacheExpanded] = useState(false);
   const [consoleExpanded, setConsoleExpanded] = useState(true);
   const [improvementsExpanded, setImprovementsExpanded] = useState(true);
 
@@ -207,20 +205,6 @@ export const DebuggingTab: React.FC<DebuggingTabProps> = ({ monitorStore }) => {
   const issues =
     React.useSyncExternalStore(issueStore.subscribe, issueStore.getSnapshot) ??
     [];
-
-  const cacheCountStore = React.useMemo(
-    () =>
-      createPollingStore(async () => {
-        const entries = await monitorStore.loadCacheEntries();
-        return entries.length;
-      }, 5000),
-    [monitorStore]
-  );
-  const cacheCount =
-    React.useSyncExternalStore(
-      cacheCountStore.subscribe,
-      cacheCountStore.getSnapshot
-    ) ?? 0;
 
   const searchFilter = useCallback(
     (issue: Issue) => {
@@ -445,23 +429,6 @@ export const DebuggingTab: React.FC<DebuggingTabProps> = ({ monitorStore }) => {
           {improvementsExpanded && (
             <ImprovementsTab monitorStore={monitorStore} />
           )}
-        </div>
-
-        <div className={styles.section}>
-          <button
-            type="button"
-            className={styles.sectionHeaderButton}
-            onClick={() => setCacheExpanded(!cacheExpanded)}
-          >
-            <span>Cache</span>
-            <span className={styles.sectionCount}>{cacheCount} entries</span>
-            <Icon
-              icon={cacheExpanded ? "chevron-down" : "chevron-right"}
-              size={14}
-              className={styles.sectionChevron}
-            />
-          </button>
-          {cacheExpanded && <CacheInspectorTab monitorStore={monitorStore} />}
         </div>
       </div>
     </div>

--- a/packages/react-devtools/src/components/MonitoringPanel.tsx
+++ b/packages/react-devtools/src/components/MonitoringPanel.tsx
@@ -27,6 +27,7 @@ import { validateFiberAccess } from "../fiber/validation.js";
 import { usePersistedState } from "../hooks/usePersistedState.js";
 import type { MonitorStore } from "../store/MonitorStore.js";
 import type { PanelPosition } from "../types/index.js";
+import { CacheInspectorTab } from "./CacheInspectorTab.js";
 import { ComputeTab } from "./ComputeTab.js";
 import { DebuggingTab } from "./DebuggingTab.js";
 import { InterceptTab } from "./InterceptTab.js";
@@ -102,7 +103,7 @@ export const MonitoringPanel: React.FC<MonitoringPanelProps> = ({
   const computeStore = monitorStore.getComputeStore();
   const fiberCapabilities = useFiberCapabilities();
   const [activeTab, setActiveTab] = useState<
-    "performance" | "compute" | "intercept" | "debugging"
+    "performance" | "compute" | "intercept" | "debugging" | "cache"
   >("performance");
   const [position, setPosition] = usePersistedState<PanelPosition>(
     "osdk-monitor-position",
@@ -537,23 +538,29 @@ export const MonitoringPanel: React.FC<MonitoringPanelProps> = ({
         </div>
 
         <div className={styles.tabs} role="tablist" aria-label="Devtools tabs">
-          {(["performance", "compute", "intercept", "debugging"] as const).map(
-            (tab) => (
-              <button
-                key={tab}
-                type="button"
-                role="tab"
-                aria-selected={activeTab === tab}
-                className={classNames(
-                  styles.tabButton,
-                  activeTab === tab && styles.tabButtonActive
-                )}
-                onClick={() => setActiveTab(tab)}
-              >
-                {tab.charAt(0).toUpperCase() + tab.slice(1)}
-              </button>
-            )
-          )}
+          {(
+            [
+              "performance",
+              "cache",
+              "compute",
+              "intercept",
+              "debugging",
+            ] as const
+          ).map((tab) => (
+            <button
+              key={tab}
+              type="button"
+              role="tab"
+              aria-selected={activeTab === tab}
+              className={classNames(
+                styles.tabButton,
+                activeTab === tab && styles.tabButtonActive
+              )}
+              onClick={() => setActiveTab(tab)}
+            >
+              {tab.charAt(0).toUpperCase() + tab.slice(1)}
+            </button>
+          ))}
         </div>
 
         <div className={styles.content}>
@@ -600,6 +607,15 @@ export const MonitoringPanel: React.FC<MonitoringPanelProps> = ({
             }
           >
             <DebuggingTab monitorStore={monitorStore} />
+          </div>
+          <div
+            className={
+              activeTab === "cache"
+                ? styles.tabContentVisible
+                : styles.tabContentHidden
+            }
+          >
+            <CacheInspectorTab monitorStore={monitorStore} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## What

Promotes the cache inspector out of the collapsible section nested inside the **Debugging** tab and into its own top-level Devtools tab.

- `MonitoringPanel` now renders `CacheInspectorTab` as a dedicated tab alongside Performance, Compute, Intercept, and Debugging.
- `DebuggingTab` drops the collapsible **Cache** section and its supporting polling state (`cacheCount`), since the inspector is no longer nested there.

## Why

`CacheInspectorTab` is already a self-contained tab (own title, stats, search, and clear/refresh controls), so nesting it behind a collapsible section inside Debugging was redundant. Surfacing it as a first-class tab makes it easier to reach.

<img width="1116" height="712" alt="cache_Demo" src="https://github.com/user-attachments/assets/23ccdb84-6910-4320-b7a0-962dfe3dd364" />
