### PR TITLE
Fix ObjectTable header menu re-applying an existing sort instead of removing it

### DIFF
--- a/.changeset/object-table-unsort-on-toggle.md
+++ b/.changeset/object-table-unsort-on-toggle.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Fix `ObjectTable` column header menu re-applying an existing sort instead of removing it: clicking `Sort ascending` on a column already sorted ascending (or `Sort descending` on one already sorted descending) now returns that column to unsorted. Only that column's sort is removed, so the remaining columns of a multi-column sort keep their direction and relative order.

--- a/.changeset/object-table-unsort-on-toggle.md
+++ b/.changeset/object-table-unsort-on-toggle.md
@@ -2,4 +2,8 @@
 "@osdk/react-components": patch
 ---
 
-Fix `ObjectTable` column header menu re-applying an existing sort instead of removing it: clicking `Sort ascending` on a column already sorted ascending (or `Sort descending` on one already sorted descending) now returns that column to unsorted. Only that column's sort is removed, so the remaining columns of a multi-column sort keep their direction and relative order.
+Fix two `ObjectTable` column header menu bugs.
+
+Clicking `Sort ascending` on a column already sorted ascending (or `Sort descending` on one already sorted descending) re-applied the same sort instead of removing it; it now returns that column to unsorted. Only that column's sort is removed, so the remaining columns of a multi-column sort keep their direction and relative order.
+
+The header menu's active-item highlight never rendered, because its style rule used a descendant selector for a class applied to the same element as the base class. The applied sort direction and `Unpin Column` (while a column is pinned) are now highlighted as intended.

--- a/packages/react-components/src/object-table/TableHeaderWithPopover.module.css
+++ b/packages/react-components/src/object-table/TableHeaderWithPopover.module.css
@@ -114,7 +114,8 @@
   }
 }
 
-.osdkHeaderMenuItem .osdkHeaderActiveMenuItem {
+/* Compound, not descendant: both classes land on the same menu item element. */
+.osdkHeaderMenuItem.osdkHeaderActiveMenuItem {
   background-color: var(--osdk-intent-primary-rest);
   color: var(--osdk-intent-primary-foreground);
 

--- a/packages/react-components/src/object-table/TableHeaderWithPopover.tsx
+++ b/packages/react-components/src/object-table/TableHeaderWithPopover.tsx
@@ -146,12 +146,23 @@ export function TableHeaderWithPopover<TData extends RowData>({
     });
   }, [header.column.id, setColumnPinning]);
 
+  // Clicking the direction a column is already sorted by removes its sort.
+  // `clearSorting` drops only this column, so the remaining columns of a
+  // multi-column sort keep their direction and relative order.
   const handleSortAscending = useCallback(() => {
+    if (header.column.getIsSorted() === "asc") {
+      header.column.clearSorting();
+      return;
+    }
     header.column.toggleSorting(false);
     setSorting?.([{ id: header.column.id, desc: false }]);
   }, [header.column, setSorting]);
 
   const handleSortDescending = useCallback(() => {
+    if (header.column.getIsSorted() === "desc") {
+      header.column.clearSorting();
+      return;
+    }
     header.column.toggleSorting(true);
     setSorting?.([{ id: header.column.id, desc: true }]);
   }, [header.column, setSorting]);

