### PR TITLE
render only components, console, and cache tabs in devtools

### DIFF
--- a/.changeset/devtools-core-tabs.md
+++ b/.changeset/devtools-core-tabs.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+render only the Overview, Components, Console, and Cache tabs in the devtools panel, dropping the Performance, Compute, Intercept, and Debugging tabs

--- a/.changeset/devtools-core-tabs.md
+++ b/.changeset/devtools-core-tabs.md
@@ -2,4 +2,4 @@
 "@osdk/react-devtools": patch
 ---
 
-render only the Overview, Components, Console, and Cache tabs in the devtools panel, dropping the Performance, Compute, Intercept, and Debugging tabs
+render only the Components, Console, and Cache tabs in the devtools panel, replacing the Performance, Compute, Intercept, and Debugging tabs

--- a/.changeset/devtools-core-tabs.md
+++ b/.changeset/devtools-core-tabs.md
@@ -2,4 +2,4 @@
 "@osdk/react-devtools": patch
 ---
 
-render only the Components, Console, and Cache tabs in the devtools panel, replacing the Performance, Compute, Intercept, and Debugging tabs. Section interior padding is now opt-in via an `OverviewSection` `padded` prop, so the cache sections render flush
+render only the Components, Console, and Cache tabs in the devtools panel, replacing the Performance, Compute, Intercept, and Debugging tabs. The cache sections now render flush, dropping the extra section padding via an `OverviewSection` `padded` prop

--- a/.changeset/devtools-core-tabs.md
+++ b/.changeset/devtools-core-tabs.md
@@ -2,4 +2,4 @@
 "@osdk/react-devtools": patch
 ---
 
-render only the Components, Console, and Cache tabs in the devtools panel, replacing the Performance, Compute, Intercept, and Debugging tabs
+render only the Components, Console, and Cache tabs in the devtools panel, replacing the Performance, Compute, Intercept, and Debugging tabs. Section interior padding is now opt-in via an `OverviewSection` `padded` prop, so the cache sections render flush

