### PR TITLE
Fit ObjectTable columns to the parent container width

### DIFF
--- a/.changeset/objecttable-columns-fill-container.md
+++ b/.changeset/objecttable-columns-fill-container.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+Stretch `ObjectTable` columns to fill the parent container instead of leaving dead space to the right of the last column. Columns given an explicit `width`, pinned columns, and columns the user has resized keep their exact width; the rest share the leftover width in proportion to their current width, up to any `maxWidth`. `LoadingCell` accepts a new optional `flexGrow` prop so custom loading rows can stay aligned with the stretched header.

--- a/.changeset/objecttable-columns-fill-container.md
+++ b/.changeset/objecttable-columns-fill-container.md
@@ -2,4 +2,4 @@
 "@osdk/react-components": minor
 ---
 
-Stretch `ObjectTable` columns to fill the parent container instead of leaving dead space to the right of the last column. Columns given an explicit `width`, pinned columns, and columns the user has resized keep their exact width; the rest share the leftover width in proportion to their current width, up to any `maxWidth`. `LoadingCell` accepts a new optional `flexGrow` prop so custom loading rows can stay aligned with the stretched header.
+Stretch `ObjectTable` columns to fill the parent container instead of leaving dead space to the right of the last column. Columns given an explicit `width`, pinned columns, and columns the user has resized keep their exact width; the rest share the leftover width in proportion to their current width, up to any `maxWidth`. Resizing a column only takes width from, or gives width to, the columns to its right, so the divider being dragged follows the pointer; the rightmost column takes up any width released by the drag. `LoadingCell` accepts a new optional `flexGrow` prop so custom loading rows can stay aligned with the stretched header.

--- a/packages/react-components/src/object-table/LoadingCell.tsx
+++ b/packages/react-components/src/object-table/LoadingCell.tsx
@@ -30,9 +30,15 @@ export function LoadingCellContent(): React.ReactElement {
   );
 }
 
