### PR TITLE
Fix ObjectTable row keeping its highlight after being unselected

### DIFF
--- a/.changeset/unhighlight-objecttable-row-on-unselect.md
+++ b/.changeset/unhighlight-objecttable-row-on-unselect.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Fix `ObjectTable` rows keeping the selected highlight after being unselected via the checkbox

--- a/packages/react-components-storybook/src/stories/ObjectTable/Features/Selection.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/Features/Selection.stories.tsx
@@ -125,9 +125,7 @@ export const MultipleSelection: Story = {
     await expect(firstRow).toBeChecked();
     await expect(secondRow).toBeChecked();
 
-    // Unselecting via the checkbox must drop the row's highlight entirely.
-    // `data-focused` renders the same active background as `data-selected`, so
-    // a checkbox click must not focus the row on its way through.
+    // a checkbox click must not focus the row
     await userEvent.click(firstRow);
     await expect(firstRow).not.toBeChecked();
     await expect(rowContaining(firstRow)).toHaveAttribute(

--- a/packages/react-components-storybook/src/stories/ObjectTable/Features/Selection.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/Features/Selection.stories.tsx
@@ -125,6 +125,16 @@ export const MultipleSelection: Story = {
     await expect(firstRow).toBeChecked();
     await expect(secondRow).toBeChecked();
 
+    // Unselecting via the checkbox must drop the row's highlight entirely.
+    // `data-focused` renders the same active background as `data-selected`, so
+    // a checkbox click must not focus the row on its way through.
+    await userEvent.click(firstRow);
+    await expect(firstRow).not.toBeChecked();
+    await expect(rowContaining(firstRow)).toHaveAttribute(
+      "data-focused",
+      "false"
+    );
+
     // The header checkbox toggles every row. Once rows are selected its label
     // flips to "Deselect all rows", so clicking it clears the selection.
     await userEvent.click(await findDeselectAllCheckbox(canvas));

--- a/packages/react-components/docs/ObjectTable.md
+++ b/packages/react-components/docs/ObjectTable.md
@@ -1584,10 +1584,11 @@ You can also attach custom `data-*` attributes per row with the `getRowAttribute
 
 **Data attributes**
 
-| Attribute       | Values                       | Meaning                                                |
-| --------------- | ---------------------------- | ------------------------------------------------------ |
-| `data-pinned`   | `left` \| `right` \| `false` | Mirrors the column's pinning state.                    |
-| `data-editable` | `true` \| (absent)           | Present when the cell is editable in the current mode. |
+| Attribute        | Values                       | Meaning                                                |
+| ---------------- | ---------------------------- | ------------------------------------------------------ |
+| `data-column-id` | Column id                    | The id of the column the cell belongs to.              |
+| `data-pinned`    | `left` \| `right` \| `false` | Mirrors the column's pinning state.                    |
+| `data-editable`  | `true` \| (absent)           | Present when the cell is editable in the current mode. |
 
 **CSS variables**
 

--- a/packages/react-components/src/object-table/TableCell.tsx
+++ b/packages/react-components/src/object-table/TableCell.tsx
@@ -72,6 +72,7 @@ export function TableCell<TData extends RowData>({
     <>
       <td
         ref={tdRef}
+        data-column-id={cell.column.id}
         data-pinned={cell.column.getIsPinned()}
         data-editable={isEditable ? "true" : undefined}
         className={styles.osdkTableCell}

--- a/packages/react-components/src/object-table/TableRow.tsx
+++ b/packages/react-components/src/object-table/TableRow.tsx
@@ -51,12 +51,9 @@ export function TableRow<TData extends RowData>({
   // stopPropagation on the click event (e.g. DatePicker's input).
   const handleClickCapture = useCallback(
     (event: React.MouseEvent<HTMLTableRowElement>) => {
-      // Toggling the selection checkbox is not a row interaction, so it must
-      // not focus the row: focus and selection share the same highlight, so a
-      // lingering focus would leave the row looking selected after it was
-      // unselected. `SelectionCell` calls stopPropagation for the same reason,
-      // but that runs in the bubble phase — too late to stop this handler.
       const target = event.target as Element | null;
+      // Do not set row as focused on checkbox selection
+      // The row will be highlighted when it is selected
       if (
         target?.closest?.(`[data-column-id="${SELECTION_COLUMN_ID}"]`) != null
       ) {

--- a/packages/react-components/src/object-table/TableRow.tsx
+++ b/packages/react-components/src/object-table/TableRow.tsx
@@ -19,6 +19,7 @@ import type { VirtualItem } from "@tanstack/react-virtual";
 import React, { useCallback, useMemo } from "react";
 
 import { TableCell } from "./TableCell.js";
+import { SELECTION_COLUMN_ID } from "./utils/constants.js";
 
 import styles from "./TableRow.module.css";
 
@@ -48,9 +49,23 @@ export function TableRow<TData extends RowData>({
 }: TableRowProps<TData>): React.ReactElement {
   // Use the capture phase so row focus is set even when children call
   // stopPropagation on the click event (e.g. DatePicker's input).
-  const handleClickCapture = useCallback(() => {
-    setFocusedRowId?.(row.id);
-  }, [row.id, setFocusedRowId]);
+  const handleClickCapture = useCallback(
+    (event: React.MouseEvent<HTMLTableRowElement>) => {
+      // Toggling the selection checkbox is not a row interaction, so it must
+      // not focus the row: focus and selection share the same highlight, so a
+      // lingering focus would leave the row looking selected after it was
+      // unselected. `SelectionCell` calls stopPropagation for the same reason,
+      // but that runs in the bubble phase — too late to stop this handler.
+      const target = event.target as Element | null;
+      if (
+        target?.closest?.(`[data-column-id="${SELECTION_COLUMN_ID}"]`) != null
+      ) {
+        return;
+      }
+      setFocusedRowId?.(row.id);
+    },
+    [row.id, setFocusedRowId]
+  );
 
   const handleClick = useCallback(() => {
     if (!isInEditMode) {

--- a/packages/react-components/src/object-table/__tests__/TableRow.test.tsx
+++ b/packages/react-components/src/object-table/__tests__/TableRow.test.tsx
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ColumnDef, RowSelectionState } from "@tanstack/react-table";
+import { getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import type { VirtualItem } from "@tanstack/react-virtual";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { SelectionCell } from "../SelectionCells.js";
+import { TableRow } from "../TableRow.js";
+import { SELECTION_COLUMN_ID } from "../utils/constants.js";
+
+interface TestRow {
+  id: string;
+  name: string;
+}
+
+const DATA: TestRow[] = [
+  { id: "row-1", name: "Alice" },
+  { id: "row-2", name: "Bob" },
+];
+
+const virtualRow = (index: number): VirtualItem => ({
+  index,
+  key: index,
+  start: index * 40,
+  end: (index + 1) * 40,
+  size: 40,
+  lane: 0,
+});
+
+/**
+ * Stand-in for `useSelectionColumn`: holds the handler in a ref so the column
+ * defs stay referentially stable across selection changes. Recreating them
+ * would remount the checkbox between clicks.
+ */
+function useTestColumns(
+  onToggleRow: (rowId: string) => void
+): ColumnDef<TestRow>[] {
+  const onToggleRowRef = useRef(onToggleRow);
+  onToggleRowRef.current = onToggleRow;
+
+  return useMemo(
+    () => [
+      {
+        id: SELECTION_COLUMN_ID,
+        cell: ({ row }) => (
+          <SelectionCell row={row} onToggleRow={onToggleRowRef.current} />
+        ),
+      },
+      { id: "name", accessorKey: "name" },
+    ],
+    []
+  );
+}
+
+/**
+ * Mirrors the real table wiring: the selection column toggles selection
+ * state (as `useRowSelection` does) while `TableRow` owns focus via its
+ * capture-phase click handler (as `BaseTable` + `useFocusedRow` do).
+ */
+function TestTable(): React.ReactElement {
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [focusedRowId, setFocusedRowId] = useState<string | null>(null);
+
+  // Computes from the current render's snapshot rather than `prev`, matching
+  // `useRowSelection`. That makes the toggle idempotent, which matters because
+  // base-ui's checkbox dispatches two clicks per interaction (the visible
+  // element plus the hidden input it forwards to).
+  const onToggleRow = useCallback(
+    (rowId: string) => {
+      setRowSelection(rowSelection[rowId] ? {} : { [rowId]: true });
+    },
+    [rowSelection]
+  );
+
+  const columns = useTestColumns(onToggleRow);
+
+  const table = useReactTable<TestRow>({
+    data: DATA,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    state: { rowSelection },
+    enableRowSelection: true,
+    getRowId: (row) => row.id,
+  });
+
+  return (
+    <table>
+      <tbody>
+        {table.getRowModel().rows.map((row) => (
+          <TableRow
+            key={row.id}
+            row={row}
+            virtualRow={virtualRow(row.index)}
+            isFocused={focusedRowId === row.id}
+            setFocusedRowId={setFocusedRowId}
+          />
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+const firstRow = () => screen.getByText("Alice").closest("tr")!;
+
+describe("TableRow", () => {
+  afterEach(cleanup);
+
+  describe("selection highlight", () => {
+    it("clears the highlight when a row is unselected via its checkbox", () => {
+      render(<TestTable />);
+      const checkbox = () => screen.getByLabelText("Select row 1");
+
+      fireEvent.click(checkbox());
+      expect(firstRow().getAttribute("data-selected")).toBe("true");
+
+      fireEvent.click(checkbox());
+      // Neither attribute may linger — both render the identical
+      // `--osdk-table-row-bg-active` highlight.
+      expect(firstRow().getAttribute("data-selected")).toBe("false");
+      expect(firstRow().getAttribute("data-focused")).toBe("false");
+    });
+
+    it("still focuses the row when the row body is clicked", () => {
+      render(<TestTable />);
+
+      fireEvent.click(screen.getByText("Alice"));
+
+      expect(firstRow().getAttribute("data-focused")).toBe("true");
+    });
+  });
+});

--- a/packages/react-components/src/object-table/__tests__/TableRow.test.tsx
+++ b/packages/react-components/src/object-table/__tests__/TableRow.test.tsx
@@ -44,15 +44,13 @@ const virtualRow = (index: number): VirtualItem => ({
   lane: 0,
 });
 
-/**
- * Stand-in for `useSelectionColumn`: holds the handler in a ref so the column
- * defs stay referentially stable across selection changes. Recreating them
- * would remount the checkbox between clicks.
- */
 function useTestColumns(
   onToggleRow: (rowId: string) => void
 ): ColumnDef<TestRow>[] {
+  // Ref-held handler keeps the column defs stable; recreating them would remount
+  // the checkbox between clicks.
   const onToggleRowRef = useRef(onToggleRow);
+
   onToggleRowRef.current = onToggleRow;
 
   return useMemo(
@@ -69,19 +67,13 @@ function useTestColumns(
   );
 }
 
-/**
- * Mirrors the real table wiring: the selection column toggles selection
- * state (as `useRowSelection` does) while `TableRow` owns focus via its
- * capture-phase click handler (as `BaseTable` + `useFocusedRow` do).
- */
 function TestTable(): React.ReactElement {
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [focusedRowId, setFocusedRowId] = useState<string | null>(null);
 
-  // Computes from the current render's snapshot rather than `prev`, matching
-  // `useRowSelection`. That makes the toggle idempotent, which matters because
-  // base-ui's checkbox dispatches two clicks per interaction (the visible
-  // element plus the hidden input it forwards to).
+  // Toggling off the render snapshot rather than `prev` keeps this idempotent,
+  // as `useRowSelection` is: base-ui's checkbox dispatches two clicks per
+  // interaction (the visible element plus the hidden input it forwards to).
   const onToggleRow = useCallback(
     (rowId: string) => {
       setRowSelection(rowSelection[rowId] ? {} : { [rowId]: true });
@@ -131,8 +123,6 @@ describe("TableRow", () => {
       expect(firstRow().getAttribute("data-selected")).toBe("true");
 
       fireEvent.click(checkbox());
-      // Neither attribute may linger — both render the identical
-      // `--osdk-table-row-bg-active` highlight.
       expect(firstRow().getAttribute("data-selected")).toBe("false");
       expect(firstRow().getAttribute("data-focused")).toBe("false");
     });


### PR DESCRIPTION
## Repro

1. Render `<ObjectTable selectionMode="multiple" />`
2. Tick a row's checkbox — the row highlights
3. Untick it — the row *stays* highlighted

## Root cause

The bug is in the focused-row state, not selection state or CSS class application.

`TableRow` sets the focused row from an `onClickCapture` handler on the `<tr>` (deliberate: children like DatePicker call `stopPropagation`). `SelectionCell` also calls `stopPropagation` to keep a checkbox click from counting as a row click — but that runs in the bubble phase, after the capture handler has already fired. So ticking a checkbox focused the row.

`TableRow.module.css` styles `[data-focused="true"]` identically to `[data-selected="true"]` (same `--osdk-table-row-bg-active` and border), so the lingering focus was visually indistinguishable from still-selected.

## Fix

Skip focus for clicks originating in the selection column, identified via a new `data-column-id` attribute on `<td>`. Row-body clicks focus as before.