### PR TITLE
Expose headless hooks for Excel, Email, and TIFF document viewers

### DIFF
--- a/.changeset/document-viewer-headless-hooks.md
+++ b/.changeset/document-viewer-headless-hooks.md
@@ -2,4 +2,4 @@
 "@osdk/react-components": minor
 ---
 
-Expose headless hooks for the Excel, Email, and TIFF document-viewer renderers (`useExcelViewerState`, `useEmailViewerState`, `useTiffRenderer`) so consumers can build custom UI on the same logic, matching the existing PdfViewer pattern.
+Expose headless hooks for the Excel, Email, and TIFF document-viewer renderers (`useExcelViewerState`, `useEmailViewerState`, `useTiffRenderer`) so consumers can build their own UI on the same logic, matching the existing PdfViewer pattern. Each hook takes the raw media bytes and parses/decodes them internally, and `BaseExcelViewer` / `BaseEmailViewer` now accept `content` (raw bytes) instead of pre-parsed data.

--- a/.changeset/document-viewer-headless-hooks.md
+++ b/.changeset/document-viewer-headless-hooks.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+Expose headless hooks for the Excel, Email, and TIFF document-viewer renderers (`useExcelViewerState`, `useEmailViewerState`, `useTiffRenderer`) so consumers can build custom UI on the same logic, matching the existing PdfViewer pattern.

