### PR TITLE
Reject unknown top-level keys in aggregate() options

### DIFF
--- a/.changeset/aggregate-reject-unknown-keys.md
+++ b/.changeset/aggregate-reject-unknown-keys.md
@@ -1,0 +1,5 @@
+---
+"@osdk/api": minor
+---
+
+Reject unknown top-level keys in `aggregate()` options (e.g. a misspelled group-by key or a non-existent `$orderBy`). These were previously accepted by the type checker and silently ignored at runtime.

--- a/packages/api/src/__quickinfo_snapshot__/__snapshots__/objectSet.snap
+++ b/packages/api/src/__quickinfo_snapshot__/__snapshots__/objectSet.snap
@@ -19,7 +19,7 @@ type objectSet_aggregate_req_param = AggregateOpts<EmployeeApiTest> & {
   $groupBy:
     & Pick<GroupByClause<EmployeeApiTest> | undefined, never>
     & Record<never, never>;
-};
+} & Record<never, never>;
 
 /** The result of objectSet.asyncIter(). */
 type objectSet_asyncIter_result = AsyncIterableIterator<

--- a/packages/api/src/aggregate/AggregateOptsThatErrors.ts
+++ b/packages/api/src/aggregate/AggregateOptsThatErrors.ts
@@ -77,4 +77,5 @@ type AggregateOptsThatErrors<
               Exclude<keyof AO["$groupBy"], keyof GroupByClause<Q>>,
               never
             >;
-        });
+        }) &
+  Record<Exclude<keyof AO, keyof AggregateOpts<Q>>, never>;

--- a/packages/client/src/object/aggregate.test.ts
+++ b/packages/client/src/object/aggregate.test.ts
@@ -548,6 +548,20 @@ describe("aggregate", () => {
     });
   });
 
+  it("rejects unknown top-level keys", async () => {
+    await client(Todo).aggregate({
+      $select: { $count: "unordered" },
+      // @ts-expect-error unknown top-level keys must not be silently accepted
+      $orderBy: { group: "string" },
+    });
+
+    await client(Todo).aggregate({
+      // @ts-expect-error misspelled $groupBy must be rejected
+      $groupByy: { text: "exact" },
+      $select: { $count: "unordered" },
+    });
+  });
+
   describe("$exact", () => {
     it("correctly nulls bucket type when $includeNullValue is true", async () => {
       const result = await client(Todo).aggregate({

--- a/packages/e2e.sandbox.catchall/src/typeChecks.ts
+++ b/packages/e2e.sandbox.catchall/src/typeChecks.ts
@@ -57,9 +57,6 @@ export async function typeChecks(client: Client): Promise<void> {
         string: "exact",
         stringArray: "exact",
       },
-      $orderBy: {
-        group: "string",
-      },
     });
   }
 


### PR DESCRIPTION
## Problem

`aggregate()` silently accepted arbitrary extra keys. Its signature infers the option type from the argument:

```ts
readonly aggregate: <AO extends AggregateOpts<Q>>(
  req: AggregateOptsThatErrorsAndDisallowsOrderingWithMultipleGroupBy<Q, AO>
) => ...
```

Because `AO` is inferred from the literal and the parameter type is derived from that same `AO` (`AO & {…}`), TypeScript's excess-property check is bypassed. Any extra `$`-key — a misspelled `$grupBy`, a non-existent `$orderBy`, etc. — compiled cleanly and was **silently dropped at runtime**.

## Fix

Map any top-level key not in `AggregateOpts` to `never`, so unknown/misspelled keys are now type errors:

```ts
& Record<Exclude<keyof AO, keyof AggregateOpts<Q>>, never>
```

This is the same `Record<Exclude<…>, never>` pattern the type already applied to `$select` and `$groupBy` sub-keys — just extended to the top level.

Running the full-repo typecheck surfaced exactly one casualty: a dead `$orderBy` in the catchall sandbox demo (`$orderBy` was never a real key; ordering is expressed inline in `$select`). It had been doing nothing since it was written and is removed.

## Tests

- New `@ts-expect-error` regression test asserting unknown top-level keys (`$orderBy`, a misspelled `$groupBy`) are rejected.
- Quickinfo snapshot regenerated (adds the no-op `& Record<never, never>` to the rendered type, consistent with how `$select`/`$groupBy` already render).
- Full-repo `pnpm turbo typecheck` passes (212 packages).

## Notes

This is a type-level tightening, so downstream consumers with their own latent dead keys will get **new** compile errors on upgrade (as our own sandbox did) — hence the `minor` bump on `@osdk/api`. Flag for reviewers if a major is preferred.

Split out from #3742 (which handles forwarding the `$accuracy` option).

🤖 Generated with [Claude Code](https://claude.com/claude-code)