### PR TITLE
feat(react-components): add creatable combobox support to DropdownField

### DIFF
--- a/.changeset/plucky-otters-wander.md
+++ b/.changeset/plucky-otters-wander.md
@@ -2,4 +2,4 @@
 "@osdk/react-components": minor
 ---
 
-Add creatable combobox support to `DropdownField`: pass `createItemFromQuery` to offer a synthetic "Create …" item that commits a user-entered value (click or Enter) coerced by the caller, with an optional `renderCreateLabel` for the item label. Works for single-select and multi-select (creatable tag input).
+Add creatable combobox support to `DropdownField`

--- a/.changeset/plucky-otters-wander.md
+++ b/.changeset/plucky-otters-wander.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+Add creatable combobox support to `DropdownField`: pass `createItemFromQuery` to offer a synthetic "Create …" item that commits a user-entered value (click or Enter) coerced by the caller, with an optional `renderCreateLabel` for the item label. Works for single-select and multi-select (creatable tag input).

--- a/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
@@ -1338,6 +1338,13 @@ const creatableDropdownFormContent: ReadonlyArray<FormContentItem> = [
     fieldComponentProps: {
       items: DEPARTMENT_ITEMS,
       createNewItemFromQuery: coerceStringQuery,
+      // createNewItemRenderer overrides only the visible content of the
+      // "Create …" item; the accessible name stays the default.
+      createNewItemRenderer: (query) => (
+        <span>
+          <strong>Add</strong> new department "{query}"
+        </span>
+      ),
       placeholder: "Search or create a department...",
     },
   }),
