### PR TITLE
Lowercase generated package.json name fields

### DIFF
--- a/.changeset/lowercase-template-names.md
+++ b/.changeset/lowercase-template-names.md
@@ -1,0 +1,18 @@
+---
+"@osdk/create-app": patch
+"@osdk/create-widget": patch
+"@osdk/create-app.template.expo.v2": patch
+"@osdk/create-app.template.react": patch
+"@osdk/create-app.template.react.beta": patch
+"@osdk/create-app.template.tutorial-todo-aip-app": patch
+"@osdk/create-app.template.tutorial-todo-aip-app.beta": patch
+"@osdk/create-app.template.tutorial-todo-app": patch
+"@osdk/create-app.template.tutorial-todo-app.beta": patch
+"@osdk/create-app.template.typescript-library.beta": patch
+"@osdk/create-app.template.vue": patch
+"@osdk/create-app.template.vue.v2": patch
+"@osdk/create-widget.template.minimal-react.v2": patch
+"@osdk/create-widget.template.react.v2": patch
+---
+
+Lowercase the generated package.json name field so scaffolded projects with uppercase names are npm-publishable

--- a/.changeset/lowercase-template-names.md
+++ b/.changeset/lowercase-template-names.md
@@ -1,4 +1,5 @@
 ---
+"@osdk/generator-utils": minor
 "@osdk/create-app": patch
 "@osdk/create-widget": patch
 "@osdk/create-app.template.expo.v2": patch

