### PR TITLE
Add new `Annotated` type to `@osdk/functions`

### DIFF
--- a/.changeset/empty-toes-do.md
+++ b/.changeset/empty-toes-do.md
@@ -1,0 +1,5 @@
+---
+"@osdk/functions": minor
+---
+
+Add new Annotated type to @osdk/functions

--- a/etc/functions.report.api.md
+++ b/etc/functions.report.api.md
@@ -43,6 +43,12 @@ declare namespace Aliases {
     }
 }
 
+// @public (undocumented)
+export type Annotated<
+	T,
+	A extends Record<string, string>
+> = T;
+
 export { Attachment }
 
 // @public (undocumented)

--- a/packages/functions/src/Annotated.ts
+++ b/packages/functions/src/Annotated.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type Annotated<T, A extends Record<string, string>> = T;

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -56,6 +56,8 @@ export type { FunctionConfig } from "./FunctionConfig.js";
 export type { ClassificationMarking, MandatoryMarking } from "./Markings.js";
 export type { GroupId, Principal, UserId } from "./UserGroup.js";
 
+export type { Annotated } from "./Annotated.js";
+
 export type {
   Geometry,
   GeometryCollection,


### PR DESCRIPTION
We need the ability to annotate function input and output types with additional metadata to enable custom rendering in the front end. For example, today, if you want to represent a ZIP code, your best option is probably a string. We would like to be able to encode the fact that a string type is a ZIP code in the function data type by exporting a type like this from a library:

```typescript
export type ZipCode = Annotated<string, {"com.palantir.functions.typeRenderHint", "zipCode"}>;
```

Consumers of the library would then be able to write function code like this:

```typescript
import { ZipCode } from "@palantir/my-types";

export default function myZipCodeFunction(zipCode: ZipCode): ZipCode {
    return zipCode;
}
```