### PR TITLE
Export Scenarios helpers from client/experimental

### DIFF
--- a/.changeset/three-schools-wave.md
+++ b/.changeset/three-schools-wave.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Export scenario helpers from experimental

--- a/packages/client/src/public/experimental.ts
+++ b/packages/client/src/public/experimental.ts
@@ -16,3 +16,7 @@
 
 export { createClientWithTransaction } from "../createClient.js";
 export { createClientFromWriteableClient } from "../createClientFromWriteableClient.js";
+
+export { createScenario } from "../scenarios/createScenario.js";
+export type { EXPERIMENTAL_ScenarioClient } from "../scenarios/ScenarioClient.js";
+export { withScenario } from "../scenarios/withScenario.js";


### PR DESCRIPTION
`import.meta.env` usages make `unstable-do-not-use` exports fail when used in modules that use Jest. This PR exports from a cleaner subpath