### PR TITLE
Extract active components list into its own Components tab

### DIFF
--- a/.changeset/witty-melons-cheer.md
+++ b/.changeset/witty-melons-cheer.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+Move the active components list out of the Debugging tab into its own Components tab in the devtools panel

--- a/packages/react-devtools/src/components/ComponentsTab.module.scss
+++ b/packages/react-devtools/src/components/ComponentsTab.module.scss
@@ -1,0 +1,62 @@
+@use 'tokens' as t;
+@use 'mixins' as m;
+
+.componentsTab {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid t.$border-default;
+  background: t.$bg-raised;
+  flex-shrink: 0;
+}
+
+.searchInput {
+  flex: 1;
+}
+
+.feed {
+  flex: 1;
+  overflow-y: auto;
+  @include m.dt-scrollbar;
+}
+
+.section {
+  border-bottom: 1px solid t.$border-default;
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.sectionHeader {
+  @include m.dt-label;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: t.$bg-raised;
+  border-bottom: 1px solid t.$border-subtle;
+  position: sticky;
+  top: 0;
+  z-index: t.$z-sticky;
+}
+
+.sectionCount {
+  color: t.$text-tertiary;
+  font-weight: t.$font-weight-normal;
+  font-variant-numeric: tabular-nums;
+}
+
+.emptyState {
+  @include m.dt-empty-state;
+  font-size: t.$font-size-base;
+  padding: 24px 16px;
+}

--- a/packages/react-devtools/src/components/ComponentsTab.tsx
+++ b/packages/react-devtools/src/components/ComponentsTab.tsx
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InputGroup } from "@blueprintjs/core";
+import React, { useMemo, useState } from "react";
+
+import { createPollingStore } from "../hooks/createPollingStore.js";
+import { useActiveComponents } from "../hooks/useActiveComponents.js";
+import type { MonitorStore } from "../store/MonitorStore.js";
+import type { ComponentHookBinding } from "../utils/ComponentQueryRegistry.js";
+import { formatTime } from "../utils/format.js";
+import { collectIssues } from "./collectIssues.js";
+import { ComponentCard } from "./ComponentCard.js";
+import type { Issue } from "./issueTypes.js";
+import { resolveComponentName } from "./resolveComponentName.js";
+
+import styles from "./ComponentsTab.module.scss";
+
+export interface ComponentsTabProps {
+  monitorStore: MonitorStore;
+}
+
+export const ComponentsTab: React.FC<ComponentsTabProps> = ({
+  monitorStore,
+}) => {
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const activeComponents = useActiveComponents(monitorStore);
+
+  const issueStore = useMemo(
+    () =>
+      createPollingStore(() => collectIssues(monitorStore, Date.now()), 2000),
+    [monitorStore]
+  );
+  const issues =
+    React.useSyncExternalStore(issueStore.subscribe, issueStore.getSnapshot) ??
+    [];
+
+  const issuesByComponent = useMemo(() => {
+    const map = new Map<string, Issue[]>();
+    for (const issue of issues) {
+      if (issue.componentId) {
+        const existing = map.get(issue.componentId);
+        if (existing) {
+          existing.push(issue);
+        } else {
+          map.set(issue.componentId, [issue]);
+        }
+      }
+    }
+    return map;
+  }, [issues]);
+
+  const filteredComponents = useMemo<
+    Map<string, ComponentHookBinding[]>
+  >(() => {
+    if (!searchQuery.trim()) {
+      return activeComponents;
+    }
+
+    const q = searchQuery.toLowerCase();
+    const filtered = new Map<string, ComponentHookBinding[]>();
+
+    for (const [componentId, bindings] of activeComponents) {
+      const displayName = resolveComponentName(bindings).toLowerCase();
+
+      if (displayName.includes(q) || componentId.includes(q)) {
+        filtered.set(componentId, bindings);
+      }
+    }
+
+    return filtered;
+  }, [activeComponents, searchQuery]);
+
+  return (
+    <div className={styles.componentsTab}>
+      <div className={styles.controls}>
+        <InputGroup
+          leftIcon="search"
+          placeholder="Search components..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className={styles.searchInput}
+          fill={true}
+        />
+      </div>
+
+      <div className={styles.feed}>
+        <div className={styles.section}>
+          <div className={styles.sectionHeader}>
+            <span>Components</span>
+            <span className={styles.sectionCount}>
+              {filteredComponents.size}
+            </span>
+          </div>
+          {filteredComponents.size === 0 && (
+            <div className={styles.emptyState}>
+              {searchQuery
+                ? "No components match your search"
+                : "No active components found"}
+            </div>
+          )}
+          {[...filteredComponents].map(([componentId, bindings], index) => (
+            <ComponentCard
+              key={componentId}
+              componentId={componentId}
+              bindings={bindings}
+              formatTime={formatTime}
+              monitorStore={monitorStore}
+              issues={issuesByComponent.get(componentId)}
+              style={{ "--entrance-index": index } as React.CSSProperties}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/react-devtools/src/components/DebuggingTab.tsx
+++ b/packages/react-devtools/src/components/DebuggingTab.tsx
@@ -16,7 +16,7 @@
 
 import { Icon, InputGroup } from "@blueprintjs/core";
 import classNames from "classnames";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 
 import { createPollingStore } from "../hooks/createPollingStore.js";
 import { useConsoleLogs } from "../hooks/useConsoleLogs.js";
@@ -39,6 +39,8 @@ export const DebuggingTab: React.FC<DebuggingTabProps> = ({ monitorStore }) => {
   const [cacheExpanded, setCacheExpanded] = useState(false);
   const [consoleExpanded, setConsoleExpanded] = useState(true);
   const [improvementsExpanded, setImprovementsExpanded] = useState(true);
+
+  const componentRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
   const {
     entries: consoleEntries,
@@ -103,6 +105,14 @@ export const DebuggingTab: React.FC<DebuggingTabProps> = ({ monitorStore }) => {
     );
   }, [consoleEntries, searchQuery]);
 
+  const handleComponentClick = useCallback((componentId: string) => {
+    const el = componentRefs.current.get(componentId);
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+      el.click();
+    }
+  }, []);
+
   return (
     <div className={styles.debuggingTab}>
       <div className={styles.controls}>
@@ -135,6 +145,7 @@ export const DebuggingTab: React.FC<DebuggingTabProps> = ({ monitorStore }) => {
               <IssueCard
                 key={issue.id}
                 issue={issue}
+                onComponentClick={handleComponentClick}
                 style={{ "--entrance-index": index } as React.CSSProperties}
               />
             ))

--- a/packages/react-devtools/src/components/DebuggingTab.tsx
+++ b/packages/react-devtools/src/components/DebuggingTab.tsx
@@ -16,172 +16,22 @@
 
 import { Icon, InputGroup } from "@blueprintjs/core";
 import classNames from "classnames";
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 
 import { createPollingStore } from "../hooks/createPollingStore.js";
-import { useActiveComponents } from "../hooks/useActiveComponents.js";
 import { useConsoleLogs } from "../hooks/useConsoleLogs.js";
 import type { MonitorStore } from "../store/MonitorStore.js";
-import type { ComponentHookBinding } from "../utils/ComponentQueryRegistry.js";
-import { formatTime } from "../utils/format.js";
 import { CacheInspectorTab } from "./CacheInspectorTab.js";
-import { ComponentCard } from "./ComponentCard.js";
+import { collectIssues } from "./collectIssues.js";
 import { ImprovementsTab } from "./ImprovementsTab.js";
 import { IssueCard } from "./IssueCard.js";
 import type { Issue } from "./issueTypes.js";
 import { LogEntryCard } from "./LogEntryCard.js";
-import { resolveComponentName } from "./resolveComponentName.js";
 
 import styles from "./DebuggingTab.module.scss";
 
 export interface DebuggingTabProps {
   monitorStore: MonitorStore;
-}
-
-const SEVERITY_ORDER: Record<Issue["severity"], number> = {
-  error: 0,
-  warning: 1,
-  info: 2,
-};
-
-function collectIssues(monitorStore: MonitorStore, now: number): Issue[] {
-  const issues: Issue[] = [];
-
-  for (const err of monitorStore.getMetricsStore().getActionErrors()) {
-    issues.push({
-      id: err.id,
-      severity: "error",
-      category: "action failure",
-      title: "Action failed",
-      message: err.message,
-      suggestion: err.validationErrors?.length
-        ? "Fix validation errors before retrying"
-        : undefined,
-      timestamp: err.timestamp,
-      expandable: {
-        stack: err.stack,
-        detailsJson: JSON.stringify(
-          {
-            actionType: err.actionType,
-            parameters: err.parameters,
-          },
-          null,
-          2
-        ),
-      },
-    });
-  }
-
-  const windowErrors = monitorStore.getWindowErrorStore().getEntries();
-  // Bucketed at 100ms granularity. The lookup checks the current bucket plus
-  // the two adjacent buckets so that any console.error within ±100ms of a
-  // window error collides regardless of where the timestamps fall.
-  const windowErrorBuckets = new Set<string>();
-  for (const we of windowErrors) {
-    const expandable: NonNullable<Issue["expandable"]> = {};
-    if (we.stack) {
-      expandable.stack = we.stack;
-    }
-    if (we.filename || we.lineno || we.colno) {
-      expandable.detailsJson = JSON.stringify(
-        {
-          filename: we.filename,
-          lineno: we.lineno,
-          colno: we.colno,
-        },
-        null,
-        2
-      );
-    }
-    const hasExpandable =
-      expandable.stack !== undefined || expandable.detailsJson !== undefined;
-
-    issues.push({
-      id: `windowError-${we.id}`,
-      severity: "error",
-      category:
-        we.kind === "unhandledrejection"
-          ? "unhandled rejection"
-          : "uncaught error",
-      title:
-        we.kind === "unhandledrejection"
-          ? "Unhandled promise rejection"
-          : "Uncaught error",
-      message: we.message,
-      timestamp: we.timestamp,
-      ...(hasExpandable ? { expandable } : {}),
-    });
-
-    const bucket = Math.floor(we.timestamp / 100);
-    windowErrorBuckets.add(`${we.message}|${bucket}`);
-  }
-
-  for (const entry of monitorStore.getConsoleLogStore().getEntries()) {
-    if (entry.level !== "error") {
-      continue;
-    }
-    const messageText = entry.args.join(" ");
-    const bucket = Math.floor(entry.timestamp / 100);
-    if (
-      windowErrorBuckets.has(`${messageText}|${bucket - 1}`) ||
-      windowErrorBuckets.has(`${messageText}|${bucket}`) ||
-      windowErrorBuckets.has(`${messageText}|${bucket + 1}`)
-    ) {
-      continue;
-    }
-    const issue: Issue = {
-      id: `console-${entry.id}`,
-      severity: "error",
-      category: "console error",
-      title: "console.error",
-      message: messageText,
-      timestamp: entry.timestamp,
-    };
-    if (entry.source) {
-      issue.expandable = {
-        detailsJson: JSON.stringify({ source: entry.source }, null, 2),
-      };
-    }
-    issues.push(issue);
-  }
-
-  for (const wr of monitorStore.getPropertyAccessTracker().getWastedRenders()) {
-    issues.push({
-      id: `wasted-${wr.componentId}-${wr.timestamp}`,
-      severity: "warning",
-      category: "wasted render",
-      title: `${wr.count} renders without property access`,
-      message: `${wr.componentName} renders but doesn't use the data`,
-      suggestion: "Check if this component needs this data subscription",
-      componentId: wr.componentId,
-      componentName: wr.componentName,
-      timestamp: wr.timestamp,
-    });
-  }
-
-  for (const up of monitorStore
-    .getPropertyAccessTracker()
-    .getUnusedProperties()) {
-    issues.push({
-      id: `unused-${up.componentId}-${up.propertyName}`,
-      severity: "info",
-      category: "unused field",
-      title: `"${up.propertyName}" loaded but never accessed`,
-      message: `${up.componentName} fetches this field but never reads it`,
-      suggestion: "Remove from query to reduce payload",
-      componentId: up.componentId,
-      componentName: up.componentName,
-      timestamp: now,
-    });
-  }
-
-  issues.sort(
-    (a, b) =>
-      SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity] ||
-      b.timestamp - a.timestamp
-  );
-
-  return issues;
 }
 
 export const DebuggingTab: React.FC<DebuggingTabProps> = ({ monitorStore }) => {
@@ -190,9 +40,6 @@ export const DebuggingTab: React.FC<DebuggingTabProps> = ({ monitorStore }) => {
   const [consoleExpanded, setConsoleExpanded] = useState(true);
   const [improvementsExpanded, setImprovementsExpanded] = useState(true);
 
-  const componentRefs = useRef<Map<string, HTMLDivElement>>(new Map());
-
-  const activeComponents = useActiveComponents(monitorStore);
   const {
     entries: consoleEntries,
     count: consoleCount,
@@ -256,56 +103,12 @@ export const DebuggingTab: React.FC<DebuggingTabProps> = ({ monitorStore }) => {
     );
   }, [consoleEntries, searchQuery]);
 
-  const issuesByComponent = useMemo(() => {
-    const map = new Map<string, Issue[]>();
-    for (const issue of issues) {
-      if (issue.componentId) {
-        const existing = map.get(issue.componentId);
-        if (existing) {
-          existing.push(issue);
-        } else {
-          map.set(issue.componentId, [issue]);
-        }
-      }
-    }
-    return map;
-  }, [issues]);
-
-  const filteredComponents = useMemo<
-    Map<string, ComponentHookBinding[]>
-  >(() => {
-    if (!searchQuery.trim()) {
-      return activeComponents;
-    }
-
-    const q = searchQuery.toLowerCase();
-    const filtered = new Map<string, ComponentHookBinding[]>();
-
-    for (const [componentId, bindings] of activeComponents) {
-      const displayName = resolveComponentName(bindings).toLowerCase();
-
-      if (displayName.includes(q) || componentId.includes(q)) {
-        filtered.set(componentId, bindings);
-      }
-    }
-
-    return filtered;
-  }, [activeComponents, searchQuery]);
-
-  const handleComponentClick = useCallback((componentId: string) => {
-    const el = componentRefs.current.get(componentId);
-    if (el) {
-      el.scrollIntoView({ behavior: "smooth", block: "center" });
-      el.click();
-    }
-  }, []);
-
   return (
     <div className={styles.debuggingTab}>
       <div className={styles.controls}>
         <InputGroup
           leftIcon="search"
-          placeholder="Search issues and components..."
+          placeholder="Search issues..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           className={styles.searchInput}
@@ -332,7 +135,6 @@ export const DebuggingTab: React.FC<DebuggingTabProps> = ({ monitorStore }) => {
               <IssueCard
                 key={issue.id}
                 issue={issue}
-                onComponentClick={handleComponentClick}
                 style={{ "--entrance-index": index } as React.CSSProperties}
               />
             ))
@@ -390,43 +192,6 @@ export const DebuggingTab: React.FC<DebuggingTabProps> = ({ monitorStore }) => {
                   />
                 ))
             ))}
