### PR TITLE
Align pnpm check with CI

### DIFF
--- a/.changeset/align-template-checks-with-ci.md
+++ b/.changeset/align-template-checks-with-ci.md
@@ -1,0 +1,7 @@
+---
+"@osdk/create-app.template.typescript-library.beta": patch
+"@osdk/create-app.template.react.beta": patch
+"@osdk/create-app": patch
+---
+
+Template scripts express every check as a standard lint/typecheck/test task instead of a bespoke `check` script, so a scaffolded project's verification runs under the same tasks its CI already runs. The TypeScript Library template folds formatting into `lint` (`ultracite check`); the React template gains a `typecheck` script (`tsc --noEmit`). Both drop their standalone `check` script.

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ A TypeScript library for interacting with Palantir's Ontology.
 
 ## Packages
 
-| Package | Version |
-|---------|---------|
-| @osdk/client | [![npm](https://img.shields.io/npm/v/@osdk/client.svg)](https://www.npmjs.com/package/@osdk/client) |
-| @osdk/api | [![npm](https://img.shields.io/npm/v/@osdk/api.svg)](https://www.npmjs.com/package/@osdk/api) |
+| Package                     | Version                                                                                                                           |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| @osdk/client                | [![npm](https://img.shields.io/npm/v/@osdk/client.svg)](https://www.npmjs.com/package/@osdk/client)                               |
+| @osdk/api                   | [![npm](https://img.shields.io/npm/v/@osdk/api.svg)](https://www.npmjs.com/package/@osdk/api)                                     |
 | @osdk/foundry-sdk-generator | [![npm](https://img.shields.io/npm/v/@osdk/foundry-sdk-generator.svg)](https://www.npmjs.com/package/@osdk/foundry-sdk-generator) |
-| @osdk/oauth | [![npm](https://img.shields.io/npm/v/@osdk/oauth.svg)](https://www.npmjs.com/package/@osdk/oauth) |
+| @osdk/oauth                 | [![npm](https://img.shields.io/npm/v/@osdk/oauth.svg)](https://www.npmjs.com/package/@osdk/oauth)                                 |
 
 ## Getting Started
 
@@ -98,7 +98,17 @@ For more details, refer to the [public docs](https://www.palantir.com/docs/found
 2. Create a branch
 3. `pnpm install`
 4. Add your code
-5. Run all lint rules and tests with `pnpm check` from root. Run `pnpm turbo typecheck` to quickly check any issues with your types.
+5. Run `pnpm check` from root before pushing.
+
+   `pnpm check` runs the **same set of tasks CI runs**: lint (incl. formatting), typecheck, unit tests, the API report (`api-extractor`), package-typing checks (`attw`), bundle checks, spelling, and monorepolint. A green `pnpm check` locally means CI will be green too, so there is no separate CI-only check to get surprised by.
+
+   To iterate faster, run a single task, optionally scoped to one package with turbo's `--filter`:
+   - Types: `pnpm turbo typecheck --filter=@osdk/<package>`
+   - Lint + formatting: `pnpm turbo lint --filter=@osdk/<package>`
+   - Tests: `pnpm turbo test --filter=@osdk/<package>`
+
+   > 📘 Note
+   > Target packages with `--filter`; don't pass `pnpm --dir <path> turbo` (the `--dir` flag breaks turbo).
 6. Add a changeset
 
    > 📘 Note

--- a/examples/example-react-sdk-2.x-no-osdk/package.json
+++ b/examples/example-react-sdk-2.x-no-osdk/package.json
@@ -9,13 +9,13 @@
   },
   "scripts": {
     "build": "tsc && vite build",
-    "check": "eslint . --report-unused-disable-directives --max-warnings 0 && tsc --noEmit && vitest run",
     "dev": "vite",
     "format": "prettier --write src/",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint --report-unused-disable-directives --max-warnings 0 --fix",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@blueprintjs/core": "^6.10.0",

--- a/examples/example-react-sdk-2.x/package.json
+++ b/examples/example-react-sdk-2.x/package.json
@@ -9,13 +9,13 @@
   },
   "scripts": {
     "build": "tsc && vite build",
-    "check": "eslint . --report-unused-disable-directives --max-warnings 0 && tsc --noEmit && vitest run",
     "dev": "vite",
     "format": "prettier --write src/",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint --report-unused-disable-directives --max-warnings 0 --fix",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@blueprintjs/core": "^6.10.0",

--- a/examples/example-typescript-library-sdk-2.x/package.json
+++ b/examples/example-typescript-library-sdk-2.x/package.json
@@ -15,11 +15,10 @@
   },
   "scripts": {
     "build": "tsc",
-    "check": "ultracite check",
     "clean": "rm -rf dist",
     "fix": "ultracite fix",
     "format": "oxfmt .",
-    "lint": "oxlint",
+    "lint": "ultracite check",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/create-app.template.react.beta/templates/package.json.osdk.hbs
+++ b/packages/create-app.template.react.beta/templates/package.json.osdk.hbs
@@ -9,8 +9,8 @@
     "format": "prettier --write src/",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint --report-unused-disable-directives --max-warnings 0 --fix",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "check": "eslint . --report-unused-disable-directives --max-warnings 0 && tsc --noEmit && vitest run",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/packages/create-app.template.react.beta/templates/package.json.psdk.hbs
+++ b/packages/create-app.template.react.beta/templates/package.json.psdk.hbs
@@ -9,8 +9,8 @@
     "format": "prettier --write src/",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint --report-unused-disable-directives --max-warnings 0 --fix",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "check": "eslint . --report-unused-disable-directives --max-warnings 0 && tsc --noEmit && vitest run",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/packages/create-app.template.typescript-library.beta/templates/package.json.hbs
+++ b/packages/create-app.template.typescript-library.beta/templates/package.json.hbs
@@ -18,10 +18,9 @@
     "clean": "rm -rf dist",
     "test": "vitest run",
     "test:watch": "vitest",
-    "check": "ultracite check",
     "fix": "ultracite fix",
     "format": "oxfmt .",
-    "lint": "oxlint"
+    "lint": "ultracite check"
   },
   "devDependencies": {
     "oxfmt": "^0.53.0",

--- a/turbo.json
+++ b/turbo.json
@@ -29,6 +29,8 @@
         "*.html",
         ".eslintrc.cjs",
         "eslint.config.mjs",
+        "oxlint.config.ts",
+        "oxfmt.config.ts",
         "tsconfig.json"
       ],
       "outputs": [],
@@ -290,7 +292,7 @@
         "check-attw",
         "check-bundle",
         "check-api",
-        "check-spelling",
+        "//#cspell:all",
         "check-gen-props"
       ]
     }


### PR DESCRIPTION
## Align `pnpm check` with CI

> Follow-up to #3712 (now merged), which fixed the TypeScript Library template formatting. This closes the underlying gap that let that break reach `main` green.

### Why

`pnpm check` (`turbo check`) runs each package's own `check` script **plus** the `lint`/`typecheck`/`test`/`check-*` tasks it depends on. CI, for speed, runs those individual tasks in parallel jobs but **never** the aggregate `check` task, so any per-package `check` script was never executed in CI. The TypeScript Library example's formatting check lived only in its `check` script (`ultracite check`), so a formatting break passed CI and only failed locally (the bug that started this).

Rather than bolt `turbo check` onto CI, this makes local and CI verification identical **by construction**: every check is expressed as one of the standard tasks CI already runs, and no package defines a `check` script anymore.

### Benefits

- **Local == CI.** A green `pnpm check` now means a green CI: there is no task `pnpm check` runs that CI doesn't, and none CI runs that `pnpm check` doesn't. No more "passes locally, fails in CI" (or vice-versa) for this class of check.
- **No CI change needed.** CI's existing `lint` and `typecheck` jobs pick up the decomposed scripts automatically, so there's nothing extra to maintain in `ci.yml`.
- **Future-proof.** Because checks are standard tasks (not bespoke per-package scripts), a new package can't accidentally add verification that silently escapes CI.
- **Consistent with the rest of the repo**, where formatting is part of `lint` and there is no per-package `check` aggregate.

### Changes

- **typescript-library template**: fold formatting into `lint` (`ultracite check`); drop the standalone `check` script.
- **react template**: add a `typecheck` script (`tsc --noEmit`); drop the combined `check` script (its `eslint`/`vitest` were already `lint`/`test`).
- **`turbo.json` `lint` inputs**: also hash each package's local `oxlint.config.ts` / `oxfmt.config.ts`, so a change to those (or a formatting issue within the config files themselves) invalidates the lint cache instead of being masked by a stale hit.
- **`turbo.json` `check` task**: depend on the whole-repo cspell pass (`//#cspell:all`) that CI runs, instead of the per-package `check-spelling` task, so spelling is verified identically locally and in CI (the whole-repo pass is a superset).
- **README**: the Dev workflow section now states that `pnpm check` runs the same tasks as CI, with per-task/`--filter` commands for faster iteration.
- Regenerated the affected examples.

### Verification

- `pnpm check` is green.
- No package defines a `check` script; `turbo check`'s graph covers the ts-library and react examples via `lint`/`typecheck`/`test`, and its only spelling task is the single whole-repo `//#cspell:all`.
- Confirmed the `foundry/osdk-templates-bundle` scaffolded CIs run only `install`/`lint`/`test`/`build` (never `check`), so dropping the `check` scripts doesn't break downstream template CI.