--- a/packages/e2e.sandbox.peopleapp/src/App.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/App.tsx
@@ -19,7 +19,9 @@ function PeopleApp() {
             ? "form"
             : path === "/aip-agent-chat"
               ? "aip-agent-chat"
-              : "offices";
+              : path === "/media-viewers"
+                ? "media-viewers"
+                : "offices";
 
   return (
     <main className="flex min-h-screen flex-col items-center p-24">
@@ -67,6 +69,13 @@ function PeopleApp() {
           onClick={() => navigate("/aip-agent-chat")}
         >
           AipAgentChat
+        </Button>
+        <Button
+          variant="tab"
+          active={activeTab === "media-viewers"}
+          onClick={() => navigate("/media-viewers")}
+        >
+          Media Viewers
         </Button>
       </div>
 

--- a/packages/e2e.sandbox.peopleapp/src/app/media-viewers/CustomEmailViewer.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/media-viewers/CustomEmailViewer.tsx
@@ -1,0 +1,103 @@
+import type { Media } from "@osdk/api";
+import { useEmailViewerState } from "@osdk/react-components/experimental/email-viewer";
+import React from "react";
+
+import { useMediaBytes } from "./useMediaBytes.js";
+
+interface CustomEmailViewerProps {
+  /** A media property (e.g. `employee.employeeDocuments`) holding an .eml file. */
+  media: Media;
+}
+
+/*
+ * Fully custom (headless) email viewer:
+ *
+ *   useMediaBytes         fetches the media's bytes in the page (our own fetch)
+ *   useEmailViewerState   parses those bytes and derives body mode + addresses
+ *
+ * Renders a compact "card" layout instead of the shipped `BaseEmailViewer`.
+ */
+export function CustomEmailViewer({
+  media,
+}: CustomEmailViewerProps): React.ReactElement {
+  const { data, loading, error } = useMediaBytes(media);
+
+  return (
+    <div className="w-full">
+      {loading && (
+        <div className="text-sm italic text-gray-500">Loading email…</div>
+      )}
+      {error != null && (
+        <div className="text-sm text-red-600">
+          Failed to load: {error.message}
+        </div>
+      )}
+      {data != null && <EmailCard content={data} />}
+    </div>
+  );
+}
+
+function EmailCard({ content }: { content: ArrayBuffer }): React.ReactElement {
+  const {
+    loading,
+    error,
+    email,
+    bodyMode,
+    formattedFrom,
+    formattedTo,
+    formattedCc,
+  } = useEmailViewerState({ content });
+
+  if (loading) {
+    return <div className="text-sm italic text-gray-500">Parsing email…</div>;
+  }
+  if (error != null) {
+    return (
+      <div className="text-sm text-red-600">
+        Could not parse as an email: {error.message}
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded border border-gray-200 p-3 text-sm">
+      {email?.subject != null && (
+        <div className="font-semibold text-base mb-1">{email.subject}</div>
+      )}
+      <dl className="grid grid-cols-[3rem_1fr] gap-x-2 text-gray-700 mb-2">
+        {formattedFrom != null && (
+          <>
+            <dt className="text-gray-400">From</dt>
+            <dd>{formattedFrom}</dd>
+          </>
+        )}
+        {email != null && email.to.length > 0 && (
+          <>
+            <dt className="text-gray-400">To</dt>
+            <dd>{formattedTo}</dd>
+          </>
+        )}
+        {email != null && email.cc.length > 0 && (
+          <>
+            <dt className="text-gray-400">Cc</dt>
+            <dd>{formattedCc}</dd>
+          </>
+        )}
+      </dl>
+      {bodyMode === "html" && (
+        <iframe
+          className="w-full h-64 border border-gray-100"
+          sandbox="allow-same-origin"
+          srcDoc={email?.html}
+          title="Email body"
+        />
+      )}
+      {bodyMode === "text" && (
+        <pre className="whitespace-pre-wrap font-sans">{email?.text}</pre>
+      )}
+      {bodyMode === "empty" && (
+        <div className="italic text-gray-400">No content</div>
+      )}
+    </div>
+  );
+}

--- a/packages/e2e.sandbox.peopleapp/src/app/media-viewers/CustomExcelViewer.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/media-viewers/CustomExcelViewer.tsx
@@ -1,0 +1,98 @@
+import type { Media } from "@osdk/api";
+import { useExcelViewerState } from "@osdk/react-components/experimental/excel-viewer";
+import React from "react";
+
+import { useMediaBytes } from "./useMediaBytes.js";
+
+interface CustomExcelViewerProps {
+  /** A media property (e.g. `employee.employeeDocuments`) holding an .xlsx file. */
+  media: Media;
+}
+
+/*
+ * Fully custom (headless) spreadsheet viewer:
+ *
+ *   useMediaBytes         fetches the media's bytes in the page (our own fetch)
+ *   useExcelViewerState   parses those bytes and owns the active-sheet state
+ *
+ * The markup is entirely bespoke (a vertical sheet rail + a bare grid) instead
+ * of the shipped `BaseExcelViewer`, showing a consumer can build their own UI
+ * on the hook.
+ */
+export function CustomExcelViewer({
+  media,
+}: CustomExcelViewerProps): React.ReactElement {
+  const { data, loading, error } = useMediaBytes(media);
+
+  return (
+    <div className="w-full">
+      {loading && (
+        <div className="text-sm italic text-gray-500">Loading spreadsheet…</div>
+      )}
+      {error != null && (
+        <div className="text-sm text-red-600">
+          Failed to load: {error.message}
+        </div>
+      )}
+      {data != null && <SpreadsheetView content={data} />}
+    </div>
+  );
+}
+
+function SpreadsheetView({
+  content,
+}: {
+  content: ArrayBuffer;
+}): React.ReactElement {
+  const { error, sheets, activeSheetIndex, activeSheet, selectSheet } =
+    useExcelViewerState({ content });
+
+  if (error != null) {
+    return (
+      <div className="text-sm text-red-600">
+        Could not parse as a spreadsheet: {error.message}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex gap-3">
+      <ul className="list-none w-40 shrink-0 border-r border-gray-200 pr-2">
+        {sheets.map((sheet, index) => (
+          <li key={sheet.name}>
+            <button
+              type="button"
+              onClick={() => selectSheet(index)}
+              className={`w-full text-left px-2 py-1 rounded text-sm ${
+                index === activeSheetIndex
+                  ? "bg-blue-100 font-semibold"
+                  : "hover:bg-gray-100"
+              }`}
+            >
+              {sheet.name}
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div className="grow overflow-auto">
+        {activeSheet != null ? (
+          <table className="border-collapse text-left text-sm">
+            <tbody>
+              {activeSheet.rows.map((row, rowIndex) => (
+                <tr key={rowIndex} className="border-b border-gray-100">
+                  {row.map((cell, cellIndex) => (
+                    <td key={cellIndex} className="py-1 px-2 whitespace-nowrap">
+                      {cell}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <div className="text-sm italic text-gray-500">No sheets</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/e2e.sandbox.peopleapp/src/app/media-viewers/CustomTiffViewer.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/media-viewers/CustomTiffViewer.tsx
@@ -1,0 +1,81 @@
+import type { Media } from "@osdk/api";
+import { useTiffRenderer } from "@osdk/react-components/experimental/tiff-renderer";
+import React, { useCallback, useMemo } from "react";
+
+import { useMediaBytes } from "./useMediaBytes.js";
+
+interface CustomTiffViewerProps {
+  /** A media property (e.g. `employee.employeeMedia`) holding a .tiff image. */
+  media: Media;
+}
+
+/*
+ * Fully custom (headless) TIFF viewer:
+ *
+ *   useMediaBytes     fetches the media's bytes in the page (our own fetch)
+ *   useTiffRenderer   decodes the bytes to RGBA + tracks the decode result
+ *
+ * Rendering (a <canvas> plus a dimensions caption) is entirely bespoke here
+ * rather than using the shipped `TiffRenderer` component.
+ */
+export function CustomTiffViewer({
+  media,
+}: CustomTiffViewerProps): React.ReactElement {
+  const { data, loading, error } = useMediaBytes(media);
+
+  return (
+    <div className="w-full">
+      {loading && (
+        <div className="text-sm italic text-gray-500">Loading image…</div>
+      )}
+      {error != null && (
+        <div className="text-sm text-red-600">
+          Failed to load: {error.message}
+        </div>
+      )}
+      {data != null && <TiffCanvas content={data} />}
+    </div>
+  );
+}
+
+function TiffCanvas({ content }: { content: ArrayBuffer }): React.ReactElement {
+  const bytes = useMemo(() => new Uint8Array(content), [content]);
+  const { result } = useTiffRenderer({ content: bytes });
+
+  const canvasRef = useCallback(
+    (canvas: HTMLCanvasElement | null) => {
+      if (canvas == null || result == null || result.status !== "ok") {
+        return;
+      }
+      const ctx = canvas.getContext("2d");
+      if (ctx == null) {
+        return;
+      }
+      const image = ctx.createImageData(result.data.width, result.data.height);
+      image.data.set(result.data.content);
+      ctx.putImageData(image, 0, 0);
+    },
+    [result]
+  );
+
+  if (result == null) {
+    return <div className="text-sm italic text-gray-500">Decoding…</div>;
+  }
+  if (result.status === "error") {
+    return <div className="text-sm text-red-600">{result.message}</div>;
+  }
+
+  return (
+    <figure className="m-0">
+      <canvas
+        ref={canvasRef}
+        width={result.data.width}
+        height={result.data.height}
+        className="max-w-full border border-gray-200"
+      />
+      <figcaption className="text-xs text-gray-400 mt-1">
+        {result.data.width} × {result.data.height}px
+      </figcaption>
+    </figure>
+  );
+}

--- a/packages/e2e.sandbox.peopleapp/src/app/media-viewers/CustomTiffViewer.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/media-viewers/CustomTiffViewer.tsx
@@ -44,7 +44,7 @@ function TiffCanvas({ content }: { content: ArrayBuffer }): React.ReactElement {
 
   const canvasRef = useCallback(
     (canvas: HTMLCanvasElement | null) => {
-      if (canvas == null || result == null || result.status !== "ok") {
+      if (canvas == null || result.status !== "ok") {
         return;
       }
       const ctx = canvas.getContext("2d");
@@ -58,9 +58,6 @@ function TiffCanvas({ content }: { content: ArrayBuffer }): React.ReactElement {
     [result]
   );
 
-  if (result == null) {
-    return <div className="text-sm italic text-gray-500">Decoding…</div>;
-  }
   if (result.status === "error") {
     return <div className="text-sm text-red-600">{result.message}</div>;
   }

--- a/packages/e2e.sandbox.peopleapp/src/app/media-viewers/page.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/media-viewers/page.tsx
@@ -1,0 +1,116 @@
+import { useOsdkObjects } from "@osdk/react";
+import { useCallback, useMemo, useState } from "react";
+
+import { H2 } from "../../components/headers.js";
+import { Section } from "../../components/Section.js";
+import { Employee } from "../../generatedNoCheck2/index.js";
+import { CustomEmailViewer } from "./CustomEmailViewer.js";
+import { CustomExcelViewer } from "./CustomExcelViewer.js";
+import { CustomTiffViewer } from "./CustomTiffViewer.js";
+
+/*
+ * Demonstrates building fully custom (headless) viewers from the hooks exported
+ * by `@osdk/react-components/experimental/{excel-viewer,email-viewer,tiff-renderer}`.
+ * Each card fetches a real Employee media property's bytes in the page (via the
+ * local `useMediaBytes` hook) and hands them to a viewer hook, which parses /
+ * decodes the bytes and drives a bespoke UI instead of the shipped components.
+ *
+ * Note: whether a given media property is actually an .xlsx / .eml / .tiff
+ * depends on your ontology data, so mismatched files surface a parse error —
+ * that is expected and shows each viewer's error handling.
+ */
+export function MediaViewersPage(): React.ReactElement {
+  const { data: employees, isLoading, error } = useOsdkObjects(Employee, {});
+
+  const [selectedPk, setSelectedPk] = useState<string | undefined>(undefined);
+
+  const selected = useMemo(
+    () => employees?.find((e) => String(e.$primaryKey) === selectedPk),
+    [employees, selectedPk]
+  );
+
+  // Memoize the media references so the child fetch hooks don't refetch on
+  // every render.
+  const documentsMedia = useMemo(() => selected?.employeeDocuments, [selected]);
+  const imageMedia = useMemo(() => selected?.employeeMedia, [selected]);
+
+  const onSelectChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      setSelectedPk(event.target.value === "" ? undefined : event.target.value);
+    },
+    []
+  );
+
+  return (
+    <div className="flex flex-col w-full max-w-3xl text-left">
+      <H2>Headless media viewers</H2>
+      <p className="text-sm text-gray-600 mb-3">
+        Custom UIs built directly on <code>useExcelViewerState</code>,{" "}
+        <code>useEmailViewerState</code>, and <code>useTiffRenderer</code>, fed
+        by bytes we fetch in the page.
+      </p>
+
+      <div className="mb-4">
+        <label htmlFor="media-viewer-employee" className="text-sm mr-2">
+          Employee:
+        </label>
+        <select
+          id="media-viewer-employee"
+          className="border border-gray-300 rounded px-2 py-1 text-sm"
+          value={selectedPk ?? ""}
+          onChange={onSelectChange}
+        >
+          <option value="">
+            {isLoading ? "Loading employees…" : "Select an employee…"}
+          </option>
+          {employees?.map((employee) => (
+            <option
+              key={String(employee.$primaryKey)}
+              value={String(employee.$primaryKey)}
+            >
+              {employee.fullName ?? String(employee.$primaryKey)}
+            </option>
+          ))}
+        </select>
+        {error != null && (
+          <span className="text-sm text-red-600 ml-2">
+            Failed to load employees: {error.message}
+          </span>
+        )}
+      </div>
+
+      <Section>
+        <H2>Excel (useExcelViewerState)</H2>
+        {documentsMedia != null ? (
+          <CustomExcelViewer media={documentsMedia} />
+        ) : (
+          <div className="text-sm italic text-gray-500">
+            Select an employee with an <code>employeeDocuments</code> file.
+          </div>
+        )}
+      </Section>
+
+      <Section>
+        <H2>Email (useEmailViewerState)</H2>
+        {documentsMedia != null ? (
+          <CustomEmailViewer media={documentsMedia} />
+        ) : (
+          <div className="text-sm italic text-gray-500">
+            Select an employee with an <code>employeeDocuments</code> file.
+          </div>
+        )}
+      </Section>
+
+      <Section>
+        <H2>TIFF (useTiffRenderer)</H2>
+        {imageMedia != null ? (
+          <CustomTiffViewer media={imageMedia} />
+        ) : (
+          <div className="text-sm italic text-gray-500">
+            Select an employee with an <code>employeeMedia</code> image.
+          </div>
+        )}
+      </Section>
+    </div>
+  );
+}

--- a/packages/e2e.sandbox.peopleapp/src/app/media-viewers/useMediaBytes.ts
+++ b/packages/e2e.sandbox.peopleapp/src/app/media-viewers/useMediaBytes.ts
@@ -1,0 +1,50 @@
+import type { Media } from "@osdk/api";
+import { useEffect, useState } from "react";
+
+export interface UseMediaBytesResult {
+  data: ArrayBuffer | undefined;
+  loading: boolean;
+  error: Error | undefined;
+}
+
+/*
+ * Fetches the raw bytes of an OSDK Media object in the page — the same "fetch
+ * your own data" role that `useObjectTableData` plays for the custom table
+ * example. The bytes are then handed to the viewer hooks, which parse/decode
+ * them internally. Kept local to the sandbox on purpose: it shows a consumer
+ * doing the fetch themselves, using only the public OSDK `Media` API.
+ */
+export function useMediaBytes(media: Media): UseMediaBytesResult {
+  const [data, setData] = useState<ArrayBuffer | undefined>(undefined);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | undefined>(undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(undefined);
+    setData(undefined);
+
+    media
+      .fetchContents()
+      .then((response) => response.arrayBuffer())
+      .then((buffer) => {
+        if (!cancelled) {
+          setData(buffer);
+          setLoading(false);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err : new Error(String(err)));
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [media]);
+
+  return { data, loading, error };
+}

--- a/packages/e2e.sandbox.peopleapp/src/router.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/router.tsx
@@ -7,6 +7,7 @@ import { AuthCallbackPage } from "./app/auth/callback/page.js";
 import { EmployeesFilterListPage } from "./app/employees/filterListPage.js";
 import { EmployeesPage } from "./app/employees/page.js";
 import { FormPage } from "./app/form/page.js";
+import { MediaViewersPage } from "./app/media-viewers/page.js";
 import { OfficesPage } from "./app/offices/page.js";
 
 const router = createBrowserRouter([
@@ -47,6 +48,10 @@ const router = createBrowserRouter([
       {
         path: "/aip-agent-chat",
         element: <AipAgentChatPage />,
+      },
+      {
+        path: "/media-viewers",
+        element: <MediaViewersPage />,
       },
     ],
   },

--- a/packages/monorepo.cspell/dict.osdk-code.txt
+++ b/packages/monorepo.cspell/dict.osdk-code.txt
@@ -35,6 +35,7 @@ groupby
 Gtfs
 highbury
 IDPS
+ifds
 Kaguinaldo
 Kelce
 LISTOGRAM

--- a/packages/react-components-storybook/src/stories/EmailViewer/EmailViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/EmailViewer/EmailViewer.stories.tsx
@@ -18,7 +18,6 @@ import type { Media } from "@osdk/api";
 import type {
   BaseEmailViewerProps,
   EmailViewerMediaProps,
-  ParsedEmail,
 } from "@osdk/react-components/experimental/email-viewer";
 import {
   BaseEmailViewer,
@@ -26,50 +25,54 @@ import {
 } from "@osdk/react-components/experimental/email-viewer";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-const SAMPLE_EMAIL: ParsedEmail = {
-  subject: "Q3 Project Update - Action Items",
-  from: { name: "Alice Johnson", address: "alice@example.com" },
-  to: [
-    { name: "Bob Smith", address: "bob@example.com" },
-    { name: "Carol Davis", address: "carol@example.com" },
-  ],
-  cc: [{ name: "Dave Wilson", address: "dave@example.com" }],
-  date: "2026-03-15T14:30:00Z",
-  html: `
-    <div style="font-family: Arial, sans-serif; padding: 16px;">
-      <p>Hi team,</p>
-      <p>Here's a quick update on our Q3 project milestones:</p>
-      <ul>
-        <li><strong>Phase 1</strong> — Completed on schedule</li>
-        <li><strong>Phase 2</strong> — In progress, 80% done</li>
-        <li><strong>Phase 3</strong> — Starting next week</li>
-      </ul>
-      <p>Please review the attached documents and respond by Friday.</p>
-      <p>Best regards,<br/>Alice</p>
-    </div>
-  `,
-  text: undefined,
-};
-
-const SAMPLE_TEXT_EMAIL: ParsedEmail = {
-  subject: "Meeting Notes",
-  from: { name: "Bob Smith", address: "bob@example.com" },
-  to: [{ name: "Alice Johnson", address: "alice@example.com" }],
-  cc: [],
-  date: "2026-03-16T09:00:00Z",
-  html: undefined,
-  text: "Hi Alice,\n\nHere are the meeting notes from today:\n\n1. Discussed budget allocation\n2. Reviewed timeline\n3. Assigned action items\n\nThanks,\nBob",
-};
-
-const SAMPLE_EML_CONTENT = `From: Alice Johnson <alice@example.com>
-To: Bob Smith <bob@example.com>
-Subject: Test Email
-Date: Sat, 15 Mar 2026 14:30:00 +0000
+const SAMPLE_HTML_EML = `From: Alice Johnson <alice@example.com>
+To: Bob Smith <bob@example.com>, Carol Davis <carol@example.com>
+Cc: Dave Wilson <dave@example.com>
+Subject: Q3 Project Update - Action Items
+Date: Sun, 15 Mar 2026 14:30:00 +0000
 MIME-Version: 1.0
 Content-Type: text/html; charset=utf-8
 
-<html><body><p>Hello Bob!</p><p>This is a <strong>test email</strong>.</p></body></html>
+<div style="font-family: Arial, sans-serif; padding: 16px;">
+  <p>Hi team,</p>
+  <p>Here's a quick update on our Q3 project milestones:</p>
+  <ul>
+    <li><strong>Phase 1</strong> — Completed on schedule</li>
+    <li><strong>Phase 2</strong> — In progress, 80% done</li>
+    <li><strong>Phase 3</strong> — Starting next week</li>
+  </ul>
+  <p>Please review the attached documents and respond by Friday.</p>
+  <p>Best regards,<br/>Alice</p>
+</div>
 `;
+
+const SAMPLE_TEXT_EML = `From: Bob Smith <bob@example.com>
+To: Alice Johnson <alice@example.com>
+Subject: Meeting Notes
+Date: Mon, 16 Mar 2026 09:00:00 +0000
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+
+Hi Alice,
+
+Here are the meeting notes from today:
+
+1. Discussed budget allocation
+2. Reviewed timeline
+3. Assigned action items
+
+Thanks,
+Bob
+`;
+
+/** Encodes a raw .eml string into the ArrayBuffer the Base component expects. */
+function emlToArrayBuffer(eml: string): ArrayBuffer {
+  const bytes = new TextEncoder().encode(eml);
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength
+  );
+}
 
 function createMockEmailMedia(emlContent: string): Media {
   return {
@@ -99,7 +102,7 @@ const meta: Meta<BaseEmailViewerProps> = {
   component: BaseEmailViewer,
   tags: ["beta"],
   args: {
-    email: SAMPLE_EMAIL,
+    content: emlToArrayBuffer(SAMPLE_HTML_EML),
   },
   render: (args: BaseEmailViewerProps) => (
     <div style={{ height: "500px" }}>
@@ -110,8 +113,8 @@ const meta: Meta<BaseEmailViewerProps> = {
     controls: { expanded: true },
   },
   argTypes: {
-    email: {
-      description: "Parsed email data",
+    content: {
+      description: "Raw .eml bytes to parse and display",
       control: false,
     },
     className: {
@@ -126,7 +129,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: StoryObj<EmailViewerMediaProps> = {
   args: {
-    media: createMockEmailMedia(SAMPLE_EML_CONTENT),
+    media: createMockEmailMedia(SAMPLE_HTML_EML),
   },
   render: (args: EmailViewerMediaProps) => (
     <div style={{ height: "500px" }}>
@@ -150,7 +153,8 @@ export const HtmlEmail: Story = {
       source: {
         code: `import { BaseEmailViewer } from "@osdk/react-components/experimental/email-viewer";
 
-<BaseEmailViewer email={parsedEmail} />`,
+// content is raw .eml bytes (e.g. from media.fetchContents())
+<BaseEmailViewer content={emlBytes} />`,
       },
     },
   },
@@ -158,6 +162,6 @@ export const HtmlEmail: Story = {
 
 export const PlainTextEmail: Story = {
   args: {
-    email: SAMPLE_TEXT_EMAIL,
+    content: emlToArrayBuffer(SAMPLE_TEXT_EML),
   },
 };

--- a/packages/react-components-storybook/src/stories/ExcelViewer/ExcelViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ExcelViewer/ExcelViewer.stories.tsx
@@ -159,12 +159,31 @@ function createMockExcelMedia(): Media {
   };
 }
 
+/** Serializes a parsed spreadsheet back to .xlsx bytes for the byte-based Base component. */
+function toXlsxArrayBuffer(spreadsheet: ParsedSpreadsheet): ArrayBuffer {
+  const workbook = utils.book_new();
+  for (const sheet of spreadsheet.sheets) {
+    const ws = utils.aoa_to_sheet(sheet.rows as string[][]);
+    utils.book_append_sheet(workbook, ws, sheet.name);
+  }
+  // `write` with type "array" returns an ArrayBuffer here; normalize to a
+  // standalone ArrayBuffer regardless of whether it hands back a view.
+  const out = write(workbook, { type: "array", bookType: "xlsx" }) as
+    | ArrayBuffer
+    | Uint8Array;
+  const bytes = out instanceof Uint8Array ? out : new Uint8Array(out);
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength
+  ) as ArrayBuffer;
+}
+
 const meta: Meta<BaseExcelViewerProps> = {
   title: "Components/DocumentViewer/Renderers/ExcelViewer",
   component: BaseExcelViewer,
   tags: ["beta"],
   args: {
-    spreadsheet: SAMPLE_SPREADSHEET,
+    content: toXlsxArrayBuffer(SAMPLE_SPREADSHEET),
   },
   render: (args: BaseExcelViewerProps) => (
     <div style={{ height: "500px" }}>
@@ -175,8 +194,8 @@ const meta: Meta<BaseExcelViewerProps> = {
     controls: { expanded: true },
   },
   argTypes: {
-    spreadsheet: {
-      description: "Parsed spreadsheet data",
+    content: {
+      description: "Raw .xlsx bytes to parse and display",
       control: false,
     },
     className: {
@@ -209,13 +228,14 @@ export const Default: StoryObj<ExcelViewerMediaProps> = {
   },
 };
 
-export const WithSpreadsheet: Story = {
+export const WithContent: Story = {
   parameters: {
     docs: {
       source: {
         code: `import { BaseExcelViewer } from "@osdk/react-components/experimental/excel-viewer";
 
-<BaseExcelViewer spreadsheet={parsedSpreadsheet} />`,
+// content is raw .xlsx bytes (e.g. from media.fetchContents())
+<BaseExcelViewer content={xlsxBytes} />`,
       },
     },
   },
@@ -223,9 +243,9 @@ export const WithSpreadsheet: Story = {
 
 export const SingleSheet: Story = {
   args: {
-    spreadsheet: {
+    content: toXlsxArrayBuffer({
       sheets: [SAMPLE_SPREADSHEET.sheets[0]!],
-    },
+    }),
   },
 };
 

--- a/packages/react-components/docs/EmailViewer.md
+++ b/packages/react-components/docs/EmailViewer.md
@@ -41,15 +41,15 @@ import { BaseEmailViewer } from "@osdk/react-components/experimental/email-viewe
 
 `useEmailViewerState({ content })` returns:
 
-| Field           | Description                                                             |
-| --------------- | ----------------------------------------------------------------------- |
-| `loading`       | Whether the email is still being parsed                                 |
-| `error`         | Error thrown while parsing the bytes, if any                            |
-| `email`         | The parsed email, or `undefined` while loading / on error               |
-| `bodyMode`      | Which body to render: `"html" \| "text" \| "empty"`                     |
-| `formattedFrom` | Formatted sender address, or `undefined` when absent                    |
-| `formattedTo`   | Comma-separated formatted recipient addresses                           |
-| `formattedCc`   | Comma-separated formatted CC addresses                                  |
+| Field           | Description                                               |
+| --------------- | --------------------------------------------------------- |
+| `loading`       | Whether the email is still being parsed                   |
+| `error`         | Error thrown while parsing the bytes, if any              |
+| `email`         | The parsed email, or `undefined` while loading / on error |
+| `bodyMode`      | Which body to render: `"html" \| "text" \| "empty"`       |
+| `formattedFrom` | Formatted sender address, or `undefined` when absent      |
+| `formattedTo`   | Comma-separated formatted recipient addresses             |
+| `formattedCc`   | Comma-separated formatted CC addresses                    |
 
 ```tsx
 import { useEmailViewerState } from "@osdk/react-components/experimental/email-viewer";

--- a/packages/react-components/docs/EmailViewer.md
+++ b/packages/react-components/docs/EmailViewer.md
@@ -14,7 +14,7 @@ import {
 ```
 
 - **`EmailViewer`** — Primary component for OSDK usage. Accepts an OSDK `Media` object, parses the .eml contents, and renders the email.
-- **`BaseEmailViewer`** — Lower-level component that accepts a pre-parsed `ParsedEmail` object.
+- **`BaseEmailViewer`** — Lower-level component that accepts raw .eml bytes and parses them.
 
 ## Usage
 
@@ -26,23 +26,48 @@ import { EmailViewer } from "@osdk/react-components/experimental/email-viewer";
 <EmailViewer media={ticket.emailAttachment} />;
 ```
 
-### With parsed email data
+### With raw bytes
 
 ```tsx
 import { BaseEmailViewer } from "@osdk/react-components/experimental/email-viewer";
 
-<BaseEmailViewer
-  email={{
-    subject: "Hello",
-    from: { name: "Alice", address: "alice@example.com" },
-    to: [{ name: "Bob", address: "bob@example.com" }],
-    cc: [],
-    date: "2026-01-15T10:30:00Z",
-    html: "<p>Hello Bob!</p>",
-    text: "Hello Bob!",
-  }}
-/>;
+// content is raw .eml bytes (e.g. from media.fetchContents())
+<BaseEmailViewer content={emlBytes} />;
 ```
+
+## Headless usage
+
+`useEmailViewerState` takes the raw .eml bytes, parses them (asynchronously), and derives the body mode and formatted addresses — so you can build a fully custom email UI on top of it, the same way `usePdfViewerState` works. Fetch the bytes yourself (e.g. `media.fetchContents()`) and hand them to the hook.
+
+`useEmailViewerState({ content })` returns:
+
+| Field           | Description                                                             |
+| --------------- | ----------------------------------------------------------------------- |
+| `loading`       | Whether the email is still being parsed                                 |
+| `error`         | Error thrown while parsing the bytes, if any                            |
+| `email`         | The parsed email, or `undefined` while loading / on error               |
+| `bodyMode`      | Which body to render: `"html" \| "text" \| "empty"`                     |
+| `formattedFrom` | Formatted sender address, or `undefined` when absent                    |
+| `formattedTo`   | Comma-separated formatted recipient addresses                           |
+| `formattedCc`   | Comma-separated formatted CC addresses                                  |
+
+```tsx
+import { useEmailViewerState } from "@osdk/react-components/experimental/email-viewer";
+
+function CustomEmail({ content }: { content: ArrayBuffer }) {
+  const { loading, error, email, bodyMode, formattedFrom } =
+    useEmailViewerState({ content });
+  if (loading) return <div>Loading…</div>;
+  if (error != null) return <div>Failed: {error.message}</div>;
+  // …render your own header from `formattedFrom` (and `formattedTo`/`formattedCc`)
+  // and switch the body on `bodyMode` (reading `email.html` / `email.text`).
+}
+
+// Fetch the bytes in your component, then pass them in:
+const content = await media.fetchContents().then((r) => r.arrayBuffer());
+```
+
+A complete, runnable version lives in the `e2e.sandbox.peopleapp` app under the "Media Viewers" tab (`src/app/media-viewers/`).
 
 ## Props
 
@@ -50,7 +75,7 @@ import { BaseEmailViewer } from "@osdk/react-components/experimental/email-viewe
 
 | Prop        | Type          | Required | Description                           |
 | ----------- | ------------- | -------- | ------------------------------------- |
-| `email`     | `ParsedEmail` | Yes      | Parsed email data                     |
+| `content`   | `ArrayBuffer` | Yes      | Raw .eml bytes to parse and display   |
 | `className` | `string`      | No       | CSS class applied to the root element |
 
 ### EmailViewerMediaProps

--- a/packages/react-components/docs/ExcelViewer.md
+++ b/packages/react-components/docs/ExcelViewer.md
@@ -39,13 +39,13 @@ import { BaseExcelViewer } from "@osdk/react-components/experimental/excel-viewe
 
 `useExcelViewerState({ content })` returns:
 
-| Field              | Description                                                     |
-| ------------------ | --------------------------------------------------------------- |
-| `error`            | Error thrown while parsing the bytes, if any                    |
-| `sheets`           | All sheets in the workbook                                      |
-| `activeSheetIndex` | Index of the active sheet, clamped to the available range       |
+| Field              | Description                                                      |
+| ------------------ | ---------------------------------------------------------------- |
+| `error`            | Error thrown while parsing the bytes, if any                     |
+| `sheets`           | All sheets in the workbook                                       |
+| `activeSheetIndex` | Index of the active sheet, clamped to the available range        |
 | `activeSheet`      | The active sheet, or `undefined` when the workbook has no sheets |
-| `selectSheet`      | `(index: number) => void` — select a sheet                      |
+| `selectSheet`      | `(index: number) => void` — select a sheet                       |
 
 ```tsx
 import { useExcelViewerState } from "@osdk/react-components/experimental/excel-viewer";
@@ -68,10 +68,10 @@ A complete, runnable version lives in the `e2e.sandbox.peopleapp` app under the 
 
 ### BaseExcelViewerProps
 
-| Prop        | Type          | Required | Description                                     |
-| ----------- | ------------- | -------- | ----------------------------------------------- |
-| `content`   | `ArrayBuffer` | Yes      | Raw .xlsx bytes to parse and display            |
-| `className` | `string`      | No       | CSS class applied to the root element           |
+| Prop        | Type          | Required | Description                           |
+| ----------- | ------------- | -------- | ------------------------------------- |
+| `content`   | `ArrayBuffer` | Yes      | Raw .xlsx bytes to parse and display  |
+| `className` | `string`      | No       | CSS class applied to the root element |
 
 ### ExcelViewerMediaProps
 

--- a/packages/react-components/docs/ExcelViewer.md
+++ b/packages/react-components/docs/ExcelViewer.md
@@ -12,7 +12,7 @@ import {
 ```
 
 - **`ExcelViewer`** — Primary component for OSDK usage. Accepts an OSDK `Media` object, parses the spreadsheet, and renders it.
-- **`BaseExcelViewer`** — Lower-level component that accepts a pre-parsed `ParsedSpreadsheet` object.
+- **`BaseExcelViewer`** — Lower-level component that accepts raw .xlsx bytes and parses them.
 
 ## Usage
 
@@ -24,35 +24,54 @@ import { ExcelViewer } from "@osdk/react-components/experimental/excel-viewer";
 <ExcelViewer media={report.spreadsheet} />;
 ```
 
-### With parsed data
+### With raw bytes
 
 ```tsx
 import { BaseExcelViewer } from "@osdk/react-components/experimental/excel-viewer";
 
-<BaseExcelViewer
-  spreadsheet={{
-    sheets: [
-      {
-        name: "Sheet1",
-        rows: [
-          ["Name", "Age", "City"],
-          ["Alice", "30", "New York"],
-          ["Bob", "25", "London"],
-        ],
-      },
-    ],
-  }}
-/>;
+// content is raw .xlsx bytes (e.g. from media.fetchContents())
+<BaseExcelViewer content={xlsxBytes} />;
 ```
+
+## Headless usage
+
+`useExcelViewerState` takes the raw .xlsx bytes, parses them, and owns the active-sheet selection — so you can build a fully custom spreadsheet UI on top of it, the same way `usePdfViewerState` works. Fetch the bytes yourself (e.g. `media.fetchContents()`) and hand them to the hook.
+
+`useExcelViewerState({ content })` returns:
+
+| Field              | Description                                                     |
+| ------------------ | --------------------------------------------------------------- |
+| `error`            | Error thrown while parsing the bytes, if any                    |
+| `sheets`           | All sheets in the workbook                                      |
+| `activeSheetIndex` | Index of the active sheet, clamped to the available range       |
+| `activeSheet`      | The active sheet, or `undefined` when the workbook has no sheets |
+| `selectSheet`      | `(index: number) => void` — select a sheet                      |
+
+```tsx
+import { useExcelViewerState } from "@osdk/react-components/experimental/excel-viewer";
+
+function CustomSpreadsheet({ content }: { content: ArrayBuffer }) {
+  const { error, sheets, activeSheetIndex, activeSheet, selectSheet } =
+    useExcelViewerState({ content });
+  if (error != null) return <div>Failed: {error.message}</div>;
+  // …render your own tabs from `sheets`/`activeSheetIndex`/`selectSheet`
+  // and your own grid from `activeSheet`.
+}
+
+// Fetch the bytes in your component, then pass them in:
+const content = await media.fetchContents().then((r) => r.arrayBuffer());
+```
+
+A complete, runnable version lives in the `e2e.sandbox.peopleapp` app under the "Media Viewers" tab (`src/app/media-viewers/`).
 
 ## Props
 
 ### BaseExcelViewerProps
 
-| Prop          | Type                | Required | Description                           |
-| ------------- | ------------------- | -------- | ------------------------------------- |
-| `spreadsheet` | `ParsedSpreadsheet` | Yes      | Parsed spreadsheet data               |
-| `className`   | `string`            | No       | CSS class applied to the root element |
+| Prop        | Type          | Required | Description                                     |
+| ----------- | ------------- | -------- | ----------------------------------------------- |
+| `content`   | `ArrayBuffer` | Yes      | Raw .xlsx bytes to parse and display            |
+| `className` | `string`      | No       | CSS class applied to the root element           |
 
 ### ExcelViewerMediaProps
 

--- a/packages/react-components/docs/TiffViewer.md
+++ b/packages/react-components/docs/TiffViewer.md
@@ -60,7 +60,6 @@ import { useTiffRenderer } from "@osdk/react-components/experimental/tiff-render
 
 function CustomTiff({ content }: { content: Uint8Array }) {
   const { result } = useTiffRenderer({ content });
-  if (result == null) return <div>Decoding…</div>;
   if (result.status === "error") return <div>{result.message}</div>;
   // …draw `result.data` (width/height/RGBA content) onto your own <canvas>.
 }

--- a/packages/react-components/docs/TiffViewer.md
+++ b/packages/react-components/docs/TiffViewer.md
@@ -67,7 +67,7 @@ function CustomTiff({ content }: { content: Uint8Array }) {
 
 // Fetch the bytes in your component, then pass them in:
 const content = new Uint8Array(
-  await media.fetchContents().then((r) => r.arrayBuffer()),
+  await media.fetchContents().then((r) => r.arrayBuffer())
 );
 ```
 

--- a/packages/react-components/docs/TiffViewer.md
+++ b/packages/react-components/docs/TiffViewer.md
@@ -49,6 +49,30 @@ import { TiffRenderer } from "@osdk/react-components/experimental/tiff-renderer"
 | `className` | `string`     | `undefined` | CSS class applied to the root element    |
 | `onError`   | `() => void` | `undefined` | Callback fired when rendering fails      |
 
+## Headless usage
+
+`useTiffRenderer` exposes the decode logic (size guard, UTIF decode, result state) so you can build a fully custom TIFF UI on top of it, the same way `usePdfViewerState` works. Fetch the bytes yourself (e.g. `media.fetchContents()`) and hand them to the hook.
+
+`useTiffRenderer({ content })` returns `result` — a `TiffDecodeResult`, which is either `{ status: "ok", data }` (with `width`, `height`, and RGBA `content`) or `{ status: "error", message }`.
+
+```tsx
+import { useTiffRenderer } from "@osdk/react-components/experimental/tiff-renderer";
+
+function CustomTiff({ content }: { content: Uint8Array }) {
+  const { result } = useTiffRenderer({ content });
+  if (result == null) return <div>Decoding…</div>;
+  if (result.status === "error") return <div>{result.message}</div>;
+  // …draw `result.data` (width/height/RGBA content) onto your own <canvas>.
+}
+
+// Fetch the bytes in your component, then pass them in:
+const content = new Uint8Array(
+  await media.fetchContents().then((r) => r.arrayBuffer()),
+);
+```
+
+A complete, runnable version lives in the `e2e.sandbox.peopleapp` app under the "Media Viewers" tab (`src/app/media-viewers/`).
+
 ## Features
 
 - Decodes and renders TIFF images onto a `<canvas>` element using the `utif` library

--- a/packages/react-components/src/email-viewer/BaseEmailViewer.tsx
+++ b/packages/react-components/src/email-viewer/BaseEmailViewer.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Error as ErrorIcon, Spin } from "@blueprintjs/icons";
 import classnames from "classnames";
 import React, { useMemo } from "react";
 
@@ -23,11 +24,18 @@ import { useEmailViewerState } from "./hooks/useEmailViewerState.js";
 import styles from "./BaseEmailViewer.module.css";
 
 export function BaseEmailViewer({
-  email,
+  content,
   className,
 }: BaseEmailViewerProps): React.ReactElement {
-  const { bodyMode, formattedFrom, formattedTo, formattedCc } =
-    useEmailViewerState({ email });
+  const {
+    loading,
+    error,
+    email,
+    bodyMode,
+    formattedFrom,
+    formattedTo,
+    formattedCc,
+  } = useEmailViewerState({ content });
   const rootClassName = classnames(styles.container, className);
 
   const bodyContent = useMemo(() => {
@@ -48,22 +56,44 @@ export function BaseEmailViewer({
           <iframe
             className={styles.bodyIframe}
             sandbox="allow-same-origin"
-            srcDoc={email.html}
+            srcDoc={email?.html}
             title="Email body"
           />
         </div>
       );
     }
     if (bodyMode === "text") {
-      return <div className={styles.textBody}>{email.text}</div>;
+      return <div className={styles.textBody}>{email?.text}</div>;
     }
     return <div className={styles.emptyBody}>No content</div>;
-  }, [bodyMode, email.html, email.text]);
+  }, [bodyMode, email?.html, email?.text]);
+
+  if (loading) {
+    return (
+      <div className={rootClassName}>
+        <div className={styles.loadingContainer}>
+          <Spin className={styles.spinnerIcon} />
+          Loading…
+        </div>
+      </div>
+    );
+  }
+
+  if (error != null) {
+    return (
+      <div className={rootClassName}>
+        <div className={styles.errorContainer}>
+          <ErrorIcon className={styles.errorIcon} />
+          Failed to parse email: {error.message}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={rootClassName}>
       <div className={styles.header}>
-        {email.subject != null && (
+        {email?.subject != null && (
           <div className={styles.subject}>{email.subject}</div>
         )}
         {formattedFrom != null && (
@@ -72,19 +102,19 @@ export function BaseEmailViewer({
             <span className={styles.headerValue}>{formattedFrom}</span>
           </div>
         )}
-        {email.to.length > 0 && (
+        {email != null && email.to.length > 0 && (
           <div className={styles.headerRow}>
             <span className={styles.headerLabel}>To:</span>
             <span className={styles.headerValue}>{formattedTo}</span>
           </div>
         )}
-        {email.cc.length > 0 && (
+        {email != null && email.cc.length > 0 && (
           <div className={styles.headerRow}>
             <span className={styles.headerLabel}>Cc:</span>
             <span className={styles.headerValue}>{formattedCc}</span>
           </div>
         )}
-        {email.date != null && (
+        {email?.date != null && (
           <div className={styles.headerRow}>
             <span className={styles.headerLabel}>Date:</span>
             <span className={styles.headerValue}>{email.date}</span>

--- a/packages/react-components/src/email-viewer/BaseEmailViewer.tsx
+++ b/packages/react-components/src/email-viewer/BaseEmailViewer.tsx
@@ -17,29 +17,21 @@
 import classnames from "classnames";
 import React, { useMemo } from "react";
 
-import type { BaseEmailViewerProps, EmailAddress } from "./EmailViewerApi.js";
+import type { BaseEmailViewerProps } from "./EmailViewerApi.js";
+import { useEmailViewerState } from "./hooks/useEmailViewerState.js";
 
 import styles from "./BaseEmailViewer.module.css";
-
-function formatAddress(address: EmailAddress): string {
-  if (address.name) {
-    return `${address.name} <${address.address}>`;
-  }
-  return address.address;
-}
-
-function formatAddressList(addresses: readonly EmailAddress[]): string {
-  return addresses.map(formatAddress).join(", ");
-}
 
 export function BaseEmailViewer({
   email,
   className,
 }: BaseEmailViewerProps): React.ReactElement {
+  const { bodyMode, formattedFrom, formattedTo, formattedCc } =
+    useEmailViewerState({ email });
   const rootClassName = classnames(styles.container, className);
 
   const bodyContent = useMemo(() => {
-    if (email.html != null) {
+    if (bodyMode === "html") {
       return (
         <div className={styles.bodyContainer}>
           {/*
@@ -62,11 +54,11 @@ export function BaseEmailViewer({
         </div>
       );
     }
-    if (email.text != null) {
+    if (bodyMode === "text") {
       return <div className={styles.textBody}>{email.text}</div>;
     }
     return <div className={styles.emptyBody}>No content</div>;
-  }, [email.html, email.text]);
+  }, [bodyMode, email.html, email.text]);
 
   return (
     <div className={rootClassName}>
@@ -74,28 +66,22 @@ export function BaseEmailViewer({
         {email.subject != null && (
           <div className={styles.subject}>{email.subject}</div>
         )}
-        {email.from != null && (
+        {formattedFrom != null && (
           <div className={styles.headerRow}>
             <span className={styles.headerLabel}>From:</span>
-            <span className={styles.headerValue}>
-              {formatAddress(email.from)}
-            </span>
+            <span className={styles.headerValue}>{formattedFrom}</span>
           </div>
         )}
         {email.to.length > 0 && (
           <div className={styles.headerRow}>
             <span className={styles.headerLabel}>To:</span>
-            <span className={styles.headerValue}>
-              {formatAddressList(email.to)}
-            </span>
+            <span className={styles.headerValue}>{formattedTo}</span>
           </div>
         )}
         {email.cc.length > 0 && (
           <div className={styles.headerRow}>
             <span className={styles.headerLabel}>Cc:</span>
-            <span className={styles.headerValue}>
-              {formatAddressList(email.cc)}
-            </span>
+            <span className={styles.headerValue}>{formattedCc}</span>
           </div>
         )}
         {email.date != null && (

--- a/packages/react-components/src/email-viewer/BaseEmailViewer.tsx
+++ b/packages/react-components/src/email-viewer/BaseEmailViewer.tsx
@@ -68,60 +68,54 @@ export function BaseEmailViewer({
     return <div className={styles.emptyBody}>No content</div>;
   }, [bodyMode, email?.html, email?.text]);
 
-  if (loading) {
-    return (
-      <div className={rootClassName}>
+  return (
+    <div className={rootClassName}>
+      {loading && (
         <div className={styles.loadingContainer}>
           <Spin className={styles.spinnerIcon} />
           Loading…
         </div>
-      </div>
-    );
-  }
-
-  if (error != null) {
-    return (
-      <div className={rootClassName}>
+      )}
+      {error != null && (
         <div className={styles.errorContainer}>
           <ErrorIcon className={styles.errorIcon} />
           Failed to parse email: {error.message}
         </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className={rootClassName}>
-      <div className={styles.header}>
-        {email?.subject != null && (
-          <div className={styles.subject}>{email.subject}</div>
-        )}
-        {formattedFrom != null && (
-          <div className={styles.headerRow}>
-            <span className={styles.headerLabel}>From:</span>
-            <span className={styles.headerValue}>{formattedFrom}</span>
+      )}
+      {!loading && error == null && (
+        <>
+          <div className={styles.header}>
+            {email?.subject != null && (
+              <div className={styles.subject}>{email.subject}</div>
+            )}
+            {formattedFrom != null && (
+              <div className={styles.headerRow}>
+                <span className={styles.headerLabel}>From:</span>
+                <span className={styles.headerValue}>{formattedFrom}</span>
+              </div>
+            )}
+            {email != null && email.to.length > 0 && (
+              <div className={styles.headerRow}>
+                <span className={styles.headerLabel}>To:</span>
+                <span className={styles.headerValue}>{formattedTo}</span>
+              </div>
+            )}
+            {email != null && email.cc.length > 0 && (
+              <div className={styles.headerRow}>
+                <span className={styles.headerLabel}>Cc:</span>
+                <span className={styles.headerValue}>{formattedCc}</span>
+              </div>
+            )}
+            {email?.date != null && (
+              <div className={styles.headerRow}>
+                <span className={styles.headerLabel}>Date:</span>
+                <span className={styles.headerValue}>{email.date}</span>
+              </div>
+            )}
           </div>
-        )}
-        {email != null && email.to.length > 0 && (
-          <div className={styles.headerRow}>
-            <span className={styles.headerLabel}>To:</span>
-            <span className={styles.headerValue}>{formattedTo}</span>
-          </div>
-        )}
-        {email != null && email.cc.length > 0 && (
-          <div className={styles.headerRow}>
-            <span className={styles.headerLabel}>Cc:</span>
-            <span className={styles.headerValue}>{formattedCc}</span>
-          </div>
-        )}
-        {email?.date != null && (
-          <div className={styles.headerRow}>
-            <span className={styles.headerLabel}>Date:</span>
-            <span className={styles.headerValue}>{email.date}</span>
-          </div>
-        )}
-      </div>
-      {bodyContent}
+          {bodyContent}
+        </>
+      )}
     </div>
   );
 }

--- a/packages/react-components/src/email-viewer/EmailViewer.tsx
+++ b/packages/react-components/src/email-viewer/EmailViewer.tsx
@@ -20,10 +20,12 @@ import React from "react";
 
 import { useMediaContents } from "../shared/hooks/useMediaContents.js";
 import { BaseEmailViewer } from "./BaseEmailViewer.js";
-import type { EmailViewerMediaProps, ParsedEmail } from "./EmailViewerApi.js";
-import { parseEmailFromResponse } from "./parseEmail.js";
+import type { EmailViewerMediaProps } from "./EmailViewerApi.js";
 
 import styles from "./BaseEmailViewer.module.css";
+
+const fetchArrayBuffer = (response: Response): Promise<ArrayBuffer> =>
+  response.arrayBuffer();
 
 export function EmailViewer({
   media,
@@ -31,10 +33,10 @@ export function EmailViewer({
   ...emailViewerProps
 }: EmailViewerMediaProps): React.ReactElement {
   const {
-    data: email,
+    data: content,
     loading,
     error,
-  } = useMediaContents<ParsedEmail>(media, parseEmailFromResponse);
+  } = useMediaContents(media, fetchArrayBuffer);
 
   const rootClassName = classnames(styles.container, className);
 
@@ -52,7 +54,9 @@ export function EmailViewer({
           Failed to load email: {error.message}
         </div>
       )}
-      {email != null && <BaseEmailViewer email={email} {...emailViewerProps} />}
+      {content != null && (
+        <BaseEmailViewer content={content} {...emailViewerProps} />
+      )}
     </div>
   );
 }

--- a/packages/react-components/src/email-viewer/EmailViewerApi.ts
+++ b/packages/react-components/src/email-viewer/EmailViewerApi.ts
@@ -32,8 +32,8 @@ export interface ParsedEmail {
 }
 
 export interface BaseEmailViewerProps {
-  /** Parsed email data */
-  email: ParsedEmail;
+  /** Raw .eml bytes to parse and display */
+  content: ArrayBuffer;
   /** Additional CSS class name for the root element
    * @default undefined */
   className?: string;
@@ -41,7 +41,7 @@ export interface BaseEmailViewerProps {
 
 export interface EmailViewerMediaProps extends Omit<
   BaseEmailViewerProps,
-  "email"
+  "content"
 > {
   /** The Media object to fetch EML contents from */
   media: Media;

--- a/packages/react-components/src/email-viewer/__tests__/BaseEmailViewer.test.tsx
+++ b/packages/react-components/src/email-viewer/__tests__/BaseEmailViewer.test.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BaseEmailViewer } from "../BaseEmailViewer.js";
+import type { ParsedEmail } from "../EmailViewerApi.js";
+import type { UseEmailViewerStateResult } from "../hooks/useEmailViewerState.js";
+
+vi.mock("../hooks/useEmailViewerState.js", () => ({
+  useEmailViewerState: vi.fn(),
+}));
+
+const { useEmailViewerState } = await import("../hooks/useEmailViewerState.js");
+const mockedUseState = vi.mocked(useEmailViewerState);
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const CONTENT = new ArrayBuffer(0);
+
+function stateResult(
+  overrides: Partial<UseEmailViewerStateResult> = {}
+): UseEmailViewerStateResult {
+  return {
+    loading: false,
+    error: undefined,
+    email: undefined,
+    bodyMode: "empty",
+    formattedFrom: undefined,
+    formattedTo: "",
+    formattedCc: "",
+    ...overrides,
+  };
+}
+
+function makeEmail(overrides: Partial<ParsedEmail> = {}): ParsedEmail {
+  return {
+    subject: undefined,
+    from: undefined,
+    to: [],
+    cc: [],
+    date: undefined,
+    html: undefined,
+    text: undefined,
+    ...overrides,
+  };
+}
+
+describe("BaseEmailViewer", () => {
+  it("shows a loading indicator and no header while parsing", () => {
+    mockedUseState.mockReturnValue(stateResult({ loading: true }));
+    render(<BaseEmailViewer content={CONTENT} />);
+
+    expect(screen.getByText(/Loading/u)).toBeTruthy();
+    expect(screen.queryByText("From:")).toBeNull();
+  });
+
+  it("shows a parse error", () => {
+    mockedUseState.mockReturnValue(
+      stateResult({ error: new Error("bad eml") })
+    );
+    render(<BaseEmailViewer content={CONTENT} />);
+
+    expect(screen.getByText(/Failed to parse email: bad eml/u)).toBeTruthy();
+    expect(screen.queryByText("From:")).toBeNull();
+  });
+
+  it("renders headers and the html body in a sandboxed iframe", () => {
+    mockedUseState.mockReturnValue(
+      stateResult({
+        email: makeEmail({
+          subject: "Hello",
+          to: [{ name: "Bob", address: "bob@example.com" }],
+          html: "<p>hi</p>",
+        }),
+        bodyMode: "html",
+        formattedFrom: "Alice <alice@example.com>",
+        formattedTo: "Bob <bob@example.com>",
+      })
+    );
+    render(<BaseEmailViewer content={CONTENT} />);
+
+    expect(screen.getByText("Hello")).toBeTruthy();
+    expect(screen.getByText("From:")).toBeTruthy();
+    expect(screen.getByText("Alice <alice@example.com>")).toBeTruthy();
+    expect(screen.getByText("To:")).toBeTruthy();
+
+    const iframe = screen.getByTitle("Email body");
+    expect(iframe.getAttribute("srcdoc")).toBe("<p>hi</p>");
+    expect(iframe.getAttribute("sandbox")).toBe("allow-same-origin");
+  });
+
+  it("renders the plain-text body", () => {
+    mockedUseState.mockReturnValue(
+      stateResult({
+        email: makeEmail({ subject: "Notes", text: "line 1\nline 2" }),
+        bodyMode: "text",
+      })
+    );
+    render(<BaseEmailViewer content={CONTENT} />);
+
+    expect(screen.getByText("line 1 line 2")).toBeTruthy();
+    expect(screen.queryByTitle("Email body")).toBeNull();
+  });
+
+  it("shows 'No content' for an empty body", () => {
+    mockedUseState.mockReturnValue(
+      stateResult({ email: makeEmail({ subject: "Empty" }), bodyMode: "empty" })
+    );
+    render(<BaseEmailViewer content={CONTENT} />);
+
+    expect(screen.getByText("No content")).toBeTruthy();
+  });
+
+  it("omits the To/Cc rows when there are no recipients", () => {
+    mockedUseState.mockReturnValue(
+      stateResult({
+        email: makeEmail({ subject: "Solo" }),
+        bodyMode: "empty",
+      })
+    );
+    render(<BaseEmailViewer content={CONTENT} />);
+
+    expect(screen.queryByText("To:")).toBeNull();
+    expect(screen.queryByText("Cc:")).toBeNull();
+  });
+});

--- a/packages/react-components/src/email-viewer/__tests__/parseEmail.test.ts
+++ b/packages/react-components/src/email-viewer/__tests__/parseEmail.test.ts
@@ -18,19 +18,13 @@ import PostalMime from "postal-mime";
 import type { Email } from "postal-mime";
 import { describe, expect, it, vi } from "vitest";
 
-import { parseEmailFromResponse } from "../parseEmail.js";
+import { parseEmail } from "../parseEmail.js";
 
 vi.mock("postal-mime", () => ({
   default: { parse: vi.fn() },
 }));
 
 const mockedParse = vi.mocked(PostalMime.parse);
-
-function mockResponse(): Response {
-  return {
-    arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
-  } as Response;
-}
 
 function baseEmail(overrides: Partial<Email> = {}): Email {
   return {
@@ -41,7 +35,7 @@ function baseEmail(overrides: Partial<Email> = {}): Email {
   };
 }
 
-describe("parseEmailFromResponse", () => {
+describe("parseEmail", () => {
   it("parses a complete email with all fields", async () => {
     mockedParse.mockResolvedValue(
       baseEmail({
@@ -55,7 +49,7 @@ describe("parseEmailFromResponse", () => {
       })
     );
 
-    const result = await parseEmailFromResponse(mockResponse());
+    const result = await parseEmail(new ArrayBuffer(0));
 
     expect(result).toEqual({
       subject: "Hello",
@@ -75,7 +69,7 @@ describe("parseEmailFromResponse", () => {
       })
     );
 
-    const result = await parseEmailFromResponse(mockResponse());
+    const result = await parseEmail(new ArrayBuffer(0));
 
     expect(result).toEqual({
       subject: "",
@@ -106,7 +100,7 @@ describe("parseEmailFromResponse", () => {
       })
     );
 
-    const result = await parseEmailFromResponse(mockResponse());
+    const result = await parseEmail(new ArrayBuffer(0));
 
     expect(result.to).toEqual([
       { name: "Alice", address: "alice@example.com" },
@@ -127,7 +121,7 @@ describe("parseEmailFromResponse", () => {
       })
     );
 
-    const result = await parseEmailFromResponse(mockResponse());
+    const result = await parseEmail(new ArrayBuffer(0));
 
     expect(result.to).toHaveLength(2);
     expect(result.cc).toHaveLength(1);
@@ -144,7 +138,7 @@ describe("parseEmailFromResponse", () => {
       })
     );
 
-    const result = await parseEmailFromResponse(mockResponse());
+    const result = await parseEmail(new ArrayBuffer(0));
 
     expect(result.from).toBeUndefined();
   });

--- a/packages/react-components/src/email-viewer/hooks/__tests__/useEmailViewerState.test.ts
+++ b/packages/react-components/src/email-viewer/hooks/__tests__/useEmailViewerState.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { ParsedEmail } from "../../EmailViewerApi.js";
+import { useEmailViewerState } from "../useEmailViewerState.js";
+
+const EMPTY_EMAIL: ParsedEmail = {
+  subject: undefined,
+  from: undefined,
+  to: [],
+  cc: [],
+  date: undefined,
+  html: undefined,
+  text: undefined,
+};
+
+describe("useEmailViewerState", () => {
+  describe("bodyMode", () => {
+    it("should prefer html when present", () => {
+      const { result } = renderHook(() =>
+        useEmailViewerState({
+          email: { ...EMPTY_EMAIL, html: "<p>Hi</p>", text: "Hi" },
+        })
+      );
+      expect(result.current.bodyMode).toBe("html");
+    });
+
+    it("should fall back to text when html is absent", () => {
+      const { result } = renderHook(() =>
+        useEmailViewerState({ email: { ...EMPTY_EMAIL, text: "Hi" } })
+      );
+      expect(result.current.bodyMode).toBe("text");
+    });
+
+    it("should be empty when neither html nor text is present", () => {
+      const { result } = renderHook(() =>
+        useEmailViewerState({ email: EMPTY_EMAIL })
+      );
+      expect(result.current.bodyMode).toBe("empty");
+    });
+  });
+
+  describe("address formatting", () => {
+    it("should format an address with a name as 'Name <addr>'", () => {
+      const { result } = renderHook(() =>
+        useEmailViewerState({
+          email: {
+            ...EMPTY_EMAIL,
+            from: { name: "Ada Lovelace", address: "ada@example.com" },
+          },
+        })
+      );
+      expect(result.current.formattedFrom).toBe(
+        "Ada Lovelace <ada@example.com>"
+      );
+    });
+
+    it("should format an address without a name as the bare address", () => {
+      const { result } = renderHook(() =>
+        useEmailViewerState({
+          email: { ...EMPTY_EMAIL, from: { name: "", address: "x@y.com" } },
+        })
+      );
+      expect(result.current.formattedFrom).toBe("x@y.com");
+    });
+
+    it("should leave formattedFrom undefined when there is no sender", () => {
+      const { result } = renderHook(() =>
+        useEmailViewerState({ email: EMPTY_EMAIL })
+      );
+      expect(result.current.formattedFrom).toBeUndefined();
+    });
+
+    it("should join multiple recipients with commas", () => {
+      const { result } = renderHook(() =>
+        useEmailViewerState({
+          email: {
+            ...EMPTY_EMAIL,
+            to: [
+              { name: "A", address: "a@x.com" },
+              { name: "", address: "b@x.com" },
+            ],
+            cc: [{ name: "C", address: "c@x.com" }],
+          },
+        })
+      );
+      expect(result.current.formattedTo).toBe("A <a@x.com>, b@x.com");
+      expect(result.current.formattedCc).toBe("C <c@x.com>");
+    });
+
+    it("should return empty strings for empty recipient lists", () => {
+      const { result } = renderHook(() =>
+        useEmailViewerState({ email: EMPTY_EMAIL })
+      );
+      expect(result.current.formattedTo).toBe("");
+      expect(result.current.formattedCc).toBe("");
+    });
+  });
+});

--- a/packages/react-components/src/email-viewer/hooks/__tests__/useEmailViewerState.test.ts
+++ b/packages/react-components/src/email-viewer/hooks/__tests__/useEmailViewerState.test.ts
@@ -14,102 +14,133 @@
  * limitations under the License.
  */
 
-import { renderHook } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ParsedEmail } from "../../EmailViewerApi.js";
 import { useEmailViewerState } from "../useEmailViewerState.js";
 
-const EMPTY_EMAIL: ParsedEmail = {
-  subject: undefined,
-  from: undefined,
-  to: [],
-  cc: [],
-  date: undefined,
-  html: undefined,
-  text: undefined,
-};
+vi.mock("../../parseEmail.js", () => ({
+  parseEmail: vi.fn(),
+}));
+
+const { parseEmail } = await import("../../parseEmail.js");
+const mockedParse = vi.mocked(parseEmail);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+const CONTENT = new ArrayBuffer(8);
+
+function makeEmail(overrides: Partial<ParsedEmail> = {}): ParsedEmail {
+  return {
+    subject: undefined,
+    from: undefined,
+    to: [],
+    cc: [],
+    date: undefined,
+    html: undefined,
+    text: undefined,
+    ...overrides,
+  };
+}
 
 describe("useEmailViewerState", () => {
+  it("should start loading and resolve to the parsed email", async () => {
+    mockedParse.mockResolvedValue(makeEmail({ html: "<p>Hi</p>" }));
+    const { result } = renderHook(() =>
+      useEmailViewerState({ content: CONTENT })
+    );
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.email).toBeUndefined();
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockedParse).toHaveBeenCalledWith(CONTENT);
+    expect(result.current.email?.html).toBe("<p>Hi</p>");
+    expect(result.current.error).toBeUndefined();
+  });
+
   describe("bodyMode", () => {
-    it("should prefer html when present", () => {
-      const { result } = renderHook(() =>
-        useEmailViewerState({
-          email: { ...EMPTY_EMAIL, html: "<p>Hi</p>", text: "Hi" },
-        })
+    it("should prefer html when present", async () => {
+      mockedParse.mockResolvedValue(
+        makeEmail({ html: "<p>Hi</p>", text: "Hi" })
       );
+      const { result } = renderHook(() =>
+        useEmailViewerState({ content: CONTENT })
+      );
+      await waitFor(() => expect(result.current.loading).toBe(false));
       expect(result.current.bodyMode).toBe("html");
     });
 
-    it("should fall back to text when html is absent", () => {
+    it("should fall back to text when html is absent", async () => {
+      mockedParse.mockResolvedValue(makeEmail({ text: "Hi" }));
       const { result } = renderHook(() =>
-        useEmailViewerState({ email: { ...EMPTY_EMAIL, text: "Hi" } })
+        useEmailViewerState({ content: CONTENT })
       );
+      await waitFor(() => expect(result.current.loading).toBe(false));
       expect(result.current.bodyMode).toBe("text");
     });
 
-    it("should be empty when neither html nor text is present", () => {
+    it("should be empty when neither html nor text is present", async () => {
+      mockedParse.mockResolvedValue(makeEmail());
       const { result } = renderHook(() =>
-        useEmailViewerState({ email: EMPTY_EMAIL })
+        useEmailViewerState({ content: CONTENT })
       );
+      await waitFor(() => expect(result.current.loading).toBe(false));
       expect(result.current.bodyMode).toBe("empty");
     });
   });
 
   describe("address formatting", () => {
-    it("should format an address with a name as 'Name <addr>'", () => {
-      const { result } = renderHook(() =>
-        useEmailViewerState({
-          email: {
-            ...EMPTY_EMAIL,
-            from: { name: "Ada Lovelace", address: "ada@example.com" },
-          },
+    it("should format addresses and join multiple recipients", async () => {
+      mockedParse.mockResolvedValue(
+        makeEmail({
+          from: { name: "Ada Lovelace", address: "ada@example.com" },
+          to: [
+            { name: "A", address: "a@x.com" },
+            { name: "", address: "b@x.com" },
+          ],
+          cc: [{ name: "C", address: "c@x.com" }],
         })
       );
+      const { result } = renderHook(() =>
+        useEmailViewerState({ content: CONTENT })
+      );
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
       expect(result.current.formattedFrom).toBe(
         "Ada Lovelace <ada@example.com>"
-      );
-    });
-
-    it("should format an address without a name as the bare address", () => {
-      const { result } = renderHook(() =>
-        useEmailViewerState({
-          email: { ...EMPTY_EMAIL, from: { name: "", address: "x@y.com" } },
-        })
-      );
-      expect(result.current.formattedFrom).toBe("x@y.com");
-    });
-
-    it("should leave formattedFrom undefined when there is no sender", () => {
-      const { result } = renderHook(() =>
-        useEmailViewerState({ email: EMPTY_EMAIL })
-      );
-      expect(result.current.formattedFrom).toBeUndefined();
-    });
-
-    it("should join multiple recipients with commas", () => {
-      const { result } = renderHook(() =>
-        useEmailViewerState({
-          email: {
-            ...EMPTY_EMAIL,
-            to: [
-              { name: "A", address: "a@x.com" },
-              { name: "", address: "b@x.com" },
-            ],
-            cc: [{ name: "C", address: "c@x.com" }],
-          },
-        })
       );
       expect(result.current.formattedTo).toBe("A <a@x.com>, b@x.com");
       expect(result.current.formattedCc).toBe("C <c@x.com>");
     });
 
-    it("should return empty strings for empty recipient lists", () => {
+    it("should leave from undefined and lists empty when absent", async () => {
+      mockedParse.mockResolvedValue(makeEmail());
       const { result } = renderHook(() =>
-        useEmailViewerState({ email: EMPTY_EMAIL })
+        useEmailViewerState({ content: CONTENT })
       );
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.formattedFrom).toBeUndefined();
       expect(result.current.formattedTo).toBe("");
       expect(result.current.formattedCc).toBe("");
     });
+  });
+
+  it("should surface a parse error", async () => {
+    mockedParse.mockRejectedValue(new Error("corrupt eml"));
+    const { result } = renderHook(() =>
+      useEmailViewerState({ content: CONTENT })
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error?.message).toBe("corrupt eml");
+    expect(result.current.email).toBeUndefined();
+    expect(result.current.bodyMode).toBe("empty");
   });
 });

--- a/packages/react-components/src/email-viewer/hooks/useEmailViewerState.ts
+++ b/packages/react-components/src/email-viewer/hooks/useEmailViewerState.ts
@@ -14,19 +14,26 @@
  * limitations under the License.
  */
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import type { EmailAddress, ParsedEmail } from "../EmailViewerApi.js";
+import { parseEmail } from "../parseEmail.js";
 
 /** Which representation of the email body should be rendered. */
 export type EmailBodyMode = "html" | "text" | "empty";
 
 export interface UseEmailViewerStateOptions {
-  /** Parsed email to display */
-  email: ParsedEmail;
+  /** Raw .eml bytes to parse and display (e.g. from `media.fetchContents()`). */
+  content: ArrayBuffer;
 }
 
 export interface UseEmailViewerStateResult {
+  /** Whether the email is still being parsed */
+  loading: boolean;
+  /** Error thrown while parsing the email bytes, if any */
+  error: Error | undefined;
+  /** The parsed email, or undefined while loading or on error */
+  email: ParsedEmail | undefined;
   /**
    * Which representation of the body should be rendered: the sanitized HTML
    * body when present, otherwise the plain-text body, otherwise nothing.
@@ -52,21 +59,58 @@ function formatAddressList(addresses: readonly EmailAddress[]): string {
 }
 
 /**
- * Headless state for an email viewer: derives which body representation to
- * render and formats the sender / recipient addresses into display strings.
+ * Headless state for an email viewer: parses raw .eml bytes (asynchronously),
+ * then derives which body representation to render and formats the sender /
+ * recipient addresses into display strings.
  */
 export function useEmailViewerState({
-  email,
+  content,
 }: UseEmailViewerStateOptions): UseEmailViewerStateResult {
+  const [email, setEmail] = useState<ParsedEmail | undefined>(undefined);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | undefined>(undefined);
+
+  useEffect(
+    function parseEmailContent() {
+      let cancelled = false;
+      setLoading(true);
+      setError(undefined);
+      setEmail(undefined);
+
+      parseEmail(content)
+        .then((parsed) => {
+          if (!cancelled) {
+            setEmail(parsed);
+            setLoading(false);
+          }
+        })
+        .catch((err: unknown) => {
+          if (!cancelled) {
+            setError(err instanceof Error ? err : new Error(String(err)));
+            setLoading(false);
+          }
+        });
+
+      return () => {
+        cancelled = true;
+      };
+    },
+    [content]
+  );
+
   return useMemo((): UseEmailViewerStateResult => {
     const bodyMode: EmailBodyMode =
-      email.html != null ? "html" : email.text != null ? "text" : "empty";
+      email?.html != null ? "html" : email?.text != null ? "text" : "empty";
 
     return {
+      loading,
+      error,
+      email,
       bodyMode,
-      formattedFrom: email.from != null ? formatAddress(email.from) : undefined,
-      formattedTo: formatAddressList(email.to),
-      formattedCc: formatAddressList(email.cc),
+      formattedFrom:
+        email?.from != null ? formatAddress(email.from) : undefined,
+      formattedTo: email != null ? formatAddressList(email.to) : "",
+      formattedCc: email != null ? formatAddressList(email.cc) : "",
     };
-  }, [email.html, email.text, email.from, email.to, email.cc]);
+  }, [loading, error, email]);
 }

--- a/packages/react-components/src/email-viewer/hooks/useEmailViewerState.ts
+++ b/packages/react-components/src/email-viewer/hooks/useEmailViewerState.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo } from "react";
+
+import type { EmailAddress, ParsedEmail } from "../EmailViewerApi.js";
+
+/** Which representation of the email body should be rendered. */
+export type EmailBodyMode = "html" | "text" | "empty";
+
+export interface UseEmailViewerStateOptions {
+  /** Parsed email to display */
+  email: ParsedEmail;
+}
+
+export interface UseEmailViewerStateResult {
+  /**
+   * Which representation of the body should be rendered: the sanitized HTML
+   * body when present, otherwise the plain-text body, otherwise nothing.
+   */
+  bodyMode: EmailBodyMode;
+  /** Formatted "From" address ("Name <addr>" or "addr"), or undefined when absent */
+  formattedFrom: string | undefined;
+  /** Comma-separated formatted "To" addresses */
+  formattedTo: string;
+  /** Comma-separated formatted "Cc" addresses */
+  formattedCc: string;
+}
+
+function formatAddress(address: EmailAddress): string {
+  if (address.name) {
+    return `${address.name} <${address.address}>`;
+  }
+  return address.address;
+}
+
+function formatAddressList(addresses: readonly EmailAddress[]): string {
+  return addresses.map(formatAddress).join(", ");
+}
+
+/**
+ * Headless state for an email viewer: derives which body representation to
+ * render and formats the sender / recipient addresses into display strings.
+ */
+export function useEmailViewerState({
+  email,
+}: UseEmailViewerStateOptions): UseEmailViewerStateResult {
+  return useMemo((): UseEmailViewerStateResult => {
+    const bodyMode: EmailBodyMode =
+      email.html != null ? "html" : email.text != null ? "text" : "empty";
+
+    return {
+      bodyMode,
+      formattedFrom: email.from != null ? formatAddress(email.from) : undefined,
+      formattedTo: formatAddressList(email.to),
+      formattedCc: formatAddressList(email.cc),
+    };
+  }, [email.html, email.text, email.from, email.to, email.cc]);
+}

--- a/packages/react-components/src/email-viewer/parseEmail.ts
+++ b/packages/react-components/src/email-viewer/parseEmail.ts
@@ -50,11 +50,12 @@ function extractSingleAddress(
   return undefined;
 }
 
-export async function parseEmailFromResponse(
-  response: Response
-): Promise<ParsedEmail> {
-  const buffer = await response.arrayBuffer();
-  const email = await PostalMime.parse(buffer);
+/**
+ * Parses raw .eml bytes into a {@link ParsedEmail}. The caller is responsible
+ * for fetching the bytes (e.g. via `media.fetchContents`).
+ */
+export async function parseEmail(content: ArrayBuffer): Promise<ParsedEmail> {
+  const email = await PostalMime.parse(content);
 
   return {
     subject: email.subject,

--- a/packages/react-components/src/email-viewer/parseEmail.ts
+++ b/packages/react-components/src/email-viewer/parseEmail.ts
@@ -51,8 +51,7 @@ function extractSingleAddress(
 }
 
 /**
- * Parses raw .eml bytes into a {@link ParsedEmail}. The caller is responsible
- * for fetching the bytes (e.g. via `media.fetchContents`).
+ * Parses raw .eml bytes into a {@link ParsedEmail}.
  */
 export async function parseEmail(content: ArrayBuffer): Promise<ParsedEmail> {
   const email = await PostalMime.parse(content);

--- a/packages/react-components/src/excel-viewer/BaseExcelViewer.tsx
+++ b/packages/react-components/src/excel-viewer/BaseExcelViewer.tsx
@@ -15,9 +15,10 @@
  */
 
 import classnames from "classnames";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useMemo } from "react";
 
 import type { BaseExcelViewerProps, SheetData } from "./ExcelViewerApi.js";
+import { useExcelViewerState } from "./hooks/useExcelViewerState.js";
 
 import styles from "./BaseExcelViewer.module.css";
 
@@ -82,21 +83,9 @@ export function BaseExcelViewer({
   spreadsheet,
   className,
 }: BaseExcelViewerProps): React.ReactElement {
-  const [activeSheetIndex, setActiveSheetIndex] = useState(0);
+  const { sheets, activeSheetIndex, activeSheet, selectSheet } =
+    useExcelViewerState({ spreadsheet });
   const rootClassName = classnames(styles.container, className);
-
-  const safeIndex = Math.min(
-    activeSheetIndex,
-    Math.max(0, spreadsheet.sheets.length - 1)
-  );
-  const activeSheet = useMemo(
-    () => spreadsheet.sheets[safeIndex],
-    [spreadsheet.sheets, safeIndex]
-  );
-
-  const handleTabClick = useCallback((index: number) => {
-    setActiveSheetIndex(index);
-  }, []);
 
   return (
     <div className={rootClassName}>
@@ -105,15 +94,15 @@ export function BaseExcelViewer({
       ) : (
         <div className={styles.emptySheet}>No sheets</div>
       )}
-      {spreadsheet.sheets.length > 1 && (
+      {sheets.length > 1 && (
         <div className={styles.tabBar}>
-          {spreadsheet.sheets.map((sheet, index) => (
+          {sheets.map((sheet, index) => (
             <button
               key={sheet.name}
               className={classnames(styles.tab, {
-                [styles.tabActive]: index === safeIndex,
+                [styles.tabActive]: index === activeSheetIndex,
               })}
-              onClick={() => handleTabClick(index)}
+              onClick={() => selectSheet(index)}
               type="button"
             >
               {sheet.name}

--- a/packages/react-components/src/excel-viewer/BaseExcelViewer.tsx
+++ b/packages/react-components/src/excel-viewer/BaseExcelViewer.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Error as ErrorIcon } from "@blueprintjs/icons";
 import classnames from "classnames";
 import React, { useMemo } from "react";
 
@@ -80,12 +81,23 @@ const SheetTable: React.FunctionComponent<{ sheet: SheetData }> = React.memo(
 SheetTable.displayName = "SheetTable";
 
 export function BaseExcelViewer({
-  spreadsheet,
+  content,
   className,
 }: BaseExcelViewerProps): React.ReactElement {
-  const { sheets, activeSheetIndex, activeSheet, selectSheet } =
-    useExcelViewerState({ spreadsheet });
+  const { error, sheets, activeSheetIndex, activeSheet, selectSheet } =
+    useExcelViewerState({ content });
   const rootClassName = classnames(styles.container, className);
+
+  if (error != null) {
+    return (
+      <div className={rootClassName}>
+        <div className={styles.errorContainer}>
+          <ErrorIcon className={styles.errorIcon} />
+          Failed to parse spreadsheet: {error.message}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={rootClassName}>

--- a/packages/react-components/src/excel-viewer/BaseExcelViewer.tsx
+++ b/packages/react-components/src/excel-viewer/BaseExcelViewer.tsx
@@ -88,39 +88,37 @@ export function BaseExcelViewer({
     useExcelViewerState({ content });
   const rootClassName = classnames(styles.container, className);
 
-  if (error != null) {
-    return (
-      <div className={rootClassName}>
+  return (
+    <div className={rootClassName}>
+      {error != null ? (
         <div className={styles.errorContainer}>
           <ErrorIcon className={styles.errorIcon} />
           Failed to parse spreadsheet: {error.message}
         </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className={rootClassName}>
-      {activeSheet != null ? (
-        <SheetTable sheet={activeSheet} />
       ) : (
-        <div className={styles.emptySheet}>No sheets</div>
-      )}
-      {sheets.length > 1 && (
-        <div className={styles.tabBar}>
-          {sheets.map((sheet, index) => (
-            <button
-              key={sheet.name}
-              className={classnames(styles.tab, {
-                [styles.tabActive]: index === activeSheetIndex,
-              })}
-              onClick={() => selectSheet(index)}
-              type="button"
-            >
-              {sheet.name}
-            </button>
-          ))}
-        </div>
+        <>
+          {activeSheet != null ? (
+            <SheetTable sheet={activeSheet} />
+          ) : (
+            <div className={styles.emptySheet}>No sheets</div>
+          )}
+          {sheets.length > 1 && (
+            <div className={styles.tabBar}>
+              {sheets.map((sheet, index) => (
+                <button
+                  key={sheet.name}
+                  className={classnames(styles.tab, {
+                    [styles.tabActive]: index === activeSheetIndex,
+                  })}
+                  onClick={() => selectSheet(index)}
+                  type="button"
+                >
+                  {sheet.name}
+                </button>
+              ))}
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/packages/react-components/src/excel-viewer/ExcelViewer.tsx
+++ b/packages/react-components/src/excel-viewer/ExcelViewer.tsx
@@ -16,17 +16,16 @@
 
 import { Error as ErrorIcon, Spin } from "@blueprintjs/icons";
 import classnames from "classnames";
-import React, { useCallback } from "react";
+import React from "react";
 
 import { useMediaContents } from "../shared/hooks/useMediaContents.js";
 import { BaseExcelViewer } from "./BaseExcelViewer.js";
-import type {
-  ExcelViewerMediaProps,
-  ParsedSpreadsheet,
-} from "./ExcelViewerApi.js";
-import { parseSpreadsheetFromResponse } from "./parseSpreadsheet.js";
+import type { ExcelViewerMediaProps } from "./ExcelViewerApi.js";
 
 import styles from "./BaseExcelViewer.module.css";
+
+const fetchArrayBuffer = (response: Response): Promise<ArrayBuffer> =>
+  response.arrayBuffer();
 
 export function ExcelViewer({
   media,
@@ -34,13 +33,10 @@ export function ExcelViewer({
   ...excelViewerProps
 }: ExcelViewerMediaProps): React.ReactElement {
   const {
-    data: spreadsheet,
+    data: content,
     loading,
     error,
-  } = useMediaContents<ParsedSpreadsheet>(
-    media,
-    useCallback(parseSpreadsheetFromResponse, [])
-  );
+  } = useMediaContents(media, fetchArrayBuffer);
 
   const rootClassName = classnames(styles.container, className);
 
@@ -58,8 +54,8 @@ export function ExcelViewer({
           Failed to load spreadsheet: {error.message}
         </div>
       )}
-      {spreadsheet != null && (
-        <BaseExcelViewer spreadsheet={spreadsheet} {...excelViewerProps} />
+      {content != null && (
+        <BaseExcelViewer content={content} {...excelViewerProps} />
       )}
     </div>
   );

--- a/packages/react-components/src/excel-viewer/ExcelViewerApi.ts
+++ b/packages/react-components/src/excel-viewer/ExcelViewerApi.ts
@@ -29,8 +29,8 @@ export interface ParsedSpreadsheet {
 }
 
 export interface BaseExcelViewerProps {
-  /** Parsed spreadsheet data */
-  spreadsheet: ParsedSpreadsheet;
+  /** Raw .xlsx bytes to parse and display */
+  content: ArrayBuffer;
   /** Additional CSS class name for the root element
    * @default undefined */
   className?: string;
@@ -38,7 +38,7 @@ export interface BaseExcelViewerProps {
 
 export interface ExcelViewerMediaProps extends Omit<
   BaseExcelViewerProps,
-  "spreadsheet"
+  "content"
 > {
   /** The Media object to fetch Excel contents from */
   media: Media;

--- a/packages/react-components/src/excel-viewer/__tests__/BaseExcelViewer.test.tsx
+++ b/packages/react-components/src/excel-viewer/__tests__/BaseExcelViewer.test.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BaseExcelViewer } from "../BaseExcelViewer.js";
+import type { SheetData } from "../ExcelViewerApi.js";
+import type { UseExcelViewerStateResult } from "../hooks/useExcelViewerState.js";
+
+vi.mock("../hooks/useExcelViewerState.js", () => ({
+  useExcelViewerState: vi.fn(),
+}));
+
+const { useExcelViewerState } = await import("../hooks/useExcelViewerState.js");
+const mockedUseState = vi.mocked(useExcelViewerState);
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const CONTENT = new ArrayBuffer(0);
+
+function stateResult(
+  overrides: Partial<UseExcelViewerStateResult> = {}
+): UseExcelViewerStateResult {
+  return {
+    error: undefined,
+    sheets: [],
+    activeSheetIndex: 0,
+    activeSheet: undefined,
+    selectSheet: vi.fn(),
+    ...overrides,
+  };
+}
+
+const SHEET_A: SheetData = {
+  name: "Alpha",
+  rows: [
+    ["Name", "Age"],
+    ["Alice", "30"],
+  ],
+};
+const SHEET_B: SheetData = { name: "Beta", rows: [["x"]] };
+
+describe("BaseExcelViewer", () => {
+  it("shows a parse error", () => {
+    mockedUseState.mockReturnValue(
+      stateResult({ error: new Error("corrupt workbook") })
+    );
+    render(<BaseExcelViewer content={CONTENT} />);
+
+    expect(
+      screen.getByText(/Failed to parse spreadsheet: corrupt workbook/u)
+    ).toBeTruthy();
+  });
+
+  it("renders the active sheet as a table", () => {
+    mockedUseState.mockReturnValue(
+      stateResult({ sheets: [SHEET_A], activeSheet: SHEET_A })
+    );
+    render(<BaseExcelViewer content={CONTENT} />);
+
+    expect(screen.getByText("Name")).toBeTruthy();
+    expect(screen.getByText("Alice")).toBeTruthy();
+    expect(screen.getByText("30")).toBeTruthy();
+  });
+
+  it("shows 'No sheets' when there is no active sheet", () => {
+    mockedUseState.mockReturnValue(stateResult({ sheets: [] }));
+    render(<BaseExcelViewer content={CONTENT} />);
+
+    expect(screen.getByText("No sheets")).toBeTruthy();
+  });
+
+  it("renders a tab per sheet and calls selectSheet on click", () => {
+    const selectSheet = vi.fn();
+    mockedUseState.mockReturnValue(
+      stateResult({
+        sheets: [SHEET_A, SHEET_B],
+        activeSheet: SHEET_A,
+        activeSheetIndex: 0,
+        selectSheet,
+      })
+    );
+    render(<BaseExcelViewer content={CONTENT} />);
+
+    const betaTab = screen.getByRole("button", { name: "Beta" });
+    expect(screen.getByRole("button", { name: "Alpha" })).toBeTruthy();
+
+    fireEvent.click(betaTab);
+    expect(selectSheet).toHaveBeenCalledWith(1);
+  });
+
+  it("renders no tab bar for a single-sheet workbook", () => {
+    mockedUseState.mockReturnValue(
+      stateResult({ sheets: [SHEET_A], activeSheet: SHEET_A })
+    );
+    render(<BaseExcelViewer content={CONTENT} />);
+
+    expect(screen.queryByRole("button", { name: "Alpha" })).toBeNull();
+  });
+});

--- a/packages/react-components/src/excel-viewer/hooks/__tests__/useExcelViewerState.test.ts
+++ b/packages/react-components/src/excel-viewer/hooks/__tests__/useExcelViewerState.test.ts
@@ -15,10 +15,21 @@
  */
 
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ParsedSpreadsheet } from "../../ExcelViewerApi.js";
 import { useExcelViewerState } from "../useExcelViewerState.js";
+
+vi.mock("../../parseSpreadsheet.js", () => ({
+  parseSpreadsheet: vi.fn(),
+}));
+
+const { parseSpreadsheet } = await import("../../parseSpreadsheet.js");
+const mockedParse = vi.mocked(parseSpreadsheet);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
 
 function makeSpreadsheet(sheetNames: readonly string[]): ParsedSpreadsheet {
   return {
@@ -26,19 +37,29 @@ function makeSpreadsheet(sheetNames: readonly string[]): ParsedSpreadsheet {
   };
 }
 
-describe("useExcelViewerState", () => {
-  it("should default to the first sheet", () => {
-    const spreadsheet = makeSpreadsheet(["Alpha", "Beta"]);
-    const { result } = renderHook(() => useExcelViewerState({ spreadsheet }));
+// Distinct buffer lengths let the parse mock return different workbooks per
+// content, so we can exercise re-parsing on content change.
+const CONTENT = new ArrayBuffer(8);
 
+describe("useExcelViewerState", () => {
+  it("should parse the content and default to the first sheet", () => {
+    mockedParse.mockReturnValue(makeSpreadsheet(["Alpha", "Beta"]));
+    const { result } = renderHook(() =>
+      useExcelViewerState({ content: CONTENT })
+    );
+
+    expect(mockedParse).toHaveBeenCalledWith(CONTENT);
+    expect(result.current.error).toBeUndefined();
     expect(result.current.activeSheetIndex).toBe(0);
     expect(result.current.activeSheet?.name).toBe("Alpha");
     expect(result.current.sheets).toHaveLength(2);
   });
 
   it("should select a sheet by index", () => {
-    const spreadsheet = makeSpreadsheet(["Alpha", "Beta", "Gamma"]);
-    const { result } = renderHook(() => useExcelViewerState({ spreadsheet }));
+    mockedParse.mockReturnValue(makeSpreadsheet(["Alpha", "Beta", "Gamma"]));
+    const { result } = renderHook(() =>
+      useExcelViewerState({ content: CONTENT })
+    );
 
     act(() => {
       result.current.selectSheet(2);
@@ -48,11 +69,17 @@ describe("useExcelViewerState", () => {
     expect(result.current.activeSheet?.name).toBe("Gamma");
   });
 
-  it("should clamp the active index when the workbook shrinks", () => {
+  it("should re-parse and clamp the active index when content changes", () => {
+    mockedParse.mockImplementation((content: ArrayBuffer) =>
+      content.byteLength === 3
+        ? makeSpreadsheet(["A"])
+        : makeSpreadsheet(["A", "B", "C"])
+    );
+
     const { result, rerender } = renderHook(
-      ({ spreadsheet }: { spreadsheet: ParsedSpreadsheet }) =>
-        useExcelViewerState({ spreadsheet }),
-      { initialProps: { spreadsheet: makeSpreadsheet(["A", "B", "C"]) } }
+      ({ content }: { content: ArrayBuffer }) =>
+        useExcelViewerState({ content }),
+      { initialProps: { content: new ArrayBuffer(9) } }
     );
 
     act(() => {
@@ -60,19 +87,33 @@ describe("useExcelViewerState", () => {
     });
     expect(result.current.activeSheetIndex).toBe(2);
 
-    rerender({ spreadsheet: makeSpreadsheet(["A"]) });
+    rerender({ content: new ArrayBuffer(3) });
 
     expect(result.current.activeSheetIndex).toBe(0);
     expect(result.current.activeSheet?.name).toBe("A");
   });
 
   it("should return undefined activeSheet for an empty workbook", () => {
+    mockedParse.mockReturnValue({ sheets: [] });
     const { result } = renderHook(() =>
-      useExcelViewerState({ spreadsheet: { sheets: [] } })
+      useExcelViewerState({ content: CONTENT })
     );
 
     expect(result.current.activeSheetIndex).toBe(0);
     expect(result.current.activeSheet).toBeUndefined();
     expect(result.current.sheets).toHaveLength(0);
+  });
+
+  it("should surface a parse error and fall back to no sheets", () => {
+    mockedParse.mockImplementation(() => {
+      throw new Error("corrupt workbook");
+    });
+    const { result } = renderHook(() =>
+      useExcelViewerState({ content: CONTENT })
+    );
+
+    expect(result.current.error?.message).toBe("corrupt workbook");
+    expect(result.current.sheets).toHaveLength(0);
+    expect(result.current.activeSheet).toBeUndefined();
   });
 });

--- a/packages/react-components/src/excel-viewer/hooks/__tests__/useExcelViewerState.test.ts
+++ b/packages/react-components/src/excel-viewer/hooks/__tests__/useExcelViewerState.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { ParsedSpreadsheet } from "../../ExcelViewerApi.js";
+import { useExcelViewerState } from "../useExcelViewerState.js";
+
+function makeSpreadsheet(sheetNames: readonly string[]): ParsedSpreadsheet {
+  return {
+    sheets: sheetNames.map((name) => ({ name, rows: [[name]] })),
+  };
+}
+
+describe("useExcelViewerState", () => {
+  it("should default to the first sheet", () => {
+    const spreadsheet = makeSpreadsheet(["Alpha", "Beta"]);
+    const { result } = renderHook(() => useExcelViewerState({ spreadsheet }));
+
+    expect(result.current.activeSheetIndex).toBe(0);
+    expect(result.current.activeSheet?.name).toBe("Alpha");
+    expect(result.current.sheets).toHaveLength(2);
+  });
+
+  it("should select a sheet by index", () => {
+    const spreadsheet = makeSpreadsheet(["Alpha", "Beta", "Gamma"]);
+    const { result } = renderHook(() => useExcelViewerState({ spreadsheet }));
+
+    act(() => {
+      result.current.selectSheet(2);
+    });
+
+    expect(result.current.activeSheetIndex).toBe(2);
+    expect(result.current.activeSheet?.name).toBe("Gamma");
+  });
+
+  it("should clamp the active index when the workbook shrinks", () => {
+    const { result, rerender } = renderHook(
+      ({ spreadsheet }: { spreadsheet: ParsedSpreadsheet }) =>
+        useExcelViewerState({ spreadsheet }),
+      { initialProps: { spreadsheet: makeSpreadsheet(["A", "B", "C"]) } }
+    );
+
+    act(() => {
+      result.current.selectSheet(2);
+    });
+    expect(result.current.activeSheetIndex).toBe(2);
+
+    rerender({ spreadsheet: makeSpreadsheet(["A"]) });
+
+    expect(result.current.activeSheetIndex).toBe(0);
+    expect(result.current.activeSheet?.name).toBe("A");
+  });
+
+  it("should return undefined activeSheet for an empty workbook", () => {
+    const { result } = renderHook(() =>
+      useExcelViewerState({ spreadsheet: { sheets: [] } })
+    );
+
+    expect(result.current.activeSheetIndex).toBe(0);
+    expect(result.current.activeSheet).toBeUndefined();
+    expect(result.current.sheets).toHaveLength(0);
+  });
+});

--- a/packages/react-components/src/excel-viewer/hooks/useExcelViewerState.ts
+++ b/packages/react-components/src/excel-viewer/hooks/useExcelViewerState.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+
+import type { ParsedSpreadsheet, SheetData } from "../ExcelViewerApi.js";
+
+export interface UseExcelViewerStateOptions {
+  /** Parsed spreadsheet whose sheets are displayed */
+  spreadsheet: ParsedSpreadsheet;
+}
+
+export interface UseExcelViewerStateResult {
+  /** All sheets in the workbook */
+  sheets: readonly SheetData[];
+  /** Index of the active sheet, clamped to the range of available sheets */
+  activeSheetIndex: number;
+  /** The active sheet, or undefined when the workbook has no sheets */
+  activeSheet: SheetData | undefined;
+  /** Select the sheet at the given index */
+  selectSheet: (index: number) => void;
+}
+
+/**
+ * Headless state for a spreadsheet viewer: tracks the active sheet and exposes
+ * a setter, clamping the active index to the range of available sheets so it
+ * stays valid when the workbook changes.
+ */
+export function useExcelViewerState({
+  spreadsheet,
+}: UseExcelViewerStateOptions): UseExcelViewerStateResult {
+  const [activeSheetIndex, setActiveSheetIndex] = useState(0);
+
+  const safeIndex = Math.min(
+    activeSheetIndex,
+    Math.max(0, spreadsheet.sheets.length - 1)
+  );
+
+  const activeSheet = useMemo(
+    () => spreadsheet.sheets[safeIndex],
+    [spreadsheet.sheets, safeIndex]
+  );
+
+  const selectSheet = useCallback((index: number) => {
+    setActiveSheetIndex(index);
+  }, []);
+
+  return useMemo(
+    (): UseExcelViewerStateResult => ({
+      sheets: spreadsheet.sheets,
+      activeSheetIndex: safeIndex,
+      activeSheet,
+      selectSheet,
+    }),
+    [spreadsheet.sheets, safeIndex, activeSheet, selectSheet]
+  );
+}

--- a/packages/react-components/src/excel-viewer/hooks/useExcelViewerState.ts
+++ b/packages/react-components/src/excel-viewer/hooks/useExcelViewerState.ts
@@ -17,13 +17,18 @@
 import { useCallback, useMemo, useState } from "react";
 
 import type { ParsedSpreadsheet, SheetData } from "../ExcelViewerApi.js";
+import { parseSpreadsheet } from "../parseSpreadsheet.js";
+
+const EMPTY_SPREADSHEET: ParsedSpreadsheet = { sheets: [] };
 
 export interface UseExcelViewerStateOptions {
-  /** Parsed spreadsheet whose sheets are displayed */
-  spreadsheet: ParsedSpreadsheet;
+  /** Raw .xlsx bytes to parse and display (e.g. from `media.fetchContents()`). */
+  content: ArrayBuffer;
 }
 
 export interface UseExcelViewerStateResult {
+  /** Error thrown while parsing the spreadsheet bytes, if any */
+  error: Error | undefined;
   /** All sheets in the workbook */
   sheets: readonly SheetData[];
   /** Index of the active sheet, clamped to the range of available sheets */
@@ -35,13 +40,28 @@ export interface UseExcelViewerStateResult {
 }
 
 /**
- * Headless state for a spreadsheet viewer: tracks the active sheet and exposes
- * a setter, clamping the active index to the range of available sheets so it
- * stays valid when the workbook changes.
+ * Headless state for a spreadsheet viewer: parses raw .xlsx bytes into sheets
+ * (synchronously) and tracks the active-sheet selection, clamping the active
+ * index to the range of available sheets so it stays valid when the workbook
+ * changes.
  */
 export function useExcelViewerState({
-  spreadsheet,
+  content,
 }: UseExcelViewerStateOptions): UseExcelViewerStateResult {
+  const { spreadsheet, error } = useMemo((): {
+    spreadsheet: ParsedSpreadsheet;
+    error: Error | undefined;
+  } => {
+    try {
+      return { spreadsheet: parseSpreadsheet(content), error: undefined };
+    } catch (err: unknown) {
+      return {
+        spreadsheet: EMPTY_SPREADSHEET,
+        error: err instanceof Error ? err : new Error(String(err)),
+      };
+    }
+  }, [content]);
+
   const [activeSheetIndex, setActiveSheetIndex] = useState(0);
 
   const safeIndex = Math.min(
@@ -60,11 +80,12 @@ export function useExcelViewerState({
 
   return useMemo(
     (): UseExcelViewerStateResult => ({
+      error,
       sheets: spreadsheet.sheets,
       activeSheetIndex: safeIndex,
       activeSheet,
       selectSheet,
     }),
-    [spreadsheet.sheets, safeIndex, activeSheet, selectSheet]
+    [error, spreadsheet.sheets, safeIndex, activeSheet, selectSheet]
   );
 }

--- a/packages/react-components/src/excel-viewer/parseSpreadsheet.ts
+++ b/packages/react-components/src/excel-viewer/parseSpreadsheet.ts
@@ -21,8 +21,7 @@ import { read, utils } from "xlsx-republish";
 import type { ParsedSpreadsheet, SheetData } from "./ExcelViewerApi.js";
 
 /**
- * Parses raw .xlsx bytes into a {@link ParsedSpreadsheet}. Synchronous — the
- * caller is responsible for fetching the bytes (e.g. via `media.fetchContents`).
+ * Parses raw .xlsx bytes into a {@link ParsedSpreadsheet}. Synchronous.
  */
 export function parseSpreadsheet(content: ArrayBuffer): ParsedSpreadsheet {
   const workbook = read(content, { type: "array" });

--- a/packages/react-components/src/excel-viewer/parseSpreadsheet.ts
+++ b/packages/react-components/src/excel-viewer/parseSpreadsheet.ts
@@ -20,11 +20,12 @@ import { read, utils } from "xlsx-republish";
 
 import type { ParsedSpreadsheet, SheetData } from "./ExcelViewerApi.js";
 
-export async function parseSpreadsheetFromResponse(
-  response: Response
-): Promise<ParsedSpreadsheet> {
-  const buffer = await response.arrayBuffer();
-  const workbook = read(buffer, { type: "array" });
+/**
+ * Parses raw .xlsx bytes into a {@link ParsedSpreadsheet}. Synchronous — the
+ * caller is responsible for fetching the bytes (e.g. via `media.fetchContents`).
+ */
+export function parseSpreadsheet(content: ArrayBuffer): ParsedSpreadsheet {
+  const workbook = read(content, { type: "array" });
 
   const sheets: SheetData[] = workbook.SheetNames.map((name) => {
     const sheet = workbook.Sheets[name];

--- a/packages/react-components/src/images/tiff-renderer/TiffRenderer.tsx
+++ b/packages/react-components/src/images/tiff-renderer/TiffRenderer.tsx
@@ -67,10 +67,6 @@ export const TiffRenderer: React.FunctionComponent<TiffRendererProps> =
   React.memo(({ content, onError }) => {
     const { result } = useTiffRenderer({ content, onError });
 
-    if (result == null) {
-      return null;
-    }
-
     if (result.status === "error") {
       return <ErrorMessage message={result.message} />;
     }

--- a/packages/react-components/src/images/tiff-renderer/TiffRenderer.tsx
+++ b/packages/react-components/src/images/tiff-renderer/TiffRenderer.tsx
@@ -14,71 +14,14 @@
  * limitations under the License.
  */
 
-/* cspell:words ifds */
-
 import { Error as ErrorIcon } from "@blueprintjs/icons";
-import React, { useCallback, useEffect, useRef, useState } from "react";
-import * as UTIF from "utif";
+import React, { useCallback } from "react";
 
+import { useTiffRenderer } from "./hooks/useTiffRenderer.js";
+import type { TiffImageData } from "./hooks/useTiffRenderer.js";
 import type { TiffRendererProps } from "./types.js";
 
 import styles from "./TiffRenderer.module.css";
-
-// 25 MB limit — TIFF decoding expands compressed data into a full RGBA bitmap
-// in memory, so capping the input size prevents the browser from allocating an
-// unreasonably large buffer.
-const MAX_IMAGE_SIZE = 25_000_000;
-const MAX_IMAGE_SIZE_MB_STRING = (MAX_IMAGE_SIZE / 1_000_000).toFixed(1);
-
-interface TiffImageData {
-  content: Uint8Array;
-  width: number;
-  height: number;
-}
-
-type DecodeResult =
-  | { status: "ok"; data: TiffImageData }
-  | { status: "error"; message: string };
-
-function decodeTiff(content: Uint8Array): DecodeResult {
-  if (content.byteLength > MAX_IMAGE_SIZE) {
-    return {
-      status: "error",
-      message: `TIFF file exceeds maximum size of ${MAX_IMAGE_SIZE_MB_STRING}MB`,
-    };
-  }
-
-  try {
-    const buffer = content.buffer as ArrayBuffer;
-    const ifds = UTIF.decode(buffer);
-    const image = ifds[0];
-    if (image == null) {
-      return {
-        status: "error",
-        message: "Could not render TIFF file (it may be corrupted)",
-      };
-    }
-    UTIF.decodeImage(buffer, image);
-    const rgba = UTIF.toRGBA8(image);
-
-    if (image.width == null || image.height == null) {
-      return {
-        status: "error",
-        message: "Could not render TIFF file (it may be corrupted)",
-      };
-    }
-
-    return {
-      status: "ok",
-      data: { width: image.width, height: image.height, content: rgba },
-    };
-  } catch {
-    return {
-      status: "error",
-      message: "Could not render TIFF file (it may be corrupted)",
-    };
-  }
-}
 
 const ErrorMessage: React.FunctionComponent<{ message: string }> = React.memo(
   ({ message }) => (
@@ -122,17 +65,7 @@ const TiffCanvas: React.FunctionComponent<{ imageData: TiffImageData }> =
 
 export const TiffRenderer: React.FunctionComponent<TiffRendererProps> =
   React.memo(({ content, onError }) => {
-    const [result, setResult] = useState<DecodeResult | undefined>(undefined);
-    const onErrorRef = useRef(onError);
-    onErrorRef.current = onError;
-
-    useEffect(() => {
-      const decodeResult = decodeTiff(content);
-      setResult(decodeResult);
-      if (decodeResult.status === "error") {
-        onErrorRef.current?.();
-      }
-    }, [content]);
+    const { result } = useTiffRenderer({ content, onError });
 
     if (result == null) {
       return null;

--- a/packages/react-components/src/images/tiff-renderer/hooks/__tests__/useTiffRenderer.test.ts
+++ b/packages/react-components/src/images/tiff-renderer/hooks/__tests__/useTiffRenderer.test.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import type { IFD } from "utif";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useTiffRenderer } from "../useTiffRenderer.js";
+
+vi.mock("utif", () => ({
+  decode: vi.fn(),
+  decodeImage: vi.fn(),
+  toRGBA8: vi.fn(),
+}));
+
+const UTIF = await import("utif");
+const mockedDecode = vi.mocked(UTIF.decode);
+const mockedDecodeImage = vi.mocked(UTIF.decodeImage);
+const mockedToRGBA8 = vi.mocked(UTIF.toRGBA8);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function createMockImage(width: number, height: number) {
+  return { width, height } as IFD;
+}
+
+describe("useTiffRenderer", () => {
+  it("should return an ok result with decoded dimensions for valid data", () => {
+    const mockImage = createMockImage(100, 50);
+    mockedDecode.mockReturnValue([mockImage]);
+    mockedDecodeImage.mockReturnValue(undefined);
+    const rgba = new Uint8Array(100 * 50 * 4);
+    mockedToRGBA8.mockReturnValue(rgba);
+
+    const content = new Uint8Array(100);
+    const { result } = renderHook(() => useTiffRenderer({ content }));
+
+    expect(result.current.result).toEqual({
+      status: "ok",
+      data: { width: 100, height: 50, content: rgba },
+    });
+  });
+
+  it("should return an error result when the TIFF exceeds the max size", () => {
+    const onError = vi.fn();
+    const largeContent = new Uint8Array(26_000_000);
+    const { result } = renderHook(() =>
+      useTiffRenderer({ content: largeContent, onError })
+    );
+
+    expect(result.current.result).toEqual({
+      status: "error",
+      message: expect.stringMatching(/exceeds maximum size/u),
+    });
+    expect(mockedDecode).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("should call onError and return an error result when decoding throws", () => {
+    mockedDecode.mockImplementation(() => {
+      throw new Error("Bad TIFF");
+    });
+    const onError = vi.fn();
+    const content = new Uint8Array(100);
+    const { result } = renderHook(() => useTiffRenderer({ content, onError }));
+
+    expect(result.current.result?.status).toBe("error");
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("should return an error result when the TIFF has no frames", () => {
+    mockedDecode.mockReturnValue([]);
+    const onError = vi.fn();
+    const content = new Uint8Array(100);
+    const { result } = renderHook(() => useTiffRenderer({ content, onError }));
+
+    expect(result.current.result).toEqual({
+      status: "error",
+      message: expect.stringMatching(/Could not render TIFF/u),
+    });
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("should call onError when the image has missing dimensions", () => {
+    const mockImage = {
+      width: undefined,
+      height: undefined,
+    } as unknown as IFD;
+    mockedDecode.mockReturnValue([mockImage]);
+    mockedDecodeImage.mockReturnValue(undefined);
+    mockedToRGBA8.mockReturnValue(new Uint8Array(0));
+
+    const onError = vi.fn();
+    const content = new Uint8Array(100);
+    const { result } = renderHook(() => useTiffRenderer({ content, onError }));
+
+    expect(result.current.result?.status).toBe("error");
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("should re-decode when content changes", () => {
+    const mockImage = createMockImage(10, 10);
+    mockedDecode.mockReturnValue([mockImage]);
+    mockedDecodeImage.mockReturnValue(undefined);
+    mockedToRGBA8.mockReturnValue(new Uint8Array(10 * 10 * 4));
+
+    const { rerender } = renderHook(
+      ({ content }: { content: Uint8Array }) => useTiffRenderer({ content }),
+      { initialProps: { content: new Uint8Array(10) } }
+    );
+    expect(mockedDecode).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      rerender({ content: new Uint8Array(20) });
+    });
+    expect(mockedDecode).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/react-components/src/images/tiff-renderer/hooks/useTiffRenderer.ts
+++ b/packages/react-components/src/images/tiff-renderer/hooks/useTiffRenderer.ts
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-/* cspell:words ifds */
-
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import * as UTIF from "utif";
 
 // 25 MB limit — TIFF decoding expands compressed data into a full RGBA bitmap
@@ -90,8 +88,8 @@ export interface UseTiffRendererOptions {
 }
 
 export interface UseTiffRendererResult {
-  /** The decode result, or undefined until decoding completes */
-  result: TiffDecodeResult | undefined;
+  /** The decode result for the current content */
+  result: TiffDecodeResult;
 }
 
 /**
@@ -102,17 +100,16 @@ export function useTiffRenderer({
   content,
   onError,
 }: UseTiffRendererOptions): UseTiffRendererResult {
-  const [result, setResult] = useState<TiffDecodeResult | undefined>(undefined);
   const onErrorRef = useRef(onError);
   onErrorRef.current = onError;
 
+  const result = useMemo(() => decodeTiff(content), [content]);
+
   useEffect(() => {
-    const decodeResult = decodeTiff(content);
-    setResult(decodeResult);
-    if (decodeResult.status === "error") {
+    if (result.status === "error") {
       onErrorRef.current?.();
     }
-  }, [content]);
+  }, [result]);
 
   return { result };
 }

--- a/packages/react-components/src/images/tiff-renderer/hooks/useTiffRenderer.ts
+++ b/packages/react-components/src/images/tiff-renderer/hooks/useTiffRenderer.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* cspell:words ifds */
+
+import { useEffect, useRef, useState } from "react";
+import * as UTIF from "utif";
+
+// 25 MB limit — TIFF decoding expands compressed data into a full RGBA bitmap
+// in memory, so capping the input size prevents the browser from allocating an
+// unreasonably large buffer.
+const MAX_IMAGE_SIZE = 25_000_000;
+const MAX_IMAGE_SIZE_MB_STRING = (MAX_IMAGE_SIZE / 1_000_000).toFixed(1);
+
+export interface TiffImageData {
+  /** Decoded RGBA pixel data */
+  content: Uint8Array;
+  /** Image width in pixels */
+  width: number;
+  /** Image height in pixels */
+  height: number;
+}
+
+export type TiffDecodeResult =
+  | { status: "ok"; data: TiffImageData }
+  | { status: "error"; message: string };
+
+/**
+ * Decodes TIFF bytes into RGBA pixel data, rejecting inputs that exceed the
+ * in-memory size cap and reporting a friendly message for corrupt files.
+ */
+function decodeTiff(content: Uint8Array): TiffDecodeResult {
+  if (content.byteLength > MAX_IMAGE_SIZE) {
+    return {
+      status: "error",
+      message: `TIFF file exceeds maximum size of ${MAX_IMAGE_SIZE_MB_STRING}MB`,
+    };
+  }
+
+  try {
+    const buffer = content.buffer as ArrayBuffer;
+    const ifds = UTIF.decode(buffer);
+    const image = ifds[0];
+    if (image == null) {
+      return {
+        status: "error",
+        message: "Could not render TIFF file (it may be corrupted)",
+      };
+    }
+    UTIF.decodeImage(buffer, image);
+    const rgba = UTIF.toRGBA8(image);
+
+    if (image.width == null || image.height == null) {
+      return {
+        status: "error",
+        message: "Could not render TIFF file (it may be corrupted)",
+      };
+    }
+
+    return {
+      status: "ok",
+      data: { width: image.width, height: image.height, content: rgba },
+    };
+  } catch {
+    return {
+      status: "error",
+      message: "Could not render TIFF file (it may be corrupted)",
+    };
+  }
+}
+
+export interface UseTiffRendererOptions {
+  /** TIFF bytes to decode */
+  content: Uint8Array;
+  /** Callback fired when decoding fails */
+  onError?: () => void;
+}
+
+export interface UseTiffRendererResult {
+  /** The decode result, or undefined until decoding completes */
+  result: TiffDecodeResult | undefined;
+}
+
+/**
+ * Headless state for a TIFF renderer: decodes the given bytes into RGBA pixel
+ * data whenever the content changes and invokes `onError` when decoding fails.
+ */
+export function useTiffRenderer({
+  content,
+  onError,
+}: UseTiffRendererOptions): UseTiffRendererResult {
+  const [result, setResult] = useState<TiffDecodeResult | undefined>(undefined);
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+
+  useEffect(() => {
+    const decodeResult = decodeTiff(content);
+    setResult(decodeResult);
+    if (decodeResult.status === "error") {
+      onErrorRef.current?.();
+    }
+  }, [content]);
+
+  return { result };
+}

--- a/packages/react-components/src/public/experimental/email-viewer.ts
+++ b/packages/react-components/src/public/experimental/email-viewer.ts
@@ -23,6 +23,14 @@ export type {
   ParsedEmail,
 } from "../../email-viewer/EmailViewerApi.js";
 
+// EmailViewer hooks
+export {
+  type EmailBodyMode,
+  useEmailViewerState,
+  type UseEmailViewerStateOptions,
+  type UseEmailViewerStateResult,
+} from "../../email-viewer/hooks/useEmailViewerState.js";
+
 // EmailViewer (Media wrapper)
 import { EmailViewer as _EmailViewer } from "../../email-viewer/EmailViewer.js";
 import { withOsdkMetrics } from "../../util/withOsdkMetrics.js";

--- a/packages/react-components/src/public/experimental/excel-viewer.ts
+++ b/packages/react-components/src/public/experimental/excel-viewer.ts
@@ -23,6 +23,13 @@ export type {
   SheetData,
 } from "../../excel-viewer/ExcelViewerApi.js";
 
+// ExcelViewer hooks
+export {
+  useExcelViewerState,
+  type UseExcelViewerStateOptions,
+  type UseExcelViewerStateResult,
+} from "../../excel-viewer/hooks/useExcelViewerState.js";
+
 // ExcelViewer (Media wrapper)
 import { ExcelViewer as _ExcelViewer } from "../../excel-viewer/ExcelViewer.js";
 import { withOsdkMetrics } from "../../util/withOsdkMetrics.js";

--- a/packages/react-components/src/public/experimental/tiff-renderer.ts
+++ b/packages/react-components/src/public/experimental/tiff-renderer.ts
@@ -18,6 +18,15 @@
 export { TiffRenderer } from "../../images/tiff-renderer/TiffRenderer.js";
 export type { TiffRendererProps } from "../../images/tiff-renderer/types.js";
 
+// TiffRenderer hooks
+export {
+  type TiffDecodeResult,
+  type TiffImageData,
+  useTiffRenderer,
+  type UseTiffRendererOptions,
+  type UseTiffRendererResult,
+} from "../../images/tiff-renderer/hooks/useTiffRenderer.js";
+
 // TiffViewerMedia (Media wrapper)
 import { TiffViewerMedia as _TiffViewerMedia } from "../../images/tiff-renderer/TiffViewerMedia.js";
 import { withOsdkMetrics } from "../../util/withOsdkMetrics.js";


### PR DESCRIPTION
## Summary

Exposes the interaction/parse logic of three document-viewer renderers as headless React hooks, re-exported from the experimental barrels — matching the `PdfViewer` pattern (`hooks/use<Name>.ts` exporting `Options`/`Result` types, re-exported from `public/experimental/<name>.ts`).

Each hook takes the **raw media bytes** and parses/decodes them internally (like `usePdfViewerState`), so a consumer can build a fully custom UI without re-implementing parsing:

| Renderer | New hook | Takes | Does |
|---|---|---|---|
| excel-viewer | `useExcelViewerState` | `content: ArrayBuffer` | parses .xlsx (sync) + active-sheet selection |
| email-viewer | `useEmailViewerState` | `content: ArrayBuffer` | parses .eml (async) + body mode + formatted addresses |
| tiff-renderer | `useTiffRenderer` | `content: Uint8Array` | UTIF decode + 25 MB guard + `onError` |

The `Base*` components consume their hook, and the OSDK Media wrappers (`ExcelViewer` / `EmailViewer`) now just fetch the bytes and hand them down.

## API changes (experimental)

This is **not** a no-op refactor — the exported Base components change shape:

- `BaseExcelViewer` / `BaseEmailViewer` now take **`content` (raw bytes)** instead of pre-parsed `spreadsheet` / `email` props.
- Parse errors now surface inside the Base component ("Failed to parse …") rather than the Media wrapper ("Failed to load …").
- Internal parser helpers were renamed to `parseSpreadsheet` / `parseEmail` (now take `ArrayBuffer`); these are internal, not part of the public surface.

Shipped as a `minor` changeset since these are all `experimental/` exports.

## New public exports

From `@osdk/react-components/experimental/{excel-viewer,email-viewer,tiff-renderer}`:

- `useExcelViewerState`, `UseExcelViewerStateOptions`, `UseExcelViewerStateResult`
- `useEmailViewerState`, `EmailBodyMode`, `UseEmailViewerStateOptions`, `UseEmailViewerStateResult`
- `useTiffRenderer`, `TiffImageData`, `TiffDecodeResult`, `UseTiffRendererOptions`, `UseTiffRendererResult`

## Deliberately skipped

Single-element / thin-wrapper renderers with no logic to extract: **video** (`<video>`), **image** (`<img>`), **xml** (`<pre><code>`), **markdown** (wraps `react-markdown`).

## Docs & examples

- Headless-usage sections added to the Excel / Email / TIFF component docs.
- New "Media Viewers" tab in `e2e.sandbox.peopleapp` builds fully custom viewers on the hooks, fetching an `Employee` media property's bytes in the page (via a local `useMediaBytes` hook) and handing them to the viewer hooks.
