### PR TITLE
Seed client package

### DIFF
--- a/.changeset/client-unstable-seed.md
+++ b/.changeset/client-unstable-seed.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client.unstable.seed": minor
+---
+
+Add conjure client for the com.palantir.foundry-cli (cli-api) service.

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -57,6 +57,7 @@ const OXC_NESTED_CONFIG_PACKAGES = {
   "react-components": "packages/react-components/oxlint.config.ts",
   "client.unstable": "packages/client.unstable/oxlint.config.ts",
   "client.unstable.tpsa": "packages/client.unstable.tpsa/oxlint.config.ts",
+  "client.unstable.seed": "packages/client.unstable.seed/oxlint.config.ts",
   "client": "packages/client/oxlint.config.ts",
   "maker": "packages/maker/oxlint.config.ts",
   "maker-experimental": "packages/maker-experimental/oxlint.config.ts",

--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -447,6 +447,7 @@ const archetypeRules = archetypes(
     [
       "@osdk/client.unstable",
       "@osdk/client.unstable.tpsa",
+      "@osdk/client.unstable.seed",
     ],
     {
       ...LIBRARY_RULES,

--- a/dprint.json
+++ b/dprint.json
@@ -41,6 +41,7 @@
     "packages/react-components/",
     "packages/client.unstable/",
     "packages/client.unstable.tpsa/",
+    "packages/client.unstable.seed/",
     "packages/client/",
     "packages/maker/",
     "packages/maker-experimental/",

--- a/packages/client.unstable.seed/oxlint.config.ts
+++ b/packages/client.unstable.seed/oxlint.config.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineConfig } from "oxlint";
+
+import root from "../../oxlint.config.ts";
+
+// Nested oxlint config for @osdk/client.unstable.seed. Like @osdk/client.unstable
+// it is almost entirely conjure-generated code under src/generated. This repo
+// treats src/generated/ as first-class checked-in source (only
+// src/generatedNoCheck{,2}/ are excluded, and ESLint linted src/generated before
+// the oxc migration), so this config re-includes it: the inherited Ultracite
+// preset ignores `**/generated`, which is removed from `ignorePatterns` below so
+// the generated tree is linted (and oxfmt-formatted; see the root oxfmt.config.ts)
+// just as ESLint + dprint did before.
+//
+// The error-level rules below — surfaced both by the generated tree and by the
+// hand-written src/index.ts barrel — were not enforced by the prior ESLint
+// config; turning them off keeps the ESLint -> oxlint migration behavior-
+// preserving (the package is migrated, not rewritten). cf. the nested-config
+// pattern in packages/react-components/oxlint.config.ts.
+//
+// `extends` only carries `rules`/`plugins`/`overrides`, so the root's
+// `ignorePatterns` are re-applied explicitly (minus `**/generated`).
+export default defineConfig({
+  extends: [root],
+  ignorePatterns: (root.ignorePatterns ?? []).filter(
+    (p) => p !== "**/generated"
+  ),
+
+  rules: {
+    // Barrels: src/index.ts re-exports the generated cli service tree
+    // (`export type * from "./generated/.../index.js"`), and the generated
+    // per-service index.ts files are barrels too. Barrels are intrinsic here;
+    // not enforced by prior ESLint. (cf. react-components, which disables the
+    // same rule for its published barrel.)
+    "oxc/no-barrel-file": "off",
+    // The hand-written `export {};` at the end of src/index.ts. Removing it is the
+    // autofix, but that is a source rewrite; keep it as authored. Not enforced by
+    // prior ESLint.
+    "typescript/no-useless-empty-export": "off",
+    "unicorn/require-module-specifiers": "off",
+    // oxfmt owns import spacing in this migration; the generated files do not
+    // carry a blank line after their import block. Not enforced by prior ESLint.
+    "import/newline-after-import": "off",
+    // The conjure generator emits every service method as `async`, and many have
+    // no `await` (they just build and return a request). This is generated code
+    // (regenerated on codegen, not hand-editable), and the `async` is load-bearing
+    // for the methods' `Promise`-returning signatures, so require-await is disabled
+    // here rather than rewriting the generated tree. Not enforced by prior ESLint.
+    "require-await": "off",
+    "typescript/require-await": "off",
+  },
+});

--- a/packages/client.unstable.seed/package.json
+++ b/packages/client.unstable.seed/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@osdk/client.unstable.seed",
+  "version": "0.0.0",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/palantir/osdk-ts.git"
+  },
+  "exports": {
+    ".": {
+      "browser": "./build/browser/index.js",
+      "import": {
+        "types": "./build/types/index.d.ts",
+        "default": "./build/esm/index.js"
+      },
+      "require": "./build/cjs/index.cjs",
+      "default": "./build/browser/index.js"
+    },
+    "./*": {
+      "browser": "./build/browser/public/*.js",
+      "import": {
+        "types": "./build/types/public/*.d.ts",
+        "default": "./build/esm/public/*.js"
+      },
+      "require": "./build/cjs/public/*.cjs",
+      "default": "./build/browser/public/*.js"
+    }
+  },
+  "scripts": {
+    "check-attw": "attw --pack .",
+    "check-bundle": "monorepo.tool.check-bundle",
+    "check-spelling": "cspell --quiet .",
+    "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
+    "fix-lint": "oxlint -c ./oxlint.config.ts --fix . && oxfmt -c ../../oxfmt.config.ts .",
+    "lint": "oxlint -c ./oxlint.config.ts . && oxfmt -c ../../oxfmt.config.ts --check .",
+    "transpileBrowser": "monorepo.tool.transpile -f esm -m bundle -t browser",
+    "transpileCjs": "monorepo.tool.transpile -f cjs -m bundle -t node",
+    "transpileEsm": "monorepo.tool.transpile -f esm -m bundle -t node",
+    "transpileTypes": "monorepo.tool.transpile -f esm -m types -t node",
+    "typecheck": "tsc --noEmit --emitDeclarationOnly false"
+  },
+  "dependencies": {
+    "conjure-lite": "^0.4.4"
+  },
+  "devDependencies": {
+    "@osdk/monorepo.api-extractor": "workspace:~",
+    "@osdk/monorepo.tool.check-bundle": "workspace:~",
+    "@osdk/monorepo.tsconfig": "workspace:~",
+    "typescript": "~5.5.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "build/cjs",
+    "build/esm",
+    "build/browser",
+    "build/types",
+    "CHANGELOG.md",
+    "package.json",
+    "templates",
+    "*.d.ts"
+  ],
+  "main": "./build/cjs/index.cjs",
+  "module": "./build/esm/index.js",
+  "types": "./build/cjs/index.d.cts",
+  "type": "module"
+}

