### PR TITLE
Fix empty {} placeholder for interface action parameters in docs

### DIFF
--- a/.changeset/eleven-melons-take.md
+++ b/.changeset/eleven-melons-take.md
@@ -1,0 +1,6 @@
+---
+"@osdk/typescript-sdk-docs": patch
+"@osdk/react-sdk-docs": patch
+---
+
+Fix empty {} placeholder for interface action parameters in docs

--- a/packages/react-sdk-docs/src/docs.ts
+++ b/packages/react-sdk-docs/src/docs.ts
@@ -162,7 +162,9 @@ function renderType(
       }
       return "{}";
     }
-    case "interface":
+    case "interface": {
+      return `{ $objectType: "objectTypeApiName", $primaryKey: "primaryKeyValue" }`;
+    }
     case "marking": {
       return "{}";
     }

--- a/packages/typescript-sdk-docs/src/docs.ts
+++ b/packages/typescript-sdk-docs/src/docs.ts
@@ -423,7 +423,9 @@ function renderType(
     case "attachment": {
       return type.hasAttachments ? "attachment" : "{}";
     }
-    case "interface":
+    case "interface": {
+      return `{ $objectType: "objectTypeApiName", $primaryKey: "primaryKeyValue" }`;
+    }
     case "marking": {
       return "{}";
     }


### PR DESCRIPTION
Interface action parameters were showing up as an empty `{}` in the generated docs, so there was no hint about what to actually pass. Now they render a real placeholder:

```ts
"myInterfaceParam": { $objectType: "objectTypeApiName", $primaryKey: "primaryKeyValue" }
```

which matches the shape the client actually expects (`ActionParam.InterfaceType`). Fixed in both the TypeScript and React doc renderers.