### PR TITLE
Revert "chore: re-enable oxlint no-useless-switch-case" (#3624)

### DIFF
--- a/.changeset/brave-otters-clap.md
+++ b/.changeset/brave-otters-clap.md
@@ -1,0 +1,9 @@
+---
+"@osdk/maker": patch
+"@osdk/maker-experimental": patch
+"@osdk/react-devtools": patch
+"@osdk/react-sdk-docs": patch
+"@osdk/typescript-sdk-docs": patch
+---
+
+Revert re-enabling the `unicorn/no-useless-switch-case` oxlint rule; the rule is disabled again and the explicit `case` labels are restored. Behavior-preserving with no runtime or API changes.

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -53,9 +53,13 @@ export default defineConfig({
     "unicorn/no-lonely-if": "off",
     "jsdoc/require-param-description": "off",
     "jsdoc/require-returns-description": "off",
-    // Cyclomatic-complexity ceiling. Not a pure autofix (requires extracting
-    // helpers, which adds bundle size), so it's handled in its own PR.
+    // Cyclomatic-complexity ceiling; the large discriminated-union switch helpers
+    // in the docs packages exceed it. Splitting them up is pure churn here.
     "complexity": "off",
+    // Several switches list known discriminant values (e.g. "string", "unknown")
+    // that share the `default` body. Keeping the explicit cases documents intent;
+    // removing them would be churn with no behavioral change.
+    "unicorn/no-useless-switch-case": "off",
 
     // Rules whose autofix would change behavior or the public API of these
     // already-published packages. Kept at prior severity / disabled so the

--- a/packages/e2e.sandbox.officenetwork/src/utils/reorgAlgorithms.ts
+++ b/packages/e2e.sandbox.officenetwork/src/utils/reorgAlgorithms.ts
@@ -22,6 +22,7 @@ export function generateChanges(
       return generateSwapChanges(employees, offices, config);
     case "consolidate":
       return generateConsolidateChanges(employees, offices, config);
+    case "manual":
     default:
       return generateManualChanges(employees);
   }

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertDatasourceDefinition.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertDatasourceDefinition.ts
@@ -126,6 +126,7 @@ export function convertDatasourceDefinition(
         },
       };
 
+    case "dataset":
     default:
       // Use generateLocator for dataset datasources
       const datasetLocator = ridGenerator.generateDatasetLocator(

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertLink.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertLink.ts
@@ -321,6 +321,7 @@ export function convertLinkStatus(
       return { type: "experimental", experimental: {} };
     case "example":
       return { type: "example", example: {} };
+    case "active":
     default:
       return { type: "active", active: {} };
   }

--- a/packages/maker/src/conversion/toMarketplace/convertDatasourceDefinition.ts
+++ b/packages/maker/src/conversion/toMarketplace/convertDatasourceDefinition.ts
@@ -88,6 +88,7 @@ export function convertDatasourceDefinition(
           ),
         },
       };
+    case "dataset":
     default:
       if (
         objectType.properties?.some(

--- a/packages/maker/src/conversion/toMarketplace/convertLink.ts
+++ b/packages/maker/src/conversion/toMarketplace/convertLink.ts
@@ -293,6 +293,7 @@ export function convertLinkStatus(
       return { type: "experimental", experimental: {} };
     case "example":
       return { type: "example", example: {} };
+    case "active":
     default:
       return { type: "active", active: {} };
   }

--- a/packages/react-devtools/src/components/HookRow.tsx
+++ b/packages/react-devtools/src/components/HookRow.tsx
@@ -178,6 +178,7 @@ export const HookRow: React.FC<HookRowProps> = ({
             </Tag>
           </Tooltip>
         );
+      case "idle":
       default:
         return null;
     }

--- a/packages/react-sdk-docs/src/docs.ts
+++ b/packages/react-sdk-docs/src/docs.ts
@@ -183,6 +183,7 @@ function renderType(
     case "string": {
       return `"${type.value ?? "value"}"`;
     }
+    case "unknown":
     default: {
       return `"value"`;
     }

--- a/packages/typescript-sdk-docs/src/docs.ts
+++ b/packages/typescript-sdk-docs/src/docs.ts
@@ -454,6 +454,8 @@ function renderType(
       )}: ${renderType(type.valueType, majorVersion, context)}}`;
     }
 
+    case "string":
+    case "unknown":
     default: {
       return `"${type.value ?? "value"}"`;
     }


### PR DESCRIPTION
Reverts #3624.

Re-disables the `unicorn/no-useless-switch-case` oxlint rule and restores the explicit fall-through `case` labels it had removed. Behavior-preserving — no runtime or API changes.