### PR TITLE
Stop saving codegen in build dir

### DIFF
--- a/.changeset/nine-snakes-invent.md
+++ b/.changeset/nine-snakes-invent.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker-experimental": patch
+---
+
+Make codegen and build dir different arguments

--- a/packages/maker-experimental/src/cli/main.ts
+++ b/packages/maker-experimental/src/cli/main.ts
@@ -63,6 +63,7 @@ export default async function main(
     valueTypesOutput: string;
     apiNamespace: string;
     buildDir: string;
+    codegenDir: string;
     temporaryBlockDataFile?: string;
     functionsDir?: string;
     nodeModulesDir?: string;
@@ -104,6 +105,13 @@ export default async function main(
         describe: "Directory for build files",
         type: "string",
         default: "build/",
+        coerce: path.resolve,
+      },
+      codegenDir: {
+        alias: "c",
+        describe: "Output directory for generated TypeScript files",
+        type: "string",
+        default: ".",
         coerce: path.resolve,
       },
       temporaryBlockDataFile: {
@@ -201,7 +209,7 @@ export default async function main(
   } = await loadOntology(
     commandLineOpts.input,
     apiNamespace,
-    commandLineOpts.buildDir,
+    commandLineOpts.codegenDir,
     functionsIrFile,
     commandLineOpts.randomnessKey
   );

--- a/packages/maker-experimental/src/cli/main.ts
+++ b/packages/maker-experimental/src/cli/main.ts
@@ -63,7 +63,7 @@ export default async function main(
     valueTypesOutput: string;
     apiNamespace: string;
     buildDir: string;
-    codegenDir: string;
+    codegenDir?: string;
     temporaryBlockDataFile?: string;
     functionsDir?: string;
     nodeModulesDir?: string;
@@ -109,9 +109,9 @@ export default async function main(
       },
       codegenDir: {
         alias: "c",
-        describe: "Output directory for generated TypeScript files",
+        describe:
+          "Output directory for generated TypeScript files (defaults to the parent of the input file's directory)",
         type: "string",
-        default: ".",
         coerce: path.resolve,
       },
       temporaryBlockDataFile: {
@@ -201,6 +201,11 @@ export default async function main(
     );
   }
 
+  // Default the codegen output directory to the parent of the input file's directory.
+  const codegenDir =
+    commandLineOpts.codegenDir ??
+    path.dirname(path.dirname(commandLineOpts.input));
+
   const {
     ontologyIr,
     shapes,
@@ -209,7 +214,7 @@ export default async function main(
   } = await loadOntology(
     commandLineOpts.input,
     apiNamespace,
-    commandLineOpts.codegenDir,
+    codegenDir,
     functionsIrFile,
     commandLineOpts.randomnessKey
   );


### PR DESCRIPTION
the maker-experimental codegen is always saved in the build dir right now. This excludes it from transpilation and makes cross-oac imports more complicated than necessary.