### PR TITLE
Version Packages

### DIFF
--- a/.changeset/mighty-otters-cheer.md
+++ b/.changeset/mighty-otters-cheer.md
@@ -1,6 +1,0 @@
----
-"@osdk/react-devtools": patch
-"@osdk/react-components": patch
----
-
-Detect actions and resolve memo component names in the component tree, and clarify the components and cache-hit-rate copy

--- a/packages/react-components-styles/CHANGELOG.md
+++ b/packages/react-components-styles/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @osdk/react-components-styles
 
+## 0.37.0
+
 ## 0.36.0
 
 ## 0.35.0

--- a/packages/react-components-styles/package.json
+++ b/packages/react-components-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/react-components-styles",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/react-components
 
+## 0.37.0
+
+### Minor Changes
+
+- df15011: Detect actions and resolve memo component names in the component tree, and clarify the components and cache-hit-rate copy
+
 ## 0.36.0
 
 ### Minor Changes

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/react-components",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/react-devtools/CHANGELOG.md
+++ b/packages/react-devtools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/react-devtools
 
+## 0.14.0
+
+### Minor Changes
+
+- df15011: Detect actions and resolve memo component names in the component tree, and clarify the components and cache-hit-rate copy
+
 ## 0.13.0
 
 ### Minor Changes

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/react-devtools",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Developer tools and debugging utilities for OSDK React Toolkit",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.


# Releases
## @osdk/react-components@0.37.0

### Minor Changes

-   df15011: Detect actions and resolve memo component names in the component tree, and clarify the components and cache-hit-rate copy

## @osdk/react-devtools@0.14.0

### Minor Changes

-   df15011: Detect actions and resolve memo component names in the component tree, and clarify the components and cache-hit-rate copy

## @osdk/react-components-styles@0.37.0


