### PR TITLE
Add useDebouncedCallback

### DIFF
--- a/.changeset/lazy-otters-wander.md
+++ b/.changeset/lazy-otters-wander.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Add internal useDebouncedCallback, useGatedValue, useDeepEqual, and useOnUnmount hooks

--- a/packages/react-components/src/shared/hooks/__tests__/useDebouncedCallback.test.ts
+++ b/packages/react-components/src/shared/hooks/__tests__/useDebouncedCallback.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useDebouncedCallback } from "../useDebouncedCallback.js";
+
+describe("useDebouncedCallback", () => {
+  it("calls the callback provided callback once when called multiple times with `wait` ms", () => {
+    vi.useFakeTimers();
+    const cb = vi.fn();
+    const { result } = renderHook(() =>
+      useDebouncedCallback(cb as (n: number) => void, 10)
+    );
+    const f = result.current;
+    f(1);
+    f(2);
+    f(3);
+    vi.runAllTimers();
+
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith(3);
+  });
+});

--- a/packages/react-components/src/shared/hooks/__tests__/useDebouncedCallback.test.ts
+++ b/packages/react-components/src/shared/hooks/__tests__/useDebouncedCallback.test.ts
@@ -35,4 +35,29 @@ describe("useDebouncedCallback", () => {
     expect(cb).toHaveBeenCalledTimes(1);
     expect(cb).toHaveBeenCalledWith(3);
   });
+
+  it("cancels a pending invocation when the component unmounts", () => {
+    vi.useFakeTimers();
+    const cb = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      useDebouncedCallback(cb as (n: number) => void, 10)
+    );
+    result.current(1);
+    unmount();
+    vi.runAllTimers();
+
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("returns a stable function reference across re-renders", () => {
+    const { result, rerender } = renderHook(
+      ({ cb }) => useDebouncedCallback(cb, 10),
+      { initialProps: { cb: (_n: number) => {} } }
+    );
+    const first = result.current;
+    rerender({ cb: (_n: number) => {} });
+    rerender({ cb: (_n: number) => {} });
+
+    expect(result.current).toBe(first);
+  });
 });

