### PR TITLE
Add the mrl-required coverage block to vite-plugin-code-workspace-preview

### DIFF
--- a/.changeset/vite-plugin-code-workspace-preview-mrl-coverage.md
+++ b/.changeset/vite-plugin-code-workspace-preview-mrl-coverage.md
@@ -1,0 +1,5 @@
+---
+"@osdk/vite-plugin-code-workspace-preview": patch
+---
+
+Add the monorepolint-required `coverage` block to `vitest.config.mts` so `check-mrl` passes; no runtime change

--- a/packages/vite-plugin-code-workspace-preview/vitest.config.mts
+++ b/packages/vite-plugin-code-workspace-preview/vitest.config.mts
@@ -20,6 +20,18 @@ export default defineConfig({
   test: {
     pool: "forks",
     exclude: [...configDefaults.exclude, "**/build/**/*"],
+    coverage: {
+      include: ["src/**"],
+      // Exclude tests, generated code, and index.ts barrels (no logic).
+      exclude: [
+        "**/*.test.*",
+        "**/__tests__/**",
+        "**/__mocks__/**",
+        "**/generatedNoCheck/**",
+        "**/*.d.ts",
+        "**/index.ts",
+      ],
+    },
     fakeTimers: {
       toFake: ["setTimeout", "clearTimeout", "Date"],
     },


### PR DESCRIPTION
## Problem

`check-mrl` fails on `main`, which turns the **Lint** job red on every open PR.

`packages/vite-plugin-code-workspace-preview/vitest.config.mts` was added (in #3671) without the `coverage` block that monorepolint's template generates, so the file no longer matches what the rule expects:

```
@osdk/vite-plugin-code-workspace-preview
  Error! vitest.config.mts: Expect file contents to match
```

## Fix

Add the block, copied verbatim from the template at `.monorepolint.config.mjs:1452`. Equivalent to `pnpm exec mrl check --fix` for this package.

## Verification

- `pnpm run check-mrl` exits **100** on `main` and **0** with this change.
- Below the license header the file is now byte-identical to its sibling `packages/vite-plugin-oac/vitest.config.mts`, which passes the same rule.

No behavior change — `coverage.include` / `coverage.exclude` only affect coverage reporting, and this package's tests don't run with `--coverage` in CI.

Opened as a draft so #3671's authors can confirm the omission wasn't deliberate before this merges.
