### PR TITLE
Fix TypeScript Library template so scaffolded projects pass ultracite check

### DIFF
--- a/.changeset/typescript-library-template-oxfmt-config.md
+++ b/.changeset/typescript-library-template-oxfmt-config.md
@@ -1,0 +1,6 @@
+---
+"@osdk/create-app.template.typescript-library.beta": patch
+"@osdk/create-app": patch
+---
+
+Fix the TypeScript Library template so a freshly scaffolded project passes `ultracite check`: exclude package.json/tsconfig.json from oxfmt (their key order is owned by the package manager and tsc) and remove the stray blank line between imports in oxlint.config.ts

--- a/examples/example-typescript-library-sdk-2.x/oxfmt.config.ts
+++ b/examples/example-typescript-library-sdk-2.x/oxfmt.config.ts
@@ -3,4 +3,9 @@ import ultracite from "ultracite/oxfmt";
 
 export default defineConfig({
   ...ultracite,
+  ignorePatterns: [
+    ...(ultracite.ignorePatterns ?? []),
+    "**/package.json",
+    "**/tsconfig.json",
+  ],
 });

--- a/examples/example-typescript-library-sdk-2.x/oxlint.config.ts
+++ b/examples/example-typescript-library-sdk-2.x/oxlint.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig } from "oxlint";
-
 import core from "ultracite/oxlint/core";
 
 export default defineConfig({

--- a/packages/create-app.template.typescript-library.beta/templates/oxfmt.config.ts
+++ b/packages/create-app.template.typescript-library.beta/templates/oxfmt.config.ts
@@ -3,4 +3,9 @@ import ultracite from "ultracite/oxfmt";
 
 export default defineConfig({
   ...ultracite,
+  ignorePatterns: [
+    ...(ultracite.ignorePatterns ?? []),
+    "**/package.json",
+    "**/tsconfig.json",
+  ],
 });

--- a/packages/create-app.template.typescript-library.beta/templates/oxlint.config.ts
+++ b/packages/create-app.template.typescript-library.beta/templates/oxlint.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig } from "oxlint";
-
 import core from "ultracite/oxlint/core";
 
 export default defineConfig({


### PR DESCRIPTION
## Fix TypeScript Library template so scaffolded projects pass `ultracite check`

### What was broken

`pnpm check` fails on `@osdk/examples.typescript-library-sdk-2.x#check` (an `ultracite`/oxfmt format check) with format issues in two committed files: `oxlint.config.ts` and `package.json`.

### Root cause

That example is generated by `@osdk/example-generator` from the `@osdk/create-app.template.typescript-library.beta` template, so the real fix lives in the template. Two issues:

1. **`package.json` key order.** The generator runs monorepolint, whose global `packageOrder` rule enforces a repo-wide key order. The template's `oxfmt.config.ts` was a bare `{ ...ultracite }` with no ignore rules, so oxfmt also tried to reorder `package.json` (a different order than mrl), and the two fought. The root `oxfmt.config.ts` already excludes `**/package.json` and `**/tsconfig.json` for exactly this reason, but the template didn't mirror it.
2. **Stray blank line** between the two imports in `oxlint.config.ts`, which oxfmt strips.

These were mutually exclusive on the committed tree: `example-generator#test` requires the committed example to byte-match generator output, while the example's own `check` requires it formatted. So the fix had to make the generator itself produce oxfmt-clean output, not just reformat the committed copy.

### Changes

- `create-app.template.typescript-library.beta/templates/oxfmt.config.ts`: exclude `**/package.json` and `**/tsconfig.json` from oxfmt.
- `create-app.template.typescript-library.beta/templates/oxlint.config.ts`: remove the blank line between imports.
- Regenerated `examples/example-typescript-library-sdk-2.x` so it stays byte-identical to the generator output.
- Changeset (`patch`) for `@osdk/create-app.template.typescript-library.beta` and `@osdk/create-app` (which bundles the templates).
