### PR TITLE
[Components] remove deprecated ObjectTable props and unsupported API

### DIFF
--- a/.changeset/quick-otters-remember.md
+++ b/.changeset/quick-otters-remember.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+Remove the deprecated `onRowSelection` prop and the dead filtering API (`enableFiltering`, `onFilterChanged`, and the per-column `filterable`) from ObjectTable. Use `onRowSelectionChanged` for selection changes; programmatic filtering via the controlled `filter` prop is unchanged.

--- a/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/ObjectTable.stories.tsx
@@ -196,17 +196,9 @@ const meta: Meta<EmployeeTableProps> = {
         "The currently selected rows in the table. If provided, the row selection is controlled.",
       control: false,
     },
-    onRowSelection: {
-      description:
-        "Called when the row selection changes. Required when row selection is controlled.",
-      control: false,
-      table: {
-        category: "Events",
-      },
-    },
     onRowSelectionChanged: {
       description:
-        "Called when the row selection changes, with a RowSelectionChange payload (selectedRows, isSelectAll, derived objectSet). Preferred over the deprecated onRowSelection callback.",
+        "Called when the row selection changes, with a RowSelectionChange payload (selectedRows, isSelectAll, derived objectSet).",
       control: false,
       table: {
         category: "Events",

--- a/packages/react-components/CLAUDE.md
+++ b/packages/react-components/CLAUDE.md
@@ -62,7 +62,7 @@ Every feature that holds state the user can change (selection, sort, filter, exp
 ```ts
 /**
  * Controlled mode only. Caller owns selection state; component does not
- * maintain internal selection. Pair with `onRowSelection` to observe changes.
+ * maintain internal selection. Pair with `onRowSelectionChanged` to observe changes.
  */
 selectedRows?: RowSelectionState;
 ```
@@ -76,9 +76,9 @@ selectedRows?: RowSelectionState;
 defaultOrderBy?: OrderBy;
 ```
 
-**Naming**: `<feature>` (controlled), `default<Feature>` (uncontrolled seed), `on<Feature>Changed` (callback). Match `ObjectTableApi.ts` exactly: `selectedRows` / `onRowSelection`, `orderBy` / `defaultOrderBy` / `onOrderByChanged`, `filter` / `onFilterChanged`.
+**Naming**: `<feature>` (controlled), `default<Feature>` (uncontrolled seed), `on<Feature>Changed` (callback). Match `ObjectTableApi.ts` exactly: `selectedRows` / `onRowSelectionChanged`, `orderBy` / `defaultOrderBy` / `onOrderByChanged`.
 
-**Canonical implementation** (both modes): see `src/object-table/hooks/useRowSelection.ts` — `rowSelectionState` is computed from `selectedRows` when controlled, falls back to `internalRowSelection` (a `useState({})`) otherwise; `onRowSelection` fires in both modes. Use this pattern when implementing both modes; for single-mode features, drop the branch you don't support.
+**Canonical implementation** (both modes): see `src/object-table/hooks/useRowSelection.ts` — `rowSelectionState` is computed from `selectedRows` when controlled, falls back to `internalRowSelection` (a `useState({})`) otherwise; `onRowSelectionChanged` fires in both modes. Use this pattern when implementing both modes; for single-mode features, drop the branch you don't support.
 
 ### Render override slots
 

--- a/packages/react-components/docs/ObjectTable.md
+++ b/packages/react-components/docs/ObjectTable.md
@@ -87,9 +87,7 @@ Type parameters: `Q extends ObjectOrInterfaceDefinition`, `RDPs extends Record<s
 | `streamUpdates`             | `boolean`                                                                                                                                | Enable streaming updates via websocket subscription. When true, the table will automatically update when matching objects are added, updated, or removed in Foundry.<br /><br />Limitations: `streamUpdates` cannot be used together with `pivotTo` or `withProperties`. The server does not support websocket subscriptions for link-traversal or derived-property queries. Those queries still fetch data normally but won't receive real-time updates. Defaults to `false`. |
 | `pageSize`                  | `number`                                                                                                                                 | Number of objects to fetch per page. Defaults to `50`.                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | `columnDefinitions`         | `Array<ColumnDefinition<Q, RDPs, FunctionColumns>>`                                                                                      | Ordered list of column definitions to show in the table<br /><br />If not provided, all of the properties of the object type will be shown in default order.                                                                                                                                                                                                                                                                                                                   |
-| `enableFiltering`           | `boolean`                                                                                                                                | Whether the table is filterable by the user. Defaults to `true`.                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `filter`                    | `WhereClause<Q, RDPs>`                                                                                                                   | The current where clause to filter the objects in the table. If provided, the filter is controlled.                                                                                                                                                                                                                                                                                                                                                                            |
-| `onFilterChanged`           | `(newWhere: WhereClause<Q, RDPs>) => void`                                                                                               | Called when the where clause is changed. Required when filter is controlled.                                                                                                                                                                                                                                                                                                                                                                                                   |
 | `enableOrdering`            | `boolean`                                                                                                                                | Whether the table is sortable by the user. Defaults to `true`.                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `enableColumnPinning`       | `boolean`                                                                                                                                | Whether columns can be pinned by the user. Defaults to `true`.                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `enableColumnResizing`      | `boolean`                                                                                                                                | Whether columns can be resized by the user. Defaults to `true`.                                                                                                                                                                                                                                                                                                                                                                                                                |
@@ -111,7 +109,6 @@ Type parameters: `Q extends ObjectOrInterfaceDefinition`, `RDPs extends Record<s
 | `selectionMode`             | `"single" \| "multiple" \| "none"`                                                                                                       | Selection mode for the table rows.<br /><br />If multiple, a checkbox will be shown for each row to allow selecting multiple rows as well as a top-level checkbox in the header to select all rows. Defaults to `"none"`.                                                                                                                                                                                                                                                      |
 | `selectedRows`              | `PrimaryKeyType<Q>[]`                                                                                                                    | The currently selected rows in the table. If provided, the row selection is controlled.                                                                                                                                                                                                                                                                                                                                                                                        |
 | `isAllSelected`             | `boolean`                                                                                                                                | Indicates whether all rows are selected in controlled mode. When true, the table will show all rows as selected regardless of the selectedRows array.                                                                                                                                                                                                                                                                                                                          |
-| `onRowSelection`            | `(selectedRowIds: PrimaryKeyType<Q>[], isSelectAll?: boolean) => void`                                                                   | **Deprecated** — Use `onRowSelectionChanged` instead. The new callback delivers a `RowSelectionChange` object with `selectedRows`, `isSelectAll`, and a derived `objectSet`. This legacy callback continues to fire alongside the new one for backwards compatibility. Called when the row selection changes.                                                                                                                                                                  |
 | `onRowSelectionChanged`     | `(change: RowSelectionChange<Q, RDPs>) => void`                                                                                          | Called when the row selection changes, with a `RowSelectionChange` payload describing the new state.                                                                                                                                                                                                                                                                                                                                                                           |
 | `renderCellContextMenu`     | `(row: Osdk.Instance<Q, "$allBaseProperties", PropertyKeys<Q>, RDPs>, cellValue: unknown) => React.ReactNode`                            | If provided, will render this context menu when right clicking on a cell                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `renderEmptyState`          | `() => React.ReactNode`                                                                                                                  | Render override for the empty state. Called when the table has no rows and no error. When omitted, a default "No Data" indicator is rendered.                                                                                                                                                                                                                                                                                                                                  |
@@ -158,7 +155,6 @@ Type parameters: `Q extends ObjectOrInterfaceDefinition`, `RDPs extends Record<s
 | `maxWidth`        | `number`                                                                                                                                                 |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `resizable`       | `boolean`                                                                                                                                                |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `orderable`       | `boolean`                                                                                                                                                |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| `filterable`      | `boolean`                                                                                                                                                |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `renderCell`      | `(object: Osdk.Instance<Q, "$allBaseProperties", PropertyKeys<Q>, RDPs>, locator: ColumnDefinitionLocator<Q, RDPs, FunctionColumns>) => React.ReactNode` | Custom renderer for the cell value.<br /><br />Interaction with `editable` columns: - When `editMode: "manual"` (default), `renderCell` is used while the table is read-only (Edit Table button visible) and the editable cell takes over once the user enters edit mode. - When `editMode: "always"`, the editable cell always wins on editable columns and `renderCell` is ignored — `editMode: "always"` opts the column into a permanently-editable surface, leaving no read-only state for `renderCell` to render. Use `editMode: "manual"` if you need a custom display alongside editing. |
 | `columnName`      | `string`                                                                                                                                                 | If provided, this will be used in the column header. If both columnName and renderHeader are provided, renderHeader will take precedence in the table header. columnName will still be used in other parts where the column name is displayed.<br /><br />If not provided, for a property column, the property displayName will be used for other columns, the id will be used.                                                                                                                                                                                                                  |
 | `renderHeader`    | `() => React.ReactNode`                                                                                                                                  | If provided, this will be used to render the header component. When both columnName and renderHeader are provided, renderHeader will take precedence in the table header.                                                                                                                                                                                                                                                                                                                                                                                                                        |
@@ -627,22 +623,11 @@ function EmployeesTable() {
   const [selectedRows, setSelectedRows] = useState<string[]>([]);
   const [isAllSelected, setIsAllSelected] = useState(false);
 
-  const handleRowSelection = (
-    selectedRowIds: string[],
-    isSelectAll?: boolean,
-  ) => {
-    if (isSelectAll) {
-      if (selectedRowIds.length === 0) {
-        setIsAllSelected(false);
-        setSelectedRows([]);
-      } else {
-        setIsAllSelected(true);
-        setSelectedRows([]);
-      }
-    } else {
-      setIsAllSelected(false);
-      setSelectedRows(selectedRowIds);
-    }
+  const handleRowSelectionChanged = ({ selectedRows, isSelectAll }) => {
+    setIsAllSelected(isSelectAll);
+    setSelectedRows(
+      isSelectAll ? [] : selectedRows.map((row) => row.$primaryKey),
+    );
   };
 
   return (
@@ -653,7 +638,7 @@ function EmployeesTable() {
         selectionMode="multiple"
         selectedRows={selectedRows}
         isAllSelected={isAllSelected}
-        onRowSelection={handleRowSelection}
+        onRowSelectionChanged={handleRowSelectionChanged}
       />
     </div>
   );
@@ -662,11 +647,11 @@ function EmployeesTable() {
 
 **Key points about select all behavior:**
 
-- The `isSelectAll` parameter in `onRowSelection` indicates whether the change was triggered by the "select all" checkbox
+- The `isSelectAll` field in the `onRowSelectionChanged` payload indicates whether the change was triggered by the "select all" checkbox
 - When `isAllSelected` is `true`, the table shows all rows as selected regardless of the `selectedRows` array content
 - This allows efficient handling of "select all" without loading all object IDs
 - Individual row selections automatically set `isAllSelected` to `false`
-- After "select all", new rows loaded via scroll (`fetchMore`) stay visually checked and `onRowSelection` refires with the expanded id list so controlled callers stay in sync
+- After "select all", new rows loaded via scroll (`fetchMore`) stay visually checked and `onRowSelectionChanged` refires with the expanded selection so controlled callers stay in sync
 
 ### Listening to selection changes
 
@@ -699,17 +684,6 @@ function EmployeesTable() {
   }}
 />;
 ```
-
-#### Migrating from `onRowSelection`
-
-The legacy `onRowSelection(selectedRowIds, isSelectAll?)` callback is deprecated but still fires for backwards compatibility. The equivalents in `onRowSelectionChanged` are:
-
-| Legacy parameter           | New payload field                      |
-| -------------------------- | -------------------------------------- |
-| `selectedRowIds`           | `selectedRows.map(r => r.$primaryKey)` |
-| `isSelectAll` (second arg) | `isSelectAll`                          |
-| _(not previously exposed)_ | `selectedRows`                         |
-| _(not previously exposed)_ | `objectSet`                            |
 
 ### Example 12: Custom Column Type
 
@@ -1211,7 +1185,6 @@ const columnDefinitions: Array<ColumnDefinition<typeof Employee>> = [
   {
     locator: { type: "property", id: "fullName" },
     orderable: false,
-    filterable: false,
   },
 ];
 ```
@@ -1520,7 +1493,7 @@ type EmployeeProps = PropertyKeys<typeof Employee>;
 ### Selection not working
 
 - Ensure `selectionMode` is set to "single" or "multiple"
-- For controlled mode, provide both `selectedRows` and `onRowSelection`
+- For controlled mode, provide both `selectedRows` and `onRowSelectionChanged`
 
 ### Custom rendering not appearing
 

--- a/packages/react-components/src/object-table/ObjectTable.tsx
+++ b/packages/react-components/src/object-table/ObjectTable.tsx
@@ -66,8 +66,6 @@ export function ObjectTable<
   onOrderByChanged,
   onColumnsPinnedChanged,
   onColumnResize,
-  // eslint-disable-next-line @typescript-eslint/no-deprecated -- intentional pass-through to fire alongside onRowSelectionChanged for backwards compatibility
-  onRowSelection,
   onRowSelectionChanged,
   onColumnHeaderClick,
   renderCellContextMenu,
@@ -150,7 +148,6 @@ export function ObjectTable<
     selectionMode,
     selectedRows,
     isAllSelected: isAllSelectedProp,
-    onRowSelection,
     onRowSelectionChanged: handleRowSelectionChanged,
     data,
   });

--- a/packages/react-components/src/object-table/ObjectTableApi.ts
+++ b/packages/react-components/src/object-table/ObjectTableApi.ts
@@ -73,7 +73,6 @@ interface SharedColumnDefinition<
   maxWidth?: number;
   resizable?: boolean;
   orderable?: boolean;
-  filterable?: boolean;
 
   /**
    * Custom renderer for the cell value.
@@ -349,25 +348,10 @@ export interface ObjectTableProps<
   columnDefinitions?: Array<ColumnDefinition<Q, RDPs, FunctionColumns>>;
 
   /**
-   * Whether the table is filterable by the user.
-   *
-   * @default true
-   */
-  enableFiltering?: boolean;
-
-  /**
    * The current where clause to filter the objects in the table.
    * If provided, the filter is controlled.
    */
   filter?: WhereClause<Q, RDPs>;
-
-  /**
-   * Called when the where clause is changed.
-   * Required when filter is controlled.
-   *
-   * @param newWhere The new where clause
-   */
-  onFilterChanged?: (newWhere: WhereClause<Q, RDPs>) => void;
 
   /**
    * Whether the table is sortable by the user.
@@ -583,22 +567,6 @@ export interface ObjectTableProps<
    * When true, the table will show all rows as selected regardless of the selectedRows array.
    */
   isAllSelected?: boolean;
-
-  /**
-   * Called when the row selection changes.
-   *
-   * @deprecated Use {@link onRowSelectionChanged} instead. The new callback
-   * delivers a {@link RowSelectionChange} object with `selectedRows`,
-   * `isSelectAll`, and a derived `objectSet`. This legacy callback
-   * continues to fire alongside the new one for backwards compatibility.
-   *
-   * @param selectedRowIds The primary keys of currently selected rows
-   * @param isSelectAll Whether the change was triggered by a "select all" action. Defaults to false
-   */
-  onRowSelection?: (
-    selectedRowIds: PrimaryKeyType<Q>[],
-    isSelectAll?: boolean
-  ) => void;
 
   /**
    * Called when the row selection changes, with a {@link RowSelectionChange}

--- a/packages/react-components/src/object-table/hooks/__tests__/useColumnDefs.test.tsx
+++ b/packages/react-components/src/object-table/hooks/__tests__/useColumnDefs.test.tsx
@@ -212,7 +212,6 @@ describe(useColumnDefs, () => {
           maxWidth: 400,
           resizable: true,
           orderable: true,
-          filterable: false,
         },
         {
           locator: { type: "property", id: "email" as TestObjectKeys },
@@ -244,7 +243,6 @@ describe(useColumnDefs, () => {
       expect(nameColumn.maxSize).toBe(400);
       expect(nameColumn.enableResizing).toBe(true);
       expect(nameColumn.enableSorting).toBe(true);
-      expect(nameColumn.enableColumnFilter).toBe(false);
 
       const emailColumn = result.current.columns[1];
       expect(emailColumn.id).toBe("email");
@@ -267,7 +265,6 @@ describe(useColumnDefs, () => {
           maxWidth: 400,
           resizable: true,
           orderable: true,
-          filterable: false,
         },
         {
           locator: { type: "property", id: "email" as TestObjectKeys },

--- a/packages/react-components/src/object-table/hooks/__tests__/useRowSelection.test.tsx
+++ b/packages/react-components/src/object-table/hooks/__tests__/useRowSelection.test.tsx
@@ -94,13 +94,13 @@ describe("useRowSelection", () => {
 
   describe("uncontrolled mode", () => {
     describe("single selection mode", () => {
-      it("selects a single row and calls onRowSelection", () => {
+      it("selects a single row and calls onRowSelectionChanged", () => {
         const data = createMockData(5);
-        const onRowSelection = vi.fn();
+        const onRowSelectionChanged = vi.fn();
         const { result } = renderHook(() =>
           useRowSelection({
             selectionMode: "single",
-            onRowSelection,
+            onRowSelectionChanged,
             data,
           })
         );
@@ -112,19 +112,19 @@ describe("useRowSelection", () => {
         expect(result.current.enableRowSelection).toBe(true);
         expect(result.current.rowSelection).toEqual({ "item-0": true });
         expect(result.current.hasSelection).toBe(true);
-        expect(onRowSelection).toHaveBeenCalledWith(
-          [data[0].$primaryKey],
-          false
-        );
+        expect(onRowSelectionChanged).toHaveBeenCalledWith({
+          selectedRows: [data[0]],
+          isSelectAll: false,
+        });
       });
 
-      it("deselects when toggling selected row and calls onRowSelection", () => {
+      it("deselects when toggling selected row and calls onRowSelectionChanged", () => {
         const data = createMockData(5);
-        const onRowSelection = vi.fn();
+        const onRowSelectionChanged = vi.fn();
         const { result } = renderHook(() =>
           useRowSelection({
             selectionMode: "single",
-            onRowSelection,
+            onRowSelectionChanged,
             data,
           })
         );
@@ -143,7 +143,10 @@ describe("useRowSelection", () => {
 
         expect(result.current.rowSelection).toEqual({});
         expect(result.current.hasSelection).toBe(false);
-        expect(onRowSelection).toHaveBeenLastCalledWith([], false);
+        expect(onRowSelectionChanged).toHaveBeenLastCalledWith({
+          selectedRows: [],
+          isSelectAll: false,
+        });
       });
 
       it("replaces selection when selecting different row", () => {
@@ -171,11 +174,11 @@ describe("useRowSelection", () => {
 
       it("onToggleAll selects all rows in single selection mode", () => {
         const data = createMockData(3);
-        const onRowSelection = vi.fn();
+        const onRowSelectionChanged = vi.fn();
         const { result } = renderHook(() =>
           useRowSelection({
             selectionMode: "single",
-            onRowSelection,
+            onRowSelectionChanged,
             data,
           })
         );
@@ -190,10 +193,10 @@ describe("useRowSelection", () => {
           "item-2": true,
         });
         expect(result.current.isAllSelected).toBe(true);
-        expect(onRowSelection).toHaveBeenCalledWith(
-          data.map((item) => item.$primaryKey),
-          true
-        );
+        expect(onRowSelectionChanged).toHaveBeenCalledWith({
+          selectedRows: data,
+          isSelectAll: true,
+        });
 
         // Toggling all again deselects
         act(() => {
@@ -227,13 +230,13 @@ describe("useRowSelection", () => {
     });
 
     describe("multiple selection mode", () => {
-      it("selects multiple rows independently and calls onRowSelection", () => {
+      it("selects multiple rows independently and calls onRowSelectionChanged", () => {
         const data = createMockData(5);
-        const onRowSelection = vi.fn();
+        const onRowSelectionChanged = vi.fn();
         const { result } = renderHook(() =>
           useRowSelection({
             selectionMode: "multiple",
-            onRowSelection,
+            onRowSelectionChanged,
             data,
           })
         );
@@ -254,10 +257,10 @@ describe("useRowSelection", () => {
           "item-2": true,
         });
         expect(result.current.isAllSelected).toBe(false);
-        expect(onRowSelection).toHaveBeenLastCalledWith(
-          [data[0].$primaryKey, data[2].$primaryKey],
-          false
-        );
+        expect(onRowSelectionChanged).toHaveBeenLastCalledWith({
+          selectedRows: [data[0], data[2]],
+          isSelectAll: false,
+        });
       });
 
       it("deselects individual rows", () => {
@@ -290,13 +293,13 @@ describe("useRowSelection", () => {
         expect(result.current.rowSelection).toEqual({ "item-1": true });
       });
 
-      it("selects range with shift-click and calls onRowSelection", () => {
+      it("selects range with shift-click and calls onRowSelectionChanged", () => {
         const data = createMockData(5);
-        const onRowSelection = vi.fn();
+        const onRowSelectionChanged = vi.fn();
         const { result } = renderHook(() =>
           useRowSelection({
             selectionMode: "multiple",
-            onRowSelection,
+            onRowSelectionChanged,
             data,
           })
         );
@@ -316,10 +319,10 @@ describe("useRowSelection", () => {
           "item-2": true,
           "item-3": true,
         });
-        expect(onRowSelection).toHaveBeenLastCalledWith(
-          [data[1].$primaryKey, data[2].$primaryKey, data[3].$primaryKey],
-          false
-        );
+        expect(onRowSelectionChanged).toHaveBeenLastCalledWith({
+          selectedRows: [data[1], data[2], data[3]],
+          isSelectAll: false,
+        });
       });
 
       it("selects range in reverse order (shift-click up)", () => {
@@ -476,11 +479,11 @@ describe("useRowSelection", () => {
 
       it("toggles all rows", () => {
         const data = createMockData(3);
-        const onRowSelection = vi.fn();
+        const onRowSelectionChanged = vi.fn();
         const { result } = renderHook(() =>
           useRowSelection({
             selectionMode: "multiple",
-            onRowSelection,
+            onRowSelectionChanged,
             data,
           })
         );
@@ -498,10 +501,10 @@ describe("useRowSelection", () => {
           "item-2": true,
         });
         expect(result.current.isAllSelected).toBe(true);
-        expect(onRowSelection).toHaveBeenCalledWith(
-          [data[0].$primaryKey, data[1].$primaryKey, data[2].$primaryKey],
-          true
-        );
+        expect(onRowSelectionChanged).toHaveBeenCalledWith({
+          selectedRows: [data[0], data[1], data[2]],
+          isSelectAll: true,
+        });
 
         // Deselect all
         act(() => {
@@ -510,18 +513,21 @@ describe("useRowSelection", () => {
 
         expect(result.current.rowSelection).toEqual({});
         expect(result.current.isAllSelected).toBe(false);
-        expect(onRowSelection).toHaveBeenLastCalledWith([], false);
+        expect(onRowSelectionChanged).toHaveBeenLastCalledWith({
+          selectedRows: [],
+          isSelectAll: false,
+        });
       });
     });
 
     describe("lastSelectedRowIndex after onToggleAll", () => {
       it("shift-click after select-all then deselect-all treats click as normal (no stale anchor)", () => {
         const data = createMockData(5);
-        const onRowSelection = vi.fn();
+        const onRowSelectionChanged = vi.fn();
         const { result } = renderHook(() =>
           useRowSelection({
             selectionMode: "multiple",
-            onRowSelection,
+            onRowSelectionChanged,
             data,
           })
         );
@@ -549,21 +555,21 @@ describe("useRowSelection", () => {
           result.current.onToggleRow("item-3", 3, true);
         });
 
-        expect(onRowSelection).toHaveBeenLastCalledWith(
-          [data[1].$primaryKey, data[2].$primaryKey, data[3].$primaryKey],
-          false
-        );
+        expect(onRowSelectionChanged).toHaveBeenLastCalledWith({
+          selectedRows: [data[1], data[2], data[3]],
+          isSelectAll: false,
+        });
       });
     });
 
     describe("onToggleAll from indeterminate state", () => {
       it("deselects all when some rows are selected (uncontrolled)", () => {
         const data = createMockData(5);
-        const onRowSelection = vi.fn();
+        const onRowSelectionChanged = vi.fn();
         const { result } = renderHook(() =>
           useRowSelection({
             selectionMode: "multiple",
-            onRowSelection,
+            onRowSelectionChanged,
             data,
           })
         );
@@ -587,17 +593,20 @@ describe("useRowSelection", () => {
         expect(result.current.rowSelection).toEqual({});
         expect(result.current.isAllSelected).toBe(false);
         expect(result.current.hasSelection).toBe(false);
-        expect(onRowSelection).toHaveBeenLastCalledWith([], false);
+        expect(onRowSelectionChanged).toHaveBeenLastCalledWith({
+          selectedRows: [],
+          isSelectAll: false,
+        });
       });
 
       it("deselects all when controlled selectedRows is non-empty but not all", () => {
         const data = createMockData(5);
-        const onRowSelection = vi.fn();
+        const onRowSelectionChanged = vi.fn();
         const { result } = renderHook(() =>
           useRowSelection({
             selectionMode: "multiple",
             selectedRows: [data[0].$primaryKey, data[2].$primaryKey],
-            onRowSelection,
+            onRowSelectionChanged,
             data,
           })
         );
@@ -609,19 +618,22 @@ describe("useRowSelection", () => {
           result.current.onToggleAll();
         });
 
-        expect(onRowSelection).toHaveBeenCalledWith([], false);
+        expect(onRowSelectionChanged).toHaveBeenCalledWith({
+          selectedRows: [],
+          isSelectAll: false,
+        });
       });
     });
 
     describe("select-all persists when data grows (scroll/fetchMore)", () => {
       it("keeps all rows checked when new rows arrive after select-all", () => {
         const initialData = createMockData(3);
-        const onRowSelection = vi.fn();
+        const onRowSelectionChanged = vi.fn();
         const { result, rerender } = renderHook(
           ({ data }) =>
             useRowSelection({
               selectionMode: "multiple",
-              onRowSelection,
+              onRowSelectionChanged,
               data,
             }),
           { initialProps: { data: initialData } }
@@ -654,20 +666,20 @@ describe("useRowSelection", () => {
         expect(result.current.isAllSelected).toBe(true);
         expect(result.current.hasSelection).toBe(true);
 
-        // onRowSelection refires with the expanded id list so callers stay in sync
-        expect(onRowSelection).toHaveBeenLastCalledWith(
-          moreData.map((item) => item.$primaryKey),
-          true
-        );
+        // onRowSelectionChanged refires with the expanded id list so callers stay in sync
+        expect(onRowSelectionChanged).toHaveBeenLastCalledWith({
+          selectedRows: moreData,
+          isSelectAll: true,
+        });
       });
 
       it("drops out of select-all when an individual row is toggled", () => {
         const initialData = createMockData(3);
-        const onRowSelection = vi.fn();
+        const onRowSelectionChanged = vi.fn();
         const { result } = renderHook(() =>
           useRowSelection({
             selectionMode: "multiple",
-            onRowSelection,
+            onRowSelectionChanged,
             data: initialData,
           })
         );
@@ -687,20 +699,20 @@ describe("useRowSelection", () => {
           "item-0": true,
           "item-2": true,
         });
-        expect(onRowSelection).toHaveBeenLastCalledWith(
-          [initialData[0].$primaryKey, initialData[2].$primaryKey],
-          false
-        );
+        expect(onRowSelectionChanged).toHaveBeenLastCalledWith({
+          selectedRows: [initialData[0], initialData[2]],
+          isSelectAll: false,
+        });
       });
 
-      it("does not re-fire onRowSelection if data identity changes but ids stay the same", () => {
+      it("does not re-fire onRowSelectionChanged if data identity changes but ids stay the same", () => {
         const initialData = createMockData(3);
-        const onRowSelection = vi.fn();
+        const onRowSelectionChanged = vi.fn();
         const { result, rerender } = renderHook(
           ({ data }) =>
             useRowSelection({
               selectionMode: "multiple",
-              onRowSelection,
+              onRowSelectionChanged,
               data,
             }),
           { initialProps: { data: initialData } }
@@ -709,21 +721,23 @@ describe("useRowSelection", () => {
         act(() => {
           result.current.onToggleAll();
         });
-        const callsAfterToggleAll = onRowSelection.mock.calls.length;
+        const callsAfterToggleAll = onRowSelectionChanged.mock.calls.length;
 
         // Same ids, different array identity (common after refetch with unchanged data)
         rerender({ data: createMockData(3) });
 
-        expect(onRowSelection).toHaveBeenCalledTimes(callsAfterToggleAll);
+        expect(onRowSelectionChanged).toHaveBeenCalledTimes(
+          callsAfterToggleAll
+        );
       });
 
       it("does not auto-fire when data arrives after mount with no select-all active", () => {
-        const onRowSelection = vi.fn();
+        const onRowSelectionChanged = vi.fn();
         const { rerender } = renderHook(
           ({ data }) =>
             useRowSelection({
               selectionMode: "multiple",
-              onRowSelection,
+              onRowSelectionChanged,
               data,
             }),
           {
@@ -745,16 +759,16 @@ describe("useRowSelection", () => {
         rerender({ data: createMockData(3) });
 
         // No select-all was active, so no callback fire expected.
-        expect(onRowSelection).not.toHaveBeenCalled();
+        expect(onRowSelectionChanged).not.toHaveBeenCalled();
       });
 
       it("does not re-fire after deselect-all when data grows", () => {
-        const onRowSelection = vi.fn();
+        const onRowSelectionChanged = vi.fn();
         const { result, rerender } = renderHook(
           ({ data }) =>
             useRowSelection({
               selectionMode: "multiple",
-              onRowSelection,
+              onRowSelectionChanged,
               data,
             }),
           { initialProps: { data: createMockData(3) } }
@@ -768,13 +782,13 @@ describe("useRowSelection", () => {
           result.current.onToggleAll();
         });
 
-        const callsAfterDeselect = onRowSelection.mock.calls.length;
+        const callsAfterDeselect = onRowSelectionChanged.mock.calls.length;
 
-        // More rows arrive — should not refire onRowSelection because we
+        // More rows arrive — should not refire onRowSelectionChanged because we
         // explicitly exited "select all" mode.
         rerender({ data: createMockData(5) });
 
-        expect(onRowSelection).toHaveBeenCalledTimes(callsAfterDeselect);
+        expect(onRowSelectionChanged).toHaveBeenCalledTimes(callsAfterDeselect);
       });
     });
   });
@@ -795,15 +809,15 @@ describe("useRowSelection", () => {
         expect(result.current.hasSelection).toBe(true);
       });
 
-      it("calls onRowSelection when toggling but does not update internal state", () => {
+      it("calls onRowSelectionChanged when toggling but does not update internal state", () => {
         const data = createMockData(5);
-        const onRowSelection = vi.fn();
+        const onRowSelectionChanged = vi.fn();
         const { result, rerender } = renderHook(
           ({ selectedRows }) =>
             useRowSelection({
               selectionMode: "single",
               selectedRows,
-              onRowSelection,
+              onRowSelectionChanged,
               data,
             }),
           {
@@ -819,10 +833,10 @@ describe("useRowSelection", () => {
         });
 
         // Callback is called
-        expect(onRowSelection).toHaveBeenCalledWith(
-          [data[0].$primaryKey],
-          false
-        );
+        expect(onRowSelectionChanged).toHaveBeenCalledWith({
+          selectedRows: [data[0]],
+          isSelectAll: false,
+        });
 
         // State doesn't change (controlled)
         expect(result.current.rowSelection).toEqual({});
@@ -852,14 +866,14 @@ describe("useRowSelection", () => {
         });
       });
 
-      it("calls onRowSelection when toggling rows", () => {
+      it("calls onRowSelectionChanged when toggling rows", () => {
         const data = createMockData(5);
-        const onRowSelection = vi.fn();
+        const onRowSelectionChanged = vi.fn();
         const { result } = renderHook(() =>
           useRowSelection({
             selectionMode: "multiple",
             selectedRows: [data[0].$primaryKey],
-            onRowSelection,
+            onRowSelectionChanged,
             data,
           })
         );
@@ -869,27 +883,30 @@ describe("useRowSelection", () => {
           result.current.onToggleRow("item-2", 2);
         });
 
-        expect(onRowSelection).toHaveBeenCalledWith(
-          [data[0].$primaryKey, data[2].$primaryKey],
-          false
-        );
+        expect(onRowSelectionChanged).toHaveBeenCalledWith({
+          selectedRows: [data[0], data[2]],
+          isSelectAll: false,
+        });
 
         // Remove selection from selectedRows
         act(() => {
           result.current.onToggleRow("item-0", 0);
         });
 
-        expect(onRowSelection).toHaveBeenCalledWith([], false);
+        expect(onRowSelectionChanged).toHaveBeenCalledWith({
+          selectedRows: [],
+          isSelectAll: false,
+        });
       });
 
-      it("calls onRowSelection for shift-click range selection", () => {
+      it("calls onRowSelectionChanged for shift-click range selection", () => {
         const data = createMockData(5);
-        const onRowSelection = vi.fn();
+        const onRowSelectionChanged = vi.fn();
         const { result } = renderHook(() =>
           useRowSelection({
             selectionMode: "multiple",
             selectedRows: [],
-            onRowSelection,
+            onRowSelectionChanged,
             data,
           })
         );
@@ -904,21 +921,21 @@ describe("useRowSelection", () => {
           result.current.onToggleRow("item-3", 3, true);
         });
 
-        expect(onRowSelection).toHaveBeenLastCalledWith(
-          [data[1].$primaryKey, data[2].$primaryKey, data[3].$primaryKey],
-          false
-        );
+        expect(onRowSelectionChanged).toHaveBeenLastCalledWith({
+          selectedRows: [data[1], data[2], data[3]],
+          isSelectAll: false,
+        });
       });
 
       it("shift-click range merges with updated controlled selectedRows", () => {
         const data = createMockData(5);
-        const onRowSelection = vi.fn();
+        const onRowSelectionChanged = vi.fn();
         const { result, rerender } = renderHook(
           ({ selectedRows }) =>
             useRowSelection({
               selectionMode: "multiple",
               selectedRows,
-              onRowSelection,
+              onRowSelectionChanged,
               data,
             }),
           {
@@ -941,20 +958,20 @@ describe("useRowSelection", () => {
           result.current.onToggleRow("item-3", 3, true);
         });
 
-        expect(onRowSelection).toHaveBeenLastCalledWith(
-          [data[1].$primaryKey, data[2].$primaryKey, data[3].$primaryKey],
-          false
-        );
+        expect(onRowSelectionChanged).toHaveBeenLastCalledWith({
+          selectedRows: [data[1], data[2], data[3]],
+          isSelectAll: false,
+        });
       });
 
-      it("calls onRowSelection when toggling all rows", () => {
+      it("calls onRowSelectionChanged when toggling all rows", () => {
         const data = createMockData(3);
-        const onRowSelection = vi.fn();
+        const onRowSelectionChanged = vi.fn();
         const { result } = renderHook(() =>
           useRowSelection({
             selectionMode: "multiple",
             selectedRows: [],
-            onRowSelection,
+            onRowSelectionChanged,
             data,
           })
         );
@@ -963,10 +980,10 @@ describe("useRowSelection", () => {
           result.current.onToggleAll();
         });
 
-        expect(onRowSelection).toHaveBeenCalledWith(
-          [data[0].$primaryKey, data[1].$primaryKey, data[2].$primaryKey],
-          true
-        );
+        expect(onRowSelectionChanged).toHaveBeenCalledWith({
+          selectedRows: [data[0], data[1], data[2]],
+          isSelectAll: true,
+        });
       });
 
       it("updates when selectedRows prop changes", () => {
@@ -999,14 +1016,14 @@ describe("useRowSelection", () => {
         });
       });
 
-      it("passes isSelectAll parameter to onRowSelection callback", () => {
+      it("passes isSelectAll parameter to onRowSelectionChanged callback", () => {
         const data = createMockData(3);
-        const onRowSelection = vi.fn();
+        const onRowSelectionChanged = vi.fn();
         const { result } = renderHook(() =>
           useRowSelection({
             selectionMode: "multiple",
             selectedRows: [],
-            onRowSelection,
+            onRowSelectionChanged,
             data,
           })
         );
@@ -1016,32 +1033,32 @@ describe("useRowSelection", () => {
           result.current.onToggleAll();
         });
 
-        expect(onRowSelection).toHaveBeenCalledWith(
-          data.map((item) => item.$primaryKey),
-          true
-        );
+        expect(onRowSelectionChanged).toHaveBeenCalledWith({
+          selectedRows: data,
+          isSelectAll: true,
+        });
 
         // Toggle individual row - should pass isSelectAll=false
         act(() => {
           result.current.onToggleRow("item-1", 1);
         });
 
-        expect(onRowSelection).toHaveBeenLastCalledWith(
-          [data[1].$primaryKey],
-          false
-        );
+        expect(onRowSelectionChanged).toHaveBeenLastCalledWith({
+          selectedRows: [data[1]],
+          isSelectAll: false,
+        });
       });
 
-      it("does not auto-fire onRowSelection in controlled mode when isAllSelected and data grows", () => {
+      it("does not auto-fire onRowSelectionChanged in controlled mode when isAllSelected and data grows", () => {
         const initialData = createMockData(3);
-        const onRowSelection = vi.fn();
+        const onRowSelectionChanged = vi.fn();
         const { rerender } = renderHook(
           ({ data }) =>
             useRowSelection({
               selectionMode: "multiple",
               selectedRows: [] as PrimaryKeyType<TestObject>[],
               isAllSelected: true,
-              onRowSelection,
+              onRowSelectionChanged,
               data,
             }),
           { initialProps: { data: initialData } }
@@ -1050,7 +1067,7 @@ describe("useRowSelection", () => {
         rerender({ data: createMockData(5) });
         rerender({ data: createMockData(8) });
 
-        expect(onRowSelection).not.toHaveBeenCalled();
+        expect(onRowSelectionChanged).not.toHaveBeenCalled();
       });
 
       it("when isAllSelected is true, selects all rows and updates when data changes", () => {
@@ -1098,13 +1115,13 @@ describe("useRowSelection", () => {
 
       it("onToggleAll deselects when controlled isAllSelected is already true", () => {
         const data = createMockData(3);
-        const onRowSelection = vi.fn();
+        const onRowSelectionChanged = vi.fn();
         const { result } = renderHook(() =>
           useRowSelection({
             selectionMode: "multiple",
             selectedRows: data.map((item) => item.$primaryKey),
             isAllSelected: true,
-            onRowSelection,
+            onRowSelectionChanged,
             data,
           })
         );
@@ -1116,19 +1133,22 @@ describe("useRowSelection", () => {
           result.current.onToggleAll();
         });
 
-        expect(onRowSelection).toHaveBeenCalledWith([], false);
+        expect(onRowSelectionChanged).toHaveBeenCalledWith({
+          selectedRows: [],
+          isSelectAll: false,
+        });
       });
 
       it("when both selectedRows and isAllSelected props are provided", () => {
         const data = createMockData(5);
-        const onRowSelection = vi.fn();
+        const onRowSelectionChanged = vi.fn();
         const { result, rerender } = renderHook(
           ({ selectedRows, isAllSelected }) =>
             useRowSelection({
               selectionMode: "multiple",
               selectedRows,
               isAllSelected,
-              onRowSelection,
+              onRowSelectionChanged,
               data,
             }),
           {
@@ -1359,37 +1379,6 @@ describe("useRowSelection", () => {
       });
     });
 
-    it("deselect-all passes isSelectAll=false to both callbacks", () => {
-      const data = createMockData(3);
-      const onRowSelection = vi.fn();
-      const onRowSelectionChanged = vi.fn();
-      const { result } = renderHook(() =>
-        useRowSelection({
-          selectionMode: "multiple",
-          onRowSelection,
-          onRowSelectionChanged,
-          data,
-        })
-      );
-
-      // Select all
-      act(() => {
-        result.current.onToggleAll();
-      });
-
-      // Deselect all
-      act(() => {
-        result.current.onToggleAll();
-      });
-
-      // Both callbacks consistently report isSelectAll=false on deselect
-      expect(onRowSelection).toHaveBeenLastCalledWith([], false);
-      expect(onRowSelectionChanged).toHaveBeenLastCalledWith({
-        selectedRows: [],
-        isSelectAll: false,
-      });
-    });
-
     it("re-fires with expanded data on select-all with data growth", () => {
       const initialData = createMockData(3);
       const onRowSelectionChanged = vi.fn();
@@ -1412,51 +1401,6 @@ describe("useRowSelection", () => {
 
       expect(onRowSelectionChanged).toHaveBeenLastCalledWith({
         selectedRows: moreData,
-        isSelectAll: true,
-      });
-    });
-
-    it("fires both onRowSelection and onRowSelectionChanged on same action", () => {
-      const data = createMockData(3);
-      const onRowSelection = vi.fn();
-      const onRowSelectionChanged = vi.fn();
-      const { result } = renderHook(() =>
-        useRowSelection({
-          selectionMode: "single",
-          onRowSelection,
-          onRowSelectionChanged,
-          data,
-        })
-      );
-
-      act(() => {
-        result.current.onToggleRow("item-0", 0);
-      });
-
-      expect(onRowSelection).toHaveBeenCalledWith([data[0].$primaryKey], false);
-      expect(onRowSelectionChanged).toHaveBeenCalledWith({
-        selectedRows: [data[0]],
-        isSelectAll: false,
-      });
-    });
-
-    it("works without legacy onRowSelection callback", () => {
-      const data = createMockData(3);
-      const onRowSelectionChanged = vi.fn();
-      const { result } = renderHook(() =>
-        useRowSelection({
-          selectionMode: "multiple",
-          onRowSelectionChanged,
-          data,
-        })
-      );
-
-      act(() => {
-        result.current.onToggleAll();
-      });
-
-      expect(onRowSelectionChanged).toHaveBeenCalledWith({
-        selectedRows: data,
         isSelectAll: true,
       });
     });

--- a/packages/react-components/src/object-table/hooks/useColumnDefs.ts
+++ b/packages/react-components/src/object-table/hooks/useColumnDefs.ts
@@ -101,7 +101,6 @@ function getColumnsFromColumnDefinitions<
       maxWidth,
       resizable,
       orderable,
-      filterable,
       editable,
       renderCell,
       renderHeader,
@@ -148,7 +147,6 @@ function getColumnsFromColumnDefinitions<
       enableResizing: resizable,
       // Function-backed columns must be sorted on the frontend, so disable sorting for now
       enableSorting: locator.type === "function" ? false : orderable,
-      enableColumnFilter: filterable,
       cell: (cellContext) => {
         const object: Osdk.Instance<
           Q,

--- a/packages/react-components/src/object-table/hooks/useRowSelection.ts
+++ b/packages/react-components/src/object-table/hooks/useRowSelection.ts
@@ -47,13 +47,6 @@ export interface UseRowSelectionProps<
   selectionMode?: "single" | "multiple" | "none";
   selectedRows?: PrimaryKeyType<Q>[];
   isAllSelected?: boolean;
-  /**
-   * @deprecated Use {@link onRowSelectionChanged} instead.
-   */
-  onRowSelection?: (
-    selectedRowIds: PrimaryKeyType<Q>[],
-    isSelectAll: boolean
-  ) => void;
   onRowSelectionChanged?: (change: UseRowSelectionChange<Q, RDPs>) => void;
   data:
     | Array<Osdk.Instance<Q, "$allBaseProperties", PropertyKeys<Q>, RDPs>>
@@ -80,8 +73,6 @@ export function useRowSelection<
   selectionMode = "none",
   selectedRows,
   isAllSelected: isAllSelectedProp,
-  // eslint-disable-next-line @typescript-eslint/no-deprecated -- intentional pass-through to fire alongside onRowSelectionChanged for backwards compatibility
-  onRowSelection,
   onRowSelectionChanged,
   data,
 }: UseRowSelectionProps<Q, RDPs>): UseRowSelectionResult {
@@ -139,7 +130,6 @@ export function useRowSelection<
 
   const fireSelectionCallbacks = useEventCallback(
     (ids: PrimaryKeyType<Q>[], isSelectAll: boolean) => {
-      onRowSelection?.(ids, isSelectAll);
       if (onRowSelectionChanged) {
         const currentData = data ?? [];
         const selectedKeySet = new Set(ids.map((id) => String(id)));


### PR DESCRIPTION
As part of the work to GA the ObjectTable, removed:
- deprecated `onRowSelection` prop (superseded by `onRowSelectionChanged`)
- unimplemented filtering API: `enableFiltering`, `onFilterChanged`, and per-column `filterable` (never wired to any filter UI)

Callback-observation tests migrate from the removed `onRowSelection` (id array) to `onRowSelectionChanged` (instance payload). Docs, storybook argTypes, and the package CLAUDE.md naming guidance updated to match.