### PR TITLE
Fix ObjectTable last-row border landing on an off-screen virtualized row

### DIFF
--- a/.changeset/objecttable-last-row-border.md
+++ b/.changeset/objecttable-last-row-border.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Fix `ObjectTable` bottom border landing on an off-screen virtualized row instead of the last row

--- a/packages/react-components/src/object-table/LoadingRow.tsx
+++ b/packages/react-components/src/object-table/LoadingRow.tsx
@@ -28,6 +28,12 @@ interface LoadingRowProps<TData extends RowData> {
   translateY: number;
   rowHeight?: number;
   columnWidth?: number;
+  /**
+   * Whether this row sits at the visual bottom of the table body and should
+   * carry the terminating border. `LoadingStateTable` renders a whole column
+   * of skeleton rows, so only its final row sets this.
+   */
+  isLastRow?: boolean;
 }
 
 export function LoadingRow<TData extends RowData>({
@@ -36,10 +42,12 @@ export function LoadingRow<TData extends RowData>({
   translateY,
   rowHeight = DEFAULT_ROW_HEIGHT,
   columnWidth = DEFAULT_COLUMN_WIDTH,
+  isLastRow = false,
 }: LoadingRowProps<TData>): React.ReactElement {
   return (
     <tr
       className={rowStyles.osdkTableRow}
+      data-last-row={isLastRow ? "true" : undefined}
       style={{
         height: `${rowHeight}px`,
         transform: `translateY(${translateY}px)`,

--- a/packages/react-components/src/object-table/LoadingStateTable.tsx
+++ b/packages/react-components/src/object-table/LoadingStateTable.tsx
@@ -127,6 +127,7 @@ export function LoadingStateTable<TData extends RowData>({
             translateY={rowHeight * index}
             rowHeight={rowHeight}
             columnWidth={columnWidth}
+            isLastRow={index === loadingRowCount - 1}
           />
         ))}
       </tbody>

--- a/packages/react-components/src/object-table/TableBody.tsx
+++ b/packages/react-components/src/object-table/TableBody.tsx
@@ -93,6 +93,10 @@ export function TableBody<TData extends RowData>({
             setFocusedRowId={setFocusedRowId}
             isInEditMode={isInEditMode}
             getRowAttributes={getRowAttributes}
+            // The terminating border belongs to whichever row is visually
+            // last. While loading more, that's the skeleton row below —
+            // marking both would butt two 1px borders into a 2px line.
+            isLastRow={!isLoadingMore && virtualRow.index === rows.length - 1}
           />
         );
       })}
@@ -102,6 +106,7 @@ export function TableBody<TData extends RowData>({
           translateY={totalSize}
           rowHeight={rowHeight}
           columnCount={headers.length}
+          isLastRow={true}
         />
       )}
     </tbody>

--- a/packages/react-components/src/object-table/TableRow.module.css
+++ b/packages/react-components/src/object-table/TableRow.module.css
@@ -23,7 +23,10 @@
   border-top: var(--osdk-table-row-divider);
   border-bottom: var(--osdk-table-border-width) solid transparent;
 
-  &:last-child {
+  /* Terminating border for the visually last row — keyed off an explicit
+     attribute, not :last-child, because rows are virtualized and the last
+     rendered row is usually a trailing overscan row below the fold. */
+  &[data-last-row="true"] {
     border-bottom: var(--osdk-table-border);
   }
 

--- a/packages/react-components/src/object-table/TableRow.tsx
+++ b/packages/react-components/src/object-table/TableRow.tsx
@@ -34,6 +34,12 @@ interface TableRowProps<TData extends RowData> {
   setFocusedRowId?: (id: string | null) => void;
   isInEditMode?: boolean;
   getRowAttributes?: (object: TData) => Record<string, string | undefined>;
+  /**
+   * Whether this row sits at the visual bottom of the table body and should
+   * carry the terminating border. Derived from the data index rather than DOM
+   * position because rows are virtualized.
+   */
+  isLastRow?: boolean;
 }
 
 export function TableRow<TData extends RowData>({
@@ -45,6 +51,7 @@ export function TableRow<TData extends RowData>({
   setFocusedRowId,
   isInEditMode,
   getRowAttributes,
+  isLastRow = false,
 }: TableRowProps<TData>): React.ReactElement {
   // Use the capture phase so row focus is set even when children call
   // stopPropagation on the click event (e.g. DatePicker's input).
@@ -75,6 +82,7 @@ export function TableRow<TData extends RowData>({
       data-selected={row.getIsSelected()}
       data-focused={isFocused}
       data-row-parity={virtualRow.index % 2 === 0 ? "even" : "odd"}
+      data-last-row={isLastRow ? "true" : undefined}
       className={styles.osdkTableRow}
       style={{
         height: `${virtualRow.size}px`,

--- a/packages/react-components/src/object-table/__tests__/TableBody.test.tsx
+++ b/packages/react-components/src/object-table/__tests__/TableBody.test.tsx
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import { cleanup, render } from "@testing-library/react";
+import React, { useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { LoadingStateTable } from "../LoadingStateTable.js";
+import { TableBody } from "../TableBody.js";
+import {
+  DEFAULT_ROW_HEIGHT,
+  VIRTUALIZER_OVERSCAN,
+} from "../utils/constants.js";
+
+interface TestRow {
+  id: string;
+  name: string;
+}
+
+const COLUMNS = [{ accessorKey: "name", id: "name", header: "Name" }];
+
+/**
+ * happy-dom reports every element as 0x0. `@tanstack/react-virtual` sizes its
+ * window from the scroll element's `offsetHeight`, so without this stub the
+ * virtualizer renders nothing at all.
+ */
+const VIEWPORT_HEIGHT = DEFAULT_ROW_HEIGHT * 10;
+
+/**
+ * Rows the virtualizer keeps mounted at scroll offset 0: the visible window
+ * plus `VIRTUALIZER_OVERSCAN` trailing rows.
+ */
+const RENDERED_ROW_COUNT =
+  VIEWPORT_HEIGHT / DEFAULT_ROW_HEIGHT + VIRTUALIZER_OVERSCAN;
+
+function makeRows(count: number): TestRow[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `row-${index}`,
+    name: `Row ${index}`,
+  }));
+}
+
+/**
+ * Renders `TableBody` against a real TanStack table instance. The scroll
+ * container has no layout in happy-dom, so the virtualizer keeps its window
+ * near the top of the list — which is exactly the condition under which a
+ * DOM-position-based last-row selector misfires.
+ */
+function TableBodyHarness({
+  rowCount,
+  isLoadingMore = false,
+}: {
+  rowCount: number;
+  isLoadingMore?: boolean;
+}): React.ReactElement {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const table = useReactTable<TestRow>({
+    data: makeRows(rowCount),
+    columns: COLUMNS,
+    getCoreRowModel: getCoreRowModel(),
+    getRowId: (row) => row.id,
+  });
+
+  return (
+    <div ref={containerRef}>
+      <table>
+        <TableBody
+          rows={table.getRowModel().rows}
+          tableContainerRef={containerRef}
+          headerGroups={table.getHeaderGroups()}
+          isLoadingMore={isLoadingMore}
+        />
+      </table>
+    </div>
+  );
+}
+
+/** Renders the full-table loading skeleton (`LoadingStateTable`). */
+function LoadingSkeletonHarness(): React.ReactElement {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const table = useReactTable<TestRow>({
+    data: makeRows(0),
+    columns: COLUMNS,
+    getCoreRowModel: getCoreRowModel(),
+    getRowId: (row) => row.id,
+  });
+
+  return (
+    <div ref={containerRef}>
+      <table>
+        <LoadingStateTable
+          table={table}
+          tableContainerRef={containerRef}
+          headerGroups={table.getHeaderGroups()}
+        />
+      </table>
+    </div>
+  );
+}
+
+function renderedRows(container: HTMLElement): HTMLTableRowElement[] {
+  return Array.from(container.querySelectorAll("tbody tr"));
+}
+
+function lastRowMarked(container: HTMLElement): HTMLTableRowElement[] {
+  return renderedRows(container).filter(
+    (row) => row.getAttribute("data-last-row") === "true"
+  );
+}
+
+describe(TableBody, () => {
+  const originalDescriptors = new Map<string, PropertyDescriptor | undefined>();
+
+  function stubLayout(property: "offsetHeight" | "offsetWidth", value: number) {
+    originalDescriptors.set(
+      property,
+      Object.getOwnPropertyDescriptor(HTMLElement.prototype, property)
+    );
+    Object.defineProperty(HTMLElement.prototype, property, {
+      configurable: true,
+      get: () => value,
+    });
+  }
+
+  beforeEach(() => {
+    stubLayout("offsetHeight", VIEWPORT_HEIGHT);
+    stubLayout("offsetWidth", 800);
+  });
+
+  afterEach(() => {
+    cleanup();
+    for (const [property, descriptor] of originalDescriptors) {
+      if (descriptor != null) {
+        Object.defineProperty(HTMLElement.prototype, property, descriptor);
+      } else {
+        Reflect.deleteProperty(HTMLElement.prototype, property);
+      }
+    }
+    originalDescriptors.clear();
+  });
+
+  describe("last row bottom border", () => {
+    it("marks the final data row so it can carry the terminating border", () => {
+      const { container } = render(<TableBodyHarness rowCount={3} />);
+
+      const rows = renderedRows(container);
+      expect(rows).toHaveLength(3);
+
+      const marked = lastRowMarked(container);
+      expect(marked).toHaveLength(1);
+      expect(marked[0]).toBe(rows[rows.length - 1]);
+    });
+
+    it("does not mark the last rendered row when it is only an overscan row", () => {
+      // Far more rows than the virtualizer renders, so the final data row is
+      // outside the virtual window. Keying the border off DOM position would
+      // paint it on an arbitrary mid-list row instead.
+      const { container } = render(<TableBodyHarness rowCount={500} />);
+
+      const rows = renderedRows(container);
+      expect(rows).toHaveLength(RENDERED_ROW_COUNT);
+
+      // The DOM's `:last-child` here is a trailing overscan row sitting below
+      // the fold — not row 499 — which is why the border cannot be keyed off
+      // DOM position.
+      const lastRendered = rows[rows.length - 1];
+      expect(lastRendered.textContent).toContain(
+        `Row ${RENDERED_ROW_COUNT - 1}`
+      );
+
+      expect(lastRowMarked(container)).toHaveLength(0);
+    });
+
+    it("hands the terminating border to the loading row while fetching more", () => {
+      const { container } = render(
+        <TableBodyHarness rowCount={3} isLoadingMore={true} />
+      );
+
+      const rows = renderedRows(container);
+      // 3 data rows plus the loading skeleton row.
+      expect(rows).toHaveLength(4);
+
+      // Exactly one border, on the skeleton row at the visual bottom. Marking
+      // the last data row too would butt its 1px bottom border against the
+      // skeleton's 1px top border and render a doubled 2px line.
+      const marked = lastRowMarked(container);
+      expect(marked).toHaveLength(1);
+      expect(marked[0]).toBe(rows[3]);
+      expect(rows[2].getAttribute("data-last-row")).toBeNull();
+    });
+
+    it("gives the full-table loading skeleton exactly one terminating border", () => {
+      // LoadingStateTable renders a whole column of LoadingRows, so the
+      // attribute must not be baked into LoadingRow itself.
+      const { container } = render(<LoadingSkeletonHarness />);
+
+      const rows = renderedRows(container);
+      expect(rows.length).toBeGreaterThan(1);
+
+      const marked = lastRowMarked(container);
+      expect(marked).toHaveLength(1);
+      expect(marked[0]).toBe(rows[rows.length - 1]);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

The last row of the table body looked visually unterminated. A `tr:last-child` rule already existed to draw the terminating border, but `TableBody` virtualizes rows — so the DOM's last child is normally a trailing overscan row sitting below the fold, not the final data row.

Measured in a browser (500 rows, 400px viewport, `overscan: 5`):

| scroll state | rendered | row that got the border |
| --- | --- | --- |
| at top | Row 0–14 | Row 14 (below the fold) |
| mid-scroll | Row 95–114 | Row 114 (below the fold) |
| scrolled to bottom | Row 486–499 | Row 499 (correct, by luck) |
| full-table loading skeleton | 9 rows | **all 9** |

So the border only landed correctly when scrolled fully to the bottom, and the full-table skeleton drew one under every row.

## Fix

Mark the visually last row explicitly with `data-last-row`, derived from the **data index** rather than DOM position, and key the CSS off that attribute. This mirrors the precedent already established for zebra striping one line above in the same file:

```css
/* Zebra rows — keyed off data index, not DOM position, because rows are virtualized */
```

While fetching more, the marker goes to the `LoadingRow` instead of the last data row — marking both would butt the data row's 1px `border-bottom` against the skeleton's 1px `border-top` and render a doubled 2px line.

Reuses the existing `--osdk-table-border` token. No hardcoded colors, no new CSS variables, no public API change (`check-api` reports no delta; `TableRow`/`TableBody`/`LoadingRow` are internal).

## Verification

After the fix, exactly one row carries the border in every state — 0 at top and mid-scroll (nothing to terminate there; separators come from each row's `border-top`), 1 on Row 499 at the bottom, 1 on the skeleton, 0 in the empty state (header keeps its own border).

## Regression test

`__tests__/TableBody.test.tsx` (new — no `TableBody` test existed) pins all four cases:

- the final data row is marked
- the last *rendered* row is not marked when it is only an overscan row
- the loading row takes the border while fetching more
- the full-table loading skeleton gets exactly one border, not one per row

The suite stubs `offsetHeight`, since happy-dom reports every element as 0x0 and the virtualizer would otherwise render nothing.
