### PR TITLE
Add "View less" collapse toggle to ListogramInput

### DIFF
--- a/.changeset/silly-mangos-cheer.md
+++ b/.changeset/silly-mangos-cheer.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Make the ListogramInput "View all (N)" button a two-way toggle so it collapses back to "View less"

--- a/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
+++ b/packages/react-components-storybook/src/stories/FilterList/FilterList.stories.tsx
@@ -1409,7 +1409,8 @@ export const WithBelowFoldSelection: Story = {
         story:
           "A selected value that sorts below the collapsed fold stays visible, " +
           "appended at the tail of the collapsed view rather than hoisted to " +
-          'the top. The "View all" button remains so the rest can be revealed.',
+          'the top. The "View all" toggle reveals the rest, and "View less" ' +
+          "collapses back to this state.",
       },
       source: {
         code: `<FilterList
@@ -1422,6 +1423,95 @@ export const WithBelowFoldSelection: Story = {
     },
   },
   render: (args) => <WithBelowFoldSelectionStory {...args} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Every distinct department bucket, used to read the rendered row order
+    // regardless of which are currently visible.
+    const allDepartments = [
+      "Engineering",
+      "Marketing",
+      "Design",
+      "Data",
+      "Finance",
+      "Operations",
+      "People",
+      "Sales",
+      "Customer Success",
+      "Legal",
+      "Product",
+    ];
+    const departmentRowName =
+      /^(Engineering|Marketing|Design|Data|Finance|Operations|People|Sales|Customer Success|Legal|Product)\s+\d+/u;
+
+    const renderedDepartments = () =>
+      canvas.getAllByRole("button", { name: departmentRowName }).map((row) => {
+        const label = allDepartments.find((name) =>
+          row.textContent?.includes(name)
+        );
+        if (label == null) {
+          throw new Error(
+            `Unable to identify department row from "${row.textContent}"`
+          );
+        }
+        return label;
+      });
+
+    // Collapsed initial state: the five highest-count departments form the
+    // head, plus the below-fold selected "Sales" appended at the tail.
+    const initialCollapsedOrder = [
+      "Engineering",
+      "Marketing",
+      "Design",
+      "Data",
+      "Finance",
+      "Sales",
+    ];
+    // With no below-fold selection the collapsed view is just the head.
+    const headOnlyOrder = [
+      "Engineering",
+      "Marketing",
+      "Design",
+      "Data",
+      "Finance",
+    ];
+
+    await canvas.findByRole("button", { name: "Marketing 4" });
+    await expect(renderedDepartments()).toEqual(initialCollapsedOrder);
+    await expect(
+      canvas.getByRole("button", { name: "Sales 2" })
+    ).toHaveAttribute("aria-pressed", "true");
+
+    // Unselect the below-fold "Sales": it is no longer selected, so it drops
+    // out of the collapsed view and the list falls back to the head alone.
+    await userEvent.click(canvas.getByRole("button", { name: "Sales 2" }));
+    await waitFor(() => expect(renderedDepartments()).toEqual(headOnlyOrder));
+    await expect(canvas.queryByRole("button", { name: "Sales 2" })).toBeNull();
+
+    // Expand with "View all (N)" to reach "Sales" again, then re-select it.
+    await userEvent.click(
+      canvas.getByRole("button", { name: /^View all \(\d+\)/u })
+    );
+    await canvas.findByRole("button", { name: "View less" });
+    await userEvent.click(canvas.getByRole("button", { name: "Sales 2" }));
+    await waitFor(() =>
+      expect(canvas.getByRole("button", { name: "Sales 2" })).toHaveAttribute(
+        "aria-pressed",
+        "true"
+      )
+    );
+
+    // "View less" collapses back to the initial state: the head plus the
+    // re-selected below-fold "Sales" appended at the tail.
+    await userEvent.click(canvas.getByRole("button", { name: "View less" }));
+    await canvas.findByRole("button", { name: /^View all \(\d+\)/u });
+    await expect(
+      canvas.queryByRole("button", { name: "View less" })
+    ).toBeNull();
+    await waitFor(() =>
+      expect(renderedDepartments()).toEqual(initialCollapsedOrder)
+    );
+  },
 };
 
 function WithRemovableFiltersStory(args: Partial<EmployeeFilterListProps>) {

--- a/packages/react-components/src/filter-list/base/inputs/ListogramInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/ListogramInput.tsx
@@ -70,6 +70,8 @@ function ListogramInputInner({
 }: ListogramInputProps): React.ReactElement {
   const [isExpanded, setIsExpanded] = useState(false);
 
+  const toggleExpanded = useCallback(() => setIsExpanded((v) => !v), []);
+
   const stableValues = useStableData(values, isLoading);
 
   const selectedSet = useMemo(() => new Set(selectedValues), [selectedValues]);
@@ -208,8 +210,7 @@ function ListogramInputInner({
               type="button"
               className={styles.viewAllButton}
               aria-expanded={isExpanded}
-              // eslint-disable-next-line react/jsx-no-bind
-              onClick={() => setIsExpanded((v) => !v)}
+              onClick={toggleExpanded}
             >
               {isExpanded ? "View less" : `View all (${filteredValues.length})`}
             </Button>

--- a/packages/react-components/src/filter-list/base/inputs/ListogramInput.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/ListogramInput.tsx
@@ -99,8 +99,9 @@ function ListogramInputInner({
   // checkbox must never reorder rows. In the collapsed view we still keep
   // below-fold selected values visible by appending them at the tail (matching
   // Foundry Workshop's listogram), without hoisting them or displacing the
-  // head. Unchecking a below-fold row drops it from the tail; "View all"
-  // reveals it again.
+  // head. Unchecking a below-fold row drops it from the tail; the "View all"
+  // toggle reveals every value, and clicking it again ("View less") collapses
+  // back to the head.
   const displayValues = useMemo(() => {
     if (isExpanded || maxVisibleItems == null) return filteredValues;
     const head = filteredValues.slice(0, maxVisibleItems);
@@ -202,14 +203,15 @@ function ListogramInputInner({
             );
           })}
 
-          {hasMore && !isExpanded && (
+          {hasMore && (
             <Button
               type="button"
               className={styles.viewAllButton}
+              aria-expanded={isExpanded}
               // eslint-disable-next-line react/jsx-no-bind
-              onClick={() => setIsExpanded(true)}
+              onClick={() => setIsExpanded((v) => !v)}
             >
-              View all ({filteredValues.length})
+              {isExpanded ? "View less" : `View all (${filteredValues.length})`}
             </Button>
           )}
         </div>

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/ListogramInput.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/ListogramInput.test.tsx
@@ -206,9 +206,9 @@ describe("ListogramInput ordering", () => {
       "Support",
     ]);
 
-    const collapseToggle = getToggle();
-    expect(collapseToggle).not.toBeNull();
-    fireEvent.click(collapseToggle!);
+    const viewLessToggle = getToggle("viewLess");
+    expect(viewLessToggle).not.toBeNull();
+    fireEvent.click(viewLessToggle!);
 
     expect(getRenderedOrder()).toEqual(["Engineering", "Sales"]);
     expect(queryRow("Marketing")).toBeNull();
@@ -229,15 +229,15 @@ describe("ListogramInput ordering", () => {
 
     fireEvent.click(collapsed);
 
-    const expanded = getToggle();
-    expect(expanded).not.toBeNull();
-    expect(expanded!.getAttribute("aria-expanded")).toBe("true");
+    const viewLessToggle = getToggle("viewLess");
+    expect(viewLessToggle).not.toBeNull();
+    expect(viewLessToggle!.getAttribute("aria-expanded")).toBe("true");
 
-    fireEvent.click(expanded!);
+    fireEvent.click(viewLessToggle!);
 
-    const collapsedAgain = getToggle();
-    expect(collapsedAgain).not.toBeNull();
-    expect(collapsedAgain!.getAttribute("aria-expanded")).toBe("false");
+    const viewAllToggle = getToggle("viewAll");
+    expect(viewAllToggle).not.toBeNull();
+    expect(viewAllToggle!.getAttribute("aria-expanded")).toBe("false");
   });
 });
 
@@ -257,12 +257,13 @@ function queryRow(value: string): HTMLElement | null {
 }
 
 // The expand/collapse toggle is the only button whose label reads "View
-// all…"/"View less"; row buttons never contain that text. Returns null unless
-// exactly one such toggle is mounted so callers can assert its presence.
-function getToggle(): HTMLElement | null {
-  const toggles = screen.queryAllByRole("button", {
-    name: /View (all|less)/u,
-  });
+// all…" (collapsed) or "View less" (expanded); row buttons never contain that
+// text. Pass the expected label so the assertion is explicit about which state
+// the toggle should be in. Returns null unless exactly one such toggle is
+// mounted so callers can assert its presence.
+function getToggle(label: "viewAll" | "viewLess"): HTMLElement | null {
+  const name = label === "viewAll" ? /View all/u : /View less/u;
+  const toggles = screen.queryAllByRole("button", { name });
   return toggles.length === 1 ? toggles[0] : null;
 }
 

--- a/packages/react-components/src/filter-list/base/inputs/__tests__/ListogramInput.test.tsx
+++ b/packages/react-components/src/filter-list/base/inputs/__tests__/ListogramInput.test.tsx
@@ -132,7 +132,7 @@ describe("ListogramInput ordering", () => {
     expect(screen.queryByRole("button", { name: "View all (4)" })).toBeNull();
   });
 
-  it("omits the View all button when all values fit in the collapsed view", () => {
+  it("omits the view toggle entirely when all values fit in the collapsed view", () => {
     render(
       <ControlledListogram
         values={mockValues}
@@ -147,7 +147,97 @@ describe("ListogramInput ordering", () => {
       "Marketing",
       "Support",
     ]);
+    expect(
+      screen.queryByRole("button", { name: /View (all|less)/u })
+    ).toBeNull();
+  });
+
+  it("keeps a single view toggle present in both the collapsed and expanded states", () => {
+    render(
+      <ControlledListogram
+        values={mockValues}
+        maxCount={42}
+        maxVisibleItems={2}
+      />
+    );
+
+    expect(
+      screen.queryAllByRole("button", { name: /View (all|less)/u })
+    ).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "View all (4)" }));
+
+    expect(
+      screen.queryAllByRole("button", { name: /View (all|less)/u })
+    ).toHaveLength(1);
+  });
+
+  it("labels the toggle with the filtered count when collapsed and drops the count once expanded", () => {
+    render(
+      <ControlledListogram
+        values={mockValues}
+        maxCount={42}
+        maxVisibleItems={2}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "View all (4)" })).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "View all (4)" }));
+
+    expect(screen.queryByRole("button", { name: "View less" })).not.toBeNull();
     expect(screen.queryByRole("button", { name: /View all/u })).toBeNull();
+  });
+
+  it("collapses back to the head values when the toggle is clicked a second time", () => {
+    render(
+      <ControlledListogram
+        values={mockValues}
+        maxCount={42}
+        maxVisibleItems={2}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "View all (4)" }));
+    expect(getRenderedOrder()).toEqual([
+      "Engineering",
+      "Sales",
+      "Marketing",
+      "Support",
+    ]);
+
+    const collapseToggle = getToggle();
+    expect(collapseToggle).not.toBeNull();
+    fireEvent.click(collapseToggle!);
+
+    expect(getRenderedOrder()).toEqual(["Engineering", "Sales"]);
+    expect(queryRow("Marketing")).toBeNull();
+    expect(queryRow("Support")).toBeNull();
+  });
+
+  it("flips aria-expanded on the toggle across clicks", () => {
+    render(
+      <ControlledListogram
+        values={mockValues}
+        maxCount={42}
+        maxVisibleItems={2}
+      />
+    );
+
+    const collapsed = screen.getByRole("button", { name: "View all (4)" });
+    expect(collapsed.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(collapsed);
+
+    const expanded = getToggle();
+    expect(expanded).not.toBeNull();
+    expect(expanded!.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.click(expanded!);
+
+    const collapsedAgain = getToggle();
+    expect(collapsedAgain).not.toBeNull();
+    expect(collapsedAgain!.getAttribute("aria-expanded")).toBe("false");
   });
 });
 
@@ -164,6 +254,16 @@ function queryRow(value: string): HTMLElement | null {
   return screen.queryByRole("button", {
     name: new RegExp(`^${value}\\s+\\d+`, "u"),
   });
+}
+
+// The expand/collapse toggle is the only button whose label reads "View
+// all…"/"View less"; row buttons never contain that text. Returns null unless
+// exactly one such toggle is mounted so callers can assert its presence.
+function getToggle(): HTMLElement | null {
+  const toggles = screen.queryAllByRole("button", {
+    name: /View (all|less)/u,
+  });
+  return toggles.length === 1 ? toggles[0] : null;
 }
 
 /** Controlled wrapper so a click actually updates selection and re-renders. */


### PR DESCRIPTION
## What

Makes the ListogramInput **"View all (N)"** button a two-way toggle. Today it expands the truncated list one-way and then unmounts — there's no way to collapse back. Now clicking it again (**"View less"**) collapses the list to its head.

## Details

- Render condition changed from `hasMore && !isExpanded` to `hasMore`, so the button stays mounted and relabels rather than unmounting.
- Label reads `View all (N)` when collapsed and `View less` when expanded; `onClick` flips `isExpanded`.
- Added `aria-expanded` on the toggle for screen-reader state. No `aria-controls`/wrapper — this is a truncated-list show-more/less affordance, not an APG disclosure.
- Collapse reuses the existing display memo (head + below-fold-selected tail) — no new layout logic, no public API change, no CSS change.

## Storybook

Added an interaction play to the `WithBelowFoldSelection` story exercising the full round-trip: a below-fold selected value sits at the tail → unselect it (drops below the fold) → expand via "View all" → re-select it → "View less" collapses back to the initial state.

## Testing

- Unit tests in `ListogramInput.test.tsx` cover the label branch, render condition, and `aria-expanded`, and preserve the existing ordering/tail invariants.
- The Storybook interaction test verifies the collapse round-trip end-to-end.

<img width="1100" height="604" alt="demo" src="https://github.com/user-attachments/assets/d12b195b-cb71-4b64-8fee-b5bcef50a79c" />
