### PR TITLE
Fix pagination in asyncIterLinks

### DIFF
--- a/.changeset/public-grapes-post.md
+++ b/.changeset/public-grapes-post.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Pipe next page token through to PSDK loadLinks call in asyncIterLinks

--- a/packages/client/src/objectSet/createObjectSet.ts
+++ b/packages/client/src/objectSet/createObjectSet.ts
@@ -334,7 +334,8 @@ export function createObjectSet<Q extends ObjectOrInterfaceDefinition>(
           })),
           objectType,
           objectSet,
-          links
+          links,
+          $nextPageToken
         );
         $nextPageToken = result.nextPageToken;
 

--- a/packages/client/src/objectSet/fetchLinksPage.ts
+++ b/packages/client/src/objectSet/fetchLinksPage.ts
@@ -37,7 +37,8 @@ export const fetchLinksPage = async <
   client: MinimalClient,
   objectType: Q,
   objectSet: ObjectSet,
-  links: LINK_TYPES[]
+  links: LINK_TYPES[],
+  pageToken: string | undefined
 ): Promise<FetchLinksPageResult<Q, LINK_TYPES>> => {
   if (objectType.type === "interface") {
     throw new Error("Interface object sets are not supported yet.");
@@ -53,6 +54,7 @@ export const fetchLinksPage = async <
     {
       objectSet,
       links,
+      pageToken,
     },
     { branch: client.branch, preview: true }
   );


### PR DESCRIPTION
I had forgotten to pass the received `pageToken` back into the next `loadLinks` PSDK call. This means that for object sets > 1000 items in size, the method would never finish loading links. We unfortunately didn't catch this in testing because I had only tested with object sets larger than 5000 items (the limit at the time) using PSDK when I was writing the endpoint. E2E through the OSDK I used a different object type with more types of links but fewer instances.