### PR TITLE
Version Packages

### DIFF
--- a/.changeset/components-overview-full-height.md
+++ b/.changeset/components-overview-full-height.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-components-storybook": patch
----
-
-Make the Components Overview page fill the full available height so the ObjectTable, FilterList, and DocumentViewer stretch to the viewport.

--- a/.changeset/devtools-core-tabs.md
+++ b/.changeset/devtools-core-tabs.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-devtools": patch
----
-
-render only the Components, Console, and Cache tabs in the devtools panel, replacing the Performance, Compute, Intercept, and Debugging tabs. The cache sections now render flush, dropping the extra section padding via an `OverviewSection` `padded` prop

--- a/.changeset/devtools-overview-tab.md
+++ b/.changeset/devtools-overview-tab.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-devtools": patch
----
-
-fix outlined primary buttons ("View documentation", "Copy fix prompt") in the devtools panel to use the soft blue tint and readable blue label instead of a solid fill with low-contrast text

--- a/.changeset/dt2-client-metrics.md
+++ b/.changeset/dt2-client-metrics.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-devtools": patch
----
-
-add client metrics (cache, latency, and optimistic-update effectiveness) computed from the metrics store

--- a/.changeset/dt2-tab-cache.md
+++ b/.changeset/dt2-tab-cache.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-devtools": patch
----
-
-add the Cache tab: a cache entry inspector with size and entries stats stacked above a cache history timeline

--- a/.changeset/dt2-tab-components.md
+++ b/.changeset/dt2-tab-components.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-devtools": patch
----
-
-rebuild the Components base tab as a collapsible ontology tree showing the object types, actions, and properties each component touches, with search and per-component health badges

--- a/.changeset/dt2-tab-console.md
+++ b/.changeset/dt2-tab-console.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-devtools": patch
----
-
-fix devtools panel tooltips and popover menus not responding to hover or clicks, caused by portaled overlays inheriting the panel's pointer-events:none

--- a/.changeset/dt2-tab-performance.md
+++ b/.changeset/dt2-tab-performance.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-devtools": patch
----
-
-surface performance recommendations as a section on the Overview tab

--- a/.changeset/lucky-pandas-wave.md
+++ b/.changeset/lucky-pandas-wave.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-devtools": patch
----
-
-Use real metrics in the Overview tab

--- a/.changeset/quiet-otters-dream.md
+++ b/.changeset/quiet-otters-dream.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-devtools": patch
----
-
-Restyle the monitoring panel header background and remove the uppercase transform from the title

--- a/.changeset/witty-lions-cheer.md
+++ b/.changeset/witty-lions-cheer.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-devtools": patch
----
-
-Restyle the MonitoringPanel devtools tab bar to use Blueprint Tabs

--- a/packages/react-components-storybook/CHANGELOG.md
+++ b/packages/react-components-storybook/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/react-components-storybook
 
+## 0.36.0
+
+### Minor Changes
+
+- d99575d: Make the Components Overview page fill the full available height so the ObjectTable, FilterList, and DocumentViewer stretch to the viewport.
+
 ## 0.35.0
 
 ### Minor Changes

--- a/packages/react-components-storybook/package.json
+++ b/packages/react-components-storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/react-components-storybook",
   "private": true,
-  "version": "0.35.0",
+  "version": "0.36.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/react-devtools/CHANGELOG.md
+++ b/packages/react-devtools/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @osdk/react-devtools
 
+## 0.13.0
+
+### Minor Changes
+
+- 928a117: render only the Components, Console, and Cache tabs in the devtools panel, replacing the Performance, Compute, Intercept, and Debugging tabs. The cache sections now render flush, dropping the extra section padding via an `OverviewSection` `padded` prop
+- ebb4850: fix outlined primary buttons ("View documentation", "Copy fix prompt") in the devtools panel to use the soft blue tint and readable blue label instead of a solid fill with low-contrast text
+- e3a6fa4: add client metrics (cache, latency, and optimistic-update effectiveness) computed from the metrics store
+- 63139b8: add the Cache tab: a cache entry inspector with size and entries stats stacked above a cache history timeline
+- b5c9ab3: rebuild the Components base tab as a collapsible ontology tree showing the object types, actions, and properties each component touches, with search and per-component health badges
+- b03e461: fix devtools panel tooltips and popover menus not responding to hover or clicks, caused by portaled overlays inheriting the panel's pointer-events:none
+- cfa111e: surface performance recommendations as a section on the Overview tab
+- a4b03d5: Use real metrics in the Overview tab
+- 7995be0: Restyle the monitoring panel header background and remove the uppercase transform from the title
+- 7449f91: Restyle the MonitoringPanel devtools tab bar to use Blueprint Tabs
+
 ## 0.12.0
 
 ### Minor Changes

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/react-devtools",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Developer tools and debugging utilities for OSDK React Toolkit",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.


# Releases
## @osdk/react-devtools@0.13.0

### Minor Changes

-   928a117: render only the Components, Console, and Cache tabs in the devtools panel, replacing the Performance, Compute, Intercept, and Debugging tabs. The cache sections now render flush, dropping the extra section padding via an `OverviewSection` `padded` prop
-   ebb4850: fix outlined primary buttons ("View documentation", "Copy fix prompt") in the devtools panel to use the soft blue tint and readable blue label instead of a solid fill with low-contrast text
-   e3a6fa4: add client metrics (cache, latency, and optimistic-update effectiveness) computed from the metrics store
-   63139b8: add the Cache tab: a cache entry inspector with size and entries stats stacked above a cache history timeline
-   b5c9ab3: rebuild the Components base tab as a collapsible ontology tree showing the object types, actions, and properties each component touches, with search and per-component health badges
-   b03e461: fix devtools panel tooltips and popover menus not responding to hover or clicks, caused by portaled overlays inheriting the panel's pointer-events:none
-   cfa111e: surface performance recommendations as a section on the Overview tab
-   a4b03d5: Use real metrics in the Overview tab
-   7995be0: Restyle the monitoring panel header background and remove the uppercase transform from the title
-   7449f91: Restyle the MonitoringPanel devtools tab bar to use Blueprint Tabs

## @osdk/react-components-storybook@0.36.0

### Minor Changes

-   d99575d: Make the Components Overview page fill the full available height so the ObjectTable, FilterList, and DocumentViewer stretch to the viewport.