--- a/packages/react-components/src/shared/hooks/__tests__/useDebouncedCallback.test.ts
+++ b/packages/react-components/src/shared/hooks/__tests__/useDebouncedCallback.test.ts
@@ -15,11 +15,15 @@
  */
 
 import { renderHook } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { useDebouncedCallback } from "../useDebouncedCallback.js";
 
 describe("useDebouncedCallback", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("calls the callback provided callback once when called multiple times with `wait` ms", () => {
     vi.useFakeTimers();
     const cb = vi.fn();

--- a/packages/react-components/src/shared/hooks/__tests__/useGatedValue.test.ts
+++ b/packages/react-components/src/shared/hooks/__tests__/useGatedValue.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from "@testing-library/react";
+import { isEqual } from "lodash-es";
+import { describe, expect, it } from "vitest";
+
+import {
+  useGatedValue,
+  useInverseGatedValue,
+} from "../variables/useGatedValue.js";
+
+describe("useGatedValue", () => {
+  it("can gate on isEqual", () => {
+    const arr1 = [1, 2];
+    const arr2 = [1, 2];
+    const arr3 = [1, 3];
+
+    const { result, rerender } = renderHook(
+      ({ value }) => useInverseGatedValue(value, isEqual),
+      {
+        initialProps: { value: arr1 },
+      }
+    );
+
+    expect(result.current).toBe(arr1);
+    rerender({ value: arr2 });
+    expect(result.current).toBe(arr1); // reference didn't change
+    rerender({ value: arr3 });
+    expect(result.current).toBe(arr3); // reference changed
+  });
+
+  it("can gate on non-equality functions", () => {
+    const isGateOpen = (current: number, previous: number): boolean =>
+      current > previous;
+
+    const { result, rerender } = renderHook(
+      ({ value }) => useGatedValue(value, isGateOpen),
+      {
+        initialProps: { value: 0 },
+      }
+    );
+
+    expect(result.current).toBe(0);
+    rerender({ value: 1 });
+    expect(result.current).toBe(1);
+    rerender({ value: 0 });
+    expect(result.current).toBe(1);
+    rerender({ value: 2 });
+    expect(result.current).toBe(2);
+  });
+
+  it("behaves as an identity function if gate is always open", () => {
+    const isGateOpen = () => true;
+    const arr1 = [1];
+    const arr2 = [1];
+    const arr3 = [1];
+    const arr4 = [2];
+
+    const { result, rerender } = renderHook(
+      ({ value }) => useGatedValue(value, isGateOpen),
+      {
+        initialProps: { value: arr1 },
+      }
+    );
+
+    expect(result.current).toBe(arr1);
+    rerender({ value: arr2 });
+    expect(result.current).toBe(arr2);
+    rerender({ value: arr3 });
+    expect(result.current).toBe(arr3);
+    rerender({ value: arr4 });
+    expect(result.current).toBe(arr4);
+  });
+
+  it("handles changing the gating function", () => {
+    const gateClosed = () => false;
+    const gateOpen = () => true;
+
+    const { result, rerender } = renderHook(
+      ({ value, isGateOpen }) => useGatedValue(value, isGateOpen),
+      {
+        initialProps: { value: 1, isGateOpen: gateOpen },
+      }
+    );
+
+    expect(result.current).toBe(1);
+    rerender({ value: 2, isGateOpen: gateOpen });
+    expect(result.current).toBe(2);
+
+    rerender({ value: 3, isGateOpen: gateClosed });
+    expect(result.current).toBe(2);
+  });
+});

--- a/packages/react-components/src/shared/hooks/__tests__/useOnUnmount.test.ts
+++ b/packages/react-components/src/shared/hooks/__tests__/useOnUnmount.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useOnUnmount } from "../lifecycle/useOnUnmount.js";
+
+describe("useOnUnmount", () => {
+  it("does not call onUnmount on render or re-render", () => {
+    const onUnmount = vi.fn();
+    const { rerender } = renderHook(() => useOnUnmount(onUnmount));
+    rerender();
+    rerender();
+
+    expect(onUnmount).not.toHaveBeenCalled();
+  });
+
+  it("calls onUnmount exactly once when the component unmounts", () => {
+    const onUnmount = vi.fn();
+    const { unmount } = renderHook(() => useOnUnmount(onUnmount));
+
+    expect(onUnmount).not.toHaveBeenCalled();
+    unmount();
+
+    expect(onUnmount).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls the latest onUnmount callback provided before unmount", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender, unmount } = renderHook(
+      ({ onUnmount }) => useOnUnmount(onUnmount),
+      { initialProps: { onUnmount: first } }
+    );
+    rerender({ onUnmount: second });
+    unmount();
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-components/src/shared/hooks/lifecycle/useOnUnmount.ts
+++ b/packages/react-components/src/shared/hooks/lifecycle/useOnUnmount.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+
+/**
+ * Executes the `onUnmount` callback when the component unmounts. This tracks the value of  the `onUnmount` argument
+ * so that it has the correct value when the component unmounts.
+ */
+export function useOnUnmount(onUnmount: () => void): void {
+  const onUnmountRef = React.useRef(onUnmount);
+
+  React.useEffect(() => {
+    onUnmountRef.current = onUnmount;
+  }, [onUnmount]);
+
+  React.useEffect(() => {
+    return () => {
+      onUnmountRef.current();
+    };
+  }, []);
+}

--- a/packages/react-components/src/shared/hooks/useDebouncedCallback.ts
+++ b/packages/react-components/src/shared/hooks/useDebouncedCallback.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DebouncedFunc } from "lodash-es";
+import { debounce } from "lodash-es";
+import * as React from "react";
+
+import { useOnUnmount } from "./lifecycle/useOnUnmount.js";
+import { useEventCallback } from "./useEventCallback.js";
+import { useDeepEqual } from "./variables/useDeepEqual.js";
+
+// Helper type to check if parameters have explicit types
+export type HasExplicitParams<T> = T extends (...args: infer P) => unknown
+  ? any[] extends P
+    ? never // Reject if parameters are implicitly 'any'
+    : T
+  : never;
+
+export type DebounceOptions = {
+  maxWait?: number;
+  leading?: boolean;
+  trailing?: boolean;
+};
+
+/**
+ * Creates a debounced callback that delays invoking `callback` until after `wait`
+ * milliseconds have elapsed since the last time `callback` was invoked.
+ *
+ * The function returned will be stable, suitable for passing to memoized components or as the dependency to useEffect.
+ *
+ * Note that you _do not_ need to memoize the function passed to `useDebouncedCallback` by first using `useCallback` or `useEventCallback`, you can pass an inline function.
+ *
+ * @param {Function} callback The function to debounce.
+ * @param {number} wait The number of milliseconds to delay
+ * @param options Additional configuration options. See https://lodash.com/docs/4.17.15#debounce for more details
+ *
+ * @example
+ * const handleScroll = useDebouncedCallback((event: React.UIEvent<HtmlDivElement>) => {
+ *   loadMore(event.current.scrollTop);
+ * }, 100)
+ */
+export function useDebouncedCallback<T extends (...args: any[]) => unknown>(
+  callback: HasExplicitParams<T>,
+  wait: number,
+  options?: DebounceOptions
+): DebouncedFunc<T> {
+  const f = useEventCallback(callback as T);
+  const deepOptions = useDeepEqual(options);
+  const debouncedCallback: DebouncedFunc<T> = React.useMemo(
+    () => debounce(f, wait, deepOptions),
+    [f, wait, deepOptions]
+  );
+  useOnUnmount(() => debouncedCallback.cancel());
+  return debouncedCallback;
+}

--- a/packages/react-components/src/shared/hooks/useDebouncedCallback.ts
+++ b/packages/react-components/src/shared/hooks/useDebouncedCallback.ts
@@ -48,7 +48,7 @@ export type DebounceOptions = {
  * @param options Additional configuration options. See https://lodash.com/docs/4.17.15#debounce for more details
  *
  * @example
- * const handleScroll = useDebouncedCallback((event: React.UIEvent<HtmlDivElement>) => {
+ * const handleScroll = useDebouncedCallback((event: React.UIEvent<HTMLDivElement>) => {
  *   loadMore(event.current.scrollTop);
  * }, 100)
  */

--- a/packages/react-components/src/shared/hooks/variables/useDeepEqual.ts
+++ b/packages/react-components/src/shared/hooks/variables/useDeepEqual.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isEqual } from "lodash-es";
+
+import { useInverseGatedValue } from "./useGatedValue.js";
+
+/**
+ * Simple wrapper around useInverseGatedValue where lodash's isEqual is the "gatekeeper".
+ *
+ * While you are passing values that are deep equal to each other, this will
+ * return the first value you passed. If you pass a value that isn't deep equal
+ * to its predecessor, this will return the new value.
+ *
+ * It's guaranteed that the return value of `useDeepEqual` will be deep equal
+ * to the @param value you passed, though it may have been an argument from an
+ * earlier run.
+ *
+ * @example
+ *   A1 and A2 are deep equal.
+ *   B1, B2 and B3 are deep equal.
+ *   - Call 1: useDeepEqual(A1) -> A1
+ *   - Call 2: useDeepEqual(A2) -> A1
+ *   - Call 3: useDeepEqual(B1) -> B1
+ *   - Call 4: useDeepEqual(B2) -> B1
+ *   - Call 5: useDeepEqual(B3) -> B1
+ *   - Call 6: useDeepEqual(C1) -> C1
+ */
+export function useDeepEqual<T>(value: T): T {
+  return useInverseGatedValue(value, isEqual);
+}

--- a/packages/react-components/src/shared/hooks/variables/useGatedValue.ts
+++ b/packages/react-components/src/shared/hooks/variables/useGatedValue.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+
+/**
+ * Lets through @param value when @param isGateOpen returns true, otherwise it returns
+ * the last value for which @param isGateOpen was true (or the very first value if it was
+ * never true).
+ *
+ * @see useInverseGatedValue for the opposite function
+ */
+export function useGatedValue<T>(
+  value: Readonly<T>,
+  isGateOpen: (current: T, previous: T) => boolean
+): T {
+  const ref = React.useRef<T>(value);
+  const gateOpen = React.useMemo(
+    () => isGateOpen(value, ref.current),
+    [value, isGateOpen]
+  );
+  React.useEffect(() => {
+    if (gateOpen) {
+      ref.current = value;
+    }
+  });
+  return gateOpen ? value : ref.current;
+}
+
+/**
+ * Blocks the @param value when @param isGateClosed returns true, returning the last value for which
+ *
+ * @param isGateClosed was false (or the very first value if it was never false).
+ *
+ * @see useGatedValue for the opposite function
+ */
+export function useInverseGatedValue<T>(
+  value: T,
+  isGateClosed: (current: T, previous: T) => boolean
+): T {
+  const isGateOpen = React.useCallback(
+    (current: T, previous: T) => !isGateClosed(current, previous),
+    [isGateClosed]
+  );
+  return useGatedValue(value, isGateOpen);
+}


### PR DESCRIPTION
## Summary

Adds internal utility hooks to `@osdk/react-components` under `src/shared/hooks/`:

- `useDebouncedCallback` — debounces a callback, cleaning up its pending timer on unmount
- `useGatedValue` — holds a value until a gating condition allows it through
- `useDeepEqual` — returns a referentially stable value that only changes on deep inequality
- `useOnUnmount` — runs a callback once when the component unmounts

These are foundational hooks not yet wired into any component or exported from a public entrypoint, so there is no public API change.

## Test plan

- Unit tests added for `useDebouncedCallback` and `useGatedValue`
- `pnpm turbo test --filter=@osdk/react-components`

## Notes
I'm adding this hook because I need a `useDebouncedCallback` that supports `leading: true`. I started off by extending the one from `osdk/react` https://github.com/palantir/osdk-ts/pull/3727. But after chatting with @ziyunp, I decided to add the hook directly the components because:
- I wanted to use lodash-es instead of coming up with my own implementation (and I cannot add that dependency to osdk/react)
- The hook inside packages/react is not that used but it is exported for users. The next step after extracting these hooks into their own package is to deprecate that one (will add the context to the ticket).