### PR TITLE
Add ObservableClient.applyChanges for external cache updates

### DIFF
--- a/.changeset/lohi-apply-changes.md
+++ b/.changeset/lohi-apply-changes.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": minor
+---
+
+Add `ObservableClient.applyChanges` for pushing externally-sourced object upserts and deletes directly into the observable cache. Changes flow through the same ingest path as server fetches and websocket stream updates, so all observing hooks update reactively without a network round trip. This lets an embedded or offline ontology stream locally-synced deltas into the hooks.

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -63,6 +63,44 @@ export namespace ObservableClient {
   export interface ApplyActionOptions {
     optimisticUpdate?: (ctx: OptimisticBuilder) => void;
   }
+
+  /**
+   * A batch of externally-sourced object changes to apply directly to the
+   * observable cache via {@link ObservableClient.applyChanges}.
+   *
+   * Changes are written through the same store ingest path that server fetches,
+   * action results, and websocket stream updates use, so every observing hook
+   * (objects, lists, object sets, links, and dependent functions) updates
+   * reactively without a network round trip. This is the seam an embedded or
+   * offline ontology engine uses to push locally-synced deltas into the hooks.
+   */
+  export interface Changes {
+    /**
+     * Full object or interface instances to insert or update.
+     *
+     * Instances must be produced by the client's object factory — i.e. wire
+     * data converted through the client's `objectFactory`, or an existing
+     * instance's `$clone` — so they carry the internal holder representation
+     * the cache stores. Each instance should carry all of its base properties
+     * (`"$allBaseProperties"`); an instance carrying only a subset of
+     * properties merges into any existing cached value rather than replacing
+     * it.
+     */
+    upserts?: ReadonlyArray<
+      Osdk.Instance<ObjectOrInterfaceDefinition, "$allBaseProperties">
+    >;
+
+    /**
+     * Objects to remove from the cache, identified by their concrete object
+     * type API name and primary key. Removing an object tombstones it along
+     * with every registered cache variant, so lists and object sets that
+     * contain it drop it reactively.
+     */
+    deletes?: ReadonlyArray<{
+      objectType: string;
+      primaryKey: string | number;
+    }>;
+  }
 }
 
 export interface CacheSnapshot {
@@ -566,6 +604,26 @@ export interface ObservableClient extends ObserveLinks {
     action: Q,
     args: Parameters<ActionSignatureFromDef<Q>["applyAction"]>[0]
   ) => Promise<ActionValidationResponse>;
+
+  /**
+   * Apply a batch of externally-sourced object changes directly to the cache,
+   * bypassing the network.
+   *
+   * Upserts and deletes flow through the same store ingest path used by server
+   * fetches, action results, and websocket stream updates, so all observing
+   * hooks update reactively. Intended for data that arrives outside the normal
+   * fetch/action flow, e.g. an embedded or offline ontology engine streaming
+   * locally-synced deltas, or an external system pushing updates.
+   *
+   * Applying an empty set of changes is a no-op. This method is additive and
+   * non-breaking for callers that never invoke it.
+   *
+   * @param changes - Object upserts and/or deletes to apply
+   * @returns Promise that resolves once the changes have been written to the
+   *   cache. Object observers are notified synchronously; list and object-set
+   *   propagation happens reactively.
+   */
+  applyChanges(changes: ObservableClient.Changes): Promise<void>;
 
   /**
    * Invalidates the entire cache, forcing all queries to refetch.

--- a/packages/client/src/observable/internal/ObservableClientImpl.ts
+++ b/packages/client/src/observable/internal/ObservableClientImpl.ts
@@ -284,6 +284,10 @@ export class ObservableClientImpl implements ObservableClient {
     );
   }
 
+  public applyChanges(changes: ObservableClient.Changes): Promise<void> {
+    return this.__experimentalStore.applyChanges(changes);
+  }
+
   public invalidateAll(): Promise<void> {
     return this.__experimentalStore.invalidateAll();
   }

--- a/packages/client/src/observable/internal/Store.applyChanges.test.ts
+++ b/packages/client/src/observable/internal/Store.applyChanges.test.ts
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Osdk } from "@osdk/api";
+import { Employee } from "@osdk/client.test.ontology";
+import { FauxFoundry, ontologies, startNodeApiServer } from "@osdk/shared.test";
+import { beforeAll, beforeEach, describe, it } from "vitest";
+
+import type { Client } from "../../Client.js";
+import { createClient } from "../../createClient.js";
+import { TestLogger } from "../../logger/TestLogger.js";
+import type { ObservableClient } from "../ObservableClient.js";
+import { ObservableClientImpl } from "./ObservableClientImpl.js";
+import { Store } from "./Store.js";
+import {
+  createDefer,
+  expectNoMoreCalls,
+  expectSingleListCallAndClear,
+  expectSingleObjectCallAndClear,
+  mockListSubCallback,
+  mockSingleSubCallback,
+  updateList,
+  updateObject,
+  waitForCall,
+} from "./testUtils.js";
+
+// Defer utility to track subscriptions for cleanup
+const defer = createDefer();
+
+const logger = new TestLogger({});
+
+function setupOntology(fauxFoundry: FauxFoundry) {
+  ontologies.addEmployeeOntology(fauxFoundry.getDefaultOntology());
+}
+
+function setupSomeEmployees(fauxFoundry: FauxFoundry) {
+  const dataStore = fauxFoundry.getDefaultDataStore();
+  dataStore.registerObject(Employee, {
+    employeeId: 1,
+    fullName: "Employee One",
+  });
+  dataStore.registerObject(Employee, {
+    employeeId: 2,
+    fullName: "Employee Two",
+  });
+  dataStore.registerObject(Employee, {
+    employeeId: 3,
+    fullName: "Employee Three",
+  });
+}
+
+describe("Store.applyChanges", () => {
+  let client: Client;
+  let cache: Store;
+  let observableClient: ObservableClient;
+  let employeesAsServerReturns: Osdk.Instance<Employee>[];
+
+  beforeAll(async () => {
+    const testSetup = startNodeApiServer(
+      new FauxFoundry("https://stack.palantir.com/"),
+      createClient,
+      { logger }
+    );
+    ({ client } = testSetup);
+
+    setupOntology(testSetup.fauxFoundry);
+    setupSomeEmployees(testSetup.fauxFoundry);
+
+    employeesAsServerReturns = (
+      await client(Employee).fetchPage({ $includeRid: true })
+    ).data;
+
+    return () => {
+      testSetup.apiServer.close();
+    };
+  });
+
+  beforeEach(() => {
+    cache = new Store(client);
+    observableClient = new ObservableClientImpl(cache);
+    return () => {
+      cache = undefined!;
+      observableClient = undefined!;
+    };
+  });
+
+  it("upserts update an observed object without a network fetch", async () => {
+    const emp = employeesAsServerReturns[0];
+    // pre-seed the truth layer with the "real" value
+    updateObject(cache, emp);
+
+    const subFn = mockSingleSubCallback();
+    defer(
+      cache.objects.observe(
+        { apiName: Employee, pk: emp.$primaryKey, mode: "offline" },
+        subFn
+      )
+    );
+    expectSingleObjectCallAndClear(subFn, emp, "loaded");
+
+    const renamed = emp.$clone({ fullName: "Renamed via applyChanges" });
+    await observableClient.applyChanges({ upserts: [renamed] });
+
+    // Object subscribers are notified synchronously during the batch.
+    expectSingleObjectCallAndClear(subFn, renamed, "loaded");
+  });
+
+  it("upserts insert a matching object into an observed list without a network fetch", async () => {
+    const emp = employeesAsServerReturns[0];
+    const where = { $primaryKey: { $in: [emp.$primaryKey] } };
+
+    // seed an empty list query for this where clause
+    updateList(cache, { type: Employee, where, orderBy: {} }, []);
+
+    const listSubFn = mockListSubCallback();
+    defer(
+      cache.lists.observe(
+        { type: Employee, where, orderBy: {}, mode: "offline" },
+        listSubFn
+      )
+    );
+
+    await waitForCall(listSubFn, 1);
+    expectSingleListCallAndClear(listSubFn, []);
+
+    // emp is not yet in the object cache, so it is a strict-match add.
+    await observableClient.applyChanges({ upserts: [emp] });
+
+    await waitForCall(listSubFn, 1);
+    expectSingleListCallAndClear(listSubFn, [emp], {
+      status: "loaded",
+      isOptimistic: false,
+    });
+  });
+
+  it("deletes remove an object from the cache and observed lists", async () => {
+    const emp = employeesAsServerReturns[0];
+    updateList(cache, { type: Employee, where: {}, orderBy: {} }, [emp]);
+
+    const objSubFn = mockSingleSubCallback();
+    defer(
+      cache.objects.observe(
+        { apiName: Employee, pk: emp.$primaryKey, mode: "offline" },
+        objSubFn
+      )
+    );
+    expectSingleObjectCallAndClear(objSubFn, emp);
+
+    const listSubFn = mockListSubCallback();
+    defer(
+      cache.lists.observe(
+        { type: Employee, where: {}, orderBy: {}, mode: "offline" },
+        listSubFn
+      )
+    );
+    await waitForCall(listSubFn, 1);
+    expectSingleListCallAndClear(listSubFn, [emp], { status: "loaded" });
+
+    await observableClient.applyChanges({
+      deletes: [{ objectType: "Employee", primaryKey: emp.$primaryKey }],
+    });
+
+    // The object is tombstoned (observed value becomes undefined)...
+    expectSingleObjectCallAndClear(objSubFn, undefined);
+
+    // ...and drops out of the list.
+    await waitForCall(listSubFn, 1);
+    expectSingleListCallAndClear(listSubFn, []);
+  });
+
+  it("applies upserts and deletes together in a single batch", async () => {
+    const kept = employeesAsServerReturns[0];
+    const removed = employeesAsServerReturns[1];
+    updateList(cache, { type: Employee, where: {}, orderBy: {} }, [
+      kept,
+      removed,
+    ]);
+
+    const listSubFn = mockListSubCallback();
+    defer(
+      cache.lists.observe(
+        { type: Employee, where: {}, orderBy: {}, mode: "offline" },
+        listSubFn
+      )
+    );
+    await waitForCall(listSubFn, 1);
+    expectSingleListCallAndClear(listSubFn, [kept, removed], {
+      status: "loaded",
+    });
+
+    const renamedKept = kept.$clone({ fullName: "Kept + renamed" });
+    await observableClient.applyChanges({
+      upserts: [renamedKept],
+      deletes: [{ objectType: "Employee", primaryKey: removed.$primaryKey }],
+    });
+
+    // A single revalidation pass reflects both the update and the deletion.
+    await waitForCall(listSubFn, 1);
+    expectSingleListCallAndClear(listSubFn, [renamedKept]);
+  });
+
+  it("is a no-op for empty changes", async () => {
+    const emp = employeesAsServerReturns[0];
+    updateObject(cache, emp);
+
+    const subFn = mockSingleSubCallback();
+    defer(
+      cache.objects.observe(
+        { apiName: Employee, pk: emp.$primaryKey, mode: "offline" },
+        subFn
+      )
+    );
+    expectSingleObjectCallAndClear(subFn, emp, "loaded");
+
+    await observableClient.applyChanges({});
+    await observableClient.applyChanges({ upserts: [], deletes: [] });
+
+    expectNoMoreCalls(subFn);
+  });
+});

--- a/packages/client/src/observable/internal/Store.ts
+++ b/packages/client/src/observable/internal/Store.ts
@@ -33,6 +33,7 @@ import { DEBUG_REFCOUNTS } from "../DebugFlags.js";
 import type {
   CacheEntry,
   CacheSnapshot,
+  ObservableClient,
   ObservableClientOptions,
 } from "../ObservableClient.js";
 import type { OptimisticBuilder } from "../OptimisticBuilder.js";
@@ -320,6 +321,51 @@ export class Store {
     changes: Changes;
   } {
     return this.layers.batch({ optimisticId, changes }, batchFn);
+  }
+
+  /**
+   * Apply a batch of externally-sourced object changes directly to the cache.
+   *
+   * Upserts reuse the same ingest path as server page fetches and websocket
+   * stream updates (`storeOsdkInstances` -> `writeToStore` -> `propagateWrite`).
+   * Deletes reuse the existing tombstone path used by action results: every
+   * registered cache variant of the object is tombstoned via
+   * `deleteFromStore` -> `propagateWrite`. Objects that were never loaded have
+   * no registered variants and are ignored (there is nothing observing them).
+   *
+   * Everything runs inside a single {@link batch} so the accumulated changes
+   * propagate to observing queries in one revalidation pass. Applying no
+   * changes is a no-op.
+   */
+  public applyChanges(changes: ObservableClient.Changes): Promise<void> {
+    const { upserts, deletes } = changes;
+    const hasUpserts = upserts != null && upserts.length > 0;
+    const hasDeletes = deletes != null && deletes.length > 0;
+
+    if (hasUpserts || hasDeletes) {
+      this.batch({}, (batch) => {
+        if (hasUpserts) {
+          // Spread to a mutable array so the readonly public type is assignable
+          // to storeOsdkInstances' parameter.
+          this.objects.storeOsdkInstances([...upserts], batch);
+        }
+
+        for (const { objectType, primaryKey } of deletes ?? []) {
+          // Tombstone every registered variant (base + RDP/select variants) so
+          // the deletion is recorded in `batch.changes` and lists/object sets
+          // containing the object drop it. Loading an object into any query
+          // registers its cache key, so anything currently observed is covered.
+          for (const cacheKey of this.objectCacheKeyRegistry.getVariants(
+            objectType,
+            primaryKey
+          )) {
+            this.queries.peek(cacheKey)?.deleteFromStore("loaded", batch);
+          }
+        }
+      });
+    }
+
+    return Promise.resolve();
   }
 
   public invalidateObject<T extends ObjectTypeDefinition>(

--- a/packages/monorepo.cspell/dict.normal-dev-words.txt
+++ b/packages/monorepo.cspell/dict.normal-dev-words.txt
@@ -40,6 +40,7 @@ struct
 structs
 subdependencies
 subdeps
+tombstoned
 trackpad
 tsdoc
 typecheck
@@ -51,4 +52,6 @@ ungroup
 unioned
 unresolve
 Unsubscribable
+upsert
+upserts
 webapi


### PR DESCRIPTION
## What

Adds a new `applyChanges` method (and an `ObservableClient.Changes` type) to `@osdk/client`'s `ObservableClient`. It pushes externally-sourced object upserts and deletes straight into the observable cache that the `@osdk/react` / `@osdk/react-components` hooks read.

```ts
export namespace ObservableClient {
  export interface Changes {
    upserts?: ReadonlyArray<Osdk.Instance<ObjectOrInterfaceDefinition, "$allBaseProperties">>;
    deletes?: ReadonlyArray<{ objectType: string; primaryKey: string | number }>;
  }
}

interface ObservableClient {
  applyChanges(changes: ObservableClient.Changes): Promise<void>;
}
```

## How

It reuses the existing ingest paths rather than inventing a new one, all inside a single `Store.batch`:

- **upserts** go through `objects.storeOsdkInstances` -> `writeToStore` -> `propagateWrite`, the same path server page fetches and websocket stream updates use.
- **deletes** tombstone every registered cache variant of the object via `deleteFromStore` -> `propagateWrite` (the same path action-result deletes use). Objects that were never loaded have no registered variants and are ignored.

Because it runs in one batch, all observing hooks (objects, lists, object sets, links, dependent functions) update reactively without a network round trip.

## Why

This is the seam an embedded or offline ontology engine uses to stream locally-synced deltas into the hooks. Combined with the already-public `createClientWithSubscriptionConnection` (subscription transport), the `fetchFn` override on `createClient` (reads/writes), and `objectFactory` (wire to instance conversion), it lets such an engine drive every hook online and offline with live updates.

## Compatibility

Additive and non-breaking. Callers that never invoke `applyChanges` are unaffected. The `ObservableClient` interface lives on the `@osdk/client/observable` subpath, which is not part of the api-extractor main-entry report, so no API report changes.

## Testing

- New `Store.applyChanges.test.ts` (5 tests, FauxFoundry harness, `mode: "offline"`): upsert updates an observed object, upsert inserts a matching object into an observed list, delete removes an object from list + cache, combined upsert/delete in one batch, and empty no-op. All exercise cache-only updates with no network fetch.
- `pnpm turbo typecheck --filter=@osdk/client --filter=@osdk/react-devtools` passes.
- `pnpm turbo check-api --filter=@osdk/client`: report up to date.
- Full `@osdk/client` observable suite passes (356 passed, 1 skipped).

A changeset (`@osdk/client: minor`) is included.