### PR TITLE
Forward aggregation $accuracy option to the aggregate request

### DIFF
--- a/.changeset/aggregation-accuracy-passthrough.md
+++ b/.changeset/aggregation-accuracy-passthrough.md
@@ -1,0 +1,6 @@
+---
+"@osdk/api": minor
+"@osdk/client": patch
+---
+
+Forward the aggregation `$accuracy` option (`REQUIRE_ACCURATE` | `ALLOW_APPROXIMATE`) through to the aggregate request instead of silently dropping it

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -198,6 +198,7 @@ export interface Affix {
 export type AggregateOpts<Q extends ObjectOrInterfaceDefinition> = {
     	$select: UnorderedAggregationClause<Q> | OrderedAggregationClause<Q>
     	$groupBy?: GroupByClause<Q>
+    	$accuracy?: AggregationAccuracyRequest
 };
 
 // Warning: (ae-forgotten-export) The symbol "ContainsExactMatchWithNull" needs to be exported by the entry point index.d.ts
@@ -210,10 +211,15 @@ export type AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<
 > = ContainsExactMatchWithNull<AO["$groupBy"]> extends true ? {
     	$groupBy: AO["$groupBy"]
     	$select: UnorderedAggregationClause<Q>
+    	$accuracy?: AO["$accuracy"]
 } : SingleKeyObject<AO["$groupBy"]> extends never ? AO["$select"] extends UnorderedAggregationClause<Q> ? AggregateOptsThatErrors<Q, AO> : {} extends AO["$groupBy"] ? AggregateOptsThatErrors<Q, AO> : {
     	$groupBy: AO["$groupBy"]
     	$select: UnorderedAggregationClause<Q>
+    	$accuracy?: AO["$accuracy"]
 } : AggregateOptsThatErrors<Q, AO>;
+
+// @public
+export type AggregationAccuracyRequest = "REQUIRE_ACCURATE" | "ALLOW_APPROXIMATE";
 
 // @public (undocumented)
 export type AggregationClause<Q extends ObjectOrInterfaceDefinition> = UnorderedAggregationClause<Q> | OrderedAggregationClause<Q>;
@@ -2471,8 +2477,8 @@ export type WirePropertyTypes = BaseWirePropertyTypes | Record<string, BaseWireP
 //
 // src/OsdkObjectFrom.ts:312:35 - (ae-forgotten-export) The symbol "OtHasNonLocalInterfaceImpl" needs to be exported by the entry point index.d.ts
 // src/OsdkObjectFrom.ts:357:13 - (ae-forgotten-export) The symbol "ObjectPropertySecurities" needs to be exported by the entry point index.d.ts
-// src/aggregate/AggregateOpts.ts:25:3 - (ae-forgotten-export) The symbol "UnorderedAggregationClause" needs to be exported by the entry point index.d.ts
-// src/aggregate/AggregateOpts.ts:25:3 - (ae-forgotten-export) The symbol "OrderedAggregationClause" needs to be exported by the entry point index.d.ts
+// src/aggregate/AggregateOpts.ts:33:3 - (ae-forgotten-export) The symbol "UnorderedAggregationClause" needs to be exported by the entry point index.d.ts
+// src/aggregate/AggregateOpts.ts:33:3 - (ae-forgotten-export) The symbol "OrderedAggregationClause" needs to be exported by the entry point index.d.ts
 // src/aggregate/AggregationResultsWithGroups.ts:35:3 - (ae-forgotten-export) The symbol "MaybeNullable_2" needs to be exported by the entry point index.d.ts
 // src/aggregate/AggregationResultsWithGroups.ts:35:3 - (ae-forgotten-export) The symbol "OsdkObjectPropertyTypeNotUndefined" needs to be exported by the entry point index.d.ts
 // src/objectSet/ObjectSetLinks.ts:36:3 - (ae-forgotten-export) The symbol "LinkedObjectType" needs to be exported by the entry point index.d.ts

--- a/packages/api/src/aggregate/AggregateOpts.ts
+++ b/packages/api/src/aggregate/AggregateOpts.ts
@@ -21,7 +21,18 @@ import type {
   UnorderedAggregationClause,
 } from "./AggregationsClause.js";
 
+/**
+ * Controls whether the backend is allowed to return an approximate aggregation
+ * result. `"REQUIRE_ACCURATE"` forces an exact computation (which may fail or be
+ * rejected when limits are exceeded), while `"ALLOW_APPROXIMATE"` permits the
+ * backend to return an approximate result.
+ */
+export type AggregationAccuracyRequest =
+  | "REQUIRE_ACCURATE"
+  | "ALLOW_APPROXIMATE";
+
 export type AggregateOpts<Q extends ObjectOrInterfaceDefinition> = {
   $select: UnorderedAggregationClause<Q> | OrderedAggregationClause<Q>;
   $groupBy?: GroupByClause<Q>;
+  $accuracy?: AggregationAccuracyRequest;
 };

--- a/packages/api/src/aggregate/AggregateOptsThatErrors.ts
+++ b/packages/api/src/aggregate/AggregateOptsThatErrors.ts
@@ -29,6 +29,7 @@ export type AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<
     ? {
         $groupBy: AO["$groupBy"];
         $select: UnorderedAggregationClause<Q>;
+        $accuracy?: AO["$accuracy"];
       }
     : SingleKeyObject<AO["$groupBy"]> extends never
       ? AO["$select"] extends UnorderedAggregationClause<Q>
@@ -38,6 +39,7 @@ export type AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<
           : {
               $groupBy: AO["$groupBy"];
               $select: UnorderedAggregationClause<Q>;
+              $accuracy?: AO["$accuracy"];
             }
       : AggregateOptsThatErrors<Q, AO>;
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -23,7 +23,10 @@ export type {
   ApplyBatchActionOptions,
 } from "./actions/Actions.js";
 export type { ValidAggregationKeys } from "./aggregate/AggregatableKeys.js";
-export type { AggregateOpts } from "./aggregate/AggregateOpts.js";
+export type {
+  AggregateOpts,
+  AggregationAccuracyRequest,
+} from "./aggregate/AggregateOpts.js";
 export type { AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy } from "./aggregate/AggregateOptsThatErrors.js";
 export type { AggregationResultsWithGroups } from "./aggregate/AggregationResultsWithGroups.js";
 export type { AggregationResultsWithoutGroups } from "./aggregate/AggregationResultsWithoutGroups.js";

--- a/packages/api/src/objectSet/ObjectSet.ts
+++ b/packages/api/src/objectSet/ObjectSet.ts
@@ -482,7 +482,8 @@ interface Aggregate<Q extends ObjectOrInterfaceDefinition> {
   /**
    * Aggregate on a field in an object type
    * @param req - an aggregation request where you can select fields and choose how to aggregate, e.g., max, min, avg, and also choose
-   * whether or not you order your results. You can also specify a groupBy field to group your aggregations
+   * whether or not you order your results. You can also specify a groupBy field to group your aggregations. Use `$accuracy` to control
+   * whether the backend may return an approximate result (`"ALLOW_APPROXIMATE"`) or must compute it exactly (`"REQUIRE_ACCURATE"`)
    * @example
    * ```ts
    * const testAggregateCountWithGroups = await client(BoundariesUsState)

--- a/packages/client/src/object/aggregate.test.ts
+++ b/packages/client/src/object/aggregate.test.ts
@@ -529,6 +529,66 @@ describe("aggregate", () => {
     >(false); // subselect should hide unused keys
   });
 
+  it("forwards $accuracy to the request body", async () => {
+    await aggregate(
+      clientCtx,
+      objectTypeWithAllPropertyTypes,
+      {
+        type: "base",
+        objectType: "ToDo",
+      },
+      {
+        $select: {
+          $count: "unordered",
+        },
+        $accuracy: "ALLOW_APPROXIMATE",
+      }
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://host.com/api/v2/ontologies/ri.a.b.c.d/objectSets/aggregate",
+      {
+        body: JSON.stringify({
+          objectSet: { type: "base", objectType: "ToDo" },
+          groupBy: [],
+          aggregation: [{ type: "count", name: "count" }],
+          accuracy: "ALLOW_APPROXIMATE",
+        }),
+        method: "POST",
+        headers: expect.anything(),
+      }
+    );
+  });
+
+  it("omits accuracy from the request body when $accuracy is not provided", async () => {
+    await aggregate(
+      clientCtx,
+      objectTypeWithAllPropertyTypes,
+      {
+        type: "base",
+        objectType: "ToDo",
+      },
+      {
+        $select: {
+          $count: "unordered",
+        },
+      }
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://host.com/api/v2/ontologies/ri.a.b.c.d/objectSets/aggregate",
+      {
+        body: JSON.stringify({
+          objectSet: { type: "base", objectType: "ToDo" },
+          groupBy: [],
+          aggregation: [{ type: "count", name: "count" }],
+        }),
+        method: "POST",
+        headers: expect.anything(),
+      }
+    );
+  });
+
   it("prohibits ordered select with multiple groupBy", async () => {
     await client(Todo).aggregate({
       $select: {

--- a/packages/client/src/object/aggregate.ts
+++ b/packages/client/src/object/aggregate.ts
@@ -52,6 +52,7 @@ export async function aggregate<
     aggregation: modernToLegacyAggregationClause<AO["$select"]>(req.$select),
     groupBy: [],
     where: undefined,
+    accuracy: req.$accuracy,
   };
 
   if (req.$groupBy) {
@@ -69,6 +70,7 @@ export async function aggregate<
       objectSet,
       groupBy: body.groupBy,
       aggregation: body.aggregation,
+      accuracy: body.accuracy,
     },
     {
       branch: clientCtx.branch,


### PR DESCRIPTION
## Problem

The aggregate request builder in `packages/client/src/object/aggregate.ts` never read an accuracy option. The wire request type (`AggregateObjectSetRequestV2` / `AggregateObjectsRequestV2`) has always supported `accuracy?: "REQUIRE_ACCURATE" | "ALLOW_APPROXIMATE"`, but there was no way for a caller to set it, so the field was always omitted — callers could not control exact vs. approximate results.

## Fix

- Add `$accuracy?: AggregationAccuracyRequest` (`"REQUIRE_ACCURATE" | "ALLOW_APPROXIMATE"`) to `AggregateOpts` in `@osdk/api`, exported from the package index and documented on `objectSet.aggregate`.
- Carry `$accuracy` through the `AggregateOptsThatErrors*` type branches so it isn't stripped.
- Forward it as `accuracy` in the request built by `aggregate.ts`. When unset it is `undefined` and omitted from the serialized body, so existing requests are unchanged.

All aggregate entry points (direct client, `objectSet.aggregate`, observable/react hooks) funnel through `AggregateOpts` + `aggregate.ts`, so they all inherit the option.

## Tests

- `$accuracy` is forwarded into the request body, and omitted when not provided.
- API report and changeset updated.

## Follow-ups (separate PRs)

- Rejecting unknown top-level keys in `aggregate()` options (the excess-property hole) is handled in a separate PR.
- Surfacing response `accuracy` / `excludedItems` is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)