### PR TITLE
Fix EditBatch update rejecting edits with array-valued properties

### DIFF
--- a/.changeset/edit-batch-interface-array-props.md
+++ b/.changeset/edit-batch-interface-array-props.md
@@ -1,0 +1,5 @@
+---
+"@osdk/functions": patch
+---
+
+Fix EditBatch/WriteableClient `update` rejecting interface (and object) edits whose types have array-valued properties.

--- a/packages/client/src/fetchMetadata.test.ts
+++ b/packages/client/src/fetchMetadata.test.ts
@@ -272,6 +272,16 @@ describe("FetchMetadata", () => {
           },
         },
         "properties": {
+          "fooArray": {
+            "description": "An array-valued Foo property",
+            "displayName": "Foo Array",
+            "hasReducers": false,
+            "multiplicity": true,
+            "nullable": true,
+            "type": "string",
+            "valueFormatting": undefined,
+            "valueTypeApiName": undefined,
+          },
           "fooIdp": {
             "description": "A Foo IDP",
             "displayName": "Foo IDP",

--- a/packages/client/src/object/convertWireToOsdkObjects.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.test.ts
@@ -716,246 +716,256 @@ describe("convertWireToOsdkObjects", () => {
           employee.$__EXPERIMENTAL__NOT_SUPPORTED_YET__metadata.ObjectMetadata
         ).toMatchInlineSnapshot(
           `
-            {
-              "apiName": "Employee",
-              "description": "A full-time or part-time 
+          {
+            "apiName": "Employee",
+            "description": "A full-time or part-time 
 
-             employee of our firm",
-              "displayName": "Employee",
-              "icon": {
-                "color": "blue",
-                "name": "person",
-                "type": "blueprint",
-              },
-              "implements": [
-                "FooInterface",
-              ],
-              "interfaceImplementations": {
-                "FooInterface": {
-                  "fooIdp": {
-                    "propertyApiName": "office",
-                    "type": "localProperty",
-                  },
-                  "fooSpt": {
-                    "propertyApiName": "fullName",
-                    "type": "localProperty",
-                  },
+           employee of our firm",
+            "displayName": "Employee",
+            "icon": {
+              "color": "blue",
+              "name": "person",
+              "type": "blueprint",
+            },
+            "implements": [
+              "FooInterface",
+            ],
+            "interfaceImplementations": {
+              "FooInterface": {
+                "fooIdp": {
+                  "propertyApiName": "office",
+                  "type": "localProperty",
+                },
+                "fooSpt": {
+                  "propertyApiName": "fullName",
+                  "type": "localProperty",
                 },
               },
-              "interfaceMap": {
-                "FooInterface": {
-                  "fooIdp": "office",
-                  "fooSpt": "fullName",
-                },
+            },
+            "interfaceMap": {
+              "FooInterface": {
+                "fooIdp": "office",
+                "fooSpt": "fullName",
               },
-              "inverseInterfaceMap": {
-                "FooInterface": {
-                  "fullName": "fooSpt",
-                  "office": "fooIdp",
-                },
+            },
+            "inverseInterfaceMap": {
+              "FooInterface": {
+                "fullName": "fooSpt",
+                "office": "fooIdp",
               },
-              "links": {
-                "lead": {
-                  "multiplicity": false,
-                  "targetType": "Employee",
-                },
-                "officeLink": {
-                  "multiplicity": false,
-                  "targetType": "Office",
-                },
-                "peeps": {
-                  "multiplicity": true,
-                  "targetType": "Employee",
-                },
-                "visitedOffices": {
-                  "multiplicity": true,
-                  "targetType": "Office",
-                },
+            },
+            "links": {
+              "lead": {
+                "multiplicity": false,
+                "targetType": "Employee",
               },
-              "pluralDisplayName": "Employees",
-              "primaryKeyApiName": "employeeId",
-              "primaryKeyType": "integer",
-              "properties": {
-                "class": {
-                  "description": "",
-                  "displayName": undefined,
-                  "multiplicity": false,
-                  "nullable": true,
-                  "type": "string",
-                  "valueFormatting": undefined,
-                  "valueTypeApiName": undefined,
-                },
-                "employeeId": {
-                  "description": undefined,
-                  "displayName": undefined,
-                  "multiplicity": false,
-                  "nullable": false,
-                  "type": "integer",
-                  "valueFormatting": undefined,
-                  "valueTypeApiName": undefined,
-                },
-                "employeeLocation": {
-                  "description": "Geotime series reference of the location of the employee",
-                  "displayName": undefined,
-                  "multiplicity": false,
-                  "nullable": true,
-                  "type": "geotimeSeriesReference",
-                  "valueFormatting": undefined,
-                  "valueTypeApiName": undefined,
-                },
-                "employeeProfile": {
-                  "description": "Employee profile with main value being the bio",
-                  "displayName": undefined,
-                  "mainValue": {
-                    "fields": [
-                      "bio",
-                    ],
-                  },
-                  "multiplicity": false,
-                  "nullable": true,
-                  "type": {
-                    "bio": "string",
-                    "yearsExperience": "integer",
-                  },
-                  "valueFormatting": undefined,
-                  "valueTypeApiName": undefined,
-                },
-                "employeeSensor": {
-                  "description": "TimeSeries sensor of the status of the employee",
-                  "displayName": undefined,
-                  "multiplicity": false,
-                  "nullable": true,
-                  "type": "stringTimeseries",
-                  "valueFormatting": undefined,
-                  "valueTypeApiName": undefined,
-                },
-                "employeeStatus": {
-                  "description": "TimeSeries of the status of the employee",
-                  "displayName": undefined,
-                  "multiplicity": false,
-                  "nullable": true,
-                  "type": "stringTimeseries",
-                  "valueFormatting": undefined,
-                  "valueTypeApiName": undefined,
-                },
-                "favoriteRestaurants": {
-                  "description": undefined,
-                  "displayName": undefined,
-                  "hasReducers": false,
-                  "multiplicity": true,
-                  "nullable": true,
-                  "type": "string",
-                  "valueFormatting": undefined,
-                  "valueTypeApiName": undefined,
-                },
-                "fullName": {
-                  "description": undefined,
-                  "displayName": undefined,
-                  "multiplicity": false,
-                  "nullable": true,
-                  "type": "string",
-                  "valueFormatting": undefined,
-                  "valueTypeApiName": undefined,
-                },
-                "office": {
-                  "description": "The unique "ID" of the employee's \\"primary\\" assigned office.
-             This is some more text.",
-                  "displayName": undefined,
-                  "multiplicity": false,
-                  "nullable": true,
-                  "type": "string",
-                  "valueFormatting": undefined,
-                  "valueTypeApiName": undefined,
-                },
-                "performanceScores": {
-                  "description": "Array of performance scores with reducers",
-                  "displayName": undefined,
-                  "hasReducers": true,
-                  "multiplicity": true,
-                  "nullable": true,
-                  "type": "double",
-                  "valueFormatting": undefined,
-                  "valueTypeApiName": undefined,
-                },
-                "skillSet": {
-                  "description": "The skills of the employee",
-                  "displayName": undefined,
-                  "multiplicity": false,
-                  "nullable": true,
-                  "type": "string",
-                  "valueFormatting": undefined,
-                  "valueTypeApiName": undefined,
-                },
-                "skillSetEmbedding": {
-                  "description": "Vectorized skill set",
-                  "displayName": undefined,
-                  "multiplicity": false,
-                  "nullable": true,
-                  "type": "vector",
-                  "valueFormatting": undefined,
-                  "valueTypeApiName": undefined,
-                },
-                "startDate": {
-                  "description": "The date the employee was hired (most recently, if they were re-hired)",
-                  "displayName": undefined,
-                  "multiplicity": false,
-                  "nullable": true,
-                  "type": "datetime",
-                  "valueFormatting": undefined,
-                  "valueTypeApiName": undefined,
-                },
+              "officeLink": {
+                "multiplicity": false,
+                "targetType": "Office",
               },
-              "rid": "ri.ontology.main.object-type.401ac022-89eb-4591-8b7e-0a912b9efb44",
-              "status": "ACTIVE",
-              "titleProperty": "fullName",
-              "type": "object",
-              "visibility": "NORMAL",
-              Symbol(InterfaceDefinitions): {
-                "FooInterface": {
-                  "def": {
-                    "apiName": "FooInterface",
-                    "description": "Interface for Foo",
-                    "displayName": "Foo Interface",
-                    "implementedBy": [
-                      "Employee",
-                      "Person",
-                    ],
-                    "implements": [],
-                    "links": {
-                      "toBar": {
-                        "multiplicity": true,
-                        "targetType": "interface",
-                        "targetTypeApiName": "BarInterface",
-                      },
+              "peeps": {
+                "multiplicity": true,
+                "targetType": "Employee",
+              },
+              "visitedOffices": {
+                "multiplicity": true,
+                "targetType": "Office",
+              },
+            },
+            "pluralDisplayName": "Employees",
+            "primaryKeyApiName": "employeeId",
+            "primaryKeyType": "integer",
+            "properties": {
+              "class": {
+                "description": "",
+                "displayName": undefined,
+                "multiplicity": false,
+                "nullable": true,
+                "type": "string",
+                "valueFormatting": undefined,
+                "valueTypeApiName": undefined,
+              },
+              "employeeId": {
+                "description": undefined,
+                "displayName": undefined,
+                "multiplicity": false,
+                "nullable": false,
+                "type": "integer",
+                "valueFormatting": undefined,
+                "valueTypeApiName": undefined,
+              },
+              "employeeLocation": {
+                "description": "Geotime series reference of the location of the employee",
+                "displayName": undefined,
+                "multiplicity": false,
+                "nullable": true,
+                "type": "geotimeSeriesReference",
+                "valueFormatting": undefined,
+                "valueTypeApiName": undefined,
+              },
+              "employeeProfile": {
+                "description": "Employee profile with main value being the bio",
+                "displayName": undefined,
+                "mainValue": {
+                  "fields": [
+                    "bio",
+                  ],
+                },
+                "multiplicity": false,
+                "nullable": true,
+                "type": {
+                  "bio": "string",
+                  "yearsExperience": "integer",
+                },
+                "valueFormatting": undefined,
+                "valueTypeApiName": undefined,
+              },
+              "employeeSensor": {
+                "description": "TimeSeries sensor of the status of the employee",
+                "displayName": undefined,
+                "multiplicity": false,
+                "nullable": true,
+                "type": "stringTimeseries",
+                "valueFormatting": undefined,
+                "valueTypeApiName": undefined,
+              },
+              "employeeStatus": {
+                "description": "TimeSeries of the status of the employee",
+                "displayName": undefined,
+                "multiplicity": false,
+                "nullable": true,
+                "type": "stringTimeseries",
+                "valueFormatting": undefined,
+                "valueTypeApiName": undefined,
+              },
+              "favoriteRestaurants": {
+                "description": undefined,
+                "displayName": undefined,
+                "hasReducers": false,
+                "multiplicity": true,
+                "nullable": true,
+                "type": "string",
+                "valueFormatting": undefined,
+                "valueTypeApiName": undefined,
+              },
+              "fullName": {
+                "description": undefined,
+                "displayName": undefined,
+                "multiplicity": false,
+                "nullable": true,
+                "type": "string",
+                "valueFormatting": undefined,
+                "valueTypeApiName": undefined,
+              },
+              "office": {
+                "description": "The unique "ID" of the employee's \\"primary\\" assigned office.
+           This is some more text.",
+                "displayName": undefined,
+                "multiplicity": false,
+                "nullable": true,
+                "type": "string",
+                "valueFormatting": undefined,
+                "valueTypeApiName": undefined,
+              },
+              "performanceScores": {
+                "description": "Array of performance scores with reducers",
+                "displayName": undefined,
+                "hasReducers": true,
+                "multiplicity": true,
+                "nullable": true,
+                "type": "double",
+                "valueFormatting": undefined,
+                "valueTypeApiName": undefined,
+              },
+              "skillSet": {
+                "description": "The skills of the employee",
+                "displayName": undefined,
+                "multiplicity": false,
+                "nullable": true,
+                "type": "string",
+                "valueFormatting": undefined,
+                "valueTypeApiName": undefined,
+              },
+              "skillSetEmbedding": {
+                "description": "Vectorized skill set",
+                "displayName": undefined,
+                "multiplicity": false,
+                "nullable": true,
+                "type": "vector",
+                "valueFormatting": undefined,
+                "valueTypeApiName": undefined,
+              },
+              "startDate": {
+                "description": "The date the employee was hired (most recently, if they were re-hired)",
+                "displayName": undefined,
+                "multiplicity": false,
+                "nullable": true,
+                "type": "datetime",
+                "valueFormatting": undefined,
+                "valueTypeApiName": undefined,
+              },
+            },
+            "rid": "ri.ontology.main.object-type.401ac022-89eb-4591-8b7e-0a912b9efb44",
+            "status": "ACTIVE",
+            "titleProperty": "fullName",
+            "type": "object",
+            "visibility": "NORMAL",
+            Symbol(InterfaceDefinitions): {
+              "FooInterface": {
+                "def": {
+                  "apiName": "FooInterface",
+                  "description": "Interface for Foo",
+                  "displayName": "Foo Interface",
+                  "implementedBy": [
+                    "Employee",
+                    "Person",
+                  ],
+                  "implements": [],
+                  "links": {
+                    "toBar": {
+                      "multiplicity": true,
+                      "targetType": "interface",
+                      "targetTypeApiName": "BarInterface",
                     },
-                    "properties": {
-                      "fooIdp": {
-                        "description": "A Foo IDP",
-                        "displayName": "Foo IDP",
-                        "multiplicity": false,
-                        "nullable": true,
-                        "type": "string",
-                        "valueFormatting": undefined,
-                        "valueTypeApiName": undefined,
-                      },
-                      "fooSpt": {
-                        "description": "A foo",
-                        "displayName": "Foo",
-                        "multiplicity": false,
-                        "nullable": true,
-                        "type": "string",
-                        "valueFormatting": undefined,
-                        "valueTypeApiName": undefined,
-                      },
-                    },
-                    "rid": "ri.interface.main.interface.1",
-                    "type": "interface",
                   },
-                  "handler": undefined,
+                  "properties": {
+                    "fooArray": {
+                      "description": "An array-valued Foo property",
+                      "displayName": "Foo Array",
+                      "hasReducers": false,
+                      "multiplicity": true,
+                      "nullable": true,
+                      "type": "string",
+                      "valueFormatting": undefined,
+                      "valueTypeApiName": undefined,
+                    },
+                    "fooIdp": {
+                      "description": "A Foo IDP",
+                      "displayName": "Foo IDP",
+                      "multiplicity": false,
+                      "nullable": true,
+                      "type": "string",
+                      "valueFormatting": undefined,
+                      "valueTypeApiName": undefined,
+                    },
+                    "fooSpt": {
+                      "description": "A foo",
+                      "displayName": "Foo",
+                      "multiplicity": false,
+                      "nullable": true,
+                      "type": "string",
+                      "valueFormatting": undefined,
+                      "valueTypeApiName": undefined,
+                    },
+                  },
+                  "rid": "ri.interface.main.interface.1",
+                  "type": "interface",
                 },
+                "handler": undefined,
               },
-            }
-          `
+            },
+          }
+        `
         );
       });
 
@@ -1014,46 +1024,56 @@ describe("convertWireToOsdkObjects", () => {
             .InterfaceMetadata
         ).toMatchInlineSnapshot(
           `
-            {
-              "apiName": "FooInterface",
-              "description": "Interface for Foo",
-              "displayName": "Foo Interface",
-              "implementedBy": [
-                "Employee",
-                "Person",
-              ],
-              "implements": [],
-              "links": {
-                "toBar": {
-                  "multiplicity": true,
-                  "targetType": "interface",
-                  "targetTypeApiName": "BarInterface",
-                },
+          {
+            "apiName": "FooInterface",
+            "description": "Interface for Foo",
+            "displayName": "Foo Interface",
+            "implementedBy": [
+              "Employee",
+              "Person",
+            ],
+            "implements": [],
+            "links": {
+              "toBar": {
+                "multiplicity": true,
+                "targetType": "interface",
+                "targetTypeApiName": "BarInterface",
               },
-              "properties": {
-                "fooIdp": {
-                  "description": "A Foo IDP",
-                  "displayName": "Foo IDP",
-                  "multiplicity": false,
-                  "nullable": true,
-                  "type": "string",
-                  "valueFormatting": undefined,
-                  "valueTypeApiName": undefined,
-                },
-                "fooSpt": {
-                  "description": "A foo",
-                  "displayName": "Foo",
-                  "multiplicity": false,
-                  "nullable": true,
-                  "type": "string",
-                  "valueFormatting": undefined,
-                  "valueTypeApiName": undefined,
-                },
+            },
+            "properties": {
+              "fooArray": {
+                "description": "An array-valued Foo property",
+                "displayName": "Foo Array",
+                "hasReducers": false,
+                "multiplicity": true,
+                "nullable": true,
+                "type": "string",
+                "valueFormatting": undefined,
+                "valueTypeApiName": undefined,
               },
-              "rid": "ri.interface.main.interface.1",
-              "type": "interface",
-            }
-          `
+              "fooIdp": {
+                "description": "A Foo IDP",
+                "displayName": "Foo IDP",
+                "multiplicity": false,
+                "nullable": true,
+                "type": "string",
+                "valueFormatting": undefined,
+                "valueTypeApiName": undefined,
+              },
+              "fooSpt": {
+                "description": "A foo",
+                "displayName": "Foo",
+                "multiplicity": false,
+                "nullable": true,
+                "type": "string",
+                "valueFormatting": undefined,
+                "valueTypeApiName": undefined,
+              },
+            },
+            "rid": "ri.interface.main.interface.1",
+            "type": "interface",
+          }
+        `
         );
       });
       it("$experimental_metadata is not enumerable", async () => {

--- a/packages/foundry-sdk-generator/src/ontologyMetadata/__snapshots__/metadataResolver.test.ts.snap
+++ b/packages/foundry-sdk-generator/src/ontologyMetadata/__snapshots__/metadataResolver.test.ts.snap
@@ -164,6 +164,20 @@ exports[`Load Ontologies Metadata > Loads action types with media refs, interfac
           },
         },
         "allPropertiesV2": {
+          "fooArray": {
+            "apiName": "fooArray",
+            "dataType": {
+              "subType": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "description": "An array-valued Foo property",
+            "displayName": "Foo Array",
+            "requireImplementation": false,
+            "rid": "ri.interfacePropertyType.main.interfacePropertyType.2",
+            "typeClasses": [],
+          },
           "fooIdp": {
             "apiName": "fooIdp",
             "dataType": {
@@ -222,6 +236,21 @@ exports[`Load Ontologies Metadata > Loads action types with media refs, interfac
           },
         },
         "propertiesV2": {
+          "fooArray": {
+            "apiName": "fooArray",
+            "dataType": {
+              "subType": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "description": "An array-valued Foo property",
+            "displayName": "Foo Array",
+            "requireImplementation": false,
+            "rid": "ri.interfacePropertyType.main.interfacePropertyType.2",
+            "type": "interfaceDefinedPropertyType",
+            "typeClasses": [],
+          },
           "fooIdp": {
             "apiName": "fooIdp",
             "dataType": {
@@ -949,6 +978,20 @@ exports[`Load Ontologies Metadata > Loads object, action, interface types withou
           },
         },
         "allPropertiesV2": {
+          "fooArray": {
+            "apiName": "fooArray",
+            "dataType": {
+              "subType": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "description": "An array-valued Foo property",
+            "displayName": "Foo Array",
+            "requireImplementation": false,
+            "rid": "ri.interfacePropertyType.main.interfacePropertyType.2",
+            "typeClasses": [],
+          },
           "fooIdp": {
             "apiName": "fooIdp",
             "dataType": {
@@ -1007,6 +1050,21 @@ exports[`Load Ontologies Metadata > Loads object, action, interface types withou
           },
         },
         "propertiesV2": {
+          "fooArray": {
+            "apiName": "fooArray",
+            "dataType": {
+              "subType": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "description": "An array-valued Foo property",
+            "displayName": "Foo Array",
+            "requireImplementation": false,
+            "rid": "ri.interfacePropertyType.main.interfacePropertyType.2",
+            "type": "interfaceDefinedPropertyType",
+            "typeClasses": [],
+          },
           "fooIdp": {
             "apiName": "fooIdp",
             "dataType": {

--- a/packages/foundry-sdk-generator/src/ontologyMetadata/__snapshots__/metadataResolver.test.ts.snap
+++ b/packages/foundry-sdk-generator/src/ontologyMetadata/__snapshots__/metadataResolver.test.ts.snap
@@ -167,6 +167,7 @@ exports[`Load Ontologies Metadata > Loads action types with media refs, interfac
           "fooArray": {
             "apiName": "fooArray",
             "dataType": {
+              "reducers": [],
               "subType": {
                 "type": "string",
               },
@@ -239,6 +240,7 @@ exports[`Load Ontologies Metadata > Loads action types with media refs, interfac
           "fooArray": {
             "apiName": "fooArray",
             "dataType": {
+              "reducers": [],
               "subType": {
                 "type": "string",
               },
@@ -981,6 +983,7 @@ exports[`Load Ontologies Metadata > Loads object, action, interface types withou
           "fooArray": {
             "apiName": "fooArray",
             "dataType": {
+              "reducers": [],
               "subType": {
                 "type": "string",
               },
@@ -1053,6 +1056,7 @@ exports[`Load Ontologies Metadata > Loads object, action, interface types withou
           "fooArray": {
             "apiName": "fooArray",
             "dataType": {
+              "reducers": [],
               "subType": {
                 "type": "string",
               },

--- a/packages/functions/src/edits/EditBatch.ts
+++ b/packages/functions/src/edits/EditBatch.ts
@@ -41,12 +41,6 @@ interface ObjectTypeDefinitionForLocator<
   apiName: OL["$apiName"];
 }
 
-interface InterfaceDefinitionForLocator<
-  IL extends ObjectLocator<any>,
-> extends InterfaceDefinition {
-  apiName: IL["$apiName"];
-}
-
 // AddLink helper types
 export type AddLinkSources<X extends AnyEdit> =
   X extends AddLink<infer OTD, any> ? ObjectLocator<OTD> : never;
@@ -133,12 +127,11 @@ export type UpdatableObjectOrInterfaceLocators<X extends AnyEdit> =
 export type UpdatableObjectOrInterfaceLocatorProperties<
   X extends AnyEdit,
   OL extends ObjectLocator<any>,
-> =
-  X extends UpdateObject<ObjectTypeDefinitionForLocator<OL>>
+> = X extends UpdateObject<any> | UpdateObjectForInterface<any>
+  ? OL["$apiName"] extends X["obj"]["$apiName"]
     ? X["properties"]
-    : X extends UpdateObjectForInterface<InterfaceDefinitionForLocator<OL>>
-      ? X["properties"]
-      : never;
+    : never
+  : never;
 
 export interface EditBatch<X extends AnyEdit = never> {
   link: <SOL extends AddLinkSources<X>, A extends AddLinkApiNames<X, SOL>>(

--- a/packages/functions/src/edits/EditBatch.ts
+++ b/packages/functions/src/edits/EditBatch.ts
@@ -129,7 +129,11 @@ export type UpdatableObjectOrInterfaceLocatorProperties<
   OL extends ObjectLocator<any>,
 > = X extends UpdateObject<any> | UpdateObjectForInterface<any>
   ? OL["$apiName"] extends X["obj"]["$apiName"]
-    ? X["properties"]
+    ? X["obj"] extends InterfaceLocator<any>
+      ? OL extends { $objectType: unknown }
+        ? X["properties"]
+        : never
+      : X["properties"]
     : never
   : never;
 

--- a/packages/functions/src/edits/createEditBatch.test.ts
+++ b/packages/functions/src/edits/createEditBatch.test.ts
@@ -112,7 +112,10 @@ describe(createEditBatch, () => {
       $objectType: "Task",
       fooSpt: "created interface",
     });
-    editBatch.update(fooInterfaceInstance, { fooSpt: "fooSpt" });
+    editBatch.update(fooInterfaceInstance, {
+      fooSpt: "fooSpt",
+      fooArray: ["a", "b"],
+    });
     editBatch.update(
       {
         $apiName: "FooInterface",
@@ -239,7 +242,7 @@ describe(createEditBatch, () => {
           $primaryKey: 21,
           $objectType: "FooObjectType",
         },
-        properties: { fooSpt: "fooSpt" },
+        properties: { fooSpt: "fooSpt", fooArray: ["a", "b"] },
       },
       {
         type: "updateObjectForInterface",

--- a/packages/functions/src/edits/createEditBatch.test.ts
+++ b/packages/functions/src/edits/createEditBatch.test.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-import type { Attachment, Client, Osdk } from "@osdk/client";
+import type {
+  Attachment,
+  Client,
+  InterfaceDefinition,
+  ObjectTypeDefinition,
+  Osdk,
+  PropertyDef,
+} from "@osdk/client";
 import type { Employee, Person } from "@osdk/client.test.ontology";
 import {
   FooInterface,
@@ -413,5 +420,84 @@ describe(createEditBatch, () => {
 
     // @ts-expect-error
     editBatch.update({ $apiName: "Task", $primaryKey: 2 }, { capacity: 4 }); // Using Office properties
+  });
+
+  it("disambiguates an object and interface that share an apiName", () => {
+    interface SharedObj extends ObjectTypeDefinition {
+      type: "object";
+      apiName: "Shared";
+      __DefinitionMetadata?: {
+        apiName: "Shared";
+        displayName: "x";
+        pluralDisplayName: "x";
+        description: "x";
+        rid: "ri.o";
+        type: "object";
+        primaryKeyApiName: "id";
+        primaryKeyType: "integer";
+        titleProperty: "id";
+        status: "ACTIVE";
+        icon: undefined;
+        visibility: undefined;
+        implements: [];
+        interfaceMap: {};
+        inverseInterfaceMap: {};
+        links: {};
+        properties: {
+          id: PropertyDef<"integer", "non-nullable", "single">;
+          objOnly: PropertyDef<"string", "nullable", "single">;
+        };
+        objectSet: any;
+        props: any;
+        strictProps: any;
+        linksType: any;
+      };
+    }
+    interface SharedInt extends InterfaceDefinition {
+      type: "interface";
+      apiName: "Shared";
+      __DefinitionMetadata?: {
+        apiName: "Shared";
+        displayName: "x";
+        description: "x";
+        rid: "ri.i";
+        type: "interface";
+        implementedBy: [];
+        implements: [];
+        links: {};
+        properties: { intOnly: PropertyDef<"boolean", "nullable", "single"> };
+        objectSet: any;
+        props: any;
+        strictProps: any;
+        linksType: any;
+      };
+    }
+
+    function _typeCheck(
+      batch: EditBatch<Edits.Object<SharedObj> | Edits.Interface<SharedInt>>,
+      sharedObjDef: SharedObj,
+      sharedIntDef: SharedInt
+    ) {
+      batch.update({ $apiName: "Shared", $primaryKey: 1 }, { objOnly: "x" });
+      // @ts-expect-error
+      batch.update({ $apiName: "Shared", $primaryKey: 1 }, { intOnly: true });
+      batch.update(
+        { $apiName: "Shared", $objectType: "Impl", $primaryKey: 1 },
+        { intOnly: true }
+      );
+
+      batch.create(sharedObjDef, { id: 1, objOnly: "x" });
+      // @ts-expect-error
+      batch.create(sharedObjDef, { intOnly: true });
+      batch.create(sharedIntDef, { $objectType: "Impl", intOnly: true });
+      // @ts-expect-error
+      batch.create(sharedIntDef, { objOnly: "x" });
+
+      batch.delete({ $apiName: "Shared", $primaryKey: 1 });
+      batch.delete({ $apiName: "Shared", $objectType: "Impl", $primaryKey: 1 });
+      // @ts-expect-error
+      batch.delete({ $apiName: "Nope", $primaryKey: 1 });
+    }
+    expect(_typeCheck).toBeDefined();
   });
 });

--- a/packages/shared.test/src/stubs/interfaceTypes.ts
+++ b/packages/shared.test/src/stubs/interfaceTypes.ts
@@ -35,6 +35,21 @@ const idp: InterfaceDefinedPropertyType = {
   typeClasses: [],
 };
 
+const arrayIdp: InterfaceDefinedPropertyType = {
+  rid: "ri.interfacePropertyType.main.interfacePropertyType.2",
+  apiName: "fooArray",
+  displayName: "Foo Array",
+  description: "An array-valued Foo property",
+  dataType: {
+    type: "array",
+    subType: {
+      type: "string",
+    },
+  },
+  requireImplementation: false,
+  typeClasses: [],
+};
+
 export const BarInterface: InterfaceType = {
   apiName: "BarInterface",
   description: "Interface for Bar",
@@ -97,6 +112,10 @@ export const FooInterface: InterfaceType = {
       ...idp,
       type: "interfaceDefinedPropertyType",
     },
+    fooArray: {
+      ...arrayIdp,
+      type: "interfaceDefinedPropertyType",
+    },
   },
   links: {
     toBar: {
@@ -127,6 +146,9 @@ export const FooInterface: InterfaceType = {
     },
     fooIdp: {
       ...idp,
+    },
+    fooArray: {
+      ...arrayIdp,
     },
   },
   allExtendsInterfaces: [],

--- a/packages/shared.test/src/stubs/interfaceTypes.ts
+++ b/packages/shared.test/src/stubs/interfaceTypes.ts
@@ -45,6 +45,7 @@ const arrayIdp: InterfaceDefinedPropertyType = {
     subType: {
       type: "string",
     },
+    reducers: [],
   },
   requireImplementation: false,
   typeClasses: [],


### PR DESCRIPTION
[TS Playground
](https://www.typescriptlang.org/play/?#code/JYOwLgpgTgZghgYwgAgApQPYAdpgJ4AqeOyA3gFDLIDWoAJgFzIBEAzmFKAObPIA+LEAFcAtgCNovAczEYMAGwhwQzANyVkwVgEEoUOHiayFSkKuQB6C8jAALFMxFD5YYFnnAEwfLxjy4XOQAvuTkoJCwiCjo2Lh4AGpw8kIQAOrAUBAEGADCHhDgZBrsnCBcTCXc6lTC4tBMtRJQ1cjGispGcu1mwaH4JInJEADyMAA8ACLIEAAekCB0rGiYOFD4RDgAfMgAvMgTANrMWrr6eMwAutNzBYs2UCkaAPzIpwZjMav4gynpmdl5YAFMAHQ7MWgLS4XTYaJifOI-NIZLK5fLgUFHCF0KHqULhaDwJDIYZiABWEAQYA2EAmEBgoG8wAwICKVBEEDAcCeTFIyCwK1wQNYTAAShSMFA6GNKmUADTLWJrQjECDbILqELkfooACyHLgk2u8zuJPJlOptPpIEZzO2ewAcsz7c5-GJFJMjuzOZdNuptQqsABpCB4ViG2bGpamilUlWWhmuW27GghjAwZB6zmTTZHfmK1wQViXZAAMmQMq4uKsyDo0GAADcIHQWE3vHA3Sg818hb4Jcg4DW6QmmSAtSqA6xRuGbgso2SYxah9bEyA7Wg4GtgEkxhpeQdA5oWZ9g6HsxcmIip5mDRMc8wu4LC5d99DkCFfaFq9pkAhmQhMpAg5WjaLIAO7eLYyCZEk8oeBESTIF6cB0HAnKHgg8gAHT9iyG5nAAtPWSQpM2XaYWE4AElEyAAKIiO4GB4BAEAAOIFNAqFNpaRq3HOZqxjg8bLiOrKIfq3KiVQD6boWPIaFQNRwOyPI0PQTBsBw3BqJoOh6AYTDwPIrAoOq8kKZyXDCmQqkLOpFbaScemGPcKRvuY1ZjPh-ZOYRxFNmZplUKZmrVjkf4QFgYDIAATEwdgOJkv4gCUQiUiOvCACgEPGzsgABCcDGdxYhCFFdArEs8XIHBHHyGJnKyuQ1asBgyAAAbSQWrCtcghlGa0iDUDYLWVVw7GcAgbVir+krSppcr7IW-5uGAEqbK15H4pERIAJKUVtNJ0gAYpgIgADIYAgqF9hGvHEvO5pxkuIFkJq-phSA-4chAu0RISB3pnsnyTuMdEMUxrFjZxdCWh+1YKQAek8jXWFQgMbq4268iASkQBJFbmBZrB43NXAHFcQQwmOJBTcyKWUk2QPJkDU4-VRSCWsdGBnRdV1QLDKNUIjyMKWjm6Y8gBwzBUJPnuWJP8MgjTQArbSmG+2xUJ55aXf4UDIMy8h4J+1g0TMWDKHcK39vItVYBgrCsMAHZoIGrBU9EAoyawh0SgAqlgKGQB8a6oNldw08lHCpZAdCMy8ocNBAjbNKE7t5UIXBcHgTOe51PtQP7gcQGM72fZArP7TD6hw4LSPC1QoHKGAcLo1u8hjFjOPE6UlY2AERPSz3ZPq-XyBcBgUWJ8nCla7lvssUwrWE4P3Bk91WiKxP-YO8AXDY87VuVawOsboetYzKn1YEPYPXAFLNbMgA5FFiW01HlLYb7xk2DfSVlygtZgIrkfksDAoEWS1k4I2Ui5UGrVlArYTwkF+SFmgI2NqjkzhxQeBAdaacxTNXkI2Q6d8mzTkjHdfii4gEjhDuVKct4-TjhITMJsyYCEKGIaQqUoN5CMWYmxEAHEY5V3IEldgyAAD69JWF0GDBFXSWDkAsLYXsTuylBDMHlMvCWzA4BaJYGIYs6pLDWAwNQeUeEDB8kyMZKA0CgA)
Interface object updates for interface types that contained array properties failed to compile. Users saw 

```
Argument of type 'any' is not assignable to parameter of type 'never'.ts(2345)
```
for example code 
```
const interfaceObj = client(InterfaceType).fetchPage().data[0]
batch.update(interfaceObj, {anyProp: "hey"})
```

This is because of how we narrowed the scope of the edit batch to know which properties are valid for the locator. The type we used for this was `UpdatableObjectOrInterfaceLocatorProperties`. Inside, it contained a clause that checked `X extends UpdateObjectForInterface<InterfaceDefinitionForLocator<OL>>`, where X was the entire edit scope `X extends AnyEdit`.  

`InterfaceDefinitionForLocator<OL>>` created an interface definition type 

```
interface InterfaceDefinitionForLocator<
  IL extends ObjectLocator<any>,
> extends InterfaceDefinition {
  apiName: IL["$apiName"];
}
```

which resolved essentially to a very generic

```
{
 apiName: "SpecificApiName"
 DefinitionMetadata: {
      ...
      properties: record<any, ObjectMetadata.Property>
 }
}.
```

Then, when we pass that locator into UpdateObjectForInterface, we get

```
export interface UpdateObjectForInterface<S extends InterfaceDefinition> {
  type: "updateObjectForInterface";
  obj: InterfaceLocator<S>;
  properties: Partial<{
    [P in PropertyKeys<S>]: OsdkObjectCreatePropertyType<
      CompileTimeMetadata<S>["properties"][P]
    >;
  }>;
}
// resolves to for above locator
{
type: "updateObjectForInterface";
  obj: InterfaceLocator<S>;
  properties: Partial<{ [x: string]: string | number | boolean | CipherText | Media | … }>
}
```

Properties resolves to this Partial because it indexes into this type
```
export type OsdkObjectCreatePropertyType<
  T extends ObjectMetadata.Property,
  STRICTLY_ENFORCE_NULLABLE extends boolean = true,
> = STRICTLY_ENFORCE_NULLABLE extends false
  ? MaybeArray<T, GetCreatePropertyValueFromWire<T["type"]>> | undefined
  : MaybeNullable<T, MaybeArray<T, GetCreatePropertyValueFromWire<T["type"]>>>;
```

and in the generic case, the MaybeArray case resolves to "boolean" instead of true for the array type. This means that it resolves to 
```
Partial<{property: PropertyValueWireToCreate[property]>
```
which is basically
```
Partial<{ [x: string]: string | number | boolean | CipherText | Media | … }>
``` 

almost ALL properties are included in the values of PropertyValueWireToCreate, including number[] (see vector type).

When the value of UpdateObjectForInterface is used in the original UpdatableObjectOrInterfaceLocatorProperties 

```
export type UpdatableObjectOrInterfaceLocatorProperties<
  X extends AnyEdit,
  OL extends ObjectLocator<any>,
> =
  X extends UpdateObject<ObjectTypeDefinitionForLocator<OL>>
    ? X["properties"]
    : X extends UpdateObjectForInterface<InterfaceDefinitionForLocator<OL>>
      ? X["properties"]
      : never;
 ```
the check in  X extends UpdateObjectForInterface<InterfaceDefinitionForLocator<OL>> basically resolves to

```
does {type: "updateObjectForInterface";
  obj: InterfaceLocator<S>;
  properties: Partial<{ fooIdp: string | undefined; fooSpt: string[] | undefined }>
 }
extends {type: "updateObjectForInterface";
  obj: InterfaceLocator<S>;
  properties: Partial<{ [x: string]: string | number | boolean | CipherText | Media | … }>
}
```

and because string[] isn't in the generic union, the type collapses to never.

 **Why objects weren't affected**

  UpdateObject excludes the primary key from its property keys; UpdateObjectForInterface doesn't:
```
  // UpdateObject
  properties: Partial<{
    [P in Exclude<PropertyKeys<S>, CompileTimeMetadata<S>["primaryKeyApiName"]>]: ...
  }>;

  // UpdateObjectForInterface
  properties: Partial<{ [P in PropertyKeys</>]: ... }>;   // no exclusion
```
  On the generic object:
  - PropertyKeys<SynObj> = keyof Record<any, Property> & string = string
  - primaryKeyApiName = keyof this["properties"] = keyof Record<any, Property> = string | number
  - Exclude<string, string | number> = never → Partial<{ [P in never]: … }> = Partial<{}> = {}

  So the object synthetic's properties is {}, and everything extends {} — the props part of the object gate always passes, arrays included, and it returns the concrete
  props.
  
 **Why create still worked**
Create still worked because it captures the entire concrete definition from the first arguement 
```
  create: <OI extends CreatableObjectOrInterfaceTypes<X>>(
    objectOrInterfaceType: OI,           // ← you pass FooInterface (the definition, full metadata)
    properties: CreatableObjectOrInterfaceTypeProperties<X, OI>
  ) => void;
  ```
  whereas our update update takes a locator
```
  update: <OL extends UpdatableObjectOrInterfaceLocators<X>>(
    obj: OL,                              // ← you pass { $apiName, $objectType, $primaryKey } — identity only, NO schema
    properties: UpdatableObjectOrInterfaceLocatorProperties<X, OL>
  ) => void;
  ```
  
The current fix makes what we're trying to narrow explicit -> find the right objects properties instead of trying to match the whole objects edit type.