### PR TITLE
add experimental hydrate osdk object

### DIFF
--- a/.changeset/hydrate-osdk-object.md
+++ b/.changeset/hydrate-osdk-object.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": minor
+---
+
+Add unstable `hydrateOsdkObject` helper to hydrate raw wire objects into OSDK object instances using a caller-supplied map of object definitions.

--- a/packages/client/src/object/convertWireToOsdkObjects.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.ts
@@ -69,7 +69,8 @@ export async function convertWireToOsdkObjects(
   interfaceToObjectTypeMappingsV2?: Record<
     InterfaceTypeApiName,
     InterfaceToObjectTypeMappingsV2
-  >
+  >,
+  objectDefsByApiName?: Record<string, ObjectMetadata>
 ): Promise<Array<InterfaceHolder>>;
 export async function convertWireToOsdkObjects(
   client: MinimalClient,
@@ -87,7 +88,8 @@ export async function convertWireToOsdkObjects(
   interfaceToObjectTypeMappingsV2?: Record<
     InterfaceTypeApiName,
     InterfaceToObjectTypeMappingsV2
-  >
+  >,
+  objectDefsByApiName?: Record<string, ObjectMetadata>
 ): Promise<Array<ObjectHolder>>;
 export async function convertWireToOsdkObjects(
   client: MinimalClient,
@@ -105,7 +107,8 @@ export async function convertWireToOsdkObjects(
   interfaceToObjectTypeMappingsV2?: Record<
     InterfaceTypeApiName,
     InterfaceToObjectTypeMappingsV2
-  >
+  >,
+  objectDefsByApiName?: Record<string, ObjectMetadata>
 ): Promise<Array<ObjectHolder | InterfaceHolder>>;
 /**
  * @internal
@@ -126,7 +129,8 @@ export async function convertWireToOsdkObjects(
   interfaceToObjectTypeMappingsV2: Record<
     InterfaceTypeApiName,
     InterfaceToObjectTypeMappingsV2
-  > = {}
+  > = {},
+  objectDefsByApiName?: Record<string, ObjectMetadata>
 ): Promise<Array<ObjectHolder | InterfaceHolder>> {
   fixObjectPropertiesInPlace(objects, forceRemoveRid);
 
@@ -141,9 +145,15 @@ export async function convertWireToOsdkObjects(
   const isInterfaceScoped = Object.keys(effectiveMappings).length > 0;
   const ret = [];
   for (const rawObj of objects) {
-    const objectDef = await client.ontologyProvider.getObjectDefinition(
-      rawObj.$apiName
-    );
+    // If caller supplied object definitions, use them exclusively instead of
+    // hitting the ontology provider - a missing entry is an error rather than a
+    // fallback. Only when no map is provided do we defer to the provider, so
+    // existing behavior is preserved.
+    const objectDef = (
+      objectDefsByApiName != null
+        ? objectDefsByApiName[rawObj.$apiName]
+        : await client.ontologyProvider.getObjectDefinition(rawObj.$apiName)
+    ) as FetchedObjectTypeDefinition;
     invariant(objectDef, `Missing definition for '${rawObj.$apiName}'`);
 
     const interfaceToObjMapping =

--- a/packages/client/src/object/hydrateOsdkObject.ts
+++ b/packages/client/src/object/hydrateOsdkObject.ts
@@ -34,12 +34,13 @@ import { convertWireToOsdkObjects } from "./convertWireToOsdkObjects.js";
  * throws. When the map is omitted, definitions are resolved via the ontology
  * provider.
  *
+ * Unstable API. Do not depend on this outside of experimental usage.
+ *
  * @param client - the OSDK client
  * @param objects - the raw wire objects to hydrate
  * @param objectDefsByApiName - optional map of object type api name to its
  * definition. When provided, every object's api name must be present.
  * @param propertySecurities - optional property securities for the objects
- *
  */
 export function hydrateOsdkObject(
   client: Client,

--- a/packages/client/src/object/hydrateOsdkObject.ts
+++ b/packages/client/src/object/hydrateOsdkObject.ts
@@ -25,14 +25,13 @@ import { additionalContext } from "../Client.js";
 import { convertWireToOsdkObjects } from "./convertWireToOsdkObjects.js";
 
 /**
- * Hydrates raw wire objects into OSDK object instances without going through a
- * network fetch.
+ * Hydrates raw wire objects into OSDK object instances.
  *
  * When supplied, the `objectDefsByApiName` map (object type api name -> object
  * definition) is used exclusively to resolve each object's type, avoiding calls
  * to the ontology provider; an object whose api name is missing from the map
  * throws. When the map is omitted, definitions are resolved via the ontology
- * provider.
+ * provider network call.
  *
  * Unstable API. Do not depend on this outside of experimental usage.
  *

--- a/packages/client/src/object/hydrateOsdkObject.ts
+++ b/packages/client/src/object/hydrateOsdkObject.ts
@@ -24,6 +24,7 @@ import type { Client } from "../Client.js";
 import { additionalContext } from "../Client.js";
 import { convertWireToOsdkObjects } from "./convertWireToOsdkObjects.js";
 
+// oxlint-disable-next-line require-await -- intentionally async
 /**
  * Hydrates raw wire objects into OSDK object instances.
  *

--- a/packages/client/src/object/hydrateOsdkObject.ts
+++ b/packages/client/src/object/hydrateOsdkObject.ts
@@ -24,7 +24,6 @@ import type { Client } from "../Client.js";
 import { additionalContext } from "../Client.js";
 import { convertWireToOsdkObjects } from "./convertWireToOsdkObjects.js";
 
-// oxlint-disable-next-line require-await -- intentionally async
 /**
  * Hydrates raw wire objects into OSDK object instances.
  *
@@ -42,6 +41,7 @@ import { convertWireToOsdkObjects } from "./convertWireToOsdkObjects.js";
  * definition. When provided, every object's api name must be present.
  * @param propertySecurities - optional property securities for the objects
  */
+// oxlint-disable-next-line require-await -- intentionally async
 export async function hydrateOsdkObject(
   client: Client,
   objects: OntologyObjectV2[],

--- a/packages/client/src/object/hydrateOsdkObject.ts
+++ b/packages/client/src/object/hydrateOsdkObject.ts
@@ -42,7 +42,7 @@ import { convertWireToOsdkObjects } from "./convertWireToOsdkObjects.js";
  * definition. When provided, every object's api name must be present.
  * @param propertySecurities - optional property securities for the objects
  */
-export function hydrateOsdkObject(
+export async function hydrateOsdkObject(
   client: Client,
   objects: OntologyObjectV2[],
   objectDefsByApiName?: Record<string, ObjectMetadata>,

--- a/packages/client/src/object/hydrateOsdkObject.ts
+++ b/packages/client/src/object/hydrateOsdkObject.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectMetadata, Osdk } from "@osdk/api";
+import type {
+  OntologyObjectV2,
+  PropertySecurities,
+} from "@osdk/foundry.ontologies";
+
+import type { Client } from "../Client.js";
+import { additionalContext } from "../Client.js";
+import { convertWireToOsdkObjects } from "./convertWireToOsdkObjects.js";
+
+/**
+ * Hydrates raw wire objects into OSDK object instances without going through a
+ * network fetch.
+ *
+ * When supplied, the `objectDefsByApiName` map (object type api name -> object
+ * definition) is used exclusively to resolve each object's type, avoiding calls
+ * to the ontology provider; an object whose api name is missing from the map
+ * throws. When the map is omitted, definitions are resolved via the ontology
+ * provider.
+ *
+ * @param client - the OSDK client
+ * @param objects - the raw wire objects to hydrate
+ * @param objectDefsByApiName - optional map of object type api name to its
+ * definition. When provided, every object's api name must be present.
+ * @param propertySecurities - optional property securities for the objects
+ *
+ * @internal Unstable API. Do not depend on this outside of experimental usage.
+ */
+export function hydrateOsdkObject(
+  client: Client,
+  objects: OntologyObjectV2[],
+  objectDefsByApiName?: Record<string, ObjectMetadata>,
+  propertySecurities?: PropertySecurities[]
+): Promise<Array<Osdk.Instance<any>>> {
+  return convertWireToOsdkObjects(
+    client[additionalContext],
+    objects,
+    /* interfaceApiName */ undefined,
+    /* derivedPropertyTypeByName */ {},
+    propertySecurities,
+    /* forceRemoveRid */ undefined,
+    /* selectedProps */ undefined,
+    /* strictNonNull */ undefined,
+    /* interfaceToObjectTypeMappings */ undefined,
+    /* interfaceToObjectTypeMappingsV2 */ undefined,
+    objectDefsByApiName
+  ) as unknown as Promise<Array<Osdk.Instance<any>>>;
+}

--- a/packages/client/src/object/hydrateOsdkObject.ts
+++ b/packages/client/src/object/hydrateOsdkObject.ts
@@ -40,7 +40,6 @@ import { convertWireToOsdkObjects } from "./convertWireToOsdkObjects.js";
  * definition. When provided, every object's api name must be present.
  * @param propertySecurities - optional property securities for the objects
  *
- * @internal Unstable API. Do not depend on this outside of experimental usage.
  */
 export function hydrateOsdkObject(
   client: Client,

--- a/packages/client/src/public/unstable-do-not-use.ts
+++ b/packages/client/src/public/unstable-do-not-use.ts
@@ -15,6 +15,7 @@
  */
 
 export { augment } from "../object/fetchPage.js";
+export { hydrateOsdkObject } from "../object/hydrateOsdkObject.js";
 export { getWireObjectSet, isObjectSet } from "../objectSet/createObjectSet.js";
 
 export {


### PR DESCRIPTION
Adds an experimental hydrate osdk object method. This does not work for interface or objects defined with RDPs as of now