--- a/packages/client.unstable.seed/src/generated/cli/OntologySeedingService.ts
+++ b/packages/client.unstable.seed/src/generated/cli/OntologySeedingService.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { setSeed } from "./OntologySeedingService/setSeed.js";

--- a/packages/client.unstable.seed/src/generated/cli/OntologySeedingService/setSeed.ts
+++ b/packages/client.unstable.seed/src/generated/cli/OntologySeedingService/setSeed.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { conjureFetch, type ConjureContext } from "conjure-lite";
+
+import type {
+  OntologySeed as _OntologySeed,
+  SetSeedResponse as _SetSeedResponse,
+} from "../__components.js";
+
+/**
+ * Sets the seed state of the local ontology server. Succeeds with an
+ * empty `200` response; failures surface as errors: 400 for a malformed
+ * request body, 503 while the server is still starting, and 500 (with
+ * the underlying detail) for seeding failures.
+ */
+export async function setSeed(
+  ctx: ConjureContext,
+  seed: _OntologySeed
+): Promise<_SetSeedResponse> {
+  return conjureFetch(ctx, `/seed`, "PUT", seed);
+}

--- a/packages/client.unstable.seed/src/generated/cli/StatusService.ts
+++ b/packages/client.unstable.seed/src/generated/cli/StatusService.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { publishStatus } from "./StatusService/publishStatus.js";
+export { getStatus } from "./StatusService/getStatus.js";