-export function LoadingCell({ width }: { width: number }): React.ReactElement {
+export function LoadingCell({
+  width,
+  flexGrow,
+}: {
+  width: number;
+  flexGrow?: number;
+}): React.ReactElement {
   return (
-    <td className={cellStyles.osdkTableCell} style={{ width }}>
+    <td className={cellStyles.osdkTableCell} style={{ width, flexGrow }}>
       <LoadingCellContent />
     </td>
   );

--- a/packages/react-components/src/object-table/LoadingRow.tsx
+++ b/packages/react-components/src/object-table/LoadingRow.tsx
@@ -19,6 +19,7 @@ import React from "react";
 
 import { LoadingCell } from "./LoadingCell.js";
 import { DEFAULT_COLUMN_WIDTH, DEFAULT_ROW_HEIGHT } from "./utils/constants.js";
+import { getColumnFlexGrow } from "./utils/getColumnPinningStyles.js";
 
 import rowStyles from "./TableRow.module.css";
 
@@ -48,9 +49,19 @@ export function LoadingRow<TData extends RowData>({
       {
         <>
           {Array.from({ length: columnCount }).map((_, index) => {
-            const width =
-              headers.length > index ? headers[index].getSize() : columnWidth;
-            return <LoadingCell key={`loading-cell-${index}`} width={width} />;
+            const header = headers.length > index ? headers[index] : undefined;
+            return (
+              <LoadingCell
+                key={`loading-cell-${index}`}
+                width={header?.getSize() ?? columnWidth}
+                // Stretch alongside the real header cells above, which are laid
+                // out by getColumnPinningStyles, so the skeleton columns stay
+                // lined up with them.
+                flexGrow={
+                  header != null ? getColumnFlexGrow(header.column) : undefined
+                }
+              />
+            );
           })}
         </>
       }

--- a/packages/react-components/src/object-table/TableCell.tsx
+++ b/packages/react-components/src/object-table/TableCell.tsx
@@ -59,10 +59,7 @@ export function TableCell<TData extends RowData>({
     !!renderCellContextMenu;
 
   const table = cell.getContext().table;
-  const { columnStyles } = getColumnPinningStyles(
-    cell.column,
-    table.getState().columnSizing
-  );
+  const { columnStyles } = getColumnPinningStyles(cell.column, table);
 
   const tableMeta = table.options.meta;
   const columnMeta = cell.column.columnDef.meta;

--- a/packages/react-components/src/object-table/TableCell.tsx
+++ b/packages/react-components/src/object-table/TableCell.tsx
@@ -58,9 +58,13 @@ export function TableCell<TData extends RowData>({
     !!popoverPosition &&
     !!renderCellContextMenu;
 
-  const { columnStyles } = getColumnPinningStyles(cell.column);
+  const table = cell.getContext().table;
+  const { columnStyles } = getColumnPinningStyles(
+    cell.column,
+    table.getState().columnSizing
+  );
 
-  const tableMeta = cell.getContext().table.options.meta;
+  const tableMeta = table.options.meta;
   const columnMeta = cell.column.columnDef.meta;
   const isEditable = shouldShowEditableCell(
     isCellEditable(columnMeta?.editable, cell.row.original),

--- a/packages/react-components/src/object-table/TableHeader.tsx
+++ b/packages/react-components/src/object-table/TableHeader.tsx
@@ -67,6 +67,48 @@ const getHeaderName = <TData,>(
   return meta?.columnName ?? id;
 };
 
+/**
+ * Records a stretched column's painted width as its size, so that starting a
+ * resize on it doesn't collapse it.
+ *
+ * Columns that stretch to fill the container are painted wider than
+ * `column.getSize()` — the extra width comes from flex-grow, see
+ * `getColumnFlexGrow`. TanStack takes the start width for a drag from
+ * `getSize()`, so without this the column would snap back to that stored width
+ * on the first pointer move.
+ *
+ * `pointerdown` fires ahead of both `mousedown` and `touchstart`, which is what
+ * makes this work: React commits the new sizing state before the resize handler
+ * runs and reads it.
+ *
+ * Nothing moves on screen as a result. The share of leftover width this column
+ * stops claiming is exactly the growth it keeps, leaving every other column's
+ * painted width unchanged.
+ */
+function pinPaintedColumnWidth<TData extends RowData>(
+  table: Table<TData>,
+  header: Header<TData, unknown>,
+  resizer: HTMLElement
+): void {
+  const headerCell = resizer.closest("th");
+  if (headerCell == null) {
+    return;
+  }
+
+  const paintedWidth = Math.round(headerCell.getBoundingClientRect().width);
+
+  // A column that was never stretched needs no adjusting; the tolerance keeps
+  // sub-pixel rounding from being reported as a resize.
+  if (paintedWidth <= 0 || Math.abs(paintedWidth - header.getSize()) <= 1) {
+    return;
+  }
+
+  table.setColumnSizing((prev) => ({
+    ...prev,
+    [header.column.id]: paintedWidth,
+  }));
+}
+
 export function TableHeader<TData extends RowData>({
   table,
   headerMenuFeatureFlags,
@@ -79,6 +121,7 @@ export function TableHeader<TData extends RowData>({
   const currentSorting = table.getState().sorting;
   const currentVisibility = table.getState().columnVisibility;
   const currentColumnOrder = table.getState().columnOrder;
+  const currentColumnSizing = table.getState().columnSizing;
 
   const isResizing = !!table.getState().columnSizingInfo?.isResizingColumn;
 
@@ -145,7 +188,10 @@ export function TableHeader<TData extends RowData>({
         {table.getHeaderGroups().map((headerGroup) => (
           <tr key={headerGroup.id} className={styles.osdkTableHeaderRow}>
             {headerGroup.headers.map((header) => {
-              const { columnStyles } = getColumnPinningStyles(header.column);
+              const { columnStyles } = getColumnPinningStyles(
+                header.column,
+                currentColumnSizing
+              );
               const isColumnPinned = header.column.getIsPinned();
               const isSelectColumn = header.id === SELECTION_COLUMN_ID;
               return (
@@ -176,6 +222,13 @@ export function TableHeader<TData extends RowData>({
                       <div
                         className={styles.osdkTableHeaderResizer}
                         onDoubleClick={() => header.column.resetSize()}
+                        onPointerDown={(event) =>
+                          pinPaintedColumnWidth(
+                            table,
+                            header,
+                            event.currentTarget
+                          )
+                        }
                         onMouseDown={header.getResizeHandler()}
                         onTouchStart={header.getResizeHandler()}
                       />

--- a/packages/react-components/src/object-table/TableHeader.tsx
+++ b/packages/react-components/src/object-table/TableHeader.tsx
@@ -16,6 +16,7 @@
 
 import type {
   Column,
+  ColumnSizingState,
   Header,
   RowData,
   SortingState,
@@ -68,45 +69,79 @@ const getHeaderName = <TData,>(
 };
 
 /**
- * Records a stretched column's painted width as its size, so that starting a
- * resize on it doesn't collapse it.
+ * Records the painted width of the column being resized and of every column
+ * before it, so that a resize drag behaves the way the pointer says it should.
  *
- * Columns that stretch to fill the container are painted wider than
- * `column.getSize()` — the extra width comes from flex-grow, see
- * `getColumnFlexGrow`. TanStack takes the start width for a drag from
- * `getSize()`, so without this the column would snap back to that stored width
- * on the first pointer move.
+ * Two problems this solves, both caused by stretched columns being painted wider
+ * than `column.getSize()` (the extra width comes from flex-grow — see
+ * `getColumnFlexGrow`):
+ *
+ * 1. TanStack takes the start width for a drag from `getSize()`, so the dragged
+ *    column would snap back to that stored width on the first pointer move.
+ * 2. The rows are stretched to at least the full container width, so any width
+ *    the dragged column gives up is immediately re-claimed by whichever columns
+ *    can still grow — *including columns to its left*. That pushes the dragged
+ *    column's right edge back where it started, and the divider the user is
+ *    holding does not move at all. Pinning the earlier columns takes them out of
+ *    the pool, so the width can only come from the columns to the right and the
+ *    divider tracks the pointer.
  *
  * `pointerdown` fires ahead of both `mousedown` and `touchstart`, which is what
  * makes this work: React commits the new sizing state before the resize handler
  * runs and reads it.
  *
- * Nothing moves on screen as a result. The share of leftover width this column
- * stops claiming is exactly the growth it keeps, leaving every other column's
- * painted width unchanged.
+ * Nothing moves on screen as a result. Leftover width is shared in proportion to
+ * each column's own width, so the share a column stops claiming is exactly the
+ * growth it keeps — every column keeps its painted width, including the ones
+ * still growing.
  */
-function pinPaintedColumnWidth<TData extends RowData>(
+function pinPaintedColumnWidths<TData extends RowData>(
   table: Table<TData>,
   header: Header<TData, unknown>,
   resizer: HTMLElement
 ): void {
   const headerCell = resizer.closest("th");
-  if (headerCell == null) {
+  const headerRow = headerCell?.closest("tr");
+  if (headerCell == null || headerRow == null) {
     return;
   }
 
-  const paintedWidth = Math.round(headerCell.getBoundingClientRect().width);
-
-  // A column that was never stretched needs no adjusting; the tolerance keeps
-  // sub-pixel rounding from being reported as a resize.
-  if (paintedWidth <= 0 || Math.abs(paintedWidth - header.getSize()) <= 1) {
+  // The cells are rendered straight from `headers` in order, so their positions
+  // line up.
+  const cells = [...headerRow.children];
+  const dragIndex = cells.indexOf(headerCell);
+  if (dragIndex < 0) {
     return;
   }
 
-  table.setColumnSizing((prev) => ({
-    ...prev,
-    [header.column.id]: paintedWidth,
-  }));
+  const { headers } = header.headerGroup;
+  const paintedWidths: ColumnSizingState = {};
+
+  for (const [index, cell] of cells.slice(0, dragIndex + 1).entries()) {
+    const cellHeader = headers[index];
+    if (cellHeader == null) {
+      continue;
+    }
+
+    const paintedWidth = Math.round(cell.getBoundingClientRect().width);
+
+    // A column that was never stretched needs no adjusting; the tolerance keeps
+    // sub-pixel rounding from being reported as a resize.
+    if (
+      paintedWidth <= 0 ||
+      Math.abs(paintedWidth - cellHeader.getSize()) <= 1
+    ) {
+      continue;
+    }
+
+    paintedWidths[cellHeader.column.id] = paintedWidth;
+  }
+
+  if (Object.keys(paintedWidths).length === 0) {
+    return;
+  }
+
+  table.setColumnSizing((prev) => ({ ...prev, ...paintedWidths }));
 }
 
 export function TableHeader<TData extends RowData>({
@@ -121,7 +156,6 @@ export function TableHeader<TData extends RowData>({
   const currentSorting = table.getState().sorting;
   const currentVisibility = table.getState().columnVisibility;
   const currentColumnOrder = table.getState().columnOrder;
-  const currentColumnSizing = table.getState().columnSizing;
 
   const isResizing = !!table.getState().columnSizingInfo?.isResizingColumn;
 
@@ -190,7 +224,7 @@ export function TableHeader<TData extends RowData>({
             {headerGroup.headers.map((header) => {
               const { columnStyles } = getColumnPinningStyles(
                 header.column,
-                currentColumnSizing
+                table
               );
               const isColumnPinned = header.column.getIsPinned();
               const isSelectColumn = header.id === SELECTION_COLUMN_ID;
@@ -223,7 +257,7 @@ export function TableHeader<TData extends RowData>({
                         className={styles.osdkTableHeaderResizer}
                         onDoubleClick={() => header.column.resetSize()}
                         onPointerDown={(event) =>
-                          pinPaintedColumnWidth(
+                          pinPaintedColumnWidths(
                             table,
                             header,
                             event.currentTarget

--- a/packages/react-components/src/object-table/hooks/__tests__/useColumnDefs.test.tsx
+++ b/packages/react-components/src/object-table/hooks/__tests__/useColumnDefs.test.tsx
@@ -803,6 +803,63 @@ describe(useColumnDefs, () => {
     });
   });
 
+  describe("column width", () => {
+    // `size` left unset is what marks a column as free to stretch and fill the
+    // container width — see getColumnFlexGrow. TanStack merges in its own 150px
+    // default for any column def that omits the key, so these columns have to
+    // carry `size: undefined` explicitly.
+    it("leaves size unset on default columns so they can fill the container", async () => {
+      const deferred = pDefer();
+      const fakeClient = {
+        fetchMetadata: vitest.fn(() => deferred.promise),
+      } as unknown as Client;
+
+      const { result } = renderHook(() => useColumnDefs(TestObjectType), {
+        wrapper: createWrapper(fakeClient),
+      });
+
+      deferred.resolve(mockMetadata);
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.columns).not.toHaveLength(0);
+      for (const column of result.current.columns) {
+        expect(column).toHaveProperty("size", undefined);
+      }
+    });
+
+    it("leaves size unset for a columnDefinition with no width", async () => {
+      const deferred = pDefer();
+      const fakeClient = {
+        fetchMetadata: vitest.fn(() => deferred.promise),
+      } as unknown as Client;
+
+      const columnDefinitions: Array<ColumnDefinition<TestObject, {}, {}>> = [
+        { locator: { type: "property", id: "name" as TestObjectKeys } },
+        {
+          locator: { type: "property", id: "email" as TestObjectKeys },
+          width: 200,
+        },
+      ];
+
+      const { result } = renderHook(
+        () => useColumnDefs(TestObjectType, columnDefinitions),
+        { wrapper: createWrapper(fakeClient) }
+      );
+
+      deferred.resolve(mockMetadata);
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.columns[0]).toHaveProperty("size", undefined);
+      expect(result.current.columns[1]?.size).toBe(200);
+    });
+  });
+
   it("memoizes columns based on metadata properties", async () => {
     const deferred = pDefer();
     const fakeClient = {

--- a/packages/react-components/src/object-table/hooks/useColumnDefs.ts
+++ b/packages/react-components/src/object-table/hooks/useColumnDefs.ts
@@ -141,6 +141,11 @@ function getColumnsFromColumnDefinitions<
         markingType,
         validateEdit,
       },
+      // Assigned unconditionally, unlike minSize/maxSize below: leaving `size`
+      // undefined is what marks the column as free to stretch to fill the
+      // container. A conditional spread here would let TanStack merge in its
+      // own 150px default and pin the column to a fixed width. See
+      // getColumnFlexGrow.
       size: width,
       ...(minWidth ? { minSize: minWidth } : {}),
       ...(maxWidth ? { maxSize: maxWidth } : {}),
@@ -190,6 +195,10 @@ function getDefaultColumns<
     > = {
       accessorKey: key,
       header: property.displayName ?? key,
+      // No caller-supplied width, so leave `size` unset rather than letting
+      // TanStack merge in its 150px default — that keeps these columns free to
+      // stretch and fill the container. See getColumnFlexGrow.
+      size: undefined,
     };
     return colDef;
   });

--- a/packages/react-components/src/object-table/utils/__tests__/getColumnPinningStyles.test.ts
+++ b/packages/react-components/src/object-table/utils/__tests__/getColumnPinningStyles.test.ts
@@ -81,7 +81,7 @@ describe(getColumnPinningStyles, () => {
 
       const { columnStyles } = getColumnPinningStyles(
         getColumn(table, "name"),
-        table.getState().columnSizing
+        table
       );
 
       // Leftover container width is shared out via flex-grow, weighted by the
@@ -95,7 +95,7 @@ describe(getColumnPinningStyles, () => {
 
       const { columnStyles } = getColumnPinningStyles(
         getColumn(table, "age"),
-        table.getState().columnSizing
+        table
       );
 
       expect(columnStyles.width).toBe(200);
@@ -107,7 +107,7 @@ describe(getColumnPinningStyles, () => {
 
       const { columnStyles } = getColumnPinningStyles(
         getColumn(table, "email"),
-        table.getState().columnSizing
+        table
       );
 
       expect(columnStyles.width).toBe(300);
@@ -116,20 +116,17 @@ describe(getColumnPinningStyles, () => {
 
     it("keeps pinned columns fixed so their sticky offsets stay aligned", () => {
       const table = renderTestTable();
-      const columnSizing = table.getState().columnSizing;
 
       // getStart("left") / getAfter("right") derive sticky offsets from
       // getSize(), so a pinned column that grew past getSize() would push the
       // columns pinned beside it out of alignment.
       expect(
-        getColumnPinningStyles(
-          getColumn(table, SELECTION_COLUMN_ID),
-          columnSizing
-        ).columnStyles.flexGrow
+        getColumnPinningStyles(getColumn(table, SELECTION_COLUMN_ID), table)
+          .columnStyles.flexGrow
       ).toBe(0);
       expect(
-        getColumnPinningStyles(getColumn(table, "notes"), columnSizing)
-          .columnStyles.flexGrow
+        getColumnPinningStyles(getColumn(table, "notes"), table).columnStyles
+          .flexGrow
       ).toBe(0);
     });
 
@@ -138,7 +135,7 @@ describe(getColumnPinningStyles, () => {
 
       const { columnStyles } = getColumnPinningStyles(
         getColumn(table, "notes"),
-        table.getState().columnSizing
+        table
       );
 
       expect(columnStyles.maxWidth).toBe(220);
@@ -149,7 +146,7 @@ describe(getColumnPinningStyles, () => {
 
       const { columnStyles } = getColumnPinningStyles(
         getColumn(table, "name"),
-        table.getState().columnSizing
+        table
       );
 
       // tanstack defaults maxSize to Number.MAX_SAFE_INTEGER; that must not
@@ -158,24 +155,67 @@ describe(getColumnPinningStyles, () => {
     });
   });
 
+  describe("absorbing width released by a resize", () => {
+    // A resize only takes width from, or gives it to, the columns right of the
+    // drag handle. When those all have explicit widths the released width has
+    // nowhere to go, so the rightmost unpinned column gives up its explicit
+    // width once the table has been resized.
+    it("lets the last unpinned column grow once a column has been resized", () => {
+      const table = renderTestTable({ email: 300 });
+
+      const { columnStyles } = getColumnPinningStyles(
+        getColumn(table, "age"),
+        table
+      );
+
+      expect(columnStyles.flexGrow).toBe(200);
+    });
+
+    it("keeps explicit widths exact until something is resized", () => {
+      const table = renderTestTable();
+
+      expect(
+        getColumnPinningStyles(getColumn(table, "age"), table).columnStyles
+          .flexGrow
+      ).toBe(0);
+    });
+
+    it("does not let the last unpinned column override its own resized width", () => {
+      const table = renderTestTable({ age: 260 });
+
+      const { columnStyles } = getColumnPinningStyles(
+        getColumn(table, "age"),
+        table
+      );
+
+      expect(columnStyles.width).toBe(260);
+      expect(columnStyles.flexGrow).toBe(0);
+    });
+
+    it("treats the table as un-resized when no table is supplied", () => {
+      const table = renderTestTable({ email: 300 });
+
+      expect(
+        getColumnPinningStyles(getColumn(table, "age")).columnStyles.flexGrow
+      ).toBe(0);
+    });
+  });
+
   describe("pinning offsets", () => {
     it("still positions pinned columns", () => {
       const table = renderTestTable();
-      const columnSizing = table.getState().columnSizing;
 
       expect(
-        getColumnPinningStyles(
-          getColumn(table, SELECTION_COLUMN_ID),
-          columnSizing
-        ).columnStyles.left
-      ).toBe("0px");
-      expect(
-        getColumnPinningStyles(getColumn(table, "notes"), columnSizing)
-          .columnStyles.right
-      ).toBe("0px");
-      expect(
-        getColumnPinningStyles(getColumn(table, "name"), columnSizing)
+        getColumnPinningStyles(getColumn(table, SELECTION_COLUMN_ID), table)
           .columnStyles.left
+      ).toBe("0px");
+      expect(
+        getColumnPinningStyles(getColumn(table, "notes"), table).columnStyles
+          .right
+      ).toBe("0px");
+      expect(
+        getColumnPinningStyles(getColumn(table, "name"), table).columnStyles
+          .left
       ).toBeUndefined();
     });
   });

--- a/packages/react-components/src/object-table/utils/__tests__/getColumnPinningStyles.test.ts
+++ b/packages/react-components/src/object-table/utils/__tests__/getColumnPinningStyles.test.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  Column,
+  ColumnDef,
+  ColumnSizingState,
+  Table,
+} from "@tanstack/react-table";
+import { getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SELECTION_COLUMN_ID } from "../constants.js";
+import { getColumnPinningStyles } from "../getColumnPinningStyles.js";
+
+interface TestRow {
+  name: string;
+  email: string;
+  age: number;
+  notes: string;
+}
+
+// Mirrors the column defs useColumnDefs produces: `size` is only set when the
+// caller supplied an explicit `width` in columnDefinitions.
+const TEST_COLUMNS: Array<ColumnDef<TestRow>> = [
+  { id: SELECTION_COLUMN_ID, size: 50, minSize: 50, maxSize: 50 },
+  { id: "name", accessorKey: "name", size: undefined },
+  { id: "email", accessorKey: "email", size: undefined },
+  { id: "age", accessorKey: "age", size: 200 },
+  { id: "notes", accessorKey: "notes", size: undefined, maxSize: 220 },
+];
+
+function renderTestTable(columnSizing: ColumnSizingState = {}): Table<TestRow> {
+  const { result } = renderHook(() =>
+    // Same shape as the table ObjectTable builds.
+    useReactTable<TestRow>({
+      data: [],
+      columns: TEST_COLUMNS,
+      getCoreRowModel: getCoreRowModel(),
+      state: {
+        columnSizing,
+        columnPinning: { left: [SELECTION_COLUMN_ID], right: ["notes"] },
+      },
+      columnResizeMode: "onChange",
+      defaultColumn: { minSize: 80 },
+    })
+  );
+
+  return result.current;
+}
+
+function getColumn(
+  table: Table<TestRow>,
+  id: string
+): Column<TestRow, unknown> {
+  const column = table.getColumn(id);
+  if (column == null) {
+    throw new Error(`Test column ${id} not found`);
+  }
+  return column;
+}
+
+describe(getColumnPinningStyles, () => {
+  describe("filling the parent container width", () => {
+    it("lets a column with no explicit width grow, in proportion to its width", () => {
+      const table = renderTestTable();
+
+      const { columnStyles } = getColumnPinningStyles(
+        getColumn(table, "name"),
+        table.getState().columnSizing
+      );
+
+      // Leftover container width is shared out via flex-grow, weighted by the
+      // width the column already has.
+      expect(columnStyles.width).toBe(150);
+      expect(columnStyles.flexGrow).toBe(150);
+    });
+
+    it("keeps a column at the explicit width supplied in columnDefinitions", () => {
+      const table = renderTestTable();
+
+      const { columnStyles } = getColumnPinningStyles(
+        getColumn(table, "age"),
+        table.getState().columnSizing
+      );
+
+      expect(columnStyles.width).toBe(200);
+      expect(columnStyles.flexGrow).toBe(0);
+    });
+
+    it("keeps a column the user has resized at its resized width", () => {
+      const table = renderTestTable({ email: 300 });
+
+      const { columnStyles } = getColumnPinningStyles(
+        getColumn(table, "email"),
+        table.getState().columnSizing
+      );
+
+      expect(columnStyles.width).toBe(300);
+      expect(columnStyles.flexGrow).toBe(0);
+    });
+
+    it("keeps pinned columns fixed so their sticky offsets stay aligned", () => {
+      const table = renderTestTable();
+      const columnSizing = table.getState().columnSizing;
+
+      // getStart("left") / getAfter("right") derive sticky offsets from
+      // getSize(), so a pinned column that grew past getSize() would push the
+      // columns pinned beside it out of alignment.
+      expect(
+        getColumnPinningStyles(
+          getColumn(table, SELECTION_COLUMN_ID),
+          columnSizing
+        ).columnStyles.flexGrow
+      ).toBe(0);
+      expect(
+        getColumnPinningStyles(getColumn(table, "notes"), columnSizing)
+          .columnStyles.flexGrow
+      ).toBe(0);
+    });
+
+    it("caps growth at the column's maxWidth", () => {
+      const table = renderTestTable();
+
+      const { columnStyles } = getColumnPinningStyles(
+        getColumn(table, "notes"),
+        table.getState().columnSizing
+      );
+
+      expect(columnStyles.maxWidth).toBe(220);
+    });
+
+    it("leaves maxWidth unset for columns with no maxWidth", () => {
+      const table = renderTestTable();
+
+      const { columnStyles } = getColumnPinningStyles(
+        getColumn(table, "name"),
+        table.getState().columnSizing
+      );
+
+      // tanstack defaults maxSize to Number.MAX_SAFE_INTEGER; that must not
+      // reach the DOM as a max-width.
+      expect(columnStyles.maxWidth).toBeUndefined();
+    });
+  });
+
+  describe("pinning offsets", () => {
+    it("still positions pinned columns", () => {
+      const table = renderTestTable();
+      const columnSizing = table.getState().columnSizing;
+
+      expect(
+        getColumnPinningStyles(
+          getColumn(table, SELECTION_COLUMN_ID),
+          columnSizing
+        ).columnStyles.left
+      ).toBe("0px");
+      expect(
+        getColumnPinningStyles(getColumn(table, "notes"), columnSizing)
+          .columnStyles.right
+      ).toBe("0px");
+      expect(
+        getColumnPinningStyles(getColumn(table, "name"), columnSizing)
+          .columnStyles.left
+      ).toBeUndefined();
+    });
+  });
+});

--- a/packages/react-components/src/object-table/utils/getColumnPinningStyles.ts
+++ b/packages/react-components/src/object-table/utils/getColumnPinningStyles.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { Column, ColumnSizingState } from "@tanstack/react-table";
+import type { Column, Table } from "@tanstack/react-table";
 import type React from "react";
 
 interface PinningStyles {
@@ -40,22 +40,64 @@ interface PinningStyles {
  *   its own 150px default via `defaultColumnSizing`, so `columnDef.size` is
  *   only set when a width was actually supplied (see `useColumnDefs`).
  * - columns the user has resized, which is what `columnSizing` records.
+ *
+ * The one exception is the rightmost unpinned column once the user has resized
+ * anything: see {@link absorbsLeftoverWidth}.
+ *
+ * Omitting `table` treats the table as never resized and disables that
+ * exception, which is what the loading skeleton wants.
  */
 export function getColumnFlexGrow<TData>(
   column: Column<TData, unknown>,
-  columnSizing?: ColumnSizingState
+  table?: Table<TData>
 ): number {
-  const hasFixedWidth =
-    column.getIsPinned() !== false ||
-    column.columnDef.size != null ||
-    columnSizing?.[column.id] != null;
+  const columnSizing = table?.getState().columnSizing;
 
-  return hasFixedWidth ? 0 : column.getSize();
+  if (column.getIsPinned() !== false || columnSizing?.[column.id] != null) {
+    return 0;
+  }
+
+  if (column.columnDef.size == null) {
+    return column.getSize();
+  }
+
+  return table != null && absorbsLeftoverWidth(column, table)
+    ? column.getSize()
+    : 0;
+}
+
+/**
+ * Whether `column` should take up leftover width despite having been given an
+ * explicit `width`.
+ *
+ * Resizing a column only ever takes width from, or gives width to, the columns
+ * to its right — `pinPaintedColumnWidths` pins everything from the drag handle
+ * leftwards so that the divider follows the pointer. That leaves the width the
+ * dragged column releases with nowhere to go when the columns to its right all
+ * have explicit widths, so a gap opens at the right edge mid-drag.
+ *
+ * Treating an explicit `width` as the column's *initial* width rather than a
+ * hard cap closes that gap: the rightmost unpinned column absorbs the slack.
+ * This deliberately only applies once `columnSizing` records a resize, so a
+ * table the user has not touched still lays out exactly at the widths its
+ * `columnDefinitions` asked for.
+ */
+function absorbsLeftoverWidth<TData>(
+  column: Column<TData, unknown>,
+  table: Table<TData>
+): boolean {
+  const columnSizing = table.getState().columnSizing;
+  if (Object.keys(columnSizing).length === 0) {
+    return false;
+  }
+
+  const unpinnedColumns = table.getCenterVisibleLeafColumns();
+  return unpinnedColumns[unpinnedColumns.length - 1]?.id === column.id;
 }
 
 export function getColumnPinningStyles<TData>(
   column: Column<TData, unknown>,
-  columnSizing?: ColumnSizingState
+  table?: Table<TData>
 ): PinningStyles {
   const isPinned = column.getIsPinned();
   const { maxSize } = column.columnDef;
@@ -65,7 +107,7 @@ export function getColumnPinningStyles<TData>(
       left: isPinned === "left" ? `${column.getStart("left")}px` : undefined,
       right: isPinned === "right" ? `${column.getAfter("right")}px` : undefined,
       width: column.getSize(),
-      flexGrow: getColumnFlexGrow(column, columnSizing),
+      flexGrow: getColumnFlexGrow(column, table),
       // Growth stops at the column's maxWidth. TanStack defaults maxSize to
       // Number.MAX_SAFE_INTEGER, which must not reach the DOM as a max-width.
       maxWidth:

--- a/packages/react-components/src/object-table/utils/getColumnPinningStyles.ts
+++ b/packages/react-components/src/object-table/utils/getColumnPinningStyles.ts
@@ -14,23 +14,64 @@
  * limitations under the License.
  */
 
-import type { Column } from "@tanstack/react-table";
+import type { Column, ColumnSizingState } from "@tanstack/react-table";
 import type React from "react";
 
 interface PinningStyles {
   columnStyles: React.CSSProperties;
 }
 
+/**
+ * The flex-grow factor for a column's header and body cells. Header rows and
+ * body rows are flex containers stretched to at least the full width of the
+ * scroll container, so a non-zero grow factor lets columns share out whatever
+ * width is left over instead of leaving dead space to the right of the last
+ * column.
+ *
+ * Growable columns use their own width as the factor, so the leftover width is
+ * shared in proportion to how wide the columns already are. A factor of 0 keeps
+ * the column at exactly `getSize()`, which is what we want for columns whose
+ * width is already decided:
+ *
+ * - pinned columns, because sticky offsets come from `getStart`/`getAfter`,
+ *   which sum `getSize()`. A pinned column painted wider than its `getSize()`
+ *   would leave the columns pinned beside it misaligned.
+ * - columns given an explicit `width` in `columnDefinitions`. TanStack fills in
+ *   its own 150px default via `defaultColumnSizing`, so `columnDef.size` is
+ *   only set when a width was actually supplied (see `useColumnDefs`).
+ * - columns the user has resized, which is what `columnSizing` records.
+ */
+export function getColumnFlexGrow<TData>(
+  column: Column<TData, unknown>,
+  columnSizing?: ColumnSizingState
+): number {
+  const hasFixedWidth =
+    column.getIsPinned() !== false ||
+    column.columnDef.size != null ||
+    columnSizing?.[column.id] != null;
+
+  return hasFixedWidth ? 0 : column.getSize();
+}
+
 export function getColumnPinningStyles<TData>(
-  column: Column<TData, unknown>
+  column: Column<TData, unknown>,
+  columnSizing?: ColumnSizingState
 ): PinningStyles {
   const isPinned = column.getIsPinned();
+  const { maxSize } = column.columnDef;
 
   return {
     columnStyles: {
       left: isPinned === "left" ? `${column.getStart("left")}px` : undefined,
       right: isPinned === "right" ? `${column.getAfter("right")}px` : undefined,
       width: column.getSize(),
+      flexGrow: getColumnFlexGrow(column, columnSizing),
+      // Growth stops at the column's maxWidth. TanStack defaults maxSize to
+      // Number.MAX_SAFE_INTEGER, which must not reach the DOM as a max-width.
+      maxWidth:
+        maxSize != null && maxSize < Number.MAX_SAFE_INTEGER
+          ? maxSize
+          : undefined,
     },
   };
 }


### PR DESCRIPTION
## Repro

Render `ObjectTable` in a container wider than its columns total. The row box stretches to 100% of the container, but no cell claims the surplus, so there is dead space to the right of the last column. Five 150px columns in a 1252px container leaves 502px empty.

## Cause

`getColumnPinningStyles` gave every `<th>`/`<td>` a hard inline `width` from `column.getSize()` with no grow factor. Column sizes came from tanstack only — the container width never entered the calculation.

## Fix

Emit a `flex-grow` factor proportional to the column's current width, so leftover width is shared in proportion to how wide the columns already are. A column keeps an exact width when its width is already decided:

- **pinned columns** — sticky offsets come from `getStart`/`getAfter`, which sum `getSize()`; a pinned column painted wider than its `getSize()` would misalign the columns pinned beside it
- **columns given an explicit `width`** in `columnDefinitions`
- **columns the user has resized**

Growth is capped by `maxWidth`. This is pure CSS — no `ResizeObserver`, and it re-fits on container resize for free.

**Resize seed.** A stretched column is painted wider than the size tanstack has stored, and tanstack takes the start width for a drag from `getSize()`, so grabbing the handle would have snapped the column back. `pointerdown` records the painted width one event ahead of the resize handler, which is enough for React to commit the state before the handler reads it. Freezing one column is layout-neutral: the share of leftover width it stops claiming is exactly the growth it keeps.

## Notes

- **`BaseTable` consumers opt in per column** by leaving `size: undefined`. Tanstack merges its own `size: 150` into any column def that omits the key, so a hand-written def is indistinguishable from one with an explicit width of 150. Only `ObjectTable` (via `useColumnDefs`) leaves it unset.
- **Pressing a resize handle on a stretched column fires `onColumnResize` once** with the painted width, before any drag movement.