--- a/packages/react-devtools/src/components/MonitoringPanel.test.tsx
+++ b/packages/react-devtools/src/components/MonitoringPanel.test.tsx
@@ -80,7 +80,6 @@ describe("MonitoringPanel", () => {
     render(<MonitoringPanel monitorStore={store} />);
 
     expect(shadowContains("OSDK Devtools")).toBe(true);
-    expect(shadow().getByRole("tab", { name: "Overview" })).not.toBeNull();
     expect(shadow().getByRole("tab", { name: "Components" })).not.toBeNull();
     expect(shadow().getByRole("tab", { name: "Console" })).not.toBeNull();
     expect(shadow().getByRole("tab", { name: "Cache" })).not.toBeNull();
@@ -93,12 +92,12 @@ describe("MonitoringPanel", () => {
     expect(shadowContains("Beta")).toBe(true);
   });
 
-  it("defaults to the overview tab", () => {
+  it("defaults to the components tab", () => {
     const store = createMockMonitorStore();
     render(<MonitoringPanel monitorStore={store} />);
 
     expect(
-      shadow().getByRole("tab", { name: "Overview", selected: true })
+      shadow().getByRole("tab", { name: "Components", selected: true })
     ).not.toBeNull();
   });
 
@@ -131,16 +130,16 @@ describe("MonitoringPanel", () => {
     ).toContain("components");
   });
 
-  it("keeps all four tab panels mounted across a tab switch", () => {
+  it("keeps all three tab panels mounted across a tab switch", () => {
     const store = createMockMonitorStore();
     render(<MonitoringPanel monitorStore={store} />);
 
     // hidden: true includes the aria-hidden inactive panels that stay mounted.
-    expect(shadow().getAllByRole("tabpanel", { hidden: true })).toHaveLength(4);
+    expect(shadow().getAllByRole("tabpanel", { hidden: true })).toHaveLength(3);
 
     fireEvent.click(shadow().getByRole("tab", { name: "Cache" }));
 
-    expect(shadow().getAllByRole("tabpanel", { hidden: true })).toHaveLength(4);
+    expect(shadow().getAllByRole("tabpanel", { hidden: true })).toHaveLength(3);
   });
 
   it("preserves the selected tab across a minimize and reopen cycle", () => {

--- a/packages/react-devtools/src/components/MonitoringPanel.test.tsx
+++ b/packages/react-devtools/src/components/MonitoringPanel.test.tsx
@@ -80,10 +80,10 @@ describe("MonitoringPanel", () => {
     render(<MonitoringPanel monitorStore={store} />);
 
     expect(shadowContains("OSDK Devtools")).toBe(true);
-    expect(shadowContains("Performance")).toBe(true);
-    expect(shadowContains("Compute")).toBe(true);
-    expect(shadowContains("Intercept")).toBe(true);
-    expect(shadowContains("Debugging")).toBe(true);
+    expect(shadow().getByRole("tab", { name: "Overview" })).not.toBeNull();
+    expect(shadow().getByRole("tab", { name: "Components" })).not.toBeNull();
+    expect(shadow().getByRole("tab", { name: "Console" })).not.toBeNull();
+    expect(shadow().getByRole("tab", { name: "Cache" })).not.toBeNull();
   });
 
   it("renders the beta badge", () => {
@@ -93,11 +93,13 @@ describe("MonitoringPanel", () => {
     expect(shadowContains("Beta")).toBe(true);
   });
 
-  it("defaults to the performance tab", () => {
+  it("defaults to the overview tab", () => {
     const store = createMockMonitorStore();
     render(<MonitoringPanel monitorStore={store} />);
 
-    expect(shadowContains("Cache Hit Rate")).toBe(true);
+    expect(
+      shadow().getByRole("tab", { name: "Overview", selected: true })
+    ).not.toBeNull();
   });
 
   it("renders into an isolated shadow root, not the page", () => {
@@ -118,15 +120,15 @@ describe("MonitoringPanel", () => {
     const store = createMockMonitorStore();
     render(<MonitoringPanel monitorStore={store} />);
 
-    fireEvent.click(shadow().getByRole("tab", { name: "Compute" }));
+    fireEvent.click(shadow().getByRole("tab", { name: "Components" }));
 
     expect(
-      shadow().getByRole("tab", { name: "Compute", selected: true })
+      shadow().getByRole("tab", { name: "Components", selected: true })
     ).not.toBeNull();
-    // The single visible tabpanel is the one owned by the Compute tab.
+    // The single visible tabpanel is the one owned by the Components tab.
     expect(
       shadow().getByRole("tabpanel").getAttribute("aria-labelledby")
-    ).toContain("compute");
+    ).toContain("components");
   });
 
   it("keeps all four tab panels mounted across a tab switch", () => {
@@ -136,7 +138,7 @@ describe("MonitoringPanel", () => {
     // hidden: true includes the aria-hidden inactive panels that stay mounted.
     expect(shadow().getAllByRole("tabpanel", { hidden: true })).toHaveLength(4);
 
-    fireEvent.click(shadow().getByRole("tab", { name: "Debugging" }));
+    fireEvent.click(shadow().getByRole("tab", { name: "Cache" }));
 
     expect(shadow().getAllByRole("tabpanel", { hidden: true })).toHaveLength(4);
   });
@@ -145,9 +147,9 @@ describe("MonitoringPanel", () => {
     const store = createMockMonitorStore();
     render(<MonitoringPanel monitorStore={store} />);
 
-    fireEvent.click(shadow().getByRole("tab", { name: "Compute" }));
+    fireEvent.click(shadow().getByRole("tab", { name: "Components" }));
     expect(
-      shadow().getByRole("tab", { name: "Compute", selected: true })
+      shadow().getByRole("tab", { name: "Components", selected: true })
     ).not.toBeNull();
 
     fireEvent.click(

--- a/packages/react-devtools/src/components/MonitoringPanel.tsx
+++ b/packages/react-devtools/src/components/MonitoringPanel.tsx
@@ -36,11 +36,11 @@ import { usePersistedState } from "../hooks/usePersistedState.js";
 import { getDevtoolsShadowMount } from "../shadow/ShadowHost.js";
 import type { MonitorStore } from "../store/MonitorStore.js";
 import type { PanelPosition } from "../types/index.js";
-import { ComputeTab } from "./ComputeTab.js";
-import { DebuggingTab } from "./DebuggingTab.js";
-import { InterceptTab } from "./InterceptTab.js";
+import { CachePanel } from "./cache/CachePanel.js";
+import { ComponentsPanel } from "./components/ComponentsPanel.js";
+import { ConsolePanel } from "./console/ConsolePanel.js";
 import { MonitorErrorBoundary } from "./MonitorErrorBoundary.js";
-import { PerformanceTab } from "./PerformanceTab.js";
+import { OverviewTab } from "./OverviewTab.js";
 
 import styles from "./MonitoringPanel.module.scss";
 
@@ -99,10 +99,10 @@ const UI_CONSTANTS = {
 };
 
 const DEVTOOLS_TAB_IDS = [
-  "performance",
-  "compute",
-  "intercept",
-  "debugging",
+  "overview",
+  "components",
+  "console",
+  "cache",
 ] as const;
 
 type DevtoolsTabId = (typeof DEVTOOLS_TAB_IDS)[number];
@@ -116,9 +116,8 @@ export const MonitoringPanel: React.FC<MonitoringPanelProps> = ({
   monitorStore,
 }) => {
   const metricsStore = monitorStore.getMetricsStore();
-  const computeStore = monitorStore.getComputeStore();
   const fiberCapabilities = useFiberCapabilities();
-  const [activeTab, setActiveTab] = useState<DevtoolsTabId>("performance");
+  const [activeTab, setActiveTab] = useState<DevtoolsTabId>("overview");
   const onActiveTabChange = useCallback((newTabId: TabId) => {
     if (isDevtoolsTabId(newTabId)) {
       setActiveTab(newTabId);
@@ -584,38 +583,28 @@ export const MonitoringPanel: React.FC<MonitoringPanelProps> = ({
             onChange={onActiveTabChange}
           >
             <Tab
-              id="performance"
-              title="Performance"
+              id="overview"
+              title="Overview"
               panelClassName={styles.tabPanel}
-              panel={
-                <PerformanceTab
-                  metricsStore={metricsStore}
-                  monitorStore={monitorStore}
-                />
-              }
+              panel={<OverviewTab monitorStore={monitorStore} />}
             />
             <Tab
-              id="compute"
-              title="Compute"
+              id="components"
+              title="Components"
               panelClassName={styles.tabPanel}
-              panel={<ComputeTab computeStore={computeStore} />}
+              panel={<ComponentsPanel monitorStore={monitorStore} />}
             />
             <Tab
-              id="intercept"
-              title="Intercept"
+              id="console"
+              title="Console"
               panelClassName={styles.tabPanel}
-              panel={
-                <InterceptTab
-                  monitorStore={monitorStore}
-                  theme={resolvedTheme}
-                />
-              }
+              panel={<ConsolePanel monitorStore={monitorStore} />}
             />
             <Tab
-              id="debugging"
-              title="Debugging"
+              id="cache"
+              title="Cache"
               panelClassName={styles.tabPanel}
-              panel={<DebuggingTab monitorStore={monitorStore} />}
+              panel={<CachePanel monitorStore={monitorStore} />}
             />
           </Tabs>
         </div>

--- a/packages/react-devtools/src/components/MonitoringPanel.tsx
+++ b/packages/react-devtools/src/components/MonitoringPanel.tsx
@@ -40,7 +40,6 @@ import { CachePanel } from "./cache/CachePanel.js";
 import { ComponentsPanel } from "./components/ComponentsPanel.js";
 import { ConsolePanel } from "./console/ConsolePanel.js";
 import { MonitorErrorBoundary } from "./MonitorErrorBoundary.js";
-import { OverviewTab } from "./OverviewTab.js";
 
 import styles from "./MonitoringPanel.module.scss";
 
@@ -98,12 +97,7 @@ const UI_CONSTANTS = {
   MAX_DOCKED_RIGHT_WIDTH: 800,
 };
 
-const DEVTOOLS_TAB_IDS = [
-  "overview",
-  "components",
-  "console",
-  "cache",
-] as const;
+const DEVTOOLS_TAB_IDS = ["components", "console", "cache"] as const;
 
 type DevtoolsTabId = (typeof DEVTOOLS_TAB_IDS)[number];
 
@@ -117,7 +111,7 @@ export const MonitoringPanel: React.FC<MonitoringPanelProps> = ({
 }) => {
   const metricsStore = monitorStore.getMetricsStore();
   const fiberCapabilities = useFiberCapabilities();
-  const [activeTab, setActiveTab] = useState<DevtoolsTabId>("overview");
+  const [activeTab, setActiveTab] = useState<DevtoolsTabId>("components");
   const onActiveTabChange = useCallback((newTabId: TabId) => {
     if (isDevtoolsTabId(newTabId)) {
       setActiveTab(newTabId);
@@ -582,12 +576,6 @@ export const MonitoringPanel: React.FC<MonitoringPanelProps> = ({
             selectedTabId={activeTab}
             onChange={onActiveTabChange}
           >
-            <Tab
-              id="overview"
-              title="Overview"
-              panelClassName={styles.tabPanel}
-              panel={<OverviewTab monitorStore={monitorStore} />}
-            />
             <Tab
               id="components"
               title="Components"

--- a/packages/react-devtools/src/components/OverviewSection.module.scss
+++ b/packages/react-devtools/src/components/OverviewSection.module.scss
@@ -11,7 +11,12 @@
   }
 
   .overviewSectionCard {
-    padding: 12px;
     background: t.$bg-surface;
+
+    // Interior padding is opt-in via the `padded` prop; sections whose content
+    // owns its own spacing (e.g. the cache lists) render flush without it.
+    &.padded {
+      padding: 12px;
+    }
   }
 }

--- a/packages/react-devtools/src/components/OverviewSection.tsx
+++ b/packages/react-devtools/src/components/OverviewSection.tsx
@@ -15,6 +15,7 @@
  */
 
 import { Section, SectionCard } from "@blueprintjs/core";
+import classNames from "classnames";
 import React from "react";
 
 import styles from "./OverviewSection.module.scss";
@@ -24,11 +25,18 @@ export interface OverviewSectionProps {
   title: string;
   /** The section body — typically a grid of tiles. */
   children: React.ReactNode;
+  /**
+   * Adds interior padding around the section body. Disabled by default so
+   * sections whose content owns its own spacing (e.g. the cache lists) render
+   * flush; enable it for tile grids that need breathing room.
+   */
+  padded?: boolean;
 }
 
 export function OverviewSection({
   title,
   children,
+  padded = false,
 }: OverviewSectionProps): React.JSX.Element {
   return (
     <Section
@@ -37,7 +45,12 @@ export function OverviewSection({
       title={title}
       className={styles.overviewSection}
     >
-      <SectionCard className={styles.overviewSectionCard}>
+      <SectionCard
+        padded={false}
+        className={classNames(styles.overviewSectionCard, {
+          [styles.padded]: padded,
+        })}
+      >
         {children}
       </SectionCard>
     </Section>

--- a/packages/react-devtools/src/components/OverviewSection.tsx
+++ b/packages/react-devtools/src/components/OverviewSection.tsx
@@ -26,9 +26,9 @@ export interface OverviewSectionProps {
   /** The section body — typically a grid of tiles. */
   children: React.ReactNode;
   /**
-   * Adds interior padding around the section body. Disabled by default so
-   * sections whose content owns its own spacing (e.g. the cache lists) render
-   * flush; enable it for tile grids that need breathing room.
+   * Adds interior padding around the section body. Enabled by default; disable
+   * it for sections whose content owns its own spacing (e.g. the cache lists)
+   * so they render flush.
    */
   padded?: boolean;
 }
@@ -36,7 +36,7 @@ export interface OverviewSectionProps {
 export function OverviewSection({
   title,
   children,
-  padded = false,
+  padded = true,
 }: OverviewSectionProps): React.JSX.Element {
   return (
     <Section

--- a/packages/react-devtools/src/components/cache/CachePanel.tsx
+++ b/packages/react-devtools/src/components/cache/CachePanel.tsx
@@ -31,10 +31,10 @@ interface CachePanelProps {
 export const CachePanel: FC<CachePanelProps> = ({ monitorStore }) => {
   return (
     <div className={styles.panel}>
-      <OverviewSection title="Cache inspector">
+      <OverviewSection title="Cache inspector" padded={false}>
         <CacheInspectorTab monitorStore={monitorStore} />
       </OverviewSection>
-      <OverviewSection title="Cache history">
+      <OverviewSection title="Cache history" padded={false}>
         <CacheTimeline monitorStore={monitorStore} />
       </OverviewSection>
     </div>


### PR DESCRIPTION
trims the osdk react devtools panel down to three core tabs

• MonitoringPanel now renders only Components, Console, and Cache, replacing the Performance, Compute, Intercept, and Debugging tabs
• Console renders the ConsolePanel added in #3632
• Components is the default active tab; the Overview component stays in the tree but is intentionally not wired up yet
• OverviewSection interior padding is now opt-in via a padded prop, defaulting off so the cache sections render flush