--- a/packages/client.unstable.seed/src/generated/cli/StatusService/getStatus.ts
+++ b/packages/client.unstable.seed/src/generated/cli/StatusService/getStatus.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { conjureFetch, type ConjureContext } from "conjure-lite";
+
+import type { ServiceStatus as _ServiceStatus } from "../__components.js";
+
+/**
+ * Return the current status of all services.
+ */
+export async function getStatus(
+  ctx: ConjureContext
+): Promise<Array<_ServiceStatus>> {
+  return conjureFetch(ctx, `/status`, "GET");
+}

--- a/packages/client.unstable.seed/src/generated/cli/StatusService/publishStatus.ts
+++ b/packages/client.unstable.seed/src/generated/cli/StatusService/publishStatus.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { conjureFetch, type ConjureContext } from "conjure-lite";
+
+import type { ServiceStatus as _ServiceStatus } from "../__components.js";
+
+/**
+ * Publish a lifecycle event. Called by services whenever a status
+ * transition occurs.
+ */
+export async function publishStatus(
+  ctx: ConjureContext,
+  status: _ServiceStatus
+): Promise<void> {
+  return conjureFetch(ctx, `/status`, "POST", status);
+}

--- a/packages/client.unstable.seed/src/generated/cli/__components.ts
+++ b/packages/client.unstable.seed/src/generated/cli/__components.ts
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Marketplace bundling settings; CLI flags override these values when provided
+ */
+export interface BundleConfig {
+  associatedRid?: string | null | undefined;
+  description: string;
+  installMode: InstallMode;
+  mavenCoordinate?: string | null | undefined;
+  name: string;
+  salt?: string | null | undefined;
+}
+/**
+ * A single component declared in a superrepo's `foundry.yml`.
+ */
+export interface Component {
+  path: string;
+  type: ServiceName;
+}
+/**
+ * Runtime metadata published by a started preview service so
+ * other services in the superrepo can locate it. Each running
+ * service writes a file at
+ * `<foundry.yml dir>/.palantir/.<service-name>-discovery.json`
+ * (kebab-cased `ServiceName`). Readers treat the file as stale
+ * if the recorded process is no longer alive.
+ */
+export interface ComponentDiscovery {
+  caCertPath?: string | null | undefined;
+  pid: number;
+  processStartTimeSecs: number;
+  url: string;
+}
+export interface FoundryBackendError {
+  backtrace?: string | null | undefined;
+  errorInstanceId?: string | null | undefined;
+  errorName: string;
+  message: string;
+}
+/**
+ * Project-level configuration loaded from `foundry.yml`.
+ * Contains repo-wide settings and a list of products. Single-product
+ * foundry.yml files (with top-level `components`) are normalized into
+ * this shape at load time with one product.
+ */
+export interface FoundryConfig {
+  functionsTypescriptRuntimeVersion?: string | null | undefined;
+  minCliVersion: string;
+  platformApiProxy?: PlatformApiProxyConfig | null | undefined;
+  products: Array<ProductConfig>;
+}
+export interface GenericFoundryCliError {
+  errorName: string;
+  message: string;
+}
+/**
+ * A single import entry. All fields are optional so the schema can
+ * be extended with new import kinds without breaking existing
+ * manifests.
+ */
+export interface ImportConfig {
+  ontology?: string | null | undefined;
+}
+/**
+ * Install strategy for a marketplace block set.
+ */
+export type InstallMode = "PRODUCTION" | "BOOTSTRAP" | "SINGLETON";
+
+/**
+ * A single seed object's property bag: keys are property API names,
+ * values are the corresponding property values. Serializes to
+ * `Record<string, unknown>` in the OSDK `SeedOutput`.
+ */
+export type ObjectSeed = Record<string, SeedPropertyValue>;
+
+/**
+ * The seed state of a local ontology. Mirrors the `SeedOutput`
+ * shape produced by the OSDK seed helpers (palantir/osdk-ts,
+ * `packages/seed-helpers/src/types.ts`): the seed objects keyed by
+ * object-type API name, plus the links between them.
+ */
+export interface OntologySeed {
+  links: Array<SeedLinkEntry>;
+  objects: Record<string, Array<ObjectSeed>>;
+}
+/**
+ * Routing rules consumed by `foundry start platform-api-proxy`.
+ * Both lists default to empty when omitted.
+ */
+export interface PlatformApiProxyConfig {
+  ontologyFoundryFallback: Array<PlatformApiProxyRoute>;
+  passthrough: Array<PlatformApiProxyRoute>;
+}
+/**
+ * A path glob plus the HTTP methods that may match.
+ */
+export interface PlatformApiProxyRoute {
+  methods: Array<string>;
+  path: string;
+}
+/**
+ * A single product within a superrepo.
+ */
+export interface ProductConfig {
+  apiNamespace: string;
+  bundle?: BundleConfig | null | undefined;
+  components: Array<Component>;
+  contentSecurityPolicyAdditions?:
+    | Record<string, Array<string>>
+    | null
+    | undefined;
+  imports?: Array<ImportConfig> | null | undefined;
+  includeInBundle?: boolean | null | undefined;
+  osdkOutput: string;
+}
+export interface PythonArtifactsChannel {
+  channel: string;
+  name: string;
+}
+export interface PythonDependencyChannels {
+  conda: Array<PythonArtifactsChannel>;
+  pip: Array<PythonArtifactsChannel>;
+}
+/**
+ * A single link instance between two seeded objects.
+ */
+export interface SeedLinkEntry {
+  linkType: string;
+  name: string;
+  sourceKey: string;
+  sourceObjectType: string;
+  targetKey: string;
+  targetObjectType: string;
+}
+/**
+ * A single property value within a seed object. Opaque JSON whose
+ * concrete shape depends on the object type's property definitions.
+ */
+export type SeedPropertyValue = any;
+export interface SerializableFoundryCliError_foundryBackendError {
+  type: "foundryBackendError";
+  foundryBackendError: FoundryBackendError;
+}
+
+export interface SerializableFoundryCliError_genericFoundryCliError {
+  type: "genericFoundryCliError";
+  genericFoundryCliError: GenericFoundryCliError;
+}
+
+export interface SerializableFoundryCliError_unsupportedFeaturesError {
+  type: "unsupportedFeaturesError";
+  unsupportedFeaturesError: UnsupportedFeaturesError;
+}
+
+export interface SerializableFoundryCliError_unsupportedTemplateTypeError {
+  type: "unsupportedTemplateTypeError";
+  unsupportedTemplateTypeError: UnsupportedTemplateTypeError;
+}
+export type SerializableFoundryCliError =
+  | SerializableFoundryCliError_foundryBackendError
+  | SerializableFoundryCliError_genericFoundryCliError
+  | SerializableFoundryCliError_unsupportedFeaturesError
+  | SerializableFoundryCliError_unsupportedTemplateTypeError;
+
+/**
+ * Unified lifecycle stages shared by all services. Each service uses
+ * the stages that apply to it.
+ */
+export type ServiceLifecycle =
+  | "PREPARING"
+  | "READY"
+  | "FAILED"
+  | "STARTING"
+  | "STOPPED";
+
+/**
+ * The kinds of services managed by Foundry. ONTOLOGY,
+ * TYPESCRIPT_FUNCTIONS, PYTHON_FUNCTIONS, and APP are user-owned
+ * component types declared in `foundry.yml`. STATUS_SERVER and
+ * PLATFORM_API_PROXY are internal Foundry-managed services started
+ * implicitly by the CLI and must not be declared in `foundry.yml`.
+ */
+export type ServiceName =
+  | "ONTOLOGY"
+  | "TYPESCRIPT_FUNCTIONS"
+  | "PYTHON_FUNCTIONS"
+  | "APP"
+  | "STATUS_SERVER"
+  | "PLATFORM_API_PROXY";
+
+/**
+ * The status of a service. Published by services on lifecycle
+ * transitions (POST /status), and returned by the server as the
+ * current snapshot (GET /status).
+ */
+export interface ServiceStatus {
+  level: StatusLevel;
+  message?: string | null | undefined;
+  service: ServiceName;
+  status: ServiceLifecycle;
+  timestamp: string;
+}
+/**
+ * Result of a successful `setSeed` call.
+ */
+export interface SetSeedResponse {}
+/**
+ * Severity of a status.
+ */
+export type StatusLevel = "INFO" | "WARN" | "ERROR";
+export interface UnsupportedFeaturesError {
+  messages: Array<string>;
+}
+export interface UnsupportedTemplateTypeError {
+  message: string;
+}