-        </div>
-
-        <div className={styles.section}>
-          <div className={styles.sectionHeader}>
-            <span>Components</span>
-            <span className={styles.sectionCount}>
-              {filteredComponents.size}
-            </span>
-          </div>
-          {filteredComponents.size === 0 && (
-            <div className={styles.emptyState}>
-              {searchQuery
-                ? "No components match your search"
-                : "No active components found"}
-            </div>
-          )}
-          {[...filteredComponents].map(([componentId, bindings], index) => (
-            <div
-              key={componentId}
-              ref={(el) => {
-                if (el) {
-                  componentRefs.current.set(componentId, el);
-                } else {
-                  componentRefs.current.delete(componentId);
-                }
-              }}
-            >
-              <ComponentCard
-                componentId={componentId}
-                bindings={bindings}
-                formatTime={formatTime}
-                monitorStore={monitorStore}
-                issues={issuesByComponent.get(componentId)}
-                style={{ "--entrance-index": index } as React.CSSProperties}
-              />
-            </div>
-          ))}
         </div>
 
         <div className={styles.section}>

--- a/packages/react-devtools/src/components/MonitoringPanel.tsx
+++ b/packages/react-devtools/src/components/MonitoringPanel.tsx
@@ -27,6 +27,7 @@ import { validateFiberAccess } from "../fiber/validation.js";
 import { usePersistedState } from "../hooks/usePersistedState.js";
 import type { MonitorStore } from "../store/MonitorStore.js";
 import type { PanelPosition } from "../types/index.js";
