### PR TITLE
Fix flaky codegen ERR_MODULE_NOT_FOUND (missing transpileEsm ordering edge)

### DIFF
--- a/packages/tool.generate-with-mock-ontology/turbo.json
+++ b/packages/tool.generate-with-mock-ontology/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "transpileEsm": {
+      "dependsOn": ["^transpileEsm"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes a flaky CI failure where the build intermittently dies with `ERR_MODULE_NOT_FOUND` and then passes on a manual re-run. The failure is a build-ordering race caused by a missing dependency edge in the turbo task graph. This adds the missing edge so the ordering is correct by construction.

Observed failure (example run: PR #3722):

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
'.../packages/tool.generate-with-mock-ontology/node_modules/@osdk/foundry-sdk-generator/build/esm/index.js'
imported from '.../packages/tool.generate-with-mock-ontology/build/esm/generateWithMockOntology.js'
```

The failing task is `@osdk/tests.verify-cjs-node10#codegen`, and the same applies to `verify-cjs-node16` and `verify-esm-node16`, which all run the `generate-with-mock-ontology` bin.

## Root cause and how it was identified

`codegen` runs the `generate-with-mock-ontology` bin, whose compiled ESM imports `@osdk/foundry-sdk-generator` at runtime, resolving to that package's `build/esm/index.js`. That file is produced only by `@osdk/foundry-sdk-generator#transpileEsm`.

Tracing the real turbo graph (`turbo run codegen --filter=@osdk/tests.verify-cjs-node10 --dry-run=json`) showed that `foundry-sdk-generator#transpileEsm` was **not** an ordering ancestor of `codegen`:

- `verify-*#codegen` depends on `@osdk/tool.generate-with-mock-ontology#transpile`.
- The tool's `transpile` reaches `transpileCjs`, which carries `^transpileCjs` and `^transpileTypes` topologically. That gave us foundry-sdk-generator's `build/types` (and a no-op `transpileCjs`, since it has no such script), but never its `build/esm`.
- The tool's `transpileEsm` does not declare `^transpileEsm`, so `foundry-sdk-generator#transpileEsm` was absent from `codegen`'s task closure entirely.

In CI's global `turbo run transpile transpileTypes`, foundry-sdk-generator's esm does get built (it is a target), but with no edge to `codegen` the two run concurrently. foundry-sdk-generator uses slow rollup bundle mode (`-m bundle`) and sits at the end of a long dependency chain, so its esm output lands late, and `codegen` often fires before `build/esm/index.js` exists. On re-run the file is already on disk, so it passes. That passes-on-re-run behavior is the signature of a missing ordering edge rather than a real code error.

## The fix

Add a package-level `packages/tool.generate-with-mock-ontology/turbo.json` so the tool's esm build waits for its dependencies' esm builds:

```json
{
  "extends": ["//"],
  "tasks": {
    "transpileEsm": {
      "dependsOn": ["^transpileEsm"]
    }
  }
}
```

This is the same pattern `@osdk/foundry-sdk-generator` already declares on itself. It creates the enforced ordering path:

```
verify-*#codegen
  -> tool.generate-with-mock-ontology#transpileEsm
  -> ^transpileEsm
  -> foundry-sdk-generator#transpileEsm
```

Because foundry-sdk-generator's own turbo.json already declares `^transpileEsm`, the recursion also covers its `client.unstable` / `client.unstable.tpsa` subtree, which are the only other slow bundle-mode esm builds in this closure. Every slow esm build the bin needs is now ordered before `codegen`. One file fixes all three consumers.

## How it was verified

Graph, before and after:
- Before: `foundry-sdk-generator#transpileEsm` is not in the graph; `codegen` does not order after it (confirmed for all three verify packages).
- After: all three `codegen` tasks have `foundry-sdk-generator#transpileEsm` as a transitive ancestor.

Runtime, deterministic isolation against a fully-built tree (matching CI conditions), varying only the fix:

| Test | Fix | foundry `build/esm` | Result |
|------|-----|--------------------|--------|
| 1 | present | on disk | `codegen` passes |
| 2 | removed | deleted; turbo does not rebuild it | `codegen` fails with the exact CI error |
| 3 | restored | deleted; turbo rebuilds it first, then runs | `codegen` passes |

In Test 2 every other runtime esm dep was present, isolating foundry-sdk-generator as the sole cause, and turbo confirmably did not schedule its `transpileEsm`. In Test 3 turbo scheduled `foundry-sdk-generator:transpileEsm` (the rollup build), produced the output, and `codegen` succeeded.

Safety:
- Full-repo dry-run (682 tasks) with the fix: no dependency cycle.
- foundry-sdk-generator is a leaf on this chain (nothing it depends on loops back to the tool), so no cycle is possible.

## Performance impact

- **No new work.** The global build (`turbo run transpile transpileTypes`) has 682 tasks with and without the fix. Every esm build the edge references already runs in CI. This is ordering only.
- **No critical-path regression.** `verify-*#transpile` is a leaf (nothing depends on it), and `codegen` feeds only its own package's transpile tasks, so delaying it delays nothing downstream. The edge only holds `codegen`'s start until the foundry esm subtree (already being built) is ready. foundry-sdk-generator's own rollup step is about 1s in isolation; `codegen`'s own runtime (about 17s) was already part of the build job.
- **Warm cache: zero impact.** On unchanged code, `codegen` and the esm builds are turbo cache hits, so ordering is moot.
- **One-time cost.** The new `dependsOn` changes the hash of the tool's `transpileEsm`, so the first CI run after merge recomputes it and `codegen` once (about 17s), then caches normally.
- **Net effect: faster and more reliable.** Each flaky failure today costs a full job re-run plus a manual re-trigger. Removing that outweighs a worst-case few-second tail on cold builds.

Stages affected (all jobs that run a global `turbo transpile` pull `codegen`): `build` (primary fix site, produces a correct cache), the restore steps of `test` / `typecheck` / `lint`, and `e2e` / `bundle-size`. Effect is identical everywhere: correct ordering plus reliable cache hits, no new work. `build-apps` is not meaningfully affected (no app depends on `verify-*`).

## Notes

- No changeset: `@osdk/tool.generate-with-mock-ontology` is `private: true`, and this is a build-config-only change to an unpublished package.