--- a/packages/client.unstable.seed/src/generated/cli/index.ts
+++ b/packages/client.unstable.seed/src/generated/cli/index.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * as OntologySeedingService from "./OntologySeedingService.js";
+export * as StatusService from "./StatusService.js";
+
+export type {
+  BundleConfig,
+  Component,
+  ComponentDiscovery,
+  FoundryBackendError,
+  FoundryConfig,
+  GenericFoundryCliError,
+  ImportConfig,
+  InstallMode,
+  ObjectSeed,
+  OntologySeed,
+  PlatformApiProxyConfig,
+  PlatformApiProxyRoute,
+  ProductConfig,
+  PythonArtifactsChannel,
+  PythonDependencyChannels,
+  SeedLinkEntry,
+  SeedPropertyValue,
+  SerializableFoundryCliError,
+  ServiceLifecycle,
+  ServiceName,
+  ServiceStatus,
+  SetSeedResponse,
+  StatusLevel,
+  UnsupportedFeaturesError,
+  UnsupportedTemplateTypeError,
+} from "./__components.js";

--- a/packages/client.unstable.seed/src/index.ts
+++ b/packages/client.unstable.seed/src/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type * from "./generated/cli/index.js";
+export { getStatus } from "./generated/cli/StatusService/getStatus.js";
+export { publishStatus } from "./generated/cli/StatusService/publishStatus.js";
+export {};