+import { ComponentsTab } from "./ComponentsTab.js";
 import { ComputeTab } from "./ComputeTab.js";
 import { DebuggingTab } from "./DebuggingTab.js";
 import { InterceptTab } from "./InterceptTab.js";
@@ -102,7 +103,7 @@ export const MonitoringPanel: React.FC<MonitoringPanelProps> = ({
   const computeStore = monitorStore.getComputeStore();
   const fiberCapabilities = useFiberCapabilities();
   const [activeTab, setActiveTab] = useState<
-    "performance" | "compute" | "intercept" | "debugging"
+    "performance" | "compute" | "intercept" | "debugging" | "components"
   >("performance");
   const [position, setPosition] = usePersistedState<PanelPosition>(
     "osdk-monitor-position",
@@ -537,23 +538,29 @@ export const MonitoringPanel: React.FC<MonitoringPanelProps> = ({
         </div>
 
         <div className={styles.tabs} role="tablist" aria-label="Devtools tabs">
-          {(["performance", "compute", "intercept", "debugging"] as const).map(
-            (tab) => (
-              <button
-                key={tab}
-                type="button"
-                role="tab"
-                aria-selected={activeTab === tab}
-                className={classNames(
-                  styles.tabButton,
-                  activeTab === tab && styles.tabButtonActive
-                )}
-                onClick={() => setActiveTab(tab)}
-              >
-                {tab.charAt(0).toUpperCase() + tab.slice(1)}
-              </button>
-            )
-          )}
+          {(
+            [
+              "performance",
+              "compute",
+              "intercept",
+              "debugging",
+              "components",
+            ] as const
+          ).map((tab) => (
+            <button
+              key={tab}
+              type="button"
+              role="tab"
+              aria-selected={activeTab === tab}
+              className={classNames(
+                styles.tabButton,
+                activeTab === tab && styles.tabButtonActive
+              )}
+              onClick={() => setActiveTab(tab)}
+            >
+              {tab.charAt(0).toUpperCase() + tab.slice(1)}
+            </button>
+          ))}
         </div>
 
         <div className={styles.content}>
@@ -600,6 +607,15 @@ export const MonitoringPanel: React.FC<MonitoringPanelProps> = ({
             }
           >
             <DebuggingTab monitorStore={monitorStore} />
+          </div>
+          <div
+            className={
+              activeTab === "components"
+                ? styles.tabContentVisible
+                : styles.tabContentHidden
+            }
+          >
+            <ComponentsTab monitorStore={monitorStore} />
           </div>
         </div>
       </div>

--- a/packages/react-devtools/src/components/collectIssues.ts
+++ b/packages/react-devtools/src/components/collectIssues.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { MonitorStore } from "../store/MonitorStore.js";
+import type { Issue } from "./issueTypes.js";
+
+const SEVERITY_ORDER: Record<Issue["severity"], number> = {
+  error: 0,
+  warning: 1,
+  info: 2,
+};
+
+export function collectIssues(
+  monitorStore: MonitorStore,
+  now: number
+): Issue[] {
+  const issues: Issue[] = [];
+
+  for (const err of monitorStore.getMetricsStore().getActionErrors()) {
+    issues.push({
+      id: err.id,
+      severity: "error",
+      category: "action failure",
+      title: "Action failed",
+      message: err.message,
+      suggestion: err.validationErrors?.length
+        ? "Fix validation errors before retrying"
+        : undefined,
+      timestamp: err.timestamp,
+      expandable: {
+        stack: err.stack,
+        detailsJson: JSON.stringify(
+          {
+            actionType: err.actionType,
+            parameters: err.parameters,
+          },
+          null,
+          2
+        ),
+      },
+    });
+  }
+
+  const windowErrors = monitorStore.getWindowErrorStore().getEntries();
+  // Bucketed at 100ms granularity. The lookup checks the current bucket plus
+  // the two adjacent buckets so that any console.error within ±100ms of a
+  // window error collides regardless of where the timestamps fall.
+  const windowErrorBuckets = new Set<string>();
+  for (const we of windowErrors) {
+    const expandable: NonNullable<Issue["expandable"]> = {};
+    if (we.stack) {
+      expandable.stack = we.stack;
+    }
+    if (we.filename || we.lineno || we.colno) {
+      expandable.detailsJson = JSON.stringify(
+        {
+          filename: we.filename,
+          lineno: we.lineno,
+          colno: we.colno,
+        },
+        null,
+        2
+      );
+    }
+    const hasExpandable =
+      expandable.stack !== undefined || expandable.detailsJson !== undefined;
+
+    issues.push({
+      id: `windowError-${we.id}`,
+      severity: "error",
+      category:
+        we.kind === "unhandledrejection"
+          ? "unhandled rejection"
+          : "uncaught error",
+      title:
+        we.kind === "unhandledrejection"
+          ? "Unhandled promise rejection"
+          : "Uncaught error",
+      message: we.message,
+      timestamp: we.timestamp,
+      ...(hasExpandable ? { expandable } : {}),
+    });
+
+    const bucket = Math.floor(we.timestamp / 100);
+    windowErrorBuckets.add(`${we.message}|${bucket}`);
+  }
+
+  for (const entry of monitorStore.getConsoleLogStore().getEntries()) {
+    if (entry.level !== "error") {
+      continue;
+    }
+    const messageText = entry.args.join(" ");
+    const bucket = Math.floor(entry.timestamp / 100);
+    if (
+      windowErrorBuckets.has(`${messageText}|${bucket - 1}`) ||
+      windowErrorBuckets.has(`${messageText}|${bucket}`) ||
+      windowErrorBuckets.has(`${messageText}|${bucket + 1}`)
+    ) {
+      continue;
+    }
+    const issue: Issue = {
+      id: `console-${entry.id}`,
+      severity: "error",
+      category: "console error",
+      title: "console.error",
+      message: messageText,
+      timestamp: entry.timestamp,
+    };
+    if (entry.source) {
+      issue.expandable = {
+        detailsJson: JSON.stringify({ source: entry.source }, null, 2),
+      };
+    }
+    issues.push(issue);
+  }
+
+  for (const wr of monitorStore.getPropertyAccessTracker().getWastedRenders()) {
+    issues.push({
+      id: `wasted-${wr.componentId}-${wr.timestamp}`,
+      severity: "warning",
+      category: "wasted render",
+      title: `${wr.count} renders without property access`,
+      message: `${wr.componentName} renders but doesn't use the data`,
+      suggestion: "Check if this component needs this data subscription",
+      componentId: wr.componentId,
+      componentName: wr.componentName,
+      timestamp: wr.timestamp,
+    });
+  }
+
+  for (const up of monitorStore
+    .getPropertyAccessTracker()
+    .getUnusedProperties()) {
+    issues.push({
+      id: `unused-${up.componentId}-${up.propertyName}`,
+      severity: "info",
+      category: "unused field",
+      title: `"${up.propertyName}" loaded but never accessed`,
+      message: `${up.componentName} fetches this field but never reads it`,
+      suggestion: "Remove from query to reduce payload",
+      componentId: up.componentId,
+      componentName: up.componentName,
+      timestamp: now,
+    });
+  }
+
+  issues.sort(
+    (a, b) =>
+      SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity] ||
+      b.timestamp - a.timestamp
+  );
+
+  return issues;
+}


### PR DESCRIPTION
## What

Moves the active-components list out of the **Debugging** tab into its own top-level **Components** tab in the devtools `MonitoringPanel`.

- New `ComponentsTab` — self-contained: its own search box, `useActiveComponents`, and issue polling to drive the per-component health dots in `ComponentCard`. Takes only `monitorStore`.
- Extracted the pure `collectIssues` helper into `collectIssues.ts` so both `DebuggingTab` and `ComponentsTab` derive issues from one source instead of duplicating the logic.
- `DebuggingTab` now keeps Errors / Console / Improvements / Cache; the Components section and its now-dead supporting code are removed.
- `MonitoringPanel` gains the `components` tab button and content pane.

## Note on a dropped interaction

The old Components section wired `handleComponentClick` into the **error** `IssueCard`s so clicking a component tag scrolled to it. Error issues never carry a `componentId` (only wasted-render / unused-field issues do, and those weren't rendered as cards in the Errors section), so that handler never fired — it's dropped rather than preserved. Component-linking from issues into the new tab would be a separate, deliberate feature.

## Verification

Typecheck, lint (oxlint + oxfmt), and the package test suite all pass.