### PR TITLE
Make latest-registered mock client stub win

### DIFF
--- a/.changeset/mock-client-latest-stub-wins.md
+++ b/.changeset/mock-client-latest-stub-wins.md
@@ -1,0 +1,5 @@
+---
+"@osdk/unit-testing": patch
+---
+
+Re-registering a mock client stub with the same pattern now overrides the previous stub (latest registered wins) instead of being shadowed by it.

--- a/packages/unit-testing/src/mock/__tests__/createMockClient.test.ts
+++ b/packages/unit-testing/src/mock/__tests__/createMockClient.test.ts
@@ -110,6 +110,32 @@ describe("createMockClient", () => {
       ).rejects.toThrow();
     });
 
+    it("re-registering the same pattern overrides the previous stub", async () => {
+      const mockClient = createMockClient();
+      const emp = createMockOsdkObject(Employee, { employeeId: 1 });
+
+      mockClient
+        .when((c) =>
+          c(Employee)
+            .where({ office: { $eq: "NYC" } })
+            .fetchPage()
+        )
+        .thenReturnObjects([]);
+      mockClient
+        .when((c) =>
+          c(Employee)
+            .where({ office: { $eq: "NYC" } })
+            .fetchPage()
+        )
+        .thenReturnObjects([emp]);
+
+      const result = await mockClient(Employee)
+        .where({ office: { $eq: "NYC" } })
+        .fetchPage();
+
+      expect(result.data).toHaveLength(1);
+    });
+
     it("types: when((c) => c(T).fetchPage()) → FetchPageStubBuilder", () => {
       const mockClient = createMockClient();
       const builder = mockClient.when((c) => c(Employee).fetchPage());

--- a/packages/unit-testing/src/mock/createMockClient.ts
+++ b/packages/unit-testing/src/mock/createMockClient.ts
@@ -75,7 +75,8 @@ export function createMockClient(): MockClient {
     );
 
   const resolveQuery = (queryApiName: string, params: unknown): unknown => {
-    for (const stub of queryStubs) {
+    for (let i = queryStubs.length - 1; i >= 0; i--) {
+      const stub = queryStubs[i];
       if (stub.queryApiName !== queryApiName) continue;
       if (deepEqual(stub.params, params)) {
         if (stub.error !== undefined) {

--- a/packages/unit-testing/src/mock/createMockObjectSetWithResolver.ts
+++ b/packages/unit-testing/src/mock/createMockObjectSetWithResolver.ts
@@ -117,7 +117,8 @@ export function resolveStub(
   calls: Call[],
   errorMsg: string
 ): unknown {
-  for (const stub of stubs) {
+  for (let s = stubs.length - 1; s >= 0; s--) {
+    const stub = stubs[s];
     if (stub.calls.length !== calls.length) continue;
     if (
       stub.calls.every(


### PR DESCRIPTION
## Summary

Re-registering a mock client stub with the same pattern now **overrides** the previous stub (latest registered wins) instead of being silently shadowed by the first one.

Previously, `stubs` were stored in an array and resolution walked it front-to-back returning the first match. So calling `.when(...).thenReturnObjects(...)` twice with the same pattern appended a second stub that was never reached — the original value always won. This surprised users who expected re-stubbing to update the return value (and forced them to `clearStubs()`, which wipes *every* stub).

Now both resolution loops (`resolveStub` for object sets, `resolveQuery` for queries) iterate newest-first, so the most recently registered matching stub wins.

## Changes
- `resolveStub` iterates stubs newest-first
- `resolveQuery` iterates query stubs newest-first
- Regression test: re-registering the same pattern overrides the previous stub
- Changeset (`@osdk/unit-testing`: patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)