### PR TITLE
Set default formatter to oxc (vscode)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,14 @@
 {
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "dprint.dprint",
+  "editor.defaultFormatter": "oxc.oxc-vscode",
   "[javascript]": {
-    "editor.defaultFormatter": "dprint.dprint"
+    "editor.defaultFormatter": "oxc.oxc-vscode"
   },
   "[typescript]": {
-    "editor.defaultFormatter": "dprint.dprint"
+    "editor.defaultFormatter": "oxc.oxc-vscode"
   },
   "[json]": {
-    "editor.defaultFormatter": "dprint.dprint"
+    "editor.defaultFormatter": "oxc.oxc-vscode"
   },
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
@@ -24,7 +24,7 @@
   ],
   "typescript.tsdk": "node_modules/typescript/lib",
   "[jsonc]": {
-    "editor.defaultFormatter": "dprint.dprint"
+    "editor.defaultFormatter": "oxc.oxc-vscode"
   },
   "typescript.preferences.autoImportSpecifierExcludeRegexes": [
     "\\.\\./build",
@@ -34,7 +34,7 @@
     "\\./index.js"
   ],
   "[markdown]": {
-    "editor.defaultFormatter": "dprint.dprint"
+    "editor.defaultFormatter": "oxc.oxc-vscode"
   },
   "[css]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,8 +36,14 @@
   "[markdown]": {
     "editor.defaultFormatter": "oxc.oxc-vscode"
   },
+  "[html]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
   "[css]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[scss]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
   },
   // This opens a prompt in the VS Code GUI asking developers if they want to
   // apply the "typescript.tsdk" option below. The "typescript.tsdk" option
@@ -52,5 +58,5 @@
   //  2. It reduces strange TypeScript bugs such as
   //     https://github.com/microsoft/TypeScript/issues/55427
   "js/ts.tsdk.promptToUseWorkspaceVersion": true,
-  "js/ts.tsdk.path": ".vscode/../node_modules/typescript/lib",
+  "js/ts.tsdk.path": ".vscode/../node_modules/typescript/lib"
 }


### PR DESCRIPTION
Sets default formatter for vscode to oxc, since we are moving to `oxfmt`. Requires the [oxc extension](https://marketplace.visualstudio.com/items?itemName=oxc.oxc-vscode) installed