### PR TITLE
Use action parameter displayName for ActionForm labels

### DIFF
--- a/.changeset/wise-otters-wander.md
+++ b/.changeset/wise-otters-wander.md
@@ -1,0 +1,7 @@
+---
+"@osdk/react-components": patch
+"@osdk/generator-converters": patch
+"@osdk/api": patch
+---
+
+Surface action parameter displayName in metadata and use it for ActionForm field labels

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -110,6 +110,8 @@ export namespace ActionMetadata {
         		// (undocumented)
         description?: string;
         		// (undocumented)
+        displayName?: string;
+        		// (undocumented)
         multiplicity?: boolean;
         		// (undocumented)
         nullable?: boolean;

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/actions/completeTodo.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/actions/completeTodo.ts
@@ -14,12 +14,14 @@ export namespace completeTodo {
   export type ParamsDefinition = {
     is_complete: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'boolean';
     };
     Todo: {
       description: 'A todo Object';
+      displayName: undefined;
       multiplicity: true;
       nullable: false;
       type: ActionMetadata.DataType.Object<Todo>;

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/actions/createOffice.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/actions/createOffice.ts
@@ -13,24 +13,28 @@ export namespace createOffice {
   export type ParamsDefinition = {
     address: {
       description: "The office's physical address (not necessarily shipping address)";
+      displayName: undefined;
       multiplicity: false;
       nullable: true;
       type: 'string';
     };
     capacity: {
       description: 'The maximum seated-at-desk capacity of the office (maximum fire-safe capacity may be higher)';
+      displayName: undefined;
       multiplicity: false;
       nullable: true;
       type: 'integer';
     };
     officeId: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'string';
     };
     officeNames: {
       description: 'A list of all office names';
+      displayName: undefined;
       multiplicity: true;
       nullable: true;
       type: 'string';

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/actions/createOfficeAndEmployee.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/actions/createOfficeAndEmployee.ts
@@ -13,30 +13,35 @@ export namespace createOfficeAndEmployee {
   export type ParamsDefinition = {
     address: {
       description: "The office's physical address (not necessarily shipping address)";
+      displayName: undefined;
       multiplicity: false;
       nullable: true;
       type: 'string';
     };
     capacity: {
       description: 'The maximum seated-at-desk capacity of the office (maximum fire-safe capacity may be higher)';
+      displayName: undefined;
       multiplicity: false;
       nullable: true;
       type: 'integer';
     };
     employeeId: {
       description: 'New employee Id';
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'integer';
     };
     officeId: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'string';
     };
     officeNames: {
       description: 'A list of all office names';
+      displayName: undefined;
       multiplicity: true;
       nullable: true;
       type: 'string';

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/actions/createTodo.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/actions/createTodo.ts
@@ -13,12 +13,14 @@ export namespace createTodo {
   export type ParamsDefinition = {
     is_complete: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'boolean';
     };
     Todo: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'string';

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/actions/moveOffice.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/actions/moveOffice.ts
@@ -13,24 +13,28 @@ export namespace moveOffice {
   export type ParamsDefinition = {
     newAddress: {
       description: "The office's new physical address (not necessarily shipping address)";
+      displayName: undefined;
       multiplicity: false;
       nullable: true;
       type: 'string';
     };
     newCapacity: {
       description: 'The maximum seated-at-desk capacity of the new office (maximum fire-safe capacity may be higher)';
+      displayName: undefined;
       multiplicity: false;
       nullable: true;
       type: 'integer';
     };
     officeId: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'string';
     };
     officeNames: {
       description: 'A list of all office names';
+      displayName: undefined;
       multiplicity: true;
       nullable: true;
       type: 'integer';

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/actions/promoteEmployee.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/actions/promoteEmployee.ts
@@ -13,18 +13,21 @@ export namespace promoteEmployee {
   export type ParamsDefinition = {
     employeeId: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'integer';
     };
     newCompensation: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'double';
     };
     newTitle: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'string';

--- a/examples-extra/docs_example/src/generatedNoCheck/ontology/actions/promoteEmployeeObject.ts
+++ b/examples-extra/docs_example/src/generatedNoCheck/ontology/actions/promoteEmployeeObject.ts
@@ -14,18 +14,21 @@ export namespace promoteEmployeeObject {
   export type ParamsDefinition = {
     employee: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: ActionMetadata.DataType.Object<Employee>;
     };
     newCompensation: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'double';
     };
     newTitle: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'string';

--- a/packages/api/src/ontology/ActionDefinition.ts
+++ b/packages/api/src/ontology/ActionDefinition.ts
@@ -50,6 +50,7 @@ export namespace ActionMetadata {
       | DataType.Interface<any>
       | DataType.Struct<any>;
     description?: string;
+    displayName?: string;
     multiplicity?: boolean;
     nullable?: boolean;
   }

--- a/packages/client/src/fetchMetadata.test.ts
+++ b/packages/client/src/fetchMetadata.test.ts
@@ -316,24 +316,28 @@ describe("FetchMetadata", () => {
         "parameters": {
           "newAddress": {
             "description": "The office's new physical address (not necessarily shipping address)",
+            "displayName": "New Address",
             "multiplicity": false,
             "nullable": true,
             "type": "string",
           },
           "newCapacity": {
             "description": "The maximum seated-at-desk capacity of the new office (maximum fire-safe capacity may be higher)",
+            "displayName": "New Capacity",
             "multiplicity": false,
             "nullable": true,
             "type": "integer",
           },
           "officeId": {
             "description": undefined,
+            "displayName": "Office ID",
             "multiplicity": false,
             "nullable": false,
             "type": "string",
           },
           "officeNames": {
             "description": "A list of all office names",
+            "displayName": "Office Names",
             "multiplicity": true,
             "nullable": true,
             "type": "integer",

--- a/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/actions/setTaskBody.ts
+++ b/packages/e2e.generated.api-namespace.local/src/generatedNoCheck/ontology/actions/setTaskBody.ts
@@ -14,12 +14,14 @@ export namespace setTaskBody {
   export type ParamsDefinition = {
     body: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'string';
     };
     task: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: ActionMetadata.DataType.Object<$Imported$com$example$dep$Task>;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/actionTakesAllParameterTypes.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/actionTakesAllParameterTypes.ts
@@ -15,36 +15,42 @@ export namespace actionTakesAllParameterTypes {
   export type ParamsDefinition = {
     attachmentArray: {
       description: undefined;
+      displayName: undefined;
       multiplicity: true;
       nullable: false;
       type: 'attachment';
     };
     dateArray: {
       description: undefined;
+      displayName: undefined;
       multiplicity: true;
       nullable: true;
       type: 'datetime';
     };
     object: {
       description: 'A person Object';
+      displayName: undefined;
       multiplicity: false;
       nullable: true;
       type: ActionMetadata.DataType.Object<Person>;
     };
     objectSet: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: ActionMetadata.DataType.ObjectSet<Todo>;
     };
     string: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'string';
     };
     'time-stamp': {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'timestamp';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/assignEmployee1.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/assignEmployee1.ts
@@ -15,12 +15,14 @@ export namespace assignEmployee1 {
   export type ParamsDefinition = {
     'employee-1': {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: ActionMetadata.DataType.Object<Employee>;
     };
     'venture-1': {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: ActionMetadata.DataType.Object<Venture>;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createFooInterface.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createFooInterface.ts
@@ -13,6 +13,7 @@ export namespace createFooInterface {
   export type ParamsDefinition = {
     createdInterface: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'objectType';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createMediaObject.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createMediaObject.ts
@@ -13,12 +13,14 @@ export namespace createMediaObject {
   export type ParamsDefinition = {
     media_reference: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'mediaReference';
     };
     path: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'string';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createMediaViaFunction.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createMediaViaFunction.ts
@@ -13,6 +13,7 @@ export namespace createMediaViaFunction {
   export type ParamsDefinition = {
     mediaItem: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'mediaReference';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createOsdkTestObject.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createOsdkTestObject.ts
@@ -13,18 +13,21 @@ export namespace createOsdkTestObject {
   export type ParamsDefinition = {
     description: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'string';
     };
     osdk_object_name: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'string';
     };
     string_property: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'string';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createScenarioTestOsdk.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createScenarioTestOsdk.ts
@@ -13,12 +13,14 @@ export namespace createScenarioTestOsdk {
   export type ParamsDefinition = {
     scenarioRidCreatedOn: {
       description: undefined;
+      displayName: 'ScenarioRidCreatedOn';
       multiplicity: false;
       nullable: false;
       type: 'string';
     };
     string: {
       description: undefined;
+      displayName: 'String';
       multiplicity: false;
       nullable: false;
       type: 'string';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createStructPerson.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createStructPerson.ts
@@ -13,6 +13,7 @@ export namespace createStructPerson {
   export type ParamsDefinition = {
     address: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: true;
       type: ActionMetadata.DataType.Struct<{
@@ -22,6 +23,7 @@ export namespace createStructPerson {
     };
     name: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'string';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createStructPersonOpiTeam.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createStructPersonOpiTeam.ts
@@ -13,6 +13,7 @@ export namespace createStructPersonOpiTeam {
   export type ParamsDefinition = {
     address: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: true;
       type: ActionMetadata.DataType.Struct<{
@@ -23,12 +24,14 @@ export namespace createStructPersonOpiTeam {
     };
     age: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'integer';
     };
     id: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'string';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createTestGeoAction.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createTestGeoAction.ts
@@ -13,18 +13,21 @@ export namespace createTestGeoAction {
   export type ParamsDefinition = {
     geo_title: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'string';
     };
     geohash_prop: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'geohash';
     };
     geoshape_prop: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'geoshape';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createUnstructuredImageExample.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/createUnstructuredImageExample.ts
@@ -13,12 +13,14 @@ export namespace createUnstructuredImageExample {
   export type ParamsDefinition = {
     media_reference: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'mediaReference';
     };
     path: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'string';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/deleteFooInterface.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/deleteFooInterface.ts
@@ -14,6 +14,7 @@ export namespace deleteFooInterface {
   export type ParamsDefinition = {
     deletedInterface: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: ActionMetadata.DataType.Interface<FooInterface>;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/deleteOsdkTestObject.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/deleteOsdkTestObject.ts
@@ -14,6 +14,7 @@ export namespace deleteOsdkTestObject {
   export type ParamsDefinition = {
     OsdkTestObject: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: ActionMetadata.DataType.Object<OsdkTestObject>;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/deleteScenarioTestOsdk.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/deleteScenarioTestOsdk.ts
@@ -14,6 +14,7 @@ export namespace deleteScenarioTestOsdk {
   export type ParamsDefinition = {
     ScenarioTestOsdk: {
       description: undefined;
+      displayName: 'Scenario Test Osdk';
       multiplicity: false;
       nullable: false;
       type: ActionMetadata.DataType.Object<ScenarioTestOsdk>;

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/editOsdkTestObject.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/editOsdkTestObject.ts
@@ -14,12 +14,14 @@ export namespace editOsdkTestObject {
   export type ParamsDefinition = {
     OsdkTestObject: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: ActionMetadata.DataType.Object<OsdkTestObject>;
     };
     string_property: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'string';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/scenarioOsdkTestAction.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/actions/scenarioOsdkTestAction.ts
@@ -13,6 +13,7 @@ export namespace scenarioOsdkTestAction {
   export type ParamsDefinition = {
     scenario: {
       description: undefined;
+      displayName: 'Scenario';
       multiplicity: false;
       nullable: false;
       type: 'scenarioReference';

--- a/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/ontology/actions/endAssignment.ts
+++ b/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/ontology/actions/endAssignment.ts
@@ -14,12 +14,14 @@ export namespace endAssignment {
   export type ParamsDefinition = {
     assignment: {
       description: 'The assignment to end.';
+      displayName: 'Assignment';
       multiplicity: false;
       nullable: false;
       type: ActionMetadata.DataType.Object<Assignment>;
     };
     endDate: {
       description: 'Date the assignment ended.';
+      displayName: 'End Date';
       multiplicity: false;
       nullable: false;
       type: 'datetime';

--- a/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/ontology/actions/recordStatusUpdate.ts
+++ b/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/ontology/actions/recordStatusUpdate.ts
@@ -14,60 +14,70 @@ export namespace recordStatusUpdate {
   export type ParamsDefinition = {
     assignment: {
       description: 'The assignment this status update belongs to.';
+      displayName: 'Assignment';
       multiplicity: false;
       nullable: false;
       type: ActionMetadata.DataType.Object<Assignment>;
     };
     comment: {
       description: 'Optional free-text note.';
+      displayName: 'Comment';
       multiplicity: false;
       nullable: true;
       type: 'string';
     };
     isExcluded: {
       description: 'Whether the row is excluded by the metrics layer. Defaults to false.';
+      displayName: 'Is Excluded';
       multiplicity: false;
       nullable: true;
       type: 'boolean';
     };
     recordedBy: {
       description: 'User who recorded the status.';
+      displayName: 'Recorded By';
       multiplicity: false;
       nullable: true;
       type: 'string';
     };
     statusUpdateId: {
       description: 'Primary key for the new status update row.';
+      displayName: 'Status Update ID';
       multiplicity: false;
       nullable: false;
       type: 'string';
     };
     timestamp: {
       description: 'When the status was recorded (display).';
+      displayName: 'Timestamp';
       multiplicity: false;
       nullable: false;
       type: 'timestamp';
     };
     timestampEpochMs: {
       description: 'Millisecond epoch matching the timestamp. Must equal the timestamp in epoch ms.';
+      displayName: 'Timestamp Epoch Ms';
       multiplicity: false;
       nullable: false;
       type: 'long';
     };
     type: {
       description: 'Status category.';
+      displayName: 'Type';
       multiplicity: false;
       nullable: false;
       type: 'string';
     };
     typeValue: {
       description: "Combined '{type} - {value}' string (space-hyphen-space separator).";
+      displayName: 'Type Value';
       multiplicity: false;
       nullable: false;
       type: 'string';
     };
     value: {
       description: 'Status value within the type (e.g. Remote, Yes, Elevated).';
+      displayName: 'Value';
       multiplicity: false;
       nullable: false;
       type: 'string';

--- a/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/ontology/actions/toggleStatusExclusion.ts
+++ b/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/ontology/actions/toggleStatusExclusion.ts
@@ -14,12 +14,14 @@ export namespace toggleStatusExclusion {
   export type ParamsDefinition = {
     isExcluded: {
       description: 'The new exclusion state. Pre-filled with the current value; flip it to toggle.';
+      displayName: 'Is Excluded';
       multiplicity: false;
       nullable: false;
       type: 'boolean';
     };
     statusUpdate: {
       description: 'The status update row to toggle.';
+      displayName: 'Status Update';
       multiplicity: false;
       nullable: false;
       type: ActionMetadata.DataType.Object<StatusUpdate>;

--- a/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/ontology/actions/updateAssignment.ts
+++ b/packages/e2e.sandbox.officeassignment/src/generatedNoCheck2/ontology/actions/updateAssignment.ts
@@ -14,36 +14,42 @@ export namespace updateAssignment {
   export type ParamsDefinition = {
     assignment: {
       description: 'The assignment to update.';
+      displayName: 'Assignment';
       multiplicity: false;
       nullable: false;
       type: ActionMetadata.DataType.Object<Assignment>;
     };
     floorId: {
       description: 'Foreign key to the Floor.';
+      displayName: 'Floor ID';
       multiplicity: false;
       nullable: true;
       type: 'string';
     };
     function: {
       description: 'Team / function.';
+      displayName: 'Function';
       multiplicity: false;
       nullable: true;
       type: 'string';
     };
     managerId: {
       description: 'Foreign key to the Manager.';
+      displayName: 'Manager ID';
       multiplicity: false;
       nullable: true;
       type: 'string';
     };
     officeId: {
       description: 'Foreign key to the Office.';
+      displayName: 'Office ID';
       multiplicity: false;
       nullable: true;
       type: 'string';
     };
     title: {
       description: 'Role title.';
+      displayName: 'Title';
       multiplicity: false;
       nullable: true;
       type: 'string';

--- a/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/ontology/actions/createOffice.ts
+++ b/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/ontology/actions/createOffice.ts
@@ -13,12 +13,14 @@ export namespace createOffice {
   export type ParamsDefinition = {
     location: {
       description: undefined;
+      displayName: 'Location';
       multiplicity: false;
       nullable: false;
       type: 'geohash';
     };
     name: {
       description: undefined;
+      displayName: 'Name';
       multiplicity: false;
       nullable: false;
       type: 'string';

--- a/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/ontology/actions/deleteOffice.ts
+++ b/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/ontology/actions/deleteOffice.ts
@@ -14,6 +14,7 @@ export namespace deleteOffice {
   export type ParamsDefinition = {
     Office: {
       description: undefined;
+      displayName: 'Office';
       multiplicity: false;
       nullable: false;
       type: ActionMetadata.DataType.Object<Office>;

--- a/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/ontology/actions/editOffice.ts
+++ b/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/ontology/actions/editOffice.ts
@@ -14,18 +14,21 @@ export namespace editOffice {
   export type ParamsDefinition = {
     location: {
       description: undefined;
+      displayName: 'Location';
       multiplicity: false;
       nullable: false;
       type: 'geohash';
     };
     name: {
       description: undefined;
+      displayName: 'Name';
       multiplicity: false;
       nullable: false;
       type: 'string';
     };
     Office: {
       description: undefined;
+      displayName: 'Office';
       multiplicity: false;
       nullable: false;
       type: ActionMetadata.DataType.Object<Office>;

--- a/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/ontology/actions/modifyEmployee.ts
+++ b/packages/e2e.sandbox.peopleapp/src/generatedNoCheck2/ontology/actions/modifyEmployee.ts
@@ -14,18 +14,21 @@ export namespace modifyEmployee {
   export type ParamsDefinition = {
     employee: {
       description: undefined;
+      displayName: 'Employee';
       multiplicity: false;
       nullable: false;
       type: ActionMetadata.DataType.Object<Employee>;
     };
     primary_office_id: {
       description: undefined;
+      displayName: 'Primary Office ID';
       multiplicity: false;
       nullable: true;
       type: 'string';
     };
     stockOptions: {
       description: undefined;
+      displayName: 'Stock Options';
       multiplicity: false;
       nullable: true;
       type: 'long';

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/ontology/actions/completeTodo.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/ontology/actions/completeTodo.ts
@@ -14,12 +14,14 @@ export namespace completeTodo {
   export type ParamsDefinition = {
     is_complete: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'boolean';
     };
     Todo: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: ActionMetadata.DataType.Object<Todo>;

--- a/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/ontology/actions/createTodo.ts
+++ b/packages/e2e.sandbox.todoapp/src/generatedNoCheck2/ontology/actions/createTodo.ts
@@ -13,18 +13,21 @@ export namespace createTodo {
   export type ParamsDefinition = {
     is_complete: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'boolean';
     };
     location: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: true;
       type: 'string';
     };
     Todo: {
       description: undefined;
+      displayName: undefined;
       multiplicity: false;
       nullable: false;
       type: 'string';

--- a/packages/generator-converters/src/wireActionTypeV2ToSdkActionMetadata.ts
+++ b/packages/generator-converters/src/wireActionTypeV2ToSdkActionMetadata.ts
@@ -20,6 +20,7 @@ import type {
   ActionParameterV2,
   ActionTypeV2,
 } from "@osdk/foundry.ontologies";
+
 import { GeneratorError } from "./GeneratorError.js";
 import { getModifiedEntityTypes } from "./getEditedEntities.js";
 import {
@@ -37,11 +38,12 @@ export function wireActionTypeV2ToSdkActionMetadata(
     apiName: input.apiName,
     unsanitizedApiName: unsanitizedApiName ?? input.apiName,
     parameters: Object.fromEntries(
-      Object.entries(input.parameters).sort(
-        ([a], [b]) => a.localeCompare(b),
-      ).map((
-        [key, value],
-      ) => [key, wireActionParameterV2ToSdkParameterDefinition(value)]),
+      Object.entries(input.parameters)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, value]) => [
+          key,
+          wireActionParameterV2ToSdkParameterDefinition(value),
+        ]),
     ),
     displayName: input.displayName,
     description: input.description,
@@ -67,6 +69,7 @@ function wireActionParameterV2ToSdkParameterDefinition(
     ),
     nullable: !value.required,
     description: value.description,
+    displayName: value.displayName,
   };
 }
 

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -599,6 +599,7 @@ describe("generator", () => {
           export type ParamsDefinition = {
             object: {
               description: 'Todo(s) to be deleted';
+              displayName: 'deleteTodos';
               multiplicity: true;
               nullable: true;
               type: ActionMetadata.DataType.Object<Todo>;
@@ -683,6 +684,7 @@ describe("generator", () => {
           export type ParamsDefinition = {
             object: {
               description: 'A Todo to mark completed';
+              displayName: 'markTodoCompleted';
               multiplicity: false;
               nullable: true;
               type: ActionMetadata.DataType.Object<Todo>;
@@ -1295,6 +1297,7 @@ describe("generator", () => {
           export type ParamsDefinition = {
             object: {
               description: 'Todo(s) to be deleted';
+              displayName: 'deleteTodos';
               multiplicity: true;
               nullable: true;
               type: ActionMetadata.DataType.Object<Todo>;
@@ -1379,6 +1382,7 @@ describe("generator", () => {
           export type ParamsDefinition = {
             object: {
               description: 'A Todo to mark completed';
+              displayName: 'markTodoCompleted';
               multiplicity: false;
               nullable: true;
               type: ActionMetadata.DataType.Object<Todo>;
@@ -2216,12 +2220,14 @@ describe("generator", () => {
             export type ParamsDefinition = {
               body: {
                 description: undefined;
+                displayName: 'body';
                 multiplicity: false;
                 nullable: false;
                 type: 'string';
               };
               task: {
                 description: undefined;
+                displayName: 'taskBody';
                 multiplicity: false;
                 nullable: false;
                 type: ActionMetadata.DataType.Object<$Imported$com$example$dep$Task>;

--- a/packages/react-components/src/action-form/utils/__tests__/getDefaultFieldDefinitions.test.ts
+++ b/packages/react-components/src/action-form/utils/__tests__/getDefaultFieldDefinitions.test.ts
@@ -19,12 +19,14 @@ import { describe, expect, it } from "vitest";
 
 import { getDefaultFieldDefinitions } from "../getDefaultFieldDefinitions.js";
 
-function makeMetadata(parameter: ActionMetadata.Parameter): ActionMetadata {
+function makeMetadata(
+  parameters: ActionMetadata["parameters"]
+): ActionMetadata {
   return {
     type: "action",
     apiName: "TestAction",
     displayName: "Test action",
-    parameters: { tags: parameter },
+    parameters,
     status: "ACTIVE",
     rid: "ri.action.test",
   };
@@ -41,8 +43,10 @@ describe("getDefaultFieldDefinitions", () => {
     (parameterType) => {
       const [fieldDefinition] = getDefaultFieldDefinitions(
         makeMetadata({
-          type: parameterType,
-          nullable: false,
+          tags: {
+            type: parameterType,
+            nullable: false,
+          },
         })
       );
 
@@ -57,8 +61,10 @@ describe("getDefaultFieldDefinitions", () => {
   it("renders interface parameters as unsupported", () => {
     const [fieldDefinition] = getDefaultFieldDefinitions(
       makeMetadata({
-        type: { type: "interface", interface: "Employee" },
-        nullable: false,
+        tags: {
+          type: { type: "interface", interface: "Employee" },
+          nullable: false,
+        },
       })
     );
 
@@ -72,8 +78,10 @@ describe("getDefaultFieldDefinitions", () => {
   it("renders struct parameters as unsupported", () => {
     const [fieldDefinition] = getDefaultFieldDefinitions(
       makeMetadata({
-        type: { type: "struct", struct: { name: "string" } },
-        nullable: false,
+        tags: {
+          type: { type: "struct", struct: { name: "string" } },
+          nullable: false,
+        },
       })
     );
 
@@ -88,9 +96,11 @@ describe("getDefaultFieldDefinitions", () => {
     it("uses the parameter displayName when present", () => {
       const [fieldDefinition] = getDefaultFieldDefinitions(
         makeMetadata({
-          type: "string",
-          nullable: false,
-          displayName: "Tags",
+          tags: {
+            type: "string",
+            nullable: false,
+            displayName: "Tags",
+          },
         })
       );
 
@@ -100,8 +110,10 @@ describe("getDefaultFieldDefinitions", () => {
     it("falls back to the parameter key when displayName is absent", () => {
       const [fieldDefinition] = getDefaultFieldDefinitions(
         makeMetadata({
-          type: "string",
-          nullable: false,
+          tags: {
+            type: "string",
+            nullable: false,
+          },
         })
       );
 

--- a/packages/react-components/src/action-form/utils/__tests__/getDefaultFieldDefinitions.test.ts
+++ b/packages/react-components/src/action-form/utils/__tests__/getDefaultFieldDefinitions.test.ts
@@ -83,4 +83,29 @@ describe("getDefaultFieldDefinitions", () => {
       fieldComponentProps: {},
     });
   });
+
+  describe("label", () => {
+    it("uses the parameter displayName when present", () => {
+      const [fieldDefinition] = getDefaultFieldDefinitions(
+        makeMetadata({
+          type: "string",
+          nullable: false,
+          displayName: "Tags",
+        })
+      );
+
+      expect(fieldDefinition.label).toBe("Tags");
+    });
+
+    it("falls back to the parameter key when displayName is absent", () => {
+      const [fieldDefinition] = getDefaultFieldDefinitions(
+        makeMetadata({
+          type: "string",
+          nullable: false,
+        })
+      );
+
+      expect(fieldDefinition.label).toBe("tags");
+    });
+  });
 });

--- a/packages/react-components/src/action-form/utils/getDefaultFieldDefinitions.ts
+++ b/packages/react-components/src/action-form/utils/getDefaultFieldDefinitions.ts
@@ -45,7 +45,7 @@ function buildFieldDefinition(
 ): RendererFieldDefinition {
   const base = {
     fieldKey: key,
-    label: key,
+    label: param.displayName ?? key,
     isRequired: !param.nullable,
     fieldType: param.type,
   };


### PR DESCRIPTION
## What

`ActionForm` labeled each parameter with its raw parameter key/id (e.g. `primary_office_id`). Foundry already provides a human-friendly `displayName` on every action parameter, so this surfaces it and uses it for the default field labels.

## Changes

- `@osdk/api` — add `displayName?: string` to `ActionMetadata.Parameter`.
- `@osdk/generator-converters` — `wireActionParameterV2ToSdkParameterDefinition` now copies `displayName` from the wire response.
- `@osdk/react-components` — `getDefaultFieldDefinitions` uses `param.displayName ?? key`, so labels prefer the display name and fall back to the key when it's absent. Caller-supplied `formFieldDefinitions` are unchanged — callers still own their labels there.

## Testing

- `getDefaultFieldDefinitions` unit tests cover the displayName-present and fallback-to-key cases.
- `typecheck`, `check-api`, and `lint` pass for the touched packages.

### Before
<img width="1487" height="827" alt="Screenshot 2026-07-22 at 15 13 41" src="https://github.com/user-attachments/assets/914a9422-50e5-4968-9267-914c08159cdf" />

### After
<img width="1487" height="827" alt="Screenshot 2026-07-22 at 15 13 35" src="https://github.com/user-attachments/assets/d642bbd8-78fb-4f74-bd99-59a2b46644a6" />