### PR TITLE
fix: escape comment terminators in generated JSDoc

### DIFF
--- a/.changeset/escape-jsdoc-comment-terminator.md
+++ b/.changeset/escape-jsdoc-comment-terminator.md
@@ -1,0 +1,5 @@
+---
+"@osdk/generator": patch
+---
+
+Escape `*/` in ontology descriptions and display names so they cannot prematurely close generated JSDoc comments and break SDK generation.

--- a/packages/generator/src/shared/propertyJsdoc.ts
+++ b/packages/generator/src/shared/propertyJsdoc.ts
@@ -16,6 +16,7 @@
 
 import type { ObjectMetadata } from "@osdk/api";
 import type { PropertyV2 } from "@osdk/foundry.ontologies";
+import { escapeJsDocText } from "../util/escapeJsDocText.js";
 
 export function propertyJsdoc(
   property: ObjectMetadata.Property,
@@ -31,12 +32,16 @@ export function propertyJsdoc(
       let deprecationStatus = "";
       if (status.type === "deprecated") {
         deprecationStatus += ` *   @deprecated\n`;
-        deprecationStatus += ` *   - ${status.message}\n`;
+        deprecationStatus += ` *   - ${escapeJsDocText(status.message)}\n`;
         if (status.deadline) {
-          deprecationStatus += ` *   - deadline: ${status.deadline}\n`;
+          deprecationStatus += ` *   - deadline: ${
+            escapeJsDocText(status.deadline)
+          }\n`;
         }
         if (status.replacedBy) {
-          deprecationStatus += ` *   - replaced by: ${status.replacedBy}\n`;
+          deprecationStatus += ` *   - replaced by: ${
+            escapeJsDocText(status.replacedBy)
+          }\n`;
         }
         ret.push(deprecationStatus);
       } else if (status.type === "experimental") {
@@ -50,14 +55,14 @@ export function propertyJsdoc(
 
     if (renderDisplayName) {
       ret.push(
-        ` *   display name: '${property.displayName}'${
+        ` *   display name: '${escapeJsDocText(property.displayName!)}'${
           property.description ? "," : ""
         }\n`,
       );
     }
 
     if (property.description) {
-      ret.push(` *   description: ${property.description}\n`);
+      ret.push(` *   description: ${escapeJsDocText(property.description)}\n`);
     }
   } else {
     ret.push(` * (no ontology metadata)\n`);

--- a/packages/generator/src/util/escapeJsDocText.test.ts
+++ b/packages/generator/src/util/escapeJsDocText.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { escapeJsDocText } from "./escapeJsDocText.js";
+
+describe("escapeJsDocText", () => {
+  it("leaves ordinary text untouched", () => {
+    expect(escapeJsDocText("A normal description.")).toBe(
+      "A normal description.",
+    );
+  });
+
+  it("neutralizes a comment terminator so it cannot close a JSDoc block", () => {
+    const escaped = escapeJsDocText("matches the glob a/*/b");
+    expect(escaped).toBe("matches the glob a/*\\/b");
+    expect(escaped).not.toContain("*/");
+  });
+
+  it("escapes every occurrence", () => {
+    expect(escapeJsDocText("a */ b */ c")).toBe("a *\\/ b *\\/ c");
+  });
+
+  it("does not reintroduce a terminator from adjacent stars", () => {
+    expect(escapeJsDocText("foo **/ bar")).not.toContain("*/");
+  });
+});

--- a/packages/generator/src/util/escapeJsDocText.ts
+++ b/packages/generator/src/util/escapeJsDocText.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Escapes arbitrary ontology metadata (descriptions, display names, etc.) so it
+ * can be safely embedded inside a generated JSDoc block comment.
+ *
+ * A block comment is terminated by the first star-slash sequence, so if that
+ * sequence appears in the metadata it would prematurely close the comment and
+ * leave the remainder of the text as invalid TypeScript, breaking SDK
+ * generation. We insert a backslash between the star and slash to neutralize
+ * it. This matches TSDoc's escaping rules, so renderers that understand TSDoc
+ * still display the original text.
+ */
+export function escapeJsDocText(text: string): string {
+  return text.replace(/\*\//gu, "*\\/");
+}

--- a/packages/generator/src/util/escapeJsDocText.ts
+++ b/packages/generator/src/util/escapeJsDocText.ts
@@ -15,15 +15,8 @@
  */
 
 /**
- * Escapes arbitrary ontology metadata (descriptions, display names, etc.) so it
- * can be safely embedded inside a generated JSDoc block comment.
- *
- * A block comment is terminated by the first star-slash sequence, so if that
- * sequence appears in the metadata it would prematurely close the comment and
- * leave the remainder of the text as invalid TypeScript, breaking SDK
- * generation. We insert a backslash between the star and slash to neutralize
- * it. This matches TSDoc's escaping rules, so renderers that understand TSDoc
- * still display the original text.
+ * Escapes text so it can be embedded in a JSDoc block comment without
+ * prematurely closing it.
  */
 export function escapeJsDocText(text: string): string {
   return text.replace(/\*\//gu, "*\\/");

--- a/packages/generator/src/v2.0/generatePerActionDataFiles.ts
+++ b/packages/generator/src/v2.0/generatePerActionDataFiles.ts
@@ -26,6 +26,7 @@ import type { ForeignType } from "../GenerateContext/ForeignType.js";
 import type { GenerateContext } from "../GenerateContext/GenerateContext.js";
 import { getObjectImports } from "../shared/getObjectImports.js";
 import { deleteUndefineds } from "../util/deleteUndefineds.js";
+import { escapeJsDocText } from "../util/escapeJsDocText.js";
 import { stringify } from "../util/stringify.js";
 import { formatTs } from "../util/test/formatTs.js";
 import { getDescriptionIfPresent } from "./getDescriptionIfPresent.js";
@@ -149,7 +150,7 @@ export async function generatePerActionDataFiles(
         const oldParamsIdentifier = `${action.shortApiName}$Params`;
         const jsDocBlock = ["/**"];
         if (action.description != null) {
-          jsDocBlock.push(`* ${action.description}`);
+          jsDocBlock.push(`* ${escapeJsDocText(action.description)}`);
 
           // Add note about null values to the action description if there are nullable parameters
           const hasNullableParams = Object.values(
@@ -174,7 +175,7 @@ export async function generatePerActionDataFiles(
         // the params must be a `type` to align properly with the `ActionDefinition` interface
         // this way we can generate a strict type for the function itself and reference it from the Action Definition
         return `
-        
+
           export namespace ${action.shortApiName}{
             ${createParamsDef()}
 
@@ -193,7 +194,7 @@ export async function generatePerActionDataFiles(
               jsDocBlock.push(
                 `* @param {${getActionParamType(ogValue.type)}} ${
                   ogValue.nullable ? `[${ogKey}]` : ogKey
-                } ${ogValue.description ?? ""}`,
+                } ${escapeJsDocText(ogValue.description ?? "")}`,
               );
               return [key, value];
             },
@@ -205,13 +206,13 @@ export async function generatePerActionDataFiles(
             export interface Signatures {
               ${getDescriptionIfPresent(action.description)}
               applyAction<OP extends ApplyActionOptions>(args: ${action.paramsIdentifier}, options?: OP): Promise<ActionReturnTypeForOptions<OP>>;
-           
+
               batchApplyAction<OP extends ApplyBatchActionOptions>(args: ReadonlyArray<${action.paramsIdentifier}>, options?: OP): Promise<ActionReturnTypeForOptions<OP>>;
             }
-  
+
           }
 
-          
+
           ${jsDocBlock.join("\n")}
           */
           export interface ${action.shortApiName} extends ActionDefinition<${action.shortApiName}.Signatures> {
@@ -221,7 +222,7 @@ export async function generatePerActionDataFiles(
             "parameters": () => action.definitionParamsIdentifier,
           })
         }
-              
+
               signatures: ${action.shortApiName}.Signatures;
             },
             ${
@@ -240,7 +241,7 @@ export async function generatePerActionDataFiles(
       }
 
       function createV2Object() {
-        return `  export const ${action.shortApiName}: ${action.shortApiName} = 
+        return `  export const ${action.shortApiName}: ${action.shortApiName} =
         {
           ${
           stringify(fullActionDef, {
@@ -335,7 +336,7 @@ export async function generatePerActionDataFiles(
           import { $osdkMetadata} from "../../OntologyMetadata${importExt}";
           ${imports}
 
-        
+
           ${createV2Types()}
 
           ${createV2Object()}

--- a/packages/generator/src/v2.0/generatePerQueryDataFiles.test.ts
+++ b/packages/generator/src/v2.0/generatePerQueryDataFiles.test.ts
@@ -226,6 +226,76 @@ describe("generatePerQueryDataFiles", () => {
     ts.createDocumentRegistry();
   });
 
+  it("escapes comment terminators in parameter descriptions", async () => {
+    const helper = createMockMinimalFiles();
+    const BASE_PATH = "/foo";
+
+    await generatePerQueryDataFilesV2(
+      {
+        fs: helper.minimalFiles,
+        ontology: enhanceOntology({
+          sanitized: {
+            actionTypes: {},
+            interfaceTypes: {},
+            objectTypes: {},
+            ontology: {
+              apiName: "foo",
+              description: "foo",
+              displayName: "foo",
+              rid: "ri.foo",
+            },
+            queryTypes: {
+              sampleQuery: {
+                rid: "rid.query.sample",
+                version: "0",
+                apiName: "sampleQuery",
+                parameters: {
+                  flag: {
+                    description:
+                      "Preview changes for glob patterns such as a/*/b before writing.",
+                    dataType: { type: "boolean" },
+                    required: false,
+                  },
+                },
+                output: { type: "boolean" },
+                typeReferences: {},
+              },
+            },
+            sharedPropertyTypes: {},
+            valueTypes: {},
+          },
+          importExt: ".js",
+          externalObjects: new Map(),
+          externalInterfaces: new Map(),
+          externalSpts: new Map(),
+        }),
+        outDir: BASE_PATH,
+        importExt: ".js",
+        forInternalUse: true,
+        fixedVersionQueryTypes: [],
+      },
+      true,
+    );
+
+    const generated = helper.getFiles()["/foo/ontology/queries/sampleQuery.ts"];
+
+    // The description must not prematurely close the JSDoc block comment.
+    expect(generated).toContain("a/*\\/b");
+
+    // The generated file must be syntactically valid TypeScript. Before the
+    // fix, the unescaped `*/` closed the comment early and left invalid code.
+    const sourceFile = ts.createSourceFile(
+      "sampleQuery.ts",
+      generated,
+      ts.ScriptTarget.Latest,
+      /* setParentNodes */ true,
+    );
+    const parseDiagnostics =
+      (sourceFile as unknown as { parseDiagnostics: ts.Diagnostic[] })
+        .parseDiagnostics;
+    expect(parseDiagnostics).toHaveLength(0);
+  });
+
   it("generates structs for queries", async () => {
     const helper = createMockMinimalFiles();
     const BASE_PATH = "/foo";

--- a/packages/generator/src/v2.0/generatePerQueryDataFiles.ts
+++ b/packages/generator/src/v2.0/generatePerQueryDataFiles.ts
@@ -33,6 +33,7 @@ import { getInterfaceTypeApiNamesFromQuery } from "../shared/getInterfaceTypeApi
 import { getObjectImports } from "../shared/getObjectImports.js";
 import { getObjectTypeApiNamesFromQuery } from "../shared/getObjectTypeApiNamesFromQuery.js";
 import { deleteUndefineds } from "../util/deleteUndefineds.js";
+import { escapeJsDocText } from "../util/escapeJsDocText.js";
 import { stringify } from "../util/stringify.js";
 import { formatTs } from "../util/test/formatTs.js";
 import { getDescriptionIfPresent } from "./getDescriptionIfPresent.js";
@@ -213,14 +214,14 @@ async function generateV2QueryFile(
             ${getLineFor__OsdkTargetType(ontology, query.output)}
             };
             signature: ${query.shortApiName}.Signature;
-        }, 
+        },
         ${
       stringify(baseProps, {
         "description": () => undefined,
         "displayName": () => undefined,
         "rid": () => undefined,
       })
-    }, 
+    },
           osdkMetadata: typeof $osdkMetadata;
               }
 
@@ -277,7 +278,7 @@ export function queryParamJsDoc(
 
   if (param.description) {
     if (param.description) {
-      ret += ` *   description: ${param.description}\n`;
+      ret += ` *   description: ${escapeJsDocText(param.description)}\n`;
     }
   } else {
     ret += ` * (no ontology metadata)\n`;
@@ -359,7 +360,7 @@ export function getQueryParamType(
         input.threeDimensionalAggregation.valueType.keyType === "range"
           ? `Query${type}.RangeKey<"${input.threeDimensionalAggregation.valueType.keySubtype}">`
           : `"${input.threeDimensionalAggregation.valueType.keyType}"`
-      }, 
+      },
         "${input.threeDimensionalAggregation.valueType.valueType}">`;
       break;
     case "object":

--- a/packages/generator/src/v2.0/getDescriptionIfPresent.ts
+++ b/packages/generator/src/v2.0/getDescriptionIfPresent.ts
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
+import { escapeJsDocText } from "../util/escapeJsDocText.js";
+
 export function getDescriptionIfPresent(
   description?: string,
   includeNewline?: boolean,
 ): string {
   if (description) {
     // Preserve line breaks in multi-line descriptions
-    const lines = description.split("\n");
+    const lines = escapeJsDocText(description).split("\n");
     const formattedLines = lines.map(line => ` * ${line}`).join("\n");
     return `/**
 ${formattedLines}


### PR DESCRIPTION
## Problem

`@osdk/generator` interpolates ontology descriptions and display names verbatim into generated JSDoc block comments. A block comment is terminated by the first `*/` sequence, so when a description contains `*/`, it prematurely closes the comment and leaves the remainder of the text as invalid TypeScript — breaking SDK generation.

This was hit in the wild by a query (pro-code function) parameter whose description contained a `*/` (e.g. text like ``a/*/b``). Generation failed while formatting the generated query file:

```
SyntaxError: Property or signature expected.
  23 |                 /**
> 24 |  *   description: ... (a/*/b) ...
  25 |  */
  26 | readonly "dryRun"?: QueryParam.PrimitiveType<"boolean">,
    at generateV2QueryFile (@osdk/generator/.../generatePerQueryDataFiles.js)
```

## Fix

Add a shared `escapeJsDocText` helper that neutralizes the comment terminator (`*/` → `*\/`, which is also TSDoc-correct, so renderers still show the original text). Apply it at every site that embeds ontology metadata into a generated comment:

- `getDescriptionIfPresent` — query & action descriptions, action parameter descriptions
- `queryParamJsDoc` — query parameter descriptions
- `propertyJsdoc` — object/interface property descriptions, display names, and deprecation message/deadline/replacedBy
- `generatePerActionDataFiles` `jsDocBlock` — action description and `@param` descriptions

Metadata embedded into `__DefinitionMetadata` is unaffected because it already goes through `JSON.stringify` (a `*/` inside a string literal is harmless).

## Tests

- New unit tests for `escapeJsDocText`.
- New regression test in `generatePerQueryDataFiles` that generates a query with a parameter description containing `*/` and asserts the output escapes it and parses with zero TypeScript syntax diagnostics.
- Full `@osdk/generator` suite passes with no snapshot changes (descriptions without `*/` are byte-identical — no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)