--- a/packages/react-components/src/object-table/__tests__/TableHeaderWithPopover.test.tsx
+++ b/packages/react-components/src/object-table/__tests__/TableHeaderWithPopover.test.tsx
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-import type { Header, Table } from "@tanstack/react-table";
+import type {
+  ColumnDef,
+  Header,
+  OnChangeFn,
+  SortingState,
+  Table,
+} from "@tanstack/react-table";
+import { getCoreRowModel, useReactTable } from "@tanstack/react-table";
 import {
   cleanup,
   fireEvent,
@@ -22,7 +29,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import React, { createRef } from "react";
+import React, { createRef, useCallback, useRef, useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { PortalContainerProvider } from "../../shared/PortalContainerContext.js";
@@ -31,6 +38,7 @@ import { TableHeaderWithPopover } from "../TableHeaderWithPopover.js";
 
 interface TestRow {
   name: string;
+  age: number;
 }
 
 describe(TableHeaderWithPopover, () => {
@@ -109,7 +117,195 @@ describe(TableHeaderWithPopover, () => {
       ).toBeTruthy();
     });
   });
+
+  describe("sort menu item toggling", () => {
+    it("removes the column's sort when the already-active ascending item is clicked", async () => {
+      const onSortingChanged = vi.fn();
+
+      render(
+        <SortMenuHarness
+          columnId="name"
+          initialSorting={[{ id: "name", desc: false }]}
+          onSortingChanged={onSortingChanged}
+        />
+      );
+
+      await clickSortMenuItem("name", "Sort ascending");
+
+      expect(latestSorting(onSortingChanged)).toEqual([]);
+    });
+
+    it("removes the column's sort when the already-active descending item is clicked", async () => {
+      const onSortingChanged = vi.fn();
+
+      render(
+        <SortMenuHarness
+          columnId="name"
+          initialSorting={[{ id: "name", desc: true }]}
+          onSortingChanged={onSortingChanged}
+        />
+      );
+
+      await clickSortMenuItem("name", "Sort descending");
+
+      expect(latestSorting(onSortingChanged)).toEqual([]);
+    });
+
+    it("keeps other columns sorted when one column of a multi-column sort is unsorted", async () => {
+      const onSortingChanged = vi.fn();
+
+      render(
+        <SortMenuHarness
+          columnId="name"
+          initialSorting={[
+            { id: "name", desc: false },
+            { id: "age", desc: true },
+          ]}
+          onSortingChanged={onSortingChanged}
+        />
+      );
+
+      await clickSortMenuItem("name", "Sort ascending");
+
+      expect(latestSorting(onSortingChanged)).toEqual([
+        { id: "age", desc: true },
+      ]);
+    });
+
+    it("still flips direction when the inactive item is clicked", async () => {
+      const onSortingChanged = vi.fn();
+
+      render(
+        <SortMenuHarness
+          columnId="name"
+          initialSorting={[{ id: "name", desc: false }]}
+          onSortingChanged={onSortingChanged}
+        />
+      );
+
+      await clickSortMenuItem("name", "Sort descending");
+
+      expect(latestSorting(onSortingChanged)).toEqual([
+        { id: "name", desc: true },
+      ]);
+    });
+
+    it("sorts an unsorted column ascending", async () => {
+      const onSortingChanged = vi.fn();
+
+      render(
+        <SortMenuHarness
+          columnId="name"
+          initialSorting={EMPTY_SORTING}
+          onSortingChanged={onSortingChanged}
+        />
+      );
+
+      await clickSortMenuItem("name", "Sort ascending");
+
+      expect(latestSorting(onSortingChanged)).toEqual([
+        { id: "name", desc: false },
+      ]);
+    });
+  });
 });