--- a/packages/create-app.template.expo.v2/templates/package.json.osdk.hbs
+++ b/packages/create-app.template.expo.v2/templates/package.json.osdk.hbs
@@ -1,5 +1,5 @@
 {
-  "name": "{{project}}",
+  "name": "{{lowercase project}}",
   "private": true,
   "main": "expo-router/entry",
   "version": "1.0.0",

--- a/packages/create-app.template.expo.v2/templates/package.json.psdk.hbs
+++ b/packages/create-app.template.expo.v2/templates/package.json.psdk.hbs
@@ -1,5 +1,5 @@
 {
-  "name": "{{project}}",
+  "name": "{{lowercase project}}",
   "private": true,
   "main": "expo-router/entry",
   "version": "1.0.0",

--- a/packages/create-app.template.react.beta/templates/package.json.osdk.hbs
+++ b/packages/create-app.template.react.beta/templates/package.json.osdk.hbs
@@ -1,5 +1,5 @@
 {
-  "name": "{{project}}",
+  "name": "{{lowercase project}}",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/packages/create-app.template.react.beta/templates/package.json.psdk.hbs
+++ b/packages/create-app.template.react.beta/templates/package.json.psdk.hbs
@@ -1,5 +1,5 @@
 {
-  "name": "{{project}}",
+  "name": "{{lowercase project}}",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/packages/create-app.template.react/templates/package.json.hbs
+++ b/packages/create-app.template.react/templates/package.json.hbs
@@ -1,5 +1,5 @@
 {
-  "name": "{{project}}",
+  "name": "{{lowercase project}}",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/package.json.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/package.json.hbs
@@ -1,5 +1,5 @@
 {
-  "name": "{{project}}",
+  "name": "{{lowercase project}}",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/packages/create-app.template.tutorial-todo-aip-app/templates/package.json.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app/templates/package.json.hbs
@@ -1,5 +1,5 @@
 {
-  "name": "{{project}}",
+  "name": "{{lowercase project}}",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/package.json.hbs
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/package.json.hbs
@@ -1,5 +1,5 @@
 {
-  "name": "{{project}}",
+  "name": "{{lowercase project}}",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/packages/create-app.template.tutorial-todo-app/templates/package.json.hbs
+++ b/packages/create-app.template.tutorial-todo-app/templates/package.json.hbs
@@ -1,5 +1,5 @@
 {
-  "name": "{{project}}",
+  "name": "{{lowercase project}}",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/packages/create-app.template.typescript-library.beta/templates/package.json.hbs
+++ b/packages/create-app.template.typescript-library.beta/templates/package.json.hbs
@@ -1,5 +1,5 @@
 {
-  "name": "{{project}}",
+  "name": "{{lowercase project}}",
   "version": "0.0.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/create-app.template.vue.v2/templates/package.json.osdk.hbs
+++ b/packages/create-app.template.vue.v2/templates/package.json.osdk.hbs
@@ -1,5 +1,5 @@
 {
-  "name": "{{project}}",
+  "name": "{{lowercase project}}",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/packages/create-app.template.vue.v2/templates/package.json.psdk.hbs
+++ b/packages/create-app.template.vue.v2/templates/package.json.psdk.hbs
@@ -1,5 +1,5 @@
 {
-  "name": "{{project}}",
+  "name": "{{lowercase project}}",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/packages/create-app.template.vue/templates/package.json.hbs
+++ b/packages/create-app.template.vue/templates/package.json.hbs
@@ -1,5 +1,5 @@
 {
-  "name": "{{project}}",
+  "name": "{{lowercase project}}",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/packages/create-app/src/cli.test.ts
+++ b/packages/create-app/src/cli.test.ts
@@ -108,6 +108,30 @@ test(`CLI rejects no OSDK with 1.x`, async () => {
   ).rejects.toThrowError();
 });
 
+test(`CLI lowercases the package.json name field`, async () => {
+  // Project names may contain uppercase characters, but npm rejects package
+  // names that aren't all lowercase. The `name` field is rendered via the
+  // `lowercase` Handlebars helper, so an uppercase project must produce a
+  // lowercase package name.
+  const project = "My-Uppercase-App";
+  await runTest({
+    project,
+    template: VISIBLE_TEMPLATE,
+    corsProxy: false,
+    sdkVersion: "2.x",
+    skipOsdk: false,
+    ontology: "ri.ontology.main.ontology.fake",
+    osdkPackage: "@fake/sdk",
+    osdkRegistryUrl:
+      "https://example.palantirfoundry.com/artifacts/api/repositories/ri.artifacts.main.repository.fake/contents/release/npm",
+  });
+
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(process.cwd(), project, "package.json"), "utf-8")
+  );
+  expect(packageJson.name).toBe(project.toLowerCase());
+});
+
 async function runTest({
   project,
   template,

--- a/packages/create-app/src/cli.test.ts
+++ b/packages/create-app/src/cli.test.ts
@@ -18,6 +18,8 @@ import fs from "node:fs";
 import path, { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { lowercase } from "@osdk/generator-utils";
+import Handlebars from "handlebars";
 import { dirSync } from "tmp";
 import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -130,6 +132,27 @@ test(`CLI lowercases the package.json name field`, async () => {
     fs.readFileSync(path.join(process.cwd(), project, "package.json"), "utf-8")
   );
   expect(packageJson.name).toBe(project.toLowerCase());
+});
+
+describe("lowercase Handlebars helper", () => {
+  // Mirrors how run.ts wires the shared helper into the template engine.
+  const handlebars = Handlebars.create();
+  handlebars.registerHelper("lowercase", lowercase);
+
+  test(`renders a package.json name field lowercased`, () => {
+    const rendered = handlebars.compile(`{ "name": "{{lowercase project}}" }`)({
+      project: "@Foundry/My-Uppercase-App",
+    });
+    expect(JSON.parse(rendered).name).toBe("@foundry/my-uppercase-app");
+  });
+
+  test(`throws when its argument cannot be resolved`, () => {
+    // A missing/misspelled token resolves to undefined, so rendering must fail
+    // rather than silently produce an invalid "undefined" package name.
+    expect(() =>
+      handlebars.compile(`{{lowercase typoToken}}`)({ project: "my-app" })
+    ).toThrowError(/requires a string argument/u);
+  });
 });
 
 async function runTest({

--- a/packages/create-app/src/run.ts
+++ b/packages/create-app/src/run.ts
@@ -32,6 +32,13 @@ import { generateNpmRc } from "./generate/generateNpmRc.js";
 import { green } from "./highlight.js";
 import type { SdkVersion, Template, TemplateContext } from "./templates.js";
 
+// Lowercases a substituted token value. Used for `package.json` name fields,
+// since npm rejects package names containing uppercase characters but the
+// project name entered by the user may contain them.
+Handlebars.registerHelper("lowercase", (value: unknown) =>
+  String(value).toLowerCase()
+);
+
 interface RunArgs {
   project: string;
   overwrite: boolean;

--- a/packages/create-app/src/run.ts
+++ b/packages/create-app/src/run.ts
@@ -18,7 +18,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { changeVersionPrefix } from "@osdk/generator-utils";
+import { changeVersionPrefix, lowercase } from "@osdk/generator-utils";
 import { findUpSync } from "find-up";
 import Handlebars from "handlebars";
 
@@ -32,12 +32,9 @@ import { generateNpmRc } from "./generate/generateNpmRc.js";
 import { green } from "./highlight.js";
 import type { SdkVersion, Template, TemplateContext } from "./templates.js";
 
-// Lowercases a substituted token value. Used for `package.json` name fields,
-// since npm rejects package names containing uppercase characters but the
-// project name entered by the user may contain them.
-Handlebars.registerHelper("lowercase", (value: unknown) =>
-  String(value).toLowerCase()
-);
+// Register the shared `lowercase` helper so template `package.json` name
+// fields can enforce npm-safe (lowercase) package names.
+Handlebars.registerHelper("lowercase", lowercase);
 
 interface RunArgs {
   project: string;

--- a/packages/create-widget.template.minimal-react.v2/templates/package.json.hbs
+++ b/packages/create-widget.template.minimal-react.v2/templates/package.json.hbs
@@ -1,5 +1,5 @@
 {
-  "name": "{{project}}",
+  "name": "{{lowercase project}}",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/packages/create-widget.template.react.v2/templates/package.json.hbs
+++ b/packages/create-widget.template.react.v2/templates/package.json.hbs
@@ -1,5 +1,5 @@
 {
-  "name": "{{project}}",
+  "name": "{{lowercase project}}",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/packages/create-widget/src/cli.test.ts
+++ b/packages/create-widget/src/cli.test.ts
@@ -59,6 +59,26 @@ for (const template of TEMPLATES) {
   });
 }
 
+test(`CLI lowercases the package.json name field`, async () => {
+  // Project names may contain uppercase characters, but npm rejects package
+  // names that aren't all lowercase. The `name` field is rendered via the
+  // `lowercase` Handlebars helper, so an uppercase project must produce a
+  // lowercase package name.
+  const template = TEMPLATES[0];
+  const project = "My-Uppercase-Widget";
+  await runTest({
+    project,
+    template,
+    sdkVersion: "2.x",
+    requiresOsdk: template.requiresOsdk,
+  });
+
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(process.cwd(), project, "package.json"), "utf-8")
+  );
+  expect(packageJson.name).toBe(project.toLowerCase());
+});
+
 async function runTest({
   project,
   template,

--- a/packages/create-widget/src/run.ts
+++ b/packages/create-widget/src/run.ts
@@ -25,6 +25,13 @@ import { generateNpmRc } from "./generate/generateNpmRc.js";
 import { green } from "./highlight.js";
 import type { SdkVersion, Template, TemplateContext } from "./templates.js";
 
+// Lowercases a substituted token value. Used for `package.json` name fields,
+// since npm rejects package names containing uppercase characters but the
+// project name entered by the user may contain them.
+Handlebars.registerHelper("lowercase", (value: unknown) =>
+  String(value).toLowerCase()
+);
+
 interface RunArgs {
   project: string;
   overwrite: boolean;

--- a/packages/create-widget/src/run.ts
+++ b/packages/create-widget/src/run.ts
@@ -17,6 +17,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { lowercase } from "@osdk/generator-utils";
 import Handlebars from "handlebars";
 
 import { consola } from "./consola.js";
@@ -25,12 +26,9 @@ import { generateNpmRc } from "./generate/generateNpmRc.js";
 import { green } from "./highlight.js";
 import type { SdkVersion, Template, TemplateContext } from "./templates.js";
 
-// Lowercases a substituted token value. Used for `package.json` name fields,
-// since npm rejects package names containing uppercase characters but the
-// project name entered by the user may contain them.
-Handlebars.registerHelper("lowercase", (value: unknown) =>
-  String(value).toLowerCase()
-);
+// Register the shared `lowercase` helper so template `package.json` name
+// fields can enforce npm-safe (lowercase) package names.
+Handlebars.registerHelper("lowercase", lowercase);
 
 interface RunArgs {
   project: string;

--- a/packages/generator-utils/package.json
+++ b/packages/generator-utils/package.json
@@ -32,6 +32,7 @@
     "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
     "fix-lint": "eslint . --fix && dprint fmt",
     "lint": "eslint . && dprint check",
+    "test": "vitest run",
     "transpileBrowser": "monorepo.tool.transpile -f esm -m normal -t browser",
     "transpileCjs": "monorepo.tool.transpile -f cjs -m bundle -t node",
     "transpileEsm": "monorepo.tool.transpile -f esm -m normal -t node",

--- a/packages/generator-utils/src/index.ts
+++ b/packages/generator-utils/src/index.ts
@@ -16,4 +16,5 @@
 
 export { changeVersionPrefix } from "./changeVersionPrefix.js";
 export { getDependencyVersionFromFindUpPackageJson } from "./getDependencyVersionFromFindUpPackageJson.js";
+export { lowercase } from "./lowercase.js";
 export { resolveDependenciesFromFindUp } from "./resolveDependenciesFromFindUp.js";

--- a/packages/generator-utils/src/lowercase.test.ts
+++ b/packages/generator-utils/src/lowercase.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { lowercase } from "./lowercase.js";
+
+describe(lowercase, () => {
+  it.each([
+    ["My-App", "my-app"],
+    ["UPPER", "upper"],
+    ["@Foundry/My-Package", "@foundry/my-package"],
+    ["my-osdk-app", "my-osdk-app"],
+    ["", ""],
+  ])(`lowercases %j to %j`, (input, expected) => {
+    expect(lowercase(input)).toBe(expected);
+  });
+
+  it.each<[string, unknown]>([
+    ["undefined", undefined],
+    ["null", null],
+    ["a number", 123],
+    ["a boolean", true],
+    ["an object", {}],
+    ["an array", ["Foo"]],
+  ])(`throws when the argument is %s`, (_label, value) => {
+    expect(() => lowercase(value)).toThrowError(
+      /requires a string argument/,
+    );
+  });
+});

--- a/packages/generator-utils/src/lowercase.ts
+++ b/packages/generator-utils/src/lowercase.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Handlebars helper that lowercases a substituted token value.
+ *
+ * `npm publish` rejects package names containing uppercase characters, but a
+ * project name supplied when scaffolding a template can contain them, so
+ * template `package.json` `name` fields wrap their token as
+ * `{{lowercase project}}`.
+ *
+ * Throws when the argument is not a string. An unresolved or misspelled token
+ * is passed by Handlebars as `undefined`, so throwing surfaces the mistake as
+ * a template-rendering error instead of silently producing an invalid
+ * `package.json` name such as `"undefined"`.
+ */
+export function lowercase(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new Error(
+      `The "lowercase" template helper requires a string argument but received `
+        + `a value of type "${typeof value}". This usually means the token passed `
+        + `to it could not be resolved.`,
+    );
+  }
+  return value.toLowerCase();
+}


### PR DESCRIPTION
## Before this PR
The `create-app` and `create-widget` CLIs render each template's `package.json` `name` field from the user-supplied project name via `{{project}}`. The project-name validation regex (`^[a-zA-Z0-9-_]+$`) allows uppercase characters, so a project named e.g. `MyApp` produces `"name": "MyApp"`. `npm publish` rejects package names containing uppercase characters, so a scaffolded project with a capitalised name fails to publish.

## After this PR
- Registers a `lowercase` Handlebars helper in both CLIs (`create-app`, `create-widget`).
- Wraps the name-field token as `{{lowercase project}}` in **every** TypeScript template's `package.json.*.hbs` (all 15 files across 12 template packages), so generated projects are always npm-safe.

## Scope
Every template in this repo is TypeScript-based (each has a `tsconfig` and `.ts`/`.tsx` sources), so all templates are covered. There are no non-TypeScript templates to skip. Only the `name` field changed; incidental JS config files (e.g. the Expo template's `metro.config.js`) were left untouched.

## Templates changed
- create-app: `expo.v2` (osdk+psdk), `react`, `react.beta` (osdk+psdk), `tutorial-todo-aip-app`, `tutorial-todo-aip-app.beta`, `tutorial-todo-app`, `tutorial-todo-app.beta`, `typescript-library.beta`, `vue`, `vue.v2` (osdk+psdk)
- create-widget: `minimal-react.v2`, `react.v2`

## Testing
- Added a test in each CLI that scaffolds with an uppercase project name and asserts the generated `package.json` `name` is fully lowercase.
- `pnpm turbo test typecheck --filter=@osdk/create-app --filter=@osdk/create-widget` passes (create-app 92 tests, create-widget 37 tests).
- `dprint check` and `pnpm turbo lint` on both packages pass.

<img width="605" height="175" alt="image" src="https://github.com/user-attachments/assets/a75a1fe9-21e8-43a4-aa18-6ec33c6c74d6" />
