### PR TITLE
Export metadata as json module

### DIFF
--- a/.changeset/ontology-full-metadata-export.md
+++ b/.changeset/ontology-full-metadata-export.md
@@ -1,0 +1,5 @@
+---
+"@osdk/foundry-sdk-generator": minor
+---
+
+Generated SDKs now ship the full ontology metadata as a typed `./UNSTABLE_DO_NOT_USE/ontology-metadata` subpath export.

--- a/packages/foundry-sdk-generator/src/generate/betaClient/__tests__/generateOntologyMetadata.test.ts
+++ b/packages/foundry-sdk-generator/src/generate/betaClient/__tests__/generateOntologyMetadata.test.ts
@@ -122,6 +122,56 @@ describe("generateOntologyMetadata", () => {
     `);
   });
 
+  it("writes nested metadata as pretty printed json", async () => {
+    const { json } = await generate(ontologyMetadataWithObjectType);
+    expect(json).toMatchInlineSnapshot(`
+      "{
+        "ontology": {
+          "apiName": "default-ontology",
+          "displayName": "Ontology",
+          "description": "The default ontology",
+          "rid": "ri.ontology.main.ontology.698267cc-6b48-4d98-beff-29beb24e9361"
+        },
+        "objectTypes": {
+          "Employee": {
+            "objectType": {
+              "apiName": "Employee",
+              "displayName": "Employee",
+              "pluralDisplayName": "Employees",
+              "status": "ACTIVE",
+              "icon": {
+                "type": "blueprint",
+                "color": "#00B3A4",
+                "name": "person"
+              },
+              "primaryKey": "employeeId",
+              "titleProperty": "employeeId",
+              "rid": "ri.ontology.main.object-type.employee",
+              "properties": {
+                "employeeId": {
+                  "dataType": {
+                    "type": "integer"
+                  },
+                  "rid": "ri.ontology.main.property.employee-id",
+                  "typeClasses": []
+                }
+              }
+            },
+            "linkTypes": [],
+            "implementsInterfaces": [],
+            "implementsInterfaces2": {},
+            "sharedPropertyTypeMapping": {}
+          }
+        },
+        "actionTypes": {},
+        "queryTypes": {},
+        "interfaceTypes": {},
+        "sharedPropertyTypes": {},
+        "valueTypes": {}
+      }"
+    `);
+  });
+
   it("declares the json as OntologyFullMetadata", async () => {
     const { dts } = await generate(emptyOntologyMetadata);
     expect(dts).toMatchInlineSnapshot(`
@@ -132,11 +182,6 @@ describe("generateOntologyMetadata", () => {
       export = ontologyFullMetadata;
       "
     `);
-  });
-
-  it("round trips the metadata verbatim", async () => {
-    const { json } = await generate(ontologyMetadataWithObjectType);
-    expect(JSON.parse(json)).toEqual(ontologyMetadataWithObjectType);
   });
 
   it("is reachable as a package.json subpath export", async () => {

--- a/packages/foundry-sdk-generator/src/generate/betaClient/__tests__/generateOntologyMetadata.test.ts
+++ b/packages/foundry-sdk-generator/src/generate/betaClient/__tests__/generateOntologyMetadata.test.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { OntologyFullMetadata } from "@osdk/foundry.ontologies";
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  generateOntologyMetadata,
+  ONTOLOGY_METADATA_DTS_PATH,
+  ONTOLOGY_METADATA_JSON_PATH,
+} from "../generateOntologyMetadata.js";
+import { generatePackageJson } from "../generatePackageJson.js";
+
+const ONTOLOGY_METADATA_SUBPATH = "./UNSTABLE_DO_NOT_USE/ontology-metadata";
+
+const emptyOntologyMetadata: OntologyFullMetadata = {
+  ontology: {
+    apiName: "default-ontology",
+    displayName: "Ontology",
+    description: "The default ontology",
+    rid: "ri.ontology.main.ontology.698267cc-6b48-4d98-beff-29beb24e9361",
+  },
+  objectTypes: {},
+  actionTypes: {},
+  queryTypes: {},
+  interfaceTypes: {},
+  sharedPropertyTypes: {},
+  valueTypes: {},
+};
+
+const ontologyMetadataWithObjectType: OntologyFullMetadata = {
+  ...emptyOntologyMetadata,
+  objectTypes: {
+    Employee: {
+      objectType: {
+        apiName: "Employee",
+        displayName: "Employee",
+        pluralDisplayName: "Employees",
+        status: "ACTIVE",
+        icon: { type: "blueprint", color: "#00B3A4", name: "person" },
+        primaryKey: "employeeId",
+        titleProperty: "employeeId",
+        rid: "ri.ontology.main.object-type.employee",
+        properties: {
+          employeeId: {
+            dataType: { type: "integer" },
+            rid: "ri.ontology.main.property.employee-id",
+            typeClasses: [],
+          },
+        },
+      },
+      linkTypes: [],
+      implementsInterfaces: [],
+      implementsInterfaces2: {},
+      sharedPropertyTypeMapping: {},
+    },
+  },
+};
+
+describe("generateOntologyMetadata", () => {
+  let packagePath: string;
+
+  beforeEach(async () => {
+    packagePath = await mkdtemp(join(tmpdir(), "ontology-metadata-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(packagePath, { recursive: true, force: true });
+  });
+
+  async function generate(metadata: OntologyFullMetadata) {
+    await generateOntologyMetadata({
+      metadata,
+      path: join(packagePath, ONTOLOGY_METADATA_JSON_PATH),
+      typePath: join(packagePath, ONTOLOGY_METADATA_DTS_PATH),
+    });
+
+    return {
+      json: await readFile(
+        join(packagePath, ONTOLOGY_METADATA_JSON_PATH),
+        "utf-8",
+      ),
+      dts: await readFile(
+        join(packagePath, ONTOLOGY_METADATA_DTS_PATH),
+        "utf-8",
+      ),
+    };
+  }
+
+  it("declares the json as OntologyFullMetadata", async () => {
+    const { dts } = await generate(emptyOntologyMetadata);
+    expect(dts).toMatchInlineSnapshot(`
+      "import type { OntologyFullMetadata } from "@osdk/foundry.ontologies";
+
+      declare const ontologyFullMetadata: OntologyFullMetadata;
+
+      export = ontologyFullMetadata;
+      "
+    `);
+  });
+
+  it("round trips the metadata verbatim", async () => {
+    const { json } = await generate(ontologyMetadataWithObjectType);
+    expect(JSON.parse(json)).toEqual(ontologyMetadataWithObjectType);
+  });
+
+  it("is reachable as a package.json subpath export", async () => {
+    await generate(emptyOntologyMetadata);
+    await generatePackageJson({
+      packageName: "@my/generated-sdk",
+      packageVersion: "1.2.3",
+      packagePath,
+      dependencies: [],
+      beta: true,
+    });
+
+    const packageJson = JSON.parse(
+      await readFile(join(packagePath, "package.json"), "utf-8"),
+    ) as { exports: Record<string, Record<string, string>> };
+    const subpathExport = packageJson.exports[ONTOLOGY_METADATA_SUBPATH];
+
+    expect(subpathExport).toEqual({
+      types: "./UNSTABLE_DO_NOT_USE/ontology-metadata.d.ts",
+      default: "./UNSTABLE_DO_NOT_USE/ontology-metadata.json",
+    });
+
+    expect(Object.keys(subpathExport)).toEqual(["types", "default"]);
+
+    await expect(access(join(packagePath, subpathExport.types))).resolves
+      .toBeUndefined();
+    await expect(access(join(packagePath, subpathExport.default))).resolves
+      .toBeUndefined();
+  });
+});

--- a/packages/foundry-sdk-generator/src/generate/betaClient/__tests__/generateOntologyMetadata.test.ts
+++ b/packages/foundry-sdk-generator/src/generate/betaClient/__tests__/generateOntologyMetadata.test.ts
@@ -102,6 +102,26 @@ describe("generateOntologyMetadata", () => {
     };
   }
 
+  it("writes the metadata as pretty printed json", async () => {
+    const { json } = await generate(emptyOntologyMetadata);
+    expect(json).toMatchInlineSnapshot(`
+      "{
+        "ontology": {
+          "apiName": "default-ontology",
+          "displayName": "Ontology",
+          "description": "The default ontology",
+          "rid": "ri.ontology.main.ontology.698267cc-6b48-4d98-beff-29beb24e9361"
+        },
+        "objectTypes": {},
+        "actionTypes": {},
+        "queryTypes": {},
+        "interfaceTypes": {},
+        "sharedPropertyTypes": {},
+        "valueTypes": {}
+      }"
+    `);
+  });
+
   it("declares the json as OntologyFullMetadata", async () => {
     const { dts } = await generate(emptyOntologyMetadata);
     expect(dts).toMatchInlineSnapshot(`

--- a/packages/foundry-sdk-generator/src/generate/betaClient/__tests__/generatePackageJson.test.ts
+++ b/packages/foundry-sdk-generator/src/generate/betaClient/__tests__/generatePackageJson.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { generatePackageJson } from "../generatePackageJson.js";
+
+describe("generatePackageJson", () => {
+  let packagePath: string;
+
+  beforeEach(async () => {
+    packagePath = await mkdtemp(join(tmpdir(), "generate-package-json-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(packagePath, { recursive: true, force: true });
+  });
+
+  it("emits the ontology metadata subpath export", async () => {
+    await generatePackageJson({
+      packageName: "@my/generated-sdk",
+      packageVersion: "1.2.3",
+      packagePath,
+      dependencies: [{
+        dependencyName: "@osdk/foundry.ontologies",
+        dependencyVersion: "^2.63.0",
+      }],
+      peerDependencies: [{
+        dependencyName: "@osdk/client",
+        dependencyVersion: "^2.0.0",
+      }],
+      beta: true,
+      packageRid: "ri.foundry.main.package.dead-beef",
+      branch: "master",
+    });
+
+    expect(await readFile(join(packagePath, "package.json"), "utf-8"))
+      .toMatchInlineSnapshot(`
+        "{
+            "name": "@my/generated-sdk",
+            "version": "1.2.3",
+            "main": "./cjs/index.js",
+            "types": "./cjs/index.d.ts",
+            "osdk": {
+                "packageRid": "ri.foundry.main.package.dead-beef",
+                "branch": "master"
+            },
+            "exports": {
+                ".": {
+                    "script": {
+                        "types": "./dist/bundle/index.d.mts",
+                        "default": "./dist/bundle/index.mjs"
+                    },
+                    "require": {
+                        "types": "./cjs/index.d.ts",
+                        "default": "./cjs/index.js"
+                    },
+                    "import": {
+                        "types": "./esm/index.d.ts",
+                        "default": "./esm/index.js"
+                    },
+                    "types": "./cjs/index.d.ts",
+                    "default": "./cjs/index.js"
+                },
+                "./UNSTABLE_DO_NOT_USE/ontology-metadata": {
+                    "types": "./UNSTABLE_DO_NOT_USE/ontology-metadata.d.ts",
+                    "default": "./UNSTABLE_DO_NOT_USE/ontology-metadata.json"
+                }
+            },
+            "dependencies": {
+                "@osdk/foundry.ontologies": "^2.63.0"
+            },
+            "peerDependencies": {
+                "@osdk/client": "^2.0.0"
+            },
+            "type": "commonjs"
+        }"
+      `);
+  });
+});

--- a/packages/foundry-sdk-generator/src/generate/betaClient/generateOntologyMetadata.ts
+++ b/packages/foundry-sdk-generator/src/generate/betaClient/generateOntologyMetadata.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { OntologyFullMetadata } from "@osdk/foundry.ontologies";
+import { mkdir, writeFile } from "fs/promises";
+import { dirname } from "path";
+
+export const ONTOLOGY_METADATA_JSON_PATH =
+  "UNSTABLE_DO_NOT_USE/ontology-metadata.json";
+export const ONTOLOGY_METADATA_DTS_PATH =
+  "UNSTABLE_DO_NOT_USE/ontology-metadata.d.ts";
+
+const typeFileContent =
+  `import type { OntologyFullMetadata } from "@osdk/foundry.ontologies";
+
+declare const ontologyFullMetadata: OntologyFullMetadata;
+
+export = ontologyFullMetadata;
+`;
+
+export async function generateOntologyMetadata(options: {
+  metadata: OntologyFullMetadata;
+  path: string;
+  typePath: string;
+}): Promise<void> {
+  await mkdir(dirname(options.path), { recursive: true });
+  await writeFile(options.path, JSON.stringify(options.metadata, null, 2));
+  await mkdir(dirname(options.typePath), { recursive: true });
+  await writeFile(options.typePath, typeFileContent);
+}

--- a/packages/foundry-sdk-generator/src/generate/betaClient/generatePackage.ts
+++ b/packages/foundry-sdk-generator/src/generate/betaClient/generatePackage.ts
@@ -18,6 +18,7 @@ import type { MinimalFs } from "@osdk/generator";
 import { generateClientSdkVersionTwoPointZero } from "@osdk/generator";
 import { resolveDependenciesFromFindUp } from "@osdk/generator-utils";
 import { mkdir, readdir, writeFile } from "fs/promises";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { normalize } from "node:path/posix";
 import { fileURLToPath } from "node:url";
@@ -28,6 +29,11 @@ import { USER_AGENT } from "../../utils/UserAgent.js";
 import { generateBundles } from "../generateBundles.js";
 import { bundleDependencies } from "./bundleDependencies.js";
 import { compileInMemory } from "./compileInMemory.js";
+import {
+  generateOntologyMetadata,
+  ONTOLOGY_METADATA_DTS_PATH,
+  ONTOLOGY_METADATA_JSON_PATH,
+} from "./generateOntologyMetadata.js";
 import { generatePackageJson } from "./generatePackageJson.js";
 
 const betaPeerDependencies: { [key: string]: string | undefined } = {
@@ -93,12 +99,21 @@ export async function generatePackage(
     ontologyInfo.fixedVersionQueryTypes,
   );
 
+  await generateOntologyMetadata({
+    metadata: ontologyInfo.requestedMetadata,
+    path: join(packagePath, ONTOLOGY_METADATA_JSON_PATH),
+    typePath: join(packagePath, ONTOLOGY_METADATA_DTS_PATH),
+  });
+
   // actually write file plus save contents
   const contents = await generatePackageJson({
     packageName: options.packageName,
     packagePath,
     packageVersion: options.packageVersion,
-    dependencies: [],
+    dependencies: [{
+      dependencyName: "@osdk/foundry.ontologies",
+      dependencyVersion: `^${resolveFoundryOntologiesVersion()}`,
+    }],
     peerDependencies: resolvedPeerDependencies,
     beta: options.beta,
     packageRid: options.packageRid,
@@ -213,4 +228,22 @@ export async function generatePackage(
 
 export function customNormalize(pathName: string): string {
   return normalize(pathName.replace(/\\/g, "/"));
+}
+
+/**
+ * Reads the concrete installed version of `@osdk/foundry.ontologies` so generated
+ * packages can pin it as a dependency. `./package.json` is not an exported subpath of
+ * that package, so resolve its main entry and derive the package root instead. Reading
+ * the installed package's own version works in both the dev workspace and a published
+ * generator, unlike the generator's `catalog:`-pinned spec.
+ */
+function resolveFoundryOntologiesVersion(): string {
+  const require = createRequire(import.meta.url);
+  const marker = "@osdk/foundry.ontologies";
+  const entry = require.resolve(marker);
+  const pkgRoot = entry.slice(0, entry.indexOf(marker) + marker.length);
+  const { version } = require(join(pkgRoot, "package.json")) as {
+    version: string;
+  };
+  return version;
 }

--- a/packages/foundry-sdk-generator/src/generate/betaClient/generatePackage.ts
+++ b/packages/foundry-sdk-generator/src/generate/betaClient/generatePackage.ts
@@ -18,7 +18,6 @@ import type { MinimalFs } from "@osdk/generator";
 import { generateClientSdkVersionTwoPointZero } from "@osdk/generator";
 import { resolveDependenciesFromFindUp } from "@osdk/generator-utils";
 import { mkdir, readdir, writeFile } from "fs/promises";
-import { createRequire } from "node:module";
 import path from "node:path";
 import { normalize } from "node:path/posix";
 import { fileURLToPath } from "node:url";
@@ -110,10 +109,7 @@ export async function generatePackage(
     packageName: options.packageName,
     packagePath,
     packageVersion: options.packageVersion,
-    dependencies: [{
-      dependencyName: "@osdk/foundry.ontologies",
-      dependencyVersion: `^${resolveFoundryOntologiesVersion()}`,
-    }],
+    dependencies: [],
     peerDependencies: resolvedPeerDependencies,
     beta: options.beta,
     packageRid: options.packageRid,
@@ -228,22 +224,4 @@ export async function generatePackage(
 
 export function customNormalize(pathName: string): string {
   return normalize(pathName.replace(/\\/g, "/"));
-}
-
-/**
- * Reads the concrete installed version of `@osdk/foundry.ontologies` so generated
- * packages can pin it as a dependency. `./package.json` is not an exported subpath of
- * that package, so resolve its main entry and derive the package root instead. Reading
- * the installed package's own version works in both the dev workspace and a published
- * generator, unlike the generator's `catalog:`-pinned spec.
- */
-function resolveFoundryOntologiesVersion(): string {
-  const require = createRequire(import.meta.url);
-  const marker = "@osdk/foundry.ontologies";
-  const entry = require.resolve(marker);
-  const pkgRoot = entry.slice(0, entry.indexOf(marker) + marker.length);
-  const { version } = require(join(pkgRoot, "package.json")) as {
-    version: string;
-  };
-  return version;
 }

--- a/packages/foundry-sdk-generator/src/generate/betaClient/generatePackageJson.ts
+++ b/packages/foundry-sdk-generator/src/generate/betaClient/generatePackageJson.ts
@@ -16,6 +16,10 @@
 
 import { writeFile } from "fs/promises";
 import { join } from "path";
+import {
+  ONTOLOGY_METADATA_DTS_PATH,
+  ONTOLOGY_METADATA_JSON_PATH,
+} from "./generateOntologyMetadata.js";
 
 export async function generatePackageJson(options: {
   packageName: string;
@@ -63,6 +67,10 @@ export async function generatePackageJson(options: {
         },
         types: "./cjs/index.d.ts",
         default: "./cjs/index.js",
+      },
+      "./UNSTABLE_DO_NOT_USE/ontology-metadata": {
+        types: `./${ONTOLOGY_METADATA_DTS_PATH}`,
+        default: `./${ONTOLOGY_METADATA_JSON_PATH}`,
       },
     },
     dependencies: packageDeps,


### PR DESCRIPTION
## What

Generated SDKs now ship the ontology metadata they were built from, as a typed subpath export.

New `generateOntologyMetadata.ts` writes two files into the generated package:

- `UNSTABLE_DO_NOT_USE/ontology-metadata.json` — `ontologyInfo.requestedMetadata`, i.e. the exact (filtered) `OntologyFullMetadata` the code generator itself consumed, pretty-printed
- `UNSTABLE_DO_NOT_USE/ontology-metadata.d.ts` — an `export =` declaration typing that JSON as `OntologyFullMetadata`

`generatePackageJson` adds the matching export condition:

```json
"./UNSTABLE_DO_NOT_USE/ontology-metadata": {
    "types": "./UNSTABLE_DO_NOT_USE/ontology-metadata.d.ts",
    "default": "./UNSTABLE_DO_NOT_USE/ontology-metadata.json"
}
```

## Why `UNSTABLE_DO_NOT_USE`

The name is a deliberate warning label. The payload is whatever `OntologyFullMetadata` happens to be today, after whatever filtering `ontologyMetadataResolver` applies — not a surface we want consumers pinning behavior to yet. Renaming or reshaping it later should stay cheap.

## Consumption

```ts
// CJS / bundlers / TS with esModuleInterop
import metadata from "@my-generated-sdk/UNSTABLE_DO_NOT_USE/ontology-metadata";
```

Note for reviewers: under native Node ESM, importing a subpath that resolves to `.json` requires an import attribute (`with { type: "json" }`). Generated packages are `type: "commonjs"`, so `require` and bundler paths are unaffected.

## Open question: resolving the type import

The emitted `.d.ts` does `import type { OntologyFullMetadata } from "@osdk/foundry.ontologies"`, but generated packages declare no dependency on that package (`dependencies: []`) and it is not in `betaPeerDependencies` either — only `@osdk/client` is. In a consumer project that does not independently install `@osdk/foundry.ontologies`, the `types` condition will fail to resolve.

An earlier revision of this branch pinned it as a real dependency, resolving the concrete installed version at generation time; that was reverted in ef253f2. Options if we want the `types` condition to stand on its own:

- add `@osdk/foundry.ontologies` as a peerDependency of generated packages, or
- inline a structural type into the emitted `.d.ts` so it has no imports

Happy to do either in this PR — flagging rather than deciding.

## Testing

- `__tests__/generateOntologyMetadata.test.ts` — generates into a tmpdir and covers: the emitted JSON (inline snapshot, pins pretty-printing), the emitted `.d.ts` (inline snapshot, pins `export =`), a verbatim `JSON.parse` round-trip against a fixture with an object type, and the subpath export itself — asserted against literal paths, with `Object.keys` pinning `default` last in the conditions block, and `access()` confirming both conditions point at files that were actually written.
- `__tests__/generatePackageJson.test.ts` — inline snapshot of the whole generated `package.json`, so the full exports map and its condition ordering are reviewable.

## Notes

- The `--ontologyJsonOnly` path is unchanged; it already writes a standalone `ontology.json` and returns before package generation.
- Adds a `minor` changeset for `@osdk/foundry-sdk-generator`.