+
+const EMPTY_SORTING: SortingState = [];
+const TEST_DATA: TestRow[] = [{ name: "Alice", age: 30 }];
+const TEST_COLUMNS: Array<ColumnDef<TestRow>> = [
+  { accessorKey: "name", header: "Name" },
+  { accessorKey: "age", header: "Age" },
+];
+
+interface SortMenuHarnessProps {
+  columnId: string;
+  initialSorting: SortingState;
+  onSortingChanged: (sorting: SortingState) => void;
+}
+
+/**
+ * Renders the header menu for a single column of a real TanStack table so
+ * sort toggling is exercised against the actual table state rather than a
+ * hand-rolled mock.
+ */
+function SortMenuHarness({
+  columnId,
+  initialSorting,
+  onSortingChanged,
+}: SortMenuHarnessProps): React.ReactElement {
+  const portalContainerRef = useRef<HTMLDivElement>(null);
+  const [sorting, setSorting] = useState<SortingState>(initialSorting);
+  // Tracked in a ref as well so back-to-back updates within one click handler
+  // each see the previous value instead of the stale render-time state.
+  const sortingRef = useRef<SortingState>(initialSorting);
+
+  const onSortingChange: OnChangeFn<SortingState> = useCallback(
+    (updater) => {
+      const next =
+        typeof updater === "function" ? updater(sortingRef.current) : updater;
+      sortingRef.current = next;
+      setSorting(next);
+      onSortingChanged(next);
+    },
+    [onSortingChanged]
+  );
+
+  const table = useReactTable<TestRow>({
+    data: TEST_DATA,
+    columns: TEST_COLUMNS,
+    getCoreRowModel: getCoreRowModel(),
+    state: { sorting },
+    onSortingChange,
+    manualSorting: true,
+  });
+
+  const header = table
+    .getHeaderGroups()[0]
+    .headers.find((h) => h.column.id === columnId);
+  if (header == null) {
+    throw new Error(`No header found for column id=${columnId}`);
+  }
+
+  return (
+    <PortalContainerProvider container={portalContainerRef}>
+      <TableHeaderWithPopover
+        table={table}
+        header={header}
+        isColumnPinned={false}
+        featureFlags={{ showSortingItems: true }}
+      />
+      <div data-testid="header-menu-portal" ref={portalContainerRef} />
+    </PortalContainerProvider>
+  );
+}
+
+async function clickSortMenuItem(
+  columnId: string,
+  itemLabel: string
+): Promise<void> {
+  fireEvent.click(
+    screen.getByRole("button", {
+      name: `Open header menu for column with id=${columnId}`,
+    })
+  );
+
+  const item = await waitFor(() =>
+    screen.getByRole("menuitem", { name: itemLabel })
+  );
+
+  fireEvent.click(item);
+}
+
+/**
+ * The final sorting state the header menu settled on. The menu may notify
+ * more than once per click, so only the last value is meaningful.
+ */
+function latestSorting(
+  onSortingChanged: ReturnType<typeof vi.fn>
+): SortingState | undefined {
+  const calls = onSortingChanged.mock.calls;
+  return calls.at(-1)?.[0] as SortingState | undefined;
+}
 
 function createTable(): Table<TestRow> {
   return {

--- a/packages/react-components/src/object-table/__tests__/TableHeaderWithPopover.test.tsx
+++ b/packages/react-components/src/object-table/__tests__/TableHeaderWithPopover.test.tsx
@@ -36,6 +36,8 @@ import { PortalContainerProvider } from "../../shared/PortalContainerContext.js"
 import { ObjectTableLabelsProvider } from "../ObjectTableLabels.js";
 import { TableHeaderWithPopover } from "../TableHeaderWithPopover.js";
 
+import styles from "../TableHeaderWithPopover.module.css";
+
 interface TestRow {
   name: string;
   age: number;
@@ -118,6 +120,42 @@ describe(TableHeaderWithPopover, () => {
     });
   });
 
+  describe("active menu item styling for pinning", () => {
+    it("marks the unpin item active while the column is pinned", async () => {
+      render(
+        <PortalContainerProvider container={createRef<HTMLDivElement>()}>
+          <TableHeaderWithPopover
+            table={createTable()}
+            header={createHeader()}
+            isColumnPinned="left"
+            featureFlags={{ showPinningItems: true }}
+          />
+        </PortalContainerProvider>
+      );
+
+      await openHeaderMenu("name");
+
+      expect(activeStateByMenuItem()).toEqual({ "Unpin Column": true });
+    });
+
+    it("does not mark the pin item active while the column is unpinned", async () => {
+      render(
+        <PortalContainerProvider container={createRef<HTMLDivElement>()}>
+          <TableHeaderWithPopover
+            table={createTable()}
+            header={createHeader()}
+            isColumnPinned={false}
+            featureFlags={{ showPinningItems: true }}
+          />
+        </PortalContainerProvider>
+      );
+
+      await openHeaderMenu("name");
+
+      expect(activeStateByMenuItem()).toEqual({ "Pin column": false });
+    });
+  });
+
   describe("sort menu item toggling", () => {
     it("removes the column's sort when the already-active ascending item is clicked", async () => {
       const onSortingChanged = vi.fn();
@@ -188,6 +226,59 @@ describe(TableHeaderWithPopover, () => {
       expect(latestSorting(onSortingChanged)).toEqual([
         { id: "name", desc: true },
       ]);
+    });
+
+    it("marks the matching direction item active while leaving the other inactive", async () => {
+      render(
+        <SortMenuHarness
+          columnId="name"
+          initialSorting={[{ id: "name", desc: false }]}
+          onSortingChanged={vi.fn()}
+        />
+      );
+
+      await openHeaderMenu("name");
+
+      expect(activeStateByMenuItem()).toEqual({
+        "Sort ascending": true,
+        "Sort descending": false,
+        "Clear all sorts": false,
+      });
+    });
+
+    it("moves the active marker to the descending item when sorted descending", async () => {
+      render(
+        <SortMenuHarness
+          columnId="name"
+          initialSorting={[{ id: "name", desc: true }]}
+          onSortingChanged={vi.fn()}
+        />
+      );
+
+      await openHeaderMenu("name");
+
+      expect(activeStateByMenuItem()).toEqual({
+        "Sort ascending": false,
+        "Sort descending": true,
+        "Clear all sorts": false,
+      });
+    });
+
+    it("marks no direction item active while the column is unsorted", async () => {
+      render(
+        <SortMenuHarness
+          columnId="name"
+          initialSorting={EMPTY_SORTING}
+          onSortingChanged={vi.fn()}
+        />
+      );
+
+      await openHeaderMenu("name");
+
+      expect(activeStateByMenuItem()).toEqual({
+        "Sort ascending": false,
+        "Sort descending": false,
+      });
     });
 
     it("sorts an unsorted column ascending", async () => {
@@ -279,21 +370,38 @@ function SortMenuHarness({
   );
 }
 
-async function clickSortMenuItem(
-  columnId: string,
-  itemLabel: string
-): Promise<void> {
+async function openHeaderMenu(columnId: string): Promise<void> {
   fireEvent.click(
     screen.getByRole("button", {
       name: `Open header menu for column with id=${columnId}`,
     })
   );
 
-  const item = await waitFor(() =>
-    screen.getByRole("menuitem", { name: itemLabel })
-  );
+  await waitFor(() => screen.getAllByRole("menuitem"));
+}
 
-  fireEvent.click(item);
+async function clickSortMenuItem(
+  columnId: string,
+  itemLabel: string
+): Promise<void> {
+  await openHeaderMenu(columnId);
+  fireEvent.click(screen.getByRole("menuitem", { name: itemLabel }));
+}
+
+/**
+ * Whether each open menu item carries the active-styling class, keyed by
+ * label. Vitest stubs CSS modules, so this asserts the class is applied to
+ * the right item — not that the stylesheet renders it.
+ */
+function activeStateByMenuItem(): Record<string, boolean> {
+  return Object.fromEntries(
+    screen
+      .getAllByRole("menuitem")
+      .map((item) => [
+        item.textContent?.trim() ?? "",
+        item.classList.contains(styles.osdkHeaderActiveMenuItem),
+      ])
+  );
 }
 
 /**


### PR DESCRIPTION
## Repro

1. Render `ObjectTable`/`BaseTable` with `headerMenuFeatureFlags={{ showSortingItems: true }}`
2. Open a column's header menu, click **Sort ascending**
3. Open it again, click **Sort ascending** a second time

Expected: the column returns to unsorted. Actual: it stays sorted ascending.

## Root cause

`toggleSorting` was always called with an explicit direction, so TanStack never took its sort-removal branch. The `setSorting([{ ... }])` that followed also replaced the whole sorting array, dropping any other multi-sorted columns.

## Fix

Clicking the direction a column is already sorted by now short-circuits to `Column.clearSorting()`, which removes only that column — the rest of a multi-column sort keeps its direction and relative order. Clicking the *inactive* direction still flips, unchanged.

## Regression coverage

5 cases in `TableHeaderWithPopover.test.tsx`, driven against a real TanStack table (not a mock) so the multi-sort assertion is meaningful:

- active asc item => unsorted
- active desc item => unsorted
- `[name asc, age desc]`, unsort `name` => `[age desc]`
- inactive item still flips direction
- unsorted column still sorts asc

Also verified in Storybook (`BaseTable > With Sorting`) in a real browser.