### PR TITLE
fix low-contrast outlined primary buttons in devtools

### DIFF
--- a/.changeset/devtools-overview-tab.md
+++ b/.changeset/devtools-overview-tab.md
@@ -2,4 +2,4 @@
 "@osdk/react-devtools": patch
 ---
 
-wire the Overview tab back into the devtools panel as the default tab, and fix outlined primary buttons ("View documentation", "Copy fix prompt") to use the soft blue tint and readable blue label instead of a solid fill with low-contrast text
+fix outlined primary buttons ("View documentation", "Copy fix prompt") in the devtools panel to use the soft blue tint and readable blue label instead of a solid fill with low-contrast text

--- a/.changeset/devtools-overview-tab.md
+++ b/.changeset/devtools-overview-tab.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-devtools": patch
+---
+
+wire the Overview tab back into the devtools panel as the default tab, and fix outlined primary buttons ("View documentation", "Copy fix prompt") to use the soft blue tint and readable blue label instead of a solid fill with low-contrast text

--- a/packages/react-devtools/src/components/MonitoringPanel.module.scss
+++ b/packages/react-devtools/src/components/MonitoringPanel.module.scss
@@ -611,9 +611,9 @@
           background: t.$blue-hover;
         }
 
-        // Outlined primary buttons (e.g. "View documentation", "Copy fix
-        // prompt") mirror the soft tint the other intents use instead of the
-        // solid fill, so their label stays readable on the panel surface.
+        // Outlined primary buttons mirror the soft tint the other intents use
+        // instead of the solid fill, so their label stays readable on the
+        // panel surface.
         &.bp6-outlined {
           background: t.$blue-bg;
           border-color: var(--dt-blue-border);

--- a/packages/react-devtools/src/components/MonitoringPanel.module.scss
+++ b/packages/react-devtools/src/components/MonitoringPanel.module.scss
@@ -610,6 +610,19 @@
         &:hover {
           background: t.$blue-hover;
         }
+
+        // Outlined primary buttons (e.g. "View documentation", "Copy fix
+        // prompt") mirror the soft tint the other intents use instead of the
+        // solid fill, so their label stays readable on the panel surface.
+        &.bp6-outlined {
+          background: t.$blue-bg;
+          border-color: var(--dt-blue-border);
+          color: t.$blue;
+
+          &:hover {
+            background: var(--dt-blue-hover-bg);
+          }
+        }
       }
 
       &.bp6-intent-danger {

--- a/packages/react-devtools/src/components/_theme.scss
+++ b/packages/react-devtools/src/components/_theme.scss
@@ -58,6 +58,7 @@
   --dt-red-hover-bg: rgba(224, 82, 82, 0.2);
   --dt-green-hover-bg: rgba(50, 164, 103, 0.2);
   --dt-orange-hover-bg: rgba(212, 136, 15, 0.2);
+  --dt-blue-hover-bg: rgba(45, 140, 240, 0.2);
   --dt-blue-resize-hover: rgba(45, 140, 240, 0.2);
 
   // Revalidation
@@ -140,6 +141,7 @@
   --dt-red-hover-bg: rgba(205, 66, 70, 0.15);
   --dt-green-hover-bg: rgba(35, 133, 81, 0.15);
   --dt-orange-hover-bg: rgba(200, 118, 25, 0.15);
+  --dt-blue-hover-bg: rgba(45, 114, 210, 0.15);
   --dt-blue-resize-hover: rgba(45, 114, 210, 0.2);
 
   // Revalidation


### PR DESCRIPTION
## Summary
outlined primary buttons (View documentation, Copy fix prompt) rendered with a solid blue fill and low-contrast text instead of the soft tint the other intents use

• added a bp6-outlined sub-rule under bp6-intent-primary so it matches the danger/warning/success pattern
• added the missing --dt-blue-hover-bg token for both themes