### PR TITLE
Add propetiesV2 to imported interface shapes

### DIFF
--- a/.changeset/full-jokes-give.md
+++ b/.changeset/full-jokes-give.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker-experimental": patch
+---
+
+Add propertiesV2 to imported interface shapes

--- a/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ImportedShapeExtractor.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ImportedShapeExtractor.ts
@@ -327,6 +327,19 @@ function extractImportedInterfaceTypes(
       )
     );
 
+    const propertiesV2: string[] = [];
+    for (const [propertyRid] of Object.entries(
+      interfaceType.propertiesV3 ?? {}
+    )) {
+      const propReadableId = ridGenerator
+        .getInterfacePropertyTypeRids()
+        .inverse()
+        .get(propertyRid);
+      if (propReadableId) {
+        propertiesV2.push(ridGenerator.toBlockInternalId(propReadableId));
+      }
+    }
+
     // Build links list
     const links: string[] = (interfaceType.links ?? []).map(
       (ilt: MarketplaceInterfaceLinkType) => {
@@ -351,7 +364,7 @@ function extractImportedInterfaceTypes(
       ),
       actionTypeConstraints,
       properties,
-      propertiesV2: [],
+      propertiesV2,
       links,
     };
 


### PR DESCRIPTION
These shouldn't have been removed [here](https://github.com/palantir/osdk-ts/pull/3297) 