### PR TITLE
Restrict base-ui/react version to <1.4.0

### DIFF
--- a/.changeset/rare-chairs-glow.md
+++ b/.changeset/rare-chairs-glow.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+Restrict base-ui/react version to <1.4.0

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -197,7 +197,7 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@base-ui/react": "^1.0.0",
+    "@base-ui/react": ">=1.0.0 <1.4.0",
     "@blueprintjs/icons": "^6.7.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4741,7 +4741,7 @@ importers:
   packages/react-components:
     dependencies:
       '@base-ui/react':
-        specifier: ^1.0.0
+        specifier: '>=1.0.0 <1.4.0'
         version: 1.0.0(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@blueprintjs/icons':
         specifier: ^6.7.0


### PR DESCRIPTION
Version pin `@base-ui/react` to versions `>=1.0.0 <1.4.0` to avoid pnpm pulling in a greater version of `base-ui/react` (1.6) that would require consumers to update their date-fns versions to >v4. 

Alternate solution to https://github.com/palantir/osdk-ts/pull/3693