@@ -1363,7 +1370,7 @@ export const WithCreatableDropdown: Story = {
     docs: {
       description: {
         story:
-          'Passing `createNewItemFromQuery` turns a dropdown into a creatable combobox: typing a value that matches no existing item offers a "Create …" option that commits the typed value (by click or by pressing Enter). Works for single-select and multi-select, where it behaves like a tag input.',
+          'Passing `createNewItemFromQuery` turns a dropdown into a creatable combobox: typing a value that matches no existing item offers a "Create …" option that commits the typed value (by click or by pressing Enter). Works for single-select and multi-select, where it behaves like a tag input. Pass `createNewItemRenderer` to customize the visible content of the "Create …" option (the accessible name stays the default).',
       },
       source: {
         code: `const coerceStringQuery = (query) => query.trim();

--- a/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
@@ -1330,6 +1330,79 @@ export const WithMultiSelectDropdown: Story = {
   },
 };
 
+const creatableDropdownFormContent: ReadonlyArray<FormContentItem> = [
+  field({
+    fieldKey: "department",
+    fieldComponent: "DROPDOWN",
+    label: "Department (creatable)",
+    fieldComponentProps: {
+      items: DEPARTMENT_ITEMS,
+      createNewItemFromQuery: coerceStringQuery,
+      placeholder: "Search or create a department...",
+    },
+  }),
+  field({
+    fieldKey: "tags",
+    fieldComponent: "DROPDOWN",
+    label: "Tags (creatable multi-select)",
+    fieldComponentProps: {
+      items: TAG_ITEMS,
+      isMultiple: true,
+      createNewItemFromQuery: coerceStringQuery,
+      placeholder: "Search or create tags...",
+    },
+  }),
+];
+
+export const WithCreatableDropdown: Story = {
+  args: {
+    formContent: creatableDropdownFormContent,
+    onSubmit: handleSubmit,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Passing `createNewItemFromQuery` turns a dropdown into a creatable combobox: typing a value that matches no existing item offers a "Create …" option that commits the typed value (by click or by pressing Enter). Works for single-select and multi-select, where it behaves like a tag input.',
+      },
+      source: {
+        code: `const coerceStringQuery = (query) => query.trim();
+
+const formContent = [
+  {
+    fieldKey: "department",
+    fieldComponent: "DROPDOWN",
+    label: "Department (creatable)",
+    fieldComponentProps: {
+      items: ["Engineering", "Marketing", "Sales", "Finance", "Operations", "Legal"],
+      createNewItemFromQuery: coerceStringQuery,
+      placeholder: "Search or create a department...",
+    },
+  },
+  {
+    fieldKey: "tags",
+    fieldComponent: "DROPDOWN",
+    label: "Tags (creatable multi-select)",
+    fieldComponentProps: {
+      items: ["Urgent", "Review", "Follow-up", "Archived", "Pinned"],
+      isMultiple: true,
+      createNewItemFromQuery: coerceStringQuery,
+      placeholder: "Search or create tags...",
+    },
+  },
+];
+
+// createNewItemFromQuery coerces the raw query into an item value.
+// Return undefined to reject a query (no create option shown).
+<BaseForm
+  formContent={formContent}
+  onSubmit={(formState) => console.log("Submitted:", formState)}
+/>`,
+      },
+    },
+  },
+};
+
 const richDropdownLabelFormContent: ReadonlyArray<FormContentItem> = [
   field({
     fieldKey: "assigneeUserId",
@@ -2310,6 +2383,10 @@ export const WithGridSection: Story = {
     onSubmit: handleSubmit,
   },
 };
+function coerceStringQuery(query: string): string {
+  return query.trim();
+}
+
 function getUserIdLabel(item: unknown): string {
   if (typeof item !== "string") {
     return String(item);

--- a/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ActionForm/BaseForm.stories.tsx
@@ -1383,6 +1383,11 @@ const formContent = [
     fieldComponentProps: {
       items: ["Engineering", "Marketing", "Sales", "Finance", "Operations", "Legal"],
       createNewItemFromQuery: coerceStringQuery,
+      createNewItemRenderer: (query) => (
+        <span>
+          <strong>Add</strong> new department "{query}"
+        </span>
+      ),
       placeholder: "Search or create a department...",
     },
   },

--- a/packages/react-components/src/action-form/FormFieldApi.ts
+++ b/packages/react-components/src/action-form/FormFieldApi.ts
@@ -244,6 +244,31 @@ export interface DropdownFieldProps<
   disableClientSideFiltering?: boolean;
 
   /**
+   * Enables the creatable combobox pattern for single-select searchable
+   * dropdowns. When the trimmed search query is non-empty and matches no
+   * existing item, a synthetic "Create …" item is offered. Selecting it — by
+   * click or by pressing Enter while it is highlighted — commits the value this
+   * callback returns through `onChange`.
+   *
+   * Coerce/convert the raw query into an item value here (e.g. via
+   * `coerceFieldValue`). Return `undefined` to reject the query, in which case
+   * no create item is shown.
+   *
+   * Providing this callback implies a searchable dropdown. Works for both
+   * single-select and multi-select — multi-select behaves like a creatable tag
+   * input, appending each created value to the selection.
+   */
+  createItemFromQuery?: (query: string) => V | undefined;
+
+  /**
+   * Renders the label shown for the synthetic create item. Receives the trimmed
+   * query.
+   *
+   * @default query => `Create "${query}"`
+   */
+  renderCreateLabel?: (query: string) => React.ReactNode;
+
+  /**
    * Status message rendered below the search input and above the item list
    * inside the popup. Use for loading/error/empty messages.
    */

--- a/packages/react-components/src/action-form/FormFieldApi.ts
+++ b/packages/react-components/src/action-form/FormFieldApi.ts
@@ -244,29 +244,21 @@ export interface DropdownFieldProps<
   disableClientSideFiltering?: boolean;
 
   /**
-   * Enables the creatable combobox pattern for single-select searchable
-   * dropdowns. When the trimmed search query is non-empty and matches no
-   * existing item, a synthetic "Create …" item is offered. Selecting it — by
-   * click or by pressing Enter while it is highlighted — commits the value this
-   * callback returns through `onChange`.
+   * If provided, allows new items to be created from the current search query.
+   * When the trimmed query is non-empty and matches no existing item, a
+   * "create" option is offered; selecting it — by click or by pressing Enter
+   * while it is highlighted — commits the value returned here through
+   * `onChange`.
    *
    * Coerce/convert the raw query into an item value here (e.g. via
    * `coerceFieldValue`). Return `undefined` to reject the query, in which case
-   * no create item is shown.
+   * no create option is shown.
    *
    * Providing this callback implies a searchable dropdown. Works for both
    * single-select and multi-select — multi-select behaves like a creatable tag
    * input, appending each created value to the selection.
    */
-  createItemFromQuery?: (query: string) => V | undefined;
-
-  /**
-   * Renders the label shown for the synthetic create item. Receives the trimmed
-   * query.
-   *
-   * @default query => `Create "${query}"`
-   */
-  renderCreateLabel?: (query: string) => React.ReactNode;
+  createNewItemFromQuery?: (query: string) => V | undefined;
 
   /**
    * Status message rendered below the search input and above the item list

--- a/packages/react-components/src/action-form/FormFieldApi.ts
+++ b/packages/react-components/src/action-form/FormFieldApi.ts
@@ -261,6 +261,16 @@ export interface DropdownFieldProps<
   createNewItemFromQuery?: (query: string) => V | undefined;
 
   /**
+   * Overrides the rendered content of the synthetic "Create …" item shown in
+   * creatable mode (see {@link createNewItemFromQuery}). Receives the trimmed
+   * query the item would create.
+   *
+   * Defaults to text reading `Create "<query>"`. The item's accessible name
+   * stays `Create "<query>"` regardless, so an override only changes visuals.
+   */
+  createNewItemRenderer?: (query: string) => React.ReactNode;
+
+  /**
    * Status message rendered below the search input and above the item list
    * inside the popup. Use for loading/error/empty messages.
    */

--- a/packages/react-components/src/action-form/FormFieldApi.ts
+++ b/packages/react-components/src/action-form/FormFieldApi.ts
@@ -467,6 +467,7 @@ export type ObjectSelectFieldProps<
   | "onQueryChange"
   | "disableClientSideFiltering"
   | "renderItemList"
+  | "createNewItemFromQuery"
 > &
   ObjectSelectDataSource<Q>;
 

--- a/packages/react-components/src/action-form/__tests__/AsyncDropdownField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/AsyncDropdownField.test.tsx
@@ -60,6 +60,7 @@ function renderAsyncDropdown(
     hasMore?: boolean;
     onFetchMore?: () => void;
     fetchError?: Error;
+    createNewItemFromQuery?: (query: string) => string | undefined;
   } = {}
 ) {
   return render(
@@ -214,6 +215,50 @@ describe("AsyncDropdownField", () => {
       expect(document.querySelector("[role='alert']")).toBeNull();
       const skeletonBars = getPopup()?.querySelectorAll("[class*='skeleton']");
       expect(skeletonBars?.length ?? 0).toBe(0);
+    });
+  });
+
+  describe("creatable", () => {
+    it.each([
+      { status: "loading", isLoading: true, isSearching: false },
+      { status: "searching", isLoading: false, isSearching: true },
+    ])(
+      "does not offer creation while results are $status",
+      async ({ isLoading, isSearching }) => {
+        renderAsyncDropdown({
+          items: [],
+          isLoading,
+          isSearching,
+          createNewItemFromQuery: (query) => query,
+        });
+        await openCombobox();
+
+        fireEvent.change(screen.getByPlaceholderText("Search…"), {
+          target: { value: "Delta" },
+        });
+
+        expect(
+          screen.queryByRole("option", { name: 'Create "Delta"' })
+        ).toBeNull();
+      }
+    );
+
+    it("offers creation after results resolve", async () => {
+      renderAsyncDropdown({
+        items: [],
+        createNewItemFromQuery: (query) => query,
+      });
+      await openCombobox();
+
+      fireEvent.change(screen.getByPlaceholderText("Search…"), {
+        target: { value: "Delta" },
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          screen.getByRole("option", { name: 'Create "Delta"' })
+        ).toBeDefined();
+      });
     });
   });
 });

--- a/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
@@ -928,33 +928,6 @@ describe("DropdownField", () => {
       expect(createNewItemFromQuery).toHaveBeenCalledWith("dana");
     });
 
-    it("commits the coerced value when Enter is pressed on the create item", async () => {
-      const onChange = vi.fn();
-      render(
-        <DropdownField
-          value={null}
-          items={STRING_ITEMS}
-          isSearchable={true}
-          onChange={onChange}
-          createNewItemFromQuery={coerceToUpper}
-        />
-      );
-
-      const input = await openAndType("dana");
-
-      await vi.waitFor(() => {
-        expect(
-          screen.getByRole("option", { name: 'Create "dana"' })
-        ).toBeDefined();
-      });
-
-      fireEvent.keyDown(input, { key: "Enter" });
-
-      await vi.waitFor(() => {
-        expect(onChange).toHaveBeenCalledWith("DANA", expect.anything());
-      });
-    });
-
     it("does not show a create item when createNewItemFromQuery returns undefined", async () => {
       render(
         <DropdownField<number>

--- a/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
@@ -853,6 +853,23 @@ describe("DropdownField", () => {
       expect(screen.queryByRole("option", { name: /^Create/u })).toBeNull();
     });
 
+    it("does not create a value that is equal to an existing item", async () => {
+      render(
+        <DropdownField
+          value={null}
+          items={STRING_ITEMS}
+          createNewItemFromQuery={() => "Alice"}
+        />
+      );
+
+      await openAndType("Ali");
+
+      await vi.waitFor(() => {
+        expect(screen.getByRole("option", { name: "Alice" })).toBeDefined();
+      });
+      expect(screen.queryByRole("option", { name: /^Create/u })).toBeNull();
+    });
+
     it("commits the coerced value when the create item is clicked", async () => {
       const onChange = vi.fn();
       const createNewItemFromQuery = vi.fn(coerceToUpper);
@@ -927,6 +944,29 @@ describe("DropdownField", () => {
       expect(screen.queryByRole("option", { name: /^Create/u })).toBeNull();
     });
 
+    it("keeps a create item visible when coercion changes its string label", async () => {
+      const onChange = vi.fn();
+      render(
+        <DropdownField<number>
+          value={null}
+          items={[]}
+          onChange={onChange}
+          createNewItemFromQuery={(query) => Math.trunc(Number(query))}
+        />
+      );
+
+      await openAndType("3.14");
+
+      const createOption = await screen.findByRole("option", {
+        name: 'Create "3.14"',
+      });
+      fireEvent.click(createOption);
+
+      await vi.waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(3, expect.anything());
+      });
+    });
+
     it("renders the create option after the matching items", async () => {
       render(
         <DropdownField
@@ -994,6 +1034,27 @@ describe("DropdownField", () => {
       expect(screen.queryByRole("option", { name: /^Create/u })).toBeNull();
     });
 
+    it("does not offer a value matched to the selection by isItemEqual", async () => {
+      const selected = { id: 1, label: "Existing label" };
+      render(
+        <DropdownField<typeof selected, true>
+          value={[selected]}
+          items={[]}
+          isMultiple={true}
+          itemToStringLabel={(item) => item.label}
+          isItemEqual={(a, b) => a.id === b.id}
+          createNewItemFromQuery={(query) => ({ id: 1, label: query })}
+        />
+      );
+
+      await openAndType("alias");
+
+      await vi.waitFor(() => {
+        expect(screen.getByText("No results")).toBeDefined();
+      });
+      expect(screen.queryByRole("option", { name: /^Create/u })).toBeNull();
+    });
+
     it("surfaces a created-and-selected value as a row in multi-select", async () => {
       render(
         <DropdownField<string, true>
@@ -1016,6 +1077,27 @@ describe("DropdownField", () => {
       });
     });
 
+    it("does not duplicate a selected item matched by isItemEqual", async () => {
+      const listed = { id: 1, label: "Alice" };
+      const selected = { id: 1, label: "Alicia" };
+      render(
+        <DropdownField<typeof listed, true>
+          value={[selected]}
+          items={[listed]}
+          isMultiple={true}
+          itemToStringLabel={(item) => item.label}
+          isItemEqual={(a, b) => a.id === b.id}
+          createNewItemFromQuery={(query) => ({ id: 2, label: query })}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("combobox"));
+
+      await vi.waitFor(() => {
+        expect(screen.getAllByRole("option")).toHaveLength(1);
+      });
+    });
+
     it("surfaces a created-and-selected value as the last row in single-select", async () => {
       render(
         <DropdownField
@@ -1033,6 +1115,29 @@ describe("DropdownField", () => {
           "DANA"
         );
       });
+    });
+
+    it("treats an array-valued single selection as one item", async () => {
+      const selected: ArrayItem = ["Dana", "Reviewer"];
+      render(
+        <DropdownField<ArrayItem>
+          value={selected}
+          items={[]}
+          itemToStringLabel={arrayItemToStringLabel}
+          itemToKey={arrayItemToKey}
+          isItemEqual={isSameArrayItem}
+          createNewItemFromQuery={(query) => [query, "Created"]}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("combobox"));
+
+      await vi.waitFor(() => {
+        expect(
+          screen.getByRole("option", { name: "Dana Reviewer" })
+        ).toBeDefined();
+      });
+      expect(screen.getAllByRole("option")).toHaveLength(1);
     });
 
     it("does not surface selected-but-absent values when not creatable", async () => {

--- a/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
@@ -1191,6 +1191,30 @@ describe("DropdownField", () => {
       // gets no synthetic row.
       expect(screen.queryByRole("option", { name: "DANA" })).toBeNull();
     });
+
+    it("renders custom create-item content via createNewItemRenderer while keeping the default accessible name", async () => {
+      render(
+        <DropdownField
+          value={null}
+          items={STRING_ITEMS}
+          createNewItemFromQuery={coerceToUpper}
+          createNewItemRenderer={(query) => (
+            <span data-testid="custom-create">Add {query}</span>
+          )}
+        />
+      );
+
+      await openAndType("Dana");
+
+      await vi.waitFor(() => {
+        // Accessible name stays the default so the action is announced
+        // consistently; only the visible content is overridden.
+        expect(
+          screen.getByRole("option", { name: 'Create "Dana"' })
+        ).toBeDefined();
+      });
+      expect(screen.getByTestId("custom-create").textContent).toBe("Add Dana");
+    });
   });
 });
 

--- a/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
@@ -508,6 +508,38 @@ describe("DropdownField", () => {
       });
     });
 
+    it("preserves the last controlled query when returning to uncontrolled mode", async () => {
+      const { rerender } = render(
+        <DropdownField value={null} items={STRING_ITEMS} isSearchable={true} />
+      );
+
+      fireEvent.click(screen.getByRole("combobox"));
+
+      const searchInput = await vi.waitFor(() =>
+        screen.getByPlaceholderText("Search…")
+      );
+      if (!(searchInput instanceof HTMLInputElement)) {
+        throw new Error("Expected search input to be an HTMLInputElement");
+      }
+
+      fireEvent.change(searchInput, { target: { value: "Al" } });
+
+      rerender(
+        <DropdownField
+          value={null}
+          items={STRING_ITEMS}
+          isSearchable={true}
+          query="Bo"
+        />
+      );
+      expect(searchInput.value).toBe("Bo");
+
+      rerender(
+        <DropdownField value={null} items={STRING_ITEMS} isSearchable={true} />
+      );
+      expect(searchInput.value).toBe("Bo");
+    });
+
     it("filters items when portalContainer is set", async () => {
       const portalContainer = document.createElement("div");
       document.body.append(portalContainer);

--- a/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
@@ -986,10 +986,73 @@ describe("DropdownField", () => {
 
       await openAndType("dana");
 
+      // The already-selected created value surfaces as its own (checked) row,
+      // but no duplicate "Create" option is offered for it.
       await vi.waitFor(() => {
-        expect(screen.getByText("No results")).toBeDefined();
+        expect(screen.getByRole("option", { name: "DANA" })).toBeDefined();
       });
       expect(screen.queryByRole("option", { name: /^Create/u })).toBeNull();
+    });
+
+    it("surfaces a created-and-selected value as a row in multi-select", async () => {
+      render(
+        <DropdownField<string, true>
+          value={["DANA"]}
+          items={STRING_ITEMS}
+          isMultiple={true}
+          createNewItemFromQuery={coerceToUpper}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("combobox"));
+
+      await vi.waitFor(() => {
+        const options = screen.getAllByRole("option");
+        // Existing items first, created value last.
+        expect(options.map((o) => o.getAttribute("aria-label"))).toEqual([
+          ...STRING_ITEMS,
+          "DANA",
+        ]);
+      });
+    });
+
+    it("surfaces a created-and-selected value as the last row in single-select", async () => {
+      render(
+        <DropdownField
+          value={"DANA"}
+          items={STRING_ITEMS}
+          createNewItemFromQuery={coerceToUpper}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("combobox"));
+
+      await vi.waitFor(() => {
+        const options = screen.getAllByRole("option");
+        expect(options[options.length - 1].getAttribute("aria-label")).toBe(
+          "DANA"
+        );
+      });
+    });
+
+    it("does not surface selected-but-absent values when not creatable", async () => {
+      render(
+        <DropdownField<string, true>
+          value={["DANA"]}
+          items={STRING_ITEMS}
+          isMultiple={true}
+          isSearchable={true}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("combobox"));
+
+      await vi.waitFor(() => {
+        expect(screen.getByRole("option", { name: "Alice" })).toBeDefined();
+      });
+      // Without createNewItemFromQuery, a selected value absent from `items`
+      // gets no synthetic row.
+      expect(screen.queryByRole("option", { name: "DANA" })).toBeNull();
     });
   });
 });

--- a/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
@@ -906,7 +906,7 @@ describe("DropdownField", () => {
       });
     });
 
-    it("does not show a create item when createNewItemFromQuery rejects the query", async () => {
+    it("does not show a create item when createNewItemFromQuery returns undefined", async () => {
       render(
         <DropdownField<number>
           value={null}

--- a/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
@@ -779,25 +779,15 @@ describe("DropdownField", () => {
 
   describe("creatable", () => {
     // Coerces the query to upper case so the test can prove the committed value
-    // is what `createItemFromQuery` returned, not the raw query text.
+    // is what `createNewItemFromQuery` returned, not the raw query text.
     const coerceToUpper = (query: string): string => query.trim().toUpperCase();
 
-    async function openAndType(text: string): Promise<HTMLElement> {
-      fireEvent.click(screen.getByRole("combobox"));
-      await vi.waitFor(() => {
-        expect(screen.getByPlaceholderText("Search…")).toBeDefined();
-      });
-      const input = screen.getByPlaceholderText("Search…");
-      fireEvent.change(input, { target: { value: text } });
-      return input;
-    }
-
-    it("renders a searchable combobox when createItemFromQuery is provided without isSearchable", async () => {
+    it("renders a searchable combobox when createNewItemFromQuery is provided without isSearchable", async () => {
       render(
         <DropdownField
           value={null}
           items={STRING_ITEMS}
-          createItemFromQuery={coerceToUpper}
+          createNewItemFromQuery={coerceToUpper}
         />
       );
 
@@ -814,7 +804,7 @@ describe("DropdownField", () => {
           value={null}
           items={STRING_ITEMS}
           isSearchable={true}
-          createItemFromQuery={coerceToUpper}
+          createNewItemFromQuery={coerceToUpper}
         />
       );
 
@@ -833,7 +823,7 @@ describe("DropdownField", () => {
           value={null}
           items={STRING_ITEMS}
           isSearchable={true}
-          createItemFromQuery={coerceToUpper}
+          createNewItemFromQuery={coerceToUpper}
         />
       );
 
@@ -851,7 +841,7 @@ describe("DropdownField", () => {
           value={null}
           items={STRING_ITEMS}
           isSearchable={true}
-          createItemFromQuery={coerceToUpper}
+          createNewItemFromQuery={coerceToUpper}
         />
       );
 
@@ -865,14 +855,14 @@ describe("DropdownField", () => {
 
     it("commits the coerced value when the create item is clicked", async () => {
       const onChange = vi.fn();
-      const createItemFromQuery = vi.fn(coerceToUpper);
+      const createNewItemFromQuery = vi.fn(coerceToUpper);
       render(
         <DropdownField
           value={null}
           items={STRING_ITEMS}
           isSearchable={true}
           onChange={onChange}
-          createItemFromQuery={createItemFromQuery}
+          createNewItemFromQuery={createNewItemFromQuery}
         />
       );
 
@@ -886,7 +876,7 @@ describe("DropdownField", () => {
       await vi.waitFor(() => {
         expect(onChange).toHaveBeenCalledWith("DANA", expect.anything());
       });
-      expect(createItemFromQuery).toHaveBeenCalledWith("dana");
+      expect(createNewItemFromQuery).toHaveBeenCalledWith("dana");
     });
 
     it("commits the coerced value when Enter is pressed on the create item", async () => {
@@ -897,7 +887,7 @@ describe("DropdownField", () => {
           items={STRING_ITEMS}
           isSearchable={true}
           onChange={onChange}
-          createItemFromQuery={coerceToUpper}
+          createNewItemFromQuery={coerceToUpper}
         />
       );
 
@@ -916,13 +906,13 @@ describe("DropdownField", () => {
       });
     });
 
-    it("does not show a create item when createItemFromQuery rejects the query", async () => {
+    it("does not show a create item when createNewItemFromQuery rejects the query", async () => {
       render(
         <DropdownField<number>
           value={null}
           items={NUMBER_ITEMS}
           isSearchable={true}
-          createItemFromQuery={(query) => {
+          createNewItemFromQuery={(query) => {
             const parsed = Number(query.trim());
             return Number.isNaN(parsed) ? undefined : parsed;
           }}
@@ -937,22 +927,23 @@ describe("DropdownField", () => {
       expect(screen.queryByRole("option", { name: /^Create/u })).toBeNull();
     });
 
-    it("renders a custom create label via renderCreateLabel", async () => {
+    it("renders the create option after the matching items", async () => {
       render(
         <DropdownField
           value={null}
           items={STRING_ITEMS}
           isSearchable={true}
-          createItemFromQuery={coerceToUpper}
-          renderCreateLabel={(query) => <span>Add {query}</span>}
+          createNewItemFromQuery={coerceToUpper}
         />
       );
 
-      await openAndType("Dana");
+      await openAndType("Al");
 
       await vi.waitFor(() => {
-        const option = screen.getByRole("option", { name: 'Create "Dana"' });
-        expect(within(option).getByText("Add Dana")).toBeDefined();
+        const options = screen.getAllByRole("option");
+        expect(options[options.length - 1].getAttribute("aria-label")).toBe(
+          'Create "Al"'
+        );
       });
     });
 
@@ -964,7 +955,7 @@ describe("DropdownField", () => {
           items={STRING_ITEMS}
           isMultiple={true}
           onChange={onChange}
-          createItemFromQuery={coerceToUpper}
+          createNewItemFromQuery={coerceToUpper}
         />
       );
 
@@ -989,7 +980,7 @@ describe("DropdownField", () => {
           value={["DANA"]}
           items={STRING_ITEMS}
           isMultiple={true}
-          createItemFromQuery={coerceToUpper}
+          createNewItemFromQuery={coerceToUpper}
         />
       );
 
@@ -1069,4 +1060,14 @@ function arrayItemToKey(item: ArrayItem): string {
 
 function isSameArrayItem(a: ArrayItem, b: ArrayItem): boolean {
   return a[0] === b[0] && a[1] === b[1];
+}
+
+async function openAndType(text: string): Promise<HTMLElement> {
+  fireEvent.click(screen.getByRole("combobox"));
+  await vi.waitFor(() => {
+    expect(screen.getByPlaceholderText("Search…")).toBeDefined();
+  });
+  const input = screen.getByPlaceholderText("Search…");
+  fireEvent.change(input, { target: { value: text } });
+  return input;
 }

--- a/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
+++ b/packages/react-components/src/action-form/__tests__/DropdownField.test.tsx
@@ -776,9 +776,236 @@ describe("DropdownField", () => {
       expect(onChange).not.toHaveBeenCalled();
     });
   });
+
+  describe("creatable", () => {
+    // Coerces the query to upper case so the test can prove the committed value
+    // is what `createItemFromQuery` returned, not the raw query text.
+    const coerceToUpper = (query: string): string => query.trim().toUpperCase();
+
+    async function openAndType(text: string): Promise<HTMLElement> {
+      fireEvent.click(screen.getByRole("combobox"));
+      await vi.waitFor(() => {
+        expect(screen.getByPlaceholderText("Search…")).toBeDefined();
+      });
+      const input = screen.getByPlaceholderText("Search…");
+      fireEvent.change(input, { target: { value: text } });
+      return input;
+    }
+
+    it("renders a searchable combobox when createItemFromQuery is provided without isSearchable", async () => {
+      render(
+        <DropdownField
+          value={null}
+          items={STRING_ITEMS}
+          createItemFromQuery={coerceToUpper}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("combobox"));
+
+      await vi.waitFor(() => {
+        expect(screen.getByPlaceholderText("Search…")).toBeDefined();
+      });
+    });
+
+    it("shows a synthetic create item when the query matches no option", async () => {
+      render(
+        <DropdownField
+          value={null}
+          items={STRING_ITEMS}
+          isSearchable={true}
+          createItemFromQuery={coerceToUpper}
+        />
+      );
+
+      await openAndType("Dana");
+
+      await vi.waitFor(() => {
+        expect(
+          screen.getByRole("option", { name: 'Create "Dana"' })
+        ).toBeDefined();
+      });
+    });
+
+    it("does not show a create item for an empty or whitespace query", async () => {
+      render(
+        <DropdownField
+          value={null}
+          items={STRING_ITEMS}
+          isSearchable={true}
+          createItemFromQuery={coerceToUpper}
+        />
+      );
+
+      await openAndType("   ");
+
+      await vi.waitFor(() => {
+        expect(screen.getByRole("option", { name: "Alice" })).toBeDefined();
+      });
+      expect(screen.queryByRole("option", { name: /^Create/u })).toBeNull();
+    });
+
+    it("does not show a create item when the query matches an existing option", async () => {
+      render(
+        <DropdownField
+          value={null}
+          items={STRING_ITEMS}
+          isSearchable={true}
+          createItemFromQuery={coerceToUpper}
+        />
+      );
+
+      await openAndType("Alice");
+
+      await vi.waitFor(() => {
+        expect(screen.getByRole("option", { name: "Alice" })).toBeDefined();
+      });
+      expect(screen.queryByRole("option", { name: /^Create/u })).toBeNull();
+    });
+
+    it("commits the coerced value when the create item is clicked", async () => {
+      const onChange = vi.fn();
+      const createItemFromQuery = vi.fn(coerceToUpper);
+      render(
+        <DropdownField
+          value={null}
+          items={STRING_ITEMS}
+          isSearchable={true}
+          onChange={onChange}
+          createItemFromQuery={createItemFromQuery}
+        />
+      );
+
+      await openAndType("dana");
+
+      const createOption = await vi.waitFor(() =>
+        screen.getByRole("option", { name: 'Create "dana"' })
+      );
+      fireEvent.click(createOption);
+
+      await vi.waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith("DANA", expect.anything());
+      });
+      expect(createItemFromQuery).toHaveBeenCalledWith("dana");
+    });
+
+    it("commits the coerced value when Enter is pressed on the create item", async () => {
+      const onChange = vi.fn();
+      render(
+        <DropdownField
+          value={null}
+          items={STRING_ITEMS}
+          isSearchable={true}
+          onChange={onChange}
+          createItemFromQuery={coerceToUpper}
+        />
+      );
+
+      const input = await openAndType("dana");
+
+      await vi.waitFor(() => {
+        expect(
+          screen.getByRole("option", { name: 'Create "dana"' })
+        ).toBeDefined();
+      });
+
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      await vi.waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith("DANA", expect.anything());
+      });
+    });
+
+    it("does not show a create item when createItemFromQuery rejects the query", async () => {
+      render(
+        <DropdownField<number>
+          value={null}
+          items={NUMBER_ITEMS}
+          isSearchable={true}
+          createItemFromQuery={(query) => {
+            const parsed = Number(query.trim());
+            return Number.isNaN(parsed) ? undefined : parsed;
+          }}
+        />
+      );
+
+      await openAndType("abc");
+
+      await vi.waitFor(() => {
+        expect(screen.getByText("No results")).toBeDefined();
+      });
+      expect(screen.queryByRole("option", { name: /^Create/u })).toBeNull();
+    });
+
+    it("renders a custom create label via renderCreateLabel", async () => {
+      render(
+        <DropdownField
+          value={null}
+          items={STRING_ITEMS}
+          isSearchable={true}
+          createItemFromQuery={coerceToUpper}
+          renderCreateLabel={(query) => <span>Add {query}</span>}
+        />
+      );
+
+      await openAndType("Dana");
+
+      await vi.waitFor(() => {
+        const option = screen.getByRole("option", { name: 'Create "Dana"' });
+        expect(within(option).getByText("Add Dana")).toBeDefined();
+      });
+    });
+
+    it("appends the coerced value to the selection in multi-select", async () => {
+      const onChange = vi.fn();
+      render(
+        <DropdownField<string, true>
+          value={["Alice"]}
+          items={STRING_ITEMS}
+          isMultiple={true}
+          onChange={onChange}
+          createItemFromQuery={coerceToUpper}
+        />
+      );
+
+      await openAndType("dana");
+
+      const createOption = await vi.waitFor(() =>
+        screen.getByRole("option", { name: 'Create "dana"' })
+      );
+      fireEvent.click(createOption);
+
+      await vi.waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(
+          ["Alice", "DANA"],
+          expect.anything()
+        );
+      });
+    });
+
+    it("does not offer to create a value already selected in multi-select", async () => {
+      render(
+        <DropdownField<string, true>
+          value={["DANA"]}
+          items={STRING_ITEMS}
+          isMultiple={true}
+          createItemFromQuery={coerceToUpper}
+        />
+      );
+
+      await openAndType("dana");
+
+      await vi.waitFor(() => {
+        expect(screen.getByText("No results")).toBeDefined();
+      });
+      expect(screen.queryByRole("option", { name: /^Create/u })).toBeNull();
+    });
+  });
 });
 
 const STRING_ITEMS = ["Alice", "Bob", "Charlie"];
+
+const NUMBER_ITEMS = [1, 2, 3];
 
 interface TestUser {
   id: number;

--- a/packages/react-components/src/action-form/fields/AsyncDropdownField.tsx
+++ b/packages/react-components/src/action-form/fields/AsyncDropdownField.tsx
@@ -102,6 +102,11 @@ export const AsyncDropdownField: <V, Multiple extends boolean = false>(
         ) : null
       }
       disableClientSideFiltering={dropdownProps.onQueryChange != null}
+      createNewItemFromQuery={
+        isLoading || isSearching
+          ? undefined
+          : dropdownProps.createNewItemFromQuery
+      }
     />
   );
 });

--- a/packages/react-components/src/action-form/fields/DropdownField.tsx
+++ b/packages/react-components/src/action-form/fields/DropdownField.tsx
@@ -299,7 +299,12 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
   // search text when the query isn't controlled, so we can derive the
   // synthetic item.
   const isCreatable = createNewItemFromQuery != null;
-  const [internalQuery, setInternalQuery] = useState("");
+  const [internalQuery, setInternalQuery] = useState(query ?? "");
+  React.useEffect(() => {
+    if (query !== undefined) {
+      setInternalQuery(query);
+    }
+  }, [query]);
   const currentQuery = query ?? internalQuery;
   const trimmedQuery = isCreatable ? currentQuery.trim() : "";
 
@@ -324,7 +329,7 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
   }, [isMultiple, value]);
 
   const areItemsEqual = useCallback(
-    (a: V, b: V) => (isItemEqual != null ? isItemEqual(a, b) : a === b),
+    (a: V, b: V) => (isItemEqual != null ? isItemEqual(a, b) : Object.is(a, b)),
     [isItemEqual]
   );
 
@@ -392,10 +397,11 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
   // the typed query — e.g. a numeric coercer where "4.9" becomes value 4 with
   // label "4". Exempt it by identity so it stays visible whenever it exists,
   // while real items still filter normally via base-ui's locale-aware matcher.
-  const { contains } = BaseUICombobox.useFilter({ multiple: true });
+  const { contains } = BaseUICombobox.useFilter({ multiple: isMultiple });
   const creatableFilter = useCallback(
     (item: V, nextQuery: string, itemToString?: (item: V) => string) =>
-      item === syntheticItem || contains(item, nextQuery, itemToString),
+      (syntheticItem !== undefined && Object.is(item, syntheticItem)) ||
+      contains(item, nextQuery, itemToString),
     [contains, syntheticItem]
   );
 
@@ -512,7 +518,7 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
         itemToStringLabel={itemToStringLabel}
         isItemEqualToValue={isItemEqual}
         items={effectiveItems}
-        inputValue={isCreatable ? currentQuery : query}
+        inputValue={currentQuery}
         onInputValueChange={handleInputValueChange}
         filter={
           disableClientSideFiltering

--- a/packages/react-components/src/action-form/fields/DropdownField.tsx
+++ b/packages/react-components/src/action-form/fields/DropdownField.tsx
@@ -15,7 +15,7 @@
  */
 
 import { CaretDown, Cross, SmallCross, Tick } from "@blueprintjs/icons";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 
 import { Combobox } from "../../base-components/combobox/Combobox.js";
 import { Select } from "../../base-components/select/Select.js";
@@ -57,6 +57,8 @@ interface InnerComboboxProps<
   disableClientSideFiltering?: boolean;
   popupStatus?: React.ReactNode;
   trailingItem?: DropdownFieldProps<V, Multiple>["trailingItem"];
+  createItemFromQuery?: DropdownFieldProps<V, Multiple>["createItemFromQuery"];
+  renderCreateLabel?: DropdownFieldProps<V, Multiple>["renderCreateLabel"];
 }
 
 export const DropdownField: <V, Multiple extends boolean = false>(
@@ -76,6 +78,8 @@ export const DropdownField: <V, Multiple extends boolean = false>(
   disableClientSideFiltering,
   popupStatus,
   trailingItem,
+  createItemFromQuery,
+  renderCreateLabel,
   modal = true,
   ...rest
 }: DropdownFieldProps<V, Multiple> & {
@@ -97,8 +101,13 @@ export const DropdownField: <V, Multiple extends boolean = false>(
     [itemToKey, resolvedItemToStringLabel]
   );
 
+  // Creatable implies a searchable combobox: the user needs the search input
+  // to type the value they want to create.
+  const isCreatable = createItemFromQuery != null;
+  const searchable = isSearchable || isCreatable;
+
   // Multi-select always uses Combobox for the chip-based UI because it looks better
-  if (isSearchable || isMultiple) {
+  if (searchable || isMultiple) {
     return (
       <ComboboxDropdown
         {...rest}
@@ -107,12 +116,14 @@ export const DropdownField: <V, Multiple extends boolean = false>(
         itemToStringLabel={resolvedItemToStringLabel}
         renderItemLabel={resolvedRenderItemLabel}
         getKey={getKey}
-        isSearchable={isSearchable}
+        isSearchable={searchable}
         query={query}
         onQueryChange={onQueryChange}
         disableClientSideFiltering={disableClientSideFiltering}
         popupStatus={popupStatus}
         trailingItem={trailingItem}
+        createItemFromQuery={createItemFromQuery}
+        renderCreateLabel={renderCreateLabel}
         modal={modal}
       />
     );
@@ -275,12 +286,75 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
   disableClientSideFiltering,
   popupStatus,
   trailingItem,
+  createItemFromQuery,
+  renderCreateLabel,
   onBlur,
   modal = true,
   disabled,
 }: InnerComboboxProps<V, Multiple>): React.ReactElement {
   const [open, setOpen] = useState(false);
   const isOpen = !disabled && open;
+
+  // Creatable works for single- and multi-select. `internalQuery` tracks the
+  // search text when the query isn't controlled, so we can derive the
+  // synthetic item.
+  const isCreatable = createItemFromQuery != null;
+  const [internalQuery, setInternalQuery] = useState("");
+  const currentQuery = query ?? internalQuery;
+  const trimmedQuery = isCreatable ? currentQuery.trim() : "";
+
+  const handleInputValueChange = useCallback(
+    (nextValue: string) => {
+      if (isCreatable && query == null) {
+        setInternalQuery(nextValue);
+      }
+      onQueryChange?.(nextValue);
+    },
+    [isCreatable, query, onQueryChange]
+  );
+
+  // The synthetic "Create …" item is a real (already-coerced) value injected
+  // into the item list, so base-ui handles both click and Enter selection.
+  const syntheticItem = useMemo<V | undefined>(() => {
+    if (!isCreatable || trimmedQuery === "" || createItemFromQuery == null) {
+      return undefined;
+    }
+    const lowerQuery = trimmedQuery.toLowerCase();
+    const matchesExisting = items.some(
+      (item) => itemToStringLabel(item).trim().toLowerCase() === lowerQuery
+    );
+    if (matchesExisting) {
+      return undefined;
+    }
+    const created = createItemFromQuery(trimmedQuery);
+    if (created === undefined) {
+      return undefined;
+    }
+    // Don't offer to create a value that's already selected — array membership
+    // for multi-select, equality for single-select.
+    const sameValue = (a: V, b: V): boolean =>
+      isItemEqual != null ? isItemEqual(a, b) : Object.is(a, b);
+    const alreadySelected = Array.isArray(value)
+      ? value.some((selected) => sameValue(created, selected as V))
+      : value != null && sameValue(created, value as V);
+    if (alreadySelected) {
+      return undefined;
+    }
+    return created;
+  }, [
+    isCreatable,
+    trimmedQuery,
+    createItemFromQuery,
+    items,
+    itemToStringLabel,
+    isItemEqual,
+    value,
+  ]);
+
+  const effectiveItems = useMemo(
+    () => (syntheticItem !== undefined ? [...items, syntheticItem] : items),
+    [items, syntheticItem]
+  );
 
   const hasValue = isMultiple
     ? Array.isArray(value) && value.length > 0
@@ -348,6 +422,22 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
 
   const renderItem = useCallback(
     (item: V) => {
+      // The synthetic create item is the exact reference we appended, so an
+      // identity check reliably distinguishes it from real options.
+      if (syntheticItem !== undefined && Object.is(item, syntheticItem)) {
+        const createLabel = `Create "${trimmedQuery}"`;
+        return (
+          <Combobox.Item
+            key="__osdk_create_item__"
+            value={item}
+            aria-label={createLabel}
+          >
+            {renderCreateLabel != null
+              ? renderCreateLabel(trimmedQuery)
+              : createLabel}
+          </Combobox.Item>
+        );
+      }
       const itemLabel = itemToStringLabel(item);
       return (
         <Combobox.Item key={getKey(item)} value={item} aria-label={itemLabel}>
@@ -360,7 +450,15 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
         </Combobox.Item>
       );
     },
-    [getKey, isMultiple, itemToStringLabel, renderItemLabel]
+    [
+      getKey,
+      isMultiple,
+      itemToStringLabel,
+      renderItemLabel,
+      syntheticItem,
+      trimmedQuery,
+      renderCreateLabel,
+    ]
   );
 
   return (
@@ -373,10 +471,11 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
         multiple={isMultiple}
         itemToStringLabel={itemToStringLabel}
         isItemEqualToValue={isItemEqual}
-        items={items}
-        inputValue={query}
-        onInputValueChange={onQueryChange}
+        items={effectiveItems}
+        inputValue={isCreatable ? currentQuery : query}
+        onInputValueChange={handleInputValueChange}
         filter={disableClientSideFiltering ? null : undefined}
+        autoHighlight={isCreatable || undefined}
         disabled={disabled}
       >
         <Combobox.Trigger

--- a/packages/react-components/src/action-form/fields/DropdownField.tsx
+++ b/packages/react-components/src/action-form/fields/DropdownField.tsx
@@ -43,6 +43,7 @@ interface InnerSelectProps<V, Multiple extends boolean> extends Omit<
   itemToStringLabel: (item: V) => string;
   renderItemLabel: (item: V) => React.ReactNode;
   getKey: (item: V) => string;
+  isItemEqual: (a: V, b: V) => boolean;
   portalRef?: React.Ref<HTMLDivElement>;
   query?: string;
   onQueryChange?: (query: string) => void;
@@ -62,6 +63,10 @@ interface InnerComboboxProps<
     V,
     Multiple
   >["createNewItemFromQuery"];
+  createNewItemRenderer?: DropdownFieldProps<
+    V,
+    Multiple
+  >["createNewItemRenderer"];
 }
 
 export const DropdownField: <V, Multiple extends boolean = false>(
@@ -82,6 +87,8 @@ export const DropdownField: <V, Multiple extends boolean = false>(
   popupStatus,
   trailingItem,
   createNewItemFromQuery,
+  createNewItemRenderer,
+  isItemEqual,
   modal = true,
   ...rest
 }: DropdownFieldProps<V, Multiple> & {
@@ -103,21 +110,29 @@ export const DropdownField: <V, Multiple extends boolean = false>(
     [itemToKey, resolvedItemToStringLabel]
   );
 
+  const resolvedIsItemEqual = isItemEqual ?? defaultIsItemEqual;
+
   // Creatable implies a searchable combobox: the user needs the search input
   // to type the value they want to create.
   const isCreatable = createNewItemFromQuery != null;
   const searchable = isSearchable || isCreatable;
+
+  const commonProps = {
+    modal,
+    getKey,
+    value: normalizedValue,
+    isItemEqual: resolvedIsItemEqual,
+    renderItemLabel: resolvedRenderItemLabel,
+    itemToStringLabel: resolvedItemToStringLabel,
+  };
 
   // Multi-select always uses Combobox for the chip-based UI because it looks better
   if (searchable || isMultiple) {
     return (
       <ComboboxDropdown
         {...rest}
+        {...commonProps}
         isMultiple={isMultiple}
-        value={normalizedValue}
-        itemToStringLabel={resolvedItemToStringLabel}
-        renderItemLabel={resolvedRenderItemLabel}
-        getKey={getKey}
         isSearchable={searchable}
         query={query}
         onQueryChange={onQueryChange}
@@ -125,22 +140,13 @@ export const DropdownField: <V, Multiple extends boolean = false>(
         popupStatus={popupStatus}
         trailingItem={trailingItem}
         createNewItemFromQuery={createNewItemFromQuery}
-        modal={modal}
+        createNewItemRenderer={createNewItemRenderer}
       />
     );
   }
 
   // TODO: Support trailingItem
-  return (
-    <SelectDropdown
-      {...rest}
-      value={normalizedValue}
-      itemToStringLabel={resolvedItemToStringLabel}
-      renderItemLabel={resolvedRenderItemLabel}
-      getKey={getKey}
-      modal={modal}
-    />
-  );
+  return <SelectDropdown {...rest} {...commonProps} />;
 });
 
 const SelectDropdown = typedReactMemo(function SelectDropdownFn<
@@ -288,6 +294,7 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
   popupStatus,
   trailingItem,
   createNewItemFromQuery,
+  createNewItemRenderer,
   onBlur,
   modal = true,
   disabled,
@@ -310,12 +317,10 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
 
   const handleInputValueChange = useCallback(
     (nextValue: string) => {
-      if (query == null) {
-        setInternalQuery(nextValue);
-      }
+      setInternalQuery(nextValue);
       onQueryChange?.(nextValue);
     },
-    [query, onQueryChange]
+    [onQueryChange]
   );
 
   // Normalize single/multi selection to an array once so downstream key checks
@@ -328,11 +333,6 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
     return isMultiple ? (value as V[]) : [value as V];
   }, [isMultiple, value]);
 
-  const areItemsEqual = useCallback(
-    (a: V, b: V) => (isItemEqual != null ? isItemEqual(a, b) : Object.is(a, b)),
-    [isItemEqual]
-  );
-
   // Created items only ever land in `value`, never in `items`. Surface any
   // selected value that isn't a known item as a row (at the end, in selection
   // order) so created items stay visible — and, in multi-select, uncheckable —
@@ -342,9 +342,9 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
       return EMPTY_ARRAY;
     }
     return selectedItems.filter(
-      (selected) => !items.some((item) => areItemsEqual(item, selected))
+      (selected) => !items.some((item) => isItemEqual(item, selected))
     );
-  }, [isCreatable, selectedItems, items, areItemsEqual]);
+  }, [isCreatable, selectedItems, items, isItemEqual]);
 
   const dropdownItems = useMemo(
     () => [...items, ...createdSelectedItems],
@@ -372,7 +372,7 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
     }
     // `dropdownItems` already includes every selected value (created selections
     // are surfaced into it), so this also suppresses already-selected values.
-    if (dropdownItems.some((item) => areItemsEqual(item, created))) {
+    if (dropdownItems.some((item) => isItemEqual(item, created))) {
       return undefined;
     }
     return created;
@@ -381,7 +381,7 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
     createNewItemFromQuery,
     dropdownItems,
     itemToStringLabel,
-    areItemsEqual,
+    isItemEqual,
   ]);
 
   const effectiveItems = useMemo(
@@ -457,9 +457,7 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
       if (!isMultiple || !Array.isArray(value)) {
         return;
       }
-      const next = value.filter((v) =>
-        isItemEqual != null ? !isItemEqual(v, itemToRemove) : v !== itemToRemove
-      );
+      const next = value.filter((v) => !isItemEqual(v, itemToRemove));
       (handleValueChange as (v: V[] | V | null) => void)(next);
     },
     [isMultiple, value, handleValueChange, isItemEqual]
@@ -479,9 +477,12 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
           <Combobox.Item
             key="__osdk_create_item__"
             value={item}
+            // Keep the default string as the accessible name even when a custom
+            // renderer supplies the visible content, so the create action is
+            // announced consistently to screen readers.
             aria-label={createLabel}
           >
-            {createLabel}
+            {createNewItemRenderer?.(trimmedQuery) ?? createLabel}
           </Combobox.Item>
         );
       }
@@ -504,6 +505,7 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
       renderItemLabel,
       syntheticItem,
       trimmedQuery,
+      createNewItemRenderer,
     ]
   );
 
@@ -527,7 +529,6 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
               ? creatableFilter
               : undefined
         }
-        autoHighlight={isCreatable || undefined}
         disabled={disabled}
       >
         <Combobox.Trigger
@@ -634,4 +635,8 @@ function defaultItemToStringLabel<V>(item: V): string {
     return item.label;
   }
   return String(item);
+}
+
+function defaultIsItemEqual<V>(a: V, b: V): boolean {
+  return a === b;
 }

--- a/packages/react-components/src/action-form/fields/DropdownField.tsx
+++ b/packages/react-components/src/action-form/fields/DropdownField.tsx
@@ -304,12 +304,12 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
 
   const handleInputValueChange = useCallback(
     (nextValue: string) => {
-      if (isCreatable && query == null) {
+      if (query == null) {
         setInternalQuery(nextValue);
       }
       onQueryChange?.(nextValue);
     },
-    [isCreatable, query, onQueryChange]
+    [query, onQueryChange]
   );
 
   // The synthetic "Create …" item is a real (already-coerced) value injected
@@ -319,11 +319,11 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
     if (createNewItemFromQuery == null || trimmedQuery === "") {
       return undefined;
     }
-    // The query already names an existing option — nothing to create.
     const lowerQuery = trimmedQuery.toLowerCase();
     const matchesExisting = items.some(
       (item) => itemToStringLabel(item).trim().toLowerCase() === lowerQuery
     );
+    // The query already names an existing option — nothing to create.
     if (matchesExisting) {
       return undefined;
     }
@@ -331,20 +331,27 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
     if (created === undefined) {
       return undefined;
     }
-    // Don't offer to create a value that's already selected — array membership
-    // for multi-select, equality for single-select.
-    const sameValue = (a: V, b: V): boolean =>
-      isItemEqual != null ? isItemEqual(a, b) : Object.is(a, b);
-    const alreadySelected = Array.isArray(value)
-      ? value.some((selected) => sameValue(created, selected as V))
-      : value != null && sameValue(created, value as V);
+    // Don't offer to create a value that's already selected — compare by the
+    // canonical item key (itemToKey ?? label). Normalize single/multi selection
+    // to an array first so the key check is uniform.
+    const createdKey = getKey(created);
+    const currentValue: V[] | V | null = value;
+    const selectedItems: readonly V[] =
+      currentValue == null
+        ? EMPTY_ARRAY
+        : Array.isArray(currentValue)
+          ? currentValue
+          : [currentValue];
+    const alreadySelected = selectedItems.some(
+      (selected) => getKey(selected) === createdKey
+    );
     return alreadySelected ? undefined : created;
   }, [
     trimmedQuery,
     createNewItemFromQuery,
     items,
     itemToStringLabel,
-    isItemEqual,
+    getKey,
     value,
   ]);
 

--- a/packages/react-components/src/action-form/fields/DropdownField.tsx
+++ b/packages/react-components/src/action-form/fields/DropdownField.tsx
@@ -57,8 +57,10 @@ interface InnerComboboxProps<
   disableClientSideFiltering?: boolean;
   popupStatus?: React.ReactNode;
   trailingItem?: DropdownFieldProps<V, Multiple>["trailingItem"];
-  createItemFromQuery?: DropdownFieldProps<V, Multiple>["createItemFromQuery"];
-  renderCreateLabel?: DropdownFieldProps<V, Multiple>["renderCreateLabel"];
+  createNewItemFromQuery?: DropdownFieldProps<
+    V,
+    Multiple
+  >["createNewItemFromQuery"];
 }
 
 export const DropdownField: <V, Multiple extends boolean = false>(
@@ -78,8 +80,7 @@ export const DropdownField: <V, Multiple extends boolean = false>(
   disableClientSideFiltering,
   popupStatus,
   trailingItem,
-  createItemFromQuery,
-  renderCreateLabel,
+  createNewItemFromQuery,
   modal = true,
   ...rest
 }: DropdownFieldProps<V, Multiple> & {
@@ -103,7 +104,7 @@ export const DropdownField: <V, Multiple extends boolean = false>(
 
   // Creatable implies a searchable combobox: the user needs the search input
   // to type the value they want to create.
-  const isCreatable = createItemFromQuery != null;
+  const isCreatable = createNewItemFromQuery != null;
   const searchable = isSearchable || isCreatable;
 
   // Multi-select always uses Combobox for the chip-based UI because it looks better
@@ -122,8 +123,7 @@ export const DropdownField: <V, Multiple extends boolean = false>(
         disableClientSideFiltering={disableClientSideFiltering}
         popupStatus={popupStatus}
         trailingItem={trailingItem}
-        createItemFromQuery={createItemFromQuery}
-        renderCreateLabel={renderCreateLabel}
+        createNewItemFromQuery={createNewItemFromQuery}
         modal={modal}
       />
     );
@@ -286,8 +286,7 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
   disableClientSideFiltering,
   popupStatus,
   trailingItem,
-  createItemFromQuery,
-  renderCreateLabel,
+  createNewItemFromQuery,
   onBlur,
   modal = true,
   disabled,
@@ -298,7 +297,7 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
   // Creatable works for single- and multi-select. `internalQuery` tracks the
   // search text when the query isn't controlled, so we can derive the
   // synthetic item.
-  const isCreatable = createItemFromQuery != null;
+  const isCreatable = createNewItemFromQuery != null;
   const [internalQuery, setInternalQuery] = useState("");
   const currentQuery = query ?? internalQuery;
   const trimmedQuery = isCreatable ? currentQuery.trim() : "";
@@ -316,9 +315,11 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
   // The synthetic "Create …" item is a real (already-coerced) value injected
   // into the item list, so base-ui handles both click and Enter selection.
   const syntheticItem = useMemo<V | undefined>(() => {
-    if (!isCreatable || trimmedQuery === "" || createItemFromQuery == null) {
+    // Not creatable, or the user hasn't typed anything yet.
+    if (createNewItemFromQuery == null || trimmedQuery === "") {
       return undefined;
     }
+    // The query already names an existing option — nothing to create.
     const lowerQuery = trimmedQuery.toLowerCase();
     const matchesExisting = items.some(
       (item) => itemToStringLabel(item).trim().toLowerCase() === lowerQuery
@@ -326,7 +327,7 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
     if (matchesExisting) {
       return undefined;
     }
-    const created = createItemFromQuery(trimmedQuery);
+    const created = createNewItemFromQuery(trimmedQuery);
     if (created === undefined) {
       return undefined;
     }
@@ -337,14 +338,10 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
     const alreadySelected = Array.isArray(value)
       ? value.some((selected) => sameValue(created, selected as V))
       : value != null && sameValue(created, value as V);
-    if (alreadySelected) {
-      return undefined;
-    }
-    return created;
+    return alreadySelected ? undefined : created;
   }, [
-    isCreatable,
     trimmedQuery,
-    createItemFromQuery,
+    createNewItemFromQuery,
     items,
     itemToStringLabel,
     isItemEqual,
@@ -432,9 +429,7 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
             value={item}
             aria-label={createLabel}
           >
-            {renderCreateLabel != null
-              ? renderCreateLabel(trimmedQuery)
-              : createLabel}
+            {createLabel}
           </Combobox.Item>
         );
       }
@@ -457,7 +452,6 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
       renderItemLabel,
       syntheticItem,
       trimmedQuery,
-      renderCreateLabel,
     ]
   );
 

--- a/packages/react-components/src/action-form/fields/DropdownField.tsx
+++ b/packages/react-components/src/action-form/fields/DropdownField.tsx
@@ -312,6 +312,17 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
     [query, onQueryChange]
   );
 
+  // Normalize single/multi selection to an array once so downstream key checks
+  // (already-selected suppression, surfacing created items) are uniform.
+  const selectedItems = useMemo<readonly V[]>(() => {
+    const currentValue: V[] | V | null = value;
+    return currentValue == null
+      ? EMPTY_ARRAY
+      : Array.isArray(currentValue)
+        ? currentValue
+        : [currentValue];
+  }, [value]);
+
   // The synthetic "Create …" item is a real (already-coerced) value injected
   // into the item list, so base-ui handles both click and Enter selection.
   const syntheticItem = useMemo<V | undefined>(() => {
@@ -332,16 +343,8 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
       return undefined;
     }
     // Don't offer to create a value that's already selected — compare by the
-    // canonical item key (itemToKey ?? label). Normalize single/multi selection
-    // to an array first so the key check is uniform.
+    // canonical item key (itemToKey ?? label).
     const createdKey = getKey(created);
-    const currentValue: V[] | V | null = value;
-    const selectedItems: readonly V[] =
-      currentValue == null
-        ? EMPTY_ARRAY
-        : Array.isArray(currentValue)
-          ? currentValue
-          : [currentValue];
     const alreadySelected = selectedItems.some(
       (selected) => getKey(selected) === createdKey
     );
@@ -352,12 +355,29 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
     items,
     itemToStringLabel,
     getKey,
-    value,
+    selectedItems,
   ]);
 
+  // Created items only ever land in `value`, never in `items`. Surface any
+  // selected value that isn't a known item as a row (at the end, in selection
+  // order) so created items stay visible — and, in multi-select, uncheckable —
+  // after selection. Gated on creatable so plain dropdowns are unaffected.
+  const createdSelectedItems = useMemo<readonly V[]>(() => {
+    if (!isCreatable) {
+      return EMPTY_ARRAY;
+    }
+    return selectedItems.filter(
+      (selected) => !items.some((item) => getKey(item) === getKey(selected))
+    );
+  }, [isCreatable, selectedItems, items, getKey]);
+
   const effectiveItems = useMemo(
-    () => (syntheticItem !== undefined ? [...items, syntheticItem] : items),
-    [items, syntheticItem]
+    () => [
+      ...items,
+      ...createdSelectedItems,
+      ...(syntheticItem !== undefined ? [syntheticItem] : []),
+    ],
+    [items, createdSelectedItems, syntheticItem]
   );
 
   const hasValue = isMultiple

--- a/packages/react-components/src/action-form/fields/DropdownField.tsx
+++ b/packages/react-components/src/action-form/fields/DropdownField.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Combobox as BaseUICombobox } from "@base-ui/react/combobox";
 import { CaretDown, Cross, SmallCross, Tick } from "@blueprintjs/icons";
 import React, { useCallback, useMemo, useState } from "react";
 
@@ -315,13 +316,17 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
   // Normalize single/multi selection to an array once so downstream key checks
   // (already-selected suppression, surfacing created items) are uniform.
   const selectedItems = useMemo<readonly V[]>(() => {
-    const currentValue: V[] | V | null = value;
-    return currentValue == null
-      ? EMPTY_ARRAY
-      : Array.isArray(currentValue)
-        ? currentValue
-        : [currentValue];
-  }, [value]);
+    if (value == null) {
+      return EMPTY_ARRAY;
+    }
+    // TypeScript cannot narrow the conditional value type from `isMultiple`.
+    return isMultiple ? (value as V[]) : [value as V];
+  }, [isMultiple, value]);
+
+  const areItemsEqual = useCallback(
+    (a: V, b: V) => (isItemEqual != null ? isItemEqual(a, b) : a === b),
+    [isItemEqual]
+  );
 
   // Created items only ever land in `value`, never in `items`. Surface any
   // selected value that isn't a known item as a row (at the end, in selection
@@ -332,9 +337,9 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
       return EMPTY_ARRAY;
     }
     return selectedItems.filter(
-      (selected) => !items.some((item) => getKey(item) === getKey(selected))
+      (selected) => !items.some((item) => areItemsEqual(item, selected))
     );
-  }, [isCreatable, selectedItems, items, getKey]);
+  }, [isCreatable, selectedItems, items, areItemsEqual]);
 
   const dropdownItems = useMemo(
     () => [...items, ...createdSelectedItems],
@@ -360,20 +365,18 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
     if (created === undefined) {
       return undefined;
     }
-    // Don't offer to create a value that's already selected — compare by the
-    // canonical item key (itemToKey ?? label).
-    const createdKey = getKey(created);
-    const alreadySelected = selectedItems.some(
-      (selected) => getKey(selected) === createdKey
-    );
-    return alreadySelected ? undefined : created;
+    // `dropdownItems` already includes every selected value (created selections
+    // are surfaced into it), so this also suppresses already-selected values.
+    if (dropdownItems.some((item) => areItemsEqual(item, created))) {
+      return undefined;
+    }
+    return created;
   }, [
     trimmedQuery,
     createNewItemFromQuery,
     dropdownItems,
     itemToStringLabel,
-    getKey,
-    selectedItems,
+    areItemsEqual,
   ]);
 
   const effectiveItems = useMemo(
@@ -382,6 +385,18 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
       ...(syntheticItem !== undefined ? [syntheticItem] : []),
     ],
     [dropdownItems, syntheticItem]
+  );
+
+  // The synthetic "Create …" item is injected into the item list, so base-ui's
+  // built-in filter would hide it whenever its (coerced) label doesn't contain
+  // the typed query — e.g. a numeric coercer where "4.9" becomes value 4 with
+  // label "4". Exempt it by identity so it stays visible whenever it exists,
+  // while real items still filter normally via base-ui's locale-aware matcher.
+  const { contains } = BaseUICombobox.useFilter({ multiple: true });
+  const creatableFilter = useCallback(
+    (item: V, nextQuery: string, itemToString?: (item: V) => string) =>
+      item === syntheticItem || contains(item, nextQuery, itemToString),
+    [contains, syntheticItem]
   );
 
   const hasValue = isMultiple
@@ -499,7 +514,13 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
         items={effectiveItems}
         inputValue={isCreatable ? currentQuery : query}
         onInputValueChange={handleInputValueChange}
-        filter={disableClientSideFiltering ? null : undefined}
+        filter={
+          disableClientSideFiltering
+            ? null
+            : isCreatable
+              ? creatableFilter
+              : undefined
+        }
         autoHighlight={isCreatable || undefined}
         disabled={disabled}
       >

--- a/packages/react-components/src/action-form/fields/DropdownField.tsx
+++ b/packages/react-components/src/action-form/fields/DropdownField.tsx
@@ -323,6 +323,24 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
         : [currentValue];
   }, [value]);
 
+  // Created items only ever land in `value`, never in `items`. Surface any
+  // selected value that isn't a known item as a row (at the end, in selection
+  // order) so created items stay visible — and, in multi-select, uncheckable —
+  // after selection. Gated on creatable so plain dropdowns are unaffected.
+  const createdSelectedItems = useMemo<readonly V[]>(() => {
+    if (!isCreatable) {
+      return EMPTY_ARRAY;
+    }
+    return selectedItems.filter(
+      (selected) => !items.some((item) => getKey(item) === getKey(selected))
+    );
+  }, [isCreatable, selectedItems, items, getKey]);
+
+  const dropdownItems = useMemo(
+    () => [...items, ...createdSelectedItems],
+    [items, createdSelectedItems]
+  );
+
   // The synthetic "Create …" item is a real (already-coerced) value injected
   // into the item list, so base-ui handles both click and Enter selection.
   const syntheticItem = useMemo<V | undefined>(() => {
@@ -331,7 +349,7 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
       return undefined;
     }
     const lowerQuery = trimmedQuery.toLowerCase();
-    const matchesExisting = items.some(
+    const matchesExisting = dropdownItems.some(
       (item) => itemToStringLabel(item).trim().toLowerCase() === lowerQuery
     );
     // The query already names an existing option — nothing to create.
@@ -352,32 +370,18 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
   }, [
     trimmedQuery,
     createNewItemFromQuery,
-    items,
+    dropdownItems,
     itemToStringLabel,
     getKey,
     selectedItems,
   ]);
 
-  // Created items only ever land in `value`, never in `items`. Surface any
-  // selected value that isn't a known item as a row (at the end, in selection
-  // order) so created items stay visible — and, in multi-select, uncheckable —
-  // after selection. Gated on creatable so plain dropdowns are unaffected.
-  const createdSelectedItems = useMemo<readonly V[]>(() => {
-    if (!isCreatable) {
-      return EMPTY_ARRAY;
-    }
-    return selectedItems.filter(
-      (selected) => !items.some((item) => getKey(item) === getKey(selected))
-    );
-  }, [isCreatable, selectedItems, items, getKey]);
-
   const effectiveItems = useMemo(
     () => [
-      ...items,
-      ...createdSelectedItems,
+      ...dropdownItems,
       ...(syntheticItem !== undefined ? [syntheticItem] : []),
     ],
-    [items, createdSelectedItems, syntheticItem]
+    [dropdownItems, syntheticItem]
   );
 
   const hasValue = isMultiple

--- a/packages/react-components/src/action-form/fields/DropdownField.tsx
+++ b/packages/react-components/src/action-form/fields/DropdownField.tsx
@@ -312,8 +312,7 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
       setInternalQuery(query);
     }
   }, [query]);
-  const currentQuery = query ?? internalQuery;
-  const trimmedQuery = isCreatable ? currentQuery.trim() : "";
+  const trimmedQuery = isCreatable ? internalQuery.trim() : "";
 
   const handleInputValueChange = useCallback(
     (nextValue: string) => {
@@ -520,7 +519,7 @@ const ComboboxDropdown = typedReactMemo(function ComboboxDropdownFn<
         itemToStringLabel={itemToStringLabel}
         isItemEqualToValue={isItemEqual}
         items={effectiveItems}
-        inputValue={currentQuery}
+        inputValue={internalQuery}
         onInputValueChange={handleInputValueChange}
         filter={
           disableClientSideFiltering


### PR DESCRIPTION
## What

Adds a creatable ("Create …") capability to `DropdownField`'s searchable Combobox.

Two optional props on `DropdownFieldProps`:

- `createNewItemFromQuery?: (query) => V | undefined` — presence enables creatable mode (implies searchable). When the trimmed query is non-empty and matches no existing option, a synthetic "Create …" item is offered; selecting it (by click, or by pressing Enter when the create row is the highlighted option) commits the value this callback returns via `onChange`. The **caller** does the coercion here (e.g. `coerceFieldValue`) and returns `undefined` to reject a query. Keeps `DropdownField` OSDK-agnostic.
- `createNewItemRenderer?: (query) => ReactNode` — overrides the **visible** content of the "Create …" item (defaults to `Create "<query>"`). The item's accessible name stays `Create "<query>"` regardless, so an override only changes visuals.

Works for both single-select and multi-select (multi behaves like a creatable tag input, appending each created value). The synthetic item is injected as a real, already-coerced `V` into base-ui's item list so base-ui handles click and keyboard selection natively. An already-selected value is never re-offered, and created values absent from `items` are surfaced back into the list so they stay visible — and, in multi-select, uncheckable — after selection.

## Scope

This is the reusable building block for the `oneOf` + `otherValuesAllowed: true` slice.

**Known follow-up:** Enter-to-create through `autoHighlight` (not added in this PR because it doesn't play nicely with the AsyncDropdown)

## Verification

- `pnpm turbo typecheck --filter=@osdk/react-components`
- `pnpm turbo check --filter=@osdk/react-components`
- `pnpm --dir packages/react-components exec vitest run src/action-form` (creatable tests cover: synthetic item appears/suppressed, click + Enter commit with coercion, multi-select append, rejected coercion, custom renderer)

<img width="1288" height="734" alt="update" src="https://github.com/user-attachments/assets/6e51cf2e-4fef-449f-a116-99dce82a4fcb" />
