### PR TITLE
Add "merge when ready" label to release PRs

### DIFF
--- a/.changeset/release-pr-merge-when-ready-label.md
+++ b/.changeset/release-pr-merge-when-ready-label.md
@@ -1,0 +1,5 @@
+---
+"@osdk/tool.release": patch
+---
+
+Add "merge when ready" label to release PRs when they are created or updated.

--- a/packages/tool.release/src/createOrUpdatePr.ts
+++ b/packages/tool.release/src/createOrUpdatePr.ts
@@ -20,6 +20,8 @@ import { consola } from "consola";
 import type { GithubContext } from "./runVersion.js";
 import { getExistingPr } from "./runVersion.js";
 
+const MERGE_WHEN_READY_LABEL = "merge when ready";
+
 export async function createOrUpdatePr(
   context: GithubContext,
   title: string,
@@ -48,6 +50,8 @@ export async function createOrUpdatePr(
       base,
       "--head",
       head,
+      "--label",
+      MERGE_WHEN_READY_LABEL,
     ]);
   } else {
     consola.info(`updating found pull request #${pullRequest.number}`);
@@ -60,6 +64,8 @@ export async function createOrUpdatePr(
       title,
       "--body",
       body,
+      "--add-label",
+      MERGE_WHEN_READY_LABEL,
     ]);
   }
 }


### PR DESCRIPTION
## Summary

Adds the `merge when ready` label to version/release PRs that `@osdk/tool.release` opens.

- When creating a new release PR, pass `--label "merge when ready"` to `gh pr create`.
- When updating an existing release PR, pass `--add-label "merge when ready"` to `gh pr edit` so the label is applied even on PRs that predate this change.

## Test plan

- `pnpm turbo typecheck --filter=@osdk/tool.release` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)