--- a/packages/client.unstable.seed/src/index.ts
+++ b/packages/client.unstable.seed/src/index.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-export type * from "./generated/cli/index.js";
-export { getStatus } from "./generated/cli/StatusService/getStatus.js";
-export { publishStatus } from "./generated/cli/StatusService/publishStatus.js";
+export { OntologySeedingService } from "./generated/cli/index.js";
+export type {
+  ObjectSeed,
+  OntologySeed,
+  SeedLinkEntry,
+  SetSeedResponse,
+} from "./generated/cli/index.js";
 export {};

--- a/packages/client.unstable.seed/tsconfig.json
+++ b/packages/client.unstable.seed/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@osdk/monorepo.tsconfig/base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build/esm"
+  },
+  "include": [
+    "./src/**/*"
+  ],
+  "references": []
+}

--- a/packages/client.unstable.seed/turbo.json
+++ b/packages/client.unstable.seed/turbo.json
@@ -1,0 +1,11 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "transpileEsm": {
+      "dependsOn": ["^transpileEsm"]
+    },
+    "transpileBrowser": {
+      "dependsOn": ["^transpileBrowser"]
+    }
+  }
+}

--- a/packages/client.unstable.seed/vitest.config.mts
+++ b/packages/client.unstable.seed/vitest.config.mts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { configDefaults, defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    pool: "forks",
+    exclude: [...configDefaults.exclude, "**/build/**/*"],
+    fakeTimers: {
+      toFake: ["setTimeout", "clearTimeout", "Date"],
+    },
+  },
+});

