### PR TITLE
Added support for actions in function Scope

### DIFF
--- a/.changeset/rotten-mammals-attend.md
+++ b/.changeset/rotten-mammals-attend.md
@@ -1,0 +1,5 @@
+---
+"@osdk/functions": minor
+---
+
+Added support for actions in function Scope

--- a/etc/functions.report.api.md
+++ b/etc/functions.report.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import type { ActionDefinition } from '@osdk/client';
 import { Attachment } from '@osdk/client';
 import type { Client } from '@osdk/client';
 import type { CompileTimeMetadata } from '@osdk/client';

--- a/packages/functions/src/scope/types.ts
+++ b/packages/functions/src/scope/types.ts
@@ -18,12 +18,13 @@ import type {
   InterfaceDefinition,
   ObjectTypeDefinition,
   QueryDefinition,
+  ActionDefinition,
 } from "@osdk/client";
 
 /**
  * Declare which resources a function needs access to.
  *
- * For `objects`, `interfaces` and `queries`, you may provide either:
+ * For `objects`, `interfaces`, `actions` and `queries`, you may provide either:
  * - A string alias from resources.json (e.g. `"myObject"`)
  * - An OSDK type reference imported from your generated ontology SDK (e.g. `Employee`)
  *
@@ -31,6 +32,7 @@ import type {
  */
 export interface ScopeResources {
   queries?: Array<string | QueryDefinition>;
+  actions?: Array<string | ActionDefinition>;
   objects?: Array<string | ObjectTypeDefinition>;
   interfaces?: Array<string | InterfaceDefinition>;
   links?: string[];


### PR DESCRIPTION
actions are new fields that would allow functions to declare these types resources as part of the scope

```tsx
  import { FunctionConfig } from "@osdk/functions";

  export const config: FunctionConfig = {
    scope: {
      resources: { actions: ["actionTypeA"]},
    },
  };
  export function myFunction(): void {}

```

```tsx
  import { FunctionConfig } from "@osdk/functions";
  import { ActionTypeA } from "@ontology/sdk"
  
  export const config: FunctionConfig = {
    scope: {
      resources: { actions: [ActionTypeA]},
    },
  };
  export function myFunction(): void {}

```