--- a/packages/client.unstable.seed/vitest.config.mts
+++ b/packages/client.unstable.seed/vitest.config.mts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/client.unstable.seed/vitest.config.mts
+++ b/packages/client.unstable.seed/vitest.config.mts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2113,6 +2113,25 @@ importers:
         specifier: ~5.5.4
         version: 5.5.4
 
+  packages/client.unstable.seed:
+    dependencies:
+      conjure-lite:
+        specifier: ^0.4.4
+        version: 0.4.4
+    devDependencies:
+      '@osdk/monorepo.api-extractor':
+        specifier: workspace:~
+        version: link:../monorepo.api-extractor
+      '@osdk/monorepo.tool.check-bundle':
+        specifier: workspace:~
+        version: link:../monorepo.tool.check-bundle
+      '@osdk/monorepo.tsconfig':
+        specifier: workspace:~
+        version: link:../monorepo.tsconfig
+      typescript:
+        specifier: ~5.5.4
+        version: 5.5.4
+
   packages/client.unstable.tpsa:
     dependencies:
       conjure-lite:

--- a/scripts/generateConjure.sh
+++ b/scripts/generateConjure.sh
@@ -37,6 +37,7 @@ generateConjure "com.palantir.ontology" "type-registry-api" "${SCRIPT_DIR}/../pa
 generateConjure "com.palantir.object-set-service" "object-set-service-api" "${SCRIPT_DIR}/../packages/client.unstable"
 generateConjure "com.palantir.ontology" "ontology-metadata-api" "${SCRIPT_DIR}/../packages/client.unstable"
 generateConjure "com.palantir.foundry.third-party-application-service" "third-party-application-service-api" "${SCRIPT_DIR}/../packages/client.unstable.tpsa"
+generateConjure "com.palantir.foundry-cli" "cli-api" "${SCRIPT_DIR}/../packages/client.unstable.seed"
 
 # Reset git changes if the generated files are only changed by copyright year
 git status --porcelain --untracked-files=no | while read line; do


### PR DESCRIPTION
## Summary

Adds `@osdk/client.unstable.seed`, a conjure-generated wire client for the foundry-cli conjure API. It follows the existing `@osdk/client.unstable.tpsa` convention exactly: a checked-in `src/generated/` tree produced by `conjure-lite`, a thin hand-written `src/index.ts` barrel on top, and a new target wired into `scripts/generateConjure.sh`.

## What's included

**New package `packages/client.unstable.seed/`**
- `package.json` (single runtime dep `conjure-lite`), `tsconfig.json`, `turbo.json`, `vitest.config.mts`, and a nested `oxlint.config.ts` that re-includes the generated tree (mirrors tpsa).
- `src/index.ts` — barrel: `export type *` for all generated types, plus `getStatus` / `publishStatus` re-exported as callables.
- `src/generated/cli/**` — conjure output, checked in as first-class source: `StatusService` (`getStatus`, `publishStatus`) and `__components.ts` (foundry-cli config/status types).

## How the generated code was produced

Generated from `cli-api` `0.195.0` (latest release) via the existing pipeline — `conjure-lite generate` fed by the IR fetched from the internal conjure Maven repo. Only the new `cli-api` target was generated; the existing `client.unstable` / `client.unstable.tpsa` trees are untouched.

To regenerate: set `MAVEN_CONJURE_BASE_PATH` in `.envrc` and run `./scripts/generateConjure.sh` (or point `--ir` at a local `cli-api.conjure.json` for a local build).

## Notes / follow-ups

- The current `conjure-lite` (0.7.3, what `@osdk/client` pins) leaves a stray `/**/` placeholder atop each generated file that the newer oxlint license rule prepends to rather than replaces; these were stripped to match the checked-in convention. Anyone regenerating conjure clients today will hit the same and needs the same cleanup until the header handling is reconciled.